### PR TITLE
Add dependencies silently required by opencv-python

### DIFF
--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -20,6 +20,7 @@ except ImportError:
 # and cuda_v for cuXX version
 # NOTE: First version will be picked in case of one_config_only
 packages = {"numpy" : ["1.11.1"],
+            "opencv-python" : ["4.1.0.25"],
             "mxnet-cu90" : ["1.4.0"],
             "mxnet-cu100" : ["1.4.0"],
             "tensorflow-gpu" : {"90": ["1.12.0", "1.11", "1.7"], "100": ["1.13.1"]},

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -7,6 +7,14 @@ set -x
 
 topdir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/..
 
+# Install dependencies: opencv-python from 3.3.0.10 onwards uses QT which requires
+# X11 and other libraries that are not present in clean docker images or bundled there
+apt-get update
+apt-get install -y --no-install-recommends libsm6 libice6 libxrender1 libxext6 libx11-6 glib-2.0
+# Note: glib-2.0 depends on python2, so reinstall the desired python afterward
+# to make sure defaults are right
+apt-get install -y --no-install-recommends --reinstall python$PYVER python$PYVER-dev
+
 CUDA_VERSION=$(nvcc --version | grep -E ".*release ([0-9]+)\.([0-9]+).*" | sed 's/.*release \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
 CUDA_VERSION=${CUDA_VERSION:-90}
 # Set proper CUDA version for packages, like MXNet, requiring it


### PR DESCRIPTION
Needed from opencv-python 3.3.0.10 onwards, that starts using QT.
glib is also required.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>