### PR TITLE
Fix TypeTable initialization

### DIFF
--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -20,11 +20,14 @@
 
 #define DALI_TYPEID_REGISTERER(Type, dtype)                           \
 {                                                                     \
-  std::lock_guard<std::mutex> lock(mutex_);                           \
-  static DALIDataType type_id = TypeTable::RegisterType<Type>(dtype); \
+  auto &inst = instance();                                            \
+  std::lock_guard<std::mutex> lock(inst.mutex_);                      \
+  static DALIDataType type_id = inst.RegisterType<Type>(dtype);       \
   return type_id;                                                     \
 }
 
+#define DALI_REGISTER_TYPE_IMPL(Type, Name, Id) \
+const auto &_type_info_##Id = TypeTable::GetTypeID<Type>()
 
 #include "dali/pipeline/data/types.h"
 #include "dali/util/half.hpp"
@@ -32,10 +35,11 @@
 #include "dali/pipeline/data/backend.h"
 
 namespace dali {
-std::mutex TypeTable::mutex_;
-std::unordered_map<std::type_index, DALIDataType> TypeTable::type_map_;
-std::unordered_map<size_t, TypeInfo> TypeTable::type_info_map_;
-int TypeTable::index_ = DALI_DATATYPE_END;
+
+TypeTable &TypeTable::instance() {
+  static TypeTable singleton;
+  return singleton;
+}
 
 template <>
 void TypeInfo::Copy<CPUBackend, CPUBackend>(void *dst,

--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -18,12 +18,10 @@
   return TypeString;                         \
 }
 
-#define DALI_TYPEID_REGISTERER(Type, dtype)                           \
-{                                                                     \
-  auto &inst = instance();                                            \
-  std::lock_guard<std::mutex> lock(inst.mutex_);                      \
-  static DALIDataType type_id = inst.RegisterType<Type>(dtype);       \
-  return type_id;                                                     \
+#define DALI_TYPEID_REGISTERER(Type, dtype)                                      \
+{                                                                                \
+  static DALIDataType type_id = TypeTable::instance().RegisterType<Type>(dtype); \
+  return type_id;                                                                \
 }
 
 #define DALI_REGISTER_TYPE_IMPL(Type, Name, Id) \

--- a/dali/pipeline/data/types_test.cc
+++ b/dali/pipeline/data/types_test.cc
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 #include "dali/pipeline/data/types.h"
-
 #include <gtest/gtest.h>
-
 #include <string>
-
+#include <utility>
 #include "dali/test/dali_test.h"
 
 namespace dali {
@@ -31,6 +29,35 @@ class TypesTest : public DALITest {
 
 namespace {
   static constexpr size_t DUMMY_ARRAY_SIZE = 42;
+}
+
+template <typename T>
+auto GetTypeInfo() {
+  return std::make_pair(type2id<T>::value, &TypeTable::GetTypeInfo(type2id<T>::value));
+}
+
+static std::pair<DALIDataType, const TypeInfo *> g_types[] = {
+  GetTypeInfo<uint8_t>(),
+  GetTypeInfo<int8_t>(),
+  GetTypeInfo<uint16_t>(),
+  GetTypeInfo<int16_t>(),
+  GetTypeInfo<uint32_t>(),
+  GetTypeInfo<int32_t>(),
+  GetTypeInfo<uint64_t>(),
+  GetTypeInfo<int64_t>(),
+  GetTypeInfo<bool>(),
+  GetTypeInfo<float>(),
+  GetTypeInfo<double>(),
+  GetTypeInfo<string>(),
+  GetTypeInfo<DALIDataType>()
+};
+
+
+TEST(TypeTableTest, BasicTypesLookup) {
+  for (auto &info : g_types) {
+    ASSERT_NE(info.second, nullptr);
+    EXPECT_EQ(info.first, info.second->id());
+  }
 }
 
 #define TYPENAME_FUNC(type, type_name)           \

--- a/include/dali/core/spinlock.h
+++ b/include/dali/core/spinlock.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_SPINLOCK_H_
+#define DALI_CORE_SPINLOCK_H_
+
+#include <atomic>
+
+namespace dali {
+
+class spinlock {
+ public:
+  void lock() noexcept {
+    while (flag_.test_and_set(std::memory_order_acquire)) {
+      // busy-wait
+    }
+  }
+
+  bool try_lock() noexcept {
+      return !flag_.test_and_set(std::memory_order_acquire);
+  }
+
+  void unlock() noexcept {
+    flag_.clear(std::memory_order_release);
+  }
+
+ private:
+  std::atomic_flag flag_ = ATOMIC_FLAG_INIT;
+};
+
+}  // namespace dali
+
+#endif  // DALI_CORE_SPINLOCK_H_


### PR DESCRIPTION
Populate basic types in TypeTable at startup.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
- It fixes a bug with basic types not being put into `TypeTable` before first use of `GetTypeID<T>`.
- It improves concurrency handling

#### What happened in this PR?
 - TypeTable is now a singleton, not a bunch of static fields
 - Added a macro that registers types by calling `GetTypeID<T>`
 - Tested with GTest, by getting typeinfo into global variables
 - Mutex replaced with spinlock
 - Mutex no longer guards static variable initialization - c++11 guarantees "magic statics".


**JIRA TASK**: NONE

This PR supersedes #1269
