### PR TITLE
Updating default value for crop_pos

### DIFF
--- a/dali/pipeline/operators/crop/crop_attr.cc
+++ b/dali/pipeline/operators/crop/crop_attr.cc
@@ -31,14 +31,14 @@ with size `(c,c)`)code",
 Actual position is calculated as `crop_x = crop_x_norm * (W - crop_W)`,
 where `crop_x_norm` is the normalized position, `W` is the width of the image
 and `crop_W` is the width of the cropping window)code",
-        0.5f, true)
+        0.0f, true)
     .AddOptionalArg(
         "crop_pos_y",
         R"code(Normalized (0.0 - 1.0) vertical position of the cropping window (upper left corner).
 Actual position is calculated as `crop_y = crop_y_norm * (H - crop_H)`,
 where `crop_y_norm` is the normalized position, `H` is the height of the image
 and `crop_H` is the height of the cropping window)code",
-        0.5f, true)
+        0.0f, true)
     .AddOptionalArg(
         "crop_w",
         R"code(cropping window height (in pixels).

--- a/dali/pipeline/operators/decoder/host_decoder_crop_test.cc
+++ b/dali/pipeline/operators/decoder/host_decoder_crop_test.cc
@@ -21,7 +21,9 @@ class HostDecoderCropTest : public DecodeTestBase<ImgType> {
  protected:
   OpSpec DecodingOp() const override {
     return this->GetOpSpec("HostDecoderCrop")
-      .AddArg("crop", std::vector<float>{1.0f*crop_H, 1.0f*crop_W});
+      .AddArg("crop", std::vector<float>{1.0f*crop_H, 1.0f*crop_W})
+      .AddArg("crop_pos_x", 0.5f)
+      .AddArg("crop_pos_y", 0.5f);
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {

--- a/dali/pipeline/operators/fused/resize_crop_mirror_test.cc
+++ b/dali/pipeline/operators/fused/resize_crop_mirror_test.cc
@@ -38,29 +38,41 @@ TYPED_TEST_SUITE(ResizeCropMirrorTest, Types);
 
 TYPED_TEST(ResizeCropMirrorTest, TestFixedResizeAndCrop) {
   this->TstBody(this->DefaultSchema()
-                .AddArg("resize_shorter", 480.f)
-                .AddArg("crop", vector<float>{224, 224}), 5e-6);
+                        .AddArg("resize_shorter", 480.f)
+                        .AddArg("crop_pos_x", 0.5f)
+                        .AddArg("crop_pos_y", 0.5f)
+                        .AddArg("crop", vector<float>{224, 224}), 5e-6);
 }
+
 
 TYPED_TEST(ResizeCropMirrorTest, TestFixedResizeAndCropWarp) {
   this->TstBody(this->DefaultSchema()
-                .AddArg("resize_x", 480.f)
-                .AddArg("resize_y", 480.f)
-                .AddArg("crop", vector<float>{224, 224}), 5e-6);
+                        .AddArg("resize_x", 480.f)
+                        .AddArg("resize_y", 480.f)
+                        .AddArg("crop_pos_x", 0.5f)
+                        .AddArg("crop_pos_y", 0.5f)
+                        .AddArg("crop", vector<float>{224, 224}), 5e-6);
+
 }
+
 
 TYPED_TEST(ResizeCropMirrorTest, TestFixedFastResizeAndCrop) {
   this->TstBody(this->DefaultSchema(true)
-                .AddArg("resize_shorter", 480.f)
-                .AddArg("crop", vector<float>{224, 224}), 1.98);
+                        .AddArg("resize_shorter", 480.f)
+                        .AddArg("crop_pos_x", 0.5f)
+                        .AddArg("crop_pos_y", 0.5f)
+                        .AddArg("crop", vector<float>{224, 224}), 1.98);
+
 }
+
 
 TYPED_TEST(ResizeCropMirrorTest, TestFixedFastResizeAndCropWarp) {
   this->TstBody(this->DefaultSchema(true)
-                    .AddArg("resize_x", 480.f)
-                    .AddArg("resize_y", 480.f)
-                    .AddArg("crop", vector<float>{224, 224}),
-                1.80);
+                        .AddArg("resize_x", 480.f)
+                        .AddArg("resize_y", 480.f)
+                        .AddArg("crop_pos_x", 0.5f)
+                        .AddArg("crop_pos_y", 0.5f)
+                        .AddArg("crop", vector<float>{224, 224}), 1.80);
 }
 
 }  // namespace dali

--- a/dali/pipeline/operators/fused/resize_crop_mirror_test.cc
+++ b/dali/pipeline/operators/fused/resize_crop_mirror_test.cc
@@ -52,7 +52,6 @@ TYPED_TEST(ResizeCropMirrorTest, TestFixedResizeAndCropWarp) {
                         .AddArg("crop_pos_x", 0.5f)
                         .AddArg("crop_pos_y", 0.5f)
                         .AddArg("crop", vector<float>{224, 224}), 5e-6);
-
 }
 
 
@@ -62,7 +61,6 @@ TYPED_TEST(ResizeCropMirrorTest, TestFixedFastResizeAndCrop) {
                         .AddArg("crop_pos_x", 0.5f)
                         .AddArg("crop_pos_y", 0.5f)
                         .AddArg("crop", vector<float>{224, 224}), 1.98);
-
 }
 
 


### PR DESCRIPTION
(0.5, 0.5) default value for crop in not really usable, since when user doesn't want the cropping (e.g. in fused ops), he needs to have (0.0, 0.0). 

Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>