### PR TITLE
Add Setup API to Operator

### DIFF
--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -223,6 +223,7 @@ class DLL_PUBLIC Executor : public ExecutorBase, public WorkspacePolicy, public 
   // To introduce dependency from MIXED stage to GPU stage for callback only
   // in some edge cases where there are no operators
   std::vector<cudaEvent_t> mixed_callback_events_;
+
  private:
   template <typename Workspace>
   void RunHelper(OpNode &op_node, Workspace &ws) {

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -149,6 +149,10 @@ class DLL_PUBLIC Executor : public ExecutorBase, public WorkspacePolicy, public 
       DALI_ENFORCE(
           static_cast<size_t>(ws.NumOutput()) == output_desc.size(),
           "Operator::Setup returned shape and type information for mismatched number of outputs");
+      DALI_ENFORCE(op.CanInferOutputs(),
+                   "Operator::Setup returned true indicating that it successfully calculated shape "
+                   "and type information for Operator outputs. In that case CanInferOutputs should "
+                   "always return true.");
       for (int i = 0; i < ws.NumOutput(); i++) {
         auto &desc = output_desc[i];
         if (ws.template OutputIsType<CPUBackend>(i)) {
@@ -159,6 +163,11 @@ class DLL_PUBLIC Executor : public ExecutorBase, public WorkspacePolicy, public 
           ws.template OutputRef<GPUBackend>(i).set_type(desc.type);
         }
       }
+    } else {
+      DALI_ENFORCE(!op.CanInferOutputs(),
+                   "Operator::Setup returned false indicating that it cannot calculate shape and "
+                   "type information for Operator outputs. In that case CanInferOutputs should "
+                   "always return false.");
     }
     op.Run(&ws);
   }
@@ -171,6 +180,10 @@ class DLL_PUBLIC Executor : public ExecutorBase, public WorkspacePolicy, public 
       DALI_ENFORCE(
           static_cast<size_t>(ws.NumOutput()) == output_desc.size(),
           "Operator::Setup returned shape and type information for mismatched number of outputs.");
+      DALI_ENFORCE(op.CanInferOutputs(),
+                   "Operator::Setup returned true indicating that it successfully calculated shape "
+                   "and type information for Operator outputs. In that case CanInferOutputs should "
+                   "always return true.");
       for (int i = 0; i < ws.NumOutput(); i++) {
         auto &desc = output_desc[i];
         DALI_ENFORCE(desc.shape.size() == 1,
@@ -183,6 +196,11 @@ class DLL_PUBLIC Executor : public ExecutorBase, public WorkspacePolicy, public 
           ws.template OutputRef<GPUBackend>(i).set_type(desc.type);
         }
       }
+    } else {
+      DALI_ENFORCE(!op.CanInferOutputs(),
+                   "Operator::Setup returned false indicating that it cannot calculate shape and "
+                   "type information for Operator outputs. In that case CanInferOutputs should "
+                   "always return false.");
     }
     op.Run(&ws);
   }

--- a/dali/pipeline/graph/op_graph.h
+++ b/dali/pipeline/graph/op_graph.h
@@ -74,6 +74,8 @@ struct OpNode {
 
   // parent and children tensors indexed by our inputs and outputs
   std::vector<TensorNodeId> parent_tensors, children_tensors;
+  // To reduce number of allocation of shapes in Setup
+  std::vector<OutputDesc> output_desc;
 
   std::string instance_name;
   OpType op_type;

--- a/dali/pipeline/operators/color/color_twist.h
+++ b/dali/pipeline/operators/color/color_twist.h
@@ -181,6 +181,10 @@ class ColorTwistBase : public Operator<Backend> {
   }
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   std::vector<ColorAugment*> augments_;

--- a/dali/pipeline/operators/color_space/color_space_conversion.h
+++ b/dali/pipeline/operators/color_space/color_space_conversion.h
@@ -16,6 +16,8 @@
 #ifndef DALI_PIPELINE_OPERATORS_COLOR_SPACE_COLOR_SPACE_CONVERSION_H_
 #define DALI_PIPELINE_OPERATORS_COLOR_SPACE_COLOR_SPACE_CONVERSION_H_
 
+#include <vector>
+
 #include "dali/pipeline/operators/operator.h"
 
 namespace dali {
@@ -30,6 +32,10 @@ class ColorSpaceConversion : public Operator<Backend> {
   }
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   USE_OPERATOR_MEMBERS();

--- a/dali/pipeline/operators/crop/bbox_crop.h
+++ b/dali/pipeline/operators/crop/bbox_crop.h
@@ -98,6 +98,10 @@ class RandomBBoxCrop : public Operator<Backend> {
   ~RandomBBoxCrop() override = default;
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   void WriteCropToOutput(SampleWorkspace *ws, const Crop &crop) const;

--- a/dali/pipeline/operators/crop/slice_base.h
+++ b/dali/pipeline/operators/crop/slice_base.h
@@ -38,6 +38,10 @@ class SliceBase : public Operator<Backend> {
   }
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   void SetupSharedSampleParams(Workspace<Backend> *ws) override {

--- a/dali/pipeline/operators/decoder/host/host_decoder.h
+++ b/dali/pipeline/operators/decoder/host/host_decoder.h
@@ -15,6 +15,8 @@
 #ifndef DALI_PIPELINE_OPERATORS_DECODER_HOST_HOST_DECODER_H_
 #define DALI_PIPELINE_OPERATORS_DECODER_HOST_HOST_DECODER_H_
 
+#include <vector>
+
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
 #include "dali/pipeline/operators/operator.h"
@@ -35,6 +37,10 @@ class HostDecoder : public Operator<CPUBackend> {
   DISABLE_COPY_MOVE_ASSIGN(HostDecoder);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    return false;
+  }
+
   void RunImpl(SampleWorkspace *ws) override;
 
   virtual CropWindowGenerator GetCropWindowGenerator(int data_idx) const {

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
@@ -90,7 +90,11 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
     }
   }
 
-  void RunImpl(SampleWorkspace *ws) {
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    return false;
+  }
+
+  void RunImpl(SampleWorkspace *ws) override {
     const int data_idx = ws->data_idx();
     const auto& in = ws->Input<CPUBackend>(0);
     const auto *input_data = in.data<uint8_t>();

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -164,6 +164,10 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     }
   }
 
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const MixedWorkspace &ws) override {
+    return false;
+  }
+
   using dali::OperatorBase::Run;
   void Run(MixedWorkspace *ws) override {
     SetupSharedSampleParams(ws);

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_gpu.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_gpu.h
@@ -62,6 +62,10 @@ class nvJPEGDecoderGPUStage : public Operator<MixedBackend> {
     }
   }
 
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const MixedWorkspace &ws) override {
+    return false;
+  }
+
   using dali::OperatorBase::Run;
   void Run(MixedWorkspace *ws) override {
     std::vector<std::vector<Index>> output_shape(batch_size_);

--- a/dali/pipeline/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
@@ -198,6 +198,10 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     }
   }
 
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const MixedWorkspace &ws) override {
+    return false;
+  }
+
   using dali::OperatorBase::Run;
   void Run(MixedWorkspace *ws) override {
     // TODO(slayton): Is this necessary?

--- a/dali/pipeline/operators/detection/box_encoder.cuh
+++ b/dali/pipeline/operators/detection/box_encoder.cuh
@@ -67,6 +67,10 @@ class BoxEncoder<GPUBackend> : public Operator<GPUBackend> {
   DISABLE_COPY_MOVE_ASSIGN(BoxEncoder);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const DeviceWorkspace &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<GPUBackend> *ws) override;
 
  private:

--- a/dali/pipeline/operators/detection/box_encoder.h
+++ b/dali/pipeline/operators/detection/box_encoder.h
@@ -67,6 +67,10 @@ class BoxEncoder<CPUBackend>: public Operator<CPUBackend> {
   DISABLE_COPY_MOVE_ASSIGN(BoxEncoder);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<CPUBackend> *ws) override;
   using Operator<CPUBackend>::RunImpl;
 

--- a/dali/pipeline/operators/detection/random_crop.h
+++ b/dali/pipeline/operators/detection/random_crop.h
@@ -55,6 +55,10 @@ class SSDRandomCrop : public Operator<Backend> {
   using Operator<Backend>::RunImpl;
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> * ws) override;
   void SetupSharedSampleParams(Workspace<Backend> *ws) override;
 

--- a/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
+++ b/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
@@ -106,6 +106,10 @@ class DisplacementFilter<CPUBackend, Displacement, per_channel_transform>
     Warp<interp, per_channel_transform>(out, in, displace, fill);
   }
 
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    return false;
+  }
+
   void RunImpl(SampleWorkspace *ws) override {
     DataDependentSetup(ws);
 

--- a/dali/pipeline/operators/displacement/displacement_filter_impl_gpu.cuh
+++ b/dali/pipeline/operators/displacement/displacement_filter_impl_gpu.cuh
@@ -15,6 +15,8 @@
 #ifndef DALI_PIPELINE_OPERATORS_DISPLACEMENT_DISPLACEMENT_FILTER_IMPL_GPU_CUH_
 #define DALI_PIPELINE_OPERATORS_DISPLACEMENT_DISPLACEMENT_FILTER_IMPL_GPU_CUH_
 
+#include <vector>
+
 #include "dali/core/common.h"
 #include "dali/kernels/imgproc/sampler.h"
 #include "dali/pipeline/operators/displacement/displacement_filter.h"
@@ -222,6 +224,10 @@ class DisplacementFilter<GPUBackend, Displacement,
 
   virtual ~DisplacementFilter() {
      displace_.Cleanup();
+  }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const DeviceWorkspace &ws) override {
+    return false;
   }
 
   void RunImpl(DeviceWorkspace* ws) override {

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -57,6 +57,10 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
   inline ~CropMirrorNormalize() override = default;
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   void SetupSharedSampleParams(Workspace<Backend> *ws) override {

--- a/dali/pipeline/operators/fused/normalize_permute.h
+++ b/dali/pipeline/operators/fused/normalize_permute.h
@@ -59,6 +59,10 @@ class NormalizePermute : public Operator<Backend> {
   inline ~NormalizePermute() override = default;
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   template <typename OUT>

--- a/dali/pipeline/operators/fused/resize_crop_mirror.h
+++ b/dali/pipeline/operators/fused/resize_crop_mirror.h
@@ -216,6 +216,10 @@ class ResizeCropMirror : public Operator<CPUBackend>, protected ResizeCropMirror
   ~ResizeCropMirror() override = default;
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    return false;
+  }
+
   inline void SetupSharedSampleParams(SampleWorkspace *ws) override {
     per_thread_meta_[ws->thread_idx()] = GetTransfomMeta(ws, spec_);
   }

--- a/dali/pipeline/operators/geometric/bb_flip.cuh
+++ b/dali/pipeline/operators/geometric/bb_flip.cuh
@@ -15,7 +15,9 @@
 #ifndef DALI_PIPELINE_OPERATORS_GEOMETRIC_BB_FLIP_CUH_
 #define DALI_PIPELINE_OPERATORS_GEOMETRIC_BB_FLIP_CUH_
 
-#include <dali/pipeline/operators/geometric/bb_flip.h>
+#include <vector>
+
+#include "dali/pipeline/operators/geometric/bb_flip.h"
 
 namespace dali {
 
@@ -23,6 +25,10 @@ template <>
 class BbFlip<GPUBackend> : public Operator<GPUBackend> {
  public:
   explicit BbFlip(const OpSpec &spec) : Operator<GPUBackend>(spec) {}
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const DeviceWorkspace &ws) override {
+    return false;
+  }
 
   void RunImpl(Workspace<GPUBackend> *ws) override;
  private:

--- a/dali/pipeline/operators/geometric/bb_flip.h
+++ b/dali/pipeline/operators/geometric/bb_flip.h
@@ -15,9 +15,11 @@
 #ifndef DALI_PIPELINE_OPERATORS_GEOMETRIC_BB_FLIP_H_
 #define DALI_PIPELINE_OPERATORS_GEOMETRIC_BB_FLIP_H_
 
-#include <dali/pipeline/operators/common.h>
-#include <dali/pipeline/operators/operator.h>
 #include <string>
+#include <vector>
+
+#include "dali/pipeline/operators/common.h"
+#include "dali/pipeline/operators/operator.h"
 
 namespace dali {
 
@@ -33,6 +35,10 @@ class BbFlip<CPUBackend> : public Operator<CPUBackend> {
   DISABLE_COPY_MOVE_ASSIGN(BbFlip);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    return false;
+  }
+
   void RunImpl(SampleWorkspace *ws) override;
   using Operator<CPUBackend>::RunImpl;
 

--- a/dali/pipeline/operators/geometric/flip.h
+++ b/dali/pipeline/operators/geometric/flip.h
@@ -32,6 +32,10 @@ class Flip: public Operator<Backend> {
   DISABLE_COPY_MOVE_ASSIGN(Flip);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   int GetHorizontal(const ArgumentWorkspace *ws, int idx) {

--- a/dali/pipeline/operators/operator.h
+++ b/dali/pipeline/operators/operator.h
@@ -113,7 +113,7 @@ class DLL_PUBLIC OperatorBase {
    * @brief If Operator can infer the output shapes it means that its output would use a single
    * underlying allocation, especailly for CPU TensorVector will use contiguous mode.
    */
-  DLL_PUBLIC virtual bool CanInferOutputs() {
+  DLL_PUBLIC virtual bool CanInferOutputs() const {
     return false;
   }
 

--- a/dali/pipeline/operators/optical_flow/optical_flow.h
+++ b/dali/pipeline/operators/optical_flow/optical_flow.h
@@ -86,6 +86,10 @@ class OpticalFlow : public Operator<Backend> {
   DISABLE_COPY_MOVE_ASSIGN(OpticalFlow);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
 

--- a/dali/pipeline/operators/paste/bbox_paste.h
+++ b/dali/pipeline/operators/paste/bbox_paste.h
@@ -15,6 +15,8 @@
 #ifndef DALI_PIPELINE_OPERATORS_PASTE_BBOX_PASTE_H_
 #define DALI_PIPELINE_OPERATORS_PASTE_BBOX_PASTE_H_
 
+#include <vector>
+
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
 #include "dali/pipeline/operators/common.h"
@@ -32,6 +34,11 @@ class BBoxPaste : public Operator<Backend> {
 
  protected:
   bool use_ltrb_ = false;
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   USE_OPERATOR_MEMBERS();

--- a/dali/pipeline/operators/paste/paste.h
+++ b/dali/pipeline/operators/paste/paste.h
@@ -53,6 +53,10 @@ class Paste : public Operator<Backend> {
   virtual inline ~Paste() = default;
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   void SetupSharedSampleParams(Workspace<Backend> *ws) override;

--- a/dali/pipeline/operators/python_function/python_function.h
+++ b/dali/pipeline/operators/python_function/python_function.h
@@ -16,6 +16,9 @@
 #define DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_PYTHON_FUNCTION_H_
 
 #include <pybind11/embed.h>
+
+#include <vector>
+
 #include "dali/util/pybind.h"
 #include "dali/pipeline/operators/operator.h"
 
@@ -30,6 +33,10 @@ class PythonFunctionImpl : public Operator<Backend> {
         reinterpret_cast<PyObject*>(spec.GetArgument<int64_t>("function_id")))) {}
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   USE_OPERATOR_MEMBERS();

--- a/dali/pipeline/operators/reader/reader_op.h
+++ b/dali/pipeline/operators/reader/reader_op.h
@@ -124,6 +124,10 @@ class DataReader : public Operator<Backend> {
     }
   }
 
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   // CPUBackend operators
   void Run(HostWorkspace* ws) override {
     // If necessary start prefetching thread and wait for a consumable batch

--- a/dali/pipeline/operators/resize/random_resized_crop.h
+++ b/dali/pipeline/operators/resize/random_resized_crop.h
@@ -52,6 +52,10 @@ class RandomResizedCrop : public Operator<Backend>
   using Operator<Backend>::RunImpl;
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> * ws) override;
   void SetupSharedSampleParams(Workspace<Backend> *ws) override;
 

--- a/dali/pipeline/operators/resize/resize.h
+++ b/dali/pipeline/operators/resize/resize.h
@@ -54,6 +54,10 @@ class Resize : public Operator<Backend>
   explicit Resize(const OpSpec &spec);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
   void SetupSharedSampleParams(Workspace<Backend> *ws) override;
 

--- a/dali/pipeline/operators/sequence/element_extract.h
+++ b/dali/pipeline/operators/sequence/element_extract.h
@@ -51,6 +51,10 @@ class ElementExtract : public Operator<Backend> {
   }
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   USE_OPERATOR_MEMBERS();

--- a/dali/pipeline/operators/support/random/coin_flip.h
+++ b/dali/pipeline/operators/support/random/coin_flip.h
@@ -16,6 +16,7 @@
 #define DALI_PIPELINE_OPERATORS_SUPPORT_RANDOM_COIN_FLIP_H_
 
 #include <random>
+#include <vector>
 
 #include "dali/pipeline/operators/operator.h"
 
@@ -36,6 +37,10 @@ class CoinFlip : public Operator<SupportBackend> {
   using Operator<SupportBackend>::RunImpl;
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const SupportWorkspace &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<SupportBackend> * ws) override;
 
  private:

--- a/dali/pipeline/operators/support/random/uniform.h
+++ b/dali/pipeline/operators/support/random/uniform.h
@@ -41,6 +41,10 @@ class Uniform : public Operator<SupportBackend> {
   using Operator<SupportBackend>::RunImpl;
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const SupportWorkspace &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<SupportBackend> * ws) override;
 
  private:

--- a/dali/pipeline/operators/transpose/transpose.h
+++ b/dali/pipeline/operators/transpose/transpose.h
@@ -46,6 +46,10 @@ class Transpose : public Operator<Backend> {
   DISABLE_COPY_MOVE_ASSIGN(Transpose);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
  private:

--- a/dali/pipeline/operators/util/cast.h
+++ b/dali/pipeline/operators/util/cast.h
@@ -15,6 +15,8 @@
 #ifndef DALI_PIPELINE_OPERATORS_UTIL_CAST_H_
 #define DALI_PIPELINE_OPERATORS_UTIL_CAST_H_
 
+#include <vector>
+
 #include "dali/pipeline/operators/operator.h"
 #include "dali/core/convert.h"
 
@@ -33,6 +35,10 @@ class Cast : public Operator<Backend> {
   DISABLE_COPY_MOVE_ASSIGN(Cast);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
  private:

--- a/dali/pipeline/operators/util/copy.h
+++ b/dali/pipeline/operators/util/copy.h
@@ -16,6 +16,7 @@
 #define DALI_PIPELINE_OPERATORS_UTIL_COPY_H_
 
 #include <cstring>
+#include <vector>
 
 #include "dali/pipeline/operators/operator.h"
 
@@ -32,6 +33,10 @@ class Copy : public Operator<Backend> {
   DISABLE_COPY_MOVE_ASSIGN(Copy);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 };
 

--- a/dali/pipeline/operators/util/dummy_op.h
+++ b/dali/pipeline/operators/util/dummy_op.h
@@ -15,6 +15,8 @@
 #ifndef DALI_PIPELINE_OPERATORS_UTIL_DUMMY_OP_H_
 #define DALI_PIPELINE_OPERATORS_UTIL_DUMMY_OP_H_
 
+#include <vector>
+
 #include "dali/pipeline/operators/operator.h"
 
 namespace dali {
@@ -30,6 +32,10 @@ class DummyOp : public Operator<Backend> {
   DISABLE_COPY_MOVE_ASSIGN(DummyOp);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *) override {
     DALI_FAIL("I'm a dummy op don't run me");
   }

--- a/dali/pipeline/operators/util/dump_image.h
+++ b/dali/pipeline/operators/util/dump_image.h
@@ -16,6 +16,7 @@
 #define DALI_PIPELINE_OPERATORS_UTIL_DUMP_IMAGE_H_
 
 #include <string>
+#include <vector>
 
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
@@ -36,6 +37,10 @@ class DumpImage : public Operator<Backend> {
   inline ~DumpImage() override = default;
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   const string suffix_;

--- a/dali/pipeline/operators/util/external_source.h
+++ b/dali/pipeline/operators/util/external_source.h
@@ -88,6 +88,10 @@ class ExternalSource : public Operator<Backend> {
   DISABLE_COPY_MOVE_ASSIGN(ExternalSource);
 
  protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<Backend> *ws) override;
 
   string output_name_;

--- a/dali/pipeline/operators/util/make_contiguous.h
+++ b/dali/pipeline/operators/util/make_contiguous.h
@@ -40,6 +40,10 @@ class MakeContiguous : public Operator<MixedBackend> {
 
   virtual inline ~MakeContiguous() = default;
 
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const MixedWorkspace &ws) override {
+    return false;
+  }
+
   using Operator<MixedBackend>::Run;
   void Run(MixedWorkspace *ws) override {
     const auto& input = ws->Input<CPUBackend>(0, 0);

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -293,6 +293,10 @@ class DummyPresizeOpCPU : public Operator<CPUBackend> {
       : Operator<CPUBackend>(spec) {
   }
 
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    return false;
+  }
+
   void RunImpl(Workspace<CPUBackend>* ws) override {
     auto &input = ws->Input<CPUBackend>(0);
     auto &output = ws->Output<CPUBackend>(0);
@@ -309,6 +313,10 @@ class DummyPresizeOpGPU : public Operator<GPUBackend> {
  public:
   explicit DummyPresizeOpGPU(const OpSpec &spec)
       : Operator<GPUBackend>(spec) {
+  }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const DeviceWorkspace &ws) override {
+    return false;
   }
 
   void RunImpl(Workspace<GPUBackend>* ws) override {
@@ -328,6 +336,10 @@ class DummyPresizeOpMixed : public Operator<MixedBackend> {
  public:
   explicit DummyPresizeOpMixed(const OpSpec &spec)
       : Operator<MixedBackend>(spec) {
+  }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const MixedWorkspace &ws) override {
+    return false;
   }
 
   using Operator<MixedBackend>::Run;
@@ -680,6 +692,10 @@ class DummyOpToAdd : public Operator<CPUBackend> {
  public:
   explicit DummyOpToAdd(const OpSpec &spec) : Operator<CPUBackend>(spec) {}
 
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    return false;
+  }
+
   void RunImpl(HostWorkspace *ws) override {}
 };
 
@@ -694,6 +710,10 @@ DALI_SCHEMA(DummyOpToAdd)
 class DummyOpNoSync : public Operator<CPUBackend> {
  public:
   explicit DummyOpNoSync(const OpSpec &spec) : Operator<CPUBackend>(spec) {}
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    return false;
+  }
 
   void RunImpl(HostWorkspace *ws) override {}
 };

--- a/dali/pipeline/util/backend2workspace_map.h
+++ b/dali/pipeline/util/backend2workspace_map.h
@@ -62,6 +62,60 @@ class Backend2WorkspaceMap<MixedBackend> {
 template<typename Backend>
 using Workspace = typename Backend2WorkspaceMap<Backend>::Type;
 
+// Actual trait-conventions used, maps as above with exception of CPUBackend -> HostWorkspace
+template <typename Backend>
+struct backend_to_ws {};
+
+template <>
+struct backend_to_ws<SupportBackend> { using type = SampleWorkspace; };
+
+template <>
+struct backend_to_ws<CPUBackend> { using type = HostWorkspace; };
+
+template <>
+struct backend_to_ws<MixedBackend> { using type = MixedWorkspace; };
+
+template <>
+struct backend_to_ws<GPUBackend> { using type = DeviceWorkspace; };
+
+template <typename Backend>
+using workspace_t = typename backend_to_ws<Backend>::type;
+
+template <OpType>
+struct op_to_workspace;
+
+template <>
+struct op_to_workspace<OpType::SUPPORT> { using type = SupportWorkspace; };
+
+template <>
+struct op_to_workspace<OpType::CPU> { using type = HostWorkspace; };
+
+template <>
+struct op_to_workspace<OpType::MIXED> { using type = MixedWorkspace; };
+
+template <>
+struct op_to_workspace<OpType::GPU> { using type = DeviceWorkspace; };
+
+template <OpType op_type>
+using op_to_workspace_t = typename op_to_workspace<op_type>::type;
+
+
+template <typename T>
+struct workspace_to_op;
+
+template <>
+struct workspace_to_op<SupportWorkspace> { static constexpr OpType value = OpType::SUPPORT; };
+
+template <>
+struct workspace_to_op<HostWorkspace> { static constexpr OpType value = OpType::CPU; };
+
+template <>
+struct workspace_to_op<MixedWorkspace> { static constexpr OpType value = OpType::MIXED; };
+
+template <>
+struct workspace_to_op<DeviceWorkspace> { static constexpr OpType value = OpType::GPU; };
+
+
 }  // namespace dali
 
 #endif  // DALI_PIPELINE_UTIL_BACKEND2WORKSPACE_MAP_H_

--- a/dali/pipeline/util/backend2workspace_map.h
+++ b/dali/pipeline/util/backend2workspace_map.h
@@ -28,39 +28,27 @@ namespace dali {
  * proper Backend
  */
 template <typename Backend>
-class Backend2WorkspaceMap {};
+struct Backend2WorkspaceMap {};
 
-template<>
-class Backend2WorkspaceMap<CPUBackend> {
- public:
-  typedef SampleWorkspace Type;
-};
+template <>
+struct Backend2WorkspaceMap<CPUBackend> { using type = SampleWorkspace; };
 
-template<>
-class Backend2WorkspaceMap<GPUBackend> {
- public:
-  typedef DeviceWorkspace Type;
-};
+template <>
+struct Backend2WorkspaceMap<GPUBackend> { using type = DeviceWorkspace; };
 
-template<>
-class Backend2WorkspaceMap<SupportBackend> {
- public:
-  typedef SupportWorkspace Type;
-};
+template <>
+struct Backend2WorkspaceMap<SupportBackend> { using type = SupportWorkspace; };
 
-template<>
-class Backend2WorkspaceMap<MixedBackend> {
- public:
-  typedef MixedWorkspace Type;
-};
+template <>
+struct Backend2WorkspaceMap<MixedBackend> { using type = MixedWorkspace; };
 
 
 // Workspace<CPUBackend> maps to SampleWorkspace
 // Workspace<GPUBackend> maps to DeviceWorkspace
 // Workspace<MixedBackend> maps to MixedWorkspace
 // Workspace<SupportBackend> maps to SupportWorkspace
-template<typename Backend>
-using Workspace = typename Backend2WorkspaceMap<Backend>::Type;
+template <typename Backend>
+using Workspace = typename Backend2WorkspaceMap<Backend>::type;
 
 // Actual trait-conventions used, maps as above with exception of CPUBackend -> HostWorkspace
 template <typename Backend>

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -28,6 +28,15 @@
 namespace dali {
 
 /**
+ * @brief Used to specify the shape and type of Output
+ * that a Workspace can hold.
+ */
+struct OutputDesc {
+  kernels::TensorListShape<> shape;
+  TypeInfo type;
+};
+
+/**
  * @brief ArgumentWorskpace is a base class of
  * objects storing tensor arguments
  * of operators

--- a/dali/test/plugins/dummy/dummy.h
+++ b/dali/test/plugins/dummy/dummy.h
@@ -16,6 +16,8 @@
 #define DALI_TEST_PLUGINS_DUMMY_DUMMY_H_
 
 #include <cstring>
+#include <vector>
+
 #include "dali/pipeline/operators/operator.h"
 
 namespace other_ns {
@@ -31,6 +33,11 @@ class Dummy : public ::dali::Operator<Backend> {
   DISABLE_COPY_MOVE_ASSIGN(Dummy);
 
  protected:
+  bool SetupImpl(std::vector<::dali::OutputDesc> &output_desc,
+                 const ::dali::workspace_t<Backend> &ws) override {
+    return false;
+  }
+
   void RunImpl(::dali::Workspace<Backend> *ws) override;
 };
 


### PR DESCRIPTION
#### Why we need this PR?
- Refactoring to separate Running operator from memory allocation

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
Added an pure virtual `SetupImpl` function for Operator type that is called by executor through `Operator::Setup`. If the operator can provide ahead of time it's output sizes and types it should return true and overload `CanInferOutputs` to return true.
CropMirrorNormalize Op example moved to #1140.
 - What was changed, added, removed?
`Setup` and `SetupImpl` member functions were added, `SetupImpl` was implemented in all operators.
`CanInferOutputs` function was added to allow contiguous variant of TensorVector to be used from start.
 - What is most important part that reviewers should focus on?
operator.h changes, executor change with `RunHelper`
- Was this PR tested? How?
Not yet
 - Were docs and examples updated, if necessary?
Doxygen was updated.

**JIRA TASK**: [DALI-834]