### PR TITLE
Fix python operator with side effects.

### DIFF
--- a/dali/pipeline/operators/python_function/python_function.cc
+++ b/dali/pipeline/operators/python_function/python_function.cc
@@ -90,9 +90,12 @@ void CopyOutputs(SampleWorkspace *ws, int idx, const py::tuple &output) {
   }
 }
 
+static std::mutex operator_lock{};
+
 template<>
 void PythonFunctionImpl<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
-  py::gil_scoped_acquire guard{};
+  std::lock_guard<std::mutex> operator_guard(operator_lock);
+  py::gil_scoped_acquire interpreter_guard{};
   py::list args_list = PrepareInputList(ws, idx);
   py::object output_o;
   try {

--- a/dali/test/python/test_operator_python_function.py
+++ b/dali/test/python/test_operator_python_function.py
@@ -385,7 +385,7 @@ def test_func_with_side_effects():
         assert counter == len(out_one) + len(out_two)
         elems_one = [out_one.at(s)[0][0][0] for s in range(BATCH_SIZE)]
         elems_one.sort()
-        assert elems_one == range(1, BATCH_SIZE + 1)
+        assert elems_one == [i for i in range(1, BATCH_SIZE + 1)]
         elems_two = [out_two.at(s)[0][0][0] for s in range(BATCH_SIZE)]
         elems_two.sort()
-        assert elems_two == range(BATCH_SIZE + 1, 2 * BATCH_SIZE + 1)
+        assert elems_two == [i for i in range(BATCH_SIZE + 1, 2 * BATCH_SIZE + 1)]

--- a/dali/test/python/test_operator_python_function.py
+++ b/dali/test/python/test_operator_python_function.py
@@ -383,10 +383,9 @@ def test_func_with_side_effects():
 
         print('Iter ' + str(it) + ' Len one ' + str(len(out_one)) + ' len two ' + str(len(out_two)))
         assert counter == len(out_one) + len(out_two)
-
-        for s in range(BATCH_SIZE):
-            elem_one = out_one.at(s)[0][0][0]
-            elem_two = out_two.at(s)[0][0][0]
-
-            assert 0 < elem_one <= len(out_one)
-            assert BATCH_SIZE < elem_two <= len(out_one) + len(out_two)
+        elems_one = [out_one.at(s)[0][0][0] for s in range(BATCH_SIZE)]
+        elems_one.sort()
+        assert elems_one == range(1, BATCH_SIZE + 1)
+        elems_two = [out_two.at(s)[0][0][0] for s in range(BATCH_SIZE)]
+        elems_two.sort()
+        assert elems_two == range(BATCH_SIZE + 1, 2 * BATCH_SIZE + 1)


### PR DESCRIPTION
Signed-off-by: Rafal <Banas.Rafal97@gmail.com>

#### Why we need this PR?
- It fixes a race condition in the python operator with side effects.

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
    A global mutex was added in python operator implementation to protect the python function
    execution.
 - What was changed, added, removed?
    A simple change in _python_function.cc_
 - Was this PR tested? How?
    A test in _test\_operator\_python\_function.py_ was added.

**JIRA TASK**: [DALI-837]