### PR TITLE
Let OpenCV pick libjpeg-turbo from the system (instead of building its own)

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -52,26 +52,7 @@ RUN LMDB_VERSION=0.9.22 && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
     rm -rf /lmdb
 
-# OpenCV
-RUN OPENCV_VERSION=3.4.3 && \
-    curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf - && \
-    cd /opencv-${OPENCV_VERSION} && mkdir build && cd build && \
-    cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=/usr/local \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DWITH_CUDA=OFF -DWITH_1394=OFF -DWITH_IPP=OFF -DWITH_OPENCL=OFF -DWITH_GTK=OFF \
-          -DBUILD_DOCS=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_PNG=ON \
-          -DBUILD_opencv_cudalegacy=OFF -DBUILD_opencv_stitching=OFF .. && \
-    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
-    rm -rf /opencv-${OPENCV_VERSION}
-
 # libjpeg-turbo
-#
-# Note: the preceding OpenCV installation intentionally does NOT use libjpeg-turbo.
-# DALI will directly call libjpeg-turbo first, and if it fails, DALI will fall back
-# to OpenCV, which in turn will call its bundled (built-from-source) libjpeg.
-# To be extra sure OpenCV doesn't pick up libjpeg-turbo (in which case we'd have no
-# fallback), libjpeg-turbo is built and installed _after_ OpenCV.
-#
 RUN JPEG_TURBO_VERSION=1.5.3 && \
     curl -L https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${JPEG_TURBO_VERSION}.tar.gz | tar -xzf - && \
     cd /libjpeg-turbo-${JPEG_TURBO_VERSION} && \
@@ -80,6 +61,18 @@ RUN JPEG_TURBO_VERSION=1.5.3 && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install 2>&1 >/dev/null && \
     rm -rf /libjpeg-turbo-${JPEG_TURBO_VERSION}
 
+# OpenCV
+RUN OPENCV_VERSION=3.4.3 && \
+    curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf - && \
+    cd /opencv-${OPENCV_VERSION} && mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DWITH_CUDA=OFF -DWITH_1394=OFF -DWITH_IPP=OFF -DWITH_OPENCL=OFF -DWITH_GTK=OFF \
+          -DBUILD_JPEG=OFF -DWITH_JPEG=ON \
+          -DBUILD_DOCS=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_PNG=ON \
+          -DBUILD_opencv_cudalegacy=OFF -DBUILD_opencv_stitching=OFF .. && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
+    rm -rf /opencv-${OPENCV_VERSION}
 
 # Clang
 RUN CLANG_VERSION=6.0.1 && \

--- a/dali/python/bundle-wheel.sh
+++ b/dali/python/bundle-wheel.sh
@@ -21,17 +21,17 @@
 # Copyright (c) 2016, Hugh Perkins
 # Copyright (c) 2016, Soumith Chintala
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # * Redistributions of source code must retain the above copyright notice, this
 #   list of conditions and the following disclaimer.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the following disclaimer in the documentation
 #   and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -89,6 +89,7 @@ make_wheel_record() {
 
 DEPS_LIST=(
     "/usr/local/lib/libturbojpeg.so.0"
+    "/usr/local/lib/libjpeg.so.62"
     "/usr/local/lib/libavformat.so.57"
     "/usr/local/lib/libavcodec.so.57"
     "/usr/local/lib/libavfilter.so.6"
@@ -97,6 +98,7 @@ DEPS_LIST=(
 
 DEPS_SONAME=(
     "libturbojpeg.so.0"
+    "libjpeg.so.62"
     "libavformat.so.57"
     "libavcodec.so.57"
     "libavfilter.so.6"
@@ -180,7 +182,7 @@ done
 #Tag: cp27-cp27mu-none-manylinux1_x86_64
 sed -i 's/\(Tag:.*\)-none-/\1-/;s/\(Root-Is-Purelib:\) true/\1 false/' ${PKGNAME}-*.dist-info/WHEEL
 
-# regenerate the RECORD file with new hashes 
+# regenerate the RECORD file with new hashes
 RECORD_FILE=$(ls $PKGNAME-*.dist-info/RECORD)
 echo "Generating new record file $RECORD_FILE"
 rm -f $RECORD_FILE
@@ -198,4 +200,3 @@ zip -rq $OUTDIR/$OUTWHLNAME *
 # clean up
 popd
 rm -rf $TMPDIR
-


### PR DESCRIPTION
, as it was building turbojpeg anyway (libjpeg usage was deprecated)
See https://github.com/opencv/opencv/pull/11497
Signed-off-by: Joaquin Anton <janton@nvidia.com>