### PR TITLE
Change cast in resampling setup to silence a warning

### DIFF
--- a/dali/kernels/imgproc/resample/resampling_setup.cc
+++ b/dali/kernels/imgproc/resample/resampling_setup.cc
@@ -161,7 +161,7 @@ void BatchResamplingSetup::SetupBatch(
     Initialize();
 
   int N = in.num_samples();
-  assert(params.size() == static_cast<size_t>(N));
+  assert(params.size() == static_cast<ptrdiff_t>(N));
 
   sample_descs.resize(N);
   intermediate_shape.resize(N);


### PR DESCRIPTION
Signed-off-by: Serge Panev <spanev@nvidia.com>