### PR TITLE
Improved sampler

### DIFF
--- a/dali/kernels/imgproc/sampler_cpu_test.cc
+++ b/dali/kernels/imgproc/sampler_cpu_test.cc
@@ -114,7 +114,7 @@ TEST(SamplerCPU, Linear) {
       for (int c = 0; c < surf.channels; c++) {
         float s0 = src[0][c] * px + src[1][c] * qx;
         float s1 = src[2][c] * px + src[3][c] * qx;
-        ref[c] = s0 * py + s1 * qy;
+        ref[c] = std::round(s0 * py + s1 * qy);
       }
 
       Pixel pixel = { 0, 0, 0 };

--- a/dali/kernels/imgproc/sampler_cpu_test.cc
+++ b/dali/kernels/imgproc/sampler_cpu_test.cc
@@ -14,11 +14,13 @@
 
 #include <gtest/gtest.h>
 #include "dali/kernels/imgproc/sampler_test.h"
+#include "dali/core/geom/vec.h"
 
 namespace dali {
 namespace kernels {
 
 using Pixel = std::array<uint8_t, 3>;
+using PixelF = std::array<float, 3>;
 
 TEST(SamplerCPU, NN) {
   SamplerTestData sd;
@@ -90,6 +92,8 @@ TEST(SamplerCPU, Linear) {
     }
   }
 
+  const float epsF = 255.00006 - 255;  // 4 ULP in IEEE 32-bit float for 0-255 range
+  const float eps = 0.50000025f;  // 0.5 + 4 ULP
   for (float y = -1; y <= surf.height+2; y += 0.125f) {
     float fy = y - 0.5f;
     int iy0 = floorf(fy);
@@ -107,22 +111,38 @@ TEST(SamplerCPU, Linear) {
       src[1] = fetch(ix1, iy0);
       src[2] = fetch(ix0, iy1);
       src[3] = fetch(ix1, iy1);
-      Pixel ref;
+      PixelF ref;
 
       float qx = fx - ix0;
       float px = 1 - qx;
       for (int c = 0; c < surf.channels; c++) {
         float s0 = src[0][c] * px + src[1][c] * qx;
         float s1 = src[2][c] * px + src[3][c] * qx;
-        ref[c] = std::round(s0 * py + s1 * qy);
+        ref[c] = s0 * py + s1 * qy;
       }
 
       Pixel pixel = { 0, 0, 0 };
+      PixelF pixelF = { 0, 0, 0 };
       sampler(pixel.data(), x, y, border.data());
-      EXPECT_EQ(pixel, ref) << " mismatch at (" << x << ",  " << y << ")";
       for (int c = 0; c < surf.channels; c++) {
-        EXPECT_EQ(sampler.at<uint8_t>(x, y, c, border.data()), ref[c])
-         << " mismatch at (" << x << ",  " << y << ")[" << c << "]";
+        EXPECT_NEAR(pixel[c], ref[c], eps)
+          << " mismatch at (x" << x << ", " << y << ")[" << c << "] when sampling all channels";
+      }
+
+      for (int c = 0; c < surf.channels; c++) {
+        EXPECT_NEAR(sampler.at<uint8_t>(x, y, c, border.data()), ref[c], eps)
+         << " mismatch at (" << x << ",  " << y << ")[" << c << "] when sampling single channel";
+      }
+
+      sampler(pixelF.data(), x, y, border.data());
+      for (int c = 0; c < surf.channels; c++) {
+        EXPECT_NEAR(pixelF[c], ref[c], epsF)
+          << " mismatch at (x" << x << ", " << y << ")[" << c << "] when sampling all channels";
+      }
+
+      for (int c = 0; c < surf.channels; c++) {
+        EXPECT_NEAR(sampler.at<float>(x, y, c, border.data()), ref[c], epsF)
+         << " mismatch at (" << x << ",  " << y << ")[" << c << "] when sampling single channel";
       }
     }
   }

--- a/dali/kernels/imgproc/sampler_gpu_test.cu
+++ b/dali/kernels/imgproc/sampler_gpu_test.cu
@@ -20,6 +20,7 @@ namespace dali {
 namespace kernels {
 
 using Pixel = std::array<uint8_t, 3>;
+using PixelF = std::array<float, 3>;
 
 template <typename Out, DALIInterpType interp, int MaxChannels = 8, typename In>
 __global__ void RunSampler(
@@ -129,17 +130,13 @@ TEST(SamplerGPU, Linear) {
 
   cudaMemcpy(out_cpu.data, out_surf.data, w*h*c, cudaMemcpyDeviceToHost);
 
+  const float eps = 0.50000025f;  // 0.5 + 4 ULP
   for (int oy = 0; oy < h; oy++) {
-    int eps = 0;
     float y = oy * dy + y0;
-    if (y == std::floor(y))
-      eps |= 1;
     for (int ox = 0; ox < w; ox++) {
       float x = ox * dx + x0;
-      if (x == std::floor(x))
-        eps |= 1;
 
-      Pixel ref;
+      PixelF ref;
       sampler_cpu(ref.data(), x, y, border.data());
 
       Pixel pixel;

--- a/dali/kernels/imgproc/sampler_gpu_test.cu
+++ b/dali/kernels/imgproc/sampler_gpu_test.cu
@@ -130,17 +130,23 @@ TEST(SamplerGPU, Linear) {
   cudaMemcpy(out_cpu.data, out_surf.data, w*h*c, cudaMemcpyDeviceToHost);
 
   for (int oy = 0; oy < h; oy++) {
+    int eps = 0;
     float y = oy * dy + y0;
+    if (y == std::floor(y))
+      eps |= 1;
     for (int ox = 0; ox < w; ox++) {
       float x = ox * dx + x0;
+      if (x == std::floor(x))
+        eps |= 1;
 
       Pixel ref;
       sampler_cpu(ref.data(), x, y, border.data());
 
       Pixel pixel;
-      for (int c = 0; c< surf_cpu.channels; c++)
+      for (int c = 0; c< surf_cpu.channels; c++) {
         pixel[c] = out_cpu(ox, oy, c);
-      EXPECT_EQ(pixel, ref) << " mismatch at (" << x << ",  " << y << ")";
+        EXPECT_NEAR(pixel[c], ref[c], eps) << " mismatch at (" << x << ",  " << y << ")";
+      }
     }
   }
 }


### PR DESCRIPTION
#### Why we need this PR?
*Pick one*
- It fixes type conversion in Sampler
- It adds missing function onverloads

#### What happend in this PR?
- Added overloads to `at` and call operator
- Changed clamp to ConverSat
- Updated tests to use floating point reference
