### PR TITLE
Span improvements.

### DIFF
--- a/dali/kernels/imgproc/resample/resampling_setup.cc
+++ b/dali/kernels/imgproc/resample/resampling_setup.cc
@@ -161,7 +161,7 @@ void BatchResamplingSetup::SetupBatch(
     Initialize();
 
   int N = in.num_samples();
-  assert(params.size() == static_cast<ptrdiff_t>(N));
+  assert(params.size() == static_cast<span_extent_t>(N));
 
   sample_descs.resize(N);
   intermediate_shape.resize(N);

--- a/dali/kernels/tensor_shape.h
+++ b/dali/kernels/tensor_shape.h
@@ -465,14 +465,16 @@ struct TensorListShapeBase {
   TensorListShape<DynamicDimensions> last(int count) const;
 
   /// @brief Return a span containing the shape of `sample`
-  span<int64_t, sample_ndim == DynamicDimensions ? dynamic_extent : sample_ndim>
+  span<int64_t, sample_ndim == DynamicDimensions ?
+                dynamic_extent : span_extent_t(sample_ndim)>
   tensor_shape_span(int64_t sample) {
-    return {&shapes[sample * sample_dim()], sample_dim()};
+    return {&shapes[sample * sample_dim()], span_extent_t(sample_dim())};
   }
 
-  span<const int64_t, sample_ndim == DynamicDimensions ? dynamic_extent : sample_ndim>
+  span<const int64_t, sample_ndim == DynamicDimensions ?
+                      dynamic_extent : span_extent_t(sample_ndim)>
   tensor_shape_span(int64_t sample) const {
-    return {&shapes[sample * sample_dim()], sample_dim()};
+    return {&shapes[sample * sample_dim()], span_extent_t(sample_dim())};
   }
 
   /// @brief Return the TensorShape for given `sample`

--- a/dali/kernels/tensor_view.h
+++ b/dali/kernels/tensor_view.h
@@ -297,11 +297,11 @@ struct TensorListViewBase {
     return shape.template tensor_shape<output_dim>(sample);
   }
 
-  span<int64_t, sample_ndim> tensor_shape_span(int sample) {
+  auto tensor_shape_span(int sample) {
     return shape.tensor_shape_span(sample);
   }
 
-  span<const int64_t, sample_ndim> tensor_shape_span(int sample) const {
+  auto tensor_shape_span(int sample) const {
     return shape.tensor_shape_span(sample);
   }
 

--- a/dali/kernels/test/span_gpu_test.cu
+++ b/dali/kernels/test/span_gpu_test.cu
@@ -21,7 +21,7 @@ namespace dali {
 namespace kernels {
 namespace {
 
-template <typename T, ptrdiff_t extent>
+template <typename T, span_extent_t extent>
 __global__ void TestSpanKernel(span<T, extent> span) {
   int x = threadIdx.x + blockIdx.x*blockDim.x;
   if (x < span.size()) {
@@ -30,6 +30,22 @@ __global__ void TestSpanKernel(span<T, extent> span) {
 }
 
 }  // namespace
+
+inline void Validate(span<const int> s) {
+  int i = 1;
+  for (auto a : s)
+    EXPECT_EQ(a, i++);
+  EXPECT_EQ(i, static_cast<int>(s.size() + 1));
+}
+
+TEST(Span, Convert) {
+  int A[10];
+  auto s = make_span(A);
+  int i = 1;
+  for (auto &a : s)
+    a = i++;
+  Validate(s);
+}
 
 TEST(TestGPUSpan, Test1) {
   const int N = 1000;

--- a/dali/kernels/test/test_data_test.cc
+++ b/dali/kernels/test/test_data_test.cc
@@ -51,7 +51,7 @@ struct TestDataImpl {
       file.resize(length);
       f.read(file.data(), length);
     }
-    return { reinterpret_cast<uint8_t*>(file.data()), (ptrdiff_t)file.size() };
+    return { reinterpret_cast<uint8_t*>(file.data()), (span_extent_t)file.size() };
   }
 
   const cv::Mat &image(const char *name, bool color) {


### PR DESCRIPTION
Add converting constructor.
Add `front()` and `back()` functions.
Add `span_extent_t` typedef - seems like there's no consensus in commitee (size_t vs ptrdiff_t).
Fix C-array `make_span` bug.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>