### PR TITLE
Unified naming for float16 type.

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -196,7 +196,7 @@ cmake_parse_arguments(
   "" # multi value keywords
   ${ARGV})
 
-  file(GLOB collect_headers_tmp *.h)
+  file(GLOB collect_headers_tmp *.h *.hpp)
   set(${DALI_HEADERS_GROUP} ${${DALI_HEADERS_GROUP}} ${collect_headers_tmp})
   # We remove filenames containing substring test
   if(NOT COLLECT_HEADERS_INCLUDE_TEST)

--- a/dali/kernels/imgproc/color_manipulation/hsv_cpu.h
+++ b/dali/kernels/imgproc/color_manipulation/hsv_cpu.h
@@ -77,8 +77,8 @@ TensorShape<ndims_roi + 1> roi_shape(Roi<ndims_roi> roi, size_t nchannels) {
 template <class OutputType, class InputType>
 class HsvCpu {
   // TODO(mszolucha): implement float16
-  static_assert(!std::is_same<OutputType, float16_cpu>::value &&
-                !std::is_same<InputType, float16_cpu>::value, "float16 not implemented yet");
+  static_assert(!std::is_same<OutputType, float16>::value &&
+                !std::is_same<InputType, float16>::value, "float16 not implemented yet");
 
  public:
   using Roi = hsv::Roi<hsv::kNdims - 1>;

--- a/dali/kernels/slice/slice_flip_normalize_permute_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_gpu.h
@@ -102,7 +102,7 @@ class SliceFlipNormalizePermutePadGPU {
       norm_add_cpu[i] = -mean_data[i] * inv_stddev_data[i];
       norm_mul_cpu[i] = inv_stddev_data[i];
     }
-    unsigned normalization_dim;
+    unsigned normalization_dim = Dims + 1;
     std::vector<size_t> sample_sizes(in.size());
     for (int i = 0; i < in.size(); i++) {
       const auto in_shape = in.tensor_shape(i);

--- a/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
@@ -370,9 +370,9 @@ using SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES = ::testing::Types<
 >;
 
 using SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES_CPU_ONLY = ::testing::Types<
-    SliceTestArgs<uint8_t, float16_cpu, 3, 1, 2,
-      SliceFlipNormPermArgsGen_SliceOnly<float16_cpu, 3>>,
-    SliceTestArgs<float16_cpu, uint8_t, 3, 1, 2,
+    SliceTestArgs<uint8_t, float16, 3, 1, 2,
+      SliceFlipNormPermArgsGen_SliceOnly<float16, 3>>,
+    SliceTestArgs<float16, uint8_t, 3, 1, 2,
       SliceFlipNormPermArgsGen_SliceOnly<uint8_t, 3>>
 >;
 

--- a/dali/kernels/slice/slice_kernel_test.h
+++ b/dali/kernels/slice/slice_kernel_test.h
@@ -192,9 +192,9 @@ using SLICE_TEST_TYPES = ::testing::Types<
 >;
 
 using SLICE_TEST_TYPES_CPU_ONLY = ::testing::Types<
-    SliceTestArgs<int, float16_cpu, 3, 1, 2, SliceArgsGenerator_WholeTensor<3>>,
-    SliceTestArgs<float16_cpu, int, 3, 1, 2, SliceArgsGenerator_WholeTensor<3>>,
-    SliceTestArgs<float16_cpu, float16_cpu, 3, 1, 2, SliceArgsGenerator_WholeTensor<3>>
+    SliceTestArgs<int, float16, 3, 1, 2, SliceArgsGenerator_WholeTensor<3>>,
+    SliceTestArgs<float16, int, 3, 1, 2, SliceArgsGenerator_WholeTensor<3>>,
+    SliceTestArgs<float16, float16, 3, 1, 2, SliceArgsGenerator_WholeTensor<3>>
 >;
 
 }  // namespace kernels

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -348,7 +348,7 @@ DALI_REGISTER_TYPE(std::vector<float>, DALI_FLOAT_VEC);
  * type - DALIDataType
  * DType becomes a type corresponding to given DALIDataType
  */
-#define DALI_TYPE_SWITCH_WITH_FP16_GPU(type, DType, ...) \
+#define DALI_TYPE_SWITCH_WITH_FP16(type, DType, ...) \
   switch (type) {                                    \
     case DALI_NO_TYPE:                               \
       DALI_FAIL("Invalid type.");                    \
@@ -403,68 +403,6 @@ DALI_REGISTER_TYPE(std::vector<float>, DALI_FLOAT_VEC);
     default:                                         \
       DALI_FAIL("Unknown type");                     \
   }
-
-/**
- * @brief Easily instantiate templates for all types
- * type - DALIDataType
- * DType becomes a type corresponding to given DALIDataType
- */
-#define DALI_TYPE_SWITCH_WITH_FP16_CPU(type, DType, ...) \
-  switch (type) {                                    \
-    case DALI_NO_TYPE:                               \
-      DALI_FAIL("Invalid type.");                    \
-    case DALI_UINT8:                                 \
-      {                                              \
-        typedef uint8 DType;                         \
-        {__VA_ARGS__}                                \
-      }                                              \
-      break;                                         \
-    case DALI_INT16:                                 \
-      {                                              \
-        typedef int16 DType;                         \
-        {__VA_ARGS__}                                \
-      }                                              \
-      break;                                         \
-    case DALI_INT32:                                 \
-      {                                              \
-        typedef int32 DType;                         \
-        {__VA_ARGS__}                                \
-      }                                              \
-      break;                                         \
-    case DALI_INT64:                                 \
-      {                                              \
-        typedef int64 DType;                         \
-        {__VA_ARGS__}                                \
-      }                                              \
-      break;                                         \
-    case DALI_FLOAT16:                               \
-      {                                              \
-        typedef float16 DType;                   \
-        {__VA_ARGS__}                                \
-      }                                              \
-      break;                                         \
-    case DALI_FLOAT:                                 \
-      {                                              \
-        typedef float DType;                         \
-        {__VA_ARGS__}                                \
-      }                                              \
-      break;                                         \
-    case DALI_FLOAT64:                               \
-      {                                              \
-        typedef double DType;                        \
-        {__VA_ARGS__}                                \
-      }                                              \
-      break;                                         \
-    case DALI_BOOL:                                  \
-      {                                              \
-        typedef bool DType;                          \
-        {__VA_ARGS__}                                \
-      }                                              \
-      break;                                         \
-    default:                                         \
-      DALI_FAIL("Unknown type");                     \
-  }
-
 
 #define DALI_TYPE_SWITCH(type, DType, ...)           \
   switch (type) {                                    \

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -144,19 +144,6 @@ struct id2type_helper<id> { using type = data_type; };
 // Dummy type to represent the invalid default state of dali types.
 struct NoType {};
 
-template <typename T>
-struct NormalizedType { using type = T; };
-
-// This way SetType<float16_cpu> will set SetType<float16>
-// As these types are compatible python wont need a special
-// case for float16_cpu
-template <>
-struct NormalizedType<float16_cpu> { using type = float16; };
-
-template <typename T>
-using normalize_t = typename NormalizedType<T>::type;
-
-
 // Stores the unqiue ID for a type and its size in bytes
 class DLL_PUBLIC TypeInfo {
  public:
@@ -171,7 +158,7 @@ class DLL_PUBLIC TypeInfo {
     return type;
   }
 
-  template <typename T, typename U = normalize_t<T> >
+  template <typename T>
   DLL_PUBLIC inline void SetType(DALIDataType dtype = DALI_NO_TYPE);
 
   template <typename DstBackend, typename SrcBackend>
@@ -284,7 +271,7 @@ struct TypeNameHelper<std::array<T, N> > {
   }
 };
 
-template <typename, typename T>
+template <typename T>
 void TypeInfo::SetType(DALIDataType dtype) {
   // Note: We enforce the fact that NoType is invalid by
   // explicitly setting its type size as 0
@@ -452,7 +439,7 @@ DALI_REGISTER_TYPE(std::vector<float>, DALI_FLOAT_VEC);
       break;                                         \
     case DALI_FLOAT16:                               \
       {                                              \
-        typedef float16_cpu DType;                   \
+        typedef float16 DType;                   \
         {__VA_ARGS__}                                \
       }                                              \
       break;                                         \

--- a/dali/pipeline/operators/crop/slice_base.cc
+++ b/dali/pipeline/operators/crop/slice_base.cc
@@ -72,8 +72,8 @@ void SliceBase<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
   auto data_idx = ws.data_idx();
 
-  DALI_TYPE_SWITCH_WITH_FP16_CPU(input_type_, InputType,
-    DALI_TYPE_SWITCH_WITH_FP16_CPU(output_type_, OutputType,
+  DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
+    DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
       detail::RunHelper<OutputType, InputType>(
         output, input, slice_anchors_[data_idx], slice_shapes_[data_idx]);
     )

--- a/dali/pipeline/operators/crop/slice_base.cu
+++ b/dali/pipeline/operators/crop/slice_base.cu
@@ -77,8 +77,8 @@ void SliceBase<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   const auto &input = ws.Input<GPUBackend>(0);
   auto &output = ws.Output<GPUBackend>(0);
 
-  DALI_TYPE_SWITCH_WITH_FP16_GPU(input_type_, InputType,
-    DALI_TYPE_SWITCH_WITH_FP16_GPU(output_type_, OutputType,
+  DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
+    DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
       detail::RunHelper<OutputType, InputType>(
         output, input, slice_anchors_, slice_shapes_, ws.stream(), scratch_alloc_);
     )

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cc
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cc
@@ -64,8 +64,8 @@ bool CropMirrorNormalize<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
   const auto &input = ws.InputRef<CPUBackend>(0);
   auto &output = ws.OutputRef<CPUBackend>(0);
   std::size_t number_of_dims = input.shape().sample_dim();
-  DALI_TYPE_SWITCH_WITH_FP16_CPU(input_type_, InputType,
-    DALI_TYPE_SWITCH_WITH_FP16_CPU(output_type_, OutputType,
+  DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
+    DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
       VALUE_SWITCH(number_of_dims, Dims, (3, 4),
       (
         using Kernel = kernels::SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims>;
@@ -97,8 +97,8 @@ void CropMirrorNormalize<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   auto sample_idx = data_idx;
   std::size_t number_of_dims = input.shape().sample_dim();
 
-  DALI_TYPE_SWITCH_WITH_FP16_CPU(input_type_, InputType,
-    DALI_TYPE_SWITCH_WITH_FP16_CPU(output_type_, OutputType,
+  DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
+    DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
       VALUE_SWITCH(number_of_dims, Dims, (3, 4),
       (
         using Kernel = kernels::SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims>;

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cu
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cu
@@ -29,8 +29,8 @@ bool CropMirrorNormalize<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
   const auto &input = ws.Input<GPUBackend>(0);
   auto &output = ws.OutputRef<GPUBackend>(0);
   std::size_t number_of_dims = input.shape().sample_dim();
-  DALI_TYPE_SWITCH_WITH_FP16_GPU(input_type_, InputType,
-    DALI_TYPE_SWITCH_WITH_FP16_GPU(output_type_, OutputType,
+  DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
+    DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
       VALUE_SWITCH(number_of_dims, Dims, (3, 4),
       (
         using Kernel = kernels::SliceFlipNormalizePermutePadGPU<OutputType, InputType, Dims>;
@@ -58,8 +58,8 @@ void CropMirrorNormalize<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   auto &output = ws.Output<GPUBackend>(0);
 
   std::size_t number_of_dims = input.shape().sample_dim();
-  DALI_TYPE_SWITCH_WITH_FP16_GPU(input_type_, InputType,
-    DALI_TYPE_SWITCH_WITH_FP16_GPU(output_type_, OutputType,
+  DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
+    DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
       VALUE_SWITCH(number_of_dims, Dims, (3, 4),
       (
         using Kernel = kernels::SliceFlipNormalizePermutePadGPU<OutputType, InputType, Dims>;

--- a/dali/pipeline/operators/util/cast.cc
+++ b/dali/pipeline/operators/util/cast.cc
@@ -24,10 +24,10 @@ void Cast<CPUBackend>::RunImpl(SampleWorkspace &ws) {
 
   DALIDataType itype = input.type().id();
 
-  DALI_TYPE_SWITCH_WITH_FP16_CPU(output_type_, OType,
+  DALI_TYPE_SWITCH_WITH_FP16(output_type_, OType,
       output.mutable_data<OType>();
       output.ResizeLike(input);
-      DALI_TYPE_SWITCH_WITH_FP16_CPU(itype, IType,
+      DALI_TYPE_SWITCH_WITH_FP16(itype, IType,
         CPUHelper<IType, OType>(
           output.mutable_data<OType>(),
           input.data<IType>(),

--- a/dali/python/MANIFEST.in
+++ b/dali/python/MANIFEST.in
@@ -1,4 +1,5 @@
 include Acknowledgements.txt LICENSE COPYRIGHT
 recursive-include nvidia/dali/include *.h
+recursive-include nvidia/dali/include *.hpp
 recursive-include nvidia/dali *.bin
 recursive-include nvidia/dali *.so

--- a/dali/util/CMakeLists.txt
+++ b/dali/util/CMakeLists.txt
@@ -16,6 +16,7 @@ set(DALI_INST_HDRS ${DALI_INST_HDRS}
   "${CMAKE_CURRENT_SOURCE_DIR}/crop_window.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/custream.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/file.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/half.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/image.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/local_file.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/npp.h"

--- a/include/dali/core/cuda_utils.h
+++ b/include/dali/core/cuda_utils.h
@@ -21,20 +21,18 @@
 #include "dali/core/host_dev.h"
 #include "dali/core/dynlink_cuda.h"
 #include "dali/core/cuda_error.h"
-
-// For the CPU we use half_float lib and float16_cpu type
-namespace half_float {
-
-class half;
-
-}
+#ifndef __CUDA_ARCH__
+#include "dali/util/half.hpp"
+#endif
 
 namespace dali {
 
 // For the GPU
-typedef __half float16;
-// For the CPU
-typedef half_float::half float16_cpu;
+#ifdef __CUDA_ARCH__
+using float16 = __half;
+#else
+using float16 = half_float::half;
+#endif
 
 // Compatible wrapper for CUDA 8 which does not have builtin
 // static_cast<float16>


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one*
- Refactoring to improve handling of 16-bit floating point numbers.

#### What happened in this PR?
* Add `#ifdef` guarded typedefs for float16
* Add `#ifnfdef` guardded inclusion of `half.hpp`
* Remove `normalize_t`
* Change all uses of `float16_cpu` to `float16`.
* Unify cpu/gpu variants of DALI_TYPE_SWITCH_WITH_FP16
* Add `half.hpp` to dali python wheel
* Covered by existing tests.

**JIRA TASK**: [DALI-398]
