### PR TITLE
Remove inconsistent-missing-override Clang warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror -Wno-unused-variable -Wno-unused-function -fno-strict-aliasing -O2 -fPIC -fvisibility=hidden")
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register -Wno-inconsistent-missing-override")
 
   # CUDA does not support current clang as host compiler, we need use gcc
   # CUDA_HOST_COMPILER variable operates on paths

--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -78,7 +78,7 @@ class FileLoader : public Loader<CPUBackend> {
     current_index_ = start_index(shard_id_, num_shards_, Size());
   }
 
-  void ReadSample(Tensor<CPUBackend>* tensor);
+  void ReadSample(Tensor<CPUBackend>* tensor) override;
 
   Index Size() override;
 


### PR DESCRIPTION
-Winconsistent-missing-override is Clang warning
which is turned on by Wall, but it is not present in gcc.
Turned off to have consistent builds between compilers.

Currently this frequently breaks clang build each time somebody overrides some
virtual function, and forcing override everywhere is not a sensible option.

I would merge this to not have to fix it after each commit.