### PR TITLE
Move Loader metadata parsing out of ctor

### DIFF
--- a/dali/pipeline/operators/reader/caffe2_reader_op.h
+++ b/dali/pipeline/operators/reader/caffe2_reader_op.h
@@ -25,7 +25,7 @@ class Caffe2Reader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit Caffe2Reader(const OpSpec& spec)
   : DataReader<CPUBackend, Tensor<CPUBackend>>(spec) {
-    loader_.reset(new LMDBReader(spec));
+    loader_ = InitLoader<LMDBReader>(spec);
     parser_.reset(new Caffe2Parser(spec));
   }
 

--- a/dali/pipeline/operators/reader/caffe_reader_op.h
+++ b/dali/pipeline/operators/reader/caffe_reader_op.h
@@ -25,7 +25,7 @@ class CaffeReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit CaffeReader(const OpSpec& spec)
   : DataReader<CPUBackend, Tensor<CPUBackend>>(spec) {
-    loader_.reset(new LMDBReader(spec));
+    loader_ = InitLoader<LMDBReader>(spec);
     parser_.reset(new CaffeParser(spec));
   }
 

--- a/dali/pipeline/operators/reader/coco_reader_op.h
+++ b/dali/pipeline/operators/reader/coco_reader_op.h
@@ -56,15 +56,15 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
         "shuffle_after_epoch and stick_to_shard cannot be both true");
 
     if (spec.HasArgument("file_list"))
-      loader_.reset(new FileLoader(
+      loader_ = InitLoader<FileLoader>(
         spec,
         std::vector<std::pair<string, int>>(),
-        shuffle_after_epoch));
+        shuffle_after_epoch);
     else
-      loader_.reset(new FileLoader(
+      loader_ = InitLoader<FileLoader>(
         spec,
         image_id_pairs_,
-        shuffle_after_epoch));
+        shuffle_after_epoch);
     parser_.reset(new COCOParser(spec, annotations_multimap_, save_img_ids_));
   }
 

--- a/dali/pipeline/operators/reader/file_reader_op.h
+++ b/dali/pipeline/operators/reader/file_reader_op.h
@@ -24,7 +24,7 @@ class FileReader : public DataReader<CPUBackend, ImageLabelWrapper> {
  public:
   explicit FileReader(const OpSpec& spec)
     : DataReader<CPUBackend, ImageLabelWrapper>(spec) {
-    loader_.reset(new FileLoader(spec));
+    loader_ = InitLoader<FileLoader>(spec);
   }
 
   void RunImpl(SampleWorkspace *ws, const int i) override {

--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -56,16 +56,15 @@ class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
       shuffle_after_epoch_(shuffle_after_epoch),
       current_index_(0),
       current_epoch_(0) {
+    mmap_reserver = FileStream::FileStreamMappinReserver(
+        static_cast<unsigned int>(initial_buffer_fill_));
+    copy_read_data_ = !mmap_reserver.CanShareMappedData();
   }
 
   void PrepareEmpty(ImageLabelWrapper &tensor) override;
   void ReadSample(ImageLabelWrapper &tensor) override;
 
   void PrepareMetadata() override {
-    mmap_reserver = FileStream::FileStreamMappinReserver(
-        static_cast<unsigned int>(initial_buffer_fill_));
-    copy_read_data_ = !mmap_reserver.CanShareMappedData();
-
     if (image_label_pairs_.empty()) {
       if (file_list_ == "") {
         image_label_pairs_ = filesystem::traverse_directories(file_root_);

--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -51,11 +51,17 @@ class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
     bool shuffle_after_epoch = false)
     : Loader<CPUBackend, ImageLabelWrapper>(spec),
       file_root_(spec.GetArgument<string>("file_root")),
+      file_list_(spec.GetArgument<string>("file_list")),
       image_label_pairs_(image_label_pairs),
       shuffle_after_epoch_(shuffle_after_epoch),
       current_index_(0),
       current_epoch_(0) {
-    file_list_ = spec.GetArgument<string>("file_list");
+  }
+
+  void PrepareEmpty(ImageLabelWrapper &tensor) override;
+  void ReadSample(ImageLabelWrapper &tensor) override;
+
+  void PrepareMetadata() override {
     mmap_reserver = FileStream::FileStreamMappinReserver(
         static_cast<unsigned int>(initial_buffer_fill_));
     copy_read_data_ = !mmap_reserver.CanShareMappedData();
@@ -88,9 +94,6 @@ class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
     }
     Reset(true);
   }
-
-  void PrepareEmpty(ImageLabelWrapper &tensor) override;
-  void ReadSample(ImageLabelWrapper &tensor) override;
 
   Index Size() override;
 

--- a/dali/pipeline/operators/reader/loader/indexed_file_loader.h
+++ b/dali/pipeline/operators/reader/loader/indexed_file_loader.h
@@ -29,12 +29,9 @@ namespace dali {
 
 class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
  public:
-  explicit IndexedFileLoader(const OpSpec& options, bool init = true)
+  explicit IndexedFileLoader(const OpSpec& options)
     : Loader(options),
       current_file_(nullptr) {
-      // trick for https://stackoverflow.com/questions/962132/calling-virtual-functions-inside-constructors
-      if (init)
-        Init(options);
     }
 
   void ReadSample(Tensor<CPUBackend>& tensor) override {
@@ -112,7 +109,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
   }
 
  protected:
-  void Init(const OpSpec& options) {
+  void PrepareMetadata(const OpSpec& options) {
     uris_ = options.GetRepeatedArgument<std::string>("path");
     DALI_ENFORCE(!uris_.empty(), "No files specified.");
     std::vector<std::string> index_uris = options.GetRepeatedArgument<std::string>("index_path");

--- a/dali/pipeline/operators/reader/loader/lmdb.h
+++ b/dali/pipeline/operators/reader/loader/lmdb.h
@@ -67,6 +67,7 @@ class LMDBReader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     : Loader(options),
       db_path_(options.GetArgument<string>("path")) {
   }
+
   ~LMDBReader() override {
     mdb_cursor_close(mdb_cursor_);
     mdb_dbi_close(mdb_env_, mdb_dbi_);

--- a/dali/pipeline/operators/reader/loader/loader.cc
+++ b/dali/pipeline/operators/reader/loader/loader.cc
@@ -43,7 +43,7 @@ processing is CPU stage-bound, trading memory consumption for better interleavin
       R"code(If set to true, loading data will be skipped when the sample is present in the decoder cache.
 In such case the output of the loader will be empty)code", false)
   .AddOptionalArg("lazy",
-      R"code(If set to true, Loader will parse and prepare the dataset meta data only during the first Run
+      R"code(If set to true, Loader will parse and prepare the dataset metadata only during the first `Run`
 instead of in the constructor.)code", false);
 
 size_t start_index(const size_t shard_id,

--- a/dali/pipeline/operators/reader/loader/loader.cc
+++ b/dali/pipeline/operators/reader/loader/loader.cc
@@ -41,7 +41,10 @@ accesses.)code", false)
 processing is CPU stage-bound, trading memory consumption for better interleaving with the Loader thread.)code", 1)
   .AddOptionalArg("skip_cached_images",
       R"code(If set to true, loading data will be skipped when the sample is present in the decoder cache.
-In such case the output of the loader will be empty)code", false);
+In such case the output of the loader will be empty)code", false)
+  .AddOptionalArg("lazy",
+      R"code(If set to true, Loader will parse and prepare the dataset meta data only during the first Run
+instead of in the constructor.)code", false);
 
 size_t start_index(const size_t shard_id,
                    const size_t shard_num,

--- a/dali/pipeline/operators/reader/loader/loader.h
+++ b/dali/pipeline/operators/reader/loader/loader.h
@@ -68,12 +68,17 @@ class Loader {
     dis = std::uniform_int_distribution<>(0, initial_buffer_fill_);
     std::seed_seq seq({seed_});
     e_ = std::default_random_engine(seq);
+  }
+
+  virtual ~Loader() = default;
+
+  // We need this two stage init because overriden PrepareMetadata
+  // is not known in Loader ctor
+  void Init() {
     if (!lazy_) {
       PrepareMetadata();
     }
   }
-
-  virtual ~Loader() = default;
 
   virtual void PrepareEmpty(LoadTarget& tensor) {
     PrepareEmptyTensor(tensor);

--- a/dali/pipeline/operators/reader/loader/recordio_loader.h
+++ b/dali/pipeline/operators/reader/loader/recordio_loader.h
@@ -29,8 +29,7 @@ namespace dali {
 class RecordIOLoader : public IndexedFileLoader {
  public:
   explicit RecordIOLoader(const OpSpec& options)
-    : IndexedFileLoader(options, false) {
-    Init(options);
+    : IndexedFileLoader(options) {
   }
   ~RecordIOLoader() override {}
 

--- a/dali/pipeline/operators/reader/loader/sequence_loader.h
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.h
@@ -94,6 +94,9 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
         streams_(filesystem::GatherExtractedStreams(file_root_)),
         sequences_(detail::GenerateSequences(streams_, sequence_length_, step_, stride_)),
         total_size_(sequences_.size()) {
+  }
+
+  void PrepareMetadata() override {
     DALI_ENFORCE(sequence_length_ > 0, "Sequence length must be positive");
     DALI_ENFORCE(step_ > 0, "Step must be positive");
     DALI_ENFORCE(stride_ > 0, "Stride must be positive");

--- a/dali/pipeline/operators/reader/loader/sequence_loader.h
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.h
@@ -90,13 +90,13 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
         file_root_(spec.GetArgument<string>("file_root")),
         sequence_length_(spec.GetArgument<int32_t>("sequence_length")),
         step_(spec.GetArgument<int32_t>("step")),
-        stride_(spec.GetArgument<int32_t>("stride")),
-        streams_(filesystem::GatherExtractedStreams(file_root_)),
-        sequences_(detail::GenerateSequences(streams_, sequence_length_, step_, stride_)),
-        total_size_(sequences_.size()) {
+        stride_(spec.GetArgument<int32_t>("stride")) {
   }
 
   void PrepareMetadata() override {
+    streams_ = filesystem::GatherExtractedStreams(file_root_);
+    sequences_ = detail::GenerateSequences(streams_, sequence_length_, step_, stride_);
+    total_size_ = sequences_.size();
     DALI_ENFORCE(sequence_length_ > 0, "Sequence length must be positive");
     DALI_ENFORCE(step_ > 0, "Step must be positive");
     DALI_ENFORCE(stride_ > 0, "Stride must be positive");

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -113,11 +113,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       filenames_(filenames),
       codec_id_(0),
       done_(false) {
-      if (step_ < 0)
-        step_ = count_;
-  }
-
-  void PrepareMetadata() {
+    if (step_ < 0)
+      step_ = count_;
     DALI_ENFORCE(cuvidInitChecked(0),
      "Failed to load libnvcuvid.so, needed by the VideoReader operator. "
      "If you are running in a Docker container, please refer "
@@ -129,7 +126,9 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
     CUDA_CALL(cudaGetDevice(&device_id_));
 
     av_register_all();
+  }
 
+  void PrepareMetadata() {
     for (size_t i = 0; i < filenames_.size(); ++i) {
       int frame_count = get_or_open_file(filenames_[i]).frame_count_;
       for (int s = 0; s < frame_count && s + count_ <= frame_count; s += step_) {

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -117,7 +117,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
         step_ = count_;
   }
 
-  void init() {
+  void PrepareMetadata() {
     DALI_ENFORCE(cuvidInitChecked(0),
      "Failed to load libnvcuvid.so, needed by the VideoReader operator. "
      "If you are running in a Docker container, please refer "

--- a/dali/pipeline/operators/reader/mxnet_reader_op.h
+++ b/dali/pipeline/operators/reader/mxnet_reader_op.h
@@ -24,7 +24,7 @@ class MXNetReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit MXNetReader(const OpSpec& spec)
   : DataReader<CPUBackend, Tensor<CPUBackend>>(spec) {
-    loader_.reset(new RecordIOLoader(spec));
+    loader_ = InitLoader<RecordIOLoader>(spec);
     parser_.reset(new RecordIOParser(spec));
   }
 

--- a/dali/pipeline/operators/reader/reader_op.h
+++ b/dali/pipeline/operators/reader/reader_op.h
@@ -168,13 +168,6 @@ class DataReader : public Operator<Backend> {
     return sample_ptr;
   }
 
-  template<typename T, typename... Args>
-  std::unique_ptr<T> InitLoader(const OpSpec& spec, Args... args) {
-    std::unique_ptr<T> l (new T(spec, args...));
-    l->Init();
-    return l;
-  }
-
  protected:
   void ProducerStop(std::exception_ptr error = nullptr) {
     {

--- a/dali/pipeline/operators/reader/reader_op.h
+++ b/dali/pipeline/operators/reader/reader_op.h
@@ -168,6 +168,13 @@ class DataReader : public Operator<Backend> {
     return sample_ptr;
   }
 
+  template<typename T, typename... Args>
+  std::unique_ptr<T> InitLoader(const OpSpec& spec, Args... args) {
+    std::unique_ptr<T> l (new T(spec, args...));
+    l->Init();
+    return l;
+  }
+
  protected:
   void ProducerStop(std::exception_ptr error = nullptr) {
     {

--- a/dali/pipeline/operators/reader/sequence_reader_op.h
+++ b/dali/pipeline/operators/reader/sequence_reader_op.h
@@ -24,7 +24,7 @@ namespace dali {
 class SequenceReader : public DataReader<CPUBackend, TensorSequence> {
  public:
   explicit SequenceReader(const OpSpec& spec) : DataReader<CPUBackend, TensorSequence>(spec) {
-    loader_.reset(new SequenceLoader(spec));
+    loader_ = InitLoader<SequenceLoader>(spec);
     parser_.reset(new SequenceParser(spec));
   }
 

--- a/dali/pipeline/operators/reader/tfrecord_reader_op.h
+++ b/dali/pipeline/operators/reader/tfrecord_reader_op.h
@@ -27,7 +27,7 @@ class TFRecordReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit TFRecordReader(const OpSpec& spec)
   : DataReader<CPUBackend, Tensor<CPUBackend>>(spec) {
-    loader_.reset(new IndexedFileLoader(spec));
+    loader_ = InitLoader<IndexedFileLoader>(spec);
     parser_.reset(new TFRecordParser(spec));
   }
 

--- a/dali/pipeline/operators/reader/video_reader_op.h
+++ b/dali/pipeline/operators/reader/video_reader_op.h
@@ -43,8 +43,7 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
 
     // TODO(spanev): support rescale
       try {
-        loader_.reset(new VideoLoader(spec, filenames_));
-        dynamic_cast<VideoLoader*>(loader_.get())->init();
+        loader_ = InitLoader<VideoLoader>(spec, filenames_);
         auto w_h = dynamic_cast<VideoLoader*>(loader_.get())->load_width_height(filenames_[0]);
         width_ = static_cast<int>(w_h.first * output_scale_);
         height_ = static_cast<int>(w_h.second * output_scale_);


### PR DESCRIPTION
- Factorizing Loader init out of constructor
- Adding Reader/Loader option to make the init lazy: executed only on the first Run
- Moves COCOReader data preparation logic in COCOLoader

Co-author @awolant 

Moved to #746 