### PR TITLE
VideoReader stride

### DIFF
--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -210,8 +210,8 @@ void VideoLoader::read_file() {
     auto req = send_queue_.pop();
 
     LOG_LINE << "Got a request for " << req.filename << " frame " << req.frame
-                << " send_queue_ has " << send_queue_.size() << " frames left"
-                << std::endl;
+             << " count " << req.count << " send_queue_ has " << send_queue_.size()
+             << " frames left" << std::endl;
 
     if (stop_) {
       break;
@@ -244,6 +244,7 @@ void VideoLoader::read_file() {
       auto frame = av_rescale_q(pkt->pts,
                                 file.stream_base_,
                                 file.frame_base_);
+      LOG_LINE << "Frame candidate " << frame << " (for " << req.frame  <<" )...\n";
 
       file.last_frame_ = frame;
       auto key = pkt->flags & AV_PKT_FLAG_KEY;
@@ -365,7 +366,8 @@ void VideoLoader::read_file() {
 }
 
 void VideoLoader::push_sequence_to_read(std::string filename, int frame, int count) {
-    auto req = FrameReq{filename, frame, count};
+    int total_count = 1 + (count - 1) * stride_;
+    auto req = FrameReq{filename, frame, total_count, stride_};
     // give both reader thread and decoder a copy of what is coming
     send_queue_.push(req);
 }

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -105,6 +105,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
     : Loader<GPUBackend, SequenceWrapper>(spec),
       count_(spec.GetArgument<int>("sequence_length")),
       step_(spec.GetArgument<int>("step")),
+      stride_(spec.GetArgument<int>("stride")),
       height_(0),
       width_(0),
       image_type_(spec.GetArgument<DALIImageType>("image_type")),
@@ -114,7 +115,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       codec_id_(0),
       stop_(false) {
     if (step_ < 0)
-      step_ = count_;
+      step_ = count_ * stride_;
     DALI_ENFORCE(cuvidInitChecked(0),
      "Failed to load libnvcuvid.so, needed by the VideoReader operator. "
      "If you are running in a Docker container, please refer "
@@ -188,6 +189,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   // Params
   int count_;
   int step_;
+  int stride_;
   int output_height_;
   int output_width_;
   int height_;

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -158,9 +158,10 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   Index SizeImpl() override;
 
   void PrepareMetadataImpl() override {
+    int total_count = 1 + (count_ - 1) * stride_;
     for (size_t i = 0; i < filenames_.size(); ++i) {
       int frame_count = get_or_open_file(filenames_[i]).frame_count_;
-      for (int s = 0; s < frame_count && s + count_ <= frame_count; s += step_) {
+      for (int s = 0; s < frame_count && s + total_count <= frame_count; s += step_) {
         frame_starts_.emplace_back(i, s);
       }
     }

--- a/dali/pipeline/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/pipeline/operators/reader/nvdecoder/nvdecoder.cc
@@ -281,10 +281,11 @@ NvDecoder::TextureObject::operator cudaTextureObject_t() const {
 int NvDecoder::handle_display_(CUVIDPARSERDISPINFO* disp_info) {
   auto frame = av_rescale_q(disp_info->timestamp,
                             nv_time_base_, frame_base_);
+
   if (current_recv_.count <= 0) {
     if (recv_queue_.empty()) {
       LOG_LINE << "Ditching frame " << frame << " since "
-              << "the receive queue is empty." << std::endl;
+               << "the receive queue is empty." << std::endl;
       return kNvcuvid_success;
     }
     LOG_LINE << "Moving on to next request, " << recv_queue_.size()
@@ -314,8 +315,8 @@ int NvDecoder::handle_display_(CUVIDPARSERDISPINFO* disp_info) {
               << " disp_info->picture_index: " << disp_info->picture_index
               << "\e[0m" << std::endl;
 
-  current_recv_.frame++;
-  current_recv_.count--;
+  current_recv_.frame += current_recv_.stride;
+  current_recv_.count -= current_recv_.stride;
 
   frame_in_use_[disp_info->picture_index] = true;
   frame_queue_.push(disp_info);

--- a/dali/pipeline/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/pipeline/operators/reader/nvdecoder/nvdecoder.h
@@ -55,6 +55,7 @@ struct FrameReq {
   std::string filename;
   int frame;
   int count;
+  int stride;
 };
 
 enum ScaleMethod {

--- a/dali/pipeline/operators/reader/video_reader_op.cc
+++ b/dali/pipeline/operators/reader/video_reader_op.cc
@@ -57,5 +57,7 @@ number of frames).)code")
   .AddOptionalArg("dtype",
       R"code(The data type of the output frames (supports FLOAT and UINT8).)code",
       DALI_UINT8)
+  .AddOptionalArg("stride",
+      R"code(Distance between consecutive frames in sequence.)code", 1u, false)
   .AddParent("LoaderBase");
 }  // namespace dali

--- a/dali/test/python/test_video_pipeline.py
+++ b/dali/test/python/test_video_pipeline.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+import random
+from math import ceil, sqrt
+
+import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
+
+import nvidia.dali.ops as ops
+import nvidia.dali.types as types
+from nvidia.dali.backend_impl import TensorListGPU
+from nvidia.dali.pipeline import Pipeline
+
+VIDEO_DIRECTORY="video_files"
+VIDEO_FILES=os.listdir(VIDEO_DIRECTORY)
+VIDEO_FILES = [VIDEO_DIRECTORY + '/' + f for f in VIDEO_FILES]
+
+ITER=6
+BATCH_SIZE=4
+COUNT=5
+
+class VideoPipe(Pipeline):
+    def __init__(self, batch_size, data, shuffle=False, stride=1, step=-1):
+        super(VideoPipe, self).__init__(batch_size, num_threads=2, device_id=0, seed=12)
+        self.input = ops.VideoReader(device="gpu", filenames=data, sequence_length=COUNT,
+                                     shard_id=0, num_shards=1, random_shuffle=shuffle,
+                                     normalized=True, image_type=types.YCbCr, dtype=types.FLOAT,
+                                     step=step, stride=stride)
+
+    def define_graph(self):
+        output = self.input(name="Reader")
+        return output
+
+def test_simple_videopipeline():
+    pipe = VideoPipe(batch_size=BATCH_SIZE, data=VIDEO_FILES)
+    pipe.build()
+    for i in range(ITER):
+        print("Iter " + str(i))
+        pipe_out = pipe.run()
+    del pipe
+
+def test_step_video_pipeline():
+    pipe = VideoPipe(batch_size=BATCH_SIZE, data=VIDEO_FILES, step=1)
+    pipe.build()
+    for i in range(ITER):
+        print("Iter " + str(i))
+        pipe_out = pipe.run()
+    del pipe
+
+def test_stride_video_pipeline():
+    pipe = VideoPipe(batch_size=BATCH_SIZE, data=VIDEO_FILES, stride=3)
+    pipe.build()
+    for i in range(ITER):
+        print("Iter " + str(i))
+        pipe_out = pipe.run()
+    del pipe
+

--- a/qa/L0_videoreader_test/test.sh
+++ b/qa/L0_videoreader_test/test.sh
@@ -7,20 +7,21 @@ apt-get install -y wget ffmpeg
 
 pushd ../..
 
+source qa/setup_dali_extra.sh
+
 cd docs/examples/video
 
 mkdir -p video_files
 
-container_name=prepared.mp4
 
-# Download video sample
-wget -q -O ${container_name} https://download.blender.org/durian/trailer/sintel_trailer-720p.mp4
+container_path=${DALI_EXTRA_PATH}/db/optical_flow/sintel_trailer/sintel_trailer.mp4
 
-IFS='.' read -a splitted <<< "$container_name"
+IFS='/' read -a container_name <<< "$container_path"
+IFS='.' read -a splitted <<< "${container_name[-1]}"
 
 for i in {0..4};
 do
-    ffmpeg -ss 00:00:${i}0 -t 00:00:10 -i $container_name -vcodec copy -acodec copy -y video_files/${splitted[0]}_$i.${splitted[1]}
+    ffmpeg -ss 00:00:${i}0 -t 00:00:10 -i $container_path -vcodec copy -acodec copy -y video_files/${splitted[0]}_$i.${splitted[1]} 
 done
 
 test_body() {

--- a/qa/L0_videoreader_test/test.sh
+++ b/qa/L0_videoreader_test/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-pip_packages="numpy"
+pip_packages="nose numpy"
 
 apt-get update
 apt-get install -y wget ffmpeg
@@ -26,6 +26,7 @@ done
 test_body() {
     # test code
     python video_example.py
+    nosetests --verbose ../../../dali/test/python/test_video_pipeline.py
 }
 
 source ../../../qa/test_template.sh


### PR DESCRIPTION
- Add a `stride` argument (default 1): Extracted sequence of size `n` and stride `s` starting at frame 'f' is now the following sequence:
```
[f, f+s*1, f+s*2 ... f + s*(n-1)]
```
- Add Python test units for VideoReader based pipeline for L0 tests