### PR TITLE
Fix DALI TF installation script

### DIFF
--- a/dali_tf_plugin/dali_tf_plugin_install_tool.py
+++ b/dali_tf_plugin/dali_tf_plugin_install_tool.py
@@ -75,7 +75,7 @@ class InstallerHelper:
             print("Prebuilt DALI TF plugin version {} is not present. Best match is {}".format(self.tf_version, best_version))
             tf_version_underscore = best_version.replace('.', '_')
             plugin_name = 'libdali_tf_' + tf_version_underscore + '.so'
-            prebuilt_plugin = src_path + '/' + plugin_name
+            prebuilt_plugin = self.src_path + '/' + plugin_name
         plugin_dest = self.plugin_dest_dir + '/' + plugin_name
         print("Copy {} to {}".format(prebuilt_plugin, self.plugin_dest_dir))
         copyfile(prebuilt_plugin, plugin_dest)

--- a/dali_tf_plugin/dali_tf_plugin_utils.py
+++ b/dali_tf_plugin/dali_tf_plugin_utils.py
@@ -86,8 +86,8 @@ def which(program):
 
 # Checks whether we are inside a conda env
 def is_conda_env():
-    return "" != os.environ.get('CONDA_PREFIX')
-    
+    return True if os.environ.get('CONDA_PREFIX') else False
+
 # Get compile and link flags for installed tensorflow
 def get_tf_build_flags():
     tf_cflags = ''
@@ -134,7 +134,7 @@ def get_cuda_build_flags():
     cuda_cflags=" ".join(["-I" + cuda_home + "/include"])
     cuda_lflags=" ".join([])
     return (cuda_cflags, cuda_lflags)
-    
+
 def find_available_prebuilt_tf(requested_version, available_libs):
     req_ver_first, req_ver_second = [int(v) for v in requested_version.split('.', 2)]
     selected_ver = None
@@ -147,4 +147,3 @@ def find_available_prebuilt_tf(requested_version, available_libs):
             if ver_second <= req_ver_second and (selected_ver is None or selected_ver < (ver_first, ver_second)):
                 selected_ver = (ver_first, ver_second)
     return '.'.join([str(v) for v in selected_ver]) if selected_ver is not None else None
-


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
os.get.environ can return either `""` or `None` when the variable doesn't exist, causing issues in DALI TF installation script

#### What happened in this PR?
Changed empty string checking logic to detect whether the dali tf installation is launched from a conda environment

**JIRA TASK**: [DALI-XXXX]