### PR TITLE
Make loading of the versioned libnvidia-opticalflow.so the primary path

### DIFF
--- a/dali/pipeline/operators/optical_flow/turing_of/optical_flow_turing.cc
+++ b/dali/pipeline/operators/optical_flow/turing_of/optical_flow_turing.cc
@@ -197,10 +197,10 @@ NV_OF_EXECUTE_OUTPUT_PARAMS OpticalFlowTuring::GenerateExecuteOutParams
 
 
 void OpticalFlowTuring::LoadTuringOpticalFlow(const std::string &library_path) {
-  auto handle = dlopen(library_path.c_str(), RTLD_LOCAL | RTLD_LAZY);
+  const std::string library_path_1 = library_path + ".1";
+  auto handle = dlopen(library_path_1.c_str(), RTLD_LOCAL | RTLD_LAZY);
   if (!handle) {
-    const std::string library_path_1 = library_path + ".1";
-    handle = dlopen(library_path_1.c_str(), RTLD_LOCAL | RTLD_LAZY);
+    handle = dlopen(library_path.c_str(), RTLD_LOCAL | RTLD_LAZY);
     if (!handle) {
       throw unsupported_exception("Failed to load TuringOF library: " + std::string(dlerror()));
     }


### PR DESCRIPTION
- before that change, DALI had tried to load libnvidia-opticalflow.so first then
  libnvidia-opticalflow.so.1 while the versioned library should be used in the
  first place

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
-  before that change, DALI had tried to load libnvidia-opticalflow.so first then
  libnvidia-opticalflow.so.1 while the versioned library should be used in the
  first place

#### What happened in this PR?
 - now DALI attempts to load libnvidia-opticalflow.so.1 first before loading unversioned libnvidia-opticalflow.so
 - current optical flow tests covers that already

**JIRA TASK**: NA