### PR TITLE
Update docs of the Readers

### DIFF
--- a/dali/pipeline/operators/decoder/cache/cached_decoder_impl.cc
+++ b/dali/pipeline/operators/decoder/cache/cached_decoder_impl.cc
@@ -87,7 +87,7 @@ DALI_SCHEMA(CachedDecoderAttr)
 images bigger than `cache_threshold` will be cached in memory.)code",
       0)
   .AddOptionalArg("cache_threshold",
-      R"code(Size threshold (in bytes) for images to be cached.)code",
+      R"code(Size threshold (in bytes) for images (after decoding) to be cached.)code",
       0)
   .AddOptionalArg("cache_debug",
       R"code(Print debug information about decoder cache.)code",

--- a/dali/pipeline/operators/reader/coco_reader_op.cc
+++ b/dali/pipeline/operators/reader/coco_reader_op.cc
@@ -21,7 +21,7 @@ DALI_SCHEMA(COCOReader)
   .NumInput(0)
   .NumOutput(3)
   .DocStr(R"code(Read data from a COCO dataset composed of directory with images
-and an anotation files. For each image, with `m` bboxes, returns its bboxes as (m,4)
+and an annotation files. For each image, with `m` bboxes, returns its bboxes as (m,4)
 Tensor (`m` * `[x, y, w, h] or `m` * [left, top, right, bottom]`) and labels as `(m,1)` Tensor (`m` * `category_id`).)code")
   .AddArg("file_root",
       R"code(Path to a directory containing data files.)code",
@@ -40,7 +40,8 @@ Tensor (`m` * `[x, y, w, h] or `m` * [left, top, right, bottom]`) and labels as 
       R"code(If true, bboxes returned values as expressed as ratio w.r.t. to the image width and height.)code",
       false)
   .AddOptionalArg("size_threshold",
-      R"code(If width or height of a bounding box representing an instance of an object is under this value, object will be skipped during reading. It is represented as absolute value.)code",
+      R"code(If width or height of a bounding box representing an instance of an object is under this value,
+object will be skipped during reading. It is represented as absolute value.)code",
       0.1f,
       false)
   .AddOptionalArg("skip_empty",

--- a/dali/pipeline/operators/reader/coco_reader_op.h
+++ b/dali/pipeline/operators/reader/coco_reader_op.h
@@ -36,21 +36,9 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
   explicit COCOReader(const OpSpec& spec)
   : DataReader<CPUBackend, ImageLabelWrapper>(spec) {
     bool shuffle_after_epoch = spec.GetArgument<bool>("shuffle_after_epoch");
-    bool stick_to_shard = spec.GetArgument<bool>("stick_to_shard");
 
     DALI_ENFORCE(!skip_cached_images_,
       "COCOReader doesn't support `skip_cached_images` option");
-
-    /*
-     * Those options are mutually exclusive as `shuffle_after_epoch` will make every shard looks differently
-     * after each epoch so coexistence with `stick_to_shard` doesn't make any sense
-     * Still when `shuffle_after_epoch` we will set `stick_to_shard` internally in the FileLoader so all
-     * DALI instances will do shuffling after each epoch
-     */
-    if (shuffle_after_epoch || stick_to_shard)
-      DALI_ENFORCE(
-        !shuffle_after_epoch || !stick_to_shard,
-        "shuffle_after_epoch and stick_to_shard cannot be both true");
 
     if (spec.HasArgument("file_list"))
       loader_ = InitLoader<FileLoader>(

--- a/dali/pipeline/operators/reader/coco_reader_op_test.cc
+++ b/dali/pipeline/operators/reader/coco_reader_op_test.cc
@@ -191,6 +191,17 @@ TEST_F(CocoReaderTest, MutuallyExclusiveOptions) {
   EXPECT_THROW(pipe.Build(this->Outputs()), std::runtime_error);
 }
 
+TEST_F(CocoReaderTest, MutuallyExclusiveOptions2) {
+  Pipeline pipe(1, 1, 0);
+
+  pipe.AddOperator(
+    this->CocoReaderOpSpec()
+    .AddArg("random_shuffle", true)
+    .AddArg("shuffle_after_epoch", true));
+
+  EXPECT_THROW(pipe.Build(this->Outputs()), std::runtime_error);
+}
+
 TEST_F(CocoReaderTest, SkipEmpty) {
   Pipeline pipe(this->SmallCocoSize() - this->EmptyImages(), 1, 0);
 

--- a/dali/pipeline/operators/reader/file_reader_op.cc
+++ b/dali/pipeline/operators/reader/file_reader_op.cc
@@ -31,6 +31,10 @@ DALI_SCHEMA(FileReader)
       R"code(Path to the file with a list of pairs ``file label``
 (leave empty to traverse the `file_root` directory to obtain files and labels))code",
       std::string())
+.AddOptionalArg("shuffle_after_epoch",
+      R"code(If true, reader shuffles whole dataset after each epoch. It is exclusive with
+`stick_to_shard` and `random_shuffle`.)code",
+      false)
   .AddParent("LoaderBase");
 
 }  // namespace dali

--- a/dali/pipeline/operators/reader/file_reader_op.h
+++ b/dali/pipeline/operators/reader/file_reader_op.h
@@ -15,6 +15,9 @@
 #ifndef DALI_PIPELINE_OPERATORS_READER_FILE_READER_OP_H_
 #define DALI_PIPELINE_OPERATORS_READER_FILE_READER_OP_H_
 
+#include <utility>
+#include <string>
+#include <vector>
 #include "dali/pipeline/operators/reader/reader_op.h"
 #include "dali/pipeline/operators/reader/loader/file_loader.h"
 
@@ -24,7 +27,9 @@ class FileReader : public DataReader<CPUBackend, ImageLabelWrapper> {
  public:
   explicit FileReader(const OpSpec& spec)
     : DataReader<CPUBackend, ImageLabelWrapper>(spec) {
-    loader_ = InitLoader<FileLoader>(spec);
+    bool shuffle_after_epoch = spec.GetArgument<bool>("shuffle_after_epoch");
+    loader_ = InitLoader<FileLoader>(spec, std::vector<std::pair<string, int>>(),
+                                     shuffle_after_epoch);
   }
 
   void RunImpl(SampleWorkspace *ws, const int i) override {

--- a/dali/pipeline/operators/reader/loader/file_loader.h
+++ b/dali/pipeline/operators/reader/loader/file_loader.h
@@ -57,6 +57,20 @@ class FileLoader : public Loader<CPUBackend, ImageLabelWrapper> {
       current_index_(0),
       current_epoch_(0) {
       /*
+      * Those options are mutually exclusive as `shuffle_after_epoch` will make every shard looks differently
+      * after each epoch so coexistence with `stick_to_shard` doesn't make any sense
+      * Still when `shuffle_after_epoch` we will set `stick_to_shard` internally in the FileLoader so all
+      * DALI instances will do shuffling after each epoch
+      */
+      if (shuffle_after_epoch_ || stick_to_shard_)
+        DALI_ENFORCE(
+          !shuffle_after_epoch_ || !stick_to_shard_,
+          "shuffle_after_epoch and stick_to_shard cannot be both true");
+      if (shuffle_after_epoch_ || shuffle_)
+        DALI_ENFORCE(
+          !shuffle_after_epoch_ || !shuffle_,
+          "shuffle_after_epoch and random_shuffle cannot be both true");
+      /*
        * Imply `stick_to_shard` from  `shuffle_after_epoch`
        */
       if (shuffle_after_epoch_) {

--- a/dali/pipeline/operators/reader/loader/loader.cc
+++ b/dali/pipeline/operators/reader/loader/loader.cc
@@ -19,9 +19,11 @@ namespace dali {
 
 DALI_SCHEMA(LoaderBase)
   .AddOptionalArg("random_shuffle",
-      R"code(Whether to randomly shuffle data.)code", false)
+      R"code(Whether to randomly shuffle data. Prefetch buffer of `initial_fill` size is used
+to sequentially read data and then randomly sample it to form a batch.)code", false)
   .AddOptionalArg("initial_fill",
-      R"code(Size of the buffer used for shuffling.)code", 1024)
+      R"code(Size of the buffer used for shuffling. If `random_shuffle` is off then
+this parameter is ignored.)code", 1024)
   .AddOptionalArg("num_shards",
       R"code(Partition the data into this many parts (used for multiGPU training).)code", 1)
   .AddOptionalArg("shard_id",


### PR DESCRIPTION
- gives more details about `shuffle_after_epoch`, `random_shuffle`
  and `initial_fill` options
- gives more details about nvJPEG cache threshold option meaning

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>