### PR TITLE
Add casting to float before normalization in SliceFlipNormalizePermute tests

### DIFF
--- a/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
@@ -111,7 +111,8 @@ class SliceFlipNormalizePermuteTest : public ::testing::Test {
         if (!is_zero_pad) {
           if (!mean.empty() && !inv_stddev.empty()) {
             auto c = mean.size() == 1 ? 0 : out_idx % out_shape[Dims - 1];
-            output_value = (clamp<OutputType>(in_tensor[in_idx]) - mean[c]) * inv_stddev[c];
+            output_value = clamp<OutputType>(
+              (static_cast<float>(in_tensor[in_idx]) - mean[c]) * inv_stddev[c]);
           } else {
             output_value = clamp<OutputType>(in_tensor[in_idx]);
           }


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>