### PR TITLE
Revert #142. It seems that TF doesn't like having lable tensor size a…

### DIFF
--- a/dali/tensorflow/daliop.cc
+++ b/dali/tensorflow/daliop.cc
@@ -76,12 +76,7 @@ REGISTER_OP("Dali")
         c->MakeShapeFromPartialTensorShape(shape, &passed_shape));
     TF_RETURN_IF_ERROR(
         c->WithRank(passed_shape, NUM_DIMS, &passed_shape));
-    tf::shape_inference::ShapeHandle label_shape;
-    TF_RETURN_IF_ERROR(
-        c->MakeShapeFromPartialTensorShape(tf::PartialTensorShape {shape.dim_size(0)},
-                                           &label_shape));
     c->set_output(0, passed_shape);
-    c->set_output(1, label_shape);
     return tf::Status::OK();
   })
   .Doc(R"doc(


### PR DESCRIPTION
…lways defined.

Somehow TF during training instead of having (n,) tensor redefines it as a (n, 1)
and complains that it cannot be 2D.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>