### PR TITLE
Unify random crop generation.

### DIFF
--- a/dali/pipeline/operators/decoder/host_decoder_random_crop.cc
+++ b/dali/pipeline/operators/decoder/host_decoder_random_crop.cc
@@ -57,7 +57,7 @@ Output of the decoder is in `HWC` ordering.)code")
   .NumInput(1)
   .NumOutput(1)
   .AddOptionalArg("random_aspect_ratio",
-      R"code(Range from which to choose random aspect ratio.)code",
+      R"code(Range from which to choose random aspect ratio (width/height).)code",
       std::vector<float>{3./4., 4./3.})
   .AddOptionalArg("random_area",
       R"code(Range from which to choose random area factor `A`.

--- a/dali/pipeline/operators/resize/random_resized_crop.cc
+++ b/dali/pipeline/operators/resize/random_resized_crop.cc
@@ -29,7 +29,7 @@ DALI_SCHEMA(RandomResizedCrop)
   .NumOutput(1)
   .AllowMultipleInputSets()
   .AddOptionalArg("random_aspect_ratio",
-      R"code(Range from which to choose random aspect ratio.)code",
+      R"code(Range from which to choose random aspect ratio (width/height).)code",
       std::vector<float>{3./4., 4./3.})
   .AddOptionalArg("random_area",
       R"code(Range from which to choose random area factor `A`.
@@ -45,39 +45,6 @@ Before resizing, the cropped image's area will be equal to `A` * original image'
       R"code(Maximum number of attempts used to choose random area and aspect ratio.)code",
       10)
   .EnforceInputLayout(DALI_NHWC);
-
-template<>
-struct RandomResizedCrop<CPUBackend>::Params {
-  std::vector<std::mt19937> rand_gens;
-  std::vector<std::uniform_real_distribution<float>> aspect_ratio_dis;
-  std::vector<std::uniform_real_distribution<float>> area_dis;
-  std::vector<std::uniform_real_distribution<float>> uniform;
-
-  std::vector<CropInfo> crops;
-};
-
-template<>
-void RandomResizedCrop<CPUBackend>::InitParams(const OpSpec &spec) {
-  params_->rand_gens.resize(batch_size_);
-  std::seed_seq seq{spec.GetArgument<int64_t>("seed")};
-  std::vector<int> seeds(batch_size_);
-  seq.generate(seeds.begin(), seeds.end());
-  for (size_t i = 0; i < seeds.size(); ++i) {
-    params_->rand_gens[i].seed(seeds[i]);
-  }
-  params_->aspect_ratio_dis.resize(batch_size_);
-  params_->area_dis.resize(batch_size_);
-  params_->uniform.resize(batch_size_);
-  for (size_t i = 0; i < params_->aspect_ratio_dis.size(); ++i) {
-    params_->aspect_ratio_dis[i] = std::uniform_real_distribution<float>(aspect_ratios_[0],
-                                                                         aspect_ratios_[1]);
-    params_->area_dis[i] = std::uniform_real_distribution<float>(area_[0],
-                                                                 area_[1]);
-    params_->uniform[i] = std::uniform_real_distribution<float>(0, 1);
-  }
-
-  params_->crops.resize(batch_size_);
-}
 
 template<>
 void RandomResizedCrop<CPUBackend>::RunImpl(SampleWorkspace * ws, const int idx) {
@@ -96,7 +63,7 @@ void RandomResizedCrop<CPUBackend>::RunImpl(SampleWorkspace * ws, const int idx)
   output.set_type(input.type());
   output.Resize({newH, newW, C});
 
-  const CropInfo &crop = params_->crops[ws->data_idx()];
+  const CropWindow &crop = params_->crops[ws->data_idx()];
   int channel_flag = C == 3 ? CV_8UC3 : CV_8UC1;
   const uint8_t *img = input.data<uint8_t>();
 
@@ -125,31 +92,9 @@ void RandomResizedCrop<CPUBackend>::SetupSharedSampleParams(SampleWorkspace *ws)
 
   int H = input_shape[0];
   int W = input_shape[1];
-
-  CropInfo crop;
-  int attempt = 0;
   int id = ws->data_idx();
 
-  for (attempt = 0; attempt < num_attempts_; ++attempt) {
-    if (TryCrop(H, W,
-                params_->aspect_ratio_dis[id],
-                params_->area_dis[id],
-                params_->uniform[id],
-                params_->rand_gens[id],
-                crop)) {
-      break;
-    }
-  }
-
-  if (attempt == num_attempts_) {
-    int min_dim = H < W ? H : W;
-    crop.w = min_dim;
-    crop.h = min_dim;
-    crop.x = (W - min_dim) / 2;
-    crop.y = (H - min_dim) / 2;
-  }
-
-  params_->crops[id] = crop;
+  params_->crops[id] = params_->crop_gens[id].GenerateCropWindow(H, W);
 }
 
 DALI_REGISTER_OPERATOR(RandomResizedCrop, RandomResizedCrop<CPUBackend>, CPU);

--- a/dali/pipeline/operators/resize/resize.cc
+++ b/dali/pipeline/operators/resize/resize.cc
@@ -22,12 +22,13 @@ DALI_SCHEMA(ResizeAttr)
   .AddOptionalArg("image_type",
         R"code(The color space of input and output image.)code", DALI_RGB)
   .AddOptionalArg("interp_type",
-      R"code(Type of interpolation used.)code",
+      R"code(Type of interpolation used. Use `min_filter` and `mag_filter` to specify
+      different filtering for downscaling and upscaling.)code",
       DALI_INTERP_LINEAR)
   .AddOptionalArg("mag_filter", "Filter used when scaling up",
       DALI_INTERP_LINEAR)
   .AddOptionalArg("min_filter", "Filter used when scaling down",
-      DALI_INTERP_LINEAR)
+      DALI_INTERP_TRIANGULAR)
   .AddOptionalArg("resize_x", "The length of the X dimension of the resized image. "
       "This option is mutually exclusive with `resize_shorter`. "
       "If the `resize_y` is left at 0, then the op will keep "

--- a/dali/util/random_crop_generator.cc
+++ b/dali/util/random_crop_generator.cc
@@ -26,63 +26,89 @@ RandomCropGenerator::RandomCropGenerator(
   : aspect_ratio_dis_(aspect_ratio_range.first, aspect_ratio_range.second)
   , inv_aspect_ratio_dis_(1/aspect_ratio_range.second, 1/aspect_ratio_range.first)
   , area_dis_(area_range.first, area_range.second)
-  , uniform_(0.0f, 1.0f)
   , rand_gen_(seed)
   , seed_(seed)
   , num_attempts_(num_attempts) {
 }
 
 CropWindow RandomCropGenerator::GenerateCropWindowImpl(int H, int W) {
-    DALI_ENFORCE(H > 0);
-    DALI_ENFORCE(W > 0);
+  CropWindow crop = {};
+  if (W <= 0 || H <= 0) {
+    return crop;
+  }
 
-    for (int attempt = 0; attempt < num_attempts_; attempt++) {
-        float scale = area_dis_(rand_gen_);
-        bool swap = coin_flip_(rand_gen_);
+  float min_wh_ratio = aspect_ratio_dis_.param().a();
+  float max_wh_ratio = aspect_ratio_dis_.param().b();
+  float max_hw_ratio = inv_aspect_ratio_dis_.param().b();
+  float min_area = W * H * area_dis_.a();
+  int maxW = std::max<int>(1, H * max_wh_ratio);
+  int maxH = std::max<int>(1, W * max_hw_ratio);
 
-        size_t original_area = H * W;
-        float target_area = scale * original_area;
+  // detect two impossible cases early
+  if (H * maxW < min_area) {  // image too wide
+    crop.h = H;
+    crop.w = maxW;
+  } else if (W * maxH < min_area) {  // image too tall
+    crop.w = W;
+    crop.h = maxH;
+  } else {
+    // it can still fail for very small images when size granularity matters
+    int attempts_left = num_attempts_;
+    for (; attempts_left > 0; attempts_left--) {
+      float scale = area_dis_(rand_gen_);
+      bool swap = coin_flip_(rand_gen_);
 
-        int w, h;
+      size_t original_area = H * W;
+      float target_area = scale * original_area;
 
-        // Uniform distribution is not suitable for aspect ratios. Here, we randomly
-        // draw either W/H or H/W aspec ratio which has a mean equal 1 for ranges with
-        // reciprocal aspect ratio ranges, such as 3/4..4/3
-        if (swap) {
-          float ratio = inv_aspect_ratio_dis_(rand_gen_);
-          w = static_cast<int>(
-              std::roundf(sqrtf(target_area / ratio)));
-          h = static_cast<int>(
-              std::roundf(sqrtf(target_area * ratio)));
-        } else {
-          float ratio = aspect_ratio_dis_(rand_gen_);
-          w = static_cast<int>(
-              std::roundf(sqrtf(target_area * ratio)));
-          h = static_cast<int>(
-              std::roundf(sqrtf(target_area / ratio)));
-        }
+      // Uniform distribution is not suitable for aspect ratios. Here, we randomly
+      // draw either W/H or H/W aspec ratio which has a mean equal 1 for ranges with
+      // reciprocal aspect ratio ranges, such as 3/4..4/3
+      if (swap) {
+        float ratio = inv_aspect_ratio_dis_(rand_gen_);
+        crop.w = static_cast<int>(
+            std::roundf(sqrtf(target_area / ratio)));
+        crop.h = static_cast<int>(
+            std::roundf(sqrtf(target_area * ratio)));
+      } else {
+        float ratio = aspect_ratio_dis_(rand_gen_);
+        crop.w = static_cast<int>(
+            std::roundf(sqrtf(target_area * ratio)));
+        crop.h = static_cast<int>(
+            std::roundf(sqrtf(target_area / ratio)));
+      }
+      if (crop.w < 1)
+        crop.w = 1;
+      if (crop.h < 1)
+        crop.h = 1;
 
-        CropWindow crop;
-        if (w > 0 && h > 0 && w <= W && h <= H) {
-            float rand_x = uniform_(rand_gen_);
-            float rand_y = uniform_(rand_gen_);
-
-            crop.w = w;
-            crop.h = h;
-            crop.x = static_cast<int>(rand_x * (W - w));
-            crop.y = static_cast<int>(rand_y * (H - h));
-            return crop;
-        }
+      float ratio = static_cast<float>(crop.w) / crop.h;
+      if (crop.w <= W && crop.h <= H && ratio >= min_wh_ratio && ratio <= max_wh_ratio)
+        break;
     }
 
-    // If kMaxAttempts were consumed, use default crop
-    int min_dim = H < W ? H : W;
-    CropWindow crop;
-    crop.w = min_dim;
-    crop.h = min_dim;
-    crop.x = (W - min_dim) / 2;
-    crop.y = (H - min_dim) / 2;
-    return crop;
+    if (attempts_left <= 0) {
+      float max_area = area_dis_.param().b() * W * H;
+      float ratio = static_cast<float>(W)/H;
+      if (ratio > max_wh_ratio) {
+        crop.h = H;
+        crop.w = maxW;
+      } else if (ratio < min_wh_ratio) {
+        crop.w = W;
+        crop.h = maxH;
+      } else {
+        crop.w = W;
+        crop.h = H;
+      }
+      float scale = std::min(1.0f, max_area / (crop.w * crop.h));
+      crop.w = std::max<int>(1, crop.w * sqrt(scale));
+      crop.h = std::max<int>(1, crop.h * sqrt(scale));
+    }
+  }
+
+  crop.x = std::uniform_int_distribution<int>(0, W - crop.w)(rand_gen_);
+  crop.y = std::uniform_int_distribution<int>(0, H - crop.h)(rand_gen_);
+  return crop;
 }
 
 CropWindow RandomCropGenerator::GenerateCropWindow(int H, int W) {

--- a/dali/util/random_crop_generator.h
+++ b/dali/util/random_crop_generator.h
@@ -28,20 +28,19 @@ using AreaRange = std::pair<float, float>;
 
 class DLL_PUBLIC RandomCropGenerator {
  public:
-  RandomCropGenerator(AspectRatioRange aspect_ratio_range,
-                      AreaRange area_range,
-                      int64_t seed = time(0),
-                      int num_attempts_ = 10);
+  explicit DLL_PUBLIC RandomCropGenerator(
+    AspectRatioRange aspect_ratio_range = { 3.0f/4, 4.0f/3 },
+    AreaRange area_range = { 0.08, 1 },
+    int64_t seed = time(0),
+    int num_attempts_ = 10);
 
   DLL_PUBLIC CropWindow GenerateCropWindow(int H, int W);
   DLL_PUBLIC std::vector<CropWindow> GenerateCropWindows(int H, int W, std::size_t N);
-
  private:
   CropWindow GenerateCropWindowImpl(int H, int W);
 
   std::uniform_real_distribution<float> aspect_ratio_dis_, inv_aspect_ratio_dis_;
   std::uniform_real_distribution<float> area_dis_;
-  std::uniform_real_distribution<float> uniform_;
   std::bernoulli_distribution coin_flip_;
   std::mt19937 rand_gen_;
   int64_t seed_;

--- a/dali/util/random_crop_generator.h
+++ b/dali/util/random_crop_generator.h
@@ -39,9 +39,11 @@ class DLL_PUBLIC RandomCropGenerator {
  private:
   CropWindow GenerateCropWindowImpl(int H, int W);
 
-  std::uniform_real_distribution<float> aspect_ratio_dis_, inv_aspect_ratio_dis_;
+  AspectRatioRange aspect_ratio_range_;
+  // Aspect ratios are uniformly distributed on logarithmic scale.
+  // This provides natural symmetry and smoothness of the distribution.
+  std::uniform_real_distribution<float> aspect_ratio_log_dis_;
   std::uniform_real_distribution<float> area_dis_;
-  std::bernoulli_distribution coin_flip_;
   std::mt19937 rand_gen_;
   int64_t seed_;
   int num_attempts_;


### PR DESCRIPTION
Remove random crop window generation from RandomResizedCrop and use RandomCropGenerator.
Fix numerical issues in RandomCropGenerator.
Add fast path to RandomCropGenerator when it's impossible to generate a crop that's in defined ratio and area bounds.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>