### PR TITLE
Remove BUILD_ID from sdist package name as it is interpreted as part …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,5 @@ RUN pip wheel -v dali/python \
 
 RUN pushd dali/python/tf_plugin/ && \
     python setup.py sdist && \
-    version_str=$(basename dist/nvidia-dali-tf-plugin-*.tar.gz | sed -n "s/nvidia-dali-tf-plugin-\(\S*\).tar.gz$/\1/p") && \
-    mv dist/nvidia-dali-tf-plugin-${version_str}.tar.gz /wheelhouse/nvidia-dali-tf-plugin-${version_str}-${NVIDIA_BUILD_ID}.tar.gz && \
+    mv dist/nvidia-dali-tf-plugin-*.tar.gz /wheelhouse/ && \
     popd


### PR DESCRIPTION
…of the version by pip

Signed-off-by: Joaquin Anton <janton@nvidia.com>