### PR TITLE
Add at method to TensorListGPU

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -355,7 +355,7 @@ void ExposeTensorList(py::module &m) { // NOLINT
     .def("at",
         [](TensorList<GPUBackend> &t, Index id) -> std::unique_ptr<Tensor<GPUBackend>> {
           std::unique_ptr<Tensor<GPUBackend>> ptr(new Tensor<GPUBackend>());
-          ptr->ShareData(this, id);
+          ptr->ShareData(&t, id);
           return ptr;
         },
       R"code(

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -352,6 +352,19 @@ void ExposeTensorList(py::module &m) { // NOLINT
       Parameters
       ----------
       )code")
+    .def("at",
+        [](TensorList<GPUBackend> &t, Index id) -> std::unique_ptr<Tensor<GPUBackend>> {
+          std::unique_ptr<Tensor<GPUBackend>> ptr(new Tensor<GPUBackend>());
+          ptr->ShareData(this, id);
+          return ptr;
+        },
+      R"code(
+      Returns a tensor at given position in the list.
+
+      Parameters
+      ----------
+      )code",
+      py::keep_alive<0,1>())
     .def("as_tensor", &TensorList<GPUBackend>::AsTensor,
       R"code(
       Returns a tensor that is a view of this `TensorList`.


### PR DESCRIPTION
This PR adds a way to access individual tensors of TensorListGPU (without additional copies).