### PR TITLE
Fix for bundle-wheel.sh

### DIFF
--- a/dali/python/bundle-wheel.sh
+++ b/dali/python/bundle-wheel.sh
@@ -98,6 +98,7 @@ DEPS_LIST=(
     "/usr/local/lib/libFLAC.so.8"
     "/usr/local/lib/libogg.so.0"
     "/usr/local/lib/libvorbis.so.0"
+    "/usr/local/lib/libvorbisenc.so.2"
 )
 
 DEPS_SONAME=(
@@ -111,6 +112,7 @@ DEPS_SONAME=(
     "libFLAC.so.8"
     "libogg.so.0"
     "libvorbis.so.0"
+    "libvorbisenc.so.2"
 )
 
 TMPDIR=$(mktemp -d)


### PR DESCRIPTION
Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

Fix a bug of not including `libvorbisenc.so` to the whl