### PR TITLE
Make libjpegturbo root dir hint preceding pkgconfig

### DIFF
--- a/cmake/modules/FindJpegTurbo.cmake
+++ b/cmake/modules/FindJpegTurbo.cmake
@@ -14,7 +14,7 @@
 set(JPEG_TURBO_ROOT_DIR "" CACHE PATH "Folder contains JpegTurbo")
 
 if (NOT JPEG_TURBO_ROOT_DIR)
-    # if JPEG_TURBO_ROOT_DIR not provided use PkgConfig
+    # if JPEG_TURBO_ROOT_DIR is not provided use PkgConfig
     find_package(PkgConfig QUIET)
     if (PkgConfig_FOUND)
         # use pkg-config only if it has been found, if it fails it fall back to

--- a/cmake/modules/FindJpegTurbo.cmake
+++ b/cmake/modules/FindJpegTurbo.cmake
@@ -13,11 +13,14 @@
 
 set(JPEG_TURBO_ROOT_DIR "" CACHE PATH "Folder contains JpegTurbo")
 
-find_package(PkgConfig QUIET)
-if (PkgConfig_FOUND)
-    # use pkg-config only if it has been found, if it fails it fall back to
-    # JPEG_TURBO_ROOT_DIR hint
-    pkg_check_modules(JpegTurbo QUIET libturbojpeg)
+if (NOT JPEG_TURBO_ROOT_DIR)
+    # if JPEG_TURBO_ROOT_DIR not provided use PkgConfig
+    find_package(PkgConfig QUIET)
+    if (PkgConfig_FOUND)
+        # use pkg-config only if it has been found, if it fails it fall back to
+        # JPEG_TURBO_ROOT_DIR hint
+        pkg_check_modules(JpegTurbo QUIET libturbojpeg)
+    endif()
 endif()
 
 find_path(JpegTurbo_INCLUDE_DIR turbojpeg.h


### PR DESCRIPTION
If the user provides libjpegturbo root dir pkgconfig will be skipped
and version in the provided path will be used.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>