### PR TITLE
Make `dali_kernel_test_lib` respect `BUILD_TEST`

### DIFF
--- a/dali/kernels/CMakeLists.txt
+++ b/dali/kernels/CMakeLists.txt
@@ -25,6 +25,8 @@ collect_sources(DALI_KERNEL_SRCS)
 collect_test_sources(DALI_KERNEL_TEST_SRCS)
 
 cuda_add_library(${dali_kernel_lib} STATIC "${DALI_KERNEL_SRCS}")
-cuda_add_library(${dali_kernel_test_lib} STATIC "${DALI_KERNEL_TEST_SRCS}")
 
+if (BUILD_TEST)
+cuda_add_library(${dali_kernel_test_lib} STATIC "${DALI_KERNEL_TEST_SRCS}")
 target_link_libraries(${dali_kernel_test_lib} ${dali_kernel_lib})
+endif()


### PR DESCRIPTION
currently `dali_kernel_test_lib` is built regardless of `BUILD_TEST` settings