### PR TITLE
Fix memory corruption caused by sparse tensor handling

### DIFF
--- a/dali/tensorflow/daliop.cc
+++ b/dali/tensorflow/daliop.cc
@@ -215,6 +215,10 @@ class DaliOp : public tf::OpKernel {
         for (unsigned n = 0; n < elms; ++n) {
           TF_DALI_CALL(data_output_shape = DaliToShape(AutoCPtr<int64_t>(
                        daliShapeAtSample(&pipe_handle_, i, n))));
+          // it seems that num_elements() return 1 for empty tensors
+          if (data_output_shape.dims() == 0) {
+            continue;
+          }
           // squeeze
           if (data_output_shape.dim_size(data_output_shape.dims() - 1) == 1) {
             data_output_shape.RemoveLastDims(1);


### PR DESCRIPTION
- TensorFlow shape returns the number of elements 1 for empty tensors
  and a special case is needed for that

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>