### PR TITLE
Fix aspect ratio distribution.

### DIFF
--- a/dali/pipeline/operators/resize/random_resized_crop.cc
+++ b/dali/pipeline/operators/resize/random_resized_crop.cc
@@ -132,11 +132,11 @@ void RandomResizedCrop<CPUBackend>::SetupSharedSampleParams(SampleWorkspace *ws)
 
   for (attempt = 0; attempt < num_attempts_; ++attempt) {
     if (TryCrop(H, W,
-                &params_->aspect_ratio_dis[id],
-                &params_->area_dis[id],
-                &params_->uniform[id],
-                &params_->rand_gens[id],
-                &crop)) {
+                params_->aspect_ratio_dis[id],
+                params_->area_dis[id],
+                params_->uniform[id],
+                params_->rand_gens[id],
+                crop)) {
       break;
     }
   }

--- a/dali/pipeline/operators/resize/random_resized_crop.cu
+++ b/dali/pipeline/operators/resize/random_resized_crop.cu
@@ -142,11 +142,11 @@ void RandomResizedCrop<GPUBackend>::SetupSharedSampleParams(DeviceWorkspace *ws)
 
     for (attempt = 0; attempt < num_attempts_; ++attempt) {
       if (TryCrop(H, W,
-                  &params_->aspect_ratio_dis,
-                  &params_->area_dis,
-                  &params_->uniform,
-                  &params_->rand_gen,
-                  &crop)) {
+                  params_->aspect_ratio_dis,
+                  params_->area_dis,
+                  params_->uniform,
+                  params_->rand_gen,
+                  crop)) {
         break;
       }
     }

--- a/dali/util/random_crop_generator.h
+++ b/dali/util/random_crop_generator.h
@@ -39,9 +39,10 @@ class DLL_PUBLIC RandomCropGenerator {
  private:
   CropWindow GenerateCropWindowImpl(int H, int W);
 
-  std::uniform_real_distribution<float> aspect_ratio_dis_;
+  std::uniform_real_distribution<float> aspect_ratio_dis_, inv_aspect_ratio_dis_;
   std::uniform_real_distribution<float> area_dis_;
   std::uniform_real_distribution<float> uniform_;
+  std::bernoulli_distribution coin_flip_;
   std::mt19937 rand_gen_;
   int64_t seed_;
   int num_attempts_;


### PR DESCRIPTION
Previously we swapped width and height to symmetrize distribution
- that only works for symmetrical distributions, such as 3/4..4/3,
but fails for ratio ranges like 4/3..16/9, which should never produce
portrait images.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>