### PR TITLE
Add deprecation warning for Python 2.7

### DIFF
--- a/dali/python/nvidia/dali/backend.py
+++ b/dali/python/nvidia/dali/backend.py
@@ -15,6 +15,7 @@
 from nvidia.dali.backend_impl import *
 import warnings
 import os
+import sys
 
 # Note: If we ever need to add more complex functionality
 # for importing the DALI c++ extensions, we can do it here
@@ -28,11 +29,14 @@ if not initialized:
     Init(OpSpec("CPUAllocator"), OpSpec("PinnedCPUAllocator"), OpSpec("GPUAllocator"))
     initialized = True
 
-    # pybind11 deprecations
-    def asCPU(self):
-        warnings.warn("asCPU is deprecated since v0.7, please use as_cpu", DeprecationWarning, stacklevel=2)
-        return self.as_cpu()
-    TensorListGPU.asCPU = asCPU
+    # py27 deprecation
+    if sys.version_info[0] < 3:
+        # show only this warning
+        with warnings.catch_warnings():
+            warnings.simplefilter("default")
+            warnings.warn("DALI 0.17 is the last official release for Python 2.7, which"
+                        "reaches the end of life on January 1st, 2020. To stay up to date with"
+                        "DALI, please upgrade to Python 3.5 or later.", Warning, stacklevel=2)
 
     for lib in default_plugins:
         LoadLibrary(os.path.join(os.path.dirname(__file__), lib))

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -723,8 +723,8 @@ def test_transpose():
 
     for _ in range(iterations):
         pipe_out = pipe.run()
-        images = pipe_out[0].asCPU().as_array()
-        images_transposed = pipe_out[1].asCPU().as_array()
+        images = pipe_out[0].as_cpu().as_array()
+        images_transposed = pipe_out[1].as_cpu().as_array()
 
         for b in range(batch_size):
             np_transposed = images[b].transpose((2, 0, 1))


### PR DESCRIPTION
- EOF for Python 2.7 will happen on January 1st, 2020. This change
  adds an appropriate warning
- removes asCPU method support that has been deprecated a long time ago

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- add deprecation warning for Python 2.7

#### What happened in this PR?
 - EOF for Python 2.7 will happen on January 1st, 2020. This change adds an appropriate warning
 - removes asCPU method support that has been deprecated a long time ago
 - no dedicated test it available

**JIRA TASK**: [NA]