### PR TITLE
TiffImage::PeekShapeImpl parse and return number of channels

### DIFF
--- a/dali/image/tiff.cc
+++ b/dali/image/tiff.cc
@@ -22,6 +22,7 @@ constexpr int COUNT_SIZE = 2;
 constexpr int ENTRY_SIZE = 12;
 constexpr int WIDTH_TAG = 256;
 constexpr int HEIGHT_TAG = 257;
+constexpr int SAMPLESPERPIXEL_TAG = 277;
 constexpr int TYPE_WORD = 3;
 constexpr int TYPE_DWORD = 4;
 
@@ -51,15 +52,15 @@ Image::Shape TiffImage::PeekShapeImpl(const uint8_t *encoded_buffer, size_t leng
 
   const auto ifd_offset = buffer.Read<uint32_t>(4);
   const auto entry_count = buffer.Read<uint16_t>(ifd_offset);
-  bool width_read = false, height_read = false;
-  int64_t width = 0, height = 0;
+  bool width_read = false, height_read = false, nchannels_read = false;
+  int64_t width = 0, height = 0, nchannels = 0;
 
   for (int entry_idx = 0;
-       entry_idx < entry_count && !(width_read && height_read);
+       entry_idx < entry_count && !(width_read && height_read && nchannels_read);
        entry_idx++) {
     const auto entry_offset = ifd_offset + COUNT_SIZE + entry_idx * ENTRY_SIZE;
     const auto tag_id = buffer.Read<uint16_t>(entry_offset);
-    if (tag_id == WIDTH_TAG || tag_id == HEIGHT_TAG) {
+    if (tag_id == WIDTH_TAG || tag_id == HEIGHT_TAG || tag_id == SAMPLESPERPIXEL_TAG) {
       const auto value_type = buffer.Read<uint16_t>(entry_offset + 2);
       const auto value_count = buffer.Read<uint32_t>(entry_offset + 4);
       DALI_ENFORCE(value_count == 1);
@@ -76,18 +77,20 @@ Image::Shape TiffImage::PeekShapeImpl(const uint8_t *encoded_buffer, size_t leng
       if (tag_id == WIDTH_TAG) {
         width = value;
         width_read = true;
-      } else {
+      } else if (tag_id == HEIGHT_TAG) {
         height = value;
         height_read = true;
+      } else if (tag_id == SAMPLESPERPIXEL_TAG) {
+        nchannels = value;
+        nchannels_read = true;
       }
     }
   }
-  if (!(width_read && height_read)) {
-    DALI_FAIL("TIFF image dims haven't been peeked properly");
-  }
 
-  // TODO(mszolucha): fill channels count
-  return {height, width, 0};
+  DALI_ENFORCE(width_read && height_read && nchannels_read,
+    "TIFF image dims haven't been peeked properly");
+
+  return {height, width, nchannels};
 }
 
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
TiffImage::PeekShapleImpl returns C=0

#### What happened in this PR?
Implemented parsing of number of channels

**JIRA TASK**: [DALI-XXXX]