### PR TITLE
Allow `stream()` to be called for every Workspace

### DIFF
--- a/dali/pipeline/workspace/device_workspace.h
+++ b/dali/pipeline/workspace/device_workspace.h
@@ -96,15 +96,10 @@ class DLL_PUBLIC DeviceWorkspace : public WorkspaceBase<DeviceInputType, DeviceO
   /**
    * @brief Returns true if 'set_stream' has been called.
    */
-  DLL_PUBLIC inline bool has_stream() const { return has_stream_; }
-
-  /**
-   * @brief Returns the cuda stream that this work is to be done in.
-   */
-  DLL_PUBLIC inline cudaStream_t stream() const {
-    DALI_ENFORCE(has_stream_, "Workspace does not have a stream.");
-    return stream_;
+  DLL_PUBLIC inline bool has_stream() const override {
+    return has_stream_;
   }
+
 
   /**
    * @brief Sets the event for this workspace.
@@ -139,6 +134,10 @@ class DLL_PUBLIC DeviceWorkspace : public WorkspaceBase<DeviceInputType, DeviceO
   DLL_PUBLIC inline vector<cudaEvent_t> ParentEvents() const { return parent_events_; }
 
  private:
+  cudaStream_t stream_impl() const override {
+    return stream_;
+  }
+
   bool has_stream_ = false, has_event_ = false;
   cudaStream_t stream_;
   cudaEvent_t event_;

--- a/dali/pipeline/workspace/host_workspace.h
+++ b/dali/pipeline/workspace/host_workspace.h
@@ -100,7 +100,15 @@ class DLL_PUBLIC HostWorkspace : public WorkspaceBase<HostInputType, HostOutputT
     return *thread_pool_;
   }
 
+  bool has_stream() const override {
+    return false;
+  };
+
  private:
+  cudaStream_t stream_impl() const override {
+    return nullptr;
+  }
+
   ThreadPool* thread_pool_ = nullptr;
 };
 

--- a/dali/pipeline/workspace/mixed_workspace.h
+++ b/dali/pipeline/workspace/mixed_workspace.h
@@ -83,15 +83,10 @@ class DLL_PUBLIC MixedWorkspace : public WorkspaceBase<MixedInputType, MixedOutp
   /**
    * @brief Returns true if 'set_stream' has been called.
    */
-  DLL_PUBLIC inline bool has_stream() const { return has_stream_; }
-
-  /**
-   * @brief Returns the cuda stream that this work is to be done in.
-   */
-  DLL_PUBLIC inline cudaStream_t stream() const {
-    DALI_ENFORCE(has_stream_, "Workspace does not have a stream.");
-    return stream_;
+  DLL_PUBLIC inline bool has_stream() const override {
+    return has_stream_;
   }
+
 
   /**
    * @brief Sets the event for this workspace.
@@ -115,6 +110,10 @@ class DLL_PUBLIC MixedWorkspace : public WorkspaceBase<MixedInputType, MixedOutp
   }
 
  private:
+  cudaStream_t stream_impl() const override {
+    return stream_;
+  }
+
   bool has_stream_ = false, has_event_ = false;
   cudaStream_t stream_;
   cudaEvent_t event_;

--- a/dali/pipeline/workspace/sample_workspace.h
+++ b/dali/pipeline/workspace/sample_workspace.h
@@ -102,14 +102,8 @@ class DLL_PUBLIC SampleWorkspace : public WorkspaceBase<SampleInputType, SampleO
   /**
    * @brief Returns true if the workspace contains a valid stream.
    */
-  DLL_PUBLIC inline bool has_stream() const { return has_stream_; }
-
-  /**
-   * @brief Returns the cuda stream that this work is to be done in.
-   */
-  DLL_PUBLIC inline cudaStream_t stream() const {
-    DALI_ENFORCE(has_stream_, "Workspace does not have a valid stream.");
-    return stream_;
+  DLL_PUBLIC inline bool has_stream() const override {
+    return has_stream_;
   }
 
   /**
@@ -121,6 +115,10 @@ class DLL_PUBLIC SampleWorkspace : public WorkspaceBase<SampleInputType, SampleO
   }
 
  private:
+  cudaStream_t stream_impl() const override {
+    return stream_;
+  }
+
   int data_idx_, thread_idx_;
   cudaStream_t stream_;
   bool has_stream_;

--- a/dali/pipeline/workspace/support_workspace.h
+++ b/dali/pipeline/workspace/support_workspace.h
@@ -54,6 +54,15 @@ class DLL_PUBLIC SupportWorkspace : public WorkspaceBase<SupportInputType, Suppo
    */
   template <typename Backend>
   DLL_PUBLIC Tensor<Backend>& Output(int idx);
+
+  bool has_stream() const override {
+    return false;
+  }
+
+ private:
+  cudaStream_t stream_impl() const override {
+    return nullptr;
+  }
 };
 
 }  // namespace dali

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -215,12 +215,12 @@ class WorkspaceBase : public ArgumentWorkspace {
    */
   cudaStream_t stream() const {
     DALI_ENFORCE(has_stream(),
-                 "Provided workspace doesn't allow for CUDA calculations. "
+                 "No valid CUDA stream in the Workspace. "
+                 "Either the Workspace doesn't support CUDA streams or "
+                 "the stream hasn't been successfully set. "
                  "Use `has_stream()`, to runtime-check, "
                  "if CUDA stream is available for this workspace");
     auto stream = stream_impl();
-    DALI_ENFORCE(stream != nullptr, "Something bad happened. "
-                                    "Make sure, the stream is properly created");
     return stream;
   }
 

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -203,6 +203,28 @@ class WorkspaceBase : public ArgumentWorkspace {
                                      StorageDevice::GPU);
   }
 
+
+  /**
+   * @brief Returns true if this workspace has CUDA stream available
+   */
+  virtual bool has_stream() const = 0;
+
+
+  /**
+   * @brief Returns the CUDA stream that this work is to be done in.
+   */
+  cudaStream_t stream() const {
+    DALI_ENFORCE(has_stream(),
+                 "Provided workspace doesn't allow for CUDA calculations. "
+                 "Use `has_stream()`, to runtime-check, "
+                 "if CUDA stream is available for this workspace");
+    auto stream = stream_impl();
+    DALI_ENFORCE(stream != nullptr, "Something bad happened. "
+                                    "Make sure, the stream is properly created");
+    return stream;
+  }
+
+
   /**
    * @brief Adds new CPU output
    */
@@ -415,6 +437,12 @@ class WorkspaceBase : public ArgumentWorkspace {
       + ")");
     return index_map[idx];
   }
+
+
+  /**
+   * @brief Returns CUDA stream or nullptr, if the stream is unavailable
+   */
+  virtual cudaStream_t stream_impl() const = 0;
 };
 
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

#### Why we need this PR?
Add ability to call `stream()` request for every instance of `Workspace`.

This is a further step so that there's no need to explicitly specialize `RunImpl` for every backend in every operator