### PR TITLE
Make cspan

### DIFF
--- a/dali/core/span_test.cc
+++ b/dali/core/span_test.cc
@@ -1,0 +1,49 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/core/span.h"
+
+namespace dali {
+namespace test {
+
+template <typename T>
+void Verify(span<T> s, std::vector<T> vec) {
+  ASSERT_EQ(vec.size(), s.size());
+  for (int i = 0; i < s.size(); i++) {
+    EXPECT_EQ(vec[i], s[i]);
+  }
+}
+
+
+template <typename T>
+void Verify(span<const T> s, std::vector<T> vec) {
+  ASSERT_EQ(vec.size(), s.size());
+  for (int i = 0; i < s.size(); i++) {
+    EXPECT_EQ(vec[i], s[i]);
+  }
+}
+
+
+TEST(SpanTest, cspan_test) {
+  std::vector<int> v = {1, 2, 3, 4, 5};
+  auto &ref = v;
+  const auto &cref = v;
+  Verify(make_cspan(v), v);
+  Verify(make_cspan(ref), v);
+  Verify(make_cspan(cref), v);
+}
+
+}  // namespace test
+}  // namespace dali

--- a/include/dali/core/span.h
+++ b/include/dali/core/span.h
@@ -216,6 +216,47 @@ DALI_HOST_DEV constexpr span<T, N> make_span(T (&a)[N]) {
   return { a };
 }
 
+template <span_extent_t Extent, typename T>
+DALI_HOST_DEV constexpr span<const T, Extent> make_cspan(T *data) { return { data }; }
+
+template <span_extent_t Extent = dynamic_extent, typename T>
+DALI_HOST_DEV constexpr span<const T, Extent> make_cspan(T *data, span_extent_t extent) {
+  return { data, extent };
+}
+
+DALI_NO_EXEC_CHECK
+template <typename Collection>
+DALI_HOST_DEV constexpr auto make_cspan(Collection &c) {
+  return make_cspan(c.data(), c.size());
+}
+
+DALI_NO_EXEC_CHECK
+template <typename Collection>
+DALI_HOST_DEV constexpr auto make_cspan(Collection &&c) {
+  static_assert(!std::is_rvalue_reference<Collection&&>::value,
+                "Cannot create a span from an r-value.");
+  return make_cspan(c.data(), c.size());
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T, size_t N>
+DALI_HOST_DEV constexpr span<const T, N> make_cspan(const std::array<T, N> &a) {
+  return { a.data() };
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T, size_t N>
+DALI_HOST_DEV constexpr span<const T, N> make_cspan(std::array<T, N> &&a) {
+  static_assert(!std::is_rvalue_reference<std::array<T, N> &&>::value,
+                "Cannot create a span from an r-value.");
+  return { a.data() };
+}
+
+template <typename T, size_t N>
+DALI_HOST_DEV constexpr span<const T, N> make_cspan(T (&a)[N]) {
+  return { a };
+}
+
 }  // namespace dali
 
 #endif  // DALI_CORE_SPAN_H_


### PR DESCRIPTION
#### Why we need this PR?
Utility function, so that we can make const span from non-const collection
