### PR TITLE
Add option to select targeted CUDA archs:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,16 @@ endif()
 include(cmake/CUDA_utils.cmake)
 CUDA_find_supported_arch_values(CUDA_supported_archs ${CUDA_known_archs})
 message(STATUS "CUDA supported archs: ${CUDA_supported_archs}")
-CUDA_get_gencode_args(CUDA_gencode_flags ${CUDA_supported_archs})
+
+set(CUDA_TARGET_ARCHS_SORTED ${CUDA_TARGET_ARCHS})
+list(SORT CUDA_TARGET_ARCHS_SORTED)
+CUDA_find_supported_arch_values(CUDA_targeted_archs ${CUDA_TARGET_ARCHS_SORTED})
+message(STATUS "CUDA targeted archs: ${CUDA_targeted_archs}")
+if (NOT CUDA_targeted_archs)
+  message(FATAL_ERROR "None of the provided CUDA archs: {${CUDA_TARGET_ARCHS}} is supported by the nvcc, you should use one of ${CUDA_supported_archs}")
+endif()
+
+CUDA_get_gencode_args(CUDA_gencode_flags ${CUDA_targeted_archs})
 message(STATUS "Generated gencode flags: ${CUDA_gencode_flags}")
 
 # Add ptx & bin flags for cuda

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ list(SORT CUDA_TARGET_ARCHS_SORTED)
 CUDA_find_supported_arch_values(CUDA_targeted_archs ${CUDA_TARGET_ARCHS_SORTED})
 message(STATUS "CUDA targeted archs: ${CUDA_targeted_archs}")
 if (NOT CUDA_targeted_archs)
-  message(FATAL_ERROR "None of the provided CUDA archs: {${CUDA_TARGET_ARCHS}} is supported by the nvcc, you should use one of ${CUDA_supported_archs}")
+  message(FATAL_ERROR "None of the provided CUDA architectures ({${CUDA_TARGET_ARCHS}}) is supported by nvcc, use one or more of: ${CUDA_supported_archs}")
 endif()
 
 CUDA_get_gencode_args(CUDA_gencode_flags ${CUDA_targeted_archs})

--- a/cmake/CUDA_utils.cmake
+++ b/cmake/CUDA_utils.cmake
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 # List of currently used arch values
 set(CUDA_known_archs "35" "50" "52" "60" "61" "70" "75")
+
+set(CUDA_TARGET_ARCHS ${CUDA_known_archs} CACHE STRING "List of target CUDA archs")
 
 # Find if passing `flags` to nvcc producess success or failure
 # Unix only

--- a/cmake/CUDA_utils.cmake
+++ b/cmake/CUDA_utils.cmake
@@ -16,7 +16,7 @@
 # List of currently used arch values
 set(CUDA_known_archs "35" "50" "52" "60" "61" "70" "75")
 
-set(CUDA_TARGET_ARCHS ${CUDA_known_archs} CACHE STRING "List of target CUDA archs")
+set(CUDA_TARGET_ARCHS ${CUDA_known_archs} CACHE STRING "List of target CUDA architectures")
 
 # Find if passing `flags` to nvcc producess success or failure
 # Unix only


### PR DESCRIPTION
Usage:
cmake -DCUDA_TARGET_ARCHS=70 # for single arch
cmake "-DCUDA_TARGET_ARCHS=60;70;75" #for list of archs

Archs are sorted, some error checking is added.
By default we target all supported archs

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>