### PR TITLE
Add ROI-based GPU resampling

### DIFF
--- a/dali/kernels/imgproc/resample/bilinear_impl.cuh
+++ b/dali/kernels/imgproc/resample/bilinear_impl.cuh
@@ -81,13 +81,13 @@ __device__ void LinearHorz(
   VALUE_SWITCH(channels, static_channels, (1, 2, 3, 4),
   (
     LinearHorz_Channels<static_channels>(
-      x0, x1, y0, y1, 0, scale,
+      x0, x1, y0, y1, src_x0, scale,
       out, out_stride, in, in_stride, in_w,
       static_channels);
   ),  // NOLINT
   (
     LinearHorz_Channels<-1>(
-      x0, x1, y0, y1, 0, scale,
+      x0, x1, y0, y1, src_x0, scale,
       out, out_stride, in, in_stride, in_w,
       channels);
   ));  // NOLINT

--- a/dali/kernels/imgproc/resample/params.h
+++ b/dali/kernels/imgproc/resample/params.h
@@ -60,9 +60,20 @@ struct FilterDesc {
   float radius = 0;
 };
 
+/// @brief Resampling parameters for 1 dimension
 struct ResamplingParams {
   FilterDesc min_filter, mag_filter;
-  int output_size;
+  int output_size = KeepOriginalSize;
+
+  /// @brief 1D region of interest
+  struct ROI {
+    ROI() = default;
+    ROI(float start, float end) : use_roi(true), start(start), end(end) {}
+    bool use_roi = false;
+    float start = 0;
+    float end = 0;
+  };
+  ROI roi;
 };
 
 using ResamplingParams2D = std::array<ResamplingParams, 2>;

--- a/dali/kernels/imgproc/resample/resampling_impl.cuh
+++ b/dali/kernels/imgproc/resample/resampling_impl.cuh
@@ -254,13 +254,13 @@ __device__ void ResampleHorz(
   VALUE_SWITCH(channels, static_channels, (1, 2, 3, 4),
   (
     ResampleHorz_Channels<static_channels>(
-      x0, x1, y0, y1, 0, scale,
+      x0, x1, y0, y1, src_x0, scale,
       out, out_stride, in, in_stride, in_w,
       static_channels, filter, support);
   ),  // NOLINT
   (
     ResampleHorz_Channels<-1>(
-      x0, x1, y0, y1, 0, scale,
+      x0, x1, y0, y1, src_x0, scale,
       out, out_stride, in, in_stride, in_w,
       channels, filter, support);
   ));  // NOLINT
@@ -279,13 +279,13 @@ __device__ void ResampleVert(
   VALUE_SWITCH(channels, static_channels, (1, 2, 3, 4),
   (
     ResampleVert_Channels<static_channels>(
-      x0, x1, y0, y1, 0, scale,
+      x0, x1, y0, y1, src_y0, scale,
       out, out_stride, in, in_stride, in_h,
       static_channels, filter, support);
   ),  // NOLINT
   (
     ResampleVert_Channels<-1>(
-      x0, x1, y0, y1, 0, scale,
+      x0, x1, y0, y1, src_y0, scale,
       out, out_stride, in, in_stride, in_h,
       channels, filter, support);
   ));  // NOLINT

--- a/dali/kernels/imgproc/resample/resampling_setup.cc
+++ b/dali/kernels/imgproc/resample/resampling_setup.cc
@@ -21,19 +21,75 @@ namespace kernels {
 inline ResamplingFilter GetResamplingFilter(
     const ResamplingFilters *filters, const FilterDesc &params) noexcept {
   switch (params.type) {
-    case ResamplingFilterType::Gaussian:
-      return filters->Gaussian(params.radius*0.5f/M_SQRT2);
+    case ResamplingFilterType::Linear:
+      return filters->Triangular(1);
     case ResamplingFilterType::Triangular:
       return filters->Triangular(params.radius);
-    case ResamplingFilterType::Lanczos3:
-      return filters->Lanczos3();
+    case ResamplingFilterType::Gaussian:
+      return filters->Gaussian(params.radius*0.5f/M_SQRT2);
     case ResamplingFilterType::Cubic:
       return filters->Cubic();
+    case ResamplingFilterType::Lanczos3:
+      return filters->Lanczos3();
     default:
       return { nullptr, 0, 0, 0 };
   }
 }
 
+void SeparableResamplingSetup::SetFilters(SampleDesc &desc, const ResamplingParams2D &params) {
+  const auto &out_shape = desc.shapes[IdxOut];
+  for (int axis = 0; axis < 2; axis++) {
+    float in_size;
+    if (params[axis].roi.use_roi) {
+      in_size = std::abs(params[axis].roi.end - params[axis].roi.start);
+    } else {
+      in_size = desc.shapes[IdxIn][axis];
+    }
+
+    auto fdesc = out_shape[axis] < in_size ? params[axis].min_filter
+                                           : params[axis].mag_filter;
+    if (fdesc.radius == 0)
+      fdesc.radius = DefaultFilterRadius(fdesc.type, in_size, out_shape[axis]);
+    desc.filter_type[axis] = fdesc.type;
+    auto &filter = desc.filter[axis];
+    filter = GetResamplingFilter(filters.get(), fdesc);
+  }
+}
+
+SeparableResamplingSetup::ROI SeparableResamplingSetup::ComputeScaleAndROI(
+    SampleDesc &desc, const ResamplingParams2D &params) {
+  ROI roi;
+
+  for (int axis = 0; axis < 2; axis++) {
+    float roi_start, roi_end;
+    if (params[axis].roi.use_roi) {
+      roi_start = params[axis].roi.start;
+      roi_end = params[axis].roi.end;
+    } else {
+      roi_start = 0;
+      roi_end = desc.shapes[IdxIn][axis];
+    }
+    desc.origin[axis] = roi_start;
+    desc.scale[axis] = (roi_end-roi_start) / desc.shapes[IdxOut][axis];
+
+    auto &filter = desc.filter[axis];
+
+    int support = filter.num_coeffs ? filter.support() : 1;
+
+    float lo, hi;
+    if (roi_start <= roi_end) {
+      lo = roi_start - filter.anchor;
+      hi = roi_end - filter.anchor + support;
+    } else {  // flipped
+      lo = roi_end - filter.anchor;
+      hi = roi_start - filter.anchor + support;
+    }
+    roi.lo[axis] = std::max<int>(0, std::min<int>(desc.shapes[IdxIn][axis], std::floor(lo)));
+    roi.hi[axis] = std::max<int>(0, std::min<int>(desc.shapes[IdxIn][axis], std::floor(hi)));
+  }
+
+  return roi;
+}
 
 void SeparableResamplingSetup::SetupComputation(
     const TensorListShape<3> &in, const Params &params) {
@@ -69,61 +125,66 @@ void SeparableResamplingSetup::SetupComputation(
     ts_out[1] = out_W;
     ts_out[2] = C;
 
-    desc.shapes[0] = {{ H, W }};
-    desc.shapes[2] = {{ out_H, out_W }};
-    desc.origin = {{ 0, 0 }};
-    desc.scale[0] = static_cast<float>(H)/out_H;
-    desc.scale[1] = static_cast<float>(W)/out_W;
+    desc.shapes[IdxIn] = {{ H, W }};
+    desc.shapes[IdxOut] = {{ out_H, out_W }};
+    SetFilters(desc, params[i]);
+    ROI roi = ComputeScaleAndROI(desc, params[i]);
 
-    int size_vert = W * out_H;
-    int size_horz = H * out_W;
-    int filter_support[2];
-    for (int axis = 0; axis < 2; axis++) {
-      auto fdesc = ts_out[axis] < ts_in[axis] ? params[i][axis].min_filter
-                                              : params[i][axis].mag_filter;
-      if (fdesc.radius == 0)
-        fdesc.radius = DefaultFilterRadius(fdesc.type, ts_in[axis], ts_out[axis]);
-      desc.filter_type[axis] = fdesc.type;
-      auto &filter = desc.filter[axis];
-      filter = GetResamplingFilter(filters.get(), fdesc);
-      filter_support[axis] = filter.num_coeffs > 0 ? filter.support() : 1;
-    }
-    int compute_vert = size_vert * filter_support[0];
-    int compute_horz = size_horz * filter_support[1];
+    int size_vert = roi.size(1) * out_H;
+    int size_horz = roi.size(0) * out_W;
+    int filter_support[2] = {
+      std::max(1, desc.filter[0].support()),
+      std::max(1, desc.filter[1].support())
+    };
+
+    int compute_vh = size_vert * filter_support[0] + out_W * out_H * filter_support[1];
+    int compute_hv = size_horz * filter_support[1] + out_W * out_H * filter_support[0];
 
     // ...maybe fine tune the size/compute weights?
     const float size_weight = 3;
-    float cost_vert = size_weight*size_vert + compute_vert;
-    float cost_horz = size_weight*size_horz + compute_horz;
+    float cost_vert = size_weight*size_vert + compute_vh;
+    float cost_horz = size_weight*size_horz + compute_hv;
 
     auto ts_tmp = intermediate_shape.tensor_shape_span(i);
     if (cost_vert < cost_horz) {
       sample_descs[i].order = VertHorz;
       ts_tmp[0] = out_H;
-      ts_tmp[1] = W;
+      ts_tmp[1] = roi.size(1);
       desc.block_count.pass[0] = (out_H + block_size.y - 1) / block_size.y;
       desc.block_count.pass[1] = (out_W + block_size.x - 1) / block_size.x;
     } else {
       sample_descs[i].order = HorzVert;
-      ts_tmp[0] = H;
+      ts_tmp[0] = roi.size(0);
       ts_tmp[1] = out_W;
       desc.block_count.pass[0] = (out_W + block_size.x - 1) / block_size.x;
       desc.block_count.pass[1] = (out_H + block_size.y - 1) / block_size.y;
     }
     ts_tmp[2] = C;
-    desc.shapes[1] = {{ static_cast<int>(ts_tmp[0]), static_cast<int>(ts_tmp[1]) }};
+    desc.shapes[IdxTmp] = {{ static_cast<int>(ts_tmp[0]), static_cast<int>(ts_tmp[1]) }};
 
     for (int stage = 0; stage < 3; stage++)
       desc.strides[stage] = desc.shapes[stage][1] * C;
     desc.channels = C;
 
-    desc.offsets = {{ in_offset, tmp_offset, out_offset }};
+    desc.offsets[IdxIn] = in_offset;
+    desc.offsets[IdxTmp] = tmp_offset;
+    desc.offsets[IdxOut] = out_offset;
+
+    if (desc.order == VertHorz) {
+      desc.origin[1] -= roi.lo[1];
+      desc.offsets[IdxIn] += roi.lo[1] * desc.channels;
+      desc.shapes[IdxIn][1] = roi.size(1);
+    } else {
+      desc.origin[0] -= roi.lo[0];
+      desc.offsets[IdxIn] += roi.lo[0] * desc.strides[IdxIn];
+      desc.shapes[IdxIn][0] = roi.size(0);
+    }
 
     in_offset  += volume(ts_in);
     tmp_offset += volume(ts_tmp);
     out_offset += volume(ts_out);
 
-    total_blocks.pass[0]  += desc.block_count.pass[0];
+    total_blocks.pass[0] += desc.block_count.pass[0];
     total_blocks.pass[1] += desc.block_count.pass[1];
   }
   intermediate_size = tmp_offset;

--- a/dali/kernels/imgproc/resample/resampling_setup.h
+++ b/dali/kernels/imgproc/resample/resampling_setup.h
@@ -39,6 +39,12 @@ struct SeparableResamplingSetup {
     VertHorz
   };
 
+  enum BufferIdx : int {
+    IdxIn = 0,
+    IdxTmp = 1,
+    IdxOut = 2,
+  };
+
   /// Number of blocks per pass may differ depending on
   /// the image aspect ratio and block aspect ratio.
   struct BlockCount {
@@ -78,6 +84,14 @@ struct SeparableResamplingSetup {
 
   void SetupComputation(const TensorListShape<3> &in, const Params &params);
   void InitializeSampleLookup(const OutTensorCPU<SampleBlockInfo, 1> &sample_lookup);
+
+  struct ROI {
+    int lo[2], hi[2];
+    int size(int dim) const { return hi[dim] - lo[dim]; }
+  };
+
+  void SetFilters(SampleDesc &desc, const ResamplingParams2D &params);
+  ROI ComputeScaleAndROI(SampleDesc &desc, const ResamplingParams2D &params);
 };
 
 }  // namespace kernels

--- a/dali/kernels/test/resampling_test/resampling_test_params.h
+++ b/dali/kernels/test/resampling_test/resampling_test_params.h
@@ -72,6 +72,32 @@ struct ResamplingTestEntry {
     params[1].mag_filter = params[1].min_filter = fx;
   }
 
+  ResamplingTestEntry(std::string input,
+                      std::string reference,
+                      std::array<float, 4> ROI_LTRB,
+                      std::array<int, 2> sizeWH,
+                      FilterDesc filter,
+                      double epsilon = 1)
+    : ResamplingTestEntry(
+        std::move(input), std::move(reference),
+        ROI_LTRB, sizeWH, filter, filter, epsilon) {}
+
+  ResamplingTestEntry(std::string input,
+                      std::string reference,
+                      std::array<float, 4> ROI_LTRB,
+                      std::array<int, 2> sizeWH,
+                      FilterDesc fx,
+                      FilterDesc fy,
+                      double epsilon = 1)
+    : input(std::move(input)), reference(std::move(reference)), epsilon(epsilon) {
+    params[0].output_size = sizeWH[1];
+    params[1].output_size = sizeWH[0];
+    params[0].roi = { ROI_LTRB[1], ROI_LTRB[3] };
+    params[0].mag_filter = params[0].min_filter = fy;
+    params[1].mag_filter = params[1].min_filter = fx;
+    params[1].roi = { ROI_LTRB[0], ROI_LTRB[2] };
+  }
+
   std::string input, reference;
   ResamplingParams2D params;
   double epsilon = 1;

--- a/dali/kernels/test/resampling_test/separable_cpu_test.cc
+++ b/dali/kernels/test/resampling_test/separable_cpu_test.cc
@@ -108,11 +108,10 @@ static std::vector<ResamplingTestEntry> ResampleTests = {
     "imgproc_test/score.png", "imgproc_test/ref_out/score_lanczos3.png",
     { 540, 250 }, lanczos(), 1
   },
-  // TODO(michalz): uncomment when test data propagates to CI
-  /*{
+  {
     "imgproc_test/score.png", "imgproc_test/ref_out/score_cubic.png",
     { 200, 93 }, cubic(), 1
-  },*/
+  },
   {
     "imgproc_test/alley.png", "imgproc_test/ref_out/alley_blurred.png",
     { 681, 960 }, gauss(12), 2


### PR DESCRIPTION
Resampling parameters now contain ROI.
Batch preparation now handles ROIs.
Added tests, fixed bugs.

Resampling a ROI allows the resampling filter support to extend beyond the crop window. This reduces boundary artifacts and allows for perfect stiching.
The intermediate image is sampled from the whole image (as opposed to fully cropped one) and the intermediate image is enlarged to cover the filter support before/past the specified ROI.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>
