### PR TITLE
Fix float16 support in DALI TensorFlow plugin

### DIFF
--- a/dali/test/python/test_RN50_data_fw_iterators.py
+++ b/dali/test/python/test_RN50_data_fw_iterators.py
@@ -141,9 +141,13 @@ for iterator_name, IteratorClass in Iterators:
         daliop = IteratorClass()
         for dev in range(args.gpus):
             with tf.device('/gpu:%i' % dev):
+                if args.fp16:
+                    out_type = tf.float16
+                else:
+                    out_type = tf.float32
                 image, label = daliop(pipeline = pipes[dev],
                     shapes = [(args.batch_size, 3, 224, 224), ()],
-                    dtypes = [tf.int32, tf.float32])
+                    dtypes = [out_type, tf.int32])
                 images.append(image)
                 labels.append(label)
         gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.8)

--- a/dali_tf_plugin/daliop.cc
+++ b/dali_tf_plugin/daliop.cc
@@ -283,7 +283,7 @@ class DaliOp : public tf::OpKernel {
       }
       switch (types_[j]) {
         case tf::DT_HALF:
-              dst = reinterpret_cast<void*>(out_tensor->flat<uint16_t>().data());
+              dst = reinterpret_cast<void*>(out_tensor->flat<Eigen::half>().data());
           break;
         case tf::DT_FLOAT:
               dst = reinterpret_cast<void*>(out_tensor->flat<float>().data());

--- a/docker/Dockerfile_dali_tf
+++ b/docker/Dockerfile_dali_tf
@@ -6,7 +6,7 @@ WORKDIR /opt/dali
 FROM base as base_with_wheel
 
 COPY dali_tf_plugin/whl whl
-RUN pip install whl/*.whl && rm -rf whl
+RUN pip install whl/*cp${PYV}*.whl && rm -rf whl
 
 FROM base_with_wheel
 

--- a/qa/TL0_FW_iterators/test.sh
+++ b/qa/TL0_FW_iterators/test.sh
@@ -14,6 +14,7 @@ NUM_GPUS=$(nvidia-smi -L | wc -l)
 
 test_body() {
     python test_RN50_data_fw_iterators.py --gpus ${NUM_GPUS} -b 13 --workers 3 --prefetch 2 -i 100 --epochs 2
+    python test_RN50_data_fw_iterators.py --gpus ${NUM_GPUS} -b 13 --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
 
     nosetests --verbose test_fw_iterators_detection.py
 }


### PR DESCRIPTION
- the destination TensorFlow memory was improperly cast to uint16 instead of half
  type before copying
- adds test for float16 support in DALI TensorFlow plugin
- makes Dockerfile.customopbuilder.clean to install DALI wheel for current
  python version

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- fixes wrong handling of FP16 in DALI TensorFlow plugin

#### What happened in this PR?
 - destination memory in TensorFlow was improperly cast to uint16 instead of half
 - added test for CI

