### PR TITLE
Use the same lock to condition for cv in ExternalSource

### DIFF
--- a/dali/pipeline/operators/util/external_source.cu
+++ b/dali/pipeline/operators/util/external_source.cu
@@ -22,7 +22,10 @@ void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace *ws, const int idx) {
 
   auto &output = ws->Output<GPUBackend>(idx);
   output.Copy(tl_data_, (ws->has_stream() ? ws->stream() : 0));
-  busy_ = false;
+  {
+    std::lock_guard<std::mutex> busy_lock(busy_m_);
+    busy_ = false;
+  }
   cv_.notify_all();
 }
 

--- a/dali/pipeline/operators/util/external_source.h
+++ b/dali/pipeline/operators/util/external_source.h
@@ -54,7 +54,7 @@ class ExternalSource : public Operator<Backend> {
     // Note: If we create a GPU source, we will need to figure
     // out what stream we want to do this copy in. CPU we can
     // pass anything as it is ignored.
-    std::unique_lock<std::mutex> lock(m_);
+    std::unique_lock<std::mutex> lock(busy_m_);
     cv_.wait(lock,  [this]{return !this->busy_;});
     tl_data_.Copy(tl, 0);
     data_in_tl_ = true;
@@ -70,7 +70,7 @@ class ExternalSource : public Operator<Backend> {
     // out what stream we want to do this copy in. CPU we can
     // pass anything as it is ignored.
 
-    std::unique_lock<std::mutex> lock(m_);
+    std::unique_lock<std::mutex> lock(busy_m_);
     cv_.wait(lock,  [this]{return !this->busy_;});
 
     t_data_.resize(t.size());
@@ -91,11 +91,11 @@ class ExternalSource : public Operator<Backend> {
   std::vector<Tensor<Backend>> t_data_;
   bool data_in_tl_;
 
-  std::atomic<int> samples_processed_;
+  int samples_processed_;
 
   bool busy_;
   std::condition_variable cv_;
-  std::mutex m_;
+  std::mutex busy_m_;
   std::mutex samples_processed_m_;
 };
 


### PR DESCRIPTION
Changes to variable that holds sleep condition
should be propagated with the same mutex

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>