### PR TITLE
Rework Support Ops to use TensorList

### DIFF
--- a/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
+++ b/dali/pipeline/operators/displacement/displacement_filter_impl_cpu.h
@@ -183,7 +183,7 @@ class DisplacementFilter<CPUBackend, Displacement, per_channel_transform>
   float fill_value_;
 
   bool has_mask_;
-  const Tensor<CPUBackend> *mask_;
+  const TensorList<CPUBackend> *mask_;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operators/displacement/displacement_filter_impl_gpu.cuh
+++ b/dali/pipeline/operators/displacement/displacement_filter_impl_gpu.cuh
@@ -403,7 +403,7 @@ class DisplacementFilter<GPUBackend, Displacement,
   Tensor<GPUBackend> meta_gpu;
 
   bool has_mask_;
-  Tensor<GPUBackend> mask_gpu_;
+  TensorList<GPUBackend> mask_gpu_;
 
   Tensor<CPUBackend> params_;
   Tensor<GPUBackend> params_gpu_;

--- a/dali/pipeline/operators/displacement/warp_param_provider.h
+++ b/dali/pipeline/operators/displacement/warp_param_provider.h
@@ -240,7 +240,7 @@ class WarpParamProvider : public InterpTypeProvider, public BorderTypeProvider<B
             (shape.num_samples() == 1 && (shape[0] == kernels::TensorShape<>(N, spatial_ndim) ||
                                           shape[0] == kernels::TensorShape<>(N * spatial_ndim))),
         "Output sizes must either be a batch of `dim`-sized tensors, flat array of size "
-        "num_samples*dim or a one 2-dim tensor of shape {num_samples, dim}.");
+        "num_samples*dim or one 2D tensor of shape {num_samples, dim}.");
 
     out_sizes.resize(N);
     if (shape.num_samples() == N) {

--- a/dali/pipeline/operators/displacement/warp_param_provider.h
+++ b/dali/pipeline/operators/displacement/warp_param_provider.h
@@ -39,11 +39,11 @@ class InterpTypeProvider {
   void SetInterp(const OpSpec &spec, const ArgumentWorkspace &ws, int num_samples) {
     interp_types_.clear();
     if (spec.HasTensorArgument("interp_type")) {
-      auto &tensor = ws.ArgumentInput("interp_type");
-      int n = tensor.shape()[0];
+      auto &tensor_list = ws.ArgumentInput("interp_type");
+      int n = tensor_list.shape().num_samples();
       DALI_ENFORCE(n == 1 || n == num_samples,
         "interp_type must be a single value or contain one value per sample");
-      auto *data = tensor.template data<DALIInterpType>();
+      auto *data = tensor_list.template data<DALIInterpType>();
       interp_types_.resize(n);
 
       for (int i = 0; i < n; i++)
@@ -229,19 +229,29 @@ class WarpParamProvider : public InterpTypeProvider, public BorderTypeProvider<B
 
   virtual void GetExplicitPerSampleSize(std::vector<SpatialShape> &out_sizes) const {
     assert(HasExplicitPerSampleSize());
-    const Tensor<CPUBackend> &tensor = ws_->ArgumentInput(size_arg_name_);
-    auto tv = view<const int>(tensor);
+    const TensorList<CPUBackend> &tensor_list = ws_->ArgumentInput(size_arg_name_);
+    const auto &shape = tensor_list.shape();
+    auto tv = view<const int>(tensor_list);
     const int N = num_samples_;
+
+    DALI_ENFORCE(is_uniform(shape), "Output sizes must be passed as uniform Tensor List.");
     DALI_ENFORCE(
-      tv.shape == kernels::TensorShape<>(N, spatial_ndim) ||
-      tv.shape == kernels::TensorShape<>(N * spatial_ndim),
-      "Output sizes must either be a flat array of size num_samples*dim "
-      "or a 2D tensor of size num_samples x dim");
+        (shape.num_samples() == N && shape[0] == kernels::TensorShape<>(spatial_ndim)) ||
+            (shape.num_samples() == 1 && (shape[0] == kernels::TensorShape<>(N, spatial_ndim) ||
+                                          shape[0] == kernels::TensorShape<>(N * spatial_ndim))),
+        "Output sizes must either be a batch of `dim`-sized tensors, flat array of size "
+        "num_samples*dim or a one 2-dim tensor of shape {num_samples, dim}.");
 
     out_sizes.resize(N);
-    for (int i = 0; i < N; i++)
-      for (int d = 0; d < spatial_ndim; d++)
-        out_sizes[i][d] = tv.data[i*N + d];
+    if (shape.num_samples() == N) {
+      for (int i = 0; i < N; i++)
+        for (int d = 0; d < spatial_ndim; d++)
+          out_sizes[i][d] = tv.data[i][d];
+    } else {
+      for (int i = 0; i < N; i++)
+        for (int d = 0; d < spatial_ndim; d++)
+          out_sizes[i][d] = tv.data[0][i*N + d];
+    }
   }
 
   void SetExplicitSize() {

--- a/dali/pipeline/operators/op_spec.h
+++ b/dali/pipeline/operators/op_spec.h
@@ -416,6 +416,50 @@ class DLL_PUBLIC OpSpec {
   template <typename T, typename S>
   inline T GetArgumentImpl(const string &name, const ArgumentWorkspace *ws, Index idx) const;
 
+  /**
+   * @brief Check if the ArgumentInput of given shape can be used with GetArgument(),
+   *        representing a batch of scalars
+   *
+   * @argument should_throw whether this function should throw an error if the shape doesn't match
+   * @return true iff the shape is allowed to be used as Argument
+   */
+  bool CheckArgumentShape(const kernels::TensorListShape<> &shape, int batch_size,
+                          const std::string &name, bool should_throw = false) const {
+    if (shape.num_samples() == 1) {
+      // TODO(klecki): 1 sample version will be of no use after the switch to CPU ops unless we
+      // generalize accepted batch sizes throughout the pipeline
+      bool is_one_sample_with_batch = shape[0] == kernels::TensorShape<>(batch_size);
+      if (should_throw) {
+        DALI_ENFORCE(is_one_sample_with_batch,
+            "Unexpected shape of argument \"" + name +
+                "\". If only one tensor is passed, it should have a shape equal to {" +
+                std::to_string(batch_size) +
+                "}.  When accessing arguments as scalars 1 tensor of shape {" +
+                std::to_string(batch_size) + "} or " + std::to_string(batch_size) +
+                " tensors of shape {1} are expected. To access argument inputs where samples are "
+                "not scalars use ArgumentWorkspace::ArgumentInput method directly.");
+      } else if (!is_one_sample_with_batch) {
+        return false;
+      }
+    } else {
+      bool is_batch_of_scalars =
+          shape.num_samples() == batch_size && shape.sample_dim() == 1 && shape[0][0] == 1;
+      if (should_throw) {
+        DALI_ENFORCE(is_batch_of_scalars,
+            "Unexpected shape of argument \"" + name + "\". Expected batch of " +
+                std::to_string(batch_size) + " tensors of shape {1}, got " +
+                std::to_string(shape.num_samples()) + " samples of " +
+                std::to_string(shape.sample_dim()) +
+                "-dim tensors. Alternatively 1 tensor of shape {" + std::to_string(batch_size) +
+                "} can be passed. To access argument inputs where samples are not scalars "
+                "use ArgumentWorkspace::ArgumentInput method directly.");
+      } else if (!is_batch_of_scalars) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   template <typename T, typename S>
   inline bool TryGetArgumentImpl(T &result,
                                  const string &name,
@@ -437,6 +481,7 @@ class DLL_PUBLIC OpSpec {
   vector<InOutDeviceDesc> inputs_, outputs_;
 };
 
+
 template <typename T, typename S>
 inline T OpSpec::GetArgumentImpl(
       const string &name,
@@ -449,32 +494,8 @@ inline T OpSpec::GetArgumentImpl(
     DALI_ENFORCE(kernels::is_uniform(value.shape()),
                  "Arguments should be passed as uniform TensorLists. Argument \"" + name +
                      "\" is not uniform.");
-    auto check_shape = [](const auto &shape, int batch_size, const std::string &name) {
-      if (shape.num_samples() == 1) {
-        // TODO(klecki): 1 sample version will be of no use after the switch to CPU ops unless we
-        // generalize accepted batch sizes throughout the pipeline
-        DALI_ENFORCE(
-            shape[0] == kernels::TensorShape<>(batch_size),
-            "Unexpected shape of argument \"" + name +
-                "\". If only one tensor is passed, it should have a shape equal to {" +
-                std::to_string(batch_size) +
-                "}.  When accessing arguments as scalars 1 tensor of shape {" +
-                std::to_string(batch_size) + "} or " + std::to_string(batch_size) +
-                " tensors of shape {1} are expected. To access argument inputs where samples are "
-                "not scalars use ArgumentWorkspace::ArgumentInput method directly.");
-      } else {
-        DALI_ENFORCE(
-            shape.num_samples() == batch_size && shape.sample_dim() == 1 && shape[0][0] == 1,
-            "Unexpected shape of argument \"" + name + "\". Expected batch of " +
-                std::to_string(batch_size) + " tensors of shape {1}, got " +
-                std::to_string(shape.num_samples()) + " samples of " +
-                std::to_string(shape.sample_dim()) +
-                "-dim tensors. Alternatively 1 tensor of shape {" + std::to_string(batch_size) +
-                "} can be passed. To access argument inputs where samples are not scalars "
-                "use ArgumentWorkspace::ArgumentInput method directly.");
-      }
-    };
-    check_shape(value.shape(), GetArgument<int>("batch_size"), name);
+
+    CheckArgumentShape(value.shape(), GetArgument<int>("batch_size"), name, true);
     DALI_ENFORCE(IsType<T>(value.type()),
         "Unexpected type of argument \"" + name + "\". Expected " +
         TypeTable::GetTypeName<T>() + " and got " + value.type().name());
@@ -503,7 +524,7 @@ inline bool OpSpec::TryGetArgumentImpl(
     if (ws == nullptr)
       return false;
     const auto& value = ws->ArgumentInput(name);
-    if (value.shape() != kernels::uniform_list_shape(GetArgument<int>("batch_size"), {1})) {
+    if (!CheckArgumentShape(value.shape(), GetArgument<int>("batch_size"), name, false)) {
       return false;
     }
     if (!IsType<T>(value.type()))

--- a/dali/pipeline/operators/op_spec_test.cc
+++ b/dali/pipeline/operators/op_spec_test.cc
@@ -1,0 +1,169 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <gtest/gtest.h>
+
+#include "dali/pipeline/pipeline.h"
+
+#include "dali/core/common.h"
+#include "dali/pipeline/data/backend.h"
+#include "dali/pipeline/data/buffer.h"
+#include "dali/pipeline/data/tensor.h"
+#include "dali/pipeline/operators/operator.h"
+#include "dali/pipeline/workspace/workspace.h"
+#include "dali/test/dali_test.h"
+
+
+namespace dali {
+
+class SupportGeneratingOp : public Operator<SupportBackend> {
+ public:
+  explicit SupportGeneratingOp(const OpSpec &spec) : Operator<SupportBackend>(spec) {}
+
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const SupportWorkspace &ws) override {
+    output_desc.resize(4);
+    output_desc[0] = {kernels::uniform_list_shape(batch_size_, {1}), TypeInfo::Create<int>()};
+    output_desc[1] = {kernels::TensorListShape<>{{10}}, TypeInfo::Create<float>()};
+    // Non-matching shapes
+    output_desc[2] = {kernels::uniform_list_shape(batch_size_ + 5, {1}), TypeInfo::Create<int>()};
+    output_desc[3] = {kernels::uniform_list_shape(batch_size_, {1, 2}), TypeInfo::Create<int>()};
+    return true;
+  }
+
+  void RunImpl(SupportWorkspace &ws) override {
+    // Initialize all the data with a 0, 1, 2 .... sequence
+    auto &out0 = ws.OutputRef<CPUBackend>(0);
+    for (int i = 0; i < out0.shape().num_samples(); i++) {
+      *out0.mutable_tensor<int>(i) = i;
+    }
+
+    auto &out1 = ws.OutputRef<CPUBackend>(1);
+    for (int i = 0; i < out1.shape()[0][0]; i++) {
+      out1.mutable_data<float>()[i] = i;
+    }
+
+    auto &out2 = ws.OutputRef<CPUBackend>(2);
+    for (int i = 0; i < out2.shape().num_samples(); i++) {
+      *out2.mutable_tensor<int>(i) = i;
+    }
+
+    auto &out3 = ws.OutputRef<CPUBackend>(3);
+    for (int i = 0; i < out3.shape().num_samples(); i++) {
+      for (int j = 0; j < 2; j++) {
+        out3.mutable_tensor<int>(i)[j] = i;
+      }
+    }
+  }
+};
+
+DALI_REGISTER_OPERATOR(SupportGeneratingOp, SupportGeneratingOp, Support);
+
+DALI_SCHEMA(SupportGeneratingOp)
+  .DocStr("SupportGeneratingOp")
+  .NumInput(0)
+  .NumOutput(4);
+
+
+class SupportAccessingOp : public Operator<CPUBackend> {
+ public:
+  explicit SupportAccessingOp(const OpSpec &spec) : Operator<CPUBackend>(spec) {}
+
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    output_desc.resize(1);
+    output_desc[0] = {kernels::uniform_list_shape(batch_size_, {1}), TypeInfo::Create<int>()};
+    return true;
+  }
+
+  void RunImpl(HostWorkspace &ws) override {
+    for (int i = 0; i < batch_size_; i++) {
+      EXPECT_EQ(spec_.GetArgument<int>("arg0", &ws, i), i);
+      EXPECT_EQ(spec_.GetArgument<float>("arg1", &ws, i), i);
+    }
+    // Non-matching shapes (differnet than 1 scalar value per sample) should not work with
+    // OpSpec::GetArgument()
+    ASSERT_THROW(auto z = spec_.GetArgument<float>("arg2", &ws, 0), std::runtime_error);
+    ASSERT_THROW(auto z = spec_.GetArgument<float>("arg3", &ws, 0), std::runtime_error);
+
+    // They can be accessed as proper ArgumentInputs
+    auto &ref_2 = ws.ArgumentInput("arg2");
+    ASSERT_EQ(ref_2.shape().num_samples(), batch_size_ + 5);
+    ASSERT_TRUE(kernels::is_uniform(ref_2.shape()));
+    ASSERT_EQ(ref_2.shape()[0], kernels::TensorShape<>(1));
+    for (int i = 0; i < ref_2.shape().num_samples(); i++) {
+      EXPECT_EQ(ref_2.tensor<int>(i)[0], i);
+    }
+
+    auto &ref_3 = ws.ArgumentInput("arg3");
+    ASSERT_EQ(ref_3.shape().num_samples(), batch_size_);
+    ASSERT_TRUE(kernels::is_uniform(ref_3.shape()));
+    ASSERT_EQ(ref_3.shape()[0], kernels::TensorShape<>(1, 2));
+    for (int i = 0; i < ref_3.shape().num_samples(); i++) {
+      for (int j = 0; j < 2; j++) {
+        EXPECT_EQ(ref_3.tensor<int>(i)[j], i);
+      }
+    }
+  }
+};
+
+DALI_REGISTER_OPERATOR(SupportAccessingOp, SupportAccessingOp, CPU);
+
+DALI_SCHEMA(SupportAccessingOp)
+  .DocStr("SupportAccessingOp")
+  .NumInput(0)
+  .NumOutput(1)
+  .AddOptionalArg("arg0", "no-doc", 42, true)
+  .AddOptionalArg("arg1", "no-doc", 42.f, true)
+  .AddOptionalArg("arg2", "no-doc", 42, true)
+  .AddOptionalArg("arg3", "no-doc", 42, true);
+
+TEST(ArgumentInputTest, OpSpecAccess) {
+  Pipeline pipe(10, 4, 0);
+  pipe.AddOperator(
+      OpSpec("SupportGeneratingOp")
+      .AddArg("device", "support")
+      .AddOutput("support_arg0", "cpu")
+      .AddOutput("support_arg1", "cpu")
+      .AddOutput("support_arg2", "cpu")
+      .AddOutput("support_arg3", "cpu"));
+
+  pipe.AddOperator(
+      OpSpec("SupportAccessingOp")
+      .AddArg("device", "cpu")
+      .AddArgumentInput("arg0", "support_arg0")
+      .AddArgumentInput("arg1", "support_arg1")
+      .AddArgumentInput("arg2", "support_arg2")
+      .AddArgumentInput("arg3", "support_arg3")
+      .AddOutput("I need to specify something", "cpu")
+      .AddArg("preserve", true));
+
+  vector<std::pair<string, string>> outputs = { {"I need to specify something", "cpu"} };
+  pipe.Build(outputs);
+
+  pipe.RunCPU();
+  pipe.RunGPU();
+
+  DeviceWorkspace ws;
+  pipe.Outputs(&ws);
+}
+
+}  // namespace dali

--- a/dali/pipeline/operators/support/random/coin_flip.cc
+++ b/dali/pipeline/operators/support/random/coin_flip.cc
@@ -19,7 +19,6 @@ namespace dali {
 
 void CoinFlip::RunImpl(SupportWorkspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
-  output.Resize({batch_size_});
 
   int *out_data = output.template mutable_data<int>();
 

--- a/dali/pipeline/operators/support/random/coin_flip.h
+++ b/dali/pipeline/operators/support/random/coin_flip.h
@@ -37,8 +37,15 @@ class CoinFlip : public Operator<SupportBackend> {
   using Operator<SupportBackend>::RunImpl;
 
  protected:
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const SupportWorkspace &ws) override {
-    return false;
+    output_desc.resize(1);
+    output_desc[0].shape = kernels::uniform_list_shape(batch_size_, {1});
+    output_desc[0].type = TypeInfo::Create<int>();
+    return true;
   }
 
   void RunImpl(Workspace<SupportBackend> &ws) override;

--- a/dali/pipeline/operators/support/random/uniform.cc
+++ b/dali/pipeline/operators/support/random/uniform.cc
@@ -21,8 +21,6 @@ namespace dali {
 
 void Uniform::RunImpl(SupportWorkspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
-  output.Resize({batch_size_});
-
   float *out_data = output.template mutable_data<float>();
 
   for (int i = 0; i < batch_size_; ++i) {

--- a/dali/pipeline/operators/support/random/uniform.h
+++ b/dali/pipeline/operators/support/random/uniform.h
@@ -41,8 +41,15 @@ class Uniform : public Operator<SupportBackend> {
   using Operator<SupportBackend>::RunImpl;
 
  protected:
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const SupportWorkspace &ws) override {
-    return false;
+    output_desc.resize(1);
+    output_desc[0].shape = kernels::uniform_list_shape(batch_size_, {1});
+    output_desc[0].type = TypeInfo::Create<float>();
+    return true;
   }
 
   void RunImpl(Workspace<SupportBackend> &ws) override;

--- a/dali/pipeline/workspace/support_workspace.cc
+++ b/dali/pipeline/workspace/support_workspace.cc
@@ -17,12 +17,12 @@
 namespace dali {
 
 template <>
-const Tensor<CPUBackend>& SupportWorkspace::Input(int idx) const {
+const TensorList<CPUBackend>& SupportWorkspace::Input(int idx) const {
   return *CPUInput(idx);
 }
 
 template <>
-Tensor<CPUBackend>& SupportWorkspace::Output(int idx) {
+TensorList<CPUBackend>& SupportWorkspace::Output(int idx) {
   return *CPUOutput(idx);
 }
 

--- a/dali/pipeline/workspace/support_workspace.h
+++ b/dali/pipeline/workspace/support_workspace.h
@@ -27,9 +27,9 @@
 namespace dali {
 
 template <typename Backend>
-using SupportInputType = shared_ptr<Tensor<Backend>>;
+using SupportInputType = shared_ptr<TensorList<Backend>>;
 template <typename Backend>
-using SupportOutputType = shared_ptr<Tensor<Backend>>;
+using SupportOutputType = shared_ptr<TensorList<Backend>>;
 
 /**
  * @brief SupportWorkspace stores all data that a support operator operates on,
@@ -47,13 +47,13 @@ class DLL_PUBLIC SupportWorkspace : public WorkspaceBase<SupportInputType, Suppo
    * @brief Returns the input Tensor at index `idx`.
    */
   template <typename Backend>
-  DLL_PUBLIC const Tensor<Backend>& Input(int idx) const;
+  DLL_PUBLIC const TensorList<Backend>& Input(int idx) const;
 
   /**
    * @brief Returns the output Tensor at index `idx`.
    */
   template <typename Backend>
-  DLL_PUBLIC Tensor<Backend>& Output(int idx);
+  DLL_PUBLIC TensorList<Backend>& Output(int idx);
 
   bool has_stream() const override {
     return false;

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -50,17 +50,17 @@ class ArgumentWorkspace {
     argument_inputs_.clear();
   }
 
-  void AddArgumentInput(shared_ptr<Tensor<CPUBackend>> input, const std::string &arg_name) {
+  void AddArgumentInput(shared_ptr<TensorList<CPUBackend>> input, const std::string &arg_name) {
     argument_inputs_[arg_name] = std::move(input);
   }
 
-  void SetArgumentInput(shared_ptr<Tensor<CPUBackend>> input, const std::string &arg_name) {
+  void SetArgumentInput(shared_ptr<TensorList<CPUBackend>> input, const std::string &arg_name) {
     DALI_ENFORCE(argument_inputs_.find(arg_name) != argument_inputs_.end(),
         "Argument \"" + arg_name + "\" not found.");
     argument_inputs_[arg_name] = std::move(input);
   }
 
-  const Tensor<CPUBackend>& ArgumentInput(const std::string &arg_name) const {
+  const TensorList<CPUBackend>& ArgumentInput(const std::string &arg_name) const {
     DALI_ENFORCE(argument_inputs_.find(arg_name) != argument_inputs_.end(),
         "Argument \"" + arg_name + "\" not found.");
     return *(argument_inputs_.at(arg_name));
@@ -68,7 +68,7 @@ class ArgumentWorkspace {
 
  protected:
   // Argument inputs
-  std::unordered_map<std::string, shared_ptr<Tensor<CPUBackend>>> argument_inputs_;
+  std::unordered_map<std::string, shared_ptr<TensorList<CPUBackend>>> argument_inputs_;
 };
 
 /**


### PR DESCRIPTION
Extend OpSpec GetArgument
Add test to verify how ArgumentInputs can be accessed

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- Change the output type of SupportOps to TensorList so they can be replaced by regular CPU/GPU ops in the future.

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
Output of SupportOp is changed to TensorList. It also allows for arbitrary shaped batches to be used as Argument Inputs.
 - What was changed, added, removed?
OpSpec code for obtaining tensor arguments was adjusted.
 - What is most important part that reviewers should focus on?
N/A
 - Was this PR tested? How?
A test was added to check the constraints on the Tensor Argument shape and access to Argument Inputs. CI will run L3.
 - Were docs and examples updated, if necessary?


**JIRA TASK**: [DALI-1044]