### PR TITLE
Bound installed torchvision version with present CUDA version in tests

### DIFF
--- a/dali/test/python/test_python_function_operator.py
+++ b/dali/test/python/test_python_function_operator.py
@@ -5,16 +5,15 @@ import nvidia.dali.ops as ops
 import nvidia.dali.types as types
 import numpy
 import random
-import torchvision.transforms as transforms
 from PIL import Image
 import os
 
 test_data_root = os.environ['DALI_EXTRA_PATH']
 images_dir = os.path.join(test_data_root, 'db', 'single', 'jpeg')
 
+
 def resize(image):
-    res = transforms.Resize((300, 300))
-    return numpy.array(res(Image.fromarray(image)))
+    return numpy.array(Image.fromarray(image).resize((300, 300)))
 
 
 class CommonPipeline(Pipeline):

--- a/qa/L0_python-self-test/test.sh
+++ b/qa/L0_python-self-test/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy opencv-python torchvision"
+pip_packages="nose numpy opencv-python pillow"
 
 pushd ../..
 

--- a/qa/L2_FW_iterators_perf/test.sh
+++ b/qa/L2_FW_iterators_perf/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="tensorflow-gpu torchvision mxnet-cu##CUDA_VERSION##"
+pip_packages="tensorflow-gpu torchvision mxnet-cu##CUDA_VERSION## torch"
 one_config_only=true
 
 pushd ../..

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -24,7 +24,8 @@ packages = {
             "mxnet-cu90" : ["1.4.0"],
             "mxnet-cu100" : ["1.4.0"],
             "tensorflow-gpu" : {"90": ["1.12.0", "1.11", "1.7"], "100": ["1.13.1"]},
-            "torch" : ["http://download.pytorch.org/whl/{cuda_v}/torch-1.1.0-{0}.whl"]
+            "torch" : ["http://download.pytorch.org/whl/{cuda_v}/torch-1.1.0-{0}.whl"],
+            "torchvision" : ["https://download.pytorch.org/whl/{cuda_v}/torchvision-0.3.0-{0}.whl"]
             }
 
 parser = argparse.ArgumentParser(description='Env setup helper')


### PR DESCRIPTION
- tests tend to install CUDA9 based torchvision package even for
  CUDA 10. Make it use the proper version.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>