### PR TITLE
Fix segfault in MXNetReader when given bad path to index file

### DIFF
--- a/dali/pipeline/operators/reader/loader/recordio_loader.h
+++ b/dali/pipeline/operators/reader/loader/recordio_loader.h
@@ -46,6 +46,8 @@ class RecordIOLoader : public IndexedFileLoader {
         "RecordIOReader supports only a single index file");
     const std::string& path = index_uris[0];
     std::ifstream index_file(path);
+    DALI_ENFORCE(index_file.good(),
+        "Could not open RecordIO index file. Provided path: \"" + path + "\"");
     std::vector<size_t> temp;
     size_t index, offset;
     while (index_file >> index >> offset) {


### PR DESCRIPTION
Signed-off-by: ptredak <ptredak@nvidia.com>