### PR TITLE
Add zlib dependency warning to libtiff build step

### DIFF
--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -60,13 +60,26 @@ RUN JPEG_TURBO_VERSION=2.0.2 && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install 2>&1 >/dev/null && \
     rm -rf /libjpeg-turbo-${JPEG_TURBO_VERSION}
 
+# libz
+RUN LIBZ_VERSION=1.2.11 && \
+    cd /tmp && \
+    curl -L http://www.zlib.net/zlib-${LIBZ_VERSION}.tar.gz | tar -xzf - && \
+    cd zlib-${LIBZ_VERSION} && \
+    ./configure --prefix=/usr/local && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && \
+    make install && \
+    cd && \
+    rm -rf /tmp/libz-${LIBZ_VERSION}
+
 # libtiff
 RUN LIBTIFF_VERSION=4.0.10 && \
     cd /tmp && \
     curl -L http://download.osgeo.org/libtiff/tiff-${LIBTIFF_VERSION}.tar.gz | tar -xzf - && \
     cd tiff-${LIBTIFF_VERSION} && \
     ./autogen.sh && \
-    ./configure --prefix=/usr/local && \
+    ./configure --prefix=/usr/local \
+                --with-zlib-include-dir=/usr/local/include \
+                --with-zlib-lib-dir=/usr/local/lib && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && \
     make install && \
     cd && \
@@ -135,7 +148,7 @@ RUN OGG_VERSION=1.3.4 && cd /tmp                                                
     cd libogg-$OGG_VERSION                                                           && \
     ./configure && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
     cd /tmp && rm -rf libogg-$OGG_VERSION
-    
+
 # libvorbis
 # Install after libogg
 RUN VORBIS_VERSION=1.3.6 && cd /tmp                                                   && \

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -13,7 +13,7 @@ FROM ${CUDA_IMAGE} as cuda
 FROM ${FROM_IMAGE_NAME}
 
 # Install yum Dependencies
-RUN yum install -y zip wget yasm doxygen graphviz
+RUN yum install -y zip wget yasm doxygen graphviz zlib-devel
 
 # Don't want the short-unicode version for Python 2.7
 RUN rm -f /opt/python/cp27-cp27m
@@ -60,26 +60,15 @@ RUN JPEG_TURBO_VERSION=2.0.2 && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install 2>&1 >/dev/null && \
     rm -rf /libjpeg-turbo-${JPEG_TURBO_VERSION}
 
-# libz
-RUN LIBZ_VERSION=1.2.11 && \
-    cd /tmp && \
-    curl -L http://www.zlib.net/zlib-${LIBZ_VERSION}.tar.gz | tar -xzf - && \
-    cd zlib-${LIBZ_VERSION} && \
-    ./configure --prefix=/usr/local && \
-    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && \
-    make install && \
-    cd && \
-    rm -rf /tmp/libz-${LIBZ_VERSION}
-
 # libtiff
+# Note: libtiff should be built with support for zlib. If running this step alone on a custom
+#       system, zlib should be installed first
 RUN LIBTIFF_VERSION=4.0.10 && \
     cd /tmp && \
     curl -L http://download.osgeo.org/libtiff/tiff-${LIBTIFF_VERSION}.tar.gz | tar -xzf - && \
     cd tiff-${LIBTIFF_VERSION} && \
     ./autogen.sh && \
-    ./configure --prefix=/usr/local \
-                --with-zlib-include-dir=/usr/local/include \
-                --with-zlib-lib-dir=/usr/local/lib && \
+    ./configure --prefix=/usr/local && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && \
     make install && \
     cd && \

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -123,6 +123,7 @@ Prerequisites
    | |jpegturbo link|_ or later             | *This can be unofficially disabled. See below.*                                             |
    +----------------------------------------+---------------------------------------------------------------------------------------------+
    | |libtiff link|_ or later               | *This can be unofficially disabled. See below.*                                             |
+   |                                        | Note: libtiff should be built with zlib support                                             |
    +----------------------------------------+---------------------------------------------------------------------------------------------+
    | |ffmpeg link|_ or later                | We recommend using version 4.2.1 compiled following the *instructions below*.               |
    +----------------------------------------+---------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- Some systems don't have libz installed

#### What happened in this PR?
- Build and install libz from source in Dockerfile.deps
- Explicitly depend on libz on libtiff build step

**JIRA TASK**: [DALI-XXXX]