### PR TITLE
Change TensorReference to EdgeReference for code clarity

### DIFF
--- a/dali/python/nvidia/dali/__init__.py
+++ b/dali/python/nvidia/dali/__init__.py
@@ -17,7 +17,7 @@ from pkg_resources import get_distribution, DistributionNotFound
 
 from . import ops
 from . import pipeline
-from . import tensor
+from . import edge
 from . import tfrecord
 from . import types
 from . import plugin_manager

--- a/dali/python/nvidia/dali/edge.py
+++ b/dali/python/nvidia/dali/edge.py
@@ -17,7 +17,7 @@ import nvidia.dali.backend
 from nvidia.dali.backend import TensorCPU
 from nvidia.dali.backend import TensorListCPU
 
-class TensorReference(object):
+class EdgeReference(object):
     def __init__(self, name, device="cpu", source=None):
         self.name = name
         self.device = device
@@ -27,7 +27,7 @@ class TensorReference(object):
     # of a tensor, we keep the source argument the same so that
     # the pipeline can backtrack through the user-defined graph
     def cpu(self):
-        return TensorReference(self.name, "cpu", self.source)
+        return EdgeReference(self.name, "cpu", self.source)
 
     def gpu(self):
-        return TensorReference(self.name, "gpu", self.source)
+        return EdgeReference(self.name, "gpu", self.source)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -17,7 +17,7 @@ import sys
 import copy
 from itertools import count
 from nvidia.dali import backend as b
-from nvidia.dali.tensor import TensorReference
+from nvidia.dali.edge import EdgeReference
 from nvidia.dali.types import _type_name_convert_to_string, _type_convert_value, DALIDataType
 from future.utils import with_metaclass
 
@@ -95,12 +95,12 @@ class _OperatorInstance(object):
             self._name = '__' + type(op).__name__ + "_" + str(self._counter.id)
         # Add inputs
         if inputs:
-            if isinstance(inputs[0], TensorReference):
+            if isinstance(inputs[0], EdgeReference):
                 for inp in inputs:
-                    if not isinstance(inp, TensorReference):
+                    if not isinstance(inp, EdgeReference):
                         raise TypeError(
                             ("Expected inputs of type " +
-                            "TensorReference. Received " +
+                            "EdgeReference. Received " +
                             "input type {}.")
                             .format(type(inp).__name__))
                     self._spec.AddInput(inp.name, inp.device)
@@ -111,7 +111,7 @@ class _OperatorInstance(object):
                         if not isinstance(inp, list):
                             raise TypeError(
                                 ("Expected inputs of type list of " +
-                                "TensorReference. Received " +
+                                "EdgeReference. Received " +
                                 "input type {}.")
                                 .format(type(inp).__name__))
                         if len(inp) != length:
@@ -121,26 +121,26 @@ class _OperatorInstance(object):
                                     "({}). Received list of " +
                                     "length {}.")
                                     .format(length, len(inp)))
-                        if not isinstance(inp[i], TensorReference):
+                        if not isinstance(inp[i], EdgeReference):
                             raise TypeError(
                                 ("Expected inputs of type " +
-                                "TensorReference. Received " +
+                                "EdgeReference. Received " +
                                 "input type {}.")
                                 .format(type(inp[i]).__name__))
                         self._spec.AddInput(inp[i].name, inp[i].device)
                 self._spec.AddArg("num_input_sets", length)
             else:
                 raise TypeError(
-                    ("Expected inputs of type TensorReference or list of " +
-                    "TensorReference. Received input type {}")
+                    ("Expected inputs of type EdgeReference or list of " +
+                    "EdgeReference. Received input type {}")
                     .format(type(inputs[0]).__name__))
         # Argument inputs
         for k in sorted(kwargs.keys()):
             if k not in ["name"]:
-                if not isinstance(kwargs[k], TensorReference):
+                if not isinstance(kwargs[k], EdgeReference):
                     raise TypeError(
                             ("Expected inputs of type " +
-                            "TensorReference. Received " +
+                            "EdgeReference. Received " +
                             "input type {}")
                             .format(type(kwargs[k]).__name__))
                 self._spec.AddArgumentInput(k, kwargs[k].name)
@@ -160,7 +160,7 @@ class _OperatorInstance(object):
 
         for i in range(num_output):
             t_name = type(self._op).__name__ + "_id_" + str(self.id) + "_output_" + str(i)
-            t = TensorReference(t_name, output_device, self)
+            t = EdgeReference(t_name, output_device, self)
             self._spec.AddOutput(t.name, t.device)
             self.append_output(t)
 
@@ -322,7 +322,7 @@ class TFRecordReader(with_metaclass(_DaliOperatorMeta, object)):
         features = []
         for i, (feature_name, feature) in enumerate(self._features.items()):
             t_name = "_TFRecordReader" + "_id_" + str(op_instance.id) + "_output_" + str(i)
-            t = TensorReference(t_name, self._device, op_instance)
+            t = EdgeReference(t_name, self._device, op_instance)
             op_instance.spec.AddOutput(t.name, t.device)
             op_instance.append_output(t)
             outputs[feature_name] = t

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -15,7 +15,7 @@
 #pylint: disable=no-member
 from collections import deque
 from nvidia.dali import backend as b
-from nvidia.dali import tensor as nt
+from nvidia.dali import edge
 
 class Pipeline(object):
     """Pipeline class encapsulates all data required to define and run
@@ -137,25 +137,25 @@ class Pipeline(object):
             outputs = (outputs,)
 
         for output in outputs:
-            if not isinstance(output, nt.TensorReference):
+            if not isinstance(output, edge.EdgeReference):
                 raise TypeError(
                     ("Expected outputs of type "
-                    "TensorReference. Received "
+                    "EdgeReference. Received "
                     "output type {}")
                     .format(type(output).__name__)
                 )
 
         # Backtrack to construct the graph
         op_ids = set()
-        tensors = deque(outputs)
+        edges = deque(outputs)
         ops = []
-        while tensors:
-            current_tensor = tensors.popleft()
-            source_op = current_tensor.source
+        while edges:
+            current_edge = edges.popleft()
+            source_op = current_edge.source
             if source_op is None:
                 raise RuntimeError(
                     "Pipeline encountered "
-                    "Tensor with no source op.")
+                    "Edge with no source op.")
 
             # To make sure we don't double count ops in
             # the case that they produce more than one
@@ -173,19 +173,19 @@ class Pipeline(object):
                 # when adding to the backend pipeline
                 ops.remove(source_op)
                 ops.append(source_op)
-            for tensor in source_op.inputs:
-                if isinstance(tensor, list):
-                    for t in tensor:
-                        tensors.append(t)
+            for edge in source_op.inputs:
+                if isinstance(edge, list):
+                    for edge in edge:
+                        edges.append(e)
                 else:
-                    tensors.append(tensor)
+                    edges.append(edge)
 
         # Add the ops to the graph and build the backend
         while ops:
             op = ops.pop()
             self._pipe.AddOperator(op.spec, op.name)
         self._prepared = True
-        self._names_and_devices = [(t.name, t.device) for t in outputs]
+        self._names_and_devices = [(e.name, e.device) for e in outputs]
 
     def build(self):
         """Build the pipeline.
@@ -207,20 +207,20 @@ class Pipeline(object):
         operator."""
         if not self._built:
             raise RuntimeError("Pipeline must be built first.")
-        if not isinstance(ref, nt.TensorReference):
+        if not isinstance(ref, edge.EdgeReference):
             raise TypeError(
                 ("Expected argument one to "
-                "be TensorReference. "
+                "be EdgeReference. "
                 "Received output type {}")
                 .format(type(ref).__name__)
             )
         if isinstance(data, list):
             inputs = []
             for datum in data:
-                inputs.append(nt.TensorCPU(datum))
+                inputs.append(edge.TensorCPU(datum))
             self._pipe.SetExternalTensorInput(ref.name, inputs)
         else:
-            inp = nt.TensorListCPU(data)
+            inp = edge.TensorListCPU(data)
             self._pipe.SetExternalTLInput(ref.name, inp)
 
     def _run_cpu(self):
@@ -336,7 +336,7 @@ class Pipeline(object):
         """This function is defined by the user to construct the
         graph of operations for their pipeline.
 
-        It returns a list of output `TensorReference`."""
+        It returns a list of output `EdgeReference`."""
         raise NotImplementedError
 
     def iter_setup(self):

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -15,7 +15,7 @@
 #pylint: disable=no-member
 from collections import deque
 from nvidia.dali import backend as b
-from nvidia.dali import edge
+from nvidia.dali import edge as Edge
 
 class Pipeline(object):
     """Pipeline class encapsulates all data required to define and run
@@ -137,7 +137,7 @@ class Pipeline(object):
             outputs = (outputs,)
 
         for output in outputs:
-            if not isinstance(output, edge.EdgeReference):
+            if not isinstance(output, Edge.EdgeReference):
                 raise TypeError(
                     ("Expected outputs of type "
                     "EdgeReference. Received "
@@ -175,7 +175,7 @@ class Pipeline(object):
                 ops.append(source_op)
             for edge in source_op.inputs:
                 if isinstance(edge, list):
-                    for edge in edge:
+                    for e in edge:
                         edges.append(e)
                 else:
                     edges.append(edge)
@@ -207,7 +207,7 @@ class Pipeline(object):
         operator."""
         if not self._built:
             raise RuntimeError("Pipeline must be built first.")
-        if not isinstance(ref, edge.EdgeReference):
+        if not isinstance(ref, Edge.EdgeReference):
             raise TypeError(
                 ("Expected argument one to "
                 "be EdgeReference. "
@@ -217,10 +217,10 @@ class Pipeline(object):
         if isinstance(data, list):
             inputs = []
             for datum in data:
-                inputs.append(edge.TensorCPU(datum))
+                inputs.append(Edge.TensorCPU(datum))
             self._pipe.SetExternalTensorInput(ref.name, inputs)
         else:
-            inp = edge.TensorListCPU(data)
+            inp = Edge.TensorListCPU(data)
             self._pipe.SetExternalTLInput(ref.name, inp)
 
     def _run_cpu(self):


### PR DESCRIPTION
`TensorReference` is often mistaken for `Tensor` and `TensorList`.

Change the name for code readibility.