### PR TITLE
Fix the wrong usage of find_library when searching for FFmpeg libs

### DIFF
--- a/cmake/Dependencies.common.cmake
+++ b/cmake/Dependencies.common.cmake
@@ -118,11 +118,14 @@ if(BUILD_FFMPEG)
         pkg_check_modules(${m} REQUIRED lib${m})
         list(APPEND FFmpeg_LIBS ${m})
       else()
-        find_library(FFmpeg_Lib ${m}
+        # Set the name of the destination variable, it cannot be the same across
+        # consecutive find_library calls to avoid caching
+        set(FFmpeg_Lib "FFmpeg_Lib${m}")
+        find_library(${FFmpeg_Lib} ${m}
               PATHS ${FFMPEG_ROOT_DIR}
               PATH_SUFFIXES lib lib64
               NO_DEFAULT_PATH)
-        list(APPEND FFmpeg_LIBS ${FFmpeg_Lib})
+        list(APPEND FFmpeg_LIBS ${${FFmpeg_Lib}})
         message(STATUS ${m})
       endif()
   endforeach(m)


### PR DESCRIPTION
- find_library caches content of the destination variable, so
  consecutive calls with the same name (even different lib that
  is searched for) will return the result of the first call. In effect
  when FFMPEG_ROOT_DIR is passed the only libavformat if properly found
  and others are skipped

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- It fixes a bug because find_library caches content of the destination variable, so
  consecutive calls with the same name (even different lib that
  is searched for) will return the result of the first call. In effect
  when FFMPEG_ROOT_DIR is passed the only libavformat if properly found
  and others are skipped

#### What happened in this PR?
 - find_library caches content of the destination variable, so
  consecutive calls with the same name (even different lib that
  is searched for) will return the result of the first call
- for each find_library when searching for FFmpeg libs different destination variable name is used
 - tested with CI

**JIRA TASK**: [NA]