### PR TITLE
Wait for thread pool to finish work in BrightnessConstrast

### DIFF
--- a/dali/operators/audio/preemphasis_filter_op.cc
+++ b/dali/operators/audio/preemphasis_filter_op.cc
@@ -57,12 +57,13 @@ void PreemphasisFilterCpu::RunImpl(workspace_t<CPUBackend> &ws) {
   TYPE_SWITCH(input.type().id(), type2id, InputType, PREEMPH_TYPES, (
     TYPE_SWITCH(output_type_, type2id, OutputType, PREEMPH_TYPES, (
           for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
-            auto work = [&, sample_id](int thread_id) {
-                    const auto in_ptr = input[sample_id].data<InputType>();
-                    auto out_ptr = output[sample_id].mutable_data<OutputType>();
-                    auto num_samples = volume(output[sample_id].shape());
-                    DALI_ENFORCE(input[sample_id].shape() == output[sample_id].shape(),
-                             "Input and output shapes don't match");
+            tp.DoWorkWithID(
+              [&, sample_id](int thread_id) {
+                const auto in_ptr = input[sample_id].data<InputType>();
+                auto out_ptr = output[sample_id].mutable_data<OutputType>();
+                auto num_samples = volume(output[sample_id].shape());
+                DALI_ENFORCE(input[sample_id].shape() == output[sample_id].shape(),
+                          "Input and output shapes don't match");
                 if (preemph_coeff_[sample_id] == 0.f) {
                   for (long j = 0; j < num_samples; j++) {  // NOLINT (long)
                     out_ptr[j] = ConvertSat<OutputType>(in_ptr[j]);
@@ -74,8 +75,7 @@ void PreemphasisFilterCpu::RunImpl(workspace_t<CPUBackend> &ws) {
                   }
                   out_ptr[0] = ConvertSat<OutputType>(in_ptr[0] * preemph_coeff_[sample_id]);
                 }
-            };
-            tp.DoWorkWithID(work);
+              });
           }
     ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
   ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())))  // NOLINT

--- a/dali/operators/color/brightness_contrast.cc
+++ b/dali/operators/color/brightness_contrast.cc
@@ -52,7 +52,7 @@ bool BrightnessContrastCpu::SetupImpl(std::vector<OutputDesc> &output_desc,
           {
               using Kernel = TheKernel<OutputType, InputType>;
               kernel_manager_.Initialize<Kernel>();
-              auto shapes = CallSetup<Kernel, InputType>(input, ws.data_idx());
+              auto shapes = CallSetup<Kernel, InputType>(input);
               TypeInfo type;
               type.SetType<OutputType>(output_type_);
               output_desc[0] = {shapes, type};

--- a/dali/operators/color/brightness_contrast.cu
+++ b/dali/operators/color/brightness_contrast.cu
@@ -38,7 +38,7 @@ bool BrightnessContrastGpu::SetupImpl(std::vector<OutputDesc> &output_desc,
           {
               using Kernel = TheKernel<OutputType, InputType>;
               kernel_manager_.Initialize<Kernel>();
-              auto shapes = CallSetup<Kernel, InputType>(input, ws.data_idx());
+              auto shapes = CallSetup<Kernel, InputType>(input);
               TypeInfo type;
               type.SetType<OutputType>(output_type_);
               output_desc[0] = {shapes, type};
@@ -59,7 +59,7 @@ void BrightnessContrastGpu::RunImpl(workspace_t<GPUBackend> &ws) {
               kernels::KernelContext ctx;
               auto tvin = view<const InputType, 3>(input);
               auto tvout = view<OutputType, 3>(output);
-              kernel_manager_.Run<Kernel>(ws.thread_idx(), ws.data_idx(), ctx, tvout, tvin,
+              kernel_manager_.Run<Kernel>(ws.thread_idx(), 0, ctx, tvout, tvin,
                                           brightness_, contrast_);
           }
       ), DALI_FAIL("Unsupported output type"))  // NOLINT

--- a/dali/operators/color/brightness_contrast.h
+++ b/dali/operators/color/brightness_contrast.h
@@ -94,15 +94,14 @@ class BrightnessContrastCpu : public BrightnessContrastOp<CPUBackend> {
 
  private:
   template <typename Kernel, typename InputType>
-  TensorListShape<> CallSetup(const TensorVector<CPUBackend> &input, int instance_idx) {
+  TensorListShape<> CallSetup(const TensorVector<CPUBackend> &input) {
     kernels::KernelContext ctx;
     TensorListShape<> sh = input.shape();
     TensorListShape<> ret(sh.num_samples(), 3);
     assert(static_cast<size_t>(sh.num_samples()) == brightness_.size());
     for (int i = 0; i < sh.num_samples(); i++) {
       const auto tvin = view<const InputType, 3>(input[i]);
-      const auto reqs = kernel_manager_.Setup<Kernel>(instance_idx, ctx, tvin, brightness_[i],
-                                                      contrast_[i]);
+      const auto reqs = kernel_manager_.Setup<Kernel>(i, ctx, tvin, brightness_[i], contrast_[i]);
       const TensorListShape<> &out_sh = reqs.output_shapes[0];
       ret.set_tensor_shape(i, out_sh.tensor_shape(0));
     }
@@ -126,11 +125,10 @@ class BrightnessContrastGpu : public BrightnessContrastOp<GPUBackend> {
 
  private:
   template <typename Kernel, typename InputType>
-  TensorListShape<> CallSetup(const TensorList<GPUBackend> &tl, int instance_idx) {
+  TensorListShape<> CallSetup(const TensorList<GPUBackend> &tl) {
     kernels::KernelContext ctx;
     const auto tvin = view<const InputType, 3>(tl);
-    const auto reqs = kernel_manager_.Setup<Kernel>(instance_idx, ctx, tvin, brightness_,
-                                                    contrast_);
+    const auto reqs = kernel_manager_.Setup<Kernel>(0, ctx, tvin, brightness_, contrast_);
     return reqs.output_shapes[0];
   }
 };

--- a/dali/operators/color/hsv.cu
+++ b/dali/operators/color/hsv.cu
@@ -37,7 +37,7 @@ bool HsvGpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<G
           {
               using Kernel = TheKernel<OutputType, InputType>;
               kernel_manager_.Initialize<Kernel>();
-              auto shapes = CallSetup<Kernel, InputType>(input, ws.data_idx());
+              auto shapes = CallSetup<Kernel, InputType>(input);
               TypeInfo type;
               type.SetType<OutputType>(output_type_);
               output_desc[0] = {shapes, type};
@@ -58,8 +58,8 @@ void HsvGpu::RunImpl(workspace_t<GPUBackend> &ws) {
               kernels::KernelContext ctx;
               auto tvin = view<const InputType, 3>(input);
               auto tvout = view<OutputType, 3>(output);
-              kernel_manager_.Run<Kernel>(ws.thread_idx(), ws.data_idx(),
-                      ctx, tvout, tvin, make_cspan(tmatrices_));
+              kernel_manager_.Run<Kernel>(ws.thread_idx(), 0, ctx, tvout, tvin,
+                                          make_cspan(tmatrices_));
           }
       ), DALI_FAIL("Unsupported output type"))  // NOLINT
   ), DALI_FAIL("Unsupported input type"))  // NOLINT

--- a/dali/operators/color/hsv.h
+++ b/dali/operators/color/hsv.h
@@ -174,14 +174,14 @@ class HsvCpu : public HsvOp<CPUBackend> {
 
  private:
   template <typename Kernel, typename InputType>
-  TensorListShape<> CallSetup(const TensorVector<CPUBackend> &input, int instance_idx) {
+  TensorListShape<> CallSetup(const TensorVector<CPUBackend> &input) {
     kernels::KernelContext ctx;
     TensorListShape<> sh = input.shape();
     TensorListShape<> ret(sh.num_samples(), 3);
     assert(static_cast<size_t>(sh.num_samples()) == tmatrices_.size());
     for (int i = 0; i < sh.num_samples(); i++) {
       const auto tvin = view<const InputType, 3>(input[i]);
-      const auto reqs = kernel_manager_.Setup<Kernel>(instance_idx, ctx, tvin, tmatrices_[i]);
+      const auto reqs = kernel_manager_.Setup<Kernel>(i, ctx, tvin, tmatrices_[i]);
       const TensorListShape<> &out_sh = reqs.output_shapes[0];
       ret.set_tensor_shape(i, out_sh.tensor_shape(0));
     }
@@ -206,11 +206,10 @@ class HsvGpu : public HsvOp<GPUBackend> {
 
  private:
   template <typename Kernel, typename InputType>
-  TensorListShape<> CallSetup(const TensorList<GPUBackend> &tl, int instance_idx) {
+  TensorListShape<> CallSetup(const TensorList<GPUBackend> &tl) {
     kernels::KernelContext ctx;
     const auto tvin = view<const InputType, 3>(tl);
-    const auto reqs = kernel_manager_.Setup<Kernel>(instance_idx, ctx, tvin,
-                                                    make_cspan(tmatrices_));
+    const auto reqs = kernel_manager_.Setup<Kernel>(0, ctx, tvin, make_cspan(tmatrices_));
     return reqs.output_shapes[0];
   }
 };

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -104,6 +104,7 @@ void AudioDecoderCpu::RunImpl(workspace_t<Backend> &ws) {
         }
     });
   }
+  tp.WaitForWork();
 }
 
 }  // namespace dali

--- a/dali/operators/expressions/arithmetic.cc
+++ b/dali/operators/expressions/arithmetic.cc
@@ -39,6 +39,7 @@ void ArithmeticGenericOp<CPUBackend>::RunImpl(HostWorkspace &ws) {
       }
     });
   }
+  pool.WaitForWork();
 }
 
 DALI_SCHEMA(ArithmeticGenericOp)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one*
- It fixes a bug in BrightnessContrast operator where a reference captured by a lambda was going out of scope before the lambda finished

#### What happened in this PR?
- Add WaitForWork

**JIRA TASK**: [DALI-XXXX]