### PR TITLE
Enforce shares_data_ in Buffer

### DIFF
--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -104,12 +104,14 @@ class Buffer {
    */
   template <typename T>
   inline const T* data() const {
+    // clang-format off
     DALI_ENFORCE(IsValidType(type_),
                  "Buffer has no type, 'mutable_data<T>()' must be called "
                  "on non-const buffer to set valid type for " + type_.name());
     DALI_ENFORCE(type_.id() == TypeTable::GetTypeID<T>(),
                  "Calling type does not match buffer data type: " +
                  TypeTable::GetTypeName<T>() + " v. " + type_.name());
+    // clang-format on
     return static_cast<T*>(data_.get());
   }
 

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -330,6 +330,7 @@ class Buffer {
 // classes that derive from Buffer
 #define USE_BUFFER_MEMBERS()           \
   using Buffer<Backend>::ResizeHelper; \
+  using Buffer<Backend>::reset;        \
   using Buffer<Backend>::backend_;     \
   using Buffer<Backend>::type_;        \
   using Buffer<Backend>::data_;        \

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -71,14 +71,7 @@ class Buffer {
   /**
    * @brief Initializes a buffer of size 0.
    */
-  inline Buffer() : data_(nullptr),
-                    size_(0),
-                    shares_data_(false),
-                    num_bytes_(0),
-                    pinned_(true),
-                    device_(-1)
-    {}
-
+  inline Buffer() {}
   virtual ~Buffer() = default;
 
   /**
@@ -247,7 +240,7 @@ class Buffer {
 
     DALI_ENFORCE(!shares_data_,
                  "Cannot reallocate Buffer if it is sharing data. "
-                 "Clear the status by `UnshareData()` first.");
+                 "Clear the status by `Reset()` first.");
     data_.reset();
     data_.reset(
       Backend::New(new_num_bytes, pinned_),
@@ -256,8 +249,7 @@ class Buffer {
     num_bytes_ = new_num_bytes;
   }
 
-  void UnshareData() {
-    DALI_ENFORCE(shares_data_, "Cannot unshare data if the Buffer is not sharing data");
+  void reset() {
     backend_ = Backend();
     type_ = TypeInfo::Create<NoType>();
     data_.reset();
@@ -291,7 +283,7 @@ class Buffer {
     if (shares_data_) {
       DALI_ENFORCE(new_num_bytes == num_bytes_ || new_num_bytes == 0,
                    "Cannot change size of a Buffer if it is sharing data. "
-                   "Clear the status by `UnshareData()` first.");
+                   "Clear the status by `Reset()` first.");
     }
 
     size_ = new_size;
@@ -322,19 +314,19 @@ class Buffer {
 
   Backend backend_;
 
-  TypeInfo type_;  // Data type of underlying storage
-  shared_ptr<void> data_;  // Pointer to underlying storage
-  Index size_;  // The number of elements in the buffer
-  bool shares_data_;
+  TypeInfo type_ = {};  // Data type of underlying storage
+  shared_ptr<void> data_ = nullptr;  // Pointer to underlying storage
+  Index size_ = 0;  // The number of elements in the buffer
+  bool shares_data_ = false;
 
   // To keep track of the true size
   // of the underlying allocation
-  size_t num_bytes_;
+  size_t num_bytes_ = 0;
 
-  bool pinned_;  // Whether the allocation uses pinned memory
+  bool pinned_ = true;  // Whether the allocation uses pinned memory
 
   // device the buffer was allocated on
-  int device_;
+  int device_ = -1;
 };
 
 // Macro so we don't have to list these in all

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -446,6 +446,14 @@ class Tensor : public Buffer<Backend> {
     return *this;
   }
 
+  const DALIMeta &GetMeta() const {
+    return meta_;
+  }
+
+  void SetMeta(const DALIMeta &meta)  {
+    meta_ = meta;
+  }
+
   inline DALITensorLayout GetLayout() const {
     return meta_.GetLayout();
   }

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -145,6 +145,11 @@ class Tensor : public Buffer<Backend> {
    * until both the owner and the sharer are finished with it. Thus,
    * it is up to the user to manage the scope of the sharing objects
    * to ensure correctness.
+   *
+   * The total size after using `set_type` and `Resize` must match
+   * underlying allocation size (`num_bytes_`) for that tensor in TL
+   * if the data is shared.
+   * It can be set to 0 as intemediate step.
    */
   inline void ShareData(TensorList<Backend> *tl, int idx) {
     DALI_ENFORCE(tl != nullptr, "Input TensorList is nullptr");
@@ -176,6 +181,10 @@ class Tensor : public Buffer<Backend> {
    *
    * If the input does not store any data, shares_data_ is left
    * as false.
+   *
+   * The total size after using `set_type` and `Resize` must match
+   * underlying allocation size (`num_bytes_`) if the data is shared.
+   * It can be set to 0 as intemediate step.
    */
   inline void ShareData(Tensor<Backend> *t) {
     DALI_ENFORCE(t != nullptr, "Input Tensor is nullptr");
@@ -205,6 +214,9 @@ class Tensor : public Buffer<Backend> {
    * of shape vector, and its type is reset to NoType. Future calls to
    * Resize or setting of the Tensor type will evaluate whether or not the
    * current allocation is large enough to be used and proceed appropriately.
+   * The total size after using `set_type` and `Resize` must match
+   * underlying allocation size (`bytes`) if the data is shared.
+   * It can be set to 0 as intemediate step.
    *
    * The Tensor object assumes no ownership of the input allocation, and will
    * not de-allocate it when it is done using it. It is up to the user to
@@ -237,6 +249,9 @@ class Tensor : public Buffer<Backend> {
    * of shape vector, and its type is reset to NoType. Future calls to
    * Resize or setting of the Tensor type will evaluate whether or not the
    * current allocation is large enough to be used and proceed appropriately.
+   * The total size after using `set_type` and `Resize` must match
+   * underlying allocation size (`bytes`) if the data is shared.
+   * It can be set to 0 as intemediate step.
    *
    * The Tensor object assumes no ownership of the input allocation, and will
    * not de-allocate it when it is done using it. It is up to the user to
@@ -256,6 +271,9 @@ class Tensor : public Buffer<Backend> {
    * type is reset to NoType. Future calls to Resize or setting of the
    * Tensor type will evaluate whether or not the current allocation is
    * large enough to be used and proceed appropriately.
+   * The total size after using `set_type` and `Resize` must match
+   * underlying allocation size (`bytes`) if the data is shared.
+   * It can be set to 0 as intemediate step.
    *
    * The Tensor object assumes no ownership of the input allocation, and will
    * not de-allocate it when it is done using it. It is up to the user to
@@ -319,6 +337,12 @@ class Tensor : public Buffer<Backend> {
     num_bytes_ = type_.size() * size_;
     device_ = tl->device_id();
     shares_data_ = true;
+  }
+
+  inline void UnshareData() {
+    Buffer<Backend>::UnshareData();
+    shape_ = kernels::TensorShape<>();
+    meta_ = {};
   }
 
   /**

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -148,8 +148,8 @@ class Tensor : public Buffer<Backend> {
    *
    * After calling this function any following call to `set_type` and `Resize`
    * must match the total size of underlying allocation (`num_bytes_`) of
-   * shared data or call will fail.
-   * It can be set to 0 as intermediate step.
+   * shared data or the call will fail.
+   * Size can be set to 0 and type to NoType as intermediate step.
    */
   inline void ShareData(TensorList<Backend> *tl, int idx) {
     DALI_ENFORCE(tl != nullptr, "Input TensorList is nullptr");
@@ -184,8 +184,8 @@ class Tensor : public Buffer<Backend> {
    *
    * After calling this function any following call to `set_type` and `Resize`
    * must match the total size of underlying allocation (`num_bytes_`) of
-   * shared data or call will fail.
-   * It can be set to 0 as intermediate step.
+   * shared data or the call will fail.
+   * Size can be set to 0 and type to NoType as intermediate step.
    */
   inline void ShareData(Tensor<Backend> *t) {
     DALI_ENFORCE(t != nullptr, "Input Tensor is nullptr");
@@ -215,8 +215,8 @@ class Tensor : public Buffer<Backend> {
    * of shape vector, and its type is reset to NoType.
    * After calling this function any following call to `set_type` and `Resize`
    * must match the total size of underlying allocation (`num_bytes_`) of
-   * shared data or call will fail.
-   * It can be set to 0 as intermediate step.
+   * shared data or the call will fail.
+   * Size can be set to 0 and type to NoType as intermediate step.
    *
    * The Tensor object assumes no ownership of the input allocation, and will
    * not de-allocate it when it is done using it. It is up to the user to
@@ -249,8 +249,8 @@ class Tensor : public Buffer<Backend> {
    * of shape vector, and its type is reset to NoType.
    * After calling this function any following call to `set_type` and `Resize`
    * must match the total size of underlying allocation (`num_bytes_`) of
-   * shared data or call will fail.
-   * It can be set to 0 as intermediate step.
+   * shared data or the call will fail.
+   * Size can be set to 0 and type to NoType as intermediate step.
    *
    * The Tensor object assumes no ownership of the input allocation, and will
    * not de-allocate it when it is done using it. It is up to the user to
@@ -270,8 +270,8 @@ class Tensor : public Buffer<Backend> {
    * type is reset to NoType.
    * After calling this function any following call to `set_type` and `Resize`
    * must match the total size of underlying allocation (`num_bytes_`) of
-   * shared data or call will fail.
-   * It can be set to 0 as intermediate step.
+   * shared data or the call will fail.
+   * Size can be set to 0 and type to NoType as intermediate step.
    *
    * The Tensor object assumes no ownership of the input allocation, and will
    * not de-allocate it when it is done using it. It is up to the user to
@@ -338,8 +338,8 @@ class Tensor : public Buffer<Backend> {
   }
 
   inline void Reset() {
-    Buffer<Backend>::reset();
-    shape_ = kernels::TensorShape<>();
+    reset();  // free the underlying buffer
+    shape_ = {};
     meta_ = {};
   }
 

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -337,8 +337,8 @@ class Tensor : public Buffer<Backend> {
     shares_data_ = true;
   }
 
-  inline void UnshareData() {
-    Buffer<Backend>::UnshareData();
+  inline void Reset() {
+    Buffer<Backend>::reset();
     shape_ = kernels::TensorShape<>();
     meta_ = {};
   }

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -146,10 +146,10 @@ class Tensor : public Buffer<Backend> {
    * it is up to the user to manage the scope of the sharing objects
    * to ensure correctness.
    *
-   * The total size after using `set_type` and `Resize` must match
-   * underlying allocation size (`num_bytes_`) for that tensor in TL
-   * if the data is shared.
-   * It can be set to 0 as intemediate step.
+   * After calling this function any following call to `set_type` and `Resize`
+   * must match the total size of underlying allocation (`num_bytes_`) of
+   * shared data or call will fail.
+   * It can be set to 0 as intermediate step.
    */
   inline void ShareData(TensorList<Backend> *tl, int idx) {
     DALI_ENFORCE(tl != nullptr, "Input TensorList is nullptr");
@@ -182,9 +182,10 @@ class Tensor : public Buffer<Backend> {
    * If the input does not store any data, shares_data_ is left
    * as false.
    *
-   * The total size after using `set_type` and `Resize` must match
-   * underlying allocation size (`num_bytes_`) if the data is shared.
-   * It can be set to 0 as intemediate step.
+   * After calling this function any following call to `set_type` and `Resize`
+   * must match the total size of underlying allocation (`num_bytes_`) of
+   * shared data or call will fail.
+   * It can be set to 0 as intermediate step.
    */
   inline void ShareData(Tensor<Backend> *t) {
     DALI_ENFORCE(t != nullptr, "Input Tensor is nullptr");
@@ -211,12 +212,11 @@ class Tensor : public Buffer<Backend> {
    * state and is NOT marked as sharing data. Also sets shape of new Tensor.
    *
    * After wrapping the allocation, the Tensors size is set to dot product
-   * of shape vector, and its type is reset to NoType. Future calls to
-   * Resize or setting of the Tensor type will evaluate whether or not the
-   * current allocation is large enough to be used and proceed appropriately.
-   * The total size after using `set_type` and `Resize` must match
-   * underlying allocation size (`bytes`) if the data is shared.
-   * It can be set to 0 as intemediate step.
+   * of shape vector, and its type is reset to NoType.
+   * After calling this function any following call to `set_type` and `Resize`
+   * must match the total size of underlying allocation (`num_bytes_`) of
+   * shared data or call will fail.
+   * It can be set to 0 as intermediate step.
    *
    * The Tensor object assumes no ownership of the input allocation, and will
    * not de-allocate it when it is done using it. It is up to the user to
@@ -246,12 +246,11 @@ class Tensor : public Buffer<Backend> {
    * state and is NOT marked as sharing data. Also sets shape of new Tensor.
    *
    * After wrapping the allocation, the Tensors size is set to dot product
-   * of shape vector, and its type is reset to NoType. Future calls to
-   * Resize or setting of the Tensor type will evaluate whether or not the
-   * current allocation is large enough to be used and proceed appropriately.
-   * The total size after using `set_type` and `Resize` must match
-   * underlying allocation size (`bytes`) if the data is shared.
-   * It can be set to 0 as intemediate step.
+   * of shape vector, and its type is reset to NoType.
+   * After calling this function any following call to `set_type` and `Resize`
+   * must match the total size of underlying allocation (`num_bytes_`) of
+   * shared data or call will fail.
+   * It can be set to 0 as intermediate step.
    *
    * The Tensor object assumes no ownership of the input allocation, and will
    * not de-allocate it when it is done using it. It is up to the user to
@@ -268,12 +267,11 @@ class Tensor : public Buffer<Backend> {
    * state and is NOT marked as sharing data.
    *
    * After wrapping the allocation, the Tensors size is set to 0, and its
-   * type is reset to NoType. Future calls to Resize or setting of the
-   * Tensor type will evaluate whether or not the current allocation is
-   * large enough to be used and proceed appropriately.
-   * The total size after using `set_type` and `Resize` must match
-   * underlying allocation size (`bytes`) if the data is shared.
-   * It can be set to 0 as intemediate step.
+   * type is reset to NoType.
+   * After calling this function any following call to `set_type` and `Resize`
+   * must match the total size of underlying allocation (`num_bytes_`) of
+   * shared data or call will fail.
+   * It can be set to 0 as intermediate step.
    *
    * The Tensor object assumes no ownership of the input allocation, and will
    * not de-allocate it when it is done using it. It is up to the user to

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -147,9 +147,10 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
    * list shares data with another list, 'shares_data()' will
    * return 'true'.
    *
-   * The total size after using `set_type` and `Resize` must match
-   * underlying allocation size (`num_bytes_`) if the data is shared.
-   * It can be set to 0 as intemediate step.
+   * After calling this function any following call to `set_type` and `Resize`
+   * must match the total size of underlying allocation (`num_bytes_`) of
+   * shared data or call will fail.
+   * It can be set to 0 as intermediate step.
    */
   DLL_PUBLIC inline void ShareData(TensorList<Backend> *other) {
     DALI_ENFORCE(other != nullptr, "Input TensorList is nullptr");
@@ -179,13 +180,11 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
    * a default state and is NOT marked as sharing data.
    *
    * After wrapping the allocation, the TensorLists size is set to 0,
-   * and its type is reset to NoType. Future calls to Resize or setting
-   * of the Tensor type will evaluate whether or not the current
-   * allocation is large enough to be used and proceed appropriately.
-   *
-   * The total size after using `set_type` and `Resize` must match
-   * underlying allocation size (`bytes`) if the data is shared.
-   * It can be set to 0 as intemediate step.
+   * and its type is reset to NoType.
+   * After calling this function any following call to `set_type` and `Resize`
+   * must match the total size of underlying allocation (`num_bytes_`) of
+   * shared data or call will fail.
+   * It can be set to 0 as intermediate step.
    *
    * The TensorList object assumes no ownership of the input allocation,
    * and will not de-allocate it when it is done using it. It is up to

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -149,8 +149,8 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
    *
    * After calling this function any following call to `set_type` and `Resize`
    * must match the total size of underlying allocation (`num_bytes_`) of
-   * shared data or call will fail.
-   * It can be set to 0 as intermediate step.
+   * shared data or the call will fail.
+   * Size can be set to 0 and type to NoType as intermediate step.
    */
   DLL_PUBLIC inline void ShareData(TensorList<Backend> *other) {
     DALI_ENFORCE(other != nullptr, "Input TensorList is nullptr");
@@ -183,8 +183,8 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
    * and its type is reset to NoType.
    * After calling this function any following call to `set_type` and `Resize`
    * must match the total size of underlying allocation (`num_bytes_`) of
-   * shared data or call will fail.
-   * It can be set to 0 as intermediate step.
+   * shared data or the call will fail.
+   * Size can be set to 0 and type to NoType as intermediate step.
    *
    * The TensorList object assumes no ownership of the input allocation,
    * and will not de-allocate it when it is done using it. It is up to
@@ -212,8 +212,8 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
   }
 
   DLL_PUBLIC void Reset() {
-    Buffer<Backend>::reset();
-    shape_ = kernels::TensorListShape<>();
+    reset();  // free the underlying buffer
+    shape_ = {};
     offsets_.clear();
     meta_.clear();
     tensor_views_.clear();

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -211,8 +211,8 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     shares_data_ = num_bytes_ > 0 ? true : false;
   }
 
-  DLL_PUBLIC void UnshareData() {
-    Buffer<Backend>::UnshareData();
+  DLL_PUBLIC void Reset() {
+    Buffer<Backend>::reset();
     shape_ = kernels::TensorListShape<>();
     offsets_.clear();
     meta_.clear();

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -493,7 +493,7 @@ TYPED_TEST(TensorListTest, TestShareData) {
 
   // Trigger allocation through buffer API, verify we cannot do that
   ASSERT_THROW(tensor_list2.template mutable_data<double>(), std::runtime_error);
-  tensor_list2.UnshareData();
+  tensor_list2.Reset();
   ASSERT_FALSE(tensor_list2.shares_data());
 
   // Check the internals

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -237,7 +237,7 @@ TYPED_TEST(TensorListTest, TestGetBytesThenAlloc) {
 
   // Give the buffer a type bigger than float.
   // This normally would cause a reallocation,
-  // but we do not allow for that implicitly when sharing data
+  // but we that's forbidden when using shared data.
   ASSERT_THROW(tl.template mutable_data<double>(), std::runtime_error);
 }
 

--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -172,7 +172,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeNoAlloc) {
   ASSERT_TRUE(IsType<float>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
-  t.UnshareData();
+  t.Reset();
   ASSERT_EQ(t.raw_data(), nullptr);
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
@@ -229,7 +229,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeAlloc) {
   ASSERT_TRUE(IsType<float>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
-  t.UnshareData();
+  t.Reset();
   ASSERT_EQ(t.raw_data(), nullptr);
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
@@ -282,7 +282,7 @@ TYPED_TEST(TensorTest, TestGetBytesSizeTypeNoAlloc) {
   ASSERT_TRUE(IsType<float>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
-  t.UnshareData();
+  t.Reset();
   ASSERT_EQ(t.raw_data(), nullptr);
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
@@ -336,7 +336,7 @@ TYPED_TEST(TensorTest, TestGetBytesSizeTypeAlloc) {
   ASSERT_TRUE(IsType<float>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
-  t.UnshareData();
+  t.Reset();
   ASSERT_EQ(t.raw_data(), nullptr);
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
@@ -200,8 +200,8 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
       type.SetType<uint8_t>();
 
       std::shared_ptr<ImageInfo> info_p(new ImageInfo());
-      info_tensor.ShareData(info_p, 1, {1});
-      info_tensor.set_type(type);
+      info_tensor.ShareData(info_p, sizeof(ImageInfo), {1});
+      info_tensor.set_type(TypeInfo::Create<ImageInfo>());
 
       std::shared_ptr<StateNvJPEG> state_p(new StateNvJPEG(),
         [](StateNvJPEG* s) {
@@ -223,12 +223,12 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
                                         &state_p->decoder_hybrid_state));
       NVJPEG_CALL(nvjpegJpegStreamCreate(handle_, &state_p->jpeg_stream));
 
-      state_tensor.ShareData(state_p, 1, {1});
-      state_tensor.set_type(type);
+      state_tensor.ShareData(state_p, sizeof(StateNvJPEG), {1});
+      state_tensor.set_type(TypeInfo::Create<StateNvJPEG>());
     }
 
-    ImageInfo* info = reinterpret_cast<ImageInfo*>(info_tensor.raw_mutable_data());
-    StateNvJPEG* nvjpeg_state = reinterpret_cast<StateNvJPEG*>(state_tensor.raw_mutable_data());
+    ImageInfo* info = info_tensor.mutable_data<ImageInfo>();
+    StateNvJPEG* nvjpeg_state = state_tensor.mutable_data<StateNvJPEG>();
     return std::make_pair(info, nvjpeg_state);
   }
 

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_gpu.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_gpu.h
@@ -70,8 +70,7 @@ class nvJPEGDecoderGPUStage : public Operator<MixedBackend> {
     std::vector<std::pair<size_t, size_t>> image_order(batch_size_);
     for (int i = 0; i < batch_size_; i++) {
       const auto& info_tensor = ws->Input<CPUBackend>(0, i);
-      const ImageInfo* info =
-          reinterpret_cast<const ImageInfo*>(info_tensor.raw_data());
+      const ImageInfo* info = info_tensor.data<ImageInfo>();
       int c = NumberOfChannels(output_image_type_);
       output_shape[i] = {info->heights[0], info->widths[0], c};
       image_order[i] = std::make_pair(volume(output_shape[i]), i);
@@ -139,10 +138,8 @@ class nvJPEGDecoderGPUStage : public Operator<MixedBackend> {
 
   inline std::pair<const ImageInfo*, const StateNvJPEG*>
   GetInfoState(const Tensor<CPUBackend>& info_tensor, const Tensor<CPUBackend>& state_tensor) {
-    const ImageInfo* info =
-          reinterpret_cast<const ImageInfo*>(info_tensor.raw_data());
-    const StateNvJPEG* nvjpeg_state =
-          reinterpret_cast<const StateNvJPEG*>(state_tensor.raw_data());
+    const auto* info = info_tensor.data<ImageInfo>();
+    const auto* nvjpeg_state = state_tensor.data<StateNvJPEG>();
     return std::make_pair(info, nvjpeg_state);
   }
 

--- a/dali/pipeline/operators/reader/loader/file_loader.cc
+++ b/dali/pipeline/operators/reader/loader/file_loader.cc
@@ -117,6 +117,9 @@ void FileLoader::ReadSample(ImageLabelWrapper &image_label) {
   Index image_size = current_image->Size();
 
   if (copy_read_data_) {
+    if (image_label.image.shares_data()) {
+      image_label.image.UnshareData();
+    }
     image_label.image.Resize({image_size});
     // copy the image
     current_image->Read(image_label.image.mutable_data<uint8_t>(), image_size);

--- a/dali/pipeline/operators/reader/loader/file_loader.cc
+++ b/dali/pipeline/operators/reader/loader/file_loader.cc
@@ -107,9 +107,15 @@ void FileLoader::ReadSample(ImageLabelWrapper &image_label) {
 
   // if image is cached, skip loading
   if (ShouldSkipImage(image_pair.first)) {
-    image_label.image.set_type(TypeInfo::Create<uint8_t>());
-    image_label.image.Resize({1});
     image_label.image.SetSkipSample(true);
+    if (image_label.image.shares_data()) {
+      auto meta = image_label.image.GetMeta();
+      image_label.image.UnshareData();
+      image_label.image.SetMeta(meta);
+      return;
+    }
+    image_label.image.set_type(TypeInfo::Create<uint8_t>());
+    image_label.image.Resize({0});
     return;
   }
 

--- a/dali/pipeline/operators/reader/loader/file_loader.cc
+++ b/dali/pipeline/operators/reader/loader/file_loader.cc
@@ -102,18 +102,15 @@ void FileLoader::ReadSample(ImageLabelWrapper &image_label) {
 
   // copy the label
   image_label.label = image_pair.second;
-  image_label.image.SetSourceInfo(image_pair.first);
-  image_label.image.SetSkipSample(false);
+  DALIMeta meta;
+  meta.SetSourceInfo(image_pair.first);
+  meta.SetSkipSample(false);
 
   // if image is cached, skip loading
   if (ShouldSkipImage(image_pair.first)) {
-    image_label.image.SetSkipSample(true);
-    if (image_label.image.shares_data()) {
-      auto meta = image_label.image.GetMeta();
-      image_label.image.UnshareData();
-      image_label.image.SetMeta(meta);
-      return;
-    }
+    meta.SetSkipSample(true);
+    image_label.image.Reset();
+    image_label.image.SetMeta(meta);
     image_label.image.set_type(TypeInfo::Create<uint8_t>());
     image_label.image.Resize({0});
     return;
@@ -124,7 +121,7 @@ void FileLoader::ReadSample(ImageLabelWrapper &image_label) {
 
   if (copy_read_data_) {
     if (image_label.image.shares_data()) {
-      image_label.image.UnshareData();
+      image_label.image.Reset();
     }
     image_label.image.Resize({image_size});
     // copy the image
@@ -136,12 +133,12 @@ void FileLoader::ReadSample(ImageLabelWrapper &image_label) {
     image_label.image.set_type(TypeInfo::Create<uint8_t>());
   }
 
-  image_label.image.SetSourceInfo(image_pair.first);
   // close the file handle
   current_image->Close();
 
   // copy the label
   image_label.label = image_pair.second;
+  image_label.image.SetMeta(meta);
 }
 
 Index FileLoader::SizeImpl() {

--- a/dali/pipeline/operators/reader/loader/indexed_file_loader.h
+++ b/dali/pipeline/operators/reader/loader/indexed_file_loader.h
@@ -56,10 +56,16 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
 
     // if image is cached, skip loading
     if (ShouldSkipImage(image_key)) {
-      tensor.set_type(TypeInfo::Create<uint8_t>());
-      tensor.Resize({1});
       tensor.SetSkipSample(true);
       should_seek_ = true;
+      if (tensor.shares_data()) {
+        auto meta = tensor.GetMeta();
+        tensor.UnshareData();
+        tensor.SetMeta(meta);
+        return;
+      }
+      tensor.set_type(TypeInfo::Create<uint8_t>());
+      tensor.Resize({0});
       return;
     }
 

--- a/dali/pipeline/operators/reader/loader/lmdb.h
+++ b/dali/pipeline/operators/reader/loader/lmdb.h
@@ -93,9 +93,15 @@ class LMDBLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
 
     // if image is cached, skip loading
     if (ShouldSkipImage(image_key)) {
-      tensor.set_type(TypeInfo::Create<uint8_t>());
-      tensor.Resize({1});
       tensor.SetSkipSample(true);
+      if (tensor.shares_data()) {
+        auto meta = tensor.GetMeta();
+        tensor.UnshareData();
+        tensor.SetMeta(meta);
+        return;
+      }
+      tensor.set_type(TypeInfo::Create<uint8_t>());
+      tensor.Resize({0});
       return;
     }
 

--- a/dali/pipeline/operators/reader/loader/lmdb.h
+++ b/dali/pipeline/operators/reader/loader/lmdb.h
@@ -87,24 +87,24 @@ class LMDBLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
 
     std::string image_key =
       db_path_ + " at key " + to_string(reinterpret_cast<char*>(key_.mv_data));
-    tensor.SetSourceInfo(image_key);
+    DALIMeta meta;
+
+    meta.SetSourceInfo(image_key);
+    meta.SetSkipSample(false);
+
     tensor.set_type(TypeInfo::Create<uint8_t>());
-    tensor.SetSkipSample(false);
 
     // if image is cached, skip loading
     if (ShouldSkipImage(image_key)) {
-      tensor.SetSkipSample(true);
-      if (tensor.shares_data()) {
-        auto meta = tensor.GetMeta();
-        tensor.UnshareData();
-        tensor.SetMeta(meta);
-        return;
-      }
+      meta.SetSkipSample(true);
+      tensor.Reset();
+      tensor.SetMeta(meta);
       tensor.set_type(TypeInfo::Create<uint8_t>());
       tensor.Resize({0});
       return;
     }
 
+    tensor.SetMeta(meta);
     tensor.Resize({static_cast<Index>(value_.mv_size)});
     std::memcpy(tensor.raw_mutable_data(),
                 reinterpret_cast<uint8_t*>(value_.mv_data),

--- a/dali/pipeline/operators/reader/loader/recordio_loader.h
+++ b/dali/pipeline/operators/reader/loader/recordio_loader.h
@@ -113,7 +113,11 @@ class RecordIOLoader : public IndexedFileLoader {
         p = current_file_->Get(size);
         // file is divided between two files, we need to fallback to read here
         if (p == nullptr) {
+          if (tensor.shares_data()) {
+            tensor.UnshareData();
+          }
           tensor.Resize({size});
+          tensor.set_type(TypeInfo::Create<uint8_t>());
           use_read = true;
         } else {
           n_read = size;

--- a/dali/pipeline/operators/reader/loader/recordio_loader.h
+++ b/dali/pipeline/operators/reader/loader/recordio_loader.h
@@ -90,10 +90,16 @@ class RecordIOLoader : public IndexedFileLoader {
 
     // if image is cached, skip loading
     if (ShouldSkipImage(image_key)) {
-      tensor.set_type(TypeInfo::Create<uint8_t>());
-      tensor.Resize({1});
       tensor.SetSkipSample(true);
       should_seek_ = true;
+      if (tensor.shares_data()) {
+        auto meta = tensor.GetMeta();
+        tensor.UnshareData();
+        tensor.SetMeta(meta);
+        return;
+      }
+      tensor.set_type(TypeInfo::Create<uint8_t>());
+      tensor.Resize({0});
       return;
     }
 

--- a/dali/pipeline/operators/reader/loader/recordio_loader.h
+++ b/dali/pipeline/operators/reader/loader/recordio_loader.h
@@ -85,19 +85,16 @@ class RecordIOLoader : public IndexedFileLoader {
     ++current_index_;
 
     std::string image_key = uris_[file_index] + " at index " + to_string(seek_pos);
-    tensor.SetSourceInfo(image_key);
-    tensor.SetSkipSample(false);
+    DALIMeta meta;
+    meta.SetSourceInfo(image_key);
+    meta.SetSkipSample(false);
 
     // if image is cached, skip loading
     if (ShouldSkipImage(image_key)) {
-      tensor.SetSkipSample(true);
+      meta.SetSkipSample(true);
       should_seek_ = true;
-      if (tensor.shares_data()) {
-        auto meta = tensor.GetMeta();
-        tensor.UnshareData();
-        tensor.SetMeta(meta);
-        return;
-      }
+      tensor.Reset();
+      tensor.SetMeta(meta);
       tensor.set_type(TypeInfo::Create<uint8_t>());
       tensor.Resize({0});
       return;
@@ -120,7 +117,7 @@ class RecordIOLoader : public IndexedFileLoader {
         // file is divided between two files, we need to fallback to read here
         if (p == nullptr) {
           if (tensor.shares_data()) {
-            tensor.UnshareData();
+            tensor.Reset();
           }
           tensor.Resize({size});
           tensor.set_type(TypeInfo::Create<uint8_t>());
@@ -144,6 +141,7 @@ class RecordIOLoader : public IndexedFileLoader {
         continue;
       }
     }
+    tensor.SetMeta(meta);
   }
 
  private:

--- a/dali/pipeline/operators/reader/loader/sequence_loader.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.cc
@@ -126,9 +126,15 @@ void SequenceLoader::LoadFrame(const std::vector<std::string> &s, Index frame_id
 
   // if image is cached, skip loading
   if (ShouldSkipImage(frame_filename)) {
-    target->set_type(TypeInfo::Create<uint8_t>());
-    target->Resize({1});
     target->SetSkipSample(true);
+    if (target->shares_data()) {
+      auto meta = target->GetMeta();
+      target->UnshareData();
+      target->SetMeta(meta);
+      return;
+    }
+    target->set_type(TypeInfo::Create<uint8_t>());
+    target->Resize({0});
     return;
   }
 

--- a/dali/pipeline/operators/reader/loader/sequence_loader.cc
+++ b/dali/pipeline/operators/reader/loader/sequence_loader.cc
@@ -136,6 +136,9 @@ void SequenceLoader::LoadFrame(const std::vector<std::string> &s, Index frame_id
   Index frame_size = frame->Size();
   // Release and unmap memory previously obtained by Get call
   if (copy_read_data_) {
+    if (target->shares_data()) {
+      target->UnshareData();
+    }
     target->Resize({frame_size});
     frame->Read(target->mutable_data<uint8_t>(), frame_size);
   } else {


### PR DESCRIPTION
If the Buffer is sharing data, it's size and type
can be either 0 and NoType or the actual size
should match the underlying allocation.

Add UnshareData() to release the Buffer

Readers and NVJpeg are adjusted

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- Change the semantics of shares_data_ in Buffer

#### What happend in this PR?
 - Explain solution of the problem, new feature added.
It disallows inappropriate usage of Buffer API (Tensor or TensorList) that shares data with some allocation. If the buffer is sharing data, calling Resize or set_type that would make the buffer size different than underlying allocation will throw. To use them, Buffer must be first unshared using UnshareData.
 - What was changed, added, removed?
DALI_ENFORCE in set_type and ResizeHelper, test were adjusted
 - What is most important part that reviewers should focus on?
shares_data_ logic in Buffer.
 - Was this PR tested? How?
CI will test
 - Were docs and examples updated, if necessary?
Yes