### PR TITLE
Fix link error in debug mode.

### DIFF
--- a/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_kernel_test.h
@@ -38,7 +38,7 @@ class SliceFlipNormalizePermuteTest : public ::testing::Test {
   using KernelArgs = SliceFlipNormalizePermutePadArgs<Dims>;
 
   void PrepareData(TestTensorList<InputType, Dims>& test_data) {
-    std::vector<int> sample_dims(Dims, DimSize);
+    std::vector<int> sample_dims(Dims, static_cast<int>(DimSize));
     sample_dims[0] = DimSize0;
     sample_dims[1] = DimSize1;
     TensorListShape<Dims> shape = uniform_list_shape<Dims>(NumSamples, sample_dims);

--- a/dali/kernels/slice/slice_kernel_test.h
+++ b/dali/kernels/slice/slice_kernel_test.h
@@ -59,7 +59,7 @@ class SliceTest : public ::testing::Test {
   using ArgsGenerator = typename TestArgs::ArgsGenerator;
 
   void PrepareData(TestTensorList<InputType, Dims>& test_data) {
-    std::vector<int> sample_dims(Dims, DimSize);
+    std::vector<int> sample_dims(Dims, static_cast<int>(DimSize));
     TensorListShape<Dims> shape = uniform_list_shape<Dims>(NumSamples, sample_dims);
     test_data.reshape(shape);
 


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
- It fixes a link error when building in debug mode, caused by passing a constexpr value by reference, thus necessitating external linkage.

#### What happened in this PR?
 - Added `static_cast<int>(offending_variable)` to force passing by value and remove the need for actual pointer

**JIRA TASK**: [DALI-XXXX]