### PR TITLE
Predownload TensorFlow binaries to base docker image used for custom operator

### DIFF
--- a/dali_tf_plugin/build_in_custom_op_docker.sh
+++ b/dali_tf_plugin/build_in_custom_op_docker.sh
@@ -19,7 +19,7 @@ test ${CUDA_VERSION} = "10" && export SUPPORTED_TF_VERSIONS="1.13.1 1.14.0"
 
 for TF_VERSION in ${SUPPORTED_TF_VERSIONS}; do
     echo "Building DALI TF plugin for TF version ${TF_VERSION}"
-    pip install tensorflow-gpu=="${TF_VERSION}"
+    pip install tensorflow-gpu=="${TF_VERSION}" -f /pip-packages
 
     SUFFIX=$(echo $TF_VERSION | sed 's/\([0-9]\+\)\.\([0-9]\+\).*/\1_\2/')
     LIB_NAME=libdali_tf_${SUFFIX}.so

--- a/docker/Dockerfile.customopbuilder.clean
+++ b/docker/Dockerfile.customopbuilder.clean
@@ -57,3 +57,9 @@ RUN rm -f /usr/bin/python && \
 
 COPY --from=cuda /usr/local/cuda /usr/local/cuda
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs/:${LD_LIBRARY_PATH}
+RUN export USE_CUDA_VERSION=$(cat /usr/local/cuda/version.txt | head -1 | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1/') &&\
+    if [ "${USE_CUDA_VERSION}" = "9" ]; then export SUPPORTED_TF_VERSIONS="1.7.0 1.11.0 1.12.0"; fi && \
+    if [ "${USE_CUDA_VERSION}" = "10" ]; then export SUPPORTED_TF_VERSIONS="1.13.1 1.14.0"; fi && \
+    for TF_VERSION in ${SUPPORTED_TF_VERSIONS}; do \
+        pip download tensorflow-gpu==${TF_VERSION} -d /pip-packages; \
+    done


### PR DESCRIPTION
- downloads TensorFlow binaries into the base, clean image used for DALI plugin build

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- downloads wheel packages into base, clean image used for TensorFlow DALI plugin build

#### What happend in this PR?
 - base, clean image should have predownloaded TensorFlow packages in some dir which is used as the first place when looking for the appropriate wheel when pip installs new binary
 - tested on CI
