### PR TITLE
Device-usable TensorsShape and core utils.

### DIFF
--- a/dali/core/small_vector_test.cc
+++ b/dali/core/small_vector_test.cc
@@ -366,4 +366,24 @@ TEST(SmallVector, Erase) {
   EXPECT_EQ(TestObj::total, 0);
 }
 
+TEST(SmallVector, Resize) {
+  SmallVector<TestObj, 4> v;
+  v.resize(3, 5);
+  ASSERT_EQ(v.size(), 3);
+  EXPECT_EQ(v[0], 5);
+  EXPECT_EQ(v[1], 5);
+  EXPECT_EQ(v[2], 5);
+  EXPECT_EQ(TestObj::total, 3);
+  v.resize(16, 42);
+  ASSERT_EQ(v.size(), 16);
+  EXPECT_EQ(TestObj::total, 16);
+  EXPECT_EQ(TestObj::zombies, 0);
+  for (int i = 3; i < 16; i++)
+    EXPECT_EQ(v[i], 42);
+  v.resize(6);
+  EXPECT_EQ(v.size(), 6);
+  EXPECT_EQ(TestObj::total, 6);
+  EXPECT_EQ(TestObj::zombies, 0);
+}
+
 }  // namespace dali

--- a/dali/core/small_vector_test.cu
+++ b/dali/core/small_vector_test.cu
@@ -64,3 +64,19 @@ DEVICE_TEST(SmallVectorDev, MovePoD, 1, 1) {
   DEV_EXPECT_EQ(a.data(), ptr);
   DEV_EXPECT_TRUE(b.empty());
 }
+
+
+DEVICE_TEST(SmallVectorDev, Resize, 1, 1) {
+  dali::SmallVector<int32_t, 4> v;
+  v.resize(3, 5);
+  DEV_ASSERT_EQ(v.size(), 3);
+  DEV_EXPECT_EQ(v[0], 5);
+  DEV_EXPECT_EQ(v[1], 5);
+  DEV_EXPECT_EQ(v[2], 5);
+  v.resize(16, 42);
+  DEV_ASSERT_EQ(v.size(), 16);
+  for (int i = 3; i < 16; i++)
+    DEV_EXPECT_EQ(v[i], 42);
+  v.resize(6);
+  DEV_EXPECT_EQ(v.size(), 6);
+}

--- a/dali/core/utils_test.cu
+++ b/dali/core/utils_test.cu
@@ -1,0 +1,76 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/test/device_test.h"
+#include "dali/core/util.h"
+#include "dali/core/dev_array.h"
+#include "dali/core/small_vector.h"
+#include "dali/core/span.h"
+
+namespace dali {
+
+DEVICE_TEST(CoreUtilsDev, Volume, 1, 1) {
+  int a0[] = { 42 };
+  DEV_EXPECT_EQ(volume(a0), 42);
+  int a1[] = { 2, 3, 4 };
+  DEV_EXPECT_EQ(volume(a1), 2*3*4);
+  DeviceArray<int, 2> b = { 10000000, 10000000 };
+  DEV_EXPECT_EQ(volume(b), 100000000000000LL);
+}
+
+DEVICE_TEST(CoreUtilsDev, Size, 1, 1) {
+  int a0[] = { 42 };
+  DEV_EXPECT_EQ(size(a0), 1);
+  int a1[] = { 2, 3, 4 };
+  DEV_EXPECT_EQ(size(a1), 3);
+
+  SmallVector<int, 5> v;
+  v.resize(10);
+  DEV_EXPECT_EQ(v.size(), 10);
+  DEV_EXPECT_EQ(size(v), 10);
+}
+
+DEFINE_TEST_KERNEL(CoreUtilsDev, Span, span<float> data) {
+  DEV_ASSERT_EQ(data.size(), 1000);
+  int x = threadIdx.x + blockDim.x*blockIdx.x;
+  if (x < data.size())
+    data[x] = x + 5;
+
+  __syncthreads();
+
+  auto blk = make_span(data.data() + blockDim.x*blockIdx.x, blockDim.x);
+
+  x = blockDim.x*blockIdx.x;
+  for (auto v : blk) {
+    if (x < data.size()) {
+      DEV_EXPECT_EQ(v, x + 5);
+    }
+    x++;
+  }
+}
+
+TEST(CoreUtilsDev, Span) {
+  using T = float;
+  const int N = 1000;
+  T *dev_data;
+  CUDA_CALL(cudaMalloc(&dev_data, sizeof(T)*N));
+  DEVICE_TEST_CASE_BODY(CoreUtilsDev, Span, div_ceil(N, 256), 256, make_span(dev_data, N));
+  T host_data[N];
+  CUDA_CALL(cudaMemcpy(host_data, dev_data, sizeof(host_data), cudaMemcpyDeviceToHost));
+  for (int i = 0; i < N; i++)
+    EXPECT_EQ(host_data[i], i + 5);
+  CUDA_CALL(cudaFree(dev_data));
+}
+
+}  // namespace dali

--- a/dali/kernels/test/tensor_shape_test.cu
+++ b/dali/kernels/test/tensor_shape_test.cu
@@ -52,6 +52,15 @@ DEVICE_TEST(TensorShapeDev, Copy, 1, 1) {
   DEV_EXPECT_EQ(a, c);
 }
 
+DEVICE_TEST(TensorShapeDev, Move, 1, 1) {
+  dali::kernels::TensorShape<3> a = { 4, 5, 6 };
+  dali::kernels::TensorShape<3> ref = a;
+  dali::kernels::TensorShape<3> c = dali::cuda_move(a), d;
+  DEV_EXPECT_EQ(c, ref);
+  d = dali::cuda_move(c);
+  DEV_EXPECT_EQ(d, ref);
+}
+
 DEVICE_TEST(TensorShapeDev, ForEach, 1, 1) {
   dali::kernels::TensorShape<3> a = { 4, 5, 6 };
   int64_t arr[3];
@@ -64,6 +73,24 @@ DEVICE_TEST(TensorShapeDev, ForEach, 1, 1) {
   DEV_EXPECT_EQ(arr[0], 4);
   DEV_EXPECT_EQ(arr[1], 5);
   DEV_EXPECT_EQ(arr[2], 6);
+}
+
+DEVICE_TEST(TensorShapeDev, FirstLast, 1, 1) {
+  dali::kernels::TensorShape<5> a = { 11, 22, 33, 44, 55 };
+  auto first = a.first<3>();
+  auto last = a.last<4>();
+  static_assert(std::is_same<decltype(first), dali::kernels::TensorShape<3>>::value,
+    "Wrong type inferred for first()");
+  static_assert(std::is_same<decltype(last), dali::kernels::TensorShape<4>>::value,
+    "Wrong type inferred for last()");
+  DEV_EXPECT_EQ(first[0], a[0]);
+  DEV_EXPECT_EQ(first[1], a[1]);
+  DEV_EXPECT_EQ(first[2], a[2]);
+
+  DEV_EXPECT_EQ(last[0], a[1]);
+  DEV_EXPECT_EQ(last[1], a[2]);
+  DEV_EXPECT_EQ(last[2], a[3]);
+  DEV_EXPECT_EQ(last[3], a[4]);
 }
 
 DEFINE_TEST_KERNEL(TensorShapeDev, KernelArg, dali::kernels::TensorShape<4> a) {

--- a/dali/kernels/test/tensor_shape_test.cu
+++ b/dali/kernels/test/tensor_shape_test.cu
@@ -1,0 +1,76 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/kernels/tensor_shape.h"
+#include "dali/kernels/tensor_shape_print.h"
+#include "dali/test/device_test.h"
+
+namespace dali {
+template <int N>
+__device__ DeviceString dev_to_string(const dali::kernels::TensorShape<N> &s) {
+  DeviceString result;
+  for (int i = 0; i < N; i++) {
+    if (i)
+      result += "x";
+    result += dev_to_string(s[i]);
+  }
+  return result;
+}
+}  // namespace dali
+
+DEVICE_TEST(TensorShapeDev, Construct, 1, 1) {
+  dali::kernels::TensorShape<3> a = { 4, 5, 6 };
+  DEV_EXPECT_EQ(a[0], 4);
+  DEV_EXPECT_EQ(a[1], 5);
+  DEV_EXPECT_EQ(a[2], 6);
+  DEV_EXPECT_EQ(dali::volume(a), 4*5*6);
+
+  dali::kernels::TensorShape<4> b;
+  DEV_EXPECT_EQ(b[0], 0);
+  DEV_EXPECT_EQ(b[1], 0);
+  DEV_EXPECT_EQ(b[2], 0);
+  DEV_EXPECT_EQ(b[3], 0);
+}
+
+
+DEVICE_TEST(TensorShapeDev, Copy, 1, 1) {
+  dali::kernels::TensorShape<3> a = { 4, 5, 6 };
+  dali::kernels::TensorShape<3> b = a, c;
+  c = b;
+  DEV_EXPECT_EQ(a, b);
+  DEV_EXPECT_EQ(a, c);
+}
+
+DEVICE_TEST(TensorShapeDev, ForEach, 1, 1) {
+  dali::kernels::TensorShape<3> a = { 4, 5, 6 };
+  int64_t arr[3];
+  int i = 0;
+  for (auto v : a) {
+    DEV_ASSERT_LT(i, 3);
+    arr[i++] = v;
+  }
+  DEV_EXPECT_EQ(i, 3);
+  DEV_EXPECT_EQ(arr[0], 4);
+  DEV_EXPECT_EQ(arr[1], 5);
+  DEV_EXPECT_EQ(arr[2], 6);
+}
+
+DEFINE_TEST_KERNEL(TensorShapeDev, KernelArg, dali::kernels::TensorShape<4> a) {
+  DEV_EXPECT_EQ(a[threadIdx.x], threadIdx.x + 2);
+}
+
+TEST(TensorShapeDev, KernelArg) {
+  dali::kernels::TensorShape<4> a = { 2, 3, 4, 5 };
+  DEVICE_TEST_CASE_BODY(TensorShapeDev, KernelArg, 1, 4, a);
+}

--- a/include/dali/core/cuda_utils.h
+++ b/include/dali/core/cuda_utils.h
@@ -21,6 +21,13 @@
 #include "dali/core/cuda_error.h"
 #include <type_traits>
 
+#if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__))
+#define DALI_NO_EXEC_CHECK #pragma nv_exec_check_disable
+#else
+#define DALI_NO_EXEC_CHECK
+#endif
+#define DALI_HOST_DEV __host__ __device__
+
 // For the CPU we use half_float lib and float16_cpu type
 namespace half_float {
 

--- a/include/dali/core/cuda_utils.h
+++ b/include/dali/core/cuda_utils.h
@@ -17,16 +17,10 @@
 
 #include <cuda_fp16.h>  // for __half & related methods
 #include <cuda_runtime_api.h>  // for __align__ & CUDART_VERSION
+#include <type_traits>
+#include "dali/core/host_dev.h"
 #include "dali/core/dynlink_cuda.h"
 #include "dali/core/cuda_error.h"
-#include <type_traits>
-
-#if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__))
-#define DALI_NO_EXEC_CHECK #pragma nv_exec_check_disable
-#else
-#define DALI_NO_EXEC_CHECK
-#endif
-#define DALI_HOST_DEV __host__ __device__
 
 // For the CPU we use half_float lib and float16_cpu type
 namespace half_float {

--- a/include/dali/core/dev_array.h
+++ b/include/dali/core/dev_array.h
@@ -31,6 +31,12 @@ class DeviceArray {
       data_[i] = src[i];
   }
 
+  template <typename... Args>
+  __host__ __device__ DeviceArray(const T &arg0, const Args&... args)
+  : data_{arg0, args...} {
+    static_assert(sizeof...(Args) == N-1, "Wrong number of initializers");
+  }
+
   __host__ operator std::array<T, N>() const
   noexcept(noexcept(std::array<T, N>()[0] = *static_cast<T*>(nullptr))) {
     std::array<T, N> ret;
@@ -81,10 +87,10 @@ template <typename T>
 class DeviceArray<T, 0> {
  public:
   constexpr DeviceArray() = default;
-  __host__ DeviceArray(const std::array<T, 0> &) noexcept {
+  __host__ __device__ DeviceArray(const std::array<T, 0> &) noexcept {
   }
 
-  constexpr __host__ operator std::array<T, 0>() const noexcept {
+  constexpr __host__ __device__ operator std::array<T, 0>() const noexcept {
     return {};
   }
 

--- a/include/dali/core/dev_array.h
+++ b/include/dali/core/dev_array.h
@@ -36,6 +36,12 @@ class DeviceArray {
     return ret;
   }
 
+  using value_type = T;
+  using reference = T&;
+  using const_reference = const T&;
+  using iterator = T*;
+  using const_iterator = const T*;
+
   __host__ __device__ T &operator[](ptrdiff_t index)
   { return data_[index]; }
   __host__ __device__ constexpr const T &operator[](ptrdiff_t index) const
@@ -50,7 +56,7 @@ class DeviceArray {
   __host__ __device__ constexpr size_t size() const { return N; }
   __host__ __device__ constexpr bool empty() const { return N == 0; }
   __host__ __device__ inline T *data() { return data_; }
-  __host__ __device__ constexpr T *data() const { return data_; }
+  __host__ __device__ constexpr const T *data() const { return data_; }
 
   __host__ __device__ inline bool operator==(const DeviceArray &other) const {
     for (size_t i = 0; i < N; i++) {
@@ -66,6 +72,40 @@ class DeviceArray {
 
  private:
   T data_[N];
+};
+
+template <typename T>
+class DeviceArray<T, 0> {
+ public:
+  constexpr DeviceArray() = default;
+  __host__ DeviceArray(const std::array<T, 0> &) {
+  }
+
+  constexpr __host__ operator std::array<T, 0>() const noexcept {
+    return {};
+  }
+
+  using value_type = T;
+  using reference = T&;
+  using const_reference = const T&;
+  using iterator = T*;
+  using const_iterator = const T*;
+
+  __host__ __device__ T &operator[](ptrdiff_t index)
+  { return data()[index]; }
+  __host__ __device__ constexpr const T &operator[](ptrdiff_t index) const
+  { return data()[index]; }
+
+  __host__ __device__ inline T *begin() { return data(); }
+  __host__ __device__ constexpr const T *begin() const { return data(); }
+  __host__ __device__ constexpr const T *cbegin() const { return data(); }
+  __host__ __device__ inline T *end() { return data(); }
+  __host__ __device__ constexpr const T *end() const { return data(); }
+  __host__ __device__ constexpr const T *cend() const { return data(); }
+  __host__ __device__ constexpr size_t size() const { return 0; }
+  __host__ __device__ constexpr bool empty() const { return true; }
+  __host__ __device__ inline T *data() { return reinterpret_cast<T*>(this); }
+  __host__ __device__ constexpr const T *data() const { return reinterpret_cast<const T*>(this); }
 };
 
 }  // namespace dali

--- a/include/dali/core/dev_array.h
+++ b/include/dali/core/dev_array.h
@@ -17,6 +17,7 @@
 
 #include <cuda_runtime.h>
 #include <array>
+#include "dali/core/util.h"
 
 namespace dali {
 
@@ -24,12 +25,14 @@ template <typename T, size_t N>
 class DeviceArray {
  public:
   constexpr DeviceArray() = default;
-  __host__ DeviceArray(const std::array<T, N> &src) {
+  __host__ DeviceArray(const std::array<T, N> &src)
+  noexcept(noexcept(std::declval<T*>()[0] = src[0])) {
     for (size_t i = 0; i < N; i++)
       data_[i] = src[i];
   }
 
-  __host__ operator std::array<T, N>() const noexcept {
+  __host__ operator std::array<T, N>() const
+  noexcept(noexcept(std::array<T, N>()[0] = *static_cast<T*>(nullptr))) {
     std::array<T, N> ret;
     for (size_t i = 0; i < N; i++)
       ret[i] = data_[i];
@@ -42,23 +45,23 @@ class DeviceArray {
   using iterator = T*;
   using const_iterator = const T*;
 
-  __host__ __device__ T &operator[](ptrdiff_t index)
+  __host__ __device__ T &operator[](ptrdiff_t index) noexcept
   { return data_[index]; }
-  __host__ __device__ constexpr const T &operator[](ptrdiff_t index) const
+  __host__ __device__ constexpr const T &operator[](ptrdiff_t index) const noexcept
   { return data_[index]; }
 
-  __host__ __device__ inline T *begin() { return data_; }
-  __host__ __device__ constexpr const T *begin() const { return data_; }
-  __host__ __device__ constexpr const T *cbegin() const { return data_; }
-  __host__ __device__ inline T *end() { return data_ + N; }
-  __host__ __device__ constexpr const T *end() const { return data_ + N; }
-  __host__ __device__ constexpr const T *cend() const { return data_ + N; }
-  __host__ __device__ constexpr size_t size() const { return N; }
-  __host__ __device__ constexpr bool empty() const { return N == 0; }
-  __host__ __device__ inline T *data() { return data_; }
-  __host__ __device__ constexpr const T *data() const { return data_; }
+  __host__ __device__ inline T *begin() noexcept { return data_; }
+  __host__ __device__ constexpr const T *begin() const noexcept { return data_; }
+  __host__ __device__ constexpr const T *cbegin() const noexcept { return data_; }
+  __host__ __device__ inline T *end() noexcept { return data_ + N; }
+  __host__ __device__ constexpr const T *end() const noexcept { return data_ + N; }
+  __host__ __device__ constexpr const T *cend() const noexcept { return data_ + N; }
+  __host__ __device__ constexpr size_t size() const noexcept { return N; }
+  __host__ __device__ constexpr bool empty() const noexcept { return N == 0; }
+  __host__ __device__ inline T *data() noexcept { return data_; }
+  __host__ __device__ constexpr const T *data() const noexcept { return data_; }
 
-  __host__ __device__ inline bool operator==(const DeviceArray &other) const {
+  __host__ __device__ inline bool operator==(const DeviceArray &other) const noexcept {
     for (size_t i = 0; i < N; i++) {
       if (data_[i] != other.data_[i])
         return false;
@@ -66,7 +69,7 @@ class DeviceArray {
     return true;
   }
 
-  __host__ __device__ inline bool operator!=(const DeviceArray &other) const {
+  __host__ __device__ inline bool operator!=(const DeviceArray &other) const noexcept {
     return !(*this == other);
   }
 
@@ -78,7 +81,7 @@ template <typename T>
 class DeviceArray<T, 0> {
  public:
   constexpr DeviceArray() = default;
-  __host__ DeviceArray(const std::array<T, 0> &) {
+  __host__ DeviceArray(const std::array<T, 0> &) noexcept {
   }
 
   constexpr __host__ operator std::array<T, 0>() const noexcept {
@@ -91,22 +94,42 @@ class DeviceArray<T, 0> {
   using iterator = T*;
   using const_iterator = const T*;
 
-  __host__ __device__ T &operator[](ptrdiff_t index)
+  __host__ __device__ T &operator[](ptrdiff_t index) noexcept
   { return data()[index]; }
-  __host__ __device__ constexpr const T &operator[](ptrdiff_t index) const
+  __host__ __device__ constexpr const T &operator[](ptrdiff_t index) const noexcept
   { return data()[index]; }
 
-  __host__ __device__ inline T *begin() { return data(); }
-  __host__ __device__ constexpr const T *begin() const { return data(); }
-  __host__ __device__ constexpr const T *cbegin() const { return data(); }
-  __host__ __device__ inline T *end() { return data(); }
-  __host__ __device__ constexpr const T *end() const { return data(); }
-  __host__ __device__ constexpr const T *cend() const { return data(); }
-  __host__ __device__ constexpr size_t size() const { return 0; }
-  __host__ __device__ constexpr bool empty() const { return true; }
-  __host__ __device__ inline T *data() { return reinterpret_cast<T*>(this); }
-  __host__ __device__ constexpr const T *data() const { return reinterpret_cast<const T*>(this); }
+  __host__ __device__ inline T *begin() noexcept { return data(); }
+  __host__ __device__ constexpr const T *begin() const noexcept{ return data(); }
+  __host__ __device__ constexpr const T *cbegin() const noexcept{ return data(); }
+  __host__ __device__ inline T *end() noexcept { return data(); }
+  __host__ __device__ constexpr const T *end() const noexcept { return data(); }
+  __host__ __device__ constexpr const T *cend() const noexcept{ return data(); }
+  __host__ __device__ constexpr size_t size() const noexcept{ return 0; }
+  __host__ __device__ constexpr bool empty() const noexcept{ return true; }
+
+  __host__ __device__ inline T *data() noexcept {
+    return reinterpret_cast<T*>(this);
+  }
+  __host__ __device__ constexpr const T *data() const noexcept {
+    return reinterpret_cast<const T*>(this);
+  }
 };
+
+
+template <typename T>
+constexpr __host__ __device__ volume_t<T> volume(const DeviceArray<T, 0> &) {
+  return 0;
+}
+
+template <typename T, size_t N>
+__host__ __device__ volume_t<T> volume(const DeviceArray<T, N> &arr) {
+  volume_t<T> v = arr[0];
+  for (size_t i = 1; i < N; i++) {
+    v *= arr[i];
+  }
+  return v;
+}
 
 }  // namespace dali
 

--- a/include/dali/core/dev_string.h
+++ b/include/dali/core/dev_string.h
@@ -86,10 +86,36 @@ struct DeviceString {
     return *this;
   }
 
+  __device__ DeviceString operator+(const DeviceString &other) {
+    size_t l1 = length();
+    size_t l2 = other.length();
+    if (!l2)
+      return *this;
+    if (!l1)
+      return other;
+    DeviceString result;
+    result.data_ = static_cast<char*>(malloc(l1+l2+1));
+    for (size_t i = 0; i < l1; i++)
+      result.data_[i] = data_[i];
+    for (size_t i = 0; i < l2; i++)
+      result.data_[i + l1] = other.data_[i];
+    result.data_[l1+l2] = 0;
+    result.length_ = l1+l2;
+    return result;
+  }
+
   __device__ DeviceString &operator=(DeviceString &&other) {
     cuda_swap(data_, other.data_);
     cuda_swap(length_, other.length_);
     return *this;
+  }
+
+  __device__ DeviceString &operator+=(const DeviceString &other) {
+    if (!other.length())
+      return *this;
+    if (!length())
+      return *this = other;
+    return *this = (*this + other);
   }
 
   __device__ char &operator[](ptrdiff_t idx) { return data_[idx]; }

--- a/include/dali/core/host_dev.h
+++ b/include/dali/core/host_dev.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/dali/core/host_dev.h
+++ b/include/dali/core/host_dev.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_HOST_DEV_H_
+#define DALI_CORE_HOST_DEV_H_
+
+#if defined(__CUDACC__) && !(defined(__CUDA__) && defined(__clang__))
+#define DALI_NO_EXEC_CHECK #pragma nv_exec_check_disable
+#else
+#define DALI_NO_EXEC_CHECK
+#endif
+
+#if defined(__CUDACC__)
+#define DALI_HOST_DEV __host__ __device__
+#else
+#define DALI_HOST_DEV
+#endif
+
+#endif  // DALI_CORE_HOST_DEV_H_

--- a/include/dali/core/span.h
+++ b/include/dali/core/span.h
@@ -15,15 +15,10 @@
 #ifndef DALI_CORE_SPAN_H_
 #define DALI_CORE_SPAN_H_
 
-#if defined(__host__) || defined(__CUDACC__)
-#define DALI_HOST_DEVICE __host__ __device__
-#else
-#define DALI_HOST_DEVICE
-#endif
-
 #include <cstddef>
 #include <array>
 #include <type_traits>
+#include "dali/core/host_dev.h"
 
 namespace dali {
 
@@ -52,11 +47,11 @@ class span {
   // [span.cons], span constructors, copy, assignment, and destructor
   // This constructor shall not participate in overload resolution unless Extent <= 0 is true
   constexpr span() noexcept = delete;
-  DALI_HOST_DEVICE constexpr span(pointer ptr, index_type count = Extent) : data_(ptr) {  // NOLINT
+  DALI_HOST_DEV constexpr span(pointer ptr, index_type count = Extent) : data_(ptr) {  // NOLINT
     /* assert(count == Extent); */
   }
 
-  DALI_HOST_DEVICE constexpr span(pointer firstElem, pointer lastElem) : data_(firstElem) {
+  DALI_HOST_DEV constexpr span(pointer firstElem, pointer lastElem) : data_(firstElem) {
     /* assert(lastElem - firstElem == Extent); */
   }
 
@@ -66,22 +61,22 @@ class span {
   // [span.sub], span subviews
 
   // [span.obs], span observers
-  DALI_HOST_DEVICE constexpr index_type size() const noexcept { return Extent; }
-  DALI_HOST_DEVICE constexpr index_type size_bytes() const noexcept {
+  DALI_HOST_DEV constexpr index_type size() const noexcept { return Extent; }
+  DALI_HOST_DEV constexpr index_type size_bytes() const noexcept {
     return Extent * sizeof(value_type);
   }
-  DALI_HOST_DEVICE constexpr bool empty() const noexcept { return false; }
+  DALI_HOST_DEV constexpr bool empty() const noexcept { return false; }
 
   // [span.elem], span element access
-  DALI_HOST_DEVICE constexpr reference operator[](index_type idx) const { return data_[idx]; }
-  DALI_HOST_DEVICE constexpr reference operator()(index_type idx) const { return data_[idx]; }
-  DALI_HOST_DEVICE constexpr pointer data() const noexcept { return data_; }
+  DALI_HOST_DEV constexpr reference operator[](index_type idx) const { return data_[idx]; }
+  DALI_HOST_DEV constexpr reference operator()(index_type idx) const { return data_[idx]; }
+  DALI_HOST_DEV constexpr pointer data() const noexcept { return data_; }
 
   // [span.iterators], span iterator support
-  DALI_HOST_DEVICE constexpr iterator begin() const noexcept { return data_; }
-  DALI_HOST_DEVICE constexpr iterator end() const noexcept { return data_ + Extent; }
-  DALI_HOST_DEVICE constexpr const_iterator cbegin() const noexcept { return data_; }
-  DALI_HOST_DEVICE constexpr const_iterator cend() const noexcept { return data_ + Extent; }
+  DALI_HOST_DEV constexpr iterator begin() const noexcept { return data_; }
+  DALI_HOST_DEV constexpr iterator end() const noexcept { return data_ + Extent; }
+  DALI_HOST_DEV constexpr const_iterator cbegin() const noexcept { return data_; }
+  DALI_HOST_DEV constexpr const_iterator cend() const noexcept { return data_ + Extent; }
 
  private:
   pointer data_;
@@ -102,9 +97,9 @@ class span<ElementType, dynamic_extent> {
   static constexpr index_type extent = dynamic_extent;
 
   // [span.cons], span constructors, copy, assignment, and destructor
-  DALI_HOST_DEVICE constexpr span() noexcept : data_(nullptr), size_(0) {}
-  DALI_HOST_DEVICE constexpr span(pointer ptr, index_type count) : data_(ptr), size_(count) {}
-  DALI_HOST_DEVICE constexpr span(pointer firstElem, pointer lastElem)
+  DALI_HOST_DEV constexpr span() noexcept : data_(nullptr), size_(0) {}
+  DALI_HOST_DEV constexpr span(pointer ptr, index_type count) : data_(ptr), size_(count) {}
+  DALI_HOST_DEV constexpr span(pointer firstElem, pointer lastElem)
       : data_(firstElem), size_(lastElem - firstElem) {}
 
   constexpr span(const span &other) noexcept = default;
@@ -114,22 +109,22 @@ class span<ElementType, dynamic_extent> {
   // [span.sub], span subviews
 
   // [span.obs], span observers
-  DALI_HOST_DEVICE constexpr index_type size() const noexcept { return size_; }
-  DALI_HOST_DEVICE constexpr index_type size_bytes() const noexcept {
+  DALI_HOST_DEV constexpr index_type size() const noexcept { return size_; }
+  DALI_HOST_DEV constexpr index_type size_bytes() const noexcept {
     return size_ * sizeof(value_type);
   }
-  DALI_HOST_DEVICE constexpr bool empty() const noexcept { return size() == 0; }
+  DALI_HOST_DEV constexpr bool empty() const noexcept { return size() == 0; }
 
   // [span.elem], span element access
-  DALI_HOST_DEVICE constexpr reference operator[](index_type idx) const { return data_[idx]; }
-  DALI_HOST_DEVICE constexpr reference operator()(index_type idx) const { return data_[idx]; }
-  DALI_HOST_DEVICE constexpr pointer data() const noexcept { return data_; }
+  DALI_HOST_DEV constexpr reference operator[](index_type idx) const { return data_[idx]; }
+  DALI_HOST_DEV constexpr reference operator()(index_type idx) const { return data_[idx]; }
+  DALI_HOST_DEV constexpr pointer data() const noexcept { return data_; }
 
   // [span.iterators], span iterator support
-  DALI_HOST_DEVICE constexpr iterator begin() const noexcept { return data_; }
-  DALI_HOST_DEVICE constexpr iterator end() const noexcept { return data_ + size(); }
-  DALI_HOST_DEVICE constexpr const_iterator cbegin() const noexcept { return data_; }
-  DALI_HOST_DEVICE constexpr const_iterator cend() const noexcept { return data_ + size(); }
+  DALI_HOST_DEV constexpr iterator begin() const noexcept { return data_; }
+  DALI_HOST_DEV constexpr iterator end() const noexcept { return data_ + size(); }
+  DALI_HOST_DEV constexpr const_iterator cbegin() const noexcept { return data_; }
+  DALI_HOST_DEV constexpr const_iterator cend() const noexcept { return data_ + size(); }
 
  private:
   pointer data_;
@@ -138,7 +133,7 @@ class span<ElementType, dynamic_extent> {
 
 // [span.comparison], span comparison operators
 template <class ElementL, ptrdiff_t ExtentL, class ElementR, ptrdiff_t ExtentR>
-DALI_HOST_DEVICE /* constexpr */ bool
+DALI_HOST_DEV /* constexpr */ bool
 operator==(span<ElementL, ExtentL> l, span<ElementR, ExtentR> r) {
   if (l.size() != r.size()) {
     return false;
@@ -152,57 +147,55 @@ operator==(span<ElementL, ExtentL> l, span<ElementR, ExtentR> r) {
   return true;
 }
 template <class ElementL, ptrdiff_t ExtentL, class ElementR, ptrdiff_t ExtentR>
-DALI_HOST_DEVICE /* constexpr */ bool
+DALI_HOST_DEV /* constexpr */ bool
 operator!=(span<ElementL, ExtentL> l, span<ElementR, ExtentR> r) {
   return !(l == r);
 }
 
 // @brief Helper function for pre-C++17
 template <ptrdiff_t Extent, typename T>
-DALI_HOST_DEVICE constexpr span<T, Extent> make_span(T *data) { return { data }; }
+DALI_HOST_DEV constexpr span<T, Extent> make_span(T *data) { return { data }; }
 
 // @brief Helper function for pre-C++17
 template <ptrdiff_t Extent = dynamic_extent, typename T>
-DALI_HOST_DEVICE constexpr span<T, Extent> make_span(T *data, ptrdiff_t extent) {
+DALI_HOST_DEV constexpr span<T, Extent> make_span(T *data, ptrdiff_t extent) {
   return { data, extent };
 }
 
 template <typename Collection>
-DALI_HOST_DEVICE auto make_span(Collection &c)->decltype(make_span(c.data(), c.size())) {
+DALI_HOST_DEV auto make_span(Collection &c)->decltype(make_span(c.data(), c.size())) {
   return make_span(c.data(), c.size());
 }
 
 template <typename Collection>
-DALI_HOST_DEVICE auto make_span(Collection &&c)->decltype(make_span(c.data(), c.size())) {
+DALI_HOST_DEV auto make_span(Collection &&c)->decltype(make_span(c.data(), c.size())) {
   static_assert(!std::is_rvalue_reference<Collection&&>::value,
     "Cannot create a span from an r-value.");
   return make_span(c.data(), c.size());
 }
 
 template <typename T, size_t N>
-DALI_HOST_DEVICE constexpr span<T, N> make_span(std::array<T, N> &a) {
+DALI_HOST_DEV constexpr span<T, N> make_span(std::array<T, N> &a) {
   return { a.data() };
 }
 
 template <typename T, size_t N>
-DALI_HOST_DEVICE constexpr span<const T, N> make_span(const std::array<T, N> &a) {
+DALI_HOST_DEV constexpr span<const T, N> make_span(const std::array<T, N> &a) {
   return { a.data() };
 }
 
 template <typename T, size_t N>
-DALI_HOST_DEVICE constexpr span<const T, N> make_span(std::array<T, N> &&a) {
+DALI_HOST_DEV constexpr span<const T, N> make_span(std::array<T, N> &&a) {
   static_assert(!std::is_rvalue_reference<std::array<T, N> &&>::value,
     "Cannot create a span from an r-value.");
   return { a.data() };
 }
 
 template <typename T, size_t N>
-DALI_HOST_DEVICE constexpr span<const T, N> make_span(T (&a)[N]) {
+DALI_HOST_DEV constexpr span<const T, N> make_span(T (&a)[N]) {
   return { a };
 }
 
 }  // namespace dali
-
-#undef DALI_HOST_DEVICE
 
 #endif  // DALI_CORE_SPAN_H_

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -238,7 +238,9 @@ volume(Iter shape_begin, Iter shape_end) {
 
 /// @brief Returns the product of all elements in shape
 /// @param shape - an iterable collection of extents
+DALI_NO_EXEC_CHECK
 template <typename Shape>
+DALI_HOST_DEV
 inline auto volume(const Shape &shape)->decltype(volume(dali::begin(shape), dali::end(shape))) {
   return volume(dali::begin(shape), dali::end(shape));
 }


### PR DESCRIPTION
Change storage for static `TensorShape` to `DeviceArray`.
Add `DALI_HOST_DEV` and `DALI_NO_EXEC_CHECK` macros to add host/device qualifiers and suppress nvcc warnings.
Add host/device qualified `dali::begin` and `dali::end`.
