### PR TITLE
Disables cupy test for python 2.7

### DIFF
--- a/qa/TL0_python_self_test_frameworks/test_cupy.sh
+++ b/qa/TL0_python_self_test_frameworks/test_cupy.sh
@@ -4,7 +4,10 @@ pip_packages="nose numpy cupy"
 target_dir=./dali/test/python
 
 test_body() {
-    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*cupy' test_dltensor_operator.py
+    if [[ ${PYTHON_VERSION} != 2.7 ]]
+    then
+        nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*cupy' test_dltensor_operator.py
+    fi
 }
 
 pushd ../..


### PR DESCRIPTION
- cupy 7.0.0 doesn't work with python 2.7 so disable relevant tests
  for this python version

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- disables cupy test for python 2.7

#### What happened in this PR?
 - cupy 7.0.0 doesn't work with python 2.7 so disable relevant tests for this python version
 - tested in CI

**JIRA TASK**: [NA]