### PR TITLE
Fix for low accuracy in Tensorflow training

### DIFF
--- a/dali/pipeline/operators/reader/loader/indexed_file_loader.h
+++ b/dali/pipeline/operators/reader/loader/indexed_file_loader.h
@@ -38,7 +38,7 @@ class IndexedFileLoader : public Loader<CPUBackend> {
     }
 
   void ReadSample(Tensor<CPUBackend>* tensor) override {
-    if (current_index_ >= indices_.size()) {
+    if (current_index_ == max_index_) {
       Reset();
     }
     int64 seek_pos, size;
@@ -94,6 +94,9 @@ class IndexedFileLoader : public Loader<CPUBackend> {
     ReadIndexFile(index_uris);
     size_t num_indices = indices_.size();
     current_index_ = num_indices/num_shards_ * shard_id_;
+    max_index_ = (shard_id_ != num_shards_ - 1)
+      ? num_indices/num_shards_ * (shard_id_ + 1)
+      : num_indices;
     int64 seek_pos, size;
     std::tie(seek_pos, size, current_file_index_) = indices_[current_index_];
     current_file_.reset(FileStream::Open(uris_[current_file_index_]));
@@ -117,6 +120,7 @@ class IndexedFileLoader : public Loader<CPUBackend> {
   std::vector<std::string> uris_;
   std::vector<std::tuple<int64, int64, size_t>> indices_;
   size_t current_index_;
+  size_t max_index_;
   size_t current_file_index_;
   std::unique_ptr<FileStream> current_file_;
 };

--- a/dali/pipeline/operators/reader/loader/indexed_file_loader.h
+++ b/dali/pipeline/operators/reader/loader/indexed_file_loader.h
@@ -38,7 +38,7 @@ class IndexedFileLoader : public Loader<CPUBackend> {
     }
 
   void ReadSample(Tensor<CPUBackend>* tensor) override {
-    if (current_index_ == max_index_) {
+    if (current_index_ == indices_.size()) {
       Reset();
     }
     int64 seek_pos, size;
@@ -94,7 +94,6 @@ class IndexedFileLoader : public Loader<CPUBackend> {
     ReadIndexFile(index_uris);
     size_t num_indices = indices_.size();
     current_index_ = num_indices/num_shards_ * shard_id_;
-    max_index_ = num_indices * (shard_id_ + 1) / num_shards_;
     int64 seek_pos, size;
     std::tie(seek_pos, size, current_file_index_) = indices_[current_index_];
     current_file_.reset(FileStream::Open(uris_[current_file_index_]));
@@ -102,8 +101,7 @@ class IndexedFileLoader : public Loader<CPUBackend> {
   }
 
   void Reset() {
-    size_t num_indices = indices_.size();
-    current_index_ = num_indices/num_shards_ * shard_id_;
+    current_index_ = 0;
     int64 seek_pos, size;
     size_t file_index;
     std::tie(seek_pos, size, file_index) = indices_[current_index_];
@@ -118,7 +116,6 @@ class IndexedFileLoader : public Loader<CPUBackend> {
   std::vector<std::string> uris_;
   std::vector<std::tuple<int64, int64, size_t>> indices_;
   size_t current_index_;
-  size_t max_index_;
   size_t current_file_index_;
   std::unique_ptr<FileStream> current_file_;
 };

--- a/dali/pipeline/operators/reader/loader/indexed_file_loader.h
+++ b/dali/pipeline/operators/reader/loader/indexed_file_loader.h
@@ -94,9 +94,7 @@ class IndexedFileLoader : public Loader<CPUBackend> {
     ReadIndexFile(index_uris);
     size_t num_indices = indices_.size();
     current_index_ = num_indices/num_shards_ * shard_id_;
-    max_index_ = (shard_id_ != num_shards_ - 1)
-      ? num_indices/num_shards_ * (shard_id_ + 1)
-      : num_indices;
+    max_index_ = num_indices * (shard_id_ + 1) / num_shards_;
     int64 seek_pos, size;
     std::tie(seek_pos, size, current_file_index_) = indices_[current_index_];
     current_file_.reset(FileStream::Open(uris_[current_file_index_]));


### PR DESCRIPTION
Indexed_file_loader.h performs a sharded read of the index files supplied alongside the tfrecords for training. Thus, ReadSample() is called from multiple threads with different shard_id_. When all indexes have been read, we proceed to reset current_index_ to start again at the beginning of the shard.

This commit fixes a defect in the detection that the shard has arrived to the end, by comparing the value of current_index to the size of all the indexes. The fix consists in comparing against the end of the shard instead of the end of the indices.

Before the fix, the code would work correctly for 1 GPU when there is only 1 shard, but with >1 GPUs, it would result in a loss in accuracy due to---most likely---redundant reads.

Signed-off-by: Pablo Ribalta Lorenzo <pribalta@nvidia.com>