### PR TITLE
Remove warning to make WERROR build possible

### DIFF
--- a/dali/pipeline/data/meta.h
+++ b/dali/pipeline/data/meta.h
@@ -53,7 +53,7 @@ class DALIMeta {
   }
 
  private:
-  DALITensorLayout layout_;
+  DALITensorLayout layout_ = DALITensorLayout::DALI_UNKNOWN;
   std::string source_info_;
   bool skip_sample_ = false;
 };


### PR DESCRIPTION
Init DALITensorLayout to remove warning

Signed-off-by: Albert Wolant <awolant@nvidia.com>