### PR TITLE
Add cubic filter for CPU and GPU.

### DIFF
--- a/dali/kernels/imgproc/resample/params.h
+++ b/dali/kernels/imgproc/resample/params.h
@@ -26,8 +26,14 @@ enum class ResamplingFilterType : uint8_t {
   Linear,
   Triangular,
   Gaussian,
+  Cubic,
   Lanczos3,
 };
+
+inline const char * FilterName(ResamplingFilterType type) {
+  static const char *names[] = { "NN", "Linear", "Triangular", "Gaussian", "Cubic", "Lanczos3" };
+  return names[static_cast<int>(type)];
+}
 
 constexpr int KeepOriginalSize = -1;
 
@@ -37,6 +43,8 @@ inline float DefaultFilterRadius(ResamplingFilterType type, float in_size, float
     return in_size > out_size ? in_size/out_size : 1;
   case ResamplingFilterType::Gaussian:
     return in_size > out_size ? in_size/out_size : 1;
+  case ResamplingFilterType::Cubic:
+    return 2;
   case ResamplingFilterType::Lanczos3:
     return 3;
   default:

--- a/dali/kernels/imgproc/resample/resampling_filters.cu
+++ b/dali/kernels/imgproc/resample/resampling_filters.cu
@@ -21,6 +21,7 @@
 #include "dali/kernels/imgproc/resample/resampling_filters.cuh"
 #include "dali/kernels/alloc.h"
 #include "dali/kernels/span.h"
+#include "dali/kernels/imgproc/resample/resampling_windows.h"
 
 namespace dali {
 namespace kernels {
@@ -40,20 +41,18 @@ __global__ void InitGaussianFilter(ResamplingFilter filter) {
   });
 }
 
-inline __host__ __device__ float sinc(float x) {
-  return x ? sinf(x * M_PI) / (x * M_PI) : 1;
-}
-
-inline __host__ __device__ float LanczosWindow(float x, float a) {
-  if (fabsf(x) >= a)
-    return 0.0f;
-  return sinc(x)*sinc(x / a);
-}
-
 __global__ void InitLanczosFilter(ResamplingFilter filter, float a) {
   InitFilter(filter, [&](int i) {
     float x = 2 * a * (i - (filter.num_coeffs-1)*0.5f) / (filter.num_coeffs-1);
     return LanczosWindow(x, a);
+  });
+}
+
+
+__global__ void InitCubicFilter(ResamplingFilter filter) {
+  InitFilter(filter, [&](int i) {
+    float x = 4 * (i - (filter.num_coeffs-1)*0.5f) / (filter.num_coeffs-1);
+    return CubicWindow(x);
   });
 }
 
@@ -62,6 +61,7 @@ void InitFilters(ResamplingFilters &filters, cudaStream_t stream) {
   const int lanczos_a = 3;
   const int triangular_size = 3;
   const int gaussian_size = 65;
+  const int cubic_size = 129;
   const int lanczos_size = (2*lanczos_a*lanczos_resolution + 1);
   const int total_size = triangular_size + gaussian_size + lanczos_size;
 
@@ -76,6 +76,7 @@ void InitFilters(ResamplingFilters &filters, cudaStream_t stream) {
   add_filter(triangular_size);
   add_filter(gaussian_size);
   add_filter(lanczos_size);
+  add_filter(cubic_size);
 
   float triangle[3] = { 0, 1, 0 };
 
@@ -84,9 +85,15 @@ void InitFilters(ResamplingFilters &filters, cudaStream_t stream) {
 
   InitGaussianFilter<<<1, gaussian_size, 0, stream>>>(filters.filters[1]);
   InitLanczosFilter<<<1, lanczos_size, 0, stream>>>(filters.filters[2], lanczos_a);
+  InitCubicFilter<<<1, cubic_size, 0, stream>>>(filters.filters[3]);
 
   filters[2].rescale(6);
+  filters[3].rescale(4);
   cudaStreamSynchronize(stream);
+}
+
+ResamplingFilter ResamplingFilters::Cubic() const noexcept {
+  return filters[3];
 }
 
 ResamplingFilter ResamplingFilters::Gaussian(float sigma) const noexcept {

--- a/dali/kernels/imgproc/resample/resampling_filters.cuh
+++ b/dali/kernels/imgproc/resample/resampling_filters.cuh
@@ -69,6 +69,7 @@ struct ResamplingFilter {
 struct ResamplingFilters {
   std::unique_ptr<float, std::function<void(void*)>> filter_data;
 
+  ResamplingFilter Cubic() const noexcept;
   ResamplingFilter Gaussian(float sigma) const noexcept;
   ResamplingFilter Lanczos3() const noexcept;
   ResamplingFilter Triangular(float radius) const noexcept;

--- a/dali/kernels/imgproc/resample/resampling_setup.cc
+++ b/dali/kernels/imgproc/resample/resampling_setup.cc
@@ -27,8 +27,10 @@ inline ResamplingFilter GetResamplingFilter(
       return filters->Triangular(params.radius);
     case ResamplingFilterType::Lanczos3:
       return filters->Lanczos3();
-  default:
-    return { nullptr, 0, 0, 0 };
+    case ResamplingFilterType::Cubic:
+      return filters->Cubic();
+    default:
+      return { nullptr, 0, 0, 0 };
   }
 }
 
@@ -39,7 +41,7 @@ void SeparableResamplingSetup::SetupComputation(
     Initialize(0);
 
   int N = in.num_samples();
-  assert(params.size() == N);
+  assert(params.size() == static_cast<size_t>(N));
 
   sample_descs.resize(N);
   intermediate_shape.resize(N);

--- a/dali/kernels/imgproc/resample/resampling_windows.h
+++ b/dali/kernels/imgproc/resample/resampling_windows.h
@@ -56,16 +56,15 @@ inline __host__ __device__ float Lanczos3Window(float x) {
 
 inline __host__ __device__ float CubicWindow(float x) {
   x = fabsf(x);
-  if (x >= 2) {
+  if (x >= 2)
     return 0;
-  } else {
-    float x2 = x*x;
-    float x3 = x2*x;
-    if (x > 1)
-      return -0.5f*x3 + 2.5f*x2 - 4.0f*x + 2.0f;
-    else
-      return 1.5f*x3 - 2.5f*x2 + 1.0f;
-  }
+
+  float x2 = x*x;
+  float x3 = x2*x;
+  if (x > 1)
+    return -0.5f*x3 + 2.5f*x2 - 4.0f*x + 2.0f;
+  else
+    return 1.5f*x3 - 2.5f*x2 + 1.0f;
 }
 
 struct FilterWindow {
@@ -82,7 +81,7 @@ struct FilterWindow {
 
 inline FilterWindow GaussianFilter(float radius, float sigma = 0) {
   float scale = sigma ? M_SQRT1_2 / sigma : 2 / radius;
-  radius = floorf(radius + 0.4f)+0.5f;
+  radius = floorf(radius + 0.4f) + 0.5f;
   return { 2*radius, radius, scale, ExpMinusX2 };
 }
 

--- a/dali/kernels/imgproc/resample/resampling_windows.h
+++ b/dali/kernels/imgproc/resample/resampling_windows.h
@@ -54,6 +54,20 @@ inline __host__ __device__ float Lanczos3Window(float x) {
   return LanczosWindow(x, 3);
 }
 
+inline __host__ __device__ float CubicWindow(float x) {
+  x = fabsf(x);
+  if (x >= 2) {
+    return 0;
+  } else {
+    float x2 = x*x;
+    float x3 = x2*x;
+    if (x > 1)
+      return -0.5f*x3 + 2.5f*x2 - 4.0f*x + 2.0f;
+    else
+      return 1.5f*x3 - 2.5f*x2 + 1.0f;
+  }
+}
+
 struct FilterWindow {
   float size, anchor, scale;
   std::function<float(float)> func;
@@ -68,7 +82,7 @@ struct FilterWindow {
 
 inline FilterWindow GaussianFilter(float radius, float sigma = 0) {
   float scale = sigma ? M_SQRT1_2 / sigma : 2 / radius;
-  radius = std::floor(radius + 0.4f)+0.5f;
+  radius = floorf(radius + 0.4f)+0.5f;
   return { 2*radius, radius, scale, ExpMinusX2 };
 }
 
@@ -78,12 +92,16 @@ inline FilterWindow TriangularFilter(float radius) {
   return { 2*radius, radius, 1/radius, TriangularWindow };
 }
 
+inline  FilterWindow CubicFilter() {
+  return { 4, 2, 1, CubicWindow };
+}
+
 inline  FilterWindow Lanczos3Filter() {
   return { 6, 3, 1, Lanczos3Window };
 }
 
 inline  FilterWindow LanczosFilter(float a) {
-  return { 6, 3, 1, [a](float x) { return LanczosWindow(x, a); } };
+  return { 2*a, a, 1, [a](float x) { return LanczosWindow(x, a); } };
 }
 
 inline  FilterWindow LinearFilter() {

--- a/dali/kernels/imgproc/resample/separable_cpu.h
+++ b/dali/kernels/imgproc/resample/separable_cpu.h
@@ -49,6 +49,8 @@ struct ResamplingSetupCPU {
       return TriangularFilter(desc.radius);
     case ResamplingFilterType::Gaussian:
       return GaussianFilter(desc.radius);
+    case ResamplingFilterType::Cubic:
+      return CubicFilter();
     case ResamplingFilterType::Lanczos3:
       return Lanczos3Filter();
     default:

--- a/dali/kernels/test/resampling_test/resampling_internal_test.cu
+++ b/dali/kernels/test/resampling_test/resampling_internal_test.cu
@@ -501,5 +501,17 @@ TEST_F(ResamplingTest, Lanczos3) {
   Verify(1, "score_lanczos_dif.png");
 }
 
+// It passes. It's DISABLED until the test data propagates to CI
+TEST_F(ResamplingTest, DISABLED_Cubic) {
+  SetSource("imgproc_test/score.png", "imgproc_test/ref_out/score_cubic.png");
+  SetOutputSize(200, 93);
+  auto filters = GetResamplingFilters(0);
+  ResamplingFilter f = filters->Cubic();
+  SetFilters(f, f);
+  Prepare();
+  Run();
+  Verify(1, "score_cubic_dif.png");
+}
+
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/test/resampling_test/resampling_test_params.h
+++ b/dali/kernels/test/resampling_test/resampling_test_params.h
@@ -42,6 +42,10 @@ constexpr FilterDesc lanczos() {
   return { ResamplingFilterType::Lanczos3, 0 };
 }
 
+constexpr FilterDesc cubic() {
+  return { ResamplingFilterType::Cubic, 0 };
+}
+
 constexpr FilterDesc gauss(float radius) {
   return { ResamplingFilterType::Gaussian, radius };
 }
@@ -77,10 +81,23 @@ struct ResamplingTestEntry {
 using ResamplingTestBatch = std::vector<ResamplingTestEntry>;
 
 inline std::ostream &operator<<(std::ostream &os, const FilterDesc fd) {
-  const char *names[] = { "NN", "Linear", "Triangular", "Gaussian", "Lanczos3" };
-  os << names[static_cast<int>(fd.type)];
-  if (static_cast<int>(fd.type) > static_cast<int>(ResamplingFilterType::Linear) && fd.radius)
-    os << "(r = " << fd.radius << ")";
+  os << FilterName(fd.type);
+  if (fd.radius) {
+    switch (fd.type) {
+    case ResamplingFilterType::Gaussian:
+    case ResamplingFilterType::Triangular:
+      os << "(r = " << fd.radius << ")";
+      break;
+    case ResamplingFilterType::Cubic:
+      if (fd.radius != 4) os << "(custom radius: " << fd.radius << ")";
+      break;
+    case ResamplingFilterType::Lanczos3:
+      if (fd.radius != 3) os << "(custom radius: " << fd.radius << ")";
+      break;
+    default:
+      break;
+    }
+  }
   return os;
 }
 

--- a/dali/kernels/test/resampling_test/separable_cpu_test.cc
+++ b/dali/kernels/test/resampling_test/separable_cpu_test.cc
@@ -108,6 +108,11 @@ static std::vector<ResamplingTestEntry> ResampleTests = {
     "imgproc_test/score.png", "imgproc_test/ref_out/score_lanczos3.png",
     { 540, 250 }, lanczos(), 1
   },
+  // TODO(michalz): uncomment when test data propagates to CI
+  /*{
+    "imgproc_test/score.png", "imgproc_test/ref_out/score_cubic.png",
+    { 200, 93 }, cubic(), 1
+  },*/
   {
     "imgproc_test/alley.png", "imgproc_test/ref_out/alley_blurred.png",
     { 681, 960 }, gauss(12), 2

--- a/dali/kernels/test/resampling_test/separable_impl_test.cc
+++ b/dali/kernels/test/resampling_test/separable_impl_test.cc
@@ -117,6 +117,11 @@ ResamplingTestBatch Batch1 = {
     "imgproc_test/score.png", "imgproc_test/ref_out/score_lanczos3.png",
     { 540, 250 }, lanczos(), 1
   },
+  // TODO(michalz): uncomment when test data propagates to CI
+  /*{
+    "imgproc_test/score.png", "imgproc_test/ref_out/score_cubic.png",
+    { 200, 93 }, cubic(), 1
+  },*/
   {
     "imgproc_test/alley.png", "imgproc_test/ref_out/alley_blurred.png",
     { 681, 960 }, gauss(12), 2


### PR DESCRIPTION
Remove duplicate functions from GPU filter initialization.
Add tests.
TODO: some tests are disabled now, because test data propagates to CI nodes only once a week.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>