### PR TITLE
Add bbox clipping to `COCOReader`

### DIFF
--- a/dali/pipeline/operators/reader/coco_reader_op.cc
+++ b/dali/pipeline/operators/reader/coco_reader_op.cc
@@ -50,6 +50,9 @@ object will be skipped during reading. It is represented as absolute value.)code
   .AddOptionalArg("ratio",
       R"code(If true, bboxes returned values as expressed as ratio w.r.t. to the image width and height.)code",
       false)
+  .AddOptionalArg("clip",
+      R"code(If true, bboxes will be clipped to the image boundaries.)code",
+      false)
   .AddOptionalArg("file_list",
       R"code(Path to the file with a list of pairs ``file id``
 (leave empty to traverse the `file_root` directory to obtain files and labels))code",


### PR DESCRIPTION
not all datasets are properly sanitized (cough.. openimages... cough)
without this, `CheckBounds` will just error out

Signed-off-by: Yang Zhang <yangzhang@live.com>

#### Why we need this PR?
*Pick one*
- It fixes a bug *bug description*
- It adds new feature needed because *why we need this feature*
- Refactoring to improve *what*

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
 - What was changed, added, removed?
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
 - Were docs and examples updated, if necessary?

**JIRA TASK**: [DALI-XXXX]