### PR TITLE
Add virtual env and conda test case for DALI TF plugin

### DIFF
--- a/qa/TL0_tensorflow_plugin/test.sh
+++ b/qa/TL0_tensorflow_plugin/test.sh
@@ -3,6 +3,11 @@
 pip_packages="nose tensorflow-gpu"
 target_dir=./dali/test/python
 
+# populate epilog and prolog with variants to enable/disable conda and virtual env
+# every test will be executed for bellow configs
+prolog=(: enable_conda enable_virtualenv)
+epilog=(: disable_conda disable_virtualenv)
+
 test_body() {
     # Manually removing the supported plugin so that it fails
     lib_dir=$(python -c 'import nvidia.dali.sysconfig as sc; print(sc.get_lib_dir())')

--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -9,6 +9,7 @@ then
     return 0
 fi
 PYTHON_VERSION=$(python -c "from __future__ import print_function; import sys; print(\"{}.{}\".format(sys.version_info[0],sys.version_info[1]))")
+PYTHON_VERSION_SHORT=${PYTHON_VERSION/\./}
 
 NVIDIA_SMI_DRIVER_VERSION=$(nvidia-smi | grep -Po '(?<=Driver Version: )\d+.\d+')
 
@@ -40,4 +41,26 @@ put_optflow_libs() {
       export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIB_OF_DIR_PATH}
       rm -rf NVIDIA-Linux-*
   fi
+}
+
+enable_conda() {
+    echo "Activate conda"
+    # functions are not exported by default to be made available in subshells
+    eval "$(conda shell.bash hook)"
+    conda activate conda_py${PYTHON_VERSION_SHORT}_env
+}
+
+disable_conda() {
+    echo "Deactivate conda"
+    conda deactivate
+}
+
+enable_virtualenv() {
+    echo "Activate virtual env"
+    source /virtualenv_${PYTHON_VERSION_SHORT}/bin/activate
+}
+
+disable_virtualenv() {
+    echo "Deactivate virtual env"
+    deactivate
 }


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- adds virtual env and conda test case for DALI TF plugin

#### What happened in this PR?
 - adds the ability to add a list of prolog-epilog functions run
  for each test variant before required pip packages are installed
 - adds prolog/epilog that activates/deactivates conda and virtual env
  inside DALI TensorFlow plugin test
 - it assumes /virtualenv_${PYTHON_VERSION}/bin/activate and
  conda_py${PYTHON_VERSION}_env (without a dot are present in the system)
 - it utilizes conda and virtual env set up in the CI runners
 - CI runs this additional test case

**JIRA TASK**: DALI-953