### PR TITLE
Add include(CheckSymbolExists) to allow the usage of the check_symbol_exists() macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 3.11)
+# allow usage of check_symbol_exists() macro
+include(CheckSymbolExists)
 
 if (POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)


### PR DESCRIPTION
When compiling from source, I got the following error.

```bash
dali/build> cmake ..
-- The CXX compiler identification is GNU 7.4.0
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- DALI version: 0.12.0dev
-- Build configuration: Release
-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found CUDA: /usr/local/cuda-10.1 (found suitable version "10.1", minimum required is "8.0") 
-- Found NVJPEG: /usr/local/cuda-10.1/include (found suitable version "10.1", minimum required is "9.0") 
/usr/local/cuda-10.1
CMake Error at cmake/modules/FindNVJPEG.cmake:39 (check_symbol_exists):
  Unknown CMake command "check_symbol_exists".
Call Stack (most recent call first):
  cmake/Dependencies.cmake:28 (find_package)
  CMakeLists.txt:68 (include)
```

To allow the usage for the `check_symbol_exists` macro, I needed to include it in the `CMakeLists.txt`. 

I'm running Ubuntu 18.04 with

```bash
> nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2019 NVIDIA Corporation
Built on Wed_Apr_24_19:10:27_PDT_2019
Cuda compilation tools, release 10.1, V10.1.168
```

and 

```bash
> cmake --version
cmake version 3.15.0-rc3
```

