### PR TITLE
Add optional resize_longer argument to resize op. Extend COCOReader o…

### DIFF
--- a/dali/pipeline/operators/paste/paste.cc
+++ b/dali/pipeline/operators/paste/paste.cc
@@ -38,6 +38,9 @@ Length of the tuple needs to be equal to `n_channels`.)code",
   .AddOptionalArg("paste_y",
       R"code(Vertical position of the paste in image coordinates (0.0 - 1.0))code",
       0.5f, true)
+  .AddOptionalArg("min_canvas_size",
+      R"code(Enforce minimum paste canvas dimension after scaling input size by ratio.)code",
+      0.0f, true)
   .EnforceInputLayout(DALI_NHWC);
 
 }  // namespace dali

--- a/dali/pipeline/operators/paste/paste.cu
+++ b/dali/pipeline/operators/paste/paste.cu
@@ -143,6 +143,14 @@ void Paste<GPUBackend>::SetupSampleParams(DeviceWorkspace *ws, const int idx) {
 
     int new_H = static_cast<int>(ratio * H);
     int new_W = static_cast<int>(ratio * W);
+
+    int min_canvas_size_ = spec_.GetArgument<float>("min_canvas_size", ws, i);
+    DALI_ENFORCE(min_canvas_size_ >= 0.,
+      "min_canvas_size_ of less than 0 is not supported");
+
+    new_H = std::max(new_H, static_cast<int>(min_canvas_size_));
+    new_W = std::max(new_W, static_cast<int>(min_canvas_size_));
+
     output_shape[i] = {new_H, new_W, C_};
 
     float paste_x_ = spec_.GetArgument<float>("paste_x", ws, i);

--- a/dali/pipeline/operators/reader/coco_reader_op.cc
+++ b/dali/pipeline/operators/reader/coco_reader_op.cc
@@ -309,6 +309,12 @@ Tensor (`m` * `[x, y, w, h] or `m` * [left, top, right, bottom]`) and labels as 
   .AddOptionalArg("ratio",
       R"code(If true, bboxes returned values as expressed as ratio w.r.t. to the image width and height. Default: False)code",
       false)
+  .AddOptionalArg("save_img_ids",
+      R"code(If true, image IDs will also be returned. Default: False)code",
+      false)
+  .AdditionalOutputsFn([](const OpSpec& spec) {
+    return static_cast<int>(spec.GetArgument<bool>("img_ids"));
+  })
   .AddParent("LoaderBase");
 
 

--- a/dali/pipeline/operators/reader/coco_reader_op.cc
+++ b/dali/pipeline/operators/reader/coco_reader_op.cc
@@ -313,7 +313,7 @@ Tensor (`m` * `[x, y, w, h] or `m` * [left, top, right, bottom]`) and labels as 
       R"code(If true, image IDs will also be returned. Default: False)code",
       false)
   .AdditionalOutputsFn([](const OpSpec& spec) {
-    return static_cast<int>(spec.GetArgument<bool>("img_ids"));
+    return static_cast<int>(spec.GetArgument<bool>("save_img_ids"));
   })
   .AddParent("LoaderBase");
 

--- a/dali/pipeline/operators/reader/coco_reader_op.h
+++ b/dali/pipeline/operators/reader/coco_reader_op.h
@@ -41,10 +41,11 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
   : DataReader<CPUBackend, ImageLabelWrapper>(spec),
     annotations_filename_(spec.GetRepeatedArgument<std::string>("annotations_file")),
     ltrb_(spec.GetArgument<bool>("ltrb")),
-    ratio_(spec.GetArgument<bool>("ratio")) {
+    ratio_(spec.GetArgument<bool>("ratio")),
+    save_img_ids_(spec.GetArgument<bool>("save_img_ids")) {
     ParseAnnotationFiles();
     loader_.reset(new FileLoader(spec, image_id_pairs_));
-    parser_.reset(new COCOParser(spec, annotations_multimap_));
+    parser_.reset(new COCOParser(spec, annotations_multimap_, save_img_ids_));
   }
 
   void RunImpl(SampleWorkspace* ws, const int i) override {
@@ -68,6 +69,7 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
   std::vector<std::pair<std::string, int>> image_id_pairs_;
   bool ltrb_;
   bool ratio_;
+  bool save_img_ids_;
   USE_READER_OPERATOR_MEMBERS(CPUBackend, ImageLabelWrapper);
 };
 

--- a/dali/pipeline/operators/reader/parser/coco_parser.h
+++ b/dali/pipeline/operators/reader/parser/coco_parser.h
@@ -52,7 +52,7 @@ using AnnotationMap = std::multimap<int, Annotation>;
 
 class COCOParser: public Parser<ImageLabelWrapper> {
  public:
-  explicit COCOParser(const OpSpec& spec, const AnnotationMap& annotations_multimap, const bool save_img_ids)
+  explicit COCOParser(const OpSpec& spec, const AnnotationMap& annotations_multimap, const bool& save_img_ids)
     : Parser<ImageLabelWrapper>(spec),
     annotations_multimap_(annotations_multimap),
     save_img_ids_(save_img_ids) {}

--- a/dali/pipeline/operators/reader/parser/coco_parser.h
+++ b/dali/pipeline/operators/reader/parser/coco_parser.h
@@ -52,7 +52,8 @@ using AnnotationMap = std::multimap<int, Annotation>;
 
 class COCOParser: public Parser<ImageLabelWrapper> {
  public:
-  explicit COCOParser(const OpSpec& spec, const AnnotationMap& annotations_multimap, const bool& save_img_ids)
+  explicit COCOParser(const OpSpec& spec, const AnnotationMap& annotations_multimap,
+                      const bool& save_img_ids)
     : Parser<ImageLabelWrapper>(spec),
     annotations_multimap_(annotations_multimap),
     save_img_ids_(save_img_ids) {}

--- a/dali/pipeline/operators/reader/parser/coco_parser.h
+++ b/dali/pipeline/operators/reader/parser/coco_parser.h
@@ -101,7 +101,7 @@ class COCOParser: public Parser<ImageLabelWrapper> {
   }
 
   const AnnotationMap& annotations_multimap_;
-  const bool& save_img_ids_;
+  const bool save_img_ids_;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/resize/resize.cc
+++ b/dali/pipeline/operators/resize/resize.cc
@@ -33,7 +33,10 @@ DALI_SCHEMA(ResizeAttr)
       "If the `resize_x` is left at 0, then the op will keep "
       "the aspect ratio of the original image.", 0.f, true)
   .AddOptionalArg("resize_shorter", "The length of the shorter dimension of the resized image. "
-      "This option is mutually exclusive with `resize_x` and `resize_y`. "
+      "This option is mutually exclusive with `resize_longer`, `resize_x` and `resize_y`. "
+      "The op will keep the aspect ratio of the original image.", 0.f, true)
+  .AddOptionalArg("resize_longer", "The length of the longer dimension of the resized image. "
+      "This option is mutually exclusive with `resize_shorter`,`resize_x` and `resize_y`. "
       "The op will keep the aspect ratio of the original image.", 0.f, true);
 
 DALI_SCHEMA(Resize)
@@ -119,8 +122,8 @@ void Resize<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
 
       attr_output->Resize(Dims{2});
       int *t = attr_output->mutable_data<int>();
-      t[0] = meta.rsz_h;
-      t[1] = meta.rsz_w;
+      t[0] = meta.H;
+      t[1] = meta.W;
     }
 }
 

--- a/dali/pipeline/operators/resize/resize.cu
+++ b/dali/pipeline/operators/resize/resize.cu
@@ -155,8 +155,8 @@ void Resize<GPUBackend>::RunImpl(DeviceWorkspace *ws, const int idx) {
 
       for (size_t i = 0; i < input.ntensor(); ++i) {
         int *t = attr_output_cpu.mutable_tensor<int>(i);
-        t[0] = sizes(output_t).data()[i].height;
-        t[1] = sizes(output_t).data()[i].width;
+        t[0] = sizes(input_t).data()[i].height;
+        t[1] = sizes(input_t).data()[i].width;
       }
       ws->Output<GPUBackend>(outputs_per_idx_ * idx + 1)->Copy(attr_output_cpu, ws->stream());
     }

--- a/dali/pipeline/operators/resize/resize_test.cc
+++ b/dali/pipeline/operators/resize/resize_test.cc
@@ -25,14 +25,20 @@ namespace dali {
 static double testEps[] = {     //     TEST:
                     0.7, 1.8,   // ResizeShorter_LINEAR
                     2.1, 4.2,   // ResizeShorter_A_LINEAR
+                    1.7, 3.8,   // ResizeLonger_LINEAR
+                    3.1, 6.2,   // ResizeLonger_A_LINEAR
                     2.8, 5.6,   // ResizeXY_LINEAR
                     1.8, 3.4,   // ResizeXY_A_LINEAR
                     1.5, 2.9,   // ResizeShorter_NN
                     3.4, 5.3,   // ResizeShorter_A_NN
+                    2.5, 3.9,   // ResizeLonger_NN
+                    4.4, 6.3,   // ResizeLonger_A_NN
                     3.4, 5.3,   // ResizeXY_NN
                     2.4, 4.1,   // ResizeXY_A_NN
                     0.8, 2.1,   // ResizeShorter_CUBIC
                     2.4, 4.9,   // ResizeShorter_A_CUBIC
+                    1.8, 4.1,   // ResizeLonger_CUBIC
+                    3.4, 6.9,   // ResizeLonger_A_CUBIC
                     3.2, 6.4,   // ResizeXY_CUBIC
                     2.0, 4.0,   // ResizeXY_A_CUBIC
 };
@@ -57,14 +63,20 @@ TYPED_TEST_CASE(ResizeTest, Types);
 typedef enum {
   t_ResizeShorter_LINEAR,
   t_ResizeShorter_A_LINEAR,
+  t_ResizeLonger_LINEAR,
+  t_ResizeLonger_A_LINEAR,
   t_ResizeXY_LINEAR,
   t_ResizeXY_A_LINEAR,
   t_ResizeShorter_NN,
   t_ResizeShorter_A_NN,
+  t_ResizeLonger_NN,
+  t_ResizeLonger_A_NN,
   t_ResizeXY_NN,
   t_ResizeXY_A_NN,
   t_ResizeShorter_CUBIC,
   t_ResizeShorter_A_CUBIC,
+  t_ResizeLonger_CUBIC,
+  t_ResizeLonger_A_CUBIC,
   t_ResizeXY_CUBIC,
   t_ResizeXY_A_CUBIC
 } test_ID;
@@ -109,18 +121,24 @@ enum {
 
 TYPED_TESTS(ResizeShorter,   LINEAR, .AddArg("resize_shorter", 480.f))
 TYPED_TESTS(ResizeShorter_A, LINEAR, .AddArg("resize_shorter", 224.f))
+TYPED_TESTS(ResizeLonger,    LINEAR, .AddArg("resize_longer",  640.f))
+TYPED_TESTS(ResizeLonger_A,  LINEAR, .AddArg("resize_longer",  960.f))
 TYPED_TESTS(ResizeXY,        LINEAR, .AddArg("resize_x", 224.f)         \
                                      .AddArg("resize_y", 224.f))
 TYPED_TESTS(ResizeXY_A,      LINEAR, .AddArg("resize_x", 240.f)         \
                                      .AddArg("resize_y", 480.f))
 TYPED_TESTS(ResizeShorter,       NN, .AddArg("resize_shorter", 480.f))
 TYPED_TESTS(ResizeShorter_A,     NN, .AddArg("resize_shorter", 224.f))
+TYPED_TESTS(ResizeLonger,        NN, .AddArg("resize_longer",  640.f))
+TYPED_TESTS(ResizeLonger_A,      NN, .AddArg("resize_longer",  960.f))
 TYPED_TESTS(ResizeXY,            NN, .AddArg("resize_x", 224.f)         \
                                      .AddArg("resize_y", 224.f))
 TYPED_TESTS(ResizeXY_A,          NN, .AddArg("resize_x", 240.f)         \
                                      .AddArg("resize_y", 480.f))
 TYPED_TESTS(ResizeShorter,    CUBIC, .AddArg("resize_shorter", 480.f))
 TYPED_TESTS(ResizeShorter_A,  CUBIC, .AddArg("resize_shorter", 224.f))
+TYPED_TESTS(ResizeLonger,     CUBIC, .AddArg("resize_longer",  640.f))
+TYPED_TESTS(ResizeLonger_A,   CUBIC, .AddArg("resize_longer",  960.f))
 TYPED_TESTS(ResizeXY,         CUBIC, .AddArg("resize_x", 224.f)         \
                                      .AddArg("resize_y", 224.f))
 TYPED_TESTS(ResizeXY_A,       CUBIC, .AddArg("resize_x", 240.f)         \

--- a/dali/test/dali_test_resize.h
+++ b/dali/test/dali_test_resize.h
@@ -41,14 +41,15 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
 
       resize_a = spec.GetArgument<float>("resize_x");
       warp_resize = resize_a != 0;
-      if (warp_resize)
+      if (warp_resize) {
         resize_b = spec.GetArgument<float>("resize_y");
-      else
+      } else {
         resize_a = spec.GetArgument<float>("resize_shorter");
         if (resize_a == 0) {
           resize_a = spec.GetArgument<float>("resize_longer");
           resize_shorter = false;
         }
+      }
     }
 
     int crop_h = 0, crop_w = 0;


### PR DESCRIPTION
--Add optional resize_longer argument to resize op. 
--Extend COCOReader op to optionally return img_ids. 
--Add optional min_canvas_size argument to paste op.
--Change behavior of resize save_attrs to return original image dimensions before resizing instead of after resize

Signed-off-by: Prethvi Kashinkunti <pkashinkunti@nvidia.com>