### PR TITLE
Generalize Executor Test

### DIFF
--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -83,6 +83,7 @@ class DLL_PUBLIC Executor {
 
   DLL_PUBLIC virtual void SetCompletionCallback(ExecutorCallback cb);
 
+  template <typename T>
   friend class ExecutorTest;
 
   DISABLE_COPY_MOVE_ASSIGN(Executor);


### PR DESCRIPTION
Generalize test for executor, rebased in between, but can be merged separately.

Used by (next) #577