### PR TITLE
Handle nchannels>3 in ImageDecoder

### DIFF
--- a/dali/image/bmp.cc
+++ b/dali/image/bmp.cc
@@ -21,7 +21,7 @@ BmpImage::BmpImage(const uint8_t *encoded_buffer, size_t length, DALIImageType i
 }
 
 
-Image::Shape BmpImage::PeekShape(const uint8_t *bmp, size_t length) const {
+Image::Shape BmpImage::PeekShapeImpl(const uint8_t *bmp, size_t length) const {
   DALI_ENFORCE(bmp);
 
   // https://en.wikipedia.org/wiki/BMP_file_format#DIB_header_(bitmap_information_header)

--- a/dali/image/bmp.h
+++ b/dali/image/bmp.h
@@ -27,7 +27,7 @@ class BmpImage final : public GenericImage {
   BmpImage(const uint8_t *encoded_buffer, size_t length, DALIImageType image_type);
 
  private:
-  Image::Shape PeekShape(const uint8_t *bmp, size_t length) const override;
+  Image::Shape PeekShapeImpl(const uint8_t *bmp, size_t length) const override;
 };
 
 }  // namespace dali

--- a/dali/image/generic_image.cc
+++ b/dali/image/generic_image.cc
@@ -80,7 +80,7 @@ GenericImage::DecodeImpl(DALIImageType image_type,
 }
 
 
-Image::Shape GenericImage::PeekShape(const uint8_t *encoded_buffer, size_t length) const {
+Image::Shape GenericImage::PeekShapeImpl(const uint8_t *encoded_buffer, size_t length) const {
   DALI_FAIL("Cannot peek dims for Generic image (of unknown format)");
 }
 

--- a/dali/image/generic_image.h
+++ b/dali/image/generic_image.h
@@ -30,7 +30,7 @@ class GenericImage : public Image {
   std::pair<std::shared_ptr<uint8_t>, Shape>
   DecodeImpl(DALIImageType image_type, const uint8_t *encoded_buffer, size_t length) const override;
 
-  Shape PeekShape(const uint8_t *encoded_buffer, size_t length) const override;
+  Shape PeekShapeImpl(const uint8_t *encoded_buffer, size_t length) const override;
 };
 
 }  // namespace dali

--- a/dali/image/image.cc
+++ b/dali/image/image.cc
@@ -67,12 +67,13 @@ std::shared_ptr<uint8_t> Image::GetImage() const {
   return decoded_image_;
 }
 
-Image::Shape Image::GetShape() const {
-  if (decoded_) {
-    return shape_;
-  }
-  return PeekShape(encoded_image_, length_);
+Image::Shape Image::PeekShape() const {
+  return PeekShapeImpl(encoded_image_, length_);
 }
 
+Image::Shape Image::GetShape() const {
+  DALI_ENFORCE(decoded_, "Image not decoded. Run Decode()");
+  return shape_;
+}
 
 }  // namespace dali

--- a/dali/image/image.h
+++ b/dali/image/image.h
@@ -66,11 +66,17 @@ class Image {
 
 
   /**
-   * Returns image dimensions. If image hasn't been decoded,
-   * reads the dims without decoding the image.
-   * @return [height, width, depth (channels)]
+   * Returns the decoded image dimensions.
+   * It will fail if image hasn't been decoded,
+   * @return [height, width, depth channels]
    */
   DLL_PUBLIC Shape GetShape() const;
+
+  /**
+   * Reads the original image dimensions without decoding the image.
+   * @return [height, width, channels]
+   */
+  DLL_PUBLIC Shape PeekShape() const;
 
  /**
   * Sets crop window generator
@@ -123,7 +129,7 @@ class Image {
    * @param length length of the encoded buffer
    * @return [height, width, depth]
    */
-  virtual Shape PeekShape(const uint8_t *encoded_buffer, size_t length) const = 0;
+  virtual Shape PeekShapeImpl(const uint8_t *encoded_buffer, size_t length) const = 0;
 
   Image(const uint8_t *encoded_buffer, size_t length, DALIImageType image_type);
 

--- a/dali/image/image_factory.h
+++ b/dali/image/image_factory.h
@@ -23,7 +23,7 @@ namespace dali {
 class ImageFactory {
  public:
   DLL_PUBLIC static std::unique_ptr<Image>
-  CreateImage(const uint8_t *encoded_image, size_t length, DALIImageType image_type = DALI_RGB);
+  CreateImage(const uint8_t *encoded_image, size_t length, DALIImageType image_type);
 };
 
 }  // namespace dali

--- a/dali/image/jpeg.cc
+++ b/dali/image/jpeg.cc
@@ -60,7 +60,7 @@ bool get_jpeg_size(const uint8 *data, size_t data_size, int *height, int *width)
 std::pair<std::shared_ptr<uint8_t>, Image::Shape>
 JpegImage::DecodeImpl(DALIImageType type, const uint8 *jpeg, size_t length) const {
   const int c = IsColor(type) ? 3 : 1;
-  const auto shape = PeekShape(jpeg, length);
+  const auto shape = PeekShapeImpl(jpeg, length);
   const auto h = shape[0];
   const auto w = shape[1];
 
@@ -123,8 +123,8 @@ JpegImage::DecodeImpl(DALIImageType type, const uint8 *jpeg, size_t length) cons
 #endif  // DALI_USE_JPEG_TURBO
 }
 
-Image::Shape JpegImage::PeekShape(const uint8_t *encoded_buffer,
-                                     size_t length) const {
+Image::Shape JpegImage::PeekShapeImpl(const uint8_t *encoded_buffer,
+                                      size_t length) const {
   int height = 0, width = 0, components = 0;
 #ifdef DALI_USE_JPEG_TURBO
   DALI_ENFORCE(

--- a/dali/image/jpeg.h
+++ b/dali/image/jpeg.h
@@ -35,7 +35,7 @@ class JpegImage final : public GenericImage {
   std::pair<std::shared_ptr<uint8_t>, Shape>
   DecodeImpl(DALIImageType image_type, const uint8_t *encoded_buffer, size_t length) const override;
 
-  Shape PeekShape(const uint8_t *encoded_buffer, size_t length) const override;
+  Shape PeekShapeImpl(const uint8_t *encoded_buffer, size_t length) const override;
 };
 
 }  // namespace dali

--- a/dali/image/png.cc
+++ b/dali/image/png.cc
@@ -28,7 +28,7 @@ PngImage::PngImage(const uint8_t *encoded_buffer, size_t length, DALIImageType i
 }
 
 
-Image::Shape PngImage::PeekShape(const uint8_t *encoded_buffer, size_t length) const {
+Image::Shape PngImage::PeekShapeImpl(const uint8_t *encoded_buffer, size_t length) const {
   DALI_ENFORCE(encoded_buffer);
   DALI_ENFORCE(length >= 16);
 

--- a/dali/image/png.h
+++ b/dali/image/png.h
@@ -27,7 +27,7 @@ class PngImage final : public GenericImage {
   PngImage(const uint8_t *encoded_buffer, size_t length, DALIImageType image_type);
 
  private:
-  Shape PeekShape(const uint8_t *encoded_buffer, size_t length) const override;
+  Shape PeekShapeImpl(const uint8_t *encoded_buffer, size_t length) const override;
 };
 
 }  // namespace dali

--- a/dali/image/pnm.cc
+++ b/dali/image/pnm.cc
@@ -21,7 +21,7 @@ PnmImage::PnmImage(const uint8_t *encoded_buffer, size_t length, DALIImageType i
         GenericImage(encoded_buffer, length, image_type) {
 }
 
-Image::Shape PnmImage::PeekShape(const uint8_t *pnm, size_t length) const {
+Image::Shape PnmImage::PeekShapeImpl(const uint8_t *pnm, size_t length) const {
   DALI_ENFORCE(pnm);
 
   // http://netpbm.sourceforge.net/doc/ppm.html

--- a/dali/image/pnm.h
+++ b/dali/image/pnm.h
@@ -27,7 +27,7 @@ class PnmImage final : public GenericImage {
   PnmImage(const uint8_t *encoded_buffer, size_t length, DALIImageType image_type);
 
  private:
-  Image::Shape PeekShape(const uint8_t *pnm, size_t length) const override;
+  Image::Shape PeekShapeImpl(const uint8_t *pnm, size_t length) const override;
 };
 
 }  // namespace dali

--- a/dali/image/tiff.cc
+++ b/dali/image/tiff.cc
@@ -42,7 +42,7 @@ bool is_little_endian(const unsigned char *tiff) {
 TiffImage::TiffImage(const uint8_t *encoded_buffer, size_t length, dali::DALIImageType image_type)
     : GenericImage(encoded_buffer, length, image_type) {}
 
-Image::Shape TiffImage::PeekShape(const uint8_t *encoded_buffer, size_t length) const {
+Image::Shape TiffImage::PeekShapeImpl(const uint8_t *encoded_buffer, size_t length) const {
   DALI_ENFORCE(encoded_buffer != nullptr);
   TiffBuffer buffer(
     std::string(reinterpret_cast<const char *>(encoded_buffer),

--- a/dali/image/tiff.h
+++ b/dali/image/tiff.h
@@ -89,7 +89,7 @@ class TiffImage : public GenericImage {
   TiffImage(const uint8_t *encoded_buffer, size_t length, DALIImageType image_type);
 
  protected:
-  Image::Shape PeekShape(const uint8_t *encoded_buffer, size_t length) const override;
+  Image::Shape PeekShapeImpl(const uint8_t *encoded_buffer, size_t length) const override;
 };
 
 }  // namespace dali

--- a/dali/image/tiff_libtiff.cc
+++ b/dali/image/tiff_libtiff.cc
@@ -300,6 +300,7 @@ TiffImage_Libtiff::DecodeImpl(DALIImageType image_type,
     case DALI_YCbCr:
       out_C = 3;
       break;
+    case DALI_ANY_DATA:
     default:
       out_C = C;
   }

--- a/dali/image/tiff_libtiff.cc
+++ b/dali/image/tiff_libtiff.cc
@@ -258,8 +258,8 @@ TiffImage_Libtiff::TiffImage_Libtiff(const uint8_t *encoded_buffer,
   TIFFGetField(tif_.get(), TIFFTAG_ORIENTATION, &orientation_);
 }
 
-Image::Shape TiffImage_Libtiff::PeekShape(const uint8_t *encoded_buffer,
-                                          size_t length) const {
+Image::Shape TiffImage_Libtiff::PeekShapeImpl(const uint8_t *encoded_buffer,
+                                              size_t length) const {
   DALI_ENFORCE(encoded_buffer != nullptr);
   assert(encoded_buffer == buf_.data());
   return shape_;

--- a/dali/image/tiff_libtiff.h
+++ b/dali/image/tiff_libtiff.h
@@ -33,7 +33,7 @@ class TiffImage_Libtiff : public GenericImage {
   std::pair<std::shared_ptr<uint8_t>, Image::Shape>
   DecodeImpl(DALIImageType image_type, const uint8_t *encoded_buffer, size_t length) const override;
 
-  Image::Shape PeekShape(const uint8_t *encoded_buffer, size_t length) const override;
+  Image::Shape PeekShapeImpl(const uint8_t *encoded_buffer, size_t length) const override;
 
  private:
   span<const uint8_t> buf_;

--- a/dali/pipeline/operators/decoder/host/host_decoder.cc
+++ b/dali/pipeline/operators/decoder/host/host_decoder.cc
@@ -41,14 +41,10 @@ void HostDecoder::RunImpl(SampleWorkspace &ws) {
     DALI_FAIL(e.what() + "File: " + file_name);
   }
   const auto decoded = img->GetImage();
-  const auto hwc = img->GetShape();
-  const auto h = hwc[0];
-  const auto w = hwc[1];
-  const auto c = hwc[2];
-
-  output.Resize({static_cast<int>(h), static_cast<int>(w), static_cast<int>(c)});
+  const auto shape = img->GetShape();
+  output.Resize(shape);
   unsigned char *out_data = output.mutable_data<unsigned char>();
-  std::memcpy(out_data, decoded.get(), h * w * c);
+  std::memcpy(out_data, decoded.get(), volume(shape));
 }
 
 DALI_SCHEMA(HostDecoder)

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
@@ -124,13 +124,17 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
                                                 state_nvjpeg->jpeg_stream);
     info->nvjpeg_support = ret == NVJPEG_STATUS_SUCCESS;
     auto crop_generator = GetCropWindowGenerator(data_idx);
+    int64_t nchannels = NumberOfChannels(output_image_type_);
     if (!info->nvjpeg_support) {
       try {
         const auto image = ImageFactory::CreateImage(static_cast<const uint8 *>(input_data),
-                                                     in_size);
-        const auto shape = image->GetShape();
+                                                     in_size, output_image_type_);
+        const auto shape = image->PeekShape();
         info->heights[0] = shape[0];
         info->widths[0] = shape[1];
+        if (output_image_type_ == DALI_ANY_DATA)
+          nchannels = shape[2];
+
         if (crop_generator) {
           kernels::TensorShape<> shape{info->heights[0], info->widths[0]};
           info->crop_window = crop_generator(shape);
@@ -140,8 +144,7 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
         }
         auto& out = ws.Output<CPUBackend>(2);
         out.set_type(TypeInfo::Create<uint8_t>());
-        const auto c = static_cast<Index>(NumberOfChannels(output_image_type_));
-        out.Resize({info->heights[0], info->widths[0], c});
+        out.Resize({info->heights[0], info->widths[0], nchannels});
         auto *output_data = out.mutable_data<uint8_t>();
 
         HostFallback<kernels::StorageCPU>(input_data, in_size, output_image_type_, output_data, 0,

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -199,17 +199,19 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
                                      static_cast<const unsigned char*>(input_data), in_size,
                                      &info.c, &info.subsampling,
                                      info.widths, info.heights);
-      int nchannels = static_cast<int>(NumberOfChannels(output_image_type_));
+      int64_t nchannels = NumberOfChannels(output_image_type_);
       info.nvjpeg_support = ret == NVJPEG_STATUS_SUCCESS;
       auto crop_generator = GetCropWindowGenerator(i);
       if (!info.nvjpeg_support) {
         try {
           const auto image = ImageFactory::CreateImage(
-            static_cast<const uint8 *>(input_data), in_size);
-          const auto shape = image->GetShape();
+            static_cast<const uint8 *>(input_data), in_size, output_image_type_);
+          const auto shape = image->PeekShape();
           info.heights[0] = shape[0];
           info.widths[0] = shape[1];
-          nchannels = shape[2] > 0 ? shape[2] : nchannels;
+          if (output_image_type_ == DALI_ANY_DATA)
+            nchannels = shape[2];
+
           if (crop_generator) {
             kernels::TensorShape<> shape{info.heights[0], info.widths[0]};
             info.crop_window = crop_generator(shape);
@@ -242,7 +244,6 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
           image_states_[i] = decoder_host_state_[i];
         }
       }
-      DALI_ENFORCE(nchannels > 0);
       output_shape_.set_tensor_shape(i, {info.heights[0], info.widths[0], nchannels});
       output_info_[i] = info;
     }

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_helper.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_helper.h
@@ -165,12 +165,9 @@ void HostFallback(const uint8_t *data, int size, DALIImageType image_type, uint8
     DALI_FAIL(e.what() + ". File: " + file_name);
   }
   const auto decoded = img->GetImage();
-  const auto hwc = img->GetShape();
-  const auto h = hwc[0];
-  const auto w = hwc[1];
-  const auto c = hwc[2];
-
-  kernels::copy<StorageType, kernels::StorageCPU>(output_buffer, decoded.get(), h * w * c, stream);
+  const auto shape = img->GetShape();
+  kernels::copy<StorageType, kernels::StorageCPU>(
+    output_buffer, decoded.get(), volume(shape), stream);
 }
 
 }  // namespace dali

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_helper.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_helper.h
@@ -168,7 +168,7 @@ void HostFallback(const uint8_t *data, int size, DALIImageType image_type, uint8
   const auto hwc = img->GetShape();
   const auto h = hwc[0];
   const auto w = hwc[1];
-  const auto c = hwc[2];;
+  const auto c = hwc[2];
 
   kernels::copy<StorageType, kernels::StorageCPU>(output_buffer, decoded.get(), h * w * c, stream);
 }

--- a/dali/pipeline/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
@@ -222,6 +222,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       const auto *data = in.data<uint8_t>();
 
       EncodedImageInfo info;
+      int nchannels = (output_type_ == DALI_GRAY) ? 1 : 3;
 
       // Get necessary image information
       nvjpegStatus_t ret = nvjpegGetImageInfo(handle_,
@@ -236,6 +237,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
           const auto shape = image->GetShape();
           info.heights[0] = shape[0];
           info.widths[0] = shape[1];
+          nchannels = shape[2] > 0 ? shape[2] : nchannels;
           info.nvjpeg_support = false;
         } catch (const std::runtime_error &e) {
           DALI_FAIL(e.what() + "File: " + file_name);
@@ -256,8 +258,8 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       }
 
       // Store pertinent info for later
-      const int image_depth = (output_type_ == DALI_GRAY) ? 1 : 3;
-      output_shape_.set_tensor_shape(i, {info.heights[0], info.widths[0], image_depth});
+      DALI_ENFORCE(nchannels > 0);
+      output_shape_.set_tensor_shape(i, {info.heights[0], info.widths[0], nchannels});
       output_info_[i] = info;
       image_order[i] = std::make_pair(volume(output_shape_[i]), i);
     }

--- a/dali/pipeline/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
@@ -222,7 +222,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       const auto *data = in.data<uint8_t>();
 
       EncodedImageInfo info;
-      int nchannels = (output_type_ == DALI_GRAY) ? 1 : 3;
+      int64_t nchannels = (output_type_ == DALI_GRAY) ? 1 : 3;
 
       // Get necessary image information
       nvjpegStatus_t ret = nvjpegGetImageInfo(handle_,
@@ -233,11 +233,13 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       if (ret == NVJPEG_STATUS_BAD_JPEG) {
         auto file_name = in.GetSourceInfo();
         try {
-          const auto image = ImageFactory::CreateImage(static_cast<const uint8 *>(data), in_size);
-          const auto shape = image->GetShape();
+          const auto image = ImageFactory::CreateImage(
+            static_cast<const uint8 *>(data), in_size, output_type_);
+          const auto shape = image->PeekShape();
           info.heights[0] = shape[0];
           info.widths[0] = shape[1];
-          nchannels = shape[2] > 0 ? shape[2] : nchannels;
+          if (output_type_ == DALI_ANY_DATA)
+            nchannels = shape[2];
           info.nvjpeg_support = false;
         } catch (const std::runtime_error &e) {
           DALI_FAIL(e.what() + "File: " + file_name);
@@ -258,7 +260,6 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       }
 
       // Store pertinent info for later
-      DALI_ENFORCE(nchannels > 0);
       output_shape_.set_tensor_shape(i, {info.heights[0], info.widths[0], nchannels});
       output_info_[i] = info;
       image_order[i] = std::make_pair(volume(output_shape_[i]), i);

--- a/dali/pipeline/operators/reader/parser/sequence_parser.cc
+++ b/dali/pipeline/operators/reader/parser/sequence_parser.cc
@@ -32,19 +32,19 @@ void SequenceParser::Parse(const TensorSequence& data, SampleWorkspace* ws) {
     std::unique_ptr<Image> img;
 
     try {
-      img = ImageFactory::CreateImage(data.tensors[0].data<uint8_t>(), data.tensors[0].size(),
-                                         image_type_);
+      img = ImageFactory::CreateImage(
+        data.tensors[0].data<uint8_t>(), data.tensors[0].size(), image_type_);
       img->Decode();
     } catch (std::exception &e) {
       DALI_FAIL(e.what() + " File: " + file_name);
     }
     const auto decoded = img->GetImage();
 
-    const auto hwc = img->GetShape();
-    const Index h = hwc[0];
-    const Index w = hwc[1];
-    const Index c = hwc[2];
-    const auto frame_size = h * w * c;
+    const auto shape = img->GetShape();
+    const Index h = shape[0];
+    const Index w = shape[1];
+    const Index c = shape[2];
+    const auto frame_size = volume(shape);
 
     // Calculate shape of sequence tensor, that is Frames x (Frame Shape)
     auto seq_shape = std::vector<Index>{seq_length, h, w, c};
@@ -61,7 +61,7 @@ void SequenceParser::Parse(const TensorSequence& data, SampleWorkspace* ws) {
     std::unique_ptr<Image> img;
     try {
       img = ImageFactory::CreateImage(data.tensors[frame].data<uint8_t>(),
-                                         data.tensors[frame].size(), image_type_);
+                                      data.tensors[frame].size(), image_type_);
       img->Decode();
     } catch (std::exception &e) {
       DALI_FAIL(e.what() + " File: " + file_name);

--- a/dali/test/dali_test_decoder.h
+++ b/dali/test/dali_test_decoder.h
@@ -83,12 +83,8 @@ class GenericDecoderTest : public DALISingleOpTest<ImgType> {
           imgs.data_[imgIdx], imgs.sizes_[imgIdx], this->img_type_);
       decoded_image->Decode();
       const auto shape = decoded_image->GetShape();
-      const auto h = shape[0];
-      const auto w = shape[1];
-      const auto c = shape[2];
-
       // resize the output tensor
-      image.Resize({h, w, c});
+      image.Resize(shape);
       // force allocation
       image.mutable_data<uint8_t>();
 

--- a/dali/test/dali_test_single_op.h
+++ b/dali/test/dali_test_single_op.h
@@ -678,6 +678,9 @@ class DALISingleOpTest : public DALITest {
     ASSERT_TRUE(t1);
     ASSERT_TRUE(t2);
     ASSERT_EQ(t1->ntensor(), t2->ntensor());
+    for (size_t i = 0; i < t1->ntensor(); i++) {
+      ASSERT_EQ(t1->tensor_shape(i), t2->tensor_shape(i));
+    }
     ASSERT_EQ(t1->size(), t2->size());
 
     const bool floatType = IsType<float>(t1->type());

--- a/dali/util/ocv.cc
+++ b/dali/util/ocv.cc
@@ -160,9 +160,9 @@ inline void custom_conversion(const cv::Mat& img, cv::Mat& output_img) {
 
 void OpenCvColorConversion(DALIImageType input_type, const cv::Mat& input_img,
                            DALIImageType output_type, cv::Mat& output_img) {
-  DALI_ENFORCE(input_img.elemSize()  == NumberOfChannels(input_type),
+  DALI_ENFORCE(input_img.elemSize() == static_cast<size_t>(NumberOfChannels(input_type)),
     "Incorrect number of channels");
-  DALI_ENFORCE(output_img.elemSize() == NumberOfChannels(output_type),
+  DALI_ENFORCE(output_img.elemSize() == static_cast<size_t>(NumberOfChannels(output_type)),
     "Incorrect number of channels");
   auto ocv_conversion_code = GetOpenCvColorConversionCode(input_type, output_type);
   bool ocv_supported = (ocv_conversion_code != cv::COLOR_COLORCVT_MAX);

--- a/include/dali/core/common.h
+++ b/include/dali/core/common.h
@@ -132,7 +132,7 @@ inline bool IsColor(DALIImageType type) {
   return type == DALI_RGB || type == DALI_BGR || type == DALI_YCbCr;
 }
 
-inline std::size_t NumberOfChannels(DALIImageType type) {
+inline int NumberOfChannels(DALIImageType type) {
   return IsColor(type) ? 3 : 1;
 }
 


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- Need to support C>3 in ImageDecoder

#### What happened in this PR?
Use shape[2] returned from specific decoder implementation, instead of only assuming either C=1 or C=3

**JIRA TASK**: [DALI-1038]