### PR TITLE
Common utilities for kernels.

### DIFF
--- a/dali/kernels/alloc.cc
+++ b/dali/kernels/alloc.cc
@@ -1,0 +1,109 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cuda_runtime.h>
+#include <cassert>
+#include "dali/kernels/alloc.h"
+#include "dali/kernels/static_switch.h"
+#include "dali/kernels/gpu_utils.h"
+
+namespace dali {
+namespace kernels {
+namespace memory {
+
+template <AllocType>
+struct Allocator;
+
+template <>
+struct Allocator<AllocType::Host> {
+  static void Deallocate(void *ptr, int device) noexcept {
+    (void)device;
+    free(ptr);
+  }
+
+  static void *Allocate(size_t bytes) noexcept { return malloc(bytes); }
+};
+
+template <>
+struct Allocator<AllocType::Pinned> {
+  static void Deallocate(void *ptr, int device) noexcept {
+    DeviceGuard guard(device);
+    cudaFreeHost(ptr);
+  }
+
+  static void *Allocate(size_t bytes) noexcept {
+    void *ptr = nullptr;
+    cudaMallocHost(&ptr, bytes);
+    return ptr;
+  }
+};
+
+template <>
+struct Allocator<AllocType::GPU> {
+  static void Deallocate(void *ptr, int device) noexcept {
+    DeviceGuard guard(device);
+    cudaFree(ptr);
+  }
+
+  static void *Allocate(size_t bytes) noexcept {
+    void *ptr = nullptr;
+    cudaMalloc(&ptr, bytes);
+    return ptr;
+  }
+};
+
+
+template <>
+struct Allocator<AllocType::Unified> {
+  static void Deallocate(void *ptr, int device) noexcept {
+    DeviceGuard guard(device);
+    cudaFree(ptr);
+  }
+
+  static void *Allocate(size_t bytes) noexcept {
+    void *ptr = nullptr;
+    cudaMallocManaged(&ptr, bytes);
+    return ptr;
+  }
+};
+
+void *Allocate(AllocType type, size_t size) noexcept {
+  VALUE_SWITCH(type, type_label,
+    (AllocType::Host, AllocType::Pinned, AllocType::GPU, AllocType::Unified),
+    (return Allocator<type_label>::Allocate(size)),
+    (assert(!"Invalid allocation type requested");
+    return nullptr;)
+  );  // NOLINT
+}
+
+void Deallocate(AllocType type, void *mem, int device) noexcept {
+  VALUE_SWITCH(type, type_label,
+    (AllocType::Host, AllocType::Pinned, AllocType::GPU, AllocType::Unified),
+    (return Allocator<type_label>::Deallocate(mem, device)),
+    (assert(!"Invalid allocation type requested");)
+  );  // NOLINT
+}
+
+Deleter GetDeleter(AllocType type) noexcept {
+  Deleter del;
+  del.alloc_type = type;
+  del.device = 0;
+  if (type != AllocType::Host)
+    cudaGetDevice(&del.device);
+  return del;
+}
+
+}  // namespace memory
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/alloc.h
+++ b/dali/kernels/alloc.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_ALLOC_H_
+#define DALI_KERNELS_ALLOC_H_
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include "dali/kernels/alloc_type.h"
+
+namespace dali {
+namespace kernels {
+namespace memory {
+
+void *Allocate(AllocType type, size_t size) noexcept;
+void Deallocate(AllocType type, void *mem, int device) noexcept;
+
+struct Deleter {
+  int device;
+  AllocType alloc_type;
+  inline void operator()(void *p) noexcept { Deallocate(alloc_type, p, device); }
+};
+Deleter GetDeleter(AllocType type) noexcept;
+
+template <typename T>
+std::shared_ptr<T> alloc_shared(AllocType type, size_t count) {
+  static_assert(std::is_pod<T>::value, "Only POD types are supported");
+  void *mem = Allocate(type, count*sizeof(T));
+  if (!mem)
+    throw std::bad_alloc();
+
+  // From cppreference: if additional storage cannot be allocated
+  // deleter will be called on the pointer passed to shared_ptr constructor.
+  return { static_cast<T*>(mem), GetDeleter(type) };
+}
+
+template <typename T>
+using KernelUniquePtr = std::unique_ptr<T, Deleter>;
+
+template <typename T>
+KernelUniquePtr<T> alloc_unique(AllocType type, size_t count) {
+  static_assert(std::is_pod<T>::value, "Only POD types are supported");
+  void *mem = Allocate(type, count*sizeof(T));
+  if (!mem)
+    throw std::bad_alloc();
+  return { reinterpret_cast<T*>(mem), GetDeleter(type) };
+}
+
+}  // namespace memory
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_ALLOC_H_

--- a/dali/kernels/any.h
+++ b/dali/kernels/any.h
@@ -18,6 +18,7 @@
 #include <exception>
 #include <utility>
 #include <type_traits>
+#include <typeinfo>
 
 namespace dali {
 

--- a/dali/kernels/common/CMakeLists.txt
+++ b/dali/kernels/common/CMakeLists.txt
@@ -12,23 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project(kernels)
-
-add_subdirectory(test)
-add_subdirectory(common)
-
 # Get all the source files and dump test files
 file(GLOB tmp *.cc *.cu)
 set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} ${tmp})
 file(GLOB tmp *_test.cc *_test.cu)
 remove(DALI_KERNEL_SRCS "${DALI_KERNEL_SRCS}" ${tmp})
+set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} PARENT_SCOPE)
 
 if (BUILD_TEST)
   # get all the test srcs
   file(GLOB tmp *_test.cc *_test.cu)
+  set(DALI_KERNEL_TEST_SRCS ${DALI_KERNEL_TEST_SRCS} ${tmp} PARENT_SCOPE)
 endif()
-
-cuda_add_library(${dali_kernel_lib} STATIC "${DALI_KERNEL_SRCS}")
-cuda_add_library(${dali_kernel_test_lib} STATIC "${DALI_KERNEL_TEST_SRCS}")
-
-target_link_libraries(${dali_kernel_test_lib} ${dali_kernel_lib})

--- a/dali/kernels/common/CMakeLists.txt
+++ b/dali/kernels/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dali/kernels/common/convert.h
+++ b/dali/kernels/common/convert.h
@@ -33,25 +33,36 @@ template <typename T>
 __host__ __device__ constexpr T min_value() { return const_limits<T>::min; }
 
 #define DEFINE_TYPE_RANGE(type, min_, max_) template <>\
-struct const_limits<type> { static constexpr type min = min_, max = max_; };
+struct const_limits<type> { static constexpr type min = min_, max = max_; }
 
-DEFINE_TYPE_RANGE(uint8_t,  0, 0xff)
-DEFINE_TYPE_RANGE(int8_t,  -0x80, 0x7f)
-DEFINE_TYPE_RANGE(uint16_t, 0, 0xffff)
-DEFINE_TYPE_RANGE(int16_t, -0x8000, 0x7fff)
-DEFINE_TYPE_RANGE(uint32_t, 0, 0xffffffff)
-DEFINE_TYPE_RANGE(int32_t, -0x80000000, 0x7fffffff)
-DEFINE_TYPE_RANGE(uint64_t, 0, 0xffffffffffffffffUL)
-DEFINE_TYPE_RANGE(int64_t, -0x8000000000000000L, 0x7fffffffffffffffL)
-DEFINE_TYPE_RANGE(float, -3.40282347e+38f, 3.40282347e+38f)
-DEFINE_TYPE_RANGE(double, -1.7976931348623157e+308, 1.7976931348623157e+308)
+DEFINE_TYPE_RANGE(uint8_t,  0, 0xff);
+DEFINE_TYPE_RANGE(int8_t,  -0x80, 0x7f);
+DEFINE_TYPE_RANGE(uint16_t, 0, 0xffff);
+DEFINE_TYPE_RANGE(int16_t, -0x8000, 0x7fff);
+DEFINE_TYPE_RANGE(uint32_t, 0, 0xffffffff);
+DEFINE_TYPE_RANGE(int32_t, -0x80000000, 0x7fffffff);
+DEFINE_TYPE_RANGE(uint64_t, 0, 0xffffffffffffffffUL);
+DEFINE_TYPE_RANGE(int64_t, -0x8000000000000000L, 0x7fffffffffffffffL);
+DEFINE_TYPE_RANGE(float, -3.40282347e+38f, 3.40282347e+38f);
+DEFINE_TYPE_RANGE(double, -1.7976931348623157e+308, 1.7976931348623157e+308);
 
-template <typename From, typename To,
-  bool sign_match = (std::is_signed<From>::value == std::is_signed<To>::value),
-  bool wider = (sizeof(From) > sizeof(To) &&
-      (std::is_floating_point<From>::value == std::is_floating_point<To>::value)),
-  bool fp2int = std::is_floating_point<From>::value && !std::is_floating_point<To>::value>
-struct needs_clamp : std::integral_constant<bool, !sign_match || wider || fp2int> {};
+template <typename From, typename To>
+struct needs_clamp {
+  static constexpr bool from_fp = std::is_floating_point<From>::value;
+  static constexpr bool to_fp = std::is_floating_point<To>::value;
+  static constexpr bool from_unsigned = std::is_unsigned<From>::value;
+  static constexpr bool to_unsigned = std::is_unsigned<To>::value;
+
+  static constexpr bool value =
+    // to smaller type of same kind (fp, int)
+    (from_fp == to_fp && sizeof(To) < sizeof(From)) ||
+    // fp32 has range in excess of (u)int64
+    (from_fp && !to_fp) ||
+    // converting to unsigned requires clamping negatives to zero
+    (!from_unsigned && to_unsigned) ||
+    // zero-extending signed unsigned integers requires more bits
+    (from_unsigned && !to_unsigned && sizeof(To) <= sizeof(From));
+};
 
 template <typename T>
 struct ret_type {  // a placeholder for return type

--- a/dali/kernels/common/convert.h
+++ b/dali/kernels/common/convert.h
@@ -1,0 +1,175 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_COMMON_CONVERT_H_
+#define DALI_KERNELS_COMMON_CONVERT_H_
+
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace dali {
+namespace kernels {
+
+template <typename T>
+struct const_limits;
+
+// std::numeric_limits are not compatible with CUDA
+template <typename T>
+__host__ __device__ constexpr T max_value() { return const_limits<T>::max; }
+template <typename T>
+__host__ __device__ constexpr T min_value() { return const_limits<T>::min; }
+
+#define DEFINE_TYPE_RANGE(type, min_, max_) template <>\
+struct const_limits<type> { static constexpr type min = min_, max = max_; };
+
+DEFINE_TYPE_RANGE(uint8_t,  0, 0xff)
+DEFINE_TYPE_RANGE(int8_t,  -0x80, 0x7f)
+DEFINE_TYPE_RANGE(uint16_t, 0, 0xffff)
+DEFINE_TYPE_RANGE(int16_t, -0x8000, 0x7fff)
+DEFINE_TYPE_RANGE(uint32_t, 0, 0xffffffff)
+DEFINE_TYPE_RANGE(int32_t, -0x80000000, 0x7fffffff)
+DEFINE_TYPE_RANGE(uint64_t, 0, 0xffffffffffffffffUL)
+DEFINE_TYPE_RANGE(int64_t, -0x8000000000000000L, 0x7fffffffffffffffL)
+DEFINE_TYPE_RANGE(float, -3.40282347e+38f, 3.40282347e+38f)
+DEFINE_TYPE_RANGE(double, -1.7976931348623157e+308, 1.7976931348623157e+308)
+
+template <typename From, typename To,
+  bool sign_match = (std::is_signed<From>::value == std::is_signed<To>::value),
+  bool wider = (sizeof(From) > sizeof(To) &&
+      (std::is_floating_point<From>::value == std::is_floating_point<To>::value)),
+  bool fp2int = std::is_floating_point<From>::value && !std::is_floating_point<To>::value>
+struct needs_clamp : std::integral_constant<bool, !sign_match || wider || fp2int> {};
+
+template <typename T>
+struct ret_type {  // a placeholder for return type
+  constexpr ret_type() = default;
+};
+
+template <typename T, typename U>
+__host__ __device__ constexpr typename std::enable_if<
+    needs_clamp<U, T>::value && std::is_signed<U>::value,
+    T>::type
+clamp(U value, ret_type<T>) {
+  return value < min_value<T>() ? min_value<T>() :
+         value > max_value<T>() ? max_value<T>() :
+         static_cast<T>(value);
+}
+
+template <typename T, typename U>
+__host__ __device__ constexpr typename std::enable_if<
+    needs_clamp<U, T>::value && std::is_unsigned<U>::value,
+    T>::type
+clamp(U value, ret_type<T>) {
+  return value > max_value<T>() ? max_value<T>() : static_cast<T>(value);
+}
+
+template <typename T, typename U>
+__host__ __device__ constexpr typename std::enable_if<
+    !needs_clamp<U, T>::value,
+    T>::type
+clamp(U value, ret_type<T>) { return value; }
+
+__host__ __device__ constexpr int32_t clamp(uint32_t value, ret_type<int32_t>) {
+  return value & 0x80000000u ? 0x7fffffff : value;
+}
+
+__host__ __device__ constexpr uint32_t clamp(int32_t value, ret_type<uint32_t>) {
+  return value < 0 ? 0u : value;
+}
+
+__host__ __device__ constexpr int32_t clamp(int64_t value, ret_type<int32_t>) {
+  return value < static_cast<int64_t>(min_value<int32_t>()) ? min_value<int32_t>() :
+         value > static_cast<int64_t>(max_value<int32_t>()) ? max_value<int32_t>() :
+         static_cast<int32_t>(value);
+}
+
+template <>
+__host__ __device__ constexpr int32_t clamp(uint64_t value, ret_type<int32_t>) {
+  return value > static_cast<uint64_t>(max_value<int32_t>()) ? max_value<int32_t>() :
+         static_cast<int32_t>(value);
+}
+
+template <>
+__host__ __device__ constexpr uint32_t clamp(int64_t value, ret_type<uint32_t>) {
+  return value < 0 ? 0 :
+         value > static_cast<int64_t>(max_value<uint32_t>()) ? max_value<uint32_t>() :
+         static_cast<uint32_t>(value);
+}
+
+template <>
+__host__ __device__ constexpr uint32_t clamp(uint64_t value, ret_type<uint32_t>) {
+  return value > static_cast<uint64_t>(max_value<uint32_t>()) ? max_value<uint32_t>() :
+         static_cast<uint32_t>(value);
+}
+
+template <typename T, typename U>
+__host__ __device__ constexpr T clamp(U value) {
+  return clamp(value, ret_type<T>());
+}
+
+template <typename Out, typename In>
+__host__ __device__ constexpr Out Convert(In value) {
+  return static_cast<Out>(value);
+}
+
+template <typename Out, typename In>
+__host__ __device__ constexpr Out ConvertSat(In value) {
+  return clamp<Out>(value);
+}
+
+template <typename Out, typename In>
+__host__ __device__ constexpr typename std::enable_if<
+    std::is_floating_point<Out>::value && !std::is_floating_point<In>::value, Out>::type
+ConvertNorm(In value) {
+  return value * (Out(1) / max_value<In>());
+}
+
+template <typename Out, typename In>
+__host__ __device__ constexpr typename std::enable_if<
+    std::is_floating_point<Out>::value && std::is_floating_point<In>::value, Out>::type
+ConvertNorm(In value) {
+  return static_cast<Out>(value);
+}
+
+template <typename Out>
+constexpr __device__ __host__ typename std::enable_if<std::is_unsigned<Out>::value, Out>::type
+ConvertSatNorm(float value) {
+#ifdef __CUDA_ARCH__
+  return max_value<Out>() * __saturatef(value);
+#else
+  return max_value<Out>() * (value < 0.0f ? 0.0f : value > 1.0f ? 1.0f : value);
+#endif
+}
+
+template <typename Out>
+constexpr __device__ __host__ typename std::enable_if<
+  std::is_signed<Out>::value && std::is_integral<Out>::value, Out>::type
+ConvertSatNorm(float value) {
+  return clamp<Out>(value * static_cast<float>(max_value<Out>()));
+}
+
+template <typename Out, typename In>
+__host__ __device__ constexpr typename std::enable_if<
+    !std::is_floating_point<Out>::value && std::is_floating_point<In>::value, Out>::type
+ConvertNorm(In value) {
+  return ConvertSatNorm<Out>(value);
+}
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_COMMON_CONVERT_H_
+

--- a/dali/kernels/common/convert_cuda_test.cu
+++ b/dali/kernels/common/convert_cuda_test.cu
@@ -1,0 +1,42 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/kernels/common/convert.h"
+#include "dali/kernels/common/convert_test_static.h"
+
+namespace dali {
+namespace kernels {
+
+TEST(ConvertNormCUDA, float2int) {
+  EXPECT_EQ(ConvertNorm<uint8_t>(0.0f), 0);
+  EXPECT_EQ(ConvertNorm<uint8_t>(1.0f), 255);
+  EXPECT_EQ(ConvertNorm<int8_t>(1.0f), 127);
+  EXPECT_EQ(ConvertNorm<int8_t>(-1.0f), -127);
+
+  EXPECT_EQ(ConvertNorm<uint16_t>(0.0f), 0);
+  EXPECT_EQ(ConvertNorm<uint16_t>(1.0f), 0xffff);
+  EXPECT_EQ(ConvertNorm<int16_t>(1.0f), 0x7fff);
+  EXPECT_EQ(ConvertNorm<int16_t>(-1.0f), -0x7fff);
+}
+
+TEST(ConvertNormCUDA, int2float) {
+  EXPECT_EQ((ConvertNorm<float, uint8_t>(255)), 1.0f);
+  EXPECT_NEAR((ConvertNorm<float, uint8_t>(127)), 1.0f*127/255, 1e-7f);
+  EXPECT_EQ((ConvertNorm<float, int8_t>(127)), 1.0f);
+  EXPECT_NEAR((ConvertNorm<float, int8_t>(64)), 1.0f*64/127, 1e-7f);
+}
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/common/convert_cuda_test.cu
+++ b/dali/kernels/common/convert_cuda_test.cu
@@ -21,14 +21,29 @@ namespace kernels {
 
 TEST(ConvertNormCUDA, float2int) {
   EXPECT_EQ(ConvertNorm<uint8_t>(0.0f), 0);
+  EXPECT_EQ(ConvertNorm<uint8_t>(0.499f), 127);
   EXPECT_EQ(ConvertNorm<uint8_t>(1.0f), 255);
   EXPECT_EQ(ConvertNorm<int8_t>(1.0f), 127);
+  EXPECT_EQ(ConvertNorm<int8_t>(0.499f), 63);
   EXPECT_EQ(ConvertNorm<int8_t>(-1.0f), -127);
+
 
   EXPECT_EQ(ConvertNorm<uint16_t>(0.0f), 0);
   EXPECT_EQ(ConvertNorm<uint16_t>(1.0f), 0xffff);
   EXPECT_EQ(ConvertNorm<int16_t>(1.0f), 0x7fff);
   EXPECT_EQ(ConvertNorm<int16_t>(-1.0f), -0x7fff);
+}
+
+TEST(ConvertSatNormCUDA, float2int) {
+  EXPECT_EQ(ConvertSatNorm<uint8_t>(2.0f), 255);
+  EXPECT_EQ(ConvertSatNorm<uint8_t>(0.499f), 127);
+  EXPECT_EQ(ConvertSatNorm<uint8_t>(-2.0f), 0);
+  EXPECT_EQ(ConvertSatNorm<int8_t>(2.0f), 127);
+  EXPECT_EQ(ConvertSatNorm<int8_t>(0.499f), 63);
+  EXPECT_EQ(ConvertSatNorm<int8_t>(-2.0f), -128);
+
+  EXPECT_EQ(ConvertSatNorm<int16_t>(2.0f), 0x7fff);
+  EXPECT_EQ(ConvertSatNorm<int16_t>(-2.0f), -0x8000);
 }
 
 TEST(ConvertNormCUDA, int2float) {

--- a/dali/kernels/common/convert_test.cc
+++ b/dali/kernels/common/convert_test.cc
@@ -1,0 +1,42 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/kernels/common/convert.h"
+#include "dali/kernels/common/convert_test_static.h"
+
+namespace dali {
+namespace kernels {
+
+TEST(ConvertNorm, float2int) {
+  EXPECT_EQ(ConvertNorm<uint8_t>(0.0f), 0);
+  EXPECT_EQ(ConvertNorm<uint8_t>(1.0f), 255);
+  EXPECT_EQ(ConvertNorm<int8_t>(1.0f), 127);
+  EXPECT_EQ(ConvertNorm<int8_t>(-1.0f), -127);
+
+  EXPECT_EQ(ConvertNorm<uint16_t>(0.0f), 0);
+  EXPECT_EQ(ConvertNorm<uint16_t>(1.0f), 0xffff);
+  EXPECT_EQ(ConvertNorm<int16_t>(1.0f), 0x7fff);
+  EXPECT_EQ(ConvertNorm<int16_t>(-1.0f), -0x7fff);
+}
+
+TEST(ConvertNorm, int2float) {
+  EXPECT_EQ((ConvertNorm<float, uint8_t>(255)), 1.0f);
+  EXPECT_NEAR((ConvertNorm<float, uint8_t>(127)), 1.0f*127/255, 1e-7f);
+  EXPECT_EQ((ConvertNorm<float, int8_t>(127)), 1.0f);
+  EXPECT_NEAR((ConvertNorm<float, int8_t>(64)), 1.0f*64/127, 1e-7f);
+}
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/common/convert_test.cc
+++ b/dali/kernels/common/convert_test.cc
@@ -21,14 +21,29 @@ namespace kernels {
 
 TEST(ConvertNorm, float2int) {
   EXPECT_EQ(ConvertNorm<uint8_t>(0.0f), 0);
+  EXPECT_EQ(ConvertNorm<uint8_t>(0.499f), 127);
   EXPECT_EQ(ConvertNorm<uint8_t>(1.0f), 255);
   EXPECT_EQ(ConvertNorm<int8_t>(1.0f), 127);
+  EXPECT_EQ(ConvertNorm<int8_t>(0.499f), 63);
   EXPECT_EQ(ConvertNorm<int8_t>(-1.0f), -127);
+
 
   EXPECT_EQ(ConvertNorm<uint16_t>(0.0f), 0);
   EXPECT_EQ(ConvertNorm<uint16_t>(1.0f), 0xffff);
   EXPECT_EQ(ConvertNorm<int16_t>(1.0f), 0x7fff);
   EXPECT_EQ(ConvertNorm<int16_t>(-1.0f), -0x7fff);
+}
+
+TEST(ConvertSatNorm, float2int) {
+  EXPECT_EQ(ConvertSatNorm<uint8_t>(2.0f), 255);
+  EXPECT_EQ(ConvertSatNorm<uint8_t>(0.499f), 127);
+  EXPECT_EQ(ConvertSatNorm<uint8_t>(-2.0f), 0);
+  EXPECT_EQ(ConvertSatNorm<int8_t>(2.0f), 127);
+  EXPECT_EQ(ConvertSatNorm<int8_t>(0.499f), 63);
+  EXPECT_EQ(ConvertSatNorm<int8_t>(-2.0f), -128);
+
+  EXPECT_EQ(ConvertSatNorm<int16_t>(2.0f), 0x7fff);
+  EXPECT_EQ(ConvertSatNorm<int16_t>(-2.0f), -0x8000);
 }
 
 TEST(ConvertNorm, int2float) {

--- a/dali/kernels/common/convert_test_static.h
+++ b/dali/kernels/common/convert_test_static.h
@@ -1,0 +1,108 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_COMMON_CONVERT_TEST_STATIC_H_
+#define DALI_KERNELS_COMMON_CONVERT_TEST_STATIC_H_
+
+#include "dali/kernels/common/convert.h"
+
+namespace dali {
+namespace kernels {
+
+static_assert(clamp<uint8_t>(0) == 0, "Unexpected clamp result");
+static_assert(clamp<uint8_t>(255) == 255, "Unexpected clamp result");
+static_assert(clamp<uint8_t>(100) == 100, "Unexpected clamp result");
+static_assert(clamp<uint8_t>(100.3) == 100, "Unexpected clamp result");
+static_assert(clamp<uint8_t>(256) == 255, "Unexpected clamp result");
+static_assert(clamp<uint8_t>(-4) == 0, "Unexpected clamp result");
+static_assert(clamp<uint8_t>(-4.0f) == 0, "Unexpected clamp result");
+static_assert(clamp<uint8_t>(1e+20f) == 255, "Unexpected clamp result");
+static_assert(clamp<uint8_t>(-1e+20f) == 0, "Unexpected clamp result");
+static_assert(clamp<uint8_t>(1e+200) == 255, "Unexpected clamp result");
+static_assert(clamp<uint8_t>(-1e+200) == 0, "Unexpected clamp result");
+
+static_assert(clamp<int8_t>(-4) == -4, "Unexpected clamp result");
+static_assert(clamp<int8_t>(-4.2) == -4, "Unexpected clamp result");
+static_assert(clamp<int8_t>(4.2) == 4, "Unexpected clamp result");
+static_assert(clamp<int8_t>(127) == 127, "Unexpected clamp result");
+static_assert(clamp<int8_t>(128) == 127, "Unexpected clamp result");
+static_assert(clamp<int8_t>(256) == 127, "Unexpected clamp result");
+static_assert(clamp<int8_t>(-128) == -128, "Unexpected clamp result");
+static_assert(clamp<int8_t>(-256) == -128, "Unexpected clamp result");
+static_assert(clamp<int8_t>(1e+20f) == 127, "Unexpected clamp result");
+static_assert(clamp<int8_t>(-1e+20f) == -128, "Unexpected clamp result");
+static_assert(clamp<int8_t>(1e+200) == 127, "Unexpected clamp result");
+static_assert(clamp<int8_t>(-1e+200) == -128, "Unexpected clamp result");
+
+
+static_assert(clamp<uint16_t>(0) == 0, "Unexpected clamp result");
+static_assert(clamp<uint16_t>(0xffff) == 0xffff, "Unexpected clamp result");
+static_assert(clamp<uint16_t>(100) == 100, "Unexpected clamp result");
+static_assert(clamp<uint16_t>(100.3) == 100, "Unexpected clamp result");
+static_assert(clamp<uint16_t>(0x10000) == 0xffff, "Unexpected clamp result");
+static_assert(clamp<uint16_t>(-4) == 0, "Unexpected clamp result");
+static_assert(clamp<uint16_t>(-4.0f) == 0, "Unexpected clamp result");
+static_assert(clamp<uint16_t>(1e+20f) == 0xffff, "Unexpected clamp result");
+static_assert(clamp<uint16_t>(-1e+20f) == 0, "Unexpected clamp result");
+static_assert(clamp<uint16_t>(1e+200) == 0xffff, "Unexpected clamp result");
+static_assert(clamp<uint16_t>(-1e+200) == 0, "Unexpected clamp result");
+
+
+static_assert(clamp<int16_t>(-4) == -4, "Unexpected clamp result");
+static_assert(clamp<int16_t>(-4.2) == -4, "Unexpected clamp result");
+static_assert(clamp<int16_t>(4.2) == 4, "Unexpected clamp result");
+static_assert(clamp<int16_t>(0x7fff) == 0x7fff, "Unexpected clamp result");
+static_assert(clamp<int16_t>(0x8000) == 0x7fff, "Unexpected clamp result");
+static_assert(clamp<int16_t>(0x10000) == 0x7fff, "Unexpected clamp result");
+static_assert(clamp<int16_t>(-0x8000) == -0x8000, "Unexpected clamp result");
+static_assert(clamp<int16_t>(-0x10000) == -0x8000, "Unexpected clamp result");
+static_assert(clamp<int16_t>(1e+20f) == 0x7fff, "Unexpected clamp result");
+static_assert(clamp<int16_t>(-1e+20f) == -0x8000, "Unexpected clamp result");
+static_assert(clamp<int16_t>(1e+200) == 0x7fff, "Unexpected clamp result");
+static_assert(clamp<int16_t>(-1e+200) == -0x8000, "Unexpected clamp result");
+
+static_assert(needs_clamp<float, uint32_t>::value, "Invalid clamp requirement");
+
+static_assert(sizeof(int) == 4, "Expected 32-bit integer");
+
+static_assert(clamp<uint32_t>(0) == 0, "Unexpected clamp result");
+static_assert(clamp<uint32_t>(0xffffffffLL) == 0xffffffffLL, "Unexpected clamp result");
+static_assert(clamp<uint32_t>(100) == 100, "Unexpected clamp result");
+static_assert(clamp<uint32_t>(100.3) == 100, "Unexpected clamp result");
+static_assert(clamp<uint32_t>(0x100000000LL) == 0xffffffffLL, "Unexpected clamp result");
+static_assert(clamp<uint32_t>(-4) == 0, "Unexpected clamp result");
+static_assert(clamp<uint32_t>(-4.0f) == 0, "Unexpected clamp result");
+static_assert(clamp<uint32_t>(1e+20f) == 0xffffffffu, "Unexpected clamp result");
+static_assert(clamp<uint32_t>(-1.0e+20f) == 0, "Unexpected clamp result");
+static_assert(clamp<uint32_t>(1e+200) == 0xffffffffu, "Unexpected clamp result");
+static_assert(clamp<uint32_t>(-1.0e+200) == 0, "Unexpected clamp result");
+
+static_assert(clamp<int32_t>(-4) == -4, "Unexpected clamp result");
+static_assert(clamp<int32_t>(-4LL) == -4, "Unexpected clamp result");
+static_assert(clamp<int32_t>(-4.2) == -4, "Unexpected clamp result");
+static_assert(clamp<int32_t>(4.2) == 4, "Unexpected clamp result");
+static_assert(clamp<int32_t>(0x7fffffff) == 0x7fffffff, "Unexpected clamp result");
+static_assert(clamp<int32_t>(0x80000000L) == 0x7fffffff, "Unexpected clamp result");
+static_assert(clamp<int32_t>(0x100000000L) == 0x7fffffff, "Unexpected clamp result");
+static_assert(clamp<int32_t>(-0x80000000LL) == -0x7fffffff-1, "Unexpected clamp result");
+static_assert(clamp<int32_t>(-0x100000000LL) == -0x7fffffff-1, "Unexpected clamp result");
+static_assert(clamp<int32_t>(1.0e+20f) == 0x7fffffff, "Unexpected clamp result");
+static_assert(clamp<int32_t>(-1.0e+20f) == -0x80000000L, "Unexpected clamp result");
+static_assert(clamp<int32_t>(1.0e+200) == 0x7fffffff, "Unexpected clamp result");
+static_assert(clamp<int32_t>(-1.0e+200) == -0x80000000L, "Unexpected clamp result");
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_COMMON_CONVERT_TEST_STATIC_H_

--- a/dali/kernels/common/convert_test_static.h
+++ b/dali/kernels/common/convert_test_static.h
@@ -20,6 +20,42 @@
 namespace dali {
 namespace kernels {
 
+// fp to int
+static_assert(needs_clamp<float, int8_t>::value, "Float range exceeds all ints up to 64b");
+static_assert(needs_clamp<float, uint8_t>::value, "Float range exceeds all ints up to 64b");
+static_assert(needs_clamp<float, int16_t>::value, "Float range exceeds all ints up to 64b");
+static_assert(needs_clamp<float, uint16_t>::value, "Float range exceeds all ints up to 64b");
+static_assert(needs_clamp<float, int32_t>::value, "Float range exceeds all ints up to 64b");
+static_assert(needs_clamp<float, uint32_t>::value, "Float range exceeds all ints up to 64b");
+static_assert(needs_clamp<float, int64_t>::value, "Float range exceeds all ints up to 64b");
+static_assert(needs_clamp<float, uint64_t>::value, "Float range exceeds all ints up to 64b");
+
+// same size, different signedness
+static_assert(needs_clamp<int8_t, uint8_t>::value, "Signed <-> unsigned requires clamp");
+static_assert(needs_clamp<uint8_t, int8_t>::value, "Signed <-> unsigned requires clamp");
+static_assert(needs_clamp<int16_t, uint16_t>::value, "Signed <-> unsigned requires clamp");
+static_assert(needs_clamp<uint16_t, int16_t>::value, "Signed <-> unsigned requires clamp");
+static_assert(needs_clamp<int32_t, uint32_t>::value, "Signed <-> unsigned requires clamp");
+static_assert(needs_clamp<uint32_t, int32_t>::value, "Signed <-> unsigned requires clamp");
+static_assert(needs_clamp<int64_t, uint64_t>::value, "Signed <-> unsigned requires clamp");
+static_assert(needs_clamp<uint64_t, int64_t>::value, "Signed <-> unsigned requires clamp");
+
+// larger, but unsigned
+static_assert(needs_clamp<int8_t, uint16_t>::value, "Need to clamp negatives to 0");
+static_assert(needs_clamp<int8_t, uint32_t>::value, "Need to clamp negatives to 0");
+static_assert(needs_clamp<int8_t, uint64_t>::value, "Need to clamp negatives to 0");
+static_assert(needs_clamp<int16_t, uint32_t>::value, "Need to clamp negatives to 0");
+static_assert(needs_clamp<int16_t, uint64_t>::value, "Need to clamp negatives to 0");
+static_assert(needs_clamp<int32_t, uint64_t>::value, "Need to clamp negatives to 0");
+
+
+static_assert(!needs_clamp<int8_t, int8_t>::value, "Clamping not required");
+static_assert(!needs_clamp<int8_t, int16_t>::value, "Clamping not required");
+static_assert(!needs_clamp<uint8_t, int16_t>::value, "Clamping not required");
+static_assert(!needs_clamp<uint8_t, uint16_t>::value, "Clamping not required");
+static_assert(!needs_clamp<float, float>::value, "Clamping not required");
+static_assert(!needs_clamp<float, double>::value, "Clamping not required");
+
 static_assert(clamp<uint8_t>(0) == 0, "Unexpected clamp result");
 static_assert(clamp<uint8_t>(255) == 255, "Unexpected clamp result");
 static_assert(clamp<uint8_t>(100) == 100, "Unexpected clamp result");
@@ -45,7 +81,6 @@ static_assert(clamp<int8_t>(-1e+20f) == -128, "Unexpected clamp result");
 static_assert(clamp<int8_t>(1e+200) == 127, "Unexpected clamp result");
 static_assert(clamp<int8_t>(-1e+200) == -128, "Unexpected clamp result");
 
-
 static_assert(clamp<uint16_t>(0) == 0, "Unexpected clamp result");
 static_assert(clamp<uint16_t>(0xffff) == 0xffff, "Unexpected clamp result");
 static_assert(clamp<uint16_t>(100) == 100, "Unexpected clamp result");
@@ -57,7 +92,6 @@ static_assert(clamp<uint16_t>(1e+20f) == 0xffff, "Unexpected clamp result");
 static_assert(clamp<uint16_t>(-1e+20f) == 0, "Unexpected clamp result");
 static_assert(clamp<uint16_t>(1e+200) == 0xffff, "Unexpected clamp result");
 static_assert(clamp<uint16_t>(-1e+200) == 0, "Unexpected clamp result");
-
 
 static_assert(clamp<int16_t>(-4) == -4, "Unexpected clamp result");
 static_assert(clamp<int16_t>(-4.2) == -4, "Unexpected clamp result");
@@ -71,10 +105,6 @@ static_assert(clamp<int16_t>(1e+20f) == 0x7fff, "Unexpected clamp result");
 static_assert(clamp<int16_t>(-1e+20f) == -0x8000, "Unexpected clamp result");
 static_assert(clamp<int16_t>(1e+200) == 0x7fff, "Unexpected clamp result");
 static_assert(clamp<int16_t>(-1e+200) == -0x8000, "Unexpected clamp result");
-
-static_assert(needs_clamp<float, uint32_t>::value, "Invalid clamp requirement");
-
-static_assert(sizeof(int) == 4, "Expected 32-bit integer");
 
 static_assert(clamp<uint32_t>(0) == 0, "Unexpected clamp result");
 static_assert(clamp<uint32_t>(0xffffffffLL) == 0xffffffffLL, "Unexpected clamp result");
@@ -101,6 +131,11 @@ static_assert(clamp<int32_t>(1.0e+20f) == 0x7fffffff, "Unexpected clamp result")
 static_assert(clamp<int32_t>(-1.0e+20f) == -0x80000000L, "Unexpected clamp result");
 static_assert(clamp<int32_t>(1.0e+200) == 0x7fffffff, "Unexpected clamp result");
 static_assert(clamp<int32_t>(-1.0e+200) == -0x80000000L, "Unexpected clamp result");
+
+static_assert(clamp<int64_t>(1.0e+200) == 0x7fffffffffffffffLL, "Unexpected clamp result");
+static_assert(clamp<int64_t>(-1.0e+200) == -0x7fffffffffffffffLL-1, "Unexpected clamp result");
+static_assert(clamp<uint64_t>(1.0e+200) == 0xffffffffffffffffULL, "Unexpected clamp result");
+static_assert(clamp<uint64_t>(-1.0e+200) == 0, "Unexpected clamp result");
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/gpu_utils.h
+++ b/dali/kernels/gpu_utils.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_GPU_UTILS_H_
+#define DALI_KERNELS_GPU_UTILS_H_
+
+#include <cuda_runtime.h>
+
+namespace dali {
+namespace kernels {
+
+class DeviceGuard {
+ public:
+  explicit DeviceGuard(int new_device) {
+    cudaGetDevice(&original_device_);
+    cudaSetDevice(new_device);
+  }
+  ~DeviceGuard() {
+    cudaSetDevice(original_device_);
+  }
+ private:
+  int original_device_;
+};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_GPU_UTILS_H_

--- a/dali/kernels/span.h
+++ b/dali/kernels/span.h
@@ -19,7 +19,6 @@
 #include <type_traits>
 
 namespace dali {
-namespace kernels {
 
 // Based on "span: bounds-safe views for sequences of objects"
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0122r7.pdf
@@ -153,7 +152,6 @@ constexpr span<T, Extent> make_span(T *data) { return { data }; }
 template <ptrdiff_t Extent = dynamic_extent, typename T>
 constexpr span<T, Extent> make_span(T *data, ptrdiff_t extent) { return { data, extent }; }
 
-}  // namespace kernels
 }  // namespace dali
 
 #endif  // DALI_KERNELS_SPAN_H_

--- a/dali/kernels/test/alloc_test.cc
+++ b/dali/kernels/test/alloc_test.cc
@@ -1,0 +1,104 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <cstring>
+#include "dali/kernels/alloc.h"
+
+namespace dali {
+namespace kernels {
+
+TEST(KernelAlloc, AllocFree) {
+  size_t size = 1<<20;  // 1 MiB
+  const char *names[static_cast<int>(AllocType::Count)] = { "Host", "Pinned", "GPU", "Unified" };
+  for (int i = 0; i < static_cast<int>(AllocType::Count); i++) {
+    AllocType alloc = static_cast<AllocType>(i);
+    void *mem = memory::Allocate(alloc, size);
+    EXPECT_EQ(cudaGetLastError(), 0) << "Error when allocating for " << names[i];
+    ASSERT_NE(mem, nullptr);
+    memory::GetDeleter(alloc)(mem);
+    EXPECT_EQ(cudaGetLastError(), 0) << "Error when freeing for " << names[i];
+  }
+}
+
+TEST(KernelAlloc, HostDevice) {
+  (void)cudaGetLastError();
+  size_t size = 1<<20;  // 1 MiB
+  void *pinned = memory::Allocate(AllocType::Pinned, size);
+  void *plain = memory::Allocate(AllocType::Host, size);
+  void *gpu = memory::Allocate(AllocType::GPU, size);
+
+  ASSERT_NE(pinned, nullptr);
+  ASSERT_NE(plain, nullptr);
+  ASSERT_NE(gpu, nullptr);
+
+  int *data = reinterpret_cast<int*>(pinned);
+  for (size_t i = 0; i < size/sizeof(int); i++)
+    data[i] = i*i + 5;
+  std::memset(plain, 0, size);
+
+  EXPECT_EQ(cudaMemcpy(gpu, pinned, size, cudaMemcpyHostToDevice), 0);
+  EXPECT_EQ(cudaMemcpy(plain, gpu, size, cudaMemcpyDeviceToHost), 0);
+
+  EXPECT_EQ(std::memcmp(plain, pinned, size), 0);
+
+  auto pinned_deallocator = memory::GetDeleter(AllocType::Pinned);
+  auto host_deallocator = memory::GetDeleter(AllocType::Host);
+  auto gpu_deallocator = memory::GetDeleter(AllocType::GPU);
+
+  int count = 1;
+  cudaGetDeviceCount(&count);
+  if (count > 1)
+    cudaSetDevice(1);
+  EXPECT_EQ(cudaGetLastError(), 0);
+  pinned_deallocator(pinned);
+  host_deallocator(plain);
+  gpu_deallocator(gpu);
+  EXPECT_EQ(cudaGetLastError(), 0);
+  cudaSetDevice(0);
+}
+
+TEST(KernelAlloc, Unique) {
+  size_t size = 1<<20;  // 1 M
+  const char *names[static_cast<int>(AllocType::Count)] = { "Host", "Pinned", "GPU", "Unified" };
+  for (int i = 0; i < static_cast<int>(AllocType::Count); i++) {
+    AllocType alloc = static_cast<AllocType>(i);
+    auto ptr = memory::alloc_unique<float>(alloc, size);
+    EXPECT_EQ(cudaGetLastError(), 0) << "Error when allocating for " << names[i];
+    ASSERT_NE(ptr, nullptr);
+    ptr.reset();
+    EXPECT_EQ(cudaGetLastError(), 0) << "Error when freeing for " << names[i];
+  }
+}
+
+TEST(KernelAlloc, Shared) {
+  size_t size = 1<<20;  // 1 M
+  const char *names[static_cast<int>(AllocType::Count)] = { "Host", "Pinned", "GPU", "Unified" };
+  for (int i = 0; i < static_cast<int>(AllocType::Count); i++) {
+    AllocType alloc = static_cast<AllocType>(i);
+    std::shared_ptr<float> ptr = memory::alloc_shared<float>(alloc, size);
+    EXPECT_EQ(cudaGetLastError(), 0) << "Error when allocating for " << names[i];
+    std::shared_ptr<float> ptr2 = ptr;
+    ASSERT_NE(ptr, nullptr);
+    ASSERT_NE(ptr2, nullptr);
+    ptr.reset();
+    ptr2.reset();
+    EXPECT_EQ(cudaGetLastError(), 0) << "Error when freeing for " << names[i];
+  }
+}
+
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/test/mat2tensor.h
+++ b/dali/kernels/test/mat2tensor.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef DALI_KERNELS_TEST_MAT2TENSOR_H_
+#define DALI_KERNELS_TEST_MAT2TENSOR_H_
+
+#include <gtest/gtest.h>
+#include <opencv2/core.hpp>
+#include "dali/kernels/tensor_view.h"
+
+namespace dali {
+namespace kernels {
+
+template <typename T, int ndim = 3>
+TensorView<StorageCPU, const T, ndim> view_as_tensor(const cv::Mat &mat) {
+  TensorShape<ndim> shape;
+  if (ndim != DynamicDimensions) {
+    ASSERT_EQ(ndim, mat.size.dims() + 1), TensorView<StorageCPU, const T, ndim>();
+  } else {
+    shape.resize(mat.size.dims() + 1);
+  }
+  int depth = cv::DataDepth<T>::value;
+  ASSERT_EQ(mat.depth(), depth), TensorView<StorageCPU, const T, ndim>();
+  for (int i = 0; i < mat.size.dims(); i++)
+    shape[i] = mat.size[i];
+  shape[mat.size.dims()] = mat.channels();
+  return { mat.data, shape };
+}
+
+template <typename T, int ndim = 3>
+TensorView<StorageCPU, T, ndim> view_as_tensor(cv::Mat &mat) {
+  TensorShape<ndim> shape;
+  if (ndim != DynamicDimensions) {
+    ASSERT_EQ(ndim, mat.size.dims() + 1), TensorView<StorageCPU, T, ndim>();
+  } else {
+    shape.resize(mat.size.dims() + 1);
+  }
+  int depth = cv::DataDepth<T>::value;
+  ASSERT_EQ(mat.depth(), depth), TensorView<StorageCPU, T, ndim>();
+  for (int i = 0; i < mat.size.dims(); i++)
+    shape[i] = mat.size[i];
+  shape[mat.size.dims()] = mat.channels();
+  return { mat.data, shape };
+}
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_TEST_MAT2TENSOR_H_

--- a/dali/kernels/test/mat2tensor.h
+++ b/dali/kernels/test/mat2tensor.h
@@ -16,43 +16,51 @@
 #ifndef DALI_KERNELS_TEST_MAT2TENSOR_H_
 #define DALI_KERNELS_TEST_MAT2TENSOR_H_
 
-#include <gtest/gtest.h>
 #include <opencv2/core.hpp>
+#include <stdexcept>
 #include "dali/kernels/tensor_view.h"
 
 namespace dali {
 namespace kernels {
 
-template <typename T, int ndim = 3>
-TensorView<StorageCPU, const T, ndim> view_as_tensor(const cv::Mat &mat) {
+template <int ndim>
+TensorShape<ndim> tensor_shape(const cv::Mat &mat) {
   TensorShape<ndim> shape;
   if (ndim != DynamicDimensions) {
-    ASSERT_EQ(ndim, mat.size.dims() + 1), TensorView<StorageCPU, const T, ndim>();
+    // require extra dimension for channels, if #channels > 1
+    if (ndim != mat.size.dims() + 1 && !(ndim == mat.size.dims() && mat.channels() == 1))
+      throw std::logic_error("Invalid number of dimensions");
   } else {
     shape.resize(mat.size.dims() + 1);
   }
-  int depth = cv::DataDepth<T>::value;
-  ASSERT_EQ(mat.depth(), depth), TensorView<StorageCPU, const T, ndim>();
-  for (int i = 0; i < mat.size.dims(); i++)
+  for (int i = 0; i < shape.size(); i++)
     shape[i] = mat.size[i];
-  shape[mat.size.dims()] = mat.channels();
-  return { mat.data, shape };
+  if (shape.size() > mat.size.dims())
+    shape[mat.size.dims()] = mat.channels();
+  return shape;
+}
+
+template <typename T>
+void enforce_type(const cv::Mat &mat) {
+  using U = typename std::remove_const<T>::type;
+  int depth = cv::DataDepth<U>::value;
+  if (depth != mat.depth())
+    throw std::logic_error("Invalid matrix data type");
+}
+
+template <typename T, int ndim = 3>
+TensorView<StorageCPU, T, ndim> view_as_tensor(const cv::Mat &mat) {
+  static_assert(std::is_const<T>::value,
+    "Cannot create a non-const view of a const cv::Mat (Missing `const T`?)");
+
+  enforce_type<T>(mat);
+  return { mat.ptr<T>(0), tensor_shape<ndim>(mat) };
 }
 
 template <typename T, int ndim = 3>
 TensorView<StorageCPU, T, ndim> view_as_tensor(cv::Mat &mat) {
-  TensorShape<ndim> shape;
-  if (ndim != DynamicDimensions) {
-    ASSERT_EQ(ndim, mat.size.dims() + 1), TensorView<StorageCPU, T, ndim>();
-  } else {
-    shape.resize(mat.size.dims() + 1);
-  }
-  int depth = cv::DataDepth<T>::value;
-  ASSERT_EQ(mat.depth(), depth), TensorView<StorageCPU, T, ndim>();
-  for (int i = 0; i < mat.size.dims(); i++)
-    shape[i] = mat.size[i];
-  shape[mat.size.dims()] = mat.channels();
-  return { mat.data, shape };
+  enforce_type<T>(mat);
+  return { mat.ptr<T>(0), tensor_shape<ndim>(mat) };
 }
 
 }  // namespace kernels

--- a/dali/kernels/test/mat2tensor_test.cc
+++ b/dali/kernels/test/mat2tensor_test.cc
@@ -1,0 +1,52 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/kernels/test/mat2tensor.h"
+
+namespace dali {
+namespace testing {
+
+using TensorShape = kernels::TensorShape<>;
+using kernels::view_as_tensor;
+using kernels::tensor_shape;
+
+TEST(Mat2Tensor, Shape) {
+  cv::Mat mat;
+  mat.create(480, 640, CV_8UC3);
+  EXPECT_EQ(tensor_shape<3>(mat), TensorShape(480, 640, 3));
+  mat.create(123, 321, CV_32FC2);
+  EXPECT_EQ(tensor_shape<kernels::DynamicDimensions>(mat), TensorShape(123, 321, 2));
+  mat.create(123, 321, CV_32F);
+  EXPECT_EQ(tensor_shape<3>(mat), TensorShape(123, 321, 1));
+  EXPECT_EQ(tensor_shape<2>(mat), TensorShape(123, 321));
+}
+
+TEST(Mat2Tensor, View) {
+  cv::Mat mat;
+  mat.create(480, 640, CV_32FC3);
+  auto tensor = view_as_tensor<float, 3>(mat);
+  EXPECT_EQ(tensor.data, mat.ptr<float>(0));
+  EXPECT_EQ(tensor.shape, TensorShape(480, 640, 3));
+  const cv::Mat &cmat = mat;
+  auto tensor2 = view_as_tensor<const float, 3>(mat);
+  EXPECT_EQ(tensor2.data, mat.ptr<float>(0));
+  EXPECT_EQ(tensor2.shape, TensorShape(480, 640, 3));
+  auto tensor3 = view_as_tensor<const float, 3>(cmat);
+  EXPECT_EQ(tensor3.shape, TensorShape(480, 640, 3));
+  EXPECT_EQ(tensor3.data, cmat.ptr<float>(0));
+}
+
+}  // namespace testing
+}  // namespace dali

--- a/dali/kernels/test/test_data.h
+++ b/dali/kernels/test/test_data.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_TEST_TEST_DATA_H_
+#define DALI_KERNELS_TEST_TEST_DATA_H_
+
+#include <opencv2/core.hpp>
+#include "dali/kernels/span.h"
+#include "dali/kernels/test/mat2tensor.h"
+
+namespace dali {
+namespace testing {
+
+namespace data {
+  span<uint8_t> file(const char *name);
+  const cv::Mat &image(const char *name, bool color = true);
+}  // namespace data
+
+}  // namespace testing
+}  // namespace dali
+
+#endif  // DALI_KERNELS_TEST_TEST_DATA_H_

--- a/dali/kernels/test/test_data_test.cc
+++ b/dali/kernels/test/test_data_test.cc
@@ -1,0 +1,87 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <opencv2/imgcodecs.hpp>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "dali/kernels/test/test_data.h"
+
+namespace dali {
+namespace testing {
+
+namespace {
+
+const std::string &base_folder() {
+  static const std::string path = "/data/dali/test/test_images/";
+  return path;
+}
+
+inline size_t file_length(std::ifstream &f) {
+  auto pos = f.tellg();
+  f.seekg(0, f.end);
+  size_t length = f.tellg();
+  f.seekg(pos, f.beg);
+  return length;
+}
+
+struct TestDataImpl {
+  span<uint8_t> file(const char *name) {
+    auto result = files.insert({ name, {} });
+    auto &file = result.first->second;
+    if (result.second) {
+      std::string path = name[0] == '/' ? name : base_folder() + name;
+      std::ifstream f(path, std::ios::binary|std::ios::in);
+      if (!f.good())
+        throw std::runtime_error("Cannot load file: " + path);
+      size_t length = file_length(f);
+
+      file.resize(length);
+      f.read(file.data(), length);
+    }
+    return { reinterpret_cast<uint8_t*>(file.data()), (ptrdiff_t)file.size() };
+  }
+
+  const cv::Mat &image(const char *name, bool color) {
+    std::string key = std::string(name)+":"+(color ? "BGR" : "gray");
+    auto result = images.insert({ key, {} });
+    auto &image = result.first->second;
+    if (result.second) {
+      std::string path = name[0] == '/' ? name : base_folder() + name;
+      image = cv::imread(path, color ? cv::IMREAD_COLOR : cv::IMREAD_GRAYSCALE);
+      if (image.empty())
+        throw std::runtime_error("Cannot read image: " + path);
+    }
+    return image;
+  }
+
+  std::unordered_map<std::string, std::vector<char> > files;
+  std::unordered_map<std::string, cv::Mat> images;
+} test_data;
+
+}  // namespace
+
+namespace data {
+span<uint8_t> file(const char *name) {
+  return test_data.file(name);
+}
+
+const cv::Mat &image(const char *name, bool color) {
+  return test_data.image(name, color);
+}
+}  // namespace data
+
+}  // namespace testing
+}  // namespace dali


### PR DESCRIPTION
Type conversions and clamping.
Memory allocation.

NOTE: I had to reinvent a wheel a bit, because `std::numeric_limits::max()` is not a `__device__` function and caused problems with CUDA.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>
