### PR TITLE
Change DALIOpType to dali::OpType enum class

### DIFF
--- a/dali/common.h
+++ b/dali/common.h
@@ -55,6 +55,29 @@ using uint32 = uint32_t;
 // Basic data type for our indices and dimension sizes
 typedef int64_t Index;
 
+enum class OpType {
+  GPU = 0,
+  CPU = 1,
+  MIXED = 2,
+  SUPPORT = 3,
+  COUNT = 4
+};
+
+static std::string to_string(OpType op_type) {
+  switch (op_type) {
+    case OpType::CPU:
+      return "cpu";
+    case OpType::GPU:
+      return "gpu";
+    case OpType::MIXED:
+      return "mixed";
+    case OpType::SUPPORT:
+      return "support";
+    default:
+      return "<invalid>";
+  }
+}
+
 struct DALISize {
     int width;
     int height;

--- a/dali/pipeline/executor/executor_test.cc
+++ b/dali/pipeline/executor/executor_test.cc
@@ -374,7 +374,7 @@ TEST_F(ExecutorTest, TestRunBasicGraph) {
   exe.Build(&graph, outputs);
 
   // Set the data for the external source
-  auto *src_op = dynamic_cast<ExternalSource<CPUBackend>*>(&graph.cpu_op(0));
+  auto *src_op = dynamic_cast<ExternalSource<CPUBackend>*>(graph.cpu_node(0).op.get());
   ASSERT_NE(src_op, nullptr);
   TensorList<CPUBackend> tl;
   this->MakeJPEGBatch(&tl, this->batch_size_);
@@ -421,7 +421,7 @@ TEST_F(ExecutorTest, TestRunBasicGraphWithCB) {
   exe.Build(&graph, outputs);
 
   // Set the data for the external source
-  auto *src_op = dynamic_cast<ExternalSource<CPUBackend>*>(&graph.cpu_op(0));
+  auto *src_op = dynamic_cast<ExternalSource<CPUBackend>*>(graph.cpu_node(0).op.get());
   ASSERT_NE(src_op, nullptr);
   TensorList<CPUBackend> tl;
   this->MakeJPEGBatch(&tl, this->batch_size_);
@@ -479,7 +479,7 @@ TEST_F(ExecutorTest, TestPrefetchedExecution) {
   exe.Build(&graph, outputs);
 
   // Set the data for the external source
-  auto *src_op = dynamic_cast<ExternalSource<CPUBackend>*>(&graph.cpu_op(0));
+  auto *src_op = dynamic_cast<ExternalSource<CPUBackend>*>(graph.cpu_node(0).op.get());
   ASSERT_NE(src_op, nullptr);
   TensorList<CPUBackend> tl;
   this->MakeJPEGBatch(&tl, this->batch_size_*2);

--- a/dali/pipeline/op_graph.h
+++ b/dali/pipeline/op_graph.h
@@ -30,7 +30,7 @@
 
 namespace dali {
 
-typedef int64 NodeID;
+using NodeID = int64_t;
 
 struct OpNode {
   inline OpNode() {}
@@ -117,32 +117,12 @@ class DLL_PUBLIC OpGraph {
   DLL_PUBLIC inline Index NumSupportOp() const { return support_nodes_.size(); }
 
   /**
-   * @brief Returns a reference to the `idx`-th cpu op that was
-   * added to the graph.
-   */
-  DLL_PUBLIC inline OperatorBase& cpu_op(Index idx) {
-    DALI_ENFORCE_VALID_INDEX(idx, (Index)cpu_nodes_.size());
-    DALI_ENFORCE(cpu_nodes_[idx].op != nullptr, "Operator instance is empty");
-    return *cpu_nodes_[idx].op;
-  }
-
-  /**
    * @brief Returns the node object for the `idx`-th cpu op that
    * was added to the graph.
    */
   DLL_PUBLIC inline OpNode& cpu_node(Index idx) {
     DALI_ENFORCE_VALID_INDEX(idx, (Index)cpu_nodes_.size());
     return cpu_nodes_[idx];
-  }
-
-  /**
-   * @brief Returns a reference to the `idx`-th gpu op that
-   * was added to the graph.
-   */
-  DLL_PUBLIC inline OperatorBase& gpu_op(Index idx) {
-    DALI_ENFORCE_VALID_INDEX(idx, (Index)gpu_nodes_.size());
-    DALI_ENFORCE(gpu_nodes_[idx].op != nullptr, "Operator instance is empty");
-    return *gpu_nodes_[idx].op;
   }
 
   /**
@@ -155,32 +135,12 @@ class DLL_PUBLIC OpGraph {
   }
 
   /**
-   * @brief Returns a reference to the `idx`-th mixed op
-   * that was added to the graph.
-   */
-  DLL_PUBLIC inline OperatorBase& mixed_op(Index idx) {
-    DALI_ENFORCE_VALID_INDEX(idx, (Index)mixed_nodes_.size());
-    DALI_ENFORCE(mixed_nodes_[idx].op != nullptr, "Operator instance is empty");
-    return *mixed_nodes_[idx].op;
-  }
-
-  /**
    * @brief Returns the node object for the `idx`-th mixed op that
    * was added to the graph.
    */
   DLL_PUBLIC inline OpNode& mixed_node(Index idx) {
     DALI_ENFORCE_VALID_INDEX(idx, (Index)mixed_nodes_.size());
     return mixed_nodes_[idx];
-  }
-
-  /**
-   * @brief Returns a reference to the `idx`-th support op
-   * that was added to the graph.
-   */
-  DLL_PUBLIC inline OperatorBase& support_op(Index idx) {
-    DALI_ENFORCE_VALID_INDEX(idx, (Index)support_nodes_.size());
-    DALI_ENFORCE(support_nodes_[idx].op != nullptr, "Operator instance is empty");
-    return *support_nodes_[idx].op;
   }
 
   /**
@@ -209,7 +169,7 @@ class DLL_PUBLIC OpGraph {
    * @brief Returns the type (cpu, gpu, mixed) of the node
    * at the given index.
    */
-  DLL_PUBLIC inline DALIOpType NodeType(NodeID id) const {
+  DLL_PUBLIC inline OpType NodeType(NodeID id) const {
     DALI_ENFORCE_VALID_INDEX(id, (Index)id_to_node_map_.size());
     return id_to_node_map_[id].first;
   }
@@ -285,20 +245,21 @@ class DLL_PUBLIC OpGraph {
    * map.
    */
   DLL_PUBLIC const OpNode& GetNodeForIdx(int idx) const {
-    DALIOpType type = id_to_node_map_[idx].first;
+    OpType type = id_to_node_map_[idx].first;
     Index index = id_to_node_map_[idx].second;
     switch (type) {
-    case DALI_CPU:
+    case OpType::CPU:
       return cpu_nodes_[index];
-    case DALI_GPU:
+    case OpType::GPU:
       return gpu_nodes_[index];
-    case DALI_MIXED:
+    case OpType::MIXED:
       return mixed_nodes_[index];
-    case DALI_SUPPORT:
+    case OpType::SUPPORT:
       return support_nodes_[index];
+    default:
+      string str_error = "No Node for index " + to_string(idx);
+      DALI_FAIL(str_error);
     }
-    string str_error = "No Node for index " + to_string(idx);
-    DALI_FAIL(str_error);
   }
 
 
@@ -350,7 +311,7 @@ class DLL_PUBLIC OpGraph {
   // Stores a mapping from NodeIDs to a pair where the first
   // element indicates what type of node it is,  and the second
   // is the index of the op within the specified vector.
-  vector<std::pair<DALIOpType, Index>> id_to_node_map_;
+  vector<std::pair<OpType, Index>> id_to_node_map_;
 
   std::map<string, TensorMeta> tensor_producers_;
   std::map<string, vector<TensorMeta>> tensor_consumers_;

--- a/dali/pipeline/operators/fused/crop_mirror_normalize_test.cc
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize_test.cc
@@ -33,7 +33,7 @@ class CropMirrorNormalizePermuteTest : public GenericMatchingTest<ImgType> {
     this->SetExternalInputs({{"jpegs", &data}});
 
     string device(deviceName);
-    this->setOpType(device == "gpu" ? DALI_GPU : DALI_CPU);
+    this->SetOpType(device == "gpu" ? OpType::GPU : OpType::CPU);
     OpSpec spec = OpSpec(opName)
                       .AddArg("device", device)
                       .AddInput("images", device)

--- a/dali/pipeline/operators/operator.h
+++ b/dali/pipeline/operators/operator.h
@@ -33,13 +33,6 @@
 
 namespace dali {
 
-enum DALIOpType {
-  DALI_GPU = 0,
-  DALI_CPU = 1,
-  DALI_MIXED = 2,
-  DALI_SUPPORT = 3
-};
-
 template <typename InputType>
 inline void CheckInputLayout(const InputType& input, const OpSpec& spec) {
   auto &schema = SchemaRegistry::GetSchema(spec.name());

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -137,7 +137,7 @@ class DLL_PUBLIC Pipeline {
       return;
     }
     NodeID node_id = graph_.TensorSourceID(name + "_cpu");
-    DALI_ENFORCE(graph_.NodeType(node_id) == DALI_CPU,
+    DALI_ENFORCE(graph_.NodeType(node_id) == OpType::CPU,
         "Internal error setting external input data.");
 
     auto &node = graph_.node(node_id);

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -169,7 +169,7 @@ class PipelineTest : public DALITest {
     ASSERT_EQ(graph.NumMixedOp(), 1);
     ASSERT_EQ(graph.NumGPUOp(), 1);
 
-    ASSERT_EQ(graph.mixed_op(0).name(), "MakeContiguous");
+    ASSERT_EQ(graph.mixed_node(0).op->name(), "MakeContiguous");
 
     // Validate the source op
     auto &node = graph.node(0);

--- a/dali/test/dali_test_matching.h
+++ b/dali/test/dali_test_matching.h
@@ -2,11 +2,13 @@
 #ifndef DALI_TEST_DALI_TEST_MATCHING_H_
 #define DALI_TEST_DALI_TEST_MATCHING_H_
 
-#include "dali/test/dali_test_single_op.h"
+#include <memory>
+#include <string>
 #include <utility>
 #include <vector>
-#include <string>
-#include <memory>
+
+#include "dali/common.h"
+#include "dali/test/dali_test_single_op.h"
 
 namespace dali {
 
@@ -43,7 +45,7 @@ class GenericMatchingTest : public DALISingleOpTest<ImgType, OutputImgType> {
 
   vector<TensorList<CPUBackend>*>
   Reference(const vector<TensorList<CPUBackend>*> &inputs, DeviceWorkspace *ws) override {
-    if (OpType() == DALI_GPU)
+    if (GetOpType() == OpType::GPU)
       return this->CopyToHost(ws->Output<GPUBackend>(1));
     else
       return this->CopyToHost(ws->Output<CPUBackend>(1));
@@ -70,11 +72,11 @@ class GenericMatchingTest : public DALISingleOpTest<ImgType, OutputImgType> {
     }
   }
 
-  inline DALIOpType OpType() const                { return m_nOpType; }
-  inline void setOpType(DALIOpType opType)        { m_nOpType = opType; }
+  inline OpType GetOpType() const                { return op_type_; }
+  inline void SetOpType(OpType opType)        { op_type_ = opType; }
 
 
-  DALIOpType m_nOpType = DALI_GPU;
+  OpType op_type_ = OpType::GPU;
 };
 
 }  // namespace dali


### PR DESCRIPTION
Remove cpu_op(), gpu_op(), etc from OpGraph
to simplify access to nodes.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>