### PR TITLE
Fix scalar batch handling in arithmetic ops

### DIFF
--- a/dali/operators/expressions/arithmetic_meta.h
+++ b/dali/operators/expressions/arithmetic_meta.h
@@ -429,7 +429,7 @@ inline ArithmeticOp NameToOp(const std::string &op_name) {
 }
 
 inline bool IsScalarLike(const TensorListShape<> &shape) {
-  return shape.num_samples() == 1 && shape.num_elements() == 1;
+  return is_uniform(shape) && shape.sample_dim() == 1 && shape.tensor_shape_span(0)[0] == 1;
 }
 
 }  // namespace dali

--- a/dali/operators/expressions/arithmetic_test.cc
+++ b/dali/operators/expressions/arithmetic_test.cc
@@ -144,7 +144,7 @@ template <typename T>
 T GenerateData(int sample, int element) {
   static std::mt19937 gen(42);
   auto result = uniform_distribution<T>(-1024, 1024)(gen);
-  return result == 0 ? 1 : result; // we do not want to divide by 0 so we discard those results
+  return result == 0 ? 1 : result;  // we do not want to divide by 0 so we discard those results
 }
 
 template <typename T>

--- a/dali/operators/expressions/arithmetic_test.cc
+++ b/dali/operators/expressions/arithmetic_test.cc
@@ -19,11 +19,12 @@
 #include <vector>
 
 #include "dali/core/static_switch.h"
-#include "dali/pipeline/data/types.h"
 #include "dali/operators/expressions/arithmetic.h"
 #include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/pipeline/data/types.h"
 #include "dali/pipeline/pipeline.h"
 #include "dali/test/dali_operator_test.h"
+#include "dali/test/tensor_test_utils.h"
 
 namespace dali {
 
@@ -140,19 +141,10 @@ TEST(ArithmeticOpsTest, GetTiledCover) {
 namespace {
 
 template <typename T>
-std::enable_if_t<std::is_integral<T>::value, T> GenerateData(int sample, int element) {
+T GenerateData(int sample, int element) {
   static std::mt19937 gen(42);
-  std::uniform_int_distribution<> dis(-1024, 1024);
-  auto result = dis(gen);
-  return result == 0 ? 1 : result;
-}
-
-template <typename T>
-std::enable_if_t<!std::is_integral<T>::value, T> GenerateData(int sample, int element) {
-  static std::mt19937 gen(42);
-  std::uniform_real_distribution<float> dis(-1024, 1024);
-  auto result = dis(gen);
-  return result == 0.f ? 1.f : result;
+  auto result = uniform_distribution<T>(-1024, 1024)(gen);
+  return result == 0 ? 1 : result; // we do not want to divide by 0 so we discard those results
 }
 
 template <typename T>

--- a/dali/operators/expressions/arithmetic_test.cc
+++ b/dali/operators/expressions/arithmetic_test.cc
@@ -46,7 +46,7 @@ TEST(ArithmeticOpsTest, TreePropagation) {
   ws.AddInput(in[1]);
 
   auto result_type = PropagateTypes<CPUBackend>(expr_ref, ws);
-  auto result_shape = PropagateShapes<CPUBackend>(expr_ref, ws);
+  auto result_shape = PropagateShapes<CPUBackend>(expr_ref, ws, 2);
   auto result_layout = GetCommonLayout<CPUBackend>(expr_ref, ws);
   auto expected_shpe = TensorListShape<>{{1}, {2}};
   EXPECT_EQ(result_type, DALIDataType::DALI_INT32);
@@ -61,6 +61,24 @@ TEST(ArithmeticOpsTest, TreePropagation) {
   EXPECT_EQ(func[0].GetOutputDesc(), "FT:int16");
   EXPECT_EQ(func[1].GetNodeDesc(), "CC:int32");
   EXPECT_EQ(func[1].GetOutputDesc(), "CC:int32");
+}
+
+TEST(ArithmeticOpsTest, PropagateScalarLike) {
+  std::string expr_str = "sub(&0 $1:int32))";
+  auto expr = ParseExpressionString(expr_str);
+  auto &expr_ref = *expr;
+  HostWorkspace ws;
+  std::shared_ptr<TensorVector<CPUBackend>> in[1];
+  for (auto &ptr : in) {
+    ptr = std::make_shared<TensorVector<CPUBackend>>();
+    ptr->Resize({{1}, {1}});
+    ptr->SetLayout(TensorLayout("HW"));
+  }
+  ws.AddInput(in[0]);
+
+  auto result_shape = PropagateShapes<CPUBackend>(expr_ref, ws, 2);
+  auto expected_shpe = TensorListShape<>{{1}, {1}};
+  EXPECT_EQ(result_shape, expected_shpe);
 }
 
 TEST(ArithmeticOpsTest, TreePropagationError) {
@@ -81,7 +99,7 @@ TEST(ArithmeticOpsTest, TreePropagationError) {
   ws.AddInput(in[1]);
   ws.AddInput(in[2]);
 
-  ASSERT_THROW(PropagateShapes<CPUBackend>(expr_ref, ws), std::runtime_error);
+  ASSERT_THROW(PropagateShapes<CPUBackend>(expr_ref, ws, 2), std::runtime_error);
   ASSERT_THROW(GetCommonLayout<CPUBackend>(expr_ref, ws), std::runtime_error);
 }
 
@@ -119,6 +137,38 @@ TEST(ArithmeticOpsTest, GetTiledCover) {
   EXPECT_EQ(std::get<1>(result1), range1);
 }
 
+namespace {
+
+template <typename T>
+std::enable_if_t<std::is_integral<T>::value, T> GenerateData(int sample, int element) {
+  static std::mt19937 gen(42);
+  std::uniform_int_distribution<> dis(-1024, 1024);
+  auto result = dis(gen);
+  return result == 0 ? 1 : result;
+}
+
+template <typename T>
+std::enable_if_t<!std::is_integral<T>::value, T> GenerateData(int sample, int element) {
+  static std::mt19937 gen(42);
+  std::uniform_real_distribution<float> dis(-1024, 1024);
+  auto result = dis(gen);
+  return result == 0.f ? 1.f : result;
+}
+
+template <typename T>
+void FillBatch(TensorList<CPUBackend> &batch, const TensorListShape<> shape) {
+  batch.Resize(shape);
+  batch.set_type(TypeInfo::Create<T>());
+  for (int i = 0; i < shape.num_samples(); i++) {
+    auto *t = batch.template mutable_tensor<T>(i);
+    for (int j = 0; j < shape[i].num_elements(); j++) {
+      t[j] = GenerateData<T>(i, j);
+    }
+  }
+}
+
+}  // namespace
+
 template <typename T>
 using bin_op_pointer = T (*)(T, T);
 
@@ -153,14 +203,7 @@ class BinaryArithmeticOpsTest
 
     TensorList<CPUBackend> batch[2];
     for (auto &b : batch) {
-      b.Resize(shape);
-      b.set_type(TypeInfo::Create<T>());
-      for (int i = 0; i < shape.num_samples(); i++) {
-        auto *t = b.template mutable_tensor<T>(i);
-        for (int j = 0; j < shape[i].num_elements(); j++) {
-          t[j] = GenerateData<T>(i, j);
-        }
-      }
+      FillBatch<T>(b, shape);
     }
 
     pipe.SetExternalInput("data0", batch[0]);
@@ -187,28 +230,11 @@ class BinaryArithmeticOpsTest
 
   void TestFunction() {
     TensorListShape<> shape0{{32000}, {2345}, {212}, {1}, {100}, {6400}, {8000}, {323},
-                                      {32000}, {2345}, {212}, {1}, {100}, {6400}, {8000}, {323}};
+                             {32000}, {2345}, {212}, {1}, {100}, {6400}, {8000}, {323}};
 
-    TensorListShape<> shape1{{1024, 768}, {4096, 1440}, {2435, 33},
-                                      {17, 696},   {42, 42},     {1, 1}};
+    TensorListShape<> shape1{{1024, 768}, {4096, 1440}, {2435, 33}, {17, 696}, {42, 42}, {1, 1}};
     TestFunction(shape0);
     TestFunction(shape1);
-  }
-
-  template <typename S>
-  std::enable_if_t<std::is_integral<S>::value, S> GenerateData(int sample, int element) {
-    static std::mt19937 gen(42);
-    std::uniform_int_distribution<> dis(-1024, 1024);
-    auto result = dis(gen);
-    return result == 0 ? 1 : result;
-  }
-
-  template <typename S>
-  std::enable_if_t<!std::is_integral<S>::value, S> GenerateData(int sample, int element) {
-    static std::mt19937 gen(42);
-    std::uniform_real_distribution<float> dis(-1024, 1024);
-    auto result = dis(gen);
-    return result == 0.f ? 1.f : result;
   }
 };
 
@@ -290,14 +316,7 @@ TEST(ArithmeticOpsTest, GenericPipeline) {
   pipe.Build(outputs);
 
   TensorList<CPUBackend> batch;
-  batch.Resize(uniform_list_shape(batch_size, {tensor_elements}));
-  batch.set_type(TypeInfo::Create<int32_t>());
-  for (int i = 0; i < batch_size; i++) {
-    auto *t = batch.mutable_tensor<int32_t>(i);
-    for (int j = 0; j < tensor_elements; j++) {
-      t[j] = i * tensor_elements + j;
-    }
-  }
+  FillBatch<int>(batch, uniform_list_shape(batch_size, {tensor_elements}));
 
   pipe.SetExternalInput("data0", batch);
   pipe.SetExternalInput("data1", batch);
@@ -305,14 +324,74 @@ TEST(ArithmeticOpsTest, GenericPipeline) {
   pipe.RunGPU();
   DeviceWorkspace ws;
   pipe.Outputs(&ws);
+
+  const auto *data = batch.data<int>();
+
   auto *result = ws.OutputRef<CPUBackend>(0).data<int32_t>();
   auto *result2 = ws.OutputRef<GPUBackend>(1).data<int32_t>();
   vector<int32_t> result2_cpu(batch_size * tensor_elements);
 
   MemCopy(result2_cpu.data(), result2, batch_size * tensor_elements * sizeof(int));
   for (int i = 0; i < batch_size * tensor_elements; i++) {
-    EXPECT_EQ(result[i], i + i);
-    EXPECT_EQ(result2_cpu[i], i * (i + i));
+    EXPECT_EQ(result[i], data[i] + data[i]);
+    EXPECT_EQ(result2_cpu[i], data[i] * (data[i] + data[i]));
+  }
+}
+
+TEST(ArithmeticOpsTest, FdivPipeline) {
+  constexpr int batch_size = 16;
+  constexpr int num_threads = 4;
+  constexpr int tensor_elements = 16;
+  Pipeline pipe(batch_size, num_threads, 0);
+
+  pipe.AddExternalInput("data0");
+  pipe.AddExternalInput("data1");
+
+  pipe.AddOperator(OpSpec("ArithmeticGenericOp")
+                       .AddArg("device", "cpu")
+                       .AddArg("expression_desc", "fdiv(&0 &1)")
+                       .AddInput("data0", "cpu")
+                       .AddInput("data1", "cpu")
+                       .AddOutput("result0", "cpu"),
+                   "arithm_cpu");
+
+  pipe.AddOperator(OpSpec("ArithmeticGenericOp")
+                       .AddArg("device", "gpu")
+                       .AddArg("expression_desc", "fdiv(&0 &1)")
+                       .AddInput("data0", "gpu")
+                       .AddInput("data1", "gpu")
+                       .AddOutput("result1", "gpu"),
+                   "arithm_gpu");
+
+  vector<std::pair<string, string>> outputs = {{"result0", "cpu"}, {"result1", "gpu"}};
+
+  pipe.Build(outputs);
+
+  TensorList<CPUBackend> batch[2];
+  for (auto &b : batch) {
+    FillBatch<int>(b, uniform_list_shape(batch_size, {tensor_elements}));
+  }
+
+  pipe.SetExternalInput("data0", batch[0]);
+  pipe.SetExternalInput("data1", batch[1]);
+  pipe.RunCPU();
+  pipe.RunGPU();
+  DeviceWorkspace ws;
+  pipe.Outputs(&ws);
+  ASSERT_EQ(ws.OutputRef<CPUBackend>(0).type(), TypeInfo::Create<float>());
+  ASSERT_EQ(ws.OutputRef<GPUBackend>(1).type(), TypeInfo::Create<float>());
+
+  const auto *data0 = batch[0].data<int>();
+  const auto *data1 = batch[1].data<int>();
+
+  auto *result0 = ws.OutputRef<CPUBackend>(0).data<float>();
+  auto *result1 = ws.OutputRef<GPUBackend>(1).data<float>();
+  vector<float> result1_cpu(batch_size * tensor_elements);
+
+  MemCopy(result1_cpu.data(), result1, batch_size * tensor_elements * sizeof(float));
+  for (int i = 0; i < batch_size * tensor_elements; i++) {
+    EXPECT_EQ(result0[i], static_cast<float>(data0[i]) / data1[i]);
+    EXPECT_EQ(result1_cpu[i], static_cast<float>(data0[i]) / data1[i]);
   }
 }
 
@@ -347,27 +426,180 @@ TEST(ArithmeticOpsTest, ConstantsPipeline) {
   pipe.Build(outputs);
 
   TensorList<CPUBackend> batch;
-  batch.Resize(uniform_list_shape(batch_size, {tensor_elements}));
-  batch.set_type(TypeInfo::Create<int32_t>());
-  for (int i = 0; i < batch_size; i++) {
-    auto *t = batch.mutable_tensor<int32_t>(i);
-    for (int j = 0; j < tensor_elements; j++) {
-      t[j] = i * tensor_elements + j;
-    }
-  }
+  FillBatch<int>(batch, uniform_list_shape(batch_size, {tensor_elements}));
 
   pipe.SetExternalInput("data0", batch);
   pipe.RunCPU();
   pipe.RunGPU();
   DeviceWorkspace ws;
   pipe.Outputs(&ws);
+
+  const auto *data = batch.data<int>();
   auto *result0 = ws.OutputRef<CPUBackend>(0).data<int32_t>();
   auto *result1 = ws.OutputRef<CPUBackend>(1).data<float>();
 
   for (int i = 0; i < batch_size * tensor_elements; i++) {
-    EXPECT_EQ(result0[i], i + magic_int);
-    EXPECT_EQ(result1[i], i * magic_float);
+    EXPECT_EQ(result0[i], data[i] + magic_int);
+    EXPECT_EQ(result1[i], data[i] * magic_float);
   }
 }
 
+using shape_sequence = std::vector<std::array<TensorListShape<>, 3>>;
+
+int GetBatchSize(const shape_sequence &seq) {
+  return seq[0][0].num_samples();
+}
+
+class ArithmeticOpsScalarTest :  public ::testing::TestWithParam<shape_sequence> {
+ public:
+  void Run() {
+    constexpr int num_threads = 4;
+    auto shape_seq = GetParam();
+    int batch_size = GetBatchSize(shape_seq);
+    Pipeline pipe(batch_size, num_threads, 0);
+
+    pipe.AddExternalInput("data0");
+    pipe.AddExternalInput("data1");
+
+    pipe.AddOperator(OpSpec("ArithmeticGenericOp")
+                        .AddArg("device", "cpu")
+                        .AddArg("expression_desc", "add(&0 &1)")
+                        .AddInput("data0", "cpu")
+                        .AddInput("data1", "cpu")
+                        .AddOutput("result0", "cpu"),
+                    "arithm_cpu");
+
+    pipe.AddOperator(OpSpec("ArithmeticGenericOp")
+                        .AddArg("device", "gpu")
+                        .AddArg("expression_desc", "add(&0 &1)")
+                        .AddInput("data0", "gpu")
+                        .AddInput("data1", "gpu")
+                        .AddOutput("result1", "gpu"),
+                    "arithm_gpu");
+
+    vector<std::pair<string, string>> outputs = {{"result0", "cpu"}, {"result1", "gpu"}};
+
+    pipe.Build(outputs);
+
+    for (const auto &s : shape_seq) {
+      const auto &result_shape = s[2];
+
+      TensorList<CPUBackend> batch[2];
+      for (int i = 0; i < 2; i++) {
+        FillBatch<int>(batch[i], s[i]);
+      }
+
+      pipe.SetExternalInput("data0", batch[0]);
+      pipe.SetExternalInput("data1", batch[1]);
+      pipe.RunCPU();
+      pipe.RunGPU();
+      DeviceWorkspace ws;
+      pipe.Outputs(&ws);
+
+
+      const auto *data0 = batch[0].data<int>();
+      const auto *data1 = batch[1].data<int>();
+
+      const auto *result0 = ws.OutputRef<CPUBackend>(0).data<int>();
+      const auto *result1 = ws.OutputRef<GPUBackend>(1).data<int>();
+
+      ASSERT_EQ(ws.OutputRef<CPUBackend>(0).shape(), result_shape);
+      ASSERT_EQ(ws.OutputRef<GPUBackend>(1).shape(), result_shape);
+
+      vector<int> result1_cpu(result_shape.num_elements());
+
+      MemCopy(result1_cpu.data(), result1, result_shape.num_elements() * sizeof(int));
+
+      int64_t offset_out = 0;
+      int64_t offset_in[2] = {0, 0};
+      for (int tensor_idx = 0; tensor_idx < result_shape.num_samples(); tensor_idx++) {
+        for (int j = 0; j < result_shape[tensor_idx].num_elements(); j++) {
+          auto is_scalar = [] (auto &shape, int tensor_idx) {
+            return shape[tensor_idx] == TensorShape<>{1};
+          };
+          int expected = data0[offset_in[0] + (is_scalar(s[0], tensor_idx) ? 0 : j)] +
+                         data1[offset_in[1] + (is_scalar(s[1], tensor_idx) ? 0 : j)];
+
+          ASSERT_EQ(result0[offset_out + j], expected)
+              << " difference at sample: " << tensor_idx << ", element: " << j;
+          ASSERT_EQ(result1_cpu[offset_out + j], expected)
+              << " difference at sample: " << tensor_idx << ", element: " << j;
+        }
+        offset_out += result_shape[tensor_idx].num_elements();
+        for (int in_idx = 0; in_idx < 2; in_idx++) {
+          offset_in[in_idx] += s[in_idx][tensor_idx].num_elements();
+        }
+      }
+    }
+  }
+};
+
+TEST_P(ArithmeticOpsScalarTest, TensorScalarMix) {
+  this->Run();
+}
+
+namespace {
+
+std::array<TensorListShape<>, 3> GetShapesForSequence(int batch_size, int left_elems,
+                                                      int right_elems) {
+  return {uniform_list_shape(batch_size, {left_elems}),
+          uniform_list_shape(batch_size, {right_elems}),
+          uniform_list_shape(batch_size, {std::max(left_elems, right_elems)})};
+}
+
+/**
+ * @brief Return a vector of shape_sequences
+ */
+std::vector<shape_sequence> GetTensorScalarTensorSequences(int batch_size) {
+  auto seq0 = shape_sequence{
+    GetShapesForSequence(batch_size, 5, 5),
+    GetShapesForSequence(batch_size, 1, 1),
+    GetShapesForSequence(batch_size, 6, 6),
+  };
+
+  auto seq1 = shape_sequence{
+    GetShapesForSequence(batch_size, 5, 5),
+    GetShapesForSequence(batch_size, 1, 5),
+    GetShapesForSequence(batch_size, 5, 1),
+    GetShapesForSequence(batch_size, 1, 1),
+    GetShapesForSequence(batch_size, 6, 6),
+  };
+
+  auto seq2 = shape_sequence{
+    GetShapesForSequence(batch_size, 5, 5),
+    GetShapesForSequence(batch_size, 1, 5),
+    GetShapesForSequence(batch_size, 5, 1),
+    GetShapesForSequence(batch_size, 1, 1),
+    GetShapesForSequence(batch_size, 6, 6),
+  };
+
+  auto seq3 = shape_sequence{
+    GetShapesForSequence(batch_size, 5, 5),
+    GetShapesForSequence(batch_size, 1, 5),
+    GetShapesForSequence(batch_size, 1, 1),
+    GetShapesForSequence(batch_size, 5, 1),
+    GetShapesForSequence(batch_size, 6, 6),
+  };
+
+  auto seq4 = shape_sequence{
+    GetShapesForSequence(batch_size, 5, 5),
+    GetShapesForSequence(batch_size, 5, 1),
+    GetShapesForSequence(batch_size, 1, 1),
+    GetShapesForSequence(batch_size, 1, 5),
+    GetShapesForSequence(batch_size, 6, 6),
+  };
+  return {seq0, seq1, seq2, seq3, seq4};
+}
+
+}  // namespace
+
+INSTANTIATE_TEST_SUITE_P(TensorScalarTensorBatch5,
+                         ArithmeticOpsScalarTest,
+                         ::testing::ValuesIn(GetTensorScalarTensorSequences(5)));
+
+INSTANTIATE_TEST_SUITE_P(TensorScalarTensorBatch1,
+                         ArithmeticOpsScalarTest,
+                         ::testing::ValuesIn(GetTensorScalarTensorSequences(1)));
+
 }  // namespace dali
+

--- a/dali/operators/expressions/expression_tree.h
+++ b/dali/operators/expressions/expression_tree.h
@@ -221,6 +221,15 @@ class ExprConstant : public ExprNode {
  */
 DLL_PUBLIC std::unique_ptr<ExprNode> ParseExpressionString(const std::string &expr);
 
+/**
+ * @brief Scalar-like nodes are the Constant nodes and Tensor nodes that consist of batch of
+ * scalars.
+ */
+inline bool IsScalarLike(const ExprNode &node) {
+  return node.GetNodeType() == NodeType::Constant ||
+         (node.GetNodeType() == NodeType::Tensor && IsScalarLike(node.GetShape()));
+}
+
 }  // namespace dali
 
 #endif  // DALI_OPERATORS_EXPRESSIONS_EXPRESSION_TREE_H_


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- It fixes a bug when a 1-element batch of shape {1} was treated as a scalar input. 

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
Adjust test for checking if the Tensor should be considered a scalar - uniform shape of 1-dim scalar elements. 
Allow Scalar batch to be broadcasted in the operation properly - no offset in tiles for scalar-like data, same code-path as constants.
Return shape is always a batch - fixed for Constant op Scalar inputs.
 - What was changed, added, removed?
Add C++ unit tests for Scalar Batch. - Test if Pipeline behaves properly when switching between scalar and non-scalar inputs.
Python test was extended to cover Scalar inputs, size of some of the tests was reduced.
 - What is most important part that reviewers should focus on?
Checking for scalar-like inputs, choosing the ExprImpl for it, preparing the tiles.
 - Was this PR tested? How?
CI, notebook
 - Were docs and examples updated, if necessary?
The new version of notebook will be updated.

**JIRA TASK**: [DALI-XXXX]