### PR TITLE
Add torch dependency to TL1_separate_executor

### DIFF
--- a/qa/TL1_separate_executor/test.sh
+++ b/qa/TL1_separate_executor/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="tensorflow-gpu torchvision mxnet-cu##CUDA_VERSION##"
+pip_packages="tensorflow-gpu torchvision torch mxnet-cu##CUDA_VERSION##"
 target_dir=./dali/test/python
 one_config_only=true
 


### PR DESCRIPTION
- TL1_separate_executor depends on torch, but the only torchvision is listed

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- add torch dependency to TL1_separate_executor

#### What happened in this PR?
 -TL1_separate_executor depends on torch, but the only torchvision is listed
 - tested on CI

**JIRA TASK**: [NA]