### PR TITLE
Force BOOST_PP to recognize NVCC as supporting variadic macros.

### DIFF
--- a/dali/kernels/static_switch.h
+++ b/dali/kernels/static_switch.h
@@ -15,6 +15,13 @@
 #ifndef DALI_KERNELS_STATIC_SWITCH_H_
 #define DALI_KERNELS_STATIC_SWITCH_H_
 
+#ifdef __CUDACC__
+#ifdef BOOST_PP_VARIADICS
+#undef BOOST_PP_VARIADICS
+#endif
+#define BOOST_PP_VARIADICS 1
+#endif
+
 /** @file
  *
  * This file defines two compile-time "switches" that are suitable for

--- a/dali/kernels/test/static_switch_test.cu
+++ b/dali/kernels/test/static_switch_test.cu
@@ -1,0 +1,71 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/kernels/kernel.h"
+#include "dali/kernels/static_switch.h"
+#include "dali/kernels/type_tag.h"
+
+namespace {
+template <typename I, typename O, int C>
+struct Functor {
+  void operator()(int &calls, int i, int o, int c) {
+    EXPECT_EQ(i, dali::TypeTag<I>::value);
+    EXPECT_EQ(o, dali::TypeTag<O>::value);
+    EXPECT_EQ(c, C);
+    calls++;
+  }
+};
+
+template <typename T>
+struct StaticSwitch_NVCC : testing::Test {};
+}  // namespace
+
+typedef testing::Types<int, float, double> MyTypes;
+TYPED_TEST_CASE(StaticSwitch_NVCC, MyTypes);
+
+TYPED_TEST(StaticSwitch_NVCC, TypeSwitch) {
+  using T = gtest_TypeParam_;
+  int tag = -1;
+  TYPE_SWITCH(dali::TypeTag<T>::value, dali::TypeTag, IType, (int, float, double),
+    (
+      tag = dali::TypeTag<IType>::value;
+      EXPECT_TRUE((std::is_same<IType, T>::value)) << "TypeSwitch type mismatch";
+    ),  // NOLINT
+    GTEST_FAIL() << "Invalid type";
+  );  // NOLINT
+
+  EXPECT_EQ(dali::TypeTag<T>::value, tag)
+    << "Tag mismatch - did type switch actually call anything?";
+}
+
+TEST(StaticSwitch_NVCC, Nested) {
+  int input_type = dali::TypeTag<float>();
+  int output_type = dali::TypeTag<int64_t>();
+  int calls = 0;
+  for (int channels = 1; channels <= 4; channels++) {
+    TYPE_SWITCH(input_type, dali::TypeTag, IType, (int, float, double, int64_t), (
+        TYPE_SWITCH(output_type, dali::TypeTag, OType, (int, uint8_t, int64_t), (
+            VALUE_SWITCH(channels, num_channels, (1, 2, 3, 4),
+              (Functor<IType, OType, num_channels>()(calls, input_type, output_type, channels); ),
+              FAIL() << "Unsupported value";
+            )                                       // NOLINT
+          ), FAIL() << "Unsupported output type";   // NOLINT
+        )                                           // NOLINT
+      ), FAIL() << "Unsupported input type";        // NOLINT
+    )                                               // NOLINT
+  }
+  // check that the test functor was actually called
+  EXPECT_EQ(calls, 4) << "Test functor was expected to be called 4 times";
+}


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>