### PR TITLE
Add comparison operators and bool handling in arithmetic ops

### DIFF
--- a/dali/operators/expressions/constant_storage.h
+++ b/dali/operators/expressions/constant_storage.h
@@ -32,8 +32,11 @@
 
 namespace dali {
 
-#define CONSTANT_STORAGE_ALLOWED_TYPES \
-  (uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float16, float, double)
+#define CONSTANT_STORAGE_ALLOWED_TYPES   \
+  (bool,                                 \
+  uint8_t, uint16_t, uint32_t, uint64_t, \
+  int8_t, int16_t, int32_t, int64_t,     \
+  float16, float, double)
 
 /**
  * @brief Provide integral and floating point constants under `Backend` memory accessible by

--- a/dali/operators/expressions/constant_storage_test.cc
+++ b/dali/operators/expressions/constant_storage_test.cc
@@ -47,12 +47,13 @@ class ConstantStorageTest : public ::testing::Test {
     {0, DALIDataType::DALI_FLOAT},
     {2, DALIDataType::DALI_INT32},
     {1, DALIDataType::DALI_FLOAT16},
+    {3, DALIDataType::DALI_BOOL},
   };
 
   std::vector<ExprConstant*> constant_ptrs_;
 
   OpSpec good_spec_;
-  std::vector<int> integers_ = {1, 1024, 42};
+  std::vector<int> integers_ = {1, 1024, 42, false};
   std::vector<float> reals_ = {0.1f, 0.42f};
 
   OpSpec bad_spec_;

--- a/dali/operators/expressions/expression_impl_factory.h
+++ b/dali/operators/expressions/expression_impl_factory.h
@@ -38,7 +38,8 @@ namespace dali {
 
 #define ALLOWED_BIN_OPS                                                                            \
   (ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div, ArithmeticOp::fdiv, \
-      ArithmeticOp::mod)
+      ArithmeticOp::mod, ArithmeticOp::eq, ArithmeticOp::neq, ArithmeticOp::lt, ArithmeticOp::leq, \
+      ArithmeticOp::gt, ArithmeticOp::geq)
 
 struct ExprImplTask {
   ExprImplBase *impl;
@@ -215,7 +216,7 @@ std::unique_ptr<ExprImplBase> ExprImplFactoryBinOp(const ExprFunc &expr) {
             result.reset(new ImplConstantTensor<op_static, Out_t, Left_t, Right_t>());
           } else if (expr[0].GetNodeType() == NodeType::Tensor &&
                      expr[1].GetNodeType() == NodeType::Tensor) {
-            // Bot are non-scalar tensors
+            // Both are non-scalar tensors
             result.reset(new ImplTensorTensor<op_static, Out_t, Left_t, Right_t>());
           } else {
             DALI_FAIL("Expression cannot have two scalar operands");

--- a/dali/operators/expressions/expression_tree.cc
+++ b/dali/operators/expressions/expression_tree.cc
@@ -30,6 +30,7 @@ namespace {
 
 DALIDataType TypeNameToTypeId(const std::string &type_name) {
   static std::map<std::string, DALIDataType> token_to_type_id = {
+    {"bool",    DALIDataType::DALI_BOOL},
     {"uint8",   DALIDataType::DALI_UINT8},
     {"uint16",  DALIDataType::DALI_UINT16},
     {"uint32",  DALIDataType::DALI_UINT32},

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -144,6 +144,7 @@ constexpr bool IsFloatingPoint(DALIDataType type) {
 
 constexpr bool IsIntegral(DALIDataType type) {
   switch (type) {
+    case DALI_BOOL:
     case DALI_UINT8:
     case DALI_UINT16:
     case DALI_UINT32:
@@ -152,6 +153,34 @@ constexpr bool IsIntegral(DALIDataType type) {
     case DALI_INT16:
     case DALI_INT32:
     case DALI_INT64:
+      return true;
+    default:
+      return false;
+  }
+}
+
+constexpr bool IsSigned(DALIDataType type) {
+  switch (type) {
+    case DALI_FLOAT16:
+    case DALI_FLOAT:
+    case DALI_FLOAT64:
+    case DALI_INT8:
+    case DALI_INT16:
+    case DALI_INT32:
+    case DALI_INT64:
+      return true;
+    default:
+      return false;
+  }
+}
+
+constexpr bool IsUnsigned(DALIDataType type) {
+  switch (type) {
+    case DALI_BOOL:
+    case DALI_UINT8:
+    case DALI_UINT16:
+    case DALI_UINT32:
+    case DALI_UINT64:
       return true;
     default:
       return false;

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -637,7 +637,7 @@ def _is_boolean_like(input):
 
 # Boolean and integer types are considered integer-like
 def _is_integer_like(input):
-    if type(input) == bool:
+    if _is_boolean_like(input):
         return True
     if type(input) == int:
         return True

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -20,7 +20,8 @@ from itertools import count
 import threading
 from nvidia.dali import backend as b
 from nvidia.dali.types import _type_name_convert_to_string, _type_convert_value, \
-        _vector_element_type, _int_types, _float_types, DALIDataType, CUDAStream, Constant
+        _vector_element_type, _bool_types, _int_types, _int_like_types, _float_types, \
+        DALIDataType, CUDAStream, Constant
 from nvidia.dali.pipeline import Pipeline
 from future.utils import with_metaclass
 import nvidia.dali.libpython_function_plugin
@@ -69,6 +70,24 @@ class _EdgeReference(object):
     # Shortucitng the execution, unary + is basically a no-op
     def __pos__(self):
         return self
+
+    def __eq__(self, other):
+        return _arithm_op("eq", self, other)
+
+    def __ne__(self, other):
+        return _arithm_op("neq", self, other)
+
+    def __lt__(self, other):
+        return _arithm_op("lt", self, other)
+
+    def __le__(self, other):
+        return _arithm_op("leq", self, other)
+
+    def __gt__(self, other):
+        return _arithm_op("gt", self, other)
+
+    def __ge__(self, other):
+        return _arithm_op("geq", self, other)
 
 _cpu_ops = set({})
 _gpu_ops = set({})
@@ -608,11 +627,22 @@ def _choose_device(inputs):
         return "gpu"
     return "cpu"
 
+def _is_boolean_like(input):
+    if type(input) == bool:
+        return True
+    if isinstance(input, Constant):
+        if input.dtype in _bool_types:
+            return True
+    return False
+
+# Boolean and integer types are considered integer-like
 def _is_integer_like(input):
+    if type(input) == bool:
+        return True
     if type(input) == int:
         return True
     if isinstance(input, Constant):
-        if input.dtype in _int_types:
+        if input.dtype in _int_like_types:
             return True
     return False
 
@@ -626,27 +656,30 @@ def _is_real_like(input):
 
 # <type> description required by ArithmeticGenericOp
 def _to_type_desc(input):
-    if  type(input) == int:
+    if type(input) == bool:
+        return "bool"
+    if type(input) == int:
         return "int32"
     if type(input) == float:
         return "float32" # TODO(klecki): current DALI limitation
     if isinstance(input, Constant):
         dtype_to_desc = {
-            DALIDataType.INT8: "int8",
-            DALIDataType.INT16: "int16",
-            DALIDataType.INT32: "int32",
-            DALIDataType.INT64: "int64",
-            DALIDataType.UINT8: "uint8",
-            DALIDataType.UINT16: "uint16",
-            DALIDataType.UINT32: "uint32",
-            DALIDataType.UINT64: "uint64",
+            DALIDataType.BOOL:    "bool",
+            DALIDataType.INT8:    "int8",
+            DALIDataType.INT16:   "int16",
+            DALIDataType.INT32:   "int32",
+            DALIDataType.INT64:   "int64",
+            DALIDataType.UINT8:   "uint8",
+            DALIDataType.UINT16:  "uint16",
+            DALIDataType.UINT32:  "uint32",
+            DALIDataType.UINT64:  "uint64",
             DALIDataType.FLOAT16: "float16",
-            DALIDataType.FLOAT: "float32",
+            DALIDataType.FLOAT:   "float32",
             DALIDataType.FLOAT64: "float64",
         }
         return dtype_to_desc[input.dtype]
     raise TypeError(("Constant argument to arithmetic operation not supported. Got {}, expected "
-            "a constant value of type 'int', 'float' or 'nvidia.dali.types.Constant'.")
+            "a constant value of type 'bool', 'int', 'float' or 'nvidia.dali.types.Constant'.")
             .format(str(type(input))))
 
 
@@ -670,7 +703,7 @@ def _group_inputs(inputs):
             reals.append(input)
         else:
             raise TypeError(("Argument to arithmetic operation not supported. Got {}, expected "
-                    "a return value from other DALI Operator  or a constant value of type 'int', "
+                    "a return value from other DALI Operator  or a constant value of type 'bool', 'int', "
                     "'float' or 'nvidia.dali.types.Constant'.").format(str(type(input))))
     if len(integers) == 0:
         integers = None
@@ -693,7 +726,7 @@ def _generate_input_desc(categories_idx, integers, reals):
             input_desc += " "
     return input_desc
 
-# Create arguments for ArithmeticGenericOp andd call it with supplied inputs.
+# Create arguments for ArithmeticGenericOp and call it with supplied inputs.
 # Select the `gpu` device if at least one of the inputs is `gpu`, otherwise `cpu`.
 def _arithm_op(name, *inputs):
     categories_idxs, edges, integers, reals = _group_inputs(inputs)
@@ -708,7 +741,7 @@ def _arithm_op(name, *inputs):
         dev_inputs = list(edge.gpu() for edge in edges)
     else:
         dev_inputs = edges
-    # Call it imediatelly
+    # Call it immediately
     return op(*dev_inputs)
 
 def cpu_ops():

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -102,9 +102,13 @@ class CUDAStream:
         """Raw CUDA stream pointer, stored as uint64."""
         return self._ptr
 
-_float_types = [DALIDataType.FLOAT16, DALIDataType.FLOAT, DALIDataType.FLOAT64]
+_bool_types = [DALIDataType.BOOL]
 _int_types = [DALIDataType.INT8, DALIDataType.INT16, DALIDataType.INT32, DALIDataType.INT64,
               DALIDataType.UINT8, DALIDataType.UINT16, DALIDataType.UINT32, DALIDataType.UINT64]
+_float_types = [DALIDataType.FLOAT16, DALIDataType.FLOAT, DALIDataType.FLOAT64]
+
+_int_like_types = _bool_types + _int_types
+_all_types = _bool_types + _int_types + _float_types
 
 class Constant(object):
     """Wrapper for a constant value that can be used in arithmetic operations
@@ -112,27 +116,35 @@ class Constant(object):
 
     It indicates what type it should be treated as. The integers values
     will be passed to DALI as `int32` and the floating point values as `float32`.
-    Python builtin types `int` and `float` will also be treated as those types.
+    Python builtin types `bool`, `int` and `float` will also be treated as those types.
     """
     def __init__(self, value, dtype=None):
-        if not isinstance(value, (int, float)):
-            raise TypeError("Expected scalar value of type 'int' or 'float', got {}."
+        if not isinstance(value, (bool, int, float)):
+            raise TypeError("Expected scalar value of type 'bool', int' or 'float', got {}."
                     .format(str(type(value))))
         if dtype:
             self.dtype = dtype
-            if self.dtype in _int_types:
+            if self.dtype in _bool_types:
+                self.value = bool(value)
+            elif self.dtype in _int_types:
                 self.value = int(value)
             elif self.dtype in _float_types:
                 self.value = float(value)
             else:
                 raise TypeError("DALI Constant can only hold one of: {} types."
-                        .format(_int_types + _float_types))
+                        .format(_all_types))
+        elif isinstance(value, bool):
+            self.value = value
+            self.dtype = DALIDataType.BOOL
         elif isinstance(value, int):
             self.value = value
             self.dtype = DALIDataType.INT32
         elif isinstance(value, float):
             self.value = value
             self.dtype = DALIDataType.FLOAT
+
+    def bool(self):
+        return Constant(self.value, DALIDataType.BOOL)
 
     def int8(self):
         return Constant(self.value, DALIDataType.INT8)
@@ -168,19 +180,34 @@ class Constant(object):
         return Constant(self.value, DALIDataType.FLOAT64)
 
     def __eq__(self, other):
-        return self.value == other.value and self.dtype == other.dtype
+        if isinstance(other, Constant):
+            return self.value == other.value and self.dtype == other.dtype
+        # Delegate the call to the `__eq__` of other object, most probably an `_EdgeReference`
+        return other.__eq__(self)
+
+    def __ne__(self, other):
+        if isinstance(other, Constant):
+            return self.value != other.value or self.dtype != other.dtype
+        # Delegate the call to the `__ne__` of other object, most probably an `_EdgeReference`
+        return other.__ne__(self)
+
+    def __bool__(self):
+        if self.dtype in _int_like_types:
+            return bool(self.value)
+        raise TypeError(("DALI Constant must be converted to one of bool or int types: ({}) "
+                "explicitly before casting to builtin `bool`.").format(_int_like_types))
 
     def __int__(self):
-        if self.dtype in _int_types:
-            return self.value
-        raise TypeError("DALI Constant must be converted to one of int types explicitly before "
-                "casting to builtin 'int'.")
+        if self.dtype in _int_like_types:
+            return int(self.value)
+        raise TypeError(("DALI Constant must be converted to one of bool or int types: ({}) "
+                "explicitly before casting to builtin `int`.").format(_int_like_types))
 
     def __float__(self):
         if self.dtype in _float_types:
             return self.value
-        raise TypeError("DALI Constant must be converted to one of float types explicitly before "
-                "casting to builtin 'float'.")
+        raise TypeError(("DALI Constant must be converted to one of the float types: ({}) "
+                "explicitly before casting to builtin `float`.").format(_float_types))
 
     def __str__(self):
         return "{}:{}".format(self.value, self.dtype)

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -168,7 +168,7 @@ def float_generator(shape, type, _):
         return type([np.random.rand()])
 
 # Generates inputs of required shapes and types
-# The number of inputs is based on the lenghth of tuple `types`, if types is a single elementm
+# The number of inputs is based on the length of tuple `types`, if types is a single element
 # it is considered we should generate 1 output.
 # If the kind contains 'scalar', than the result is batch of scalar tensors.
 # the "shape" of `kinds` arguments should match the `types` argument - single elements or tuples of

--- a/qa/TL0_python-self-test/test_body.sh
+++ b/qa/TL0_python-self-test/test_body.sh
@@ -2,7 +2,7 @@
 
 test_nose() {
     for test_script in $(ls test_operator_*.py test_pipeline*.py test_backend_impl.py); do
-        nosetests --verbose ${test_script}
+        nosetests --verbose --attr '!slow' ${test_script}
     done
 }
 

--- a/qa/TL1_python-self-test-slow/test.sh
+++ b/qa/TL1_python-self-test-slow/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages="nose numpy opencv-python pillow librosa"
+target_dir=./dali/test/python
+
+test_body() {
+    for test_script in $(ls test_operator_*.py test_pipeline*.py test_backend_impl.py); do
+        nosetests --verbose --attr 'slow' ${test_script}
+    done
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd


### PR DESCRIPTION
#### Why we need this PR?
It adds comparisons and boolean handling to DALI expressions/arithmetic ops.

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
The boolean type was registered for type promotions, support for Constants with booleans and native python `bool` was added.
Implementation for all possible comparisons was added, with safe handling of comparisons between singed and unsigned integers.
Tests were extended and some subset of tests was marked as 'slow' and split into a L1 level test.
 - What was changed, added, removed?
 - What is most important part that reviewers should focus on?
 - Was this PR tested? How?
 - Were docs and examples updated, if necessary?

**JIRA TASK**: [DALI-1178]