### PR TITLE
Type safe reader with user-provided custom-type handling

### DIFF
--- a/dali/pipeline/operators/reader/caffe2_reader_op.h
+++ b/dali/pipeline/operators/reader/caffe2_reader_op.h
@@ -21,28 +21,26 @@
 
 namespace dali {
 
-class Caffe2Reader : public DataReader<CPUBackend> {
+class Caffe2Reader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit Caffe2Reader(const OpSpec& spec)
-  : DataReader<CPUBackend>(spec) {
+  : DataReader<CPUBackend, Tensor<CPUBackend>>(spec) {
     loader_.reset(new LMDBReader(spec));
     parser_.reset(new Caffe2Parser(spec));
   }
-
-  DEFAULT_READER_DESTRUCTOR(Caffe2Reader, CPUBackend);
 
   void RunImpl(SampleWorkspace* ws, const int i) override {
     const int idx = ws->data_idx();
 
     auto* raw_data = prefetched_batch_[idx];
 
-    parser_->Parse(raw_data->data<uint8_t>(), raw_data->size(), ws);
+    parser_->Parse(*raw_data, ws);
 
     return;
   }
 
  protected:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>);
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/caffe_reader_op.h
+++ b/dali/pipeline/operators/reader/caffe_reader_op.h
@@ -21,28 +21,26 @@
 
 namespace dali {
 
-class CaffeReader : public DataReader<CPUBackend> {
+class CaffeReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit CaffeReader(const OpSpec& spec)
-  : DataReader<CPUBackend>(spec) {
+  : DataReader<CPUBackend, Tensor<CPUBackend>>(spec) {
     loader_.reset(new LMDBReader(spec));
     parser_.reset(new CaffeParser(spec));
   }
-
-  DEFAULT_READER_DESTRUCTOR(CaffeReader, CPUBackend);
 
   void RunImpl(SampleWorkspace* ws, const int i) override {
     const int idx = ws->data_idx();
 
     auto* raw_data = prefetched_batch_[idx];
 
-    parser_->Parse(raw_data->data<uint8_t>(), raw_data->size(), ws);
+    parser_->Parse(*raw_data, ws);
 
     return;
   }
 
  protected:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>);
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/coco_reader_op.h
+++ b/dali/pipeline/operators/reader/coco_reader_op.h
@@ -43,10 +43,10 @@ T get_from_json(const I &im, std::string field) {
 
 namespace dali {
 
-class COCOReader : public DataReader<CPUBackend> {
+class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
  public:
   explicit COCOReader(const OpSpec& spec)
-  : DataReader<CPUBackend>(spec),
+  : DataReader<CPUBackend, ImageLabelWrapper>(spec),
     annotations_filename_(spec.GetRepeatedArgument<std::string>("annotations_file")),
     ltrb_(spec.GetArgument<bool>("ltrb")),
     ratio_(spec.GetArgument<bool>("ratio")) {
@@ -55,14 +55,12 @@ class COCOReader : public DataReader<CPUBackend> {
     parser_.reset(new COCOParser(spec, annotations_multimap_));
   }
 
-  DEFAULT_READER_DESTRUCTOR(COCOReader, CPUBackend);
-
   void RunImpl(SampleWorkspace* ws, const int i) override {
     const int idx = ws->data_idx();
 
-    auto* raw_data = prefetched_batch_[idx];
+    auto* image_label = prefetched_batch_[idx];
 
-    parser_->Parse(raw_data->data<uint8_t>(), raw_data->size(), ws);
+    parser_->Parse(*image_label, ws);
 
     return;
   }
@@ -139,7 +137,7 @@ class COCOReader : public DataReader<CPUBackend> {
   std::vector<std::pair<std::string, int>> image_id_pairs_;
   bool ltrb_;
   bool ratio_;
-  USE_READER_OPERATOR_MEMBERS(CPUBackend);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, ImageLabelWrapper);
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/file_reader_op.h
+++ b/dali/pipeline/operators/reader/file_reader_op.h
@@ -20,43 +20,39 @@
 
 namespace dali {
 
-class FileReader : public DataReader<CPUBackend> {
+class FileReader : public DataReader<CPUBackend, ImageLabelWrapper> {
  public:
   explicit FileReader(const OpSpec& spec)
-    : DataReader<CPUBackend>(spec) {
+    : DataReader<CPUBackend, ImageLabelWrapper>(spec) {
     loader_.reset(new FileLoader(spec));
   }
-
-  DEFAULT_READER_DESTRUCTOR(FileReader, CPUBackend);
 
   void RunImpl(SampleWorkspace *ws, const int i) override {
     const int idx = ws->data_idx();
 
-    auto* raw_data = prefetched_batch_[idx];
+    auto* image_label = prefetched_batch_[idx];
 
     // copy from raw_data -> outputs directly
     auto *image_output = ws->Output<CPUBackend>(0);
     auto *label_output = ws->Output<CPUBackend>(1);
 
-    Index raw_size = raw_data->size();
-    Index image_size = raw_size - sizeof(int);
+    Index image_size = image_label->image.size();
 
     image_output->Resize({image_size});
     image_output->mutable_data<uint8_t>();
     label_output->Resize({1});
 
     std::memcpy(image_output->raw_mutable_data(),
-                raw_data->raw_data(),
+                image_label->image.raw_data(),
                 image_size);
-    image_output->SetSourceInfo(raw_data->GetSourceInfo());
+    image_output->SetSourceInfo(image_label->image.GetSourceInfo());
 
-    label_output->mutable_data<int>()[0] =
-       *reinterpret_cast<const int*>(raw_data->data<uint8_t>() + image_size);
+    label_output->mutable_data<int>()[0] = image_label->label;
     return;
   }
 
  protected:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, ImageLabelWrapper);
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/loader/file_loader.cc
+++ b/dali/pipeline/operators/reader/loader/file_loader.cc
@@ -89,7 +89,12 @@ vector<std::pair<string, int>> filesystem::traverse_directories(const std::strin
 
   return file_label_pairs;
 }
-void FileLoader::ReadSample(Tensor<CPUBackend>* tensor) {
+
+void FileLoader::PrepareEmpty(ImageLabelWrapper *image_label) {
+  PrepareEmptyTensor(&image_label->image);
+}
+
+void FileLoader::ReadSample(ImageLabelWrapper* image_label) {
   auto image_pair = image_label_pairs_[current_index_++];
 
   // handle wrap-around
@@ -100,18 +105,18 @@ void FileLoader::ReadSample(Tensor<CPUBackend>* tensor) {
   FileStream *current_image = FileStream::Open(file_root_ + "/" + image_pair.first);
   Index image_size = current_image->Size();
 
-  // resize tensor to hold [image, label]
-  tensor->Resize({image_size + static_cast<Index>(sizeof(int))});
+  // resize tensor to hold [image]
+  image_label->image.Resize({image_size});
 
   // copy the image
-  current_image->Read(tensor->mutable_data<uint8_t>(), image_size);
-  tensor->SetSourceInfo(image_pair.first);
+  current_image->Read(image_label->image.mutable_data<uint8_t>(), image_size);
+  image_label->image.SetSourceInfo(image_pair.first);
 
   // close the file handle
   current_image->Close();
 
   // copy the label
-  *(reinterpret_cast<int*>(&tensor->mutable_data<uint8_t>()[image_size])) = image_pair.second;
+  image_label->label = image_pair.second;
 }
 
 Index FileLoader::Size() {

--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -38,11 +38,16 @@ vector<std::pair<string, int>> traverse_directories(const std::string& path);
 
 }  // namespace filesystem
 
-class FileLoader : public Loader<CPUBackend> {
+struct ImageLabelWrapper {
+  Tensor<CPUBackend> image;
+  int label;
+};
+
+class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
  public:
   explicit inline FileLoader(const OpSpec& spec,
       vector<std::pair<string, int>> image_label_pairs = std::vector<std::pair<string, int>>())
-    : Loader<CPUBackend>(spec),
+    : Loader<CPUBackend, ImageLabelWrapper>(spec),
       file_root_(spec.GetArgument<string>("file_root")),
       image_label_pairs_(image_label_pairs),
       current_index_(0) {
@@ -78,13 +83,14 @@ class FileLoader : public Loader<CPUBackend> {
     current_index_ = start_index(shard_id_, num_shards_, Size());
   }
 
-  void ReadSample(Tensor<CPUBackend>* tensor) override;
+  void PrepareEmpty(ImageLabelWrapper *tesor) override;
+  void ReadSample(ImageLabelWrapper* tensor) override;
 
   Index Size() override;
 
  protected:
-  using Loader<CPUBackend>::shard_id_;
-  using Loader<CPUBackend>::num_shards_;
+  using Loader<CPUBackend, ImageLabelWrapper>::shard_id_;
+  using Loader<CPUBackend, ImageLabelWrapper>::num_shards_;
 
   string file_root_, file_list_;
   vector<std::pair<string, int>> image_label_pairs_;

--- a/dali/pipeline/operators/reader/loader/indexed_file_loader.h
+++ b/dali/pipeline/operators/reader/loader/indexed_file_loader.h
@@ -27,7 +27,7 @@
 
 namespace dali {
 
-class IndexedFileLoader : public Loader<CPUBackend> {
+class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit IndexedFileLoader(const OpSpec& options, bool init = true)
     : Loader(options),

--- a/dali/pipeline/operators/reader/loader/lmdb.h
+++ b/dali/pipeline/operators/reader/loader/lmdb.h
@@ -61,7 +61,7 @@ namespace lmdb {
   }
 }  // namespace lmdb
 
-class LMDBReader : public Loader<CPUBackend> {
+class LMDBReader : public Loader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit LMDBReader(const OpSpec& options)
     : Loader(options),
@@ -122,8 +122,8 @@ class LMDBReader : public Loader<CPUBackend> {
   }
 
  private:
-  using Loader<CPUBackend>::shard_id_;
-  using Loader<CPUBackend>::num_shards_;
+  using Loader<CPUBackend, Tensor<CPUBackend>>::shard_id_;
+  using Loader<CPUBackend, Tensor<CPUBackend>>::num_shards_;
 
   MDB_env* mdb_env_;
   MDB_cursor* mdb_cursor_;

--- a/dali/pipeline/operators/reader/mxnet_reader_op.h
+++ b/dali/pipeline/operators/reader/mxnet_reader_op.h
@@ -20,28 +20,26 @@
 #include "dali/pipeline/operators/reader/parser/recordio_parser.h"
 
 namespace dali {
-class MXNetReader : public DataReader<CPUBackend> {
+class MXNetReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit MXNetReader(const OpSpec& spec)
-  : DataReader<CPUBackend>(spec) {
+  : DataReader<CPUBackend, Tensor<CPUBackend>>(spec) {
     loader_.reset(new RecordIOLoader(spec));
     parser_.reset(new RecordIOParser(spec));
   }
-
-  DEFAULT_READER_DESTRUCTOR(MXNetReader, CPUBackend);
 
   void RunImpl(SampleWorkspace* ws, const int i) override {
     const int idx = ws->data_idx();
 
     auto* raw_data = prefetched_batch_[idx];
 
-    parser_->Parse(raw_data->data<uint8_t>(), raw_data->size(), ws);
+    parser_->Parse(*raw_data, ws);
 
     return;
   }
 
  protected:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>);
 };
 }  // namespace dali
 

--- a/dali/pipeline/operators/reader/parser/caffe2_parser.h
+++ b/dali/pipeline/operators/reader/parser/caffe2_parser.h
@@ -172,7 +172,7 @@ void ParseLabels(const caffe2::TensorProtos& protos,
   }
 }
 
-class Caffe2Parser : public Parser {
+class Caffe2Parser : public Parser<Tensor<CPUBackend>> {
  public:
   explicit Caffe2Parser(const OpSpec& spec)
     : Parser(spec),
@@ -180,10 +180,10 @@ class Caffe2Parser : public Parser {
       label_type_(static_cast<LabelType>(spec.GetArgument<int>("label_type"))),
       num_labels_(spec.GetArgument<int>("num_labels")) {}
 
-  void Parse(const uint8_t* data, const size_t size, SampleWorkspace* ws) override {
+  void Parse(const Tensor<CPUBackend>& data, SampleWorkspace* ws) override {
     caffe2::TensorProtos protos;
 
-    DALI_ENFORCE(protos.ParseFromArray(data, size));
+    DALI_ENFORCE(protos.ParseFromArray(data.data<uint8_t>(), data.size()));
 
     auto* image = ws->Output<CPUBackend>(0);
 

--- a/dali/pipeline/operators/reader/parser/caffe_parser.h
+++ b/dali/pipeline/operators/reader/parser/caffe_parser.h
@@ -20,15 +20,15 @@
 
 namespace dali {
 
-class CaffeParser : public Parser {
+class CaffeParser : public Parser<Tensor<CPUBackend>> {
  public:
   explicit CaffeParser(const OpSpec& spec) :
     Parser(spec) {}
 
-  void Parse(const uint8_t* data, const size_t size, SampleWorkspace* ws) override {
+  void Parse(const Tensor<CPUBackend>& data, SampleWorkspace* ws) override {
     caffe::Datum datum;
     // DALI_ENFORCE(datum.ParseFromString(string(reinterpret_cast<const char*>(data), size)));
-    DALI_ENFORCE(datum.ParseFromArray(data, size));
+    DALI_ENFORCE(datum.ParseFromArray(data.raw_data(), data.size()));
 
     auto* image = ws->Output<CPUBackend>(0);
     auto* label = ws->Output<CPUBackend>(1);

--- a/dali/pipeline/operators/reader/parser/parser.h
+++ b/dali/pipeline/operators/reader/parser/parser.h
@@ -20,22 +20,24 @@
 namespace dali {
 
 /**
- * Base class for parsing data returned from a Loader
+ * @brief Base class for parsing data returned from a Loader
+ *
+ * @tparam ParseTarget Wrapper for data to be parsed, usually LoadTarget template param
+ *                     forwarded from Loader by DataReader.
  */
+template <typename ParseTarget>
 class Parser {
  public:
   explicit Parser(const OpSpec& spec) {}
   virtual ~Parser() {}
 
   /**
-   * Parse the 'size' bytes of information contained in data to
+   * Parse the information contained in data to
    * whatever is necessary to continue the pipeline.
    * e.g. Extracting (image, label) pairs from a protobuf
    * entry
    */
-  virtual void Parse(const uint8_t* data,
-                     const size_t size,
-                     SampleWorkspace* ws) = 0;
+  virtual void Parse(const ParseTarget& data, SampleWorkspace* ws) = 0;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/parser/parser_test.cc
+++ b/dali/pipeline/operators/reader/parser/parser_test.cc
@@ -25,13 +25,18 @@
 
 namespace dali {
 
+struct IntArrayWrapper {
+  int *data;
+  size_t size;
+};
+
 template <typename Backend>
-class IntArrayParser : public Parser {
+class IntArrayParser : public Parser<IntArrayWrapper> {
  public:
   explicit IntArrayParser(const OpSpec& spec)
-    : Parser(spec) {}
-  void Parse(const uint8_t* data, size_t size, SampleWorkspace* ws) {
-    const int *int_data = reinterpret_cast<const int*>(data);
+    : Parser<IntArrayWrapper>(spec) {}
+  void Parse(const IntArrayWrapper& data, SampleWorkspace* ws) {
+    const int *int_data = data.data;
 
     const int H = int_data[0];
     const int W = int_data[1];
@@ -75,7 +80,8 @@ TYPED_TEST(ParserTest, BasicTest) {
   ws->AddOutput(t);
 
   IntArrayParser<CPUBackend> parser(OpSpec("temp"));
-  parser.Parse(reinterpret_cast<uint8_t*>(data), 3 + H*W*C, ws);
+  IntArrayWrapper ia_wrapper = {data, 3 + H*W*C};
+  parser.Parse(ia_wrapper, ws);
 }
 
 

--- a/dali/pipeline/operators/reader/parser/recordio_parser.h
+++ b/dali/pipeline/operators/reader/parser/recordio_parser.h
@@ -28,16 +28,16 @@ struct ImageRecordIOHeader {
   uint64_t image_id[2];
 };
 
-class RecordIOParser : public Parser {
+class RecordIOParser : public Parser<Tensor<CPUBackend>> {
  public:
   explicit RecordIOParser(const OpSpec& spec) :
-    Parser(spec) {
+    Parser<Tensor<CPUBackend>>(spec) {
   }
 
-  void Parse(const uint8_t* data, const size_t size, SampleWorkspace* ws) override {
+  void Parse(const Tensor<CPUBackend>& data, SampleWorkspace* ws) override {
     auto* image = ws->Output<CPUBackend>(0);
     auto* label = ws->Output<CPUBackend>(1);
-    ReadSingleImageRecordIO(image, label, data);
+    ReadSingleImageRecordIO(image, label, data.data<uint8_t>());
   }
 
  private:

--- a/dali/pipeline/operators/reader/reader_op_test.cc
+++ b/dali/pipeline/operators/reader/reader_op_test.cc
@@ -30,10 +30,10 @@
 
 namespace dali {
 
-class DummyLoader : public Loader<CPUBackend> {
+class DummyLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit DummyLoader(const OpSpec& spec) :
-    Loader<CPUBackend>(spec) {}
+    Loader<CPUBackend, Tensor<CPUBackend>>(spec) {}
 
   void ReadSample(Tensor<CPUBackend> *t) override {
     t->Resize({1});
@@ -45,16 +45,16 @@ class DummyLoader : public Loader<CPUBackend> {
     return 1;
   }
 };
-class DummyDataReader : public DataReader<CPUBackend> {
+class DummyDataReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit DummyDataReader(const OpSpec &spec)
-      : DataReader<CPUBackend>(spec),
+      : DataReader<CPUBackend, Tensor<CPUBackend>>(spec),
         count_(0) {
     loader_.reset(new DummyLoader(spec));
   }
 
   ~DummyDataReader() {
-    DataReader<CPUBackend>::StopPrefetchThread();
+    DataReader<CPUBackend, Tensor<CPUBackend>>::StopPrefetchThread();
   }
   /*
   using DataReader<CPUBackend>::prefetched_batch_;

--- a/dali/pipeline/operators/reader/tfrecord_reader_op.h
+++ b/dali/pipeline/operators/reader/tfrecord_reader_op.h
@@ -23,28 +23,26 @@
 
 namespace dali {
 
-class TFRecordReader : public DataReader<CPUBackend> {
+class TFRecordReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit TFRecordReader(const OpSpec& spec)
-  : DataReader<CPUBackend>(spec) {
+  : DataReader<CPUBackend, Tensor<CPUBackend>>(spec) {
     loader_.reset(new IndexedFileLoader(spec));
     parser_.reset(new TFRecordParser(spec));
   }
-
-  DEFAULT_READER_DESTRUCTOR(TFRecordReader, CPUBackend);
 
   void RunImpl(SampleWorkspace* ws, const int i) override {
     const int idx = ws->data_idx();
 
     auto* raw_data = prefetched_batch_[idx];
 
-    parser_->Parse(raw_data->data<uint8_t>(), raw_data->size(), ws);
+    parser_->Parse(*raw_data, ws);
 
     return;
   }
 
  protected:
-  USE_READER_OPERATOR_MEMBERS(CPUBackend);
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, Tensor<CPUBackend>);
 };
 
 }  // namespace dali


### PR DESCRIPTION
Add LoadTarget to Loader and Parser.
It is intended to allow type-safe sample loading,
as user can provide custom wrapper, where
metadata can be stored safely.

This removes UB from file_loader - int label for image
was placed in a u8 buffer with image data,
and was accessed by reinterpreting a unaligned pointer.
