### PR TITLE
Fix test_detection_pipeline failing

### DIFF
--- a/dali/pipeline/operators/detection/random_crop.cc
+++ b/dali/pipeline/operators/detection/random_crop.cc
@@ -259,7 +259,7 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
         auto xc = 0.5*(bbox[0] + bbox[2]);
         auto yc = 0.5*(bbox[1] + bbox[3]);
 
-        bool valid = (xc > left) && (xc < right) && (yc > top) && (yc < bottom);
+        bool valid = (xc >= left) && (xc <= right) && (yc >= top) && (yc <= bottom);
         if (valid) {
           mask.push_back(j);
           valid_bboxes += 1;

--- a/dali/test/python/test_detection_pipeline.py
+++ b/dali/test/python/test_detection_pipeline.py
@@ -385,8 +385,8 @@ def run_for_dataset(args, dataset):
                 print('  decode_crop =', decode_crop)
                 print('  slice_cpu =', slice_cpu)
                 print('  slice_gpu =', slice_gpu)
-                print('  boxes_crop =', decode_crop)
-                print('  labels_cpu =', labels_crop)
+                print('  boxes_crop =', boxes_crop)
+                print('  labels_crop =', labels_crop)
 
                 print('Resize =', resize)
 


### PR DESCRIPTION
SSD random crops were acting differently about filtering boxes, when box center was at the edge of the crop. This caused detection pipeline test to fail. Now both implementations include such a box.

Signed-off-by: Albert Wolant <awolant@nvidia.com>