### PR TITLE
Fix start index function

### DIFF
--- a/dali/operators/reader/loader/loader.cc
+++ b/dali/operators/reader/loader/loader.cc
@@ -54,12 +54,7 @@ with the shard size.)code", false);
 size_t start_index(const size_t shard_id,
                    const size_t shard_num,
                    const size_t size) {
-  const size_t remainder = size % shard_num;
-  if (shard_id < remainder) {
-    return (size / shard_num) * shard_id + shard_id;
-  } else {
-    return (size / shard_num) * shard_id + remainder;
-  }
+  return size * shard_id / shard_num;
 }
 
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
Fixes crash when number of samples is smaller than number of shards

#### What happened in this PR?
Modified start_index function to allow for shard_num to be smaller than the dataset size

**JIRA TASK**: [DALI-1163]