### PR TITLE
Clang build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,11 @@ endif()
 # CXX flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror -Wno-unused-variable -Wno-unused-function -fno-strict-aliasing -O2 -fPIC -fvisibility=hidden")
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register")
+endif()
+
+
 # Add ptx & bin flags for cuda
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} \
   -gencode arch=compute_35,code=sm_35 \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,18 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror -Wno-unused-var
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register")
+
+  # CUDA does not support current clang as host compiler, we need use gcc
+  # CUDA_HOST_COMPILER variable operates on paths
+  if (${CUDA_HOST_COMPILER} MATCHES "clang") 
+    message(STATUS "CUDA_HOST_COMPILER is set to ${CMAKE_C_COMPILER} - setting CUDA_HOST_COMPILER to gcc")
+    execute_process(COMMAND which gcc OUTPUT_VARIABLE PATH_TO_GCC OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (NOT PATH_TO_GCC)
+      message(FATAL_ERROR "gcc was not found in PATH")
+    else()
+      set(CUDA_HOST_COMPILER ${PATH_TO_GCC})
+    endif()
+  endif()
 endif()
 
 

--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,19 @@ To build DALI with LMDB support:
    cmake -DBUILD_LMDB=ON ..
    make -j"$(nproc)"
 
+To build DALI using clang (experimental):
+
+.. note::
+
+   This build is experimental and it is not maintained and tested
+   like the default configuration. It is not guaranteed to work. 
+   We recommend using gcc for production builds.
+
+.. code-block:: bash
+   
+   cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang  ..
+   make -j"$(nproc)"
+
 Optional CMake build parameters:
 
 -  ``BUILD_PYTHON`` - build Python bindings (default: ON)

--- a/dali/common.h
+++ b/dali/common.h
@@ -257,10 +257,10 @@ template <typename T, typename A>
 struct is_vector<std::vector<T, A> >: std::true_type {};
 
 template <typename T>
-struct is_array: std::false_type {};
+struct is_std_array: std::false_type {};
 
 template <typename T, size_t A>
-struct is_array<std::array<T, A> >: std::true_type {};
+struct is_std_array<std::array<T, A> >: std::true_type {};
 
 }  // namespace dali
 

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -182,6 +182,13 @@ class DLL_PUBLIC TypeInfo {
   string name_;
 };
 
+template <typename T>
+struct TypeNameHelper {
+  static string GetTypeName() {
+    return typeid(T).name();
+  }
+};
+
 /**
  * @brief Keeps track of mappings between types and unique identifiers.
  */
@@ -195,18 +202,8 @@ class DLL_PUBLIC TypeTable {
   }
 
   template <typename T>
-  DLL_PUBLIC static typename std::enable_if<
-    !is_vector<T>::value &&
-    !is_array<T>::value,
-    string>::type GetTypeName() {
-    return typeid(T).name();
-  }
-
-  template <typename T>
-  DLL_PUBLIC static typename std::enable_if<
-    is_vector<T>::value || is_array<T>::value,
-    string>::type GetTypeName() {
-    return "list of " + GetTypeName<typename T::value_type>();
+  DLL_PUBLIC static string GetTypeName() {
+    return TypeNameHelper<T>::GetTypeName();
   }
 
   DLL_PUBLIC static const TypeInfo& GetTypeInfo(DALIDataType dtype) {
@@ -246,6 +243,21 @@ class DLL_PUBLIC TypeTable {
   // so we need to use size_t instead of DALIDataType
   static std::unordered_map<size_t, TypeInfo> type_info_map_;
   static int index_;
+};
+
+
+template <typename T, typename A>
+struct TypeNameHelper<std::vector<T, A> > {
+  static string GetTypeName() {
+    return "list of " + TypeTable::GetTypeName<T>();
+  }
+};
+
+template <typename T, size_t N>
+struct TypeNameHelper<std::array<T, N> > {
+  static string GetTypeName() {
+    return "list of " + TypeTable::GetTypeName<T>();
+  }
 };
 
 template <typename T>

--- a/dali/pipeline/data/types_test.cc
+++ b/dali/pipeline/data/types_test.cc
@@ -29,6 +29,10 @@ class TypesTest : public DALITest {
   std::string TypeName();
 };
 
+namespace {
+  static constexpr size_t DUMMY_ARRAY_SIZE = 42;
+}
+
 #define TYPENAME_FUNC(type)                     \
   template <>                                   \
   std::string TypesTest<type>::TypeName() {     \
@@ -44,6 +48,16 @@ TYPENAME_FUNC(float);
 TYPENAME_FUNC(double);
 TYPENAME_FUNC(bool);
 
+template <>
+std::string TypesTest<std::vector<uint8>>::TypeName() {
+  return "list of uint8";
+}
+
+template <>
+std::string TypesTest<std::array<std::vector<uint8>, DUMMY_ARRAY_SIZE>>::TypeName() {
+  return "list of list of uint8";
+}
+
 typedef ::testing::Types<uint8,
                          int16,
                          int32,
@@ -51,7 +65,10 @@ typedef ::testing::Types<uint8,
                          float16,
                          float,
                          double,
-                         bool> TestTypes;
+                         bool,
+                         std::vector<uint8>,
+                         std::array<std::vector<uint8>, DUMMY_ARRAY_SIZE>
+                         > TestTypes;
 
 TYPED_TEST_CASE(TypesTest, TestTypes);
 

--- a/dali/pipeline/operators/fused/resize_crop_mirror.h
+++ b/dali/pipeline/operators/fused/resize_crop_mirror.h
@@ -56,7 +56,7 @@ class ResizeCropMirrorAttr {
     }
   }
 
-  using TransformMeta = struct {
+  struct TransformMeta {
     int H, W, C;
     int rsz_h, rsz_w;
     int crop_x, crop_y;

--- a/dali/pipeline/operators/op_schema.h
+++ b/dali/pipeline/operators/op_schema.h
@@ -164,7 +164,7 @@ class DLL_PUBLIC OpSchema {
    */
   template <typename T>
   DLL_PUBLIC inline typename std::enable_if<
-    !is_vector<T>::value && !is_array<T>::value,
+    !is_vector<T>::value && !is_std_array<T>::value,
     OpSchema&>::type AddOptionalArg(const std::string &s,
                                     const std::string &doc,
                                     T default_value,

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -44,7 +44,8 @@ class PipelineTest : public DALITest {
 
     vector<double> abs_diff(n, 0);
     for (int i = 0; i < n; ++i) {
-      abs_diff[i] = abs(static_cast<double>(tmp_cpu[i]) - static_cast<double>(ground_truth[i]));
+      abs_diff[i] = std::abs(static_cast<double>(tmp_cpu[i])
+          - static_cast<double>(ground_truth[i]));
     }
     double mean, std;
     DALITest::MeanStdDevColorNorm(abs_diff, &mean, &std);

--- a/dali/test/dali_test_matching.h
+++ b/dali/test/dali_test_matching.h
@@ -41,8 +41,8 @@ class GenericMatchingTest : public DALISingleOpTest<ImgType> {
     this->RunOperator(descr);
   }
 
-  virtual vector<TensorList<CPUBackend>*>
-  Reference(const vector<TensorList<CPUBackend>*> &inputs, DeviceWorkspace *ws) {
+  vector<TensorList<CPUBackend>*>
+  Reference(const vector<TensorList<CPUBackend>*> &inputs, DeviceWorkspace *ws) override {
     return this->CopyToHost(*ws->Output<GPUBackend>(1));
   }
 

--- a/dali/test/dali_test_single_op.h
+++ b/dali/test/dali_test_single_op.h
@@ -471,7 +471,7 @@ class DALISingleOpTest : public DALITest {
         for (int j = 0; j < jMax; ++j) {    // loop over the colors
           if (shiftHor == 0) {
             for (int i = j; i < N; i += jMax)
-              diff[i / jMax] = abs(static_cast<double>(a[i]) - static_cast<double>(b[i]));
+              diff[i / jMax] = std::abs(static_cast<double>(a[i]) - static_cast<double>(b[i]));
 
             ASSERT_EQ(N/jMax, len), -1;
           } else {
@@ -479,7 +479,7 @@ class DALISingleOpTest : public DALITest {
             for (int y = 0; y < hMax; ++y) {
               for (int x = 0; x < wMax; ++x) {
                 const int idx = (W * y + x) * c_;
-                diff[i++] = abs(static_cast<double>(a[idx]) - static_cast<double>(b[idx]));
+                diff[i++] = std::abs(static_cast<double>(a[idx]) - static_cast<double>(b[idx]));
               }
             }
 


### PR DESCRIPTION
Fixes required to build witch clang. (tested with clang 6).
Example cmake command:
cmake -DCMAKE_CXX_COMPILER=clang++-6.0 -DCMAKE_C_COMPILER=clang-6.0 -DCUDA_HOST_COMPILER=/usr/bin/g++ ${SOURCE_DIR}

Requires #156 