### PR TITLE
Fix `check_symbol_exists` usage in CMake 3.15

### DIFF
--- a/cmake/modules/FindNVJPEG.cmake
+++ b/cmake/modules/FindNVJPEG.cmake
@@ -9,6 +9,7 @@
 #  NVJPEG_FOUND
 #  NVJPEG_INCLUDE_DIR
 #  NVJPEG_LIBRARY
+include(CheckSymbolExists)
 
 set(NVJPEG_ROOT_DIR "" CACHE PATH "Folder contains NVJPEG")
 


### PR DESCRIPTION
- `check_symbol_exists` requires `CheckSymbolExists` to be included
  in the most recent CMake

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>