### PR TITLE
Minor fixes: Warning fix + enable one missing test

### DIFF
--- a/dali/kernels/common/scatter_gather.cu
+++ b/dali/kernels/common/scatter_gather.cu
@@ -70,7 +70,7 @@ void ScatterGatherGPU::MakeBlocks() {
 
   size_per_block_ = std::min(max_size, max_size_per_block_);
 
-  int num_blocks = 0;
+  size_t num_blocks = 0;
   for (auto &r : ranges_)
     num_blocks += (r.size + size_per_block_ - 1) / size_per_block_;
 

--- a/dali/kernels/test/resampling_test/resampling_internal_test.cu
+++ b/dali/kernels/test/resampling_test/resampling_internal_test.cu
@@ -498,8 +498,7 @@ TEST_F(ResamplingTest, Lanczos3) {
   Verify(1, "score_lanczos_dif.png");
 }
 
-// It passes. It's DISABLED until the test data propagates to CI
-TEST_F(ResamplingTest, DISABLED_Cubic) {
+TEST_F(ResamplingTest, Cubic) {
   SetSource("imgproc_test/score.png", "imgproc_test/ref_out/score_cubic.png");
   SetOutputSize(200, 93);
   auto filters = GetResamplingFilters();


### PR DESCRIPTION
Fix warning in scatter_gather.
Enable cubic filtering internal test.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>
