### PR TITLE
Fix problems with the external input operator

### DIFF
--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -245,6 +245,8 @@ class DALIGenericIterator(object):
                 self._counter = self._counter % self._size
             else:
                 self._counter = 0
+            for p in self._pipes:
+                p.reset()
         else:
             logging.warning("DALI iterator does not support resetting while epoch is not finished. Ignoring...")
 

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -215,10 +215,13 @@ class DALIGenericIterator(object):
         DALI iterators do not support resetting before the end of the epoch
         and will ignore such request.
         """
-        if (self._stop_at_epoch) and (self._counter >= self._size):
-            self._counter = 0
-        elif (not self._stop_at_epoch) and (self._counter >= self._size):
-            self._counter = self._counter % self._size
+        if self._counter >= self._size:
+            if self._stop_at_epoch:
+                self._counter = 0
+            else:
+               self._counter = self._counter % self._size
+            for p in self._pipes:
+                p.reset()
         else:
             logging.warning("DALI iterator does not support resetting while epoch is not finished. Ignoring...")
 


### PR DESCRIPTION
- make feeding nonexisting external input a noop. It may happen
  that given input is not used by other operators, nor returned
  as a graph output, then calling feed_input will fail with the strange
  message
- stop DALI pipeline from returning early when iter_setup rises
  StopIteration

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>