### PR TITLE
Change CHECK_STRUCT_HAS_MEMBER to use CXX

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -34,7 +34,7 @@ RUN CUDA_VERSION=10.0 && \
     curl -LO https://developer.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/local_installers/cuda_${CUDA_BUILD}_linux && \
     chmod +x cuda_${CUDA_BUILD}_linux && \
     ./cuda_${CUDA_BUILD}_linux --silent --no-opengl-libs --toolkit && \
-    rm -f cuda_${CUDA_BUILD}_linux; 
+    rm -f cuda_${CUDA_BUILD}_linux;
 
 FROM cuda-${USE_CUDA_VERSION} as cuda
 
@@ -112,7 +112,7 @@ RUN CLANG_VERSION=6.0.1 && \
 
 ENV NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
 
-# FMpeg
+# FFmpeg
 RUN FFMPEG_VERSION=3.4.2 && \
     cd /tmp && wget https://developer.download.nvidia.com/compute/redist/nvidia-dali/ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
     tar xf ffmpeg-$FFMPEG_VERSION.tar.bz2 && \

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -187,7 +187,7 @@ endforeach(m)
 
 include_directories(${avformat_INCLUDE_DIRS})
 list(APPEND DALI_LIBS ${avformat_LIBRARIES})
-CHECK_STRUCT_HAS_MEMBER("struct AVStream" codecpar libavformat/avformat.h HAVE_AVSTREAM_CODECPAR LANGUAGE C)
+CHECK_STRUCT_HAS_MEMBER("struct AVStream" codecpar libavformat/avformat.h HAVE_AVSTREAM_CODECPAR LANGUAGE CXX)
 set(CMAKE_EXTRA_INCLUDE_FILES libavcodec/avcodec.h)
 CHECK_TYPE_SIZE("AVBSFContext" AVBSFCONTEXT LANGUAGE CXX)
 


### PR DESCRIPTION
DALI project uses only CXX
Fix a typo in Dockerfile.deps

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>