### PR TITLE
Add new SliceFlipNormalizePermute CPU kernel. 

### DIFF
--- a/dali/benchmark/CMakeLists.txt
+++ b/dali/benchmark/CMakeLists.txt
@@ -24,6 +24,7 @@ if (BUILD_BENCHMARK)
     "${CMAKE_CURRENT_SOURCE_DIR}/decoder_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/displacement_cpu_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/crop_bench.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/crop_mirror_normalize_bench.cc"
   )
 
   if (BUILD_LMDB)

--- a/dali/benchmark/crop_mirror_normalize_bench.cc
+++ b/dali/benchmark/crop_mirror_normalize_bench.cc
@@ -71,7 +71,7 @@ BENCHMARK_DEFINE_F(OperatorBench, CropMirrorNormalizeCPU)(benchmark::State& st) 
     batch_size, H, W, C);
 }
 
-BENCHMARK_REGISTER_F(OperatorBench, CropMirrorNormalizeCPU)->Iterations(100)
+BENCHMARK_REGISTER_F(OperatorBench, CropMirrorNormalizeCPU)->Iterations(500)
 ->Unit(benchmark::kMicrosecond)
 ->UseRealTime()
 ->Apply(CropMirrorNormalizeCPUArgs);
@@ -109,7 +109,7 @@ BENCHMARK_DEFINE_F(OperatorBench, NewCropMirrorNormalizeCPU)(benchmark::State& s
     batch_size, H, W, C);
 }
 
-BENCHMARK_REGISTER_F(OperatorBench, NewCropMirrorNormalizeCPU)->Iterations(100)
+BENCHMARK_REGISTER_F(OperatorBench, NewCropMirrorNormalizeCPU)->Iterations(500)
 ->Unit(benchmark::kMicrosecond)
 ->UseRealTime()
 ->Apply(CropMirrorNormalizeCPUArgs);

--- a/dali/benchmark/crop_mirror_normalize_bench.cc
+++ b/dali/benchmark/crop_mirror_normalize_bench.cc
@@ -1,0 +1,117 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+#include "dali/benchmark/operator_bench.h"
+#include "dali/benchmark/dali_bench.h"
+
+namespace dali {
+
+static void CropMirrorNormalizeCPUArgs(benchmark::internal::Benchmark *b) {
+  int batch_size = 1;
+  int mean = 128, std = 1;
+  for (auto &output_dtype : {DALI_FLOAT}) {
+    for (auto &output_layout : {DALI_NHWC, DALI_NCHW}) {
+      for (int mirror : {0, 1}) {
+        for (int pad : {0, 1}) {
+          for (int H = 1000; H >= 500; H /= 2) {
+            int W = H, C = 3;
+            int crop_h = static_cast<float>(9 * H / 10);
+            int crop_w = static_cast<float>(9 * W / 10);
+            b->Args({output_dtype, output_layout, mirror, pad,
+                     batch_size, H, W, C, crop_h, crop_w,
+                     mean, std});
+          }
+        }
+      }
+    }
+  }
+}
+
+BENCHMARK_DEFINE_F(OperatorBench, CropMirrorNormalizeCPU)(benchmark::State& st) {
+  DALIDataType output_dtype = static_cast<DALIDataType>(st.range(0));
+  DALITensorLayout output_layout = static_cast<DALITensorLayout>(st.range(1));
+  int mirror = st.range(2);
+  int pad = st.range(3);
+  int batch_size = st.range(4);
+  int H = st.range(5);
+  int W = st.range(6);
+  int C = st.range(7);
+  int crop_h = st.range(8);
+  int crop_w = st.range(9);
+  float mean = static_cast<float>(st.range(10));
+  float std = static_cast<float>(st.range(11));
+
+  this->RunCPU<uint8_t>(
+    st,
+    OpSpec("CropMirrorNormalize")
+      .AddArg("batch_size", batch_size)
+      .AddArg("num_threads", 1)
+      .AddArg("device", "cpu")
+      .AddArg("output_type", DALI_RGB)
+      .AddArg("output_layout", output_layout)
+      .AddArg("output_dtype", output_dtype)
+      .AddArg("crop", std::vector<float>{static_cast<float>(crop_h), static_cast<float>(crop_w)})
+      .AddArg("crop_pos_x", 0.5f)
+      .AddArg("crop_pos_y", 0.5f)
+      .AddArg("mean", std::vector<float>(C, mean))
+      .AddArg("std", std::vector<float>(C, std))
+      .AddArg("mirror", mirror),
+    batch_size, H, W, C);
+}
+
+BENCHMARK_REGISTER_F(OperatorBench, CropMirrorNormalizeCPU)->Iterations(100)
+->Unit(benchmark::kMicrosecond)
+->UseRealTime()
+->Apply(CropMirrorNormalizeCPUArgs);
+
+
+BENCHMARK_DEFINE_F(OperatorBench, NewCropMirrorNormalizeCPU)(benchmark::State& st) {
+  DALIDataType output_dtype = static_cast<DALIDataType>(st.range(0));
+  DALITensorLayout output_layout = static_cast<DALITensorLayout>(st.range(1));
+  int mirror = st.range(2);
+  int pad = st.range(3);
+  int batch_size = st.range(4);
+  int H = st.range(5);
+  int W = st.range(6);
+  int C = st.range(7);
+  int crop_h = st.range(8);
+  int crop_w = st.range(9);
+  float mean = static_cast<float>(st.range(10));
+  float std = static_cast<float>(st.range(11));
+
+  this->RunCPU<uint8_t>(
+    st,
+    OpSpec("NewCropMirrorNormalize")
+      .AddArg("batch_size", batch_size)
+      .AddArg("num_threads", 1)
+      .AddArg("device", "cpu")
+      .AddArg("output_type", DALI_RGB)
+      .AddArg("output_layout", output_layout)
+      .AddArg("output_dtype", output_dtype)
+      .AddArg("crop", std::vector<float>{static_cast<float>(crop_h), static_cast<float>(crop_w)})
+      .AddArg("crop_pos_x", 0.5f)
+      .AddArg("crop_pos_y", 0.5f)
+      .AddArg("mean", std::vector<float>(C, mean))
+      .AddArg("std", std::vector<float>(C, std))
+      .AddArg("mirror", mirror),
+    batch_size, H, W, C);
+}
+
+BENCHMARK_REGISTER_F(OperatorBench, NewCropMirrorNormalizeCPU)->Iterations(100)
+->Unit(benchmark::kMicrosecond)
+->UseRealTime()
+->Apply(CropMirrorNormalizeCPUArgs);
+
+}  // namespace dali

--- a/dali/benchmark/crop_mirror_normalize_bench.cc
+++ b/dali/benchmark/crop_mirror_normalize_bench.cc
@@ -19,7 +19,7 @@
 namespace dali {
 
 static void CropMirrorNormalizeCPUArgs(benchmark::internal::Benchmark *b) {
-  int batch_size = 1;
+  int batch_size = 8;
   int mean = 128, std = 1;
   for (auto &output_dtype : {DALI_FLOAT}) {
     for (auto &output_layout : {DALI_NHWC, DALI_NCHW}) {

--- a/dali/benchmark/operator_bench.h
+++ b/dali/benchmark/operator_bench.h
@@ -40,6 +40,7 @@ class OperatorBench : public DALIBenchmark {
       in_ptr = std::make_shared<Tensor<CPUBackend>>();
       in_ptr->set_type(TypeInfo::Create<T>());
       in_ptr->Resize({W, H, C});
+      in_ptr->SetLayout(DALI_NHWC);
     }
 
     for (auto &out_ptr : data_out) {
@@ -81,6 +82,7 @@ class OperatorBench : public DALIBenchmark {
     auto data_in_cpu = std::make_shared<TensorList<CPUBackend>>();
     data_in_cpu->set_type(TypeInfo::Create<T>());
     data_in_cpu->Resize(std::vector<Dims>(batch_size, {W, H, C}));
+    data_in_cpu->SetLayout(DALI_NHWC);
     if (fill_in_data) {
       for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
         auto *ptr = data_in_cpu->mutable_tensor<T>(sample_idx);

--- a/dali/benchmark/operator_bench.h
+++ b/dali/benchmark/operator_bench.h
@@ -42,6 +42,10 @@ class OperatorBench : public DALIBenchmark {
       in_ptr->Resize({W, H, C});
     }
 
+    for (auto &out_ptr : data_out) {
+      out_ptr = std::make_shared<Tensor<CPUBackend>>();
+    }
+
     if (fill_in_data) {
       for (auto &in_ptr : data_in) {
         auto *ptr = in_ptr->mutable_data<T>();

--- a/dali/kernels/slice/slice_flip_normalize_permute_common.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_common.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_UTILS_H_
-#define DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_UTILS_H_
+#ifndef DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_COMMON_H_
+#define DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_COMMON_H_
 
 #include <utility>
 #include <vector>
@@ -145,4 +145,4 @@ SliceFlipNormalizePermuteProcessedArgs<OutputType, Dims> ProcessArgs(
 }  // namespace kernels
 }  // namespace dali
 
-#endif  // DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_UTILS_H_
+#endif  // DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_COMMON_H_

--- a/dali/kernels/slice/slice_flip_normalize_permute_common.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_common.h
@@ -50,7 +50,7 @@ struct SliceFlipNormalizePermuteArgs {
 
 namespace detail {
 
-template <typename OutputType, size_t Dims>
+template <size_t Dims>
 struct SliceFlipNormalizePermuteProcessedArgs {
   size_t input_offset;
   std::array<int64_t, Dims> in_shape;
@@ -82,11 +82,11 @@ std::array<int64_t, Dims> inverse_permutation(const std::array<int64_t, Dims> &p
   return inv_perm;
 }
 
-template <typename OutputType, size_t Dims, typename Shape>
-SliceFlipNormalizePermuteProcessedArgs<OutputType, Dims> ProcessArgs(
+template <size_t Dims, typename Shape>
+SliceFlipNormalizePermuteProcessedArgs<Dims> ProcessArgs(
     const SliceFlipNormalizePermuteArgs<Dims> &args,
     const Shape &in_shape) {
-  SliceFlipNormalizePermuteProcessedArgs<OutputType, Dims> processed_args;
+  SliceFlipNormalizePermuteProcessedArgs<Dims> processed_args;
 
   processed_args.input_offset = 0;
   processed_args.in_strides = GetStrides<Dims>(in_shape);

--- a/dali/kernels/slice/slice_flip_normalize_permute_common.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_common.h
@@ -1,0 +1,148 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_UTILS_H_
+#define DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_UTILS_H_
+
+#include <utility>
+#include <vector>
+#include "dali/core/common.h"
+#include "dali/kernels/kernel.h"
+#include "dali/kernels/slice/slice_kernel_test.h"
+
+namespace dali {
+namespace kernels {
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormalizePermuteArgs {
+  std::array<int64_t, Dims> anchor;
+  std::array<int64_t, Dims> shape;
+
+  bool should_pad = false;
+  std::array<int64_t, Dims> padded_shape;
+
+  bool should_flip = false;
+  std::array<bool, Dims> flip;
+
+  bool should_permute = false;
+  std::array<int64_t, Dims> permuted_dims;
+
+  bool should_normalize = false;
+  size_t normalization_dim = Dims-1;
+  size_t normalization_index = 0;
+  std::vector<float> mean;
+  std::vector<float> inv_stddev;
+};
+
+namespace detail {
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormalizePermuteProcessedArgs {
+  size_t input_offset;
+  std::array<int64_t, Dims> in_shape;
+  std::array<int64_t, Dims> in_strides;
+  std::array<int64_t, Dims> out_shape;
+  std::array<int64_t, Dims> padded_out_shape;
+  std::array<int64_t, Dims> out_strides;
+  std::vector<float> mean;
+  std::vector<float> inv_stddev;
+  size_t normalization_dim;
+};
+
+template <size_t Dims, typename Container>
+Container permute(const Container &container, const std::array<int64_t, Dims> &permuted_dims) {
+  auto permuted_container = container;
+  for (size_t d = 0; d < Dims; d++) {
+    permuted_container[d] = container[permuted_dims[d]];
+  }
+  return permuted_container;
+}
+
+template <size_t Dims>
+std::array<int64_t, Dims> inverse_permutation(const std::array<int64_t, Dims> &permutation) {
+  std::array<int64_t, Dims> inv_perm = permutation;
+  for (size_t d = 0; d < Dims; d++) {
+    auto perm_d = permutation[d];
+    inv_perm[perm_d] = d;
+  }
+  return inv_perm;
+}
+
+template <typename OutputType, size_t Dims, typename Shape>
+SliceFlipNormalizePermuteProcessedArgs<OutputType, Dims> ProcessArgs(
+    const SliceFlipNormalizePermuteArgs<OutputType, Dims> &args,
+    const Shape &in_shape) {
+  SliceFlipNormalizePermuteProcessedArgs<OutputType, Dims> processed_args;
+
+  processed_args.input_offset = 0;
+  processed_args.in_strides = GetStrides<Dims>(in_shape);
+
+  auto slice_shape = args.shape;
+  processed_args.out_shape = slice_shape;
+  processed_args.padded_out_shape = args.should_pad ? args.padded_shape : args.shape;
+
+  if (args.should_permute) {
+    processed_args.out_shape = detail::permute<Dims>(processed_args.out_shape, args.permuted_dims);
+    processed_args.padded_out_shape =
+        detail::permute<Dims>(processed_args.padded_out_shape, args.permuted_dims);
+  }
+  processed_args.out_strides = GetStrides<Dims>(processed_args.padded_out_shape);
+
+  // Flip operation is implemented by manipulating the anchor and the sign of the input strides
+  if (args.should_flip) {
+    for (size_t d = 0; d < Dims; d++) {
+      if (args.flip[d]) {
+        processed_args.input_offset +=
+            (args.anchor[d] + slice_shape[d] - 1) * processed_args.in_strides[d];
+        processed_args.in_strides[d] = -processed_args.in_strides[d];
+      } else {
+        processed_args.input_offset += args.anchor[d] * processed_args.in_strides[d];
+      }
+    }
+  } else {
+    for (size_t d = 0; d < Dims; d++) {
+      processed_args.input_offset += args.anchor[d] * processed_args.in_strides[d];
+    }
+  }
+
+  if (args.should_permute) {
+    processed_args.in_strides = detail::permute(processed_args.in_strides, args.permuted_dims);
+  }
+
+  processed_args.normalization_dim = args.normalization_dim;
+  if (args.should_normalize) {
+    processed_args.mean = args.mean;
+    DALI_ENFORCE(!processed_args.mean.empty());
+    processed_args.inv_stddev = args.inv_stddev;
+    DALI_ENFORCE(!processed_args.inv_stddev.empty());
+
+    if (args.should_permute) {
+      processed_args.normalization_dim =
+          detail::inverse_permutation(args.permuted_dims)[processed_args.normalization_dim];
+    }
+
+    // Detect the case where the last dimension is flipped
+    if (args.should_flip && args.flip[Dims - 1]) {
+      std::reverse(processed_args.mean.begin(), processed_args.mean.end());
+      std::reverse(processed_args.inv_stddev.begin(), processed_args.inv_stddev.end());
+    }
+  }
+  return processed_args;
+}
+}  // namespace detail
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_UTILS_H_

--- a/dali/kernels/slice/slice_flip_normalize_permute_cpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_cpu.h
@@ -51,8 +51,8 @@ struct NormalizePolicy {
 
 template <typename OutputType, size_t Dims>
 inline void ZeroPad(OutputType *output,
-                    const std::array<int64_t, Dims> out_strides,
-                    const std::array<int64_t, Dims> padded_out_shape,
+                    std::array<int64_t, Dims> out_strides,
+                    std::array<int64_t, Dims> padded_out_shape,
                     std::integral_constant<size_t, 1>) {
   constexpr auto d = Dims - 1;
   // zero pad
@@ -64,8 +64,8 @@ inline void ZeroPad(OutputType *output,
 
 template <typename OutputType, size_t Dims, size_t DimsLeft>
 inline void ZeroPad(OutputType *output,
-                    const std::array<int64_t, Dims> out_strides,
-                    const std::array<int64_t, Dims> padded_out_shape,
+                    std::array<int64_t, Dims> out_strides,
+                    std::array<int64_t, Dims> padded_out_shape,
                     std::integral_constant<size_t, DimsLeft>) {
   constexpr auto d = Dims - DimsLeft;
   // zero pad
@@ -79,10 +79,10 @@ inline void ZeroPad(OutputType *output,
 template <typename Policy, bool IsNormalizationDim, typename OutputType, typename InputType,
           size_t Dims>
 inline void SliceFlipNormalizePermuteImpl(OutputType *output, const InputType *input,
-                                          const std::array<int64_t, Dims> in_strides,
-                                          const std::array<int64_t, Dims> out_strides,
-                                          const std::array<int64_t, Dims> out_shape,
-                                          const std::array<int64_t, Dims> padded_out_shape,
+                                          std::array<int64_t, Dims> in_strides,
+                                          std::array<int64_t, Dims> out_strides,
+                                          std::array<int64_t, Dims> out_shape,
+                                          std::array<int64_t, Dims> padded_out_shape,
                                           const float *mean, const float *inv_stddev,
                                           size_t normalization_dim,
                                           std::integral_constant<size_t, 1>) {
@@ -105,10 +105,10 @@ inline void SliceFlipNormalizePermuteImpl(OutputType *output, const InputType *i
 template <typename Policy, bool IsNormalizationDim, typename OutputType, typename InputType,
           size_t Dims, size_t DimsLeft>
 inline void SliceFlipNormalizePermuteImpl(OutputType *output, const InputType *input,
-                                          const std::array<int64_t, Dims> in_strides,
-                                          const std::array<int64_t, Dims> out_strides,
-                                          const std::array<int64_t, Dims> out_shape,
-                                          const std::array<int64_t, Dims> padded_out_shape,
+                                          std::array<int64_t, Dims> in_strides,
+                                          std::array<int64_t, Dims> out_strides,
+                                          std::array<int64_t, Dims> out_shape,
+                                          std::array<int64_t, Dims> padded_out_shape,
                                           const float *mean, const float *inv_stddev,
                                           size_t normalization_dim,
                                           std::integral_constant<size_t, DimsLeft>) {

--- a/dali/kernels/slice/slice_flip_normalize_permute_cpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_cpu.h
@@ -70,8 +70,8 @@ inline void ZeroPad(OutputType *output,
   constexpr auto d = Dims - DimsLeft;
   // zero pad
   for (int64_t i = 0; i < padded_out_shape[d]; i++) {
-    ZeroPad<OutputType>(output, out_strides, padded_out_shape,
-                        std::integral_constant<size_t, DimsLeft - 1>());
+    ZeroPad(output, out_strides, padded_out_shape,
+            std::integral_constant<size_t, DimsLeft - 1>());
     output += out_strides[d];
   }
 }
@@ -136,8 +136,8 @@ inline void SliceFlipNormalizePermuteImpl(OutputType *output, const InputType *i
 
   // zero pad
   for (; i < padded_out_shape[d]; i++) {
-    ZeroPad<OutputType>(output, out_strides, padded_out_shape,
-                        std::integral_constant<size_t, DimsLeft - 1>());
+    ZeroPad(output, out_strides, padded_out_shape,
+            std::integral_constant<size_t, DimsLeft - 1>());
     output += out_strides[d];
   }
 }
@@ -206,7 +206,7 @@ class SliceFlipNormalizePermuteCPU {
            OutTensorCPU<OutputType, Dims> &out,
            const InTensorCPU<InputType, Dims> &in,
            const Args &args) {
-    auto processed_args = detail::ProcessArgs<OutputType, Dims>(args, in.shape);
+    auto processed_args = detail::ProcessArgs<Dims>(args, in.shape);
     detail::SliceFlipNormalizePermute(
         out.data, in.data + processed_args.input_offset, processed_args.in_strides,
         processed_args.out_strides, processed_args.out_shape, processed_args.padded_out_shape,

--- a/dali/kernels/slice/slice_flip_normalize_permute_cpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_cpu.h
@@ -162,10 +162,9 @@ class SliceFlipNormalizePermuteCPU {
            const Args &args) {
     auto processed_args = detail::ProcessArgs<OutputType, Dims>(args, in.shape);
     detail::SliceFlipNormalizePermute(
-        out.data, in.data + processed_args.input_offset, processed_args.in_strides, processed_args.out_strides,
-        processed_args.out_shape, processed_args.padded_out_shape,
-        processed_args.mean, processed_args.inv_stddev,
-        processed_args.normalization_dim);
+        out.data, in.data + processed_args.input_offset, processed_args.in_strides,
+        processed_args.out_strides, processed_args.out_shape, processed_args.padded_out_shape,
+        processed_args.mean, processed_args.inv_stddev, processed_args.normalization_dim);
   }
 };
 

--- a/dali/kernels/slice/slice_flip_normalize_permute_cpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_cpu.h
@@ -1,0 +1,272 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_CPU_H_
+#define DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_CPU_H_
+
+#include <utility>
+#include <vector>
+#include "dali/core/common.h"
+#include "dali/core/convert.h"
+#include "dali/core/error_handling.h"
+#include "dali/kernels/kernel.h"
+#include "dali/kernels/slice/slice_kernel_utils.h"
+#include "dali/util/half.hpp"
+
+namespace dali {
+namespace kernels {
+
+namespace detail {
+
+struct ClampPolicy {
+  template <typename OutputType, typename InputType>
+  static inline void Fill(OutputType &destination, InputType element,
+                          const float *mean, const float *inv_stddev) {
+    (void) mean;
+    (void) inv_stddev;
+    destination = clamp<OutputType>(element);
+  }
+};
+
+struct NormalizePolicy {
+  template <typename OutputType, typename InputType>
+  static inline void Fill(OutputType &destination, InputType element,
+                          const float *mean, const float *inv_stddev) {
+    destination = clamp<OutputType>(
+      (static_cast<float>(element) - (*mean)) * (*inv_stddev));
+  }
+};
+
+struct ZeroPadPolicy {
+  template <typename OutputType, typename InputType>
+  static inline void Fill(OutputType &destination, InputType element,
+                          const float *mean, const float *inv_stddev) {
+    (void)element;
+    (void)mean;
+    (void)inv_stddev;
+    destination = static_cast<OutputType>(0);
+  }
+};
+
+template <typename Policy, typename OutputType, typename InputType, size_t Dims>
+void SliceFlipNormalizePermuteImpl(OutputType *output, const InputType *input,
+                                   const std::array<int64_t, Dims> &in_strides,
+                                   const std::array<int64_t, Dims> &out_strides,
+                                   const TensorShape<static_cast<int>(Dims)> &out_shape,
+                                   const TensorShape<static_cast<int>(Dims)> &padded_out_shape,
+                                   const float *mean, const float *inv_stddev,
+                                   size_t normalization_dim,
+                                   const int64_t *permuted_dims,
+                                   std::integral_constant<size_t, 1>) {
+  constexpr auto d = Dims - 1;
+  for (int i = 0; i < out_shape[d]; i++) {
+    size_t norm_idx = normalization_dim == d ? i : 0;
+    Policy::Fill(*output, *input, mean + norm_idx, inv_stddev + norm_idx);
+    input += in_strides[d];
+    output += out_strides[d];
+  }
+
+  for (int i = out_shape[d]; i < padded_out_shape[d]; i++) {
+    size_t norm_idx = normalization_dim == d ? i : 0;
+    ZeroPadPolicy::Fill(*output, *input, mean + norm_idx, inv_stddev + norm_idx);
+    input += in_strides[d];
+    output += out_strides[d];
+  }
+}
+
+template <typename Policy, typename OutputType, typename InputType, size_t Dims, size_t DimsLeft>
+void SliceFlipNormalizePermuteImpl(OutputType *output, const InputType *input,
+                                   const std::array<int64_t, Dims> &in_strides,
+                                   const std::array<int64_t, Dims> &out_strides,
+                                   const TensorShape<static_cast<int>(Dims)> &out_shape,
+                                   const TensorShape<static_cast<int>(Dims)> &padded_out_shape,
+                                   const float *mean, const float *inv_stddev,
+                                   size_t normalization_dim,
+                                   const int64_t *permuted_dims,
+                                   std::integral_constant<size_t, DimsLeft>) {
+  constexpr auto d = Dims - DimsLeft;
+
+  for (int i = 0; i < out_shape[d]; i++) {
+    size_t norm_idx = normalization_dim == d ? i : 0;
+    SliceFlipNormalizePermuteImpl<Policy>(output, input, in_strides, out_strides, out_shape,
+                                          padded_out_shape, mean + norm_idx, inv_stddev + norm_idx,
+                                          normalization_dim, permuted_dims,
+                                          std::integral_constant<size_t, DimsLeft - 1>());
+    input += in_strides[d];
+    output += out_strides[d];
+  }
+
+  for (int i = out_shape[d]; i < padded_out_shape[d]; i++) {
+    size_t norm_idx = normalization_dim == d ? i : 0;
+    SliceFlipNormalizePermuteImpl<ZeroPadPolicy>(
+        output, input, in_strides, out_strides, out_shape, padded_out_shape, mean + norm_idx,
+        inv_stddev + norm_idx, normalization_dim, permuted_dims,
+        std::integral_constant<size_t, DimsLeft - 1>());
+    input += in_strides[d];
+    output += out_strides[d];
+  }
+}
+
+template <typename OutputType, typename InputType, size_t Dims>
+void SliceFlipNormalizePermute(OutputType *output, const InputType *input,
+                               const std::array<int64_t, Dims> &in_strides,
+                               const std::array<int64_t, Dims> &out_strides,
+                               const TensorShape<static_cast<int>(Dims)> &out_shape,
+                               const TensorShape<static_cast<int>(Dims)> &padded_out_shape,
+                               const std::vector<float> &mean,
+                               const std::vector<float> &inv_stddev,
+                               size_t normalization_dim,
+                               const int64_t *permuted_dims) {
+  const bool should_normalize = !mean.empty() && !inv_stddev.empty();
+  if (should_normalize) {
+    detail::SliceFlipNormalizePermuteImpl<NormalizePolicy>(
+        output, input, in_strides, out_strides, out_shape, padded_out_shape,
+        mean.data(), inv_stddev.data(), normalization_dim, permuted_dims,
+        std::integral_constant<size_t, Dims>());
+  } else {
+    detail::SliceFlipNormalizePermuteImpl<ClampPolicy>(
+        output, input, in_strides, out_strides, out_shape, padded_out_shape,
+        nullptr, nullptr, normalization_dim, permuted_dims,
+        std::integral_constant<size_t, Dims>());
+  }
+}
+
+template <size_t Dims, typename Container>
+Container permute(const Container &container, const std::array<int64_t, Dims> &permuted_dims) {
+  auto permuted_container = container;
+  for (size_t d = 0; d < Dims; d++) {
+    permuted_container[d] = container[permuted_dims[d]];
+  }
+  return permuted_container;
+}
+
+template <size_t Dims>
+std::array<int64_t, Dims> inverse_permutation(const std::array<int64_t, Dims> &permutation) {
+  std::array<int64_t, Dims> inv_perm = permutation;
+  for (size_t d = 0; d < Dims; d++) {
+    auto perm_d = permutation[d];
+    inv_perm[perm_d] = d;
+  }
+  return inv_perm;
+}
+
+}  // namespace detail
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormalizePermuteArgs {
+  std::array<int64_t, Dims> anchor;
+  std::array<int64_t, Dims> shape;
+
+  bool should_pad = false;
+  std::array<int64_t, Dims> padded_shape;
+
+  bool should_flip = false;
+  std::array<bool, Dims> flip;
+
+  bool should_permute = false;
+  std::array<int64_t, Dims> permuted_dims;
+
+  bool should_normalize = false;
+  size_t normalization_dim = Dims-1;
+  size_t normalization_index = 0;
+  std::vector<float> mean;
+  std::vector<float> inv_stddev;
+};
+
+template <typename OutputType, typename InputType, size_t Dims>
+class SliceFlipNormalizePermuteCPU {
+ public:
+  using Args = SliceFlipNormalizePermuteArgs<OutputType, Dims>;
+
+  KernelRequirements Setup(KernelContext &context,
+                           const InTensorCPU<InputType, Dims> &in,
+                           const Args &args) {
+    KernelRequirements req;
+    TensorShape<Dims> out_shape(args.shape);
+    CheckValidOutputShape<Dims>(in.shape, out_shape, args);
+
+    if (args.should_pad) {
+      out_shape = TensorShape<Dims>(args.padded_shape);
+    }
+
+    if (args.should_permute) {
+      out_shape = detail::permute<Dims>(out_shape, args.permuted_dims);
+    }
+    req.output_shapes.push_back(uniform_list_shape<Dims>(1, out_shape));
+    return req;
+  }
+
+  void Run(KernelContext &context,
+           OutTensorCPU<OutputType, Dims> &out,
+           const InTensorCPU<InputType, Dims> &in,
+           const Args &args) {
+    const auto *input = in.data;
+    auto in_strides = GetStrides<Dims>(in.shape);
+
+    auto slice_shape = args.shape;
+    auto non_padded_out_shape = args.should_permute ?
+      detail::permute<Dims>(slice_shape, args.permuted_dims) :
+      slice_shape;
+    auto padded_out_shape = out.shape;
+    auto out_strides = GetStrides<Dims>(padded_out_shape);
+
+    // Flip operation is implemented by manipulating the anchor
+    // and the sign of the input strides
+    if (args.should_flip) {
+      for (size_t d = 0; d < Dims; d++) {
+        if (args.flip[d]) {
+          input += (args.anchor[d] + slice_shape[d] - 1) * in_strides[d];
+          in_strides[d] = -in_strides[d];
+        } else {
+          input += args.anchor[d] * in_strides[d];
+        }
+      }
+    } else {
+      for (size_t d = 0; d < Dims; d++) {
+        input += args.anchor[d] * in_strides[d];
+      }
+    }
+
+    if (args.should_permute) {
+      in_strides = detail::permute(in_strides, args.permuted_dims);
+    }
+
+    std::vector<float> mean, inv_stddev;
+    size_t normalization_dim = args.normalization_dim;
+    if (args.should_normalize) {
+      mean = args.mean;
+      DALI_ENFORCE(!mean.empty());
+      inv_stddev = args.inv_stddev;
+      DALI_ENFORCE(!inv_stddev.empty());
+
+      if (args.should_permute) {
+        normalization_dim = detail::inverse_permutation(args.permuted_dims)[normalization_dim];
+      }
+
+      // Detect the case where the last dimension is flipped
+      if (args.should_flip && args.flip[Dims - 1]) {
+        std::reverse(mean.begin(), mean.end());
+        std::reverse(inv_stddev.begin(), inv_stddev.end());
+      }
+    }
+    detail::SliceFlipNormalizePermute(out.data, input, in_strides, out_strides,
+                                      non_padded_out_shape, padded_out_shape, mean, inv_stddev,
+                                      normalization_dim, nullptr);
+  }
+};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_CPU_H_

--- a/dali/kernels/slice/slice_flip_normalize_permute_cpu_test.cc
+++ b/dali/kernels/slice/slice_flip_normalize_permute_cpu_test.cc
@@ -14,21 +14,22 @@
 
 #include <gtest/gtest.h>
 #include "dali/kernels/slice/slice_kernel_test.h"
-#include "dali/kernels/slice/slice_cpu.h"
+#include "dali/kernels/slice/slice_flip_normalize_permute_cpu.h"
+#include "dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h"
 
 namespace dali {
 namespace kernels {
 
 template <typename TestArgs>
-class SliceCPUTest : public SliceTest<TestArgs> {
+class SliceFlipNormalizePermuteCPUTest : public SliceFlipNormalizePermuteTest<TestArgs> {
  public:
   using InputType = typename TestArgs::InputType;
   using OutputType = typename TestArgs::OutputType;
-  static constexpr std::size_t Dims = TestArgs::Dims;
-  static constexpr std::size_t NumSamples = TestArgs::NumSamples;
-  static constexpr std::size_t DimSize = TestArgs::DimSize;
+  static constexpr size_t Dims = TestArgs::Dims;
+  static constexpr size_t NumSamples = TestArgs::NumSamples;
+  static constexpr size_t DimSize = TestArgs::DimSize;
   using ArgsGenerator = typename TestArgs::ArgsGenerator;
-  using KernelType = SliceCPU<OutputType, InputType, Dims>;
+  using KernelType = SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims>;
 
   void Run() override {
     KernelContext ctx;
@@ -37,47 +38,45 @@ class SliceCPUTest : public SliceTest<TestArgs> {
     this->PrepareData(test_data);
 
     auto test_data_cpu = test_data.cpu();
-    auto slice_args = this->GenerateArgs(test_data_cpu);
+    auto args = this->GenerateArgs(test_data_cpu);
 
     TestTensorList<OutputType, Dims> expected_output;
-    this->PrepareExpectedOutput(test_data, slice_args, expected_output);
+    this->PrepareExpectedOutput(test_data, args, expected_output);
 
     TensorListShape<> output_shapes;
     output_shapes.resize(NumSamples, Dims);
     std::vector<KernelType> kernels(NumSamples);
-    for (std::size_t i = 0; i < NumSamples; i++) {
+    for (size_t i = 0; i < NumSamples; i++) {
       auto &kernel = kernels[i];
-      KernelRequirements kernel_req = kernel.Setup(ctx, test_data_cpu[i], slice_args[i]);
+      KernelRequirements kernel_req = kernel.Setup(ctx, test_data_cpu[i], args[i]);
       TensorShape<Dims> output_shape = kernel_req.output_shapes[0][0].to_static<Dims>();
-      AssertExpectedDimensions(output_shape, slice_args[i].shape);
+
+      auto padded_out_shape = args[i].should_pad ? args[i].padded_shape : args[i].shape;
+      auto expected_shape = padded_out_shape;
+      for (size_t d = 0; d < Dims; d++) {
+        size_t perm_d = args[i].should_permute ? args[i].permuted_dims[d] : d;
+        expected_shape[d] = padded_out_shape[perm_d];
+      }
+      AssertExpectedDimensions(output_shape, expected_shape);
       output_shapes.set_tensor_shape(i, output_shape);
     }
     TestTensorList<OutputType, Dims> output_data;
     output_data.reshape(std::move(output_shapes).to_static<Dims>());
     OutListCPU<OutputType, Dims> out_tlv = output_data.cpu();
 
-    for (std::size_t i = 0; i < NumSamples; i++) {
+    for (size_t i = 0; i < NumSamples; i++) {
       auto &kernel = kernels[i];
       auto out_tv = out_tlv[i];
       auto in_tv = test_data_cpu[i];
-      kernel.Run(ctx, out_tv, in_tv, slice_args[i]);
+      kernel.Run(ctx, out_tv, in_tv, args[i]);
     }
     EXPECT_NO_FATAL_FAILURE(Check(output_data.cpu(), expected_output.cpu()));
   }
 };
 
-TYPED_TEST_SUITE(SliceCPUTest, SLICE_TEST_TYPES);
+TYPED_TEST_SUITE(SliceFlipNormalizePermuteCPUTest, SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES);
 
-TYPED_TEST(SliceCPUTest, All) {
-  this->Run();
-}
-
-template <typename TestArgs>
-class SliceCPUTest_CPUOnlyTests : public SliceCPUTest<TestArgs> {};
-
-TYPED_TEST_SUITE(SliceCPUTest_CPUOnlyTests, SLICE_TEST_TYPES_CPU_ONLY);
-
-TYPED_TEST(SliceCPUTest_CPUOnlyTests, All) {
+TYPED_TEST(SliceFlipNormalizePermuteCPUTest, All) {
   this->Run();
 }
 

--- a/dali/kernels/slice/slice_flip_normalize_permute_cpu_test.cc
+++ b/dali/kernels/slice/slice_flip_normalize_permute_cpu_test.cc
@@ -51,10 +51,10 @@ class SliceFlipNormalizePermuteCPUTest : public SliceFlipNormalizePermuteTest<Te
       KernelRequirements kernel_req = kernel.Setup(ctx, test_data_cpu[i], args[i]);
       TensorShape<Dims> output_shape = kernel_req.output_shapes[0][0].to_static<Dims>();
 
-      auto padded_out_shape = args[i].should_pad ? args[i].padded_shape : args[i].shape;
+      auto padded_out_shape = args[i].padded_shape;
       auto expected_shape = padded_out_shape;
       for (size_t d = 0; d < Dims; d++) {
-        size_t perm_d = args[i].should_permute ? args[i].permuted_dims[d] : d;
+        size_t perm_d = args[i].permuted_dims[d];
         expected_shape[d] = padded_out_shape[perm_d];
       }
       AssertExpectedDimensions(output_shape, expected_shape);

--- a/dali/kernels/slice/slice_flip_normalize_permute_cpu_test.cc
+++ b/dali/kernels/slice/slice_flip_normalize_permute_cpu_test.cc
@@ -80,5 +80,16 @@ TYPED_TEST(SliceFlipNormalizePermuteCPUTest, All) {
   this->Run();
 }
 
+template <typename TestArgs>
+class SliceFlipNormalizePermuteCPUTest_CPUOnlyTests
+  : public SliceFlipNormalizePermuteCPUTest<TestArgs> {};
+
+TYPED_TEST_SUITE(SliceFlipNormalizePermuteCPUTest_CPUOnlyTests,
+                 SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES_CPU_ONLY);
+
+TYPED_TEST(SliceFlipNormalizePermuteCPUTest_CPUOnlyTests, All) {
+  this->Run();
+}
+
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include <string>
 #include "dali/kernels/slice/slice_kernel_test.h"
-#include "dali/kernels/slice/slice_flip_normalize_permute_cpu.h"
+#include "dali/kernels/slice/slice_flip_normalize_permute_common.h"
 
 namespace dali {
 namespace kernels {
@@ -423,7 +423,10 @@ using SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES = ::testing::Types<
     SliceTestArgs<uint8_t, float, 3, 1, 3,
       SliceFlipNormPermArgsGen_OnlyPad_GivenDim<float, 3, 0, 10>, 10, 10>,
     SliceTestArgs<int, bool, 3, 1, 2,
-      SliceFlipNormPermArgsGen_SliceOnly<bool, 3>>,
+      SliceFlipNormPermArgsGen_SliceOnly<bool, 3>>
+>;
+
+using SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES_CPU_ONLY = ::testing::Types<
     SliceTestArgs<uint8_t, float16_cpu, 3, 1, 2,
       SliceFlipNormPermArgsGen_SliceOnly<float16_cpu, 3>>,
     SliceTestArgs<float16_cpu, uint8_t, 3, 1, 2,

--- a/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
@@ -1,0 +1,436 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_KERNEL_TEST_H_
+#define DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_KERNEL_TEST_H_
+
+#include <gtest/gtest.h>
+#include <vector>
+#include <string>
+#include "dali/kernels/slice/slice_kernel_test.h"
+#include "dali/kernels/slice/slice_flip_normalize_permute_cpu.h"
+
+namespace dali {
+namespace kernels {
+
+template <typename TestArgs>
+class SliceFlipNormalizePermuteTest : public ::testing::Test {
+ public:
+  using InputType = typename TestArgs::InputType;
+  using OutputType = typename TestArgs::OutputType;
+  static constexpr size_t Dims = TestArgs::Dims;
+  static constexpr size_t NumSamples = TestArgs::NumSamples;
+  static constexpr size_t DimSize = TestArgs::DimSize;
+  static constexpr size_t DimSize0 = TestArgs::DimSize0;
+  static constexpr size_t DimSize1 = TestArgs::DimSize1;
+  using ArgsGenerator = typename TestArgs::ArgsGenerator;
+  using KernelArgs = SliceFlipNormalizePermuteArgs<OutputType, Dims>;
+
+  void PrepareData(TestTensorList<InputType, Dims>& test_data) {
+    std::vector<int> sample_dims(Dims, DimSize);
+    sample_dims[0] = DimSize0;
+    sample_dims[1] = DimSize1;
+    TensorListShape<Dims> shape = uniform_list_shape<Dims>(NumSamples, sample_dims);
+    test_data.reshape(shape);
+
+    InputType num = 0;
+    auto seq_gen = [&num]() { return num++; };
+    Fill(test_data.cpu(), seq_gen);
+  }
+
+  void PrepareExpectedOutput(TestTensorList<InputType, Dims>& input_data,
+                             std::vector<KernelArgs>& args,
+                             TestTensorList<OutputType, Dims>& output_data) {
+    auto in = input_data.cpu();
+    std::vector<TensorShape<Dims>> output_shapes;
+    std::vector<TensorShape<Dims>> slice_shapes;
+    for (int i = 0; i < in.size(); i++) {
+      auto shape = args[i].shape;
+      slice_shapes.push_back(shape);
+      auto padded_shape = args[i].should_pad ?
+        args[i].padded_shape : shape;
+      auto out_shape = padded_shape;
+      for (size_t d = 0; d < Dims; d++) {
+        auto perm_d = args[i].should_permute ? args[i].permuted_dims[d] : d;
+        out_shape[d] = padded_shape[perm_d];
+      }
+      TensorShape<Dims> out_sample_shape(out_shape);
+      output_shapes.push_back(out_sample_shape);
+    }
+    output_data.reshape(output_shapes);
+    auto out = output_data.cpu();
+
+    for (int i = 0; i < in.size(); i++) {
+      const auto& anchor = args[i].anchor;
+      const auto& flip = args[i].flip;
+      const auto *in_tensor = in.tensor_data(i);
+      auto *out_tensor = out.tensor_data(i);
+      const auto &permuted_dims = args[i].permuted_dims;
+      auto slice_shape = slice_shapes[i];
+      auto should_flip = args[i].should_flip;
+      auto should_permute = args[i].should_permute;
+      auto should_normalize = args[i].should_normalize;
+      auto should_pad = args[i].should_pad;
+
+      const auto in_shape = in.tensor_shape(i);
+      std::array<int64_t, Dims> in_strides = GetStrides<Dims>(in_shape);
+
+      const auto out_shape = out.tensor_shape(i);
+      std::array<int64_t, Dims> out_strides = GetStrides<Dims>(out_shape);
+
+      // normalization
+      auto mean = args[i].mean;
+      auto inv_stddev = args[i].inv_stddev;
+      // reverse channels if last dim flip was requested
+      if (should_normalize && should_flip && flip[Dims - 1]) {
+        std::reverse(mean.begin(), mean.end());
+        std::reverse(inv_stddev.begin(), inv_stddev.end());
+      }
+
+      // Very naive implementation just for test purposes
+      size_t total_size = volume(out_shape);
+      for (size_t out_idx = 0; out_idx < total_size; out_idx++) {
+        size_t idx = out_idx;
+        size_t in_idx = 0;
+        bool is_zero_pad = false;
+        for (size_t d = 0; d < Dims; d++) {
+          auto perm_d = should_permute ? permuted_dims[d] : d;
+          size_t i_d = idx / out_strides[d];
+          is_zero_pad = is_zero_pad ||
+            (out_shape[d] > slice_shape[perm_d] && i_d >= static_cast<size_t>(slice_shape[perm_d]));
+          idx = idx % out_strides[d];
+          auto offset = should_flip && flip[perm_d] ?
+            (anchor[perm_d] + slice_shape[perm_d] - 1 - i_d) * in_strides[perm_d] :
+            (anchor[perm_d] + i_d) * in_strides[perm_d];
+          in_idx += offset;
+        }
+
+        OutputType output_value = 0;
+        if (!is_zero_pad) {
+          if (should_normalize) {
+            auto c = out_idx % out_shape[Dims - 1];
+            output_value = (clamp<OutputType>(in_tensor[in_idx]) - mean[c]) * inv_stddev[c];
+          } else {
+            output_value = clamp<OutputType>(in_tensor[in_idx]);
+          }
+        }
+        out_tensor[out_idx] = output_value;
+      }
+    }
+  }
+
+  std::vector<KernelArgs> GenerateArgs(const InListCPU<InputType, Dims>& input_tlv) {
+    ArgsGenerator generator;
+    std::vector<KernelArgs> args;
+    for (size_t i = 0; i < NumSamples; i++) {
+      auto shape = input_tlv.tensor_shape(i);
+      args.push_back(generator.Get(shape));
+    }
+    return args;
+  }
+
+  virtual void Run() = 0;
+};
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormPermArgsGen_CopyOnly {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = false;
+    args.should_normalize = false;
+    args.should_permute = false;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = 0;
+      args.shape[d] = input_shape[d];
+      args.flip[d] = false;
+      args.permuted_dims[d] = d;
+    }
+    return args;
+  }
+};
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormPermArgsGen_SliceOnly {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = false;
+    args.should_normalize = false;
+    args.should_permute = false;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = 0;
+      args.shape[d] = (d == 0 || d == 1) ?
+        input_shape[d]/2 : input_shape[d];
+      args.flip[d] = false;
+      args.permuted_dims[d] = d;
+    }
+    return args;
+  }
+};
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormPermArgsGen_SliceOnly_WithAnchor {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = false;
+    args.should_normalize = false;
+    args.should_permute = false;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = (d == 0 || d == 1) ?
+        input_shape[d]/2 : 0;
+      args.shape[d] = (d == 0 || d == 1) ?
+        input_shape[d]/2 : input_shape[d];
+      args.flip[d] = false;
+      args.permuted_dims[d] = d;
+    }
+    return args;
+  }
+};
+
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormPermArgsGen_FlipHW {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = true;
+    args.should_normalize = false;
+    args.should_permute = false;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = 0;
+      args.shape[d] = input_shape[d];
+      args.flip[d] = (d == Dims-2 || d == Dims-3);  // assuming last dims are HWC, flip H and W
+    }
+    return args;
+  }
+};
+
+template <typename OutputType, size_t Dims, size_t FlipDim>
+struct SliceFlipNormPermArgsGen_FlipDim {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = true;
+    args.should_normalize = false;
+    args.should_permute = false;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = 0;
+      args.shape[d] = input_shape[d];
+      args.flip[d] = (d == FlipDim);
+    }
+    return args;
+  }
+};
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormPermArgsGen_NormalizeOnly {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = false;
+    args.should_normalize = true;
+    args.should_permute = false;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = 0;
+      args.shape[d] = input_shape[d];
+      args.flip[d] = false;
+    }
+    args.mean.resize(args.shape[Dims-1], 3.5f);
+    args.inv_stddev.resize(args.shape[Dims-1], 1.f/8.0f);
+    return args;
+  }
+};
+
+template <typename OutputType, size_t Dims, size_t FlipDim>
+struct SliceFlipNormPermArgsGen_NormalizeAndFlipDim {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = true;
+    args.should_normalize = true;
+    args.should_permute = false;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = 0;
+      args.shape[d] = input_shape[d];
+      args.flip[d] = (d == FlipDim);
+    }
+    args.mean.resize(args.shape[Dims-1], 3.5f);
+    args.inv_stddev.resize(args.shape[Dims-1], 1.0/3.5f);
+    return args;
+  }
+};
+
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormPermArgsGen_PermuteOnly_ReversedDims {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = false;
+    args.should_normalize = false;
+    args.should_permute = true;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = 0;
+      args.shape[d] = input_shape[d];
+      args.flip[d] = false;
+      args.permuted_dims[d] = Dims-1-d;
+    }
+    return args;
+  }
+};
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormPermArgsGen_PermuteAndSliceHalf_ReversedDims {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = false;
+    args.should_normalize = false;
+    args.should_permute = true;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = input_shape[d]/4;
+      args.shape[d] = input_shape[d]/2;
+      args.flip[d] = false;
+      args.permuted_dims[d] = Dims-1-d;
+    }
+    return args;
+  }
+};
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormPermArgsGen_PermuteAndSliceHalf_PermuteHW {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = false;
+    args.should_normalize = false;
+    args.should_permute = true;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = input_shape[d]/4;
+      args.shape[d] = input_shape[d]/2;
+      args.flip[d] = false;
+      switch (d) {
+        case 0:
+          args.permuted_dims[d] = 1;
+          break;
+        case 1:
+          args.permuted_dims[d] = 0;
+          break;
+        default:
+          args.permuted_dims[d] = d;
+          break;
+      }
+    }
+    return args;
+  }
+};
+
+template <typename OutputType, size_t Dims>
+struct SliceFlipNormPermArgsGen_SliceFlipNormalizePermute_PermuteHWC2CHW {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = true;
+    args.should_normalize = true;
+    args.should_permute = true;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = d == 0 || d == 1 ?
+        input_shape[d]/2 : 0;
+      args.shape[d] = d == 0 || d == 1 ?
+        input_shape[d]/2 : input_shape[d];
+      args.flip[d] = d == 0 || d == 1;
+      switch (d) {
+        case 0:
+          args.permuted_dims[d] = 2;
+          break;
+        case 1:
+          args.permuted_dims[d] = 0;
+          break;
+        case 2:
+          args.permuted_dims[d] = 1;
+          break;
+        default:
+          args.permuted_dims[d] = d;
+          break;
+      }
+    }
+    args.mean.resize(args.shape[Dims-1], 50.0f);
+    args.inv_stddev.resize(args.shape[Dims-1], 1.0/100.0f);
+    return args;
+  }
+};
+
+template <typename OutputType, size_t Dims, size_t PaddedDim, size_t PadSize>
+struct SliceFlipNormPermArgsGen_OnlyPad_GivenDim {
+  SliceFlipNormalizePermuteArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    args.should_flip = false;
+    args.should_normalize = false;
+    args.should_permute = false;
+    args.should_pad = true;
+    for (size_t d = 0; d < Dims; d++) {
+      args.anchor[d] = 0;
+      args.shape[d] = input_shape[d];
+      args.padded_shape[d] = (d == PaddedDim) ? args.shape[d] + PadSize : args.shape[d];
+    }
+    return args;
+  }
+};
+
+using SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES = ::testing::Types<
+    SliceTestArgs<int, float, 3, 1, 2,
+      SliceFlipNormPermArgsGen_CopyOnly<float, 3>>,
+    SliceTestArgs<int, float, 3, 1, 2,
+      SliceFlipNormPermArgsGen_SliceOnly<float, 3>>,
+    SliceTestArgs<int, float, 3, 1, 2,
+      SliceFlipNormPermArgsGen_SliceOnly_WithAnchor<float, 3>>,
+    SliceTestArgs<int, float, 3, 1, 2,
+      SliceFlipNormPermArgsGen_FlipHW<float, 3>>,
+    SliceTestArgs<int, float, 3, 1, 2,
+      SliceFlipNormPermArgsGen_FlipDim<float, 3, 0>>,
+    SliceTestArgs<int, float, 3, 1, 2,
+      SliceFlipNormPermArgsGen_FlipDim<float, 3, 1>>,
+    SliceTestArgs<int, float, 3, 1, 2,
+      SliceFlipNormPermArgsGen_FlipDim<float, 3, 2>>,
+    SliceTestArgs<int, float, 3, 1, 2,
+      SliceFlipNormPermArgsGen_NormalizeOnly<float, 3>>,
+    SliceTestArgs<int, float, 3, 1, 2,
+      SliceFlipNormPermArgsGen_NormalizeAndFlipDim<float, 3, 0>>,
+    SliceTestArgs<int, float, 2, 1, 10,
+      SliceFlipNormPermArgsGen_PermuteOnly_ReversedDims<float, 2>>,
+    SliceTestArgs<int, float, 3, 1, 2,
+      SliceFlipNormPermArgsGen_PermuteOnly_ReversedDims<float, 3>>,
+    SliceTestArgs<int, float, 2, 1, 1,
+      SliceFlipNormPermArgsGen_PermuteOnly_ReversedDims<float, 2>, 10, 2>,
+    SliceTestArgs<int, float, 2, 1, 1,
+      SliceFlipNormPermArgsGen_PermuteOnly_ReversedDims<float, 2>, 2, 10>,
+    SliceTestArgs<int, float, 2, 1, 1,
+      SliceFlipNormPermArgsGen_PermuteAndSliceHalf_ReversedDims<float, 2>, 2, 10>,
+    SliceTestArgs<int, float, 2, 1, 1,
+      SliceFlipNormPermArgsGen_PermuteAndSliceHalf_PermuteHW<float, 2>, 2, 10>,
+    SliceTestArgs<int, float, 3, 1, 2,
+      SliceFlipNormPermArgsGen_SliceFlipNormalizePermute_PermuteHWC2CHW<float, 3>, 2, 2>,
+    SliceTestArgs<int, uint8_t, 3, 1, 3,
+      SliceFlipNormPermArgsGen_PermuteAndSliceHalf_PermuteHW<uint8_t, 3>, 1000, 1000>,
+    SliceTestArgs<uint8_t, float, 3, 1, 3,
+      SliceFlipNormPermArgsGen_PermuteAndSliceHalf_PermuteHW<float, 3>, 1000, 1000>,
+    SliceTestArgs<uint8_t, float, 3, 1, 3,
+      SliceFlipNormPermArgsGen_OnlyPad_GivenDim<float, 3, 2, 1>, 10, 10>,
+    SliceTestArgs<uint8_t, float, 3, 1, 3,
+      SliceFlipNormPermArgsGen_OnlyPad_GivenDim<float, 3, 1, 10>, 10, 10>,
+    SliceTestArgs<uint8_t, float, 3, 1, 3,
+      SliceFlipNormPermArgsGen_OnlyPad_GivenDim<float, 3, 0, 10>, 10, 10>,
+    SliceTestArgs<int, bool, 3, 1, 2,
+      SliceFlipNormPermArgsGen_SliceOnly<bool, 3>>,
+    SliceTestArgs<uint8_t, float16_cpu, 3, 1, 2,
+      SliceFlipNormPermArgsGen_SliceOnly<float16_cpu, 3>>,
+    SliceTestArgs<float16_cpu, uint8_t, 3, 1, 2,
+      SliceFlipNormPermArgsGen_SliceOnly<uint8_t, 3>>
+>;
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_KERNEL_TEST_H_

--- a/dali/kernels/slice/slice_gpu_test.cu
+++ b/dali/kernels/slice/slice_gpu_test.cu
@@ -28,7 +28,7 @@ class SliceGPUTest : public SliceTest<TestArgs> {
   static constexpr std::size_t Dims = TestArgs::Dims;
   static constexpr std::size_t NumSamples = TestArgs::NumSamples;
   static constexpr std::size_t DimSize = TestArgs::DimSize;
-  using SliceArgsGenerator = typename TestArgs::SliceArgsGenerator;
+  using ArgsGenerator = typename TestArgs::ArgsGenerator;
   using KernelType = SliceGPU<OutputType, InputType, Dims>;
 
   void Run() override {
@@ -37,7 +37,7 @@ class SliceGPUTest : public SliceTest<TestArgs> {
     TestTensorList<InputType, Dims> test_data;
     this->PrepareData(test_data);
 
-    auto slice_args = this->GenerateSliceArgs(test_data.cpu());
+    auto slice_args = this->GenerateArgs(test_data.cpu());
 
     KernelType kernel;
     KernelRequirements req = kernel.Setup(ctx, test_data.gpu(), slice_args);

--- a/dali/kernels/slice/slice_kernel_utils.h
+++ b/dali/kernels/slice/slice_kernel_utils.h
@@ -46,10 +46,12 @@ void CheckValidOutputShape(const TensorShape<Dims>& in_sample_shape,
                            const Args& args) {
   for (size_t d = 0; d < Dims; d++) {
     DALI_ENFORCE(
-      args.anchor[d] >= 0 && (args.anchor[d] + out_sample_shape[d]) <= in_sample_shape[d],
+      args.anchor[d] >= 0 && (args.anchor[d] + args.shape[d]) <= in_sample_shape[d],
       "Slice dimension " + std::to_string(d) + " is out of bounds : anchor["
-      + std::to_string(args.anchor[d]) + "] size[" + std::to_string(out_sample_shape[d])
+      + std::to_string(args.anchor[d]) + "] size[" + std::to_string(args.shape[d])
       + "] input dimension size[" + std::to_string(in_sample_shape[d]) + "]");
+    DALI_ENFORCE(args.shape[d] <= out_sample_shape[d],
+      "Output shape dimension " + std::to_string(d) + " is too small");
   }
 }
 

--- a/dali/kernels/slice/slice_kernel_utils.h
+++ b/dali/kernels/slice/slice_kernel_utils.h
@@ -24,48 +24,53 @@
 namespace dali {
 namespace kernels {
 
-template <std::size_t Dims>
+template <size_t Dims>
 struct SliceArgs {
   std::array<int64_t, Dims> anchor;
   std::array<int64_t, Dims> shape;
 };
 
-template <std::size_t Dims, typename Shape>
+template <size_t Dims, typename Shape>
 std::array<int64_t, Dims> GetStrides(const Shape& shape) {
   std::array<int64_t, Dims> strides;
   strides[Dims - 1] = 1;
-  for (std::size_t d = Dims - 1; d > 0; d--) {
+  for (size_t d = Dims - 1; d > 0; d--) {
     strides[d - 1] = strides[d] * shape[d];
   }
   return strides;
 }
 
-template <typename std::size_t Dims>
-TensorShape<Dims> GetOutputShape(const TensorShape<Dims>& in_sample_shape,
-                                 const SliceArgs<Dims>& slice_args) {
-  TensorShape<Dims> out_sample_shape(slice_args.shape);
-  auto &anchor = slice_args.anchor;
-
-  for (std::size_t d = 0; d < Dims; d++) {
-    DALI_ENFORCE(anchor[d] >= 0 && (anchor[d] + out_sample_shape[d]) <= in_sample_shape[d],
-      "Slice dimension " + std::to_string(d) +
-      " is out of bounds : " + "anchor[" + std::to_string(anchor[d]) +
-      "] size[" + std::to_string(out_sample_shape[d]) + "] input dimension size[" +
-      std::to_string(in_sample_shape[d]) + "]");
+template <size_t Dims, typename Args>
+void CheckValidOutputShape(const TensorShape<Dims>& in_sample_shape,
+                           const TensorShape<Dims>& out_sample_shape,
+                           const Args& args) {
+  for (size_t d = 0; d < Dims; d++) {
+    DALI_ENFORCE(
+      args.anchor[d] >= 0 && (args.anchor[d] + out_sample_shape[d]) <= in_sample_shape[d],
+      "Slice dimension " + std::to_string(d) + " is out of bounds : anchor["
+      + std::to_string(args.anchor[d]) + "] size[" + std::to_string(out_sample_shape[d])
+      + "] input dimension size[" + std::to_string(in_sample_shape[d]) + "]");
   }
+}
+
+template <size_t Dims, typename Args>
+TensorShape<Dims> GetOutputShape(const TensorShape<Dims>& in_sample_shape,
+                                 const Args& args) {
+  TensorShape<Dims> out_sample_shape(args.shape);
+  CheckValidOutputShape<Dims>(in_sample_shape, out_sample_shape, args);
   return out_sample_shape;
 }
 
-template <std::size_t Dims>
+template <size_t Dims, typename Args>
 TensorListShape<Dims> GetOutputShapes(const TensorListShape<Dims>& in_shapes,
-                                      const std::vector<SliceArgs<Dims>> &slice_args) {
-    DALI_ENFORCE(slice_args.size() == static_cast<std::size_t>(in_shapes.size()),
+                                      const std::vector<Args> &args) {
+    DALI_ENFORCE(args.size() == static_cast<size_t>(in_shapes.size()),
       "Number of samples and size of slice arguments should match");
 
     TensorListShape<Dims> output_shapes;
     output_shapes.resize(in_shapes.size(), Dims);
     for (int i = 0; i < in_shapes.size(); i++) {
-      auto out_sample_shape = GetOutputShape<Dims>(in_shapes[i], slice_args[i]);
+      auto out_sample_shape = GetOutputShape<Dims>(in_shapes[i], args[i]);
       output_shapes.set_tensor_shape(i, out_sample_shape);
     }
     return output_shapes;

--- a/dali/pipeline/operators/crop/crop.cc
+++ b/dali/pipeline/operators/crop/crop.cc
@@ -47,7 +47,6 @@ void Crop<CPUBackend>::DataDependentSetup(SampleWorkspace *ws, const int idx) {
 
   auto data_idx = ws->data_idx();
   SetupSample(data_idx, in_layout, input.shape());
-  auto &slice_shape = slice_shapes_[data_idx];
 
   auto &output = ws->Output<CPUBackend>(idx);
   output.SetLayout(out_layout);

--- a/dali/pipeline/operators/crop/slice_base.cc
+++ b/dali/pipeline/operators/crop/slice_base.cc
@@ -72,16 +72,8 @@ void SliceBase<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
   auto &output = ws->Output<CPUBackend>(idx);
   auto data_idx = ws->data_idx();
 
-  if (input_type_ == DALI_FLOAT16 || output_type_ == DALI_FLOAT16) {
-    DALI_ENFORCE(input_type_ == output_type_,
-      "type conversion is not supported for half precision floats");
-    detail::RunHelper<float16_cpu, float16_cpu>(
-      output, input, slice_anchors_[data_idx], slice_shapes_[data_idx]);
-    return;
-  }
-
-  DALI_TYPE_SWITCH(input_type_, InputType,
-    DALI_TYPE_SWITCH(output_type_, OutputType,
+  DALI_TYPE_SWITCH_WITH_FP16_CPU(input_type_, InputType,
+    DALI_TYPE_SWITCH_WITH_FP16_CPU(output_type_, OutputType,
       detail::RunHelper<OutputType, InputType>(
         output, input, slice_anchors_[data_idx], slice_shapes_[data_idx]);
     )

--- a/dali/pipeline/operators/crop/slice_base.cu
+++ b/dali/pipeline/operators/crop/slice_base.cu
@@ -79,16 +79,8 @@ void SliceBase<GPUBackend>::RunImpl(DeviceWorkspace *ws, const int idx) {
   const auto &input = ws->Input<GPUBackend>(idx);
   auto &output = ws->Output<GPUBackend>(idx);
 
-  if (input_type_ == DALI_FLOAT16 || output_type_ == DALI_FLOAT16) {
-    DALI_ENFORCE(input_type_ == output_type_,
-      "type conversion is not supported for half precision floats");
-    detail::RunHelper<float16, float16>(
-      output, input, slice_anchors_, slice_shapes_, ws->stream(), scratch_alloc_);
-    return;
-  }
-
-  DALI_TYPE_SWITCH(input_type_, InputType,
-    DALI_TYPE_SWITCH(output_type_, OutputType,
+  DALI_TYPE_SWITCH_WITH_FP16_GPU(input_type_, InputType,
+    DALI_TYPE_SWITCH_WITH_FP16_GPU(output_type_, OutputType,
       detail::RunHelper<OutputType, InputType>(
         output, input, slice_anchors_, slice_shapes_, ws->stream(), scratch_alloc_);
     )

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -93,10 +93,12 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr  {
 
   inline Dims GetOutShape(DALITensorLayout inputLayout, DALITensorLayout *pOutLayout) {
     *pOutLayout = output_layout_ == DALI_SAME ? inputLayout : output_layout_;
+    // Pad to 4 channels
+    int pad_C = pad_ ? 4 : C_;
     if (*pOutLayout == DALI_NCHW)
-      return {C_, crop_h_, crop_w_};
+      return {pad_C, crop_h_, crop_w_};
     else
-      return {crop_h_, crop_w_, C_};
+      return {crop_h_, crop_w_, pad_C};
   }
 
   // Output data type

--- a/dali/pipeline/operators/fused/new_crop_mirror_normalize.cc
+++ b/dali/pipeline/operators/fused/new_crop_mirror_normalize.cc
@@ -20,6 +20,37 @@
 
 namespace dali {
 
+DALI_SCHEMA(NewCropMirrorNormalize)
+  .DocStr(R"code(Perform fused cropping, normalization, format conversion
+(NHWC to NCHW) if desired, and type casting.
+Normalization takes input image and produces output using formula:
+
+  output = (input - mean) / std
+)code")
+  .NumInput(1)
+  .NumOutput(1)
+  .AllowMultipleInputSets()
+  .AddOptionalArg("output_dtype",
+    R"code(Output data type.)code", DALI_FLOAT)
+  .AddOptionalArg("output_layout",
+    R"code(Output tensor data layout)code", DALI_NCHW)
+  .AddOptionalArg(
+    "pad_output",
+    R"code(Whether to pad the output to number of channels being multiple of 4.)code", false)
+  .AddOptionalArg("mirror",
+    R"code(Mask for horizontal flip.
+- `0` - do not perform horizontal flip for this image
+- `1` - perform horizontal flip for this image.
+)code",
+    0, true)
+  .AddArg("mean",
+    R"code(Mean pixel values for image normalization.)code", DALI_FLOAT_VEC)
+  .AddArg("std",
+    R"code(Standard deviation values for image normalization.)code", DALI_FLOAT_VEC)
+  .AddParent("Crop");
+
+DALI_REGISTER_OPERATOR(NewCropMirrorNormalize, NewCropMirrorNormalize<CPUBackend>, CPU);
+
 namespace detail {
 
 size_t horizontal_dim_idx(DALITensorLayout layout) {
@@ -157,35 +188,6 @@ void RunHelper(Tensor<CPUBackend> &output,
 
 }  // namespace detail
 
-DALI_SCHEMA(NewCropMirrorNormalize)
-  .DocStr(R"code(Perform fused cropping, normalization, format conversion
-(NHWC to NCHW) if desired, and type casting.
-Normalization takes input image and produces output using formula:
-
-  output = (input - mean) / std
-)code")
-  .NumInput(1)
-  .NumOutput(1)
-  .AllowMultipleInputSets()
-  .AddOptionalArg("output_dtype",
-    R"code(Output data type.)code", DALI_FLOAT)
-  .AddOptionalArg("output_layout",
-    R"code(Output tensor data layout)code", DALI_NCHW)
-  .AddOptionalArg(
-    "pad_output",
-    R"code(Whether to pad the output to number of channels being multiple of 4.)code", false)
-  .AddOptionalArg("mirror",
-    R"code(Mask for horizontal flip.
-- `0` - do not perform horizontal flip for this image
-- `1` - perform horizontal flip for this image.
-)code",
-    0, true)
-  .AddArg("mean",
-    R"code(Mean pixel values for image normalization.)code", DALI_FLOAT_VEC)
-  .AddArg("std",
-    R"code(Standard deviation values for image normalization.)code", DALI_FLOAT_VEC)
-  .AddParent("Crop");
-
 template <>
 void NewCropMirrorNormalize<CPUBackend>::SetupSharedSampleParams(SampleWorkspace *ws) {
   input_layout_ = ws->Input<CPUBackend>(0).GetLayout();
@@ -229,7 +231,5 @@ void NewCropMirrorNormalize<CPUBackend>::RunImpl(SampleWorkspace *ws, const int 
     )
   )
 }
-
-DALI_REGISTER_OPERATOR(NewCropMirrorNormalize, NewCropMirrorNormalize<CPUBackend>, CPU);
 
 }  // namespace dali

--- a/dali/pipeline/operators/fused/new_crop_mirror_normalize.cc
+++ b/dali/pipeline/operators/fused/new_crop_mirror_normalize.cc
@@ -1,0 +1,235 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/operators/fused/new_crop_mirror_normalize.h"
+#include "dali/kernels/slice/slice_flip_normalize_permute_cpu.h"
+#include "dali/util/half.hpp"
+#include "dali/core/static_switch.h"
+#include "dali/pipeline/data/views.h"
+
+namespace dali {
+
+namespace detail {
+
+size_t horizontal_dim_idx(DALITensorLayout layout) {
+  switch (layout) {
+    case DALI_NHWC:
+      return 1;
+    case DALI_NCHW:
+      return 2;
+    case DALI_NFHWC:
+      return 2;
+    case DALI_NFCHW:
+      return 3;
+    default:
+      DALI_FAIL("not supported layout: " + std::to_string(layout));
+  }
+}
+
+template <size_t Dims>
+std::array<int64_t, Dims> permuted_dims(DALITensorLayout in_layout,
+                                        DALITensorLayout out_layout) {
+  std::array<int64_t, Dims> perm_dims;
+  for (size_t d = 0; d < Dims; d++) {
+    perm_dims[d] = d;
+  }
+
+  if (in_layout != out_layout) {
+    if (in_layout == DALI_NHWC && out_layout == DALI_NCHW) {
+      perm_dims[0] = 2;
+      perm_dims[1] = 0;
+      perm_dims[2] = 1;
+    } else if (in_layout == DALI_NCHW && out_layout == DALI_NHWC) {
+      perm_dims[0] = 1;
+      perm_dims[1] = 2;
+      perm_dims[2] = 0;
+    } else if (in_layout == DALI_NFHWC && out_layout == DALI_NFCHW) {
+      perm_dims[1] = 3;
+      perm_dims[2] = 1;
+      perm_dims[3] = 2;
+    } else if (in_layout == DALI_NFCHW && out_layout == DALI_NFHWC) {
+      perm_dims[1] = 2;
+      perm_dims[2] = 3;
+      perm_dims[3] = 1;
+    } else {
+      DALI_FAIL("layout conversion from " + std::to_string(in_layout) + " to "
+        + std::to_string(out_layout) + " not supported");
+    }
+  }
+
+  return perm_dims;
+}
+
+size_t channels_dim(DALITensorLayout in_layout) {
+  switch (in_layout) {
+    case DALI_NHWC:
+      return 2;
+    case DALI_NCHW:
+      return 0;
+    case DALI_NFHWC:
+      return 3;
+    case DALI_NFCHW:
+      return 1;
+    default:
+      DALI_FAIL("not supported layout: " + std::to_string(in_layout));
+  }
+}
+
+template <typename OutputType, typename InputType>
+void RunHelper(Tensor<CPUBackend> &output,
+               const Tensor<CPUBackend> &input,
+               const std::vector<int64_t> &slice_anchor,
+               const std::vector<int64_t> &slice_shape,
+               bool horizontal_flip,
+               bool pad_output,
+               const std::vector<float> &mean,
+               const std::vector<float> &inv_std_dev) {
+  std::size_t number_of_dims = input.shape().size();
+  auto input_layout = input.GetLayout();
+  auto output_layout = output.GetLayout();
+  VALUE_SWITCH(number_of_dims, Dims, (3, 4), (
+    auto in_view = view<const InputType, Dims>(input);
+
+    kernels::SliceFlipNormalizePermuteArgs<OutputType, Dims> args;
+    auto &anchor = args.anchor;
+    auto &shape = args.shape;
+    for (std::size_t d = 0; d < Dims; d++) {
+      anchor[d] = slice_anchor[d];
+      shape[d] = slice_shape[d];
+    }
+
+    if (pad_output) {
+      args.should_pad = true;
+      args.padded_shape = args.shape;
+      args.padded_shape[channels_dim(input_layout)] = 4;
+    }
+
+    if (horizontal_flip) {
+      args.should_flip = true;
+      auto flip_dim = horizontal_dim_idx(input_layout);
+      for (size_t d = 0; d < Dims; d++) {
+        args.flip[d] = (d == flip_dim);
+      }
+    }
+
+    // Check if permutation is needed
+    if (input_layout != output_layout) {
+      args.should_permute = true;
+      args.permuted_dims = permuted_dims<Dims>(input_layout, output_layout);
+    }
+
+    args.should_normalize =
+         !std::all_of(mean.begin(), mean.end(), [](float x){ return x == 0.0f; })
+      || !std::all_of(inv_std_dev.begin(), inv_std_dev.end(), [](float x){ return x == 1.0f; });
+
+    if (args.should_normalize) {
+      args.mean = mean;
+      args.inv_stddev = inv_std_dev;
+      args.normalization_dim = channels_dim(input_layout);
+    }
+
+    kernels::SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims> kernel;
+    kernels::KernelContext ctx;
+    kernels::KernelRequirements req = kernel.Setup(ctx, in_view, args);
+
+    output.set_type(TypeInfo::Create<OutputType>());
+    output.SetLayout(input.GetLayout());
+    output.Resize(req.output_shapes[0][0].shape.to_vector());
+
+    auto out_view = view<OutputType, Dims>(output);
+    kernel.Run(ctx, out_view, in_view, args);
+  ), // NOLINT
+  (
+    DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims));
+  )); // NOLINT
+}
+
+}  // namespace detail
+
+DALI_SCHEMA(NewCropMirrorNormalize)
+  .DocStr(R"code(Perform fused cropping, normalization, format conversion
+(NHWC to NCHW) if desired, and type casting.
+Normalization takes input image and produces output using formula:
+
+  output = (input - mean) / std
+)code")
+  .NumInput(1)
+  .NumOutput(1)
+  .AllowMultipleInputSets()
+  .AddOptionalArg("output_dtype",
+    R"code(Output data type.)code", DALI_FLOAT)
+  .AddOptionalArg("output_layout",
+    R"code(Output tensor data layout)code", DALI_NCHW)
+  .AddOptionalArg(
+    "pad_output",
+    R"code(Whether to pad the output to number of channels being multiple of 4.)code", false)
+  .AddOptionalArg("mirror",
+    R"code(Mask for horizontal flip.
+- `0` - do not perform horizontal flip for this image
+- `1` - perform horizontal flip for this image.
+)code",
+    0, true)
+  .AddArg("mean",
+    R"code(Mean pixel values for image normalization.)code", DALI_FLOAT_VEC)
+  .AddArg("std",
+    R"code(Standard deviation values for image normalization.)code", DALI_FLOAT_VEC)
+  .AddParent("Crop");
+
+template <>
+void NewCropMirrorNormalize<CPUBackend>::SetupSharedSampleParams(SampleWorkspace *ws) {
+  input_layout_ = ws->Input<CPUBackend>(0).GetLayout();
+  if (output_layout_ == DALI_SAME) {
+    output_layout_ = input_layout_;
+  }
+  DALI_ENFORCE(input_layout_ == DALI_NHWC || input_layout_ == DALI_NCHW
+            || input_layout_ == DALI_NFHWC || input_layout_ == DALI_NFCHW,
+    "Unexpected data layout");
+
+  input_type_ = ws->Input<CPUBackend>(0).type().id();
+  if (output_type_ == DALI_NO_TYPE) {
+    output_type_ = input_type_;
+  }
+  CropAttr::ProcessArguments(ws);
+
+  mirror_[ws->data_idx()] = spec_.GetArgument<int>("mirror", ws, ws->data_idx());
+}
+
+template <>
+void NewCropMirrorNormalize<CPUBackend>::DataDependentSetup(SampleWorkspace *ws, const int idx) {
+  const auto &input = ws->Input<CPUBackend>(idx);
+  SetupSample(ws->data_idx(), input_layout_, input.shape());
+
+  auto &output = ws->Output<CPUBackend>(idx);
+  output.SetLayout(output_layout_);
+}
+
+template <>
+void NewCropMirrorNormalize<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
+  this->DataDependentSetup(ws, idx);
+  const auto &input = ws->Input<CPUBackend>(idx);
+  auto &output = ws->Output<CPUBackend>(idx);
+  auto data_idx = ws->data_idx();
+
+  DALI_TYPE_SWITCH_WITH_FP16_CPU(input_type_, InputType,
+    DALI_TYPE_SWITCH_WITH_FP16_CPU(output_type_, OutputType,
+      detail::RunHelper<OutputType, InputType>(
+        output, input, slice_anchors_[data_idx], slice_shapes_[data_idx],
+        mirror_[data_idx], pad_output_, mean_vec_, inv_std_vec_);
+    )
+  )
+}
+
+DALI_REGISTER_OPERATOR(NewCropMirrorNormalize, NewCropMirrorNormalize<CPUBackend>, CPU);
+
+}  // namespace dali

--- a/dali/pipeline/operators/fused/new_crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/new_crop_mirror_normalize.h
@@ -1,0 +1,162 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATORS_FUSED_NEW_CROP_MIRROR_NORMALIZE_H_
+#define DALI_PIPELINE_OPERATORS_FUSED_NEW_CROP_MIRROR_NORMALIZE_H_
+
+#include <cstring>
+#include <utility>
+#include <vector>
+
+#include "dali/core/common.h"
+#include "dali/pipeline/operators/common.h"
+#include "dali/core/error_handling.h"
+#include "dali/pipeline/operators/operator.h"
+#include "dali/pipeline/operators/crop/crop_attr.h"
+#include "dali/kernels/scratch.h"
+
+namespace dali {
+
+template <typename Backend>
+class NewCropMirrorNormalize : public Operator<Backend>, protected CropAttr {
+ public:
+  explicit inline NewCropMirrorNormalize(const OpSpec &spec)
+      : Operator<Backend>(spec),
+        CropAttr(spec),
+        output_type_(spec.GetArgument<DALIDataType>("output_dtype")),
+        output_layout_(spec.GetArgument<DALITensorLayout>("output_layout")),
+        pad_output_(spec.GetArgument<bool>("pad_output")),
+        image_type_(spec.GetArgument<DALIImageType>("image_type")),
+        C_(IsColor(image_type_) ? 3 : 1),
+        slice_anchors_(batch_size_),
+        slice_shapes_(batch_size_),
+        mirror_(batch_size_) {
+    GetSingleOrRepeatedArg(spec, mean_vec_, "mean", C_);
+    GetSingleOrRepeatedArg(spec, inv_std_vec_, "std", C_);
+    // Inverse the std-deviation
+    for (auto &element : inv_std_vec_) {
+      element = 1.f / element;
+    }
+  }
+
+  inline ~NewCropMirrorNormalize() override = default;
+
+ protected:
+  void RunImpl(Workspace<Backend> *ws, const int idx) override;
+
+  void SetupSharedSampleParams(Workspace<Backend> *ws) override {
+    const auto &input = ws->template Input<Backend>(0);
+    input_type_ = input.type().id();
+    if (output_type_ == DALI_NO_TYPE)
+      output_type_ = input_type_;
+
+    input_layout_ = input.GetLayout();
+    if (output_layout_ == DALI_SAME)
+      output_layout_ = input_layout_;
+
+    CropAttr::ProcessArguments(ws);
+  }
+
+  void DataDependentSetup(Workspace<Backend> *ws, const int idx);
+
+  void SetupSample(int data_idx, DALITensorLayout layout, const vector<Index> &shape) {
+    Index F = 1, H, W, C;
+    DALI_ENFORCE(shape.size() == 3 || shape.size() == 4,
+      "Unexpected number of dimensions: " + std::to_string(shape.size()));
+    switch (layout) {
+      case DALI_NHWC:
+        std::tie(H, W, C) = std::make_tuple(shape[0], shape[1], shape[2]);
+        break;
+      case DALI_NCHW:
+        std::tie(C, H, W) = std::make_tuple(shape[0], shape[1], shape[2]);
+        break;
+      case DALI_NFHWC:
+        std::tie(F, H, W, C) = std::make_tuple(shape[0], shape[1], shape[2], shape[3]);
+        break;
+      case DALI_NFCHW:
+        std::tie(F, C, H, W) = std::make_tuple(shape[0], shape[1], shape[2], shape[3]);
+        break;
+      default:
+        DALI_FAIL("Not supported layout");
+    }
+
+    DALI_ENFORCE(H >= crop_height_[data_idx] && W >= crop_width_[data_idx],
+      "Image dimensions for sample " + std::to_string(data_idx) + " ("
+      + std::to_string(H) + ", " + std::to_string(W) + ")"
+      + " are smaller than the cropping window" + " ("
+      + std::to_string(crop_height_[data_idx]) + ", "
+      + std::to_string(crop_width_[data_idx]) + ")");
+
+    auto crop_pos_y_x = CalculateCropYX(crop_y_norm_[data_idx], crop_x_norm_[data_idx],
+                                        crop_height_[data_idx], crop_width_[data_idx], H, W);
+
+    auto crop_h = crop_height_[data_idx];
+    auto crop_w = crop_width_[data_idx];
+
+    int64_t crop_y, crop_x;
+    std::tie(crop_y, crop_x) = crop_pos_y_x;
+
+    switch (layout) {
+      case DALI_NHWC:
+        slice_anchors_[data_idx] = {crop_y, crop_x, 0};
+        slice_shapes_[data_idx] = {crop_h, crop_w, C};
+        break;
+      case DALI_NCHW:
+        slice_anchors_[data_idx] = {0, crop_y, crop_x};
+        slice_shapes_[data_idx] = {C, crop_h, crop_w};
+        break;
+      case DALI_NFHWC:
+        slice_anchors_[data_idx] = {0, crop_y, crop_x, 0};
+        slice_shapes_[data_idx] = {F, crop_h, crop_w, C};
+        break;
+      case DALI_NFCHW:
+        slice_anchors_[data_idx] = {0, 0, crop_y, crop_x};
+        slice_shapes_[data_idx] = {F, C, crop_h, crop_w};
+        break;
+      default:
+        DALI_FAIL("Not supported layout");
+    }
+  }
+
+  DALIDataType input_type_ = DALI_NO_TYPE;
+  DALIDataType output_type_ = DALI_NO_TYPE;
+
+  DALITensorLayout input_layout_ = DALI_NHWC;
+  DALITensorLayout output_layout_ = DALI_SAME;
+
+  // Whether to pad output to 4 channels
+  bool pad_output_;
+
+  // Input/output channel meta-data
+  DALIImageType image_type_;
+  int C_;
+
+  std::vector<std::vector<int64_t>> slice_anchors_, slice_shapes_;
+
+  std::vector<float> mean_vec_, inv_std_vec_;
+  std::vector<int> mirror_;
+
+  // In current implementation scratchpad memory is only used in the GPU kernel
+  // In case of using scratchpad in the CPU kernel a scratchpad allocator per thread
+  // should be instantiated
+  typename std::conditional<std::is_same<Backend, GPUBackend>::value,
+    kernels::ScratchpadAllocator,
+    std::vector<kernels::ScratchpadAllocator>>::type scratch_alloc_;
+
+  USE_OPERATOR_MEMBERS();
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATORS_FUSED_NEW_CROP_MIRROR_NORMALIZE_H_

--- a/dali/pipeline/operators/util/cast.cc
+++ b/dali/pipeline/operators/util/cast.cc
@@ -24,10 +24,10 @@ void Cast<CPUBackend>::RunImpl(SampleWorkspace *ws, int idx) {
 
   DALIDataType itype = input.type().id();
 
-  DALI_TYPE_SWITCH(output_type_, OType,
+  DALI_TYPE_SWITCH_WITH_FP16_CPU(output_type_, OType,
       output.mutable_data<OType>();
       output.ResizeLike(input);
-      DALI_TYPE_SWITCH(itype, IType,
+      DALI_TYPE_SWITCH_WITH_FP16_CPU(itype, IType,
         CPUHelper<IType, OType>(
           output.mutable_data<OType>(),
           input.data<IType>(),

--- a/dali/pipeline/operators/util/cast.h
+++ b/dali/pipeline/operators/util/cast.h
@@ -16,6 +16,7 @@
 #define DALI_PIPELINE_OPERATORS_UTIL_CAST_H_
 
 #include "dali/pipeline/operators/operator.h"
+#include "dali/core/convert.h"
 
 namespace dali {
 
@@ -36,9 +37,9 @@ class Cast : public Operator<Backend> {
 
  private:
   template <typename IType, typename OType>
-  inline void CPUHelper(OType * out, const IType * in, size_t N) {
+  inline void CPUHelper(OType *out, const IType *in, size_t N) {
     for (size_t i = 0; i < N; ++i) {
-      out[i] = static_cast<OType>(in[i]);
+      out[i] = clamp<OType>(in[i]);
     }
   }
 

--- a/dali/test/python/test_operator_crop_mirror_normalize.py
+++ b/dali/test/python/test_operator_crop_mirror_normalize.py
@@ -87,6 +87,7 @@ def test_cmn_cpu_vs_gpu():
             for output_layout in [types.NHWC, types.NCHW]:
                 for mirror_probability in [0.0, 0.5, 1.0]:
                     for (mean, std) in [ ([0., 0., 0.], [1., 1., 1.]),
+                                         ([0.5 * 255], [0.225 * 255]),
                                          ([0.485 * 255, 0.456 * 255, 0.406 * 255], [0.229 * 255, 0.224 * 255, 0.225 * 255]) ]:
                         for pad_output in [False]: # padding doesn't work in the old CPU version
                             yield check_cmn_cpu_vs_gpu, batch_size, output_dtype, output_layout, mirror_probability, mean, std, pad_output
@@ -110,10 +111,12 @@ def test_cmn_cpu_old_vs_new():
                     for output_layout in [types.NHWC, types.NCHW]:
                         for mirror_probability in [0.0, 0.5, 1.0]:
                             norm_data = [ ([0., 0., 0.], [1., 1., 1.]),
+                                          ([0.5 * 255], [0.225 * 255]),
                                           ([0.485 * 255, 0.456 * 255, 0.406 * 255], [0.229 * 255, 0.224 * 255, 0.225 * 255]) ] \
                                         if output_dtype != types.INT32 else \
                                         [ ([0., 0., 0.], [1., 1., 1.]),
-                                        ([10, 10, 10], [10, 10, 10]) ]
+                                          ([9, 8, 10], [10, 8, 9]),
+                                          ([10, 10, 10], [10, 10, 10]) ]
                             for (mean, std) in norm_data:
                                 for pad_output in [False, True] if device_old != 'cpu' else [False]: # padding doesn't work in the old CPU version
                                     yield check_cmn_cpu_old_vs_new, device_new, device_old, batch_size, output_dtype, \

--- a/dali/test/python/test_operator_crop_mirror_normalize.py
+++ b/dali/test/python/test_operator_crop_mirror_normalize.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops as ops
+import nvidia.dali.types as types
+import nvidia.dali as dali
+from nvidia.dali.backend_impl import TensorListGPU
+import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
+import os
+
+from test_utils import check_batch
+from test_utils import compare_pipelines
+from test_utils import RandomDataIterator
+
+test_data_root = os.environ['DALI_EXTRA_PATH']
+caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
+
+class CropMirrorNormalizePipeline(Pipeline):
+    def __init__(self, device, batch_size, num_threads=1, device_id=0, num_gpus=1,
+                 is_new_cmn = False, output_dtype = types.FLOAT, output_layout = types.NHWC,
+                 mirror_probability = 0.0, mean=[0., 0., 0.], std=[1., 1., 1.], pad_output=False):
+        super(CropMirrorNormalizePipeline, self).__init__(batch_size, num_threads, device_id, seed=7865)
+        self.device = device
+        self.is_new_cmn = is_new_cmn
+        self.input = ops.CaffeReader(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
+        self.decode = ops.HostDecoder(device = "cpu", output_type = types.RGB)
+        if self.is_new_cmn:
+            self.cmn = ops.NewCropMirrorNormalize(device = self.device,
+                                                  output_dtype = output_dtype,
+                                                  output_layout = output_layout,
+                                                  crop = (224, 224),
+                                                  crop_pos_x = 0.3,
+                                                  crop_pos_y = 0.2,
+                                                  image_type = types.RGB,
+                                                  mean = mean,
+                                                  std = std,
+                                                  pad_output = pad_output)
+        else:
+            self.cmn = ops.CropMirrorNormalize(device = self.device,
+                                               output_dtype = output_dtype,
+                                               output_layout = output_layout,
+                                               crop = (224, 224),
+                                               crop_pos_x = 0.3,
+                                               crop_pos_y = 0.2,
+                                               image_type = types.RGB,
+                                               mean = mean,
+                                               std = std,
+                                               pad_output = pad_output)
+        self.coin = ops.CoinFlip(probability=mirror_probability)
+
+    def define_graph(self):
+        inputs, labels = self.input(name="Reader")
+        images = self.decode(inputs)
+        if self.device == 'gpu':
+            images = images.gpu()
+        rng = self.coin()
+        images = self.cmn(images, mirror=rng)
+        return images
+
+def check_cmn_cpu_vs_gpu(batch_size, output_dtype, output_layout, mirror_probability, mean, std, pad_output):
+    compare_pipelines(CropMirrorNormalizePipeline('cpu', batch_size, output_dtype=output_dtype,
+                                                  output_layout=output_layout, mirror_probability=mirror_probability,
+                                                  mean=mean, std=std, pad_output=pad_output,
+                                                  is_new_cmn=False),
+                      CropMirrorNormalizePipeline('gpu', batch_size, output_dtype=output_dtype,
+                                                  output_layout=output_layout, mirror_probability=mirror_probability,
+                                                  mean=mean, std=std, pad_output=pad_output,
+                                                  is_new_cmn=False),
+                      batch_size=batch_size, N_iterations=10)
+
+def test_cmn_cpu_vs_gpu():
+    for batch_size in [1, 8]:
+        for output_dtype in [types.FLOAT, types.INT32]:
+            for output_layout in [types.NHWC, types.NCHW]:
+                for mirror_probability in [0.0, 0.5, 1.0]:
+                    for (mean, std) in [ ([0., 0., 0.], [1., 1., 1.]),
+                                         ([0.485 * 255, 0.456 * 255, 0.406 * 255], [0.229 * 255, 0.224 * 255, 0.225 * 255]) ]:
+                        for pad_output in [False]: # padding doesn't work in the old CPU version
+                            yield check_cmn_cpu_vs_gpu, batch_size, output_dtype, output_layout, mirror_probability, mean, std, pad_output
+
+def check_cmn_cpu_old_vs_new(device_new, device_old, batch_size, output_dtype, output_layout, mirror_probability, mean, std, pad_output):
+    compare_pipelines(CropMirrorNormalizePipeline(device_old, batch_size, output_dtype=output_dtype,
+                                                  output_layout=output_layout, mirror_probability=mirror_probability,
+                                                  mean=mean, std=std, pad_output=pad_output,
+                                                  is_new_cmn=False),
+                      CropMirrorNormalizePipeline(device_new, batch_size, output_dtype=output_dtype,
+                                                  output_layout=output_layout, mirror_probability=mirror_probability,
+                                                  mean=mean, std=std, pad_output=pad_output,
+                                                  is_new_cmn=True),
+                      batch_size=batch_size, N_iterations=10)
+
+def test_cmn_cpu_old_vs_new():
+    for device_new in ['cpu']:
+        for device_old in ['gpu', 'cpu']:
+            for batch_size in [1, 8]:
+                for output_dtype in [types.FLOAT, types.INT32]:
+                    for output_layout in [types.NHWC, types.NCHW]:
+                        for mirror_probability in [0.0, 0.5, 1.0]:
+                            norm_data = [ ([0., 0., 0.], [1., 1., 1.]),
+                                          ([0.485 * 255, 0.456 * 255, 0.406 * 255], [0.229 * 255, 0.224 * 255, 0.225 * 255]) ] \
+                                        if output_dtype != types.INT32 else \
+                                        [ ([0., 0., 0.], [1., 1., 1.]),
+                                        ([10, 10, 10], [10, 10, 10]) ]
+                            for (mean, std) in norm_data:
+                                for pad_output in [False, True] if device_old != 'cpu' else [False]: # padding doesn't work in the old CPU version
+                                    yield check_cmn_cpu_old_vs_new, device_new, device_old, batch_size, output_dtype, \
+                                        output_layout, mirror_probability, mean, std, pad_output

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -19,7 +19,11 @@
 #include <cstdint>
 #include <limits>
 #include <type_traits>
-
+#ifndef __CUDA_ARCH__
+#include "dali/util/half.hpp"
+#else
+#include "dali/core/cuda_utils.h"
+#endif
 namespace dali {
 
 template <typename T>
@@ -27,9 +31,13 @@ struct const_limits;
 
 // std::numeric_limits are not compatible with CUDA
 template <typename T>
-__host__ __device__ constexpr T max_value() { return const_limits<T>::max; }
+__host__ __device__ constexpr T max_value() {
+  return const_limits<typename std::remove_cv<T>::type>::max;
+}
 template <typename T>
-__host__ __device__ constexpr T min_value() { return const_limits<T>::min; }
+__host__ __device__ constexpr T min_value() {
+  return const_limits<typename std::remove_cv<T>::type>::min;
+}
 
 #define DEFINE_TYPE_RANGE(type, min_, max_) template <>\
 struct const_limits<type> { static constexpr type min = min_, max = max_; }
@@ -131,6 +139,53 @@ __host__ __device__ constexpr bool clamp(T value, ret_type<bool>) {
   return static_cast<bool>(value);
 }
 
+#ifndef __CUDA_ARCH__
+template <typename T>
+__host__ __device__ constexpr half_float::half clamp(T value, ret_type<half_float::half>) {
+  return static_cast<half_float::half>(value);
+}
+
+template <typename T>
+__host__ __device__ constexpr T clamp(half_float::half value, ret_type<T>) {
+  return clamp(static_cast<float>(value), ret_type<T>());
+}
+
+__host__ __device__ inline bool clamp(half_float::half value, ret_type<bool>) {
+  return static_cast<bool>(value);
+}
+
+__host__ __device__ constexpr half_float::half clamp(half_float::half value,
+                                                     ret_type<half_float::half>) {
+  return value;
+}
+
+#else
+
+template <typename T>
+__host__ __device__ constexpr float16 clamp(T value, ret_type<float16>) {
+  return static_cast<float16>(value);
+}
+
+// __half does not have a constructor for int64_t, use long long
+__host__ __device__ inline float16 clamp(int64_t value, ret_type<float16>) {
+  return static_cast<float16>(static_cast<long long int>(value));  // NOLINT
+}
+
+template <typename T>
+__host__ __device__ constexpr T clamp(float16 value, ret_type<T>) {
+  return clamp(static_cast<float>(value), ret_type<T>());
+}
+
+__host__ __device__ inline bool clamp(float16 value, ret_type<bool>) {
+  return static_cast<bool>(value);
+}
+
+__host__ __device__ constexpr float16 clamp(float16 value, ret_type<float16>) {
+  return value;
+}
+
+#endif
+
 template <typename T, typename U>
 __host__ __device__ constexpr T clamp(U value) {
   return clamp(value, ret_type<T>());
@@ -187,4 +242,3 @@ ConvertNorm(In value) {
 }  // namespace dali
 
 #endif  // DALI_CORE_CONVERT_H_
-


### PR DESCRIPTION
* Add new SliceFlipNormalizePermute CPU kernel. 
* Add complete implementation of NewCropMirrorNormalize CPU. 
* Add python tests to check correctness against the old implementation

Signed-off-by: Joaquin Anton <janton@nvidia.com>