### PR TITLE
Handle exception when NVDEC is not available for the video format

### DIFF
--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -202,8 +202,8 @@ void VideoLoader::read_file() {
   using pkt_ptr = std::unique_ptr<AVPacket, decltype(&av_packet_unref)>;
   auto raw_pkt = AVPacket{};
   auto seek_hack = 1;
-  while (!done_) {
-    if (done_) {
+  while (!stop_) {
+    if (stop_) {
       break;
     }
 
@@ -213,7 +213,7 @@ void VideoLoader::read_file() {
                 << " send_queue_ has " << send_queue_.size() << " frames left"
                 << std::endl;
 
-    if (done_) {
+    if (stop_) {
       break;
     }
 

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -112,7 +112,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       normalized_(spec.GetArgument<bool>("normalized")),
       filenames_(filenames),
       codec_id_(0),
-      done_(false) {
+      stop_(false) {
     if (step_ < 0)
       step_ = count_;
     DALI_ENFORCE(cuvidInitChecked(0),
@@ -129,7 +129,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   }
 
   ~VideoLoader() noexcept override {
-    done_ = true;
+    stop_ = true;
     send_queue_.shutdown();
     if (vid_decoder_) {
       vid_decoder_->finish();
@@ -213,7 +213,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   std::vector<std::pair<int, int>> frame_starts_;
   Index current_frame_idx_;
 
-  volatile bool done_;
+  volatile bool stop_;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/nvdecoder/cuvideodecoder.cc
+++ b/dali/pipeline/operators/reader/nvdecoder/cuvideodecoder.cc
@@ -115,7 +115,6 @@ int CUVideoDecoder::initialize(CUVIDEOFORMAT* format) {
             (format->coded_height != decoder_info_.ulHeight) ||
             (format->chroma_format != decoder_info_.ChromaFormat)) {
             DALI_FAIL("Encountered a dynamic video format change.");
-            return 0;
         }
         return 1;
     }
@@ -146,7 +145,7 @@ int CUVideoDecoder::initialize(CUVIDEOFORMAT* format) {
         ss << "Unsupported Codec " << GetVideoCodecString(format->codec)
             << " with chroma format "
             << GetVideoChromaFormatString(format->chroma_format);
-        throw std::runtime_error(ss.str());
+        DALI_FAIL(ss.str());
     }
     LOG_LINE << "NVDEC Capabilities" << std::endl
         << "\tMax width : " << caps.nMaxWidth << std::endl
@@ -156,14 +155,14 @@ int CUVideoDecoder::initialize(CUVIDEOFORMAT* format) {
         << "\tMin height :" << caps.nMinHeight << std::endl;
     if (format->coded_width < caps.nMinWidth ||
         format->coded_height < caps.nMinHeight) {
-        throw std::runtime_error("Video is too small in at least one dimension.");
+        DALI_FAIL("Video is too small in at least one dimension.");
     }
     if (format->coded_width > caps.nMaxWidth ||
         format->coded_height > caps.nMaxHeight) {
-        throw std::runtime_error("Video is too large in at least one dimension.");
+        DALI_FAIL("Video is too large in at least one dimension.");
     }
     if (format->coded_width * format->coded_height / 256 > caps.nMaxMBCount) {
-        throw std::runtime_error("Video is too large (too many macroblocks).");
+        DALI_FAIL("Video is too large (too many macroblocks).");
     }
 
     decoder_info_.CodecType = format->codec;

--- a/dali/pipeline/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/pipeline/operators/reader/nvdecoder/nvdecoder.cc
@@ -36,6 +36,9 @@
 
 namespace dali {
 
+static constexpr int kNvcuvid_success = 1;
+static constexpr int kNvcuvid_failure = 0;
+
 NvDecoder::NvDecoder(int device_id,
                      const CodecParameters* codecpar,
                      AVRational time_base,
@@ -142,12 +145,20 @@ int NvDecoder::handle_display(void* user_data,
   return decoder->handle_display_(disp_info);
 }
 
+// Prepare params and calls cuvidCreateDecoder
 int NvDecoder::handle_sequence_(CUVIDEOFORMAT* format) {
   frame_base_ = {static_cast<int>(format->frame_rate.denominator),
                   static_cast<int>(format->frame_rate.numerator)};
-
-  // Prepare params and calls cuvidCreateDecoder
-  return decoder_.initialize(format);
+  int ret = kNvcuvid_failure;
+  try {
+    ret = decoder_.initialize(format);
+  } catch (...) {
+    done_ = true;
+    captured_exception_ = std::current_exception();
+    // Main thread is waiting on frame_queue_
+    frame_queue_.shutdown();
+  }
+  return ret;
 }
 
 int NvDecoder::handle_decode_(CUVIDPICPARAMS* pic_params) {
@@ -155,29 +166,33 @@ int NvDecoder::handle_decode_(CUVIDPICPARAMS* pic_params) {
   constexpr auto sleep_period = 500;
   constexpr auto timeout_sec = 20;
   constexpr auto enable_timeout = false;
+
+  // If something went wrong during init we exit directly
+  if (done_) return kNvcuvid_failure;
+
   while (frame_in_use_[pic_params->CurrPicIdx]) {
     if (enable_timeout &&
       total_wait++ > timeout_sec * 1000000 / sleep_period) {
-      std::cout << device_id_ << ": Waiting for picture "
-                << pic_params->CurrPicIdx
-                << " to become available..." << std::endl;
+      LOG_LINE << device_id_ << ": Waiting for picture "
+               << pic_params->CurrPicIdx
+               << " to become available..." << std::endl;
       std::stringstream ss;
       ss << "Waited too long (" << timeout_sec << " seconds) "
-          << "for decode output buffer to become available";
+         << "for decode output buffer to become available";
       DALI_FAIL(ss.str());
     }
     usleep(sleep_period);
-    if (done_) return 0;
+    if (done_) return kNvcuvid_failure;
   }
 
   LOG_LINE << "Sending a picture for decode"
-              << " size: " << pic_params->nBitstreamDataLen
-              << " pic index: " << pic_params->CurrPicIdx
-              << std::endl;
+           << " size: " << pic_params->nBitstreamDataLen
+           << " pic index: " << pic_params->CurrPicIdx
+           << std::endl;
 
   // decoder_ operator () returns a CUvideodecoder
   CUDA_CALL(cuvidDecodePicture(decoder_, pic_params));
-  return 1;
+  return kNvcuvid_success;
 }
 
 NvDecoder::MappedFrame::MappedFrame()
@@ -267,25 +282,24 @@ NvDecoder::TextureObject::operator cudaTextureObject_t() const {
 int NvDecoder::handle_display_(CUVIDPARSERDISPINFO* disp_info) {
   auto frame = av_rescale_q(disp_info->timestamp,
                             nv_time_base_, frame_base_);
-
   if (current_recv_.count <= 0) {
     if (recv_queue_.empty()) {
       LOG_LINE << "Ditching frame " << frame << " since "
               << "the receive queue is empty." << std::endl;
-      return 1;
+      return kNvcuvid_success;
     }
     LOG_LINE << "Moving on to next request, " << recv_queue_.size()
                 << " reqs left" << std::endl;
     current_recv_ = recv_queue_.pop();
   }
 
-  if (done_) return 0;
+  if (done_) return kNvcuvid_failure;
 
   if (current_recv_.count <= 0) {
     // a new req with count <= 0 probably means we are finishing
     // up and should just ditch this frame
     LOG_LINE << "Ditching frame " << frame << "since current_recv_.count <= 0" << std::endl;
-    return 1;
+    return kNvcuvid_success;
   }
 
   if (frame != current_recv_.frame) {
@@ -293,7 +307,7 @@ int NvDecoder::handle_display_(CUVIDPARSERDISPINFO* disp_info) {
     // Add exception? Directly or after countdown treshold?
     LOG_LINE << "Ditching frame " << frame << " since we are waiting for "
                 << "frame " << current_recv_.frame << std::endl;
-    return 1;
+    return kNvcuvid_success;
   }
 
   LOG_LINE << "\e[1mGoing ahead with frame " << frame
@@ -306,7 +320,7 @@ int NvDecoder::handle_display_(CUVIDPARSERDISPINFO* disp_info) {
 
   frame_in_use_[disp_info->picture_index] = true;
   frame_queue_.push(disp_info);
-  return 1;
+  return kNvcuvid_success;
 }
 
 int NvDecoder::decode_packet(AVPacket* pkt) {
@@ -321,7 +335,6 @@ int NvDecoder::decode_packet(AVPacket* pkt) {
   }
   return -1;
 }
-
 
 void NvDecoder::push_req(FrameReq req) {
   recv_queue_.push(std::move(req));
@@ -341,7 +354,9 @@ void NvDecoder::receive_frames(SequenceWrapper& sequence) {
       auto frame = MappedFrame{frame_disp_info, decoder_, stream_};
       if (done_) break;
       convert_frame(frame, sequence, i);
-    }
+  }
+  if (captured_exception_)
+    std::rethrow_exception(captured_exception_);
   record_sequence_event_(sequence);
 }
 

--- a/dali/pipeline/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/pipeline/operators/reader/nvdecoder/nvdecoder.h
@@ -196,6 +196,7 @@ class NvDecoder {
   std::unordered_map<TexID, TextureObjects, tex_hash> textures_;
 
   volatile bool done_;
+  std::exception_ptr captured_exception_;
 
   std::thread thread_convert_;
 };

--- a/dali/pipeline/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/pipeline/operators/reader/nvdecoder/nvdecoder.h
@@ -195,7 +195,7 @@ class NvDecoder {
 
   std::unordered_map<TexID, TextureObjects, tex_hash> textures_;
 
-  volatile bool done_;
+  volatile bool stop_;
   std::exception_ptr captured_exception_;
 
   std::thread thread_convert_;


### PR DESCRIPTION
The exception raised when NVDEC is not available was not properly handled by DALI pipeline.
Catches it in order to propagate in to the main thread.