### PR TITLE
Use alternative compiler (e.g. g++-5.4) when available

### DIFF
--- a/dali_tf_plugin/dali_tf_plugin_install_tool.py
+++ b/dali_tf_plugin/dali_tf_plugin_install_tool.py
@@ -108,17 +108,15 @@ class InstallerHelper:
             return
 
         if self.default_cpp_version != self.tf_compiler:
-            if self.is_conda:
+            if self.has_alt_compiler:
+                print("Will use alternative compiler {}".format(self.alt_compiler))
+                compiler = self.alt_compiler
+            elif self.is_conda:
                 error_msg = "Installation error:"
                 error_msg += "\n Conda C++ compiler version should be the same as the compiler used to build tensorflow ({} != {}).".format(self.default_cpp_version, self.tf_compiler)
                 error_msg += "\n Try to run `conda install gxx_linux-64=={}` or install an alternative compiler `g++-{}` and install again".format(self.tf_compiler, self.tf_compiler)
                 error_msg += '\n' + self.debug_str()
                 raise ImportError(error_msg)
-
-            if self.has_alt_compiler:
-                print("Will use alternative compiler {}".format(alt_compiler))
-                compiler = self.alt_compiler
-
             else:
                 error_msg = "Installation error:"
                 error_msg += "\n Tensorflow was built with a different compiler than the currently installed ({} != {})".format(self.default_cpp_version, self.tf_compiler)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
During DALI TF installation in conda environment, there is a failulre if the default compiler `CXX` doesn't match the version for Tensorflow. However, there is the possibility that there is an alternative compiler in the system that can be used to compile DALI TF (e.g. g++-5.4)

#### What happened in this PR?
Fix the logic that uses an alternative compiler when necessary

**JIRA TASK**: [DALI-1062]