### PR TITLE
 Add Step and multiple containers support in VideoReader

### DIFF
--- a/dali/error_handling.h
+++ b/dali/error_handling.h
@@ -299,7 +299,6 @@ inline void cudaResultCheck<CUresult>(CUresult status) {
   } while (0)
 
 #define LOG_LINE \
-  if (0) \
   std::cout << __FILE__ << ":" << __LINE__ << ": "
 
 }  // namespace dali

--- a/dali/error_handling.h
+++ b/dali/error_handling.h
@@ -299,6 +299,7 @@ inline void cudaResultCheck<CUresult>(CUresult status) {
   } while (0)
 
 #define LOG_LINE \
+  if (0) \
   std::cout << __FILE__ << ":" << __LINE__ << ": "
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -127,8 +127,8 @@ OpenFile& VideoLoader::get_or_open_file(std::string filename) {
     file.frame_base_ = AVRational{stream->avg_frame_rate.den,
                                   stream->avg_frame_rate.num};
     file.frame_count_ = av_rescale_q(stream->duration,
-                                      stream->time_base,
-                                      file.frame_base_);
+                                     stream->time_base,
+                                     file.frame_base_);
 
     if (codec_id == AV_CODEC_ID_H264 || codec_id == AV_CODEC_ID_HEVC) {
       const char* filtername = nullptr;
@@ -441,7 +441,8 @@ void VideoLoader::PrepareEmpty(SequenceWrapper *tensor) {
 
 void VideoLoader::ReadSample(SequenceWrapper* tensor) {
     // TODO(spanev) remove the async between the 2 following methods?
-    push_sequence_to_read(filenames_[0], frame_starts_[current_frame_idx_], count_);
+    auto& fileidx_frame = frame_starts_[current_frame_idx_];
+    push_sequence_to_read(filenames_[fileidx_frame.first], fileidx_frame.second, count_);
     receive_frames(*tensor);
     tensor->wait();
     if (++current_frame_idx_ >= frame_starts_.size()) {

--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -445,7 +445,7 @@ void VideoLoader::ReadSample(SequenceWrapper* tensor) {
     push_sequence_to_read(filenames_[fileidx_frame.first], fileidx_frame.second, count_);
     receive_frames(*tensor);
     tensor->wait();
-    if (++current_frame_idx_ >= frame_starts_.size()) {
+    if (++current_frame_idx_ >= static_cast<Index>(frame_starts_.size())) {
       current_frame_idx_ = 0;
     }
 }

--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -451,7 +451,7 @@ void VideoLoader::ReadSample(SequenceWrapper* tensor) {
 }
 
 Index VideoLoader::Size() {
-    return static_cast<Index>(total_frame_count_);
+    return static_cast<Index>(frame_starts_.size());
 }
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -103,7 +103,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   explicit inline VideoLoader(const OpSpec& spec,
     const std::vector<std::string>& filenames)
     : Loader<GPUBackend, SequenceWrapper>(spec),
-      count_(spec.GetArgument<int>("count")),
+      count_(spec.GetArgument<int>("sequence_length")),
       step_(spec.GetArgument<int>("step")),
       height_(0),
       width_(0),
@@ -112,7 +112,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       filenames_(filenames),
       codec_id_(0),
       done_(false) {
-      if (step_ == -1)
+      if (step_ < 0)
         step_ = count_;
   }
 
@@ -132,7 +132,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
     for (size_t i = 0; i < filenames_.size(); ++i) {
       int frame_count = get_or_open_file(filenames_[i]).frame_count_;
       for (int s = 0; s < frame_count; s += step_) {
-        frame_starts_.push_back(std::make_pair(i, s));
+        frame_starts_.emplace_back(i, s);
       }
     }
 

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -144,7 +144,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       std::shuffle(std::begin(frame_starts_), std::end(frame_starts_), g);
     }
 
-    current_frame_idx_ = 0;
+    current_frame_idx_ = start_index(shard_id_, num_shards_, Size());
 
     thread_file_reader_ = std::thread{&VideoLoader::read_file, this};
   }
@@ -201,7 +201,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
 
   // pair -> (filename index, frame index)
   std::vector<std::pair<int,int>> frame_starts_;
-  unsigned current_frame_idx_;
+  Index current_frame_idx_;
 
   volatile bool done_;
 };

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -129,14 +129,11 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
 
     av_register_all();
 
-    total_frame_count_ = 0;
-
     for (size_t i = 0; i < filenames_.size(); ++i) {
       int frame_count = get_or_open_file(filenames_[i]).frame_count_;
       for (int s = 0; s < frame_count; s += step_) {
         frame_starts_.push_back(std::make_pair(i, s));
       }
-      total_frame_count_ += frame_count;
     }
 
     if (shuffle_) {
@@ -202,7 +199,6 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
 
   std::thread thread_file_reader_;
 
-  int total_frame_count_;
   // pair -> (filename index, frame index)
   std::vector<std::pair<int,int>> frame_starts_;
   unsigned current_frame_idx_;

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -200,7 +200,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   std::thread thread_file_reader_;
 
   // pair -> (filename index, frame index)
-  std::vector<std::pair<int,int>> frame_starts_;
+  std::vector<std::pair<int, int>> frame_starts_;
   Index current_frame_idx_;
 
   volatile bool done_;

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -131,7 +131,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
 
     for (size_t i = 0; i < filenames_.size(); ++i) {
       int frame_count = get_or_open_file(filenames_[i]).frame_count_;
-      for (int s = 0; s < frame_count; s += step_) {
+      for (int s = 0; s < frame_count && s + count_ <= frame_count; s += step_) {
         frame_starts_.emplace_back(i, s);
       }
     }

--- a/dali/pipeline/operators/reader/video_reader_op.cc
+++ b/dali/pipeline/operators/reader/video_reader_op.cc
@@ -37,8 +37,11 @@ number of frames).)code")
       R"code(File names of the video files to load.)code",
       DALI_STRING_VEC)
   .AddArg("count",
-      R"code(Frames to load per batch.)code",
+      R"code(Frames to load per sequence.)code",
       DALI_INT32)
+  .AddOptionalArg("step",
+      R"code(Frame interval between each sequence.)code",
+      -1)
   .AddOptionalArg("scale",
       R"code(Rescaling factor of height and width.)code",
       1.f)

--- a/dali/pipeline/operators/reader/video_reader_op.cc
+++ b/dali/pipeline/operators/reader/video_reader_op.cc
@@ -29,18 +29,18 @@ DALI_SCHEMA(VideoReader)
   .DocStr(R"code(
 Load and decode H264 video codec with FFmpeg and NVDECODE, NVIDIA GPU's hardware-accelerated video decoding.
 The video codecs can be contained in most of container file formats. FFmpeg is used to parse video containers.
-Returns a batch of sequences of `count` frames of shape [N, S, H, W, C] (N being the batch size and S the
+Returns a batch of sequences of `sequence_length` frames of shape [N, F, H, W, C] (N being the batch size and F the
 number of frames).)code")
   .NumInput(0)
   .NumOutput(1)
   .AddArg("filenames",
       R"code(File names of the video files to load.)code",
       DALI_STRING_VEC)
-  .AddArg("count",
+  .AddArg("sequence_length",
       R"code(Frames to load per sequence.)code",
       DALI_INT32)
   .AddOptionalArg("step",
-      R"code(Frame interval between each sequence.)code",
+      R"code(Frame interval between each sequence (if `step` < 0, `step` is set to `sequence_length`).)code",
       -1)
   .AddOptionalArg("scale",
       R"code(Rescaling factor of height and width.)code",

--- a/dali/pipeline/operators/reader/video_reader_op.h
+++ b/dali/pipeline/operators/reader/video_reader_op.h
@@ -28,7 +28,7 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
   explicit VideoReader(const OpSpec &spec)
   : DataReader<GPUBackend, SequenceWrapper>(spec),
     filenames_(spec.GetRepeatedArgument<std::string>("filenames")),
-    count_(spec.GetArgument<int>("count")),
+    count_(spec.GetArgument<int>("sequence_length")),
     channels_(spec.GetArgument<int>("channels")),
     output_scale_(spec.GetArgument<float>("scale")) {
     DALIImageType image_type(spec.GetArgument<DALIImageType>("image_type"));

--- a/docs/examples/video/video_example.py
+++ b/docs/examples/video/video_example.py
@@ -41,7 +41,7 @@ ITER=100
 class VideoPipe(Pipeline):
     def __init__(self, batch_size, num_threads, device_id, data):
         super(VideoPipe, self).__init__(batch_size, num_threads, device_id, seed=12)
-        self.input = ops.VideoReader(device="gpu", filenames=data, sequence_lengtht=COUNT,
+        self.input = ops.VideoReader(device="gpu", filenames=data, sequence_length=COUNT,
                                      shard_id=0, num_shards=1, random_shuffle=False,
                                      normalized=True, image_type=types.YCbCr)
 

--- a/docs/examples/video/video_example.py
+++ b/docs/examples/video/video_example.py
@@ -41,10 +41,9 @@ ITER=100
 class VideoPipe(Pipeline):
     def __init__(self, batch_size, num_threads, device_id, data):
         super(VideoPipe, self).__init__(batch_size, num_threads, device_id, seed=12)
-        self.input = ops.VideoReader(device="gpu", filenames=data, count=COUNT,
+        self.input = ops.VideoReader(device="gpu", filenames=data, sequence_lengtht=COUNT,
                                      shard_id=0, num_shards=1, random_shuffle=False,
                                      normalized=True, image_type=types.YCbCr)
-
 
     def define_graph(self):
         output = self.input(name="Reader")

--- a/docs/examples/video/video_example.py
+++ b/docs/examples/video/video_example.py
@@ -1,6 +1,8 @@
 #!/bin/env python
 
+import os
 import numpy as np
+
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
@@ -20,9 +22,6 @@ except ImportError:
 BATCH_SIZE=4
 COUNT=5
 
-VIDEO_FILES=["prepared.mp4"]
-ITER=8
-
 def YUV2RGB(yuv):
     yuv = np.multiply(yuv, 255)
     m = np.array([[ 1.0, 1.0, 1.0],
@@ -33,6 +32,11 @@ def YUV2RGB(yuv):
     rgb[:,:,1]+=135.45870971679688
     rgb[:,:,2]-=226.8183044444304
     return rgb
+
+VIDEO_FILES=os.listdir("videos")
+VIDEO_FILES = ['videos/' + f for f in VIDEO_FILES]
+
+ITER=100
 
 class VideoPipe(Pipeline):
     def __init__(self, batch_size, num_threads, device_id, data):
@@ -71,3 +75,4 @@ if __name__ == "__main__":
         plt.imshow(frame_to_show.astype('uint8'), interpolation='bicubic')
         plt.show()
         plt.savefig('saved_frame.png')
+

--- a/qa/L0_videoreader_test/test.sh
+++ b/qa/L0_videoreader_test/test.sh
@@ -2,12 +2,25 @@
 
 pip_packages="numpy"
 
+apt-get install ffmpeg
+
 pushd ../..
 
 cd docs/examples/video
 
+mkdir -p videos
+
+container_name=prepared.mp4
+
 # Download video sample
-wget -q -O prepared.mp4 https://download.blender.org/durian/trailer/sintel_trailer-720p.mp4
+wget -q -O ${container_name} https://download.blender.org/durian/trailer/sintel_trailer-720p.mp4
+
+IFS='.' read -a splitted <<< "$container_name"
+
+for i in {0..4};
+do
+    ffmpeg -ss 00:00:${i}0 -t 00:00:10 -i $container_name -vcodec copy -acodec copy videos/${splitted[0]}_$i.${splitted[1]}
+done
 
 test_body() {
     # test code

--- a/qa/L0_videoreader_test/test.sh
+++ b/qa/L0_videoreader_test/test.sh
@@ -2,7 +2,8 @@
 
 pip_packages="numpy"
 
-apt-get install ffmpeg
+apt-get update
+apt-get install -y ffmpeg
 
 pushd ../..
 
@@ -24,7 +25,6 @@ done
 
 test_body() {
     # test code
-    ls
     python video_example.py
 }
 


### PR DESCRIPTION
VideoReader now supports:
- Multiple video container files as input
- `step` argument: frames interval between the sequences
- Global shuffling: each sample is drawn from a random file and random position in the file
- Rename `count` as `sequence_length`