### PR TITLE
Remove opencv package from TensorFlow test

### DIFF
--- a/qa/L1_tensorflow-dali_test/test.sh
+++ b/qa/L1_tensorflow-dali_test/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-pip_packages="opencv-python"
+pip_packages=""
 
 pushd ../..
 


### PR DESCRIPTION
OpenCV is not needed in TF test and forces to install an older version
of numpy, different than TF is using

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>