### PR TITLE
Refactor SliceFlipNormalizePermutePad kernel

### DIFF
--- a/dali/kernels/slice/slice_flip_normalize_permute_common.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_common.h
@@ -24,10 +24,10 @@
 namespace dali {
 namespace kernels {
 
-template <size_t Dims>
-struct SliceFlipNormalizePermuteArgs {
+template <size_t Dims, typename OutputType>
+struct SliceFlipNormalizePermutePadArgs {
   template <typename Shape>
-  explicit SliceFlipNormalizePermuteArgs(const Shape &_shape) {
+  explicit SliceFlipNormalizePermutePadArgs(const Shape &_shape) {
     for (size_t d = 0; d < Dims; d++) {
       anchor[d] = 0;
       shape[d] = _shape[d];
@@ -46,14 +46,14 @@ struct SliceFlipNormalizePermuteArgs {
   size_t normalization_index = 0;
   std::vector<float> mean;
   std::vector<float> inv_stddev;
+  OutputType padding_val = 0;
 };
 
 namespace detail {
 
-template <size_t Dims>
-struct SliceFlipNormalizePermuteProcessedArgs {
+template <size_t Dims, typename OutputType>
+struct SliceFlipNormalizePermutePadProcessedArgs {
   size_t input_offset;
-  std::array<int64_t, Dims> in_shape;
   std::array<int64_t, Dims> in_strides;
   std::array<int64_t, Dims> out_shape;
   std::array<int64_t, Dims> padded_out_shape;
@@ -61,6 +61,7 @@ struct SliceFlipNormalizePermuteProcessedArgs {
   std::vector<float> mean;
   std::vector<float> inv_stddev;
   size_t normalization_dim;
+  OutputType padding_val = 0;
 };
 
 template <size_t Dims, typename Container>
@@ -82,11 +83,11 @@ std::array<int64_t, Dims> inverse_permutation(const std::array<int64_t, Dims> &p
   return inv_perm;
 }
 
-template <size_t Dims, typename Shape>
-SliceFlipNormalizePermuteProcessedArgs<Dims> ProcessArgs(
-    const SliceFlipNormalizePermuteArgs<Dims> &args,
+template <size_t Dims, typename Shape, typename OutputType>
+SliceFlipNormalizePermutePadProcessedArgs<Dims, OutputType> ProcessArgs(
+    const SliceFlipNormalizePermutePadArgs<Dims, OutputType> &args,
     const Shape &in_shape) {
-  SliceFlipNormalizePermuteProcessedArgs<Dims> processed_args;
+  SliceFlipNormalizePermutePadProcessedArgs<Dims, OutputType> processed_args;
 
   processed_args.input_offset = 0;
   processed_args.in_strides = GetStrides<Dims>(in_shape);
@@ -95,6 +96,7 @@ SliceFlipNormalizePermuteProcessedArgs<Dims> ProcessArgs(
   processed_args.out_shape = detail::permute<Dims>(slice_shape, args.permuted_dims);
   processed_args.padded_out_shape =
     detail::permute<Dims>(args.padded_shape, args.permuted_dims);
+  processed_args.padding_val = args.padding_val;
   processed_args.out_strides = GetStrides<Dims>(processed_args.padded_out_shape);
 
   // Flip operation is implemented by manipulating the anchor and the sign of the input strides

--- a/dali/kernels/slice/slice_flip_normalize_permute_cpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_cpu.h
@@ -188,7 +188,7 @@ void SliceFlipNormalizePermute(OutputType *output, const InputType *input,
 template <typename OutputType, typename InputType, size_t Dims>
 class SliceFlipNormalizePermuteCPU {
  public:
-  using Args = SliceFlipNormalizePermuteArgs<Dims>;
+  using Args = SliceFlipNormalizePermutePadArgs<Dims, OutputType>;
 
   KernelRequirements Setup(KernelContext &context,
                            const InTensorCPU<InputType, Dims> &in,

--- a/dali/kernels/slice/slice_flip_normalize_permute_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_gpu.h
@@ -26,144 +26,27 @@
 #include "dali/kernels/common/copy.h"
 #include "dali/kernels/kernel.h"
 #include "dali/kernels/slice/slice_flip_normalize_permute_common.h"
-
+#include "dali/kernels/slice/slice_flip_normalize_permute_pad_cuda_impl.cuh"
 namespace dali {
 namespace kernels {
 
-namespace detail {
-
-template <size_t Dims>
-struct SampleDesc {
-  void *__restrict__ out;
-  const void *__restrict__ in;
-  DeviceArray<int64_t, Dims> in_strides;
-  DeviceArray<int64_t, Dims> out_strides;
-  DeviceArray<int64_t, Dims> out_shape;
-  DeviceArray<int64_t, Dims> padded_out_shape;
-};
-
-struct BlockDesc {
-  int sampleIdx;
-  size_t offset;
-  size_t size;
-};
-
-template <typename OutputType, typename InputType, unsigned Dims, bool should_normalize>
-__device__ inline void SliceFlipNormalizePermuteFunc(OutputType *__restrict__ out,
-                                                     const InputType *__restrict__ in,
-                                                     const int64_t *out_strides,
-                                                     const int64_t *in_strides,
-                                                     const int64_t *out_shape,
-                                                     const int64_t *padded_out_shape,
-                                                     bool should_zero_pad,
-                                                     unsigned norm_dim,
-                                                     const float *norm_add,
-                                                     const float *norm_mul,
-                                                     size_t offset, size_t block_end) {
-  if (Dims > 1 && !should_normalize &&
-      out_strides[Dims - 1] == in_strides[Dims - 1] &&
-      out_shape[Dims - 1] == padded_out_shape[Dims - 1]) {
-    const unsigned NextDims = Dims > 1 ? Dims - 1 : 1;
-    SliceFlipNormalizePermuteFunc<OutputType, InputType, NextDims, should_normalize>(
-        out, in, out_strides, in_strides, out_shape, padded_out_shape,
-        should_zero_pad, norm_dim, norm_add, norm_mul, offset, block_end);
-    return;
-  }
-
-  const bool innermost_is_dense = (out_strides[Dims-1] == 1);
-  for (; offset < block_end; offset += blockDim.x) {
-    size_t idx = offset;
-    size_t out_idx = offset;
-    size_t in_idx = 0;
-    unsigned norm_i = 0;
-    bool zero_pad = false;
-
-    for (unsigned d = 0; d < Dims; d++) {
-      unsigned out_stride = static_cast<unsigned>(out_strides[d]);
-      unsigned i_d;
-      if (d == Dims-1 && innermost_is_dense) {
-        i_d = idx;
-        idx = 0;
-      } else {
-        i_d = idx / out_stride;
-        idx %= out_stride;
-      }
-      if (zero_pad = (should_zero_pad && i_d >= out_shape[d]))
-        break;
-
-      if (d == norm_dim)
-        norm_i = i_d;
-
-      in_idx += i_d * in_strides[d];
-    }
-
-    if (zero_pad) {
-      out[out_idx] = 0;
-    } else {
-      in_idx += idx;  // remaining dims have equal strides
-      if (should_normalize) {
-        float fpout = fmaf(static_cast<float>(in[in_idx]), norm_mul[norm_i], norm_add[norm_i]);
-        if (std::is_integral<OutputType>::value) {
-          out[out_idx] = clamp<OutputType>(__float2int_rn(fpout));
-        } else {
-          out[out_idx] = clamp<OutputType>(fpout);
-        }
-      } else {
-        if (std::is_integral<OutputType>::value && std::is_floating_point<InputType>::value) {
-          out[out_idx] = clamp<OutputType>(__float2int_rn(in[in_idx]));
-        } else {
-          out[out_idx] = clamp<OutputType>(in[in_idx]);
-        }
-      }
-    }
-  }
-}
-
-template <typename OutputType, typename InputType, size_t Dims, bool should_normalize>
-__global__ void SliceFlipNormalizePermuteKernel(const SampleDesc<Dims> *samples,
-                                                const BlockDesc *blocks,
-                                                const float *norm_add,
-                                                const float *norm_mul,
-                                                unsigned normalization_dim) {
-  int sampleIdx = blocks[blockIdx.x].sampleIdx;
-  size_t offset = blocks[blockIdx.x].offset + threadIdx.x;
-  size_t block_end = blocks[blockIdx.x].offset + blocks[blockIdx.x].size;
-  auto &sample = samples[sampleIdx];
-  auto *out = static_cast<OutputType *>(sample.out);
-  auto *in = static_cast<const InputType *>(sample.in);
-
-  bool should_zero_pad = false;
-  for (size_t d = 0; d < Dims; d++) {
-    if (should_zero_pad = (sample.padded_out_shape[d] > sample.out_shape[d])) {
-      break;
-    }
-  }
-
-  SliceFlipNormalizePermuteFunc<OutputType, InputType, Dims, should_normalize>(
-    out, in, sample.out_strides.data(), sample.in_strides.data(),
-    sample.out_shape.data(), sample.padded_out_shape.data(),
-    should_zero_pad, normalization_dim, norm_add, norm_mul, offset, block_end);
-}
-
-}  // namespace detail
-
 template <typename OutputType, typename InputType, size_t Dims>
-class SliceFlipNormalizePermuteGPU {
+class SliceFlipNormalizePermutePadGPU {
  private:
   static constexpr size_t kBlockDim = 512;
   static constexpr size_t kBlockSize = 64 * kBlockDim;
   size_t block_count_ = 0;
 
  public:
-  using Args = SliceFlipNormalizePermuteArgs<Dims>;
+  using Args = SliceFlipNormalizePermutePadArgs<Dims, OutputType>;
   KernelRequirements Setup(KernelContext &context,
                            const InListGPU<InputType, Dims> &in,
                            const std::vector<Args> &args) {
     KernelRequirements req;
     ScratchpadEstimator se;
     const size_t num_samples = in.size();
-    se.add<detail::SampleDesc<Dims>>(AllocType::Host, num_samples);
-    se.add<detail::SampleDesc<Dims>>(AllocType::GPU, num_samples);
+    se.add<detail::SampleDesc<Dims, OutputType>>(AllocType::Host, num_samples);
+    se.add<detail::SampleDesc<Dims, OutputType>>(AllocType::GPU, num_samples);
 
     DALI_ENFORCE(args[0].mean.size() == args[0].inv_stddev.size());
     size_t norm_args_size = args[0].mean.size();
@@ -205,8 +88,9 @@ class SliceFlipNormalizePermuteGPU {
     auto inv_stddev_data = args[0].inv_stddev;
     DALI_ENFORCE(mean_data.size() == inv_stddev_data.size());
 
-    detail::SampleDesc<Dims>* sample_descs_cpu =
-      context.scratchpad->Allocate<detail::SampleDesc<Dims>>(AllocType::Host, num_samples);
+    detail::SampleDesc<Dims, OutputType>* sample_descs_cpu =
+      context.scratchpad->Allocate<detail::SampleDesc<Dims, OutputType>>(AllocType::Host,
+                                                                         num_samples);
     float *norm_add_cpu = mean_data.empty() ? nullptr :
       context.scratchpad->Allocate<float>(AllocType::Host, mean_data.size());
     float *norm_mul_cpu = inv_stddev_data.empty() ? nullptr :
@@ -233,6 +117,7 @@ class SliceFlipNormalizePermuteGPU {
       sample_desc.out_strides = processed_args.out_strides;
       sample_desc.out_shape = processed_args.out_shape;
       sample_desc.padded_out_shape = processed_args.padded_out_shape;
+      sample_desc.padding_val = processed_args.padding_val;
       sample_desc.in = in.tensor_data(i) + processed_args.input_offset;
       sample_desc.out = out.tensor_data(i);
       sample_sizes[i] = volume(processed_args.padded_out_shape);
@@ -250,8 +135,8 @@ class SliceFlipNormalizePermuteGPU {
       }
     }
 
-    detail::SampleDesc<Dims> *sample_descs =
-      context.scratchpad->Allocate<detail::SampleDesc<Dims>>(
+    detail::SampleDesc<Dims, OutputType> *sample_descs =
+      context.scratchpad->Allocate<detail::SampleDesc<Dims, OutputType>>(
         AllocType::GPU, num_samples);
 
     float *norm_add = mean_data.empty() ? nullptr :
@@ -267,7 +152,7 @@ class SliceFlipNormalizePermuteGPU {
         AllocType::GPU, block_count_);
 
     // Memory is allocated contiguously, so we launch only one cudaMemcpyAsync
-    size_t total_bytes = num_samples * sizeof(detail::SampleDesc<Dims>)
+    size_t total_bytes = num_samples * sizeof(detail::SampleDesc<Dims, OutputType>)
       + mean_data.size() * sizeof(float)
       + inv_stddev_data.size() * sizeof(float)
       + block_count_ * sizeof(detail::BlockDesc);
@@ -278,11 +163,11 @@ class SliceFlipNormalizePermuteGPU {
 
     const auto grid = block_count_;
     if (norm_add != nullptr && norm_mul != nullptr) {
-      detail::SliceFlipNormalizePermuteKernel<OutputType, InputType, Dims, true>
+      detail::SliceFlipNormalizePermutePadKernel<OutputType, InputType, Dims, true>
           <<<grid, kBlockDim, 0, context.gpu.stream>>>(sample_descs, block_descs, norm_add,
                                                        norm_mul, normalization_dim);
     } else {
-      detail::SliceFlipNormalizePermuteKernel<OutputType, InputType, Dims, false>
+      detail::SliceFlipNormalizePermutePadKernel<OutputType, InputType, Dims, false>
           <<<grid, kBlockDim, 0, context.gpu.stream>>>(sample_descs, block_descs, norm_add,
                                                        norm_mul, normalization_dim);
     }

--- a/dali/kernels/slice/slice_flip_normalize_permute_gpu_test.cu
+++ b/dali/kernels/slice/slice_flip_normalize_permute_gpu_test.cu
@@ -15,7 +15,7 @@
 #include <gtest/gtest.h>
 #include "dali/kernels/scratch.h"
 #include "dali/kernels/slice/slice_kernel_test.h"
-#include "dali/kernels/slice/slice_flip_normalize_permute_gpu.cuh"
+#include "dali/kernels/slice/slice_flip_normalize_permute_gpu.h"
 #include "dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h"
 
 namespace dali {
@@ -30,7 +30,7 @@ class SliceFlipNormalizePermuteGPUTest : public SliceFlipNormalizePermuteTest<Te
   static constexpr size_t NumSamples = TestArgs::NumSamples;
   static constexpr size_t DimSize = TestArgs::DimSize;
   using ArgsGenerator = typename TestArgs::ArgsGenerator;
-  using KernelType = SliceFlipNormalizePermuteGPU<OutputType, InputType, Dims>;
+  using KernelType = SliceFlipNormalizePermutePadGPU<OutputType, InputType, Dims>;
 
   void Run() override {
     KernelContext ctx;

--- a/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
@@ -35,7 +35,7 @@ class SliceFlipNormalizePermuteTest : public ::testing::Test {
   static constexpr size_t DimSize0 = TestArgs::DimSize0;
   static constexpr size_t DimSize1 = TestArgs::DimSize1;
   using ArgsGenerator = typename TestArgs::ArgsGenerator;
-  using KernelArgs = SliceFlipNormalizePermuteArgs<Dims>;
+  using KernelArgs = SliceFlipNormalizePermutePadArgs<Dims, OutputType>;
 
   void PrepareData(TestTensorList<InputType, Dims>& test_data) {
     std::vector<int> sample_dims(Dims, DimSize);
@@ -145,30 +145,30 @@ class SliceFlipNormalizePermuteTest : public ::testing::Test {
 
 template <typename OutputType, size_t Dims>
 struct SliceFlipNormPermArgsGen_CopyOnly {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
-    SliceFlipNormalizePermuteArgs<Dims> args(input_shape);
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(input_shape);
     return args;
   }
 };
 
 template <typename OutputType, size_t Dims>
 struct SliceFlipNormPermArgsGen_SliceOnly {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
     auto shape = input_shape;
     shape[0] /= 2;
     shape[1] /= 2;
-    SliceFlipNormalizePermuteArgs<Dims> args(shape);
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(shape);
     return args;
   }
 };
 
 template <typename OutputType, size_t Dims>
 struct SliceFlipNormPermArgsGen_SliceOnly_WithAnchor {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
     auto shape = input_shape;
     shape[0] = input_shape[0]/2;
     shape[1] = input_shape[0]/2;
-    SliceFlipNormalizePermuteArgs<Dims> args(shape);
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(shape);
     args.anchor[0] = input_shape[0]/2;
     args.anchor[1] = input_shape[1]/2;
     return args;
@@ -177,8 +177,8 @@ struct SliceFlipNormPermArgsGen_SliceOnly_WithAnchor {
 
 template <typename OutputType, size_t Dims>
 struct SliceFlipNormPermArgsGen_FlipHW {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
-    SliceFlipNormalizePermuteArgs<Dims> args(input_shape);
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(input_shape);
     // assuming last dims are HWC, flip H and W
     args.flip[Dims-2] = true;
     args.flip[Dims-3] = true;
@@ -188,8 +188,8 @@ struct SliceFlipNormPermArgsGen_FlipHW {
 
 template <typename OutputType, size_t Dims, size_t FlipDim>
 struct SliceFlipNormPermArgsGen_FlipDim {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
-    SliceFlipNormalizePermuteArgs<Dims> args(input_shape);
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(input_shape);
     args.flip[FlipDim] = true;
     return args;
   }
@@ -197,8 +197,8 @@ struct SliceFlipNormPermArgsGen_FlipDim {
 
 template <typename OutputType, size_t Dims>
 struct SliceFlipNormPermArgsGen_NormalizeOnly {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
-    SliceFlipNormalizePermuteArgs<Dims> args(input_shape);
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(input_shape);
     args.mean.resize(args.shape[Dims-1]);
     args.inv_stddev.resize(args.shape[Dims-1]);
     for (int i = 0; i < args.shape[Dims-1]; i++) {
@@ -211,8 +211,8 @@ struct SliceFlipNormPermArgsGen_NormalizeOnly {
 
 template <typename OutputType, size_t Dims>
 struct SliceFlipNormPermArgsGen_NormalizeOnly_Scalar {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
-    SliceFlipNormalizePermuteArgs<Dims> args(input_shape);
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(input_shape);
     args.mean = { 3.5f };
     args.inv_stddev = { 1.f / 8.0f };
     return args;
@@ -221,8 +221,8 @@ struct SliceFlipNormPermArgsGen_NormalizeOnly_Scalar {
 
 template <typename OutputType, size_t Dims, size_t FlipDim>
 struct SliceFlipNormPermArgsGen_NormalizeAndFlipDim {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
-    SliceFlipNormalizePermuteArgs<Dims> args(input_shape);
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(input_shape);
     args.flip[FlipDim] = true;
     args.mean.resize(args.shape[Dims-1], 3.5f);
     args.inv_stddev.resize(args.shape[Dims-1], 1.0/3.5f);
@@ -233,8 +233,8 @@ struct SliceFlipNormPermArgsGen_NormalizeAndFlipDim {
 
 template <typename OutputType, size_t Dims>
 struct SliceFlipNormPermArgsGen_PermuteOnly_ReversedDims {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
-    SliceFlipNormalizePermuteArgs<Dims> args(input_shape);
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(input_shape);
     for (size_t d = 0; d < Dims; d++) {
       args.permuted_dims[d] = Dims-1-d;
     }
@@ -244,8 +244,8 @@ struct SliceFlipNormPermArgsGen_PermuteOnly_ReversedDims {
 
 template <typename OutputType, size_t Dims>
 struct SliceFlipNormPermArgsGen_PermuteAndSliceHalf_ReversedDims {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
-    SliceFlipNormalizePermuteArgs<Dims> args(input_shape);
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(input_shape);
     for (size_t d = 0; d < Dims; d++) {
       args.anchor[d] = input_shape[d]/4;
       args.shape[d] = args.padded_shape[d] = input_shape[d]/2;
@@ -257,8 +257,8 @@ struct SliceFlipNormPermArgsGen_PermuteAndSliceHalf_ReversedDims {
 
 template <typename OutputType, size_t Dims>
 struct SliceFlipNormPermArgsGen_PermuteAndSliceHalf_PermuteHW {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
-    SliceFlipNormalizePermuteArgs<Dims> args(input_shape);
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(input_shape);
     for (size_t d = 0; d < Dims; d++) {
       args.anchor[d] = input_shape[d]/4;
       args.shape[d] = args.padded_shape[d] = input_shape[d]/2;
@@ -280,8 +280,8 @@ struct SliceFlipNormPermArgsGen_PermuteAndSliceHalf_PermuteHW {
 
 template <typename OutputType, size_t Dims>
 struct SliceFlipNormPermArgsGen_SliceFlipNormalizePermute_PermuteHWC2CHW {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
-    SliceFlipNormalizePermuteArgs<Dims> args(input_shape);
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(input_shape);
     for (size_t d = 0; d < Dims; d++) {
       args.anchor[d] = d == 0 || d == 1 ?
         input_shape[d]/2 : 0;
@@ -311,8 +311,8 @@ struct SliceFlipNormPermArgsGen_SliceFlipNormalizePermute_PermuteHWC2CHW {
 
 template <typename OutputType, size_t Dims, size_t PaddedDim, size_t PadSize>
 struct SliceFlipNormPermArgsGen_OnlyPad_GivenDim {
-  SliceFlipNormalizePermuteArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
-    SliceFlipNormalizePermuteArgs<Dims> args(input_shape);
+  SliceFlipNormalizePermutePadArgs<Dims, OutputType> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(input_shape);
     args.padded_shape[PaddedDim] += PadSize;
     return args;
   }

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_cuda_impl.cuh
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_cuda_impl.cuh
@@ -1,0 +1,157 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_KERNEL_H_
+#define DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_KERNEL_H_
+
+#include <cuda_runtime.h>
+#include <utility>
+#include <vector>
+#include "dali/core/common.h"
+#include "dali/core/convert.h"
+#include "dali/core/cuda_error.h"
+#include "dali/core/dev_array.h"
+#include "dali/core/error_handling.h"
+#include "dali/kernels/common/copy.h"
+#include "dali/kernels/kernel.h"
+#include "dali/kernels/slice/slice_flip_normalize_permute_common.h"
+
+
+namespace dali {
+namespace kernels {
+
+namespace detail {
+
+template <size_t Dims, typename OutputType>
+struct SampleDesc {
+  void *__restrict__ out;
+  const void *__restrict__ in;
+  DeviceArray<int64_t, Dims> in_strides;
+  DeviceArray<int64_t, Dims> out_strides;
+  DeviceArray<int64_t, Dims> out_shape;
+  DeviceArray<int64_t, Dims> padded_out_shape;
+  OutputType padding_val;
+};
+
+struct BlockDesc {
+  int sampleIdx;
+  size_t offset;
+  size_t size;
+};
+
+template <typename OutputType, typename InputType, unsigned Dims, bool should_normalize>
+__device__ inline void SliceFlipNormalizePermutePadFunc(OutputType *__restrict__ out,
+                                                        const InputType *__restrict__ in,
+                                                        const int64_t *out_strides,
+                                                        const int64_t *in_strides,
+                                                        const int64_t *out_shape,
+                                                        const int64_t *padded_out_shape,
+                                                        bool should_pad,
+                                                        unsigned norm_dim,
+                                                        const float *norm_add,
+                                                        const float *norm_mul,
+                                                        OutputType padding_val,
+                                                        size_t offset, size_t block_end) {
+  if (Dims > 1 && !should_normalize &&
+      out_strides[Dims - 1] == in_strides[Dims - 1] &&
+      out_shape[Dims - 1] == padded_out_shape[Dims - 1]) {
+    const unsigned NextDims = Dims > 1 ? Dims - 1 : 1;
+    SliceFlipNormalizePermutePadFunc<OutputType, InputType, NextDims, should_normalize>(
+        out, in, out_strides, in_strides, out_shape, padded_out_shape,
+        should_pad, norm_dim, norm_add, norm_mul, padding_val, offset, block_end);
+    return;
+  }
+
+  const bool innermost_is_dense = (out_strides[Dims-1] == 1);
+  for (; offset < block_end; offset += blockDim.x) {
+    size_t idx = offset;
+    size_t out_idx = offset;
+    size_t in_idx = 0;
+    unsigned norm_i = 0;
+    bool pad = false;
+
+    for (unsigned d = 0; d < Dims; d++) {
+      unsigned out_stride = static_cast<unsigned>(out_strides[d]);
+      unsigned i_d;
+      if (d == Dims-1 && innermost_is_dense) {
+        i_d = idx;
+        idx = 0;
+      } else {
+        i_d = idx / out_stride;
+        idx %= out_stride;
+      }
+      if (pad = (should_pad && i_d >= out_shape[d]))
+        break;
+
+      if (d == norm_dim)
+        norm_i = i_d;
+
+      in_idx += i_d * in_strides[d];
+    }
+
+    if (pad) {
+      out[out_idx] = padding_val;
+    } else {
+      in_idx += idx;  // remaining dims have equal strides
+      if (should_normalize) {
+        float fpout = fmaf(static_cast<float>(in[in_idx]), norm_mul[norm_i], norm_add[norm_i]);
+        if (std::is_integral<OutputType>::value) {
+          out[out_idx] = clamp<OutputType>(__float2int_rn(fpout));
+        } else {
+          out[out_idx] = clamp<OutputType>(fpout);
+        }
+      } else {
+        if (std::is_integral<OutputType>::value && std::is_floating_point<InputType>::value) {
+          out[out_idx] = clamp<OutputType>(__float2int_rn(in[in_idx]));
+        } else {
+          out[out_idx] = clamp<OutputType>(in[in_idx]);
+        }
+      }
+    }
+  }
+}
+
+template <typename OutputType, typename InputType, size_t Dims, bool should_normalize>
+__global__ void SliceFlipNormalizePermutePadKernel(const SampleDesc<Dims, OutputType> *samples,
+                                                   const BlockDesc *blocks,
+                                                   const float *norm_add,
+                                                   const float *norm_mul,
+                                                   unsigned normalization_dim) {
+  int sampleIdx = blocks[blockIdx.x].sampleIdx;
+  size_t offset = blocks[blockIdx.x].offset + threadIdx.x;
+  size_t block_end = blocks[blockIdx.x].offset + blocks[blockIdx.x].size;
+  auto &sample = samples[sampleIdx];
+  auto *out = static_cast<OutputType *>(sample.out);
+  auto *in = static_cast<const InputType *>(sample.in);
+
+  bool should_pad = false;
+  for (size_t d = 0; d < Dims; d++) {
+    if (should_pad = (sample.padded_out_shape[d] > sample.out_shape[d])) {
+      break;
+    }
+  }
+
+  SliceFlipNormalizePermutePadFunc<OutputType, InputType, Dims, should_normalize>(
+    out, in, sample.out_strides.data(), sample.in_strides.data(),
+    sample.out_shape.data(), sample.padded_out_shape.data(),
+    should_pad, normalization_dim, norm_add, norm_mul,
+    sample.padding_val, offset, block_end);
+}
+
+}  // namespace detail
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_SLICE_SLICE_FLIP_NORMALIZE_PERMUTE_KERNEL_H_

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cc
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cc
@@ -74,7 +74,7 @@ void RunHelper(Tensor<CPUBackend> &output,
   VALUE_SWITCH(number_of_dims, Dims, (3, 4), (
     auto in_view = view<const InputType, Dims>(input);
 
-    kernels::SliceFlipNormalizePermuteArgs<Dims> args(slice_shape);
+    kernels::SliceFlipNormalizePermutePadArgs<Dims, OutputType> args(slice_shape);
     for (std::size_t d = 0; d < Dims; d++) {
       args.anchor[d] = slice_anchor[d];
     }

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cu
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cu
@@ -15,7 +15,7 @@
 #include <utility>
 #include <vector>
 #include "dali/pipeline/operators/fused/crop_mirror_normalize.h"
-#include "dali/kernels/slice/slice_flip_normalize_permute_gpu.cuh"
+#include "dali/kernels/slice/slice_flip_normalize_permute_gpu.h"
 #include "dali/core/static_switch.h"
 #include "dali/pipeline/data/views.h"
 
@@ -38,12 +38,12 @@ void RunHelper(TensorList<GPUBackend> &output,
                kernels::ScratchpadAllocator &scratch_alloc) {
   std::size_t number_of_dims = input.tensor_shape(0).size();
   VALUE_SWITCH(number_of_dims, NumDims, (3, 4), (
-    kernels::SliceFlipNormalizePermuteGPU<OutputType, InputType, NumDims> kernel;
+    kernels::SliceFlipNormalizePermutePadGPU<OutputType, InputType, NumDims> kernel;
     kernels::KernelContext ctx;
     ctx.gpu.stream = stream;
     auto in_view = view<const InputType, NumDims>(input);
 
-    std::vector<kernels::SliceFlipNormalizePermuteArgs<NumDims>> per_sample_args;
+    std::vector<kernels::SliceFlipNormalizePermutePadArgs<NumDims, OutputType>> per_sample_args;
     per_sample_args.reserve(slice_anchors.size());
     for (std::size_t i = 0; i < slice_anchors.size(); i++) {
       per_sample_args.emplace_back(slice_shapes[i]);


### PR DESCRIPTION
Signed-off-by: Serge Panev <spanev@nvidia.com>
#### Why we need this PR?
- It adds new feature needed because we need it for the `Pad` operator.

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
The existing slice kernel is doing what is needed by the upcoming `Pad` operator: copy the input tensor to a tensor with bigger dims (with bigger strides). Add a per sample `padding_val` argument and factor the kernel out. 
 - What was changed, added, removed?
`SliceFlipNormalizePermutePad` factored out
New arg: padding_value
 - What is most important part that reviewers should focus on?
The addition of the `padding_val` arg.
 - Was this PR tested? How?
Tested by the existing tests.