### PR TITLE
Fix removal of device_id initialization in OF

### DIFF
--- a/dali/operators/optical_flow/optical_flow.h
+++ b/dali/operators/optical_flow/optical_flow.h
@@ -64,7 +64,8 @@ class OpticalFlow : public Operator<Backend> {
                   detail::kEnableExternalHintsArgName)),
           optical_flow_(std::unique_ptr<optical_flow::OpticalFlowAdapter<ComputeBackend>>(
                   new optical_flow::OpticalFlowStub<ComputeBackend>(of_params_))),
-          image_type_(spec.GetArgument<decltype(this->image_type_)>(detail::kImageTypeArgName)) {
+          image_type_(spec.GetArgument<decltype(this->image_type_)>(detail::kImageTypeArgName)),
+          device_id_(spec.GetArgument<int>("device_id")) {
     // In case external hints are enabled, we need 2 inputs
     DALI_ENFORCE((enable_external_hints_ && spec.NumInput() == 2) || !enable_external_hints_,
                  "Incorrect number of inputs. Expected: 2, Obtained: " +


### PR DESCRIPTION
- device_id initialization was accidentally removed when
  static analysis problems were fixed

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- It fixes an accidentally removal of device_id initialization in OF

#### What happened in this PR?
 - device_id initialization was accidentally removed when
  static analysis problems were fixed
 - testedin CI

**JIRA TASK**: [NA]