### PR TITLE
Adjust CropMirrorNormalize to Setup API

### DIFF
--- a/dali/kernels/slice/slice_flip_normalize_permute_common.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_common.h
@@ -26,6 +26,8 @@ namespace kernels {
 
 template <size_t Dims>
 struct SliceFlipNormalizePermutePadArgs {
+  SliceFlipNormalizePermutePadArgs() = default;
+
   template <typename Shape>
   explicit SliceFlipNormalizePermutePadArgs(const Shape &_shape) {
     for (size_t d = 0; d < Dims; d++) {

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -148,6 +148,26 @@ class TensorVector {
     return type_;
   }
 
+  inline void SetLayout(DALITensorLayout layout) {
+    if (state_ == State::noncontiguous) {
+      DALI_ENFORCE(!tensors_.empty(), "Layout cannot be set uniformly for empty batch");
+    }
+    tl_->SetLayout(layout);
+    for (auto t : tensors_) {
+      t->SetLayout(layout);
+    }
+  }
+
+  inline DALITensorLayout GetLayout() const {
+    if (state_ == State::contiguous) {
+      return tl_->GetLayout();
+    }
+    if (tensors_.size() > 0) {
+      return tensors_[0]->GetLayout();
+    }
+    return DALITensorLayout::DALI_UNKNOWN;
+  }
+
   inline void set_pinned(bool pinned) {
     // Store the value, in case we pin empty vector and later call Resize
     pinned_ = pinned;

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cc
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cc
@@ -56,92 +56,82 @@ normalization only.
 
 DALI_REGISTER_OPERATOR(CropMirrorNormalize, CropMirrorNormalize<CPUBackend>, CPU);
 
-namespace detail {
-
-template <typename OutputType, typename InputType>
-void RunHelper(Tensor<CPUBackend> &output,
-               const Tensor<CPUBackend> &input,
-               const std::vector<int64_t> &slice_anchor,
-               const std::vector<int64_t> &slice_shape,
-               bool horizontal_flip,
-               bool pad_output,
-               const std::vector<float> &mean,
-               const std::vector<float> &inv_std_dev) {
-  std::size_t number_of_dims = input.shape().size();
-  auto input_layout = input.GetLayout();
-  auto output_layout = output.GetLayout();
-  VALUE_SWITCH(number_of_dims, Dims, (3, 4), (
-    auto in_view = view<const InputType, Dims>(input);
-
-    kernels::SliceFlipNormalizePermutePadArgs<Dims> args(slice_shape);
-    for (std::size_t d = 0; d < Dims; d++) {
-      args.anchor[d] = slice_anchor[d];
-    }
-
-    if (pad_output) {
-      args.padded_shape[channels_dim(input_layout)] = 4;
-    }
-
-    if (horizontal_flip) {
-      args.flip[horizontal_dim_idx(input_layout)] = true;
-    }
-
-    // Check if permutation is needed
-    if (input_layout != output_layout) {
-      args.permuted_dims = permuted_dims<Dims>(input_layout, output_layout);
-    }
-
-    const bool should_normalize =
-         !std::all_of(mean.begin(), mean.end(), [](float x){ return x == 0.0f; })
-      || !std::all_of(inv_std_dev.begin(), inv_std_dev.end(), [](float x){ return x == 1.0f; });
-    if (should_normalize) {
-      args.mean = mean;
-      args.inv_stddev = inv_std_dev;
-      args.normalization_dim = channels_dim(input_layout);
-    }
-
-    kernels::SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims> kernel;
-    kernels::KernelContext ctx;
-    kernels::KernelRequirements req = kernel.Setup(ctx, in_view, args);
-
-    output.set_type(TypeInfo::Create<OutputType>());
-    output.SetLayout(input.GetLayout());
-    output.Resize(req.output_shapes[0][0].shape.to_vector());
-
-    auto out_view = view<OutputType, Dims>(output);
-    kernel.Run(ctx, out_view, in_view, args);
-  ), // NOLINT
+template <>
+void CropMirrorNormalize<CPUBackend>::PrepareArgs(const HostWorkspace &ws,
+                                                  std::size_t number_of_dims, int data_idx) {
+  VALUE_SWITCH(number_of_dims, Dims, (3, 4),
   (
-    DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims));
-  )); // NOLINT
+    using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
+    // We won't change the underlying type after the first allocation
+    if (!kernel_sample_args_.has_value()) {
+      kernel_sample_args_ = std::vector<Args>(batch_size_);
+    }
+    auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
+    kernel_sample_args[data_idx] = detail::GetKernelArgs<Dims>(
+        input_layout_, output_layout_, slice_anchors_[data_idx], slice_shapes_[data_idx],
+        mirror_[data_idx], pad_output_, mean_vec_, inv_std_vec_);
+    // NOLINTNEXTLINE(whitespace/parens)
+  ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
 }
 
-}  // namespace detail
-
 template <>
-void CropMirrorNormalize<CPUBackend>::DataDependentSetup(SampleWorkspace &ws) {
-  const auto &input = ws.Input<CPUBackend>(0);
-  SetupSample(ws.data_idx(), input_layout_, input.shape());
-  mirror_[ws.data_idx()] = spec_.GetArgument<int>("mirror", &ws, ws.data_idx());
+bool CropMirrorNormalize<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
+                                                const HostWorkspace &ws) {
+  output_desc.resize(1);
+  SetupAndInitialize(ws);
+  const auto &input = ws.InputRef<CPUBackend>(0);
+  auto &output = ws.OutputRef<CPUBackend>(0);
+  std::size_t number_of_dims = input.shape().sample_dim();
+  DALI_TYPE_SWITCH_WITH_FP16_CPU(input_type_, InputType,
+    DALI_TYPE_SWITCH_WITH_FP16_CPU(output_type_, OutputType,
+      VALUE_SWITCH(number_of_dims, Dims, (3, 4),
+      (
+        using Kernel = kernels::SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims>;
+        using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
+        output_desc[0].type = TypeInfo::Create<OutputType>();
+        output_desc[0].shape.resize(batch_size_, Dims);
+        kmgr_.Initialize<Kernel>();
+        // Do the kernel setup
+        auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
+        for (int sample_idx = 0; sample_idx < batch_size_; sample_idx++) {
+          auto in_view = view<const InputType, Dims>(input[sample_idx]);
+          kernels::KernelContext ctx;
+          auto &req = kmgr_.Setup<Kernel>(sample_idx, ctx, in_view, kernel_sample_args[sample_idx]);
+          output_desc[0].shape.set_tensor_shape(sample_idx, req.output_shapes[0][0].shape);
+        }
+        // NOLINTNEXTLINE(whitespace/parens)
+      ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
+    )
+  );  // NOLINT(whitespace/parens)
 
-  auto &output = ws.Output<CPUBackend>(0);
-  output.SetLayout(output_layout_);
+  return true;
 }
 
 template <>
 void CropMirrorNormalize<CPUBackend>::RunImpl(SampleWorkspace &ws) {
-  this->DataDependentSetup(ws);
   const auto &input = ws.Input<CPUBackend>(0);
   auto &output = ws.Output<CPUBackend>(0);
   auto data_idx = ws.data_idx();
+  auto sample_idx = data_idx;
+  std::size_t number_of_dims = input.shape().sample_dim();
 
   DALI_TYPE_SWITCH_WITH_FP16_CPU(input_type_, InputType,
     DALI_TYPE_SWITCH_WITH_FP16_CPU(output_type_, OutputType,
-      detail::RunHelper<OutputType, InputType>(
-        output, input, slice_anchors_[data_idx], slice_shapes_[data_idx],
-        mirror_[data_idx], pad_output_, mean_vec_, inv_std_vec_);
+      VALUE_SWITCH(number_of_dims, Dims, (3, 4),
+      (
+        using Kernel = kernels::SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims>;
+        using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
+        auto &kernel = kmgr_.Get<Kernel>(sample_idx);
+        auto in_view = view<const InputType, Dims>(input);
+        auto out_view = view<OutputType, Dims>(output);
+        auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
+        auto &args = kernel_sample_args[sample_idx];
+        kernels::KernelContext ctx;
+        kmgr_.Run<Kernel>(ws.thread_idx(), sample_idx, ctx, out_view, in_view, args);
+        // NOLINTNEXTLINE(whitespace/parens)
+      ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
     )
-  )
+  );  // NOLINT(whitespace/parens)
 }
 
 }  // namespace dali

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cu
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cu
@@ -22,24 +22,6 @@
 namespace dali {
 
 template <>
-void CropMirrorNormalize<GPUBackend>::PrepareArgs(const DeviceWorkspace &ws,
-                                                  std::size_t number_of_dims, int data_idx) {
-  VALUE_SWITCH(number_of_dims, Dims, (3, 4),
-  (
-    using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
-    // We won't change the underlying type after the first allocation
-    if (!kernel_sample_args_.has_value()) {
-      kernel_sample_args_ = std::vector<Args>(batch_size_);
-    }
-    auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
-    kernel_sample_args[data_idx] = detail::GetKernelArgs<Dims>(
-        input_layout_, output_layout_, slice_anchors_[data_idx], slice_shapes_[data_idx],
-        mirror_[data_idx], pad_output_, mean_vec_, inv_std_vec_);
-        // NOLINTNEXTLINE(whitespace/parens)
-  ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
-}
-
-template <>
 bool CropMirrorNormalize<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
                                                 const DeviceWorkspace &ws) {
   output_desc.resize(1);

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cu
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cu
@@ -21,104 +21,75 @@
 
 namespace dali {
 
-namespace detail {
-
-template <typename OutputType, typename InputType>
-void RunHelper(TensorList<GPUBackend> &output,
-               const TensorList<GPUBackend> &input,
-               const std::vector<std::vector<int64_t>>& slice_anchors,
-               const std::vector<std::vector<int64_t>>& slice_shapes,
-               const std::vector<int> &horizontal_flip,
-               bool pad_output,
-               const std::vector<float> &mean,
-               const std::vector<float> &inv_std_dev,
-               DALITensorLayout input_layout,
-               DALITensorLayout output_layout,
-               cudaStream_t stream,
-               kernels::ScratchpadAllocator &scratch_alloc) {
-  std::size_t number_of_dims = input.tensor_shape(0).size();
-  VALUE_SWITCH(number_of_dims, NumDims, (3, 4), (
-    kernels::SliceFlipNormalizePermutePadGPU<OutputType, InputType, NumDims> kernel;
-    kernels::KernelContext ctx;
-    ctx.gpu.stream = stream;
-    auto in_view = view<const InputType, NumDims>(input);
-
-    std::vector<kernels::SliceFlipNormalizePermutePadArgs<NumDims>> per_sample_args;
-    per_sample_args.reserve(slice_anchors.size());
-    for (std::size_t i = 0; i < slice_anchors.size(); i++) {
-      per_sample_args.emplace_back(slice_shapes[i]);
-      auto &args = per_sample_args[i];
-      const auto& slice_anchor = slice_anchors[i];
-      for (std::size_t d = 0; d < NumDims; d++) {
-        args.anchor[d] = slice_anchor[d];
-      }
-
-      if (horizontal_flip[i]) {
-        args.flip[horizontal_dim_idx(input_layout)] = true;
-      }
-
-      if (pad_output) {
-        args.padded_shape[channels_dim(input_layout)] = 4;
-      }
-
-      if (input_layout != output_layout) {
-        args.permuted_dims = permuted_dims<NumDims>(input_layout, output_layout);
-      }
-
-      const bool should_normalize =
-         !std::all_of(mean.begin(), mean.end(), [](float x){ return x == 0.0f; })
-      || !std::all_of(inv_std_dev.begin(), inv_std_dev.end(), [](float x){ return x == 1.0f; });
-      if (should_normalize) {
-        args.mean = mean;
-        args.inv_stddev = inv_std_dev;
-        args.normalization_dim = channels_dim(input_layout);
-      }
-    }
-
-    kernels::KernelRequirements req = kernel.Setup(ctx, in_view, per_sample_args);
-
-    output.set_type(TypeInfo::Create<OutputType>());
-    output.SetLayout(input_layout);
-    output.Resize(req.output_shapes[0]);
-
-    scratch_alloc.Reserve(req.scratch_sizes);
-    auto scratchpad = scratch_alloc.GetScratchpad();
-    ctx.scratchpad = &scratchpad;
-
-    auto out_view = view<OutputType, NumDims>(output);
-    kernel.Run(ctx, out_view, in_view, per_sample_args);
-  ),  // NOLINT
+template <>
+void CropMirrorNormalize<GPUBackend>::PrepareArgs(const DeviceWorkspace &ws,
+                                                  std::size_t number_of_dims, int data_idx) {
+  VALUE_SWITCH(number_of_dims, Dims, (3, 4),
   (
-    DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims));
-  ));  // NOLINT
+    using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
+    // We won't change the underlying type after the first allocation
+    if (!kernel_sample_args_.has_value()) {
+      kernel_sample_args_ = std::vector<Args>(batch_size_);
+    }
+    auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
+    kernel_sample_args[data_idx] = detail::GetKernelArgs<Dims>(
+        input_layout_, output_layout_, slice_anchors_[data_idx], slice_shapes_[data_idx],
+        mirror_[data_idx], pad_output_, mean_vec_, inv_std_vec_);
+        // NOLINTNEXTLINE(whitespace/parens)
+  ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
 }
 
-}  // namespace detail
-
 template <>
-void CropMirrorNormalize<GPUBackend>::DataDependentSetup(DeviceWorkspace &ws) {
+bool CropMirrorNormalize<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
+                                                const DeviceWorkspace &ws) {
+  output_desc.resize(1);
+  SetupAndInitialize(ws);
   const auto &input = ws.Input<GPUBackend>(0);
-  for (int sample_idx = 0; sample_idx < batch_size_; sample_idx++) {
-    SetupSample(sample_idx, input_layout_, input.tensor_shape(sample_idx));
-    mirror_[sample_idx] = spec_.GetArgument<int>("mirror", &ws, sample_idx);
-  }
-  auto &output = ws.Output<GPUBackend>(0);
-  output.SetLayout(output_layout_);
+  auto &output = ws.OutputRef<GPUBackend>(0);
+  std::size_t number_of_dims = input.shape().sample_dim();
+  DALI_TYPE_SWITCH_WITH_FP16_GPU(input_type_, InputType,
+    DALI_TYPE_SWITCH_WITH_FP16_GPU(output_type_, OutputType,
+      VALUE_SWITCH(number_of_dims, Dims, (3, 4),
+      (
+        using Kernel = kernels::SliceFlipNormalizePermutePadGPU<OutputType, InputType, Dims>;
+        using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
+        auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
+        output_desc[0].type = TypeInfo::Create<OutputType>();
+        output_desc[0].shape.resize(batch_size_, Dims);
+        kmgr_.Initialize<Kernel>();
+
+        kernels::KernelContext ctx;
+        ctx.gpu.stream = ws.stream();
+        auto in_view = view<const InputType, Dims>(input);
+        auto &req = kmgr_.Setup<Kernel>(0, ctx, in_view, kernel_sample_args);
+        output_desc[0].shape = req.output_shapes[0];
+        // NOLINTNEXTLINE(whitespace/parens)
+      ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
+    )
+  );  // NOLINT(whitespace/parens)
+  return true;
 }
 
 template<>
 void CropMirrorNormalize<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
-  this->DataDependentSetup(ws);
   const auto &input = ws.Input<GPUBackend>(0);
   auto &output = ws.Output<GPUBackend>(0);
 
+  std::size_t number_of_dims = input.shape().sample_dim();
   DALI_TYPE_SWITCH_WITH_FP16_GPU(input_type_, InputType,
     DALI_TYPE_SWITCH_WITH_FP16_GPU(output_type_, OutputType,
-      detail::RunHelper<OutputType, InputType>(
-        output, input, slice_anchors_, slice_shapes_,
-        mirror_, pad_output_, mean_vec_, inv_std_vec_,
-        input_layout_, output_layout_,
-        ws.stream(), scratch_alloc_);
+      VALUE_SWITCH(number_of_dims, Dims, (3, 4),
+      (
+        using Kernel = kernels::SliceFlipNormalizePermutePadGPU<OutputType, InputType, Dims>;
+        using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
+        auto in_view = view<const InputType, Dims>(input);
+        auto out_view = view<OutputType, Dims>(output);
+        kernels::KernelContext ctx;
+        ctx.gpu.stream = ws.stream();
+        auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
+        kmgr_.Run<Kernel>(0, 0, ctx, out_view, in_view, kernel_sample_args);
+        // NOLINTNEXTLINE(whitespace/parens)
+      ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
     )
   )
 }

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -19,143 +19,18 @@
 #include <utility>
 #include <vector>
 
+#include "dali/core/any.h"
 #include "dali/core/common.h"
-#include "dali/pipeline/operators/common.h"
 #include "dali/core/error_handling.h"
-#include "dali/pipeline/operators/operator.h"
-#include "dali/pipeline/operators/crop/crop_attr.h"
+#include "dali/core/static_switch.h"
+#include "dali/kernels/kernel_manager.h"
 #include "dali/kernels/scratch.h"
+#include "dali/kernels/slice/slice_flip_normalize_permute_common.h"
+#include "dali/pipeline/operators/common.h"
+#include "dali/pipeline/operators/crop/crop_attr.h"
+#include "dali/pipeline/operators/operator.h"
 
 namespace dali {
-
-template <typename Backend>
-class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
- public:
-  explicit inline CropMirrorNormalize(const OpSpec &spec)
-      : Operator<Backend>(spec),
-        CropAttr(spec),
-        output_type_(spec.GetArgument<DALIDataType>("output_dtype")),
-        output_layout_(spec.GetArgument<DALITensorLayout>("output_layout")),
-        pad_output_(spec.GetArgument<bool>("pad_output")),
-        slice_anchors_(batch_size_),
-        slice_shapes_(batch_size_),
-        mirror_(batch_size_) {
-    if (!spec.TryGetRepeatedArgument(mean_vec_, "mean")) {
-      mean_vec_ = { spec.GetArgument<float>("mean") };
-    }
-
-    if (!spec.TryGetRepeatedArgument(inv_std_vec_, "std")) {
-      inv_std_vec_ = { spec.GetArgument<float>("std") };
-    }
-
-    // Inverse the std-deviation
-    for (auto &element : inv_std_vec_) {
-      element = 1.f / element;
-    }
-  }
-
-  inline ~CropMirrorNormalize() override = default;
-
- protected:
-  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
-    return false;
-  }
-
-  void RunImpl(Workspace<Backend> &ws) override;
-
-  void SetupSharedSampleParams(Workspace<Backend> &ws) override {
-    const auto &input = ws.template Input<Backend>(0);
-    input_type_ = input.type().id();
-    if (output_type_ == DALI_NO_TYPE)
-      output_type_ = input_type_;
-
-    input_layout_ = input.GetLayout();
-    DALI_ENFORCE(input_layout_ == DALI_NHWC || input_layout_ == DALI_NCHW ||
-                 input_layout_ == DALI_NFHWC || input_layout_ == DALI_NFCHW,
-      "Unexpected data layout");
-    if (output_layout_ == DALI_SAME)
-      output_layout_ = input_layout_;
-
-    CropAttr::ProcessArguments(ws);
-  }
-
-  void DataDependentSetup(Workspace<Backend> &ws);
-
-  void SetupSample(int data_idx, DALITensorLayout layout, const kernels::TensorShape<> &shape) {
-    Index F = 1, H, W, C;
-    DALI_ENFORCE(shape.size() == 3 || shape.size() == 4,
-      "Unexpected number of dimensions: " + std::to_string(shape.size()));
-    switch (layout) {
-      case DALI_NHWC:
-        std::tie(H, W, C) = std::make_tuple(shape[0], shape[1], shape[2]);
-        break;
-      case DALI_NCHW:
-        std::tie(C, H, W) = std::make_tuple(shape[0], shape[1], shape[2]);
-        break;
-      case DALI_NFHWC:
-        std::tie(F, H, W, C) = std::make_tuple(shape[0], shape[1], shape[2], shape[3]);
-        break;
-      case DALI_NFCHW:
-        std::tie(F, C, H, W) = std::make_tuple(shape[0], shape[1], shape[2], shape[3]);
-        break;
-      default:
-        DALI_FAIL("Not supported layout");
-    }
-
-    const bool is_whole_image = IsWholeImage();
-    int crop_h = is_whole_image ? H : crop_height_[data_idx];
-    int crop_w = is_whole_image ? W : crop_width_[data_idx];
-    auto crop_pos_y_x = CalculateCropYX(crop_y_norm_[data_idx], crop_x_norm_[data_idx],
-                                        crop_h, crop_w, H, W);
-
-    int64_t crop_y, crop_x;
-    std::tie(crop_y, crop_x) = crop_pos_y_x;
-
-    switch (layout) {
-      case DALI_NHWC:
-        slice_anchors_[data_idx] = {crop_y, crop_x, 0};
-        slice_shapes_[data_idx] = {crop_h, crop_w, C};
-        break;
-      case DALI_NCHW:
-        slice_anchors_[data_idx] = {0, crop_y, crop_x};
-        slice_shapes_[data_idx] = {C, crop_h, crop_w};
-        break;
-      case DALI_NFHWC:
-        slice_anchors_[data_idx] = {0, crop_y, crop_x, 0};
-        slice_shapes_[data_idx] = {F, crop_h, crop_w, C};
-        break;
-      case DALI_NFCHW:
-        slice_anchors_[data_idx] = {0, 0, crop_y, crop_x};
-        slice_shapes_[data_idx] = {F, C, crop_h, crop_w};
-        break;
-      default:
-        DALI_FAIL("Not supported layout");
-    }
-  }
-
-  DALIDataType input_type_ = DALI_NO_TYPE;
-  DALIDataType output_type_ = DALI_NO_TYPE;
-
-  DALITensorLayout input_layout_ = DALI_NHWC;
-  DALITensorLayout output_layout_ = DALI_SAME;
-
-  // Whether to pad output to 4 channels
-  bool pad_output_;
-
-  std::vector<std::vector<int64_t>> slice_anchors_, slice_shapes_;
-
-  std::vector<float> mean_vec_, inv_std_vec_;
-  std::vector<int> mirror_;
-
-  // In current implementation scratchpad memory is only used in the GPU kernel
-  // In case of using scratchpad in the CPU kernel a scratchpad allocator per thread
-  // should be instantiated
-  std::conditional_t<std::is_same<Backend, GPUBackend>::value,
-    kernels::ScratchpadAllocator,
-    std::vector<kernels::ScratchpadAllocator>> scratch_alloc_;
-
-  USE_OPERATOR_MEMBERS();
-};
 
 namespace detail {
 
@@ -223,7 +98,197 @@ inline size_t channels_dim(DALITensorLayout in_layout) {
   }
 }
 
+// Rewrite Operator data as arguments for kernel
+// TODO(klecki): It probably could be written directly in that format
+template <size_t Dims>
+kernels::SliceFlipNormalizePermutePadArgs<Dims> GetKernelArgs(
+    DALITensorLayout input_layout, DALITensorLayout output_layout,
+    const std::vector<int64_t> &slice_anchor, const std::vector<int64_t> &slice_shape,
+    bool horizontal_flip, bool pad_output, const std::vector<float> &mean,
+    const std::vector<float> &inv_std_dev) {
+  kernels::SliceFlipNormalizePermutePadArgs<Dims> args(slice_shape);
+
+  for (std::size_t d = 0; d < Dims; d++) {
+    args.anchor[d] = slice_anchor[d];
+  }
+
+  if (pad_output) {
+    args.padded_shape[channels_dim(input_layout)] = 4;
+  }
+
+  if (horizontal_flip) {
+    args.flip[horizontal_dim_idx(input_layout)] = true;
+  }
+
+  // Check if permutation is needed
+  if (input_layout != output_layout) {
+    args.permuted_dims = permuted_dims<Dims>(input_layout, output_layout);
+  }
+  const bool should_normalize =
+      !std::all_of(mean.begin(), mean.end(), [](float x) { return x == 0.0f; }) ||
+      !std::all_of(inv_std_dev.begin(), inv_std_dev.end(), [](float x) { return x == 1.0f; });
+  if (should_normalize) {
+    args.mean = mean;
+    args.inv_stddev = inv_std_dev;
+    args.normalization_dim = channels_dim(input_layout);
+  }
+
+  return args;
+}
+
 }  // namespace detail
+
+
+template <typename Backend>
+class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
+ public:
+  explicit inline CropMirrorNormalize(const OpSpec &spec)
+      : Operator<Backend>(spec),
+        CropAttr(spec),
+        output_type_(spec.GetArgument<DALIDataType>("output_dtype")),
+        output_layout_(spec.GetArgument<DALITensorLayout>("output_layout")),
+        pad_output_(spec.GetArgument<bool>("pad_output")),
+        slice_anchors_(batch_size_),
+        slice_shapes_(batch_size_),
+        mirror_(batch_size_) {
+    if (!spec.TryGetRepeatedArgument(mean_vec_, "mean")) {
+      mean_vec_ = { spec.GetArgument<float>("mean") };
+    }
+
+    if (!spec.TryGetRepeatedArgument(inv_std_vec_, "std")) {
+      inv_std_vec_ = { spec.GetArgument<float>("std") };
+    }
+
+    // Inverse the std-deviation
+    for (auto &element : inv_std_vec_) {
+      element = 1.f / element;
+    }
+    if (std::is_same<Backend, GPUBackend>::value) {
+      kmgr_.Resize(1, 1);
+    } else {
+      kmgr_.Resize(num_threads_, batch_size_);
+    }
+  }
+
+  inline ~CropMirrorNormalize() override = default;
+
+ protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override;
+
+  void RunImpl(Workspace<Backend> &ws) override;
+
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
+    // We are fortunate enough that we need to use different type switch on different device
+  void PrepareArgs(const workspace_t<Backend> &ws, std::size_t number_of_dims, int data_idx);
+
+
+  // Propagate input -> output type and layout
+  // Gather the CropAttr (obtain arguments from Spec/ArgumentWorkspace)
+  void SetupAndInitialize(const workspace_t<Backend> &ws) {
+    const auto &input = ws.template InputRef<Backend>(0);
+    input_type_ = input.type().id();
+    if (output_type_ == DALI_NO_TYPE)
+      output_type_ = input_type_;
+
+    input_layout_ = input.GetLayout();
+    DALI_ENFORCE(input_layout_ == DALI_NHWC || input_layout_ == DALI_NCHW ||
+                 input_layout_ == DALI_NFHWC || input_layout_ == DALI_NFCHW,
+      "Unexpected data layout");
+    if (output_layout_ == DALI_SAME)
+      output_layout_ = input_layout_;
+
+    CropAttr::ProcessArguments(ws);
+
+    const auto &in_shape = input.shape();  // This can be a copy
+    std::size_t number_of_dims = in_shape.sample_dim();
+
+    // Set internal info for each sample based on CropAttr
+    for (int data_idx = 0; data_idx < batch_size_; data_idx++) {
+      mirror_[data_idx] = spec_.template GetArgument<int>("mirror", &ws, data_idx);
+      SetupSample(data_idx, input_layout_, in_shape.tensor_shape(data_idx));
+      PrepareArgs(ws, number_of_dims, data_idx);
+    }
+
+    auto &output = ws.template OutputRef<Backend>(0);
+    output.SetLayout(output_layout_);
+  }
+
+  // Calculate slice window and anchor for given data_idx
+  void SetupSample(int data_idx, DALITensorLayout layout, const kernels::TensorShape<> &shape) {
+    Index F = 1, H, W, C;
+    DALI_ENFORCE(shape.size() == 3 || shape.size() == 4,
+      "Unexpected number of dimensions: " + std::to_string(shape.size()));
+    switch (layout) {
+      case DALI_NHWC:
+        std::tie(H, W, C) = std::make_tuple(shape[0], shape[1], shape[2]);
+        break;
+      case DALI_NCHW:
+        std::tie(C, H, W) = std::make_tuple(shape[0], shape[1], shape[2]);
+        break;
+      case DALI_NFHWC:
+        std::tie(F, H, W, C) = std::make_tuple(shape[0], shape[1], shape[2], shape[3]);
+        break;
+      case DALI_NFCHW:
+        std::tie(F, C, H, W) = std::make_tuple(shape[0], shape[1], shape[2], shape[3]);
+        break;
+      default:
+        DALI_FAIL("Not supported layout");
+    }
+
+    const bool is_whole_image = IsWholeImage();
+    int crop_h = is_whole_image ? H : crop_height_[data_idx];
+    int crop_w = is_whole_image ? W : crop_width_[data_idx];
+    auto crop_pos_y_x = CalculateCropYX(crop_y_norm_[data_idx], crop_x_norm_[data_idx],
+                                        crop_h, crop_w, H, W);
+
+    int64_t crop_y, crop_x;
+    std::tie(crop_y, crop_x) = crop_pos_y_x;
+
+    switch (layout) {
+      case DALI_NHWC:
+        slice_anchors_[data_idx] = {crop_y, crop_x, 0};
+        slice_shapes_[data_idx] = {crop_h, crop_w, C};
+        break;
+      case DALI_NCHW:
+        slice_anchors_[data_idx] = {0, crop_y, crop_x};
+        slice_shapes_[data_idx] = {C, crop_h, crop_w};
+        break;
+      case DALI_NFHWC:
+        slice_anchors_[data_idx] = {0, crop_y, crop_x, 0};
+        slice_shapes_[data_idx] = {F, crop_h, crop_w, C};
+        break;
+      case DALI_NFCHW:
+        slice_anchors_[data_idx] = {0, 0, crop_y, crop_x};
+        slice_shapes_[data_idx] = {F, C, crop_h, crop_w};
+        break;
+      default:
+        DALI_FAIL("Not supported layout");
+    }
+  }
+
+  DALIDataType input_type_ = DALI_NO_TYPE;
+  DALIDataType output_type_ = DALI_NO_TYPE;
+
+  DALITensorLayout input_layout_ = DALI_NHWC;
+  DALITensorLayout output_layout_ = DALI_SAME;
+
+  // Whether to pad output to 4 channels
+  bool pad_output_;
+
+  std::vector<std::vector<int64_t>> slice_anchors_, slice_shapes_;
+
+  std::vector<float> mean_vec_, inv_std_vec_;
+  std::vector<int> mirror_;
+
+  kernels::KernelManager kmgr_;
+  any kernel_sample_args_;
+
+  USE_OPERATOR_MEMBERS();
+};
+
 
 
 }  // namespace dali


### PR DESCRIPTION
#### Why we need this PR
- Refactoring to adjust CMN to Operator::Setup

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
All state initialization of CMN Op was moved from RunImpl to SetupImpl, so the output size can be inferred before the Run.
Due to recent changes to SliceFlipNormalizePermutePadArgs we need to TypeSwitch the args over OutputType, and we have separate lists for CPU and GPU.
 - What was changed, added, removed?
Mostly moving the code around, removed the RunHelper - SetupImpl and RunImpl  call the Setup and Run of the kernel through kernel manager. 
 - What is most important part that reviewers should focus on?
Probably putting the kernel args behind any.
 - Was this PR tested? How?
CI
 - Were docs and examples updated, if necessary?
N/A

As a followup it would be worth to unify the operator storage and kernel arguments more so to reduce the copying of the data.

**JIRA TASK**: [DALI-835]