### PR TITLE
Additional deps for AudioDecoder

### DIFF
--- a/dali/python/bundle-wheel.sh
+++ b/dali/python/bundle-wheel.sh
@@ -95,6 +95,9 @@ DEPS_LIST=(
     "/usr/local/lib/libavutil.so.56"
     "/usr/local/lib/libtiff.so.5"
     "/usr/local/lib/libsndfile.so.1"
+    "/usr/local/lib/libFLAC.so.8"
+    "/usr/local/lib/libogg.so.0"
+    "/usr/local/lib/libvorbis.so.0"
 )
 
 DEPS_SONAME=(
@@ -105,6 +108,9 @@ DEPS_SONAME=(
     "libavutil.so.56"
     "libtiff.so.5"
     "libsndfile.so.1"
+    "libFLAC.so.8"
+    "libogg.so.0"
+    "libvorbis.so.0"
 )
 
 TMPDIR=$(mktemp -d)

--- a/docker/Dockerfile.build.aarch64-linux
+++ b/docker/Dockerfile.build.aarch64-linux
@@ -135,6 +135,43 @@ RUN curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | 
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
     rm -rf /opencv-${OPENCV_VERSION}
 
+# flac
+#TODO change to https://developer.nvidia.com...
+RUN FLAC_VERSION=1.3.3 && cd /tmp                                                    && \
+    wget https://ftp.osuosl.org/pub/xiph/releases/flac/flac-${FLAC_VERSION}.tar.xz   && \
+    tar -xf flac-$FLAC_VERSION.tar.xz                                                && \
+    rm flac-$FLAC_VERSION.tar.xz                                                     && \
+    cd flac-$FLAC_VERSION                                                            && \
+    ./configure CFLAGS="-fPIC" CXXFLAGS="-fPIC" CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ \
+                                             --host=aarch64-unknown-linux-gnu --prefix=/usr/aarch64-linux-gnu/ && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
+    cd /tmp && rm -rf flac-$FLAC_VERSION
+
+# libogg
+#TODO change to https://developer.nvidia.com...
+RUN OGG_VERSION=1.3.4 && cd /tmp                                                     && \
+    wget http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz         && \
+    tar -xf libogg-$OGG_VERSION.tar.gz                                               && \
+    rm libogg-$OGG_VERSION.tar.gz                                                    && \
+    cd libogg-$OGG_VERSION                                                           && \
+    ./configure CFLAGS="-fPIC" CXXFLAGS="-fPIC" CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ \
+                                             --host=aarch64-unknown-linux-gnu --prefix=/usr/aarch64-linux-gnu/ && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
+    cd /tmp && rm -rf libogg-$OGG_VERSION
+    
+# libvorbis
+# Install after libogg
+#TODO change to https://developer.nvidia.com...
+RUN VORBIS_VERSION=1.3.6 && cd /tmp                                                   && \
+    wget http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.xz && \
+    tar -xf libvorbis-$VORBIS_VERSION.tar.xz                                          && \
+    rm libvorbis-$VORBIS_VERSION.tar.xz                                               && \
+    cd libvorbis-$VORBIS_VERSION                                                      && \
+    ./configure CFLAGS="-fPIC" CXXFLAGS="-fPIC" CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ \
+                                             --host=aarch64-unknown-linux-gnu --prefix=/usr/aarch64-linux-gnu/ && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install  && \
+    cd /tmp && rm -rf libvorbis-$VORBIS_VERSION
+
 # libsnd
 RUN LIBSND_VERSION=1.0.28 && cd /tmp                                                                           && \
     wget https://developer.download.nvidia.com/compute/redist/nvidia-dali/libsndfile-${LIBSND_VERSION}.tar.gz  && \

--- a/docker/Dockerfile.build.aarch64-linux
+++ b/docker/Dockerfile.build.aarch64-linux
@@ -136,7 +136,6 @@ RUN curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | 
     rm -rf /opencv-${OPENCV_VERSION}
 
 # flac
-#TODO change to https://developer.nvidia.com...
 RUN FLAC_VERSION=1.3.3 && cd /tmp                                                    && \
     wget https://ftp.osuosl.org/pub/xiph/releases/flac/flac-${FLAC_VERSION}.tar.xz   && \
     tar -xf flac-$FLAC_VERSION.tar.xz                                                && \
@@ -148,7 +147,6 @@ RUN FLAC_VERSION=1.3.3 && cd /tmp                                               
     cd /tmp && rm -rf flac-$FLAC_VERSION
 
 # libogg
-#TODO change to https://developer.nvidia.com...
 RUN OGG_VERSION=1.3.4 && cd /tmp                                                     && \
     wget http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz         && \
     tar -xf libogg-$OGG_VERSION.tar.gz                                               && \
@@ -161,7 +159,6 @@ RUN OGG_VERSION=1.3.4 && cd /tmp                                                
     
 # libvorbis
 # Install after libogg
-#TODO change to https://developer.nvidia.com...
 RUN VORBIS_VERSION=1.3.6 && cd /tmp                                                   && \
     wget http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.xz && \
     tar -xf libvorbis-$VORBIS_VERSION.tar.xz                                          && \

--- a/docker/Dockerfile.build.aarch64-qnx
+++ b/docker/Dockerfile.build.aarch64-qnx
@@ -154,6 +154,46 @@ RUN curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | 
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install && \
     rm -rf /opencv-${OPENCV_VERSION}
 
+# flac
+#TODO change to https://developer.nvidia.com...
+RUN FLAC_VERSION=1.3.3 && cd /tmp                                                    && \
+    wget https://ftp.osuosl.org/pub/xiph/releases/flac/flac-${FLAC_VERSION}.tar.xz   && \
+    tar -xf flac-$FLAC_VERSION.tar.xz                                                && \
+    rm flac-$FLAC_VERSION.tar.xz                                                     && \
+    cd flac-$FLAC_VERSION                                                            && \
+    ./configure CFLAGS="-fPIC" CXXFLAGS="-fPIC" CC=aarch64-unknown-nto-qnx7.0.0-gcc \
+           CXX=aarch64-unknown-nto-qnx7.0.0-g++ --host=aarch64-unknown-nto-qnx7.0.0 \
+           --prefix=/usr/aarch64-unknown-nto-qnx/aarch64le                           && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install                && \
+    cd /tmp && rm -rf flac-$FLAC_VERSION
+
+# libogg
+#TODO change to https://developer.nvidia.com...
+RUN OGG_VERSION=1.3.4 && cd /tmp                                                     && \
+    wget http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz         && \
+    tar -xf libogg-$OGG_VERSION.tar.gz                                               && \
+    rm libogg-$OGG_VERSION.tar.gz                                                    && \
+    cd libogg-$OGG_VERSION                                                           && \
+    ./configure CFLAGS="-fPIC" CXXFLAGS="-fPIC" CC=aarch64-unknown-nto-qnx7.0.0-gcc \
+           CXX=aarch64-unknown-nto-qnx7.0.0-g++ --host=aarch64-unknown-nto-qnx7.0.0 \
+           --prefix=/usr/aarch64-unknown-nto-qnx/aarch64le                           && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install                && \
+    cd /tmp && rm -rf libogg-$OGG_VERSION
+    
+# libvorbis
+# Install after libogg
+#TODO change to https://developer.nvidia.com...
+RUN VORBIS_VERSION=1.3.6 && cd /tmp                                                   && \
+    wget http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.xz && \
+    tar -xf libvorbis-$VORBIS_VERSION.tar.xz                                          && \
+    rm libvorbis-$VORBIS_VERSION.tar.xz                                               && \
+    cd libvorbis-$VORBIS_VERSION                                                      && \
+    ./configure CFLAGS="-fPIC" CXXFLAGS="-fPIC" CC=aarch64-unknown-nto-qnx7.0.0-gcc \
+           CXX=aarch64-unknown-nto-qnx7.0.0-g++ --host=aarch64-unknown-nto-qnx7.0.0 \
+           --prefix=/usr/aarch64-unknown-nto-qnx/aarch64le                            && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install                 && \
+    cd /tmp && rm -rf libvorbis-$VORBIS_VERSION
+
 # libsnd
 RUN LIBSND_VERSION=1.0.28 && cd /tmp                                                                           && \
     wget https://developer.download.nvidia.com/compute/redist/nvidia-dali/libsndfile-${LIBSND_VERSION}.tar.gz  && \

--- a/docker/Dockerfile.build.aarch64-qnx
+++ b/docker/Dockerfile.build.aarch64-qnx
@@ -155,7 +155,6 @@ RUN curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | 
     rm -rf /opencv-${OPENCV_VERSION}
 
 # flac
-#TODO change to https://developer.nvidia.com...
 RUN FLAC_VERSION=1.3.3 && cd /tmp                                                    && \
     wget https://ftp.osuosl.org/pub/xiph/releases/flac/flac-${FLAC_VERSION}.tar.xz   && \
     tar -xf flac-$FLAC_VERSION.tar.xz                                                && \
@@ -168,7 +167,6 @@ RUN FLAC_VERSION=1.3.3 && cd /tmp                                               
     cd /tmp && rm -rf flac-$FLAC_VERSION
 
 # libogg
-#TODO change to https://developer.nvidia.com...
 RUN OGG_VERSION=1.3.4 && cd /tmp                                                     && \
     wget http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz         && \
     tar -xf libogg-$OGG_VERSION.tar.gz                                               && \
@@ -182,7 +180,6 @@ RUN OGG_VERSION=1.3.4 && cd /tmp                                                
     
 # libvorbis
 # Install after libogg
-#TODO change to https://developer.nvidia.com...
 RUN VORBIS_VERSION=1.3.6 && cd /tmp                                                   && \
     wget http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.xz && \
     tar -xf libvorbis-$VORBIS_VERSION.tar.xz                                          && \

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -119,6 +119,34 @@ RUN FFMPEG_VERSION=4.2.1 && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
     cd /tmp && rm -rf ffmpeg-$FFMPEG_VERSION
 
+# flac
+RUN FLAC_VERSION=1.3.3 && cd /tmp                                                    && \
+    wget https://ftp.osuosl.org/pub/xiph/releases/flac/flac-${FLAC_VERSION}.tar.xz   && \ #TODO: change to https://developer.download.nvidia.com
+    tar -xf flac-$FLAC_VERSION.tar.xz                                                && \
+    rm flac-$FLAC_VERSION.tar.xz                                                     && \
+    cd flac-$FLAC_VERSION                                                            && \
+    ./configure && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
+    cd /tmp && cd rm -rf flac-$FLAC_VERSION
+
+# libogg
+RUN OGG_VERSION=1.3.4 && cd /tmp                                                     && \
+    wget http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz         && \ #TODO: change to developers.nvidia.com...
+    tar -xf libogg-$OGG_VERSION.tar.xz                                               && \
+    rm libogg-$OGG_VERSION.tar.xz                                                    && \
+    cd libogg-$OGG_VERSION                                                           && \
+    ./configure && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
+    cd /tmp && cd rm -rf libogg-$OGG_VERSION
+    
+# libvorbis
+# Install after libogg
+RUN VORBIS_VERSION=1.3.6 && cd /tmp                                                   && \
+    wget http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.xz && \ #TODO: change to developers.nvidia.com...
+    tar -xf libvorbis-$VORBIS_VERSION                                                 && \
+    rm libvorbis-$VORBIS_VERSION.tar.xz                                               && \
+    cd libvorbis-$VORBIS_VERSION                                                      && \
+    ./configure && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install  && \
+    cd /tmp && cd rm -rf libvorbis-$VORBIS_VERSION
+
 # libsnd
 RUN LIBSND_VERSION=1.0.28 && cd /tmp                                                                           && \
     wget https://developer.download.nvidia.com/compute/redist/nvidia-dali/libsndfile-${LIBSND_VERSION}.tar.gz  && \

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -133,8 +133,8 @@ RUN FLAC_VERSION=1.3.3 && cd /tmp                                               
 #TODO change to https://developer.nvidia.com...
 RUN OGG_VERSION=1.3.4 && cd /tmp                                                     && \
     wget http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz         && \
-    tar -xf libogg-$OGG_VERSION.tar.xz                                               && \
-    rm libogg-$OGG_VERSION.tar.xz                                                    && \
+    tar -xf libogg-$OGG_VERSION.tar.gz                                               && \
+    rm libogg-$OGG_VERSION.tar.gz                                                    && \
     cd libogg-$OGG_VERSION                                                           && \
     ./configure && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
     cd /tmp && rm -rf libogg-$OGG_VERSION
@@ -144,7 +144,7 @@ RUN OGG_VERSION=1.3.4 && cd /tmp                                                
 #TODO change to https://developer.nvidia.com...
 RUN VORBIS_VERSION=1.3.6 && cd /tmp                                                   && \
     wget http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.xz && \
-    tar -xf libvorbis-$VORBIS_VERSION                                                 && \
+    tar -xf libvorbis-$VORBIS_VERSION.tar.xz                                          && \
     rm libvorbis-$VORBIS_VERSION.tar.xz                                               && \
     cd libvorbis-$VORBIS_VERSION                                                      && \
     ./configure && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install  && \

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -120,8 +120,9 @@ RUN FFMPEG_VERSION=4.2.1 && \
     cd /tmp && rm -rf ffmpeg-$FFMPEG_VERSION
 
 # flac
+#TODO change to https://developer.nvidia.com...
 RUN FLAC_VERSION=1.3.3 && cd /tmp                                                    && \
-    wget https://ftp.osuosl.org/pub/xiph/releases/flac/flac-${FLAC_VERSION}.tar.xz   && \ #TODO: change to https://developer.download.nvidia.com
+    wget https://ftp.osuosl.org/pub/xiph/releases/flac/flac-${FLAC_VERSION}.tar.xz   && \
     tar -xf flac-$FLAC_VERSION.tar.xz                                                && \
     rm flac-$FLAC_VERSION.tar.xz                                                     && \
     cd flac-$FLAC_VERSION                                                            && \
@@ -129,8 +130,9 @@ RUN FLAC_VERSION=1.3.3 && cd /tmp                                               
     cd /tmp && cd rm -rf flac-$FLAC_VERSION
 
 # libogg
+#TODO change to https://developer.nvidia.com...
 RUN OGG_VERSION=1.3.4 && cd /tmp                                                     && \
-    wget http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz         && \ #TODO: change to developers.nvidia.com...
+    wget http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz         && \
     tar -xf libogg-$OGG_VERSION.tar.xz                                               && \
     rm libogg-$OGG_VERSION.tar.xz                                                    && \
     cd libogg-$OGG_VERSION                                                           && \
@@ -139,8 +141,9 @@ RUN OGG_VERSION=1.3.4 && cd /tmp                                                
     
 # libvorbis
 # Install after libogg
+#TODO change to https://developer.nvidia.com...
 RUN VORBIS_VERSION=1.3.6 && cd /tmp                                                   && \
-    wget http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.xz && \ #TODO: change to developers.nvidia.com...
+    wget http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.xz && \
     tar -xf libvorbis-$VORBIS_VERSION                                                 && \
     rm libvorbis-$VORBIS_VERSION.tar.xz                                               && \
     cd libvorbis-$VORBIS_VERSION                                                      && \

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -127,7 +127,7 @@ RUN FLAC_VERSION=1.3.3 && cd /tmp                                               
     rm flac-$FLAC_VERSION.tar.xz                                                     && \
     cd flac-$FLAC_VERSION                                                            && \
     ./configure && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
-    cd /tmp && cd rm -rf flac-$FLAC_VERSION
+    cd /tmp && rm -rf flac-$FLAC_VERSION
 
 # libogg
 #TODO change to https://developer.nvidia.com...
@@ -137,7 +137,7 @@ RUN OGG_VERSION=1.3.4 && cd /tmp                                                
     rm libogg-$OGG_VERSION.tar.xz                                                    && \
     cd libogg-$OGG_VERSION                                                           && \
     ./configure && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
-    cd /tmp && cd rm -rf libogg-$OGG_VERSION
+    cd /tmp && rm -rf libogg-$OGG_VERSION
     
 # libvorbis
 # Install after libogg
@@ -148,7 +148,7 @@ RUN VORBIS_VERSION=1.3.6 && cd /tmp                                             
     rm libvorbis-$VORBIS_VERSION.tar.xz                                               && \
     cd libvorbis-$VORBIS_VERSION                                                      && \
     ./configure && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install  && \
-    cd /tmp && cd rm -rf libvorbis-$VORBIS_VERSION
+    cd /tmp && rm -rf libvorbis-$VORBIS_VERSION
 
 # libsnd
 RUN LIBSND_VERSION=1.0.28 && cd /tmp                                                                           && \

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -120,7 +120,6 @@ RUN FFMPEG_VERSION=4.2.1 && \
     cd /tmp && rm -rf ffmpeg-$FFMPEG_VERSION
 
 # flac
-#TODO change to https://developer.nvidia.com...
 RUN FLAC_VERSION=1.3.3 && cd /tmp                                                    && \
     wget https://ftp.osuosl.org/pub/xiph/releases/flac/flac-${FLAC_VERSION}.tar.xz   && \
     tar -xf flac-$FLAC_VERSION.tar.xz                                                && \
@@ -130,7 +129,6 @@ RUN FLAC_VERSION=1.3.3 && cd /tmp                                               
     cd /tmp && rm -rf flac-$FLAC_VERSION
 
 # libogg
-#TODO change to https://developer.nvidia.com...
 RUN OGG_VERSION=1.3.4 && cd /tmp                                                     && \
     wget http://downloads.xiph.org/releases/ogg/libogg-${OGG_VERSION}.tar.gz         && \
     tar -xf libogg-$OGG_VERSION.tar.gz                                               && \
@@ -141,7 +139,6 @@ RUN OGG_VERSION=1.3.4 && cd /tmp                                                
     
 # libvorbis
 # Install after libogg
-#TODO change to https://developer.nvidia.com...
 RUN VORBIS_VERSION=1.3.6 && cd /tmp                                                   && \
     wget http://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.xz && \
     tar -xf libvorbis-$VORBIS_VERSION.tar.xz                                          && \


### PR DESCRIPTION
Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

#### Why we need this PR?
libsnd can use external deps to decode more audio formats. Since not much is needed to support that (only make sure, that these deps are in the system when building libsnd, no code change), I'm adding them. Will post SWIPAT approval for this.
