### PR TITLE
Change Og to O0 to enable debug symbols in stacktrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ include(cmake/Dependencies.cmake)
 # add more flags after they are populated by find_package from Dependencies.cmake
 
 # Debug flags
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb -Og -DDALI_DEBUG=1")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb -O0 -DDALI_DEBUG=1")
 # Generate only line info for device as -G disables all optimizations and causes unit tests to fail
 set(CUDA_NVCC_FLAGS_DEBUG "${CUDA_NVCC_FLAGS_DEBUG} -g -lineinfo -DDALI_DEBUG=1")
 
@@ -118,4 +118,3 @@ add_subdirectory(dali)
 file(WRITE ${CMAKE_BINARY_DIR}/dali/__init__.py "")
 
 add_custom_target(lint COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/lint.cmake)
-


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>