### PR TITLE
Calculation layout setup for GPU kernels.

### DIFF
--- a/dali/kernels/common/block_setup.h
+++ b/dali/kernels/common/block_setup.h
@@ -1,0 +1,263 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_COMMON_BLOCK_SETUP_H_
+#define DALI_KERNELS_COMMON_BLOCK_SETUP_H_
+
+#include <cuda_runtime.h>
+#include <vector>
+#include <utility>
+#include "dali/kernels/kernel.h"
+#include "dali/core/geom/vec.h"
+
+namespace dali {
+namespace kernels {
+
+template <int ndim>
+struct BlockDesc {
+  int sample_idx;
+  ivec<ndim> start, end;
+};
+
+template <int n>
+DALI_HOST_DEV
+ivec<n> shape2vec(const TensorShape<n> &shape) {
+  ivec<n> ret;
+  for (int i = 0; i < n; i++)
+    ret[n-1-i] = shape[i];
+  return ret;
+}
+
+template <int skip, int n>
+DALI_HOST_DEV
+std::enable_if_t<(skip < 0), TensorShape<n>> skip_dim(const TensorShape<n> &shape) {
+  return shape;
+}
+
+template <int skip, int n>
+DALI_HOST_DEV
+std::enable_if_t<(skip >= 0), TensorShape<n-1>> skip_dim(const TensorShape<n> &shape) {
+  static_assert(skip < n, "The dimension to be skipped must not exceed input ndim");
+  return shape_cat(shape.template first<skip>(), shape.template last<n-skip-1>());
+}
+
+/// @brief A utility for calculating block layout for GPU kernels
+/// @tparam _ndim         number dimensions to take into account while calculating the layout
+/// @tparam _channel_dim  dimension in which channels are stored; channel dimension does not
+///                       participate in layout calculation \n
+///                       In cases where channel dimension can or should participate in layout
+///                       calaculation, do not specify channel dimenion and treat it as an
+///                       additional spatial dimension (e.g. for linear operations in CHW layout)\n
+///                       -1 indicates there are only spatial dimensions, all of which
+///                       participate in layout calculation.
+template <int _ndim, int _channel_dim>
+class BlockSetup {
+ public:
+  static constexpr int ndim = _ndim;
+  static constexpr int channel_dim = _channel_dim;
+  static constexpr int tensor_ndim = (channel_dim < 0 ? ndim : ndim + 1);
+  static_assert(channel_dim >= -1 && channel_dim <= ndim,
+    "Channel dimension must be in range [0..ndim] or -1 (no channel dim)");
+  using BlockDesc = kernels::BlockDesc<ndim>;
+
+  BlockSetup() {
+    for (int i = 0; i < ndim; i++)
+      default_block_size_[i] = (i < 2) ? 256 : 1;
+  }
+
+  void SetupBlocks(const TensorListShape<tensor_ndim> &output_shape,
+                   bool force_variable_size = false) {
+    blocks_.clear();
+    is_uniform_ = !force_variable_size && is_uniform(output_shape);
+
+    if (is_uniform_)
+      UniformSizeSetup(output_shape);
+    else
+      VariableSizeSetup(output_shape);
+  }
+
+  TensorListShape<tensor_ndim> GetOutputShape(
+      const TensorListShape<tensor_ndim> &in_shape,
+      span<const TensorShape<ndim>> output_sizes) {
+    TensorListShape<tensor_ndim> shape;
+    shape.resize(in_shape.num_samples(), tensor_ndim);
+    for (int i = 0; i < in_shape.num_samples(); i++) {
+      auto out_tshape = shape.tensor_shape_span(i);
+      int in_d = 0;
+      for (int j = 0; j < tensor_ndim; j++) {
+        out_tshape[j] = (j == channel_dim)
+         ? in_shape.tensor_shape_span(i)[channel_dim]
+         : output_sizes[i][in_d++];
+      }
+    }
+    return shape;
+  }
+
+
+  void ValidateOutputShape(
+      const TensorListShape<tensor_ndim> &out_shape,
+      const TensorListShape<tensor_ndim> &in_shape,
+      span<const TensorShape<ndim>> output_sizes) {
+    TensorListShape<tensor_ndim> shape;
+    shape.resize(in_shape.num_samples(), tensor_ndim);
+    for (int i = 0; i < in_shape.num_samples(); i++) {
+      auto out_tshape = out_shape[i];
+      TensorShape<tensor_ndim> expected_shape;
+
+      int in_d = 0;
+      for (int j = 0; j < tensor_ndim; j++) {
+        expected_shape[j] = (j == channel_dim)
+         ? in_shape.tensor_shape_span(i)[channel_dim]
+         : output_sizes[i][in_d++];
+      }
+
+      DALI_ENFORCE(out_tshape == expected_shape,
+        "Invalid output tensor shape for sample: " + std::to_string(i));
+    }
+  }
+
+  dim3 BlockDim() const {
+    return dim3(block_dim_.x, block_dim_.y, block_dim_.z);
+  }
+
+  ivec3 BlockDimVec() const {
+    return block_dim_;
+  }
+
+  void SetBlockDim(ivec3 block_dim) {
+    block_dim_ = block_dim;
+  }
+
+  void SetBlockDim(dim3 block_dim) {
+    block_dim_ = { block_dim.x, block_dim.y, block_dim.z };
+  }
+
+  dim3 GridDim() const {
+    return dim3(grid_dim_.x, grid_dim_.y, grid_dim_.z);
+  }
+
+  ivec3 GridDimVec() const {
+    return grid_dim_;
+  }
+
+  void SetDefaultBlockSize(ivec<ndim> block_size) {
+    default_block_size_ = block_size;
+    max_block_elements_ = volume(block_size);
+  }
+
+  span<const BlockDesc> Blocks() const { return make_span(blocks_); }
+
+  ivec<ndim> UniformOutputSize() const {
+    assert(is_uniform_);
+    return uniform_output_size_;
+  }
+
+  ivec<ndim> UniformBlockSize() const {
+    assert(is_uniform_);
+    return uniform_block_size_;
+  }
+
+  bool IsUniformSize() const { return is_uniform_; }
+
+  static inline ivec<ndim> shape2size(const TensorShape<tensor_ndim> &shape) {
+    return shape2vec(skip_dim<channel_dim>(shape));
+  }
+
+ private:
+  std::vector<BlockDesc> blocks_;
+  ivec3 block_dim_{32, 32, 1};
+  ivec3 grid_dim_{1, 1, 1};
+  ivec<ndim> uniform_block_size_, uniform_output_size_;
+  ivec<ndim> default_block_size_;
+  int max_block_elements_ = 1<<16;
+  bool is_uniform_ = false;
+
+  template <int d>
+  void MakeBlocks(BlockDesc blk, ivec<ndim> size, ivec<ndim> block_size,
+                  std::integral_constant<int, d>) {
+    for (int i = 0; i < size[d]; i += block_size[d]) {
+      blk.start[d] = i;
+      blk.end[d] = std::min(i + block_size[d], size[d]);
+      if (d > 0) {
+        constexpr int next_d = d > 0 ? d - 1: d;  // prevent infinite template expansion
+        MakeBlocks(blk, size, block_size, std::integral_constant<int, next_d>());
+      } else {
+        blocks_.push_back(blk);
+      }
+    }
+  }
+
+  void MakeBlocks(int sample_idx, ivec<ndim> size, ivec<ndim> block_size) {
+    BlockDesc blk;
+    blk.sample_idx = sample_idx;
+    MakeBlocks<ndim-1>(blk, size, block_size, {});
+    grid_dim_ = ivec3(blocks_.size(), 1, 1);
+  }
+
+  ivec<ndim> BlockSize(const ivec<ndim> &shape) const {
+    ivec<ndim> ret;
+    for (int i = 0; i < ndim; i++) {
+      switch (i) {
+      case 0:
+      case 1:
+        ret[i] = default_block_size_[i];
+        break;
+      case 2:
+        ret[i] = std::max<int>(1, volume(shape) / max_block_elements_);
+        break;
+      default:
+        ret[i] = 1;
+      }
+    }
+    return ret;
+  }
+
+  void VariableSizeSetup(const TensorListShape<tensor_ndim> &output_shape) {
+    for (int i = 0; i < output_shape.num_samples(); i++) {
+      ivec<ndim> size = shape2size(output_shape[i]);
+      ivec<ndim> block_size = BlockSize(size);
+      MakeBlocks(i, size, block_size);
+    }
+  }
+
+  void UniformSizeSetup(const TensorListShape<tensor_ndim> &output_shape) {
+    if (output_shape.empty())
+      return;
+    uniform_output_size_ = shape2size(output_shape[0]);
+    // Get the rough estimate of block size
+    uniform_block_size_ = BlockSize(uniform_output_size_);
+
+    // Make the blocks as evenly distributed as possible over the target area,
+    // but maintain alignment to CUDA block dim.
+    for (int i = 0; i < 2; i++) {  // only XY dimensions
+      int blocks_in_axis = div_ceil(uniform_output_size_[i], uniform_block_size_[i]);
+      int even_block_size = div_ceil(uniform_output_size_[i], blocks_in_axis);
+
+      // a note on div_ceil + mul combo:
+      // can't use align_up, because block_dim_ does not need to be a power of 2
+      uniform_block_size_[i] = div_ceil(even_block_size, block_dim_[i]) * block_dim_[i];
+    }
+
+    grid_dim_ = {
+      div_ceil(uniform_output_size_.x, uniform_block_size_.x),
+      div_ceil(uniform_output_size_.y, uniform_block_size_.y),
+      output_shape.num_samples()
+    };
+  }
+};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_COMMON_BLOCK_SETUP_H_

--- a/dali/kernels/test/block_setup_test.cc
+++ b/dali/kernels/test/block_setup_test.cc
@@ -1,0 +1,165 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/kernels/common/block_setup.h"
+
+namespace dali {
+namespace kernels {
+
+TEST(TensorShape, skip_dim) {
+  TensorShape<5> in = { 1, 2, 3, 4, 5 };
+  EXPECT_EQ(skip_dim<-1>(in), in);
+  EXPECT_EQ(skip_dim<0>(in), TensorShape<4>(   2, 3, 4, 5));  // NOLINT
+  EXPECT_EQ(skip_dim<1>(in), TensorShape<4>(1,    3, 4, 5));
+  EXPECT_EQ(skip_dim<2>(in), TensorShape<4>(1, 2,    4, 5));
+  EXPECT_EQ(skip_dim<3>(in), TensorShape<4>(1, 2, 3,    5));
+  EXPECT_EQ(skip_dim<4>(in), TensorShape<4>(1, 2, 3, 4   ));  // NOLINT
+}
+
+TEST(BlockSetup, shape2vec) {
+  TensorShape<1> in1 = { 123 };
+  EXPECT_EQ(shape2vec(in1), ivec1(123));
+  TensorShape<3> in3 = { 2, 3, 4 };
+  EXPECT_EQ(shape2vec(in3), ivec3(4, 3, 2));
+}
+
+namespace {
+
+template <int dim>
+struct BlockMap {
+  unsigned end;
+  std::map<unsigned, BlockMap<dim-1>> inner;
+};
+
+template <>
+struct BlockMap<0> {
+  unsigned end;
+  // dummy - to avoid specialization
+  const bool inner = false;
+};
+
+template <int dim>
+bool operator==(const BlockMap<dim> &a, const BlockMap<dim> &b) {
+  return a.end == b.end && a.inner == b.inner;
+}
+
+inline void ValidateBlockMap(const BlockMap<0> &map, const TensorShape<0> &shape) {}
+
+/// @brief Check that the output shape is covered with rectangular grid.
+///
+/// The grid cells must be aligned between rows/slices, but don't have to be uniform
+/// - typically the last cell will be smaller and that's expected.
+template <int dim>
+void ValidateBlockMap(const BlockMap<dim> &map, const TensorShape<dim> &shape) {
+  ASSERT_FALSE(map.inner.empty());
+  unsigned i = 0;
+  for (auto &p : map.inner) {
+    ASSERT_EQ(p.first, i) << "Blocks don't cover the image";
+    ASSERT_GT(p.second.end, i) << "Block end coordinate must be greater than start";
+    i = p.second.end;
+  }
+  EXPECT_EQ(i, shape[0])
+    << (i < shape[0] ? "Block does not cover whole image" : "Block exceeds image size");
+
+  const BlockMap<dim-1> *first_slice = 0;
+  for (auto &p : map.inner) {
+    if (first_slice) {
+      EXPECT_EQ(p.second.inner, first_slice->inner) << "Inner block layout must be uniform";
+    } else {
+      first_slice = &p.second;
+      // Validate the first slice recurisvely - the remaining slices should be equal and
+      // therefore don't require validation.
+      ValidateBlockMap(p.second, shape.template last<dim-1>());
+    }
+  }
+}
+
+}  // namespace
+
+
+TEST(BlockSetup, SetupBlocks_Variable) {
+  TensorListShape<3> TLS({
+    { 480, 640, 3 },
+    { 768, 1024, 3 },
+    { 600, 800, 3 },
+    { 720, 1280, 3 },
+    { 480, 864, 3 },
+    { 576, 720, 3 }
+  });
+
+  BlockSetup<2, 2> setup;
+  static_assert(setup.tensor_ndim == 3, "Incorrectly inferred tensor_ndim");
+  setup.SetupBlocks(TLS);
+  ASSERT_FALSE(setup.IsUniformSize());
+  int prev = -1;
+  BlockMap<2> map;
+  for (auto &blk : setup.Blocks()) {
+    if (blk.sample_idx != prev) {
+      if (prev != -1) {
+        ValidateBlockMap(map, TLS[prev].first<2>());
+      }
+      prev = blk.sample_idx;
+      map = {};
+    }
+    auto &b = map.inner[blk.start.y];
+    b.end = blk.end.y;
+    b.inner[blk.start.x].end = blk.end.x;
+  }
+  if (prev != -1)
+    ValidateBlockMap(map, TLS[prev].first<2>());
+
+  EXPECT_EQ(setup.GridDimVec(), ivec3(setup.Blocks().size(), 1, 1));
+}
+
+
+TEST(BlockSetup, SetupBlocks_Uniform) {
+  const int W = 1920;
+  const int H = 1080;
+  TensorListShape<3> TLS({
+    { H, W, 3 },
+    { H, W, 3 },
+    { H, W, 3 },
+    { H, W, 3 },
+    { H, W, 3 },
+    { H, W, 3 },
+    { H, W, 3 },
+    { H, W, 3 },
+    { H, W, 3 },
+    { H, W, 3 }
+  });
+
+  BlockSetup<2, 2> setup;
+  ivec2 def_block_size = { 256, 256 };
+  setup.SetDefaultBlockSize(def_block_size);
+  static_assert(setup.tensor_ndim == 3, "Incorrectly inferred tensor_ndim");
+  setup.SetupBlocks(TLS);
+  ASSERT_TRUE(setup.IsUniformSize());
+  ivec3 expected_grid = {
+    div_ceil(W, def_block_size.x),
+    div_ceil(H, def_block_size.y),
+    TLS.num_samples()
+  };
+  ivec3 block_dim = setup.BlockDimVec();
+  ivec2 expected_block = {
+    div_ceil(div_ceil(W, expected_grid.x), block_dim.x) * block_dim.x,
+    div_ceil(div_ceil(H, expected_grid.y), block_dim.y) * block_dim.y
+  };
+  EXPECT_EQ(setup.UniformBlockSize(), expected_block);
+  ivec3 grid = setup.GridDimVec();
+  EXPECT_EQ(grid, expected_grid);
+}
+
+}  // namespace kernels
+}  // namespace dali


### PR DESCRIPTION
#### Why we need this PR?
It adds common functionality for calculating block layout for GPU kernels
* Support uniform and variable output sample size
* Configurable default block footprint
* Configurable CUDA block dim
* Returns block descriptors or uniform block size and CUDA grid dim.

#### What happened in this PR?
- Added BlockSetup class
- Unit tests calculate 2D layout, ignoring channel dimension

**JIRA TASK**: [DALI-982]
