### PR TITLE
Remove batch_size_ from CoinFlip operator

### DIFF
--- a/dali/pipeline/operators/support/random/coin_flip.h
+++ b/dali/pipeline/operators/support/random/coin_flip.h
@@ -26,12 +26,13 @@ class CoinFlip : public Operator<SupportBackend> {
   inline explicit CoinFlip(const OpSpec &spec) :
     Operator<SupportBackend>(spec),
     dis_(spec.GetArgument<float>("probability")),
-    rng_(spec.GetArgument<int>("seed")),
-    batch_size_(spec.GetArgument<int>("batch_size")) {}
+    rng_(spec.GetArgument<int>("seed")) {}
 
   virtual inline ~CoinFlip() = default;
 
   DISABLE_COPY_MOVE_ASSIGN(CoinFlip);
+
+  USE_OPERATOR_MEMBERS();
 
  protected:
   void RunImpl(Workspace<SupportBackend> * ws, const int idx) override;
@@ -39,7 +40,6 @@ class CoinFlip : public Operator<SupportBackend> {
  private:
   std::bernoulli_distribution dis_;
   std::mt19937 rng_;
-  int batch_size_;
 };
 
 }  // namespace dali


### PR DESCRIPTION
batch_size_ is already handled by OperatorBase

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>