### PR TITLE
Remove deprecated HostDecoder and nvJPEGDecoder

### DIFF
--- a/dali/operators/decoder/host/fused/host_decoder_crop.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_crop.cc
@@ -29,17 +29,6 @@ HostDecoderCrop::HostDecoderCrop(const OpSpec &spec)
   , CropAttr(spec) {
 }
 
-DALI_SCHEMA(HostDecoderCrop)
-  .DocStr(R"code(Decode images on the host with a fixed cropping window size and variable anchor.
-When possible, will make use of partial decoding (e.g. libjpeg-turbo).
-When not supported, will decode the whole image and then crop.
-Output of the decoder is in `HWC` ordering)code")
-  .NumInput(1)
-  .NumOutput(1)
-  .AddParent("ImageDecoderCrop")
-  .Deprecate("ImageDecoderCrop");
-
-DALI_REGISTER_OPERATOR(HostDecoderCrop, HostDecoderCrop, CPU);
 DALI_REGISTER_OPERATOR(ImageDecoderCrop, HostDecoderCrop, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/host/fused/host_decoder_random_crop.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_random_crop.cc
@@ -23,17 +23,6 @@
 
 namespace dali {
 
-DALI_SCHEMA(HostDecoderRandomCrop)
-  .DocStr(R"code(Decode images on the host with a random cropping anchor/window.
-When possible, will make use of partial decoding (e.g. libjpeg-turbo).
-When not supported, will decode the whole image and then crop.
-Output of the decoder is in `HWC` ordering)code")
-  .NumInput(1)
-  .NumOutput(1)
-  .AddParent("ImageDecoderRandomCrop")
-  .Deprecate("ImageDecoderRandomCrop");
-
-DALI_REGISTER_OPERATOR(HostDecoderRandomCrop, HostDecoderRandomCrop, CPU);
 DALI_REGISTER_OPERATOR(ImageDecoderRandomCrop, HostDecoderRandomCrop, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/host/fused/host_decoder_slice.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_slice.cc
@@ -28,21 +28,6 @@ HostDecoderSlice::HostDecoderSlice(const OpSpec &spec)
   , slice_attr_(spec) {
 }
 
-DALI_SCHEMA(HostDecoderSlice)
-  .DocStr(R"code(Decode images on the host with a cropping window of given size and anchor.
-Inputs must be supplied as 3 tensors in a specific order: `encoded_data` containing encoded
-image data, `begin` containing the starting pixel coordinates for the `crop` in `(x,y)`
-format, and `size` containing the pixel dimensions of the `crop` in `(w,h)` format.
-For both `begin` and `size`, coordinates must be in the interval `[0.0, 1.0]`.
-When possible, will make use of partial decoding (e.g. libjpeg-turbo).
-When not supported, will decode the whole image and then crop.
-Output of the decoder is in `HWC` ordering)code")
-  .NumInput(3)
-  .NumOutput(1)
-  .AddParent("ImageDecoderSlice")
-  .Deprecate("ImageDecoderSlice");
-
-DALI_REGISTER_OPERATOR(HostDecoderSlice, HostDecoderSlice, CPU);
 DALI_REGISTER_OPERATOR(ImageDecoderSlice, HostDecoderSlice, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/host/host_decoder.cc
+++ b/dali/operators/decoder/host/host_decoder.cc
@@ -48,14 +48,6 @@ void HostDecoder::RunImpl(SampleWorkspace &ws) {
   std::memcpy(out_data, decoded.get(), volume(shape));
 }
 
-DALI_SCHEMA(HostDecoder)
-  .DocStr(R"code(Specific implementation of `ImageDecoder` for `cpu` backend)code")
-  .NumInput(1)
-  .NumOutput(1)
-  .AddParent("ImageDecoder")
-  .Deprecate("ImageDecoder");
-
-DALI_REGISTER_OPERATOR(HostDecoder, HostDecoder, CPU);
 DALI_REGISTER_OPERATOR(ImageDecoder, HostDecoder, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_crop.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_crop.cc
@@ -17,15 +17,6 @@
 
 namespace dali {
 
-DALI_SCHEMA(nvJPEGDecoderCrop)
-  .DocStr(R"code(Partially decode JPEG images using the nvJPEG library and a cropping window.
-Output of the decoder is on the GPU and uses `HWC` ordering)code")
-  .NumInput(1)
-  .NumOutput(1)
-  .AddParent("ImageDecoderCrop")
-  .Deprecate("ImageDecoderCrop");
-
-DALI_REGISTER_OPERATOR(nvJPEGDecoderCrop, nvJPEGDecoderCrop, Mixed);
 DALI_REGISTER_OPERATOR(ImageDecoderCrop, nvJPEGDecoderCrop, Mixed);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_random_crop.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_random_crop.cc
@@ -19,15 +19,6 @@
 
 namespace dali {
 
-DALI_SCHEMA(nvJPEGDecoderRandomCrop)
-  .DocStr(R"code(Partially decode JPEG images using the nvJPEG library, using a random cropping anchor/window.
-Output of the decoder is on the GPU and uses `HWC` ordering)code")
-  .NumInput(1)
-  .NumOutput(1)
-  .AddParent("ImageDecoderRandomCrop")
-  .Deprecate("ImageDecoderRandomCrop");
-
-DALI_REGISTER_OPERATOR(nvJPEGDecoderRandomCrop, nvJPEGDecoderRandomCrop, Mixed);
 DALI_REGISTER_OPERATOR(ImageDecoderRandomCrop, nvJPEGDecoderRandomCrop, Mixed);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice.cc
@@ -17,19 +17,6 @@
 
 namespace dali {
 
-DALI_SCHEMA(nvJPEGDecoderSlice)
-  .DocStr(R"code(Partially decode JPEG images using the nvJPEG library, with a cropping window of given size and anchor.
-Inputs must be supplied as 3 tensors in a specific order: `encoded_data` containing encoded
-image data, `begin` containing the starting pixel coordinates for the `crop` in `(x,y)`
-format, and `size` containing the pixel dimensions of the `crop` in `(w,h)` format.
-For both `begin` and `size`, coordinates must be in the interval `[0.0, 1.0]`.
-Output of the decoder is in `HWC` ordering)code")
-  .NumInput(3)
-  .NumOutput(1)
-  .AddParent("ImageDecoderSlice")
-  .Deprecate("ImageDecoderSlice");
-
-DALI_REGISTER_OPERATOR(nvJPEGDecoderSlice, nvJPEGDecoderSlice, Mixed);
 DALI_REGISTER_OPERATOR(ImageDecoderSlice, nvJPEGDecoderSlice, Mixed);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.cc
@@ -26,6 +26,6 @@ It is automatically inserted during the pipeline creation.)code")
   .NumInput(1)
   .NumOutput(3)
   .MakeInternal()
-  .AddParent("nvJPEGDecoder");
+  .AddParent("ImageDecoder");
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.cc
@@ -18,14 +18,6 @@
 
 namespace dali {
 
-DALI_SCHEMA(nvJPEGDecoder)
-  .DocStr(R"code(Specific implementation of `ImageDecoder` for `mixed` backend)code")
-  .NumInput(1)
-  .NumOutput(1)
-  .AddParent("ImageDecoder")
-  .Deprecate("ImageDecoder");
-
-DALI_REGISTER_OPERATOR(nvJPEGDecoder, nvJPEGDecoder, Mixed);
 DALI_REGISTER_OPERATOR(ImageDecoder, nvJPEGDecoder, Mixed);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.cc
+++ b/dali/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.cc
@@ -17,14 +17,6 @@
 
 namespace dali {
 
-DALI_SCHEMA(nvJPEGDecoder)
-  .DocStr(R"code(Specific implementation of `ImageDecoder` `mixed` backend)code")
-  .NumInput(1)
-  .NumOutput(1)
-  .AddParent("ImageDecoder")
-  .Deprecate("ImageDecoder");
-
-DALI_REGISTER_OPERATOR(nvJPEGDecoder, nvJPEGDecoder, Mixed);
 DALI_REGISTER_OPERATOR(ImageDecoder, nvJPEGDecoder, Mixed);
 
 }  // namespace dali

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -211,7 +211,7 @@ int Pipeline::AddOperator(OpSpec spec, const std::string& inst_name, int logical
   auto operator_name = spec.name();
   bool split_stages = false;
   bool is_hybrid_decoder = device == "mixed" &&
-    (has_prefix(operator_name, "nvJPEGDecoder") || has_prefix(operator_name, "ImageDecoder"));
+    (has_prefix(operator_name, "ImageDecoder"));
 
   if (is_hybrid_decoder &&
       operator_name.find("CPUStage") == std::string::npos &&
@@ -346,7 +346,7 @@ inline void Pipeline::AddSplitHybridDecoder(OpSpec &spec, const std::string &ins
 
   std::string suffix = "";
   bool any_match = false;
-  for (const std::string& prefix : {"nvJPEGDecoder", "ImageDecoder"}) {
+  for (const std::string& prefix : {"ImageDecoder"}) {
     if (has_prefix(operator_name, prefix)) {
       suffix = operator_name.substr(prefix.size());
       any_match = true;

--- a/dali/test/python/test_dali_tf_plugin_run.py
+++ b/dali/test/python/test_dali_tf_plugin_run.py
@@ -19,7 +19,7 @@ class CommonPipeline(Pipeline):
     def __init__(self, batch_size, num_threads, device_id):
         super(CommonPipeline, self).__init__(batch_size, num_threads, device_id)
 
-        self.decode = ops.nvJPEGDecoder(device = "mixed", output_type = types.RGB)
+        self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
         self.resize = ops.Resize(device = "gpu", image_type = types.RGB, interp_type = types.INTERP_LINEAR)
         self.cmn = ops.CropMirrorNormalize(device = "gpu",
                                            output_dtype = types.FLOAT,

--- a/dali/test/python/test_operator_water.py
+++ b/dali/test/python/test_operator_water.py
@@ -57,7 +57,7 @@ class WaterPythonPipeline(Pipeline):
                                            exec_async=False,
                                            exec_pipelined=False)
         self.input = ops.CaffeReader(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.HostDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
         self.water = ops.PythonFunction(function=function)
 
 


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### What happened in this PR?
Remove deprecated `HostDecoder` and `nvJPEGDecoder`, in favor of `ImageDecoder`

**JIRA TASK**: [DALI-XXXX]