### PR TITLE
Fix CPU NN resize and WarpAffine.

### DIFF
--- a/dali/kernels/tensor_view.h
+++ b/dali/kernels/tensor_view.h
@@ -107,7 +107,8 @@ struct TensorViewBase {
 
   /// @brief Utility to calculate pointer to element at given coordinates
   template <typename Offset>
-  DataType *operator()(const Offset &pos) const {
+  typename std::enable_if<!std::is_integral<Offset>::value, DataType *>::type
+  operator()(const Offset &pos) const {
     return data + CalcOffset(shape, pos);
   }
 

--- a/dali/pipeline/operators/displacement/warpaffine.h
+++ b/dali/pipeline/operators/displacement/warpaffine.h
@@ -35,20 +35,20 @@ class WarpAffineAugment {
   template <typename T>
   DISPLACEMENT_IMPL
   Point<T> operator()(int h, int w, int c, int H, int W, int C) {
-    T hp = h;
-    T wp = w;
+    float hp = h + 0.5f;
+    float wp = w + 0.5f;
     if (use_image_center) {
       hp -= H/2.0f;
       wp -= W/2.0f;
     }
-    T newX = param.matrix[0] * wp + param.matrix[1] * hp + param.matrix[2];
-    T newY = param.matrix[3] * wp + param.matrix[4] * hp + param.matrix[5];
+    float newX = param.matrix[0] * wp + param.matrix[1] * hp + param.matrix[2];
+    float newY = param.matrix[3] * wp + param.matrix[4] * hp + param.matrix[5];
     if (use_image_center) {
       newX += W/2.0f;
       newY += H/2.0f;
     }
 
-    return CreatePointLimited(newX, newY, W, H);
+    return CreatePointLimited<T>(newX, newY, W, H);
   }
 
   void Cleanup() {}
@@ -64,6 +64,10 @@ class WarpAffineAugment {
     GetSingleOrRepeatedArg(spec, &tmp, "matrix", size);
     for (int i = 0; i < size; ++i) {
       p->matrix[i] = tmp[i];
+    }
+    if (spec.GetArgument<DALIInterpType>("interp_type") != DALI_INTERP_NN) {
+      p->matrix[2] -= 0.5f;
+      p->matrix[5] -= 0.5f;
     }
   }
 

--- a/dali/pipeline/operators/resize/resize.cc
+++ b/dali/pipeline/operators/resize/resize.cc
@@ -12,11 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/pipeline/operators/resize/resize.h"
 #include <opencv2/opencv.hpp>
+#include <algorithm>
+#include "dali/pipeline/operators/resize/resize.h"
 #include "dali/util/ocv.h"
+#include "dali/kernels/static_switch.h"
+#include "dali/kernels/kernel.h"
 
 namespace dali {
+
+using kernels::InTensorCPU;
+using kernels::OutTensorCPU;
 
 DALI_SCHEMA(ResizeAttr)
   .AddOptionalArg("image_type",
@@ -24,6 +30,8 @@ DALI_SCHEMA(ResizeAttr)
   .AddOptionalArg("interp_type",
       R"code(Type of interpolation used.)code",
       DALI_INTERP_LINEAR)
+  .AddOptionalArg("align_corners", "If true, then the image corners are aligned"
+      " and corner pixel centers are resampled", false)
   .AddOptionalArg("resize_x", "The length of the X dimension of the resized image. "
       "This option is mutually exclusive with `resize_shorter`. "
       "If the `resize_y` is left at 0, then the op will keep "
@@ -76,8 +84,9 @@ Resize<CPUBackend>::Resize(const OpSpec &spec) : Operator<CPUBackend>(spec), Res
   per_sample_meta_.resize(num_threads_);
   save_attrs_ = spec_.HasArgument("save_attrs");
   outputs_per_idx_ = save_attrs_ ? 2 : 1;
+  align_corners_ = spec_.GetArgument<bool>("align_corners");
 
-// Checking the value of interp_type_
+  // Checking the value of interp_type_
   int ocv_interp_type;
   DALI_ENFORCE(OCVInterpForDALIInterp(interp_type_, &ocv_interp_type) == DALISuccess,
                "Unknown interpolation type");
@@ -86,6 +95,148 @@ Resize<CPUBackend>::Resize(const OpSpec &spec) : Operator<CPUBackend>(spec), Res
 template <>
 void Resize<CPUBackend>::SetupSharedSampleParams(SampleWorkspace *ws) {
   per_sample_meta_[ws->thread_idx()] = GetTransfomMeta(ws, spec_);
+}
+
+template <int channels>
+void ResizeAlignCornersNearest(
+    const OutTensorCPU<uint8_t, 3> &out,
+    const InTensorCPU<uint8_t, 3> &in) {
+  DALI_ENFORCE(in.shape[2] == channels, "Unexpected number of channels");
+  DALI_ENFORCE(out.shape[2] == channels, "Unexpected number of channels");
+  int h = out.shape[0];
+  int w = out.shape[1];
+  int srch = in.shape[0];
+  int srcw = in.shape[1];
+
+  std::vector<int> srcx(channels*w);
+  for (int x = 0; x < w; x++) {
+    int sx = (x + 0.5f) * srcw / w;
+    if (sx < 0) x = 0;
+    else if (sx >= srcw) sx = srcw - 1;
+    for (int c = 0; c < channels; c++)
+      srcx[channels*x + c] = channels*sx + c;
+  }
+
+  for (int y = 0; y < h; y++) {
+    int sy = (y + 0.5f) * srch / h;
+    if (sy < 0) y = 0;
+    else if (sy >= srch) sy = srch - 1;
+
+    auto *row_out = out(y);
+    auto *row_in = in(sy);
+    for (int x = 0; x < channels*w; x++) {
+      row_out[x] = row_in[srcx[x]];
+    }
+  }
+}
+
+template <int channels>
+void ResizeAlignCornersLinear(
+    const OutTensorCPU<uint8_t, 3> &out,
+    const InTensorCPU<uint8_t, 3> &in) {
+  DALI_ENFORCE(in.shape[2] == channels, "Unexpected number of channels");
+  DALI_ENFORCE(out.shape[2] == channels, "Unexpected number of channels");
+
+  int h = out.shape[0];
+  int w = out.shape[1];
+  int srch = in.shape[0];
+  int srcw = in.shape[1];
+
+  std::vector<int> srcx(2*w), srcy(2*h);
+  std::vector<float> inter_x(w);
+  std::vector<float> inter_y(h);
+
+  std::vector<float> tmpbuf(2*w*channels);
+  struct tmprow {
+    int y;
+    float *data;
+  };
+  tmprow tmp[2] = {
+    { -1, &tmpbuf[0] },
+    { -1, &tmpbuf[w*channels] }
+  };
+
+  for (int x = 0; x < w; x++) {
+    float fx = (x + 0.5f) * srcw / w  - 0.5f;
+    int sx0 = std::max<int>(0, std::floor(fx));
+    int sx1 = std::min<int>(srcw-1, std::ceil(fx));
+    inter_x[x] = fx - sx0;
+    srcx[2*x+0] = sx0 * channels;
+    srcx[2*x+1] = sx1 * channels;
+  }
+
+  for (int y = 0; y < h; y++) {
+    float fy = (y + 0.5f) * srch / h  - 0.5f;
+    int sy0 = std::max<int>(0, std::floor(fy));
+    int sy1 = std::min<int>(srch-1, std::ceil(fy));
+    inter_y[y] = fy - sy0;
+    srcy[2*y+0] = sy0;
+    srcy[2*y+1] = sy1;
+  }
+
+  auto interpX = [&](float *buf, int y) {
+    auto *row = in(y);
+    for (int x = 0, k = 0; x < w; x++) {
+      auto *in0 = &row[srcx[2*x]];
+      auto *in1 = &row[srcx[2*x+1]];
+      float q = inter_x[x];
+      for (int c = 0; c < channels; c++, k++) {
+        buf[k] = in0[c] + (in1[c] - in0[c]) * q;
+      }
+    }
+  };
+
+  for (int y = 0; y < h; y++) {
+    int sy0 = srcy[2*y];
+    int sy1 = srcy[2*y+1];
+
+    auto *src0 = in(sy0);
+    auto *src1 = in(sy1);
+
+    float *row0, *row1;
+    if (sy0 == tmp[0].y) {
+      row0 = tmp[0].data;
+    } else if (sy0 == tmp[1].y) {
+      row0 = tmp[1].data;
+    } else {
+      int tmpidx = (sy1 == tmp[0].y) ? 1 : 0;
+      row0 = tmp[tmpidx].data;
+      tmp[tmpidx].y = sy0;
+      interpX(row0, sy0);
+    }
+
+    if (sy1 == tmp[0].y) {
+      row1 = tmp[0].data;
+    } else if (sy1 == tmp[1].y) {
+      row1 = tmp[1].data;
+    } else {
+      int tmpidx = (sy0 == tmp[0].y) ? 1 : 0;
+      row1 = tmp[tmpidx].data;
+      tmp[tmpidx].y = sy1;
+      interpX(row1, sy1);
+    }
+
+    auto *row = out(y);
+    float q = inter_y[y];
+    for (int x = 0; x < w * channels; x++) {
+      row[x] = row0[x] + (row1[x] - row0[x]) * q;
+    }
+  }
+}
+
+template <int channels>
+void ResizeAlignCorners(
+    const OutTensorCPU<uint8_t, 3> &out,
+    const InTensorCPU<uint8_t, 3> &in,
+    DALIInterpType interp) {
+  DALI_ENFORCE(in.shape[2] == channels, "Unexpected number of channels");
+  DALI_ENFORCE(out.shape[2] == channels, "Unexpected number of channels");
+  if (interp == DALI_INTERP_LINEAR)
+    ResizeAlignCornersLinear<channels>(out, in);
+  else if (interp == DALI_INTERP_NN)
+    ResizeAlignCornersNearest<channels>(out, in);
+  else
+    DALI_FAIL("Unsupported interpolation type");
 }
 
 template <>
@@ -109,14 +260,22 @@ void Resize<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
   const auto W = input_shape[1];
   const auto C = input_shape[2];
 
-  const auto cvImgType = C == 3? CV_8UC3 : CV_8UC1;
-  cv::Mat inputMat(H, W, cvImgType, const_cast<unsigned char*>(pImgInp));
+  if (align_corners_) {
+    InTensorCPU<uint8_t, 3> in(pImgInp, { H, W, C });
+    OutTensorCPU<uint8_t, 3> out(pImgOut, { meta.rsz_h, meta.rsz_w, meta.C });
+    VALUE_SWITCH(C, channels, (1, 2, 3, 4),
+      (ResizeAlignCorners<channels>(out, in, interp_type_);)
+    , DALI_FAIL("Unsupported number of channels: " + std::to_string(C)));
+  } else {
+    const auto cvImgType = C == 3? CV_8UC3 : CV_8UC1;
+    cv::Mat inputMat(H, W, cvImgType, const_cast<unsigned char*>(pImgInp));
 
-  // perform the resize
-  cv::Mat rsz_img(meta.rsz_h, meta.rsz_w, cvImgType, const_cast<unsigned char*>(pImgOut));
-  int ocv_interp_type;
-  OCVInterpForDALIInterp(interp_type_, &ocv_interp_type);
-  cv::resize(inputMat, rsz_img, cv::Size(meta.rsz_w, meta.rsz_h), 0, 0, ocv_interp_type);
+    // perform the resize
+    cv::Mat rsz_img(meta.rsz_h, meta.rsz_w, cvImgType, const_cast<unsigned char*>(pImgOut));
+    int ocv_interp_type;
+    OCVInterpForDALIInterp(interp_type_, &ocv_interp_type);
+    cv::resize(inputMat, rsz_img, cv::Size(meta.rsz_w, meta.rsz_h), 0, 0, ocv_interp_type);
+  }
   if (save_attrs_) {
       auto *attr_output = ws->Output<CPUBackend>(outputs_per_idx_ * idx + 1);
 

--- a/dali/pipeline/operators/resize/resize.h
+++ b/dali/pipeline/operators/resize/resize.h
@@ -94,7 +94,7 @@ class Resize : public Operator<Backend>, protected ResizeAttr {
 
   vector<NppiPoint> *resizeParam_ = nullptr;
   USE_OPERATOR_MEMBERS();
-  bool save_attrs_;
+  bool save_attrs_, align_corners_;
   int outputs_per_idx_;
 };
 

--- a/dali/pipeline/operators/resize/resize.h
+++ b/dali/pipeline/operators/resize/resize.h
@@ -94,7 +94,7 @@ class Resize : public Operator<Backend>, protected ResizeAttr {
 
   vector<NppiPoint> *resizeParam_ = nullptr;
   USE_OPERATOR_MEMBERS();
-  bool save_attrs_, align_corners_;
+  bool save_attrs_, antialias_;
   int outputs_per_idx_;
 };
 


### PR DESCRIPTION
Add CPU Resize preserving image corners (not corner pixels!).
Fix WarpAffine to properly handle pixel centers.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>