### PR TITLE
Add support for Unary Ops: + and -

### DIFF
--- a/dali/operators/decoder/cache/image_cache.h
+++ b/dali/operators/decoder/cache/image_cache.h
@@ -48,7 +48,7 @@ class DLL_PUBLIC ImageCache {
      * @param image_key key representing the image in cache
      * @param destination_data destination buffer
      * @param stream cuda stream
-     * @returns true if successful cache read, false otherwise
+     * @return true if successful cache read, false otherwise
      */
     DLL_PUBLIC virtual bool Read(const ImageKey& image_key,
                                  void* destination_data,

--- a/dali/operators/expressions/arithmetic.h
+++ b/dali/operators/expressions/arithmetic.h
@@ -33,6 +33,9 @@
 
 namespace dali {
 
+/**
+ * @brief The first element contains vector of tiles, the second groups the tiles into task ranges
+ */
 using TileCover = std::tuple<std::vector<TileDesc>, std::vector<TileRange>>;
 
 /**
@@ -124,6 +127,9 @@ DLL_PUBLIC DALIDataType PropagateTypes(ExprNode &expr, const workspace_t<Backend
   return expr.GetTypeId();
 }
 
+/**
+ * @brief Helper for recursively filling vector of tasks to execute
+ */
 template <typename Backend>
 inline void CreateExecutionTasks(std::vector<ExprImplTask> &order, const ExprNode &expr,
                                  ExprImplCache &cache, cudaStream_t stream) {
@@ -137,6 +143,10 @@ inline void CreateExecutionTasks(std::vector<ExprImplTask> &order, const ExprNod
   order.push_back({cache.GetExprImpl<Backend>(func), {stream, &func}});
 }
 
+/**
+ * @brief Recurse over `expr` tree and looking up from `cache` return vector of tasks to execute
+ *        in given order.
+ */
 template <typename Backend>
 inline std::vector<ExprImplTask> CreateExecutionTasks(const ExprNode &expr, ExprImplCache &cache,
                                                       cudaStream_t stream) {
@@ -163,6 +173,11 @@ inline TensorListShape<> ShapePromotion(std::string op, span<const TensorListSha
   return out_shape ? *out_shape : uniform_list_shape(batch_size, {1});
 }
 
+/**
+ * @brief Recurse over expression tree and propagate shapes between expression nodes.
+ *
+ * @return The resulting shape of the expression
+ */
 template <typename Backend>
 DLL_PUBLIC inline const TensorListShape<> &PropagateShapes(ExprNode &expr,
                                                            const workspace_t<Backend> &ws,

--- a/dali/operators/expressions/arithmetic_meta.h
+++ b/dali/operators/expressions/arithmetic_meta.h
@@ -52,6 +52,7 @@ DALI_HOST_DEV constexpr int GetOpArity(ArithmeticOp op) {
     case ArithmeticOp::sub:
     case ArithmeticOp::mul:
     case ArithmeticOp::div:
+    case ArithmeticOp::fdiv:
     case ArithmeticOp::mod:
       return 2;
     default:

--- a/dali/operators/expressions/arithmetic_meta.h
+++ b/dali/operators/expressions/arithmetic_meta.h
@@ -32,6 +32,13 @@ namespace dali {
 
 constexpr int kMaxArity = 2;
 
+/**
+ * @brief Registered arithmetic and mathematical operations
+ *
+ * The enum is used to provide specializations of arithm_meta with implementation
+ * for every operation.
+ *
+ */
 enum class ArithmeticOp : int {
   plus,
   minus,
@@ -217,6 +224,14 @@ struct arithm_meta;
 //    static constexpr int num_outputs;
 // };
 
+
+/************************************************************/
+/*                                                          */
+/* Section for registering implementations of for AritihmOp */
+/*                                                          */
+/************************************************************/
+
+
 #define REGISTER_UNARY_IMPL_BACKEND(OP, EXPRESSION, BACKEND)                        \
   template <>                                                                       \
   struct arithm_meta<OP, BACKEND> {                                                 \
@@ -376,7 +391,9 @@ inline std::string to_string(ArithmeticOp op) {
   return result;
 }
 
-
+/**
+ * @brief Calculate type promotion of Binary Arithmetic op at runtime
+ */
 inline DALIDataType BinaryTypePromotion(DALIDataType left, DALIDataType right) {
   DALIDataType result = DALIDataType::DALI_NO_TYPE;
   TYPE_SWITCH(left, type2id, Left_t,
@@ -399,6 +416,9 @@ inline DALIDataType BinaryTypePromotion(DALIDataType left, DALIDataType right) {
   return result;
 }
 
+/**
+ * @brief Calculate type promotion for given `op` and input `types` at runtime
+ */
 inline DALIDataType TypePromotion(ArithmeticOp op, span<DALIDataType> types) {
   assert(types.size() == 1 || types.size() == 2);
   if (types.size() == 1) {
@@ -429,6 +449,12 @@ inline ArithmeticOp NameToOp(const std::string &op_name) {
   return it->second;
 }
 
+/**
+ * @brief Check if input of given `shape` should be considered to represent (tensor of) scalars.
+ *
+ * A tensor of scalars is uniform tensor with sample dimension equal 1 and only 1 (scalar) element
+ * in every sample.
+ */
 inline bool IsScalarLike(const TensorListShape<> &shape) {
   return is_uniform(shape) && shape.sample_dim() == 1 && shape.tensor_shape_span(0)[0] == 1;
 }

--- a/dali/operators/expressions/arithmetic_test.cc
+++ b/dali/operators/expressions/arithmetic_test.cc
@@ -592,6 +592,59 @@ INSTANTIATE_TEST_SUITE_P(TensorScalarTensorBatch5,
 INSTANTIATE_TEST_SUITE_P(TensorScalarTensorBatch1,
                          ArithmeticOpsScalarTest,
                          ::testing::ValuesIn(GetTensorScalarTensorSequences(1)));
+TEST(ArithmeticOpsTest, UnaryPipeline) {
+  constexpr int batch_size = 16;
+  constexpr int num_threads = 4;
+  constexpr int tensor_elements = 16;
+  Pipeline pipe(batch_size, num_threads, 0);
+
+  pipe.AddExternalInput("data0");
+
+  pipe.AddOperator(OpSpec("ArithmeticGenericOp")
+                       .AddArg("device", "cpu")
+                       .AddArg("expression_desc", "minus(&0)")
+                       .AddInput("data0", "cpu")
+                       .AddOutput("result0", "cpu"),
+                   "arithm_cpu_neg");
+
+  pipe.AddOperator(OpSpec("ArithmeticGenericOp")
+                       .AddArg("device", "gpu")
+                       .AddArg("expression_desc", "plus(&0)")
+                       .AddInput("result0", "gpu")
+                       .AddOutput("result1", "gpu"),
+                   "arithm_gpu_pos");
+
+  vector<std::pair<string, string>> outputs = {{"result0", "cpu"}, {"result1", "gpu"}};
+
+  pipe.Build(outputs);
+
+  TensorList<CPUBackend> batch;
+  batch.Resize(uniform_list_shape(batch_size, {tensor_elements}));
+  batch.set_type(TypeInfo::Create<int32_t>());
+  for (int i = 0; i < batch_size; i++) {
+    auto *t = batch.mutable_tensor<int32_t>(i);
+    for (int j = 0; j < tensor_elements; j++) {
+      t[j] = i * tensor_elements + j;
+    }
+  }
+
+  pipe.SetExternalInput("data0", batch);
+  pipe.RunCPU();
+  pipe.RunGPU();
+  DeviceWorkspace ws;
+  pipe.Outputs(&ws);
+  auto *result0 = ws.OutputRef<CPUBackend>(0).data<int32_t>();
+
+  auto *result1 = ws.OutputRef<GPUBackend>(1).data<int32_t>();
+  vector<int32_t> result1_cpu(batch_size * tensor_elements);
+
+  MemCopy(result1_cpu.data(), result1, batch_size * tensor_elements * sizeof(int));
+  for (int i = 0; i < batch_size * tensor_elements; i++) {
+    EXPECT_EQ(result0[i], -i);
+    EXPECT_EQ(result1_cpu[i], -i);
+  }
+}
+
 
 }  // namespace dali
 

--- a/dali/operators/expressions/arithmetic_test.cc
+++ b/dali/operators/expressions/arithmetic_test.cc
@@ -208,6 +208,7 @@ class BinaryArithmeticOpsTest
     auto *result = ws.OutputRef<Backend>(0).template data<T>();
     vector<T> result_cpu(shape.num_elements());
     MemCopy(result_cpu.data(), result, shape.num_elements() * sizeof(T));
+    cudaStreamSynchronize(0);
 
     int64_t offset = 0;
     for (int i = 0; i < shape.num_samples(); i++) {
@@ -324,6 +325,7 @@ TEST(ArithmeticOpsTest, GenericPipeline) {
   vector<int32_t> result2_cpu(batch_size * tensor_elements);
 
   MemCopy(result2_cpu.data(), result2, batch_size * tensor_elements * sizeof(int));
+  cudaStreamSynchronize(0);
   for (int i = 0; i < batch_size * tensor_elements; i++) {
     EXPECT_EQ(result[i], data[i] + data[i]);
     EXPECT_EQ(result2_cpu[i], data[i] * (data[i] + data[i]));
@@ -381,6 +383,7 @@ TEST(ArithmeticOpsTest, FdivPipeline) {
   vector<float> result1_cpu(batch_size * tensor_elements);
 
   MemCopy(result1_cpu.data(), result1, batch_size * tensor_elements * sizeof(float));
+  cudaStreamSynchronize(0);
   for (int i = 0; i < batch_size * tensor_elements; i++) {
     EXPECT_EQ(result0[i], static_cast<float>(data0[i]) / data1[i]);
     EXPECT_EQ(result1_cpu[i], static_cast<float>(data0[i]) / data1[i]);
@@ -501,6 +504,7 @@ class ArithmeticOpsScalarTest :  public ::testing::TestWithParam<shape_sequence>
       vector<int> result1_cpu(result_shape.num_elements());
 
       MemCopy(result1_cpu.data(), result1, result_shape.num_elements() * sizeof(int));
+      cudaStreamSynchronize(0);
 
       int64_t offset_out = 0;
       int64_t offset_in[2] = {0, 0};
@@ -639,6 +643,7 @@ TEST(ArithmeticOpsTest, UnaryPipeline) {
   vector<int32_t> result1_cpu(batch_size * tensor_elements);
 
   MemCopy(result1_cpu.data(), result1, batch_size * tensor_elements * sizeof(int));
+  cudaStreamSynchronize(0);
   for (int i = 0; i < batch_size * tensor_elements; i++) {
     EXPECT_EQ(result0[i], -i);
     EXPECT_EQ(result1_cpu[i], -i);

--- a/dali/operators/expressions/expression_impl_cpu.h
+++ b/dali/operators/expressions/expression_impl_cpu.h
@@ -27,6 +27,29 @@
 
 namespace dali {
 
+template <ArithmeticOp op, typename Result, typename Input0>
+class ExprImplCpuT : public ExprImplBase {
+ public:
+  void Execute(ExprImplContext &ctx, const std::vector<ExtendedTileDesc> &tiles,
+               TileRange range) override {
+    assert(range.begin + 1 == range.end &&
+           "CPU Expression implementation can handle only one tile at a time");
+    const auto &tile = tiles[range.begin];
+    auto output = static_cast<Result *>(tile.output);
+    auto input0 = static_cast<const Input0 *>(tile.args[0]);
+    Execute(output, input0, tile.desc.extent_size);
+  }
+
+ private:
+  using meta = arithm_meta<op, CPUBackend>;
+
+  static void Execute(Result *result, const Input0 *i0, int64_t extent) {
+    for (int64_t i = 0; i < extent; i++) {
+      result[i] = meta::impl(i0[i]);
+    }
+  }
+};
+
 template <ArithmeticOp op, typename Result, typename Left, typename Right>
 class ExprImplCpuTT : public ExprImplBase {
  public:

--- a/dali/operators/expressions/expression_impl_cpu.h
+++ b/dali/operators/expressions/expression_impl_cpu.h
@@ -27,7 +27,7 @@
 
 namespace dali {
 
-template <ArithmeticOp op, typename Result, typename Input0>
+template <ArithmeticOp op, typename Result, typename Input>
 class ExprImplCpuT : public ExprImplBase {
  public:
   void Execute(ExprImplContext &ctx, const std::vector<ExtendedTileDesc> &tiles,
@@ -36,14 +36,14 @@ class ExprImplCpuT : public ExprImplBase {
            "CPU Expression implementation can handle only one tile at a time");
     const auto &tile = tiles[range.begin];
     auto output = static_cast<Result *>(tile.output);
-    auto input0 = static_cast<const Input0 *>(tile.args[0]);
-    Execute(output, input0, tile.desc.extent_size);
+    auto input = static_cast<const Input *>(tile.args[0]);
+    Execute(output, input, tile.desc.extent_size);
   }
 
  private:
   using meta = arithm_meta<op, CPUBackend>;
 
-  static void Execute(Result *result, const Input0 *i0, int64_t extent) {
+  static void Execute(Result *result, const Input *i0, int64_t extent) {
     for (int64_t i = 0; i < extent; i++) {
       result[i] = meta::impl(i0[i]);
     }

--- a/dali/operators/expressions/expression_impl_factory_cpu.cc
+++ b/dali/operators/expressions/expression_impl_factory_cpu.cc
@@ -27,12 +27,15 @@ std::unique_ptr<ExprImplBase> ExprImplFactory(const HostWorkspace &ws, const Exp
   DALI_ENFORCE(expr.GetNodeType() == NodeType::Function, "Only function nodes can be executed.");
 
   switch (expr.GetSubexpressionCount()) {
+    case 1:
+      return ExprImplFactoryUnOp<ExprImplCpuT, CPUBackend>(ws,
+                                                           dynamic_cast<const ExprFunc &>(expr));
     case 2:
       return ExprImplFactoryBinOp<ExprImplCpuTT, ExprImplCpuTC, ExprImplCpuCT>(
           dynamic_cast<const ExprFunc &>(expr));
     default:
       DALI_FAIL("Expressions with " + std::to_string(expr.GetSubexpressionCount()) +
-                " subexpressions are not supported. No implemetation found.");
+                " subexpressions are not supported. No implementation found.");
       break;
   }
 }

--- a/dali/operators/expressions/expression_impl_factory_cpu.cc
+++ b/dali/operators/expressions/expression_impl_factory_cpu.cc
@@ -28,8 +28,7 @@ std::unique_ptr<ExprImplBase> ExprImplFactory(const HostWorkspace &ws, const Exp
 
   switch (expr.GetSubexpressionCount()) {
     case 1:
-      return ExprImplFactoryUnOp<ExprImplCpuT, CPUBackend>(ws,
-                                                           dynamic_cast<const ExprFunc &>(expr));
+      return ExprImplFactoryUnOp<ExprImplCpuT>(dynamic_cast<const ExprFunc &>(expr));
     case 2:
       return ExprImplFactoryBinOp<ExprImplCpuTT, ExprImplCpuTC, ExprImplCpuCT>(
           dynamic_cast<const ExprFunc &>(expr));

--- a/dali/operators/expressions/expression_impl_factory_gpu.cu
+++ b/dali/operators/expressions/expression_impl_factory_gpu.cu
@@ -27,12 +27,14 @@ std::unique_ptr<ExprImplBase> ExprImplFactory(const DeviceWorkspace &ws,
   DALI_ENFORCE(expr.GetNodeType() == NodeType::Function, "Only function nodes can be executed.");
 
   switch (expr.GetSubexpressionCount()) {
+    case 1:
+      return ExprImplFactoryUnOp<ExprImplGpuT, GPUBackend>(ws, dynamic_cast<const ExprFunc&>(expr));
     case 2:
       return ExprImplFactoryBinOp<ExprImplGpuTT, ExprImplGpuTC, ExprImplGpuCT>(
           dynamic_cast<const ExprFunc&>(expr));
     default:
       DALI_FAIL("Expressions with " + std::to_string(expr.GetSubexpressionCount()) +
-                " subexpressions are not supported. No implemetation found.");
+                " subexpressions are not supported. No implementation found.");
   }
 }
 

--- a/dali/operators/expressions/expression_impl_factory_gpu.cu
+++ b/dali/operators/expressions/expression_impl_factory_gpu.cu
@@ -28,7 +28,7 @@ std::unique_ptr<ExprImplBase> ExprImplFactory(const DeviceWorkspace &ws,
 
   switch (expr.GetSubexpressionCount()) {
     case 1:
-      return ExprImplFactoryUnOp<ExprImplGpuT, GPUBackend>(ws, dynamic_cast<const ExprFunc&>(expr));
+      return ExprImplFactoryUnOp<ExprImplGpuT>(dynamic_cast<const ExprFunc&>(expr));
     case 2:
       return ExprImplFactoryBinOp<ExprImplGpuTT, ExprImplGpuTC, ExprImplGpuCT>(
           dynamic_cast<const ExprFunc&>(expr));

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -63,10 +63,10 @@ class _EdgeReference(object):
     def __rfloordiv__(self, other):
         return _arithm_op("div", other, self)
 
-    # def __neg__(self):
-    #     return _arithm_op("minus", self)
-    # def __pos__(self):
-    #     return _arithm_op("plus", self)
+    def __neg__(self):
+        return _arithm_op("minus", self)
+    def __pos__(self):
+        return _arithm_op("plus", self)
 
 _cpu_ops = set({})
 _gpu_ops = set({})

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -65,8 +65,10 @@ class _EdgeReference(object):
 
     def __neg__(self):
         return _arithm_op("minus", self)
+
+    # Shortucitng the execution, unary + is basically a no-op
     def __pos__(self):
-        return _arithm_op("plus", self)
+        return self
 
 _cpu_ops = set({})
 _gpu_ops = set({})

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -217,7 +217,7 @@ def get_numpy_input(input, kind, type):
         return type(magic_number)
     else:
         if "scalar" in kind:
-            return input.astype(type).reshape(input.shape + (1,))
+            return input.astype(type).reshape(input.shape)
         else:
             return input.astype(type)
 
@@ -225,7 +225,7 @@ def extract_un_data(pipe_out, sample_id, kind, target_type):
     input = as_cpu(pipe_out[0]).at(sample_id)
     out = as_cpu(pipe_out[1]).at(sample_id)
     assert_equals(out.dtype, target_type)
-    in_np = get_numpy_input(input, input, target_type)
+    in_np = get_numpy_input(input, kind, target_type)
     return in_np, out
 
 def extract_bin_data(pipe_out, sample_id, kinds, target_type):


### PR DESCRIPTION
First commit is from #1391

#### Why we need this PR?
- It adds new feature needed because *we want to support unary ops*

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
Add ExprImpl for Unary Ops.
Added support for unary plus and minus operators.
 - What was changed, added, removed?
Tests were extended to cover unary operators.
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
 - Were docs and examples updated, if necessary?

**JIRA TASK**: [DALI-1109]