### PR TITLE
Fix tests that are not using prolog/epilog functions

### DIFF
--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -36,11 +36,14 @@ fi
 
 prolog=${prolog-:}
 epilog=${epilog-:}
+# get the number of elements in `prolog` array
+numer_of_prolog_elms=${#prolog[@]}
 
 for i in `seq 0 $last_config_index`;
 do
     echo "Test run $i"
-    for variant in $(seq 0 ${#prolog[@]}); do
+    # seq from 0 to number of elements in `prolog` array - 1
+    for variant in $(seq 0 $((${numer_of_prolog_elms}-1))); do
         ${prolog[variant]}
         echo "Test variant run: $variant"
         # install packages


### PR DESCRIPTION
- `seq 0 array_lenght` will produce 0...array_lenght sequence
   while we need array_lenght-1 number of values

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one*
- Fixes tests that are not using prolog/epilog functions

#### What happened in this PR?
 - `seq 0 array_lenght` will produce 0...array_lenght sequence while we need array_lenght-1 number of values
 - tested with L1 tests on CI

**JIRA TASK**: NA