### PR TITLE
Extend supported ops doc to include info about volumetric data. 

### DIFF
--- a/dali/operators/crop/crop.cc
+++ b/dali/operators/crop/crop.cc
@@ -27,6 +27,7 @@ DALI_SCHEMA(Crop)
     .NumInput(1)
     .NumOutput(1)
     .AllowSequences()
+    .SupportVolumetric()
     .AddOptionalArg(
         "image_type",
         R"code(The color space of input and output image)code",

--- a/dali/operators/crop/slice.cc
+++ b/dali/operators/crop/slice.cc
@@ -32,6 +32,7 @@ coordinates and `WH` order for the slice arguments.)code")
     .NumInput(3)
     .NumOutput(1)
     .AllowSequences()
+    .SupportVolumetric()
     .AddOptionalArg("image_type",
       R"code(The color space of input and output image)code",
       DALI_RGB, false)

--- a/dali/operators/displacement/rotate.cc
+++ b/dali/operators/displacement/rotate.cc
@@ -21,6 +21,7 @@ DALI_SCHEMA(Rotate)
   .NumInput(1)
   .NumOutput(1)
   .InputLayout(0, { "HWC", "DHWC" })
+  .SupportVolumetric()
   .AddOptionalArg<float>("axis", "3D only: axis around which to rotate.\n"
   "The vector does not need to be normalized, but must have non-zero length.\n"
   "Reversing the vector is equivalent to changing the sign of `angle`.\n",

--- a/dali/operators/displacement/warp_affine.cc
+++ b/dali/operators/displacement/warp_affine.cc
@@ -21,6 +21,7 @@ DALI_SCHEMA(WarpAffine)
   .NumInput(1, 2)
   .NumOutput(1)
   .InputLayout(0, { "HWC", "DHWC" })
+  .SupportVolumetric()
   .AddOptionalArg<float>("matrix",
       R"code(Transform matrix (dst -> src).
 Given list of values `(M11, M12, M13, M21, M22, M23)`

--- a/dali/operators/fused/crop_mirror_normalize.cc
+++ b/dali/operators/fused/crop_mirror_normalize.cc
@@ -33,6 +33,7 @@ normalization only.
   .NumInput(1)
   .NumOutput(1)
   .AllowSequences()
+  .SupportVolumetric()
   .AddOptionalArg("output_dtype",
     R"code(Output data type. Supported types: `FLOAT` and `FLOAT16`)code", DALI_FLOAT)
   .AddOptionalArg("output_layout",

--- a/dali/operators/geometric/flip.cc
+++ b/dali/operators/geometric/flip.cc
@@ -30,7 +30,8 @@ DALI_SCHEMA(Flip)
     .AddOptionalArg("vertical", R"code(Perform a vertical flip.)code", 0, true)
     .AddOptionalArg("depthwise", R"code(Perform a depthwise flip.)code", 0, true)
     .InputLayout({"FDHWC", "FHWC", "DHWC", "HWC", "FCDHW", "FCHW", "CDHW", "CHW"})
-    .AllowSequences();
+    .AllowSequences()
+    .SupportVolumetric();
 
 
 template <>

--- a/dali/operators/geometric/shapes.cc
+++ b/dali/operators/geometric/shapes.cc
@@ -20,6 +20,8 @@ DALI_SCHEMA(Shapes)
     .DocStr(R"code(Returns the shapes of inputs.)code")
     .NumInput(1)
     .NumOutput(1)
+    .AllowSequences()
+    .SupportVolumetric()
     .AddOptionalArg("type", R"code(Data type, to which the sizes are converted.)code", DALI_INT64);
 
 DALI_REGISTER_OPERATOR(Shapes, Shapes<CPUBackend>, CPU);

--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -38,6 +38,8 @@ In this case, the `synchronize_stream` flag can be set to false.')code")
 Should be set to false only if the called function schedules the device job
 to the stream used by DALI.)code", true)
     .NumInput(0, 256)
+    .AllowSequences()
+    .SupportVolumetric()
     .NoPrune()
     .AddParent("PythonFunctionBase");
 

--- a/dali/operators/python_function/python_function.cc
+++ b/dali/operators/python_function/python_function.cc
@@ -41,12 +41,16 @@ DALI_SCHEMA(PythonFunctionBase)
 DALI_SCHEMA(PythonFunction)
         .DocStr("Executes a python function")
         .NumInput(0, 256)
+        .AllowSequences()
+        .SupportVolumetric()
         .NoPrune()
         .AddParent("PythonFunctionBase");
 
 DALI_SCHEMA(TorchPythonFunction)
         .DocStr("Executes a function operating on Torch tensors")
         .NumInput(0, 256)
+        .AllowSequences()
+        .SupportVolumetric()
         .NoPrune()
         .AddParent("PythonFunctionBase");
 

--- a/dali/operators/transpose/transpose.cc
+++ b/dali/operators/transpose/transpose.cc
@@ -21,6 +21,7 @@ DALI_SCHEMA(Transpose)
   .NumInput(1)
   .NumOutput(1)
   .AllowSequences()
+  .SupportVolumetric()
   .AddArg("perm",
       R"code(Permutation of the dimensions of the input (e.g. [2, 0, 1]).)code",
       DALI_INT_VEC)

--- a/dali/operators/util/cast.cc
+++ b/dali/operators/util/cast.cc
@@ -40,6 +40,8 @@ DALI_SCHEMA(Cast)
   .DocStr("Cast tensor to a different type")
   .NumInput(1)
   .NumOutput(1)
+  .AllowSequences()
+  .SupportVolumetric()
   .AddArg("dtype",
       R"code(Output data type.)code",
       DALI_DATA_TYPE);

--- a/dali/operators/util/lookup_table.cc
+++ b/dali/operators/util/lookup_table.cc
@@ -78,6 +78,8 @@ Note: Only integer types can be used as input to this operator
 )code")
   .NumInput(1)
   .NumOutput(1)
+  .AllowSequences()
+  .SupportVolumetric()
   .AddOptionalArg("output_dtype",
     R"code(Output data type.)code",
     DALI_FLOAT)

--- a/dali/operators/util/reshape.cc
+++ b/dali/operators/util/reshape.cc
@@ -25,6 +25,8 @@ DALI_SCHEMA(Reshape)
   .DocStr(R"code(Treats content of the input as if it had a different shape and layout.)code")
   .NumInput(1, 2)
   .NumOutput(1)
+  .AllowSequences()
+  .SupportVolumetric()
   .AddOptionalArg<int>("shape", "The desired shape of the output. Number of elements in "
                                 "each sample must match that of the input sample.",
                                 std::vector<int>(), true)

--- a/dali/pipeline/operator/builtin/copy.cc
+++ b/dali/pipeline/operator/builtin/copy.cc
@@ -35,6 +35,8 @@ DALI_REGISTER_OPERATOR(Copy, Copy<CPUBackend>, CPU);
 DALI_SCHEMA(Copy)
   .DocStr("Make a copy of the input tensor")
   .NumInput(1)
-  .NumOutput(1);
+  .NumOutput(1)
+  .AllowSequences()
+  .SupportVolumetric();
 
 }  // namespace dali

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -178,12 +178,11 @@ class DLL_PUBLIC OpSchema {
   }
 
   /**
-   * Notes if the operator can process 3D data.
-   * @param support
+   * Notes that the operator can process 3D data.
    * @return
    */
-  DLL_PUBLIC inline OpSchema& SupportVolumetric(bool support = true) {
-    support_volumetric_ = support;
+  DLL_PUBLIC inline OpSchema& SupportVolumetric() {
+    support_volumetric_ = true;
     return *this;
   }
 
@@ -249,12 +248,6 @@ class DLL_PUBLIC OpSchema {
                  " already specified");
     for (auto &l : layouts) {
       DALI_ENFORCE(!l.empty(), "Cannot specify an empty layout for an input");
-    }
-    for (auto &l : layouts) {
-      if (l.contains('D')) {
-        support_volumetric_ = true;
-        break;
-      }
     }
     input_layouts_[index] = layouts;
     return *this;

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -178,6 +178,16 @@ class DLL_PUBLIC OpSchema {
   }
 
   /**
+   * Notes if the operator can process 3D data.
+   * @param support
+   * @return
+   */
+  DLL_PUBLIC inline OpSchema& SupportVolumetric(bool support = true) {
+    support_volumetric_ = support;
+    return *this;
+  }
+
+  /**
    * @brief Notes that this operator is internal to DALI backend (and shouldn't be exposed in Python API)
    */
   DLL_PUBLIC inline OpSchema& MakeInternal() {
@@ -239,6 +249,12 @@ class DLL_PUBLIC OpSchema {
                  " already specified");
     for (auto &l : layouts) {
       DALI_ENFORCE(!l.empty(), "Cannot specify an empty layout for an input");
+    }
+    for (auto &l : layouts) {
+      if (l.contains('D')) {
+        support_volumetric_ = true;
+        break;
+      }
     }
     input_layouts_[index] = layouts;
     return *this;
@@ -403,6 +419,10 @@ class DLL_PUBLIC OpSchema {
     return allow_sequences_;
   }
 
+  DLL_PUBLIC inline bool SupportsVolumetric() const {
+    return support_volumetric_;
+  }
+
   DLL_PUBLIC inline bool IsInternal() const {
     return is_internal_;
   }
@@ -490,6 +510,8 @@ class DLL_PUBLIC OpSchema {
 
   bool allow_instance_grouping_ = true;
   vector<string> parents_;
+
+  bool support_volumetric_ = false;
 
   bool allow_sequences_ = false;
   bool is_sequence_operator_ = false;

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -853,6 +853,7 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("IsTensorArgument", &OpSchema::IsTensorArgument)
     .def("IsSequenceOperator", &OpSchema::IsSequenceOperator)
     .def("AllowsSequences", &OpSchema::AllowsSequences)
+    .def("SupportsVolumetric", &OpSchema::SupportsVolumetric)
     .def("IsInternal", &OpSchema::IsInternal)
     .def("IsNoPrune", &OpSchema::IsNoPrune)
     .def("IsDeprecated", &OpSchema::IsDeprecated)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -94,6 +94,9 @@ def _docstring_generator(cls):
     elif schema.AllowsSequences():
         ret += "\nThis operator allows sequence inputs\n"
 
+    if schema.SupportsVolumetric():
+        ret += "\nThis operator supports volumetric data\n"
+
     if schema.IsDeprecated():
         use_instead = schema.DeprecatedInFavorOf()
         ret += "\n.. warning::\n\n   This operator is now deprecated"

--- a/docs/supported_op_devices.py
+++ b/docs/supported_op_devices.py
@@ -11,13 +11,13 @@ def main(argv):
     link_string = '_'
     op_name_max_len = len(max(all_ops, key=len)) + len(link_string)
     name_bar = op_name_max_len * '='
-    formater = '{:{c}<{op_name_max_len}} {:{c}^6}  {:{c}^6}  {:{c}^7} {:{c}^9}\n'
+    formater = '{:{c}<{op_name_max_len}} {:{c}^6}  {:{c}^6}  {:{c}^7} {:{c}^9} {:{c}^10}\n'
     doc_table = ''
     doc_table += 'Below table lists all available operators and devices they can operate on.\n\n'
     doc_table += '.. |v| image:: images/tick.gif\n'
     doc_table += '\n'
     doc_table += formater.format('', '', '', '', '', '', op_name_max_len = op_name_max_len, c='=')
-    doc_table += formater.format('Operator name', 'CPU', 'GPU', 'Mixed', 'Sequences', op_name_max_len = op_name_max_len, c=' ')
+    doc_table += formater.format('Operator name', 'CPU', 'GPU', 'Mixed', 'Sequences', 'Volumetric', op_name_max_len = op_name_max_len, c=' ')
     doc_table += formater.format('', '', '', '', '', '', op_name_max_len = op_name_max_len, c='=')
     for op in sorted(all_ops, key=lambda v: str(v).lower()):
         schema = b.GetSchema(op)
@@ -25,8 +25,9 @@ def main(argv):
         is_gpu = '|v|' if op in gpu_ops else ''
         is_mixed = '|v|' if op in mix_ops else ''
         supports_seq = '|v|' if schema.AllowsSequences() or schema.IsSequenceOperator() else ''
+        volumetric = '|v|' if schema.SupportsVolumetric() else ''
         op_string = op + link_string
-        op_doc = formater.format(op_string, is_cpu, is_gpu, is_mixed, supports_seq, op_name_max_len = op_name_max_len, c=' ')
+        op_doc = formater.format(op_string, is_cpu, is_gpu, is_mixed, supports_seq, volumetric, op_name_max_len = op_name_max_len, c=' ')
         doc_table += op_doc
     doc_table += formater.format('', '', '', '', '', '', op_name_max_len = op_name_max_len, c='=')
     with open(argv[0], 'w') as f:

--- a/docs/supported_ops.rst
+++ b/docs/supported_ops.rst
@@ -3,7 +3,8 @@ Supported operations
 - **CPU** operator means that the operator can be scheduled on the CPU. Outputs of CPU operators may be used as regular inputs and to provide per-sample parameters for other operators through tensor arguments.
 - **GPU** operator means that the operator can be scheduled on the GPU. Their outputs may only be used as regular inputs for other GPU operators and pipeline outputs.
 - **Mixed** operator means that the operator accepts input on the CPU while producing the output on the GPU.
-- **Sequences** are an operator that can work (produce or accept as an input) sequence (video like) kind of input.
+- **Sequences** means that the operator can work (produce or accept as an input) sequence (video like) kind of input.
+- **Volumetric** means that the operator supports 3D data processing.
 
 .. include:: op_inclusion
 


### PR DESCRIPTION
Signed-off-by: Rafal <Banas.Rafal97@gmail.com>

#### Why we need this PR?
- It extends documentation of operators to include info about the support of  3D data.

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
   It adds a property to `OpSchema`. Support of volumetric data can be also inferred from the accepted input layouts.
 - Was this PR tested? How?
   Checked how the documentation is rendered. 
 - Were docs and examples updated, if necessary?
   YES

![image](https://user-images.githubusercontent.com/32324320/69969281-6c644680-151c-11ea-95bb-b222d7671ce5.png)


**JIRA TASK**: [DALI-1161]