### PR TITLE
CPU DLTensor Operator

### DIFF
--- a/dali/pipeline/data/dltensor.cc
+++ b/dali/pipeline/data/dltensor.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "dali/pipeline/data/dltensor.h"
+#include <string>
 
 namespace dali {
 

--- a/dali/pipeline/data/dltensor.h
+++ b/dali/pipeline/data/dltensor.h
@@ -32,9 +32,11 @@ using DLMTensorPtr = std::unique_ptr<DLManagedTensor, void(*)(DLManagedTensor*)>
 DLL_PUBLIC DLDataType GetDLType(const TypeInfo &type);
 
 struct DLTensorResource {
-  explicit DLTensorResource(kernels::TensorShape<> shape): shape(std::move(shape)) {}
+  explicit DLTensorResource(kernels::TensorShape<> shape)
+  : shape(std::move(shape)) {}
 
   kernels::TensorShape<> shape;
+   DLManagedTensor dlm_tensor{};
 
   virtual ~DLTensorResource() = default;
 };
@@ -66,6 +68,8 @@ std::vector<DLMTensorPtr> GetDLTensorListView(TensorList<Backend> &tensor_list) 
   }
   return dl_tensors;
 }
+
+DLL_PUBLIC DALIDataType DLToDALIType(const DLDataType &dl_type);
 
 }  // namespace dali
 #endif  // DALI_PIPELINE_DATA_DLTENSOR_H_

--- a/dali/pipeline/data/dltensor.h
+++ b/dali/pipeline/data/dltensor.h
@@ -36,7 +36,7 @@ struct DLTensorResource {
   : shape(std::move(shape)) {}
 
   kernels::TensorShape<> shape;
-   DLManagedTensor dlm_tensor{};
+  DLManagedTensor dlm_tensor{};
 
   virtual ~DLTensorResource() = default;
 };

--- a/dali/pipeline/operators/python_function/CMakeLists.txt
+++ b/dali/pipeline/operators/python_function/CMakeLists.txt
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 set(python_function_lib "python_function_plugin")
-add_library(${python_function_lib} SHARED python_function.cc util/copy_with_stride.cc)
+set(SOURCES python_function.cc dltensor_function.cc util/copy_with_stride.cc)
+add_library(${python_function_lib} SHARED ${SOURCES})
 target_link_libraries(${python_function_lib} ${dali_lib})
 target_include_directories(${python_function_lib}
         PRIVATE ${PYBIND11_INCLUDE_DIR}  # from project CMakeLists.txt

--- a/dali/pipeline/operators/python_function/dltensor_function.cc
+++ b/dali/pipeline/operators/python_function/dltensor_function.cc
@@ -1,0 +1,29 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/operators/python_function/dltensor_function.h"
+
+namespace dali {
+
+DALI_SCHEMA(DLTensorPythonFunctionImpl).DocStr("Executes a function operating on Torch tensors").AddParent("PythonFunctionImplBase").NumInput(0, 256).NoPrune();
+
+template <>
+void DLTensorPythonFunctionImpl<CPUBackend>::RunImpl(workspace_t<CPUBackend> *ws) {
+  std::cout << ws->NumInput() << std::endl;
+
+}
+
+DALI_REGISTER_OPERATOR(DLTensorPythonFunctionImpl, DLTensorPythonFunctionImpl<CPUBackend>, CPU);
+
+}  // namespace dali

--- a/dali/pipeline/operators/python_function/dltensor_function.h
+++ b/dali/pipeline/operators/python_function/dltensor_function.h
@@ -16,8 +16,74 @@
 #define DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_DLTENSOR_FUNCTION_H_
 
 #include "dali/pipeline/operators/python_function/python_function.h"
+#include "dali/pipeline/operators/python_function/util/copy_with_stride.h"
 
 namespace dali {
+
+namespace detail {
+
+template <typename Backend>
+constexpr DLDeviceType Backend2DLDevice() {
+  if (std::is_same<Backend, CPUBackend>::value) {
+    return kDLCPU;
+  } else {
+    return kDLGPU;
+  }
+}
+
+template <typename Backend>
+std::vector<DLMTensorPtr> CastToDLTensorList(py::list &list, Index exp_size, Index out_idx) {
+  DALI_ENFORCE(list.size() == static_cast<size_t>(exp_size),
+      "Function called by DLTensorPythonFunction returned tensor list of wrong size at idx "
+      + std::to_string(out_idx) + ". Returned list is of a size "
+      + std::to_string(exp_size) + " and should be of size " + std::to_string(exp_size));
+  std::vector<DLMTensorPtr> result;
+  result.reserve(exp_size);
+  if (exp_size) {
+    DALI_ENFORCE(py::capsule::check_(list[0]),
+                 "Function called by DLTensorPythonFunction "
+                 "should return a list of DLPack tensors.");
+    auto caps = py::cast<py::capsule>(list[0]);
+    result.push_back(DLMTensorPtrFromCapsule(caps));
+    DALI_ENFORCE(result[0]->dl_tensor.ctx.device_type == Backend2DLDevice<Backend>(),
+        "Wrong output backend");
+    auto dtype = result[0]->dl_tensor.dtype;
+    for (Index i = 1; i < exp_size; ++i) {
+      auto caps = py::cast<py::capsule>(list[i]);
+      result.push_back(DLMTensorPtrFromCapsule(caps));
+      DALI_ENFORCE(result[i]->dl_tensor.ctx.device_type == Backend2DLDevice<Backend>(),
+                   "Wrong output backend.");
+      DALI_ENFORCE(DLToDALIType(result[i]->dl_tensor.dtype) == DLToDALIType(dtype),
+          "Output DLPack tensor list should have consistent data type.");
+    }
+  }
+  return result;
+}
+
+template <typename Backend>
+void CopyDlTensor(void *out_data, DLMTensorPtr &dlm_tensor_ptr) {
+  auto &dl_tensor = dlm_tensor_ptr->dl_tensor;
+  auto item_size = dl_tensor.dtype.bits / 8;
+  std::vector<Index> strides(dl_tensor.ndim);
+  if (dl_tensor.strides) {
+    for (Index i = 0; i < dl_tensor.ndim; ++i) strides[i] = dl_tensor.strides[i] * item_size;
+  } else {
+    strides.back() = item_size;
+    for (Index i = dl_tensor.ndim - 2; i >= 0; --i) {
+      strides[i] = strides[i + 1] * dl_tensor.shape[i + 1];
+    }
+  }
+  CopyWithStride<Backend>(out_data, dl_tensor.data, strides.data(),
+                          dl_tensor.shape, dl_tensor.ndim, item_size);
+}
+
+template <typename Backend>
+py::list PrepareInputs(workspace_t<Backend> &ws);
+
+template <typename Backend>
+void CopyOutputs(workspace_t<Backend> &ws, py::tuple &output);
+
+}  // namespace detail
 
 template <typename Backend>
 class DLTensorPythonFunctionImpl : public PythonFunctionImplBase<Backend> {
@@ -30,10 +96,27 @@ class DLTensorPythonFunctionImpl : public PythonFunctionImplBase<Backend> {
     return false;
   }
 
-  void RunImpl(workspace_t<Backend> *ws) override;
+  void RunImpl(workspace_t<Backend> &ws) override {
+    std::lock_guard<std::mutex> operator_guard(operator_lock);
+    py::gil_scoped_acquire interpreter_guard{};
+    py::object output_o;
+    try {
+      output_o = python_function(*py::tuple(detail::PrepareInputs<Backend>(ws)));
+    } catch(const py::error_already_set &e) {
+      throw std::runtime_error(to_string("DLTensorPythonFunction error: ") + to_string(e.what()));
+    }
+    if (!output_o.is_none()) {
+      py::tuple output = (py::tuple::check_(output_o)) ? output_o : py::make_tuple(output_o);
+      detail::CopyOutputs<Backend>(ws, output);
+    } else {
+      DALI_ENFORCE(ws.NumOutput() == 0, "Python function returned 0 outputs and "
+          + std::to_string(ws.NumOutput()) + " were expected.");
+    }
+  };
 
   USE_OPERATOR_MEMBERS();
   using Operator<Backend>::RunImpl;
+  using PythonFunctionImplBase<Backend>::python_function;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/python_function/dltensor_function.h
+++ b/dali/pipeline/operators/python_function/dltensor_function.h
@@ -12,36 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_PYTHON_FUNCTION_H_
-#define DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_PYTHON_FUNCTION_H_
+#ifndef DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_DLTENSOR_FUNCTION_H_
+#define DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_DLTENSOR_FUNCTION_H_
 
-#include <pybind11/embed.h>
-
-#include <vector>
-
-#include "dali/util/pybind.h"
-#include "dali/pipeline/operators/operator.h"
+#include "dali/pipeline/operators/python_function/python_function.h"
 
 namespace dali {
 
-extern std::mutex operator_lock;
-
 template <typename Backend>
-class PythonFunctionImplBase : public Operator<Backend> {
+class DLTensorPythonFunctionImpl : public PythonFunctionImplBase<Backend> {
  public:
-  explicit PythonFunctionImplBase(const OpSpec &spec)
-  : Operator<Backend>(spec)
-  , python_function(py::reinterpret_borrow<py::object>(
-      reinterpret_cast<PyObject*>(spec.GetArgument<int64_t>("function_id")))) {}
-
- protected:
-  py::object python_function;
-};
-
-template <typename Backend>
-class PythonFunctionImpl : public PythonFunctionImplBase<Backend> {
- public:
-  inline explicit PythonFunctionImpl(const OpSpec &spec)
+  inline explicit DLTensorPythonFunctionImpl(const OpSpec &spec)
     : PythonFunctionImplBase<Backend>(spec) {}
 
  protected:
@@ -49,13 +30,12 @@ class PythonFunctionImpl : public PythonFunctionImplBase<Backend> {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> &ws) override;
+  void RunImpl(workspace_t<Backend> *ws) override;
 
   USE_OPERATOR_MEMBERS();
   using Operator<Backend>::RunImpl;
-
 };
 
 }  // namespace dali
 
-#endif  // DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_PYTHON_FUNCTION_H_
+#endif  // DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_DLTENSOR_FUNCTION_H_

--- a/dali/pipeline/operators/python_function/dltensor_function.h
+++ b/dali/pipeline/operators/python_function/dltensor_function.h
@@ -15,6 +15,7 @@
 #ifndef DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_DLTENSOR_FUNCTION_H_
 #define DALI_PIPELINE_OPERATORS_PYTHON_FUNCTION_DLTENSOR_FUNCTION_H_
 
+#include <vector>
 #include "dali/pipeline/operators/python_function/python_function.h"
 #include "dali/pipeline/operators/python_function/util/copy_with_stride.h"
 

--- a/dali/pipeline/operators/python_function/python_function.cc
+++ b/dali/pipeline/operators/python_function/python_function.cc
@@ -21,7 +21,7 @@ namespace dali {
 DALI_SCHEMA(PythonFunctionImplBase)
         .AddArg("function_id", R"code(Id of the python function)code", DALI_INT64)
         .AddOptionalArg("num_outputs", R"code(Number of outputs)code", 1)
-        /*.MakeInternal()*/;
+        .MakeInternal();
 
 DALI_SCHEMA(PythonFunctionImpl)
         .AddParent("PythonFunctionImplBase")

--- a/dali/pipeline/operators/python_function/python_function.h
+++ b/dali/pipeline/operators/python_function/python_function.h
@@ -53,7 +53,6 @@ class PythonFunctionImpl : public PythonFunctionImplBase<Backend> {
 
   USE_OPERATOR_MEMBERS();
   using Operator<Backend>::RunImpl;
-
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/python_function/util/copy_with_stride.cc
+++ b/dali/pipeline/operators/python_function/util/copy_with_stride.cc
@@ -40,21 +40,23 @@ inline void CopyVecStatic(uint8 *output, const uint8 *input, size_t elems, size_
 }
 
 inline void CopyWithStrideHelper(void *output, const void *input,
-                                 const std::vector<Index> &in_strides,
-                                 const std::vector<Index> &out_strides,
-                                 const std::vector<Index> &shape,
+                                 const Index *in_strides,
+                                 const Index *out_strides,
+                                 const Index *shape,
+                                 Index ndim,
                                  Index dim, Index deepest_contiguous) {
   auto out_ptr = reinterpret_cast<uint8*>(output);
   auto in_ptr = reinterpret_cast<const uint8*>(input);
+  const auto item_size = out_strides[ndim - 1];
   if (dim == deepest_contiguous) {
     std::memcpy(out_ptr, in_ptr,
-        volume(shape.begin() + dim, shape.end())*out_strides.back());
+        volume(shape + dim, shape + ndim)*item_size);
     return;
   }
-  if (static_cast<size_t>(dim) == shape.size() - 1) {
-    VALUE_SWITCH(out_strides.back(), elem_size, (1, 2, 3, 4, 5, 6, 7, 8, 12, 16),
-                 (CopyVecStatic<elem_size>(out_ptr, in_ptr, shape.back(), in_strides.back())),
-                 (CopyVec(out_ptr, in_ptr, shape.back(), in_strides.back(), out_strides.back())));
+  if (dim == ndim - 1) {
+    VALUE_SWITCH(item_size, elem_size, (1, 2, 3, 4, 5, 6, 7, 8, 12, 16),
+                 (CopyVecStatic<elem_size>(out_ptr, in_ptr, shape[ndim - 1], in_strides[ndim - 1])),
+                 (CopyVec(out_ptr, in_ptr, shape[ndim - 1], in_strides[ndim - 1], item_size)));
     return;
   }
   const auto out_stride = out_strides[dim];
@@ -62,17 +64,18 @@ inline void CopyWithStrideHelper(void *output, const void *input,
   const auto n = shape[dim];
   for (Index i = 0; i < n; ++i) {
     CopyWithStrideHelper(out_ptr, in_ptr, in_strides, out_strides,
-        shape, dim + 1, deepest_contiguous);
+        shape, ndim, dim + 1, deepest_contiguous);
     out_ptr += out_stride;
     in_ptr += in_stride;
   }
 }
 
-inline Index DeepestContiguous(const std::vector<Index>& in_strides,
-                               const std::vector<Index>& shape,
+inline Index DeepestContiguous(const Index *in_strides,
+                               const Index *shape,
+                               Index ndim,
                                size_t item_size) {
   ssize_t dim_prod = 1;
-  for (int i = in_strides.size()-1; i >= 0; --i) {
+  for (int i = ndim-1; i >= 0; --i) {
     if (in_strides[i] != dim_prod*static_cast<Index>(item_size)) {
       return i+1;
     }
@@ -81,19 +84,21 @@ inline Index DeepestContiguous(const std::vector<Index>& in_strides,
   return 0;
 }
 
-void CopyWithStride(void *output, const void *input,
-                    const std::vector<Index>& in_strides,
-                    const std::vector<Index>& shape,
+template <>
+void CopyWithStride<CPUBackend>(void *output, const void *input,
+                    const Index *in_strides,
+                    const Index *shape,
+                    Index ndim,
                     size_t item_size) {
-  assert(!shape.empty());
-  assert(in_strides.size() == shape.size());
-  std::vector<Index> out_strides(shape.size());
+  assert(ndim > 0);
+  std::vector<Index> out_strides(ndim);
   out_strides.back() = item_size;
-  for (Index i = shape.size() - 2; i >= 0; --i) {
+  for (Index i = ndim - 2; i >= 0; --i) {
     out_strides[i] = out_strides[i + 1] * shape[i + 1];
   }
-  auto deepest_contiguous = DeepestContiguous(in_strides, shape, item_size);
-  CopyWithStrideHelper(output, input, in_strides, out_strides, shape, 0, deepest_contiguous);
+  auto deepest_contiguous = DeepestContiguous(in_strides, shape, ndim, item_size);
+  CopyWithStrideHelper(output, input, in_strides, out_strides.data(),
+                       shape, ndim, 0, deepest_contiguous);
 }
 
 }  // namespace dali

--- a/dali/pipeline/operators/python_function/util/copy_with_stride.h
+++ b/dali/pipeline/operators/python_function/util/copy_with_stride.h
@@ -17,12 +17,15 @@
 
 #include <vector>
 #include "dali/core/common.h"
+#include "dali/pipeline/data/backend.h"
 
 namespace dali {
 
+template <typename Backend>
 DLL_PUBLIC void CopyWithStride(void *output, const void *input,
-                               const std::vector<Index> &in_strides,
-                               const std::vector<Index> &shape,
+                               const Index *in_strides,
+                               const Index *shape,
+                               Index ndim,
                                size_t item_size);
 
 }

--- a/dali/pipeline/operators/python_function/util/copy_with_stride_test.cc
+++ b/dali/pipeline/operators/python_function/util/copy_with_stride_test.cc
@@ -20,21 +20,27 @@ namespace dali {
 TEST(CopyWithStrideTest, OneDim) {
   float data[] = {1, 2, 3, 4, 5, 6};
   std::array<float, 3> out;
-  CopyWithStride(out.data(), data, {2 * sizeof(float)}, {3}, sizeof(float));
+  Index stride = 2 * sizeof(float);
+  Index shape = 3;
+  CopyWithStride<CPUBackend>(out.data(), data, &stride, &shape, 1, sizeof(float));
   ASSERT_TRUE((out == std::array<float, 3>{1, 3, 5}));
 }
 
 TEST(CopyWithStrideTest, TwoDims)  {
   size_t data[] = {11, 12, 13, 14, 21, 22, 23, 24, 31, 32, 33, 34, 41, 42, 43, 44};
   std::array<size_t, 8> out;
-  CopyWithStride(out.data(), data, {8 * sizeof(size_t), sizeof(size_t)}, {2, 4}, sizeof(size_t));
+  Index stride[] = {8 * sizeof(size_t), sizeof(size_t)};
+  Index shape[] = {2, 4};
+  CopyWithStride<CPUBackend>(out.data(), data, stride, shape, 2, sizeof(size_t));
   ASSERT_TRUE((out == std::array<size_t, 8>{11, 12, 13, 14, 31, 32, 33, 34}));
 }
 
 TEST(CopyWithStrideTest, SimpleCopy) {
   uint8 data[] = {1, 2, 3, 4, 5, 6, 7, 8};
   std::array<uint8, 8> out;
-  CopyWithStride(out.data(), data, {4, 2, 1}, {2, 2, 2}, 1);
+  Index stride[] = {4, 2, 1};
+  Index shape[] = {2, 2, 2};
+  CopyWithStride<CPUBackend>(out.data(), data, stride, shape, 3, 1);
   ASSERT_TRUE((out == std::array<uint8, 8>{1, 2, 3, 4, 5, 6, 7, 8}));
 }
 

--- a/dali/test/python/test_dltensor_operator.py
+++ b/dali/test/python/test_dltensor_operator.py
@@ -1,0 +1,165 @@
+import nvidia.dali.ops as ops
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.types as types
+import torch.utils.dlpack as torch_dlpack
+import torch
+import os
+import random
+import numpy
+from mxnet import ndarray as mxnd
+
+test_data_root = os.environ['DALI_EXTRA_PATH']
+images_dir = os.path.join(test_data_root, 'db', 'single', 'jpeg')
+
+
+def random_seed():
+    return int(random.random() * (1 << 32))
+
+
+DEVICE_ID = 0
+BATCH_SIZE = 8
+ITERS = 32
+SEED = random_seed()
+NUM_WORKERS = 6
+
+
+class CommonPipeline(Pipeline):
+    def __init__(self):
+        super(CommonPipeline, self).__init__(BATCH_SIZE, NUM_WORKERS, DEVICE_ID, seed=SEED,
+                                             exec_async=False, exec_pipelined=False)
+        self.input = ops.FileReader(file_root=images_dir)
+        self.decode = ops.ImageDecoder(device='cpu', output_type=types.RGB)
+        self.resize = ops.Resize(resize_x=3, resize_y=3)
+
+    def load(self):
+        jpegs, labels = self.input()
+        decoded = self.decode(jpegs)
+        return self.resize(decoded)
+
+
+class LoadingPipeline(CommonPipeline):
+    def __init__(self):
+        super(LoadingPipeline, self).__init__()
+
+    def define_graph(self):
+        im = self.load()
+        im2 = self.load()
+        return im, im2
+
+
+class DLTensorOpPipeline(CommonPipeline):
+    def __init__(self, function):
+        super(DLTensorOpPipeline, self).__init__()
+        self.op = ops.DLTensorPythonFunction(function=function, num_outputs=2)
+
+    def define_graph(self):
+        im = self.load()
+        im2 = self.load()
+        return self.op(im, im2)
+
+
+def torch_adapter(fun, in1, in2):
+    tin1 = [torch_dlpack.from_dlpack(dltensor) for dltensor in in1]
+    tin2 = [torch_dlpack.from_dlpack(dltensor) for dltensor in in2]
+    tout1, tout2 = fun(tin1, tin2)
+    return [torch_dlpack.to_dlpack(tout) for tout in tout1], \
+           [torch_dlpack.to_dlpack(tout) for tout in tout2]
+
+
+def torch_wrapper(fun):
+    return lambda in1, in2: torch_adapter(fun, in1, in2)
+
+
+def torch_case(fun):
+    load_pipe = LoadingPipeline()
+    op_pipe = DLTensorOpPipeline(function=torch_wrapper(fun))
+
+    load_pipe.build()
+    op_pipe.build()
+
+    for iter in range(ITERS):
+        pre1, pre2 = load_pipe.run()
+        post1, post2 = op_pipe.run()
+
+        torch_pre1 = [torch.from_numpy(pre1.at(i)) for i in range(BATCH_SIZE)]
+        torch_pre2 = [torch.from_numpy(pre2.at(i)) for i in range(BATCH_SIZE)]
+        torch_post1, torch_post2 = fun(torch_pre1, torch_pre2)
+        for i in range(BATCH_SIZE):
+            assert numpy.array_equal(post1.at(i), torch_post1[i].numpy())
+            assert numpy.array_equal(post2.at(i), torch_post2[i].numpy())
+
+
+def simple_torch_op(in1, in2):
+    fin1 = [t.to(dtype=torch.float) for t in in1]
+    fin2 = [t.to(dtype=torch.float) for t in in2]
+    return [fin1[i] + fin2[i] for i in range(len(fin1))], \
+           [fin1[i] - fin2[i] for i in range(len(fin1))]
+
+
+def torch_red_channel_op(in1, in2):
+    return [t.narrow(2, 0, 1).squeeze() for t in in1], [t.narrow(2, 0, 1).squeeze() for t in in2]
+
+
+def test_torch_simple():
+    torch_case(simple_torch_op)
+
+
+def test_torch_red_channel():
+    torch_case(torch_red_channel_op)
+
+
+def mxnet_adapter(fun, in1, in2):
+    tin1 = [mxnd.from_dlpack(dltensor) for dltensor in in1]
+    tin2 = [mxnd.from_dlpack(dltensor) for dltensor in in2]
+    tout1, tout2 = fun(tin1, tin2)
+    return [mxnd.to_dlpack_for_read(tout) for tout in tout1], \
+           [mxnd.to_dlpack_for_read(tout) for tout in tout2]
+
+
+def mxnet_wrapper(fun):
+    return lambda in1, in2: mxnet_adapter(fun, in1, in2)
+
+
+def mxnet_case(fun):
+    load_pipe = LoadingPipeline()
+    op_pipe = DLTensorOpPipeline(function=mxnet_wrapper(fun))
+
+    load_pipe.build()
+    op_pipe.build()
+
+    for iter in range(ITERS):
+        pre1, pre2 = load_pipe.run()
+        post1, post2 = op_pipe.run()
+
+        mxnet_pre1 = [mxnd.array(pre1.at(i)) for i in range(BATCH_SIZE)]
+        mxnet_pre2 = [mxnd.array(pre2.at(i)) for i in range(BATCH_SIZE)]
+        mxnet_post1, mxnet_post2 = fun(mxnet_pre1, mxnet_pre2)
+        for i in range(BATCH_SIZE):
+            print(post1.at(i))
+            print(mxnet_post1[i].asnumpy())
+            assert numpy.array_equal(post1.at(i), mxnet_post1[i].asnumpy())
+            assert numpy.array_equal(post2.at(i), mxnet_post2[i].asnumpy())
+
+
+def mxnet_flatten(in1, in2):
+    return [mxnd.flatten(t) for t in in1], [mxnd.flatten(t) for t in in2]
+
+
+def mxnet_slice(in1, in2):
+    return [t[:, :, 1] for t in in1], [t[:, :, 2] for t in in2]
+
+
+def mxnet_cast(in1, in2):
+    return [mxnd.cast(t, dtype='float32') for t in in1], [mxnd.cast(t, dtype='int64') for t in in2]
+
+
+def test_mxnet_flatten():
+    mxnet_case(mxnet_flatten)
+
+
+def test_mxnet_slice():
+    mxnet_case(mxnet_slice)
+
+
+def test_mxnet_cast():
+    mxnet_case(mxnet_cast)

--- a/dali/util/pybind.h
+++ b/dali/util/pybind.h
@@ -18,6 +18,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
+#include <utility>
 #include <string>
 #include "dali/pipeline/data/types.h"
 #include "dali/pipeline/data/dltensor.h"

--- a/qa/TL0_python_self_test_pytorch/test.sh
+++ b/qa/TL0_python_self_test_pytorch/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy torch"
+pip_packages="nose numpy torch mxnet-cu##CUDA_VERSION##"
 target_dir=./dali/test/python
 
 test_body() {


### PR DESCRIPTION
#### Why we need this PR?
It adds a new type of PythonFunction operator which uses  DLPack Tensors interface for calling Python code. It is a first step to implement a GPU Python operator, but also it simplifies adding new types of operators cooperate with different frameworks.

#### What happened in this PR?
Implementation utilizes previously added conversions to DLPack tensors. 
 - What was changed, added, removed?
   Despite adding a new operator this PR also refactors a bit the whole PythonFunction  to make it more generic and to reuse some code. Also in `dali/util/pybind.h` there are functions to convert between native and Python wrappers with DLPack tensors.
 - What is most important part that reviewers should focus on?
   Implementation in `dltensor_function.h/.cc`. 
   Changes in `copy_with_stride.cc/.h` are just a small refactor and do not change how the function works.
 - Was this PR tested? How?
   New python test script.
 - Were docs and examples updated, if necessary?
   Yes

**JIRA TASK**: [DALI-XXXX]