### PR TITLE
[WIP] Support for Sequences with basic operators refactor

### DIFF
--- a/dali/common.h
+++ b/dali/common.h
@@ -85,9 +85,10 @@ enum DALIImageType {
  * @brief Supported tensor layouts
  */
 enum DALITensorLayout {
-  DALI_NCHW = 0,
-  DALI_NHWC = 1,
-  DALI_SAME = 2
+  DALI_NCHW  = 0,
+  DALI_NHWC  = 1,
+  DALI_NFHWC = 2,
+  DALI_SAME  = 3
 };
 
 inline bool IsColor(DALIImageType type) {

--- a/dali/common.h
+++ b/dali/common.h
@@ -223,6 +223,10 @@ inline std::string to_string(const DALITensorLayout& layout) {
       return "NCHW";
     case DALI_NHWC:
       return "NHWC";
+    case DALI_NFHWC:
+    return "NFHWC";
+    case DALI_SAME:
+      return "SAME";
     default:
       return "<unknown>";
   }

--- a/dali/pipeline/basic/CMakeLists.txt
+++ b/dali/pipeline/basic/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,22 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Add all subdirectories
-add_subdirectory(basic)
-add_subdirectory(data)
-add_subdirectory(operators)
-add_subdirectory(util)
-add_subdirectory(workspace)
-add_subdirectory(executor)
-add_subdirectory(proto)
-
 # Get all the source files and dump test files
-file(GLOB tmp *.cc)
+file(GLOB tmp *.cc *.cu)
 set(DALI_SRCS ${DALI_SRCS} ${tmp})
 file(GLOB tmp *_test.cc)
 remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-file(GLOB tmp *_bench.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
+
 set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
 
 if (BUILD_TEST)
@@ -35,14 +25,3 @@ if (BUILD_TEST)
   file(GLOB tmp *_test.cc)
   set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
 endif()
-
-if (BUILD_BENCHMARK)
-  # Get all the benchmark srcs
-  file(GLOB tmp *_bench.cc)
-  set(DALI_BENCHMARK_SRCS ${DALI_BENCHMARK_SRCS} ${tmp} PARENT_SCOPE)
-endif()
-
-# Get the protobuf files for pipe serialization
-protobuf_generate_cpp(DALI_PROTO_SRCS DALI_PROTO_HEADERS proto/dali.proto)
-add_library(DALI_PROTO OBJECT ${DALI_PROTO_HEADERS} ${DALI_PROTO_SRCS})
-install(FILES ${DALI_PROTO_HEADERS} DESTINATION include/dali/pipeline)

--- a/dali/pipeline/basic/coords.cc
+++ b/dali/pipeline/basic/coords.cc
@@ -1,0 +1,30 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/basic/coords.h"
+
+namespace dali {
+namespace basic {
+
+DALIDataType layoutToTypeId(DALITensorLayout layout) {
+  if (layout == DALITensorLayout::DALI_NHWC) {
+    return TypeInfo::Create<dali_index_sequence<0, 1, 2>>().id();
+  } else if (layout == DALITensorLayout::DALI_NCHW) {
+    return TypeInfo::Create<dali_index_sequence<2, 0, 1>>().id();
+  }
+  return DALIDataType::DALI_NO_TYPE;
+}
+
+}  // namespace basic
+}  // namespace dali

--- a/dali/pipeline/basic/coords.h
+++ b/dali/pipeline/basic/coords.h
@@ -1,0 +1,124 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_BASIC_COORDS_H_
+#define DALI_PIPELINE_BASIC_COORDS_H_
+
+#include "dali/common.h"
+#include "dali/pipeline/data/types.h"
+
+namespace dali {
+namespace basic {
+
+template <typename T>
+Index getPlane(const T& shape) {
+  return 1;
+}
+
+template <size_t I, size_t N, typename T>
+Index getPlane(const T& shape) {
+  Index result = 1;
+  for (size_t i = I; i < N; i++) {
+    result *= shape[i];
+  }
+  return result;
+}
+
+template <typename T, size_t N>
+Index getOffsetImpl(const T& shape, std::array<Index, N> coords) {
+  return 0;
+}
+
+template <Index o, Index... os, typename T, size_t N>
+Index getOffsetImpl(const T& shape, std::array<Index, N> coords) {
+  return coords[o] * getPlane<N - sizeof...(os), N>(shape) + getOffsetImpl<os...>(shape, coords);
+}
+
+template <typename T, Index>
+using order_to_type = T;
+
+/**
+ * @brief Get the offset to coordiantes after requested permutation
+ *
+ * For given shape {s_1, s_2, ... s_n} and coordinates (c_1, c_2, ..., c_n)
+ * return offset after doing axes permuation <o_1, o_2, ..., o_n> (at position i we place axis o_i).
+ *
+ * calculates:
+ *   c[o-1] * (s[o_2] * s[o_3] * ... * s[o_n])
+ * + c[o-2] * (s[o_3] * s[o_4] * ... * s[o_n])
+ * + ...
+ * + c[o_{n-1}] * (s[o_n])
+ * + c[o_n]
+ *
+ * TODO(klecki) formal explanation and handle default case
+ *
+ * Example: for given shape {N, H, W, C}, and coordiantes (n, h, w, c),
+ * and order <0, 1, 2, 3> it would calculate offsets for NHWC data layout.
+ * Other order will produce offsets to permutation of dimensions, for example:
+ * <0, 3, 1, 2> will result in offsets to NCHW data layout.
+ *
+ *
+ * @tparam order Permutation of input dimensions
+ * @tparam T type of container carrying shape information
+ * @param shape Data layout "before" permutation
+ * @param coords Coordinates "before" permutation
+ * @return Index offset to given coordinate
+ */
+template <Index... order, typename T>
+Index getOffset(const T& shape, order_to_type<Index, order>... coords) {
+  return getOffsetImpl<order...>(shape, std::array<Index, sizeof...(order)>{coords...});
+}
+
+template <Index... Ints>
+class dali_index_sequence {};
+
+template <typename T>
+struct index_to_array {};
+
+template <Index... Ints>
+struct index_to_array<dali_index_sequence<Ints...>> {
+  static constexpr std::array<Index, sizeof...(Ints)> array = {Ints...};
+  static constexpr size_t N = sizeof...(Ints);
+};
+
+template <Index... order, typename T, template <Index...> class Seq>
+Index getOffsetBySeq(Seq<order...> seq, const T& shape, order_to_type<Index, order>... coords) {
+  return getOffset<order...>(shape, coords...);
+}
+
+DALIDataType layoutToTypeId(DALITensorLayout layout);
+
+template <Index... order>
+std::array<Index, sizeof...(order)> permuteShape(const std::array<Index, sizeof...(order)>& shape) {
+  return {shape[order]...};
+}
+
+template <Index... order, template <Index...> class Seq>
+std::array<Index, sizeof...(order)> permuteShapeBySeq(
+    Seq<order...> seq, const std::array<Index, sizeof...(order)>& shape) {
+  return {shape[order]...};
+}
+
+// TODO(klecki) - case where sizes are already permutated, implement as Horner's method?
+
+}  // namespace basic
+
+using basic::dali_index_sequence;
+using basic::layoutToTypeId;
+using basic::permuteShape;
+using basic::permuteShapeBySeq;
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_BASIC_COORDS_H_

--- a/dali/pipeline/basic/crop.h
+++ b/dali/pipeline/basic/crop.h
@@ -1,0 +1,95 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_BASIC_CROP_H_
+#define DALI_PIPELINE_BASIC_CROP_H_
+
+#include <tuple>
+
+#include "dali/pipeline/basic/coords.h"
+#include "dali/pipeline/basic/runner.h"
+#include "dali/pipeline/basic/sequence.h"
+#include "dali/pipeline/basic/tensor.h"
+
+namespace dali {
+namespace basic {
+
+// TODO(klecki) allow for Schema to be present without using concrete types
+struct CropSchema {
+  using AllowedInputs = std::tuple<uint8_t>;
+  using AllowedOutputs = std::tuple<uint8_t, int8_t, int16_t, int32_t, int64_t, float>;
+};
+
+template <typename T, typename U, typename OutShape>
+class Crop {
+ public:
+  Crop() = delete;
+  static constexpr size_t input_dim = 3;
+  static constexpr size_t output_dim = 3;
+  // TODO(klecki) - should be converted to some kind of std::tuple for multiple input and outputs
+  using InputType = TensorWrapper<const T, input_dim>;
+  using OutputType = TensorWrapper<U, output_dim>;
+
+  static constexpr bool can_calculate_output_size = true;
+
+  // TODO(klecki): One of the issues is if this type can depend on T and U or if we can have
+  //               the same KernelAttributes for all concrete Crop<T, U> types.
+  struct KernelAttributes {
+    const Index h_start;
+    const Index w_start;
+    const Index H_out;
+    const Index W_out;
+  };
+
+  static void CalcOutputSize(const std::array<Index, input_dim> &in, KernelAttributes attr,
+                             std::array<Index, output_dim> &out) {  // NOLINT
+    out = permuteShapeBySeq(OutShape{}, {attr.H_out, attr.W_out, in[2]});
+  }
+
+  // signature due to change, for now it is iterator-like, should be collection of iterators
+  static void Run(InputType in, KernelAttributes attr, OutputType out) {  // NOLINT
+    const auto *in_ptr = in.ptr + getOffset<0, 1, 2>(in.GetShape(), attr.h_start, attr.w_start, 0);
+    for (Index h = 0; h < attr.H_out; h++) {
+      for (Index w = 0; w < attr.W_out; w++) {
+        for (Index c = 0; c < in.GetShape()[2]; c++) {
+          // From HWC
+          const auto in_idx = getOffset<0, 1, 2>(in.GetShape(), h, w, c);
+          // To HWC or CHW
+          const auto out_idx = getOffsetBySeq(OutShape{}, out.GetShape(), h, w, c);
+          out.ptr[out_idx] = static_cast<U>(in_ptr[in_idx]);
+        }
+      }
+    }
+  }
+};
+
+template <typename T, typename U, typename OutShape>
+using SequenceCrop = SequenceAdapter<Crop<T, U, OutShape>>;
+
+template <typename Out, typename OutShape>
+using CropRunHelper = RunHelperAllowMIS<Crop<uint8_t, Out, OutShape>>;
+
+template <typename Out, typename OutShape>
+using CropSizeHelper = SizeHelperAllowMIS<Crop<uint8_t, Out, OutShape>>;
+
+template <typename Out, typename OutShape>
+using SequenceCropRunHelper = RunHelperAllowMIS<SequenceCrop<uint8_t, Out, OutShape>>;
+
+template <typename Out, typename OutShape>
+using SequenceCropSizeHelper = SizeHelperAllowMIS<SequenceCrop<uint8_t, Out, OutShape>>;
+
+}  // namespace basic
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_BASIC_CROP_H_

--- a/dali/pipeline/basic/crop_test.cc
+++ b/dali/pipeline/basic/crop_test.cc
@@ -1,0 +1,126 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <limits>
+
+#include "dali/pipeline/basic/coords.h"
+#include "dali/pipeline/basic/crop.h"
+#include "dali/pipeline/basic/sequence.h"
+#include "dali/pipeline/basic/tensor.h"
+
+namespace dali {
+
+template <typename InT_, typename OutT_, bool is_seq_, Index S_, Index H_, Index W_, Index C_,
+          Index startH_, Index startW_, Index outH_, Index outW_>
+struct info {
+  using InT = InT_;
+  using OutT = OutT_;
+  static const bool is_seq = is_seq_;
+  static const Index S = S_;
+  static const Index H = H_;
+  static const Index W = W_;
+  static const Index C = C_;
+  static const Index startH = startH_;
+  static const Index startW = startW_;
+  static const Index outH = outH_;
+  static const Index outW = outW_;
+};
+
+template <typename T>
+class CropTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    constexpr size_t in_size = T::S * T::H * T::W * T::C;
+    constexpr size_t out_size = T::S * T::outH * T::outW * T::C;
+    input = new typename T::InT[in_size];
+    output = new typename T::OutT[out_size];
+    for (size_t i = 0; i < in_size; i++) {
+      input[i] = i % std::numeric_limits<typename T::InT>::max();
+    }
+    for (size_t i = 0; i < out_size; i++) {
+      output[i] = 0;
+    }
+  }
+
+  void TearDown() override {
+    for (Index s = 0; s < T::S; s++) {
+      auto in_off = s * T::H * T::W * T::C;
+      auto out_off = s * T::outH * T::outW * T::C;
+      verify_crop(input + in_off, output + out_off, s);
+    }
+    delete[] input;
+    delete[] output;
+  }
+
+  typename T::InT *input;
+  typename T::OutT *output;
+
+ private:
+  void verify_crop(typename T::InT *in_ptr, typename T::OutT *out_ptr, Index s) {
+    for (Index h = 0; h < T::outH; h++) {
+      for (Index w = 0; w < T::outW; w++) {
+        for (Index c = 0; c < T::C; c++) {
+          auto in_off = (T::startH + h) * T::W * T::C + (T::startW + w) * T::C + c;
+          auto out_off = h * T::outW * T::C + w * T::C + c;
+          ASSERT_EQ(in_ptr[in_off], out_ptr[out_off])
+              << " seq: " << s << " (" << h << ", " << w << ", " << c << ")";
+        }
+      }
+    }
+  }
+};
+
+using CropTypes =
+    ::testing::Types<info<uint8_t, uint8_t, false, 1, 1080, 1920, 3, 243, 333, 27, 500>,
+                     info<int32_t, float, false, 1, 1080, 1920, 3, 243, 333, 27, 500>>;
+
+template <typename T>
+using BasicCropTest = CropTest<T>;
+
+TYPED_TEST_CASE(BasicCropTest, CropTypes);
+
+TYPED_TEST(BasicCropTest, FlatCrop) {
+  std::array<Index, 3> in_shape = {TypeParam::H, TypeParam::W, TypeParam::C};
+  basic::TensorWrapper<const typename TypeParam::InT, 3> in(this->input, in_shape.cbegin());
+  std::array<Index, 3> out_shape = {TypeParam::outH, TypeParam::outW, TypeParam::C};
+  basic::TensorWrapper<typename TypeParam::OutT, 3> out(this->output, out_shape.cbegin());
+
+  basic::Crop<typename TypeParam::InT, typename TypeParam::OutT, dali_index_sequence<0, 1, 2>>::Run(
+      in, {TypeParam::startH, TypeParam::startW, TypeParam::outH, TypeParam::outW}, out);
+}
+
+using CropSequenceTypes =
+    ::testing::Types<info<uint8_t, uint8_t, false, 5, 1080, 1920, 3, 243, 333, 27, 500>,
+                     info<int32_t, float, false, 5, 1080, 1920, 3, 243, 333, 27, 500>>;
+
+template <typename T>
+using SequenceCropTest = CropTest<T>;
+
+TYPED_TEST_CASE(SequenceCropTest, CropSequenceTypes);
+
+TYPED_TEST(SequenceCropTest, SequenceCrop) {
+  std::array<Index, 4> in_shape = {TypeParam::S, TypeParam::H, TypeParam::W, TypeParam::C};
+  basic::TensorWrapper<const typename TypeParam::InT, 4> in(this->input, in_shape.cbegin());
+  std::array<Index, 4> out_shape = {TypeParam::S, TypeParam::outH, TypeParam::outW, TypeParam::C};
+  basic::TensorWrapper<typename TypeParam::OutT, 4> out(this->output, out_shape.cbegin());
+
+  basic::SequenceCrop<typename TypeParam::InT, typename TypeParam::OutT,
+                      dali_index_sequence<0, 1, 2>>::Run(in,
+                                                         {TypeParam::startH, TypeParam::startW,
+                                                          TypeParam::outH, TypeParam::outW},
+                                                         out);
+}
+
+}  // namespace dali

--- a/dali/pipeline/basic/runner.h
+++ b/dali/pipeline/basic/runner.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_BASIC_RUNNER_H_
+#define DALI_PIPELINE_BASIC_RUNNER_H_
+
+#include <utility>
+
+#include "dali/pipeline/basic/tensor.h"
+#include "dali/pipeline/workspace/sample_workspace.h"
+
+namespace dali {
+namespace basic {
+
+/**
+ * @brief Create Runner and Resize helpers for Operator
+ *
+ * AllowMIS - AllowMultipleInputSets
+ * Conviniently the operator must heave one input and output.
+ *
+ * @tparam Op - operator which we automatically create runner and resizer
+ */
+template <typename Op>
+struct SizeHelperAllowMIS {
+  template <typename... U>
+  static void Run(SampleWorkspace *ws, const int idx, U &&... u) {
+    const auto &input = ws->Input<CPUBackend>(idx);
+    // using Op = SequenceCrop<uint8_t, Out, Seq>;
+
+    std::array<Index, Op::input_dim> in_shape = TensorShape<Op::input_dim>(input).GetShape();
+    std::array<Index, Op::output_dim> out_shape;
+    Op::CalcOutputSize(in_shape, {std::forward<U>(u)...}, out_shape);
+
+    Dims out_dim;
+    for (const auto &s : out_shape) {
+      out_dim.push_back(s);
+    }
+    ws->Output<CPUBackend>(idx)->Resize(out_dim);
+  }
+};
+
+template <typename Op>
+struct RunHelperAllowMIS {
+  template <typename... U>
+  static void Run(SampleWorkspace *ws, const int idx, U &&... u) {
+    const auto &input = ws->Input<CPUBackend>(idx);
+    auto *output = ws->Output<CPUBackend>(idx);
+    // using Op = SequenceCrop<uint8_t, Out, Seq>;
+
+    // ValidateHelper not needed - TensorWrapper ensures that ptr != nullptr.
+    // TODO(klecki) - Input and output allocations should already be hanlded at this stage.
+
+    typename Op::InputType in_wrapper(input);
+    typename Op::OutputType out_wrapper(*output);
+    Op::Run(in_wrapper, {std::forward<U>(u)...}, out_wrapper);
+  }
+};
+
+}  // namespace basic
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_BASIC_RUNNER_H_

--- a/dali/pipeline/basic/sequence.h
+++ b/dali/pipeline/basic/sequence.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_BASIC_SEQUENCE_H_
+#define DALI_PIPELINE_BASIC_SEQUENCE_H_
+
+#include <type_traits>
+
+#include "dali/pipeline/basic/tensor.h"
+
+namespace dali {
+namespace basic {
+
+template <typename Adapted>
+struct SequenceAdapter {
+ public:
+  SequenceAdapter() = delete;
+  static constexpr size_t input_dim = Adapted::input_dim + 1;
+  static constexpr size_t output_dim = Adapted::output_dim + 1;
+  using InputType = add_dim_t<typename Adapted::InputType>;
+  using OutputType = add_dim_t<typename Adapted::OutputType>;
+
+  static constexpr bool can_calculate_output_size = Adapted::can_calculate_output_size;
+
+  using KernelAttributes = typename Adapted::KernelAttributes;
+
+  static typename std::enable_if<Adapted::can_calculate_output_size>::type CalcOutputSize(
+      const std::array<Index, input_dim> &in, KernelAttributes attr,
+      std::array<Index, output_dim> &out) {  // NOLINT
+    // Forward length of sequence
+    out[0] = in[0];
+    std::array<Index, Adapted::input_dim> adapted_in;
+    std::array<Index, Adapted::output_dim> adapted_out;
+    for (size_t i = 1; i < input_dim; i++) {
+      adapted_in[i - 1] = in[i];
+    }
+    Adapted::CalcOutputSize(adapted_in, attr, adapted_out);
+    for (size_t i = 1; i < output_dim; i++) {
+      out[i] = adapted_out[i - 1];
+    }
+  }
+
+  static void Run(InputType in, KernelAttributes attr, OutputType out) {  // NOLINT
+    auto in_seq = SequenceWrapper<typename InputType::type, input_dim>(in);
+    auto out_seq = SequenceWrapper<typename OutputType::type, output_dim>(out);
+    for (Index i = 0; i < in_seq.sequence_length; i++) {
+      Adapted::Run(in_seq.Get(i), attr, out_seq.Get(i));
+    }
+  }
+};
+
+}  // namespace basic
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_BASIC_SEQUENCE_H_

--- a/dali/pipeline/basic/tensor.h
+++ b/dali/pipeline/basic/tensor.h
@@ -1,0 +1,142 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_BASIC_TENSOR_H_
+#define DALI_PIPELINE_BASIC_TENSOR_H_
+
+#include "dali/common.h"
+#include "dali/pipeline/data/tensor.h"
+
+namespace dali {
+namespace basic {
+
+template <size_t N>
+struct TensorShape {
+  explicit TensorShape(const Tensor<CPUBackend>& t) {
+    for (size_t i = 0; i < N; i++) {
+      shape[i] = t.dim(i);
+    }
+  }
+
+  explicit TensorShape(const TensorShape& other) {
+    for (size_t i = 0; i < N; i++) {
+      shape[i] = other.shape[i];
+    }
+  }
+
+  // Why call for TensorWrapper (subclass) calls this instead of proper copy constructor??
+  template <typename Iter>
+  explicit TensorShape(Iter it) {
+    for (size_t i = 0; i < N; i++) {
+      shape[i] = *it;
+      ++it;
+    }
+  }
+
+  const std::array<Index, N>& GetShape() const { return shape; }
+
+ private:
+  std::array<Index, N> shape;
+};
+
+template <typename T, size_t N>
+struct TensorWrapper : public TensorShape<N> {
+  TensorWrapper() = delete;
+  // TODO(klecki): C++ way instead of Google's. Should probably be fixed
+  explicit TensorWrapper(Tensor<CPUBackend>& t)  // NOLINT
+      : TensorShape<N>(t), ptr(t.mutable_data<T>()) {
+    // TODO(klecki): I think this is not the place for this kind of checks
+    DALI_ENFORCE(ptr != nullptr, "Tensor wrapper does not accept nullptr");
+  }
+
+  TensorWrapper(const TensorWrapper& t) : TensorShape<N>(t.GetShape().cbegin()), ptr(t.ptr) {
+    DALI_ENFORCE(ptr != nullptr, "Tensor wrapper does not accept nullptr");
+  }
+
+  template <typename Iter>
+  TensorWrapper(T* ptr, Iter it) : TensorShape<N>(it), ptr(ptr) {
+    DALI_ENFORCE(ptr != nullptr, "Tensor wrapper does not accept nullptr");
+  }
+
+  T* const ptr;
+  using type = T;
+  using TensorShape<N>::GetShape;
+};
+
+template <typename T, size_t N>
+struct TensorWrapper<const T, N> : public TensorShape<N> {
+  TensorWrapper() = delete;
+  explicit TensorWrapper(const Tensor<CPUBackend>& t) : TensorShape<N>(t), ptr(t.data<T>()) {
+    DALI_ENFORCE(ptr != nullptr, "Tensor wrapper does not accept nullptr");
+  }
+
+  TensorWrapper(const TensorWrapper& t) : TensorShape<N>(t.GetShape().cbegin()), ptr(t.ptr) {
+    DALI_ENFORCE(ptr != nullptr, "Tensor wrapper does not accept nullptr");
+  }
+
+  template <typename Iter>
+  TensorWrapper(const T* ptr, Iter it) : TensorShape<N>(it), ptr(ptr) {
+    DALI_ENFORCE(ptr != nullptr, "Tensor wrapper does not accept nullptr");
+  }
+
+  const T* const ptr;
+  using type = const T;
+  using TensorShape<N>::GetShape;
+};
+
+template <typename T, size_t N>
+struct SequenceWrapper : public TensorWrapper<T, N> {
+  static_assert(N > 1, "Tensor is required to have at least 2 dimensions to become sequence");
+  SequenceWrapper() = delete;
+  explicit SequenceWrapper(const TensorWrapper<T, N>& t)
+      : TensorWrapper<T, N>(t),
+        sequence_length(t.GetShape()[0]),
+        element_offset(CalcOffset(t.GetShape())) {}
+
+  TensorWrapper<T, N - 1> Get(size_t idx) {
+    return TensorWrapper<T, N - 1>(ptr + idx * element_offset, GetShape().cbegin() + 1);
+  }
+
+  const Index sequence_length;
+  const Index element_offset;
+  using TensorWrapper<T, N>::GetShape;
+  using TensorWrapper<T, N>::ptr;
+  using typename TensorWrapper<T, N>::type;
+
+ private:
+  Index CalcOffset(const std::array<Index, N>& shape) {
+    Index offset = shape[1];
+    for (size_t i = 2; i < N; i++) {
+      offset *= shape[i];
+    }
+    return offset;
+  }
+};
+
+// TODO(klecki) template to add dim?
+template <typename T>
+struct add_dim {};
+
+template <typename T, size_t N>
+struct add_dim<TensorWrapper<T, N>> {
+  using type = TensorWrapper<T, N + 1>;
+};
+
+template <typename T>
+using add_dim_t = typename add_dim<T>::type;
+
+}  // namespace basic
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_BASIC_TENSOR_H_

--- a/dali/pipeline/basic/type_switch.h
+++ b/dali/pipeline/basic/type_switch.h
@@ -1,0 +1,145 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_BASIC_TYPE_SWITCH_H_
+#define DALI_PIPELINE_BASIC_TYPE_SWITCH_H_
+
+#include <tuple>
+#include <utility>
+
+#include "dali/common.h"
+#include "dali/pipeline/data/types.h"
+
+namespace dali {
+namespace basic {
+
+template <typename T>
+struct tuple_head {};
+
+template <typename T, typename... Ts>
+struct tuple_head<std::tuple<T, Ts...>> {
+  using type = T;
+};
+
+template <typename T>
+using tuple_head_t = typename tuple_head<T>::type;
+
+template <typename T>
+struct tuple_tail {};
+
+template <typename T, typename... Ts>
+struct tuple_tail<std::tuple<T, Ts...>> {
+  using type = std::tuple<Ts...>;
+};
+
+template <typename T>
+using tuple_tail_t = typename tuple_tail<T>::type;
+
+template <typename T, typename U>
+using map_to = T;
+
+template <typename FoundTypes, template <typename...> class Op, typename... Ts>
+struct type_switch_impl_tuples {};
+
+template <typename FoundTypes, template <typename...> class Op, typename T, typename... Ts>
+struct type_switch_impl_tuples<FoundTypes, Op, T, Ts...> {
+  template <typename... U>
+  static void Run(map_to<DALIDataType, T> type_id, map_to<DALIDataType, Ts>... type_ids, U&&... u) {
+    // Go recursively over contents of type list T
+    if (type_id == TypeInfo::Create<tuple_head_t<T>>().id()) {
+      // add type to list of found types
+      using NewResultInst = decltype(
+          std::tuple_cat(std::declval<FoundTypes>(), std::declval<std::tuple<tuple_head_t<T>>>()));
+      // search
+      type_switch_impl_tuples<NewResultInst, Op, Ts...>::Run(type_ids..., std::forward<U>(u)...);
+    } else {
+      type_switch_impl_tuples<FoundTypes, Op, tuple_tail_t<T>, Ts...>::Run(type_id, type_ids...,
+                                                                           std::forward<U>(u)...);
+    }
+  }
+};
+
+// Type search end
+template <typename FoundTypes, template <typename...> class Op, typename... Ts>
+struct type_switch_impl_tuples<FoundTypes, Op, std::tuple<>, Ts...> {
+  template <typename... U>
+  static void Run(DALIDataType type_id, map_to<DALIDataType, Ts>... type_ids, U&&... u) {
+    // Should not be called
+    DALI_FAIL("Unknown type");
+  }
+};
+
+template <typename... Ts, template <typename...> class Op>
+struct type_switch_impl_tuples<std::tuple<Ts...>, Op> {
+  template <typename... U>
+  static void Run(U&&... u) {
+    Op<Ts...>::Run(std::forward<U>(u)...);
+  }
+};
+
+/**
+ * @brief Templated type-switch
+ *
+ * @tparam Op Template class with static void Run() method TODO(klecki) forward the result
+ * @tparam Ts list of tuples for each template argument of Op to be matched
+ */
+template <template <typename...> class Op, typename... Ts>
+struct type_switch {
+  /**
+   * @brief Runs the Op<T...>::Run(u...) for types matching type_ids while forwarding arguments u.
+   *
+   * @tparam U Type of argument to forward
+   * @param type_ids Type id to match from one of the tuples in Ts
+   * @param u arguments to be forwarded
+   */
+  template <typename... U>
+  static void Run(map_to<DALIDataType, Ts>... type_ids, U&&... u) {
+    type_switch_impl_tuples<std::tuple<>, Op, Ts...>::Run(type_ids..., std::forward<U>(u)...);
+  }
+};
+
+// template <size_t N, typename T, typename... Ts>
+// struct repeat_t {
+//   using type = typename repeat_t<N - 1, T, T, Ts...>::type;
+// };
+
+// template <typename... Ts>
+// struct repeat_t<0, Ts...> {
+//   using type = std::tuple<Ts...>;
+// };
+
+// TODO(klecki): Describe usage, allow to use one list (how to create argument pack of N tuples?)
+/*
+  template <typename A, typename B>
+  struct aaa {
+
+    static void Run(int aa) {
+      std::cout << TypeInfo::Create<A>().id() " " << TypeInfo::Create<A>().id() << " " aa;
+    }
+  };
+  {
+    static int x =0;
+    type_switch<aaa, std::tuple<int8_t, int16_t, int32_t>, std::tuple<float>>::Run(
+      TypeInfo::Create<int16_t>().id(), TypeInfo::Create<float>().id(), x++);
+  }
+
+*/
+
+}  // namespace basic
+
+using basic::type_switch;
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_BASIC_TYPE_SWITCH_H_

--- a/dali/pipeline/operators/crop/crop.cc
+++ b/dali/pipeline/operators/crop/crop.cc
@@ -38,6 +38,38 @@ DALI_SCHEMA(Crop)
         std::vector<float>{0.f, 0.f})
     .EnforceInputLayout(DALI_NHWC);
 
+std::pair<int, int> CropAttr::SetCropXY(const OpSpec &spec, const ArgumentWorkspace *ws,
+    const Index dataIdx, int H, int W) {
+    DALI_ENFORCE(H >= crop_height_[dataIdx]);
+    DALI_ENFORCE(W >= crop_width_[dataIdx]);
+
+    auto crop_x_norm = spec.GetArgument<float>("crop_pos_x", ws, dataIdx);
+    auto crop_y_norm = spec.GetArgument<float>("crop_pos_y", ws, dataIdx);
+
+    DALI_ENFORCE(crop_y_norm >= 0.f && crop_y_norm <= 1.f,
+                 "Crop coordinates need to be in range [0.0, 1.0]");
+    DALI_ENFORCE(crop_x_norm >= 0.f && crop_x_norm <= 1.f,
+                 "Crop coordinates need to be in range [0.0, 1.0]");
+
+    const int crop_y = crop_y_norm * (H - crop_height_[dataIdx]);
+    const int crop_x = crop_x_norm * (W - crop_width_[dataIdx]);
+
+    return std::make_pair(crop_y, crop_x);
+}
+
+const vector<Index> CropAttr::CheckShapes(const SampleWorkspace *ws) {
+  const auto &input = ws->Input<CPUBackend>(0);
+
+  // enforce that all shapes match
+  for (int i = 1; i < ws->NumInput(); ++i) {
+    DALI_ENFORCE(input.SameShape(ws->Input<CPUBackend>(i)));
+  }
+
+  DALI_ENFORCE(input.ndim() == 3, "Operator expects 3-dimensional image input.");
+
+  return input.shape();
+}
+
 
 template<>
 Crop<CPUBackend>::Crop(const OpSpec &spec) : Operator<CPUBackend>(spec), CropAttr(spec) {
@@ -51,9 +83,9 @@ void CropKernel(
   const int W,
   const unsigned char *input_ptr,
   const int in_stride,
-  DALITensorLayout layout,
+  DALITensorLayout output_layout,
   Out *output_ptr) {
-  if (layout == DALI_NCHW) {
+  if (output_layout == DALI_NCHW) {
     for (int c = 0; c < C; ++c) {
       for (int h = 0; h < H; ++h) {
         for (int w = 0; w < W; ++w) {
@@ -87,7 +119,6 @@ void Crop<CPUBackend>::RunHelper(SampleWorkspace *ws, const int idx) {
   auto output = ws->Output<CPUBackend>(idx);
 
   const int threadIdx = ws->thread_idx();
-  const int H = per_sample_dimensions_[threadIdx].first;
   const int W = per_sample_dimensions_[threadIdx].second;
 
   const int crop_y = per_sample_crop_[threadIdx].first;
@@ -103,12 +134,13 @@ void Crop<CPUBackend>::RunHelper(SampleWorkspace *ws, const int idx) {
 template<>
 void Crop<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
   const auto &input = ws->Input<CPUBackend>(idx);
-  auto output = ws->Output<CPUBackend>(idx);
+  auto *output = ws->Output<CPUBackend>(idx);
 
   DALITensorLayout outLayout;
   output->Resize(GetOutShape(input.GetLayout(), &outLayout, ws->data_idx()));
   output->SetLayout(outLayout);
 
+  // Check if we use u8, RGB or Greyscale
   CheckParam(input, "CropCPUBackend");
   if (output_type_ == DALI_FLOAT16)
     RunHelper<half_float::half>(ws, idx);

--- a/dali/pipeline/operators/crop/crop.cc
+++ b/dali/pipeline/operators/crop/crop.cc
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <tuple>
+
 #include "dali/pipeline/operators/crop/crop.h"
 #include "dali/image/transform.h"
+#include "dali/pipeline/basic/coords.h"
+#include "dali/pipeline/basic/crop.h"
+#include "dali/pipeline/basic/tensor.h"
+#include "dali/pipeline/basic/type_switch.h"
 #include "dali/util/half.hpp"
 
 namespace dali {
@@ -70,85 +76,61 @@ const vector<Index> CropAttr::CheckShapes(const SampleWorkspace *ws) {
   return input.shape();
 }
 
-
-template<>
+template <>
 Crop<CPUBackend>::Crop(const OpSpec &spec) : Operator<CPUBackend>(spec), CropAttr(spec) {
   Init(num_threads_);
 }
 
-template<typename Out>
-void CropKernel(
-  const int C,
-  const int H,
-  const int W,
-  const unsigned char *input_ptr,
-  const int in_stride,
-  DALITensorLayout output_layout,
-  Out *output_ptr) {
-  if (output_layout == DALI_NCHW) {
-    for (int c = 0; c < C; ++c) {
-      for (int h = 0; h < H; ++h) {
-        for (int w = 0; w < W; ++w) {
-          // From HWC
-          const int in_idx = h * in_stride + w * C + c;
-          // To CHW
-          const int out_idx = (c * H + h) * W + w;
-          output_ptr[out_idx] = static_cast<Out>(input_ptr[in_idx]);
-        }
-      }
-    }
-  } else {  // Layout == DALI_NHWC
-    for (int c = 0; c < C; ++c) {
-      for (int h = 0; h < H; ++h) {
-        for (int w = 0; w < W; ++w) {
-          // From HWC
-          const int in_idx = h * in_stride + w * C + c;
-          // To HWC
-          const int out_idx = (h * W + w) * C + c;
-          output_ptr[out_idx] = static_cast<Out>(input_ptr[in_idx]);
-        }
-      }
-    }
-  }
-}
-
-template<>
-template<typename Out>
-void Crop<CPUBackend>::RunHelper(SampleWorkspace *ws, const int idx) {
-  const auto &input = ws->Input<CPUBackend>(idx);
-  auto output = ws->Output<CPUBackend>(idx);
-
-  const int threadIdx = ws->thread_idx();
-  const int W = per_sample_dimensions_[threadIdx].second;
-
-  const int crop_y = per_sample_crop_[threadIdx].first;
-  const int crop_x = per_sample_crop_[threadIdx].second;
-
-  const int dataIdx = ws->data_idx();
-  CropKernel<Out>(C_, crop_height_[dataIdx], crop_width_[dataIdx],
-                              input.template data<uint8>() + (crop_y * W + crop_x) * C_,
-                              W * C_, output_layout_,
-                              output->template mutable_data<Out>());
-}
-
-template<>
+template <>
 void Crop<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
   const auto &input = ws->Input<CPUBackend>(idx);
   auto *output = ws->Output<CPUBackend>(idx);
 
-  DALITensorLayout outLayout;
-  output->Resize(GetOutShape(input.GetLayout(), &outLayout, ws->data_idx()));
+  DALITensorLayout outLayout = output_layout_ == DALI_SAME ? input.GetLayout() : output_layout_;
   output->SetLayout(outLayout);
+  // output->Resize(GetOutShape(input.GetLayout(), &outLayout));
+  auto layout_id = layoutToTypeId(output->GetLayout());
+  using CropOutputTypes = std::tuple<uint8_t, int16_t, int32_t, int64_t, float>;
+  using CropOutputPermTypes =
+      std::tuple<dali_index_sequence<0, 1, 2>, dali_index_sequence<2, 0, 1>>;
 
   // Check if we use u8, RGB or Greyscale
   CheckParam(input, "CropCPUBackend");
-  if (output_type_ == DALI_FLOAT16)
-    RunHelper<half_float::half>(ws, idx);
-  else
-    CallRunHelper(ws, idx);
+
+  const int threadIdx = ws->thread_idx();
+  const int h_start = per_sample_crop_[threadIdx].first;
+  const int w_start = per_sample_crop_[threadIdx].second;
+
+  const int dataIdx = ws->data_idx();
+  // TODO(klecki): currently float16 on CPU is probably broken as far as TypeInfo is considered
+  if (output_type_ == DALI_FLOAT16) {
+    if (output->GetLayout() == DALITensorLayout::DALI_NHWC) {
+      basic::CropSizeHelper<half_float::half, dali_index_sequence<0, 1, 2>>::Run(
+          ws, idx, h_start, w_start, crop_height_[dataIdx], crop_width_[dataIdx]);
+    } else {
+      basic::CropSizeHelper<half_float::half, dali_index_sequence<2, 0, 1>>::Run(
+          ws, idx, h_start, w_start, crop_height_[dataIdx], crop_width_[dataIdx]);
+    }
+  } else {
+    type_switch<basic::CropSizeHelper, CropOutputTypes, CropOutputPermTypes>::Run(
+        output_type_, layout_id, ws, idx, h_start, w_start, crop_height_[dataIdx], crop_width_[dataIdx]);
+  }
+
+  if (output_type_ == DALI_FLOAT16) {
+    if (output->GetLayout() == DALITensorLayout::DALI_NHWC) {
+      basic::CropRunHelper<half_float::half, dali_index_sequence<0, 1, 2>>::Run(
+          ws, idx, h_start, w_start, crop_height_[dataIdx], crop_width_[dataIdx]);
+    } else {
+      basic::CropRunHelper<half_float::half, dali_index_sequence<2, 0, 1>>::Run(
+          ws, idx, h_start, w_start, crop_height_[dataIdx], crop_width_[dataIdx]);
+    }
+  } else {
+    type_switch<basic::CropRunHelper, CropOutputTypes, CropOutputPermTypes>::Run(
+        output_type_, layout_id, ws, idx, h_start, w_start, crop_height_[dataIdx], crop_width_[dataIdx]);
+  }
 }
 
-template<>
+template <>
 void Crop<CPUBackend>::SetupSharedSampleParams(SampleWorkspace *ws) {
   if (output_type_ == DALI_NO_TYPE) {
     const auto &input = ws->Input<CPUBackend>(0);

--- a/dali/pipeline/operators/crop/crop.h
+++ b/dali/pipeline/operators/crop/crop.h
@@ -70,7 +70,7 @@ class CropAttr {
    * @param ws
    * @return const vector<Index> One matching shape for all inputs
    */
-  const vector<Index> CheckShapes(const SampleWorkspace *ws);
+  virtual const vector<Index> CheckShapes(const SampleWorkspace *ws);
 
   vector<int> crop_height_;
   vector<int> crop_width_;
@@ -159,7 +159,9 @@ class Crop : public Operator<Backend>, protected CropAttr {
   vector<int> crop_offsets_;
 
  protected:
+  // Crop starting position (in input)
   std::vector<std::pair<int, int>> per_sample_crop_;
+  // Input dims
   std::vector<std::pair<int, int>> per_sample_dimensions_;
 
   // Output data type

--- a/dali/pipeline/operators/crop/crop.h
+++ b/dali/pipeline/operators/crop/crop.h
@@ -66,7 +66,12 @@ class CropAttr {
   const vector<Index> CheckShapes(const SampleWorkspace *ws) {
     const auto &input = ws->Input<CPUBackend>(0);
 
-    DALI_ENFORCE(input.shape().size() == 3, "Expects 3-dimensional image input.");
+    // enforce that all shapes match
+    for (int i = 1; i < ws->NumInput(); ++i) {
+      DALI_ENFORCE(input.SameShape(ws->Input<CPUBackend>(i)));
+    }
+
+    DALI_ENFORCE(input.ndim() == 3, "Operator expects 3-dimensional image input.");
 
     return input.shape();
   }
@@ -97,8 +102,8 @@ class Crop : public Operator<Backend>, protected CropAttr {
 
  private:
   template <typename Out>
-  void RunHelper(Workspace<Backend> *ws, int idx);
-  void DataDependentSetup(Workspace<Backend> *ws, int idx);
+  void RunHelper(Workspace<Backend> *ws, const int idx);
+  void DataDependentSetup(Workspace<Backend> *ws, const int idx);
   template <typename Out>
   void ValidateHelper(TensorList<Backend> *output);
 
@@ -122,8 +127,8 @@ class Crop : public Operator<Backend>, protected CropAttr {
     int C = inputShape[2];
     DALI_ENFORCE(C == C_,
                  "Input channel dimension does not match "
-                 "the output image type. Expected input with " +
-                     to_string(C_) + " channels, got " + to_string(C) + ".");
+                 "the output image type. Expected input with "
+                 + to_string(C_) + " channels, got " + to_string(C) + ".");
 
     per_sample_crop_[threadIdx] = SetCropXY(spec_, ws, dataIdx, H, W);
   }

--- a/dali/pipeline/operators/crop/sequence_crop.cc
+++ b/dali/pipeline/operators/crop/sequence_crop.cc
@@ -1,0 +1,86 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <tuple>
+#include <vector>
+
+#include "dali/pipeline/operators/crop/sequence_crop.h"
+#include "dali/pipeline/basic/crop.h"
+#include "dali/pipeline/basic/tensor.h"
+#include "dali/pipeline/basic/type_switch.h"
+
+namespace dali {
+
+DALI_SCHEMA(SequenceCrop)
+    .DocStr(R"code(Perform a random crop on a sequecne.)code")
+    .NumInput(1)
+    .NumOutput(1)
+    .AllowMultipleInputSets()
+    .AddParent("Crop")
+    .EnforceInputLayout(DALI_NHWC);
+
+void SequenceCrop::RunImpl(Workspace<CPUBackend> *ws, const int idx) {
+  const auto &input = ws->Input<CPUBackend>(idx);
+  auto *output = ws->Output<CPUBackend>(idx);
+
+  DALITensorLayout outLayout = output_layout_ == DALI_SAME ? input.GetLayout() : output_layout_;
+  output->SetLayout(outLayout);
+  // output->Resize(GetOutShape(input.GetLayout(), &outLayout));
+  auto layout_id = layoutToTypeId(output->GetLayout());
+  using CropOutputTypes = std::tuple<uint8_t, int16_t, int32_t, int64_t, float>;
+  using CropOutputPermTypes =
+      std::tuple<dali_index_sequence<0, 1, 2>, dali_index_sequence<2, 0, 1>>;
+
+  // Check if we use u8, RGB or Greyscale
+  // CheckParam(input, "CropCPUBackend");
+
+  const int threadIdx = ws->thread_idx();
+  const int h_start = per_sample_crop_[threadIdx].first;
+  const int w_start = per_sample_crop_[threadIdx].second;
+
+  // TODO(klecki): simplification - do not handle float16
+
+  const int dataIdx = ws->data_idx();
+  type_switch<basic::SequenceCropSizeHelper, CropOutputTypes, CropOutputPermTypes>::Run(
+      output_type_, layout_id, ws, idx, h_start, w_start, crop_height_[dataIdx], crop_width_[dataIdx]);
+
+  type_switch<basic::SequenceCropRunHelper, CropOutputTypes, CropOutputPermTypes>::Run(
+      output_type_, layout_id, ws, idx, h_start, w_start, crop_height_[dataIdx], crop_width_[dataIdx]);
+}
+
+const std::vector<Index> SequenceCrop::CheckShapes(const SampleWorkspace *ws) {
+  const auto &input = ws->Input<CPUBackend>(0);
+
+  DALI_ENFORCE(input.ndim() == 4, "Operator expects 4-dimensional sequence image input.");
+
+  // enforce that all shapes match
+  for (int i = 1; i < ws->NumInput(); ++i) {
+    const auto &other_input = ws->Input<CPUBackend>(i);
+    DALI_ENFORCE(other_input.ndim() == 4, "Operator expects 4-dimensional sequence image input.");
+    for (int j = 1; j < 4; j++) {
+      DALI_ENFORCE(input.dim(j) == other_input.dim(j));
+    }
+  }
+
+  std::vector<Index> frame_shape;
+  for (int i = 1; i < 4; i++) {
+    frame_shape.push_back(input.dim(i));
+  }
+
+  return frame_shape;
+}
+
+DALI_REGISTER_OPERATOR(SequenceCrop, SequenceCrop, CPU);
+
+}  // namespace dali

--- a/dali/pipeline/operators/crop/sequence_crop.h
+++ b/dali/pipeline/operators/crop/sequence_crop.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATORS_CROP_SEQUENCE_CROP_H_
+#define DALI_PIPELINE_OPERATORS_CROP_SEQUENCE_CROP_H_
+
+#include <vector>
+
+#include "dali/pipeline/operators/crop/crop.h"
+
+namespace dali {
+
+class SequenceCrop : public Crop<CPUBackend> {
+ public:
+  explicit SequenceCrop(const OpSpec &spec) : Crop<CPUBackend>(spec) {}
+
+ protected:
+  void RunImpl(Workspace<CPUBackend> *ws, const int idx) override;
+  // void SetupSharedSampleParams(Workspace<CPUBackend> *ws) override;
+  /**
+   * @brief Verify that all input frames have the same sizes. Sequences can be arbitary.
+   *        Called in SetupSharedSampleParams.
+   *
+   * @param ws
+   * @return const vector<Index> representing shape of frame (TODO(klecki) compability with regular
+   * Crop)
+   */
+  const std::vector<Index> CheckShapes(const SampleWorkspace *ws) override;
+  // using Crop<CPUBackend>::CheckParam;
+  using Crop<CPUBackend>::per_sample_crop_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATORS_CROP_SEQUENCE_CROP_H_

--- a/dali/pipeline/operators/decoder/host_decoder.cc
+++ b/dali/pipeline/operators/decoder/host_decoder.cc
@@ -19,14 +19,14 @@ namespace dali {
 DALI_REGISTER_OPERATOR(HostDecoder, HostDecoder, CPU);
 
 DALI_SCHEMA(HostDecoder)
-  .DocStr(R"code(Decode images on the host using OpenCV.
+    .DocStr(R"code(Decode images on the host using OpenCV.
 When applicable, it will pass execution to faster, format-specific decoders (like libjpeg-turbo).
-Output of the decoder is in `HWC` ordering.)code")
-  .NumInput(1)
-  .NumOutput(1)
-  .AddOptionalArg("output_type",
-      R"code(The color space of output image.)code",
-      DALI_RGB);
+Output of the decoder is in `HWC` ordering.
+In case of samples being singular images expects one input, for sequences ([frames], metadata)
+pair is expected, and decode_sequences set to true.)code")
+    .NumInput(1, 2)
+    .NumOutput(1)
+    .AddOptionalArg("output_type", R"code(The color space of output image.)code", DALI_RGB)
+    .AddOptionalArg("decode_sequences", R"code(Is input a sequence of frames.)code", false);
 
 }  // namespace dali
-

--- a/dali/pipeline/operators/decoder/host_decoder.h
+++ b/dali/pipeline/operators/decoder/host_decoder.h
@@ -17,37 +17,84 @@
 
 #include <opencv2/opencv.hpp>
 #include <tuple>
+#include <vector>
+
 #include "dali/common.h"
 #include "dali/error_handling.h"
-#include "dali/pipeline/operators/operator.h"
 #include "dali/image/image_factory.h"
-
+#include "dali/pipeline/operators/operator.h"
 
 namespace dali {
 
 class HostDecoder : public Operator<CPUBackend> {
  public:
-  explicit inline HostDecoder(const OpSpec &spec) :
-          Operator<CPUBackend>(spec),
-          output_type_(spec.GetArgument<DALIImageType>("output_type")),
-          c_(IsColor(output_type_) ? 3 : 1) {}
-
+  explicit inline HostDecoder(const OpSpec &spec)
+      : Operator<CPUBackend>(spec),
+        output_type_(spec.GetArgument<DALIImageType>("output_type")),
+        c_(IsColor(output_type_) ? 3 : 1),
+        decode_sequences_(spec.GetArgument<bool>("decode_sequences")) {}
 
   virtual inline ~HostDecoder() = default;
   DISABLE_COPY_MOVE_ASSIGN(HostDecoder);
 
  protected:
   void RunImpl(SampleWorkspace *ws, const int idx) override {
-    auto &input = ws->Input<CPUBackend>(idx);
-    auto output = ws->Output<CPUBackend>(idx);
-
+    const auto &input = ws->Input<CPUBackend>(0);
+    auto *output = ws->Output<CPUBackend>(0);
     // Verify input
-    DALI_ENFORCE(input.ndim() == 1,
-                 "Input must be 1D encoded jpeg string.");
-    DALI_ENFORCE(IsType<uint8>(input.type()),
-                 "Input must be stored as uint8 data.");
+    DALI_ENFORCE(input.ndim() == 1, "Input must be 1D encoded jpeg string.");
+    DALI_ENFORCE(IsType<uint8>(input.type()), "Input must be stored as uint8 data.");
 
-    auto img = ImageFactory::CreateImage(input.data<uint8>(), input.size(), output_type_);
+    if (!decode_sequences_) {
+      DALI_ENFORCE(ws->NumInput() == 1, "When decoding singular images one input is expected");
+      DecodeSingle(input.data<uint8_t>(), input.size(), output);
+    } else {
+      DALI_ENFORCE(ws->NumInput() == 2, "When decoding sequences two inputs are expected");
+      const auto &metadata = ws->Input<CPUBackend>(1);
+      DALI_ENFORCE(metadata.ndim() == 1, "Metadata must be 1D encoded offsets.");
+      DALI_ENFORCE(IsType<Index>(metadata.type()) == 1, "Metadata must be stored as int64 data.");
+      const auto *metadata_ptr = metadata.data<Index>();
+      const auto *input_ptr = input.data<uint8_t>();
+      Index frame_count = metadata_ptr[0];
+      for (Index frame = 0; frame < frame_count; frame++) {
+        auto frame_size = metadata_ptr[frame + 1];
+        if (frame == 0) {
+          // First frame to check sizes
+          Tensor<CPUBackend> tmp;
+          DecodeSingle(input_ptr, frame_size, &tmp);
+
+          // Calculate shape of sequence tensor, that is Frames x (Frame Shape)
+          auto frames_x_shape = std::vector<Index>();
+          frames_x_shape.push_back(frame_count);
+          auto frame_shape = tmp.shape();
+          frames_x_shape.insert(frames_x_shape.end(), frame_shape.begin(), frame_shape.end());
+          output->Resize(frames_x_shape);
+          output->set_type(TypeInfo::Create<uint8_t>());
+          // Take a view tensor for first frame and
+          auto view_0 = output->SubspaceTensor(frame);
+          std::memcpy(view_0.raw_mutable_data(), tmp.raw_data(), tmp.size());
+        } else {
+          // Rest of frames
+          auto view_tensor = output->SubspaceTensor(frame);
+          DecodeSingle(input_ptr, frame_size, &view_tensor);
+          DALI_ENFORCE(view_tensor.shares_data(),
+                       "Buffer view was invalidated after image decoding, frames do not match in "
+                       "dimensions");
+        }
+        input_ptr += frame_size;
+      }
+    }
+  }
+
+  /**
+   * @brief Decode single stream of bytes into 3-dimensional tensor of shape HWC representing image
+   *
+   * @param data input data stream
+   * @param size size of input data
+   * @param output decoded image
+   */
+  void DecodeSingle(const uint8_t *data, size_t size, Tensor<CPUBackend> *output) {
+    auto img = ImageFactory::CreateImage(data, size, output_type_);
     img->Decode();
     const auto decoded = img->GetImage();
     const auto hwc = img->GetImageDims();
@@ -56,13 +103,13 @@ class HostDecoder : public Operator<CPUBackend> {
     const auto c = std::get<2>(hwc);
 
     output->Resize({static_cast<int>(h), static_cast<int>(w), static_cast<int>(c)});
-    unsigned char *out_data = output->mutable_data<unsigned char>();
+    unsigned char *out_data = output->mutable_data<uint8_t>();
     std::memcpy(out_data, decoded.get(), h * w * c);
   }
 
-
   DALIImageType output_type_;
   int c_;
+  bool decode_sequences_;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/decoder/host_decoder_test.cc
+++ b/dali/pipeline/operators/decoder/host_decoder_test.cc
@@ -118,7 +118,17 @@ TYPED_TEST(WIPDecoderTest, SequenceTest) {
       .AddInput("meta", "cpu")
       .AddOutput("decoded", "cpu"));
 
-  std::vector<std::pair<string, string>> outputs = {{"decoded", "cpu"}};
+  pipe.AddOperator(
+      OpSpec("SeqCrop")
+      .AddArg("device", "cpu")
+      .AddArg("image_type", DALI_RGB)
+      .AddArg("crop", 256)
+      .AddInput("decoded", "cpu")
+      .AddOutput("cropped", "cpu")
+  );
+
+
+  std::vector<std::pair<string, string>> outputs = {{"cropped", "cpu"}};
   pipe.Build(outputs);
 
   DeviceWorkspace ws;

--- a/dali/pipeline/operators/decoder/host_decoder_test.cc
+++ b/dali/pipeline/operators/decoder/host_decoder_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <opencv2/opencv.hpp>
+
 #include "dali/test/dali_test_decoder.h"
 
 namespace dali {
@@ -85,4 +87,49 @@ TYPED_TEST_CASE(HostDecodeTestTiff, Types);
 TYPED_TEST(HostDecodeTestTiff, TestTiffDecode) {
   this->RunTestDecode(t_tiffImgType);
 }
+template <typename Backend>
+class WIPDecoderTest : public DALITest {
+ public:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+typedef ::testing::Types<CPUBackend> TestTypes;
+
+TYPED_TEST_CASE(WIPDecoderTest, TestTypes);
+
+
+TYPED_TEST(WIPDecoderTest, SequenceTest) {
+  Pipeline pipe(128, 1, 0);
+
+  pipe.AddOperator(
+      OpSpec("SequenceReader")
+      .AddArg("file_root", "/mnt/nvvl_data/data/540p/frames/train")
+      .AddArg("sequence_length", 3)
+      .AddOutput("seq", "cpu")
+      .AddOutput("meta", "cpu"));
+
+  pipe.AddOperator(
+      OpSpec("HostDecoder")
+      .AddArg("device", "cpu")
+      .AddArg("decode_sequences", true)
+      .AddArg("output_type", DALI_RGB)
+      .AddInput("seq", "cpu")
+      .AddInput("meta", "cpu")
+      .AddOutput("decoded", "cpu"));
+
+  std::vector<std::pair<string, string>> outputs = {{"decoded", "cpu"}};
+  pipe.Build(outputs);
+
+  DeviceWorkspace ws;
+  for (int i=0; i < 5; ++i) {
+    printf(" ======= ITER %d ======\n", i);
+    pipe.RunCPU();
+    pipe.RunGPU();
+    pipe.Outputs(&ws);
+  }
+
+  return;
+}
+
 }  // namespace dali

--- a/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
+++ b/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
@@ -177,6 +177,8 @@ class DisplacementFilter<CPUBackend, Displacement,
     auto& input = ws->Input<CPUBackend>(idx);
     auto *output = ws->Output<CPUBackend>(idx);
 
+    DALI_ENFORCE(input.ndim() == 3, "Operator expects 3-dimensional image input.");
+
     const auto H = input.shape()[0];
     const auto W = input.shape()[1];
     const auto C = input.shape()[2];

--- a/dali/pipeline/operators/fused/crop_cast_permut_test.cc
+++ b/dali/pipeline/operators/fused/crop_cast_permut_test.cc
@@ -17,8 +17,7 @@
 namespace dali {
 
 template <typename ImgType>
-class CropCastPermuteTest : public GenericMatchingTest<ImgType> {
-};
+class CropCastPermuteTest : public GenericMatchingTest<ImgType> {};
 
 typedef ::testing::Types<RGB, BGR, Gray> Types;
 TYPED_TEST_CASE(CropCastPermuteTest, Types);
@@ -30,63 +29,53 @@ TYPED_TEST(CropCastPermuteTest, CropVector) {
 }
 
 TYPED_TEST(CropCastPermuteTest, Layout_DALI_NCHW) {
-  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                          {"output_layout", "0",   DALI_INT32}};
-  this->RunTest("CropCastPermute", params, sizeof(params)/sizeof(params[0]), addImageType);
+  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC}, {"output_layout", "0", DALI_INT32}};
+  this->RunTest("CropCastPermute", params, sizeof(params) / sizeof(params[0]), addImageType);
 }
 
 TYPED_TEST(CropCastPermuteTest, Layout_DALI_NHWC) {
-  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                          {"output_layout", "1",   DALI_INT32}};
-  this->RunTest("CropCastPermute", params, sizeof(params)/sizeof(params[0]), addImageType);
+  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC}, {"output_layout", "1", DALI_INT32}};
+  this->RunTest("CropCastPermute", params, sizeof(params) / sizeof(params[0]), addImageType);
 }
 
 TYPED_TEST(CropCastPermuteTest, Layout_DALI_SAME) {
-  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                          {"output_layout", "2",   DALI_INT32}};
-  this->RunTest("CropCastPermute", params, sizeof(params)/sizeof(params[0]), addImageType);
+  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC}, {"output_layout", "3", DALI_INT32}};
+  this->RunTest("CropCastPermute", params, sizeof(params) / sizeof(params[0]), addImageType);
 }
 
 TYPED_TEST(CropCastPermuteTest, Output_DALI_NO_TYPE) {
-  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                          {"output_dtype", "-1",  DALI_INT32}};
-  this->RunTest("CropCastPermute", params, sizeof(params)/sizeof(params[0]), addImageType);
+  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC}, {"output_dtype", "-1", DALI_INT32}};
+  this->RunTest("CropCastPermute", params, sizeof(params) / sizeof(params[0]), addImageType);
 }
 
 TYPED_TEST(CropCastPermuteTest, Output_DALI_UINT8) {
-  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                          {"output_dtype", "0",   DALI_INT32}};
-  this->RunTest("CropCastPermute", params, sizeof(params)/sizeof(params[0]), addImageType);
+  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC}, {"output_dtype", "0", DALI_INT32}};
+  this->RunTest("CropCastPermute", params, sizeof(params) / sizeof(params[0]), addImageType);
 }
 
 TYPED_TEST(CropCastPermuteTest, Output_DALI_INT16) {
-  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                          {"output_dtype", "1",   DALI_INT32}};
+  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC}, {"output_dtype", "1", DALI_INT32}};
   this->RunTest("CropCastPermute", params, sizeof(params) / sizeof(params[0]), addImageType);
 }
 
 TYPED_TEST(CropCastPermuteTest, Output_DALI_INT32) {
-  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                          {"output_dtype", "2",   DALI_INT32}};
+  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC}, {"output_dtype", "2", DALI_INT32}};
   this->RunTest("CropCastPermute", params, sizeof(params) / sizeof(params[0]), addImageType);
 }
 
 TYPED_TEST(CropCastPermuteTest, Output_DALI_INT64) {
-  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                          {"output_dtype", "3",   DALI_INT32}};
-  this->RunTest("CropCastPermute", params, sizeof(params)/sizeof(params[0]), addImageType);
+  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC}, {"output_dtype", "3", DALI_INT32}};
+  this->RunTest("CropCastPermute", params, sizeof(params) / sizeof(params[0]), addImageType);
 }
 
 TYPED_TEST(CropCastPermuteTest, Output_DALI_FLOAT16) {
-  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                          {"output_dtype", "4",   DALI_INT32}};
-  this->RunTest("CropCastPermute", params, sizeof(params)/sizeof(params[0]), addImageType);
+  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC}, {"output_dtype", "4", DALI_INT32}};
+  this->RunTest("CropCastPermute", params, sizeof(params) / sizeof(params[0]), addImageType);
 }
 
 TYPED_TEST(CropCastPermuteTest, Output_DALI_FLOAT) {
-  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                          {"output_dtype", "5", DALI_INT32}};
-  this->RunTest("CropCastPermute", params, sizeof(params)/sizeof(params[0]), addImageType);
+  const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC}, {"output_dtype", "5", DALI_INT32}};
+  this->RunTest("CropCastPermute", params, sizeof(params) / sizeof(params[0]), addImageType);
 }
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/CMakeLists.txt
+++ b/dali/pipeline/operators/reader/CMakeLists.txt
@@ -16,6 +16,7 @@ add_subdirectory(loader)
 add_subdirectory(parser)
 
 list(APPEND DALI_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/file_reader_op.cc")
+list(APPEND DALI_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/sequence_reader_op.cc")
 
 if (BUILD_LMDB)
   list(APPEND DALI_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/caffe_reader_op.cc")

--- a/dali/pipeline/operators/reader/loader/sequence_loader.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.cc
@@ -1,0 +1,103 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <glob.h>
+#include <algorithm>
+#include <map>
+
+#include "dali/pipeline/operators/reader/loader/sequence_loader.h"
+#include "dali/util/file.h"
+
+namespace dali {
+
+std::string parent_dir(std::string path) {
+  size_t idx = path.rfind("/");
+  DALI_ENFORCE(idx != std::string::npos, "NO PARENT DIRECTORY FOR GIVEN PATH");
+  return path.substr(0, idx + 1);  // return with trailing "/"
+}
+
+void SequenceLoader::PrepareEmpty(TensorSequence *sequence) {
+  sequence->tensors.resize(sequence_length_);
+  for (auto &t : sequence->tensors) {
+    PrepareEmptyTensor(&t);
+  }
+}
+
+void SequenceLoader::ReadSample(TensorSequence *sequence) {
+  // TODO(klecki) this is written as a prototype for video handling
+  const auto &stream = streams_[current_stream_];
+  // TODO(klecki) we probably should buffer the "stream", or recently used
+  // frames
+  for (int i = 0; i < sequence_length_; i++) {
+    LoadFrame(stream, current_frame_ + i, &sequence->tensors[i]);
+  }
+  current_frame_++;
+  // wrap-around
+  if (current_frame_ == stream_sizes_[current_stream_]) {
+    current_stream_++;
+    current_frame_ = 0;
+  }
+  if (current_stream_ == streams_.size()) {
+    current_stream_ = 0;
+  }
+}
+
+Index SequenceLoader::Size() {
+  return total_size_;
+}
+
+std::vector<SequenceLoader::Stream> SequenceLoader::ParseStreams(string file_root) {
+  glob_t glob_buff;
+  std::string glob_pattern = file_root + "/*/*";
+  const int glob_flags = 0;
+  glob(glob_pattern.c_str(), glob_flags, nullptr, &glob_buff);
+  std::vector<std::string> files;
+  for (size_t i = 0; i < glob_buff.gl_pathc; i++) {
+    files.emplace_back(glob_buff.gl_pathv[i]);
+  }
+  std::sort(files.begin(), files.end());
+  std::map<std::string, size_t> streamName_bucket_map;
+  std::vector<Stream> streams;
+  for (auto &f : files) {
+    auto parent = parent_dir(f);
+    auto bucket = streamName_bucket_map.find(parent);
+    if (bucket == streamName_bucket_map.end()) {
+      streams.push_back({parent, {f}});
+      streamName_bucket_map[parent] = streams.size() - 1;
+    } else {
+      streams[bucket->second].second.push_back(f);
+    }
+  }
+  return streams;
+}
+
+vector<size_t> SequenceLoader::CalculateStreamSizes(const vector<Stream> &streams,
+                                                    size_t sample_lenght) {
+  vector<size_t> result;
+  for (auto &s : streams) {
+    result.push_back(s.second.size() - (sample_lenght - 1));
+  }
+  return result;
+}
+
+void SequenceLoader::LoadFrame(const Stream &s, Index frame_idx, Tensor<CPUBackend> *target) {
+  const auto frame_filename = s.second[frame_idx];
+  FileStream *frame = FileStream::Open(frame_filename);
+  Index frame_size = frame->Size();
+  target->Resize({frame_size});
+  frame->Read(target->mutable_data<uint8_t>(), frame_size);
+  frame->Close();
+}
+
+}  // namespace dali

--- a/dali/pipeline/operators/reader/loader/sequence_loader.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.cc
@@ -79,6 +79,12 @@ std::vector<SequenceLoader::Stream> SequenceLoader::ParseStreams(string file_roo
       streams[bucket->second].second.push_back(f);
     }
   }
+  // for (const auto &s : streams) {
+  //   std::cout << s.first << std::endl;
+  //   for (const auto &f : s.second) {
+  //     std::cout << "  " << f << std::endl;
+  //   }
+  // }
   return streams;
 }
 
@@ -88,6 +94,9 @@ vector<size_t> SequenceLoader::CalculateStreamSizes(const vector<Stream> &stream
   for (auto &s : streams) {
     result.push_back(s.second.size() - (sample_lenght - 1));
   }
+  // for (auto i : result) {
+  //   std::cout << i << std::endl;
+  // }
   return result;
 }
 

--- a/dali/pipeline/operators/reader/loader/sequence_loader.h
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATORS_READER_LOADER_SEQUENCE_LOADER_H_
+#define DALI_PIPELINE_OPERATORS_READER_LOADER_SEQUENCE_LOADER_H_
+
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "dali/common.h"
+#include "dali/pipeline/operators/reader/loader/loader.h"
+
+namespace dali {
+
+struct TensorSequence {
+  std::vector<Tensor<CPUBackend>> tensors;
+};
+
+// TODO(klecki) consider using FileLoader as base class
+// TODO(klecki) ?? allow for more high level grouping of sequences:
+//              we should probably make sure that other Loaders read
+//              sequentially, and allow for SequenceLoader to wrap any other
+//              loader, similar for parser and reader
+// TODO(klecki) loader is responsible for handling shuffle_
+class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
+ public:
+  // TODO(klecki) For now sequence is <directory, image list> pair, later it
+  // will be a video file
+  // TODO(klecki) SequenceBucket or other name?
+  using Stream = std::pair<std::string, std::vector<std::string>>;
+
+  explicit SequenceLoader(const OpSpec& spec)
+      : Loader(spec),
+        file_root_(spec.GetArgument<string>("file_root")),
+        sequence_length_(
+            spec.GetArgument<int32_t>("sequence_length")),  // TODO(klecki) change to size_t
+        streams_(ParseStreams(file_root_)),
+        stream_sizes_(CalculateStreamSizes(streams_, sequence_length_)),
+        total_size_(std::accumulate(stream_sizes_.begin(), stream_sizes_.end(), Index{})),
+        current_stream_(0),
+        current_frame_(0) {}
+
+  void PrepareEmpty(TensorSequence *tensor) override;
+  void ReadSample(TensorSequence *tensor) override;
+  Index Size() override;
+
+ protected:
+  string file_root_;
+  int32_t sequence_length_;
+  vector<Stream> streams_;
+  vector<size_t> stream_sizes_;
+  Index total_size_;
+  size_t current_stream_, current_frame_;
+
+  vector<Stream> ParseStreams(string file_root);
+  vector<size_t> CalculateStreamSizes(const vector<Stream> &streams, size_t sample_lenght);
+
+ private:
+  void LoadFrame(const Stream &s, Index frame, Tensor<CPUBackend> *target);
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATORS_READER_LOADER_SEQUENCE_LOADER_H_

--- a/dali/pipeline/operators/reader/parser/CMakeLists.txt
+++ b/dali/pipeline/operators/reader/parser/CMakeLists.txt
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Folder is header only save for tests
+
+file(GLOB tmp *.cc *.cu)
+set(DALI_SRCS ${DALI_SRCS} ${tmp})
+file(GLOB tmp *_test.cc)
+remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
+
+set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
+
 if (BUILD_TEST)
   file(GLOB tmp *_test.cc)
   set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)

--- a/dali/pipeline/operators/reader/parser/sequence_parser.cc
+++ b/dali/pipeline/operators/reader/parser/sequence_parser.cc
@@ -1,0 +1,44 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/operators/reader/parser/sequence_parser.h"
+
+namespace dali {
+
+void SequenceParser::Parse(const TensorSequence& data, SampleWorkspace* ws) {
+  auto* sequence = ws->Output<CPUBackend>(0);
+  auto* metadata = ws->Output<CPUBackend>(1);
+
+  metadata->Resize({static_cast<Index>(data.tensors.size() + 1)});
+  auto* metadata_ptr = metadata->mutable_data<Index>();
+
+  metadata_ptr[0] = data.tensors.size();
+
+  Index total_size = 0;
+
+  for (const auto& t : data.tensors) {
+    total_size += t.size();
+  }
+
+  sequence->Resize({total_size});
+  auto* sequence_ptr = sequence->mutable_data<uint8_t>();
+
+  for (size_t i = 0; i < data.tensors.size(); i++) {
+    std::memcpy(sequence_ptr, data.tensors[i].raw_data(), data.tensors[i].size());
+    sequence_ptr += data.tensors[i].size();
+    metadata_ptr[i + 1] = data.tensors[i].size();
+  }
+}
+
+}  // namespace dali

--- a/dali/pipeline/operators/reader/parser/sequence_parser.h
+++ b/dali/pipeline/operators/reader/parser/sequence_parser.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATORS_READER_PARSER_SEQUENCE_PARSER_H_
+#define DALI_PIPELINE_OPERATORS_READER_PARSER_SEQUENCE_PARSER_H_
+
+#include "dali/pipeline/operators/reader/loader/sequence_loader.h"
+#include "dali/pipeline/operators/reader/parser/parser.h"
+
+namespace dali {
+
+class SequenceParser : public Parser<TensorSequence> {
+ public:
+  explicit SequenceParser(const OpSpec& spec) : Parser<TensorSequence>(spec) {}
+
+  void Parse(const TensorSequence& data, SampleWorkspace* ws) override;
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATORS_READER_PARSER_SEQUENCE_PARSER_H_

--- a/dali/pipeline/operators/reader/reader_op_test.cc
+++ b/dali/pipeline/operators/reader/reader_op_test.cc
@@ -119,4 +119,29 @@ TYPED_TEST(ReaderTest, SimpleTest) {
   return;
 }
 
+
+TYPED_TEST(ReaderTest, SequenceTest) {
+  Pipeline pipe(128, 1, 0);
+
+  pipe.AddOperator(
+      OpSpec("SequenceReader")
+      .AddArg("file_root", "/mnt/nvvl_data/data/540p/frames/train/")
+      .AddArg("sequence_length", 3)
+      .AddOutput("seq_out", "cpu")
+      .AddOutput("meta_out", "cpu"));
+
+  std::vector<std::pair<string, string>> outputs = {{"seq_out", "cpu"}, {"meta_out", "cpu"}};
+  pipe.Build(outputs);
+
+  DeviceWorkspace ws;
+  for (int i=0; i < 5; ++i) {
+    printf(" ======= ITER %d ======\n", i);
+    pipe.RunCPU();
+    pipe.RunGPU();
+    pipe.Outputs(&ws);
+  }
+
+  return;
+}
+
 };  // namespace dali

--- a/dali/pipeline/operators/reader/sequence_reader_op.cc
+++ b/dali/pipeline/operators/reader/sequence_reader_op.cc
@@ -1,0 +1,44 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "dali/pipeline/operators/reader/sequence_reader_op.h"
+
+namespace dali {
+
+void SequenceReader::RunImpl(SampleWorkspace* ws, const int i) {
+  const int idx = ws->data_idx();
+
+  auto* frame_sequence = prefetched_batch_[idx];
+
+  parser_->Parse(*frame_sequence, ws);
+}
+
+DALI_REGISTER_OPERATOR(SequenceReader, SequenceReader, CPU);
+
+DALI_SCHEMA(SequenceReader)
+    .DocStr(
+        "Read [Frame] sequences from a directory representing collection of "
+        "streams")
+    .NumInput(0)
+    .NumOutput(2)  // ([Frames], FrameInfo)
+    .AddArg("file_root",
+            R"code(Path to a directory containing streams (directories representing streams).)code",
+            DALI_STRING)
+    .AddArg("sequence_length",
+            R"code(Lenght of sequence to load for each sample)code", DALI_INT32)
+    .AddParent("LoaderBase");
+
+}  // namespace dali

--- a/dali/pipeline/operators/reader/sequence_reader_op.h
+++ b/dali/pipeline/operators/reader/sequence_reader_op.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATORS_READER_SEQUENCE_READER_OP_H_
+#define DALI_PIPELINE_OPERATORS_READER_SEQUENCE_READER_OP_H_
+
+#include "dali/pipeline/operators/reader/loader/sequence_loader.h"
+#include "dali/pipeline/operators/reader/parser/sequence_parser.h"
+#include "dali/pipeline/operators/reader/reader_op.h"
+
+namespace dali {
+
+class SequenceReader : public DataReader<CPUBackend, TensorSequence> {
+ public:
+  explicit SequenceReader(const OpSpec& spec) : DataReader<CPUBackend, TensorSequence>(spec) {
+    loader_.reset(new SequenceLoader(spec));
+    parser_.reset(new SequenceParser(spec));
+  }
+
+  void RunImpl(SampleWorkspace* ws, const int i) override;
+
+ protected:
+  USE_READER_OPERATOR_MEMBERS(CPUBackend, TensorSequence);
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATORS_READER_SEQUENCE_READER_OP_H_

--- a/dali/pipeline/operators/resize/new_resize.cc
+++ b/dali/pipeline/operators/resize/new_resize.cc
@@ -21,6 +21,7 @@ template <>
 void NewResize<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
   const auto &input = ws->Input<CPUBackend>(idx);
   const auto &output = ws->Output<CPUBackend>(idx);
+  DALI_ENFORCE(input.ndim() == 3, "Operator expects 3-dimensional image input.");
 
   const auto &input_shape = input.shape();
   DALISize out_size, input_size;

--- a/dali/pipeline/operators/resize/new_resize.cu
+++ b/dali/pipeline/operators/resize/new_resize.cu
@@ -55,7 +55,7 @@ void DataDependentSetupCPU(const Tensor<CPUBackend> &input,
                            Tensor<CPUBackend> *output, const char *pOpName,
                            const uint8 **ppInRaster, uint8 **ppOutRaster,
                            vector<DALISize> *pSizes, const DALISize *out_size) {
-  DALI_ENFORCE(input.ndim() == 3);
+  DALI_ENFORCE(input.ndim() == 3, "Operator expects 3-dimensional image input.");
   DALI_ENFORCE(IsType<uint8>(input.type()), "Expects input data in uint8.");
 
   const vector<Index> &shape = input.shape();

--- a/dali/pipeline/operators/resize/random_resized_crop.cc
+++ b/dali/pipeline/operators/resize/random_resized_crop.cc
@@ -82,8 +82,8 @@ void RandomResizedCrop<CPUBackend>::InitParams(const OpSpec &spec) {
 template<>
 void RandomResizedCrop<CPUBackend>::RunImpl(SampleWorkspace * ws, const int idx) {
   auto &input = ws->Input<CPUBackend>(idx);
-  DALI_ENFORCE(IsType<uint8>(input.type()),
-      "Expected input data as uint8.");
+  DALI_ENFORCE(input.ndim() == 3, "Operator expects 3-dimensional image input.");
+  DALI_ENFORCE(IsType<uint8>(input.type()), "Expected input data as uint8.");
 
   const int W = input.shape()[1];
   const int C = input.shape()[2];

--- a/dali/pipeline/operators/resize/resize.cc
+++ b/dali/pipeline/operators/resize/resize.cc
@@ -86,6 +86,7 @@ void Resize<CPUBackend>::SetupSharedSampleParams(SampleWorkspace *ws) {
 template <>
 void Resize<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
   const auto &input = ws->Input<CPUBackend>(idx);
+  DALI_ENFORCE(input.ndim() == 3, "Operator expects 3-dimensional image input.");
   auto output = ws->Output<CPUBackend>(idx);
   const auto &input_shape = input.shape();
 

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -62,8 +62,12 @@ class DALIGenericIterator(object):
     pipelines : list of nvidia.dali.pipeline.Pipeline
                 List of pipelines to use
     output_map : list of str
-                 List of strings (either "data" or "label") which maps
-                 the output of DALI pipeline to proper type of tensor
+                 List of strings which maps consecutive outputs
+                 of DALI pipelines to proper type of tensor.
+                 Each string represents a category, and we assume all
+                 tensors from given category have the same type.
+                 "data", "label" are predefined categories,
+                 "data" is returned as gpu tensor and "label" as cpu tensor.
     size : int
            Epoch size.
     """
@@ -85,6 +89,7 @@ class DALIGenericIterator(object):
         self._data_batches = [[None, None] for i in range(self._num_gpus)]
         self._counter = 0
         self._current_data_batch = 0
+        self._output_categories = set(output_map)
         self.output_map = output_map
 
         # We need data about the batches (like shape information),
@@ -107,45 +112,79 @@ class DALIGenericIterator(object):
             outputs.append(p._share_outputs())
         for i in range(self._num_gpus):
             dev_id = self._pipes[i].device_id
-            out_data = []
-            out_labels = []
-            # segregate outputs into data/label entries
+            # initialize dict for all output categories
+            category_outputs = {key : [] for key in self._output_categories}
+            # out_data = []
+            # out_labels = []
+            # segregate outputs into categories
             for j, out in enumerate(outputs[i]):
-                if self.output_map[j] == "data":
-                    out_data.append(out)
-                elif self.output_map[j] == "label":
-                    out_labels.append(out)
+                category_outputs[self.output_map[j]].append(out)
+                # if self.output_map[j] == "data":
+                #     out_data.append(out)
+                # elif self.output_map[j] == "label":
+                #     out_labels.append(out)
 
             # Change DALI TensorLists into Tensors
-            data = [x.as_tensor() for x in out_data]
-            data_shape = [x.shape() for x in data]
-            # Change label shape from [batch_size, 1] to [batch_size]
-            labels = [x.as_tensor() for x in out_labels]
-            for l in labels:
-                l.squeeze()
+            category_tensors = dict()
+            category_shapes = dict()
+            for category, output_list in category_outputs.items():
+                category_tensors[category] = [x.as_tensor() for x in output_list]
+                category_shapes[category] = [x.shape() for x in category_tensors[category]]
 
-            label_shape = [x.shape() for x in labels]
+            # data = [x.as_tensor() for x in out_data]
+            # data_shape = [x.shape() for x in data]
+            # Change label shape from [batch_size, 1] to [batch_size]
+            if "labels" in self._output_categories:
+                for l in category_tensors["labels"]:
+                    l.squeeze()
+                # Fix label shapes:
+                category_shapes["labels"] = [x.shape() for x in category_tensors["labels"]]
+
+            # labels = [x.as_tensor() for x in out_labels]
+            # for l in labels:
+            #     l.squeeze()
+
+            # label_shape = [x.shape() for x in labels]
+
             # If we did not yet allocate memory for that batch, do it now
             if self._data_batches[i][self._current_data_batch] is None:
-
-                data_torch_type = to_torch_type[np.dtype(data[0].dtype())]
-                label_torch_type = to_torch_type[np.dtype(labels[0].dtype())]
-
+                category_torch_type = dict()
+                category_device = dict()
                 torch_gpu_device = torch.device('cuda', dev_id)
                 torch_cpu_device = torch.device('cpu')
+                # check category and device
+                for category in self._output_categories:
+                    category_torch_type[category] = to_torch_type[np.dtype(category_tensors[category][0].dtype())]
+                    from nvidia.dali.backend import TensorGPU
+                    if type(category_tensors[category][0]) is TensorGPU:
+                        category_device[category] = torch_gpu_device
+                    else:
+                        category_device[category] = torch_cpu_device
 
-                pyt_data = [torch.zeros(shape, dtype=data_torch_type, device=torch_gpu_device) for shape in data_shape]
-                pyt_labels = [torch.zeros(shape, dtype=label_torch_type, device=torch_cpu_device) for shape in label_shape]
+                pyt_tensors = dict()
+                for category in self._output_categories:
+                    pyt_tensors[category] = [torch.zeros(shape,
+                                                         dtype=category_torch_type[category],
+                                                         device=category_device[category])
+                                             for shape in category_shapes[category]]
+                # pyt_data = [torch.zeros(shape, dtype=data_torch_type, device=torch_gpu_device) for shape in data_shape]
+                # pyt_labels = [torch.zeros(shape, dtype=label_torch_type, device=torch_cpu_device) for shape in label_shape]
 
-                self._data_batches[i][self._current_data_batch] = (pyt_data, pyt_labels)
+                self._data_batches[i][self._current_data_batch] = pyt_tensors
             else:
-                pyt_data, pyt_labels = self._data_batches[i][self._current_data_batch]
+                pyt_tensors = self._data_batches[i][self._current_data_batch]
 
             # Copy data from DALI Tensors to torch tensors
-            for j, d_arr in enumerate(data):
-                feed_ndarray(d_arr, pyt_data[j])
-            for j, l_arr in enumerate(labels):
-                feed_ndarray(l_arr, pyt_labels[j])
+            for category, tensors in category_tensors.items():
+                for j, t in enumerate(tensors):
+                    feed_ndarray(t, pyt_tensors[category][j])
+            for p in self._pipes:
+                p._release_outputs()
+                p._start_run()
+            # for j, d_arr in enumerate(data):
+            #     feed_ndarray(d_arr, pyt_data[j])
+            # for j, l_arr in enumerate(labels):
+            #     feed_ndarray(l_arr, pyt_labels[j])
 
         for p in self._pipes:
             p._release_outputs()
@@ -155,6 +194,7 @@ class DALIGenericIterator(object):
         # Change index for double buffering
         self._current_data_batch = (self._current_data_batch + 1) % 2
         self._counter += self._num_gpus * self.batch_size
+        # TODO(klecki): convert to tuple for compability with "data" "labels"
         return [db[copy_db_index] for db in self._data_batches]
 
     def next(self):


### PR DESCRIPTION
This is to allow support for DALI in pytorch superres example of NVVL, 
should work with: https://github.com/klecki/nvvl/pull/1

Added Sequence Reader Operator and modified host decoder to allow processing of sequences. 
Sequences are supported as Tensors (one sample is one sequence), where first dimension is number of elements in sequence.

Pytorch plugin is broken, as superres example uses only frame sequences without labes, and plugin assumes that data always consists of images and labels.