### PR TITLE
Utilize libcudart.so version to detect the CUDA toolkit version

### DIFF
--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -7,7 +7,7 @@ do_once() {
 
     NUM_GPUS=$(nvidia-smi -L | wc -l)
 
-    CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
+    CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1\2/')
     # from 1.13.1 CUDA 10 is supported but not CUDA 9
     if [ "${CUDA_VERSION}" -ge "100" ]; then
         pip install tensorflow-gpu==1.13.1

--- a/qa/TL1_tensorflow_plugin/test.sh
+++ b/qa/TL1_tensorflow_plugin/test.sh
@@ -4,7 +4,7 @@ pip_packages="nose"
 target_dir=./dali/test/python
 
 do_once() {
-    USE_CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1/')
+    USE_CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1/')
     if [[ "$USE_CUDA_VERSION" = "10" ]]; then
         export TENSORFLOW_VERSIONS="1.13.1 1.14 1.15 2.0"
     else

--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
+CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1\2/')
 CUDA_VERSION=${CUDA_VERSION:-90}
 
 if [ -n "$gather_pip_packages" ]


### PR DESCRIPTION
- Utilize libcudart.so version to detect the CUDA toolkit version
- replaces usage of version.txt located in /usr/local/cuda to libcudart.so version itself

#### Why we need this PR?
- replaces usage of version.txt located in /usr/local/cuda to libcudart.so version itself

#### What happened in this PR?
 - replaces usage of version.txt located in /usr/local/cuda to libcudart.so version itself
 - tested on CI

**JIRA TASK**: [NA]