### PR TITLE
Upgrade to CMake 3.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 
 project(DALI CXX)
 

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -53,8 +53,8 @@ RUN BOOST_VERSION=1.66.0 && \
     ln -s ../boost_${BOOST_VERSION//./_}/boost include/boost
 
 # CMake
-RUN CMAKE_VERSION=3.5 && \
-    CMAKE_BUILD=3.5.0 && \
+RUN CMAKE_VERSION=3.11 && \
+    CMAKE_BUILD=3.11.0 && \
     curl -L https://cmake.org/files/v${CMAKE_VERSION}/cmake-${CMAKE_BUILD}.tar.gz | tar -xzf - && \
     cd /cmake-${CMAKE_BUILD} && \
     ./bootstrap --parallel=$(grep ^processor /proc/cpuinfo | wc -l) && \

--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ Prerequisites
 .. _nvjpeg link: https://developer.nvidia.com/nvjpeg
 .. |protobuf link| replace:: **protobuf**
 .. _protobuf link: https://github.com/google/protobuf
-.. |cmake link| replace:: **CMake 3.5**
+.. |cmake link| replace:: **CMake 3.11**
 .. _cmake link: https://cmake.org
 .. |jpegturbo link| replace:: **libjpeg-turbo 1.5.x**
 .. _jpegturbo link: https://github.com/libjpeg-turbo/libjpeg-turbo


### PR DESCRIPTION
CMake 3.11 was released on March 28th, 2018.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>