### PR TITLE
Enhance Slice API

### DIFF
--- a/dali/operators/crop/slice.cc
+++ b/dali/operators/crop/slice.cc
@@ -44,7 +44,7 @@ void Slice<CPUBackend>::DataDependentSetup(SampleWorkspace &ws) {
   auto data_idx = ws.data_idx();
   auto crop_window_generator = SliceAttr::GetCropWindowGenerator(data_idx);
   DALI_ENFORCE(crop_window_generator);
-  CropWindow win = crop_window_generator(images.shape());
+  CropWindow win = crop_window_generator(images.shape(), InputLayout(ws, 0));
   slice_shapes_[data_idx] = std::vector<int64_t>(win.shape.begin(), win.shape.end());
   slice_anchors_[data_idx] = std::vector<int64_t>(win.anchor.begin(), win.anchor.end());
 }

--- a/dali/operators/crop/slice.cc
+++ b/dali/operators/crop/slice.cc
@@ -35,6 +35,7 @@ DALI_SCHEMA(Slice)
       R"code(The color space of input and output image)code",
       DALI_RGB, false)
     .AddParent("SliceBase")
+    .AddParent("SliceAttr")
     .InputLayout(0, { "HW", "HWC", "DHWC" });
 
 template <>

--- a/dali/operators/crop/slice.cc
+++ b/dali/operators/crop/slice.cc
@@ -39,16 +39,14 @@ DALI_SCHEMA(Slice)
 
 template <>
 void Slice<CPUBackend>::DataDependentSetup(SampleWorkspace &ws) {
+  SliceAttr::ProcessArguments(ws);
   const auto &images = ws.Input<CPUBackend>(kImagesInId);
-  TensorLayout image_layout = InputLayout(ws, kImagesInId);
-  const auto &anchor_tensor = ws.Input<CPUBackend>(kAnchorsInId);
-  const auto &slice_shape_tensor = ws.Input<CPUBackend>(kSliceShapesInId);
-  const auto img_shape = images.shape();
-  const auto args_ndim = anchor_tensor.shape()[0];
-  const float* anchor_norm = anchor_tensor.template data<float>();
-  const float* slice_shape_norm = slice_shape_tensor.template data<float>();
-  SetupSample(ws.data_idx(), image_layout, img_shape, args_ndim,
-              anchor_norm, slice_shape_norm);
+  auto data_idx = ws.data_idx();
+  auto crop_window_generator = SliceAttr::GetCropWindowGenerator(data_idx);
+  DALI_ENFORCE(crop_window_generator);
+  CropWindow win = crop_window_generator(images.shape());
+  slice_shapes_[data_idx] = std::vector<int64_t>(win.shape.begin(), win.shape.end());
+  slice_anchors_[data_idx] = std::vector<int64_t>(win.anchor.begin(), win.anchor.end());
 }
 
 template <>

--- a/dali/operators/crop/slice.cc
+++ b/dali/operators/crop/slice.cc
@@ -41,10 +41,10 @@ coordinates and `WH` order for the slice arguments.)code")
 
 template <>
 void Slice<CPUBackend>::DataDependentSetup(SampleWorkspace &ws) {
-  SliceAttr::ProcessArguments(ws);
+  slice_attr_.ProcessArguments(ws);
   const auto &images = ws.Input<CPUBackend>(kImagesInId);
   auto data_idx = ws.data_idx();
-  auto crop_window_generator = SliceAttr::GetCropWindowGenerator(data_idx);
+  auto crop_window_generator = slice_attr_.GetCropWindowGenerator(data_idx);
   DALI_ENFORCE(crop_window_generator);
   CropWindow win = crop_window_generator(images.shape(), InputLayout(ws, 0));
   slice_shapes_[data_idx] = std::vector<int64_t>(win.shape.begin(), win.shape.end());

--- a/dali/operators/crop/slice.cc
+++ b/dali/operators/crop/slice.cc
@@ -35,7 +35,6 @@ DALI_SCHEMA(Slice)
       R"code(The color space of input and output image)code",
       DALI_RGB, false)
     .AddParent("SliceBase")
-    .AddParent("SliceAttr")
     .InputLayout(0, { "HW", "HWC", "DHWC" });
 
 template <>

--- a/dali/operators/crop/slice.cc
+++ b/dali/operators/crop/slice.cc
@@ -19,15 +19,16 @@ namespace dali {
 DALI_SCHEMA(Slice)
     .DocStr(
         R"code(Extract a subtensor or `slice` with a given shape and anchor.
- Inputs must be supplied as 3 separate tensors in a specific order: `data`
- containing input data, `anchor` containing normalize coordinates for the
- starting point of the slice (x0, x1, x2, ...), and `shape` containing the normalized
- dimensions of the slice (s0, s1, s2, ...). Both `anchor` and `shape` coordinates
- must be in the interval [0.0, 1.0] and should have as many dimensions as the input
- data. For compatibility with the previous implementation of Slice, `anchor` and
- `slice` can be specified in format (x, y) and (w, h) respectively for images.
- This way of specifying the slice arguments is deprecated and shall be removed in
- future versions of DALI.)code")
+Inputs must be supplied as 3 separate tensors in a specific order: `data`
+containing input data, `anchor` containing either normalized or absolute coordinates
+(depending on the value of `normalized_anchor`) for the starting point of the
+slice (x0, x1, x2, ...), and `shape` containing either normalized or absolute coordinates
+(depending on the value of `normalized_shape`) for the dimensions of the slice
+(s0, s1, s2, ...). Both `anchor` and `shape` coordinates must be within the interval
+[0.0, 1.0] for normalized coordinates, or within the image shape for absolute
+coordinates. Both `anchor` and `shape` inputs will provide as many dimensions as specified
+with arguments `dim_names` or `dims`. By default `Slice` operator uses normalized
+coordinates and `WH` order for the slice arguments.)code")
     .NumInput(3)
     .NumOutput(1)
     .AllowSequences()

--- a/dali/operators/crop/slice.cc
+++ b/dali/operators/crop/slice.cc
@@ -36,8 +36,7 @@ coordinates and `WH` order for the slice arguments.)code")
       R"code(The color space of input and output image)code",
       DALI_RGB, false)
     .AddParent("SliceBase")
-    .AddParent("SliceAttr")
-    .InputLayout(0, { "HW", "HWC", "DHWC" });
+    .AddParent("SliceAttr");
 
 template <>
 void Slice<CPUBackend>::DataDependentSetup(SampleWorkspace &ws) {

--- a/dali/operators/crop/slice.cc
+++ b/dali/operators/crop/slice.cc
@@ -27,7 +27,7 @@ slice (x0, x1, x2, ...), and `shape` containing either normalized or absolute co
 (s0, s1, s2, ...). Both `anchor` and `shape` coordinates must be within the interval
 [0.0, 1.0] for normalized coordinates, or within the image shape for absolute
 coordinates. Both `anchor` and `shape` inputs will provide as many dimensions as specified
-with arguments `dim_names` or `dims`. By default `Slice` operator uses normalized
+with arguments `axis_names` or `axes`. By default `Slice` operator uses normalized
 coordinates and `WH` order for the slice arguments.)code")
     .NumInput(3)
     .NumOutput(1)
@@ -45,7 +45,10 @@ void Slice<CPUBackend>::DataDependentSetup(SampleWorkspace &ws) {
   auto data_idx = ws.data_idx();
   auto crop_window_generator = slice_attr_.GetCropWindowGenerator(data_idx);
   DALI_ENFORCE(crop_window_generator);
-  CropWindow win = crop_window_generator(images.shape(), InputLayout(ws, 0));
+  auto layout = InputLayout(ws, 0);
+  if (layout.empty())
+    layout = GetDefaultLayout(images.shape().size());
+  CropWindow win = crop_window_generator(images.shape(), layout);
   slice_shapes_[data_idx] = std::vector<int64_t>(win.shape.begin(), win.shape.end());
   slice_anchors_[data_idx] = std::vector<int64_t>(win.anchor.begin(), win.anchor.end());
 }

--- a/dali/operators/crop/slice.cu
+++ b/dali/operators/crop/slice.cu
@@ -25,7 +25,7 @@ void Slice<GPUBackend>::DataDependentSetup(DeviceWorkspace &ws) {
     const auto img_shape = images.tensor_shape(data_idx);
     auto crop_window_generator = SliceAttr::GetCropWindowGenerator(data_idx);
     DALI_ENFORCE(crop_window_generator);
-    CropWindow win = crop_window_generator(img_shape);
+    CropWindow win = crop_window_generator(img_shape, InputLayout(ws, 0));
     slice_shapes_[data_idx] = std::vector<int64_t>(win.shape.begin(), win.shape.end());
     slice_anchors_[data_idx] = std::vector<int64_t>(win.anchor.begin(), win.anchor.end());
   }

--- a/dali/operators/crop/slice.cu
+++ b/dali/operators/crop/slice.cu
@@ -12,30 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <utility>
+#include <vector>
 #include "dali/operators/crop/slice.h"
 
 namespace dali {
 
 template <>
 void Slice<GPUBackend>::DataDependentSetup(DeviceWorkspace &ws) {
+  SliceAttr::ProcessArguments(ws);
   const auto &images = ws.Input<GPUBackend>(kImagesInId);
-  TensorLayout image_layout = InputLayout(ws, kImagesInId);
-  const auto &anchor_tensor = ws.Input<CPUBackend>(kAnchorsInId);
-  const auto &slice_shape_tensor = ws.Input<CPUBackend>(kSliceShapesInId);
-  for (int sample_idx = 0; sample_idx < batch_size_; sample_idx++) {
-    const auto img_shape = images.tensor_shape(sample_idx);
-    const auto args_ndims = anchor_tensor.tensor_shape(sample_idx)[0];
-    const float* anchor_norm = anchor_tensor.tensor<float>(sample_idx);
-    const float* slice_shape_norm = slice_shape_tensor.tensor<float>(sample_idx);
-    SetupSample(sample_idx, image_layout, img_shape, args_ndims,
-                anchor_norm, slice_shape_norm);
+  for (int data_idx = 0; data_idx < batch_size_; data_idx++) {
+    const auto img_shape = images.tensor_shape(data_idx);
+    auto crop_window_generator = SliceAttr::GetCropWindowGenerator(data_idx);
+    DALI_ENFORCE(crop_window_generator);
+    CropWindow win = crop_window_generator(img_shape);
+    slice_shapes_[data_idx] = std::vector<int64_t>(win.shape.begin(), win.shape.end());
+    slice_anchors_[data_idx] = std::vector<int64_t>(win.anchor.begin(), win.anchor.end());
   }
-}
-
-template <>
-void Slice<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
-  SliceBase<GPUBackend>::RunImpl(ws);
 }
 
 DALI_REGISTER_OPERATOR(Slice, Slice<GPUBackend>, GPU);

--- a/dali/operators/crop/slice.cu
+++ b/dali/operators/crop/slice.cu
@@ -25,7 +25,10 @@ void Slice<GPUBackend>::DataDependentSetup(DeviceWorkspace &ws) {
     const auto img_shape = images.tensor_shape(data_idx);
     auto crop_window_generator = slice_attr_.GetCropWindowGenerator(data_idx);
     DALI_ENFORCE(crop_window_generator);
-    CropWindow win = crop_window_generator(img_shape, InputLayout(ws, 0));
+    auto layout = InputLayout(ws, 0);
+    if (layout.empty())
+      layout = GetDefaultLayout(img_shape.size());
+    CropWindow win = crop_window_generator(img_shape, layout);
     slice_shapes_[data_idx] = std::vector<int64_t>(win.shape.begin(), win.shape.end());
     slice_anchors_[data_idx] = std::vector<int64_t>(win.anchor.begin(), win.anchor.end());
   }

--- a/dali/operators/crop/slice.cu
+++ b/dali/operators/crop/slice.cu
@@ -19,11 +19,11 @@ namespace dali {
 
 template <>
 void Slice<GPUBackend>::DataDependentSetup(DeviceWorkspace &ws) {
-  SliceAttr::ProcessArguments(ws);
+  slice_attr_.ProcessArguments(ws);
   const auto &images = ws.Input<GPUBackend>(kImagesInId);
   for (int data_idx = 0; data_idx < batch_size_; data_idx++) {
     const auto img_shape = images.tensor_shape(data_idx);
-    auto crop_window_generator = SliceAttr::GetCropWindowGenerator(data_idx);
+    auto crop_window_generator = slice_attr_.GetCropWindowGenerator(data_idx);
     DALI_ENFORCE(crop_window_generator);
     CropWindow win = crop_window_generator(img_shape, InputLayout(ws, 0));
     slice_shapes_[data_idx] = std::vector<int64_t>(win.shape.begin(), win.shape.end());

--- a/dali/operators/crop/slice.h
+++ b/dali/operators/crop/slice.h
@@ -19,6 +19,7 @@
 #include <vector>
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
+#include "dali/operators/crop/slice_attr.h"
 #include "dali/operators/crop/slice_base.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
@@ -26,10 +27,11 @@
 namespace dali {
 
 template <typename Backend>
-class Slice : public SliceBase<Backend> {
+class Slice : public SliceBase<Backend>, protected SliceAttr {
  public:
   explicit inline Slice(const OpSpec &spec)
-    : SliceBase<Backend>(spec) {}
+    : SliceBase<Backend>(spec)
+    , SliceAttr(spec) {}
 
  protected:
   using SliceBase<Backend>::input_type_;
@@ -37,7 +39,9 @@ class Slice : public SliceBase<Backend> {
   using SliceBase<Backend>::slice_anchors_;
   using SliceBase<Backend>::slice_shapes_;
 
-  void RunImpl(Workspace<Backend> &ws) override;
+  void RunImpl(Workspace<Backend> &ws) override {
+    SliceBase<Backend>::RunImpl(ws);
+  }
 
   void SetupSharedSampleParams(Workspace<Backend> &ws) override {
     DALI_ENFORCE(ws.NumInput() == 3,
@@ -46,57 +50,6 @@ class Slice : public SliceBase<Backend> {
   }
 
   void DataDependentSetup(Workspace<Backend> &ws) override;
-
-  void SetupSample(int data_idx,
-                   TensorLayout layout,
-                   const TensorShape<> &img_shape,
-                   const int64_t args_ndims,
-                   const float *anchor_norm,
-                   const float *slice_dims_norm) {
-    auto &anchor = slice_anchors_[data_idx];
-    anchor = std::vector<int64_t>(img_shape.size(), 0);
-    auto &slice_shape = slice_shapes_[data_idx];
-    slice_shape = std::vector<int64_t>(img_shape.begin(), img_shape.end());
-
-    // If only two dimensions are provided (old API style)
-    // we calculate the position of the dimensions based on
-    // layout.
-    if (args_ndims == 2 && img_shape.size() > 2) {
-      int i_h = layout.find('H');
-      int i_w = layout.find('W');
-      DALI_ENFORCE(i_h >= 0, "The layout \"" + layout.str() +
-                   "\" does not define height dimension (H)");
-      DALI_ENFORCE(i_w >= 0, "The layout \"" + layout.str() +
-                   "\" does not define width dimension (W)");
-      for (int d = 0; d < img_shape.size(); d++) {
-        anchor[d] = 0;
-        slice_shape[d] = img_shape[d];
-      }
-
-      // TODO(janton): In Slice API we receive coordinates in XY format
-      anchor[i_w] = anchor_norm[0] * img_shape[i_w];
-      anchor[i_h] = anchor_norm[1] * img_shape[i_h];
-
-      float slice_end_norm_w = anchor_norm[0] + slice_dims_norm[0];
-      slice_shape[i_w] = slice_end_norm_w * img_shape[i_w] - anchor[i_w];
-
-      float slice_end_norm_h = anchor_norm[1] + slice_dims_norm[1];
-      slice_shape[i_h] = slice_end_norm_h * img_shape[i_h] - anchor[i_h];
-
-    } else {
-      // General case expects same number of dimensions in the
-      // slice arguments as in the input image
-
-      // To decrease floating point error, first calculate the end of the
-      // bounding box and then calculate the shape
-      for (int d = 0; d < img_shape.size(); d++) {
-        anchor[d] = anchor_norm[d] * img_shape[d];
-        float slice_end_norm = anchor_norm[d] + slice_dims_norm[d];
-        int64_t slice_end = slice_end_norm * img_shape[d];
-        slice_shape[d] = slice_end - anchor[d];
-      }
-    }
-  }
 
  private:
   static const int kImagesInId = 0;

--- a/dali/operators/crop/slice.h
+++ b/dali/operators/crop/slice.h
@@ -27,11 +27,11 @@
 namespace dali {
 
 template <typename Backend>
-class Slice : public SliceBase<Backend>, protected SliceAttr {
+class Slice : public SliceBase<Backend> {
  public:
   explicit inline Slice(const OpSpec &spec)
     : SliceBase<Backend>(spec)
-    , SliceAttr(spec) {}
+    , slice_attr_(spec) {}
 
  protected:
   using SliceBase<Backend>::input_type_;
@@ -52,6 +52,8 @@ class Slice : public SliceBase<Backend>, protected SliceAttr {
   void DataDependentSetup(Workspace<Backend> &ws) override;
 
  private:
+  SliceAttr slice_attr_;
+
   static const int kImagesInId = 0;
   static const int kAnchorsInId = 1;
   static const int kSliceShapesInId = 2;

--- a/dali/operators/crop/slice.h
+++ b/dali/operators/crop/slice.h
@@ -52,6 +52,19 @@ class Slice : public SliceBase<Backend> {
   void DataDependentSetup(Workspace<Backend> &ws) override;
 
  private:
+  inline TensorLayout GetDefaultLayout(int ndims) {
+    switch (ndims) {
+      case 2:
+        return "HW";
+      case 3:
+        return "HWC";
+      case 4:
+        return "DHWC";
+      default:
+        return "";
+    }
+  }
+
   SliceAttr slice_attr_;
 
   static const int kImagesInId = 0;

--- a/dali/operators/crop/slice_attr.cc
+++ b/dali/operators/crop/slice_attr.cc
@@ -19,12 +19,12 @@ namespace dali {
 
 DALI_SCHEMA(SliceAttr)
     .DocStr(R"code(Slice attributes placeholder)code")
-    .AddOptionalArg("dims",
+    .AddOptionalArg("axes",
         R"code(Order of dimensions used for anchor and shape slice inputs, as dimension indexes)code",
         std::vector<int>{1, 0})
-    .AddOptionalArg("dim_names",
+    .AddOptionalArg("axis_names",
         R"code(Order of dimensions used for anchor and shape slice inputs, as described in layout.
-If provided, `dim_names` takes higher priority than `dims`)code",
+If provided, `axis_names` takes higher priority than `axes`)code",
         "WH")
     .AddOptionalArg("normalized_anchor",
         R"code(Whether or not the `anchor` input should be interpreted as normalized (range [0.0, 1.0])

--- a/dali/operators/crop/slice_attr.cc
+++ b/dali/operators/crop/slice_attr.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <vector>
-#include "dali/pipeline/operators/crop/slice_attr.h"
+#include "dali/operators/crop/slice_attr.h"
 
 namespace dali {
 

--- a/dali/operators/crop/slice_attr.h
+++ b/dali/operators/crop/slice_attr.h
@@ -89,7 +89,7 @@ class SliceAttr {
                               const float *slice_anchor_data,
                               const float *slice_shape_data) {
     crop_window_generators_[data_idx] =
-      [this, slice_anchor_data, slice_shape_data](const kernels::TensorShape<> &shape,
+      [this, slice_anchor_data, slice_shape_data](const TensorShape<> &shape,
                                                   const TensorLayout& shape_layout) {
         CropWindow slice;
         slice.anchor = std::vector<int64_t>(shape.size(), 0);
@@ -127,8 +127,8 @@ class SliceAttr {
       };
   }
 
-  void VerifyArgsShape(const kernels::TensorShape<>& crop_anchor_shape,
-                       const kernels::TensorShape<>& crop_shape_shape) {
+  void VerifyArgsShape(const TensorShape<>& crop_anchor_shape,
+                       const TensorShape<>& crop_shape_shape) {
     DALI_ENFORCE(crop_anchor_shape == crop_shape_shape);
     size_t args_size = volume(crop_anchor_shape);
     auto dims_size = !dim_names_.empty() ? dim_names_.size() : dims_.size();

--- a/dali/operators/crop/slice_attr.h
+++ b/dali/operators/crop/slice_attr.h
@@ -51,7 +51,6 @@ class SliceAttr {
     DALI_ENFORCE(ws.NumInput() == 3,
       "Expected 3 inputs. Received: " + std::to_string(ws.NumInput()));
     for (std::size_t data_idx = 0; data_idx < batch_size__; data_idx++) {
-      const auto &images = ws.Input<CPUBackend>(0, data_idx);
       const auto &crop_anchor = ws.Input<CPUBackend>(1, data_idx);
       const auto &crop_shape = ws.Input<CPUBackend>(2, data_idx);
       VerifyArgsShape(crop_anchor.shape(), crop_shape.shape());
@@ -62,7 +61,6 @@ class SliceAttr {
   void ProcessArguments(DeviceWorkspace &ws) {
     DALI_ENFORCE(ws.NumInput() == 3,
       "Expected 3 inputs. Received: " + std::to_string(ws.NumInput()));
-    const auto &images = ws.Input<GPUBackend>(0);
     const auto &crop_anchor = ws.Input<CPUBackend>(1);
     const auto &crop_shape = ws.Input<CPUBackend>(2);
     for (std::size_t data_idx = 0; data_idx < batch_size__; data_idx++) {
@@ -75,7 +73,6 @@ class SliceAttr {
   void ProcessArguments(const SampleWorkspace &ws) {
     DALI_ENFORCE(ws.NumInput() == 3,
       "Expected 3 inputs. Received: " + std::to_string(ws.NumInput()));
-    const auto &images = ws.Input<CPUBackend>(0);
     const auto &crop_anchor = ws.Input<CPUBackend>(1);
     const auto &crop_shape = ws.Input<CPUBackend>(2);
     VerifyArgsShape(crop_anchor.shape(), crop_shape.shape());

--- a/dali/operators/crop/slice_attr.h
+++ b/dali/operators/crop/slice_attr.h
@@ -28,7 +28,7 @@
 namespace dali {
 
 class SliceAttr {
- protected:
+ public:
   explicit inline SliceAttr(const OpSpec &spec)
       : batch_size__(spec.GetArgument<int>("batch_size"))
       , normalized_anchor_(spec.GetArgument<bool>("normalized_anchor"))
@@ -139,6 +139,7 @@ class SliceAttr {
       make_string("Unexpected number of arguments", args_size, "vs", dims_size));
   }
 
+ private:
   size_t batch_size__;
   bool normalized_anchor_, normalized_shape_;
   std::vector<CropWindowGenerator> crop_window_generators_;

--- a/dali/operators/decoder/host/fused/host_decoder_slice.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_slice.cc
@@ -25,7 +25,7 @@ namespace dali {
 
 HostDecoderSlice::HostDecoderSlice(const OpSpec &spec)
   : HostDecoder(spec)
-  , SliceAttr(spec) {
+  , slice_attr_(spec) {
 }
 
 DALI_SCHEMA(HostDecoderSlice)

--- a/dali/operators/decoder/host/fused/host_decoder_slice.h
+++ b/dali/operators/decoder/host/fused/host_decoder_slice.h
@@ -22,7 +22,7 @@
 
 namespace dali {
 
-class HostDecoderSlice : public HostDecoder, public SliceAttr {
+class HostDecoderSlice : public HostDecoder {
  public:
   explicit HostDecoderSlice(const OpSpec &spec);
 
@@ -31,15 +31,16 @@ class HostDecoderSlice : public HostDecoder, public SliceAttr {
 
  protected:
   inline void RunImpl(SampleWorkspace &ws) override {
-    SliceAttr::ProcessArguments(ws);
+    slice_attr_.ProcessArguments(ws);
     HostDecoder::RunImpl(ws);
   }
 
   inline CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return SliceAttr::GetCropWindowGenerator(data_idx);
+    return slice_attr_.GetCropWindowGenerator(data_idx);
   }
 
  private:
+  SliceAttr slice_attr_;
   std::vector<CropWindowGenerator> per_sample_crop_window_generators_;
 };
 

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -95,6 +95,7 @@ When not supported, will decode the whole image and then crop.
 Output of the decoder is in `HWC` ordering.)code")
   .NumInput(3)
   .NumOutput(1)
-  .AddParent("ImageDecoder");
+  .AddParent("ImageDecoder")
+  .AddParent("SliceAttr");
 
 }  // namespace dali

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -94,7 +94,7 @@ slice (x0, x1, x2, ...), and `shape` containing either normalized or absolute co
 (s0, s1, s2, ...). Both `anchor` and `shape` coordinates must be within the interval
 [0.0, 1.0] for normalized coordinates, or within the image shape for absolute
 coordinates. Both `anchor` and `shape` inputs will provide as many dimensions as specified
-with arguments `dim_names` or `dims`. By default `ImageDecoderSlice` operator uses normalized
+with arguments `axis_names` or `axes`. By default `ImageDecoderSlice` operator uses normalized
 coordinates and `WH` order for the slice arguments.
 When possible, will make use of partial decoding (e.g. libjpeg-turbo, nvJPEG).
 When not supported, will decode the whole image and then crop.

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -86,10 +86,16 @@ Output of the decoder is in `HWC` ordering.)code")
 
 DALI_SCHEMA(ImageDecoderSlice)
   .DocStr(R"code(Decode images on the host with a cropping window of given size and anchor.
-Inputs must be supplied as 3 tensors in a specific order: `encoded_data` containing encoded
-image data, `begin` containing the starting pixel coordinates for the `crop` in `(x,y)`
-format, and `size` containing the pixel dimensions of the `crop` in `(w,h)` format.
-For both `begin` and `size`, coordinates must be in the interval `[0.0, 1.0]`.
+Inputs must be supplied as 3 separate tensors in a specific order: `data`
+containing input data, `anchor` containing either normalized or absolute coordinates
+(depending on the value of `normalized_anchor`) for the starting point of the
+slice (x0, x1, x2, ...), and `shape` containing either normalized or absolute coordinates
+(depending on the value of `normalized_shape`) for the dimensions of the slice
+(s0, s1, s2, ...). Both `anchor` and `shape` coordinates must be within the interval
+[0.0, 1.0] for normalized coordinates, or within the image shape for absolute
+coordinates. Both `anchor` and `shape` inputs will provide as many dimensions as specified
+with arguments `dim_names` or `dims`. By default `ImageDecoderSlice` operator uses normalized
+coordinates and `WH` order for the slice arguments.
 When possible, will make use of partial decoding (e.g. libjpeg-turbo, nvJPEG).
 When not supported, will decode the whole image and then crop.
 Output of the decoder is in `HWC` ordering.)code")

--- a/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_cpu_slice.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_cpu_slice.cc
@@ -32,6 +32,7 @@ Output of the decoder is in `HWC` ordering.)code")
     .NumInput(3)
     .NumOutput(3)
     .MakeInternal()
-    .AddParent("nvJPEGDecoderCPUStage");
+    .AddParent("nvJPEGDecoderCPUStage")
+    .AddParent("SliceAttr");
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_cpu_slice.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_cpu_slice.h
@@ -21,11 +21,11 @@
 
 namespace dali {
 
-class nvJPEGDecoderCPUStageSlice : public nvJPEGDecoderCPUStage, public SliceAttr {
+class nvJPEGDecoderCPUStageSlice : public nvJPEGDecoderCPUStage {
  public:
   explicit nvJPEGDecoderCPUStageSlice(const OpSpec& spec)
     : nvJPEGDecoderCPUStage(spec)
-    , SliceAttr(spec)
+    , slice_attr_(spec)
   {}
 
   DISABLE_COPY_MOVE_ASSIGN(nvJPEGDecoderCPUStageSlice);
@@ -33,13 +33,16 @@ class nvJPEGDecoderCPUStageSlice : public nvJPEGDecoderCPUStage, public SliceAtt
  protected:
   using Operator<CPUBackend>::RunImpl;
   void RunImpl(SampleWorkspace &ws) override {
-    SliceAttr::ProcessArguments(ws);
+    slice_attr_.ProcessArguments(ws);
     nvJPEGDecoderCPUStage::RunImpl(ws);
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return SliceAttr::GetCropWindowGenerator(data_idx);
+    return slice_attr_.GetCropWindowGenerator(data_idx);
   }
+
+ private:
+  SliceAttr slice_attr_;
 };
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice.h
@@ -21,11 +21,11 @@
 
 namespace dali {
 
-class nvJPEGDecoderSlice : public nvJPEGDecoder, public SliceAttr {
+class nvJPEGDecoderSlice : public nvJPEGDecoder {
  public:
   explicit nvJPEGDecoderSlice(const OpSpec& spec)
     : nvJPEGDecoder(spec)
-    , SliceAttr(spec)
+    , slice_attr_(spec)
   {}
 
   DISABLE_COPY_MOVE_ASSIGN(nvJPEGDecoderSlice);
@@ -33,13 +33,16 @@ class nvJPEGDecoderSlice : public nvJPEGDecoder, public SliceAttr {
  protected:
   using OperatorBase::Run;
   void Run(MixedWorkspace &ws) override {
-    SliceAttr::ProcessArguments(ws);
+    slice_attr_.ProcessArguments(ws);
     nvJPEGDecoder::Run(ws);
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return SliceAttr::GetCropWindowGenerator(data_idx);
+    return slice_attr_.GetCropWindowGenerator(data_idx);
   }
+
+ private:
+  SliceAttr slice_attr_;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -328,7 +328,8 @@ class DLL_PUBLIC OpSchema {
    */
   template <typename T>
   DLL_PUBLIC inline OpSchema& AddOptionalArg(const std::string &s, const std::string &doc,
-                                  std::vector<T> default_value, bool enable_tensor_input = false) {
+                                             std::vector<T> default_value,
+                                             bool enable_tensor_input = false) {
     CheckArgument(s);
     auto to_store = Value::construct(std::vector<T>(default_value));
     optional_arguments_[s] = std::make_pair(doc, to_store.get());

--- a/dali/pipeline/operators/crop/slice_attr.cc
+++ b/dali/pipeline/operators/crop/slice_attr.cc
@@ -23,7 +23,8 @@ DALI_SCHEMA(SliceAttr)
         R"code(Order of dimensions used for anchor and shape slice inputs, as dimension indexes)code",
         std::vector<int>{1, 0})
     .AddOptionalArg("dim_names",
-        R"code(Order of dimensions used for anchor and shape slice inputs, as described in layout)code",
+        R"code(Order of dimensions used for anchor and shape slice inputs, as described in layout.
+If provided, `dim_names` takes higher priority than `dims`)code",
         "WH")
     .AddOptionalArg("normalized_anchor",
         R"code(Whether or not the `anchor` input should be interpreted as normalized (range [0.0, 1.0])

--- a/dali/pipeline/operators/crop/slice_attr.cc
+++ b/dali/pipeline/operators/crop/slice_attr.cc
@@ -1,0 +1,37 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include "dali/pipeline/operators/crop/slice_attr.h"
+
+namespace dali {
+
+DALI_SCHEMA(SliceAttr)
+    .DocStr(R"code(Slice attributes placeholder)code")
+    .AddOptionalArg("dims",
+        R"code(Order of dimensions used for anchor and shape slice inputs, as dimension indexes)code",
+        std::vector<int>{1, 0})
+    .AddOptionalArg("dim_names",
+        R"code(Order of dimensions used for anchor and shape slice inputs, as described in layout)code",
+        "WH")
+    .AddOptionalArg("normalized_anchor",
+        R"code(Whether or not the `anchor` input should be interpreted as normalized (range [0.0, 1.0])
+or absolute coordinates)code",
+        true)
+    .AddOptionalArg("normalized_shape",
+        R"code(Whether or not the `shape` input should be interpreted as normalized (range [0.0, 1.0])
+or absolute coordinates)code",
+        true);
+
+}  // namespace dali

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -35,7 +35,7 @@ test_data_video = os.path.join(test_data_root, 'db', 'optical_flow', 'sintel_tra
 class SliceSynthDataPipeline(Pipeline):
     def __init__(self, device, batch_size, layout, iterator, pos_size_iter,
                  num_threads=1, device_id=0, num_gpus=1,
-                 dims=None, dim_names=None, normalized_anchor=True, normalized_shape=True):
+                 axes=None, axis_names=None, normalized_anchor=True, normalized_shape=True):
         super(SliceSynthDataPipeline, self).__init__(
             batch_size, num_threads, device_id, seed=1234)
         self.device = device
@@ -46,16 +46,16 @@ class SliceSynthDataPipeline(Pipeline):
         self.input_crop_pos = ops.ExternalSource()
         self.input_crop_size = ops.ExternalSource()
 
-        if dim_names:
+        if axis_names:
             self.slice = ops.Slice(device = self.device,
                                    normalized_anchor=normalized_anchor,
                                    normalized_shape=normalized_shape,
-                                   dim_names = dim_names)
-        elif dims:
+                                   axis_names = axis_names)
+        elif axes:
             self.slice = ops.Slice(device = self.device,
                                    normalized_anchor=normalized_anchor,
                                    normalized_shape=normalized_shape,
-                                   dims = dims)
+                                   axes = axes)
         else:
             self.slice = ops.Slice(device = self.device,
                                    normalized_anchor=normalized_anchor,
@@ -81,7 +81,7 @@ class SliceSynthDataPipeline(Pipeline):
 class SlicePipeline(Pipeline):
     def __init__(self, device, batch_size, pos_size_iter,
                  num_threads=1, device_id=0, is_fused_decoder=False,
-                 dims=None, dim_names=None, normalized_anchor=True, normalized_shape=True):
+                 axes=None, axis_names=None, normalized_anchor=True, normalized_shape=True):
         super(SlicePipeline, self).__init__(
             batch_size, num_threads, device_id, seed=1234)
         self.is_fused_decoder = is_fused_decoder
@@ -92,18 +92,18 @@ class SlicePipeline(Pipeline):
         self.input_crop_size = ops.ExternalSource()
 
         if self.is_fused_decoder:
-            if dim_names:
+            if axis_names:
                 self.decode = ops.ImageDecoderSlice(device = "cpu",
                                                     output_type = types.RGB,
                                                     normalized_anchor=normalized_anchor,
                                                     normalized_shape=normalized_shape,
-                                                    dim_names = dim_names)
-            elif dims:
+                                                    axis_names = axis_names)
+            elif axes:
                 self.decode = ops.ImageDecoderSlice(device = "cpu",
                                                     output_type = types.RGB,
                                                     normalized_anchor=normalized_anchor,
                                                     normalized_shape=normalized_shape,
-                                                    dims = dims)
+                                                    axes = axes)
             else:
                 self.decode = ops.ImageDecoderSlice(device = "cpu",
                                                     output_type = types.RGB,
@@ -112,16 +112,16 @@ class SlicePipeline(Pipeline):
         else:
             self.decode = ops.ImageDecoder(device = "cpu",
                                            output_type = types.RGB)
-            if dim_names:
+            if axis_names:
                 self.slice = ops.Slice(device = self.device,
                                        normalized_anchor=normalized_anchor,
                                        normalized_shape=normalized_shape,
-                                       dim_names = dim_names)
-            elif dims:
+                                       axis_names = axis_names)
+            elif axes:
                 self.slice = ops.Slice(device = self.device,
                                        normalized_anchor=normalized_anchor,
                                        normalized_shape=normalized_shape,
-                                       dims = dims)
+                                       axes = axes)
             else:
                 self.slice = ops.Slice(device = self.device,
                                        normalized_anchor=normalized_anchor,
@@ -151,11 +151,11 @@ class SliceArgsIterator(object):
                  batch_size,
                  num_dims=3,
                  image_shape=None,  # Needed if normalized_anchor and normalized_shape are False
-                 image_layout=None, # Needed if dim_names is used to specify the slice
+                 image_layout=None, # Needed if axis_names is used to specify the slice
                  normalized_anchor=True,
                  normalized_shape=True,
-                 dims=None,
-                 dim_names=None,
+                 axes=None,
+                 axis_names=None,
                  min_norm_anchor=0.0,
                  max_norm_anchor=0.2,
                  min_norm_shape=0.4,
@@ -167,23 +167,23 @@ class SliceArgsIterator(object):
         self.image_layout = image_layout
         self.normalized_anchor = normalized_anchor
         self.normalized_shape = normalized_shape
-        self.dims = dims
-        self.dim_names = dim_names
+        self.axes = axes
+        self.axis_names = axis_names
         self.min_norm_anchor=min_norm_anchor
         self.max_norm_anchor=max_norm_anchor
         self.min_norm_shape=min_norm_shape
         self.max_norm_shape=max_norm_shape
         self.seed=seed
 
-        if not self.dim_names and not self.dims:
-            self.dim_names = "WH"
+        if not self.axis_names and not self.axes:
+            self.axis_names = "WH"
 
-        if self.dim_names:
-            self.dims = []
-            for dim_name in self.dim_names:
-                assert dim_name in self.image_layout
-                self.dims.append(self.image_layout.index(dim_name))
-        assert(len(self.dims)>0)
+        if self.axis_names:
+            self.axes = []
+            for axis_name in self.axis_names:
+                assert axis_name in self.image_layout
+                self.axes.append(self.image_layout.index(axis_name))
+        assert(len(self.axes)>0)
 
     def __iter__(self):
         self.i = 0
@@ -199,18 +199,18 @@ class SliceArgsIterator(object):
         shape_offset = self.min_norm_shape
         np.random.seed(self.seed)
         for k in range(self.batch_size):
-            norm_anchor = anchor_amplitude * np.random.rand(len(self.dims)) + anchor_offset
-            norm_shape = shape_amplitude * np.random.rand(len(self.dims)) + shape_offset
+            norm_anchor = anchor_amplitude * np.random.rand(len(self.axes)) + anchor_offset
+            norm_shape = shape_amplitude * np.random.rand(len(self.axes)) + shape_offset
 
             if self.normalized_anchor:
                 anchor = norm_anchor
             else:
-                anchor = [floor(norm_anchor[i] * self.image_shape[self.dims[i]]) for i in range(len(self.dims))]
+                anchor = [floor(norm_anchor[i] * self.image_shape[self.axes[i]]) for i in range(len(self.axes))]
 
             if self.normalized_shape:
                 shape = norm_shape
             else:
-                shape = [floor(norm_shape[i] * self.image_shape[self.dims[i]]) for i in range(len(self.dims))]
+                shape = [floor(norm_shape[i] * self.image_shape[self.axes[i]]) for i in range(len(self.axes))]
 
             pos.append(np.asarray(anchor, dtype=np.float32))
             size.append(np.asarray(shape, dtype=np.float32))
@@ -218,25 +218,25 @@ class SliceArgsIterator(object):
         return (pos, size)
     next = __next__
 
-def slice_func_helper(dims, dim_names, layout, normalized_anchor, normalized_shape, image, slice_anchor, slice_shape):
+def slice_func_helper(axes, axis_names, layout, normalized_anchor, normalized_shape, image, slice_anchor, slice_shape):
     # TODO(janton): remove this
-    if not dims and not dim_names:
-        dim_names = "WH"
+    if not axes and not axis_names:
+        axis_names = "WH"
 
-    if dim_names:
-        dims = []
-        for dim_name in dim_names:
-            assert(dim_name in layout)
-            dim_pos = layout.find(dim_name)
-            dims.append(dim_pos)
+    if axis_names:
+        axes = []
+        for axis_name in axis_names:
+            assert(axis_name in layout)
+            axis_pos = layout.find(axis_name)
+            axes.append(axis_pos)
 
     shape = image.shape
     full_slice_anchor = [0] * len(shape)
     full_slice_shape = list(shape)
-    for dim in dims:
-        idx = dims.index(dim)
-        full_slice_anchor[dim] = slice_anchor[idx]
-        full_slice_shape[dim] = slice_shape[idx]
+    for axis in axes:
+        idx = axes.index(axis)
+        full_slice_anchor[axis] = slice_anchor[idx]
+        full_slice_shape[axis] = slice_shape[idx]
 
     if normalized_anchor and normalized_shape:
         start = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]))
@@ -268,7 +268,7 @@ def slice_func_helper(dims, dim_names, layout, normalized_anchor, normalized_sha
 class SliceSynthDataPipelinePythonOp(Pipeline):
     def __init__(self, batch_size, layout, iterator, pos_size_iter,
                  num_threads=1, device_id=0, num_gpus=1,
-                 dims=None, dim_names=None,
+                 axes=None, axis_names=None,
                  normalized_anchor=True, normalized_shape=True):
         super(SliceSynthDataPipelinePythonOp, self).__init__(
             batch_size, num_threads, device_id,
@@ -282,7 +282,7 @@ class SliceSynthDataPipelinePythonOp(Pipeline):
         self.input_crop_size = ops.ExternalSource()
 
         function = partial(
-            slice_func_helper, dims, dim_names, self.layout,
+            slice_func_helper, axes, axis_names, self.layout,
             normalized_anchor, normalized_shape)
         self.slice = ops.PythonFunction(function=function)
 
@@ -305,7 +305,7 @@ class SliceSynthDataPipelinePythonOp(Pipeline):
 class SlicePythonOp(Pipeline):
     def __init__(self, batch_size, pos_size_iter,
                  num_threads=1, device_id=0, num_gpus=1,
-                 dims=None, dim_names=None,
+                 axes=None, axis_names=None,
                  normalized_anchor=True, normalized_shape=True):
         super(SlicePythonOp, self).__init__(
             batch_size, num_threads, device_id,
@@ -321,7 +321,7 @@ class SlicePythonOp(Pipeline):
         self.input_crop_size = ops.ExternalSource()
 
         function = partial(
-            slice_func_helper, dims, dim_names, self.layout,
+            slice_func_helper, axes, axis_names, self.layout,
             normalized_anchor, normalized_shape)
         self.slice = ops.PythonFunction(function=function)
 
@@ -339,28 +339,28 @@ class SlicePythonOp(Pipeline):
         self.feed_input(self.crop_size, crop_size)
 
 
-def check_slice_synth_data_vs_numpy(device, batch_size, input_shape, layout, dims, dim_names,
+def check_slice_synth_data_vs_numpy(device, batch_size, input_shape, layout, axes, axis_names,
                                     normalized_anchor, normalized_shape):
     eiis = [RandomDataIterator(batch_size, shape=input_shape)
             for k in range(2)]
     eii_args = [SliceArgsIterator(batch_size, len(input_shape), image_shape=input_shape,
-                image_layout=layout, dims=dims, dim_names=dim_names, normalized_anchor=normalized_anchor,
+                image_layout=layout, axes=axes, axis_names=axis_names, normalized_anchor=normalized_anchor,
                 normalized_shape=normalized_shape)
                 for k in range(2)]
 
     compare_pipelines(
         SliceSynthDataPipeline(device, batch_size, layout, iter(eiis[0]), iter(eii_args[0]),
-            dims=dims, dim_names=dim_names, normalized_anchor=normalized_anchor,
+            axes=axes, axis_names=axis_names, normalized_anchor=normalized_anchor,
             normalized_shape=normalized_shape),
         SliceSynthDataPipelinePythonOp(batch_size, layout, iter(eiis[0]), iter(eii_args[1]),
-            dims=dims, dim_names=dim_names, normalized_anchor=normalized_anchor,
+            axes=axes, axis_names=axis_names, normalized_anchor=normalized_anchor,
             normalized_shape=normalized_shape),
         batch_size=batch_size, N_iterations=5)
 
 def test_slice_synth_data_vs_numpy():
     for device in ["cpu", "gpu"]:
         for batch_size in {1, 8}:
-            for input_shape, layout, dims, dim_names in \
+            for input_shape, layout, axes, axis_names in \
                 [((200,400,3), "HWC", None, "WH"),
                 ((200,400,3), "HWC", None, "HW"),
                 ((200,400,3), "HWC", None, "C"),
@@ -377,36 +377,36 @@ def test_slice_synth_data_vs_numpy():
                 for normalized_anchor in [True, False]:
                     for normalized_shape in [True, False]:
                         yield check_slice_synth_data_vs_numpy, device, batch_size, \
-                            input_shape, layout, dims, dim_names, normalized_anchor, normalized_shape
+                            input_shape, layout, axes, axis_names, normalized_anchor, normalized_shape
 
-def check_slice_vs_fused_decoder(device, batch_size, dims, dim_names):
-    eii_args = [SliceArgsIterator(batch_size, image_layout="HWC", dims=dims, dim_names=dim_names)
+def check_slice_vs_fused_decoder(device, batch_size, axes, axis_names):
+    eii_args = [SliceArgsIterator(batch_size, image_layout="HWC", axes=axes, axis_names=axis_names)
                 for k in range(2)]
     compare_pipelines(
-        SlicePipeline(device, batch_size, iter(eii_args[0]), dims=dims, dim_names=dim_names, is_fused_decoder=False),
-        SlicePipeline(device, batch_size, iter(eii_args[1]), dims=dims, dim_names=dim_names, is_fused_decoder=True),
+        SlicePipeline(device, batch_size, iter(eii_args[0]), axes=axes, axis_names=axis_names, is_fused_decoder=False),
+        SlicePipeline(device, batch_size, iter(eii_args[1]), axes=axes, axis_names=axis_names, is_fused_decoder=True),
         batch_size=batch_size, N_iterations=5)
 
 def test_slice_vs_fused_decoder():
     for device in ["cpu", "gpu"]:
         for batch_size in {1}:
-            for dims, dim_names in \
+            for axes, axis_names in \
                 [(None, "WH"), (None, "HW"),
                 ((1,0), None), ((0,1), None)]:
-                yield check_slice_vs_fused_decoder, device, batch_size, dims, dim_names
+                yield check_slice_vs_fused_decoder, device, batch_size, axes, axis_names
 
-def check_slice_vs_numpy(device, batch_size, dims, dim_names):
-    eii_args = [SliceArgsIterator(batch_size, image_layout="HWC", dims=dims, dim_names=dim_names)
+def check_slice_vs_numpy(device, batch_size, axes, axis_names):
+    eii_args = [SliceArgsIterator(batch_size, image_layout="HWC", axes=axes, axis_names=axis_names)
                 for k in range(2)]
     compare_pipelines(
-        SlicePipeline(device, batch_size, iter(eii_args[0]), dims=dims, dim_names=dim_names),
-        SlicePythonOp(batch_size, iter(eii_args[1]), dims=dims, dim_names=dim_names),
+        SlicePipeline(device, batch_size, iter(eii_args[0]), axes=axes, axis_names=axis_names),
+        SlicePythonOp(batch_size, iter(eii_args[1]), axes=axes, axis_names=axis_names),
         batch_size=batch_size, N_iterations=5)
 
 def test_slice_vs_numpy():
     for device in ["cpu", "gpu"]:
         for batch_size in {1}:
-            for dims, dim_names in \
+            for axes, axis_names in \
                 [(None, "WH"), (None, "HW"),
                 ((1,0), None), ((0,1), None)]:
-                yield check_slice_vs_numpy, device, batch_size, dims, dim_names
+                yield check_slice_vs_numpy, device, batch_size, axes, axis_names

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -204,14 +204,14 @@ class PythonOperatorPipeline(Pipeline):
 def extract_first_channel(image):
     return image[:,:,0].reshape(image.shape[0:2] + (1,))
 
-def t3est_slice_extract_channel_cpu():
+def test_slice_extract_channel_cpu():
     for batch_size in {1, 32, 64}:
         eii = SliceArgsIteratorExtractFirstChannel(batch_size)
         compare_pipelines(SlicePipeline('cpu', batch_size, iter(eii)),
                           PythonOperatorPipeline(extract_first_channel, batch_size),
                           batch_size=batch_size, N_iterations=10)
 
-def tes2t_slice_extract_channel_gpu():
+def test_slice_extract_channel_gpu():
     for batch_size in {1, 32, 64}:
         eii = SliceArgsIteratorExtractFirstChannel(batch_size)
         compare_pipelines(SlicePipeline('gpu', batch_size, iter(eii)),
@@ -225,14 +225,14 @@ def slice_func(image):
     end_x = int(np.float32(image.shape[1]) * np.float32(0.4 + 0.3))
     return image[start_y:end_y, start_x:end_x, :]
 
-def tes2t_slice_vs_numpy_slice_gpu():
+def test_slice_vs_numpy_slice_gpu():
     for batch_size in {1, 32, 64}:
         eii = SliceArgsIteratorAllDims(batch_size)
         compare_pipelines(SlicePipeline('gpu', batch_size, iter(eii)),
                           PythonOperatorPipeline(slice_func, batch_size),
                           batch_size=batch_size, N_iterations=10)
 
-def te2st_slice_vs_numpy_slice_cpu():
+def test_slice_vs_numpy_slice_cpu():
     for batch_size in {1, 32, 64}:
         eii = SliceArgsIteratorAllDims(batch_size)
         compare_pipelines(SlicePipeline('cpu', batch_size, iter(eii)),

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -26,19 +26,64 @@ from test_utils import check_batch
 from test_utils import compare_pipelines
 from test_utils import get_dali_extra_path
 from test_utils import RandomDataIterator
+from math import floor
 
 test_data_root = get_dali_extra_path()
 caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
 test_data_video = os.path.join(test_data_root, 'db', 'optical_flow', 'sintel_trailer')
 
+class SliceSynthDataPipeline(Pipeline):
+    def __init__(self, device, batch_size, layout, iterator, pos_size_iter,
+                 num_threads=1, device_id=0, num_gpus=1,
+                 dims=None, dim_names=None, normalized_anchor=True, normalized_shape=True):
+        super(SliceSynthDataPipeline, self).__init__(
+            batch_size, num_threads, device_id, seed=1234)
+        self.device = device
+        self.layout = layout
+        self.iterator = iterator
+        self.pos_size_iter = pos_size_iter
+        self.inputs = ops.ExternalSource()
+        self.input_crop_pos = ops.ExternalSource()
+        self.input_crop_size = ops.ExternalSource()
+
+        if dim_names:
+            self.slice = ops.Slice(device = self.device,
+                                   normalized_anchor=normalized_anchor,
+                                   normalized_shape=normalized_shape,
+                                   dim_names = dim_names)
+        elif dims:
+            self.slice = ops.Slice(device = self.device,
+                                   normalized_anchor=normalized_anchor,
+                                   normalized_shape=normalized_shape,
+                                   dims = dims)
+        else:
+            self.slice = ops.Slice(device = self.device,
+                                   normalized_anchor=normalized_anchor,
+                                   normalized_shape=normalized_shape,
+)
+
+    def define_graph(self):
+        self.data = self.inputs()
+        self.crop_pos = self.input_crop_pos()
+        self.crop_size = self.input_crop_size()
+        data = self.data.gpu() if self.device == 'gpu' else self.data
+        out = self.slice(data, self.crop_pos, self.crop_size)
+        return out
+
+    def iter_setup(self):
+        data = self.iterator.next()
+        self.feed_input(self.data, data, layout=self.layout)
+
+        (crop_pos, crop_size) = self.pos_size_iter.next()
+        self.feed_input(self.crop_pos, crop_pos)
+        self.feed_input(self.crop_size, crop_size)
+
 class SlicePipeline(Pipeline):
     def __init__(self, device, batch_size, pos_size_iter,
                  num_threads=1, device_id=0, is_fused_decoder=False,
-                 dims=(1,0), dim_names="WH"):
-        super(SlicePipeline, self).__init__(batch_size,
-                                            num_threads,
-                                            device_id,
-                                            seed=1234)
+                 dims=None, dim_names=None, normalized_anchor=True, normalized_shape=True):
+        super(SlicePipeline, self).__init__(
+            batch_size, num_threads, device_id, seed=1234)
         self.is_fused_decoder = is_fused_decoder
         self.pos_size_iter = pos_size_iter
         self.device = device
@@ -47,14 +92,40 @@ class SlicePipeline(Pipeline):
         self.input_crop_size = ops.ExternalSource()
 
         if self.is_fused_decoder:
-            self.decode = ops.ImageDecoderSlice(device = 'cpu',
-                                                output_type = types.RGB)
+            if dim_names:
+                self.decode = ops.ImageDecoderSlice(device = "cpu",
+                                                    output_type = types.RGB,
+                                                    normalized_anchor=normalized_anchor,
+                                                    normalized_shape=normalized_shape,
+                                                    dim_names = dim_names)
+            elif dims:
+                self.decode = ops.ImageDecoderSlice(device = "cpu",
+                                                    output_type = types.RGB,
+                                                    normalized_anchor=normalized_anchor,
+                                                    normalized_shape=normalized_shape,
+                                                    dims = dims)
+            else:
+                self.decode = ops.ImageDecoderSlice(device = "cpu",
+                                                    output_type = types.RGB,
+                                                    normalized_anchor=normalized_anchor,
+                                                    normalized_shape=normalized_shape)
         else:
             self.decode = ops.ImageDecoder(device = "cpu",
                                            output_type = types.RGB)
-            self.slice = ops.Slice(device = device,
-                                   image_type = types.RGB,
-                                   dims=(1,0))
+            if dim_names:
+                self.slice = ops.Slice(device = self.device,
+                                       normalized_anchor=normalized_anchor,
+                                       normalized_shape=normalized_shape,
+                                       dim_names = dim_names)
+            elif dims:
+                self.slice = ops.Slice(device = self.device,
+                                       normalized_anchor=normalized_anchor,
+                                       normalized_shape=normalized_shape,
+                                       dims = dims)
+            else:
+                self.slice = ops.Slice(device = self.device,
+                                       normalized_anchor=normalized_anchor,
+                                       normalized_shape=normalized_shape)
 
     def define_graph(self):
         inputs, labels = self.input(name="Reader")
@@ -130,184 +201,24 @@ class SliceArgsIterator(object):
         for k in range(self.batch_size):
             norm_anchor = anchor_amplitude * np.random.rand(len(self.dims)) + anchor_offset
             norm_shape = shape_amplitude * np.random.rand(len(self.dims)) + shape_offset
+
             if self.normalized_anchor:
                 anchor = norm_anchor
             else:
-                anchor = norm_anchor * image_shape
+                anchor = [floor(norm_anchor[i] * self.image_shape[self.dims[i]]) for i in range(len(self.dims))]
 
             if self.normalized_shape:
                 shape = norm_shape
             else:
-                shape = norm_shape * image_shape
+                shape = [floor(norm_shape[i] * self.image_shape[self.dims[i]]) for i in range(len(self.dims))]
+
             pos.append(np.asarray(anchor, dtype=np.float32))
             size.append(np.asarray(shape, dtype=np.float32))
             self.i = (self.i + 1) % self.n
         return (pos, size)
     next = __next__
 
-def check_slice_vs_fused_decoder(device, batch_size, normalized_anchor, normalized_shape, dims, dim_names):
-    eii1 = SliceArgsIterator(batch_size)
-    eii2 = SliceArgsIterator(batch_size)
-    compare_pipelines(SlicePipeline(device, batch_size, iter(eii1), is_fused_decoder=True),
-                      SlicePipeline(device, batch_size, iter(eii2), is_fused_decoder=False),
-                      batch_size=batch_size, N_iterations=5)
-
-def tes3t_slice_vs_fused_decoder():
-    for device in ['cpu', 'gpu']:
-        for batch_size in [1, 13, 64]:
-            for normalized_anchor, normalized_shape, dims, dim_names in \
-                [(True, True, (0,1), "WH"),
-                 (True, True, (1,0), "HW"),
-                 (True, True, (2), "C")]:
-                yield check_slice_vs_fused_decoder, device, batch_size, normalized_anchor, \
-                    normalized_shape, dims, dim_names
-
-def check_slice_vs_cpu_vs_gpu(device, batch_size, normalized_anchor, normalized_shape, dims, dim_names):
-    eii1 = SliceArgsIterator(batch_size)
-    eii2 = SliceArgsIterator(batch_size)
-    compare_pipelines(SlicePipeline(device, batch_size, iter(eii1), is_fused_decoder=True),
-                      SlicePipeline(device, batch_size, iter(eii2), is_fused_decoder=False),
-                      batch_size=batch_size, N_iterations=5)
-
-def te3st_slice_cpu_vs_gpu():
-    for device in ['cpu', 'gpu']:
-        for batch_size in [1, 13, 64]:
-            for normalized_anchor, normalized_shape, dims, dim_names in \
-                [(True, True, (0,1), "WH"),
-                 (True, True, (1,0), "HW")]:
-                yield check_slice_vs_cpu_vs_gpu, device, batch_size, normalized_anchor, \
-                    normalized_shape, dims, dim_names
-
-class SliceArgsIteratorExtractFirstChannel(object):
-    def __init__(self, batch_size):
-        self.batch_size = batch_size
-
-    def __iter__(self):
-        self.i = 0
-        self.n = self.batch_size
-        return self
-
-    def __next__(self):
-        pos = []
-        size = []
-        for k in range(self.batch_size):
-            pos.append(np.asarray([0.0, 0.0, 0.0], dtype=np.float32)) # yxc
-            size.append(np.asarray([1.0, 1.0, 1./3.], dtype=np.float32)) # HWC
-            self.i = (self.i + 1) % self.n
-        return (pos, size)
-    next = __next__
-
-class PythonOperatorPipeline(Pipeline):
-    def __init__(self, function, batch_size, num_threads=1, device_id=0):
-        super(PythonOperatorPipeline, self).__init__(batch_size, num_threads, device_id,
-                                                     exec_async=False,
-                                                     exec_pipelined=False,
-                                                     seed=1234)
-        self.input = ops.CaffeReader(path = caffe_db_folder, random_shuffle=False)
-        self.decode = ops.ImageDecoder(device = 'cpu', output_type = types.RGB)
-        self.python_function = ops.PythonFunction(function=function)
-
-    def define_graph(self):
-        jpegs, _ = self.input()
-        decoded = self.decode(jpegs)
-        processed = self.python_function(decoded)
-        assert isinstance(processed, EdgeReference)
-        return processed
-
-def extract_first_channel(image):
-    return image[:,:,0].reshape(image.shape[0:2] + (1,))
-
-def te3st_slice_extract_channel_cpu():
-    for batch_size in {1, 32, 64}:
-        eii = SliceArgsIteratorExtractFirstChannel(batch_size)
-        compare_pipelines(SlicePipeline('cpu', batch_size, iter(eii)),
-                          PythonOperatorPipeline(extract_first_channel, batch_size),
-                          batch_size=batch_size, N_iterations=10)
-
-def te3st_slice_extract_channel_gpu():
-    for batch_size in {1, 32, 64}:
-        eii = SliceArgsIteratorExtractFirstChannel(batch_size)
-        compare_pipelines(SlicePipeline('gpu', batch_size, iter(eii)),
-                          PythonOperatorPipeline(extract_first_channel, batch_size),
-                          batch_size=batch_size, N_iterations=10)
-
-def slice_func(image):
-    start_y = int(np.float32(image.shape[0]) * np.float32(0.2))
-    end_y = int(np.float32(image.shape[0]) * np.float32(0.2 + 0.5))
-    start_x = int(np.float32(image.shape[1]) * np.float32(0.4))
-    end_x = int(np.float32(image.shape[1]) * np.float32(0.4 + 0.3))
-    return image[start_y:end_y, start_x:end_x, :]
-
-def te3st_slice_vs_numpy_slice_gpu():
-    for batch_size in {1, 32, 64}:
-        eii = SliceArgsIteratorAllDims(batch_size)
-        compare_pipelines(SlicePipeline('gpu', batch_size, iter(eii)),
-                          PythonOperatorPipeline(slice_func, batch_size),
-                          batch_size=batch_size, N_iterations=10)
-
-def t3st_slice_vs_numpy_slice_cpu():
-    for batch_size in {1, 32, 64}:
-        eii = SliceArgsIteratorAllDims(batch_size)
-        compare_pipelines(SlicePipeline('cpu', batch_size, iter(eii)),
-                          PythonOperatorPipeline(slice_func, batch_size),
-                          batch_size=batch_size, N_iterations=10)
-
-class SliceSynthDataPipeline(Pipeline):
-    def __init__(self, device, batch_size, layout, iterator, pos_size_iter,
-                 num_threads=1, device_id=0, num_gpus=1,
-                 dims=None, dim_names=None):
-        super(SliceSynthDataPipeline, self).__init__(batch_size, num_threads, device_id)
-        self.device = device
-        self.layout = layout
-        self.iterator = iterator
-        self.pos_size_iter = pos_size_iter
-        self.inputs = ops.ExternalSource()
-        self.input_crop_pos = ops.ExternalSource()
-        self.input_crop_size = ops.ExternalSource()
-
-        if not dims and not dim_names:
-            self.slice = ops.Slice(device = self.device)
-        elif dim_names:
-            self.slice = ops.Slice(device = self.device,
-                                   dim_names = dim_names)
-        elif dims:
-            self.slice = ops.Slice(device = self.device,
-                                   dims = dims)
-
-    def define_graph(self):
-        self.data = self.inputs()
-        self.crop_pos = self.input_crop_pos()
-        self.crop_size = self.input_crop_size()
-        data = self.data.gpu() if self.device == 'gpu' else self.data
-        out = self.slice(data, self.crop_pos, self.crop_size)
-        return out
-
-    def iter_setup(self):
-        data = self.iterator.next()
-        self.feed_input(self.data, data, layout=self.layout)
-
-        (crop_pos, crop_size) = self.pos_size_iter.next()
-        self.feed_input(self.crop_pos, crop_pos)
-        self.feed_input(self.crop_size, crop_size)
-
-class PythonOperatorPipeline(Pipeline):
-    def __init__(self, function, batch_size, num_threads=1, device_id=0):
-        super(PythonOperatorPipeline, self).__init__(batch_size, num_threads, device_id,
-                                                     exec_async=False,
-                                                     exec_pipelined=False,
-                                                     seed=1234)
-        self.input = ops.CaffeReader(path = caffe_db_folder, random_shuffle=False)
-        self.decode = ops.ImageDecoder(device = 'cpu', output_type = types.RGB)
-        self.python_function = ops.PythonFunction(function=function)
-
-    def define_graph(self):
-        jpegs, _ = self.input()
-        decoded = self.decode(jpegs)
-        processed = self.python_function(decoded)
-        assert isinstance(processed, EdgeReference)
-        return processed
-
-def slice_func_helper(dims, dim_names, layout, image, slice_anchor, slice_shape):
+def slice_func_helper(dims, dim_names, layout, normalized_anchor, normalized_shape, image, slice_anchor, slice_shape):
     # TODO(janton): remove this
     if not dims and not dim_names:
         dim_names = "WH"
@@ -327,20 +238,38 @@ def slice_func_helper(dims, dim_names, layout, image, slice_anchor, slice_shape)
         full_slice_anchor[dim] = slice_anchor[idx]
         full_slice_shape[dim] = slice_shape[idx]
 
-    start = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]))
-             for i in range(len(shape))]
-    end = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i] + full_slice_shape[i]))
-           for i in range(len(shape))]
+    if normalized_anchor and normalized_shape:
+        start = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]))
+                 for i in range(len(shape))]
+        end = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]+full_slice_shape[i]))
+               for i in range(len(shape))]
+    else:
+        if normalized_anchor:
+            start = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]))
+                    for i in range(len(shape))]
+        else:
+            start = [int(np.float32(full_slice_anchor[i]))
+                    for i in range(len(shape))]
+
+        if normalized_shape:
+            end = [start[i] + int(np.float32(shape[i]) * np.float32(full_slice_shape[i]))
+                for i in range(len(shape))]
+        else:
+            end = [start[i] + int(np.float32(full_slice_shape[i]))
+                for i in range(len(shape))]
 
     if len(full_slice_anchor) == 3:
         return image[start[0]:end[0], start[1]:end[1], start[2]:end[2]]
+    elif len(full_slice_anchor) == 4:
+        return image[start[0]:end[0], start[1]:end[1], start[2]:end[2], start[3]:end[3]]
     else:
         assert(False)
 
 class SliceSynthDataPipelinePythonOp(Pipeline):
     def __init__(self, batch_size, layout, iterator, pos_size_iter,
                  num_threads=1, device_id=0, num_gpus=1,
-                 dims=None, dim_names=None):
+                 dims=None, dim_names=None,
+                 normalized_anchor=True, normalized_shape=True):
         super(SliceSynthDataPipelinePythonOp, self).__init__(
             batch_size, num_threads, device_id,
             seed=12345, exec_async=False, exec_pipelined=False)
@@ -353,7 +282,8 @@ class SliceSynthDataPipelinePythonOp(Pipeline):
         self.input_crop_size = ops.ExternalSource()
 
         function = partial(
-            slice_func_helper, dims, dim_names, self.layout)
+            slice_func_helper, dims, dim_names, self.layout,
+            normalized_anchor, normalized_shape)
         self.slice = ops.PythonFunction(function=function)
 
     def define_graph(self):
@@ -372,28 +302,111 @@ class SliceSynthDataPipelinePythonOp(Pipeline):
         self.feed_input(self.crop_size, crop_size)
 
 
-def check_slice_synth_data_cpu_vs_gpu(device, batch_size, input_shape, layout, dims, dim_names):
+class SlicePythonOp(Pipeline):
+    def __init__(self, batch_size, pos_size_iter,
+                 num_threads=1, device_id=0, num_gpus=1,
+                 dims=None, dim_names=None,
+                 normalized_anchor=True, normalized_shape=True):
+        super(SlicePythonOp, self).__init__(
+            batch_size, num_threads, device_id,
+            seed=12345, exec_async=False, exec_pipelined=False)
+        self.device = "cpu"
+        self.layout = "HWC"
+        self.pos_size_iter = pos_size_iter
+
+        self.input = ops.CaffeReader(path = caffe_db_folder, random_shuffle=False)
+        self.decode = ops.ImageDecoder(device = 'cpu', output_type = types.RGB)
+
+        self.input_crop_pos = ops.ExternalSource()
+        self.input_crop_size = ops.ExternalSource()
+
+        function = partial(
+            slice_func_helper, dims, dim_names, self.layout,
+            normalized_anchor, normalized_shape)
+        self.slice = ops.PythonFunction(function=function)
+
+    def define_graph(self):
+        imgs, _ = self.input()
+        imgs = self.decode(imgs)
+        self.crop_pos = self.input_crop_pos()
+        self.crop_size = self.input_crop_size()
+        out = self.slice(imgs, self.crop_pos, self.crop_size)
+        return out
+
+    def iter_setup(self):
+        (crop_pos, crop_size) = self.pos_size_iter.next()
+        self.feed_input(self.crop_pos, crop_pos)
+        self.feed_input(self.crop_size, crop_size)
+
+
+def check_slice_synth_data_vs_numpy(device, batch_size, input_shape, layout, dims, dim_names,
+                                    normalized_anchor, normalized_shape):
     eiis = [RandomDataIterator(batch_size, shape=input_shape)
             for k in range(2)]
     eii_args = [SliceArgsIterator(batch_size, len(input_shape), image_shape=input_shape,
-                image_layout=layout, dims=dims, dim_names=dim_names)
+                image_layout=layout, dims=dims, dim_names=dim_names, normalized_anchor=normalized_anchor,
+                normalized_shape=normalized_shape)
                 for k in range(2)]
 
     compare_pipelines(
         SliceSynthDataPipeline(device, batch_size, layout, iter(eiis[0]), iter(eii_args[0]),
-            dims=dims, dim_names=dim_names),
+            dims=dims, dim_names=dim_names, normalized_anchor=normalized_anchor,
+            normalized_shape=normalized_shape),
         SliceSynthDataPipelinePythonOp(batch_size, layout, iter(eiis[0]), iter(eii_args[1]),
-            dims=dims, dim_names=dim_names),
+            dims=dims, dim_names=dim_names, normalized_anchor=normalized_anchor,
+            normalized_shape=normalized_shape),
         batch_size=batch_size, N_iterations=5)
 
-def test_slice_synth_data_cpu_vs_gpu():
+def test_slice_synth_data_vs_numpy():
     for device in ["cpu", "gpu"]:
         for batch_size in {1, 8}:
             for input_shape, layout, dims, dim_names in \
                 [((200,400,3), "HWC", None, "WH"),
                 ((200,400,3), "HWC", None, "HW"),
+                ((200,400,3), "HWC", None, "C"),
                 ((200,400,3), "HWC", (1,0), None),
-                ((200,400,3), "HWC", (0,1), None),]:
-                #((80, 30, 20, 3), "DHWC", (2,1,0), None),]:
-                yield check_slice_synth_data_cpu_vs_gpu, device, batch_size, \
-                    input_shape, layout, dims, dim_names
+                ((200,400,3), "HWC", (0,1), None),
+                ((200,400,3), "HWC", (2,), None),
+                ((80, 30, 20, 3), "DHWC", (2,1,0), None),
+                ((80, 30, 20, 3), "DHWC", (0,1,2), None),
+                ((80, 30, 20, 3), "DHWC", (2,1), None),
+                ((80, 30, 20, 3), "DHWC", None, "WHD"),
+                ((80, 30, 20, 3), "DHWC", None, "DHW"),
+                ((80, 30, 20, 3), "DHWC", None, "WH"),
+                ((80, 30, 20, 3), "DHWC", None, "C")]:
+                for normalized_anchor in [True, False]:
+                    for normalized_shape in [True, False]:
+                        yield check_slice_synth_data_vs_numpy, device, batch_size, \
+                            input_shape, layout, dims, dim_names, normalized_anchor, normalized_shape
+
+def check_slice_vs_fused_decoder(device, batch_size, dims, dim_names):
+    eii_args = [SliceArgsIterator(batch_size, image_layout="HWC", dims=dims, dim_names=dim_names)
+                for k in range(2)]
+    compare_pipelines(
+        SlicePipeline(device, batch_size, iter(eii_args[0]), dims=dims, dim_names=dim_names, is_fused_decoder=False),
+        SlicePipeline(device, batch_size, iter(eii_args[1]), dims=dims, dim_names=dim_names, is_fused_decoder=True),
+        batch_size=batch_size, N_iterations=5)
+
+def test_slice_vs_fused_decoder():
+    for device in ["cpu", "gpu"]:
+        for batch_size in {1}:
+            for dims, dim_names in \
+                [(None, "WH"), (None, "HW"),
+                ((1,0), None), ((0,1), None)]:
+                yield check_slice_vs_fused_decoder, device, batch_size, dims, dim_names
+
+def check_slice_vs_numpy(device, batch_size, dims, dim_names):
+    eii_args = [SliceArgsIterator(batch_size, image_layout="HWC", dims=dims, dim_names=dim_names)
+                for k in range(2)]
+    compare_pipelines(
+        SlicePipeline(device, batch_size, iter(eii_args[0]), dims=dims, dim_names=dim_names),
+        SlicePythonOp(batch_size, iter(eii_args[1]), dims=dims, dim_names=dim_names),
+        batch_size=batch_size, N_iterations=5)
+
+def test_slice_vs_numpy():
+    for device in ["cpu", "gpu"]:
+        for batch_size in {1}:
+            for dims, dim_names in \
+                [(None, "WH"), (None, "HW"),
+                ((1,0), None), ((0,1), None)]:
+                yield check_slice_vs_numpy, device, batch_size, dims, dim_names


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
Enhances Slice API:
- Provides the ability to specify anchor and shape as normalized or absolute coordinates (independently)
- Provides the ability to specify order and number of slice arguments provided by name (as in the layout) and by indexes:

Examples:
`dim_names = "WH"` : anchor and shape will follow `x, y` order for any layout (will slice dimensions 1 and 0 for `HWC` and dimensions 2 and 1 for `CHW`
`dims = (1, 0)`: anchor and shape will refer to second and first dimensions (that is, `x` and `y` for `HWC` layout, but would mean `y` and `c` for `CHW`) 

- Allows 3D slicing (depth slicing)
- Allows slicing of channel dimension
- Allows slicing of frame dimension
- Default values are normalized anchor and shape, and `dim_names="WH"`

#### What happened in this PR?
- Implemented API described above
- Wrote tests for all those options

**JIRA TASK**: [DALI-1034]