### PR TITLE
[WIP] Add shape inference in CaffeReader

### DIFF
--- a/dali/pipeline/operators/reader/parser/caffe_parser.h
+++ b/dali/pipeline/operators/reader/parser/caffe_parser.h
@@ -38,7 +38,14 @@ class CaffeParser : public Parser<Tensor<CPUBackend>> {
     label.mutable_data<int>()[0] = datum.label();
 
     // copy image
-    image.Resize({static_cast<Index>(datum.data().size())});
+    const int C = datum.channels();
+    const int H = datum.height();
+    const int W = datum.width();
+    if (C && H && W) {
+      image.Resize({H, W, C});
+    } else {
+      image.Resize({static_cast<Index>(datum.data().size())});
+    }
     std::memcpy(image.mutable_data<uint8_t>(), datum.data().data(),
                 datum.data().size()*sizeof(uint8_t));
     image.SetSourceInfo(data.GetSourceInfo());

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1468,3 +1468,17 @@ def test_python_formats():
         out_dtype = out.at(0).dtype
         assert(test_array.dtype.itemsize == out_dtype.itemsize)
         assert(test_array.dtype.str == out_dtype.str)
+
+def test_CaffeReader_shape():
+    class TestPipeline(Pipeline):
+        def __init__(self, batch_size, num_threads, device_id):
+            super(TestPipeline, self).__init__(batch_size, num_threads, device_id, seed = 12)
+            self.input = ops.CaffeReader(path = caffe_db_folder, random_shuffle = True)
+        def define_graph(self):
+            self.jpegs, self.labels = self.input()
+            return self.jpegs
+
+    pipe = TestPipeline(batch_size=128, num_threads=2, device_id = 0)
+    pipe.build()
+    pipe_out = pipe.run()
+    assert(len(pipe_out[0].at(0).shape) == 3)


### PR DESCRIPTION
- adds check if C, H, and W are present in the LMDB and use it
  to set the shape of the output tensors

ToDo:
- output tensors can be oversized if data is compressed (it seems that even for compressed data C, H, and W could be provided)

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- utilizes optional C, H, and W field in caffe LMDB format to infer output tensor shape

#### What happend in this PR?
 - caffe LMDB protobuf format has C, H, and W field giving some insight about data saved inside. Utilize it to provide shape of the output tensor
 - tested on CI, new test case added
