### PR TITLE
Add `default_cuda_stream_priority` documentation

### DIFF
--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -68,9 +68,12 @@ class DLL_PUBLIC Pipeline {
    * @param batch_size the size of the batch that should be produced.
    * @param num_threads the number of threads to use in the prefetch stage.
    * @param device_id id of the GPU to operate on.
-   * @param whether to allocate the necessary buffers to pipeline execution
+   * @param seed used for random number generation. Leaving the default value
+   * for this parameter results in random seed
+   * @param pipelined_execution whether to allocate the necessary buffers for pipeline execution
    * between the cpu and gpu portions of the graph. See PipelinedExecutor.
-   * @param whether to use extra host-threads to enable asynchronous issue
+   * @param prefetch_queue_depth sets the length of the executor internal pipeline
+   * @param async_execution whether to use extra host-threads to enable asynchronous execution
    * of cpu and gpu work. See AsyncExecutor/AsyncPipelinedExecutor.
    * @param bytes_per_sample_hint Estimated size of each sample to be processed.
    * Defaults to 0.
@@ -78,7 +81,8 @@ class DLL_PUBLIC Pipeline {
    * configured in the thread pool. Defaults to 'false'.
    * @param max_num_stream set an upper limit on the number of cudaStreams
    * that can be allocated by the pipeline.
-   * @param prefetch_queue_depth sets the length of the executor internal pipeline
+   * @param default_cuda_stream_priority  CUDA stream priority used by DALI.
+   * See `cudaStreamCreateWithPriority` in CUDA documentation
    */
   DLL_PUBLIC inline Pipeline(int batch_size, int num_threads, int device_id, int64_t seed = -1,
                              bool pipelined_execution = true, int prefetch_queue_depth = 2,

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -49,6 +49,19 @@ class Pipeline(object):
         Whether to execute the pipeline in a way that enables
         overlapping CPU and GPU computation, typically resulting
         in faster execution speed, but larger memory consumption.
+    `prefetch_queue_depth` : int or {"cpu_size": int, "gpu_size": int}, optional, default = 2
+        Depth of the executor pipeline. Deeper pipeline makes DALI
+        more resistant to uneven execution time of each batch, but it
+        also consumes more memory for internal buffers.
+        Specifying a dict:
+        ``{ "cpu_size": x, "gpu_size": y }``
+        instead of an integer will cause the pipeline to use separated
+        queues executor, with buffer queue size `x` for cpu stage
+        and `y` for mixed and gpu stages. It is not supported when both `exec_async`
+        and `exec_pipelined` are set to `False`.
+        Executor will buffer cpu and gpu stages separatelly,
+        and will fill the buffer queues when the first :meth:`nvidia.dali.pipeline.Pipeline.run`
+        is issued.
     `exec_async` : bool, optional, default = True
         Whether to execute the pipeline asynchronously.
         This makes :meth:`nvidia.dali.pipeline.Pipeline.run` method
@@ -65,19 +78,8 @@ class Pipeline(object):
         Value of -1 does not impose a limit.
         This parameter is currently unused (and behavior of
         unrestricted number of streams is assumed).
-    `prefetch_queue_depth` : int or {"cpu_size": int, "gpu_size": int}, optional, default = 2
-        Depth of the executor pipeline. Deeper pipeline makes DALI
-        more resistant to uneven execution time of each batch, but it
-        also consumes more memory for internal buffers.
-        Specifying a dict:
-        ``{ "cpu_size": x, "gpu_size": y }``
-        instead of integer will cause the pipeline to use separated
-        queues executor, with buffer queue size `x` for cpu stage
-        and `y` for mixed and gpu stages. It is not supported when both `exec_async`
-        and `exec_pipelined` are set to `False`.
-        Executor will buffer cpu and gpu stages separatelly,
-        and will fill the buffer queues when the first :meth:`nvidia.dali.pipeline.Pipeline.run`
-        is issued.
+    `default_cuda_stream_priority` : int, optional, default = 0
+        CUDA stream priority used by DALI. See `cudaStreamCreateWithPriority` in CUDA documentation
     """
     def __init__(self, batch_size = -1, num_threads = -1, device_id = -1, seed = -1,
                  exec_pipelined=True, prefetch_queue_depth=2,


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- Adds `default_cuda_stream_priority` parameter documentation documentation

#### What happened in this PR?
 - `default_cuda_stream_priority` parameter pipeline argument was not documented
 - updated only docs string in python and doxygen one in `pipeline.h`

**JIRA TASK**: NA