### PR TITLE
Expose and document fine grain control API for pipeline run

### DIFF
--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -114,7 +114,7 @@ class DALIGenericIterator(object):
         # We need data about the batches (like shape information),
         # so we need to run a single batch as part of setup to get that info
         for p in self._pipes:
-            p._run()
+            p.schedule_run()
         self._first_batch = None
         self._first_batch = self.next()
         # Set data descriptors for MXNet
@@ -146,7 +146,7 @@ class DALIGenericIterator(object):
         # Gather outputs
         outputs = []
         for p in self._pipes:
-            outputs.append(p._share_outputs())
+            outputs.append(p.share_outputs())
         for i in range(self._num_gpus):
             # MXNet wants batches with clear distinction between
             # data and label entries, so segregate outputs into
@@ -200,8 +200,8 @@ class DALIGenericIterator(object):
                 feed_ndarray(category_tensors[DALIGenericIterator.LABEL_TAG][j], l_arr)
 
         for p in self._pipes:
-            p._release_outputs()
-            p._run()
+            p.release_outputs()
+            p.schedule_run()
 
         copy_db_index = self._current_data_batch
         # Change index for double buffering

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -108,7 +108,7 @@ class DALIGenericIterator(object):
         # We need data about the batches (like shape information),
         # so we need to run a single batch as part of setup to get that info
         for p in self._pipes:
-            p._run()
+            p.schedule_run()
         self._first_batch = None
         self._first_batch = self.next()
 
@@ -124,7 +124,7 @@ class DALIGenericIterator(object):
         # Gather outputs
         outputs = []
         for p in self._pipes:
-            outputs.append(p._share_outputs())
+            outputs.append(p.share_outputs())
         for i in range(self._num_gpus):
             dev_id = self._pipes[i].device_id
             # initialize dict for all output categories
@@ -170,8 +170,8 @@ class DALIGenericIterator(object):
                   feed_ndarray(tensor, pyt_tensors[category])
 
         for p in self._pipes:
-            p._release_outputs()
-            p._run()
+            p.release_outputs()
+            p.schedule_run()
 
         copy_db_index = self._current_data_batch
         # Change index for double buffering

--- a/dali/test/python/test_data_containers.py
+++ b/dali/test/python/test_data_containers.py
@@ -149,7 +149,7 @@ for pipe_name in test_data.keys():
         print (data_set)
         for j in range(iters):
             for pipe in pipes:
-                pipe._run()
+                pipe.schedule_run()
             for pipe in pipes:
                 pipe.outputs()
             if j % LOG_INTERVAL == 0:


### PR DESCRIPTION
- exposes and documents run_no_result, share_outputs and release_outputs API
- adds a paragraph to the advanced section of the docs what kind of API to run and
  get the results from the pipeline is available to the user and how to utilize it

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>