### PR TITLE
Store Queues of Buffers for corresponding TensorNodes

### DIFF
--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -48,35 +48,41 @@ void Executor::Build(OpGraph *graph, vector<string> output_names) {
   // Check if graph is ok for execution
   CheckGraphConstraints(*graph_);
   // Clear the old data
-  tensor_to_storage_.clear();
+  tensor_to_store_queue_.clear();
+
+  // TODO(klecki) this setups the event queues as well
+  SetupOutputInfo(*graph_);
+
+  auto queue_sizes = GetTensorQueueSizes(*graph_);
+
   // Create corresponding storage type for TensorNodes in graph
-  tensor_to_storage_ = CreateBackingStorageForTensorNodes(*graph_, batch_size_);
+  tensor_to_store_queue_ = CreateBackingStorageForTensorNodes(*graph_, batch_size_, queue_sizes);
   // Setup stream and events that will be used for execution
   {
     DeviceGuard g(device_id_);
     mixed_op_stream_ = stream_pool_.GetStream();
     gpu_op_stream_ = stream_pool_.GetStream();
-    mixed_op_events_ = CreateEventsForMixedOps(event_pool_, *graph_);
+    mixed_op_events_ = CreateEventsForMixedOps(event_pool_, *graph_, queue_depth_);
   }
+
+  // Presize the workspaces based on the hint
+  PresizeData(tensor_to_store_queue_, *graph_);
 
   // Setup workspaces for each op and connect
   // their inputs and outputs.
-  WorkspaceBlob base_wsb;
-  SetupWorkspacesForGraph(&base_wsb);
-
-  // Presize the workspaces based on the hint
-  PresizeData(tensor_to_storage_, *graph_);
-
-  SetupOutputQueuesForGraph();
-
+  // TODO(klecki) rework this
   // For each set of outputs, setup another set of
   // workspaces so that nothing has to be altered
   // during execution (this is necessary for
   // asynchonrous executors that can overlap work issue)
-  for (int i = 0; i < queue_depth_; ++i) {
-    SetOutputBuffersForIter(i, &base_wsb);
-    wss_.push_back(base_wsb);
+  WorkspaceBlob base_wsb;
+  wss_.resize(queue_depth_);
+  for (int queue_idx = 0; queue_idx < queue_depth_; queue_idx++) {
+    SetupWorkspacesForGraph(queue_idx);
   }
+
+  // Producer-consumer queues info
+  SetupOutputQueuesForGraph();
 }
 
 void Executor::RunCPU() {
@@ -97,11 +103,10 @@ void Executor::RunCPU() {
 
   // Run the support ops
   try {
-    WorkspaceBlob &wsb = wss_[queue_idx];
     for (int i = 0; i < graph_->NumOp(OpType::SUPPORT); ++i) {
       OpNode &op_node = graph_->Node(OpType::SUPPORT, i);
       OperatorBase &op = *op_node.op;
-      SupportWorkspace &ws = get_workspace<OpType::SUPPORT>(wsb.op_data, i);
+      SupportWorkspace &ws = GetWorkspace<OpType::SUPPORT>(queue_idx, i);
       TimeRange tr("[Executor] Run Support op " + op_node.instance_name,
           TimeRange::kCyan);
       op.Run(&ws);
@@ -115,16 +120,15 @@ void Executor::RunCPU() {
 
   if (!exec_error_) {
     // Run the cpu-ops in the thread pool
-    WorkspaceBlob &wsb = wss_[queue_idx];
     for (int i = 0; i < batch_size_; ++i) {
       thread_pool_.DoWorkWithID(std::bind(
-            [this, &wsb] (int data_idx, int tid) {
+            [this, queue_idx] (int data_idx, int tid) {
             TimeRange tr("[Executor] RunCPU on " + to_string(data_idx));
             SampleWorkspace ws;
             for (int j = 0; j < graph_->NumOp(OpType::CPU); ++j) {
               OpNode &op_node = graph_->Node(OpType::CPU, j);
               OperatorBase &op = *op_node.op;
-              get_workspace<OpType::CPU>(wsb.op_data, op_node).GetSample(&ws, data_idx, tid);
+              GetWorkspace<OpType::CPU>(queue_idx, op_node).GetSample(&ws, data_idx, tid);
               TimeRange tr("[Executor] Run CPU op " + op_node.instance_name
                   + " on " + to_string(data_idx),
                   TimeRange::kBlue1);
@@ -158,13 +162,11 @@ void Executor::RunMixed() {
   lock.unlock();
   DeviceGuard g(device_id_);
 
-  WorkspaceBlob &wsb = wss_[queue_idx];
-
   try {
     for (int i = 0; i < graph_->NumOp(OpType::MIXED); ++i) {
       OpNode &op_node = graph_->Node(OpType::MIXED, i);
       OperatorBase &op = *op_node.op;
-      MixedWorkspace &ws = get_workspace<OpType::MIXED>(wsb.op_data, i);
+      MixedWorkspace &ws = GetWorkspace<OpType::MIXED>(queue_idx, i);
       TimeRange tr("[Executor] Run Mixed op " + op_node.instance_name,
           TimeRange::kOrange);
       op.Run(&ws);
@@ -207,11 +209,10 @@ void Executor::RunGPU() {
   }
 
   try {
-    WorkspaceBlob &wsb = wss_[queue_idx];
     for (int i = 0; i < graph_->NumOp(OpType::GPU); ++i) {
       OpNode &op_node = graph_->Node(OpType::GPU, i);
       OperatorBase &op = *op_node.op;
-      DeviceWorkspace &ws = get_workspace<OpType::GPU>(wsb.op_data, i);
+      DeviceWorkspace &ws = GetWorkspace<OpType::GPU>(queue_idx, i);
       auto parent_events = ws.ParentEvents();
 
       for (auto &event : parent_events) {
@@ -226,6 +227,7 @@ void Executor::RunGPU() {
       }
     }
 
+    // TODO(klecki): do not go over string names, please
     for (size_t i = 0; i < output_names_.size(); ++i) {
       if (graph_->TensorIsType<CPUBackend>(output_names_[i])) continue;
       OpNodeId src_id = graph_->TensorSourceID(output_names_[i]);
@@ -234,10 +236,10 @@ void Executor::RunGPU() {
       // Record events for each output requested by the user
       cudaEvent_t event = gpu_output_events_[i].GetEvent(queue_idx);
       if (graph_->NodeType(src_id) == OpType::MIXED) {
-        auto &ws = get_workspace<OpType::MIXED>(wsb.op_data, src_idx);
+        auto &ws = GetWorkspace<OpType::MIXED>(queue_idx, src_idx);
         CUDA_CALL(cudaEventRecord(event, ws.stream()));
       } else if (graph_->NodeType(src_id) == OpType::GPU) {
-        auto &ws = get_workspace<OpType::GPU>(wsb.op_data, src_idx);
+        auto &ws = GetWorkspace<OpType::GPU>(queue_idx, src_idx);
         CUDA_CALL(cudaEventRecord(event, ws.stream()));
       } else {
         DALI_FAIL("Internal error. Output node is not gpu/mixed");
@@ -317,21 +319,27 @@ void Executor::ShareOutputs(DeviceWorkspace *ws) {
   in_use_queue_.push(output_idx);
   lock.unlock();
 
-  // Gather the results TensorLists and block on their
+  // We already gathered info about outputs, so we only have to wait on respective
   // events to make sure that the computation has completed
-  for (size_t i = 0; i < output_names_.size(); ++i) {
-    auto it = type_idx_map_.find(output_names_[i]);
-    DALI_ENFORCE(it != type_idx_map_.end(), "Executor could not "
-        "find output with name '" + output_names_[i] + "'.");
-
-    if (graph_->TensorIsType<CPUBackend>(output_names_[i])) {
-      auto &tl_pool = cpu_outputs_[it->second];
-      ws->AddOutput(tl_pool.Get(output_idx));
+  for (size_t i = 0; i < pipeline_outputs_.size(); i++) {
+    auto out_tensor_id = pipeline_outputs_[i];
+    auto &out_tensor = graph_->Tensor(out_tensor_id);
+    auto op_type = graph_->Node(out_tensor.producer.node).op_type;
+    if (out_tensor.producer.storage_device == StorageDevice::GPU) {
+      VALUE_SWITCH(op_type, op_type_static, (OpType::MIXED, OpType::GPU),
+      (
+        auto &queue = get_queue<op_type_static, StorageDevice::GPU>(
+            tensor_to_store_queue_[out_tensor_id]);
+        ws->AddOutput(queue[output_idx]);
+        CUDA_CALL(cudaEventSynchronize(gpu_output_events_[i].GetEvent(output_idx)));
+      ), DALI_FAIL("Invalid op type"));  // NOLINT(whitespace/parens)
     } else {
-      auto &tl_pool = gpu_outputs_[it->second];
-      ws->AddOutput(tl_pool.Get(output_idx));
-      CUDA_CALL(cudaEventSynchronize(
-              gpu_output_events_[i].GetEvent(output_idx)));
+      VALUE_SWITCH(op_type, op_type_static, (OpType::MIXED, OpType::GPU),
+      (
+        auto &queue = get_queue<op_type_static, StorageDevice::CPU>(
+            tensor_to_store_queue_[out_tensor_id]);
+        ws->AddOutput(queue[output_idx]);
+      ), DALI_FAIL("Invalid op type"));  // NOLINT(whitespace/parens)
     }
   }
 }
@@ -393,12 +401,35 @@ void Executor::PruneUnusedGraphNodes() {
       "data produced by the pipeline.");
 }
 
-void Executor::SetupWorkspacesForGraph(WorkspaceBlob *wsb) {
+void Executor::SetupOutputInfo(const OpGraph &graph) {
+  DeviceGuard g(device_id_);
+  pipeline_outputs_ = graph.GetOutputs(output_names_);
+  for (auto tensor_id : pipeline_outputs_) {
+    if (graph.Tensor(tensor_id).producer.storage_device == StorageDevice::GPU) {
+      gpu_output_events_.push_back(EventList(queue_depth_, &event_pool_));
+    } else {
+      gpu_output_events_.push_back(EventList());
+    }
+  }
+}
+
+std::vector<int> Executor::GetTensorQueueSizes(const OpGraph &graph) {
+  std::vector<int> result;
+  // By default we need one vector
+  result.resize(graph.NumTensor(), 1);
+  auto output_ids = graph.GetOutputs(output_names_);
+  for (auto id : output_ids) {
+    result[id] = queue_depth_;
+  }
+  return result;
+}
+
+void Executor::SetupWorkspacesForGraph(int queue_idx) {
   DeviceGuard g(device_id_);
 
   // Clear any old data setup
-  wsb->Clear();
-  wsb->Resize(graph_->NumOp(OpType::SUPPORT), graph_->NumOp(OpType::CPU),
+  wss_[queue_idx].Clear();
+  wss_[queue_idx].Resize(graph_->NumOp(OpType::SUPPORT), graph_->NumOp(OpType::CPU),
               graph_->NumOp(OpType::MIXED), graph_->NumOp(OpType::GPU));
 
   for (int i = 0; i < graph_->NumOp(); i++) {
@@ -406,14 +437,14 @@ void Executor::SetupWorkspacesForGraph(WorkspaceBlob *wsb) {
     VALUE_SWITCH(node.op_type, op_type_static,
         (OpType::SUPPORT, OpType::CPU, OpType::MIXED, OpType::GPU),
     (
-      auto &ws = get_workspace<op_type_static>(wsb->op_data, node);
-      ws = CreateWorkspace<op_type_static>(*graph_, node);
+      auto &ws = GetWorkspace<op_type_static>(queue_idx, node);
+      ws = CreateWorkspace<op_type_static>(*graph_, node, QueueIdxs{queue_idx});
     ), DALI_FAIL("Invalid op type"));  // NOLINT(whitespace/parens)
   }
 }
 
 // We apply hints to all of pinned CPU buffers and all GPU buffers
-void Executor::PresizeData(std::vector<tensor_data_store_t> &tensor_to_storage,
+void Executor::PresizeData(std::vector<tensor_data_store_queue_t> &tensor_to_store_queue,
                            const OpGraph &graph) {
   DeviceGuard g(device_id_);
   TimeRange tr("[Executor] PresizeData");
@@ -431,16 +462,20 @@ void Executor::PresizeData(std::vector<tensor_data_store_t> &tensor_to_storage,
         auto &tensor = graph.Tensor(node.children_tensors[j]);
         Index hint = hints[j];
         if (tensor.producer.storage_device == StorageDevice::CPU) {
-          auto storage = get_storage<op_type_static, StorageDevice::CPU>(
-              tensor_to_storage[tensor.id]);
-          if (hint && IsPinned(storage)) {
-            Reserve(storage, hint, batch_size_);
+          auto& queue = get_queue<op_type_static, StorageDevice::CPU>(
+              tensor_to_store_queue[tensor.id]);
+          for (auto storage : queue) {
+            if (hint && IsPinned(storage)) {
+              Reserve(storage, hint, batch_size_);
+            }
           }
         } else {
-          auto storage = get_storage<op_type_static, StorageDevice::GPU>(
-              tensor_to_storage[tensor.id]);
-          if (hint) {
-            Reserve(storage, hint, batch_size_);
+          auto& queue = get_queue<op_type_static, StorageDevice::GPU>(
+              tensor_to_store_queue[tensor.id]);
+          for (auto storage : queue) {
+            if (hint) {
+              Reserve(storage, hint, batch_size_);
+            }
           }
         }
       }
@@ -456,112 +491,9 @@ std::vector<int> Executor::GetMemoryHints(const OpNode &node) {
 }
 
 void Executor::SetupOutputQueuesForGraph() {
-  DeviceGuard g(device_id_);
-  // Allocate output TensorList pools for each output
-  for (auto &name : output_names_) {
-    auto tensor_meta = graph_->TensorSourceMeta(name);
-
-    // TODO(klecki): this is a duplication of TensorNode functionality here in convoluted manner
-    // Collect meta-data about the tensor for fast lookup later.
-    OutputInfo info;
-    info.prod_and_idx = std::make_pair(tensor_meta.node, tensor_meta.index);
-    vector<TensorMeta> consumer_meta = graph_->TensorConsumerMeta(name);
-    for (auto &meta : consumer_meta) {
-      auto tmp = std::make_pair(meta.node, meta.index);
-      info.con_and_idx.push_back(tmp);
-    }
-
-    // Create the buffer and events
-    if (tensor_meta.storage_device == StorageDevice::CPU) {
-      DALI_ENFORCE(
-          !tensor_meta.is_support,
-          "Outputs of support ops cannot be outputs.");  // TODO(ptredak): lift this restriction
-      cpu_outputs_.push_back(
-          TensorListPool<CPUBackend>(queue_depth_, batch_size_, bytes_per_sample_hint_));
-      DALI_ENFORCE(
-          type_idx_map_.insert({name, cpu_outputs_.size() - 1}).second,
-          "Output tensor meta insertion failed. Duplicate output name '" + name + "' exists.");
-
-      cpu_output_info_.push_back(info);
-      gpu_output_events_.push_back(EventList());
-    } else {
-      gpu_outputs_.push_back(
-          TensorListPool<GPUBackend>(queue_depth_, batch_size_, bytes_per_sample_hint_));
-      DALI_ENFORCE(
-          type_idx_map_.insert({name, gpu_outputs_.size() - 1}).second,
-          "Output tensor meta insertion failed. Duplicate output name '" + name + "' exists.");
-
-      gpu_output_info_.push_back(info);
-      gpu_output_events_.push_back(EventList(queue_depth_, &event_pool_));
-    }
-  }
-
   // All buffers start off as free
   for (int i = 0; i < queue_depth_; ++i) {
     free_queue_.push(i);
-  }
-}
-
-void Executor::SetOutputBuffersForIter(int queue_idx, WorkspaceBlob *wsb) {
-  DeviceGuard g(device_id_);
-  // For each output, we need to hookup the next buffer
-  // to the desired output workspaces, and also the
-  // input workspaces of later ops that use them
-  for (size_t i = 0; i < cpu_outputs_.size(); ++i) {
-    auto &info = cpu_output_info_[i];
-    OpNodeId node_id = info.prod_and_idx.first;
-    int output_idx = info.prod_and_idx.second;
-    // Contiguous CPU outputs come from mixed or GPU ops
-    DALI_ENFORCE(graph_->NodeType(node_id) == OpType::MIXED ||
-                 graph_->NodeType(node_id) == OpType::GPU);
-
-    if (graph_->NodeType(node_id) == OpType::MIXED) {
-      int mixed_op_id = graph_->NodeIdx(node_id);
-      get_workspace<OpType::MIXED>(wsb->op_data, mixed_op_id)
-          .SetOutput(output_idx, cpu_outputs_[i].Get(queue_idx));
-    } else {  // OpType::GPU
-      int gpu_op_id = graph_->NodeIdx(node_id);
-      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
-          .SetOutput(output_idx, cpu_outputs_[i].Get(queue_idx));
-    }
-
-    for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
-      node_id = info.con_and_idx[j].first;
-      int input_idx = info.con_and_idx[j].second;
-      DALI_ENFORCE(graph_->NodeType(node_id) == OpType::GPU);
-
-      int gpu_op_id = graph_->NodeIdx(node_id);
-      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
-          .SetInput(input_idx, cpu_outputs_[i].Get(queue_idx));
-    }
-  }
-
-  for (size_t i = 0; i < gpu_outputs_.size(); ++i) {
-    auto &info = gpu_output_info_[i];
-    OpNodeId node_id = info.prod_and_idx.first;
-    int output_idx = info.prod_and_idx.second;
-
-    if (graph_->NodeType(node_id) == OpType::MIXED) {
-      int mixed_op_id = graph_->NodeIdx(node_id);
-      get_workspace<OpType::MIXED>(wsb->op_data, mixed_op_id)
-          .SetOutput(output_idx, gpu_outputs_[i].Get(queue_idx));
-    } else if (graph_->NodeType(node_id) == OpType::GPU) {
-      int gpu_op_id = graph_->NodeIdx(node_id);
-      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
-          .SetOutput(output_idx, gpu_outputs_[i].Get(queue_idx));
-    } else {
-      DALI_FAIL("Internal error. GPU output source is not gpu/mixed op");
-    }
-
-    for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
-      node_id = info.con_and_idx[j].first;
-      int input_idx = info.con_and_idx[j].second;
-      DALI_ENFORCE(graph_->NodeType(node_id) == OpType::GPU);
-
-      int gpu_op_id = graph_->NodeIdx(node_id);
-      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
-          .SetInput(input_idx, gpu_outputs_[i].Get(queue_idx));
-    }
   }
 }
 

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -15,12 +15,12 @@
 #ifndef DALI_PIPELINE_EXECUTOR_EXECUTOR_H_
 #define DALI_PIPELINE_EXECUTOR_EXECUTOR_H_
 
-#include <utility>
-#include <vector>
-#include <string>
-#include <queue>
 #include <map>
 #include <memory>
+#include <queue>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "dali/common.h"
 #include "dali/error_handling.h"
@@ -48,15 +48,17 @@ class DLL_PUBLIC Executor {
   using ExecutorCallback = std::function<void(void)>;
 
   DLL_PUBLIC inline Executor(int batch_size, int num_thread, int device_id,
-      size_t bytes_per_sample_hint, bool set_affinity = false,
-      int max_num_stream = -1, int prefetch_queue_depth = 2) :
-    batch_size_(batch_size), device_id_(device_id),
-    bytes_per_sample_hint_(bytes_per_sample_hint),
-    queue_depth_(prefetch_queue_depth),
-    stream_pool_(max_num_stream, true), event_pool_(max_num_stream),
-    thread_pool_(num_thread, device_id, set_affinity),
-    exec_error_(false),
-    cb_(nullptr) {
+                             size_t bytes_per_sample_hint, bool set_affinity = false,
+                             int max_num_stream = -1, int prefetch_queue_depth = 2)
+      : batch_size_(batch_size),
+        device_id_(device_id),
+        bytes_per_sample_hint_(bytes_per_sample_hint),
+        queue_depth_(prefetch_queue_depth),
+        stream_pool_(max_num_stream, true),
+        event_pool_(max_num_stream),
+        thread_pool_(num_thread, device_id, set_affinity),
+        exec_error_(false),
+        cb_(nullptr) {
     DALI_ENFORCE(batch_size_ > 0, "Batch size must be greater than 0.");
     DALI_ENFORCE(device_id >= 0, "Device id must be non-negative.");
   }
@@ -105,61 +107,58 @@ class DLL_PUBLIC Executor {
   };
   vector<WorkspaceBlob> wss_;
 
+  struct QueueIdxs {
+    int &operator[](OpType op_type) {
+      return idxs[static_cast<size_t>(op_type)];
+    }
+
+    const int &operator[](OpType op_type) const {
+      return idxs[static_cast<size_t>(op_type)];
+    }
+
+    explicit QueueIdxs(int uniform_idx)
+        : idxs{uniform_idx, uniform_idx, uniform_idx, uniform_idx} {}
+
+   private:
+    std::array<int, static_cast<size_t>(OpType::COUNT)> idxs = {{0, 0, 0, 0}};
+  };
+
   void PruneUnusedGraphNodes();
 
-  void SetupWorkspacesForGraph(WorkspaceBlob *wsb);
+  virtual std::vector<int> GetTensorQueueSizes(const OpGraph &graph);
+
+  void SetupWorkspacesForGraph(int queue_idx);
+
+  virtual void SetupOutputInfo(const OpGraph &graph);
 
   std::vector<int> GetMemoryHints(const OpNode &node);
 
-  void PresizeData(std::vector<tensor_data_store_t>& tensor_to_storage, const OpGraph& graph);
-
-  void SetupStreamsForGraph(WorkspaceBlob *wsb);
+  void PresizeData(std::vector<tensor_data_store_queue_t> &tensor_to_store_queue,
+                   const OpGraph &graph);
 
   void SetupOutputQueuesForGraph();
 
-  void SetOutputBuffersForIter(int queue_idx, WorkspaceBlob *wsb);
+  template <OpType op_type>
+  op_type_to_workspace_t<op_type> &GetWorkspace(int queue_idx, OpPartitionId partition_idx);
 
   template <OpType op_type>
-  op_type_to_workspace_t<op_type> &get_workspace(workspace_store_t &wo,
-                                                 OpPartitionId partition_idx);
-
-  template <OpType op_type>
-  op_type_to_workspace_t<op_type> &get_workspace(workspace_store_t &wo, const OpNode &node);
+  op_type_to_workspace_t<op_type> &GetWorkspace(int queue_idx, const OpNode &node);
 
   template <OpType op_type>
   void SetupInputOutput(op_type_to_workspace_t<op_type> &ws, const OpGraph &graph,
-                        const OpNode &node);
+                        const OpNode &node, const QueueIdxs idxs);
 
   template <OpType op_type>
-  void SetupPinned(op_type_to_workspace_t<op_type> &ws, const OpGraph &graph, const OpNode &node);
+  void SetupPinned(op_type_to_workspace_t<op_type> &ws, const OpGraph &graph, const OpNode &node,
+                   const QueueIdxs idxs);
 
   template <OpType op_type>
   void SetupStreamsAndEvents(op_type_to_workspace_t<op_type> &ws, const OpGraph &graph,
-                             const OpNode &node);
+                             const OpNode &node, const QueueIdxs idxs);
 
-  // TODO(klecki): this would require queue indexes for parents and children
   template <OpType op_type>
-  op_type_to_workspace_t<op_type> CreateWorkspace(const OpGraph &graph, const OpNode &node);
-
-
-  template <typename Backend>
-  class TensorListPool {
-   public:
-    inline TensorListPool(int size, int batch_size, size_t bytes_hint, bool pinned = false) {
-      for (int i = 0; i < size; ++i) {
-        tls_.push_back(std::make_shared<TensorList<Backend>>());
-        tls_.back()->set_pinned(pinned);
-        if (pinned || std::is_same<Backend, GPUBackend>::value)
-          tls_.back()->reserve(batch_size*(Index)bytes_hint);
-      }
-    }
-
-    inline shared_ptr<TensorList<Backend>> Get(int idx) {
-      return tls_[idx];
-    }
-   private:
-    vector<shared_ptr<TensorList<Backend>>> tls_;
-  };
+  op_type_to_workspace_t<op_type> CreateWorkspace(const OpGraph &graph, const OpNode &node,
+                                                  const QueueIdxs idxs);
 
   class EventList {
    public:
@@ -171,9 +170,8 @@ class DLL_PUBLIC Executor {
       }
     }
 
-    inline cudaEvent_t GetEvent(int idx) {
-      return events_[idx];
-    }
+    inline cudaEvent_t GetEvent(int idx) { return events_[idx]; }
+
    private:
     vector<cudaEvent_t> events_;
   };
@@ -184,17 +182,10 @@ class DLL_PUBLIC Executor {
   int previous_gpu_queue_idx_ = -1;
 
   vector<string> output_names_;
-  std::map<string, int> type_idx_map_;
-  vector<TensorListPool<CPUBackend>> cpu_outputs_;
-  vector<TensorListPool<GPUBackend>> gpu_outputs_;
-  vector<EventList> gpu_output_events_;
 
   // Meta-data about our stage outputs for fast lookup
-  using OutputInfo = struct {
-    std::pair<OpNodeId, int> prod_and_idx;
-    vector<std::pair<OpNodeId, int>> con_and_idx;
-  };
-  vector<OutputInfo> cpu_output_info_, gpu_output_info_;
+  std::vector<TensorNodeId> pipeline_outputs_;
+  std::vector<EventList> gpu_output_events_;
 
   // Buffers are rotated between being 'free', where the
   // pipeline is ok to fill them with data, 'ready', where
@@ -236,68 +227,73 @@ class DLL_PUBLIC Executor {
   std::mutex errors_mutex_;
   bool exec_error_;
   ExecutorCallback cb_;
-  std::vector<tensor_data_store_t> tensor_to_storage_;
+  std::vector<tensor_data_store_queue_t> tensor_to_store_queue_;
   cudaStream_t mixed_op_stream_, gpu_op_stream_;
-  std::vector<cudaEvent_t> mixed_op_events_;  // To introduce dependency from MIXED to GPU Ops
+  // MixedOpId -> queue_idx -> cudaEvent_t
+  // To introduce dependency from MIXED to GPU Ops
+  std::vector<std::vector<cudaEvent_t>> mixed_op_events_;
 };
 
-#define USE_EXECUTOR_MEMBERS()                             \
-  protected:                                               \
-  using Executor::WorkspaceBlob;                           \
-  using Executor::wss_;                                    \
-  using Executor::batch_size_;                             \
-  using Executor::device_id_;                              \
-  using Executor::bytes_per_sample_hint_;                  \
-  using Executor::queue_depth_;                            \
-  using Executor::output_names_;                           \
-  using Executor::type_idx_map_;                           \
-  using Executor::cpu_outputs_;                            \
-  using Executor::gpu_outputs_;                            \
-  using Executor::gpu_output_events_;                      \
-  using Executor::OutputInfo;                              \
-  using Executor::cpu_output_info_;                        \
-  using Executor::gpu_output_info_;                        \
-  using Executor::ready_queue_;                            \
-  using Executor::ready_mutex_;                            \
-  using Executor::ready_cond_;                             \
-  using Executor::graph_;                                  \
-  using Executor::stream_pool_;                            \
-  using Executor::event_pool_;                             \
+#define USE_EXECUTOR_MEMBERS()            \
+ protected:                               \
+  using Executor::WorkspaceBlob;          \
+  using Executor::wss_;                   \
+  using Executor::batch_size_;            \
+  using Executor::device_id_;             \
+  using Executor::bytes_per_sample_hint_; \
+  using Executor::queue_depth_;           \
+  using Executor::output_names_;          \
+  using Executor::gpu_output_events_;     \
+  using Executor::ready_queue_;           \
+  using Executor::ready_mutex_;           \
+  using Executor::ready_cond_;            \
+  using Executor::graph_;                 \
+  using Executor::stream_pool_;           \
+  using Executor::event_pool_;            \
   using Executor::thread_pool_
 
 template <OpType op_type>
-op_type_to_workspace_t<op_type> &Executor::get_workspace(workspace_store_t &wo,
-                                                         OpPartitionId partition_idx) {
-  auto &ws_vec = std::get<static_cast<size_t>(op_type)>(wo);
+op_type_to_workspace_t<op_type> &Executor::GetWorkspace(int queue_idx,
+                                                        OpPartitionId partition_idx) {
+  auto &ws_vec = std::get<static_cast<size_t>(op_type)>(wss_[queue_idx].op_data);
   return ws_vec[partition_idx];
 }
 
 template <OpType op_type>
-op_type_to_workspace_t<op_type> &Executor::get_workspace(workspace_store_t &wo,
-                                                         const OpNode &node) {
-  DALI_ENFORCE(node.op_type == op_type, "Wrong variant of method selected. OpType does not match.");
-  auto &ws_vec = std::get<static_cast<size_t>(op_type)>(wo);
+op_type_to_workspace_t<op_type> &Executor::GetWorkspace(int queue_idx, const OpNode &node) {
+  DALI_ENFORCE(node.op_type == op_type,
+               "Wrong variant of method selected. OpType does not match.");
+  auto &ws_vec = std::get<static_cast<size_t>(op_type)>(wss_[queue_idx].op_data);
   return ws_vec[node.partition_index];
 }
 
 // We instantiate the operation of adding the input only for parent op_type and device
 // that are specifically allowed
+// We always use queue_idx = 0 if give queue has only one element -> it is not queued
 template <OpType op_type, OpType producer_type, StorageDevice device>
 enable_if_t<allows_op_input<op_type>(producer_type) && allows_tensor_input<op_type>(device)>
-add_input(op_type_to_workspace_t<op_type> &ws, const tensor_data_store_t &storage) {
-  auto tensor = get_storage<producer_type, device>(storage);
+add_input(op_type_to_workspace_t<op_type> &ws, const tensor_data_store_queue_t &storage,
+          int queue_idx = 0) {
+  auto &queue = get_queue<producer_type, device>(storage);
+  DALI_ENFORCE(!queue.IsBuffered() || queue_idx < static_cast<int>(queue.size()),
+               "Backing Tensor store queue has not enough elements.");
+  auto tensor = queue[queue_idx];
   ws.AddInput(tensor);
 }
 
 // If parent op_type or device is not allowed this is a no-op
 template <OpType op_type, OpType producer_type, StorageDevice device>
 enable_if_t<!allows_op_input<op_type>(producer_type) || !allows_tensor_input<op_type>(device)>
-add_input(op_type_to_workspace_t<op_type>, const tensor_data_store_t) {}
+add_input(op_type_to_workspace_t<op_type>, const tensor_data_store_queue_t, int = 0) {}
 
 // This will be only used for allowed ones (TODO(klecki) with exception of the device)
 template <OpType op_type, StorageDevice device>
-void add_output(op_type_to_workspace_t<op_type> &ws, const tensor_data_store_t &storage) {
-  auto tensor = get_storage<op_type, device>(storage);
+void add_output(op_type_to_workspace_t<op_type> &ws, const tensor_data_store_queue_t &storage,
+                int queue_idx = 0) {
+  auto &queue = get_queue<op_type, device>(storage);
+  DALI_ENFORCE(!queue.IsBuffered() || queue_idx < static_cast<int>(queue.size()),
+               "Backing Tensor store queue has not enough elements.");
+  auto tensor = queue[queue_idx];
   ws.AddOutput(tensor);
 }
 
@@ -306,84 +302,92 @@ void add_output(op_type_to_workspace_t<op_type> &ws, const tensor_data_store_t &
 // as well with later operations
 template <OpType op_type>
 void Executor::SetupInputOutput(op_type_to_workspace_t<op_type> &ws, const OpGraph &graph,
-                                const OpNode &node) {
+                                const OpNode &node, const QueueIdxs idxs) {
   for (int j = 0; j < node.spec.NumRegularInput(); ++j) {
-    auto tid = node.parent_tensors[j];
-    auto &parent_node = graph.Node(graph.Tensor(tid).producer.node);
+    auto tensor_id = node.parent_tensors[j];
+    auto &parent_node = graph.Node(graph.Tensor(tensor_id).producer.node);
     auto parent_op_type = parent_node.op_type;
-    auto tensor_device = graph.Tensor(tid).producer.storage_device;
+    auto tensor_device = graph.Tensor(tensor_id).producer.storage_device;
 
     VALUE_SWITCH(parent_op_type, parent_op_static,
         (OpType::GPU, OpType::CPU, OpType::MIXED, OpType::SUPPORT),
     (
       VALUE_SWITCH(tensor_device, device_static, (StorageDevice::CPU, StorageDevice::GPU),
       (
-        add_input<op_type, parent_op_static, device_static>(ws, tensor_to_storage_[tid]);
+        add_input<op_type, parent_op_static, device_static>(ws,
+                                                            tensor_to_store_queue_[tensor_id],
+                                                            idxs[parent_op_static]);
       ), DALI_FAIL("Unexpected device"))  // NOLINT(whitespace/parens)
     ), DALI_FAIL("Unexpected op_type"));  // NOLINT(whitespace/parens)
   }
 
   // Argument inputs can be handled genericaly
   for (const auto &arg_pair : node.spec.ArgumentInputs()) {
-  // Get each argument input and add them to this op's workspace.
+    // Get each argument input and add them to this op's workspace.
     auto input_index = arg_pair.second;
-    auto tid = node.parent_tensors[input_index];
-    auto tensor = get_storage<OpType::SUPPORT, StorageDevice::CPU>(tensor_to_storage_[tid]);
+    auto tensor_id = node.parent_tensors[input_index];
+    auto &queue =
+        get_queue<OpType::SUPPORT, StorageDevice::CPU>(tensor_to_store_queue_[tensor_id]);
+    auto tensor = queue[idxs[OpType::MIXED]];  // TODO(klecki): check queueueueueuing
     ws.AddArgumentInput(tensor, arg_pair.first);
   }
 
   for (int j = 0; j < node.spec.NumOutput(); ++j) {
-    auto tid = node.children_tensors[j];
-    auto tensor_device = graph.Tensor(tid).producer.storage_device;
+    auto tensor_id = node.children_tensors[j];
+    auto tensor_device = graph.Tensor(tensor_id).producer.storage_device;
     VALUE_SWITCH(tensor_device, device_static, (StorageDevice::CPU, StorageDevice::GPU),
     (
-      add_output<op_type, device_static>(ws, tensor_to_storage_[tid]);
+      add_output<op_type, device_static>(ws, tensor_to_store_queue_[tensor_id], idxs[op_type]);
     ), DALI_FAIL("Unexpected device"));  // NOLINT(whitespace/parens)
   }
 }
 
 template <OpType op_type>
-void Executor::SetupPinned(op_type_to_workspace_t<op_type> &, const OpGraph &, const OpNode &) {
+void Executor::SetupPinned(op_type_to_workspace_t<op_type> &, const OpGraph &, const OpNode &,
+                           const QueueIdxs) {
   /* No-op if we are not MIXED MakeContigous node */
 }
 
 // TODO(klecki): this should be handled on Tensor level?
 template <>
-inline void Executor::SetupPinned<OpType::MIXED>(MixedWorkspace& ws, const OpGraph &graph,
-                                                           const OpNode &node) {
+inline void Executor::SetupPinned<OpType::MIXED>(MixedWorkspace &ws, const OpGraph &graph,
+                                                     const OpNode &node, const QueueIdxs idxs) {
   for (int j = 0; j < node.spec.NumRegularInput(); ++j) {
-    auto tid = node.parent_tensors[j];
+    auto tensor_id = node.parent_tensors[j];
     // Use pinned memory only when it is useful
     if (node.spec.name() == "MakeContiguous" && node.spec.NumOutput() == 1 &&
         node.spec.OutputDevice(0) == "gpu") {
       // TODO(klecki): we need some wrappers for WorkspaceOutputType with set_pinned in API
-      for (auto t : get_storage<OpType::CPU, StorageDevice::CPU>(tensor_to_storage_[tid])) {
-        t->set_pinned(true);
-      }
+      auto &parent_tensor_queue =
+          get_queue<OpType::CPU, StorageDevice::CPU>(tensor_to_store_queue_[tensor_id]);
+      auto &tensor = parent_tensor_queue[idxs[OpType::MIXED]];
+      SetPinned(tensor, true);
     }
   }
 }
 
 template <OpType op_type>
 void Executor::SetupStreamsAndEvents(op_type_to_workspace_t<op_type> &ws, const OpGraph &graph,
-                                     const OpNode &node) {
+                                     const OpNode &node, const QueueIdxs idxs) {
   /* No-op if we are not Mixed or GPU */
 }
 
 template <>
 inline void Executor::SetupStreamsAndEvents<OpType::MIXED>(MixedWorkspace &ws, const OpGraph &graph,
-                                                           const OpNode &node) {
+                                                           const OpNode &node,
+                                                           const QueueIdxs idxs) {
   // We assign unique stream to mixed ops.
   // This ensures that we won't have false dependencies
   // between mixed ops and the previous iterations
   // gpu ops.
   ws.set_stream(mixed_op_stream_);
-  ws.set_event(mixed_op_events_[node.partition_index]);
+  ws.set_event(mixed_op_events_[node.partition_index][idxs[OpType::MIXED]]);
 }
 
 template <>
+
 inline void Executor::SetupStreamsAndEvents<OpType::GPU>(DeviceWorkspace &ws, const OpGraph &graph,
-                                                         const OpNode &node) {
+                                                         const OpNode &node, const QueueIdxs idxs) {
   // I/O pipeline is always going to be launched alongside
   // some other GPU work (like DL training).
   // Therefore it is not necessary to use more than
@@ -391,26 +395,25 @@ inline void Executor::SetupStreamsAndEvents<OpType::GPU>(DeviceWorkspace &ws, co
   // the whole GPU with just I/O pipeline kernels
   // by doing so.
   ws.set_stream(gpu_op_stream_);
-  for (const auto& p : node.parents) {
+  for (const auto &p : node.parents) {
     if (graph.NodeType(p) == OpType::MIXED) {
       const auto &parent_op = graph.Node(p);
       // We need to block on this op's event to
       // make sure that we respect the dependency
-      ws.AddParentEvent(mixed_op_events_[parent_op.partition_index]);
+      ws.AddParentEvent(mixed_op_events_[parent_op.partition_index][idxs[OpType::MIXED]]);
     }
   }
 }
 
 template <OpType op_type>
-op_type_to_workspace_t<op_type> Executor::CreateWorkspace(const OpGraph &graph,
-                                                          const OpNode &node) {
+op_type_to_workspace_t<op_type> Executor::CreateWorkspace(const OpGraph &graph, const OpNode &node,
+                                                          const QueueIdxs idxs) {
   op_type_to_workspace_t<op_type> ws;
-  SetupInputOutput<op_type>(ws, graph, node);
-  SetupPinned<op_type>(ws, graph, node);
-  SetupStreamsAndEvents<op_type>(ws, graph, node);
+  SetupInputOutput<op_type>(ws, graph, node, idxs);
+  SetupPinned<op_type>(ws, graph, node, idxs);
+  SetupStreamsAndEvents<op_type>(ws, graph, node, idxs);
   return ws;
 }
-
 
 }  // namespace dali
 

--- a/dali/pipeline/executor/pipelined_executor.cc
+++ b/dali/pipeline/executor/pipelined_executor.cc
@@ -24,281 +24,31 @@ namespace dali {
 
 void PipelinedExecutor::Build(OpGraph *graph, vector<string> output_names) {
   Executor::Build(graph, output_names);
+}
 
-  // Setup queues for the intermediate outputs of each stage
-  SetupStageOutputsForGraph();
-
-  // For each set of outputs, link the correct stage
-  // output buffer to each workspace.
-  for (int i = 0; i < queue_depth_; ++i) {
-    SetStageOutputsForIter(i, &wss_[i]);
+void PipelinedExecutor::SetupOutputInfo(const OpGraph &graph) {
+  DeviceGuard g(device_id_);
+  Executor::SetupOutputInfo(graph);
+  constexpr auto stages_count = static_cast<int>(OpType::COUNT);
+  stage_outputs_.resize(stages_count);
+  // stage_output_events_.resize(stages_count);
+  for (int stage = 0; stage < stages_count; stage++) {
+    stage_outputs_[stage] = graph.GetStageOutputs(static_cast<OpType>(stage));
   }
 }
 
-void PipelinedExecutor::SetupStageOutputsForGraph() {
-  DeviceGuard g(device_id_);
-  // Make a set of the outputs names for quick lookup
-  std::set<string> output_set(output_names_.begin(), output_names_.end());
-
-  for (int i = 0; i < graph_->NumOp(OpType::SUPPORT); ++i) {
-    // Find all outputs of the support stage. An output is
-    // a tensor that is used by an op in a later stage.
-    // Do not include CPU ops inputs, since those are run
-    // synchronously with support ops
-    OpNode &node = graph_->Node(OpType::SUPPORT, i);
-    std::vector<int> hints = GetMemoryHints(node);
-
-    for (int j = 0; j < node.spec.NumOutput(); ++j) {
-      // If this tensor is a pipeline output, its
-      // queueing will be handled by the Executor base
-      string tensor_name = node.spec.Output(j);
-      DALI_ENFORCE(graph_->TensorIsType<CPUBackend>(tensor_name));
-      if (output_set.count(tensor_name) != 0) continue;
-
-      vector<TensorMeta> consumer_meta = graph_->TensorConsumerMeta(tensor_name);
-      bool found_stage_boundary = false;
-      for (auto &meta : consumer_meta) {
-        const auto &node_type = graph_->NodeType(meta.node);
-        if (node_type != OpType::SUPPORT && node_type != OpType::CPU) {
-          // We've located a tensor that is an output of
-          // the stage.
-          found_stage_boundary = true;
-        }
-      }
-      if (found_stage_boundary) {
-        OutputInfo info;
-        info.prod_and_idx = std::make_pair(node.id, j);
-        support_stage_output_info_.push_back(info);
-        support_stage_outputs_.push_back(
-            TensorPool<CPUBackend>(queue_depth_, batch_size_, hints[j]));
-        for (auto &meta : consumer_meta) {
-          OutputInfo &info = support_stage_output_info_.back();
-          auto tmp = std::make_pair(meta.node, meta.index);
-          info.con_and_idx.push_back(tmp);
-        }
-      }
-    }
+std::vector<int> PipelinedExecutor::GetTensorQueueSizes(const OpGraph &graph) {
+  std::vector<int> result;
+  result.resize(graph.NumTensor(), 1);
+  auto output_ids = graph.GetOutputs(output_names_);
+  for (int stage = 0; stage < static_cast<int>(OpType::COUNT); stage++) {
+    auto stage_outputs = graph.GetStageOutputs(static_cast<OpType>(stage));
+    output_ids.insert(output_ids.end(), stage_outputs.begin(), stage_outputs.end());
   }
-
-  for (int i = 0; i < graph_->NumOp(OpType::CPU); ++i) {
-    // Find all outputs of the cpu stage. An output is
-    // a tensor that is used by an op in a later stage.
-    OpNode &node = graph_->Node(OpType::CPU, i);
-    std::vector<int> hints = GetMemoryHints(node);
-
-    for (int j = 0; j < node.spec.NumOutput(); ++j) {
-      // If this tensor is a pipeline output, its
-      // queueing will be handled by the Executor base
-      string tensor_name = node.spec.Output(j);
-      DALI_ENFORCE(graph_->TensorIsType<CPUBackend>(tensor_name));
-      if (output_set.count(tensor_name) != 0) continue;
-
-      vector<TensorMeta> consumer_meta = graph_->TensorConsumerMeta(tensor_name);
-      bool found_stage_boundary = false;
-      bool has_gpu_consumer = false;
-      for (auto &meta : consumer_meta) {
-        auto type = graph_->NodeType(meta.node);
-        if (type != OpType::CPU) {
-          // We've located a tensor that is an output of
-          // the stage.
-          auto &consumer = graph_->Node(meta.node);
-          has_gpu_consumer =
-              has_gpu_consumer || type == OpType::GPU ||
-              (consumer.spec.name() == "MakeContiguous" && consumer.spec.OutputDevice(0) == "gpu");
-          found_stage_boundary = true;
-        }
-      }
-      if (found_stage_boundary) {
-        OutputInfo info;
-        info.prod_and_idx = std::make_pair(node.id, j);
-        cpu_stage_output_info_.push_back(info);
-        cpu_stage_outputs_.push_back(
-            TensorVectorPool<CPUBackend>(queue_depth_, batch_size_, hints[j], has_gpu_consumer));
-        for (auto &meta : consumer_meta) {
-          OutputInfo &info = cpu_stage_output_info_.back();
-          auto tmp = std::make_pair(meta.node, meta.index);
-          info.con_and_idx.push_back(tmp);
-        }
-      }
-    }
+  for (auto id : output_ids) {
+    result[id] = queue_depth_;
   }
-
-  for (int i = 0; i < graph_->NumOp(OpType::MIXED); ++i) {
-    // Find all outputs of the mixed stage. An output
-    // is a tensor that is used by an op in a later stage.
-    OpNode &node = graph_->Node(OpType::MIXED, i);
-    std::vector<int> hints = GetMemoryHints(node);
-
-    for (int j = 0; j < node.spec.NumOutput(); ++j) {
-      // If this tensor is a pipeline output, its
-      // queueing will be handled by the Executor base
-      string tensor_name = node.spec.Output(j);
-      if (output_set.count(tensor_name) != 0) continue;
-
-      vector<TensorMeta> consumer_meta = graph_->TensorConsumerMeta(tensor_name);
-      bool has_info_object = false;
-
-      if (graph_->TensorIsType<CPUBackend>(tensor_name)) {
-        for (auto &meta : consumer_meta) {
-          if (graph_->NodeType(meta.node) != OpType::MIXED) {
-            if (!has_info_object) {
-              OutputInfo info;
-              info.prod_and_idx = std::make_pair(node.id, j);
-
-              bool pinned = graph_->NodeType(meta.node) == OpType::GPU;
-
-              mixed_stage_cpu_output_info_.push_back(info);
-              mixed_stage_cpu_outputs_.push_back(
-                  TensorListPool<CPUBackend>(queue_depth_, batch_size_, hints[j], pinned));
-              has_info_object = true;
-            }
-
-            OutputInfo &info = mixed_stage_cpu_output_info_.back();
-            auto tmp = std::make_pair(meta.node, meta.index);
-            info.con_and_idx.push_back(tmp);
-          }
-        }
-      } else {
-        for (auto &meta : consumer_meta) {
-          if (graph_->NodeType(meta.node) != OpType::MIXED) {
-            if (!has_info_object) {
-              OutputInfo info;
-              info.prod_and_idx = std::make_pair(node.id, j);
-              mixed_stage_gpu_output_info_.push_back(info);
-              mixed_stage_gpu_outputs_.push_back(
-                  TensorListPool<GPUBackend>(queue_depth_, batch_size_, hints[j]));
-              has_info_object = true;
-            }
-
-            OutputInfo &info = mixed_stage_gpu_output_info_.back();
-            auto tmp = std::make_pair(meta.node, meta.index);
-            info.con_and_idx.push_back(tmp);
-          }
-        }
-      }
-    }
-  }
-}
-
-void PipelinedExecutor::SetStageOutputsForIter(int queue_idx, WorkspaceBlob *wsb) {
-  DeviceGuard g(device_id_);
-  for (size_t i = 0; i < support_stage_outputs_.size(); ++i) {
-    auto &tvp = support_stage_outputs_[i];
-    auto &info = support_stage_output_info_[i];
-    OpNodeId node_id = info.prod_and_idx.first;
-    DALI_ENFORCE(graph_->NodeType(node_id) == OpType::SUPPORT);
-
-    int support_op_id = graph_->NodeIdx(node_id);
-    int output_idx = info.prod_and_idx.second;
-    get_workspace<OpType::SUPPORT>(wsb->op_data, support_op_id)
-        .SetOutput(output_idx, tvp.Get(queue_idx));
-
-    for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
-      node_id = info.con_and_idx[j].first;
-      const OpNode &op_node = graph_->Node(node_id);
-      int child_op_id = graph_->NodeIdx(node_id);
-      int input_idx = info.con_and_idx[j].second;
-      const OpSpec &spec = op_node.spec;
-      std::string arg_name = spec.ArgumentInputName(input_idx);
-      if (graph_->NodeType(node_id) == OpType::MIXED) {
-        get_workspace<OpType::MIXED>(wsb->op_data, child_op_id)
-            .SetArgumentInput(tvp.Get(queue_idx), arg_name);
-      } else if (graph_->NodeType(node_id) == OpType::GPU) {
-        get_workspace<OpType::GPU>(wsb->op_data, child_op_id)
-            .SetArgumentInput(tvp.Get(queue_idx), arg_name);
-      } else {
-        get_workspace<OpType::CPU>(wsb->op_data, child_op_id)
-            .SetArgumentInput(tvp.Get(queue_idx), arg_name);
-      }
-    }
-  }
-
-  for (size_t i = 0; i < cpu_stage_outputs_.size(); ++i) {
-    auto &tvp = cpu_stage_outputs_[i];
-    auto &info = cpu_stage_output_info_[i];
-    OpNodeId node_id = info.prod_and_idx.first;
-    DALI_ENFORCE(graph_->NodeType(node_id) == OpType::CPU);
-
-    int cpu_op_id = graph_->NodeIdx(node_id);
-    int output_idx = info.prod_and_idx.second;
-    get_workspace<OpType::CPU>(wsb->op_data, cpu_op_id)
-        .SetOutput(output_idx, tvp.Get(queue_idx));
-
-    for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
-      node_id = info.con_and_idx[j].first;
-      if (graph_->NodeType(node_id) == OpType::MIXED) {
-        int mixed_op_id = graph_->NodeIdx(node_id);
-        int input_idx = info.con_and_idx[j].second;
-        get_workspace<OpType::MIXED>(wsb->op_data, mixed_op_id)
-            .SetInput(input_idx, tvp.Get(queue_idx));
-        const OpNode &node = graph_->Node(OpType::MIXED, mixed_op_id);
-        std::vector<int> hints = GetMemoryHints(node);
-        // Use pinned memory only when it is useful
-        if (node.spec.name() == "MakeContiguous" && node.spec.NumOutput() == 1 &&
-            node.spec.OutputDevice(0) == "gpu") {
-          for (auto &v : tvp.Get(queue_idx)) {
-            if (!v->is_pinned()) {
-              auto capacity = std::max<size_t>(v->capacity(), hints[0]);
-              v->free();
-              v->set_pinned(true);
-              v->reserve(capacity);
-            }
-          }
-        }
-      } else if (graph_->NodeType(node_id) == OpType::CPU) {
-        int cpu_op_id = graph_->NodeIdx(node_id);
-        int input_idx = info.con_and_idx[j].second;
-        get_workspace<OpType::CPU>(wsb->op_data, cpu_op_id)
-            .SetInput(input_idx, tvp.Get(queue_idx));
-      } else {
-        DALI_FAIL("Internal error - found non-CPU/mixed consumer");
-      }
-    }
-  }
-
-  for (size_t i = 0; i < mixed_stage_cpu_outputs_.size(); ++i) {
-    auto &tlp = mixed_stage_cpu_outputs_[i];
-    auto &info = mixed_stage_cpu_output_info_[i];
-    OpNodeId node_id = info.prod_and_idx.first;
-    DALI_ENFORCE(graph_->NodeType(node_id) == OpType::MIXED);
-
-    int mixed_op_id = graph_->NodeIdx(node_id);
-    int output_idx = info.prod_and_idx.second;
-    get_workspace<OpType::MIXED>(wsb->op_data, mixed_op_id)
-        .SetOutput(output_idx, tlp.Get(queue_idx));
-
-    for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
-      node_id = info.con_and_idx[j].first;
-      DALI_ENFORCE(graph_->NodeType(node_id) == OpType::GPU);
-
-      int gpu_op_id = graph_->NodeIdx(node_id);
-      int input_idx = info.con_and_idx[j].second;
-      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
-          .SetInput(input_idx, tlp.Get(queue_idx));
-    }
-  }
-
-  for (size_t i = 0; i < mixed_stage_gpu_outputs_.size(); ++i) {
-    auto &tlp = mixed_stage_gpu_outputs_[i];
-    auto &info = mixed_stage_gpu_output_info_[i];
-    OpNodeId node_id = info.prod_and_idx.first;
-    DALI_ENFORCE(graph_->NodeType(node_id) == OpType::MIXED);
-
-    int mixed_op_id = graph_->NodeIdx(node_id);
-    int output_idx = info.prod_and_idx.second;
-    get_workspace<OpType::MIXED>(wsb->op_data, mixed_op_id)
-        .SetOutput(output_idx, tlp.Get(queue_idx));
-
-    for (size_t j = 0; j < info.con_and_idx.size(); ++j) {
-      node_id = info.con_and_idx[j].first;
-      DALI_ENFORCE(graph_->NodeType(node_id) == OpType::GPU);
-
-      int gpu_op_id = graph_->NodeIdx(node_id);
-      int input_idx = info.con_and_idx[j].second;
-      get_workspace<OpType::GPU>(wsb->op_data, gpu_op_id)
-          .SetInput(input_idx, tlp.Get(queue_idx));
-    }
-  }
+  return result;
 }
 
 }  // namespace dali

--- a/dali/pipeline/graph/op_graph.h
+++ b/dali/pipeline/graph/op_graph.h
@@ -327,8 +327,8 @@ class DLL_PUBLIC OpGraph {
     ofs << "}\n";
   }
 
-  DLL_PUBLIC std::vector<TensorNodeId> GetOutputs(const std::vector<string>& output_names);
-  DLL_PUBLIC std::vector<TensorNodeId> GetStageOutputs(OpType stage);
+  DLL_PUBLIC std::vector<TensorNodeId> GetOutputs(const std::vector<string>& output_names) const;
+  DLL_PUBLIC std::vector<TensorNodeId> GetStageOutputs(OpType stage) const;
 
   DISABLE_COPY_MOVE_ASSIGN(OpGraph);
 

--- a/dali/pipeline/graph/op_graph_storage.cc
+++ b/dali/pipeline/graph/op_graph_storage.cc
@@ -18,24 +18,33 @@
 
 namespace dali {
 
-std::vector<tensor_data_store_t> CreateBackingStorageForTensorNodes(const OpGraph &op_graph,
-                                                                    int batch_size) {
-  std::vector<tensor_data_store_t> result;
+std::vector<tensor_data_store_queue_t> CreateBackingStorageForTensorNodes(
+    const OpGraph &op_graph, int batch_size, const std::vector<int> &queue_sizes) {
+  DALI_ENFORCE(static_cast<int>(queue_sizes.size()) == op_graph.NumTensor(),
+               "Data queue sizes undefined for some Tensor nodes.");
+  std::vector<tensor_data_store_queue_t> result;
   result.resize(op_graph.NumTensor());
+
   // Assign data to each Tensor node in graph
   for (int i = 0; i < op_graph.NumTensor(); i++) {
     const auto &tensor = op_graph.Tensor(i);
     auto producer_op_type = op_graph.Node(tensor.producer.node).op_type;
-    result[i] = BatchFactory(producer_op_type, tensor.producer.storage_device, batch_size);
+    result[i] =
+        BatchFactory(producer_op_type, tensor.producer.storage_device, batch_size, queue_sizes[i]);
   }
   return result;
 }
 
-std::vector<cudaEvent_t> CreateEventsForMixedOps(EventPool &event_pool, const OpGraph &op_graph) {
-  std::vector<cudaEvent_t> result;
+std::vector<std::vector<cudaEvent_t>> CreateEventsForMixedOps(EventPool &event_pool,
+                                                              const OpGraph &op_graph,
+                                                              int queue_depth) {
+  std::vector<std::vector<cudaEvent_t>> result;
   result.resize(op_graph.NumOp(OpType::MIXED));
   for (int i = 0; i < op_graph.NumOp(OpType::MIXED); i++) {
-    result[i] = event_pool.GetEvent();
+    result[i].resize(queue_depth);
+    for (int j = 0; j < queue_depth; j++) {
+      result[i][j] = event_pool.GetEvent();
+    }
   }
   return result;
 }

--- a/dali/pipeline/graph/op_graph_storage.h
+++ b/dali/pipeline/graph/op_graph_storage.h
@@ -23,11 +23,13 @@
 
 namespace dali {
 
-std::vector<tensor_data_store_t> CreateBackingStorageForTensorNodes(const OpGraph &op_graph,
-                                                                    int batch_size);
+std::vector<tensor_data_store_queue_t> CreateBackingStorageForTensorNodes(
+    const OpGraph& op_graph, int batch_size, const std::vector<int>& queue_sizes);
 
-// Mapping from MixedOp partition id to corresponding event
-std::vector<cudaEvent_t> CreateEventsForMixedOps(EventPool &event_pool, const OpGraph &op_graph);
+// Mapping from MixedOp partition id to queue of corresponding events
+std::vector<std::vector<cudaEvent_t>> CreateEventsForMixedOps(EventPool& event_pool,
+                                                              const OpGraph& op_graph,
+                                                              int queue_depth);
 
 }  // namespace dali
 

--- a/dali/test/dali_test_matching.h
+++ b/dali/test/dali_test_matching.h
@@ -36,7 +36,7 @@ class GenericMatchingTest : public DALISingleOpTest<ImgType, OutputImgType> {
       OpSpec("HostDecoder")
         .AddArg("output_type", this->ImageType())
         .AddInput("jpegs", "cpu")
-        .AddOutput("input", "cpu"));
+        .AddOutput("input", "cpu"), "HostDecoder");
 
     // Launching the same transformation on CPU (outputIdx 0) and GPU (outputIdx 1)
     this->AddOperatorWithOutput(descr);

--- a/dali/test/dali_test_single_op.h
+++ b/dali/test/dali_test_single_op.h
@@ -212,7 +212,7 @@ class DALISingleOpTest : public DALITest {
     for (int i = 0; i < spec.NumOutput(); ++i)
       outputs_.push_back(std::make_pair(spec.OutputName(i), spec.OutputDevice(i)));
 
-    pipeline_->AddOperator(spec);
+    pipeline_->AddOperator(spec, spec.name());
   }
 
   virtual void AddDefaultArgs(OpSpec& spec) {


### PR DESCRIPTION
Create Queues of Buffers for TensorNodes
    
Instead of creating single backing buffer/Tensor/TL...,
we create a queue of 1 or more elements (more for those,
that need queueing in pipelineing).
Add helper classes for buffer queues and Queue Indexes.

Events for mixed stage are now queued (todo: this should be analyzed a bit more).
    
All workspaces are created using new implementation instead of copying and than changing the pointers corresponding to queued buffers. Storage and presizing is unified for regular buffers and outputs.

Get rid of \*Tensor\*Pools

Next #609 