### PR TITLE
Add collect_sources and collect_headers macros for CMake

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -11,29 +11,29 @@
 # All contributions by the University of California:
 # Copyright (c) 2014-2017 The Regents of the University of California (Regents)
 # All rights reserved.
-# 
+#
 # All other contributions:
 # Copyright (c) 2014-2017, the respective contributors
 # All rights reserved.
-# 
+#
 # Caffe uses a shared copyright model: each contributor holds copyright over
 # their contributions to Caffe. The project versioning records all such
 # contribution and copyright details. If a contributor wants to further mark
 # their specific copyright on a particular contribution, they should indicate
 # their copyright solely in the commit message of the change when it is
 # committed.
-# 
+#
 # LICENSE
-# 
+#
 # Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met: 
-# 
+# modification, are permitted provided that the following conditions are met:
+#
 # 1. Redistributions of source code must retain the above copyright notice, this
-#    list of conditions and the following disclaimer. 
+#    list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
-#    and/or other materials provided with the distribution. 
-# 
+#    and/or other materials provided with the distribution.
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -134,3 +134,77 @@ macro(copy_post_build TARGET_NAME SRC DST)
             "${SRC}"
             "${DST}")
 endmacro(copy_post_build)
+
+
+# Glob for source files in current dir
+# Usage: collect_sources(<SRCS_VAR_NAME> [PARENT_SCOPE])
+#
+# Adds source files globed in current dir to variable SRCS_VAR_NAME
+# at the current scope, and optionally at PARENT_SCOPE.
+#
+macro(collect_sources DALI_SRCS_GROUP)
+  cmake_parse_arguments(
+    COLLECT_SOURCES # prefix of output variables
+    "PARENT_SCOPE" # all options for the respective macro
+    "" # one value keywords
+    "" # multi value keywords
+    ${ARGV})
+
+  file(GLOB collect_sources_tmp *.cc *.cu)
+  file(GLOB collect_sources_tmp_test *_test.cc *_test.cu)
+  remove(collect_sources_tmp "${collect_sources_tmp}" ${collect_sources_tmp_test})
+  set(${DALI_SRCS_GROUP} ${${DALI_SRCS_GROUP}} ${collect_sources_tmp})
+  if (COLLECT_SOURCES_PARENT_SCOPE)
+    set(${DALI_SRCS_GROUP} ${${DALI_SRCS_GROUP}} PARENT_SCOPE)
+  endif()
+endmacro(collect_sources)
+
+# Glob for test source files in current dir
+# Usage: collect_test_sources(<SRCS_VAR_NAME> [PARENT_SCOPE])
+#
+# Adds test source files globed in current dir to variable SRCS_VAR_NAME
+# at the current scope, and optionally at PARENT_SCOPE.
+#
+macro(collect_test_sources DALI_TEST_SRCS_GROUP)
+  cmake_parse_arguments(
+    COLLECT_TEST_SOURCES # prefix of output variables
+    "PARENT_SCOPE" # all options for the respective macro
+    "" # one value keywords
+    "" # multi value keywords
+    ${ARGV})
+
+  file(GLOB collect_test_sources_tmp_test *_test.cc *_test.cu)
+  set(${DALI_TEST_SRCS_GROUP} ${${DALI_TEST_SRCS_GROUP}} ${collect_test_sources_tmp_test})
+  if (COLLECT_TEST_SOURCES_PARENT_SCOPE)
+    set(${DALI_TEST_SRCS_GROUP} ${${DALI_TEST_SRCS_GROUP}} PARENT_SCOPE)
+  endif()
+endmacro()
+
+
+# Glob for the header files in current dir
+# Usage: collect_headers(<HDRS_VAR_NAME> [PARENT_SCOPE] [INCLUDE_TEST])
+#
+# Adds *.h files to HDRS_VAR_NAME list at the current scope and optionally at PARENT_SCOPE.
+# Does not collect files that contain `test` substring it the filename,
+# unless INCLUDE_TEST is specified.
+#
+macro(collect_headers DALI_HEADERS_GROUP)
+cmake_parse_arguments(
+  COLLECT_HEADERS # prefix of output variables
+  "PARENT_SCOPE;INCLUDE_TEST" # all options for the respective macro
+  "" # one value keywords
+  "" # multi value keywords
+  ${ARGV})
+
+  file(GLOB collect_headers_tmp RELATIVE ${CMAKE_SOURCE_DIR} *.h)
+  set(${DALI_HEADERS_GROUP} ${${DALI_HEADERS_GROUP}} ${collect_headers_tmp})
+  # We remove filenames containing substring test
+  if(NOT COLLECT_HEADERS_INCLUDE_TEST)
+    file(GLOB collect_headers_tmp RELATIVE ${CMAKE_SOURCE_DIR} *test*)
+    remove(${DALI_HEADERS_GROUP} "${${DALI_HEADERS_GROUP}}" ${collect_headers_tmp})
+  endif()
+  if(COLLECT_HEADERS_PARENT_SCOPE)
+    set(${DALI_HEADERS_GROUP} ${${DALI_HEADERS_GROUP}} PARENT_SCOPE)
+  endif()
+endmacro(collect_headers)
+

--- a/dali/CMakeLists.txt
+++ b/dali/CMakeLists.txt
@@ -24,6 +24,8 @@ set(dali_operator_lib "dali_operators")
 set(dali_kernel_lib "dali_kernels")
 set(dali_kernel_test_lib "dali_kernel_test")
 set(dali_core_lib "dali_core")
+set(DALI_WHEEL_DIR "dali/python/nvidia/dali")
+set(DALI_INCLUDE_DIR "${DALI_WHEEL_DIR}/include/")
 
 ################################################
 # Build libdali
@@ -38,8 +40,8 @@ add_subdirectory(c_api)
 add_subdirectory(pipeline/operators/python_function)
 
 # Collect source files for dali
-file(GLOB tmp *.cc)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
 
 set(DALI_PROTO_OBJ $<TARGET_OBJECTS:DALI_PROTO>)
 if (BUILD_LMDB)
@@ -90,37 +92,18 @@ target_link_libraries(${dali_lib} PRIVATE ${DALI_LIBS})
 
 # install libdali to the wheel dir
 set_target_properties(${dali_lib} PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/dali/python/nvidia/dali/
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${DALI_WHEEL_DIR}"
 )
 
 set_target_properties(${dali_operator_lib} PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
 )
 
-# filter all *.h which don't have 'test' in name, create pairs 'src dst' string with sed and call xargs
-# with install command to copy with dest recursive dir creation
-add_custom_target(install_headers ALL
-    DEPENDS ${dali_lib}
-)
-
-
-
-add_custom_command(
-    TARGET install_headers
-    COMMAND find "${PROJECT_SOURCE_DIR}/dali" -regex ".*\\\\.h"
-    | grep --invert test
-    | sed -r 's,\(^${PROJECT_SOURCE_DIR}/dali\)\(.*\),\\1\\2 ${PROJECT_BINARY_DIR}/dali/python/nvidia/dali/include/dali\\2,'
-    | xargs -n 2 install -D
-    COMMAND find "${PROJECT_SOURCE_DIR}/include" -regex ".*\\\\.h"
-    | sed -r 's,\(^${PROJECT_SOURCE_DIR}\)\(.*\),\\1\\2 ${PROJECT_BINARY_DIR}/dali/python/nvidia/dali/\\2,'
-    | xargs -n 2 install -D
-  )
-
 ################################################
 # Build test suite
 ################################################
 if (BUILD_TEST)
-  set(TEST_BINARY_DIR ${PROJECT_BINARY_DIR}/dali/python/nvidia/dali/test)
+  set(TEST_BINARY_DIR "${PROJECT_BINARY_DIR}/${DALI_WHEEL_DIR}/test")
 
   # get all test srcs
   add_subdirectory(test)
@@ -162,7 +145,7 @@ if (BUILD_BENCHMARK)
   target_link_libraries(${benchmark_bin} PRIVATE ${DALI_LIBS} ${dali_lib} benchmark pthread)
 
   set_target_properties(${benchmark_bin} PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/dali/python/nvidia/dali/test)
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${DALI_WHEEL_DIR}/test")
 endif()
 
 
@@ -214,7 +197,7 @@ if (BUILD_TENSORFLOW)
     target_link_libraries(${customop_lib} PRIVATE ${dali_lib})
 
     set_target_properties(${customop_lib} PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/dali/python/nvidia/dali/plugin")
+      LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${DALI_WHEEL_DIR}/plugin")
   ENDFOREACH()
 endif()
 
@@ -226,3 +209,27 @@ if (BUILD_PYTHON)
   # Get all python srcs
   add_subdirectory(python)
 endif()
+
+
+################################################
+# Gather DALI headers for whl
+################################################
+
+# Copy all headers from DALI_INST_HDRS list to DALI_WHEEL_DIR using install command
+# with `-D` option, that recursively creates missing directories in destination path
+add_custom_target(install_headers ALL
+    DEPENDS ${dali_lib}
+)
+
+# Process the DALI_INST_HDRS list
+foreach(INSTALL_HEADER ${DALI_INST_HDRS})
+  add_custom_command(
+    TARGET install_headers
+    COMMAND install -D "${CMAKE_SOURCE_DIR}/${INSTALL_HEADER}" "${PROJECT_BINARY_DIR}/${DALI_INCLUDE_DIR}/${INSTALL_HEADER}")
+endforeach(INSTALL_HEADER)
+
+# Copy proper `include` dir
+add_custom_command(
+  TARGET install_headers
+  COMMAND cp -r "${CMAKE_SOURCE_DIR}/include/." "${PROJECT_BINARY_DIR}/${DALI_INCLUDE_DIR}"
+)

--- a/dali/benchmark/CMakeLists.txt
+++ b/dali/benchmark/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 if (BUILD_BENCHMARK)
+  collect_headers(DALI_INST_HDRS PARENT_SCOPE)
   # Get basic benchmark sources that don't depend on any other options
   set(DALI_BENCHMARK_SRCS
     #"${CMAKE_CURRENT_SOURCE_DIR}/makecontiguous_bench.cc"

--- a/dali/c_api/CMakeLists.txt
+++ b/dali/c_api/CMakeLists.txt
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 # Get all the source files
-file(GLOB tmp *.cc)
-set(DALI_SRCS ${DALI_SRCS} ${tmp} PARENT_SCOPE)
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)

--- a/dali/core/CMakeLists.txt
+++ b/dali/core/CMakeLists.txt
@@ -13,15 +13,8 @@
 # limitations under the License.
 
 # Get all the source files
-file(GLOB tmp *.cc *.cu)
-set(DALI_SRCS ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_CORE_SRCS ${DALI_SRCS})
-cuda_add_library(${dali_core_lib} STATIC ${DALI_CORE_SRCS})
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_CORE_SRCS)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)
 
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+cuda_add_library(${dali_core_lib} STATIC ${DALI_CORE_SRCS})

--- a/dali/image/CMakeLists.txt
+++ b/dali/image/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files
-file(GLOB tmp *.cc *.cu)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/kernels/CMakeLists.txt
+++ b/dali/kernels/CMakeLists.txt
@@ -19,15 +19,9 @@ add_subdirectory(common)
 add_subdirectory(imgproc)
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} ${tmp})
-file(GLOB tmp *_test.cc *_test.cu)
-remove(DALI_KERNEL_SRCS "${DALI_KERNEL_SRCS}" ${tmp})
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc *_test.cu)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_KERNEL_SRCS)
+collect_test_sources(DALI_KERNEL_TEST_SRCS)
 
 cuda_add_library(${dali_kernel_lib} STATIC "${DALI_KERNEL_SRCS}")
 cuda_add_library(${dali_kernel_test_lib} STATIC "${DALI_KERNEL_TEST_SRCS}")

--- a/dali/kernels/common/CMakeLists.txt
+++ b/dali/kernels/common/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} ${tmp})
-file(GLOB tmp *_test.cc *_test.cu)
-remove(DALI_KERNEL_SRCS "${DALI_KERNEL_SRCS}" ${tmp})
-set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc *_test.cu)
-  set(DALI_KERNEL_TEST_SRCS ${DALI_KERNEL_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_KERNEL_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_KERNEL_TEST_SRCS PARENT_SCOPE)

--- a/dali/kernels/imgproc/CMakeLists.txt
+++ b/dali/kernels/imgproc/CMakeLists.txt
@@ -15,14 +15,6 @@
 add_subdirectory(resample)
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} ${tmp})
-file(GLOB tmp *_test.cc *_test.cu)
-remove(DALI_KERNEL_SRCS "${DALI_KERNEL_SRCS}" ${tmp})
-set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc *_test.cu)
-  set(DALI_KERNEL_TEST_SRCS ${DALI_KERNEL_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_KERNEL_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_KERNEL_TEST_SRCS PARENT_SCOPE)

--- a/dali/kernels/imgproc/resample/CMakeLists.txt
+++ b/dali/kernels/imgproc/resample/CMakeLists.txt
@@ -15,14 +15,6 @@
 project(kernels)
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} ${tmp})
-file(GLOB tmp *_test.cc *_test.cu)
-remove(DALI_KERNEL_SRCS "${DALI_KERNEL_SRCS}" ${tmp})
-set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc *_test.cu)
-  set(DALI_KERNEL_TEST_SRCS ${DALI_KERNEL_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_KERNEL_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_KERNEL_TEST_SRCS PARENT_SCOPE)

--- a/dali/kernels/test/CMakeLists.txt
+++ b/dali/kernels/test/CMakeLists.txt
@@ -14,15 +14,6 @@
 
 add_subdirectory(resampling_test)
 
-# Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} ${tmp})
-file(GLOB tmp *_test.cc *_test.cu)
-remove(DALI_KERNEL_SRCS "${DALI_KERNEL_SRCS}" ${tmp})
-set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc *_test.cu)
-  set(DALI_KERNEL_TEST_SRCS ${DALI_KERNEL_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+# Get all the source files and dump test files, but not the headers
+collect_sources(DALI_KERNEL_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_KERNEL_TEST_SRCS PARENT_SCOPE)

--- a/dali/kernels/test/resampling_test/CMakeLists.txt
+++ b/dali/kernels/test/resampling_test/CMakeLists.txt
@@ -12,15 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} ${tmp})
-file(GLOB tmp *_test.cc *_test.cu)
-remove(DALI_KERNEL_SRCS "${DALI_KERNEL_SRCS}" ${tmp})
-set(DALI_KERNEL_SRCS ${DALI_KERNEL_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc *_test.cu)
-  set(DALI_KERNEL_TEST_SRCS ${DALI_KERNEL_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+# Get all the source files and dump test files, but not the headers
+collect_sources(DALI_KERNEL_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_KERNEL_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/CMakeLists.txt
+++ b/dali/pipeline/CMakeLists.txt
@@ -22,19 +22,9 @@ add_subdirectory(executor)
 add_subdirectory(proto)
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-file(GLOB tmp *_bench.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)
 
 if (BUILD_BENCHMARK)
   # Get all the benchmark srcs

--- a/dali/pipeline/data/CMakeLists.txt
+++ b/dali/pipeline/data/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc *_test.cu)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc *_test.cu)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/executor/CMakeLists.txt
+++ b/dali/pipeline/executor/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/graph/CMakeLists.txt
+++ b/dali/pipeline/graph/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/CMakeLists.txt
+++ b/dali/pipeline/operators/CMakeLists.txt
@@ -30,17 +30,8 @@ add_subdirectory(transpose)
 add_subdirectory(util)
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)
 
 set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} PARENT_SCOPE)

--- a/dali/pipeline/operators/color/CMakeLists.txt
+++ b/dali/pipeline/operators/color/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/color_space/CMakeLists.txt
+++ b/dali/pipeline/operators/color_space/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/crop/CMakeLists.txt
+++ b/dali/pipeline/operators/crop/CMakeLists.txt
@@ -15,14 +15,6 @@
 add_subdirectory(kernel)
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/crop/kernel/CMakeLists.txt
+++ b/dali/pipeline/operators/crop/kernel/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/decoder/CMakeLists.txt
+++ b/dali/pipeline/operators/decoder/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 add_subdirectory(cache)
 
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+
 # Get all the source files and dump test files
 if (BUILD_NVJPEG)
   if (NVJPEG_DECOUPLED_API)

--- a/dali/pipeline/operators/decoder/cache/CMakeLists.txt
+++ b/dali/pipeline/operators/decoder/cache/CMakeLists.txt
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_SRCS ${DALI_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/detection/CMakeLists.txt
+++ b/dali/pipeline/operators/detection/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/displacement/CMakeLists.txt
+++ b/dali/pipeline/operators/displacement/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/fused/CMakeLists.txt
+++ b/dali/pipeline/operators/fused/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/geometric/CMakeLists.txt
+++ b/dali/pipeline/operators/geometric/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/optical_flow/CMakeLists.txt
+++ b/dali/pipeline/operators/optical_flow/CMakeLists.txt
@@ -15,14 +15,6 @@
 add_subdirectory(turing_of)
 add_subdirectory(optical_flow_adapter)
 
-file(GLOB tmp *.cc)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/optical_flow/optical_flow_adapter/CMakeLists.txt
+++ b/dali/pipeline/operators/optical_flow/optical_flow_adapter/CMakeLists.txt
@@ -12,15 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-file(GLOB tmp *.cc *.cu)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
 
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
-
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/optical_flow/turing_of/CMakeLists.txt
+++ b/dali/pipeline/operators/optical_flow/turing_of/CMakeLists.txt
@@ -12,15 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-file(GLOB tmp *.cc *.cu)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
-
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/paste/CMakeLists.txt
+++ b/dali/pipeline/operators/paste/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/reader/CMakeLists.txt
+++ b/dali/pipeline/operators/reader/CMakeLists.txt
@@ -16,6 +16,8 @@ add_subdirectory(loader)
 add_subdirectory(parser)
 add_subdirectory(nvdecoder)
 
+collect_headers(DALI_INST_HDRS PARENT_SCOPE) # TODO (ONLY SUPPORTED ONES)
+
 list(APPEND DALI_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/file_reader_op.cc")
 list(APPEND DALI_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/sequence_reader_op.cc")
 

--- a/dali/pipeline/operators/reader/loader/CMakeLists.txt
+++ b/dali/pipeline/operators/reader/loader/CMakeLists.txt
@@ -13,12 +13,8 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
 
 # we don't want to test Caffe2 reader if LMDB is not present
 if (BUILD_TEST AND BUILD_LMDB)

--- a/dali/pipeline/operators/reader/nvdecoder/CMakeLists.txt
+++ b/dali/pipeline/operators/reader/nvdecoder/CMakeLists.txt
@@ -13,15 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/reader/parser/CMakeLists.txt
+++ b/dali/pipeline/operators/reader/parser/CMakeLists.txt
@@ -12,18 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-file(GLOB tmp *.cc *.cu)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)
 
 # caffe, C2
 protobuf_generate_cpp(CAFFE_PROTO_SRCS CAFFE_PROTO_HEADERS proto/caffe.proto)

--- a/dali/pipeline/operators/resize/CMakeLists.txt
+++ b/dali/pipeline/operators/resize/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/sequence/CMakeLists.txt
+++ b/dali/pipeline/operators/sequence/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/support/CMakeLists.txt
+++ b/dali/pipeline/operators/support/CMakeLists.txt
@@ -15,14 +15,6 @@
 add_subdirectory(random)
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/support/random/CMakeLists.txt
+++ b/dali/pipeline/operators/support/random/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/transpose/CMakeLists.txt
+++ b/dali/pipeline/operators/transpose/CMakeLists.txt
@@ -15,14 +15,6 @@
 add_subdirectory(cutt)
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/transpose/cutt/CMakeLists.txt
+++ b/dali/pipeline/operators/transpose/cutt/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/util/CMakeLists.txt
+++ b/dali/pipeline/operators/util/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/proto/CMakeLists.txt
+++ b/dali/pipeline/proto/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/util/CMakeLists.txt
+++ b/dali/pipeline/util/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/workspace/CMakeLists.txt
+++ b/dali/pipeline/workspace/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/plugin/CMakeLists.txt
+++ b/dali/plugin/CMakeLists.txt
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files
-file(GLOB tmp *.cc *.cu)
-set(DALI_SRCS ${DALI_SRCS} ${tmp})
-file(GLOB tmp *_test.cc)
-remove(DALI_SRCS "${DALI_SRCS}" ${tmp})
-set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/python/CMakeLists.txt
+++ b/dali/python/CMakeLists.txt
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 # Get all the srcs
-file(GLOB tmp *.cc)
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_PYTHON_BACKEND_SRCS)
 set(dali_python_lib "backend_impl")
-pybind11_add_module(${dali_python_lib} MODULE ${tmp})
+pybind11_add_module(${dali_python_lib} MODULE ${DALI_PYTHON_BACKEND_SRCS})
 message(STATUS "Adding dependencies to ${dali_python_lib}: '${dali_lib}'")
 add_dependencies(${dali_python_lib} ${dali_lib})
 

--- a/dali/tensorflow/CMakeLists.txt
+++ b/dali/tensorflow/CMakeLists.txt
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 if (BUILD_TENSORFLOW)
+  collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+  collect_sources(DALI_TF_SRCS PARENT_SCOPE)
 
-  file(GLOB tmp *.cc)
-  set(DALI_TF_SRCS ${DALI_TF_SRCS} ${tmp} PARENT_SCOPE)
-
-  message( STATUS "Installing sources for dali_tf: ${tmp}")
-  file(COPY        ${tmp}
+  message( STATUS "Installing sources for dali_tf: ${DALI_TF_SRCS}")
+  file(COPY        ${DALI_TF_SRCS}
        DESTINATION ${PROJECT_BINARY_DIR}/dali/python/tf_plugin/nvidia/dali/plugin)
 
 endif()

--- a/dali/util/CMakeLists.txt
+++ b/dali/util/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-file(GLOB tmp *.cc *.cu)
-file(GLOB tmp_test *_test.cc)
-remove(tmp "${tmp}" ${tmp_test})
-
-set(DALI_SRCS ${DALI_SRCS} ${tmp} PARENT_SCOPE)
-
-if (BUILD_TEST)
-  # get all the test srcs
-  file(GLOB tmp *_test.cc)
-  set(DALI_TEST_SRCS ${DALI_TEST_SRCS} ${tmp} PARENT_SCOPE)
-endif()
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)


### PR DESCRIPTION
collect_sources() replaces the copy-pasted globing for source files.
collect_headers() now gathers all headers from current directory
and appends to a list. Limiting files int DALI_INST_HDRS
will allow for limiting the number of headers published.

It also allows to not publish headers for turned off features

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>