### PR TITLE
Enable CUDA 10 compatibility layer for Conda build

### DIFF
--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -10,6 +10,23 @@ fi
 
 nvidia-smi
 
+# If driver version is less than 410 and CUDA version is 10,
+# add /usr/local/cuda/compat to LD_LIBRARY_PATH
+CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
+CUDA_VERSION=${CUDA_VERSION:-90}
+
+NVIDIA_SMI_DRIVER_VERSION=$(nvidia-smi | grep -Po '(?<=Driver Version: )\d+.\d+')
+
+function version_gt() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1"; }
+function version_le() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" == "$1"; }
+function version_lt() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1"; }
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
+
+version_ge "$CUDA_VERSION" "100" && \
+version_lt "$NVIDIA_SMI_DRIVER_VERSION" "410.0" && \
+export LD_LIBRARY_PATH="/usr/local/cuda/compat:$LD_LIBRARY_PATH"
+echo "LD_LIBRARY_PATH is $LD_LIBRARY_PATH"
+
 # Adding conda-forge channel for dependencies
 conda config --add channels conda-forge
 

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -42,6 +42,7 @@ build:
    - GIT_SHA
    - DALI_TIMESTAMP
    - NVIDIA_DALI_BUILD_FLAVOR
+   - LD_LIBRARY_PATH
   number: 0
   string: py{{ python | replace(".","") }}
 


### PR DESCRIPTION
- when DALI Conda build is run for CUDA 10 and the underlying
  driver happens to be < 410 enable CUDA compatibility layer

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- fix DALI build with CUDA 10 and driver < 410

#### What happened in this PR?
 - when DALI Conda build is run for CUDA 10 and the underlying
  driver happens to be < 410 enable CUDA compatibility layer
- tested in CI

**JIRA TASK**: [NA]