### PR TITLE
Add skip_vfr_check option to VideoReader

### DIFF
--- a/dali/pipeline/operators/reader/loader/video_loader.cc
+++ b/dali/pipeline/operators/reader/loader/video_loader.cc
@@ -269,7 +269,7 @@ OpenFile& VideoLoader::get_or_open_file(const std::string &filename) {
 
     DALI_ENFORCE(ret >=0, "Unable to read frame from file :" + filename);
 
-    DALI_ENFORCE(
+    DALI_ENFORCE(skip_vfr_check_ ||
       almost_equal(av_q2d(file.frame_base_), pkt.duration * av_q2d(file.stream_base_), 2),
       "Variable frame rate videos are unsupported. Check failed for file: " + filename);
 

--- a/dali/pipeline/operators/reader/loader/video_loader.h
+++ b/dali/pipeline/operators/reader/loader/video_loader.h
@@ -135,6 +135,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       filenames_(filenames),
       device_id_(spec.GetArgument<int>("device_id")),
       codec_id_(0),
+      skip_vfr_check_(spec.GetArgument<bool>("skip_vfr_check")),
       stop_(false) {
     if (step_ < 0)
       step_ = count_ * stride_;
@@ -245,6 +246,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
 
   int device_id_;
   int codec_id_;
+  bool skip_vfr_check_;
   VideoLoaderStats stats_;
 
   std::unordered_map<std::string, OpenFile> open_files_;

--- a/dali/pipeline/operators/reader/video_reader_op.cc
+++ b/dali/pipeline/operators/reader/video_reader_op.cc
@@ -72,5 +72,7 @@ This option is mutually exclusive with `filenames` and `file_root`.)code",
       DALI_UINT8)
   .AddOptionalArg("stride",
       R"code(Distance between consecutive frames in sequence.)code", 1u, false)
+  .AddOptionalArg("skip_vfr_check",
+      R"code(Skips check for variable frame rate on videos. This is useful when heuristic fails.)code", false)
   .AddParent("LoaderBase");
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Abhishek Sansanwal <asansanwal@nvidia.com>

#### Why we need this PR?
*Pick one*
- It fixes a bug *bug description*
- It adds new feature needed because *why we need this feature*
Adds `skip_vfr_check` parameter to VideoReader. 
- Refactoring to improve *what*

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
This allows disabling the variable frame rate heuristic check if the user feels confident that there are no vfr videos in the dataset. 
 - What was changed, added, removed?
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
Checked using video_label_example.py script.
 - Were docs and examples updated, if necessary?
Not updated.

**JIRA TASK**: [DALI-XXXX]