### PR TITLE
Fix Gluon example that mixes simple and iterator DALI API

### DIFF
--- a/docs/examples/mxnet/gluon.ipynb
+++ b/docs/examples/mxnet/gluon.ipynb
@@ -183,6 +183,9 @@
    "outputs": [],
    "source": [
     "from nvidia.dali.plugin.mxnet import DALIGenericIterator\n",
+    "# recreate pipeline to avoid mixing simple with iterator API\n",
+    "pipe = HybridPipe(batch_size=batch_size, num_threads=4, device_id = 0)\n",
+    "pipe.build()\n",
     "dali_iter = DALIGenericIterator(pipe, [(\"data\", DALIGenericIterator.DATA_TAG)], pipe.epoch_size(\"Reader\"))"
    ]
   },


### PR DESCRIPTION
- now there is enforce that prevent from mixing simple, iterator
  and fine control API. If fails as Gluon example is mixing them
- fix Gluon example

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- fix Gluon example that  simple and iterator DALI API 

#### What happened in this PR?
 - disabled API check in Gluon example
 - tested in CI

**JIRA TASK**: NA