### PR TITLE
Extend external source operator capacity

### DIFF
--- a/dali/benchmark/resnet50_bench.cc
+++ b/dali/benchmark/resnet50_bench.cc
@@ -111,10 +111,12 @@ BENCHMARK_DEFINE_F(RN50, C2Pipe)(benchmark::State& st) { // NOLINT
   pipe.Outputs(&ws);
 
   while (st.KeepRunning()) {
+    pipe.SetExternalInput("raw_jpegs", data);
     if (st.iterations() == 1 && pipelined) {
       // We will start he processing for the next batch
       // immediately after issueing work to the gpu to
       // pipeline the cpu/copy/gpu work
+      pipe.SetExternalInput("raw_jpegs", data);
       pipe.RunCPU();
       pipe.RunGPU();
     }
@@ -244,10 +246,12 @@ BENCHMARK_DEFINE_F(RN50, HybridPipe)(benchmark::State& st) { // NOLINT
   pipe.Outputs(&ws);
 
   while (st.KeepRunning()) {
+    pipe.SetExternalInput("raw_jpegs", data);
     if (st.iterations() == 1 && pipelined) {
       // We will start he processing for the next batch
       // immediately after issueing work to the gpu to
       // pipeline the cpu/copy/gpu work
+      pipe.SetExternalInput("raw_jpegs", data);
       pipe.RunCPU();
       pipe.RunGPU();
     }
@@ -355,10 +359,12 @@ BENCHMARK_DEFINE_F(RN50, nvJPEGPipe)(benchmark::State& st) { // NOLINT
   pipe.Outputs(&ws);
 
   while (st.KeepRunning()) {
+    pipe.SetExternalInput("raw_jpegs", data);
     if (st.iterations() == 1 && pipelined) {
       // We will start he processing for the next batch
       // immediately after issueing work to the gpu to
       // pipeline the cpu/copy/gpu work
+      pipe.SetExternalInput("raw_jpegs", data);
       pipe.RunCPU();
       pipe.RunGPU();
     }

--- a/dali/benchmark/resnet50_bench.py
+++ b/dali/benchmark/resnet50_bench.py
@@ -53,7 +53,6 @@ class C2Pipe(Pipeline):
         self.uniform = ops.Uniform(range = (0., 1.))
         self.resize_uniform = ops.Uniform(range = (256., 480.))
         self.mirror = ops.CoinFlip(probability = 0.5)
-        self.iter = 0
 
     def define_graph(self):
         self.jpegs = self.input()
@@ -66,10 +65,8 @@ class C2Pipe(Pipeline):
         return output
 
     def iter_setup(self):
-        if self.iter == 0:
-            raw_data = make_batch(self.batch_size)
-            self.feed_input(self.jpegs, raw_data)
-            self.iter += 1
+        raw_data = make_batch(self.batch_size)
+        self.feed_input(self.jpegs, raw_data)
 
 class HybridPipe(Pipeline):
     def __init__(self, batch_size, num_threads, device_id, pipelined = True, exec_async = True):
@@ -92,7 +89,6 @@ class HybridPipe(Pipeline):
         self.uniform = ops.Uniform(range = (0., 1.))
         self.resize_uniform = ops.Uniform(range = (256., 480.))
         self.mirror = ops.CoinFlip(probability = 0.5)
-        self.iter = 0
 
     def define_graph(self):
         self.jpegs = self.input()
@@ -104,10 +100,8 @@ class HybridPipe(Pipeline):
         return output
 
     def iter_setup(self):
-        if self.iter == 0:
-            raw_data = make_batch(self.batch_size)
-            self.feed_input(self.jpegs, raw_data)
-            self.iter += 1
+        raw_data = make_batch(self.batch_size)
+        self.feed_input(self.jpegs, raw_data)
 
 def run_benchmarks(PipeType, args):
     print("Running Benchmarks For {}".format(PipeType.__name__))

--- a/dali/pipeline/executor/executor_test.cc
+++ b/dali/pipeline/executor/executor_test.cc
@@ -348,6 +348,7 @@ TYPED_TEST(ExecutorTest, DISABLED_TestDataSetup) {
   graph.AddOp(this->PrepareSpec(
           OpSpec("ExternalSource")
           .AddArg("device", "cpu")
+          .AddArg("device_id", 0)
           .AddOutput("data1", "cpu")), "");
 
   graph.AddOp(this->PrepareSpec(
@@ -404,6 +405,7 @@ TYPED_TEST(ExecutorTest, TestRunBasicGraph) {
   graph.AddOp(this->PrepareSpec(
           OpSpec("ExternalSource")
           .AddArg("device", "cpu")
+          .AddArg("device_id", 0)
           .AddOutput("data", "cpu")), "");
 
   graph.AddOp(this->PrepareSpec(
@@ -449,6 +451,7 @@ TYPED_TEST(ExecutorTest, TestRunBasicGraphWithCB) {
   graph.AddOp(this->PrepareSpec(
           OpSpec("ExternalSource")
           .AddArg("device", "cpu")
+          .AddArg("device_id", 0)
           .AddOutput("data", "cpu")), "");
 
   graph.AddOp(this->PrepareSpec(
@@ -510,6 +513,7 @@ TYPED_TEST(ExecutorSyncTest, TestPrefetchedExecution) {
   graph.AddOp(this->PrepareSpec(
           OpSpec("ExternalSource")
           .AddArg("device", "cpu")
+          .AddArg("device_id", 0)
           .AddOutput("data", "cpu")), "");
 
   graph.AddOp(this->PrepareSpec(

--- a/dali/pipeline/operators/operator.h
+++ b/dali/pipeline/operators/operator.h
@@ -270,7 +270,7 @@ class Operator<CPUBackend> : public OperatorBase {
    * @brief Legacy implementation of CPU operator using per-sample approach
    *
    * Usage of this API is deprecated. For CPU Ops `void RunImpl(HostWorkspace &ws)`
-   * should be overrided instead.
+   * should be overridden instead.
    */
   virtual void RunImpl(SampleWorkspace &ws) {}
 

--- a/dali/pipeline/operators/util/external_source.cu
+++ b/dali/pipeline/operators/util/external_source.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,56 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <utility>
+#include <memory>
+#include <list>
+
 #include "dali/pipeline/operators/util/external_source.h"
 
 namespace dali {
 
+template <>
+struct ExternalSource<GPUBackend>::RecycleFunctor {
+  RecycleFunctor() = default;
+  RecycleFunctor(const RecycleFunctor &) {
+    assert(!"Should never happen");
+  }
+  RecycleFunctor(RecycleFunctor &&) = default;
+
+  RecycleFunctor(
+      ExternalSource<GPUBackend> *owner,
+      std::list<uptr_cuda_event_type> event,
+      std::list<uptr_tl_type> ptr)
+  : owner(owner), event(std::move(event)), ptr(std::move(ptr)) {}
+
+  ExternalSource<GPUBackend> *owner;
+  std::list<uptr_cuda_event_type> event;
+  std::list<uptr_tl_type> ptr;
+  void operator()() {
+    owner->RecycleBuffer(ptr, &event);
+  }
+};
+
 template<>
 void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
-  DALI_ENFORCE(data_in_tl_, "Cannot feed non-contiguous data to GPU op.");
+  std::list<uptr_tl_type> data;
+  std::list<uptr_cuda_event_type> cuda_event;
+  {
+    std::unique_lock<std::mutex> busy_lock(busy_m_);
+    cv_.wait(busy_lock, [&data = data_in_tl_]{return !data.empty();});
+    auto is_data_in_tl = data_in_tl_.front();
+    data_in_tl_.pop_front();
+    DALI_ENFORCE(is_data_in_tl, "Cannot feed non-contiguous data to GPU op.");
+    data = tl_data_.PopFront();
+    cuda_event = cuda_events_.GetEmpty();
+  }
 
   auto &output = ws.Output<GPUBackend>(0);
-  output.Copy(tl_data_, (ws.has_stream() ? ws.stream() : 0));
-  {
-    std::lock_guard<std::mutex> busy_lock(busy_m_);
-    busy_ = false;
-  }
-  cv_.notify_all();
+  cudaStream_t stream_used = ws.has_stream() ? ws.stream() : 0;
+  output.Copy(*(data.front()), stream_used);
+  // record an event so Recycle can synchronize on it
+  cudaEventRecord(cuda_event.front()->event, stream_used);
+  sync_worker_.DoWork(RecycleFunctor{ this, std::move(cuda_event), std::move(data) });
 }
 
 DALI_REGISTER_OPERATOR(ExternalSource, ExternalSource<GPUBackend>, GPU);

--- a/dali/pipeline/operators/util/external_source.h
+++ b/dali/pipeline/operators/util/external_source.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,29 +18,120 @@
 #include <atomic>
 #include <string>
 #include <vector>
-#include <condition_variable>
+#include <memory>
+#include <list>
 #include <mutex>
+#include <condition_variable>
+#include <utility>
 
 #include "dali/pipeline/operators/operator.h"
+#include "dali/pipeline/util/worker_thread.h"
 
 namespace dali {
+
+namespace detail {
+
+struct CudaEventWrapper {
+  CudaEventWrapper() {
+    auto res = cudaEventCreate(&event);
+    if (res != cudaSuccess) {
+      DALI_WARN("Fatal error: " + to_string(res) + " in CudaEventWrapper()");
+      std::terminate();
+    }
+  }
+  ~CudaEventWrapper() {
+    auto res = cudaEventDestroy(event);
+    if (res != cudaSuccess) {
+      DALI_WARN("Fatal error:: " + to_string(res) + " in ~CudaEventWrapper()");
+      std::terminate();
+    }
+  }
+  cudaEvent_t event;
+};
+
+}  // namespace detail
+
+namespace detail {
+
+/**
+ * CachingList differs from std::List by the ability to recycle empty elements. When allocating memory
+ * is expensive it is better to store already allocated but no longer needed element in the list of the free
+ * elements, than to free the memory and allocate it again later. CachingList supports the following operations:
+ * - GetEmpty moves an empty element of type T, either allocate it or use one from the free list
+ * - PopFront moves the element from the front and removes it from the full list, the behavior
+ * is undefined when the list is empty
+ * - Recycle moves passed element to the free list
+ * - AddBack moves element to the full list
+ * - IsEmpty checks if the full list is empty
+ * All functions operate on one element list as transferring elements between list is a very low cost
+ * operation, which doesn't involve any memory allocation, while adding an element to the list requires
+ * allocation of the memory for the storage in the list.
+ */
+template <typename T>
+class CachingList {
+ public:
+  CachingList() = default;
+
+  bool IsEmpty() const {
+    return full_data_.empty();
+  }
+
+  std::list<T> PopFront() {
+    std::list<T> tmp;
+    tmp.splice(tmp.begin(), full_data_, full_data_.begin());
+    return tmp;
+  }
+
+  void Recycle(std::list<T> &elm) {
+    empty_data_.splice(empty_data_.end(), elm, elm.begin());
+  }
+
+  std::list<T> GetEmpty() {
+    std::list<T> tmp;
+    if (empty_data_.empty()) {
+      tmp.emplace_back(std::make_unique<typename T::element_type>());
+    } else {
+      tmp.splice(tmp.begin(), empty_data_, empty_data_.begin());
+    }
+    return tmp;
+  }
+
+  void AddBack(std::list<T> &elm) {
+    full_data_.splice(full_data_.end(), elm, elm.begin());
+  }
+
+ private:
+  std::list<T> full_data_;
+  std::list<T> empty_data_;
+};
+
+}  // namespace detail
 
 /**
  * @brief Provides in-graph access to data fed in from outside of dali.
  * For now, we do a copy from the passed in data into our data to avoid
  * potential scoping and data corruption issues.
+ * Please note, that it is not allowed to call this concurrently as it
+ * may mix the order of inputted data.
  */
 template <typename Backend>
 class ExternalSource : public Operator<Backend> {
+  using uptr_tl_type = std::unique_ptr<TensorList<CPUBackend>>;
+  using uptr_vt_type = std::unique_ptr<std::vector<Tensor<CPUBackend>>>;
+  using uptr_cuda_event_type = std::unique_ptr<detail::CudaEventWrapper>;
+
  public:
   inline explicit ExternalSource(const OpSpec &spec) :
     Operator<Backend>(spec),
-    samples_processed_(0),
-    busy_(false) {
+    sync_worker_(spec.GetArgument<int>("device_id"), false) {
     output_name_ = spec.Output(0);
+    sync_worker_.WaitForInit();
   }
 
-  inline ~ExternalSource() override = default;
+  inline ~ExternalSource() {
+    sync_worker_.ForceStop();
+    sync_worker_.Shutdown();
+  }
 
   inline string name() const override {
     return "ExternalSource (" + output_name_ + ")";
@@ -50,39 +141,53 @@ class ExternalSource : public Operator<Backend> {
    * @brief Sets the data that should be passed out of the op
    * on the next iteration.
    */
-  inline void SetDataSource(const TensorList<Backend> &tl) {
+  inline void SetDataSource(const TensorList<CPUBackend> &tl) {
     DALI_ENFORCE(OperatorBase::batch_size_ == static_cast<int>(tl.ntensor()),
       "Data list provided to ExternalSource needs to have batch_size length.");
     // Note: If we create a GPU source, we will need to figure
     // out what stream we want to do this copy in. CPU we can
     // pass anything as it is ignored.
-    std::unique_lock<std::mutex> lock(busy_m_);
-    cv_.wait(lock,  [this]{return !this->busy_;});
-    tl_data_.Copy(tl, 0);
-    data_in_tl_ = true;
-    busy_ = true;
+    std::list<uptr_tl_type> data;
+    {
+      std::lock_guard<std::mutex> busy_lock(busy_m_);
+      data = tl_data_.GetEmpty();
+    }
+
+    data.front()->Copy(tl, 0);
+    {
+      std::lock_guard<std::mutex> busy_lock(busy_m_);
+      tl_data_.AddBack(data);
+      data_in_tl_.push_back(true);
+    }
+    cv_.notify_one();
   }
 
   /**
    * @brief Sets the data that should be passed out of the op
    * on the next iteration.
    */
-  inline void SetDataSource(const vector<Tensor<Backend>> &t) {
+  inline void SetDataSource(const vector<Tensor<CPUBackend>> &t) {
     DALI_ENFORCE(OperatorBase::batch_size_ == static_cast<int>(t.size()),
       "Data list provided to ExternalSource needs to have batch_size length.");
     // Note: If we create a GPU source, we will need to figure
     // out what stream we want to do this copy in. CPU we can
     // pass anything as it is ignored.
-
-    std::unique_lock<std::mutex> lock(busy_m_);
-    cv_.wait(lock,  [this]{return !this->busy_;});
-
-    t_data_.resize(t.size());
-    for (size_t i = 0; i < t.size(); ++i) {
-      t_data_[i].Copy(t[i], 0);
+    std::list<uptr_vt_type> data;
+    {
+      std::lock_guard<std::mutex> busy_lock(busy_m_);
+      data = t_data_.GetEmpty();
     }
-    data_in_tl_ = false;
-    busy_ = true;
+
+    data.front()->resize(t.size());
+    for (size_t i = 0; i < t.size(); ++i) {
+      (*(data.front()))[i].Copy(t[i], 0);
+    }
+    {
+      std::lock_guard<std::mutex> busy_lock(busy_m_);
+      t_data_.AddBack(data);
+      data_in_tl_.push_back(false);
+    }
+    cv_.notify_one();
   }
 
   DISABLE_COPY_MOVE_ASSIGN(ExternalSource);
@@ -92,19 +197,42 @@ class ExternalSource : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> &ws) override;
+  void RunImpl(workspace_t<Backend> &ws) override;
+
+  void RecycleHelper(std::list<uptr_tl_type> &data) {
+    tl_data_.Recycle(data);
+  }
+
+  void RecycleHelper(std::list<uptr_vt_type> &data) {
+    t_data_.Recycle(data);
+  }
+
+  // pass cuda_event by pointer to allow default, nullptr value, with the
+  // reference it is not that easy
+  template<typename DataType>
+  void RecycleBuffer(DataType &data,
+                     std::list<uptr_cuda_event_type> *cuda_event = nullptr) {
+    if (cuda_event) {
+      cudaEventSynchronize(cuda_event->front()->event);
+    }
+    std::lock_guard<std::mutex> busy_lock(busy_m_);
+    RecycleHelper(data);
+    if (cuda_event) {
+      cuda_events_.Recycle(*cuda_event);
+    }
+  }
 
   string output_name_;
-  TensorList<Backend> tl_data_;
-  std::vector<Tensor<Backend>> t_data_;
-  bool data_in_tl_;
+  detail::CachingList<uptr_tl_type> tl_data_;
+  detail::CachingList<uptr_vt_type> t_data_;
+  detail::CachingList<uptr_cuda_event_type> cuda_events_;
+  std::list<bool> data_in_tl_;
+  struct RecycleFunctor;
 
-  int samples_processed_;
-
-  bool busy_;
-  std::condition_variable cv_;
   std::mutex busy_m_;
-  std::mutex samples_processed_m_;
+  std::condition_variable cv_;
+
+  WorkerThread sync_worker_;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/util/external_source_test.cc
+++ b/dali/pipeline/operators/util/external_source_test.cc
@@ -1,0 +1,339 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <utility>
+
+#include "dali/test/dali_test_decoder.h"
+#include "dali/pipeline/executor/async_pipelined_executor.h"
+#include "dali/pipeline/operators/util/external_source.h"
+
+namespace dali {
+
+template <typename LoopsCount>
+class ExternalSourceTest : public::testing::WithParamInterface<int>,
+                           public GenericDecoderTest<RGB> {
+ protected:
+  template <typename... T>
+  std::unique_ptr<AsyncPipelinedExecutor> GetExecutor(T&&... args) {
+    return std::make_unique<AsyncPipelinedExecutor>(std::forward<T>(args)...);
+  }
+
+  uint32_t GetImageLoadingFlags() const override {
+    return t_loadJPEGs + t_decodeJPEGs;
+  }
+
+  void SetUp() override {
+    DALISingleOpTest::SetUp();
+    set_batch_size(10);
+    vt_.resize(this->batch_size_);
+    fill_counter_ = 0;
+    check_counter_ = 0;
+  }
+
+  inline void set_batch_size(int size) { batch_size_ = size; }
+
+  inline OpSpec PrepareSpec(OpSpec spec) const {
+    spec.AddArg("batch_size", batch_size_)
+      .AddArg("num_threads", num_threads_);
+    return spec;
+  }
+
+  void BuildCPUGraph() {
+    graph_.AddOp(this->PrepareSpec(
+        OpSpec("ExternalSource")
+        .AddArg("device", "cpu")
+        .AddArg("device_id", 0)
+        .AddOutput("data", "cpu")), "");
+
+    graph_.AddOp(this->PrepareSpec(
+            OpSpec("MakeContiguous")
+            .AddArg("device", "mixed")
+            .AddInput("data", "cpu")
+            .AddOutput("final_images", "gpu")), "");
+  }
+
+  void BuildGPUGraph() {
+    graph_.AddOp(this->PrepareSpec(
+          OpSpec("ExternalSource")
+          .AddArg("device", "gpu")
+          .AddArg("device_id", 0)
+          .AddOutput("final_images", "gpu")), "");
+  }
+
+  ExternalSource<CPUBackend>* CreateCPUExe() {
+    exe_ = this->GetExecutor(this->batch_size_, this->num_threads_, 0, 1);
+    exe_->Init();
+    BuildCPUGraph();
+
+    vector<string> outputs = {"final_images_gpu"};
+    exe_->Build(&graph_, outputs);
+    return dynamic_cast<ExternalSource<CPUBackend> *>(graph_.Node(OpType::CPU, 0).op.get());
+  }
+
+  ExternalSource<GPUBackend>* CreateGPUExe() {
+    exe_ = this->GetExecutor(this->batch_size_, this->num_threads_, 0, 1);
+    exe_->Init();
+    this->BuildGPUGraph();
+
+    vector<string> outputs = {"final_images_gpu"};
+    exe_->Build(&graph_, outputs);
+    return dynamic_cast<ExternalSource<GPUBackend> *>(this->graph_.Node(OpType::GPU, 0).op.get());
+  }
+
+  template<typename T>
+  void FeedWithVector(T *src_op) {
+    for (int j = 0; j < this->batch_size_; ++j) {
+      auto &tensor = vt_[j];
+      tensor.set_type(TypeInfo::Create<int>());
+      tensor.Resize({10, 10});
+      auto data = tensor.template mutable_data<int>();
+      for (int i = 0; i < tensor.size(); ++i) {
+        data[i] = fill_counter_;
+      }
+       ++fill_counter_;
+    }
+    src_op->SetDataSource(vt_);
+  }
+
+  template<typename T>
+  void FeedWithList(T *src_op) {
+    tl_.set_type(TypeInfo::Create<int>());
+    kernels::TensorListShape<> shape = kernels::uniform_list_shape(this->batch_size_, {10, 10});
+    tl_.Resize(shape);
+    for (int j = 0; j < this->batch_size_; ++j) {
+      auto data = tl_.template mutable_tensor<int>(j);
+      for (int i = 0; i < volume(tl_.tensor_shape(j)); ++i) {
+        data[i] = fill_counter_;
+      }
+      ++fill_counter_;
+    }
+    src_op->SetDataSource(tl_);
+  }
+
+  void RunExe() {
+    exe_->RunCPU();
+    exe_->RunMixed();
+    exe_->RunGPU();
+  }
+
+  bool RunOutputs() {
+    DeviceWorkspace ws;
+    exe_->Outputs(&ws);
+    auto &tensor_gpu_list = ws.Output<GPUBackend>(0);
+    TensorList<CPUBackend> tensor_cpu_list;
+    tensor_cpu_list.Copy(tensor_gpu_list, (ws.has_stream() ? ws.stream() : 0));
+    cudaStreamSynchronize(ws.has_stream() ? ws.stream() : 0);
+
+    for (int j = 0; j < this->batch_size_; ++j) {
+      auto data = tensor_cpu_list.template mutable_tensor<int>(j);
+      for (int i = 0; i < volume(tensor_cpu_list.tensor_shape(j)); ++i) {
+        if (data[i] != check_counter_) {
+          return false;
+        }
+      }
+      ++check_counter_;
+    }
+    return true;
+  }
+
+  int batch_size_, num_threads_ = 1;
+  std::unique_ptr<AsyncPipelinedExecutor> exe_;
+  OpGraph graph_;
+  TensorList<CPUBackend> tl_;
+  std::vector<Tensor<CPUBackend>> vt_;
+  int fill_counter_;
+  int check_counter_;
+};
+
+template <int number_of_loops>
+struct FeedCount {
+  static const int loops = number_of_loops;
+};
+
+typedef ::testing::Types<FeedCount<1>,
+                         FeedCount<2>,
+                         FeedCount<4>,
+                         FeedCount<10>> NumLoops;
+TYPED_TEST_SUITE(ExternalSourceTest, NumLoops);
+
+TYPED_TEST(ExternalSourceTest, FeedThenConsume) {
+  auto *src_op = this->CreateCPUExe();
+  ASSERT_NE(src_op, nullptr);
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    this->FeedWithList(src_op);
+  }
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    this->RunExe();
+    EXPECT_TRUE(this->RunOutputs());
+  }
+}
+
+TYPED_TEST(ExternalSourceTest, Interleaved) {
+  auto *src_op = this->CreateCPUExe();
+  ASSERT_NE(src_op, nullptr);
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    this->FeedWithList(src_op);
+    this->RunExe();
+    EXPECT_TRUE(this->RunOutputs());
+  }
+}
+
+TYPED_TEST(ExternalSourceTest, InterleavedVector) {
+  auto *src_op = this->CreateCPUExe();
+  ASSERT_NE(src_op, nullptr);
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    this->FeedWithVector(src_op);
+    this->RunExe();
+    EXPECT_TRUE(this->RunOutputs());
+  }
+}
+
+TYPED_TEST(ExternalSourceTest, InterleavedGPU) {
+  auto *src_op = this->CreateCPUExe();
+  ASSERT_NE(src_op, nullptr);
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    this->FeedWithList(src_op);
+    this->RunExe();
+    EXPECT_TRUE(this->RunOutputs());
+  }
+}
+
+TYPED_TEST(ExternalSourceTest, FeedThenConsumeVector) {
+  auto *src_op = this->CreateCPUExe();
+  ASSERT_NE(src_op, nullptr);
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    this->FeedWithVector(src_op);
+  }
+
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    this->RunExe();
+    EXPECT_TRUE(this->RunOutputs());
+  }
+}
+
+TYPED_TEST(ExternalSourceTest, FeedThenConsumeGPU) {
+  auto *src_op = this->CreateGPUExe();
+  ASSERT_NE(src_op, nullptr);
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    this->FeedWithList(src_op);
+  }
+
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    this->RunExe();
+    EXPECT_TRUE(this->RunOutputs());
+  }
+}
+
+TYPED_TEST(ExternalSourceTest, FeedThenConsumeGPUVector) {
+  auto *src_op = this->CreateGPUExe();
+  ASSERT_NE(src_op, nullptr);
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    this->FeedWithVector(src_op);
+  }
+
+  this->RunExe();
+  EXPECT_ANY_THROW(this->RunOutputs());
+}
+
+TYPED_TEST(ExternalSourceTest, FeedThenConsumeMixed) {
+  auto *src_op = this->CreateCPUExe();
+  ASSERT_NE(src_op, nullptr);
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    if (i % 2 == 0) {
+      this->FeedWithVector(src_op);
+    } else {
+      this->FeedWithList(src_op);
+    }
+  }
+
+  for (int i = 0; i < TypeParam::loops; ++i) {
+    this->RunExe();
+    EXPECT_TRUE(this->RunOutputs());
+  }
+}
+
+TYPED_TEST(ExternalSourceTest, ConsumeOneThenFeeds) {
+  auto *src_op = this->CreateCPUExe();
+  ASSERT_NE(src_op, nullptr);
+  this->FeedWithList(src_op);
+
+  this->RunExe();
+  for (int i = 1; i < TypeParam::loops; ++i) {
+    this->FeedWithList(src_op);
+  }
+
+  EXPECT_TRUE(this->RunOutputs());
+  for (int i = 1; i < TypeParam::loops; ++i) {
+    this->RunExe();
+    EXPECT_TRUE(this->RunOutputs());
+  }
+}
+
+TYPED_TEST(ExternalSourceTest, ConsumeOneThenFeedsVector) {
+  auto *src_op = this->CreateCPUExe();
+  ASSERT_NE(src_op, nullptr);
+  this->FeedWithVector(src_op);
+
+  this->RunExe();
+  for (int i = 1; i < TypeParam::loops; ++i) {
+      this->FeedWithVector(src_op);
+  }
+
+  EXPECT_TRUE(this->RunOutputs());
+  for (int i = 1; i < TypeParam::loops; ++i) {
+    this->RunExe();
+    EXPECT_TRUE(this->RunOutputs());
+  }
+}
+
+TYPED_TEST(ExternalSourceTest, ConsumeOneThenFeedsMixed) {
+  auto *src_op = this->CreateCPUExe();
+  ASSERT_NE(src_op, nullptr);
+  this->FeedWithVector(src_op);
+
+  this->RunExe();
+  for (int i = 1; i < TypeParam::loops; ++i) {
+    if (i % 2 == 0) {
+      this->FeedWithVector(src_op);
+    } else {
+      this->FeedWithList(src_op);
+    }
+  }
+
+  EXPECT_TRUE(this->RunOutputs());
+  for (int i = 1; i < TypeParam::loops; ++i) {
+    this->RunExe();
+    EXPECT_TRUE(this->RunOutputs());
+  }
+}
+
+TYPED_TEST(ExternalSourceTest, ConsumeOneThenFeedsGPU) {
+  auto *src_op = this->CreateCPUExe();
+  ASSERT_NE(src_op, nullptr);
+  this->FeedWithList(src_op);
+
+  this->RunExe();
+  for (int i = 1; i < TypeParam::loops; ++i) {
+    this->FeedWithList(src_op);
+  }
+
+  EXPECT_TRUE(this->RunOutputs());
+  for (int i = 1; i < TypeParam::loops; ++i) {
+    this->RunExe();
+    EXPECT_TRUE(this->RunOutputs());
+  }
+}
+
+}  // namespace dali

--- a/dali/pipeline/util/backend2workspace_map.h
+++ b/dali/pipeline/util/backend2workspace_map.h
@@ -24,7 +24,7 @@
 namespace dali {
 
 /**
- * @brief Utility clas, which maps the type of workspace with
+ * @brief Utility class, which maps the type of workspace with
  * proper Backend
  */
 template <typename Backend>

--- a/dali/pipeline/util/worker_thread.h
+++ b/dali/pipeline/util/worker_thread.h
@@ -21,6 +21,7 @@
 #include <queue>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
@@ -103,7 +104,7 @@ class WorkerThread {
 
   inline void DoWork(Work work) {
     std::unique_lock<std::mutex> lock(mutex_);
-    work_queue_.push(work);
+    work_queue_.push(std::move(work));
     work_complete_ = false;
     cv_.notify_one();
   }
@@ -177,7 +178,7 @@ class WorkerThread {
         break;
       }
 
-      Work work = work_queue_.front();
+      Work work = std::move(work_queue_.front());
       work_queue_.pop();
       lock.unlock();
 


### PR DESCRIPTION
- makes external source to be able to hold more than one sample
  at the time so the user can feed more data ahead before it is consumed
  by RunCPU/RunGPU

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
-  makes external source to be able to hold more than one sample
  at the time so the user can feed more data ahead before it is consumed

#### What happened in this PR?
 - so far ExternalSource was able to keep only one piece of data and every try to provide it with more was waiting for pipeline to consume what is already there
 - adds queue with data to ExternalSource which caches already consumed tensors to avoid expensive allocations when new piece is provided
 - test is added, tested on CI

**JIRA TASK**: DALI-954