### PR TITLE
Remove .cpu function from EdgeReference

### DIFF
--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -256,21 +256,23 @@ int Pipeline::AddOperator(OpSpec spec, const std::string& inst_name, int logical
 
     if (device == "cpu" || device == "mixed") {
       DALI_ENFORCE(input_device == "cpu", "cpu/mixed ops can only take cpu "
-          "inputs. " + error_str);
+          "inputs. CPU op cannot follow GPU op. " + error_str);
       DALI_ENFORCE(it->second.has_cpu, "cpu input requested by op exists "
-          "only on gpu. " + error_str);
+          "only on gpu. CPU op cannot follow GPU op. " + error_str);
       DALI_ENFORCE(!it->second.is_support,
-          "Argument input can only be used as regular input by support ops. " + error_str);
+          "Argument input can only be used as regular input by support ops. "
+          "CPU op cannot follow GPU op. " + error_str);
     } else if (device == "support") {
-      DALI_ENFORCE(input_device == "cpu", "Support ops can only take cpu inputs. " + error_str);
+      DALI_ENFORCE(input_device == "cpu", "Support ops can only take cpu inputs. "
+          "CPU op cannot follow GPU op. " + error_str);
       DALI_ENFORCE(it->second.has_cpu, "cpu input requested by op exists "
-          "only on gpu. " + error_str);
+          "only on gpu. CPU op cannot follow GPU op. " + error_str);
       DALI_ENFORCE(it->second.is_support,
           "Support ops can only take inputs produced by other support ops." + error_str);
     } else if (input_device == "cpu") {
       // device == gpu
       DALI_ENFORCE(it->second.has_cpu, "cpu input requested by op exists "
-          "only on gpu. " + error_str);
+          "only on gpu. CPU op cannot follow GPU op. " + error_str);
       SetupCPUInput(it, i, &spec);
     } else {
       SetupGPUInput(it);

--- a/dali/python/nvidia/dali/edge.py
+++ b/dali/python/nvidia/dali/edge.py
@@ -26,8 +26,5 @@ class EdgeReference(object):
     # Note: Regardless of whether we want the cpu or gpu version
     # of a tensor, we keep the source argument the same so that
     # the pipeline can backtrack through the user-defined graph
-    def cpu(self):
-        return EdgeReference(self.name, "cpu", self.source)
-
     def gpu(self):
         return EdgeReference(self.name, "gpu", self.source)


### PR DESCRIPTION
Signed-off-by: Albert Wolant <awolant@nvidia.com>

#### Why we need this PR?
- Refactoring to improve information about DALI execution policy about CPU ops after GPU ops.

#### What happened in this PR?
 - What was changed, added, removed?
Remove `.cpu()` from `EdgeReference`. Update the docs and error messages.
 - Were docs and examples updated, if necessary?
Getting started example was updated

**JIRA TASK**: [DALI-None]

Follow-up to #1176 