### PR TITLE
DALI does not presently support windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Note: DALI v0.1 is a pre-release software, which means certain features may not 
 
 ## Prerequisities
 
+* Linux
 * [NVIDIA CUDA 9.0](https://developer.nvidia.com/cuda-downloads)
 * DALI can work with any of the following Deep Learning frameworks:
   - [MXNet](http://mxnet.incubator.apache.org)
@@ -35,6 +36,7 @@ Note: DALI v0.1 is a pre-release software, which means certain features may not 
 
 ## Prerequisities
 
+* Linux
 * [NVIDIA CUDA 9.0](https://developer.nvidia.com/cuda-downloads)
 * [nvJPEG library](https://developer.nvidia.com/nvjpeg)
 * [protobuf](https://github.com/google/protobuf) version 2 or above (version 3 or above is required for TensorFlow TFRecord file format support)


### PR DESCRIPTION
People have asked why `pip.exe install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali` does not work -- but there `pip.exe` implies Windows; the answer simply is that DALI does not presently support Windows and hence has no pre-built packages for Windows.