### PR TITLE
Suppress warning when FileReader encounters dot and dot-dot entries

### DIFF
--- a/dali/image/image.cc
+++ b/dali/image/image.cc
@@ -34,6 +34,15 @@ std::string ListSupportedExtensions() {
 bool HasKnownImageExtension(const std::string &image_path) {
   std::string path_low{image_path};
   std::transform(path_low.begin(), path_low.end(), path_low.begin(), ::tolower);
+
+  /** Skip but without any warning */
+  for (const auto &ext : kSkipImageExtensions) {
+    if (strlen(ext) == strlen(image_path.c_str()) &&
+        strncmp(ext, image_path.c_str(), strlen(ext)) == 0) {
+      return false;
+    }
+  }
+
   for (const auto &ext : kKnownImageExtensions) {
     size_t pos = path_low.rfind(ext);
     if (pos != std::string::npos && pos + strlen(ext) == path_low.size()) {

--- a/dali/image/image.h
+++ b/dali/image/image.h
@@ -35,6 +35,11 @@ static const char *kKnownImageExtensions[] = {".jpg", ".jpeg", ".png", ".gif",
                                               ".bmp", ".tif",  ".tiff",
                                               ".pnm", ".ppm", ".pgm", ".pbm"};
 
+/**
+ * Some file systems returns `.` and `..` as entries in the directory. DALI should just skip them
+ */
+static const char *kSkipImageExtensions[] = {"..", ".", };
+
 DLL_PUBLIC bool HasKnownImageExtension(const std::string &image_path);
 
 class Image {


### PR DESCRIPTION
- in some file systems, readdir call returns dot and dot-dot as a valid
  entries in a given directory. Currently, DALI will print warning that
  this file is not supported. Instead, it should be silently skipped.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- addresses https://github.com/NVIDIA/DALI/issues/1226

#### What happened in this PR?
 - in some file systems, readdir call returns dot and dot-dot as a valid
  entries in a given directory. Currently, DALI will print warning that
  this file is not supported. Instead, it should be silently skipped.
 - added silent skip of dot and dot-dot entries in scanned directories
 - CI

**JIRA TASK**: [NA]