### PR TITLE
Fix Keras GPU example

### DIFF
--- a/docs/examples/tensorflow/tensorflow-dataset.ipynb
+++ b/docs/examples/tensorflow/tensorflow-dataset.ipynb
@@ -139,21 +139,21 @@
      "text": [
       "Train on 100 steps\n",
       "Epoch 1/5\n",
-      "100/100 [==============================] - 1s 6ms/step - loss: 0.9044 - accuracy: 0.7439\n",
+      "100/100 [==============================] - 1s 6ms/step - loss: 0.8921 - accuracy: 0.7462\n",
       "Epoch 2/5\n",
-      "100/100 [==============================] - 0s 4ms/step - loss: 0.4064 - accuracy: 0.8842\n",
+      "100/100 [==============================] - 0s 4ms/step - loss: 0.4115 - accuracy: 0.8847\n",
       "Epoch 3/5\n",
-      "100/100 [==============================] - 0s 4ms/step - loss: 0.3242 - accuracy: 0.9098\n",
+      "100/100 [==============================] - 0s 3ms/step - loss: 0.3235 - accuracy: 0.9062\n",
       "Epoch 4/5\n",
-      "100/100 [==============================] - 0s 4ms/step - loss: 0.2881 - accuracy: 0.9191\n",
+      "100/100 [==============================] - 0s 4ms/step - loss: 0.2926 - accuracy: 0.9202\n",
       "Epoch 5/5\n",
-      "100/100 [==============================] - 0s 4ms/step - loss: 0.2618 - accuracy: 0.9241\n"
+      "100/100 [==============================] - 0s 4ms/step - loss: 0.2617 - accuracy: 0.9245\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<tensorflow.python.keras.callbacks.History at 0x7f086d1c4f28>"
+       "<tensorflow.python.keras.callbacks.History at 0x7fc3a4955518>"
       ]
      },
      "execution_count": 4,
@@ -242,15 +242,15 @@
      "text": [
       "Train on 100 steps\n",
       "Epoch 1/5\n",
-      "100/100 [==============================] - 1s 6ms/step - loss: 0.8807 - accuracy: 0.7469\n",
+      "100/100 [==============================] - 1s 7ms/step - loss: 0.9235 - accuracy: 0.7381\n",
       "Epoch 2/5\n",
-      "100/100 [==============================] - 1s 6ms/step - loss: 0.4087 - accuracy: 0.8841\n",
+      "100/100 [==============================] - 1s 6ms/step - loss: 0.4115 - accuracy: 0.8856\n",
       "Epoch 3/5\n",
-      "100/100 [==============================] - 1s 6ms/step - loss: 0.3282 - accuracy: 0.9069\n",
+      "100/100 [==============================] - 1s 6ms/step - loss: 0.3243 - accuracy: 0.9050\n",
       "Epoch 4/5\n",
-      "100/100 [==============================] - 1s 6ms/step - loss: 0.2915 - accuracy: 0.9150\n",
+      "100/100 [==============================] - 0s 5ms/step - loss: 0.2932 - accuracy: 0.9166\n",
       "Epoch 5/5\n",
-      "100/100 [==============================] - 1s 6ms/step - loss: 0.2644 - accuracy: 0.9270\n"
+      "100/100 [==============================] - 1s 7ms/step - loss: 0.2606 - accuracy: 0.9212\n"
      ]
     }
    ],
@@ -267,7 +267,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is important to note here, that there is no intermediate CPU buffer between DALI and TensorFlow in the execution above. DALI GPU outputs are copied straight to TF GPU Tensors used by the model. This guarantees the best performance."
+    "It is important to note here, that there is no intermediate CPU buffer between DALI and TensorFlow in the execution above. DALI GPU outputs are copied straight to TF GPU Tensors used by the model.\n",
+    "\n",
+    "In this particular toy example performance of the GPU variant is lower than the CPU one. The MNIST images are small and nvJPEG decoder used in the GPU DALI pipeline to decode them is not well suited for such circumstance. We use it here to show how to integrate it properly in the real life case."
    ]
   },
   {
@@ -351,7 +353,7 @@
     {
      "data": {
       "text/plain": [
-       "<tensorflow_estimator.python.estimator.canned.dnn.DNNClassifier at 0x7f086f411b38>"
+       "<tensorflow_estimator.python.estimator.canned.dnn.DNNClassifier at 0x7fc3a6ad8b70>"
       ]
      },
      "execution_count": 9,
@@ -372,10 +374,10 @@
     {
      "data": {
       "text/plain": [
-       "{'accuracy': 0.8915625,\n",
-       " 'average_loss': 0.47590116,\n",
-       " 'loss': 30.457674,\n",
-       " 'global_step': 4500}"
+       "{'accuracy': 0.87921876,\n",
+       " 'average_loss': 0.49361104,\n",
+       " 'loss': 31.591106,\n",
+       " 'global_step': 17500}"
       ]
      },
      "execution_count": 10,
@@ -458,12 +460,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Step 0, accuracy: 0.140625\n",
-      "Step 100, accuracy: 0.90625\n",
-      "Step 200, accuracy: 0.875\n",
-      "Step 300, accuracy: 0.890625\n",
-      "Step 400, accuracy: 0.859375\n",
-      "Final accuracy:  0.90625\n"
+      "Step 0, accuracy: 0.109375\n",
+      "Step 100, accuracy: 0.828125\n",
+      "Step 200, accuracy: 0.828125\n",
+      "Step 300, accuracy: 0.96875\n",
+      "Step 400, accuracy: 0.890625\n",
+      "Final accuracy:  0.90734375\n"
      ]
     }
    ],

--- a/docs/examples/tensorflow/tensorflow-dataset.ipynb
+++ b/docs/examples/tensorflow/tensorflow-dataset.ipynb
@@ -139,21 +139,21 @@
      "text": [
       "Train on 100 steps\n",
       "Epoch 1/5\n",
-      "100/100 [==============================] - 1s 6ms/step - loss: 0.8940 - acc: 0.7477\n",
+      "100/100 [==============================] - 1s 6ms/step - loss: 0.9044 - accuracy: 0.7439\n",
       "Epoch 2/5\n",
-      "100/100 [==============================] - 0s 3ms/step - loss: 0.4054 - acc: 0.8872\n",
+      "100/100 [==============================] - 0s 4ms/step - loss: 0.4064 - accuracy: 0.8842\n",
       "Epoch 3/5\n",
-      "100/100 [==============================] - 0s 3ms/step - loss: 0.3245 - acc: 0.9058\n",
+      "100/100 [==============================] - 0s 4ms/step - loss: 0.3242 - accuracy: 0.9098\n",
       "Epoch 4/5\n",
-      "100/100 [==============================] - 0s 3ms/step - loss: 0.2976 - acc: 0.9164\n",
+      "100/100 [==============================] - 0s 4ms/step - loss: 0.2881 - accuracy: 0.9191\n",
       "Epoch 5/5\n",
-      "100/100 [==============================] - 0s 3ms/step - loss: 0.2659 - acc: 0.9239\n"
+      "100/100 [==============================] - 0s 4ms/step - loss: 0.2618 - accuracy: 0.9241\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<tensorflow.python.keras.callbacks.History at 0x7f3508e31a58>"
+       "<tensorflow.python.keras.callbacks.History at 0x7f086d1c4f28>"
       ]
      },
      "execution_count": 4,
@@ -226,7 +226,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These are all the necessary changes. Training looks the same as before, but now it is done using the GPU."
+    "We move the training to the GPU as well. This allows TensorFlow to pick up GPU instance of DALI dataset."
    ]
   },
   {
@@ -242,34 +242,25 @@
      "text": [
       "Train on 100 steps\n",
       "Epoch 1/5\n",
-      "100/100 [==============================] - 1s 7ms/step - loss: 0.8800 - acc: 0.7519\n",
+      "100/100 [==============================] - 1s 6ms/step - loss: 0.8807 - accuracy: 0.7469\n",
       "Epoch 2/5\n",
-      "100/100 [==============================] - 1s 7ms/step - loss: 0.4155 - acc: 0.8789\n",
+      "100/100 [==============================] - 1s 6ms/step - loss: 0.4087 - accuracy: 0.8841\n",
       "Epoch 3/5\n",
-      "100/100 [==============================] - 1s 7ms/step - loss: 0.3267 - acc: 0.9048\n",
+      "100/100 [==============================] - 1s 6ms/step - loss: 0.3282 - accuracy: 0.9069\n",
       "Epoch 4/5\n",
-      "100/100 [==============================] - 1s 7ms/step - loss: 0.2933 - acc: 0.9173\n",
+      "100/100 [==============================] - 1s 6ms/step - loss: 0.2915 - accuracy: 0.9150\n",
       "Epoch 5/5\n",
-      "100/100 [==============================] - 1s 7ms/step - loss: 0.2649 - acc: 0.9220\n"
+      "100/100 [==============================] - 1s 6ms/step - loss: 0.2644 - accuracy: 0.9270\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<tensorflow.python.keras.callbacks.History at 0x7f350909cd68>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
     "# Train on the GPU\n",
-    "model.fit(\n",
-    "    mnist_set,\n",
-    "    epochs=EPOCHS,\n",
-    "    steps_per_epoch=ITERATIONS_PER_EPOCH)"
+    "with tf.device('/gpu:0'):\n",
+    "    model.fit(\n",
+    "        mnist_set,\n",
+    "        epochs=EPOCHS,\n",
+    "        steps_per_epoch=ITERATIONS_PER_EPOCH)"
    ]
   },
   {
@@ -360,7 +351,7 @@
     {
      "data": {
       "text/plain": [
-       "<tensorflow_estimator.python.estimator.canned.dnn.DNNClassifier at 0x7f3500576cf8>"
+       "<tensorflow_estimator.python.estimator.canned.dnn.DNNClassifier at 0x7f086f411b38>"
       ]
      },
      "execution_count": 9,
@@ -381,10 +372,10 @@
     {
      "data": {
       "text/plain": [
-       "{'accuracy': 0.8875,\n",
-       " 'average_loss': 0.48246202,\n",
-       " 'loss': 30.87757,\n",
-       " 'global_step': 1500}"
+       "{'accuracy': 0.8915625,\n",
+       " 'average_loss': 0.47590116,\n",
+       " 'loss': 30.457674,\n",
+       " 'global_step': 4500}"
       ]
      },
      "execution_count": 10,
@@ -467,12 +458,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Step 0, accuracy: 0.09375\n",
-      "Step 100, accuracy: 0.890625\n",
-      "Step 200, accuracy: 0.84375\n",
-      "Step 300, accuracy: 0.953125\n",
-      "Step 400, accuracy: 0.90625\n",
-      "Final accuracy:  0.91125\n"
+      "Step 0, accuracy: 0.140625\n",
+      "Step 100, accuracy: 0.90625\n",
+      "Step 200, accuracy: 0.875\n",
+      "Step 300, accuracy: 0.890625\n",
+      "Step 400, accuracy: 0.859375\n",
+      "Final accuracy:  0.90625\n"
      ]
     }
    ],


### PR DESCRIPTION
Signed-off-by: Albert Wolant <awolant@nvidia.com>

#### Why we need this PR?
- It fixes an issue with Keras MNIST GPU example

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
It is necessary to explicitly move `model.fit` to the GPU for TensorFlow to pick up GPU allocator for DALI dataset. We do it with `with tf.device()`
 - Were docs and examples updated, if necessary?
Yes

**JIRA TASK**: [DALI-XXXX]