### PR TITLE
Replace std::pair alias with actual type

### DIFF
--- a/dali/pipeline/operators/op_spec.cc
+++ b/dali/pipeline/operators/op_spec.cc
@@ -28,9 +28,8 @@ OpSpec& OpSpec::AddInput(const string &name, const string &device, bool regular_
         "All regular inputs (particularly, `" + name + "`) need to be added to the op `" +
         this->name() + "` before argument inputs.");
   }
-  StrPair name_device_pair = std::make_pair(name, device);
 
-  inputs_.push_back(std::make_pair(name, device));
+  inputs_.push_back({name, device});
   return *this;
 }
 
@@ -38,12 +37,12 @@ OpSpec& OpSpec::AddOutput(const string &name, const string &device) {
   DALI_ENFORCE(device == "gpu" || device == "cpu", "Invalid device "
       "specifier \"" + device + "\" for output \"" + name + "\". "
       "Valid options are \"cpu\" or \"gpu\"");
-  StrPair name_device_pair = std::make_pair(name, device);
+  InOutDeviceDesc name_device_pair = {name, device};
   DALI_ENFORCE(output_name_idx_.count(name_device_pair) == 0,
       "Output '" + name + "' with device '" + device + "' "
       "already added to OpSpec");
 
-  outputs_.push_back(std::make_pair(name, device));
+  outputs_.push_back({name, device});
   auto ret = output_name_idx_.insert({name_device_pair, outputs_.size()-1});
   DALI_ENFORCE(ret.second, "Output name/device insertion failed.");
   return *this;

--- a/dali/pipeline/operators/op_spec.h
+++ b/dali/pipeline/operators/op_spec.h
@@ -42,7 +42,13 @@ class DLL_PUBLIC OpSpec {
  public:
   template <typename T>
   using TensorPtr = shared_ptr<Tensor<T>>;
-  using StrPair = std::pair<string, string>;
+  struct InOutDeviceDesc {
+    std::string name;
+    std::string device;
+    bool operator<(const InOutDeviceDesc &other) const {
+      return std::make_pair(name, device) < std::make_pair(other.name, other.device);
+    }
+  };
 
   DLL_PUBLIC inline OpSpec() {}
 
@@ -170,17 +176,17 @@ class DLL_PUBLIC OpSpec {
 
   DLL_PUBLIC inline string Input(int idx) const {
     DALI_ENFORCE_VALID_INDEX(idx, NumInput());
-    return TensorName(inputs_[idx].first, inputs_[idx].second);
+    return TensorName(inputs_[idx].name, inputs_[idx].device);
   }
 
   DLL_PUBLIC inline string InputName(int idx) const {
     DALI_ENFORCE_VALID_INDEX(idx, NumInput());
-    return inputs_[idx].first;
+    return inputs_[idx].name;
   }
 
   DLL_PUBLIC inline string InputDevice(int idx) const {
     DALI_ENFORCE_VALID_INDEX(idx, NumInput());
-    return inputs_[idx].second;
+    return inputs_[idx].device;
   }
 
   DLL_PUBLIC inline bool IsArgumentInput(int idx) const {
@@ -203,17 +209,17 @@ class DLL_PUBLIC OpSpec {
 
   DLL_PUBLIC inline string Output(int idx) const {
     DALI_ENFORCE_VALID_INDEX(idx, NumOutput());
-    return TensorName(outputs_[idx].first, outputs_[idx].second);
+    return TensorName(outputs_[idx].name, outputs_[idx].device);
   }
 
   DLL_PUBLIC inline string OutputName(int idx) const {
     DALI_ENFORCE_VALID_INDEX(idx, NumOutput());
-    return outputs_[idx].first;
+    return outputs_[idx].name;
   }
 
   DLL_PUBLIC inline string OutputDevice(int idx) const {
     DALI_ENFORCE_VALID_INDEX(idx, NumOutput());
-    return outputs_[idx].second;
+    return outputs_[idx].device;
   }
 
   DLL_PUBLIC inline const std::unordered_map<string, Index>& ArgumentInputs() const {
@@ -225,7 +231,7 @@ class DLL_PUBLIC OpSpec {
   }
 
   DLL_PUBLIC inline int OutputIdxForName(const string &name, const string &device) {
-    auto it = output_name_idx_.find(std::make_pair(name, device));
+    auto it = output_name_idx_.find({name, device});
     DALI_ENFORCE(it != output_name_idx_.end(), "Output with name '" +
         name + "' and device '" + device + "' does not exist.");
     return it->second;
@@ -314,12 +320,12 @@ class DLL_PUBLIC OpSpec {
     return *this;
   }
 
-  DLL_PUBLIC inline StrPair& MutableInput(int idx) {
+  DLL_PUBLIC inline InOutDeviceDesc& MutableInput(int idx) {
     DALI_ENFORCE_VALID_INDEX(idx, NumInput());
     return inputs_[idx];
   }
 
-  DLL_PUBLIC inline StrPair& MutableOutput(int idx) {
+  DLL_PUBLIC inline InOutDeviceDesc& MutableOutput(int idx) {
     DALI_ENFORCE_VALID_INDEX(idx, NumOutput());
     return outputs_[idx];
   }
@@ -369,8 +375,8 @@ class DLL_PUBLIC OpSpec {
   std::unordered_map<string, Index> argument_inputs_;
   std::set<Index> argument_inputs_indexes_;
 
-  std::map<StrPair, int> output_name_idx_;
-  vector<StrPair> inputs_, outputs_;
+  std::map<InOutDeviceDesc, int> output_name_idx_;
+  vector<InOutDeviceDesc> inputs_, outputs_;
 };
 
 template <typename T, typename S>

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -360,11 +360,11 @@ inline void Pipeline::AddSplitHybridDecoder(OpSpec &spec, const std::string &ins
   spec.SetArg("device", "cpu");
 
   auto& op_output = spec.MutableOutput(0);
-  string op_output_name = op_output.first;
+  string op_output_name = op_output.name;
 
   const std::string mangled_outputname(cpu_stage_name + inst_name);
-  op_output.first = mangled_outputname + "0";
-  op_output.second = "cpu";
+  op_output.name = mangled_outputname + "0";
+  op_output.device = "cpu";
   spec.AddOutput(mangled_outputname + "1", "cpu");
   spec.AddOutput(mangled_outputname + "2", "cpu");
 
@@ -604,10 +604,10 @@ void Pipeline::SetupCPUInput(std::map<string, EdgeMeta>::iterator it, int input_
 
   // Update the OpSpec to use the contiguous input
   auto& input_strs = spec->MutableInput(input_idx);
-  DALI_ENFORCE(input_strs.first == it->first, "Input at index " +
+  DALI_ENFORCE(input_strs.name == it->first, "Input at index " +
       std::to_string(input_idx) + " does not match input iterator "
-      "name (" + input_strs.first + " v. " + it->first + ").");
-  input_strs.first = "contiguous_" + input_strs.first;
+      "name (" + input_strs.name + " v. " + it->first + ").");
+  input_strs.name = "contiguous_" + input_strs.name;
 }
 
 void Pipeline::SetupGPUInput(std::map<string, EdgeMeta>::iterator it) {


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- Refactoring to improve OpSpec

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
Using aliases to std::pair in cases where there is a lot of .first and .second accesses can lead to obfuscated code because we don't know their meaning. It was replaced by a type holding proper names.
 - What was changed, added, removed?
`using StrPair = std::pair<std::string, std::string>` was replaced with a type that has proper names for it's members.
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
CI
 - Were docs and examples updated, if necessary?
NO

**JIRA TASK**: [DALI-XXXX]