### PR TITLE
Fix double free in loader destructor and race condition in consumer/producer

### DIFF
--- a/dali/pipeline/operators/reader/caffe2_reader_op.h
+++ b/dali/pipeline/operators/reader/caffe2_reader_op.h
@@ -30,13 +30,7 @@ class Caffe2Reader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   }
 
   void RunImpl(SampleWorkspace* ws, const int i) override {
-    const int idx = ws->data_idx();
-
-    auto* raw_data = GetSample(idx);
-
-    parser_->Parse(*raw_data, ws);
-
-    return;
+    parser_->Parse(GetSample(ws->data_idx()), ws);
   }
 
  protected:

--- a/dali/pipeline/operators/reader/caffe_reader_op.h
+++ b/dali/pipeline/operators/reader/caffe_reader_op.h
@@ -30,13 +30,7 @@ class CaffeReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   }
 
   void RunImpl(SampleWorkspace* ws, const int i) override {
-    const int idx = ws->data_idx();
-
-    auto* raw_data = GetSample(idx);
-
-    parser_->Parse(*raw_data, ws);
-
-    return;
+    parser_->Parse(GetSample(ws->data_idx()), ws);
   }
 
  protected:

--- a/dali/pipeline/operators/reader/coco_reader_op.h
+++ b/dali/pipeline/operators/reader/coco_reader_op.h
@@ -61,13 +61,7 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
   }
 
   void RunImpl(SampleWorkspace* ws, const int i) override {
-    const int idx = ws->data_idx();
-
-    auto* image_label = GetSample(idx);
-
-    parser_->Parse(*image_label, ws);
-
-    return;
+    parser_->Parse(GetSample(ws->data_idx()), ws);
   }
 
  protected:

--- a/dali/pipeline/operators/reader/file_reader_op.h
+++ b/dali/pipeline/operators/reader/file_reader_op.h
@@ -30,25 +30,24 @@ class FileReader : public DataReader<CPUBackend, ImageLabelWrapper> {
   void RunImpl(SampleWorkspace *ws, const int i) override {
     const int idx = ws->data_idx();
 
-    auto* image_label = GetSample(idx);
+    const auto& image_label = GetSample(idx);
 
     // copy from raw_data -> outputs directly
     auto &image_output = ws->Output<CPUBackend>(0);
     auto &label_output = ws->Output<CPUBackend>(1);
 
-    Index image_size = image_label->image.size();
+    Index image_size = image_label.image.size();
 
     image_output.Resize({image_size});
     image_output.mutable_data<uint8_t>();
     label_output.Resize({1});
 
     std::memcpy(image_output.raw_mutable_data(),
-                image_label->image.raw_data(),
+                image_label.image.raw_data(),
                 image_size);
-    image_output.SetSourceInfo(image_label->image.GetSourceInfo());
+    image_output.SetSourceInfo(image_label.image.GetSourceInfo());
 
-    label_output.mutable_data<int>()[0] = image_label->label;
-    return;
+    label_output.mutable_data<int>()[0] = image_label.label;
   }
 
  protected:

--- a/dali/pipeline/operators/reader/loader/file_loader.cc
+++ b/dali/pipeline/operators/reader/loader/file_loader.cc
@@ -90,11 +90,11 @@ vector<std::pair<string, int>> filesystem::traverse_directories(const std::strin
   return file_label_pairs;
 }
 
-void FileLoader::PrepareEmpty(ImageLabelWrapper *image_label) {
-  PrepareEmptyTensor(&image_label->image);
+void FileLoader::PrepareEmpty(ImageLabelWrapper &image_label) {
+  PrepareEmptyTensor(image_label.image);
 }
 
-void FileLoader::ReadSample(ImageLabelWrapper* image_label) {
+void FileLoader::ReadSample(ImageLabelWrapper &image_label) {
   auto image_pair = image_label_pairs_[current_index_++];
 
   // handle wrap-around
@@ -104,25 +104,22 @@ void FileLoader::ReadSample(ImageLabelWrapper* image_label) {
   Index image_size = current_image->Size();
 
   if (copy_read_data_) {
-    image_label->image.Resize({image_size});
+    image_label.image.Resize({image_size});
     // copy the image
-    current_image->Read(image_label->image.mutable_data<uint8_t>(), image_size);
+    current_image->Read(image_label.image.mutable_data<uint8_t>(), image_size);
   } else {
     auto p = current_image->Get(image_size);
     // Wrap the raw data in the Tensor object.
-    image_label->image.ShareData(p, image_size, {image_size});
-
-    TypeInfo type;
-    type.SetType<uint8_t>();
-    image_label->image.set_type(type);
+    image_label.image.ShareData(p, image_size, {image_size});
+    image_label.image.set_type(TypeInfo::Create<uint8_t>());
   }
 
-  image_label->image.SetSourceInfo(image_pair.first);
+  image_label.image.SetSourceInfo(image_pair.first);
   // close the file handle
   current_image->Close();
 
   // copy the label
-  image_label->label = image_pair.second;
+  image_label.label = image_pair.second;
 }
 
 Index FileLoader::Size() {

--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -89,8 +89,8 @@ class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
     Reset(true);
   }
 
-  void PrepareEmpty(ImageLabelWrapper *tensor) override;
-  void ReadSample(ImageLabelWrapper *tensor) override;
+  void PrepareEmpty(ImageLabelWrapper &tensor) override;
+  void ReadSample(ImageLabelWrapper &tensor) override;
 
   Index Size() override;
 

--- a/dali/pipeline/operators/reader/loader/lmdb.h
+++ b/dali/pipeline/operators/reader/loader/lmdb.h
@@ -91,18 +91,18 @@ class LMDBReader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     mdb_env_ = nullptr;
   }
 
-  void ReadSample(Tensor<CPUBackend>* tensor) override {
+  void ReadSample(Tensor<CPUBackend>& tensor) override {
     // assume cursor is valid, read next, loop to start if necessary
     lmdb::SeekLMDB(mdb_cursor_, MDB_NEXT, &key_, &value_);
     ++current_index_;
 
     MoveToNextShard(current_index_);
 
-    tensor->Resize({static_cast<Index>(value_.mv_size)});
-    tensor->mutable_data<uint8_t>();
-    tensor->SetSourceInfo(db_path_ + " at key " + to_string(reinterpret_cast<char*>(key_.mv_data)));
+    tensor.Resize({static_cast<Index>(value_.mv_size)});
+    tensor.set_type(TypeInfo::Create<uint8_t>());
+    tensor.SetSourceInfo(db_path_ + " at key " + to_string(reinterpret_cast<char*>(key_.mv_data)));
 
-    std::memcpy(tensor->raw_mutable_data(),
+    std::memcpy(tensor.raw_mutable_data(),
                 reinterpret_cast<uint8_t*>(value_.mv_data),
                 value_.mv_size*sizeof(uint8_t));
 

--- a/dali/pipeline/operators/reader/loader/loader.h
+++ b/dali/pipeline/operators/reader/loader/loader.h
@@ -16,12 +16,13 @@
 #define DALI_PIPELINE_OPERATORS_READER_LOADER_LOADER_H_
 
 #include <map>
+#include <memory>
 #include <mutex>
 #include <random>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
-#include <type_traits>
 
 #include "dali/common.h"
 #include "dali/error_handling.h"
@@ -43,7 +44,7 @@ DLL_PUBLIC size_t start_index(const size_t shard_id,
 template <typename Backend, typename LoadTarget>
 class Loader {
  public:
-  using LoadTarget_t = LoadTarget;
+  using LoadTargetPtr = std::unique_ptr<LoadTarget>;
   explicit Loader(const OpSpec& options)
     : shuffle_(options.GetArgument<bool>("random_shuffle")),
       initial_buffer_fill_(shuffle_ ? options.GetArgument<int>("initial_fill") : 1),
@@ -64,36 +65,24 @@ class Loader {
     e_ = std::default_random_engine(seq);
   }
 
-  virtual ~Loader() {
-    // delete all the temporary tensors
-    while (!sample_buffer_.empty()) {
-      LoadTarget * t = sample_buffer_.back();
-      delete t;
-      sample_buffer_.pop_back();
-    }
-    while (!empty_tensors_.empty()) {
-      LoadTarget * t = empty_tensors_.back();
-      delete t;
-      empty_tensors_.pop_back();
-    }
-  }
+  virtual ~Loader() = default;
 
-  virtual void PrepareEmpty(LoadTarget *tensor) {
+  virtual void PrepareEmpty(LoadTarget& tensor) {
     PrepareEmptyTensor(tensor);
   }
 
   template <typename T>
   typename std::enable_if<std::is_same<T, Tensor<CPUBackend>>::value>::type
-  PrepareEmptyTensor(T *tensor) {
-    tensor->set_pinned(false);
+  PrepareEmptyTensor(T& tensor) {
+    tensor.set_pinned(false);
     // Initialize tensors to a set size to limit expensive reallocations
-    tensor->Resize({tensor_init_bytes_});
-    tensor->template mutable_data<uint8_t>();
+    tensor.Resize({tensor_init_bytes_});
+    tensor.template mutable_data<uint8_t>();
   }
 
   template <typename T>
   typename std::enable_if<!std::is_same<T, Tensor<CPUBackend>>::value>::type
-  PrepareEmptyTensor(T *) {
+  PrepareEmptyTensor(T&) {
     constexpr bool T_is_Tensor = std::is_same<T, Tensor<CPUBackend>>::value;
     DALI_ENFORCE(T_is_Tensor,
       "Please overload PrepareEmpty for custom LoadTarget type other than Tensor");
@@ -101,28 +90,28 @@ class Loader {
 
 
   // Get a random read sample
-  LoadTarget* ReadOne() {
+  LoadTargetPtr ReadOne() {
     TimeRange tr("[Loader] ReadOne", TimeRange::kGreen1);
     // perform an iniital buffer fill if it hasn't already happened
     if (!initial_buffer_filled_) {
       TimeRange tr("[Loader] Filling initial buffer", TimeRange::kBlue1);
-      std::lock_guard<std::mutex> lock(return_mutex_);
+
       // Read an initial number of samples to fill our
       // sample buffer
       for (int i = 0; i < initial_buffer_fill_; ++i) {
-        LoadTarget* tensor = new LoadTarget();
-        PrepareEmpty(tensor);
-
-        ReadSample(tensor);
-        sample_buffer_.push_back(tensor);
+        auto tensor_ptr = LoadTargetPtr(new LoadTarget());
+        PrepareEmpty(*tensor_ptr);
+        ReadSample(*tensor_ptr);
+        sample_buffer_.push_back(std::move(tensor_ptr));
       }
 
-      TimeRange tr2("[Loader] Filling empty list", TimeRange::kOrange);
       // need some entries in the empty_tensors_ list
+      TimeRange tr2("[Loader] Filling empty list", TimeRange::kOrange);
+      std::lock_guard<std::mutex> lock(empty_tensors_mutex_);
       for (int i = 0; i < initial_empty_size_; ++i) {
-        LoadTarget* tensor = new LoadTarget();
-        PrepareEmpty(tensor);
-        empty_tensors_.push_back(tensor);
+        auto tensor_ptr = LoadTargetPtr(new LoadTarget());
+        PrepareEmpty(*tensor_ptr);
+        empty_tensors_.push_back(std::move(tensor_ptr));
       }
 
       initial_buffer_filled_ = true;
@@ -133,40 +122,36 @@ class Loader {
     // swap end and idx, return the tensor to empties
     std::swap(sample_buffer_[idx], sample_buffer_.back());
     // remove last element
-    LoadTarget* elem = sample_buffer_.back();
+    LoadTargetPtr sample_ptr = std::move(sample_buffer_.back());
     sample_buffer_.pop_back();
 
     // now grab an empty tensor, fill it and add to filled buffers
     // empty_tensors_ needs to be thread-safe w.r.t. RecycleTensor()
     // being called by multiple consumer threads
-    LoadTarget* t;
+    LoadTargetPtr tensor_ptr;
     {
-      std::lock_guard<std::mutex> lock(return_mutex_);
+      std::lock_guard<std::mutex> lock(empty_tensors_mutex_);
       DALI_ENFORCE(empty_tensors_.size() > 0, "No empty tensors - did you forget to return them?");
-      t = empty_tensors_.back();
+      tensor_ptr = std::move(empty_tensors_.back());
       empty_tensors_.pop_back();
     }
-    ReadSample(t);
-    sample_buffer_.push_back(t);
+    ReadSample(*tensor_ptr);
+    sample_buffer_.push_back(std::move(tensor_ptr));
 
-    return elem;
+    return sample_ptr;
   }
 
   // return a tensor to the empty pile
   // called by multiple consumer threads
-  void RecycleTensor(LoadTarget* tensor) {
-    std::lock_guard<std::mutex> lock(return_mutex_);
-    const auto it = std::find(empty_tensors_.begin(), empty_tensors_.end(), tensor);
-    DALI_ENFORCE(it == empty_tensors_.end(),
-      "Tensor " + std::to_string(reinterpret_cast<uint64_t>(tensor)) +
-          " is already in empty_tensors_");
-    empty_tensors_.push_back(tensor);
+  void RecycleTensor(LoadTargetPtr&& tensor_ptr) {
+    std::lock_guard<std::mutex> lock(empty_tensors_mutex_);
+    empty_tensors_.push_back(std::move(tensor_ptr));
   }
 
   // Read an actual sample from the FileStore,
   // used to populate the sample buffer for "shuffled"
   // reads.
-  virtual void ReadSample(LoadTarget* tensor) = 0;
+  virtual void ReadSample(LoadTarget& tensor) = 0;
 
   // Give the size of the data accessed through the Loader
   virtual Index Size() = 0;
@@ -186,9 +171,9 @@ class Loader {
             (stick_to_shard_ && shard_id_ + 1 < num_shards_ &&
             current_index >= static_cast<Index>(start_index(shard_id_ + 1, num_shards_, Size())));
   }
-  std::vector<LoadTarget*> sample_buffer_;
+  std::vector<LoadTargetPtr> sample_buffer_;
 
-  std::vector<LoadTarget*> empty_tensors_;
+  std::vector<LoadTargetPtr> empty_tensors_;
 
   // number of samples to initialize buffer with
   // ~1 minibatch seems reasonable
@@ -204,7 +189,7 @@ class Loader {
   Index seed_;
 
   // control return of tensors
-  std::mutex return_mutex_;
+  std::mutex empty_tensors_mutex_;
 
   // sharding
   const int shard_id_;

--- a/dali/pipeline/operators/reader/loader/loader_test.cc
+++ b/dali/pipeline/operators/reader/loader/loader_test.cc
@@ -51,7 +51,7 @@ TYPED_TEST(DataLoadStoreTest, LMDBTest) {
     // grab an entry from the reader
     auto* sample = reader->ReadOne();
     // return the tensor to the reader for refilling
-    reader->ReturnTensor(sample);
+    reader->RecycleTensor(sample);
   }
 
   return;
@@ -68,7 +68,7 @@ TYPED_TEST(DataLoadStoreTest, LoaderTest) {
     // grab an entry from the reader
     auto* sample = reader->ReadOne();
     // return the tensor to the reader for refilling
-    reader->ReturnTensor(sample);
+    reader->RecycleTensor(sample);
   }
 
   return;
@@ -101,7 +101,7 @@ TYPED_TEST(DataLoadStoreTest, CachedLMDBTest) {
     // grab an entry from the reader
     auto* sample = reader->ReadOne();
     // return the tensor to the reader for refilling
-    reader->ReturnTensor(sample);
+    reader->RecycleTensor(sample);
   }
 
   return;

--- a/dali/pipeline/operators/reader/loader/loader_test.cc
+++ b/dali/pipeline/operators/reader/loader/loader_test.cc
@@ -49,9 +49,8 @@ TYPED_TEST(DataLoadStoreTest, LMDBTest) {
 
   for (int i = 0; i < 10500; ++i) {
     // grab an entry from the reader
-    auto* sample = reader->ReadOne();
     // return the tensor to the reader for refilling
-    reader->RecycleTensor(sample);
+    reader->RecycleTensor(reader->ReadOne());
   }
 
   return;
@@ -66,9 +65,8 @@ TYPED_TEST(DataLoadStoreTest, LoaderTest) {
 
   for (int i = 0; i < 11; ++i) {
     // grab an entry from the reader
-    auto* sample = reader->ReadOne();
     // return the tensor to the reader for refilling
-    reader->RecycleTensor(sample);
+    reader->RecycleTensor(reader->ReadOne());
   }
 
   return;

--- a/dali/pipeline/operators/reader/loader/sequence_loader.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.cc
@@ -94,20 +94,20 @@ std::vector<std::vector<std::string>> GenerateSequences(
 
 }  // namespace detail
 
-void SequenceLoader::PrepareEmpty(TensorSequence *sequence) {
-  sequence->tensors.resize(sequence_length_);
-  for (auto &t : sequence->tensors) {
-    PrepareEmptyTensor(&t);
+void SequenceLoader::PrepareEmpty(TensorSequence &sequence) {
+  sequence.tensors.resize(sequence_length_);
+  for (auto &t : sequence.tensors) {
+    PrepareEmptyTensor(t);
   }
 }
 
-void SequenceLoader::ReadSample(TensorSequence *sequence) {
+void SequenceLoader::ReadSample(TensorSequence &sequence) {
   // TODO(klecki) this is written as a prototype for video handling
   const auto &sequence_paths = sequences_[current_sequence_];
   // TODO(klecki) we probably should buffer the "stream", or recently used
   // frames
   for (int i = 0; i < sequence_length_; i++) {
-    LoadFrame(sequence_paths, i, &sequence->tensors[i]);
+    LoadFrame(sequence_paths, i, &sequence.tensors[i]);
   }
   current_sequence_++;
   // wrap-around
@@ -132,10 +132,7 @@ void SequenceLoader::LoadFrame(const std::vector<std::string> &s, Index frame_id
     auto p = frame->Get(frame_size);
     // Wrap the raw data in the Tensor object.
     target->ShareData(p, frame_size, {frame_size});
-
-    TypeInfo type;
-    type.SetType<uint8_t>();
-    target->set_type(type);
+    target->set_type(TypeInfo::Create<uint8_t>());
   }
   frame->Close();
 }

--- a/dali/pipeline/operators/reader/loader/sequence_loader.h
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.h
@@ -110,8 +110,8 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
     Reset(true);
   }
 
-  void PrepareEmpty(TensorSequence *tensor) override;
-  void ReadSample(TensorSequence *tensor) override;
+  void PrepareEmpty(TensorSequence &tensor) override;
+  void ReadSample(TensorSequence &tensor) override;
   Index Size() override;
 
  private:

--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -436,16 +436,16 @@ std::pair<int, int> VideoLoader::load_width_height(const std::string& filename) 
                         codecpar(stream)->height);
 }
 
-void VideoLoader::PrepareEmpty(SequenceWrapper *tensor) {
-  tensor->initialize(count_, height_, width_, 3);
+void VideoLoader::PrepareEmpty(SequenceWrapper &tensor) {
+  tensor.initialize(count_, height_, width_, 3);
 }
 
-void VideoLoader::ReadSample(SequenceWrapper* tensor) {
+void VideoLoader::ReadSample(SequenceWrapper& tensor) {
     // TODO(spanev) remove the async between the 2 following methods?
     auto& fileidx_frame = frame_starts_[current_frame_idx_];
     push_sequence_to_read(filenames_[fileidx_frame.first], fileidx_frame.second, count_);
-    receive_frames(*tensor);
-    tensor->wait();
+    receive_frames(tensor);
+    tensor.wait();
     ++current_frame_idx_;
 
     MoveToNextShard(current_frame_idx_);

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -165,8 +165,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
     }
   }
 
-  void PrepareEmpty(SequenceWrapper *tensor) override;
-  void ReadSample(SequenceWrapper *tensor) override;
+  void PrepareEmpty(SequenceWrapper &tensor) override;
+  void ReadSample(SequenceWrapper &tensor) override;
   Index Size() override;
 
   OpenFile& get_or_open_file(std::string filename);

--- a/dali/pipeline/operators/reader/mxnet_reader_op.h
+++ b/dali/pipeline/operators/reader/mxnet_reader_op.h
@@ -29,13 +29,7 @@ class MXNetReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   }
 
   void RunImpl(SampleWorkspace* ws, const int i) override {
-    const int idx = ws->data_idx();
-
-    auto* raw_data = GetSample(idx);
-
-    parser_->Parse(*raw_data, ws);
-
-    return;
+    parser_->Parse(GetSample(ws->data_idx()), ws);
   }
 
  protected:

--- a/dali/pipeline/operators/reader/reader_op_test.cc
+++ b/dali/pipeline/operators/reader/reader_op_test.cc
@@ -35,10 +35,9 @@ class DummyLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
   explicit DummyLoader(const OpSpec& spec) :
     Loader<CPUBackend, Tensor<CPUBackend>>(spec) {}
 
-  void ReadSample(Tensor<CPUBackend> *t) override {
-    t->Resize({1});
-    t->mutable_data<uint8>();
-    return;
+  void ReadSample(Tensor<CPUBackend> &t) override {
+    t.Resize({1});
+    t.set_type(TypeInfo::Create<uint8_t>());
   }
 
   Index Size() override {
@@ -73,7 +72,7 @@ class DummyDataReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   void RunImpl(SampleWorkspace* ws, int idx) override {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
-    ws->Output<CPUBackend>(0).Copy(*GetSample(ws->data_idx()), 0);
+    ws->Output<CPUBackend>(0).Copy(GetSample(ws->data_idx()), 0);
   }
 
  private:
@@ -190,9 +189,7 @@ class TestLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
   explicit TestLoader(const OpSpec& spec) :
     Loader<CPUBackend, Tensor<CPUBackend>>(spec), current_index_(0) {}
 
-  void ReadSample(Tensor<CPUBackend> *t) override {
-    return;
-  }
+  void ReadSample(Tensor<CPUBackend> &t) override {}
 
   Index Size() override {
     return 10;

--- a/dali/pipeline/operators/reader/sequence_reader_op.cc
+++ b/dali/pipeline/operators/reader/sequence_reader_op.cc
@@ -19,11 +19,7 @@
 namespace dali {
 
 void SequenceReader::RunImpl(SampleWorkspace* ws, const int i) {
-  const int idx = ws->data_idx();
-
-  auto* sequence = GetSample(idx);
-
-  parser_->Parse(*sequence, ws);
+  parser_->Parse(GetSample(ws->data_idx()), ws);
 }
 
 DALI_REGISTER_OPERATOR(SequenceReader, SequenceReader, CPU);

--- a/dali/pipeline/operators/reader/tfrecord_reader_op.h
+++ b/dali/pipeline/operators/reader/tfrecord_reader_op.h
@@ -32,13 +32,7 @@ class TFRecordReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   }
 
   void RunImpl(SampleWorkspace* ws, const int i) override {
-    const int idx = ws->data_idx();
-
-    auto* raw_data = GetSample(idx);
-
-    parser_->Parse(*raw_data, ws);
-
-    return;
+    parser_->Parse(GetSample(ws->data_idx()), ws);
   }
 
  protected:

--- a/dali/pipeline/operators/reader/video_reader_op.h
+++ b/dali/pipeline/operators/reader/video_reader_op.h
@@ -79,10 +79,10 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
     for (int data_idx = 0; data_idx < batch_size_; ++data_idx) {
       auto* sequence_output = tl_sequence_output.raw_mutable_tensor(data_idx);
 
-      auto* prefetched_sequence = GetSample(data_idx);
+      auto& prefetched_sequence = GetSample(data_idx);
       tl_sequence_output.type().Copy<GPUBackend, GPUBackend>(sequence_output,
-                                  prefetched_sequence->sequence.raw_data(),
-                                  prefetched_sequence->sequence.size(),
+                                  prefetched_sequence.sequence.raw_data(),
+                                  prefetched_sequence.sequence.size(),
                                   ws->stream());
     }
   }


### PR DESCRIPTION
The problem was a race condition with using atomic counter by several worker threads. Using fetch_add to resolve the race condition. 
Bonus: Using smart pointers to prevent any more double deletes to ever happen.

Signed-off-by: Joaquin Anton <janton@nvidia.com>