### PR TITLE
Make test_RN50_data_fw_iterators.py run once per FW to avoid out-of-memory errors

### DIFF
--- a/dali/test/python/test_RN50_data_fw_iterators.py
+++ b/dali/test/python/test_RN50_data_fw_iterators.py
@@ -93,10 +93,11 @@ parser.add_argument('-i', '--iters', default=-1, type=int, metavar='N',
                     help='Number of iterations to run (default: -1 - whole data set)')
 parser.add_argument('-e', '--epochs', default=1, type=int, metavar='N',
                     help='Number of epochs to run (default: 1)')
+parser.add_argument('--framework', type=str)
 args = parser.parse_args()
 
-print("GPUs: {}, batch: {}, workers: {}, prefetch depth: {}, loging interval: {}, fp16: {}, args.nhwc: {}"
-      .format(args.gpus, args.batch_size, args.workers, args.prefetch, args.print_freq, args.fp16, args.nhwc))
+print("Framework: {}, GPUs: {}, batch: {}, workers: {}, prefetch depth: {}, loging interval: {}, fp16: {}, args.nhwc: {}"
+      .format(args.framework, args.gpus, args.batch_size, args.workers, args.prefetch, args.print_freq, args.fp16, args.nhwc))
 
 PREFETCH = args.prefetch
 if args.separate_queue:
@@ -122,11 +123,8 @@ class AverageMeter(object):
         self.count += n
         self.avg = self.sum / self.count
 
-Iterators = [("mxnet.DALIClassificationIterator"   , MXNetIterator),
-             ("pytorch.DALIClassificationIterator" , PyTorchIterator),
-             ("tf.DALIIterator" , TensorFlowIterator)]
-
-for iterator_name, IteratorClass in Iterators:
+def test_fw_iter(IteratorClass, args):
+    iterator_name = IteratorClass.__module__ + "." + IteratorClass.__name__
     print("Start testing {}".format(iterator_name))
     sess = None
     daliop = None
@@ -152,7 +150,7 @@ for iterator_name, IteratorClass in Iterators:
         if iters_tmp != iters * args.gpus:
             iters += 1
 
-    if iterator_name == "tf.DALIIterator":
+    if iterator_name == "nvidia.dali.plugin.tf.DALIIterator":
         daliop = IteratorClass()
         for dev in range(args.gpus):
             with tf.device('/gpu:%i' % dev):
@@ -177,7 +175,7 @@ for iterator_name, IteratorClass in Iterators:
             print("Test run " + str(i))
         data_time = AverageMeter()
 
-        if iterator_name == "tf.DALIIterator":
+        if iterator_name == "nvidia.dali.plugin.tf.DALIIterator":
             assert sess != None
             for j in range(iters):
                 res = sess.run([images, labels])
@@ -198,3 +196,13 @@ for iterator_name, IteratorClass in Iterators:
                 j = j + 1
                 if j > iters:
                     break
+
+Iterators = {
+    "mxnet": [MXNetIterator],
+    "pytorch": [PyTorchIterator],
+    "tf": [TensorFlowIterator]
+}
+
+assert(args.framework in Iterators, "Error, framework {} not supported".format(args.framework))
+for IteratorClass in Iterators[args.framework]:
+    test_fw_iter(IteratorClass, args)

--- a/qa/TL0_FW_iterators/test.sh
+++ b/qa/TL0_FW_iterators/test.sh
@@ -12,9 +12,12 @@ do_once() {
 }
 
 test_body() {
-    python test_RN50_data_fw_iterators.py --gpus ${NUM_GPUS} -b 13 --workers 3 --prefetch 2 -i 100 --epochs 2
-    python test_RN50_data_fw_iterators.py --gpus ${NUM_GPUS} -b 13 --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
-
+    for fw in "mxnet" "pytorch" "tf"; do
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --prefetch 2 -i 100 --epochs 2
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
+    done
     nosetests --verbose test_fw_iterators_detection.py
     nosetests --verbose test_fw_iterators.py
 }

--- a/qa/TL1_separate_executor/test.sh
+++ b/qa/TL1_separate_executor/test.sh
@@ -9,11 +9,14 @@ do_once() {
 }
 
 test_body() {
-    python test_RN50_data_pipeline.py --gpus ${NUM_GPUS} -b 256 --workers 3 --separate_queue --cpu_size 2 --gpu_size 2 --fp16 --nhwc
-
-    python test_RN50_data_pipeline.py --gpus ${NUM_GPUS} -b 256 --workers 3 --separate_queue --cpu_size 5 --gpu_size 3 --fp16 --nhwc
-
-    python test_RN50_data_fw_iterators.py --gpus ${NUM_GPUS} -b 13 --workers 3 --separate_queue --cpu_size 3 --gpu_size 2 --iters 32 --epochs 2
+    python test_RN50_data_pipeline.py --gpus ${NUM_GPUS} -b 256 --workers 3 --separate_queue \
+        --cpu_size 2 --gpu_size 2 --fp16 --nhwc
+    python test_RN50_data_pipeline.py --gpus ${NUM_GPUS} -b 256 --workers 3 --separate_queue \
+        --cpu_size 5 --gpu_size 3 --fp16 --nhwc
+    for fw in "mxnet" "pytorch" "tf"; do
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --separate_queue --cpu_size 3 --gpu_size 2 --iters 32 --epochs 2
+    done
 }
 
 pushd ../..

--- a/qa/TL2_FW_iterators_perf/test.sh
+++ b/qa/TL2_FW_iterators_perf/test.sh
@@ -9,7 +9,10 @@ do_once() {
 }
 
 test_body() {
-    python test_RN50_data_fw_iterators.py --gpus ${NUM_GPUS} -b 13 --workers 3 --prefetch 2 --epochs 3
+    for fw in "mxnet" "pytorch" "tf"; do
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --prefetch 2 --epochs 3
+    done
 }
 
 pushd ../..


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
test_RN50_data_fw_iterators.py including all FWs in a loop caused out-of-memory errors when running TF and PaddlePaddle tests one after another.
FWs allocate memory in a greedy manner and we have no control of when exactly that memory gets released inside the python code.

#### What happened in this PR?
Reworked test_RN50_data_fw_iterators.py to take an argument specifying the framework to be tested, and changed TL0_FW_iterators to run it once per framework

**JIRA TASK**: [DALI-1104]