### PR TITLE
Update RN50 examples to use nvJPEG random crop decoding

### DIFF
--- a/docs/examples/mxnet/mxnet-resnet50.ipynb
+++ b/docs/examples/mxnet/mxnet-resnet50.ipynb
@@ -58,8 +58,12 @@
     "        super(HybridTrainPipe, self).__init__(batch_size, num_threads, device_id, seed = 12 + device_id)\n",
     "        self.input = ops.MXNetReader(path = [db_folder+\"train.rec\"], index_path=[db_folder+\"train.idx\"],\n",
     "                                     random_shuffle = True, shard_id = device_id, num_shards = num_gpus)\n",
-    "        self.decode = ops.nvJPEGDecoder(device = \"mixed\", output_type = types.RGB)\n",
-    "        self.rrc = ops.RandomResizedCrop(device = \"gpu\", size = (224, 224))\n",
+    "        self.decode = ops.nvJPEGDecoderRandomCrop(device = \"mixed\",\n",
+    "                                                  output_type = types.RGB,\n",
+    "                                                  random_aspect_ratio = [0.8, 1.25],\n",
+    "                                                  random_area = [0.1, 1.0],\n",
+    "                                                  num_attempts = 100)\n",
+    "        self.resize = ops.Resize(device = \"gpu\", resize_x = 224, resize_y = 224)\n",
     "        self.cmnp = ops.CropMirrorNormalize(device = \"gpu\",\n",
     "                                            output_dtype = types.FLOAT,\n",
     "                                            output_layout = types.NCHW,\n",
@@ -73,7 +77,7 @@
     "        rng = self.coin()\n",
     "        self.jpegs, self.labels = self.input(name = \"Reader\")\n",
     "        images = self.decode(self.jpegs)\n",
-    "        images = self.rrc(images)\n",
+    "        images = self.resize(images)\n",
     "        output = self.cmnp(images, mirror = rng)\n",
     "        return [output, self.labels]\n"
    ]

--- a/docs/examples/pytorch/resnet50/main.py
+++ b/docs/examples/pytorch/resnet50/main.py
@@ -84,15 +84,19 @@ class HybridTrainPipe(Pipeline):
         #let user decide which pipeline works him bets for RN version he runs
         if dali_cpu:
             dali_device = "cpu"
-            self.decode = ops.HostDecoderRandomCrop(device=dali_device, output_type=types.RGB)
-            self.res = ops.Resize(resize_x=crop, resize_y=crop)
+            self.decode = ops.HostDecoderRandomCrop(device=dali_device, output_type=types.RGB,
+                                                    random_aspect_ratio=[0.8, 1.25],
+                                                    random_area=[0.1, 1.0],
+                                                    num_attempts=100)
         else:
             dali_device = "gpu"
             # This padding sets the size of the internal nvJPEG buffers to be able to handle all images from full-sized ImageNet
             # without additional reallocations
-            self.decode = ops.nvJPEGDecoder(device="mixed", output_type=types.RGB, device_memory_padding=211025920, host_memory_padding=140544512)
-            self.res = ops.RandomResizedCrop(device=dali_device, size =(crop, crop))
-
+            self.decode = ops.nvJPEGDecoderRandomCrop(device="mixed", output_type=types.RGB, device_memory_padding=211025920, host_memory_padding=140544512,
+                                                      random_aspect_ratio=[0.8, 1.25],
+                                                      random_area=[0.1, 1.0],
+                                                      num_attempts=100)
+        self.res = ops.Resize("gpu", resize_x=crop, resize_y=crop, interp_type=types.INTERP_TRIANGULAR)
         self.cmnp = ops.CropMirrorNormalize(device="gpu",
                                             output_dtype=types.FLOAT,
                                             output_layout=types.NCHW,
@@ -116,7 +120,7 @@ class HybridValPipe(Pipeline):
         super(HybridValPipe, self).__init__(batch_size, num_threads, device_id, seed=12 + device_id)
         self.input = ops.FileReader(file_root=data_dir, shard_id=args.local_rank, num_shards=args.world_size, random_shuffle=False)
         self.decode = ops.nvJPEGDecoder(device="mixed", output_type=types.RGB)
-        self.res = ops.Resize(device="gpu", resize_shorter=size)
+        self.res = ops.Resize(device="gpu", resize_shorter=size, interp_type=types.INTERP_TRIANGULAR)
         self.cmnp = ops.CropMirrorNormalize(device="gpu",
                                             output_dtype=types.FLOAT,
                                             output_layout=types.NCHW,

--- a/docs/examples/tensorflow/demo/nvutils/image_processing.py
+++ b/docs/examples/tensorflow/demo/nvutils/image_processing.py
@@ -69,22 +69,16 @@ class HybridPipe(dali.pipeline.Pipeline):
                 num_attempts=100)
             resize_device = "cpu"
         else:
-            self.decode = dali.ops.nvJPEGDecoder(
+            self.decode = dali.ops.nvJPEGDecoderRandomCrop(
                 device="mixed",
-                output_type=dali.types.RGB)
+                output_type=dali.types.RGB,
+                random_aspect_ratio=[0.8, 1.25],
+                random_area=[0.1, 1.0],
+                num_attempts=100)
             resize_device = "gpu"
 
         if training:
-            if dali_cpu:
-                self.resize = dali.ops.Resize (device=resize_device, resize_x=width, resize_y=height)
-            else:
-                self.resize = dali.ops.RandomResizedCrop(
-                    device=resize_device,
-                    size=[height, width],
-                    interp_type=dali.types.INTERP_LINEAR,
-                    random_aspect_ratio=[0.8, 1.25],
-                    random_area=[0.1, 1.0],
-                    num_attempts=100)
+            self.resize = dali.ops.Resize (device=resize_device, resize_x=width, resize_y=height)
         else:
             # Make sure that every image > 224 for CropMirrorNormalize
             self.resize = dali.ops.Resize (device=resize_device, resize_shorter=256)


### PR DESCRIPTION
- adds triangular resampling for PyTorch example as it works on raw ImageNet
- updates TensorFlow, MXNet and PyTorch examples

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>