### PR TITLE
Fix L3 RN50 tests accuracy

### DIFF
--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -72,7 +72,7 @@ class DALIGenericIterator(object):
     auto_reset : bool, optional, default = False
                  Whether the iterator resets itself for the next epoch
                  or it requires reset() to be called separately.
-    stop_at_epoch : bool, optional, default = True
+    stop_at_epoch : bool, optional, default = False
                  Whether to return a fraction of a full batch of data
                  such that the total entries returned by the
                  iterator == 'size'. Setting this flag to False will
@@ -84,7 +84,7 @@ class DALIGenericIterator(object):
                  output_map,
                  size,
                  auto_reset=False,
-                 stop_at_epoch=True):
+                 stop_at_epoch=False):
         if not isinstance(pipelines, list):
             pipelines = [pipelines]
         self._num_gpus = len(pipelines)

--- a/qa/L3_RN50_convergence/test_tensorflow.sh
+++ b/qa/L3_RN50_convergence/test_tensorflow.sh
@@ -6,10 +6,11 @@ mkdir -p idx-files/
 
 NUM_GPUS=$(nvidia-smi -L | wc -l)
 
-for file in $(ls /data/imagenet/train-val-tfrecord-480);
+DATA_SET_DIR=/data/imagenet/train-val-tfrecord-480
+for file in $(ls $DATA_SET_DIR --ignore *\.txt);
 do
     echo ${file}
-    python /opt/dali/tools/tfrecord2idx /data/imagenet/train-val-tfrecord-480/${file} \
+    python /opt/dali/tools/tfrecord2idx $DATA_SET_DIR/${file} \
         idx-files/${file}.idx;
 done
 
@@ -23,7 +24,7 @@ OUT=${LOG%.log}.dir
 SECONDS=0
 mpiexec --allow-run-as-root --bind-to socket -np ${NUM_GPUS} \
     python -u resnet.py --layers=18 \
-    --data_dir=/data/imagenet/train-val-tfrecord-480-subset --data_idx_dir=idx-files/ \
+    --data_dir=$DATA_SET_DIR --data_idx_dir=idx-files/ \
     --precision=fp16   --num_iter=90  --iter_unit=epoch --display_every=50 \
     --batch=256 --use_dali=GPU --log_dir=$OUT \
     2>&1 | tee $LOG


### PR DESCRIPTION
- fix wrong path to TensorFlow data set
- make stop_at_epoch default to False in PyTorch plugin

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>