### PR TITLE
Fix CropMirrorNormalize compilation with GCC 8

### DIFF
--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -212,7 +212,7 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
 
       // Set internal info for each sample based on CropAttr
       for (int data_idx = 0; data_idx < batch_size_; data_idx++) {
-        mirror_[data_idx] = spec_.template GetArgument<int>("mirror", &ws, data_idx);
+        mirror_[data_idx] = this->spec_.template GetArgument<int>("mirror", &ws, data_idx);
         SetupSample(data_idx, input_layout_, in_shape.tensor_shape(data_idx));
         // convert the Operator representation to Kernel parameter representation
         kernel_sample_args[data_idx] = detail::GetKernelArgs<Dims>(


### PR DESCRIPTION
- adds this to spec_.* call to properly resolve a variable name

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- fix CropMirrorNormalize compilation with GCC 8

#### What happened in this PR?
 - addresses https://github.com/NVIDIA/DALI/issues/1257
 - tested on CI
 - adds `this` to spec_.* call to properly resolve a variable name

**JIRA TASK**: [NA]