### PR TITLE
Add additional_decode_surfaces parameter to videoreader

### DIFF
--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -129,6 +129,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       stride_(spec.GetArgument<int>("stride")),
       max_height_(0),
       max_width_(0),
+      additional_decode_surfaces_(spec.GetArgument<int>("additional_decode_surfaces")),
       image_type_(spec.GetArgument<DALIImageType>("image_type")),
       dtype_(spec.GetArgument<DALIDataType>("dtype")),
       normalized_(spec.GetArgument<bool>("normalized")),
@@ -206,7 +207,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
                       dtype_,
                       normalized_,
                       ALIGN16(max_height_),
-                      ALIGN16(max_width_))};
+                      ALIGN16(max_width_),
+                      additional_decode_surfaces_)};
 
     if (shuffle_) {
       // TODO(spanev) decide of a policy for multi-gpu here and SequenceLoader
@@ -237,6 +239,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   int stride_;
   int max_height_;
   int max_width_;
+  int additional_decode_surfaces_;
   static constexpr int channels_ = 3;
   DALIImageType image_type_;
   DALIDataType dtype_;

--- a/dali/operators/reader/nvdecoder/cuvideodecoder.h
+++ b/dali/operators/reader/nvdecoder/cuvideodecoder.h
@@ -23,7 +23,7 @@ namespace dali {
 class CUVideoDecoder {
  public:
   CUVideoDecoder();
-  CUVideoDecoder(int, int);
+  CUVideoDecoder(int, int, int);
   explicit CUVideoDecoder(CUvideodecoder);
   ~CUVideoDecoder();
 
@@ -51,6 +51,7 @@ class CUVideoDecoder {
   bool initialized_;
   int max_height_;
   int max_width_;
+  int additional_decode_surfaces_;
 };
 
 }  // namespace dali

--- a/dali/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/operators/reader/nvdecoder/nvdecoder.cc
@@ -45,10 +45,11 @@ NvDecoder::NvDecoder(int device_id,
                      DALIDataType dtype,
                      bool normalized,
                      int max_height,
-                     int max_width)
+                     int max_width,
+                     int additional_decode_surfaces)
     : device_id_(device_id), stream_(device_id, false, 0), codecpar_(codecpar),
       rgb_(image_type == DALI_RGB), dtype_(dtype), normalized_(normalized),
-      device_(), parser_(), decoder_(max_height, max_width),
+      device_(), parser_(), decoder_(max_height, max_width, additional_decode_surfaces),
       time_base_{time_base.num, time_base.den},
       frame_in_use_(32),  // 32 is cuvid's max number of decode surfaces
       recv_queue_(), frame_queue_(),

--- a/dali/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/operators/reader/nvdecoder/nvdecoder.h
@@ -80,7 +80,8 @@ class NvDecoder {
             DALIDataType dtype,
             bool normalized,
             int max_height,
-            int max_width);
+            int max_width,
+            int additional_decode_surfaces);
 
   NvDecoder(const NvDecoder&) = default;
   NvDecoder(NvDecoder&&) = default;

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -61,6 +61,12 @@ This option is mutually exclusive with `filenames` and `file_root`.)code",
   .AddOptionalArg("channels",
       R"code(Number of channels.)code",
       3)
+  .AddOptionalArg("additional_decode_surfaces",
+      R"code(Additional decode surfaces to use beyond minimum required.
+      This is ignored when decoder is not able to determine minimum
+      number of decode surfaces, which may happen when using an older driver.
+      This parameter can be used trade off memory usage with performance.)code",
+      2)
   .AddOptionalArg("normalized",
       R"code(Get output as normalized data.)code",
       false)


### PR DESCRIPTION
#### Why we need this PR?
*Pick one*
- Refactoring to improve *what*
Adds `additional_decode_surfaces` parameter to VideoReader.
Also reduces device memory usage as mentioned in https://github.com/NVIDIA/DALI/issues/1372#issuecomment-542056035

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
By default we use min_num_decode_surfaces + 2. If however using older API/driver the nvdec api does not return min_num_decode_surfaces, we use 20 surfaces as before.
The parameter can be used to control memory usage.
 - What was changed, added, removed?
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
Tested with videoreader benchmark #1173. Before and after results were within tolerance of each other.
 - Were docs and examples updated, if necessary?

**JIRA TASK**: [DALI-XXXX]