### PR TITLE
Type casting in Python

### DIFF
--- a/dali/pipeline/operators/common.h
+++ b/dali/pipeline/operators/common.h
@@ -35,10 +35,13 @@ inline void GetSingleOrRepeatedArg(const OpSpec &spec, vector<T> *arg,
   }
 
   if (arg->size() == 1) {
-    for (int i = 0; i < repeat_count - 1; ++i) {
-      arg->push_back(arg->back());
-    }
+    arg->assign(repeat_count, arg->back());
   }
+
+  DALI_ENFORCE(arg->size() == repeat_count,
+      "Argument \"" + argName + "\" expects either a single value "
+      "or a list of " + to_string(repeat_count) + " elements. " +
+      to_string(arg->size()) + " given.");
 }
 
 }  // namespace dali

--- a/dali/pipeline/operators/common.h
+++ b/dali/pipeline/operators/common.h
@@ -16,13 +16,14 @@
 #define DALI_PIPELINE_OPERATORS_COMMON_H_
 
 #include <vector>
+#include <string>
 
 #include "dali/pipeline/operators/op_spec.h"
 
 namespace dali {
 template <typename T>
-inline void GetSingleOrDoubleArg(const OpSpec &spec, vector<T> *arg, const char *argName,
-                          bool doubleArg = true) {
+inline void GetSingleOrRepeatedArg(const OpSpec &spec, vector<T> *arg,
+                                   const std::string &argName, int repeat_count = 2) {
   try {
       *arg = spec.GetRepeatedArgument<T>(argName);
   } catch (std::runtime_error e) {
@@ -33,8 +34,11 @@ inline void GetSingleOrDoubleArg(const OpSpec &spec, vector<T> *arg, const char 
       }
   }
 
-  if (doubleArg && arg->size() == 1)
-    arg->push_back(arg->back());
+  if (arg->size() == 1) {
+    for (int i = 0; i < repeat_count - 1; ++i) {
+      arg->push_back(arg->back());
+    }
+  }
 }
 
 }  // namespace dali

--- a/dali/pipeline/operators/displacement/warpaffine.h
+++ b/dali/pipeline/operators/displacement/warpaffine.h
@@ -19,6 +19,7 @@
 #include <vector>
 #include "dali/pipeline/operators/operator.h"
 #include "dali/pipeline/operators/displacement/displacement_filter.h"
+#include "dali/pipeline/operators/common.h"
 
 namespace dali {
 
@@ -62,7 +63,8 @@ class WarpAffineAugment {
   Param param;
 
   void Prepare(Param* p, const OpSpec& spec, ArgumentWorkspace *ws, int index) {
-    const std::vector<float>& tmp = spec.GetRepeatedArgument<float>("matrix");
+    std::vector<float> tmp;
+    GetSingleOrRepeatedArg(spec, &tmp, "matrix", size);
     DALI_ENFORCE(tmp.size() == size, "Warp affine matrix needs to have 6 elements");
     for (int i = 0; i < size; ++i) {
       p->matrix[i] = tmp[i];

--- a/dali/pipeline/operators/displacement/warpaffine.h
+++ b/dali/pipeline/operators/displacement/warpaffine.h
@@ -65,7 +65,6 @@ class WarpAffineAugment {
   void Prepare(Param* p, const OpSpec& spec, ArgumentWorkspace *ws, int index) {
     std::vector<float> tmp;
     GetSingleOrRepeatedArg(spec, &tmp, "matrix", size);
-    DALI_ENFORCE(tmp.size() == size, "Warp affine matrix needs to have 6 elements");
     for (int i = 0; i < size; ++i) {
       p->matrix[i] = tmp[i];
     }

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -40,8 +40,6 @@ class CropMirrorNormalize : public Operator<Backend> {
     vector<int> temp_crop;
     GetSingleOrRepeatedArg(spec, &temp_crop, "crop", 2);
 
-    DALI_ENFORCE(temp_crop.size() == 2, "Argument \"crop\" expects a list of at most 2 elements, "
-        + to_string(temp_crop.size()) + " given.");
     crop_h_ = temp_crop[0];
     crop_w_ = temp_crop[1];
 
@@ -62,13 +60,6 @@ class CropMirrorNormalize : public Operator<Backend> {
 
     GetSingleOrRepeatedArg(spec, &mean_vec_, "mean", C_);
     GetSingleOrRepeatedArg(spec, &inv_std_vec_, "std", C_);
-    // Validate & save mean & std params
-    DALI_ENFORCE((int)mean_vec_.size() == C_,
-        "Argument \"mean\" expects a list of " + to_string(C_) +
-        " elements, " + to_string(mean_vec_.size()) + " given.");
-    DALI_ENFORCE((int)inv_std_vec_.size() == C_,
-        "Argument \"std\" expects a list of " + to_string(C_) +
-        " elements, " + to_string(inv_std_vec_.size()) + " given.");
 
     // Inverse the std-deviation
     for (int i = 0; i < C_; ++i) {

--- a/dali/pipeline/operators/fused/normalize_permute.h
+++ b/dali/pipeline/operators/fused/normalize_permute.h
@@ -17,6 +17,7 @@
 
 #include <vector>
 
+#include "dali/pipeline/operators/common.h"
 #include "dali/pipeline/operators/operator.h"
 
 namespace dali {
@@ -34,10 +35,15 @@ class NormalizePermute : public Operator<Backend> {
     DALI_ENFORCE(W_ > 0);
     DALI_ENFORCE(C_ == 3 || C_ == 1);
 
-    vector<float> mean = spec.GetRepeatedArgument<float>("mean");
-    vector<float> std = spec.GetRepeatedArgument<float>("std");
-    DALI_ENFORCE((int)mean.size() == C_);
-    DALI_ENFORCE((int)std.size() == C_);
+    vector<float> mean, std;
+    GetSingleOrRepeatedArg(spec, &mean, "mean", C_);
+    GetSingleOrRepeatedArg(spec, &std, "std", C_);
+    DALI_ENFORCE((int)mean.size() == C_,
+        "Argument \"mean\" expects a list of " + to_string(C_) +
+        " elements, " + to_string(mean.size()) + " given.");
+    DALI_ENFORCE((int)std.size() == C_,
+        "Argument \"std\" expects a list of " + to_string(C_) +
+        " elements, " + to_string(std.size()) + " given.");
 
     // Inverse the std-deviation
     for (int i = 0; i < C_; ++i) {

--- a/dali/pipeline/operators/fused/normalize_permute.h
+++ b/dali/pipeline/operators/fused/normalize_permute.h
@@ -38,12 +38,6 @@ class NormalizePermute : public Operator<Backend> {
     vector<float> mean, std;
     GetSingleOrRepeatedArg(spec, &mean, "mean", C_);
     GetSingleOrRepeatedArg(spec, &std, "std", C_);
-    DALI_ENFORCE((int)mean.size() == C_,
-        "Argument \"mean\" expects a list of " + to_string(C_) +
-        " elements, " + to_string(mean.size()) + " given.");
-    DALI_ENFORCE((int)std.size() == C_,
-        "Argument \"std\" expects a list of " + to_string(C_) +
-        " elements, " + to_string(std.size()) + " given.");
 
     // Inverse the std-deviation
     for (int i = 0; i < C_; ++i) {

--- a/dali/pipeline/operators/fused/resize_crop_mirror.h
+++ b/dali/pipeline/operators/fused/resize_crop_mirror.h
@@ -22,6 +22,7 @@
 #include "dali/error_handling.h"
 #include "dali/image/transform.h"
 #include "dali/pipeline/operators/operator.h"
+#include "dali/pipeline/operators/common.h"
 
 namespace dali {
 
@@ -35,19 +36,7 @@ class ResizeCropMirror : public Operator<CPUBackend> {
   explicit inline ResizeCropMirror(const OpSpec &spec) :
     Operator(spec) {
     vector<int> temp_crop;
-    try {
-      temp_crop = spec.GetRepeatedArgument<int>("crop");
-      if (temp_crop.size() == 1) {
-        temp_crop.push_back(temp_crop.back());
-      }
-    } catch (std::runtime_error e) {
-      try {
-        int temp = spec.GetArgument<int>("crop");
-        temp_crop = {temp, temp};
-      } catch (std::runtime_error e) {
-        DALI_FAIL("Invalid type of argument \"crop\". Expected int or list of int");
-      }
-    }
+    GetSingleOrRepeatedArg(spec, &temp_crop, "crop", 2);
 
     DALI_ENFORCE(temp_crop.size() == 2, "Argument \"crop\" expects a list of at most 2 elements, "
         + to_string(temp_crop.size()) + " given.");

--- a/dali/pipeline/operators/fused/resize_crop_mirror.h
+++ b/dali/pipeline/operators/fused/resize_crop_mirror.h
@@ -38,8 +38,6 @@ class ResizeCropMirror : public Operator<CPUBackend> {
     vector<int> temp_crop;
     GetSingleOrRepeatedArg(spec, &temp_crop, "crop", 2);
 
-    DALI_ENFORCE(temp_crop.size() == 2, "Argument \"crop\" expects a list of at most 2 elements, "
-        + to_string(temp_crop.size()) + " given.");
     crop_h_ = temp_crop[0];
     crop_w_ = temp_crop[1];
     // Validate input parameters

--- a/dali/pipeline/operators/resize/random_resized_crop.cc
+++ b/dali/pipeline/operators/resize/random_resized_crop.cc
@@ -17,6 +17,7 @@
 #include <random>
 
 #include "dali/pipeline/operators/resize/random_resized_crop.h"
+#include "dali/pipeline/operators/common.h"
 #include "dali/util/ocv.h"
 
 namespace dali {
@@ -32,7 +33,7 @@ DALI_SCHEMA(RandomResizedCrop)
       std::vector<float>{3./4., 4./3.})
   .AddOptionalArg("random_area",
       R"code(Range from which to choose random area factor `A`.
-      Before resizing, the cropped image's area will be equal to `A` * original image's area.)code",
+Before resizing, the cropped image's area will be equal to `A` * original image's area.)code",
       std::vector<float>{0.08, 1.0})
   .AddOptionalArg("interp_type",
       R"code(Type of interpolation used.)code",
@@ -64,24 +65,14 @@ void RandomResizedCrop<CPUBackend>::InitParams(const OpSpec &spec) {
   for (size_t i = 0; i < seeds.size(); ++i) {
     params_->rand_gens[i].seed(seeds[i]);
   }
-  std::vector<float> aspect_ratios = spec.GetRepeatedArgument<float>("random_aspect_ratio");
-  std::vector<float> area = spec.GetRepeatedArgument<float>("random_area");
-  DALI_ENFORCE(aspect_ratios.size() == 2,
-      "\"random_aspect_ratio\" argument should be a list of size 2");
-  DALI_ENFORCE(aspect_ratios[0] <= aspect_ratios[1],
-      "Provided empty range");
-  DALI_ENFORCE(area.size() == 2,
-      "\"random_area\" argument should be a list of size 2");
-  DALI_ENFORCE(area[0] <= area[1],
-      "Provided empty range");
   params_->aspect_ratio_dis.resize(batch_size_);
   params_->area_dis.resize(batch_size_);
   params_->uniform.resize(batch_size_);
   for (size_t i = 0; i < params_->aspect_ratio_dis.size(); ++i) {
-    params_->aspect_ratio_dis[i] = std::uniform_real_distribution<float>(aspect_ratios[0],
-                                                                         aspect_ratios[1]);
-    params_->area_dis[i] = std::uniform_real_distribution<float>(area[0],
-                                                                 area[1]);
+    params_->aspect_ratio_dis[i] = std::uniform_real_distribution<float>(aspect_ratios_[0],
+                                                                         aspect_ratios_[1]);
+    params_->area_dis[i] = std::uniform_real_distribution<float>(area_[0],
+                                                                 area_[1]);
     params_->uniform[i] = std::uniform_real_distribution<float>(0, 1);
   }
 

--- a/dali/pipeline/operators/resize/random_resized_crop.cu
+++ b/dali/pipeline/operators/resize/random_resized_crop.cu
@@ -33,20 +33,10 @@ struct RandomResizedCrop<GPUBackend>::Params {
 template<>
 void RandomResizedCrop<GPUBackend>::InitParams(const OpSpec &spec) {
   params_->rand_gen.seed(spec.GetArgument<int>("seed"));
-  std::vector<float> aspect_ratios = spec.GetRepeatedArgument<float>("random_aspect_ratio");
-  std::vector<float> area = spec.GetRepeatedArgument<float>("random_area");
-  DALI_ENFORCE(aspect_ratios.size() == 2,
-      "\"random_aspect_ratio\" argument should be a list of size 2");
-  DALI_ENFORCE(aspect_ratios[0] <= aspect_ratios[1],
-      "Provided empty range");
-  DALI_ENFORCE(area.size() == 2,
-      "\"random_area\" argument should be a list of size 2");
-  DALI_ENFORCE(area[0] <= area[1],
-      "Provided empty range");
-  params_->aspect_ratio_dis = std::uniform_real_distribution<float>(aspect_ratios[0],
-                                                                    aspect_ratios[1]);
-  params_->area_dis = std::uniform_real_distribution<float>(area[0],
-                                                            area[1]);
+  params_->aspect_ratio_dis = std::uniform_real_distribution<float>(aspect_ratios_[0],
+                                                                    aspect_ratios_[1]);
+  params_->area_dis = std::uniform_real_distribution<float>(area_[0],
+                                                            area_[1]);
   params_->uniform = std::uniform_real_distribution<float>(0, 1);
 
   params_->crops.resize(batch_size_);

--- a/dali/pipeline/operators/resize/random_resized_crop.h
+++ b/dali/pipeline/operators/resize/random_resized_crop.h
@@ -35,18 +35,10 @@ class RandomResizedCrop : public Operator<Backend> {
     num_attempts_(spec.GetArgument<int>("num_attempts")),
     interp_type_(spec.GetArgument<DALIInterpType>("interp_type")) {
     GetSingleOrRepeatedArg(spec, &size_, "size", 2);
-    DALI_ENFORCE((int)size_.size() == 2,
-      "Argument \"size\" expects a list of 2 elements, " +
-      to_string(size_.size()) + " given.");
-
     GetSingleOrRepeatedArg(spec, &aspect_ratios_, "random_aspect_ratio", 2);
     GetSingleOrRepeatedArg(spec, &area_, "random_area", 2);
-    DALI_ENFORCE(aspect_ratios_.size() == 2,
-        "\"random_aspect_ratio\" argument should be a list of size 2");
     DALI_ENFORCE(aspect_ratios_[0] <= aspect_ratios_[1],
         "Provided empty range");
-    DALI_ENFORCE(area_.size() == 2,
-        "\"random_area\" argument should be a list of size 2");
     DALI_ENFORCE(area_[0] <= area_[1],
         "Provided empty range");
     InitParams(spec);

--- a/dali/pipeline/operators/resize/random_resized_crop.h
+++ b/dali/pipeline/operators/resize/random_resized_crop.h
@@ -22,6 +22,7 @@
 
 #include "dali/pipeline/operators/operator.h"
 #include "dali/pipeline/operators/op_spec.h"
+#include "dali/pipeline/operators/common.h"
 
 namespace dali {
 
@@ -31,9 +32,23 @@ class RandomResizedCrop : public Operator<Backend> {
   explicit inline RandomResizedCrop(const OpSpec &spec) :
     Operator<Backend>(spec),
     params_(new Params()),
-    size_(spec.GetRepeatedArgument<int>("size")),
     num_attempts_(spec.GetArgument<int>("num_attempts")),
     interp_type_(spec.GetArgument<DALIInterpType>("interp_type")) {
+    GetSingleOrRepeatedArg(spec, &size_, "size", 2);
+    DALI_ENFORCE((int)size_.size() == 2,
+      "Argument \"size\" expects a list of 2 elements, " +
+      to_string(size_.size()) + " given.");
+
+    GetSingleOrRepeatedArg(spec, &aspect_ratios_, "random_aspect_ratio", 2);
+    GetSingleOrRepeatedArg(spec, &area_, "random_area", 2);
+    DALI_ENFORCE(aspect_ratios_.size() == 2,
+        "\"random_aspect_ratio\" argument should be a list of size 2");
+    DALI_ENFORCE(aspect_ratios_[0] <= aspect_ratios_[1],
+        "Provided empty range");
+    DALI_ENFORCE(area_.size() == 2,
+        "\"random_area\" argument should be a list of size 2");
+    DALI_ENFORCE(area_[0] <= area_[1],
+        "Provided empty range");
     InitParams(spec);
   }
 
@@ -97,6 +112,9 @@ class RandomResizedCrop : public Operator<Backend> {
   std::vector<int> size_;
   int num_attempts_;
   DALIInterpType interp_type_;
+
+  std::vector<float> aspect_ratios_;
+  std::vector<float> area_;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/support/random/uniform.h
+++ b/dali/pipeline/operators/support/random/uniform.h
@@ -30,7 +30,6 @@ class Uniform : public Operator<SupportBackend> {
     rng_(spec.GetArgument<int>("seed")) {
     std::vector<float> range;
     GetSingleOrRepeatedArg(spec, &range, "range", 2);
-    DALI_ENFORCE(range.size() == 2, "Range parameter needs to have 2 elements.");
     dis_ = std::uniform_real_distribution<float>(range[0], range[1]);
   }
 

--- a/dali/pipeline/operators/support/random/uniform.h
+++ b/dali/pipeline/operators/support/random/uniform.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "dali/pipeline/operators/operator.h"
+#include "dali/pipeline/operators/common.h"
 
 namespace dali {
 
@@ -27,7 +28,8 @@ class Uniform : public Operator<SupportBackend> {
   inline explicit Uniform(const OpSpec &spec) :
     Operator<SupportBackend>(spec),
     rng_(spec.GetArgument<int>("seed")) {
-    std::vector<float> range = spec.GetRepeatedArgument<float>("range");
+    std::vector<float> range;
+    GetSingleOrRepeatedArg(spec, &range, "range", 2);
     DALI_ENFORCE(range.size() == 2, "Range parameter needs to have 2 elements.");
     dis_ = std::uniform_real_distribution<float>(range[0], range[1]);
   }

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -18,7 +18,7 @@ import copy
 from itertools import count
 from nvidia.dali import backend as b
 from nvidia.dali.tensor import TensorReference
-from nvidia.dali.types import _type_name_convert_to_string, _type_convert_value
+from nvidia.dali.types import _type_name_convert_to_string, _type_convert_value, DALIDataType
 from future.utils import with_metaclass
 
 def _docstring_generator(cls):
@@ -42,8 +42,8 @@ Parameters
                 default_value = eval(default_value_string)
             else:
                 default_value = default_value_string
-            if dtype == nvidia.dali.types.DALIDataType.STRING:
-                default_value = "\'" + str(val) + "\'"
+            if dtype == DALIDataType.STRING:
+                default_value = "\'" + str(default_value) + "\'"
             ret += (", optional, default = " +
                     str(_type_convert_value(dtype, default_value)))
         indent = '\n' + " " * len(arg_name_doc)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -42,6 +42,8 @@ Parameters
                 default_value = eval(default_value_string)
             else:
                 default_value = default_value_string
+            if dtype == nvidia.dali.types.DALIDataType.STRING:
+                default_value = "\'" + str(val) + "\'"
             ret += (", optional, default = " +
                     str(_type_convert_value(dtype, default_value)))
         indent = '\n' + " " * len(arg_name_doc)
@@ -180,16 +182,19 @@ def python_op_factory(name, op_device = "cpu"):
             # the device that our outputs will be stored on
             if "device" in kwargs.keys():
                 self._device = kwargs["device"]
+                del kwargs["device"]
             else:
-                self._spec.AddArg("device", op_device)
                 self._device = op_device
+            self._spec.AddArg("device", self._device)
 
             # Store the specified arguments
             for key, value in kwargs.items():
                 if isinstance(value, list):
                     if not value:
                         raise RuntimeError("List arguments need to have at least 1 element.")
-                self._spec.AddArg(key, value)
+                dtype = self._schema.GetArgumentType(key)
+                converted_value = _type_convert_value(dtype, value)
+                self._spec.AddArg(key, converted_value)
 
         @property
         def spec(self):

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -20,12 +20,9 @@ try:
 except ImportError:
     _tfrecord_support = False
 
-def _to_string(val):
-    return "\'" + str(val) + "\'"
-
 def _to_list(func):
     def _to_list_instance(val):
-        if isinstance(val, list):
+        if isinstance(val, (list, tuple)):
             return [func(v) for v in val]
         else:
             return [func(val)]
@@ -39,10 +36,10 @@ _known_types = {
         DALIDataType.INT64 : ("int", int),
         DALIDataType.FLOAT : ("float", float),
         DALIDataType.BOOL : ("bool", bool),
-        DALIDataType.STRING : ("str", _to_string),
+        DALIDataType.STRING : ("str", str),
         DALIDataType._BOOL_VEC : ("bool or list of bool", _to_list(bool)),
         DALIDataType._INT32_VEC : ("int or list of int",_to_list(int)),
-        DALIDataType._STRING_VEC : ("str or list of str", _to_list(_to_string)),
+        DALIDataType._STRING_VEC : ("str or list of str", _to_list(str)),
         DALIDataType._FLOAT_VEC : ("float or list of float", _to_list(float)),
         DALIDataType.IMAGE_TYPE : ("nvidia.dali.types.DALIImageType", lambda x: DALIImageType(int(x))),
         DALIDataType.DATA_TYPE : ("nvidia.dali.types.DALIDataType", lambda x: DALIDataType(int(x))),

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -19,6 +19,7 @@ import nvidia.dali.tfrecord as tfrec
 import numpy as np
 from timeit import default_timer as timer
 import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
 
 caffe_db_folder = "/data/imagenet/train-lmdb-256x256"
 
@@ -350,3 +351,59 @@ def test_warpaffine():
         diff = out - dali_output
         diff[dali_output==[128.,128.,128.]] = 0
         assert(np.max(np.abs(diff)/255.0) < 0.025)
+
+def test_type_conversion():
+    class HybridPipe(Pipeline):
+        def __init__(self, batch_size, num_threads, device_id):
+            super(HybridPipe, self).__init__(batch_size, num_threads, device_id, seed = 12)
+            self.input = ops.CaffeReader(path = caffe_db_folder, random_shuffle = True)
+            self.decode = ops.nvJPEGDecoder(device = "mixed", output_type = types.RGB)
+            self.cmnp_all = ops.CropMirrorNormalize(device = "gpu",
+                                                    output_dtype = types.FLOAT,
+                                                    output_layout = types.NHWC,
+                                                    crop = (224, 224),
+                                                    image_type = types.RGB,
+                                                    mean = [128., 128., 128.],
+                                                    std = [1., 1., 1.])
+            self.cmnp_int = ops.CropMirrorNormalize(device = "gpu",
+                                                    output_dtype = types.FLOAT,
+                                                    output_layout = types.NHWC,
+                                                    crop = (224, 224),
+                                                    image_type = types.RGB,
+                                                    mean = [128, 128, 128],
+                                                    std = [1., 1, 1])  # Left 1 of the arguments as float to test whether mixing types works
+            self.cmnp_1arg = ops.CropMirrorNormalize(device = "gpu",
+                                                     output_dtype = types.FLOAT,
+                                                     output_layout = types.NHWC,
+                                                     crop = (224, 224),
+                                                     image_type = types.RGB,
+                                                     mean = 128,
+                                                     std = 1)
+            self.uniform = ops.Uniform(range = (0,1))
+
+        def define_graph(self):
+            self.jpegs, self.labels = self.input()
+            images = self.decode(self.jpegs)
+            outputs = [ None for i in range(3)]
+            crop_pos_x = self.uniform()
+            crop_pos_y = self.uniform()
+            outputs[0] = self.cmnp_all(images,
+                                       crop_pos_x = crop_pos_x,
+                                       crop_pos_y = crop_pos_y)
+            outputs[1] = self.cmnp_int(images,
+                                       crop_pos_x = crop_pos_x,
+                                       crop_pos_y = crop_pos_y)
+            outputs[2] = self.cmnp_1arg(images,
+                                        crop_pos_x = crop_pos_x,
+                                        crop_pos_y = crop_pos_y)
+            return [self.labels] + outputs
+
+    pipe = HybridPipe(batch_size=128, num_threads=2, device_id = 0)
+    pipe.build()
+    for i in range(10):
+        pipe_out = pipe.run()
+        orig_cpu = pipe_out[1].asCPU()
+        int_cpu  = pipe_out[2].asCPU()
+        arg1_cpu = pipe_out[3].asCPU()
+        assert_array_equal(orig_cpu, int_cpu)
+        assert_array_equal(orig_cpu, arg1_cpu)

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -402,8 +402,8 @@ def test_type_conversion():
     pipe.build()
     for i in range(10):
         pipe_out = pipe.run()
-        orig_cpu = pipe_out[1].asCPU()
-        int_cpu  = pipe_out[2].asCPU()
-        arg1_cpu = pipe_out[3].asCPU()
+        orig_cpu = pipe_out[1].asCPU().as_tensor()
+        int_cpu  = pipe_out[2].asCPU().as_tensor()
+        arg1_cpu = pipe_out[3].asCPU().as_tensor()
         assert_array_equal(orig_cpu, int_cpu)
         assert_array_equal(orig_cpu, arg1_cpu)


### PR DESCRIPTION
This PR enables:
- using different types of values as arguments (e.g. if the op requires float it will accept int as well)
- using single values instead of vectors (e.g. instead of `std = [1, 1, 1]` one can write `std = 1`)