### PR TITLE
Fix pipeline serialization/deserialization for logical_id

### DIFF
--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -271,9 +271,9 @@ int Pipeline::AddOperator(OpSpec spec, const std::string& inst_name, int logical
       // device == gpu
       DALI_ENFORCE(it->second.has_cpu, "cpu input requested by op exists "
           "only on gpu. " + error_str);
-      SetupCPUInput(it, i, &spec, GetNextLogicalId());
+      SetupCPUInput(it, i, &spec);
     } else {
-      SetupGPUInput(it, GetNextLogicalId());
+      SetupGPUInput(it);
     }
   }
 
@@ -375,6 +375,7 @@ inline void Pipeline::AddSplitHybridDecoder(OpSpec &spec, const std::string &ins
   gpu_spec.SetArg("device", "mixed");
 
   // TODO(spanev): handle serialization for nvJPEGDecoderNew
+  // Considering Logical Ids, they would not cause collisions as they are explicitly serialized
   this->AddOperator(spec, inst_name, logical_id);
   this->AddOperator(gpu_spec, inst_name + "_gpu", GetNextLogicalId());
 }
@@ -386,8 +387,8 @@ void Pipeline::AddToOpSpecs(const std::string &inst_name, const OpSpec &spec, in
     DALI_ENFORCE(
         group_name == spec.name(),
         "Different Operator types cannot be groupped with the same logical id. Tried to group " +
-            spec.name() + " using logical_id " + std::to_string(logical_id) +
-            " which is already assigned to " + group_name);
+            spec.name() + " using logical_id=" + std::to_string(logical_id) +
+            " which is already assigned to " + group_name + ".");
     const OpSchema &schema = SchemaRegistry::GetSchema(spec.name());
     DALI_ENFORCE(schema.AllowsInstanceGrouping(),
                  "Operator " + spec.name() + " does not support synced random execution required "
@@ -482,7 +483,7 @@ void Pipeline::Build(vector<std::pair<string, string>> output_names) {
           .AddArg("device", "mixed")
           .AddInput(name, "cpu")
           .AddOutput("contiguous_" + name, "cpu");
-        PrepareOpSpec(&spec, GetNextLogicalId());
+        PrepareOpSpec(&spec, GetNextInternalLogicalId());
 
         graph_.AddOp(spec, "__MakeContiguous_" + name);
 
@@ -587,8 +588,7 @@ void Pipeline::ReleaseOutputs() {
     }
 }
 
-void Pipeline::SetupCPUInput(std::map<string, EdgeMeta>::iterator it,
-    int input_idx, OpSpec *spec, int logical_id) {
+void Pipeline::SetupCPUInput(std::map<string, EdgeMeta>::iterator it, int input_idx, OpSpec *spec) {
   if (!it->second.has_contiguous) {
     OpSpec make_contiguous_spec =
       OpSpec("MakeContiguous")
@@ -596,7 +596,7 @@ void Pipeline::SetupCPUInput(std::map<string, EdgeMeta>::iterator it,
       .AddInput(it->first, "cpu")
       .AddOutput("contiguous_" + it->first, "cpu");
     // don't put it into op_specs_for_serialization_, only op_specs_
-    AddToOpSpecs("__MakeContiguous_" + it->first, make_contiguous_spec, logical_id);
+    AddToOpSpecs("__MakeContiguous_" + it->first, make_contiguous_spec, GetNextInternalLogicalId());
     it->second.has_contiguous = true;
   }
 
@@ -608,7 +608,7 @@ void Pipeline::SetupCPUInput(std::map<string, EdgeMeta>::iterator it,
   input_strs.first = "contiguous_" + input_strs.first;
 }
 
-void Pipeline::SetupGPUInput(std::map<string, EdgeMeta>::iterator it, int logical_id) {
+void Pipeline::SetupGPUInput(std::map<string, EdgeMeta>::iterator it) {
   if (it->second.has_gpu) return;
   OpSpec copy_to_dev_spec =
     OpSpec("MakeContiguous")
@@ -616,7 +616,7 @@ void Pipeline::SetupGPUInput(std::map<string, EdgeMeta>::iterator it, int logica
     .AddInput(it->first, "cpu")
     .AddOutput(it->first, "gpu");
   // don't put it into op_specs_for_serialization_, only op_specs_
-  AddToOpSpecs("__Copy_" + it->first, copy_to_dev_spec, logical_id);
+  AddToOpSpecs("__Copy_" + it->first, copy_to_dev_spec, GetNextInternalLogicalId());
   it->second.has_gpu = true;
 }
 
@@ -753,6 +753,12 @@ void Pipeline::SaveGraphToDotFile(const std::string &filename) {
 int Pipeline::GetNextLogicalId() {
   int ret = next_logical_id_;
   next_logical_id_++;
+  return ret;
+}
+
+int Pipeline::GetNextInternalLogicalId() {
+  int ret = next_internal_logical_id_;
+  next_internal_logical_id_--;
   return ret;
 }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -370,10 +370,9 @@ class DLL_PUBLIC Pipeline {
     return base_ptr_offset;
   }
 
-  void SetupCPUInput(std::map<string, EdgeMeta>::iterator it, int input_idx, OpSpec *spec,
-                     int logical_id);
+  void SetupCPUInput(std::map<string, EdgeMeta>::iterator it, int input_idx, OpSpec *spec);
 
-  void SetupGPUInput(std::map<string, EdgeMeta>::iterator it, int logical_id);
+  void SetupGPUInput(std::map<string, EdgeMeta>::iterator it);
 
   inline EdgeMeta NewEdge(const std::string &device) {
     EdgeMeta edge;
@@ -410,6 +409,7 @@ class DLL_PUBLIC Pipeline {
   inline void AddToOpSpecs(const std::string &inst_name, const OpSpec &spec, int logical_id);
 
   int GetNextLogicalId();
+  int GetNextInternalLogicalId();
 
   const int MAX_SEEDS = 1024;
 
@@ -423,6 +423,7 @@ class DLL_PUBLIC Pipeline {
   int max_num_stream_;
   int default_cuda_stream_priority_;
   int next_logical_id_ = 0;
+  int next_internal_logical_id_ = -1;
   QueueSizes prefetch_queue_depth_;
 
   std::vector<int64_t> seed_;


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
*Pick one*
- It fixes a bug with deserialization of pipeline and logical id numbering.

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
Pipeline was serialized with assigned logical ids, but internal nodes like MakeContiguous are not serialized (but still get an id). When deserializing, there was collision between new ids for MakeContiguous and old id from serialized pipeline
 - What was changed, added, removed?
Now the internal nodes use independent numbering (with negative numbers).
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
CI
 - Were docs and examples updated, if necessary?
Error message was made verbose.

**JIRA Task**: [DALI-990]
