### PR TITLE
Add prefetched batch queue in Reader

### DIFF
--- a/dali/pipeline/operators/reader/caffe2_reader_op.h
+++ b/dali/pipeline/operators/reader/caffe2_reader_op.h
@@ -32,7 +32,7 @@ class Caffe2Reader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   void RunImpl(SampleWorkspace* ws, const int i) override {
     const int idx = ws->data_idx();
 
-    auto* raw_data = prefetched_batch_[idx];
+    auto* raw_data = GetSample(idx);
 
     parser_->Parse(*raw_data, ws);
 

--- a/dali/pipeline/operators/reader/caffe_reader_op.h
+++ b/dali/pipeline/operators/reader/caffe_reader_op.h
@@ -32,7 +32,7 @@ class CaffeReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   void RunImpl(SampleWorkspace* ws, const int i) override {
     const int idx = ws->data_idx();
 
-    auto* raw_data = prefetched_batch_[idx];
+    auto* raw_data = GetSample(idx);
 
     parser_->Parse(*raw_data, ws);
 

--- a/dali/pipeline/operators/reader/coco_reader_op.h
+++ b/dali/pipeline/operators/reader/coco_reader_op.h
@@ -63,7 +63,7 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
   void RunImpl(SampleWorkspace* ws, const int i) override {
     const int idx = ws->data_idx();
 
-    auto* image_label = prefetched_batch_[idx];
+    auto* image_label = GetSample(idx);
 
     parser_->Parse(*image_label, ws);
 

--- a/dali/pipeline/operators/reader/file_reader_op.h
+++ b/dali/pipeline/operators/reader/file_reader_op.h
@@ -23,7 +23,7 @@ namespace dali {
 class FileReader : public DataReader<CPUBackend, ImageLabelWrapper> {
  public:
   explicit FileReader(const OpSpec& spec)
-    : DataReader<CPUBackend, ImageLabelWrapper>(spec, 2) {
+    : DataReader<CPUBackend, ImageLabelWrapper>(spec) {
     loader_.reset(new FileLoader(spec));
   }
 

--- a/dali/pipeline/operators/reader/file_reader_op.h
+++ b/dali/pipeline/operators/reader/file_reader_op.h
@@ -23,14 +23,14 @@ namespace dali {
 class FileReader : public DataReader<CPUBackend, ImageLabelWrapper> {
  public:
   explicit FileReader(const OpSpec& spec)
-    : DataReader<CPUBackend, ImageLabelWrapper>(spec) {
+    : DataReader<CPUBackend, ImageLabelWrapper>(spec, 2) {
     loader_.reset(new FileLoader(spec));
   }
 
   void RunImpl(SampleWorkspace *ws, const int i) override {
     const int idx = ws->data_idx();
 
-    auto* image_label = prefetched_batch_[idx];
+    auto* image_label = GetSample(idx);
 
     // copy from raw_data -> outputs directly
     auto &image_output = ws->Output<CPUBackend>(0);

--- a/dali/pipeline/operators/reader/loader/loader.cc
+++ b/dali/pipeline/operators/reader/loader/loader.cc
@@ -37,16 +37,15 @@ accuracy in some cases)code", false)
 RecordIO or TFRecord it will slow down first access but will decrease the time of all following
 accesses.)code", false)
   .AddOptionalArg("prefeth_queue_depth",
-      R"code(Specifies the depth of the batches prefetched by the internal Loader. When the pipeline
-is CPU stage-bound, trading memory consumption for better interleaving with the Loader thread.)code", 1);
-
+      R"code(Specifies the number of batches prefetched by the internal Loader. To be increased when pipeline
+processing is CPU stage-bound, trading memory consumption for better interleaving with the Loader thread.)code", 1);
 
 size_t start_index(const size_t shard_id,
                    const size_t shard_num,
                    const size_t size) {
   const size_t remainder = size % shard_num;
   if (shard_id < remainder) {
-    return (size / shard_num) *shard_id + shard_id;
+    return (size / shard_num) * shard_id + shard_id;
   } else {
     return (size / shard_num) * shard_id + remainder;
   }

--- a/dali/pipeline/operators/reader/loader/loader.cc
+++ b/dali/pipeline/operators/reader/loader/loader.cc
@@ -36,7 +36,7 @@ accuracy in some cases)code", false)
       R"code(Whether accessed data should be read ahead. In case of big files like LMDB,
 RecordIO or TFRecord it will slow down first access but will decrease the time of all following
 accesses.)code", false)
-  .AddOptionalArg("prefeth_queue_depth",
+  .AddOptionalArg("prefetch_queue_depth",
       R"code(Specifies the number of batches prefetched by the internal Loader. To be increased when pipeline
 processing is CPU stage-bound, trading memory consumption for better interleaving with the Loader thread.)code", 1);
 

--- a/dali/pipeline/operators/reader/loader/loader.cc
+++ b/dali/pipeline/operators/reader/loader/loader.cc
@@ -35,7 +35,10 @@ accuracy in some cases)code", false)
   .AddOptionalArg("read_ahead",
       R"code(Whether accessed data should be read ahead. In case of big files like LMDB,
 RecordIO or TFRecord it will slow down first access but will decrease the time of all following
-accesses.)code", false);
+accesses.)code", false)
+  .AddOptionalArg("prefeth_queue_depth",
+      R"code(Specifies the depth of the batches prefetched by the internal Loader. When the pipeline
+is CPU stage-bound, trading memory consumption for better interleaving with the Loader thread.)code", 1);
 
 
 size_t start_index(const size_t shard_id,

--- a/dali/pipeline/operators/reader/loader/loader.h
+++ b/dali/pipeline/operators/reader/loader/loader.h
@@ -48,7 +48,8 @@ class Loader {
   explicit Loader(const OpSpec& options)
     : shuffle_(options.GetArgument<bool>("random_shuffle")),
       initial_buffer_fill_(shuffle_ ? options.GetArgument<int>("initial_fill") : 1),
-      initial_empty_size_(2 * options.GetArgument<int>("batch_size")),
+      initial_empty_size_(2 * options.GetArgument<int>("prefeth_queue_depth")
+                          * options.GetArgument<int>("batch_size")),
       tensor_init_bytes_(options.GetArgument<int>("tensor_init_bytes")),
       seed_(options.GetArgument<Index>("seed")),
       shard_id_(options.GetArgument<int>("shard_id")),

--- a/dali/pipeline/operators/reader/loader/loader.h
+++ b/dali/pipeline/operators/reader/loader/loader.h
@@ -48,7 +48,7 @@ class Loader {
   explicit Loader(const OpSpec& options)
     : shuffle_(options.GetArgument<bool>("random_shuffle")),
       initial_buffer_fill_(shuffle_ ? options.GetArgument<int>("initial_fill") : 1),
-      initial_empty_size_(2 * options.GetArgument<int>("prefeth_queue_depth")
+      initial_empty_size_(2 * options.GetArgument<int>("prefetch_queue_depth")
                           * options.GetArgument<int>("batch_size")),
       tensor_init_bytes_(options.GetArgument<int>("tensor_init_bytes")),
       seed_(options.GetArgument<Index>("seed")),

--- a/dali/pipeline/operators/reader/mxnet_reader_op.h
+++ b/dali/pipeline/operators/reader/mxnet_reader_op.h
@@ -31,7 +31,7 @@ class MXNetReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   void RunImpl(SampleWorkspace* ws, const int i) override {
     const int idx = ws->data_idx();
 
-    auto* raw_data = prefetched_batch_[idx];
+    auto* raw_data = GetSample(idx);
 
     parser_->Parse(*raw_data, ws);
 

--- a/dali/pipeline/operators/reader/reader_op.h
+++ b/dali/pipeline/operators/reader/reader_op.h
@@ -122,7 +122,7 @@ class DataReader : public Operator<Backend> {
     // consume sample
     TimeRange tr("DataReader::Run #" + to_string(curr_batch_consumer_), TimeRange::kViolet);
     Operator<Backend>::Run(ws);
-    auto &sample = prefetched_batch_queue_[curr_batch_consumer_][ws->data_idx()];
+    auto *sample = GetSample(ws->data_idx());
     loader_->ReturnTensor(sample);
     sample = nullptr;
     samples_processed_++;
@@ -199,12 +199,12 @@ class DataReader : public Operator<Backend> {
 
   bool IsPrefetchQueueEmpty() {
     return curr_batch_producer_ == curr_batch_consumer_
-        && consumer_cycle_ == producer_cycle_;
+           && consumer_cycle_ == producer_cycle_;
   }
 
   bool IsPrefetchQueueFull() {
     return curr_batch_producer_ == curr_batch_consumer_
-        && consumer_cycle_ != producer_cycle_;
+           && consumer_cycle_ != producer_cycle_;
   }
 
   std::thread prefetch_thread_;

--- a/dali/pipeline/operators/reader/reader_op.h
+++ b/dali/pipeline/operators/reader/reader_op.h
@@ -47,12 +47,12 @@ namespace dali {
 template <typename Backend, typename LoadTarget, typename ParseTarget = LoadTarget>
 class DataReader : public Operator<Backend> {
  public:
-  inline explicit DataReader(const OpSpec& spec, int prefetch_queue_depth = 3) :
+  inline explicit DataReader(const OpSpec& spec) :
     Operator<Backend>(spec),
   prefetch_ready_workers_(false),
   finished_(false),
-  prefetch_queue_depth_(prefetch_queue_depth),
-  prefetched_batch_queue_(prefetch_queue_depth),
+  prefetch_queue_depth_(spec.GetArgument<int>("prefeth_queue_depth")),
+  prefetched_batch_queue_(prefetch_queue_depth_),
   curr_batch_consumer_(0),
   curr_batch_producer_(0),
   consumer_cycle_(false),
@@ -162,7 +162,8 @@ class DataReader : public Operator<Backend> {
 
       if (!prefetch_ready_workers_) {
         // grab the actual prefetching lock
-        TimeRange tr("CONSUMER " + to_string(curr_batch_consumer_) +  " waiting", TimeRange::kMagenta);
+        TimeRange tr("CONSUMER " + to_string(curr_batch_consumer_) +  " waiting",
+                     TimeRange::kMagenta);
         std::unique_lock<std::mutex> prefetch_lock(prefetch_access_mutex_);
 
         // Wait until prefetch is ready
@@ -246,7 +247,6 @@ class DataReader : public Operator<Backend> {
   }
 
  protected:
-
   int NextIdx(int curr_batch, bool& cycle) {
     if (curr_batch == prefetch_queue_depth_ - 1)
       cycle = !cycle;
@@ -286,7 +286,6 @@ class DataReader : public Operator<Backend> {
   int curr_batch_producer_;
   bool consumer_cycle_;
   bool producer_cycle_;
-  // TODO(spanev): implem double buffering of prefetched_batch_queue_;
 
   // keep track of how many samples have been processed
   // over all threads.

--- a/dali/pipeline/operators/reader/reader_op.h
+++ b/dali/pipeline/operators/reader/reader_op.h
@@ -50,7 +50,7 @@ class DataReader : public Operator<Backend> {
   inline explicit DataReader(const OpSpec& spec)
       : Operator<Backend>(spec),
         finished_(false),
-        prefetch_queue_depth_(spec.GetArgument<int>("prefeth_queue_depth")),
+        prefetch_queue_depth_(spec.GetArgument<int>("prefetch_queue_depth")),
         prefetched_batch_queue_(prefetch_queue_depth_),
         curr_batch_consumer_(0),
         curr_batch_producer_(0),

--- a/dali/pipeline/operators/reader/reader_op_test.cc
+++ b/dali/pipeline/operators/reader/reader_op_test.cc
@@ -111,8 +111,28 @@ TYPED_TEST(ReaderTest, SimpleTest) {
   pipe.Build(outputs);
 
   DeviceWorkspace ws;
-  for (int i=0; i < 10; ++i) {
-    printf(" ======= ITER %d ======\n", i);
+  for (int i=0; i < 5; ++i) {
+    pipe.RunCPU();
+    pipe.RunGPU();
+    pipe.Outputs(&ws);
+  }
+
+  return;
+}
+
+TYPED_TEST(ReaderTest, PrefetchQueueTest) {
+  Pipeline pipe(128, 1, 0);
+
+  pipe.AddOperator(
+      OpSpec("DummyDataReader")
+      .AddOutput("data_out", "cpu")
+      .AddArg("prefetch_queue_depth", 3));
+
+  std::vector<std::pair<string, string>> outputs = {{"data_out", "cpu"}};
+  pipe.Build(outputs);
+
+  DeviceWorkspace ws;
+  for (int i=0; i < 5; ++i) {
     pipe.RunCPU();
     pipe.RunGPU();
     pipe.Outputs(&ws);
@@ -136,7 +156,6 @@ TYPED_TEST(ReaderTest, SequenceTest) {
 
   DeviceWorkspace ws;
   for (int i = 0; i < 4; ++i) {
-    printf(" ======= ITER %d ======\n", i);
     pipe.RunCPU();
     pipe.RunGPU();
     pipe.Outputs(&ws);

--- a/dali/pipeline/operators/reader/reader_op_test.cc
+++ b/dali/pipeline/operators/reader/reader_op_test.cc
@@ -73,7 +73,7 @@ class DummyDataReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   void RunImpl(SampleWorkspace* ws, int idx) override {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
-    ws->Output<CPUBackend>(0).Copy(*prefetched_batch_[ws->data_idx()], 0);
+    ws->Output<CPUBackend>(0).Copy(*GetSample(ws->data_idx()), 0);
   }
 
  private:

--- a/dali/pipeline/operators/reader/sequence_reader_op.cc
+++ b/dali/pipeline/operators/reader/sequence_reader_op.cc
@@ -21,7 +21,7 @@ namespace dali {
 void SequenceReader::RunImpl(SampleWorkspace* ws, const int i) {
   const int idx = ws->data_idx();
 
-  auto* sequence = prefetched_batch_[idx];
+  auto* sequence = GetSample(idx);
 
   parser_->Parse(*sequence, ws);
 }

--- a/dali/pipeline/operators/reader/tfrecord_reader_op.h
+++ b/dali/pipeline/operators/reader/tfrecord_reader_op.h
@@ -34,7 +34,7 @@ class TFRecordReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   void RunImpl(SampleWorkspace* ws, const int i) override {
     const int idx = ws->data_idx();
 
-    auto* raw_data = prefetched_batch_[idx];
+    auto* raw_data = GetSample(idx);
 
     parser_->Parse(*raw_data, ws);
 

--- a/dali/pipeline/operators/reader/video_reader_op.h
+++ b/dali/pipeline/operators/reader/video_reader_op.h
@@ -79,7 +79,7 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
     for (int data_idx = 0; data_idx < batch_size_; ++data_idx) {
       auto* sequence_output = tl_sequence_output.raw_mutable_tensor(data_idx);
 
-      auto* prefetched_sequence = prefetched_batch_[data_idx];
+      auto* prefetched_sequence = GetSample(data_idx);
       tl_sequence_output.type().Copy<GPUBackend, GPUBackend>(sequence_output,
                                   prefetched_sequence->sequence.raw_data(),
                                   prefetched_sequence->sequence.size(),


### PR DESCRIPTION
`Reader` op has now a queue of prefetched batch (default size 1), which depth is a parameter of the operator. 

Co-author @jantonguirao 