### PR TITLE
Sort operators in docs, add padding to allocations

### DIFF
--- a/dali/aux/optical_flow/turing_of/optical_flow_turing_test.cc
+++ b/dali/aux/optical_flow/turing_of/optical_flow_turing_test.cc
@@ -19,6 +19,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <numeric>
 #include "dali/util/cuda_utils.h"
 #include "dali/aux/optical_flow/turing_of/optical_flow_turing.h"
 #include "dali/kernels/alloc.h"

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -276,6 +276,7 @@ class Buffer {
     size_t new_num_bytes = new_size * type_.size();
     if (new_num_bytes > num_bytes_) {
       size_t grow = num_bytes_*alloc_mult;
+      grow = (grow + pading) & ~(pading - 1);
       if (grow > new_num_bytes)
         new_num_bytes = grow;
       reserve(new_num_bytes);
@@ -283,6 +284,8 @@ class Buffer {
   }
 
   const double alloc_mult = 1.0;
+  // round to 1kB
+  const size_t pading = 1024;
 
   Backend backend_;
 

--- a/docs/supported_op_devices.py
+++ b/docs/supported_op_devices.py
@@ -20,7 +20,7 @@ def main(argv):
     doc_table += formater.format('', '', '', '', '', '', op_name_max_len = op_name_max_len, c='=')
     doc_table += formater.format('Operator name', 'CPU', 'GPU', 'Mixed', 'Support', 'Sequences', op_name_max_len = op_name_max_len, c=' ')
     doc_table += formater.format('', '', '', '', '', '', op_name_max_len = op_name_max_len, c='=')
-    for op in sorted(all_ops):
+    for op in sorted(all_ops, key=lambda v: str(v).lower()):
         schema = b.GetSchema(op)
         is_cpu = '|v|' if op in cpu_ops else ''
         is_gpu = '|v|' if op in gpu_ops else ''


### PR DESCRIPTION
- makes operators in the docs table sorted disregarding case size
- adds allocation padding to 1kB to avoid frequent reallocations by a small factor

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>