### PR TITLE
Add missing examples to DALI sphinx docs

### DIFF
--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -4,6 +4,9 @@ Tutorials
 .. toctree::
    :maxdepth: 2
 
+   audio_decoder.ipynb
+   hsv_example.ipynb
+   brightness_contrast_example.ipynb
    dataloading
    serialization.ipynb
    detection_pipeline.ipynb


### PR DESCRIPTION
#### Why we need this PR?

There were few examples missing from sphinx docs. This PR adds them