### PR TITLE
Make sticking to data shard optional

### DIFF
--- a/dali/pipeline/operators/reader/loader/file_loader.cc
+++ b/dali/pipeline/operators/reader/loader/file_loader.cc
@@ -98,9 +98,7 @@ void FileLoader::ReadSample(ImageLabelWrapper* image_label) {
   auto image_pair = image_label_pairs_[current_index_++];
 
   // handle wrap-around
-  if (IsNextShard(current_index_)) {
-    Reset();
-  }
+  MoveToNextShard(current_index_);
 
   auto current_image = FileStream::Open(file_root_ + "/" + image_pair.first, read_ahead_);
   Index image_size = current_image->Size();

--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -82,7 +82,7 @@ class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
       std::mt19937 g(524287);
       std::shuffle(image_label_pairs_.begin(), image_label_pairs_.end(), g);
     }
-    Reset();
+    Reset(true);
   }
 
   void PrepareEmpty(ImageLabelWrapper *tensor) override;
@@ -91,8 +91,12 @@ class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
   Index Size() override;
 
  protected:
-  void Reset() override {
-    current_index_ = start_index(shard_id_, num_shards_, Size());
+  void Reset(bool wrap_to_shard) override {
+    if (wrap_to_shard) {
+      current_index_ = start_index(shard_id_, num_shards_, Size());
+    } else {
+      current_index_ = 0;
+    }
   }
   using Loader<CPUBackend, ImageLabelWrapper>::shard_id_;
   using Loader<CPUBackend, ImageLabelWrapper>::num_shards_;

--- a/dali/pipeline/operators/reader/loader/loader.cc
+++ b/dali/pipeline/operators/reader/loader/loader.cc
@@ -28,6 +28,10 @@ DALI_SCHEMA(LoaderBase)
       R"code(Id of the part to read.)code", 0)
   .AddOptionalArg("tensor_init_bytes",
       R"code(Hint for how much memory to allocate per image.)code", 1048576)
+  .AddOptionalArg("stick_to_shard",
+      R"code(Whether reader should stick to given data shard instead of going through the whole dataset.
+When decoder caching is used, it reduces significantly the amount of data to be cached, but could affect
+accuracy in some cases)code", false)
   .AddOptionalArg("read_ahead",
       R"code(Whether accessed data should be read ahead. In case of big files like LMDB,
 RecordIO or TFRecord it will slow down first access but will decrease the time of all following

--- a/dali/pipeline/operators/reader/loader/loader.h
+++ b/dali/pipeline/operators/reader/loader/loader.h
@@ -53,7 +53,8 @@ class Loader {
       seed_(options.GetArgument<Index>("seed")),
       shard_id_(options.GetArgument<int>("shard_id")),
       num_shards_(options.GetArgument<int>("num_shards")),
-      read_ahead_(options.GetArgument<bool>("read_ahead")) {
+      read_ahead_(options.GetArgument<bool>("read_ahead")),
+      stick_to_shard_(options.GetArgument<bool>("stick_to_shard")) {
     DALI_ENFORCE(initial_empty_size_ > 0, "Batch size needs to be greater than 0");
     DALI_ENFORCE(num_shards_ > shard_id_, "num_shards needs to be greater than shard_id");
     // initialize a random distribution -- this will be
@@ -167,14 +168,19 @@ class Loader {
   virtual Index Size() = 0;
 
  protected:
+  virtual void MoveToNextShard(Index current_index) {
+    if (IsNextShard(current_index)) {
+      Reset(stick_to_shard_);
+    }
+  }
   // Reset reader to the first sample
-  virtual void Reset() = 0;
+  virtual void Reset(bool wrap_to_shard) = 0;
 
   // Check if given reader moved to the next shard
   virtual inline bool IsNextShard(Index current_index) {
      return current_index >= Size() ||
-            (shard_id_ + 1 < num_shards_ &&
-            current_index == static_cast<Index>(start_index(shard_id_ + 1, num_shards_, Size())));
+            (stick_to_shard_ && shard_id_ + 1 < num_shards_ &&
+            current_index >= static_cast<Index>(start_index(shard_id_ + 1, num_shards_, Size())));
   }
   std::vector<LoadTarget*> sample_buffer_;
 
@@ -204,6 +210,9 @@ class Loader {
   bool copy_read_data_;
   // if accessed files should be loaded into memory in advance at the first access
   bool read_ahead_;
+  // if reader for the given GPU should read over and over the same shard or should go through
+  // whole data set
+  bool stick_to_shard_;
 };
 
 };  // namespace dali

--- a/dali/pipeline/operators/reader/loader/recordio_loader.h
+++ b/dali/pipeline/operators/reader/loader/recordio_loader.h
@@ -77,9 +77,7 @@ class RecordIOLoader : public IndexedFileLoader {
 
   void ReadSample(Tensor<CPUBackend>* tensor) override {
     // if we moved to next shard wrap up
-    if (IsNextShard(current_index_)) {
-      Reset();
-    }
+    MoveToNextShard(current_index_);
 
     int64 seek_pos, size;
     size_t file_index;

--- a/dali/pipeline/operators/reader/loader/sequence_loader.h
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.h
@@ -107,7 +107,7 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
       std::mt19937 g(524287);
       std::shuffle(sequences_.begin(), sequences_.end(), g);
     }
-    Reset();
+    Reset(true);
   }
 
   void PrepareEmpty(TensorSequence *tensor) override;
@@ -115,8 +115,12 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
   Index Size() override;
 
  private:
-  void Reset() override {
-    current_sequence_ = start_index(shard_id_, num_shards_, Size());
+  void Reset(bool wrap_to_shard) override {
+    if (wrap_to_shard) {
+      current_sequence_ = start_index(shard_id_, num_shards_, Size());
+    } else {
+      current_sequence_ = 0;
+    }
   }
   // TODO(klecki) For now sequence is <directory, image list> pair, later it
   // will be a video file

--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -447,9 +447,8 @@ void VideoLoader::ReadSample(SequenceWrapper* tensor) {
     receive_frames(*tensor);
     tensor->wait();
     ++current_frame_idx_;
-    if (IsNextShard(current_frame_idx_)) {
-      Reset();
-    }
+
+    MoveToNextShard(current_frame_idx_);
 }
 
 Index VideoLoader::Size() {

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -145,7 +145,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       std::shuffle(std::begin(frame_starts_), std::end(frame_starts_), g);
     }
 
-    Reset();
+    Reset(true);
 
     thread_file_reader_ = std::thread{&VideoLoader::read_file, this};
   }
@@ -177,8 +177,12 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   std::pair<int, int> load_width_height(const std::string& filename);
 
  private:
-  void Reset() override {
-    current_frame_idx_ = start_index(shard_id_, num_shards_, Size());
+  void Reset(bool wrap_to_shard) override {
+    if (wrap_to_shard) {
+      current_frame_idx_ = start_index(shard_id_, num_shards_, Size());
+    } else {
+      current_frame_idx_ = 0;
+    }
   }
   // Params
   int count_;


### PR DESCRIPTION
- Adds stick_to_shard option to the reader
- Makes sticking to given data shard optional so in case of affected
  accuracy user can disable this
- Enables file mmap for the sequence reader

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>