### PR TITLE
Add polygons mask support to COCOReader

### DIFF
--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -48,7 +48,7 @@ For a given sample, the polygons are represented by two tensors:
 One mask can have one or more `masks_meta` having the same `mask_idx`, which means that the mask for that given
 index consists of several polygons).
 `start_idx` indicates the index of the first coords in `masks_coords`.
-Skip `is_crowd=1` annotations.)code",
+Currently skips objects with `iscrowd=1` annotations (RLE masks, not suitable for instance segmentation).)code",
       false)
   .AddOptionalArg("skip_empty",
       R"code(If true, reader will skip samples with no object instances in them)code",

--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -39,6 +39,17 @@ Tensor (`m` * `[x, y, w, h] or `m` * [left, top, right, bottom]`) and labels as 
   .AddOptionalArg("ltrb",
       R"code(If true, bboxes are returned as [left, top, right, bottom], else [x, y, width, height].)code",
       false)
+  .AddOptionalArg("masks",
+      R"code(If true, segmentation masks are read and returned as polygons.
+Each mask can be one or more polygons. A polygon is a list of points (2 floats).
+For a given sample, the polygons are represented by two tensors:
+  `masks_meta` -> list of tuples (mask_idx, start_idx, count)
+  `masks_coords`-> list of (x,y) coordinates
+One mask can have one or more `masks_meta` having the same `mask_idx`, which means that the mask for that given
+index consists of several polygons).
+`start_idx` indicates the index of the first coords in `masks_coords`.
+Skip `is_crowd=1` annotations.)code",
+      false)
   .AddOptionalArg("skip_empty",
       R"code(If true, reader will skip samples with no object instances in them)code",
       false)
@@ -65,7 +76,8 @@ object will be skipped during reading. It is represented as absolute value.)code
     "Path to directory for saving meta files containing preprocessed COCO annotations.",
     std::string())
   .AdditionalOutputsFn([](const OpSpec& spec) {
-    return static_cast<int>(spec.GetArgument<bool>("save_img_ids"));
+    return static_cast<int>(spec.GetArgument<bool>("masks")) * 2
+           + static_cast<int>(spec.GetArgument<bool>("save_img_ids"));
   })
   .AddParent("LoaderBase");
 

--- a/dali/operators/reader/coco_reader_op.h
+++ b/dali/operators/reader/coco_reader_op.h
@@ -44,6 +44,7 @@ class COCOReader : public DataReader<CPUBackend, ImageLabelWrapper> {
       counts_,
       masks_meta_,
       mask_coords_,
+      read_masks_,
       save_img_ids_,
       original_ids_,
       shuffle_after_epoch);

--- a/dali/operators/reader/loader/coco_loader.h
+++ b/dali/operators/reader/loader/coco_loader.h
@@ -45,6 +45,7 @@ class CocoLoader : public FileLoader {
     std::vector<int> &counts,
     std::vector<std::vector<int> > &masks_meta,
     std::vector<std::vector<float> > &masks_coords,
+    bool read_masks,
     bool save_img_ids,
     std::vector<int> &original_ids,
     bool shuffle_after_epoch = false) :
@@ -57,6 +58,7 @@ class CocoLoader : public FileLoader {
       counts_(counts),
       masks_meta_(masks_meta),
       masks_coords_(masks_coords),
+      read_masks_(read_masks),
       save_img_ids_(save_img_ids),
       original_ids_(original_ids) {}
 
@@ -98,6 +100,7 @@ class CocoLoader : public FileLoader {
   std::vector<std::vector<int> > &masks_meta_;
   std::vector<std::vector<float> > &masks_coords_;
 
+  bool read_masks_;
   bool save_img_ids_;
   std::vector<int> &original_ids_;
 };

--- a/dali/operators/reader/loader/coco_loader.h
+++ b/dali/operators/reader/loader/coco_loader.h
@@ -43,6 +43,8 @@ class CocoLoader : public FileLoader {
     std::vector<float> &boxes,
     std::vector<int> &labels,
     std::vector<int> &counts,
+    std::vector<std::vector<int> > &masks_meta,
+    std::vector<std::vector<float> > &masks_coords,
     bool save_img_ids,
     std::vector<int> &original_ids,
     bool shuffle_after_epoch = false) :
@@ -53,6 +55,8 @@ class CocoLoader : public FileLoader {
       boxes_(boxes),
       labels_(labels),
       counts_(counts),
+      masks_meta_(masks_meta),
+      masks_coords_(masks_coords),
       save_img_ids_(save_img_ids),
       original_ids_(original_ids) {}
 
@@ -88,6 +92,11 @@ class CocoLoader : public FileLoader {
   std::vector<float> &boxes_;
   std::vector<int> &labels_;
   std::vector<int> &counts_;
+
+  // mask_meta: (mask_idx, offset, size)
+  // mask_coords: (all polygons concatenated )
+  std::vector<std::vector<int> > &masks_meta_;
+  std::vector<std::vector<float> > &masks_coords_;
 
   bool save_img_ids_;
   std::vector<int> &original_ids_;


### PR DESCRIPTION
#### Why we need this PR?
We need the support of polygons masks (used for instance segmentation) in the existing `COCOReader`, which only supports the object detection part of [COCO-style datasets](http://cocodataset.org/#format-data). 

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
Add segmentation support in the RapidJSON-based parser. 
Optional argument added to `COCOReader`, `masks` that add two additional outputs to the operator (`masks_meta` and `masks_coords`, described in the operator docstring).
 - What was changed, added, removed?
Changed: `COCOReader`, `COCOLoader` and their tests.
 - Was this PR tested? How?
Tests case added in the existing test suite and DALI_EXTRA accordingly updated for polygons masks (https://github.com/NVIDIA/DALI_extra/pull/31).
 - Were docs and examples updated, if necessary?
Op docstring explaining the internal polygons mask format in DALI.