### PR TITLE
Fix error message formatting in python

### DIFF
--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -99,9 +99,9 @@ class _OperatorInstance(object):
                 for inp in inputs:
                     if not isinstance(inp, TensorReference):
                         raise TypeError(
-                            "Expected inputs of type " +
+                            ("Expected inputs of type " +
                             "TensorReference. Received " +
-                            "input type {}."
+                            "input type {}.")
                             .format(type(inp).__name__))
                     self._spec.AddInput(inp.name, inp.device)
             elif isinstance(inputs[0], list):
@@ -110,38 +110,38 @@ class _OperatorInstance(object):
                     for inp in inputs:
                         if not isinstance(inp, list):
                             raise TypeError(
-                                "Expected inputs of type list of " +
+                                ("Expected inputs of type list of " +
                                 "TensorReference. Received " +
-                                "input type {}."
+                                "input type {}.")
                                 .format(type(inp).__name__))
                         if len(inp) != length:
                             raise RuntimeError(
-                                    "Expected input lists " +
+                                    ("Expected input lists " +
                                     "to have the same length " +
                                     "({}). Received list of " +
-                                    "length {}."
+                                    "length {}.")
                                     .format(length, len(inp)))
                         if not isinstance(inp[i], TensorReference):
                             raise TypeError(
-                                "Expected inputs of type " +
+                                ("Expected inputs of type " +
                                 "TensorReference. Received " +
-                                "input type {}."
+                                "input type {}.")
                                 .format(type(inp[i]).__name__))
                         self._spec.AddInput(inp[i].name, inp[i].device)
                 self._spec.AddArg("num_input_sets", length)
             else:
                 raise TypeError(
-                    "Expected inputs of type TensorReference or list of " +
-                    "TensorReference. Received input type {}"
+                    ("Expected inputs of type TensorReference or list of " +
+                    "TensorReference. Received input type {}")
                     .format(type(inputs[0]).__name__))
         # Argument inputs
         for k in sorted(kwargs.keys()):
             if k not in ["name"]:
                 if not isinstance(kwargs[k], TensorReference):
                     raise TypeError(
-                            "Expected inputs of type " +
+                            ("Expected inputs of type " +
                             "TensorReference. Received " +
-                            "input type {}"
+                            "input type {}")
                             .format(type(kwargs[k]).__name__))
                 self._spec.AddArgumentInput(k, kwargs[k].name)
                 self._inputs = list(self._inputs) + [kwargs[k]]
@@ -232,8 +232,8 @@ def python_op_factory(name, op_device = "cpu"):
             if (len(inputs) > self._schema.MaxNumInput() or
                     len(inputs) < self._schema.MinNumInput()):
                 raise ValueError(
-                    "Operator {} expects [{}, " +
-                    "{}] inputs, but received {}"
+                    ("Operator {} expects [{}, " +
+                    "{}] inputs, but received {}")
                     .format(type(self).__name__,
                             self._schema.MinNumInput(),
                             self._schema.MaxNumInput(),
@@ -304,8 +304,8 @@ class TFRecordReader(with_metaclass(_DaliOperatorMeta, object)):
         if (len(inputs) > self._schema.MaxNumInput() or
                 len(inputs) < self._schema.MinNumInput()):
             raise ValueError(
-                "Operator {} expects [{}, " +
-                "{}] inputs, but received {}"
+                ("Operator {} expects [{}, " +
+                "{}] inputs, but received {}")
                 .format(type(self).__name__,
                         self._schema.MinNumInput(),
                         self._schema.MaxNumInput(),

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -139,9 +139,9 @@ class Pipeline(object):
         for output in outputs:
             if not isinstance(output, nt.TensorReference):
                 raise TypeError(
-                    "Expected outputs of type "
+                    ("Expected outputs of type "
                     "TensorReference. Received "
-                    "output type {}"
+                    "output type {}")
                     .format(type(output).__name__)
                 )
 
@@ -209,9 +209,9 @@ class Pipeline(object):
             raise RuntimeError("Pipeline must be built first.")
         if not isinstance(ref, nt.TensorReference):
             raise TypeError(
-                "Expected argument one to "
+                ("Expected argument one to "
                 "be TensorReference. "
-                "Received output type {}"
+                "Received output type {}")
                 .format(type(ref).__name__)
             )
         if isinstance(data, list):


### PR DESCRIPTION
`.format()` for error message strings broken
into more than one line using `+` was applied
only to one part of the string.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>