### PR TITLE
Added bounding box flipping on GPU.

### DIFF
--- a/dali/pipeline/operators/arg_helper.h
+++ b/dali/pipeline/operators/arg_helper.h
@@ -1,0 +1,81 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATORS_ARG_HELPER_H_
+#define DALI_PIPELINE_OPERATORS_ARG_HELPER_H_
+
+#include <dali/pipeline/operators/argument.h>
+#include <dali/pipeline/operators/op_spec.h>
+#include <dali/pipeline/data/tensor.h>
+#include <memory>
+#include <string>
+
+namespace dali {
+
+template <typename T>
+class ArgValue {
+ public:
+  ArgValue() = default;
+  ArgValue(ArgValue &&) = default;
+  inline ArgValue(const ArgValue &other) { *this = other; }
+  inline ArgValue(const std::string &name, const OpSpec &spec, ArgumentWorkspace *ws) {
+    if (spec.HasTensorArgument(name)) {
+      tensor_ = &ws->ArgumentInput(name);
+      data_ = tensor_->data<T>();
+    } else {
+      value_ = spec.GetArgument<T>(name, ws);
+    }
+  }
+
+  ArgValue &operator=(ArgValue &&) = default;
+  inline ArgValue &operator=(const ArgValue &other) {
+    gpu_.reset();
+    value_  = other.value_;
+    tensor_ = other.tensor_;
+    data_   = other.data_;
+    return *this;
+  }
+
+  inline bool IsTensor() const { return data_ != nullptr; }
+
+  inline const T &operator[](Index index) {
+    if (IsTensor()) {
+#if DALI_DEBUG
+      DALI_ENFORCE(index < tensor_->size());
+#endif
+      return data_[index];
+    } else {
+      return  value_;
+    }
+  }
+
+  inline const Tensor<GPUBackend> *AsGPU(cudaStream_t stream) {
+    DALI_ENFORCE(IsTensor());
+    if (!gpu_) {
+      gpu_.reset(new Tensor<GPUBackend>());
+      gpu_->Copy(*tensor_, stream);
+    }
+    return gpu_.get();
+  }
+
+ private:
+  T value_;
+  const T *data_ = nullptr;
+  const Tensor<CPUBackend> *tensor_ = nullptr;
+  std::unique_ptr<Tensor<GPUBackend>> gpu_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATORS_ARG_HELPER_H_

--- a/dali/pipeline/operators/geometric/bb_flip.cc
+++ b/dali/pipeline/operators/geometric/bb_flip.cc
@@ -22,7 +22,7 @@ const std::string kHorizontalArgName = "horizontal";  //NOLINT
 const std::string kVerticalArgName = "vertical";  //NOLINT
 
 
-DALI_REGISTER_OPERATOR(BbFlip, BbFlip, CPU);
+DALI_REGISTER_OPERATOR(BbFlip, BbFlip<CPUBackend>, CPU);
 
 
 DALI_SCHEMA(BbFlip)
@@ -44,7 +44,7 @@ False for for width-height representation. Default: False)code",
                                 0, true);
 
 
-BbFlip::BbFlip(const dali::OpSpec &spec) :
+BbFlip<CPUBackend>::BbFlip(const dali::OpSpec &spec) :
         Operator<CPUBackend>(spec),
         coordinates_type_ltrb_(spec.GetArgument<bool>(kCoordinatesTypeArgName)) {
   vflip_is_tensor_ = spec.HasTensorArgument(kVerticalArgName);
@@ -52,7 +52,7 @@ BbFlip::BbFlip(const dali::OpSpec &spec) :
 }
 
 
-void BbFlip::RunImpl(dali::SampleWorkspace *ws, const int idx) {
+void BbFlip<CPUBackend>::RunImpl(dali::SampleWorkspace *ws, const int idx) {
   const auto &input = ws->Input<CPUBackend>(idx);
   const auto input_data = input.data<float>();
 

--- a/dali/pipeline/operators/geometric/bb_flip.cu
+++ b/dali/pipeline/operators/geometric/bb_flip.cu
@@ -1,0 +1,147 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <dali/pipeline/operators/geometric/bb_flip.cuh>
+#include <dali/pipeline/operators/arg_helper.h>
+#include <vector>
+
+namespace dali {
+
+/// @param output                - output bounding boxes
+/// @param input                 - input bounding boxes
+/// @param num_boxes             - number of bounding boxes in the input
+/// @param sample_indices        - when using per-sample flip, contains sample indices for each
+///                                bounding box in the input tensor list
+/// @param per_sample_horizontal - per-sample flag indicating whether bounding boxes from
+//                                 a given sample should be flipped horizontally; may by NULL
+/// @param per_sample_vertical   - per-sample flag indicating whether bounding boxes from
+//                                 a given sample should be flipped vertically; may be NULL
+/// @param global_horizontal     - whether to flip horizontally; overriden by
+///                                per_sample_horizontal, if specified
+/// @param global_vertical       - whether to flip vertically; overriden by
+///                                per_sample_vertical, if specified
+template <bool ltrb>
+__global__ void BbFlipKernel(float *output, const float *input, size_t num_boxes,
+                             bool global_horizontal, const int *per_sample_horizontal,
+                             bool global_vertical, const int *per_sample_vertical,
+                             const int *sample_indices) {
+  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= num_boxes)
+    return;
+
+  bool h = per_sample_horizontal
+         ? per_sample_horizontal[sample_indices[idx]]
+         : global_horizontal;
+  bool v = per_sample_vertical
+         ? per_sample_vertical[sample_indices[idx]]
+         : global_vertical;
+
+  const auto *in = &input[4 * idx];
+  auto *out = &output[4 * idx];
+  if (ltrb) {
+    out[0] = h ? 1.0f - in[2] : in[0];
+    out[1] = v ? 1.0f - in[3] : in[1];
+    out[2] = h ? 1.0f - in[0] : in[2];
+    out[3] = v ? 1.0f - in[1] : in[3];
+  } else {
+    // No range checking required if the parenthesis is respected in the two lines below.
+    // If the original bounding box satisfies the condition that x + w <= 1.0f, then the expression
+    // 1.0f - (x + w) is guaranteed to yield a non-negative result. QED.
+    out[0] = h ? 1.0f - (in[0] + in[2]) : in[0];
+    out[1] = v ? 1.0f - (in[1] + in[3]) : in[1];
+    out[2] = in[2];  // width and
+    out[3] = in[3];  // height remain unaffected
+  }
+}
+
+
+void BbFlip<GPUBackend>::RunImpl(Workspace<GPUBackend> *ws, int idx) {
+  auto &input = ws->Input<GPUBackend>(idx);
+  auto output = ws->Output<GPUBackend>(idx);
+
+  DALI_ENFORCE(IsType<float>(input.type()), "Expected input data as float;"
+               " got " + input.type().name());
+  DALI_ENFORCE(input.size() % 4 == 0,
+               "Input data size must be a multiple of 4 if it contains bounding boxes;"
+               " got " + std::to_string(input.size()));
+
+  ArgValue<int> horz("horizontal", spec_, ws);
+  ArgValue<int> vert("vertical", spec_, ws);
+  bool ltrb = spec_.GetArgument<bool>("ltrb");
+
+  auto stream = ws->stream();
+
+  const auto num_boxes = input.size() / 4;
+
+  const int *sample_idx = nullptr;
+  const int *per_sample_horz = nullptr;
+  const int *per_sample_vert = nullptr;
+
+  // contains a map from box index to sample index - used
+  // for accessing per-sample horz/vert arguments.
+  Tensor<GPUBackend> sample_idx_tensor;
+
+  if (horz.IsTensor() || vert.IsTensor()) {
+    std::vector<int> indices;
+    indices.reserve(num_boxes);
+
+    // populate the index map
+    auto shape = input.shape();
+    for (size_t sample = 0; sample < shape.size(); sample++) {
+      auto dim = shape[sample].size();
+
+      DALI_ENFORCE(dim < 2 || shape[sample][dim-1] == 4,
+                   "If bounding box tensor is >= 2D, innermost dimension must be 4");
+      DALI_ENFORCE(dim > 1 || shape[sample][0] % 4 == 0,
+                   "Flat representation of bouding boxes must have size divisible by 4");
+
+      size_t sample_boxes = dim == 2 ? shape[sample][0] : shape[sample][0] / 4;
+      for (size_t i = 0; i < sample_boxes ; i++) {
+        indices.push_back(sample);
+      }
+    }
+    sample_idx_tensor.Copy(indices, stream);
+
+    if (horz.IsTensor())
+      per_sample_horz = horz.AsGPU(stream)->data<int>();
+
+    if (vert.IsTensor())
+      per_sample_vert = vert.AsGPU(stream)->data<int>();
+
+    sample_idx = sample_idx_tensor.data<int>();
+  }
+
+  output->ResizeLike(input);
+
+  const unsigned block = num_boxes < 1024 ? num_boxes : 1024;
+  const unsigned grid = (num_boxes + block - 1) / block;
+
+  if (ltrb) {
+    BbFlipKernel<true><<<grid, block, 0, stream>>>(
+      output->mutable_data<float>(), input.data<float>(), num_boxes,
+      !per_sample_horz && horz[0], per_sample_horz,
+      !per_sample_vert && vert[0], per_sample_vert,
+      sample_idx);
+  } else {
+    BbFlipKernel<false><<<grid, block, 0, stream>>>(
+      output->mutable_data<float>(), input.data<float>(), num_boxes,
+      !per_sample_horz && horz[0], per_sample_horz,
+      !per_sample_vert && vert[0], per_sample_vert,
+      sample_idx);
+  }
+}
+
+DALI_REGISTER_OPERATOR(BbFlip, BbFlip<GPUBackend>, GPU);
+
+}  // namespace dali

--- a/dali/pipeline/operators/geometric/bb_flip.cuh
+++ b/dali/pipeline/operators/geometric/bb_flip.cuh
@@ -1,0 +1,33 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATORS_GEOMETRIC_BB_FLIP_CUH_
+#define DALI_PIPELINE_OPERATORS_GEOMETRIC_BB_FLIP_CUH_
+
+#include <dali/pipeline/operators/geometric/bb_flip.h>
+
+namespace dali {
+
+template <>
+class BbFlip<GPUBackend> : public Operator<GPUBackend> {
+ public:
+  explicit BbFlip(const OpSpec &spec) : Operator<GPUBackend>(spec) {}
+
+  void RunImpl(Workspace<GPUBackend> *ws, int idx = 0) override;
+ private:
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATORS_GEOMETRIC_BB_FLIP_CUH_

--- a/dali/pipeline/operators/geometric/bb_flip.h
+++ b/dali/pipeline/operators/geometric/bb_flip.h
@@ -21,7 +21,11 @@
 
 namespace dali {
 
-class BbFlip : public Operator<CPUBackend> {
+template <typename Backend>
+class BbFlip;
+
+template <>
+class BbFlip<CPUBackend> : public Operator<CPUBackend> {
  public:
   explicit BbFlip(const OpSpec &spec);
 


### PR DESCRIPTION
BbFlip operator on the GPU takes "horizontal", "vertical", and "ltrb" arguments.
"ltrb" is a scalar argument that selects both input and output format for the flipped boxes. "horizontal" and "vertical" can be tensor arguments.
The operator prepares temporary GPU tensors for arguments and an index tensor that maps bounding boxes to sample IDs. The execution is run on flat array of bounding boxes, with indirect indexing of per-sample flip flags.
If no per-sample flags are specified, then index array is not necessary and is neither created nor accessed in the kernel.
LTRB is subject to a runtime check in the host code and appropriate, specialized GPU kernel is selected based on the flag.
Care is taken that the bounding boxes that originally were within (0,1) bounds stay within those bounds after flipping.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>