### PR TITLE
Make it possible to build DALI with any CUDA version

### DIFF
--- a/conda/recipe/build.sh
+++ b/conda/recipe/build.sh
@@ -46,10 +46,27 @@ export CXXFLAGS="${CXXFLAGS} -DNO_ALIGNED_ALLOC"
 cmake -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda \
       -DCUDA_rt_LIBRARY=$BUILD_PREFIX/${ARCH_LONGNAME}-linux-gnu/sysroot/usr/lib/librt.so \
       -DCUDA_CUDA_LIBRARY=/usr/local/cuda/targets/${ARCH}-linux/lib/stubs/libcuda.so \
-      -DNVJPEG_ROOT_DIR=/usr/local/cuda \
-      -DFFMPEG_ROOT_DIR=$PREFIX/lib \
+      -DNVJPEG_ROOT_DIR=/usr/local/cuda                   \
+      -DFFMPEG_ROOT_DIR=$PREFIX/lib                       \
       -DCMAKE_PREFIX_PATH="$PREFIX/libjpeg-turbo;$PREFIX" \
-      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX                      \
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}     \
+      -DBUILD_TEST=${BUILD_TEST:-ON}                      \
+      -DBUILD_BENCHMARK=${BUILD_BENCHMARK:-ON}            \
+      -DBUILD_NVTX=${BUILD_NVTX:-OFF}                     \
+      -DBUILD_PYTHON=${BUILD_PYTHON:-ON}                  \
+      -DBUILD_LMDB=${BUILD_LMDB:-ON}                      \
+      -DBUILD_JPEG_TURBO=${BUILD_JPEG_TURBO:-ON}          \
+      -DBUILD_NVJPEG=${BUILD_NVJPEG:-ON}                  \
+      -DBUILD_LIBTIFF=${BUILD_LIBTIFF:-ON}                \
+      -DBUILD_NVOF=${BUILD_NVOF:-ON}                      \
+      -DBUILD_NVDEC=${BUILD_NVDEC:-ON}                    \
+      -DBUILD_NVML=${BUILD_NVML:-ON}                      \
+      -DVERBOSE_LOGS=${VERBOSE_LOGS:-OFF}                 \
+      -DWERROR=${WERROR:-ON}                              \
+      -DBUILD_WITH_ASAN=${BUILD_WITH_ASAN:-OFF}           \
+      -DDALI_BUILD_FLAVOR=${NVIDIA_DALI_BUILD_FLAVOR}     \
+      -DTIMESTAMP=${DALI_TIMESTAMP} -DGIT_SHA=${GIT_SHA-${GIT_FULL_HASH}} \
       ..
 make -j"$(nproc --all)"
 make install

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -22,6 +22,26 @@ source:
   git_url: ../..
 
 build:
+  script_env:
+   - CMAKE_BUILD_TYPE
+   - BUILD_TEST
+   - BUILD_BENCHMARK
+   - BUILD_NVTX
+   - BUILD_PYTHON
+   - BUILD_LMDB
+   - BUILD_JPEG_TURBO
+   - BUILD_NVJPEG
+   - BUILD_LIBTIFF
+   - BUILD_NVOF
+   - BUILD_NVDEC
+   - BUILD_NVML
+   - VERBOSE_LOGS
+   - WERROR
+   - BUILD_WITH_ASAN
+   - NVIDIA_BUILD_ID
+   - GIT_SHA
+   - DALI_TIMESTAMP
+   - NVIDIA_DALI_BUILD_FLAVOR
   number: 0
   string: py{{ python | replace(".","") }}
 
@@ -42,6 +62,7 @@ requirements:
     - libopencv >=3.4.1
     - opencv >=3.4.1
     - boost >=1.67
+    - lmdb >=0.9.22
   run:
     - python
     - future >=0.17.1
@@ -51,3 +72,4 @@ requirements:
     - tensorflow-gpu
     - libopencv >=3.4.1
     - opencv >=3.4.1
+    - lmdb >=0.9.22

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,8 @@ ENV PYBIN=${PYTHONPATH}/bin \
     PYLIB=${PYTHONPATH}/lib
 
 ENV PATH=${PYBIN}:${PATH} \
-    LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:/opt/dali/${DALI_BUILD_DIR}:${PYLIB}:${LD_LIBRARY_PATH}
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:/opt/dali/${DALI_BUILD_DIR}:${PYLIB}:${LD_LIBRARY_PATH} \
+    LIBRARY_PATH=/usr/local/cuda/lib64/stubs:/opt/dali/${DALI_BUILD_DIR}:${PYLIB}:${LIBRARY_PATH}
 
 RUN ln -s /opt/python/cp${PYV}* /opt/python/v
 

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -26,8 +26,8 @@ Building Python wheel and (optionally) Docker image
 
 Change directory (``cd``) into ``docker`` directory and run ``./build.sh``. If needed, set the following environment variables:
 
-* PYVER - Python version. Default is ``2.7``.
-* CUDA_VERSION - CUDA toolkit version (9 for 9.0 or 10 for 10.0). Default is ``10``.
+* PYVER - Python version. Default is ``3.6``.
+* CUDA_VERSION - CUDA toolkit version (9 for 9.0 or 10 for 10.0). Default is ``10``. If the version is prefixed with `.` then any value ``XX`` can be passed and the user needs to make sure that Dockerfile.cudaXX.deps is present in `docker/` directory.
 * NVIDIA_BUILD_ID - Custom ID of the build. Default is ``1234``.
 * CREATE_WHL - Create a standalone wheel. Default is ``YES``.
 * BUILD_TF_PLUGIN - Create a DALI TensorFlow plugin as well. Default is ``NO``.
@@ -284,7 +284,7 @@ Build the aarch64 Linux Build Container
 
 .. code-block:: bash
 
-    docker build -t dali_builder:aarch64-linux -f Dockerfile.build.aarch64-linux .
+    docker build -t nvidia/dali:builder_aarch64-linux -f docker/Dockerfile.build.aarch64-linux .
 
 Compile
 ^^^^^^^
@@ -292,7 +292,7 @@ From the root of the DALI source tree
 
 .. code-block:: bash
 
-    docker run -v $(pwd):/dali dali_builder:aarch64-linux
+    docker run -v $(pwd):/dali nvidia/dali:builder_aarch64-linux
 
 The relevant artifacts will be in ``build/install`` and ``build/dali/python/nvidia/dali``
 
@@ -320,7 +320,7 @@ Build the aarch64 Build Container
 
 .. code-block:: bash
 
-    docker build -t dali_builder:aarch64-qnx -f Dockerfile.build.aarch64-qnx .
+    docker build -t nvidia/dali:builder_aarch64-qnx -f docker/Dockerfile.build.aarch64-qnx .
 
 Compile
 ^^^^^^^
@@ -328,6 +328,6 @@ From the root of the DALI source tree
 
 .. code-block:: bash
 
-    docker run -v $(pwd):/dali dali_builder:aarch64-qnx
+    docker run -v $(pwd):/dali nvidia/dali:builder_aarch64-qnx
 
 The relevant artifacts will be in ``build/install`` and ``build/dali/python/nvidia/dali``

--- a/qa/TL0_FW_iterators/test.sh
+++ b/qa/TL0_FW_iterators/test.sh
@@ -2,7 +2,7 @@
 # used pip packages
 
 
-pip_packages="nose numpy opencv-python tensorflow-gpu torch torchvision mxnet-cu##CUDA_VERSION##"
+pip_packages="nose numpy opencv-python tensorflow-gpu torch torchvision mxnet-cu{cuda_v}"
 target_dir=./dali/test/python
 
 one_config_only=true

--- a/qa/TL0_framework_imports/test.sh
+++ b/qa/TL0_framework_imports/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 
-pip_packages="mxnet-cu##CUDA_VERSION## tensorflow-gpu torchvision torch"
+pip_packages="mxnet-cu{cuda_v} tensorflow-gpu torchvision torch"
 
 test_body() {
     # test code

--- a/qa/TL0_python_self_test_frameworks/test.sh
+++ b/qa/TL0_python_self_test_frameworks/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy torch mxnet-cu##CUDA_VERSION##"
+pip_packages="nose numpy torch mxnet-cu{cuda_v}"
 target_dir=./dali/test/python
 
 test_body() {

--- a/qa/TL1_jupyter_plugins/test.sh
+++ b/qa/TL1_jupyter_plugins/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # used pip packages
-pip_packages="jupyter matplotlib mxnet-cu##CUDA_VERSION## tensorflow-gpu torchvision torch"
+pip_packages="jupyter matplotlib mxnet-cu{cuda_v} tensorflow-gpu torchvision torch"
 target_dir=./docs/examples
 
 do_once() {

--- a/qa/TL1_separate_executor/test.sh
+++ b/qa/TL1_separate_executor/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="tensorflow-gpu torchvision torch mxnet-cu##CUDA_VERSION##"
+pip_packages="tensorflow-gpu torchvision torch mxnet-cu{cuda_v}"
 target_dir=./dali/test/python
 one_config_only=true
 

--- a/qa/TL2_FW_iterators_perf/test.sh
+++ b/qa/TL2_FW_iterators_perf/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="tensorflow-gpu torchvision mxnet-cu##CUDA_VERSION## torch"
+pip_packages="tensorflow-gpu torchvision mxnet-cu{cuda_v} torch"
 target_dir=./dali/test/python
 one_config_only=true
 


### PR DESCRIPTION
- adds an ability to force build with any CUDA XX version as long
  an appropriate Dockerfile.cudaXX.deps is present in `docker/` directory

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- make it possible to build DALI with any CUDA version

#### What happened in this PR?
 - adds an ability to force build with any CUDA XX version as long an appropriate Dockerfile.cudaXX.deps is present in `docker/` directory
 - Tested locally
 - Docs updated

**JIRA TASK**: NA]