### PR TITLE
Expose arithm ops in Python

### DIFF
--- a/dali/operators/expressions/arithmetic.h
+++ b/dali/operators/expressions/arithmetic.h
@@ -122,7 +122,7 @@ DLL_PUBLIC DALIDataType PropagateTypes(ExprNode &expr, const workspace_t<Backend
   for (int i = 0; i < subexpression_count; i++) {
     types[i] = PropagateTypes<Backend>(func[i], ws);
   }
-  expr.SetTypeId(TypePromotion(make_span(types)));
+  expr.SetTypeId(TypePromotion(NameToOp(func.GetFuncName()), make_span(types)));
   return expr.GetTypeId();
 }
 

--- a/dali/operators/expressions/arithmetic_meta.h
+++ b/dali/operators/expressions/arithmetic_meta.h
@@ -39,6 +39,7 @@ enum class ArithmeticOp : int {
   sub,
   mul,
   div,
+  fdiv,
   mod,
 };
 
@@ -162,98 +163,109 @@ REGISTER_TYPE_PROMOTION(uint64_t, int64_t, int64_t);
 template <typename L, typename R>
 using binary_result_t = typename binary_op_promotion<L, R>::type;
 
-inline DALIDataType TypePromotion(DALIDataType left, DALIDataType right) {
-  DALIDataType result = DALIDataType::DALI_NO_TYPE;
-  TYPE_SWITCH(left, type2id, Left_t,
-    (int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
-        int64_t, uint64_t, float16, float, double),
-    (
-      TYPE_SWITCH(right, type2id, Right_t,
-        (int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
-            int64_t, uint64_t, float16, float, double),
-        (
-          using Result_t = binary_result_t<Left_t, Right_t>;
-          result = TypeInfo::Create<Result_t>().id();
-        ),  // NOLINT(whitespace/parens)
-        (DALI_FAIL("Right operand data type not supported, DALIDataType: " +
-            std::to_string(right));)
-      );   // NOLINT(whitespace/parens)
-    ),  // NOLINT(whitespace/parens)
-    (DALI_FAIL("Left operand data type not supported, DALIDataType: " + std::to_string(left));)
-  );  // NOLINT(whitespace/parens)
-  return result;
-}
-
-inline DALIDataType TypePromotion(span<DALIDataType> types) {
-  assert(types.size() == 1 || types.size() == 2);
-  if (types.size() == 1) {
-    return types[0];
-  }
-  return TypePromotion(types[0], types[1]);
-}
-
 /**
  * @brief Struct intended as a mapping from ArithmeticOp enum to it's implemetation.
+ *
  * It should provide an `impl` static member function of required arity accepting scalar inputs
- * of arbitrary arithmetic types.
+ * of arbitrary arithmetic types and the template allowing to calculate it's output type
  *
  * It also contains input and output counts as well as to_string member function.
+ *
+ * The full specification is provided in comment below
  *
  * @tparam op  Mapped Op.
  * @tparam Backend Allows to specialize for given backend
  */
 template <ArithmeticOp op, typename Backend>
-struct arithm_meta {
-  template <typename T>
-  DALI_HOST_DEV static constexpr std::enable_if_t<GetOpArity(op) == 1, T> impl(T v);
+struct arithm_meta;
 
-  template <typename L, typename R>
-  DALI_HOST_DEV static constexpr
-  std::enable_if_t<GetOpArity(op) == 2, binary_result_t<L, R>> impl(L l, R r);
+// Specification for arithm_meta
+//
+// template <ArithmeticOp op, typename Backend>
+// struct arithm_meta {
+//   /**
+//    * @brief Alias taking `num_inputs` types and returning a result type of the operation
+//    * For example for regular arithmetic binary operations it should be `binary_result_t`
+//    */
+//    template <typename... T>
+//    using result_t = ...;
+//
+//   /**
+//    * @brief Implementation of the operation on scalar values
+//    *
+//    * @tparam T Types of the arguments
+//    * @param t scalar values of the arguments
+//    * @return result of the oparation
+//    */
+//    template <typename... T>
+//    DALI_HOST_DEV static constexpr result_t<T...> impl(T... t);
+//
+//   /**
+//    * @brief Simple representation of the operation, like `+` or `sin`
+//    */
+//    static std::string to_string();
+//
+//   /**
+//    * @brief Constants defining the number of inputs and outputs of the operation
+//    */
+//    static constexpr int num_inputs;
+//    static constexpr int num_outputs;
+// };
 
-  static std::string to_string();
-
-  static constexpr int num_inputs = GetOpArity(op);
-  static constexpr int num_outputs = 1;
-};
-
-#define REGISTER_UNARY_IMPL_BACKEND(OP, EXPRESSION, BACKEND)                       \
-  template <>                                                                      \
-  template <typename T>                                                            \
-  DALI_HOST_DEV constexpr std::enable_if_t<GetOpArity(OP) == 1, T>                 \
-  arithm_meta<OP, BACKEND>::impl(T v) {                                            \
-    static_assert(GetOpArity(OP) == 1,                                             \
-                  "Registered operation arity does not match the requirements.");  \
-    return EXPRESSION v;                                                           \
-  }                                                                                \
-  template <>                                                                      \
-  inline std::string arithm_meta<OP, BACKEND>::to_string() {                       \
-    return #EXPRESSION;                                                            \
+#define REGISTER_UNARY_IMPL_BACKEND(OP, EXPRESSION, BACKEND)                        \
+  template <>                                                                       \
+  struct arithm_meta<OP, BACKEND> {                                                 \
+    template <typename T>                                                           \
+    using result_t = T;                                                             \
+                                                                                    \
+    template <typename T>                                                           \
+    DALI_HOST_DEV static constexpr result_t<T> impl(T v) {                          \
+      static_assert(GetOpArity(OP) == 1,                                            \
+                    "Registered operation arity does not match the requirements."); \
+      auto v_ = static_cast<result_t<T>>(v);                                        \
+      return EXPRESSION v_;                                                         \
+    }                                                                               \
+                                                                                    \
+    static inline std::string to_string() {                                         \
+      return #EXPRESSION;                                                           \
+    }                                                                               \
+                                                                                    \
+    static constexpr int num_inputs = 1;                                            \
+    static constexpr int num_outputs = 1;                                           \
   }
 
-#define REGISTER_UNARY_IMPL(OP, EXPRESSION)               \
-  REGISTER_UNARY_IMPL_BACKEND(OP, EXPRESSION, CPUBackend) \
+#define REGISTER_UNARY_IMPL(OP, EXPRESSION)                \
+  REGISTER_UNARY_IMPL_BACKEND(OP, EXPRESSION, CPUBackend); \
   REGISTER_UNARY_IMPL_BACKEND(OP, EXPRESSION, GPUBackend)
 
 REGISTER_UNARY_IMPL(ArithmeticOp::plus, +);
 REGISTER_UNARY_IMPL(ArithmeticOp::minus, -);
 
-#define REGISTER_BINARY_IMPL_BACKEND(OP, EXPRESSION, BACKEND)                          \
-  template <>                                                                          \
-  template <typename L, typename R>                                                    \
-  DALI_HOST_DEV constexpr std::enable_if_t<GetOpArity(OP) == 2, binary_result_t<L, R>> \
-  arithm_meta<OP, BACKEND>::impl(L l, R r) {                                           \
-    static_assert(GetOpArity(OP) == 2,                                                 \
-                  "Registered operation arity does not match the requirements.");      \
-    return l EXPRESSION r;                                                             \
-  }                                                                                    \
-  template <>                                                                          \
-  inline std::string arithm_meta<OP, BACKEND>::to_string() {                           \
-    return #EXPRESSION;                                                                \
+#define REGISTER_BINARY_IMPL_BACKEND(OP, EXPRESSION, BACKEND)                       \
+  template <>                                                                       \
+  struct arithm_meta<OP, BACKEND> {                                                 \
+    template <typename L, typename R>                                               \
+    using result_t = binary_result_t<L, R>;                                         \
+                                                                                    \
+    template <typename L, typename R>                                               \
+    DALI_HOST_DEV static constexpr result_t<L, R> impl(L l, R r) {                  \
+      static_assert(GetOpArity(OP) == 2,                                            \
+                    "Registered operation arity does not match the requirements."); \
+      auto l_ = static_cast<result_t<L, R>>(l);                                     \
+      auto r_ = static_cast<result_t<L, R>>(r);                                     \
+      return l_ EXPRESSION r_;                                                      \
+    }                                                                               \
+                                                                                    \
+    static inline std::string to_string() {                                         \
+      return #EXPRESSION;                                                           \
+    }                                                                               \
+                                                                                    \
+    static constexpr int num_inputs = 2;                                            \
+    static constexpr int num_outputs = 1;                                           \
   }
 
-#define REGISTER_BINARY_IMPL(OP, EXPRESSION)               \
-  REGISTER_BINARY_IMPL_BACKEND(OP, EXPRESSION, CPUBackend) \
+#define REGISTER_BINARY_IMPL(OP, EXPRESSION)                \
+  REGISTER_BINARY_IMPL_BACKEND(OP, EXPRESSION, CPUBackend); \
   REGISTER_BINARY_IMPL_BACKEND(OP, EXPRESSION, GPUBackend)
 
 REGISTER_BINARY_IMPL(ArithmeticOp::add, +);
@@ -261,18 +273,42 @@ REGISTER_BINARY_IMPL(ArithmeticOp::sub, -);
 REGISTER_BINARY_IMPL(ArithmeticOp::mul, *);
 REGISTER_BINARY_IMPL(ArithmeticOp::div, /);
 
+template <typename Backend>
+struct arithm_meta<ArithmeticOp::fdiv, Backend> {
+  template <typename L, typename R>
+  using result_t = std::conditional_t<!is_fp_or_half<L>::value && !is_fp_or_half<R>::value, float,
+                                      binary_result_t<L, R>>;
+
+  template <typename L, typename R>
+  DALI_HOST_DEV static constexpr result_t<L, R> impl(L l, R r) {
+    auto l_ = static_cast<result_t<L, R>>(l);
+    auto r_ = static_cast<result_t<L, R>>(r);
+    return l_ / r_;
+  }
+
+  static inline std::string to_string() {
+    return "/";
+  }
+
+  static constexpr int num_inputs = 2;
+  static constexpr int num_outputs = 1;
+};
+
 template <>
 struct arithm_meta<ArithmeticOp::mod, CPUBackend> {
   template <typename L, typename R>
+  using result_t = binary_result_t<L, R>;
+
+  template <typename L, typename R>
   static constexpr std::enable_if_t<
-      std::is_integral<L>::value && std::is_integral<R>::value, binary_result_t<L, R>>
+      std::is_integral<L>::value && std::is_integral<R>::value, result_t<L, R>>
   impl(L l, R r) {
     return l % r;
   }
 
   template <typename L, typename R>
   static constexpr std::enable_if_t<
-      !std::is_integral<L>::value || !std::is_integral<R>::value, binary_result_t<L, R>>
+      !std::is_integral<L>::value || !std::is_integral<R>::value, result_t<L, R>>
   impl(L l, R r) {
     using L_promotion = std::conditional_t<std::is_same<float16, L>::value, float, L>;
     using R_promotion = std::conditional_t<std::is_same<float16, R>::value, float, R>;
@@ -290,8 +326,11 @@ struct arithm_meta<ArithmeticOp::mod, CPUBackend> {
 template <>
 struct arithm_meta<ArithmeticOp::mod, GPUBackend> {
   template <typename L, typename R>
+  using result_t = binary_result_t<L, R>;
+
+  template <typename L, typename R>
   __device__ static constexpr std::enable_if_t<
-      std::is_integral<L>::value && std::is_integral<R>::value, binary_result_t<L, R>>
+      std::is_integral<L>::value && std::is_integral<R>::value, result_t<L, R>>
   impl(L l, R r) {
     return l % r;
   }
@@ -300,7 +339,7 @@ struct arithm_meta<ArithmeticOp::mod, GPUBackend> {
   __device__ static constexpr std::enable_if_t<
       (!std::is_integral<L>::value || !std::is_integral<R>::value) &&
           (sizeof(L) < sizeof(double) && sizeof(R) < sizeof(double)),
-      binary_result_t<L, R>>
+      result_t<L, R>>
   impl(L l, R r) {
     return remainderf(static_cast<float>(l), static_cast<float>(r));
   }
@@ -332,6 +371,43 @@ inline std::string to_string(ArithmeticOp op) {
   return result;
 }
 
+
+inline DALIDataType BinaryTypePromotion(DALIDataType left, DALIDataType right) {
+  DALIDataType result = DALIDataType::DALI_NO_TYPE;
+  TYPE_SWITCH(left, type2id, Left_t,
+    (int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+        int64_t, uint64_t, float16, float, double),
+    (
+      TYPE_SWITCH(right, type2id, Right_t,
+        (int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
+            int64_t, uint64_t, float16, float, double),
+        (
+          using Result_t = binary_result_t<Left_t, Right_t>;
+          result = TypeInfo::Create<Result_t>().id();
+        ),  // NOLINT(whitespace/parens)
+        (DALI_FAIL("Right operand data type not supported, DALIDataType: " +
+            std::to_string(right));)
+      );   // NOLINT(whitespace/parens)
+    ),  // NOLINT(whitespace/parens)
+    (DALI_FAIL("Left operand data type not supported, DALIDataType: " + std::to_string(left));)
+  );  // NOLINT(whitespace/parens)
+  return result;
+}
+
+inline DALIDataType TypePromotion(ArithmeticOp op, span<DALIDataType> types) {
+  assert(types.size() == 1 || types.size() == 2);
+  if (types.size() == 1) {
+    return types[0];
+  }
+  if (op == ArithmeticOp::fdiv) {
+    if (!IsFloatingPoint(types[0]) && !IsFloatingPoint(types[1])) {
+      return DALIDataType::DALI_FLOAT;
+    }
+  }
+  return BinaryTypePromotion(types[0], types[1]);
+}
+
+
 inline ArithmeticOp NameToOp(const std::string &op_name) {
   static std::map<std::string, ArithmeticOp> token_to_op = {
       {"plus",  ArithmeticOp::plus},
@@ -340,6 +416,7 @@ inline ArithmeticOp NameToOp(const std::string &op_name) {
       {"sub",   ArithmeticOp::sub},
       {"mul",   ArithmeticOp::mul},
       {"div",   ArithmeticOp::div},
+      {"fdiv",  ArithmeticOp::fdiv},
       {"mod",   ArithmeticOp::mod}
   };
   auto it = token_to_op.find(op_name);

--- a/dali/operators/expressions/expression_impl_factory_cpu.cc
+++ b/dali/operators/expressions/expression_impl_factory_cpu.cc
@@ -20,11 +20,13 @@
 #include "dali/operators/expressions/expression_impl_cpu.h"
 #include "dali/operators/expressions/expression_impl_factory.h"
 
+// TODO(klecki): float16
 #define ALLOWED_TYPES \
-  (uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float16, float, double)
+  (uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double)
 
-#define ALLOWED_OPS \
-  (ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div, ArithmeticOp::mod)
+#define ALLOWED_OPS                                                                                \
+  (ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div, ArithmeticOp::fdiv, \
+      ArithmeticOp::mod)
 
 namespace dali {
 
@@ -39,7 +41,7 @@ std::unique_ptr<ExprImplBase> ExprImplFactory2(const HostWorkspace &ws,
   TYPE_SWITCH(left_type, type2id, Left_t, ALLOWED_TYPES, (
     TYPE_SWITCH(right_type, type2id, Right_t, ALLOWED_TYPES, (
         VALUE_SWITCH(op, op_static, ALLOWED_OPS, (
-          using Out_t = binary_result_t<Left_t, Right_t>;
+          using Out_t = arithm_meta<op_static, CPUBackend>::result_t<Left_t, Right_t>;
           if (expr[0].GetNodeType() == NodeType::Tensor &&
               expr[1].GetNodeType() == NodeType::Tensor) {
             result.reset(new ExprImplBinCPU<op_static, Out_t,

--- a/dali/operators/expressions/expression_impl_factory_gpu.cu
+++ b/dali/operators/expressions/expression_impl_factory_gpu.cu
@@ -20,12 +20,13 @@
 #include "dali/operators/expressions/expression_impl_gpu.cuh"
 #include "dali/operators/expressions/expression_impl_factory.h"
 
-// float16
+// TODO(klecki): float16
 #define ALLOWED_TYPES \
   (uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double)
 
-#define ALLOWED_OPS \
-  (ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div, ArithmeticOp::mod)
+#define ALLOWED_OPS                                                                                \
+  (ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div, ArithmeticOp::fdiv, \
+      ArithmeticOp::mod)
 
 namespace dali {
 
@@ -42,7 +43,7 @@ std::unique_ptr<ExprImplBase> ExprImplFactory2(const DeviceWorkspace &ws,
   TYPE_SWITCH(left_type, type2id, Left_t, ALLOWED_TYPES, (
     TYPE_SWITCH(right_type, type2id, Right_t, ALLOWED_TYPES, (
         VALUE_SWITCH(op, op_static, ALLOWED_OPS, (
-          using Out_t = binary_result_t<Left_t, Right_t>;
+          using Out_t = arithm_meta<op_static, GPUBackend>::result_t<Left_t, Right_t>;
           if (expr[0].GetNodeType() == NodeType::Tensor &&
               expr[1].GetNodeType() == NodeType::Tensor) {
             result.reset(new ExprImplBinGPU<op_static, Out_t,

--- a/dali/python/__init__.py.in
+++ b/dali/python/__init__.py.in
@@ -16,7 +16,8 @@ from __future__ import absolute_import
 
 from . import ops
 from . import pipeline
-from . import edge
+from . import tensors
+from . import check_edge
 from . import tfrecord
 from . import types
 from . import plugin_manager

--- a/dali/python/nvidia/dali/check_edge.py
+++ b/dali/python/nvidia/dali/check_edge.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _validate_edge_reference(edge):
+    # TODO(klecki): adjust to <class 'nvidia.dali.ops._EdgeReference'>
+    if not "EdgeReference" in str(type(edge)):
+        raise TypeError(("Expected outputs of type compatible with \"EdgeReference\"."
+                " Received output type with name \"{}\" that does not match.")
+                .format(type(edge).__name__))
+    for attr in ["name", "device", "source"]:
+      if not hasattr(edge, attr):
+          raise TypeError(("Expected outputs of type compatible with \"EdgeReference\". Received"
+                  " output type \"{}\" does not have the attribute \"{}\" that is required.")
+                  .format(type(edge).__name__, attr))
+    return True

--- a/dali/python/nvidia/dali/edge.py
+++ b/dali/python/nvidia/dali/edge.py
@@ -17,8 +17,17 @@ import nvidia.dali.backend
 from nvidia.dali.backend import TensorCPU
 from nvidia.dali.backend import TensorListCPU
 
+print("[Warning] nvidia.dali.edge is deprecated. For TensorCPU and TensorListCPU " +
+        "use nvidia.dali.tensors. EdgeReference is intended to be created only by " +
+        "DALI Operators, and should not be instantiated directly by the user. " +
+        "This class will be removed in DALI 0.17.")
+
+# Deprecate and move to ops.py
 class EdgeReference(object):
     def __init__(self, name, device="cpu", source=None):
+        print("[Warning] EdgeReference from nvidia.dali.edge module is now deprecated. " +
+                "This class is intended to be created only by DALI Operators, and should not be " +
+                "instantiated directly by the user. This class will be removed in DALI 0.17.")
         self.name = name
         self.device = device
         self.source = source

--- a/dali/python/nvidia/dali/tensors.py
+++ b/dali/python/nvidia/dali/tensors.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#pylint: disable=no-name-in-module, unused-import
+import nvidia.dali.backend
+from nvidia.dali.backend import TensorCPU
+from nvidia.dali.backend import TensorListCPU
+from nvidia.dali.backend import TensorGPU
+from nvidia.dali.backend import TensorListGPU

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+from __future__ import division
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops as ops
+import nvidia.dali.types as types
+from nvidia.dali.tensors import TensorListGPU
+import numpy as np
+from nose.tools import assert_equals
+
+from test_utils import check_batch
+
+batch_size = 8
+
+# Shape of the samples
+shape = (8, 8)
+
+devices = ["cpu_cpu", "cpu_gpu", "gpu_gpu", "gpu_gpu"]
+
+# float16 is marked as TODO in backend for gpu
+types = [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64,
+         np.float32, np.float64]
+
+
+sane_operations = [((lambda x, y: x + y), "+"), ((lambda x, y: x - y), "-"),
+                   ((lambda x, y: x * y), "*")]
+
+def as_cpu(tl):
+    if isinstance(tl, TensorListGPU):
+        return tl.as_cpu()
+    return tl
+
+
+def max_dtype(kind, left_dtype, right_dtype):
+    return np.dtype(kind + str(max(left_dtype.itemsize, right_dtype.itemsize)))
+
+def float_bin_promote(left_dtype, right_dtype):
+    if 'f' in left_dtype.kind and not 'f' in right_dtype.kind:
+        return left_dtype
+    if not 'f' in left_dtype.kind and 'f' in right_dtype.kind:
+        return right_dtype
+    return max_dtype('f', left_dtype, right_dtype)
+
+def signed_unsigned_bin_promote(signed_type, unsigned_type):
+    if signed_type.itemsize > unsigned_type.itemsize:
+        return np.dtype('i' + str(signed_type.itemsize))
+    itemsize = min(unsigned_type.itemsize * 2, 8)
+    return np.dtype('i' + str(itemsize))
+
+def bin_promote_dtype(left_dtype, right_dtype):
+    if left_dtype == right_dtype:
+        return left_dtype
+    if 'f' in left_dtype.kind or 'f' in right_dtype.kind:
+        return float_bin_promote(left_dtype, right_dtype)
+    if 'i' in left_dtype.kind and 'i' in right_dtype.kind:
+        return max_dtype('i', left_dtype, right_dtype)
+    if 'u' in left_dtype.kind and 'u' in right_dtype.kind:
+        return max_dtype('u', left_dtype, right_dtype)
+    if 'i' in left_dtype.kind:
+        return signed_unsigned_bin_promote(left_dtype, right_dtype)
+    return signed_unsigned_bin_promote(right_dtype, left_dtype)
+
+
+def bin_promote(left_type, right_type):
+    left_dtype = np.dtype(left_type)
+    right_dtype = np.dtype(right_type)
+    return bin_promote_dtype(left_dtype, right_dtype).type
+
+# For __truediv__ we promote integer results to float, otherwise proceed like with bin op
+def div_promote(left_type, right_type):
+    left_dtype = np.dtype(left_type)
+    right_dtype = np.dtype(right_type)
+    if 'f' not in left_dtype.kind and 'f' not in right_dtype.kind:
+        return np.float32
+    return float_bin_promote(left_dtype, right_dtype)
+
+
+def int_generator(shape, type):
+    iinfo = np.iinfo(type)
+    result = np.random.randint(iinfo.min / 2, iinfo.max / 2, shape, type)
+    zero_mask = result == 0
+    return result + zero_mask
+
+
+class ExternalInputIterator(object):
+    def __init__(self, batch_size, left_type, right_type):
+        self.batch_size = batch_size
+        self.left_type = left_type
+        self.right_type = right_type
+        self.gen_l = self.get_generator(self.left_type)
+        self.gen_r = self.get_generator(self.right_type)
+        self.shape = shape
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        left = []
+        right = []
+        for sample in range(self.batch_size):
+            left.append(self.gen_l(self.shape))
+            right.append(self.gen_r(self.shape))
+        return (left, right)
+
+    def get_generator(self, type):
+        if type in [np.float16, np.float32, np.float64]:
+            return lambda shape : type(np.random.rand(shape[0], shape[1]))
+        else:
+            return lambda shape : int_generator(shape, type)
+
+    next = __next__
+
+
+class ExprOpPipeline(Pipeline):
+    def __init__(self, dev, iterator, op, batch_size, num_threads, device_id):
+        super(ExprOpPipeline, self).__init__(batch_size, num_threads, device_id, seed=12)
+        self.left_source = ops.ExternalSource()
+        self.right_source = ops.ExternalSource()
+        self.dev = dev
+        self.iterator = iterator
+        self.op = op
+
+    def define_graph(self):
+        self.left = self.left_source()
+        self.right = self.right_source()
+        if self.dev == "cpu_cpu":
+            return self.left, self.right, self.op(self.left, self.right)
+        elif self.dev == "gpu_cpu":
+            return self.left, self.right, self.op(self.left.gpu(), self.right)
+        elif self.dev == "cpu_gpu":
+            return self.left, self.right, self.op(self.left, self.right.gpu())
+        else:
+            return self.left, self.right, self.op(self.left.gpu(), self.right.gpu())
+
+    def iter_setup(self):
+        (l, r) = self.iterator.next()
+        self.feed_input(self.left, l)
+        self.feed_input(self.right, r)
+
+# Regular arithmetic ops that can be validated as straight numpy
+def check_arithm_op(dev, left_type, right_type, op, op_desc):
+    target_type = bin_promote(left_type, right_type)
+    iterator = iter(ExternalInputIterator(batch_size, left_type, right_type))
+    pipe = ExprOpPipeline(dev, iterator, op, batch_size = batch_size, num_threads = 2,
+            device_id = 0)
+    pipe.build()
+    pipe_out = pipe.run()
+    l = as_cpu(pipe_out[0]).as_array()
+    r = as_cpu(pipe_out[1]).as_array()
+    out = as_cpu(pipe_out[2]).as_array()
+    assert_equals(out.dtype, target_type)
+    if 'f' in np.dtype(target_type).kind:
+        np.testing.assert_allclose(out, op(l.astype(target_type), r.astype(target_type)),
+            rtol=1e-07 if target_type != np.float16 else 0.005)
+    else:
+        np.testing.assert_array_equal(out, op(l.astype(target_type), r.astype(target_type)))
+
+def test_arithmetic_ops():
+    for dev in devices:
+        for (op, op_desc) in sane_operations:
+            for left_type in types:
+                for right_type in types:
+                    yield check_arithm_op, dev, left_type, right_type, op, op_desc
+
+# The div operator that always returns floating point values
+def check_arithm_fdiv(dev, left_type, right_type):
+    target_type = div_promote(left_type, right_type)
+    iterator = iter(ExternalInputIterator(batch_size, left_type, right_type))
+    pipe = ExprOpPipeline(dev, iterator, (lambda x, y : x / y), batch_size = batch_size,
+            num_threads = 2, device_id = 0)
+    pipe.build()
+    pipe_out = pipe.run()
+    l = as_cpu(pipe_out[0]).as_array()
+    r = as_cpu(pipe_out[1]).as_array()
+    out = as_cpu(pipe_out[2]).as_array()
+    assert_equals(out.dtype, target_type)
+    np.testing.assert_allclose(out, l.astype(target_type) / r.astype(target_type),
+        rtol=1e-07 if target_type != np.float16 else 0.005)
+
+def test_arithmetic_float_division():
+    for dev in devices:
+        for left_type in types:
+                for right_type in types:
+                    yield check_arithm_fdiv, dev, left_type, right_type
+
+# The div operator behaves like C/C++ one
+def check_arithm_div(dev, left_type, right_type):
+    target_type = bin_promote(left_type, right_type)
+    iterator = iter(ExternalInputIterator(batch_size, left_type, right_type))
+    pipe = ExprOpPipeline(dev, iterator, (lambda x, y : x // y), batch_size = batch_size,
+            num_threads = 2, device_id = 0)
+    pipe.build()
+    pipe_out = pipe.run()
+    l = as_cpu(pipe_out[0]).as_array()
+    r = as_cpu(pipe_out[1]).as_array()
+    out = as_cpu(pipe_out[2]).as_array()
+    assert_equals(out.dtype, target_type)
+    if 'f' in np.dtype(target_type).kind:
+        np.testing.assert_allclose(out, l.astype(target_type) / r.astype(target_type),
+            rtol=1e-07 if target_type != np.float16 else 0.005)
+    else:
+        # Approximate validation, as np does something different than C
+        result = np.abs(l.astype(target_type)) // np.abs(r.astype(target_type))
+        neg = ((l < 0) & (r > 0)) | ((l > 0) & (r < 0))
+        pos = ~neg
+        result = result * (pos * 1 - neg * 1)
+        np.testing.assert_array_equal(out, result)
+
+def test_arithmetic_division():
+    for dev in devices:
+        for left_type in types:
+                for right_type in types:
+                    yield check_arithm_div, dev, left_type, right_type

--- a/dali/test/python/test_operator_python_function.py
+++ b/dali/test/python/test_operator_python_function.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from nvidia.dali.pipeline import Pipeline
-from nvidia.dali.edge import EdgeReference
+from nvidia.dali.ops import _EdgeReference
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
 import numpy
@@ -56,7 +56,7 @@ class PythonOperatorPipeline(CommonPipeline):
     def define_graph(self):
         images, labels = self.load()
         processed = self.python_function(images)
-        assert isinstance(processed, EdgeReference)
+        assert isinstance(processed, _EdgeReference)
         return processed
 
 class PythonOperatorInvalidPipeline(PythonOperatorPipeline):
@@ -90,8 +90,8 @@ class TwoOutputsPythonOperatorPipeline(CommonPipeline):
     def define_graph(self):
         images, labels = self.load()
         out1, out2 = self.python_function(images)
-        assert isinstance(out1, EdgeReference)
-        assert isinstance(out2, EdgeReference)
+        assert isinstance(out1, _EdgeReference)
+        assert isinstance(out2, _EdgeReference)
         return out1, out2
 
 
@@ -105,9 +105,9 @@ class MultiInputMultiOutputPipeline(CommonPipeline):
         images1, labels1 = self.load()
         images2, labels2 = self.load()
         out1, out2, out3 = self.python_function(images1, images2)
-        assert isinstance(out1, EdgeReference)
-        assert isinstance(out2, EdgeReference)
-        assert isinstance(out3, EdgeReference)
+        assert isinstance(out1, _EdgeReference)
+        assert isinstance(out2, _EdgeReference)
+        assert isinstance(out3, _EdgeReference)
         return out1, out2, out3
 
 

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from nvidia.dali.pipeline import Pipeline
-from nvidia.dali.edge import EdgeReference
+from nvidia.dali.ops import _EdgeReference
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
 import nvidia.dali as dali

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -14,7 +14,6 @@
 
 import glob
 from nvidia.dali.pipeline import Pipeline
-from nvidia.dali.edge import EdgeReference
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
 import nvidia.dali.tfrecord as tfrec
@@ -124,10 +123,10 @@ def test_multiple_input_sets():
             boxes = [boxes_ssd0, boxes_ssd1]
             labels = [labels_ssd0, labels_ssd1]
             enc_boxes0, enc_labels0 = self.box_encoder_cpu(boxes, labels)
-            # Test one list with one EdgeReference
+            # Test one list with one _EdgeReference
             enc_boxes1, enc_labels1 = self.box_encoder_cpu(boxes, labels_ssd0)
 
-            # Return everything (only EdgeReferences allowed)
+            # Return everything (only _EdgeReference allowed)
             return (encoded_boxes0, encoded_labels0, encoded_boxes1, encoded_labels1,
                     enc_boxes0[0], enc_labels0[0], enc_boxes0[1], enc_labels0[1],
                     enc_boxes1[0], enc_labels1[0], enc_boxes1[1], enc_labels1[1])

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -15,7 +15,6 @@
 from __future__ import print_function
 
 from nvidia.dali.pipeline import Pipeline
-from nvidia.dali.edge import EdgeReference
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
 import nvidia.dali as dali

--- a/docs/examples/expressions.ipynb
+++ b/docs/examples/expressions.ipynb
@@ -1,0 +1,193 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DALI expressions and arithmetic operators\n",
+    "\n",
+    "In this example, we will see how to use arithmetic operators in DALI Pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import types\n",
+    "import collections\n",
+    "import numpy as np\n",
+    "from nvidia.dali.pipeline import Pipeline\n",
+    "import nvidia.dali.ops as ops            \n",
+    "import nvidia.dali.types as types\n",
+    "\n",
+    "batch_size = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Defining the iterator\n",
+    "\n",
+    "We will use custom iterator producing small tensors filled with series of numbers, so we can easily inspect the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ExternalInputIterator(object):\n",
+    "    def __init__(self, batch_size, left_type, right_type):\n",
+    "        self.batch_size = batch_size\n",
+    "        self.left_type = left_type\n",
+    "        self.right_type = right_type\n",
+    "\n",
+    "    def __iter__(self):\n",
+    "        self.i = 0\n",
+    "        self.n = 128\n",
+    "        return self\n",
+    "\n",
+    "    def __next__(self):\n",
+    "        left = []\n",
+    "        right = []\n",
+    "        for sample in range(self.batch_size):\n",
+    "            left.append(np.array([sample + self.i], dtype = self.left_type))\n",
+    "            right.append(np.array([self.batch_size + self.i + sample], dtype = self.right_type))\n",
+    "        self.i = (self.i + 1) % self.n\n",
+    "        return (left, right)\n",
+    "    \n",
+    "    next = __next__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Instantiating the iterators\n",
+    "\n",
+    "We create instances of the `ExternalInputIterator` with different type combinations. Type promotions for binary operators are described below. They apply to `+`, `-`, `*` and `//`. The `/` always returns a float32 for integer inputs, and applies the rules below when at least one of the inputs is a floating point number.\n",
+    "\n",
+    "```\n",
+    "  T      op T      = T\n",
+    "  floatX op T      = floatX           (where T is not a float)\n",
+    "  floatX op floatY = float(max(X, Y))\n",
+    "  intX   op intY   = int(max(X, Y))\n",
+    "  uintX  op uintY  = uint(max(X, Y))\n",
+    "  intX   op uintY  = int2Y            (if X <= Y)\n",
+    "  intX   op uintY  = intX             (if X > Y)\n",
+    " ```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iterator_u8_u8 = iter(ExternalInputIterator(batch_size, np.uint8, np.uint8))\n",
+    "iterator_u8_i32 = iter(ExternalInputIterator(batch_size, np.uint8, np.int32))\n",
+    "iterator_i16_u8 = iter(ExternalInputIterator(batch_size, np.int16, np.uint8))\n",
+    "iterator_i32_f32 = iter(ExternalInputIterator(batch_size, np.int32, np.float32))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Defining the pipeline\n",
+    "\n",
+    "The next step is to define the Pipeline.\n",
+    "\n",
+    "We override `Pipeline.iter_setup`, a method called by the pipeline before every `Pipeline.run`, to call the iterator\n",
+    "and feed the result to `ExternalSource()` operators, referenced by `self.left` and `self.right`, by using `feed_input`.\n",
+    "\n",
+    "Note, that we do not need to instantiate any additional operators, we can use regular Python arithmetic expression on the results of other operators in the `define_graph` step.\n",
+    "\n",
+    "Here we return both of the inputs and the result of `self.right + self.right * self.left`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    " class ExternalSourcePipeline(Pipeline):                   \n",
+    "    def __init__(self, iterator, batch_size, num_threads, device_id):\n",
+    "        super(ExternalSourcePipeline, self).__init__(batch_size, num_threads, device_id, seed=12)\n",
+    "        self.left_source = ops.ExternalSource()\n",
+    "        self.right_source = ops.ExternalSource()\n",
+    "        self.iterator = iterator\n",
+    "\n",
+    "    def define_graph(self):                                                                \n",
+    "        self.left = self.left_source()\n",
+    "        self.right = self.right_source()\n",
+    "        return self.left, self.right, self.right + self.right * self.left\n",
+    "\n",
+    "    def iter_setup(self):\n",
+    "        (l, r) = self.iterator.next()\n",
+    "        self.feed_input(self.left, l)\n",
+    "        self.feed_input(self.right, r)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using the pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1]] + [[1]] * [[0]] = [[1]] of type uint8\n",
+      "[[1]] + [[1]] * [[0]] = [[1]] of type int32\n",
+      "[[1]] + [[1]] * [[0]] = [[1]] of type int16\n",
+      "[[1.]] + [[1.]] * [[0]] = [[1.]] of type float32\n"
+     ]
+    }
+   ],
+   "source": [
+    "for it in [iterator_u8_u8, iterator_u8_i32, iterator_i16_u8, iterator_i32_f32]:\n",
+    "    pipe = ExternalSourcePipeline(it, batch_size=batch_size, num_threads=2, device_id = 0)\n",
+    "    pipe.build()                                                        \n",
+    "    pipe_out = pipe.run()\n",
+    "    l = pipe_out[0].as_array()\n",
+    "    r = pipe_out[1].as_array()\n",
+    "    out = pipe_out[2].as_array()\n",
+    "    print(\"{} + {} * {} = {} of type {}\".format(r, r, l, out, out.dtype))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -15,3 +15,4 @@ Tutorials
    optical_flow/optical_flow_example.ipynb
    extend/create_a_custom_operator.ipynb
    python_operator/python_operator.ipynb
+   expressions.ipynb


### PR DESCRIPTION
Make arithmetic ops accessible from python using python special methods for operator overloading on _EdgeReference.
Supported ops: +, -, *, /, //

#### Why we need this PR?
So we can use arithmetic Ops in natural way through python API.

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
EdgeReference (the return value type of Operator call) was extended with overloaded operators (like __add__, __mul__, ...) that place a appropriate ArithmeticGenericOp.
Additionally `artihm_meta` is now fully specialized every time.
A `fdiv` op was added to reflect python's insistence of producing float in division.
 - What was changed, added, removed?
`EdgeReference` from `nvidia.dali.edge` was deprecated and is replaced by `_EdgeReference`, that was placed in `nvidia.dali.ops`.
 - What is most important part that reviewers should focus on?
Pipeline validation of EdgeReference-like objects, loading of arithmetic ops
 - Was this PR tested? How?
Jupyter notebook, will add a nose test.
 - Were docs and examples updated, if necessary?
There is an example utilizing numpy added, in future PRs I will add some image blending but I want to have more backend features available for it.

**JIRA TASK**: [DALI-1054]