### PR TITLE
Make files to be copied after build not only when libdali is rebuild

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -119,9 +119,17 @@ endmacro()
 
 # add a post-build step to the provided target which copies
 # files or directories recursively from SRC to DSTrunnable
+# create phony target first (if not exists with given name yet)
+# and add comand attached to it
 macro(copy_post_build TARGET_NAME SRC DST)
+    if (NOT (TARGET install_${TARGET_NAME}))
+        add_custom_target(install_${TARGET_NAME} ALL
+             DEPENDS ${TARGET_NAME}
+        )
+    endif()
+
     add_custom_command(
-    TARGET ${TARGET_NAME} POST_BUILD
+    TARGET install_${TARGET_NAME}
     COMMAND cp -r
             "${SRC}"
             "${DST}")

--- a/dali/CMakeLists.txt
+++ b/dali/CMakeLists.txt
@@ -73,11 +73,16 @@ set_target_properties(${dali_lib} PROPERTIES
 
 # filter all *.h which don't have 'test' in name, create pairs 'src dst' string with sed and call xargs
 # with install command to copy with dest recursive dir creation
+add_custom_target(install_headers ALL
+    DEPENDS ${dali_lib}
+)
+  
 add_custom_command(
-    TARGET ${dali_lib} POST_BUILD
+    TARGET install_headers
     COMMAND find ${CMAKE_CURRENT_LIST_DIR} -regex ".*\\\\.h" | grep --invert test
     | sed -r 's,\(^${CMAKE_CURRENT_LIST_DIR}\)\(.*\),\\1\\2 ${CMAKE_BINARY_DIR}/include/dali\\2,'
-    | xargs -n 2 install -D)
+    | xargs -n 2 install -D
+  )
 
 ################################################
 # Build test suite


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>