### PR TITLE
Refactor OpGraph - OpNodes and TensorNodes

### DIFF
--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -160,8 +160,8 @@ class DLL_PUBLIC Executor {
 
   // Meta-data about our stage outputs for fast lookup
   using OutputInfo = struct {
-    std::pair<NodeID, int> prod_and_idx;
-    vector<std::pair<NodeID, int>> con_and_idx;
+    std::pair<OpNodeId, int> prod_and_idx;
+    vector<std::pair<OpNodeId, int>> con_and_idx;
   };
   vector<OutputInfo> cpu_output_info_, gpu_output_info_;
 

--- a/dali/pipeline/executor/executor_test.cc
+++ b/dali/pipeline/executor/executor_test.cc
@@ -103,12 +103,12 @@ TEST_F(ExecutorTest, TestPruneBasicGraph) {
   // Validate the graph - op 3 should
   // have been pruned as its outputs
   // are unused.
-  ASSERT_EQ(graph.NumCPUOp(), 2);
-  ASSERT_EQ(graph.NumMixedOp(), 1);
-  ASSERT_EQ(graph.NumGPUOp(), 0);
+  ASSERT_EQ(graph.NumOp(OpType::CPU), 2);
+  ASSERT_EQ(graph.NumOp(OpType::MIXED), 1);
+  ASSERT_EQ(graph.NumOp(OpType::GPU), 0);
 
   // Validate the source op
-  auto& node = graph.node(0);
+  auto& node = graph.Node(0);
   ASSERT_EQ(node.id, 0);
   ASSERT_EQ(node.children.size(), 1);
   ASSERT_EQ(node.parents.size(), 0);
@@ -117,7 +117,7 @@ TEST_F(ExecutorTest, TestPruneBasicGraph) {
   ASSERT_EQ(graph.TensorIdxInSource(node.spec.Output(0)), 0);
   ASSERT_TRUE(graph.TensorIsType<CPUBackend>(node.spec.Output(0)));
 
-  auto& node2 = graph.node(1);
+  auto& node2 = graph.Node(1);
   ASSERT_EQ(node2.id, 1);
   ASSERT_EQ(node2.children.size(), 1);
   ASSERT_EQ(node2.parents.size(), 1);
@@ -127,7 +127,7 @@ TEST_F(ExecutorTest, TestPruneBasicGraph) {
   ASSERT_TRUE(graph.TensorIsType<CPUBackend>(node2.spec.Output(0)));
   ASSERT_EQ(node2.spec.Output(0), "data3_cpu");
 
-  auto& node3 = graph.node(2);
+  auto& node3 = graph.Node(2);
   ASSERT_EQ(node3.id, 2);
   ASSERT_EQ(node3.children.size(), 0);
   ASSERT_EQ(node3.parents.size(), 1);
@@ -174,12 +174,12 @@ TEST_F(ExecutorTest, TestPruneMultiple) {
 
   // Validate the graph - op 2&3 should
   // have been pruned
-  ASSERT_EQ(graph.NumCPUOp(), 1);
-  ASSERT_EQ(graph.NumMixedOp(), 1);
-  ASSERT_EQ(graph.NumGPUOp(), 0);
+  ASSERT_EQ(graph.NumOp(OpType::CPU), 1);
+  ASSERT_EQ(graph.NumOp(OpType::MIXED), 1);
+  ASSERT_EQ(graph.NumOp(OpType::GPU), 0);
 
   // Validate the source op
-  auto& node = graph.node(0);
+  auto& node = graph.Node(0);
   ASSERT_EQ(node.id, 0);
   ASSERT_EQ(node.children.size(), 1);
   ASSERT_EQ(node.parents.size(), 0);
@@ -190,7 +190,7 @@ TEST_F(ExecutorTest, TestPruneMultiple) {
   ASSERT_EQ(node.spec.Output(0), "data1_cpu");
   ASSERT_EQ(node.spec.Output(1), "data2_cpu");
 
-  auto& node2 = graph.node(1);
+  auto& node2 = graph.Node(1);
   ASSERT_EQ(node2.id, 1);
   ASSERT_EQ(node2.children.size(), 0);
   ASSERT_EQ(node2.parents.size(), 1);
@@ -237,12 +237,12 @@ TEST_F(ExecutorTest, TestPruneRecursive) {
 
   // Validate the graph - op 2&3 should
   // have been pruned
-  ASSERT_EQ(graph.NumCPUOp(), 1);
-  ASSERT_EQ(graph.NumMixedOp(), 1);
-  ASSERT_EQ(graph.NumGPUOp(), 0);
+  ASSERT_EQ(graph.NumOp(OpType::CPU), 1);
+  ASSERT_EQ(graph.NumOp(OpType::MIXED), 1);
+  ASSERT_EQ(graph.NumOp(OpType::GPU), 0);
 
   // Validate the source op
-  auto& node = graph.node(0);
+  auto& node = graph.Node(0);
   ASSERT_EQ(node.id, 0);
   ASSERT_EQ(node.children.size(), 1);
   ASSERT_EQ(node.parents.size(), 0);
@@ -252,7 +252,7 @@ TEST_F(ExecutorTest, TestPruneRecursive) {
   ASSERT_EQ(node.spec.NumOutput(), 1);
   ASSERT_EQ(node.spec.Output(0), "data1_cpu");
 
-  auto& node2 = graph.node(1);
+  auto& node2 = graph.Node(1);
   ASSERT_EQ(node2.id, 1);
   ASSERT_EQ(node2.children.size(), 0);
   ASSERT_EQ(node2.parents.size(), 1);
@@ -374,7 +374,8 @@ TEST_F(ExecutorTest, TestRunBasicGraph) {
   exe.Build(&graph, outputs);
 
   // Set the data for the external source
-  auto *src_op = dynamic_cast<ExternalSource<CPUBackend>*>(graph.cpu_node(0).op.get());
+  auto *src_op =
+      dynamic_cast<ExternalSource<CPUBackend> *>(graph.Node(OpType::CPU, 0).op.get());
   ASSERT_NE(src_op, nullptr);
   TensorList<CPUBackend> tl;
   this->MakeJPEGBatch(&tl, this->batch_size_);
@@ -421,7 +422,8 @@ TEST_F(ExecutorTest, TestRunBasicGraphWithCB) {
   exe.Build(&graph, outputs);
 
   // Set the data for the external source
-  auto *src_op = dynamic_cast<ExternalSource<CPUBackend>*>(graph.cpu_node(0).op.get());
+  auto *src_op =
+      dynamic_cast<ExternalSource<CPUBackend> *>(graph.Node(OpType::CPU, 0).op.get());
   ASSERT_NE(src_op, nullptr);
   TensorList<CPUBackend> tl;
   this->MakeJPEGBatch(&tl, this->batch_size_);
@@ -479,7 +481,8 @@ TEST_F(ExecutorTest, TestPrefetchedExecution) {
   exe.Build(&graph, outputs);
 
   // Set the data for the external source
-  auto *src_op = dynamic_cast<ExternalSource<CPUBackend>*>(graph.cpu_node(0).op.get());
+  auto *src_op =
+      dynamic_cast<ExternalSource<CPUBackend> *>(graph.Node(OpType::CPU, 0).op.get());
   ASSERT_NE(src_op, nullptr);
   TensorList<CPUBackend> tl;
   this->MakeJPEGBatch(&tl, this->batch_size_*2);

--- a/dali/pipeline/graph_descr.cc
+++ b/dali/pipeline/graph_descr.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+
 #include "dali/pipeline/op_graph.h"
 
 #include "dali/pipeline/operators/op_schema.h"
@@ -93,54 +95,49 @@ StorageDevice ParseStorageDevice(const std::string &io_device) {
 
 }  // namespace
 
+OpNode& OpGraph::PlaceNewOp(OpType op_type, OpSpec op_spec, std::string instance_name) {
+  op_nodes_.push_back(OpNode());
+  auto &node = op_nodes_.back();
+  node.id = op_nodes_.size() - 1;
+  node.spec = op_spec;
+  node.instance_name = std::move(instance_name);
+  node.op_type = op_type;
+  auto new_partition_id = NumOp(op_type);
+  node.partition_index = new_partition_id;
+  node_partitions_[static_cast<int>(op_type)].push_back(node.id);
+  return node;
+}
+
+TensorNode& OpGraph::PlaceNewTensor() {
+  tensor_nodes_.push_back(TensorNode());
+  tensor_nodes_.back().id = tensor_nodes_.size() - 1;
+  return tensor_nodes_.back();
+}
+
 void OpGraph::AddOp(const OpSpec &spec, const std::string& name) {
   // Validate the op specification
   CheckOpConstraints(spec);
 
   string device = spec.GetArgument<string>("device");
   auto op_type = ParseOpType(device);
-  OpNode *new_node;
   switch (op_type) {
     case OpType::CPU: {
       // Enforce graph constraints
       DALI_ENFORCE(AllInputsCPU(spec), "CPU ops cannot receive GPU input data.");
       DALI_ENFORCE(AllOutputsCPU(spec), "CPU ops can only produce CPU output data.");
-
-      cpu_nodes_.resize(cpu_nodes_.size()+1);
-      OpNode &cpu_node = cpu_nodes_.back();
-      id_to_node_map_.push_back({OpType::CPU, cpu_nodes_.size()-1});
-
-      new_node = &cpu_node;
       break;
     }
     case OpType::GPU: {
-      gpu_nodes_.resize(gpu_nodes_.size()+1);
-      OpNode &gpu_node = gpu_nodes_.back();
-      id_to_node_map_.push_back({OpType::GPU, gpu_nodes_.size()-1});
-
-      new_node = &gpu_node;
       break;
     }
     case OpType::MIXED: {
       // Enforce graph constraints
       DALI_ENFORCE(AllInputsCPU(spec), "Mixed ops cannot receive GPU input data.");
-
-      mixed_nodes_.resize(mixed_nodes_.size()+1);
-      OpNode &mixed_node = mixed_nodes_.back();
-      id_to_node_map_.push_back({OpType::MIXED, mixed_nodes_.size()-1});
-
-      new_node = &mixed_node;
       break;
     }
     case OpType::SUPPORT: {
       // Enforce graph constraints
       DALI_ENFORCE(AllInputsCPU(spec), "Support ops cannot receive GPU input data.");
-
-      support_nodes_.resize(support_nodes_.size()+1);
-      OpNode &support_node = support_nodes_.back();
-      id_to_node_map_.push_back({OpType::SUPPORT, support_nodes_.size() - 1});
-
-      new_node = &support_node;
       break;
     }
     default:
@@ -148,305 +145,375 @@ void OpGraph::AddOp(const OpSpec &spec, const std::string& name) {
           "\". Valid options are \"cpu\", \"gpu\" or \"mixed\"");
       break;
   }
-
   // Add node meta-data and add to the list of nodes
-  new_node->id = NumOp()-1;
-  new_node->spec = spec;
-  new_node->instance_name = name;
+  auto &new_node = PlaceNewOp(op_type, spec, name);
 
   // Setup references between nodes. We require that the
   // ops are added to the graph in a topological ordering.
   // This loop will verify this by ensuring that all inputs
   // to the new op have already been created.
   for (int i = 0; i < spec.NumInput(); ++i) {
-    // Add parent node id
-    auto parent_id = TensorSourceID(spec.Input(i));
+    // Get the tensor id we are consuming by its name
+    auto it = tensor_name_to_id_.find(spec.Input(i));
+    DALI_ENFORCE(it != tensor_name_to_id_.end(), "Tensor with name \"" +
+        name + "\" has no known source.");
+    auto consumed_tensor_id = it->second;
+
+    // Add parent node id, checks if parent node exists in graph
+    auto parent_id = tensor_nodes_[consumed_tensor_id].producer.node;
 
     // Note: We don't care if the parent has already
     // been added to this nodes set of parents, so
     // we don't check the return value.
-    new_node->parents.insert(parent_id);
+    new_node.parents.insert(parent_id);
 
     // Add new node as child
-    auto &parent_node = this->node(parent_id);
-    parent_node.children.insert(new_node->id);
+    auto &parent_node = this->Node(parent_id);
+    parent_node.children.insert(new_node.id);
+
+    // Place it as a parent tensor
+    new_node.parent_tensors.push_back(consumed_tensor_id);
 
     // Update the consumer info for this tensor
     TensorMeta meta;
-    meta.node = new_node->id;
+    meta.node = new_node.id;
     meta.index = i;
     meta.is_support = spec.IsArgumentInput(i);
     meta.storage_device = ParseStorageDevice(spec.InputDevice(i));
 
-    vector<TensorMeta> &consumer_info = tensor_consumers_[spec.Input(i)];
-    consumer_info.push_back(meta);
+    // Insert new tensor consumer
+    tensor_nodes_[consumed_tensor_id].consumers.push_back(meta);
   }
 
   // Mark this op as the source of its output tensors
+  // Create TensorNodes for outputs and respective edges for this OpNode -> TensorNodes
   for (int i = 0; i < spec.NumOutput(); ++i) {
-    string name = spec.Output(i);
-
     // Set the producer info for this tensor
     TensorMeta meta;
-    meta.node = new_node->id;
+    meta.node = new_node.id;
     meta.index = i;
     meta.is_support = spec.GetArgument<string>("device") == "support";
     meta.storage_device = ParseStorageDevice(spec.OutputDevice(i));
 
-    auto ret = tensor_producers_.insert({name, meta});
-    DALI_ENFORCE(ret.second, "Operator '" + spec.name() +
+    string name = spec.Output(i);
+
+    // Place new Tensor with producer info and add edge to OpNode.
+    auto &new_tensor = PlaceNewTensor();
+    new_tensor.producer = meta;
+    new_tensor.name = name;
+    new_node.children_tensors.push_back(new_tensor.id);
+
+    auto it_inserted = tensor_name_to_id_.insert({name, new_tensor.id});
+    DALI_ENFORCE(it_inserted.second, "Operator '" + spec.name() +
         "' has output with name " + name + ", but output "
         "with this name already exists as output of op '" +
-        this->node(TensorSourceID(name)).spec.name() + "'");
+        this->Node(TensorSourceID(name)).spec.name() + "'");
   }
 }
 
 void OpGraph::InstantiateOperators() {
   // traverse devices by topological order (support, cpu, mixed, gpu)
-  for (auto &node : support_nodes_) {
-    if (node.op)
-      continue;
-    auto &spec = node.spec;
-    string device = spec.GetArgument<string>("device");
-    node.op = SupportOperatorRegistry::Registry().Create(spec.name(), spec, &device);
-  }
-  for (auto &node : cpu_nodes_) {
-    if (node.op)
-      continue;
-    auto &spec = node.spec;
-    string device = spec.GetArgument<string>("device");
-    node.op = CPUOperatorRegistry::Registry().Create(spec.name(), spec, &device);
-  }
-  for (auto &node : mixed_nodes_) {
-    if (node.op)
-      continue;
-    auto &spec = node.spec;
-    string device = spec.GetArgument<string>("device");
-    node.op = MixedOperatorRegistry::Registry().Create(spec.name(), spec, &device);
-  }
-  for (auto &node : gpu_nodes_) {
-    if (node.op)
-      continue;
-    auto &spec = node.spec;
-    string device = spec.GetArgument<string>("device");
-    node.op = GPUOperatorRegistry::Registry().Create(spec.name(), spec, &device);
+  OpType order[] = {OpType::SUPPORT, OpType::CPU, OpType::MIXED, OpType::GPU};
+
+  for (auto op_type : order) {
+    for (auto op_id : node_partitions_[static_cast<int>(op_type)]) {
+      op_nodes_[op_id].InstantiateOperator();
+    }
   }
 }
 
+void OpGraph::SwapTensorNodes(TensorNodeId left_id, TensorNodeId right_id) {
+  auto &left = tensor_nodes_[left_id];
+  auto &right = tensor_nodes_[right_id];
+  // Change ids in producers (there is only one) of left
+  auto &left_prod = Node(left.producer.node);
+  left_prod.children_tensors[left.producer.index] = right_id;
+  // Change ids in producers (there is only one) of right
+  auto &right_prod = Node(right.producer.node);
+  right_prod.children_tensors[right.producer.index] = left_id;
+  // Change ids in consumers of left node to right id
+  for (auto &cons_edge : left.consumers) {
+    auto &cons = Node(cons_edge.node);
+    cons.parent_tensors[cons_edge.index] = right_id;
+  }
+  // Change ids in consumers of right node to left id
+  for (auto &cons_edge : right.consumers) {
+    auto &cons = Node(cons_edge.node);
+    cons.parent_tensors[cons_edge.index] = left_id;
+  }
+  // Clean up names mapping
+  tensor_name_to_id_[left.name] = right_id;
+  tensor_name_to_id_[right.name] = left_id;
+  // Swap the actual nodes
+  left.id = right_id;
+  right.id = left_id;
+  std::swap(left, right);
+}
+
+void OpGraph::RemoveTensorNode(TensorNodeId id) {
+  DALI_ENFORCE_VALID_INDEX(id, (Index)tensor_nodes_.size());
+  DALI_ENFORCE(tensor_nodes_[id].consumers.empty(),
+               "Removed tensors cannot have any consumers.");
+  // Swap it out
+  for (TensorNodeId i = id + 1; i < static_cast<int>(tensor_nodes_.size()); i++) {
+    // Move from i to i - 1
+    SwapTensorNodes(i, i - 1);
+  }
+  // We remove the last element
+  tensor_nodes_.pop_back();
+  // There is no option to remove from positional array of tensor produced by parent op
+}
+
+void OpGraph::SwapOpNodes(OpNodeId left_id, OpNodeId right_id) {
+  auto &left = op_nodes_[left_id];
+  auto &right = op_nodes_[right_id];
+  // Swap all references in tensor edges
+  // Produced tensors (children)
+  {
+    auto &tensor_nodes_ref = tensor_nodes_;
+    auto swap_ids_in_parent_tensor = [&tensor_nodes_ref](OpNode &node, OpNodeId new_id) {
+      for (auto tid : node.children_tensors) {
+        auto &tensor = tensor_nodes_ref[tid];
+        // edges from node to tensor
+        tensor.producer.node = new_id;
+      }
+    };
+    swap_ids_in_parent_tensor(left, right_id);
+    swap_ids_in_parent_tensor(right, left_id);
+  }
+  // Consumed tensors (parents). As we can have overlapping parents, we do this in two steps
+  // otherwise we could overwrite twice.
+  {
+    auto &tensor_nodes_ref = tensor_nodes_;
+    auto swap_ids_in_child_tensor = [&tensor_nodes_ref](OpNode &node, OpNodeId old_id,
+                                                        OpNodeId new_id) {
+      for (auto tid : node.parent_tensors) {
+        auto &tensor = tensor_nodes_ref[tid];
+        // edges from tensor to node
+        for (auto &edge : tensor.consumers) {
+          if (edge.node == old_id) {
+            edge.node = new_id;
+          }
+        }
+      }
+    };
+    constexpr OpNodeId dummy_id = -1;
+    swap_ids_in_child_tensor(left, left_id, dummy_id);
+    swap_ids_in_child_tensor(right, right_id, left_id);
+    swap_ids_in_child_tensor(left, dummy_id, right_id);
+  }
+  // Swap all references in parent and children ops
+  {
+    auto &op_nodes_ref = op_nodes_;
+    auto remove_id_in_family_op = [&op_nodes_ref](OpNode &node, OpNodeId old_id) {
+      for (auto oid : node.parents) {
+        op_nodes_ref[oid].children.erase(old_id);
+      }
+      for (auto oid : node.children) {
+        op_nodes_ref[oid].parents.erase(old_id);
+      }
+    };
+    auto add_id_in_family_op = [&op_nodes_ref](OpNode &node, OpNodeId new_id) {
+      for (auto oid : node.parents) {
+        op_nodes_ref[oid].children.insert(new_id);
+      }
+      for (auto oid : node.children) {
+        op_nodes_ref[oid].parents.insert(new_id);
+      }
+    };
+    remove_id_in_family_op(left, left_id);
+    remove_id_in_family_op(right, right_id);
+    add_id_in_family_op(left, right_id);
+    add_id_in_family_op(right, left_id);
+  }
+
+  // Swap the nodes
+  left.id = right_id;
+  right.id = left_id;
+  std::swap(left, right);
+}
+
+void OpGraph::RemoveOpNode(OpNodeId id) {
+  DALI_ENFORCE_VALID_INDEX(id, (Index)op_nodes_.size());
+  auto &target_op = op_nodes_[id];
+  DALI_ENFORCE(target_op.children.empty(), "Overwritten ops cannot have any children.");
+  DALI_ENFORCE(target_op.children_tensors.empty(),
+               "All produced tensors should be removed before removing op"
+               " and list of children tensors should be invalidated.");
+  for (OpNodeId i = id + 1; i < static_cast<int>(op_nodes_.size()); i++) {
+    // Move from i to i - 1
+    SwapOpNodes(i - 1, i);
+  }
+  // Remove the edge from parent Ops
+  for (auto parent_id : op_nodes_.back().parents) {
+    Node(parent_id).children.erase(op_nodes_.back().id);
+  }
+  // assume that we removed one element
+  op_nodes_.pop_back();
+}
+
+namespace {
+
+/**
+ * @brief Removes element from `index` by swapping with back and poping
+ *
+ * Does not maintain the order of elements in vector
+ * @tparam T
+ * @param vector
+ * @param index
+ */
+template <typename T>
+void RemoveVectorElement(T& vector, int index) {
+  std::swap(vector[index], vector.back());
+  vector.pop_back();
+}
+
+}  // namespace
+
 // Op Removal Process:
-// 1. Validate we can remove it (it has no children)
-// 2. Remove its tensors
-// 3. Remove it as a child of all ops
-// 4. Decrement all child ids > id
-// 5. Decrement all parent ids > id
-// 5. Decrement all op ids > id
-// 6. remove id map entry for target
-// 7. remove object for target
-// 8. update id map for ops after target in its typed vector
-void OpGraph::RemoveOp(NodeID id) {
-  OpNode &target = this->node(id);
+// 1. Validate we can remove it (it has no children & no consumers for produced tensors)
+// 2. Remove tensors it produces
+// 3. Remove us from consumer lists of parent tensors
+// 4. Remove the OpNode with edges from parent Ops
+// 6. Correct the partitions as we changed the ids while removing OpNode
+void OpGraph::RemoveOp(OpNodeId id) {
+  OpNode &target = this->Node(id);
 
   // If the node has any children, we cannot remove it
   DALI_ENFORCE(target.children.empty(), "Node '" + target.spec.name() +
       "' has " + std::to_string(target.children.size()) +
       ". Cannot remove");
-
-  // Remove this nodes tensors from the graph
-  for (int i = 0; i < target.spec.NumOutput(); ++i) {
-    tensor_producers_.erase(target.spec.Output(i));
+  for (auto t : target.children_tensors) {
+    DALI_ENFORCE(tensor_nodes_[t].consumers.empty(), "Node '" + target.spec.name() +
+      "' produces a tensor that has " + std::to_string(tensor_nodes_[t].consumers.size()) +
+      " consumers. Cannot remove");
   }
 
-  // Remove references to this node as a consumer
-  for (int i = 0; i < target.spec.NumInput(); ++i) {
-    auto it = tensor_consumers_.find(target.spec.Input(i));
-    DALI_ENFORCE(it != tensor_consumers_.end(), "Could not find "
-        "consumer entries for tensor, but target node is a consumer.");
-    vector<TensorMeta> &consumer_info = it->second;
-    bool erased = false;
-    for (size_t j = 0; j < consumer_info.size(); ++j) {
-      if (consumer_info[j].node == id) {
-        consumer_info.erase(consumer_info.begin() + j);
-        erased = true;
-        break;
-      }
-    }
-    DALI_ENFORCE(erased, "Could not find entry for target node as tensor consumer.");
+  // Remove all tensors produced by this node and invalidate list of children tensors
+  for (auto t : target.children_tensors) {
+    RemoveTensorNode(t);
   }
+  target.children_tensors.clear();
 
-  for (int i = 0; i < this->NumOp(); ++i) {
-    OpNode &node = this->node(i);
-    if (node.id > id) {
-      // Decrement this nodes id to account for
-      // the removal of the node with id `id`.
-      --node.id;
-
-      // Update all of its outputs with the new id
-      for (int j = 0; j < node.spec.NumOutput(); ++j) {
-        auto it = tensor_producers_.find(node.spec.Output(j));
-        DALI_ENFORCE(it != tensor_producers_.end(),
-            "Could not find tensor source entry.");
-
-        it->second.node = node.id;
+  // In case we consume this tensor more than once, we try to remove all occurences
+  for (auto t : target.parent_tensors) {
+    auto &sibling_consumers = tensor_nodes_[t].consumers;
+    for (size_t i = 0; i < sibling_consumers.size(); i++) {
+      if (sibling_consumers[i].node == id) {
+        RemoveVectorElement(sibling_consumers, i);
       }
-
-      // Update all of its consumer records with new id
-      for (int j = 0; j < node.spec.NumInput(); ++j) {
-        auto it = tensor_consumers_.find(node.spec.Input(j));
-        DALI_ENFORCE(it != tensor_consumers_.end(), "Could not find "
-            "consumer entries for tensor, but current node is a consumer.");
-        vector<TensorMeta> &consumer_info = it->second;
-        bool found = false;
-        for (size_t k = 0; k < consumer_info.size(); ++k) {
-          if (consumer_info[k].node == node.id+1) {
-            consumer_info[k].node = node.id;
-            found = true;
-            break;
-          }
-        }
-        DALI_ENFORCE(found, "Could not find entry for current "
-            "node as tensor consumer.");
-      }
-    }
-
-    // Scan its parents and children. If the target is
-    // a child, remove it as it no longer exists. If
-    // a node with an id > the target id is a parent
-    // or child, we will decrement its id to account
-    // for the removal.
-    vector<NodeID> to_add;
-    auto it = node.parents.begin();
-    while (it != node.parents.end()) {
-      // This should never occur, we have previously checked
-      // that the target has no children in the graph
-      DALI_ENFORCE(*it != id, "Found node with target as parent.");
-      if (*it > id) {
-        to_add.push_back((*it) - 1);
-        it = node.parents.erase(it);
-      } else {
-        ++it;
-      }
-    }
-    for (auto &parent : to_add) {
-      DALI_ENFORCE(node.parents.insert(parent).second,
-          "Insertion of updated parent id failed.");
-    }
-    to_add.clear();
-
-    // Remove the target node id if it is a child
-    node.children.erase(id);
-    it = node.children.begin();
-    while (it != node.children.end()) {
-      if (*it > id) {
-        to_add.push_back((*it) - 1);
-        it = node.children.erase(it);
-      } else {
-        ++it;
-      }
-    }
-    for (auto &child : to_add) {
-      DALI_ENFORCE(node.children.insert(child).second,
-          "Insertion of updated child id failed.");
     }
   }
 
-  // Remove this nodes entry from the id map. This will
-  // effectively decrement all node ids after this node
-  // to fill the gap.
-  //
-  auto type_and_idx = id_to_node_map_[id];
-  OpType type = type_and_idx.first;
-  int idx = type_and_idx.second;
-  id_to_node_map_.erase(id_to_node_map_.begin() + id);
+  RemoveOpNode(id);
+  Repartition();
+}
 
-  // Remove the typed node object for the target node.
-  // We will then need to update the id map entry for
-  // all nodes of this type that follow the deleted node
-  switch (type) {
-  case OpType::CPU:
-    cpu_nodes_.erase(cpu_nodes_.begin() + idx);
-
-    for (size_t i = idx; i < cpu_nodes_.size(); ++i) {
-      OpNode &cpu_node = this->cpu_node(i);
-      id_to_node_map_[cpu_node.id].second = i;
-    }
-    break;
-  case OpType::GPU:
-    gpu_nodes_.erase(gpu_nodes_.begin() + idx);
-
-    for (size_t i = idx; i < gpu_nodes_.size(); ++i) {
-      OpNode &gpu_node = this->gpu_node(i);
-      id_to_node_map_[gpu_node.id].second = i;
-    }
-    break;
-  case OpType::MIXED:
-    mixed_nodes_.erase(mixed_nodes_.begin() + idx);
-
-    for (size_t i = idx; i < mixed_nodes_.size(); ++i) {
-      OpNode &mixed_node = this->mixed_node(i);
-      id_to_node_map_[mixed_node.id].second = i;
-    }
-    break;
-  case OpType::SUPPORT:
-    support_nodes_.erase(support_nodes_.begin() + idx);
-
-    for (size_t i = idx; i < support_nodes_.size(); ++i) {
-      OpNode &support_node = this->support_node(i);
-      id_to_node_map_[support_node.id].second = i;
-    }
-    break;
-  default:
-    DALI_FAIL("Invalid OpType");
+void OpGraph::Repartition() {
+  for (auto & p : node_partitions_) {
+    p.clear();
+  }
+  for (auto &node : op_nodes_) {
+    auto new_partition_id = NumOp(node.op_type);
+    node.partition_index = new_partition_id;
+    node_partitions_[static_cast<int>(node.op_type)].push_back(node.id);
   }
 }
 
-OpNode& OpGraph::node(NodeID id) {
-  DALI_ENFORCE_VALID_INDEX(id, id_to_node_map_.size());
-  auto idx_pair = id_to_node_map_[id];
-
-  switch (idx_pair.first) {
-  case OpType::CPU:
-    return cpu_nodes_[idx_pair.second];
-    break;
-  case OpType::GPU:
-    return gpu_nodes_[idx_pair.second];
-    break;
-  case OpType::MIXED:
-    return mixed_nodes_[idx_pair.second];
-    break;
-  case OpType::SUPPORT:
-    return support_nodes_[idx_pair.second];
-    break;
-  default:
-    DALI_FAIL("Internal error. Invalid node type index.");
-  }
-}
-
-OpNode& OpGraph::node(const std::string& name) {
-  // Search cpu nodes
-  for (auto& node : cpu_nodes_) {
-    if (node.instance_name == name) {
-      return node;
-    }
-  }
-  // Search gpu nodes
-  for (auto& node : gpu_nodes_) {
-    if (node.instance_name == name) {
-      return node;
-    }
-  }
-  // Search mixed nodes
-  for (auto& node : mixed_nodes_) {
-    if (node.instance_name == name) {
-      return node;
-    }
-  }
-  // Search support nodes
-  for (auto& node : support_nodes_) {
+// TODO(klecki): get rid of string indexing
+OpNode& OpGraph::Node(const std::string& name) {
+  for (auto &node : op_nodes_) {
     if (node.instance_name == name) {
       return node;
     }
   }
   DALI_FAIL("Operator node with name " + name + " not found.");
+}
+
+namespace {
+  /**
+   * @brief Prints instance_name of OpNode to stream
+   *
+   * @param ofs
+   * @param node
+   * @param show_ids Whether to print name concatenated with `_id`.
+   * @return std::ofstream&
+   */
+  std::ofstream& PrintTo(std::ofstream &ofs, const OpNode& node, bool show_ids) {
+    ofs << node.instance_name;
+    if (show_ids) {
+      ofs << "_" << node.id;
+    }
+    return ofs;
+  }
+  /**
+   * @brief Prints TensorNode's name to stream
+   *
+   * @param ofs
+   * @param node
+   * @param show_ids Whether to print name concatenated with `_id`.
+   * @return std::ofstream&
+   */
+  std::ofstream&  PrintTo(std::ofstream &ofs, const TensorNode& node, bool show_ids) {
+    ofs << node.name;
+    if (show_ids) {
+      ofs << "_" << node.id;
+    }
+    return ofs;
+  }
+  std::string GetOpColor(OpType op_type) {
+    switch (op_type) {
+      case OpType::CPU:
+        return "blue";
+      case OpType::GPU:
+        return "#76b900";
+      case OpType::MIXED:
+        return "cyan";
+      case OpType::SUPPORT:
+        return "grey";
+      default:
+        return "black";
+    }
+  }
+}  // namespace
+
+void OpGraph::GenerateDOTFromGraph(std::ofstream &ofs, bool show_tensors, bool show_ids,
+                                   bool use_colors) {
+  // Just output all the edges
+  for (auto &op : op_nodes_) {
+    if (use_colors) {
+      PrintTo(ofs, op, show_ids) << "[color=\"" << GetOpColor(op.op_type) << "\"];\n";
+    }
+    for (auto child_id : op.children) {
+      auto& child_node = Node(child_id);
+      PrintTo(ofs, op, show_ids) << " -> ";
+      PrintTo(ofs, child_node, show_ids);
+      if (show_tensors) {
+        ofs << "[style=dotted]";
+      }
+      ofs << ";\n";
+    }
+    if (show_tensors) {
+      int i = 0;
+      for (auto t_id : op.children_tensors) {
+        TensorNode& child_tensor = Tensor(t_id);
+        PrintTo(ofs, child_tensor, show_ids) << "[shape=box];\n";
+        PrintTo(ofs, op, show_ids) << " -> ";
+        PrintTo(ofs, child_tensor, show_ids) << "[label=" << i++ <<"];\n";
+        GenerateDOTFromGraph(child_tensor, ofs, show_tensors, show_ids);
+      }
+    }
+    ofs << "\n";
+  }
+}
+
+void OpGraph::GenerateDOTFromGraph(const TensorNode &current_node, std::ofstream &ofs,
+                                   bool show_tensors, bool show_ids) {
+  for (auto edge : current_node.consumers) {
+      PrintTo(ofs, current_node, show_ids) << " -> ";
+      auto &child_op = Node(edge.node);
+      PrintTo(ofs, child_op, show_ids) << "[label=" << edge.index << "];\n";
+  }
 }
 
 template <>

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -263,9 +263,9 @@ void Pipeline::PropagateMemoryHint(OpNode &node) {
   assert(node.parents.size() == 1);
   for (int inp_idx = 0; inp_idx < node.spec.NumRegularInput(); inp_idx++) {
     auto input_name = node.spec.Input(inp_idx);
-    NodeID parent_node_id = graph_.TensorSourceID(input_name);
+    OpNodeId parent_node_id = graph_.TensorSourceID(input_name);
     int idx = graph_.TensorIdxInSource(input_name);
-    auto &src = graph_.node(parent_node_id);
+    auto &src = graph_.Node(parent_node_id);
     int hint = GetMemoryHint(src.spec, idx);
     if (hint) {
       // inp_idx == out_idx for MakeContiguous
@@ -365,8 +365,8 @@ void Pipeline::Build(vector<std::pair<string, string>> output_names) {
     }
   }
 
-  for (int i = 0; i < graph_.NumMixedOp(); i++) {
-    OpNode &node = graph_.mixed_node(i);
+  for (int i = 0; i < graph_.NumOp(OpType::MIXED); i++) {
+    OpNode &node = graph_.Node(OpType::MIXED, i);
     if (node.spec.name() == "MakeContiguous") {
       PropagateMemoryHint(node);
     }
@@ -573,20 +573,20 @@ string Pipeline::SerializeToProtobuf() const {
 }
 
 OpNode * Pipeline::GetOperatorNode(const std::string& name) {
-  return &(graph_.node(name));
+  return &(graph_.Node(name));
 }
 
 std::map<std::string, Index> Pipeline::EpochSize() {
   std::map<std::string, Index> ret;
-  for (Index i = 0; i < graph_.NumCPUOp(); ++i) {
-    const OpNode& current = graph_.cpu_node(i);
+  for (Index i = 0; i < graph_.NumOp(OpType::CPU); ++i) {
+    const OpNode &current = graph_.Node(OpType::CPU, i);
     Index epoch_size = current.op->epoch_size();
     if (epoch_size != -1) {
       ret.insert(make_pair(current.instance_name, epoch_size));
     }
   }
-  for (Index i = 0; i < graph_.NumGPUOp(); ++i) {
-    const OpNode& current = graph_.gpu_node(i);
+  for (Index i = 0; i < graph_.NumOp(OpType::GPU); ++i) {
+    const OpNode &current = graph_.Node(OpType::GPU, i);
     Index epoch_size = current.op->epoch_size();
     if (epoch_size != -1) {
       ret.insert(make_pair(current.instance_name, epoch_size));

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -136,11 +136,11 @@ class DLL_PUBLIC Pipeline {
       // Trying to set data for non existing node is a noop
       return;
     }
-    NodeID node_id = graph_.TensorSourceID(name + "_cpu");
+    OpNodeId node_id = graph_.TensorSourceID(name + "_cpu");
     DALI_ENFORCE(graph_.NodeType(node_id) == OpType::CPU,
         "Internal error setting external input data.");
 
-    auto &node = graph_.node(node_id);
+    auto &node = graph_.Node(node_id);
     auto *op_ptr = &node.InstantiateOperator();
     ExternalSource<CPUBackend> *source =
       dynamic_cast<ExternalSource<CPUBackend>*>(op_ptr);

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -165,21 +165,21 @@ class PipelineTest : public DALITest {
     OpGraph &graph = this->GetGraph(&pipe);
 
       // Validate the graph
-    ASSERT_EQ(graph.NumCPUOp(), 1);
-    ASSERT_EQ(graph.NumMixedOp(), 1);
-    ASSERT_EQ(graph.NumGPUOp(), 1);
+    ASSERT_EQ(graph.NumOp(OpType::CPU), 1);
+    ASSERT_EQ(graph.NumOp(OpType::MIXED), 1);
+    ASSERT_EQ(graph.NumOp(OpType::GPU), 1);
 
-    ASSERT_EQ(graph.mixed_node(0).op->name(), "MakeContiguous");
+    ASSERT_EQ(graph.Node(OpType::MIXED, 0).op->name(), "MakeContiguous");
 
     // Validate the source op
-    auto &node = graph.node(0);
+    auto &node = graph.Node(0);
     ASSERT_EQ(node.id, 0);
     ASSERT_EQ(node.children.size(), 1);
     ASSERT_EQ(node.parents.size(), 0);
     ASSERT_EQ(node.children.count(1), 1);
 
     // Validate the MakeContiguous op
-    auto &node2 = graph.node(1);
+    auto &node2 = graph.Node(1);
     ASSERT_EQ(node2.id, 1);
     ASSERT_EQ(node2.children.size(), 1);
     ASSERT_EQ(node2.parents.size(), 1);
@@ -187,7 +187,7 @@ class PipelineTest : public DALITest {
     ASSERT_EQ(node2.children.count(2), 1);
 
     // Validate the copy op
-    auto &node3 = graph.node(2);
+    auto &node3 = graph.Node(2);
     ASSERT_EQ(node3.id, 2);
     ASSERT_EQ(node3.children.size(), 0);
     ASSERT_EQ(node3.parents.size(), 1);
@@ -252,12 +252,12 @@ TYPED_TEST(PipelineTest, TestExternalSource) {
   OpGraph &graph = this->GetGraph(&pipe);
 
   // Validate the graph
-  ASSERT_EQ(graph.NumCPUOp(), 1);
-  ASSERT_EQ(graph.NumMixedOp(), 0);
-  ASSERT_EQ(graph.NumGPUOp(), 0);
+  ASSERT_EQ(graph.NumOp(OpType::CPU), 1);
+  ASSERT_EQ(graph.NumOp(OpType::MIXED), 0);
+  ASSERT_EQ(graph.NumOp(OpType::GPU), 0);
 
   // Validate the gpu source op
-  auto& node = graph.node(0);
+  auto& node = graph.Node(0);
   ASSERT_EQ(node.id, 0);
   ASSERT_EQ(node.children.size(), 0);
   ASSERT_EQ(node.parents.size(), 0);
@@ -302,9 +302,12 @@ TYPED_TEST(PipelineTest, TestSerialization) {
   OpGraph &loaded_graph = this->GetGraph(&loaded_pipe);
 
   // Validate the graph contains the same ops
-  ASSERT_EQ(loaded_graph.NumCPUOp(), original_graph.NumCPUOp());
-  ASSERT_EQ(loaded_graph.NumMixedOp(), original_graph.NumMixedOp());
-  ASSERT_EQ(loaded_graph.NumGPUOp(), original_graph.NumGPUOp());
+  ASSERT_EQ(loaded_graph.NumOp(OpType::CPU),
+            original_graph.NumOp(OpType::CPU));
+  ASSERT_EQ(loaded_graph.NumOp(OpType::MIXED),
+            original_graph.NumOp(OpType::MIXED));
+  ASSERT_EQ(loaded_graph.NumOp(OpType::GPU),
+            original_graph.NumOp(OpType::GPU));
 }
 
 /*
@@ -449,8 +452,8 @@ TYPED_TEST(PipelineTest, TestSeedSet) {
   OpGraph &original_graph = this->GetGraph(&pipe);
 
   // Check if seed can be manually set to the reader
-  ASSERT_EQ(original_graph.node(3).spec.Arguments().at("seed")->Get<int64_t>(), seed_set);
-  ASSERT_NE(original_graph.node(0).spec.Arguments().at("seed")->Get<int64_t>(), seed_set);
+  ASSERT_EQ(original_graph.Node(3).spec.Arguments().at("seed")->Get<int64_t>(), seed_set);
+  ASSERT_NE(original_graph.Node(0).spec.Arguments().at("seed")->Get<int64_t>(), seed_set);
 }
 
 }  // namespace dali


### PR DESCRIPTION
OpNodes are now stored as 1 collection instead of splitting them into 4 groups.
Introduce TensorNodes with unique index.
OpGraph now has interleaved layers of OpNodes and TensorNodes.

Remove duplicated code for handling OpNodes partitions.
Fix and improve .dot file generation for OpGraph.

TODO: Test TensorNodes in graph, better names for some metadata.

Next: #602