### PR TITLE
Fix DALI TF installation for TF 2.0

### DIFF
--- a/dali_tf_plugin/dali_tf_plugin_utils.py
+++ b/dali_tf_plugin/dali_tf_plugin_utils.py
@@ -41,10 +41,11 @@ def get_module_path(module_name):
 
 # Get compiler version used to build tensorflow
 def get_tf_compiler_version():
-    tensorflow_path = get_module_path('tensorflow')
-    tensorflow_libs = find('libtensorflow_framework*so*', tensorflow_path)
+    tensorflow_libs = find('libtensorflow_framework*so*', get_module_path('tensorflow'))
     if not tensorflow_libs:
-        return ''
+        tensorflow_libs = find('libtensorflow_framework*so*', get_module_path('tensorflow_core'))
+        if not tensorflow_libs:
+            return ''
     lib = tensorflow_libs[0]
     cmd = 'strings -a ' + lib + ' | grep "GCC: ("'
     s = str(subprocess.check_output(cmd, shell=True))


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
Broken DALI TF 2.0 installation

#### What happened in this PR?
- Adjust get_tf_compiler_version to look both in `tensorflow` and `tensorflow_core` directories

**JIRA TASK**: [DALI-XXXX]