### PR TITLE
Check whether random row access is allowed in libtiff based decoder implementation

### DIFF
--- a/dali/image/tiff_libtiff.cc
+++ b/dali/image/tiff_libtiff.cc
@@ -253,9 +253,10 @@ TiffImage_Libtiff::TiffImage_Libtiff(const uint8_t *encoded_buffer,
     TIFFGetField(tif_.get(), TIFFTAG_BITSPERSAMPLE, &bit_depth_));
   DALI_ENFORCE(bit_depth_ <= 64,
     "Unexpected bit depth: " + std::to_string(bit_depth_));
-
   // optional
   TIFFGetField(tif_.get(), TIFFTAG_ORIENTATION, &orientation_);
+  TIFFGetField(tif_.get(), TIFFTAG_ROWSPERSTRIP, &rows_per_strip_);
+  TIFFGetField(tif_.get(), TIFFTAG_COMPRESSION, &compression_);
 }
 
 Image::Shape TiffImage_Libtiff::PeekShapeImpl(const uint8_t *encoded_buffer,
@@ -339,13 +340,11 @@ TiffImage_Libtiff::DecodeImpl(DALIImageType image_type,
   // strip. In this case, the library does not support random access to the data. The data should
   // either be accessed sequentially, or the file should be converted so that each strip is made up
   // of one row of data.
+  const bool allow_random_row_access =
+    (compression_ == COMPRESSION_NONE || rows_per_strip_ == 1);
 
-  // First try to access random row
-  const bool can_access_roi_y = (roi_y == 0)
-    || (1 == TIFFReadScanline(tif_.get(), row_in, roi_y, 0));
-
-  // If random access did not work, need to read sequentially all previous rows
-  if (!can_access_roi_y) {
+  // If random access is not allowed, need to read sequentially all previous rows
+  if (!allow_random_row_access) {
     for (int64_t y = 0; y < roi_y; y++) {
       LIBTIFF_CALL(
         TIFFReadScanline(tif_.get(), row_in, y, 0));

--- a/dali/image/tiff_libtiff.h
+++ b/dali/image/tiff_libtiff.h
@@ -44,6 +44,8 @@ class TiffImage_Libtiff : public GenericImage {
   bool is_tiled_ = false;
   uint16_t bit_depth_ = 8;
   uint16_t orientation_ = ORIENTATION_TOPLEFT;
+  uint32_t rows_per_strip_ = 0xFFFFFFFF;
+  uint16_t compression_ = COMPRESSION_NONE;
 };
 
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
We have a warning when trying to access random row in libtiff and it is not supported (compression != none and rows per strip > 1)

#### What happened in this PR?
Add check before trying to access random row, instead of checking the status of reading the row

**JIRA TASK**: [DALI-XXXX]