### PR TITLE
Rework how DALI handles py_buffer format string

### DIFF
--- a/dali/util/pybind.h
+++ b/dali/util/pybind.h
@@ -26,24 +26,42 @@ namespace dali {
 namespace py = pybind11;
 
 static std::string FormatStrFromType(const TypeInfo &type) {
-  if (IsType<uint8>(type)) {
-    return py::format_descriptor<uint8>::format();
-  } else if (IsType<int16>(type)) {
-    return py::format_descriptor<int16>::format();
-  } else if (IsType<int>(type)) {
-    return py::format_descriptor<int>::format();
-  } else if (IsType<long>(type)) { // NOLINT
-    return py::format_descriptor<long>::format(); // NOLINT
-  } else if (IsType<int64>(type)) { // NOLINT
-    return py::format_descriptor<long long>::format(); // NOLINT
+  if (IsType<int8_t>(type)) {
+    return "=b";
+  } else if (IsType<uint8_t>(type)) {
+    return "=B";
+  } else if (IsType<char>(type)) {
+    return "=c";
+  } else if (IsType<int16_t>(type)) {
+    return "=h";
+  } else if (IsType<uint16_t>(type)) {
+    return "=H";
+  } else if (IsType<int32_t>(type) ||
+            (IsType<long>(type) && sizeof(long) == sizeof(int32_t))) {  // NOLINT
+    return "=i";
+  } else if (IsType<uint32_t>(type) ||
+            (IsType<unsigned long>(type) && sizeof(unsigned long) == sizeof(uint32_t))) {  // NOLINT
+    return "=I";
+  } else if (IsType<int64_t>(type) ||
+            (IsType<long>(type) && sizeof(long) == sizeof(int64_t)) ||  // NOLINT
+            (IsType<long long>(type) && sizeof(long long) == sizeof(int64_t))) {  // NOLINT
+    return "=q";
+  } else if (IsType<uint64_t>(type) ||
+            (IsType<unsigned long>(type) && sizeof(unsigned long) == sizeof(uint64_t)) ||  // NOLINT
+            (IsType<unsigned long long>(type) && sizeof(unsigned long long) == sizeof(uint64_t))) {  // NOLINT
+    return "=Q";
   } else if (IsType<float>(type)) {
-    return py::format_descriptor<float>::format();
+    return "=f";
   } else if (IsType<double>(type)) {
-    return py::format_descriptor<double>::format();
+    return "=d";
   } else if (IsType<bool>(type)) {
-    return py::format_descriptor<bool>::format();
+    return "=?";
   } else if (IsType<float16>(type)) {
-    return "f2";
+    return "=e";
+  } else if (IsType<ssize_t>(type)) {
+    return "=n";
+  } else if (IsType<size_t>(type)) {
+    return "=N";
   } else {
     DALI_FAIL("Cannot convert type " + type.name() +
         " to format descriptor string");
@@ -51,26 +69,86 @@ static std::string FormatStrFromType(const TypeInfo &type) {
 }
 
 static TypeInfo TypeFromFormatStr(const std::string &format) {
-  if (format == py::format_descriptor<uint8>::format()) {
-    return TypeInfo::Create<uint8>();
-  } else if (format == py::format_descriptor<int16>::format()) {
-    return TypeInfo::Create<int16>();
-  } else if (format == py::format_descriptor<int>::format()) {
-    return TypeInfo::Create<int>();
-  } else if (format == py::format_descriptor<long>::format()) { // NOLINT
-    return TypeInfo::Create<long>(); // NOLINT
-  } else if (format == py::format_descriptor<long long>::format()) { // NOLINT
-    return TypeInfo::Create<int64>(); // NOLINT
-  } else if (format == py::format_descriptor<float>::format()) {
-    return TypeInfo::Create<float>();
-  } else if (format == py::format_descriptor<double>::format()) {
-    return TypeInfo::Create<double>();
-  } else if (format == py::format_descriptor<bool>::format()) {
-    return TypeInfo::Create<bool>();
-  } else if (format == "f2") {
-    return TypeInfo::Create<float16>();
-  } else {
-    DALI_FAIL("Cannot create type for unknown format string: " + format);
+  std::string format_letter = format;
+  std::string modificator_letter = "@";
+  if (format.size() > 1) {
+    format_letter = std::string(format, 1, 1);
+    modificator_letter = std::string(format, 0, 1);
+  }
+
+  if (modificator_letter == "=") {
+    // create tensors with well defined element sizes under the hood
+    if (format_letter == "c") {
+      return TypeInfo::Create<char>();
+    } else if (format_letter == "b") {
+      return TypeInfo::Create<int8_t>();
+    } else if (format_letter == "B") {
+      return TypeInfo::Create<uint8_t>();
+    } else if (format_letter == "h") {
+      return TypeInfo::Create<int16_t>();
+    } else if (format_letter == "H") {
+      return TypeInfo::Create<uint16_t>();
+    } else if (format_letter == "i" || format_letter == "l") {
+      return TypeInfo::Create<int32_t>();
+    } else if (format_letter == "I") {
+      return TypeInfo::Create<uint32_t>();
+    } else if (format_letter == "q") {
+      return TypeInfo::Create<int64_t>();
+    } else if (format_letter == "Q") {
+      return TypeInfo::Create<uint64_t>();
+    } else if (format_letter == "f") {
+      return TypeInfo::Create<float>();
+    } else if (format_letter == "d") {
+      return TypeInfo::Create<double>();
+    } else if (format_letter == "?") {
+      return TypeInfo::Create<bool>();
+    } else if (format_letter == "e") {
+      return TypeInfo::Create<float16>();
+    } else if (format_letter == "n") {
+      return TypeInfo::Create<ssize_t>();
+    } else if (format_letter == "N") {
+      return TypeInfo::Create<size_t>();
+    } else {
+      DALI_FAIL("Cannot create type for unknown format string: " + format);
+    }
+  } else {  // for '@' or any other case as we don't care about endianess, at least now
+    // create tensor with elements of whatever size there is under the hood
+    if (format_letter == "c") {
+      return TypeInfo::Create<char>();
+    } else if (format_letter == "b") {
+      return TypeInfo::Create<signed char>();
+    } else if (format_letter == "B") {
+      return TypeInfo::Create<unsigned char>();
+    } else if (format_letter == "h") {
+      return TypeInfo::Create<short>();  // NOLINT
+    } else if (format_letter == "H") {
+      return TypeInfo::Create<unsigned short>();  // NOLINT
+    } else if (format_letter == "i" ||
+              (format_letter == "l" && sizeof(long) == sizeof(int))) { // NOLINT
+      // long size may differ depending on the platform, special case for that here
+      return TypeInfo::Create<int>();
+    } else if (format_letter == "I" ||
+              (format_letter == "L" && sizeof(long) == sizeof(int))) { // NOLINT
+      return TypeInfo::Create<unsigned int>();
+    } else if (format_letter == "q" ||
+              (format_letter == "l" && sizeof(long) == sizeof(long long))) { // NOLINT
+      // long size may differ depending on the platform, special case for that here
+      return TypeInfo::Create<long long>();  // NOLINT
+    } else if (format_letter == "Q" ||
+              (format_letter == "L" && sizeof(long) == sizeof(long long))) { // NOLINT
+      // long size may differ depending on the platform, special case for that here
+      return TypeInfo::Create<unsigned long long>();  // NOLINT
+    } else if (format_letter == "f") {
+      return TypeInfo::Create<float>();
+    } else if (format_letter == "d") {
+      return TypeInfo::Create<double>();
+    } else if (format_letter == "?") {
+      return TypeInfo::Create<bool>();
+    } else if (format_letter == "e") {
+      return TypeInfo::Create<float16>();
+    } else {
+      DALI_FAIL("Cannot create type for unknown format string: " + format);
+    }
   }
 }
 


### PR DESCRIPTION
- makes DALI more alligned with py_buffer protocol format characters, adds
  cases for native and standard size specifier
- adds support for the proper float16 format character

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>