### PR TITLE
Adjust Operator::Run to take reference instead of pointer

### DIFF
--- a/dali/benchmark/displacement_cpu_bench.cc
+++ b/dali/benchmark/displacement_cpu_bench.cc
@@ -105,10 +105,10 @@ void DisplacementBench(benchmark::State& st) {//NOLINT
   ws.SetThreadPool(&tp);
 
   // Run once so output is allocated
-  df.Run(&ws);
+  df.Run(ws);
 
   for (auto _ : st) {
-    df.Run(&ws);
+    df.Run(ws);
   }
 }
 

--- a/dali/benchmark/operator_bench.h
+++ b/dali/benchmark/operator_bench.h
@@ -67,9 +67,9 @@ class OperatorBench : public DALIBenchmark {
     ThreadPool tp(num_threads, 0, false);
     ws.SetThreadPool(&tp);
 
-    op_ptr->Run(&ws);
+    op_ptr->Run(ws);
     for (auto _ : st) {
-      op_ptr->Run(&ws);
+      op_ptr->Run(ws);
       st.counters["FPS"] = benchmark::Counter(st.iterations() + 1,
         benchmark::Counter::kIsRate);
     }
@@ -108,10 +108,10 @@ class OperatorBench : public DALIBenchmark {
     ws.AddOutput(data_out_gpu);
     ws.set_stream(0);
 
-    op_ptr->Run(&ws);
+    op_ptr->Run(ws);
     CUDA_CALL(cudaStreamSynchronize(0));
     for (auto _ : st) {
-      op_ptr->Run(&ws);
+      op_ptr->Run(ws);
       CUDA_CALL(cudaStreamSynchronize(0));
 
       int num_batches = st.iterations() + 1;

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -255,7 +255,7 @@ class DLL_PUBLIC Executor : public ExecutorBase, public WorkspacePolicy, public 
                    "type information for Operator outputs. In that case CanInferOutputs should "
                    "always return false.");
     }
-    op.Run(&ws);
+    op.Run(ws);
   }
 };
 

--- a/dali/pipeline/operators/color/color_twist.cc
+++ b/dali/pipeline/operators/color/color_twist.cc
@@ -104,9 +104,9 @@ Values >= 0 are accepted. For example:
     .AddParent("ColorTransformBase");
 
 template <>
-void ColorTwistBase<CPUBackend>::RunImpl(SampleWorkspace *ws) {
-  const auto &input = ws->Input<CPUBackend>(0);
-  auto &output = ws->Output<CPUBackend>(0);
+void ColorTwistBase<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+  const auto &input = ws.Input<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
   const auto &input_shape = input.shape();
 
   CheckParam(input, "Color augmentation");
@@ -125,7 +125,7 @@ void ColorTwistBase<CPUBackend>::RunImpl(SampleWorkspace *ws) {
     float *m = reinterpret_cast<float *>(matrix);
     IdentityMatrix(m);
     for (size_t j = 0; j < augments_.size(); ++j) {
-      augments_[j]->Prepare(ws->data_idx(), spec_, ws);
+      augments_[j]->Prepare(ws.data_idx(), spec_, &ws);
       (*augments_[j])(m);
     }
 

--- a/dali/pipeline/operators/color/color_twist.h
+++ b/dali/pipeline/operators/color/color_twist.h
@@ -185,7 +185,7 @@ class ColorTwistBase : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
   std::vector<ColorAugment*> augments_;
   const int C_;

--- a/dali/pipeline/operators/color_space/color_space_conversion.cc
+++ b/dali/pipeline/operators/color_space/color_space_conversion.cc
@@ -31,9 +31,9 @@ DALI_SCHEMA(ColorSpaceConversion)
         DALI_IMAGE_TYPE);
 
 template <>
-void ColorSpaceConversion<CPUBackend>::RunImpl(SampleWorkspace *ws) {
-  const auto &input = ws->Input<CPUBackend>(0);
-  auto &output = ws->Output<CPUBackend>(0);
+void ColorSpaceConversion<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+  const auto &input = ws.Input<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
   const auto &input_shape = input.shape();
   auto output_shape = input_shape;
 

--- a/dali/pipeline/operators/color_space/color_space_conversion.cu
+++ b/dali/pipeline/operators/color_space/color_space_conversion.cu
@@ -91,11 +91,11 @@ auto ConvertYCbCrToGray8uKernel = ConvertYCbCrToGrayKernel<uint8_t>;
 }  // namespace detail
 
 template<>
-void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
-  const auto &input = ws->Input<GPUBackend>(0);
+void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
+  const auto &input = ws.Input<GPUBackend>(0);
   DALI_ENFORCE(IsType<uint8_t>(input.type()),
       "Color space conversion accept only uint8 tensors");
-  auto &output = ws->Output<GPUBackend>(0);
+  auto &output = ws.Output<GPUBackend>(0);
 
   TensorList<CPUBackend> attr_output_cpu;
 
@@ -114,7 +114,7 @@ void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
   output.set_type(input.type());
 
   cudaStream_t old_stream = nppGetStream();
-  auto stream = ws->stream();
+  auto stream = ws.stream();
   nppSetStream(stream);
 
   if (input.GetLayout() == DALI_NHWC) {

--- a/dali/pipeline/operators/color_space/color_space_conversion.h
+++ b/dali/pipeline/operators/color_space/color_space_conversion.h
@@ -36,7 +36,7 @@ class ColorSpaceConversion : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
   USE_OPERATOR_MEMBERS();
   using Operator<Backend>::RunImpl;

--- a/dali/pipeline/operators/crop/bbox_crop.cc
+++ b/dali/pipeline/operators/crop/bbox_crop.cc
@@ -58,11 +58,11 @@ Default values disallow changes in aspect ratio.)code",
 
 template <>
 void RandomBBoxCrop<CPUBackend>::WriteCropToOutput(
-  SampleWorkspace *ws, const Crop &crop) const {
+  SampleWorkspace &ws, const Crop &crop) const {
   const auto coordinates = crop.AsXywh();
 
   // Copy the anchor to output
-  auto &anchor_out = ws->Output<CPUBackend>(0);
+  auto &anchor_out = ws.Output<CPUBackend>(0);
   anchor_out.Resize({2});
 
   auto *anchor_out_data = anchor_out.mutable_data<float>();
@@ -70,7 +70,7 @@ void RandomBBoxCrop<CPUBackend>::WriteCropToOutput(
   anchor_out_data[1] = coordinates[1];
 
   // Copy the offsets to output 1
-  auto &offsets_out = ws->Output<CPUBackend>(1);
+  auto &offsets_out = ws.Output<CPUBackend>(1);
   offsets_out.Resize({2});
 
   auto *offsets_out_data = offsets_out.mutable_data<float>();
@@ -80,8 +80,8 @@ void RandomBBoxCrop<CPUBackend>::WriteCropToOutput(
 
 template <>
 void RandomBBoxCrop<CPUBackend>::WriteBoxesToOutput(
-    SampleWorkspace *ws, const BoundingBoxes &bounding_boxes) const {
-  auto &bbox_out = ws->Output<CPUBackend>(2);
+    SampleWorkspace &ws, const BoundingBoxes &bounding_boxes) const {
+  auto &bbox_out = ws.Output<CPUBackend>(2);
   bbox_out.Resize(
       {static_cast<int64_t>(bounding_boxes.size()), static_cast<int64_t>(BoundingBox::kSize)});
 
@@ -99,8 +99,8 @@ void RandomBBoxCrop<CPUBackend>::WriteBoxesToOutput(
 
 template <>
 void RandomBBoxCrop<CPUBackend>::WriteLabelsToOutput(
-  SampleWorkspace *ws, const std::vector<int> &labels) const {
-  auto &labels_out = ws->Output<CPUBackend>(3);
+  SampleWorkspace &ws, const std::vector<int> &labels) const {
+  auto &labels_out = ws.Output<CPUBackend>(3);
   labels_out.Resize({static_cast<Index>(labels.size()), 1});
 
   auto *labels_out_data = labels_out.mutable_data<int>();
@@ -110,8 +110,8 @@ void RandomBBoxCrop<CPUBackend>::WriteLabelsToOutput(
 }
 
 template <>
-void RandomBBoxCrop<CPUBackend>::RunImpl(SampleWorkspace *ws) {
-  const auto &boxes_tensor = ws->Input<CPUBackend>(0);
+void RandomBBoxCrop<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+  const auto &boxes_tensor = ws.Input<CPUBackend>(0);
 
   BoundingBoxes bounding_boxes;
   bounding_boxes.reserve(static_cast<size_t>(boxes_tensor.dim(0)));
@@ -125,7 +125,7 @@ void RandomBBoxCrop<CPUBackend>::RunImpl(SampleWorkspace *ws) {
     bounding_boxes.emplace_back(box);
   }
 
-  const auto &labels_tensor = ws->Input<CPUBackend>(1);
+  const auto &labels_tensor = ws.Input<CPUBackend>(1);
 
   std::vector<int> labels;
   labels.reserve(static_cast<size_t>(labels_tensor.dim(0)));
@@ -136,7 +136,7 @@ void RandomBBoxCrop<CPUBackend>::RunImpl(SampleWorkspace *ws) {
   }
 
   ProspectiveCrop prospective_crop;
-  int sample = ws->data_idx();
+  int sample = ws.data_idx();
   while (!prospective_crop.success)
     prospective_crop  = FindProspectiveCrop(
         bounding_boxes, labels, SelectMinimumOverlap(sample), sample);

--- a/dali/pipeline/operators/crop/bbox_crop.h
+++ b/dali/pipeline/operators/crop/bbox_crop.h
@@ -102,14 +102,14 @@ class RandomBBoxCrop : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
-  void WriteCropToOutput(SampleWorkspace *ws, const Crop &crop) const;
+  void WriteCropToOutput(SampleWorkspace &ws, const Crop &crop) const;
 
   void WriteBoxesToOutput(
-    SampleWorkspace *ws, const BoundingBoxes &bounding_boxes) const;
+    SampleWorkspace &ws, const BoundingBoxes &bounding_boxes) const;
 
-  void WriteLabelsToOutput(SampleWorkspace *ws, const std::vector<int> &labels) const;
+  void WriteLabelsToOutput(SampleWorkspace &ws, const std::vector<int> &labels) const;
 
   const std::pair<float, bool> SelectMinimumOverlap(int sample) {
     std::uniform_int_distribution<> sampler(

--- a/dali/pipeline/operators/crop/crop.cc
+++ b/dali/pipeline/operators/crop/crop.cc
@@ -35,8 +35,8 @@ DALI_SCHEMA(Crop)
     .AddParent("SliceBase");
 
 template <>
-void Crop<CPUBackend>::DataDependentSetup(SampleWorkspace *ws) {
-  const auto &input = ws->Input<CPUBackend>(0);
+void Crop<CPUBackend>::DataDependentSetup(SampleWorkspace &ws) {
+  const auto &input = ws.Input<CPUBackend>(0);
 
   const DALITensorLayout in_layout = input.GetLayout();
   DALI_ENFORCE(in_layout == DALI_NHWC || in_layout == DALI_NCHW
@@ -44,10 +44,10 @@ void Crop<CPUBackend>::DataDependentSetup(SampleWorkspace *ws) {
     "Unexpected data layout");
   DALITensorLayout out_layout = in_layout;
 
-  auto data_idx = ws->data_idx();
+  auto data_idx = ws.data_idx();
   SetupSample(data_idx, in_layout, input.shape());
 
-  auto &output = ws->Output<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
   output.SetLayout(out_layout);
 }
 

--- a/dali/pipeline/operators/crop/crop.cu
+++ b/dali/pipeline/operators/crop/crop.cu
@@ -22,8 +22,8 @@
 namespace dali {
 
 template <>
-void Crop<GPUBackend>::DataDependentSetup(DeviceWorkspace *ws) {
-  const auto &input = ws->Input<GPUBackend>(0);
+void Crop<GPUBackend>::DataDependentSetup(DeviceWorkspace &ws) {
+  const auto &input = ws.Input<GPUBackend>(0);
 
   const DALITensorLayout in_layout = input.GetLayout();
   DALI_ENFORCE(in_layout == DALI_NHWC || in_layout == DALI_NCHW
@@ -34,7 +34,7 @@ void Crop<GPUBackend>::DataDependentSetup(DeviceWorkspace *ws) {
   for (int i = 0; i < batch_size_; ++i) {
     SetupSample(i, in_layout, input.tensor_shape(i));
   }
-  auto &output = ws->Output<GPUBackend>(0);
+  auto &output = ws.Output<GPUBackend>(0);
   output.SetLayout(out_layout);
 }
 

--- a/dali/pipeline/operators/crop/crop.h
+++ b/dali/pipeline/operators/crop/crop.h
@@ -39,16 +39,16 @@ class Crop : public SliceBase<Backend>, protected CropAttr {
   }
 
  protected:
-  void RunImpl(Workspace<Backend> *ws) override {
+  void RunImpl(Workspace<Backend> &ws) override {
     SliceBase<Backend>::RunImpl(ws);
   }
 
-  void SetupSharedSampleParams(Workspace<Backend> *ws) override {
+  void SetupSharedSampleParams(Workspace<Backend> &ws) override {
     CropAttr::ProcessArguments(ws);
     SliceBase<Backend>::SetupSharedSampleParams(ws);
   }
 
-  void DataDependentSetup(Workspace<Backend> *ws) override;
+  void DataDependentSetup(Workspace<Backend> &ws) override;
 
   using SliceBase<Backend>::slice_anchors_;
   using SliceBase<Backend>::slice_shapes_;

--- a/dali/pipeline/operators/crop/crop_attr.h
+++ b/dali/pipeline/operators/crop/crop_attr.h
@@ -99,14 +99,14 @@ class CropAttr {
       };
   }
 
-  void ProcessArguments(const ArgumentWorkspace *ws) {
+  void ProcessArguments(const ArgumentWorkspace &ws) {
     for (std::size_t data_idx = 0; data_idx < batch_size__; data_idx++) {
-      ProcessArguments(ws, data_idx);
+      ProcessArguments(&ws, data_idx);
     }
   }
 
-  void ProcessArguments(const SampleWorkspace *ws) {
-    ProcessArguments(ws, ws->data_idx());
+  void ProcessArguments(const SampleWorkspace &ws) {
+    ProcessArguments(&ws, ws.data_idx());
   }
 
   const CropWindowGenerator& GetCropWindowGenerator(std::size_t data_idx) const {

--- a/dali/pipeline/operators/crop/slice.cc
+++ b/dali/pipeline/operators/crop/slice.cc
@@ -38,20 +38,20 @@ DALI_SCHEMA(Slice)
     .AddParent("SliceBase");
 
 template <>
-void Slice<CPUBackend>::DataDependentSetup(SampleWorkspace *ws) {
-  const auto &images = ws->Input<CPUBackend>(kImagesInId);
-  const auto &anchor_tensor = ws->Input<CPUBackend>(kAnchorsInId);
-  const auto &slice_shape_tensor = ws->Input<CPUBackend>(kSliceShapesInId);
+void Slice<CPUBackend>::DataDependentSetup(SampleWorkspace &ws) {
+  const auto &images = ws.Input<CPUBackend>(kImagesInId);
+  const auto &anchor_tensor = ws.Input<CPUBackend>(kAnchorsInId);
+  const auto &slice_shape_tensor = ws.Input<CPUBackend>(kSliceShapesInId);
   const auto img_shape = images.shape();
   const auto args_ndim = anchor_tensor.shape()[0];
   const float* anchor_norm = anchor_tensor.template data<float>();
   const float* slice_shape_norm = slice_shape_tensor.template data<float>();
-  SetupSample(ws->data_idx(), images.GetLayout(), img_shape, args_ndim,
+  SetupSample(ws.data_idx(), images.GetLayout(), img_shape, args_ndim,
               anchor_norm, slice_shape_norm);
 }
 
 template <>
-void Slice<CPUBackend>::RunImpl(SampleWorkspace *ws) {
+void Slice<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   SliceBase<CPUBackend>::RunImpl(ws);
 }
 

--- a/dali/pipeline/operators/crop/slice.cu
+++ b/dali/pipeline/operators/crop/slice.cu
@@ -18,10 +18,10 @@
 namespace dali {
 
 template <>
-void Slice<GPUBackend>::DataDependentSetup(DeviceWorkspace *ws) {
-  const auto &images = ws->Input<GPUBackend>(kImagesInId);
-  const auto &anchor_tensor = ws->Input<CPUBackend>(kAnchorsInId);
-  const auto &slice_shape_tensor = ws->Input<CPUBackend>(kSliceShapesInId);
+void Slice<GPUBackend>::DataDependentSetup(DeviceWorkspace &ws) {
+  const auto &images = ws.Input<GPUBackend>(kImagesInId);
+  const auto &anchor_tensor = ws.Input<CPUBackend>(kAnchorsInId);
+  const auto &slice_shape_tensor = ws.Input<CPUBackend>(kSliceShapesInId);
   for (int sample_idx = 0; sample_idx < batch_size_; sample_idx++) {
     const auto img_shape = images.tensor_shape(sample_idx);
     const auto args_ndims = anchor_tensor.tensor_shape(sample_idx)[0];
@@ -33,7 +33,7 @@ void Slice<GPUBackend>::DataDependentSetup(DeviceWorkspace *ws) {
 }
 
 template <>
-void Slice<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
+void Slice<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   SliceBase<GPUBackend>::RunImpl(ws);
 }
 

--- a/dali/pipeline/operators/crop/slice.h
+++ b/dali/pipeline/operators/crop/slice.h
@@ -37,15 +37,15 @@ class Slice : public SliceBase<Backend> {
   using SliceBase<Backend>::slice_anchors_;
   using SliceBase<Backend>::slice_shapes_;
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
-  void SetupSharedSampleParams(Workspace<Backend> *ws) override {
-    DALI_ENFORCE(ws->NumInput() == 3,
-      "Expected 3 inputs. Received: " + std::to_string(ws->NumInput()));
+  void SetupSharedSampleParams(Workspace<Backend> &ws) override {
+    DALI_ENFORCE(ws.NumInput() == 3,
+      "Expected 3 inputs. Received: " + std::to_string(ws.NumInput()));
     SliceBase<Backend>::SetupSharedSampleParams(ws);
   }
 
-  void DataDependentSetup(Workspace<Backend> *ws) override;
+  void DataDependentSetup(Workspace<Backend> &ws) override;
 
   void SetupSample(int data_idx,
                    DALITensorLayout layout,

--- a/dali/pipeline/operators/crop/slice_attr.h
+++ b/dali/pipeline/operators/crop/slice_attr.h
@@ -41,14 +41,14 @@ class SliceAttr {
         crop_window_generators_.resize(batch_size__, {});
     }
 
-    void ProcessArguments(const SampleWorkspace *ws) {
-        DALI_ENFORCE(ws->NumInput() == 3,
-            "Expected 3 inputs. Received: " + std::to_string(ws->NumInput()));
+    void ProcessArguments(const SampleWorkspace &ws) {
+        DALI_ENFORCE(ws.NumInput() == 3,
+            "Expected 3 inputs. Received: " + std::to_string(ws.NumInput()));
 
-        const auto &images = ws->Input<CPUBackend>(0);
-        const auto &crop_begin = ws->Input<CPUBackend>(1);
-        const auto &crop_size = ws->Input<CPUBackend>(2);
-        int data_idx = ws->data_idx();
+        const auto &images = ws.Input<CPUBackend>(0);
+        const auto &crop_begin = ws.Input<CPUBackend>(1);
+        const auto &crop_size = ws.Input<CPUBackend>(2);
+        int data_idx = ws.data_idx();
         // Assumes xywh
         ProcessArgumentsHelper(
             data_idx,
@@ -58,13 +58,13 @@ class SliceAttr {
             crop_begin.data<float>()[1]);
     }
 
-    void ProcessArguments(MixedWorkspace *ws) {
-        DALI_ENFORCE(ws->NumInput() == 3,
-            "Expected 3 inputs. Received: " + std::to_string(ws->NumInput()));
+    void ProcessArguments(MixedWorkspace &ws) {
+        DALI_ENFORCE(ws.NumInput() == 3,
+            "Expected 3 inputs. Received: " + std::to_string(ws.NumInput()));
         for (std::size_t data_idx = 0; data_idx < batch_size__; data_idx++) {
-            const auto &images = ws->Input<CPUBackend>(0, data_idx);
-            const auto &crop_begin = ws->Input<CPUBackend>(1, data_idx);
-            const auto &crop_size = ws->Input<CPUBackend>(2, data_idx);
+            const auto &images = ws.Input<CPUBackend>(0, data_idx);
+            const auto &crop_begin = ws.Input<CPUBackend>(1, data_idx);
+            const auto &crop_size = ws.Input<CPUBackend>(2, data_idx);
             // Assumes xywh
             ProcessArgumentsHelper(
                 data_idx,

--- a/dali/pipeline/operators/crop/slice_base.cc
+++ b/dali/pipeline/operators/crop/slice_base.cc
@@ -66,11 +66,11 @@ DALI_SCHEMA(SliceBase)
       DALI_NO_TYPE);
 
 template <>
-void SliceBase<CPUBackend>::RunImpl(SampleWorkspace *ws) {
+void SliceBase<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   this->DataDependentSetup(ws);
-  const auto &input = ws->Input<CPUBackend>(0);
-  auto &output = ws->Output<CPUBackend>(0);
-  auto data_idx = ws->data_idx();
+  const auto &input = ws.Input<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
+  auto data_idx = ws.data_idx();
 
   DALI_TYPE_SWITCH_WITH_FP16_CPU(input_type_, InputType,
     DALI_TYPE_SWITCH_WITH_FP16_CPU(output_type_, OutputType,

--- a/dali/pipeline/operators/crop/slice_base.cu
+++ b/dali/pipeline/operators/crop/slice_base.cu
@@ -72,15 +72,15 @@ void RunHelper(TensorList<GPUBackend>& output,
 
 
 template <>
-void SliceBase<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
+void SliceBase<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   this->DataDependentSetup(ws);
-  const auto &input = ws->Input<GPUBackend>(0);
-  auto &output = ws->Output<GPUBackend>(0);
+  const auto &input = ws.Input<GPUBackend>(0);
+  auto &output = ws.Output<GPUBackend>(0);
 
   DALI_TYPE_SWITCH_WITH_FP16_GPU(input_type_, InputType,
     DALI_TYPE_SWITCH_WITH_FP16_GPU(output_type_, OutputType,
       detail::RunHelper<OutputType, InputType>(
-        output, input, slice_anchors_, slice_shapes_, ws->stream(), scratch_alloc_);
+        output, input, slice_anchors_, slice_shapes_, ws.stream(), scratch_alloc_);
     )
   )
 }

--- a/dali/pipeline/operators/crop/slice_base.h
+++ b/dali/pipeline/operators/crop/slice_base.h
@@ -42,16 +42,16 @@ class SliceBase : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
-  void SetupSharedSampleParams(Workspace<Backend> *ws) override {
-    const auto &input = ws->template Input<Backend>(0);
+  void SetupSharedSampleParams(Workspace<Backend> &ws) override {
+    const auto &input = ws.template Input<Backend>(0);
     input_type_ = input.type().id();
     if (output_type_ == DALI_NO_TYPE)
       output_type_ = input_type_;
   }
 
-  virtual void DataDependentSetup(Workspace<Backend> *ws) = 0;
+  virtual void DataDependentSetup(Workspace<Backend> &ws) = 0;
 
   std::vector<std::vector<int64_t>> slice_anchors_, slice_shapes_;
   DALIDataType input_type_ = DALI_NO_TYPE;

--- a/dali/pipeline/operators/decoder/host/fused/host_decoder_crop.h
+++ b/dali/pipeline/operators/decoder/host/fused/host_decoder_crop.h
@@ -29,7 +29,7 @@ class HostDecoderCrop : public HostDecoder, protected CropAttr {
   inline ~HostDecoderCrop() override = default;
   DISABLE_COPY_MOVE_ASSIGN(HostDecoderCrop);
 
-  void inline SetupSharedSampleParams(SampleWorkspace *ws) override {
+  void inline SetupSharedSampleParams(SampleWorkspace &ws) override {
     CropAttr::ProcessArguments(ws);
   }
 

--- a/dali/pipeline/operators/decoder/host/fused/host_decoder_slice.h
+++ b/dali/pipeline/operators/decoder/host/fused/host_decoder_slice.h
@@ -30,7 +30,7 @@ class HostDecoderSlice : public HostDecoder, public SliceAttr {
   DISABLE_COPY_MOVE_ASSIGN(HostDecoderSlice);
 
  protected:
-  inline void RunImpl(SampleWorkspace *ws) override {
+  inline void RunImpl(SampleWorkspace &ws) override {
     SliceAttr::ProcessArguments(ws);
     HostDecoder::RunImpl(ws);
   }

--- a/dali/pipeline/operators/decoder/host/host_decoder.cc
+++ b/dali/pipeline/operators/decoder/host/host_decoder.cc
@@ -20,9 +20,9 @@
 
 namespace dali {
 
-void HostDecoder::RunImpl(SampleWorkspace *ws) {
-  const auto &input = ws->Input<CPUBackend>(0);
-  auto &output = ws->Output<CPUBackend>(0);
+void HostDecoder::RunImpl(SampleWorkspace &ws) {
+  const auto &input = ws.Input<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
   auto file_name = input.GetSourceInfo();
 
   // Verify input
@@ -34,7 +34,7 @@ void HostDecoder::RunImpl(SampleWorkspace *ws) {
   std::unique_ptr<Image> img;
   try {
     img = ImageFactory::CreateImage(input.data<uint8>(), input.size(), output_type_);
-    img->SetCropWindowGenerator(GetCropWindowGenerator(ws->data_idx()));
+    img->SetCropWindowGenerator(GetCropWindowGenerator(ws.data_idx()));
     img->SetUseFastIdct(use_fast_idct_);
     img->Decode();
   } catch (std::exception &e) {

--- a/dali/pipeline/operators/decoder/host/host_decoder.h
+++ b/dali/pipeline/operators/decoder/host/host_decoder.h
@@ -41,7 +41,7 @@ class HostDecoder : public Operator<CPUBackend> {
     return false;
   }
 
-  void RunImpl(SampleWorkspace *ws) override;
+  void RunImpl(SampleWorkspace &ws) override;
 
   virtual CropWindowGenerator GetCropWindowGenerator(int data_idx) const {
     return {};

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_cpu_crop.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_cpu_crop.h
@@ -35,7 +35,7 @@ class nvJPEGDecoderCPUStageCrop : public nvJPEGDecoderCPUStage, protected CropAt
     return CropAttr::GetCropWindowGenerator(data_idx);
   }
 
-  void SetupSharedSampleParams(SampleWorkspace *ws) override {
+  void SetupSharedSampleParams(SampleWorkspace &ws) override {
     CropAttr::ProcessArguments(ws);
   }
 };

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_cpu_slice.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_cpu_slice.h
@@ -32,7 +32,7 @@ class nvJPEGDecoderCPUStageSlice : public nvJPEGDecoderCPUStage, public SliceAtt
 
  protected:
   using Operator<CPUBackend>::RunImpl;
-  void RunImpl(SampleWorkspace *ws) override {
+  void RunImpl(SampleWorkspace &ws) override {
     SliceAttr::ProcessArguments(ws);
     nvJPEGDecoderCPUStage::RunImpl(ws);
   }

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_crop.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_crop.h
@@ -35,7 +35,7 @@ class nvJPEGDecoderCrop : public nvJPEGDecoder, protected CropAttr {
     return CropAttr::GetCropWindowGenerator(data_idx);
   }
 
-  void SetupSharedSampleParams(MixedWorkspace *ws) override {
+  void SetupSharedSampleParams(MixedWorkspace &ws) override {
     CropAttr::ProcessArguments(ws);
   }
 };

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice.h
@@ -32,7 +32,7 @@ class nvJPEGDecoderSlice : public nvJPEGDecoder, public SliceAttr {
 
  protected:
   using OperatorBase::Run;
-  void Run(MixedWorkspace *ws) override {
+  void Run(MixedWorkspace &ws) override {
     SliceAttr::ProcessArguments(ws);
     nvJPEGDecoder::Run(ws);
   }

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
@@ -94,9 +94,9 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
     return false;
   }
 
-  void RunImpl(SampleWorkspace *ws) override {
-    const int data_idx = ws->data_idx();
-    const auto& in = ws->Input<CPUBackend>(0);
+  void RunImpl(SampleWorkspace &ws) override {
+    const int data_idx = ws.data_idx();
+    const auto& in = ws.Input<CPUBackend>(0);
     const auto *input_data = in.data<uint8_t>();
     const auto in_size = in.size();
     const auto file_name = in.GetSourceInfo();
@@ -111,10 +111,10 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
 
     ImageInfo* info;
     StateNvJPEG* state_nvjpeg;
-    std::tie(info, state_nvjpeg) = InitAndGet(ws->Output<CPUBackend>(0),
-                                              ws->Output<CPUBackend>(1));
+    std::tie(info, state_nvjpeg) = InitAndGet(ws.Output<CPUBackend>(0),
+                                              ws.Output<CPUBackend>(1));
 
-    ws->Output<CPUBackend>(0).SetSourceInfo(file_name);
+    ws.Output<CPUBackend>(0).SetSourceInfo(file_name);
 
     nvjpegStatus_t ret = nvjpegJpegStreamParse(handle_,
                                                 static_cast<const unsigned char*>(input_data),
@@ -137,7 +137,7 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
           info->widths[0] = info->crop_window.w;
           info->heights[0] = info->crop_window.h;
         }
-        auto& out = ws->Output<CPUBackend>(2);
+        auto& out = ws.Output<CPUBackend>(2);
         out.set_type(TypeInfo::Create<uint8_t>());
         const auto c = static_cast<Index>(NumberOfChannels(output_image_type_));
         out.Resize({info->heights[0], info->widths[0], c});

--- a/dali/pipeline/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
@@ -203,7 +203,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
   }
 
   using dali::OperatorBase::Run;
-  void Run(MixedWorkspace *ws) override {
+  void Run(MixedWorkspace &ws) override {
     // TODO(slayton): Is this necessary?
     // CUDA_CALL(cudaStreamSynchronize(ws->stream()));
     CUDA_CALL(cudaEventRecord(master_event_, ws->stream()));

--- a/dali/pipeline/operators/detection/box_encoder.cc
+++ b/dali/pipeline/operators/detection/box_encoder.cc
@@ -153,9 +153,9 @@ void BoxEncoder<CPUBackend>::WriteMatchesToOutput(
   }
 }
 
-void BoxEncoder<CPUBackend>::RunImpl(SampleWorkspace *ws) {
-  const auto &bboxes_input = ws->Input<CPUBackend>(kBoxesInId);
-  const auto &labels_input = ws->Input<CPUBackend>(kLabelsInId);
+void BoxEncoder<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+  const auto &bboxes_input = ws.Input<CPUBackend>(kBoxesInId);
+  const auto &labels_input = ws.Input<CPUBackend>(kLabelsInId);
 
   const auto num_boxes = bboxes_input.dim(0);
 
@@ -163,12 +163,12 @@ void BoxEncoder<CPUBackend>::RunImpl(SampleWorkspace *ws) {
   const auto boxes = ReadBoxesFromInput(bboxes_input.data<float>(), num_boxes);
 
   // Create output
-  auto &bboxes_output = ws->Output<CPUBackend>(kBoxesOutId);
+  auto &bboxes_output = ws.Output<CPUBackend>(kBoxesOutId);
   bboxes_output.set_type(bboxes_input.type());
   bboxes_output.Resize({static_cast<int>(anchors_.size()), static_cast<int>(BoundingBox::kSize)});
   auto out_boxes = bboxes_output.mutable_data<float>();
 
-  auto &labels_output = ws->Output<CPUBackend>(kLabelsOutId);
+  auto &labels_output = ws.Output<CPUBackend>(kLabelsOutId);
   labels_output.set_type(labels_input.type());
   labels_output.Resize({static_cast<int>(anchors_.size())});
   auto out_labels = labels_output.mutable_data<int>();

--- a/dali/pipeline/operators/detection/box_encoder.cu
+++ b/dali/pipeline/operators/detection/box_encoder.cu
@@ -270,9 +270,9 @@ int *BoxEncoder<GPUBackend>::CalculateBoxesOffsets(
   return offsets_data;
 }
 
-void BoxEncoder<GPUBackend>::RunImpl(Workspace<GPUBackend> *ws) {
-  const auto &boxes_input = ws->Input<GPUBackend>(kBoxesInId);
-  const auto &labels_input = ws->Input<GPUBackend>(kLabelsInId);
+void BoxEncoder<GPUBackend>::RunImpl(Workspace<GPUBackend> &ws) {
+  const auto &boxes_input = ws.Input<GPUBackend>(kBoxesInId);
+  const auto &labels_input = ws.Input<GPUBackend>(kLabelsInId);
 
   const auto anchors_data = reinterpret_cast<const float4 *>(anchors_.data<float>());
   const auto anchors_as_cwh_data =
@@ -280,17 +280,17 @@ void BoxEncoder<GPUBackend>::RunImpl(Workspace<GPUBackend> *ws) {
   const auto boxes_data = reinterpret_cast<const float4 *>(boxes_input.data<float>());
   const auto labels_data = labels_input.data<int>();
 
-  const auto buffers = ClearBuffers(ws->stream());
+  const auto buffers = ClearBuffers(ws.stream());
 
-  auto boxes_offsets_data = CalculateBoxesOffsets(boxes_input, ws->stream());
+  auto boxes_offsets_data = CalculateBoxesOffsets(boxes_input, ws.stream());
   auto dims = CalculateDims(boxes_input);
 
-  auto &boxes_output = ws->Output<GPUBackend>(kBoxesOutId);
+  auto &boxes_output = ws.Output<GPUBackend>(kBoxesOutId);
   boxes_output.set_type(boxes_input.type());
   boxes_output.Resize(dims.first);
   auto boxes_out_data = reinterpret_cast<float4 *>(boxes_output.mutable_data<float>());
 
-  auto &labels_output = ws->Output<GPUBackend>(kLabelsOutId);
+  auto &labels_output = ws.Output<GPUBackend>(kLabelsOutId);
   labels_output.set_type(labels_input.type());
   labels_output.Resize(dims.second);
   auto labels_out_data = labels_output.mutable_data<int>();
@@ -299,11 +299,11 @@ void BoxEncoder<GPUBackend>::RunImpl(Workspace<GPUBackend> *ws) {
   const auto stds_data = stds_.data<float>();
 
   if (!offset_)
-    WriteAnchorsToOutput(boxes_out_data, labels_out_data, ws->stream());
+    WriteAnchorsToOutput(boxes_out_data, labels_out_data, ws.stream());
   else
-    ClearOutput(boxes_out_data, labels_out_data, ws->stream());
+    ClearOutput(boxes_out_data, labels_out_data, ws.stream());
 
-  Encode<BlockSize><<<batch_size_, BlockSize, 0, ws->stream()>>>(
+  Encode<BlockSize><<<batch_size_, BlockSize, 0, ws.stream()>>>(
     boxes_data,
     labels_data,
     boxes_offsets_data,

--- a/dali/pipeline/operators/detection/box_encoder.cuh
+++ b/dali/pipeline/operators/detection/box_encoder.cuh
@@ -71,7 +71,7 @@ class BoxEncoder<GPUBackend> : public Operator<GPUBackend> {
     return false;
   }
 
-  void RunImpl(Workspace<GPUBackend> *ws) override;
+  void RunImpl(Workspace<GPUBackend> &ws) override;
 
  private:
   static constexpr int kBoxesOutputDim = 2;

--- a/dali/pipeline/operators/detection/box_encoder.h
+++ b/dali/pipeline/operators/detection/box_encoder.h
@@ -71,7 +71,7 @@ class BoxEncoder<CPUBackend>: public Operator<CPUBackend> {
     return false;
   }
 
-  void RunImpl(Workspace<CPUBackend> *ws) override;
+  void RunImpl(Workspace<CPUBackend> &ws) override;
   using Operator<CPUBackend>::RunImpl;
 
  private:

--- a/dali/pipeline/operators/detection/random_crop.cc
+++ b/dali/pipeline/operators/detection/random_crop.cc
@@ -176,13 +176,13 @@ void crop(const Tensor<CPUBackend>& img, vector<int> bounds, Tensor<CPUBackend>&
 }  // namespace detail
 
 template <>
-void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace *ws) {
+void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   // [H, W, C], dtype=uint8_t
-  const auto& img = ws->Input<CPUBackend>(0);
+  const auto& img = ws.Input<CPUBackend>(0);
   // [N] : [ltrb, ... ], dtype=float
-  const auto& bboxes = ws->Input<CPUBackend>(1);
-  const auto& labels = ws->Input<CPUBackend>(2);
-  int sample = ws->data_idx();
+  const auto& bboxes = ws.Input<CPUBackend>(1);
+  const auto& labels = ws.Input<CPUBackend>(2);
+  int sample = ws.data_idx();
 
   auto N = bboxes.dim(0);
   const float* bbox_data = bboxes.data<float>();
@@ -202,9 +202,9 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace *ws) {
 
     if (option.no_crop()) {
       // copy directly to output without modification
-      ws->Output<CPUBackend>(0).Copy(img, 0);
-      ws->Output<CPUBackend>(1).Copy(bboxes, 0);
-      ws->Output<CPUBackend>(2).Copy(labels, 0);
+      ws.Output<CPUBackend>(0).Copy(img, 0);
+      ws.Output<CPUBackend>(1).Copy(bboxes, 0);
+      ws.Output<CPUBackend>(2).Copy(labels, 0);
       return;
     }
 
@@ -273,9 +273,9 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace *ws) {
 
       // now we know how many output bboxes there will be, we can allocate
       // the output.
-      auto &img_out = ws->Output<CPUBackend>(0);
-      auto &bbox_out = ws->Output<CPUBackend>(1);
-      auto &label_out = ws->Output<CPUBackend>(2);
+      auto &img_out = ws.Output<CPUBackend>(0);
+      auto &bbox_out = ws.Output<CPUBackend>(1);
+      auto &label_out = ws.Output<CPUBackend>(2);
 
       bbox_out.Resize({valid_bboxes, 4});
       auto *bbox_out_data = bbox_out.mutable_data<float>();
@@ -313,7 +313,7 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace *ws) {
 
       // perform the crop
       detail::crop(img, {left_idx, top_idx, right_idx, bottom_idx},
-                   ws->Output<CPUBackend>(0));
+                   ws.Output<CPUBackend>(0));
 
       return;
     }  // end num_attempts loop
@@ -321,7 +321,7 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace *ws) {
 }
 
 template <>
-void SSDRandomCrop<CPUBackend>::SetupSharedSampleParams(SampleWorkspace *ws) {
+void SSDRandomCrop<CPUBackend>::SetupSharedSampleParams(SampleWorkspace &ws) {
   return;
 }
 

--- a/dali/pipeline/operators/detection/random_crop.h
+++ b/dali/pipeline/operators/detection/random_crop.h
@@ -59,8 +59,8 @@ class SSDRandomCrop : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> * ws) override;
-  void SetupSharedSampleParams(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
+  void SetupSharedSampleParams(Workspace<Backend> &ws) override;
 
  private:
   struct CropInfo {

--- a/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
+++ b/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
@@ -90,11 +90,11 @@ class DisplacementFilter<CPUBackend, Displacement, per_channel_transform>
   }
 
   template <typename Out, typename In, DALIInterpType interp>
-  void RunWarp(SampleWorkspace *ws, int idx) {
-    auto &input = ws->Input<CPUBackend>(idx);
-    auto &output = ws->Output<CPUBackend>(idx);
+  void RunWarp(SampleWorkspace &ws, int idx) {
+    auto &input = ws.Input<CPUBackend>(idx);
+    auto &output = ws.Output<CPUBackend>(idx);
 
-    auto &displace = displace_[ws->thread_idx()];
+    auto &displace = displace_[ws.thread_idx()];
     In fill[1024];
     auto in = view_as_tensor<const Out, 3>(input);
     auto out = view_as_tensor<In, 3>(output);
@@ -110,12 +110,12 @@ class DisplacementFilter<CPUBackend, Displacement, per_channel_transform>
     return false;
   }
 
-  void RunImpl(SampleWorkspace *ws) override {
+  void RunImpl(SampleWorkspace &ws) override {
     DataDependentSetup(ws);
 
-    auto &input = ws->Input<CPUBackend>(0);
+    auto &input = ws.Input<CPUBackend>(0);
 
-    if (!has_mask_ || mask_->template data<bool>()[ws->data_idx()]) {
+    if (!has_mask_ || mask_->template data<bool>()[ws.data_idx()]) {
       switch (interp_type_) {
         case DALI_INTERP_NN:
           if (IsType<float>(input.type())) {
@@ -141,8 +141,8 @@ class DisplacementFilter<CPUBackend, Displacement, per_channel_transform>
               " only NN and LINEAR are supported for this operation");
       }
     } else {
-      auto &output = ws->Output<CPUBackend>(0);
-      output.Copy(input, ws->stream());
+      auto &output = ws.Output<CPUBackend>(0);
+      output.Copy(input, ws.stream());
     }
   }
 
@@ -161,17 +161,17 @@ class DisplacementFilter<CPUBackend, Displacement, per_channel_transform>
    * @brief Do basic input checking and output setup
    * assuming output_shape = input_shape
    */
-  virtual void DataDependentSetup(SampleWorkspace *ws) {
-    auto &input = ws->Input<CPUBackend>(0);
-    auto &output = ws->Output<CPUBackend>(0);
+  virtual void DataDependentSetup(SampleWorkspace &ws) {
+    auto &input = ws.Input<CPUBackend>(0);
+    auto &output = ws.Output<CPUBackend>(0);
     output.ResizeLike(input);
   }
 
-  void SetupSharedSampleParams(SampleWorkspace *ws) override {
+  void SetupSharedSampleParams(SampleWorkspace &ws) override {
     if (has_mask_) {
-      mask_ = &(ws->ArgumentInput("mask"));
+      mask_ = &(ws.ArgumentInput("mask"));
     }
-    PrepareDisplacement(ws);
+    PrepareDisplacement(&ws);
   }
 
   USE_OPERATOR_MEMBERS();

--- a/dali/pipeline/operators/displacement/displacement_filter_impl_gpu.cuh
+++ b/dali/pipeline/operators/displacement/displacement_filter_impl_gpu.cuh
@@ -230,23 +230,23 @@ class DisplacementFilter<GPUBackend, Displacement,
     return false;
   }
 
-  void RunImpl(DeviceWorkspace* ws) override {
+  void RunImpl(DeviceWorkspace& ws) override {
     DataDependentSetup(ws);
 
-    auto &input = ws->Input<GPUBackend>(0);
+    auto &input = ws.Input<GPUBackend>(0);
     if (IsType<float>(input.type())) {
-      BatchedGPUKernel<float>(ws, 0);
+      BatchedGPUKernel<float>(&ws, 0);
     } else if (IsType<uint8_t>(input.type())) {
-      BatchedGPUKernel<uint8_t>(ws, 0);
+      BatchedGPUKernel<uint8_t>(&ws, 0);
     } else {
       DALI_FAIL("Unexpected input type " + input.type().name());
     }
   }
 
-  virtual void DataDependentSetup(DeviceWorkspace *ws) {
+  virtual void DataDependentSetup(DeviceWorkspace &ws) {
     // check input is valid, resize output
-    auto &input = ws->Input<GPUBackend>(0);
-    auto &output = ws->Output<GPUBackend>(0);
+    auto &input = ws.Input<GPUBackend>(0);
+    auto &output = ws.Output<GPUBackend>(0);
     output.ResizeLike(input);
   }
 
@@ -266,14 +266,14 @@ class DisplacementFilter<GPUBackend, Displacement,
   template <typename U = Displacement>
   std::enable_if_t<!HasParam<U>::value> PrepareDisplacement(DeviceWorkspace *) {}
 
-  void SetupSharedSampleParams(DeviceWorkspace *ws) override {
+  void SetupSharedSampleParams(DeviceWorkspace &ws) override {
     if (has_mask_) {
-      const auto &mask = ws->ArgumentInput("mask");
+      const auto &mask = ws.ArgumentInput("mask");
       mask_gpu_.ResizeLike(mask);
       mask_gpu_.template mutable_data<int>();
-      mask_gpu_.Copy(mask, ws->stream());
+      mask_gpu_.Copy(mask, ws.stream());
     }
-    PrepareDisplacement(ws);
+    PrepareDisplacement(&ws);
   }
 
   USE_OPERATOR_MEMBERS();

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cc
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cc
@@ -119,21 +119,21 @@ void RunHelper(Tensor<CPUBackend> &output,
 }  // namespace detail
 
 template <>
-void CropMirrorNormalize<CPUBackend>::DataDependentSetup(SampleWorkspace *ws) {
-  const auto &input = ws->Input<CPUBackend>(0);
-  SetupSample(ws->data_idx(), input_layout_, input.shape());
-  mirror_[ws->data_idx()] = spec_.GetArgument<int>("mirror", ws, ws->data_idx());
+void CropMirrorNormalize<CPUBackend>::DataDependentSetup(SampleWorkspace &ws) {
+  const auto &input = ws.Input<CPUBackend>(0);
+  SetupSample(ws.data_idx(), input_layout_, input.shape());
+  mirror_[ws.data_idx()] = spec_.GetArgument<int>("mirror", &ws, ws.data_idx());
 
-  auto &output = ws->Output<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
   output.SetLayout(output_layout_);
 }
 
 template <>
-void CropMirrorNormalize<CPUBackend>::RunImpl(SampleWorkspace *ws) {
+void CropMirrorNormalize<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   this->DataDependentSetup(ws);
-  const auto &input = ws->Input<CPUBackend>(0);
-  auto &output = ws->Output<CPUBackend>(0);
-  auto data_idx = ws->data_idx();
+  const auto &input = ws.Input<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
+  auto data_idx = ws.data_idx();
 
   DALI_TYPE_SWITCH_WITH_FP16_CPU(input_type_, InputType,
     DALI_TYPE_SWITCH_WITH_FP16_CPU(output_type_, OutputType,

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cu
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cu
@@ -96,21 +96,21 @@ void RunHelper(TensorList<GPUBackend> &output,
 }  // namespace detail
 
 template <>
-void CropMirrorNormalize<GPUBackend>::DataDependentSetup(DeviceWorkspace *ws) {
-  const auto &input = ws->Input<GPUBackend>(0);
+void CropMirrorNormalize<GPUBackend>::DataDependentSetup(DeviceWorkspace &ws) {
+  const auto &input = ws.Input<GPUBackend>(0);
   for (int sample_idx = 0; sample_idx < batch_size_; sample_idx++) {
     SetupSample(sample_idx, input_layout_, input.tensor_shape(sample_idx));
-    mirror_[sample_idx] = spec_.GetArgument<int>("mirror", ws, sample_idx);
+    mirror_[sample_idx] = spec_.GetArgument<int>("mirror", &ws, sample_idx);
   }
-  auto &output = ws->Output<GPUBackend>(0);
+  auto &output = ws.Output<GPUBackend>(0);
   output.SetLayout(output_layout_);
 }
 
 template<>
-void CropMirrorNormalize<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
+void CropMirrorNormalize<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   this->DataDependentSetup(ws);
-  const auto &input = ws->Input<GPUBackend>(0);
-  auto &output = ws->Output<GPUBackend>(0);
+  const auto &input = ws.Input<GPUBackend>(0);
+  auto &output = ws.Output<GPUBackend>(0);
 
   DALI_TYPE_SWITCH_WITH_FP16_GPU(input_type_, InputType,
     DALI_TYPE_SWITCH_WITH_FP16_GPU(output_type_, OutputType,
@@ -118,7 +118,7 @@ void CropMirrorNormalize<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
         output, input, slice_anchors_, slice_shapes_,
         mirror_, pad_output_, mean_vec_, inv_std_vec_,
         input_layout_, output_layout_,
-        ws->stream(), scratch_alloc_);
+        ws.stream(), scratch_alloc_);
     )
   )
 }

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -61,10 +61,10 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
-  void SetupSharedSampleParams(Workspace<Backend> *ws) override {
-    const auto &input = ws->template Input<Backend>(0);
+  void SetupSharedSampleParams(Workspace<Backend> &ws) override {
+    const auto &input = ws.template Input<Backend>(0);
     input_type_ = input.type().id();
     if (output_type_ == DALI_NO_TYPE)
       output_type_ = input_type_;
@@ -79,7 +79,7 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
     CropAttr::ProcessArguments(ws);
   }
 
-  void DataDependentSetup(Workspace<Backend> *ws);
+  void DataDependentSetup(Workspace<Backend> &ws);
 
   void SetupSample(int data_idx, DALITensorLayout layout, const kernels::TensorShape<> &shape) {
     Index F = 1, H, W, C;

--- a/dali/pipeline/operators/fused/normalize_permute.cc
+++ b/dali/pipeline/operators/fused/normalize_permute.cc
@@ -17,9 +17,9 @@
 namespace dali {
 
   template<>
-  void NormalizePermute<CPUBackend>::RunImpl(SampleWorkspace *ws) {
-    const auto &input = ws->Input<CPUBackend>(0);
-    auto &output = ws->Output<CPUBackend>(0);
+  void NormalizePermute<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+    const auto &input = ws.Input<CPUBackend>(0);
+    auto &output = ws.Output<CPUBackend>(0);
 
     DALI_ENFORCE(IsType<uint8>(input.type()));
     DALI_ENFORCE(input.ndim() == 3,

--- a/dali/pipeline/operators/fused/normalize_permute.cu
+++ b/dali/pipeline/operators/fused/normalize_permute.cu
@@ -104,11 +104,11 @@ void NormalizePermute<GPUBackend>::GPURunHelper(DeviceWorkspace *ws) {
 }
 
 template<>
-void NormalizePermute<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
+void NormalizePermute<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   if (output_type_ == DALI_FLOAT) {
-    GPURunHelper<float>(ws);
+    GPURunHelper<float>(&ws);
   } else if (output_type_ == DALI_FLOAT16) {
-    GPURunHelper<float16>(ws);
+    GPURunHelper<float16>(&ws);
   } else {
     DALI_FAIL("Unsupported output type.");
   }

--- a/dali/pipeline/operators/fused/normalize_permute.h
+++ b/dali/pipeline/operators/fused/normalize_permute.h
@@ -63,7 +63,7 @@ class NormalizePermute : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
   template <typename OUT>
   void CPURunHelper(const Tensor<CPUBackend> &input, Tensor<CPUBackend> &output);

--- a/dali/pipeline/operators/geometric/bb_flip.cc
+++ b/dali/pipeline/operators/geometric/bb_flip.cc
@@ -49,23 +49,23 @@ BbFlip<CPUBackend>::BbFlip(const dali::OpSpec &spec)
   hflip_is_tensor_ = spec.HasTensorArgument(kHorizontalArgName);
 }
 
-void BbFlip<CPUBackend>::RunImpl(dali::SampleWorkspace *ws) {
-  const auto &input = ws->Input<CPUBackend>(0);
+void BbFlip<CPUBackend>::RunImpl(dali::SampleWorkspace &ws) {
+  const auto &input = ws.Input<CPUBackend>(0);
   const auto input_data = input.data<float>();
 
   DALI_ENFORCE(input.type().id() == DALI_FLOAT, "Bounding box in wrong format");
 
   const auto vertical =
       vflip_is_tensor_
-          ? spec_.GetArgument<int>(kVerticalArgName, ws, ws->data_idx())
+          ? spec_.GetArgument<int>(kVerticalArgName, &ws, ws.data_idx())
           : spec_.GetArgument<int>(kVerticalArgName);
 
   const auto horizontal =
       hflip_is_tensor_
-          ? spec_.GetArgument<int>(kHorizontalArgName, ws, ws->data_idx())
+          ? spec_.GetArgument<int>(kHorizontalArgName, &ws, ws.data_idx())
           : spec_.GetArgument<int>(kHorizontalArgName);
 
-  auto &output = ws->Output<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
   // XXX: Setting type of output (i.e. Buffer -> buffer.h)
   //      explicitly is required for further processing
   //      It can also be achieved with mutable_data<>()

--- a/dali/pipeline/operators/geometric/bb_flip.cu
+++ b/dali/pipeline/operators/geometric/bb_flip.cu
@@ -66,9 +66,9 @@ __global__ void BbFlipKernel(float *output, const float *input, size_t num_boxes
 }
 
 
-void BbFlip<GPUBackend>::RunImpl(Workspace<GPUBackend> *ws) {
-  auto &input = ws->Input<GPUBackend>(0);
-  auto&output = ws->Output<GPUBackend>(0);
+void BbFlip<GPUBackend>::RunImpl(Workspace<GPUBackend> &ws) {
+  auto &input = ws.Input<GPUBackend>(0);
+  auto&output = ws.Output<GPUBackend>(0);
 
   DALI_ENFORCE(IsType<float>(input.type()), "Expected input data as float;"
                " got " + input.type().name());
@@ -76,11 +76,11 @@ void BbFlip<GPUBackend>::RunImpl(Workspace<GPUBackend> *ws) {
                "Input data size must be a multiple of 4 if it contains bounding boxes;"
                " got " + std::to_string(input.size()));
 
-  ArgValue<int> horz("horizontal", spec_, ws);
-  ArgValue<int> vert("vertical", spec_, ws);
+  ArgValue<int> horz("horizontal", spec_, &ws);
+  ArgValue<int> vert("vertical", spec_, &ws);
   bool ltrb = spec_.GetArgument<bool>("ltrb");
 
-  auto stream = ws->stream();
+  auto stream = ws.stream();
 
   const auto num_boxes = input.size() / 4;
 

--- a/dali/pipeline/operators/geometric/bb_flip.cuh
+++ b/dali/pipeline/operators/geometric/bb_flip.cuh
@@ -30,7 +30,7 @@ class BbFlip<GPUBackend> : public Operator<GPUBackend> {
     return false;
   }
 
-  void RunImpl(Workspace<GPUBackend> *ws) override;
+  void RunImpl(Workspace<GPUBackend> &ws) override;
  private:
 };
 

--- a/dali/pipeline/operators/geometric/bb_flip.h
+++ b/dali/pipeline/operators/geometric/bb_flip.h
@@ -39,7 +39,7 @@ class BbFlip<CPUBackend> : public Operator<CPUBackend> {
     return false;
   }
 
-  void RunImpl(SampleWorkspace *ws) override;
+  void RunImpl(SampleWorkspace &ws) override;
   using Operator<CPUBackend>::RunImpl;
 
  private:

--- a/dali/pipeline/operators/geometric/flip.cc
+++ b/dali/pipeline/operators/geometric/flip.cc
@@ -52,15 +52,15 @@ void RunFlip(Tensor<CPUBackend> &output, const Tensor<CPUBackend> &input,
 }
 
 template <>
-void Flip<CPUBackend>::RunImpl(Workspace<CPUBackend> *ws) {
-  const auto &input = ws->Input<CPUBackend>(0);
-  auto &output = ws->Output<CPUBackend>(0);
+void Flip<CPUBackend>::RunImpl(Workspace<CPUBackend> &ws) {
+  const auto &input = ws.Input<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
   DALI_ENFORCE(input.ndim() == 3);
   output.SetLayout(input.GetLayout());
   output.set_type(input.type());
   output.ResizeLike(input);
-  auto _horizontal = GetHorizontal(ws, ws->data_idx());
-  auto _vertical = GetVertical(ws, ws->data_idx());
+  auto _horizontal = GetHorizontal(ws, ws.data_idx());
+  auto _vertical = GetVertical(ws, ws.data_idx());
   if (!_horizontal && !_vertical) {
     output.Copy(input, nullptr);
   } else {

--- a/dali/pipeline/operators/geometric/flip.cu
+++ b/dali/pipeline/operators/geometric/flip.cu
@@ -42,16 +42,16 @@ void RunKernel(TensorList<GPUBackend> &output, const TensorList<GPUBackend> &inp
 }
 
 template <>
-void Flip<GPUBackend>::RunImpl(Workspace<GPUBackend> *ws) {
-  const auto &input = ws->Input<GPUBackend>(0);
-  auto &output = ws->Output<GPUBackend>(0);
+void Flip<GPUBackend>::RunImpl(Workspace<GPUBackend> &ws) {
+  const auto &input = ws.Input<GPUBackend>(0);
+  auto &output = ws.Output<GPUBackend>(0);
   DALI_ENFORCE(input.GetLayout() == DALI_NHWC || input.GetLayout() == DALI_NCHW);
   output.SetLayout(input.GetLayout());
   output.set_type(input.type());
   output.ResizeLike(input);
   auto horizontal = GetHorizontal(ws);
   auto vertical = GetVertical(ws);
-  RunKernel(output, input, horizontal, vertical, ws->stream());
+  RunKernel(output, input, horizontal, vertical, ws.stream());
 }
 
 DALI_REGISTER_OPERATOR(Flip, Flip<GPUBackend>, GPU);

--- a/dali/pipeline/operators/geometric/flip.h
+++ b/dali/pipeline/operators/geometric/flip.h
@@ -36,22 +36,22 @@ class Flip: public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
-  int GetHorizontal(const ArgumentWorkspace *ws, int idx) {
-    return this->spec_.template GetArgument<int>("horizontal", ws, idx);
+  int GetHorizontal(const ArgumentWorkspace &ws, int idx) {
+    return this->spec_.template GetArgument<int>("horizontal", &ws, idx);
   }
 
-  int GetVertical(const ArgumentWorkspace *ws, int idx) {
-    return this->spec_.template GetArgument<int>("vertical", ws, idx);
+  int GetVertical(const ArgumentWorkspace &ws, int idx) {
+    return this->spec_.template GetArgument<int>("vertical", &ws, idx);
   }
 
-  std::vector<int> GetHorizontal(const ArgumentWorkspace *ws) {
-    return GetTensorArgument(ws, "horizontal");
+  std::vector<int> GetHorizontal(const ArgumentWorkspace &ws) {
+    return GetTensorArgument(&ws, "horizontal");
   }
 
-  std::vector<int> GetVertical(const ArgumentWorkspace *ws) {
-    return GetTensorArgument(ws, "vertical");
+  std::vector<int> GetVertical(const ArgumentWorkspace &ws) {
+    return GetTensorArgument(&ws, "vertical");
   }
 
  private:

--- a/dali/pipeline/operators/operator_test.cc
+++ b/dali/pipeline/operators/operator_test.cc
@@ -45,7 +45,7 @@ TEST(InstantiateOperator, RunMethodIsAccessible) {
   // We just want to test that Run method is visible (exported to the so file)
   // It is expected that the call throws as the worspace is empty
   ASSERT_THROW(
-    op->Run(&ws),
+    op->Run(ws),
     std::runtime_error);
 }
 

--- a/dali/pipeline/operators/optical_flow/optical_flow.cc
+++ b/dali/pipeline/operators/optical_flow/optical_flow.cc
@@ -56,18 +56,18 @@ constexpr int kNInputDims = 4;
 
 
 template<>
-void OpticalFlow<GPUBackend>::RunImpl(Workspace<GPUBackend> *ws) {
+void OpticalFlow<GPUBackend>::RunImpl(Workspace<GPUBackend> &ws) {
   if (enable_external_hints_) {
     // Fetch data
     // Input is a TensorList, where every Tensor is a sequence
-    const auto &input = ws->Input<GPUBackend>(0);
-    const auto &hints = ws->Input<GPUBackend>(1);
-    auto &output = ws->Output<GPUBackend>(0);
+    const auto &input = ws.Input<GPUBackend>(0);
+    const auto &hints = ws.Input<GPUBackend>(1);
+    auto &output = ws.Output<GPUBackend>(0);
 
     // Extract calculation params
     ExtractParams(input, hints);
 
-    of_lazy_init(frames_width_, frames_height_, depth_, image_type_, device_id_, ws->stream());
+    of_lazy_init(frames_width_, frames_height_, depth_, image_type_, device_id_, ws.stream());
 
     auto out_shape = optical_flow_->GetOutputShape();
     kernels::TensorListShape<> new_sizes(nsequences_, 1 + out_shape.sample_dim());
@@ -101,14 +101,14 @@ void OpticalFlow<GPUBackend>::RunImpl(Workspace<GPUBackend> *ws) {
   } else {
     // Fetch data
     // Input is a TensorList, where every Tensor is a sequence
-    const auto &input = ws->Input<GPUBackend>(0);
-    auto &output = ws->Output<GPUBackend>(0);
+    const auto &input = ws.Input<GPUBackend>(0);
+    auto &output = ws.Output<GPUBackend>(0);
 
 
     // Extract calculation params
     ExtractParams(input);
 
-    of_lazy_init(frames_width_, frames_height_, depth_, image_type_, device_id_, ws->stream());
+    of_lazy_init(frames_width_, frames_height_, depth_, image_type_, device_id_, ws.stream());
 
     auto out_shape = optical_flow_->GetOutputShape();
     kernels::TensorListShape<> new_sizes(nsequences_, 1 + out_shape.sample_dim());

--- a/dali/pipeline/operators/optical_flow/optical_flow.h
+++ b/dali/pipeline/operators/optical_flow/optical_flow.h
@@ -90,7 +90,7 @@ class OpticalFlow : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
 
  private:

--- a/dali/pipeline/operators/paste/bbox_paste.cc
+++ b/dali/pipeline/operators/paste/bbox_paste.cc
@@ -51,24 +51,24 @@ False for for width-height representation.)code",
       0.5f, true);
 
 template<>
-void BBoxPaste<CPUBackend>::RunImpl(Workspace<CPUBackend> *ws) {
-  const auto &input = ws->Input<CPUBackend>(0);
+void BBoxPaste<CPUBackend>::RunImpl(Workspace<CPUBackend> &ws) {
+  const auto &input = ws.Input<CPUBackend>(0);
   const auto input_data = input.data<float>();
 
   DALI_ENFORCE(input.type().id() == DALI_FLOAT, "Bounding box in wrong format");
   DALI_ENFORCE(input.size() % 4 == 0, "Bounding box tensor size must be a multiple of 4."
                                       "Got: " + std::to_string(input.size()));
 
-  auto &output = ws->Output<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
   output.set_type(TypeInfo::Create<float>());
   output.ResizeLike(input);
   auto *output_data = output.mutable_data<float>();
 
-  const auto data_idx = ws->data_idx();
+  const auto data_idx = ws.data_idx();
   // pasting onto a larger canvas scales bounding boxes down by scale ratio
-  float ratio = spec_.GetArgument<float>("ratio", ws, data_idx);
-  float px = spec_.GetArgument<float>("paste_x", ws, data_idx);
-  float py = spec_.GetArgument<float>("paste_y", ws, data_idx);
+  float ratio = spec_.GetArgument<float>("ratio", &ws, data_idx);
+  float px = spec_.GetArgument<float>("paste_x", &ws, data_idx);
+  float py = spec_.GetArgument<float>("paste_y", &ws, data_idx);
   float scale = 1 / ratio;
 
   // offsets are scaled so that (0,0) pastes the image aligned to the top-left

--- a/dali/pipeline/operators/paste/bbox_paste.h
+++ b/dali/pipeline/operators/paste/bbox_paste.h
@@ -39,7 +39,7 @@ class BBoxPaste : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
   USE_OPERATOR_MEMBERS();
   using Operator<Backend>::RunImpl;

--- a/dali/pipeline/operators/paste/paste.h
+++ b/dali/pipeline/operators/paste/paste.h
@@ -57,13 +57,13 @@ class Paste : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
-  void SetupSharedSampleParams(Workspace<Backend> *ws) override;
+  void SetupSharedSampleParams(Workspace<Backend> &ws) override;
 
-  void SetupSampleParams(Workspace<Backend> *ws);
+  void SetupSampleParams(Workspace<Backend> &ws);
 
-  void RunHelper(Workspace<Backend> *ws);
+  void RunHelper(Workspace<Backend> &ws);
 
   // Op parameters
   int C_;

--- a/dali/pipeline/operators/python_function/python_function.h
+++ b/dali/pipeline/operators/python_function/python_function.h
@@ -37,7 +37,7 @@ class PythonFunctionImpl : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
   USE_OPERATOR_MEMBERS();
   using Operator<Backend>::RunImpl;

--- a/dali/pipeline/operators/reader/caffe2_reader_op.h
+++ b/dali/pipeline/operators/reader/caffe2_reader_op.h
@@ -29,9 +29,9 @@ class Caffe2Reader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
     parser_.reset(new Caffe2Parser(spec));
   }
 
-  void RunImpl(SampleWorkspace* ws) override {
-    const auto& tensor = GetSample(ws->data_idx());
-    ParseIfNeeded(tensor, ws);
+  void RunImpl(SampleWorkspace &ws) override {
+    const auto& tensor = GetSample(ws.data_idx());
+    ParseIfNeeded(tensor, &ws);
   }
 
  protected:

--- a/dali/pipeline/operators/reader/caffe_reader_op.h
+++ b/dali/pipeline/operators/reader/caffe_reader_op.h
@@ -29,9 +29,9 @@ class CaffeReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
     parser_.reset(new CaffeParser(spec));
   }
 
-  void RunImpl(SampleWorkspace* ws) override {
-    const auto& tensor = GetSample(ws->data_idx());
-    ParseIfNeeded(tensor, ws);
+  void RunImpl(SampleWorkspace &ws) override {
+    const auto& tensor = GetSample(ws.data_idx());
+    ParseIfNeeded(tensor, &ws);
   }
 
  protected:

--- a/dali/pipeline/operators/reader/coco_reader_op.h
+++ b/dali/pipeline/operators/reader/coco_reader_op.h
@@ -46,11 +46,11 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
       shuffle_after_epoch);
   }
 
-  void RunImpl(SampleWorkspace* ws) override {
-    const ImageLabelWrapper& image_label = GetSample(ws->data_idx());
+  void RunImpl(SampleWorkspace &ws) override {
+    const ImageLabelWrapper& image_label = GetSample(ws.data_idx());
 
     Index image_size = image_label.image.size();
-    auto &image_output = ws->Output<CPUBackend>(0);
+    auto &image_output = ws.Output<CPUBackend>(0);
     int image_id = image_label.label;
 
     image_output.Resize({image_size});
@@ -61,7 +61,7 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
       image_size);
     image_output.SetSourceInfo(image_label.image.GetSourceInfo());
 
-    auto &boxes_output = ws->Output<CPUBackend>(1);
+    auto &boxes_output = ws.Output<CPUBackend>(1);
     boxes_output.Resize({counts_[image_id], 4});
     auto boxes_out_data = boxes_output.mutable_data<float>();
     memcpy(
@@ -69,7 +69,7 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
       boxes_.data() + 4 * offsets_[image_id],
       counts_[image_id] * 4 * sizeof(float));
 
-    auto &labels_output = ws->Output<CPUBackend>(2);
+    auto &labels_output = ws.Output<CPUBackend>(2);
     labels_output.Resize({counts_[image_id], 1});
     auto labels_out_data = labels_output.mutable_data<int>();
     memcpy(
@@ -78,7 +78,7 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
       counts_[image_id] * sizeof(int));
 
     if (save_img_ids_) {
-      auto &id_output = ws->Output<CPUBackend>(3);
+      auto &id_output = ws.Output<CPUBackend>(3);
       id_output.Resize({1});
       auto id_out_data = id_output.mutable_data<int>();
       memcpy(

--- a/dali/pipeline/operators/reader/file_reader_op.h
+++ b/dali/pipeline/operators/reader/file_reader_op.h
@@ -32,14 +32,14 @@ class FileReader : public DataReader<CPUBackend, ImageLabelWrapper> {
                                      shuffle_after_epoch);
   }
 
-  void RunImpl(SampleWorkspace *ws) override {
-    const int idx = ws->data_idx();
+  void RunImpl(SampleWorkspace &ws) override {
+    const int idx = ws.data_idx();
 
     const auto& image_label = GetSample(idx);
 
     // copy from raw_data -> outputs directly
-    auto &image_output = ws->Output<CPUBackend>(0);
-    auto &label_output = ws->Output<CPUBackend>(1);
+    auto &image_output = ws.Output<CPUBackend>(0);
+    auto &label_output = ws.Output<CPUBackend>(1);
 
     Index image_size = image_label.image.size();
 

--- a/dali/pipeline/operators/reader/mxnet_reader_op.h
+++ b/dali/pipeline/operators/reader/mxnet_reader_op.h
@@ -28,9 +28,9 @@ class MXNetReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
     parser_.reset(new RecordIOParser(spec));
   }
 
-  void RunImpl(SampleWorkspace* ws) override {
-    const auto& tensor = GetSample(ws->data_idx());
-    ParseIfNeeded(tensor, ws);
+  void RunImpl(SampleWorkspace &ws) override {
+    const auto& tensor = GetSample(ws.data_idx());
+    ParseIfNeeded(tensor, &ws);
   }
 
  protected:

--- a/dali/pipeline/operators/reader/reader_op.h
+++ b/dali/pipeline/operators/reader/reader_op.h
@@ -129,7 +129,7 @@ class DataReader : public Operator<Backend> {
   }
 
   // CPUBackend operators
-  void Run(HostWorkspace* ws) override {
+  void Run(HostWorkspace &ws) override {
     // If necessary start prefetching thread and wait for a consumable batch
     StartPrefetchThread();
     ConsumerWait();
@@ -145,14 +145,14 @@ class DataReader : public Operator<Backend> {
   }
 
   // GPUBackend operators
-  void Run(DeviceWorkspace* ws) override {
+  void Run(DeviceWorkspace &ws) override {
     // If necessary start prefetching thread and wait for a consumable batch
     StartPrefetchThread();
     ConsumerWait();
 
     // Consume batch
     Operator<Backend>::Run(ws);
-    CUDA_CALL(cudaStreamSynchronize(ws->stream()));
+    CUDA_CALL(cudaStreamSynchronize(ws.stream()));
     for (int sample_idx = 0; sample_idx < Operator<Backend>::batch_size_; sample_idx++) {
       auto sample = MoveSample(sample_idx);
     }

--- a/dali/pipeline/operators/reader/reader_op_test.cc
+++ b/dali/pipeline/operators/reader/reader_op_test.cc
@@ -86,10 +86,10 @@ class DummyDataReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
   }
   */
 
-  void RunImpl(SampleWorkspace* ws) override {
+  void RunImpl(SampleWorkspace &ws) override {
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
-    ws->Output<CPUBackend>(0).Copy(GetSample(ws->data_idx()), 0);
+    ws.Output<CPUBackend>(0).Copy(GetSample(ws.data_idx()), 0);
   }
 
  private:

--- a/dali/pipeline/operators/reader/sequence_reader_op.cc
+++ b/dali/pipeline/operators/reader/sequence_reader_op.cc
@@ -18,8 +18,8 @@
 
 namespace dali {
 
-void SequenceReader::RunImpl(SampleWorkspace* ws) {
-  parser_->Parse(GetSample(ws->data_idx()), ws);
+void SequenceReader::RunImpl(SampleWorkspace &ws) {
+  parser_->Parse(GetSample(ws.data_idx()), &ws);
 }
 
 DALI_REGISTER_OPERATOR(SequenceReader, SequenceReader, CPU);

--- a/dali/pipeline/operators/reader/sequence_reader_op.h
+++ b/dali/pipeline/operators/reader/sequence_reader_op.h
@@ -28,7 +28,7 @@ class SequenceReader : public DataReader<CPUBackend, TensorSequence> {
     parser_.reset(new SequenceParser(spec));
   }
 
-  void RunImpl(SampleWorkspace* ws) override;
+  void RunImpl(SampleWorkspace &ws) override;
 
  protected:
   USE_READER_OPERATOR_MEMBERS(CPUBackend, TensorSequence);

--- a/dali/pipeline/operators/reader/tfrecord_reader_op.h
+++ b/dali/pipeline/operators/reader/tfrecord_reader_op.h
@@ -33,9 +33,9 @@ class TFRecordReader : public DataReader<CPUBackend, Tensor<CPUBackend>> {
       "TFRecordReader doesn't support `skip_cached_images` option");
   }
 
-  void RunImpl(SampleWorkspace* ws) override {
-    const auto& tensor = GetSample(ws->data_idx());
-    parser_->Parse(tensor, ws);
+  void RunImpl(SampleWorkspace &ws) override {
+    const auto& tensor = GetSample(ws.data_idx());
+    parser_->Parse(tensor, &ws);
   }
 
  protected:

--- a/dali/pipeline/operators/reader/video_reader_op.h
+++ b/dali/pipeline/operators/reader/video_reader_op.h
@@ -72,11 +72,11 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
   inline ~VideoReader() override = default;
 
  protected:
-  void SetupSharedSampleParams(DeviceWorkspace *ws) override {
+  void SetupSharedSampleParams(DeviceWorkspace &ws) override {
   }
 
-  void RunImpl(DeviceWorkspace *ws) override {
-    auto& tl_sequence_output = ws->Output<GPUBackend>(0);
+  void RunImpl(DeviceWorkspace &ws) override {
+    auto& tl_sequence_output = ws.Output<GPUBackend>(0);
     TensorList<GPUBackend> *label_output = NULL;
 
     if (dtype_ == DALI_FLOAT) {
@@ -89,7 +89,7 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
     tl_sequence_output.SetLayout(DALI_NFHWC);
 
     if (enable_label_output_) {
-      label_output = &ws->Output<GPUBackend>(1);
+      label_output = &ws.Output<GPUBackend>(1);
       label_output->set_type(TypeInfo::Create<int>());
       label_output->Resize(label_shape_);
     }
@@ -101,12 +101,12 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
       tl_sequence_output.type().Copy<GPUBackend, GPUBackend>(sequence_output,
                                   prefetched_sequence.sequence.raw_data(),
                                   prefetched_sequence.sequence.size(),
-                                  ws->stream());
+                                  ws.stream());
 
         if (enable_label_output_) {
           auto *label = label_output->mutable_tensor<int>(data_idx);
           CUDA_CALL(cudaMemcpyAsync(label, &prefetched_sequence.label, sizeof(int),
-                                    cudaMemcpyDefault, ws->stream()));
+                                    cudaMemcpyDefault, ws.stream()));
         }
     }
   }

--- a/dali/pipeline/operators/resize/random_resized_crop.cc
+++ b/dali/pipeline/operators/resize/random_resized_crop.cc
@@ -42,8 +42,8 @@ void RandomResizedCrop<CPUBackend>::BackendInit() {
 }
 
 template<>
-void RandomResizedCrop<CPUBackend>::RunImpl(SampleWorkspace * ws) {
-  auto &input = ws->Input<CPUBackend>(0);
+void RandomResizedCrop<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+  auto &input = ws.Input<CPUBackend>(0);
   DALI_ENFORCE(input.ndim() == 3, "Operator expects 3-dimensional image input.");
   DALI_ENFORCE(IsType<uint8>(input.type()), "Expected input data as uint8.");
 
@@ -53,24 +53,24 @@ void RandomResizedCrop<CPUBackend>::RunImpl(SampleWorkspace * ws) {
   const int newH = size_[0];
   const int newW = size_[1];
 
-  auto &output = ws->Output<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
 
-  RunCPU(output, input, ws->thread_idx());
+  RunCPU(output, input, ws.thread_idx());
 }
 
 template<>
-void RandomResizedCrop<CPUBackend>::SetupSharedSampleParams(SampleWorkspace *ws) {
-  auto &input = ws->Input<CPUBackend>(0);
+void RandomResizedCrop<CPUBackend>::SetupSharedSampleParams(SampleWorkspace &ws) {
+  auto &input = ws.Input<CPUBackend>(0);
   auto& input_shape = input.shape();
   DALI_ENFORCE(input_shape.size() == 3,
       "Expects 3-dimensional image input.");
 
   int H = input_shape[0];
   int W = input_shape[1];
-  int id = ws->data_idx();
+  int id = ws.data_idx();
 
   crops_[id] = GetCropWindowGenerator(id)(H, W);
-  resample_params_[ws->thread_idx()] = CalcResamplingParams(id);
+  resample_params_[ws.thread_idx()] = CalcResamplingParams(id);
 }
 
 DALI_REGISTER_OPERATOR(RandomResizedCrop, RandomResizedCrop<CPUBackend>, CPU);

--- a/dali/pipeline/operators/resize/random_resized_crop.cu
+++ b/dali/pipeline/operators/resize/random_resized_crop.cu
@@ -28,21 +28,21 @@ void RandomResizedCrop<GPUBackend>::BackendInit() {
 }
 
 template<>
-void RandomResizedCrop<GPUBackend>::RunImpl(DeviceWorkspace * ws) {
-  auto &input = ws->Input<GPUBackend>(0);
+void RandomResizedCrop<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
+  auto &input = ws.Input<GPUBackend>(0);
   DALI_ENFORCE(IsType<uint8>(input.type()),
       "Expected input data as uint8.");
 
   const int newH = size_[0];
   const int newW = size_[1];
 
-  auto &output = ws->Output<GPUBackend>(0);
-  RunGPU(output, input, ws->stream());
+  auto &output = ws.Output<GPUBackend>(0);
+  RunGPU(output, input, ws.stream());
 }
 
 template<>
-void RandomResizedCrop<GPUBackend>::SetupSharedSampleParams(DeviceWorkspace *ws) {
-  auto &input = ws->Input<GPUBackend>(0);
+void RandomResizedCrop<GPUBackend>::SetupSharedSampleParams(DeviceWorkspace &ws) {
+  auto &input = ws.Input<GPUBackend>(0);
   DALI_ENFORCE(IsType<uint8>(input.type()),
       "Expected input data as uint8.");
 

--- a/dali/pipeline/operators/resize/random_resized_crop.h
+++ b/dali/pipeline/operators/resize/random_resized_crop.h
@@ -56,8 +56,8 @@ class RandomResizedCrop : public Operator<Backend>
     return false;
   }
 
-  void RunImpl(Workspace<Backend> * ws) override;
-  void SetupSharedSampleParams(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
+  void SetupSharedSampleParams(Workspace<Backend> &ws) override;
 
  private:
   void BackendInit();

--- a/dali/pipeline/operators/resize/resize.cc
+++ b/dali/pipeline/operators/resize/resize.cc
@@ -79,17 +79,17 @@ Resize<CPUBackend>::Resize(const OpSpec &spec)
 }
 
 template <>
-void Resize<CPUBackend>::SetupSharedSampleParams(SampleWorkspace *ws) {
-  const int thread_idx = ws->thread_idx();
-  per_sample_meta_[thread_idx] = GetTransfomMeta(ws, spec_);
+void Resize<CPUBackend>::SetupSharedSampleParams(SampleWorkspace &ws) {
+  const int thread_idx = ws.thread_idx();
+  per_sample_meta_[thread_idx] = GetTransfomMeta(&ws, spec_);
   resample_params_[thread_idx] = GetResamplingParams(per_sample_meta_[thread_idx]);
 }
 
 template <>
-void Resize<CPUBackend>::RunImpl(SampleWorkspace *ws) {
-  const int thread_idx = ws->thread_idx();
-  const auto &input = ws->Input<CPUBackend>(0);
-  auto &output = ws->Output<CPUBackend>(0);
+void Resize<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+  const int thread_idx = ws.thread_idx();
+  const auto &input = ws.Input<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
 
   DALI_ENFORCE(IsType<uint8>(input.type()), "Expected input data as uint8.");
   DALI_ENFORCE(input.ndim() == 3, "Resize expects 3-dimensional tensor input.");
@@ -101,7 +101,7 @@ void Resize<CPUBackend>::RunImpl(SampleWorkspace *ws) {
   RunCPU(output, input, thread_idx);
 
   if (save_attrs_) {
-    auto &attr_output = ws->Output<CPUBackend>(1);
+    auto &attr_output = ws.Output<CPUBackend>(1);
     auto &in_shape = input.shape();
 
     attr_output.Resize({2});

--- a/dali/pipeline/operators/resize/resize.cu
+++ b/dali/pipeline/operators/resize/resize.cu
@@ -37,8 +37,8 @@ Resize<GPUBackend>::Resize(const OpSpec &spec)
 }
 
 template<>
-void Resize<GPUBackend>::SetupSharedSampleParams(DeviceWorkspace* ws) {
-  auto &input = ws->Input<GPUBackend>(0);
+void Resize<GPUBackend>::SetupSharedSampleParams(DeviceWorkspace &ws) {
+  auto &input = ws.Input<GPUBackend>(0);
 
   DALI_ENFORCE(IsType<uint8>(input.type()), "Expected input data as uint8.");
   if (input.GetLayout() != DALI_UNKNOWN) {
@@ -50,17 +50,17 @@ void Resize<GPUBackend>::SetupSharedSampleParams(DeviceWorkspace* ws) {
     auto input_shape = input.tensor_shape(i);
     DALI_ENFORCE(input_shape.size() == 3, "Expects 3-dimensional image input.");
 
-    per_sample_meta_[i] = GetTransformMeta(spec_, input_shape, ws, i, ResizeInfoNeeded());
+    per_sample_meta_[i] = GetTransformMeta(spec_, input_shape, &ws, i, ResizeInfoNeeded());
     resample_params_[i] = GetResamplingParams(per_sample_meta_[i]);
   }
 }
 
 template<>
-void Resize<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
-  const auto &input = ws->Input<GPUBackend>(0);
-  auto &output = ws->Output<GPUBackend>(0);
+void Resize<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
+  const auto &input = ws.Input<GPUBackend>(0);
+  auto &output = ws.Output<GPUBackend>(0);
 
-  RunGPU(output, input, ws->stream());
+  RunGPU(output, input, ws.stream());
 
   // Setup and output the resize attributes if necessary
   if (save_attrs_) {
@@ -80,7 +80,7 @@ void Resize<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
       t[0] = sample_shape[0];
       t[1] = sample_shape[1];
     }
-    ws->Output<GPUBackend>(1).Copy(attr_output_cpu, ws->stream());
+    ws.Output<GPUBackend>(1).Copy(attr_output_cpu, ws.stream());
   }
 }
 

--- a/dali/pipeline/operators/resize/resize.h
+++ b/dali/pipeline/operators/resize/resize.h
@@ -58,8 +58,8 @@ class Resize : public Operator<Backend>
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
-  void SetupSharedSampleParams(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
+  void SetupSharedSampleParams(Workspace<Backend> &ws) override;
 
   kernels::ResamplingParams2D GetResamplingParams(const TransformMeta &meta) const {
     kernels::ResamplingParams2D params;

--- a/dali/pipeline/operators/sequence/element_extract.cc
+++ b/dali/pipeline/operators/sequence/element_extract.cc
@@ -34,8 +34,8 @@ DALI_SCHEMA(ElementExtract)
         });
 
 template <>
-void ElementExtract<CPUBackend>::RunImpl(SampleWorkspace *ws) {
-    const auto &input = ws->Input<CPUBackend>(0);
+void ElementExtract<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+    const auto &input = ws.Input<CPUBackend>(0);
     auto element_layout = GetElementLayout(input.GetLayout());
 
     auto shape = input.shape();
@@ -49,7 +49,7 @@ void ElementExtract<CPUBackend>::RunImpl(SampleWorkspace *ws) {
     TypeInfo type = input.type();
     for (std::size_t k = 0; k < elements_per_sample; k++) {
         auto output_idx = output_offset + k;
-        auto &output = ws->Output<CPUBackend>(output_idx);
+        auto &output = ws.Output<CPUBackend>(output_idx);
         output.set_type(input.type());
         output.SetLayout(element_layout);
         output.Resize(output_shape);

--- a/dali/pipeline/operators/sequence/element_extract.cu
+++ b/dali/pipeline/operators/sequence/element_extract.cu
@@ -34,8 +34,8 @@ kernels::TensorListShape<> GetOutputShape(const TensorList<GPUBackend> &input,
 }  // namespace detail
 
 template <>
-void ElementExtract<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
-    auto &input = ws->Input<GPUBackend>(0);
+void ElementExtract<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
+    auto &input = ws.Input<GPUBackend>(0);
     auto output_shape = detail::GetOutputShape(input, element_map_);
     auto element_layout = GetElementLayout(input.GetLayout());
     int elements_per_sample = element_map_.size();
@@ -43,7 +43,7 @@ void ElementExtract<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
     auto data_type = input.type();
     for (int k = 0; k < elements_per_sample; k++) {
         int element = element_map_[k];
-        auto &output = ws->Output<GPUBackend>(output_offset + k);
+        auto &output = ws.Output<GPUBackend>(output_offset + k);
         output.set_type(input.type());
         output.SetLayout(element_layout);
         output.Resize(output_shape);
@@ -57,7 +57,7 @@ void ElementExtract<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
                 output.raw_mutable_tensor(i),
                 static_cast<const uint8_t*>(input.raw_tensor(i)) + input_offset_bytes,
                 element_size,
-                ws->stream());
+                ws.stream());
         }
     }
 }

--- a/dali/pipeline/operators/sequence/element_extract.h
+++ b/dali/pipeline/operators/sequence/element_extract.h
@@ -55,7 +55,7 @@ class ElementExtract : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
   USE_OPERATOR_MEMBERS();
   using Operator<Backend>::RunImpl;

--- a/dali/pipeline/operators/support/random/coin_flip.cc
+++ b/dali/pipeline/operators/support/random/coin_flip.cc
@@ -17,11 +17,11 @@
 
 namespace dali {
 
-void CoinFlip::RunImpl(SupportWorkspace * ws) {
-  auto &output = ws->Output<CPUBackend>(0);
+void CoinFlip::RunImpl(SupportWorkspace &ws) {
+  auto &output = ws.Output<CPUBackend>(0);
   output.Resize({batch_size_});
 
-  int * out_data = output.template mutable_data<int>();
+  int *out_data = output.template mutable_data<int>();
 
   for (int i = 0; i < batch_size_; ++i) {
     out_data[i] = dis_(rng_) ? 1 : 0;

--- a/dali/pipeline/operators/support/random/coin_flip.h
+++ b/dali/pipeline/operators/support/random/coin_flip.h
@@ -41,7 +41,7 @@ class CoinFlip : public Operator<SupportBackend> {
     return false;
   }
 
-  void RunImpl(Workspace<SupportBackend> * ws) override;
+  void RunImpl(Workspace<SupportBackend> &ws) override;
 
  private:
   std::bernoulli_distribution dis_;

--- a/dali/pipeline/operators/support/random/uniform.cc
+++ b/dali/pipeline/operators/support/random/uniform.cc
@@ -19,11 +19,11 @@
 
 namespace dali {
 
-void Uniform::RunImpl(SupportWorkspace * ws) {
-  auto &output = ws->Output<CPUBackend>(0);
+void Uniform::RunImpl(SupportWorkspace &ws) {
+  auto &output = ws.Output<CPUBackend>(0);
   output.Resize({batch_size_});
 
-  float * out_data = output.template mutable_data<float>();
+  float *out_data = output.template mutable_data<float>();
 
   for (int i = 0; i < batch_size_; ++i) {
     out_data[i] = dis_(rng_);

--- a/dali/pipeline/operators/support/random/uniform.h
+++ b/dali/pipeline/operators/support/random/uniform.h
@@ -45,7 +45,7 @@ class Uniform : public Operator<SupportBackend> {
     return false;
   }
 
-  void RunImpl(Workspace<SupportBackend> * ws) override;
+  void RunImpl(Workspace<SupportBackend> &ws) override;
 
  private:
   std::uniform_real_distribution<float> dis_;

--- a/dali/pipeline/operators/transpose/transpose.cu
+++ b/dali/pipeline/operators/transpose/transpose.cu
@@ -134,9 +134,9 @@ inline kernels::TensorShape<> GetPermutedDims(const kernels::TensorShape<>& dims
 }
 
 template<>
-void Transpose<GPUBackend>::RunImpl(DeviceWorkspace* ws) {
-  const auto& input = ws->Input<GPUBackend>(0);
-  auto& output = ws->Output<GPUBackend>(0);
+void Transpose<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
+  const auto& input = ws.Input<GPUBackend>(0);
+  auto& output = ws.Output<GPUBackend>(0);
 
   TypeInfo itype = input.type();
   DALI_ENFORCE((itype.size() == 1 || itype.size() == 2 || itype.size() == 4 || itype.size() == 8),
@@ -162,13 +162,13 @@ void Transpose<GPUBackend>::RunImpl(DeviceWorkspace* ws) {
     auto permuted_dims = GetPermutedDims(input_shape, perm_);
     output.Resize(kernels::uniform_list_shape(batch_size_, permuted_dims));
     if (itype.size() == 1) {
-      kernel::cuTTKernelBatched<uint8_t>(input, output, perm_, &cutt_handle_, ws->stream());
+      kernel::cuTTKernelBatched<uint8_t>(input, output, perm_, &cutt_handle_, ws.stream());
     } else if (itype.size() == 2) {
-      kernel::cuTTKernelBatched<uint16_t>(input, output, perm_, &cutt_handle_, ws->stream());
+      kernel::cuTTKernelBatched<uint16_t>(input, output, perm_, &cutt_handle_, ws.stream());
     } else if (itype.size() == 4) {
-      kernel::cuTTKernelBatched<int32_t>(input, output, perm_, &cutt_handle_, ws->stream());
+      kernel::cuTTKernelBatched<int32_t>(input, output, perm_, &cutt_handle_, ws.stream());
     } else {  // itype.size() == 8
-      kernel::cuTTKernelBatched<int64_t>(input, output, perm_, &cutt_handle_, ws->stream());
+      kernel::cuTTKernelBatched<int64_t>(input, output, perm_, &cutt_handle_, ws.stream());
     }
   } else {
     std::vector<kernels::TensorShape<>> tl_shape;
@@ -178,13 +178,13 @@ void Transpose<GPUBackend>::RunImpl(DeviceWorkspace* ws) {
     }
     output.Resize(tl_shape);
     if (itype.size() == 1) {
-      kernel::cuTTKernel<uint8_t>(input, output, perm_, ws->stream());
+      kernel::cuTTKernel<uint8_t>(input, output, perm_, ws.stream());
     } else if (itype.size() == 2) {
-      kernel::cuTTKernel<uint16_t>(input, output, perm_, ws->stream());
+      kernel::cuTTKernel<uint16_t>(input, output, perm_, ws.stream());
     } else if (itype.size() == 4) {
-      kernel::cuTTKernel<int32_t>(input, output, perm_, ws->stream());
+      kernel::cuTTKernel<int32_t>(input, output, perm_, ws.stream());
     } else {  // itype.size() == 8
-      kernel::cuTTKernel<int64_t>(input, output, perm_, ws->stream());
+      kernel::cuTTKernel<int64_t>(input, output, perm_, ws.stream());
     }
   }
 }

--- a/dali/pipeline/operators/transpose/transpose.h
+++ b/dali/pipeline/operators/transpose/transpose.h
@@ -50,7 +50,7 @@ class Transpose : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
  private:
   std::vector<int> perm_;

--- a/dali/pipeline/operators/util/cast.cc
+++ b/dali/pipeline/operators/util/cast.cc
@@ -18,9 +18,9 @@
 namespace dali {
 
 template<>
-void Cast<CPUBackend>::RunImpl(SampleWorkspace *ws) {
-  auto &input = ws->Input<CPUBackend>(0);
-  auto &output = ws->Output<CPUBackend>(0);
+void Cast<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+  auto &input = ws.Input<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
 
   DALIDataType itype = input.type().id();
 

--- a/dali/pipeline/operators/util/cast.cu
+++ b/dali/pipeline/operators/util/cast.cu
@@ -45,9 +45,9 @@ DALIError_t BatchedCast(OType * output,
 }
 
 template<>
-void Cast<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
-  const auto &input = ws->Input<GPUBackend>(0);
-  auto &output = ws->Output<GPUBackend>(0);
+void Cast<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
+  const auto &input = ws.Input<GPUBackend>(0);
+  auto &output = ws.Output<GPUBackend>(0);
 
   DALIDataType itype = input.type().id();
 
@@ -59,7 +59,7 @@ void Cast<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
             output.mutable_data<OType>(),
             input.data<IType>(),
             input.size(),
-            ws->stream()));););
+            ws.stream()));););
 }
 
 DALI_REGISTER_OPERATOR(Cast, Cast<GPUBackend>, GPU);

--- a/dali/pipeline/operators/util/cast.h
+++ b/dali/pipeline/operators/util/cast.h
@@ -39,7 +39,7 @@ class Cast : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
  private:
   template <typename IType, typename OType>

--- a/dali/pipeline/operators/util/copy.cc
+++ b/dali/pipeline/operators/util/copy.cc
@@ -17,9 +17,9 @@
 namespace dali {
 
 template<>
-void Copy<CPUBackend>::RunImpl(SampleWorkspace *ws) {
-  auto &input = ws->Input<CPUBackend>(0);
-  auto &output = ws->Output<CPUBackend>(0);
+void Copy<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+  auto &input = ws.Input<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
   output.set_type(input.type());
   output.SetLayout(input.GetLayout());
   output.ResizeLike(input);

--- a/dali/pipeline/operators/util/copy.cu
+++ b/dali/pipeline/operators/util/copy.cu
@@ -18,9 +18,9 @@
 namespace dali {
 
 template<>
-void Copy<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
-  auto &input = ws->Input<GPUBackend>(0);
-  auto &output = ws->Output<GPUBackend>(0);
+void Copy<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
+  auto &input = ws.Input<GPUBackend>(0);
+  auto &output = ws.Output<GPUBackend>(0);
   output.set_type(input.type());
   output.SetLayout(input.GetLayout());
   output.ResizeLike(input);
@@ -29,7 +29,7 @@ void Copy<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
           input.raw_data(),
           input.nbytes(),
           cudaMemcpyDeviceToDevice,
-          ws->stream()));
+          ws.stream()));
 }
 
 DALI_REGISTER_OPERATOR(Copy, Copy<GPUBackend>, GPU);

--- a/dali/pipeline/operators/util/copy.h
+++ b/dali/pipeline/operators/util/copy.h
@@ -37,7 +37,7 @@ class Copy : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/util/dummy_op.h
+++ b/dali/pipeline/operators/util/dummy_op.h
@@ -36,7 +36,7 @@ class DummyOp : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *) override {
+  void RunImpl(Workspace<Backend> &) override {
     DALI_FAIL("I'm a dummy op don't run me");
   }
 };

--- a/dali/pipeline/operators/util/dump_image.cc
+++ b/dali/pipeline/operators/util/dump_image.cc
@@ -18,9 +18,9 @@
 namespace dali {
 
 template<>
-void DumpImage<CPUBackend>::RunImpl(SampleWorkspace *ws) {
-  auto &input = ws->Input<CPUBackend>(0);
-  auto &output = ws->Output<CPUBackend>(0);
+void DumpImage<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+  auto &input = ws.Input<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
 
   DALI_ENFORCE(input.ndim() == 3,
       "Input images must have three dimensions.");
@@ -30,7 +30,7 @@ void DumpImage<CPUBackend>::RunImpl(SampleWorkspace *ws) {
   int c = input.dim(2);
 
   WriteHWCImage(input.template data<uint8>(),
-      h, w, c, std::to_string(ws->data_idx()) + "-" + suffix_ + "-" + std::to_string(0));
+      h, w, c, std::to_string(ws.data_idx()) + "-" + suffix_ + "-" + std::to_string(0));
 
   // Forward the input
   output.Copy(input, 0);

--- a/dali/pipeline/operators/util/dump_image.cu
+++ b/dali/pipeline/operators/util/dump_image.cu
@@ -18,14 +18,14 @@
 namespace dali {
 
 template<>
-void DumpImage<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
-  auto &input = ws->Input<GPUBackend>(0);
-  auto &output = ws->Output<GPUBackend>(0);
+void DumpImage<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
+  auto &input = ws.Input<GPUBackend>(0);
+  auto &output = ws.Output<GPUBackend>(0);
 
   WriteHWCBatch(input, suffix_ + "-" + std::to_string(0));
 
   // Forward the input
-  output.Copy(input, ws->stream());
+  output.Copy(input, ws.stream());
 }
 
 DALI_REGISTER_OPERATOR(DumpImage, DumpImage<GPUBackend>, GPU);

--- a/dali/pipeline/operators/util/dump_image.h
+++ b/dali/pipeline/operators/util/dump_image.h
@@ -41,7 +41,7 @@ class DumpImage : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
   const string suffix_;
 };

--- a/dali/pipeline/operators/util/external_source.cc
+++ b/dali/pipeline/operators/util/external_source.cc
@@ -17,18 +17,18 @@
 namespace dali {
 
 template<>
-void ExternalSource<CPUBackend>::RunImpl(SampleWorkspace *ws) {
+void ExternalSource<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   // Wrap the output tensor around our data
-  auto &output = ws->Output<CPUBackend>(0);
-  cudaStream_t stream = ws->has_stream() ? ws->stream() : 0;
+  auto &output = ws.Output<CPUBackend>(0);
+  cudaStream_t stream = ws.has_stream() ? ws.stream() : 0;
   if (data_in_tl_) {
     DALI_ENFORCE(OperatorBase::batch_size_ == static_cast<int>(tl_data_.ntensor()),
       "Data list provided to ExternalSource needs to have batch_size length.");
-    output.Copy(tl_data_, ws->data_idx(), stream);
+    output.Copy(tl_data_, ws.data_idx(), stream);
   } else {
     DALI_ENFORCE(OperatorBase::batch_size_ == static_cast<int>(t_data_.size()),
       "Data list provided to ExternalSource needs to have batch_size length.");
-    auto &data = t_data_[ws->data_idx()];
+    auto &data = t_data_[ws.data_idx()];
     output.Copy(data, stream);
   }
 

--- a/dali/pipeline/operators/util/external_source.cu
+++ b/dali/pipeline/operators/util/external_source.cu
@@ -17,11 +17,11 @@
 namespace dali {
 
 template<>
-void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace *ws) {
+void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   DALI_ENFORCE(data_in_tl_, "Cannot feed non-contiguous data to GPU op.");
 
-  auto &output = ws->Output<GPUBackend>(0);
-  output.Copy(tl_data_, (ws->has_stream() ? ws->stream() : 0));
+  auto &output = ws.Output<GPUBackend>(0);
+  output.Copy(tl_data_, (ws.has_stream() ? ws.stream() : 0));
   {
     std::lock_guard<std::mutex> busy_lock(busy_m_);
     busy_ = false;

--- a/dali/pipeline/operators/util/external_source.h
+++ b/dali/pipeline/operators/util/external_source.h
@@ -92,7 +92,7 @@ class ExternalSource : public Operator<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> *ws) override;
+  void RunImpl(Workspace<Backend> &ws) override;
 
   string output_name_;
   TensorList<Backend> tl_data_;

--- a/dali/pipeline/operators/util/make_contiguous.h
+++ b/dali/pipeline/operators/util/make_contiguous.h
@@ -45,15 +45,15 @@ class MakeContiguous : public Operator<MixedBackend> {
   }
 
   using Operator<MixedBackend>::Run;
-  void Run(MixedWorkspace *ws) override {
-    const auto& input = ws->Input<CPUBackend>(0, 0);
+  void Run(MixedWorkspace &ws) override {
+    const auto& input = ws.Input<CPUBackend>(0, 0);
     int sample_dim = input.shape().sample_dim();
     kernels::TensorListShape<> output_shape(batch_size_, sample_dim);
     DALITensorLayout layout = input.GetLayout();
     TypeInfo type = input.type();
     size_t total_bytes = 0;
     for (int i = 0; i < batch_size_; ++i) {
-      auto &sample = ws->Input<CPUBackend>(0, i);
+      auto &sample = ws.Input<CPUBackend>(0, i);
       output_shape.set_tensor_shape(i, sample.shape());
       size_t sample_bytes = sample.nbytes();
       if (coalesced && sample_bytes > COALESCE_TRESHOLD)
@@ -65,14 +65,14 @@ class MakeContiguous : public Operator<MixedBackend> {
           "in input batch. Cannot copy to contiguous device buffer.");
     }
 
-    if (ws->OutputIsType<CPUBackend>(0)) {
-      auto &output = ws->Output<CPUBackend>(0);
+    if (ws.OutputIsType<CPUBackend>(0)) {
+      auto &output = ws.Output<CPUBackend>(0);
       output.Resize(output_shape);
       output.SetLayout(layout);
       output.set_type(type);
 
       for (int i = 0; i < batch_size_; ++i) {
-        auto &input = ws->Input<CPUBackend>(0, i);
+        auto &input = ws.Input<CPUBackend>(0, i);
 
         // Note: We know that this will translate into
         // a std::memcpy, so it is safe to pass stream 0
@@ -81,7 +81,7 @@ class MakeContiguous : public Operator<MixedBackend> {
             input.raw_data(), input.size(), 0);
       }
     } else {
-      auto &output = ws->Output<GPUBackend>(0);
+      auto &output = ws.Output<GPUBackend>(0);
       output.Resize(output_shape);
       output.SetLayout(layout);
       output.set_type(type);
@@ -99,7 +99,7 @@ class MakeContiguous : public Operator<MixedBackend> {
         cpu_output_buff.set_type(type);
 
         for (int i = 0; i < batch_size_; ++i) {
-          auto &input = ws->Input<CPUBackend>(0, i);
+          auto &input = ws.Input<CPUBackend>(0, i);
           memcpy(cpu_output_buff.raw_mutable_tensor(i), input.raw_data(), input.nbytes());
         }
         CUDA_CALL(cudaMemcpyAsync(
@@ -107,17 +107,17 @@ class MakeContiguous : public Operator<MixedBackend> {
               cpu_output_buff.raw_mutable_data(),
               cpu_output_buff.nbytes(),
               cudaMemcpyHostToDevice,
-              ws->stream()));
+              ws.stream()));
       } else {
         TimeRange tm("non coalesced", TimeRange::kGreen);
         for (int i = 0; i < batch_size_; ++i) {
-          auto &input = ws->Input<CPUBackend>(0, i);
+          auto &input = ws.Input<CPUBackend>(0, i);
           CUDA_CALL(cudaMemcpyAsync(
                   output.raw_mutable_tensor(i),
                   input.raw_data(),
                   input.nbytes(),
                   cudaMemcpyHostToDevice,
-                  ws->stream()));
+                  ws.stream()));
         }
       }
     }

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -297,9 +297,9 @@ class DummyPresizeOpCPU : public Operator<CPUBackend> {
     return false;
   }
 
-  void RunImpl(Workspace<CPUBackend>* ws) override {
-    auto &input = ws->Input<CPUBackend>(0);
-    auto &output = ws->Output<CPUBackend>(0);
+  void RunImpl(Workspace<CPUBackend> &ws) override {
+    auto &input = ws.Input<CPUBackend>(0);
+    auto &output = ws.Output<CPUBackend>(0);
     auto tmp_size = output.capacity();
     output.mutable_data<size_t>();
     output.Resize({2});
@@ -319,15 +319,15 @@ class DummyPresizeOpGPU : public Operator<GPUBackend> {
     return false;
   }
 
-  void RunImpl(Workspace<GPUBackend>* ws) override {
-    auto &input = ws->Input<GPUBackend>(0);
-    auto &output = ws->Output<GPUBackend>(0);
+  void RunImpl(Workspace<GPUBackend> &ws) override {
+    auto &input = ws.Input<GPUBackend>(0);
+    auto &output = ws.Output<GPUBackend>(0);
     output.mutable_data<size_t>();
     size_t tmp_size[2] = {output.capacity(), input.capacity()};
     std::vector< std::vector<Index> > shape {{1}};
     output.Resize(shape);
     auto out = output.mutable_data<size_t>();
-    CUDA_CALL(cudaStreamSynchronize(ws->stream()));
+    CUDA_CALL(cudaStreamSynchronize(ws.stream()));
     CUDA_CALL(cudaMemcpy(out, &tmp_size, sizeof(size_t) * 2, cudaMemcpyDefault));
   }
 };
@@ -343,15 +343,15 @@ class DummyPresizeOpMixed : public Operator<MixedBackend> {
   }
 
   using Operator<MixedBackend>::Run;
-  void Run(MixedWorkspace* ws) override {
-    auto &input = ws->Input<CPUBackend>(0, 0);
-    auto &output = ws->Output<GPUBackend>(0);
+  void Run(MixedWorkspace &ws) override {
+    auto &input = ws.Input<CPUBackend>(0, 0);
+    auto &output = ws.Output<GPUBackend>(0);
     output.mutable_data<size_t>();
     size_t tmp_size[2] = {output.capacity(), input.capacity()};
     std::vector< std::vector<Index> > shape {{1}};
     output.Resize(shape);
     auto out = output.mutable_data<size_t>();
-    CUDA_CALL(cudaStreamSynchronize(ws->stream()));
+    CUDA_CALL(cudaStreamSynchronize(ws.stream()));
     CUDA_CALL(cudaMemcpy(out, &tmp_size, sizeof(size_t) * 2, cudaMemcpyDefault));
   }
 };
@@ -696,7 +696,7 @@ class DummyOpToAdd : public Operator<CPUBackend> {
     return false;
   }
 
-  void RunImpl(HostWorkspace *ws) override {}
+  void RunImpl(HostWorkspace &ws) override {}
 };
 
 DALI_REGISTER_OPERATOR(DummyOpToAdd, DummyOpToAdd, CPU);
@@ -715,7 +715,7 @@ class DummyOpNoSync : public Operator<CPUBackend> {
     return false;
   }
 
-  void RunImpl(HostWorkspace *ws) override {}
+  void RunImpl(HostWorkspace &ws) override {}
 };
 
 DALI_REGISTER_OPERATOR(DummyOpNoSync, DummyOpNoSync, CPU);

--- a/dali/test/plugins/dummy/dummy.cc
+++ b/dali/test/plugins/dummy/dummy.cc
@@ -17,9 +17,9 @@
 namespace other_ns {
 
 template<>
-void Dummy<::dali::CPUBackend>::RunImpl(::dali::SampleWorkspace *ws) {
-  auto &input = ws->Input<::dali::CPUBackend>(0);
-  auto &output = ws->Output<::dali::CPUBackend>(0);
+void Dummy<::dali::CPUBackend>::RunImpl(::dali::SampleWorkspace &ws) {
+  auto &input = ws.Input<::dali::CPUBackend>(0);
+  auto &output = ws.Output<::dali::CPUBackend>(0);
   output.set_type(input.type());
   output.ResizeLike(input);
 

--- a/dali/test/plugins/dummy/dummy.cu
+++ b/dali/test/plugins/dummy/dummy.cu
@@ -18,9 +18,9 @@
 namespace other_ns {
 
 template<>
-void Dummy<::dali::GPUBackend>::RunImpl(::dali::DeviceWorkspace *ws) {
-  auto &input = ws->Input<::dali::GPUBackend>(0);
-  auto &output = ws->Output<::dali::GPUBackend>(0);
+void Dummy<::dali::GPUBackend>::RunImpl(::dali::DeviceWorkspace &ws) {
+  auto &input = ws.Input<::dali::GPUBackend>(0);
+  auto &output = ws.Output<::dali::GPUBackend>(0);
   output.set_type(input.type());
   output.ResizeLike(input);
   CUDA_CALL(cudaMemcpyAsync(
@@ -28,7 +28,7 @@ void Dummy<::dali::GPUBackend>::RunImpl(::dali::DeviceWorkspace *ws) {
           input.raw_data(),
           input.nbytes(),
           cudaMemcpyDeviceToDevice,
-          ws->stream()));
+          ws.stream()));
 }
 
 }  // namespace other_ns

--- a/dali/test/plugins/dummy/dummy.h
+++ b/dali/test/plugins/dummy/dummy.h
@@ -38,7 +38,7 @@ class Dummy : public ::dali::Operator<Backend> {
     return false;
   }
 
-  void RunImpl(::dali::Workspace<Backend> *ws) override;
+  void RunImpl(::dali::Workspace<Backend> &ws) override;
 };
 
 }  // namespace other_ns

--- a/docs/examples/extend/customdummy/dummy.cc
+++ b/docs/examples/extend/customdummy/dummy.cc
@@ -3,9 +3,9 @@
 namespace other_ns {
 
 template<>
-void Dummy<::dali::CPUBackend>::RunImpl(::dali::SampleWorkspace *ws) {
-  const auto &input = ws->Input<::dali::CPUBackend>(0);
-  auto &output = ws->Output<::dali::CPUBackend>(0);
+void Dummy<::dali::CPUBackend>::RunImpl(::dali::SampleWorkspace &ws) {
+  const auto &input = ws.Input<::dali::CPUBackend>(0);
+  auto &output = ws.Output<::dali::CPUBackend>(0);
 
   ::dali::TypeInfo type = input.type();
   type.Copy<::dali::CPUBackend, ::dali::CPUBackend>(

--- a/docs/examples/extend/customdummy/dummy.cu
+++ b/docs/examples/extend/customdummy/dummy.cu
@@ -4,15 +4,15 @@
 namespace other_ns {
 
 template<>
-void Dummy<::dali::GPUBackend>::RunImpl(::dali::DeviceWorkspace *ws) {
-  const auto &input = ws->Input<::dali::GPUBackend>(0);
-  auto &output = ws->Output<::dali::GPUBackend>(0);
+void Dummy<::dali::GPUBackend>::RunImpl(::dali::DeviceWorkspace &ws) {
+  const auto &input = ws.Input<::dali::GPUBackend>(0);
+  auto &output = ws.Output<::dali::GPUBackend>(0);
   CUDA_CALL(cudaMemcpyAsync(
           output.raw_mutable_data(),
           input.raw_data(),
           input.nbytes(),
           cudaMemcpyDeviceToDevice,
-          ws->stream()));
+          ws.stream()));
 }
 
 }  // namespace other_ns

--- a/docs/examples/extend/customdummy/dummy.h
+++ b/docs/examples/extend/customdummy/dummy.h
@@ -33,7 +33,7 @@ class Dummy : public ::dali::Operator<Backend> {
     return true;
   }
 
-  void RunImpl(::dali::Workspace<Backend> *ws) override;
+  void RunImpl(::dali::Workspace<Backend> &ws) override;
 };
 
 }  // namespace other_ns


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- Refactoring to improve Operator API

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
The Operator::Run and RunImpl signatures are changed from accepting `pointer to workspace` to `reference to workspace`.
This is more C++ way of things and matches the signature of `Setup`.
 - What was changed, added, removed?
Run, RunImpl and similar signatures where changed from (Workspace *ws) to (Workspace &ws),
access to ws changed from `ws->x` to `ws.x`. For some functions call was changed from `fun(ws)` to `fun(&ws)`, as I intended to change only Run and related functions.
 - What is most important part that reviewers should focus on?
Mostly mechanical changes. Check if there is no docs mismatch.
 - Was this PR tested? How?
CI
 - Were docs and examples updated, if necessary?
Yes, dummy plugin was also updated.

Would be nice to followup with adjusting `GetArgument` to take a ref.

**JIRA TASK**: [DALI-XXXX]