### PR TITLE
Better sharding when number of shards does not divide the dataset size evenly

### DIFF
--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -132,8 +132,7 @@ class FileLoader : public Loader<CPUBackend> {
       std::shuffle(image_label_pairs_.begin(), image_label_pairs_.end(), g);
     }
 
-    int samples_per_shard = Size() / num_shards_;
-    current_index_ = shard_id_ * samples_per_shard;
+    current_index_ = start_index(shard_id_, num_shards_, Size());
   }
 
   void ReadSample(Tensor<CPUBackend>* tensor) override {

--- a/dali/pipeline/operators/reader/loader/indexed_file_loader.h
+++ b/dali/pipeline/operators/reader/loader/indexed_file_loader.h
@@ -93,7 +93,7 @@ class IndexedFileLoader : public Loader<CPUBackend> {
       options.GetRepeatedArgument<std::string>("index_path");
     ReadIndexFile(index_uris);
     size_t num_indices = indices_.size();
-    current_index_ = num_indices/num_shards_ * shard_id_;
+    current_index_ = start_index(shard_id_, num_shards_, num_indices);
     int64 seek_pos, size;
     std::tie(seek_pos, size, current_file_index_) = indices_[current_index_];
     current_file_.reset(FileStream::Open(uris_[current_file_index_]));

--- a/dali/pipeline/operators/reader/loader/lmdb.h
+++ b/dali/pipeline/operators/reader/loader/lmdb.h
@@ -82,8 +82,7 @@ class LMDBReader : public Loader<CPUBackend> {
 
     // work out how many entries to move forward to handle sharding
     if (shard_id_ == 0) return;
-    int samples_per_shard = Size() / num_shards_;
-    int start_idx = shard_id_ * samples_per_shard;
+    int start_idx = start_index(shard_id_, num_shards_, Size());
 
     for (int i = 0; i < start_idx; ++i) {
       bool ok = lmdb::SeekLMDB(mdb_cursor_, MDB_NEXT, &key_, &value_);

--- a/dali/pipeline/operators/reader/loader/loader.cc
+++ b/dali/pipeline/operators/reader/loader/loader.cc
@@ -30,4 +30,15 @@ DALI_SCHEMA(LoaderBase)
       R"code(Hint for how much memory to allocate per image.)code", 1048576);
 
 
+size_t start_index(const size_t shard_id,
+                   const size_t shard_num,
+                   const size_t size) {
+  const size_t remainder = size % shard_num;
+  if (shard_id < remainder) {
+    return (size / shard_num) *shard_id + shard_id;
+  } else {
+    return (size / shard_num) * shard_id + remainder;
+  }
+}
+
 }  // namespace dali

--- a/dali/pipeline/operators/reader/loader/loader.h
+++ b/dali/pipeline/operators/reader/loader/loader.h
@@ -30,6 +30,10 @@
 
 namespace dali {
 
+DLL_PUBLIC size_t start_index(const size_t shard_id,
+                              const size_t shard_num,
+                              const size_t size);
+
 template <class Backend>
 class Loader {
  public:


### PR DESCRIPTION
Before (let's assume dataset size 19 and 4 shards):
 - shard 0 starts at 0 and gets 4 elements
 - shard 1 starts at 4 and gets 4 elements
 - shard 2 starts at 8 and gets 4 elements
 - shard 3 starts at 12 and gets 7 elements

With local batch size 2 you get:
 - 1st batch [0,1,4,5,8,9,12,13]
 - 2nd batch [2,3,6,7,10,11,14,15]
 - 3rd batch [4,5,8,9,12,13,16,17] <- element 18 was not seen yet but the epoch ended

After:
 - shard 0 starts at 0 and gets 5 elements
 - shard 1 starts at 5 and gets 5 elements
 - shard 2 starts at 10 and gets 5 elements
 - shard 3 starts at 15 and gets 4 elements

With local batch size 2 you get:
 - 1st batch [0,1,5,6,10,11,15,16]
 - 2nd batch [2,3,7,8,12,13,17,18]
 - 3rd batch [4,5,9,10,14,15,0,1] <- all elements were seen in the epoch
