### PR TITLE
Reduced batch size to avoid out of memory condition in 19.07 container.

### DIFF
--- a/qa/TL3_RN50_convergence/test_mxnet.sh
+++ b/qa/TL3_RN50_convergence/test_mxnet.sh
@@ -6,7 +6,7 @@ min_perf=10000
 
 NUM_GPUS=`nvidia-smi -L | wc -l`
 
-python /opt/mxnet/example/image-classification/train_imagenet_runner -n $NUM_GPUS --seed 42 2>&1 | tee dali.log
+python /opt/mxnet/example/image-classification/train_imagenet_runner -b 208 -n $NUM_GPUS --seed 42 2>&1 | tee dali.log
 
 cat dali.log  | grep -o "Validation-accuracy=0\.[0-9]*" > tmp2.log
 cat dali.log  | grep -o "Speed: [0-9]*\.[0-9]*" > tmp3.log


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
- It fixes a problem with out-of-memory error in 19.07 container

#### What happend in this PR?
- Batch size reduced to 208 per GPU (from default of 256).