### PR TITLE
Add favicon to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,6 +139,12 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# Download favicon and set it (the variable `html_favicon`) for this project.
+# It must be relative path.
+favicon_rel_path = "nvidia.ico"
+subprocess.call(["wget", "-O", favicon_rel_path, "https://docs.nvidia.com/images/nvidia.ico"])
+html_favicon = favicon_rel_path
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Because our docs look dull without favicon.

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
The docs building script download the favicon from the nvidia.docs site and puts it in the sphinx generated docs. Sphinx setup require relative path to file starting from position of conf.py. I don't want to add a copyrighted image to the repo, so I just download it when building docs.
 - What was changed, added, removed?
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
 - Were docs and examples updated, if necessary?
Yes

**JIRA TASK**: [DALI-XXXX]