### PR TITLE
Use SmallVector in TensorShape.

### DIFF
--- a/dali/core/small_vector_test.cc
+++ b/dali/core/small_vector_test.cc
@@ -386,4 +386,48 @@ TEST(SmallVector, Resize) {
   EXPECT_EQ(TestObj::zombies, 0);
 }
 
+TEST(SmallVector, FromVector) {
+  std::vector<TestObj> vec = { 1, 2, 3, 4 };
+  SmallVector<TestObj, 3> v1 = vec;
+  SmallVector<TestObj, 5> v2;
+  ASSERT_EQ(v1.size(), 4);
+  EXPECT_TRUE(v1.is_dynamic());
+  EXPECT_EQ(v1[0], 1);
+  EXPECT_EQ(v1[1], 2);
+  EXPECT_EQ(v1[2], 3);
+  EXPECT_EQ(v1[3], 4);
+  EXPECT_EQ(TestObj::total, 8);
+  EXPECT_EQ(TestObj::zombies, 0);
+
+  v2.push_back(666);
+  v2 = vec;
+  EXPECT_FALSE(v2.is_dynamic());
+  ASSERT_EQ(v2.size(), 4);
+  EXPECT_EQ(v2[0], 1);
+  EXPECT_EQ(v2[1], 2);
+  EXPECT_EQ(v2[2], 3);
+  EXPECT_EQ(v2[3], 4);
+  EXPECT_EQ(TestObj::total, 12);
+  EXPECT_EQ(TestObj::zombies, 0);
+}
+
+TEST(SmallVector, InitList) {
+  SmallVector<TestObj, 3> v = { 1, 2, 3 };
+  EXPECT_EQ(v[0], 1);
+  EXPECT_EQ(v[1], 2);
+  EXPECT_EQ(v[2], 3);
+  EXPECT_EQ(TestObj::total, 3);
+  EXPECT_EQ(TestObj::zombies, 0);
+}
+
+TEST(SmallVector, ToVector) {
+  SmallVector<TestObj, 3> sv = { 1, 2, 3 };
+  std::vector<TestObj> vec = sv.to_vector();
+  EXPECT_EQ(vec[0], 1);
+  EXPECT_EQ(vec[1], 2);
+  EXPECT_EQ(vec[2], 3);
+  EXPECT_EQ(TestObj::total, 6);
+  EXPECT_EQ(TestObj::zombies, 0);
+}
+
 }  // namespace dali

--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -159,13 +159,17 @@ struct TensorShapeBase {
   DALI_HOST_DEV TensorShapeBase(Container &&c) : shape(cuda_move(c)) {}  // NOLINT
 };
 
+using DynamicTensorShapeContainer = SmallVector<int64_t, 6>;
+
 /// @brief Dynamic TensorShape can be constructed from any Static TensorShape
 template <>
 struct TensorShape<DynamicDimensions>
-    : public TensorShapeBase<std::vector<int64_t>, DynamicDimensions> {
-  using Base = TensorShapeBase<std::vector<int64_t>, DynamicDimensions>;
+    : public TensorShapeBase<DynamicTensorShapeContainer, DynamicDimensions> {
+  using Base = TensorShapeBase<DynamicTensorShapeContainer, DynamicDimensions>;
 
-  TensorShape(const std::vector<int64_t> &s) : Base(s) {}  // NOLINT
+  TensorShape(const std::vector<int64_t> &s)  // NOLINT
+  : Base(DynamicTensorShapeContainer(s.data(), s.size())) {}
+  TensorShape(const DynamicTensorShapeContainer &s) : Base(s) {}  // NOLINT
 
   template <size_t N>
   TensorShape(const std::array<int64_t, N> &s)  // NOLINT

--- a/dali/kernels/test/tensor_view_test.cc
+++ b/dali/kernels/test/tensor_view_test.cc
@@ -74,8 +74,9 @@ TEST(TensorViewTest, Addressing) {
 }
 
 TEST(TensorViewTest, TypePromotion) {
-  TensorView<EmptyBackendTag, int, 3> tv{nullptr, {1, 2, 3}};
-  TensorView<EmptyBackendTag, const int, 3> tvc = tv;
+  int junk_data = 0;
+  TensorView<EmptyBackendTag, int, 10> tv{&junk_data, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}};
+  TensorView<EmptyBackendTag, const int, 10> tvc = tv;
   EXPECT_EQ(tvc.shape, tv.shape);
   EXPECT_EQ(tvc.data, tv.data);
   tvc = {};

--- a/dali/pipeline/operators/crop/slice_base.cc
+++ b/dali/pipeline/operators/crop/slice_base.cc
@@ -43,7 +43,7 @@ void RunHelper(Tensor<CPUBackend> &output,
 
     kernels::SliceCPU<OutputType, InputType, NumDims> kernel;
     kernels::KernelRequirements req = kernel.Setup(ctx, in_view, slice_args);
-    output.Resize(req.output_shapes[0][0].shape);
+    output.Resize(req.output_shapes[0][0].shape.to_vector());
 
     auto out_view = view<OutputType, NumDims>(output);
     kernel.Run(ctx, out_view, in_view, slice_args);

--- a/dali/pipeline/operators/resize/resize_base.cc
+++ b/dali/pipeline/operators/resize/resize_base.cc
@@ -186,7 +186,7 @@ void ResizeBase::RunCPU(Tensor<CPUBackend> &output,
   const auto &input_shape = input.shape();
 
   auto out_shape = kdata.requirements.output_shapes[0][0];
-  out_shape_[thread_idx] = out_shape.shape;
+  out_shape_[thread_idx] = out_shape.shape.to_vector();
 
   // Resize the output & run
   output.Resize(out_shape_[thread_idx]);

--- a/include/dali/core/small_vector.h
+++ b/include/dali/core/small_vector.h
@@ -18,6 +18,7 @@
 #include <cuda_runtime.h>
 #include <utility>
 #include <memory>
+#include <vector>
 #include "dali/kernels/alloc.h"
 #include "dali/core/util.h"
 #include "dali/core/cuda_utils.h"

--- a/include/dali/core/small_vector.h
+++ b/include/dali/core/small_vector.h
@@ -19,6 +19,7 @@
 #include <utility>
 #include <memory>
 #include "dali/kernels/alloc.h"
+#include "dali/core/util.h"
 #include "dali/core/cuda_utils.h"
 
 namespace dali {
@@ -119,6 +120,26 @@ class SmallVector : SmallVectorAlloc<T, allocator>, SmallVectorBase<T> {
   __host__ __device__ explicit SmallVector(allocator &&alloc) : Alloc(cuda_move(alloc)) {}
   __host__ __device__ explicit SmallVector(const allocator &alloc) : Alloc(alloc) {}
 
+  __host__ __device__ SmallVector(const T *data, size_t count) {
+    copy_assign(data, count);
+  }
+
+  template <typename Iterator>
+  __host__ __device__ SmallVector(Iterator begin, Iterator end) {
+    copy_assign(begin, end);
+  }
+
+  __host__ __device__ SmallVector(const std::vector<T> &v) {
+    *this = v;
+  }
+
+
+  __host__ __device__ SmallVector(std::initializer_list<T> il) {
+    auto *data = &*il.begin();
+    auto count = il.end() - il.begin();
+    copy_assign(data, count);
+  }
+
   __host__ __device__ ~SmallVector() {
     T *ptr = data();
     this->destroy(ptr, size());
@@ -153,6 +174,51 @@ class SmallVector : SmallVectorAlloc<T, allocator>, SmallVectorBase<T> {
     return *this;
   }
 
+  template <typename Collection>
+  __host__ __device__ if_array_like<Collection, SmallVector &> operator=(const Collection &c) {
+    auto n = dali::size(c);
+    clear();
+    reserve(n);
+    T *ptr = data();
+    for (size_t i = 0; i < n; i++) {
+      new(ptr+i) T(c[i]);
+      if (!noexcept(new(ptr+i) T(c[i])))
+        set_size(i+1);
+    }
+    set_size(n);
+    return *this;
+  }
+
+  template <typename Iterator>
+  __host__ __device__ void copy_assign(Iterator begin, Iterator end) {
+    auto n = end - begin;
+    clear();
+    reserve(n);
+    for (Iterator i = begin; i != end; i++) {
+      push_back(*i);
+    }
+  }
+
+  __host__ __device__ void copy_assign(const T *begin, const T *end) {
+    copy_assign(begin, end-begin);
+  }
+
+  __host__ __device__ void copy_assign(const T *data, size_t count) {
+    clear();
+    reserve(count);
+    T *ptr = this->data();
+    if (std::is_pod<T>::value) {
+      this->copy(ptr, data, count);
+      set_size(count);
+    } else {
+      for (size_t i = 0; i < count; i++) {
+        new(ptr+i) T(data[i]);
+        if (!noexcept(new(ptr+i) T(data[i])))
+          set_size(i+1);
+      }
+      set_size(count);
+    }
+  }
 
   template <size_t other_static_size, typename alloc>
   __host__ __device__ void copy_assign(const SmallVector<T, other_static_size, alloc> &v) {
@@ -510,6 +576,10 @@ class SmallVector : SmallVectorAlloc<T, allocator>, SmallVectorBase<T> {
         set_dynamic_data(new_data);
       set_capacity(new_capacity);
     }
+  }
+
+  __host__ std::vector<T> to_vector() const {
+    return std::vector<T>(begin(), end());
   }
 
  private:


### PR DESCRIPTION
Add conversions and constructors to SmallVector.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>