### PR TITLE
[WIP] Release buffers in separeted executor after it is processed

### DIFF
--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -509,6 +509,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::ShareOutputs(DeviceWorkspace *ws) {
       ), DALI_FAIL("Invalid op type"));  // NOLINT(whitespace/parens)
     }
   }
+  QueuePolicy::ReleaseNonOutputIdxs();
 }
 
 template <typename WorkspacePolicy, typename QueuePolicy>


### PR DESCRIPTION
This fixes Separated Executor error:
Mixed stage was releasing CPU outputs (marking them as free),
but they might still be in use as Mixed can work in
asynchronous manner on a stream.
Now we release all the output buffers (as free) from the stages
only when we know all the processing was finished and data was
consumed properly.

This release can be done as soon as we synchronize
GPU for ShareOutputs call.

Another possible solution is to put a callback on a stream
that will release the buffers as soon as they are consumed

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>