### PR TITLE
Fix `shuffle_after_epoch` option

### DIFF
--- a/dali/pipeline/operators/reader/coco_reader_op.h
+++ b/dali/pipeline/operators/reader/coco_reader_op.h
@@ -41,6 +41,12 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
     DALI_ENFORCE(!skip_cached_images_,
       "COCOReader doesn't support `skip_cached_images` option");
 
+    /*
+     * Those options are mutually exclusive as `shuffle_after_epoch` will make every shard looks differently
+     * after each epoch so coexistence with `stick_to_shard` doesn't make any sense
+     * Still when `shuffle_after_epoch` we will set `stick_to_shard` internally in the FileLoader so all
+     * DALI instances will do shuffling after each epoch
+     */
     if (shuffle_after_epoch || stick_to_shard)
       DALI_ENFORCE(
         !shuffle_after_epoch || !stick_to_shard,

--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -56,6 +56,12 @@ class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
       shuffle_after_epoch_(shuffle_after_epoch),
       current_index_(0),
       current_epoch_(0) {
+      /*
+       * Imply `stick_to_shard` from  `shuffle_after_epoch`
+       */
+      if (shuffle_after_epoch_) {
+        stick_to_shard_ = true;
+      }
     mmap_reserver = FileStream::FileStreamMappinReserver(
         static_cast<unsigned int>(initial_buffer_fill_));
     copy_read_data_ = !mmap_reserver.CanShareMappedData();


### PR DESCRIPTION
- before that change, global shuffling happened only when
  data reader reached the end of data set, while it should happen when it goes beyond its shard. Now `shuffle_after_epoch` uses
  `stick_to_shard` to achieve that. Still, the user cannot use both
  of that options as `stick_to_shard` is meant to provide the same
  data inside the same shard at each epoch wile in conjunction with
  `shuffle_after_epoch` it will differ

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>