### PR TITLE
Add parsing of number of channels in JpegImage::PeekShapeImpl

### DIFF
--- a/dali/image/jpeg.cc
+++ b/dali/image/jpeg.cc
@@ -25,15 +25,15 @@ JpegImage::JpegImage(const uint8_t *encoded_buffer,
                      DALIImageType image_type)
   : GenericImage(encoded_buffer, length, image_type) {
 }
-#if !defined(DALI_USE_JPEG_TURBO)
-bool get_jpeg_size(const uint8 *data, size_t data_size, int *height, int *width) {
+#ifndef DALI_USE_JPEG_TURBO
+bool get_jpeg_size(const uint8 *data, size_t data_size, int *height, int *width, int *nchannels) {
   // Check for valid JPEG image
   unsigned int i = 0;  // Keeps track of the position within the file
   if (data[i] == 0xFF && data[i + 1] == 0xD8) {
     i += 4;
     // Retrieve the block length of the first block since
     // the first block will not contain the size of file
-    uint16_t block_length = data[i] * 256 + data[i + 1];
+    uint16_t block_length = (data[i] << 8) + data[i + 1];
     while (i < data_size) {
       i += block_length;  // Increase the file index to get to the next block
       if (i >= data_size) return false;  // Check to protect against segmentation faults
@@ -41,13 +41,14 @@ bool get_jpeg_size(const uint8 *data, size_t data_size, int *height, int *width)
       if (data[i + 1] >= 0xC0 && data[i + 1] <= 0xC3) {
         // 0xFFC0 is the "Start of frame" marker which contains the file size
         // The structure of the 0xFFC0 block is quite simple
-        // [0xFFC0][ushort length][uchar precision][ushort x][ushort y]
-        *height = data[i + 5] * 256 + data[i + 6];
-        *width = data[i + 7] * 256 + data[i + 8];
+        // [0xFFC0][ushort length][uchar precision][ushort x][ushort y][uchar number_of_components]
+        *height = (data[i + 5] << 8) + data[i + 6];
+        *width  = (data[i + 7] << 8) + data[i + 8];
+        *nchannels = data[i + 9];
         return true;
       } else {
         i += 2;  // Skip the block marker
-        block_length = data[i] * 256 + data[i + 1];  // Go to the next block
+        block_length = (data[i] << 8) + data[i + 1];  // Go to the next block
       }
     }
     return false;  // If this point is reached then no size was found
@@ -130,7 +131,7 @@ Image::Shape JpegImage::PeekShapeImpl(const uint8_t *encoded_buffer,
   DALI_ENFORCE(
     jpeg::GetImageInfo(encoded_buffer, length, &width, &height, &components) == true);
 #else
-  DALI_ENFORCE(get_jpeg_size(encoded_buffer, length, &height, &width));
+  DALI_ENFORCE(get_jpeg_size(encoded_buffer, length, &height, &width, &components));
 #endif
   return {height, width, components};
 }

--- a/dali/image/jpeg.cc
+++ b/dali/image/jpeg.cc
@@ -41,7 +41,7 @@ bool get_jpeg_size(const uint8 *data, size_t data_size, int *height, int *width,
       if (data[i + 1] >= 0xC0 && data[i + 1] <= 0xC3) {
         // 0xFFC0 is the "Start of frame" marker which contains the file size
         // The structure of the 0xFFC0 block is quite simple
-        // [0xFFC0][ushort length][uchar precision][ushort x][ushort y][uchar number_of_components]
+        // [0xFFC0][ushort length][uchar precision][ushort height][ushort width][uchar components]
         *height = (data[i + 5] << 8) + data[i + 6];
         *width  = (data[i + 7] << 8) + data[i + 8];
         *nchannels = data[i + 9];

--- a/dali/image/jpeg.cc
+++ b/dali/image/jpeg.cc
@@ -29,11 +29,11 @@ JpegImage::JpegImage(const uint8_t *encoded_buffer,
 
 #ifndef DALI_USE_JPEG_TURBO
 bool get_jpeg_size(const uint8 *data, size_t data_size, int *height, int *width, int *nchannels) {
-  // Check for valid JPEG image
-  if (ReadValueBE<uint16_t>(data) != 0xFFD8)
+  unsigned int i = 0;
+  if (!(data[i] == 0xFF && data[i + 1] == 0xD8))
     return false;  // Not a valid SOI header
 
-  unsigned int i = 4;
+  i += 4;
   // Retrieve the block length of the first block since
   // the first block will not contain the size of file
   uint16_t block_length = ReadValueBE<uint16_t>(data + i);

--- a/dali/image/jpeg.cc
+++ b/dali/image/jpeg.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include "dali/image/jpeg_mem.h"
 #include "dali/util/ocv.h"
+#include "dali/core/byte_io.h"
 
 namespace dali {
 
@@ -25,36 +26,35 @@ JpegImage::JpegImage(const uint8_t *encoded_buffer,
                      DALIImageType image_type)
   : GenericImage(encoded_buffer, length, image_type) {
 }
+
 #ifndef DALI_USE_JPEG_TURBO
 bool get_jpeg_size(const uint8 *data, size_t data_size, int *height, int *width, int *nchannels) {
   // Check for valid JPEG image
-  unsigned int i = 0;  // Keeps track of the position within the file
-  if (data[i] == 0xFF && data[i + 1] == 0xD8) {
-    i += 4;
-    // Retrieve the block length of the first block since
-    // the first block will not contain the size of file
-    uint16_t block_length = (data[i] << 8) + data[i + 1];
-    while (i < data_size) {
-      i += block_length;  // Increase the file index to get to the next block
-      if (i >= data_size) return false;  // Check to protect against segmentation faults
-      if (data[i] != 0xFF) return false;  // Check that we are truly at the start of another block
-      if (data[i + 1] >= 0xC0 && data[i + 1] <= 0xC3) {
-        // 0xFFC0 is the "Start of frame" marker which contains the file size
-        // The structure of the 0xFFC0 block is quite simple
-        // [0xFFC0][ushort length][uchar precision][ushort height][ushort width][uchar components]
-        *height = (data[i + 5] << 8) + data[i + 6];
-        *width  = (data[i + 7] << 8) + data[i + 8];
-        *nchannels = data[i + 9];
-        return true;
-      } else {
-        i += 2;  // Skip the block marker
-        block_length = (data[i] << 8) + data[i + 1];  // Go to the next block
-      }
-    }
-    return false;  // If this point is reached then no size was found
-  } else {
+  if (ReadValueBE<uint16_t>(data) != 0xFFD8)
     return false;  // Not a valid SOI header
+
+  unsigned int i = 4;
+  // Retrieve the block length of the first block since
+  // the first block will not contain the size of file
+  uint16_t block_length = ReadValueBE<uint16_t>(data + i);
+  while (i < data_size) {
+    i += block_length;  // Increase the file index to get to the next block
+    if (i >= data_size) return false;  // Check to protect against segmentation faults
+    if (data[i] != 0xFF) return false;  // Check that we are truly at the start of another block
+    if (data[i + 1] >= 0xC0 && data[i + 1] <= 0xC3) {
+      // 0xFFC0 is the "Start of frame" marker which contains the file size
+      // The structure of the 0xFFC0 block is quite simple
+      // [0xFFC0][ushort length][uchar precision][ushort x][ushort y][uchar number_of_components]
+      *height = ReadValueBE<uint16_t>(data + i + 5);
+      *width  = ReadValueBE<uint16_t>(data + i + 7);
+      *nchannels = ReadValueBE<uint8_t>(data + i + 9);
+      return true;
+    } else {
+      i += 2;  // Skip the block marker
+      block_length = ReadValueBE<uint16_t>(data + i);  // Go to the next block
+    }
   }
+  return false;  // If this point is reached then no size was found
 }
 #endif
 


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
JpegImage::PeekShapeImpl harcodes C = 0 when libjpeg-turbo support is disabled

#### What happened in this PR?
Add parsing of number of channels

**JIRA TASK**: [DALI-XXXX]