### PR TITLE
Generalize helper code to unary inputs

### DIFF
--- a/dali/operators/expressions/arithmetic.cc
+++ b/dali/operators/expressions/arithmetic.cc
@@ -14,8 +14,8 @@
 
 #include <vector>
 
-#include "dali/operators/expressions/arithmetic.h"
 #include "dali/kernels/type_tag.h"
+#include "dali/operators/expressions/arithmetic.h"
 
 namespace dali {
 

--- a/dali/operators/expressions/expression_tree.h
+++ b/dali/operators/expressions/expression_tree.h
@@ -58,6 +58,7 @@ inline std::ostream &operator<<(std::ostream &os, const TileRange &v) {
 class ExprNode;
 
 struct ExprImplContext {
+  cudaStream_t stream;
   const ExprNode *node;
 };
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Generalize type and shape propagation for expressions by supporting unary and binary inputs with possibility to extend for higher arities (depending on the needs and spec).

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
Use small vector where possible to functions like `TypePromotion` and `ShapePromotion`.
 - What was changed, added, removed?
Additionaly added parsing of types for constants. 
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
 - Were docs and examples updated, if necessary?

**JIRA TASK**: [DALI-XXXX]