### PR TITLE
Add warning if syscall fails during avformat_open_input

### DIFF
--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -185,8 +185,9 @@ OpenFile& VideoLoader::get_or_open_file(const std::string &filename) {
     LOG_LINE << "Opening file " << filename << std::endl;
 
     AVFormatContext* raw_fmt_ctx = nullptr;
-    if (avformat_open_input(&raw_fmt_ctx, filename.c_str(), NULL, NULL) < 0) {
-      DALI_FAIL(std::string("Could not open file ") + filename);
+    int ret = avformat_open_input(&raw_fmt_ctx, filename.c_str(), NULL, NULL);
+    if (ret < 0) {
+      DALI_FAIL(std::string("Could not open file ") + filename + " because of " + av_err2str(ret));
     }
     file.fmt_ctx_ = make_unique_av<AVFormatContext>(raw_fmt_ctx, avformat_close_input);
 
@@ -262,7 +263,6 @@ OpenFile& VideoLoader::get_or_open_file(const std::string &filename) {
 
     // This check is based on heuristic FFMPEG API
     AVPacket pkt = AVPacket{};
-    int ret;
     while ((ret = av_read_frame(file.fmt_ctx_.get(), &pkt)) >= 0) {
       if (pkt.stream_index == file.vid_stream_idx_) break;
     }


### PR DESCRIPTION
Signed-off-by: Abhishek Sansanwal <asansanwal@nvidia.com>

#### Why we need this PR?
*Pick one*
- Refactoring to improve *what*
Adds error message when DALI fails to open videos.
As described in #1350, there is kernel limit on the the number of files that can be opened by process. But the user was not being warned of this. In case of errno `EMFILE`, we will report an error message `Too many open files`

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
 - What was changed, added, removed?
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
Tested by opening more files than the process limit.
 - Were docs and examples updated, if necessary?

**JIRA TASK**: [DALI-XXXX]