### PR TITLE
Copy multiple collections to scratchpad.

### DIFF
--- a/dali/kernels/scratch_copy_impl.h
+++ b/dali/kernels/scratch_copy_impl.h
@@ -1,0 +1,155 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_SCRATCH_COPY_IMPL_H_
+#define DALI_KERNELS_SCRATCH_COPY_IMPL_H_
+
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <tuple>
+#include <memory>
+#include "dali/core/traits.h"
+#include "dali/kernels/context.h"
+
+namespace dali {
+namespace kernels {
+
+namespace detail {
+
+inline void copy_to_buffer(char *buffer, const size_t *offsets) {}
+
+/// @brief Copy contents of collections `{ c, tail... }` to pointers stored in `ptrs`.
+template <typename Collection, typename... Collections>
+void copy_to_buffer(char *buffer,
+                  const size_t *offsets,
+                  const Collection &c,
+                  const Collections &... tail) {
+  using T = std::remove_cv_t<element_t<Collection>>;
+  std::copy(dali::begin(c), dali::end(c), reinterpret_cast<T*>(buffer + offsets[0]));
+  copy_to_buffer(buffer, offsets+1, tail...);
+}
+
+inline void GetCollectionOffsets(size_t base, size_t *offsets) { *offsets = base; }
+
+/// @brief Allocate storage for contiguous elements from collections `{ c, tail... }`
+///        using allocator `a` and return tuple of pointers.
+/// @remarks The allocation happens in left-to-right order.
+template <typename Collection, typename... Collections>
+void GetCollectionOffsets(size_t base, size_t *offsets,
+                              const Collection &c,
+                              const Collections &...tail) {
+  using T = std::remove_cv_t<element_t<Collection>>;
+  base = align_up(base, alignof(T));
+  *offsets = base;
+  base += size(c) * sizeof(T);
+  GetCollectionOffsets(base, offsets + 1, tail...);
+}
+
+constexpr std::tuple<> GetCollectionPtrs(void *base, const size_t *offsets) { return {}; }
+
+template <typename Collection, typename... Collections>
+auto GetCollectionPtrs(void *base, const size_t *offsets,
+                       const Collection &c,
+                       const Collections &...tail) {
+  using T = std::remove_cv_t<element_t<Collection>>;
+  return std::tuple_cat(
+    std::make_tuple(static_cast<T*>(base)),
+    GetCollectionPtrs(static_cast<char *>(base) + offsets[1], offsets+1, tail...));
+}
+
+}  // namespace detail
+
+/// @brief Allocates host memory using provided allocator and copies the collections
+///        to this buffer.
+///
+/// @remarks The first pointer in the output tuple is the one returned by the allocator.
+///          Note that for memory returned by PreallocatedScratchpad, this pointer needs
+///          no deletion.
+template <typename AlignedAllocator, typename... Collections,
+          typename = decltype(std::declval<AlignedAllocator>()(0, 0))>
+auto ToContiguousHostMem(AlignedAllocator &alloc, const Collections &... c) {
+  const size_t N = sizeof...(Collections);
+  static_assert(
+    all_of<std::is_pod<std::remove_cv_t<element_t<Collections>>>::value...>::value,
+    "ToGPU must be used with collections of POD types");
+
+  std::array<size_t, N + 1> offsets;
+  detail::GetCollectionOffsets(0, &offsets[0], c...);
+  size_t alignment = std::max({alignof(element_t<Collections>)...});
+  size_t total_size = std::get<N>(offsets);
+
+  auto *tmp = reinterpret_cast<char*>(alloc(total_size, alignment));
+  detail::copy_to_buffer(tmp, &offsets[0], c...);
+
+  return detail::GetCollectionPtrs(tmp, &offsets[0], c...);
+}
+
+/// @brief Allocates GPU memory using provided allocator, copies the collections to a
+///        temporary host buffer and then transfers the contents to the GPU in just one
+///        `cudaMemcpyAsync`.
+///
+/// @remarks The first pointer in the output tuple is the one returned by the allocator.
+///          Note that for memory returned by PreallocatedScratchpad, this pointer needs
+///          no deletion.
+template <typename AlignedAllocator, typename... Collections,
+          typename = decltype(std::declval<AlignedAllocator>()(0, 0))>
+auto ToContiguousGPUMem(AlignedAllocator &&alloc, cudaStream_t stream, const Collections &... c) {
+  const size_t N = sizeof...(Collections);
+  static_assert(
+    all_of<std::is_pod<std::remove_cv_t<element_t<Collections>>>::value...>::value,
+    "ToGPU must be used with collections of POD types");
+
+  std::array<size_t, N + 1> offsets;
+  detail::GetCollectionOffsets(0, &offsets[0], c...);
+  size_t alignment = std::max({alignof(element_t<Collections>)...});
+  size_t total_size = std::get<N>(offsets);
+
+  char *tmp;
+  std::unique_ptr<char[]> heap_buf;
+  if (total_size <= 0x2000) {
+     tmp = static_cast<char*>(alloca(0x2000));
+  } else {
+    heap_buf.reset(new char[total_size]);
+    tmp = heap_buf.get();
+  }
+
+  detail::copy_to_buffer(tmp, &offsets[0], c...);
+  void *out_ptr = alloc(total_size, alignment);
+
+  cudaMemcpyAsync(out_ptr, tmp, total_size, cudaMemcpyHostToDevice, stream);
+  return detail::GetCollectionPtrs(out_ptr, &offsets[0], c...);
+}
+
+template <typename... Collections>
+std::tuple<std::remove_cv_t<element_t<Collections>>*...>
+ToContiguousHostMem(Scratchpad &scratchpad, const Collections &... c) {
+  auto alloc = [&](size_t n, size_t align) {
+    return scratchpad.Alloc(AllocType::Host, n, align);
+  };
+  return ToContiguousHostMem(alloc, c...);
+}
+
+template <typename... Collections>
+std::tuple<std::remove_cv_t<element_t<Collections>>*...>
+ToContiguousGPUMem(Scratchpad &scratchpad, cudaStream_t stream, const Collections &... c) {
+  auto alloc = [&](size_t n, size_t align) {
+    return scratchpad.Alloc(AllocType::GPU, n, align);
+  };
+  return ToContiguousGPUMem(alloc, stream, c...);
+}
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_SCRATCH_COPY_IMPL_H_

--- a/dali/kernels/scratch_copy_impl.h
+++ b/dali/kernels/scratch_copy_impl.h
@@ -42,9 +42,12 @@ void copy_to_buffer(char *buffer,
 
 inline void GetCollectionOffsets(size_t base, size_t *offsets) { *offsets = base; }
 
-/// @brief Allocate storage for contiguous elements from collections `{ c, tail... }`
-///        using allocator `a` and return tuple of pointers.
-/// @remarks The allocation happens in left-to-right order.
+/// @brief Assuming aligned storage in a single buffer,
+///        calculates start offsets of collections `{ c, tail... }`
+/// @param base     - offset of the first element of the first collection `c`
+/// @param offsets  - the array to store the offsets
+/// @param c        - collection to be stored at (aligned) `base`
+/// @param tail     - collections to be stored after `c`
 template <typename Collection, typename... Collections>
 void GetCollectionOffsets(size_t base, size_t *offsets,
                               const Collection &c,
@@ -85,6 +88,7 @@ auto variadic_max(T0 t0, T... tail) {
 }
 
 }  // namespace detail
+
 
 /// @brief Allocates host memory using provided allocator and copies the collections
 ///        to this buffer.

--- a/dali/kernels/test/scratch_copy_test.cc
+++ b/dali/kernels/test/scratch_copy_test.cc
@@ -1,0 +1,61 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <numeric>
+#include "dali/kernels/kernel_req.h"
+#include "dali/kernels/scratch.h"
+#include "dali/kernels/scratch_copy_impl.h"
+#include "dali/core/tuple_helpers.h"
+
+namespace dali {
+namespace kernels {
+
+template <typename C, typename = element_t<C>>
+constexpr auto size_bytes(const C &c) { return size(c) * sizeof(element_t<C>); }
+
+TEST(Scratchpad, ToContiguous) {
+  ScratchpadEstimator se;
+  std::vector<char> chars(301);
+  std::vector<float> floats(1927);
+  std::iota(chars.begin(), chars.end(), 1);
+  std::iota(floats.begin(), floats.end(), 1);
+
+  se.add<char>(AllocType::GPU, chars.size());
+  se.add<float>(AllocType::GPU, floats.size());
+  se.add<char>(AllocType::Host, chars.size());
+  se.add<float>(AllocType::Host, floats.size());
+  ScratchpadAllocator sa;
+  sa.Reserve(se.sizes);
+  auto scratchpad = sa.GetScratchpad();
+  auto ptrs = ToContiguousGPUMem(scratchpad, 0, chars, floats);
+  std::vector<char> chars2(chars.size());
+  std::vector<float> floats2(floats.size());
+  cudaDeviceSynchronize();
+  cudaMemcpy(chars2.data(), std::get<0>(ptrs), size_bytes(chars2), cudaMemcpyDeviceToHost);
+  cudaMemcpy(floats2.data(), std::get<1>(ptrs), size_bytes(floats2), cudaMemcpyDeviceToHost);
+
+  EXPECT_EQ(chars, chars);
+  EXPECT_EQ(floats, floats2);
+
+  ptrs = ToContiguousHostMem(scratchpad, chars, floats);
+  memcpy(chars2.data(), std::get<0>(ptrs), size_bytes(chars2));
+  memcpy(floats2.data(), std::get<1>(ptrs), size_bytes(floats2));
+
+  EXPECT_EQ(chars, chars);
+  EXPECT_EQ(floats, floats2);
+}
+
+}  // namespace kernels
+}  // namespace dali

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -31,13 +31,13 @@ template <typename T, size_t N>
 DALI_HOST_DEV constexpr T *end(T (&array)[N]) noexcept { return array + N; }
 
 DALI_NO_EXEC_CHECK
-template <typename T>
+template <typename T, typename = std::enable_if_t<!std::is_const<T>::value>>
 DALI_HOST_DEV constexpr auto begin(T &collection)->decltype(collection.begin()) {
   return collection.begin();
 }
 
 DALI_NO_EXEC_CHECK
-template <typename T>
+template <typename T, typename = std::enable_if_t<!std::is_const<T>::value>>
 DALI_HOST_DEV constexpr auto end(T &collection)->decltype(collection.end()) {
   return collection.end();
 }


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
- Reduce boilerplate code when allocating and copying multiple collections in kernel API's `Scratchpad`
- Reduce probability of errors which might occur as a result of misalignment between staging buffer and target device buffer

#### What happend in this PR?
- Add ToGPU, ToHost, ToPinned to Scractchpad, which allocate and copy memory from a collection.
- Add `ToContiguousHostMem` and `ToContiguousGPUMem`
- Add `ToContiguousHost` and `ToContiguousGPU` to `Scratchpad`

The functions build a tuple of pointers which point to the pieces of scratchpad memory where contiguous representations of the collections reside.
