### PR TITLE
Volume function unification + tests + minor refactoring.

### DIFF
--- a/dali/kernels/context.h
+++ b/dali/kernels/context.h
@@ -43,7 +43,7 @@ class Scratchpad {
   ///        in the memory of type `alloc_type`.
   template <AllocType alloc_type, typename T, size_t dim>
   TensorView<AllocBackend<alloc_type>, T, dim> AllocTensor(TensorShape<dim> shape) {
-    return { Allocate<T>(alloc_type, Volume(shape)), std::move(shape) };
+    return { Allocate<T>(alloc_type, volume(shape)), std::move(shape) };
   }
 
   /// @brief Allocates storage for a TensorList of elements `T` and given `shape`

--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,21 +26,6 @@
 
 namespace dali {
 namespace kernels {
-
-/// @brief Returns the product of all elements in shape
-/// @param shape - shape of a tensor whose elements we count
-template <typename T>
-inline int64_t volume(const T &shape) {
-  int n = shape.size();
-  if (n < 1) {
-    return 0;
-  }
-  int64_t v = shape[0];
-  for (int i = 1; i < n; i++) {
-    v *= shape[i];
-  }
-  return v;
-}
 
 constexpr int DynamicDimensions = -1;
 constexpr int InferDimensions = -2;
@@ -431,7 +416,7 @@ struct TensorListShapeBase {
       return {};
 
     Derived ret;
-    int dim = dali::kernels::size(ss);
+    int dim = dali::size(ss);
     ret.set_sample_dim(dim);
     ret.shapes.resize(dim * num_samples);
 

--- a/dali/kernels/tensor_view.h
+++ b/dali/kernels/tensor_view.h
@@ -414,19 +414,18 @@ TensorListView<StorageGPU, T, ndim> make_tensor_list_gpu(T *data, TensorListShap
   return { data, std::move(shape) };
 }
 
-
-template <typename Backend, typename T, int ndim>
-struct element_type<TensorView<Backend, T, ndim>> {
-  using type = T;
-};
-
-template <typename Backend, typename T, int ndim>
-struct element_type<TensorListView<Backend, T, ndim>> {
-  using type = T;
-};
-
-
 }  // namespace kernels
+
+template <typename Backend, typename T, int ndim>
+struct element_type<kernels::TensorView<Backend, T, ndim>> {
+  using type = T;
+};
+
+template <typename Backend, typename T, int ndim>
+struct element_type<kernels::TensorListView<Backend, T, ndim>> {
+  using type = T;
+};
+
 }  // namespace dali
 
 #endif  // DALI_KERNELS_TENSOR_VIEW_H_

--- a/dali/kernels/test/kernel_test_utils.h
+++ b/dali/kernels/test/kernel_test_utils.h
@@ -39,9 +39,9 @@ struct SimpleKernelTestBase {
   using Arg = typename std::tuple_element<i, kernels::kernel_args<Kernel>>::type;
 
   template <int i>
-  using InputElement = typename std::remove_const<kernels::element_t<Input<i>>>::type;
+  using InputElement = typename std::remove_const<element_t<Input<i>>>::type;
   template <int i>
-  using OutputElement = kernels::element_t<Output<i>>;
+  using OutputElement = element_t<Output<i>>;
 };
 
 }  // namespace testing

--- a/dali/kernels/test/tensor_shape_test.cc
+++ b/dali/kernels/test/tensor_shape_test.cc
@@ -20,6 +20,14 @@
 namespace dali {
 namespace kernels {
 
+static_assert(compile_time_size_impl<int[41]>::value == 41, "Unexpected value");
+static_assert(compile_time_size_impl<std::array<uint16_t, 123>>::value == 123,
+  "Unexpected array size");
+static_assert(compile_time_size_impl<TensorShape<9>>::value == 9,
+  "Unexpected tensor shape size");
+static_assert(compile_time_size_impl<TensorShape<>>::value == DynamicDimensions,
+  "Unexpected tensor shape size");
+
 TEST(TensorShapeTest, DefaultStaticShapeConstructor) {
   TensorShape<0> zero_tensor;
   ASSERT_EQ(zero_tensor.size(), 0);

--- a/dali/kernels/test/util_test.cc
+++ b/dali/kernels/test/util_test.cc
@@ -1,0 +1,68 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <list>
+#include "dali/kernels/util.h"
+#include "dali/kernels/tensor_shape.h"
+
+namespace dali {
+
+static_assert(std::is_same<volume_t<uint8_t>, int>::value, "Expected promotion to `int`");
+static_assert(std::is_same<volume_t<int16_t>, int>::value, "Expected promotion to `int`");
+static_assert(std::is_same<volume_t<int32_t>, int64_t>::value,
+  "Expected promotion to `int64_t`");
+static_assert(std::is_same<volume_t<uint32_t>, uint64_t>::value,
+  "Expected promotion to `uint64_t`");
+static_assert(std::is_same<volume_t<float>, float>::value,
+  "Floating-point volume should keep extent type");
+static_assert(std::is_same<volume_t<double>, double>::value,
+  "Floating-point volume should keep extent type");
+
+using kernels::TensorShape;
+
+TEST(Volume, Scalar) {
+  EXPECT_EQ(volume(5), 5);
+  EXPECT_EQ(volume(12.25f), 12.25f);
+  EXPECT_EQ(volume(0.625), 0.625);
+}
+
+TEST(Volume, Collections) {
+  int c_array[] = { 5, 7, 4 };
+  std::array<int, 4> cpp_array = { 2, 4, 6, 8 };
+  EXPECT_EQ(volume(c_array), 5*7*4);
+  EXPECT_EQ(volume(cpp_array), 2*4*6*8);
+  std::list<uint8_t> list = { 3, 5, 7, 9 };
+  EXPECT_EQ(volume(list), 3*5*7*9);
+  TensorShape<3> ts = { 11, 22, 33 };
+  EXPECT_EQ(volume(ts), 11*22*33);
+  // initializer list
+  EXPECT_EQ(volume({4, 9, 2, 3}), 4*9*2*3);
+}
+
+TEST(Volume, Ranges) {
+  int c_array[] = { 5, 7, 4 };
+  std::array<int, 4> cpp_array = { 2, 4, 6, 8 };
+  EXPECT_EQ(volume(c_array+1, c_array+3), 7*4);
+  EXPECT_EQ(volume(cpp_array.begin()+1, cpp_array.end()-1), 4*6);
+  std::list<uint8_t> list = { 3, 5, 7, 9 };
+  EXPECT_EQ(volume(std::next(list.begin()), std::prev(list.end())), 5*7);
+
+  std::initializer_list<int> il = {1, 2, 4, 9, 2, 3, 9, 10};
+  auto b = il.begin();
+  auto e = il.end();
+  EXPECT_EQ(volume(b + 2, e - 2), 4*9*2*3);
+}
+
+}  // namespace dali

--- a/dali/kernels/util.h
+++ b/dali/kernels/util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 
 #include <cstddef>
 #include <utility>
+#include <initializer_list>
 
 namespace dali {
-namespace kernels {
 
 using std::size_t;
 
@@ -114,7 +114,69 @@ template <typename T>\
 struct has_unique_function_##function_name : \
   decltype(HasUniqueFunction_##function_name<T>(nullptr)) {}; \
 
-}  // namespace kernels
+
+/// @brief Type of a volume with given `ExtentType`
+template <typename ExtentType, bool arithm = std::is_arithmetic<ExtentType>::value>
+struct volume_type {
+  using type = decltype(std::declval<ExtentType>() * std::declval<ExtentType>());
+};
+
+/// @brief volume_type is undefined for non-arithmetic types, by default
+template <typename ExtentType>
+struct volume_type<ExtentType, false> {};
+
+/// @brief 32-bit integers need promotion to 64-bit to store volume safely
+template <>
+struct volume_type<int32_t, true> {
+  using type = int64_t;
+};
+
+/// @brief 32-bit integers need promotion to 64-bit to store volume safely
+template <>
+struct volume_type<uint32_t, true> {
+  using type = uint64_t;
+};
+
+template <typename ExtentType>
+using volume_t = typename volume_type<
+  typename std::remove_const<typename std::remove_reference<ExtentType>::type>::type>::type;
+
+/// @brief Returns the product of all elements in shape
+/// @param shape_begin - start of the shape extent list
+/// @param shape_end - end of the shape extent list
+template <typename Iter>
+inline volume_t<decltype(*std::declval<Iter>())>
+volume(Iter shape_begin, Iter shape_end) {
+  if (shape_begin == shape_end)
+    return 0;  // perhaps we should return 1 as a neutral element of multiplication?
+  auto it = shape_begin;
+  volume_t<decltype(*shape_begin)> v = *it;
+  for (++it; it != shape_end; ++it)
+    v *= *it;
+  return v;
+}
+
+/// @brief Returns the product of all elements in shape
+/// @param shape - an iterable collection of extents
+template <typename Shape>
+inline auto volume(const Shape &shape)->decltype(volume(std::begin(shape), std::end(shape))) {
+  return volume(std::begin(shape), std::end(shape));
+}
+
+/// @brief Returns the product of all elements in shape
+/// @param shape - an initializer_list of extents
+template <typename Extent>
+inline volume_t<Extent> volume(std::initializer_list<Extent> shape) {
+  return volume(shape.begin(), shape.end());
+}
+
+/// @brief Returns the argument, promoted to an appropriate volume_t
+/// @param single_dim - the sole dimension to be returned as a volume
+template <typename Extent>
+constexpr volume_t<Extent> volume(Extent single_dim) {
+  return single_dim;
+}
+
 }  // namespace dali
 
 #endif  // DALI_KERNELS_UTIL_H_

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -26,21 +26,11 @@
 #include "dali/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/data/types.h"
+#include "dali/kernels/util.h"
 
 namespace dali {
 
 class GPUBackend;
-
-// Helper function to get product of dims
-inline Index Volume(vector<Index>::const_iterator it_begin,
-                     vector<Index>::const_iterator it_end) {
-  if (it_begin == it_end) return 0;
-  return std::accumulate(it_begin, it_end, 1, std::multiplies<Index>());
-}
-
-inline Index Volume(const vector<Index> &shape) {
-  return Volume(shape.begin(), shape.end());
-}
 
 // Helper function to get a string of the data shape
 inline string ShapeString(vector<Index> shape) {

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -28,6 +28,7 @@
 #include "dali/pipeline/data/buffer.h"
 #include "dali/pipeline/data/tensor_list.h"
 #include "dali/pipeline/data/meta.h"
+#include "dali/kernels/util.h"
 
 namespace dali {
 
@@ -114,13 +115,13 @@ class Tensor : public Buffer<Backend> {
   }
 
   /**
-   * @brief Resizes the buffer to fit `Volume(shape)` elements.
+   * @brief Resizes the buffer to fit `volume(shape)` elements.
    * The underlying storage is only reallocated in the case that
    * the current buffer is not large enough for the requested
    * number of elements.
    */
   inline void Resize(const vector<Index> &shape) {
-    Index new_size = Volume(shape);
+    Index new_size = volume(shape);
     ResizeHelper(new_size);
     shape_ = shape;
   }
@@ -155,7 +156,7 @@ class Tensor : public Buffer<Backend> {
 
     // Get the meta-data for the target tensor
     shape_ = tl->tensor_shape(idx);
-    size_ = Volume(shape_);
+    size_ = volume(shape_);
     type_ = tl->type();
     num_bytes_ = type_.size() * size_;
     shares_data_ = true;
@@ -212,7 +213,7 @@ class Tensor : public Buffer<Backend> {
     data_ = ptr;
     num_bytes_ = bytes;
     type_ = TypeInfo::Create<NoType>();
-    Index new_size = Volume(shape);
+    Index new_size = volume(shape);
     shape_ = shape;
     size_ = new_size;
 
@@ -279,7 +280,7 @@ class Tensor : public Buffer<Backend> {
     // Get the meta-data for the target tensor
     shape_ = tl->tensor_shape(0);
     shape_.insert(shape_.begin(), tl->ntensor());
-    size_ = Volume(shape_);
+    size_ = volume(shape_);
     type_ = tl->type();
     num_bytes_ = type_.size() * size_;
     device_ = tl->device_id();

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -112,7 +112,7 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
       }
     }
     for (Index i = 0; i < num_tensor; ++i) {
-      auto tensor_size = Volume(new_shape[i]);
+      auto tensor_size = volume(new_shape[i]);
 
       // Save the offset of the current sample & accumulate the size
       offsets_[i] = new_size;
@@ -292,7 +292,7 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
       if (offset != offsets_[i]) {
         return false;
       }
-      offset += Volume(o);
+      offset += volume(o);
     }
     return true;
   }
@@ -305,7 +305,7 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     size_t elms = 0;
 
     for (auto &shape : shape_) {
-      elms += Volume(shape);
+      elms += volume(shape);
     }
     return elms;
   }

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -64,7 +64,7 @@ class TensorListTest : public DALITest {
     Index offset = 0;
     for (auto &tmp : shape) {
       offsets->push_back(offset);
-      offset += Volume(tmp);
+      offset += volume(tmp);
     }
 
     // Resize the buffer
@@ -115,7 +115,7 @@ TYPED_TEST(TensorListTest, TestGetTypeSizeBytes) {
   Index size = 0;
   for (auto &tmp : shape) {
     offsets.push_back(size);
-    size += Volume(tmp);
+    size += volume(tmp);
   }
 
   // Validate the internals
@@ -142,7 +142,7 @@ TYPED_TEST(TensorListTest, TestGetSizeTypeBytes) {
   Index size = 0;
   for (auto& tmp : shape) {
     offsets.push_back(size);
-    size += Volume(tmp);
+    size += volume(tmp);
   }
 
   // Verify the internals
@@ -183,7 +183,7 @@ TYPED_TEST(TensorListTest, TestGetBytesThenNoAlloc) {
   Index size = 0;
   for (auto &tmp : shape) {
     offsets.push_back(size);
-    size += Volume(tmp);
+    size += volume(tmp);
   }
 
   // Verify the internals
@@ -228,7 +228,7 @@ TYPED_TEST(TensorListTest, TestGetBytesThenAlloc) {
   Index size = 0;
   for (auto &tmp : shape) {
     offsets.push_back(size);
-    size += Volume(tmp);
+    size += volume(tmp);
   }
 
   // Verify the internals
@@ -332,7 +332,7 @@ TYPED_TEST(TensorListTest, TestMultipleResize) {
     Index offset = 0;
     for (auto &tmp : shape) {
       offsets.push_back(offset);
-      offset += Volume(tmp);
+      offset += volume(tmp);
     }
   }
 

--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -80,7 +80,7 @@ TYPED_TEST(TensorTest, TestGetTypeSizeBytes) {
   // Give the tensor a size. This
   // should trigger an allocation
   auto shape = this->GetRandShape();
-  auto size = Volume(shape);
+  auto size = volume(shape);
   t.Resize(shape);
 
   // Validate the internals
@@ -96,7 +96,7 @@ TYPED_TEST(TensorTest, TestGetSizeTypeBytes) {
 
   // Give the tensor a size
   auto shape = this->GetRandShape();
-  auto size = Volume(shape);
+  auto size = volume(shape);
   t.Resize(shape);
 
   ASSERT_EQ(t.size(), size);
@@ -120,7 +120,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeNoAlloc) {
 
   // Get an allocation
   auto shape = this->GetRandShape();
-  auto size = Volume(shape);
+  auto size = volume(shape);
   float *ptr = new float[size];
 
   // Wrap the allocation
@@ -159,7 +159,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeAlloc) {
 
   // Get an allocation
   auto shape = this->GetRandShape();
-  auto size = Volume(shape);
+  auto size = volume(shape);
   float *ptr = new float[size];
 
   // Wrap the allocation
@@ -198,7 +198,7 @@ TYPED_TEST(TensorTest, TestGetBytesSizeTypeNoAlloc) {
 
   // Get an allocation
   auto shape = this->GetRandShape();
-  auto size = Volume(shape);
+  auto size = volume(shape);
   float *ptr = new float[size];
 
   // Wrap the allocation
@@ -235,7 +235,7 @@ TYPED_TEST(TensorTest, TestGetBytesSizeTypeAlloc) {
 
   // Get an allocation
   auto shape = this->GetRandShape();
-  auto size = Volume(shape);
+  auto size = volume(shape);
   float *ptr = new float[size];
 
   // Wrap the allocation
@@ -289,7 +289,7 @@ TYPED_TEST(TensorTest, TestShareData) {
     ASSERT_EQ(tensor.type(), tl.type());
     ASSERT_EQ(tensor.shape(), tl.tensor_shape(i));
 
-    Index size = Volume(tl.tensor_shape(i));
+    Index size = volume(tl.tensor_shape(i));
     ASSERT_EQ(tensor.size(), size);
     ASSERT_EQ(tensor.nbytes(), size*sizeof(float));
   }
@@ -304,7 +304,7 @@ TYPED_TEST(TensorTest, TestResize) {
 
   // Verify the settings
   ASSERT_NE(tensor.template mutable_data<float>(), nullptr);
-  ASSERT_EQ(tensor.size(), Volume(shape));
+  ASSERT_EQ(tensor.size(), volume(shape));
   ASSERT_EQ(tensor.ndim(), shape.size());
   for (size_t i = 0; i < shape.size(); ++i) {
     ASSERT_EQ(tensor.dim(i), shape[i]);
@@ -322,7 +322,7 @@ TYPED_TEST(TensorTest, TestMultipleResize) {
 
     // Verify the settings
     ASSERT_NE(tensor.template mutable_data<float>(), nullptr);
-    ASSERT_EQ(tensor.size(), Volume(shape));
+    ASSERT_EQ(tensor.size(), volume(shape));
     ASSERT_EQ(tensor.ndim(), shape.size());
     for (size_t i = 0; i < shape.size(); ++i) {
       ASSERT_EQ(tensor.dim(i), shape[i]);
@@ -339,7 +339,7 @@ TYPED_TEST(TensorTest, TestResizeScalar) {
 
   // Verify the settings
   ASSERT_NE(tensor.template mutable_data<float>(), nullptr);
-  ASSERT_EQ(tensor.size(), Volume(shape));
+  ASSERT_EQ(tensor.size(), volume(shape));
   ASSERT_EQ(tensor.ndim(), shape.size());
 }
 
@@ -352,7 +352,7 @@ TYPED_TEST(TensorTest, TestResizeZeroSize) {
 
   // Verify the settings
   ASSERT_EQ(tensor.template mutable_data<float>(), nullptr);
-  ASSERT_EQ(tensor.size(), Volume(shape));
+  ASSERT_EQ(tensor.size(), volume(shape));
   ASSERT_EQ(tensor.ndim(), shape.size());
 }
 
@@ -365,7 +365,7 @@ TYPED_TEST(TensorTest, TestTypeChange) {
 
   // Verify the settings
   ASSERT_NE(tensor.template mutable_data<float>(), nullptr);
-  ASSERT_EQ(tensor.size(), Volume(shape));
+  ASSERT_EQ(tensor.size(), volume(shape));
   ASSERT_EQ(tensor.ndim(), shape.size());
   for (size_t i = 0; i < shape.size(); ++i) {
     ASSERT_EQ(tensor.dim(i), shape[i]);
@@ -379,7 +379,7 @@ TYPED_TEST(TensorTest, TestTypeChange) {
   tensor.template mutable_data<int>();
 
   // Verify the settings
-  ASSERT_EQ(tensor.size(), Volume(shape));
+  ASSERT_EQ(tensor.size(), volume(shape));
   ASSERT_EQ(tensor.ndim(), shape.size());
   for (size_t i = 0; i < shape.size(); ++i) {
     ASSERT_EQ(tensor.dim(i), shape[i]);
@@ -393,7 +393,7 @@ TYPED_TEST(TensorTest, TestTypeChange) {
   tensor.template mutable_data<uint8>();
 
   // Verify the settings
-  ASSERT_EQ(tensor.size(), Volume(shape));
+  ASSERT_EQ(tensor.size(), volume(shape));
   ASSERT_EQ(tensor.ndim(), shape.size());
   for (size_t i = 0; i < shape.size(); ++i) {
     ASSERT_EQ(tensor.dim(i), shape[i]);
@@ -407,7 +407,7 @@ TYPED_TEST(TensorTest, TestTypeChange) {
   tensor.template mutable_data<double>();
 
   // Verify the settings
-  ASSERT_EQ(tensor.size(), Volume(shape));
+  ASSERT_EQ(tensor.size(), volume(shape));
   ASSERT_EQ(tensor.ndim(), shape.size());
   for (size_t i = 0; i < shape.size(); ++i) {
     ASSERT_EQ(tensor.dim(i), shape[i]);

--- a/dali/pipeline/executor/executor_test.cc
+++ b/dali/pipeline/executor/executor_test.cc
@@ -498,11 +498,11 @@ TEST_F(ExecutorTest, TestPrefetchedExecution) {
     std::memcpy(
         tl1.template mutable_tensor<uint8>(i),
         tl.template tensor<uint8>(i),
-        Volume(tl.tensor_shape(i)));
+        volume(tl.tensor_shape(i)));
     std::memcpy(
         tl2.template mutable_tensor<uint8>(i),
         tl.template tensor<uint8>(i+batch_size),
-        Volume(tl.tensor_shape(i+batch_size)));
+        volume(tl.tensor_shape(i+batch_size)));
   }
 
   // Run twice without getting the results

--- a/dali/pipeline/operators/color/color_twist.cu
+++ b/dali/pipeline/operators/color/color_twist.cu
@@ -55,7 +55,7 @@ void ColorTwistBase<GPUBackend>::RunImpl(DeviceWorkspace *ws, const int idx) {
     } else {
       CUDA_CALL(cudaMemcpyAsync(output.raw_mutable_tensor(i),
                                 input.raw_tensor(i),
-                                Volume(input.tensor_shape(i)),
+                                volume(input.tensor_shape(i)),
                                 cudaMemcpyDefault,
                                 ws->stream()));
     }

--- a/dali/pipeline/operators/decoder/host_decoder_test.h
+++ b/dali/pipeline/operators/decoder/host_decoder_test.h
@@ -70,7 +70,7 @@ class HostDecodeTestBase : public GenericDecoderTest<ImgType> {
 
   for (size_t i = 0; i < encoded_data.ntensor(); ++i) {
     auto *data = encoded_data.tensor<unsigned char>(i);
-    auto data_size = Volume(encoded_data.tensor_shape(i));
+    auto data_size = volume(encoded_data.tensor_shape(i));
     this->DecodeImage(
       data, data_size, c, this->ImageType(),
       &out[i], GetCropWindowGenerator());

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder.h
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder.h
@@ -222,7 +222,7 @@ class nvJPEGDecoder : public Operator<MixedBackend> {
       const int image_depth = (output_type_ == DALI_GRAY) ? 1 : 3;
       output_shape_[i] = Dims({info.heights[0], info.widths[0], image_depth});
       output_info_[i] = info;
-      image_order[i] = std::make_pair(Volume(output_shape_[i]), i);
+      image_order[i] = std::make_pair(volume(output_shape_[i]), i);
     }
 
     // Resize the output (contiguous)

--- a/dali/pipeline/operators/reader/parser/tfrecord_parser.h
+++ b/dali/pipeline/operators/reader/parser/tfrecord_parser.h
@@ -87,7 +87,7 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
               encoded_feature.int64_list().value().size()*sizeof(int64_t));
           break;
         case FeatureType::string:
-          if (!f.HasShape() || Volume(f.Shape()) > 1) {
+          if (!f.HasShape() || volume(f.Shape()) > 1) {
             DALI_FAIL("Tensors of strings are not supported.");
           }
           output.Resize({static_cast<Index>(encoded_feature.bytes_list().value(0).size())});

--- a/dali/pipeline/operators/sequence/element_extract.cc
+++ b/dali/pipeline/operators/sequence/element_extract.cc
@@ -42,7 +42,7 @@ void ElementExtract<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
     auto shape = input.shape();
     detail::CheckInputShape(shape, element_map_);
     Dims output_shape(shape.begin()+1, shape.end());
-    auto element_size = Volume(output_shape);
+    auto element_size = volume(output_shape);
 
     auto elements_per_sample = element_map_.size();
     auto output_offset = idx * elements_per_sample;

--- a/dali/pipeline/operators/sequence/element_extract.cu
+++ b/dali/pipeline/operators/sequence/element_extract.cu
@@ -50,7 +50,7 @@ void ElementExtract<GPUBackend>::RunImpl(DeviceWorkspace *ws, int idx) {
 
         for (unsigned int i = 0; i < input.ntensor(); i++) {
             const auto& tensor_shape = input.tensor_shape(i);
-            auto element_size = Volume(tensor_shape.begin()+1, tensor_shape.end());
+            auto element_size = volume(tensor_shape.begin()+1, tensor_shape.end());
             auto input_offset_bytes = element * element_size * data_type.size();
 
             data_type.Copy<GPUBackend, GPUBackend>(

--- a/dali/pipeline/operators/transpose/transpose_test.cc
+++ b/dali/pipeline/operators/transpose/transpose_test.cc
@@ -28,8 +28,8 @@ namespace {
 // Fill tensors of consecutive numbers
 template <typename T>
 void Arrange(T* ptr, const std::vector<Index>& shape) {
-  auto volume = Volume(shape);
-  for (int i = 0; i < volume; ++i) {
+  auto vol = volume(shape);
+  for (int i = 0; i < vol; ++i) {
     ptr[i] = static_cast<T>(i);
   }
 }
@@ -153,8 +153,8 @@ void CheckTransposition(const T* in_tensor, const T* out_tensor,
                         const std::vector<Index>& old_shape,
                         const std::vector<Index>& new_shape,
                         const std::vector<int>& perm) {
-  auto old_volume = Volume(old_shape);
-  auto new_volume = Volume(new_shape);
+  auto old_volume = volume(old_shape);
+  auto new_volume = volume(new_shape);
   ASSERT_EQ(old_volume, new_volume);
 
   auto old_strides = GetStrides(old_shape);

--- a/dali/plugin/copy.cu
+++ b/dali/plugin/copy.cu
@@ -73,14 +73,14 @@ void CopyToExternalTensor(const Tensor<CPUBackend>& t, void* ptr,
                           device_type_t dst_type) {
   DALI_ENFORCE(t.ndim() > 0, "Can't copy empty Tensor!");
   CopyToExternalTensorHelper<CPUBackend>(t, ptr, dst_type,
-                                         Volume(t.shape()) * t.type().size());
+                                         volume(t.shape()) * t.type().size());
 }
 
 void CopyToExternalTensor(const Tensor<GPUBackend>& t, void* ptr,
                           device_type_t dst_type) {
   DALI_ENFORCE(t.ndim() > 0, "Can't copy empty Tensor!");
   CopyToExternalTensorHelper<GPUBackend>(t, ptr, dst_type,
-                                         Volume(t.shape()) * t.type().size());
+                                         volume(t.shape()) * t.type().size());
 }
 void CopyToExternalTensor(TensorList<CPUBackend>* tl, void* ptr,
                           device_type_t dst_type) {

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -116,7 +116,7 @@ void ExposeTensor(py::module &m) { // NOLINT
           for (auto &dim : info.shape) {
             i_shape.push_back(dim);
           }
-          size_t bytes = Volume(i_shape) * info.itemsize;
+          size_t bytes = volume(i_shape) * info.itemsize;
 
           // Validate the stride
           ssize_t dim_prod = 1;
@@ -221,7 +221,7 @@ void ExposeTensorList(py::module &m) { // NOLINT
             tensor_shape[i-1] = info.shape[i];
           }
           std::vector<Dims> i_shape(info.shape[0], tensor_shape);
-          size_t bytes = Volume(tensor_shape)*i_shape.size()*info.itemsize;
+          size_t bytes = volume(tensor_shape)*i_shape.size()*info.itemsize;
 
           // Validate the stride
           ssize_t dim_prod = 1;

--- a/dali/test/dali_test.h
+++ b/dali/test/dali_test.h
@@ -164,7 +164,7 @@ class DALITest : public ::testing::Test {
     tl->Resize(shape);
     for (int i = 0; i < n; ++i) {
       std::memcpy(tl->template mutable_tensor<uint8>(i),
-                  images[i % images.size()], Volume(tl->tensor_shape(i)));
+                  images[i % images.size()], volume(tl->tensor_shape(i)));
     }
   }
 

--- a/dali/test/dali_test_decoder.h
+++ b/dali/test/dali_test_decoder.h
@@ -26,7 +26,7 @@ class GenericDecoderTest : public DALISingleOpTest<ImgType> {
     const int c = this->GetNumColorComp();
     for (size_t i = 0; i < encoded_data.ntensor(); ++i) {
       auto *data = encoded_data.tensor<unsigned char>(i);
-      auto data_size = Volume(encoded_data.tensor_shape(i));
+      auto data_size = volume(encoded_data.tensor_shape(i));
 
       this->DecodeImage(data, data_size, c, this->ImageType(), &out[i]);
     }

--- a/dali/test/operator_argument.h
+++ b/dali/test/operator_argument.h
@@ -52,7 +52,7 @@ struct TestOpArgToStringImpl<std::string> {
 };
 
 template <typename T>
-struct TestOpArgToStringImpl<T, kernels::if_iterable<T, void>> {
+struct TestOpArgToStringImpl<T, if_iterable<T, void>> {
   static std::string to_string(const T& val) {
     std::stringstream ss;
     if (val.size() == 0) {
@@ -60,7 +60,7 @@ struct TestOpArgToStringImpl<T, kernels::if_iterable<T, void>> {
     } else {
       ss << "[ ";
     }
-    using element_type = kernels::element_t<T>;
+    using element_type = element_t<T>;
     bool first = true;
     for (const auto& e : val) {
       if (!first) {


### PR DESCRIPTION
Generalize `volume` function.
Move utilities in dali/kernels/util.h to namespace `dali`.
Remove all references to old `Volume` and use new `volume` instead.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>