### PR TITLE
Fix unnecesary memory usage when reallocating

### DIFF
--- a/dali/kernels/scratch.h
+++ b/dali/kernels/scratch.h
@@ -149,6 +149,7 @@ class ScratchpadAllocator {
     }
 
     if (new_capacity != buf.capacity) {
+      buf.mem.reset();
       buf.mem = memory::alloc_unique<char>(type, new_capacity + alignment);
       uintptr_t ptr = reinterpret_cast<uintptr_t>(buf.mem.get());
       size_t padding = (alignment-1) & (-ptr);

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -236,6 +236,7 @@ class Buffer {
       CUDA_CALL(cudaGetDevice(&device_));
     }
 
+    data_.reset();
     data_.reset(
       Backend::New(new_num_bytes, pinned_),
       std::bind(FreeMemory, std::placeholders::_1, new_num_bytes, device_, pinned_));

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -452,6 +452,10 @@ TYPED_TEST(TensorListTest, TestTypeChangeLarger) {
   const void *ptr = tensor_list.raw_data();
   size_t nbytes = tensor_list.nbytes();
 
+  // Allocate some memory in the hope of not getting the same pointer for a larger buffer.
+  TensorList<TypeParam> get_in_the_way;
+  get_in_the_way.reserve(1<<16);
+
   // Change the data type to something larger
   tensor_list.template mutable_data<double>();
 


### PR DESCRIPTION
We don't assume that buffer contents are maintained accross allocation - as such, we can free the memory before attempting to allocate a new buffer.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>