### PR TITLE
Fix segfault in Filereader if directory does not exist.

### DIFF
--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -53,6 +53,9 @@ vector<std::pair<string, int>> traverse_directories(const std::string& path) {
   // open the root
   DIR *dir = opendir(path.c_str());
 
+  DALI_ENFORCE(dir != nullptr,
+      "Directory " + path + " could not be opened.");
+
   struct dirent *entry;
   int dir_count = 0;
 


### PR DESCRIPTION
Signed-off-by: ptredak <ptredak@nvidia.com>