### PR TITLE
Make nvJpeg operator to fallback to the CPU even for wrong images

### DIFF
--- a/dali/pipeline/operators/decoder/nvjpeg_decoder.h
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder.h
@@ -372,7 +372,7 @@ class nvJPEGDecoder : public Operator<MixedBackend> {
 
     // If image is somehow not supported try hostdecoder
     if (ret != NVJPEG_STATUS_SUCCESS) {
-      if (ret == NVJPEG_STATUS_JPEG_NOT_SUPPORTED) {
+      if (ret == NVJPEG_STATUS_JPEG_NOT_SUPPORTED || ret == NVJPEG_STATUS_BAD_JPEG) {
         OCVFallback(data, in_size, output, stream, file_name);
         CUDA_CALL(cudaStreamSynchronize(stream));
         return;


### PR DESCRIPTION
- for some images nvJPEG returns "bad jpeg" while CPU implementation
  can still handle it. In such cases fallback to the CPU

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>