### PR TITLE
Read COCO categories from json file in COCOReader

### DIFF
--- a/dali/pipeline/operators/reader/loader/coco_loader.cc
+++ b/dali/pipeline/operators/reader/loader/coco_loader.cc
@@ -349,11 +349,12 @@ void ParseAnnotationFilesHelper(std::vector<std::string> &annotations_filename,
       } else if (0 == strcmp(key, "categories")) {
         RAPIDJSON_ASSERT(r.PeekType() == kArrayType);
         r.EnterArray();
-        int id = -1;
+        int id;
         while (r.NextArrayValue()) {
           if (r.PeekType() != kObjectType) {
             continue;
           }
+          id = -1;
           r.EnterObject();
           while (const char* internal_key = r.NextObjectKey()) {
             if (0 == strcmp(internal_key, "id")) {
@@ -362,10 +363,9 @@ void ParseAnnotationFilesHelper(std::vector<std::string> &annotations_filename,
               r.SkipValue();
             }
           }
-          if (id != -1) {
-            category_ids.insert(std::make_pair(id, current_id));
-            current_id++;
-          }
+          DALI_ENFORCE(id != -1, "Missing category ID in the JSON annotations file");
+          category_ids.insert(std::make_pair(id, current_id));
+          current_id++;
         }
       } else if (0 == strcmp(key, "annotations")) {
         RAPIDJSON_ASSERT(r.PeekType() == kArrayType);


### PR DESCRIPTION
This PR allows COCOReader to gather the COCO categories directly from the json annotation file instead of hardcoding the id -> category_id map.

This is necessary to be able to use annotations from other datasets converted into the COCO format and be future proof regarding COCO changes.

This was tested on the official COCO 2017 train/val annotations and on the [Pascal VOC 2007 COCO annotations](https://storage.googleapis.com/coco-dataset/external/PASCAL_VOC.zip).