### PR TITLE
Image cache batch copy

### DIFF
--- a/dali/kernels/common/scatter_gather.cu
+++ b/dali/kernels/common/scatter_gather.cu
@@ -1,0 +1,121 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cassert>
+#include "dali/kernels/common/scatter_gather.h"
+
+namespace dali {
+namespace kernels {
+
+void ScatterGatherGPU::Coalesce() {
+  if (ranges_.empty())
+    return;
+  std::sort(ranges_.begin(), ranges_.end(), [](const CopyRange &a, const CopyRange &b) {
+    return a.src < b.src;
+  });
+
+  int start = 0;
+  int n = ranges_.size();
+  bool changed = false;
+
+  // merge
+  for (int i = 1; i < n; i++) {
+    if (ranges_[i].src == ranges_[start].src + ranges_[start].size &&
+        ranges_[i].dst == ranges_[start].dst + ranges_[start].size) {
+      ranges_[start].size += ranges_[i].size;
+      ranges_[i] = { nullptr, nullptr, 0 };
+      changed = true;
+    } else {
+      start = i;
+    }
+  }
+
+  if (changed) {
+    // compact
+    int new_size = 1;  // first item is guaranteed to be non-empty
+    for (int i = 1; i < n; i++) {
+      if (ranges_[i].size > 0) {
+        int j = new_size++;
+        if (j != i)
+          ranges_[j] = ranges_[i];
+      }
+    }
+    ranges_.resize(new_size);
+  }
+}
+
+void ScatterGatherGPU::MakeBlocks() {
+  size_t max_size = 0;
+
+  for (auto &r : ranges_) {
+    if (r.size > max_size)
+      max_size = r.size;
+  }
+
+  size_per_block_ = std::min(max_size, max_size_per_block_);
+
+  int num_blocks = 0;
+  for (auto &r : ranges_)
+    num_blocks += (r.size + size_per_block_ - 1) / size_per_block_;
+
+  blocks_.clear();
+  blocks_.reserve(num_blocks);
+  for (auto &r : ranges_) {
+    for (size_t ofs = 0; ofs < r.size; ofs += size_per_block_) {
+      blocks_.push_back({ r.src + ofs, r.dst + ofs, std::min(r.size - ofs, size_per_block_) });
+    }
+  }
+  assert(blocks_.size() == num_blocks);
+
+  ReserveGPUBlocks();
+}
+
+void ScatterGatherGPU::ReserveGPUBlocks() {
+  if (block_capacity_ < blocks_.capacity()) {
+    block_capacity_ = blocks_.capacity();
+    blocks_dev_ = memory::alloc_unique<CopyRange>(AllocType::GPU, block_capacity_);
+  }
+}
+
+__global__ void BatchCopy(const ScatterGatherGPU::CopyRange *ranges) {
+  auto range = ranges[blockIdx.x];
+
+  for (int i = threadIdx.x; i < range.size; i += blockDim.x) {
+    range.dst[i] = range.src[i];
+  }
+}
+
+void ScatterGatherGPU::Run(cudaStream_t stream) {
+  Coalesce();
+  if (ranges_.size() <= 2) {
+    for (auto &r : ranges_) {
+      cudaMemcpyAsync(r.dst, r.src, r.size, cudaMemcpyDeviceToDevice, stream);
+    }
+    return;
+  }
+
+  MakeBlocks();
+  cudaMemcpyAsync(blocks_dev_.get(), blocks_.data(), blocks_.size() * sizeof(blocks_[0]),
+    cudaMemcpyDeviceToDevice, stream);
+
+  dim3 grid(blocks_.size());
+  dim3 block(std::min<size_t>(size_per_block_, 1024));
+  BatchCopy<<<grid, block>>>(blocks_dev_.get());
+}
+
+
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/common/scatter_gather.cu
+++ b/dali/kernels/common/scatter_gather.cu
@@ -99,12 +99,12 @@ __global__ void BatchCopy(const ScatterGatherGPU::CopyRange *ranges) {
   }
 }
 
-void ScatterGatherGPU::Run(cudaStream_t stream, bool reset) {
+void ScatterGatherGPU::Run(cudaStream_t stream, bool reset, bool useMemcpyOnly) {
   Coalesce();
 
   // TODO(michalz): Error handling
 
-  if (ranges_.size() <= 2) {
+  if (useMemcpyOnly || ranges_.size() <= 2) {
     for (auto &r : ranges_) {
       cudaMemcpyAsync(r.dst, r.src, r.size, cudaMemcpyDeviceToDevice, stream);
     }

--- a/dali/kernels/common/scatter_gather.cu
+++ b/dali/kernels/common/scatter_gather.cu
@@ -116,7 +116,7 @@ void ScatterGatherGPU::Run(cudaStream_t stream, bool reset, bool useMemcpyOnly) 
 
     dim3 grid(blocks_.size());
     dim3 block(std::min<size_t>(size_per_block_, 1024));
-    BatchCopy<<<grid, block>>>(blocks_dev_.get());
+    BatchCopy<<<grid, block, 0, stream>>>(blocks_dev_.get());
     cudaGetLastError();
   }
 

--- a/dali/kernels/common/scatter_gather.h
+++ b/dali/kernels/common/scatter_gather.h
@@ -1,0 +1,79 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <vector>
+#include "dali/kernels/alloc.h"
+#include "dali/api_helper.h"
+
+namespace dali {
+namespace kernels {
+
+class DLL_PUBLIC ScatterGatherGPU {
+ public:
+  static constexpr size_t kDefaultBlockSize = 64<<10;
+
+  ScatterGatherGPU() = default;
+
+  ScatterGatherGPU(size_t max_size_per_block, size_t estimated_num_blocks)
+  : max_size_per_block_(max_size_per_block) {
+    blocks_.reserve(estimated_num_blocks);
+    ReserveGPUBlocks();
+  }
+
+  explicit ScatterGatherGPU(size_t max_size_per_block) : ScatterGatherGPU(max_size_per_block, 0) {}
+
+  ScatterGatherGPU(size_t max_size_per_block, size_t total_size, size_t num_ranges)
+  : ScatterGatherGPU(
+      max_size_per_block,
+      (total_size + num_ranges * (max_size_per_block - 1)) / max_size_per_block)
+  {}
+
+  void Reset() {
+    ranges_.clear();
+    blocks_.clear();
+  }
+
+  void AddCopy(void *dst, const void *src, size_t size) {
+    ranges_.push_back({
+      static_cast<const char*>(src),
+      static_cast<char*>(dst),
+      size
+    });
+  }
+  DLL_PUBLIC void Run(cudaStream_t stream);
+
+  struct CopyRange {
+    const char *src;
+    char *dst;
+    size_t size;
+  };
+ private:
+  std::vector<CopyRange> ranges_;
+
+  void Coalesce();
+  void MakeBlocks();
+  void ReserveGPUBlocks();
+
+  size_t max_size_per_block_ = kDefaultBlockSize;
+  std::vector<CopyRange> blocks_;
+  kernels::memory::KernelUniquePtr<CopyRange> blocks_dev_;
+  size_t block_capacity_ = 0;
+  size_t size_per_block_ = 0;
+
+};
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/common/scatter_gather.h
+++ b/dali/kernels/common/scatter_gather.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef DALI_KERNELS_COMMON_SCATTER_GATHER_H_
+#define DALI_KERNELS_COMMON_SCATTER_GATHER_H_
+
 #include <cuda_runtime.h>
 #include <cstdint>
 #include <vector>
@@ -50,8 +53,7 @@ class DLL_PUBLIC ScatterGatherGPU {
   ScatterGatherGPU(size_t max_size_per_block, size_t total_size, size_t num_ranges)
   : ScatterGatherGPU(
       max_size_per_block,
-      (total_size + num_ranges * (max_size_per_block - 1)) / max_size_per_block)
-  {
+      (total_size + num_ranges * (max_size_per_block - 1)) / max_size_per_block) {
     ranges_.reserve(num_ranges);
   }
 
@@ -79,6 +81,7 @@ class DLL_PUBLIC ScatterGatherGPU {
   DLL_PUBLIC void Run(cudaStream_t stream, bool reset = true, bool useMemcpyOnly = false);
 
   using CopyRange = detail::CopyRange;
+
  private:
   std::vector<CopyRange> ranges_;
 
@@ -99,8 +102,9 @@ class DLL_PUBLIC ScatterGatherGPU {
   kernels::memory::KernelUniquePtr<CopyRange> blocks_dev_;
   size_t block_capacity_ = 0;
   size_t size_per_block_ = 0;
-
 };
 
 }  // namespace kernels
 }  // namespace dali
+
+#endif  // DALI_KERNELS_COMMON_SCATTER_GATHER_H_

--- a/dali/kernels/common/scatter_gather.h
+++ b/dali/kernels/common/scatter_gather.h
@@ -51,7 +51,9 @@ class DLL_PUBLIC ScatterGatherGPU {
   : ScatterGatherGPU(
       max_size_per_block,
       (total_size + num_ranges * (max_size_per_block - 1)) / max_size_per_block)
-  {}
+  {
+    ranges_.reserve(num_ranges);
+  }
 
   void Reset() {
     ranges_.clear();
@@ -72,7 +74,9 @@ class DLL_PUBLIC ScatterGatherGPU {
   /// @brief Executes the copies
   /// @param stream - the cudaStream on which the copies are scheduled
   /// @param reset - if true, calls Reset after processing is over
-  DLL_PUBLIC void Run(cudaStream_t stream, bool reset = true);
+  /// @param useMemcpyOnly - if true, all copies are executed using cudaMemcpy;
+  ///                        otherwise a batched kernel is used if there are more than 2 ranges
+  DLL_PUBLIC void Run(cudaStream_t stream, bool reset = true, bool useMemcpyOnly = false);
 
   using CopyRange = detail::CopyRange;
  private:

--- a/dali/kernels/test/scatter_gather_test.cc
+++ b/dali/kernels/test/scatter_gather_test.cc
@@ -1,0 +1,121 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <vector>
+#include <algorithm>
+#include "dali/kernels/common/scatter_gather.h"
+
+namespace std {
+inline bool operator==(const dali::kernels::detail::CopyRange &a,
+                       const dali::kernels::detail::CopyRange &b) {
+  return a.src == b.src && a.dst == b.dst && a.size == b.size;
+}
+}  // namespace std
+
+namespace dali {
+namespace kernels {
+
+TEST(ScatterGather, Coalesce) {
+  static char A1[1<<12];
+  static char A2[1<<12];
+  using detail::CopyRange;
+  std::vector<CopyRange> in;
+  std::vector<CopyRange> ref;
+  in.push_back({ A1 + 1000, A2 + 2000, 10 });
+  in.push_back({ A1 + 0, A2 + 0, 120 });
+  in.push_back({ A1 + 120, A2 + 120, 10 });
+  in.push_back({ A1 + 130, A2 + 130, 20 });
+  in.push_back({ A1 + 150, A2 + 160, 10 });
+  in.push_back({ A1 + 170, A2 + 170, 10 });
+  in.push_back({ A1 + 180, A2 + 180, 30 });
+
+  ref.push_back({ A1 + 0, A2 + 0, 150 });
+  ref.push_back({ A1 + 150, A2 + 160, 10 });
+  ref.push_back({ A1 + 170, A2 + 170, 40 });
+  ref.push_back({ A1 + 1000, A2 + 2000, 10 });
+
+  size_t n = detail::Coalesce(make_span(in.data(), in.size()));
+  ASSERT_LE(n, in.size());
+  EXPECT_EQ(n, ref.size());
+
+  in.resize(n);
+  EXPECT_EQ(in, ref);
+}
+
+TEST(ScatterGather, Copy) {
+  const size_t max_l = 1024;
+  std::vector<char> in(1<<14);
+  std::vector<char> out(1<<14);
+  unsigned seed = 42;
+
+  auto in_ptr = kernels::memory::alloc_unique<char>(AllocType::GPU, in.size());
+  auto out_ptr = kernels::memory::alloc_unique<char>(AllocType::GPU, out.size());
+
+  std::vector<detail::CopyRange> ranges;
+  std::vector<detail::CopyRange> back_ranges;
+
+  size_t i = 0, j = 0;
+  for (;;) {
+    detail::CopyRange r;
+
+    if ((rand_r(&seed)&3) == 0) {
+      i += rand_r(&seed) % max_l;
+      j += rand_r(&seed) % max_l;
+    }
+
+    size_t l = rand_r(&seed) % max_l + 1;
+    if (i + l > in.size() || j + l > out.size())
+      break;
+
+    for (size_t x = i; x < i + l; x++)
+        in[x] = rand_r(&seed);
+
+
+    r.src = in_ptr.get() + i;
+    r.dst = out_ptr.get() + j;
+    r.size = l;
+    ranges.push_back(r);
+    r.dst = in_ptr.get() + i;
+    r.src = out_ptr.get() + j;
+    back_ranges.push_back(r);
+
+    i += l;
+    j += l;
+  }
+
+  std::random_shuffle(ranges.begin(), ranges.end());
+  std::random_shuffle(back_ranges.begin(), back_ranges.end());
+
+  cudaMemcpy(in_ptr.get(), in.data(), in.size(), cudaMemcpyHostToDevice);
+  cudaMemset(out_ptr.get(), 0, out.size());
+
+  ScatterGatherGPU sg(64);
+  // copy
+  for (auto &r : ranges)
+    sg.AddCopy(r.dst, r.src, r.size);
+  sg.Run(0);
+
+  // copy back
+  cudaMemset(in_ptr.get(), 0, in.size());
+  for (auto &r : back_ranges)
+    sg.AddCopy(r.dst, r.src, r.size);
+  sg.Run(0);
+  cudaMemcpy(out.data(), in_ptr.get(), in.size(), cudaMemcpyDeviceToHost);
+
+  EXPECT_EQ(in, out);
+}
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/pipeline/operators/decoder/cache/cached_decoder_impl.cc
+++ b/dali/pipeline/operators/decoder/cache/cached_decoder_impl.cc
@@ -36,7 +36,7 @@ CachedDecoderImpl::CachedDecoderImpl(const OpSpec& spec)
       device_id_, cache_type, cache_size, cache_debug, cache_threshold);
 
     auto batch_size = spec.GetArgument<int>("batch_size");
-    const size_t kMaxSizePerBlock = 1<<18; // 256 kB per block
+    const size_t kMaxSizePerBlock = 1<<18;  // 256 kB per block
     scatter_gather_.reset(new kernels::ScatterGatherGPU(
       kMaxSizePerBlock, cache_size, batch_size));
   }

--- a/dali/pipeline/operators/decoder/cache/cached_decoder_impl.h
+++ b/dali/pipeline/operators/decoder/cache/cached_decoder_impl.h
@@ -55,6 +55,7 @@ class CachedDecoderImpl {
 
  protected:
   ~CachedDecoderImpl();
+
  private:
   std::shared_ptr<ImageCache> cache_;
   std::unique_ptr<kernels::ScatterGatherGPU> scatter_gather_;

--- a/dali/pipeline/operators/decoder/cache/cached_decoder_impl.h
+++ b/dali/pipeline/operators/decoder/cache/cached_decoder_impl.h
@@ -45,7 +45,7 @@ class CachedDecoderImpl {
   ImageCache::ImageShape CacheImageShape(
     const std::string& file_name);
 
- private:
+ protected:
   std::shared_ptr<ImageCache> cache_;
   int device_id_;
 };

--- a/dali/pipeline/operators/decoder/cache/cached_decoder_impl.h
+++ b/dali/pipeline/operators/decoder/cache/cached_decoder_impl.h
@@ -46,7 +46,7 @@ class CachedDecoderImpl {
 
   bool DeferCacheLoad(const std::string& file_name, uint8_t *output_data);
 
-  void LoadDeferred(cudaStream_t stream, bool useMemcpyOnly = false);
+  void LoadDeferred(cudaStream_t stream);
 
   ImageCache::ImageShape CacheImageShape(
     const std::string& file_name);
@@ -60,6 +60,7 @@ class CachedDecoderImpl {
   std::shared_ptr<ImageCache> cache_;
   std::unique_ptr<kernels::ScatterGatherGPU> scatter_gather_;
   int device_id_;
+  bool use_batch_copy_kernel_ = true;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/decoder/cache/image_cache.h
+++ b/dali/pipeline/operators/decoder/cache/image_cache.h
@@ -76,7 +76,6 @@ class DLL_PUBLIC ImageCache {
    *          images from the cache.
    */
   DLL_PUBLIC virtual DecodedImage Get(const ImageKey &image_key) const = 0;
-
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/decoder/cache/image_cache.h
+++ b/dali/pipeline/operators/decoder/cache/image_cache.h
@@ -19,30 +19,32 @@
 #include <string>
 #include "dali/api_helper.h"
 #include "dali/kernels/tensor_shape.h"
+#include "dali/kernels/tensor_view.h"
 
 namespace dali {
 
 class DLL_PUBLIC ImageCache {
  public:
-    using ImageKey = std::string;
-    using ImageShape = kernels::TensorShape<3>;
+  using ImageKey = std::string;
+  using ImageShape = kernels::TensorShape<3>;
+  using DecodedImage = kernels::TensorView<kernels::StorageGPU, uint8_t, 3>;
 
-    DLL_PUBLIC virtual ~ImageCache() = default;
+  DLL_PUBLIC virtual ~ImageCache() = default;
+
+  /**
+   * @brief Check whether an image is present in the cache
+   * @param image_key key representing the image in cache
+   */
+  DLL_PUBLIC virtual bool IsCached(const ImageKey& image_key) const = 0;
+
+  /**
+   * @brief Get image dimensions
+   * @param image_key key representing the image in cache
+   */
+  DLL_PUBLIC virtual const ImageShape& GetShape(const ImageKey& image_key) const = 0;
 
     /**
-     * @brief Check whether an image is present in the cache
-     * @param image_key key representing the image in cache
-     */
-    DLL_PUBLIC virtual bool IsCached(const ImageKey& image_key) const = 0;
-
-    /**
-     * @brief Get image dimensions
-     * @param image_key key representing the image in cache
-     */
-    DLL_PUBLIC virtual const ImageShape& GetShape(const ImageKey& image_key) const = 0;
-
-    /**
-     * @briefs Try to read from cache
+     * @brief Try to read from cache
      * @param image_key key representing the image in cache
      * @param destination_data destination buffer
      * @param stream cuda stream
@@ -52,19 +54,29 @@ class DLL_PUBLIC ImageCache {
                                  void* destination_data,
                                  cudaStream_t stream) const = 0;
 
-    /**
-     * @briefs Try to add entry to cache.
-     * @remarks Whether the entry is registered or not depends on the particular implementation
-     *          and the state of the cache
-     * @param image_key key representing the image in cache
-     * @param data buffer
-     * @param data_shape dimensions of the data to be stored
-     * @param stream cuda stream
-     */
-    DLL_PUBLIC virtual void Add(const ImageKey& image_key,
-                                const uint8_t *data,
-                                const ImageShape& data_shape,
-                                cudaStream_t stream) = 0;
+  /**
+   * @brief Try to add entry to cache.
+   * @remarks Whether the entry is registered or not depends on the particular implementation
+   *          and the state of the cache
+   * @param image_key key representing the image in cache
+   * @param data buffer
+   * @param data_shape dimensions of the data to be stored
+   * @param stream cuda stream
+   */
+  DLL_PUBLIC virtual void Add(const ImageKey& image_key,
+                              const uint8_t *data,
+                              const ImageShape& data_shape,
+                              cudaStream_t stream) = 0;
+
+  /**
+   * @brief Get a cache entry describing an image
+   * @param image_key key of the cached image
+   * @return Pointer and shape of the cached image; if not found, data is null
+   * @remarks This function is valid only if the implementation doesn't evict
+   *          images from the cache.
+   */
+  DLL_PUBLIC virtual DecodedImage Get(const ImageKey &image_key) const = 0;
+
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/decoder/cache/image_cache_blob.cc
+++ b/dali/pipeline/operators/decoder/cache/image_cache_blob.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/pipeline/operators/decoder/cache/image_cache_blob.h"
 #include <fstream>
 #include <mutex>
 #include <unordered_map>
@@ -20,6 +19,7 @@
 #include "dali/kernels/alloc.h"
 #include "dali/kernels/span.h"
 #include "dali/pipeline/data/backend.h"
+#include "dali/pipeline/operators/decoder/cache/image_cache_blob.h"
 
 namespace dali {
 

--- a/dali/pipeline/operators/decoder/cache/image_cache_blob.cc
+++ b/dali/pipeline/operators/decoder/cache/image_cache_blob.cc
@@ -80,6 +80,7 @@ ImageCache::DecodedImage ImageCacheBlob::Get(const ImageKey& image_key) const {
   const auto it = cache_.find(image_key);
   if (it == cache_.end())
     return {};
+  if (stats_enabled_) stats_[image_key].reads++;
   auto ret = it->second;  // make a copy _before_ leaving the mutex
   return ret;
 }

--- a/dali/pipeline/operators/decoder/cache/image_cache_blob.h
+++ b/dali/pipeline/operators/decoder/cache/image_cache_blob.h
@@ -48,6 +48,8 @@ class DLL_PUBLIC ImageCacheBlob : public ImageCache {
              const ImageShape& data_shape,
              cudaStream_t stream) override;
 
+    DecodedImage Get(const ImageKey &image_key) const override;
+
  protected:
     void print_stats() const;
 
@@ -60,16 +62,6 @@ class DLL_PUBLIC ImageCacheBlob : public ImageCache {
         DALI_ENFORCE(buffer_end_ >= tail_);
         return static_cast<std::size_t>(buffer_end_ - tail_);
     }
-
-    struct DecodedImage {
-        span<uint8_t, dynamic_extent> data;
-        ImageShape dims;
-
-        inline bool operator==(const DecodedImage& oth) const {
-            return data == oth.data
-                && dims == oth.dims;
-        }
-    };
 
     std::size_t cache_size_ = 0;
     std::size_t image_size_threshold_ = 0;

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder.h
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder.h
@@ -35,6 +35,7 @@
 #include "dali/image/image_factory.h"
 #include "dali/common.h"
 #include "dali/kernels/common/scatter_gather.h"
+#include "dali/kernels/tensor_shape_print.h"
 
 namespace dali {
 
@@ -310,7 +311,9 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
           auto img = cache_->Get(file_name);
           cached_images_[j] = img;
-          scatter_gather_.AddCopy(img.data, output.raw_mutable_tensor(j), img.num_elements());
+          if (img.data) {
+            scatter_gather_.AddCopy(output.raw_mutable_tensor(j), img.data, img.num_elements());
+          }
         }
         scatter_gather_.Run(ws->stream());
       }
@@ -512,8 +515,6 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
   // Thread pool
   ThreadPool thread_pool_;
-
-  std::shared_ptr<ImageCache> cache_;
 };
 
 }  // namespace dali

--- a/dali/test/python/test_nvjpeg_cache.py
+++ b/dali/test/python/test_nvjpeg_cache.py
@@ -29,8 +29,11 @@ batch_size = 20
 
 def compare(tl1, tl2):
     tl1_cpu = tl1.as_cpu()
+    tl2_cpu = tl2.as_cpu()
     #tl2 = tl2.as_cpu()
-    #print(tl1_cpu)
+    assert(len(tl1_cpu) == len(tl2_cpu))
+    for i in range(0, len(tl1_cpu)):
+        assert_array_equal(tl1_cpu.at(i), tl2_cpu.at(i), "cached and non-cached images differ")
 
 class nvJPEGDecoderPipeline(Pipeline):
     def __init__(self, batch_size, num_threads, device_id, cache_size):
@@ -39,28 +42,31 @@ class nvJPEGDecoderPipeline(Pipeline):
         policy = None
         if cache_size > 0:
           policy = "threshold"
-        self.decode = ops.nvJPEGDecoder(device = 'mixed', output_type = types.RGB, cache_size = cache_size, cache_type = policy)
+        self.decode = ops.nvJPEGDecoder(device = 'mixed', output_type = types.RGB, cache_debug = True, cache_size = cache_size, cache_type = policy)
 
     def define_graph(self):
-        jpegs, labels = self.input()
+        jpegs, labels = self.input(name="Reader")
         images = self.decode(jpegs)
         return (images, labels)
 
 def test_nvjpeg_cached():
     ref_pipe = nvJPEGDecoderPipeline(batch_size, 1, 0, 0)
     ref_pipe.build()
-    #cached_pipe = nvJPEGDecoderPipeline(batch_size, 1, 0, 100)
-    #cached_pipe.build()
+    cached_pipe = nvJPEGDecoderPipeline(batch_size, 1, 0, 100)
+    cached_pipe.build()
+    epoch_size = ref_pipe.epoch_size("Reader")
 
-    ref_images, _ = ref_pipe.run()
-    out_images, _ = ref_pipe.run()
-    compare(ref_images, out_images)
-    ref_images, _ = ref_pipe.run()
-    out_images, _ = ref_pipe.run()
-    compare(ref_images, out_images)
-    ref_images, _ = ref_pipe.run()
-    out_images, _ = ref_pipe.run()
-    compare(ref_images, out_images)
+    for i in range(0, (2*epoch_size + batch_size - 1) // batch_size):
+      print("Batch %d-%d / %d"%(i*batch_size, (i+1)*batch_size, epoch_size))
+      ref_images, _ = ref_pipe.run()
+      out_images, _ = cached_pipe.run()
+      compare(ref_images, out_images)
+      ref_images, _ = ref_pipe.run()
+      out_images, _ = cached_pipe.run()
+      compare(ref_images, out_images)
+      ref_images, _ = ref_pipe.run()
+      out_images, _ = cached_pipe.run()
+      compare(ref_images, out_images)
 
 def main():
     test_nvjpeg_cached()

--- a/dali/test/python/test_nvjpeg_cache.py
+++ b/dali/test/python/test_nvjpeg_cache.py
@@ -42,7 +42,7 @@ class nvJPEGDecoderPipeline(Pipeline):
         policy = None
         if cache_size > 0:
           policy = "threshold"
-        self.decode = ops.nvJPEGDecoder(device = 'mixed', output_type = types.RGB, cache_debug = True, cache_size = cache_size, cache_type = policy)
+        self.decode = ops.nvJPEGDecoder(device = 'mixed', output_type = types.RGB, cache_debug = False, cache_size = cache_size, cache_type = policy, cache_batch_copy = True)
 
     def define_graph(self):
         jpegs, labels = self.input(name="Reader")

--- a/dali/test/python/test_nvjpeg_cache.py
+++ b/dali/test/python/test_nvjpeg_cache.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops as ops
+import nvidia.dali.types as types
+import nvidia.dali.tfrecord as tfrec
+from timeit import default_timer as timer
+import numpy as np
+import os
+from numpy.testing import assert_array_equal, assert_allclose
+
+seed = 1549361629
+
+img_root = os.environ["DALI_EXTRA_PATH"]
+image_dir = img_root + "/db/single/jpeg"
+batch_size = 20
+
+def compare(tl1, tl2):
+    tl1_cpu = tl1.as_cpu()
+    #tl2 = tl2.as_cpu()
+    #print(tl1_cpu)
+
+class nvJPEGDecoderPipeline(Pipeline):
+    def __init__(self, batch_size, num_threads, device_id, cache_size):
+        super(nvJPEGDecoderPipeline, self).__init__(batch_size, num_threads, device_id, seed = seed)
+        self.input = ops.FileReader(file_root = image_dir)
+        policy = None
+        if cache_size > 0:
+          policy = "threshold"
+        self.decode = ops.nvJPEGDecoder(device = 'mixed', output_type = types.RGB, cache_size = cache_size, cache_type = policy)
+
+    def define_graph(self):
+        jpegs, labels = self.input()
+        images = self.decode(jpegs)
+        return (images, labels)
+
+def test_nvjpeg_cached():
+    ref_pipe = nvJPEGDecoderPipeline(batch_size, 1, 0, 0)
+    ref_pipe.build()
+    #cached_pipe = nvJPEGDecoderPipeline(batch_size, 1, 0, 100)
+    #cached_pipe.build()
+
+    ref_images, _ = ref_pipe.run()
+    out_images, _ = ref_pipe.run()
+    compare(ref_images, out_images)
+    ref_images, _ = ref_pipe.run()
+    out_images, _ = ref_pipe.run()
+    compare(ref_images, out_images)
+    ref_images, _ = ref_pipe.run()
+    out_images, _ = ref_pipe.run()
+    compare(ref_images, out_images)
+
+def main():
+    test_nvjpeg_cached()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
When there are more than 2 images hit the cache in a batch, use a batched kernel to copy the images; for 2 or fewer, use `cudaMemcpyAsync`.
`cache_batch_copy=False` can be used to explicitly disable the new functionality for performance investigation.
