### PR TITLE
Make `Deallocate` public API

### DIFF
--- a/dali/kernels/alloc.h
+++ b/dali/kernels/alloc.h
@@ -19,13 +19,14 @@
 #include <memory>
 #include <type_traits>
 #include "dali/kernels/alloc_type.h"
+#include "dali/core/api_helper.h"
 
 namespace dali {
 namespace kernels {
 namespace memory {
 
-void *Allocate(AllocType type, size_t size) noexcept;
-void Deallocate(AllocType type, void *mem, int device) noexcept;
+DLL_PUBLIC void *Allocate(AllocType type, size_t size) noexcept;
+DLL_PUBLIC void Deallocate(AllocType type, void *mem, int device) noexcept;
 
 struct Deleter {
   int device;


### PR DESCRIPTION
the allocators are used by some public APIs (e.g., `KernelManager`). If a
custom operator makes use of these APIs, it will encounter `undefined
symbols` errors when deallocation takes place, e.g., when program exits

`Allocate` gets the same treatment so that it doesn't get jealous 😜
