### PR TITLE
Add Shapes operator returning sample shapes.

### DIFF
--- a/dali/pipeline/operators/geometric/shapes.cc
+++ b/dali/pipeline/operators/geometric/shapes.cc
@@ -1,0 +1,28 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/operators/geometric/shapes.h"
+
+namespace dali {
+
+DALI_SCHEMA(Shapes)
+    .DocStr(R"code(Returns the shapes of inputs.)code")
+    .NumInput(1)
+    .NumOutput(1)
+    .AddOptionalArg("type", R"code(Data type, to which the sizes are converted.)code", DALI_INT64);
+
+DALI_REGISTER_OPERATOR(Shapes, Shapes<CPUBackend>, CPU);
+DALI_REGISTER_OPERATOR(Shapes, Shapes<GPUBackend>, GPU);
+
+}  // namespace dali

--- a/dali/pipeline/operators/geometric/shapes.h
+++ b/dali/pipeline/operators/geometric/shapes.h
@@ -1,0 +1,134 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATORS_GEOMETRIC_SHAPES_H_
+#define DALI_PIPELINE_OPERATORS_GEOMETRIC_SHAPES_H_
+
+#include <memory>
+#include <vector>
+#include "dali/kernels/tensor_shape.h"
+#include "dali/pipeline/operators/operator.h"
+#include "dali/core/static_switch.h"
+
+namespace dali {
+
+template <typename Backend>
+class Shapes : public Operator<Backend> {
+ public:
+  Shapes(const Shapes &) = delete;
+  explicit Shapes(const OpSpec &spec) : Operator<Backend>(spec) {
+    output_type_ = spec.GetArgument<DALIDataType>("type");
+    switch (output_type_) {
+    case DALI_INT32:
+    case DALI_UINT32:
+    case DALI_INT64:
+    case DALI_UINT64:
+    case DALI_FLOAT:
+    case DALI_FLOAT64:
+      break;
+    default:
+      {
+        auto &name = TypeTable::GetTypeInfo(output_type_).name();
+        DALI_FAIL("Operator Shapes can return the output as one of the following:\n"
+          "int32, uint32, int64, uint64, float or double;\n"
+          "requested: " + name);
+        break;
+      }
+    }
+  }
+  bool CanInferOutputs() const override { return true; }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    output_desc.resize(1);
+    output_desc[0].type = TypeTable::GetTypeInfo(output_type_);
+    decltype(auto) shape = GetInputShape(ws);
+    output_desc[0].shape = ShapeShape(shape);;
+    return true;
+  }
+
+  void RunImpl(workspace_t<Backend> &ws) override {
+    RunBackend(ws);
+  }
+
+  template <typename type>
+  void ConvertShape(TensorList<CPUBackend> &out, const kernels::TensorListShape<> &shape) {
+    assert(out.shape().num_samples() == shape.num_samples());
+    for (int i = 0; i < shape.num_samples(); i++) {
+      type *data = out.mutable_tensor<type>(i);
+      auto tshape = shape.tensor_shape_span(i);
+      for (int j = 0; j < shape.sample_dim(); j++)
+        data[j] = tshape[j];
+    }
+  }
+
+  void ConvertShape(TensorList<CPUBackend> &out, const kernels::TensorListShape<> &shape) {
+    TYPE_SWITCH(output_type_, type2id, type,
+                (int32_t, uint32_t, int64_t, uint64_t, float, double),
+      (ConvertShape<type>(out, shape);),
+      (DALI_FAIL("Unsupported type for Shapes")));
+  }
+
+  void ConvertShapes(const workspace_t<Backend> &ws, bool pinned) {
+    if (!tmp_.raw_data()) {
+      auto &type = TypeTable::GetTypeInfo(output_type_);
+      tmp_.set_type(type);
+      tmp_.set_pinned(pinned);
+    }
+
+    auto &output = ws.template OutputRef<Backend>(0);
+    tmp_.Resize(output.shape());
+    ConvertShape(tmp_, GetInputShape(ws));
+  }
+
+  void RunBackend(DeviceWorkspace &ws) {
+    ConvertShapes(ws, true);
+    auto &output = ws.template OutputRef<Backend>(0);
+    output.Copy(tmp_, ws.stream());
+  }
+
+  void RunBackend(HostWorkspace &ws) {
+    ConvertShapes(ws, false);
+    auto &output = ws.template OutputRef<Backend>(0);
+    for (int i = 0 ; static_cast<size_t>(i) < tmp_.ntensor(); i++) {
+      auto &output_tensor = output[i];
+      auto *dest = output_tensor.raw_mutable_data();
+      auto *src = tmp_.raw_mutable_tensor(i);
+      std::memcpy(dest, src, output_tensor.nbytes());
+    }
+  }
+
+  static kernels::TensorListShape<1> ShapeShape(const kernels::TensorListShape<> &shape) {
+    return kernels::uniform_list_shape<1>(shape.num_samples(), { shape.sample_dim() });
+  }
+
+  static const kernels::TensorListShape<> &GetInputShape(const DeviceWorkspace &ws) {
+    if (ws.InputIsType<GPUBackend>(0)) {
+      return ws.InputRef<GPUBackend>(0).shape();
+    } else {
+      return ws.InputRef<CPUBackend>(0).shape();
+    }
+  }
+
+  static auto GetInputShape(const HostWorkspace &ws) {
+    return ws.InputRef<CPUBackend>(0).shape();
+  }
+
+ private:
+  TensorList<CPUBackend> tmp_;
+  DALIDataType output_type_ = DALI_INT64;
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATORS_GEOMETRIC_SHAPES_H_

--- a/dali/pipeline/operators/geometric/shapes_test.cc
+++ b/dali/pipeline/operators/geometric/shapes_test.cc
@@ -1,0 +1,155 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <random>
+#include "dali/pipeline/operators/geometric/shapes.h"
+#include "dali/test/dali_operator_test.h"
+#include "dali/kernels/tensor_shape_print.h"
+
+namespace dali {
+
+template <typename Backend, typename RNG>
+void GenerateShapeTestInputs(TensorList<Backend> &out, RNG &rng, int num_samples, int sample_dim) {
+  kernels::TensorListShape<> shape;
+  // this should give a distribution such that the batch is no bigger than 1e+8 elements
+  int max = std::ceil(std::pow(1e+6 / num_samples, 1.0 / sample_dim));
+  std::uniform_int_distribution<int> dist(1, max);
+
+  shape.resize(num_samples, sample_dim);
+  for (int i = 0; i < num_samples; i++) {
+    for (int j = 0; j < sample_dim; j++) {
+      shape.tensor_shape_span(i)[j] = dist(rng);
+    }
+  }
+  out.Reset();
+  out.Resize(shape);
+  (void)out.template mutable_data<uint8_t>();
+}
+
+template <typename OutputBackend, typename InputBackend, typename OutputType>
+struct ShapesTestArgs {
+  using out_backend = OutputBackend;
+  using in_backend = InputBackend;
+  using output_type = OutputType;
+
+  static DALIDataType type_id() {
+    return TypeTable::GetTypeID<output_type>();
+  }
+};
+
+template <typename TestArgs>
+class ShapesOpTest;
+
+template <typename Backend>
+static std::vector<std::unique_ptr<TensorList<Backend>>> inputs;
+
+
+template <typename OutputBackend, typename InputBackend, typename OutputType>
+class ShapesOpTest<ShapesTestArgs<OutputBackend, InputBackend, OutputType>>
+: public testing::DaliOperatorTest {
+ public:
+  using TestArgs = ShapesTestArgs<OutputBackend, InputBackend, OutputType>;
+
+  ShapesOpTest() {
+    if (inputs<InputBackend>.empty()) {
+      std::mt19937_64 rng(12345);
+      for (int dim = 1; dim <= 6; dim++) {
+        inputs<InputBackend>.emplace_back(new TensorList<InputBackend>());
+        inputs<InputBackend>.back()->set_pinned(false);
+        int num_samples = 1 << (8-dim);  // Start with 128 and halve with each new dimension
+        GenerateShapeTestInputs(*inputs<InputBackend>.back(), rng, num_samples, dim);
+      }
+    }
+  }
+
+  testing::GraphDescr GenerateOperatorGraph() const override {
+      return {"Shapes"};
+  }
+
+  void Run() {
+    testing::Arguments args;
+    args.emplace("type", TestArgs::type_id());
+    args.emplace("device", testing::detail::BackendStringName<OutputBackend>());
+    for (auto &in : inputs<InputBackend>) {
+      testing::TensorListWrapper out;
+      this->RunTest(in.get(), out, args, VerifyShape);
+    }
+  }
+
+  static void VerifyShape(
+      const testing::TensorListWrapper &in_wrapper,
+      const testing::TensorListWrapper &out_wrapper,
+      const testing::Arguments &args) {
+    ASSERT_TRUE(in_wrapper.has<InputBackend>());
+    ASSERT_TRUE(out_wrapper.has<OutputBackend>());
+    auto &in = *in_wrapper.get<InputBackend>();
+    auto &out = *out_wrapper.get<OutputBackend>();
+    VerifyShapeImpl(in, out);
+  }
+
+  static void VerifyShapeImpl(
+      const TensorList<CPUBackend> &in,
+      const TensorList<GPUBackend> &out) {
+    TensorList<CPUBackend> tmp;
+    tmp.Copy(out, 0);
+    cudaDeviceSynchronize();
+    VerifyShapeImpl(in, tmp);
+  }
+
+  static void VerifyShapeImpl(
+      const TensorList<CPUBackend> &in,
+      const TensorList<CPUBackend> &out) {
+    auto shape = in.shape();
+    auto out_shape = out.shape();
+    const int N = shape.num_samples();
+    const int D = shape.sample_dim();
+    ASSERT_EQ(N, out_shape.num_samples());
+    ASSERT_TRUE(kernels::is_uniform(out_shape));
+    ASSERT_EQ(out_shape.sample_dim(), 1);
+    ASSERT_EQ(out_shape[0][0], D);
+
+    for (int i = 0; i < N; i++) {
+      const OutputType *shape_data = out.template tensor<OutputType>(i);
+      auto tshape = shape.tensor_shape_span(i);
+      for (int j = 0; j < D; j++) {
+        EXPECT_EQ(shape_data[j], static_cast<OutputType>(tshape[j]));
+      }
+    }
+  }
+};
+
+using ShapesOpArgs = ::testing::Types<
+  ShapesTestArgs<CPUBackend, CPUBackend, int32_t>,
+  ShapesTestArgs<CPUBackend, CPUBackend, uint32_t>,
+  ShapesTestArgs<CPUBackend, CPUBackend, int64_t>,
+  ShapesTestArgs<CPUBackend, CPUBackend, uint64_t>,
+  ShapesTestArgs<CPUBackend, CPUBackend, float>,
+  ShapesTestArgs<CPUBackend, CPUBackend, double>,
+
+  ShapesTestArgs<GPUBackend, CPUBackend, int32_t>,
+  ShapesTestArgs<GPUBackend, CPUBackend, uint32_t>,
+  ShapesTestArgs<GPUBackend, CPUBackend, int64_t>,
+  ShapesTestArgs<GPUBackend, CPUBackend, uint64_t>,
+  ShapesTestArgs<GPUBackend, CPUBackend, float>,
+  ShapesTestArgs<GPUBackend, CPUBackend, double>>;
+
+TYPED_TEST_SUITE(ShapesOpTest, ShapesOpArgs);
+
+TYPED_TEST(ShapesOpTest, All) {
+    this->Run();
+}
+
+
+}  // namespace dali


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one*
- It adds an operator that will be required to build meaningful warp matrices

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
    * added Shapes operator that returns input shape as a list of 1D tensors containing input shapes
 - Was this PR tested? How?
    * Ran in jupyter
 - Were docs and examples updated, if necessary?
    * No

**JIRA TASK**: [DALI-XXXX]