### PR TITLE
Add support for reading video files with labels using file_list argument

### DIFF
--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <fstream>
 
 namespace dali {
 
@@ -69,7 +70,8 @@ inline void assemble_video_list(const std::string& path, const std::string& curr
 
 vector<std::pair<string, int>> filesystem::get_file_label_pair(
     const std::string& file_root,
-    const std::vector<std::string>& filenames) {
+    const std::vector<std::string>& filenames,
+    const std::string& file_list) {
   // open the root
   std::vector<std::pair<std::string, int>> file_label_pairs;
   std::vector<std::string> entry_name_list;
@@ -105,6 +107,19 @@ vector<std::pair<string, int>> filesystem::get_file_label_pair(
 
     // sort file names as well
     std::sort(file_label_pairs.begin(), file_label_pairs.end());
+  } else if (!file_list.empty()) {
+    // load (path, label) pairs from list
+    std::ifstream s(file_list);
+    DALI_ENFORCE(s.is_open());
+
+    string video_file;
+    int label;
+    while (s >> video_file >> label) {
+      file_label_pairs.push_back(std::make_pair(video_file, label));
+    }
+
+    DALI_ENFORCE(s.eof(), "Wrong format of file_list.");
+    s.close();
   } else {
     for (unsigned file_count = 0; file_count < filenames.size(); ++file_count)
         file_label_pairs.push_back(std::make_pair(filenames[file_count], 0));

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -56,7 +56,7 @@ auto codecpar(AVStream* stream) -> decltype(stream->codec);
 namespace filesystem {
 
 std::vector<std::pair<std::string, int>> get_file_label_pair(const std::string& path,
-    const std::vector<std::string>& filenames);
+    const std::vector<std::string>& filenames, const std::string& file_list);
 
 }  // namespace filesystem
 
@@ -120,6 +120,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
     const std::vector<std::string>& filenames)
     : Loader<GPUBackend, SequenceWrapper>(spec),
       file_root_(spec.GetArgument<std::string>("file_root")),
+      file_list_(spec.GetArgument<std::string>("file_list")),
       count_(spec.GetArgument<int>("sequence_length")),
       step_(spec.GetArgument<int>("step")),
       stride_(spec.GetArgument<int>("stride")),
@@ -135,7 +136,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
     if (step_ < 0)
       step_ = count_ * stride_;
 
-    file_label_pair_ = filesystem::get_file_label_pair(file_root_, filenames_);
+    file_label_pair_ = filesystem::get_file_label_pair(file_root_, filenames_,
+                                                       file_list_);
 
     DALI_ENFORCE(cuvidInitChecked(0),
      "Failed to load libnvcuvid.so, needed by the VideoReader operator. "
@@ -209,6 +211,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   }
   // Params
   std::string file_root_;
+  std::string file_list_;
   int count_;
   int step_;
   int stride_;

--- a/dali/pipeline/operators/reader/video_reader_op.cc
+++ b/dali/pipeline/operators/reader/video_reader_op.cc
@@ -34,15 +34,20 @@ number of frames).)code")
   .NumInput(0)
   .OutputFn([](const OpSpec &spec) {
       std::string file_root = spec.GetArgument<std::string>("file_root");
-      return file_root.empty() ? 1 : 2;
+      std::string file_list = spec.GetArgument<std::string>("file_list");
+      return (file_root.empty() && file_list.empty()) ? 1 : 2;
     })
   .AddOptionalArg("filenames",
       R"code(File names of the video files to load.
-This option is mutually exclusive with `file_root`.)code",
+This option is mutually exclusive with `file_root` and `file_list`.)code",
       std::vector<std::string>{})
   .AddOptionalArg("file_root",
       R"code(Path to a directory containing data files.
-This option is mutually exclusive with `filenames`.)code",
+This option is mutually exclusive with `filenames` and `file_list`.)code",
+      std::string())
+  .AddOptionalArg("file_list",
+      R"code(Path to the file with a list of pairs ``file label``.
+This option is mutually exclusive with `filenames` and `file_root`.)code",
       std::string())
   .AddArg("sequence_length",
       R"code(Frames to load per sequence.)code",

--- a/dali/test/python/test_video_pipeline.py
+++ b/dali/test/python/test_video_pipeline.py
@@ -25,6 +25,7 @@ from nvidia.dali.pipeline import Pipeline
 VIDEO_DIRECTORY="video_files"
 VIDEO_FILES=os.listdir(VIDEO_DIRECTORY)
 VIDEO_FILES = [VIDEO_DIRECTORY + '/' + f for f in VIDEO_FILES]
+FILE_LIST="file_list.txt"
 
 ITER=6
 BATCH_SIZE=4
@@ -43,8 +44,25 @@ class VideoPipe(Pipeline):
         output = self.input(name="Reader")
         return output
 
+class VideoPipeList(Pipeline):
+    def __init__(self, batch_size, data, device_id=0):
+        super(VideoPipeList, self).__init__(batch_size, num_threads=2, device_id=device_id)
+        self.input = ops.VideoReader(device="gpu", file_list=data, sequence_length=COUNT)
+
+    def define_graph(self):
+        output = self.input(name="Reader")
+        return output
+
 def test_simple_videopipeline():
     pipe = VideoPipe(batch_size=BATCH_SIZE, data=VIDEO_FILES)
+    pipe.build()
+    for i in range(ITER):
+        print("Iter " + str(i))
+        pipe_out = pipe.run()
+    del pipe
+
+def test_file_list_videopipeline():
+    pipe = VideoPipeList(batch_size=BATCH_SIZE, data=FILE_LIST)
     pipe.build()
     for i in range(ITER):
         print("Iter " + str(i))

--- a/docs/examples/video/video_label_example.py
+++ b/docs/examples/video/video_label_example.py
@@ -41,6 +41,8 @@ class VideoPipe(Pipeline):
     def __init__(self, batch_size, num_threads, device_id, data):
         super(VideoPipe, self).__init__(batch_size, num_threads, device_id, seed=12)
         self.input = ops.VideoReader(device="gpu", file_root = data, sequence_length=COUNT,
+        # instead of file_root, path to text file with pairs video_filepath label_value can be provided
+        # self.input = ops.VideoReader(device="gpu", file_list = "file_list.txt", sequence_length=COUNT,
                                      shard_id=0, num_shards=1, random_shuffle=False,
                                      normalized=True, image_type=types.YCbCr, dtype=types.FLOAT)
 

--- a/qa/L0_videoreader_test/test.sh
+++ b/qa/L0_videoreader_test/test.sh
@@ -29,6 +29,9 @@ do
     ffmpeg -ss 00:00:$((i*5)) -t 00:00:05 -i $container_path -vcodec copy -acodec copy -y labelled_videos/$((i % 3))//${split[0]}_$i.${split[1]}
 done
 
+# generate file_list.txt from video_files directory
+ls -d video_files/*  | tr " " "\n" | awk '{print $0, NR;}' > file_list.txt
+
 test_body() {
     # test code
     # First running simple code


### PR DESCRIPTION
This PR adds support for reading video and respective label from a text file to `VideoReader.`

When `file_list` argument is provided, VideorReader will read from the provided text file. VideoReader expects a `filename label` pair on each line. This behavior is similar to FileReader.
```
cat/2/cat_12.mp4 0
dog/2/dog_34.mp4 1
koala/2/koala_56.mp4 2
bird/0/bird_78.mp4 3
```
Additionally, It is ensured that `file_list` argument is mutually exclusive with `file_root` and `filenames`. 

Signed-off-by: Abhishek Sansanwal asansanwal@nvidia.com