### PR TITLE
Fix ResizeAttr usage in Resize operator

### DIFF
--- a/dali/pipeline/op_graph.cc
+++ b/dali/pipeline/op_graph.cc
@@ -66,9 +66,9 @@ void CheckOpConstraints(const OpSpec &spec) {
       "' supports a minimum of " + std::to_string(schema.MinNumInput()) + " inputs, "
       "but was passed " + std::to_string(spec.NumRegularInput()) + ".");
   DALI_ENFORCE(spec.NumOutput() == schema.CalculateOutputs(spec) + additional_outputs,
-      "Operator '" + spec.name() +
-      "' supports " + std::to_string(schema.CalculateOutputs(spec)/num_input_sets) + " outputs, "
-      "but was passed " + std::to_string(spec.NumOutput()/num_input_sets) + ".");
+      "Operator '" + spec.name() + "' supports "
+      + std::to_string((schema.CalculateOutputs(spec) + additional_outputs)/num_input_sets)
+      + " outputs, but was passed " + std::to_string(spec.NumOutput()/num_input_sets) + ".");
 }
 
 }  // namespace

--- a/dali/pipeline/operators/op_schema_test.cc
+++ b/dali/pipeline/operators/op_schema_test.cc
@@ -118,4 +118,28 @@ TEST(OpSchemaTest, OptionalArgumentDefaultValueMultipleParent) {
   ASSERT_EQ(schema.GetDefaultValueForOptionalArgument<float>("dummy"), 1.85f);
 }
 
+DALI_SCHEMA(Dummy8)
+  .NumInput(1)
+  .NumOutput(1)
+  .AddOptionalArg("extra_out", R"code()code", 1, true)
+  .AdditionalOutputsFn([](const OpSpec& spec) {
+    return static_cast<int>(spec.GetArgument<int>("extra_out"));
+  });
+
+TEST(OpSchemaTest, AdditionalOutputFNTest) {
+  auto spec = OpSpec("Dummy8")
+              .AddInput("in", "cpu")
+              .AddArg("extra_out", 3);
+  auto spec2 = OpSpec("Dummy8")
+              .AddInput("in", "cpu")
+              .AddArg("extra_out", 0);
+  auto schema = SchemaRegistry::GetSchema("Dummy8");
+
+  ASSERT_EQ(schema.CalculateOutputs(spec), 1);
+  ASSERT_EQ(schema.CalculateAdditionalOutputs(spec), 3);
+
+  ASSERT_EQ(schema.CalculateOutputs(spec2), 1);
+  ASSERT_EQ(schema.CalculateAdditionalOutputs(spec2), 0);
+}
+
 }  // namespace dali

--- a/dali/pipeline/operators/resize/resize.cu
+++ b/dali/pipeline/operators/resize/resize.cu
@@ -95,6 +95,9 @@ DALIError_t BatchedResize(const uint8 **in_batch, int N, int C, const DALISize *
 
 template<>
 Resize<GPUBackend>::Resize(const OpSpec &spec) : Operator<GPUBackend>(spec), ResizeAttr(spec) {
+  save_attrs_ = spec_.HasArgument("save_attrs");
+  outputs_per_idx_ = save_attrs_ ? 2 : 1;
+
   resizeParam_ = new  vector<NppiPoint>(batch_size_ * 2);
   // Resize per-image data
   input_ptrs_.resize(batch_size_);
@@ -122,10 +125,8 @@ void Resize<GPUBackend>::SetupSharedSampleParams(DeviceWorkspace* ws) {
 template<>
 void Resize<GPUBackend>::RunImpl(DeviceWorkspace *ws, const int idx) {
     const auto &input = ws->Input<GPUBackend>(idx);
-    const bool save_attrs = spec_.HasArgument("save_attrs");
-    const int outputs_per_idx = save_attrs ? 2 : 1;
 
-    auto output = ws->Output<GPUBackend>(outputs_per_idx * idx);
+    auto output = ws->Output<GPUBackend>(outputs_per_idx_ * idx);
 
     ResizeParamDescr resizeDescr(this, resizeParam_->data());
     DataDependentSetupGPU(input, output, batch_size_, false,
@@ -142,22 +143,22 @@ void Resize<GPUBackend>::RunImpl(DeviceWorkspace *ws, const int idx) {
     nppSetStream(old_stream);
 
     // Setup and output the resize attributes if necessary
-    if (save_attrs) {
-      auto *attr_output = ws->Output<CPUBackend>(outputs_per_idx * idx + 1);
-
+    if (save_attrs_) {
+      TensorList<CPUBackend> attr_output_cpu;
       vector<Dims> resize_shape(input.ntensor());
 
       for (size_t i = 0; i < input.ntensor(); ++i) {
         resize_shape[i] = Dims{2};
       }
 
-      attr_output->Resize(resize_shape);
+      attr_output_cpu.Resize(resize_shape);
 
       for (size_t i = 0; i < input.ntensor(); ++i) {
-        int *t = attr_output->mutable_tensor<int>(i);
+        int *t = attr_output_cpu.mutable_tensor<int>(i);
         t[0] = sizes(output_t).data()[i].height;
         t[1] = sizes(output_t).data()[i].width;
       }
+      ws->Output<GPUBackend>(outputs_per_idx_ * idx + 1)->Copy(attr_output_cpu, ws->stream());
     }
 }
 

--- a/dali/pipeline/operators/resize/resize.h
+++ b/dali/pipeline/operators/resize/resize.h
@@ -93,6 +93,8 @@ class Resize : public Operator<Backend>, protected ResizeAttr {
 
   vector<NppiPoint> *resizeParam_ = nullptr;
   USE_OPERATOR_MEMBERS();
+  bool save_attrs_;
+  int outputs_per_idx_;
 };
 
 }  // namespace dali

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -690,6 +690,7 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("MinNumInput", &OpSchema::MinNumInput)
     .def("HasOutputFn", &OpSchema::HasOutputFn)
     .def("CalculateOutputs", &OpSchema::CalculateOutputs)
+    .def("CalculateAdditionalOutputs", &OpSchema::CalculateAdditionalOutputs)
     .def("SupportsInPlace", &OpSchema::SupportsInPlace)
     .def("CheckArgs", &OpSchema::CheckArgs)
     .def("GetArgumentDox", &OpSchema::GetArgumentDox)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -136,7 +136,7 @@ class _OperatorInstance(object):
         else:
             output_device = "cpu"
 
-        num_output = self._op.schema.CalculateOutputs(self._spec)
+        num_output = self._op.schema.CalculateOutputs(self._spec) + self._op.schema.CalculateAdditionalOutputs(self._spec)
 
         for i in range(num_output):
             t_name = type(self._op).__name__ + "_id_" + str(self.id) + "_output_" + str(i)


### PR DESCRIPTION
Makes ResizeAttr implementation consistent as for CPU variant is was not existing.
Also GPU variant was trying to return CPU tensor what is not possible for the GPU
operator.
Introduces small fix to verification of the number of outputs to take into account
additional outputs as well.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>