### PR TITLE
Add initial support for constants in python API

### DIFF
--- a/dali/operators/expressions/constant_storage.h
+++ b/dali/operators/expressions/constant_storage.h
@@ -32,7 +32,6 @@
 
 namespace dali {
 
-
 #define CONSTANT_STORAGE_ALLOWED_TYPES \
   (uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float16, float, double)
 

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -101,3 +101,89 @@ class CUDAStream:
     def ptr(self):
         """Raw CUDA stream pointer, stored as uint64."""
         return self._ptr
+
+_float_types = [DALIDataType.FLOAT16, DALIDataType.FLOAT, DALIDataType.FLOAT64]
+_int_types = [DALIDataType.INT8, DALIDataType.INT16, DALIDataType.INT32, DALIDataType.INT64,
+              DALIDataType.UINT8, DALIDataType.UINT16, DALIDataType.UINT32, DALIDataType.UINT64]
+
+class Constant(object):
+    """Wrapper for a constant value that can be used in arithmetic operations
+    with the results of DALI Operators in `define_graph()` step.
+
+    It indicates what type it should be treated as. The integers values
+    will be passed to DALI as `int32` and the floating point values as `float32`.
+    Python builtin types `int` and `float` will also be treated as those types.
+    """
+    def __init__(self, value, dtype=None):
+        if not isinstance(value, (int, float)):
+            raise TypeError("Expected scalar value of type 'int' or 'float', got {}."
+                    .format(str(type(value))))
+        if dtype:
+            self.dtype = dtype
+            if self.dtype in _int_types:
+                self.value = int(value)
+            elif self.dtype in _float_types:
+                self.value = float(value)
+            else:
+                raise TypeError("DALI Constant can only hold one of: {} types."
+                        .format(_int_types + _float_types))
+        elif isinstance(value, int):
+            self.value = value
+            self.dtype = DALIDataType.INT32
+        elif isinstance(value, float):
+            self.value = value
+            self.dtype = DALIDataType.FLOAT
+
+    def int8(self):
+        return Constant(self.value, DALIDataType.INT8)
+
+    def int16(self):
+        return Constant(self.value, DALIDataType.INT16)
+
+    def int32(self):
+        return Constant(self.value, DALIDataType.INT32)
+
+    def int64(self):
+        return Constant(self.value, DALIDataType.INT64)
+
+    def uint8(self):
+        return Constant(self.value, DALIDataType.UINT8)
+
+    def uint16(self):
+        return Constant(self.value, DALIDataType.UINT16)
+
+    def uint32(self):
+        return Constant(self.value, DALIDataType.UINT32)
+
+    def uint64(self):
+        return Constant(self.value, DALIDataType.UINT64)
+
+    def float16(self):
+        return Constant(self.value, DALIDataType.FLOAT16)
+
+    def float32(self):
+        return Constant(self.value, DALIDataType.FLOAT)
+
+    def float64(self):
+        return Constant(self.value, DALIDataType.FLOAT64)
+
+    def __eq__(self, other):
+        return self.value == other.value and self.dtype == other.dtype
+
+    def __int__(self):
+        if self.dtype in _int_types:
+            return self.value
+        raise TypeError("DALI Constant must be converted to one of int types explicitly before "
+                "casting to builtin 'int'.")
+
+    def __float__(self):
+        if self.dtype in _float_types:
+            return self.value
+        raise TypeError("DALI Constant must be converted to one of float types explicitly before "
+                "casting to builtin 'float'.")
+
+    def __str__(self):
+        return "{}:{}".format(self.value, self.dtype)
+
+    def __repr__(self):
+        return "{}".format(self.value)

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -111,7 +111,7 @@ def div_promote(left_type, right_type):
     right_dtype = np.dtype(hack_builtin_types(right_type))
     if 'f' not in left_dtype.kind and 'f' not in right_dtype.kind:
         return np.float32
-    return float_bin_promote(left_dtype, right_dtype)
+    return float_bin_promote(left_dtype, right_dtype).type
 
 
 def int_generator(shape, type):
@@ -262,8 +262,8 @@ def check_arithm_div(kinds, types):
             rtol=1e-07 if target_type != np.float16 else 0.005)
     else:
         # Approximate validation, as np does something different than C
-        result = np.abs(l_np // r_np)
-        neg = ((l < 0) & (r > 0)) | ((l > 0) & (r < 0))
+        result = np.floor_divide(np.abs(l_np), np.abs(r_np))
+        neg = ((l_np < 0) & (r_np > 0)) | ((l_np > 0) & (r_np < 0))
         pos = ~neg
         result = result * (pos * 1 - neg * 1)
         np.testing.assert_array_equal(out, result)

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -20,6 +20,7 @@ import nvidia.dali.types as types
 from nvidia.dali.tensors import TensorListGPU
 import numpy as np
 from nose.tools import assert_equals
+import itertools
 
 from test_utils import check_batch
 
@@ -28,12 +29,30 @@ batch_size = 4
 # Shape of the samples
 shape = (256, 256)
 
-devices = ["cpu_cpu", "cpu_gpu", "gpu_gpu", "gpu_gpu"]
+# A number used to test constant inputs
+magic_number = 42
+
+# We cannot have constant x constant operations with DALI op.
+input_kinds = list(itertools.product(["cpu", "gpu"], ["cpu", "gpu", "const"])) +  list(
+        itertools.product(["const"], ["cpu", "gpu"]))
 
 # float16 is marked as TODO in backend for gpu
-types = [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64,
-         np.float32, np.float64]
+input_types = [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64,
+        np.float32, np.float64]
 
+np_types_to_dali = {
+    np.int8:    types.INT8,
+    np.int16:   types.INT16,
+    np.int32:   types.INT32,
+    np.int64:   types.INT64,
+    np.uint8:   types.UINT8,
+    np.uint16:  types.UINT16,
+    np.uint32:  types.UINT32,
+    np.uint64:  types.UINT64,
+    np.float16: types.FLOAT16,
+    np.float32: types.FLOAT,
+    np.float64: types.FLOAT64,
+}
 
 sane_operations = [((lambda x, y: x + y), "+"), ((lambda x, y: x - y), "-"),
                    ((lambda x, y: x * y), "*")]
@@ -73,16 +92,23 @@ def bin_promote_dtype(left_dtype, right_dtype):
         return signed_unsigned_bin_promote(left_dtype, right_dtype)
     return signed_unsigned_bin_promote(right_dtype, left_dtype)
 
+def hack_builtin_types(input_type):
+    if type(input_type) == int:
+        return np.int32
+    elif type(input_type) == float:
+        return np.float32
+    else:
+        return input_type
 
 def bin_promote(left_type, right_type):
-    left_dtype = np.dtype(left_type)
-    right_dtype = np.dtype(right_type)
+    left_dtype = np.dtype(hack_builtin_types(left_type))
+    right_dtype = np.dtype(hack_builtin_types(right_type))
     return bin_promote_dtype(left_dtype, right_dtype).type
 
 # For __truediv__ we promote integer results to float, otherwise proceed like with bin op
 def div_promote(left_type, right_type):
-    left_dtype = np.dtype(left_type)
-    right_dtype = np.dtype(right_type)
+    left_dtype = np.dtype(hack_builtin_types(left_type))
+    right_dtype = np.dtype(hack_builtin_types(right_type))
     if 'f' not in left_dtype.kind and 'f' not in right_dtype.kind:
         return np.float32
     return float_bin_promote(left_dtype, right_dtype)
@@ -125,36 +151,50 @@ class ExternalInputIterator(object):
 
 
 class ExprOpPipeline(Pipeline):
-    def __init__(self, dev, iterator, op, batch_size, num_threads, device_id):
+    def __init__(self, kinds, types, iterator, op, batch_size, num_threads, device_id):
         super(ExprOpPipeline, self).__init__(batch_size, num_threads, device_id, seed=12)
         self.left_source = ops.ExternalSource()
         self.right_source = ops.ExternalSource()
-        self.dev = dev
+        self.kinds = kinds
+        self.types = types
         self.iterator = iterator
         self.op = op
 
     def define_graph(self):
         self.left = self.left_source()
         self.right = self.right_source()
-        if self.dev == "cpu_cpu":
-            return self.left, self.right, self.op(self.left, self.right)
-        elif self.dev == "gpu_cpu":
-            return self.left, self.right, self.op(self.left.gpu(), self.right)
-        elif self.dev == "cpu_gpu":
-            return self.left, self.right, self.op(self.left, self.right.gpu())
-        else:
-            return self.left, self.right, self.op(self.left.gpu(), self.right.gpu())
+        left_kind, right_kind = self.kinds
+        left_type, right_type = self.types
+        l = self.get_operand(self.left, left_kind, left_type)
+        r = self.get_operand(self.right, right_kind, right_type)
+        return self.left, self.right, self.op(l, r)
+
+    def get_operand(self, operand, kind, operand_type):
+        if kind == "const":
+            return types.Constant(magic_number, np_types_to_dali[operand_type])
+        elif kind == "cpu":
+            return operand
+        elif kind == "gpu":
+            return operand.gpu()
 
     def iter_setup(self):
         (l, r) = self.iterator.next()
         self.feed_input(self.left, l)
         self.feed_input(self.right, r)
 
+def get_numpy_input(input, kind, type):
+    if kind == "const":
+        return type(magic_number)
+    else:
+        return input.astype(type)
+
 # Regular arithmetic ops that can be validated as straight numpy
-def check_arithm_op(dev, left_type, right_type, op, op_desc):
+def check_arithm_op(kinds, types, op, _):
+    left_type, right_type = types
+    left_kind, right_kind = kinds
     target_type = bin_promote(left_type, right_type)
     iterator = iter(ExternalInputIterator(batch_size, left_type, right_type))
-    pipe = ExprOpPipeline(dev, iterator, op, batch_size = batch_size, num_threads = 2,
+    pipe = ExprOpPipeline(kinds, types, iterator, op, batch_size = batch_size, num_threads = 2,
             device_id = 0)
     pipe.build()
     pipe_out = pipe.run()
@@ -162,24 +202,28 @@ def check_arithm_op(dev, left_type, right_type, op, op_desc):
     r = as_cpu(pipe_out[1]).as_array()
     out = as_cpu(pipe_out[2]).as_array()
     assert_equals(out.dtype, target_type)
+    l_np = get_numpy_input(l, left_kind, target_type)
+    r_np = get_numpy_input(r, right_kind, target_type)
     if 'f' in np.dtype(target_type).kind:
-        np.testing.assert_allclose(out, op(l.astype(target_type), r.astype(target_type)),
+        np.testing.assert_allclose(out, op(l_np, r_np),
             rtol=1e-07 if target_type != np.float16 else 0.005)
     else:
-        np.testing.assert_array_equal(out, op(l.astype(target_type), r.astype(target_type)))
+        np.testing.assert_array_equal(out, op(l_np, r_np))
 
 def test_arithmetic_ops():
-    for dev in devices:
+    for kinds in input_kinds:
         for (op, op_desc) in sane_operations:
-            for left_type in types:
-                for right_type in types:
-                    yield check_arithm_op, dev, left_type, right_type, op, op_desc
+            for types_in in itertools.product(input_types, input_types):
+                yield check_arithm_op, kinds, types_in, op, op_desc
+
 
 # The div operator that always returns floating point values
-def check_arithm_fdiv(dev, left_type, right_type):
+def check_arithm_fdiv(kinds, types):
+    left_type, right_type = types
+    left_kind, right_kind = kinds
     target_type = div_promote(left_type, right_type)
     iterator = iter(ExternalInputIterator(batch_size, left_type, right_type))
-    pipe = ExprOpPipeline(dev, iterator, (lambda x, y : x / y), batch_size = batch_size,
+    pipe = ExprOpPipeline(kinds, types, iterator, (lambda x, y : x / y), batch_size = batch_size,
             num_threads = 2, device_id = 0)
     pipe.build()
     pipe_out = pipe.run()
@@ -187,20 +231,23 @@ def check_arithm_fdiv(dev, left_type, right_type):
     r = as_cpu(pipe_out[1]).as_array()
     out = as_cpu(pipe_out[2]).as_array()
     assert_equals(out.dtype, target_type)
-    np.testing.assert_allclose(out, l.astype(target_type) / r.astype(target_type),
+    l_np = get_numpy_input(l, left_kind, target_type)
+    r_np = get_numpy_input(r, right_kind, target_type)
+    np.testing.assert_allclose(out, l_np / r_np,
         rtol=1e-07 if target_type != np.float16 else 0.005)
 
 def test_arithmetic_float_division():
-    for dev in devices:
-        for left_type in types:
-                for right_type in types:
-                    yield check_arithm_fdiv, dev, left_type, right_type
+    for kinds in input_kinds:
+        for types_in in itertools.product(input_types, input_types):
+            yield check_arithm_fdiv, kinds, types_in
 
 # The div operator behaves like C/C++ one
-def check_arithm_div(dev, left_type, right_type):
+def check_arithm_div(kinds, types):
+    left_type, right_type = types
+    left_kind, right_kind = kinds
     target_type = bin_promote(left_type, right_type)
     iterator = iter(ExternalInputIterator(batch_size, left_type, right_type))
-    pipe = ExprOpPipeline(dev, iterator, (lambda x, y : x // y), batch_size = batch_size,
+    pipe = ExprOpPipeline(kinds, types, iterator, (lambda x, y : x // y), batch_size = batch_size,
             num_threads = 2, device_id = 0)
     pipe.build()
     pipe_out = pipe.run()
@@ -208,19 +255,20 @@ def check_arithm_div(dev, left_type, right_type):
     r = as_cpu(pipe_out[1]).as_array()
     out = as_cpu(pipe_out[2]).as_array()
     assert_equals(out.dtype, target_type)
+    l_np = get_numpy_input(l, left_kind, target_type)
+    r_np = get_numpy_input(r, right_kind, target_type)
     if 'f' in np.dtype(target_type).kind:
-        np.testing.assert_allclose(out, l.astype(target_type) / r.astype(target_type),
+        np.testing.assert_allclose(out, l_np / r_np,
             rtol=1e-07 if target_type != np.float16 else 0.005)
     else:
         # Approximate validation, as np does something different than C
-        result = np.abs(l.astype(target_type)) // np.abs(r.astype(target_type))
+        result = np.abs(l_np // r_np)
         neg = ((l < 0) & (r > 0)) | ((l > 0) & (r < 0))
         pos = ~neg
         result = result * (pos * 1 - neg * 1)
         np.testing.assert_array_equal(out, result)
 
 def test_arithmetic_division():
-    for dev in devices:
-        for left_type in types:
-                for right_type in types:
-                    yield check_arithm_div, dev, left_type, right_type
+    for kinds in input_kinds:
+        for types_in in itertools.product(input_types, input_types):
+            yield check_arithm_div, kinds, types_in

--- a/dali/test/python/test_operator_ops_expression_internals.py
+++ b/dali/test/python/test_operator_ops_expression_internals.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nvidia.dali.ops as ops
+from nvidia.dali.types import Constant
+import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
+from nose.tools import assert_equal, assert_raises
+
+
+def test_group_inputs():
+    e0 = ops._EdgeReference("op0", "cpu")
+    e1 = ops._EdgeReference("op1", "cpu")
+    inputs = [e0, e1, 10.0, Constant(0).uint8(), 42]
+    cat_idx, edges, integers, reals = ops._group_inputs(inputs)
+    assert_equal([("edge", 0), ("edge", 1), ("real", 0),
+                  ("integer", 0), ("integer", 1)], cat_idx)
+    assert_equal([e0, e1], edges)
+    assert_equal([Constant(0).uint8(), 42], integers)
+    assert_equal([10.0], reals)
+    assert_raises(TypeError, ops._group_inputs, [np.complex()])
+    _, _, _, none_reals = ops._group_inputs([e0, 10])
+    assert_equal(None, none_reals)
+
+
+
+def test_generate_input_desc():
+    desc0 = ops._generate_input_desc([("edge", 0)], [], [])
+    desc1 = ops._generate_input_desc(
+        [("edge", 0), ("edge", 1), ("edge", 2)], [], [])
+    assert_equal("&0", desc0)
+    assert_equal("&0 &1 &2", desc1)
+
+    desc2 = ops._generate_input_desc([("integer", 1), ("integer", 0), ("edge", 0)],
+                                     [Constant(42).uint8(), 42], [])
+    assert_equal("$1:int32 $0:uint8 &0", desc2)
+
+    c = Constant(42)
+    desc3 = ops._generate_input_desc(
+        [("integer", 0), ("integer", 1), ("integer", 2), ("integer", 3), ("integer", 4),
+         ("integer", 5), ("integer", 6), ("integer", 7), ("integer", 8)],
+        [int(), c.uint8(), c.uint16(), c.uint32(), c.uint64(), c.int8(), c.int16(),
+         c.int32(), c.int64()],
+        [])
+    assert_equal("$0:int32 $1:uint8 $2:uint16 $3:uint32 $4:uint64 $5:int8 $6:int16 $7:int32 $8:int64", desc3)
+
+    desc4 = ops._generate_input_desc(
+        [("real", 0), ("real", 1), ("real", 2), ("real", 3)],
+        [],
+        [float(), c.float16(), c.float32(), c.float64()])
+    assert_equal("$0:float32 $1:float16 $2:float32 $3:float64", desc4)


### PR DESCRIPTION
#### Why we need this PR?
It allows to use constants with arithmetic operators.

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
int is treated as int32
float is treated as float32

To indicate type of constant operand nvidia.dali.types.Constant
was introduced
 - What was changed, added, removed?
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
 - Were docs and examples updated, if necessary?

**JIRA TASK**: [DALI-1107]