### PR TITLE
Provide default initialization for scratch sizes in KernelRequiements.

### DIFF
--- a/dali/kernels/kernel_req.h
+++ b/dali/kernels/kernel_req.h
@@ -29,7 +29,7 @@ namespace kernels {
 struct KernelRequirements {
   std::vector<TensorListShape<DynamicDimensions>> output_shapes;
 
-  std::array<size_t, (size_t)AllocType::Count> scratch_sizes;
+  std::array<size_t, (size_t)AllocType::Count> scratch_sizes = {};
 
   /// @param reuse_scratch  - if true, scratch size is taken to be maximum from that for
   ///                         all input sets, otherwise it's the sum
@@ -53,8 +53,6 @@ struct KernelRequirements {
 /// @brief A utility class for adding scratchpad requirements with proper alignment,
 ///        assuming bump allocation.
 struct ScratchpadEstimator {
-  ScratchpadEstimator() : sizes{} {}  // zero-fill
-
   /// @brief Adds a new memory requirement for count instances of T
   ///
   /// The method includes padding, assuming the add function is called in order of allocations.
@@ -74,7 +72,7 @@ struct ScratchpadEstimator {
     return sizes[(size_t)alloc_type];
   }
 
-  std::array<size_t, (size_t)AllocType::Count> sizes;
+  std::array<size_t, (size_t)AllocType::Count> sizes = {};
 };
 
 }  // namespace kernels

--- a/dali/kernels/test/scratch_test.cc
+++ b/dali/kernels/test/scratch_test.cc
@@ -45,6 +45,24 @@ void test_add(ScratchpadEstimator &E, AllocType type, size_t count, size_t align
   EXPECT_EQ(E.sizes[static_cast<int>(type)], base + count*sizeof(T));
 }
 
+TEST(Scratch, Estimator_Init) {
+  char data[sizeof(ScratchpadEstimator)];
+  memset(data, 0xCC, sizeof(data));
+  auto &se = *new (data) ScratchpadEstimator;
+  for (auto &s : se.sizes)
+    EXPECT_EQ(s, 0) << "Initial scratchpad estimation should be 0";
+  se.~ScratchpadEstimator();
+}
+
+TEST(Scratch, Req_Init) {
+  char data[sizeof(KernelRequirements)];
+  memset(data, 0xCC, sizeof(data));
+  auto &req = *new (data) KernelRequirements;
+  for (auto &s : req.scratch_sizes)
+    EXPECT_EQ(s, 0) << "Initial scratchpad sizes in KernelRequirements be 0";
+  req.~KernelRequirements();
+}
+
 TEST(Scratch, Estimator) {
   ScratchpadEstimator E;
   test_add<float>(E, AllocType::Host, 9);


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
- It fixes a (potential) bug in usages where scratch_sizes is not initialized.

#### What happened in this PR?
 - Added default initialization to `KernelRequirements::scratch_sizes` field.
 - Added a unit test that placment-constructs ScratchpadEstimator and KernelRequirements in deliberately non-zero filled memory.

**JIRA TASK**: NONE