### PR TITLE
Update aarch64 build docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,10 +393,16 @@ Install Python bindings
 
     pip install dali/python
 
-.. installation-end-marker-do-not-remove
 
 Cross-compiling DALI C++ API for aarch64 Linux (Docker)
 -------------------------------------------------------
+
+.. note::
+
+  Support for aarch64 Linux platform is experimental. Some of the features are available only for
+  x86-64 target and they are turned off in this build. There is no support for DALI Python library
+  on aarch64 yet. Some Operators may not work as intended due to x86-64 specific implementations.
+
 Build the aarch64 Linux Build Container
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -414,31 +420,8 @@ From the root of the DALI source tree
 
 The relevant artifacts will be in ``build/install`` and ``build/dali/python/nvidia/dali``
 
-Cross-compiling DALI C++ API for aarch64 QNX (Docker)
------------------------------------------------------
-Setup
-^^^^^
-After aquiring the QNX Toolchain, place it in a directory called ``qnx`` in the root of the DALI tree.
-Then using the SDK Manager for NVIDIA DRIVE, select **QNX** as the *Target Operating System* and select **DRIVE OS 5.1.0.0 SDK**
-In STEP 02 under **Download & Install Options**, select *Download Now. Install Later*. and agree to the Terms and Conditions.
-Once downloaded move the **cuda-repo-cross-qnx** debian package into the ``qnx`` directory you created in the DALI tree.
+.. installation-end-marker-do-not-remove
 
-Build the aarch64 Build Container
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: bash
-
-    docker build -t dali_builder:aarch64-qnx -f Dockerfile.build.aarch64-qnx .
-
-Compile
-^^^^^^^
-From the root of the DALI source tree
-
-.. code-block:: bash
-
-    docker run -v $(pwd):/dali dali_builder:aarch64-qnx
-
-The relevant artifacts will be in ``build/install`` and ``build/dali/python/nvidia/dali``
 
 Getting started
 ---------------


### PR DESCRIPTION
* Add a note about build being experimental
* Remove instructions for QNX which is not supported yet

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>