### PR TITLE
Refactor Executor and OpGraph

### DIFF
--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -20,6 +20,10 @@
 #include "dali/pipeline/executor/executor.h"
 #include "dali/pipeline/operators/common.h"
 
+#include "dali/pipeline/workspace/workspace_data_factory.h"
+#include "dali/pipeline/graph/op_graph_storage.h"
+
+
 namespace dali {
 
 
@@ -41,16 +45,27 @@ void Executor::Build(OpGraph *graph, vector<string> output_names) {
   // will not be used as an output or by another node
   PruneUnusedGraphNodes();
 
+  // Check if graph is ok for execution
+  CheckGraphConstraints(*graph_);
+  // Clear the old data
+  tensor_to_storage_.clear();
+  // Create corresponding storage type for TensorNodes in graph
+  tensor_to_storage_ = CreateBackingStorageForTensorNodes(*graph_, batch_size_);
+  // Setup stream and events that will be used for execution
+  {
+    DeviceGuard g(device_id_);
+    mixed_op_stream_ = stream_pool_.GetStream();
+    gpu_op_stream_ = stream_pool_.GetStream();
+    mixed_op_events_ = CreateEventsForMixedOps(event_pool_, *graph_);
+  }
+
   // Setup workspaces for each op and connect
   // their inputs and outputs.
   WorkspaceBlob base_wsb;
-  SetupDataForGraph(&base_wsb);
+  SetupWorkspacesForGraph(&base_wsb);
 
   // Presize the workspaces based on the hint
-  PresizeData(&base_wsb);
-
-  // Assign streams to all mixed & gpu ops
-  SetupStreamsForGraph(&base_wsb);
+  PresizeData(tensor_to_storage_, *graph_);
 
   SetupOutputQueuesForGraph();
 
@@ -86,7 +101,7 @@ void Executor::RunCPU() {
     for (int i = 0; i < graph_->NumOp(OpType::SUPPORT); ++i) {
       OpNode &op_node = graph_->Node(OpType::SUPPORT, i);
       OperatorBase &op = *op_node.op;
-      SupportWorkspace &ws = wsb.support_op_data[i];
+      SupportWorkspace &ws = get_workspace<OpType::SUPPORT>(wsb.op_data, i);
       TimeRange tr("[Executor] Run Support op " + op_node.instance_name,
           TimeRange::kCyan);
       op.Run(&ws);
@@ -109,7 +124,7 @@ void Executor::RunCPU() {
             for (int j = 0; j < graph_->NumOp(OpType::CPU); ++j) {
               OpNode &op_node = graph_->Node(OpType::CPU, j);
               OperatorBase &op = *op_node.op;
-              wsb.cpu_op_data[j].GetSample(&ws, data_idx, tid);
+              get_workspace<OpType::CPU>(wsb.op_data, op_node).GetSample(&ws, data_idx, tid);
               TimeRange tr("[Executor] Run CPU op " + op_node.instance_name
                   + " on " + to_string(data_idx),
                   TimeRange::kBlue1);
@@ -149,7 +164,7 @@ void Executor::RunMixed() {
     for (int i = 0; i < graph_->NumOp(OpType::MIXED); ++i) {
       OpNode &op_node = graph_->Node(OpType::MIXED, i);
       OperatorBase &op = *op_node.op;
-      MixedWorkspace &ws = wsb.mixed_op_data[i];
+      MixedWorkspace &ws = get_workspace<OpType::MIXED>(wsb.op_data, i);
       TimeRange tr("[Executor] Run Mixed op " + op_node.instance_name,
           TimeRange::kOrange);
       op.Run(&ws);
@@ -196,7 +211,7 @@ void Executor::RunGPU() {
     for (int i = 0; i < graph_->NumOp(OpType::GPU); ++i) {
       OpNode &op_node = graph_->Node(OpType::GPU, i);
       OperatorBase &op = *op_node.op;
-      DeviceWorkspace &ws = wsb.gpu_op_data[i];
+      DeviceWorkspace &ws = get_workspace<OpType::GPU>(wsb.op_data, i);
       auto parent_events = ws.ParentEvents();
 
       for (auto &event : parent_events) {
@@ -219,10 +234,10 @@ void Executor::RunGPU() {
       // Record events for each output requested by the user
       cudaEvent_t event = gpu_output_events_[i].GetEvent(queue_idx);
       if (graph_->NodeType(src_id) == OpType::MIXED) {
-        auto &ws = wsb.mixed_op_data[src_idx];
+        auto &ws = get_workspace<OpType::MIXED>(wsb.op_data, src_idx);
         CUDA_CALL(cudaEventRecord(event, ws.stream()));
       } else if (graph_->NodeType(src_id) == OpType::GPU) {
-        auto &ws = wsb.gpu_op_data[src_idx];
+        auto &ws = get_workspace<OpType::GPU>(wsb.op_data, src_idx);
         CUDA_CALL(cudaEventRecord(event, ws.stream()));
       } else {
         DALI_FAIL("Internal error. Output node is not gpu/mixed");
@@ -378,328 +393,66 @@ void Executor::PruneUnusedGraphNodes() {
       "data produced by the pipeline.");
 }
 
-void Executor::SetupDataForGraph(WorkspaceBlob *wsb) {
+void Executor::SetupWorkspacesForGraph(WorkspaceBlob *wsb) {
   DeviceGuard g(device_id_);
 
   // Clear any old data setup
   wsb->Clear();
+  wsb->Resize(graph_->NumOp(OpType::SUPPORT), graph_->NumOp(OpType::CPU),
+              graph_->NumOp(OpType::MIXED), graph_->NumOp(OpType::GPU));
 
-  // Create workspaces for each operator
-  wsb->cpu_op_data.resize(graph_->NumOp(OpType::CPU));
-  wsb->mixed_op_data.resize(graph_->NumOp(OpType::MIXED));
-  wsb->gpu_op_data.resize(graph_->NumOp(OpType::GPU));
-  wsb->support_op_data.resize(graph_->NumOp(OpType::SUPPORT));
-
-  // Setup support op input and output buffers
-  for (int i = 0; i < graph_->NumOp(OpType::SUPPORT); ++i) {
-    OpNode &node = graph_->Node(OpType::SUPPORT, i);
-    SupportWorkspace &ws = wsb->support_op_data[i];
-    // Support ops do not take argument inputs
-    DALI_ENFORCE(node.spec.NumInput() == node.spec.NumRegularInput(),
-        "Support ops do not support tensor arguments");
-    for (int j = 0; j < node.spec.NumRegularInput(); ++j) {
-      // Get each regular input and add them to this op's workspace.
-
-      OpNodeId parent_node_id = graph_->TensorSourceID(node.spec.Input(j));
-      OpType parent_op_type = graph_->NodeType(parent_node_id);
-      DALI_ENFORCE(parent_op_type == OpType::SUPPORT,
-          "Executor encountered support op with non-support input.");
-      int parent_idx = graph_->NodeIdx(parent_node_id);
-      int input_src_idx = graph_->TensorIdxInSource(node.spec.Input(j));
-
-      SupportWorkspace &src_ws = wsb->support_op_data[parent_idx];
-      const auto input = src_ws.SharedCPUOutput(input_src_idx);
-      ws.AddInput(input);
-    }
-
-    for (int j = 0; j < node.spec.NumOutput(); ++j) {
-      // Allocate tensors for output
-      shared_ptr<Tensor<CPUBackend>> output(new Tensor<CPUBackend>);
-      output->set_pinned(false);
-      ws.AddOutput(output);
-    }
-  }
-
-  // Setup cpu op input and output buffers
-  for (int i = 0; i < graph_->NumOp(OpType::CPU); ++i) {
-    OpNode &node = graph_->Node(OpType::CPU, i);
-    HostWorkspace &ws = wsb->cpu_op_data[i];
-    for (int j = 0; j < node.spec.NumRegularInput(); ++j) {
-      // Get each regular input and add them to this op's workspace.
-      OpNodeId parent_node_id = graph_->TensorSourceID(node.spec.Input(j));
-      OpType parent_op_type = graph_->NodeType(parent_node_id);
-      DALI_ENFORCE(parent_op_type == OpType::CPU,
-          "Executor encountered cpu op with non-cpu input.");
-      int parent_idx = graph_->NodeIdx(parent_node_id);
-      int input_src_idx = graph_->TensorIdxInSource(node.spec.Input(j));
-
-      HostWorkspace &src_ws = wsb->cpu_op_data[parent_idx];
-      const auto input = src_ws.SharedCPUOutput(input_src_idx);
-      ws.AddInput(input);
-    }
-
-    // Add argument tensors
-    for (const auto &arg_pair : node.spec.ArgumentInputs()) {
-      // Get each argument input and add them to this op's workspace.
-      OpNodeId parent_node_id = graph_->TensorSourceID(node.spec.Input(arg_pair.second));
-      OpType parent_op_type = graph_->NodeType(parent_node_id);
-      DALI_ENFORCE(parent_op_type == OpType::SUPPORT,
-          "Executor encountered argument input produced by non-cpu op.");
-      int parent_idx = graph_->NodeIdx(parent_node_id);
-      int input_src_idx = graph_->TensorIdxInSource(node.spec.Input(arg_pair.second));
-
-      SupportWorkspace &src_ws = wsb->support_op_data[parent_idx];
-      const auto input = src_ws.SharedCPUOutput(input_src_idx);
-      ws.AddArgumentInput(input, arg_pair.first);
-    }
-
-    for (int j = 0; j < node.spec.NumOutput(); ++j) {
-      // Allocate `batch_size` Tensors for this ops
-      // results and add them to the workspace.
-      vector<shared_ptr<Tensor<CPUBackend>>> output(batch_size_, nullptr);
-      for (auto &tensor_ptr : output) {
-        tensor_ptr.reset(new Tensor<CPUBackend>);
-        tensor_ptr->set_pinned(false);
-      }
-
-      ws.AddOutput(output);
-    }
-  }
-
-  // Setup mixed op input and output buffers
-  for (int i = 0; i < graph_->NumOp(OpType::MIXED); ++i) {
-    OpNode &node = graph_->Node(OpType::MIXED, i);
-    MixedWorkspace &ws = wsb->mixed_op_data[i];
-
-    for (int j = 0; j < node.spec.NumRegularInput(); ++j) {
-      // Go get each set of input Tensors and add
-      // them to this mixed ops workspace.
-      OpNodeId parent_node_id = graph_->TensorSourceID(node.spec.Input(j));
-      OpType parent_op_type = graph_->NodeType(parent_node_id);
-      DALI_ENFORCE(parent_op_type == OpType::CPU,
-          "Executor encountered mixed op with non-cpu input.");
-      int parent_idx = graph_->NodeIdx(parent_node_id);
-      int input_src_idx = graph_->TensorIdxInSource(node.spec.Input(j));
-
-      HostWorkspace &src_ws = wsb->cpu_op_data[parent_idx];
-      auto input = src_ws.SharedCPUOutput(input_src_idx);
-      // Use pinned memory only when it is useful
-      if (node.spec.name() == "MakeContiguous" &&
-          node.spec.NumOutput() == 1 &&
-          node.spec.OutputDevice(0) == "gpu") {
-        for (auto t : input) {
-          t->set_pinned(true);
-        }
-      }
-      ws.AddInput(input);
-    }
-
-    // Add argument tensors
-    for (const auto &arg_pair : node.spec.ArgumentInputs()) {
-      // Get each argument input and add them to this op's workspace.
-      OpNodeId parent_node_id = graph_->TensorSourceID(node.spec.Input(arg_pair.second));
-      OpType parent_op_type = graph_->NodeType(parent_node_id);
-      DALI_ENFORCE(parent_op_type == OpType::SUPPORT,
-          "Executor encountered argument input produced by non-cpu op.");
-      int parent_idx = graph_->NodeIdx(parent_node_id);
-      int input_src_idx = graph_->TensorIdxInSource(node.spec.Input(arg_pair.second));
-
-      SupportWorkspace &src_ws = wsb->support_op_data[parent_idx];
-      const auto input = src_ws.SharedCPUOutput(input_src_idx);
-      ws.AddArgumentInput(input, arg_pair.first);
-    }
-
-    for (int j = 0; j < node.spec.NumOutput(); ++j) {
-      if (node.spec.OutputDevice(j) == "cpu") {
-        // Allocate TensorLists for this ops outputs
-        ws.AddOutput(std::make_shared<TensorList<CPUBackend>>());
-      } else if (node.spec.OutputDevice(j) == "gpu") {
-        ws.AddOutput(std::make_shared<TensorList<GPUBackend>>());
-      } else {
-        DALI_FAIL("Executor encountered mixed op with non-gpu/cpu output.");
-      }
-    }
-  }
-
-  // Setup gpu op input and output buffers
-  for (int i = 0; i < graph_->NumOp(OpType::GPU); ++i) {
-    OpNode &node = graph_->Node(OpType::GPU, i);
-    DeviceWorkspace &ws = wsb->gpu_op_data[i];
-    for (int j = 0; j < node.spec.NumRegularInput(); ++j) {
-      // Get each input and add them to this GPU op's workspace.
-      OpNodeId parent_node_id = graph_->TensorSourceID(node.spec.Input(j));
-      OpType parent_op_type = graph_->NodeType(parent_node_id);
-      int parent_idx = graph_->NodeIdx(parent_node_id);
-      int input_src_idx = graph_->TensorIdxInSource(node.spec.Input(j));
-
-      if (parent_op_type == OpType::MIXED) {
-        MixedWorkspace &src_ws = wsb->mixed_op_data[parent_idx];
-        if (node.spec.InputDevice(j) == "cpu") {
-          const auto input = src_ws.SharedCPUOutput(input_src_idx);
-          ws.AddInput(input);
-        } else if (node.spec.InputDevice(j) == "gpu") {
-          const auto input = src_ws.SharedGPUOutput(input_src_idx);
-          ws.AddInput(input);
-        } else {
-          DALI_FAIL("Executor encountered gpu op with non-cpu/gpu input.");
-        }
-      } else if (parent_op_type == OpType::GPU) {
-        DeviceWorkspace &src_ws = wsb->gpu_op_data[parent_idx];
-        if (node.spec.InputDevice(j) == "cpu") {
-          // Note: This path should currently never occur, as we
-          // do not allow gpu ops to produce cpu data outputs.
-          const auto input = src_ws.SharedCPUOutput(input_src_idx);
-          ws.AddInput(input);
-        } else if (node.spec.InputDevice(j) == "gpu") {
-          const auto input = src_ws.SharedGPUOutput(input_src_idx);
-          ws.AddInput(input);
-        } else {
-          DALI_FAIL("Executor encountered gpu op with non-cpu/gpu input.");
-        }
-      } else {
-        DALI_FAIL("Executor encountered gpu op with non-mixed/gpu input.");
-      }
-    }
-
-    // Add argument tensors
-    for (const auto &arg_pair : node.spec.ArgumentInputs()) {
-      // Get each argument input and add them to this op's workspace.
-      OpNodeId parent_node_id = graph_->TensorSourceID(node.spec.Input(arg_pair.second));
-      OpType parent_op_type = graph_->NodeType(parent_node_id);
-      DALI_ENFORCE(parent_op_type == OpType::SUPPORT,
-          "Executor encountered argument input produced by non-cpu op.");
-      int parent_idx = graph_->NodeIdx(parent_node_id);
-      int input_src_idx = graph_->TensorIdxInSource(node.spec.Input(arg_pair.second));
-
-      SupportWorkspace &src_ws = wsb->support_op_data[parent_idx];
-      auto input = src_ws.SharedCPUOutput(input_src_idx);
-      input->set_pinned(true);
-      ws.AddArgumentInput(input, arg_pair.first);
-    }
-
-    for (int j = 0; j < node.spec.NumOutput(); ++j) {
-      // Allocate TensorLists for this ops output
-      if (node.spec.OutputDevice(j) == "gpu") {
-        ws.AddOutput(std::make_shared<TensorList<GPUBackend>>());
-      } else if (node.spec.OutputDevice(j) == "cpu") {
-        ws.AddOutput(std::make_shared<TensorList<CPUBackend>>());
-      } else {
-        DALI_FAIL("Executor encountered gpu op with non cpu/gpu output.");
-      }
-    }
+  for (int i = 0; i < graph_->NumOp(); i++) {
+    auto &node = graph_->Node(i);
+    VALUE_SWITCH(node.op_type, op_type_static,
+        (OpType::SUPPORT, OpType::CPU, OpType::MIXED, OpType::GPU),
+    (
+      auto &ws = get_workspace<op_type_static>(wsb->op_data, node);
+      ws = CreateWorkspace<op_type_static>(*graph_, node);
+    ), DALI_FAIL("Invalid op type"));  // NOLINT(whitespace/parens)
   }
 }
 
-void Executor::PresizeData(WorkspaceBlob *wsb) {
+// We apply hints to all of pinned CPU buffers and all GPU buffers
+void Executor::PresizeData(std::vector<tensor_data_store_t> &tensor_to_storage,
+                           const OpGraph &graph) {
+  DeviceGuard g(device_id_);
   TimeRange tr("[Executor] PresizeData");
-  DeviceGuard g(device_id_);
 
-  auto mem_hints = [&](OpNode &node) {
-    std::vector<int> hints;
-    int noutputs = node.spec.NumOutput();
-    GetSingleOrRepeatedArg(node.spec, &hints, "bytes_per_sample_hint", noutputs);
-    for (auto &h : hints) {
-      if (h == 0)
-        h = this->bytes_per_sample_hint_;
-    }
-    return hints;
-  };
-
-  // Note: At some point our graph has source nodes that
-  // only have outputs (data readers or external inputs).
-  // Thus, the set of all outputs buffers in our workspaces
-  // represents all the unique buffers in our graph.
-  for (int op_idx = 0; op_idx < graph_->NumOp(OpType::CPU); op_idx++) {
-    auto &ws = wsb->cpu_op_data[op_idx];
-    std::vector<int> hints = mem_hints(graph_->Node(OpType::CPU, op_idx));
-
-    for (int i = 0; i < ws.NumOutput(); ++i) {
-      DALI_ENFORCE(ws.NumOutputAtIdx(i) == batch_size_, "Executor "
-          "encountered cpu op workspace where the number of tensors "
-          "is not equal to the batch size.");
-      DALI_ENFORCE(ws.OutputIsType<CPUBackend>(i), "Executor "
-          "encountered cpu op with non-cpu output.");
-      for (int j = 0; j < ws.NumOutputAtIdx(i); ++j) {
-        Tensor<CPUBackend> &tensor = ws.Output<CPUBackend>(i, j);
-        Index hint = hints[i];
-        if (tensor.is_pinned() && hint) {
-          tensor.reserve(hint);
+  // To avoid handling the arguments several times for each operator that
+  // has more than one output, we go over the operators instead of tensors
+  for (int i = 0; i < graph.NumOp(); i++) {
+    auto &node = graph.Node(i);
+    auto hints = GetMemoryHints(node);
+    VALUE_SWITCH(node.op_type, op_type_static,
+        (OpType::SUPPORT, OpType::CPU, OpType::MIXED, OpType::GPU),
+    (
+      // For all tensors we produce
+      for (size_t j = 0; j < node.children_tensors.size(); j++) {
+        auto &tensor = graph.Tensor(node.children_tensors[j]);
+        Index hint = hints[j];
+        if (tensor.producer.storage_device == StorageDevice::CPU) {
+          auto storage = get_storage<op_type_static, StorageDevice::CPU>(
+              tensor_to_storage[tensor.id]);
+          if (hint && IsPinned(storage)) {
+            Reserve(storage, hint, batch_size_);
+          }
+        } else {
+          auto storage = get_storage<op_type_static, StorageDevice::GPU>(
+              tensor_to_storage[tensor.id]);
+          if (hint) {
+            Reserve(storage, hint, batch_size_);
+          }
         }
       }
-    }
-  }
-
-  for (int op_idx = 0; op_idx < graph_->NumOp(OpType::MIXED); op_idx++) {
-    auto &ws = wsb->mixed_op_data[op_idx];
-    std::vector<int> hints = mem_hints(graph_->Node(OpType::MIXED, op_idx));
-
-    for (int i = 0; i < ws.NumOutput(); ++i) {
-      Index hint = hints[i];
-      if (ws.OutputIsType<CPUBackend>(i)) {
-        TensorList<CPUBackend> &tl = ws.Output<CPUBackend>(i);
-        if (tl.is_pinned()) {
-          tl.reserve(hint*batch_size_);
-        }
-      } else {
-        TensorList<GPUBackend> &tl = ws.Output<GPUBackend>(i);
-        tl.reserve(hint*batch_size_);
-      }
-    }
-  }
-
-  for (int op_idx = 0; op_idx < graph_->NumOp(OpType::GPU); op_idx++) {
-    auto &ws = wsb->gpu_op_data[op_idx];
-    std::vector<int> hints = mem_hints(graph_->Node(OpType::GPU, op_idx));
-
-    for (int i = 0; i < ws.NumOutput(); ++i) {
-      Index hint = hints[i];
-      if (ws.OutputIsType<GPUBackend>(i)) {
-        TensorList<GPUBackend> &tl = ws.Output<GPUBackend>(i);
-        tl.reserve(hint*batch_size_);
-      } else {
-        TensorList<CPUBackend> &tl = ws.Output<CPUBackend>(i);
-        if (tl.is_pinned()) {
-          tl.reserve(hint*batch_size_);
-        }
-      }
-    }
+    ), DALI_FAIL("Invalid op type"));  // NOLINT(whitespace/parens)
   }
 }
 
-void Executor::SetupStreamsForGraph(WorkspaceBlob *wsb) {
-  DeviceGuard g(device_id_);
-  auto mixed_op_stream = stream_pool_.GetStream();
-  for (int i = 0; i < graph_->NumOp(OpType::MIXED); ++i) {
-    // We assign unique stream to mixed ops.
-    // This ensures that we won't have false dependencies
-    // between mixed ops and the previous iterations
-    // gpu ops.
-    MixedWorkspace &ws = wsb->mixed_op_data[i];
-    ws.set_stream(mixed_op_stream);
-    ws.set_event(event_pool_.GetEvent());
-  }
-
-  // I/O pipeline is always going to be launched alongside
-  // some other GPU work (like DL training).
-  // Therefore it is not necessary to use more than
-  // 1 stream for GPU ops, even though we may not fill
-  // the whole GPU with just I/O pipeline kernels
-  // by doing so.
-  auto gpu_op_stream = stream_pool_.GetStream();
-  for (int i = 0; i < graph_->NumOp(OpType::GPU); ++i) {
-    DeviceWorkspace &ws = wsb->gpu_op_data[i];
-    ws.set_stream(gpu_op_stream);
-    const OpNode &node = graph_->Node(OpType::GPU, i);
-    for (const auto& p : node.parents) {
-      if (graph_->NodeType(p) == OpType::MIXED) {
-        // We need to block on this op's event to
-        // make sure that we respect the dependency
-        int parent_op_idx = graph_->NodeIdx(p);
-        MixedWorkspace parent_ws = wsb->mixed_op_data[parent_op_idx];
-        ws.AddParentEvent(parent_ws.event());
-      }
-    }
-  }
+std::vector<int> Executor::GetMemoryHints(const OpNode &node) {
+  std::vector<int> hints;
+  GetSingleOrRepeatedArg(node.spec, &hints, "bytes_per_sample_hint", node.spec.NumOutput());
+  std::replace(hints.begin(), hints.end(), 0, static_cast<int>(bytes_per_sample_hint_));
+  return hints;
 }
 
 void Executor::SetupOutputQueuesForGraph() {
@@ -708,6 +461,7 @@ void Executor::SetupOutputQueuesForGraph() {
   for (auto &name : output_names_) {
     auto tensor_meta = graph_->TensorSourceMeta(name);
 
+    // TODO(klecki): this is a duplication of TensorNode functionality here in convoluted manner
     // Collect meta-data about the tensor for fast lookup later.
     OutputInfo info;
     info.prod_and_idx = std::make_pair(tensor_meta.node, tensor_meta.index);
@@ -719,22 +473,23 @@ void Executor::SetupOutputQueuesForGraph() {
 
     // Create the buffer and events
     if (tensor_meta.storage_device == StorageDevice::CPU) {
-      DALI_ENFORCE(!tensor_meta.is_support,
+      DALI_ENFORCE(
+          !tensor_meta.is_support,
           "Outputs of support ops cannot be outputs.");  // TODO(ptredak): lift this restriction
-      cpu_outputs_.push_back(TensorListPool<CPUBackend>(
-              queue_depth_, batch_size_, bytes_per_sample_hint_));
-      DALI_ENFORCE(type_idx_map_.insert({name, cpu_outputs_.size()-1}).second,
-          "Output tensor meta insertion failed. Duplicate output name '" +
-          name + "' exists.");
+      cpu_outputs_.push_back(
+          TensorListPool<CPUBackend>(queue_depth_, batch_size_, bytes_per_sample_hint_));
+      DALI_ENFORCE(
+          type_idx_map_.insert({name, cpu_outputs_.size() - 1}).second,
+          "Output tensor meta insertion failed. Duplicate output name '" + name + "' exists.");
 
       cpu_output_info_.push_back(info);
       gpu_output_events_.push_back(EventList());
     } else {
-      gpu_outputs_.push_back(TensorListPool<GPUBackend>(
-              queue_depth_, batch_size_, bytes_per_sample_hint_));
-      DALI_ENFORCE(type_idx_map_.insert({name, gpu_outputs_.size()-1}).second,
-          "Output tensor meta insertion failed. Duplicate output name '" +
-          name + "' exists.");
+      gpu_outputs_.push_back(
+          TensorListPool<GPUBackend>(queue_depth_, batch_size_, bytes_per_sample_hint_));
+      DALI_ENFORCE(
+          type_idx_map_.insert({name, gpu_outputs_.size() - 1}).second,
+          "Output tensor meta insertion failed. Duplicate output name '" + name + "' exists.");
 
       gpu_output_info_.push_back(info);
       gpu_output_events_.push_back(EventList(queue_depth_, &event_pool_));
@@ -762,12 +517,12 @@ void Executor::SetOutputBuffersForIter(int queue_idx, WorkspaceBlob *wsb) {
 
     if (graph_->NodeType(node_id) == OpType::MIXED) {
       int mixed_op_id = graph_->NodeIdx(node_id);
-      wsb->mixed_op_data[mixed_op_id].SetOutput(
-          output_idx, cpu_outputs_[i].Get(queue_idx));
+      get_workspace<OpType::MIXED>(wsb->op_data, mixed_op_id)
+          .SetOutput(output_idx, cpu_outputs_[i].Get(queue_idx));
     } else {  // OpType::GPU
       int gpu_op_id = graph_->NodeIdx(node_id);
-      wsb->gpu_op_data[gpu_op_id].SetOutput(output_idx,
-          cpu_outputs_[i].Get(queue_idx));
+      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
+          .SetOutput(output_idx, cpu_outputs_[i].Get(queue_idx));
     }
 
     for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
@@ -776,8 +531,8 @@ void Executor::SetOutputBuffersForIter(int queue_idx, WorkspaceBlob *wsb) {
       DALI_ENFORCE(graph_->NodeType(node_id) == OpType::GPU);
 
       int gpu_op_id = graph_->NodeIdx(node_id);
-      wsb->gpu_op_data[gpu_op_id].SetInput(
-          input_idx, cpu_outputs_[i].Get(queue_idx));
+      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
+          .SetInput(input_idx, cpu_outputs_[i].Get(queue_idx));
     }
   }
 
@@ -788,15 +543,14 @@ void Executor::SetOutputBuffersForIter(int queue_idx, WorkspaceBlob *wsb) {
 
     if (graph_->NodeType(node_id) == OpType::MIXED) {
       int mixed_op_id = graph_->NodeIdx(node_id);
-      wsb->mixed_op_data[mixed_op_id].SetOutput(output_idx,
-          gpu_outputs_[i].Get(queue_idx));
+      get_workspace<OpType::MIXED>(wsb->op_data, mixed_op_id)
+          .SetOutput(output_idx, gpu_outputs_[i].Get(queue_idx));
     } else if (graph_->NodeType(node_id) == OpType::GPU) {
       int gpu_op_id = graph_->NodeIdx(node_id);
-      wsb->gpu_op_data[gpu_op_id].SetOutput(output_idx,
-          gpu_outputs_[i].Get(queue_idx));
+      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
+          .SetOutput(output_idx, gpu_outputs_[i].Get(queue_idx));
     } else {
-      DALI_FAIL("Internal error. GPU output source is "
-          "not gpu/mixed op");
+      DALI_FAIL("Internal error. GPU output source is not gpu/mixed op");
     }
 
     for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
@@ -805,8 +559,8 @@ void Executor::SetOutputBuffersForIter(int queue_idx, WorkspaceBlob *wsb) {
       DALI_ENFORCE(graph_->NodeType(node_id) == OpType::GPU);
 
       int gpu_op_id = graph_->NodeIdx(node_id);
-      wsb->gpu_op_data[gpu_op_id].SetInput(input_idx,
-          gpu_outputs_[i].Get(queue_idx));
+      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
+          .SetInput(input_idx, gpu_outputs_[i].Get(queue_idx));
     }
   }
 }

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -24,14 +24,16 @@
 
 #include "dali/common.h"
 #include "dali/error_handling.h"
+#include "dali/pipeline/graph/op_graph.h"
+#include "dali/pipeline/graph/op_graph_verifier.h"
+#include "dali/pipeline/util/event_pool.h"
+#include "dali/pipeline/util/stream_pool.h"
+#include "dali/pipeline/util/thread_pool.h"
 #include "dali/pipeline/workspace/device_workspace.h"
 #include "dali/pipeline/workspace/host_workspace.h"
 #include "dali/pipeline/workspace/mixed_workspace.h"
 #include "dali/pipeline/workspace/support_workspace.h"
-#include "dali/pipeline/op_graph.h"
-#include "dali/pipeline/util/event_pool.h"
-#include "dali/pipeline/util/stream_pool.h"
-#include "dali/pipeline/util/thread_pool.h"
+#include "dali/pipeline/workspace/workspace_data_factory.h"
 
 namespace dali {
 
@@ -84,32 +86,61 @@ class DLL_PUBLIC Executor {
   DISABLE_COPY_MOVE_ASSIGN(Executor);
 
  protected:
-  using WorkspaceBlob = struct {
-    vector<HostWorkspace> cpu_op_data;
-    vector<MixedWorkspace> mixed_op_data;
-    vector<DeviceWorkspace> gpu_op_data;
-    vector<SupportWorkspace> support_op_data;
+  struct WorkspaceBlob {
+    workspace_store_t op_data;
+
+    void Resize(int support, int cpu, int mixed, int gpu) {
+      std::get<static_cast<int>(OpType::SUPPORT)>(op_data).resize(support);
+      std::get<static_cast<int>(OpType::CPU)>(op_data).resize(cpu);
+      std::get<static_cast<int>(OpType::MIXED)>(op_data).resize(mixed);
+      std::get<static_cast<int>(OpType::GPU)>(op_data).resize(gpu);
+    }
 
     void Clear() {
-      cpu_op_data.clear();
-      mixed_op_data.clear();
-      gpu_op_data.clear();
-      support_op_data.clear();
+      std::get<static_cast<int>(OpType::SUPPORT)>(op_data).clear();
+      std::get<static_cast<int>(OpType::CPU)>(op_data).clear();
+      std::get<static_cast<int>(OpType::MIXED)>(op_data).clear();
+      std::get<static_cast<int>(OpType::GPU)>(op_data).clear();
     }
   };
   vector<WorkspaceBlob> wss_;
 
   void PruneUnusedGraphNodes();
 
-  void SetupDataForGraph(WorkspaceBlob *wsb);
+  void SetupWorkspacesForGraph(WorkspaceBlob *wsb);
 
-  void PresizeData(WorkspaceBlob *wsb);
+  std::vector<int> GetMemoryHints(const OpNode &node);
+
+  void PresizeData(std::vector<tensor_data_store_t>& tensor_to_storage, const OpGraph& graph);
 
   void SetupStreamsForGraph(WorkspaceBlob *wsb);
 
   void SetupOutputQueuesForGraph();
 
   void SetOutputBuffersForIter(int queue_idx, WorkspaceBlob *wsb);
+
+  template <OpType op_type>
+  op_type_to_workspace_t<op_type> &get_workspace(workspace_store_t &wo,
+                                                 OpPartitionId partition_idx);
+
+  template <OpType op_type>
+  op_type_to_workspace_t<op_type> &get_workspace(workspace_store_t &wo, const OpNode &node);
+
+  template <OpType op_type>
+  void SetupInputOutput(op_type_to_workspace_t<op_type> &ws, const OpGraph &graph,
+                        const OpNode &node);
+
+  template <OpType op_type>
+  void SetupPinned(op_type_to_workspace_t<op_type> &ws, const OpGraph &graph, const OpNode &node);
+
+  template <OpType op_type>
+  void SetupStreamsAndEvents(op_type_to_workspace_t<op_type> &ws, const OpGraph &graph,
+                             const OpNode &node);
+
+  // TODO(klecki): this would require queue indexes for parents and children
+  template <OpType op_type>
+  op_type_to_workspace_t<op_type> CreateWorkspace(const OpGraph &graph, const OpNode &node);
+
 
   template <typename Backend>
   class TensorListPool {
@@ -205,6 +236,9 @@ class DLL_PUBLIC Executor {
   std::mutex errors_mutex_;
   bool exec_error_;
   ExecutorCallback cb_;
+  std::vector<tensor_data_store_t> tensor_to_storage_;
+  cudaStream_t mixed_op_stream_, gpu_op_stream_;
+  std::vector<cudaEvent_t> mixed_op_events_;  // To introduce dependency from MIXED to GPU Ops
 };
 
 #define USE_EXECUTOR_MEMBERS()                             \
@@ -230,6 +264,153 @@ class DLL_PUBLIC Executor {
   using Executor::stream_pool_;                            \
   using Executor::event_pool_;                             \
   using Executor::thread_pool_
+
+template <OpType op_type>
+op_type_to_workspace_t<op_type> &Executor::get_workspace(workspace_store_t &wo,
+                                                         OpPartitionId partition_idx) {
+  auto &ws_vec = std::get<static_cast<size_t>(op_type)>(wo);
+  return ws_vec[partition_idx];
+}
+
+template <OpType op_type>
+op_type_to_workspace_t<op_type> &Executor::get_workspace(workspace_store_t &wo,
+                                                         const OpNode &node) {
+  DALI_ENFORCE(node.op_type == op_type, "Wrong variant of method selected. OpType does not match.");
+  auto &ws_vec = std::get<static_cast<size_t>(op_type)>(wo);
+  return ws_vec[node.partition_index];
+}
+
+// We instantiate the operation of adding the input only for parent op_type and device
+// that are specifically allowed
+template <OpType op_type, OpType producer_type, StorageDevice device>
+enable_if_t<allows_op_input<op_type>(producer_type) && allows_tensor_input<op_type>(device)>
+add_input(op_type_to_workspace_t<op_type> &ws, const tensor_data_store_t &storage) {
+  auto tensor = get_storage<producer_type, device>(storage);
+  ws.AddInput(tensor);
+}
+
+// If parent op_type or device is not allowed this is a no-op
+template <OpType op_type, OpType producer_type, StorageDevice device>
+enable_if_t<!allows_op_input<op_type>(producer_type) || !allows_tensor_input<op_type>(device)>
+add_input(op_type_to_workspace_t<op_type>, const tensor_data_store_t) {}
+
+// This will be only used for allowed ones (TODO(klecki) with exception of the device)
+template <OpType op_type, StorageDevice device>
+void add_output(op_type_to_workspace_t<op_type> &ws, const tensor_data_store_t &storage) {
+  auto tensor = get_storage<op_type, device>(storage);
+  ws.AddOutput(tensor);
+}
+
+// TODO(klecki): should we move this to OpNode, and make it subclasses for
+// all OpTypes -> implement `add_input` and add_output for all of the subclasses
+// as well with later operations
+template <OpType op_type>
+void Executor::SetupInputOutput(op_type_to_workspace_t<op_type> &ws, const OpGraph &graph,
+                                const OpNode &node) {
+  for (int j = 0; j < node.spec.NumRegularInput(); ++j) {
+    auto tid = node.parent_tensors[j];
+    auto &parent_node = graph.Node(graph.Tensor(tid).producer.node);
+    auto parent_op_type = parent_node.op_type;
+    auto tensor_device = graph.Tensor(tid).producer.storage_device;
+
+    VALUE_SWITCH(parent_op_type, parent_op_static,
+        (OpType::GPU, OpType::CPU, OpType::MIXED, OpType::SUPPORT),
+    (
+      VALUE_SWITCH(tensor_device, device_static, (StorageDevice::CPU, StorageDevice::GPU),
+      (
+        add_input<op_type, parent_op_static, device_static>(ws, tensor_to_storage_[tid]);
+      ), DALI_FAIL("Unexpected device"))  // NOLINT(whitespace/parens)
+    ), DALI_FAIL("Unexpected op_type"));  // NOLINT(whitespace/parens)
+  }
+
+  // Argument inputs can be handled genericaly
+  for (const auto &arg_pair : node.spec.ArgumentInputs()) {
+  // Get each argument input and add them to this op's workspace.
+    auto input_index = arg_pair.second;
+    auto tid = node.parent_tensors[input_index];
+    auto tensor = get_storage<OpType::SUPPORT, StorageDevice::CPU>(tensor_to_storage_[tid]);
+    ws.AddArgumentInput(tensor, arg_pair.first);
+  }
+
+  for (int j = 0; j < node.spec.NumOutput(); ++j) {
+    auto tid = node.children_tensors[j];
+    auto tensor_device = graph.Tensor(tid).producer.storage_device;
+    VALUE_SWITCH(tensor_device, device_static, (StorageDevice::CPU, StorageDevice::GPU),
+    (
+      add_output<op_type, device_static>(ws, tensor_to_storage_[tid]);
+    ), DALI_FAIL("Unexpected device"));  // NOLINT(whitespace/parens)
+  }
+}
+
+template <OpType op_type>
+void Executor::SetupPinned(op_type_to_workspace_t<op_type> &, const OpGraph &, const OpNode &) {
+  /* No-op if we are not MIXED MakeContigous node */
+}
+
+// TODO(klecki): this should be handled on Tensor level?
+template <>
+inline void Executor::SetupPinned<OpType::MIXED>(MixedWorkspace& ws, const OpGraph &graph,
+                                                           const OpNode &node) {
+  for (int j = 0; j < node.spec.NumRegularInput(); ++j) {
+    auto tid = node.parent_tensors[j];
+    // Use pinned memory only when it is useful
+    if (node.spec.name() == "MakeContiguous" && node.spec.NumOutput() == 1 &&
+        node.spec.OutputDevice(0) == "gpu") {
+      // TODO(klecki): we need some wrappers for WorkspaceOutputType with set_pinned in API
+      for (auto t : get_storage<OpType::CPU, StorageDevice::CPU>(tensor_to_storage_[tid])) {
+        t->set_pinned(true);
+      }
+    }
+  }
+}
+
+template <OpType op_type>
+void Executor::SetupStreamsAndEvents(op_type_to_workspace_t<op_type> &ws, const OpGraph &graph,
+                                     const OpNode &node) {
+  /* No-op if we are not Mixed or GPU */
+}
+
+template <>
+inline void Executor::SetupStreamsAndEvents<OpType::MIXED>(MixedWorkspace &ws, const OpGraph &graph,
+                                                           const OpNode &node) {
+  // We assign unique stream to mixed ops.
+  // This ensures that we won't have false dependencies
+  // between mixed ops and the previous iterations
+  // gpu ops.
+  ws.set_stream(mixed_op_stream_);
+  ws.set_event(mixed_op_events_[node.partition_index]);
+}
+
+template <>
+inline void Executor::SetupStreamsAndEvents<OpType::GPU>(DeviceWorkspace &ws, const OpGraph &graph,
+                                                         const OpNode &node) {
+  // I/O pipeline is always going to be launched alongside
+  // some other GPU work (like DL training).
+  // Therefore it is not necessary to use more than
+  // 1 stream for GPU ops, even though we may not fill
+  // the whole GPU with just I/O pipeline kernels
+  // by doing so.
+  ws.set_stream(gpu_op_stream_);
+  for (const auto& p : node.parents) {
+    if (graph.NodeType(p) == OpType::MIXED) {
+      const auto &parent_op = graph.Node(p);
+      // We need to block on this op's event to
+      // make sure that we respect the dependency
+      ws.AddParentEvent(mixed_op_events_[parent_op.partition_index]);
+    }
+  }
+}
+
+template <OpType op_type>
+op_type_to_workspace_t<op_type> Executor::CreateWorkspace(const OpGraph &graph,
+                                                          const OpNode &node) {
+  op_type_to_workspace_t<op_type> ws;
+  SetupInputOutput<op_type>(ws, graph, node);
+  SetupPinned<op_type>(ws, graph, node);
+  SetupStreamsAndEvents<op_type>(ws, graph, node);
+  return ws;
+}
+
 
 }  // namespace dali
 

--- a/dali/pipeline/executor/executor_test.cc
+++ b/dali/pipeline/executor/executor_test.cc
@@ -40,15 +40,15 @@ class ExecutorTest : public GenericDecoderTest<RGB> {
   }
 
   vector<HostWorkspace> CPUData(Executor *exe, int idx) const {
-    return exe->wss_[idx].cpu_op_data;
+    return std::get<static_cast<int>(OpType::CPU)>(exe->wss_[idx].op_data);
   }
 
   vector<MixedWorkspace> MixedData(Executor *exe, int idx) const {
-    return exe->wss_[idx].mixed_op_data;
+    return std::get<static_cast<int>(OpType::MIXED)>(exe->wss_[idx].op_data);
   }
 
   vector<DeviceWorkspace> GPUData(Executor *exe, int idx) const {
-    return exe->wss_[idx].gpu_op_data;
+    return std::get<static_cast<int>(OpType::GPU)>(exe->wss_[idx].op_data);
   }
 
   void VerifyDecode(const uint8 *img, int h, int w, int img_id) const {

--- a/dali/pipeline/executor/pipelined_executor.cc
+++ b/dali/pipeline/executor/pipelined_executor.cc
@@ -35,13 +35,6 @@ void PipelinedExecutor::Build(OpGraph *graph, vector<string> output_names) {
   }
 }
 
-std::vector<int> PipelinedExecutor::GetMemoryHints(const OpSpec &spec) {
-  std::vector<int> hints;
-  GetSingleOrRepeatedArg(spec, &hints, "bytes_per_sample_hint", spec.NumOutput());
-  std::replace(hints.begin(), hints.end(), 0, static_cast<int>(bytes_per_sample_hint_));
-  return hints;
-}
-
 void PipelinedExecutor::SetupStageOutputsForGraph() {
   DeviceGuard g(device_id_);
   // Make a set of the outputs names for quick lookup
@@ -53,7 +46,7 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
     // Do not include CPU ops inputs, since those are run
     // synchronously with support ops
     OpNode &node = graph_->Node(OpType::SUPPORT, i);
-    std::vector<int> hints = GetMemoryHints(node.spec);
+    std::vector<int> hints = GetMemoryHints(node);
 
     for (int j = 0; j < node.spec.NumOutput(); ++j) {
       // If this tensor is a pipeline output, its
@@ -62,13 +55,11 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
       DALI_ENFORCE(graph_->TensorIsType<CPUBackend>(tensor_name));
       if (output_set.count(tensor_name) != 0) continue;
 
-      vector<TensorMeta> consumer_meta =
-        graph_->TensorConsumerMeta(tensor_name);
+      vector<TensorMeta> consumer_meta = graph_->TensorConsumerMeta(tensor_name);
       bool found_stage_boundary = false;
       for (auto &meta : consumer_meta) {
-        const auto& node_type = graph_->NodeType(meta.node);
-        if (node_type != OpType::SUPPORT &&
-            node_type != OpType::CPU) {
+        const auto &node_type = graph_->NodeType(meta.node);
+        if (node_type != OpType::SUPPORT && node_type != OpType::CPU) {
           // We've located a tensor that is an output of
           // the stage.
           found_stage_boundary = true;
@@ -79,8 +70,7 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
         info.prod_and_idx = std::make_pair(node.id, j);
         support_stage_output_info_.push_back(info);
         support_stage_outputs_.push_back(
-            TensorPool<CPUBackend>(
-                queue_depth_, batch_size_, hints[j]));
+            TensorPool<CPUBackend>(queue_depth_, batch_size_, hints[j]));
         for (auto &meta : consumer_meta) {
           OutputInfo &info = support_stage_output_info_.back();
           auto tmp = std::make_pair(meta.node, meta.index);
@@ -94,7 +84,7 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
     // Find all outputs of the cpu stage. An output is
     // a tensor that is used by an op in a later stage.
     OpNode &node = graph_->Node(OpType::CPU, i);
-    std::vector<int> hints = GetMemoryHints(node.spec);
+    std::vector<int> hints = GetMemoryHints(node);
 
     for (int j = 0; j < node.spec.NumOutput(); ++j) {
       // If this tensor is a pipeline output, its
@@ -103,8 +93,7 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
       DALI_ENFORCE(graph_->TensorIsType<CPUBackend>(tensor_name));
       if (output_set.count(tensor_name) != 0) continue;
 
-      vector<TensorMeta> consumer_meta =
-        graph_->TensorConsumerMeta(tensor_name);
+      vector<TensorMeta> consumer_meta = graph_->TensorConsumerMeta(tensor_name);
       bool found_stage_boundary = false;
       bool has_gpu_consumer = false;
       for (auto &meta : consumer_meta) {
@@ -114,10 +103,8 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
           // the stage.
           auto &consumer = graph_->Node(meta.node);
           has_gpu_consumer =
-              has_gpu_consumer ||
-              type == OpType::GPU ||
-              (consumer.spec.name() == "MakeContiguous" &&
-              consumer.spec.OutputDevice(0) == "gpu");
+              has_gpu_consumer || type == OpType::GPU ||
+              (consumer.spec.name() == "MakeContiguous" && consumer.spec.OutputDevice(0) == "gpu");
           found_stage_boundary = true;
         }
       }
@@ -126,8 +113,7 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
         info.prod_and_idx = std::make_pair(node.id, j);
         cpu_stage_output_info_.push_back(info);
         cpu_stage_outputs_.push_back(
-            TensorVectorPool<CPUBackend>(
-                queue_depth_, batch_size_, hints[j], has_gpu_consumer));
+            TensorVectorPool<CPUBackend>(queue_depth_, batch_size_, hints[j], has_gpu_consumer));
         for (auto &meta : consumer_meta) {
           OutputInfo &info = cpu_stage_output_info_.back();
           auto tmp = std::make_pair(meta.node, meta.index);
@@ -141,7 +127,7 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
     // Find all outputs of the mixed stage. An output
     // is a tensor that is used by an op in a later stage.
     OpNode &node = graph_->Node(OpType::MIXED, i);
-    std::vector<int> hints = GetMemoryHints(node.spec);
+    std::vector<int> hints = GetMemoryHints(node);
 
     for (int j = 0; j < node.spec.NumOutput(); ++j) {
       // If this tensor is a pipeline output, its
@@ -149,8 +135,7 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
       string tensor_name = node.spec.Output(j);
       if (output_set.count(tensor_name) != 0) continue;
 
-      vector<TensorMeta> consumer_meta =
-        graph_->TensorConsumerMeta(tensor_name);
+      vector<TensorMeta> consumer_meta = graph_->TensorConsumerMeta(tensor_name);
       bool has_info_object = false;
 
       if (graph_->TensorIsType<CPUBackend>(tensor_name)) {
@@ -164,8 +149,7 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
 
               mixed_stage_cpu_output_info_.push_back(info);
               mixed_stage_cpu_outputs_.push_back(
-                  TensorListPool<CPUBackend>(
-                      queue_depth_, batch_size_, hints[j], pinned));
+                  TensorListPool<CPUBackend>(queue_depth_, batch_size_, hints[j], pinned));
               has_info_object = true;
             }
 
@@ -182,8 +166,7 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
               info.prod_and_idx = std::make_pair(node.id, j);
               mixed_stage_gpu_output_info_.push_back(info);
               mixed_stage_gpu_outputs_.push_back(
-                  TensorListPool<GPUBackend>(
-                      queue_depth_, batch_size_, hints[j]));
+                  TensorListPool<GPUBackend>(queue_depth_, batch_size_, hints[j]));
               has_info_object = true;
             }
 
@@ -197,8 +180,7 @@ void PipelinedExecutor::SetupStageOutputsForGraph() {
   }
 }
 
-void PipelinedExecutor::SetStageOutputsForIter(
-    int queue_idx, WorkspaceBlob *wsb) {
+void PipelinedExecutor::SetStageOutputsForIter(int queue_idx, WorkspaceBlob *wsb) {
   DeviceGuard g(device_id_);
   for (size_t i = 0; i < support_stage_outputs_.size(); ++i) {
     auto &tvp = support_stage_outputs_[i];
@@ -208,25 +190,25 @@ void PipelinedExecutor::SetStageOutputsForIter(
 
     int support_op_id = graph_->NodeIdx(node_id);
     int output_idx = info.prod_and_idx.second;
-    wsb->support_op_data[support_op_id].SetOutput(
-        output_idx, tvp.Get(queue_idx));
+    get_workspace<OpType::SUPPORT>(wsb->op_data, support_op_id)
+        .SetOutput(output_idx, tvp.Get(queue_idx));
 
     for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
       node_id = info.con_and_idx[j].first;
-      const OpNode& op_node = graph_->Node(node_id);
+      const OpNode &op_node = graph_->Node(node_id);
       int child_op_id = graph_->NodeIdx(node_id);
       int input_idx = info.con_and_idx[j].second;
-      const OpSpec& spec = op_node.spec;
+      const OpSpec &spec = op_node.spec;
       std::string arg_name = spec.ArgumentInputName(input_idx);
       if (graph_->NodeType(node_id) == OpType::MIXED) {
-        wsb->mixed_op_data[child_op_id].SetArgumentInput(
-          tvp.Get(queue_idx), arg_name);
+        get_workspace<OpType::MIXED>(wsb->op_data, child_op_id)
+            .SetArgumentInput(tvp.Get(queue_idx), arg_name);
       } else if (graph_->NodeType(node_id) == OpType::GPU) {
-        wsb->gpu_op_data[child_op_id].SetArgumentInput(
-          tvp.Get(queue_idx), arg_name);
+        get_workspace<OpType::GPU>(wsb->op_data, child_op_id)
+            .SetArgumentInput(tvp.Get(queue_idx), arg_name);
       } else {
-        wsb->cpu_op_data[child_op_id].SetArgumentInput(
-          tvp.Get(queue_idx), arg_name);
+        get_workspace<OpType::CPU>(wsb->op_data, child_op_id)
+            .SetArgumentInput(tvp.Get(queue_idx), arg_name);
       }
     }
   }
@@ -239,23 +221,22 @@ void PipelinedExecutor::SetStageOutputsForIter(
 
     int cpu_op_id = graph_->NodeIdx(node_id);
     int output_idx = info.prod_and_idx.second;
-    wsb->cpu_op_data[cpu_op_id].SetOutput(
-        output_idx, tvp.Get(queue_idx));
+    get_workspace<OpType::CPU>(wsb->op_data, cpu_op_id)
+        .SetOutput(output_idx, tvp.Get(queue_idx));
 
     for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
       node_id = info.con_and_idx[j].first;
       if (graph_->NodeType(node_id) == OpType::MIXED) {
         int mixed_op_id = graph_->NodeIdx(node_id);
         int input_idx = info.con_and_idx[j].second;
-        wsb->mixed_op_data[mixed_op_id].SetInput(
-          input_idx, tvp.Get(queue_idx));
+        get_workspace<OpType::MIXED>(wsb->op_data, mixed_op_id)
+            .SetInput(input_idx, tvp.Get(queue_idx));
         const OpNode &node = graph_->Node(OpType::MIXED, mixed_op_id);
-        std::vector<int> hints = GetMemoryHints(node.spec);
+        std::vector<int> hints = GetMemoryHints(node);
         // Use pinned memory only when it is useful
-        if (node.spec.name() == "MakeContiguous" &&
-            node.spec.NumOutput() == 1 &&
+        if (node.spec.name() == "MakeContiguous" && node.spec.NumOutput() == 1 &&
             node.spec.OutputDevice(0) == "gpu") {
-          for (auto& v : tvp.Get(queue_idx)) {
+          for (auto &v : tvp.Get(queue_idx)) {
             if (!v->is_pinned()) {
               auto capacity = std::max<size_t>(v->capacity(), hints[0]);
               v->free();
@@ -267,10 +248,10 @@ void PipelinedExecutor::SetStageOutputsForIter(
       } else if (graph_->NodeType(node_id) == OpType::CPU) {
         int cpu_op_id = graph_->NodeIdx(node_id);
         int input_idx = info.con_and_idx[j].second;
-        wsb->cpu_op_data[cpu_op_id].SetInput(
-          input_idx, tvp.Get(queue_idx));
+        get_workspace<OpType::CPU>(wsb->op_data, cpu_op_id)
+            .SetInput(input_idx, tvp.Get(queue_idx));
       } else {
-          DALI_FAIL("Internal error - found non-CPU/mixed consumer");
+        DALI_FAIL("Internal error - found non-CPU/mixed consumer");
       }
     }
   }
@@ -283,8 +264,8 @@ void PipelinedExecutor::SetStageOutputsForIter(
 
     int mixed_op_id = graph_->NodeIdx(node_id);
     int output_idx = info.prod_and_idx.second;
-    wsb->mixed_op_data[mixed_op_id].SetOutput(
-        output_idx, tlp.Get(queue_idx));
+    get_workspace<OpType::MIXED>(wsb->op_data, mixed_op_id)
+        .SetOutput(output_idx, tlp.Get(queue_idx));
 
     for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
       node_id = info.con_and_idx[j].first;
@@ -292,11 +273,10 @@ void PipelinedExecutor::SetStageOutputsForIter(
 
       int gpu_op_id = graph_->NodeIdx(node_id);
       int input_idx = info.con_and_idx[j].second;
-      wsb->gpu_op_data[gpu_op_id].SetInput(
-          input_idx, tlp.Get(queue_idx));
+      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
+          .SetInput(input_idx, tlp.Get(queue_idx));
     }
   }
-
 
   for (size_t i = 0; i < mixed_stage_gpu_outputs_.size(); ++i) {
     auto &tlp = mixed_stage_gpu_outputs_[i];
@@ -306,8 +286,8 @@ void PipelinedExecutor::SetStageOutputsForIter(
 
     int mixed_op_id = graph_->NodeIdx(node_id);
     int output_idx = info.prod_and_idx.second;
-    wsb->mixed_op_data[mixed_op_id].SetOutput(
-        output_idx, tlp.Get(queue_idx));
+    get_workspace<OpType::MIXED>(wsb->op_data, mixed_op_id)
+        .SetOutput(output_idx, tlp.Get(queue_idx));
 
     for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
       node_id = info.con_and_idx[j].first;
@@ -315,8 +295,8 @@ void PipelinedExecutor::SetStageOutputsForIter(
 
       int gpu_op_id = graph_->NodeIdx(node_id);
       int input_idx = info.con_and_idx[j].second;
-      wsb->gpu_op_data[gpu_op_id].SetInput(
-          input_idx, tlp.Get(queue_idx));
+      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
+          .SetInput(input_idx, tlp.Get(queue_idx));
     }
   }
 }

--- a/dali/pipeline/executor/pipelined_executor.h
+++ b/dali/pipeline/executor/pipelined_executor.h
@@ -55,9 +55,6 @@ class DLL_PUBLIC PipelinedExecutor : public Executor {
 
   void SetStageOutputsForIter(int queue_idx, WorkspaceBlob *wsb);
 
-  std::vector<int> GetMemoryHints(const OpSpec &spec);
-
-
   template <typename Backend>
   class TensorVectorPool {
    public:

--- a/dali/pipeline/graph/CMakeLists.txt
+++ b/dali/pipeline/graph/CMakeLists.txt
@@ -12,21 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Add all subdirectories
-add_subdirectory(data)
-add_subdirectory(graph)
-add_subdirectory(operators)
-add_subdirectory(util)
-add_subdirectory(workspace)
-add_subdirectory(executor)
-add_subdirectory(proto)
-
 # Get all the source files and dump test files
 file(GLOB tmp *.cc)
 set(DALI_SRCS ${DALI_SRCS} ${tmp})
 file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-file(GLOB tmp *_bench.cc)
 remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
 set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
 
@@ -35,16 +24,3 @@ if (BUILD_TEST)
   file(GLOB tmp *_test.cc)
   set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
 endif()
-
-if (BUILD_BENCHMARK)
-  # Get all the benchmark srcs
-  file(GLOB tmp *_bench.cc)
-  set(DALI_BENCHMARK_SRCS ${DALI_BENCHMARK_SRCS} ${tmp} PARENT_SCOPE)
-endif()
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} PARENT_SCOPE)
-
-# Get the protobuf files for pipe serialization
-protobuf_generate_cpp(DALI_PROTO_SRCS DALI_PROTO_HEADERS proto/dali.proto)
-add_library(DALI_PROTO OBJECT ${DALI_PROTO_HEADERS} ${DALI_PROTO_SRCS})
-install(FILES ${DALI_PROTO_HEADERS} DESTINATION include/dali/pipeline)

--- a/dali/pipeline/graph/op_graph_storage.cc
+++ b/dali/pipeline/graph/op_graph_storage.cc
@@ -1,0 +1,43 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+
+#include "dali/pipeline/graph/op_graph_storage.h"
+
+namespace dali {
+
+std::vector<tensor_data_store_t> CreateBackingStorageForTensorNodes(const OpGraph &op_graph,
+                                                                    int batch_size) {
+  std::vector<tensor_data_store_t> result;
+  result.resize(op_graph.NumTensor());
+  // Assign data to each Tensor node in graph
+  for (int i = 0; i < op_graph.NumTensor(); i++) {
+    const auto &tensor = op_graph.Tensor(i);
+    auto producer_op_type = op_graph.Node(tensor.producer.node).op_type;
+    result[i] = BatchFactory(producer_op_type, tensor.producer.storage_device, batch_size);
+  }
+  return result;
+}
+
+std::vector<cudaEvent_t> CreateEventsForMixedOps(EventPool &event_pool, const OpGraph &op_graph) {
+  std::vector<cudaEvent_t> result;
+  result.resize(op_graph.NumOp(OpType::MIXED));
+  for (int i = 0; i < op_graph.NumOp(OpType::MIXED); i++) {
+    result[i] = event_pool.GetEvent();
+  }
+  return result;
+}
+
+}  // namespace dali

--- a/dali/pipeline/graph/op_graph_storage.h
+++ b/dali/pipeline/graph/op_graph_storage.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_GRAPH_OP_GRAPH_STORAGE_H_
+#define DALI_PIPELINE_GRAPH_OP_GRAPH_STORAGE_H_
+
+#include <vector>
+
+#include "dali/pipeline/graph/op_graph.h"
+#include "dali/pipeline/util/event_pool.h"
+#include "dali/pipeline/workspace/workspace_data_factory.h"
+
+namespace dali {
+
+std::vector<tensor_data_store_t> CreateBackingStorageForTensorNodes(const OpGraph &op_graph,
+                                                                    int batch_size);
+
+// Mapping from MixedOp partition id to corresponding event
+std::vector<cudaEvent_t> CreateEventsForMixedOps(EventPool &event_pool, const OpGraph &op_graph);
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_GRAPH_OP_GRAPH_STORAGE_H_

--- a/dali/pipeline/graph/op_graph_test.cc
+++ b/dali/pipeline/graph/op_graph_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/pipeline/op_graph.h"
+#include "dali/pipeline/graph/op_graph.h"
 
 #include <gtest/gtest.h>
 

--- a/dali/pipeline/graph/op_graph_verifier.cc
+++ b/dali/pipeline/graph/op_graph_verifier.cc
@@ -1,0 +1,149 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "dali/error_handling.h"
+#include "dali/pipeline/graph/op_graph.h"
+#include "dali/pipeline/graph/op_graph_verifier.h"
+
+namespace dali {
+
+namespace {
+
+std::string concatenate_alternatives(const std::set<OpType>& vec) {
+  if (vec.empty()) return "";
+  std::stringstream result;
+  bool first = true;
+  for (auto op_type : vec) {
+    if (first) {
+      first = false;
+    } else {
+      result << ", ";
+    }
+    result << to_string(op_type);
+  }
+  return result.str();
+}
+
+}  // namespace
+
+constexpr OpType parent_constraints<OpType::SUPPORT>::allowed_parents[];
+constexpr OpType parent_constraints<OpType::CPU>::allowed_parents[];
+constexpr OpType parent_constraints<OpType::MIXED>::allowed_parents[];
+constexpr OpType parent_constraints<OpType::GPU>::allowed_parents[];
+constexpr StorageDevice parent_constraints<OpType::SUPPORT>::allowed_input_tensors[];
+constexpr StorageDevice parent_constraints<OpType::CPU>::allowed_input_tensors[];
+constexpr StorageDevice parent_constraints<OpType::MIXED>::allowed_input_tensors[];
+constexpr StorageDevice parent_constraints<OpType::GPU>::allowed_input_tensors[];
+constexpr OpType parent_constraints<OpType::SUPPORT>::allowed_input_ops[];
+constexpr OpType parent_constraints<OpType::CPU>::allowed_input_ops[];
+constexpr OpType parent_constraints<OpType::MIXED>::allowed_input_ops[];
+constexpr OpType parent_constraints<OpType::GPU>::allowed_input_ops[];
+
+namespace {
+// helper to convert static information to runtime information
+template <OpType op_type>
+std::set<OpType> GetParentConstraints() {
+  return std::set<OpType>{std::begin(parent_constraints<op_type>::allowed_parents),
+                          std::end(parent_constraints<op_type>::allowed_parents)};
+}
+}  // namespace
+
+std::vector<std::set<OpType>> ParentOpTypeConstraints() {
+  std::vector<std::set<OpType>> allowed_parents;
+  allowed_parents.resize(static_cast<int>(OpType::COUNT));
+  allowed_parents[static_cast<int>(OpType::GPU)] = GetParentConstraints<OpType::GPU>();
+  allowed_parents[static_cast<int>(OpType::CPU)] = GetParentConstraints<OpType::CPU>();
+  allowed_parents[static_cast<int>(OpType::MIXED)] = GetParentConstraints<OpType::MIXED>();
+  allowed_parents[static_cast<int>(OpType::SUPPORT)] = GetParentConstraints<OpType::SUPPORT>();
+  return allowed_parents;
+}
+
+std::vector<int> ArgumentInputConstraints() {
+  std::vector<int> allows_argument_input;
+  allows_argument_input.resize(static_cast<int>(OpType::COUNT));
+  allows_argument_input[static_cast<int>(OpType::GPU)] =
+      parent_constraints<OpType::GPU>::supports_argument_inputs;
+  allows_argument_input[static_cast<int>(OpType::CPU)] =
+      parent_constraints<OpType::CPU>::supports_argument_inputs;
+  allows_argument_input[static_cast<int>(OpType::MIXED)] =
+      parent_constraints<OpType::MIXED>::supports_argument_inputs;
+  allows_argument_input[static_cast<int>(OpType::SUPPORT)] =
+      parent_constraints<OpType::SUPPORT>::supports_argument_inputs;
+  return allows_argument_input;
+}
+
+/**
+ * @brief Check if parent nodes have compatible OpType
+ */
+void CheckParentConstraints(const OpGraph& op_graph, const OpNode& op) {
+  static const auto allowed_parent_type = ParentOpTypeConstraints();
+  for (auto parent_id : op.parents) {
+    const auto& parent = op_graph.Node(parent_id);
+    const auto& allowed_parents = allowed_parent_type[static_cast<int>(op.op_type)];
+    DALI_ENFORCE(allowed_parents.find(parent.op_type) != allowed_parents.end(),
+                 "Op " + op.instance_name + " of type " + to_string(op.op_type) +
+                     " has parent Op " + parent.instance_name +
+                     " of incompatible type: " + to_string(parent.op_type) + ". Expected one of: " +
+                     concatenate_alternatives(allowed_parent_type[static_cast<int>(op.op_type)]) +
+                     ".");
+  }
+}
+
+/**
+ * @brief Check support for Argument Inputs and if Argument Inputs are produed by Support Ops
+ */
+void CheckArgumentInputConstraints(const OpGraph& op_graph, const OpNode& op) {
+  static const auto allows_argument_input = ArgumentInputConstraints();
+  bool arg_in_allowed = allows_argument_input[static_cast<int>(op.op_type)];
+  if (!arg_in_allowed) {
+    DALI_ENFORCE(op.spec.NumInput() == op.spec.NumRegularInput(),
+                 to_string(op.op_type) + " Ops do not support tensor arguments, found in " +
+                     op.instance_name + " Op.");
+  }
+  for (const auto& arg_pair : op.spec.ArgumentInputs()) {
+    auto input_idx = arg_pair.second;
+    auto in_tensor = op_graph.Tensor(op.parent_tensors[input_idx]);
+    // Parent node of this tensor is support op
+    DALI_ENFORCE(in_tensor.producer.is_support,
+                 "Argument input to " + op.instance_name + " produced by non-support Op.");
+  }
+}
+
+void CheckConsistentTensorEdges(const OpGraph& op_graph, const TensorNode& tensor) {
+  for (auto consumer_edge : tensor.consumers) {
+    DALI_ENFORCE(tensor.producer.is_support == consumer_edge.is_support,
+                 "Use of tensor " + tensor.name +
+                     " as support is mismatched between producer Op and consumer Op.");
+    DALI_ENFORCE(tensor.producer.storage_device == consumer_edge.storage_device,
+                 "Storage device of tensor " + tensor.name +
+                     " is mismatched between producer Op and consumer Op.");
+  }
+}
+
+void CheckGraphConstraints(const OpGraph& op_graph) {
+  for (int i = 0; i < op_graph.NumOp(); i++) {
+    CheckParentConstraints(op_graph, op_graph.Node(i));
+    CheckArgumentInputConstraints(op_graph, op_graph.Node(i));
+  }
+  for (int i = 0; i < op_graph.NumTensor(); i++) {
+    CheckConsistentTensorEdges(op_graph, op_graph.Tensor(i));
+  }
+}
+
+}  // namespace dali

--- a/dali/pipeline/graph/op_graph_verifier.h
+++ b/dali/pipeline/graph/op_graph_verifier.h
@@ -1,0 +1,95 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_GRAPH_OP_GRAPH_VERIFIER_H_
+#define DALI_PIPELINE_GRAPH_OP_GRAPH_VERIFIER_H_
+
+#include <set>
+#include <vector>
+
+#include "dali/pipeline/graph/op_graph.h"
+
+namespace dali {
+
+template <typename T, size_t N>
+constexpr size_t Size(T (&)[N]) {
+  return N;
+}
+
+template <typename T>
+constexpr auto Size(const T &t) -> decltype(t.size()) {
+  return t.size();
+}
+
+template <OpType op_type>
+struct parent_constraints;
+
+template <>
+struct parent_constraints<OpType::SUPPORT> {
+  static constexpr OpType allowed_parents[] = {OpType::SUPPORT};
+  static constexpr StorageDevice allowed_input_tensors[] = {StorageDevice::CPU};
+  static constexpr OpType allowed_input_ops[] = {OpType::SUPPORT};
+  static constexpr bool supports_argument_inputs = false;
+};
+
+template <>
+struct parent_constraints<OpType::CPU> {
+  static constexpr OpType allowed_parents[] = {OpType::CPU, OpType::SUPPORT};
+  static constexpr StorageDevice allowed_input_tensors[] = {StorageDevice::CPU};
+  static constexpr OpType allowed_input_ops[] = {OpType::CPU};
+  static constexpr bool supports_argument_inputs = true;
+};
+
+template <>
+struct parent_constraints<OpType::MIXED> {
+  static constexpr OpType allowed_parents[] = {OpType::CPU};
+  static constexpr StorageDevice allowed_input_tensors[] = {StorageDevice::CPU};
+  static constexpr OpType allowed_input_ops[] = {OpType::CPU};
+  static constexpr bool supports_argument_inputs = false;
+};
+
+template <>
+struct parent_constraints<OpType::GPU> {
+  static constexpr OpType allowed_parents[] = {OpType::GPU, OpType::MIXED, OpType::SUPPORT};
+  static constexpr StorageDevice allowed_input_tensors[] = {StorageDevice::CPU, StorageDevice::GPU};
+  static constexpr OpType allowed_input_ops[] = {OpType::MIXED, OpType::GPU};
+  static constexpr bool supports_argument_inputs = true;
+};
+
+template <typename T, size_t N>
+static constexpr bool is_in_array(const T value, const T (&arr)[N], size_t idx) {
+  // we encountered the end of array -> false
+  // otherwise we found at current position or search in next position recursivelly
+  return idx < N && (value == arr[idx] || is_in_array(value, arr, idx + 1));
+}
+
+template <OpType op_type>
+static constexpr bool allows_op_input(OpType parent) {
+  return is_in_array(parent, parent_constraints<op_type>::allowed_input_ops, 0);
+}
+
+template <OpType op_type>
+static constexpr bool allows_tensor_input(StorageDevice device) {
+  return is_in_array(device, parent_constraints<op_type>::allowed_input_tensors, 0);
+}
+
+std::vector<int> ArgumentInputConstraints();
+std::vector<std::set<OpType>> ParentOpTypeConstraints();
+
+// NB: we could collect all the errors in graph before reporting them to user
+void CheckGraphConstraints(const OpGraph &op_graph);
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_GRAPH_OP_GRAPH_VERIFIER_H_

--- a/dali/pipeline/graph/op_graph_verifier.h
+++ b/dali/pipeline/graph/op_graph_verifier.h
@@ -53,10 +53,10 @@ struct parent_constraints<OpType::CPU> {
 
 template <>
 struct parent_constraints<OpType::MIXED> {
-  static constexpr OpType allowed_parents[] = {OpType::CPU};
+  static constexpr OpType allowed_parents[] = {OpType::CPU, OpType::SUPPORT};
   static constexpr StorageDevice allowed_input_tensors[] = {StorageDevice::CPU};
   static constexpr OpType allowed_input_ops[] = {OpType::CPU};
-  static constexpr bool supports_argument_inputs = false;
+  static constexpr bool supports_argument_inputs = true;
 };
 
 template <>

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -29,7 +29,7 @@
 #include "dali/pipeline/data/tensor.h"
 #include "dali/pipeline/data/tensor_list.h"
 #include "dali/pipeline/operators/util/external_source.h"
-#include "dali/pipeline/op_graph.h"
+#include "dali/pipeline/graph/op_graph.h"
 
 
 namespace dali {


### PR DESCRIPTION
Check some constraints on OpGraph separately from Executor
processing the OpGraph

Add static traits for OpGraph constraints

Unify OpNodes processing for different OpType

Executor "owns" buffer for corresponding TensorNodes,
using data factory and related types

next: #551 