### PR TITLE
Add proper errors to the ExternalSource

### DIFF
--- a/dali/pipeline/operators/util/external_source.cc
+++ b/dali/pipeline/operators/util/external_source.cc
@@ -22,9 +22,12 @@ void ExternalSource<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
   auto &output = ws->Output<CPUBackend>(idx);
   cudaStream_t stream = ws->has_stream() ? ws->stream() : 0;
   if (data_in_tl_) {
+    DALI_ENFORCE(OperatorBase::batch_size_ == static_cast<int>(tl_data_.ntensor()),
+      "Data list provided to ExternalSource needs to have batch_size length.");
     output.Copy(tl_data_, ws->data_idx(), stream);
   } else {
-    DALI_ENFORCE_VALID_INDEX(ws->data_idx(), t_data_.size());
+    DALI_ENFORCE(OperatorBase::batch_size_ == static_cast<int>(t_data_.size()),
+      "Data list provided to ExternalSource needs to have batch_size length.");
     auto &data = t_data_[ws->data_idx()];
     output.Copy(data, stream);
   }

--- a/dali/pipeline/operators/util/external_source.h
+++ b/dali/pipeline/operators/util/external_source.h
@@ -51,6 +51,8 @@ class ExternalSource : public Operator<Backend> {
    * on the next iteration.
    */
   inline void SetDataSource(const TensorList<Backend> &tl) {
+    DALI_ENFORCE(OperatorBase::batch_size_ == static_cast<int>(tl.ntensor()),
+      "Data list provided to ExternalSource needs to have batch_size length.");
     // Note: If we create a GPU source, we will need to figure
     // out what stream we want to do this copy in. CPU we can
     // pass anything as it is ignored.
@@ -66,6 +68,8 @@ class ExternalSource : public Operator<Backend> {
    * on the next iteration.
    */
   inline void SetDataSource(const vector<Tensor<Backend>> &t) {
+    DALI_ENFORCE(OperatorBase::batch_size_ == static_cast<int>(t.size()),
+      "Data list provided to ExternalSource needs to have batch_size length.");
     // Note: If we create a GPU source, we will need to figure
     // out what stream we want to do this copy in. CPU we can
     // pass anything as it is ignored.

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -99,7 +99,7 @@ void ExposeTensor(py::module &m) { // NOLINT
   py::class_<Tensor<CPUBackend>>(m, "TensorCPU", py::buffer_protocol())
     .def_buffer([](Tensor<CPUBackend> &t) -> py::buffer_info {
           DALI_ENFORCE(IsValidType(t.type()), "Cannot produce "
-              "buffer info for tensor w/ invalid type.");
+            "buffer info for tensor w/ invalid type.");
 
           std::vector<ssize_t> shape(t.ndim()), stride(t.ndim());
           size_t dim_prod = 1;
@@ -125,6 +125,10 @@ void ExposeTensor(py::module &m) { // NOLINT
           std::vector<Index> i_shape;
           for (auto &dim : info.shape) {
             i_shape.push_back(dim);
+          }
+          // scalar
+          if (info.shape.size() == 0) {
+            i_shape.push_back(1);
           }
           size_t bytes = volume(i_shape) * info.itemsize;
 
@@ -711,6 +715,8 @@ PYBIND11_MODULE(backend_impl, m) {
           // instead, we cast to a reference type and manually
           // move into the vector.
           vector<Tensor<CPUBackend>> tensors(list.size());
+          DALI_ENFORCE(p->batch_size() == static_cast<int>(list.size()),
+             "Data list provided to feed_input needs to have batch_size length.");
           for (size_t i = 0; i < list.size(); ++i) {
             tensors[i] = std::move(list[i].cast<Tensor<CPUBackend>&>());
           }

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -244,6 +244,8 @@ class Pipeline(object):
                 .format(type(ref).__name__)
             )
         if isinstance(data, list):
+            if self._batch_size != len(data):
+                raise RuntimeError("Data list provided to feed_input needs to have batch_size length")
             inputs = []
             for datum in data:
                 inputs.append(Edge.TensorCPU(datum))

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1134,6 +1134,99 @@ def test_external_source():
             break
     assert(iter_num == i)
 
+def test_external_source_fail():
+    class ExternalSourcePipeline(Pipeline):
+        def __init__(self, batch_size, external_s_size, num_threads, device_id):
+            super(ExternalSourcePipeline, self).__init__(batch_size, num_threads, device_id)
+            self.input = ops.ExternalSource()
+            self.batch_size_ = batch_size
+            self.external_s_size_ = external_s_size
+
+        def define_graph(self):
+            self.batch = self.input()
+            return [self.batch]
+
+        def iter_setup(self):
+            batch = np.zeros([self.external_s_size_,4,5])
+            self.feed_input(self.batch, batch)
+
+    batch_size = 3
+    pipe = ExternalSourcePipeline(batch_size, batch_size - 1, 3, 0)
+    pipe.build()
+    try:
+        pipe.run()
+    except RuntimeError:
+        pass
+    else:
+        assert False, "ExternalSource should throw"
+
+def test_external_source_fail_list():
+    class ExternalSourcePipeline(Pipeline):
+        def __init__(self, batch_size, external_s_size, num_threads, device_id):
+            super(ExternalSourcePipeline, self).__init__(batch_size, num_threads, device_id)
+            self.input = ops.ExternalSource()
+            self.batch_size_ = batch_size
+            self.external_s_size_ = external_s_size
+
+        def define_graph(self):
+            self.batch = self.input()
+            return [self.batch]
+
+        def iter_setup(self):
+            batch = []
+            for _ in range(self.external_s_size_):
+                batch.append(np.zeros([3,4,5]))
+            self.feed_input(self.batch, batch)
+
+    batch_size = 3
+    pipe = ExternalSourcePipeline(batch_size, batch_size - 1, 3, 0)
+    pipe.build()
+    try:
+        pipe.run()
+    except RuntimeError:
+        pass
+    else:
+        assert False, "ExternalSource should throw"
+
+def test_external_source_scalar_list():
+    class ExternalSourcePipeline(Pipeline):
+        def __init__(self, batch_size, external_data, num_threads, device_id, label_data):
+            super(ExternalSourcePipeline, self).__init__(batch_size, num_threads, device_id)
+            self.input = ops.ExternalSource()
+            self.batch_size_ = batch_size
+            self.external_data = external_data
+            self.label_data_ = label_data
+
+        def define_graph(self):
+            self.batch = self.input()
+            return [self.batch]
+
+        def iter_setup(self):
+            batch = []
+            for elm in self.external_data:
+                batch.append(np.array(elm, dtype=np.uint8))
+            self.feed_input(self.batch, batch)
+
+    batch_size = 3
+    label_data = 10
+    lists = []
+    scalars = []
+    for i in range(batch_size):
+        lists.append([label_data + i])
+        scalars.append(label_data + i * 10)
+    for external_data in [lists, scalars]:
+        print(external_data)
+        pipe = ExternalSourcePipeline(batch_size, external_data, 3, 0, label_data)
+        pipe.build()
+        for _ in range(10):
+            out = pipe.run()
+            for i in range(batch_size):
+                assert out[0].as_array()[i] == external_data[i]
+        yield external_data_veri, external_data
+
+def external_data_veri(external_data):
+    pass
+
 def test_element_extract_operator():
     batch_size = 4
     F = 10


### PR DESCRIPTION
- adds checking if data provided to ExternalSource has a batch size
  length
- fixes the case when provided numpy array is a scalar

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>