### PR TITLE
Update DALI TF plugin docs to be aligned with the current functionality

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -52,7 +52,7 @@ Starting DALI 0.8.0 for CUDA 10.0 based build use:
 
 .. note::
 
-  The ``nvidia-dali`` package contains prebuilt versions of the DALI TensorFlow plugin for several versions of TensorFlow. Starting DALI 0.6.1 you can also install DALI TensorFlow plugin for the currently installed version of TensorFlow, thus allowing forward compatibility:
+  Starting 0.6.1 the ``nvidia-dali`` package no longer contains prebuilt versions of the DALI TensorFlow plugin, so you need to install DALI TensorFlow plugin for the currently installed version of TensorFlow:
 
 .. code-block:: bash
 


### PR DESCRIPTION
- removed information that DALI ships prebuilt TensorFlow plugins
- emphasized the need to install plugin package separately

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- updates installation documentation to be aligned with the current state

#### What happend in this PR?
- removed information that DALI ships prebuilt TensorFlow plugins
- emphasized the need to install plugin package separately
- checked docs generated in the CI
