### PR TITLE
Fix build for default TensorFlow version

### DIFF
--- a/dali/CMakeLists.txt
+++ b/dali/CMakeLists.txt
@@ -153,7 +153,7 @@ if (BUILD_TENSORFLOW)
 
   # append default TF version
   list(APPEND TF_PATHS ${DIST_PACKAGES_DIR})
-  list(APPEND TF_VER "")
+  list(APPEND TF_VER ";")
 
   # build TF plugin for each TF version we want to support
   list(LENGTH TF_PATHS TF_LIST_L)


### PR DESCRIPTION
When there is no any other than default installed TensorFlow
version in the system cmake complains about TF_VER list being
empty. Fix by adding proper representation of the empty element
in the cmake.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>