### PR TITLE
Add fine grained control over output buffers in the pipeline

### DIFF
--- a/dali/benchmark/caffe2_alexnet_bench.cc
+++ b/dali/benchmark/caffe2_alexnet_bench.cc
@@ -37,7 +37,7 @@ BENCHMARK_DEFINE_F(C2Alexnet, Caffe2Pipe)(benchmark::State& st) { // NOLINT
   Pipeline pipe(
       batch_size,
       num_thread,
-      0, -1, pipelined,
+      0, -1, pipelined, 2,
       async);
 
   dali::string path(std::getenv("DALI_TEST_CAFFE2_LMDB_PATH"));
@@ -165,7 +165,7 @@ BENCHMARK_DEFINE_F(C2Alexnet, HybridPipe)(benchmark::State& st) { // NOLINT
   Pipeline pipe(
       batch_size,
       num_thread,
-      0, -1, pipelined,
+      0, -1, pipelined, 2,
       async);
 
   pipe.AddOperator(

--- a/dali/benchmark/caffe_alexnet_bench.cc
+++ b/dali/benchmark/caffe_alexnet_bench.cc
@@ -37,7 +37,7 @@ BENCHMARK_DEFINE_F(Alexnet, CaffePipe)(benchmark::State& st) { // NOLINT
   Pipeline pipe(
       batch_size,
       num_thread,
-      0, -1, pipelined,
+      0, -1, pipelined, 2,
       async);
 
   dali::string path(std::getenv("DALI_TEST_CAFFE_LMDB_PATH"));
@@ -166,7 +166,7 @@ BENCHMARK_DEFINE_F(Alexnet, HybridPipe)(benchmark::State& st) { // NOLINT
   Pipeline pipe(
       batch_size,
       num_thread,
-      0, -1, pipelined,
+      0, -1, pipelined, 2,
       async);
 
   pipe.AddOperator(

--- a/dali/benchmark/decoder_bench.cc
+++ b/dali/benchmark/decoder_bench.cc
@@ -34,6 +34,7 @@ BENCHMARK_DEFINE_F(DecoderBench, HostDecoder)(benchmark::State& st) { // NOLINT
       num_thread,
       0, -1,
       true,   // pipelined
+      2,      // pipe length
       true);  // async
 
   TensorList<CPUBackend> data;
@@ -106,6 +107,7 @@ BENCHMARK_DEFINE_F(DecoderBench, nvJPEGDecoder)(benchmark::State& st) { // NOLIN
       num_thread,
       0, -1,
       true,   // pipelined
+      2,      // pipe length
       true);  // async
 
   TensorList<CPUBackend> data;
@@ -168,6 +170,7 @@ BENCHMARK_DEFINE_F(DecoderBench, nvJPEGDecoderBatched)(benchmark::State& st) { /
       num_thread,
       0, -1,
       true,   // pipelined
+      2,      // pipe length
       true);  // async
 
   TensorList<CPUBackend> data;

--- a/dali/benchmark/file_reader_alexnet_bench.cc
+++ b/dali/benchmark/file_reader_alexnet_bench.cc
@@ -36,7 +36,7 @@ BENCHMARK_DEFINE_F(FileReaderAlexnet, CaffePipe)(benchmark::State& st) { // NOLI
   Pipeline pipe(
       batch_size,
       num_thread,
-      0, -1, pipelined,
+      0, -1, pipelined, 2,
       async);
 
   dali::string list_root(std::getenv("DALI_TEST_FILE_READER_LIST_ROOT"));

--- a/dali/benchmark/resnet50_bench.cc
+++ b/dali/benchmark/resnet50_bench.cc
@@ -37,7 +37,7 @@ BENCHMARK_DEFINE_F(RN50, C2Pipe)(benchmark::State& st) { // NOLINT
   Pipeline pipe(
       batch_size,
       num_thread,
-      0, -1, pipelined,
+      0, -1, pipelined, 2,
       async);
 
   TensorList<CPUBackend> data;
@@ -167,7 +167,7 @@ BENCHMARK_DEFINE_F(RN50, HybridPipe)(benchmark::State& st) { // NOLINT
   Pipeline pipe(
       batch_size,
       num_thread,
-      0, -1, pipelined,
+      0, -1, pipelined, 2,
       async);
 
   TensorList<CPUBackend> data;
@@ -299,7 +299,7 @@ BENCHMARK_DEFINE_F(RN50, nvJPEGPipe)(benchmark::State& st) { // NOLINT
   Pipeline pipe(
       batch_size,
       num_thread,
-      0, -1, pipelined,
+      0, -1, pipelined, 2,
       async);
 
   TensorList<CPUBackend> data;

--- a/dali/benchmark/resnet50_nvjpeg_bench.cc
+++ b/dali/benchmark/resnet50_nvjpeg_bench.cc
@@ -36,7 +36,7 @@ BENCHMARK_DEFINE_F(RealRN50, nvjpegPipe)(benchmark::State& st) { // NOLINT
   Pipeline pipe(
       batch_size,
       num_thread,
-      0, -1, pipelined,
+      0, -1, pipelined, 2,
       async);
 
   pipe.AddOperator(

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -25,13 +25,15 @@ void daliCreatePipeline(daliPipelineHandle* pipe_handle,
     int length,
     int batch_size,
     int num_threads,
-    int device_id) {
+    int device_id,
+    int prefetch_queue_depth) {
   dali::Pipeline* pipe = new dali::Pipeline(
                               std::string(serialized_pipeline, length),
                               batch_size,
                               num_threads,
                               device_id,
                               true,
+                              prefetch_queue_depth,
                               true);
   pipe->Build();
   pipe_handle->pipe = reinterpret_cast<void*>(pipe);
@@ -48,6 +50,17 @@ void daliOutput(daliPipelineHandle* pipe_handle) {
   dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
   dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
   pipeline->Outputs(ws);
+}
+
+void daliShareOutput(daliPipelineHandle* pipe_handle) {
+  dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
+  dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
+  pipeline->ShareOutputs(ws);
+}
+
+void daliOutputRelease(daliPipelineHandle* pipe_handle) {
+  dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
+  pipeline->ReleaseOutputs();
 }
 
 int64_t* daliShapeAt(daliPipelineHandle* pipe_handle, int n) {

--- a/dali/c_api/c_api.h
+++ b/dali/c_api/c_api.h
@@ -36,7 +36,8 @@ extern "C" {
       int length,
       int batch_size = -1,
       int num_threads = -1,
-      int device_id = -1);
+      int device_id = -1,
+      int prefetch_queue_depth = 2);
 
   /**
    * @brief Start the execution of the pipeline.
@@ -45,8 +46,20 @@ extern "C" {
 
   /**
    * @brief Wait till the output of the pipeline is ready.
+   * Releases previously returned buffers.
    */
   DLL_PUBLIC void daliOutput(daliPipelineHandle* pipe_handle);
+
+  /**
+   * @brief Wait till the output of the pipeline is ready.
+   * Doesn't release previously returned buffers.
+   */
+  DLL_PUBLIC void daliShareOutput(daliPipelineHandle* pipe_handle);
+
+  /**
+   * @brief Releases buffer returned by last daliOutput call.
+   */
+  DLL_PUBLIC void daliOutputRelease(daliPipelineHandle* pipe_handle);
 
   /**
    * @brief Return the shape of the output tensor

--- a/dali/pipeline/executor/async_pipelined_executor.h
+++ b/dali/pipeline/executor/async_pipelined_executor.h
@@ -34,14 +34,13 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
  public:
   DLL_PUBLIC inline AsyncPipelinedExecutor(int batch_size, int num_thread,
       int device_id, size_t bytes_per_sample_hint,
-      bool set_affinity = false, int max_num_stream = -1) :
+      bool set_affinity = false, int max_num_stream = -1, int prefetch_queue_depth = 2) :
     PipelinedExecutor(batch_size, num_thread, device_id,
-        bytes_per_sample_hint, set_affinity, max_num_stream),
+        bytes_per_sample_hint, set_affinity, max_num_stream, prefetch_queue_depth),
     cpu_thread_(device_id, set_affinity),
     mixed_thread_(device_id, set_affinity),
     gpu_thread_(device_id, set_affinity),
     device_id_(device_id) {
-    Executor::queue_depth_ = 2;
   }
 
   DLL_PUBLIC virtual ~AsyncPipelinedExecutor() {

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -45,10 +45,10 @@ class DLL_PUBLIC Executor {
  public:
   DLL_PUBLIC inline Executor(int batch_size, int num_thread, int device_id,
       size_t bytes_per_sample_hint, bool set_affinity = false,
-      int max_num_stream = -1) :
+      int max_num_stream = -1, int prefetch_queue_depth = 2) :
     batch_size_(batch_size), device_id_(device_id),
     bytes_per_sample_hint_(bytes_per_sample_hint),
-    queue_depth_(2),
+    queue_depth_(prefetch_queue_depth),
     stream_pool_(max_num_stream, true), event_pool_(max_num_stream),
     thread_pool_(num_thread, device_id, set_affinity),
     exec_error_(false) {
@@ -69,6 +69,10 @@ class DLL_PUBLIC Executor {
   DLL_PUBLIC virtual void RunGPU();
 
   DLL_PUBLIC virtual void Outputs(DeviceWorkspace *ws);
+
+  DLL_PUBLIC virtual void ShareOutputs(DeviceWorkspace *ws);
+
+  DLL_PUBLIC virtual void ReleaseOutputs();
 
   friend class ExecutorTest;
 

--- a/dali/pipeline/executor/pipelined_executor.h
+++ b/dali/pipeline/executor/pipelined_executor.h
@@ -39,9 +39,9 @@ class DLL_PUBLIC PipelinedExecutor : public Executor {
  public:
   DLL_PUBLIC inline PipelinedExecutor(int batch_size, int num_thread,
       int device_id, size_t bytes_per_sample_hint,
-      bool set_affinity = false, int max_num_stream = -1) :
+      bool set_affinity = false, int max_num_stream = -1, int prefetch_queue_depth = 2) :
     Executor(batch_size, num_thread, device_id, bytes_per_sample_hint,
-        set_affinity, max_num_stream) {
+        set_affinity, max_num_stream, prefetch_queue_depth) {
     Executor::queue_depth_ = 3;
   }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -78,23 +78,24 @@ class DLL_PUBLIC Pipeline {
    * configured in the thread pool. Defaults to 'false'.
    * @param max_num_stream set an upper limit on the number of cudaStreams
    * that can be allocated by the pipeline.
+   * @param prefetch_queue_depth sets the length of the executor internal pipeline
    */
   DLL_PUBLIC inline Pipeline(int batch_size, int num_threads, int device_id, int seed = -1,
-      bool pipelined_execution = true, bool async_execution = true,
-      size_t bytes_per_sample_hint = 0, bool set_affinity = false,
-      int max_num_stream = -1) :
+      bool pipelined_execution = true, int prefetch_queue_depth = 2,
+      bool async_execution = true, size_t bytes_per_sample_hint = 0,
+      bool set_affinity = false, int max_num_stream = -1) :
     built_(false) {
     Init(batch_size, num_threads, device_id, seed,
          pipelined_execution, async_execution,
          bytes_per_sample_hint, set_affinity,
-         max_num_stream);
+         max_num_stream, prefetch_queue_depth);
   }
 
   DLL_PUBLIC Pipeline(const string &serialized_pipe,
       int batch_size = -1, int num_threads = -1, int device_id = -1,
-      bool pipelined_execution = true, bool async_execution = true,
-      size_t bytes_per_sample_hint = 0, bool set_affinity = false,
-      int max_num_stream = -1);
+      bool pipelined_execution = true, int prefetch_queue_depth = 2,
+      bool async_execution = true, size_t bytes_per_sample_hint = 0,
+      bool set_affinity = false, int max_num_stream = -1);
 
   DLL_PUBLIC ~Pipeline() = default;
 
@@ -209,11 +210,29 @@ class DLL_PUBLIC Pipeline {
 
   /**
    * @brief Fills the input device workspace with the output of the pipeline.
+   * Previously returned buffers are released.
    * This method blocks until the next batch is complete. RunCPU and RunGPU
    * must be called prior to calling this or this method will result in
    * deadlock.
    */
   DLL_PUBLIC void Outputs(DeviceWorkspace *ws);
+
+  /**
+   * @brief Fills the input device workspace with the output of the pipeline.
+   * To release previously returned buffers ReleaseOutputs need to be called.
+   * This method blocks until the next batch is complete. RunCPU and RunGPU
+   * must be called prior to calling this or this method will result in
+   * deadlock.
+   */
+  DLL_PUBLIC void ShareOutputs(DeviceWorkspace *ws);
+
+  /**
+   * @brief Release buffers returned by the Output call
+   * This method is meant for cases where buffers are coppied out
+   * or consumed in any other way, so it is possible to set them free
+   * before next Outputs call
+   */
+  DLL_PUBLIC void ReleaseOutputs();
 
   /**
    * @brief serializes the pipe to a protobuf
@@ -260,7 +279,7 @@ class DLL_PUBLIC Pipeline {
   void Init(int batch_size, int num_threads, int device_id,
             int seed, bool pipelined_execution, bool async_execution,
             size_t bytes_per_sample_hint, bool set_affinity,
-            int max_num_stream) {
+            int max_num_stream, int prefetch_queue_depth = 2) {
     this->batch_size_ = batch_size;
     this->num_threads_ = num_threads;
     this->device_id_ = device_id;
@@ -270,6 +289,7 @@ class DLL_PUBLIC Pipeline {
     this->bytes_per_sample_hint_ = bytes_per_sample_hint;
     this->set_affinity_ = set_affinity;
     this->max_num_stream_ = max_num_stream;
+    this->prefetch_queue_depth_ = prefetch_queue_depth;
     DALI_ENFORCE(batch_size_ > 0, "Batch size must be greater than 0");
     seed_.resize(MAX_SEEDS);
     current_seed_ = 0;
@@ -335,6 +355,7 @@ class DLL_PUBLIC Pipeline {
   size_t bytes_per_sample_hint_;
   int set_affinity_;
   int max_num_stream_;
+  int prefetch_queue_depth_;
 
   std::vector<int> seed_;
   int original_seed_;

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -61,16 +61,20 @@ class Pipeline(object):
                     Value of -1 does not impose a limit.
                     This parameter is currently unused (and behavior of
                     unrestricted number of streams is assumed).
+    `prefetch_queue_depth`: length of the executor pipeline. The longer the more resistant
+                    the Dali is fo uneven execution time of each batch, but it also
+                    consumes more memory for the internall buffers
     """
     def __init__(self, batch_size = -1, num_threads = -1, device_id = -1, seed = -1,
-                 exec_pipelined=True, exec_async=True,
-                 bytes_per_sample=0, set_affinity=False,
-                 max_streams=-1):
+                 exec_pipelined=True, prefetch_queue_depth=2,
+                 exec_async=True, bytes_per_sample=0,
+                 set_affinity=False, max_streams=-1):
         self._batch_size = batch_size
         self._num_threads = num_threads
         self._device_id = device_id
         self._seed = seed
         self._exec_pipelined = exec_pipelined
+        self._prefetch_queue_depth = prefetch_queue_depth
         self._built = False
         self._first_iter = True
         self._prepared = False
@@ -121,6 +125,7 @@ class Pipeline(object):
                                 self._device_id,
                                 self._seed,
                                 self._exec_pipelined,
+                                self._prefetch_queue_depth,
                                 self._exec_async,
                                 self._bytes_per_sample,
                                 self._set_affinity,
@@ -230,13 +235,30 @@ class Pipeline(object):
         self._pipe.RunGPU()
 
     def outputs(self):
-        """Returns the outputs of the pipeline.
+        """Returns the outputs of the pipeline and releases previous buffer.
 
         If the pipeline is executed asynchronously, this function blocks
         until the results become available."""
+        self._release_outputs()
+        return self._share_outputs()
+
+    def _share_outputs(self):
+        """Returns the outputs of the pipeline.
+
+        Main difference to outputs is that _share_outputs doesn't release
+        returned buffers, _release_outputs need to be called for that.
+        If the pipeline is executed asynchronously, this function blocks
+        until the results become available."""
+        return self._pipe.ShareOutputs()
+
+    def _release_outputs(self):
+        """Release buffers returned by _share_outputs calls.
+
+        It helps in case when output call result is consumed (copied)
+        and buffers can be set free before next _share_outputs call"""
         if not self._built:
             raise RuntimeError("Pipeline must be built first.")
-        return self._pipe.Outputs()
+        return self._pipe.ReleaseOutputs()
 
     def run(self):
         """Run the pipeline and return the result.
@@ -244,21 +266,29 @@ class Pipeline(object):
         If the pipeline was created with `exec_async` option set to `True`,
         this function will also start prefetching the next iteration for
         faster execution."""
+        if not self._built:
+            raise RuntimeError("Pipeline must be built first.")
+        if self._first_iter and self._exec_pipelined:
+            self._first_iter = False
+            for i in range(self._prefetch_queue_depth - 1):
+             self._start_run()
         self._start_run()
         return self.outputs()
+
+    def _prefetch(self):
+        """Executes pipeline to fill executor's pipeline."""
+        if not self._built:
+            raise RuntimeError("Pipeline must be built first.")
+        if self._first_iter and self._exec_pipelined:
+            self._first_iter = False
+            for i in range(self._prefetch_queue_depth):
+                self._start_run()
 
     def _start_run(self):
         """Start running the pipeline without waiting for its results.
 
         If the pipeline was created with `exec_async` option set to `True`,
         this function will return without waiting for the execution to end."""
-        if not self._built:
-            raise RuntimeError("Pipeline must be built first.")
-        if self._first_iter and self._exec_pipelined:
-            self.iter_setup()
-            self._run_cpu()
-            self._run_gpu()
-            self._first_iter = False
         self.iter_setup()
         self._run_cpu()
         self._run_gpu()

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -126,9 +126,9 @@ class DALIGenericIterator(object):
         # Gather outputs
         outputs = []
         for p in self._pipes:
-            p._start_run()
+            p._prefetch()
         for p in self._pipes:
-            outputs.append(p.outputs())
+            outputs.append(p._share_outputs())
         for i in range(self._num_gpus):
             out_data = []
             out_label = []
@@ -161,6 +161,11 @@ class DALIGenericIterator(object):
                 feed_ndarray(data[j], d_arr)
             for j, l_arr in enumerate(l):
                 feed_ndarray(label[j], l_arr)
+
+        for p in self._pipes:
+            p._release_outputs()
+            p._start_run()
+
         copy_db_index = self._current_data_batch
         # Change index for double buffering
         self._current_data_batch = (self._current_data_batch + 1) % 2

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -102,9 +102,9 @@ class DALIGenericIterator(object):
         # Gather outputs
         outputs = []
         for p in self._pipes:
-            p._start_run()
+            p._prefetch()
         for p in self._pipes:
-            outputs.append(p.outputs())
+            outputs.append(p._share_outputs())
         for i in range(self._num_gpus):
             dev_id = self._pipes[i].device_id
             out_data = []
@@ -146,6 +146,9 @@ class DALIGenericIterator(object):
                 feed_ndarray(d_arr, pyt_data[j])
             for j, l_arr in enumerate(labels):
                 feed_ndarray(l_arr, pyt_labels[j])
+            for p in self._pipes:
+                p._release_outputs()
+                p._start_run()
 
 
         copy_db_index = self._current_data_batch

--- a/dali/tensorflow/daliop.cc
+++ b/dali/tensorflow/daliop.cc
@@ -104,7 +104,13 @@ class DaliOp : public tf::OpKernel {
     OP_REQUIRES_OK(context, context->GetAttr("shape", &shape_));
     OP_REQUIRES_OK(context, context->GetAttr("num_threads", &num_threads));
     OP_REQUIRES_OK(context, context->GetAttr("device_id", &device_id));
+    if (context->HasAttr("prefetch_queue_depth")) {
+      OP_REQUIRES_OK(context, context->GetAttr("prefetch_queue_depth", &prefetch_queue_depth_));
+    } else {
+      prefetch_queue_depth_ = 2;
+    }
     this->device_id_ = device_id;
+    this->prefetched_ = false;
     LOG_LINE << "Initializing...\n";
 
     TF_DALI_CALL(daliCreatePipeline(&pipe_handle_,
@@ -112,7 +118,8 @@ class DaliOp : public tf::OpKernel {
                    serialized_pipeline.length(),
                    shape_.dim_size(0),
                    num_threads,
-                   device_id));
+                   device_id,
+                   prefetch_queue_depth_));
 
 #if USE_TF_ALLOCATOR
     SetupTFAllocator(device_id_);
@@ -129,19 +136,22 @@ class DaliOp : public tf::OpKernel {
 
   void Compute(tf::OpKernelContext* context) override {
     auto total_s = Clock::now();
-    LOG_LINE << "Computing...\n";
+    if (!this->prefetched_) {
+      LOG_LINE << "Prefetching...\n";
+      this->prefetched_ = true;
+      for (int i = 0; i < prefetch_queue_depth_; ++i) {
+        TF_DALI_CALL(daliRun(&pipe_handle_));
+      }
+    }
+
 #if USE_TF_ALLOCATOR
     UpdateTFAllocaterContext<tf::OpKernelContext>(context, device_id_);
-#endif
     LOG_LINE << "Updated context\n";
-    auto s = Clock::now();
-    TF_DALI_CALL(daliRun(&pipe_handle_));
-    int64_t run_time = std::chrono::duration_cast<std::chrono::microseconds>(
-                         Clock::now() - s).count();
+#endif
     LOG_LINE << "Before output...\n";
 
-    s = Clock::now();
-    TF_DALI_CALL(daliOutput(&pipe_handle_));
+    auto s = Clock::now();
+    TF_DALI_CALL(daliShareOutput(&pipe_handle_));
     int64_t output_time = std::chrono::duration_cast<std::chrono::microseconds>(
                             Clock::now() - s).count();
     LOG_LINE << "After output...\n";
@@ -183,8 +193,17 @@ class DaliOp : public tf::OpKernel {
     int64_t copy1_time =  std::chrono::duration_cast<std::chrono::microseconds>(
                             Clock::now() - s).count();
 
+    TF_DALI_CALL(daliOutputRelease(&pipe_handle_));
+
+    LOG_LINE << "Computing...\n";
+    s = Clock::now();
+    TF_DALI_CALL(daliRun(&pipe_handle_));
+    int64_t run_time = std::chrono::duration_cast<std::chrono::microseconds>(
+                         Clock::now() - s).count();
+
     int64_t total_time = std::chrono::duration_cast<std::chrono::microseconds>(
                            Clock::now() - total_s).count();
+
     LOG_LINE << "[TIMES] TOTAL " << total_time << " RUN " << run_time
       << " - OUTPUT " << output_time << " - ALLOC " << allocate_time
       << " - COPY0 " << copy0_time << " - COPY1 " << copy1_time << std::endl;
@@ -194,6 +213,8 @@ class DaliOp : public tf::OpKernel {
   daliPipelineHandle pipe_handle_;
   tf::TensorShape shape_;
   int device_id_;
+  int prefetch_queue_depth_;
+  bool prefetched_;
 };
 
 using tf::int64;

--- a/docs/examples/pytorch/main.py
+++ b/docs/examples/pytorch/main.py
@@ -234,14 +234,10 @@ def main():
 
     pipe = HybridTrainPipe(batch_size=args.batch_size, num_threads=args.workers, device_id=args.local_rank, data_dir=traindir, crop=crop_size)
     pipe.build()
-    # Test-run to validate pipe.
-    test_run_train_pipe = pipe.run()
     train_loader = DALIClassificationIterator(pipe, size=int(pipe.epoch_size("Reader") / args.world_size))
 
     pipe = HybridValPipe(batch_size=args.batch_size, num_threads=args.workers, device_id=args.local_rank, data_dir=valdir, crop=crop_size, size=val_size)
     pipe.build()
-    # Test-run to validate pipe.
-    test_run_test_pipe = pipe.run()
     val_loader = DALIClassificationIterator(pipe, size=int(pipe.epoch_size("Reader") / args.world_size))
 
     if args.evaluate:


### PR DESCRIPTION
With current asynchronous executor design, we have n-buffers, while 1
is being consumed, other can be calculated. When n is equal to 2
and we release old one and start consuming new one. If released
one cannot be filled during one network forward and backward pass
everything waits until it is filled. By this path, it is possible to immediately release the buffer as soon as data is copied to some external
tensor. Also, this change adds the ability to set pipeline length in the executor
 - the default value is 2.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>