### PR TITLE
Remove unused npp dependencies

### DIFF
--- a/cmake/Dependencies.aarch64-linux.cmake
+++ b/cmake/Dependencies.aarch64-linux.cmake
@@ -29,15 +29,9 @@ list(APPEND DALI_EXCLUDES libcudart_static.a)
 
 # NVIDIA NPPC library
 find_cuda_helper_libs(nppc_static)
-find_cuda_helper_libs(nppicom_static)
 find_cuda_helper_libs(nppicc_static)
-find_cuda_helper_libs(nppig_static)
-list(APPEND DALI_LIBS ${CUDA_nppicom_static_LIBRARY}
-  ${CUDA_nppicc_static_LIBRARY}
-  ${CUDA_nppig_static_LIBRARY})
-list(APPEND DALI_EXCLUDES libnppicom_static.a
-  libnppicc_static.a
-  libnppig_static.a)
+list(APPEND DALI_LIBS ${CUDA_nppicc_static_LIBRARY})
+list(APPEND DALI_EXCLUDES libnppicc_static.a)
 list(APPEND DALI_LIBS ${CUDA_nppc_static_LIBRARY})
 list(APPEND DALI_EXCLUDES libnppc_static.a)
 

--- a/cmake/Dependencies.aarch64-qnx.cmake
+++ b/cmake/Dependencies.aarch64-qnx.cmake
@@ -44,15 +44,9 @@ include_directories(${CUDA_INCLUDE_DIRS})
 
 # NVIDIA NPPC library
 find_cuda_helper_libs(nppc_static)
-find_cuda_helper_libs(nppicom_static)
 find_cuda_helper_libs(nppicc_static)
-find_cuda_helper_libs(nppig_static)
-list(APPEND DALI_LIBS ${CUDA_nppicom_static_LIBRARY}
-  ${CUDA_nppicc_static_LIBRARY}
-  ${CUDA_nppig_static_LIBRARY})
-list(APPEND DALI_EXCLUDES libnppicom_static.a
-  libnppicc_static.a
-  libnppig_static.a)
+list(APPEND DALI_LIBS ${CUDA_nppicc_static_LIBRARY})
+list(APPEND DALI_EXCLUDES libnppicc_static.a)
 list(APPEND DALI_LIBS ${CUDA_nppc_static_LIBRARY})
 list(APPEND DALI_EXCLUDES libnppc_static.a)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -59,15 +59,9 @@ if (${CUDA_VERSION} VERSION_LESS "9.0")
 
 else()
 
-  find_cuda_helper_libs(nppicom_static)
   find_cuda_helper_libs(nppicc_static)
-  find_cuda_helper_libs(nppig_static)
-  list(APPEND DALI_LIBS ${CUDA_nppicom_static_LIBRARY}
-    ${CUDA_nppicc_static_LIBRARY}
-    ${CUDA_nppig_static_LIBRARY})
-  list(APPEND DALI_EXCLUDES libnppicom_static.a
-    libnppicc_static.a
-    libnppig_static.a)
+  list(APPEND DALI_LIBS ${CUDA_nppicc_static_LIBRARY})
+  list(APPEND DALI_EXCLUDES libnppicc_static.a)
 endif()
 list(APPEND DALI_LIBS ${CUDA_nppc_static_LIBRARY})
 list(APPEND DALI_EXCLUDES libnppc_static.a)


### PR DESCRIPTION
- removes the dependency on nppicom and nppig as they these functionalities
  are no longer used by DALI

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- remove unused npp dependencies

#### What happened in this PR?
 - removes the dependency on nppicom and nppig as they these functionalities are no longer used by DALI
 - tested in CI

**JIRA TASK**: [NA]