### PR TITLE
Rounding Convert and ConvertSat added.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -771,7 +771,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ./dali ./docs
+INPUT                  = ./dali ./include ./docs
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/dali/core/convert_cuda_test.cu
+++ b/dali/core/convert_cuda_test.cu
@@ -63,6 +63,8 @@ DEVICE_TEST(ConvertSatNorm_Dev, float2int, 1, 1) {
   DEV_EXPECT_EQ(ConvertSatNorm<int8_t>(2.0f), 127);
   DEV_EXPECT_EQ(ConvertSatNorm<int8_t>(0.499f), 63);
   DEV_EXPECT_EQ(ConvertSatNorm<int8_t>(-2.0f), -128);
+  DEV_EXPECT_EQ(ConvertSatNorm<uint8_t>(0.4f/255), 0);
+  DEV_EXPECT_EQ(ConvertSatNorm<uint8_t>(0.6f/255), 1);
 
   DEV_EXPECT_EQ(ConvertSatNorm<int16_t>(2.0f), 0x7fff);
   DEV_EXPECT_EQ(ConvertSatNorm<int16_t>(-2.0f), -0x8000);

--- a/dali/core/convert_cuda_test.cu
+++ b/dali/core/convert_cuda_test.cu
@@ -14,38 +14,61 @@
 
 #include <gtest/gtest.h>
 #include "dali/core/convert.h"
+#include "dali/core/math_util.h"
 #include "dali/core/convert_test_static.h"
+#include "dali/test/device_test.h"
 
 namespace dali {
 
-TEST(ConvertNormCUDA, float2int) {
-  EXPECT_EQ(ConvertNorm<uint8_t>(0.0f), 0);
-  EXPECT_EQ(ConvertNorm<uint8_t>(0.499f), 127);
-  EXPECT_EQ(ConvertNorm<uint8_t>(1.0f), 255);
-  EXPECT_EQ(ConvertNorm<int8_t>(1.0f), 127);
-  EXPECT_EQ(ConvertNorm<int8_t>(0.499f), 63);
-  EXPECT_EQ(ConvertNorm<int8_t>(-1.0f), -127);
-
-
-  EXPECT_EQ(ConvertNorm<uint16_t>(0.0f), 0);
-  EXPECT_EQ(ConvertNorm<uint16_t>(1.0f), 0xffff);
-  EXPECT_EQ(ConvertNorm<int16_t>(1.0f), 0x7fff);
-  EXPECT_EQ(ConvertNorm<int16_t>(-1.0f), -0x7fff);
+DEVICE_TEST(ConvertSatCUDA_Dev, float2int, 110, 1024) {
+  float f = ldexpf(threadIdx.x-512.0f, blockIdx.x-10);
+  float integral;
+  float fract = modff(f, &integral);
+  if (fract == 0.5f || fract == -0.5f)
+    return;
+  double rounded = roundf(f);
+  int64_t clamped = clamp<double>(rounded, -128, 127);
+  DEV_EXPECT_EQ(ConvertSat<int8_t>(f), clamped);
+  clamped = clamp<double>(rounded, 0, 255);
+  DEV_EXPECT_EQ(ConvertSat<uint8_t>(f), clamped);
+  clamped = clamp<double>(rounded, -0x8000, 0x7fff);
+  DEV_EXPECT_EQ(ConvertSat<int16_t>(f), clamped);
+  clamped = clamp<double>(rounded, 0, 0xffff);
+  DEV_EXPECT_EQ(ConvertSat<uint16_t>(f), clamped);
+  clamped = clamp<double>(rounded, int32_t(~0x7fffffff), 0x7fffffff);
+  DEV_EXPECT_EQ(ConvertSat<int32_t>(f), clamped);
+  clamped = clamp<double>(rounded, 0, 0xffffffffu);
+  DEV_EXPECT_EQ(ConvertSat<uint32_t>(f), clamped);
 }
 
-TEST(ConvertSatNormCUDA, float2int) {
-  EXPECT_EQ(ConvertSatNorm<uint8_t>(2.0f), 255);
-  EXPECT_EQ(ConvertSatNorm<uint8_t>(0.499f), 127);
-  EXPECT_EQ(ConvertSatNorm<uint8_t>(-2.0f), 0);
-  EXPECT_EQ(ConvertSatNorm<int8_t>(2.0f), 127);
-  EXPECT_EQ(ConvertSatNorm<int8_t>(0.499f), 63);
-  EXPECT_EQ(ConvertSatNorm<int8_t>(-2.0f), -128);
+DEVICE_TEST(ConvertNormCUDA_Dev, float2int, 1, 1) {
+  DEV_EXPECT_EQ(ConvertNorm<uint8_t>(0.0f), 0);
+  DEV_EXPECT_EQ(ConvertNorm<uint8_t>(0.499f), 127);
+  DEV_EXPECT_EQ(ConvertNorm<uint8_t>(1.0f), 255);
+  DEV_EXPECT_EQ(ConvertNorm<int8_t>(1.0f), 127);
+  DEV_EXPECT_EQ(ConvertNorm<int8_t>(0.499f), 63);
+  DEV_EXPECT_EQ(ConvertNorm<int8_t>(-1.0f), -127);
 
-  EXPECT_EQ(ConvertSatNorm<int16_t>(2.0f), 0x7fff);
-  EXPECT_EQ(ConvertSatNorm<int16_t>(-2.0f), -0x8000);
+
+  DEV_EXPECT_EQ(ConvertNorm<uint16_t>(0.0f), 0);
+  DEV_EXPECT_EQ(ConvertNorm<uint16_t>(1.0f), 0xffff);
+  DEV_EXPECT_EQ(ConvertNorm<int16_t>(1.0f), 0x7fff);
+  DEV_EXPECT_EQ(ConvertNorm<int16_t>(-1.0f), -0x7fff);
 }
 
-TEST(ConvertNormCUDA, int2float) {
+DEVICE_TEST(ConvertSatNorm_Dev, float2int, 1, 1) {
+  DEV_EXPECT_EQ(ConvertSatNorm<uint8_t>(2.0f), 255);
+  DEV_EXPECT_EQ(ConvertSatNorm<uint8_t>(0.499f), 127);
+  DEV_EXPECT_EQ(ConvertSatNorm<uint8_t>(-2.0f), 0);
+  DEV_EXPECT_EQ(ConvertSatNorm<int8_t>(2.0f), 127);
+  DEV_EXPECT_EQ(ConvertSatNorm<int8_t>(0.499f), 63);
+  DEV_EXPECT_EQ(ConvertSatNorm<int8_t>(-2.0f), -128);
+
+  DEV_EXPECT_EQ(ConvertSatNorm<int16_t>(2.0f), 0x7fff);
+  DEV_EXPECT_EQ(ConvertSatNorm<int16_t>(-2.0f), -0x8000);
+}
+
+TEST(ConvertNorm_CUDA_Host, int2float) {
   EXPECT_EQ((ConvertNorm<float, uint8_t>(255)), 1.0f);
   EXPECT_NEAR((ConvertNorm<float, uint8_t>(127)), 1.0f*127/255, 1e-7f);
   EXPECT_EQ((ConvertNorm<float, int8_t>(127)), 1.0f);

--- a/dali/core/convert_test.cc
+++ b/dali/core/convert_test.cc
@@ -45,6 +45,10 @@ TEST(ConvertSat, float2int) {
   }
 }
 
+TEST(ConvertNorm, int2int) {
+  EXPECT_EQ((ConvertNorm<uint8_t, uint8_t>(0)), 0);
+  EXPECT_EQ((ConvertNorm<uint8_t, int8_t>(127)), 255);
+}
 
 TEST(ConvertNorm, float2int) {
   EXPECT_EQ(ConvertNorm<uint8_t>(0.0f), 0);
@@ -68,6 +72,8 @@ TEST(ConvertSatNorm, float2int) {
   EXPECT_EQ(ConvertSatNorm<int8_t>(2.0f), 127);
   EXPECT_EQ(ConvertSatNorm<int8_t>(0.499f), 63);
   EXPECT_EQ(ConvertSatNorm<int8_t>(-2.0f), -128);
+  EXPECT_EQ(ConvertSatNorm<uint8_t>(0.4f/255), 0);
+  EXPECT_EQ(ConvertSatNorm<uint8_t>(0.6f/255), 1);
 
   EXPECT_EQ(ConvertSatNorm<int16_t>(2.0f), 0x7fff);
   EXPECT_EQ(ConvertSatNorm<int16_t>(-2.0f), -0x8000);

--- a/dali/core/convert_test.cc
+++ b/dali/core/convert_test.cc
@@ -15,8 +15,36 @@
 #include <gtest/gtest.h>
 #include "dali/core/convert.h"
 #include "dali/core/convert_test_static.h"
+#include "dali/core/math_util.h"
 
 namespace dali {
+
+
+TEST(ConvertSat, float2int) {
+  for (int exp = -10; exp < 100; exp++) {
+    for (float sig = -256; sig <= 256; sig++) {
+      float f = ldexpf(sig, exp);
+      float integral;
+      float fract = modff(f, &integral);
+      if (fract == 0.5f || fract == -0.5f)
+        continue;
+      double rounded = roundf(f);
+      int64_t clamped = clamp<double>(rounded, -128, 127);
+      ASSERT_EQ(ConvertSat<int8_t>(f), clamped) << " with f = " << f;
+      clamped = clamp<double>(rounded, 0, 255);
+      ASSERT_EQ(ConvertSat<uint8_t>(f), clamped) << " with f = " << f;
+      clamped = clamp<double>(rounded, -0x8000, 0x7fff);
+      ASSERT_EQ(ConvertSat<int16_t>(f), clamped) << " with f = " << f;
+      clamped = clamp<double>(rounded, 0, 0xffff);
+      ASSERT_EQ(ConvertSat<uint16_t>(f), clamped) << " with f = " << f;
+      clamped = clamp<double>(rounded, int32_t(~0x7fffffff), 0x7fffffff);
+      ASSERT_EQ(ConvertSat<int32_t>(f), clamped) << " with f = " << f;
+      clamped = clamp<double>(rounded, 0, 0xffffffffu);
+      ASSERT_EQ(ConvertSat<uint32_t>(f), clamped) << " with f = " << f;
+    }
+  }
+}
+
 
 TEST(ConvertNorm, float2int) {
   EXPECT_EQ(ConvertNorm<uint8_t>(0.0f), 0);

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -392,9 +392,9 @@ DALI_HOST_DEV constexpr Out Convert(In value) {
 /// @brief Converts value from `In` to `Out` keeping whole (positive) dynamic range
 ///
 ///   * When converting from signed to unsigned types, negative values produce undefined result
-///   * When converting from floating point types, the value of 0.0 translates to 0 and
-///     1.0 to `max_value<Out>`. Results for arguments outside  0..1 range for unsigned
-///     and -1..1 for signed output type are undefined
+///   * When converting from floating point to integral types, the value is multiplied by
+///     `max_value<Out>()`. Results are undefined for values where `value * max_value<Out>()`
+///     cannot be represented by `Out`.
 ///   * When converting from integral type to floating point, the input value is normalized by
 ///     multiplying by reciprocal of `Out` type's maximum positive value.
 ///
@@ -432,8 +432,8 @@ DALI_HOST_DEV constexpr Out ConvertSat(In value) {
 /// @brief Converts value from `In` to `Out` keeping whole (positive) dynamic range and clamping
 ///
 ///   * When converting from signed to unsigned types, negative values produce 0
-///   * When converting from floating point types, the value is multiplied by `max_value<Out>()`
-///     and then clamped to range representable in `Out`.
+///   * When converting from floating point to integral types, the value is multiplied
+///     by `max_value<Out>()` and then clamped to range representable in `Out`.
 ///   * When converting from integral type to floating point, the input value is divided
 ///     by `Out(max_value<In>())`
 ///


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
- It applies rounding when necessary, leaving the result un-rounded otherwise.

#### What happend in this PR?
 - Added rounding to `Convert` and `ConvertSat`
 - Added `cuda_round_helper` and use intrinsic functions for rounding conversion.
 - Added `Converter` class to avoid excessive number of `enable_if` variants of `Convert[Norm][Sat]`.
 - Added trivial specialization for `Converter`

Usage:
`Convert<OutputType, [InputType]>(value)` - converts value from (possibly inferred) InputType to OutputType, rounding if necessary

`ConvertNorm<OutputType, [InputType]>(value)` - converts value from (possibly inferred) InputType to OutputType, rounding if necessary and normalizing range.
Range normalization rules:
- int->float: divide integers by max value for input type
- float->int: multiply by max value for output type
- intX->intY: same as intX->float->intY

`ConvertSat<OutputType, [InputType]>(value)` - converts value and clamp it to the range of `OutputType`

`ConvertSatNorm<OutputType, [InputType]>(value)` - scale value from input to output type, with appropriate clamping.

With normalization, clamping is not necessary when converting:
- integers to floating point types
- integers to signed integers
- unsigned integers to unsigned integers.
These cases are recognized and handled efficiently.
Clamping is still necessary when converting unsigned to signed integers and floating point values to integers.
