### PR TITLE
Limit number of Input/Output type combinations in Slice kernel family

### DIFF
--- a/dali/kernels/common/pad.h
+++ b/dali/kernels/common/pad.h
@@ -114,11 +114,11 @@ class DLL_PUBLIC PadGPU {
 
     for (int i = 0; i < in.size(); i++) {
       auto out_shape = out.tensor_shape(i);
-      auto out_strides = GetStrides<Dims>(out_shape);
+      auto out_strides = GetStrides(out_shape);
       auto out_vol = volume(out_shape);
       const auto in_shape = in.tensor_shape(i);
       auto &sample_desc = sample_descs_cpu[i];
-      sample_desc.in_strides = GetStrides<Dims>(in_shape);
+      sample_desc.in_strides = GetStrides(in_shape);
       sample_desc.out_strides = out_strides;
       sample_desc.out_shape = in_shape.shape;
       sample_desc.padded_out_shape = out_shape.shape;

--- a/dali/kernels/slice/slice_cpu_test.cc
+++ b/dali/kernels/slice/slice_cpu_test.cc
@@ -24,9 +24,9 @@ class SliceCPUTest : public SliceTest<TestArgs> {
  public:
   using InputType = typename TestArgs::InputType;
   using OutputType = typename TestArgs::OutputType;
-  static constexpr std::size_t Dims = TestArgs::Dims;
-  static constexpr std::size_t NumSamples = TestArgs::NumSamples;
-  static constexpr std::size_t DimSize = TestArgs::DimSize;
+  static constexpr int Dims = TestArgs::Dims;
+  static constexpr int NumSamples = TestArgs::NumSamples;
+  static constexpr int DimSize = TestArgs::DimSize;
   using ArgsGenerator = typename TestArgs::ArgsGenerator;
   using KernelType = SliceCPU<OutputType, InputType, Dims>;
 
@@ -44,7 +44,7 @@ class SliceCPUTest : public SliceTest<TestArgs> {
 
     TensorListShape<> output_shapes(NumSamples, Dims);
     std::vector<KernelType> kernels(NumSamples);
-    for (std::size_t i = 0; i < NumSamples; i++) {
+    for (int i = 0; i < NumSamples; i++) {
       auto &kernel = kernels[i];
       KernelRequirements kernel_req = kernel.Setup(ctx, test_data_cpu[i], slice_args[i]);
       TensorShape<Dims> output_shape = kernel_req.output_shapes[0][0].to_static<Dims>();
@@ -55,7 +55,7 @@ class SliceCPUTest : public SliceTest<TestArgs> {
     output_data.reshape(std::move(output_shapes).to_static<Dims>());
     OutListCPU<OutputType, Dims> out_tlv = output_data.cpu();
 
-    for (std::size_t i = 0; i < NumSamples; i++) {
+    for (int i = 0; i < NumSamples; i++) {
       auto &kernel = kernels[i];
       auto out_tv = out_tlv[i];
       auto in_tv = test_data_cpu[i];

--- a/dali/kernels/slice/slice_flip_normalize_permute_cpu_test.cc
+++ b/dali/kernels/slice/slice_flip_normalize_permute_cpu_test.cc
@@ -25,9 +25,9 @@ class SliceFlipNormalizePermuteCPUTest : public SliceFlipNormalizePermuteTest<Te
  public:
   using InputType = typename TestArgs::InputType;
   using OutputType = typename TestArgs::OutputType;
-  static constexpr size_t Dims = TestArgs::Dims;
-  static constexpr size_t NumSamples = TestArgs::NumSamples;
-  static constexpr size_t DimSize = TestArgs::DimSize;
+  static constexpr int Dims = TestArgs::Dims;
+  static constexpr int NumSamples = TestArgs::NumSamples;
+  static constexpr int DimSize = TestArgs::DimSize;
   using ArgsGenerator = typename TestArgs::ArgsGenerator;
   using KernelType = SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims>;
 
@@ -45,15 +45,15 @@ class SliceFlipNormalizePermuteCPUTest : public SliceFlipNormalizePermuteTest<Te
 
     TensorListShape<> output_shapes(NumSamples, Dims);
     std::vector<KernelType> kernels(NumSamples);
-    for (size_t i = 0; i < NumSamples; i++) {
+    for (int i = 0; i < NumSamples; i++) {
       auto &kernel = kernels[i];
       KernelRequirements kernel_req = kernel.Setup(ctx, test_data_cpu[i], args[i]);
       TensorShape<Dims> output_shape = kernel_req.output_shapes[0][0].to_static<Dims>();
 
       auto padded_out_shape = args[i].padded_shape;
       auto expected_shape = padded_out_shape;
-      for (size_t d = 0; d < Dims; d++) {
-        size_t perm_d = args[i].permuted_dims[d];
+      for (int d = 0; d < Dims; d++) {
+        int perm_d = args[i].permuted_dims[d];
         expected_shape[d] = padded_out_shape[perm_d];
       }
       AssertExpectedDimensions(output_shape, expected_shape);
@@ -63,7 +63,7 @@ class SliceFlipNormalizePermuteCPUTest : public SliceFlipNormalizePermuteTest<Te
     output_data.reshape(std::move(output_shapes).to_static<Dims>());
     OutListCPU<OutputType, Dims> out_tlv = output_data.cpu();
 
-    for (size_t i = 0; i < NumSamples; i++) {
+    for (int i = 0; i < NumSamples; i++) {
       auto &kernel = kernels[i];
       auto out_tv = out_tlv[i];
       auto in_tv = test_data_cpu[i];

--- a/dali/kernels/slice/slice_flip_normalize_permute_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_gpu.h
@@ -30,7 +30,7 @@
 namespace dali {
 namespace kernels {
 
-template <typename OutputType, typename InputType, size_t Dims>
+template <typename OutputType, typename InputType, int Dims>
 class SliceFlipNormalizePermutePadGPU {
  private:
   static constexpr size_t kBlockDim = 512;
@@ -70,8 +70,8 @@ class SliceFlipNormalizePermutePadGPU {
     TensorListShape<Dims> output_shapes(in_shapes.size(), Dims);
     for (int i = 0; i < in_shapes.size(); i++) {
       TensorShape<Dims> out_shape(args[i].padded_shape);
-      CheckValidOutputShape<Dims>(in_shapes[i], out_shape, args[i]);
-      out_shape = detail::permute<Dims>(out_shape, args[i].permuted_dims);
+      CheckValidOutputShape(in_shapes[i], out_shape, args[i]);
+      out_shape = detail::permute(out_shape, args[i].permuted_dims);
       output_shapes.set_tensor_shape(i, out_shape);
     }
     req.output_shapes = { output_shapes };
@@ -102,11 +102,11 @@ class SliceFlipNormalizePermutePadGPU {
       norm_add_cpu[i] = -mean_data[i] * inv_stddev_data[i];
       norm_mul_cpu[i] = inv_stddev_data[i];
     }
-    unsigned normalization_dim = Dims + 1;
+    int normalization_dim = Dims + 1;
     std::vector<size_t> sample_sizes(in.size());
     for (int i = 0; i < in.size(); i++) {
       const auto in_shape = in.tensor_shape(i);
-      auto processed_args = detail::ProcessArgs<Dims>(args[i], in_shape);
+      auto processed_args = detail::ProcessArgs(args[i], in_shape);
       if (i == 0) {
         normalization_dim = processed_args.normalization_dim;
       } else {

--- a/dali/kernels/slice/slice_flip_normalize_permute_gpu_test.cu
+++ b/dali/kernels/slice/slice_flip_normalize_permute_gpu_test.cu
@@ -26,9 +26,9 @@ class SliceFlipNormalizePermuteGPUTest : public SliceFlipNormalizePermuteTest<Te
  public:
   using InputType = typename TestArgs::InputType;
   using OutputType = typename TestArgs::OutputType;
-  static constexpr size_t Dims = TestArgs::Dims;
-  static constexpr size_t NumSamples = TestArgs::NumSamples;
-  static constexpr size_t DimSize = TestArgs::DimSize;
+  static constexpr int Dims = TestArgs::Dims;
+  static constexpr int NumSamples = TestArgs::NumSamples;
+  static constexpr int DimSize = TestArgs::DimSize;
   using ArgsGenerator = typename TestArgs::ArgsGenerator;
   using KernelType = SliceFlipNormalizePermutePadGPU<OutputType, InputType, Dims>;
 
@@ -52,8 +52,8 @@ class SliceFlipNormalizePermuteGPUTest : public SliceFlipNormalizePermuteTest<Te
     for (int i = 0; i < output_shapes.size(); i++) {
       auto padded_out_shape = args[i].padded_shape;
       auto expected_shape = padded_out_shape;
-      for (size_t d = 0; d < Dims; d++) {
-        size_t perm_d = args[i].permuted_dims[d];
+      for (int d = 0; d < Dims; d++) {
+        int perm_d = args[i].permuted_dims[d];
         expected_shape[d] = padded_out_shape[perm_d];
       }
       AssertExpectedDimensions(output_shapes[i], expected_shape);

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_cuda_impl.cuh
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_cuda_impl.cuh
@@ -33,14 +33,14 @@ namespace kernels {
 
 namespace detail {
 
-template <size_t Dims>
+template <int Dims>
 struct SampleDesc {
   void *__restrict__ out;
   const void *__restrict__ in;
-  DeviceArray<int64_t, Dims> in_strides;
-  DeviceArray<int64_t, Dims> out_strides;
-  DeviceArray<int64_t, Dims> out_shape;
-  DeviceArray<int64_t, Dims> padded_out_shape;
+  TensorShape<Dims> in_strides;
+  TensorShape<Dims> out_strides;
+  TensorShape<Dims> out_shape;
+  TensorShape<Dims> padded_out_shape;
   float padding_val;
 };
 
@@ -122,7 +122,7 @@ __device__ inline void SliceFlipNormalizePermutePadFunc(OutputType *__restrict__
   }
 }
 
-template <typename OutputType, typename InputType, size_t Dims, bool should_normalize>
+template <typename OutputType, typename InputType, int Dims, bool should_normalize>
 __global__ void SliceFlipNormalizePermutePadKernel(const SampleDesc<Dims> *samples,
                                                    const BlockDesc *blocks,
                                                    const float *norm_add,
@@ -136,7 +136,7 @@ __global__ void SliceFlipNormalizePermutePadKernel(const SampleDesc<Dims> *sampl
   auto *in = static_cast<const InputType *>(sample.in);
 
   bool should_pad = false;
-  for (size_t d = 0; d < Dims; d++) {
+  for (int d = 0; d < Dims; d++) {
     if (should_pad = (sample.padded_out_shape[d] > sample.out_shape[d])) {
       break;
     }

--- a/dali/kernels/slice/slice_gpu_test.cu
+++ b/dali/kernels/slice/slice_gpu_test.cu
@@ -25,9 +25,9 @@ class SliceGPUTest : public SliceTest<TestArgs> {
  public:
   using InputType = typename TestArgs::InputType;
   using OutputType = typename TestArgs::OutputType;
-  static constexpr std::size_t Dims = TestArgs::Dims;
-  static constexpr std::size_t NumSamples = TestArgs::NumSamples;
-  static constexpr std::size_t DimSize = TestArgs::DimSize;
+  static constexpr int Dims = TestArgs::Dims;
+  static constexpr int NumSamples = TestArgs::NumSamples;
+  static constexpr int DimSize = TestArgs::DimSize;
   using ArgsGenerator = typename TestArgs::ArgsGenerator;
   using KernelType = SliceGPU<OutputType, InputType, Dims>;
 

--- a/dali/kernels/slice/slice_kernel_utils.h
+++ b/dali/kernels/slice/slice_kernel_utils.h
@@ -24,15 +24,15 @@
 namespace dali {
 namespace kernels {
 
-template <size_t Dims>
+template <int Dims>
 struct SliceArgs {
-  std::array<int64_t, Dims> anchor;
-  std::array<int64_t, Dims> shape;
+  TensorShape<Dims> anchor;
+  TensorShape<Dims> shape;
 };
 
-template <size_t Dims, typename Shape>
-std::array<int64_t, Dims> GetStrides(const Shape& shape) {
-  std::array<int64_t, Dims> strides;
+template <int Dims>
+TensorShape<Dims> GetStrides(const TensorShape<Dims>& shape) {
+  TensorShape<Dims> strides;
   strides[Dims - 1] = 1;
   for (size_t d = Dims - 1; d > 0; d--) {
     strides[d - 1] = strides[d] * shape[d];
@@ -40,7 +40,7 @@ std::array<int64_t, Dims> GetStrides(const Shape& shape) {
   return strides;
 }
 
-template <size_t Dims, typename Args>
+template <int Dims, typename Args>
 void CheckValidOutputShape(const TensorShape<Dims>& in_sample_shape,
                            const TensorShape<Dims>& out_sample_shape,
                            const Args& args) {
@@ -55,15 +55,15 @@ void CheckValidOutputShape(const TensorShape<Dims>& in_sample_shape,
   }
 }
 
-template <size_t Dims, typename Args>
+template <int Dims, typename Args>
 TensorShape<Dims> GetOutputShape(const TensorShape<Dims>& in_sample_shape,
                                  const Args& args) {
   TensorShape<Dims> out_sample_shape(args.shape);
-  CheckValidOutputShape<Dims>(in_sample_shape, out_sample_shape, args);
+  CheckValidOutputShape(in_sample_shape, out_sample_shape, args);
   return out_sample_shape;
 }
 
-template <size_t Dims, typename Args>
+template <int Dims, typename Args>
 TensorListShape<Dims> GetOutputShapes(const TensorListShape<Dims>& in_shapes,
                                       const std::vector<Args> &args) {
     DALI_ENFORCE(args.size() == static_cast<size_t>(in_shapes.size()),
@@ -71,7 +71,7 @@ TensorListShape<Dims> GetOutputShapes(const TensorListShape<Dims>& in_shapes,
 
     TensorListShape<Dims> output_shapes(in_shapes.size(), Dims);
     for (int i = 0; i < in_shapes.size(); i++) {
-      auto out_sample_shape = GetOutputShape<Dims>(in_shapes[i], args[i]);
+      auto out_sample_shape = GetOutputShape(in_shapes[i], args[i]);
       output_shapes.set_tensor_shape(i, out_sample_shape);
     }
     return output_shapes;

--- a/dali/operators/crop/slice_base.cc
+++ b/dali/operators/crop/slice_base.cc
@@ -60,7 +60,8 @@ DALI_SCHEMA(SliceBase)
     .DocStr(R"code(Base implementation for `Slice`, `Crop` and related operators)code")
     .MakeInternal()
     .AddOptionalArg("output_dtype",
-      R"code(Output data type. By default same data type as the input will be used)code",
+      R"code(Output data type. By default same data type as the input will be used.
+Supported types: `FLOAT`, `FLOAT16`, and `UINT8`)code",
       DALI_NO_TYPE);
 
 template <>

--- a/dali/operators/crop/slice_base.h
+++ b/dali/operators/crop/slice_base.h
@@ -25,6 +25,9 @@
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
 
+#define SLICE_TYPES (uint8_t, int16_t, uint16_t, int32_t, float, float16)
+#define CMN_NDIMS (3, 4, 5)
+
 namespace dali {
 
 template <typename Backend>

--- a/dali/operators/fused/crop_mirror_normalize.cc
+++ b/dali/operators/fused/crop_mirror_normalize.cc
@@ -34,7 +34,7 @@ normalization only.
   .NumOutput(1)
   .AllowSequences()
   .AddOptionalArg("output_dtype",
-    R"code(Output data type.)code", DALI_FLOAT)
+    R"code(Output data type. Supported types: `FLOAT` and `FLOAT16`)code", DALI_FLOAT)
   .AddOptionalArg("output_layout",
     R"code(Output tensor data layout)code", "CHW")
   .AddOptionalArg("pad_output",

--- a/dali/operators/fused/crop_mirror_normalize.cc
+++ b/dali/operators/fused/crop_mirror_normalize.cc
@@ -63,10 +63,9 @@ bool CropMirrorNormalize<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
   const auto &input = ws.InputRef<CPUBackend>(0);
   auto &output = ws.OutputRef<CPUBackend>(0);
   std::size_t number_of_dims = input.shape().sample_dim();
-  DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
-    DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
-      VALUE_SWITCH(number_of_dims, Dims, (3, 4, 5),
-      (
+  TYPE_SWITCH(input_type_, type2id, InputType, CMN_IN_TYPES, (
+    TYPE_SWITCH(output_type_, type2id, OutputType, CMN_OUT_TYPES, (
+      VALUE_SWITCH(number_of_dims, Dims, CMN_NDIMS, (
         using Kernel = kernels::SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
         output_desc[0].type = TypeInfo::Create<OutputType>();
@@ -80,10 +79,9 @@ bool CropMirrorNormalize<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
           auto &req = kmgr_.Setup<Kernel>(sample_idx, ctx, in_view, kernel_sample_args[sample_idx]);
           output_desc[0].shape.set_tensor_shape(sample_idx, req.output_shapes[0][0].shape);
         }
-        // NOLINTNEXTLINE(whitespace/parens)
-      ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
-    )
-  );  // NOLINT(whitespace/parens)
+      ), DALI_FAIL(make_string("Not supported number of dimensions:", number_of_dims));); // NOLINT
+    ), DALI_FAIL(make_string("Not supported output type:", output_type_));); // NOLINT
+  ), DALI_FAIL(make_string("Not supported input type:", input_type_));); // NOLINT
 
   return true;
 }
@@ -96,10 +94,9 @@ void CropMirrorNormalize<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   auto sample_idx = data_idx;
   std::size_t number_of_dims = input.shape().sample_dim();
 
-  DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
-    DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
-      VALUE_SWITCH(number_of_dims, Dims, (3, 4, 5),
-      (
+  TYPE_SWITCH(input_type_, type2id, InputType, CMN_IN_TYPES, (
+    TYPE_SWITCH(output_type_, type2id, OutputType, CMN_OUT_TYPES, (
+      VALUE_SWITCH(number_of_dims, Dims, CMN_NDIMS, (
         using Kernel = kernels::SliceFlipNormalizePermuteCPU<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
         auto in_view = view<const InputType, Dims>(input);
@@ -108,10 +105,10 @@ void CropMirrorNormalize<CPUBackend>::RunImpl(SampleWorkspace &ws) {
         auto &args = kernel_sample_args[sample_idx];
         kernels::KernelContext ctx;
         kmgr_.Run<Kernel>(ws.thread_idx(), sample_idx, ctx, out_view, in_view, args);
-        // NOLINTNEXTLINE(whitespace/parens)
-      ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
-    )
-  );  // NOLINT(whitespace/parens)
+
+      ), DALI_FAIL(make_string("Not supported number of dimensions:", number_of_dims));); // NOLINT
+    ), DALI_FAIL(make_string("Not supported output type:", output_type_));); // NOLINT
+  ), DALI_FAIL(make_string("Not supported input type:", input_type_));); // NOLINT
 }
 
 }  // namespace dali

--- a/dali/operators/fused/crop_mirror_normalize.cu
+++ b/dali/operators/fused/crop_mirror_normalize.cu
@@ -29,10 +29,9 @@ bool CropMirrorNormalize<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
   const auto &input = ws.Input<GPUBackend>(0);
   auto &output = ws.OutputRef<GPUBackend>(0);
   std::size_t number_of_dims = input.shape().sample_dim();
-  DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
-    DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
-      VALUE_SWITCH(number_of_dims, Dims, (3, 4, 5),
-      (
+  TYPE_SWITCH(input_type_, type2id, InputType, CMN_IN_TYPES, (
+    TYPE_SWITCH(output_type_, type2id, OutputType, CMN_OUT_TYPES, (
+      VALUE_SWITCH(number_of_dims, Dims, CMN_NDIMS, (
         using Kernel = kernels::SliceFlipNormalizePermutePadGPU<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
         auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
@@ -45,10 +44,9 @@ bool CropMirrorNormalize<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
         auto in_view = view<const InputType, Dims>(input);
         auto &req = kmgr_.Setup<Kernel>(0, ctx, in_view, kernel_sample_args);
         output_desc[0].shape = req.output_shapes[0];
-        // NOLINTNEXTLINE(whitespace/parens)
-      ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
-    )
-  );  // NOLINT(whitespace/parens)
+      ), DALI_FAIL(make_string("Not supported number of dimensions:", number_of_dims));); // NOLINT
+    ), DALI_FAIL(make_string("Not supported output type:", output_type_));); // NOLINT
+  ), DALI_FAIL(make_string("Not supported input type:", input_type_));); // NOLINT
   return true;
 }
 
@@ -58,10 +56,9 @@ void CropMirrorNormalize<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   auto &output = ws.Output<GPUBackend>(0);
 
   std::size_t number_of_dims = input.shape().sample_dim();
-  DALI_TYPE_SWITCH_WITH_FP16(input_type_, InputType,
-    DALI_TYPE_SWITCH_WITH_FP16(output_type_, OutputType,
-      VALUE_SWITCH(number_of_dims, Dims, (3, 4, 5),
-      (
+  TYPE_SWITCH(input_type_, type2id, InputType, CMN_IN_TYPES, (
+    TYPE_SWITCH(output_type_, type2id, OutputType, CMN_OUT_TYPES, (
+      VALUE_SWITCH(number_of_dims, Dims, CMN_NDIMS, (
         using Kernel = kernels::SliceFlipNormalizePermutePadGPU<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
         auto in_view = view<const InputType, Dims>(input);
@@ -70,10 +67,9 @@ void CropMirrorNormalize<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
         ctx.gpu.stream = ws.stream();
         auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
         kmgr_.Run<Kernel>(0, 0, ctx, out_view, in_view, kernel_sample_args);
-        // NOLINTNEXTLINE(whitespace/parens)
-      ), DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims)););
-    )
-  )
+      ), DALI_FAIL(make_string("Not supported number of dimensions:", number_of_dims));); // NOLINT
+    ), DALI_FAIL(make_string("Not supported output type:", output_type_));); // NOLINT
+  ), DALI_FAIL(make_string("Not supported input type:", input_type_));); // NOLINT
 }
 
 DALI_REGISTER_OPERATOR(CropMirrorNormalize, CropMirrorNormalize<GPUBackend>, GPU);

--- a/dali/operators/fused/crop_mirror_normalize.h
+++ b/dali/operators/fused/crop_mirror_normalize.h
@@ -30,6 +30,10 @@
 #include "dali/operators/crop/crop_attr.h"
 #include "dali/pipeline/operator/operator.h"
 
+#define CMN_IN_TYPES (uint8_t, int16_t, uint16_t, int32_t, float, float16)
+#define CMN_OUT_TYPES (float, float16)
+#define CMN_NDIMS (3, 4, 5)
+
 namespace dali {
 
 namespace detail {
@@ -44,7 +48,7 @@ T NextPowerOfTwo(T value) {
 
 // Rewrite Operator data as arguments for kernel
 // TODO(klecki): It probably could be written directly in that format
-template <size_t Dims>
+template <int Dims>
 kernels::SliceFlipNormalizePermutePadArgs<Dims> GetKernelArgs(
     TensorLayout input_layout, TensorLayout output_layout,
     const std::vector<int64_t> &slice_anchor, const std::vector<int64_t> &slice_shape,
@@ -52,7 +56,7 @@ kernels::SliceFlipNormalizePermutePadArgs<Dims> GetKernelArgs(
     const std::vector<float> &inv_std_dev) {
   kernels::SliceFlipNormalizePermutePadArgs<Dims> args(slice_shape);
 
-  for (size_t d = 0; d < Dims; d++) {
+  for (int d = 0; d < Dims; d++) {
     args.anchor[d] = slice_anchor[d];
   }
 
@@ -153,7 +157,7 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
     CropAttr::ProcessArguments(ws);
 
     int number_of_dims = in_shape.sample_dim();
-    VALUE_SWITCH(number_of_dims, Dims, (3, 4, 5),
+    VALUE_SWITCH(number_of_dims, Dims, CMN_NDIMS,
     (
       using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
       // We won't change the underlying type after the first allocation

--- a/dali/operators/fused/crop_mirror_normalize_test.cc
+++ b/dali/operators/fused/crop_mirror_normalize_test.cc
@@ -70,56 +70,6 @@ TYPED_TEST(CropMirrorNormalizeTest, Layout_DALI_SAME) {
                 addImageType, eps);
 }
 
-TYPED_TEST(CropMirrorNormalizeTest, Output_DALI_NO_TYPE) {
-  static const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                                 {"mean", "0.", DALI_FLOAT_VEC},
-                                 {"std", "1.", DALI_FLOAT_VEC},
-                                 {"output_dtype", EnumToString(DALI_NO_TYPE), DALI_INT32}};
-
-  this->RunTest(opName, params, sizeof(params) / sizeof(params[0]),
-                addImageType, eps);
-}
-
-TYPED_TEST(CropMirrorNormalizeTest, Output_DALI_UINT8) {
-  static const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                                 {"mean", "0.", DALI_FLOAT_VEC},
-                                 {"std", "1.", DALI_FLOAT_VEC},
-                                 {"output_dtype", EnumToString(DALI_UINT8), DALI_INT32}};
-
-  this->RunTest(opName, params, sizeof(params) / sizeof(params[0]),
-                addImageType, eps);
-}
-
-TYPED_TEST(CropMirrorNormalizeTest, Output_DALI_INT16) {
-  static const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                                 {"mean", "0.", DALI_FLOAT_VEC},
-                                 {"std", "1.", DALI_FLOAT_VEC},
-                                 {"output_dtype", EnumToString(DALI_INT16), DALI_INT32}};
-
-  this->RunTest(opName, params, sizeof(params) / sizeof(params[0]),
-                addImageType, eps);
-}
-
-TYPED_TEST(CropMirrorNormalizeTest, Output_DALI_INT32) {
-  static const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                                 {"mean", "0.", DALI_FLOAT_VEC},
-                                 {"std", "1.", DALI_FLOAT_VEC},
-                                 {"output_dtype", EnumToString(DALI_INT32), DALI_INT32}};
-
-  this->RunTest(opName, params, sizeof(params) / sizeof(params[0]),
-                addImageType, eps);
-}
-
-TYPED_TEST(CropMirrorNormalizeTest, Output_DALI_INT64) {
-  static const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
-                                 {"mean", "0.", DALI_FLOAT_VEC},
-                                 {"std", "1.", DALI_FLOAT_VEC},
-                                 {"output_dtype", EnumToString(DALI_INT64), DALI_INT32}};
-
-  this->RunTest(opName, params, sizeof(params) / sizeof(params[0]),
-                addImageType, eps);
-}
-
 TYPED_TEST(CropMirrorNormalizeTest, Output_DALI_FLOAT16) {
   static const OpArg params[] = {{"crop", "224, 224", DALI_FLOAT_VEC},
                                  {"mean", "0.", DALI_FLOAT_VEC},

--- a/dali/test/python/test_operator_crop.py
+++ b/dali/test/python/test_operator_crop.py
@@ -163,8 +163,8 @@ def crop_NHWC_func(image):
     return crop_func_help(image, "HWC")
 
 def check_crop_NFHWC_vs_python_op_crop(device, batch_size):
-    eii1 = RandomDataIterator(batch_size, shape=(10, 600, 800, 3))
-    eii2 = RandomDataIterator(batch_size, shape=(10, 600, 800, 3))
+    eii1 = RandomDataIterator(batch_size, shape=(10, 300, 400, 3))
+    eii2 = RandomDataIterator(batch_size, shape=(10, 300, 400, 3))
     compare_pipelines(CropSequencePipeline(device, batch_size, "FHWC", iter(eii1)),
                       CropSequencePythonOpPipeline(crop_NFHWC_func, batch_size, "FHWC", iter(eii2)),
                       batch_size=batch_size, N_iterations=10)
@@ -175,8 +175,8 @@ def test_crop_NFHWC_vs_python_op_crop():
             yield check_crop_NFHWC_vs_python_op_crop, device, batch_size
 
 def check_crop_NHWC_vs_python_op_crop(device, batch_size):
-    eii1 = RandomDataIterator(batch_size, shape=(600, 800, 3))
-    eii2 = RandomDataIterator(batch_size, shape=(600, 800, 3))
+    eii1 = RandomDataIterator(batch_size, shape=(300, 400, 3))
+    eii2 = RandomDataIterator(batch_size, shape=(300, 400, 3))
     compare_pipelines(CropSequencePipeline(device, batch_size, "HWC", iter(eii1)),
                       CropSequencePythonOpPipeline(crop_NHWC_func, batch_size, "HWC", iter(eii2)),
                       batch_size=batch_size, N_iterations=10)

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -90,6 +90,8 @@ struct TensorShapeBase {
   using size_type = int;
   using reference = value_type &;
   using const_reference = const value_type &;
+  using pointer = value_type *;
+  using const_pointer = const value_type *;
   using iterator = typename container_type::iterator;
   using const_iterator = typename container_type::const_iterator;
 
@@ -97,6 +99,10 @@ struct TensorShapeBase {
   DALI_HOST_DEV reference operator[](int d) { return shape[d]; }
   DALI_NO_EXEC_CHECK
   DALI_HOST_DEV const_reference operator[](int d) const { return shape[d]; }
+  DALI_NO_EXEC_CHECK
+  DALI_HOST_DEV pointer data() noexcept { return shape.data(); }
+  DALI_NO_EXEC_CHECK
+  DALI_HOST_DEV constexpr const_pointer data() const noexcept { return shape.data(); }
 
   DALI_NO_EXEC_CHECK
   DALI_HOST_DEV iterator begin() noexcept { return shape.begin(); }


### PR DESCRIPTION
#### Why we need this PR?
- CropMirrorNormalize and other Slice family operators take way too long to compile due to unnecessary instantiation of underlying kernels for combinations of Input/Output types

#### What happened in this PR?
- Limit Input/Output in CMN and other Slice family operators
- Change size_t to int in template arguments
- Change std::array to TensorShape for shapes

**JIRA TASK**: [DALI-XXXX]