### PR TITLE
Fix device-side conversions to 64-bit integer types.

### DIFF
--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -195,29 +195,41 @@ DALI_HOST_DEV constexpr T clamp(U value) {
 namespace detail {
 #ifdef __CUDA_ARCH__
 
-__device__ int cuda_round_helper(float f, int) {  // NOLINT
+inline __device__ int cuda_round_helper(float f, int) {  // NOLINT
   return __float2int_rn(f);
 }
-__device__ unsigned cuda_round_helper(float f, unsigned) {  // NOLINT
+inline __device__ unsigned cuda_round_helper(float f, unsigned) {  // NOLINT
   return __float2uint_rn(f);
 }
-__device__ long long  cuda_round_helper(float f, long long) {  // NOLINT
-  return __float2ll_rn(f);
+inline __device__ long long  cuda_round_helper(float f, long long) {  // NOLINT
+  return __float2ll_rd(f+0.5f);
 }
-__device__ unsigned long long cuda_round_helper(float f, unsigned long long) {  // NOLINT
-  return __float2ull_rn(f);
+inline __device__ unsigned long long cuda_round_helper(float f, unsigned long long) {  // NOLINT
+  return __float2ull_rd(f+0.5f);
 }
-__device__ int cuda_round_helper(double f, int) {  // NOLINT
+inline __device__ long cuda_round_helper(float f, long) {  // NOLINT
+  return sizeof(long) == sizeof(int) ? __float2int_rn(f) : __float2ll_rd(f+0.5f);  // NOLINT
+}
+inline __device__ unsigned long cuda_round_helper(float f, unsigned long) {  // NOLINT
+  return sizeof(unsigned long) == sizeof(unsigned int) ? __float2uint_rn(f) : __float2ull_rd(f+0.5f);  // NOLINT
+}
+inline __device__ int cuda_round_helper(double f, int) {  // NOLINT
   return __double2int_rn(f);
 }
-__device__ unsigned cuda_round_helper(double f, unsigned) {  // NOLINT
+inline __device__ unsigned cuda_round_helper(double f, unsigned) {  // NOLINT
   return __double2uint_rn(f);
 }
-__device__ long long  cuda_round_helper(double f, long long) {  // NOLINT
-  return __double2ll_rn(f);
+inline __device__ long long  cuda_round_helper(double f, long long) {  // NOLINT
+  return __double2ll_rd(f+0.5f);
 }
-__device__ unsigned long long cuda_round_helper(double f, unsigned long long) {  // NOLINT
-  return __double2ull_rn(f);
+inline __device__ unsigned long long cuda_round_helper(double f, unsigned long long) {  // NOLINT
+  return __double2ull_rd(f+0.5f);
+}
+inline __device__ long cuda_round_helper(double f, long) {  // NOLINT
+  return sizeof(long) == sizeof(int) ? __double2int_rn(f) : __double2ll_rd(f+0.5f);  // NOLINT
+}
+inline __device__ unsigned long cuda_round_helper(double f, unsigned long) {  // NOLINT
+  return sizeof(unsigned long) == sizeof(unsigned int) ? __double2uint_rn(f) : __double2ull_rd(f+0.5f);  // NOLINT
 }
 #endif
 

--- a/include/dali/core/dev_string.h
+++ b/include/dali/core/dev_string.h
@@ -130,6 +130,8 @@ constexpr __device__ const char *dev_to_string(const char *literal) { return lit
 inline __device__ DeviceString dev_to_string(bool b) { return b ? "true" : "false"; }
 
 inline __device__ DeviceString dev_to_string(long long x) {  // NOLINT
+  static_assert(sizeof(long long) == 8,  // NOLINT
+                "This function does not work when long long is not 64-bit");
   if (x == 0)
     return "0";
   char buf[32];
@@ -139,6 +141,10 @@ inline __device__ DeviceString dev_to_string(long long x) {  // NOLINT
   if (x < 0) {
     neg = true;
     x = -x;
+    if (x < 0) {
+      // number is self-negative - it must be -2^63
+      return "-9223372036854775808";
+    }
   }
   while (x) {
     int digit = x%10;


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
- It fixes a bug caused by long and long long overload resolution problem
- It works around a bug in CUDA/compiler when converting FP to 64-bit integers in round to nearest mode

#### What happened in this PR?
    * Add inline to rounding helper functions.
    * Work around a bug in __float2ll_rn and related functions.
    * Add tests for device-side conversions to 64-bit integers.
    * Fix `dev_to_string(long long)` for input value of -2^63.

**JIRA TASK**: [DALI-1031]