### PR TITLE
Fix clang warnings in half.hpp and tests

### DIFF
--- a/dali/test/dali_test_matching.h
+++ b/dali/test/dali_test_matching.h
@@ -41,8 +41,8 @@ class GenericMatchingTest : public DALISingleOpTest<ImgType> {
     this->RunOperator(descr);
   }
 
-  virtual vector<TensorList<CPUBackend>*>
-  Reference(const vector<TensorList<CPUBackend>*> &inputs, DeviceWorkspace *ws) {
+  vector<TensorList<CPUBackend>*>
+  Reference(const vector<TensorList<CPUBackend>*> &inputs, DeviceWorkspace *ws) override {
     auto from = ws->Output<GPUBackend>(1);
     auto reference = this->CopyToHost(*from);
     reference[0]->SetLayout(from->GetLayout());

--- a/dali/util/half.hpp
+++ b/dali/util/half.hpp
@@ -45,6 +45,10 @@
 	#if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L) && !defined(HALF_ENABLE_CPP11_LONG_LONG)
 		#define HALF_ENABLE_CPP11_LONG_LONG 1
 	#endif
+	#define HALF_POP_WARNINGS 1
+	// struct vs class, see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49174
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wmismatched-tags" 
 /*#elif defined(__INTEL_COMPILER)								//Intel C++
 	#if __INTEL_COMPILER >= 1100 && !defined(HALF_ENABLE_CPP11_STATIC_ASSERT)		????????
 		#define HALF_ENABLE_CPP11_STATIC_ASSERT 1
@@ -1014,6 +1018,7 @@ namespace half_float
 
     // Copy constructor overriding the one above
     // It avoids half->float->half path
+	HALF_CONSTEXPR
     CAFFE_UTIL_HD
     half(const half& rhs) :
       data_(rhs.data_) {}
@@ -3113,7 +3118,11 @@ namespace std
 #undef HALF_NOEXCEPT
 #undef HALF_NOTHROW
 #ifdef HALF_POP_WARNINGS
-	#pragma warning(pop)
+	#if defined(__clang__)
+		#pragma clang diagnostic pop	
+	#elif defined(_MSC_VER)
+		#pragma warning(pop)
+	#endif
 	#undef HALF_POP_WARNINGS
 #endif
 


### PR DESCRIPTION
Turned off clang warning for mismatched tags in
half.hpp as it complains about libstdc++'s numeric_limits.
Added missing constexpr for half(const half&) copy constructor
 - some constexpr functions were using this constructor and
were never producing constant results thus clang warning.

Added missing override in tests.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>