### PR TITLE
Enforce Crop's crop argument to be a vector of at least 2 elements

### DIFF
--- a/dali/operators/crop/crop_attr.h
+++ b/dali/operators/crop/crop_attr.h
@@ -58,16 +58,9 @@ class CropAttr {
         "`crop` argument is not compatible with `crop_h`, `crop_w`, `crop_d`");
 
       auto cropArg = spec.GetRepeatedArgument<float>("crop");
-      if (cropArg.size() == 1) {
-          DALI_WARN("Warning: Single value argument for `crop` is now deprecated. "
-                    "To produce a squared cropping window, please provide both values "
-                    "explicitly `crop=(c, c)`."
-                    "Future releases will treat this as an error");
-          cropArg.push_back(cropArg[0]);
-      }
       crop_arg_ndims = cropArg.size();
-      DALI_ENFORCE(crop_arg_ndims <= 3,
-        "Cropping windows with more than 3 dimensions are not supported");
+      DALI_ENFORCE(crop_arg_ndims >= 2 && crop_arg_ndims <= 3,
+        "`crop` argument should have 2 or 3 elements depending on the input data shape");
 
       size_t idx = 0;
       if (crop_arg_ndims == 3) {

--- a/dali/operators/crop/crop_test.cc
+++ b/dali/operators/crop/crop_test.cc
@@ -28,10 +28,6 @@ TYPED_TEST(CropTest, CropVector) {
   this->RunTest({"Crop", {"crop", "224, 256", DALI_FLOAT_VEC}}, addImageType);
 }
 
-TYPED_TEST(CropTest, CropSingleDim) {
-  this->RunTest({"Crop", {"crop", "224", DALI_FLOAT_VEC}}, addImageType);
-}
-
 TYPED_TEST(CropTest, CropWH) {
   const OpArg params[] = {{"crop_h", "224", DALI_FLOAT},
                           {"crop_w", "256", DALI_FLOAT}};
@@ -53,18 +49,12 @@ TYPED_TEST(CropTest, ErrorTooBigWindow2) {
 }
 
 TYPED_TEST(CropTest, ErrorTooBigWindow3) {
-  const OpArg params[] = {{"crop", "2240", DALI_FLOAT_VEC}};
-  EXPECT_ANY_THROW(
-    this->RunTest("Crop", params, 1, addImageType));
-}
-
-TYPED_TEST(CropTest, ErrorTooBigWindow4) {
   const OpArg params[] = {{"crop", "2240, 256", DALI_FLOAT_VEC}};
   EXPECT_ANY_THROW(
     this->RunTest("Crop", params, 1, addImageType));
 }
 
-TYPED_TEST(CropTest, ErrorTooBigWindow5) {
+TYPED_TEST(CropTest, ErrorTooBigWindow4) {
   const OpArg params[] = {{"crop", "224, 2560", DALI_FLOAT_VEC}};
   EXPECT_ANY_THROW(
     this->RunTest("Crop", params, 1, addImageType));
@@ -98,12 +88,5 @@ TYPED_TEST(CropTest, ErrorWrongArgs3_BothCropAndCropH) {
   EXPECT_ANY_THROW(
     this->RunTest("Crop", params, 2, addImageType));
 }
-
-TYPED_TEST(CropTest, ErrorWrongArgs_OnlyH) {
-  const OpArg params[] = {{"crop_h", "224", DALI_FLOAT}};
-  EXPECT_ANY_THROW(
-    this->RunTest("Crop", params, 1, addImageType));
-}
-
 
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
Disallow previously deprecated API `crop=value` meaning `crop=(value, value)`

#### What happened in this PR?
- Enforcing `crop` argument to have at least 2 elements `(crop_h, crop_w)`

**JIRA TASK**: [DALI-XXXX]