### PR TITLE
Add pipeline validation

### DIFF
--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -485,7 +485,7 @@ class PythonFunctionBase(with_metaclass(_DaliOperatorMeta, object)):
         pipeline = Pipeline.current()
         if pipeline.exec_async or pipeline.exec_pipelined:
             raise RuntimeError("PythonFunction can be used only in pipelines with `exec_async` and "
-                               "`exec_pipelined` specified to False.")
+                               "`exec_pipelined` set to False.")
         if (len(inputs) > self._schema.MaxNumInput() or
                 len(inputs) < self._schema.MinNumInput()):
             raise ValueError(

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -483,6 +483,9 @@ class PythonFunctionBase(with_metaclass(_DaliOperatorMeta, object)):
 
     def __call__(self, *inputs, **kwargs):
         pipeline = Pipeline.current()
+        if pipeline.exec_async or pipeline.exec_pipelined:
+            raise RuntimeError("PythonFunction can be used only in pipelines with `exec_async` and "
+                               "`exec_pipelined` specified to False.")
         if (len(inputs) > self._schema.MaxNumInput() or
                 len(inputs) < self._schema.MinNumInput()):
             raise ValueError(

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -134,6 +134,14 @@ class Pipeline(object):
         """Id of the GPU used by the pipeline."""
         return self._device_id
 
+    @property
+    def exec_pipelined(self):
+        return self._exec_pipelined
+
+    @property
+    def exec_async(self):
+        return self._exec_async
+
     def epoch_size(self, name = None):
         """Epoch size of a pipeline.
 

--- a/dali/test/python/test_operator_python_function.py
+++ b/dali/test/python/test_operator_python_function.py
@@ -403,9 +403,10 @@ def test_func_with_side_effects():
         assert elems_two == [i for i in range(BATCH_SIZE + 1, 2 * BATCH_SIZE + 1)]
 
 
-class WrongPipeline(Pipeline):
+class AsyncPipeline(Pipeline):
     def __init__(self, batch_size, num_threads, device_id, _seed):
-        super(WrongPipeline, self).__init__(batch_size, num_threads, device_id, seed=_seed)
+        super(AsyncPipeline, self).__init__(batch_size, num_threads, device_id, seed=_seed,
+                                            exec_async=True, exec_pipelined=True)
         self.op = ops.PythonFunction(function=lambda: numpy.zeros([2, 2, 2]))
 
     def define_graph(self):
@@ -414,5 +415,5 @@ class WrongPipeline(Pipeline):
 
 @raises(RuntimeError)
 def test_wrong_pipeline():
-    pipe = WrongPipeline(BATCH_SIZE, NUM_WORKERS, DEVICE_ID, SEED)
+    pipe = AsyncPipeline(BATCH_SIZE, NUM_WORKERS, DEVICE_ID, SEED)
     pipe.build()

--- a/dali/test/python/test_operator_python_function.py
+++ b/dali/test/python/test_operator_python_function.py
@@ -407,3 +407,22 @@ def test_func_with_side_effects():
         elems_two = [out_two.at(s)[0][0][0] for s in range(BATCH_SIZE)]
         elems_two.sort()
         assert elems_two == [i for i in range(BATCH_SIZE + 1, 2 * BATCH_SIZE + 1)]
+
+
+class WrongPipeline(Pipeline):
+    def __init__(self, batch_size, num_threads, device_id, _seed):
+        super(WrongPipeline, self).__init__(batch_size, num_threads, device_id, seed=_seed)
+        self.op = ops.PythonFunction(function=lambda: numpy.zeros([2, 2, 2]))
+
+    def define_graph(self):
+        return self.op()
+
+
+def test_wrong_pipeline():
+    pipe = WrongPipeline(BATCH_SIZE, NUM_WORKERS, DEVICE_ID, SEED)
+    try:
+        pipe.build()
+    except Exception as e:
+        print(e)
+        return
+    raise Exception('Should not pass')

--- a/dali/test/python/test_operator_python_function.py
+++ b/dali/test/python/test_operator_python_function.py
@@ -10,7 +10,7 @@ import os
 import glob
 import tempfile
 import time
-from nose.tools import assert_raises
+from nose.tools import raises
 from test_utils import get_dali_extra_path
 
 test_data_root = get_dali_extra_path()
@@ -257,21 +257,19 @@ def invalid_function(image):
     return img
 
 
+@raises(Exception)
 def test_python_operator_invalid_function():
     invalid_pipe = PythonOperatorPipeline(BATCH_SIZE, NUM_WORKERS, DEVICE_ID, SEED, images_dir,
                                           invalid_function)
     invalid_pipe.build()
-    try:
-        invalid_pipe.run()
-    except Exception as e:
-        print(e)
-        return
-    raise Exception('Should not pass')
+    invalid_pipe.run()
 
+
+@raises(TypeError)
 def test_python_operator_invalid_pipeline():
     invalid_pipe = PythonOperatorInvalidPipeline(BATCH_SIZE, NUM_WORKERS, DEVICE_ID, SEED,
                                                  images_dir, Rotate)
-    assert_raises(TypeError, invalid_pipe.build)
+    invalid_pipe.build()
 
 
 
@@ -341,16 +339,12 @@ def test_output_with_stride_mixed_types():
     run_multi_input_multi_output(output_with_stride_mixed_types)
 
 
+@raises(RuntimeError)
 def test_wrong_outputs_number():
     invalid_pipe = TwoOutputsPythonOperatorPipeline(BATCH_SIZE, NUM_WORKERS, DEVICE_ID, SEED,
                                                     images_dir, flip)
     invalid_pipe.build()
-    try:
-        invalid_pipe.run()
-    except Exception as e:
-        print(e)
-        return
-    raise Exception('Should not pass')
+    invalid_pipe.run()
 
 
 SINK_PATH = tempfile.mkdtemp()
@@ -418,11 +412,7 @@ class WrongPipeline(Pipeline):
         return self.op()
 
 
+@raises(RuntimeError)
 def test_wrong_pipeline():
     pipe = WrongPipeline(BATCH_SIZE, NUM_WORKERS, DEVICE_ID, SEED)
-    try:
-        pipe.build()
-    except Exception as e:
-        print(e)
-        return
-    raise Exception('Should not pass')
+    pipe.build()


### PR DESCRIPTION
Signed-off-by: Rafal <Banas.Rafal97@gmail.com>

#### Why we need this PR?
- Refactoring to fail with a message when the python operator is tried to be instantiated in an async pipeline.

#### What happened in this PR?
   Just a small check in the `PythonFunctionBase`.

**JIRA TASK**: NONE