### PR TITLE
Rename `Getting Started.ipynb` file

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 This directory contains examples of DALI usage. List of examples:
 
-- [Getting started](Getting started.ipynb) - build your first pipeline with DALI
+- [Getting started](Getting_started.ipynb) - build your first pipeline with DALI
 - [Augmentation gallery](AugmentationGallery.ipynb) - showcases different augmentations
 - [LMDB data loading](DataLoading-LMDB.ipynb) - example of reading data from LMDB database
 - [TFRecord data loading](DataLoading-TFRecord.ipynb) - example of reading data from TensorFlow's TFRecord file

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 This directory contains examples of DALI usage. List of examples:
 
-- [Getting started](Getting_started.ipynb) - build your first pipeline with DALI
+- [Getting started](Getting%20Started.ipynb) - build your first pipeline with DALI
 - [Augmentation gallery](AugmentationGallery.ipynb) - showcases different augmentations
 - [LMDB data loading](DataLoading-LMDB.ipynb) - example of reading data from LMDB database
 - [TFRecord data loading](DataLoading-TFRecord.ipynb) - example of reading data from TensorFlow's TFRecord file


### PR DESCRIPTION
In [Example README](https://github.com/NVIDIA/DALI/blob/master/examples/README.md), `Getting Started` link is just plain text not hypertext.

Because git markdown is can't parse link in space bar

So, I has rename file and change link address.