### PR TITLE
Fix input tiling in arithmetic ops

### DIFF
--- a/dali/operators/expressions/expression_impl_factory.h
+++ b/dali/operators/expressions/expression_impl_factory.h
@@ -84,7 +84,7 @@ inline ArgPack GetArgPack(const ExprFunc &func, workspace_t<Backend> &ws,
       const auto *ptr =
           reinterpret_cast<const char *>(GetInputSamplePointer(ws, input_idx, tile.sample_idx));
       auto tile_offset =
-          tile.tile_size * tile.extent_idx * TypeTable::GetTypeInfo(func.GetTypeId()).size();
+          tile.tile_size * tile.extent_idx * TypeTable::GetTypeInfo(tensor.GetTypeId()).size();
       result[i] = ptr + tile_offset;
     }
   }

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -23,10 +23,10 @@ from nose.tools import assert_equals
 
 from test_utils import check_batch
 
-batch_size = 8
+batch_size = 4
 
 # Shape of the samples
-shape = (8, 8)
+shape = (256, 256)
 
 devices = ["cpu_cpu", "cpu_gpu", "gpu_gpu", "gpu_gpu"]
 


### PR DESCRIPTION
The offset for input pointer in tile was calculated
using the sizeof of output type instead of input type.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fix the above mentioned bug

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
Now tile offsets are calculated based on sizeof of the input type
 - What was changed, added, removed?
The bug was fixed.
Test was adjusted to force calculation of at least 2 tiles (assuming current tiling sizes).
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
CI.
 - Were docs and examples updated, if necessary?
No.

**JIRA TASK**: [DALI-XXXX]