### PR TITLE
Add support for Constant inputs and type-erased tiles

### DIFF
--- a/dali/operators/expressions/arithmetic.cc
+++ b/dali/operators/expressions/arithmetic.cc
@@ -21,18 +21,20 @@ namespace dali {
 
 template <>
 void ArithmeticGenericOp<CPUBackend>::RunImpl(HostWorkspace &ws) {
+  PrepareTilesForTasks<CPUBackend>(tiles_per_task_, exec_order_, tile_cover_, ws, constant_storage_,
+                                   spec_);
   auto &pool = ws.GetThreadPool();
   ws.OutputRef<CPUBackend>(0).SetLayout(result_layout_);
   for (size_t task_idx = 0; task_idx < tile_range_.size(); task_idx++) {
     // TODO(klecki): reduce lambda footprint
-    pool.DoWorkWithID([this, &ws, task_idx](int thread_idx) {
+    pool.DoWorkWithID([this, task_idx](int thread_idx) {
       auto range = tile_range_[task_idx];
       // Go over "tiles"
       for (int extent_idx = range.begin; extent_idx < range.end; extent_idx++) {
         // Go over expression tree in some provided order
-        for (auto &expr_task : exec_order_) {
-          expr_task.impl->Execute(ws, spec_, expr_task.ctx, tile_cover_,
-                                  {extent_idx, extent_idx + 1});
+        for (size_t i = 0; i < exec_order_.size(); i++) {
+          exec_order_[i].impl->Execute(exec_order_[i].ctx, tiles_per_task_[i],
+                                       {extent_idx, extent_idx + 1});
         }
       }
     });
@@ -63,9 +65,9 @@ Examples:
 add(&0 mul(&1 $0:int8))
 add(&0 rand()))code",
             DALIDataType::DALI_STRING, false)
-    .AddOptionalArg("integer_scalars", "", std::vector<int>{})
-    .NumInput(1, 64)  // TODO(klecki): Some arbitrary number that needs to be validated in operator
-    .AddOptionalArg("float_scalars", "", std::vector<float>{})
+    .AddOptionalArg("integer_constants", "", std::vector<int32_t>{}, true)
+    .NumInput(1, 64)  // Some arbitrary number that needs to be validated in operator
+    .AddOptionalArg("real_constants", "", std::vector<float>{}, true)
     .NumOutput(1)
     .MakeInternal();
 

--- a/dali/operators/expressions/arithmetic.cu
+++ b/dali/operators/expressions/arithmetic.cu
@@ -19,11 +19,13 @@ namespace dali {
 
 template <>
 void ArithmeticGenericOp<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
+  PrepareTilesForTasks<GPUBackend>(tiles_per_task_, exec_order_, tile_cover_, ws, constant_storage_,
+                                   spec_);
   ws.OutputRef<GPUBackend>(0).SetLayout(result_layout_);
   assert(tile_range_.size() == 1 && "Expected to cover whole GPU execution by 1 task");
-  for (auto &expr_task : exec_order_) {
+  for (size_t i = 0; i < exec_order_.size(); i++) {
     // call impl for whole batch
-    expr_task.impl->Execute(ws, spec_, expr_task.ctx, tile_cover_, tile_range_[0]);
+    exec_order_[i].impl->Execute(exec_order_[i].ctx, tiles_per_task_[i], tile_range_[0]);
   }
 }
 

--- a/dali/operators/expressions/arithmetic_meta.h
+++ b/dali/operators/expressions/arithmetic_meta.h
@@ -59,6 +59,10 @@ DALI_HOST_DEV constexpr int GetOpArity(ArithmeticOp op) {
   }
 }
 
+// TODO(klecki): float16
+#define ARITHMETIC_ALLOWED_TYPES \
+  (uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double)
+
 /**
  * @brief Type promotion rules
  *

--- a/dali/operators/expressions/arithmetic_test.cc
+++ b/dali/operators/expressions/arithmetic_test.cc
@@ -317,6 +317,8 @@ TEST(ArithmeticOpsTest, GenericPipeline) {
 }
 
 TEST(ArithmeticOpsTest, ConstantsPipeline) {
+  constexpr int magic_int = 42;
+  constexpr int magic_float = 42.f;
   constexpr int batch_size = 16;
   constexpr int num_threads = 4;
   constexpr int tensor_elements = 16;
@@ -327,7 +329,7 @@ TEST(ArithmeticOpsTest, ConstantsPipeline) {
   pipe.AddOperator(OpSpec("ArithmeticGenericOp")
                        .AddArg("device", "cpu")
                        .AddArg("expression_desc", "add(&0 $0:int32)")
-                       .AddArg("integer_constants", std::vector<int>{42})
+                       .AddArg("integer_constants", std::vector<int>{magic_int})
                        .AddInput("data0", "cpu")
                        .AddOutput("result0", "cpu"),
                    "arithm_cpu_add");
@@ -335,7 +337,7 @@ TEST(ArithmeticOpsTest, ConstantsPipeline) {
   pipe.AddOperator(OpSpec("ArithmeticGenericOp")
                        .AddArg("device", "cpu")
                        .AddArg("expression_desc", "mul(&0 $0:float32)")
-                       .AddArg("real_constants", std::vector<float>{42.f})
+                       .AddArg("real_constants", std::vector<float>{magic_float})
                        .AddInput("data0", "cpu")
                        .AddOutput("result1", "cpu"),
                    "arithm_cpu_mul");
@@ -363,8 +365,8 @@ TEST(ArithmeticOpsTest, ConstantsPipeline) {
   auto *result1 = ws.OutputRef<CPUBackend>(1).data<float>();
 
   for (int i = 0; i < batch_size * tensor_elements; i++) {
-    EXPECT_EQ(result0[i], i + 42);
-    EXPECT_EQ(result1[i], i * 42.f);
+    EXPECT_EQ(result0[i], i + magic_int);
+    EXPECT_EQ(result1[i], i * magic_float);
   }
 }
 

--- a/dali/operators/expressions/arithmetic_test.cc
+++ b/dali/operators/expressions/arithmetic_test.cc
@@ -316,4 +316,56 @@ TEST(ArithmeticOpsTest, GenericPipeline) {
   }
 }
 
+TEST(ArithmeticOpsTest, ConstantsPipeline) {
+  constexpr int batch_size = 16;
+  constexpr int num_threads = 4;
+  constexpr int tensor_elements = 16;
+  Pipeline pipe(batch_size, num_threads, 0);
+
+  pipe.AddExternalInput("data0");
+
+  pipe.AddOperator(OpSpec("ArithmeticGenericOp")
+                       .AddArg("device", "cpu")
+                       .AddArg("expression_desc", "add(&0 $0:int32)")
+                       .AddArg("integer_constants", std::vector<int>{42})
+                       .AddInput("data0", "cpu")
+                       .AddOutput("result0", "cpu"),
+                   "arithm_cpu_add");
+
+  pipe.AddOperator(OpSpec("ArithmeticGenericOp")
+                       .AddArg("device", "cpu")
+                       .AddArg("expression_desc", "mul(&0 $0:float32)")
+                       .AddArg("real_constants", std::vector<float>{42.f})
+                       .AddInput("data0", "cpu")
+                       .AddOutput("result1", "cpu"),
+                   "arithm_cpu_mul");
+
+  vector<std::pair<string, string>> outputs = {{"result0", "cpu"}, {"result1", "cpu"}};
+
+  pipe.Build(outputs);
+
+  TensorList<CPUBackend> batch;
+  batch.Resize(uniform_list_shape(batch_size, {tensor_elements}));
+  batch.set_type(TypeInfo::Create<int32_t>());
+  for (int i = 0; i < batch_size; i++) {
+    auto *t = batch.mutable_tensor<int32_t>(i);
+    for (int j = 0; j < tensor_elements; j++) {
+      t[j] = i * tensor_elements + j;
+    }
+  }
+
+  pipe.SetExternalInput("data0", batch);
+  pipe.RunCPU();
+  pipe.RunGPU();
+  DeviceWorkspace ws;
+  pipe.Outputs(&ws);
+  auto *result0 = ws.OutputRef<CPUBackend>(0).data<int32_t>();
+  auto *result1 = ws.OutputRef<CPUBackend>(1).data<float>();
+
+  for (int i = 0; i < batch_size * tensor_elements; i++) {
+    EXPECT_EQ(result0[i], i + 42);
+    EXPECT_EQ(result1[i], i * 42.f);
+  }
+}
+
 }  // namespace dali

--- a/dali/operators/expressions/constant_storage.h
+++ b/dali/operators/expressions/constant_storage.h
@@ -1,0 +1,113 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_EXPRESSIONS_CONSTANT_STORAGE_H_
+#define DALI_OPERATORS_EXPRESSIONS_CONSTANT_STORAGE_H_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "dali/core/format.h"
+#include "dali/core/static_switch.h"
+#include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/operators/expressions/expression_tree.h"
+#include "dali/pipeline/data/types.h"
+#include "dali/pipeline/operator/op_spec.h"
+#include "dali/pipeline/util/backend2workspace_map.h"
+#include "dali/pipeline/workspace/workspace.h"
+
+namespace dali {
+
+
+#define CONSTANT_STORAGE_ALLOWED_TYPES \
+  (uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float16, float, double)
+
+/**
+ * @brief Provide integral and floating point constants under `Backend` memory accessible by
+ * a pointer.
+ * Constructed by extracting the constants from spec arguments `integer_constants` and `real_constants`
+ * based on list of constant_nodes
+ *
+ * @tparam Backend
+ */
+template <typename Backend>
+class ConstantStorage {
+ public:
+  void Initialize(const OpSpec &spec, cudaStream_t stream,
+                  const std::vector<ExprConstant *> &constant_nodes) {
+    auto integers_vec = spec.HasArgument("integer_constants")
+                            ? spec.GetRepeatedArgument<int>("integer_constants")
+                            : std::vector<int>{};
+    auto reals_vec = spec.HasArgument("real_constants")
+                         ? spec.GetRepeatedArgument<float>("real_constants")
+                         : std::vector<float>{};
+
+    std::vector<ExprConstant *> integer_nodes, real_nodes;
+    for (auto *node : constant_nodes) {
+      if (IsIntegral(node->GetTypeId())) {
+        integer_nodes.push_back(node);
+      } else {
+        real_nodes.push_back(node);
+      }
+    }
+    Rewrite(integers_, integers_vec, integer_nodes, stream);
+    Rewrite(reals_, reals_vec, real_nodes, stream);
+  }
+
+  const void *GetPointer(int constant_idx, DALIDataType type_id) const {
+    if (IsIntegral(type_id)) {
+      return integers_.template data<char>() + constant_idx * kPaddingSize;
+    }
+    return reals_.template data<char>() + constant_idx * kPaddingSize;
+  }
+
+ private:
+  Tensor<Backend> integers_, reals_;
+
+  template <typename T>
+  void Rewrite(Tensor<GPUBackend> &result, const std::vector<T> constants,
+               const std::vector<ExprConstant *> &constant_nodes, cudaStream_t stream) {
+    Tensor<CPUBackend> result_cpu;
+    Rewrite(result_cpu, constants, constant_nodes);
+    result.Copy(result_cpu, stream);
+  }
+
+  template <typename T>
+  void Rewrite(Tensor<CPUBackend> &result, const std::vector<T> constants,
+               const std::vector<ExprConstant *> &constant_nodes, cudaStream_t = NULL) {
+    result.Resize({static_cast<int64_t>(constants.size() * kPaddingSize)});
+    char *data = result.mutable_data<char>();
+    DALI_ENFORCE(
+        constants.size() == constant_nodes.size(),
+        make_string("Number of constants should match the number of nodes in expression tree. Got",
+                    constants.size(), "constants passed and found", constant_nodes.size(),
+                    "constant nodes in the expression tree"));
+    for (auto *node : constant_nodes) {
+      TYPE_SWITCH(node->GetTypeId(), type2id, Type, CONSTANT_STORAGE_ALLOWED_TYPES, (
+          auto idx = node->GetConstIndex();
+          auto *ptr = reinterpret_cast<Type *>(data + idx * kPaddingSize);
+          *ptr = static_cast<Type>(constants[idx]);
+        ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
+    }
+  }
+
+  constexpr static int kPaddingSize = 8;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_EXPRESSIONS_CONSTANT_STORAGE_H_

--- a/dali/operators/expressions/constant_storage.h
+++ b/dali/operators/expressions/constant_storage.h
@@ -105,7 +105,7 @@ class ConstantStorage {
     }
   }
 
-  constexpr static int kPaddingSize = 8;
+  constexpr static int kPaddingSize = 8;  // max(sizeof(int64_t), sizeof(double))
 };
 
 }  // namespace dali

--- a/dali/operators/expressions/constant_storage_test.cc
+++ b/dali/operators/expressions/constant_storage_test.cc
@@ -1,0 +1,105 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/operators/expressions/constant_storage.h"
+#include "dali/operators/expressions/expression_tree.h"
+#include "dali/pipeline/operator/op_spec.h"
+
+namespace dali {
+
+class ConstantStorageTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    constant_ptrs_.reserve(constant_nodes_.size());
+    for (auto &c : constant_nodes_) {
+      constant_ptrs_.push_back(&c);
+    }
+
+    good_spec_.AddArg("integer_constants", integers_);
+    good_spec_.AddArg("real_constants", reals_);
+
+    bad_spec_.AddArg("integer_constants", std::vector<int>{1, 42});
+    bad_spec_.AddArg("real_constants", std::vector<float>{0.1f, 0.42f, 54.f});
+  }
+
+  std::vector<ExprConstant> constant_nodes_ = {
+    {0, DALIDataType::DALI_UINT8},
+    {1, DALIDataType::DALI_INT32},
+    {0, DALIDataType::DALI_FLOAT},
+    {2, DALIDataType::DALI_INT32},
+    {1, DALIDataType::DALI_FLOAT16},
+  };
+
+  std::vector<ExprConstant*> constant_ptrs_;
+
+  OpSpec good_spec_;
+  std::vector<int> integers_ = {1, 1024, 42};
+  std::vector<float> reals_ = {0.1f, 0.42f};
+
+  OpSpec bad_spec_;
+};
+
+TEST_F(ConstantStorageTest, CpuValid) {
+  ConstantStorage<CPUBackend> st;
+  st.Initialize(good_spec_, 0, constant_ptrs_);
+  for (auto &node : constant_nodes_) {
+    auto type_id = node.GetTypeId();
+    TYPE_SWITCH(type_id, type2id, Type, CONSTANT_STORAGE_ALLOWED_TYPES, (
+          auto idx = node.GetConstIndex();
+          auto *ptr = reinterpret_cast<const Type *>(st.GetPointer(idx, type_id));
+          if (IsIntegral(type_id)) {
+            EXPECT_EQ(*ptr, static_cast<Type>(integers_[idx]));
+          } else {
+            EXPECT_EQ(*ptr, static_cast<Type>(reals_[idx]));
+          }
+      ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
+  }
+}
+
+TEST_F(ConstantStorageTest, GpuValid) {
+  ConstantStorage<GPUBackend> st;
+  st.Initialize(good_spec_, 0, constant_ptrs_);
+  char buf[sizeof(int64_t)];
+  for (auto &node : constant_nodes_) {
+    auto type_id = node.GetTypeId();
+    TYPE_SWITCH(type_id, type2id, Type, CONSTANT_STORAGE_ALLOWED_TYPES, (
+          auto idx = node.GetConstIndex();
+          const auto *dev_ptr = st.GetPointer(idx, type_id);
+          cudaMemcpy(buf, dev_ptr, sizeof(int64_t), cudaMemcpyDeviceToHost);
+          auto *ptr = reinterpret_cast<const Type *>(buf);
+          if (IsIntegral(type_id)) {
+            EXPECT_EQ(*ptr, static_cast<Type>(integers_[idx]));
+          } else {
+            EXPECT_EQ(*ptr, static_cast<Type>(reals_[idx]));
+          }
+      ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
+  }
+}
+
+TEST_F(ConstantStorageTest, Invalid) {
+  ConstantStorage<CPUBackend> cpu_st;
+  ASSERT_THROW(cpu_st.Initialize(bad_spec_, 0, constant_ptrs_), std::runtime_error);
+  ConstantStorage<GPUBackend> gpu_st;
+  ASSERT_THROW(gpu_st.Initialize(bad_spec_, 0, constant_ptrs_), std::runtime_error);
+}
+
+}  // namespace dali

--- a/dali/operators/expressions/expression_impl_factory.h
+++ b/dali/operators/expressions/expression_impl_factory.h
@@ -21,80 +21,150 @@
 #include <utility>
 #include <vector>
 
-#include "dali/core/any.h"
-#include "dali/pipeline/data/types.h"
+#include "dali/core/small_vector.h"
+#include "dali/core/static_switch.h"
 #include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/operators/expressions/constant_storage.h"
+#include "dali/operators/expressions/expression_tile.h"
 #include "dali/operators/expressions/expression_tree.h"
-#include "dali/pipeline/operator/op_spec.h"
+#include "dali/pipeline/data/types.h"
 #include "dali/pipeline/util/backend2workspace_map.h"
 #include "dali/pipeline/workspace/workspace.h"
 
 namespace dali {
 
-template <typename Backend>
-class ExprImplParam {
- protected:
-  // We differentiate between TensorVector and TensorList, that still have inconsistent
-  // access patterns
-  static constexpr bool is_cpu = std::is_same<Backend, CPUBackend>::value;
+#define ALLOWED_BIN_OPS                                                                            \
+  (ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div, ArithmeticOp::fdiv, \
+      ArithmeticOp::mod)
 
-  template <bool IsTensor, typename Type>
-  std::enable_if_t<IsTensor && is_cpu, const Type *> ObtainInput(const ExprFunc &expr,
-                                                                 workspace_t<Backend> &ws,
-                                                                 const OpSpec &spec,
-                                                                 TileDesc tile,
-                                                                 int subexpr_id) {
-    int input_id = dynamic_cast<const ExprTensor&>(expr[subexpr_id]).GetInputIndex();
-    auto *tensor = ws.template InputRef<Backend>(input_id)[tile.sample_idx].template data<Type>();
-    return tensor + tile.extent_idx * tile.tile_size;
-  }
-
-  template <bool IsTensor, typename Type>
-  std::enable_if_t<IsTensor && !is_cpu, const Type *> ObtainInput(const ExprFunc &expr,
-                                                                  workspace_t<Backend> &ws,
-                                                                  const OpSpec &spec,
-                                                                  TileDesc tile,
-                                                                  int subexpr_id) {
-    int input_id = dynamic_cast<const ExprTensor&>(expr[subexpr_id]).GetInputIndex();
-    auto *tensor = ws.template InputRef<Backend>(input_id).template tensor<Type>(tile.sample_idx);
-    return tensor + tile.extent_idx * tile.tile_size;
-  }
-
-  template <bool IsTensor, typename Type>
-  std::enable_if_t<!IsTensor, Type> ObtainInput(const ExprFunc &expr,
-                                                workspace_t<Backend> &ws, const OpSpec &spec,
-                                                TileDesc tile, int subexpr_id) {
-    int scalar_id = dynamic_cast<const ExprConstant&>(expr[subexpr_id]).GetConstIndex();
-    if (IsIntegral(expr.GetTypeId())) {
-      return static_cast<Type>(spec.GetArgument<std::vector<int>>("integer_scalars")[scalar_id]);
-    }
-    return static_cast<Type>(spec.GetArgument<std::vector<float>>("float_scalars")[scalar_id]);
-  }
-
-  template <typename Result>
-  std::enable_if_t<is_cpu, Result *> ObtainOutput(const ExprFunc &expr,
-                                                  workspace_t<Backend> &ws, const OpSpec &spec,
-                                                  TileDesc tile) {
-    auto *tensor =
-        ws.template OutputRef<Backend>(0)[tile.sample_idx].template mutable_data<Result>();
-    return tensor + tile.extent_idx * tile.tile_size;
-  }
-
-  template <typename Result>
-  std::enable_if_t<!is_cpu, Result *> ObtainOutput(const ExprFunc &expr,
-                                                   workspace_t<GPUBackend> &ws, const OpSpec &spec,
-                                                   TileDesc tile) {
-    auto *tensor =
-        ws.template OutputRef<Backend>(0).template mutable_tensor<Result>(tile.sample_idx);
-    return tensor + tile.extent_idx * tile.tile_size;
-  }
+struct ExprImplTask {
+  ExprImplBase *impl;
+  ExprImplContext ctx;
 };
 
-std::unique_ptr<ExprImplBase> ExprImplFactory(const HostWorkspace &ws,
-                                              const ExprNode &expr);
+inline OutputSamplePtr GetOutputSamplePointer(HostWorkspace &ws, int output_idx, int sample_idx) {
+  return ws.template OutputRef<CPUBackend>(output_idx)[sample_idx].raw_mutable_data();
+}
 
-std::unique_ptr<ExprImplBase> ExprImplFactory(const DeviceWorkspace &ws,
-                                              const ExprNode &expr);
+inline OutputSamplePtr GetOutputSamplePointer(DeviceWorkspace &ws, int output_idx, int sample_idx) {
+  return ws.template OutputRef<GPUBackend>(output_idx).raw_mutable_tensor(sample_idx);
+}
+
+inline InputSamplePtr GetInputSamplePointer(HostWorkspace &ws, int input_idx, int sample_idx) {
+  return ws.template InputRef<CPUBackend>(input_idx)[sample_idx].raw_data();
+}
+
+inline InputSamplePtr GetInputSamplePointer(DeviceWorkspace &ws, int input_idx, int sample_idx) {
+  return ws.template InputRef<GPUBackend>(input_idx).raw_tensor(sample_idx);
+}
+
+template <typename Backend>
+inline OutputSamplePtr GetOutput(const ExprFunc &func, workspace_t<Backend> &ws, TileDesc tile) {
+  return reinterpret_cast<char *>(GetOutputSamplePointer(ws, 0, tile.sample_idx)) +
+         tile.tile_size * tile.extent_idx * TypeTable::GetTypeInfo(func.GetTypeId()).size();
+}
+
+/**
+ * @brief Type erased obtaining pointers to inputs
+ */
+template <typename Backend>
+inline ArgPack GetArgPack(const ExprFunc &func, workspace_t<Backend> &ws,
+                          const ConstantStorage<Backend> &st, const OpSpec &spec, TileDesc tile) {
+  ArgPack result;
+  result.resize(func.GetSubexpressionCount());
+  for (int i = 0; i < func.GetSubexpressionCount(); i++) {
+    DALI_ENFORCE(func[i].GetNodeType() != NodeType::Function,
+                 "Function nodes are not supported as subexpressions");
+    if (func[i].GetNodeType() == NodeType::Constant) {
+      const auto &constant = dynamic_cast<const ExprConstant &>(func[i]);
+      result[i] = st.GetPointer(constant.GetConstIndex(), constant.GetTypeId());
+    } else if (func[i].GetNodeType() == NodeType::Tensor) {
+      const auto &tensor = dynamic_cast<const ExprTensor &>(func[i]);
+      auto input_idx = tensor.GetInputIndex();
+      const auto *ptr =
+          reinterpret_cast<const char *>(GetInputSamplePointer(ws, input_idx, tile.sample_idx));
+      auto tile_offset =
+          tile.tile_size * tile.extent_idx * TypeTable::GetTypeInfo(func.GetTypeId()).size();
+      result[i] = ptr + tile_offset;
+    }
+  }
+  return result;
+}
+
+/**
+ * @brief Transfor vector of TileDesc into vector of ExtendedTileDesc
+ * based on the ExprFunc by extracting the input and output pointers to data
+ * from workspace and constant storage.
+ *
+ * @param extended_tiles Output vector of ExtendedTiles for given task
+ */
+template <typename Backend>
+void TransformDescs(std::vector<ExtendedTileDesc> &extended_tiles,
+                           const std::vector<TileDesc> &tiles, const ExprFunc &func,
+                           workspace_t<Backend> &ws, const ConstantStorage<Backend> &st,
+                           const OpSpec &spec) {
+  extended_tiles.reserve(tiles.size());
+  for (auto &tile : tiles) {
+    extended_tiles.emplace_back(tile, GetOutput<Backend>(func, ws, tile),
+                                GetArgPack(func, ws, st, spec, tile));
+  }
+}
+
+/**
+ * @brief Prepare vector of ExtendedTiles for every task that we have to execute, filling
+ * the pointers to data.
+ *
+ * @param tiles_per_task  Output vectors of ExtendedTiles per evry tast to execute
+ */
+template <typename Backend>
+void PrepareTilesForTasks(std::vector<std::vector<ExtendedTileDesc>> &tiles_per_task,
+                          const std::vector<ExprImplTask> &task_exec_order,
+                          const std::vector<TileDesc> &tiles, workspace_t<Backend> &ws,
+                          const ConstantStorage<Backend> &constant_storage, const OpSpec &spec) {
+  tiles_per_task.resize(task_exec_order.size());
+  for (size_t i = 0; i < task_exec_order.size(); i++) {
+    const auto &expr_task = task_exec_order[i];
+    const auto &expr_func = dynamic_cast<const ExprFunc &>(*expr_task.ctx.node);
+    tiles_per_task[i].resize(0);
+    TransformDescs<Backend>(tiles_per_task[i], tiles, expr_func, ws, constant_storage, spec);
+  }
+}
+
+template <template <ArithmeticOp, typename...> class ImplTensorTensor,
+          template <ArithmeticOp, typename...> class ImplTensorConstant,
+          template <ArithmeticOp, typename...> class ImplConstatnTensor>
+std::unique_ptr<ExprImplBase> ExprImplFactoryBinOp(const ExprFunc &expr) {
+  std::unique_ptr<ExprImplBase> result;
+  auto op = NameToOp(expr.GetFuncName());
+  auto left_type = expr[0].GetTypeId();
+  auto right_type = expr[1].GetTypeId();
+  // 4-fold static switch
+  TYPE_SWITCH(left_type, type2id, Left_t, ARITHMETIC_ALLOWED_TYPES, (
+    TYPE_SWITCH(right_type, type2id, Right_t, ARITHMETIC_ALLOWED_TYPES, (
+        VALUE_SWITCH(op, op_static, ALLOWED_BIN_OPS, (
+          using Out_t = arithm_meta<op_static, CPUBackend>::result_t<Left_t, Right_t>;
+          if (expr[0].GetNodeType() == NodeType::Tensor &&
+              expr[1].GetNodeType() == NodeType::Tensor) {
+            result.reset(new ImplTensorTensor<op_static, Out_t, Left_t, Right_t>());
+          } else if (expr[0].GetNodeType() == NodeType::Tensor &&
+                    expr[1].GetNodeType() == NodeType::Constant) {
+            result.reset(new ImplTensorConstant<op_static, Out_t, Left_t, Right_t>());
+          } else if (expr[0].GetNodeType() == NodeType::Constant &&
+                    expr[1].GetNodeType() == NodeType::Tensor) {
+            result.reset(new ImplConstatnTensor<op_static, Out_t, Left_t, Right_t>());
+          } else {
+            DALI_FAIL("Expression cannot have two scalar operands");
+          }
+      ), DALI_FAIL("No suitable op value found"););  // NOLINT(whitespace/parens)
+    ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
+  ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
+  return result;
+}
+
+
+std::unique_ptr<ExprImplBase> ExprImplFactory(const HostWorkspace &ws, const ExprNode &expr);
+
+std::unique_ptr<ExprImplBase> ExprImplFactory(const DeviceWorkspace &ws, const ExprNode &expr);
 
 struct ExprImplCache {
   template <typename Backend>

--- a/dali/operators/expressions/expression_impl_factory_cpu.cc
+++ b/dali/operators/expressions/expression_impl_factory_cpu.cc
@@ -14,68 +14,22 @@
 
 #include <memory>
 
-#include "dali/operators/expressions/expression_tree.h"
-#include "dali/operators/expressions/arithmetic_meta.h"
 #include "dali/core/static_switch.h"
+#include "dali/operators/expressions/arithmetic_meta.h"
 #include "dali/operators/expressions/expression_impl_cpu.h"
 #include "dali/operators/expressions/expression_impl_factory.h"
-
-// TODO(klecki): float16
-#define ALLOWED_TYPES \
-  (uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double)
-
-#define ALLOWED_OPS                                                                                \
-  (ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div, ArithmeticOp::fdiv, \
-      ArithmeticOp::mod)
+#include "dali/operators/expressions/expression_tree.h"
 
 namespace dali {
 
-namespace {
-std::unique_ptr<ExprImplBase> ExprImplFactory2(const HostWorkspace &ws,
-                                               const ExprFunc &expr) {
-  std::unique_ptr<ExprImplBase> result;
-  auto op = NameToOp(expr.GetFuncName());
-  auto left_type = expr[0].GetTypeId();
-  auto right_type = expr[1].GetTypeId();
-  // 4-fold static switch
-  TYPE_SWITCH(left_type, type2id, Left_t, ALLOWED_TYPES, (
-    TYPE_SWITCH(right_type, type2id, Right_t, ALLOWED_TYPES, (
-        VALUE_SWITCH(op, op_static, ALLOWED_OPS, (
-          using Out_t = arithm_meta<op_static, CPUBackend>::result_t<Left_t, Right_t>;
-          if (expr[0].GetNodeType() == NodeType::Tensor &&
-              expr[1].GetNodeType() == NodeType::Tensor) {
-            result.reset(new ExprImplBinCPU<op_static, Out_t,
-                                                  Left_t, true,
-                                                  Right_t, true>());
-          } else if (expr[0].GetNodeType() == NodeType::Tensor &&
-                    expr[1].GetNodeType() != NodeType::Tensor) {
-            result.reset(new ExprImplBinCPU<op_static, Out_t,
-                                                  Left_t, true,
-                                                  Right_t, false>());
-          } else if (expr[0].GetNodeType() != NodeType::Tensor &&
-                    expr[1].GetNodeType() == NodeType::Tensor) {
-            result.reset(new ExprImplBinCPU<op_static, Out_t,
-                                                  Left_t, false,
-                                                  Right_t, true>());
-          } else {
-            DALI_FAIL("Expression cannot have two scalar operands");
-          }
-      ), DALI_FAIL("No suitable op value found"););  // NOLINT(whitespace/parens)
-    ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
-  ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
-  return result;
-}
-
-}  // namespace
-
-std::unique_ptr<ExprImplBase> ExprImplFactory(const HostWorkspace &ws,
-                                              const ExprNode &expr) {
+std::unique_ptr<ExprImplBase> ExprImplFactory(const HostWorkspace &ws, const ExprNode &expr) {
   std::unique_ptr<ExprImplBase> result;
   DALI_ENFORCE(expr.GetNodeType() == NodeType::Function, "Only function nodes can be executed.");
 
   switch (expr.GetSubexpressionCount()) {
     case 2:
-      return ExprImplFactory2(ws, dynamic_cast<const ExprFunc&>(expr));
+      return ExprImplFactoryBinOp<ExprImplCpuTT, ExprImplCpuTC, ExprImplCpuCT>(
+          dynamic_cast<const ExprFunc &>(expr));
     default:
       DALI_FAIL("Expressions with " + std::to_string(expr.GetSubexpressionCount()) +
                 " subexpressions are not supported. No implemetation found.");

--- a/dali/operators/expressions/expression_impl_factory_gpu.cu
+++ b/dali/operators/expressions/expression_impl_factory_gpu.cu
@@ -14,62 +14,13 @@
 
 #include <memory>
 
-#include "dali/operators/expressions/expression_tree.h"
-#include "dali/operators/expressions/arithmetic_meta.h"
 #include "dali/core/static_switch.h"
-#include "dali/operators/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/expressions/arithmetic_meta.h"
 #include "dali/operators/expressions/expression_impl_factory.h"
-
-// TODO(klecki): float16
-#define ALLOWED_TYPES \
-  (uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double)
-
-#define ALLOWED_OPS                                                                                \
-  (ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div, ArithmeticOp::fdiv, \
-      ArithmeticOp::mod)
+#include "dali/operators/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/expressions/expression_tree.h"
 
 namespace dali {
-
-namespace {
-
-std::unique_ptr<ExprImplBase> ExprImplFactory2(const DeviceWorkspace &ws,
-                                               const ExprFunc &expr) {
-  std::unique_ptr<ExprImplBase> result;
-  auto op = NameToOp(expr.GetFuncName());
-  auto left_type = expr[0].GetTypeId();
-  auto right_type = expr[1].GetTypeId();
-
-  // 4-fold static switch
-  TYPE_SWITCH(left_type, type2id, Left_t, ALLOWED_TYPES, (
-    TYPE_SWITCH(right_type, type2id, Right_t, ALLOWED_TYPES, (
-        VALUE_SWITCH(op, op_static, ALLOWED_OPS, (
-          using Out_t = arithm_meta<op_static, GPUBackend>::result_t<Left_t, Right_t>;
-          if (expr[0].GetNodeType() == NodeType::Tensor &&
-              expr[1].GetNodeType() == NodeType::Tensor) {
-            result.reset(new ExprImplBinGPU<op_static, Out_t,
-                                                  Left_t, true,
-                                                  Right_t, true>());
-          } else if (expr[0].GetNodeType() == NodeType::Tensor &&
-                      expr[1].GetNodeType() != NodeType::Tensor) {
-            result.reset(new ExprImplBinGPU<op_static, Out_t,
-                                                  Left_t, true,
-                                                  Right_t, false>());
-
-          } else if (expr[0].GetNodeType() != NodeType::Tensor &&
-                      expr[1].GetNodeType() == NodeType::Tensor) {
-            result.reset(new ExprImplBinGPU<op_static, Out_t,
-                                                  Left_t, false,
-                                                  Right_t, true>());
-          } else {
-            DALI_FAIL("Expression cannot have two scalar operands");
-          }
-      ), DALI_FAIL("No suitable op value found"););  // NOLINT(whitespace/parens)
-    ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
-  ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
-  return result;
-}
-
-}  // namespace
 
 std::unique_ptr<ExprImplBase> ExprImplFactory(const DeviceWorkspace &ws,
                                               const ExprNode &expr) {
@@ -77,7 +28,8 @@ std::unique_ptr<ExprImplBase> ExprImplFactory(const DeviceWorkspace &ws,
 
   switch (expr.GetSubexpressionCount()) {
     case 2:
-      return ExprImplFactory2(ws, dynamic_cast<const ExprFunc&>(expr));
+      return ExprImplFactoryBinOp<ExprImplGpuTT, ExprImplGpuTC, ExprImplGpuCT>(
+          dynamic_cast<const ExprFunc&>(expr));
     default:
       DALI_FAIL("Expressions with " + std::to_string(expr.GetSubexpressionCount()) +
                 " subexpressions are not supported. No implemetation found.");

--- a/dali/operators/expressions/expression_tile.h
+++ b/dali/operators/expressions/expression_tile.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_EXPRESSIONS_EXPRESSION_TILE_H_
+#define DALI_OPERATORS_EXPRESSIONS_EXPRESSION_TILE_H_
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/pipeline/data/types.h"
+#include "dali/pipeline/util/backend2workspace_map.h"
+#include "dali/pipeline/workspace/workspace.h"
+
+namespace dali {
+
+/**
+ * @brief Describe a tile of data to be processed in expression evaluation.
+ */
+struct TileDesc {
+  int sample_idx;       // id of sample inside within the batch
+  int extent_idx;       // the index of tile within this sample_idx
+  int64_t extent_size;  // actually covered extent in this tile, the last can be smaller
+  int64_t tile_size;    // the size of regular tile
+};
+
+inline std::ostream &operator<<(std::ostream &os, const TileDesc &v) {
+  os << "{" << v.sample_idx << ", " << v.extent_idx << ", " << v.extent_size << ", " << v.tile_size
+     << "}";
+  return os;
+}
+
+struct TileRange {
+  int begin;
+  int end;
+};
+
+inline std::ostream &operator<<(std::ostream &os, const TileRange &v) {
+  os << "{" << v.begin << ", " << v.end << "}";
+  return os;
+}
+
+using OutputSamplePtr = void *;
+using InputSamplePtr = const void *;
+using ArgPack = SmallVector<InputSamplePtr, kMaxArity>;
+
+struct ExtendedTileDesc {
+  ExtendedTileDesc() = default;
+  ExtendedTileDesc(const TileDesc &desc, const OutputSamplePtr &output, const ArgPack &args)
+      : desc(desc), output(output), args(args) {}
+  TileDesc desc;
+  OutputSamplePtr output;
+  ArgPack args;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_EXPRESSIONS_EXPRESSION_TILE_H_

--- a/dali/operators/expressions/expression_tile.h
+++ b/dali/operators/expressions/expression_tile.h
@@ -58,6 +58,15 @@ using OutputSamplePtr = void *;
 using InputSamplePtr = const void *;
 using ArgPack = SmallVector<InputSamplePtr, kMaxArity>;
 
+/**
+ * @brief Describe tile with pointers to output and input data for that tile.
+ *
+ * The pointers are intentionally stored as `void *` so we can use one tile type for all
+ * possible `ExprImpl` implementations.
+ * As we obtain pointers to Tensor/TensorList data, we cast them to `void *`
+ * and the ExprImpl is later aware to what type should it be casted back.
+ * This reduces the amount of types and compilation time significantly.
+ */
 struct ExtendedTileDesc {
   ExtendedTileDesc() = default;
   ExtendedTileDesc(const TileDesc &desc, const OutputSamplePtr &output, const ArgPack &args)

--- a/dali/operators/expressions/expression_tree.h
+++ b/dali/operators/expressions/expression_tree.h
@@ -21,39 +21,13 @@
 #include <utility>
 #include <vector>
 
-#include "dali/core/any.h"
-#include "dali/pipeline/data/types.h"
 #include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/operators/expressions/expression_tile.h"
+#include "dali/pipeline/data/types.h"
 #include "dali/pipeline/util/backend2workspace_map.h"
 #include "dali/pipeline/workspace/workspace.h"
 
 namespace dali {
-
-/**
- * @brief Describe a tile of data to be processed in expression evaluation.
- */
-struct TileDesc {
-  int sample_idx;       // id of sample inside within the batch
-  int extent_idx;       // the index of tile within this sample_idx
-  int64_t extent_size;  // actually covered extent in this tile, the last can be smaller
-  int64_t tile_size;    // the size of regular tile
-};
-
-inline std::ostream &operator<<(std::ostream &os, const TileDesc &v) {
-  os << "{" << v.sample_idx << ", " << v.extent_idx << ", " << v.extent_size << ", " << v.tile_size
-     << "}";
-  return os;
-}
-
-struct TileRange {
-  int begin;
-  int end;
-};
-
-inline std::ostream &operator<<(std::ostream &os, const TileRange &v) {
-  os << "{" << v.begin << ", " << v.end << "}";
-  return os;
-}
 
 class ExprNode;
 
@@ -68,8 +42,8 @@ struct ExprImplContext {
  */
 class ExprImplBase {
  public:
-  virtual void Execute(ArgumentWorkspace &workspace, const OpSpec &spec, ExprImplContext &ctx,
-                       const std::vector<TileDesc> &tiles, TileRange range) = 0;
+  virtual void Execute(ExprImplContext &ctx, const std::vector<ExtendedTileDesc> &tiles,
+                       TileRange range) = 0;
   virtual ~ExprImplBase() = default;
 };
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Support constants as inputs
Use type-erased tiles.

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
 - What was changed, added, removed?
`ConstatnStorage` was added to allow easy access to constant values in expression through type-erased `void*`
ExprImplFactory was templetized and shares the same code for type-switching on GPU and CPU.
`ExtendedTileDesc` describes inputs and output of expression by `void*`.
Obtaining pointers to data was removed from ExprImpl, now it is passed to it.
 - What is most important part that reviewers should focus on?
Tile preparation.
 - Was this PR tested? How?
 - Were docs and examples updated, if necessary?

**JIRA TASK**: [DALI-1107]