### PR TITLE
Use per-sample RNG in SSDRandomCrop and RandomBBoxCrop

### DIFF
--- a/dali/pipeline/operators/crop/bbox_crop.cc
+++ b/dali/pipeline/operators/crop/bbox_crop.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/pipeline/operators/crop/bbox_crop.cc
+++ b/dali/pipeline/operators/crop/bbox_crop.cc
@@ -136,9 +136,10 @@ void RandomBBoxCrop<CPUBackend>::RunImpl(SampleWorkspace *ws, const int) {
   }
 
   ProspectiveCrop prospective_crop;
+  int sample = ws->data_idx();
   while (!prospective_crop.success)
     prospective_crop  = FindProspectiveCrop(
-        bounding_boxes, labels, SelectMinimumOverlap());
+        bounding_boxes, labels, SelectMinimumOverlap(sample), sample);
 
   const auto &selected_boxes = prospective_crop.boxes;
   const auto &selected_labels = prospective_crop.labels;

--- a/dali/pipeline/operators/crop/bbox_crop.h
+++ b/dali/pipeline/operators/crop/bbox_crop.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/pipeline/operators/detection/random_crop.cc
+++ b/dali/pipeline/operators/detection/random_crop.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/pipeline/operators/detection/random_crop.cc
+++ b/dali/pipeline/operators/detection/random_crop.cc
@@ -182,6 +182,7 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
   // [N] : [ltrb, ... ], dtype=float
   const auto& bboxes = ws->Input<CPUBackend>(1);
   const auto& labels = ws->Input<CPUBackend>(2);
+  int sample = ws->data_idx();
 
   auto N = bboxes.dim(0);
   const float* bbox_data = bboxes.data<float>();
@@ -196,7 +197,7 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
 
   // iterate until a suitable crop has been found
   while (true) {
-    auto opt_idx = int_dis_(gen_);
+    auto opt_idx = int_dis_(rngs_[sample]);
     auto option = sample_options_[opt_idx];
 
     if (option.no_crop()) {
@@ -215,8 +216,8 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
 
     // make num_attempts_ tries to get a valid crop
     for (int i = 0; i < num_attempts_; ++i) {
-      auto w = float_dis_(gen_);
-      auto h = float_dis_(gen_);
+      auto w = float_dis_(rngs_[sample]);
+      auto h = float_dis_(rngs_[sample]);
       // aspect ratio check
       if ((w / h < 0.5) || (w / h > 2.)) {
         continue;
@@ -224,8 +225,8 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace *ws, const int idx) {
 
       // need RNG generators for left, top
       std::uniform_real_distribution<float> l_dis(0., 1. - w), t_dis(0., 1. - h);
-      auto left = l_dis(gen_);
-      auto top = t_dis(gen_);
+      auto left = l_dis(rngs_[sample]);
+      auto top = t_dis(rngs_[sample]);
 
       auto right = left + w;
       auto bottom = top + h;

--- a/dali/pipeline/operators/detection/random_crop.h
+++ b/dali/pipeline/operators/detection/random_crop.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/pipeline/operators/detection/random_crop.h
+++ b/dali/pipeline/operators/detection/random_crop.h
@@ -24,6 +24,7 @@
 #include "dali/pipeline/operators/operator.h"
 #include "dali/pipeline/operators/op_spec.h"
 #include "dali/pipeline/operators/common.h"
+#include "dali/pipeline/util/batch_rng.h"
 
 namespace dali {
 
@@ -33,7 +34,7 @@ class SSDRandomCrop : public Operator<Backend> {
   explicit inline SSDRandomCrop(const OpSpec &spec) :
     Operator<Backend>(spec),
     num_attempts_(spec.GetArgument<int>("num_attempts")),
-    gen_(spec.GetArgument<int64_t>("seed")),
+    rngs_(spec.GetArgument<int64_t>("seed"), batch_size_),
     int_dis_(0, 6),        // sample option
     float_dis_(0.3, 1.) {  // w, h generation
     // setup all possible sample types
@@ -83,7 +84,7 @@ class SSDRandomCrop : public Operator<Backend> {
   int num_attempts_;
 
   // RNG stuff
-  std::mt19937 gen_;
+  BatchRNG<std::mt19937> rngs_;
   std::uniform_int_distribution<> int_dis_;
   std::uniform_real_distribution<float> float_dis_;
 };

--- a/dali/pipeline/util/batch_rng.h
+++ b/dali/pipeline/util/batch_rng.h
@@ -18,17 +18,20 @@
 #include <random>
 #include <vector>
 
+#include "dali/core/span.h"
+
 namespace dali {
 
 template <typename RNG = std::mt19937>
 class BatchRNG {
  public:
-  BatchRNG(int64_t seed, int batch_size) : seed_(seed) {
+  BatchRNG(int64_t seed, int batch_size, int state_size = 4) : seed_(seed) {
     std::seed_seq seq{seed_};
-    std::vector<uint32_t> seeds(batch_size);
+    std::vector<uint32_t> seeds(batch_size * state_size);
     seq.generate(seeds.begin(), seeds.end());
     rngs_.reserve(batch_size);
-    for (auto s : seeds) {
+    for (int i = 0; i < batch_size * state_size; i += state_size) {
+      std::seed_seq s(seeds.begin() + i, seeds.begin() + i + state_size);
       rngs_.emplace_back(s);
     }
   }

--- a/dali/pipeline/util/batch_rng.h
+++ b/dali/pipeline/util/batch_rng.h
@@ -28,8 +28,8 @@ class BatchRNG {
     std::vector<uint32_t> seeds(batch_size);
     seq.generate(seeds.begin(), seeds.end());
     rngs_.reserve(batch_size);
-    for (auto seed : seeds) {
-      rngs_.emplace_back(seed);
+    for (auto s : seeds) {
+      rngs_.emplace_back(s);
     }
   }
 

--- a/dali/pipeline/util/batch_rng.h
+++ b/dali/pipeline/util/batch_rng.h
@@ -25,6 +25,15 @@ namespace dali {
 template <typename RNG = std::mt19937>
 class BatchRNG {
  public:
+  /**
+   * @brief Used to keep batch of RNGs, so Operators can be immune to order of sample processing
+   * while using randomness
+   *
+   * @param seed Used to generate seed_seq to initialize batch of RNGs
+   * @param batch_size How many RNGs to store
+   * @param state_size How many seed are used to initialize one RNG. Used to lower probablity of
+   * collisions between seeds used to initialize RNGs in different operators.
+   */
   BatchRNG(int64_t seed, int batch_size, int state_size = 4) : seed_(seed) {
     std::seed_seq seq{seed_};
     std::vector<uint32_t> seeds(batch_size * state_size);
@@ -36,7 +45,7 @@ class BatchRNG {
     }
   }
 
-  RNG &operator[](int sample) {
+  RNG &operator[](int sample) noexcept {
     return rngs_[sample];
   }
 

--- a/dali/pipeline/util/batch_rng.h
+++ b/dali/pipeline/util/batch_rng.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_UTIL_BATCH_RNG_H_
+#define DALI_PIPELINE_UTIL_BATCH_RNG_H_
+
+#include <random>
+#include <vector>
+
+namespace dali {
+
+template <typename RNG = std::mt19937>
+class BatchRNG {
+ public:
+  BatchRNG(int64_t seed, int batch_size) : seed_(seed) {
+    std::seed_seq seq{seed_};
+    std::vector<uint32_t> seeds(batch_size);
+    seq.generate(seeds.begin(), seeds.end());
+    rngs_.reserve(batch_size);
+    for (auto seed : seeds) {
+      rngs_.emplace_back(seed);
+    }
+  }
+
+  RNG &operator[](int sample) {
+    return rngs_[sample];
+  }
+
+ private:
+  int64_t seed_;
+  std::vector<RNG> rngs_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_UTIL_BATCH_RNG_H_


### PR DESCRIPTION
This should allow to use MIS with them

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- Refactoring to unify usage of RNG in operators 

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
When CPU operator mixes threads (per-sample processing) and RNG usage in RunImpl it is nondeterministic and does not allow for usage of Multiple Input Sets. We should use per-sample RNG that would make the operator resistant for different order of sample processing even when samples can query the RNG unspecified amount of times.

 - What was changed, added, removed?
BatchRNG type was added to hold batch-sized vector of RNGs.

 - What is most important part that reviewers should focus on?
Changes in operators
 - Was this PR tested? How?
CI
 - Were docs and examples updated, if necessary?

**JIRA TASK**: [DALI-980]