### PR TITLE
Add check for OF support

### DIFF
--- a/dali/pipeline/operators/optical_flow/turing_of/optical_flow_turing.cc
+++ b/dali/pipeline/operators/optical_flow/turing_of/optical_flow_turing.cc
@@ -50,8 +50,13 @@ OpticalFlowTuring::OpticalFlowTuring(dali::optical_flow::OpticalFlowParams param
   SetInitParams(params);
   DeviceGuard g(device_id_);
   CUDA_CALL(cuCtxGetCurrent(&context_));
-
-  TURING_OF_API_CALL(turing_of_.nvCreateOpticalFlowCuda(context_, &of_handle_));
+  {
+    auto ret = turing_of_.nvCreateOpticalFlowCuda(context_, &of_handle_);
+    if (ret != NV_OF_SUCCESS) {
+      throw unsupported_exception(
+          "Failed to create Optical Flow context: Verify that your device supports Optical Flow.");
+    }
+  }
   TURING_OF_API_CALL(turing_of_.nvOFSetIOCudaStreams(of_handle_, stream_, stream_));
   VerifySupport(turing_of_.nvOFInit(of_handle_, &init_params_));
 


### PR DESCRIPTION
Indicate that OF is not supported if the first
call after loading the library fails.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- It fixes a bug of not skipping the gtest test if OF is not supported

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
unsupported_exception is thrown if the first call fails.
 - What was changed, added, removed?
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
Local machine + CI
 - Were docs and examples updated, if necessary?

**JIRA TASK**: [DALI-XXXX]