### PR TITLE
Enable OpticalFlow test on CI

### DIFF
--- a/qa/TL0_python_self_test_TU/test.sh
+++ b/qa/TL0_python_self_test_TU/test.sh
@@ -8,6 +8,8 @@ source qa/setup_dali_extra.sh
 cd dali/test/python
 
 test_body() {
+    # workaround for the CI
+    put_optflow_libs
     nosetests --verbose test_optical_flow.py
 }
 

--- a/qa/TL1_jupyter_notebooks_TU/test.sh
+++ b/qa/TL1_jupyter_notebooks_TU/test.sh
@@ -8,6 +8,8 @@ pip_packages="jupyter matplotlib numpy"
 pushd ../../docs/examples
 
 test_body() {
+    # workaround for the CI
+    put_optflow_libs
     test_files=("optical_flow/optical_flow_example.ipynb")
 
     # test code

--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -17,3 +17,21 @@ version_ge "$CUDA_VERSION" "100" && \
 version_lt "$NVIDIA_SMI_DRIVER_VERSION" "410.0" && \
 export LD_LIBRARY_PATH="/usr/local/cuda/compat:$LD_LIBRARY_PATH"
 echo "LD_LIBRARY_PATH is $LD_LIBRARY_PATH"
+
+put_optflow_libs() {
+  # Docker v1 doesn't expose libnvidia-opticalflow.so from the host so we need to manually put it there
+  # workaround for the CI
+  if [[ ! -f /usr/lib/x86_64-linux-gnu/libnvidia-opticalflow.so ]]; then
+      NVIDIA_SMI_DRIVER_VERSION_LONG=$(nvidia-smi | grep -Po '(?<=Driver Version: )\d+.\d+.\d+')
+      curl http://us.download.nvidia.com/tesla/${NVIDIA_SMI_DRIVER_VERSION_LONG}/NVIDIA-Linux-x86_64-${NVIDIA_SMI_DRIVER_VERSION_LONG}.run --output NVIDIA-Linux-x86_64-${NVIDIA_SMI_DRIVER_VERSION_LONG}.run
+      chmod a+x *.run && ./*.run -x
+      # put it to some TMP dir just in case we encounter read only /usr/lib/x86_64-linux-gnu in docker
+      LIB_OF_DIR_PATH=$(mktemp -d)
+
+      cp NVIDIA*/libnvidia-opticalflow* ${LIB_OF_DIR_PATH}
+      ln -s ${LIB_OF_DIR_PATH}/libnvidia-opticalflow.so.${NVIDIA_SMI_DRIVER_VERSION_LONG} ${LIB_OF_DIR_PATH}/libnvidia-opticalflow.so.1
+      ln -s ${LIB_OF_DIR_PATH}/libnvidia-opticalflow.so.1 ${LIB_OF_DIR_PATH}/libnvidia-opticalflow.so
+      export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIB_OF_DIR_PATH}
+      rm -rf NVIDIA-Linux-*
+  fi
+}


### PR DESCRIPTION
- Docker v1 doesn't expose libnvidia-opticalflow.so library so test
  needs to download it and put to appropriate place manually

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- adds work around to docker v1 to enable optical flow test in CI

#### What happened in this PR?
 - Docker v1 doesn't expose libnvidia-opticalflow.so library so test needs to download it and put to appropriate place manually
 - Ci test for optical flow was enabled

**JIRA TASK**: DALI-876