### PR TITLE
Basic geometric transform functions.

### DIFF
--- a/dali/core/geom_transform_test.cc
+++ b/dali/core/geom_transform_test.cc
@@ -1,0 +1,80 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/core/geom/transform.h"
+
+namespace dali {
+
+TEST(GeomTransform, Translation2D) {
+  vec2 offset = { 1.5f, -0.5f };
+  vec3 translated = translation(offset) * vec3(5, 6, 1);
+  EXPECT_EQ(translated, vec3(6.5f, 5.5f, 1.0f));
+}
+
+TEST(GeomTransform, Translation3D) {
+  vec3 offset = { -1.5f, 0.5f, 0.25f };
+  vec4 translated = translation(offset) * vec4(5, 6, 7, 1);
+  EXPECT_EQ(translated, vec4(3.5f, 6.5f, 7.25f, 1.0f));
+}
+
+TEST(GeomTransform, Scaling2D) {
+  vec3 scaled = scaling({ 2, 3 }) * vec3(3, 5, 1);
+  EXPECT_EQ(scaled, vec3(6, 15, 1));
+}
+
+TEST(GeomTransform, Scaling3D) {
+  vec4 scaled = scaling({ 2, 3, 4 }) * vec4(3, 5, 7, 1);
+  EXPECT_EQ(scaled, vec4(6, 15, 28, 1));
+}
+
+TEST(GeomTransform, Rotation2D) {
+  vec3 rotated1 = rotation2D(M_PI/4) * vec3(1, 0, 1);
+  vec3 rotated2 = rotation2D(M_PI/4) * vec3(0, 1, 1);
+  vec3 rotated3 = rotation2D(M_PI/4) * vec3(1, 1, 1);
+  vec3 rotated4 = rotation2D(M_PI/4) * vec3(1, -1, 1);
+  EXPECT_EQ(rotated1[2], 1) << "Homogeneous vector expected";
+  EXPECT_EQ(rotated2[2], 1) << "Homogeneous vector expected";
+  EXPECT_EQ(rotated3[2], 1) << "Homogeneous vector expected";
+  EXPECT_EQ(rotated4[2], 1) << "Homogeneous vector expected";
+
+  constexpr float s2    = M_SQRT2;
+  constexpr float shalf = M_SQRT1_2;
+
+  EXPECT_NEAR(rotated1.x, shalf, 1e-6f);
+  EXPECT_NEAR(rotated1.y, shalf, 1e-6f);
+
+  EXPECT_NEAR(rotated2.x, -shalf, 1e-6f);
+  EXPECT_NEAR(rotated2.y, shalf,  1e-6f);
+
+  EXPECT_NEAR(rotated3.x, 0,  1e-6f);
+  EXPECT_NEAR(rotated3.y, s2, 1e-6f);
+
+  EXPECT_NEAR(rotated4.x, s2, 1e-6f);
+  EXPECT_NEAR(rotated4.y, 0,  1e-6f);
+}
+
+TEST(GeomTransform, Shear2D) {
+  auto shearx = shear(vec2(0.5f, 0));
+  auto sheary = shear(vec2(0, 0.5f));
+  EXPECT_EQ(shearx * vec3(1, 0, 1), vec3(1, 0, 1));
+  EXPECT_EQ(shearx * vec3(0, 1, 1), vec3(0.5f, 1, 1));
+  EXPECT_EQ(shearx * vec3(1, 1, 1), vec3(1.5f, 1, 1));
+
+  EXPECT_EQ(sheary * vec3(1, 0, 1), vec3(1, 0.5f, 1));
+  EXPECT_EQ(sheary * vec3(0, 1, 1), vec3(0, 1, 1));
+  EXPECT_EQ(sheary * vec3(1, 1, 1), vec3(1, 1.5f, 1));
+}
+
+}  // namespace dali

--- a/dali/core/geom_vec_test.cu
+++ b/dali/core/geom_vec_test.cu
@@ -178,6 +178,45 @@ DEVICE_TEST(Dev_Vec, Func, 1, 1) {
   DEV_EXPECT_EQ(c, vec3(0, 0.1f, 1.0f));
 }
 
+TEST(Vec, MinMax) {
+  vec3 a = { -0.5f, 1.0f, 2.0f };
+  vec3 b = { 0.0f, 0.5f, 3.0f };
+  EXPECT_EQ(min(a, b), vec3(-0.5f, 0.5f, 2.0f));
+  EXPECT_EQ(max(a, b), vec3(0.0f, 1.0f, 3.0f));
+}
+
+DEVICE_TEST(Dev_Vec, MinMax, 1, 1) {
+  vec3 a = { -0.5f, 1.0f, 2.0f };
+  vec3 b = { 0.0f, 0.5f, 3.0f };
+  DEV_EXPECT_EQ(min(a, b), vec3(-0.5f, 0.5f, 2.0f));
+  DEV_EXPECT_EQ(max(a, b), vec3(0.0f, 1.0f, 3.0f));
+}
+
+TEST(Vec, AllAny) {
+  bvec3 all(true, true, true);
+  bvec3 some(false, true, false);
+  bvec3 none(false, false, false);
+  EXPECT_TRUE(all_coords(all));
+  EXPECT_TRUE(any_coord(all));
+  EXPECT_FALSE(all_coords(some));
+  EXPECT_TRUE(any_coord(some));
+  EXPECT_FALSE(all_coords(none));
+  EXPECT_FALSE(any_coord(none));
+}
+
+DEVICE_TEST(Dev_Vec, AllAny, 1, 1) {
+  bvec3 all(true, true, true);
+  bvec3 some(false, true, false);
+  bvec3 none(false, false, false);
+  DEV_EXPECT_TRUE(all_coords(all));
+  DEV_EXPECT_TRUE(any_coord(all));
+  DEV_EXPECT_FALSE(all_coords(some));
+  DEV_EXPECT_TRUE(any_coord(some));
+  DEV_EXPECT_FALSE(all_coords(none));
+  DEV_EXPECT_FALSE(any_coord(none));
+}
+
+
 TEST(Vec, RoundInt) {
   vec<3> f = { -0.6f, 0.1f, 0.7f };
   auto i = round_int(f);

--- a/include/dali/core/geom/transform.h
+++ b/include/dali/core/geom/transform.h
@@ -1,0 +1,97 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_GEOM_TRANSFORM_H_
+#define DALI_CORE_GEOM_TRANSFORM_H_
+
+#include "dali/core/geom/mat.h"
+
+namespace dali {
+
+DALI_HOST_DEV
+constexpr mat3 translation(vec2 offset) {
+  return {{
+    { 1, 0, offset.x },
+    { 0, 1, offset.y },
+    { 0, 0, 1 }
+  }};
+}
+
+DALI_HOST_DEV
+constexpr mat4 translation(vec3 offset) {
+  return {{
+    { 1, 0, 0, offset.x },
+    { 0, 1, 0, offset.y },
+    { 0, 0, 1, offset.z },
+    { 0, 0, 0, 1 }
+  }};
+}
+
+DALI_HOST_DEV
+constexpr mat3 scaling(vec2 scale) {
+  return {{
+    { scale.x, 0, 0 },
+    { 0, scale.y, 0 },
+    { 0, 0,       1 }
+  }};
+}
+
+DALI_HOST_DEV
+constexpr mat4 scaling(vec3 scale) {
+  return {{
+    { scale.x, 0, 0, 0 },
+    { 0, scale.y, 0, 0 },
+    { 0, 0, scale.z, 0 },
+    { 0, 0, 0,       1 }
+  }};
+}
+
+DALI_HOST_DEV
+constexpr mat3 rotation2D(float angle) {
+#ifdef __CUDA_ARCH__
+  float c = cosf(angle);
+  float s = sinf(angle);
+#else
+  float c = std::cos(angle);
+  float s = std::sin(angle);
+#endif
+  return {{
+    { c, -s, 0 },
+    { s, c, 0 },
+    { 0, 0, 1 }
+  }};
+}
+
+DALI_HOST_DEV
+constexpr mat3 shear(vec2 shear) {
+  return {{
+    { 1, shear.x, 0 },
+    { shear.y, 1, 0 },
+    { 0, 0, 1 }
+  }};
+}
+
+DALI_HOST_DEV
+constexpr mat4 shear(mat3x2 shear) {
+  return {{
+    { 1,           shear(0, 0), shear(0, 1), 0 },
+    { shear(1, 0), 1,           shear(1, 1), 0 },
+    { shear(2, 0), shear(2, 1), 1,           0 },
+    { 0,           0,           0,           1 }
+  }};
+}
+
+}  // namespace dali
+
+#endif  // DALI_CORE_GEOM_TRANSFORM_H_

--- a/include/dali/core/geom/vec.h
+++ b/include/dali/core/geom/vec.h
@@ -403,7 +403,7 @@ struct is_true {
 };
 
 template <size_t N, typename T, typename Pred = is_true>
-DALI_HOST_DEV constexpr bool all(const vec<N, T> &a, Pred P = {}) {
+DALI_HOST_DEV constexpr bool all_coords(const vec<N, T> &a, Pred P = {}) {
   for (size_t i = 0; i < N; i++)
     if (!P(a[i]))
       return false;
@@ -411,7 +411,7 @@ DALI_HOST_DEV constexpr bool all(const vec<N, T> &a, Pred P = {}) {
 }
 
 template <size_t N, typename T, typename Pred = is_true>
-DALI_HOST_DEV constexpr bool any(const vec<N, T> &a, Pred P = {}) {
+DALI_HOST_DEV constexpr bool any_coord(const vec<N, T> &a, Pred P = {}) {
   for (size_t i = 0; i < N; i++)
     if (P(a[i]))
       return true;
@@ -457,16 +457,6 @@ clamp(const vec<N, T> &in, const vec<N, T> &lo, const vec<N, T> &hi) {
   IMPL_VEC_ELEMENTWISE(clamp(in[i], lo[i], hi[i]));
 }
 
-template <size_t N, typename T>
-DALI_HOST_DEV vec<N, T> min(const vec<N, T> &a, const vec<N, T> &b) {
-  IMPL_VEC_ELEMENTWISE(min(a[i], b[i]));
-}
-
-template <size_t N, typename T>
-DALI_HOST_DEV vec<N, T> max(const vec<N, T> &a, const vec<N, T> &b) {
-  IMPL_VEC_ELEMENTWISE(max(a[i], b[i]));
-}
-
 #ifdef __CUDA_ARCH__
 template <size_t N>
 __device__ vec<N> floor(const vec<N> &a) {
@@ -477,6 +467,17 @@ template <size_t N>
 __device__ vec<N> ceil(const vec<N> &a) {
   IMPL_VEC_ELEMENTWISE(ceilf(a[i]));
 }
+
+template <size_t N, typename T>
+__device__ vec<N, T> min(const vec<N, T> &a, const vec<N, T> &b) {
+  IMPL_VEC_ELEMENTWISE(::min(a[i], b[i]));
+}
+
+template <size_t N, typename T>
+__device__ vec<N, T> max(const vec<N, T> &a, const vec<N, T> &b) {
+  IMPL_VEC_ELEMENTWISE(::max(a[i], b[i]));
+}
+
 #else
 
 template <size_t N, typename T>
@@ -487,6 +488,16 @@ constexpr vec<N, T> floor(const vec<N, T> &a) {
 template <size_t N, typename T>
 constexpr vec<N, T> ceil(const vec<N, T> &a) {
   IMPL_VEC_ELEMENTWISE(std::ceil(a[i]));
+}
+
+template <size_t N, typename T>
+constexpr vec<N, T> min(const vec<N, T> &a, const vec<N, T> &b) {
+  IMPL_VEC_ELEMENTWISE(std::min(a[i], b[i]));
+}
+
+template <size_t N, typename T>
+constexpr vec<N, T> max(const vec<N, T> &a, const vec<N, T> &b) {
+  IMPL_VEC_ELEMENTWISE(std::max(a[i], b[i]));
 }
 
 #endif


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
- adds functions that generate common affine transform matrices

#### What happend in this PR?
Added functions for
- translation (2D, 3D)
- non-uniform scaling along major axes (2D, 3D)
- shear (2D, 3D)
- rotation (2D)
All transforms are homogeneous (i.e. can be extended to perspective transforms!)
