### PR TITLE
Force inline

### DIFF
--- a/include/dali/core/force_inline.h
+++ b/include/dali/core/force_inline.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_FORCE_INLINE_H_
+#define DALI_CORE_FORCE_INLINE_H_
+
+#ifndef DALI_FORCEINLINE
+#if defined(_MSC_VER)
+#define DALI_FORCEINLINE __forceinline
+#elif defined(__GNUC__) && __GNUC__ >= 4
+#define DALI_FORCEINLINE __attribute__((always_inline)) inline
+#else
+#define DALI_FORCEINLINE inline
+#endif
+#endif
+
+#endif  // DALI_CORE_FORCE_INLINE_H_

--- a/include/dali/core/geom/transform.h
+++ b/include/dali/core/geom/transform.h
@@ -92,6 +92,39 @@ constexpr mat4 shear(mat3x2 shear) {
   }};
 }
 
+template <int out_n, int in_n>
+DALI_HOST_DEV
+constexpr vec<out_n> affine(const mat<out_n, in_n + 1> &transform, const vec<in_n> &v) {
+  vec<out_n> out = {};
+  for (int i = 0; i < out_n; i++) {
+    float sum = transform(i, in_n);
+    for (int j = 0; j < in_n; j++) {
+      sum += transform(i, j) * v[j];
+    }
+    out[i] = sum;
+  }
+  return out;
+}
+
+template<>
+DALI_HOST_DEV
+constexpr vec2 affine<2, 2>(const mat<2, 3> &transform, const vec2 &v) {
+  return {
+    transform(0, 2) + transform(0, 0) * v.x + transform(0, 1) * v.y,
+    transform(1, 2) + transform(1, 0) * v.x + transform(1, 1) * v.y,
+  };
+}
+
+template<>
+DALI_HOST_DEV
+constexpr vec3 affine<3, 3>(const mat<3, 4> &transform, const vec3 &v) {
+  return {
+    transform(0, 3) + transform(0, 0) * v.x + transform(0, 1) * v.y + transform(0, 2) * v.z,
+    transform(1, 3) + transform(1, 0) * v.x + transform(1, 1) * v.y + transform(1, 2) * v.z,
+    transform(2, 3) + transform(2, 0) * v.x + transform(2, 1) * v.y + transform(2, 2) * v.z,
+  };
+}
+
 }  // namespace dali
 
 #endif  // DALI_CORE_GEOM_TRANSFORM_H_

--- a/include/dali/core/geom/vec.h
+++ b/include/dali/core/geom/vec.h
@@ -23,6 +23,7 @@
 #include "dali/core/host_dev.h"
 #include "dali/core/util.h"
 #include "dali/core/math_util.h"
+#include "dali/core/force_inline.h"
 
 namespace dali {
 
@@ -219,13 +220,13 @@ struct vec : vec_base<N, T> {
   DALI_HOST_DEV
   constexpr vec(mat<N, 1, U> &m) : vec(m.col(0).template cast<T>()) {}  // NOLINT
 
-  DALI_HOST_DEV
+  DALI_HOST_DEV DALI_FORCEINLINE
   constexpr T &operator[](int i) { return v[i]; }
-  DALI_HOST_DEV
+  DALI_HOST_DEV DALI_FORCEINLINE
   constexpr const T &operator[](int i) const { return v[i]; }
 
   template <typename U>
-  DALI_HOST_DEV
+  DALI_HOST_DEV DALI_FORCEINLINE
   constexpr vec<N, U> cast() const {
     vec<N, U> ret = {};
     for (int i = 0; i < N; i++) {
@@ -234,7 +235,7 @@ struct vec : vec_base<N, T> {
     return ret;
   }
 
-  DALI_HOST_DEV constexpr int size() const { return N; }
+  DALI_HOST_DEV DALI_FORCEINLINE constexpr int size() const { return N; }
 
   DALI_HOST_DEV constexpr T *begin() { return &v[0]; }
   DALI_HOST_DEV constexpr const T *cbegin() const { return &v[0]; }
@@ -244,7 +245,7 @@ struct vec : vec_base<N, T> {
   DALI_HOST_DEV constexpr const T *end() const { return &v[N]; }
 
   /// @brief Calculates the sum of squares of components.
-  DALI_HOST_DEV constexpr auto length_square() const {
+  DALI_HOST_DEV DALI_FORCEINLINE constexpr auto length_square() const {
     decltype(v[0]*v[0] + v[0]*v[0]) ret = v[0]*v[0];
     for (int i = 1; i < N; i++)
       ret += v[i]*v[i];
@@ -265,11 +266,11 @@ struct vec : vec_base<N, T> {
   }
 
   /// @brief Returns a copy. Doesn't promote type to int.
-  DALI_HOST_DEV constexpr vec operator+() const { return *this; }
+  DALI_HOST_DEV DALI_FORCEINLINE constexpr vec operator+() const { return *this; }
 
   /// @brief Negates all components. Doesn't promote type to int.
   DALI_HOST_DEV
-  inline vec operator-() const {
+  DALI_FORCEINLINE vec operator-() const {
     vec<N, T> ret;
     for (int i = 0; i < N; i++) {
       ret.v[i] = -v[i];
@@ -277,7 +278,7 @@ struct vec : vec_base<N, T> {
     return ret;
   }
   DALI_HOST_DEV
-  inline vec operator~() const {
+  DALI_FORCEINLINE vec operator~() const {
     vec<N, T> ret;
     for (int i = 0; i < N; i++) {
       ret.v[i] = ~v[i];
@@ -285,16 +286,17 @@ struct vec : vec_base<N, T> {
     return ret;
   }
 
-#define DEFINE_ASSIGN_VEC_OP(op)                                                         \
-  template <typename U>                                                                  \
-  DALI_HOST_DEV vec &operator op(const vec<N, U> &rhs) {                                 \
-    for (int i = 0; i < N; i++) v[i] op rhs[i];                                       \
-    return *this;                                                                        \
-  }                                                                                      \
-  template <typename U>                                                                  \
-  DALI_HOST_DEV std::enable_if_t<is_scalar<U>::value, vec &> operator op(const U &rhs) { \
-    for (int i = 0; i < N; i++) v[i] op rhs;                                          \
-    return *this;                                                                        \
+#define DEFINE_ASSIGN_VEC_OP(op)                                            \
+  template <typename U>                                                     \
+  DALI_HOST_DEV DALI_FORCEINLINE vec &operator op(const vec<N, U> &rhs) {   \
+    for (int i = 0; i < N; i++) v[i] op rhs[i];                             \
+    return *this;                                                           \
+  }                                                                         \
+  template <typename U>                                                     \
+  DALI_HOST_DEV DALI_FORCEINLINE                                            \
+  std::enable_if_t<is_scalar<U>::value, vec &> operator op(const U &rhs) {  \
+    for (int i = 0; i < N; i++) v[i] op rhs;                                \
+    return *this;                                                           \
   }
 
   DEFINE_ASSIGN_VEC_OP(=)
@@ -314,7 +316,7 @@ struct vec : vec_base<N, T> {
 
 template <int N, typename T, typename U>
 DALI_HOST_DEV
-constexpr auto dot(const vec<N, T> &a, const vec<N, U> &b) {
+DALI_FORCEINLINE constexpr auto dot(const vec<N, T> &a, const vec<N, U> &b) {
   decltype(a[0]*b[0] + a[0]*b[0]) ret = a[0]*b[0];
   for (int i = 1; i < N; i++)
     ret += a[i]*b[i];
@@ -323,7 +325,7 @@ constexpr auto dot(const vec<N, T> &a, const vec<N, U> &b) {
 
 template <typename T, typename U>
 DALI_HOST_DEV
-constexpr auto cross(const vec<3, T> &a, const vec<3, U> &b) {
+DALI_FORCEINLINE constexpr auto cross(const vec<3, T> &a, const vec<3, U> &b) {
   using R = decltype(a[0]*b[0] + a[0]*b[0]);
   return vec<3, R>{
     a.y * b.z - b.y * a.z,
@@ -335,30 +337,30 @@ constexpr auto cross(const vec<3, T> &a, const vec<3, U> &b) {
 /// @brief Calculates `z` coordinate of a cross product of two 2D vectors
 template <typename T, typename U>
 DALI_HOST_DEV
-constexpr auto cross(const vec<2, T> &a, const vec<2, U> &b) {
+DALI_FORCEINLINE constexpr auto cross(const vec<2, T> &a, const vec<2, U> &b) {
   return a.x * b.y - b.x * a.y;
 }
 
-#define DEFINE_ELEMENTIWSE_VEC_BIN_OP(op)                                              \
-  template <int N, typename T, typename U>                                          \
-  DALI_HOST_DEV inline auto operator op(const vec<N, T> &a, const vec<N, U> &b) {      \
-    vec<N, promote_vec_t<T, U>> ret;                                                   \
-    for (int i = 0; i < N; i++) ret[i] = a[i] op b[i];                              \
-    return ret;                                                                        \
-  }                                                                                    \
-  template <int N, typename T, typename U, typename R = promote_vec_scalar_t<T, U>> \
-  DALI_HOST_DEV inline std::enable_if_t<is_scalar<U>::value, vec<N, R>> operator op(   \
-      const vec<N, T> &a, const U &b) {                                                \
-    vec<N, R> ret;                                                                     \
-    for (int i = 0; i < N; i++) ret[i] = a[i] op b;                                 \
-    return ret;                                                                        \
-  }                                                                                    \
-  template <int N, typename T, typename U, typename R = promote_vec_scalar_t<U, T>> \
-  DALI_HOST_DEV inline std::enable_if_t<is_scalar<T>::value, vec<N, R>> operator op(   \
-      const T &a, const vec<N, U> &b) {                                                \
-    vec<N, R> ret;                                                                     \
-    for (int i = 0; i < N; i++) ret[i] = a op b[i];                                 \
-    return ret;                                                                        \
+#define DEFINE_ELEMENTIWSE_VEC_BIN_OP(op)                                                       \
+  template <int N, typename T, typename U>                                                      \
+  DALI_HOST_DEV DALI_FORCEINLINE auto operator op(const vec<N, T> &a, const vec<N, U> &b) {     \
+    vec<N, promote_vec_t<T, U>> ret;                                                            \
+    for (int i = 0; i < N; i++) ret[i] = a[i] op b[i];                                          \
+    return ret;                                                                                 \
+  }                                                                                             \
+  template <int N, typename T, typename U, typename R = promote_vec_scalar_t<T, U>>             \
+  DALI_HOST_DEV DALI_FORCEINLINE std::enable_if_t<is_scalar<U>::value, vec<N, R>> operator op(  \
+      const vec<N, T> &a, const U &b) {                                                         \
+    vec<N, R> ret;                                                                              \
+    for (int i = 0; i < N; i++) ret[i] = a[i] op b;                                             \
+    return ret;                                                                                 \
+  }                                                                                             \
+  template <int N, typename T, typename U, typename R = promote_vec_scalar_t<U, T>>             \
+  DALI_HOST_DEV DALI_FORCEINLINE std::enable_if_t<is_scalar<T>::value, vec<N, R>> operator op(  \
+      const T &a, const vec<N, U> &b) {                                                         \
+    vec<N, R> ret;                                                                              \
+    for (int i = 0; i < N; i++) ret[i] = a op b[i];                                             \
+    return ret;                                                                                 \
   }
 
 DEFINE_ELEMENTIWSE_VEC_BIN_OP(+)
@@ -374,26 +376,27 @@ DEFINE_ELEMENTIWSE_VEC_BIN_OP(>)  // NOLINT
 DEFINE_ELEMENTIWSE_VEC_BIN_OP(<=)
 DEFINE_ELEMENTIWSE_VEC_BIN_OP(>=)
 
-#define DEFINE_SHIFT_VEC_BIN_OP(op)                                                                \
-  template <int N, typename T, typename U>                                                      \
-  DALI_HOST_DEV vec<N, T> operator op(const vec<N, T> &a, const vec<N, U> &b) {                    \
-    vec<N, T> ret;                                                                                 \
-    for (int i = 0; i < N; i++) ret[i] = a[i] op b[i];                                          \
-    return ret;                                                                                    \
-  }                                                                                                \
-  template <int N, typename T, typename U>                                                      \
-  DALI_HOST_DEV std::enable_if_t<is_scalar<U>::value, vec<N, T>> operator op(const vec<N, T> &a,   \
-                                                                             const U &b) {         \
-    vec<N, T> ret;                                                                                 \
-    for (int i = 0; i < N; i++) ret[i] = a[i] op b;                                             \
-    return ret;                                                                                    \
-  }                                                                                                \
-  template <int N, typename T, typename U>                                                      \
-  DALI_HOST_DEV std::enable_if_t<is_scalar<T>::value, vec<N, T>> operator op(const T &a,           \
-                                                                             const vec<N, U> &b) { \
-    vec<N, T> ret;                                                                                 \
-    for (int i = 0; i < N; i++) ret[i] = a op b[i];                                             \
-    return ret;                                                                                    \
+#define DEFINE_SHIFT_VEC_BIN_OP(op)                                               \
+  template <int N, typename T, typename U>                                        \
+  DALI_HOST_DEV DALI_FORCEINLINE vec<N, T> operator                               \
+  op(const vec<N, T> &a, const vec<N, U> &b) {                                    \
+    vec<N, T> ret;                                                                \
+    for (int i = 0; i < N; i++) ret[i] = a[i] op b[i];                            \
+    return ret;                                                                   \
+  }                                                                               \
+  template <int N, typename T, typename U>                                        \
+  DALI_HOST_DEV DALI_FORCEINLINE std::enable_if_t<is_scalar<U>::value, vec<N, T>> \
+  operator op(const vec<N, T> &a, const U &b) {                                   \
+    vec<N, T> ret;                                                                \
+    for (int i = 0; i < N; i++) ret[i] = a[i] op b;                               \
+    return ret;                                                                   \
+  }                                                                               \
+  template <int N, typename T, typename U>                                        \
+  DALI_HOST_DEV DALI_FORCEINLINE std::enable_if_t<is_scalar<T>::value, vec<N, T>> \
+  operator op(const T &a, const vec<N, U> &b) {                                   \
+    vec<N, T> ret;                                                                \
+    for (int i = 0; i < N; i++) ret[i] = a op b[i];                               \
+    return ret;                                                                   \
   }
 
 DEFINE_SHIFT_VEC_BIN_OP(<<)
@@ -451,7 +454,7 @@ DALI_HOST_DEV constexpr bool operator!=(const vec<N, T> &a, const vec<N, U> &b) 
   return result;
 
 template <typename To, int N, typename From>
-DALI_HOST_DEV inline vec<N, To> cast(const vec<N, From> &v) {
+DALI_HOST_DEV DALI_FORCEINLINE vec<N, To> cast(const vec<N, From> &v) {
   return v.template cast<To>();
 }
 
@@ -512,7 +515,7 @@ DALI_HOST_DEV ivec<N> round_int(const vec<N> &a) {
 }
 
 template <typename T, int size0, int size1>
-DALI_HOST_DEV
+DALI_HOST_DEV DALI_FORCEINLINE
 constexpr auto cat(const vec<size0, T> &v0, const vec<size1, T> &v1) {
   vec<size0 + size1, T> ret = {};
   for (int i = 0; i < size0; i ++) {
@@ -525,7 +528,7 @@ constexpr auto cat(const vec<size0, T> &v0, const vec<size1, T> &v1) {
 }
 
 template <typename T, int size0>
-DALI_HOST_DEV
+DALI_HOST_DEV DALI_FORCEINLINE
 constexpr auto cat(const vec<size0, T> &v0, T v1) {
   vec<size0 + 1, T> ret = {};
   for (int i = 0; i < size0; i ++) {
@@ -536,7 +539,7 @@ constexpr auto cat(const vec<size0, T> &v0, T v1) {
 }
 
 template <typename T, int size1>
-DALI_HOST_DEV
+DALI_HOST_DEV DALI_FORCEINLINE
 constexpr auto cat(T v0, const vec<size1, T> &v1) {
   vec<size1 + 1, T> ret = {};
   ret[0] = v0;
@@ -547,13 +550,13 @@ constexpr auto cat(T v0, const vec<size1, T> &v1) {
 }
 
 template <typename T, int size0, int... sizes>
-DALI_HOST_DEV
+DALI_HOST_DEV DALI_FORCEINLINE
 constexpr auto cat(const vec<size0, T> &v0, const vec<sizes, T> &...tail) {
   return cat(v0, cat(tail...));
 }
 
 template <int sub_n, int n, typename T>
-DALI_HOST_DEV
+DALI_HOST_DEV DALI_FORCEINLINE
 constexpr auto sub(const vec<n, T> &orig, int start = 0) {
   static_assert(sub_n <= n, "Cannot extend a vector using `sub` function.");
   vec<sub_n, T> ret = {};
@@ -563,6 +566,7 @@ constexpr auto sub(const vec<n, T> &orig, int start = 0) {
 }
 
 template <int... indices, int N, typename T>
+DALI_HOST_DEV DALI_FORCEINLINE
 constexpr vec<sizeof...(indices), T> shuffle(const vec<N, T> &v) {
   static_assert(all_of<(indices < N)...>::value, "Vector component index out of range");
   return { v[indices]... };

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -20,6 +20,7 @@
 #include <initializer_list>
 
 #include "dali/core/host_dev.h"
+#include "dali/core/force_inline.h"
 
 namespace dali {
 


### PR DESCRIPTION
#### Why we need this PR?
`DALI_FORCEINLINE`:
- because compiler forgets to inline
- because debug code is prohibitively slow
`affine`:
- because even with DALI_FORCEINLINE, the code doesn't approach the speed of a custom-made affine transform

#### What happened in this PR?
 - Added `DALI_FORCEINLINE` macro
 - Added `affine` function which accepts N x (M+1) and M-d vector to produce N-d output

**JIRA TASK**: [DALI-XXXX]