### PR TITLE
Fix DALI __version__ for non-release builds

### DIFF
--- a/dali/python/CMakeLists.txt
+++ b/dali/python/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 # Add the COPYRIGHT, LICENSE, and Acknowledgements
 copy_post_build(${dali_python_lib} "${PROJECT_SOURCE_DIR}/dali/python/nvidia" "${PROJECT_BINARY_DIR}/dali/python")
-configure_file("${PROJECT_SOURCE_DIR}/dali/python/__init__.py.in" "${PROJECT_BINARY_DIR}//dali/python/nvidia/dali/__init__.py")
+configure_file("${PROJECT_SOURCE_DIR}/dali/python/__init__.py.in" "${PROJECT_BINARY_DIR}/dali/python/nvidia/dali/__init__.py")
 configure_file("${PROJECT_SOURCE_DIR}/dali/python/setup.py.in" "${PROJECT_BINARY_DIR}/stage/setup.py")
 copy_post_build(${dali_python_lib} "${PROJECT_BINARY_DIR}/stage/setup.py" "${PROJECT_BINARY_DIR}/dali/python")
 copy_post_build(${dali_python_lib} "${PROJECT_SOURCE_DIR}/dali/python/MANIFEST.in" "${PROJECT_BINARY_DIR}/dali/python")

--- a/dali/python/CMakeLists.txt
+++ b/dali/python/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 
 # Add the COPYRIGHT, LICENSE, and Acknowledgements
 copy_post_build(${dali_python_lib} "${PROJECT_SOURCE_DIR}/dali/python/nvidia" "${PROJECT_BINARY_DIR}/dali/python")
+configure_file("${PROJECT_SOURCE_DIR}/dali/python/__init__.py.in" "${PROJECT_BINARY_DIR}//dali/python/nvidia/dali/__init__.py")
 configure_file("${PROJECT_SOURCE_DIR}/dali/python/setup.py.in" "${PROJECT_BINARY_DIR}/stage/setup.py")
 copy_post_build(${dali_python_lib} "${PROJECT_BINARY_DIR}/stage/setup.py" "${PROJECT_BINARY_DIR}/dali/python")
 copy_post_build(${dali_python_lib} "${PROJECT_SOURCE_DIR}/dali/python/MANIFEST.in" "${PROJECT_BINARY_DIR}/dali/python")

--- a/dali/python/__init__.py.in
+++ b/dali/python/__init__.py.in
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from pkg_resources import get_distribution, DistributionNotFound
 
 from . import ops
 from . import pipeline
@@ -23,7 +22,4 @@ from . import types
 from . import plugin_manager
 from . import sysconfig
 
-try:
-    __version__ = get_distribution('nvidia-dali').version
-except:
-    __version__ = None
+__version__ = '@DALI_VERSION@'


### PR DESCRIPTION
- hardcodes __version__ during build process instead of obtaining it in the runtime

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>