### PR TITLE
Tweak DaliOperatorTest

### DIFF
--- a/dali/test/argument_key.h
+++ b/dali/test/argument_key.h
@@ -58,6 +58,14 @@ class ArgumentKey {
   std::string node_name_, arg_name_;
 };
 
+inline std::ostream& operator<<(std::ostream& os, const ArgumentKey& ak) {
+  if (ak.node_name().empty()) {
+    os << ak.arg_name();
+  } else {
+    os << ak.node_name() << ":" << ak.arg_name();
+  }
+  return os;
+}
 
 }  // namespace testing
 }  // namespace dali

--- a/dali/test/dali_operator_test_utils.h
+++ b/dali/test/dali_operator_test_utils.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_TEST_DALI_OPERATOR_TEST_UTILS_H_
+#define DALI_TEST_DALI_OPERATOR_TEST_UTILS_H_
+
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "dali/test/dali_operator_test.h"
+
+namespace dali {
+namespace testing {
+
+inline std::vector<testing::Arguments> cartesian(std::vector<testing::Arguments> args_vec) {
+  return args_vec;
+}
+
+template <typename... Ts>
+inline std::vector<testing::Arguments> cartesian(std::vector<testing::Arguments> args_vec,
+                                          Ts... args_vecs) {
+  std::vector<testing::Arguments> result;
+  for (auto args : args_vec) {
+    auto prod_rest = cartesian(args_vecs...);
+    for (auto args_rest : prod_rest) {
+      args_rest.insert(args.begin(), args.end());
+      result.push_back(std::move(args_rest));
+    }
+  }
+  return result;
+}
+
+}  // namespace testing
+}  // namespace dali
+
+#endif  // DALI_TEST_DALI_OPERATOR_TEST_UTILS_H_

--- a/dali/test/dali_operator_test_utils_test.cc
+++ b/dali/test/dali_operator_test_utils_test.cc
@@ -22,15 +22,16 @@ namespace testing {
 
 TEST(ArgumentsCartesianTest, NoOp) {
   std::vector<testing::Arguments> args = {
-      {{"arg0", 42}, {"arg1", std::string{"What is the answer"}}},
-      {}
-  };
+      {{"arg0", std::string{"What is the answer to the ultimate question of life,"
+                            " the universe and everything?"}},
+       {"arg1", 42}},
+      {}};
   auto c = cartesian(args);
   ASSERT_EQ(c.size(), args.size());
   ASSERT_EQ(c[0].size(), args[0].size());
   ASSERT_EQ(c[1].size(), args[1].size());
-  ASSERT_EQ(c[0].at("arg0").GetValue<int>(), args[0].at("arg0").GetValue<int>());
-  ASSERT_EQ(c[0].at("arg1").GetValue<std::string>(), args[0].at("arg1").GetValue<std::string>());
+  ASSERT_EQ(c[0].at("arg0").GetValue<std::string>(), args[0].at("arg0").GetValue<std::string>());
+  ASSERT_EQ(c[0].at("arg1").GetValue<int>(), args[0].at("arg1").GetValue<int>());
 }
 
 TEST(ArgumentsCartesianTest, Merge) {

--- a/dali/test/dali_operator_test_utils_test.cc
+++ b/dali/test/dali_operator_test_utils_test.cc
@@ -1,0 +1,58 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "dali/test/dali_operator_test.h"
+#include "dali/test/dali_operator_test_utils.h"
+
+namespace dali {
+namespace testing {
+
+TEST(ArgumentsCartesianTest, NoOp) {
+  std::vector<testing::Arguments> args = {
+      {{"arg0", 42}, {"arg1", std::string{"What is the answer"}}},
+      {}
+  };
+  auto c = cartesian(args);
+  ASSERT_EQ(c.size(), args.size());
+  ASSERT_EQ(c[0].size(), args[0].size());
+  ASSERT_EQ(c[1].size(), args[1].size());
+  ASSERT_EQ(c[0].at("arg0").GetValue<int>(), args[0].at("arg0").GetValue<int>());
+  ASSERT_EQ(c[0].at("arg1").GetValue<std::string>(), args[0].at("arg1").GetValue<std::string>());
+}
+
+TEST(ArgumentsCartesianTest, Merge) {
+  std::vector<testing::Arguments> args0 = {
+      {{"arg00", 0}, {"arg01", 1}},
+      {{"arg00", 2}, {"arg01", 3}},
+  };
+
+  std::vector<testing::Arguments> args1 = {
+      {{"arg10", 0}, {"arg11", 1}},
+      {{"arg10", 2}, {"arg11", 3}},
+  };
+
+  std::vector<testing::Arguments> args2 = {
+      {{"arg00", 10}, {"arg01", 11}},
+      {{"arg00", 12}, {"arg01", 13}},
+  };
+  ASSERT_EQ(cartesian(args0, args1).size(), 4);
+  ASSERT_EQ(cartesian(args0, args1)[0].at("arg00").GetValue<int>(), 0);
+  ASSERT_EQ(cartesian(args0, args1, args2).size(), 8);
+  ASSERT_EQ(cartesian(args0, args1, args2)[0].at("arg00").GetValue<int>(), 10);
+}
+
+}  // namespace testing
+}  // namespace dali

--- a/dali/test/operator_argument.h
+++ b/dali/test/operator_argument.h
@@ -60,8 +60,7 @@ struct TestOpArgToStringImpl<T, kernels::if_iterable<T, void>> {
     } else {
       ss << "[ ";
     }
-    using element_t =
-        typename std::remove_cv<typename std::remove_reference<decltype(*begin(val))>::type>::type;
+    using element_type = kernels::element_t<T>;
     bool first = true;
     for (const auto& e : val) {
       if (!first) {
@@ -69,7 +68,7 @@ struct TestOpArgToStringImpl<T, kernels::if_iterable<T, void>> {
       } else {
         first = false;
       }
-      ss << TestOpArgToStringImpl<element_t>::to_string(e);
+      ss << TestOpArgToStringImpl<element_type>::to_string(e);
     }
     ss << " ]";
     return ss.str();

--- a/dali/test/tensor_list_wrapper.h
+++ b/dali/test/tensor_list_wrapper.h
@@ -83,7 +83,8 @@ class TensorListWrapper {
   template <typename Backend>
   std::unique_ptr<TensorList<Backend>> CopyTo() const {
     std::unique_ptr<TensorList<Backend>> result(new TensorList<Backend>());
-    DALI_ENFORCE(has_cpu() != has_gpu(), "Should contain TensorList from exactly one backend");
+    ASSERT_NE(has_cpu(), has_gpu())
+        << "Should contain TensorList from exactly one backend", nullptr;
     if (has_cpu()) {
       result->Copy(*cpu_, 0);
     } else {
@@ -92,7 +93,6 @@ class TensorListWrapper {
     CUDA_CALL(cudaStreamSynchronize(0));
     return result;
   }
-
 
   explicit constexpr operator bool() const noexcept {
     return cpu_ || gpu_;

--- a/dali/test/tensor_list_wrapper.h
+++ b/dali/test/tensor_list_wrapper.h
@@ -16,7 +16,9 @@
 #define DALI_TEST_TENSOR_LIST_WRAPPER_H_
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <string>
+
 #include "dali/pipeline/data/tensor_list.h"
 
 namespace dali {
@@ -38,6 +40,11 @@ class TensorListWrapper {
   template<typename Backend>
   const TensorList<Backend> *get() const {
     FAIL() << "Backend type not supported. You may want to write your own specialization", nullptr;
+  }
+
+  template<typename Backend>
+  constexpr bool has() const {
+    FAIL() << "Backend type not supported. You may want to write your own specialization", false;
   }
 
 
@@ -73,6 +80,19 @@ class TensorListWrapper {
     return *gpu_;
   }
 
+  template <typename Backend>
+  std::unique_ptr<TensorList<Backend>> CopyTo() const {
+    std::unique_ptr<TensorList<Backend>> result(new TensorList<Backend>());
+    DALI_ENFORCE(has_cpu() != has_gpu(), "Should contain TensorList from exactly one backend");
+    if (has_cpu()) {
+      result->Copy(*cpu_, 0);
+    } else {
+      result->Copy(*gpu_, 0);
+    }
+    CUDA_CALL(cudaStreamSynchronize(0));
+    return result;
+  }
+
 
   explicit constexpr operator bool() const noexcept {
     return cpu_ || gpu_;
@@ -98,6 +118,15 @@ inline const TensorList<GPUBackend> *TensorListWrapper::get() const {
   return gpu_;
 }
 
+template <>
+inline bool TensorListWrapper::has<CPUBackend>() const {
+  return has_cpu();
+}
+
+template <>
+inline bool TensorListWrapper::has<GPUBackend>() const {
+  return has_gpu();
+}
 
 }  // namespace testing
 }  // namespace dali


### PR DESCRIPTION
Add `device="gpu"` handling
Easy access for CPU/GPU copy of TensorList from TensorWrapper
Printing Arguments by GTest
Cartesian product for Arguments
Remove need to specify Backend in RunTest

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>