### PR TITLE
Adjust QA scripts remove installing pip whl from direct links as pip will disregard the "-f" option in that case

### DIFF
--- a/qa/download_pip_packages.sh
+++ b/qa/download_pip_packages.sh
@@ -10,15 +10,11 @@ do
     source test.sh
     popd
     echo ${pip_packages}
-    last_config_index=$(python setup_packages.py -n -u $pip_packages --cuda ${CUDA_VERSION})
-    for i in `seq 0 $last_config_index`;
-    do
-        packages=($(python setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION} --include-link | tr -d '[],'))
-        for pkg in ${packages}; do
-            # remove single quotes ('')
-            pkg="${pkg%\'}"
-            pkg="${pkg#\'}"
-            pip download $pkg -d /pip-packages
+    last_config_index=`./setup_packages.py -n -u $pip_packages --cuda ${CUDA_VERSION}`
+    for i in `seq 0 $last_config_index`; do
+        eval "packages=(`./setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION} --include-link | tr -d '[],'`)"
+        for pkg in "${packages[@]}"; do
+            pip download "$pkg" -d /pip-packages
         done
     done
 done

--- a/qa/download_pip_packages.sh
+++ b/qa/download_pip_packages.sh
@@ -13,10 +13,12 @@ do
     last_config_index=$(python setup_packages.py -n -u $pip_packages --cuda ${CUDA_VERSION})
     for i in `seq 0 $last_config_index`;
     do
-        inst=$(python setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION})
-        if [ -n "$inst" ]
-        then
-            pip download $inst -d /pip-packages
-        fi
+        packages=($(python setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION} --include-link | tr -d '[],'))
+        for pkg in ${packages}; do
+            # remove single quotes ('')
+            pkg="${pkg%\'}"
+            pkg="${pkg#\'}"
+            pip download $pkg -d /pip-packages
+        done
     done
 done

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -124,7 +124,7 @@ def get_all_strings(use, cuda):
             elif isinstance(val, tuple):
                 version, _ = val
                 pkg_str = key + '==' + version
-            ret.append(key)
+            ret.append(pkg_str)
     # add all remaining used packages with default versions
     additional = [v for v in use if v not in package_data.keys()]
     return ret + additional

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -19,16 +19,22 @@ except ImportError:
 # put {0} in pacage link as a placeholder for python pip package version (i.e. cp27-cp27mu-linux_x86_64)
 # and cuda_v for cuXX version
 # NOTE: First version will be picked in case of one_config_only
-packages = {
-            "opencv-python" : ["4.1.0.25"],
-            "mxnet-cu90" : ["1.5.0"],
-            "mxnet-cu100" : ["1.5.0"],
-            "tensorflow-gpu" : {"90": ["1.12.0", "1.11", "1.7"], "100": ["1.13.1", "1.14.0"]},
-            "torch" : {"90": ["http://download.pytorch.org/whl/{cuda_v}/torch-1.1.0-{0}.whl"],
-                       "100": ["http://download.pytorch.org/whl/{cuda_v}/torch-1.2.0-{0}.whl"]},
-            "torchvision" : {"90": ["https://download.pytorch.org/whl/{cuda_v}/torchvision-0.3.0-{0}.whl"],
-                             "100": ["https://download.pytorch.org/whl/{cuda_v}/torchvision-0.4.0-{0}.whl"]},
-            }
+package_data = {
+    "opencv-python" : ["4.1.0.25"],
+    "mxnet-cu90" : ["1.5.0"],
+    "mxnet-cu100" : ["1.5.0"],
+    "tensorflow-gpu" : {
+        "90": ["1.12.0", "1.11", "1.7"],
+        "100": ["1.13.1", "1.14.0"]},
+    "torch" : {
+        "90": [("1.1.0", "http://download.pytorch.org/whl/90/torch_stable.html")],
+        "100": [("1.2.0", "http://download.pytorch.org/whl/100/torch_stable.html")]
+    },
+    "torchvision" : {
+        "90": [("0.3.0", "http://download.pytorch.org/whl/90/torch_stable.html")],
+        "100": [("0.4.0", "http://download.pytorch.org/whl/100/torch_stable.html")],
+    }
+}
 
 parser = argparse.ArgumentParser(description='Env setup helper')
 parser.add_argument('--list', '-l', help='list configs', action='store_true', default=False)
@@ -38,14 +44,15 @@ parser.add_argument('--all', '-a', dest='getall', action='store_true', help='ret
 parser.add_argument('--remove', '-r', dest='remove', help="list packages to remove", action='store_true', default=False)
 parser.add_argument('--cuda', dest='cuda', default="90", help="CUDA version to use")
 parser.add_argument('--use', '-u', dest='use', default=[], help="provide only packages from this list", nargs='*')
+parser.add_argument('--include-link', dest='include_link', help='include -f links', action='store_true', default=False)
 args = parser.parse_args()
 
-def get_package(packages, key, cuda):
-    if key in packages.keys():
-        if isinstance(packages[key], dict):
-            return packages[key][cuda]
+def get_package_list(package_data, key, cuda):
+    if key in package_data.keys():
+        if isinstance(package_data[key], dict):
+            return package_data[key][cuda]
         else:
-            return packages[key]
+            return package_data[key]
     else:
         return None
 
@@ -62,58 +69,71 @@ def get_pyvers_name(name, cuda):
              pass
     return ""
 
+def get_version(package_version_entry):
+    if isinstance(package_version_entry, tuple):
+        return package_version_entry[0]
+    elif isinstance(package_version_entry, str):
+        return package_version_entry
+    else:
+        return "Default"
+
 def print_configs(cuda):
-    for key in packages.keys():
+    for key in package_data.keys():
         print (key + ":")
-        for val in get_package(packages, key, cuda):
-            if val == None:
-                val = "Default"
-            elif val.startswith('http'):
-                val = get_pyvers_name(val, cuda)
-            print ('\t' + val)
+        for val in get_package_list(package_data, key, cuda):
+            print ('\t' + get_version(val))
 
 def get_install_string(variant, use, cuda):
     ret = []
-    for key in packages.keys():
+    for key in package_data.keys():
         if key not in use:
             continue
-        tmp = variant % len(get_package(packages, key, cuda))
-        val = get_package(packages, key, cuda)[tmp]
-        if val == None:
-            ret.append(key)
-        elif val.startswith('http'):
-            ret.append(get_pyvers_name(val, cuda))
-        else:
-            ret.append(key + "==" + val)
-        variant = variant // len(get_package(packages, key, cuda))
+        pkg_list_len = len(get_package_list(package_data, key, cuda))
+        idx = variant % pkg_list_len
+        val = get_package_list(package_data, key, cuda)[idx]
+        pkg_str = key
+        if isinstance(val, str):
+            if val.startswith('http'):
+                pkg_str = get_pyvers_name(val, cuda)
+            else:
+                pkg_str = key + "==" + val
+        elif isinstance(val, tuple):
+            version, url = val
+            pkg_str = key + '==' + version
+            if url and args.include_link:
+                pkg_str = pkg_str + ' -f ' + url
+        ret.append(pkg_str)
+        variant = variant // pkg_list_len
     # add all remaining used packages with default versions
-    additional = [v for v in use if v not in packages.keys()]
+    additional = [v for v in use if v not in package_data.keys()]
+    return ret + additional
     return " ".join(ret + additional)
 
 def get_remove_string(use, cuda):
     # Remove only these which version we want to change
     to_remove = []
-    for key in packages.keys():
+    for key in package_data.keys():
         if key not in use:
             continue
-        if len(get_package(packages, key, cuda)) > 1:
+        pkg_list_len = len(get_package_list(package_data, key, cuda))
+        if pkg_list_len > 1:
             to_remove.append(key)
     return " ".join(to_remove)
 
 def cal_num_of_configs(use, cuda):
     ret = 1
-    for key in packages.keys():
+    for key in package_data.keys():
         if key not in use:
             continue
-        ret *= len(get_package(packages, key, cuda))
+        ret *= len(get_package_list(package_data, key, cuda))
     return ret
 
 def get_all_strings(use, cuda):
     ret = []
-    for key in packages.keys():
+    for key in package_data.keys():
         if key not in use:
             continue
-        for val in get_package(packages, key, cuda):
+        for val in get_package_list(package_data, key, cuda):
             if val is None:
                 ret.append(key)
             elif val.startswith('http'):
@@ -121,7 +141,7 @@ def get_all_strings(use, cuda):
             else:
                 ret.append(key + "==" + val)
     # add all remaining used packages with default versions
-    additional = [v for v in use if v not in packages.keys()]
+    additional = [v for v in use if v not in package_data.keys()]
     return " ".join(ret + additional)
 
 def main():

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -107,7 +107,6 @@ def get_install_string(variant, use, cuda):
     # add all remaining used packages with default versions
     additional = [v for v in use if v not in package_data.keys()]
     return ret + additional
-    return " ".join(ret + additional)
 
 def get_remove_string(use, cuda):
     # Remove only these which version we want to change
@@ -118,7 +117,7 @@ def get_remove_string(use, cuda):
         pkg_list_len = len(get_package_list(package_data, key, cuda))
         if pkg_list_len > 1:
             to_remove.append(key)
-    return " ".join(to_remove)
+    return to_remove
 
 def cal_num_of_configs(use, cuda):
     ret = 1
@@ -142,7 +141,7 @@ def get_all_strings(use, cuda):
                 ret.append(key + "==" + val)
     # add all remaining used packages with default versions
     additional = [v for v in use if v not in package_data.keys()]
-    return " ".join(ret + additional)
+    return ret + additional
 
 def main():
     global args

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -47,8 +47,8 @@ for i in `seq 0 $last_config_index`; do
         # install packages
         eval "packages=(`$topdir/qa/setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION} | tr -d '[],'`)"
         eval "packages_with_link=(`$topdir/qa/setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION} --include-link | tr -d '[],'`)"
-        last_j=`expr ${#packages[@]} - 1`
-        for j in `seq 0 $last_j`; do
+        number_of_packages=${#packages[@]}
+        for j in $(seq 0 $((${number_of_packages}-1))); do
             pkg="${packages[${j}]}"
             pkg_with_link="${packages_with_link[${j}]}"
 
@@ -59,15 +59,15 @@ for i in `seq 0 $last_config_index`; do
                 pip uninstall -y nvidia-dali-tf-plugin || true
                 pip install /opt/dali/nvidia-dali-tf-plugin*.tar.gz
             fi
-        fi
+        done
         # test code
         test_body
 
         # remove packages
-        eval "remove=`$topdir/qa/setup_packages.py -r  -u $pip_packages --cuda ${CUDA_VERSION} | tr -d '[],'`)"
+        eval "remove=(`$topdir/qa/setup_packages.py -r  -u $pip_packages --cuda ${CUDA_VERSION} | tr -d '[],'`)"
         for pkg in "${packages[@]}"; do
             pip uninstall -y "$pkg"
-        fi
+        done
         ${epilog[variant]}
     done
 done


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
Reduce QA tests are redownloading pytorch, because it was specified from a url

#### What happened in this PR?
Modify QA test utilities to first try to download pytorch from downloaded pip packages first and only if that doesn't work try to fetch it from the url

**JIRA TASK**: [DALI-XXXX]