### PR TITLE
Parse number of channels in PNGImage::PeekShape

### DIFF
--- a/dali/image/png.cc
+++ b/dali/image/png.cc
@@ -57,7 +57,7 @@ T ReadValue(const uint8_t* data) {
   static_assert(sizeof(T) >= nbytes, "T can't hold the requested number of bytes");
   T value = 0;
   for (int i = 0; i < nbytes; i++) {
-    value = (value<<8) + data[offset + i];
+    value = (value << 8) + data[offset + i];
   }
   return value;
 }


### PR DESCRIPTION
#### Why we need this PR?
C is hardcoded to 0 in PngImage implementation

#### What happened in this PR?
Parse number of channels from PNG encoded string

**JIRA TASK**: [DALI-XXXX]