### PR TITLE
Fix assert check for dynamic tensor shapes

### DIFF
--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -381,7 +381,9 @@ struct TensorListShapeBase {
   TensorShape<tensor_ndim> tensor_shape(int64_t sample) const {
     static_assert(tensor_ndim == sample_ndim || sample_ndim == DynamicDimensions
                   || tensor_ndim == DynamicDimensions, "Cannot convert to other static ndim");
-    assert(tensor_ndim == sample_dim() && "Cannot convert to other ndim");
+    if (tensor_ndim != DynamicDimensions) {
+      assert(tensor_ndim == sample_dim() && "Cannot convert to other ndim");
+    }
     TensorShape<tensor_ndim> out;
     out.resize(sample_dim());
     int64_t base = sample_dim() * sample;

--- a/dali/kernels/tensor_view.h
+++ b/dali/kernels/tensor_view.h
@@ -177,7 +177,9 @@ TensorView<Backend, DataType, other_ndim> TensorViewBase<Backend, DataType, ndim
   static_assert(other_ndim != DynamicDimensions,
                 "Conversion to static only allowed for static shape");
   static_assert(ndim == other_ndim || ndim == DynamicDimensions, "Cannot convert to other ndim");
-  // assert(other_ndim == dim() && "Cannot convert to other ndim");
+  if (other_ndim == DynamicDimensions) {
+    assert(other_ndim == dim() && "Cannot convert to other ndim");
+  }
   return {data, shape.template to_static<other_ndim>()};
 }
 


### PR DESCRIPTION
If the result had dynamic size (-1 for static ndim),
it was compared with current runtime dim of object.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>