### PR TITLE
Add 3D case to shape layout verification in CropAttr

### DIFF
--- a/dali/pipeline/operators/crop/crop_attr.h
+++ b/dali/pipeline/operators/crop/crop_attr.h
@@ -110,8 +110,9 @@ class CropAttr {
     crop_window_generators_[data_idx] =
       [this, data_idx](kernels::TensorShape<> input_shape,
                        const TensorLayout& shape_layout) {
-        DALI_ENFORCE(shape_layout == "HW",
-          make_string("Unexpected input shape layout:", shape_layout.c_str(), "vs HW"));
+        DALI_ENFORCE(shape_layout == "HW" || shape_layout == "DHW",
+          make_string("Unexpected input shape layout:", shape_layout.c_str(),
+            " (expected HW or DHW)"));
         CropWindow crop_window;
         if (input_shape.size() == 3) {
           auto crop_d = has_crop_d_ && crop_depth_[data_idx] > 0 ?


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
Recent change in CropAttr disabled the crop 3d case in crop attr accidentally

#### What happened in this PR?
- Enable Crop 3d case in CropAttr by adding the 3D tensor layout case to the verification

**JIRA TASK**: [DALI-XXXX]