### PR TITLE
Fix build for the old version of nvJPEG

### DIFF
--- a/dali/pipeline/operators/decoder/CMakeLists.txt
+++ b/dali/pipeline/operators/decoder/CMakeLists.txt
@@ -42,8 +42,6 @@ if (BUILD_NVJPEG)
         "${CMAKE_CURRENT_SOURCE_DIR}/nvjpeg_decoder_split_crop_test.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/nvjpeg_decoder_split_slice_test.cc"
         "${CMAKE_CURRENT_SOURCE_DIR}/nvjpeg_decoder_split_random_crop_test.cc")
-    else()
-      list(APPEND DALI_TEST_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/nvjpeg_decoder_test.cc")
     endif()
   endif()
 endif()


### PR DESCRIPTION
- nvjpeg_decoder_test.cc was removed from the source tree, but for the old
  nvJPEG API CMake still tries to use it during the build

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>