### PR TITLE
Fix test header inclusion

### DIFF
--- a/dali/kernels/slice/slice_flip_normalize_permute_common.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_common.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include "dali/core/common.h"
 #include "dali/kernels/kernel.h"
-#include "dali/kernels/slice/slice_kernel_test.h"
+#include "dali/kernels/slice/slice_kernel_utils.h"
 
 namespace dali {
 namespace kernels {


### PR DESCRIPTION
A test header is included, presumably  unintentionally.