### PR TITLE
Workaround for nppiResize out of bound access

### DIFF
--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -276,6 +276,7 @@ class Buffer {
     size_t new_num_bytes = new_size * type_.size();
     if (new_num_bytes > num_bytes_) {
       size_t grow = num_bytes_*alloc_mult;
+      grow = (grow + pading) & ~(pading - 1);
       if (grow > new_num_bytes)
         new_num_bytes = grow;
       reserve(new_num_bytes);
@@ -283,6 +284,8 @@ class Buffer {
   }
 
   const double alloc_mult = 1.0;
+  // round to 1kB
+  const size_t pading = 1024;
 
   Backend backend_;
 

--- a/qa/L0_python-self-test/test.sh
+++ b/qa/L0_python-self-test/test.sh
@@ -12,8 +12,8 @@ test_body() {
     nosetests --verbose test_plugin_manager.py
 
     # DISABLED FAILING TESTS DUE TO RANDOM FAILS IN THE CI
-    # python test_random_bbcrop.py -i 300
-    # python test_RN50_data_pipeline.py -i 10
+    python test_random_bbcrop.py -i 100
+    python test_RN50_data_pipeline.py -i 10
 
     # TensorFlow supports only CUDA 9.0 now
     if [ "${CUDA_VERSION}" == "90"]; then


### PR DESCRIPTION
- for some resize factor and window it happens that npp tries to read
  one more line from the image what causes invalid read. Fix this problem
 resizing input image by this one line
- add padding to the buffer allocations to reduce the number of it
- enables RN50 and SSD pipeline tests

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>