### PR TITLE
Fix pipeline serialization with make_continious inside

### DIFF
--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -125,6 +125,9 @@ void Pipeline::AddOperator(OpSpec spec, const std::string& inst_name) {
   DALI_ENFORCE(!built_, "Alterations to the pipeline after "
       "\"Build()\" has been called are not allowed");
 
+  // Take a copy of the passed OpSpec for serialization purposes before any modification
+  this->op_specs_for_serialization_.push_back(make_pair(inst_name, spec));
+
   // If necessary, split nvJPEGDecoder operator in two separated stages (CPU and Mixed-GPU)
 #ifdef NVJPEG_DECOUPLED_API
   auto operator_name = spec.name();
@@ -253,9 +256,8 @@ void Pipeline::AddOperator(OpSpec spec, const std::string& inst_name) {
         "Output name insertion failure.");
   }
 
-  // Take a copy of the passed OpSpec for serialization purposes
+  // store updated spec
   this->op_specs_.push_back(make_pair(inst_name, spec));
-  this->op_specs_to_serialize_.push_back(true);
 }
 
 inline void Pipeline::AddSplitNvJPEGDecoder(OpSpec &spec, const std::string& inst_name) {
@@ -488,8 +490,8 @@ void Pipeline::SetupCPUInput(std::map<string, EdgeMeta>::iterator it,
       .AddArg("device", "mixed")
       .AddInput(it->first, "cpu")
       .AddOutput("contiguous_" + it->first, "cpu");
+    // don't put it into op_specs_for_serialization_, only op_specs_
     this->op_specs_.push_back(make_pair("__MakeContiguous_" + it->first, make_contiguous_spec));
-    this->op_specs_to_serialize_.push_back(false);
     it->second.has_contiguous = true;
   }
 
@@ -508,8 +510,8 @@ void Pipeline::SetupGPUInput(std::map<string, EdgeMeta>::iterator it) {
     .AddArg("device", "mixed")
     .AddInput(it->first, "cpu")
     .AddOutput(it->first, "gpu");
+  // don't put it into op_specs_for_serialization_, only op_specs_
   this->op_specs_.push_back(make_pair("__Copy_" + it->first, copy_to_dev_spec));
-  this->op_specs_to_serialize_.push_back(false);
   it->second.has_gpu = true;
 }
 
@@ -581,17 +583,15 @@ string Pipeline::SerializeToProtobuf() const {
   }
 
   // loop over ops, create messages and append
-  for (size_t i = 0; i < this->op_specs_.size(); ++i) {
-    if (op_specs_to_serialize_[i]) {
-      dali_proto::OpDef *op_def = pipe.add_op();
+  for (size_t i = 0; i < this->op_specs_for_serialization_.size(); ++i) {
+    dali_proto::OpDef *op_def = pipe.add_op();
 
-      const auto& p = this->op_specs_[i];
-      const OpSpec& spec = p.second;
+    const auto& p = this->op_specs_for_serialization_[i];
+    const OpSpec& spec = p.second;
 
-      // As long as spec isn't an ExternalSource node, serialize
-      if (spec.name() != "ExternalSource") {
-        dali::SerializeToProtobuf(op_def, p.first, spec);
-      }
+    // As long as spec isn't an ExternalSource node, serialize
+    if (spec.name() != "ExternalSource") {
+      dali::SerializeToProtobuf(op_def, p.first, spec);
     }
   }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -442,7 +442,7 @@ class DLL_PUBLIC Pipeline {
   // serialized form
   vector<string> external_inputs_;
   vector<std::pair<string, OpSpec>> op_specs_;
-  vector<bool> op_specs_to_serialize_;
+  vector<std::pair<string, OpSpec>> op_specs_for_serialization_;
   vector<std::pair<string, string>> output_names_;
 };
 


### PR DESCRIPTION
- when DALI pipeline is serialized make_continious nodes are
  skipped (inserting such node into graph updates names of the
  following operator input to consume the output from make_continious),
  while updated input names of following operators are not
  reverted back to the original name. In effect when the pipeline
  is deserialized input cannot match outputs in the graph

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>