### PR TITLE
Adjust TensorFlow ResNet50 example to 1.14 version API

### DIFF
--- a/docs/examples/tensorflow/demo/nvutils/runner.py
+++ b/docs/examples/tensorflow/demo/nvutils/runner.py
@@ -44,7 +44,7 @@ class _LogSessionRunHook(tf.train.SessionRunHook):
     def before_run(self, run_context):
         self.t0 = time.time()
         return tf.train.SessionRunArgs(
-            fetches=['step_update:0', 'loss:0', 'total_loss:0',
+            fetches=['global_step:0', 'loss:0', 'total_loss:0',
                      'learning_rate:0'])
     def after_run(self, run_context, run_values):
         self.elapsed_secs += time.time() - self.t0


### PR DESCRIPTION
- changes how after iteration hook works in the example

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- fixes problem of compatibility with 1.14 - `KeyError: "The name 'step_update:0' refers to a Tensor which does not exist. The operation, 'step_update', does not exist in the graph."`

#### What happend in this PR?
 - changes variable used in LogSessionRunHook from `step_update` to `global_step`
 - tested on CI with the full training
