### PR TITLE
Add parsing of number of channels in JpegImage::PeekShapeImpl

### DIFF
--- a/dali/image/jpeg.cc
+++ b/dali/image/jpeg.cc
@@ -25,15 +25,15 @@ JpegImage::JpegImage(const uint8_t *encoded_buffer,
                      DALIImageType image_type)
   : GenericImage(encoded_buffer, length, image_type) {
 }
-#if !defined(DALI_USE_JPEG_TURBO)
-bool get_jpeg_size(const uint8 *data, size_t data_size, int *height, int *width) {
+#ifndef DALI_USE_JPEG_TURBO
+bool get_jpeg_size(const uint8 *data, size_t data_size, int *height, int *width, int *nchannels) {
   // Check for valid JPEG image
   unsigned int i = 0;  // Keeps track of the position within the file
   if (data[i] == 0xFF && data[i + 1] == 0xD8) {
     i += 4;
     // Retrieve the block length of the first block since
     // the first block will not contain the size of file
-    uint16_t block_length = data[i] * 256 + data[i + 1];
+    uint16_t block_length = (data[i] << 8) + data[i + 1];
     while (i < data_size) {
       i += block_length;  // Increase the file index to get to the next block
       if (i >= data_size) return false;  // Check to protect against segmentation faults
@@ -41,13 +41,14 @@ bool get_jpeg_size(const uint8 *data, size_t data_size, int *height, int *width)
       if (data[i + 1] >= 0xC0 && data[i + 1] <= 0xC3) {
         // 0xFFC0 is the "Start of frame" marker which contains the file size
         // The structure of the 0xFFC0 block is quite simple
-        // [0xFFC0][ushort length][uchar precision][ushort x][ushort y]
-        *height = data[i + 5] * 256 + data[i + 6];
-        *width = data[i + 7] * 256 + data[i + 8];
+        // [0xFFC0][ushort length][uchar precision][ushort x][ushort y][uchar number_of_components]
+        *height = (data[i + 5] << 8) + data[i + 6];
+        *width  = (data[i + 7] << 8) + data[i + 8];
+        *nchannels = data[i + 9];
         return true;
       } else {
         i += 2;  // Skip the block marker
-        block_length = data[i] * 256 + data[i + 1];  // Go to the next block
+        block_length = (data[i] << 8) + data[i + 1];  // Go to the next block
       }
     }
     return false;  // If this point is reached then no size was found
@@ -130,7 +131,7 @@ Image::Shape JpegImage::PeekShapeImpl(const uint8_t *encoded_buffer,
   DALI_ENFORCE(
     jpeg::GetImageInfo(encoded_buffer, length, &width, &height, &components) == true);
 #else
-  DALI_ENFORCE(get_jpeg_size(encoded_buffer, length, &height, &width));
+  DALI_ENFORCE(get_jpeg_size(encoded_buffer, length, &height, &width, &components));
 #endif
   return {height, width, components};
 }

--- a/dali/image/tiff.cc
+++ b/dali/image/tiff.cc
@@ -22,6 +22,7 @@ constexpr int COUNT_SIZE = 2;
 constexpr int ENTRY_SIZE = 12;
 constexpr int WIDTH_TAG = 256;
 constexpr int HEIGHT_TAG = 257;
+constexpr int SAMPLESPERPIXEL_TAG = 277;
 constexpr int TYPE_WORD = 3;
 constexpr int TYPE_DWORD = 4;
 
@@ -51,15 +52,15 @@ Image::Shape TiffImage::PeekShapeImpl(const uint8_t *encoded_buffer, size_t leng
 
   const auto ifd_offset = buffer.Read<uint32_t>(4);
   const auto entry_count = buffer.Read<uint16_t>(ifd_offset);
-  bool width_read = false, height_read = false;
-  int64_t width = 0, height = 0;
+  bool width_read = false, height_read = false, nchannels_read = false;
+  int64_t width = 0, height = 0, nchannels = 0;
 
   for (int entry_idx = 0;
-       entry_idx < entry_count && !(width_read && height_read);
+       entry_idx < entry_count && !(width_read && height_read && nchannels_read);
        entry_idx++) {
     const auto entry_offset = ifd_offset + COUNT_SIZE + entry_idx * ENTRY_SIZE;
     const auto tag_id = buffer.Read<uint16_t>(entry_offset);
-    if (tag_id == WIDTH_TAG || tag_id == HEIGHT_TAG) {
+    if (tag_id == WIDTH_TAG || tag_id == HEIGHT_TAG || tag_id == SAMPLESPERPIXEL_TAG) {
       const auto value_type = buffer.Read<uint16_t>(entry_offset + 2);
       const auto value_count = buffer.Read<uint32_t>(entry_offset + 4);
       DALI_ENFORCE(value_count == 1);
@@ -76,18 +77,20 @@ Image::Shape TiffImage::PeekShapeImpl(const uint8_t *encoded_buffer, size_t leng
       if (tag_id == WIDTH_TAG) {
         width = value;
         width_read = true;
-      } else {
+      } else if (tag_id == HEIGHT_TAG) {
         height = value;
         height_read = true;
+      } else if (tag_id == SAMPLESPERPIXEL_TAG) {
+        nchannels = value;
+        nchannels_read = true;
       }
     }
   }
-  if (!(width_read && height_read)) {
-    DALI_FAIL("TIFF image dims haven't been peeked properly");
-  }
 
-  // TODO(mszolucha): fill channels count
-  return {height, width, 0};
+  DALI_ENFORCE(width_read && height_read && nchannels_read,
+    "TIFF image dims haven't been peeked properly");
+
+  return {height, width, nchannels};
 }
 
 }  // namespace dali


### PR DESCRIPTION
#### Why we need this PR?
JpegImage::PeekShapeImpl harcodes C = 0 when libjpeg-turbo support is disabled

#### What happened in this PR?
Add parsing of number of channels 

**JIRA TASK**: [DALI-XXXX]