### PR TITLE
Resampling ND - ground work

### DIFF
--- a/dali/kernels/imgproc/resample/bilinear_impl.cuh
+++ b/dali/kernels/imgproc/resample/bilinear_impl.cuh
@@ -21,6 +21,7 @@
 #endif
 #include "dali/core/static_switch.h"
 #include "dali/core/convert.h"
+#include "dali/core/math_util.h"
 
 namespace dali {
 namespace kernels {
@@ -48,8 +49,8 @@ __device__ void LinearHorz_Channels(
     const float sx0f = j * scale + src_x0;
     const int sx0i = __float2int_rd(sx0f);
     const float q = sx0f - sx0i;
-    const int sx0 = min(max(0, sx0i), in_w-1);
-    const int sx1 = min(max(0, sx0i+1), in_w-1);
+    const int sx0 = clamp(sx0i, 0, in_w-1);
+    const int sx1 = clamp(sx0i+1, 0, in_w-1);
 
     const Src *in_col1 = &in[sx0 * channels];
     const Src *in_col2 = &in[sx1 * channels];
@@ -119,8 +120,8 @@ __device__ void LinearVert(
     const float sy0f = i * scale + src_y0;
     const int sy0i = __float2int_rd(sy0f);
     const float q = sy0f - sy0i;
-    const int sy0 = min(max(0, sy0i), in_h-1);
-    const int sy1 = min(max(0, sy0i+1), in_h-1);
+    const int sy0 = clamp(sy0i,   0, in_h-1);
+    const int sy1 = clamp(sy0i+1, 0, in_h-1);
 
     Dst *out_row = &out[i * out_stride];
     const Src *in1 = &in[sy0 * in_stride];

--- a/dali/kernels/imgproc/resample/nearest_impl.cuh
+++ b/dali/kernels/imgproc/resample/nearest_impl.cuh
@@ -20,6 +20,7 @@
 #include <algorithm>
 #endif
 #include "dali/core/convert.h"
+#include "dali/core/math_util.h"
 
 namespace dali {
 namespace kernels {
@@ -34,14 +35,14 @@ __device__ void NNResample(
   src_x0 += 0.5f * scale_x;
   for (int i = y0 + threadIdx.y; i < y1; i += blockDim.y) {
     int ysrc = i * scale_y + src_y0;
-    ysrc = min(max(0, ysrc), in_h-1);
+    ysrc = clamp(ysrc, 0, in_h-1);
 
     Dst *out_row = &out[i * out_stride];
     const Src *in_row = &in[ysrc * in_stride];
 
     for (int j = x0 + threadIdx.x; j < x1; j += blockDim.x) {
       int xsrc = j * scale_x + src_x0;
-      xsrc = min(max(0, xsrc), in_w-1);
+      xsrc = clamp(xsrc, 0, in_w-1);
       const Src *src_px = &in_row[xsrc * channels];
       for (int c = 0; c < channels; c++)
         out_row[j*channels + c] = __ldg(&src_px[c]);

--- a/dali/kernels/imgproc/resample/nearest_impl.cuh
+++ b/dali/kernels/imgproc/resample/nearest_impl.cuh
@@ -21,28 +21,28 @@
 #endif
 #include "dali/core/convert.h"
 #include "dali/core/math_util.h"
+#include "dali/core/geom/box.h"
 
 namespace dali {
 namespace kernels {
 
 template <typename Dst, typename Src>
 __device__ void NNResample(
-    int x0, int x1, int y0, int y1,
-    float src_x0, float src_y0, float scale_x, float scale_y,
-    Dst *__restrict__ out, int out_stride,
-    const Src *__restrict__ in, int in_stride, int in_w, int in_h, int channels) {
-  src_y0 += 0.5f * scale_y;
-  src_x0 += 0.5f * scale_x;
-  for (int i = y0 + threadIdx.y; i < y1; i += blockDim.y) {
-    int ysrc = i * scale_y + src_y0;
-    ysrc = clamp(ysrc, 0, in_h-1);
+    Box<2, int> out_roi,
+    vec2 origin, vec2 scale,
+    Dst *__restrict__ out,  vec<1, ptrdiff_t> out_stride,
+    const Src *__restrict__ in, vec<1, ptrdiff_t> in_stride, ivec2 in_size, int channels) {
+  origin += 0.5f * scale;
+  for (int i = out_roi.lo.y + threadIdx.y; i < out_roi.hi.y; i += blockDim.y) {
+    int ysrc = floor_int(i * scale.y + origin.y);
+    ysrc = clamp(ysrc, 0, in_size.y-1);
 
-    Dst *out_row = &out[i * out_stride];
-    const Src *in_row = &in[ysrc * in_stride];
+    Dst *out_row = &out[i * out_stride.x];
+    const Src *in_row = &in[ysrc * in_stride.x];
 
-    for (int j = x0 + threadIdx.x; j < x1; j += blockDim.x) {
-      int xsrc = j * scale_x + src_x0;
-      xsrc = clamp(xsrc, 0, in_w-1);
+    for (int j = out_roi.lo.x + threadIdx.x; j < out_roi.hi.x; j += blockDim.x) {
+      int xsrc = floor_int(j * scale.x + origin.x);
+      xsrc = clamp(xsrc, 0, in_size.x-1);
       const Src *src_px = &in_row[xsrc * channels];
       for (int c = 0; c < channels; c++)
         out_row[j*channels + c] = __ldg(&src_px[c]);

--- a/dali/kernels/imgproc/resample/params.h
+++ b/dali/kernels/imgproc/resample/params.h
@@ -81,6 +81,8 @@ struct ResamplingParams {
 };
 
 using ResamplingParams2D = std::array<ResamplingParams, 2>;
+template <int ndim>
+using ResamplingParamsND = std::array<ResamplingParams, ndim>;
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/imgproc/resample/params.h
+++ b/dali/kernels/imgproc/resample/params.h
@@ -80,9 +80,10 @@ struct ResamplingParams {
   ROI roi;
 };
 
-using ResamplingParams2D = std::array<ResamplingParams, 2>;
 template <int ndim>
 using ResamplingParamsND = std::array<ResamplingParams, ndim>;
+
+using ResamplingParams2D = ResamplingParamsND<2>;
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/imgproc/resample/resampling_batch.cu
+++ b/dali/kernels/imgproc/resample/resampling_batch.cu
@@ -130,6 +130,14 @@ template DLL_PUBLIC void BatchedSeparableResample<spatial_ndim, Output, Input>( 
   const SampleDesc<spatial_ndim> *samples,                                      \
   const SampleBlockInfo *block2sample, int num_blocks,                          \
   int2 block_size, cudaStream_t stream)
+
+// Instantiate the resampling functions.
+// The resampling always goes through intermediate image of float type.
+// Currently limited to only uint8 <-> float and float <-> float
+// because the operator doesn't support anything else.
+// To be extended when we support more image types.
+
+INSTANTIATE_BATCHED_RESAMPLE(2, float, float);
 INSTANTIATE_BATCHED_RESAMPLE(2, float, uint8_t);
 INSTANTIATE_BATCHED_RESAMPLE(2, uint8_t, float);
 /*
@@ -139,7 +147,6 @@ INSTANTIATE_BATCHED_RESAMPLE(2, float, uint16_t);
 INSTANTIATE_BATCHED_RESAMPLE(2, float, int16_t);
 INSTANTIATE_BATCHED_RESAMPLE(2, float, uint32_t);
 INSTANTIATE_BATCHED_RESAMPLE(2, float, int32_t);*/
-INSTANTIATE_BATCHED_RESAMPLE(2, float, float);
 /*
 INSTANTIATE_BATCHED_RESAMPLE(2, uint8_t,  float);
 INSTANTIATE_BATCHED_RESAMPLE(2, int8_t,   float);
@@ -148,7 +155,10 @@ INSTANTIATE_BATCHED_RESAMPLE(2, int16_t,  float);
 INSTANTIATE_BATCHED_RESAMPLE(2, uint32_t, float);
 INSTANTIATE_BATCHED_RESAMPLE(2, int32_t,  float);*/
 
-/*INSTANTIATE_BATCHED_RESAMPLE(3, float, uint8_t);
+// 3D not available yet
+/*
+INSTANTIATE_BATCHED_RESAMPLE(3, float,    float);
+INSTANTIATE_BATCHED_RESAMPLE(3, float, uint8_t);
 INSTANTIATE_BATCHED_RESAMPLE(3, float, int8_t);
 INSTANTIATE_BATCHED_RESAMPLE(3, float, uint16_t);
 INSTANTIATE_BATCHED_RESAMPLE(3, float, int16_t);
@@ -162,7 +172,7 @@ INSTANTIATE_BATCHED_RESAMPLE(3, uint16_t, float);
 INSTANTIATE_BATCHED_RESAMPLE(3, int16_t,  float);
 INSTANTIATE_BATCHED_RESAMPLE(3, uint32_t, float);
 INSTANTIATE_BATCHED_RESAMPLE(3, int32_t,  float);
-INSTANTIATE_BATCHED_RESAMPLE(3, float,    float);*/
+*/
 
 }  // namespace resampling
 }  // namespace kernels

--- a/dali/kernels/imgproc/resample/resampling_batch.cu
+++ b/dali/kernels/imgproc/resample/resampling_batch.cu
@@ -133,22 +133,18 @@ template DLL_PUBLIC void BatchedSeparableResample<spatial_ndim, Output, Input>( 
 // To be extended when we support more image types.
 
 INSTANTIATE_BATCHED_RESAMPLE(2, float, float);
+
 INSTANTIATE_BATCHED_RESAMPLE(2, float, uint8_t);
 INSTANTIATE_BATCHED_RESAMPLE(2, uint8_t, float);
-/*
-INSTANTIATE_BATCHED_RESAMPLE(2, float, uint8_t);
-INSTANTIATE_BATCHED_RESAMPLE(2, float, int8_t);
-INSTANTIATE_BATCHED_RESAMPLE(2, float, uint16_t);
+
 INSTANTIATE_BATCHED_RESAMPLE(2, float, int16_t);
-INSTANTIATE_BATCHED_RESAMPLE(2, float, uint32_t);
-INSTANTIATE_BATCHED_RESAMPLE(2, float, int32_t);*/
-/*
-INSTANTIATE_BATCHED_RESAMPLE(2, uint8_t,  float);
-INSTANTIATE_BATCHED_RESAMPLE(2, int8_t,   float);
+INSTANTIATE_BATCHED_RESAMPLE(2, int16_t, float);
+
 INSTANTIATE_BATCHED_RESAMPLE(2, uint16_t, float);
-INSTANTIATE_BATCHED_RESAMPLE(2, int16_t,  float);
-INSTANTIATE_BATCHED_RESAMPLE(2, uint32_t, float);
-INSTANTIATE_BATCHED_RESAMPLE(2, int32_t,  float);*/
+INSTANTIATE_BATCHED_RESAMPLE(2, float, uint16_t);
+
+INSTANTIATE_BATCHED_RESAMPLE(2, int32_t, float);
+INSTANTIATE_BATCHED_RESAMPLE(2, float, int32_t);
 
 // 3D not available yet
 /*

--- a/dali/kernels/imgproc/resample/resampling_batch.h
+++ b/dali/kernels/imgproc/resample/resampling_batch.h
@@ -19,14 +19,17 @@
 
 namespace dali {
 namespace kernels {
+namespace resampling {
 
-template <int which_pass, typename Output, typename Input>
+template <int spatial_ndim, typename Output, typename Input>
 void BatchedSeparableResample(
-  const SeparableResamplingSetup::SampleDesc *samples,
+  int which_pass,
+  const SampleDesc<spatial_ndim> *samples,
   const SampleBlockInfo *block2sample, int num_blocks,
   int2 block_size,
   cudaStream_t stream);
 
+}  // namespace resampling
 }  // namespace kernels
 }  // namespace dali
 

--- a/dali/kernels/imgproc/resample/resampling_impl_cpu.h
+++ b/dali/kernels/imgproc/resample/resampling_impl_cpu.h
@@ -167,9 +167,9 @@ inline void ResampleHorz(Surface2D<Out> out, Surface2D<In> in,
 template <typename Out, typename In>
 inline void ResampleAxis(Surface2D<Out> out, Surface2D<In> in,
                          const int *in_indices, const float *coeffs, int support, int axis) {
-  if (axis == 0)
+  if (axis == 1)
     ResampleVert(out, in, in_indices, coeffs, support);
-  else if (axis == 1)
+  else if (axis == 0)
     ResampleHorz(out, in, in_indices, coeffs, support);
   else
     assert(!"Invalid axis index");

--- a/dali/kernels/imgproc/resample/resampling_setup.cc
+++ b/dali/kernels/imgproc/resample/resampling_setup.cc
@@ -14,9 +14,11 @@
 
 #include <cuda_runtime.h>
 #include "dali/kernels/imgproc/resample/resampling_setup.h"
+#include "dali/kernels/common/block_setup.h"
 
 namespace dali {
 namespace kernels {
+namespace resampling {
 
 ResamplingFilter GetResamplingFilter(const ResamplingFilters *filters, const FilterDesc &params) {
   switch (params.type) {
@@ -35,8 +37,11 @@ ResamplingFilter GetResamplingFilter(const ResamplingFilters *filters, const Fil
   }
 }
 
-void SeparableResamplingSetup::SetFilters(SampleDesc &desc, const ResamplingParams2D &params) {
-  for (int axis = 0; axis < 2; axis++) {
+template <int spatial_ndim>
+void SeparableResamplingSetup<spatial_ndim>::SetFilters(
+    SampleDesc &desc,
+    const ResamplingParamsND<spatial_ndim> &params) {
+  for (int axis = 0; axis < spatial_ndim; axis++) {
     float in_size;
     if (params[axis].roi.use_roi) {
       in_size = std::abs(params[axis].roi.end - params[axis].roi.start);
@@ -54,11 +59,13 @@ void SeparableResamplingSetup::SetFilters(SampleDesc &desc, const ResamplingPara
   }
 }
 
-SeparableResamplingSetup::ROI SeparableResamplingSetup::ComputeScaleAndROI(
-    SampleDesc &desc, const ResamplingParams2D &params) {
+template <int spatial_ndim>
+typename SeparableResamplingSetup<spatial_ndim>::ROI
+SeparableResamplingSetup<spatial_ndim>::ComputeScaleAndROI(
+    SampleDesc &desc, const ResamplingParamsND<spatial_ndim> &params) {
   ROI roi;
 
-  for (int axis = 0; axis < 2; axis++) {
+  for (int axis = 0; axis < spatial_ndim; axis++) {
     float roi_start, roi_end;
     if (params[axis].roi.use_roi) {
       roi_start = params[axis].roi.start;
@@ -89,10 +96,12 @@ SeparableResamplingSetup::ROI SeparableResamplingSetup::ComputeScaleAndROI(
   return roi;
 }
 
-void SeparableResamplingSetup::SetupSample(
+template <>
+void SeparableResamplingSetup<2>::SetupSample(
     SampleDesc &desc,
-    const TensorShape<3> &in_shape,
+    const TensorShape<tensor_ndim> &in_shape,
     const ResamplingParams2D &params) {
+
   int H = in_shape[0];
   int W = in_shape[1];
   int C = in_shape[2];
@@ -124,19 +133,19 @@ void SeparableResamplingSetup::SetupSample(
 
   int tmp_H, tmp_W;
   if (cost_vert < cost_horz) {
-    desc.order = VertHorz;
+    desc.order = VertHorz();
     tmp_H = out_H;
     tmp_W = roi.size(1);
-    desc.block_count.pass[0] = (out_H + block_size.y - 1) / block_size.y;
-    desc.block_count.pass[1] = (out_W + block_size.x - 1) / block_size.x;
+    desc.block_count[0] = (out_H + block_size.y - 1) / block_size.y;
+    desc.block_count[1] = (out_W + block_size.x - 1) / block_size.x;
   } else {
-    desc.order = HorzVert;
+    desc.order = HorzVert();
     tmp_H = roi.size(0);
     tmp_W = out_W;
-    desc.block_count.pass[0] = (out_W + block_size.x - 1) / block_size.x;
-    desc.block_count.pass[1] = (out_H + block_size.y - 1) / block_size.y;
+    desc.block_count[0] = (out_W + block_size.x - 1) / block_size.x;
+    desc.block_count[1] = (out_H + block_size.y - 1) / block_size.y;
   }
-  desc.tmp_shape() = {{ tmp_H, tmp_W }};
+  desc.tmp_shape(0) = {{ tmp_H, tmp_W }};
 
   for (int stage = 0; stage < 3; stage++) {
     desc.strides[stage] = desc.shapes[stage][1] * C;
@@ -144,7 +153,7 @@ void SeparableResamplingSetup::SetupSample(
   }
   desc.channels = C;
 
-  if (desc.order == VertHorz) {
+  if (desc.order == VertHorz()) {
     desc.origin[1] -= roi.lo[1];
     desc.in_offset() += roi.lo[1] * desc.channels;
     desc.in_shape()[1] = roi.size(1);
@@ -155,7 +164,8 @@ void SeparableResamplingSetup::SetupSample(
   }
 }
 
-void BatchResamplingSetup::SetupBatch(
+template <>
+void BatchResamplingSetup<2>::SetupBatch(
     const TensorListShape<3> &in, const Params &params) {
   if (!filters)
     Initialize();
@@ -164,9 +174,12 @@ void BatchResamplingSetup::SetupBatch(
   assert(params.size() == static_cast<span_extent_t>(N));
 
   sample_descs.resize(N);
-  intermediate_shape.resize(N);
+  for (auto &shape : intermediate_shapes)
+    shape.resize(N);
+
   output_shape.resize(N);
-  intermediate_size = 0;
+  for (auto &size : intermediate_sizes)
+    size = 0;
 
   total_blocks = { 0, 0 };
 
@@ -175,41 +188,53 @@ void BatchResamplingSetup::SetupBatch(
     auto ts_in = in.tensor_shape(i);
     SetupSample(desc, ts_in, params[i]);
 
-    auto ts_tmp = intermediate_shape.tensor_shape_span(i);
-    ts_tmp[0] = desc.tmp_shape()[0];
-    ts_tmp[1] = desc.tmp_shape()[1];
-    ts_tmp[2] = desc.channels;
+    for (int t = 0; t < num_tmp_buffers; t++) {
+      auto ts_tmp = intermediate_shapes[t].tensor_shape_span(i);
+      for (int d = 0; d < spatial_ndim; d++) {
+        ts_tmp[d] = desc.tmp_shape(t)[d];
+      }
+      ts_tmp[channel_dim] = desc.channels;
+      intermediate_sizes[t] += volume(ts_tmp);
+    }
 
     auto ts_out = output_shape.tensor_shape_span(i);
     ts_out[0] = desc.out_shape()[0];
     ts_out[1] = desc.out_shape()[1];
-    ts_out[2] = desc.channels;
+    ts_out[channel_dim] = desc.channels;
 
-    intermediate_size += volume(ts_tmp);
-
-    total_blocks.pass[0] += desc.block_count.pass[0];
-    total_blocks.pass[1] += desc.block_count.pass[1];
+    total_blocks += desc.block_count;
   }
 }
 
-void BatchResamplingSetup::InitializeSampleLookup(
+template <int spatial_ndim>
+void BatchResamplingSetup<spatial_ndim>::InitializeSampleLookup(
     const OutTensorCPU<SampleBlockInfo, 1> &sample_lookup) {
-  assert(sample_lookup.shape[0] >= total_blocks.pass[0] + total_blocks.pass[1]);
+  int blocks_in_all_passes = 0;
+  for (int i = 0; i < spatial_ndim; i++)
+    blocks_in_all_passes = total_blocks[i];
+
+  assert(sample_lookup.shape[0] >= blocks_in_all_passes);
+  (void)blocks_in_all_passes;  // for non-debug builds
+
   int block = 0;
   int N = sample_descs.size();
   for (int i = 0; i < N; i++) {
-    for (int b = 0; b < sample_descs[i].block_count.pass[0]; b++) {
+    for (int b = 0; b < sample_descs[i].block_count[0]; b++) {
       sample_lookup.data[block++] = { i, b };
     }
   }
-  assert(block == total_blocks.pass[0]);
+  assert(block == total_blocks[0]);
   for (int i = 0; i < N; i++) {
-    for (int b = 0; b < sample_descs[i].block_count.pass[1]; b++) {
+    for (int b = 0; b < sample_descs[i].block_count[1]; b++) {
       sample_lookup.data[block++] = { i, b };
     }
   }
-  assert(block == total_blocks.pass[0] + total_blocks.pass[1]);
+  assert(block == total_blocks[0] + total_blocks[1]);
 }
 
+template class BatchResamplingSetup<2>;
+template class BatchResamplingSetup<3>;
+
+}  // namespace resampling
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/imgproc/resample/separable.h
+++ b/dali/kernels/imgproc/resample/separable.h
@@ -26,14 +26,16 @@ namespace kernels {
 /**
  * @brief Defines an interface of a separable resampling filter
  */
-template <typename OutputElement, typename InputElement>
+template <typename OutputElement, typename InputElement, int _spatial_ndim = 2>
 struct SeparableResamplingFilter {
-  using Input = InListGPU<InputElement, 3>;
-  using Output = OutListGPU<OutputElement, 3>;
+  static constexpr int spatial_ndim = _spatial_ndim;
+  static constexpr int tensor_ndim = spatial_ndim + 1;
+  using Input = InListGPU<InputElement, tensor_ndim>;
+  using Output = OutListGPU<OutputElement, tensor_ndim>;
 
   virtual ~SeparableResamplingFilter() = default;
 
-  using Params = span<ResamplingParams2D>;
+  using Params = span<ResamplingParamsND<spatial_ndim> >;
 
   virtual KernelRequirements
   Setup(KernelContext &context, const Input &in, const Params &params) = 0;

--- a/dali/kernels/imgproc/resample/separable_cpu.h
+++ b/dali/kernels/imgproc/resample/separable_cpu.h
@@ -22,20 +22,31 @@
 
 namespace dali {
 namespace kernels {
+namespace resampling {
 
-struct ResamplingSetupCPU : SeparableResamplingSetup {
+template <int _spatial_ndim>
+struct ResamplingSetupCPU : SeparableResamplingSetup<_spatial_ndim> {
+  using Base = SeparableResamplingSetup<_spatial_ndim>;
+  using Base::spatial_ndim;
+  using typename Base::SampleDesc;
+
   ResamplingSetupCPU() {
-    InitializeCPU();
+    this->InitializeCPU();
   }
 
   static bool IsPureNN(const SampleDesc &desc) {
-    return
-      desc.filter_type[0] == ResamplingFilterType::Nearest &&
-      desc.filter_type[1] == ResamplingFilterType::Nearest;
+    for (auto flt_type : desc.filter_type)
+      if (flt_type != ResamplingFilterType::Nearest)
+        return false;
+    return true;
   }
 
   struct MemoryReq {
+    // size, in elements, of intermediate buffers
     size_t tmp_size = 0;
+    // offset, in elements, of the odd intermediate buffer
+    size_t tmp_odd_offset = 0;
+
     size_t coeffs_size = 0;
     size_t indices_size = 0;
 
@@ -51,47 +62,84 @@ struct ResamplingSetupCPU : SeparableResamplingSetup {
   };
 
   MemoryReq GetMemoryRequirements(const SampleDesc &desc) {
-    if (IsPureNN(desc)) {
+    if (this->IsPureNN(desc)) {
       return {};  // no memory required for Nearest Neighbour on CPU
     } else {
       MemoryReq req;
-      req.tmp_size = volume(desc.tmp_shape()) * desc.channels;
-      int axis_order[2];
-      axis_order[0] = desc.order == HorzVert ? 1 : 0;  // axis 1 is horizontal, HWC layout
-      axis_order[1] = 1 - axis_order[0];
+      // temporary buffers are swapped every second stage
+      size_t tmp_sizes[2] = { 0, 0 };
+      for (int i = 0; i < desc.num_tmp_buffers; i++) {
+        size_t v = volume(desc.tmp_shape(i)) * desc.channels;
+        if (v > tmp_sizes[i&1])
+          tmp_sizes[i&1] = v;
+      }
+      req.tmp_size = tmp_sizes[0] + tmp_sizes[1];
+      req.tmp_odd_offset = tmp_sizes[0];
 
-      req.indices_size = std::max(desc.tmp_shape()[axis_order[0]],
-                                  desc.out_shape()[axis_order[1]]);
+      const int num_stages = spatial_ndim;
 
-      int support[2] = { desc.filter[0].support(), desc.filter[1].support() };
-      req.coeffs_size = std::max(desc.tmp_shape()[axis_order[0]] * support[axis_order[0]],
-                                 desc.out_shape()[axis_order[1]] * support[axis_order[1]]);
+      // returns extent of the dimensions resized at given stage - e.g. if processing
+      // (Y, Z, X)), then extent for stage 0 is height, stage 1 - depth, stage 2 - width
+      auto resized_dim_extent = [&](int stage) {
+        return stage == num_stages - 1
+          ? desc.out_shape()[desc.order[num_stages - 1]]
+          : desc.tmp_shape(stage)[desc.order[stage]];
+      };
+
+      // maximum support of the filter used at given stage
+      auto filter_support = [&](int stage) {
+        return desc.filter[desc.order[stage]].support();
+      };
+
+      req.indices_size = 0;
+      req.coeffs_size = 0;
+
+      for (int stage = 0; stage < num_stages; stage++) {
+        size_t extent = resized_dim_extent(stage);
+        size_t support = filter_support(stage);
+        size_t num_coeffs = extent * support;
+
+        if (extent > req.indices_size)
+          req.indices_size = extent;
+        if (num_coeffs > req.coeffs_size)
+          req.coeffs_size = num_coeffs;
+      }
+
       return req;
     }
   }
 };
 
-struct ResamplingSetupSingleImage : ResamplingSetupCPU {
-  void Setup(const TensorShape<3> &in_shape, const ResamplingParams2D &params) {
-    SetupSample(desc, in_shape, params);
-    memory = GetMemoryRequirements(desc);
+template <int spatial_ndim>
+struct ResamplingSetupSingleImage : ResamplingSetupCPU<spatial_ndim> {
+  using Base = ResamplingSetupCPU<spatial_ndim>;
+  using typename Base::SampleDesc;
+  using typename Base::MemoryReq;
+  using Base::tensor_ndim;
+
+  void Setup(const TensorShape<tensor_ndim> &in_shape,
+             const ResamplingParamsND<spatial_ndim> &params) {
+    this->SetupSample(desc, in_shape, params);
+    memory = this->GetMemoryRequirements(desc);
   }
 
   SampleDesc desc;
   MemoryReq memory;
 };
 
-template <typename OutputElement, typename InputElement>
+template <typename OutputElement, typename InputElement, int _spatial_ndim>
 struct SeparableResampleCPU  {
-  using Input =  InTensorCPU<InputElement, 3>;
-  using Output = OutTensorCPU<OutputElement, 3>;
+  static constexpr int spatial_ndim = _spatial_ndim;
+  static constexpr int tensor_ndim = spatial_ndim + 1;
+  using Input =  InTensorCPU<InputElement, tensor_ndim>;
+  using Output = OutTensorCPU<OutputElement, tensor_ndim>;
 
   KernelRequirements Setup(KernelContext &context,
                            const Input &input,
                            const ResamplingParams2D &params) {
     setup.Setup(input.shape, params);
 
-    TensorShape<3> out_shape =
+    TensorShape<tensor_ndim> out_shape =
         { setup.desc.out_shape()[0], setup.desc.out_shape()[1], setup.desc.channels };
 
     ScratchpadEstimator se;
@@ -108,57 +156,69 @@ struct SeparableResampleCPU  {
     return req;
   }
 
+  template <typename T, size_t n>
+  static vec<n, T> arr2vec(const DeviceArray<T, n> &shape) {
+    vec<n, T> ret = {};
+    for (size_t i = 0; i < n; i++) {
+      ret[i] = shape[n - 1 - i];
+    }
+    return ret;
+  }
+
   void Run(KernelContext &context,
            const Output &output,
            const Input &input,
-           const ResamplingParams2D &params) {
+           const ResamplingParamsND<spatial_ndim> &params) {
     auto &desc = setup.desc;
 
     desc.set_base_pointers(input.data, static_cast<char*>(nullptr), output.data);
 
-    auto in_ROI = as_surface_HWC(input);
-    in_ROI.size.x = desc.in_shape()[1];
-    in_ROI.size.y = desc.in_shape()[0];
-    in_ROI.data   = desc.template in_ptr<InputElement>();
+    auto in_ROI = as_surface_channel_last(input);
+    in_ROI.size = arr2vec(desc.in_shape());
+    in_ROI.data = desc.template in_ptr<InputElement>();
 
-    auto out_ROI = as_surface_HWC(output);
-    out_ROI.size.x = desc.out_shape()[1];
-    out_ROI.size.y = desc.out_shape()[0];
-    out_ROI.data   = desc.template out_ptr<OutputElement>();
+    auto out_ROI = as_surface_channel_last(output);
+    out_ROI.size = arr2vec(desc.out_shape());
+    out_ROI.data = desc.template out_ptr<OutputElement>();
 
     if (setup.IsPureNN(desc)) {
       ResampleNN(out_ROI, in_ROI,
-                 desc.origin[1], desc.origin[0], desc.scale[1], desc.scale[0]);
+                 arr2vec(desc.origin), arr2vec(desc.scale));
     } else {
-      TensorShape<3> tmp_shape = { desc.tmp_shape()[0], desc.tmp_shape()[1], desc.channels };
-      auto tmp = context.scratchpad->AllocTensor<AllocType::Host, float, 3>(tmp_shape);
+      TensorShape<tensor_ndim> tmp_shapes[num_tmp_buffers];
+      for (int i = 0; i < num_tmp_buffers; i++) {
+        tmp_shapes[i] = { desc.tmp_shape(i)[0], desc.tmp_shape(i)[1], desc.channels };
+      }
+
+      auto tmp = context.scratchpad->AllocTensor<AllocType::Host, float, 3>(tmp_shapes[0]);
 
       auto tmp_surf = as_surface_HWC(tmp);
 
       void *filter_mem = context.scratchpad->Allocate<int32_t>(AllocType::Host,
         setup.memory.coeffs_size + setup.memory.indices_size);
 
-      if (desc.order == setup.VertHorz) {
-        ResamplePass<0, float, InputElement>(tmp_surf, in_ROI, filter_mem);
-        ResamplePass<1, OutputElement, float>(out_ROI, tmp_surf, filter_mem);
+      if (desc.order == VertHorz()) {
+        ResamplePass<float, InputElement>(tmp_surf, in_ROI, filter_mem, 0);
+        ResamplePass<OutputElement, float>(out_ROI, tmp_surf, filter_mem, 1);
       } else {
-        ResamplePass<1, float, InputElement>(tmp_surf, in_ROI, filter_mem);
-        ResamplePass<0, OutputElement, float>(out_ROI, tmp_surf, filter_mem);
+        ResamplePass<float, InputElement>(tmp_surf, in_ROI, filter_mem, 1);
+        ResamplePass<OutputElement, float>(out_ROI, tmp_surf, filter_mem, 0);
       }
     }
   }
 
-  template <int axis, typename PassOutput, typename PassInput>
+  template <typename PassOutput, typename PassInput>
   void ResamplePass(const Surface2D<PassOutput> &out,
                     const Surface2D<const PassInput> &in,
-                    void *mem) {
+                    void *mem,
+                    int axis) {
     auto &desc = setup.desc;
 
     if (desc.filter_type[axis] == ResamplingFilterType::Nearest) {
       // use specialized NN resampling pass - should be faster
       ResampleNN(out, in,
-        desc.origin[1], desc.origin[0],
-        (axis == 1 ? desc.scale[1] : 1.0f), (axis == 0 ? desc.scale[0] : 1.0f));
+        { desc.origin[1], desc.origin[0] },
+        { (axis == 1 ? desc.scale[1] : 1.0f), (axis == 0 ? desc.scale[0] : 1.0f) });
     } else {
       int32_t *indices = static_cast<int32_t*>(mem);
       float *coeffs = static_cast<float*>(static_cast<void*>(indices + desc.out_shape()[axis]));
@@ -171,9 +231,12 @@ struct SeparableResampleCPU  {
     }
   }
 
-  ResamplingSetupSingleImage setup;
+  using ResamplingSetup = ResamplingSetupSingleImage<spatial_ndim>;
+  ResamplingSetup setup;
+  static constexpr int num_tmp_buffers = ResamplingSetup::num_tmp_buffers;
 };
 
+}  // namespace resampling
 }  // namespace kernels
 }  // namespace dali
 

--- a/dali/kernels/imgproc/resample/separable_impl_select.h
+++ b/dali/kernels/imgproc/resample/separable_impl_select.h
@@ -21,11 +21,15 @@
 namespace dali {
 namespace kernels {
 
-template <typename OutputElement, typename InputElement>
-typename SeparableResamplingFilter<OutputElement, InputElement>::Ptr
-SeparableResamplingFilter<OutputElement, InputElement>::Create(const Params &params) {
+using namespace resampling;  // NOLINT
+
+template <typename OutputElement, typename InputElement, int spatial_ndim>
+typename SeparableResamplingFilter<OutputElement, InputElement, spatial_ndim>::Ptr
+SeparableResamplingFilter<OutputElement, InputElement, spatial_ndim>::Create(
+    const Params &params) {
   (void)params;
-  using ImplType = SeparableResamplingGPUImpl<OutputElement, InputElement>;
+  using ImplType =
+    resampling::SeparableResamplingGPUImpl<OutputElement, InputElement, spatial_ndim>;
   return Ptr(new ImplType());
 }
 

--- a/dali/kernels/imgproc/resample_cpu.h
+++ b/dali/kernels/imgproc/resample_cpu.h
@@ -22,8 +22,8 @@
 namespace dali {
 namespace kernels {
 
-template <typename OutputElement, typename InputElement>
-using ResampleCPU = SeparableResampleCPU<OutputElement, InputElement>;
+template <typename OutputElement, typename InputElement, int spatial_ndim = 2>
+using ResampleCPU = resampling::SeparableResampleCPU<OutputElement, InputElement, spatial_ndim>;
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/test/resampling_test/resampling_impl_cpu_test.cc
+++ b/dali/kernels/test/resampling_test/resampling_impl_cpu_test.cc
@@ -173,7 +173,7 @@ TEST(ResampleCPU, NN) {
   auto out_tensor = view_as_tensor<uint8_t, 3>(out_img);
 
   ResampleNN(as_surface_HWC(out_tensor), as_surface_HWC(in_tensor),
-    0, 0, scalex, scaley);
+    { 0, 0 }, { scalex, scaley });
 
   auto ref_tensor = view_as_tensor<const uint8_t, 3>(ref);
   Check(ref_tensor, out_tensor);
@@ -196,7 +196,7 @@ TEST(ResampleCPU, NN_Identity) {
   auto out_tensor = view_as_tensor<uint8_t, 3>(out_img);
 
   ResampleNN(as_surface_HWC(out_tensor), as_surface_HWC(in_tensor),
-    0, 0, scalex, scaley);
+    { 0, 0 }, { scalex, scaley });
 
   Check(in_tensor, out_tensor);
 }

--- a/dali/kernels/test/resampling_test/separable_cpu_test.cc
+++ b/dali/kernels/test/resampling_test/separable_cpu_test.cc
@@ -25,6 +25,9 @@ namespace dali {
 namespace kernels {
 namespace resample_test {
 
+using namespace resampling;  // NOLINT
+
+
 template <typename ElementType>
 cv::Mat MatWithShape(TensorShape<3> shape) {
   using U = std::remove_const_t<ElementType>;
@@ -43,7 +46,7 @@ TEST_P(ResamplingTestCPU, Impl) {
   auto in_tensor = view_as_tensor<const uint8_t, 3>(img);
   auto ref_tensor = view_as_tensor<const uint8_t, 3>(ref);
 
-  SeparableResampleCPU<uint8_t, uint8_t> resample;
+  SeparableResampleCPU<uint8_t, uint8_t, 2> resample;
   KernelContext context;
   ScratchpadAllocator scratch_alloc;
 
@@ -147,11 +150,8 @@ static std::vector<ResamplingTestEntry> CropResampleTests = {
   },
 };
 
-
-
 INSTANTIATE_TEST_SUITE_P(Basic, ResamplingTestCPU, ::testing::ValuesIn(ResampleTests));
 INSTANTIATE_TEST_SUITE_P(Crop , ResamplingTestCPU, ::testing::ValuesIn(CropResampleTests));
-
 
 }  // namespace resample_test
 }  // namespace kernels

--- a/dali/kernels/test/resampling_test/separable_impl_test.cc
+++ b/dali/kernels/test/resampling_test/separable_impl_test.cc
@@ -65,7 +65,7 @@ TEST(SeparableImpl, Setup) {
   int N = 32;
   KernelContext ctx;
   ctx.gpu.stream = 0;
-  SeparableResamplingGPUImpl<uint8_t, uint8_t> resampling;
+  SeparableResamplingGPUImpl<uint8_t, uint8_t, 2> resampling;
   TestTensorList<uint8_t, 3> input, output;
 
   TensorListShape<3> tls;
@@ -91,11 +91,11 @@ TEST(SeparableImpl, Setup) {
     };
     EXPECT_EQ(req.output_shapes[0].tensor_shape(i), expected_shape);
 
-    EXPECT_GE(resampling.setup.sample_descs[i].block_count.pass[0], 1);
-    EXPECT_GE(resampling.setup.sample_descs[i].block_count.pass[1], 1);
+    EXPECT_GE(resampling.setup.sample_descs[i].block_count[0], 1);
+    EXPECT_GE(resampling.setup.sample_descs[i].block_count[1], 1);
   }
-  EXPECT_GT(resampling.setup.total_blocks.pass[0], N);
-  EXPECT_GT(resampling.setup.total_blocks.pass[1], N);
+  EXPECT_GT(resampling.setup.total_blocks[0], N);
+  EXPECT_GT(resampling.setup.total_blocks[1], N);
 }
 
 ResamplingTestBatch SingleImageBatch = {
@@ -169,7 +169,7 @@ TEST_P(BatchResamplingTest, ResamplingImpl) {
   ScratchpadAllocator scratch_alloc;
   KernelContext ctx;
   ctx.gpu.stream = 0;
-  SeparableResamplingGPUImpl<uint8_t, uint8_t> resampling;
+  SeparableResamplingGPUImpl<uint8_t, uint8_t, 2> resampling;
   TestTensorList<uint8_t, 3> input, output;
 
   FilterDesc tri;
@@ -209,8 +209,8 @@ TEST_P(BatchResamplingTest, ResamplingImpl) {
     };
     ASSERT_EQ(req.output_shapes[0].tensor_shape(i), expected_shape);
 
-    EXPECT_GE(resampling.setup.sample_descs[i].block_count.pass[0], 1);
-    EXPECT_GE(resampling.setup.sample_descs[i].block_count.pass[1], 1);
+    EXPECT_GE(resampling.setup.sample_descs[i].block_count[0], 1);
+    EXPECT_GE(resampling.setup.sample_descs[i].block_count[1], 1);
   }
 
   auto scratchpad = scratch_alloc.GetScratchpad();


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one*
- It is intermediate step for Volume Resampling

#### What happened in this PR?
- Number of dimensions in resampling kernels is now a template argument
- Pass number moved from template argument to function argument (no need to specialize over that one)
- **Important**: switched coordinate ordering; when unclear, the general scheme is: `dim` is a tensor-like dimensions (0 is outermost), `axis` is vector-like (0 is X).

**JIRA TASK**: [DALI-1075]