### PR TITLE
Add non_blocking option to CopyToExternalTensor

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -205,37 +205,40 @@ unsigned daliGetNumOutput(daliPipelineHandle* pipe_handle) {
 
 template <typename T>
 static void daliCopyTensorListNToHelper(dali::DeviceWorkspace* ws, void* dst, int n,
-                                        device_type_t dst_type, cudaStream_t stream) {
-  dali::CopyToExternalTensor(&(ws->Output<T>(n)), dst, (dali::device_type_t)dst_type, stream);
+                                        device_type_t dst_type, cudaStream_t stream,
+                                        bool non_blocking) {
+  dali::CopyToExternalTensor(&(ws->Output<T>(n)), dst, (dali::device_type_t)dst_type, stream,
+                             non_blocking);
 }
 
 void daliCopyTensorListNTo(daliPipelineHandle* pipe_handle, void* dst, int n,
-                           device_type_t dst_type, cudaStream_t stream) {
+                           device_type_t dst_type, cudaStream_t stream, bool non_blocking) {
   dali::TimeRange tr("daliCopyTensorNTo", dali::TimeRange::kGreen);
   dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
   if (ws->OutputIsType<dali::CPUBackend>(n)) {
-    daliCopyTensorListNToHelper<dali::CPUBackend>(ws, dst, n, dst_type, stream);
+    daliCopyTensorListNToHelper<dali::CPUBackend>(ws, dst, n, dst_type, stream, non_blocking);
   } else {
-    daliCopyTensorListNToHelper<dali::GPUBackend>(ws, dst, n, dst_type, stream);
+    daliCopyTensorListNToHelper<dali::GPUBackend>(ws, dst, n, dst_type, stream, non_blocking);
   }
 }
 
 template <typename T>
 static void daliCopyTensorNToHelper(dali::DeviceWorkspace* ws, void* dst, int n,
-                                    device_type_t dst_type, cudaStream_t stream) {
+                                    device_type_t dst_type, cudaStream_t stream,
+                                    bool non_blocking) {
   dali::Tensor<T> t;
   t.ShareData(&(ws->Output<T>(n)));
-  dali::CopyToExternalTensor(t, dst, (dali::device_type_t)dst_type, stream);
+  dali::CopyToExternalTensor(t, dst, (dali::device_type_t)dst_type, stream, non_blocking);
 }
 
 void daliCopyTensorNTo(daliPipelineHandle* pipe_handle, void* dst, int n, device_type_t dst_type,
-                       cudaStream_t stream) {
+                       cudaStream_t stream, bool non_blocking) {
   dali::TimeRange tr("daliCopyTensorNTo", dali::TimeRange::kGreen);
   dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
   if (ws->OutputIsType<dali::CPUBackend>(n)) {
-    daliCopyTensorNToHelper<dali::CPUBackend>(ws, dst, n, dst_type, stream);
+    daliCopyTensorNToHelper<dali::CPUBackend>(ws, dst, n, dst_type, stream, non_blocking);
   } else {
-    daliCopyTensorNToHelper<dali::GPUBackend>(ws, dst, n, dst_type, stream);
+    daliCopyTensorNToHelper<dali::GPUBackend>(ws, dst, n, dst_type, stream, non_blocking);
   }
 }
 

--- a/dali/c_api/c_api.h
+++ b/dali/c_api/c_api.h
@@ -133,7 +133,8 @@ extern "C" {
    * @remarks Tensor list doesn't need to be dense
    */
   DLL_PUBLIC void daliCopyTensorListNTo(daliPipelineHandle* pipe_handle, void* dst, int n,
-                                        device_type_t dst_type, cudaStream_t stream);
+                                        device_type_t dst_type, cudaStream_t stream,
+                                        bool non_blocking);
 
   /**
    * @brief Returns number of DALI pipeline outputs
@@ -146,7 +147,8 @@ extern "C" {
    * @remarks If the output is tensor list then it need to be dense
    */
   DLL_PUBLIC void daliCopyTensorNTo(daliPipelineHandle* pipe_handle, void* dst, int n,
-                                    device_type_t dst_type, cudaStream_t stream);
+                                    device_type_t dst_type, cudaStream_t stream,
+                                    bool non_blocking);
 
   /**
    * @brief Delete the pipeline object.

--- a/dali/plugin/copy.h
+++ b/dali/plugin/copy.h
@@ -29,19 +29,23 @@ enum device_type_t {
 DLL_PUBLIC void CopyToExternalTensor(TensorList<CPUBackend>* tl,
                                      void* ptr,
                                      device_type_t dst_type,
-                                     cudaStream_t stream = 0);
+                                     cudaStream_t stream = 0,
+                                     bool non_blocking = false);
 DLL_PUBLIC void CopyToExternalTensor(TensorList<GPUBackend>* tl,
                                      void* ptr,
                                      device_type_t dst_type,
-                                     cudaStream_t stream = 0);
+                                     cudaStream_t stream = 0,
+                                     bool non_blocking = false);
 DLL_PUBLIC void CopyToExternalTensor(const Tensor<CPUBackend>& tl,
                                      void* ptr,
                                      device_type_t dst_type,
-                                     cudaStream_t stream = 0);
+                                     cudaStream_t stream = 0,
+                                     bool non_blocking = false);
 DLL_PUBLIC void CopyToExternalTensor(const Tensor<GPUBackend>& tl,
                                      void* ptr,
                                      device_type_t dst_type,
-                                     cudaStream_t stream = 0);
+                                     cudaStream_t stream = 0,
+                                     bool non_blocking = false);
 
 }  // namespace dali
 

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -127,7 +127,7 @@ void ExposeTensor(py::module &m) { // NOLINT
          )code")
     .def("copy_to_external",
         [](Tensor<CPUBackend> &t, py::object p) {
-          CopyToExternalTensor(t, ctypes_void_ptr(p), CPU, 0);
+          CopyToExternalTensor(t, ctypes_void_ptr(p), CPU, 0, false);
         },
       "ptr"_a,
       R"code(
@@ -156,15 +156,16 @@ void ExposeTensor(py::module &m) { // NOLINT
          Remove single-dimensional entries from the shape of the Tensor.
          )code")
     .def("copy_to_external",
-        [](Tensor<GPUBackend> &t, py::object p, py::object cuda_stream) {
+        [](Tensor<GPUBackend> &t, py::object p, py::object cuda_stream, bool non_blocking) {
           void *ptr = ctypes_void_ptr(p);
           cudaStream_t stream = static_cast<cudaStream_t>(
             ctypes_void_ptr(cuda_stream));
 
-          CopyToExternalTensor(t, ptr, GPU, stream);
+          CopyToExternalTensor(t, ptr, GPU, stream, non_blocking);
         },
       "ptr"_a,
       "cuda_stream"_a = 0,
+      "non_blocking"_a = false,
       R"code(
       Copy to external pointer in the GPU memory.
 
@@ -174,6 +175,8 @@ void ExposeTensor(py::module &m) { // NOLINT
             Destination of the copy.
       cuda_stream : ctypes.c_void_p
             CUDA stream to schedule the copy on (default stream if not provided).
+      non_blocking : bool
+            Asynchronous copy.
       )code")
     .def("dtype",
         [](Tensor<GPUBackend> &t) {
@@ -386,14 +389,15 @@ void ExposeTensorList(py::module &m) { // NOLINT
       may be viewed as a tensor of shape `(N, H, W, C)`.
       )code")
     .def("copy_to_external",
-        [](TensorList<GPUBackend> &t, py::object p, py::object cuda_stream) {
+        [](TensorList<GPUBackend> &t, py::object p, py::object cuda_stream, bool non_blocking) {
           void *ptr = ctypes_void_ptr(p);
           cudaStream_t stream = static_cast<cudaStream_t>(
             ctypes_void_ptr(cuda_stream));
-          CopyToExternalTensor(&t, ptr, GPU, stream);
+          CopyToExternalTensor(&t, ptr, GPU, stream, non_blocking);
         },
       "ptr"_a,
       "cuda_stream"_a = 0,
+      "non_blocking"_a = false,
       R"code(
       Copy the contents of this `TensorList` to an external pointer
       residing in CPU memory.
@@ -407,6 +411,8 @@ void ExposeTensorList(py::module &m) { // NOLINT
             Destination of the copy.
       cuda_stream : ctypes.c_void_p
             CUDA stream to schedule the copy on (default stream if not provided).
+      non_blocking : bool
+            Asynchronous copy.
       )code")
     .def("at",
         [](TensorList<GPUBackend> &t, Index id) -> std::unique_ptr<Tensor<GPUBackend>> {

--- a/dali_tf_plugin/daliop.cc
+++ b/dali_tf_plugin/daliop.cc
@@ -308,10 +308,10 @@ class DaliOp : public tf::OpKernel {
       }
 
       if (!should_be_sparse_tensor) {
-        TF_DALI_CALL(daliCopyTensorNTo(&pipe_handle_, dst, i, this->device_type_, stream));
+        TF_DALI_CALL(daliCopyTensorNTo(&pipe_handle_, dst, i, this->device_type_, stream, false));
       } else {
         // copy values
-        TF_DALI_CALL(daliCopyTensorListNTo(&pipe_handle_, dst, i, this->device_type_, stream));
+        TF_DALI_CALL(daliCopyTensorListNTo(&pipe_handle_, dst, i, this->device_type_, stream, false));
         ++j;
         // copy out shape
         OP_REQUIRES_OK(context, outputs.allocate(j, tf::TensorShape({dims}),


### PR DESCRIPTION
Signed-off-by: Yuichiro Ueno <y1r.ueno@gmail.com>

#### Why we need this PR?
- It adds new feature needed because I want to use asynchronous `copy_to_external`

#### What happened in this PR?
* Add `non_blocking` to copy_to_external, and corresponding internal APIs.
* Update Python and C API to support internal APIs update.

FYI, this feature is discussed at https://github.com/NVIDIA/DALI/pull/807#issuecomment-486305770