### PR TITLE
Fix cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@
 
 cmake_minimum_required(VERSION 3.11)
 
+if (POLICY CMP0075)
+  cmake_policy(SET CMP0075 NEW)
+endif()
+
 project(DALI CXX)
 
 # Build options


### PR DESCRIPTION
Fixing cmake warning:
```
CMake Warning (dev) at /usr/local/share/cmake-3.14/Modules/CheckIncludeFileCXX.cmake:79 (message):
  Policy CMP0075 is not set: Include file check macros honor
  CMAKE_REQUIRED_LIBRARIES.  Run "cmake --help-policy CMP0075" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  CMAKE_REQUIRED_LIBRARIES is set to:

    /usr/local/cuda/lib64/libnvjpeg_static.a;-L/usr/local/cuda/lib64;-lcudart_static;-lculibos;dl;-pthread;rt

  For compatibility with CMake 3.11 and below this check is ignoring it.
Call Stack (most recent call first):
  /usr/local/share/cmake-3.14/Modules/CheckTypeSize.cmake:234 (check_include_file_cxx)
  cmake/Dependencies.cmake:193 (CHECK_TYPE_SIZE)
  CMakeLists.txt:62 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>