### PR TITLE
Add CropMirrorNormalize 3D support

### DIFF
--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cc
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cc
@@ -37,9 +37,8 @@ normalization only.
     R"code(Output data type.)code", DALI_FLOAT)
   .AddOptionalArg("output_layout",
     R"code(Output tensor data layout)code", "CHW")
-  .AddOptionalArg(
-    "pad_output",
-    R"code(Whether to pad the output to number of channels being multiple of 4.)code", false)
+  .AddOptionalArg("pad_output",
+    R"code(Whether to pad the output to number of channels being a power of 2.)code", false)
   .AddOptionalArg("mirror",
     R"code(Mask for horizontal flip.
 - `0` - do not perform horizontal flip for this image

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cc
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cc
@@ -66,7 +66,7 @@ bool CropMirrorNormalize<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
   std::size_t number_of_dims = input.shape().sample_dim();
   DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
     DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
-      VALUE_SWITCH(number_of_dims, Dims, (3, 4),
+      VALUE_SWITCH(number_of_dims, Dims, (3, 4, 5),
       (
         using Kernel = kernels::SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
@@ -99,7 +99,7 @@ void CropMirrorNormalize<CPUBackend>::RunImpl(SampleWorkspace &ws) {
 
   DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
     DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
-      VALUE_SWITCH(number_of_dims, Dims, (3, 4),
+      VALUE_SWITCH(number_of_dims, Dims, (3, 4, 5),
       (
         using Kernel = kernels::SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.cu
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.cu
@@ -31,7 +31,7 @@ bool CropMirrorNormalize<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
   std::size_t number_of_dims = input.shape().sample_dim();
   DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
     DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
-      VALUE_SWITCH(number_of_dims, Dims, (3, 4),
+      VALUE_SWITCH(number_of_dims, Dims, (3, 4, 5),
       (
         using Kernel = kernels::SliceFlipNormalizePermutePadGPU<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
@@ -60,7 +60,7 @@ void CropMirrorNormalize<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   std::size_t number_of_dims = input.shape().sample_dim();
   DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
     DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
-      VALUE_SWITCH(number_of_dims, Dims, (3, 4),
+      VALUE_SWITCH(number_of_dims, Dims, (3, 4, 5),
       (
         using Kernel = kernels::SliceFlipNormalizePermutePadGPU<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -196,9 +196,9 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
     W = shape[w_dim];
     C = shape[c_dim];
     if (f_dim >= 0)
-      F = shape[layout.find('F')];
+      F = shape[f_dim];
     if (d_dim >= 0)
-      D = shape[layout.find('D')];
+      D = shape[d_dim];
 
     auto crop_window_gen = GetCropWindowGenerator(data_idx);
     auto win = spatial_ndim == 3 ? crop_window_gen({D, H, W}) : crop_window_gen({H, W});

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -34,16 +34,6 @@ namespace dali {
 
 namespace detail {
 
-inline size_t horizontal_dim_idx(const TensorLayout &layout) {
-  return layout.find('W');
-}
-
-
-
-inline int channels_dim(TensorLayout in_layout) {
-  return ImageLayoutInfo::ChannelDimIndex(in_layout);
-}
-
 // Rewrite Operator data as arguments for kernel
 // TODO(klecki): It probably could be written directly in that format
 template <size_t Dims>
@@ -54,16 +44,20 @@ kernels::SliceFlipNormalizePermutePadArgs<Dims> GetKernelArgs(
     const std::vector<float> &inv_std_dev) {
   kernels::SliceFlipNormalizePermutePadArgs<Dims> args(slice_shape);
 
-  for (std::size_t d = 0; d < Dims; d++) {
+  for (size_t d = 0; d < Dims; d++) {
     args.anchor[d] = slice_anchor[d];
   }
 
+  int channel_dim_idx = ImageLayoutInfo::ChannelDimIndex(input_layout);
+  assert(channel_dim_idx >= 0);
   if (pad_output) {
-    args.padded_shape[channels_dim(input_layout)] = 4;
+    args.padded_shape[channel_dim_idx] = 4;
   }
 
   if (horizontal_flip) {
-    args.flip[horizontal_dim_idx(input_layout)] = true;
+    int horizontal_dim_idx = input_layout.find('W');
+    assert(horizontal_dim_idx >= 0);
+    args.flip[horizontal_dim_idx] = true;
   }
 
   // Check if permutation is needed
@@ -75,7 +69,7 @@ kernels::SliceFlipNormalizePermutePadArgs<Dims> GetKernelArgs(
   if (should_normalize) {
     args.mean = mean;
     args.inv_stddev = inv_std_dev;
-    args.normalization_dim = channels_dim(input_layout);
+    args.normalization_dim = channel_dim_idx;
   }
 
   return args;
@@ -150,9 +144,8 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
 
     CropAttr::ProcessArguments(ws);
 
-    std::size_t number_of_dims = in_shape.sample_dim();
-
-    VALUE_SWITCH(number_of_dims, Dims, (3, 4),
+    int number_of_dims = in_shape.sample_dim();
+    VALUE_SWITCH(number_of_dims, Dims, (3, 4, 5),
     (
       using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
       // We won't change the underlying type after the first allocation
@@ -174,26 +167,27 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
       // NOLINTNEXTLINE(whitespace/parens)
     ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
 
-
-
     auto &output = ws.template OutputRef<Backend>(0);
     output.SetLayout(output_layout_);
   }
 
   // Calculate slice window and anchor for given data_idx
   void SetupSample(int data_idx, TensorLayout layout, const kernels::TensorShape<> &shape) {
-    Index F = 1, H, W, C;
-    DALI_ENFORCE(shape.size() == 3 || shape.size() == 4,
+    Index F = 1, D = 1, H, W, C;
+    DALI_ENFORCE(shape.size() >= 3 || shape.size() <= 5,
       "Unexpected number of dimensions: " + std::to_string(shape.size()));
-    DALI_ENFORCE(ImageLayoutInfo::NumSpatialDims(layout) == 2,
-      "Only 2D images and sequences of images are supported");
+    DALI_ENFORCE(layout.ndim() == shape.size());
+    const int spatial_ndim = ImageLayoutInfo::NumSpatialDims(layout);
+    DALI_ENFORCE(spatial_ndim == 2 || spatial_ndim == 3,
+      "Only 2D or 3D images and sequences of images are supported");
     DALI_ENFORCE(ImageLayoutInfo::HasChannel(layout),
-      "This operator expects an explicit channel dimesnion, even for monochrome images");
+      "This operator expects an explicit channel dimension, even for monochrome images");
 
     int h_dim = layout.find('H');
     int w_dim = layout.find('W');
     int c_dim = layout.find('C');
     int f_dim = layout.find('F');
+    int d_dim = layout.find('D');
 
     DALI_ENFORCE(h_dim >= 0 && w_dim >= 0 && c_dim >= 0,
       "Height, Width and Channel must be present in the layout. Got: " + layout.str());
@@ -201,29 +195,32 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
     H = shape[h_dim];
     W = shape[w_dim];
     C = shape[c_dim];
-    if (f_dim >= 0) {
+    if (f_dim >= 0)
       F = shape[layout.find('F')];
-    }
+    if (d_dim >= 0)
+      D = shape[layout.find('D')];
 
-    const bool is_whole_image = IsWholeImage();
-    int crop_h = is_whole_image ? H : crop_height_[data_idx];
-    int crop_w = is_whole_image ? W : crop_width_[data_idx];
-
-    float anchor_norm[2] = {crop_y_norm_[data_idx], crop_x_norm_[data_idx]};
-    auto anchor = CalculateAnchor(make_span(anchor_norm), {crop_h, crop_w}, {H, W});
-    int64_t crop_y = anchor[0], crop_x = anchor[1];
+    auto crop_window_gen = GetCropWindowGenerator(data_idx);
+    auto win = spatial_ndim == 3 ? crop_window_gen({D, H, W}) : crop_window_gen({H, W});
 
     int ndim = shape.sample_dim();
     slice_anchors_[data_idx].resize(ndim);
     slice_shapes_[data_idx].resize(ndim);
 
-    slice_anchors_[data_idx][h_dim] = crop_y;
-    slice_shapes_[data_idx][h_dim] = crop_h;
-    slice_anchors_[data_idx][w_dim] = crop_x;
-    slice_shapes_[data_idx][w_dim] = crop_w;
+    if (d_dim >= 0) {
+      slice_anchors_[data_idx][d_dim] = win.anchor[spatial_ndim - 3];
+      slice_shapes_[data_idx][d_dim] = win.shape[spatial_ndim - 3];
+    }
+
+    slice_anchors_[data_idx][h_dim] = win.anchor[spatial_ndim - 2];
+    slice_shapes_[data_idx][h_dim] = win.shape[spatial_ndim - 2];
+
+    slice_anchors_[data_idx][w_dim] = win.anchor[spatial_ndim - 1];
+    slice_shapes_[data_idx][w_dim] = win.shape[spatial_ndim - 1];
 
     slice_anchors_[data_idx][c_dim] = 0;
     slice_shapes_[data_idx][c_dim] = C;
+
     if (f_dim >= 0) {
       slice_anchors_[data_idx][f_dim] = 0;
       slice_shapes_[data_idx][f_dim] = F;
@@ -233,7 +230,7 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
   DALIDataType input_type_ = DALI_NO_TYPE;
   DALIDataType output_type_ = DALI_NO_TYPE;
 
-  TensorLayout input_layout_ = "HWC";
+  TensorLayout input_layout_;
   TensorLayout output_layout_;
 
   // Whether to pad output to 4 channels

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -34,6 +34,14 @@ namespace dali {
 
 namespace detail {
 
+template <typename T>
+T NextPowerOfTwo(T value) {
+  T power = 1;
+  while (power < value)
+    power <<= 1;
+  return power;
+}
+
 // Rewrite Operator data as arguments for kernel
 // TODO(klecki): It probably could be written directly in that format
 template <size_t Dims>
@@ -51,7 +59,7 @@ kernels::SliceFlipNormalizePermutePadArgs<Dims> GetKernelArgs(
   int channel_dim_idx = ImageLayoutInfo::ChannelDimIndex(input_layout);
   assert(channel_dim_idx >= 0);
   if (pad_output) {
-    args.padded_shape[channel_dim_idx] = 4;
+    args.padded_shape[channel_dim_idx] = NextPowerOfTwo(args.shape[channel_dim_idx]);
   }
 
   if (horizontal_flip) {

--- a/dali/test/python/test_operator_crop_mirror_normalize.py
+++ b/dali/test/python/test_operator_crop_mirror_normalize.py
@@ -181,7 +181,7 @@ def crop_mirror_normalize_func(crop_z, crop_y, crop_x,
     end_x = start_x + crop_w
     if input_layout.count('D') > 0:
         assert D >= crop_d
-        start_z = int(np.round(np.float32(crop_z) * np.float32(D - crop_d)))
+        start_z = int(np.float32(crop_z) * np.float32(D - crop_d) + np.float32(0.5))
         end_z = start_z + crop_d
 
     # Crop

--- a/dali/test/python/test_operator_crop_mirror_normalize.py
+++ b/dali/test/python/test_operator_crop_mirror_normalize.py
@@ -30,6 +30,9 @@ from test_utils import get_dali_extra_path
 test_data_root = get_dali_extra_path()
 caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
 
+def next_power_of_two(x):
+    return 1 if x == 0 else 2**(x - 1).bit_length()
+
 class CropMirrorNormalizePipeline(Pipeline):
     def __init__(self, device, batch_size, num_threads=1, device_id=0, num_gpus=1,
                  output_dtype = types.FLOAT, output_layout = "HWC",
@@ -215,7 +218,9 @@ def crop_mirror_normalize_func(crop_z, crop_y, crop_x,
     out1 = np.flip(out, horizontal_dim) if should_flip else out
 
     # Pad, normalize, transpose
-    out_C = C + 1 if should_pad else C
+
+    out_C = next_power_of_two(C) if should_pad else C
+
     if input_layout == "HWC":
         out2 = np.zeros([H, W, out_C], dtype=np.float32)
         out2[:, :, 0:C] = (np.float32(out1) - mean) * inv_std

--- a/dali/test/python/test_operator_crop_mirror_normalize.py
+++ b/dali/test/python/test_operator_crop_mirror_normalize.py
@@ -142,23 +142,47 @@ cmn_coin_flip_samples = {
 }
 cmn_idx = 0
 
-def crop_mirror_normalize_func(crop_y, crop_x, crop_h, crop_w, mirror_probability, should_pad, mean, std,
+def crop_mirror_normalize_func(crop_z, crop_y, crop_x,
+                               crop_d, crop_h, crop_w,
+                               mirror_probability, should_pad, mean, std,
                                input_layout, output_layout, image):
-    assert input_layout == "HWC" or input_layout == "FHWC"
-    if input_layout == "HWC":
-        assert output_layout == "HWC" or output_layout == "CHW"
-        assert len(image.shape) == 3
-        F, H, W, C = 1, image.shape[0], image.shape[1], image.shape[2]
-    elif input_layout == "FHWC":
-        assert output_layout == "FHWC" or output_layout == "FCHW"
-        assert len(image.shape) == 4
-        F, H, W, C = image.shape[0], image.shape[1], image.shape[2], image.shape[3]
+    assert input_layout == "HWC" or input_layout == "FHWC" \
+        or input_layout == "DHWC" or input_layout == "FDHWC"
+    assert len(input_layout) == len(image.shape)
+
+    assert input_layout.count('H') > 0
+    dim_h = input_layout.find('H')
+    H = image.shape[dim_h]
+
+    assert input_layout.count('W') > 0
+    dim_w = input_layout.find('W')
+    W = image.shape[dim_w]
+
+    assert input_layout.count('C') > 0
+    dim_c = input_layout.find('C')
+    C = image.shape[dim_c]
+
+    D = 1
+    if input_layout.count('D') > 0:
+        dim_d = input_layout.find('D')
+        D = image.shape[dim_d]
+        assert D >= crop_d
+
+    F = 1
+    if input_layout.count('F') > 0:
+        dim_f = input_layout.find('F')
+        F = image.shape[dim_f]
+
     assert H >= crop_h and W >= crop_w
 
     start_y = int(np.float32(crop_y) * np.float32(H - crop_h) + np.float32(0.5))
     end_y = start_y + crop_h
     start_x = int(np.float32(crop_x) * np.float32(W - crop_w) + np.float32(0.5))
     end_x = start_x + crop_w
+    if input_layout.count('D') > 0:
+        assert D >= crop_d
+        start_z = int(np.round(np.float32(crop_z) * np.float32(D - crop_d)))
+        end_z = start_z + crop_d
 
     # Crop
     if input_layout == "HWC":
@@ -167,6 +191,12 @@ def crop_mirror_normalize_func(crop_y, crop_x, crop_h, crop_w, mirror_probabilit
     elif input_layout == "FHWC":
         out = image[:, start_y:end_y, start_x:end_x, :]
         H, W = out.shape[1], out.shape[2]
+    elif input_layout == "DHWC":
+        out = image[start_z:end_z, start_y:end_y, start_x:end_x, :]
+        D, H, W = out.shape[0], out.shape[1], out.shape[2]
+    elif input_layout == "FDHWC":
+        out = image[:, start_z:end_z, start_y:end_y, start_x:end_x, :]
+        D, H, W = out.shape[1], out.shape[2], out.shape[3]
 
     if len(mean) == 1:
         mean = C * mean
@@ -180,8 +210,9 @@ def crop_mirror_normalize_func(crop_y, crop_x, crop_h, crop_w, mirror_probabilit
     should_flip = cmn_coin_flip_samples[mirror_probability][cmn_idx]
     cmn_idx = (cmn_idx + 1) % len(cmn_coin_flip_samples[mirror_probability])
 
-    dim_h = 2 if input_layout == "FHWC" else 1
-    out1 = np.flip(out, dim_h) if should_flip else out
+    assert input_layout.count('W') > 0
+    horizontal_dim = input_layout.find('W')
+    out1 = np.flip(out, horizontal_dim) if should_flip else out
 
     # Pad, normalize, transpose
     out_C = C + 1 if should_pad else C
@@ -193,6 +224,14 @@ def crop_mirror_normalize_func(crop_y, crop_x, crop_h, crop_w, mirror_probabilit
         out2 = np.zeros([F, H, W, out_C], dtype=np.float32)
         out2[:, :, :, 0:C] = (np.float32(out1) - mean) * inv_std
         return np.transpose(out2, (0, 3, 1, 2)) if output_layout == "FCHW" else out2
+    elif input_layout == "DHWC":
+        out2 = np.zeros([D, H, W, out_C], dtype=np.float32)
+        out2[:, :, :, 0:C] = (np.float32(out1) - mean) * inv_std
+        return np.transpose(out2, (3, 0, 1, 2)) if output_layout == "CDHW" else out2
+    elif input_layout == "FDHWC":
+        out2 = np.zeros([F, D, H, W, out_C], dtype=np.float32)
+        out2[:, :, :, :, 0:C] = (np.float32(out1) - mean) * inv_std
+        return np.transpose(out2, (0, 4, 1, 2, 3)) if output_layout == "FCDHW" else out2
     else:
         assert False
 
@@ -202,9 +241,12 @@ def check_cmn_vs_numpy(device, batch_size, output_dtype, output_layout,
     global cmn_idx
     cmn_idx = 0
 
-    crop_y, crop_x, crop_h, crop_w = (0.2, 0.3, 224, 224)
+    crop_z, crop_y, crop_x = (0.1, 0.2, 0.3)
+    crop_d, crop_h, crop_w = (10, 224, 224)
     function = partial(crop_mirror_normalize_func,
-                       crop_y, crop_x, crop_h, crop_w, mirror_probability, should_pad,
+                       crop_z, crop_y, crop_x,
+                       crop_d, crop_h, crop_w,
+                       mirror_probability, should_pad,
                        mean, std, "HWC", output_layout)
 
     iterations = 8 if batch_size == 1 else 1
@@ -239,16 +281,32 @@ class CMNRandomDataPipeline(Pipeline):
         self.layout = layout
         self.iterator = iterator
         self.inputs = ops.ExternalSource()
-        self.cmn = ops.CropMirrorNormalize(device = self.device,
-                                           output_dtype = output_dtype,
-                                           output_layout = output_layout,
-                                           crop = (224, 224),
-                                           crop_pos_x = 0.3,
-                                           crop_pos_y = 0.2,
-                                           image_type = types.RGB,
-                                           mean = mean,
-                                           std = std,
-                                           pad_output = pad_output)
+        if layout.count('D') > 0:
+            self.cmn = ops.CropMirrorNormalize(device = self.device,
+                                               output_dtype = output_dtype,
+                                               output_layout = output_layout,
+                                               crop_d = 8,
+                                               crop_h = 16,
+                                               crop_w = 32,
+                                               crop_pos_x = 0.3,
+                                               crop_pos_y = 0.2,
+                                               crop_pos_z = 0.1,
+                                               image_type = types.RGB,
+                                               mean = mean,
+                                               std = std,
+                                               pad_output = pad_output)
+        else:
+            self.cmn = ops.CropMirrorNormalize(device = self.device,
+                                               output_dtype = output_dtype,
+                                               output_layout = output_layout,
+                                               crop_h = 16,
+                                               crop_w = 32,
+                                               crop_pos_x = 0.3,
+                                               crop_pos_y = 0.2,
+                                               image_type = types.RGB,
+                                               mean = mean,
+                                               std = std,
+                                               pad_output = pad_output)
         self.coin = ops.CoinFlip(probability=mirror_probability, seed=7865)
 
     def define_graph(self):
@@ -285,7 +343,8 @@ class CMNRandomDataPythonOpPipeline(Pipeline):
 
 def check_cmn_random_data_vs_numpy(device, batch_size, output_dtype, input_layout, input_shape,
                                    output_layout, mirror_probability, mean, std, should_pad):
-    crop_y, crop_x, crop_h, crop_w = (0.2, 0.3, 224, 224)
+    crop_z, crop_y, crop_x = (0.1, 0.2, 0.3)
+    crop_d, crop_h, crop_w = (8, 16, 32)
     eii1 = RandomDataIterator(batch_size, shape=input_shape)
     eii2 = RandomDataIterator(batch_size, shape=input_shape)
 
@@ -294,42 +353,47 @@ def check_cmn_random_data_vs_numpy(device, batch_size, output_dtype, input_layou
     cmn_idx = 0
 
     function = partial(crop_mirror_normalize_func,
-                       crop_y, crop_x, crop_h, crop_w, mirror_probability, should_pad,
+                       crop_z, crop_y, crop_x,
+                       crop_d, crop_h, crop_w,
+                       mirror_probability, should_pad,
                        mean, std, input_layout, output_layout)
 
-    compare_pipelines(CMNRandomDataPipeline(device, batch_size, input_layout, iter(eii1),
-                                          output_dtype = output_dtype, output_layout = output_layout,
-                                          mirror_probability = mirror_probability, mean = mean, std= std,
-                                          pad_output = should_pad),
-                      CMNRandomDataPythonOpPipeline(function, batch_size, input_layout, iter(eii2)),
-                      batch_size=batch_size, N_iterations=1)
+    compare_pipelines( \
+        CMNRandomDataPipeline(device, batch_size, input_layout, iter(eii1),
+                              output_dtype = output_dtype, output_layout = output_layout,
+                              mirror_probability = mirror_probability, mean = mean, std= std,
+                              pad_output = should_pad),
+        CMNRandomDataPythonOpPipeline(function, batch_size, input_layout, iter(eii2)),
+                                      batch_size=batch_size, N_iterations=1)
 
 def test_cmn_random_data_vs_numpy():
     norm_data = [ ([0., 0., 0.], [1., 1., 1.]),
                   ([0.485 * 255, 0.456 * 255, 0.406 * 255], [0.229 * 255, 0.224 * 255, 0.225 * 255]) ]
     output_layouts = {
         "HWC" : ["HWC", "CHW"],
-        "FHWC" : ["FHWC", "FCHW"]
+        "FHWC" : ["FHWC", "FCHW"],
+        "DHWC" : ["DHWC", "CDHW"],
+        "FDHWC" :["FDHWC", "FCDHW"]
     }
 
     input_shapes = {
-        "HWC" : [(600, 800, 3)],
-        "FHWC" : [(5, 600, 800, 3)],
+        "HWC" : [(60, 80, 3)],
+        "FHWC" : [(3, 60, 80, 3)],
+        "DHWC" : [(10, 60, 80, 3)],
+        "FDHWC" : [(3, 10, 60, 80, 3)]
     }
 
     for device in ['cpu', 'gpu']:
         for batch_size in [1, 8]:
             for output_dtype in [types.FLOAT]:
-                for input_layout in ["HWC", "FHWC"]:
+                for input_layout in ["HWC", "FHWC", "DHWC", "FDHWC"]:
                     for input_shape in input_shapes[input_layout]:
-                        if input_layout == "FHWC":
-                            assert len(input_shape) == 4
-                        elif input_layout == "HWC":
-                            assert len(input_shape) == 3
+                        assert len(input_layout) == len(input_shape)
                         for output_layout in output_layouts[input_layout]:
                             mirror_probs = [0.5] if batch_size > 1 else [0.0, 1.0]
                             for mirror_probability in mirror_probs:
                                 for (mean, std) in norm_data:
                                     for should_pad in [False, True]:
-                                        yield check_cmn_random_data_vs_numpy, device, batch_size, output_dtype, input_layout, input_shape, \
-                                            output_layout, mirror_probability, mean, std, should_pad
+                                        yield check_cmn_random_data_vs_numpy, device, batch_size, output_dtype, \
+                                            input_layout, input_shape, output_layout, mirror_probability, \
+                                            mean, std, should_pad

--- a/include/dali/core/tensor_layout.h
+++ b/include/dali/core/tensor_layout.h
@@ -394,7 +394,7 @@ struct ImageLayoutInfo : LayoutInfo {
     return NumSpatialDims(tl) == 3;
   }
 
-  /** @brief Returns the index at which 'C' dimesnion (channel) is present or -1 if not found */
+  /** @brief Returns the index at which 'C' dimension (channel) is present or -1 if not found */
   DALI_HOST_DEV
   static int ChannelDimIndex(const TensorLayout &tl) {
     return DimIndex(tl, 'C');


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
Need to support 3D inputs in CropMirrorNormalize

#### What happened in this PR?
Modified CropMirrorNormalize operator to support crop arguments in the third spatial dimension (`depth`)

**JIRA TASK**: [DALI-1035]