### PR TITLE
GTest naming in STYLE_GUIDE

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -27,9 +27,19 @@ and introduces ugly code like `foo(&bar)` or `(*buf)[i]`.
 
 ### Test suites naming guide
 
-We use GTest for most of testing code in DALI. TestSuites names should start with a capital letter and end with `Test`. 
+We use GTest for most of testing code in DALI. Names of TestSuites should start with a capital letter and end with `Test`. 
 Additionally, both suite and case name mustn't contain underscores (`_`). 
 For details on the latter, cf. [GTest FAQ](https://github.com/google/googletest/blob/master/googletest/docs/faq.md#why-should-test-suite-names-and-test-names-not-contain-underscore).
+Examples:
+```
+TEST(MatTest, IdentityMatrix) {}  // OK
+TEST_F(PregnancyTest, AlwaysPositive) {}  // OK
+TYPED_TEST(CannyOperatorTest, EmptyImage) {}  // OK
+TYPED_TEST_SUITE(Skittles, InTheSky);  // Wrong! Should be "SkittlesTest"
+INSTANTIATE_TYPED_TEST_SUITE_P(Integral, HelloTest, IntegralTypes);  // OK. "Integral" is a prefix for type-parameterized test suite
+
+```
+
 
 ## DALI specific rules
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -25,6 +25,12 @@ Parameters can be passed as non-const lvalue reference. [Google rule](https://go
 prohibits semantically valid restriction of not passing null pointer
 and introduces ugly code like `foo(&bar)` or `(*buf)[i]`.
 
+### Test suites naming guide
+
+We use GTest for most of testing code in DALI. TestSuites names should start with a capital letter and end with `Test`. 
+Additionally, both suite and case name mustn't contain underscores (`_`). 
+For details on the latter, cf. [GTest FAQ](https://github.com/google/googletest/blob/master/googletest/docs/faq.md#why-should-test-suite-names-and-test-names-not-contain-underscore).
+
 ## DALI specific rules
 
 ### DALI Kernels argument order


### PR DESCRIPTION
Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

#### Why we need this PR?
I suggest adding a naming rule, that enforces ending names of TestSuites in GTest with `*Test`.

The rationale is that GTest macro-magic produces class for every case, which is a concatenated suite and case name, e.g.
```
TEST(SuiteName, CaseName)   ->   class SuiteName_CaseName
```
If there's a `TEST(Skittles, OnTheGround)`, the resulting class name doesn't imply, that this is in fact a test. Furthermore, after GTest's FAQ, I added the requirement, that the names shouldn't contain underscore, for reasons explained there.