### PR TITLE
Fix rounding down of the RN50 PyTorch example epoch length

### DIFF
--- a/docs/examples/pytorch/resnet50/main.py
+++ b/docs/examples/pytorch/resnet50/main.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import shutil
 import time
+import math
 
 import torch
 from torch.autograd import Variable
@@ -306,7 +307,7 @@ def train(train_loader, model, criterion, optimizer, epoch):
     for i, data in enumerate(train_loader):
         input = data[0]["data"]
         target = data[0]["label"].squeeze().cuda().long()
-        train_loader_len = int(train_loader._size / args.batch_size)
+        train_loader_len = int(math.ceil(train_loader._size / args.batch_size))
 
         adjust_learning_rate(optimizer, epoch, i, train_loader_len)
 


### PR DESCRIPTION


Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
 - fixes rounding down of the RN50 PyTorch example epoch length by using math.ceil()

#### What happened in this PR?
 - fixes rounding down of the RN50 PyTorch example epoch length by using math.ceil()
 - ad https://github.com/NVIDIA/DALI/issues/1427
 - this affects only warmup learning rate adjustment in RN50 training script so the difference should be significant (if any in the most cases)
 - tested in CI

**JIRA TASK**: [NA]