### PR TITLE
Fix lint in dali/pipeline/operators/reader/loader/loader.h

### DIFF
--- a/dali/pipeline/operators/reader/loader/loader.h
+++ b/dali/pipeline/operators/reader/loader/loader.h
@@ -127,7 +127,6 @@ class Loader {
         PrepareEmpty(*tensor_ptr);
         ReadSample(*tensor_ptr);
         IncreaseReadSampleCounter();
-       
         sample_buffer_.push_back(std::move(tensor_ptr));
         ++shards_.back().end;
       }


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- fixes lint warning in dali/pipeline/operators/reader/loader/loader.h 

#### What happened in this PR?
 - removes empty spaces in dali/pipeline/operators/reader/loader/loader.h 
 - tested on CI

**JIRA TASK**: NA