### PR TITLE
Stop returning memory allocated with new from the C API

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -72,17 +72,19 @@ int64_t* daliShapeAt(daliPipelineHandle* pipe_handle, int n) {
     t.ShareData(ws->Output<dali::CPUBackend>(n));
 
     std::vector<dali::Index> shape = t.shape();
-    c_shape = new int64_t[shape.size() + 1];
+    c_shape = static_cast<int64_t*>(
+      malloc(sizeof(int64_t) * (shape.size() + 1)));
     c_shape[shape.size()] = 0;
-    memcpy(c_shape, &shape[0], shape.size() * sizeof (int64_t));
+    memcpy(c_shape, &shape[0], shape.size() * sizeof(int64_t));
   } else {
     dali::Tensor<dali::GPUBackend> t;
     t.ShareData(ws->Output<dali::GPUBackend>(n));
 
     std::vector<dali::Index> shape = t.shape();
-    c_shape = new int64_t[shape.size() + 1];
+    c_shape = static_cast<int64_t*>(
+      malloc(sizeof(int64_t) * (shape.size() + 1)));
     c_shape[shape.size()] = 0;
-    memcpy(c_shape, &shape[0], shape.size() * sizeof (int64_t));
+    memcpy(c_shape, &shape[0], shape.size() * sizeof(int64_t));
   }
   return c_shape;
 }
@@ -119,4 +121,3 @@ void daliDeletePipeline(daliPipelineHandle* pipe_handle) {
 void daliLoadLibrary(const char* lib_path) {
     dali::PluginManager::LoadLibrary(lib_path);
 }
-

--- a/dali/c_api/c_api.h
+++ b/dali/c_api/c_api.h
@@ -71,6 +71,7 @@ extern "C" {
    * stored at position `n` in the pipeline.
    * This function may only be called after
    * calling Output function.
+   * @remarks Caller is responsible to 'free' the memory returned
    */
   DLL_PUBLIC int64_t* daliShapeAt(daliPipelineHandle* pipe_handle, int n);
 
@@ -92,7 +93,7 @@ extern "C" {
   DLL_PUBLIC void daliDeletePipeline(daliPipelineHandle* pipe_handle);
 
   /**
-   * @brief Load plugin library 
+   * @brief Load plugin library
    */
   DLL_PUBLIC void daliLoadLibrary(const char* lib_path);
 }


### PR DESCRIPTION
Replacing new by malloc allocated memory in the C API

Signed-off-by: Joaquin Anton <janton@nvidia.com>