### PR TITLE
Add support for 3d shapes in crop window

### DIFF
--- a/dali/image/generic_image.cc
+++ b/dali/image/generic_image.cc
@@ -41,11 +41,11 @@ GenericImage::DecodeImpl(DALIImageType image_type,
   auto crop_generator = GetCropWindowGenerator();
   if (crop_generator) {
       cv::Mat decoded_image_roi;
-      auto crop = crop_generator(H, W);
-      const int x = crop.x;
-      const int y = crop.y;
-      const int newW = crop.w;
-      const int newH = crop.h;
+      auto crop = crop_generator({H, W});
+      const int y = crop.anchor[0];
+      const int x = crop.anchor[1];
+      const int newH = crop.shape[0];
+      const int newW = crop.shape[1];
       DALI_ENFORCE(newW > 0 && newW <= W);
       DALI_ENFORCE(newH > 0 && newH <= H);
       cv::Rect roi(x, y, newW, newH);

--- a/dali/image/image.h
+++ b/dali/image/image.h
@@ -79,15 +79,15 @@ class Image {
   inline void SetCropWindow(const CropWindow& crop_window) {
     if (!crop_window)
       return;
-    crop_window_generator_ = [crop_window](int H, int W) {
-      DALI_ENFORCE(crop_window.IsInRange(H, W),
+    crop_window_generator_ = [crop_window](const kernels::TensorShape<>& shape) {
+      DALI_ENFORCE(crop_window.IsInRange(shape),
         "crop_window["
-        + std::to_string(crop_window.x)
-        + ", " + std::to_string(crop_window.y)
-        + ", " + std::to_string(crop_window.w)
-        + ", " + std::to_string(crop_window.h) + "]"
+        + std::to_string(crop_window.anchor[1])
+        + ", " + std::to_string(crop_window.anchor[0])
+        + ", " + std::to_string(crop_window.shape[1])
+        + ", " + std::to_string(crop_window.shape[0]) + "]"
         + " not valid from image dimensions [0, 0, "
-        + std::to_string(W) + ", " + std::to_string(H) + "]");
+        + std::to_string(shape[1]) + ", " + std::to_string(shape[0]) + "]");
       return crop_window;
     };
   }

--- a/dali/image/jpeg.cc
+++ b/dali/image/jpeg.cc
@@ -85,12 +85,13 @@ JpegImage::DecodeImpl(DALIImageType type, const uint8 *jpeg, size_t length) cons
   auto crop_window_generator = GetCropWindowGenerator();
   if (crop_window_generator) {
     flags.crop = true;
-    auto crop = crop_window_generator(h, w);
-    DALI_ENFORCE(crop.IsInRange(h, w));
-    flags.crop_x = crop.x;
-    flags.crop_y = crop.y;
-    flags.crop_width = crop.w;
-    flags.crop_height = crop.h;
+    kernels::TensorShape<> shape{static_cast<int>(h), static_cast<int>(w)};
+    auto crop = crop_window_generator(shape);
+    DALI_ENFORCE(crop.IsInRange(shape));
+    flags.crop_y = crop.anchor[0];
+    flags.crop_x = crop.anchor[1];
+    flags.crop_height = crop.shape[0];
+    flags.crop_width = crop.shape[1];
   }
 
   DALI_ENFORCE(type == DALI_RGB || type == DALI_BGR || type == DALI_GRAY,

--- a/dali/pipeline/operators/crop/crop.h
+++ b/dali/pipeline/operators/crop/crop.h
@@ -81,11 +81,9 @@ class Crop : public SliceBase<Backend>, protected CropAttr {
 
     auto crop_h = crop_height_[data_idx];
     auto crop_w = crop_width_[data_idx];
-    auto crop_pos_y_x = CalculateCropYX(crop_y_norm_[data_idx], crop_x_norm_[data_idx],
-                                        crop_h, crop_w, H, W);
-
-    int64_t crop_y, crop_x;
-    std::tie(crop_y, crop_x) = crop_pos_y_x;
+    float anchor_norm[2] = {crop_y_norm_[data_idx], crop_x_norm_[data_idx]};
+    auto crop_anchor = CalculateAnchor(make_span(anchor_norm), {crop_h, crop_w}, {H, W});
+    int64_t crop_y = crop_anchor[0], crop_x = crop_anchor[1];
 
     switch (layout) {
       case DALI_NHWC:

--- a/dali/pipeline/operators/crop/crop_attr.cc
+++ b/dali/pipeline/operators/crop/crop_attr.cc
@@ -24,7 +24,8 @@ DALI_SCHEMA(CropAttr)
         R"code(Size of the cropped image, specified as a pair `(crop_H, crop_W)`.
 If only a single value `c` is provided, the resulting crop will be square
 with size `(c,c)`. Providing `crop` argument is incompatible with providing separate
-arguments `crop_h` and `crop_w`.)code",
+arguments `crop_h` and `crop_w`. To specify 3-dimensional cropping windows, use `crop_h`,
+`crop_w`, `crop_d` instead)code",
         std::vector<float>{0.f, 0.f})
     .AddOptionalArg(
         "crop_pos_x",
@@ -41,15 +42,28 @@ where `crop_y_norm` is the normalized position, `H` is the height of the image
 and `crop_H` is the height of the cropping window.)code",
         0.5f, true)
     .AddOptionalArg(
+        "crop_pos_z",
+        R"code(**Volumetric inputs only** Normalized (0.0 - 1.0) normal position of the cropping window (front plane).
+Actual position is calculated as `crop_z = crop_z_norm * (D - crop_d)`,
+where `crop_z_norm` is the normalized position, `D` is the depth of the image
+and `crop_d` is the depth of the cropping window.)code",
+        0.5f, true)
+    .AddOptionalArg(
         "crop_w",
-        R"code(cropping window height (in pixels).
+        R"code(Cropping window width (in pixels).
 If provided, `crop_h` should be provided as well. Providing `crop_w`, `crop_h` is incompatible with
 providing fixed crop window dimensions (argument `crop`).)code",
         0.0f, true)
     .AddOptionalArg(
         "crop_h",
-        R"code(cropping window height (in pixels).
+        R"code(Cropping window height (in pixels).
 If provided, `crop_w` should be provided as well. Providing `crop_w`, `crop_h` is incompatible with
+providing fixed crop window dimensions (argument `crop`).)code",
+        0.0f, true)
+    .AddOptionalArg(
+        "crop_d",
+        R"code(**Volumetric inputs only** cropping window depth (in pixels).
+If provided, `crop_h` and `crop_w` should be provided as well. Providing `crop_w`, `crop_h`, `crop_d` is incompatible with
 providing fixed crop window dimensions (argument `crop`).)code",
         0.0f, true);
 

--- a/dali/pipeline/operators/crop/crop_attr.h
+++ b/dali/pipeline/operators/crop/crop_attr.h
@@ -36,23 +36,29 @@ class CropAttr {
   explicit inline CropAttr(const OpSpec &spec)
     : spec__(spec)
     , batch_size__(spec__.GetArgument<int>("batch_size")) {
-    int crop_h = 0, crop_w = 0;
+    int crop_h = 0, crop_w = 0, crop_d = 0;
     bool has_crop_arg = spec__.HasArgument("crop");
     bool has_crop_w_arg = spec__.ArgumentDefined("crop_w");
     bool has_crop_h_arg = spec__.ArgumentDefined("crop_h");
-    is_whole_image_ = !has_crop_arg && !has_crop_w_arg && !has_crop_h_arg;
+    bool has_crop_d_arg = spec__.ArgumentDefined("crop_d");
+    is_whole_image_ = !has_crop_arg && !has_crop_w_arg && !has_crop_h_arg && !has_crop_d_arg;
 
     DALI_ENFORCE(has_crop_w_arg == has_crop_h_arg,
       "`crop_w` and `crop_h` arguments must be provided together");
 
+    if (has_crop_d_arg) {
+      DALI_ENFORCE(has_crop_w_arg,
+        "`crop_d` argument must be provided together with `crop_w` and `crop_h`");
+    }
+
     if (has_crop_arg) {
-      DALI_ENFORCE(!has_crop_h_arg && !has_crop_w_arg,
-        "`crop` argument is not compatible with `crop_h`, `crop_w`");
+      DALI_ENFORCE(!has_crop_h_arg && !has_crop_w_arg && !has_crop_d_arg,
+        "`crop` argument is not compatible with `crop_h`, `crop_w`, `crop_d`");
 
       auto cropArg = spec.GetRepeatedArgument<float>("crop");
       DALI_ENFORCE(cropArg.size() > 0 && cropArg.size() <= 2);
       crop_h = static_cast<int>(cropArg[0]);
-      crop_w = static_cast<int>(cropArg.size() == 2 ? cropArg[1] : cropArg[0]);
+      crop_w = static_cast<int>(cropArg.size() >= 2 ? cropArg[1] : cropArg[0]);
 
       DALI_ENFORCE(crop_h >= 0,
         "Crop height must be greater than zero. Received: " +
@@ -60,19 +66,25 @@ class CropAttr {
 
       DALI_ENFORCE(crop_w >= 0,
         "Crop width must be greater than zero. Received: " +
-        std::to_string(crop_w));
+         std::to_string(crop_w));
     }
 
     crop_height_.resize(batch_size__, crop_h);
     crop_width_.resize(batch_size__, crop_w);
+    if (has_crop_d_arg)
+      crop_depth_.resize(batch_size__, crop_d);
     crop_x_norm_.resize(batch_size__, 0.0f);
     crop_y_norm_.resize(batch_size__, 0.0f);
+    if (has_crop_d_arg)
+      crop_z_norm_.resize(batch_size__, 0.0f);
     crop_window_generators_.resize(batch_size__, {});
   }
 
   void ProcessArguments(const ArgumentWorkspace *ws, std::size_t data_idx) {
     crop_x_norm_[data_idx] = spec__.GetArgument<float>("crop_pos_x", ws, data_idx);
     crop_y_norm_[data_idx] = spec__.GetArgument<float>("crop_pos_y", ws, data_idx);
+    if (Is3dCrop())
+      crop_z_norm_[data_idx] = spec__.GetArgument<float>("crop_pos_z", ws, data_idx);
     if (!is_whole_image_) {
       if (crop_width_[data_idx] == 0) {
         crop_width_[data_idx] = static_cast<int>(
@@ -82,21 +94,58 @@ class CropAttr {
         crop_height_[data_idx] = static_cast<int>(
           spec__.GetArgument<float>("crop_h", ws, data_idx));
       }
+      if (Is3dCrop() && crop_depth_[data_idx] == 0) {
+        crop_depth_[data_idx] = static_cast<int>(
+          spec__.GetArgument<float>("crop_d", ws, data_idx));
+      }
     }
 
     crop_window_generators_[data_idx] =
-      [this, data_idx](int H, int W) {
+      [this, data_idx](kernels::TensorShape<> input_shape) {
         CropWindow crop_window;
-        crop_window.h = crop_height_[data_idx];
-        crop_window.w = crop_width_[data_idx];
-        std::tie(crop_window.y, crop_window.x) =
-          CalculateCropYX(
-            crop_y_norm_[data_idx], crop_x_norm_[data_idx],
-            crop_window.h, crop_window.w,
-            H, W);
-        DALI_ENFORCE(crop_window.IsInRange(H, W));
+        if (input_shape.size() == 3) {
+          kernels::TensorShape<> crop_shape =
+            {crop_depth_[data_idx], crop_height_[data_idx], crop_width_[data_idx]};
+          crop_window.SetShape(crop_shape);
+
+          float anchor_norm[3] =
+            {crop_z_norm_[data_idx], crop_y_norm_[data_idx], crop_x_norm_[data_idx]};
+          auto anchor = CalculateAnchor(make_span(anchor_norm), crop_shape, input_shape);
+          crop_window.SetAnchor(std::move(anchor));
+        } else if (input_shape.size() == 2) {
+          kernels::TensorShape<> crop_shape = {crop_height_[data_idx], crop_width_[data_idx]};
+          crop_window.SetShape(crop_shape);
+
+          float anchor_norm[2] = {crop_y_norm_[data_idx], crop_x_norm_[data_idx]};
+          auto anchor = CalculateAnchor(make_span(anchor_norm), crop_shape, input_shape);
+          crop_window.SetAnchor(std::move(anchor));
+        } else {
+          DALI_FAIL("not supported number of dimensions (" +
+                    std::to_string(input_shape.size()) + ")");
+        }
+        DALI_ENFORCE(crop_window.IsInRange(input_shape));
         return crop_window;
-      };
+    };
+  }
+
+  kernels::TensorShape<> CalculateAnchor(const span<float>& anchor_norm,
+                                         const kernels::TensorShape<>& crop_shape,
+                                         const kernels::TensorShape<>& input_shape) {
+    DALI_ENFORCE(anchor_norm.size() == crop_shape.size()
+              && anchor_norm.size() == input_shape.size());
+
+    kernels::TensorShape<> anchor(anchor_norm.size(), 0);
+    for (int dim = 0; dim < anchor_norm.size(); dim++) {
+      DALI_ENFORCE(anchor_norm[dim] >= 0.0f && anchor_norm[dim] <= 1.0f,
+        "Anchor for dimension " + std::to_string(dim) + " (" + std::to_string(anchor_norm[dim]) +
+        ") is out of range [0.0, 1.0]");
+      DALI_ENFORCE(crop_shape[dim] > 0 && crop_shape[dim] <= input_shape[dim],
+        "Crop shape for dimension " + std::to_string(dim) + " (" + std::to_string(crop_shape[dim]) +
+        ") is out of range [0, " + std::to_string(input_shape[dim]) + "]");
+      anchor[dim] = std::roundf(anchor_norm[dim] * (input_shape[dim] - crop_shape[dim]));
+    }
+
+    return anchor;
   }
 
   void ProcessArguments(const ArgumentWorkspace &ws) {
@@ -114,35 +163,20 @@ class CropAttr {
     return crop_window_generators_[data_idx];
   }
 
-  /**
-   * @brief Calculate coordinate where the crop starts in pixels.
-   */
-  std::pair<int, int> CalculateCropYX(float crop_y_norm, float crop_x_norm,
-                                      int crop_H, int crop_W,
-                                      int H, int W) {
-    DALI_ENFORCE(crop_y_norm >= 0.f && crop_y_norm <= 1.f,
-      "Crop coordinates need to be in range [0.0, 1.0]");
-    DALI_ENFORCE(crop_x_norm >= 0.f && crop_x_norm <= 1.f,
-      "Crop coordinates need to be in range [0.0, 1.0]");
-    DALI_ENFORCE(crop_W > 0 && crop_W <= W, "Invalid crop_width: " + std::to_string(crop_W)
-      + " (image_width: " + std::to_string(W) + ")");
-    DALI_ENFORCE(crop_H > 0 && crop_H <= H, "Invalid crop_heigth: " + std::to_string(crop_H)
-      + " (image_heigth: " + std::to_string(H) + ")");
-
-    const int crop_y = std::round(crop_y_norm * (H - crop_H));
-    const int crop_x = std::round(crop_x_norm * (W - crop_W));
-
-    return std::make_pair(crop_y, crop_x);
-  }
-
   inline bool IsWholeImage() const {
     return is_whole_image_;
   }
 
+  inline bool Is3dCrop() const {
+    return !crop_depth_.empty();
+  }
+
   std::vector<int> crop_height_;
   std::vector<int> crop_width_;
+  std::vector<int> crop_depth_;
   std::vector<float> crop_x_norm_;
   std::vector<float> crop_y_norm_;
+  std::vector<float> crop_z_norm_;
   std::vector<CropWindowGenerator> crop_window_generators_;
   bool is_whole_image_ = false;
 

--- a/dali/pipeline/operators/crop/random_crop_attr.h
+++ b/dali/pipeline/operators/crop/random_crop_attr.h
@@ -61,7 +61,7 @@ class RandomCropAttr {
           {aspect_ratio[0], aspect_ratio[1]}, {area[0], area[1]}, seeds[i], num_attempts));
       crop_window_generators_[i] = std::bind(
         &RandomCropGenerator::GenerateCropWindow, random_crop_generator,
-        std::placeholders::_1, std::placeholders::_2);
+        std::placeholders::_1);
     }
   }
 

--- a/dali/pipeline/operators/crop/slice_attr.h
+++ b/dali/pipeline/operators/crop/slice_attr.h
@@ -87,35 +87,35 @@ class SliceAttr {
   std::vector<CropWindowGenerator> crop_window_generators_;
 
  private:
-    void ProcessArgumentsHelper(int data_idx, float crop_w, float crop_h,
-                                float crop_x_norm, float crop_y_norm) {
-        crop_width_[data_idx] = crop_w;
-        crop_height_[data_idx] = crop_h;
-        crop_x_norm_[data_idx] = crop_x_norm;
-        crop_y_norm_[data_idx] = crop_y_norm;
+  void ProcessArgumentsHelper(int data_idx, float crop_w, float crop_h,
+                              float crop_x_norm, float crop_y_norm) {
+    crop_width_[data_idx] = crop_w;
+    crop_height_[data_idx] = crop_h;
+    crop_x_norm_[data_idx] = crop_x_norm;
+    crop_y_norm_[data_idx] = crop_y_norm;
 
-        DALI_ENFORCE(crop_x_norm + crop_w <= 1.0f,
-            "crop_x[" + std::to_string(crop_x_norm) + "] + crop_width["
-            + std::to_string(crop_w) + "] must be <= 1.0f");
-        DALI_ENFORCE(crop_y_norm + crop_h <= 1.0f,
-            "crop_y[" + std::to_string(crop_y_norm) + "] + crop_height["
-            + std::to_string(crop_h) + "] must be <= 1.0f");
+    DALI_ENFORCE(crop_x_norm + crop_w <= 1.0f,
+      "crop_x[" + std::to_string(crop_x_norm) + "] + crop_width["
+      + std::to_string(crop_w) + "] must be <= 1.0f");
+    DALI_ENFORCE(crop_y_norm + crop_h <= 1.0f,
+      "crop_y[" + std::to_string(crop_y_norm) + "] + crop_height["
+      + std::to_string(crop_h) + "] must be <= 1.0f");
 
-        crop_window_generators_[data_idx] =
-            [this, data_idx](int H, int W) {
-                CropWindow crop_window;
-                crop_window.y = crop_y_norm_[data_idx] * H;
-                crop_window.x = crop_x_norm_[data_idx] * W;
-                crop_window.h =
-                    (crop_height_[data_idx] + crop_y_norm_[data_idx]) * H - crop_window.y;
-                crop_window.w =
-                    (crop_width_[data_idx] + crop_x_norm_[data_idx]) * W - crop_window.x;
-                DALI_ENFORCE(crop_window.IsInRange(H, W));
-                return crop_window;
-            };
-    }
+    crop_window_generators_[data_idx] =
+      [this, data_idx](const kernels::TensorShape<>& shape) {
+        CropWindow crop_window;
+        crop_window.anchor[0] = crop_y_norm_[data_idx] * shape[0];
+        crop_window.anchor[1] = crop_x_norm_[data_idx] * shape[1];
+        crop_window.shape[0] =
+          (crop_height_[data_idx] + crop_y_norm_[data_idx]) * shape[0] - crop_window.anchor[0];
+        crop_window.shape[1] =
+          (crop_width_[data_idx] + crop_x_norm_[data_idx]) * shape[1] - crop_window.anchor[1];
+        DALI_ENFORCE(crop_window.IsInRange(shape));
+        return crop_window;
+    };
+  }
 
-    std::size_t batch_size__;
+  std::size_t batch_size__;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/decoder/host/fused/host_decoder_crop_test.cc
+++ b/dali/pipeline/operators/decoder/host/fused/host_decoder_crop_test.cc
@@ -26,12 +26,12 @@ class ImageDecoderCropTest_CPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (int H, int W) {
+    return [this] (const kernels::TensorShape<>& shape) {
       CropWindow crop_window;
-      crop_window.h = crop_H;
-      crop_window.w = crop_W;
-      crop_window.y = std::round(0.5f * (H - crop_window.h));
-      crop_window.x = std::round(0.5f * (W - crop_window.w));
+      crop_window.shape[0] = crop_H;
+      crop_window.shape[1] = crop_W;
+      crop_window.anchor[0] = std::round(0.5f * (shape[0] - crop_window.shape[0]));
+      crop_window.anchor[1] = std::round(0.5f * (shape[1] - crop_window.shape[1]));
       return crop_window;
     };
   }

--- a/dali/pipeline/operators/decoder/host/fused/host_decoder_slice_test.cc
+++ b/dali/pipeline/operators/decoder/host/fused/host_decoder_slice_test.cc
@@ -52,12 +52,12 @@ class ImageDecoderSliceTest_CPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (int H, int W) {
+    return [this] (const kernels::TensorShape<>& shape) {
       CropWindow crop_window;
-      crop_window.y = crop_y * H;
-      crop_window.x = crop_x * W;
-      crop_window.h = (crop_h + crop_y) * H - crop_window.y;
-      crop_window.w = (crop_w + crop_x) * W - crop_window.x;
+      crop_window.anchor[0] = crop_y * shape[0];
+      crop_window.anchor[1] = crop_x * shape[1];
+      crop_window.shape[0] = (crop_h + crop_y) * shape[0] - crop_window.anchor[0];
+      crop_window.shape[1] = (crop_w + crop_x) * shape[1] - crop_window.anchor[1];
       return crop_window;
     };
   }

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_crop_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_crop_test.cc
@@ -26,12 +26,12 @@ class ImageDecoderCropTest_GPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (int H, int W) {
+    return [this] (const kernels::TensorShape<>& shape) {
       CropWindow crop_window;
-      crop_window.h = crop_H;
-      crop_window.w = crop_W;
-      crop_window.y = std::round(0.5f * (H - crop_window.h));
-      crop_window.x = std::round(0.5f * (W - crop_window.w));
+      crop_window.shape[0] = crop_H;
+      crop_window.shape[1] = crop_W;
+      crop_window.anchor[0] = std::round(0.5f * (shape[0] - crop_window.shape[0]));
+      crop_window.anchor[1] = std::round(0.5f * (shape[1] - crop_window.shape[1]));
       return crop_window;
     };
   }

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice_test.cc
@@ -56,12 +56,12 @@ class ImageDecoderSliceTest_GPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (int H, int W) {
+    return [this] (const kernels::TensorShape<>& shape) {
       CropWindow crop_window;
-      crop_window.y = crop_y * H;
-      crop_window.x = crop_x * W;
-      crop_window.h = (crop_h + crop_y) * H - crop_window.y;
-      crop_window.w = (crop_w + crop_x) * W - crop_window.x;
+      crop_window.anchor[0] = crop_y * shape[0];
+      crop_window.anchor[1] = crop_x * shape[1];
+      crop_window.shape[0] = (crop_h + crop_y) * shape[0] - crop_window.anchor[0];
+      crop_window.shape[1] = (crop_w + crop_x) * shape[1] - crop_window.anchor[1];
       return crop_window;
     };
   }

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_crop_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_crop_test.cc
@@ -27,12 +27,12 @@ class ImageDecoderSplitCropTest_GPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (int H, int W) {
+    return [this] (const kernels::TensorShape<>& shape) {
       CropWindow crop_window;
-      crop_window.h = crop_H;
-      crop_window.w = crop_W;
-      crop_window.y = std::round(0.5f * (H - crop_window.h));
-      crop_window.x = std::round(0.5f * (W - crop_window.w));
+      crop_window.shape[0] = crop_H;
+      crop_window.shape[1] = crop_W;
+      crop_window.anchor[0] = std::round(0.5f * (shape[0] - crop_window.shape[0]));
+      crop_window.anchor[1] = std::round(0.5f * (shape[1] - crop_window.shape[1]));
       return crop_window;
     };
   }

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_slice_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_slice_test.cc
@@ -57,12 +57,12 @@ class ImageDecoderSplitSliceTest_GPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (int H, int W) {
+    return [this] (const kernels::TensorShape<>& shape) {
       CropWindow crop_window;
-      crop_window.y = crop_y * H;
-      crop_window.x = crop_x * W;
-      crop_window.h = (crop_h + crop_y) * H - crop_window.y;
-      crop_window.w = (crop_w + crop_x) * W - crop_window.x;
+      crop_window.anchor[0] = crop_y * shape[0];
+      crop_window.anchor[1] = crop_x * shape[1];
+      crop_window.shape[0] = (crop_h + crop_y) * shape[0] - crop_window.anchor[0];
+      crop_window.shape[1] = (crop_w + crop_x) * shape[1] - crop_window.anchor[1];
       return crop_window;
     };
   }

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_helper.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_helper.h
@@ -143,8 +143,8 @@ inline bool ShouldUseHybridHuffman(EncodedImageInfo<T>& info,
                                    unsigned int threshold) {
   auto &roi = info.crop_window;
   unsigned int w = static_cast<unsigned int>(info.widths[0]);
-  unsigned int h = static_cast<unsigned int>(roi ? (roi.y + roi.h)
-                                                  : info.heights[0]);
+  unsigned int h = static_cast<unsigned int>(
+    roi ? (roi.anchor[0] + roi.shape[0]) : info.heights[0]);
   // TODO(spanev): replace it by nvJPEG API function when available in future release
   // We don't wanna call IsProgressiveJPEG if not needed
   return h*w > threshold && !IsProgressiveJPEG(input, size);

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -254,11 +254,10 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
     const bool is_whole_image = IsWholeImage();
     int crop_h = is_whole_image ? H : crop_height_[data_idx];
     int crop_w = is_whole_image ? W : crop_width_[data_idx];
-    auto crop_pos_y_x = CalculateCropYX(crop_y_norm_[data_idx], crop_x_norm_[data_idx],
-                                        crop_h, crop_w, H, W);
 
-    int64_t crop_y, crop_x;
-    std::tie(crop_y, crop_x) = crop_pos_y_x;
+    float anchor_norm[2] = {crop_y_norm_[data_idx], crop_x_norm_[data_idx]};
+    auto anchor = CalculateAnchor(make_span(anchor_norm), {crop_h, crop_w}, {H, W});
+    int64_t crop_y = anchor[0], crop_x = anchor[1];
 
     switch (layout) {
       case DALI_NHWC:

--- a/dali/pipeline/operators/fused/resize_crop_mirror.h
+++ b/dali/pipeline/operators/fused/resize_crop_mirror.h
@@ -138,14 +138,14 @@ class ResizeCropMirrorAttr : protected CropAttr {
     }
 
     if (flag & t_crop) {
-      auto crop_x_norm = spec.GetArgument<float>("crop_pos_x", ws, index);
-      auto crop_y_norm = spec.GetArgument<float>("crop_pos_y", ws, index);
-      meta.crop = CalculateCropYX(
-        crop_y_norm,
-        crop_x_norm,
-        crop_height_[index],
-        crop_width_[index],
-        meta.rsz_h, meta.rsz_w);
+      float crop_anchor_norm[2];
+      crop_anchor_norm[0] = spec.GetArgument<float>("crop_pos_y", ws, index);
+      crop_anchor_norm[1] = spec.GetArgument<float>("crop_pos_x", ws, index);
+
+      auto anchor_abs = CalculateAnchor(make_span(crop_anchor_norm),
+                                        {crop_height_[index], crop_width_[index]},
+                                        {meta.rsz_h, meta.rsz_w});
+      meta.crop = {anchor_abs[0], anchor_abs[1]};
     }
 
     if (flag & t_mirrorHor) {

--- a/dali/pipeline/operators/resize/random_resized_crop.cc
+++ b/dali/pipeline/operators/resize/random_resized_crop.cc
@@ -69,7 +69,7 @@ void RandomResizedCrop<CPUBackend>::SetupSharedSampleParams(SampleWorkspace &ws)
   int W = input_shape[1];
   int id = ws.data_idx();
 
-  crops_[id] = GetCropWindowGenerator(id)(H, W);
+  crops_[id] = GetCropWindowGenerator(id)({H, W});
   resample_params_[ws.thread_idx()] = CalcResamplingParams(id);
 }
 

--- a/dali/pipeline/operators/resize/random_resized_crop.cu
+++ b/dali/pipeline/operators/resize/random_resized_crop.cu
@@ -54,7 +54,7 @@ void RandomResizedCrop<GPUBackend>::SetupSharedSampleParams(DeviceWorkspace &ws)
     int H = input_shape[0];
     int W = input_shape[1];
 
-    crops_[i] = GetCropWindowGenerator(i)(H, W);
+    crops_[i] = GetCropWindowGenerator(i)({H, W});
   }
   CalcResamplingParams();
 }

--- a/dali/pipeline/operators/resize/random_resized_crop.h
+++ b/dali/pipeline/operators/resize/random_resized_crop.h
@@ -72,8 +72,8 @@ class RandomResizedCrop : public Operator<Backend>
   kernels::ResamplingParams2D CalcResamplingParams(int index) const {
     auto &wnd = crops_[index];
     auto params = shared_params_;
-    params[0].roi = kernels::ResamplingParams::ROI(wnd.y, wnd.y+wnd.h);
-    params[1].roi = kernels::ResamplingParams::ROI(wnd.x, wnd.x+wnd.w);
+    params[0].roi = kernels::ResamplingParams::ROI(wnd.anchor[0], wnd.anchor[0]+wnd.shape[0]);
+    params[1].roi = kernels::ResamplingParams::ROI(wnd.anchor[1], wnd.anchor[1]+wnd.shape[1]);
     return params;
   }
 

--- a/dali/test/dali_test.h
+++ b/dali/test/dali_test.h
@@ -82,8 +82,8 @@ class DALITest : public ::testing::Test {
 
     if (crop_window_generator) {
       cv::Mat cropped;
-      auto crop = crop_window_generator(tmp.rows, tmp.cols);
-      cv::Rect roi(crop.x, crop.y, crop.w, crop.h);
+      auto crop = crop_window_generator({tmp.rows, tmp.cols});
+      cv::Rect roi(crop.anchor[1], crop.anchor[0], crop.shape[1], crop.shape[0]);
       tmp(roi).copyTo(cropped);
       tmp = cropped;
     }

--- a/dali/util/crop_window.h
+++ b/dali/util/crop_window.h
@@ -21,44 +21,42 @@
 namespace dali {
 
 struct CropWindow {
-    // TODO(janton): there must be a better type to represent n-dimensional coordinates
-    kernels::TensorShape<> anchor;
+  kernels::TensorShape<> anchor;
+  kernels::TensorShape<> shape;
 
-    kernels::TensorShape<> shape;
+  CropWindow()
+    : anchor{0, 0}, shape{0, 0}
+  {}
 
-    CropWindow()
-      : anchor{0, 0}, shape{0, 0}
-    {}
+  operator bool() const {
+    for (int dim = 0; dim < shape.size(); dim++)
+      if (shape[dim] <= 0)
+        return false;
+    return true;
+  }
 
-    operator bool() const {
-      bool res = true;
-      for (int dim = 0; dim < shape.size(); dim++)
-        res = res && shape[dim] > 0;
-      return res;
-    }
+  inline bool operator==(const CropWindow& oth) const {
+    return anchor == oth.anchor && shape == oth.shape;
+  }
 
-    inline bool operator==(const CropWindow& oth) const {
-      return anchor == oth.anchor && shape == oth.shape;
-    }
+  inline bool operator!=(const CropWindow& oth) const {
+    return !operator==(oth);
+  }
 
-    inline bool operator!=(const CropWindow& oth) const {
-      return !operator==(oth);
-    }
+  inline bool IsInRange(const kernels::TensorShape<>& input_shape) const {
+    for (int dim = 0; dim < input_shape.size(); dim++)
+      if (anchor[dim] < 0 || anchor[dim] + shape[dim] > input_shape[dim])
+        return false;
+    return true;
+  }
 
-    inline bool IsInRange(const kernels::TensorShape<>& input_shape) const {
-      bool res = true;
-      for (int dim = 0; dim < input_shape.size(); dim++)
-        res = res && anchor[dim] >= 0 && anchor[dim] + shape[dim] <= input_shape[dim];
-      return res;
-    }
+  void SetAnchor(const kernels::TensorShape<>& anchor_abs) {
+    anchor = anchor_abs;
+  }
 
-    void SetAnchor(const kernels::TensorShape<>& anchor_abs) {
-      anchor = anchor_abs;
-    }
-
-    void SetShape(const kernels::TensorShape<>& shape_) {
-      shape = shape_;
-    }
+  void SetShape(const kernels::TensorShape<>& shape_) {
+    shape = shape_;
+  }
 };
 
 using CropWindowGenerator = std::function<CropWindow(const kernels::TensorShape<>& shape)>;

--- a/dali/util/random_crop_generator.cc
+++ b/dali/util/random_crop_generator.cc
@@ -33,6 +33,7 @@ RandomCropGenerator::RandomCropGenerator(
 }
 
 CropWindow RandomCropGenerator::GenerateCropWindowImpl(const kernels::TensorShape<>& shape) {
+  assert(shape.size() == 2);
   CropWindow crop;
   int H = shape[0], W = shape[1];
   if (W <= 0 || H <= 0) {

--- a/dali/util/random_crop_generator.h
+++ b/dali/util/random_crop_generator.h
@@ -34,10 +34,11 @@ class DLL_PUBLIC RandomCropGenerator {
     int64_t seed = time(0),
     int num_attempts_ = 10);
 
-  DLL_PUBLIC CropWindow GenerateCropWindow(int H, int W);
-  DLL_PUBLIC std::vector<CropWindow> GenerateCropWindows(int H, int W, std::size_t N);
+  DLL_PUBLIC CropWindow GenerateCropWindow(const kernels::TensorShape<>& shape);
+  DLL_PUBLIC std::vector<CropWindow> GenerateCropWindows(const kernels::TensorShape<>& shape,
+                                                         std::size_t N);
  private:
-  CropWindow GenerateCropWindowImpl(int H, int W);
+  CropWindow GenerateCropWindowImpl(const kernels::TensorShape<>& shape);
 
   AspectRatioRange aspect_ratio_range_;
   // Aspect ratios are uniformly distributed on logarithmic scale.

--- a/dali/util/random_crop_generator_test.cc
+++ b/dali/util/random_crop_generator_test.cc
@@ -33,70 +33,70 @@ class RandomCropGeneratorTest : public ::testing::Test {
 };
 
 TEST_F(RandomCropGeneratorTest, GenerateOneCropWindow) {
-    auto crop = MakeGenerator().GenerateCropWindow(default_H_, default_W_);
-    EXPECT_TRUE(crop.IsInRange(default_H_, default_W_));
+    auto crop = MakeGenerator().GenerateCropWindow({default_H_, default_W_});
+    EXPECT_TRUE(crop.IsInRange({default_H_, default_W_}));
 }
 
 TEST_F(RandomCropGeneratorTest, SameSeedProduceSameResult) {
-    auto crop1 = MakeGenerator(seed_).GenerateCropWindow(default_H_, default_W_);
-    EXPECT_TRUE(crop1.IsInRange(default_H_, default_W_));
-    auto crop2 = MakeGenerator(seed_).GenerateCropWindow(default_H_, default_W_);
-    EXPECT_TRUE(crop2.IsInRange(default_H_, default_W_));
+    auto crop1 = MakeGenerator(seed_).GenerateCropWindow({default_H_, default_W_});
+    EXPECT_TRUE(crop1.IsInRange({default_H_, default_W_}));
+    auto crop2 = MakeGenerator(seed_).GenerateCropWindow({default_H_, default_W_});
+    EXPECT_TRUE(crop2.IsInRange({default_H_, default_W_}));
     EXPECT_EQ(crop1, crop2);
 }
 
 TEST_F(RandomCropGeneratorTest, DifferentSeedProduceDifferentResult) {
-    auto crop1 = MakeGenerator(seed_).GenerateCropWindow(default_H_, default_W_);
-    EXPECT_TRUE(crop1.IsInRange(default_H_, default_W_));
-    auto crop2 = MakeGenerator(seed_+1).GenerateCropWindow(default_H_, default_W_);
-    EXPECT_TRUE(crop2.IsInRange(default_H_, default_W_));
+    auto crop1 = MakeGenerator(seed_).GenerateCropWindow({default_H_, default_W_});
+    EXPECT_TRUE(crop1.IsInRange({default_H_, default_W_}));
+    auto crop2 = MakeGenerator(seed_+1).GenerateCropWindow({default_H_, default_W_});
+    EXPECT_TRUE(crop2.IsInRange({default_H_, default_W_}));
     EXPECT_NE(crop1, crop2);
 }
 
 TEST_F(RandomCropGeneratorTest, GeneratingMultipleWindowsProduceDifferentResults) {
-    auto crops = MakeGenerator().GenerateCropWindows(default_H_, default_W_, 1000);
+    auto crops = MakeGenerator().GenerateCropWindows({default_H_, default_W_}, 1000);
     for (std::size_t i = 1; i < crops.size(); i++) {
-        EXPECT_TRUE(crops[i-1].IsInRange(default_H_, default_W_));
+        EXPECT_TRUE(crops[i-1].IsInRange({default_H_, default_W_}));
         EXPECT_NE(crops[i-1], crops[i]);
     }
 }
 
 TEST_F(RandomCropGeneratorTest, DifferentSeedProduceDifferentResultBatchedVersion) {
-    auto crops1 = MakeGenerator(seed_).GenerateCropWindows(default_H_, default_W_, 1000);
-    auto crops2 = MakeGenerator(seed_+1).GenerateCropWindows(default_H_, default_W_, 1000);
+    auto crops1 = MakeGenerator(seed_).GenerateCropWindows({default_H_, default_W_}, 1000);
+    auto crops2 = MakeGenerator(seed_+1).GenerateCropWindows({default_H_, default_W_}, 1000);
     ASSERT_EQ(crops1.size(), crops2.size());
     for (std::size_t i = 0; i < crops1.size(); i++) {
-        EXPECT_TRUE(crops1[i].IsInRange(default_H_, default_W_));
-        EXPECT_TRUE(crops2[i].IsInRange(default_H_, default_W_));
+        EXPECT_TRUE(crops1[i].IsInRange({default_H_, default_W_}));
+        EXPECT_TRUE(crops2[i].IsInRange({default_H_, default_W_}));
         EXPECT_NE(crops1[i], crops2[i]);
     }
 }
 
 TEST_F(RandomCropGeneratorTest, DimensionH1W1) {
-    for (auto crop : MakeGenerator().GenerateCropWindows(1, 1, 1000)) {
-        EXPECT_TRUE(crop.IsInRange(1, 1));
-        EXPECT_EQ(0, crop.x);
-        EXPECT_EQ(0, crop.y);
-        EXPECT_EQ(1, crop.h);
-        EXPECT_EQ(1, crop.w);
+    for (auto crop : MakeGenerator().GenerateCropWindows({1, 1}, 1000)) {
+        EXPECT_TRUE(crop.IsInRange({1, 1}));
+        EXPECT_EQ(0, crop.anchor[1]);
+        EXPECT_EQ(0, crop.anchor[0]);
+        EXPECT_EQ(1, crop.shape[0]);
+        EXPECT_EQ(1, crop.shape[1]);
     }
 }
 
 TEST_F(RandomCropGeneratorTest, DimensionH1) {
-    for (auto crop : MakeGenerator().GenerateCropWindows(1, default_W_, 1000)) {
-        EXPECT_TRUE(crop.IsInRange(1, default_W_));
-        EXPECT_EQ(0, crop.y);
-        EXPECT_EQ(1, crop.h);
-        EXPECT_EQ(1, crop.w);
+    for (auto crop : MakeGenerator().GenerateCropWindows({1, default_W_}, 1000)) {
+        EXPECT_TRUE(crop.IsInRange({1, default_W_}));
+        EXPECT_EQ(0, crop.anchor[0]);
+        EXPECT_EQ(1, crop.shape[0]);
+        EXPECT_EQ(1, crop.shape[1]);
     }
 }
 
 TEST_F(RandomCropGeneratorTest, DimensionW1) {
-    for (auto crop : MakeGenerator().GenerateCropWindows(default_H_, 1, 1000)) {
-        EXPECT_TRUE(crop.IsInRange(default_H_, 1));
-        EXPECT_EQ(0, crop.x);
-        EXPECT_EQ(1, crop.h);
-        EXPECT_EQ(1, crop.w);
+    for (auto crop : MakeGenerator().GenerateCropWindows({default_H_, 1}, 1000)) {
+        EXPECT_TRUE(crop.IsInRange({default_H_, 1}));
+        EXPECT_EQ(0, crop.anchor[1]);
+        EXPECT_EQ(1, crop.shape[0]);
+        EXPECT_EQ(1, crop.shape[1]);
     }
 }
 
@@ -116,26 +116,30 @@ TEST_F(RandomCropGeneratorTest, AspectRatio) {
       int H = std::roundf(s/r);
       if (!W) W = 1;
       if (!H) H = 1;
-      CropWindow window = gen.GenerateCropWindow(H, W);
-      float aspect = static_cast<float>(window.w) / window.h;
-      EXPECT_GE(aspect, min_ratio) << window.w << "x" << window.h;
-      EXPECT_LE(aspect, max_ratio) << window.w << "x" << window.h;
-      EXPECT_GE(window.w, 1) << window.w << "x" << window.h;
-      EXPECT_GE(window.h, 1) << window.w << "x" << window.h;
-      EXPECT_LE(window.w, W) << window.w << "x" << window.h;
-      EXPECT_LE(window.h, H) << window.w << "x" << window.h;
-      EXPECT_LT(window.x, W) << window.x << "x" << window.y;
-      EXPECT_LT(window.y, H) << window.x << "x" << window.y;
-      EXPECT_LE(window.x + window.w, W) << window.x << "x" << window.y;
-      EXPECT_LE(window.y + window.h, H) << window.x << "x" << window.y;
+      CropWindow window = gen.GenerateCropWindow({H, W});
+      auto shape_W = window.shape[1];
+      auto shape_H = window.shape[0];
+      auto anchor_x = window.anchor[1];
+      auto anchor_y = window.anchor[0];
+      float aspect = static_cast<float>(shape_W) / shape_H;
+      EXPECT_GE(aspect, min_ratio) << shape_W << "x" << shape_H;
+      EXPECT_LE(aspect, max_ratio) << shape_W << "x" << shape_H;
+      EXPECT_GE(shape_W, 1) << shape_W << "x" << shape_H;
+      EXPECT_GE(shape_H, 1) << shape_W << "x" << shape_H;
+      EXPECT_LE(shape_W, W) << shape_W << "x" << shape_H;
+      EXPECT_LE(shape_H, H) << shape_W << "x" << shape_H;
+      EXPECT_LT(anchor_x, W) << anchor_x << "x" << anchor_y;
+      EXPECT_LT(anchor_y, H) << anchor_x << "x" << anchor_y;
+      EXPECT_LE(anchor_x + shape_W, W) << anchor_x << "x" << anchor_y;
+      EXPECT_LE(anchor_y + shape_H, H) << anchor_x << "x" << anchor_y;
     }
 }
 
 TEST_F(RandomCropGeneratorTest, ConsecutiveGenerationsAreNotTheSame) {
     auto generator = MakeGenerator();
-    auto prev_crop = generator.GenerateCropWindow(default_H_, default_W_);
+    auto prev_crop = generator.GenerateCropWindow({default_H_, default_W_});
     for (std::size_t i = 1; i < 100; i++) {
-        auto crop = generator.GenerateCropWindow(default_H_, default_W_);
+        auto crop = generator.GenerateCropWindow({default_H_, default_W_});
         EXPECT_NE(prev_crop, crop);
         prev_crop = crop;
     }
@@ -146,8 +150,8 @@ TEST_F(RandomCropGeneratorTest, SameSeedConsecutiveGenerations) {
     auto generator2 = MakeGenerator(seed_);
     for (std::size_t i = 0; i < 100; i++) {
         EXPECT_EQ(
-            generator1.GenerateCropWindow(default_H_, default_W_),
-            generator2.GenerateCropWindow(default_H_, default_W_));
+            generator1.GenerateCropWindow({default_H_, default_W_}),
+            generator2.GenerateCropWindow({default_H_, default_W_}));
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one*
- Need to support n-dimensional coordinates in CropWindow and CropWindowGenerator (Slice family operators)
- First step before adding support for volumetric cropping windows in `Crop` operator

#### What happened in this PR?
 - What was changed, added, removed?
Changed using `x`, `y`, `w` and `h` for `anchor` and `shape`, represented as `kernels::TensorShape<>`
Adjusted usage of CropWindow generator to use the new API
 - What is most important part that reviewers should focus on?
The correctness of the changes from explicitly named coordinates to index based
 - Was this PR tested? How? 
Unit tests and python tests
 - Were docs and examples updated, if necessary?
NA
**JIRA TASK**: [DALI-1032]