### PR TITLE
Add an ability to return a duplicated outputs from the DALI pipeline

### DIFF
--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -485,12 +485,9 @@ void Pipeline::Build(vector<std::pair<string, string>> output_names) {
         PrepareOpSpec(&spec, GetNextInternalLogicalId());
 
         graph_.AddOp(spec, "__MakeContiguous_" + name);
-
-        outputs.push_back("contiguous_" + name + "_" + device);
-      } else {
-        // handle contiguous output from gpu ops
-        outputs.push_back(name + "_" + device);
+        it->second.has_contiguous = true;
       }
+      outputs.push_back("contiguous_" + name + "_" + device);
     } else if (device == "gpu") {
       if (!it->second.has_gpu) {
         DALI_ENFORCE(it->second.has_cpu, "Output '" + name +
@@ -719,7 +716,7 @@ string Pipeline::SerializeToProtobuf() const {
   printf("%s\n", pipe.DebugString().c_str());
 #endif
 
-  return pipe.SerializeAsString();
+  return output;
 }
 
 OpNode * Pipeline::GetOperatorNode(const std::string& name) {

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -19,7 +19,15 @@ from nvidia.dali import tensors as Tensors
 from nvidia.dali import types
 from nvidia.dali import check_edge as Edge
 from threading import local as tls
+import warnings
 pipeline_tls = tls()
+
+def _show_deprecation_warning(deprecated, in_favor_of):
+    # show only this warning
+    with warnings.catch_warnings():
+        warnings.simplefilter("default")
+        warnings.warn("{} is deprecated, please use {} instead".format(deprecated, in_favor_of),
+                      Warning, stacklevel=2)
 
 
 class Pipeline(object):
@@ -377,6 +385,7 @@ class Pipeline(object):
     # for the backward compatibility
     def _run(self):
         """Deprecated. Use `nvidia.dali.pipeline.Pipeline.schedule_run` instead."""
+        _show_deprecation_warning("_run", "schedule_run")
         self.schedule_run()
 
     def share_outputs(self):
@@ -392,7 +401,7 @@ class Pipeline(object):
         Needs to be used together with :meth:`nvidia.dali.pipeline.Pipeline.release_outputs`
         and :meth:`nvidia.dali.pipeline.Pipeline.schedule_run`
         Should not be mixed with :meth:`nvidia.dali.pipeline.Pipeline.run` in the same pipeline"""
-        with self._check_api_type_scope(types.PipelineAPIType.SCHEDULED) as check:
+        with self._check_api_type_scope(types.PipelineAPIType.SCHEDULED):
             if self._batches_to_consume == 0 or self._gpu_batches_to_consume == 0:
                 raise StopIteration
             self._batches_to_consume -= 1
@@ -402,6 +411,7 @@ class Pipeline(object):
     # for the backward compatibility
     def _share_outputs(self):
         """Deprecated. Use :meth:`nvidia.dali.pipeline.Pipeline.share_outputs` instead"""
+        _show_deprecation_warning("_share_outputs", "share_outputs")
         self.share_outputs()
 
     def release_outputs(self):
@@ -415,7 +425,7 @@ class Pipeline(object):
         Needs to be used together with :meth:`nvidia.dali.pipeline.Pipeline.schedule_run`
         and :meth:`nvidia.dali.pipeline.Pipeline.share_outputs`
         Should not be mixed with :meth:`nvidia.dali.pipeline.Pipeline.run` in the same pipeline"""
-        with self._check_api_type_scope(types.PipelineAPIType.SCHEDULED) as check:
+        with self._check_api_type_scope(types.PipelineAPIType.SCHEDULED):
             if not self._built:
                 raise RuntimeError("Pipeline must be built first.")
             return self._pipe.ReleaseOutputs()
@@ -423,6 +433,7 @@ class Pipeline(object):
     # for the backward compatibility
     def _release_outputs(self):
         """Deprecated. Use :meth:`nvidia.dali.pipeline.Pipeline.release_outputs` instead"""
+        _show_deprecation_warning("_release_outputs", "release_outputs")
         self.release_outputs()
 
     def _outputs(self):
@@ -433,7 +444,7 @@ class Pipeline(object):
         if not self._built:
             raise RuntimeError("Pipeline must be built first.")
         return self._pipe.Outputs()
-
+    
     def run(self):
         """Run the pipeline and return the result.
 
@@ -443,7 +454,7 @@ class Pipeline(object):
         Should not be mixed with :meth:`nvidia.dali.pipeline.Pipeline.schedule_run` in the same pipeline,
         :meth:`nvidia.dali.pipeline.Pipeline.share_outputs` and
         :meth:`nvidia.dali.pipeline.Pipeline.release_outputs`"""
-        with self._check_api_type_scope(types.PipelineAPIType.BASIC) as check:
+        with self._check_api_type_scope(types.PipelineAPIType.BASIC):
             self.schedule_run()
             return self.outputs()
 

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -136,7 +136,7 @@ class DALIGenericIterator(object):
         self._dynamic_shape = dynamic_shape
         # Build all pipelines
         for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR) as check:
+            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.build()
         # Use double-buffering of data batches
         self._data_batches = [[None] for i in range(self._num_gpus)]
@@ -154,7 +154,7 @@ class DALIGenericIterator(object):
         # We need data about the batches (like shape information),
         # so we need to run a single batch as part of setup to get that info
         for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR) as check:
+            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.schedule_run()
         self._first_batch = None
         self._first_batch = self.next()
@@ -187,7 +187,7 @@ class DALIGenericIterator(object):
         # Gather outputs
         outputs = []
         for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR) as check:
+            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 outputs.append(p.share_outputs())
         for i in range(self._num_gpus):
             # MXNet wants batches with clear distinction between
@@ -251,7 +251,7 @@ class DALIGenericIterator(object):
                 feed_ndarray(category_tensors[DALIGenericIterator.LABEL_TAG][j], l_arr)
 
         for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR) as check:
+            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.release_outputs()
                 p.schedule_run()
 
@@ -300,7 +300,7 @@ class DALIGenericIterator(object):
             for p in self._pipes:
                 p.reset()
                 if p.empty():
-                    with p._check_api_type_scope(types.PipelineAPIType.ITERATOR) as check:
+                    with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                         p.schedule_run()
         else:
             logging.warning("DALI iterator does not support resetting while epoch is not finished. Ignoring...")

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -129,7 +129,7 @@ class DALIGenericIterator(object):
         self._pipes = pipelines
         # Build all pipelines
         for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR) as check:
+            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.build()
         # Use double-buffering of data batches
         self._data_batches = [None for i in range(self._num_gpus)]
@@ -141,7 +141,7 @@ class DALIGenericIterator(object):
         # We need data about the batches (like shape information),
         # so we need to run a single batch as part of setup to get that info
         for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR) as check:
+            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.schedule_run()
         self._first_batch = None
         self._first_batch = self.next()
@@ -158,7 +158,7 @@ class DALIGenericIterator(object):
         # Gather outputs
         outputs = []
         for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR) as check:
+            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                outputs.append(p.share_outputs())
         for i in range(self._num_gpus):
             dev_id = self._pipes[i].device_id
@@ -209,7 +209,7 @@ class DALIGenericIterator(object):
                   feed_ndarray(tensor, pyt_tensors[category])
 
         for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR) as check:
+            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.release_outputs()
                 p.schedule_run()
 
@@ -260,7 +260,7 @@ class DALIGenericIterator(object):
             for p in self._pipes:
                 p.reset()
                 if p.empty():
-                    with p._check_api_type_scope(types.PipelineAPIType.ITERATOR) as check:
+                    with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                         p.schedule_run()
         else:
             logging.warning("DALI iterator does not support resetting while epoch is not finished. Ignoring...")

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -109,7 +109,7 @@ def check_batch(batch1, batch2, batch_size, eps = 1e-07):
 def compare_pipelines(pipe1, pipe2, batch_size, N_iterations, eps = 1e-07):
     pipe1.build()
     pipe2.build()
-    for k in range(N_iterations):
+    for _ in range(N_iterations):
         out1 = pipe1.run()
         out2 = pipe2.run()
         assert len(out1) == len(out2)


### PR DESCRIPTION
- adds a code that prevents adding "MakeContiguous" multiple times to the output
- adds tests for CPU, GPU and Mixed operators outputs that duplicates
- some small clean up in used API checker in the Pipeline

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- add an ability to return a duplicated outputs from the DALI pipeline

#### What happened in this PR?
 - adds a code that prevents adding "MakeContiguous" multiple times to the output
 - adds a visible deprecation warning for some pipeline methods
 - some small code cleanup
 - tests are added for the duplicated outputs (CPU, GPU and Mixed operators outputs)
 - no docs update is necessary

**JIRA TASK**: [NA]