### PR TITLE
Remove debug prints from async_pipelined_executor

### DIFF
--- a/dali/pipeline/executor/async_pipelined_executor.cc
+++ b/dali/pipeline/executor/async_pipelined_executor.cc
@@ -36,9 +36,7 @@ void AsyncPipelinedExecutor::RunCPU() {
           return;
         }
 
-        // std::cout << "got cpu work" << endl;
         PipelinedExecutor::RunCPU();
-        // std::cout << "finished cpu work" << endl;
 
         // Mark that there is now mixed work to do
         // and signal to any threads that are waiting


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>