### PR TITLE
Fix TensorFLow example

### DIFF
--- a/docs/examples/tensorflow/demo/nvutils/image_processing.py
+++ b/docs/examples/tensorflow/demo/nvutils/image_processing.py
@@ -66,14 +66,16 @@ class HybridPipe(dali.pipeline.Pipeline):
                 random_aspect_ratio=[0.8, 1.25],
                 random_area=[0.1, 1.0],
                 num_attempts=100)
+            resize_device = "cpu"
         else:
             self.decode = dali.ops.nvJPEGDecoder(
                 device="mixed",
                 output_type=dali.types.RGB)
+            resize_device = "gpu"
 
         if training:
             if dali_cpu:
-                self.resize = dali.ops.Resize (device="cpu", resize_x=width, resize_y=heigth)
+                self.resize = dali.ops.Resize (device=resize_device, resize_x=width, resize_y=height)
             else:
                 self.resize = dali.ops.RandomResizedCrop(
                     device=resize_device,

--- a/qa/L3_RN50_convergence/test_tensorflow.sh
+++ b/qa/L3_RN50_convergence/test_tensorflow.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-cd /opt/tensorflow/nvidia-examples/cnn/
+cd /opt/dali/docs/examples/tensorflow/demo
 
 mkdir -p idx-files/
 
@@ -26,7 +26,7 @@ mpiexec --allow-run-as-root --bind-to socket -np ${NUM_GPUS} \
     python -u resnet.py --layers=50 \
     --data_dir=$DATA_SET_DIR --data_idx_dir=idx-files/ \
     --precision=fp16   --num_iter=90  --iter_unit=epoch --display_every=50 \
-    --batch=256 --use_dali=GPU --log_dir=$OUT \
+    --batch=256 --log_dir=$OUT \
     2>&1 | tee $LOG
 
 RET=${PIPESTATUS[0]}


### PR DESCRIPTION
- fix type in TensorFlow + DALI pipeline example
- make L3 test to run DALI TF example instead of container one

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>