### PR TITLE
CPU warp, with tests.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -281,7 +281,7 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 # Note that for custom extensions you also need to set FILE_PATTERNS otherwise
 # the files are not read by doxygen.
 
-EXTENSION_MAPPING      =
+EXTENSION_MAPPING      = cu=C++ cuh=C++
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
@@ -796,7 +796,10 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f, *.for, *.tcl,
 # *.vhd, *.vhdl, *.ucf, *.qsf, *.as and *.js.
 
-FILE_PATTERNS          =
+FILE_PATTERNS          = *.c *.cpp *.cc *.C *.cxx *.h *.hpp *.hxx *.H \
+                         *.inc *.inl *.cu *.cuh *.m \
+                         *.idl *.f *.py *.s *.asm *.S *.ptx *.sass *.ll \
+                         *.cmake *.dox *.markdown *.md
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -811,7 +814,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = 
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/dali/kernels/imgproc/warp/block_warp.cuh
+++ b/dali/kernels/imgproc/warp/block_warp.cuh
@@ -19,28 +19,12 @@
 #include "dali/kernels/imgproc/sampler.h"
 #include "dali/kernels/imgproc/warp/warp_setup.cuh"
 #include "dali/kernels/imgproc/warp/mapping_traits.h"
+#include "dali/kernels/imgproc/warp/map_coords.h"
 
 namespace dali {
 namespace kernels {
 namespace warp {
 
-template <typename Mapping, std::size_t dim>
-DALI_HOST_DEV
-enable_if_t<is_fp_mapping<Mapping>::value, vec<dim>> map_coords(const Mapping &m, ivec<dim> pos) {
-  // When given floating point coordinates, samplers expect pixel centers to be offset by half.
-  // Since ultimately our destination coordinates are integer, we need to move to pixel-center
-  // frame before applying the mapping and passing the output to a sampler.
-  return m(pos + 0.5f);
-}
-
-template <typename Mapping, std::size_t dim>
-DALI_HOST_DEV
-enable_if_t<!is_fp_mapping<Mapping>::value, ivec<dim>> map_coords(const Mapping &m, ivec<dim> pos) {
-  // When given integer point coordinates, samplers simply uses them as 0-based indices.
-  // If the mapping producces integral coordinates, there's no point in going from indices to
-  // pixel centers and then back to integral coordinates - hence, 0.5 is not added.
-  return m(pos);
-}
 
 template <DALIInterpType interp_type, typename Mapping,
           int ndim, typename OutputType, typename InputType,

--- a/dali/kernels/imgproc/warp/map_coords.h
+++ b/dali/kernels/imgproc/warp/map_coords.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_IMGPROC_WARP_MAP_COORDS_H_
+#define DALI_KERNELS_IMGPROC_WARP_MAP_COORDS_H_
+
+#include "dali/kernels/kernel.h"
+#include "dali/kernels/imgproc/sampler.h"
+#include "dali/kernels/imgproc/warp/warp_setup.cuh"
+#include "dali/kernels/imgproc/warp/mapping_traits.h"
+
+namespace dali {
+namespace kernels {
+namespace warp {
+
+template <typename Mapping, std::size_t dim>
+DALI_HOST_DEV
+enable_if_t<is_fp_mapping<Mapping>::value, vec<dim>> map_coords(const Mapping &m, ivec<dim> pos) {
+  // When given floating point coordinates, samplers expect pixel centers to be offset by half.
+  // Since ultimately our destination coordinates are integer, we need to move to pixel-center
+  // frame before applying the mapping and passing the output to a sampler.
+  return m(pos + 0.5f);
+}
+
+template <typename Mapping, std::size_t dim>
+DALI_HOST_DEV
+enable_if_t<!is_fp_mapping<Mapping>::value, ivec<dim>> map_coords(const Mapping &m, ivec<dim> pos) {
+  // When given integer point coordinates, samplers simply uses them as 0-based indices.
+  // If the mapping producces integral coordinates, there's no point in going from indices to
+  // pixel centers and then back to integral coordinates - hence, 0.5 is not added.
+  return m(pos);
+}
+
+}  // namespace warp
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_IMGPROC_WARP_MAP_COORDS_H_

--- a/dali/kernels/imgproc/warp/map_coords.h
+++ b/dali/kernels/imgproc/warp/map_coords.h
@@ -24,6 +24,11 @@ namespace dali {
 namespace kernels {
 namespace warp {
 
+/** @brief Converts destination _integer_ coordinates to _floating point_ source coordinates
+ *
+ * This function is used by warp implementations to calculate source coordinates using
+ * using non-integer mapping. The coordinates are converted to pixel-centered.
+ */
 template <typename Mapping, std::size_t dim>
 DALI_HOST_DEV
 enable_if_t<is_fp_mapping<Mapping>::value, vec<dim>> map_coords(const Mapping &m, ivec<dim> pos) {
@@ -33,6 +38,11 @@ enable_if_t<is_fp_mapping<Mapping>::value, vec<dim>> map_coords(const Mapping &m
   return m(pos + 0.5f);
 }
 
+/** @brief Converts destination _integer_ coordinates to _integer_ source coordinates
+ *
+ * This function is used by warp implementations to calculate source coordinates using
+ * using integer mapping.
+ */
 template <typename Mapping, std::size_t dim>
 DALI_HOST_DEV
 enable_if_t<!is_fp_mapping<Mapping>::value, ivec<dim>> map_coords(const Mapping &m, ivec<dim> pos) {

--- a/dali/kernels/imgproc/warp/warp_setup.cuh
+++ b/dali/kernels/imgproc/warp/warp_setup.cuh
@@ -23,32 +23,39 @@
 
 namespace dali {
 namespace kernels {
+
+/** @brief Contains implementation of warping kernels */
 namespace warp {
 
-template <int ndim, typename OutputType, typename InputType>
+template <int spatial_ndim, typename OutputType, typename InputType>
 struct SampleDesc {
   OutputType *__restrict__ output;
   const InputType *__restrict__ input;
-  ivec<ndim> out_size, out_strides, in_size, in_strides;
+  ivec<spatial_ndim> out_size, out_strides, in_size, in_strides;
   int channels;
   DALIInterpType interp;
 };
 
-
-template <int ndim, typename OutputType, typename InputType>
-class WarpSetup : public BlockSetup<ndim, ndim> {
-  static_assert(ndim == 2 || ndim == 3,
+/**
+ * @brief Prepares batched execution of warping kernel.
+ *
+ * This class is a helper that calculates block setup and sample descriptors
+ * for warping kernels. It's independent of actual mapping used.
+ */
+template <int spatial_ndim, typename OutputType, typename InputType>
+class WarpSetup : public BlockSetup<spatial_ndim, spatial_ndim> {
+  static_assert(spatial_ndim == 2 || spatial_ndim == 3,
     "Warping is defined only for 2D and 3D data with interleaved channels");
 
  public:
-  using Base = BlockSetup<ndim, ndim>;
+  using Base = BlockSetup<spatial_ndim, spatial_ndim>;
   using Base::tensor_ndim;
   using Base::Blocks;
   using Base::IsUniformSize;
   using Base::SetupBlocks;
   using Base::shape2size;
-  using SampleDesc = warp::SampleDesc<ndim, OutputType, InputType>;
-  using BlockDesc = kernels::BlockDesc<ndim>;
+  using SampleDesc = warp::SampleDesc<spatial_ndim, OutputType, InputType>;
+  using BlockDesc = kernels::BlockDesc<spatial_ndim>;
 
   KernelRequirements Setup(const TensorListShape<tensor_ndim> &output_shape,
                            bool force_variable_size = false) {
@@ -76,7 +83,7 @@ class WarpSetup : public BlockSetup<ndim, ndim> {
       sample.output = out.tensor_data(i);
       auto out_shape = out.tensor_shape(i);
       auto in_shape = in.tensor_shape(i);
-      int channels = out_shape[ndim];
+      int channels = out_shape[spatial_ndim];
       sample.channels = channels;
       sample.out_size = shape2size(out_shape);
       sample.in_size = shape2size(in_shape);

--- a/dali/kernels/imgproc/warp_cpu.h
+++ b/dali/kernels/imgproc/warp_cpu.h
@@ -1,0 +1,118 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_IMGPROC_WARP_CPU_H_
+#define DALI_KERNELS_IMGPROC_WARP_CPU_H_
+
+#include "dali/core/common.h"
+#include "dali/core/geom/vec.h"
+#include "dali/core/static_switch.h"
+#include "dali/kernels/kernel.h"
+#include "dali/kernels/imgproc/warp/mapping_traits.h"
+#include "dali/kernels/imgproc/sampler.h"
+#include "dali/kernels/imgproc/warp/map_coords.h"
+
+namespace dali {
+namespace kernels {
+
+/// @remarks Assume HWC layout
+template <typename _Mapping, int ndim, typename _OutputType, typename _InputType,
+          typename _BorderType>
+class WarpCPU {
+ public:
+  static constexpr int spatial_ndim = ndim;
+  static constexpr int tensor_ndim = ndim + 1;
+  static constexpr int channel_dim = ndim;
+
+  static_assert(spatial_ndim == 2, "Not implemented for spatial_ndim != 2");
+
+  using Mapping = _Mapping;
+  using OutputType = _OutputType;
+  using InputType = _InputType;
+  using BorderType = _BorderType;
+  using MappingParams = warp::mapping_params_t<Mapping>;
+
+  KernelRequirements Setup(
+      KernelContext &context,
+      const InTensorCPU<InputType, tensor_ndim> &input,
+      const MappingParams &mapping_params,
+      const TensorShape<spatial_ndim> &out_size,
+      DALIInterpType interp = DALI_INTERP_LINEAR,
+      const BorderType &border = {}) {
+    KernelRequirements req;
+    req.output_shapes.resize(1);
+    auto out_shape = shape_cat(out_size, input.shape[channel_dim]);
+    req.output_shapes[0] = TensorListShape<tensor_ndim>({out_shape});
+    return req;
+  }
+
+  void Run(
+      KernelContext &context,
+      const OutTensorCPU<OutputType, tensor_ndim> &output,
+      const InTensorCPU<InputType, tensor_ndim> &input,
+      const MappingParams &mapping_params,
+      const TensorShape<spatial_ndim> &out_size,
+      DALIInterpType interp = DALI_INTERP_LINEAR,
+      const BorderType &border = {}) {
+    Mapping mapping = mapping_params;
+
+    assert(output.shape == shape_cat(out_size, input.shape[channel_dim]));
+
+    VALUE_SWITCH(interp, static_interp, (DALI_INTERP_NN, DALI_INTERP_LINEAR),
+      (RunImpl<static_interp>(context, output, input, mapping, border);),
+      (DALI_FAIL("Unsupported interpolation type"))
+    ); // NOLINT
+  }
+
+  template <DALIInterpType static_interp>
+  void RunImpl(
+      KernelContext &context,
+      const OutTensorCPU<OutputType, 3> &output,
+      const InTensorCPU<InputType, 3> &input,
+      Mapping &mapping,
+      const BorderType &border = {}) {
+    static_assert(spatial_ndim == 2, "No channel dimesnion or too many dimensions.");
+
+    int out_w = output.shape[1];
+    int out_h = output.shape[0];
+    int c     = output.shape[2];
+    int in_w  = input.shape[1];
+    int in_h  = input.shape[0];
+
+    Surface2D<OutputType> out = {
+      output.data,
+      out_w, out_h, c,
+      c, out_w*c, 1
+    };
+    Surface2D<const InputType> in = {
+      input.data,
+      in_w, in_h, c,
+      c, in_w*c, 1
+    };
+
+    Sampler<static_interp, InputType> sampler(in);
+
+    for (int y = 0; y < out_h; y++) {
+      for (int x = 0; x < out_w; x++) {
+        auto src = warp::map_coords(mapping, ivec2(x, y));
+        sampler(&out(x, y), src, border);
+      }
+    }
+  }
+};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_IMGPROC_WARP_CPU_H_

--- a/dali/kernels/imgproc/warp_gpu.h
+++ b/dali/kernels/imgproc/warp_gpu.h
@@ -27,15 +27,23 @@ namespace dali {
 namespace kernels {
 
 /**
- * @remarks Assume HWC layout
+ * @brief Performs generic warping of a batch of tensors (on GPU)
+ *
+ * The warping uses a mapping functors to map destination coordinates to source
+ * coordinates and samples the source tensors at the resulting locations.
+ *
+ * @remarks
+ *  * Assumes HWC layout
+ *  * Output and input have same number of spatial dimenions
+ *  * Output and input have same number of channels and layout
  */
-template <typename _Mapping, int ndim, typename _OutputType, typename _InputType,
+template <typename _Mapping, int _spatial_ndim, typename _OutputType, typename _InputType,
           typename _BorderType>
 class WarpGPU {
  public:
-  using WarpSetup = warp::WarpSetup<ndim, _OutputType, _InputType>;
-  static constexpr int spatial_ndim = ndim;
-  static constexpr int tensor_ndim = ndim + 1;
+  using WarpSetup = warp::WarpSetup<_spatial_ndim, _OutputType, _InputType>;
+  static constexpr int spatial_ndim = _spatial_ndim;
+  static constexpr int tensor_ndim = spatial_ndim + 1;
 
   using Mapping = _Mapping;
   using OutputType = _OutputType;

--- a/dali/kernels/test/warp_test/warp_cpu_test.cc
+++ b/dali/kernels/test/warp_test/warp_cpu_test.cc
@@ -1,0 +1,150 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+#include <string>
+#include <vector>
+#include "dali/kernels/imgproc/warp_cpu.h"
+#include "dali/kernels/imgproc/warp/affine.h"
+#include "dali/kernels/test/tensor_test_utils.h"
+#include "dali/kernels/test/dump_diff.h"
+#include "dali/kernels/test/mat2tensor.h"
+#include "dali/kernels/test/test_tensors.h"
+#include "dali/kernels/scratch.h"
+#include "dali/kernels/alloc.h"
+#include "dali/test/dali_test_config.h"
+#include "dali/core/geom/transform.h"
+#include "dali/kernels/test/warp_test/warp_test_helper.h"
+
+namespace dali {
+namespace kernels {
+
+inline void IsWarpKernelValid() {
+  check_kernel<WarpCPU<AffineMapping2D, 2, float, uint8_t, float>>();
+}
+
+TEST(WarpCPU, Affine_Transpose_Single) {
+  AffineMapping2D mapping_cpu = mat2x3{{
+    { 0, 1, 0 },
+    { 1, 0, 0 }
+  }};
+
+  cv::Mat cv_img = cv::imread(testing::dali_extra_path() + "/db/imgproc/alley.png");
+  auto cpu_img = view_as_tensor<uint8_t>(cv_img);
+
+  WarpCPU<AffineMapping2D, 2, uint8_t, uint8_t, BorderClamp> warp;
+
+  ScratchpadAllocator scratch_alloc;
+
+  TensorShape<2> out_shape = { cpu_img.shape[1], cpu_img.shape[0] };
+  KernelContext ctx = {};
+
+  auto interp = DALI_INTERP_NN;
+  KernelRequirements req;
+
+  req = warp.Setup(ctx, cpu_img, mapping_cpu, out_shape, interp);
+
+  scratch_alloc.Reserve(req.scratch_sizes);
+  TestTensorList<uint8_t, 3> out;
+  out.reshape(req.output_shapes[0].to_static<3>());
+  auto scratchpad = scratch_alloc.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+  warp.Run(ctx, out.cpu(0)[0], cpu_img, mapping_cpu, out_shape, interp);
+
+  auto cpu_out = out.cpu(0)[0];
+  ASSERT_EQ(cpu_out.shape[0], cpu_img.shape[1]);
+  ASSERT_EQ(cpu_out.shape[1], cpu_img.shape[0]);
+  ASSERT_EQ(cpu_out.shape[2], 3);
+
+  int errors = 0;
+  int printed = 0;
+  for (int y = 0; y < cpu_out.shape[0]; y++) {
+    for (int x = 0; x < cpu_out.shape[1]; x++) {
+      for (int c = 0; c < 3; c++) {
+        if (*cpu_out(y, x, c) != *cpu_img(x, y, c)) {
+          if (errors++ < 100) {
+            printed++;
+            EXPECT_EQ(*cpu_out(y, x, c), *cpu_img(x, y, c))
+              << "@ x = " << x << " y = " << y << " c = " << c;
+          }
+        }
+      }
+    }
+  }
+  if (printed != errors) {
+    FAIL() << (errors - printed) << " more erors.";
+  }
+}
+
+TEST(WarpCPU, Affine_RotateScale) {
+  WarpCPU<AffineMapping2D, 2, uint8_t, uint8_t, uint8_t> warp;
+  ScratchpadAllocator scratch_alloc;
+
+  static const std::string names[] = { "dots", "alley" };
+  static const float scales[] = { 10.0f, 0.5f };
+  for (int img_idx = 0; img_idx < 2; img_idx++) {
+    const auto &name = names[img_idx];
+    float scale = scales[img_idx];
+
+    cv::Mat cv_img = cv::imread(testing::dali_extra_path() + "/db/imgproc/" + name + ".png");
+    auto cpu_img = view_as_tensor<uint8_t>(cv_img);
+
+    vec2 center(cv_img.cols * 0.5f, cv_img.rows * 0.5f);
+
+    auto tr = translation(center) * rotation2D(-M_PI/4) *
+              translation(-center) * scaling(vec2(1.0f/scale, 1.0f/scale));
+    AffineMapping2D mapping_cpu = sub<2, 3>(tr, 0, 0);
+
+    int out_h = cpu_img.shape[0] * scale;
+    int out_w = cpu_img.shape[1] * scale;
+    TensorShape<2> out_shape = { out_h, out_w };
+    KernelContext ctx = {};
+
+    auto interp = DALI_INTERP_LINEAR;
+    KernelRequirements req;
+
+    req = warp.Setup(ctx, cpu_img, mapping_cpu, out_shape, interp, 255);
+
+    scratch_alloc.Reserve(req.scratch_sizes);
+    TestTensorList<uint8_t, 3> out;
+    out.reshape(req.output_shapes[0].to_static<3>());
+    auto scratchpad = scratch_alloc.GetScratchpad();
+    ctx.scratchpad = &scratchpad;
+    warp.Run(ctx, out.cpu(0)[0], cpu_img, mapping_cpu, out_shape, interp, 255);
+
+    auto cpu_out = out.cpu(0)[0];
+    ASSERT_EQ(cpu_out.shape[0], out_shape[0]);
+    ASSERT_EQ(cpu_out.shape[1], out_shape[1]);
+    ASSERT_EQ(cpu_out.shape[2], 3);
+
+    cv::Mat cv_out(cpu_out.shape[0], cpu_out.shape[1], CV_8UC3, cpu_out.data);
+
+    cv::Matx<float, 2, 3> cv_transform = AffineToCV(mapping_cpu);
+
+    cv::Mat cv_ref;
+    cv::warpAffine(cv_img, cv_ref,
+                  cv_transform, cv::Size(out_shape[1], out_shape[0]),
+                  cv::INTER_LINEAR|cv::WARP_INVERSE_MAP,
+                  cv::BORDER_CONSTANT, cv::Scalar(255, 255, 255, 255));
+    auto ref_img = view_as_tensor<uint8_t>(cv_ref);
+    Check(cpu_out, ref_img, EqualEps(8));
+    if (HasFailure)
+      testing::DumpDiff("WarpAffine_RotateScale_" + name, cv_out, cv_ref);
+  }
+}
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/test/warp_test/warp_cpu_test.cc
+++ b/dali/kernels/test/warp_test/warp_cpu_test.cc
@@ -32,8 +32,9 @@
 namespace dali {
 namespace kernels {
 
-inline void IsWarpKernelValid() {
+TEST(WarpCPU, check_kernel) {
   check_kernel<WarpCPU<AffineMapping2D, 2, float, uint8_t, float>>();
+  SUCCEED();
 }
 
 TEST(WarpCPU, Affine_Transpose_Single) {
@@ -141,7 +142,7 @@ TEST(WarpCPU, Affine_RotateScale) {
                   cv::BORDER_CONSTANT, cv::Scalar(255, 255, 255, 255));
     auto ref_img = view_as_tensor<uint8_t>(cv_ref);
     Check(cpu_out, ref_img, EqualEps(8));
-    if (HasFailure)
+    if (HasFailure())
       testing::DumpDiff("WarpAffine_RotateScale_" + name, cv_out, cv_ref);
   }
 }

--- a/dali/kernels/test/warp_test/warp_gpu_test.cu
+++ b/dali/kernels/test/warp_test/warp_gpu_test.cu
@@ -41,8 +41,9 @@ class WarpPrivateTest {
   }
 };
 
-inline void IsWarpKernelValid() {
+TEST(WarpGPU, check_kernel) {
   check_kernel<WarpGPU<AffineMapping2D, 2, float, uint8_t, float>>();
+  SUCCEED();
 }
 
 void WarpGPU_Affine_Transpose(bool force_variable) {
@@ -199,7 +200,7 @@ TEST(WarpGPU, Affine_RotateScale_Single) {
                  cv::BORDER_CONSTANT, cv::Scalar(255, 255, 255, 255));
   auto ref_img = view_as_tensor<uint8_t>(cv_ref);
   Check(cpu_out, ref_img, EqualEps(8));
-  if (HasFailure)
+  if (HasFailure())
     testing::DumpDiff("WarpAffine_RotateScale", cv_out, cv_ref);
 }
 

--- a/dali/kernels/test/warp_test/warp_gpu_test.cu
+++ b/dali/kernels/test/warp_test/warp_gpu_test.cu
@@ -41,7 +41,7 @@ class WarpPrivateTest {
   }
 };
 
-void IsWarpKernelValid() {
+inline void IsWarpKernelValid() {
   check_kernel<WarpGPU<AffineMapping2D, 2, float, uint8_t, float>>();
 }
 

--- a/dali/kernels/test/warp_test/warp_test_helper.h
+++ b/dali/kernels/test/warp_test/warp_test_helper.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_TEST_WARP_TEST_WARP_TEST_HELPER_H_
+#define DALI_KERNELS_TEST_WARP_TEST_WARP_TEST_HELPER_H_
+
+#include "dali/kernels/imgproc/warp/affine.h"
+
+namespace dali {
+namespace kernels {
+
+/// @brief Apply correction of pixel centers and convert the mapping to
+///        OpenCV matrix type.
+inline cv::Matx<float, 2, 3> AffineToCV(const AffineMapping2D &mapping) {
+  vec2 translation = mapping({0.5f, 0.5f}) - vec2(0.5f, 0.5f);
+  mat2x3 tmp = mapping.transform;
+  tmp.set_col(2, translation);
+
+  cv::Matx<float, 2, 3> cv_transform;
+  for (int i = 0; i < 2; i++)
+    for (int j = 0; j < 3; j++)
+      cv_transform(i, j) = tmp(i, j);
+  return cv_transform;
+}
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_TEST_WARP_TEST_WARP_TEST_HELPER_H_


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one*
- It adds WarpCPU kernel to use in Warp operator family.

#### What happened in this PR?
 - What was changed, added, removed?
  * Added WarpCPU kernel class.
  * Moved some utilities outside files used by GPU implementation.
 - What is most important part that reviewers should focus on?
  * `warp_cpu.h`
 - Was this PR tested?
  * Unit tests
 - Were docs and examples updated, if necessary?
  * No

**JIRA TASK**: [DALI-826]