### PR TITLE
Add support for step, stride & shuffling in SequenceReader

### DIFF
--- a/dali/image/image.cc
+++ b/dali/image/image.cc
@@ -16,6 +16,16 @@
 
 namespace dali {
 
+bool HasKnownImageExtension(std::string image_path) {
+  std::transform(image_path.begin(), image_path.end(), image_path.begin(), ::tolower);
+  for (const auto &ext : kKnownImageExtensions) {
+    size_t pos = image_path.rfind(ext);
+    if (pos != std::string::npos && pos + strlen(ext) == image_path.size()) {
+      return true;
+    }
+  }
+  return false;
+}
 
 Image::Image(const uint8_t *encoded_buffer, size_t length, DALIImageType image_type) :
         encoded_image_(encoded_buffer),

--- a/dali/image/image.cc
+++ b/dali/image/image.cc
@@ -12,18 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <iostream>
+#include <sstream>
+
 #include "dali/image/image.h"
 
 namespace dali {
 
+std::string ListSupportedExtensions() {
+  std::stringstream ss;
+  size_t known_extensions_count = sizeof(kKnownImageExtensions) / sizeof(*kKnownImageExtensions);
+  for (size_t i = 0; i < known_extensions_count; i++) {
+    ss << kKnownImageExtensions[i];
+    if (i != known_extensions_count - 1) {
+      ss << ", ";
+    }
+  }
+  return ss.str();
+}
+
 bool HasKnownImageExtension(std::string image_path) {
-  std::transform(image_path.begin(), image_path.end(), image_path.begin(), ::tolower);
+  std::string path_low{image_path};
+  std::transform(path_low.begin(), path_low.end(), path_low.begin(), ::tolower);
   for (const auto &ext : kKnownImageExtensions) {
-    size_t pos = image_path.rfind(ext);
-    if (pos != std::string::npos && pos + strlen(ext) == image_path.size()) {
+    size_t pos = path_low.rfind(ext);
+    if (pos != std::string::npos && pos + strlen(ext) == path_low.size()) {
       return true;
     }
   }
+  std::cerr << "[Warning]: File " + image_path +
+                   " has extension that is not supproted by the decoder. " +
+                   "Supported extensions: " + ListSupportedExtensions() + "."
+            << std::endl;
   return false;
 }
 

--- a/dali/image/image.h
+++ b/dali/image/image.h
@@ -15,7 +15,9 @@
 #ifndef DALI_IMAGE_IMAGE_H_
 #define DALI_IMAGE_IMAGE_H_
 
+#include <algorithm>
 #include <array>
+#include <cstring>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -28,8 +30,10 @@
 
 namespace dali {
 
-static const std::array<string, 7> RegisteredImageExtensions = {".jpg", ".jpeg", ".png", ".gif",
-                                                                ".bmp", ".tif",  ".tiff"};
+static const char *kKnownImageExtensions[] = {".jpg", ".jpeg", ".png", ".gif",
+                                              ".bmp", ".tif",  ".tiff"};
+
+DLL_PUBLIC bool HasKnownImageExtension(std::string image_path);
 
 class Image {
  public:

--- a/dali/image/image.h
+++ b/dali/image/image.h
@@ -15,9 +15,12 @@
 #ifndef DALI_IMAGE_IMAGE_H_
 #define DALI_IMAGE_IMAGE_H_
 
+#include <array>
 #include <memory>
+#include <string>
 #include <tuple>
 #include <utility>
+
 #include "dali/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/operator.h"
@@ -25,6 +28,8 @@
 
 namespace dali {
 
+static const std::array<string, 7> RegisteredImageExtensions = {".jpg", ".jpeg", ".png", ".gif",
+                                                                ".bmp", ".tif",  ".tiff"};
 
 class Image {
  public:

--- a/dali/pipeline/operators/reader/loader/file_loader.cc
+++ b/dali/pipeline/operators/reader/loader/file_loader.cc
@@ -17,6 +17,7 @@
 #include <memory>
 
 #include "dali/common.h"
+#include "dali/image/image.h"
 #include "dali/pipeline/operators/reader/loader/file_loader.h"
 #include "dali/util/file.h"
 
@@ -28,8 +29,6 @@ inline void assemble_file_list(const std::string& path, const std::string& curr_
   DIR *dir = opendir(curr_dir_path.c_str());
 
   struct dirent *entry;
-
-  const std::vector<std::string> valid_extensions({".jpg", ".jpeg", ".png", ".bmp"});
 
   while ((entry = readdir(dir))) {
     std::string full_path = curr_dir_path + "/" + std::string{entry->d_name};
@@ -44,15 +43,8 @@ inline void assemble_file_list(const std::string& path, const std::string& curr_
     }
 #endif
     std::string rel_path = curr_entry + "/" + std::string{entry->d_name};
-    std::string file_name_lowercase = std::string{entry->d_name};
-    std::transform(file_name_lowercase.begin(), file_name_lowercase.end(),
-                   file_name_lowercase.begin(), ::tolower);
-    for (const std::string& s : valid_extensions) {
-      size_t pos = file_name_lowercase.rfind(s);
-      if (pos != std::string::npos && pos + s.size() == file_name_lowercase.size()) {
-        file_label_pairs->push_back(std::make_pair(rel_path, label));
-        break;
-      }
+    if (HasKnownImageExtension(std::string(entry->d_name))) {
+      file_label_pairs->push_back(std::make_pair(rel_path, label));
     }
   }
   closedir(dir);

--- a/dali/pipeline/operators/reader/loader/sequence_loader.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.cc
@@ -76,7 +76,7 @@ std::vector<std::vector<std::string>> GenerateSequences(
     size_t stride) {
   std::vector<std::vector<std::string>> sequences;
   for (const auto &s : streams) {
-    for (int i = 0; i < s.second.size(); i += step) {
+    for (size_t i = 0; i < s.second.size(); i += step) {
       std::vector<std::string> sequence;
       sequence.reserve(sequence_length);
       // this sequence won't fit
@@ -84,7 +84,7 @@ std::vector<std::vector<std::string>> GenerateSequences(
         break;
       }
       // fill the sequence
-      for (int seq_elem = 0; seq_elem < sequence_length; seq_elem++) {
+      for (size_t seq_elem = 0; seq_elem < sequence_length; seq_elem++) {
         sequence.push_back(s.second[i + seq_elem * stride]);
       }
       sequences.push_back((sequence));

--- a/dali/pipeline/operators/reader/loader/sequence_loader.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.cc
@@ -124,6 +124,7 @@ Index SequenceLoader::Size() {
 void SequenceLoader::LoadFrame(const std::vector<std::string> &s, Index frame_idx,
                                Tensor<CPUBackend> *target) {
   const auto frame_filename = s[frame_idx];
+  target->SetSourceInfo(frame_filename);
   auto frame = FileStream::Open(frame_filename);
   Index frame_size = frame->Size();
   target->Resize({frame_size});

--- a/dali/pipeline/operators/reader/loader/sequence_loader.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.cc
@@ -46,15 +46,8 @@ std::vector<Stream> GatherExtractedStreams(string file_root) {
   std::vector<std::string> files;
   for (size_t i = 0; i < glob_buff.gl_pathc; i++) {
     std::string file = glob_buff.gl_pathv[i];
-    std::string file_name_lowercase = std::string{file};
-    std::transform(file_name_lowercase.begin(), file_name_lowercase.end(),
-                   file_name_lowercase.begin(), ::tolower);
-    for (const std::string &ext : RegisteredImageExtensions) {
-      size_t pos = file_name_lowercase.rfind(ext);
-      if (pos != std::string::npos && pos + ext.size() == file_name_lowercase.size()) {
-        files.push_back(std::move(file));
-        break;
-      }
+    if (HasKnownImageExtension(file)) {
+      files.push_back(std::move(file));
     }
   }
   globfree(&glob_buff);
@@ -79,19 +72,19 @@ std::vector<Stream> GatherExtractedStreams(string file_root) {
 namespace detail {
 
 std::vector<std::vector<std::string>> GenerateSequences(
-    const std::vector<filesystem::Stream> &streams, size_t sequence_lenght, size_t step,
+    const std::vector<filesystem::Stream> &streams, size_t sequence_length, size_t step,
     size_t stride) {
   std::vector<std::vector<std::string>> sequences;
   for (const auto &s : streams) {
     for (int i = 0; i < s.second.size(); i += step) {
       std::vector<std::string> sequence;
-      sequence.reserve(sequence_lenght);
+      sequence.reserve(sequence_length);
       // this sequence won't fit
-      if (i + (sequence_lenght - 1) * stride >= s.second.size()) {
+      if (i + (sequence_length - 1) * stride >= s.second.size()) {
         break;
       }
       // fill the sequence
-      for (int seq_elem = 0; seq_elem < sequence_lenght; seq_elem++) {
+      for (int seq_elem = 0; seq_elem < sequence_length; seq_elem++) {
         sequence.push_back(s.second[i + seq_elem * stride]);
       }
       sequences.push_back((sequence));

--- a/dali/pipeline/operators/reader/loader/sequence_loader.h
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.h
@@ -25,6 +25,55 @@
 
 namespace dali {
 
+namespace filesystem {
+using Stream = std::pair<std::string, std::vector<std::string>>;
+
+/**
+ * @brief Gather info about extracted streams
+ *
+ * Expects file_root to contain set of directories, each of them represents one extracted video
+ * stream. Extracted video stream is represented by one file for each frame, sorting the paths to
+ * frames lexicographically should give the original order of frames.
+ *
+ * Example:
+ * > file_root
+ *   > 0
+ *     > 00001.png
+ *     > 00002.png
+ *     > 00003.png
+ *     > 00004.png
+ *     > 00005.png
+ *     > 00006.png
+ *     ....
+ *   > 1
+ *     > 00001.png
+ *     > 00002.png
+ *     > 00003.png
+ *     > 00004.png
+ *     > 00005.png
+ *     > 00006.png
+ *     ....
+ *
+ * @param file_root
+ * @return std::vector<Stream> GatherExtractedStreams
+ */
+std::vector<Stream> DLL_PUBLIC GatherExtractedStreams(string file_root);
+
+}  // namespace filesystem
+
+namespace detail {
+/**
+ * @brief Calculate how many full sequences of sequence_lenght fit in each stream.
+ *
+ * For stream [0, 1, 2, 3, 4, 5], and sequence_lenght = 3 we will consider:
+ * [0, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5] -> 4 full sequences
+ *
+ * Behaviour for sequence of length 0 is undefined
+ */
+std::vector<size_t> DLL_PUBLIC
+CalculateSequencesCounts(const std::vector<filesystem::Stream> &streams, size_t sequence_lenght);
+}  // namespace detail
+
 struct TensorSequence {
   std::vector<Tensor<CPUBackend>> tensors;
 };
@@ -42,9 +91,9 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
         file_root_(spec.GetArgument<string>("file_root")),
         sequence_length_(
             spec.GetArgument<int32_t>("sequence_length")),  // TODO(klecki) change to size_t
-        streams_(ParseStreams(file_root_)),
-        stream_sizes_(CalculateStreamSizes(streams_, sequence_length_)),
-        total_size_(std::accumulate(stream_sizes_.begin(), stream_sizes_.end(), Index{})),
+        streams_(filesystem::GatherExtractedStreams(file_root_)),
+        sequences_counts_(detail::CalculateSequencesCounts(streams_, sequence_length_)),
+        total_size_(std::accumulate(sequences_counts_.begin(), sequences_counts_.end(), Index{})),
         current_stream_(0),
         current_frame_(0) {}
 
@@ -55,20 +104,15 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
  private:
   // TODO(klecki) For now sequence is <directory, image list> pair, later it
   // will be a video file
-  using Stream = std::pair<std::string, std::vector<std::string>>;
 
   string file_root_;
   int32_t sequence_length_;
-  std::vector<Stream> streams_;
-  std::vector<size_t> stream_sizes_;
+  std::vector<filesystem::Stream> streams_;
+  std::vector<size_t> sequences_counts_;
   Index total_size_;
   size_t current_stream_, current_frame_;
 
-  std::vector<Stream> ParseStreams(string file_root);
-  std::vector<size_t> CalculateStreamSizes(const std::vector<Stream> &streams,
-                                           size_t sample_lenght);
-
-  void LoadFrame(const Stream &s, Index frame, Tensor<CPUBackend> *target);
+  void LoadFrame(const filesystem::Stream &s, Index frame, Tensor<CPUBackend> *target);
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/loader/sequence_loader.h
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.h
@@ -68,7 +68,7 @@ namespace detail {
  * Only consider full sequences that do not cross stream boundary
  */
 std::vector<std::vector<std::string>> DLL_PUBLIC
-GenerateSequences(const std::vector<filesystem::Stream> &streams, size_t sequence_lenght,
+GenerateSequences(const std::vector<filesystem::Stream> &streams, size_t sequence_length,
                   size_t step, size_t stride);
 }  // namespace detail
 
@@ -87,14 +87,16 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
   explicit SequenceLoader(const OpSpec &spec)
       : Loader(spec),
         file_root_(spec.GetArgument<string>("file_root")),
-        sequence_length_(
-            spec.GetArgument<int32_t>("sequence_length")),  // TODO(klecki) change to size_t
+        sequence_length_(spec.GetArgument<int32_t>("sequence_length")),
         step_(spec.GetArgument<int32_t>("step")),
         stride_(spec.GetArgument<int32_t>("stride")),
         streams_(filesystem::GatherExtractedStreams(file_root_)),
         sequences_(detail::GenerateSequences(streams_, sequence_length_, step_, stride_)),
         total_size_(sequences_.size()),
         current_sequence_(0) {
+    DALI_ENFORCE(sequence_length_ > 0, "Sequence length must be positive");
+    DALI_ENFORCE(step_ > 0, "Step must be positive");
+    DALI_ENFORCE(stride_ > 0, "Stride must be positive");
     if (shuffle_) {
       // seeded with hardcoded value to get
       // the same sequence on every shard

--- a/dali/pipeline/operators/reader/loader/sequence_loader.h
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.h
@@ -120,7 +120,7 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
   std::vector<filesystem::Stream> streams_;
   std::vector<std::vector<std::string>> sequences_;
   Index total_size_;
-  size_t current_sequence_;
+  Index current_sequence_;
 
   void LoadFrame(const std::vector<std::string> &s, Index frame, Tensor<CPUBackend> *target);
 };

--- a/dali/pipeline/operators/reader/loader/sequence_loader_test.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader_test.cc
@@ -1,0 +1,85 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "dali/pipeline/operators/reader/loader/sequence_loader.h"
+#include "dali/test/dali_test.h"
+
+namespace dali {
+
+namespace {
+
+std::string print_frame_num(int i) {
+  std::stringstream ss;
+  ss << std::setfill('0') << std::setw(5) << i;
+  return ss.str();
+}
+
+}  // namespace
+
+TEST(GatherExtractedStreamsTest, LoadTestDir) {
+  const auto frames_dir = image_folder + "/frames";
+  auto result = filesystem::GatherExtractedStreams(frames_dir);
+  ASSERT_EQ(result.size(), 2);
+  const auto first_stream = frames_dir + "/0/";
+  ASSERT_EQ(result[0].first, first_stream);
+  ASSERT_EQ(result[0].second.size(), 16);
+  for (int i = 0; i < 16; i++) {
+    ASSERT_EQ(result[0].second[i], first_stream + print_frame_num(i + 1) + ".png");
+  }
+
+  const auto second_stream = frames_dir + "/1/";
+  ASSERT_EQ(result[1].first, second_stream);
+  ASSERT_EQ(result[1].second.size(), 16);
+  for (int i = 0; i < 16; i++) {
+    ASSERT_EQ(result[1].second[i], second_stream + print_frame_num(i + 1) + ".png");
+  }
+}
+
+TEST(CalculateSequencesCountsTest, Test) {
+  std::vector<filesystem::Stream> zero_stream = {{"/0", {}}};
+  auto zero_length_1 = detail::CalculateSequencesCounts(zero_stream, 1);
+  ASSERT_EQ(zero_length_1[0], 0);
+  auto zero_length_2 = detail::CalculateSequencesCounts(zero_stream, 2);
+  ASSERT_EQ(zero_length_2[0], 0);
+
+
+  std::vector<filesystem::Stream> test_streams = {
+      {"/0", {"/0/00.png", "/0/01.png", "/0/02.png", "/0/03.png", "/0/04.png", "/0/05.png"}},
+      {"/1", {"/1/00.png", "/1/01.png", "/1/02.png", "/1/03.png"}}};
+  auto length_1 = detail::CalculateSequencesCounts(test_streams, 1);
+  ASSERT_EQ(length_1[0], 6);
+  ASSERT_EQ(length_1[1], 4);
+  auto length_2 = detail::CalculateSequencesCounts(test_streams, 2);
+  ASSERT_EQ(length_2[0], 5);
+  ASSERT_EQ(length_2[1], 3);
+  auto length_3 = detail::CalculateSequencesCounts(test_streams, 3);
+  ASSERT_EQ(length_3[0], 4);
+  ASSERT_EQ(length_3[1], 2);
+  auto length_4 = detail::CalculateSequencesCounts(test_streams, 4);
+  ASSERT_EQ(length_4[0], 3);
+  ASSERT_EQ(length_4[1], 1);
+  auto length_5 = detail::CalculateSequencesCounts(test_streams, 5);
+  ASSERT_EQ(length_5[0], 2);
+  ASSERT_EQ(length_5[1], 0);
+  auto length_6 = detail::CalculateSequencesCounts(test_streams, 6);
+  ASSERT_EQ(length_6[0], 1);
+  ASSERT_EQ(length_6[1], 0);
+  auto length_7 = detail::CalculateSequencesCounts(test_streams, 7);
+  ASSERT_EQ(length_7[0], 0);
+  ASSERT_EQ(length_7[1], 0);
+}
+
+}  // namespace dali

--- a/dali/pipeline/operators/reader/loader/sequence_loader_test.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader_test.cc
@@ -48,38 +48,43 @@ TEST(GatherExtractedStreamsTest, LoadTestDir) {
   }
 }
 
-TEST(CalculateSequencesCountsTest, Test) {
+TEST(GenerateSequencesTest, Test) {
   std::vector<filesystem::Stream> zero_stream = {{"/0", {}}};
-  auto zero_length_1 = detail::CalculateSequencesCounts(zero_stream, 1);
-  ASSERT_EQ(zero_length_1[0], 0);
-  auto zero_length_2 = detail::CalculateSequencesCounts(zero_stream, 2);
-  ASSERT_EQ(zero_length_2[0], 0);
-
+  auto zero_length_1 = detail::GenerateSequences(zero_stream, 1, 1, 1);
+  ASSERT_EQ(zero_length_1.size(), 0);
 
   std::vector<filesystem::Stream> test_streams = {
       {"/0", {"/0/00.png", "/0/01.png", "/0/02.png", "/0/03.png", "/0/04.png", "/0/05.png"}},
       {"/1", {"/1/00.png", "/1/01.png", "/1/02.png", "/1/03.png"}}};
-  auto length_1 = detail::CalculateSequencesCounts(test_streams, 1);
-  ASSERT_EQ(length_1[0], 6);
-  ASSERT_EQ(length_1[1], 4);
-  auto length_2 = detail::CalculateSequencesCounts(test_streams, 2);
-  ASSERT_EQ(length_2[0], 5);
-  ASSERT_EQ(length_2[1], 3);
-  auto length_3 = detail::CalculateSequencesCounts(test_streams, 3);
-  ASSERT_EQ(length_3[0], 4);
-  ASSERT_EQ(length_3[1], 2);
-  auto length_4 = detail::CalculateSequencesCounts(test_streams, 4);
-  ASSERT_EQ(length_4[0], 3);
-  ASSERT_EQ(length_4[1], 1);
-  auto length_5 = detail::CalculateSequencesCounts(test_streams, 5);
-  ASSERT_EQ(length_5[0], 2);
-  ASSERT_EQ(length_5[1], 0);
-  auto length_6 = detail::CalculateSequencesCounts(test_streams, 6);
-  ASSERT_EQ(length_6[0], 1);
-  ASSERT_EQ(length_6[1], 0);
-  auto length_7 = detail::CalculateSequencesCounts(test_streams, 7);
-  ASSERT_EQ(length_7[0], 0);
-  ASSERT_EQ(length_7[1], 0);
+
+  auto seq_1_1_1 = detail::GenerateSequences(test_streams, 1, 1, 1);
+  auto exp_1_1_1 = std::vector<std::vector<std::string>>{
+      {"/0/00.png"}, {"/0/01.png"}, {"/0/02.png"}, {"/0/03.png"}, {"/0/04.png"},
+      {"/0/05.png"}, {"/1/00.png"}, {"/1/01.png"}, {"/1/02.png"}, {"/1/03.png"}};
+  ASSERT_EQ(seq_1_1_1, exp_1_1_1);
+
+  auto seq_1_2_1 = detail::GenerateSequences(test_streams, 1, 2, 1);
+  auto exp_1_2_1 = std::vector<std::vector<std::string>>{
+      {"/0/00.png"}, {"/0/02.png"}, {"/0/04.png"}, {"/1/00.png"}, {"/1/02.png"}};
+  ASSERT_EQ(seq_1_2_1, exp_1_2_1);
+
+  auto seq_2_1_1 = detail::GenerateSequences(test_streams, 2, 1, 1);
+  auto exp_2_1_1 = std::vector<std::vector<std::string>>{
+      {"/0/00.png", "/0/01.png"}, {"/0/01.png", "/0/02.png"}, {"/0/02.png", "/0/03.png"},
+      {"/0/03.png", "/0/04.png"}, {"/0/04.png", "/0/05.png"}, {"/1/00.png", "/1/01.png"},
+      {"/1/01.png", "/1/02.png"}, {"/1/02.png", "/1/03.png"}};
+  ASSERT_EQ(seq_2_1_1, exp_2_1_1);
+
+  auto seq_2_1_2 = detail::GenerateSequences(test_streams, 2, 1, 2);
+  auto exp_2_1_2 = std::vector<std::vector<std::string>>{
+      {"/0/00.png", "/0/02.png"}, {"/0/01.png", "/0/03.png"}, {"/0/02.png", "/0/04.png"},
+      {"/0/03.png", "/0/05.png"}, {"/1/00.png", "/1/02.png"}, {"/1/01.png", "/1/03.png"}};
+  ASSERT_EQ(seq_2_1_2, exp_2_1_2);
+
+  auto seq_2_2_2 = detail::GenerateSequences(test_streams, 2, 2, 2);
+  auto exp_2_2_2 = std::vector<std::vector<std::string>>{
+      {"/0/00.png", "/0/02.png"}, {"/0/02.png", "/0/04.png"}, {"/1/00.png", "/1/02.png"}};
+  ASSERT_EQ(seq_2_2_2, exp_2_2_2);
 }
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/parser/sequence_parser.cc
+++ b/dali/pipeline/operators/reader/parser/sequence_parser.cc
@@ -36,7 +36,7 @@ void SequenceParser::Parse(const TensorSequence& data, SampleWorkspace* ws) {
                                          image_type_);
       img->Decode();
     } catch(std::runtime_error &e) {
-      DALI_FAIL(e.what() + "File: " + file_name);
+      DALI_FAIL(e.what() + " File: " + file_name);
     }
     const auto decoded = img->GetImage();
 
@@ -64,7 +64,7 @@ void SequenceParser::Parse(const TensorSequence& data, SampleWorkspace* ws) {
                                          data.tensors[frame].size(), image_type_);
       img->Decode();
     } catch(std::runtime_error &e) {
-      DALI_FAIL(e.what() + "File: " + file_name);
+      DALI_FAIL(e.what() + " File: " + file_name);
     }
     img->GetImage(view_tensor.mutable_data<uint8_t>());
     DALI_ENFORCE(view_tensor.shares_data(),

--- a/dali/pipeline/operators/reader/sequence_reader_op.cc
+++ b/dali/pipeline/operators/reader/sequence_reader_op.cc
@@ -30,8 +30,28 @@ DALI_REGISTER_OPERATOR(SequenceReader, SequenceReader, CPU);
 
 DALI_SCHEMA(SequenceReader)
     .DocStr(
-        "Read [Frame] sequences from a directory representing collection of "
-        "streams")
+        R"code(Read [Frame] sequences from a directory representing collection of streams."
+Expects file_root to contain set of directories, each of them represents one extracted video
+stream. Extracted video stream is represented by one file for each frame, sorting the paths to
+frames lexicographically should give the original order of frames.
+Example:
+> file_root
+  > 0
+    > 00001.png
+    > 00002.png
+    > 00003.png
+    > 00004.png
+    > 00005.png
+    > 00006.png
+    ....
+  > 1
+    > 00001.png
+    > 00002.png
+    > 00003.png
+    > 00004.png
+    > 00005.png
+    > 00006.png
+    ....)code")
     .NumInput(0)
     .NumOutput(1)  // ([Frames])
     .AddArg("file_root",

--- a/dali/pipeline/operators/reader/sequence_reader_op.cc
+++ b/dali/pipeline/operators/reader/sequence_reader_op.cc
@@ -59,7 +59,7 @@ Example:
             R"code(Path to a directory containing streams (directories representing streams).)code",
             DALI_STRING)
     .AddArg("sequence_length",
-            R"code(Lenght of sequence to load for each sample)code", DALI_INT32)
+            R"code(Length of sequence to load for each sample)code", DALI_INT32)
     .AddOptionalArg("step",
                     R"code(Distance between first frames of consecutive sequences)code", 1, false)
     .AddOptionalArg("stride",

--- a/dali/pipeline/operators/reader/sequence_reader_op.cc
+++ b/dali/pipeline/operators/reader/sequence_reader_op.cc
@@ -30,10 +30,11 @@ DALI_REGISTER_OPERATOR(SequenceReader, SequenceReader, CPU);
 
 DALI_SCHEMA(SequenceReader)
     .DocStr(
-        R"code(Read [Frame] sequences from a directory representing collection of streams."
+        R"code(Read [Frame] sequences from a directory representing collection of streams.
 Expects file_root to contain set of directories, each of them represents one extracted video
 stream. Extracted video stream is represented by one file for each frame, sorting the paths to
 frames lexicographically should give the original order of frames.
+Sequences do not cross stream boundary and only full sequences are considered - there is no padding.
 Example:
 > file_root
   > 0
@@ -59,8 +60,12 @@ Example:
             DALI_STRING)
     .AddArg("sequence_length",
             R"code(Lenght of sequence to load for each sample)code", DALI_INT32)
+    .AddOptionalArg("step",
+                    R"code(Distance between first frames of consecutive sequences)code", 1, false)
+    .AddOptionalArg("stride",
+                    R"code(Distance between consecutive frames in sequence)code", 1, false)
     .AddOptionalArg("image_type",
-            R"code(The color space of input and output image)code", DALI_RGB, false)
+                    R"code(The color space of input and output image)code", DALI_RGB, false)
     .AddParent("LoaderBase");
 
 }  // namespace dali


### PR DESCRIPTION
Rename, refactor and write docs for SequenceReader and SequenceLoader.
Add filtering for gathered extensions.
Add support for step, stride & shuffling with some tests.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>