### PR TITLE
Resampling in mini-batches

### DIFF
--- a/dali/kernels/imgproc/resample/resampling_setup.h
+++ b/dali/kernels/imgproc/resample/resampling_setup.h
@@ -114,7 +114,7 @@ class SeparableResamplingSetup {
 
 class BatchResamplingSetup : public SeparableResamplingSetup {
  public:
-  using Params = std::vector<ResamplingParams2D>;
+  using Params = span<ResamplingParams2D>;
 
   std::vector<SampleDesc> sample_descs;
   TensorListShape<3> output_shape, intermediate_shape;
@@ -122,6 +122,11 @@ class BatchResamplingSetup : public SeparableResamplingSetup {
   BlockCount total_blocks;
 
   void SetupBatch(const TensorListShape<3> &in, const Params &params);
+
+  template <typename Collection>
+  void SetupBatch(const TensorListShape<3> &in, const Collection &params) {
+    SetupBatch(in, make_span(params));
+  }
   void InitializeSampleLookup(const OutTensorCPU<SampleBlockInfo, 1> &sample_lookup);
 };
 

--- a/dali/kernels/imgproc/resample/separable.h
+++ b/dali/kernels/imgproc/resample/separable.h
@@ -17,7 +17,7 @@
 
 #include <cuda_runtime.h>
 #include <memory>
-#include <vector>
+#include "dali/kernels/span.h"
 #include "dali/kernels/imgproc/resample/params.h"
 
 namespace dali {
@@ -31,7 +31,7 @@ struct SeparableResamplingFilter {
 
   virtual ~SeparableResamplingFilter() = default;
 
-  using Params = std::vector<ResamplingParams2D>;
+  using Params = span<ResamplingParams2D>;
 
   virtual KernelRequirements
   Setup(KernelContext &context, const Input &in, const Params &params) = 0;

--- a/dali/kernels/span.h
+++ b/dali/kernels/span.h
@@ -16,6 +16,7 @@
 #define DALI_KERNELS_SPAN_H_
 
 #include <cstddef>
+#include <array>
 #include <type_traits>
 
 namespace dali {
@@ -151,6 +152,27 @@ constexpr span<T, Extent> make_span(T *data) { return { data }; }
 // @brief Helper function for pre-C++17
 template <ptrdiff_t Extent = dynamic_extent, typename T>
 constexpr span<T, Extent> make_span(T *data, ptrdiff_t extent) { return { data, extent }; }
+
+template <typename Collection>
+auto make_span(Collection &c)->decltype(make_span(c.data(), c.size())) {
+  return make_span(c.data(), c.size());
+}
+
+template <typename T, size_t N>
+constexpr span<T, N> make_span(std::array<T, N> &a) {
+  return { a.data() };
+}
+
+template <typename T, size_t N>
+constexpr span<const T, N> make_span(const std::array<T, N> &a) {
+  return { a.data() };
+}
+
+template <typename T, size_t N>
+constexpr span<const T, N> make_span(T (&a)[N]) {
+  return { a };
+}
+
 
 }  // namespace dali
 

--- a/dali/kernels/span.h
+++ b/dali/kernels/span.h
@@ -158,6 +158,13 @@ auto make_span(Collection &c)->decltype(make_span(c.data(), c.size())) {
   return make_span(c.data(), c.size());
 }
 
+template <typename Collection>
+auto make_span(Collection &&c)->decltype(make_span(c.data(), c.size())) {
+  static_assert(!std::is_rvalue_reference<Collection&&>::value,
+    "Cannot create a span from an r-value.");
+  return make_span(c.data(), c.size());
+}
+
 template <typename T, size_t N>
 constexpr span<T, N> make_span(std::array<T, N> &a) {
   return { a.data() };
@@ -169,10 +176,16 @@ constexpr span<const T, N> make_span(const std::array<T, N> &a) {
 }
 
 template <typename T, size_t N>
+constexpr span<const T, N> make_span(std::array<T, N> &&a) {
+  static_assert(!std::is_rvalue_reference<std::array<T, N> &&>::value,
+    "Cannot create a span from an r-value.");
+  return { a.data() };
+}
+
+template <typename T, size_t N>
 constexpr span<const T, N> make_span(T (&a)[N]) {
   return { a };
 }
-
 
 }  // namespace dali
 

--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -478,7 +478,7 @@ struct TensorListShapeBase {
  protected:
   int size() const { return static_cast<const Derived *>(this)->size(); }
   int sample_dim() const { return static_cast<const Derived *>(this)->sample_dim(); }
-  void set_sample_dim(int dim) { static_cast<const Derived *>(this)->set_sample_dim(dim); }
+  void set_sample_dim(int dim) { static_cast<Derived *>(this)->set_sample_dim(dim); }
   TensorListShapeBase() = default;
   TensorListShapeBase(const std::vector<int64_t> &shapes) : shapes(shapes) {}        // NOLINT
   TensorListShapeBase(std::vector<int64_t> &&shapes) : shapes(std::move(shapes)) {}  // NOLINT

--- a/dali/kernels/test/resampling_test/resampling_compare_test.cc
+++ b/dali/kernels/test/resampling_test/resampling_compare_test.cc
@@ -124,7 +124,7 @@ TEST_P(ResamplingCompareTest, ResamplingKernelAPI) {
   }
   OutListCPU<uint8_t, 3> in_cpu = input.cpu();
 
-  auto req_gpu = KernelGPU::GetRequirements(ctx_gpu, in_gpu, params);
+  auto req_gpu = KernelGPU::GetRequirements(ctx_gpu, in_gpu, make_span(params));
   std::vector<TensorShape<3>> size_cpu;
   ASSERT_EQ(req_gpu.output_shapes.size(), 1);
   ASSERT_EQ(req_gpu.output_shapes[0].num_samples(), N);
@@ -165,7 +165,7 @@ TEST_P(ResamplingCompareTest, ResamplingKernelAPI) {
 
   auto scratchpad = scratch_alloc_gpu.GetScratchpad();
   ctx_gpu.scratchpad = &scratchpad;
-  KernelGPU::Run(ctx_gpu, out_gpu, in_gpu, params);
+  KernelGPU::Run(ctx_gpu, out_gpu, in_gpu, make_span(params));
 
   for (int i = 0; i < N; i++) {
     KernelCPU::GetRequirements(ctx_cpu, in_cpu[i], params[i]);

--- a/dali/kernels/test/resampling_test/resampling_internal_test.cu
+++ b/dali/kernels/test/resampling_test/resampling_internal_test.cu
@@ -31,10 +31,6 @@
 namespace dali {
 namespace kernels {
 
-inline constexpr int divUp(int total, int grain) {
-  return (total + grain - 1) / grain;
-}
-
 template <typename Dst, typename Src>
 __global__ void ResampleHorzTestKernel(
     Dst *out, int out_stride, int out_w,
@@ -336,22 +332,22 @@ class ResamplingTest : public ::testing::Test {
     if (vert_first_) {
       assert(img_tmp_.shape == TensorShape<3>(outH, W, channels));
 
-      dim3 grid = per_span ? dim3(divUp(tmpW, block.x), divUp(tmpH, block.y)) : dim3(1);
+      dim3 grid = per_span ? dim3(div_ceil(tmpW, block.x), div_ceil(tmpH, block.y)) : dim3(1);
       ResampleVertTestKernel<<<grid, block, ResampleSharedMemSize>>>(
         img_tmp_.data, tmpW*channels, tmpH, img_in_.data, W*channels, W, H, channels,
         flt_y_, flt_y_.support());
-      grid = per_span ? dim3(divUp(outW, block.x), divUp(outH, block.y)) : dim3(1);
+      grid = per_span ? dim3(div_ceil(outW, block.x), div_ceil(outH, block.y)) : dim3(1);
       ResampleHorzTestKernel<<<grid, block, ResampleSharedMemSize>>>(
         img_out_.data, outW*channels, outW, img_tmp_.data, tmpW*channels, tmpW, tmpH, channels,
         flt_x_, flt_x_.support());
     } else {
       assert(img_tmp_.shape == TensorShape<3>(H, outW, channels));
 
-      dim3 grid = per_span ? dim3(divUp(tmpW, block.x), divUp(tmpH, block.y)) : dim3(1);
+      dim3 grid = per_span ? dim3(div_ceil(tmpW, block.x), div_ceil(tmpH, block.y)) : dim3(1);
       ResampleHorzTestKernel<<<grid, block, ResampleSharedMemSize>>>(
         img_tmp_.data, tmpW*channels, tmpW, img_in_.data, W*channels, W, H, channels,
         flt_x_, flt_x_.support());
-      grid = per_span ? dim3(divUp(outW, block.x), divUp(outH, block.y)) : dim3(1);
+      grid = per_span ? dim3(div_ceil(outW, block.x), div_ceil(outH, block.y)) : dim3(1);
       ResampleVertTestKernel<<<grid, block, ResampleSharedMemSize>>>(
         img_out_.data, outW*channels, outH, img_tmp_.data, tmpW*channels, tmpW, tmpH, channels,
         flt_y_, flt_y_.support());

--- a/dali/kernels/test/resampling_test/separable_impl_test.cc
+++ b/dali/kernels/test/resampling_test/separable_impl_test.cc
@@ -76,7 +76,7 @@ TEST(SeparableImpl, Setup) {
 
   InListGPU<uint8_t, 3> in_tv = input.gpu();
 
-  auto req = resampling.Setup(ctx, in_tv, params);
+  auto req = resampling.Setup(ctx, in_tv, make_span(params));
   ASSERT_EQ(req.output_shapes.size(), 1);
   ASSERT_EQ(req.output_shapes[0].num_samples(), N);
 
@@ -189,7 +189,7 @@ TEST_P(BatchResamplingTest, ResamplingImpl) {
     copy(in_tv[i], view_as_tensor<uint8_t, 3>(cv_img[i]));
   }
 
-  auto req = resampling.Setup(ctx, in_tv, params);
+  auto req = resampling.Setup(ctx, in_tv, make_span(params));
   ASSERT_EQ(req.output_shapes.size(), 1);
   ASSERT_EQ(req.output_shapes[0].num_samples(), N);
 
@@ -219,7 +219,7 @@ TEST_P(BatchResamplingTest, ResamplingImpl) {
 
   auto scratchpad = scratch_alloc.GetScratchpad();
   ctx.scratchpad = &scratchpad;
-  resampling.Run(ctx, out_tv, in_tv, params);
+  resampling.Run(ctx, out_tv, in_tv, make_span(params));
   for (int i = 0; i < N; i++) {
     auto ref_tensor = view_as_tensor<uint8_t, 3>(cv_ref[i]);
     auto out_tensor = output.cpu()[i];
@@ -276,7 +276,7 @@ TEST_P(BatchResamplingTest, ResamplingKernelAPI) {
     copy(in_tv[i], view_as_tensor<uint8_t, 3>(cv_img[i]));
   }
 
-  auto req = Kernel::GetRequirements(ctx, in_tv, params);
+  auto req = Kernel::GetRequirements(ctx, in_tv, make_span(params));
   ASSERT_EQ(req.output_shapes.size(), 1);
   ASSERT_EQ(req.output_shapes[0].num_samples(), N);
 
@@ -297,7 +297,7 @@ TEST_P(BatchResamplingTest, ResamplingKernelAPI) {
 
   auto scratchpad = scratch_alloc.GetScratchpad();
   ctx.scratchpad = &scratchpad;
-  Kernel::Run(ctx, out_tv, in_tv, params);
+  Kernel::Run(ctx, out_tv, in_tv, make_span(params));
   for (int i = 0; i < N; i++) {
     auto ref_tensor = view_as_tensor<uint8_t, 3>(cv_ref[i]);
     auto out_tensor = output.cpu()[i];

--- a/dali/kernels/util.h
+++ b/dali/kernels/util.h
@@ -38,7 +38,6 @@ size_t size(const T (&a)[N]) {
   return N;
 }
 
-
 template <typename Value, typename Alignment>
 constexpr Value align_up(Value v, Alignment a) {
   return v + ((a - 1) & -v);

--- a/dali/kernels/util.h
+++ b/dali/kernels/util.h
@@ -38,10 +38,33 @@ size_t size(const T (&a)[N]) {
   return N;
 }
 
+
 template <typename Value, typename Alignment>
 constexpr Value align_up(Value v, Alignment a) {
   return v + ((a - 1) & -v);
 }
+
+
+constexpr int32_t div_ceil(int32_t total, uint32_t grain) {
+  return (total + grain - 1) / grain;
+}
+
+constexpr uint32_t div_ceil(uint32_t total, uint32_t grain) {
+  return (total + grain - 1) / grain;
+}
+
+constexpr int64_t div_ceil(int64_t total, uint64_t grain) {
+  return (total + grain - 1) / grain;
+}
+
+constexpr uint64_t div_ceil(uint64_t total, uint64_t grain) {
+  return (total + grain - 1) / grain;
+}
+
+static_assert(div_ceil(0, 32) == 0, "Should not change");
+static_assert(div_ceil(1, 32) == 1, "Should align up");
+static_assert(div_ceil(32, 32) == 1, "Should not align up");
+static_assert(div_ceil(65, 64) == 2, "Should align up");
 
 static_assert(align_up(17, 16) == 32, "Should align up");
 static_assert(align_up(8, 8) == 8, "Should be already aligned");

--- a/dali/pipeline/operators/resize/random_resized_crop.cu
+++ b/dali/pipeline/operators/resize/random_resized_crop.cu
@@ -24,7 +24,7 @@ namespace dali {
 
 template<>
 void RandomResizedCrop<GPUBackend>::BackendInit() {
-  InitializeGPU();
+  InitializeGPU(batch_size_, spec_.GetArgument<int>("minibatch_size"));
 }
 
 template<>

--- a/dali/pipeline/operators/resize/resize.cu
+++ b/dali/pipeline/operators/resize/resize.cu
@@ -32,7 +32,7 @@ Resize<GPUBackend>::Resize(const OpSpec &spec)
   outputs_per_idx_ = save_attrs_ ? 2 : 1;
 
   ResizeAttr::SetBatchSize(batch_size_);
-  InitializeGPU();
+  InitializeGPU(batch_size_, spec_.GetArgument<int>("minibatch_size"));
   resample_params_.resize(batch_size_);
 }
 

--- a/dali/pipeline/operators/resize/resize_base.cc
+++ b/dali/pipeline/operators/resize/resize_base.cc
@@ -84,7 +84,7 @@ void ResizeBase::RunGPU(TensorList<GPUBackend> &output,
   kdata.requirements = Kernel::GetRequirements(
       kdata.context,
       view<const uint8_t, 3>(input),
-      resample_params_);
+      make_span(resample_params_));
 
   kdata.scratch_alloc.Reserve(kdata.requirements.scratch_sizes);
 
@@ -95,7 +95,7 @@ void ResizeBase::RunGPU(TensorList<GPUBackend> &output,
   kdata.context.scratchpad = &scratchpad;
   auto in_view = view<const uint8_t, 3>(input);
   auto out_view = view<uint8_t, 3>(output);
-  Kernel::Run(kdata.context, out_view, in_view, resample_params_);
+  Kernel::Run(kdata.context, out_view, in_view, make_span(resample_params_));
 }
 
 void ResizeBase::Initialize(int num_threads) {
@@ -104,7 +104,7 @@ void ResizeBase::Initialize(int num_threads) {
   resample_params_.resize(num_threads);
 }
 
-void ResizeBase::InitializeGPU() {
+void ResizeBase::InitializeGPU(int batch_size, int mini_batch_size) {
   kernel_data_.resize(1);
   auto &kdata = GetKernelData();
   auto &gpu_scratch = kdata.requirements.scratch_sizes[static_cast<int>(kernels::AllocType::GPU)];

--- a/dali/pipeline/operators/resize/resize_base.cc
+++ b/dali/pipeline/operators/resize/resize_base.cc
@@ -49,7 +49,9 @@ DALI_SCHEMA(ResamplingFilterAttr)
   .AddOptionalArg("temp_buffer_hint",
       "Initial size, in bytes, of a temporary buffer for resampling.\n"
       "Ingored for CPU variant.\n",
-      0);
+      0)
+  .AddOptionalArg("minibatch_size", "Maximum number of images processed in a single kernel call",
+      32);
 
 ResamplingFilterAttr::ResamplingFilterAttr(const OpSpec &spec) {
   DALIInterpType interp_min = DALIInterpType::DALI_INTERP_LINEAR;
@@ -71,6 +73,38 @@ ResamplingFilterAttr::ResamplingFilterAttr(const OpSpec &spec) {
   temp_buffer_hint_ = spec.GetArgument<int64_t>("temp_buffer_hint");
 }
 
+template <typename Backend, typename Element, int ndim>
+inline void SampleRange(
+      kernels::TensorListView<Backend, Element, ndim> &slice,
+      const kernels::TensorListView<Backend, Element, ndim> &input,
+      int start_sample,
+      int num_samples) {
+  int dim = input.sample_dim();
+  slice.shape.resize(num_samples, dim);
+  slice.offsets.resize(num_samples+1);
+  auto start_offset = input.offsets[start_sample];
+  slice.data = input.data + start_offset;
+  for (int sample = 0; sample < num_samples; sample++) {
+    auto o_shape = slice.shape.tensor_shape_span(sample);
+    auto i_shape = input.shape.tensor_shape_span(sample + start_sample);
+    for (int d = 0; d < dim; d++)
+      o_shape[d] = i_shape[d];
+    slice.offsets[sample] = input.offsets[sample + start_sample] - start_offset;
+  }
+  slice.offsets[num_samples] = input.offsets[num_samples + start_sample] - start_offset;
+}
+
+void ResizeBase::SubdivideInput(const kernels::InListGPU<uint8_t, 3> &in) {
+  for (auto &mb : minibatches_) {
+    SampleRange(mb.input, in, mb.start, mb.count);
+  }
+}
+
+void ResizeBase::SubdivideOutput(const kernels::OutListGPU<uint8_t, 3> &out) {
+  for (auto &mb : minibatches_) {
+    SampleRange(mb.output, out, mb.start, mb.count);
+  }
+}
 void ResizeBase::RunGPU(TensorList<GPUBackend> &output,
                         const TensorList<GPUBackend> &input,
                         cudaStream_t stream) {
@@ -78,24 +112,50 @@ void ResizeBase::RunGPU(TensorList<GPUBackend> &output,
   output.SetLayout(DALI_NHWC);
 
   using Kernel = kernels::ResampleGPU<uint8_t, uint8_t>;
-  auto &kdata = GetKernelData();
+  auto &alloc = GetGPUScratchAlloc();
 
-  kdata.context.gpu.stream = stream;
-  kdata.requirements = Kernel::GetRequirements(
-      kdata.context,
-      view<const uint8_t, 3>(input),
-      make_span(resample_params_));
+  auto in_view = view<const uint8_t, 3>(input);
+  SubdivideInput(in_view);
 
-  kdata.scratch_alloc.Reserve(kdata.requirements.scratch_sizes);
+  decltype(kernels::KernelRequirements::scratch_sizes) scratch_sizes;
+  for (auto &size : scratch_sizes)
+    size = 0;
 
-  to_dims_vec(out_shape_, kdata.requirements.output_shapes[0]);
+  out_shape_.clear();
+  for (size_t b = 0; b < minibatches_.size(); b++) {
+    auto &kdata = kernel_data_[b];
+    MiniBatch &mb = minibatches_[b];
+
+    kdata.context.gpu.stream = stream;
+    kdata.requirements = Kernel::GetRequirements(
+        kdata.context,
+        mb.input,
+        make_span(resample_params_.data() + mb.start, mb.count));
+
+    for (size_t type = 0; type < scratch_sizes.size(); type++) {
+      auto s = kdata.requirements.scratch_sizes[type];
+      if (s > scratch_sizes[type])
+        scratch_sizes[type] = s;
+    }
+
+    to_dims_vec(mb.out_shape, kdata.requirements.output_shapes[0]);
+    append(out_shape_, mb.out_shape);
+  }
+
+  alloc.Reserve(scratch_sizes);
   output.Resize(out_shape_);
 
-  auto scratchpad = kdata.scratch_alloc.GetScratchpad();
-  kdata.context.scratchpad = &scratchpad;
-  auto in_view = view<const uint8_t, 3>(input);
   auto out_view = view<uint8_t, 3>(output);
-  Kernel::Run(kdata.context, out_view, in_view, make_span(resample_params_));
+  SubdivideOutput(out_view);
+
+  for (size_t b = 0; b < minibatches_.size(); b++) {
+    auto &kdata = kernel_data_[b];
+    MiniBatch &mb = minibatches_[b];
+
+    auto scratchpad = alloc.GetScratchpad();
+    kdata.context.scratchpad = &scratchpad;
+    Kernel::Run(kdata.context, mb.output, mb.input, make_span(resample_params_));
+  }
 }
 
 void ResizeBase::Initialize(int num_threads) {
@@ -105,12 +165,23 @@ void ResizeBase::Initialize(int num_threads) {
 }
 
 void ResizeBase::InitializeGPU(int batch_size, int mini_batch_size) {
-  kernel_data_.resize(1);
-  auto &kdata = GetKernelData();
+  DALI_ENFORCE(batch_size > 0, "Batch size must be positive");
+  DALI_ENFORCE(mini_batch_size > 0, "Mini-batch size must be positive");
+  const int num_minibatches = div_ceil(batch_size, mini_batch_size);
+  kernel_data_.resize(num_minibatches);
+  auto &kdata = kernel_data_[0];
   auto &gpu_scratch = kdata.requirements.scratch_sizes[static_cast<int>(kernels::AllocType::GPU)];
   if (gpu_scratch < temp_buffer_hint_)
     gpu_scratch = temp_buffer_hint_;
   kdata.scratch_alloc.Reserve(kdata.requirements.scratch_sizes);
+  minibatches_.resize(num_minibatches);
+  for (int i = 0; i < num_minibatches; i++) {
+    int start = batch_size * i / num_minibatches;
+    int end = (batch_size * (i + 1)) / num_minibatches;
+
+    minibatches_[i].start = start;
+    minibatches_[i].count = end-start;
+  }
 }
 
 void ResizeBase::RunCPU(Tensor<CPUBackend> &output,

--- a/dali/pipeline/operators/resize/resize_base.h
+++ b/dali/pipeline/operators/resize/resize_base.h
@@ -48,7 +48,7 @@ class DLL_PUBLIC ResizeBase : public ResamplingFilterAttr {
   std::vector<KernelData> kernel_data_;
 
   DLL_PUBLIC void Initialize(int num_threads = 1);
-  DLL_PUBLIC void InitializeGPU();
+  DLL_PUBLIC void InitializeGPU(int batch_size, int minibatch_size);
 
   inline KernelData &GetKernelData() {
     DALI_ENFORCE(!kernel_data_.empty(), "Resize kernel data not initialized");


### PR DESCRIPTION
Resampling operators (Resize, RandomResizedCrop) can now process images in mini-batches. Mini-batch must be smaller than batch size - otherwise it's ignored.

Changes:
- convert resampling `Params` from `vector` to `span`
- add multiple kernel data objects to GPU kernel
- bug fixes
