### PR TITLE
Remove unreliable tests that expected reallocation to give different pointer.

### DIFF
--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -452,10 +452,6 @@ TYPED_TEST(TensorListTest, TestTypeChangeLarger) {
   const void *ptr = tensor_list.raw_data();
   size_t nbytes = tensor_list.nbytes();
 
-  // Allocate some memory in the hope of not getting the same pointer for a larger buffer.
-  TensorList<TypeParam> get_in_the_way;
-  get_in_the_way.reserve(1<<16);
-
   // Change the data type to something larger
   tensor_list.template mutable_data<double>();
 
@@ -465,9 +461,6 @@ TYPED_TEST(TensorListTest, TestTypeChangeLarger) {
     ASSERT_EQ(tensor_list.tensor_shape(i), shape[i]);
     ASSERT_EQ(tensor_list.tensor_offset(i), offsets[i]);
   }
-
-  // Size doubled, memory allocation should have occured
-  ASSERT_NE(ptr, tensor_list.raw_data());
 
   // nbytes should have increased by a factor of 2
   ASSERT_EQ(nbytes / sizeof(float) * sizeof(double), tensor_list.nbytes());

--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -421,10 +421,6 @@ TYPED_TEST(TensorTest, TestTypeChange) {
   // Save the pointer
   const void *ptr = tensor.raw_data();
 
-  // Allocate some memory in the hope of not getting the same pointer for a larger buffer.
-  Tensor<TypeParam> get_in_the_way;
-  get_in_the_way.reserve(1<<16);
-
   // Change the type of the buffer
   tensor.template mutable_data<int>();
 
@@ -463,7 +459,6 @@ TYPED_TEST(TensorTest, TestTypeChange) {
     ASSERT_EQ(tensor.dim(i), shape[i]);
   }
 
-  ASSERT_NE(tensor.raw_data(), ptr);
   ASSERT_EQ(num_elements * sizeof(double), tensor.nbytes());
 }
 


### PR DESCRIPTION
The tests were failing occasionally.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>