### PR TITLE
Make test scripts verbose

### DIFF
--- a/qa/setup_test.sh
+++ b/qa/setup_test.sh
@@ -2,4 +2,12 @@
 
 # Fetch test data
 export DALI_EXTRA_PATH=/opt/dali_extra
-git clone --depth=1 https://github.com/NVIDIA/DALI_extra.git ${DALI_EXTRA_PATH}
+DALI_EXTRA_URL="https://github.com/NVIDIA/DALI_extra.git"
+if [ ! -d "$DALI_EXTRA_PATH" ] ; then
+    git clone --depth=1 "$DALI_EXTRA_URL" "$DALI_EXTRA_PATH"
+else 
+    pushd "$DALI_EXTRA_PATH"
+    git fetch origin master
+    git checkout origin/master
+    popd
+fi

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -1,3 +1,10 @@
+#!/bin/bash
+
+# Force error checking
+set -e
+# Force tests to be verbose
+set -x
+
 topdir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/..
 
 # Install dependencies


### PR DESCRIPTION
Allow to rerun test by not cloning when dali_extra exits

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>