### PR TITLE
Fix pipeline completion callback

### DIFF
--- a/dali/pipeline/executor/executor_test.cc
+++ b/dali/pipeline/executor/executor_test.cc
@@ -14,6 +14,8 @@
 
 
 #include <gtest/gtest.h>
+#include <chrono>
+#include <future>
 
 #include "dali/test/dali_test_decoder.h"
 #include "dali/pipeline/executor/executor.h"
@@ -455,9 +457,13 @@ TYPED_TEST(ExecutorTest, TestRunBasicGraphWithCB) {
 
   vector<string> outputs = {"final_images_cpu"};
   int cb_counter = 0;
-  exe->SetCompletionCallback([&cb_counter]() {
+  std::promise<void> barrier;
+  auto barrier_future = barrier.get_future();
+  exe->SetCompletionCallback([&cb_counter, &barrier]() mutable {
     ++cb_counter;
+    barrier.set_value();
   });
+
   exe->Build(&graph, outputs);
 
   // Set the data for the external source
@@ -476,6 +482,8 @@ TYPED_TEST(ExecutorTest, TestRunBasicGraphWithCB) {
   exe->Outputs(&ws);
   ASSERT_EQ(ws.NumInput(), 0);
   ASSERT_EQ(ws.NumOutput(), 1);
+  auto status = barrier_future.wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status, std::future_status::ready);
   ASSERT_EQ(cb_counter, 1);
   ASSERT_TRUE(ws.OutputIsType<CPUBackend>(0));
 }
@@ -516,7 +524,16 @@ TYPED_TEST(ExecutorSyncTest, TestPrefetchedExecution) {
 
   vector<string> outputs = {"final_images_gpu"};
   int cb_counter = 0;
-  exe->SetCompletionCallback([&cb_counter]() {
+  std::promise<void> barrier_0, barrier_1;
+  auto barrier_future_0 = barrier_0.get_future();
+  auto barrier_future_1 = barrier_1.get_future();
+  exe->SetCompletionCallback([&cb_counter, &barrier_0, &barrier_1]() mutable {
+    if (cb_counter == 0) {
+      barrier_0.set_value();
+    }
+    if (cb_counter == 1) {
+      barrier_1.set_value();
+    }
     ++cb_counter;
   });
   exe->Build(&graph, outputs);
@@ -555,6 +572,8 @@ TYPED_TEST(ExecutorSyncTest, TestPrefetchedExecution) {
   exe->RunMixed();
   exe->RunGPU();
 
+  auto status_0 = barrier_future_0.wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status_0, std::future_status::ready);
   ASSERT_EQ(cb_counter, 1);
   src_op->SetDataSource(tl2);
   exe->RunCPU();
@@ -579,6 +598,9 @@ TYPED_TEST(ExecutorSyncTest, TestPrefetchedExecution) {
   ASSERT_EQ(ws.NumOutput(), 1);
   ASSERT_EQ(ws.NumInput(), 0);
   ASSERT_TRUE(ws.OutputIsType<GPUBackend>(0));
+
+  auto status_1 = barrier_future_1.wait_for(std::chrono::seconds(5));
+  ASSERT_EQ(status_1, std::future_status::ready);
   ASSERT_EQ(cb_counter, 2);
   TensorList<GPUBackend> &res2 = ws.Output<GPUBackend>(0);
   for (int i = 0; i < batch_size; ++i) {


### PR DESCRIPTION
Make it run after the async gpu work is finished.
Add some barriers in tests.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>