### PR TITLE
Ensure consistency between different implementations of random crop attr

### DIFF
--- a/dali/pipeline/operators/decoder/decoder_test.h
+++ b/dali/pipeline/operators/decoder/decoder_test.h
@@ -34,7 +34,7 @@ class DecodeTestBase : public GenericDecoderTest<ImgType> {
     image_type_ = image_type;
   }
 
-  inline virtual CropWindowGenerator GetCropWindowGenerator() const {
+  inline virtual CropWindowGenerator GetCropWindowGenerator(int data_idx) const {
     return {};
   }
 
@@ -71,7 +71,7 @@ class DecodeTestBase : public GenericDecoderTest<ImgType> {
       auto data_size = volume(encoded_data.tensor_shape(i));
       this->DecodeImage(
         data, data_size, c, this->ImageType(),
-        &out[i], GetCropWindowGenerator());
+        &out[i], GetCropWindowGenerator(i));
     }
 
     vector<TensorList<CPUBackend> *> outputs(1);

--- a/dali/pipeline/operators/decoder/host_decoder_crop_test.cc
+++ b/dali/pipeline/operators/decoder/host_decoder_crop_test.cc
@@ -19,12 +19,12 @@ namespace dali {
 template <typename ImgType>
 class HostDecoderCropTest : public DecodeTestBase<ImgType> {
  protected:
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return this->GetOpSpec("HostDecoderCrop")
       .AddArg("crop", std::vector<float>{1.0f*crop_H, 1.0f*crop_W});
   }
 
-  CropWindowGenerator GetCropWindowGenerator() const override {
+  CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
     return [this] (int H, int W) {
       CropWindow crop_window;
       crop_window.h = crop_H;

--- a/dali/pipeline/operators/decoder/host_decoder_random_crop_test.cc
+++ b/dali/pipeline/operators/decoder/host_decoder_random_crop_test.cc
@@ -13,35 +13,32 @@
 // limitations under the License.
 
 #include "dali/pipeline/operators/decoder/decoder_test.h"
-#include "dali/util/random_crop_generator.h"
+#include "dali/pipeline/operators/crop/random_crop_attr.h"
 
 namespace dali {
+
+static constexpr int64_t kSeed = 1212334;
 
 template <typename ImgType>
 class HostDecoderRandomCropTest : public DecodeTestBase<ImgType> {
  public:
   HostDecoderRandomCropTest()
-    : random_crop_generator(
-        new RandomCropGenerator(aspect_ratio_range, area_range, seed)) {
-  }
+    : random_crop_attr(
+      OpSpec("RandomCropAttr")
+        .AddArg("batch_size", this->batch_size_)
+        .AddArg("seed", kSeed)) {}
 
  protected:
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return this->GetOpSpec("HostDecoderRandomCrop")
-      .AddArg("seed", seed);
+      .AddArg("seed", kSeed);
   }
 
-  CropWindowGenerator GetCropWindowGenerator() const override {
-    return std::bind(
-      &RandomCropGenerator::GenerateCropWindow,
-      random_crop_generator,
-      std::placeholders::_1, std::placeholders::_2);
+  CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
+    return random_crop_attr.GetCropWindowGenerator(data_idx);
   }
 
-  int64_t seed = 1212334;
-  AspectRatioRange aspect_ratio_range{3.0f/4.0f, 4.0f/3.0f};
-  AreaRange area_range{0.08f, 1.0f};
-  std::shared_ptr<RandomCropGenerator> random_crop_generator;
+  RandomCropAttr random_crop_attr;
 };
 
 typedef ::testing::Types<RGB, BGR, Gray> Types;

--- a/dali/pipeline/operators/decoder/host_decoder_slice_test.cc
+++ b/dali/pipeline/operators/decoder/host_decoder_slice_test.cc
@@ -44,13 +44,13 @@ class HostDecoderSliceTest : public DecodeTestBase<ImgType> {
       inputs.push_back(std::make_pair("crop", &crop_data));
   }
 
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return this->GetOpSpec("HostDecoderSlice")
       .AddInput("begin", "cpu")
       .AddInput("crop", "cpu");
   }
 
-  CropWindowGenerator GetCropWindowGenerator() const override {
+  CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
     return [this] (int H, int W) {
       CropWindow crop_window;
       crop_window.y = crop_y * H;

--- a/dali/pipeline/operators/decoder/host_decoder_test.cc
+++ b/dali/pipeline/operators/decoder/host_decoder_test.cc
@@ -19,7 +19,7 @@ namespace dali {
 template <typename ImgType>
 class HostDecodeTest : public DecodeTestBase<ImgType> {
  protected:
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return this->GetOpSpec("HostDecoder");
   }
 };

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder_crop_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder_crop_test.cc
@@ -19,12 +19,12 @@ namespace dali {
 template <typename ImgType>
 class nvJpegDecoderCropTest : public DecodeTestBase<ImgType> {
  protected:
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return this->GetOpSpec("nvJPEGDecoderCrop", "mixed")
       .AddArg("crop", std::vector<float>{1.0f*crop_H, 1.0f*crop_W});
   }
 
-  CropWindowGenerator GetCropWindowGenerator() const override {
+  CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
     return [this] (int H, int W) {
       CropWindow crop_window;
       crop_window.h = crop_H;

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder_decoupled_api_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder_decoupled_api_test.cc
@@ -19,7 +19,7 @@ namespace dali {
 template <typename ImgType>
 class nvjpegDecodeDecoupledAPITest : public GenericDecoderTest<ImgType> {
  protected:
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return OpSpec("nvJPEGDecoder")
       .AddArg("device", "mixed")
       .AddArg("output_type", this->img_type_)

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder_random_crop_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder_random_crop_test.cc
@@ -13,35 +13,32 @@
 // limitations under the License.
 
 #include "dali/pipeline/operators/decoder/decoder_test.h"
-#include "dali/util/random_crop_generator.h"
+#include "dali/pipeline/operators/crop/random_crop_attr.h"
 
 namespace dali {
+
+static constexpr int64_t kSeed = 1212334;
 
 template <typename ImgType>
 class nvJpegDecoderRandomCropTest : public DecodeTestBase<ImgType> {
  public:
   nvJpegDecoderRandomCropTest()
-    : random_crop_generator(
-      new RandomCropGenerator(aspect_ratio_range, area_range, seed)) {
-  }
+    : random_crop_attr(
+      OpSpec("RandomCropAttr")
+        .AddArg("batch_size", this->batch_size_)
+        .AddArg("seed", kSeed)) {}
 
  protected:
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return this->GetOpSpec("nvJPEGDecoderRandomCrop", "mixed")
-      .AddArg("seed", seed);
+      .AddArg("seed", kSeed);
   }
 
-  CropWindowGenerator GetCropWindowGenerator() const override {
-    return std::bind(
-      &RandomCropGenerator::GenerateCropWindow,
-      random_crop_generator,
-      std::placeholders::_1, std::placeholders::_2);
+  CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
+    return random_crop_attr.GetCropWindowGenerator(data_idx);
   }
 
-  int64_t seed = 1212334;
-  AspectRatioRange aspect_ratio_range{3.0f/4.0f, 4.0f/3.0f};
-  AreaRange area_range{0.08f, 1.0f};
-  std::shared_ptr<RandomCropGenerator> random_crop_generator;
+  RandomCropAttr random_crop_attr;
 };
 
 typedef ::testing::Types<RGB, BGR, Gray> Types;

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder_slice_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder_slice_test.cc
@@ -48,13 +48,13 @@ class nvJpegDecoderSliceTest : public DecodeTestBase<ImgType> {
       inputs.push_back(std::make_pair("crop", &crop_data));
   }
 
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return this->GetOpSpec("nvJPEGDecoderSlice", "mixed")
       .AddInput("begin", "cpu")
       .AddInput("crop", "cpu");
   }
 
-  CropWindowGenerator GetCropWindowGenerator() const override {
+  CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
     return [this] (int H, int W) {
       CropWindow crop_window;
       crop_window.y = crop_y * H;

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder_split_crop_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder_split_crop_test.cc
@@ -19,13 +19,13 @@ namespace dali {
 template <typename ImgType>
 class nvJpegDecoderSplitCropTest : public DecodeTestBase<ImgType> {
  protected:
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return this->GetOpSpec("nvJPEGDecoderCrop", "mixed")
       .AddArg("crop", std::vector<float>{1.0f*crop_H, 1.0f*crop_W})
       .AddArg("split_stages", true);
   }
 
-  CropWindowGenerator GetCropWindowGenerator() const override {
+  CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
     return [this] (int H, int W) {
       CropWindow crop_window;
       crop_window.h = crop_H;

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder_split_random_crop_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder_split_random_crop_test.cc
@@ -13,36 +13,33 @@
 // limitations under the License.
 
 #include "dali/pipeline/operators/decoder/decoder_test.h"
-#include "dali/util/random_crop_generator.h"
+#include "dali/pipeline/operators/crop/random_crop_attr.h"
 
 namespace dali {
+
+static constexpr int64_t kSeed = 1212334;
 
 template <typename ImgType>
 class nvJpegDecoderSplitRandomCropTest : public DecodeTestBase<ImgType> {
  public:
   nvJpegDecoderSplitRandomCropTest()
-    : random_crop_generator(
-      new RandomCropGenerator(aspect_ratio_range, area_range, seed)) {
-  }
+    : random_crop_attr(
+      OpSpec("RandomCropAttr")
+        .AddArg("batch_size", this->batch_size_)
+        .AddArg("seed", kSeed)) {}
 
  protected:
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return this->GetOpSpec("nvJPEGDecoderRandomCrop", "mixed")
-      .AddArg("seed", seed)
+      .AddArg("seed", kSeed)
       .AddArg("split_stages", true);
   }
 
-  CropWindowGenerator GetCropWindowGenerator() const override {
-    return std::bind(
-      &RandomCropGenerator::GenerateCropWindow,
-      random_crop_generator,
-      std::placeholders::_1, std::placeholders::_2);
+  CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
+    return random_crop_attr.GetCropWindowGenerator(data_idx);
   }
 
-  int64_t seed = 1212334;
-  AspectRatioRange aspect_ratio_range{3.0f/4.0f, 4.0f/3.0f};
-  AreaRange area_range{0.08f, 1.0f};
-  std::shared_ptr<RandomCropGenerator> random_crop_generator;
+  RandomCropAttr random_crop_attr;
 };
 
 typedef ::testing::Types<RGB, BGR, Gray> Types;

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder_split_slice_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder_split_slice_test.cc
@@ -48,14 +48,14 @@ class nvJpegDecoderSplitSliceTest : public DecodeTestBase<ImgType> {
       inputs.push_back(std::make_pair("crop", &crop_data));
   }
 
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return this->GetOpSpec("nvJPEGDecoderSlice", "mixed")
       .AddArg("split_stages", true)
       .AddInput("begin", "cpu")
       .AddInput("crop", "cpu");
   }
 
-  CropWindowGenerator GetCropWindowGenerator() const override {
+  CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
     return [this] (int H, int W) {
       CropWindow crop_window;
       crop_window.y = crop_y * H;

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder_split_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder_split_test.cc
@@ -19,7 +19,7 @@ namespace dali {
 template <typename ImgType>
 class nvjpegDecodeSplitTest : public GenericDecoderTest<ImgType> {
  protected:
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return OpSpec("nvJPEGDecoder")
       .AddArg("device", "mixed")
       .AddArg("output_type", this->img_type_)

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder_test.cc
@@ -19,7 +19,7 @@ namespace dali {
 template <typename ImgType>
 class nvjpegDecodeTest : public GenericDecoderTest<ImgType> {
  protected:
-  const OpSpec DecodingOp() const override {
+  OpSpec DecodingOp() const override {
     return OpSpec("nvJPEGDecoder")
       .AddArg("device", "mixed")
       .AddArg("output_type", this->img_type_)

--- a/dali/pipeline/operators/resize/random_resized_crop.cc
+++ b/dali/pipeline/operators/resize/random_resized_crop.cc
@@ -69,7 +69,7 @@ void RandomResizedCrop<CPUBackend>::SetupSharedSampleParams(SampleWorkspace *ws)
   int W = input_shape[1];
   int id = ws->data_idx();
 
-  params_.crops[id] = params_.crop_gens[id].GenerateCropWindow(H, W);
+  crops_[id] = GetCropWindowGenerator(id)(H, W);
   resample_params_[ws->thread_idx()] = CalcResamplingParams(id);
 }
 

--- a/dali/pipeline/operators/resize/random_resized_crop.cu
+++ b/dali/pipeline/operators/resize/random_resized_crop.cu
@@ -54,7 +54,7 @@ void RandomResizedCrop<GPUBackend>::SetupSharedSampleParams(DeviceWorkspace *ws)
     int H = input_shape[0];
     int W = input_shape[1];
 
-    params_.crops[i] = params_.crop_gens[i].GenerateCropWindow(H, W);
+    crops_[i] = GetCropWindowGenerator(i)(H, W);
   }
   CalcResamplingParams();
 }

--- a/dali/pipeline/operators/resize/random_resized_crop.h
+++ b/dali/pipeline/operators/resize/random_resized_crop.h
@@ -24,27 +24,22 @@
 #include "dali/pipeline/operators/op_spec.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/pipeline/operators/resize/resize_base.h"
-#include "dali/util/random_crop_generator.h"
+#include "dali/pipeline/operators/crop/random_crop_attr.h"
 #include "dali/kernels/imgproc/resample/params.h"
 
 namespace dali {
 
 template <typename Backend>
 class RandomResizedCrop : public Operator<Backend>
-                        , protected ResizeBase {
+                        , protected ResizeBase
+                        , protected RandomCropAttr {
  public:
   explicit inline RandomResizedCrop(const OpSpec &spec)
       : Operator<Backend>(spec)
       , ResizeBase(spec)
-      , num_attempts_(spec.GetArgument<int>("num_attempts"))
+      , RandomCropAttr(spec)
       , interp_type_(spec.GetArgument<DALIInterpType>("interp_type")) {
     GetSingleOrRepeatedArg(spec, &size_, "size", 2);
-    GetSingleOrRepeatedArg(spec, &aspect_ratio_range_, "random_aspect_ratio", 2);
-    GetSingleOrRepeatedArg(spec, &area_range_, "random_area", 2);
-    DALI_ENFORCE(aspect_ratio_range_[0] <= aspect_ratio_range_[1],
-        "Provided empty range");
-    DALI_ENFORCE(area_range_[0] <= area_range_[1],
-        "Provided empty range");
     InitParams(spec);
     BackendInit();
   }
@@ -62,39 +57,15 @@ class RandomResizedCrop : public Operator<Backend>
  private:
   void BackendInit();
 
-  struct Params {
-    void Initialize(
-        int num_gens,
-        int64_t seed,
-        const std::pair<float, float> &aspect_ratio_range,
-        const std::pair<float, float> &area_range,
-        int num_attempts) {
-      std::seed_seq seq{seed};
-      std::vector<int> seeds(num_gens);
-      seq.generate(seeds.begin(), seeds.end());
-
-      crop_gens.resize(num_gens);
-      for (int i = 0; i < num_gens; i++) {
-        crop_gens[i] = RandomCropGenerator(aspect_ratio_range, area_range, seeds[i], num_attempts);
-      }
-
-      crops.resize(num_gens);
-    }
-
-    std::vector<RandomCropGenerator> crop_gens;
-    std::vector<CropWindow> crops;
-  };
-
-
   void CalcResamplingParams() {
-    const int n = params_.crops.size();
+    const int n = crops_.size();
     resample_params_.resize(n);
     for (int i = 0; i < n; i++)
       resample_params_[i] = CalcResamplingParams(i);
   }
 
   kernels::ResamplingParams2D CalcResamplingParams(int index) const {
-    auto &wnd = params_.crops[index];
+    auto &wnd = crops_[index];
     auto params = shared_params_;
     params[0].roi = kernels::ResamplingParams::ROI(wnd.y, wnd.y+wnd.h);
     params[1].roi = kernels::ResamplingParams::ROI(wnd.x, wnd.x+wnd.w);
@@ -102,28 +73,17 @@ class RandomResizedCrop : public Operator<Backend>
   }
 
   void InitParams(const OpSpec &spec) {
-    auto seed = spec.GetArgument<int64_t>("seed");
-    params_.Initialize(
-        batch_size_, seed,
-        { aspect_ratio_range_[0], aspect_ratio_range_[1] },
-        { area_range_[0], area_range_[1] },
-        num_attempts_);
-
+    crops_.resize(batch_size_);
     shared_params_[0].output_size = size_[0];
     shared_params_[1].output_size = size_[1];
     shared_params_[0].min_filter = shared_params_[1].min_filter = min_filter_;
     shared_params_[0].mag_filter = shared_params_[1].mag_filter = mag_filter_;
   }
 
-  Params params_;
-  int num_attempts_;
-
   std::vector<int> size_;
   DALIInterpType interp_type_;
   kernels::ResamplingParams2D shared_params_;
-
-  std::vector<float> aspect_ratio_range_;
-  std::vector<float> area_range_;
+  std::vector<CropWindow> crops_;
 };
 
 }  // namespace dali

--- a/dali/test/dali_test_decoder.h
+++ b/dali/test/dali_test_decoder.h
@@ -38,7 +38,7 @@ class GenericDecoderTest : public DALISingleOpTest<ImgType> {
   }
 
  protected:
-  virtual const OpSpec DecodingOp() const { return OpSpec(); }
+  virtual OpSpec DecodingOp() const { return OpSpec(); }
 
   inline uint32_t GetTestCheckType() const override {
     return t_checkColorComp;  // + t_checkElements + t_checkAll + t_checkNoAssert;


### PR DESCRIPTION
We found that different implementations of RandomCrop don't produce the same random cropping windows when provided with the same seed.
This PR attempts to unify the implementation to ensure consistency

Signed-off-by: Joaquin Anton <janton@nvidia.com>