### PR TITLE
Fix reporing of the end of epoch in MXNet and pyTorch plugins

### DIFF
--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -116,7 +116,7 @@ class DALIGenericIterator(object):
             batch = self._first_batch
             self._first_batch = None
             return batch
-        if self._counter > self._size:
+        if self._counter >= self._size:
             raise StopIteration
         # Gather outputs
         outputs = []
@@ -177,7 +177,7 @@ class DALIGenericIterator(object):
         DALI iterators do not support resetting before the end of the epoch
         and will ignore such request.
         """
-        if self._counter > self._size:
+        if self._counter >= self._size:
             self._counter = self._counter % self._size
         else:
             logging.warning("DALI iterator does not support resetting while epoch is not finished. Ignoring...")

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -97,7 +97,7 @@ class DALIGenericIterator(object):
             batch = self._first_batch
             self._first_batch = None
             return batch
-        if self._counter > self._size:
+        if self._counter >= self._size:
             raise StopIteration
         # Gather outputs
         outputs = []
@@ -169,7 +169,7 @@ class DALIGenericIterator(object):
         DALI iterators do not support resetting before the end of the epoch
         and will ignore such request.
         """
-        if self._counter > self._size:
+        if self._counter >= self._size:
             self._counter = self._counter % self._size
         else:
             logging.warning("DALI iterator does not support resetting while epoch is not finished. Ignoring...")


### PR DESCRIPTION
In the previous version, if the epoch size is divisible by the batch size, they would return 1 additional batch.

Signed-off-by: ptredak <ptredak@nvidia.com>