### PR TITLE
Attempt to fix issue with tf plugin install and gcc 4.8

### DIFF
--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -146,7 +146,7 @@ class CustomInstall(install, object):
         is_tf_built_with_gpp_4_8 = tf_compiler == '4.8'
         has_gpp_4_8 = which('g++-4.8') is not None
         is_compatible_with_prebuilt_bin = platform.system() == 'Linux' and platform.machine() == 'x86_64'
-        if is_tf_built_with_gpp_4_8 and default_gpp_version != '4.8' and not has_gpp_4_8 and is_compatible_with_prebuilt_bin:
+        if is_tf_built_with_gpp_4_8 and is_compatible_with_prebuilt_bin:
             tf_version = get_tf_version()
             tf_version_underscore = tf_version.replace('.', '_')
             plugin_name = 'libdali_tf_' + tf_version_underscore + '.so'


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
Attemps to fix https://github.com/NVIDIA/DALI/issues/1200

#### What happened in this PR?
Removes special handling of default gcc version 4.8 and provides prebuilt plugin as with other versions of gcc

**JIRA TASK**: [DALI-XXXX]