### PR TITLE
Prevent replacing DALI op by constant in the constant folding process

### DIFF
--- a/dali/tensorflow/daliop.cc
+++ b/dali/tensorflow/daliop.cc
@@ -65,6 +65,8 @@ REGISTER_OP("Dali")
   .Attr("prefetch_queue_depth: int = 2")
   .Output("data: dtypes")
   .Attr("dtypes: list({half, float, uint8, int16, int32, int64}) >= 1")
+  // To prevent replacing DALI op with constant tensor during TF constant folding process
+  .SetIsStateful()
   .SetShapeFn([](tf::shape_inference::InferenceContext* c) {
     std::vector<tf::PartialTensorShape> shapes;
     TF_RETURN_IF_ERROR(c->GetAttr("shapes", &shapes));


### PR DESCRIPTION
During constant folding process, TensorFlow checks if nodes that have
constant input produces constant outputs and replaces them with constants.
In our case, it can happen as DALI op provides a deterministic output when running once
just after construction. Also, DALI op provides CPU variant so now TensorFlow
can run DALI on CPU for constant folding examination. To prevent this
DALI op needs to tell that it is stateful.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>