### PR TITLE
Introduce number of samples to TensorListShape

### DIFF
--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -596,6 +596,14 @@ struct TensorListShape<DynamicDimensions>
     other.num_samples_ = 0;
   }
 
+  explicit TensorListShape(int num_samples) : Base() {
+    resize(num_samples);
+  }
+
+  TensorListShape(int num_samples, int ndim) : Base()  {
+    resize(num_samples, ndim);
+  }
+
   TensorListShape(const std::vector<std::vector<int64_t>> &sample_shapes)  // NOLINT
       : Base(flatten_shapes(sample_shapes), sample_shapes.size()),
         dim(get_dim_from_uniform(sample_shapes)) {}
@@ -606,8 +614,19 @@ struct TensorListShape<DynamicDimensions>
 
   TensorListShape(const std::vector<int64_t> &shapes, int ndim)
       : Base(shapes, shapes.size() / ndim), dim(ndim) {}
+
   TensorListShape(std::vector<int64_t> &&shapes, int ndim)
       : Base(std::move(shapes), shapes.size() / ndim), dim(ndim) {}
+
+  TensorListShape(const std::vector<int64_t> &shapes, int num_samples, int ndim)
+      : Base(shapes, num_samples), dim(ndim) {
+    assert(num_samples == shapes.size() / ndim);
+  }
+
+  TensorListShape(std::vector<int64_t> &&shapes, int num_samples, int ndim)
+      : Base(std::move(shapes), num_samples), dim(ndim) {
+    assert(num_samples == shapes.size() / ndim);
+  }
 
   TensorListShape &operator=(const TensorListShape &) = default;
   TensorListShape &operator=(TensorListShape &&other) {
@@ -681,18 +700,38 @@ struct TensorListShape : TensorListShapeBase<TensorListShape<sample_ndim>, sampl
     other.num_samples_ = 0;
   }
 
+  explicit TensorListShape(int num_samples) : Base() {
+    Base::resize(num_samples);
+  }
+
+  TensorListShape(int num_samples, int ndim) : Base()  {
+    assert(ndim == sample_ndim);
+    Base::resize(num_samples, ndim);
+  }
+
   TensorListShape(const std::vector<TensorShape<sample_ndim>> &sample_shapes)  // NOLINT
       : Base(flatten_shapes(sample_shapes), sample_shapes.size()) {}
+
+  TensorListShape(const std::vector<int64_t> &shapes, int ndim)
+      : Base(shapes, shapes.size() / ndim) {
+    assert(ndim == sample_ndim);
+  }
+
+  TensorListShape(std::vector<int64_t> &&shapes, int ndim)
+      : Base(std::move(shapes), shapes.size() / ndim) {
+    assert(ndim == sample_ndim);
+  }
 
   TensorListShape(const std::vector<int64_t> &shapes, int num_samples, int ndim)
       : Base(shapes, num_samples) {
     assert(ndim == sample_ndim);
-    assert(num_samples == static_cast<int>(shapes.size()) / ndim);
+    assert(num_samples == shapes.size() / ndim);
   }
 
   TensorListShape(std::vector<int64_t> &&shapes, int num_samples, int ndim)
       : Base(std::move(shapes), num_samples) {
     assert(ndim == sample_ndim);
+    assert(num_samples == shapes.size() / ndim);
   }
 
   TensorListShape &operator=(const TensorListShape &) = default;

--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -620,12 +620,12 @@ struct TensorListShape<DynamicDimensions>
 
   TensorListShape(const std::vector<int64_t> &shapes, int num_samples, int ndim)
       : Base(shapes, num_samples), dim(ndim) {
-    assert(num_samples == shapes.size() / ndim);
+    assert(num_samples == static_cast<int>(shapes.size()) / ndim);
   }
 
   TensorListShape(std::vector<int64_t> &&shapes, int num_samples, int ndim)
       : Base(std::move(shapes), num_samples), dim(ndim) {
-    assert(num_samples == shapes.size() / ndim);
+    assert(num_samples == static_cast<int>(shapes.size()) / ndim);
   }
 
   TensorListShape &operator=(const TensorListShape &) = default;
@@ -725,13 +725,13 @@ struct TensorListShape : TensorListShapeBase<TensorListShape<sample_ndim>, sampl
   TensorListShape(const std::vector<int64_t> &shapes, int num_samples, int ndim)
       : Base(shapes, num_samples) {
     assert(ndim == sample_ndim);
-    assert(num_samples == shapes.size() / ndim);
+    assert(num_samples == static_cast<int>(shapes.size()) / ndim);
   }
 
   TensorListShape(std::vector<int64_t> &&shapes, int num_samples, int ndim)
       : Base(std::move(shapes), num_samples) {
     assert(ndim == sample_ndim);
-    assert(num_samples == shapes.size() / ndim);
+    assert(num_samples == static_cast<int>(shapes.size()) / ndim);
   }
 
   TensorListShape &operator=(const TensorListShape &) = default;

--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -495,6 +495,7 @@ struct TensorListShapeBase {
     return out;
   }
 
+  // Resolves ambiguity when used with brace-enclosed initializer list
   void set_tensor_shape(int64_t sample, const TensorShape<sample_ndim> &sample_shape) {
     set_tensor_shape<TensorShape<sample_ndim>>(sample, sample_shape);
   }

--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -641,8 +641,6 @@ struct TensorListShape<DynamicDimensions>
 
   int sample_dim() const { return dim; }
 
-  void set_sample_dim(int dim) { this->dim = dim; }
-
   int dim;
   using Base::shapes;
 
@@ -665,6 +663,11 @@ struct TensorListShape<DynamicDimensions>
     assert(sample_dim() == other_ndim && "Cannot convert to other ndim");
     return { std::move(shapes), size(), other_ndim };
   }
+
+ private:
+  void set_sample_dim(int dim) { this->dim = dim; }
+
+  friend struct TensorListShapeBase<TensorListShape<DynamicDimensions>, DynamicDimensions>;
 };
 
 template <int sample_ndim>
@@ -711,10 +714,6 @@ struct TensorListShape : TensorListShapeBase<TensorListShape<sample_ndim>, sampl
 
   constexpr int sample_dim() const noexcept { return sample_ndim; }
 
-  void set_sample_dim(int dim) {
-    assert(dim == sample_ndim && "Cannot change number of dimensions");
-  }
-
   using Base::shapes;
   using Base::num_samples_;
 
@@ -730,8 +729,12 @@ struct TensorListShape : TensorListShapeBase<TensorListShape<sample_ndim>, sampl
     return { std::move(shapes), num_samples_, other_ndim };
   }
 
-  template <int other_sample_ndim>
-  friend struct TensorListShape;
+ private:
+  void set_sample_dim(int dim) {
+    assert(dim == sample_ndim && "Cannot change number of dimensions");
+  }
+
+  friend struct TensorListShapeBase<TensorListShape<sample_ndim>, sample_ndim>;
 };
 
 

--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -558,10 +558,10 @@ struct TensorListShapeBase {
     shapes.resize(num_samples * sample_dim());
   }
 
-  void resize(int num_samples, int dim) {
+  void resize(int num_samples, int sample_dim) {
     num_samples_ = num_samples;
-    set_sample_dim(dim);
-    shapes.resize(num_samples * dim);
+    set_sample_dim(sample_dim);
+    shapes.resize(num_samples * sample_dim);
   }
 
  protected:
@@ -600,8 +600,8 @@ struct TensorListShape<DynamicDimensions>
     resize(num_samples);
   }
 
-  TensorListShape(int num_samples, int ndim) : Base()  {
-    resize(num_samples, ndim);
+  explicit TensorListShape(int num_samples, int sample_dim) : Base()  {
+    resize(num_samples, sample_dim);
   }
 
   TensorListShape(const std::vector<std::vector<int64_t>> &sample_shapes)  // NOLINT
@@ -612,20 +612,20 @@ struct TensorListShape<DynamicDimensions>
       : Base(flatten_shapes(sample_shapes), sample_shapes.size()),
         dim(get_dim_from_uniform(sample_shapes)) {}
 
-  TensorListShape(const std::vector<int64_t> &shapes, int ndim)
-      : Base(shapes, shapes.size() / ndim), dim(ndim) {}
+  TensorListShape(const std::vector<int64_t> &shapes, int sample_dim)
+      : Base(shapes, shapes.size() / sample_dim), dim(sample_dim) {}
 
-  TensorListShape(std::vector<int64_t> &&shapes, int ndim)
-      : Base(std::move(shapes), shapes.size() / ndim), dim(ndim) {}
+  TensorListShape(std::vector<int64_t> &&shapes, int sample_dim)
+      : Base(std::move(shapes), shapes.size() / sample_dim), dim(sample_dim) {}
 
-  TensorListShape(const std::vector<int64_t> &shapes, int num_samples, int ndim)
-      : Base(shapes, num_samples), dim(ndim) {
-    assert(num_samples == static_cast<int>(shapes.size()) / ndim);
+  TensorListShape(const std::vector<int64_t> &shapes, int num_samples, int sample_dim)
+      : Base(shapes, num_samples), dim(sample_dim) {
+    assert(num_samples == static_cast<int>(shapes.size()) / sample_dim);
   }
 
-  TensorListShape(std::vector<int64_t> &&shapes, int num_samples, int ndim)
-      : Base(std::move(shapes), num_samples), dim(ndim) {
-    assert(num_samples == static_cast<int>(shapes.size()) / ndim);
+  TensorListShape(std::vector<int64_t> &&shapes, int num_samples, int sample_dim)
+      : Base(std::move(shapes), num_samples), dim(sample_dim) {
+    assert(num_samples == static_cast<int>(shapes.size()) / sample_dim);
   }
 
   TensorListShape &operator=(const TensorListShape &) = default;
@@ -704,34 +704,34 @@ struct TensorListShape : TensorListShapeBase<TensorListShape<sample_ndim>, sampl
     Base::resize(num_samples);
   }
 
-  TensorListShape(int num_samples, int ndim) : Base()  {
-    assert(ndim == sample_ndim);
-    Base::resize(num_samples, ndim);
+  explicit TensorListShape(int num_samples, int sample_dim) : Base()  {
+    assert(sample_dim == sample_ndim);
+    Base::resize(num_samples, sample_dim);
   }
 
   TensorListShape(const std::vector<TensorShape<sample_ndim>> &sample_shapes)  // NOLINT
       : Base(flatten_shapes(sample_shapes), sample_shapes.size()) {}
 
-  TensorListShape(const std::vector<int64_t> &shapes, int ndim)
-      : Base(shapes, shapes.size() / ndim) {
-    assert(ndim == sample_ndim);
+  TensorListShape(const std::vector<int64_t> &shapes, int sample_dim)
+      : Base(shapes, shapes.size() / sample_dim) {
+    assert(sample_dim == sample_ndim);
   }
 
-  TensorListShape(std::vector<int64_t> &&shapes, int ndim)
-      : Base(std::move(shapes), shapes.size() / ndim) {
-    assert(ndim == sample_ndim);
+  TensorListShape(std::vector<int64_t> &&shapes, int sample_dim)
+      : Base(std::move(shapes), shapes.size() / sample_dim) {
+    assert(sample_dim == sample_ndim);
   }
 
-  TensorListShape(const std::vector<int64_t> &shapes, int num_samples, int ndim)
+  TensorListShape(const std::vector<int64_t> &shapes, int num_samples, int sample_dim)
       : Base(shapes, num_samples) {
-    assert(ndim == sample_ndim);
-    assert(num_samples == static_cast<int>(shapes.size()) / ndim);
+    assert(sample_dim == sample_ndim);
+    assert(num_samples == static_cast<int>(shapes.size()) / sample_dim);
   }
 
-  TensorListShape(std::vector<int64_t> &&shapes, int num_samples, int ndim)
+  TensorListShape(std::vector<int64_t> &&shapes, int num_samples, int sample_dim)
       : Base(std::move(shapes), num_samples) {
-    assert(ndim == sample_ndim);
-    assert(num_samples == static_cast<int>(shapes.size()) / ndim);
+    assert(sample_dim == sample_ndim);
+    assert(num_samples == static_cast<int>(shapes.size()) / sample_dim);
   }
 
   TensorListShape &operator=(const TensorListShape &) = default;

--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -806,6 +806,7 @@ TensorListShape<DynamicDimensions> TensorListShapeBase<Derived, sample_ndim>::la
 
 template <int left_ndim, int right_ndim>
 bool operator==(const TensorListShape<left_ndim> &left, const TensorListShape<right_ndim> &right) {
+  detail::check_compatible_ndim<left_ndim, right_ndim>();
   if (left.sample_dim() != right.sample_dim()) {
     return false;
   }
@@ -817,6 +818,7 @@ bool operator==(const TensorListShape<left_ndim> &left, const TensorListShape<ri
 
 template <int left_ndim, int right_ndim>
 bool operator!=(const TensorListShape<left_ndim> &left, const TensorListShape<right_ndim> &right) {
+  detail::check_compatible_ndim<left_ndim, right_ndim>();
   return !(left == right);
 }
 

--- a/dali/kernels/test/tensor_shape_test.cc
+++ b/dali/kernels/test/tensor_shape_test.cc
@@ -521,6 +521,79 @@ TEST(TensorListShapeTest, Size) {
   ASSERT_EQ(single_empty_6.size(), 1);
 }
 
+TEST(TensorListShapeTest, Constructors) {
+  TensorListShape<> tls_5samples(5), tls_5samples_2dim(5, 2);
+  EXPECT_EQ(tls_5samples.size(), 5);
+  EXPECT_EQ(tls_5samples.sample_dim(), 0);
+  EXPECT_EQ(tls_5samples_2dim.size(), 5);
+  EXPECT_EQ(tls_5samples_2dim.sample_dim(), 2);
+  EXPECT_EQ(tls_5samples_2dim, uniform_list_shape(5, {0, 0}));
+
+  TensorListShape<2> tls_5samples_static2dim(5), tls_5samples_static2dim_2(5, 2);
+  EXPECT_EQ(tls_5samples_static2dim.size(), 5);
+  EXPECT_EQ(tls_5samples_static2dim.sample_dim(), 2);
+  EXPECT_EQ(tls_5samples_static2dim, uniform_list_shape(5, {0, 0}));
+  EXPECT_EQ(tls_5samples_static2dim_2.size(), 5);
+  EXPECT_EQ(tls_5samples_static2dim_2.sample_dim(), 2);
+  EXPECT_EQ(tls_5samples_static2dim_2, uniform_list_shape(5, {0, 0}));
+}
+
+TEST(TensorListShapeTest, Resize) {
+  TensorListShape<> tls_0, tls_1(5, 2);
+  tls_0.resize(5);
+  EXPECT_EQ(tls_0.size(), 5);
+  EXPECT_EQ(tls_0.sample_dim(), 0);
+  EXPECT_TRUE(tls_0.shapes.empty());
+
+  tls_0.resize(5, 2);
+  EXPECT_EQ(tls_0.size(), 5);
+  EXPECT_EQ(tls_0.sample_dim(), 2);
+  EXPECT_EQ(tls_0.shapes, std::vector<int64_t>(10, 0));
+
+  tls_1.resize(5, 3);
+  EXPECT_EQ(tls_1.size(), 5);
+  EXPECT_EQ(tls_1.sample_dim(), 3);
+  EXPECT_EQ(tls_1.shapes, std::vector<int64_t>(15, 0));
+  tls_1.resize(6, 3);
+  EXPECT_EQ(tls_1.size(), 6);
+  EXPECT_EQ(tls_1.sample_dim(), 3);
+  EXPECT_EQ(tls_1.shapes, std::vector<int64_t>(18, 0));
+
+  TensorListShape<2> tls_2, tls_3(5);
+  tls_2.resize(5);
+  EXPECT_EQ(tls_2.size(), 5);
+  EXPECT_EQ(tls_2.sample_dim(), 2);
+  EXPECT_EQ(tls_2.shapes, std::vector<int64_t>(10, 0));
+
+  tls_1.resize(6, 2);
+  EXPECT_EQ(tls_1.size(), 6);
+  EXPECT_EQ(tls_1.sample_dim(), 2);
+  EXPECT_EQ(tls_1.shapes, std::vector<int64_t>(12, 0));
+}
+
+TEST(TensorListShapeTest, ConstructorsFromVector) {
+  auto shapes = std::vector<int64_t>{0, 1, 2, 3, 4, 5};
+
+  TensorListShape<> tls_dyn_2_3(shapes, 2, 3);
+  EXPECT_EQ(tls_dyn_2_3.shapes, shapes);
+  EXPECT_EQ(tls_dyn_2_3.size(), 2);
+  EXPECT_EQ(tls_dyn_2_3.sample_dim(), 3);
+
+  TensorListShape<3> tls_static_2_3(shapes, 2, 3);
+  EXPECT_EQ(tls_static_2_3.shapes, shapes);
+  EXPECT_EQ(tls_static_2_3.size(), 2);
+  EXPECT_EQ(tls_static_2_3.sample_dim(), 3);
+
+  TensorListShape<> tls_dyn_3(shapes, 3);
+  EXPECT_EQ(tls_dyn_3.shapes, shapes);
+  EXPECT_EQ(tls_dyn_3.size(), 2);
+  EXPECT_EQ(tls_dyn_3.sample_dim(), 3);
+
+  TensorListShape<3> tls_static_3(shapes, 3);
+  EXPECT_EQ(tls_static_3.shapes, shapes);
+  EXPECT_EQ(tls_static_3.size(), 2);
+  EXPECT_EQ(tls_static_3.sample_dim(), 3);
+}
 
 TEST(TensorListShapeTest, IsUniform) {
   TensorListShape<3> non_uniform({{1, 2, 3}, {2, 3, 4}, {3, 4, 5}});


### PR DESCRIPTION
Allow for 0-element TLS.
Fixes size for 0-dim TLS.

Add tests for size().
Add non-template overload so set_tensor_shape
can be used with brace initializer.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>