### PR TITLE
Surface2D -> ND generalization

### DIFF
--- a/dali/kernels/common/block_setup.h
+++ b/dali/kernels/common/block_setup.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include <utility>
 #include "dali/kernels/kernel.h"
-#include "dali/core/geom/vec.h"
+#include "dali/kernels/imgproc/roi.h"
 
 namespace dali {
 namespace kernels {
@@ -29,28 +29,6 @@ struct BlockDesc {
   int sample_idx;
   ivec<ndim> start, end;
 };
-
-template <int n>
-DALI_HOST_DEV
-ivec<n> shape2vec(const TensorShape<n> &shape) {
-  ivec<n> ret;
-  for (int i = 0; i < n; i++)
-    ret[n-1-i] = shape[i];
-  return ret;
-}
-
-template <int skip, int n>
-DALI_HOST_DEV
-std::enable_if_t<(skip < 0), TensorShape<n>> skip_dim(const TensorShape<n> &shape) {
-  return shape;
-}
-
-template <int skip, int n>
-DALI_HOST_DEV
-std::enable_if_t<(skip >= 0), TensorShape<n-1>> skip_dim(const TensorShape<n> &shape) {
-  static_assert(skip < n, "The dimension to be skipped must not exceed input ndim");
-  return shape_cat(shape.template first<skip>(), shape.template last<n-skip-1>());
-}
 
 /**
  * @brief A utility for calculating block layout for GPU kernels

--- a/dali/kernels/imgproc/resample/separable_cpu.h
+++ b/dali/kernels/imgproc/resample/separable_cpu.h
@@ -117,13 +117,13 @@ struct SeparableResampleCPU  {
     desc.set_base_pointers(input.data, static_cast<char*>(nullptr), output.data);
 
     auto in_ROI = as_surface_HWC(input);
-    in_ROI.width  = desc.in_shape()[1];
-    in_ROI.height = desc.in_shape()[0];
+    in_ROI.size.x = desc.in_shape()[1];
+    in_ROI.size.y = desc.in_shape()[0];
     in_ROI.data   = desc.template in_ptr<InputElement>();
 
     auto out_ROI = as_surface_HWC(output);
-    out_ROI.width  = desc.out_shape()[1];
-    out_ROI.height = desc.out_shape()[0];
+    out_ROI.size.x = desc.out_shape()[1];
+    out_ROI.size.y = desc.out_shape()[0];
     out_ROI.data   = desc.template out_ptr<OutputElement>();
 
     if (setup.IsPureNN(desc)) {

--- a/dali/kernels/imgproc/sampler.h
+++ b/dali/kernels/imgproc/sampler.h
@@ -61,8 +61,8 @@ struct Sampler<DALI_INTERP_NN, In> {
   DALI_HOST_DEV T at(
       int x, int y, int c,
       BorderValue border_value) const {
-    if (x < 0 || x >= surface.width ||
-        y < 0 || y >= surface.height) {
+    if (x < 0 || x >= surface.size.x ||
+        y < 0 || y >= surface.size.y) {
       return ConvertSat<T>(GetBorderChannel<In>(border_value, c));
     } else {
       return ConvertSat<T>(surface(x, y, c));
@@ -73,8 +73,7 @@ struct Sampler<DALI_INTERP_NN, In> {
   DALI_HOST_DEV T at(
       int x, int y, int c,
       BorderClamp) const {
-    x = clamp(x, 0, surface.width - 1);
-    y = clamp(y, 0, surface.height - 1);
+    ivec2 clamped = clamp(ivec2(x, y), ivec2(0, 0), surface.size);
 
     return ConvertSat<T>(surface(x, y, c));
   }
@@ -113,8 +112,8 @@ struct Sampler<DALI_INTERP_NN, In> {
       T *pixel,
       int x, int y,
       BorderValue border_value) const {
-    if (x < 0 || x >= surface.width ||
-        y < 0 || y >= surface.height) {
+    if (x < 0 || x >= surface.size.x ||
+        y < 0 || y >= surface.size.y) {
       for (int c = 0; c < surface.channels; c++) {
         pixel[c] = GetBorderChannel(border_value, c);
       }
@@ -130,10 +129,9 @@ struct Sampler<DALI_INTERP_NN, In> {
       T *pixel,
       int x, int y,
       BorderClamp) const {
-    x = clamp(x, 0, surface.width - 1);
-    y = clamp(y, 0, surface.height - 1);
+    ivec2 clamped = clamp(ivec2(x, y), ivec2(0, 0), surface.size);
     for (int c = 0; c < surface.channels; c++) {
-      pixel[c] = ConvertSat<T>(surface(x, y, c));
+      pixel[c] = ConvertSat<T>(surface(clamped, c));
     }
   }
 

--- a/dali/kernels/imgproc/sampler.h
+++ b/dali/kernels/imgproc/sampler.h
@@ -73,7 +73,7 @@ struct Sampler<DALI_INTERP_NN, In> {
   DALI_HOST_DEV T at(
       int x, int y, int c,
       BorderClamp) const {
-    ivec2 clamped = clamp(ivec2(x, y), ivec2(0, 0), surface.size);
+    ivec2 clamped = clamp(ivec2(x, y), ivec2(0, 0), surface.size - 1);
     return ConvertSat<T>(surface(clamped, c));
   }
 
@@ -128,7 +128,7 @@ struct Sampler<DALI_INTERP_NN, In> {
       T *pixel,
       int x, int y,
       BorderClamp) const {
-    ivec2 clamped = clamp(ivec2(x, y), ivec2(0, 0), surface.size);
+    ivec2 clamped = clamp(ivec2(x, y), ivec2(0, 0), surface.size - 1);
     for (int c = 0; c < surface.channels; c++) {
       pixel[c] = ConvertSat<T>(surface(clamped, c));
     }

--- a/dali/kernels/imgproc/sampler.h
+++ b/dali/kernels/imgproc/sampler.h
@@ -74,8 +74,7 @@ struct Sampler<DALI_INTERP_NN, In> {
       int x, int y, int c,
       BorderClamp) const {
     ivec2 clamped = clamp(ivec2(x, y), ivec2(0, 0), surface.size);
-
-    return ConvertSat<T>(surface(x, y, c));
+    return ConvertSat<T>(surface(clamped, c));
   }
 
   template <typename T = In, typename BorderValue>

--- a/dali/kernels/imgproc/sampler_cpu_test.cc
+++ b/dali/kernels/imgproc/sampler_cpu_test.cc
@@ -30,13 +30,13 @@ TEST(SamplerCPU, NN) {
 
   Pixel border = { 50, 100, 200 };
 
-  for (float y = -1; y <= surf.height+1; y += 0.1f) {
+  for (float y = -1; y <= surf.size.y+1; y += 0.1f) {
     int iy = floorf(y);
-    for (float x = -1; x <= surf.width+1; x += 0.1f) {
+    for (float x = -1; x <= surf.size.x+1; x += 0.1f) {
       int ix = floorf(x);
 
       Pixel ref;
-      if (ix < 0 || iy < 0 || ix >= surf.width || iy >= surf.height) {
+      if (ix < 0 || iy < 0 || ix >= surf.size.x || iy >= surf.size.y) {
         ref = border;
       } else {
         for (int c = 0; c < surf.channels; c++)
@@ -63,7 +63,7 @@ TEST(SamplerCPU, Linear) {
   ASSERT_EQ(sampler.surface.channels, 3);
 
   auto fetch = [&surf, &border](int ix, int iy)->Pixel {
-    if (ix < 0 || iy < 0 || ix >= surf.width || iy >= surf.height) {
+    if (ix < 0 || iy < 0 || ix >= surf.size.x || iy >= surf.size.y) {
       return border;
     } else {
       Pixel px;
@@ -73,10 +73,10 @@ TEST(SamplerCPU, Linear) {
     }
   };
 
-  for (int iy = -1; iy <= surf.height; iy++) {
-    for (int ix = -1; ix <= surf.width; ix++) {
+  for (int iy = -1; iy <= surf.size.y; iy++) {
+    for (int ix = -1; ix <= surf.size.x; ix++) {
       Pixel ref;
-      if (ix < 0 || iy < 0 || ix >= surf.width || iy >= surf.height) {
+      if (ix < 0 || iy < 0 || ix >= surf.size.x || iy >= surf.size.y) {
         ref = border;
       } else {
         for (int c = 0; c < surf.channels; c++)
@@ -94,14 +94,14 @@ TEST(SamplerCPU, Linear) {
 
   const float epsF = 255.00006 - 255;  // 4 ULP in IEEE 32-bit float for 0-255 range
   const float eps = 0.50000025f;  // 0.5 + 4 ULP
-  for (float y = -1; y <= surf.height+2; y += 0.125f) {
+  for (float y = -1; y <= surf.size.y+2; y += 0.125f) {
     float fy = y - 0.5f;
     int iy0 = floorf(fy);
     int iy1 = iy0 + 1;
     float qy = fy - iy0;
     float py = 1 - qy;
 
-    for (float x = -1; x <= surf.width+2; x += 0.125f) {
+    for (float x = -1; x <= surf.size.x+2; x += 0.125f) {
       float fx = x - 0.5f;
       int ix0 = floorf(fx);
       int ix1 = ix0 + 1;

--- a/dali/kernels/imgproc/sampler_test.h
+++ b/dali/kernels/imgproc/sampler_test.h
@@ -44,11 +44,11 @@ struct SamplerTestData {
     } else {
       surface.data = data;
     }
-    surface.width    = W;
-    surface.height   = H;
+    surface.size.x = W;
+    surface.size.y = H;
     surface.channels = C;
-    surface.pixel_stride   = C;
-    surface.row_stride     = W*C;
+    surface.strides.x = C;
+    surface.strides.y = W*C;
     surface.channel_stride = 1;
     return surface;
   }

--- a/dali/kernels/imgproc/surface.h
+++ b/dali/kernels/imgproc/surface.h
@@ -16,18 +16,92 @@
 #define DALI_KERNELS_IMGPROC_SURFACE_H_
 
 #include <cuda_runtime.h>
+#include <type_traits>
 #include "dali/kernels/tensor_view.h"
 #include "dali/kernels/imgproc/roi.h"
 
 namespace dali {
 namespace kernels {
 
-template <typename T>
-struct Surface2D {
+
+template <int _spatial_ndim, typename T>
+struct Surface {
+  static constexpr int spatial_ndim = _spatial_ndim;
+
+  constexpr Surface() = default;
+
+  template <int N = spatial_ndim, std::enable_if_t<N == 2, int> = 0>
+  DALI_HOST_DEV
+  constexpr Surface(T *data,
+                    int width, int height, int channels,
+                    int pixel_stride, int row_stride, int channel_stride)
+  : data(data), size(width, height), channels(channels),
+    strides(pixel_stride, row_stride), channel_stride(channel_stride) {
+  }
+
+  template <int N = spatial_ndim, std::enable_if_t<N == 3, int> = 0>
+  DALI_HOST_DEV
+  constexpr Surface(T *data,
+                    int width, int height, int depth, int channels,
+                    int pixel_stride, int row_stride, int slice_stride, int channel_stride)
+  : data(data), size(width, height, depth), channels(channels),
+    strides(pixel_stride, row_stride, slice_stride), channel_stride(channel_stride) {
+  }
+
+  DALI_HOST_DEV
+  constexpr Surface(T *data,
+                    ivec<spatial_ndim> size, int channels,
+                    ivec<spatial_ndim> strides, int channel_stride)
+  : data(data), size(size), channels(channels), strides(strides), channel_stride(channel_stride) {
+  }
+
   T *data;
-  int width, height, channels, pixel_stride, row_stride, channel_stride;
-  __host__ __device__ constexpr T &operator()(int x, int y, int c = 0) const {
-    return data[y * row_stride + x * pixel_stride + c * channel_stride];
+  ivec<spatial_ndim> size;
+  int channels;
+  ivec<spatial_ndim> strides;
+  int channel_stride;
+
+  DALI_HOST_DEV constexpr ivec<spatial_ndim + 1> strides_ch() const {
+    return cat(strides, channel_stride);
+  }
+
+  template <int N = spatial_ndim>
+  DALI_HOST_DEV
+  constexpr std::enable_if_t<N == 1, T &> operator()(int x, int c = 0) const {
+    static_assert(N == spatial_ndim, "N mustn't be explicitly set");
+    return (*this)({x, c});
+  }
+
+  template <int N = spatial_ndim>
+  DALI_HOST_DEV
+  constexpr std::enable_if_t<N == 2, T &> operator()(int x, int y, int c = 0) const {
+    static_assert(N == spatial_ndim, "N mustn't be explicitly set");
+    return (*this)({x, y, c});
+  }
+
+  template <int N = spatial_ndim>
+  DALI_HOST_DEV
+  constexpr std::enable_if_t<N == 3, T &> operator()(int x, int y, int z, int c = 0) const {
+    static_assert(N == spatial_ndim, "N mustn't be explicitly set");
+    return (*this)({x, y, z, c});
+  }
+
+  DALI_HOST_DEV constexpr T &operator()(ivec<spatial_ndim> pos, int c = 0) const {
+    return (*this)(cat(pos, c));
+  }
+
+  DALI_HOST_DEV constexpr T &operator()(ivec<spatial_ndim + 1> pos_and_channel) const {
+    return data[dot(pos_and_channel, this->strides_ch())];
+  }
+
+  DALI_HOST_DEV constexpr Surface<spatial_ndim - 1, T> slice(int outermost_pos = 0) const {
+    return {
+      &data[strides[spatial_ndim-1] * outermost_pos],
+      sub<spatial_ndim - 1>(size),
+      channels,
+      sub<spatial_ndim - 1>(strides),
+      channel_stride
+    };
   }
 
   /**
@@ -39,8 +113,8 @@ struct Surface2D {
    */
   template <typename U = T,
             typename V = std::enable_if_t<!std::is_const<U>::value, const U>>
-  __host__ __device__ operator Surface2D<V>&() {
-    return *reinterpret_cast<Surface2D<V>*>(this);
+  DALI_HOST_DEV operator Surface<spatial_ndim, V>&() {
+    return *reinterpret_cast<Surface<spatial_ndim, V>*>(this);
   }
 
   /**
@@ -52,57 +126,55 @@ struct Surface2D {
    */
   template <typename U = T,
             typename V = std::enable_if_t<!std::is_const<U>::value, const U>>
-  __host__ __device__ constexpr operator const Surface2D<V>&() const {
-    return *reinterpret_cast<const Surface2D<V>*>(this);
+  DALI_HOST_DEV constexpr operator const Surface<spatial_ndim, V>&() const {
+    return *reinterpret_cast<const Surface<spatial_ndim, V>*>(this);
   }
 };
+
+template <typename T>
+using Surface2D = Surface<2, T>;
+
+template <typename T>
+using Surface3D = Surface<3, T>;
 
 template <typename T, typename Storage>
 constexpr Surface2D<T> as_surface_HWC(const TensorView<Storage, T, 3> &t) {
   return { t.data,
-    static_cast<int>(t.shape[1]),  // width
-    static_cast<int>(t.shape[0]),  // height
-    static_cast<int>(t.shape[2]),  // channels
-    static_cast<int>(t.shape[2]),  // pixel stride
-    static_cast<int>(t.shape[1]) * static_cast<int>(t.shape[2]),  // row stride
-    1                              // channel stride - contiguous
+    ivec2(t.shape[1], t.shape[0]),                // width, height
+    static_cast<int>(t.shape[2]),                 // channels
+    ivec2(t.shape[2], t.shape[1] * t.shape[2]),   // pixel and row stride
+    1                                             // channel stride - contiguous
   };
 }
 
 template <typename T, typename Storage>
 constexpr Surface2D<T> as_surface_CHW(const TensorView<Storage, T, 3> &t) {
   return { t.data,
-    static_cast<int>(t.shape[2]),  // width
-    static_cast<int>(t.shape[1]),  // height
-    static_cast<int>(t.shape[0]),  // channels
-    1,                             // pixel stride - contiguous
-    static_cast<int>(t.shape[2]),  // row stride
-    static_cast<int>(t.shape[1]) * static_cast<int>(t.shape[2])  // channel stride - planes
+    ivec2(t.shape[2], t.shape[1]),                // width, height
+    static_cast<int>(t.shape[0]),                 // channels
+    ivec2(1, t.shape[2]),                         // pixel and row stride
+    static_cast<int>(t.shape[1] * t.shape[2])     // channel stride - planes
   };
 }
 
 template <typename T, typename Storage>
 constexpr Surface2D<T> as_surface(const TensorView<Storage, T, 2> &t) {
   return { t.data,
-    static_cast<int>(t.shape[1]),  // width
-    static_cast<int>(t.shape[0]),  // height
-    1,                             // channels
-    1,                             // pixel stride - contiguous
-    static_cast<int>(t.shape[1]),  // row stride
-    0                              // channel stride - irrelevant
+    ivec2(t.shape[1], t.shape[0]),  // width, height
+    1,                              // channels
+    ivec2(1, t.shape[1]),           // pixel and row stride
+    0                               // channel stride - irrelevant
   };
 }
-
 
 /**
  * Crops Surface according to given Roi
  */
-template <typename T>
-DALI_HOST_DEV constexpr Surface2D<T> crop(const Surface2D<T> &surface, const Roi<2> &roi) {
+template <int n, typename T>
+DALI_HOST_DEV constexpr Surface<n, T> crop(const Surface<n, T> &surface, const Roi<n> &roi) {
   auto cropped = surface;
-  cropped.data = &surface(roi.lo.x, roi.lo.y);
-  cropped.width = roi.extent().x;
-  cropped.height = roi.extent().y;
+  cropped.data = &surface(roi.lo);
+  cropped.size = roi.extent();
   return cropped;
 }
 

--- a/dali/kernels/imgproc/surface_test.cc
+++ b/dali/kernels/imgproc/surface_test.cc
@@ -32,7 +32,7 @@ TEST(Surface, HWC) {
 
   EXPECT_EQ(s.channel_stride, 1);
   EXPECT_EQ(s.strides.x, C);
-  EXPECT_EQ(s.strides.y, W*C);
+  EXPECT_EQ(s.strides.y, C*W);
 
   EXPECT_EQ(&s(0, 0, 0), data);
   EXPECT_EQ(&s(0, 0, 1), &data[1]);
@@ -81,6 +81,83 @@ TEST(Surface, HW) {
   EXPECT_EQ(&s(0, 1), &data[W]);
   EXPECT_EQ(&s(W-1, H-1, 0), &data[H*W-1]);
 }
+
+
+TEST(Surface, DHWC) {
+  const int H = 4;
+  const int W = 10;
+  const int D = 7;
+  const int C = 3;
+  float data[D*W*H*C];
+  auto tensor = make_tensor_cpu<4>(data, { D, H, W, C });
+  Surface3D<float> s = as_surface_channel_last(tensor);
+  EXPECT_EQ(s.size.x, W);
+  EXPECT_EQ(s.size.y, H);
+  EXPECT_EQ(s.size.z, D);
+  EXPECT_EQ(s.channels, C);
+
+  EXPECT_EQ(s.channel_stride, 1);
+  EXPECT_EQ(s.strides.x, C);
+  EXPECT_EQ(s.strides.y, C*W);
+  EXPECT_EQ(s.strides.z, C*W*H);
+
+  EXPECT_EQ(&s(0, 0, 0, 0), data);
+  EXPECT_EQ(&s(0, 0, 0, 1), &data[1]);
+  EXPECT_EQ(&s(1, 0, 0, 0), &data[C]);
+  EXPECT_EQ(&s(0, 1, 0, 0), &data[C*W]);
+  EXPECT_EQ(&s(0, 0, 1, 0), &data[C*W*H]);
+  EXPECT_EQ(&s(W-1, H-1, D-1, C-1), &data[D*H*W*C-1]);
+}
+
+TEST(Surface, CDHW) {
+  const int H = 4;
+  const int W = 10;
+  const int D = 7;
+  const int C = 3;
+  float data[D*W*H*C];
+  auto tensor = make_tensor_cpu<4>(data, { C, D, H, W });
+  Surface3D<float> s = as_surface_channel_first(tensor);
+  EXPECT_EQ(s.size.x, W);
+  EXPECT_EQ(s.size.y, H);
+  EXPECT_EQ(s.size.z, D);
+  EXPECT_EQ(s.channels, C);
+
+  EXPECT_EQ(s.channel_stride, W*H*D);
+  EXPECT_EQ(s.strides.x, 1);
+  EXPECT_EQ(s.strides.y, W);
+  EXPECT_EQ(s.strides.z, W*H);
+
+  EXPECT_EQ(&s(0, 0, 0, 0), data);
+  EXPECT_EQ(&s(0, 0, 0, 1), &data[D*W*H]);
+  EXPECT_EQ(&s(1, 0, 0, 0), &data[1]);
+  EXPECT_EQ(&s(0, 1, 0, 0), &data[W]);
+  EXPECT_EQ(&s(0, 0, 1, 0), &data[W*H]);
+  EXPECT_EQ(&s(W-1, H-1, D-1, C-1), &data[D*H*W*C-1]);
+}
+
+TEST(Surface, DHW) {
+  const int H = 4;
+  const int W = 10;
+  const int D = 7;
+  float data[D*W*H];
+  auto tensor = make_tensor_cpu<3>(data, { D, H, W });
+  Surface3D<float> s = as_surface(tensor);
+  EXPECT_EQ(s.size.x, W);
+  EXPECT_EQ(s.size.y, H);
+  EXPECT_EQ(s.size.z, D);
+  EXPECT_EQ(s.channels, 1);
+
+  EXPECT_EQ(s.strides.x, 1);
+  EXPECT_EQ(s.strides.y, W);
+  EXPECT_EQ(s.strides.z, W*H);
+
+  EXPECT_EQ(&s(0, 0, 0), data);
+  EXPECT_EQ(&s(1, 0, 0), &data[1]);
+  EXPECT_EQ(&s(0, 1, 0), &data[W]);
+  EXPECT_EQ(&s(0, 0, 1), &data[W*H]);
+  EXPECT_EQ(&s(W-1, H-1, D-1), &data[D*H*W-1]);
+}
+
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/imgproc/surface_test.cc
+++ b/dali/kernels/imgproc/surface_test.cc
@@ -26,13 +26,13 @@ TEST(Surface, HWC) {
   float data[W*H*C];
   auto tensor = make_tensor_cpu<3>(data, { H, W, C });
   Surface2D<float> s = as_surface_HWC(tensor);
-  EXPECT_EQ(s.width, W);
-  EXPECT_EQ(s.height, H);
+  EXPECT_EQ(s.size.x, W);
+  EXPECT_EQ(s.size.y, H);
   EXPECT_EQ(s.channels, C);
 
   EXPECT_EQ(s.channel_stride, 1);
-  EXPECT_EQ(s.pixel_stride, C);
-  EXPECT_EQ(s.row_stride, W*C);
+  EXPECT_EQ(s.strides.x, C);
+  EXPECT_EQ(s.strides.y, W*C);
 
   EXPECT_EQ(&s(0, 0, 0), data);
   EXPECT_EQ(&s(0, 0, 1), &data[1]);
@@ -48,13 +48,13 @@ TEST(Surface, CHW) {
   float data[W*H*C];
   auto tensor = make_tensor_cpu<3>(data, { C, H, W, });
   Surface2D<float> s = as_surface_CHW(tensor);
-  EXPECT_EQ(s.width, W);
-  EXPECT_EQ(s.height, H);
+  EXPECT_EQ(s.size.x, W);
+  EXPECT_EQ(s.size.y, H);
   EXPECT_EQ(s.channels, C);
 
   EXPECT_EQ(s.channel_stride, W*H);
-  EXPECT_EQ(s.pixel_stride, 1);
-  EXPECT_EQ(s.row_stride, W);
+  EXPECT_EQ(s.strides.x, 1);
+  EXPECT_EQ(s.strides.y, W);
 
   EXPECT_EQ(&s(0, 0, 0), data);
   EXPECT_EQ(&s(0, 0, 1), &data[W*H]);
@@ -69,12 +69,12 @@ TEST(Surface, HW) {
   float data[W*H];
   auto tensor = make_tensor_cpu<2>(data, { H, W, });
   Surface2D<float> s = as_surface(tensor);
-  EXPECT_EQ(s.width, W);
-  EXPECT_EQ(s.height, H);
+  EXPECT_EQ(s.size.x, W);
+  EXPECT_EQ(s.size.y, H);
   EXPECT_EQ(s.channels, 1);
 
-  EXPECT_EQ(s.pixel_stride, 1);
-  EXPECT_EQ(s.row_stride, W);
+  EXPECT_EQ(s.strides.x, 1);
+  EXPECT_EQ(s.strides.y, W);
 
   EXPECT_EQ(&s(0, 0), data);
   EXPECT_EQ(&s(1, 0), &data[1]);


### PR DESCRIPTION
Change surface from named sizes and strides to `ivec<n>`.
Templatize number of dimensions.
Refactor all the code that uses surfaces to adopt the new interface.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one*
- It adds ND surfaces because we need 3D surfaces for volumetric data handling

#### What happened in this PR?
 - Templatize `Surface` over number of spatial dimensions.
 - Pack spatial extents (width, height, depth) into `ivec<n>`
 - Make Surface2D and Surface3D template aliases
 - Old tests apply

**JIRA TASK**: [DALI-XXXX]