### PR TITLE
Remove unnecessary copies by using const ref or move

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,7 @@ AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 # Empty and Inline instead of ALL
-AllowShortFunctionsOnASingleLine: Inline
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None

--- a/dali/core/error_handling.cc
+++ b/dali/core/error_handling.cc
@@ -27,13 +27,13 @@ string DALIGetLastError() {
   return error_str;
 }
 
-void DALISetLastError(string error_str) {
+void DALISetLastError(const string &error_str) {
   // Note: This currently overwrites the string if there is
   // already an error string stored.
   g_dali_error_string = error_str;
 }
 
-void DALIAppendToLastError(string error_str) {
+void DALIAppendToLastError(const string &error_str) {
   // Adds additional info to previously returned error
   g_dali_error_string += error_str;
 }

--- a/dali/image/image.cc
+++ b/dali/image/image.cc
@@ -31,7 +31,7 @@ std::string ListSupportedExtensions() {
   return ss.str();
 }
 
-bool HasKnownImageExtension(std::string image_path) {
+bool HasKnownImageExtension(const std::string &image_path) {
   std::string path_low{image_path};
   std::transform(path_low.begin(), path_low.end(), path_low.begin(), ::tolower);
   for (const auto &ext : kKnownImageExtensions) {

--- a/dali/image/image.h
+++ b/dali/image/image.h
@@ -34,7 +34,7 @@ static const char *kKnownImageExtensions[] = {".jpg", ".jpeg", ".png", ".gif",
                                               ".bmp", ".tif",  ".tiff",
                                               ".pnm", ".ppm", ".pgm", ".pbm"};
 
-DLL_PUBLIC bool HasKnownImageExtension(std::string image_path);
+DLL_PUBLIC bool HasKnownImageExtension(const std::string &image_path);
 
 class Image {
  public:

--- a/dali/image/transform.cc
+++ b/dali/image/transform.cc
@@ -166,7 +166,7 @@ inline bool SupportsSequence(const std::string &opname) {
 }
 
 void CheckParam(const Tensor<CPUBackend> &input, const std::string &opName) {
-  const auto shape = input.shape();
+  const auto &shape = input.shape();
   if (SupportsSequence(opName)) {
     DALI_ENFORCE(shape.size() == 3 || shape.size() == 4);
   } else {

--- a/dali/kernels/test/tensor_test_utils.h
+++ b/dali/kernels/test/tensor_test_utils.h
@@ -247,7 +247,7 @@ void ConstantFill(
 }
 
 template <typename TensorListView>
-std::string BatchToStr(const TensorListView& batch, const std::string sample_prefix = "Sample ") {
+std::string BatchToStr(const TensorListView& batch, const std::string &sample_prefix = "Sample ") {
   std::stringstream ss;
   for (int i = 0; i < batch.num_samples(); i++) {
     ss << sample_prefix << i << ":";

--- a/dali/pipeline/data/meta.h
+++ b/dali/pipeline/data/meta.h
@@ -40,7 +40,7 @@ class DALIMeta {
     return source_info_;
   }
 
-  inline void SetSourceInfo(std::string source_info) {
+  inline void SetSourceInfo(const std::string &source_info) {
     source_info_ = source_info;
   }
 

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -399,7 +399,7 @@ class Tensor : public Buffer<Backend> {
     return meta_.GetSourceInfo();
   }
 
-  inline void SetSourceInfo(string source_info) {
+  inline void SetSourceInfo(const string &source_info) {
     meta_.SetSourceInfo(source_info);
   }
 

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -286,14 +286,14 @@ inline std::string to_string(const DALIDataType& dtype) {
  * @brief Utility to check types
  */
 template <typename T>
-DLL_PUBLIC inline bool IsType(TypeInfo type) {
+DLL_PUBLIC inline bool IsType(const TypeInfo &type) {
   return type.id() == TypeTable::GetTypeID<T>();
 }
 
 /**
  * @brief Utility to check for valid type
  */
-DLL_PUBLIC inline bool IsValidType(TypeInfo type) {
+DLL_PUBLIC inline bool IsValidType(const TypeInfo &type) {
   return !IsType<NoType>(type);
 }
 

--- a/dali/pipeline/executor/workspace_policy.h
+++ b/dali/pipeline/executor/workspace_policy.h
@@ -47,7 +47,7 @@ add_input(op_type_to_workspace_t<op_type> &ws, const tensor_data_store_queue_t &
 // If parent op_type or device is not allowed this is a no-op
 template <OpType op_type, OpType producer_type, StorageDevice device>
 enable_if_t<!allows_op_input<op_type>(producer_type) || !allows_tensor_input<op_type>(device)>
-add_input(op_type_to_workspace_t<op_type>, const tensor_data_store_queue_t, int = 0) {}
+add_input(op_type_to_workspace_t<op_type>, const tensor_data_store_queue_t &, int = 0) {}
 
 template <OpType op_type, StorageDevice device>
 void add_output(op_type_to_workspace_t<op_type> &ws, const tensor_data_store_queue_t &storage,

--- a/dali/pipeline/graph/graph_descr.cc
+++ b/dali/pipeline/graph/graph_descr.cc
@@ -96,7 +96,7 @@ StorageDevice ParseStorageDevice(const std::string &io_device) {
 
 }  // namespace
 
-OpNode& OpGraph::PlaceNewOp(OpType op_type, OpSpec op_spec, std::string instance_name) {
+OpNode& OpGraph::PlaceNewOp(OpType op_type, const OpSpec &op_spec, std::string instance_name) {
   op_nodes_.push_back(OpNode());
   auto &node = op_nodes_.back();
   node.id = op_nodes_.size() - 1;

--- a/dali/pipeline/graph/op_graph.h
+++ b/dali/pipeline/graph/op_graph.h
@@ -318,7 +318,7 @@ class DLL_PUBLIC OpGraph {
    * @brief Save graph in DOT directed graph format
    * in filename.
    */
-  DLL_PUBLIC void SaveToDotFile(const string filename, bool show_tensors = false,
+  DLL_PUBLIC void SaveToDotFile(const string &filename, bool show_tensors = false,
                                 bool show_ids = false, bool use_colors = false) {
     std::ofstream ofs(filename);
     ofs << "digraph graphname {\n";
@@ -350,7 +350,7 @@ class DLL_PUBLIC OpGraph {
    *
    * @return Reference to the newly added OpNode.
    */
-  OpNode& PlaceNewOp(OpType op_type, OpSpec op_spec, std::string instance_name);
+  OpNode& PlaceNewOp(OpType op_type, const OpSpec &op_spec, std::string instance_name);
 
   /**
    * @brief Creates new tensor node with conscutive id.

--- a/dali/pipeline/operators/decoder/cache/image_cache_largest.cc
+++ b/dali/pipeline/operators/decoder/cache/image_cache_largest.cc
@@ -59,7 +59,7 @@ void ImageCacheLargest::Add(const ImageKey& image_key,
             && biggest_images_total_ + data_size > cache_size_
             && biggest_images_.top().first < data_size) {
           biggest_images_total_ -= biggest_images_.top().first;
-          to_be_discarded.push(std::move(biggest_images_.top()));
+          to_be_discarded.push(biggest_images_.top());
           biggest_images_.pop();
         }
 

--- a/dali/pipeline/operators/detection/box_encoder_test.cc
+++ b/dali/pipeline/operators/detection/box_encoder_test.cc
@@ -30,7 +30,7 @@ class BoxEncoderTest : public GenericBBoxesTest<ImgType> {
   TensorList<CPUBackend> labels_;
   vector<float> anchors_;
 
-  void RunForCocoCpu(vector<float> anchors, float criteria) {
+  void RunForCocoCpu(const vector<float> &anchors, float criteria) {
     this->SetBatchSize(coco_batch_size);
     this->SetExternalInputs({{"bboxes", &this->boxes_}, {"labels", &this->labels_}});
     this->AddSingleOp(OpSpec("BoxEncoder")
@@ -47,7 +47,7 @@ class BoxEncoderTest : public GenericBBoxesTest<ImgType> {
     this->CheckAnswersForCocoOnCpu(&ws);
   }
 
-  void RunForCocoGpu(vector<float> anchors, float criteria) {
+  void RunForCocoGpu(const vector<float> &anchors, float criteria) {
     this->SetBatchSize(coco_batch_size);
     this->SetExternalInputs({{"bboxes", &this->boxes_}, {"labels", &this->labels_}});
     this->AddSingleOp(OpSpec("BoxEncoder")
@@ -638,7 +638,7 @@ class BoxEncoderTest : public GenericBBoxesTest<ImgType> {
     for (int idx = 0; idx < feat_count; ++idx) {
       auto sk1 = scales[idx] / fig_size;
       auto sk2 = scales[idx + 1] / fig_size;
-      auto sk3 = sqrt(sk1 * sk2);
+      auto sk3 = std::sqrt(sk1 * sk2);
       vector<std::pair<float, float>> all_sizes{{sk1, sk1}, {sk3, sk3}};
 
       for (auto &alpha : aspect_ratios[idx]) {

--- a/dali/pipeline/operators/displacement/rotate.h
+++ b/dali/pipeline/operators/displacement/rotate.h
@@ -31,12 +31,12 @@ class RotateAugment : public WarpAffineAugment {
 
   void Prepare(Param* p, const OpSpec& spec, ArgumentWorkspace *ws, int index) {
     float angle = spec.GetArgument<float>("angle", ws, index);
-    float angle_rad = angle * M_PI / 180.0;
-    p->matrix[0] = cos(angle_rad);
-    p->matrix[1] = sin(angle_rad);
+    float angle_rad = angle * (M_PI / 180.0);
+    p->matrix[0] = std::cos(angle_rad);
+    p->matrix[1] = std::sin(angle_rad);
     p->matrix[2] = 0.0;
-    p->matrix[3] = -sin(angle_rad);
-    p->matrix[4] = cos(angle_rad);
+    p->matrix[3] = -std::sin(angle_rad);
+    p->matrix[4] = std::cos(angle_rad);
     p->matrix[5] = 0.0;
   }
 };

--- a/dali/pipeline/operators/op_schema.cc
+++ b/dali/pipeline/operators/op_schema.cc
@@ -44,7 +44,7 @@ void OpSchema::CheckArgs(const OpSpec &spec) const {
   for (auto& arg_pair : required_arguments) {
     req_arguments_left.insert(arg_pair.first);
   }
-  for (std::string s : vec) {
+  for (const auto &s : vec) {
     DALI_ENFORCE(HasArgument(s) ||
         internal_arguments_.find(s) != internal_arguments_.end(),
         "Got an unexpected argument \"" + s + "\"");

--- a/dali/pipeline/operators/op_schema.h
+++ b/dali/pipeline/operators/op_schema.h
@@ -104,7 +104,7 @@ class DLL_PUBLIC OpSchema {
    * does not need to be added to the schema
    */
   DLL_PUBLIC inline OpSchema& OutputFn(SpecFunc f) {
-    output_fn_ = f;
+    output_fn_ = std::move(f);
     return *this;
   }
 
@@ -120,7 +120,7 @@ class DLL_PUBLIC OpSchema {
    * numbers used within operators) to the user
    */
   DLL_PUBLIC inline OpSchema& AdditionalOutputsFn(SpecFunc f) {
-    additional_outputs_fn_ = f;
+    additional_outputs_fn_ = std::move(f);
     return *this;
   }
 
@@ -250,6 +250,7 @@ class DLL_PUBLIC OpSchema {
    * be executed in-place depending on the ops specification.
    */
   DLL_PUBLIC inline OpSchema& InPlaceFn(SpecFunc f) {
+    (void)f;
     REPORT_FATAL_PROBLEM("In-place op support not yet implemented.");
     return *this;
   }

--- a/dali/pipeline/operators/op_spec.h
+++ b/dali/pipeline/operators/op_spec.h
@@ -50,7 +50,7 @@ class DLL_PUBLIC OpSpec {
    * @brief Returns a full tensor name
    * given its name and device
    */
-  DLL_PUBLIC static std::string TensorName(std::string name, std::string device) {
+  DLL_PUBLIC static std::string TensorName(const std::string &name, const std::string &device) {
     return name + "_" + device;
   }
 

--- a/dali/pipeline/operators/reader/coco_reader_op_test.cc
+++ b/dali/pipeline/operators/reader/coco_reader_op_test.cc
@@ -44,7 +44,7 @@ class CocoReaderTest : public ::testing::Test {
 
   std::vector<int> CopyIds(DeviceWorkspace &ws) {
     auto &output = ws.Output<dali::CPUBackend>(3);
-    auto shape = output.shape();
+    const auto &shape = output.shape();
 
     vector<int> ids(shape.size());
 
@@ -59,8 +59,8 @@ class CocoReaderTest : public ::testing::Test {
     const auto &boxes_output = ws.Output<dali::CPUBackend>(1);
     const auto &labels_output = ws.Output<dali::CPUBackend>(2);
 
-    const auto boxes_shape = boxes_output.shape();
-    const auto labels_shape = labels_output.shape();
+    const auto &boxes_shape = boxes_output.shape();
+    const auto &labels_shape = labels_output.shape();
 
     ASSERT_EQ(labels_shape.size(), SmallCocoSize());
     ASSERT_EQ(boxes_shape.size(), SmallCocoSize());

--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -52,7 +52,7 @@ class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
     : Loader<CPUBackend, ImageLabelWrapper>(spec),
       file_root_(spec.GetArgument<string>("file_root")),
       file_list_(spec.GetArgument<string>("file_list")),
-      image_label_pairs_(image_label_pairs),
+      image_label_pairs_(std::move(image_label_pairs)),
       shuffle_after_epoch_(shuffle_after_epoch),
       current_index_(0),
       current_epoch_(0) {

--- a/dali/pipeline/operators/reader/loader/sequence_loader.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.cc
@@ -25,8 +25,8 @@ namespace dali {
 
 namespace {
 
-std::string parent_dir(std::string path) {
-  size_t idx = path.rfind("/");
+std::string parent_dir(const std::string &path) {
+  size_t idx = path.rfind('/');
   DALI_ENFORCE(idx != std::string::npos, "NO PARENT DIRECTORY FOR GIVEN PATH");
   return path.substr(0, idx + 1);  // return with trailing "/"
 }
@@ -35,7 +35,7 @@ std::string parent_dir(std::string path) {
 
 namespace filesystem {
 
-std::vector<Stream> GatherExtractedStreams(string file_root) {
+std::vector<Stream> GatherExtractedStreams(const string &file_root) {
   glob_t glob_buff;
   std::string glob_pattern = file_root + "/*/*";
   const int glob_flags = 0;

--- a/dali/pipeline/operators/reader/loader/sequence_loader.h
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.h
@@ -58,7 +58,7 @@ using Stream = std::pair<std::string, std::vector<std::string>>;
  * @param file_root
  * @return std::vector<Stream> GatherExtractedStreams
  */
-std::vector<Stream> DLL_PUBLIC GatherExtractedStreams(string file_root);
+std::vector<Stream> DLL_PUBLIC GatherExtractedStreams(const string &file_root);
 
 }  // namespace filesystem
 

--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -47,7 +47,7 @@ static constexpr auto frames_used_warning_ratio = 3.0f;
 static constexpr auto frames_used_warning_minimum = 1000;
 static constexpr auto frames_used_warning_interval = 10000;
 
-OpenFile& VideoLoader::get_or_open_file(std::string filename) {
+OpenFile& VideoLoader::get_or_open_file(const std::string &filename) {
   auto& file = open_files_[filename];
 
   if (!file.open) {
@@ -366,7 +366,7 @@ void VideoLoader::read_file() {
 
 void VideoLoader::push_sequence_to_read(std::string filename, int frame, int count) {
     int total_count = 1 + (count - 1) * stride_;
-    auto req = FrameReq{filename, frame, total_count, stride_};
+    auto req = FrameReq{std::move(filename), frame, total_count, stride_};
     // give both reader thread and decoder a copy of what is coming
     send_queue_.push(req);
 }

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -147,7 +147,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   void PrepareEmpty(SequenceWrapper &tensor) override;
   void ReadSample(SequenceWrapper &tensor) override;
 
-  OpenFile& get_or_open_file(std::string filename);
+  OpenFile& get_or_open_file(const std::string &filename);
   void seek(OpenFile& file, int frame);
   void read_file();
   void push_sequence_to_read(std::string filename, int frame, int count);

--- a/dali/pipeline/operators/reader/parser/tf_feature.h
+++ b/dali/pipeline/operators/reader/parser/tf_feature.h
@@ -17,8 +17,9 @@
 
 #ifdef DALI_BUILD_PROTO3
 
-#include <vector>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "dali/core/common.h"
 #include "dali/pipeline/proto/dali_proto_utils.h"
@@ -44,15 +45,15 @@ class Feature {
 
   Feature(std::vector<Index> shape, FeatureType type, Value val) {
     has_shape_ = true;
-    shape_ = shape;
+    shape_ = std::move(shape);
     type_ = type;
-    val_ = val;
+    val_ = std::move(val);
   }
 
   Feature(FeatureType type, Value val) {
     has_shape_ = false;
     type_ = type;
-    val_ = val;
+    val_ = std::move(val);
   }
 
   FeatureType GetType() const { return type_; }

--- a/dali/pipeline/operators/reader/reader_op_test.cc
+++ b/dali/pipeline/operators/reader/reader_op_test.cc
@@ -32,7 +32,7 @@ namespace dali {
 
 class DummyLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
  public:
-  explicit DummyLoader(const OpSpec& spec, std::string dummyfile = "") :
+  explicit DummyLoader(const OpSpec& spec, const std::string &dummyfile = "") :
     Loader<CPUBackend, Tensor<CPUBackend>>(spec),
     dummyfile_(dummyfile) {}
 

--- a/dali/pipeline/operators/sequence/element_extract_test.cc
+++ b/dali/pipeline/operators/sequence/element_extract_test.cc
@@ -39,7 +39,7 @@ class ElementExtractTest : public DaliOperatorTest {
         , H_(H)
         , W_(W)
         , C_(C)
-        , element_map_(element_map) {
+        , element_map_(std::move(element_map)) {
     }
 
     std::unique_ptr<TensorList<CPUBackend>>

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -426,7 +426,7 @@ void Pipeline::Build(vector<std::pair<string, string>> output_names) {
   built_ = true;
 }
 
-void Pipeline::SetOutputNames(vector<std::pair<string, string>> output_names) {
+void Pipeline::SetOutputNames(const vector<std::pair<string, string>> &output_names) {
   output_names_ = output_names;
 }
 
@@ -444,7 +444,7 @@ void Pipeline::RunGPU() {
 }
 
 void Pipeline::SetCompletionCallback(ExecutorBase::ExecutorCallback cb) {
-  executor_->SetCompletionCallback(cb);
+  executor_->SetCompletionCallback(std::move(cb));
 }
 
 void Pipeline::Outputs(DeviceWorkspace *ws) {
@@ -644,7 +644,7 @@ std::map<std::string, Index> Pipeline::EpochSize() {
   return ret;
 }
 
-void Pipeline::SaveGraphToDotFile(const std::string filename) {
+void Pipeline::SaveGraphToDotFile(const std::string &filename) {
   graph_.SaveToDotFile(filename);
 }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -234,7 +234,7 @@ class DLL_PUBLIC Pipeline {
    * @brief Set name output_names of the pipeline. Used to update the graph without
    * running the executor.
    */
-  void SetOutputNames(vector<std::pair<string, string>> output_names);
+  void SetOutputNames(const vector<std::pair<string, string>> &output_names);
 
   /**
    * @brief Run the cpu portion of the pipeline.
@@ -288,7 +288,7 @@ class DLL_PUBLIC Pipeline {
    * @brief Save graph in DOT direct graph format
    * in filename.
    */
-  DLL_PUBLIC void SaveGraphToDotFile(const std::string filename);
+  DLL_PUBLIC void SaveGraphToDotFile(const std::string &filename);
 
   /**
    * @brief Returns the batch size that will be produced by the pipeline.
@@ -384,7 +384,7 @@ class DLL_PUBLIC Pipeline {
 
   void SetupGPUInput(std::map<string, EdgeMeta>::iterator it);
 
-  inline EdgeMeta NewEdge(string device) {
+  inline EdgeMeta NewEdge(const std::string &device) {
     EdgeMeta edge;
     edge.has_cpu = false;
     edge.has_gpu = false;

--- a/dali/pipeline/util/bounding_box.h
+++ b/dali/pipeline/util/bounding_box.h
@@ -171,7 +171,7 @@ class BoundingBox {
   }
 
  private:
-  static void CheckBounds(float value, float lower, float upper, string name) {
+  static void CheckBounds(float value, float lower, float upper, const string &name) {
     DALI_ENFORCE(
       value >= lower && value <= upper,
       "Expected " + to_string(lower) + " <= " + name + " <= " + to_string(upper) +

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -41,17 +41,17 @@ class ArgumentWorkspace {
     argument_inputs_.clear();
   }
 
-  void AddArgumentInput(shared_ptr<Tensor<CPUBackend>> input, std::string arg_name) {
-    argument_inputs_[arg_name] = input;
+  void AddArgumentInput(shared_ptr<Tensor<CPUBackend>> input, const std::string &arg_name) {
+    argument_inputs_[arg_name] = std::move(input);
   }
 
-  void SetArgumentInput(shared_ptr<Tensor<CPUBackend>> input, std::string arg_name) {
+  void SetArgumentInput(shared_ptr<Tensor<CPUBackend>> input, const std::string &arg_name) {
     DALI_ENFORCE(argument_inputs_.find(arg_name) != argument_inputs_.end(),
         "Argument \"" + arg_name + "\" not found.");
-    argument_inputs_[arg_name] = input;
+    argument_inputs_[arg_name] = std::move(input);
   }
 
-  const Tensor<CPUBackend>& ArgumentInput(std::string arg_name) const {
+  const Tensor<CPUBackend>& ArgumentInput(const std::string &arg_name) const {
     DALI_ENFORCE(argument_inputs_.find(arg_name) != argument_inputs_.end(),
         "Argument \"" + arg_name + "\" not found.");
     return *(argument_inputs_.at(arg_name));

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -46,7 +46,7 @@ static void* ctypes_void_ptr(const py::object& object) {
   return ptr;
 }
 
-static std::string FormatStrFromType(TypeInfo type) {
+static std::string FormatStrFromType(const TypeInfo &type) {
   if (IsType<uint8>(type)) {
     return py::format_descriptor<uint8>::format();
   } else if (IsType<int16>(type)) {
@@ -71,7 +71,7 @@ static std::string FormatStrFromType(TypeInfo type) {
   }
 }
 
-static TypeInfo TypeFromFormatStr(std::string format) {
+static TypeInfo TypeFromFormatStr(const std::string &format) {
   if (format == py::format_descriptor<uint8>::format()) {
     return TypeInfo::Create<uint8>();
   } else if (format == py::format_descriptor<int16>::format()) {
@@ -332,7 +332,7 @@ void ExposeTensorList(py::module &m) { // NOLINT
           return py::array(py::buffer_info(
               raw_mutable_data,
               type_size,
-              std::move(format),
+              format,
               shape.size(), shape, strides));
         },
       R"code(

--- a/dali/util/image.cc
+++ b/dali/util/image.cc
@@ -66,7 +66,7 @@ std::vector<std::string> list_files(
 }  // namespace
 
 void LoadImages(const vector<string> &image_names, ImgSetDescr *imgs) {
-  for (auto img_name : image_names) {
+  for (const auto &img_name : image_names) {
     std::ifstream img_file(img_name);
     DALI_ENFORCE(img_file.is_open());
 

--- a/dali/util/random_crop_generator.cc
+++ b/dali/util/random_crop_generator.cc
@@ -91,8 +91,8 @@ CropWindow RandomCropGenerator::GenerateCropWindowImpl(int H, int W) {
         crop.h = H;
       }
       float scale = std::min(1.0f, max_area / (crop.w * crop.h));
-      crop.w = std::max<int>(1, crop.w * sqrt(scale));
-      crop.h = std::max<int>(1, crop.h * sqrt(scale));
+      crop.w = std::max<int>(1, crop.w * std::sqrt(scale));
+      crop.h = std::max<int>(1, crop.h * std::sqrt(scale));
     }
   }
 

--- a/include/dali/core/common.h
+++ b/include/dali/core/common.h
@@ -281,7 +281,7 @@ auto to_string(const T& t) -> decltype(t.ToString()) {
 template <typename T>
 std::string to_string(const std::vector<T>& v) {
   std::string ret = "[";
-  for (T t : v) {
+  for (const T &t : v) {
     ret += to_string(t);
     ret += ", ";
   }

--- a/include/dali/core/error_handling.h
+++ b/include/dali/core/error_handling.h
@@ -56,11 +56,11 @@ enum DALIError_t {
 DLL_PUBLIC string DALIGetLastError();
 
 // Sets the error string. Used internally by DALI to pass error strings out to the user
-DLL_PUBLIC void DALISetLastError(string error_str);
+DLL_PUBLIC void DALISetLastError(const string &error_str);
 
 // Appends additional info to last error. Used internally by DALI to pass error
 // strings out to the user
-DLL_PUBLIC void DALIAppendToLastError(string error_str);
+DLL_PUBLIC void DALIAppendToLastError(const string &error_str);
 
 class DALIException : public std::runtime_error {
  public:
@@ -69,8 +69,8 @@ class DALIException : public std::runtime_error {
 
 inline string BuildErrorString(string statement, string file, int line) {
   string line_str = std::to_string(line);
-  string error = "[" + file + ":" + line_str +
-    "]: Assert on \"" + statement +
+  string error = "[" + std::move(file) + ":" + std::move(line_str) +
+    "]: Assert on \"" + std::move(statement) +
     "\" failed";
   return error;
 }


### PR DESCRIPTION
Based on clang-tidy performance-* checks.
Mostly fixes for some string passing and TypeInfo.
Format argument.h to current style.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>