### PR TITLE
Change unconditional move to forward

### DIFF
--- a/dali/kernels/any.h
+++ b/dali/kernels/any.h
@@ -174,7 +174,7 @@ class any {
       "only copy-constructible types can be stored in 'any'");
     static_assert(std::is_destructible<T>::value,
       "objects stored in 'any' must be destructible");
-    assign<T>(std::move(value));
+    assign<T>(std::forward<T>(value));
   }
 
   void reset() {


### PR DESCRIPTION
Universal references should be forwarded

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>