### PR TITLE
Add CUDA version name to whl binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,13 +59,13 @@ RUN pip wheel -v dali/python \
         --build-option --python-tag=$(basename /opt/python/cp${PYV}-*) \
         --build-option --plat-name=manylinux1_x86_64 \
         --build-option --build-number=${NVIDIA_BUILD_ID} && \
-    ../dali/python/bundle-wheel.sh nvidia_dali-*.whl && \
+    ../dali/python/bundle-wheel.sh nvidia_dali[_-]*.whl && \
     UNZIP_PATH="$(mktemp -d)" && \
-    unzip /wheelhouse/nvidia_dali-*.whl -d $UNZIP_PATH && \
+    unzip /wheelhouse/nvidia_dali*.whl -d $UNZIP_PATH && \
     python ../tools/test_bundled_libs.py $(find $UNZIP_PATH -iname *.so* | tr '\n' ' ') && \
     rm -rf $UNZIP_PATH
 
 RUN pushd dali/python/tf_plugin/ && \
     python setup.py sdist && \
-    mv dist/nvidia-dali-tf-plugin-*.tar.gz /wheelhouse/ && \
+    mv dist/nvidia-dali-tf-plugin*.tar.gz /wheelhouse/ && \
     popd

--- a/README.rst
+++ b/README.rst
@@ -55,23 +55,37 @@ Prerequisites
 Installation
 ^^^^^^^^^^^^
 
+For CUDA 9.0 based build issue:
+
 .. code-block:: bash
 
    pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali
 
+For CUDA 10.0 based build issue:
+
+.. code-block:: bash
+
+   pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cu100
+
 .. note::
-   nvidia-dali package contains prebuilt versions of the dali tensorflow plugin for several versions of tensorflow.
-   Since release 0.6.1 there is also a possibility to install dali tensorflow plugin for the currently installed version of tensorflow, thus allowing forward compatibility:
+   nvidia-dali package contains prebuilt versions of the dali TensorFlow plugin for several versions of TensorFlow.
+   Since release 0.6.1 there is also a possibility to install dali TensorFlow plugin for the currently installed version of TensorFlow, thus allowing forward compatibility:
 
 .. code-block:: bash
 
    pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-tf-plugin
 
-.. note::
-Installing this package will install nvidia-dali and its dependencies if not already installed. The package tensorflow-gpu must be installed before attempting to install nvidia-dali-tf-plugin.
+For CUDA 10.0 based build issue:
+
+.. code-block:: bash
+
+   pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-tf-plugin-cu100
 
 .. note::
-The package nvidia-dali-tf-plugin has a strict requirement with nvidia-dali as its exact same version. Thus, installing nvidia-dali-tf-plugin at its latest version will replace any older nvidia-dali versions already installed with the latest. To work with older versions of DALI, please provide the version explicitely to the pip install command.
+   Installing this package will install nvidia-dali and its dependencies if not already installed. The package tensorflow-gpu must be installed before attempting to install nvidia-dali-tf-plugin.
+
+.. note::
+   The package nvidia-dali-tf-plugin has a strict requirement with nvidia-dali as its exact same version. Thus, installing nvidia-dali-tf-plugin at its latest version will replace any older nvidia-dali versions already installed with the latest. To work with older versions of DALI, please provide the version explicitly to the pip install command.
 
 .. code-block:: bash
 

--- a/dali/python/CMakeLists.txt
+++ b/dali/python/CMakeLists.txt
@@ -26,6 +26,12 @@ target_link_libraries(${dali_python_lib} PRIVATE ${CUDA_LIBRARIES} ${dali_lib})
 set_target_properties(${dali_python_lib} PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/dali/python/nvidia/dali)
 
+string(REPLACE "." "" CUDA_VERSION_LONG ${CUDA_VERSION})
+set(CU_DALI_VERSION "")
+if (${CUDA_VERSION} VERSION_GREATER "9.2")
+  set(CU_DALI_VERSION "_cu${CUDA_VERSION_LONG}")
+endif()
+
 # Add the COPYRIGHT, LICENSE, and Acknowledgements
 copy_post_build(${dali_python_lib} "${PROJECT_SOURCE_DIR}/dali/python/nvidia" "${PROJECT_BINARY_DIR}/dali/python")
 configure_file("${PROJECT_SOURCE_DIR}/dali/python/setup.py.in" "${PROJECT_BINARY_DIR}/stage/setup.py")

--- a/dali/python/bundle-wheel.sh
+++ b/dali/python/bundle-wheel.sh
@@ -52,12 +52,13 @@ OUTWHLNAME=${OUTWHLNAME//-none-/-}
 
 PKGNAME=$(echo "$OUTWHLNAME" | sed 's/-.*$//')
 PKGNAME_PATH=$(echo "$PKGNAME" | sed 's/_/\//' )
+# Strip cuda version from the name
+PKGNAME_PATH=${PKGNAME_PATH%%_cu*}
 
 if [[ -z "$INWHL" || ! -f "$INWHL" || -z "$PKGNAME" ]]; then
     echo "Usage: $0 <inputfile.whl>"
     exit 1
 fi
-
 
 #######################################################################
 # ADD DEPENDENCIES INTO THE WHEEL

--- a/dali/python/setup.py.in
+++ b/dali/python/setup.py.in
@@ -14,8 +14,8 @@
 
 from setuptools import setup, find_packages
 
-setup(name='nvidia-dali',
-      description='NVIDIA DALI',
+setup(name='nvidia-dali@CU_DALI_VERSION@',
+      description='NVIDIA DALI for CUDA @CUDA_VERSION@',
       url='https://github.com/NVIDIA/dali',
       version='@DALI_VERSION@',
       author='NVIDIA Corporation',

--- a/dali/python/tf_plugin/setup.py.in
+++ b/dali/python/tf_plugin/setup.py.in
@@ -77,8 +77,8 @@ class CustomInstall(install, object):
 
         super(CustomInstall, self).run()
 
-setup(name='nvidia-dali-tf-plugin',
-      description='NVIDIA DALI Tensorflow plugin',
+setup(name='nvidia-dali-tf-plugin@CU_DALI_VERSION@',
+      description='NVIDIA DALI Tensorflow plugin for CUDA @CUDA_VERSION@',
       url='https://github.com/NVIDIA/dali',
       version='@DALI_VERSION@',
       author='NVIDIA Corporation',
@@ -87,7 +87,7 @@ setup(name='nvidia-dali-tf-plugin',
       include_package_data=True,
       zip_safe=False,
       install_requires = [
-          'nvidia-dali==@DALI_VERSION@'
+          'nvidia-dali@CU_DALI_VERSION@==@DALI_VERSION@'
           ],
       cmdclass = {
           'install': CustomInstall

--- a/tools/test_bundled_libs.py
+++ b/tools/test_bundled_libs.py
@@ -19,7 +19,7 @@ from sys import argv
 import subprocess
 
 def check_ldd_out(lib, linked_lib, bundled_lib_names, allowed_libs):
-    # Gather all libs that may be linked wiht 'lib' and don't need to be bundled
+    # Gather all libs that may be linked with 'lib' and don't need to be bundled
     # Entries from 'lib' key in allowed_libs should cover all 'lib*' libs
     # Empty key is used for all libs
     allowed_libs_to_check = []


### PR DESCRIPTION
- all CUDA > 10 based build will have _cuXXX in the name to
  make package distinct from the 9.0 builds

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>