### PR TITLE
Add "dali_core" library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ option(WERROR "Threat all warnings as errors" OFF)
 
 include(cmake/Utils.cmake)
 
-get_dali_version(${CMAKE_PROJECT_DIR}/VERSION DALI_VERSION)
+get_dali_version(${PROJECT_SOURCE_DIR}/VERSION DALI_VERSION)
 
 # Default to release build
 if (NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ option(WERROR "Threat all warnings as errors" OFF)
 
 include(cmake/Utils.cmake)
 
-get_dali_version(${CMAKE_SOURCE_DIR}/VERSION DALI_VERSION)
+get_dali_version(${CMAKE_PROJECT_DIR}/VERSION DALI_VERSION)
 
 # Default to release build
 if (NOT CMAKE_BUILD_TYPE)
@@ -106,10 +106,14 @@ message(STATUS "Generated gencode flags: ${CUDA_gencode_flags}")
 # Add ptx & bin flags for cuda
 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ${CUDA_gencode_flags}")
 
-# Project dir
-include_directories(BEFORE ${PROJECT_SOURCE_DIR})
-include_directories(BEFORE ${PROJECT_BINARY_DIR})
-cuda_include_directories(${PROJECT_SOURCE_DIR})
+# Include directories
+include_directories(BEFORE
+  "${PROJECT_SOURCE_DIR}"
+  "${PROJECT_SOURCE_DIR}/include"
+  "${PROJECT_BINARY_DIR}")
+cuda_include_directories(
+  "${PROJECT_SOURCE_DIR}"
+  "${PROJECT_SOURCE_DIR}/include")
 
 # Project build
 add_subdirectory(dali)

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -1,83 +1,94 @@
 # Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
-get_filename_component(CMAKE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
-set(LINT_COMMAND python ${CMAKE_SOURCE_DIR}/third_party/cpplint.py)
-file(GLOB_RECURSE LINT_FILES ${CMAKE_SOURCE_DIR}/dali/*.cc ${CMAKE_SOURCE_DIR}/dali/*.h ${CMAKE_SOURCE_DIR}/dali/*.cu ${CMAKE_SOURCE_DIR}/dali/*.cuh)
+get_filename_component(CMAKE_PROJECT_DIR "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+set(LINT_COMMAND python ${CMAKE_PROJECT_DIR}/third_party/cpplint.py)
+set(DALI_SRC_DIR "${CMAKE_PROJECT_DIR}/dali")
+set(DALI_INC_DIR "${CMAKE_PROJECT_DIR}/include")
+file(GLOB_RECURSE LINT_SRC "${DALI_SRC_DIR}/*.cc" "${DALI_SRC_DIR}/*.h" "${DALI_SRC_DIR}/*.cu" "${DALI_SRC_DIR}/*.cuh")
+file(GLOB_RECURSE LINT_INC "${DALI_INC_DIR}/*.h" "${DALI_INC_DIR}/*.cuh" "${DALI_INC_DIR}/*.inc" "${DALI_SRC_DIR}/*.inl")
 
 # Excluded files
 # rapidjson
-list(REMOVE_ITEM LINT_FILES
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/allocators.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/cursorstreamwrapper.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/document.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/encodedstream.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/encodings.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/filereadstream.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/filewritestream.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/fwd.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/istreamwrapper.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/memorybuffer.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/memorystream.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/ostreamwrapper.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/pointer.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/prettywriter.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/rapidjson.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/reader.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/schema.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/stream.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/stringbuffer.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/writer.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/error/en.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/error/error.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/biginteger.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/diyfp.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/dtoa.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/ieee754.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/itoa.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/meta.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/pow10.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/regex.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/stack.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/strfunc.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/strtod.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/internal/swap.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/msinttypes/inttypes.h
-    ${CMAKE_SOURCE_DIR}/dali/util/rapidjson/msinttypes/stdint.h
+list(REMOVE_ITEM LINT_SRC
+    ${DALI_SRC_DIR}/util/rapidjson/allocators.h
+    ${DALI_SRC_DIR}/util/rapidjson/cursorstreamwrapper.h
+    ${DALI_SRC_DIR}/util/rapidjson/document.h
+    ${DALI_SRC_DIR}/util/rapidjson/encodedstream.h
+    ${DALI_SRC_DIR}/util/rapidjson/encodings.h
+    ${DALI_SRC_DIR}/util/rapidjson/filereadstream.h
+    ${DALI_SRC_DIR}/util/rapidjson/filewritestream.h
+    ${DALI_SRC_DIR}/util/rapidjson/fwd.h
+    ${DALI_SRC_DIR}/util/rapidjson/istreamwrapper.h
+    ${DALI_SRC_DIR}/util/rapidjson/memorybuffer.h
+    ${DALI_SRC_DIR}/util/rapidjson/memorystream.h
+    ${DALI_SRC_DIR}/util/rapidjson/ostreamwrapper.h
+    ${DALI_SRC_DIR}/util/rapidjson/pointer.h
+    ${DALI_SRC_DIR}/util/rapidjson/prettywriter.h
+    ${DALI_SRC_DIR}/util/rapidjson/rapidjson.h
+    ${DALI_SRC_DIR}/util/rapidjson/reader.h
+    ${DALI_SRC_DIR}/util/rapidjson/schema.h
+    ${DALI_SRC_DIR}/util/rapidjson/stream.h
+    ${DALI_SRC_DIR}/util/rapidjson/stringbuffer.h
+    ${DALI_SRC_DIR}/util/rapidjson/writer.h
+    ${DALI_SRC_DIR}/util/rapidjson/error/en.h
+    ${DALI_SRC_DIR}/util/rapidjson/error/error.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/biginteger.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/diyfp.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/dtoa.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/ieee754.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/itoa.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/meta.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/pow10.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/regex.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/stack.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/strfunc.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/strtod.h
+    ${DALI_SRC_DIR}/util/rapidjson/internal/swap.h
+    ${DALI_SRC_DIR}/util/rapidjson/msinttypes/inttypes.h
+    ${DALI_SRC_DIR}/util/rapidjson/msinttypes/stdint.h
 )
 
 # nvdecoder
-list(REMOVE_ITEM LINT_FILES
-    ${CMAKE_SOURCE_DIR}/dali/util/dynlink_cuda.h
-    ${CMAKE_SOURCE_DIR}/dali/util/dynlink_cuda.cc
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/reader/nvdecoder/dynlink_nvcuvid.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/reader/nvdecoder/dynlink_cuviddec.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/reader/nvdecoder/dynlink_nvcuvid.cc
+list(REMOVE_ITEM LINT_SRC
+    ${DALI_SRC_DIR}/util/dynlink_cuda.h
+    ${DALI_SRC_DIR}/util/dynlink_cuda.cc
+    ${DALI_SRC_DIR}/pipeline/operators/reader/nvdecoder/dynlink_nvcuvid.h
+    ${DALI_SRC_DIR}/pipeline/operators/reader/nvdecoder/dynlink_cuviddec.h
+    ${DALI_SRC_DIR}/pipeline/operators/reader/nvdecoder/dynlink_nvcuvid.cc
 )
 
 # cuTT
-list(REMOVE_ITEM LINT_FILES
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/cutt.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/cutt.cc
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/cuttplan.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/cuttplan.cc
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/cuttkernel.cu
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/cuttkernel.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/calls.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/cuttGpuModel.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/cuttGpuModel.cc
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/cuttGpuModelKernel.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/cuttGpuModelKernel.cu
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/CudaMemcpy.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/CudaMemcpy.cu
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/CudaUtils.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/CudaUtils.cu
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/cuttTypes.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/int_vector.h
-    ${CMAKE_SOURCE_DIR}/dali/pipeline/operators/transpose/cutt/LRUCache.h
+list(REMOVE_ITEM LINT_SRC
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/cutt.h
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/cutt.cc
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/cuttplan.h
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/cuttplan.cc
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/cuttkernel.cu
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/cuttkernel.h
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/calls.h
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/cuttGpuModel.h
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/cuttGpuModel.cc
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/cuttGpuModelKernel.h
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/cuttGpuModelKernel.cu
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/CudaMemcpy.h
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/CudaMemcpy.cu
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/CudaUtils.h
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/CudaUtils.cu
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/cuttTypes.h
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/int_vector.h
+    ${DALI_SRC_DIR}/pipeline/operators/transpose/cutt/LRUCache.h
 )
 
 execute_process(
-  COMMAND ${LINT_COMMAND} --linelength=100 ${LINT_FILES}
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMAND ${LINT_COMMAND} --linelength=100 --root=include ${LINT_INC}
+  WORKING_DIRECTORY ${CMAKE_PROJECT_DIR}
+  RESULT_VARIABLE LINT_RESULT
+  ERROR_VARIABLE LINT_ERROR
+  OUTPUT_QUIET
+)
+
+execute_process(
+  COMMAND ${LINT_COMMAND} --linelength=100 ${LINT_SRC}
+  WORKING_DIRECTORY ${CMAKE_PROJECT_DIR}
   RESULT_VARIABLE LINT_RESULT
   ERROR_VARIABLE LINT_ERROR
   OUTPUT_QUIET

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -1,8 +1,9 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
-get_filename_component(CMAKE_PROJECT_DIR "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
-set(LINT_COMMAND python ${CMAKE_PROJECT_DIR}/third_party/cpplint.py)
-set(DALI_SRC_DIR "${CMAKE_PROJECT_DIR}/dali")
-set(DALI_INC_DIR "${CMAKE_PROJECT_DIR}/include")
+# Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
+# Get the project dir - not set for this target
+get_filename_component(PROJECT_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+set(LINT_COMMAND python ${PROJECT_SOURCE_DIR}/third_party/cpplint.py)
+set(DALI_SRC_DIR "${PROJECT_SOURCE_DIR}/dali")
+set(DALI_INC_DIR "${PROJECT_SOURCE_DIR}/include")
 file(GLOB_RECURSE LINT_SRC "${DALI_SRC_DIR}/*.cc" "${DALI_SRC_DIR}/*.h" "${DALI_SRC_DIR}/*.cu" "${DALI_SRC_DIR}/*.cuh")
 file(GLOB_RECURSE LINT_INC "${DALI_INC_DIR}/*.h" "${DALI_INC_DIR}/*.cuh" "${DALI_INC_DIR}/*.inc" "${DALI_SRC_DIR}/*.inl")
 
@@ -80,7 +81,7 @@ list(REMOVE_ITEM LINT_SRC
 
 execute_process(
   COMMAND ${LINT_COMMAND} --linelength=100 --root=include ${LINT_INC}
-  WORKING_DIRECTORY ${CMAKE_PROJECT_DIR}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   RESULT_VARIABLE LINT_RESULT
   ERROR_VARIABLE LINT_ERROR
   OUTPUT_QUIET
@@ -88,7 +89,7 @@ execute_process(
 
 execute_process(
   COMMAND ${LINT_COMMAND} --linelength=100 ${LINT_SRC}
-  WORKING_DIRECTORY ${CMAKE_PROJECT_DIR}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   RESULT_VARIABLE LINT_RESULT
   ERROR_VARIABLE LINT_ERROR
   OUTPUT_QUIET

--- a/dali/CMakeLists.txt
+++ b/dali/CMakeLists.txt
@@ -101,11 +101,16 @@ add_custom_target(install_headers ALL
     DEPENDS ${dali_lib}
 )
 
+
+
 add_custom_command(
     TARGET install_headers
-    COMMAND find "${CMAKE_CURRENT_LIST_DIR}" "${CMAKE_CURRENT_LIST_DIR}/../include" -regex ".*\\\\.h"
+    COMMAND find "${PROJECT_SOURCE_DIR}/dali" -regex ".*\\\\.h"
     | grep --invert test
-    | sed -r 's,\(^${CMAKE_CURRENT_LIST_DIR}\)\(.*\),\\1\\2 ${PROJECT_BINARY_DIR}/dali/python/nvidia/dali/include/dali\\2,'
+    | sed -r 's,\(^${PROJECT_SOURCE_DIR}/dali\)\(.*\),\\1\\2 ${PROJECT_BINARY_DIR}/dali/python/nvidia/dali/include/dali\\2,'
+    | xargs -n 2 install -D
+    COMMAND find "${PROJECT_SOURCE_DIR}/include" -regex ".*\\\\.h"
+    | sed -r 's,\(^${PROJECT_SOURCE_DIR}\)\(.*\),\\1\\2 ${PROJECT_BINARY_DIR}/dali/python/nvidia/dali/\\2,'
     | xargs -n 2 install -D
   )
 

--- a/dali/CMakeLists.txt
+++ b/dali/CMakeLists.txt
@@ -23,11 +23,13 @@ set(dali_lib "dali")
 set(dali_operator_lib "dali_operators")
 set(dali_kernel_lib "dali_kernels")
 set(dali_kernel_test_lib "dali_kernel_test")
+set(dali_core_lib "dali_core")
 
 ################################################
 # Build libdali
 ################################################
 add_subdirectory(image)
+add_subdirectory(core)
 add_subdirectory(kernels)
 add_subdirectory(pipeline)
 add_subdirectory(util)
@@ -52,7 +54,7 @@ if(${CMAKE_VERSION} VERSION_LESS "3.9.0")
   set(CUDA_LIBRARIES ${CUDA_LINK_LIBRARIES_KEYWORD} ${CUDA_LIBRARIES})
 endif()
 cuda_add_library(${dali_operator_lib} STATIC ${DALI_OPERATOR_SRCS})
-target_link_libraries(${dali_operator_lib} PRIVATE "${dali_kernel_lib}")
+target_link_libraries(${dali_operator_lib} PRIVATE "${dali_kernel_lib}" "${dali_core_lib}")
 
 cuda_add_library(${dali_lib} SHARED ${DALI_SRCS} ${DALI_PROTO_OBJ})
 
@@ -101,7 +103,8 @@ add_custom_target(install_headers ALL
 
 add_custom_command(
     TARGET install_headers
-    COMMAND find ${CMAKE_CURRENT_LIST_DIR} -regex ".*\\\\.h" | grep --invert test
+    COMMAND find "${CMAKE_CURRENT_LIST_DIR}" "${CMAKE_CURRENT_LIST_DIR}/../include" -regex ".*\\\\.h"
+    | grep --invert test
     | sed -r 's,\(^${CMAKE_CURRENT_LIST_DIR}\)\(.*\),\\1\\2 ${PROJECT_BINARY_DIR}/dali/python/nvidia/dali/include/dali\\2,'
     | xargs -n 2 install -D
   )
@@ -120,7 +123,7 @@ if (BUILD_TEST)
 
   # Link to the dali lib
   message(STATUS "Adding dependencies to ${test_main_bin}: '${dali_lib}'")
-  add_dependencies(${test_main_bin} ${dali_lib} ${dali_kernel_test_lib} ${dali_kernel_lib})
+  add_dependencies(${test_main_bin} ${dali_lib} ${dali_kernel_test_lib} ${dali_kernel_lib} ${dali_core_lib})
 
   # We'll have to add dependency libs
   target_link_libraries(${test_main_bin} PRIVATE

--- a/dali/benchmark/dali_bench.cc
+++ b/dali/benchmark/dali_bench.cc
@@ -16,7 +16,7 @@
 
 #include <benchmark/benchmark.h>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/data/allocator.h"
 #include "dali/pipeline/init.h"
 #include "dali/pipeline/operators/op_spec.h"

--- a/dali/benchmark/dali_bench.h
+++ b/dali/benchmark/dali_bench.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/util/image.h"
 
 namespace dali {

--- a/dali/c_api/c_api.h
+++ b/dali/c_api/c_api.h
@@ -17,7 +17,7 @@
 
 #include <cuda_runtime_api.h>
 #include <inttypes.h>
-#include "dali/api_helper.h"
+#include "dali/core/api_helper.h"
 
 // Trick to bypass gcc4.9 old ABI name mangling used by TF
 extern "C" {

--- a/dali/core/CMakeLists.txt
+++ b/dali/core/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Get all the source files
+file(GLOB tmp *.cc *.cu)
+set(DALI_SRCS ${tmp})
+file(GLOB tmp *_test.cc)
+remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
+set(DALI_CORE_SRCS ${DALI_SRCS})
+cuda_add_library(${dali_core_lib} STATIC ${DALI_CORE_SRCS})
+
+if (BUILD_TEST)
+  # get all the test srcs
+  file(GLOB tmp *_test.cc)
+  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
+endif()

--- a/dali/core/common.cc
+++ b/dali/core/common.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 namespace dali {
 

--- a/dali/core/convert_cuda_test.cu
+++ b/dali/core/convert_cuda_test.cu
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include "dali/kernels/common/convert.h"
-#include "dali/kernels/common/convert_test_static.h"
+#include "dali/core/convert.h"
+#include "dali/core/convert_test_static.h"
 
 namespace dali {
-namespace kernels {
 
-TEST(ConvertNorm, float2int) {
+TEST(ConvertNormCUDA, float2int) {
   EXPECT_EQ(ConvertNorm<uint8_t>(0.0f), 0);
   EXPECT_EQ(ConvertNorm<uint8_t>(0.499f), 127);
   EXPECT_EQ(ConvertNorm<uint8_t>(1.0f), 255);
@@ -34,7 +33,7 @@ TEST(ConvertNorm, float2int) {
   EXPECT_EQ(ConvertNorm<int16_t>(-1.0f), -0x7fff);
 }
 
-TEST(ConvertSatNorm, float2int) {
+TEST(ConvertSatNormCUDA, float2int) {
   EXPECT_EQ(ConvertSatNorm<uint8_t>(2.0f), 255);
   EXPECT_EQ(ConvertSatNorm<uint8_t>(0.499f), 127);
   EXPECT_EQ(ConvertSatNorm<uint8_t>(-2.0f), 0);
@@ -46,12 +45,11 @@ TEST(ConvertSatNorm, float2int) {
   EXPECT_EQ(ConvertSatNorm<int16_t>(-2.0f), -0x8000);
 }
 
-TEST(ConvertNorm, int2float) {
+TEST(ConvertNormCUDA, int2float) {
   EXPECT_EQ((ConvertNorm<float, uint8_t>(255)), 1.0f);
   EXPECT_NEAR((ConvertNorm<float, uint8_t>(127)), 1.0f*127/255, 1e-7f);
   EXPECT_EQ((ConvertNorm<float, int8_t>(127)), 1.0f);
   EXPECT_NEAR((ConvertNorm<float, int8_t>(64)), 1.0f*64/127, 1e-7f);
 }
 
-}  // namespace kernels
 }  // namespace dali

--- a/dali/core/convert_test.cc
+++ b/dali/core/convert_test.cc
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include "dali/kernels/common/convert.h"
-#include "dali/kernels/common/convert_test_static.h"
+#include "dali/core/convert.h"
+#include "dali/core/convert_test_static.h"
 
 namespace dali {
-namespace kernels {
 
-TEST(ConvertNormCUDA, float2int) {
+TEST(ConvertNorm, float2int) {
   EXPECT_EQ(ConvertNorm<uint8_t>(0.0f), 0);
   EXPECT_EQ(ConvertNorm<uint8_t>(0.499f), 127);
   EXPECT_EQ(ConvertNorm<uint8_t>(1.0f), 255);
@@ -34,7 +33,7 @@ TEST(ConvertNormCUDA, float2int) {
   EXPECT_EQ(ConvertNorm<int16_t>(-1.0f), -0x7fff);
 }
 
-TEST(ConvertSatNormCUDA, float2int) {
+TEST(ConvertSatNorm, float2int) {
   EXPECT_EQ(ConvertSatNorm<uint8_t>(2.0f), 255);
   EXPECT_EQ(ConvertSatNorm<uint8_t>(0.499f), 127);
   EXPECT_EQ(ConvertSatNorm<uint8_t>(-2.0f), 0);
@@ -46,12 +45,11 @@ TEST(ConvertSatNormCUDA, float2int) {
   EXPECT_EQ(ConvertSatNorm<int16_t>(-2.0f), -0x8000);
 }
 
-TEST(ConvertNormCUDA, int2float) {
+TEST(ConvertNorm, int2float) {
   EXPECT_EQ((ConvertNorm<float, uint8_t>(255)), 1.0f);
   EXPECT_NEAR((ConvertNorm<float, uint8_t>(127)), 1.0f*127/255, 1e-7f);
   EXPECT_EQ((ConvertNorm<float, int8_t>(127)), 1.0f);
   EXPECT_NEAR((ConvertNorm<float, int8_t>(64)), 1.0f*64/127, 1e-7f);
 }
 
-}  // namespace kernels
 }  // namespace dali

--- a/dali/core/convert_test_static.h
+++ b/dali/core/convert_test_static.h
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_COMMON_CONVERT_TEST_STATIC_H_
-#define DALI_KERNELS_COMMON_CONVERT_TEST_STATIC_H_
+#ifndef DALI_CORE_CONVERT_TEST_STATIC_H_
+#define DALI_CORE_CONVERT_TEST_STATIC_H_
 
-#include "dali/kernels/common/convert.h"
+#include "dali/core/convert.h"
 
 namespace dali {
 namespace kernels {
@@ -140,4 +140,4 @@ static_assert(clamp<uint64_t>(-1.0e+200) == 0, "Unexpected clamp result");
 }  // namespace kernels
 }  // namespace dali
 
-#endif  // DALI_KERNELS_COMMON_CONVERT_TEST_STATIC_H_
+#endif  // DALI_CORE_CONVERT_TEST_STATIC_H_

--- a/dali/error_handling.h
+++ b/dali/error_handling.h
@@ -30,7 +30,7 @@
 #include <algorithm>
 #include <iostream>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 namespace dali {
 

--- a/dali/image/image.h
+++ b/dali/image/image.h
@@ -23,7 +23,7 @@
 #include <tuple>
 #include <utility>
 #include <functional>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/operator.h"
 #include "dali/util/crop_window.h"

--- a/dali/image/jpeg.h
+++ b/dali/image/jpeg.h
@@ -18,7 +18,7 @@
 #include <utility>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/image/generic_image.h"
 
 namespace dali {

--- a/dali/image/jpeg_handle.h
+++ b/dali/image/jpeg_handle.h
@@ -22,7 +22,7 @@ limitations under the License.
 #define DALI_IMAGE_JPEG_HANDLE_H_
 
 #include <string>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/image/jpeg_utils.h"
 
 namespace dali {

--- a/dali/image/jpeg_mem.h
+++ b/dali/image/jpeg_mem.h
@@ -25,7 +25,7 @@ limitations under the License.
 
 #include <functional>
 #include <string>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/image/jpeg_utils.h"
 
 namespace dali {

--- a/dali/image/transform.h
+++ b/dali/image/transform.h
@@ -17,7 +17,7 @@
 
 #include <string>
 #include <utility>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/data/tensor.h"
 

--- a/dali/kernels/alloc.cc
+++ b/dali/kernels/alloc.cc
@@ -15,8 +15,8 @@
 #include <cuda_runtime.h>
 #include <cassert>
 #include "dali/kernels/alloc.h"
-#include "dali/kernels/static_switch.h"
-#include "dali/kernels/gpu_utils.h"
+#include "dali/core/static_switch.h"
+#include "dali/core/gpu_utils.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/common/scatter_gather.h
+++ b/dali/kernels/common/scatter_gather.h
@@ -19,8 +19,8 @@
 #include <cstdint>
 #include <vector>
 #include "dali/kernels/alloc.h"
-#include "dali/kernels/span.h"
-#include "dali/api_helper.h"
+#include "dali/core/span.h"
+#include "dali/core/api_helper.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/imgproc/resample/bilinear_impl.cuh
+++ b/dali/kernels/imgproc/resample/bilinear_impl.cuh
@@ -19,8 +19,8 @@
 #ifndef __CUDACC__
 #include <algorithm>
 #endif
-#include "dali/kernels/static_switch.h"
-#include "dali/kernels/common/convert.h"
+#include "dali/core/static_switch.h"
+#include "dali/core/convert.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/imgproc/resample/nearest_impl.cuh
+++ b/dali/kernels/imgproc/resample/nearest_impl.cuh
@@ -19,7 +19,7 @@
 #ifndef __CUDACC__
 #include <algorithm>
 #endif
-#include "dali/kernels/common/convert.h"
+#include "dali/core/convert.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/imgproc/resample/resampling_filters.cu
+++ b/dali/kernels/imgproc/resample/resampling_filters.cu
@@ -22,7 +22,7 @@
 #include "dali/kernels/imgproc/resample/resampling_filters.cuh"
 #include "dali/kernels/imgproc/resample/resampling_windows.h"
 #include "dali/kernels/alloc.h"
-#include "dali/kernels/span.h"
+#include "dali/core/span.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/imgproc/resample/resampling_impl.cuh
+++ b/dali/kernels/imgproc/resample/resampling_impl.cuh
@@ -16,8 +16,8 @@
 #define DALI_KERNELS_IMGPROC_RESAMPLE_RESAMPLING_IMPL_CUH_
 
 #include <cuda_runtime.h>
-#include "dali/kernels/static_switch.h"
-#include "dali/kernels/common/convert.h"
+#include "dali/core/static_switch.h"
+#include "dali/core/convert.h"
 #include "dali/kernels/imgproc/resample/resampling_filters.cuh"
 
 namespace dali {

--- a/dali/kernels/imgproc/resample/resampling_impl_cpu.h
+++ b/dali/kernels/imgproc/resample/resampling_impl_cpu.h
@@ -17,8 +17,8 @@
 
 #include <cassert>
 #include <type_traits>
-#include "dali/kernels/static_switch.h"
-#include "dali/kernels/common/convert.h"
+#include "dali/core/static_switch.h"
+#include "dali/core/convert.h"
 #include "dali/kernels/imgproc/surface.h"
 
 namespace dali {

--- a/dali/kernels/imgproc/resample/resampling_setup.h
+++ b/dali/kernels/imgproc/resample/resampling_setup.h
@@ -20,7 +20,7 @@
 #include <vector>
 #include "dali/kernels/imgproc/resample/params.h"
 #include "dali/kernels/imgproc/resample/resampling_filters.cuh"
-#include "dali/kernels/dev_array.h"
+#include "dali/core/dev_array.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/imgproc/resample/separable.h
+++ b/dali/kernels/imgproc/resample/separable.h
@@ -17,7 +17,7 @@
 
 #include <cuda_runtime.h>
 #include <memory>
-#include "dali/kernels/span.h"
+#include "dali/core/span.h"
 #include "dali/kernels/imgproc/resample/params.h"
 
 namespace dali {

--- a/dali/kernels/imgproc/sampler.h
+++ b/dali/kernels/imgproc/sampler.h
@@ -16,8 +16,8 @@
 #define DALI_KERNELS_IMGPROC_SAMPLER_H_
 
 #include <cmath>
-#include "dali/common.h"
-#include "dali/kernels/common/convert.h"
+#include "dali/core/common.h"
+#include "dali/core/convert.h"
 #include "dali/kernels/tensor_view.h"
 #include "dali/kernels/imgproc/surface.h"
 
@@ -128,7 +128,7 @@ struct Sampler<DALI_INTERP_LINEAR, In> {
 
     float s0 = s00 * px + s01 * qx;
     float s1 = s10 * px + s11 * qx;
-    return kernels::clamp<T>(s0 + (s1 - s0) * qy);
+    return clamp<T>(s0 + (s1 - s0) * qy);
   }
 
   template <typename T>
@@ -160,7 +160,7 @@ struct Sampler<DALI_INTERP_LINEAR, In> {
       In s11 = NN.at(x0+1, y0+1, c, border_value);
       float s0 = s00 * px + s01 * qx;
       float s1 = s10 * px + s11 * qx;
-      out_pixel[c] = kernels::clamp<T>(s0 + (s1 - s0) * qy);
+      out_pixel[c] = clamp<T>(s0 + (s1 - s0) * qy);
     }
   }
 

--- a/dali/kernels/kernel.h
+++ b/dali/kernels/kernel.h
@@ -22,8 +22,8 @@
 #include "dali/kernels/kernel_params.h"
 #include "dali/kernels/kernel_req.h"
 #include "dali/kernels/kernel_traits.h"
-#include "dali/kernels/tuple_helpers.h"
-#include "dali/kernels/util.h"
+#include "dali/core/tuple_helpers.h"
+#include "dali/core/util.h"
 
 namespace dali {
 

--- a/dali/kernels/kernel_req.h
+++ b/dali/kernels/kernel_req.h
@@ -19,8 +19,8 @@
 #include <vector>
 #include <algorithm>
 #include "dali/kernels/context.h"
-#include "dali/kernels/tuple_helpers.h"
-#include "dali/kernels/util.h"
+#include "dali/core/tuple_helpers.h"
+#include "dali/core/util.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/kernel_traits.h
+++ b/dali/kernels/kernel_traits.h
@@ -19,8 +19,8 @@
 #include <tuple>
 #include <type_traits>
 #include "dali/kernels/kernel_params.h"
-#include "dali/kernels/util.h"
-#include "dali/kernels/tuple_helpers.h"
+#include "dali/core/util.h"
+#include "dali/core/tuple_helpers.h"
 #include "dali/kernels/kernel_req.h"
 
 namespace dali {

--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -21,8 +21,8 @@
 #include <iostream>
 #include <utility>
 #include <vector>
-#include "dali/kernels/span.h"
-#include "dali/kernels/util.h"
+#include "dali/core/span.h"
+#include "dali/core/util.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/test/any_test.cc
+++ b/dali/kernels/test/any_test.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include "dali/kernels/any.h"
+#include "dali/core/any.h"
 
 namespace dali {
 

--- a/dali/kernels/test/dev_array_test.cu
+++ b/dali/kernels/test/dev_array_test.cu
@@ -14,7 +14,7 @@
 
 #include <gtest/gtest.h>
 #include <array>
-#include "dali/kernels/dev_array.h"
+#include "dali/core/dev_array.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/test/kernel_test.cc
+++ b/dali/kernels/test/kernel_test.cc
@@ -16,8 +16,8 @@
 #include <tuple>
 #include "dali/kernels/kernel.h"
 #include "dali/kernels/type_tag.h"
-#include "dali/kernels/static_switch.h"
-#include "dali/kernels/tuple_helpers.h"
+#include "dali/core/static_switch.h"
+#include "dali/core/tuple_helpers.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/test/kernel_test_utils.h
+++ b/dali/kernels/test/kernel_test_utils.h
@@ -17,7 +17,7 @@
 
 #include <type_traits>
 #include <tuple>
-#include "dali/kernels/util.h"
+#include "dali/core/util.h"
 #include "dali/kernels/kernel_traits.h"
 
 namespace dali {

--- a/dali/kernels/test/span_gpu_test.cu
+++ b/dali/kernels/test/span_gpu_test.cu
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include "dali/kernels/span.h"
+#include "dali/core/span.h"
 #include "dali/kernels/alloc.h"
-#include "dali/kernels/util.h"
+#include "dali/core/util.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/test/static_switch_test.cc
+++ b/dali/kernels/test/static_switch_test.cc
@@ -14,7 +14,7 @@
 
 #include <gtest/gtest.h>
 #include "dali/kernels/kernel.h"
-#include "dali/kernels/static_switch.h"
+#include "dali/core/static_switch.h"
 #include "dali/kernels/type_tag.h"
 
 namespace {

--- a/dali/kernels/test/static_switch_test.cu
+++ b/dali/kernels/test/static_switch_test.cu
@@ -14,7 +14,7 @@
 
 #include <gtest/gtest.h>
 #include "dali/kernels/kernel.h"
-#include "dali/kernels/static_switch.h"
+#include "dali/core/static_switch.h"
 #include "dali/kernels/type_tag.h"
 
 namespace {

--- a/dali/kernels/test/tensor_test_utils.h
+++ b/dali/kernels/test/tensor_test_utils.h
@@ -23,7 +23,7 @@
 #include "dali/kernels/tensor_view.h"
 #include "dali/kernels/tensor_shape_print.h"
 #include "dali/kernels/backend_tags.h"
-#include "dali/kernels/util.h"
+#include "dali/core/util.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/test/test_data.h
+++ b/dali/kernels/test/test_data.h
@@ -16,7 +16,7 @@
 #define DALI_KERNELS_TEST_TEST_DATA_H_
 
 #include <opencv2/core.hpp>
-#include "dali/kernels/span.h"
+#include "dali/core/span.h"
 #include "dali/kernels/test/mat2tensor.h"
 
 namespace dali {

--- a/dali/kernels/test/tuple_test.cc
+++ b/dali/kernels/test/tuple_test.cc
@@ -15,7 +15,7 @@
 #include <gtest/gtest.h>
 #include "dali/kernels/kernel.h"
 #include "dali/kernels/type_tag.h"
-#include "dali/kernels/static_switch.h"
+#include "dali/core/static_switch.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/test/util_test.cc
+++ b/dali/kernels/test/util_test.cc
@@ -14,7 +14,7 @@
 
 #include <gtest/gtest.h>
 #include <list>
-#include "dali/kernels/util.h"
+#include "dali/core/util.h"
 #include "dali/kernels/tensor_shape.h"
 
 namespace dali {

--- a/dali/pipeline/data/backend.cc
+++ b/dali/pipeline/data/backend.cc
@@ -19,7 +19,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/data/allocator.h"
 #include "dali/pipeline/operators/op_spec.h"
 

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -23,10 +23,10 @@
 #include <type_traits>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/data/types.h"
-#include "dali/kernels/util.h"
+#include "dali/core/util.h"
 
 namespace dali {
 

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -22,13 +22,13 @@
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/buffer.h"
 #include "dali/pipeline/data/tensor_list.h"
 #include "dali/pipeline/data/meta.h"
-#include "dali/kernels/util.h"
+#include "dali/core/util.h"
 
 namespace dali {
 

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -27,7 +27,7 @@
 #include <typeinfo>
 #include <unordered_map>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/util/cuda_utils.h"
 #include "dali/error_handling.h"
 

--- a/dali/pipeline/executor/async_pipelined_executor.h
+++ b/dali/pipeline/executor/async_pipelined_executor.h
@@ -16,7 +16,7 @@
 #define DALI_PIPELINE_EXECUTOR_ASYNC_PIPELINED_EXECUTOR_H_
 
 #include <string>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/executor/pipelined_executor.h"
 #include "dali/pipeline/util/worker_thread.h"

--- a/dali/pipeline/executor/async_separated_pipelined_executor.h
+++ b/dali/pipeline/executor/async_separated_pipelined_executor.h
@@ -16,7 +16,7 @@
 #define DALI_PIPELINE_EXECUTOR_ASYNC_SEPARATED_PIPELINED_EXECUTOR_H_
 
 #include <string>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/executor/pipelined_executor.h"
 #include "dali/pipeline/util/worker_thread.h"

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/executor/queue_metadata.h"
 #include "dali/pipeline/executor/queue_policy.h"

--- a/dali/pipeline/executor/pipelined_executor.h
+++ b/dali/pipeline/executor/pipelined_executor.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/executor/executor.h"
 

--- a/dali/pipeline/executor/queue_metadata.h
+++ b/dali/pipeline/executor/queue_metadata.h
@@ -15,7 +15,7 @@
 #ifndef DALI_PIPELINE_EXECUTOR_QUEUE_METADATA_H_
 #define DALI_PIPELINE_EXECUTOR_QUEUE_METADATA_H_
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 namespace dali {
 

--- a/dali/pipeline/executor/workspace_policy.h
+++ b/dali/pipeline/executor/workspace_policy.h
@@ -17,7 +17,7 @@
 
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/executor/queue_metadata.h"
 #include "dali/pipeline/graph/op_graph.h"

--- a/dali/pipeline/graph/op_graph.h
+++ b/dali/pipeline/graph/op_graph.h
@@ -24,7 +24,7 @@
 #include <fstream>
 #include <set>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/operator.h"
 

--- a/dali/pipeline/operators/argument.h
+++ b/dali/pipeline/operators/argument.h
@@ -21,7 +21,7 @@
 #include <utility>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/data/types.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/proto/dali_proto_utils.h"

--- a/dali/pipeline/operators/crop/bbox_crop.h
+++ b/dali/pipeline/operators/crop/bbox_crop.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <tuple>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/pipeline/operators/operator.h"

--- a/dali/pipeline/operators/crop/crop.h
+++ b/dali/pipeline/operators/crop/crop.h
@@ -18,7 +18,7 @@
 #include <utility>
 #include <vector>
 #include <tuple>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/pipeline/operators/crop/kernel/crop_kernel.h"

--- a/dali/pipeline/operators/crop/crop_attr.h
+++ b/dali/pipeline/operators/crop/crop_attr.h
@@ -17,7 +17,7 @@
 
 #include <utility>
 #include <vector>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/pipeline/operators/operator.h"

--- a/dali/pipeline/operators/crop/kernel/crop_kernel.h
+++ b/dali/pipeline/operators/crop/kernel/crop_kernel.h
@@ -18,7 +18,7 @@
 #include <tuple>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/crop/kernel/coords.h"
 #include "dali/pipeline/operators/crop/kernel/sequence.h"
 

--- a/dali/pipeline/operators/crop/random_crop_attr.h
+++ b/dali/pipeline/operators/crop/random_crop_attr.h
@@ -19,7 +19,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/pipeline/operators/operator.h"

--- a/dali/pipeline/operators/crop/slice.h
+++ b/dali/pipeline/operators/crop/slice.h
@@ -18,7 +18,7 @@
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/pipeline/operators/crop/crop.h"

--- a/dali/pipeline/operators/crop/slice_attr.h
+++ b/dali/pipeline/operators/crop/slice_attr.h
@@ -17,7 +17,7 @@
 
 #include <utility>
 #include <vector>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/pipeline/operators/operator.h"

--- a/dali/pipeline/operators/decoder/cache/image_cache.h
+++ b/dali/pipeline/operators/decoder/cache/image_cache.h
@@ -17,7 +17,7 @@
 
 #include <cuda_runtime.h>
 #include <string>
-#include "dali/api_helper.h"
+#include "dali/core/api_helper.h"
 #include "dali/kernels/tensor_shape.h"
 #include "dali/kernels/tensor_view.h"
 

--- a/dali/pipeline/operators/decoder/cache/image_cache_blob.cc
+++ b/dali/pipeline/operators/decoder/cache/image_cache_blob.cc
@@ -17,7 +17,7 @@
 #include <unordered_map>
 #include "dali/error_handling.h"
 #include "dali/kernels/alloc.h"
-#include "dali/kernels/span.h"
+#include "dali/core/span.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/operators/decoder/cache/image_cache_blob.h"
 

--- a/dali/pipeline/operators/decoder/cache/image_cache_blob.h
+++ b/dali/pipeline/operators/decoder/cache/image_cache_blob.h
@@ -18,7 +18,7 @@
 #include <fstream>
 #include <mutex>
 #include <unordered_map>
-#include "dali/kernels/span.h"
+#include "dali/core/span.h"
 #include "dali/error_handling.h"
 #include "dali/kernels/alloc.h"
 #include "dali/pipeline/operators/decoder/cache/image_cache.h"

--- a/dali/pipeline/operators/decoder/cache/image_cache_largest.h
+++ b/dali/pipeline/operators/decoder/cache/image_cache_largest.h
@@ -21,7 +21,7 @@
 #include <utility>
 #include <vector>
 #include "dali/pipeline/operators/decoder/cache/image_cache_blob.h"
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 namespace dali {
 

--- a/dali/pipeline/operators/decoder/host_decoder.h
+++ b/dali/pipeline/operators/decoder/host_decoder.h
@@ -15,7 +15,7 @@
 #ifndef DALI_PIPELINE_OPERATORS_DECODER_HOST_DECODER_H_
 #define DALI_PIPELINE_OPERATORS_DECODER_HOST_DECODER_H_
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/operator.h"
 #include "dali/util/crop_window.h"

--- a/dali/pipeline/operators/decoder/host_decoder_crop.h
+++ b/dali/pipeline/operators/decoder/host_decoder_crop.h
@@ -16,7 +16,7 @@
 #define DALI_PIPELINE_OPERATORS_DECODER_HOST_DECODER_CROP_H_
 
 #include <vector>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/decoder/host_decoder.h"
 #include "dali/pipeline/operators/crop/crop_attr.h"
 

--- a/dali/pipeline/operators/decoder/host_decoder_random_crop.h
+++ b/dali/pipeline/operators/decoder/host_decoder_random_crop.h
@@ -15,7 +15,7 @@
 #ifndef DALI_PIPELINE_OPERATORS_DECODER_HOST_DECODER_RANDOM_CROP_H_
 #define DALI_PIPELINE_OPERATORS_DECODER_HOST_DECODER_RANDOM_CROP_H_
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/decoder/host_decoder.h"
 #include "dali/pipeline/operators/crop/random_crop_attr.h"
 

--- a/dali/pipeline/operators/decoder/host_decoder_slice.h
+++ b/dali/pipeline/operators/decoder/host_decoder_slice.h
@@ -16,7 +16,7 @@
 #define DALI_PIPELINE_OPERATORS_DECODER_HOST_DECODER_SLICE_H_
 
 #include <vector>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/decoder/host_decoder.h"
 #include "dali/pipeline/operators/crop/slice_attr.h"
 

--- a/dali/pipeline/operators/decoder/nvjpeg_allocator.h
+++ b/dali/pipeline/operators/decoder/nvjpeg_allocator.h
@@ -27,7 +27,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/util/cuda_utils.h"
 

--- a/dali/pipeline/operators/decoder/nvjpeg_decoder.h
+++ b/dali/pipeline/operators/decoder/nvjpeg_decoder.h
@@ -33,7 +33,7 @@
 #include "dali/util/image.h"
 #include "dali/util/ocv.h"
 #include "dali/image/image_factory.h"
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 namespace dali {
 

--- a/dali/pipeline/operators/decoder/nvjpeg_helper.h
+++ b/dali/pipeline/operators/decoder/nvjpeg_helper.h
@@ -19,7 +19,7 @@
 
 #include <string>
 #include <memory>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/util/crop_window.h"
 #include "dali/kernels/backend_tags.h"

--- a/dali/pipeline/operators/displacement/displacement_filter.h
+++ b/dali/pipeline/operators/displacement/displacement_filter.h
@@ -15,7 +15,7 @@
 #ifndef DALI_PIPELINE_OPERATORS_DISPLACEMENT_DISPLACEMENT_FILTER_H_
 #define DALI_PIPELINE_OPERATORS_DISPLACEMENT_DISPLACEMENT_FILTER_H_
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/operator.h"
 
 /**

--- a/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
+++ b/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/displacement/displacement_filter.h"
 
 namespace dali {

--- a/dali/pipeline/operators/displacement/displacement_filter_impl_gpu.cuh
+++ b/dali/pipeline/operators/displacement/displacement_filter_impl_gpu.cuh
@@ -15,7 +15,7 @@
 #ifndef DALI_PIPELINE_OPERATORS_DISPLACEMENT_DISPLACEMENT_FILTER_IMPL_GPU_CUH_
 #define DALI_PIPELINE_OPERATORS_DISPLACEMENT_DISPLACEMENT_FILTER_IMPL_GPU_CUH_
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/displacement/displacement_filter.h"
 
 namespace dali {

--- a/dali/pipeline/operators/displacement/water.cc
+++ b/dali/pipeline/operators/displacement/water.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/displacement/water.h"
 #include "dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h"
 

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/operator.h"

--- a/dali/pipeline/operators/fused/resize_crop_mirror.h
+++ b/dali/pipeline/operators/fused/resize_crop_mirror.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include <utility>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/image/transform.h"
 #include "dali/pipeline/operators/operator.h"

--- a/dali/pipeline/operators/op_schema.h
+++ b/dali/pipeline/operators/op_schema.h
@@ -23,7 +23,8 @@
 #include <utility>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
+#include "dali/core/traits.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/argument.h"
 

--- a/dali/pipeline/operators/op_spec.h
+++ b/dali/pipeline/operators/op_spec.h
@@ -23,7 +23,7 @@
 #include <memory>
 #include <set>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/argument.h"
 #include "dali/pipeline/data/tensor.h"

--- a/dali/pipeline/operators/operator.h
+++ b/dali/pipeline/operators/operator.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/workspace/device_workspace.h"
 #include "dali/pipeline/data/backend.h"

--- a/dali/pipeline/operators/operator_factory.h
+++ b/dali/pipeline/operators/operator_factory.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <functional>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/op_schema.h"
 

--- a/dali/pipeline/operators/optical_flow/turing_of/optical_flow_turing.h
+++ b/dali/pipeline/operators/optical_flow/turing_of/optical_flow_turing.h
@@ -22,7 +22,7 @@
 #include "dali/util/custream.h"
 #include "nvOpticalFlowCuda.h"
 #include "nvOpticalFlowCommon.h"
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/optical_flow/optical_flow_adapter/optical_flow_adapter.h"
 #include "dali/pipeline/operators/optical_flow/turing_of/optical_flow_buffer.h"
 

--- a/dali/pipeline/operators/paste/bbox_paste.h
+++ b/dali/pipeline/operators/paste/bbox_paste.h
@@ -15,7 +15,7 @@
 #ifndef DALI_PIPELINE_OPERATORS_PASTE_BBOX_PASTE_H_
 #define DALI_PIPELINE_OPERATORS_PASTE_BBOX_PASTE_H_
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/pipeline/operators/operator.h"

--- a/dali/pipeline/operators/paste/paste.h
+++ b/dali/pipeline/operators/paste/paste.h
@@ -20,7 +20,7 @@
 #include <vector>
 #include <random>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/operator.h"

--- a/dali/pipeline/operators/reader/loader/coco_loader.h
+++ b/dali/pipeline/operators/reader/loader/coco_loader.h
@@ -23,7 +23,7 @@
 
 #include "dali/pipeline/operators/reader/loader/file_loader.h"
 #include "dali/pipeline/operators/reader/parser/coco_parser.h"
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 
 namespace dali {

--- a/dali/pipeline/operators/reader/loader/file_loader.cc
+++ b/dali/pipeline/operators/reader/loader/file_loader.cc
@@ -16,7 +16,7 @@
 #include <errno.h>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/image/image.h"
 #include "dali/pipeline/operators/reader/loader/file_loader.h"
 #include "dali/util/file.h"

--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -26,7 +26,7 @@
 #include <vector>
 #include <algorithm>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/reader/loader/loader.h"
 #include "dali/util/file.h"
 

--- a/dali/pipeline/operators/reader/loader/indexed_file_loader.h
+++ b/dali/pipeline/operators/reader/loader/indexed_file_loader.h
@@ -21,7 +21,7 @@
 #include <fstream>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/reader/loader/loader.h"
 #include "dali/util/file.h"
 

--- a/dali/pipeline/operators/reader/loader/lmdb.h
+++ b/dali/pipeline/operators/reader/loader/lmdb.h
@@ -18,7 +18,7 @@
 #include <lmdb.h>
 #include <string>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/reader/loader/loader.h"
 
 namespace dali {

--- a/dali/pipeline/operators/reader/loader/loader.h
+++ b/dali/pipeline/operators/reader/loader/loader.h
@@ -25,7 +25,7 @@
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/op_spec.h"
 #include "dali/pipeline/data/tensor.h"

--- a/dali/pipeline/operators/reader/loader/loader_test.cc
+++ b/dali/pipeline/operators/reader/loader/loader_test.cc
@@ -15,7 +15,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/operators/op_spec.h"
 #include "dali/test/dali_test.h"

--- a/dali/pipeline/operators/reader/loader/recordio_loader.h
+++ b/dali/pipeline/operators/reader/loader/recordio_loader.h
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include "dali/pipeline/operators/reader/loader/indexed_file_loader.h"
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 
 namespace dali {

--- a/dali/pipeline/operators/reader/loader/sequence_loader.h
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.h
@@ -20,7 +20,7 @@
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/reader/loader/loader.h"
 #include "dali/util/file.h"
 

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -29,7 +29,7 @@ extern "C" {
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/reader/loader/loader.h"
 #include "dali/pipeline/operators/reader/nvdecoder/nvdecoder.h"
 #include "dali/pipeline/operators/reader/nvdecoder/sequencewrapper.h"

--- a/dali/pipeline/operators/reader/nvdecoder/imgproc.h
+++ b/dali/pipeline/operators/reader/nvdecoder/imgproc.h
@@ -16,7 +16,7 @@
 #define DALI_PIPELINE_OPERATORS_READER_NVDECODER_IMGPROC_H_
 
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/reader/nvdecoder/sequencewrapper.h"
 
 namespace dali {

--- a/dali/pipeline/operators/reader/nvdecoder/sequencewrapper.h
+++ b/dali/pipeline/operators/reader/nvdecoder/sequencewrapper.h
@@ -19,7 +19,7 @@
 #include <mutex>
 #include <thread>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/argument.h"
 #include "dali/pipeline/data/tensor.h"

--- a/dali/pipeline/operators/reader/parser/parser_test.cc
+++ b/dali/pipeline/operators/reader/parser/parser_test.cc
@@ -15,7 +15,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/pipeline.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/operators/op_spec.h"

--- a/dali/pipeline/operators/reader/parser/tf_feature.h
+++ b/dali/pipeline/operators/reader/parser/tf_feature.h
@@ -20,7 +20,7 @@
 #include <vector>
 #include <string>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/proto/dali_proto_utils.h"
 
 namespace dali {

--- a/dali/pipeline/operators/reader/parser/tfrecord_parser.h
+++ b/dali/pipeline/operators/reader/parser/tfrecord_parser.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <exception>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/argument.h"
 #include "dali/pipeline/operators/op_spec.h"
 #include "dali/pipeline/operators/reader/parser/parser.h"

--- a/dali/pipeline/operators/reader/video_reader_op.cc
+++ b/dali/pipeline/operators/reader/video_reader_op.cc
@@ -14,7 +14,7 @@
 
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/pipeline/operators/op_spec.h"

--- a/dali/pipeline/operators/resize/resize.cu
+++ b/dali/pipeline/operators/resize/resize.cu
@@ -18,7 +18,7 @@
 #include <vector>
 
 #include "dali/pipeline/operators/resize/resize.h"
-#include "dali/kernels/static_switch.h"
+#include "dali/core/static_switch.h"
 #include "dali/pipeline/data/views.h"
 
 namespace dali {

--- a/dali/pipeline/operators/resize/resize.h
+++ b/dali/pipeline/operators/resize/resize.h
@@ -19,7 +19,7 @@
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/operator.h"

--- a/dali/pipeline/operators/resize/resize_base.h
+++ b/dali/pipeline/operators/resize/resize_base.h
@@ -18,7 +18,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/kernels/scratch.h"
 #include "dali/kernels/kernel.h"

--- a/dali/pipeline/operators/sequence/element_extract.h
+++ b/dali/pipeline/operators/sequence/element_extract.h
@@ -17,7 +17,7 @@
 #define DALI_PIPELINE_OPERATORS_SEQUENCE_ELEMENT_EXTRACT_H_
 
 #include <vector>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/operators/operator.h"
 
 namespace dali {

--- a/dali/pipeline/operators/transpose/transpose.cu
+++ b/dali/pipeline/operators/transpose/transpose.cu
@@ -19,7 +19,7 @@
 
 #include "dali/pipeline/operators/transpose/transpose.h"
 #include "dali/error_handling.h"
-#include "dali/kernels/static_switch.h"
+#include "dali/core/static_switch.h"
 
 namespace dali {
 

--- a/dali/pipeline/operators/util/dump_image.h
+++ b/dali/pipeline/operators/util/dump_image.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/operators/operator.h"
 

--- a/dali/pipeline/operators/util/make_contiguous.h
+++ b/dali/pipeline/operators/util/make_contiguous.h
@@ -20,7 +20,7 @@
 
 #include "dali/pipeline/operators/operator.h"
 #include "dali/pipeline/operators/common.h"
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 // Found by benchmarking coalesced vs non coalesced on diff size images
 #define COALESCE_TRESHOLD 8192

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -24,7 +24,7 @@
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/executor/executor.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/tensor.h"

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -17,7 +17,7 @@
 #include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/buffer.h"
 #include "dali/pipeline/data/tensor.h"

--- a/dali/pipeline/proto/dali_proto_intern.cc
+++ b/dali/pipeline/proto/dali_proto_intern.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/dali.pb.h"
 #include "dali/pipeline/proto/dali_proto_intern.h"
 

--- a/dali/pipeline/proto/dali_proto_intern.h
+++ b/dali/pipeline/proto/dali_proto_intern.h
@@ -17,7 +17,7 @@
 
 #include <string>
 #include <vector>
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 namespace dali_proto {
 class Argument;

--- a/dali/pipeline/proto/dali_proto_utils.h
+++ b/dali/pipeline/proto/dali_proto_utils.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/proto/dali_proto_intern.h"
 
 namespace dali {

--- a/dali/pipeline/util/event_pool.h
+++ b/dali/pipeline/util/event_pool.h
@@ -19,7 +19,7 @@
 #include <map>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/util/device_guard.h"
 

--- a/dali/pipeline/util/op_type_to_workspace.h
+++ b/dali/pipeline/util/op_type_to_workspace.h
@@ -15,7 +15,7 @@
 #ifndef DALI_PIPELINE_UTIL_OP_TYPE_TO_WORKSPACE_H_
 #define DALI_PIPELINE_UTIL_OP_TYPE_TO_WORKSPACE_H_
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/workspace/device_workspace.h"
 #include "dali/pipeline/workspace/sample_workspace.h"
 #include "dali/pipeline/workspace/mixed_workspace.h"

--- a/dali/pipeline/util/stream_pool.h
+++ b/dali/pipeline/util/stream_pool.h
@@ -19,7 +19,7 @@
 #include <map>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/util/device_guard.h"
 

--- a/dali/pipeline/util/thread_pool.h
+++ b/dali/pipeline/util/thread_pool.h
@@ -23,7 +23,7 @@
 #include <thread>
 #include <vector>
 #include <string>
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 
 namespace dali {

--- a/dali/pipeline/util/worker_thread.h
+++ b/dali/pipeline/util/worker_thread.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <thread>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/util/nvml.h"
 

--- a/dali/pipeline/workspace/device_workspace.h
+++ b/dali/pipeline/workspace/device_workspace.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/data/tensor.h"
 #include "dali/pipeline/data/tensor_list.h"

--- a/dali/pipeline/workspace/host_workspace.h
+++ b/dali/pipeline/workspace/host_workspace.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/tensor.h"

--- a/dali/pipeline/workspace/mixed_workspace.h
+++ b/dali/pipeline/workspace/mixed_workspace.h
@@ -19,7 +19,7 @@
 #include <utility>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/tensor.h"

--- a/dali/pipeline/workspace/sample_workspace.h
+++ b/dali/pipeline/workspace/sample_workspace.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/workspace/device_workspace.h"
 #include "dali/pipeline/data/tensor.h"

--- a/dali/pipeline/workspace/support_workspace.h
+++ b/dali/pipeline/workspace/support_workspace.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/data/tensor.h"
 #include "dali/pipeline/workspace/workspace.h"

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/tensor.h"
 

--- a/dali/pipeline/workspace/workspace_data_factory.h
+++ b/dali/pipeline/workspace/workspace_data_factory.h
@@ -26,8 +26,8 @@
 #include "dali/pipeline/workspace/mixed_workspace.h"
 #include "dali/pipeline/workspace/support_workspace.h"
 
-#include "dali/kernels/static_switch.h"
-#include "dali/kernels/tuple_helpers.h"
+#include "dali/core/static_switch.h"
+#include "dali/core/tuple_helpers.h"
 #include "dali/pipeline/util/op_type_to_workspace.h"
 
 namespace dali {

--- a/dali/plugin/plugin_manager.h
+++ b/dali/plugin/plugin_manager.h
@@ -16,7 +16,7 @@
 #define DALI_PLUGIN_PLUGIN_MANAGER_H_
 
 #include <string>
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 namespace dali {
 

--- a/dali/tensorflow/daliop.cc
+++ b/dali/tensorflow/daliop.cc
@@ -31,7 +31,7 @@
 #endif
 
 #include "dali/c_api/c_api.h"
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 typedef std::chrono::high_resolution_clock Clock;
 

--- a/dali/tensorflow/tfallocator.h
+++ b/dali/tensorflow/tfallocator.h
@@ -26,7 +26,7 @@
 #include "tensorflow/stream_executor/stream.h"
 
 #include "dali/pipeline/data/allocator.h"
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/c_api/c_api.h"
 #include "dali/pipeline/operators/op_spec.h"
 #include "dali/pipeline/data/backend.h"

--- a/dali/test/dali_test.h
+++ b/dali/test/dali_test.h
@@ -25,7 +25,7 @@
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/image/jpeg.h"
 #include "dali/pipeline/data/backend.h"

--- a/dali/test/dali_test_matching.h
+++ b/dali/test/dali_test_matching.h
@@ -7,7 +7,7 @@
 #include <utility>
 #include <vector>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/test/dali_test_single_op.h"
 
 namespace dali {

--- a/dali/test/operator_argument.h
+++ b/dali/test/operator_argument.h
@@ -19,7 +19,7 @@
 #include <memory>
 #include <vector>
 
-#include "dali/kernels/util.h"
+#include "dali/core/util.h"
 #include "dali/pipeline/operators/op_spec.h"
 
 namespace dali {

--- a/dali/util/custream.h
+++ b/dali/util/custream.h
@@ -16,7 +16,7 @@
 #define DALI_UTIL_CUSTREAM_H_
 
 #include <driver_types.h>
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 namespace dali {
 

--- a/dali/util/device_guard.h
+++ b/dali/util/device_guard.h
@@ -15,7 +15,7 @@
 #ifndef DALI_UTIL_DEVICE_GUARD_H_
 #define DALI_UTIL_DEVICE_GUARD_H_
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 
 namespace dali {

--- a/dali/util/file.h
+++ b/dali/util/file.h
@@ -19,8 +19,8 @@
 #include <string>
 #include <memory>
 
-#include "dali/api_helper.h"
-#include "dali/common.h"
+#include "dali/core/api_helper.h"
+#include "dali/core/common.h"
 
 namespace dali {
 

--- a/dali/util/image.h
+++ b/dali/util/image.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include <string>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/tensor.h"

--- a/dali/util/local_file.h
+++ b/dali/util/local_file.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <memory>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/util/file.h"
 
 namespace dali {

--- a/dali/util/npp.h
+++ b/dali/util/npp.h
@@ -18,7 +18,7 @@
 #include <npp.h>
 
 #include "dali/error_handling.h"
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 namespace dali {
 

--- a/dali/util/nvml_wrap.h
+++ b/dali/util/nvml_wrap.h
@@ -23,7 +23,7 @@
 
 #include <nvml.h>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/error_handling.h"
 
 namespace dali {

--- a/dali/util/ocv.h
+++ b/dali/util/ocv.h
@@ -17,7 +17,7 @@
 
 #include <opencv2/opencv.hpp>
 
-#include "dali/common.h"
+#include "dali/core/common.h"
 
 namespace dali {
 

--- a/dali/util/random_crop_generator.h
+++ b/dali/util/random_crop_generator.h
@@ -18,7 +18,7 @@
 #include <vector>
 #include <random>
 #include <utility>
-#include "dali/common.h"
+#include "dali/core/common.h"
 #include "dali/util/crop_window.h"
 
 namespace dali {

--- a/include/dali/core/any.h
+++ b/include/dali/core/any.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_ANY_H_
-#define DALI_KERNELS_ANY_H_
+#ifndef DALI_CORE_ANY_H_
+#define DALI_CORE_ANY_H_
 
 #include <exception>
 #include <utility>
@@ -21,9 +21,7 @@
 #include <typeinfo>
 
 namespace dali {
-
 namespace detail {
-
 
 struct alignas(8)
 any_placeholder {
@@ -390,4 +388,4 @@ any make_any(std::initializer_list<U> il, Args&&... args) {
 
 }  // namespace dali
 
-#endif  // DALI_KERNELS_ANY_H_
+#endif  // DALI_CORE_ANY_H_

--- a/include/dali/core/api_helper.h
+++ b/include/dali/core/api_helper.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_API_HELPER_H_
-#define DALI_API_HELPER_H_
+#ifndef DALI_CORE_API_HELPER_H_
+#define DALI_CORE_API_HELPER_H_
 
 #if defined _WIN32 || defined __CYGWIN__
   #ifdef BUILDING_DLL
@@ -42,4 +42,4 @@
   #endif
 #endif
 
-#endif  // DALI_API_HELPER_H_
+#endif  // DALI_CORE_API_HELPER_H_

--- a/include/dali/core/common.h
+++ b/include/dali/core/common.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_COMMON_H_
-#define DALI_COMMON_H_
+#ifndef DALI_CORE_COMMON_H_
+#define DALI_CORE_COMMON_H_
 
 #ifdef DALI_USE_NVTX
 #include "nvToolsExt.h"
@@ -27,13 +27,13 @@
 #include <type_traits>
 #include <vector>
 
-#include "dali/api_helper.h"
+#include "dali/core/api_helper.h"
 
 namespace dali {
 
 // pi
 #ifndef M_PI
-const float M_PI = 3.14159265358979323846;
+#define M_PI 3.14159265358979323846
 #endif
 
 // Using declaration for common types
@@ -289,22 +289,8 @@ std::string to_string(const std::vector<T>& v) {
   return ret;
 }
 
-template <typename T>
-struct is_vector : std::false_type {};
-
-template <typename T, typename A>
-struct is_vector<std::vector<T, A> > : std::true_type {};
-
-template <typename T>
-struct is_std_array : std::false_type {};
-
-template <typename T, size_t A>
-struct is_std_array<std::array<T, A> > : std::true_type {};
-
 std::vector<std::string> string_split(const std::string &s, const char delim);
 
-template <bool Value, typename Type = void>
-using enable_if_t = typename std::enable_if<Value, Type>::type;
 
 }  // namespace dali
 
@@ -316,4 +302,4 @@ using enable_if_t = typename std::enable_if<Value, Type>::type;
   if (1) \
   std::cerr << __FILE__ << ":" << __LINE__ << ": "
 
-#endif  // DALI_COMMON_H_
+#endif  // DALI_CORE_COMMON_H_

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_COMMON_CONVERT_H_
-#define DALI_KERNELS_COMMON_CONVERT_H_
+#ifndef DALI_CORE_CONVERT_H_
+#define DALI_CORE_CONVERT_H_
 
 #include <cuda_runtime.h>
 #include <cstdint>
@@ -21,7 +21,6 @@
 #include <type_traits>
 
 namespace dali {
-namespace kernels {
 
 template <typename T>
 struct const_limits;
@@ -179,8 +178,7 @@ ConvertNorm(In value) {
   return ConvertSatNorm<Out>(value);
 }
 
-}  // namespace kernels
 }  // namespace dali
 
-#endif  // DALI_KERNELS_COMMON_CONVERT_H_
+#endif  // DALI_CORE_CONVERT_H_
 

--- a/include/dali/core/dev_array.h
+++ b/include/dali/core/dev_array.h
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_DEV_ARRAY_H_
-#define DALI_KERNELS_DEV_ARRAY_H_
+#ifndef DALI_CORE_DEV_ARRAY_H_
+#define DALI_CORE_DEV_ARRAY_H_
 
 #include <cuda_runtime.h>
 #include <array>
 
 namespace dali {
-namespace kernels {
 
 template <typename T, size_t N>
 class DeviceArray {
@@ -69,7 +68,6 @@ class DeviceArray {
   T data_[N];
 };
 
-}  // namespace kernels
 }  // namespace dali
 
-#endif  // DALI_KERNELS_DEV_ARRAY_H_
+#endif  // DALI_CORE_DEV_ARRAY_H_

--- a/include/dali/core/gpu_utils.h
+++ b/include/dali/core/gpu_utils.h
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_GPU_UTILS_H_
-#define DALI_KERNELS_GPU_UTILS_H_
+#ifndef DALI_CORE_GPU_UTILS_H_
+#define DALI_CORE_GPU_UTILS_H_
 
 #include <cuda_runtime.h>
 
 namespace dali {
-namespace kernels {
 
 class DeviceGuard {
  public:
@@ -33,7 +32,6 @@ class DeviceGuard {
   int original_device_;
 };
 
-}  // namespace kernels
 }  // namespace dali
 
-#endif  // DALI_KERNELS_GPU_UTILS_H_
+#endif  // DALI_CORE_GPU_UTILS_H_

--- a/include/dali/core/span.h
+++ b/include/dali/core/span.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_SPAN_H_
-#define DALI_KERNELS_SPAN_H_
+#ifndef DALI_CORE_SPAN_H_
+#define DALI_CORE_SPAN_H_
 
 #if defined(__host__) || defined(__CUDACC__)
 #define DALI_HOST_DEVICE __host__ __device__
@@ -205,4 +205,4 @@ DALI_HOST_DEVICE constexpr span<const T, N> make_span(T (&a)[N]) {
 
 #undef DALI_HOST_DEVICE
 
-#endif  // DALI_KERNELS_SPAN_H_
+#endif  // DALI_CORE_SPAN_H_

--- a/include/dali/core/static_switch.h
+++ b/include/dali/core/static_switch.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_STATIC_SWITCH_H_
-#define DALI_KERNELS_STATIC_SWITCH_H_
+#ifndef DALI_CORE_STATIC_SWITCH_H_
+#define DALI_CORE_STATIC_SWITCH_H_
 
 #ifdef __CUDACC__
 #ifdef BOOST_PP_VARIADICS
@@ -135,4 +135,4 @@
   { BOOST_PP_REMOVE_PARENS(default_); } \
   }
 
-#endif  // DALI_KERNELS_STATIC_SWITCH_H_
+#endif  // DALI_CORE_STATIC_SWITCH_H_

--- a/include/dali/core/traits.h
+++ b/include/dali/core/traits.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_UTIL_TYPE_CONVERSION_H_
-#define DALI_UTIL_TYPE_CONVERSION_H_
-
-#include "dali/core/common.h"
+#include <type_traits>
+#include <array>
+#include <vector>
 
 namespace dali {
 
-// Type conversions for data on GPU. All conversions
-// run in the default stream
-template <typename IN, typename OUT>
-DLL_PUBLIC void Convert(const IN *data, int n, OUT *out);
+template <typename T>
+struct is_vector : std::false_type {};
+
+template <typename T, typename A>
+struct is_vector<std::vector<T, A> > : std::true_type {};
+
+template <typename T>
+struct is_std_array : std::false_type {};
+
+template <typename T, size_t A>
+struct is_std_array<std::array<T, A> > : std::true_type {};
+
+
+template <bool Value, typename Type = void>
+using enable_if_t = typename std::enable_if<Value, Type>::type;
 
 }  // namespace dali
-
-#endif  // DALI_UTIL_TYPE_CONVERSION_H_

--- a/include/dali/core/tuple_helpers.h
+++ b/include/dali/core/tuple_helpers.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_TUPLE_HELPERS_H_
-#define DALI_KERNELS_TUPLE_HELPERS_H_
+#ifndef DALI_CORE_TUPLE_HELPERS_H_
+#define DALI_CORE_TUPLE_HELPERS_H_
 
 #include <tuple>
 #include <utility>
@@ -235,4 +235,4 @@ using detail::apply_all;
 
 }  // namespace dali
 
-#endif  // DALI_KERNELS_TUPLE_HELPERS_H_
+#endif  // DALI_CORE_TUPLE_HELPERS_H_

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_UTIL_H_
-#define DALI_KERNELS_UTIL_H_
+#ifndef DALI_CORE_UTIL_H_
+#define DALI_CORE_UTIL_H_
 
 #include <cstddef>
 #include <utility>
@@ -237,4 +237,4 @@ static_assert(!all_of<true, false, true>::value,
 
 }  // namespace dali
 
-#endif  // DALI_KERNELS_UTIL_H_
+#endif  // DALI_CORE_UTIL_H_


### PR DESCRIPTION
Add `dali_core` target.
Add `include` directory.
Move some common utilities from `dali/kernels` and `dali/.` to the `core` library.
Add linter command to process `include` contents.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>