### PR TITLE
Add layout handling to Transpose op

### DIFF
--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
@@ -144,6 +144,7 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
         }
         auto& out = ws.Output<CPUBackend>(2);
         out.set_type(TypeInfo::Create<uint8_t>());
+        out.SetLayout("HWC");
         out.Resize({info->heights[0], info->widths[0], nchannels});
         auto *output_data = out.mutable_data<uint8_t>();
 

--- a/dali/pipeline/operators/transpose/transpose.cc
+++ b/dali/pipeline/operators/transpose/transpose.cc
@@ -23,5 +23,13 @@ DALI_SCHEMA(Transpose)
   .AllowSequences()
   .AddArg("perm",
       R"code(Permutation of the dimensions of the input (e.g. [2, 0, 1]).)code",
-      DALI_INT_VEC);
+      DALI_INT_VEC)
+  .AddOptionalArg("transpose_layout",
+      R"code(When set to true, the output data layout will be transposed according to perm.
+Otherwise, the input layout is copied to the output)code",
+      true)
+  .AddOptionalArg("output_layout",
+      R"code(If provided, sets output data layout, overriding any `transpose_layout` setting)code",
+      "");
+
 }  // namespace dali

--- a/dali/pipeline/operators/transpose/transpose.cu
+++ b/dali/pipeline/operators/transpose/transpose.cu
@@ -183,7 +183,7 @@ void Transpose<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
       "cuTT transpose supports only [1-2-4-8] bytes types.");
 
   output.set_type(itype);
-  // output.SetLayout(DALI_UNKNOWN);
+  output.SetLayout(output_layout_);
 
   auto input_shape = input.tensor_shape(0);
   DALI_ENFORCE(input_shape.size() == static_cast<int>(perm_.size()),

--- a/dali/pipeline/operators/transpose/transpose.h
+++ b/dali/pipeline/operators/transpose/transpose.h
@@ -24,6 +24,21 @@
 
 namespace dali {
 
+namespace detail {
+
+template <typename T>
+T Permute(const T& in, const std::vector<int>& permutation) {
+  T out = in;
+  for (size_t i = 0; i < permutation.size(); i++) {
+    auto idx = permutation[i];
+    out[i] = in[idx];
+  }
+  return out;
+}
+
+}  // namespace detail
+
+
 template <typename Backend>
 class Transpose : public Operator<Backend> {
  public:
@@ -57,9 +72,7 @@ class Transpose : public Operator<Backend> {
     if (!output_layout_arg_.empty()) {
       output_layout_ = output_layout_arg_;
     } else if (transpose_layout_) {
-      for (int d = 0; d < in_layout.ndim(); d++) {
-        output_layout_[d] = in_layout[perm_[d]];
-      }
+      output_layout_ = detail::Permute(in_layout, perm_);
     }
     return false;
   }

--- a/dali/pipeline/operators/transpose/transpose.h
+++ b/dali/pipeline/operators/transpose/transpose.h
@@ -52,7 +52,7 @@ class Transpose : public Operator<Backend> {
         "Providing an empty output layout is not supported");
     }
 
-    DALI_ENFORCE(
+    auto check_permutation =
       [](std::vector<int> perm) {
         std::sort(perm.begin(), perm.end());
         for (int i = 0; i < static_cast<int>(perm.size()); ++i) {
@@ -61,8 +61,11 @@ class Transpose : public Operator<Backend> {
           }
         }
         return true;
-      }(perm_), "Invalid permutation: sorted `perm` is not equal to [0, ..., n-1].");
-    }
+      };
+
+    DALI_ENFORCE(check_permutation(perm_),
+      "Invalid permutation: sorted `perm` is not equal to [0, ..., n-1].");
+  }
 
   ~Transpose() override;
 
@@ -73,11 +76,11 @@ class Transpose : public Operator<Backend> {
                  const workspace_t<Backend> &ws) override {
     const auto &input = ws.template Input<Backend>(0);
     auto in_layout = input.GetLayout();
-    auto sample_ndims = input.shape().sample_dim();
-    DALI_ENFORCE(in_layout.ndim() == sample_ndims || in_layout.empty());
+    auto sample_ndim = input.shape().sample_dim();
+    DALI_ENFORCE(in_layout.ndim() == sample_ndim || in_layout.empty());
     output_layout_ = in_layout;
     if (!output_layout_arg_.empty()) {
-      DALI_ENFORCE(output_layout_.ndim() == sample_ndims);
+      DALI_ENFORCE(output_layout_.ndim() == sample_ndim);
       output_layout_ = output_layout_arg_;
     } else if (transpose_layout_ && !in_layout.empty()) {
       output_layout_ = detail::Permute(in_layout, perm_);

--- a/dali/test/python/test_operator_transpose.py
+++ b/dali/test/python/test_operator_transpose.py
@@ -41,11 +41,11 @@ class TransposePipeline(Pipeline):
             self.transpose = ops.Transpose(device = self.device,
                                         perm = permutation,
                                         transpose_layout = transpose_layout,
-                                        out_layout_arg = out_layout_arg)
+                                        output_layout = out_layout_arg)
         else:
             self.transpose = ops.Transpose(device = self.device,
-                                        perm = permutation,
-                                        transpose_layout = transpose_layout)
+                                           perm = permutation,
+                                           transpose_layout = transpose_layout)
 
     def define_graph(self):
         self.data = self.inputs()
@@ -81,8 +81,8 @@ class PythonOpPipeline(Pipeline):
 def check_transpose_vs_numpy(device, batch_size, shape):
     eii1 = RandomDataIterator(batch_size, shape=shape)
     eii2 = RandomDataIterator(batch_size, shape=shape)
-    compare_pipelines(TransposePipeline(device, batch_size, types.NHWC, iter(eii1)),
-                      PythonOpPipeline(transpose_func, batch_size, types.NHWC, iter(eii2)),
+    compare_pipelines(TransposePipeline(device, batch_size, "HWC", iter(eii1)),
+                      PythonOpPipeline(transpose_func, batch_size, "HWC", iter(eii2)),
                       batch_size=batch_size, N_iterations=10)
 
 def test_transpose_vs_numpy():
@@ -95,7 +95,10 @@ def test_transpose_vs_numpy():
 def check_transpose_layout(device, batch_size, shape, in_layout, permutation,
                            transpose_layout, out_layout_arg):
     eii = RandomDataIterator(batch_size, shape=shape)
-    pipe = TransposePipeline(device, batch_size, types.NHWC, iter(eii))
+    pipe = TransposePipeline(device, batch_size, "HWC", iter(eii),
+                             permutation=permutation,
+                             transpose_layout=transpose_layout,
+                             out_layout_arg=out_layout_arg)
     pipe.build()
     out = pipe.run()
 
@@ -103,13 +106,11 @@ def check_transpose_layout(device, batch_size, shape, in_layout, permutation,
     if out_layout_arg:
         expected_out_layout = out_layout_arg
     elif transpose_layout:
-        expected_out_layout = str([list(in_layout)[d] for d in permutation])
+        expected_out_layout = "".join([list(in_layout)[d] for d in permutation])
     else:
         expected_out_layout = in_layout
 
-    print('expected_out_layout is {}'.format(expected_out_layout))
-    # TODO(janton): check layout
-    # assert (actual_layout == expected_out_layout)
+    assert(out[0].layout() == expected_out_layout)
 
 def test_transpose_layout():
     batch_size = 3
@@ -121,6 +122,7 @@ def test_transpose_layout():
              ((2, 0, 1), True, "CHW"),
              ((2, 0, 1), False, "CHW"),
              ((1, 0, 2), False, None),
+             ((1, 0, 2), True, None),
              ((1, 0, 2), True, "HWC")]:
             yield check_transpose_layout, device, batch_size, shape, \
                 in_layout, permutation, transpose_layout, out_layout_arg

--- a/dali/test/python/test_operator_transpose.py
+++ b/dali/test/python/test_operator_transpose.py
@@ -37,7 +37,8 @@ class TransposePipeline(Pipeline):
         self.iterator = iterator
         self.inputs = ops.ExternalSource()
         self.transpose = ops.Transpose(device = self.device,
-                                       perm = (1, 0, 2))
+                                       perm = (1, 0, 2),
+                                       transpose_layout = False)
 
     def define_graph(self):
         self.data = self.inputs()

--- a/dali/test/python/test_operator_transpose.py
+++ b/dali/test/python/test_operator_transpose.py
@@ -39,9 +39,9 @@ class TransposePipeline(Pipeline):
         self.inputs = ops.ExternalSource()
         if out_layout_arg:
             self.transpose = ops.Transpose(device = self.device,
-                                        perm = permutation,
-                                        transpose_layout = transpose_layout,
-                                        output_layout = out_layout_arg)
+                                           perm = permutation,
+                                           transpose_layout = transpose_layout,
+                                           output_layout = out_layout_arg)
         else:
             self.transpose = ops.Transpose(device = self.device,
                                            perm = permutation,


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- Transpose operator did not provide an output layout

#### What happened in this PR?
- Added layout handling logic in Transpose operator:
  1. By default, the output layout is generated by transposing input_layout
  2. If `transpose_layout=False`, output layout is selected to be the same as input layout
  3. If `output_layout` argument is provided, it overrides any other settings

**JIRA TASK**: [DALI-XXXX]