### PR TITLE
Fix CXX11 ABI issue

### DIFF
--- a/dali/python/nvidia/dali/sysconfig.py
+++ b/dali/python/nvidia/dali/sysconfig.py
@@ -33,6 +33,17 @@ def get_lib_dir():
     import nvidia.dali as dali
     return os.path.dirname(dali.__file__)
 
+def get_include_flags():
+    """Get the include flags for custom operators
+
+    Returns:
+        The compilation flags
+    """
+    import nvidia.dali.backend as b
+    flags = []
+    flags.append('-I%s' % get_include_dir())
+    return flags
+
 def get_compile_flags():
     """Get the compilation flags for custom operators
 

--- a/dali/test/python/test_plugin_manager.py
+++ b/dali/test/python/test_plugin_manager.py
@@ -68,6 +68,7 @@ class CustomPipeline(Pipeline):
 class TestLoadedPlugin(unittest.TestCase):
     def test_sysconfig_provides_non_empty_flags(self):
         import nvidia.dali.sysconfig as dali_sysconfig
+        assert "" != dali_sysconfig.get_include_flags()
         assert "" != dali_sysconfig.get_compile_flags()
         assert "" != dali_sysconfig.get_link_flags()
         assert "" != dali_sysconfig.get_include_dir()

--- a/dali_tf_plugin/build_dali_tf.sh
+++ b/dali_tf_plugin/build_dali_tf.sh
@@ -6,7 +6,7 @@ LIB_NAME=${1:-"libdali_tf_current.so"}
 SRCS="daliop.cc dali_dataset_op.cc"
 INCL_DIRS="-I/usr/local/cuda/include/"
 
-DALI_CFLAGS=( $($PYTHON ./dali_compile_flags.py --cflags) )
+DALI_CFLAGS=( $($PYTHON ./dali_compile_flags.py --include_flags) )
 DALI_LFLAGS=( $($PYTHON ./dali_compile_flags.py --lflags) )
 
 TF_CFLAGS=( $($PYTHON -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )

--- a/dali_tf_plugin/dali_compile_flags.py
+++ b/dali_tf_plugin/dali_compile_flags.py
@@ -17,30 +17,36 @@ def get_module_path(module_name):
 def get_dali_build_flags():
     dali_cflags = ''
     dali_lflags = ''
+    dali_include_flags = ''
     try:
         import nvidia.dali.sysconfig as dali_sc
         dali_lib_path = dali_sc.get_lib_dir()
+        dali_include_flags=" ".join(dali_sc.get_include_flags())
         dali_cflags=" ".join(dali_sc.get_compile_flags())
         dali_lflags=" ".join(dali_sc.get_link_flags())
     except:
         dali_path = get_module_path('nvidia/dali')
         if dali_path is not '':
+            dali_include_flags=" ".join(["-I" + dali_path + "/include"])
             dali_cflags=" ".join(["-I" + dali_path + "/include", "-D_GLIBCXX_USE_CXX11_ABI=0"])
             dali_lflags=" ".join(["-L" + dali_path, "-ldali"])
-    if dali_cflags is '' and dali_lflags is '':
+    if dali_include_flags is '' and dali_cflags is '' and dali_lflags is '':
         raise ImportError('Could not find DALI.')
-    return (dali_cflags, dali_lflags)
-
+    return (dali_include_flags, dali_cflags, dali_lflags)
 
 
 parser = argparse.ArgumentParser(description='DALI TF plugin compile flags')
+parser.add_argument('--include_flags', dest='include_flags', action='store_true')
 parser.add_argument('--cflags', dest='cflags', action='store_true')
 parser.add_argument('--lflags', dest='lflags', action='store_true')
 args = parser.parse_args()
 
-cflags, lflags = get_dali_build_flags()
+include_flags, cflags, lflags = get_dali_build_flags()
 
 flags = []
+
+if args.include_flags:
+    flags = flags + [include_flags]
 
 if args.cflags:
     flags = flags + [cflags]

--- a/dali_tf_plugin/dali_tf_plugin_install_tool.py
+++ b/dali_tf_plugin/dali_tf_plugin_install_tool.py
@@ -19,6 +19,7 @@ import os
 
 class InstallerHelper:
     def __init__(self):
+        self.src_path = os.path.dirname(os.path.realpath(__file__))
         self.dali_lib_path = get_module_path('nvidia/dali')
         self.tf_path = get_module_path('tensorflow')
         self.plugin_dest_dir = self.dali_lib_path + '/plugin' if self.dali_lib_path else ''
@@ -32,10 +33,11 @@ class InstallerHelper:
         self.platform_system = platform.system()
         self.platform_machine = platform.machine()
         self.is_compatible_with_prebuilt_bin = self.platform_system == 'Linux' and self.platform_machine == 'x86_64'
-        self.prebuilt_compilers = {'4.8', '5.4'}
+        self.prebuilt_dir = self.src_path + '/prebuilt/'
+        self.prebuilt_compilers = [subdir for subdir in os.listdir(self.prebuilt_dir) \
+            if os.path.isdir(os.path.join(self.prebuilt_dir, subdir))]
         self.can_install_prebuilt = self.tf_compiler in self.prebuilt_compilers and self.is_compatible_with_prebuilt_bin
         self.can_compile = self.default_cpp_version == self.tf_compiler
-        self.src_path = os.path.dirname(os.path.realpath(__file__))
 
     def debug_str(self):
         s = "\n Environment:"

--- a/dali_tf_plugin/dali_tf_plugin_utils.py
+++ b/dali_tf_plugin/dali_tf_plugin_utils.py
@@ -113,12 +113,14 @@ def get_dali_build_flags():
     try:
         import nvidia.dali.sysconfig as dali_sc
         dali_lib_path = dali_sc.get_lib_dir()
-        dali_cflags=" ".join(dali_sc.get_compile_flags())
+        # We are linking with DALI's C library, so we don't need the C++ compile flags
+        # including the CXX11_ABI setting
+        dali_cflags=" ".join(dali_sc.get_include_flags())
         dali_lflags=" ".join(dali_sc.get_link_flags())
     except:
         dali_path = get_module_path('nvidia/dali')
         if dali_path is not '':
-            dali_cflags=" ".join(["-I" + dali_path + "/include", "-D_GLIBCXX_USE_CXX11_ABI=0"])
+            dali_cflags=" ".join(["-I" + dali_path + "/include"])
             dali_lflags=" ".join(["-L" + dali_path, "-ldali"])
     if dali_cflags is '' and dali_lflags is '':
         raise ImportError('Could not find DALI.')

--- a/docker/Dockerfile.customopbuilder.clean
+++ b/docker/Dockerfile.customopbuilder.clean
@@ -45,9 +45,11 @@ ENV PYTHONIOENCODING=utf-8
 ENV LC_ALL=C.UTF-8
 RUN rm -f /usr/bin/python && \
     rm -f /usr/bin/python`echo $PYVER | cut -c1-1` && \
+    rm -f /usr/local/bin/pip || true && \
     if [ "${PYVER}" = "3.7" ]; then \
         ln -s /usr/local/bin/python3.7 /usr/bin/python3.7 && \
         ln -s /usr/local/bin/python3.7 /usr/bin/python && \
+        ln -s /usr/local/bin/pip3.7 /usr/local/bin/pip && \
         ln -s /usr/local/bin/pip3.7 /usr/bin/pip3.7 && \
         ln -s /usr/local/bin/pip3.7 /usr/bin/pip; \
     else \


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- When building DALI TF plugin against a python 3.7 version of tensorflow-gpu, we get the flag `-D_GLIBCXX_USE_CXX11_ABI=1` from TF compile flags and `-D_GLIBCXX_USE_CXX11_ABI=0` from DALI, which causes the code to be compiled with the latter flag. Actually, to build DALI TF we don't need to provide DALI's CXX11 ABI flag, since we are only building against DALI's C API.

#### What happened in this PR?
- Remove `GLIBCXX_USE_CXX11_ABI` from DALI TF build scripts

**JIRA TASK**: [DALI-XXXX]