### PR TITLE
Move builtin operators to dali/pipeline.

### DIFF
--- a/dali/operators/operators.cc
+++ b/dali/operators/operators.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/operators/util/dummy_op.h"
-
-#include <cstdlib>
+#include "dali/core/api_helper.h"
+#include "dali/operators/operators.h"
 
 namespace dali {
-
-DALI_REGISTER_OPERATOR(DummyOp, DummyOp<CPUBackend>, CPU);
-
-DALI_SCHEMA(DummyOp)
-  .DocStr("Dummy operator for testing")
-  .OutputFn([](const OpSpec &spec) { return spec.GetArgument<int>("num_outputs"); })
-  .NumInput(0, 10)
-  .AddOptionalArg("num_outputs",
-      R"code(Number of outputs.)code", 2);
-
+DLL_PUBLIC void InitOperatorsLib() {}
 }  // namespace dali

--- a/dali/operators/operators.h
+++ b/dali/operators/operators.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_OPERATORS_H_
+#define DALI_OPERATORS_OPERATORS_H_
+
+namespace dali {
+/**
+ * @brief The function to reference, when one needs to make sure DALI operators shared
+ *        object is actually linked against.
+ */
+DLL_PUBLIC void InitOperatorsLib();
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_OPERATORS_H_

--- a/dali/operators/util/external_source_test.cc
+++ b/dali/operators/util/external_source_test.cc
@@ -17,7 +17,7 @@
 
 #include "dali/test/dali_test_decoder.h"
 #include "dali/pipeline/executor/async_pipelined_executor.h"
-#include "dali/operators/util/external_source.h"
+#include "dali/pipeline/operator/builtin/external_source.h"
 
 namespace dali {
 

--- a/dali/pipeline/operator/builtin/CMakeLists.txt
+++ b/dali/pipeline/operator/builtin/CMakeLists.txt
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-
-add_subdirectory(builtin)
-
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(DALI_SRCS PARENT_SCOPE)
 collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/pipeline/operator/builtin/copy.cc
+++ b/dali/pipeline/operator/builtin/copy.cc
@@ -1,0 +1,40 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/operator/builtin/copy.h"
+
+namespace dali {
+
+template<>
+void Copy<CPUBackend>::RunImpl(SampleWorkspace &ws) {
+  auto &input = ws.Input<CPUBackend>(0);
+  auto &output = ws.Output<CPUBackend>(0);
+  output.set_type(input.type());
+  output.SetLayout(input.GetLayout());
+  output.ResizeLike(input);
+
+  TypeInfo type = input.type();
+  type.Copy<CPUBackend, CPUBackend>(
+      output.raw_mutable_data(),
+      input.raw_data(), input.size(), 0);
+}
+
+DALI_REGISTER_OPERATOR(Copy, Copy<CPUBackend>, CPU);
+
+DALI_SCHEMA(Copy)
+  .DocStr("Make a copy of the input tensor")
+  .NumInput(1)
+  .NumOutput(1);
+
+}  // namespace dali

--- a/dali/pipeline/operator/builtin/copy.cu
+++ b/dali/pipeline/operator/builtin/copy.cu
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <cuda_runtime_api.h>
-#include "dali/operators/util/copy.h"
+#include "dali/pipeline/operator/builtin/copy.h"
 
 namespace dali {
 

--- a/dali/pipeline/operator/builtin/copy.h
+++ b/dali/pipeline/operator/builtin/copy.h
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_OPERATORS_UTIL_DUMMY_OP_H_
-#define DALI_OPERATORS_UTIL_DUMMY_OP_H_
+#ifndef DALI_PIPELINE_OPERATOR_BUILTIN_COPY_H_
+#define DALI_PIPELINE_OPERATOR_BUILTIN_COPY_H_
 
+#include <cstring>
 #include <vector>
 
 #include "dali/pipeline/operator/operator.h"
@@ -22,25 +23,23 @@
 namespace dali {
 
 template <typename Backend>
-class DummyOp : public Operator<Backend> {
+class Copy : public Operator<Backend> {
  public:
-  inline explicit DummyOp(const OpSpec &spec) :
+  inline explicit Copy(const OpSpec &spec) :
     Operator<Backend>(spec) {}
 
-  inline ~DummyOp() override = default;
+  inline ~Copy() override = default;
 
-  DISABLE_COPY_MOVE_ASSIGN(DummyOp);
+  DISABLE_COPY_MOVE_ASSIGN(Copy);
 
  protected:
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> &) override {
-    DALI_FAIL("I'm a dummy op don't run me");
-  }
+  void RunImpl(Workspace<Backend> &ws) override;
 };
 
 }  // namespace dali
 
-#endif  // DALI_OPERATORS_UTIL_DUMMY_OP_H_
+#endif  // DALI_PIPELINE_OPERATOR_BUILTIN_COPY_H_

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/operators/util/external_source.h"
+#include "dali/pipeline/operator/builtin/external_source.h"
 
 namespace dali {
 

--- a/dali/pipeline/operator/builtin/external_source.cu
+++ b/dali/pipeline/operator/builtin/external_source.cu
@@ -16,7 +16,7 @@
 #include <memory>
 #include <list>
 
-#include "dali/operators/util/external_source.h"
+#include "dali/pipeline/operator/builtin/external_source.h"
 
 namespace dali {
 

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_OPERATORS_UTIL_EXTERNAL_SOURCE_H_
-#define DALI_OPERATORS_UTIL_EXTERNAL_SOURCE_H_
+#ifndef DALI_PIPELINE_OPERATOR_BUILTIN_EXTERNAL_SOURCE_H_
+#define DALI_PIPELINE_OPERATOR_BUILTIN_EXTERNAL_SOURCE_H_
 
 #include <atomic>
 #include <string>
@@ -244,4 +244,4 @@ class ExternalSource : public Operator<Backend> {
 
 }  // namespace dali
 
-#endif  // DALI_OPERATORS_UTIL_EXTERNAL_SOURCE_H_
+#endif  // DALI_PIPELINE_OPERATOR_BUILTIN_EXTERNAL_SOURCE_H_

--- a/dali/pipeline/operator/builtin/make_contiguous.cu
+++ b/dali/pipeline/operator/builtin/make_contiguous.cu
@@ -12,29 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/operators/util/copy.h"
+#include "dali/pipeline/operator/builtin/make_contiguous.h"
 
 namespace dali {
 
-template<>
-void Copy<CPUBackend>::RunImpl(SampleWorkspace &ws) {
-  auto &input = ws.Input<CPUBackend>(0);
-  auto &output = ws.Output<CPUBackend>(0);
-  output.set_type(input.type());
-  output.SetLayout(input.GetLayout());
-  output.ResizeLike(input);
+DALI_REGISTER_OPERATOR(MakeContiguous, MakeContiguous, Mixed);
 
-  TypeInfo type = input.type();
-  type.Copy<CPUBackend, CPUBackend>(
-      output.raw_mutable_data(),
-      input.raw_data(), input.size(), 0);
-}
-
-DALI_REGISTER_OPERATOR(Copy, Copy<CPUBackend>, CPU);
-
-DALI_SCHEMA(Copy)
-  .DocStr("Make a copy of the input tensor")
+DALI_SCHEMA(MakeContiguous)
+  .DocStr(R"code(Move input batch to a contiguous representation, more suitable for execution on the GPU)code")
   .NumInput(1)
-  .NumOutput(1);
+  .NumOutput(1)
+  .MakeInternal();
 
 }  // namespace dali

--- a/dali/pipeline/operator/builtin/make_contiguous.h
+++ b/dali/pipeline/operator/builtin/make_contiguous.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_OPERATORS_UTIL_MAKE_CONTIGUOUS_H_
-#define DALI_OPERATORS_UTIL_MAKE_CONTIGUOUS_H_
+#ifndef DALI_PIPELINE_OPERATOR_BUILTIN_MAKE_CONTIGUOUS_H_
+#define DALI_PIPELINE_OPERATOR_BUILTIN_MAKE_CONTIGUOUS_H_
 
 #include <algorithm>
 #include <vector>
@@ -135,4 +135,4 @@ class MakeContiguous : public Operator<MixedBackend> {
 
 }  // namespace dali
 
-#endif  // DALI_OPERATORS_UTIL_MAKE_CONTIGUOUS_H_
+#endif  // DALI_PIPELINE_OPERATOR_BUILTIN_MAKE_CONTIGUOUS_H_

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -25,6 +25,31 @@ std::map<string, OpSchema>& SchemaRegistry::registry() {
   return schema_map;
 }
 
+OpSchema& SchemaRegistry::RegisterSchema(const std::string &name) {
+  auto &schema_map = registry();
+  DALI_ENFORCE(schema_map.count(name) == 0, "OpSchema already "
+      "registered for operator '" + name + "'. DALI_SCHEMA(op) "
+      "should only be called once per op.");
+
+  // Insert the op schema and return a reference to it
+  schema_map.emplace(std::make_pair(name, OpSchema(name)));
+  return schema_map.at(name);
+}
+
+const OpSchema& SchemaRegistry::GetSchema(const std::string &name) {
+  auto &schema_map = registry();
+  auto it = schema_map.find(name);
+  DALI_ENFORCE(it != schema_map.end(), "Schema for operator '" +
+      name + "' not registered");
+  return it->second;
+}
+
+const OpSchema* SchemaRegistry::TryGetSchema(const std::string &name) {
+  auto &schema_map = registry();
+  auto it = schema_map.find(name);
+  return it != schema_map.end() ? &it->second : nullptr;
+}
+
 int OpSchema::CalculateOutputs(const OpSpec &spec) const {
   if (!output_fn_) {
     return num_output_;

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -513,30 +513,9 @@ class DLL_PUBLIC OpSchema {
 
 class SchemaRegistry {
  public:
-  static OpSchema& RegisterSchema(const std::string &name) {
-    auto &schema_map = registry();
-    DALI_ENFORCE(schema_map.count(name) == 0, "OpSchema already "
-        "registered for operator '" + name + "'. DALI_SCHEMA(op) "
-        "should only be called once per op.");
-
-    // Insert the op schema and return a reference to it
-    schema_map.emplace(std::make_pair(name, OpSchema(name)));
-    return schema_map.at(name);
-  }
-
-  static const OpSchema& GetSchema(const std::string &name) {
-    auto &schema_map = registry();
-    auto it = schema_map.find(name);
-    DALI_ENFORCE(it != schema_map.end(), "Schema for operator '" +
-        name + "' not registered");
-    return it->second;
-  }
-
-  static const OpSchema* TryGetSchema(const std::string &name) {
-    auto &schema_map = registry();
-    auto it = schema_map.find(name);
-    return it != schema_map.end() ? &it->second : nullptr;
-  }
+  DLL_PUBLIC static OpSchema& RegisterSchema(const std::string &name);
+  DLL_PUBLIC static const OpSchema& GetSchema(const std::string &name);
+  DLL_PUBLIC static const OpSchema* TryGetSchema(const std::string &name);
 
  private:
   inline SchemaRegistry() {}

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -29,7 +29,7 @@
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/tensor.h"
 #include "dali/pipeline/data/tensor_list.h"
-#include "dali/operators/util/external_source.h"
+#include "dali/pipeline/operator/builtin/external_source.h"
 #include "dali/pipeline/graph/op_graph.h"
 
 

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -22,7 +22,7 @@
 #include "dali/pipeline/data/buffer.h"
 #include "dali/pipeline/data/tensor.h"
 #include "dali/pipeline/operator/operator.h"
-#include "dali/operators/util/copy.h"
+#include "dali/pipeline/operator/builtin/copy.h"
 #include "dali/test/dali_test.h"
 #include "dali/test/dali_test_decoder.h"
 #include "dali/util/image.h"

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -28,6 +28,7 @@
 #include "dali/util/half.hpp"
 #include "dali/core/device_guard.h"
 #include "dali/core/python_util.h"
+#include "dali/operators/operators.h"
 
 namespace dali {
 namespace python {
@@ -541,6 +542,7 @@ TFValue ConvertTFRecordDefaultValue(TFFeatureType type, py::object val) {
 #endif  // DALI_BUILD_PROTO3
 
 PYBIND11_MODULE(backend_impl, m) {
+  dali::InitOperatorsLib();
   m.doc() = "Python bindings for the C++ portions of DALI";
 
   // DALI Init function

--- a/dali/test/dali_test.cc
+++ b/dali/test/dali_test.cc
@@ -18,13 +18,15 @@
 #include "dali/pipeline/data/allocator.h"
 #include "dali/pipeline/operator/op_spec.h"
 #include "dali/test/dali_test_config.h"
-
+#include "dali/operators/operators.h"
 
 int main(int argc, char **argv) {
   dali::DALIInit(dali::OpSpec("CPUAllocator"),
                  dali::OpSpec("PinnedCPUAllocator"),
                  dali::OpSpec("GPUAllocator"));
   ::testing::InitGoogleTest(&argc, argv);
+
+  dali::InitOperatorsLib();
 
   return RUN_ALL_TESTS();
 }

--- a/dali/test/dummy_op.cc
+++ b/dali/test/dummy_op.cc
@@ -12,10 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/operators/util/dummy_op.h"
+#include "dali/test/dummy_op.h"
+
+#include <cstdlib>
 
 namespace dali {
 
-DALI_REGISTER_OPERATOR(DummyOp, DummyOp<GPUBackend>, GPU);
+DALI_REGISTER_OPERATOR(DummyOp, DummyOp<CPUBackend>, CPU);
+
+DALI_SCHEMA(DummyOp)
+  .DocStr("Dummy operator for testing")
+  .OutputFn([](const OpSpec &spec) { return spec.GetArgument<int>("num_outputs"); })
+  .NumInput(0, 10)
+  .AddOptionalArg("num_outputs",
+      R"code(Number of outputs.)code", 2);
 
 }  // namespace dali

--- a/dali/test/dummy_op.cu
+++ b/dali/test/dummy_op.cu
@@ -12,16 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/operators/util/make_contiguous.h"
+#include "dali/test/dummy_op.h"
 
 namespace dali {
 
-DALI_REGISTER_OPERATOR(MakeContiguous, MakeContiguous, Mixed);
-
-DALI_SCHEMA(MakeContiguous)
-  .DocStr(R"code(Move input batch to a contiguous representation, more suitable for execution on the GPU)code")
-  .NumInput(1)
-  .NumOutput(1)
-  .MakeInternal();
+DALI_REGISTER_OPERATOR(DummyOp, DummyOp<GPUBackend>, GPU);
 
 }  // namespace dali

--- a/dali/test/dummy_op.h
+++ b/dali/test/dummy_op.h
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_OPERATORS_UTIL_COPY_H_
-#define DALI_OPERATORS_UTIL_COPY_H_
+#ifndef DALI_TEST_DUMMY_OP_H_
+#define DALI_TEST_DUMMY_OP_H_
 
-#include <cstring>
 #include <vector>
 
 #include "dali/pipeline/operator/operator.h"
@@ -23,23 +22,25 @@
 namespace dali {
 
 template <typename Backend>
-class Copy : public Operator<Backend> {
+class DummyOp : public Operator<Backend> {
  public:
-  inline explicit Copy(const OpSpec &spec) :
+  inline explicit DummyOp(const OpSpec &spec) :
     Operator<Backend>(spec) {}
 
-  inline ~Copy() override = default;
+  inline ~DummyOp() override = default;
 
-  DISABLE_COPY_MOVE_ASSIGN(Copy);
+  DISABLE_COPY_MOVE_ASSIGN(DummyOp);
 
  protected:
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
     return false;
   }
 
-  void RunImpl(Workspace<Backend> &ws) override;
+  void RunImpl(Workspace<Backend> &) override {
+    DALI_FAIL("I'm a dummy op don't run me");
+  }
 };
 
 }  // namespace dali
 
-#endif  // DALI_OPERATORS_UTIL_COPY_H_
+#endif  // DALI_TEST_DUMMY_OP_H_


### PR DESCRIPTION
Move `ExternalSource`, `MakeContiguous` and `Copy` to dali/pipeline.
Move `DummyOp` to dali/test.
Add forced loading of libdali_operators by explicitly calling a function `InitOperatorsLib`.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one*
- It fixes a bug with libdali_operators not being loaded.
- It removes dependence of libdali on libdali_operators (which was actually required because of ExternalSource and MakeContiguous being explicitly used as types in pipeline/executor).

#### What happened in this PR?
* Move `ExternalSource`, `MakeContiguous` and `Copy` to dali/pipeline.
* Move `DummyOp` to dali/test.
* Add forced loading of libdali_operators by explicitly calling a function `InitOperatorsLib`.

**JIRA TASK**: [DALI-XXXX]