### PR TITLE
Make thread pinning optional in the mixed ImageDecoder

### DIFF
--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -46,6 +46,9 @@ is encountered and internal buffer needs to be reallocated to decode it.)code",
 This parameter helps to avoid reallocation in nvJPEG whenever a bigger image
 is encountered and internal buffer needs to be reallocated to decode it.)code",
       8*1024*1024)  // based on ImageNet heuristics (8MB)
+  .AddOptionalArg("affine",
+      R"code(**`mixed` backend only** If internal threads should be affined to CPU cores)code",
+      true)
   .AddOptionalArg("split_stages",
       R"code(**`mixed` backend only** Split into separated CPU stage and GPU stage operators)code",
       false)

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -61,7 +61,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     device_id_(spec.GetArgument<int>("device_id")),
     thread_pool_(num_threads_,
                  spec.GetArgument<int>("device_id"),
-                 true /* pin threads */) {
+                 spec.GetArgument<bool>("affine") /* pin threads */) {
     NVJPEG_CALL(nvjpegCreateSimple(&handle_));
 
     size_t device_memory_padding = spec.GetArgument<Index>("device_memory_padding");


### PR DESCRIPTION
- in some architectures nvml nvmlDeviceGetCpuAffinity artificially
  limits available CPUs to given GPU while other CPUs may suit as well.
  This PR allows to skip pining and just relay on OS to put ImageDecoder
  thread on CPU cores

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- makes thread pinning optional in the mixed ImageDecoder

#### What happened in this PR?
 - in some architectures nvml nvmlDeviceGetCpuAffinity artificially limits available CPUs to given GPU while other CPUs may suit as well. This PR allows to skip pining and just relay on OS to put ImageDecoder thread on CPU cores
 - tested in CI

**JIRA TASK**: [NA]