### PR TITLE
Add max_size upperbound option to Resize with resize_short

### DIFF
--- a/dali/pipeline/operators/fused/resize_crop_mirror.h
+++ b/dali/pipeline/operators/fused/resize_crop_mirror.h
@@ -83,7 +83,7 @@ class ResizeCropMirrorAttr : protected CropAttr {
           const float max_size = spec.GetArgument<float>("max_size");
           if (meta.rsz_w > max_size) {
             const float ratio = meta.H / meta.W;
-            meta.rsz_h = ratio * max_size;
+            meta.rsz_h = static_cast<int>(std::round(ratio * max_size));
             meta.rsz_w = max_size;
           }
         }
@@ -96,7 +96,7 @@ class ResizeCropMirrorAttr : protected CropAttr {
           if (meta.rsz_h > max_size) {
             const float ratio = meta.W / meta.H;
             meta.rsz_h = max_size;
-            meta.rsz_w = ratio * max_size;
+            meta.rsz_w = static_cast<int>(std::round(ratio * max_size));
           }
         }
       }

--- a/dali/pipeline/operators/fused/resize_crop_mirror.h
+++ b/dali/pipeline/operators/fused/resize_crop_mirror.h
@@ -55,12 +55,9 @@ class ResizeCropMirrorAttr : protected CropAttr {
 
     max_size_enforced_ = spec.ArgumentDefined("max_size");
     if (max_size_enforced_) {
-      max_size_ = spec.GetRepeatedArgument<float>("max_size");
+      GetSingleOrRepeatedArg(spec, max_size_, "max_size", 2);
       DALI_ENFORCE(max_size_.size() > 0 && max_size_.size() <= 2,
-                    "max_size has to be either a scalar or a size 2 array.");
-      if (max_size_.size() == 1) {
-        max_size_.push_back(max_size_[0]);
-      }
+                   "max_size has to be either a scalar or a size 2 array.");
     }
   }
 

--- a/dali/pipeline/operators/fused/resize_crop_mirror.h
+++ b/dali/pipeline/operators/fused/resize_crop_mirror.h
@@ -74,17 +74,26 @@ class ResizeCropMirrorAttr : protected CropAttr {
       const int shorter_side_size = spec.GetArgument<float>("resize_shorter", ws, index);
 
       bool max_size_enforced = spec.ArgumentDefined("max_size");
+      // Contains (H, W) max sizes
+      std::vector<float> max_size;
+      if (max_size_enforced) {
+        max_size = spec.GetRepeatedArgument<float>("max_size");
+        DALI_ENFORCE(max.size() > 0 && max_size() <= 2,
+                     "max_size has to be either a scalar or a size 2 array.");
+        if (max_size.size() == 1) {
+          max_size.push_back(max_size[0]);
+        }
+      }
 
       if (meta.H < meta.W) {
         const float scale = shorter_side_size / static_cast<float>(meta.H);
         meta.rsz_h = shorter_side_size;
         meta.rsz_w = static_cast<int>(std::round(scale * meta.W));
         if (max_size_enforced) {
-          const float max_size = spec.GetArgument<float>("max_size");
-          if (meta.rsz_w > max_size) {
+          if (meta.rsz_w > max_size[1]) {
             const float ratio = meta.H / meta.W;
-            meta.rsz_h = static_cast<int>(std::round(ratio * max_size));
-            meta.rsz_w = max_size;
+            meta.rsz_h = static_cast<int>(std::round(ratio * max_size[1]));
+            meta.rsz_w = max_size[1];
           }
         }
       } else {
@@ -92,11 +101,10 @@ class ResizeCropMirrorAttr : protected CropAttr {
         meta.rsz_h = static_cast<int>(std::round(scale * meta.H));
         meta.rsz_w = shorter_side_size;
         if (max_size_enforced) {
-          const float max_size = spec.GetArgument<float>("max_size");
-          if (meta.rsz_h > max_size) {
+          if (meta.rsz_h > max_size[0]) {
             const float ratio = meta.W / meta.H;
-            meta.rsz_h = max_size;
-            meta.rsz_w = static_cast<int>(std::round(ratio * max_size));
+            meta.rsz_h = max_size[0];
+            meta.rsz_w = static_cast<int>(std::round(ratio * max_size[0]));
           }
         }
       }

--- a/dali/pipeline/operators/fused/resize_crop_mirror.h
+++ b/dali/pipeline/operators/fused/resize_crop_mirror.h
@@ -72,14 +72,33 @@ class ResizeCropMirrorAttr : protected CropAttr {
     if (resize_shorter_) {
       // resize_shorter set
       const int shorter_side_size = spec.GetArgument<float>("resize_shorter", ws, index);
+
+      bool max_size_enforced = spec.ArgumentDefined("max_size");
+
       if (meta.H < meta.W) {
         const float scale = shorter_side_size / static_cast<float>(meta.H);
         meta.rsz_h = shorter_side_size;
         meta.rsz_w = static_cast<int>(std::round(scale * meta.W));
+        if (max_size_enforced) {
+          const float max_size = spec.GetArgument<float>("max_size");
+          if (meta.rsz_w > max_size) {
+            const float ratio = meta.H / meta.W;
+            meta.rsz_h = ratio * max_size;
+            meta.rsz_w = max_size;
+          }
+        }
       } else {
         const float scale = shorter_side_size / static_cast<float>(meta.W);
         meta.rsz_h = static_cast<int>(std::round(scale * meta.H));
         meta.rsz_w = shorter_side_size;
+        if (max_size_enforced) {
+          const float max_size = spec.GetArgument<float>("max_size");
+          if (meta.rsz_h > max_size) {
+            const float ratio = meta.W / meta.H;
+            meta.rsz_h = max_size;
+            meta.rsz_w = ratio * max_size;
+          }
+        }
       }
     } else if (resize_longer_) {
         // resize_longer set
@@ -89,7 +108,6 @@ class ResizeCropMirrorAttr : protected CropAttr {
           const float scale = longer_side_size / static_cast<float>(meta.H);
           meta.rsz_h = longer_side_size;
           meta.rsz_w = static_cast<int>(std::round(scale * meta.W));
-
         } else {
           const float scale = longer_side_size / static_cast<float>(meta.W);
           meta.rsz_h = static_cast<int>(std::round(scale * meta.H));

--- a/dali/pipeline/operators/resize/resize.cc
+++ b/dali/pipeline/operators/resize/resize.cc
@@ -33,7 +33,18 @@ DALI_SCHEMA(ResizeAttr)
       "The op will keep the aspect ratio of the original image.", 0.f, true)
   .AddOptionalArg("resize_longer", "The length of the longer dimension of the resized image. "
       "This option is mutually exclusive with `resize_shorter`,`resize_x` and `resize_y`. "
-      "The op will keep the aspect ratio of the original image.", 0.f, true);
+      "The op will keep the aspect ratio of the original image.", 0.f, true)
+  .AddOptionalArg("max_size", R"code("Maximum size of the longer dimension when resizing with `resize_shorter`.
+      When set with `resize_shorter`, the shortest dimension will be resized to `resize_shorter` iff
+      the longest dim is smaller or equal to `max_size`. If not, the shortest dimension is resized to
+      satisfy the constraint "longest_dim == `max_size`.
+      Example:
+        Original image = "400x1200".
+        Resized with:
+        `resize_shorter`="200"  (`max_size` not set) => "200x600"
+        `resize_shorter`="200", `max_size`="400      => "132x400"
+        `resize_shorter`="200", `max_size`=1000      => "200x600"
+      ")code", 0.f, true);
 
 DALI_SCHEMA(Resize)
   .DocStr(R"code(Resize images.)code")

--- a/dali/pipeline/operators/resize/resize.cc
+++ b/dali/pipeline/operators/resize/resize.cc
@@ -38,7 +38,7 @@ This option is mutually exclusive with `resize_shorter`,`resize_x` and `resize_y
 The op will keep the aspect ratio of the original image.)code", 0.f, true)
   .AddOptionalArg("max_size", R"code(Maximum size of the longer dimension when resizing with `resize_shorter`.
 When set with `resize_shorter`, the shortest dimension will be resized to `resize_shorter` iff
-the longest dim is smaller or equal to `max_size`. If not, the shortest dimension is resized to
+the longest dimension is smaller or equal to `max_size`. If not, the shortest dimension is resized to
 satisfy the constraint "longest_dim == `max_size`.
 
 Example:

--- a/dali/pipeline/operators/resize/resize.cc
+++ b/dali/pipeline/operators/resize/resize.cc
@@ -40,6 +40,7 @@ The op will keep the aspect ratio of the original image.)code", 0.f, true)
 When set with `resize_shorter`, the shortest dimension will be resized to `resize_shorter` iff
 the longest dimension is smaller or equal to `max_size`. If not, the shortest dimension is resized to
 satisfy the constraint "longest_dim == `max_size`.
+Can be also an array of size 2, where the two elements are maximum size per dimension (H, W).
 
 Example:
 
@@ -49,7 +50,7 @@ Resized with:
 
 * `resize_shorter`="200"  (`max_size` not set) => "200x600"
 * `resize_shorter`="200", `max_size`="400      => "132x400"
-* `resize_shorter`="200", `max_size`=1000      => "200x600")code", 0.f, true);
+* `resize_shorter`="200", `max_size`=1000      => "200x600")code", std::vector<float>{0.f, 0.f}, true);
 
 DALI_SCHEMA(Resize)
   .DocStr(R"code(Resize images.)code")

--- a/dali/pipeline/operators/resize/resize.cc
+++ b/dali/pipeline/operators/resize/resize.cc
@@ -20,21 +20,23 @@ namespace dali {
 DALI_SCHEMA(ResizeAttr)
   .AddOptionalArg("image_type",
         R"code(The color space of input and output image.)code", DALI_RGB)
-  .AddOptionalArg("resize_x", "The length of the X dimension of the resized image. "
-      "This option is mutually exclusive with `resize_shorter`. "
-      "If the `resize_y` is left at 0, then the op will keep "
-      "the aspect ratio of the original image.", 0.f, true)
-  .AddOptionalArg("resize_y", "The length of the Y dimension of the resized image. "
-      "This option is mutually exclusive with `resize_shorter`. "
-      "If the `resize_x` is left at 0, then the op will keep "
-      "the aspect ratio of the original image.", 0.f, true)
-  .AddOptionalArg("resize_shorter", "The length of the shorter dimension of the resized image. "
-      "This option is mutually exclusive with `resize_longer`, `resize_x` and `resize_y`. "
-      "The op will keep the aspect ratio of the original image.", 0.f, true)
-  .AddOptionalArg("resize_longer", "The length of the longer dimension of the resized image. "
-      "This option is mutually exclusive with `resize_shorter`,`resize_x` and `resize_y`. "
-      "The op will keep the aspect ratio of the original image.", 0.f, true)
-  .AddOptionalArg("max_size", R"code("Maximum size of the longer dimension when resizing with `resize_shorter`.
+  .AddOptionalArg("resize_x", R"code("The length of the X dimension of the resized image.
+      This option is mutually exclusive with `resize_shorter`.
+      If the `resize_y` is left at 0, then the op will keep
+      the aspect ratio of the original image.)code", 0.f, true)
+  .AddOptionalArg("resize_y", R"code(The length of the Y dimension of the resized image.
+      This option is mutually exclusive with `resize_shorter`.
+      If the `resize_x` is left at 0, then the op will keep
+      the aspect ratio of the original image.)code", 0.f, true)
+  .AddOptionalArg("resize_shorter", R"code(The length of the shorter dimension of the resized image.
+      This option is mutually exclusive with `resize_longer`, `resize_x` and `resize_y`.
+      The op will keep the aspect ratio of the original image.
+      The longer dimension can be bounded by setting the `max_size` argument.
+      See `max_size` argument doc for more info.)code", 0.f, true)
+  .AddOptionalArg("resize_longer", R"code(The length of the longer dimension of the resized image.
+      This option is mutually exclusive with `resize_shorter`,`resize_x` and `resize_y`.
+      The op will keep the aspect ratio of the original image.)code", 0.f, true)
+  .AddOptionalArg("max_size", R"code(Maximum size of the longer dimension when resizing with `resize_shorter`.
       When set with `resize_shorter`, the shortest dimension will be resized to `resize_shorter` iff
       the longest dim is smaller or equal to `max_size`. If not, the shortest dimension is resized to
       satisfy the constraint "longest_dim == `max_size`.
@@ -43,8 +45,7 @@ DALI_SCHEMA(ResizeAttr)
         Resized with:
         `resize_shorter`="200"  (`max_size` not set) => "200x600"
         `resize_shorter`="200", `max_size`="400      => "132x400"
-        `resize_shorter`="200", `max_size`=1000      => "200x600"
-      ")code", 0.f, true);
+        `resize_shorter`="200", `max_size`=1000      => "200x600")code", 0.f, true);
 
 DALI_SCHEMA(Resize)
   .DocStr(R"code(Resize images.)code")

--- a/dali/pipeline/operators/resize/resize.cc
+++ b/dali/pipeline/operators/resize/resize.cc
@@ -20,32 +20,36 @@ namespace dali {
 DALI_SCHEMA(ResizeAttr)
   .AddOptionalArg("image_type",
         R"code(The color space of input and output image.)code", DALI_RGB)
-  .AddOptionalArg("resize_x", R"code("The length of the X dimension of the resized image.
-      This option is mutually exclusive with `resize_shorter`.
-      If the `resize_y` is left at 0, then the op will keep
-      the aspect ratio of the original image.)code", 0.f, true)
+  .AddOptionalArg("resize_x", R"code(The length of the X dimension of the resized image.
+This option is mutually exclusive with `resize_shorter`.
+If the `resize_y` is left at 0, then the op will keep
+the aspect ratio of the original image.)code", 0.f, true)
   .AddOptionalArg("resize_y", R"code(The length of the Y dimension of the resized image.
-      This option is mutually exclusive with `resize_shorter`.
-      If the `resize_x` is left at 0, then the op will keep
-      the aspect ratio of the original image.)code", 0.f, true)
+This option is mutually exclusive with `resize_shorter`.
+If the `resize_x` is left at 0, then the op will keep
+the aspect ratio of the original image.)code", 0.f, true)
   .AddOptionalArg("resize_shorter", R"code(The length of the shorter dimension of the resized image.
-      This option is mutually exclusive with `resize_longer`, `resize_x` and `resize_y`.
-      The op will keep the aspect ratio of the original image.
-      The longer dimension can be bounded by setting the `max_size` argument.
-      See `max_size` argument doc for more info.)code", 0.f, true)
+This option is mutually exclusive with `resize_longer`, `resize_x` and `resize_y`.
+The op will keep the aspect ratio of the original image.
+The longer dimension can be bounded by setting the `max_size` argument.
+See `max_size` argument doc for more info.)code", 0.f, true)
   .AddOptionalArg("resize_longer", R"code(The length of the longer dimension of the resized image.
-      This option is mutually exclusive with `resize_shorter`,`resize_x` and `resize_y`.
-      The op will keep the aspect ratio of the original image.)code", 0.f, true)
+This option is mutually exclusive with `resize_shorter`,`resize_x` and `resize_y`.
+The op will keep the aspect ratio of the original image.)code", 0.f, true)
   .AddOptionalArg("max_size", R"code(Maximum size of the longer dimension when resizing with `resize_shorter`.
-      When set with `resize_shorter`, the shortest dimension will be resized to `resize_shorter` iff
-      the longest dim is smaller or equal to `max_size`. If not, the shortest dimension is resized to
-      satisfy the constraint "longest_dim == `max_size`.
-      Example:
-        Original image = "400x1200".
-        Resized with:
-        `resize_shorter`="200"  (`max_size` not set) => "200x600"
-        `resize_shorter`="200", `max_size`="400      => "132x400"
-        `resize_shorter`="200", `max_size`=1000      => "200x600")code", 0.f, true);
+When set with `resize_shorter`, the shortest dimension will be resized to `resize_shorter` iff
+the longest dim is smaller or equal to `max_size`. If not, the shortest dimension is resized to
+satisfy the constraint "longest_dim == `max_size`.
+
+Example:
+
+Original image = "400x1200".
+
+Resized with:
+
+* `resize_shorter`="200"  (`max_size` not set) => "200x600"
+* `resize_shorter`="200", `max_size`="400      => "132x400"
+* `resize_shorter`="200", `max_size`=1000      => "200x600")code", 0.f, true);
 
 DALI_SCHEMA(Resize)
   .DocStr(R"code(Resize images.)code")

--- a/dali/pipeline/operators/resize/resize.cc
+++ b/dali/pipeline/operators/resize/resize.cc
@@ -50,7 +50,7 @@ Resized with:
 
 * `resize_shorter`="200"  (`max_size` not set) => "200x600"
 * `resize_shorter`="200", `max_size`="400      => "132x400"
-* `resize_shorter`="200", `max_size`=1000      => "200x600")code", std::vector<float>{0.f, 0.f}, true);
+* `resize_shorter`="200", `max_size`=1000      => "200x600")code", std::vector<float>{0.f, 0.f}, false);
 
 DALI_SCHEMA(Resize)
   .DocStr(R"code(Resize images.)code")

--- a/dali/pipeline/operators/resize/resize_test.cc
+++ b/dali/pipeline/operators/resize/resize_test.cc
@@ -119,29 +119,42 @@ enum {
             TESTS_WITH_CHECK(testName, interp, testArgs, Default)       \
             TESTS_WITH_CHECK(testName, interp, testArgs, Elements)
 
-TYPED_TESTS(ResizeShorter,   LINEAR, .AddArg("resize_shorter", 480.f))
-TYPED_TESTS(ResizeShorter_A, LINEAR, .AddArg("resize_shorter", 224.f))
-TYPED_TESTS(ResizeLonger,    LINEAR, .AddArg("resize_longer",  640.f))
-TYPED_TESTS(ResizeLonger_A,  LINEAR, .AddArg("resize_longer",  960.f))
-TYPED_TESTS(ResizeXY,        LINEAR, .AddArg("resize_x", 224.f)         \
+TYPED_TESTS(ResizeShorter,       LINEAR, .AddArg("resize_shorter", 480.f))
+TYPED_TESTS(ResizeShorter_A,     LINEAR, .AddArg("resize_shorter", 224.f))
+TYPED_TESTS(ResizeShorterMax,    LINEAR, .AddArg("resize_shorter", 240.f)   \
+                                         .AddArg("max_size",      400.f))
+TYPED_TESTS(ResizeShorterMax_A,  LINEAR, .AddArg("resize_shorter", 400.f)   \
+                                         .AddArg("max_size",      1000.f))
+TYPED_TESTS(ResizeLonger,        LINEAR, .AddArg("resize_longer",  640.f))
+TYPED_TESTS(ResizeLonger_A,      LINEAR, .AddArg("resize_longer",  960.f))
+TYPED_TESTS(ResizeXY,            LINEAR, .AddArg("resize_x", 224.f)         \
                                      .AddArg("resize_y", 224.f))
-TYPED_TESTS(ResizeXY_A,      LINEAR, .AddArg("resize_x", 240.f)         \
+TYPED_TESTS(ResizeXY_A,          LINEAR, .AddArg("resize_x", 240.f)         \
+                                         .AddArg("resize_y", 480.f))
+TYPED_TESTS(ResizeShorter,           NN, .AddArg("resize_shorter", 480.f))
+TYPED_TESTS(ResizeShorter_A,         NN, .AddArg("resize_shorter", 224.f))
+TYPED_TESTS(ResizeShorterMax,        NN, .AddArg("resize_shorter", 240.f)   \
+                                         .AddArg("max_size",      400.f))
+TYPED_TESTS(ResizeShorterMax_A,      NN, .AddArg("resize_shorter", 400.f)   \
+                                         .AddArg("max_size",      1000.f))
+TYPED_TESTS(ResizeLonger,            NN, .AddArg("resize_longer",  640.f))
+TYPED_TESTS(ResizeLonger_A,          NN, .AddArg("resize_longer",  960.f))
+TYPED_TESTS(ResizeXY,                NN, .AddArg("resize_x", 224.f)         \
+                                         .AddArg("resize_y", 224.f))
+TYPED_TESTS(ResizeXY_A,              NN, .AddArg("resize_x", 240.f)         \
+                                         .AddArg("resize_y", 480.f))
+TYPED_TESTS(ResizeShorter,        CUBIC, .AddArg("resize_shorter", 480.f))
+TYPED_TESTS(ResizeShorter_A,      CUBIC, .AddArg("resize_shorter", 224.f))
+TYPED_TESTS(ResizeShorterMax,     CUBIC, .AddArg("resize_shorter", 240.f)   \
+                                         .AddArg("max_size",      400.f))
+TYPED_TESTS(ResizeShorterMax_A,   CUBIC, .AddArg("resize_shorter", 400.f)   \
+                                         .AddArg("max_size",      1000.f))
+TYPED_TESTS(ResizeLonger,         CUBIC, .AddArg("resize_longer",  640.f))
+TYPED_TESTS(ResizeLonger_A,       CUBIC, .AddArg("resize_longer",  960.f))
+TYPED_TESTS(ResizeXY,             CUBIC, .AddArg("resize_x", 224.f)         \
+                                         .AddArg("resize_y", 224.f))
+TYPED_TESTS(ResizeXY_A,           CUBIC, .AddArg("resize_x", 240.f)         \
                                      .AddArg("resize_y", 480.f))
-TYPED_TESTS(ResizeShorter,       NN, .AddArg("resize_shorter", 480.f))
-TYPED_TESTS(ResizeShorter_A,     NN, .AddArg("resize_shorter", 224.f))
-TYPED_TESTS(ResizeLonger,        NN, .AddArg("resize_longer",  640.f))
-TYPED_TESTS(ResizeLonger_A,      NN, .AddArg("resize_longer",  960.f))
-TYPED_TESTS(ResizeXY,            NN, .AddArg("resize_x", 224.f)         \
-                                     .AddArg("resize_y", 224.f))
-TYPED_TESTS(ResizeXY_A,          NN, .AddArg("resize_x", 240.f)         \
-                                     .AddArg("resize_y", 480.f))
-TYPED_TESTS(ResizeShorter,    CUBIC, .AddArg("resize_shorter", 480.f))
-TYPED_TESTS(ResizeShorter_A,  CUBIC, .AddArg("resize_shorter", 224.f))
-TYPED_TESTS(ResizeLonger,     CUBIC, .AddArg("resize_longer",  640.f))
-TYPED_TESTS(ResizeLonger_A,   CUBIC, .AddArg("resize_longer",  960.f))
-TYPED_TESTS(ResizeXY,         CUBIC, .AddArg("resize_x", 224.f)         \
-                                     .AddArg("resize_y", 224.f))
-TYPED_TESTS(ResizeXY_A,       CUBIC, .AddArg("resize_x", 240.f)         \
-                                     .AddArg("resize_y", 480.f))
+
 
 }  // namespace dali

--- a/dali/pipeline/operators/resize/resize_test.cc
+++ b/dali/pipeline/operators/resize/resize_test.cc
@@ -25,18 +25,24 @@ namespace dali {
 static double testEps[] = {     //     TEST:
                     0.2, 0.3,   // ResizeShorter_LINEAR
                     0.2, 0.3,   // ResizeShorter_A_LINEAR
+                    0.2, 0.3,   // ResizeShorterMax_LINEAR
+                    0.2, 0.3,   // ResizeShorterMax_A_LINEAR
                     0.2, 0.3,   // ResizeLonger_LINEAR
                     0.2, 0.3,   // ResizeLonger_A_LINEAR
                     0.2, 0.3,   // ResizeXY_LINEAR
                     0.2, 0.3,   // ResizeXY_A_LINEAR
                     1.1, 2.2,   // ResizeShorter_NN
                     1.1, 2.2,   // ResizeShorter_A_NN
+                    1.1, 2.2,   // ResizeShorterMax_NN
+                    1.1, 2.2,   // ResizeShorterMax_A_NN
                     1.1, 2.2,   // ResizeLonger_NN
                     1.1, 2.2,   // ResizeLonger_A_NN
                     1.1, 2.2,   // ResizeXY_NN
                     1.1, 2.2,   // ResizeXY_A_NN
                     0.3, 0.6,   // ResizeShorter_CUBIC
                     0.3, 0.6,   // ResizeShorter_A_CUBIC
+                    0.3, 0.6,   // ResizeShorterMax_CUBIC
+                    0.3, 0.6,   // ResizeShorterMax_A_CUBIC
                     0.3, 0.6,   // ResizeLonger_CUBIC
                     0.3, 0.6,   // ResizeLonger_A_CUBIC
                     0.3, 0.6,   // ResizeXY_CUBIC
@@ -63,18 +69,24 @@ TYPED_TEST_SUITE(ResizeTest, Types);
 typedef enum {
   t_ResizeShorter_LINEAR,
   t_ResizeShorter_A_LINEAR,
+  t_ResizeShorterMax_LINEAR,
+  t_ResizeShorterMax_A_LINEAR,
   t_ResizeLonger_LINEAR,
   t_ResizeLonger_A_LINEAR,
   t_ResizeXY_LINEAR,
   t_ResizeXY_A_LINEAR,
   t_ResizeShorter_NN,
   t_ResizeShorter_A_NN,
+  t_ResizeShorterMax_NN,
+  t_ResizeShorterMax_A_NN,
   t_ResizeLonger_NN,
   t_ResizeLonger_A_NN,
   t_ResizeXY_NN,
   t_ResizeXY_A_NN,
   t_ResizeShorter_CUBIC,
   t_ResizeShorter_A_CUBIC,
+  t_ResizeShorterMax_CUBIC,
+  t_ResizeShorterMax_A_CUBIC,
   t_ResizeLonger_CUBIC,
   t_ResizeLonger_A_CUBIC,
   t_ResizeXY_CUBIC,
@@ -128,7 +140,7 @@ TYPED_TESTS(ResizeShorterMax_A,  LINEAR, .AddArg("resize_shorter", 400.f)   \
 TYPED_TESTS(ResizeLonger,        LINEAR, .AddArg("resize_longer",  640.f))
 TYPED_TESTS(ResizeLonger_A,      LINEAR, .AddArg("resize_longer",  960.f))
 TYPED_TESTS(ResizeXY,            LINEAR, .AddArg("resize_x", 224.f)         \
-                                     .AddArg("resize_y", 224.f))
+                                         .AddArg("resize_y", 224.f))
 TYPED_TESTS(ResizeXY_A,          LINEAR, .AddArg("resize_x", 240.f)         \
                                          .AddArg("resize_y", 480.f))
 TYPED_TESTS(ResizeShorter,           NN, .AddArg("resize_shorter", 480.f))
@@ -154,7 +166,7 @@ TYPED_TESTS(ResizeLonger_A,       CUBIC, .AddArg("resize_longer",  960.f))
 TYPED_TESTS(ResizeXY,             CUBIC, .AddArg("resize_x", 224.f)         \
                                          .AddArg("resize_y", 224.f))
 TYPED_TESTS(ResizeXY_A,           CUBIC, .AddArg("resize_x", 240.f)         \
-                                     .AddArg("resize_y", 480.f))
+                                         .AddArg("resize_y", 480.f))
 
 
 }  // namespace dali

--- a/dali/test/dali_test_resize.h
+++ b/dali/test/dali_test_resize.h
@@ -33,6 +33,8 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
 
     int resize_a = 0, resize_b = 0;
     bool warp_resize = true, resize_shorter = true;
+    bool max_size_enforced = false;
+    float max_size = 0.f;
     const OpSpec &spec = this->GetOperationSpec();
     const bool useExternSizes = (resizeOptions & t_externSizes) &&
                                 spec.GetArgument<bool>("save_attrs");
@@ -49,6 +51,10 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
         if (resize_a == 0) {
           resize_a = spec.GetArgument<float>("resize_longer");
           resize_shorter = false;
+        } else {
+          max_size_enforced = spec.ArgumentDefined("max_size");
+          if (max_size_enforced)
+            max_size = spec.GetArgument<float>("max_size");
         }
       }
     }
@@ -80,6 +86,13 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
             if (resize_shorter) {
               rsz_w = resize_a;
               rsz_h = static_cast<int>(std::round(H * static_cast<float>(rsz_w) / W));
+              if (max_size_enforced) {
+                if (rsz_h > max_size) {
+                  const float ratio = W / H;
+                  rsz_w = ratio * max_size;
+                  rsz_h = max_size;
+                }
+              }
             } else {
               rsz_h = resize_a;
               rsz_w = static_cast<int>(std::round(W * static_cast<float>(rsz_h) / H));
@@ -88,6 +101,13 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
             if (resize_shorter) {
               rsz_h = resize_a;
               rsz_w = static_cast<int>(std::round(W * static_cast<float>(rsz_h) / H));
+               if (max_size_enforced) {
+                if (rsz_w > max_size) {
+                  const float ratio = H / W;
+                  rsz_h = ratio * max_size;
+                  rsz_w = max_size;
+                }
+              }
             } else {
               rsz_w = resize_a;
               rsz_h = static_cast<int>(std::round(H * static_cast<float>(rsz_w) / W));

--- a/dali/test/dali_test_resize.h
+++ b/dali/test/dali_test_resize.h
@@ -89,7 +89,7 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
               if (max_size_enforced) {
                 if (rsz_h > max_size) {
                   const float ratio = W / H;
-                  rsz_w = ratio * max_size;
+                  rsz_w = static_cast<int>(std::round(ratio * max_size));
                   rsz_h = max_size;
                 }
               }
@@ -104,7 +104,7 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
                if (max_size_enforced) {
                 if (rsz_w > max_size) {
                   const float ratio = H / W;
-                  rsz_h = ratio * max_size;
+                  rsz_h = static_cast<int>(std::round(ratio * max_size));
                   rsz_w = max_size;
                 }
               }

--- a/dali/test/dali_test_resize.h
+++ b/dali/test/dali_test_resize.h
@@ -34,7 +34,7 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
     int resize_a = 0, resize_b = 0;
     bool warp_resize = true, resize_shorter = true;
     bool max_size_enforced = false;
-    float max_size = 0.f;
+    std::vector<float> max_size;
     const OpSpec &spec = this->GetOperationSpec();
     const bool useExternSizes = (resizeOptions & t_externSizes) &&
                                 spec.GetArgument<bool>("save_attrs");
@@ -53,8 +53,12 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
           resize_shorter = false;
         } else {
           max_size_enforced = spec.ArgumentDefined("max_size");
-          if (max_size_enforced)
-            max_size = spec.GetArgument<float>("max_size");
+          if (max_size_enforced) {
+            max_size = spec.GetRepeatedArgument<float>("max_size");
+            if (max_size.size() == 1) {
+              max_size.push_back(max_size[0]);
+            }
+          }
         }
       }
     }
@@ -87,10 +91,10 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
               rsz_w = resize_a;
               rsz_h = static_cast<int>(std::round(H * static_cast<float>(rsz_w) / W));
               if (max_size_enforced) {
-                if (rsz_h > max_size) {
+                if (rsz_h > max_size[0]) {
                   const float ratio = W / H;
-                  rsz_w = static_cast<int>(std::round(ratio * max_size));
-                  rsz_h = max_size;
+                  rsz_w = static_cast<int>(std::round(ratio * max_size[0]));
+                  rsz_h = max_size[0];
                 }
               }
             } else {
@@ -102,10 +106,10 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
               rsz_h = resize_a;
               rsz_w = static_cast<int>(std::round(W * static_cast<float>(rsz_h) / H));
                if (max_size_enforced) {
-                if (rsz_w > max_size) {
+                if (rsz_w > max_size[1]) {
                   const float ratio = H / W;
-                  rsz_h = static_cast<int>(std::round(ratio * max_size));
-                  rsz_w = max_size;
+                  rsz_h = static_cast<int>(std::round(ratio * max_size[1]));
+                  rsz_w = max_size[1];
                 }
               }
             } else {

--- a/dali/test/dali_test_resize.h
+++ b/dali/test/dali_test_resize.h
@@ -54,10 +54,7 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
         } else {
           max_size_enforced = spec.ArgumentDefined("max_size");
           if (max_size_enforced) {
-            max_size = spec.GetRepeatedArgument<float>("max_size");
-            if (max_size.size() == 1) {
-              max_size.push_back(max_size[0]);
-            }
+            GetSingleOrRepeatedArg(spec, max_size, "max_size", 2);
           }
         }
       }


### PR DESCRIPTION
Maximum size of the longer dimension when resizing with `resize_shorter`.
When set with `resize_shorter`, the shortest dimension will be resized to `resize_shorter` iff
the longest dim is smaller or equal to `max_size`. If not, the shortest dimension is resized to
satisfy the constraint "longest_dim == `max_size`.
Example:
Original image = "400x1200".
      Resized with:
        `resize_shorter`="200"  (`max_size` not set) => "200x600"
        `resize_shorter`="200", `max_size`="400      => "132x400"
        `resize_shorter`="200", `max_size`=1000      => "200x600"

Signed-off-by: Serge Panev <spanev@nvidia.com>