### PR TITLE
Remove multigpu example from jupyter tests

### DIFF
--- a/qa/TL0_jupyter/test.sh
+++ b/qa/TL0_jupyter/test.sh
@@ -11,7 +11,7 @@ do_once() {
 test_body() {
     # test code
     # dummy patern
-    black_list_files="#"
+    black_list_files="multigpu"
 
     ls *.ipynb | sed "/${black_list_files}/d" | xargs -i jupyter nbconvert \
                     --to notebook --inplace --execute \


### PR DESCRIPTION
Signed-off-by: Albert Wolant <awolant@nvidia.com>

#### Why we need this PR?
- It suppresses a bug with multigpu example in CI being run on single GPU

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
Blacklist multigpu example from the CI run.

**JIRA TASK**: [NA]