### PR TITLE
[WiP] LLVM code coverage support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,32 @@ option(BUILD_NVOF "Build with NVIDIA OPTICAL FLOW SDK support" ON)
 option(BUILD_NVDEC "Build with NVIDIA NVDEC support" ON)
 option(BUILD_NVML "Build with NVIDIA Management Library (NVML) support" ON)
 
+option(COVERAGE_SOURCE "Use LLVM Source-based Code Coverage build" OFF)
+option(COVERAGE_SANITIZER "Use LLVM Sanitizer-based Code Coverage build" OFF)
+option(USE_ADDITIONAL_CLANG_CXX_FLAGS "Use ADDITIONAL_CLANG_CXX_FLAGS variable that is passed only to Clang, do not propagete those flags to CUDA" OFF)
+
+if (COVERAGE_SOURCE AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  message(ERROR "LLVM Source-based Code Coverage build requires Clang compiler")
+endif()
+
+if (COVERAGE_SANITIZER AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  message(ERROR "LLVM Sanitizer-based Code Coverage build requires Clang compiler")
+endif()
+
+if (COVERAGE_SOURCE OR COVERAGE_SANITIZER)
+  message(STATUS "Using coverage build, turning on USE_ADDITIONAL_CLANG_CXX_FLAGS")
+  set(USE_ADDITIONAL_CLANG_CXX_FLAGS ON)
+endif()
+
+if (USE_ADDITIONAL_CLANG_CXX_FLAGS)
+  message(WARNING "USE_ADDITIONAL_CLANG_CXX_FLAGS: ON, will generate CUDA_NVCC_FLAGS by hand")
+endif()
+
+if (COVERAGE_SOURCE AND COVERAGE_SANITIZER)
+  message(ERROR "Only one type of LLVM Code Coverage can be used at a time")
+endif()
+
+
 option(WERROR "Threat all warnings as errors" OFF)
 
 # FFmpeg is required when we are using NVDEC for video reader
@@ -100,24 +126,35 @@ endif()
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register -Wsign-compare")
 
-  # Mimic the generation of -Xcompiler flags by CMake - list separated by commas
-  # presented as espaced strings: -Xcompiler ,\"-Wall\",\"-Wno-unused-variable\"
-  set(XCOMPILER_FLAGS "${CMAKE_CXX_FLAGS}")
-  string(STRIP "${CMAKE_CXX_FLAGS}" XCOMPILER_FLAGS)
-  # String to list
-  string(REPLACE " " ";" XCOMPILER_FLAGS ${XCOMPILER_FLAGS})
-  # Map list `element` to  ,\"element\"
-  list(TRANSFORM XCOMPILER_FLAGS APPEND "\\\"")
-  list(TRANSFORM XCOMPILER_FLAGS PREPEND ",\\\"")
-  # Rebuild a string
-  string(CONCAT XCOMPILER_FLAGS ${XCOMPILER_FLAGS})
-  message(STATUS "${XCOMPILER_FLAGS}")
-  # Turn off flags propagation and do it manually
-  set(CUDA_PROPAGATE_HOST_FLAGS OFF)
-  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11 -Xcompiler ${XCOMPILER_FLAGS}")
+  if (USE_ADDITIONAL_CLANG_CXX_FLAGS)
+    # Mimic the generation of -Xcompiler flags by CMake - list separated by commas
+    # presented as espaced strings: -Xcompiler ,\"-Wall\",\"-Wno-unused-variable\"
+    set(XCOMPILER_FLAGS "${CMAKE_CXX_FLAGS}")
+    string(STRIP "${CMAKE_CXX_FLAGS}" XCOMPILER_FLAGS)
+    # String to list
+    string(REPLACE " " ";" XCOMPILER_FLAGS ${XCOMPILER_FLAGS})
+    # Map list `element` to  ,\"element\"
+    list(TRANSFORM XCOMPILER_FLAGS APPEND "\\\"")
+    list(TRANSFORM XCOMPILER_FLAGS PREPEND ",\\\"")
+    # Rebuild a string
+    string(CONCAT XCOMPILER_FLAGS ${XCOMPILER_FLAGS})
+    message(STATUS "XCOMPILER_FLAGS = ${XCOMPILER_FLAGS}")
+    # Turn off flags propagation and do it manually
+    set(CUDA_PROPAGATE_HOST_FLAGS OFF)
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11 -Xcompiler ${XCOMPILER_FLAGS}")
 
-  # Set Clang specific flags
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wimplicit-fallthrough")
+    # Set Clang specific flags
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wimplicit-fallthrough ${ADDITIONAL_CLANG_CXX_FLAGS}")
+
+    if (COVERAGE_SOURCE)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+    endif()
+    if (COVERAGE_SANITIZER)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize-coverage=trace-pc-guard -fsanitize=address")
+    endif()
+  endif()
+
+
 
   # CUDA does not support current clang as host compiler, we need use gcc
   # CUDA_HOST_COMPILER variable operates on paths

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,12 +132,14 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(XCOMPILER_FLAGS "${CMAKE_CXX_FLAGS}")
     string(STRIP "${CMAKE_CXX_FLAGS}" XCOMPILER_FLAGS)
     # String to list
-    string(REPLACE " " ";" XCOMPILER_FLAGS ${XCOMPILER_FLAGS})
+    string(REPLACE " " ";" XCOMPILER_FLAGS_LIST ${XCOMPILER_FLAGS})
+    set(XCOMPILER_FLAGS_QUOTED "")
     # Map list `element` to  ,\"element\"
-    list(TRANSFORM XCOMPILER_FLAGS APPEND "\\\"")
-    list(TRANSFORM XCOMPILER_FLAGS PREPEND ",\\\"")
+    foreach(flag ${XCOMPILER_FLAGS_LIST})
+      list(APPEND XCOMPILER_FLAGS_QUOTED ",\\\"${flag}\\\"")
+    endforeach(flag)
     # Rebuild a string
-    string(CONCAT XCOMPILER_FLAGS ${XCOMPILER_FLAGS})
+    string(CONCAT XCOMPILER_FLAGS ${XCOMPILER_FLAGS_QUOTED})
     message(STATUS "XCOMPILER_FLAGS = ${XCOMPILER_FLAGS}")
     # Turn off flags propagation and do it manually
     set(CUDA_PROPAGATE_HOST_FLAGS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,25 @@ endif()
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register -Wsign-compare")
 
+  # Mimic the generation of -Xcompiler flags by CMake - list separated by commas
+  # presented as espaced strings: -Xcompiler ,\"-Wall\",\"-Wno-unused-variable\"
+  set(XCOMPILER_FLAGS "${CMAKE_CXX_FLAGS}")
+  string(STRIP "${CMAKE_CXX_FLAGS}" XCOMPILER_FLAGS)
+  # String to list
+  string(REPLACE " " ";" XCOMPILER_FLAGS ${XCOMPILER_FLAGS})
+  # Map list `element` to  ,\"element\"
+  list(TRANSFORM XCOMPILER_FLAGS APPEND "\\\"")
+  list(TRANSFORM XCOMPILER_FLAGS PREPEND ",\\\"")
+  # Rebuild a string
+  string(CONCAT XCOMPILER_FLAGS ${XCOMPILER_FLAGS})
+  message(STATUS "${XCOMPILER_FLAGS}")
+  # Turn off flags propagation and do it manually
+  set(CUDA_PROPAGATE_HOST_FLAGS OFF)
+  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11 -Xcompiler ${XCOMPILER_FLAGS}")
+
+  # Set Clang specific flags
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wimplicit-fallthrough")
+
   # CUDA does not support current clang as host compiler, we need use gcc
   # CUDA_HOST_COMPILER variable operates on paths
   if (${CUDA_HOST_COMPILER} MATCHES "clang")

--- a/qa/setup_dali_extra.sh
+++ b/qa/setup_dali_extra.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Fetch test data
-export DALI_EXTRA_PATH=/opt/dali_extra
+export DALI_EXTRA_PATH=${DALI_EXTRA_PATH:-/opt/dali_extra}
 DALI_EXTRA_URL="https://github.com/NVIDIA/DALI_extra.git"
 if [ ! -d "$DALI_EXTRA_PATH" ] ; then
     git clone --depth=1 "$DALI_EXTRA_URL" "$DALI_EXTRA_PATH"

--- a/tools/coverage_sanitizer.sh
+++ b/tools/coverage_sanitizer.sh
@@ -3,8 +3,9 @@
 # Based on https://clang.llvm.org/docs/SanitizerCoverage.html
 
 mkdir -p build_coverage_sanitizer
-cd build_coverage_sanitizer
+pushd build_coverage_sanitizer
 cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_LMDB=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCOVERAGE_SANITIZER=ON ..
+make -j"$(nproc)"
 
 # Run
 ASAN_OPTIONS=protect_shadow_gap=0:detect_odr_violation=0:coverage=1 ./dali/python/nvidia/dali/test/dali_test.bin
@@ -15,3 +16,5 @@ ASAN_OPTIONS=protect_shadow_gap=0:detect_odr_violation=0:coverage=1 ./dali/pytho
 # Get the coverage-report-server.py from https://github.com/llvm-mirror/llvm/blob/master/tools/sancov/coverage-report-server.py
 # Run the server to analize
 # coverage-report-server.py --symcov dali_test.bin.symcov --srcpath ..
+
+popd

--- a/tools/coverage_sanitizer.sh
+++ b/tools/coverage_sanitizer.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Based on https://clang.llvm.org/docs/SanitizerCoverage.html
+
+mkdir -p build_coverage_sanitizer
+cd build_coverage_sanitizer
+cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_LMDB=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCOVERAGE_SANITIZER=ON ..
+
+# Run
+ASAN_OPTIONS=protect_shadow_gap=0:detect_odr_violation=0:coverage=1 ./dali/python/nvidia/dali/test/dali_test.bin
+# Symbolize
+# TODO get the name of generated file
+# sancov-6.0 -symbolize dali_test.bin.8991.sancov ./dali/python/nvidia/dali/test/dali_test.bin > dali_test.bin.symcov
+
+# Get the coverage-report-server.py from https://github.com/llvm-mirror/llvm/blob/master/tools/sancov/coverage-report-server.py
+# Run the server to analize
+# coverage-report-server.py --symcov dali_test.bin.symcov --srcpath ..

--- a/tools/coverage_source.sh
+++ b/tools/coverage_source.sh
@@ -4,17 +4,20 @@
 
 mkdir -p build_coverage_source
 pushd build_coverage_source
-# cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_LMDB=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCOVERAGE_SOURCE=ON ..
+cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_LMDB=ON -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE_SOURCE=ON ..
 make -j$(nproc)
 
-# Run
-LLVM_PROFILE_FILE="dali_test.profraw" ./dali/python/nvidia/dali/test/dali_test.bin
+export DALI_EXTRA_PATH=dali_extra
+source ../qa/setup_dali_extra.sh
+
+# Run, and allow it to fail
+LLVM_PROFILE_FILE="dali_test.profraw" ./dali/python/nvidia/dali/test/dali_test.bin || true
 # Index the raw profile.
 llvm-profdata merge -sparse dali_test.profraw -o dali_test.profdata
 # Create file and function level reports
 llvm-cov report ./dali/python/nvidia/dali/test/dali_test.bin -instr-profile=dali_test.profdata > cov-report
-llvm-cov report ./dali/python/nvidia/dali/test/dali_test.bin -show-functions -instr-profile=dali_test.profdata -Xdemangler=c++filt .. > cov-report-functions
+llvm-cov report ./dali/python/nvidia/dali/test/dali_test.bin -show-functions -instr-profile=dali_test.profdata -Xdemangler=llvm-cxxfilt .. > cov-report-functions
 # Create a line-oriented coverage report
-llvm-cov show -format html ./dali/python/nvidia/dali/test/dali_test.bin -instr-profile=dali_test.profdata > cov-src.html
+llvm-cov show -format html ./dali/python/nvidia/dali/test/dali_test.bin -instr-profile=dali_test.profdata -Xdemangler=llvm-cxxfilt > cov-src.html
 
 popd

--- a/tools/coverage_source.sh
+++ b/tools/coverage_source.sh
@@ -1,13 +1,14 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 # Based on https://clang.llvm.org/docs/SourceBasedCodeCoverage.html
 
 mkdir -p build_coverage_source
-cd build_coverage_source
-cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_LMDB=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCOVERAGE_SOURCE=ON ..
+pushd build_coverage_source
+# cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_LMDB=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCOVERAGE_SOURCE=ON ..
+make -j$(nproc)
 
 # Run
-LLVM_PROFILE_FILE="dali_test.profraw"  ./dali/python/nvidia/dali/test/dali_test.bin
+LLVM_PROFILE_FILE="dali_test.profraw" ./dali/python/nvidia/dali/test/dali_test.bin
 # Index the raw profile.
 llvm-profdata merge -sparse dali_test.profraw -o dali_test.profdata
 # Create file and function level reports
@@ -15,3 +16,5 @@ llvm-cov report ./dali/python/nvidia/dali/test/dali_test.bin -instr-profile=dali
 llvm-cov report ./dali/python/nvidia/dali/test/dali_test.bin -show-functions -instr-profile=dali_test.profdata -Xdemangler=c++filt .. > cov-report-functions
 # Create a line-oriented coverage report
 llvm-cov show -format html ./dali/python/nvidia/dali/test/dali_test.bin -instr-profile=dali_test.profdata > cov-src.html
+
+popd

--- a/tools/coverage_source.sh
+++ b/tools/coverage_source.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Based on https://clang.llvm.org/docs/SourceBasedCodeCoverage.html
+
+mkdir -p build_coverage_source
+cd build_coverage_source
+cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_LMDB=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCOVERAGE_SOURCE=ON ..
+
+# Run
+LLVM_PROFILE_FILE="dali_test.profraw"  ./dali/python/nvidia/dali/test/dali_test.bin
+# Index the raw profile.
+llvm-profdata merge -sparse dali_test.profraw -o dali_test.profdata
+# Create file and function level reports
+llvm-cov report ./dali/python/nvidia/dali/test/dali_test.bin -instr-profile=dali_test.profdata > cov-report
+llvm-cov report ./dali/python/nvidia/dali/test/dali_test.bin -show-functions -instr-profile=dali_test.profdata -Xdemangler=c++filt .. > cov-report-functions
+# Create a line-oriented coverage report
+llvm-cov show -format html ./dali/python/nvidia/dali/test/dali_test.bin -instr-profile=dali_test.profdata > cov-src.html


### PR DESCRIPTION
Separate Clang flags from Cuda host compiler flags.
Add coverage options to CMake.
Add "example" scripts.