### PR TITLE
Add checking if Python API is not mixed between simple, scheduled and iterator

### DIFF
--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -18,7 +18,6 @@ from nvidia.dali import backend as b
 from nvidia.dali import edge as Edge
 from nvidia.dali import types
 from threading import local as tls
-
 pipeline_tls = tls()
 
 
@@ -103,6 +102,8 @@ class Pipeline(object):
         self._set_affinity = set_affinity
         self._max_streams = max_streams
         self._default_cuda_stream_priority = default_cuda_stream_priority
+        self._api_type = None
+        self._skip_api_check = False
         if type(prefetch_queue_depth) is dict:
             self._exec_separated = True
             self._cpu_queue_size = prefetch_queue_depth["cpu_size"]
@@ -169,6 +170,46 @@ class Pipeline(object):
     # Graph edges that are not connected to the output must be manually added to a pipeline
     def add_sink(self, edge):
         self._sinks.append(edge)
+
+    def _set_api_type(self, type):
+        if not types.PieplineAPIType._is_member(type):
+            raise RuntimeError("Wrong pipeline API set!"
+                               "check available values in :meth:`nvidia.dali.types.PieplineAPIType`")
+        self._api_type = type
+
+    def _check_api_type(self, type):
+        if self._api_type == None:
+            self._set_api_type(type)
+        if type != self._api_type:
+            raise RuntimeError("Mixing pipeline API type. Currently used: " + str(self._api_type) +
+                          ", but trying to use: " + str(type))
+
+    def enable_api_check(self, enable):
+        """Allows to enable or disable API check in the runtime
+        """
+        self._skip_api_check = not enable
+
+    def _check_api_type_scope(self, type):
+        """Checks the API currently used by pipeline and throws an error if it differs
+
+        It helps preventing of mixing simple, iterator and scheduled based API for
+        pipeline run. Disables further checks in its scope
+        """
+        if not self._skip_api_check:
+            self._check_api_type(type)
+
+        class api_checker():
+            def __init__(self, pipe):
+                self._pipe = pipe
+
+            def __enter__(self):
+                self._old_skip_api_check = self._pipe._skip_api_check
+                self._pipe._skip_api_check = True
+
+            def __exit__(self, type, value, traceback):
+                self._pipe._skip_api_check = self._old_skip_api_check
+
+        return api_checker(self)
 
     # Graph is constructed by backtracking from the output edges and the edges marked as sinks
     def _prepare_graph(self):
@@ -305,11 +346,12 @@ class Pipeline(object):
         If the pipeline is executed asynchronously, this function blocks
         until the results become available. It rises StopIteration if data set
         reached its end - usually when iter_setup cannot produce any more data"""
-        if self._batches_to_consume == 0 or self._gpu_batches_to_consume == 0:
-            raise StopIteration
-        self._batches_to_consume -= 1
-        self._gpu_batches_to_consume -= 1
-        return self._outputs()
+        with self._check_api_type_scope(types.PieplineAPIType.SCHEDULED) as check:
+            if self._batches_to_consume == 0 or self._gpu_batches_to_consume == 0:
+                raise StopIteration
+            self._batches_to_consume -= 1
+            self._gpu_batches_to_consume -= 1
+            return self._outputs()
 
     def schedule_run(self):
         """Run the pipeline without returning the resulting buffers.
@@ -322,10 +364,11 @@ class Pipeline(object):
         Needs to be used together with :meth:`nvidia.dali.pipeline.Pipeline.release_outputs`
         and :meth:`nvidia.dali.pipeline.Pipeline.share_outputs`.
         Should not be mixed with :meth:`nvidia.dali.pipeline.Pipeline.run` in the same pipeline"""
-        if self._first_iter and self._exec_pipelined:
-            self._prefetch()
-        else:
-            self._run_once()
+        with self._check_api_type_scope(types.PieplineAPIType.SCHEDULED) as check:
+            if self._first_iter and self._exec_pipelined:
+                self._prefetch()
+            else:
+                self._run_once()
 
     # for the backward compatibility
     def _run(self):
@@ -345,7 +388,12 @@ class Pipeline(object):
         Needs to be used together with :meth:`nvidia.dali.pipeline.Pipeline.release_outputs`
         and :meth:`nvidia.dali.pipeline.Pipeline.schedule_run`
         Should not be mixed with :meth:`nvidia.dali.pipeline.Pipeline.run` in the same pipeline"""
-        return self._pipe.ShareOutputs()
+        with self._check_api_type_scope(types.PieplineAPIType.SCHEDULED) as check:
+            if self._batches_to_consume == 0 or self._gpu_batches_to_consume == 0:
+                raise StopIteration
+            self._batches_to_consume -= 1
+            self._gpu_batches_to_consume -= 1
+            return self._pipe.ShareOutputs()
 
     # for the backward compatibility
     def _share_outputs(self):
@@ -363,9 +411,10 @@ class Pipeline(object):
         Needs to be used together with :meth:`nvidia.dali.pipeline.Pipeline.schedule_run`
         and :meth:`nvidia.dali.pipeline.Pipeline.share_outputs`
         Should not be mixed with :meth:`nvidia.dali.pipeline.Pipeline.run` in the same pipeline"""
-        if not self._built:
-            raise RuntimeError("Pipeline must be built first.")
-        return self._pipe.ReleaseOutputs()
+        with self._check_api_type_scope(types.PieplineAPIType.SCHEDULED) as check:
+            if not self._built:
+                raise RuntimeError("Pipeline must be built first.")
+            return self._pipe.ReleaseOutputs()
 
     # for the backward compatibility
     def _release_outputs(self):
@@ -390,8 +439,9 @@ class Pipeline(object):
         Should not be mixed with :meth:`nvidia.dali.pipeline.Pipeline.schedule_run` in the same pipeline,
         :meth:`nvidia.dali.pipeline.Pipeline.share_outputs` and
         :meth:`nvidia.dali.pipeline.Pipeline.release_outputs`"""
-        self.schedule_run()
-        return self.outputs()
+        with self._check_api_type_scope(types.PieplineAPIType.BASIC) as check:
+            self.schedule_run()
+            return self.outputs()
 
     def _prefetch(self):
         """Executes pipeline to fill executor's pipeline."""

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -17,6 +17,7 @@ from __future__ import division
 from __future__ import print_function
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
+from nvidia.dali import types
 import torch
 import ctypes
 import logging
@@ -105,7 +106,8 @@ class DALIGenericIterator(object):
         self._pipes = pipelines
         # Build all pipelines
         for p in self._pipes:
-            p.build()
+            with p._check_api_type_scope(types.PieplineAPIType.ITERATOR) as check:
+                p.build()
         # Use double-buffering of data batches
         self._data_batches = [[None, None] for i in range(self._num_gpus)]
         self._counter = 0
@@ -117,7 +119,8 @@ class DALIGenericIterator(object):
         # We need data about the batches (like shape information),
         # so we need to run a single batch as part of setup to get that info
         for p in self._pipes:
-            p.schedule_run()
+            with p._check_api_type_scope(types.PieplineAPIType.ITERATOR) as check:
+                p.schedule_run()
         self._first_batch = None
         self._first_batch = self.next()
 
@@ -133,7 +136,8 @@ class DALIGenericIterator(object):
         # Gather outputs
         outputs = []
         for p in self._pipes:
-            outputs.append(p.share_outputs())
+            with p._check_api_type_scope(types.PieplineAPIType.ITERATOR) as check:
+               outputs.append(p.share_outputs())
         for i in range(self._num_gpus):
             dev_id = self._pipes[i].device_id
             # initialize dict for all output categories
@@ -183,8 +187,9 @@ class DALIGenericIterator(object):
                   feed_ndarray(tensor, pyt_tensors[category])
 
         for p in self._pipes:
-            p.release_outputs()
-            p.schedule_run()
+            with p._check_api_type_scope(types.PieplineAPIType.ITERATOR) as check:
+                p.release_outputs()
+                p.schedule_run()
 
         copy_db_index = self._current_data_batch
         # Change index for double buffering

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -69,3 +69,12 @@ def _type_convert_value(dtype, val):
         raise RuntimeError(str(dtype) + " does not correspond to a known type.")
     return _known_types[dtype][1](val)
 
+class PieplineAPIType(object):
+    """Pipeline API type
+    """
+    @staticmethod
+    def _is_member(self):
+        return PieplineAPIType.__dict__.keys()
+    BASIC = 0
+    ITERATOR = 1
+    SCHEDULED = 2

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -51,9 +51,9 @@ Running DALI pipeline
 
 DALI provides a couple of ways to run a pipeline:
 
-- simple `run` method, which runs the computations and returns the results
-- `schedule_run`, `share_outputs` and `release_outputs` with fine grain control of the output buffers' lifetime
-- built-in iterators for MXNet, PyTorch, and TensorFlow
+- simple `run` method, which runs the computations and returns the results (corresponds to :meth:`nvidia.dali.types.PieplineAPIType.BASIC` API type)
+- `schedule_run`, `share_outputs` and `release_outputs` with fine grain control of the output buffers' lifetime (corresponds to :meth:`nvidia.dali.types.PieplineAPIType.SCHEDULED` API type)
+- built-in iterators for MXNet, PyTorch, and TensorFlow (corresponds to :meth:`nvidia.dali.types.PieplineAPIType.ITERATOR` API type)
 
 The first API - `run` method launches the DALI pipeline, executing prefetch iterations if necessary, waits until the first batch is ready and returns the resulting buffers. Buffers are marked as in-use till the call to `run`. In many cases, it is wasteful as data is usually copied out to the native framework tensors after which they can be returned to DALI for reuse
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,3 +45,7 @@ Enums
 .. autoclass:: nvidia.dali.types.DALITensorLayout
    :members:
    :undoc-members:
+
+.. autoclass:: nvidia.dali.types.PieplineAPIType
+   :members:
+   :undoc-members:


### PR DESCRIPTION
- adds scoped API checker which check the outermost scope and disables further API
  checks as basic API call schedules the basic one internally
- when API is mixed an exception is thrown
- adds function that dissables API check

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- It adds mechanism to prevent mixing of pipeline APIs: simple run, with iterators and spited run_scheduled family

#### What happened in this PR?
 - now when user tried to call different API family on given pipeline exception will be thrown.
 - added internal pipeline API that check API family used during calling pipeline methods
 - new test cases to test that
 - advanced section of docs updated
