### PR TITLE
Add GTC 2019 video and presentation do the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -458,7 +458,11 @@ Also note:
 Additional resources
 --------------------
 
-- GPU Technology Conference 2018 presentation about DALI, T. Gale, S. Layton and P. Tredak: `slides <http://on-demand.gputechconf.com/gtc/2018/presentation/s8906-fast-data-pipelines-for-deep-learning-training.pdf>`_, `recording <http://on-demand.gputechconf.com/gtc/2018/video/S8906/>`_.
+- GPU Technology Conference 2018; Fast data pipeline for deep learning training, T. Gale, S. Layton and P. Trędak: `slides <http://on-demand.gputechconf.com/gtc/2018/presentation/s8906-fast-data-pipelines-for-deep-learning-training.pdf>`_, `recording <http://on-demand.gputechconf.com/gtc/2018/video/S8906/>`_.
+- GPU Technology Conference 2019; Fast AI data pre-preprocessing with DALI; Janusz Lisiecki, Michał Zientkiewicz: `slides <https://developer.download.nvidia.com/video/gputechconf/gtc/2019/presentation/s9925-fast-ai-data-pre-processing-with-nvidia-dali.pdf>`_, `recording <https://developer.nvidia.com/gtc/2019/video/S9925/video>`_.
+- GPU Technology Conference 2019; Integration of DALI with TensorRT on Xavier; Josh Park and Anurag Dixit: `slides <https://developer.download.nvidia.com/video/gputechconf/gtc/2019/presentation/s9818-integration-of-tensorrt-with-dali-on-xavier.pdf>`_, `recording <https://developer.nvidia.com/gtc/2019/video/S9818/video>`_.
+- `Developer page <https://developer.nvidia.com/DALI>`_.
+- `Blog post <https://devblogs.nvidia.com/fast-ai-data-preprocessing-with-nvidia-dali/>`_.
 
 ----
 


### PR DESCRIPTION
- adds a link to the presentation and video about DALI in GTC19
- adds a link to the presentation and video about DALI and TRT on Xavier
  in GTC19
- adds a link to the developer page
- adds a link to the blog post

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>