### PR TITLE
Fix problems with seeking when stream start_time is != 0.

### DIFF
--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -23,11 +23,6 @@
 #include <fstream>
 #include <limits>
 
-#undef LOG_LINE
-
-#define LOG_LINE \
-  std::cout << "# " << __LINE__ << ": "
-
 inline int gcd(int a, int b) {
   while (b) {
     int tmp = b;

--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -23,6 +23,35 @@
 #include <fstream>
 #include <limits>
 
+inline int gcd(int a, int b) {
+  while (b) {
+    int tmp = b;
+    b = a % b;
+    a = tmp;
+  }
+  return a;
+}
+
+inline std::ostream &operator<<(std::ostream &os, AVRational r) {
+  if (!r.num) {
+    os << "0";
+  } else {
+    if (r.den < 0) {
+      r.den = -r.den;
+      r.num = -r.num;
+    }
+    int cd = gcd(r.num, r.den);
+    if (cd != 1) {
+      r.num /= cd;
+      r.den /= cd;
+    }
+    os << r.num;
+    if (r.den != 1)
+      os << "/" << r.den;
+  }
+  return os;
+}
+
 namespace dali {
 
 namespace {
@@ -228,6 +257,13 @@ OpenFile& VideoLoader::get_or_open_file(const std::string &filename) {
     // 1/frame_rate is duration of each frame (or time base of frame_num)
     file.frame_base_ = AVRational{stream->avg_frame_rate.den,
                                   stream->avg_frame_rate.num};
+    file.start_time_ = stream->start_time;
+    if (file.start_time_ == AV_NOPTS_VALUE)
+      file.start_time_ = 0;
+    LOG_LINE
+      << "\nStart time is: " << file.start_time_
+      << "\nStream base: " << file.stream_base_
+      << "\nFrame base: " << file.frame_base_ << "\n";
 
     // This check is based on heuristic FFMPEG API
     AVPacket pkt = AVPacket{};
@@ -309,9 +345,7 @@ OpenFile& VideoLoader::get_or_open_file(const std::string &filename) {
 }
 
 void VideoLoader::seek(OpenFile& file, int frame) {
-    auto seek_time = av_rescale_q(frame,
-                                  file.frame_base_,
-                                  file.stream_base_);
+    auto seek_time = av_rescale_q(frame, file.frame_base_, file.stream_base_) + file.start_time_;
     LOG_LINE << "Seeking to frame " << frame << " timestamp " << seek_time << std::endl;
 
     auto ret = av_seek_frame(file.fmt_ctx_.get(), file.vid_stream_idx_,
@@ -362,7 +396,10 @@ void VideoLoader::read_file() {
     seek(file, req.frame);
 
     auto nonkey_frame_count = 0;
-    while (req.count > 0 && av_read_frame(file.fmt_ctx_.get(), &raw_pkt) >= 0) {
+    int frames_left = req.count;
+    std::vector<bool> frames_read(frames_left, false);
+    bool key = false;
+    while (frames_left > 0 && av_read_frame(file.fmt_ctx_.get(), &raw_pkt) >= 0) {
       auto pkt = pkt_ptr(&raw_pkt, av_packet_unref);
 
       stats_.bytes_read += pkt->size;
@@ -372,18 +409,38 @@ void VideoLoader::read_file() {
           continue;
       }
 
-      auto frame = av_rescale_q(pkt->pts,
+      auto frame = av_rescale_q(pkt->pts - file.start_time_,
                                 file.stream_base_,
                                 file.frame_base_);
       LOG_LINE << "Frame candidate " << frame << " (for " << req.frame  <<" )...\n";
 
       file.last_frame_ = frame;
-      auto key = pkt->flags & AV_PKT_FLAG_KEY;
+      key = (pkt->flags & AV_PKT_FLAG_KEY) != 0;
+      int pkt_frames = 1;
+      if (pkt->duration) {
+        pkt_frames = av_rescale_q(pkt->duration, file.stream_base_, file.frame_base_);
+        LOG_LINE << "Duration: " << pkt->duration
+                 << "\nPacket contains " << pkt_frames << " frames\n";
+      }
+
+      if (frame >= req.frame && frame < req.frame + req.count) {
+        if (frames_read[frame - req.frame]) {
+          ERROR_LOG << "Frame " << frame << " appeared twice\n";
+        } else {
+          frames_read[frame - req.frame] = true;
+          frames_left--;
+          LOG_LINE << "Frames left: " << frames_left << "\n";
+        }
+      } else {
+        LOG_LINE << "Frame " << frame << " not in the interesting range.\n";
+      }
 
       if (frame >= req.frame) {
         if (key) {
+          if (frames_left <= 0)
+            break;
           static auto final_try = false;
-          if (frame > req.frame + nonkey_frame_count) {
+          if (frame >= req.frame + req.count) {
             LOG_LINE << device_id_ << ": We got ahead of ourselves! "
                           << frame << " > " << req.frame << " + "
                           << nonkey_frame_count
@@ -403,19 +460,14 @@ void VideoLoader::read_file() {
             }
             continue;
           } else {
-            req.frame += nonkey_frame_count + 1;
-            req.count -= nonkey_frame_count + 1;
             nonkey_frame_count = 0;
           }
           final_try = false;
         } else {
-          nonkey_frame_count++;
+          nonkey_frame_count += pkt_frames;
           // A heuristic so we don't go way over... what should "20" be?
           if (frame > req.frame + req.count + 20) {
-            // This should end the loop
-            req.frame += nonkey_frame_count;
-            req.count -= nonkey_frame_count;
-            nonkey_frame_count = 0;
+            frames_left = 0;;
           }
         }
       }
@@ -442,7 +494,7 @@ void VideoLoader::read_file() {
         }
         while ((ret = av_bsf_receive_packet(file.bsf_ctx_.get(), &raw_filtered_pkt)) == 0) {
           auto fpkt = pkt_ptr(&raw_filtered_pkt, av_packet_unref);
-          vid_decoder_->decode_packet(fpkt.get());
+          vid_decoder_->decode_packet(fpkt.get(), file.start_time_);
         }
         if (ret != AVERROR(EAGAIN)) {
           DALI_FAIL(std::string("BSF receive packet failed:") + av_err2str(ret));
@@ -479,19 +531,19 @@ void VideoLoader::read_file() {
           }
           *pkt.get() = fpkt;
         }
-        vid_decoder_->decode_packet(pkt.get());
+        vid_decoder_->decode_packet(pkt.get(), file.start_time_);
 #endif
       } else {
-        vid_decoder_->decode_packet(pkt.get());
+        vid_decoder_->decode_packet(pkt.get(), file.start_time_);
       }
     }
     // flush the decoder
-    vid_decoder_->decode_packet(nullptr);
+    vid_decoder_->decode_packet(nullptr, 0);
   }  // while not done
 
   if (vid_decoder_) {
     // stop decoding
-    vid_decoder_->decode_packet(nullptr);
+    vid_decoder_->decode_packet(nullptr, 0);
   }
   LOG_LINE << "Leaving read_file" << std::endl;
 }
@@ -531,7 +583,9 @@ void VideoLoader::receive_frames(SequenceWrapper& sequence) {
                 << "smaller key frame interval (GOP length).";
   }
   // We have to wait for all kernel recorded in sequence's event are completed
+  LOG_LINE << "Waiting for sequence..";
   sequence.wait();
+  LOG_LINE << ".got sequence\n";
 }
 
 std::pair<int, int> VideoLoader::load_width_height() {

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -64,6 +64,7 @@ struct OpenFile {
   bool open = false;
   AVRational frame_base_;
   AVRational stream_base_;
+  int64_t start_time_;
   int frame_count_;
 
   int vid_stream_idx_;

--- a/dali/pipeline/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/pipeline/operators/reader/nvdecoder/nvdecoder.cc
@@ -349,8 +349,7 @@ void NvDecoder::receive_frames(SequenceWrapper& sequence) {
   DeviceGuard g(device_id_);
   for (int i = 0; i < sequence.count; ++i) {
       LOG_LINE << "popping frame (" << i << "/" << sequence.count << ") "
-              << frame_queue_.size() << " reqs left"
-              << "... " << std::flush;
+               << frame_queue_.size() << " reqs left" << std::endl;
 
       auto* frame_disp_info = frame_queue_.pop();
       if (stop_) break;

--- a/dali/pipeline/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/pipeline/operators/reader/nvdecoder/nvdecoder.cc
@@ -99,8 +99,11 @@ bool NvDecoder::initialized() const {
 }
 NvDecoder::~NvDecoder() = default;
 
-int NvDecoder::decode_av_packet(AVPacket* avpkt) {
-  if (stop_) return 0;
+int NvDecoder::decode_av_packet(AVPacket* avpkt, int64_t start_time) {
+  if (stop_) {
+    LOG_LINE << "NvDecoder::stop_ requested" << std::endl;
+    return 0;
+  }
 
   CUVIDSOURCEDATAPACKET cupkt = {0};
 
@@ -112,9 +115,9 @@ int NvDecoder::decode_av_packet(AVPacket* avpkt) {
       if (avpkt->pts != AV_NOPTS_VALUE) {
         cupkt.flags = CUVID_PKT_TIMESTAMP;
         if (time_base_.num && time_base_.den) {
-          cupkt.timestamp = av_rescale_q(avpkt->pts, time_base_, nv_time_base_);
+          cupkt.timestamp = av_rescale_q(avpkt->pts - start_time, time_base_, nv_time_base_);
         } else {
-          cupkt.timestamp = avpkt->pts;
+          cupkt.timestamp = avpkt->pts - start_time;
         }
       }
   } else {
@@ -277,7 +280,7 @@ NvDecoder::TextureObject::operator cudaTextureObject_t() const {
   }
 }
 
-// Callback called by the driver decoder one a frame has been decoded
+// Callback called by the driver decoder once a frame has been decoded
 int NvDecoder::handle_display_(CUVIDPARSERDISPINFO* disp_info) {
   auto frame = av_rescale_q(disp_info->timestamp,
                             nv_time_base_, frame_base_);
@@ -323,11 +326,11 @@ int NvDecoder::handle_display_(CUVIDPARSERDISPINFO* disp_info) {
   return kNvcuvid_success;
 }
 
-int NvDecoder::decode_packet(AVPacket* pkt) {
+int NvDecoder::decode_packet(AVPacket* pkt, int64_t start_time) {
   switch (codecpar_->codec_type) {
     case AVMEDIA_TYPE_AUDIO:
     case AVMEDIA_TYPE_VIDEO:
-      return decode_av_packet(pkt);
+      return decode_av_packet(pkt, start_time);
 
     default:
       DALI_FAIL("Got to decode_packet in a decoder that is not "
@@ -346,8 +349,8 @@ void NvDecoder::receive_frames(SequenceWrapper& sequence) {
   DeviceGuard g(device_id_);
   for (int i = 0; i < sequence.count; ++i) {
       LOG_LINE << "popping frame (" << i << "/" << sequence.count << ") "
-               << frame_queue_.size() << " reqs left"
-               << std::endl;
+              << frame_queue_.size() << " reqs left"
+              << "... " << std::flush;
 
       auto* frame_disp_info = frame_queue_.pop();
       if (stop_) break;

--- a/dali/pipeline/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/pipeline/operators/reader/nvdecoder/nvdecoder.h
@@ -91,7 +91,7 @@ class NvDecoder {
   static int handle_decode(void* user_data, CUVIDPICPARAMS* pic_params);
   static int handle_display(void* user_data, CUVIDPARSERDISPINFO* disp_info);
 
-  int decode_packet(AVPacket* pkt);
+  int decode_packet(AVPacket* pkt, int64_t start_time);
 
   void push_req(FrameReq req);
 
@@ -100,7 +100,7 @@ class NvDecoder {
   void finish();
 
  private:
-  int decode_av_packet(AVPacket* pkt);
+  int decode_av_packet(AVPacket* pkt, int64_t start_time);
 
   void record_sequence_event_(SequenceWrapper& sequence);
 

--- a/dali/pipeline/operators/reader/nvdecoder/sequencewrapper.h
+++ b/dali/pipeline/operators/reader/nvdecoder/sequencewrapper.h
@@ -70,6 +70,7 @@ struct SequenceWrapper {
   void wait() const {
     LOG_LINE << event_ << " wait to start" << std::endl;
     wait_until_started_();
+    LOG_LINE << event_ << " waiting for sequence event" << std::endl;
     CUDA_CALL(cudaEventSynchronize(event_));
     LOG_LINE << event_ << " synchronized!" << std::endl;
   }


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one*
- It fixes a bug reported by VK, with decoding a file with nonzero start time

#### What happened in this PR?
 - stream `start_time` is included in converting frame<->timestamp
 - What was changed, added, removed?
    * calculating frame index uses start_time
    * start_time added to VideoLoader file structure
    * clarified mechanism of selection which frames to decode
    * fixed wrong move of a static variable in ThreadSafeQueue
 - Was this PR tested? How?
    * old tests apply; offending video is working in jupyter
 - Were docs and examples updated, if necessary?
    * not necessary

**JIRA TASK**: [DALI-1064]