### PR TITLE
Disable threading inside the OpenCV

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -98,7 +98,8 @@ RUN OPENCV_VERSION=3.4.3 && \
           -DWITH_CUDA=OFF -DWITH_1394=OFF -DWITH_IPP=OFF -DWITH_OPENCL=OFF -DWITH_GTK=OFF \
           -DBUILD_JPEG=OFF -DWITH_JPEG=ON \
           -DBUILD_DOCS=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_PNG=ON \
-          -DBUILD_opencv_cudalegacy=OFF -DBUILD_opencv_stitching=OFF .. && \
+          -DBUILD_opencv_cudalegacy=OFF -DBUILD_opencv_stitching=OFF \
+          -DWITH_TBB=OFF -DWITH_OPENMP=OFF -DWITH_PTHREADS_PF=OFF -DWITH_CSTRIPES=OFF .. && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
     rm -rf /opencv-${OPENCV_VERSION}
 


### PR DESCRIPTION
- OpenCV spawns owns thread while DALI relais on image level parallelism.
  In effect, more threads are used then user expects.
- This change affects only Docker-based builds. Building with any other
  OpenCV version will still create threads in OpenCV.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>