### PR TITLE
Fix compatibility with OpenCV 4 and 2

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -100,8 +100,11 @@ endif()
 ##################################################################
 # OpenCV
 ##################################################################
-# For OpenCV 3.x, 'imdecode()' is in the imgcodecs library
-find_package(OpenCV 3.0 QUIET COMPONENTS core imgproc imgcodecs)
+# For OpenCV 3 and later, 'imdecode()' is in the imgcodecs library
+find_package(OpenCV 4.0 QUIET COMPONENTS core imgproc imgcodecs)
+if(NOT OpenCV_FOUND)
+  find_package(OpenCV 3.0 QUIET COMPONENTS core imgproc imgcodecs)
+endif()
 if(NOT OpenCV_FOUND)
   # Note: OpenCV 2 support is unofficial
   # For OpenCV 2.x, image encode/decode functions are in highgui

--- a/dali/image/generic_image.cc
+++ b/dali/image/generic_image.cc
@@ -29,8 +29,8 @@ GenericImage::DecodeImpl(DALIImageType image_type, const uint8_t *encoded_buffer
                          size_t length) const {
   // Decode image to tmp cv::Mat
   cv::Mat decoded_image = cv::imdecode(
-          cv::Mat(1, length, CV_8UC1, (void *) (encoded_buffer)),          //NOLINT
-          IsColor(image_type) ? CV_LOAD_IMAGE_COLOR : CV_LOAD_IMAGE_GRAYSCALE);
+          cv::Mat(1, length, CV_8UC1, (void *) (encoded_buffer)),         //NOLINT
+          IsColor(image_type) ? cv::IMREAD_COLOR : cv::IMREAD_GRAYSCALE);
 
   if (decoded_image.data == nullptr) {
      DALI_FAIL("Unsupported image type.");

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder.h
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder.h
@@ -424,8 +424,8 @@ class nvJPEGDecoder : public Operator<MixedBackend> {
   void OCVFallback(const uint8_t* data, int size,
                    uint8_t *decoded_device_data, cudaStream_t s, string file_name) {
     const int c = (output_type_ == DALI_GRAY) ? 1 : 3;
-    auto decode_type = (output_type_ == DALI_GRAY) ? CV_LOAD_IMAGE_GRAYSCALE \
-                                                   : CV_LOAD_IMAGE_COLOR;
+    auto decode_type = (output_type_ == DALI_GRAY) ? cv::IMREAD_GRAYSCALE
+                                                   : cv::IMREAD_COLOR;
     cv::Mat input(1,
                   size,
                   CV_8UC1,

--- a/dali/test/dali_test.h
+++ b/dali/test/dali_test.h
@@ -84,7 +84,7 @@ class DALITest : public ::testing::Test {
     cv::Mat input(1, data_size, CV_8UC1, const_cast<unsigned char *>(data));
 
     cv::Mat tmp = cv::imdecode(
-        input, c == 1 ? CV_LOAD_IMAGE_GRAYSCALE : CV_LOAD_IMAGE_COLOR);
+        input, c == 1 ? cv::IMREAD_GRAYSCALE : cv::IMREAD_COLOR);
 
     // if different image_type needed, permute from BGR
     cv::Mat out_img(tmp.rows, tmp.cols, GetOpenCvChannelType(c));
@@ -109,7 +109,7 @@ class DALITest : public ::testing::Test {
                            vector<DimPair> *image_dims) {
     c_ = IsColor(type) ? 3 : 1;
     const int flag =
-        IsColor(type) ? CV_LOAD_IMAGE_COLOR : CV_LOAD_IMAGE_GRAYSCALE;
+        IsColor(type) ? cv::IMREAD_COLOR: cv::IMREAD_GRAYSCALE;
     const auto cType = IsColor(type) ? CV_8UC3 : CV_8UC1;
     const auto &encoded = imgs.data_;
     const auto &encoded_sizes = imgs.sizes_;

--- a/dali/util/ocv.h
+++ b/dali/util/ocv.h
@@ -43,4 +43,13 @@ void DLL_PUBLIC OpenCvColorConversion(
 
 }  // namespace dali
 
+// OpenCV 2.0 Compatibility
+#if CV_MAJOR_VERSION == 2
+namespace cv {
+using InterpolationFlags = int;
+using ColorConversionCodes = int;
+}  // namespace cv
+
+#endif
+
 #endif  // DALI_UTIL_OCV_H_


### PR DESCRIPTION
Switch to ImreadModes instead of using old C API defines
removed from OpenCV 4.
Introduce typedefs for OpenCV 2, for enums named in OpenCV 3.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>