### PR TITLE
Lower the accuracy threshold for paddle RN50 test (limited to 25 epochs)

### DIFF
--- a/qa/TL3_RN50_convergence/test_paddle.sh
+++ b/qa/TL3_RN50_convergence/test_paddle.sh
@@ -37,8 +37,8 @@ if [[ $RET -ne 0 ]]; then
     CLEAN_AND_EXIT 2
 fi
 
-MIN_TOP1=50.0  # would be 75.0 if we run 90 epochs (TODO: fine-tune the value for 25 epochs)
-MIN_TOP5=70.0  # would be 92.0 if we run 90 epochs (TODO: fine-tune the value for 25 epochs)
+MIN_TOP1=45.0  # would be 75.0 if we run 90 epochs
+MIN_TOP5=70.0  # would be 92.0 if we run 90 epochs
 MIN_PERF=2000
 
 TOP1=$(grep "^##Top-1" $LOG | awk '{print $2}')


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
Adjust the top-1 error in paddle RN50 test to something more reasonable

**JIRA TASK**: [DALI-XXXX]