### PR TITLE
Split tests per framework if possible

### DIFF
--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -16,11 +16,6 @@ from __future__ import print_function, division
 import math
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
-from nvidia.dali.plugin.mxnet import DALIGenericIterator as MXNetIterator
-from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
-from nvidia.dali.plugin.paddle import DALIGenericIterator as PaddleIterator
-import torch
-import mxnet
 import numpy as np
 import os
 from test_utils import get_dali_extra_path
@@ -75,6 +70,7 @@ def create_pipeline(creator, batch_size, num_gpus):
 
 
 def test_mxnet_iterator_last_batch_no_pad_last_batch():
+    from nvidia.dali.plugin.mxnet import DALIGenericIterator as MXNetIterator
     num_gpus = 1
     batch_size = 100
 
@@ -94,9 +90,9 @@ def test_mxnet_iterator_last_batch_no_pad_last_batch():
 
 
 def test_mxnet_iterator_last_batch_pad_last_batch():
+    from nvidia.dali.plugin.mxnet import DALIGenericIterator as MXNetIterator
     num_gpus = 1
     batch_size = 100
-    iters = 0
 
     pipes, data_size = create_pipeline(lambda gpu: COCOReaderPipeline(batch_size=batch_size, num_threads=4, shard_id=gpu, num_gpus=num_gpus,
                                                                       data_paths=data_sets[0], random_shuffle=True, stick_to_shard=False,
@@ -122,9 +118,9 @@ def test_mxnet_iterator_last_batch_pad_last_batch():
 
 
 def test_mxnet_iterator_not_fill_last_batch_pad_last_batch():
+    from nvidia.dali.plugin.mxnet import DALIGenericIterator as MXNetIterator
     num_gpus = 1
     batch_size = 100
-    iters = 0
 
     pipes, data_size = create_pipeline(lambda gpu: COCOReaderPipeline(batch_size=batch_size, num_threads=4, shard_id=gpu, num_gpus=num_gpus,
                                                                       data_paths=data_sets[0], random_shuffle=True, stick_to_shard=False,
@@ -152,9 +148,9 @@ def test_mxnet_iterator_not_fill_last_batch_pad_last_batch():
 
 
 def test_pytorch_iterator_last_batch_no_pad_last_batch():
+    from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
     num_gpus = 1
     batch_size = 100
-    iters = 0
 
     pipes, data_size = create_pipeline(lambda gpu: COCOReaderPipeline(batch_size=batch_size, num_threads=4, shard_id=gpu, num_gpus=num_gpus,
                                                                       data_paths=data_sets[0], random_shuffle=True, stick_to_shard=False,
@@ -170,9 +166,9 @@ def test_pytorch_iterator_last_batch_no_pad_last_batch():
     assert len(set(mirrored_data)) != 1
 
 def test_pytorch_iterator_last_batch_pad_last_batch():
+    from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
     num_gpus = 1
     batch_size = 100
-    iters = 0
 
     pipes, data_size = create_pipeline(lambda gpu: COCOReaderPipeline(batch_size=batch_size, num_threads=4, shard_id=gpu, num_gpus=num_gpus,
                                                                       data_paths=data_sets[0], random_shuffle=True, stick_to_shard=False,
@@ -197,9 +193,9 @@ def test_pytorch_iterator_last_batch_pad_last_batch():
 
 
 def test_pytorch_iterator_not_fill_last_batch_pad_last_batch():
+    from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
     num_gpus = 1
     batch_size = 100
-    iters = 0
 
     pipes, data_size = create_pipeline(lambda gpu: COCOReaderPipeline(batch_size=batch_size, num_threads=4, shard_id=gpu, num_gpus=num_gpus,
                                                                      data_paths=data_sets[0], random_shuffle=False, stick_to_shard=False,
@@ -226,9 +222,9 @@ def test_pytorch_iterator_not_fill_last_batch_pad_last_batch():
 
 
 def test_paddle_iterator_last_batch_no_pad_last_batch():
+    from nvidia.dali.plugin.paddle import DALIGenericIterator as PaddleIterator
     num_gpus = 1
     batch_size = 100
-    iters = 0
 
     pipes, data_size = create_pipeline(lambda gpu: COCOReaderPipeline(batch_size=batch_size, num_threads=4, shard_id=gpu, num_gpus=num_gpus,
                                                                       data_paths=data_sets[0], random_shuffle=True, stick_to_shard=False,
@@ -244,9 +240,9 @@ def test_paddle_iterator_last_batch_no_pad_last_batch():
     assert len(set(mirrored_data)) != 1
 
 def test_paddle_iterator_last_batch_pad_last_batch():
+    from nvidia.dali.plugin.paddle import DALIGenericIterator as PaddleIterator
     num_gpus = 1
     batch_size = 100
-    iters = 0
 
     pipes, data_size = create_pipeline(lambda gpu: COCOReaderPipeline(batch_size=batch_size, num_threads=4, shard_id=gpu, num_gpus=num_gpus,
                                                                       data_paths=data_sets[0], random_shuffle=True, stick_to_shard=False,
@@ -271,6 +267,7 @@ def test_paddle_iterator_last_batch_pad_last_batch():
 
 
 def test_paddle_iterator_not_fill_last_batch_pad_last_batch():
+    from nvidia.dali.plugin.paddle import DALIGenericIterator as PaddleIterator
     num_gpus = 1
     batch_size = 100
     iters = 0
@@ -357,11 +354,17 @@ def check_stop_iter(fw_iter, iterator_name, batch_size, epochs, iter_num, auto_r
             loader.reset()
     assert(count == iter_num * epochs)
 
-def test_stop_iteration():
-    for fw_iter, iter_name in [(lambda pipe, size, auto_reset : PyTorchIterator(pipe, output_map=["data"],  size=size, auto_reset=auto_reset), "PyTorchIterator"),
-                  (lambda pipe, size, auto_reset : MXNetIterator(pipe, [("data", MXNetIterator.DATA_TAG)], size=size, auto_reset=auto_reset), "MXNetIterator")]:
-        for epochs in [1, 3 ,6]:
-            for iter_num in [2, 5, 9]:
-                for batch_size in [1, 10 ,100]:
-                    for auto_reset in [True, False]:
-                        yield check_stop_iter, fw_iter, iter_name, batch_size, epochs, iter_num, auto_reset
+def test_stop_iteration_mxnet():
+    from nvidia.dali.plugin.mxnet import DALIGenericIterator as MXNetIterator
+    test_stop_iteration(lambda pipe, size, auto_reset : MXNetIterator(pipe, [("data", MXNetIterator.DATA_TAG)], size=size, auto_reset=auto_reset), "MXNetIterator")
+
+def test_stop_iteration_pytorch():
+    from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
+    test_stop_iteration(lambda pipe, size, auto_reset : PyTorchIterator(pipe, output_map=["data"],  size=size, auto_reset=auto_reset), "PyTorchIterator")
+
+def test_stop_iteration(fw_iter, iter_name):
+    for epochs in [1, 3 ,6]:
+        for iter_num in [2, 5, 9]:
+            for batch_size in [1, 10 ,100]:
+                for auto_reset in [True, False]:
+                    yield check_stop_iter, fw_iter, iter_name, batch_size, epochs, iter_num, auto_reset

--- a/dali/test/python/test_pytorch_operator.py
+++ b/dali/test/python/test_pytorch_operator.py
@@ -77,7 +77,7 @@ def torch_operation(tensor):
     return tensor_n.sin(), tensor_n.cos()
 
 
-def test_torch_operator():
+def test_pytorch_operator():
     pipe = BasicPipeline(BATCH_SIZE, NUM_WORKERS, DEVICE_ID, SEED, images_dir)
     pt_pipe = TorchPythonFunctionPipeline(BATCH_SIZE, NUM_WORKERS, DEVICE_ID,
                                           SEED, images_dir, torch_operation)

--- a/qa/TL0_FW_iterators/test.sh
+++ b/qa/TL0_FW_iterators/test.sh
@@ -1,27 +1,5 @@
 #!/bin/bash -e
-# used pip packages
-
-
-pip_packages="nose numpy opencv-python tensorflow-gpu torch torchvision mxnet-cu{cuda_v} paddle"
-target_dir=./dali/test/python
-
-one_config_only=true
-
-do_once() {
-    NUM_GPUS=$(nvidia-smi -L | wc -l)
-}
-
-test_body() {
-    for fw in "mxnet" "pytorch" "tf" "paddle"; do
-        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --prefetch 2 -i 100 --epochs 2
-        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
-    done
-    nosetests --verbose test_fw_iterators_detection.py
-    nosetests --verbose test_fw_iterators.py
-}
-
-pushd ../..
-source ./qa/test_template.sh
-popd
+./test_tf.sh
+./test_paddle.sh
+./test_mxnet.sh
+./test_pytorch.sh

--- a/qa/TL0_FW_iterators/test_mxnet.sh
+++ b/qa/TL0_FW_iterators/test_mxnet.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+# used pip packages
+
+
+pip_packages="nose numpy opencv-python mxnet-cu{cuda_v}"
+target_dir=./dali/test/python
+
+one_config_only=true
+
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
+
+test_body() {
+    for fw in "mxnet"; do
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --prefetch 2 -i 100 --epochs 2
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
+    done
+    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*mxnet*' test_fw_iterators_detection.py
+    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*mxnet*' test_fw_iterators.py
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_FW_iterators/test_paddle.sh
+++ b/qa/TL0_FW_iterators/test_paddle.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+# used pip packages
+
+
+pip_packages="nose numpy opencv-python paddle"
+target_dir=./dali/test/python
+
+one_config_only=true
+
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
+
+test_body() {
+    for fw in "paddle"; do
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --prefetch 2 -i 100 --epochs 2
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
+    done
+    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*paddle*' test_fw_iterators_detection.py
+    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*paddle*' test_fw_iterators.py
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_FW_iterators/test_pytorch.sh
+++ b/qa/TL0_FW_iterators/test_pytorch.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+# used pip packages
+
+
+pip_packages="nose numpy opencv-python torch torchvision"
+target_dir=./dali/test/python
+
+one_config_only=true
+
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
+
+test_body() {
+    for fw in "pytorch"; do
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --prefetch 2 -i 100 --epochs 2
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
+    done
+    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*pytorch*' test_fw_iterators_detection.py
+    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*pytorch*' test_fw_iterators.py
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_FW_iterators/test_tf.sh
+++ b/qa/TL0_FW_iterators/test_tf.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+# used pip packages
+
+
+pip_packages="nose numpy opencv-python tensorflow-gpu"
+target_dir=./dali/test/python
+
+one_config_only=true
+
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
+
+test_body() {
+    for fw in "tf"; do
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --prefetch 2 -i 100 --epochs 2
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
+    done
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_framework_imports/test.sh
+++ b/qa/TL0_framework_imports/test.sh
@@ -1,24 +1,4 @@
 #!/bin/bash -e
-# used pip packages
-
-pip_packages="mxnet-cu{cuda_v} tensorflow-gpu torchvision torch"
-
-test_body() {
-    # test code
-    echo "---------Testing MXNET;DALI----------"
-    ( set -x && python -c "import mxnet; import nvidia.dali.plugin.mxnet" )
-    echo "---------Testing DALI;MXNET----------"
-    ( set -x && python -c "import nvidia.dali.plugin.mxnet; import mxnet" )
-    echo "---------Testing TENSORFLOW;DALI----------"
-    ( set -x && python -c "import tensorflow; import nvidia.dali.plugin.tf as dali_tf; daliop = dali_tf.DALIIterator()" )
-    echo "---------Testing DALI;TENSORFLOW----------"
-    ( set -x && python -c "import nvidia.dali.plugin.tf as dali_tf; import tensorflow; daliop = dali_tf.DALIIterator()" )
-    echo "---------Testing PYTORCH;DALI----------"
-    ( set -x && python -c "import torch; import nvidia.dali.plugin.pytorch" )
-    echo "---------Testing DALI;PYTORCH----------"
-    ( set -x && python -c "import nvidia.dali.plugin.pytorch; import torch" )
-}
-
-pushd ../../
-source ./qa/test_template.sh
-popd
+./test_tf.sh
+./test_mxnet.sh
+./test_pytorch.sh

--- a/qa/TL0_framework_imports/test_mxnet.sh
+++ b/qa/TL0_framework_imports/test_mxnet.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+# used pip packages
+
+pip_packages="mxnet-cu{cuda_v}"
+
+test_body() {
+    # test code
+    echo "---------Testing MXNET;DALI----------"
+    ( set -x && python -c "import mxnet; import nvidia.dali.plugin.mxnet" )
+    echo "---------Testing DALI;MXNET----------"
+    ( set -x && python -c "import nvidia.dali.plugin.mxnet; import mxnet" )
+}
+
+pushd ../../
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_framework_imports/test_pytorch.sh
+++ b/qa/TL0_framework_imports/test_pytorch.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+# used pip packages
+
+pip_packages="torchvision torch"
+
+test_body() {
+    # test code
+    echo "---------Testing PYTORCH;DALI----------"
+    ( set -x && python -c "import torch; import nvidia.dali.plugin.pytorch" )
+    echo "---------Testing DALI;PYTORCH----------"
+    ( set -x && python -c "import nvidia.dali.plugin.pytorch; import torch" )
+}
+
+pushd ../../
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_framework_imports/test_tf.sh
+++ b/qa/TL0_framework_imports/test_tf.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+# used pip packages
+
+pip_packages="tensorflow-gpu"
+
+test_body() {
+    # test code
+    echo "---------Testing TENSORFLOW;DALI----------"
+    ( set -x && python -c "import tensorflow; import nvidia.dali.plugin.tf as dali_tf; daliop = dali_tf.DALIIterator()" )
+    echo "---------Testing DALI;TENSORFLOW----------"
+    ( set -x && python -c "import nvidia.dali.plugin.tf as dali_tf; import tensorflow; daliop = dali_tf.DALIIterator()" )
+}
+
+pushd ../../
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_jupyter/test.sh
+++ b/qa/TL0_jupyter/test.sh
@@ -1,35 +1,3 @@
 #!/bin/bash -e
-# used pip packages
-pip_packages="jupyter numpy matplotlib pillow opencv-python"
-if [ "$PYVER" != "2.7" ]; then
-    pip_packages="${pip_packages} simpleaudio" 
-fi
-target_dir=./docs/examples
-
-do_once() {
-    apt update
-    apt install -y libasound2-dev
-    # attempt to run jupyter on all example notebooks
-    mkdir -p idx_files
-}
-
-test_body() {
-
-    # test code
-    # dummy patern
-    black_list_files="multigpu"
-
-    # Blacklist for python2. Can be removed after dropping python2
-    if [ "$PYVER" == "2.7" ]; then
-        black_list_files="multigpu\|audio_decoder"
-    fi    
-
-    ls *.ipynb | sed "/${black_list_files}/d" | xargs -i jupyter nbconvert \
-                    --to notebook --inplace --execute \
-                    --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
-                    --ExecutePreprocessor.timeout=300 {}
-}
-
-pushd ../..
-source ./qa/test_template.sh
-popd
+./test_nofw.sh
+./test_pytorch.sh

--- a/qa/TL0_jupyter/test_nofw.sh
+++ b/qa/TL0_jupyter/test_nofw.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages="jupyter numpy matplotlib pillow opencv-python librosa"
+if [ "$PYVER" != "2.7" ]; then
+    pip_packages="${pip_packages} simpleaudio" 
+fi
+target_dir=./docs/examples
+
+do_once() {
+  # We need cmake to run the custom plugin notebook + ffmpeg, wget for video example, libasound2-dev for audio test
+  apt-get update
+  apt-get install -y --no-install-recommends wget ffmpeg cmake libasound2-dev
+  mkdir -p idx_files
+}
+
+test_body() {
+    # test code
+    # test all jupyters except one related to a particular FW,
+    # and one requiring a dedicated HW (multiGPU and OF)
+    # optical flow requires TU102 architecture whilst this test can be run on any GPU
+    black_list_files="multigpu\|mxnet.*\|tensorflow.*\|pytorch.*\|paddle*\|optical_flow.*\|python_operator.*\|#"
+
+    # Blacklist for python2. Can be removed after dropping python2
+    if [ "$PYVER" == "2.7" ]; then
+        black_list_files="audio_decoder\|"${black_list_files}
+    fi
+
+    find * -name "*.ipynb" | sed "/${black_list_files}/d" | xargs -i jupyter nbconvert \
+                    --to notebook --inplace --execute \
+                    --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
+                    --ExecutePreprocessor.timeout=300 {}
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_jupyter/test_pytorch.sh
+++ b/qa/TL0_jupyter/test_pytorch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages="jupyter numpy matplotlib torch"
+target_dir=./docs/examples
+
+test_body() {
+    # test code
+    # dummy
+    black_list_files="#"
+
+    find python_operator/* -name "*.ipynb" | sed "/${black_list_files}/d" | xargs -i jupyter nbconvert \
+                    --to notebook --inplace --execute \
+                    --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
+                    --ExecutePreprocessor.timeout=300 {}
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_python_self_test_frameworks/test.sh
+++ b/qa/TL0_python_self_test_frameworks/test.sh
@@ -1,13 +1,4 @@
 #!/bin/bash -e
-# used pip packages
-pip_packages="nose numpy torch mxnet-cu{cuda_v} cupy"
-target_dir=./dali/test/python
-
-test_body() {
-    nosetests --verbose test_pytorch_operator
-    nosetests --verbose test_dltensor_operator
-}
-
-pushd ../..
-source ./qa/test_template.sh
-popd
+./test_mxnet.sh
+./test_cupy.sh
+./test_pytorch.sh

--- a/qa/TL0_python_self_test_frameworks/test_cupy.sh
+++ b/qa/TL0_python_self_test_frameworks/test_cupy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages="nose numpy cupy"
+target_dir=./dali/test/python
+
+test_body() {
+    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*cupy' test_dltensor_operator.py
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_python_self_test_frameworks/test_mxnet.sh
+++ b/qa/TL0_python_self_test_frameworks/test_mxnet.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages="nose numpy mxnet-cu{cuda_v}"
+target_dir=./dali/test/python
+
+test_body() {
+    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*mxnet' test_dltensor_operator.py
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_python_self_test_frameworks/test_pytorch.sh
+++ b/qa/TL0_python_self_test_frameworks/test_pytorch.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages="nose numpy torch"
+target_dir=./dali/test/python
+
+test_body() {
+    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*pytorch' test_pytorch_operator.py
+    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*pytorch' test_dltensor_operator.py
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL1_jupyter_plugins/test.sh
+++ b/qa/TL1_jupyter_plugins/test.sh
@@ -1,31 +1,5 @@
 #!/bin/bash -e
-
-# used pip packages
-pip_packages="jupyter matplotlib mxnet-cu{cuda_v} tensorflow-gpu torchvision torch paddle librosa"
-target_dir=./docs/examples
-
-do_once() {
-  # We need cmake to run the custom plugin notebook + ffmpeg and wget for video example
-  apt-get update
-  apt-get install -y --no-install-recommends wget ffmpeg cmake
-  mkdir -p idx_files
-}
-
-test_body() {
-  # attempt to run jupyter on all example notebooks
-  black_list_files="optical_flow_example.ipynb\|tensorflow-dataset-*\|#" 
-  # optical flow requires TU102 architecture whilst currently L1_jupyter_plugins test can be run only on V100
-  # tensorflow-dataset requires TF >= 1.15, they are run in TL1_tensorflow_dataset
-
-
-  # test code
-  find */* -name "*.ipynb" | sed "/${black_list_files}/d" | xargs -i jupyter nbconvert \
-                  --to notebook --inplace --execute \
-                  --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
-                  --ExecutePreprocessor.timeout=600 {}
-  python${PYVER:0:1} pytorch/resnet50/main.py -t
-}
-
-pushd ../..
-source ./qa/test_template.sh
-popd
+./test_mxnet.sh
+./test_tf.sh
+./test_paddle.sh
+./test_pytorch.sh

--- a/qa/TL1_jupyter_plugins/test_mxnet.sh
+++ b/qa/TL1_jupyter_plugins/test_mxnet.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# used pip packages
+pip_packages="jupyter matplotlib mxnet-cu{cuda_v}"
+target_dir=./docs/examples
+
+do_once() {
+  mkdir -p idx_files
+}
+
+test_body() {
+  # dummy
+  black_list_files="#"
+
+  # test code
+  find mxnet/* -name "*.ipynb" | sed "/${black_list_files}/d" | xargs -i jupyter nbconvert \
+                  --to notebook --inplace --execute \
+                  --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
+                  --ExecutePreprocessor.timeout=600 {}
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL1_jupyter_plugins/test_paddle.sh
+++ b/qa/TL1_jupyter_plugins/test_paddle.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# used pip packages
+pip_packages="jupyter matplotlib paddle"
+target_dir=./docs/examples
+
+do_once() {
+  mkdir -p idx_files
+}
+
+test_body() {
+  # dummy
+  black_list_files="#"
+
+  # test code
+  find paddle/* -name "*.ipynb" | sed "/${black_list_files}/d" | xargs -i jupyter nbconvert \
+                  --to notebook --inplace --execute \
+                  --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
+                  --ExecutePreprocessor.timeout=600 {}
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL1_jupyter_plugins/test_pytorch.sh
+++ b/qa/TL1_jupyter_plugins/test_pytorch.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+# used pip packages
+pip_packages="jupyter matplotlib torchvision torch"
+target_dir=./docs/examples
+
+do_once() {
+  mkdir -p idx_files
+}
+
+test_body() {
+  # dummy
+  black_list_files="#"
+
+  # test code
+  find pytorch/* -name "*.ipynb" | sed "/${black_list_files}/d" | xargs -i jupyter nbconvert \
+                  --to notebook --inplace --execute \
+                  --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
+                  --ExecutePreprocessor.timeout=600 {}
+  python${PYVER:0:1} pytorch/resnet50/main.py -t
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL1_jupyter_plugins/test_tf.sh
+++ b/qa/TL1_jupyter_plugins/test_tf.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+# used pip packages
+pip_packages="jupyter matplotlib tensorflow-gpu"
+target_dir=./docs/examples
+
+do_once() {
+  mkdir -p idx_files
+}
+
+test_body() {
+  # attempt to run jupyter on all example notebooks
+  black_list_files="tensorflow-dataset*\|#"
+  # tensorflow-dataset requires TF >= 1.15, they are run in TL1_tensorflow_dataset
+
+
+  # test code
+  find tensorflow/* -name "*.ipynb" | sed "/${black_list_files}/d" | xargs -i jupyter nbconvert \
+                  --to notebook --inplace --execute \
+                  --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
+                  --ExecutePreprocessor.timeout=600 {}
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL1_separate_executor/test.sh
+++ b/qa/TL1_separate_executor/test.sh
@@ -1,24 +1,6 @@
 #!/bin/bash -e
-# used pip packages
-pip_packages="tensorflow-gpu torchvision torch mxnet-cu{cuda_v} paddle"
-target_dir=./dali/test/python
-one_config_only=true
-
-do_once() {
-    NUM_GPUS=$(nvidia-smi -L | wc -l)
-}
-
-test_body() {
-    python test_RN50_data_pipeline.py --gpus ${NUM_GPUS} -b 256 --workers 3 --separate_queue \
-        --cpu_size 2 --gpu_size 2 --fp16 --nhwc
-    python test_RN50_data_pipeline.py --gpus ${NUM_GPUS} -b 256 --workers 3 --separate_queue \
-        --cpu_size 5 --gpu_size 3 --fp16 --nhwc
-    for fw in "mxnet" "pytorch" "tf" "paddle"; do
-        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --separate_queue --cpu_size 3 --gpu_size 2 --iters 32 --epochs 2
-    done
-}
-
-pushd ../..
-source ./qa/test_template.sh
-popd
+./test_nofw.sh
+./test_tf.sh
+./test_pytorch.sh
+./test_mxnet.sh
+./test_paddle.sh

--- a/qa/TL1_separate_executor/test_mxnet.sh
+++ b/qa/TL1_separate_executor/test_mxnet.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages="torch mxnet-cu{cuda_v}"
+target_dir=./dali/test/python
+one_config_only=true
+
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
+
+test_body() {
+    for fw in "mxnet"; do
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --separate_queue --cpu_size 3 --gpu_size 2 --iters 32 --epochs 2
+    done
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL1_separate_executor/test_nofw.sh
+++ b/qa/TL1_separate_executor/test_nofw.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages=""
+target_dir=./dali/test/python
+one_config_only=true
+
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
+
+test_body() {
+    python test_RN50_data_pipeline.py --gpus ${NUM_GPUS} -b 256 --workers 3 --separate_queue \
+        --cpu_size 2 --gpu_size 2 --fp16 --nhwc
+    python test_RN50_data_pipeline.py --gpus ${NUM_GPUS} -b 256 --workers 3 --separate_queue \
+        --cpu_size 5 --gpu_size 3 --fp16 --nhwc
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL1_separate_executor/test_paddle.sh
+++ b/qa/TL1_separate_executor/test_paddle.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages="paddle"
+target_dir=./dali/test/python
+one_config_only=true
+
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
+
+test_body() {
+    for fw in "paddle"; do
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --separate_queue --cpu_size 3 --gpu_size 2 --iters 32 --epochs 2
+    done
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL1_separate_executor/test_pytorch.sh
+++ b/qa/TL1_separate_executor/test_pytorch.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages="torchvision torch"
+target_dir=./dali/test/python
+one_config_only=true
+
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
+
+test_body() {
+    for fw in "pytorch"; do
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --separate_queue --cpu_size 3 --gpu_size 2 --iters 32 --epochs 2
+    done
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL1_separate_executor/test_tf.sh
+++ b/qa/TL1_separate_executor/test_tf.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages="tensorflow-gpu"
+target_dir=./dali/test/python
+one_config_only=true
+
+do_once() {
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+}
+
+test_body() {
+    for fw in "tf"; do
+        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
+            --workers 3 --separate_queue --cpu_size 3 --gpu_size 2 --iters 32 --epochs 2
+    done
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd


### PR DESCRIPTION
- as tests test the cartesian product of all available FWs in setup_packages.py
  it is wasteful to test MXNet based test case with all available combinations
  of TF, MXNet, and PyTorch
- splits tests to test.sh and test_FWname.sh where possible

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
-  split tests per framework if possible

#### What happened in this PR?
 - as tests test the cartesian product of all available FWs in setup_packages.py it is wasteful to test MXNet based test case with all available combinations of TF, MXNet, and PyTorch
 - splits tests to test.sh and test_FWname.sh where possible

**JIRA TASK**: [DALI-1174]