### PR TITLE
Handle NULL pointer in ctypes_void_ptr

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -39,6 +39,9 @@ static void* ctypes_void_ptr(const py::object& object) {
     return nullptr;
   }
   PyObject *ptr_as_int = PyObject_GetAttr(p_ptr, PyUnicode_FromString("value"));
+  if (ptr_as_int == Py_None) {
+    return nullptr;
+  }
   void *ptr = PyLong_AsVoidPtr(ptr_as_int);
   return ptr;
 }


### PR DESCRIPTION
Since a94190ca4bcfcdb94802c3e74b4259fe51e5f58f, a CUDA stream can be
passed to `copy_to_external`.

When passing the default CUDA stream to this function, for instance
with `ctypes.c_void_p(0)`, this parameter is converted to the `None`
Python singleton, and thus is not a valid integer value that can be
passed to `PyLong_AsVoidPtr`. This was causing `copy_to_external` to
return with the exception "TypeError: an integer is required" being
set.

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>