### PR TITLE
Fix race in processing multiple input sets

### DIFF
--- a/dali/pipeline/operators/decoder/nvjpeg_decoder.h
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder.h
@@ -318,7 +318,7 @@ class nvJPEGDecoder : public Operator<MixedBackend> {
           stream));
 
     // Ensure previous GPU work is finished
-    CUDA_CALL(cudaStreamSynchronize(streams_[stream_idx]));
+    CUDA_CALL(cudaStreamSynchronize(stream));
 
     // Memcpy of Huffman co-efficients to device
     NVJPEG_CALL(nvjpegDecodePhaseTwo(handle, state, stream));

--- a/dali/pipeline/operators/displacement/displacement_filter_impl_gpu.cuh
+++ b/dali/pipeline/operators/displacement/displacement_filter_impl_gpu.cuh
@@ -312,6 +312,11 @@ class DisplacementFilter<GPUBackend, Displacement,
   }
 
   void RunImpl(DeviceWorkspace* ws, const int idx) override {
+    // Before we start working on the next input set, we need
+    // to wait until the last one is finished. Otherwise we risk
+    // overwriting data used by the kernel called for previous image
+    if (idx != 0)
+      CUDA_CALL(cudaStreamSynchronize(ws->stream()));
     DataDependentSetup(ws, idx);
 
     auto &input = ws->Input<GPUBackend>(idx);

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cu
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cu
@@ -304,6 +304,11 @@ void CropMirrorNormalize<GPUBackend>::DataDependentSetup(DeviceWorkspace *ws, co
 
 template<>
 void CropMirrorNormalize<GPUBackend>::RunImpl(DeviceWorkspace *ws, const int idx) {
+  // Before we start working on the next input set, we need
+  // to wait until the last one is finished. Otherwise we risk
+  // overwriting data used by the kernel called for previous image
+  if (idx != 0)
+    CUDA_CALL(cudaStreamSynchronize(ws->stream()));
   DataDependentSetup(ws, idx);
   if (output_type_ == DALI_FLOAT) {
     RunHelper<float>(ws, idx);

--- a/dali/pipeline/operators/resize/resize.cu
+++ b/dali/pipeline/operators/resize/resize.cu
@@ -80,6 +80,11 @@ void Resize<GPUBackend>::SetupSharedSampleParams(DeviceWorkspace* ws) {
 
 template<>
 void Resize<GPUBackend>::RunImpl(DeviceWorkspace *ws, const int idx) {
+    // Before we start working on the next input set, we need
+    // to wait until the last one is finished. Otherwise we risk
+    // overwriting data used by the kernel called for previous image
+    if (idx != 0)
+      CUDA_CALL(cudaStreamSynchronize(ws->stream()));
     const auto &input = ws->Input<GPUBackend>(idx);
     const bool save_attrs = spec_.HasArgument("save_attrs");
     const int outputs_per_idx = save_attrs ? 2 : 1;


### PR DESCRIPTION
When processing multiple input sets and having DataDependentSetup that fills auxiliary data structures, we need to wait between sets so that those data structures are not overwritten by DataDependentSetup of the next set.