### PR TITLE
Allow for more verbose Pipeline's graph logging

### DIFF
--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -743,8 +743,9 @@ std::map<std::string, Index> Pipeline::EpochSize() {
   return ret;
 }
 
-void Pipeline::SaveGraphToDotFile(const std::string &filename) {
-  graph_.SaveToDotFile(filename);
+void Pipeline::SaveGraphToDotFile(const std::string &filename, bool show_tensors, bool show_ids,
+                                  bool use_colors) {
+  graph_.SaveToDotFile(filename, show_tensors, show_ids, use_colors);
 }
 
 int Pipeline::GetNextLogicalId() {

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -324,7 +324,8 @@ class DLL_PUBLIC Pipeline {
    * @brief Save graph in DOT direct graph format
    * in filename.
    */
-  DLL_PUBLIC void SaveGraphToDotFile(const std::string &filename);
+  DLL_PUBLIC void SaveGraphToDotFile(const std::string &filename, bool show_tensors = false,
+                                     bool show_ids = false, bool use_colors = false);
 
   /**
    * @brief Returns the batch size that will be produced by the pipeline.

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -762,10 +762,11 @@ PYBIND11_MODULE(backend_impl, m) {
           string s = p->SerializeToProtobuf();
           return s;
           }, py::return_value_policy::take_ownership)
-    .def("SaveGraphToDotFile",
-        [](Pipeline *p, const string &filename) {
-          p->SaveGraphToDotFile(filename);
-        })
+    .def("SaveGraphToDotFile", &Pipeline::SaveGraphToDotFile,
+        "path"_a,
+        "show_tensors"_a = false,
+        "show_ids"_a = false,
+        "use_colors"_a = false)
     .def("epoch_size", &Pipeline::EpochSize)
     .def("epoch_size",
         [](Pipeline* p, const std::string& op_name) {

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -552,17 +552,24 @@ class Pipeline(object):
         self._pipe.Build()
         self._built = True
 
-    def save_graph_to_dot_file(self, filename):
+    def save_graph_to_dot_file(self, filename, show_tensors = False, show_ids = False,
+                               use_colors = False):
         """Saves the pipeline graph to a file.
 
         Parameters
         ----------
         filename : str
                    Name of the file to which the graph is written.
+        show_tensors : bool
+                   Show the Tensor nodes in the graph (by default only Operator nodes are shown)
+        show_ids : bool
+                   Add the node id to the graph representation
+        use_colors : bool
+                   Whether use color to distinguish stages
         """
         if not self._built:
             raise RuntimeError("Pipeline must be built first.")
-        self._pipe.SaveGraphToDotFile(filename)
+        self._pipe.SaveGraphToDotFile(filename, show_tensors, show_ids, use_colors)
 
     def define_graph(self):
         """This function is defined by the user to construct the


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
It allows to use more verbose .dot output of the Pipeline's graph.
The additional arguments were exposed in Python.

**JIRA TASK**: [DALI-XXXX]