### PR TITLE
Almost complete implementation of std::any.

### DIFF
--- a/dali/kernels/any.h
+++ b/dali/kernels/any.h
@@ -1,0 +1,392 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_ANY_H_
+#define DALI_KERNELS_ANY_H_
+
+#include <exception>
+#include <utility>
+#include <type_traits>
+
+namespace dali {
+
+namespace detail {
+
+
+struct alignas(8)
+any_placeholder {
+  constexpr any_placeholder() = default;
+  char data[8] = {};
+};
+
+struct any_helper_base {
+  virtual void destroy(any_placeholder *placeholder) const = 0;
+  virtual void free(any_placeholder *placeholder) const = 0;
+  virtual void *get_void(any_placeholder *placeholder) const noexcept = 0;
+  virtual const void *get_void(const any_placeholder *placeholder) const noexcept = 0;
+  virtual void clone(any_placeholder *dest, const any_placeholder *src) const = 0;
+  virtual void placement_clone(any_placeholder *dest, const any_placeholder *src) const = 0;
+  virtual bool is_same_ex(const any_helper_base *other) const = 0;
+
+  inline bool is_same(const any_helper_base *h) const {
+    return h && (this == h || is_same_ex(h));
+  }
+
+  template <typename T>
+  T *get(any_placeholder *p) const noexcept {
+    return reinterpret_cast<T*>(get_void(p));
+  }
+  template <typename T>
+  const T *get(const any_placeholder *p) const noexcept {
+    return reinterpret_cast<const T*>(get_void(p));
+  }
+};
+
+template <typename T, bool dynamic =
+  (sizeof(T) > sizeof(any_placeholder) ||
+  !std::is_pod<T>::value ||  // this could be weaker?
+  alignof(T) > alignof(any_placeholder))>
+struct any_helper : any_helper_base {
+  template <typename... Args>
+  static void create(any_placeholder *placeholder, Args&&... args) {
+    new(placeholder) T(std::forward<Args>(args)...);
+  }
+
+  void destroy(any_placeholder *placeholder) const override {
+    reinterpret_cast<T*>(placeholder)->~T();
+  }
+  void free(any_placeholder *placeholder) const override {
+    reinterpret_cast<T*>(placeholder)->~T();
+  }
+
+  void *get_void(any_placeholder *p) const noexcept override {
+    return reinterpret_cast<void*>(p);
+  }
+
+  const void *get_void(const any_placeholder *p) const noexcept override {
+    return reinterpret_cast<const void*>(p);
+  }
+
+  void clone(any_placeholder *dest, const any_placeholder *src) const override {
+    create(dest, *get<T>(src));
+  }
+
+  void placement_clone(any_placeholder *dest, const any_placeholder *src) const override {
+    create(dest, *get<T>(src));
+  }
+
+  bool is_same_ex(const any_helper_base *other) const override {
+    return dynamic_cast<const any_helper *>(other);
+  }
+
+  static any_helper instance;
+};
+
+template <typename T>
+struct any_helper<T, true> : any_helper_base {
+  template <typename... Args>
+  static void create(any_placeholder *placeholder, Args&&... args) {
+    *reinterpret_cast<T**>(placeholder) = new T(std::forward<Args>(args)...);
+  }
+
+  void destroy(any_placeholder *placeholder) const override {
+    get<T>(placeholder)->~T();
+  }
+
+  void free(any_placeholder *placeholder) const override {
+    T **pptr = reinterpret_cast<T**>(placeholder);
+    delete *pptr;
+    *pptr = nullptr;
+  }
+
+  void *get_void(any_placeholder *p) const noexcept override {
+    return *reinterpret_cast<void**>(p);
+  }
+
+  const void *get_void(const any_placeholder *p) const noexcept override {
+    return *reinterpret_cast<const void*const*>(p);
+  }
+
+  void clone(any_placeholder *dest, const any_placeholder *src) const override {
+    create(dest, *get<T>(src));
+  }
+
+  void placement_clone(any_placeholder *dest, const any_placeholder *src) const override {
+    new (get<T>(dest)) T(*get<T>(src));
+  }
+
+  bool is_same_ex(const any_helper_base *other) const override {
+    return dynamic_cast<const any_helper *>(other);
+  }
+
+  static any_helper instance;
+};
+
+template <typename T, bool d>
+any_helper<T, d> any_helper<T, d>::instance;
+
+template <typename T>
+any_helper<T, true> any_helper<T, true>::instance;
+
+}  // namespace detail
+
+class any {
+ public:
+  ~any() {
+    reset();
+  }
+
+  any(any &other) {
+    *this = other;
+  }
+  any(const any &other) {
+    *this = other;
+  }
+  any(any &&other) noexcept {
+    helper = other.helper;
+    storage = other.storage;
+    other.helper = nullptr;
+    other.storage = storage;
+  }
+
+  constexpr any() noexcept = default;
+
+  template <typename T>
+  any(const T &value) {  // NOLINT
+    assign<T>(value);
+  }
+
+  template <typename T>
+  any(T &&value) {  // NOLINT
+    static_assert(std::is_copy_constructible<T>::value,
+      "only copy-constructible types can be stored in 'any'");
+    static_assert(std::is_destructible<T>::value,
+      "objects stored in 'any' must be destructible");
+    assign<T>(std::move(value));
+  }
+
+  void reset() {
+    if (helper) {
+      helper->free(&storage);
+      helper = nullptr;
+    }
+  }
+
+  bool has_value() const noexcept { return helper != nullptr; }
+
+  void swap(any &other) noexcept {
+    std::swap(helper, other.helper);
+    std::swap(storage, other.storage);
+  }
+
+  template <typename T, typename... Args>
+  void emplace(Args&&... args) {
+    static_assert(std::is_copy_constructible<T>::value,
+      "only copy-constructible types can be stored in 'any'");
+    static_assert(std::is_destructible<T>::value,
+      "objects stored in 'any' must be destructible");
+    if (is_local_type<T>()) {
+      T *ptr = get<T>();
+      ptr->~T();
+      new (ptr) T(std::forward<Args>(args)...);
+    } else {
+      reset();
+      assign<T>(std::forward<Args>(args)...);
+    }
+  }
+
+  template <typename T>
+  any &operator=(T &&value) {
+    using U = typename std::remove_reference<T>::type;
+    emplace<U>(std::forward<T>(value));
+    return *this;
+  }
+
+  any &operator=(const any &other) {
+    if (!other.has_value()) {
+      reset();
+    } else if (helper == other.helper) {
+      // This code variant is used if and only if the pre-existing value was of exactle the same
+      // type and allocated by the same module. If the type is RTTI-compatible, but the helper
+      // address differs, use the ordinary free/allocate code path to avoid potential problems
+      // with memory management.
+      helper->destroy(&storage);
+      helper->placement_clone(&storage, &other.storage);
+    } else {
+      if (helper)
+        helper->free(&storage);
+      helper = other.helper;
+      helper->clone(&storage, &other.storage);
+    }
+    return *this;
+  }
+
+  any &operator=(any &&other) {
+    swap(other);
+    other.reset();
+    return *this;
+  }
+
+  any &operator=(any &other) {
+    *this = const_cast<const any &>(other);
+    return *this;
+  }
+
+ private:
+  template <typename T, typename... Args>
+  void assign(Args&&... args) {
+    helper = &detail::any_helper<T>::instance;
+    detail::any_helper<T>::create(&storage, std::forward<Args>(args)...);
+  }
+
+  template <typename T>
+  friend struct any_cast_helper;
+
+  /// @brief True, if contained type is T, regardless of which module it comes from
+  template <typename T>
+  constexpr bool is_type() const { return detail::any_helper<T>::instance.is_same(helper); }
+
+  /// @brief True, if contained type is exactly T and defined in the same module as the caller
+  template <typename T>
+  constexpr bool is_local_type() const { return &detail::any_helper<T>::instance == helper; }
+  detail::any_helper_base *helper = nullptr;
+  detail::any_placeholder storage;
+
+  template <typename T>
+  T *get() noexcept {
+    return helper->get<T>(&storage);
+  }
+
+  template <typename T>
+  const T *get() const noexcept {
+    return helper->get<T>(&storage);
+  }
+};
+
+struct bad_any_cast : std::bad_cast {
+  const char *what() const noexcept override {
+    return "bad_any_cast";
+  }
+};
+
+template <typename T>
+struct any_cast_helper {
+  static T get(any &a) {
+    if (!a.is_type<T>())
+      throw bad_any_cast();
+    return *a.get<T>();
+  }
+
+  static T get(const any &a) {
+    if (!a.is_type<T>())
+      throw bad_any_cast();
+    return *a.get<T>();
+  }
+
+  static T *get(any *a) {
+    if (!a->is_type<T>())
+      return nullptr;
+    return a->get<T>();
+  }
+};
+
+template <typename T>
+struct any_cast_helper<const T> {
+  static const T get(any &a) {
+    return any_cast_helper<T>::get(a);
+  }
+  static const T get(const any &a) {
+    return any_cast_helper<T>::get(a);
+  }
+
+  static const T *get(const any *a) {
+    if (!a->is_type<T>())
+      return nullptr;
+    return a->get<T>();
+  }
+};
+
+template <typename T>
+struct any_cast_helper<T &> {
+  static T &get(any &a) {
+    if (!a.is_type<T>())
+      throw bad_any_cast();
+    return *a.get<T>();
+  }
+};
+
+template <typename T>
+struct any_cast_helper<const T &> {
+  static const T &get(const any &a) {
+    if (!a.is_type<T>())
+      throw bad_any_cast();
+    return *a.get<T>();
+  }
+};
+
+
+template <typename T>
+struct any_cast_helper<T &&> {
+  static T &&get(any &&a) {
+    if (!a.is_type<T>())
+      throw bad_any_cast();
+    return std::move(*a.get<T>());
+  }
+};
+
+template <typename T>
+T any_cast(any &a) {
+  return any_cast_helper<T>::get(a);
+}
+
+template <typename T>
+T any_cast(any &&a) {
+  return any_cast_helper<T>::get(std::move(a));
+}
+
+template <typename T>
+T &any_cast(const any &a) {
+  return any_cast_helper<T>::get(a);
+}
+
+
+template <typename T>
+T *any_cast(any *a) {
+  return any_cast_helper<T>::get(a);
+}
+
+template <typename T>
+const T *any_cast(const any *a) {
+  return any_cast_helper<const T>::get(a);
+}
+
+// based on example reference implementation
+template <typename T, typename... Args>
+any make_any(Args&&... args) {
+  any a;
+  a.emplace<T>(std::forward<Args>(args)...);
+  return a;
+}
+
+// based on example reference implementation
+template <typename T, typename U, typename... Args>
+any make_any(std::initializer_list<U> il, Args&&... args) {
+  any a;
+  a.emplace<T>(il, std::forward<Args>(args)...);
+  return a;
+}
+
+}  // namespace dali
+
+#endif  // DALI_KERNELS_ANY_H_

--- a/dali/kernels/test/any_test.cc
+++ b/dali/kernels/test/any_test.cc
@@ -1,0 +1,133 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/kernels/any.h"
+
+namespace dali {
+
+TEST(Any, AnyCast) {
+  any a = 5;
+  EXPECT_EQ(any_cast<int>(a), 5);
+  EXPECT_THROW(any_cast<int8_t>(a), bad_any_cast);
+  any_cast<int&>(a) = 7;
+  EXPECT_EQ(any_cast<int>(a), 7);
+  EXPECT_EQ(&any_cast<const int&>(a), &any_cast<int&>(a));
+  const any *ca = &a;
+  EXPECT_EQ(any_cast<int>(&a), any_cast<int>(ca));
+  *any_cast<int>(&a) = 9;
+  EXPECT_EQ(any_cast<int&>(a), 9);
+  EXPECT_EQ(any_cast<const int&>(a), 9);
+  EXPECT_EQ(any_cast<int&&>(std::move(a)), 9);
+}
+
+struct test_string {
+  test_string(size_t *track, std::string str) : track(track), str(std::move(str)) {
+    (*track)++;
+  }
+  test_string(const test_string &other) : track(other.track), str(other.str) {
+    (*track)++;
+  }
+  test_string(test_string &&other) : track(other.track), str(std::move(other.str)) {
+    (*track)++;
+  }
+  ~test_string() {
+    (*track)--;
+  }
+
+  test_string &operator=(const test_string &other) {
+    if (track) (*track)--;
+    track = other.track;
+    (*track)++;
+    str = other.str;
+    return *this;
+  }
+
+  test_string &operator=(test_string &&other) {
+    if (track) (*track)--;
+    track = other.track;
+    (*track)++;
+    str = std::move(other.str);
+    return *this;
+  }
+
+  size_t *track = nullptr;
+  std::string str;
+};
+
+TEST(Any, Assign) {
+  size_t track = 0;
+
+  {
+    any a = 5;
+    EXPECT_EQ(any_cast<int>(a), 5);
+    any_cast<int&>(a) = 7;
+    EXPECT_EQ(any_cast<int>(a), 7);
+    float fp = 9;
+    a = fp;
+    EXPECT_EQ(any_cast<float>(a), 9);
+
+    EXPECT_THROW(any_cast<int>(a), bad_any_cast);
+
+    test_string s(&track, "hello, world");
+    EXPECT_EQ(track, 1) << "Missing initial instance count";
+    a = s;
+    EXPECT_EQ(track, 2) << "'a' should count as an instance";
+
+    any b = a;
+    EXPECT_EQ(track, 3) << "instances 's', 'a', 'b' should be counted";
+
+    EXPECT_EQ(any_cast<test_string>(a).str, "hello, world");
+    EXPECT_EQ(any_cast<test_string>(b).str, "hello, world");
+    const char *ptr = any_cast<test_string&>(b).str.data();
+    any c = std::move(b);
+    EXPECT_FALSE(b.has_value());
+    EXPECT_EQ(track, 3) << "instances 's', 'a', 'c' should be counted; b is cleared";
+
+    EXPECT_EQ(any_cast<test_string>(c).str, "hello, world");
+    EXPECT_EQ(any_cast<test_string&>(c).str.data(), ptr) << "Data not moved properly";
+
+    any d;
+    EXPECT_FALSE(d.has_value());
+    d = c;
+    EXPECT_EQ(track, 4) << "valid instances: 's', 'a', 'c', 'd'";
+    EXPECT_EQ(any_cast<test_string>(d).str, "hello, world");
+    any e;
+    d = e;
+    EXPECT_FALSE(d.has_value());
+    EXPECT_EQ(track, 3) << "valid instances: 's', 'a', 'c'";
+
+    any f = c;
+    EXPECT_EQ(track, 4) << "valid instances: 's', 'a', 'c', 'f'";
+    f = std::move(a);
+    EXPECT_FALSE(a.has_value());
+    EXPECT_EQ(track, 3) << "valid instances: 's', 'c', 'f'";
+
+    f = 42;
+    EXPECT_EQ(track, 2) << "valid instances: 's', 'c'";
+  }
+  EXPECT_EQ(track, 0);
+}
+
+TEST(Any, MakeAny) {
+  auto a = make_any<std::string>("test string");
+  EXPECT_EQ(any_cast<std::string>(a), "test string");
+
+  a = make_any<std::vector<int>>({ 3, 4, 5, 6, 7});
+  std::vector<int> vec = { 3, 4, 5, 6, 7};
+  EXPECT_EQ(any_cast<std::vector<int>>(a), vec);
+}
+
+}  // namespace dali
+


### PR DESCRIPTION
Extra features:
Uses RTTI to check for type equivalence - this works with dynamically loaded libraries (`std::any` doesn't).

Features omitted:
`const std::type_info type()` function
Constructors using `in_place_t`.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>