### PR TITLE
Remove PyTorch iterator double buffering

### DIFF
--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -57,6 +57,10 @@ class DALIGenericIterator(object):
     outputs from the DALI pipeline in the form of MXNet's DataBatch
     of NDArrays.
 
+    Please keep in mind that NDArrays returned by the iterator are
+    still owned by DALI. They are valid till the next iterator call.
+    If the content needs to be preserved please copy it to another NDArray.
+
     Parameters
     ----------
     pipelines : list of nvidia.dali.pipeline.Pipeline
@@ -325,6 +329,10 @@ class DALIClassificationIterator(DALIGenericIterator):
                             label_name, DALIClassificationIterator.LABEL_TAG],
                            size, data_name, label_name,
                            data_layout)
+
+    Please keep in mind that NDArrays returned by the iterator are
+    still owned by DALI. They are valid till the next iterator call.
+    If the content needs to be preserved please copy it to another NDArray.
 
     Parameters
     ----------


### PR DESCRIPTION
- removes unneeded PyTorch iterator double buffering as DALI
  does this already under the hood
- adds a note to the MXNet and PyTorch iterator plugin about
  the ownership of the returned tensors

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- removes PyTorch iterator double buffering

#### What happened in this PR?
 - removes unneeded PyTorch iterator double buffering as DALI
   does this already under the hood
 - adds a note to the MXNet and PyTorch iterator plugin about
   the ownership of the returned tensors
 - tested in CI
 - responds to https://github.com/NVIDIA/DALI/issues/1375

**JIRA TASK**: [NA]