### PR TITLE
Add types to TypeTable during initialization

### DIFF
--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -31,6 +31,9 @@
 
 #include "dali/pipeline/data/backend.h"
 
+#define DALI_ADD_TO_TYPE_TABLE(Type) \
+static const auto ANONYMIZE_VARIABLE(id) = TypeTable::GetTypeID<Type>()
+
 namespace dali {
 std::mutex TypeTable::mutex_;
 std::unordered_map<std::type_index, DALIDataType> TypeTable::type_map_;
@@ -63,5 +66,30 @@ void TypeInfo::Copy<GPUBackend, GPUBackend>(void *dst,
   MemCopy(dst, src, n*size(), stream);
 }
 
+DALI_ADD_TO_TYPE_TABLE(uint8_t);
+DALI_ADD_TO_TYPE_TABLE(uint16_t);
+DALI_ADD_TO_TYPE_TABLE(uint32_t);
+DALI_ADD_TO_TYPE_TABLE(uint64_t);
+DALI_ADD_TO_TYPE_TABLE(int8_t);
+DALI_ADD_TO_TYPE_TABLE(int16_t);
+DALI_ADD_TO_TYPE_TABLE(int32_t);
+DALI_ADD_TO_TYPE_TABLE(int64_t);
+DALI_ADD_TO_TYPE_TABLE(float16);
+DALI_ADD_TO_TYPE_TABLE(float);
+DALI_ADD_TO_TYPE_TABLE(double);
+DALI_ADD_TO_TYPE_TABLE(bool);
+DALI_ADD_TO_TYPE_TABLE(string);
+DALI_ADD_TO_TYPE_TABLE(DALIImageType);
+DALI_ADD_TO_TYPE_TABLE(DALIDataType);
+DALI_ADD_TO_TYPE_TABLE(DALIInterpType);
+DALI_ADD_TO_TYPE_TABLE(DALITensorLayout);
+#ifdef DALI_BUILD_PROTO3
+DALI_ADD_TO_TYPE_TABLE(TFUtil::Feature);
+DALI_ADD_TO_TYPE_TABLE(std::vector<TFUtil::Feature>);
+#endif
+DALI_ADD_TO_TYPE_TABLE(std::vector<bool>);
+DALI_ADD_TO_TYPE_TABLE(std::vector<int>);
+DALI_ADD_TO_TYPE_TABLE(std::vector<std::string>);
+DALI_ADD_TO_TYPE_TABLE(std::vector<float>);
 
 }  // namespace dali

--- a/dali/pipeline/data/types_test.cc
+++ b/dali/pipeline/data/types_test.cc
@@ -84,4 +84,35 @@ TYPED_TEST(TypesTest, TestRegisteredType) {
   ASSERT_EQ(type.name(), this->TypeName());
 }
 
+#define GET_TYPE_INFO(Type) \
+const auto &ANONYMIZE_VARIABLE(info) = TypeTable::GetTypeInfo(type2id<Type>::value)
+
+TEST(TypeTableTest, BasicTypesLookup) {
+  GET_TYPE_INFO(uint8_t);
+  GET_TYPE_INFO(uint16_t);
+  GET_TYPE_INFO(uint32_t);
+  GET_TYPE_INFO(uint64_t);
+  GET_TYPE_INFO(int8_t);
+  GET_TYPE_INFO(int16_t);
+  GET_TYPE_INFO(int32_t);
+  GET_TYPE_INFO(int64_t);
+  GET_TYPE_INFO(float16);
+  GET_TYPE_INFO(float);
+  GET_TYPE_INFO(double);
+  GET_TYPE_INFO(bool);
+  GET_TYPE_INFO(string);
+  GET_TYPE_INFO(DALIImageType);
+  GET_TYPE_INFO(DALIDataType);
+  GET_TYPE_INFO(DALIInterpType);
+  GET_TYPE_INFO(DALITensorLayout);
+#ifdef DALI_BUILD_PROTO3
+  GET_TYPE_INFO(TFUtil::Feature);
+  GET_TYPE_INFO(std::vector<TFUtil::Feature>);
+#endif
+  GET_TYPE_INFO(std::vector<bool>);
+  GET_TYPE_INFO(std::vector<int>);
+  GET_TYPE_INFO(std::vector<std::string>);
+  GET_TYPE_INFO(std::vector<float>);
+}
+
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Rafal <Banas.Rafal97@gmail.com>

#### Why we need this PR?
- It fixes a bug.
  Basic types were not added to `TypeTable` during initialization, so DALI relied on adding them on runtime in some specific cases. This caused an error when calling `TypeTable::GetTypeInfo<Type>()` in some situations. 

#### What happened in this PR?
   In this PR all basic types are added to the `TypeTable` during the initialization. 

**JIRA TASK**: NONE