### PR TITLE
Rename Protobuf_PROTOC_EXECUTABLE to PROTOBUF_PROTOC_EXECUTABLE for C…

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -25,8 +25,8 @@ RUN BOOST_VERSION=1.66.0 && \
     ln -s ../boost_${BOOST_VERSION//./_}/boost include/boost
 
 # CMake
-RUN CMAKE_VERSION=3.11 && \
-    CMAKE_BUILD=3.11.3 && \
+RUN CMAKE_VERSION=3.5 && \
+    CMAKE_BUILD=3.5.0 && \
     curl -L https://cmake.org/files/v${CMAKE_VERSION}/cmake-${CMAKE_BUILD}.tar.gz | tar -xzf - && \
     cd /cmake-${CMAKE_BUILD} && \
     ./bootstrap --parallel=$(grep ^processor /proc/cpuinfo | wc -l) && \

--- a/cmake/ProtobufGenCpp.cmake
+++ b/cmake/ProtobufGenCpp.cmake
@@ -25,7 +25,7 @@ function(DALI_PROTOBUF_GENERATE_CPP SRCS HDRS)
   if(NOT DEFINED DALI_PROTOBUF_GENERATE_CPP_APPEND_PATH)
     set(DALI_PROTOBUF_GENERATE_CPP_APPEND_PATH TRUE)
   endif()
-  
+
   cmake_parse_arguments(dali_protobuf "" "EXPORT_MACRO" "" ${ARGN})
 
   set(PROTO_FILES "${dali_protobuf_UNPARSED_ARGUMENTS}")
@@ -84,9 +84,9 @@ function(DALI_PROTOBUF_GENERATE_CPP SRCS HDRS)
     add_custom_command(
       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc"
              "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h"
-      COMMAND  ${Protobuf_PROTOC_EXECUTABLE}
+      COMMAND  ${PROTOBUF_PROTOC_EXECUTABLE}
       ARGS "--cpp_out=${DLL_EXPORT_DECL}${CMAKE_CURRENT_BINARY_DIR}" ${_protobuf_include_path} ${ABS_FIL}
-      DEPENDS ${ABS_FIL} ${Protobuf_PROTOC_EXECUTABLE}
+      DEPENDS ${ABS_FIL} ${PROTOBUF_PROTOC_EXECUTABLE}
       COMMENT "Running C++ protocol buffer compiler on ${FIL}"
       VERBATIM )
   endforeach()


### PR DESCRIPTION
…make 3.5 compatibility

Update docker to use cmake 3.5

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>