### PR TITLE
Relax check for libnvidia-opticalflow is test script.

### DIFF
--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -28,7 +28,8 @@ echo "LD_LIBRARY_PATH is $LD_LIBRARY_PATH"
 put_optflow_libs() {
   # Docker v1 doesn't expose libnvidia-opticalflow.so from the host so we need to manually put it there
   # workaround for the CI
-  if [[ ! -f /usr/lib/x86_64-linux-gnu/libnvidia-opticalflow.so ]]; then
+  if [[ ! -f /usr/lib/x86_64-linux-gnu/libnvidia-opticalflow.so ]] &&
+     [[ ! -f /usr/lib/x86_64-linux-gnu/libnvidia-opticalflow.so.1 ]]; then
       NVIDIA_SMI_DRIVER_VERSION_LONG=$(nvidia-smi | grep -Po '(?<=Driver Version: )\d+.\d+.\d+')
 
       # Hack alert: This url doesn't work with 430.XX family


### PR DESCRIPTION
* Check if neither `libnvidia-opticalflow.so` nor `libnvidia-opticalflow.so.1` exists.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
Because CI fails when there's no libnvidia-opticalflow.so and that particular file is not necessary.

#### What happened in this PR?
 - Added `libnvidia-opticalflow.so.1` as an alternative - if it's there, driver installation can be skipped.

**JIRA TASK**: [DALI-XXXX]