### PR TITLE
Add new ws policy for separated executor

### DIFF
--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -28,6 +28,6 @@
 
 namespace dali {
 
-template class Executor<AOT_WS_Policy, UniformQueuePolicy>;
+template class Executor<AOT_WS_Policy<UniformQueuePolicy>, UniformQueuePolicy>;
 
 }  // namespace dali

--- a/dali/pipeline/executor/pipelined_executor.cc
+++ b/dali/pipeline/executor/pipelined_executor.cc
@@ -22,8 +22,8 @@
 
 namespace dali {
 
-template class PipelinedExecutorImpl<AOT_WS_Policy, UniformQueuePolicy>;
-template class PipelinedExecutorImpl<JIT_WS_Policy, SeparateQueuePolicy>;
+template class PipelinedExecutorImpl<AOT_WS_Policy<UniformQueuePolicy>, UniformQueuePolicy>;
+template class PipelinedExecutorImpl<AOT_WS_Policy<SeparateQueuePolicy>, SeparateQueuePolicy>;
 
 }  // namespace dali
 

--- a/dali/pipeline/executor/pipelined_executor.h
+++ b/dali/pipeline/executor/pipelined_executor.h
@@ -113,22 +113,22 @@ std::vector<int> PipelinedExecutorImpl<WorkspacePolicy, QueuePolicy>::GetTensorQ
 
         // We do not buffer if we do not touch GPU (SUPPORT is synchronous with CPU)
         // otherwise we buffer for a pair of CPU x GPU
-        result[tid] = gpu_consumers == 0 ? 1 : stage_queue_depths_[stage];
+        result[tid] = gpu_consumers == 0 ? 1 : stage_queue_depths_[static_cast<OpType>(stage)];
       }
 
     } else {
       for (auto id : stage_outputs_[stage]) {
-        result[id] = stage_queue_depths_[stage];
+        result[id] = stage_queue_depths_[static_cast<OpType>(stage)];
       }
     }
   }
   return result;
 }
 
-
-using PipelinedExecutor = PipelinedExecutorImpl<AOT_WS_Policy, UniformQueuePolicy>;
-using SeparatedPipelinedExecutor = PipelinedExecutorImpl<JIT_WS_Policy, SeparateQueuePolicy>;
-
+using PipelinedExecutor =
+    PipelinedExecutorImpl<AOT_WS_Policy<UniformQueuePolicy>, UniformQueuePolicy>;
+using SeparatedPipelinedExecutor =
+    PipelinedExecutorImpl<AOT_WS_Policy<SeparateQueuePolicy>, SeparateQueuePolicy>;
 
 }  // namespace dali
 

--- a/dali/pipeline/executor/queue_metadata.h
+++ b/dali/pipeline/executor/queue_metadata.h
@@ -19,16 +19,30 @@
 
 namespace dali {
 
-struct QueueIdxs {
+// Used to store Stage queue sizes
+struct StageQueues {
   int &operator[](OpType op_type) { return idxs[static_cast<size_t>(op_type)]; }
 
   const int &operator[](OpType op_type) const { return idxs[static_cast<size_t>(op_type)]; }
 
-  explicit QueueIdxs(int uniform_idx) : idxs{uniform_idx, uniform_idx, uniform_idx, uniform_idx} {}
+  StageQueues() = default;
+
+  explicit StageQueues(int uniform_idx)
+      : idxs{uniform_idx, uniform_idx, uniform_idx, uniform_idx} {}
+
+  StageQueues(int support, int cpu, int mixed, int gpu) {
+    operator[](OpType::SUPPORT) = support;
+    operator[](OpType::CPU) = cpu;
+    operator[](OpType::MIXED) = mixed;
+    operator[](OpType::GPU) = gpu;
+  }
 
  private:
   std::array<int, static_cast<size_t>(OpType::COUNT)> idxs = {{0, 0, 0, 0}};
 };
+
+// Used for indexing into stage queues
+using QueueIdxs = StageQueues;
 
 struct QueueSizes {
   QueueSizes() = default;
@@ -64,7 +78,7 @@ struct OutputIdxs {
   }
 };
 
-static std::ostream &operator<<(std::ostream &os, QueueIdxs idxs) {
+static std::ostream &operator<<(std::ostream &os, StageQueues idxs) {
   os << "{" << idxs[OpType::SUPPORT] << ", " << idxs[OpType::CPU] << ", "
      << idxs[OpType::MIXED] << ", " << idxs[OpType::GPU] << "}";
   return os;

--- a/dali/pipeline/executor/workspace_policy.h
+++ b/dali/pipeline/executor/workspace_policy.h
@@ -167,6 +167,7 @@ op_type_to_workspace_t<op_type> CreateWorkspace(
  * @brief Policy that is responsible for providing executor with workspaces used
  * during RunX() functions.
  */
+// template <typename QueuePolicy>
 // struct WS_Policy {
 //   // Type trait describing how will the workspace be returned (usually by copy or by ref)
 //   template <OpType op_type>
@@ -213,6 +214,7 @@ op_type_to_workspace_t<op_type> CreateWorkspace(
  *
  * Intended to be used with SeparateQueuePolicy
  */
+template <typename QueuePolicy>
 struct JIT_WS_Policy {
   template <OpType op_type>
   using ws_t = op_type_to_workspace_t<op_type>;
@@ -250,16 +252,189 @@ struct JIT_WS_Policy {
   cudaStream_t mixed_op_stream_, gpu_op_stream_;
   std::vector<std::vector<cudaEvent_t>> mixed_op_events_;
   QueueSizes queue_sizes_;
+
+  static_assert(std::is_same<QueuePolicy, SeparateQueuePolicy>::value,
+                "Incompatible QueuePolicy used with this WorkspacePolicy");
 };
+
+inline int SequentialIndex(QueueIdxs idxs, StageQueues depth, OpType last_stage) {
+  constexpr static OpType order[] = {OpType::SUPPORT, OpType::CPU, OpType::MIXED, OpType::GPU};
+  // Horner's method
+  int result = 0;
+  for (auto op_type : order) {
+    result += idxs[op_type];
+    if (op_type == last_stage) {
+      return result;
+    }
+    // We never get here for GPU, so we can safely call next stage
+    result *= depth[NextStage(op_type)];
+  }
+  DALI_FAIL("Error when calculating index - unexpected stage");
+}
+
+/**
+ * @brief Ahead Of Time Workspace Policy
+ *
+ * Creates all workspaces ahead of time
+ */
+template <typename QueuePolicy>
+struct AOT_WS_Policy;
+
+
+/**
+ * @brief Ahead Of Time Workspace Policy for Separated Executor
+ *
+ * Intended to be used with SeparateQueuePolicy, creates all workspaces ahead of time
+ */
+template <>
+struct AOT_WS_Policy<SeparateQueuePolicy> {
+  AOT_WS_Policy() : depths_(0) {}
+
+  template <OpType op_type>
+  using ws_t = op_type_to_workspace_t<op_type> &;
+
+  void InitializeWorkspaceStore(const OpGraph &graph,
+                                const std::vector<tensor_data_store_queue_t> &tensor_to_store_queue,
+                                cudaStream_t mixed_op_stream, cudaStream_t gpu_op_stream,
+                                const std::vector<std::vector<cudaEvent_t>> &mixed_op_events,
+                                const QueueSizes idxs) {
+    depths_ = SeparateQueuePolicy::GetQueueSizes(idxs);
+
+    support_workspaces_.resize(depths_[OpType::SUPPORT]);
+    cpu_workspaces_.resize(depths_[OpType::CPU] * depths_[OpType::SUPPORT]);
+    // Mixed and GPU are bound together due to being outputs
+    // We do not create another layer of ws, as we process Mixed and GPU together
+    mixed_workspaces_.resize(depths_[OpType::MIXED] * depths_[OpType::CPU] *
+                             depths_[OpType::SUPPORT]);
+    gpu_workspaces_.resize(depths_[OpType::MIXED] * depths_[OpType::CPU] *
+                           depths_[OpType::SUPPORT]);
+
+    // now we do cover possible calls for GetWorkspace - for all possible QueueIdxs idxs that
+    // we may get in this call
+    for (int support_id = 0; support_id < depths_[OpType::SUPPORT]; support_id++) {
+      // Get sequential index and prepare space all Support Ops
+      auto queue_idxs = QueueIdxs{support_id, 0, 0, 0};
+      PlaceWorkspace<OpType::SUPPORT>(support_workspaces_, queue_idxs, graph, tensor_to_store_queue,
+                                      mixed_op_stream, gpu_op_stream, mixed_op_events);
+    }
+
+    for (int support_id = 0; support_id < depths_[OpType::SUPPORT]; support_id++) {
+      for (int cpu_id = 0; cpu_id < depths_[OpType::CPU]; cpu_id++) {
+        // Get sequential index and prepare space all CPU Ops
+        auto queue_idxs = QueueIdxs{support_id, cpu_id, 0, 0};
+        PlaceWorkspace<OpType::CPU>(cpu_workspaces_, queue_idxs, graph, tensor_to_store_queue,
+                                    mixed_op_stream, gpu_op_stream, mixed_op_events);
+      }
+    }
+
+    for (int support_id = 0; support_id < depths_[OpType::SUPPORT]; support_id++) {
+      for (int cpu_id = 0; cpu_id < depths_[OpType::CPU]; cpu_id++) {
+        for (int mixed_id = 0; mixed_id < depths_[OpType::MIXED]; mixed_id++) {
+          // Get sequential index and prepare space all MIXED Ops
+          auto queue_idxs = QueueIdxs{support_id, cpu_id, mixed_id, 0};
+          PlaceWorkspace<OpType::MIXED>(mixed_workspaces_, queue_idxs, graph, tensor_to_store_queue,
+                                        mixed_op_stream, gpu_op_stream, mixed_op_events);
+        }
+      }
+    }
+
+    // we reuse the loop for Mixed with GPU as they are in sync
+    for (int support_id = 0; support_id < depths_[OpType::SUPPORT]; support_id++) {
+      for (int cpu_id = 0; cpu_id < depths_[OpType::CPU]; cpu_id++) {
+        for (int mixed_id = 0; mixed_id < depths_[OpType::MIXED]; mixed_id++) {
+          // Get sequential index and prepare space all GPU Ops
+          auto queue_idxs = QueueIdxs{support_id, cpu_id, mixed_id, mixed_id};
+          PlaceWorkspace<OpType::GPU, OpType::MIXED>(gpu_workspaces_, queue_idxs, graph,
+                                                     tensor_to_store_queue, mixed_op_stream,
+                                                     gpu_op_stream, mixed_op_events);
+        }
+      }
+    }
+  }
+
+  template <OpType op_type>
+  ws_t<op_type> GetWorkspace(QueueIdxs idxs, const OpGraph &graph, OpPartitionId partition_idx) {
+    // Handle MIXED and GPU indexing together
+    auto index_for_op_type = op_type == OpType::GPU ? OpType::MIXED : op_type;
+    int sequential_ws_idx = SequentialIndex(idxs, depths_, index_for_op_type);
+    auto &workspaces = GetWorkspacesCollection<op_type>();
+    return workspaces[sequential_ws_idx][partition_idx];
+  }
+
+  template <OpType op_type>
+  ws_t<op_type> GetWorkspace(QueueIdxs idxs, const OpGraph &graph, const OpNode &node) {
+    DALI_ENFORCE(node.op_type == op_type,
+                 "Wrong variant of method selected. OpType does not match.");
+    return GetWorkspace<op_type>(idxs, graph, node.partition_index);
+  }
+
+ private:
+  StageQueues depths_;
+  // ws_id -> op_id -> workspace
+  std::vector<std::vector<SupportWorkspace>> support_workspaces_;
+  std::vector<std::vector<HostWorkspace>> cpu_workspaces_;
+  std::vector<std::vector<MixedWorkspace>> mixed_workspaces_;
+  std::vector<std::vector<DeviceWorkspace>> gpu_workspaces_;
+
+  template <OpType op_type>
+  using ws_collection_t = typename std::vector<std::vector<op_type_to_workspace_t<op_type>>>;
+
+  // Access one of `support_workspaces_`, `cpu_workspaces_`, `mixed_workspaces_`, `gpu_workspaces_`
+  // based on op_type. Below are specialization for the sake of simplicity
+  template <OpType op_type>
+  ws_collection_t<op_type> &GetWorkspacesCollection() {
+    return detail::get<ws_collection_t<op_type>&>(
+        std::tie(support_workspaces_, cpu_workspaces_, mixed_workspaces_, gpu_workspaces_));
+  }
+
+  template <OpType op_type, OpType group_as = op_type, typename T>
+  void PlaceWorkspace(T &workspaces, QueueIdxs idxs, const OpGraph &graph,
+                      const std::vector<tensor_data_store_queue_t> &tensor_to_store_queue,
+                      cudaStream_t mixed_op_stream, cudaStream_t gpu_op_stream,
+                      const std::vector<std::vector<cudaEvent_t>> &mixed_op_events) {
+    int sequential_ws_idx = SequentialIndex(idxs, depths_, group_as);
+    workspaces[sequential_ws_idx].resize(graph.NumOp(op_type));
+    for (OpPartitionId partition_idx = 0; partition_idx < graph.NumOp(op_type); partition_idx++) {
+      auto &node = graph.Node(op_type, partition_idx);
+      workspaces[sequential_ws_idx][partition_idx] =
+          CreateWorkspace<op_type>(graph, node, tensor_to_store_queue, mixed_op_stream,
+                                   gpu_op_stream, mixed_op_events, idxs);
+    }
+  }
+};
+
+template <>
+inline std::vector<std::vector<SupportWorkspace>>&
+    AOT_WS_Policy<SeparateQueuePolicy>::GetWorkspacesCollection<OpType::SUPPORT>() {
+  return support_workspaces_;
+}
+
+template <>
+inline std::vector<std::vector<HostWorkspace>>&
+    AOT_WS_Policy<SeparateQueuePolicy>::GetWorkspacesCollection<OpType::CPU>() {
+  return cpu_workspaces_;
+}
+
+template <>
+inline std::vector<std::vector<MixedWorkspace>>&
+    AOT_WS_Policy<SeparateQueuePolicy>::GetWorkspacesCollection<OpType::MIXED>() {
+  return mixed_workspaces_;
+}
+
+template <>
+inline std::vector<std::vector<DeviceWorkspace>>&
+    AOT_WS_Policy<SeparateQueuePolicy>::GetWorkspacesCollection<OpType::GPU>() {
+  return gpu_workspaces_;
+}
 
 /**
  * @brief Ahead Of Time Workspace Policy
  *
  * Creates all required workspaces during InitializeWorkspaceStore,
  * and provides references to the as required.
- * Inteded to be used with UniforQueuePolicy.
  */
-struct AOT_WS_Policy {
+template <>
+struct AOT_WS_Policy<UniformQueuePolicy> {
   template <OpType op_type>
   using ws_t = op_type_to_workspace_t<op_type> &;
 


### PR DESCRIPTION
Creates all ws for separated executor ahead of time

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>