### PR TITLE
Add shape layout input to crop window generator signature

### DIFF
--- a/dali/image/generic_image.cc
+++ b/dali/image/generic_image.cc
@@ -41,7 +41,7 @@ GenericImage::DecodeImpl(DALIImageType image_type,
   auto crop_generator = GetCropWindowGenerator();
   if (crop_generator) {
       cv::Mat decoded_image_roi;
-      auto crop = crop_generator({H, W});
+      auto crop = crop_generator({H, W}, "HW");
       const int y = crop.anchor[0];
       const int x = crop.anchor[1];
       const int newH = crop.shape[0];

--- a/dali/image/image.h
+++ b/dali/image/image.h
@@ -93,7 +93,10 @@ class Image {
   inline void SetCropWindow(const CropWindow& crop_window) {
     if (!crop_window)
       return;
-    crop_window_generator_ = [crop_window](const kernels::TensorShape<>& shape) {
+    crop_window_generator_ = [crop_window](const kernels::TensorShape<>& shape,
+                                           const TensorLayout& shape_layout) {
+      DALI_ENFORCE(shape_layout == "HW",
+        make_string("Unexpected input shape layout:", shape_layout.c_str(), "vs HW"));
       DALI_ENFORCE(crop_window.IsInRange(shape),
         "crop_window["
         + std::to_string(crop_window.anchor[1])

--- a/dali/image/jpeg.cc
+++ b/dali/image/jpeg.cc
@@ -87,7 +87,7 @@ JpegImage::DecodeImpl(DALIImageType type, const uint8 *jpeg, size_t length) cons
   if (crop_window_generator) {
     flags.crop = true;
     kernels::TensorShape<> shape{static_cast<int>(h), static_cast<int>(w)};
-    auto crop = crop_window_generator(shape);
+    auto crop = crop_window_generator(shape, "HW");
     DALI_ENFORCE(crop.IsInRange(shape));
     flags.crop_y = crop.anchor[0];
     flags.crop_x = crop.anchor[1];

--- a/dali/image/tiff_libtiff.cc
+++ b/dali/image/tiff_libtiff.cc
@@ -282,7 +282,7 @@ TiffImage_Libtiff::DecodeImpl(DALIImageType image_type,
   int64_t roi_x = 0, roi_y = 0;
   int64_t roi_h = H, roi_w = W;
   if (roi_generator) {
-    auto roi = roi_generator({H, W});
+    auto roi = roi_generator({H, W}, "HW");
     roi_y = roi.anchor[0];
     roi_x = roi.anchor[1];
     roi_h = roi.shape[0];

--- a/dali/pipeline/operators/crop/crop.h
+++ b/dali/pipeline/operators/crop/crop.h
@@ -84,7 +84,7 @@ class Crop : public SliceBase<Backend>, protected CropAttr {
     assert(spatial_ndim >= 2);  // bug-check: should never occur with h_dim, w_dim >= 0
 
     auto crop_window_gen = GetCropWindowGenerator(data_idx);
-    auto win = spatial_ndim == 3 ? crop_window_gen({D, H, W}) : crop_window_gen({H, W});
+    auto win = spatial_ndim == 3 ? crop_window_gen({D, H, W}, "DHW") : crop_window_gen({H, W}, "HW");
 
     int ndim = shape.sample_dim();
     slice_anchors_[data_idx].resize(ndim);

--- a/dali/pipeline/operators/crop/crop.h
+++ b/dali/pipeline/operators/crop/crop.h
@@ -84,7 +84,8 @@ class Crop : public SliceBase<Backend>, protected CropAttr {
     assert(spatial_ndim >= 2);  // bug-check: should never occur with h_dim, w_dim >= 0
 
     auto crop_window_gen = GetCropWindowGenerator(data_idx);
-    auto win = spatial_ndim == 3 ? crop_window_gen({D, H, W}, "DHW") : crop_window_gen({H, W}, "HW");
+    auto win = spatial_ndim == 3 ?
+      crop_window_gen({D, H, W}, "DHW") : crop_window_gen({H, W}, "HW");
 
     int ndim = shape.sample_dim();
     slice_anchors_[data_idx].resize(ndim);

--- a/dali/pipeline/operators/crop/crop_attr.h
+++ b/dali/pipeline/operators/crop/crop_attr.h
@@ -108,7 +108,10 @@ class CropAttr {
     }
 
     crop_window_generators_[data_idx] =
-      [this, data_idx](kernels::TensorShape<> input_shape) {
+      [this, data_idx](kernels::TensorShape<> input_shape,
+                       const TensorLayout& shape_layout) {
+        DALI_ENFORCE(shape_layout == "HW",
+          make_string("Unexpected input shape layout:", shape_layout.c_str(), "vs HW"));
         CropWindow crop_window;
         if (input_shape.size() == 3) {
           auto crop_d = has_crop_d_ && crop_depth_[data_idx] > 0 ?

--- a/dali/pipeline/operators/crop/slice.cc
+++ b/dali/pipeline/operators/crop/slice.cc
@@ -31,11 +31,11 @@ DALI_SCHEMA(Slice)
     .NumInput(3)
     .NumOutput(1)
     .AllowSequences()
-    .AddOptionalArg(
-      "image_type",
+    .AddOptionalArg("image_type",
       R"code(The color space of input and output image)code",
       DALI_RGB, false)
     .AddParent("SliceBase")
+    .AddParent("SliceAttr")
     .InputLayout(0, { "HW", "HWC", "DHWC" });
 
 template <>

--- a/dali/pipeline/operators/crop/slice.cc
+++ b/dali/pipeline/operators/crop/slice.cc
@@ -35,7 +35,6 @@ DALI_SCHEMA(Slice)
       R"code(The color space of input and output image)code",
       DALI_RGB, false)
     .AddParent("SliceBase")
-    .AddParent("SliceAttr")
     .InputLayout(0, { "HW", "HWC", "DHWC" });
 
 template <>

--- a/dali/pipeline/operators/crop/slice_attr.h
+++ b/dali/pipeline/operators/crop/slice_attr.h
@@ -22,6 +22,7 @@
 #include "dali/pipeline/operators/common.h"
 #include "dali/pipeline/operators/operator.h"
 #include "dali/util/crop_window.h"
+#include "dali/core/tensor_layout.h"
 
 namespace dali {
 
@@ -102,7 +103,8 @@ class SliceAttr {
       + std::to_string(crop_h) + "] must be <= 1.0f");
 
     crop_window_generators_[data_idx] =
-      [this, data_idx](const kernels::TensorShape<>& shape) {
+      [this, data_idx](const kernels::TensorShape<>& shape,
+                       const TensorLayout& layout) {
         CropWindow crop_window;
         crop_window.anchor[0] = crop_y_norm_[data_idx] * shape[0];
         crop_window.anchor[1] = crop_x_norm_[data_idx] * shape[1];

--- a/dali/pipeline/operators/decoder/host/fused/host_decoder_crop_test.cc
+++ b/dali/pipeline/operators/decoder/host/fused/host_decoder_crop_test.cc
@@ -26,7 +26,10 @@ class ImageDecoderCropTest_CPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (const kernels::TensorShape<>& shape) {
+    return [this](const kernels::TensorShape<>& shape,
+                  const TensorLayout& shape_layout) {
+      DALI_ENFORCE(shape_layout == "HW",
+        make_string("Unexpected input shape layout:", shape_layout.c_str(), "vs HW"));
       CropWindow crop_window;
       crop_window.shape[0] = crop_H;
       crop_window.shape[1] = crop_W;

--- a/dali/pipeline/operators/decoder/host/fused/host_decoder_slice_test.cc
+++ b/dali/pipeline/operators/decoder/host/fused/host_decoder_slice_test.cc
@@ -52,7 +52,10 @@ class ImageDecoderSliceTest_CPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (const kernels::TensorShape<>& shape) {
+    return [this] (const kernels::TensorShape<>& shape,
+                   const TensorLayout& shape_layout) {
+      DALI_ENFORCE(shape_layout == "HW",
+        make_string("Unexpected input shape layout:", shape_layout.c_str(), "vs HW"));
       CropWindow crop_window;
       crop_window.anchor[0] = crop_y * shape[0];
       crop_window.anchor[1] = crop_x * shape[1];

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_crop_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_crop_test.cc
@@ -26,7 +26,10 @@ class ImageDecoderCropTest_GPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (const kernels::TensorShape<>& shape) {
+    return [this] (const kernels::TensorShape<>& shape,
+                   const TensorLayout& shape_layout) {
+      DALI_ENFORCE(shape_layout == "HW",
+        make_string("Unexpected input shape layout:", shape_layout.c_str(), "vs HW"));
       CropWindow crop_window;
       crop_window.shape[0] = crop_H;
       crop_window.shape[1] = crop_W;

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice_test.cc
@@ -56,7 +56,10 @@ class ImageDecoderSliceTest_GPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (const kernels::TensorShape<>& shape) {
+    return [this] (const kernels::TensorShape<>& shape,
+                   const TensorLayout& shape_layout) {
+      DALI_ENFORCE(shape_layout == "HW",
+        make_string("Unexpected input shape layout:", shape_layout.c_str(), "vs HW"));
       CropWindow crop_window;
       crop_window.anchor[0] = crop_y * shape[0];
       crop_window.anchor[1] = crop_x * shape[1];

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_crop_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_crop_test.cc
@@ -27,7 +27,10 @@ class ImageDecoderSplitCropTest_GPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (const kernels::TensorShape<>& shape) {
+    return [this] (const kernels::TensorShape<>& shape,
+                   const TensorLayout& shape_layout) {
+      DALI_ENFORCE(shape_layout == "HW",
+        make_string("Unexpected input shape layout:", shape_layout.c_str(), "vs HW"));
       CropWindow crop_window;
       crop_window.shape[0] = crop_H;
       crop_window.shape[1] = crop_W;

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_slice_test.cc
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_slice_test.cc
@@ -57,7 +57,10 @@ class ImageDecoderSplitSliceTest_GPU : public DecodeTestBase<ImgType> {
   }
 
   CropWindowGenerator GetCropWindowGenerator(int data_idx) const override {
-    return [this] (const kernels::TensorShape<>& shape) {
+    return [this] (const kernels::TensorShape<>& shape,
+                   const TensorLayout& shape_layout) {
+      DALI_ENFORCE(shape_layout == "HW",
+        make_string("Unexpected input shape layout:", shape_layout.c_str(), "vs HW"));
       CropWindow crop_window;
       crop_window.anchor[0] = crop_y * shape[0];
       crop_window.anchor[1] = crop_x * shape[1];

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
@@ -137,7 +137,7 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
 
         if (crop_generator) {
           kernels::TensorShape<> shape{info->heights[0], info->widths[0]};
-          info->crop_window = crop_generator(shape);
+          info->crop_window = crop_generator(shape, "HW");
           DALI_ENFORCE(info->crop_window.IsInRange(shape));
           info->heights[0] = info->crop_window.shape[0];
           info->widths[0] = info->crop_window.shape[1];
@@ -162,7 +162,7 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
 
       if (crop_generator) {
         kernels::TensorShape<> shape{info->heights[0], info->widths[0]};
-        info->crop_window = crop_generator(shape);
+        info->crop_window = crop_generator(shape, "HW");
         auto &crop_window = info->crop_window;
         DALI_ENFORCE(crop_window.IsInRange(shape));
         nvjpegDecodeParamsSetROI(decode_params_[data_idx],

--- a/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/pipeline/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -214,7 +214,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
           if (crop_generator) {
             kernels::TensorShape<> shape{info.heights[0], info.widths[0]};
-            info.crop_window = crop_generator(shape);
+            info.crop_window = crop_generator(shape, "HW");
             DALI_ENFORCE(info.crop_window.IsInRange(shape));
             info.heights[0] = info.crop_window.shape[0];
             info.widths[0] = info.crop_window.shape[1];
@@ -226,7 +226,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       } else {
         if (crop_generator) {
           kernels::TensorShape<> shape{info.heights[0], info.widths[0]};
-          info.crop_window = crop_generator(shape);
+          info.crop_window = crop_generator(shape, "HW");
           auto &crop_window = info.crop_window;
           DALI_ENFORCE(crop_window.IsInRange(shape));
           nvjpegDecodeParamsSetROI(decode_params_[i],

--- a/dali/pipeline/operators/fused/crop_mirror_normalize.h
+++ b/dali/pipeline/operators/fused/crop_mirror_normalize.h
@@ -209,7 +209,8 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
       D = shape[d_dim];
 
     auto crop_window_gen = GetCropWindowGenerator(data_idx);
-    auto win = spatial_ndim == 3 ? crop_window_gen({D, H, W}) : crop_window_gen({H, W});
+    auto win = spatial_ndim == 3 ?
+      crop_window_gen({D, H, W}, "DHW") : crop_window_gen({H, W}, "HW");
 
     int ndim = shape.sample_dim();
     slice_anchors_[data_idx].resize(ndim);

--- a/dali/pipeline/operators/resize/random_resized_crop.cc
+++ b/dali/pipeline/operators/resize/random_resized_crop.cc
@@ -70,7 +70,7 @@ void RandomResizedCrop<CPUBackend>::SetupSharedSampleParams(SampleWorkspace &ws)
   int W = input_shape[1];
   int id = ws.data_idx();
 
-  crops_[id] = GetCropWindowGenerator(id)({H, W});
+  crops_[id] = GetCropWindowGenerator(id)({H, W}, "HW");
   resample_params_[ws.thread_idx()] = CalcResamplingParams(id);
 }
 

--- a/dali/pipeline/operators/resize/random_resized_crop.cu
+++ b/dali/pipeline/operators/resize/random_resized_crop.cu
@@ -55,7 +55,7 @@ void RandomResizedCrop<GPUBackend>::SetupSharedSampleParams(DeviceWorkspace &ws)
     int H = input_shape[0];
     int W = input_shape[1];
 
-    crops_[i] = GetCropWindowGenerator(i)({H, W});
+    crops_[i] = GetCropWindowGenerator(i)({H, W}, "HW");
   }
   CalcResamplingParams();
 }

--- a/dali/test/dali_test.h
+++ b/dali/test/dali_test.h
@@ -82,7 +82,7 @@ class DALITest : public ::testing::Test {
 
     if (crop_window_generator) {
       cv::Mat cropped;
-      auto crop = crop_window_generator({tmp.rows, tmp.cols});
+      auto crop = crop_window_generator({tmp.rows, tmp.cols}, "HW");
       cv::Rect roi(crop.anchor[1], crop.anchor[0], crop.shape[1], crop.shape[0]);
       tmp(roi).copyTo(cropped);
       tmp = cropped;

--- a/dali/util/crop_window.h
+++ b/dali/util/crop_window.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <utility>
 #include "dali/kernels/tensor_shape.h"
+#include "dali/kernels/tensor_shape_print.h"
 #include "dali/core/tensor_layout.h"
 #include "dali/core/format.h"
 
@@ -47,11 +48,11 @@ struct CropWindow {
   }
 
   inline bool IsInRange(const kernels::TensorShape<>& input_shape) const {
-    DALI_ENFORCE(input_shape.size() == anchor.size() && input_shape.size() == shape.size(),
-      make_string(
-        "Input shape number of dimensions (", input_shape.size(),
-        ") doesn't match the  number of dimensions of the anchor (",
-        anchor.size(), ") and/or shape (", shape.size(), ")"));
+    DALI_ENFORCE(input_shape.size() == anchor.size()
+              && input_shape.size() == shape.size(),
+      make_string("Input shape, output shape and anchor must have the "
+                  "same number of dimensions. Got:\ninput: ",
+                  input_shape, "\nanchor: ", anchor, "\noutput shape:", shape));
     for (int dim = 0; dim < input_shape.size(); dim++)
       if (anchor[dim] < 0 || anchor[dim] + shape[dim] > input_shape[dim])
         return false;
@@ -67,7 +68,8 @@ struct CropWindow {
   }
 };
 
-using CropWindowGenerator = std::function<CropWindow(const kernels::TensorShape<>& shape)>;
+  using CropWindowGenerator = std::function<CropWindow(const kernels::TensorShape<>& shape,
+                                                       const TensorLayout& shape_layout)>;
 
 }  // namespace dali
 

--- a/dali/util/crop_window.h
+++ b/dali/util/crop_window.h
@@ -18,6 +18,8 @@
 #include <functional>
 #include <utility>
 #include "dali/kernels/tensor_shape.h"
+#include "dali/core/tensor_layout.h"
+#include "dali/core/format.h"
 
 namespace dali {
 
@@ -45,9 +47,11 @@ struct CropWindow {
   }
 
   inline bool IsInRange(const kernels::TensorShape<>& input_shape) const {
-    DALI_ENFORCE(input_shape.size() == anchor.size()
-              && input_shape.size() == shape.size(),
-      "Input shape doesn't match number of dimensions of the anchor and/or shape");
+    DALI_ENFORCE(input_shape.size() == anchor.size() && input_shape.size() == shape.size(),
+      make_string(
+        "Input shape number of dimensions (", input_shape.size(),
+        ") doesn't match the  number of dimensions of the anchor (",
+        anchor.size(), ") and/or shape (", shape.size(), ")"));
     for (int dim = 0; dim < input_shape.size(); dim++)
       if (anchor[dim] < 0 || anchor[dim] + shape[dim] > input_shape[dim])
         return false;


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
Need to stop assuming layout of the given shape in crop window generator to stop
preventing more complicated use cases to happen (e.g. arbitrary input layout)

#### What happened in this PR?
- Added a TensorLayout argument to CropWindowGenerator signature, specifying the interpretation of the given shape (e.g. `generator({H, W}, "HW")`)

**JIRA TASK**: [DALI-XXXX]