### PR TITLE
Further test TF binary compat

### DIFF
--- a/qa/L0_framework_imports/test.sh
+++ b/qa/L0_framework_imports/test.sh
@@ -35,9 +35,9 @@ do
     ( set -x && python -c "import nvidia.dali.plugin.mxnet; import mxnet" )
 
     echo "---------Testing TENSORFLOW;DALI----------"
-    ( set -x && python -c "import tensorflow; import nvidia.dali.plugin.tf" )
+    ( set -x && python -c "import tensorflow; import nvidia.dali.plugin.tf as dali_tf; daliop = dali_tf.DALIIterator()" )
     echo "---------Testing DALI;TENSORFLOW----------"
-    ( set -x && python -c "import nvidia.dali.plugin.tf; import tensorflow" )
+    ( set -x && python -c "import nvidia.dali.plugin.tf as dali_tf; import tensorflow; daliop = dali_tf.DALIIterator()" )
 
     echo "---------Testing PYTORCH;DALI----------"
     ( set -x && python -c "import torch; import nvidia.dali.plugin.pytorch" )

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -20,7 +20,7 @@ except ImportError:
 packages = {"numpy" : ["1.11.1"],
             "opencv-python" : ["3.1.0"],
             "mxnet-cu90" : ["1.3.0b20180612"],
-            "tensorflow-gpu" : ["1.7", "1.8", "1.9"],
+            "tensorflow-gpu" : ["1.7", "1.8", "1.9", "1.10.0rc0"],
             "pytorch" : ["http://download.pytorch.org/whl/cu90/torch-0.4.0-{0}.whl"]
             }
 


### PR DESCRIPTION
Add TF 0.10.0rc0 to test.
Also improve the imports test to actually create a `DALIIterator()` during the TF portion of the test, as this is what would have called attention to https://github.com/NVIDIA/DALI/issues/52 .