### PR TITLE
Make DALI_extra repo path settable from the env

### DIFF
--- a/qa/setup_dali_extra.sh
+++ b/qa/setup_dali_extra.sh
@@ -3,7 +3,7 @@
 # Fetch test data
 export DALI_EXTRA_PATH=${DALI_EXTRA_PATH:-/opt/dali_extra}
 
-DALI_EXTRA_URL="https://github.com/NVIDIA/DALI_extra.git"
+export DALI_EXTRA_URL=${DALI_EXTRA_URL:-"https://github.com/NVIDIA/DALI_extra.git"}
 DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 DALI_EXTRA_VERSION_PATH="${DIR}/../DALI_EXTRA_VERSION"
 read -r DALI_EXTRA_VERSION < ${DALI_EXTRA_VERSION_PATH}


### PR DESCRIPTION
- makes it possible to set path to DALI_extra repo from the env

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- makes it possible to set path to DALI_extra repo from the env so some internal mirror
  can be used to save GitHub quota

#### What happened in this PR?
 - makes it possible to set path to DALI_extra repo from the env so some internal mirror
  can be used to save GitHub quota

**JIRA TASK**: [NA]