### PR TITLE
Enhance CaffeReader and Caffe2Reader to support multiple LMDB files

### DIFF
--- a/dali/operators/reader/caffe2_reader_op.cc
+++ b/dali/operators/reader/caffe2_reader_op.cc
@@ -32,8 +32,8 @@ DALI_SCHEMA(Caffe2Reader)
     return 1 + num_label_outputs + additional_inputs + has_bbox;
   })
   .AddArg("path",
-      R"code(Path to Caffe2 LMDB directory.)code",
-      DALI_STRING)
+      R"code(List of paths to Caffe2 LMDB directories.)code",
+      DALI_STRING_VEC)
   .AddOptionalArg("num_labels",
       R"code(Number of classes in dataset. Required when sparse labels are used.)code", 1)
   .AddOptionalArg("label_type",

--- a/dali/operators/reader/caffe_reader_op.cc
+++ b/dali/operators/reader/caffe_reader_op.cc
@@ -23,8 +23,8 @@ DALI_SCHEMA(CaffeReader)
   .NumInput(0)
   .NumOutput(2)  // (Images, Labels)
   .AddArg("path",
-      R"code(Path to Caffe LMDB directory.)code",
-      DALI_STRING)
+      R"code(List of paths to Caffe LMDB directories.)code",
+      DALI_STRING_VEC)
   .AddParent("LoaderBase");
 
 }  // namespace dali

--- a/dali/operators/reader/loader/lmdb.h
+++ b/dali/operators/reader/loader/lmdb.h
@@ -18,6 +18,7 @@
 #include <lmdb.h>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "dali/core/common.h"
 #include "dali/operators/reader/loader/loader.h"
@@ -30,65 +31,147 @@ namespace dali {
                                         ", with file: " + filename); \
   } while (0)
 
-namespace lmdb {
-  inline bool SeekLMDB(MDB_cursor* cursor, MDB_cursor_op op, MDB_val* key, MDB_val *value,
-                       const string &filename) {
-    int status = mdb_cursor_get(cursor, key, value, op);
 
-    if (status == MDB_NOTFOUND) {
-      // reached the end of the db
-      return false;
+class IndexedLMDB {
+  MDB_env* mdb_env_ = nullptr;
+  MDB_cursor* mdb_cursor_ = nullptr;
+  MDB_dbi mdb_dbi_;
+  MDB_txn* mdb_transaction_ = nullptr;
+  int num_;
+  Index mdb_index_;
+  std::string db_path_;
+  Index mdb_size_;
+
+ public:
+  void Open(const std::string& path, int num) {
+    DALI_ENFORCE(mdb_env_ == nullptr, "Previous MDB environment was not closed");
+    db_path_ = path;
+    num_ = num;
+    CHECK_LMDB(mdb_env_create(&mdb_env_), db_path_);
+    auto mdb_flags = MDB_RDONLY | MDB_NOTLS | MDB_NOLOCK;
+    CHECK_LMDB(mdb_env_open(mdb_env_, path.c_str(), mdb_flags, 0664), db_path_);
+
+    // Create transaction and cursor
+    CHECK_LMDB(mdb_txn_begin(mdb_env_, NULL, MDB_RDONLY, &mdb_transaction_), db_path_);
+    CHECK_LMDB(mdb_dbi_open(mdb_transaction_, NULL, 0, &mdb_dbi_), db_path_);
+    CHECK_LMDB(mdb_cursor_open(mdb_transaction_, mdb_dbi_, &mdb_cursor_), db_path_);
+    MDB_stat stat;
+    CHECK_LMDB(mdb_stat(mdb_transaction_, mdb_dbi_, &stat), db_path_);
+    mdb_size_ = stat.ms_entries;
+    LOG_LINE << "lmdb " << num_ << " " << db_path_
+             << " has " << mdb_size_ << " entries" << std::endl;
+    mdb_index_ = 0;
+  }
+  size_t GetSize() const { return mdb_size_; }
+  Index GetIndex() const { return mdb_index_; }
+  void SeekByIndex(Index index, MDB_val* key = nullptr, MDB_val* value = nullptr) {
+    MDB_val tmp_key, tmp_value;
+    if (nullptr == key) {
+      key = &tmp_key;
+    }
+    if (nullptr == value) {
+      value = &tmp_value;
+    }
+    if (index == 0) {
+      LOG_LINE << "lmdb " << num_ << " " << db_path_
+               << " rewind to the begin from " << mdb_index_ << std::endl;
+    }
+    DALI_ENFORCE(index >= 0 && index < mdb_size_);
+    if (index == 0) {
+      CHECK_LMDB(mdb_cursor_get(mdb_cursor_, key, value, MDB_FIRST), db_path_);
+    } else if (index == mdb_size_ - 1) {
+      CHECK_LMDB(mdb_cursor_get(mdb_cursor_, key, value, MDB_LAST), db_path_);
+    } else if (index == mdb_index_) {
+      CHECK_LMDB(mdb_cursor_get(mdb_cursor_, key, value, MDB_GET_CURRENT), db_path_);
+    } else if (index == mdb_index_ - 1) {
+      CHECK_LMDB(mdb_cursor_get(mdb_cursor_, key, value, MDB_PREV), db_path_);
+    } else if (index == mdb_index_ + 1) {
+      CHECK_LMDB(mdb_cursor_get(mdb_cursor_, key, value, MDB_NEXT), db_path_);
+    } else if (index > mdb_index_) {
+      LOG_LINE << "lmdb " << num_ << " " << db_path_
+               << " exec a large step forward " << mdb_index_ << "->" << index << std::endl;
+      for (Index i = mdb_index_; i < index; ++i) {
+        CHECK_LMDB(mdb_cursor_get(mdb_cursor_, key, value, MDB_NEXT), db_path_);
+      }
     } else {
-      CHECK_LMDB(status, filename);
-      return true;
+      // index < mdb_index_
+      LOG_LINE << "lmdb " << num_ << " " << db_path_
+               << " exec a large step backward " << mdb_index_ << "->" << index << std::endl;
+      for (Index i = index; i < mdb_index_; i++) {
+        CHECK_LMDB(mdb_cursor_get(mdb_cursor_, key, value, MDB_PREV), db_path_);
+      }
+    }
+    mdb_index_ = index;
+  }
+
+  void Close() {
+    if (mdb_cursor_) {
+      mdb_cursor_close(mdb_cursor_);
+      mdb_dbi_close(mdb_env_, mdb_dbi_);
+      mdb_cursor_ = nullptr;
+    }
+    if (mdb_transaction_) {
+      mdb_txn_abort(mdb_transaction_);
+      mdb_transaction_ = nullptr;
+    }
+    if (mdb_env_) {
+      mdb_env_close(mdb_env_);
+      mdb_env_ = nullptr;
     }
   }
+};
 
-  inline uint64_t LMDB_size(MDB_txn* txn, MDB_dbi dbi, const string &filename) {
-    MDB_stat stat;
+static int find_lower_bound(const std::vector<Index>& a, Index x) {
+  DALI_ENFORCE(x >= a.front() && x < a.back() && a.size() >= 2);
+  int low = 0;
+  int high = a.size()-2;
+  do {
+    int mid = (low+high) / 2;
+    if (x >= a[mid] && x < a[mid+1]) {
+      return mid;
+    } else if (x >= a[mid+1]) {
+      low = mid+1;
+    } else if (x < a[mid]) {
+      high = mid-1;
+    }
+  } while (low <= high);
 
-    CHECK_LMDB(mdb_stat(txn, dbi, &stat), filename);
-
-    return stat.ms_entries;
-  }
-
-  inline void PrintLMDBStats(MDB_txn* txn, MDB_dbi dbi, const string &filename) {
-    MDB_stat stat;
-
-    CHECK_LMDB(mdb_stat(txn, dbi, &stat), filename);
-
-    printf("DB has %d entries\n", static_cast<int>(stat.ms_entries));
-  }
-}  // namespace lmdb
+  DALI_FAIL("the array is not in ascending order.");
+  return -1;
+}
 
 class LMDBLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit LMDBLoader(const OpSpec& options)
-    : Loader(options),
-      db_path_(options.GetArgument<string>("path")) {
-  }
+      : Loader(options),
+        db_paths_(options.GetRepeatedArgument<std::string>("path")) {}
 
   ~LMDBLoader() override {
-    if (mdb_cursor_) {
-      mdb_cursor_close(mdb_cursor_);
-      mdb_dbi_close(mdb_env_, mdb_dbi_);
+    for (size_t i = 0; i < db_paths_.size(); i++) {
+      mdb_[i].Close();
     }
-    if (mdb_transaction_)
-      mdb_txn_abort(mdb_transaction_);
-    if (mdb_env_)
-      mdb_env_close(mdb_env_);
-    mdb_env_ = nullptr;
+  }
+
+  void MapIndexToFile(Index index, Index* file_index, Index* local_index) {
+    DALI_ENFORCE(index >= 0 && index < offsets_[db_paths_.size()]);
+    *file_index = find_lower_bound(offsets_, index);
+    *local_index = index - offsets_[*file_index];
   }
 
   void ReadSample(Tensor<CPUBackend>& tensor) override {
     // assume cursor is valid, read next, loop to start if necessary
-    lmdb::SeekLMDB(mdb_cursor_, MDB_NEXT, &key_, &value_, db_path_);
+
+    Index file_index, local_index;
+    MapIndexToFile(current_index_, &file_index, &local_index);
+
+    MDB_val key, value;
+    mdb_[file_index].SeekByIndex(local_index, &key, &value);
     ++current_index_;
 
     MoveToNextShard(current_index_);
 
-    std::string image_key =
-      db_path_ + " at key " + to_string(reinterpret_cast<char*>(key_.mv_data));
+    std::string image_key = db_paths_[file_index] + " at key " +
+                            to_string(reinterpret_cast<char*>(key.mv_data));
     DALIMeta meta;
 
     meta.SetSourceInfo(image_key);
@@ -107,64 +190,50 @@ class LMDBLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     }
 
     tensor.SetMeta(meta);
-    tensor.Resize({static_cast<Index>(value_.mv_size)});
+    tensor.Resize({static_cast<Index>(value.mv_size)});
     std::memcpy(tensor.raw_mutable_data(),
-                reinterpret_cast<uint8_t*>(value_.mv_data),
-                value_.mv_size*sizeof(uint8_t));
+                reinterpret_cast<uint8_t*>(value.mv_data),
+                value.mv_size * sizeof(uint8_t));
   }
 
  protected:
-  Index SizeImpl() override {
-    return lmdb_size_;
-  }
+  Index SizeImpl() override { return offsets_[db_paths_.size()]; }
 
   void PrepareMetadataImpl() override {
-    // Create the db environment, open the passed DB
-    CHECK_LMDB(mdb_env_create(&mdb_env_), db_path_);
-    auto mdb_flags = MDB_RDONLY | MDB_NOTLS | MDB_NOLOCK;
-    CHECK_LMDB(mdb_env_open(mdb_env_, db_path_.c_str(), mdb_flags, 0664), db_path_);
-
-    // Create transaction and cursor
-    CHECK_LMDB(mdb_txn_begin(mdb_env_, NULL, MDB_RDONLY, &mdb_transaction_), db_path_);
-    CHECK_LMDB(mdb_dbi_open(mdb_transaction_, NULL, 0, &mdb_dbi_), db_path_);
-    CHECK_LMDB(mdb_cursor_open(mdb_transaction_, mdb_dbi_, &mdb_cursor_), db_path_);
-    lmdb_size_ = lmdb::LMDB_size(mdb_transaction_, mdb_dbi_, db_path_);
-
-    // Optional: debug printing
-    lmdb::PrintLMDBStats(mdb_transaction_, mdb_dbi_, db_path_);
-
+    offsets_.resize(db_paths_.size() + 1);
+    offsets_[0] = 0;
+    mdb_.resize(db_paths_.size());
+    for (size_t i = 0; i < db_paths_.size(); i++) {
+      mdb_[i].Open(db_paths_[i], i);
+      offsets_[i + 1] = offsets_[i] + mdb_[i].GetSize();
+    }
     Reset(true);
   }
 
  private:
   void Reset(bool wrap_to_shard) override {
     // work out how many entries to move forward to handle sharding
-    current_index_ = start_index(shard_id_, num_shards_, Size());
-    bool ok = lmdb::SeekLMDB(mdb_cursor_, MDB_FIRST, &key_, &value_, db_path_);
-    DALI_ENFORCE(ok, "lmdb::SeekLMDB to the beginning failed");
-
     if (wrap_to_shard) {
-      for (size_t i = 0; i < current_index_; ++i) {
-        bool ok = lmdb::SeekLMDB(mdb_cursor_, MDB_NEXT, &key_, &value_, db_path_);
-        DALI_ENFORCE(ok, "lmdb::SeekLMDB to position " + to_string(current_index_) + " failed");
-      }
+      current_index_ = start_index(shard_id_, num_shards_, Size());
+    } else {
+      current_index_ = 0;
     }
+    Index file_index, local_index;
+    MapIndexToFile(current_index_, &file_index, &local_index);
+
+    mdb_[file_index].SeekByIndex(local_index);
   }
   using Loader<CPUBackend, Tensor<CPUBackend>>::shard_id_;
   using Loader<CPUBackend, Tensor<CPUBackend>>::num_shards_;
 
-  MDB_env* mdb_env_ = nullptr;
-  MDB_cursor* mdb_cursor_ = nullptr;
-  MDB_dbi mdb_dbi_;
-  MDB_txn* mdb_transaction_ = nullptr;
-  size_t current_index_;
-  Index lmdb_size_;
+  std::vector<IndexedLMDB> mdb_;
 
-  // values
-  MDB_val key_, value_;
+  Index current_index_ = 0;
+
+  std::vector<Index> offsets_;
 
   // options
-  string db_path_;
+  std::vector<std::string> db_paths_;
 };
 
 };  // namespace dali

--- a/dali/operators/reader/loader/lmdb.h
+++ b/dali/operators/reader/loader/lmdb.h
@@ -152,17 +152,17 @@ class LMDBLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     }
   }
 
-  void MapIndexToFile(Index index, Index* file_index, Index* local_index) {
+  void MapIndexToFile(Index index, Index& file_index, Index& local_index) {
     DALI_ENFORCE(index >= 0 && index < offsets_[db_paths_.size()]);
-    *file_index = find_lower_bound(offsets_, index);
-    *local_index = index - offsets_[*file_index];
+    file_index = find_lower_bound(offsets_, index);
+    local_index = index - offsets_[file_index];
   }
 
   void ReadSample(Tensor<CPUBackend>& tensor) override {
     // assume cursor is valid, read next, loop to start if necessary
 
     Index file_index, local_index;
-    MapIndexToFile(current_index_, &file_index, &local_index);
+    MapIndexToFile(current_index_, file_index, local_index);
 
     MDB_val key, value;
     mdb_[file_index].SeekByIndex(local_index, &key, &value);
@@ -219,7 +219,7 @@ class LMDBLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
       current_index_ = 0;
     }
     Index file_index, local_index;
-    MapIndexToFile(current_index_, &file_index, &local_index);
+    MapIndexToFile(current_index_, file_index, local_index);
 
     mdb_[file_index].SeekByIndex(local_index);
   }

--- a/dali/operators/reader/loader/lmdb.h
+++ b/dali/operators/reader/loader/lmdb.h
@@ -143,8 +143,13 @@ static int find_lower_bound(const std::vector<Index>& a, Index x) {
 class LMDBLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
  public:
   explicit LMDBLoader(const OpSpec& options)
-      : Loader(options),
-        db_paths_(options.GetRepeatedArgument<std::string>("path")) {}
+      : Loader(options) {
+    bool ret = options.TryGetRepeatedArgument<std::string>(db_paths_, "path");
+    if (!ret) {
+      std::string path = options.GetArgument<std::string>("path");
+      db_paths_.push_back(path);
+    }
+  }
 
   ~LMDBLoader() override {
     for (size_t i = 0; i < mdb_.size(); i++) {

--- a/dali/operators/reader/loader/loader_test.cc
+++ b/dali/operators/reader/loader/loader_test.cc
@@ -43,7 +43,7 @@ TYPED_TEST(DataLoadStoreTest, LMDBTest) {
       new LMDBLoader(
           OpSpec("CaffeReader")
           .AddArg("batch_size", 32)
-          .AddArg("path", testing::dali_extra_path() + "/db/c2lmdb/")
+          .AddArg("path", std::vector<string>({testing::dali_extra_path() + "/db/c2lmdb/"}))
           .AddArg("device_id", 0)));
 
   reader->PrepareMetadata();

--- a/dali/operators/reader/loader/loader_test.cc
+++ b/dali/operators/reader/loader/loader_test.cc
@@ -43,7 +43,7 @@ TYPED_TEST(DataLoadStoreTest, LMDBTest) {
       new LMDBLoader(
           OpSpec("CaffeReader")
           .AddArg("batch_size", 32)
-          .AddArg("path", std::vector<string>({testing::dali_extra_path() + "/db/c2lmdb/"}))
+          .AddArg("path", testing::dali_extra_path() + "/db/c2lmdb/")
           .AddArg("device_id", 0)));
 
   reader->PrepareMetadata();

--- a/dali/test/python/test_operator_caffe_reader.py
+++ b/dali/test/python/test_operator_caffe_reader.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops as ops
+import nvidia.dali.types as types
+import nvidia.dali as dali
+from nvidia.dali.backend_impl import TensorListGPU
+import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
+import os
+
+from test_utils import check_batch
+from test_utils import save_image
+from test_utils import compare_pipelines
+from test_utils import RandomDataIterator
+from test_utils import get_dali_extra_path
+
+test_data_root = get_dali_extra_path()
+caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
+
+class CaffeReaderPipeline(Pipeline):
+    def __init__(self, path, batch_size, num_threads=1, device_id=0, num_gpus=1):
+        super(CaffeReaderPipeline, self).__init__(batch_size,
+                                           num_threads,
+                                           device_id)
+        self.input = ops.CaffeReader(path = path, shard_id = device_id, num_shards = num_gpus)
+
+        self.decode = ops.ImageDecoderCrop(device = "cpu",
+                                           crop = (224, 224),
+                                           crop_pos_x = 0.3,
+                                           crop_pos_y = 0.2,
+                                           output_type = types.RGB)
+    def define_graph(self):
+        inputs, labels = self.input(name="Reader")
+
+        images = self.decode(inputs)
+        return images, labels
+
+# test 1: rewind
+def check_reader_vs_rewind(path):
+    # the db has 43 entries, 44 should trigger rewind
+    if isinstance(path, str):
+        num_paths = 1
+    else:
+        num_paths = len(path)
+    num = 43*num_paths + 1
+    pipe = CaffeReaderPipeline(path, 1)
+    pipe.build()
+    for i in range(num):
+        pipe_out = pipe.run()
+        if i == 0:
+            image0 = pipe_out[0].at(0)
+            label0 = pipe_out[1].at(0)
+        if i == num-1:
+            image0_rewind = pipe_out[0].at(0)
+            label0_rewind = pipe_out[1].at(0)
+        
+    assert_array_equal(image0, image0_rewind)
+    assert_array_equal(label0, label0_rewind)
+
+def test_reader_vs_rewind():
+    for path in [caffe_db_folder, [caffe_db_folder], [caffe_db_folder, caffe_db_folder]]:
+        yield check_reader_vs_rewind, path
+
+# test 2: compare with previous CaffeReader
+# run the previous CaffeReader to get the db statistics [image.mean(), label], 
+# regarded as ground truth
+db_stat = [
+    [118.10, 1],
+    [95.21, 1],
+    [105.89, 1],
+    [135.78, 1],
+    [152.72, 1],
+    [93.08, 0],
+    [153.97, 0],
+    [177.89, 0],
+    [163.62, 1],
+    [82.04, 1],
+    [214.37, 1],
+    [77.89, 1],
+    [231.43, 0],
+    [100.98, 1],
+    [157.01, 1],
+    [167.31, 1],
+    [98.75, 0],
+    [101.37, 1],
+    [125.64, 1],
+    [120.80, 1],
+    [128.53, 1],
+    [95.86, 1],
+    [56.78, 0],
+    [89.86, 1],
+    [86.71, 1],
+    [118.33, 1],
+    [76.55, 1],
+    [108.08, 0],
+    [147.95, 0],
+    [188.69, 0],
+    [135.47, 1],
+    [164.58, 0],
+    [172.21, 1],
+    [111.00, 1],
+    [175.26, 0],
+    [99.32, 1],
+    [138.10, 1],
+    [97.69, 1],
+    [108.19, 0],
+    [60.03, 0],
+    [145.58, 1],
+    [135.89, 1],
+    [141.06, 0],
+]
+
+def check_reader_vs_db_stat(path, batch_size, num_threads, num_gpus):
+    pipelines = [CaffeReaderPipeline(path, batch_size, num_threads, device_id, num_gpus) for device_id in range(num_gpus)]
+    
+    num_batches = 2
+    for pipe in pipelines:
+        pipe.build()
+        count = 0
+        for i in range(num_batches):
+            pipe_out = pipe.run()
+            for idx in range(len(pipe_out[0])):
+                image = pipe_out[0].at(idx)
+                label = pipe_out[1].at(idx)
+                dstid = count % len(db_stat)
+                assert_allclose(image.mean(), db_stat[dstid][0], rtol=1e-3)
+                assert_array_equal(label[0], db_stat[dstid][1])
+                count+=1
+
+def test_reader_vs_db_stat():
+    num_gpus = 1
+    for path in [caffe_db_folder, [caffe_db_folder], [caffe_db_folder, caffe_db_folder]]:
+        for batch_size in {1, 32, 44}:
+            for num_threads in {1, 2}:
+                yield check_reader_vs_db_stat, path, batch_size, num_threads, num_gpus
+
+# test 3: compare with a simple CaffeReader with batch_size=1
+def check_reader_vs_simple(path, batch_size, num_threads, num_gpus, images, labels):
+    pipelines = [CaffeReaderPipeline(path, batch_size, num_threads, device_id, num_gpus) for device_id in range(num_gpus)]
+    num_paths = 1 if isinstance(path, str) else len(path)
+
+    num_batches = 2
+    for pipe in pipelines:
+        pipe.build()
+        count = 0
+        for i in range(num_batches):
+            pipe_out = pipe.run()
+            for idx in range(len(pipe_out[0])):
+                image = pipe_out[0].at(idx)
+                label = pipe_out[1].at(idx)
+                dstid = count % len(images)
+                assert_array_equal(image, images[dstid])
+                assert_array_equal(label, labels[dstid])
+                count+=1
+
+def test_reader_vs_simple():
+    pipe = CaffeReaderPipeline(caffe_db_folder, 1)
+    pipe.build()
+    images = []
+    labels = []
+    num = 43
+    for i in range(num):
+        pipe_out = pipe.run()
+        image = pipe_out[0].at(0)
+        label = pipe_out[1].at(0)
+        images.append(image)
+        labels.append(label)
+
+    num_gpus = 1
+    for path in [caffe_db_folder, [caffe_db_folder], [caffe_db_folder, caffe_db_folder]]:
+        for batch_size in {1, 32, 44}:
+            for num_threads in {1, 2}:
+                yield check_reader_vs_simple, path, batch_size, num_threads, num_gpus, images, labels
+
+
+if __name__ == '__main__':
+    # run this using previous CaffeReader to get the db statistics
+    num = 43
+    pipe = CaffeReaderPipeline(caffe_db_folder, 1)
+    pipe.build()
+    db_stat = []
+    for i in range(num):
+        pipe_out = pipe.run()
+        image = pipe_out[0].at(0)
+        label = pipe_out[1].at(0)
+        print(['%.2f' % image.mean(), label[0]])
+
+


### PR DESCRIPTION
Signed-off-by: Jianjun Liu <00liujj@163.com>

#### Why we need this PR?

#1208 

- Refactoring to enhance LMDBLoader so it can support multiple LMDB files.

#### What happened in this PR?
 - Implements a new LMDBLoader.
 - Changes the type of path option of CaffeReader and Caffe2Reader from DALI_STRING to DALI_STRING_VEC, for python it will compatible with previous API.
 - Adds a test 'test_operator_caffe_reader.py'. 
 - 'make lint' passed.

