### PR TITLE
Optimize test build.

### DIFF
--- a/dali_tf_plugin/build_in_custom_op_docker.sh
+++ b/dali_tf_plugin/build_in_custom_op_docker.sh
@@ -19,7 +19,7 @@ test ${CUDA_VERSION} = "10" && export SUPPORTED_TF_VERSIONS="1.13.1 1.14.0"
 
 for TF_VERSION in ${SUPPORTED_TF_VERSIONS}; do
     echo "Building DALI TF plugin for TF version ${TF_VERSION}"
-    pip install tensorflow-gpu=="${TF_VERSION}"
+    pip install tensorflow-gpu=="${TF_VERSION}" -f /pip-packages
 
     SUFFIX=$(echo $TF_VERSION | sed 's/\([0-9]\+\)\.\([0-9]\+\).*/\1_\2/')
     LIB_NAME=libdali_tf_${SUFFIX}.so

--- a/dali_tf_plugin/build_in_custom_op_docker.sh
+++ b/dali_tf_plugin/build_in_custom_op_docker.sh
@@ -13,15 +13,15 @@ DALI_TOPDIR="${PYTHON_DIST_PACKAGES}/nvidia/dali"
 DALI_CFLAGS=( $(python ./dali_compile_flags.py --cflags) )
 DALI_LFLAGS=( $(python ./dali_compile_flags.py --lflags) )
 
-CUDA_VERSION=$(cat /usr/local/cuda/version.txt | head -1 | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1/')
-test ${CUDA_VERSION} = "9"  && export SUPPORTED_TF_VERSIONS="1.7.0 1.11.0 1.12.0"
-test ${CUDA_VERSION} = "10" && export SUPPORTED_TF_VERSIONS="1.13.1 1.14.0"
+CUDA_VERSION=$(cat /usr/local/cuda/version.txt | head -1 | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
+LAST_CONFIG_INDEX=$(python ../qa/setup_packages.py -n -u tensorflow-gpu --cuda ${CUDA_VERSION})
+for i in `seq 0 $LAST_CONFIG_INDEX`;
+do
+    INST=$(python ../qa/setup_packages.py -i $i -u tensorflow-gpu --cuda ${CUDA_VERSION})
+    echo "Building DALI TF plugin for TF version ${INST}"
+    pip install ${INST} -f /pip-packages
 
-for TF_VERSION in ${SUPPORTED_TF_VERSIONS}; do
-    echo "Building DALI TF plugin for TF version ${TF_VERSION}"
-    pip install tensorflow-gpu=="${TF_VERSION}" -f /pip-packages
-
-    SUFFIX=$(echo $TF_VERSION | sed 's/\([0-9]\+\)\.\([0-9]\+\).*/\1_\2/')
+    SUFFIX=$(echo $INST | sed 's/.*=\([0-9]\+\)\.\([0-9]\+\).*/\1_\2/')
     LIB_NAME=libdali_tf_${SUFFIX}.so
     TF_CFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )
     TF_LFLAGS=( $(python -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))') )

--- a/docker/Dockerfile.customopbuilder.clean
+++ b/docker/Dockerfile.customopbuilder.clean
@@ -58,9 +58,13 @@ RUN rm -f /usr/bin/python && \
 COPY --from=cuda /usr/local/cuda /usr/local/cuda
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs/:${LD_LIBRARY_PATH}
 
-RUN export USE_CUDA_VERSION=$(cat /usr/local/cuda/version.txt | head -1 | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1/') &&\
-    if [ "${USE_CUDA_VERSION}" = "9" ]; then export SUPPORTED_TF_VERSIONS="1.7.0 1.11.0 1.12.0"; fi && \
-    if [ "${USE_CUDA_VERSION}" = "10" ]; then export SUPPORTED_TF_VERSIONS="1.13.1 1.14.0"; fi && \
-    for TF_VERSION in ${SUPPORTED_TF_VERSIONS}; do \
-        pip download tensorflow-gpu==${TF_VERSION} -d /pip-packages; \
+WORKDIR /opt/dali
+COPY qa/setup_packages.py qa/setup_packages.py
+
+# get current CUDA version, ask setup_packages.py which TensorFlow we need to support and loop over all version downloading
+# them to /pip-packages dir one by one. In effect all TF versions are stored in only one place setup_packages.py
+RUN export USE_CUDA_VERSION=$(cat /usr/local/cuda/version.txt | head -1 | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/') && \
+    export last_config_index=$(python qa/setup_packages.py -n -u tensorflow-gpu --cuda ${USE_CUDA_VERSION}) && \
+    for i in `seq 0 $last_config_index`; do \
+        pip download $(python qa/setup_packages.py -i $i -u tensorflow-gpu --cuda ${USE_CUDA_VERSION}) -d /pip-packages; \
     done

--- a/docker/Dockerfile.customopbuilder.clean
+++ b/docker/Dockerfile.customopbuilder.clean
@@ -57,3 +57,10 @@ RUN rm -f /usr/bin/python && \
 
 COPY --from=cuda /usr/local/cuda /usr/local/cuda
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs/:${LD_LIBRARY_PATH}
+
+RUN export USE_CUDA_VERSION=$(cat /usr/local/cuda/version.txt | head -1 | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1/') &&\
+    if [ "${USE_CUDA_VERSION}" = "9" ]; then export SUPPORTED_TF_VERSIONS="1.7.0 1.11.0 1.12.0"; fi && \
+    if [ "${USE_CUDA_VERSION}" = "10" ]; then export SUPPORTED_TF_VERSIONS="1.13.1 1.14.0"; fi && \
+    for TF_VERSION in ${SUPPORTED_TF_VERSIONS}; do \
+        pip download tensorflow-gpu==${TF_VERSION} -d /pip-packages; \
+    done

--- a/qa/TL0_FW_iterators/test.sh
+++ b/qa/TL0_FW_iterators/test.sh
@@ -1,16 +1,15 @@
 #!/bin/bash -e
 # used pip packages
 
-source ../setup_dali_extra.sh
 
 pip_packages="nose numpy opencv-python tensorflow-gpu torchvision mxnet-cu##CUDA_VERSION##"
+target_dir=./dali/test/python
+
 one_config_only=true
 
-pushd ../..
-
-cd dali/test/python
-
-NUM_GPUS=$(nvidia-smi -L | wc -l)
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
 
 test_body() {
     python test_RN50_data_fw_iterators.py --gpus ${NUM_GPUS} -b 13 --workers 3 --prefetch 2 -i 100 --epochs 2
@@ -20,6 +19,6 @@ test_body() {
     nosetests --verbose test_FW_iterators_shuffling.py
 }
 
-source ../../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL0_abi/test.sh
+++ b/qa/TL0_abi/test.sh
@@ -1,18 +1,18 @@
 #!/bin/bash -e
 
+test_body() {
+  DIRNAME=$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))')
+  # skip non core libs
+  for SOFILE in $(find $DIRNAME -iname 'libdali*.so' -not -iname '*tf*')
+  do
+      # first line is for the debug
+      echo $SOFILE":"
+      nm -gC --defined-only $SOFILE | grep -v "dali::" | grep -i " t " | grep -vx ".*T dali.*" | grep -vx ".*T _fini" | grep -vx ".*T _init" || true
+      nm -gC --defined-only $SOFILE | grep -v "dali::" | grep -i " t " | grep -vx ".*T dali.*" | grep -vx ".*T _fini" | grep -vxq ".*T _init" && exit 1
+  done
+  echo "Done"
+}
+
 pushd ../..
-
-source qa/setup_test_common.sh
-
-DIRNAME=$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))')
-# skip non core libs
-for SOFILE in $(find $DIRNAME -iname 'libdali*.so' -not -iname '*tf*')
-do
-    # first line is for the debug
-    echo $SOFILE":"
-    nm -gC --defined-only $SOFILE | grep -v "dali::" | grep -i " t " | grep -vx ".*T dali.*" | grep -vx ".*T _fini" | grep -vx ".*T _init" || true
-    nm -gC --defined-only $SOFILE | grep -v "dali::" | grep -i " t " | grep -vx ".*T dali.*" | grep -vx ".*T _fini" | grep -vxq ".*T _init" && exit 1
-done
-echo "Done"
-
+source ./qa/test_template.sh
 popd

--- a/qa/TL0_framework_imports/test.sh
+++ b/qa/TL0_framework_imports/test.sh
@@ -19,4 +19,6 @@ test_body() {
     ( set -x && python -c "import nvidia.dali.plugin.pytorch; import torch" )
 }
 
-source ../test_template.sh
+pushd ../../
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_jupyter/test.sh
+++ b/qa/TL0_jupyter/test.sh
@@ -1,15 +1,12 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages="jupyter numpy matplotlib pillow"
+target_dir=./docs/examples
 
-source ../setup_dali_extra.sh
-
-pushd ../..
-
-# attempt to run jupyter on all example notebooks
-mkdir -p idx_files
-
-cd docs/examples
+do_once() {
+    # attempt to run jupyter on all example notebooks
+    mkdir -p idx_files
+}
 
 test_body() {
     # test code
@@ -22,6 +19,6 @@ test_body() {
                     --ExecutePreprocessor.timeout=300 {}
 }
 
-source ../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL0_plugin_manager/test.sh
+++ b/qa/TL0_plugin_manager/test.sh
@@ -1,16 +1,12 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages="nose numpy"
-
-pushd ../..
-
-source qa/setup_dali_extra.sh
-cd dali/test/python
+target_dir=./dali/test/python
 
 test_body() {
     nosetests --verbose test_plugin_manager.py
 }
 
-source ../../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL0_python-self-test/test.sh
+++ b/qa/TL0_python-self-test/test.sh
@@ -1,15 +1,11 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages="nose numpy opencv-python pillow"
+target_dir=./dali/test/python
 
 # test_body definition is in separate file so it can be used without setup
 source test_body.sh
 
 pushd ../..
-
-source qa/setup_dali_extra.sh
-cd dali/test/python
-
-source ../../../qa/test_template.sh
-
+source ./qa/test_template.sh
 popd

--- a/qa/TL0_python_self_test_TU/test.sh
+++ b/qa/TL0_python_self_test_TU/test.sh
@@ -1,11 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages="nose numpy"
-
-pushd ../..
-
-source qa/setup_dali_extra.sh
-cd dali/test/python
+target_dir=./dali/test/python
 
 test_body() {
     # workaround for the CI
@@ -13,6 +9,7 @@ test_body() {
     nosetests --verbose test_optical_flow.py
 }
 
-source ../../../qa/test_template.sh
 
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL0_python_self_test_pytorch/test.sh
+++ b/qa/TL0_python_self_test_pytorch/test.sh
@@ -1,16 +1,12 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages="nose numpy torch"
-
-pushd ../..
-
-source qa/setup_dali_extra.sh
-cd dali/test/python
+target_dir=./dali/test/python
 
 test_body() {
     nosetests --verbose test_pytorch_operator
 }
 
-source ../../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL0_rn50-benchmarks/test.sh
+++ b/qa/TL0_rn50-benchmarks/test.sh
@@ -1,22 +1,26 @@
 #!/bin/bash -ex
 
-source ../setup_test_common.sh
+test_body() {
+  BINNAME=dali_benchmark.bin
 
-BINNAME=dali_benchmark.bin
+  for DIRNAME in \
+    "../../build/dali/python/nvidia/dali" \
+    "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
+  do
+      if [ -x "$DIRNAME/test/$BINNAME" ]; then
+          FULLPATH="$DIRNAME/test/$BINNAME"
+          break
+      fi
+  done
 
-for DIRNAME in \
-  "../../build/dali/python/nvidia/dali" \
-  "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
-do
-    if [ -x "$DIRNAME/test/$BINNAME" ]; then
-        FULLPATH="$DIRNAME/test/$BINNAME"
-        break
-    fi
-done
+  if [[ -z "$FULLPATH" ]]; then
+      echo "ERROR: $BINNAME not found"
+      exit 1
+  fi
 
-if [[ -z "$FULLPATH" ]]; then
-    echo "ERROR: $BINNAME not found"
-    exit 1
-fi
+  "$FULLPATH" --benchmark_filter="RN50*"
+}
 
-"$FULLPATH" --benchmark_filter="RN50*"
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_rn50_python-benchmarks/test.sh
+++ b/qa/TL0_rn50_python-benchmarks/test.sh
@@ -1,16 +1,13 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages="numpy"
-
-pushd ../..
-
-cd dali/benchmark
+target_dir=./dali/benchmark
 
 test_body() {
     # test code
     python resnet50_bench.py
 }
 
-source ../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL0_self-test/test.sh
+++ b/qa/TL0_self-test/test.sh
@@ -1,23 +1,26 @@
 #!/bin/bash -ex
 
-source ../setup_test_common.sh
-source ../setup_dali_extra.sh
+test_body() {
+  BINNAME=dali_test.bin
 
-BINNAME=dali_test.bin
+  for DIRNAME in \
+    "../../build/dali/python/nvidia/dali" \
+    "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
+  do
+      if [ -x "$DIRNAME/test/$BINNAME" ]; then
+          FULLPATH="$DIRNAME/test/$BINNAME"
+          break
+      fi
+  done
 
-for DIRNAME in \
-  "../../build/dali/python/nvidia/dali" \
-  "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
-do
-    if [ -x "$DIRNAME/test/$BINNAME" ]; then
-        FULLPATH="$DIRNAME/test/$BINNAME"
-        break
-    fi
-done
+  if [[ -z "$FULLPATH" ]]; then
+      echo "ERROR: $BINNAME not found"
+      exit 1
+  fi
 
-if [[ -z "$FULLPATH" ]]; then
-    echo "ERROR: $BINNAME not found"
-    exit 1
-fi
+  "$FULLPATH"
+}
 
-"$FULLPATH"
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_tensorflow_plugin/test.sh
+++ b/qa/TL0_tensorflow_plugin/test.sh
@@ -1,11 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages="nose tensorflow-gpu"
-
-pushd ../..
-
-source qa/setup_dali_extra.sh
-cd dali/test/python
+target_dir=./dali/test/python
 
 test_body() {
     # Manually removing the supported plugin so that it fails
@@ -23,6 +19,6 @@ test_body() {
     nosetests --verbose test_dali_tf_plugin_run.py
 }
 
-source ../../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL1_jupyter_notebooks_TU/test.sh
+++ b/qa/TL1_jupyter_notebooks_TU/test.sh
@@ -1,11 +1,8 @@
 #!/bin/bash -e
 
-source ../setup_dali_extra.sh
-
 # used pip packages
 pip_packages="jupyter matplotlib numpy"
-
-pushd ../../docs/examples
+target_dir=./docs/examples
 
 test_body() {
     # workaround for the CI
@@ -19,6 +16,6 @@ test_body() {
                    --ExecutePreprocessor.timeout=600 {}
 }
 
-source ../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL1_jupyter_plugins/test.sh
+++ b/qa/TL1_jupyter_plugins/test.sh
@@ -1,22 +1,18 @@
 #!/bin/bash -e
 
-source ../setup_dali_extra.sh
-
 # used pip packages
 pip_packages="jupyter matplotlib mxnet-cu##CUDA_VERSION## tensorflow-gpu torchvision torch"
+target_dir=./docs/examples
 
-# We need cmake to run the custom plugin notebook + ffmpeg and wget for video example
-apt-get update
-apt-get install -y --no-install-recommends wget ffmpeg cmake
-
-pushd ../..
-
-# attempt to run jupyter on all example notebooks
-mkdir -p idx_files
-
-cd docs/examples
+do_once() {
+  # We need cmake to run the custom plugin notebook + ffmpeg and wget for video example
+  apt-get update
+  apt-get install -y --no-install-recommends wget ffmpeg cmake
+  mkdir -p idx_files
+}
 
 test_body() {
+  # attempt to run jupyter on all example notebooks
     black_list_files="optical_flow_example.ipynb\|#" # optical flow requires TU102 architecture
                                                      # whilst currently L1_jupyter_plugins test
                                                      # can be run only on V100
@@ -29,6 +25,6 @@ test_body() {
     python${PYVER:0:1} pytorch/resnet50/main.py -t
 }
 
-source ../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL1_python-nvjpeg_test/test.sh
+++ b/qa/TL1_python-nvjpeg_test/test.sh
@@ -1,18 +1,17 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages=""
+target_dir=./dali/test/python
 
-pushd ../..
-
-cd dali/test/python
-
-NUM_GPUS=$(nvidia-smi -L | wc -l)
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
 
 test_body() {
     # test code
     python test_data_containers.py --gpus ${NUM_GPUS} -b 2048 -p 10
 }
 
-source ../../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL1_separate_executor/test.sh
+++ b/qa/TL1_separate_executor/test.sh
@@ -1,13 +1,12 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages="tensorflow-gpu torchvision mxnet-cu##CUDA_VERSION##"
+target_dir=./dali/test/python
 one_config_only=true
 
-pushd ../..
-
-cd dali/test/python
-
-NUM_GPUS=$(nvidia-smi -L | wc -l)
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
 
 test_body() {
     python test_RN50_data_pipeline.py --gpus ${NUM_GPUS} -b 256 --workers 3 --separate_queue --cpu_size 2 --gpu_size 2 --fp16 --nhwc
@@ -17,6 +16,6 @@ test_body() {
     python test_RN50_data_fw_iterators.py --gpus ${NUM_GPUS} -b 13 --workers 3 --separate_queue --cpu_size 3 --gpu_size 2 --iters 32 --epochs 2
 }
 
-source ../../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL1_ssd_training/test.sh
+++ b/qa/TL1_ssd_training/test.sh
@@ -1,10 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages="numpy torch torchvision mlperf_compliance matplotlib Cython"
-
-pushd ../..
-
-cd docs/examples/pytorch/single_stage_detector/
+target_dir=./docs/examples/pytorch/single_stage_detector/
 
 test_body() {
     # workaround due to errors while pycocotools is int "pip_packages" above
@@ -19,6 +16,7 @@ test_body() {
     python -m torch.distributed.launch --nproc_per_node=8 main.py --backbone resnet50 --warmup 300 --bs 64 --eval-batch-size 8 --epochs 4 --data /data/coco/coco-2017/coco2017/ --data_pipeline dali --target 0.085
 }
 
-source ../../../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd
+

--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -1,64 +1,63 @@
 #!/bin/bash -e
 pip_packages=""
+target_dir=./docs/examples/tensorflow/demo
 
-pushd ../..
+do_once() {
+    mkdir -p idx-files/
 
-cd docs/examples/tensorflow/demo
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
 
-mkdir -p idx-files/
+    CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
+    # from 1.13.1 CUDA 10 is supported but not CUDA 9
+    if [ "${CUDA_VERSION}" -ge "100" ]; then
+        pip install tensorflow-gpu==1.13.1
+    else
+        pip install tensorflow-gpu==1.12
+    fi
+    pip uninstall -y nvidia-dali-tf-plugin || true
+    pip install /opt/dali/nvidia-dali-tf-plugin*.tar.gz
 
-NUM_GPUS=$(nvidia-smi -L | wc -l)
+    export PATH=$PATH:/usr/local/mpi/bin
+    # MPI might be present in CUDA 10 image already so no need to build it if that is the case
+    if ! [ -x "$(command -v mpicxx)" ]; then
+        apt-get update && apt-get install -y wget
+        OPENMPI_VERSION=3.0.0
+        wget -q -O - https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-${OPENMPI_VERSION}.tar.gz | tar -xzf -
+        cd openmpi-${OPENMPI_VERSION}
+        ./configure --enable-orterun-prefix-by-default --prefix=/usr/local/mpi --disable-getpwuid -with-cma=no
+        make -j"$(nproc)" install
+        cd .. && rm -rf openmpi-${OPENMPI_VERSION}
+        echo "/usr/local/mpi/lib" >> /etc/ld.so.conf.d/openmpi.conf && ldconfig
 
-CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
-# from 1.13.1 CUDA 10 is supported but not CUDA 9
-if [ "${CUDA_VERSION}" -ge "100" ]; then
-    pip install tensorflow-gpu==1.13.1
-else
-    pip install tensorflow-gpu==1.12
-fi
-pip uninstall -y nvidia-dali-tf-plugin || true
-pip install /opt/dali/nvidia-dali-tf-plugin*.tar.gz
+        /bin/echo -e '#!/bin/bash'\
+        '\ncat <<EOF'\
+        '\n======================================================================'\
+        '\nTo run a multi-node job, install an ssh client and clear plm_rsh_agent'\
+        '\nin '/usr/local/mpi/etc/openmpi-mca-params.conf'.'\
+        '\n======================================================================'\
+        '\nEOF'\
+        '\nexit 1' >> /usr/local/mpi/bin/rsh_warn.sh
+        chmod +x /usr/local/mpi/bin/rsh_warn.sh
+        echo "plm_rsh_agent = /usr/local/mpi/bin/rsh_warn.sh" >> /usr/local/mpi/etc/openmpi-mca-params.conf
+    fi
 
-export PATH=$PATH:/usr/local/mpi/bin
-# MPI might be present in CUDA 10 image already so no need to build it if that is the case
-if ! [ -x "$(command -v mpicxx)" ]; then
-    apt-get update && apt-get install -y wget
-    OPENMPI_VERSION=3.0.0
-    wget -q -O - https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-${OPENMPI_VERSION}.tar.gz | tar -xzf -
-    cd openmpi-${OPENMPI_VERSION}
-    ./configure --enable-orterun-prefix-by-default --prefix=/usr/local/mpi --disable-getpwuid -with-cma=no
-    make -j"$(nproc)" install
-    cd .. && rm -rf openmpi-${OPENMPI_VERSION}
-    echo "/usr/local/mpi/lib" >> /etc/ld.so.conf.d/openmpi.conf && ldconfig
+    export HOROVOD_GPU_ALLREDUCE=NCCL
+    export HOROVOD_NCCL_INCLUDE=/usr/include
+    export HOROVOD_NCCL_LIB=/usr/lib/x86_64-linux-gnu
+    export HOROVOD_NCCL_LINK=SHARED
+    export HOROVOD_WITHOUT_PYTORCH=1
+    pip install horovod==0.15.1
 
-    /bin/echo -e '#!/bin/bash'\
-    '\ncat <<EOF'\
-    '\n======================================================================'\
-    '\nTo run a multi-node job, install an ssh client and clear plm_rsh_agent'\
-    '\nin '/usr/local/mpi/etc/openmpi-mca-params.conf'.'\
-    '\n======================================================================'\
-    '\nEOF'\
-    '\nexit 1' >> /usr/local/mpi/bin/rsh_warn.sh
-    chmod +x /usr/local/mpi/bin/rsh_warn.sh
-    echo "plm_rsh_agent = /usr/local/mpi/bin/rsh_warn.sh" >> /usr/local/mpi/etc/openmpi-mca-params.conf
-fi
+    for file in $(ls /data/imagenet/train-val-tfrecord-480-subset);
+    do
+        python ../../../../tools/tfrecord2idx /data/imagenet/train-val-tfrecord-480-subset/${file} \
+            idx-files/${file}.idx;
+    done
 
-export HOROVOD_GPU_ALLREDUCE=NCCL
-export HOROVOD_NCCL_INCLUDE=/usr/include
-export HOROVOD_NCCL_LIB=/usr/lib/x86_64-linux-gnu
-export HOROVOD_NCCL_LINK=SHARED
-export HOROVOD_WITHOUT_PYTORCH=1
-pip install horovod==0.15.1
-
-for file in $(ls /data/imagenet/train-val-tfrecord-480-subset);
-do
-    python ../../../../tools/tfrecord2idx /data/imagenet/train-val-tfrecord-480-subset/${file} \
-        idx-files/${file}.idx;
-done
-
-# OMPI_MCA_blt is needed if running in a container w/o cap SYS_PRACE
-# More info: https://github.com/radiasoft/devops/issues/132
-export OMPI_MCA_blt=self,sm,tcp
+    # OMPI_MCA_blt is needed if running in a container w/o cap SYS_PRACE
+    # More info: https://github.com/radiasoft/devops/issues/132
+    export OMPI_MCA_blt=self,sm,tcp
+}
 
 test_body() {
     # test code
@@ -69,6 +68,6 @@ test_body() {
         --batch=256 --dali_cpu --log_dir=dali_log
 }
 
-source ../../../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL1_tensorflow_plugin/test.sh
+++ b/qa/TL1_tensorflow_plugin/test.sh
@@ -1,15 +1,13 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages="nose"
+target_dir=./dali/test/python
 
-pushd ../..
-
-source qa/setup_dali_extra.sh
-cd dali/test/python
-
-USE_CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1/')
-test "$USE_CUDA_VERSION" = "10" && export TENSORFLOW_VERSIONS="1.13.1 1.14"
-test "$USE_CUDA_VERSION" = "9" && export TENSORFLOW_VERSIONS="1.7 1.8 1.9 1.10 1.11 1.12"
+do_once() {
+    USE_CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1/')
+    test "$USE_CUDA_VERSION" = "10" && export TENSORFLOW_VERSIONS="1.13.1 1.14"
+    test "$USE_CUDA_VERSION" = "9" && export TENSORFLOW_VERSIONS="1.7 1.8 1.9 1.10 1.11 1.12"
+}
 
 test_body() {
     # Manually removing the supported plugin so that it fails
@@ -35,6 +33,6 @@ test_body() {
     done
 }
 
-source ../../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL2_FW_iterators_perf/test.sh
+++ b/qa/TL2_FW_iterators_perf/test.sh
@@ -1,18 +1,17 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages="tensorflow-gpu torchvision mxnet-cu##CUDA_VERSION## torch"
+target_dir=./dali/test/python
 one_config_only=true
 
-pushd ../..
-
-cd dali/test/python
-
-NUM_GPUS=$(nvidia-smi -L | wc -l)
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
 
 test_body() {
     python test_RN50_data_fw_iterators.py --gpus ${NUM_GPUS} -b 13 --workers 3 --prefetch 2 --epochs 3
 }
 
-source ../../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL2_RN50_data_perf/test.sh
+++ b/qa/TL2_RN50_data_perf/test.sh
@@ -1,12 +1,11 @@
 #!/bin/bash -e
 # used pip packages
 pip_packages=""
+target_dir=./dali/test/python
 
-pushd ../..
-
-cd dali/test/python
-
-NUM_GPUS=$(nvidia-smi -L | wc -l)
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
 
 test_body() {
     # test code
@@ -17,6 +16,6 @@ test_body() {
     python test_RN50_data_pipeline.py --gpus ${NUM_GPUS} -b 16 --workers 3 --prefetch 11 --fp16 --nhwc
 }
 
-source ../../../qa/test_template.sh
-
+pushd ../..
+source ./qa/test_template.sh
 popd

--- a/qa/TL3_RN50_convergence/test_mxnet.sh
+++ b/qa/TL3_RN50_convergence/test_mxnet.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e
-#!/bin/bash
 
 threshold=0.75
 min_perf=10000

--- a/qa/download_pip_packages.sh
+++ b/qa/download_pip_packages.sh
@@ -4,7 +4,7 @@ pip_packages="nose matplotlib jupyter numpy torch tensorflow-gpu mxnet-cu##CUDA_
 pip_packages=$(echo ${pip_packages} | sed "s/##CUDA_VERSION##/${CUDA_VERSION}/")
 
 mkdir /pip-packages
-pip download $(/qa/setup_packages.py -a -u $pip_packages --cuda ${CUDA_VERSION}) -d /pip-packages
+pip download $(/opt/dali/qa/setup_packages.py -a -u ${pip_packages} --cuda ${CUDA_VERSION}) -d /pip-packages
 
 
 

--- a/qa/download_pip_packages.sh
+++ b/qa/download_pip_packages.sh
@@ -7,9 +7,6 @@ pip_packages="nose matplotlib jupyter numpy torch tensorflow-gpu mxnet-cu${CUDA_
 echo ${CUDA_VERSION}
 mkdir /pip-packages
 to_download=$(/opt/dali/qa/setup_packages.py -a -u ${pip_packages} --cuda ${CUDA_VERSION})
-for p in $( to_download ); do
+for p in ${to_download}; do
     pip download ${p} -d /pip-packages
 done
-
-
-

--- a/qa/download_pip_packages.sh
+++ b/qa/download_pip_packages.sh
@@ -3,7 +3,7 @@
 CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
 CUDA_VERSION=${CUDA_VERSION:-90}
 
-pip_packages="nose matplotlib jupyter numpy torch tensorflow-gpu mxnet-cu${CUDA_VERSION} torchvision pillow"
+pip_packages="nose matplotlib jupyter numpy torch tensorflow-gpu mxnet-cu${CUDA_VERSION} torchvision pillow opencv-python"
 echo ${CUDA_VERSION}
 mkdir /pip-packages
 to_download=$(/opt/dali/qa/setup_packages.py -a -u ${pip_packages} --cuda ${CUDA_VERSION})

--- a/qa/download_pip_packages.sh
+++ b/qa/download_pip_packages.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-pip_packages="nose matplotlib jupyter numpy torch tensorflow-gpu mxnet-cu##CUDA_VERSION## torchvision pillow"
-pip_packages=$(echo ${pip_packages} | sed "s/##CUDA_VERSION##/${CUDA_VERSION}/")
+CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
+CUDA_VERSION=${CUDA_VERSION:-90}
 
+pip_packages="nose matplotlib jupyter numpy torch tensorflow-gpu mxnet-cu${CUDA_VERSION} torchvision pillow"
+echo ${CUDA_VERSION}
 mkdir /pip-packages
 pip download $(/opt/dali/qa/setup_packages.py -a -u ${pip_packages} --cuda ${CUDA_VERSION}) -d /pip-packages
 

--- a/qa/download_pip_packages.sh
+++ b/qa/download_pip_packages.sh
@@ -6,7 +6,10 @@ CUDA_VERSION=${CUDA_VERSION:-90}
 pip_packages="nose matplotlib jupyter numpy torch tensorflow-gpu mxnet-cu${CUDA_VERSION} torchvision pillow"
 echo ${CUDA_VERSION}
 mkdir /pip-packages
-pip download $(/opt/dali/qa/setup_packages.py -a -u ${pip_packages} --cuda ${CUDA_VERSION}) -d /pip-packages
+to_download=$(/opt/dali/qa/setup_packages.py -a -u ${pip_packages} --cuda ${CUDA_VERSION})
+for p in $( to_download ); do
+    pip download ${p} -d /pip-packages
+done
 
 
 

--- a/qa/download_pip_packages.sh
+++ b/qa/download_pip_packages.sh
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
 
-CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
-CUDA_VERSION=${CUDA_VERSION:-90}
+mkdir -p /pip-packages
+gather_pip_packages=yes
 
-pip_packages="nose matplotlib jupyter numpy torch tensorflow-gpu mxnet-cu${CUDA_VERSION} torchvision pillow opencv-python"
-echo ${CUDA_VERSION}
-mkdir /pip-packages
-to_download=$(/opt/dali/qa/setup_packages.py -a -u ${pip_packages} --cuda ${CUDA_VERSION})
-for p in ${to_download}; do
-    pip download ${p} -d /pip-packages
+for folder in $(ls -d */ | grep -v TL3);
+do
+    echo ${folder}
+    pushd ${folder}
+    source test.sh
+    popd
+    echo ${pip_packages}
+    last_config_index=$(python setup_packages.py -n -u $pip_packages --cuda ${CUDA_VERSION})
+    for i in `seq 0 $last_config_index`;
+    do
+        inst=$(python setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION})
+        if [ -n "$inst" ]
+        then
+            pip download $inst -d /pip-packages
+        fi
+    done
 done

--- a/qa/download_pip_packages.sh
+++ b/qa/download_pip_packages.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+pip_packages="nose matplotlib jupyter numpy torch tensorflow-gpu mxnet-cu##CUDA_VERSION## torchvision pillow"
+pip_packages=$(echo ${pip_packages} | sed "s/##CUDA_VERSION##/${CUDA_VERSION}/")
+
+mkdir /pip-packages
+pip download $(/qa/setup_packages.py -a -u $pip_packages --cuda ${CUDA_VERSION}) -d /pip-packages
+
+
+

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -32,6 +32,7 @@ parser = argparse.ArgumentParser(description='Env setup helper')
 parser.add_argument('--list', '-l', help='list configs', action='store_true', default=False)
 parser.add_argument('--num', '-n', help='return number of all configurations possible', action='store_true', default=False)
 parser.add_argument('--install', '-i', dest='install', type=int, help="get Nth configuration", default=-1)
+parser.add_argument('--all', '-a', dest='getall', action='store_true', help='return packages in all versions')
 parser.add_argument('--remove', '-r', dest='remove', help="list packages to remove", action='store_true', default=False)
 parser.add_argument('--cuda', dest='cuda', default="90", help="CUDA version to use")
 parser.add_argument('--use', '-u', dest='use', default=[], help="provide only packages from this list", nargs='*')
@@ -105,6 +106,22 @@ def cal_num_of_configs(use, cuda):
         ret *= len(get_package(packages, key, cuda))
     return ret
 
+def get_all_string(use, cuda):
+    ret = []
+    for key in packages.keys():
+        if key not in use:
+            continue
+        for val in get_package(packages, key, cuda):
+            if val is None:
+                ret.append(key)
+            elif 'http' in val:
+                ret.append(get_pyvers_name(val, cuda))
+            else:
+                ret.append(key + "==" + val)
+    # add all remaining used packages with default versions
+    additional = [v for v in use if v not in packages.keys()]
+    return " ".join(ret + additional)
+
 def main():
     global args
     if args.list:
@@ -113,6 +130,8 @@ def main():
         print (cal_num_of_configs(args.use, args.cuda) - 1)
     elif args.remove:
         print (get_remove_string(args.use, args.cuda))
+    elif args.getall:
+        print(get_all_string(args.use, args.cuda))
     elif args.install >= 0:
         if args.install > cal_num_of_configs(args.use, args.cuda):
             args.install = 1

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -66,7 +66,7 @@ def print_configs(cuda):
         for val in get_package(packages, key, cuda):
             if val == None:
                 val = "Default"
-            elif 'http' in val:
+            elif val.startswith('http'):
                 val = get_pyvers_name(val, cuda)
             print ('\t' + val)
 
@@ -79,7 +79,7 @@ def get_install_string(variant, use, cuda):
         val = get_package(packages, key, cuda)[tmp]
         if val == None:
             ret.append(key)
-        elif 'http' in val:
+        elif val.startswith('http'):
             ret.append(get_pyvers_name(val, cuda))
         else:
             ret.append(key + "==" + val)
@@ -106,7 +106,7 @@ def cal_num_of_configs(use, cuda):
         ret *= len(get_package(packages, key, cuda))
     return ret
 
-def get_all_string(use, cuda):
+def get_all_strings(use, cuda):
     ret = []
     for key in packages.keys():
         if key not in use:
@@ -114,7 +114,7 @@ def get_all_string(use, cuda):
         for val in get_package(packages, key, cuda):
             if val is None:
                 ret.append(key)
-            elif 'http' in val:
+            elif val.startswith('http'):
                 ret.append(get_pyvers_name(val, cuda))
             else:
                 ret.append(key + "==" + val)
@@ -131,7 +131,7 @@ def main():
     elif args.remove:
         print (get_remove_string(args.use, args.cuda))
     elif args.getall:
-        print(get_all_string(args.use, args.cuda))
+        print(get_all_strings(args.use, args.cuda))
     elif args.install >= 0:
         if args.install > cal_num_of_configs(args.use, args.cuda):
             args.install = 1

--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -2,6 +2,12 @@
 
 CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
 CUDA_VERSION=${CUDA_VERSION:-90}
+
+if [ -n "$gather_pip_packages" ]
+then
+    # early exit
+    return 0
+fi
 PYTHON_VERSION=$(python -c "from __future__ import print_function; import sys; print(\"{}.{}\".format(sys.version_info[0],sys.version_info[1]))")
 
 NVIDIA_SMI_DRIVER_VERSION=$(nvidia-smi | grep -Po '(?<=Driver Version: )\d+.\d+')

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -25,7 +25,7 @@ do
     inst=$($topdir/qa/setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION})
     if [ -n "$inst" ]
     then
-      pip install $inst
+      pip install $inst -f /pip-packages
 
       # If we just installed tensorflow, we need to reinstall DALI TF plugin
       if [[ "$inst" == *tensorflow-gpu* ]]; then

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -12,10 +12,26 @@ source $topdir/qa/setup_test_common.sh
 pip_packages=$(echo ${pip_packages} | sed "s/##CUDA_VERSION##/${CUDA_VERSION}/")
 last_config_index=$($topdir/qa/setup_packages.py -n -u $pip_packages --cuda ${CUDA_VERSION})
 
+if [ -n "$gather_pip_packages" ]
+then
+    # early exit
+    return 0
+fi
+
+source $topdir/qa//setup_dali_extra.sh
+
+target_dir=${target_dir-./}
+cd ${target_dir}
+
 # Limit to only one configuration (First version of each package)
 if [[ $one_config_only = true ]]; then
     echo "Limiting test run to one configuration of packages (first version of each)"
     last_config_index=0
+fi
+
+# some global test setup
+if [ "$(type -t do_once)" = 'function' ]; then
+    do_once
 fi
 
 for i in `seq 0 $last_config_index`;

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -8,14 +8,6 @@ set -x
 topdir=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/..
 source $topdir/qa/setup_test_common.sh
 
-# Install dependencies: opencv-python from 3.3.0.10 onwards uses QT which requires
-# X11 and other libraries that are not present in clean docker images or bundled there
-apt-get update
-apt-get install -y --no-install-recommends libsm6 libice6 libxrender1 libxext6 libx11-6 glib-2.0
-# Note: glib-2.0 depends on python2, so reinstall the desired python afterward
-# to make sure defaults are right
-apt-get install -y --no-install-recommends --reinstall python$PYVER python$PYVER-dev
-
 # Set proper CUDA version for packages, like MXNet, requiring it
 pip_packages=$(echo ${pip_packages} | sed "s/##CUDA_VERSION##/${CUDA_VERSION}/")
 last_config_index=$($topdir/qa/setup_packages.py -n -u $pip_packages --cuda ${CUDA_VERSION})


### PR DESCRIPTION
Why we need this PR?

   We want to avoid downloading packages during CI build.

What happend in this PR?

   Script for listing pip package configurations was extended to provide a list of all versions of all packages needed to be predownloaded. All pip installs now use /pip-packages directory to find predownloaded packages. 

Signed-off-by: Rafal <Banas.Rafal97@gmail.com>
