### PR TITLE
Fix determinism in argument inputs

### DIFF
--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -115,7 +115,7 @@ class _OperatorInstance(object):
                     TensorReference. Received input type {}"""
                     .format(type(inputs[0]).__name__))
         # Argument inputs
-        for k in kwargs.keys():
+        for k in sorted(kwargs.keys()):
             if k not in ["name"]:
                 if not isinstance(kwargs[k], TensorReference):
                     raise TypeError(


### PR DESCRIPTION
Python 3 randomizes the ordering of keys in a map, which can result in different order of construction of the ops. This leads to grabbing different seeds.