### PR TITLE
Make use right PyTorch capitalization everywhere

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -14,4 +14,4 @@ Examples specific to frameworks integration:
 
 - [MXNet](mxnet)
 - [TensorFlow](tensorflow)
-- [pyTorch](pytorch)
+- [PyTorch](pytorch)

--- a/docs/examples/pytorch/resnet50/pytorch-resnet50.rst
+++ b/docs/examples/pytorch/resnet50/pytorch-resnet50.rst
@@ -22,7 +22,7 @@ Requirements
    :language: bash
 
 - `APEx <https://www.github.com/nvidia/apex>`_ - optional, required for fp16 mode or distributed (multi-GPU) operation
-- Install PyTorch from source, master branch of `pytorch on github <https://www.github.com/pytorch/pytorch>`_
+- Install PyTorch from source, master branch of `PyTorch on github <https://www.github.com/pytorch/pytorch>`_
 - :bash:`pip install -r requirements.txt`
 - Download the ImageNet dataset and move validation images to labeled subfolders
 

--- a/docs/examples/pytorch/single_stage_detector/src/utils.py
+++ b/docs/examples/pytorch/single_stage_detector/src/utils.py
@@ -421,7 +421,7 @@ class SSDTransformer(object):
         self.img_trans = transforms.Compose(train_trans) 
         self.hflip = RandomHorizontalFlip()
 
-        # All Pytorch Tensor will be normalized
+        # All PyTorch Tensor will be normalized
         # https://discuss.pytorch.org/t/how-to-preprocess-input-for-pre-trained-networks/683
         self.normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                                std=[0.229, 0.224, 0.225])

--- a/docs/examples/video/superres_pytorch/common/fp16.py
+++ b/docs/examples/video/superres_pytorch/common/fp16.py
@@ -197,7 +197,7 @@ class FP16_Optimizer(object):
         """
         Returns a dict containing the current state of this FP16_Optimizer instance.
         This dict contains attributes of FP16_Optimizer, as well as the state_dict
-        of the contained Pytorch optimizer.
+        of the contained PyTorch optimizer.
 
         Untested.
         """

--- a/docs/examples/video/superres_pytorch/main.py
+++ b/docs/examples/video/superres_pytorch/main.py
@@ -40,11 +40,11 @@ parser.add_argument('--crop_size', type=int, nargs='+', default=[256, 256],
 parser.add_argument('--batchsize', type=int, default=1,
                     help='per rank batch size')
 parser.add_argument('--loader', type=str, default='DALI',
-                    help='dataloader: pytorch or DALI')
+                    help='dataloader: PyTorch or DALI')
 parser.add_argument('--rank', type=int, default=0,
-                    help='pytorch distributed rank')
+                    help='PyTorch distributed rank')
 parser.add_argument('--world_size', default=1, type=int, metavar='N',
-                    help='num processes for pytorch distributed')
+                    help='num processes for PyTorch distributed')
 parser.add_argument('--ip', default='localhost', type=str,
                     help='IP address for distributed init.')
 parser.add_argument('--max_iter', type=int, default=1000,
@@ -122,7 +122,7 @@ def main(args):
         epoch = floor(total_iter / train_batches)
 
         # only if we are using DistributedSampler
-        if args.world_size > 1 and args.loader == 'pytorch':
+        if args.world_size > 1 and args.loader == 'PyTorch':
             sampler.set_epoch(epoch)
 
         model.train()

--- a/docs/examples/video/superres_pytorch/run.sh
+++ b/docs/examples/video/superres_pytorch/run.sh
@@ -6,7 +6,7 @@
 
 export DATA_DIR=data_dir
 export RESOLUTION=720p  # options: 540p, 720p, 1080p, 4K
-export LOADER="DALI"  # options: "DALI" or "pytorch"
+export LOADER="DALI"  # options: "DALI" or "PyTorch"
 export DATA_TYPE=scenes # options: "scenes" or "frames"
 #export CODEC="h264"  #
 #export CRF="18"      # set these three only if used during preprocessing

--- a/docs/plugins/pytorch_plugin_api.rst
+++ b/docs/plugins/pytorch_plugin_api.rst
@@ -1,4 +1,4 @@
-pyTorch Plugin API reference
+PyTorch Plugin API reference
 ============================
 
 .. automodule:: nvidia.dali.plugin.pytorch

--- a/docs/plugins/pytorch_tutorials.rst
+++ b/docs/plugins/pytorch_tutorials.rst
@@ -1,4 +1,4 @@
-pyTorch
+PyTorch
 =======
 
 .. toctree::


### PR DESCRIPTION
- converts all pyTorch, Pytorch, etc to PyTorch

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- converts all pyTorch, Pytorch, etc to PyTorch

#### What happened in this PR?
 - unifies different PyTorch capitalization in the docs
 - docs and examples are updated

**JIRA TASK**: DALI-989