### PR TITLE
Add options for COCOReader

### DIFF
--- a/dali/pipeline/operators/reader/coco_reader_op.cc
+++ b/dali/pipeline/operators/reader/coco_reader_op.cc
@@ -319,6 +319,9 @@ Tensor (`m` * `[x, y, w, h] or `m` * [left, top, right, bottom]`) and labels as 
   .AddOptionalArg("save_img_ids",
       R"code(If true, image IDs will also be returned.)code",
       false)
+  .AddOptionalArg("shuffle_after_epoch",
+      R"code(If true, reader shuffles whole dataset after each epoch.)code",
+      false)
   .AdditionalOutputsFn([](const OpSpec& spec) {
     return static_cast<int>(spec.GetArgument<bool>("save_img_ids"));
   })

--- a/dali/pipeline/operators/reader/coco_reader_op.h
+++ b/dali/pipeline/operators/reader/coco_reader_op.h
@@ -46,7 +46,14 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
     skip_empty_(spec.GetArgument<bool>("skip_empty")),
     save_img_ids_(spec.GetArgument<bool>("save_img_ids")) {
     ParseAnnotationFiles();
-    loader_.reset(new FileLoader(spec, image_id_pairs_));
+
+    if (spec.HasArgument("file_list"))
+      loader_.reset(new FileLoader(spec));
+    else
+      loader_.reset(new FileLoader(
+        spec,
+        image_id_pairs_,
+        spec.GetArgument<bool>("shuffle_after_epoch")));
     parser_.reset(new COCOParser(spec, annotations_multimap_, save_img_ids_));
   }
 

--- a/dali/pipeline/operators/reader/coco_reader_op.h
+++ b/dali/pipeline/operators/reader/coco_reader_op.h
@@ -49,8 +49,8 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
 
     if (spec.HasArgument("file_list"))
       loader_.reset(new FileLoader(
-        spec, 
-        std::vector<std::pair<string,int>>(), 
+        spec,
+        std::vector<std::pair<string, int>>(),
         spec.GetArgument<bool>("shuffle_after_epoch")));
     else
       loader_.reset(new FileLoader(

--- a/dali/pipeline/operators/reader/coco_reader_op.h
+++ b/dali/pipeline/operators/reader/coco_reader_op.h
@@ -48,7 +48,10 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
     ParseAnnotationFiles();
 
     if (spec.HasArgument("file_list"))
-      loader_.reset(new FileLoader(spec));
+      loader_.reset(new FileLoader(
+        spec, 
+        std::vector<std::pair<string,int>>(), 
+        spec.GetArgument<bool>("shuffle_after_epoch")));
     else
       loader_.reset(new FileLoader(
         spec,

--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -45,12 +45,16 @@ struct ImageLabelWrapper {
 
 class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
  public:
-  explicit inline FileLoader(const OpSpec& spec,
-      vector<std::pair<string, int>> image_label_pairs = std::vector<std::pair<string, int>>())
+  explicit inline FileLoader(
+    const OpSpec& spec,
+    vector<std::pair<string, int>> image_label_pairs = std::vector<std::pair<string, int>>(),
+    bool shuffle_after_epoch = false)
     : Loader<CPUBackend, ImageLabelWrapper>(spec),
       file_root_(spec.GetArgument<string>("file_root")),
       image_label_pairs_(image_label_pairs),
-      current_index_(0) {
+      shuffle_after_epoch_(shuffle_after_epoch),
+      current_index_(0),
+      current_epoch_(0) {
     file_list_ = spec.GetArgument<string>("file_list");
     mmap_reserver = FileStream::FileStreamMappinReserver(
         static_cast<unsigned int>(initial_buffer_fill_));
@@ -97,13 +101,23 @@ class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
     } else {
       current_index_ = 0;
     }
+
+    current_epoch_++;
+
+    if (shuffle_after_epoch_) {
+      std::mt19937 g(524287 + current_epoch_);
+      std::shuffle(image_label_pairs_.begin(), image_label_pairs_.end(), g);
+    }
   }
+
   using Loader<CPUBackend, ImageLabelWrapper>::shard_id_;
   using Loader<CPUBackend, ImageLabelWrapper>::num_shards_;
 
   string file_root_, file_list_;
   vector<std::pair<string, int>> image_label_pairs_;
+  bool shuffle_after_epoch_;
   Index current_index_;
+  int current_epoch_;
   FileStream::FileStreamMappinReserver mmap_reserver;
 };
 


### PR DESCRIPTION
Added `after_epoch_shuffle` option to `COCReader`
Fixed `file_list` option support for `COCOReader`

Signed-off-by: Albert Wolant <awolant@nvidia.com>