### PR TITLE
Conda recipe: Point to local git repository for build source, relax version dependencies and use on conda-forge for some dependencies

### DIFF
--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -10,12 +10,15 @@ fi
 
 nvidia-smi
 
+# Adding conda-forge channel for dependencies
+conda config --add channels conda-forge
+
 CONDA_BUILD_OPTIONS="--python=${PYVER} --exclusive-config-file config/conda_build_config.yaml"
 
 CONDA_PREFIX=${CONDA_PREFIX:-/root/miniconda3}
 
-# Building dependency packages
-conda build ${CONDA_BUILD_OPTIONS} third_party/jpeg_turbo/recipe
+# Note: To building dependency packages:
+# run 'install_requirements.txt' before installing DALI conda package)
 
 # Building DALI package
 conda build ${CONDA_BUILD_OPTIONS} recipe

--- a/conda/install_requirements.sh
+++ b/conda/install_requirements.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+conda install --yes -c conda-forge 'protobuf >=3.5'
+conda install --yes -c conda-forge 'libjpeg-turbo >=1.5'
+conda install --yes -c conda-forge 'ffmpeg >=4.1'
+conda install --yes -c conda-forge 'opencv >=3.4.1'

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -17,8 +17,8 @@ package:
   version: {{ GIT_DESCRIBE_TAG | replace("-","_") }}.{{ GIT_BUILD_STR }}
 
 source:
-  git_url: https://github.com/NVIDIA/DALI/
-  git_rev: {{ GIT_DESCRIBE_TAG }}
+  # Beware: Only commited files are used
+  git_url: ../..
 
 build:
   number: 0
@@ -36,7 +36,7 @@ requirements:
     - future 0.17.1
     - protobuf 3.7.1
     - jpeg-turbo 1.5.0
-    - ffmpeg 4.2.1
+    - ffmpeg 4.0
     - tensorflow-gpu
     - libopencv 3.4.2
     - opencv 3.4.2
@@ -46,7 +46,7 @@ requirements:
     - future 0.17.1
     - protobuf 3.7.1
     - jpeg-turbo 1.5.0
-    - ffmpeg 4.2.1
+    - ffmpeg 4.0
     - tensorflow-gpu
     - libopencv 3.4.2
     - opencv 3.4.2

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,4 +1,5 @@
 # (C) Copyright IBM Corp. 2019. All Rights Reserved.
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,25 +29,25 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx')}}
-    - pkg-config 0.29.2
-    - cmake 3.12.2
-    - make 4.2.1
+    - pkg-config >=0.29.2
+    - cmake >=3.12.2
+    - make >=4.2.1
   host:
     - python
-    - future 0.17.1
-    - protobuf 3.7.1
-    - jpeg-turbo 1.5.0
-    - ffmpeg 4.0
+    - future >=0.17.1
+    - protobuf >=3.5
+    - libjpeg-turbo >=1.5
+    - ffmpeg >=4.1
     - tensorflow-gpu
-    - libopencv 3.4.2
-    - opencv 3.4.2
-    - boost 1.67
+    - libopencv >=3.4.1
+    - opencv >=3.4.1
+    - boost >=1.67
   run:
     - python
-    - future 0.17.1
-    - protobuf 3.7.1
-    - jpeg-turbo 1.5.0
-    - ffmpeg 4.0
+    - future >=0.17.1
+    - protobuf >=3.5
+    - libjpeg-turbo >=1.5
+    - ffmpeg >=4.1
     - tensorflow-gpu
-    - libopencv 3.4.2
-    - opencv 3.4.2
+    - libopencv >=3.4.1
+    - opencv >=3.4.1

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -12,43 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{% set build_version = "master" %}
+package:
+  name: dali
+  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
 
-  package:
-    name: dali
-    version: {{ build_version }}
+source:
+  # Beware, it only captures commited code
+  git_url: ../..
 
-  source:
-    git_url: https://github.com/NVIDIA/DALI/
-    git_rev: master
+build:
+  number: 0
+  string: py{{ python | replace(".","") }}
 
+requirements:
   build:
-    number: 0
-    string: py{{ python | replace(".","") }}
-
-  requirements:
-    build:
-      - {{ compiler('c') }}
-      - {{ compiler('cxx')}}
-      - pkg-config 0.29.2
-      - cmake 3.12.2
-      - make 4.2.1
-    host:
-      - python
-      - future 0.17.1
-      - protobuf 3.7.1
-      - jpeg-turbo 1.5.0
-      - ffmpeg >= 4.2.1
-      - tensorflow-gpu
-      - libopencv 3.4.2
-      - opencv 3.4.2
-      - boost 1.67
-    run:
-      - python
-      - future 0.17.1
-      - protobuf 3.7.1
-      - jpeg-turbo 1.5.0
-      - ffmpeg >= 4.2.1
-      - tensorflow-gpu
-      - libopencv 3.4.2
-      - opencv 3.4.2
+    - {{ compiler('c') }}
+    - {{ compiler('cxx')}}
+    - pkg-config 0.29.2
+    - cmake 3.12.2
+    - make 4.2.1
+  host:
+    - python
+    - future 0.17.1
+    - protobuf 3.7.1
+    - jpeg-turbo 1.5.0
+    - ffmpeg >= 4.2.1
+    - tensorflow-gpu
+    - libopencv 3.4.2
+    - opencv 3.4.2
+    - boost 1.67
+  run:
+    - python
+    - future 0.17.1
+    - protobuf 3.7.1
+    - jpeg-turbo 1.5.0
+    - ffmpeg >= 4.2.1
+    - tensorflow-gpu
+    - libopencv 3.4.2
+    - opencv 3.4.2

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -38,7 +38,7 @@
       - future 0.17.1
       - protobuf 3.7.1
       - jpeg-turbo 1.5.0
-      - ffmpeg
+      - ffmpeg >= 4.2.1
       - tensorflow-gpu
       - libopencv 3.4.2
       - opencv 3.4.2
@@ -48,7 +48,7 @@
       - future 0.17.1
       - protobuf 3.7.1
       - jpeg-turbo 1.5.0
-      - ffmpeg
+      - ffmpeg >= 4.2.1
       - tensorflow-gpu
       - libopencv 3.4.2
       - opencv 3.4.2

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - future 0.17.1
     - protobuf 3.7.1
     - jpeg-turbo 1.5.0
-    - ffmpeg >= 4.2.1
+    - ffmpeg 4.2.1
     - tensorflow-gpu
     - libopencv 3.4.2
     - opencv 3.4.2
@@ -46,7 +46,7 @@ requirements:
     - future 0.17.1
     - protobuf 3.7.1
     - jpeg-turbo 1.5.0
-    - ffmpeg >= 4.2.1
+    - ffmpeg 4.2.1
     - tensorflow-gpu
     - libopencv 3.4.2
     - opencv 3.4.2

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -14,7 +14,7 @@
 
 package:
   name: dali
-  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+  version: {{ GIT_DESCRIBE_TAG | replace("-","_") }}.{{ GIT_BUILD_STR }}
 
 source:
   # Beware, it only captures commited code

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -17,8 +17,8 @@ package:
   version: {{ GIT_DESCRIBE_TAG | replace("-","_") }}.{{ GIT_BUILD_STR }}
 
 source:
-  # Beware, it only captures commited code
-  git_url: ../..
+  git_url: https://github.com/NVIDIA/DALI/
+  git_rev: {{ GIT_DESCRIBE_TAG }}
 
 build:
   number: 0


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- Conda recipe points to github/master branch and the version is fixed. We need to be able to build conda package for the specific branch/pr
- Strict version dependencies are hard to satisfy, especially when we have packages depending on each other. 
- We need to compile with ffmpeg >=4.1 which is not provided by anaconda (but it is provided by conda-forge).

#### What happened in this PR?
- Using local git repository for source and use git describe for the version string
- Change strict version requirements in conda recipe to minimum version requirements
- Switching requirement for libjpeg-turbo from custom recipe to conda-forge
- Using ffmpeg from conda-forge, which forces us to use opencv from conda-forge as well

**JIRA TASK**: [DALI-XXXX]