### PR TITLE
Reimplement GetSingleOrRepeatedArg without use of exceptions for normal flow.

### DIFF
--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -683,7 +683,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::PresizeData(
 template <typename WorkspacePolicy, typename QueuePolicy>
 std::vector<int> Executor<WorkspacePolicy, QueuePolicy>::GetMemoryHints(const OpNode &node) {
   std::vector<int> hints;
-  GetSingleOrRepeatedArg(node.spec, &hints, "bytes_per_sample_hint", node.spec.NumOutput());
+  GetSingleOrRepeatedArg(node.spec, hints, "bytes_per_sample_hint", node.spec.NumOutput());
   std::replace(hints.begin(), hints.end(), 0, static_cast<int>(bytes_per_sample_hint_));
   return hints;
 }

--- a/dali/pipeline/operators/argument.h
+++ b/dali/pipeline/operators/argument.h
@@ -142,6 +142,9 @@ class Argument {
   T Get();
 
   template<typename T>
+  bool IsType();
+
+  template<typename T>
   static Argument * Store(const std::string& s,
       const T& val);
 
@@ -232,6 +235,11 @@ class ArgumentInst<std::vector<T>> : public Argument {
 };
 
 DLL_PUBLIC Argument *DeserializeProtobuf(const DaliProtoPriv arg);
+
+template<typename T>
+bool Argument::IsType() {
+  return dynamic_cast<ArgumentInst<T>*>(this) != nullptr;
+}
 
 template<typename T>
 T Argument::Get() {

--- a/dali/pipeline/operators/common.h
+++ b/dali/pipeline/operators/common.h
@@ -22,26 +22,20 @@
 
 namespace dali {
 template <typename T>
-inline void GetSingleOrRepeatedArg(const OpSpec &spec, vector<T> *arg,
+inline void GetSingleOrRepeatedArg(const OpSpec &spec, vector<T> &result,
                                    const std::string &argName, size_t repeat_count = 2) {
-  try {
-      *arg = spec.GetRepeatedArgument<T>(argName);
-  } catch (std::runtime_error e) {
-      try {
-        *arg = {spec.GetArgument<T>(argName)};
-      } catch (std::runtime_error e) {
-          DALI_FAIL("Invalid type of argument \"" + argName + "\"");
-      }
+  if (!spec.TryGetRepeatedArgument<T>(result, argName)) {
+      T scalar = spec.GetArgument<T>(argName);
+      result.assign(repeat_count, scalar);
+  } else if (result.size() == 1 && repeat_count != 1) {
+      T scalar = result.front();
+      result.assign(repeat_count, scalar);
   }
 
-  if (arg->size() == 1) {
-    arg->assign(repeat_count, arg->back());
-  }
-
-  DALI_ENFORCE(arg->size() == repeat_count,
+  DALI_ENFORCE(result.size() == repeat_count,
       "Argument \"" + argName + "\" expects either a single value "
       "or a list of " + to_string(repeat_count) + " elements. " +
-      to_string(arg->size()) + " given.");
+      to_string(result.size()) + " given.");
 }
 
 }  // namespace dali

--- a/dali/pipeline/operators/crop/random_crop_attr.h
+++ b/dali/pipeline/operators/crop/random_crop_attr.h
@@ -39,11 +39,11 @@ class RandomCropAttr {
     int num_attempts = spec.GetArgument<int>("num_attempts");
 
     std::vector<float> aspect_ratio;
-    GetSingleOrRepeatedArg(spec, &aspect_ratio, "random_aspect_ratio", 2);
+    GetSingleOrRepeatedArg(spec, aspect_ratio, "random_aspect_ratio", 2);
     DALI_ENFORCE(aspect_ratio[0] <= aspect_ratio[1], "Provided empty range");
 
     std::vector<float> area;
-    GetSingleOrRepeatedArg(spec, &area, "random_area", 2);
+    GetSingleOrRepeatedArg(spec, area, "random_area", 2);
     DALI_ENFORCE(area[0] <= area[1], "Provided empty range");
 
     int64_t seed = spec.GetArgument<int64_t>("seed");

--- a/dali/pipeline/operators/displacement/warpaffine.h
+++ b/dali/pipeline/operators/displacement/warpaffine.h
@@ -61,7 +61,7 @@ class WarpAffineAugment {
 
   void Prepare(Param* p, const OpSpec& spec, ArgumentWorkspace *ws, int index) {
     std::vector<float> tmp;
-    GetSingleOrRepeatedArg(spec, &tmp, "matrix", size);
+    GetSingleOrRepeatedArg(spec, tmp, "matrix", size);
     for (int i = 0; i < size; ++i) {
       p->matrix[i] = tmp[i];
     }

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -38,7 +38,7 @@ class CropMirrorNormalize : public Operator<Backend> {
     color_(IsColor(image_type_)),
     C_(color_ ? 3 : 1) {
     vector<float> temp_crop;
-    GetSingleOrRepeatedArg(spec, &temp_crop, "crop", 2);
+    GetSingleOrRepeatedArg(spec, temp_crop, "crop", 2);
 
     crop_h_ = temp_crop[0];
     crop_w_ = temp_crop[1];
@@ -53,8 +53,8 @@ class CropMirrorNormalize : public Operator<Backend> {
 
     DALI_ENFORCE(crop_h_ > 0 && crop_w_ > 0);
 
-    GetSingleOrRepeatedArg(spec, &mean_vec_, "mean", C_);
-    GetSingleOrRepeatedArg(spec, &inv_std_vec_, "std", C_);
+    GetSingleOrRepeatedArg(spec, mean_vec_, "mean", C_);
+    GetSingleOrRepeatedArg(spec, inv_std_vec_, "std", C_);
 
     // Inverse the std-deviation
     for (int i = 0; i < C_; ++i) {

--- a/dali/pipeline/operators/fused/normalize_permute.h
+++ b/dali/pipeline/operators/fused/normalize_permute.h
@@ -36,8 +36,8 @@ class NormalizePermute : public Operator<Backend> {
     DALI_ENFORCE(C_ == 3 || C_ == 1);
 
     vector<float> mean, std;
-    GetSingleOrRepeatedArg(spec, &mean, "mean", C_);
-    GetSingleOrRepeatedArg(spec, &std, "std", C_);
+    GetSingleOrRepeatedArg(spec, mean, "mean", C_);
+    GetSingleOrRepeatedArg(spec, std, "std", C_);
 
     // Inverse the std-deviation
     for (int i = 0; i < C_; ++i) {

--- a/dali/pipeline/operators/op_schema.h
+++ b/dali/pipeline/operators/op_schema.h
@@ -326,14 +326,19 @@ class DLL_PUBLIC OpSchema {
 
   DLL_PUBLIC void CheckArgs(const OpSpec &spec) const;
 
-  DLL_PUBLIC inline const OpSchema& GetSchemaWithArgument(const string& name) const;
-
   template<typename T>
   DLL_PUBLIC inline T GetDefaultValueForOptionalArgument(const std::string &s) const;
 
   DLL_PUBLIC bool HasRequiredArgument(const std::string &name, const bool local_only = false) const;
 
   DLL_PUBLIC bool HasOptionalArgument(const std::string &name, const bool local_only = false) const;
+
+  /// @brief Finds default value for a given argument
+  /// @return A pair of the defining schema and the value
+  DLL_PUBLIC std::pair<const OpSchema *, const Value *>
+  FindDefaultValue(const std::string &arg_name,
+                   bool local_only = false,
+                   bool include_internal = true) const;
 
   DLL_PUBLIC inline bool HasArgument(const std::string &name) const {
     return HasRequiredArgument(name) || HasOptionalArgument(name);
@@ -412,54 +417,16 @@ class SchemaRegistry {
   DLL_PUBLIC static std::map<string, OpSchema>& registry();
 };
 
-inline string GetSchemaWithArg(const string& start, const string& arg) {
-  const OpSchema& s = SchemaRegistry::GetSchema(start);
-
-  // Found locally, return immediately
-  if (s.HasOptionalArgument(arg, true)) {
-    return start;
-  }
-  // otherwise, loop over any parents
-  for (auto& parent : s.GetParents()) {
-    // recurse
-    string tmp = GetSchemaWithArg(parent, arg);
-
-    // we found the schema, return
-    if (!tmp.empty()) {
-      return tmp;
-    }
-  }
-  // default case, return empty string
-  return string{};
-}
-
 template<typename T>
 inline T OpSchema::GetDefaultValueForOptionalArgument(const std::string &s) const {
-  // check if argument exists in this schema
-  const bool argFound = HasOptionalArgument(s, true);
+  const Value *v = FindDefaultValue(s, false, true).second;
+  DALI_ENFORCE(v != nullptr, "Optional argument \"" + s + "\" is not defined for schema \""
+      + this->name() + "\"");
 
-  if (argFound || internal_arguments_.find(s) != internal_arguments_.end()) {
-    Value* v;
-    if (argFound) {
-      auto arg_pair = *optional_arguments_.find(s);
-      v = arg_pair.second.second;
-    } else {
-      auto arg_pair = *internal_arguments_.find(s);
-      v = arg_pair.second.second;
-    }
-    ValueInst<T> * vT = dynamic_cast<ValueInst<T>*>(v);
-    DALI_ENFORCE(vT != nullptr, "Unexpected type of the default value for argument \"" + s +
-         "\" of schema \"" + this->name() + "\"");
-    return vT->Get();
-  } else {
-    // get the parent schema that has the optional argument and return from there
-    string tmp = GetSchemaWithArg(name(), s);
-    DALI_ENFORCE(!tmp.empty(), "Optional argument \"" + s + "\" is not defined for schema \""
-        + this->name() + "\"");
-
-    const OpSchema& schema = SchemaRegistry::GetSchema(tmp);
-    return schema.template GetDefaultValueForOptionalArgument<T>(s);
-  }
+  const ValueInst<T> * vT = dynamic_cast<const ValueInst<T>*>(v);
+  DALI_ENFORCE(vT != nullptr, "Unexpected type of the default value for argument \"" + s +
+        "\" of schema \"" + this->name() + "\"");
+  return vT->Get();
 }
 
 #define DALI_SCHEMA_REG(OpName)      \

--- a/dali/pipeline/operators/op_spec.h
+++ b/dali/pipeline/operators/op_spec.h
@@ -280,15 +280,31 @@ class DLL_PUBLIC OpSpec {
     return GetArgument<T, T>(name, ws, idx);
   }
 
+  template <typename T>
+  DLL_PUBLIC inline bool TryGetArgument(T &result,
+                                        const string &name,
+                                        const ArgumentWorkspace *ws,
+                                        Index idx) const {
+    return TryGetArgumentImpl<T, T>(result, name, ws, idx);
+  }
+
   /**
    * @brief Checks the Spec for a repeated argument of the given name/type.
    * Returns the default if an argument with the given name does not exist.
    */
   template <typename T>
-  DLL_PUBLIC inline std::vector<T> GetRepeatedArgument(
-      const string &name, const ArgumentWorkspace *ws = nullptr, Index idx = 0) const {
-    DALI_ENFORCE(idx == 0, "Tensor arguments cannot be used for vector values");
-    return GetArgument<T, std::vector<T>>(name, ws, idx);
+  DLL_PUBLIC inline std::vector<T> GetRepeatedArgument(const string &name) const {
+    return GetArgument<T, std::vector<T>>(name, nullptr, 0);
+  }
+
+  /**
+   * @brief Checks the Spec for a repeated argument of the given name/type.
+   * Returns the default if an argument with the given name does not exist.
+   */
+  template <typename T>
+  DLL_PUBLIC inline bool TryGetRepeatedArgument(std::vector<T> &result,
+      const string &name) const {
+    return TryGetArgumentImpl<T, std::vector<T>>(result, name, nullptr, 0);
   }
 
   DLL_PUBLIC OpSpec& ShareArguments(OpSpec& other) {
@@ -342,6 +358,12 @@ class DLL_PUBLIC OpSpec {
   template <typename T, typename S>
   inline S GetArgument(const string &name, const ArgumentWorkspace *ws, Index idx) const;
 
+  template <typename T, typename S>
+  inline bool TryGetArgumentImpl(S &result,
+                                 const string &name,
+                                 const ArgumentWorkspace *ws,
+                                 Index idx) const;
+
   string name_;
   std::unordered_map<string, std::shared_ptr<Argument>> arguments_;
   std::unordered_map<string, Index> argument_inputs_;
@@ -374,6 +396,43 @@ inline S OpSpec::GetArgument(const string &name, const ArgumentWorkspace *ws, In
   }
 }
 
+template <typename T, typename S>
+inline bool OpSpec::TryGetArgumentImpl(
+      S &result,
+      const string &name,
+      const ArgumentWorkspace *ws,
+      Index idx) const {
+  // Search for the argument in tensor arguments first
+  if (this->HasTensorArgument(name)) {
+    if (ws == nullptr)
+      return false;
+    const auto& value = ws->ArgumentInput(name);
+    if (!IsType<S>(value.type()))
+      return false;
+    result = value.template data<S>()[idx];
+    return true;
+  }
+  // Search for the argument locally
+  auto arg_it = arguments_.find(name);
+  if (arg_it != arguments_.end()) {
+    // Found locally - return
+    if (arg_it->second->template IsType<S>()) {
+      result = arg_it->second->template Get<S>();
+      return true;
+    }
+  } else {
+    // Argument wasn't present locally, get the default from the associated schema
+    const OpSchema& schema = SchemaRegistry::GetSchema(this->name());
+    auto schema_val = schema.FindDefaultValue(name);
+    using VT = const ValueInst<S>;
+    if (VT *vt = dynamic_cast<VT *>(schema_val.second)) {
+      result = vt->Get();
+      return true;
+    }
+  }
+  return false;
+}
+
 #define INSTANTIATE_ARGUMENT_AS_INT64(T)                                                        \
   template<>                                                                                    \
   inline OpSpec& OpSpec::SetArg(const string& name, const T& val) {                             \
@@ -391,25 +450,52 @@ inline S OpSpec::GetArgument(const string &name, const ArgumentWorkspace *ws, In
   }                                                                                             \
   template<>                                                                                    \
   inline T OpSpec::GetArgument(const string& name, const ArgumentWorkspace *ws, Index idx) const { \
-    if (this->HasTensorArgument(name)) {                                                           \
-      DALI_ENFORCE(ws != nullptr, "Tensor value is unexpected for argument \"" + name + "\".");    \
-      const auto& value = ws->ArgumentInput(name);                                                 \
-      if (IsType<T>(value.type())) {                                                               \
-        return value.template data<T>()[idx];                                                      \
-      }                                                                                            \
-    }                                                                                              \
-    int64 tmp = this->GetArgument<int64>(name, ws, idx);                                           \
-    return static_cast<T>(tmp);                                                                    \
-  }                                                                                                \
-  template<>                                                                                       \
-  inline std::vector<T> OpSpec::GetRepeatedArgument(                                               \
-      const string& name, const ArgumentWorkspace *ws, Index idx) const {                          \
-    vector<int64> tmp = this->GetRepeatedArgument<int64>(name, ws, idx);                           \
-    vector<T> ret;                                                                                 \
-    for (auto t : tmp) {                                                                           \
-      ret.push_back(static_cast<T>(t));                                                            \
-    }                                                                                              \
-    return ret;                                                                                    \
+    if (this->HasTensorArgument(name)) {                                                          \
+      DALI_ENFORCE(ws != nullptr, "Tensor value is unexpected for argument \"" + name + "\".");   \
+      const auto& value = ws->ArgumentInput(name);                                                \
+      if (IsType<T>(value.type())) {                                                              \
+        return value.template data<T>()[idx];                                                     \
+      }                                                                                           \
+    }                                                                                             \
+    int64 tmp = this->GetArgument<int64>(name, ws, idx);                                          \
+    return static_cast<T>(tmp);                                                                   \
+  }                                                                                               \
+  template<>                                                                                      \
+  inline bool OpSpec::TryGetArgument(T &result, const string& name,                               \
+                                     const ArgumentWorkspace *ws, Index idx) const {              \
+    if (this->HasTensorArgument(name)) {                                                          \
+      if (ws == nullptr)                                                                          \
+        return false;                                                                             \
+      const auto& value = ws->ArgumentInput(name);                                                \
+      if (IsType<T>(value.type())) {                                                              \
+        return value.template data<T>()[idx];                                                     \
+      }                                                                                           \
+    }                                                                                             \
+    int64 tmp;                                                                                    \
+    if (this->TryGetArgument<int64>(tmp, name, ws, idx)) {                                        \
+      result = static_cast<T>(tmp);                                                               \
+      return true;                                                                                \
+    }                                                                                             \
+    return false;                                                                                 \
+  }                                                                                               \
+  template<>                                                                                      \
+  inline std::vector<T> OpSpec::GetRepeatedArgument(const string& name) const {                   \
+    vector<int64> tmp = this->GetRepeatedArgument<int64>(name);                                   \
+    vector<T> ret(tmp.size());                                                                    \
+    for (size_t i = 0; i < tmp.size(); i++)                                                       \
+      ret[i] = static_cast<T>(tmp[i]);                                                            \
+    return ret;                                                                                   \
+  }                                                                                               \
+  template<>                                                                                      \
+  inline bool OpSpec::TryGetRepeatedArgument(                                                     \
+      vector<T> &ret, const string& name) const {                                                 \
+    vector<int64> tmp;                                                                            \
+    if (!this->TryGetRepeatedArgument<int64>(tmp, name))                                          \
+      return false;                                                                               \
+    ret.resize(tmp.size());                                                                       \
+    for (size_t i = 0; i < tmp.size(); i++)                                                       \
+      ret[i] = static_cast<T>(tmp[i]);                                                            \
+    return true;                                                                                  \
   }
 
 INSTANTIATE_ARGUMENT_AS_INT64(int);

--- a/dali/pipeline/operators/paste/paste.h
+++ b/dali/pipeline/operators/paste/paste.h
@@ -42,7 +42,7 @@ class Paste : public Operator<Backend> {
     DALI_ENFORCE(C_ <= 1024,
       "n_channels of more than 1024 is not supported");
     std::vector<uint8> rgb;
-    GetSingleOrRepeatedArg(spec, &rgb, "fill_value", C_);
+    GetSingleOrRepeatedArg(spec, rgb, "fill_value", C_);
     fill_value_.Copy(rgb, 0);
 
     input_ptrs_.Resize({batch_size_});

--- a/dali/pipeline/operators/resize/random_resized_crop.h
+++ b/dali/pipeline/operators/resize/random_resized_crop.h
@@ -39,7 +39,7 @@ class RandomResizedCrop : public Operator<Backend>
       , ResizeBase(spec)
       , RandomCropAttr(spec)
       , interp_type_(spec.GetArgument<DALIInterpType>("interp_type")) {
-    GetSingleOrRepeatedArg(spec, &size_, "size", 2);
+    GetSingleOrRepeatedArg(spec, size_, "size", 2);
     InitParams(spec);
     BackendInit();
   }

--- a/dali/pipeline/operators/support/random/uniform.h
+++ b/dali/pipeline/operators/support/random/uniform.h
@@ -29,7 +29,7 @@ class Uniform : public Operator<SupportBackend> {
     Operator<SupportBackend>(spec),
     rng_(spec.GetArgument<int64_t>("seed")) {
     std::vector<float> range;
-    GetSingleOrRepeatedArg(spec, &range, "range", 2);
+    GetSingleOrRepeatedArg(spec, range, "range", 2);
     dis_ = std::uniform_real_distribution<float>(range[0], range[1]);
   }
 

--- a/dali/pipeline/operators/util/make_contiguous.h
+++ b/dali/pipeline/operators/util/make_contiguous.h
@@ -33,7 +33,7 @@ class MakeContiguous : public Operator<MixedBackend> {
       Operator<MixedBackend>(spec),
       coalesced(true) {
     std::vector<int> hints;
-    GetSingleOrRepeatedArg(spec, &hints, "bytes_per_sample_hint", spec.NumOutput());
+    GetSingleOrRepeatedArg(spec, hints, "bytes_per_sample_hint", spec.NumOutput());
     if (!hints.empty())
       bytes_per_sample_hint = hints[0];
   }

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -294,7 +294,7 @@ inline int GetMemoryHint(OpSpec &spec, int index) {
   if (!spec.HasArgument("bytes_per_sample_hint"))
     return 0;
   std::vector<int> hints;
-  GetSingleOrRepeatedArg(spec, &hints, "bytes_per_sample_hint", spec.NumOutput());
+  GetSingleOrRepeatedArg(spec, hints, "bytes_per_sample_hint", spec.NumOutput());
 
   DALI_ENFORCE(index < static_cast<int>(hints.size()),
                "Output index out of range: " + std::to_string(index));
@@ -308,7 +308,7 @@ inline void SetMemoryHint(OpSpec &spec, int index, int value) {
   DALI_ENFORCE(index < no, "Output index out of range: " +
     std::to_string(index) + " >= " + std::to_string(no));
 
-  GetSingleOrRepeatedArg(spec, &hints, "bytes_per_sample_hint", no);
+  GetSingleOrRepeatedArg(spec, hints, "bytes_per_sample_hint", no);
   hints[index] = value;
   spec.SetArg("bytes_per_sample_hint", hints);
 }


### PR DESCRIPTION
Add TryGetArgument and TryGetRepeatedArgument to OpSpec.
Add FindDefaultValue without type to OpSchema.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>
