### PR TITLE
Check that third_party git submodules are synced

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -6,9 +6,9 @@ include(cmake/Utils.cmake)
 # Google C++ testing framework
 ##################################################################
 if (BUILD_TEST)
-  set(BUILD_GTEST ON CACHE INTERNAL "Builds gtest submodule")
-  set(BUILD_GMOCK OFF CACHE INTERNAL "Builds gmock submodule")
-  add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/googletest EXCLUDE_FROM_ALL)
+  set(BUILD_GTEST ON CACHE INTERNAL "Build gtest submodule")
+  set(BUILD_GMOCK OFF CACHE INTERNAL "Build gmock submodule")
+  check_and_add_cmake_submodule(${PROJECT_SOURCE_DIR}/third_party/googletest EXCLUDE_FROM_ALL)
   include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/third_party/googletest/googletest/include)
 endif()
 
@@ -17,7 +17,7 @@ endif()
 ##################################################################
 if (BUILD_BENCHMARK)
   set(BENCHMARK_ENABLE_TESTING OFF CACHE INTERNAL "Build benchmark testsuite")
-  add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/benchmark EXCLUDE_FROM_ALL)
+  check_and_add_cmake_submodule(${PROJECT_SOURCE_DIR}/third_party/benchmark EXCLUDE_FROM_ALL)
   include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/third_party/benchmark/include/benchmark)
 endif()
 
@@ -115,7 +115,7 @@ list(APPEND DALI_EXCLUDES libopencv_core.a;libopencv_imgproc.a;libopencv_highgui
 ##################################################################
 if (BUILD_PYTHON)
   set(PYBIND11_CPP_STANDARD -std=c++11)
-  add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/pybind11)
+  check_and_add_cmake_submodule(${PROJECT_SOURCE_DIR}/third_party/pybind11)
 endif()
 
 ##################################################################

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -1,3 +1,10 @@
+# Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+
+# caffe_parse_header
+# Reads set of version defines from the header file
+# Usage:
+#   caffe_parse_header(<file> <define1> <define2> <define3> ..)
+#
 # From https://github.com/caffe2/caffe2/blob/d42952c5d7f9192b919cce1b7f7c00e4d825625f/cmake/Utils.cmake
 # Which derives from https://github.com/BVLC/caffe/blob/master/cmake/Utils.cmake
 #
@@ -37,11 +44,6 @@
 # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-################################################################################################
-# Reads set of version defines from the header file
-# Usage:
-#   caffe_parse_header(<file> <define1> <define2> <define3> ..)
 macro(caffe_parse_header FILENAME FILE_VAR)
   set(vars_regex "")
   set(__parnet_scope OFF)
@@ -81,4 +83,20 @@ macro(caffe_parse_header FILENAME FILE_VAR)
     endif()
   endforeach()
 endmacro()
+
+# check_and_add_cmake_submodule
+# Checks for presence of a git submodule that includes a CMakeLists.txt
+# Usage:
+#   check_and_add_cmake_submodule(<submodule_path> ..)
+macro(check_and_add_cmake_submodule SUBMODULE_PATH)
+  if(NOT EXISTS ${SUBMODULE_PATH}/CMakeLists.txt)
+    message(FATAL_ERROR "File ${SUBMODULE_PATH}/CMakeLists.txt not found. "
+                        "Did you forget to `git clone --recursive`? Try this:\n"
+                        "  cd ${PROJECT_SOURCE_DIR} && \\\n"
+                        "  git submodule sync --recursive && \\\n"
+                        "  git submodule update --init --recursive && \\\n"
+                        "  cd -\n")
+  endif()
+  add_subdirectory(${SUBMODULE_PATH} ${ARGN})
+endmacro(check_and_add_cmake_submodule)
 


### PR DESCRIPTION
If third_party/*/CMakeLists.txt files are not found, it probably means that the user forgot to do `git clone --recursive`, as in https://github.com/NVIDIA/DALI/issues/39#issuecomment-404700933.  We can notice this and provide them a more useful message as to how to fix up the situation.

Signed-off-by: Cliff Woolley <jwoolley@nvidia.com>