### PR TITLE
Per-operator buffer presizing.

### DIFF
--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -211,17 +211,6 @@ class Buffer {
   inline void set_type(const TypeInfo &new_type) {
     DALI_ENFORCE(IsValidType(new_type), "new_type must be valid type.");
     if (new_type == type_) return;
-
-    if (!IsValidType(type_)) {
-      // If the buffer has no type, set the type to the
-      // calling type and allocate the buffer
-      DALI_ENFORCE((data_ == nullptr) || shares_data_,
-          "Buffer has no type and does not share data, "
-          "data_ should be nullptr.");
-      DALI_ENFORCE((num_bytes_ == 0) || shares_data_,
-          "Buffer has no type and does not share data, "
-          "num_bytes_ should be 0.");
-    }
     type_ = new_type;
 
     size_t new_num_bytes = size_ * type_.size();
@@ -248,6 +237,13 @@ class Buffer {
 
     // If we were sharing data, we aren't anymore
     shares_data_ = false;
+  }
+
+  inline void free() {
+    if (!shares_data_) {
+      data_.reset();
+      num_bytes_ = 0;
+    }
   }
 
   /**
@@ -279,16 +275,6 @@ class Buffer {
     DALI_ENFORCE(new_size >= 0, "Input size less than zero not supported.");
 
     if (!IsValidType(type_)) {
-      // If the type has not been set yet, we just set the size of the
-      // buffer and do not allocate any memory. Any previous size is
-      // overwritten.
-      DALI_ENFORCE((data_ == nullptr) || shares_data_,
-          "Buffer has no type and does not share data, "
-          "data_ should be nullptr.");
-      DALI_ENFORCE((num_bytes_ == 0) || shares_data_,
-          "Buffer has no type and does not share data, "
-          "num_bytes_ should be 0.");
-
       size_ = new_size;
       return;
     }

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -15,12 +15,13 @@
 #ifndef DALI_PIPELINE_DATA_BUFFER_H_
 #define DALI_PIPELINE_DATA_BUFFER_H_
 
-#include <limits>
-#include <numeric>
 #include <functional>
-#include <vector>
-#include <string>
+#include <limits>
 #include <memory>
+#include <numeric>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 #include "dali/common.h"
 #include "dali/error_handling.h"
@@ -64,6 +65,9 @@ inline string ShapeString(vector<Index> shape) {
  * current type, but only re-allocates memory if it does not have enough bytes
  * of allocated storage to store the number of elements in the buffer with the
  * new data type size.
+ *
+ * Buffers should be used to store POD types only. No construction or
+ * destruction is provided, only raw memory allocation.
  */
 template <typename Backend>
 class Buffer {
@@ -223,20 +227,27 @@ class Buffer {
     size_t new_num_bytes = size_ * type_.size();
     if (new_num_bytes > num_bytes_) {
       new_num_bytes *= alloc_mult;
+      reserve(new_num_bytes);
+    }
+  }
 
-      // re-allocating: get the device
-      if (std::is_same<Backend, GPUBackend>::value) {
-        CUDA_CALL(cudaGetDevice(&device_));
-      }
-      data_.reset(Backend::New(new_num_bytes, pinned_), std::bind(
-              &Buffer<Backend>::DeleterHelper,
-              this, std::placeholders::_1,
-              type_, size_, device_, pinned_));
-      num_bytes_ = new_num_bytes;
-      shares_data_ = false;
+  inline void reserve(size_t new_num_bytes) {
+    if (new_num_bytes <= num_bytes_)
+      return;
+
+    // re-allocating: get the device
+    if (std::is_same<Backend, GPUBackend>::value) {
+      CUDA_CALL(cudaGetDevice(&device_));
     }
 
-    type_.template Construct<Backend>(data_.get(), size_);
+    data_.reset(
+      Backend::New(new_num_bytes, pinned_),
+      std::bind(FreeMemory, std::placeholders::_1, new_num_bytes, device_, pinned_));
+
+    num_bytes_ = new_num_bytes;
+
+    // If we were sharing data, we aren't anymore
+    shares_data_ = false;
   }
 
   /**
@@ -244,10 +255,10 @@ class Buffer {
    */
   inline bool shares_data() const { return shares_data_; }
 
-  // Helper function for cleaning up data storage. This unfortunately
-  // has to be public so that we can bind it into the deleter of our
-  // shared pointers
-  void DeleterHelper(void *ptr, TypeInfo type, Index size, int device, bool pinned) {
+  DISABLE_COPY_MOVE_ASSIGN(Buffer);
+
+ protected:
+  static void FreeMemory(void *ptr, size_t bytes, int device, bool pinned) {
     // change to correct device for deletion
     // Note: Can't use device guard due to potentially not GPUBackend.
     int current_device = 0;
@@ -255,8 +266,7 @@ class Buffer {
       CUDA_CALL(cudaGetDevice(&current_device));
       CUDA_CALL(cudaSetDevice(device));
     }
-    type.template Destruct<Backend>(ptr, size);
-    Backend::Delete(ptr, size*type.size(), pinned);
+    Backend::Delete(ptr, bytes, pinned);
 
     // reset to original calling device for consistency
     if (std::is_same<Backend, GPUBackend>::value) {
@@ -264,9 +274,6 @@ class Buffer {
     }
   }
 
-  DISABLE_COPY_MOVE_ASSIGN(Buffer);
-
- protected:
   // Helper to resize the underlying allocation
   inline void ResizeHelper(Index new_size) {
     DALI_ENFORCE(new_size >= 0, "Input size less than zero not supported.");
@@ -286,28 +293,13 @@ class Buffer {
       return;
     }
 
+    size_ = new_size;
+
     size_t new_num_bytes = new_size * type_.size();
     if (new_num_bytes > num_bytes_) {
       new_num_bytes *= alloc_mult;
-      // re-allocating: get the device
-      if (std::is_same<Backend, GPUBackend>::value) {
-        CUDA_CALL(cudaGetDevice(&device_));
-      }
-      data_.reset(Backend::New(new_num_bytes, pinned_), std::bind(
-              &Buffer<Backend>::DeleterHelper,
-              this, std::placeholders::_1,
-              type_, new_size, device_, pinned_));
-
-      num_bytes_ = new_num_bytes;
-
-      // Call the constructor for the underlying datatype
-      type_.template Construct<Backend>(data_.get(), new_size);
-
-      // If we were sharing data, we aren't anymore
-      shares_data_ = false;
+      reserve(new_num_bytes);
     }
-
-    size_ = new_size;
   }
 
   const double alloc_mult = 1.0;

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -240,10 +240,8 @@ class Buffer {
   }
 
   inline void free() {
-    if (!shares_data_) {
-      data_.reset();
-      num_bytes_ = 0;
-    }
+    data_.reset();
+    num_bytes_ = 0;
   }
 
   /**

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -181,6 +181,10 @@ class Buffer {
     pinned_ = pinned;
   }
 
+  inline bool is_pinned() const {
+    return pinned_;
+  }
+
   /**
    * @brief Returns a device this buffer was allocated on
    * If the backend is CPUBackend, return -1

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -84,35 +84,6 @@ typedef ::testing::Types<CPUBackend,
                          GPUBackend> Backends;
 TYPED_TEST_CASE(TensorListTest, Backends);
 
-class TestType {
- public:
-  explicit TestType(int size = 2) : ptr_(nullptr), size_(size) {
-    ptr_ = new float[size];
-  }
-
-  ~TestType() {
-    delete[] ptr_;
-  }
-
-  float *ptr_;
-  int size_;
-};
-
-class TestType2 {
- public:
-  explicit TestType2(int size = 1) : ptr_(nullptr), size_(size), id_(5) {
-    ptr_ = new float[size];
-  }
-
-  ~TestType2() {
-    delete[] ptr_;
-  }
-
-  float *ptr_;
-  int size_;
-  int id_;
-};
-
 // Note: A TensorList in a valid state has a type. To get to a valid state, we
 // can aquire our type relative to the allocation and the size of the buffer
 // in the following orders:
@@ -332,34 +303,6 @@ TYPED_TEST(TensorListTest, TestScalarResize) {
   for (int i = 0; i < num_scalar; ++i) {
     ASSERT_EQ(tensor_list.tensor_shape(i), vector<Index>{1});
     ASSERT_EQ(tensor_list.tensor_offset(i), i);
-  }
-}
-
-TYPED_TEST(TensorListTest, TestDataTypeConstructor) {
-  if (std::is_same<TypeParam, GPUBackend>::value) return;
-  TensorList<TypeParam> tensor_list;
-
-  // Setup shape & resize the buffer
-  vector<Dims> shape = this->GetSmallRandShape();
-  tensor_list.Resize(shape);
-
-  tensor_list.template mutable_data<TestType>();
-
-  for (int i = 0; i < tensor_list.size(); ++i) {
-    // verify that the internal data has been constructed
-    TestType &obj = tensor_list.template mutable_data<TestType>()[i];
-    ASSERT_EQ(obj.size_, 2);
-    ASSERT_NE(obj.ptr_, nullptr);
-  }
-
-  // Switch the type to TestType2
-  tensor_list.template mutable_data<TestType2>();
-  for (int i = 0; i < tensor_list.size(); ++i) {
-    // verify that the internal data has been constructed
-    TestType2 &obj = tensor_list.template mutable_data<TestType2>()[i];
-    ASSERT_EQ(obj.size_, 1);
-    ASSERT_EQ(obj.id_, 5);
-    ASSERT_NE(obj.ptr_, nullptr);
   }
 }
 

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -590,7 +590,6 @@ void Executor::PresizeData(WorkspaceBlob *wsb) {
       if (h == 0)
         h = this->bytes_per_sample_hint_;
     }
-    hints.resize(noutputs, bytes_per_sample_hint_);
     return hints;
   };
 

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -610,8 +610,6 @@ void Executor::PresizeData(WorkspaceBlob *wsb) {
         Tensor<CPUBackend> *tensor = ws.Output<CPUBackend>(i, j);
         auto hint = hints[i];
         if (tensor->is_pinned() && hint) {
-          cout << "Node " << graph_->cpu_node(op_idx).instance_name << "\n";
-          cout << "Presizing pinned tensor to " << hint << " bytes\n";
           // We set the type of the tensor to uint8 temporarily
           tensor->mutable_data<uint8>();
           tensor->Resize({(Index)hint});
@@ -620,7 +618,6 @@ void Executor::PresizeData(WorkspaceBlob *wsb) {
     }
   }
 
-  //for (auto &ws : wsb->mixed_op_data) {
   for (int op_idx = 0; op_idx < graph_->NumMixedOp(); op_idx++) {
     auto &ws = wsb->mixed_op_data[op_idx];
     std::vector<int> hints = mem_hints(graph_->mixed_node(op_idx));
@@ -630,39 +627,30 @@ void Executor::PresizeData(WorkspaceBlob *wsb) {
       if (ws.OutputIsType<CPUBackend>(i)) {
         TensorList<CPUBackend> *tl = ws.Output<CPUBackend>(i);
         if (tl->is_pinned()) {
-          cout << "Node " << graph_->mixed_node(op_idx).instance_name << "\n";
-          cout << "Presizing pinned tensor list to " << hint << " bytes\n";
           tl->mutable_data<uint8>();
           tl->Resize({{(Index)hint*batch_size_}});
         }
       } else {
         TensorList<GPUBackend> *tl = ws.Output<GPUBackend>(i);
-        cout << "Node " << graph_->mixed_node(op_idx).instance_name << "\n";
-        cout << "Presizing gpu tensor list to " << hint << " bytes\n";
         tl->mutable_data<uint8>();
         tl->Resize({{(Index)hint*batch_size_}});
       }
     }
   }
 
-  //for (auto &ws : wsb->gpu_op_data) {
   for (int op_idx = 0; op_idx < graph_->NumGPUOp(); op_idx++) {
-    auto &ws = wsb->mixed_op_data[op_idx];
+    auto &ws = wsb->gpu_op_data[op_idx];
     std::vector<int> hints = mem_hints(graph_->gpu_node(op_idx));
 
     for (int i = 0; i < ws.NumOutput(); ++i) {
       auto hint = hints[i];
       if (ws.OutputIsType<GPUBackend>(i)) {
         TensorList<GPUBackend> *tl = ws.Output<GPUBackend>(i);
-        cout << "Node " << graph_->gpu_node(op_idx).instance_name << "\n";
-        cout << "Presizing gpu tensor list to " << hint << " bytes\n";
         tl->mutable_data<uint8>();
         tl->Resize({{(Index)hint*batch_size_}});
       } else {
         TensorList<CPUBackend> *tl = ws.Output<CPUBackend>(i);
         if (tl->is_pinned()) {
-          cout << "Node " << graph_->gpu_node(op_idx).instance_name << "\n";
-          cout << "Presizing pinned tensor list to " << hint << " bytes\n";
           tl->mutable_data<uint8>();
           tl->Resize({{(Index)hint*batch_size_}});
         }

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -608,10 +608,10 @@ void Executor::PresizeData(WorkspaceBlob *wsb) {
       DALI_ENFORCE(ws.OutputIsType<CPUBackend>(i), "Executor "
           "encountered cpu op with non-cpu output.");
       for (int j = 0; j < ws.NumOutputAtIdx(i); ++j) {
-        Tensor<CPUBackend> *tensor = ws.Output<CPUBackend>(i, j);
+        Tensor<CPUBackend> &tensor = ws.Output<CPUBackend>(i, j);
         Index hint = hints[i];
-        if (tensor->is_pinned() && hint) {
-          tensor->reserve(hint);
+        if (tensor.is_pinned() && hint) {
+          tensor.reserve(hint);
         }
       }
     }
@@ -624,13 +624,13 @@ void Executor::PresizeData(WorkspaceBlob *wsb) {
     for (int i = 0; i < ws.NumOutput(); ++i) {
       Index hint = hints[i];
       if (ws.OutputIsType<CPUBackend>(i)) {
-        TensorList<CPUBackend> *tl = ws.Output<CPUBackend>(i);
-        if (tl->is_pinned()) {
-          tl->reserve(hint*batch_size_);
+        TensorList<CPUBackend> &tl = ws.Output<CPUBackend>(i);
+        if (tl.is_pinned()) {
+          tl.reserve(hint*batch_size_);
         }
       } else {
-        TensorList<GPUBackend> *tl = ws.Output<GPUBackend>(i);
-        tl->reserve(hint*batch_size_);
+        TensorList<GPUBackend> &tl = ws.Output<GPUBackend>(i);
+        tl.reserve(hint*batch_size_);
       }
     }
   }
@@ -642,12 +642,12 @@ void Executor::PresizeData(WorkspaceBlob *wsb) {
     for (int i = 0; i < ws.NumOutput(); ++i) {
       Index hint = hints[i];
       if (ws.OutputIsType<GPUBackend>(i)) {
-        TensorList<GPUBackend> *tl = ws.Output<GPUBackend>(i);
-        tl->reserve(hint*batch_size_);
+        TensorList<GPUBackend> &tl = ws.Output<GPUBackend>(i);
+        tl.reserve(hint*batch_size_);
       } else {
-        TensorList<CPUBackend> *tl = ws.Output<CPUBackend>(i);
-        if (tl->is_pinned()) {
-          tl->reserve(hint*batch_size_);
+        TensorList<CPUBackend> &tl = ws.Output<CPUBackend>(i);
+        if (tl.is_pinned()) {
+          tl.reserve(hint*batch_size_);
         }
       }
     }

--- a/dali/pipeline/graph_descr.cc
+++ b/dali/pipeline/graph_descr.cc
@@ -90,7 +90,6 @@ void OpGraph::AddOp(const OpSpec &spec, const std::string& name) {
 
     new_node = &cpu_node;
   } else if (device == "gpu") {
-
     gpu_nodes_.resize(gpu_nodes_.size()+1);
     OpNode &gpu_node = gpu_nodes_.back();
     id_to_node_map_.push_back({DALI_GPU, gpu_nodes_.size()-1});
@@ -193,7 +192,6 @@ void OpGraph::InstantiateOperators() {
     string device = spec.GetArgument<string>("device");
     node.op = GPUOperatorRegistry::Registry().Create(spec.name(), spec, &device);
   }
-
 }
 
 // Op Removal Process:

--- a/dali/pipeline/op_graph.h
+++ b/dali/pipeline/op_graph.h
@@ -294,6 +294,8 @@ class DLL_PUBLIC OpGraph {
     DALI_FAIL(str_error);
   }
 
+
+
   /**
    * @brief Helper function for saving graph to DOT file
    */
@@ -311,6 +313,11 @@ class DLL_PUBLIC OpGraph {
         GenerateDOTFromGraph(child_node, ofs);
     }
   }
+
+  /**
+   * @brief Instantiates the operators based on OpSpecs in nodes
+   */
+  DLL_PUBLIC void InstantiateOperators();
 
   /**
    * @brief Save graph in DOT directed graph format

--- a/dali/pipeline/op_graph.h
+++ b/dali/pipeline/op_graph.h
@@ -119,6 +119,7 @@ class DLL_PUBLIC OpGraph {
    */
   DLL_PUBLIC inline OperatorBase& cpu_op(Index idx) {
     DALI_ENFORCE_VALID_INDEX(idx, (Index)cpu_nodes_.size());
+    DALI_ENFORCE(cpu_nodes_[idx].op != nullptr, "Operator instance is empty");
     return *cpu_nodes_[idx].op;
   }
 
@@ -137,6 +138,7 @@ class DLL_PUBLIC OpGraph {
    */
   DLL_PUBLIC inline OperatorBase& gpu_op(Index idx) {
     DALI_ENFORCE_VALID_INDEX(idx, (Index)gpu_nodes_.size());
+    DALI_ENFORCE(gpu_nodes_[idx].op != nullptr, "Operator instance is empty");
     return *gpu_nodes_[idx].op;
   }
 
@@ -155,6 +157,7 @@ class DLL_PUBLIC OpGraph {
    */
   DLL_PUBLIC inline OperatorBase& mixed_op(Index idx) {
     DALI_ENFORCE_VALID_INDEX(idx, (Index)mixed_nodes_.size());
+    DALI_ENFORCE(mixed_nodes_[idx].op != nullptr, "Operator instance is empty");
     return *mixed_nodes_[idx].op;
   }
 
@@ -173,6 +176,7 @@ class DLL_PUBLIC OpGraph {
    */
   DLL_PUBLIC inline OperatorBase& support_op(Index idx) {
     DALI_ENFORCE_VALID_INDEX(idx, (Index)support_nodes_.size());
+    DALI_ENFORCE(support_nodes_[idx].op != nullptr, "Operator instance is empty");
     return *support_nodes_[idx].op;
   }
 

--- a/dali/pipeline/op_graph.h
+++ b/dali/pipeline/op_graph.h
@@ -34,6 +34,8 @@ using OpPtr = unique_ptr<OperatorBase>;
 
 typedef int64 NodeID;
 
+DLL_PUBLIC OpPtr InstantiateOperator(const OpSpec &spec);
+
 struct OpNode {
   inline OpNode() {}
   virtual ~OpNode() = default;
@@ -41,6 +43,11 @@ struct OpNode {
 
   OpNode(OpNode &&) = default;
   OpNode& operator=(OpNode &&) = default;
+
+  inline OperatorBase &InstantiateOperator() {
+    if (!op) op = dali::InstantiateOperator(spec);
+    return *op;
+  }
 
   OpPtr op;
   NodeID id;

--- a/dali/pipeline/operators/op_schema.h
+++ b/dali/pipeline/operators/op_schema.h
@@ -66,9 +66,8 @@ class DLL_PUBLIC OpSchema {
     internal_arguments_["seed"] = std::make_pair("Random seed", v.get());
     internal_arguments_unq_.push_back(std::move(v));
 
-    std::vector<int> hint;
     AddOptionalArg("bytes_per_sample_hint", "Output size hint (bytes), "
-      "per sample. The memory will be preallocated if it uses GPU or page-locked memory", hint);
+      "per sample. The memory will be preallocated if it uses GPU or page-locked memory", 0);
   }
 
   DLL_PUBLIC inline ~OpSchema() = default;

--- a/dali/pipeline/operators/op_schema.h
+++ b/dali/pipeline/operators/op_schema.h
@@ -65,10 +65,10 @@ class DLL_PUBLIC OpSchema {
     v = Value::construct(1234);
     internal_arguments_["seed"] = std::make_pair("Random seed", v.get());
     internal_arguments_unq_.push_back(std::move(v));
-    v = Value::construct(1);
-    internal_arguments_["bytes_per_sample_hint"] = std::make_pair("Output size hint (bytes), "
-      "per sample. The memory will be preallocated if it uses GPU or page-locked memory", v.get());
-    internal_arguments_unq_.push_back(std::move(v));
+
+    std::vector<int> hint;
+    AddOptionalArg("bytes_per_sample_hint", "Output size hint (bytes), "
+      "per sample. The memory will be preallocated if it uses GPU or page-locked memory", hint);
   }
 
   DLL_PUBLIC inline ~OpSchema() = default;

--- a/dali/pipeline/operators/op_schema.h
+++ b/dali/pipeline/operators/op_schema.h
@@ -65,6 +65,10 @@ class DLL_PUBLIC OpSchema {
     v = Value::construct(1234);
     internal_arguments_["seed"] = std::make_pair("Random seed", v.get());
     internal_arguments_unq_.push_back(std::move(v));
+    v = Value::construct(1);
+    internal_arguments_["bytes_per_sample_hint"] = std::make_pair("Output size hint (bytes), "
+      "per sample. The memory will be preallocated if it uses GPU or page-locked memory", v.get());
+    internal_arguments_unq_.push_back(std::move(v));
   }
 
   DLL_PUBLIC inline ~OpSchema() = default;

--- a/dali/pipeline/operators/op_spec.h
+++ b/dali/pipeline/operators/op_spec.h
@@ -77,7 +77,18 @@ class DLL_PUBLIC OpSpec {
    */
   template <typename T>
   DLL_PUBLIC inline OpSpec& AddArg(const string &name, const T &val) {
-    return AddInitializedArg(name, Argument::Store(name, val));
+    DALI_ENFORCE(arguments_.find(name) == arguments_.end(),
+        "AddArg failed. Argument with name \"" + name +
+        "\" already exists. ");
+    return SetArg(name, val);
+  }
+
+  /**
+   * @brief Sets or adds an argument with the given name and value.
+   */
+  template <typename T>
+  DLL_PUBLIC inline OpSpec& SetArg(const string &name, const T &val) {
+    return SetInitializedArg(name, Argument::Store(name, val));
   }
 
   /**
@@ -91,10 +102,17 @@ class DLL_PUBLIC OpSpec {
     return *this;
   }
 
+  /**
+   * @brief Sets or adds an argument with given name
+   */
+  DLL_PUBLIC inline OpSpec& SetInitializedArg(const string& name, Argument* arg) {
+    arguments_[name].reset(arg);
+    return *this;
+  }
   // Forward to string implementation
   template <unsigned N>
-  DLL_PUBLIC inline OpSpec& AddArg(const string &name, const char (&c_str)[N]) {
-    return this->AddArg<std::string>(name, c_str);
+  DLL_PUBLIC inline OpSpec& SetArg(const string &name, const char (&c_str)[N]) {
+    return this->SetArg<std::string>(name, c_str);
   }
 
   /**
@@ -340,19 +358,16 @@ inline S OpSpec::GetArgument(const string &name, const ArgumentWorkspace *ws, In
 
 #define INSTANTIATE_ARGUMENT_AS_INT64(T)                                                        \
   template<>                                                                                    \
-  inline OpSpec& OpSpec::AddArg(const string& name, const T& val) {                             \
-    return this->AddArg<int64>(name, static_cast<int64>(val));                                  \
+  inline OpSpec& OpSpec::SetArg(const string& name, const T& val) {                             \
+    return this->SetArg<int64>(name, static_cast<int64>(val));                                  \
   }                                                                                             \
   template<>                                                                                    \
-  inline OpSpec& OpSpec::AddArg(const string& name, const std::vector<T>& val) {                \
+  inline OpSpec& OpSpec::SetArg(const string& name, const std::vector<T>& val) {                \
     vector<int64> tmp;                                                                          \
     for (auto t : val) {                                                                        \
       tmp.push_back(static_cast<int64>(t));                                                     \
     }                                                                                           \
     Argument * arg = Argument::Store(name, tmp);                                                \
-    DALI_ENFORCE(arguments_.find(name) == arguments_.end(),                                     \
-        "AddArg failed. Argument with name \"" + name +                                         \
-        "\" already exists. ");                                                                 \
     arguments_[name].reset(arg);                                                                \
     return *this;                                                                               \
   }                                                                                             \

--- a/dali/pipeline/operators/util/make_contiguous.h
+++ b/dali/pipeline/operators/util/make_contiguous.h
@@ -84,7 +84,7 @@ class MakeContiguous : public Operator<MixedBackend> {
           cpu_output_buff.reserve(total_bytes);
         }
 
-        cpu_output_buff.ResizeLike(*output);
+        cpu_output_buff.ResizeLike(output);
         cpu_output_buff.set_type(type);
 
         for (int i = 0; i < batch_size_; ++i) {

--- a/dali/pipeline/operators/util/make_contiguous.h
+++ b/dali/pipeline/operators/util/make_contiguous.h
@@ -15,9 +15,11 @@
 #ifndef DALI_PIPELINE_OPERATORS_UTIL_MAKE_CONTIGUOUS_H_
 #define DALI_PIPELINE_OPERATORS_UTIL_MAKE_CONTIGUOUS_H_
 
+#include <algorithm>
 #include <vector>
 
 #include "dali/pipeline/operators/operator.h"
+#include "dali/pipeline/operators/common.h"
 #include "dali/common.h"
 
 // Found by benchmarking coalesced vs non coalesced on diff size images
@@ -30,7 +32,10 @@ class MakeContiguous : public Operator<MixedBackend> {
   inline explicit MakeContiguous(const OpSpec &spec) :
       Operator<MixedBackend>(spec),
       coalesced(true) {
-    bytes_per_sample_hint = spec.GetArgument<int>("bytes_per_sample_hint");
+    std::vector<int> hints;
+    GetSingleOrRepeatedArg(spec, &hints, "bytes_per_sample_hint", spec.NumOutput());
+    if (!hints.empty())
+      bytes_per_sample_hint = hints[0];
   }
 
   virtual inline ~MakeContiguous() = default;

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -255,7 +255,6 @@ inline void SetMemoryHint(OpSpec &spec, int index, int value) {
     std::to_string(index) + " >= " + std::to_string(no));
 
   GetSingleOrRepeatedArg(spec, &hints, "bytes_per_sample_hint", no);
-  hints.resize(no, 0);
   hints[index] = value;
   spec.SetArg("bytes_per_sample_hint", hints);
 }

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -372,6 +372,8 @@ void Pipeline::Build(vector<std::pair<string, string>> output_names) {
     }
   }
 
+  graph_.InstantiateOperators();
+
   // Load the final graph into the executor
   executor_->Build(&graph_, outputs);
   built_ = true;

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -240,7 +240,7 @@ inline int GetMemoryHint(OpSpec &spec, int index) {
   std::vector<int> hints;
   GetSingleOrRepeatedArg(spec, &hints, "bytes_per_sample_hint", spec.NumOutput());
 
-  if (index < (int)hints.size())
+  if (index < static_cast<int>(hints.size()))
     return hints[index];
   else
     return 0;
@@ -278,7 +278,6 @@ void Pipeline::Build(vector<std::pair<string, string>> output_names) {
   output_names_ = output_names;
   DALI_ENFORCE(!built_, "\"Build()\" can only be called once.");
   DALI_ENFORCE(output_names.size() > 0, "User specified zero outputs.");
-
 
   // Creating the executor
   if (pipelined_execution_ && async_execution_) {

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -140,8 +140,8 @@ class DLL_PUBLIC Pipeline {
     DALI_ENFORCE(graph_.NodeType(node_id) == DALI_CPU,
         "Internal error setting external input data.");
 
-    int op_idx = graph_.NodeIdx(node_id);
-    auto *op_ptr = &graph_.cpu_op(op_idx);
+    auto &node = graph_.node(node_id);
+    auto *op_ptr = &node.InstantiateOperator();
     ExternalSource<CPUBackend> *source =
       dynamic_cast<ExternalSource<CPUBackend>*>(op_ptr);
     DALI_ENFORCE(source != nullptr, "Input name '" +
@@ -158,13 +158,13 @@ class DLL_PUBLIC Pipeline {
     SetExternalInputHelper(name, tl);
   }
 
-  /**
-   * @brief Sets the external input with the input name to the
-   * input data.
-   */
-  DLL_PUBLIC inline void SetExternalInput(const string &name,
-      const vector<Tensor<CPUBackend>> &tl) {
-    SetExternalInputHelper(name, tl);
+    auto &node = graph_.node(node_id);
+    auto *op_ptr = &node.InstantiateOperator();
+    ExternalSource<CPUBackend> *source =
+      dynamic_cast<ExternalSource<CPUBackend>*>(op_ptr);
+    DALI_ENFORCE(source != nullptr, "Input name '" +
+        name + "' is not marked as an external input.");
+    source->SetDataSource(tl);
   }
 
   /**

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -158,13 +158,13 @@ class DLL_PUBLIC Pipeline {
     SetExternalInputHelper(name, tl);
   }
 
-    auto &node = graph_.node(node_id);
-    auto *op_ptr = &node.InstantiateOperator();
-    ExternalSource<CPUBackend> *source =
-      dynamic_cast<ExternalSource<CPUBackend>*>(op_ptr);
-    DALI_ENFORCE(source != nullptr, "Input name '" +
-        name + "' is not marked as an external input.");
-    source->SetDataSource(tl);
+  /**
+   * @brief Sets the external input with the input name to the
+   * input data.
+   */
+  DLL_PUBLIC inline void SetExternalInput(const string &name,
+      const vector<Tensor<CPUBackend>> &tl) {
+    SetExternalInputHelper(name, tl);
   }
 
   /**

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -357,6 +357,8 @@ class DLL_PUBLIC Pipeline {
   // Helper to add pipeline meta-data
   void PrepareOpSpec(OpSpec *spec);
 
+  void PropagateMemoryHint(OpNode &node);
+
   const int MAX_SEEDS = 1024;
 
   bool built_;


### PR DESCRIPTION
Make `OpSpec` mutable (added `SetArg` and `SetInitializedArg`).
Add `bytes_per_sample_hint` optional argument to default `OpSchema`
Remove operator instantiation from `OpGraph::AddOp` and move them to `OpGraph::InstantiateOperators`.
Propagate memory hints to `MakeContiguous` nodes.
MakeContiguous internal staging buffer is also pre-sized.

*Assumptions changed*:
Buffer has been refactored to only accept POD data - any elaborate construction/destruction has been abandoned.
