### PR TITLE
Add read_ahead option to file readers

### DIFF
--- a/dali/pipeline/operators/reader/loader/file_loader.cc
+++ b/dali/pipeline/operators/reader/loader/file_loader.cc
@@ -102,7 +102,7 @@ void FileLoader::ReadSample(ImageLabelWrapper* image_label) {
     current_index_ = 0;
   }
 
-  auto current_image = FileStream::Open(file_root_ + "/" + image_pair.first);
+  auto current_image = FileStream::Open(file_root_ + "/" + image_pair.first, read_ahead_);
   Index image_size = current_image->Size();
 
   if (copy_read_data_) {

--- a/dali/pipeline/operators/reader/loader/indexed_file_loader.h
+++ b/dali/pipeline/operators/reader/loader/indexed_file_loader.h
@@ -46,7 +46,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     std::tie(seek_pos, size, file_index) = indices_[current_index_];
     if (file_index != current_file_index_) {
       current_file_->Close();
-      current_file_ = FileStream::Open(uris_[file_index]);
+      current_file_ = FileStream::Open(uris_[file_index], read_ahead_);
       current_file_index_ = file_index;
     }
 
@@ -107,7 +107,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     current_index_ = start_index(shard_id_, num_shards_, num_indices);
     int64 seek_pos, size;
     std::tie(seek_pos, size, current_file_index_) = indices_[current_index_];
-    current_file_ = FileStream::Open(uris_[current_file_index_]);
+    current_file_ = FileStream::Open(uris_[current_file_index_], read_ahead_);
     current_file_->Seek(seek_pos);
 
     mmap_reserver = FileStream::FileStreamMappinReserver(uris_.size());
@@ -121,7 +121,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     std::tie(seek_pos, size, file_index) = indices_[current_index_];
     if (file_index != current_file_index_) {
       current_file_->Close();
-      current_file_ = FileStream::Open(uris_[file_index]);
+      current_file_ = FileStream::Open(uris_[file_index], read_ahead_);
       current_file_index_ = file_index;
     }
     current_file_->Seek(seek_pos);

--- a/dali/pipeline/operators/reader/loader/loader.cc
+++ b/dali/pipeline/operators/reader/loader/loader.cc
@@ -27,7 +27,11 @@ DALI_SCHEMA(LoaderBase)
   .AddOptionalArg("shard_id",
       R"code(Id of the part to read.)code", 0)
   .AddOptionalArg("tensor_init_bytes",
-      R"code(Hint for how much memory to allocate per image.)code", 1048576);
+      R"code(Hint for how much memory to allocate per image.)code", 1048576)
+  .AddOptionalArg("read_ahead",
+      R"code(Whether accessed data should be read ahead. In case of big files like LMDB,
+RecordIO or TFRecord it will slow down first access but will decrease the time of all following
+accesses.)code", false);
 
 
 size_t start_index(const size_t shard_id,

--- a/dali/pipeline/operators/reader/loader/loader.h
+++ b/dali/pipeline/operators/reader/loader/loader.h
@@ -52,7 +52,8 @@ class Loader {
       tensor_init_bytes_(options.GetArgument<int>("tensor_init_bytes")),
       seed_(options.GetArgument<Index>("seed")),
       shard_id_(options.GetArgument<int>("shard_id")),
-      num_shards_(options.GetArgument<int>("num_shards")) {
+      num_shards_(options.GetArgument<int>("num_shards")),
+      read_ahead_(options.GetArgument<bool>("read_ahead")) {
     DALI_ENFORCE(initial_empty_size_ > 0, "Batch size needs to be greater than 0");
     DALI_ENFORCE(num_shards_ > shard_id_, "num_shards needs to be greater than shard_id");
     // initialize a random distribution -- this will be
@@ -192,6 +193,8 @@ class Loader {
 
   // if read data need to be copied or can be just shared with tensor
   bool copy_read_data_;
+  // if accessed files should be loaded into memory in advance at the first access
+  bool read_ahead_;
 };
 
 };  // namespace dali

--- a/dali/pipeline/operators/reader/loader/recordio_loader.h
+++ b/dali/pipeline/operators/reader/loader/recordio_loader.h
@@ -38,7 +38,7 @@ class RecordIOLoader : public IndexedFileLoader {
     std::vector<size_t> file_offsets;
     file_offsets.push_back(0);
     for (std::string& path : uris_) {
-      auto tmp = FileStream::Open(path);
+      auto tmp = FileStream::Open(path, read_ahead_);
       file_offsets.push_back(tmp->Size() + file_offsets.back());
       tmp->Close();
     }
@@ -80,7 +80,7 @@ class RecordIOLoader : public IndexedFileLoader {
       // Release previously opened file
       current_index_ = 0;
       current_file_index_ = 0;
-      current_file_ = FileStream::Open(uris_[current_file_index_]);
+      current_file_ = FileStream::Open(uris_[current_file_index_], read_ahead_);
     }
 
     int64 seek_pos, size;
@@ -118,7 +118,7 @@ class RecordIOLoader : public IndexedFileLoader {
         DALI_ENFORCE(current_file_index_ + 1 < uris_.size(),
           "Incomplete or corrupted record files");
         // Release previously opened file
-        current_file_ = FileStream::Open(uris_[++current_file_index_]);
+        current_file_ = FileStream::Open(uris_[++current_file_index_], read_ahead_);
         continue;
       }
      tensor->SetSourceInfo(uris_[current_file_index_] + " at index " + to_string(seek_pos));

--- a/dali/pipeline/operators/reader/loader/sequence_loader.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.cc
@@ -124,7 +124,7 @@ void SequenceLoader::LoadFrame(const std::vector<std::string> &s, Index frame_id
                                Tensor<CPUBackend> *target) {
   const auto frame_filename = s[frame_idx];
   target->SetSourceInfo(frame_filename);
-  auto frame = FileStream::Open(frame_filename);
+  auto frame = FileStream::Open(frame_filename, read_ahead_);
   Index frame_size = frame->Size();
 // ToDo - move to mmap version bellow when more tests are available
 #if 1

--- a/dali/util/file.cc
+++ b/dali/util/file.cc
@@ -20,12 +20,12 @@
 
 namespace dali {
 
-std::unique_ptr<FileStream> FileStream::Open(const std::string& uri) {
+std::unique_ptr<FileStream> FileStream::Open(const std::string& uri, bool read_ahead) {
   if (uri.find("file://") == 0) {
     return std::unique_ptr<FileStream>(
-            new LocalFileStream(uri.substr(std::string("file://").size())));
+            new LocalFileStream(uri.substr(std::string("file://").size()), read_ahead));
   } else {
-    return std::unique_ptr<FileStream>(new LocalFileStream(uri));
+    return std::unique_ptr<FileStream>(new LocalFileStream(uri, read_ahead));
   }
 }
 

--- a/dali/util/file.h
+++ b/dali/util/file.h
@@ -70,7 +70,7 @@ class DLL_PUBLIC FileStream {
    private:
      unsigned int reserved;
   };
-  static std::unique_ptr<FileStream> Open(const std::string& uri);
+  static std::unique_ptr<FileStream> Open(const std::string& uri, bool read_ahead);
 
   virtual void Close() = 0;
   virtual size_t Read(uint8_t * buffer, size_t n_bytes) = 0;

--- a/dali/util/local_file.h
+++ b/dali/util/local_file.h
@@ -26,7 +26,7 @@ namespace dali {
 
 class LocalFileStream : public FileStream {
  public:
-  explicit LocalFileStream(const std::string& path);
+  explicit LocalFileStream(const std::string& path, bool read_ahead);
   void Close() override;
   shared_ptr<void> Get(size_t n_bytes) override;
   static bool ReserveFileMappings(unsigned int num);
@@ -44,6 +44,7 @@ class LocalFileStream : public FileStream {
   size_t length_;
   size_t pos_;
   string path_;
+  bool read_ahead_whole_file_;
 };
 
 }  // namespace dali


### PR DESCRIPTION
Setting read_ahead will ask mmap to read ahead the whole file to process memory.
It will be slow at the first access but will improve consequitive one.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>