### PR TITLE
Apply modernize-use-override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,11 @@ if (WERROR)
 endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register -Wno-inconsistent-missing-override")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register")
 
   # CUDA does not support current clang as host compiler, we need use gcc
   # CUDA_HOST_COMPILER variable operates on paths
-  if (${CUDA_HOST_COMPILER} MATCHES "clang") 
+  if (${CUDA_HOST_COMPILER} MATCHES "clang")
     message(STATUS "CUDA_HOST_COMPILER is set to ${CMAKE_C_COMPILER} - setting CUDA_HOST_COMPILER to gcc")
     execute_process(COMMAND which gcc OUTPUT_VARIABLE PATH_TO_GCC OUTPUT_STRIP_TRAILING_WHITESPACE)
     if (NOT PATH_TO_GCC)

--- a/dali/benchmark/dali_bench.h
+++ b/dali/benchmark/dali_bench.h
@@ -36,7 +36,7 @@ class DALIBenchmark : public benchmark::Fixture {
     LoadJPEGS(image_folder, &jpeg_names_, &jpegs_);
   }
 
-  virtual ~DALIBenchmark() = default;
+  ~DALIBenchmark() override = default;
 
   int RandInt(int a, int b) {
     return std::uniform_int_distribution<>(a, b)(rand_gen_);

--- a/dali/common.h
+++ b/dali/common.h
@@ -49,12 +49,12 @@ using std::unique_ptr;
 using std::vector;
 
 // Common types
-typedef uint8_t uint8;
-typedef int16_t int16;
-typedef int64_t int64;
-typedef uint64_t uint64;
-typedef int32_t int32;
-typedef uint32_t uint32_t;
+using uint8 = uint8_t;
+using int16 = int16_t;
+using int64 = int64_t;
+using uint64 = uint64_t;
+using int32 = int32_t;
+using uint32 = uint32_t;
 
 // Basic data type for our indices and dimension sizes
 typedef int64_t Index;

--- a/dali/image/jpeg.h
+++ b/dali/image/jpeg.h
@@ -33,7 +33,7 @@ class JpegImage final : public GenericImage {
  public:
   JpegImage(const uint8_t *encoded_buffer, size_t length, DALIImageType image_type);
 
-  ~JpegImage();
+  ~JpegImage() override;
 
  protected:
   std::pair<std::shared_ptr<uint8_t>, ImageDims>

--- a/dali/pipeline/data/allocator.h
+++ b/dali/pipeline/data/allocator.h
@@ -56,13 +56,13 @@ class AllocatorBase {
 class GPUAllocator : public AllocatorBase {
  public:
   explicit GPUAllocator(const OpSpec &spec) : AllocatorBase(spec) {}
-  virtual ~GPUAllocator() = default;
+  ~GPUAllocator() override = default;
 
-  virtual void New(void **ptr, size_t bytes) {
+  void New(void **ptr, size_t bytes) override {
     CUDA_CALL(cudaMalloc(ptr, bytes));
   }
 
-  virtual void Delete(void *ptr, size_t /* unused */) {
+  void Delete(void *ptr, size_t /* unused */) override {
     if (ptr != nullptr) {
       CUDA_CALL(cudaFree(ptr));
     }
@@ -82,7 +82,7 @@ DALI_DECLARE_OPTYPE_REGISTRY(GPUAllocator, GPUAllocator);
 class CPUAllocator : public AllocatorBase {
  public:
   explicit CPUAllocator(const OpSpec &spec) : AllocatorBase(spec) {}
-  virtual ~CPUAllocator() = default;
+  ~CPUAllocator() override = default;
 
   void New(void **ptr, size_t bytes) override {
     *ptr = ::operator new(bytes);
@@ -105,7 +105,7 @@ DALI_DECLARE_OPTYPE_REGISTRY(CPUAllocator, CPUAllocator);
 class PinnedCPUAllocator : public CPUAllocator {
  public:
   explicit PinnedCPUAllocator(const OpSpec &spec) : CPUAllocator(spec) {}
-  virtual ~PinnedCPUAllocator() = default;
+  ~PinnedCPUAllocator() override = default;
 
   void New(void **ptr, size_t bytes) override {
     CUDA_CALL(cudaMallocHost(ptr, bytes));

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -39,7 +39,7 @@ template <typename Backend>
 class Tensor : public Buffer<Backend> {
  public:
   inline Tensor() : meta_(DALI_NHWC) {}
-  inline ~Tensor() = default;
+  inline ~Tensor() override = default;
 
   /**
    *

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -45,7 +45,7 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
   DLL_PUBLIC TensorList() : meta_(DALI_NHWC),
                             tensor_view_(nullptr) {}
 
-  DLL_PUBLIC ~TensorList() {
+  DLL_PUBLIC ~TensorList() override {
     delete tensor_view_;
   }
 

--- a/dali/pipeline/executor/async_pipelined_executor.h
+++ b/dali/pipeline/executor/async_pipelined_executor.h
@@ -43,7 +43,7 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
     device_id_(device_id) {
   }
 
-  DLL_PUBLIC virtual ~AsyncPipelinedExecutor() {
+  DLL_PUBLIC ~AsyncPipelinedExecutor() override {
     cpu_thread_.ForceStop();
     mixed_thread_.ForceStop();
     gpu_thread_.ForceStop();

--- a/dali/pipeline/executor/pipelined_executor.h
+++ b/dali/pipeline/executor/pipelined_executor.h
@@ -44,7 +44,7 @@ class DLL_PUBLIC PipelinedExecutor : public Executor {
         set_affinity, max_num_stream, prefetch_queue_depth) {
   }
 
-  DLL_PUBLIC virtual ~PipelinedExecutor() = default;
+  DLL_PUBLIC ~PipelinedExecutor() override = default;
 
   DLL_PUBLIC void Build(OpGraph *graph, vector<string> output_names) override;
 

--- a/dali/pipeline/operators/color/color_twist.h
+++ b/dali/pipeline/operators/color/color_twist.h
@@ -174,7 +174,7 @@ class ColorTwistBase : public Operator<Backend> {
     DALI_ENFORCE(C_ == 3, "Color transformation is implemented only for RGB images");
   }
 
-  virtual ~ColorTwistBase() {
+  ~ColorTwistBase() override {
     for (auto * a : augments_) {
       delete a;
     }
@@ -209,7 +209,7 @@ class BrightnessAdjust : public ColorTwistBase<Backend> {
     this->augments_.push_back(new Brightness());
   }
 
-  virtual ~BrightnessAdjust() = default;
+  ~BrightnessAdjust() override = default;
 };
 
 template <typename Backend>
@@ -219,7 +219,7 @@ class ContrastAdjust : public ColorTwistBase<Backend> {
     this->augments_.push_back(new Contrast());
   }
 
-  virtual ~ContrastAdjust() = default;
+  ~ContrastAdjust() override = default;
 };
 
 template<typename Backend>
@@ -229,7 +229,7 @@ class HueAdjust : public ColorTwistBase<Backend> {
     this->augments_.push_back(new Hue());
   }
 
-  virtual ~HueAdjust() = default;
+  ~HueAdjust() override = default;
 };
 
 template<typename Backend>
@@ -239,7 +239,7 @@ class SaturationAdjust : public ColorTwistBase<Backend> {
     this->augments_.push_back(new Saturation());
   }
 
-  virtual ~SaturationAdjust() = default;
+  ~SaturationAdjust() override = default;
 };
 
 template<typename Backend>
@@ -252,7 +252,7 @@ class ColorTwistAdjust : public ColorTwistBase<Backend> {
     this->augments_.push_back(new Brightness());
   }
 
-  virtual ~ColorTwistAdjust() = default;
+  ~ColorTwistAdjust() override = default;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/crop/bbox_crop.h
+++ b/dali/pipeline/operators/crop/bbox_crop.h
@@ -76,7 +76,7 @@ class RandomBBoxCrop : public Operator<Backend> {
     }
   }
 
-  virtual ~RandomBBoxCrop() = default;
+  ~RandomBBoxCrop() override = default;
 
  protected:
   void RunImpl(Workspace<Backend> *ws, const int idx) override;

--- a/dali/pipeline/operators/decoder/host_decoder.h
+++ b/dali/pipeline/operators/decoder/host_decoder.h
@@ -34,7 +34,7 @@ class HostDecoder : public Operator<CPUBackend> {
           c_(IsColor(output_type_) ? 3 : 1) {}
 
 
-  virtual inline ~HostDecoder() = default;
+  inline ~HostDecoder() override = default;
   DISABLE_COPY_MOVE_ASSIGN(HostDecoder);
 
  protected:

--- a/dali/pipeline/operators/detection/box_encoder.h
+++ b/dali/pipeline/operators/detection/box_encoder.h
@@ -48,7 +48,7 @@ class BoxEncoder<CPUBackend>: public Operator<CPUBackend> {
     anchors_ = ReadBoxesFromInput(anchors.data(), anchors.size() / BoundingBox::kSize);
   }
 
-  virtual ~BoxEncoder() = default;
+  ~BoxEncoder() override = default;
 
   DISABLE_COPY_MOVE_ASSIGN(BoxEncoder);
 

--- a/dali/pipeline/operators/detection/random_crop.h
+++ b/dali/pipeline/operators/detection/random_crop.h
@@ -46,7 +46,7 @@ class SSDRandomCrop : public Operator<Backend> {
     sample_options_.push_back(SampleOption{false, FLT_MAX});
   }
 
-  virtual inline ~SSDRandomCrop() = default;
+  inline ~SSDRandomCrop() override = default;
 
   DISABLE_COPY_MOVE_ASSIGN(SSDRandomCrop);
 

--- a/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
+++ b/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
@@ -50,7 +50,7 @@ class DisplacementFilter<CPUBackend, Displacement, per_channel_transform>
     }
   }
 
-  virtual ~DisplacementFilter() {
+  ~DisplacementFilter() override {
     for (auto &d : displace_) {
       d.Cleanup();
     }

--- a/dali/pipeline/operators/displacement/flip.h
+++ b/dali/pipeline/operators/displacement/flip.h
@@ -47,7 +47,7 @@ class Flip : public DisplacementFilter<Backend, FlipAugment> {
   inline explicit Flip(const OpSpec &spec)
     : DisplacementFilter<Backend, FlipAugment>(spec) {}
 
-  virtual ~Flip() = default;
+  ~Flip() override = default;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/displacement/rotate.h
+++ b/dali/pipeline/operators/displacement/rotate.h
@@ -47,7 +47,7 @@ class Rotate : public DisplacementFilter<Backend, RotateAugment> {
   inline explicit Rotate(const OpSpec &spec)
     : DisplacementFilter<Backend, RotateAugment>(spec) {}
 
-  virtual ~Rotate() = default;
+  ~Rotate() override = default;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/displacement/sphere.h
+++ b/dali/pipeline/operators/displacement/sphere.h
@@ -56,7 +56,7 @@ class Sphere : public DisplacementFilter<Backend, SphereAugment> {
       : DisplacementFilter<Backend, SphereAugment>(spec) {}
 
 
-    virtual ~Sphere() = default;
+    ~Sphere() override = default;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/displacement/warpaffine.h
+++ b/dali/pipeline/operators/displacement/warpaffine.h
@@ -77,7 +77,7 @@ class WarpAffine : public DisplacementFilter<Backend, WarpAffineAugment> {
     inline explicit WarpAffine(const OpSpec &spec)
       : DisplacementFilter<Backend, WarpAffineAugment>(spec) {}
 
-    virtual ~WarpAffine() = default;
+    ~WarpAffine() override = default;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/displacement/water.h
+++ b/dali/pipeline/operators/displacement/water.h
@@ -66,7 +66,7 @@ class Water : public DisplacementFilter<Backend, WaterAugment> {
   explicit Water(const OpSpec& spec)
     : DisplacementFilter<Backend, WaterAugment>(spec) {}
 
-  virtual ~Water() = default;
+  ~Water() override = default;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -74,7 +74,7 @@ class CropMirrorNormalize : public Operator<Backend> {
     per_sample_dimensions_.resize(batch_size_);
   }
 
-  virtual inline ~CropMirrorNormalize() = default;
+  inline ~CropMirrorNormalize() override = default;
 
  protected:
   void RunImpl(Workspace<Backend> *ws, const int idx) override;

--- a/dali/pipeline/operators/fused/normalize_permute.h
+++ b/dali/pipeline/operators/fused/normalize_permute.h
@@ -51,7 +51,7 @@ class NormalizePermute : public Operator<Backend> {
     for (auto &shape : output_shape_) shape = {C_, H_, W_};
   }
 
-  virtual inline ~NormalizePermute() = default;
+  inline ~NormalizePermute() override = default;
 
  protected:
   void RunImpl(Workspace<Backend> *ws, const int idx) override;

--- a/dali/pipeline/operators/geometric/bb_flip.h
+++ b/dali/pipeline/operators/geometric/bb_flip.h
@@ -29,7 +29,7 @@ class BbFlip<CPUBackend> : public Operator<CPUBackend> {
  public:
   explicit BbFlip(const OpSpec &spec);
 
-  virtual ~BbFlip() = default;
+  ~BbFlip() override = default;
   DISABLE_COPY_MOVE_ASSIGN(BbFlip);
 
  protected:

--- a/dali/pipeline/operators/op_schema_test.cc
+++ b/dali/pipeline/operators/op_schema_test.cc
@@ -24,8 +24,8 @@ DALI_SCHEMA(Dummy1)
 
 class OpSchemaTest : public DALITest {
  public:
-  inline void SetUp() {}
-  inline void TearDown() {}
+  inline void SetUp() override {}
+  inline void TearDown() override {}
 };
 
 TEST(OpSchemaTest, SimpleTest) {

--- a/dali/pipeline/operators/operator.h
+++ b/dali/pipeline/operators/operator.h
@@ -166,7 +166,7 @@ class Operator : public OperatorBase {
     OperatorBase(spec)
   {}
 
-  virtual inline ~Operator() noexcept(false)
+  inline ~Operator() noexcept(false) override
   {}
 
   using OperatorBase::Run;
@@ -221,7 +221,7 @@ class Operator<MixedBackend> : public OperatorBase {
     OperatorBase(spec)
   {}
 
-  virtual inline ~Operator() noexcept(false)
+  inline ~Operator() noexcept(false) override
   {}
 
   using OperatorBase::Run;

--- a/dali/pipeline/operators/paste/bbox_paste_test.cc
+++ b/dali/pipeline/operators/paste/bbox_paste_test.cc
@@ -55,7 +55,7 @@ class BBoxPasteTest<std::integral_constant<bool, ltrb>> : public DALISingleOpTes
 
   vector<TensorList<CPUBackend>*>
   Reference(const vector<TensorList<CPUBackend>*> &inputs,
-            DeviceWorkspace *ws) {
+            DeviceWorkspace *ws) override {
     (void)inputs;
     (void)ws;
     auto ref = ToTensorList(output_);

--- a/dali/pipeline/operators/reader/loader/indexed_file_loader.h
+++ b/dali/pipeline/operators/reader/loader/indexed_file_loader.h
@@ -64,7 +64,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     return indices_.size();
   }
 
-  virtual ~IndexedFileLoader() {
+  ~IndexedFileLoader() override {
     if (current_file_ != nullptr) {
       current_file_->Close();
     }

--- a/dali/pipeline/operators/reader/loader/lmdb.h
+++ b/dali/pipeline/operators/reader/loader/lmdb.h
@@ -89,7 +89,7 @@ class LMDBReader : public Loader<CPUBackend, Tensor<CPUBackend>> {
       DALI_ENFORCE(ok, "lmdb::SeekLMDB failed");
     }
   }
-  ~LMDBReader() {
+  ~LMDBReader() override {
     mdb_cursor_close(mdb_cursor_);
     mdb_dbi_close(mdb_env_, mdb_dbi_);
     mdb_txn_abort(mdb_transaction_);

--- a/dali/pipeline/operators/reader/loader/recordio_loader.h
+++ b/dali/pipeline/operators/reader/loader/recordio_loader.h
@@ -32,7 +32,7 @@ class RecordIOLoader : public IndexedFileLoader {
     : IndexedFileLoader(options, false) {
     Init(options);
   }
-  ~RecordIOLoader() {}
+  ~RecordIOLoader() override {}
 
   void ReadIndexFile(const std::vector<std::string>& index_uris) override {
     std::vector<size_t> file_offsets;

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -149,7 +149,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
     thread_file_reader_ = std::thread{&VideoLoader::read_file, this};
   }
 
-  ~VideoLoader() noexcept {
+  ~VideoLoader() noexcept override {
     done_ = true;
     send_queue_.shutdown();
     if (vid_decoder_) {

--- a/dali/pipeline/operators/reader/parser/parser_test.cc
+++ b/dali/pipeline/operators/reader/parser/parser_test.cc
@@ -35,7 +35,7 @@ class IntArrayParser : public Parser<IntArrayWrapper> {
  public:
   explicit IntArrayParser(const OpSpec& spec)
     : Parser<IntArrayWrapper>(spec) {}
-  void Parse(const IntArrayWrapper& data, SampleWorkspace* ws) {
+  void Parse(const IntArrayWrapper& data, SampleWorkspace* ws) override {
     const int *int_data = data.data;
 
     const int H = int_data[0];

--- a/dali/pipeline/operators/reader/reader_op.h
+++ b/dali/pipeline/operators/reader/reader_op.h
@@ -55,7 +55,7 @@ class DataReader : public Operator<Backend> {
   batch_stop_(false) {
   }
 
-  virtual ~DataReader() noexcept {
+  ~DataReader() noexcept override {
     StopPrefetchThread();
     for (size_t i = 0; i < prefetched_batch_.size(); ++i) {
       // return unconsumed batches

--- a/dali/pipeline/operators/reader/reader_op_test.cc
+++ b/dali/pipeline/operators/reader/reader_op_test.cc
@@ -53,7 +53,7 @@ class DummyDataReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
     loader_.reset(new DummyLoader(spec));
   }
 
-  ~DummyDataReader() {
+  ~DummyDataReader() override {
     DataReader<CPUBackend, Tensor<CPUBackend>>::StopPrefetchThread();
   }
   /*

--- a/dali/pipeline/operators/reader/video_reader_op.h
+++ b/dali/pipeline/operators/reader/video_reader_op.h
@@ -54,10 +54,10 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
       }
   }
 
-  virtual inline ~VideoReader() = default;
+  inline ~VideoReader() override = default;
 
  protected:
-  void SetupSharedSampleParams(DeviceWorkspace *ws) {
+  void SetupSharedSampleParams(DeviceWorkspace *ws) override {
     auto* tl_sequence_output = ws->Output<GPUBackend>(0);
     tl_sequence_output->set_type(TypeInfo::Create<float>());
     tl_sequence_output->Resize(tl_shape_);

--- a/dali/pipeline/operators/resize/new_resize.h
+++ b/dali/pipeline/operators/resize/new_resize.h
@@ -131,7 +131,7 @@ class NewResize : public Resize<Backend> {
     }
   }
 
-  virtual inline ~NewResize() {
+  inline ~NewResize() override {
     for (size_t i = 0; i < _countof(mapMem_); ++i)
       CUDA_CALL(cudaFree(mapMem_[i]));
 

--- a/dali/pipeline/operators/resize/random_resized_crop.h
+++ b/dali/pipeline/operators/resize/random_resized_crop.h
@@ -44,7 +44,7 @@ class RandomResizedCrop : public Operator<Backend> {
     InitParams(spec);
   }
 
-  virtual inline ~RandomResizedCrop() = default;
+  inline ~RandomResizedCrop() override = default;
 
   DISABLE_COPY_MOVE_ASSIGN(RandomResizedCrop);
 

--- a/dali/pipeline/operators/resize/resize.h
+++ b/dali/pipeline/operators/resize/resize.h
@@ -85,7 +85,7 @@ template <typename Backend>
 class Resize : public Operator<Backend>, protected ResizeAttr {
  public:
   explicit Resize(const OpSpec &spec);
-  virtual inline ~Resize()    { delete resizeParam_; }
+  inline ~Resize() override    { delete resizeParam_; }
 
  protected:
   void RunImpl(Workspace<Backend> *ws, int idx) override;

--- a/dali/pipeline/operators/support/random/coin_flip.h
+++ b/dali/pipeline/operators/support/random/coin_flip.h
@@ -28,7 +28,7 @@ class CoinFlip : public Operator<SupportBackend> {
     dis_(spec.GetArgument<float>("probability")),
     rng_(spec.GetArgument<int64_t>("seed")) {}
 
-  virtual inline ~CoinFlip() = default;
+  inline ~CoinFlip() override = default;
 
   DISABLE_COPY_MOVE_ASSIGN(CoinFlip);
 

--- a/dali/pipeline/operators/support/random/uniform.h
+++ b/dali/pipeline/operators/support/random/uniform.h
@@ -33,7 +33,7 @@ class Uniform : public Operator<SupportBackend> {
     dis_ = std::uniform_real_distribution<float>(range[0], range[1]);
   }
 
-  virtual inline ~Uniform() = default;
+  inline ~Uniform() override = default;
 
   DISABLE_COPY_MOVE_ASSIGN(Uniform);
 

--- a/dali/pipeline/operators/util/cast.h
+++ b/dali/pipeline/operators/util/cast.h
@@ -27,7 +27,7 @@ class Cast : public Operator<Backend> {
     output_type_(spec.GetArgument<DALIDataType>("dtype"))
     {}
 
-  virtual inline ~Cast() = default;
+  inline ~Cast() override = default;
 
   DISABLE_COPY_MOVE_ASSIGN(Cast);
 

--- a/dali/pipeline/operators/util/copy.h
+++ b/dali/pipeline/operators/util/copy.h
@@ -27,7 +27,7 @@ class Copy : public Operator<Backend> {
   inline explicit Copy(const OpSpec &spec) :
     Operator<Backend>(spec) {}
 
-  virtual inline ~Copy() = default;
+  inline ~Copy() override = default;
 
   DISABLE_COPY_MOVE_ASSIGN(Copy);
 

--- a/dali/pipeline/operators/util/dummy_op.h
+++ b/dali/pipeline/operators/util/dummy_op.h
@@ -25,7 +25,7 @@ class DummyOp : public Operator<Backend> {
   inline explicit DummyOp(const OpSpec &spec) :
     Operator<Backend>(spec) {}
 
-  virtual inline ~DummyOp() = default;
+  inline ~DummyOp() override = default;
 
   DISABLE_COPY_MOVE_ASSIGN(DummyOp);
 

--- a/dali/pipeline/operators/util/dump_image.h
+++ b/dali/pipeline/operators/util/dump_image.h
@@ -33,7 +33,7 @@ class DumpImage : public Operator<Backend> {
         "CHW not supported yet.");
   }
 
-  virtual inline ~DumpImage() = default;
+  inline ~DumpImage() override = default;
 
  protected:
   void RunImpl(Workspace<Backend> *ws, int idx) override;

--- a/dali/pipeline/operators/util/external_source.h
+++ b/dali/pipeline/operators/util/external_source.h
@@ -40,7 +40,7 @@ class ExternalSource : public Operator<Backend> {
     output_name_ = spec.Output(0);
   }
 
-  inline ~ExternalSource() = default;
+  inline ~ExternalSource() override = default;
 
   inline string name() const override {
     return "ExternalSource (" + output_name_ + ")";

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -31,7 +31,7 @@ namespace dali {
 template <typename ThreadCount>
 class PipelineTest : public DALITest {
  public:
-  inline void SetUp() {
+  inline void SetUp() override {
     DALITest::SetUp();
     DALITest::DecodeJPEGS(DALI_RGB);
   }

--- a/dali/pipeline/workspace/device_workspace.h
+++ b/dali/pipeline/workspace/device_workspace.h
@@ -42,7 +42,7 @@ using DeviceOutputType = shared_ptr<TensorList<Backend>>;
 class DLL_PUBLIC DeviceWorkspace : public WorkspaceBase<DeviceInputType, DeviceOutputType> {
  public:
   DLL_PUBLIC DeviceWorkspace() : stream_(0) {}
-  DLL_PUBLIC ~DeviceWorkspace() = default;
+  DLL_PUBLIC ~DeviceWorkspace() override = default;
 
   /**
    * @brief Clears the contents of the workspaces, resetting it

--- a/dali/pipeline/workspace/host_workspace.h
+++ b/dali/pipeline/workspace/host_workspace.h
@@ -41,7 +41,7 @@ class SampleWorkspace;
 class DLL_PUBLIC HostWorkspace : public WorkspaceBase<HostInputType, HostOutputType> {
  public:
   DLL_PUBLIC inline HostWorkspace() {}
-  DLL_PUBLIC inline ~HostWorkspace() = default;
+  DLL_PUBLIC inline ~HostWorkspace() override = default;
 
   /**
    * @brief Returns a sample workspace for the given sample

--- a/dali/pipeline/workspace/mixed_workspace.h
+++ b/dali/pipeline/workspace/mixed_workspace.h
@@ -41,7 +41,7 @@ using MixedOutputType = shared_ptr<TensorList<Backend>>;
 class DLL_PUBLIC MixedWorkspace : public WorkspaceBase<MixedInputType, MixedOutputType> {
  public:
   DLL_PUBLIC inline MixedWorkspace() : stream_(0) {}
-  DLL_PUBLIC inline ~MixedWorkspace() = default;
+  DLL_PUBLIC inline ~MixedWorkspace() override = default;
 
 
   /**

--- a/dali/pipeline/workspace/sample_workspace.h
+++ b/dali/pipeline/workspace/sample_workspace.h
@@ -44,7 +44,7 @@ class DLL_PUBLIC SampleWorkspace : public WorkspaceBase<SampleInputType, SampleO
  public:
   DLL_PUBLIC SampleWorkspace() : data_idx_(-1), thread_idx_(-1), has_stream_(false) {}
 
-  DLL_PUBLIC ~SampleWorkspace() = default;
+  DLL_PUBLIC ~SampleWorkspace() override = default;
 
   /**
    * @brief Clears the contents of the workspaces, reseting it

--- a/dali/pipeline/workspace/support_workspace.h
+++ b/dali/pipeline/workspace/support_workspace.h
@@ -39,7 +39,7 @@ using SupportOutputType = shared_ptr<Tensor<Backend>>;
 class DLL_PUBLIC SupportWorkspace : public WorkspaceBase<SupportInputType, SupportOutputType> {
  public:
   DLL_PUBLIC SupportWorkspace() {}
-  DLL_PUBLIC ~SupportWorkspace() = default;
+  DLL_PUBLIC ~SupportWorkspace() override = default;
 
   /**
    * @brief Returns the input Tensor at index `idx`.

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -72,7 +72,7 @@ template <template<typename> class InputType, template<typename> class OutputTyp
 class WorkspaceBase : public ArgumentWorkspace {
  public:
   WorkspaceBase() {}
-  virtual ~WorkspaceBase() = default;
+  ~WorkspaceBase() override = default;
 
   /**
    * @brief Clears the contents of the workspaces, reseting it

--- a/dali/test/dali_test_decoder.h
+++ b/dali/test/dali_test_decoder.h
@@ -15,7 +15,7 @@ template <typename ImgType>
 class GenericDecoderTest : public DALISingleOpTest<ImgType> {
  public:
   vector<TensorList<CPUBackend> *> Reference(
-      const vector<TensorList<CPUBackend> *> &inputs, DeviceWorkspace *ws) {
+      const vector<TensorList<CPUBackend> *> &inputs, DeviceWorkspace *ws) override {
     // single input - encoded images
     // single output - decoded images
 

--- a/dali/test/dali_test_resize.h
+++ b/dali/test/dali_test_resize.h
@@ -19,7 +19,7 @@ template <typename ImgType>
 class GenericResizeTest : public DALISingleOpTest<ImgType> {
  public:
   vector<TensorList<CPUBackend>*>
-  Reference(const vector<TensorList<CPUBackend>*> &inputs, DeviceWorkspace *ws) {
+  Reference(const vector<TensorList<CPUBackend>*> &inputs, DeviceWorkspace *ws) override {
     const int c = this->GetNumColorComp();
     auto cv_type = (c == 3) ? CV_8UC3 : CV_8UC1;
 


### PR DESCRIPTION
Apply modernize-use-override
Removes -Wno-inconsistent-missing-override from clang build
to reenable warning in CI.
Fix applied with clang-tidy

Fix typedefs in common.h

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>