### PR TITLE
WIP - Kernel API design

### DIFF
--- a/dali/kernels/CMakeLists.txt
+++ b/dali/kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dali/kernels/alloc_type.h
+++ b/dali/kernels/alloc_type.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_ALLOC_TYPE_H_
+#define DALI_KERNELS_ALLOC_TYPE_H_
+
+#include <dali/kernels/backend_tags.h>
+
+namespace dali {
+namespace kernels {
+
+enum class AllocType : uint8_t {
+  Host = 0,
+  Pinned,
+  GPU,
+  Unified,
+  Count,
+};
+
+template <AllocType alloc>
+struct alloc_to_backend {
+  using type = StorageCPU;
+};
+
+template <>
+struct alloc_to_backend<AllocType::GPU> {
+  using type = StorageGPU;
+};
+template <>
+struct alloc_to_backend<AllocType::Unified> {
+  using type = StorageUnified;
+};
+
+template <AllocType alloc>
+using AllocBackend = typename alloc_to_backend<alloc>::type;
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_ALLOC_TYPE_H_

--- a/dali/kernels/alloc_type.h
+++ b/dali/kernels/alloc_type.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #ifndef DALI_KERNELS_ALLOC_TYPE_H_
 #define DALI_KERNELS_ALLOC_TYPE_H_
 
-#include <dali/kernels/backend_tags.h>
+#include "dali/kernels/backend_tags.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/backend_tags.h
+++ b/dali/kernels/backend_tags.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/kernels/backend_tags.h
+++ b/dali/kernels/backend_tags.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_BACKEND_TAGS_H_
+#define DALI_KERNELS_BACKEND_TAGS_H_
+
+namespace dali {
+namespace kernels {
+
+struct StorageGPU {};
+struct StorageCPU {};
+struct StorageUnified {};
+
+struct ComputeGPU {};
+struct ComputeCPU {};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_BACKEND_TAGS_H_

--- a/dali/kernels/context.h
+++ b/dali/kernels/context.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_CONTEXT_H_
+#define DALI_KERNELS_CONTEXT_H_
+
+#include <cuda_runtime_api.h>
+#include <dali/kernels/tensor_view.h>
+#include <dali/kernels/alloc_type.h>
+#include <vector>
+
+namespace dali {
+namespace kernels {
+
+template <typename ComputeBackend>
+struct Context {};
+
+template <>
+struct Context<ComputeGPU> {
+  cudaStream_t stream;
+};
+
+class ScratchpadAllocator {
+ public:
+  virtual void *Alloc(AllocType alloc_type, size_t bytes, size_t alignment) = 0;
+
+  template <AllocType alloc_type, typename T, size_t dim>
+  TensorView<AllocBackend<alloc_type>, T, dim> AllocTensor(TensorShape<dim> shape) {
+    return { New<T>(alloc_type, Volume(shape)), shape };
+  }
+
+  template <AllocType alloc_type, typename T, size_t dim>
+  TensorListView<AllocBackend<alloc_type>, T, dim>
+  AllocTensorList(std::vector<TensorShape<dim>> shape) {
+    TensorListView<AllocBackend<alloc_type>, T, dim> tlv(nullptr, shape);
+    tlv.data = New<T>(alloc_type, tlv.total_size());
+    return tlv;
+  }
+
+  template <typename T>
+  T *New(AllocType alloc_type, size_t count, size_t alignment = alignof(T)) {
+    return reinterpret_cast<T*>(Alloc(alloc_type, count*sizeof(T), alignment));
+  }
+
+ protected:
+  ~ScratchpadAllocator() = default;
+};
+
+using CPUContext = Context<ComputeCPU>;
+using GPUContext = Context<ComputeGPU>;
+
+struct KernelContext {
+  CPUContext cpu;
+  GPUContext gpu;
+  ScratchpadAllocator *scratchpad;
+};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_CONTEXT_H_

--- a/dali/kernels/context.h
+++ b/dali/kernels/context.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 #define DALI_KERNELS_CONTEXT_H_
 
 #include <cuda_runtime_api.h>
-#include <dali/kernels/tensor_view.h>
-#include <dali/kernels/alloc_type.h>
 #include <vector>
+#include "dali/kernels/tensor_view.h"
+#include "dali/kernels/alloc_type.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/kernel.h
+++ b/dali/kernels/kernel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
 #ifndef DALI_KERNELS_KERNEL_H_
 #define DALI_KERNELS_KERNEL_H_
 
-#include <dali/kernels/tensor_view.h>
-#include <dali/kernels/context.h>
-#include <dali/kernels/kernel_params.h>
-#include <dali/kernels/kernel_req.h>
-#include <dali/kernels/kernel_traits.h>
-#include <dali/kernels/tuple_helpers.h>
-#include <dali/kernels/util.h>
 #include <vector>
+#include "dali/kernels/context.h"
+#include "dali/kernels/tensor_view.h"
+#include "dali/kernels/kernel_params.h"
+#include "dali/kernels/kernel_req.h"
+#include "dali/kernels/kernel_traits.h"
+#include "dali/kernels/tuple_helpers.h"
+#include "dali/kernels/util.h"
 
 namespace dali {
 
@@ -148,7 +148,7 @@ Requirements GetRequirements(
     return {};
 
   Requirements req = GetRequirements<Kernel>(context, input_sets[0], args);
-  for (size_t i = 1; i < input_sets; i++) {
+  for (size_t i = 1; i < input_sets.size(); i++) {
     Requirements newReq = GetRequirements<Kernel>(context, input_sets[i], args);
     req.AddInputSet(newReq, true);
   }
@@ -166,7 +166,7 @@ void Run(Context &context,
   check_kernel<Kernel>();
   assert(output_sets.size() == input_sets.size());
   for (size_t i = 0; i < input_sets.size(); i++) {
-    Run<Kernel>(context, output_sets, input_sets, args);
+    Run<Kernel>(context, output_sets[i], input_sets[i], args);
   }
 }
 

--- a/dali/kernels/kernel.h
+++ b/dali/kernels/kernel.h
@@ -1,0 +1,178 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_KERNEL_H_
+#define DALI_KERNELS_KERNEL_H_
+
+#include <dali/kernels/tensor_view.h>
+#include <dali/kernels/context.h>
+#include <dali/kernels/kernel_params.h>
+#include <dali/kernels/kernel_req.h>
+#include <dali/kernels/kernel_traits.h>
+#include <dali/kernels/tuple_helpers.h>
+#include <dali/kernels/util.h>
+#include <vector>
+
+namespace dali {
+
+/// @brief Defines the DALI kernel API. See dali::kernels::examples::Kernel for details
+namespace kernels {
+
+namespace examples {
+
+/// @brief  DALI Kernel example
+///
+/// This class represents a "concept" of a DALI kernel.
+/// A kernel must provide two non-overloaded functions:
+/// Run and GetRequirements.
+///
+/// The kernel can be run directly or its inputs, outputs and arguments can be tied
+/// into tuples and then the kernel be configured and launched using:
+///
+/// `dali::kernels::kernel::GetRequirements`
+///
+/// `dali::kernels::kernel::Run`
+///
+/// Programmer can check whether their type satisfies conditions for being a kernel
+/// through instantiating check_kernel<KernelType>. If the type does not meet requirements,
+/// static_asserts should produce meaningful diagnostics that will help to rectify the problem.
+template <typename Input1, typename Input2, typename OutputType>
+struct Kernel {
+  /// @brief Returns kernel output(s) shape(s) and additional memory requirements
+  ///
+  /// GetRequirements receives full input and output tensor lists and any extra arguments that
+  /// are going to be passed to a subsequent call to Run.
+  ///
+  /// @remarks The inputs are provided mainly to inspect their shapes; actually looking at the
+  /// data may degrade performance severely.
+  ///
+  /// @param context - environment of the kernel;, cuda stream, batch info, etc.
+  ///                  At the time of call to GetRequirements, its scratch area is undefined.
+  ///
+  /// @param in1 - example input, consisting of a list of 3D tensors with element type Input1
+  /// @param in2 - example input, consisting of a list of 4D tensors with element type Input2
+  /// @param aux - some extra parameters (e.g. convolution kernel, mask)
+  static KernelRequirements GetRequirements(
+    KernelContext &context,
+    const InListGPU<Input1, 3> &in1,
+    const InListGPU<Input2, 4> &in2,
+    const InTensorCPU<float, 3> &aux);
+
+  /// @brief Runs the kernel
+  ///
+  /// Run processes the inputs and populates the pre-allocated output. Output shape is expected
+  /// to match that returned by GetRequirements.
+  ///
+  /// @param context - environment; provides scratch memory, cuda stream, batch info, etc.
+  ///                  Scratch area must satisfy requirements returned by GetRequirements.
+  /// @param in1 - example input, consisting of a list of 3D tensors with element type Input1
+  /// @param in2 - example input, consisting of a list of 4D tensors with element type Input2
+  /// @param aux - some extra parameters (e.g. convolution kernel, mask)
+  static void Run(
+    KernelContext &context,
+    const OutListGPU<OutputType, 3> &out,
+    const InListGPU<Input1, 3> &in1,
+    const InListGPU<Input2, 4> &in2,
+    const InTensorCPU<float, 3> &aux);
+};
+
+}  // namespace examples
+
+/// @brief A collection of pseudo-methods to operate on Kernel classes/objects
+namespace kernel {
+
+// avoid retyping "Kernel" every second word...
+
+template <typename Kernel>
+using inputs = kernel_inputs<Kernel>;
+
+template <typename Kernel>
+using outputs = kernel_outputs<Kernel>;
+
+template <typename Kernel>
+using args = kernel_args<Kernel>;
+
+using Context = KernelContext;
+using Requirements = KernelRequirements;
+
+/// @brief Gets requirements for given Kernel
+/// @param context            - execution environment (without scratch memory)
+/// @param input              - kernel inputs, convertible to kernel_inputs<Kernel>
+/// @param args               - kernel extra arguments, convertible to kernel_args<Kernel>
+template <typename Kernel>
+Requirements GetRequirements(
+      Context &context,
+      const inputs<Kernel> &input,
+      const args<Kernel> &args) {
+  check_kernel<Kernel>();
+  return apply_all(Kernel::GetRequirements, context, input, args);
+}
+
+/// @brief Executes a Kernel on an input set
+/// @param context             - execution environment (with scratch memory)
+/// @param input               - kernel inputs, convertible to kernel_inputs<Kernel>
+/// @param outputs             - kernel outputs, convertible to kernel_outputs<Kernel>
+/// @param args                - kernel extra arguments, convertible to kernel_args<Kernel>
+template <typename Kernel>
+void Run(
+      Context &context,
+      const outputs<Kernel> &output,
+      const inputs<Kernel> &input,
+      const args<Kernel> &args) {
+  check_kernel<Kernel>();
+  apply_all(Kernel::Run, context, output, input, args);
+}
+
+/// @brief Default implementation of requirements for multiple input sets
+/// @remarks Reuse scratch, append output shapes
+///
+/// @TODO(michalz) remove references from inputs/args?
+template <typename Kernel>
+Requirements GetRequirements(
+      Context &context,
+      const std::vector<inputs<Kernel>> &input_sets,
+      const args<Kernel> &args) {
+  check_kernel<Kernel>();
+  if (input_sets.empty())
+    return {};
+
+  Requirements req = GetRequirements<Kernel>(context, input_sets[0], args);
+  for (size_t i = 1; i < input_sets; i++) {
+    Requirements newReq = GetRequirements<Kernel>(context, input_sets[i], args);
+    req.AddInputSet(newReq, true);
+  }
+  return req;
+}
+
+/// @brief Default implementation of execution for multiple input sets
+///
+/// @TODO(michalz) remove references from inputs/outputs/args?
+template <typename Kernel>
+void Run(Context &context,
+      const std::vector<outputs<Kernel> > &output_sets,
+      const std::vector<inputs<Kernel> > &input_sets,
+      const args<Kernel> &args) {
+  check_kernel<Kernel>();
+  assert(output_sets.size() == input_sets.size());
+  for (size_t i = 0; i < input_sets.size(); i++) {
+    Run<Kernel>(context, output_sets, input_sets, args);
+  }
+}
+
+}  // namespace kernel
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_KERNEL_H_

--- a/dali/kernels/kernel_params.h
+++ b/dali/kernels/kernel_params.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_KERNEL_PARAMS_H_
+#define DALI_KERNELS_KERNEL_PARAMS_H_
+
+#include <dali/kernels/tensor_view.h>
+#include <type_traits>
+
+namespace dali {
+namespace kernels {
+
+template <typename StorageBackend, typename ElementType, int sample_dim>
+using InList = TensorListView<StorageBackend, const ElementType, sample_dim>;
+
+template <typename StorageBackend, typename ElementType, int sample_dim>
+using OutList = TensorListView<StorageBackend, ElementType, sample_dim>;
+
+template <typename ElementType, int sample_dim>
+using InListCPU = InList<StorageCPU, ElementType, sample_dim>;
+
+template <typename ElementType, int sample_dim>
+using InListGPU = InList<StorageGPU, ElementType, sample_dim>;
+
+template <typename ElementType, int sample_dim>
+using OutListCPU = OutList<StorageCPU, ElementType, sample_dim>;
+
+template <typename ElementType, int sample_dim>
+using OutListGPU = OutList<StorageGPU, ElementType, sample_dim>;
+
+template <typename StorageBackend, typename ElementType, int sample_dim>
+using InTensor = TensorView<StorageBackend, const ElementType, sample_dim>;
+
+template <typename StorageBackend, typename ElementType, int sample_dim>
+using OutTensor = TensorView<StorageBackend, ElementType, sample_dim>;
+
+template <typename ElementType, int sample_dim>
+using InTensorCPU = InTensor<StorageCPU, ElementType, sample_dim>;
+
+template <typename ElementType, int sample_dim>
+using InTensorGPU = InTensor<StorageGPU, ElementType, sample_dim>;
+
+template <typename ElementType, int sample_dim>
+using OutTensorCPU = OutTensor<StorageCPU, ElementType, sample_dim>;
+
+template <typename ElementType, int sample_dim>
+using OutTensorGPU = OutTensor<StorageGPU, ElementType, sample_dim>;
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_KERNEL_PARAMS_H_

--- a/dali/kernels/kernel_params.h
+++ b/dali/kernels/kernel_params.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 #ifndef DALI_KERNELS_KERNEL_PARAMS_H_
 #define DALI_KERNELS_KERNEL_PARAMS_H_
 
-#include <dali/kernels/tensor_view.h>
 #include <type_traits>
+#include "dali/kernels/tensor_view.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/kernel_req.h
+++ b/dali/kernels/kernel_req.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef  DALI_KERNELS_KERNEL_REQ_H_
+#define  DALI_KERNELS_KERNEL_REQ_H_
+
+#include <dali/kernels/context.h>
+#include <dali/kernels/tuple_helpers.h>
+#include <dali/kernels/util.h>
+#include <array>
+#include <vector>
+#include <algorithm>
+
+namespace dali {
+namespace kernels {
+
+/// @brief Represents requirements for kernel to do its job for given inputs and arguments.
+struct KernelRequirements {
+  std::vector<TensorListShape<-1>> output_shapes;
+
+  std::array<size_t, (size_t)AllocType::Count> scratch_sizes;
+
+  /// @param reuse_scratch  - if true, scratch size is taken to be maximum from that for
+  ///                         all input sets, otherwise it's the sum
+  /// @param new_req        - requirements for the new input set, to be merged with this one
+  /// @return               - *this, for chaining
+  KernelRequirements &AddInputSet(const KernelRequirements &new_req, bool reuse_scratch) {
+    auto &r = new_req;
+
+    append(output_shapes, r.output_shapes);
+
+    for (size_t i = 0; i < scratch_sizes.size(); i++) {
+      if (reuse_scratch)
+        scratch_sizes[i] = std::max(scratch_sizes[i], r.scratch_sizes[i]);
+      else
+        scratch_sizes[i] += r.scratch_sizes[i];
+    }
+    return *this;
+  }
+};
+
+/// @brief A utility class for adding scratchpad requirements with proper alignment,
+///        assuming bump allocation.
+struct ScratchpadEstimator {
+  ScratchpadEstimator() : sizes{} {}  // zero-fill
+
+  /// @brief Adds a new memory requirement for count instances of T
+  ///
+  /// The method includes padding, assuming the add function is called in order of allocations.
+  /// The resulting allocation size is equal to size of a structure which contains all allocated
+  /// objects assuming natural alignment.
+  /// The estimator assumes that scratch buffer implementation will provide memory block based at
+  /// largest possible alignment boundary.
+  ///
+  /// @return Total number of bytes required for given allocation method,
+  ///         including this allocation.
+  template <typename T>
+  size_t add(AllocType alloc_type, size_t count, size_t alignment = alignof(T)) {
+    size_t offset = align_up(sizes[(size_t)alloc_type], alignment);
+    if (count) {
+      sizes[(size_t)alloc_type] = offset + count * sizeof(T);
+    }
+    return sizes[(size_t)alloc_type];
+  }
+
+  std::array<size_t, (size_t)AllocType::Count> sizes;
+};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_KERNEL_REQ_H_

--- a/dali/kernels/kernel_req.h
+++ b/dali/kernels/kernel_req.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
 #ifndef  DALI_KERNELS_KERNEL_REQ_H_
 #define  DALI_KERNELS_KERNEL_REQ_H_
 
-#include <dali/kernels/context.h>
-#include <dali/kernels/tuple_helpers.h>
-#include <dali/kernels/util.h>
 #include <array>
 #include <vector>
 #include <algorithm>
+#include "dali/kernels/context.h"
+#include "dali/kernels/tuple_helpers.h"
+#include "dali/kernels/util.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/kernel_traits.h
+++ b/dali/kernels/kernel_traits.h
@@ -1,0 +1,243 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_KERNEL_TRAITS_H_
+#define DALI_KERNELS_KERNEL_TRAITS_H_
+
+#include <dali/kernels/kernel_params.h>
+#include <dali/kernels/util.h>
+#include <dali/kernels/tuple_helpers.h>
+#include <dali/kernels/kernel_req.h>
+#include <type_traits>
+#include <tuple>
+
+namespace dali {
+namespace kernels {
+
+namespace detail {
+
+template <typename T>
+struct is_input_list : std::false_type {};
+
+template <typename StorageBackend, typename T, int dim>
+struct is_input_list<InList<StorageBackend, T, dim>> : std::true_type {};
+
+template <typename T>
+struct is_output_list : std::false_type {};
+
+template <typename StorageBackend, typename T, int dim>
+struct is_output_list<TensorListView<StorageBackend, T, dim>>
+: std::integral_constant<bool, !std::is_const<T>::value> {};
+
+template <typename T>
+struct is_kernel_arg : std::true_type {};
+
+template <typename StorageBackend, typename T, int dim>
+struct is_kernel_arg<TensorListView<StorageBackend, T, dim>> : std::false_type {};
+
+template <>
+struct is_kernel_arg<KernelContext> : std::false_type {};
+
+template <typename T, template <typename> class Predicate, bool value = Predicate<
+  typename std::remove_const<typename std::remove_reference<T>::type>::type
+  >::value>
+struct filter {
+  using type = std::tuple<T>;
+};
+
+template <typename T, template <typename> class Predicate>
+struct filter<T, Predicate, false> {
+  using type = std::tuple<>;
+};
+
+
+template <typename F>
+struct input_lists;
+
+template <typename... Args>
+struct input_lists<void(Args...)> {
+  using type = dali::detail::tuple_cat_t<
+    typename filter<Args, is_input_list>::type...
+  >;
+};
+
+template <typename F>
+struct output_lists;
+
+template <typename... Args>
+struct output_lists<void(Args...)> {
+  using type = dali::detail::tuple_cat_t<
+    typename filter<Args, is_output_list>::type...
+  >;
+};
+
+template <typename F>
+struct kernel_arg_params;
+
+template <typename... Args>
+struct kernel_arg_params<void(Args...)> {
+  using type = dali::detail::tuple_cat_t<
+    typename filter<Args, is_kernel_arg>::type...
+  >;
+};
+
+template <typename Kernel>
+struct kernel_run_inputs {
+  using type = typename detail::input_lists<decltype(Kernel::Run)>::type;
+};
+
+
+template <typename Kernel>
+struct kernel_run_outputs {
+  using type = typename detail::output_lists<decltype(Kernel::Run)>::type;
+};
+
+
+template <typename Kernel>
+struct kernel_run_args {
+  using type = typename detail::kernel_arg_params<decltype(Kernel::Run)>::type;
+};
+
+
+IMPL_HAS_NESTED_TYPE(Inputs)
+IMPL_HAS_NESTED_TYPE(Outputs)
+IMPL_HAS_NESTED_TYPE(Args)
+
+template <typename Kernel, bool has_explicit_def = has_type_Inputs<Kernel>::value>
+struct KernelInputs {
+  using type = typename Kernel::Inputs;
+};
+
+template <typename Kernel>
+struct KernelInputs<Kernel, false> {
+  using type = typename kernel_run_inputs<Kernel>::type;
+};
+
+template <typename Kernel, bool has_explicit_def = has_type_Outputs<Kernel>::value>
+struct KernelOutputs {
+  using type = typename Kernel::Outputs;
+};
+
+template <typename Kernel>
+struct KernelOutputs<Kernel, false> {
+  using type = typename kernel_run_outputs<Kernel>::type;
+};
+
+template <typename Kernel, bool has_explicit_def = has_type_Args<Kernel>::value>
+struct KernelArgs {
+  using type = typename Kernel::Args;
+};
+
+template <typename Kernel>
+struct KernelArgs<Kernel, false> {
+  using type = typename kernel_run_args<Kernel>::type;
+};
+
+}  // namespace detail
+
+/// @brief Tells what inputs a kernel takes
+///
+/// If there's a type `Kernel::Inputs`, then this type is returned.
+/// Otherwise, it's a tuple of all `InList` parameters from `Kernel::Run` signature.
+template <typename Kernel>
+using kernel_inputs = typename detail::KernelInputs<Kernel>::type;
+
+/// @brief Tells what outputs a kernel produces
+///
+/// If there's a type `Kernel::Outputs`, then this type is returned.
+/// Otherwise, it's a tuple of all `OutList` parameters from `Kernel::Run` signature.
+template <typename Kernel>
+using kernel_outputs = typename detail::KernelOutputs<Kernel>::type;
+
+/// @brief Tells what extra arguments a kernel takes
+///
+/// If there's a type `Kernel::Args`, then this type is returned.
+/// Otherwise returns all parameters to `Kernel::Run` that are neither
+/// `InList`, `OutList` or KernelContext.
+template <typename Kernel>
+using kernel_args = typename detail::KernelArgs<Kernel>::type;
+
+namespace detail {
+
+IMPL_HAS_UNIQUE_FUNCTION(Run)
+IMPL_HAS_UNIQUE_FUNCTION(GetRequirements)
+
+template <typename Kernel>
+std::is_same<void, decltype(apply_all(Kernel::Run,
+    std::declval<KernelContext&>(),
+    std::declval<kernel_outputs<Kernel>>(),
+    std::declval<kernel_inputs<Kernel>>(),
+    std::declval<kernel_args<Kernel>>() ))>
+  IsKernelRunnable(Kernel*);
+
+std::false_type IsKernelRunnable(...);
+
+template <typename Kernel>
+std::is_same<KernelRequirements, decltype(apply_all(Kernel::GetRequirements,
+    std::declval<KernelContext&>(),
+    std::declval<kernel_inputs<Kernel>>(),
+    std::declval<kernel_args<Kernel>>() ))>
+  CanGetRequirements(Kernel*);
+
+std::false_type CanGetRequirements(...);
+
+template <typename Kernel,
+    bool assert_,
+    bool is_runnable = decltype(IsKernelRunnable(static_cast<Kernel*>(nullptr)))::value,
+    bool can_get_requirements = decltype(CanGetRequirements(static_cast<Kernel*>(nullptr)))::value
+    >
+struct check_kernel_params : std::integral_constant<bool, is_runnable && can_get_requirements> {
+    static_assert(!assert_ || is_runnable,
+      "Kernel::Run method cannot be run with inferred arguments.\n"
+      "Check argument order (context, [outputs], [inputs], [arguments]).\n"
+      "Check return type = void");
+
+    static_assert(!assert_ || can_get_requirements,
+      "Kernel::GetRequirements method cannot be run with inferred arguments.\n"
+      "Check argument order (context, [inputs], [arguments]).\n"
+      "Check return type = KernelRequirements");
+};
+
+template <typename Kernel, bool assert_,
+    bool has_get_requirements = has_unique_function_GetRequirements<Kernel>::value>
+struct check_kernel_has_get_requirements : std::false_type {
+  static_assert(!assert_ || has_get_requirements,
+  "Kernel class must have a unique, static GetRequirements function");
+};
+
+template <typename Kernel, bool assert_>
+struct check_kernel_has_get_requirements<Kernel, assert_, true>
+ : check_kernel_params<Kernel, assert_> {};
+
+template <typename Kernel, bool assert_, bool has_run = has_unique_function_Run<Kernel>::value>
+struct check_kernel_has_run : std::false_type {
+  static_assert(!assert_ || has_run, "Kernel class must have a unique, static Run function");
+};
+
+template <typename Kernel, bool assert_>
+struct check_kernel_has_run<Kernel, assert_, true>
+ : check_kernel_has_get_requirements<Kernel, assert_> {};
+
+}  // namespace detail
+
+template <typename Kernel, bool assert_ = true>
+using check_kernel = detail::check_kernel_has_run<Kernel, assert_>;
+
+template <typename Kernel>
+using is_kernel = check_kernel<Kernel, false>;
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_KERNEL_TRAITS_H_

--- a/dali/kernels/kernel_traits.h
+++ b/dali/kernels/kernel_traits.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
 #ifndef DALI_KERNELS_KERNEL_TRAITS_H_
 #define DALI_KERNELS_KERNEL_TRAITS_H_
 
-#include <dali/kernels/kernel_params.h>
-#include <dali/kernels/util.h>
-#include <dali/kernels/tuple_helpers.h>
-#include <dali/kernels/kernel_req.h>
 #include <type_traits>
 #include <tuple>
+#include "dali/kernels/kernel_params.h"
+#include "dali/kernels/util.h"
+#include "dali/kernels/tuple_helpers.h"
+#include "dali/kernels/kernel_req.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/span.h
+++ b/dali/kernels/span.h
@@ -145,6 +145,14 @@ template <class ElementL, ptrdiff_t ExtentL, class ElementR, ptrdiff_t ExtentR>
   return !(l == r);
 }
 
+//@brief Helper function for pre-C++17
+template <ptrdiff_t Extent, typename T>
+constexpr span<T, Extent> make_span(T *data) { return { data }; }
+
+//@brief Helper function for pre-C++17
+template <ptrdiff_t Extent = dynamic_extent, typename T>
+constexpr span<T, Extent> make_span(T *data, ptrdiff_t extent) { return { data, extent }; }
+
 }  // namespace kernels
 }  // namespace dali
 

--- a/dali/kernels/span.h
+++ b/dali/kernels/span.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,11 +145,11 @@ template <class ElementL, ptrdiff_t ExtentL, class ElementR, ptrdiff_t ExtentR>
   return !(l == r);
 }
 
-//@brief Helper function for pre-C++17
+// @brief Helper function for pre-C++17
 template <ptrdiff_t Extent, typename T>
 constexpr span<T, Extent> make_span(T *data) { return { data }; }
 
-//@brief Helper function for pre-C++17
+// @brief Helper function for pre-C++17
 template <ptrdiff_t Extent = dynamic_extent, typename T>
 constexpr span<T, Extent> make_span(T *data, ptrdiff_t extent) { return { data, extent }; }
 

--- a/dali/kernels/static_switch.h
+++ b/dali/kernels/static_switch.h
@@ -1,0 +1,131 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_STATIC_SWITCH_H_
+#define DALI_KERNELS_STATIC_SWITCH_H_
+
+/** @file
+ *
+ * This file defines two compile-time "switches" that are suitable for
+ * specializing over different values or types.
+ *
+ * The #TYPE_SWITCH macro switches over types and provides a typedef
+ * with given name for that type in each case block.
+ *
+ * The #VALUE_SWITCH macro does the same with values and defines a costant
+ * with given name within each case block.
+ *
+ * The macros can be safely (?) nested within each other.
+ *
+ * Types and values containing commas should be enclosed in parenthesis.
+ *
+ * Code blocks (case, default) must be enclosed in parenthesis if they contain commas.
+ *
+ * Proposed usage in DALI pipeline:
+ * ```
+ * #define DALI_TYPE_SWITCH(id, type, types, ...) \
+ *    TYPE_SWITCH(id, type, types, DALITypeTag, (__VA_ARGS__), \
+ *                (DALI_FAIL("Type id does not match any of " #types);)
+ * ```
+ *
+ * DALITypeTag is a proposed name for mapping types to DALITypeId
+*/
+
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/preprocessor/variadic/to_seq.hpp>
+#include <boost/preprocessor/punctuation/remove_parens.hpp>
+
+// HC SVNT DRACONES
+
+#define DALI_REMOVE_PAREN_IMPL(...) __VA_ARGS__
+#define DALI_REMOVE_PAREN(args) DALI_REMOVE_PAREN_IMPL args
+
+#define DALI_TYPE_SWITCH_IMPL3(type_, type_tag_, type_name_, code_) \
+  case type_tag_<BOOST_PP_REMOVE_PARENS(type_)>::value: { \
+  using type_name_ = BOOST_PP_REMOVE_PARENS(type_); \
+    BOOST_PP_REMOVE_PARENS(code_); \
+  } break; \
+
+#define DALI_TYPE_SWITCH_IMPL2(...) DALI_TYPE_SWITCH_IMPL3(__VA_ARGS__)
+
+#define DALI_TYPE_SWITCH_IMPL(r, args, type) DALI_TYPE_SWITCH_IMPL2(type, DALI_REMOVE_PAREN(args))
+
+/// Pastes the case_ code specialized for each type in types_.
+/// The specialization is performed by aliasing a particular type with a typedef named type_name_.
+/// @param id_         - numerical id of the type
+/// @param type_tag_   - a class template usable as type_tag<type>::value
+///                      the value should be a type id for type
+/// @param type_name_  - a name given for selected type in the switch
+/// @param types_      - parenthesised, comma-separated list of types
+///                      types containing commas should be enclosed with parenthesis
+///                      e.g. (int, float, (std::conditional<val, bool, char>::type))
+/// @param case_       - code to execute for matching cases
+/// @param default_    - code to execute when id doesn't match any type in types
+///
+/// Usage:
+/// ```
+/// TYPE_SWITCH(input_type, TypeTag, IType, (int, float, (some_type<args>::type), int64_t), (
+///    TYPE_SWITCH(output_type, TypeTag, OType, (int, double, int64_t), (
+///        VALUE_SWITCH(channels, num_channels, (1, 2, 3, 4), (
+///            SomeFunctor<IType, OType, num_channels>(
+///            inputs[0].data<IType>(), outputs[0].mutable_data<OType>());
+///          ), assert(!"Unsupported number of channels");
+///        )
+///      ), assert(!"Unsupported output type");
+///    )
+///  ), assert(!"Unsupported input type");
+/// )
+/// ```
+#define TYPE_SWITCH(id_, type_tag_, type_name_, types, case_, default_) switch (id_) { \
+    BOOST_PP_SEQ_FOR_EACH(DALI_TYPE_SWITCH_IMPL, (type_tag_, type_name_, case_), \
+                          BOOST_PP_VARIADIC_TO_SEQ(DALI_REMOVE_PAREN(types))) \
+  default: \
+  { BOOST_PP_REMOVE_PARENS(default_); } \
+  }
+
+#define DALI_VALUE_SWITCH_IMPL3(value_, value_name_, code_) case value_: { \
+  const auto value_name_ = value_; \
+    BOOST_PP_REMOVE_PARENS(code_); \
+  } break; \
+
+#define DALI_VALUE_SWITCH_IMPL2(...) DALI_VALUE_SWITCH_IMPL3(__VA_ARGS__)
+
+#define DALI_VALUE_SWITCH_IMPL(r, args, value) \
+  DALI_VALUE_SWITCH_IMPL2(value, DALI_REMOVE_PAREN(args))
+
+/// Pastes the case_ code specialized for each value in values.
+/// The specialization is performed by aliasing a value with a constant named constant_name_
+/// @param value_         - a value to switch by
+/// @param constant_name_ - a name given for selected type in the switch
+/// @param values_        - parenthesised, comma-separated list of case labels;
+///                         expressions containing commas should be enclosed with parenthesis
+/// @param case_          - code to execute for matching cases
+/// @param default_       - code to execute when value doesn't match any in values
+///
+/// Usage:
+/// ```
+/// VALUE_SWITCH(channels, num_channels, (1, 2, 3, 4), (
+///     SomeFunctor<IType, OType, num_channels>(
+///     inputs[0].data<IType>(), outputs[0].mutable_data<OType>());
+///   ), assert(!"Unsupported number of channels");
+/// )
+/// ```
+#define VALUE_SWITCH(value_, value_name_, values, case_, default_) switch (value_) { \
+    BOOST_PP_SEQ_FOR_EACH(DALI_VALUE_SWITCH_IMPL, (value_name_, case_), \
+                          BOOST_PP_VARIADIC_TO_SEQ(DALI_REMOVE_PAREN(values))) \
+  default: \
+  { BOOST_PP_REMOVE_PARENS(default_); } \
+  }
+
+#endif  // DALI_KERNELS_STATIC_SWITCH_H_

--- a/dali/kernels/static_switch.h
+++ b/dali/kernels/static_switch.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/kernels/test/CMakeLists.txt
+++ b/dali/kernels/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dali/kernels/test/kernel_test.cc
+++ b/dali/kernels/test/kernel_test.cc
@@ -1,0 +1,126 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <dali/kernels/kernel.h>
+#include <dali/kernels/type_tag.h>
+#include <dali/kernels/static_switch.h>
+#include <dali/kernels/tuple_helpers.h>
+#include <gtest/gtest.h>
+#include <tuple>
+
+namespace dali {
+namespace kernels {
+
+template <typename Input1, typename Input2, typename OutputType>
+using ExampleKernel = examples::Kernel<Input1, Input2, OutputType>;
+
+// Neither function present
+struct Empty {
+};
+
+// Two run functions
+struct TwoRuns {
+  static KernelRequirements GetRequirements(KernelContext &conext, const InListCPU<float, 3>&);
+  void Run();
+  static void Run(KernelContext &conext, const OutListCPU<float, 3>&, const InListCPU<float, 3>&);
+};
+
+// No GetRequirements
+struct NoGetReq {
+  static void Run(KernelContext &conext, const OutListCPU<float, 3>&, const InListCPU<float, 3>&);
+};
+
+// GetRequirements returns wrong type
+struct GetReqBadType {
+  static int GetRequirements(KernelContext &conext, const InListCPU<float, 3>&);
+  static void Run(KernelContext &conext, const OutListCPU<float, 3>&, const InListCPU<float, 3>&);
+};
+
+// GetRequirements doesn't take KernelContext & as its first argument
+struct GetReqBadParamsType {
+  static int GetRequirements(const InListCPU<float, 3>&);
+  static void Run(KernelContext &conext, const OutListCPU<float, 3>&, const InListCPU<float, 3>&);
+};
+
+// Run doesn't take KernelContext & as its first argument
+struct RunBadParamsType {
+  static KernelRequirements GetRequirements(KernelContext &conext, const InListCPU<float, 3> &);
+  static void Run(const OutListCPU<float, 3> &, const InListCPU<float, 3> &);
+};
+
+TEST(KernelAPI, InferIOArgs) {
+  static_assert(std::is_same<
+    kernel_inputs<ExampleKernel<float, float, float>>,
+    std::tuple<const InListGPU<float, 3>&, const InListGPU<float, 4>&>
+  >::value, "Wrong set of inputs detected");
+
+  static_assert(std::is_same<
+    kernel_outputs<ExampleKernel<float, int, int>>,
+    std::tuple<const OutListGPU<int, 3>&>
+  >::value, "Wrong set of outputs detected");
+
+  static_assert(std::is_same<
+    kernel_args<ExampleKernel<float, int, float>>,
+    std::tuple<const InTensorCPU<float, 3>&>
+  >::value, "Wrong set of arguments detected");
+}
+
+TEST(KernelAPI, EnforceConcept) {
+  static_assert(detail::has_unique_function_Run<ExampleKernel<float, int, float>>::value,
+                "ExampleKernel has Run function");
+
+  static_assert(!detail::has_unique_function_Run<Empty>::value,
+                "Empty has no Run function");
+  static_assert(!detail::has_unique_function_Run<TwoRuns>::value,
+                "TwoRuns has two Run functions");
+
+  check_kernel<ExampleKernel<int, float, int>>();
+
+  static_assert(!is_kernel<Empty>::value, "Empty has no Run function and cannot be a kernel");
+  static_assert(!is_kernel<NoGetReq>::value,
+                "Empty has no GetRequirements function and cannot be a kernel");
+  static_assert(!is_kernel<TwoRuns>::value, "ToRuns has two Run functions");
+  static_assert(!is_kernel<RunBadParamsType>::value, "Run has bad parameters");
+}
+
+template <typename I1, typename I2, typename O>
+KernelRequirements dali::kernels::examples::Kernel<I1, I2, O>::GetRequirements(
+  KernelContext &context,
+  const InListGPU<I1, 3> &in1,
+  const InListGPU<I2, 4> &in2,
+  const InTensorCPU<float, 3> &aux) {
+  return {};
+}
+
+template <typename I1, typename I2, typename O>
+void dali::kernels::examples::Kernel<I1, I2, O>::Run(KernelContext &context,
+  const OutListGPU<O, 3> &out,
+  const InListGPU<I1, 3> &in1,
+  const InListGPU<I2, 4> &in2,
+  const InTensorCPU<float, 3> &aux) {}
+
+
+TEST(KernelAPI, CallWithTuples) {
+  InListGPU<float, 3> in1;
+  InListGPU<int, 4> in2;
+  OutListGPU<float, 3> out;
+  InTensorCPU<float, 3> aux;
+
+  examples::Kernel<float, int, float> K;
+  KernelContext context;
+  kernel::Run<decltype(K)>(context, std::tie(out), std::tie(in1, in2), std::tie(aux));
+}
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/test/kernel_test.cc
+++ b/dali/kernels/test/kernel_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <dali/kernels/kernel.h>
-#include <dali/kernels/type_tag.h>
-#include <dali/kernels/static_switch.h>
-#include <dali/kernels/tuple_helpers.h>
 #include <gtest/gtest.h>
 #include <tuple>
+#include "dali/kernels/kernel.h"
+#include "dali/kernels/type_tag.h"
+#include "dali/kernels/static_switch.h"
+#include "dali/kernels/tuple_helpers.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/test/scratch_test.cc
+++ b/dali/kernels/test/scratch_test.cc
@@ -1,0 +1,64 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <dali/kernels/kernel_req.h>
+#include <gtest/gtest.h>
+#include <vector>
+#include <array>
+#include <cassert>
+
+namespace dali {
+namespace kernels {
+
+static_assert(align_up(0, 2) == 0, "0 aligned up to 2 is 0");
+static_assert(align_up(1, 2) == 2, "1 aligned up to 2 is 2");
+static_assert(align_up(2, 2) == 2, "2 aligned up to 2 is 2");
+static_assert(align_up(0, 8) == 0, "0 aligned up to 8 is 0");
+static_assert(align_up(1, 8) == 8, "1 aligned up to 8 is 8");
+static_assert(align_up(2, 8) == 8, "2 aligned up to 8 is 8");
+static_assert(align_up(3, 8) == 8, "3 aligned up to 8 is 8");
+static_assert(align_up(4, 8) == 8, "4 aligned up to 8 is 8");
+static_assert(align_up(5, 8) == 8, "5 aligned up to 8 is 8");
+static_assert(align_up(6, 8) == 8, "6 aligned up to 8 is 8");
+static_assert(align_up(7, 8) == 8, "7 aligned up to 8 is 8");
+static_assert(align_up(8, 8) == 8, "8 aligned up to 8 is 8");
+static_assert(align_up(9, 8) == 16, "9 aligned up to 8 is 16");
+
+template <typename T>
+void test_add(ScratchpadEstimator &E, AllocType type, size_t count, size_t align = alignof(T)) {
+  size_t prev = E.sizes[(int)type];
+  EXPECT_EQ(align&(align-1), 0) << "Alignment must be a power of 2";
+  size_t base = align_up(prev, align);
+  E.add<T>(type, count, align);
+  EXPECT_EQ(E.sizes[(int)type], base + count*sizeof(T));
+}
+
+TEST(Scratch, Estimator)
+{
+  ScratchpadEstimator E;
+  test_add<float>(E, AllocType::Host, 9);
+  test_add<char>(E, AllocType::Host, 1);
+  test_add<char>(E, AllocType::Host, 1);
+  test_add<double>(E, AllocType::Host, 2);
+
+  test_add<char>(E, AllocType::GPU, 1);
+  test_add<float>(E, AllocType::GPU, 9);
+  test_add<char>(E, AllocType::GPU, 1);
+  test_add<double>(E, AllocType::GPU, 2);
+  EXPECT_EQ(E.sizes[(int)AllocType::Host], 56);
+  EXPECT_EQ(E.sizes[(int)AllocType::GPU], 64);
+}
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/test/scratch_test.cc
+++ b/dali/kernels/test/scratch_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <dali/kernels/kernel_req.h>
 #include <gtest/gtest.h>
 #include <vector>
 #include <array>
 #include <cassert>
+#include "dali/kernels/kernel_req.h"
 
 namespace dali {
 namespace kernels {
@@ -37,15 +37,14 @@ static_assert(align_up(9, 8) == 16, "9 aligned up to 8 is 16");
 
 template <typename T>
 void test_add(ScratchpadEstimator &E, AllocType type, size_t count, size_t align = alignof(T)) {
-  size_t prev = E.sizes[(int)type];
+  size_t prev = E.sizes[static_cast<int>(type)];
   EXPECT_EQ(align&(align-1), 0) << "Alignment must be a power of 2";
   size_t base = align_up(prev, align);
   E.add<T>(type, count, align);
-  EXPECT_EQ(E.sizes[(int)type], base + count*sizeof(T));
+  EXPECT_EQ(E.sizes[static_cast<int>(type)], base + count*sizeof(T));
 }
 
-TEST(Scratch, Estimator)
-{
+TEST(Scratch, Estimator) {
   ScratchpadEstimator E;
   test_add<float>(E, AllocType::Host, 9);
   test_add<char>(E, AllocType::Host, 1);
@@ -56,8 +55,8 @@ TEST(Scratch, Estimator)
   test_add<float>(E, AllocType::GPU, 9);
   test_add<char>(E, AllocType::GPU, 1);
   test_add<double>(E, AllocType::GPU, 2);
-  EXPECT_EQ(E.sizes[(int)AllocType::Host], 56);
-  EXPECT_EQ(E.sizes[(int)AllocType::GPU], 64);
+  EXPECT_EQ(E.sizes[static_cast<int>(AllocType::Host)], 56);
+  EXPECT_EQ(E.sizes[static_cast<int>(AllocType::GPU)], 64);
 }
 
 }  // namespace kernels

--- a/dali/kernels/test/static_switch_test.cc
+++ b/dali/kernels/test/static_switch_test.cc
@@ -1,0 +1,71 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <dali/kernels/kernel.h>
+#include <dali/kernels/static_switch.h>
+#include <dali/kernels/type_tag.h>
+#include <gtest/gtest.h>
+
+namespace {
+template <typename I, typename O, int C>
+struct Functor {
+  void operator()(int &calls, int i, int o, int c) {
+    EXPECT_EQ(i, dali::TypeTag<I>::value);
+    EXPECT_EQ(o, dali::TypeTag<O>::value);
+    EXPECT_EQ(c, C);
+    calls++;
+  }
+};
+
+template <typename T>
+struct StaticSwitch : testing::Test {};
+}  // namespace
+
+typedef testing::Types<int, float, double> MyTypes;
+TYPED_TEST_CASE(StaticSwitch, MyTypes);
+
+TYPED_TEST(StaticSwitch, TypeSwitch) {
+  using T = gtest_TypeParam_;
+  int tag = -1;
+  TYPE_SWITCH(dali::TypeTag<T>::value, dali::TypeTag, IType, (int, float, double),
+    (
+      tag = dali::TypeTag<IType>::value;
+      EXPECT_TRUE((std::is_same<IType, T>::value)) << "TypeSwitch type mismatch";
+    ),  // NOLINT
+    GTEST_FAIL() << "Invalid type";
+  );  // NOLINT
+
+  EXPECT_EQ(dali::TypeTag<T>::value, tag)
+    << "Tag mismatch - did type switch actually call anything?";
+}
+
+TEST(StaticSwitch, Nested) {
+  int input_type = dali::TypeTag<float>();
+  int output_type = dali::TypeTag<int64_t>();
+  int calls = 0;
+  for (int channels = 1; channels <= 4; channels++) {
+    TYPE_SWITCH(input_type, dali::TypeTag, IType, (int, float, double, int64_t), (
+        TYPE_SWITCH(output_type, dali::TypeTag, OType, (int, uint8_t, int64_t), (
+            VALUE_SWITCH(channels, num_channels, (1, 2, 3, 4),
+              (Functor<IType, OType, num_channels>()(calls, input_type, output_type, channels); ),
+              FAIL() << "Unsupported value";
+            )                                       // NOLINT
+          ), FAIL() << "Unsupported output type";   // NOLINT
+        )                                           // NOLINT
+      ), FAIL() << "Unsupported input type";        // NOLINT
+    )                                               // NOLINT
+  }
+  // check that the test functor was actually called
+  EXPECT_EQ(calls, 4) << "Test functor was expected to be called 4 times";
+}

--- a/dali/kernels/test/static_switch_test.cc
+++ b/dali/kernels/test/static_switch_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <dali/kernels/kernel.h>
-#include <dali/kernels/static_switch.h>
-#include <dali/kernels/type_tag.h>
 #include <gtest/gtest.h>
+#include "dali/kernels/kernel.h"
+#include "dali/kernels/static_switch.h"
+#include "dali/kernels/type_tag.h"
 
 namespace {
 template <typename I, typename O, int C>

--- a/dali/kernels/test/tuple_test.cc
+++ b/dali/kernels/test/tuple_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <dali/kernels/kernel.h>
-#include <dali/kernels/type_tag.h>
-#include <dali/kernels/static_switch.h>
 #include <gtest/gtest.h>
+#include "dali/kernels/kernel.h"
+#include "dali/kernels/type_tag.h"
+#include "dali/kernels/static_switch.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/test/tuple_test.cc
+++ b/dali/kernels/test/tuple_test.cc
@@ -1,0 +1,87 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <dali/kernels/kernel.h>
+#include <dali/kernels/type_tag.h>
+#include <dali/kernels/static_switch.h>
+#include <gtest/gtest.h>
+
+namespace dali {
+namespace kernels {
+
+namespace {
+const int A = 1;
+const float B = 1.5f;
+const char C = 'c';
+const double D = 1.0;
+const int E = 3;
+const float F = 5.5f;
+
+}  // namespace
+
+inline double fun(int &cnt, int a, float b, char c, double d, int e, float f) {
+  cnt++;
+  EXPECT_EQ(a, A);
+  EXPECT_EQ(b, B);
+  EXPECT_EQ(c, C);
+  EXPECT_EQ(d, D);
+  EXPECT_EQ(e, E);
+  EXPECT_EQ(f, F);
+  return a+b+c+d+e+f;
+}
+
+TEST(Tuple, Apply) {
+  int cnt = 0;
+  double sum = A+B+C+D+E+F;
+  EXPECT_EQ(apply(fun, std::tie(cnt, A, B, C, D, E, F)), sum);
+  EXPECT_EQ(cnt, 1);
+}
+
+
+TEST(Tuple, ApplyAll) {
+  int cnt = 0;
+  double sum = A+B+C+D+E+F;
+  EXPECT_EQ(apply_all(fun, std::tie(cnt, A, B, C, D, E, F)), sum);
+  EXPECT_EQ(apply_all(fun, cnt, A, B, C, D, E, F), sum);
+  EXPECT_EQ(apply_all(fun, std::tie(cnt, A, B), C, D, std::make_tuple(E, F)), sum);
+  EXPECT_EQ(apply_all(fun, cnt, A, std::make_tuple(B, C), D, std::make_tuple(E, F)), sum);
+  EXPECT_EQ(apply_all(fun, cnt, A, std::make_tuple(B, C), D, std::make_tuple(E), F), sum);
+  EXPECT_EQ(cnt, 5);
+}
+
+inline void fun_void(int &cnt, int a, float b, char c, double d, int e, float f) {
+  fun(cnt, a, b, c, d, e, f);
+}
+
+TEST(Tuple, ApplyAllVoidResult) {
+  int cnt = 0;
+  double sum = A+B+C+D+E+F;
+  apply_all(fun_void, std::tie(cnt, A, B, C, D, E, F));
+  EXPECT_EQ(cnt, 1);
+}
+
+constexpr int TheAnswer() { return 42; }
+
+TEST(Tuple, ApplyAllNoParams) {
+  EXPECT_EQ(apply_all(TheAnswer), 42);
+}
+
+template <typename T, typename U>
+constexpr auto Add(T a, U b)->decltype(a+b) { return a+b; }
+
+static_assert(apply_all(Add<int, char>, 1, 'a') == 'b', "Add(1, 'a') should yield 'b'");
+
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/tuple_helpers.h
+++ b/dali/kernels/tuple_helpers.h
@@ -1,0 +1,169 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_TUPLE_HELPERS_H_
+#define DALI_KERNELS_TUPLE_HELPERS_H_
+
+#include <tuple>
+#include <utility>
+
+namespace dali {
+namespace detail {
+
+template <typename... tuples>
+struct tuple_cat_helper;
+
+template <typename t0>
+struct tuple_cat_helper<t0> { using type = t0; };
+
+template <typename t0, typename... tuples>
+struct tuple_cat_helper<t0, tuples...>
+ : tuple_cat_helper<t0, typename tuple_cat_helper<tuples...>::type> {};
+
+template <typename... T1, typename... T2>
+struct tuple_cat_helper<std::tuple<T1...>, std::tuple<T2...>> {
+  using type = std::tuple<T1..., T2...>;
+};
+
+template <typename... tuples>
+using tuple_cat_t = typename tuple_cat_helper<tuples...>::type;
+
+/// @brief Compile-time integer sequence, see C++14 stl
+template <int... indices>
+struct seq {};
+
+template <typename sequence1, typename sequence2>
+struct seq_cat_impl;
+
+template <int... s1, int... s2>
+struct seq_cat_impl<seq<s1...>, seq<s2...>> {
+  using type = seq<s1..., s2...>;
+};
+
+/// @brief Concatenates sequence types
+template <typename sequence1, typename sequence2>
+using seq_cat_t = typename seq_cat_impl<sequence1, sequence2>::type;
+
+template <int offset, typename sequence>
+struct seq_offset_impl;
+
+template <int offset, int... s>
+struct seq_offset_impl<offset, seq<s...>> {
+  using type = seq<(offset+s)...>;
+};
+
+/// @brief Applies constant offset to all elements in the sequence
+template <int offset, typename sequence>
+using seq_offset_t = typename seq_offset_impl<offset, sequence>::type;
+
+template <int start, int count>
+struct build_seq_impl;
+
+/// @brief Builds an integer sequence (start, start+1, ..., start+count-1)
+template <int start, int count>
+using build_seq_t = typename build_seq_impl<start, count>::type;
+
+template <int start, int count>
+struct build_seq_impl {
+  // first, apply offset "start" and generate 0-based sequence (for efficiency)
+  using type = seq_offset_t<start, build_seq_t<0, count>>;
+};
+
+template <int count>
+struct build_seq_impl<0, count> {
+  // concatenate two sub-sequences; since we only generate 0-based sequences,
+  // it should run in relatively short time
+  using type = seq_cat_t<build_seq_t<0, count/2>, build_seq_t<count/2, count-count/2>>;
+};
+
+template <>
+struct build_seq_impl<0, 0> { using type = seq<>; };
+
+template <>
+struct build_seq_impl<0, 1> { using type = seq<0>; };
+
+// for compilation speed
+template <>
+struct build_seq_impl<0, 2> { using type = seq<0, 1>; };
+
+// for compilation speed
+template <>
+struct build_seq_impl<0, 3> { using type = seq<0, 1, 2>; };
+
+// for compilation speed
+template <>
+struct build_seq_impl<0, 4> { using type = seq<0, 1, 2, 3>; };
+
+// for compilation speed
+template <>
+struct build_seq_impl<0, 5> { using type = seq<0, 1, 2, 3, 4>; };
+
+template <typename Tuple>
+struct tuple_indices_helper;
+
+template <typename... T>
+struct tuple_indices_helper<std::tuple<T...>> {
+  using type = build_seq_t<0, sizeof...(T)>;
+};
+
+template <typename Tuple>
+using tuple_indices_t = typename tuple_indices_helper<Tuple>::type;
+
+template <typename... T>
+using pack_indices_t = build_seq_t<0, sizeof...(T)>;
+
+template <typename... T>
+constexpr pack_indices_t<T...> tuple_indices(const std::tuple<T...> &) { return {}; }
+
+template <typename T>
+constexpr std::tuple<T&&> as_tuple(T &&t) {
+  return std::tuple<T&&>(std::forward<T>(t));
+}
+
+template <typename... T>
+constexpr std::tuple<T...> &&as_tuple(std::tuple<T...> &&t) { return t; }
+
+template <typename... T>
+constexpr std::tuple<T...> &as_tuple(std::tuple<T...> &t) { return t; }
+
+template <typename... T>
+constexpr const std::tuple<T...> &as_tuple(const std::tuple<T...> &t) { return t; }
+
+template <typename F, typename... T, int... indices>
+constexpr auto apply_indexed(F &&f, const std::tuple<T...> &args, seq<indices...>)
+  ->decltype(f(std::get<indices>(args)...)) {
+  return f(std::get<indices>(args)...);
+}
+
+template <typename F, typename... T>
+constexpr auto apply(F &&f, std::tuple<T...> &&args)
+  ->decltype(apply_indexed(f, args, tuple_indices(args))) {
+  return apply_indexed(f, args, tuple_indices(args));
+}
+
+
+template <typename F, typename... Args>
+constexpr auto apply_all(F &&f, Args&&... args)
+  ->decltype(apply(f, std::tuple_cat(as_tuple(args)...))) {
+  return apply(f, std::tuple_cat(as_tuple(args)...));
+}
+
+}  // namespace detail
+
+using detail::apply;
+using detail::apply_all;
+
+}  // namespace dali
+
+#endif  // DALI_KERNELS_TUPLE_HELPERS_H_

--- a/dali/kernels/tuple_helpers.h
+++ b/dali/kernels/tuple_helpers.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/kernels/type_tag.h
+++ b/dali/kernels/type_tag.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_TYPE_TAG_H_
+#define DALI_KERNELS_TYPE_TAG_H_
+
+#include <type_traits>
+
+namespace dali {
+
+template <typename T,
+  bool integral = std::is_integral<T>::value,
+  bool fp = std::is_floating_point<T>::value>
+struct TypeTagBase;
+
+template <typename T>
+struct TypeTagBase<T, true, false>
+ : std::integral_constant<int, sizeof(T) | (std::is_unsigned<T>::value << 8) > {};
+
+template <typename T>
+struct TypeTagBase<T, false, true>
+ : std::integral_constant<int, sizeof(T) | (1<<10) > {};
+
+template <typename T>
+struct TypeTag : TypeTagBase<T> {};
+
+}  // namespace dali
+
+#endif  // DALI_KERNELS_TYPE_TAG_H_

--- a/dali/kernels/type_tag.h
+++ b/dali/kernels/type_tag.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/kernels/util.h
+++ b/dali/kernels/util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,7 +52,8 @@ template <typename DependentName, typename Result>
 using if_istype = typename std::conditional<false, DependentName, Result>::type;
 
 template <typename Collection, typename T>
-using if_iterable = if_istype<decltype(*std::end(std::declval<Collection>())), if_istype<decltype(*std::begin(std::declval<Collection>())), T>>;
+using if_iterable = if_istype<decltype(*std::end(std::declval<Collection>())),
+                              if_istype<decltype(*std::begin(std::declval<Collection>())), T>>;
 
 template <typename C>
 struct element_type {

--- a/dali/kernels/util.h
+++ b/dali/kernels/util.h
@@ -1,0 +1,101 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_UTIL_H_
+#define DALI_KERNELS_UTIL_H_
+
+#include <cstddef>
+#include <utility>
+
+namespace dali {
+
+using std::size_t;
+
+template <typename Target, typename Source>
+void append(Target &target, const Source &source) {
+  target.insert(std::end(target), std::begin(source), std::end(source));
+}
+
+template <typename Collection>
+auto size(const Collection &c)->decltype(c.size()) {
+  return c.size();
+}
+
+template <typename T, size_t N>
+size_t size(const T (&a)[N]) {
+  return N;
+}
+
+template <typename Value, typename Alignment>
+constexpr Value align_up(Value v, Alignment a) {
+  return v + ((a - 1) & -v);
+}
+
+static_assert(align_up(17, 16) == 32, "Should align up");
+static_assert(align_up(8, 8) == 8, "Should be already aligned");
+static_assert(align_up(5, 8) == 8, "Should align");
+
+constexpr ptrdiff_t dynamic_extent = -1;
+
+template <typename T, ptrdiff_t static_extent = dynamic_extent>
+struct span {
+  span() = default;
+  span(T *p, ptrdiff_t n = static_extent) : p(p) { assert(n == static_extent); }  // NOLINT
+
+  T * const p = nullptr;
+
+  constexpr T *data() const { return p; }
+  constexpr T &operator[](ptrdiff_t index) const { return p[index]; }
+  constexpr T *begin() const { return p; }
+  constexpr T *end() const { return p + size(); }
+  constexpr ptrdiff_t size() const { return static_extent; }
+};
+
+template <typename T>
+struct span<T, dynamic_extent> {
+  span() = default;
+  span(T *p, ptrdiff_t n) : p(p), n(n) {}
+
+  T *const p = nullptr;
+  const ptrdiff_t n = 0;
+
+  constexpr T *data() const { return p; }
+  constexpr T &operator[](ptrdiff_t index) const { return p[index]; }
+  constexpr T *begin() const { return p; }
+  constexpr T *end() const { return p + size(); }
+  constexpr ptrdiff_t size() const { return n; }
+};
+
+
+#define IMPL_HAS_NESTED_TYPE(type_name)\
+template <typename T>\
+std::true_type HasNested_##type_name(typename T::type_name *);\
+template <typename T>\
+std::false_type HasNested_##type_name(...);\
+template <typename T>\
+struct has_type_##type_name : decltype(HasNested_##type_name<T>(nullptr)) {}; \
+
+#define IMPL_HAS_UNIQUE_FUNCTION(function_name)\
+template <typename T>\
+std::is_function<decltype(T::function_name)> HasUniqueFunction_##function_name(T *);\
+template <typename T>\
+std::false_type HasUniqueFunction_##function_name(...);\
+template <typename T>\
+struct has_unique_function_##function_name : \
+  decltype(HasUniqueFunction_##function_name<T>(nullptr)) {}; \
+
+
+}  // namespace dali
+
+#endif  // DALI_KERNELS_UTIL_H_


### PR DESCRIPTION
The proposed kernel API is as follows:
The kernel developer provides a class with two static methods:
```
void Run(KernelContext &context, [Outputs], [Inputs], [ExtraArgs])
KernelRequirements GetRequirements(KernelContext &context, [Inputs], [ExtraArgs])
```
Outputs, Inputs and ExtraArgs are just ordinary lists of function parameters.
Outputs are TensorLists with non-const element type
Inputs are TensorLists with const element type.
Everything else is an considered an extra argument.

`GetRequirements` provides output shapes, as calculated based on input (shape) and extra arguments.
`Run` is meant to perform the actual work.
`KernelContext` will contain a cuda stream and possibly some information for sub-batch procesing, for cases when we want to execute GetRequirements for the whole batch, but execute in minibatches. This is still a matter to discuss.

Helper methods `kernel::Run` and `kernel::GetRequirements` operate on tuples of inputs, outputs and extra arguments. Also, these tuples can be extracted using type traits:
`kernel_inputs<KernelType>` - searches the Run function signature and extracts all inputs
`kernel_outputs<KernelType>` - same, but for outputs
`kernel_args<KernelType>` - likewise, for extra args

Instantiating `check_kernel<KernelType>` for given kernel will trigger a cascade of compile-time checks that verify that the type satisifies conditions to be considered a kernel - i.e. checks for existence of unique, static methods Run and GetRequirements and verify that parameters and their order is preserved. These checks provide meaningful diagnostics using `static_assert`s.

kernel::Run has an overload taking a vector of inputs and a vector of outputs and is meant to implement the functionality of processing multiple input sets. The default implementations simply executes the kernel for each respective pair of inputs and outputs.

Finally (?)
`TYPE_SWITCH` and `VALUE_SWITCH` mechanisms provide dynamic-to-static type and value routing in a way similar to `DALI_TYPE_SWITCH`, but have capability to handle different set of types/values at each invocation. The `case` code for these switches provides either a typedef (TYPE_SWITCH) or a const auto (for VALUE_SWITCH), which can be used e.g. for template instantiation. Actual type-to-id mapping trait is configurable, as is handling of default case (to decouple the library code from DALI_ENFORCE, which is quite involved).
