### PR TITLE
Optimize python operator outputs copy.

### DIFF
--- a/dali/pipeline/operators/CMakeLists.txt
+++ b/dali/pipeline/operators/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(sequence)
 add_subdirectory(support)
 add_subdirectory(transpose)
 add_subdirectory(util)
+add_subdirectory(python_function/util)
 
 # Get all the source files and dump test files
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)

--- a/dali/pipeline/operators/python_function/CMakeLists.txt
+++ b/dali/pipeline/operators/python_function/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 set(python_function_lib "python_function_plugin")
-add_library(${python_function_lib} SHARED python_function.cc)
+add_library(${python_function_lib} SHARED python_function.cc util/copy_with_stride.cc)
 target_link_libraries(${python_function_lib} ${dali_lib})
 target_include_directories(${python_function_lib}
         PRIVATE ${PYBIND11_INCLUDE_DIR}  # from project CMakeLists.txt

--- a/dali/pipeline/operators/python_function/util/CMakeLists.txt
+++ b/dali/pipeline/operators/python_function/util/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+collect_headers(DALI_INST_HDRS PARENT_SCOPE)
+collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operators/python_function/util/copy_with_stride.cc
+++ b/dali/pipeline/operators/python_function/util/copy_with_stride.cc
@@ -69,8 +69,8 @@ inline void CopyWithStrideHelper(void *output, const void *input,
 }
 
 inline Index DeepestContiguous(const std::vector<Index>& in_strides,
-                        const std::vector<Index>& shape,
-                        size_t item_size) {
+                               const std::vector<Index>& shape,
+                               size_t item_size) {
   ssize_t dim_prod = 1;
   for (int i = in_strides.size()-1; i >= 0; --i) {
     if (in_strides[i] != dim_prod*static_cast<Index>(item_size)) {

--- a/dali/pipeline/operators/python_function/util/copy_with_stride.cc
+++ b/dali/pipeline/operators/python_function/util/copy_with_stride.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/operators/python_function/util/copy_with_stride.h"
+#include <cstring>
+#include <cassert>
+#include "dali/core/static_switch.h"
+#include "dali/core/util.h"
+
+namespace dali {
+
+inline void CopyVec(uint8 *output, const uint8 *input, size_t elems,
+                    size_t in_stride, size_t item_size) {
+  for (size_t i = 0; i < elems; ++i) {
+    for (size_t j = 0; j < item_size; j++)
+      *output++ = input[j];
+    input += in_stride;
+  }
+}
+
+template <size_t item_size>
+inline void CopyVecStatic(uint8 *output, const uint8 *input, size_t elems, size_t in_stride) {
+  for (size_t i = 0; i < elems; ++i) {
+    for (size_t j = 0; j < item_size; j++)
+      output[j] = input[j];
+    output += item_size;
+    input += in_stride;
+  }
+}
+
+inline void CopyWithStrideHelper(void *output, const void *input,
+                                 const std::vector<Index> &in_strides,
+                                 const std::vector<Index> &out_strides,
+                                 const std::vector<Index> &shape,
+                                 Index dim, Index deepest_contiguous) {
+  auto out_ptr = reinterpret_cast<uint8*>(output);
+  auto in_ptr = reinterpret_cast<const uint8*>(input);
+  if (dim == deepest_contiguous) {
+    std::memcpy(out_ptr, in_ptr,
+        volume(shape.begin() + dim, shape.end())*out_strides.back());
+    return;
+  }
+  if (static_cast<size_t>(dim) == shape.size() - 1) {
+    VALUE_SWITCH(out_strides.back(), elem_size, (1, 2, 3, 4, 5, 6, 7, 8, 12, 16),
+                 (CopyVecStatic<elem_size>(out_ptr, in_ptr, shape.back(), in_strides.back())),
+                 (CopyVec(out_ptr, in_ptr, shape.back(), in_strides.back(), out_strides.back())));
+    return;
+  }
+  const auto out_stride = out_strides[dim];
+  const auto in_stride = in_strides[dim];
+  const auto n = shape[dim];
+  for (Index i = 0; i < n; ++i) {
+    CopyWithStrideHelper(out_ptr, in_ptr, in_strides, out_strides,
+        shape, dim + 1, deepest_contiguous);
+    out_ptr += out_stride;
+    in_ptr += in_stride;
+  }
+}
+
+inline Index DeepestContiguous(const std::vector<Index>& in_strides,
+                        const std::vector<Index>& shape,
+                        size_t item_size) {
+  ssize_t dim_prod = 1;
+  for (int i = in_strides.size()-1; i >= 0; --i) {
+    if (in_strides[i] != dim_prod*static_cast<Index>(item_size)) {
+      return i+1;
+    }
+    dim_prod *= shape[i];
+  }
+  return 0;
+}
+
+void CopyWithStride(void *output, const void *input,
+                    const std::vector<Index>& in_strides,
+                    const std::vector<Index>& shape,
+                    size_t item_size) {
+  assert(!shape.empty());
+  assert(in_strides.size() == shape.size());
+  std::vector<Index> out_strides(shape.size());
+  out_strides.back() = item_size;
+  for (Index i = shape.size() - 2; i >= 0; --i) {
+    out_strides[i] = out_strides[i + 1] * shape[i + 1];
+  }
+  auto deepest_contiguous = DeepestContiguous(in_strides, shape, item_size);
+  CopyWithStrideHelper(output, input, in_strides, out_strides, shape, 0, deepest_contiguous);
+}
+
+}  // namespace dali

--- a/dali/pipeline/operators/python_function/util/copy_with_stride.h
+++ b/dali/pipeline/operators/python_function/util/copy_with_stride.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_UTIL_COPY_WITH_STRIDE_H_
+#define DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_UTIL_COPY_WITH_STRIDE_H_
+
+#include <vector>
+#include "dali/core/common.h"
+
+namespace dali {
+
+DLL_PUBLIC void CopyWithStride(void *output, const void *input,
+                               const std::vector<Index> &in_strides,
+                               const std::vector<Index> &shape,
+                               size_t item_size);
+
+}
+
+#endif  // DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_UTIL_COPY_WITH_STRIDE_H_

--- a/dali/pipeline/operators/python_function/util/copy_with_stride_test.cc
+++ b/dali/pipeline/operators/python_function/util/copy_with_stride_test.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/pipeline/operators/python_function/util/copy_with_stride.h"
+
+namespace dali {
+
+TEST(CopyTest, OneDim) {
+  float data[] = {1, 2, 3, 4, 5, 6};
+  std::array<float, 3> out;
+  CopyWithStride(out.data(), data, {2 * sizeof(float)}, {3}, sizeof(float));
+  ASSERT_TRUE((out == std::array<float, 3>{1, 3, 5}));
+}
+
+TEST(CopyTest, TwoDims)  {
+  size_t data[] = {11, 12, 13, 14, 21, 22, 23, 24, 31, 32, 33, 34, 41, 42, 43, 44};
+  std::array<size_t, 8> out;
+  CopyWithStride(out.data(), data, {8 * sizeof(size_t), sizeof(size_t)}, {2, 4}, sizeof(size_t));
+  ASSERT_TRUE((out == std::array<size_t, 8>{11, 12, 13, 14, 31, 32, 33, 34}));
+}
+
+TEST(CopyTest, SimpleCopy) {
+  uint8 data[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  std::array<uint8, 8> out;
+  CopyWithStride(out.data(), data, {4, 2, 1}, {2, 2, 2}, 1);
+  ASSERT_TRUE((out == std::array<uint8, 8>{1, 2, 3, 4, 5, 6, 7, 8}));
+}
+
+}  // namespace dali

--- a/dali/pipeline/operators/python_function/util/copy_with_stride_test.cc
+++ b/dali/pipeline/operators/python_function/util/copy_with_stride_test.cc
@@ -17,21 +17,21 @@
 
 namespace dali {
 
-TEST(CopyTest, OneDim) {
+TEST(CopyWithStrideTest, OneDim) {
   float data[] = {1, 2, 3, 4, 5, 6};
   std::array<float, 3> out;
   CopyWithStride(out.data(), data, {2 * sizeof(float)}, {3}, sizeof(float));
   ASSERT_TRUE((out == std::array<float, 3>{1, 3, 5}));
 }
 
-TEST(CopyTest, TwoDims)  {
+TEST(CopyWithStrideTest, TwoDims)  {
   size_t data[] = {11, 12, 13, 14, 21, 22, 23, 24, 31, 32, 33, 34, 41, 42, 43, 44};
   std::array<size_t, 8> out;
   CopyWithStride(out.data(), data, {8 * sizeof(size_t), sizeof(size_t)}, {2, 4}, sizeof(size_t));
   ASSERT_TRUE((out == std::array<size_t, 8>{11, 12, 13, 14, 31, 32, 33, 34}));
 }
 
-TEST(CopyTest, SimpleCopy) {
+TEST(CopyWithStrideTest, SimpleCopy) {
   uint8 data[] = {1, 2, 3, 4, 5, 6, 7, 8};
   std::array<uint8, 8> out;
   CopyWithStride(out.data(), data, {4, 2, 1}, {2, 2, 2}, 1);


### PR DESCRIPTION
Currently, for an output with non-contiguous memory, copy is done twice - to an array with contiguous memory and then to a proper tensor. This PR replaces this double copy with single copy function.

Signed-off-by: Rafal <Banas.Rafal97@gmail.com>