### PR TITLE
Support float16 in Cast GPU operator

### DIFF
--- a/dali/pipeline/operators/util/cast.cc
+++ b/dali/pipeline/operators/util/cast.cc
@@ -28,7 +28,7 @@ void Cast<CPUBackend>::RunImpl(SampleWorkspace &ws) {
       output.mutable_data<OType>();
       output.ResizeLike(input);
       DALI_TYPE_SWITCH_WITH_FP16(itype, IType,
-        CPUHelper<IType, OType>(
+        CPUHelper<OType, IType>(
           output.mutable_data<OType>(),
           input.data<IType>(),
           input.size());););

--- a/dali/pipeline/operators/util/cast.cu
+++ b/dali/pipeline/operators/util/cast.cu
@@ -15,6 +15,7 @@
 #include "dali/pipeline/operators/util/cast.h"
 #include "dali/core/error_handling.h"
 #include "dali/core/cuda_utils.h"
+#include "dali/core/convert.h"
 
 namespace dali {
 
@@ -23,11 +24,7 @@ __global__ void
 BatchedCastKernel(OType * output, const IType * in, size_t N) {
   size_t tid = threadIdx.x + blockDim.x * blockIdx.x;
   if (tid < N) {
-    if (std::is_same<IType, dali::float16>::value) {
-      output[tid] = static_cast<OType>(static_cast<float>(in[tid]));
-    } else {
-      output[tid] = static_cast<OType>(in[tid]);
-    }
+    output[tid] = ConvertSat<OType>(in[tid]);
   }
 }
 
@@ -51,10 +48,10 @@ void Cast<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
 
   DALIDataType itype = input.type().id();
 
-  DALI_TYPE_SWITCH(output_type_, OType,
+  DALI_TYPE_SWITCH_WITH_FP16(output_type_, OType,
       output.mutable_data<OType>();
       output.ResizeLike(input);
-      DALI_TYPE_SWITCH(itype, IType,
+      DALI_TYPE_SWITCH_WITH_FP16(itype, IType,
         DALI_CALL(BatchedCast(
             output.mutable_data<OType>(),
             input.data<IType>(),

--- a/dali/pipeline/operators/util/cast.cu
+++ b/dali/pipeline/operators/util/cast.cu
@@ -19,7 +19,7 @@
 
 namespace dali {
 
-template <typename IType, typename OType>
+template <typename OType, typename IType>
 __global__ void
 BatchedCastKernel(OType * output, const IType * in, size_t N) {
   size_t tid = threadIdx.x + blockDim.x * blockIdx.x;
@@ -28,7 +28,7 @@ BatchedCastKernel(OType * output, const IType * in, size_t N) {
   }
 }
 
-template <typename IType, typename OType>
+template <typename OType, typename IType>
 DALIError_t BatchedCast(OType * output,
                         const IType * input,
                         size_t N,

--- a/dali/pipeline/operators/util/cast.h
+++ b/dali/pipeline/operators/util/cast.h
@@ -42,10 +42,10 @@ class Cast : public Operator<Backend> {
   void RunImpl(Workspace<Backend> &ws) override;
 
  private:
-  template <typename IType, typename OType>
+  template <typename OType, typename IType>
   inline void CPUHelper(OType *out, const IType *in, size_t N) {
     for (size_t i = 0; i < N; ++i) {
-      out[i] = clamp<OType>(in[i]);
+      out[i] = ConvertSat<OType>(in[i]);
     }
   }
 

--- a/dali/test/python/test_operator_cast.py
+++ b/dali/test/python/test_operator_cast.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops as ops
+import nvidia.dali.types as types
+import nvidia.dali as dali
+from nvidia.dali.backend_impl import TensorListGPU
+import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
+
+from test_utils import check_batch
+from test_utils import compare_pipelines
+from test_utils import RandomDataIterator
+from test_utils import get_dali_extra_path
+
+class CastPipeline(Pipeline):
+    def __init__(self, device, batch_size, iterator, cast_dtypes, num_threads=1, device_id=0):
+        super(CastPipeline, self).__init__(batch_size, num_threads, device_id)
+        self.layout = "HWC"
+        self.device = device
+        self.iterator = iterator
+        self.inputs = ops.ExternalSource()
+        self.cast = [ops.Cast(device=device, dtype=dtype) for dtype in cast_dtypes]
+
+    def define_graph(self):
+        self.data = self.inputs()
+        out = self.data.gpu() if self.device == 'gpu' else self.data
+        for k in range(len(self.cast)):
+            out = self.cast[k](out)
+        return out
+
+    def iter_setup(self):
+        data = self.iterator.next()
+        self.feed_input(self.data, data, layout=self.layout)
+
+def check_cast_operator_float16(device, batch_size):
+    input_shape=(300, 400, 3)
+    eii1 = RandomDataIterator(batch_size, shape=input_shape)
+    eii2 = RandomDataIterator(batch_size, shape=input_shape)
+    compare_pipelines(
+        CastPipeline(device, batch_size, iter(eii1), [types.FLOAT16, types.FLOAT]),
+        CastPipeline(device, batch_size, iter(eii2), [types.FLOAT]),
+        batch_size=batch_size, N_iterations=5)
+
+def test_cast_operator_float16():
+    for device in ['cpu', 'gpu']:
+        for batch_size in [3]:
+            yield check_cast_operator_float16, device, batch_size

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -245,6 +245,34 @@ struct ConverterBase<Out, In, true, false> {
   static constexpr Out ConvertSatNorm(In value) { return value * (Out(1) / (max_value<In>())); }
 };
 
+/// Converts integral to float16 special case
+template <typename In>
+struct ConverterBase<float16, In, true, false> {
+  DALI_HOST_DEV
+  static constexpr float16 Convert(In value) {
+    auto out = ConverterBase<float, In, true, false>::Convert(value);
+    return static_cast<float16>(out);
+  }
+
+  DALI_HOST_DEV
+  static constexpr float16 ConvertSat(In value) {
+    auto out = ConverterBase<float, In, true, false>::ConvertSat(value);
+    return static_cast<float16>(out);
+  }
+
+  DALI_HOST_DEV
+  static constexpr float16 ConvertNorm(In value) {
+    auto out = ConverterBase<float, In, true, false>::ConvertNorm(value);
+    return static_cast<float16>(out);
+  }
+
+  DALI_HOST_DEV
+  static constexpr float16 ConvertSatNorm(In value) {
+    auto out = ConverterBase<float, In, true, false>::ConvertSatNorm(value);
+    return static_cast<float16>(out);
+  }
+};
+
 /// Converts FP to integral type
 template <typename Out, typename In>
 struct ConverterBase<Out, In, false, true> {


### PR DESCRIPTION
#### Why we need this PR?
*Pick one*
- Cast GPU operator didn't support float16

#### What happened in this PR?
- Added specialization of ConverterBase for OutputType=float16 to overcome the lack of __half constructor for types like int64_t
- Added support for float16 in Cast GPU operator
- Adjusted Cast operator to use ConvertSat utility
- Fixed order of template arguments in Cast Op

**JIRA TASK**: [DALI-XXXX]