### PR TITLE
Make WarpAffine test deterministic by removing random crop position from input image.

### DIFF
--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -603,9 +603,7 @@ def test_warpaffine():
         def define_graph(self):
             self.jpegs, self.labels = self.input()
             images = self.decode(self.jpegs)
-            outputs = self.cmnp([images, images],
-                                crop_pos_x = 0.5,
-                                crop_pos_y = 0.5)
+            outputs = self.cmnp([images, images])
             outputs[1] = self.affine(outputs[1])
             return [self.labels] + outputs
 

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -598,15 +598,14 @@ def test_warpaffine():
                                          fill_value = 128,
                                          interp_type = types.INTERP_LINEAR,
                                          use_image_center = True)
-            self.uniform = ops.Uniform(range = (0.0,1.0))
             self.iter = 0
 
         def define_graph(self):
             self.jpegs, self.labels = self.input()
             images = self.decode(self.jpegs)
             outputs = self.cmnp([images, images],
-                                crop_pos_x = self.uniform(),
-                                crop_pos_y = self.uniform())
+                                crop_pos_x = 0.5,
+                                crop_pos_y = 0.5)
             outputs[1] = self.affine(outputs[1])
             return [self.labels] + outputs
 


### PR DESCRIPTION
Fixes randomly failing L0 test.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>