### PR TITLE
Fix stream usage in HSV and BrighnessContrast.

### DIFF
--- a/dali/operators/color/brightness_contrast.cu
+++ b/dali/operators/color/brightness_contrast.cu
@@ -41,7 +41,7 @@ bool BrightnessContrastGpu::SetupImpl(std::vector<OutputDesc> &output_desc,
           {
               using Kernel = TheKernel<OutputType, InputType>;
               kernel_manager_.Initialize<Kernel>();
-              auto shapes = CallSetup<Kernel, InputType>(input);
+              auto &shapes = CallSetup<Kernel, InputType>(ws, input);
               TypeInfo type;
               type.SetType<OutputType>(output_type_);
               output_desc[0] = {shapes, type};
@@ -61,6 +61,7 @@ void BrightnessContrastGpu::RunImpl(workspace_t<GPUBackend> &ws) {
           {
               using Kernel = TheKernel<OutputType, InputType>;
               kernels::KernelContext ctx;
+              ctx.gpu.stream = ws.stream();
               auto tvin = view<const InputType, 3>(input);
               auto tvout = view<OutputType, 3>(output);
               for (int i = 0; i < tvin.num_samples(); i++) {

--- a/dali/operators/color/brightness_contrast.h
+++ b/dali/operators/color/brightness_contrast.h
@@ -165,10 +165,11 @@ class BrightnessContrastGpu : public BrightnessContrastOp<GPUBackend> {
 
  private:
   template <typename Kernel, typename InputType>
-  TensorListShape<> CallSetup(const TensorList<GPUBackend> &tl) {
+  const TensorListShape<> &CallSetup(const DeviceWorkspace &ws, const TensorList<GPUBackend> &tl) {
     kernels::KernelContext ctx;
+    ctx.gpu.stream = ws.stream();
     const auto tvin = view<const InputType, 3>(tl);
-    const auto reqs = kernel_manager_.Setup<Kernel>(0, ctx, tvin, brightness_, contrast_);
+    const auto &reqs = kernel_manager_.Setup<Kernel>(0, ctx, tvin, brightness_, contrast_);
     return reqs.output_shapes[0];
   }
   std::vector<float> addends_, multipliers_;

--- a/dali/operators/color/hsv.cu
+++ b/dali/operators/color/hsv.cu
@@ -37,7 +37,7 @@ bool HsvGpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<G
           {
               using Kernel = TheKernel<OutputType, InputType>;
               kernel_manager_.Initialize<Kernel>();
-              auto shapes = CallSetup<Kernel, InputType>(input);
+              auto &shapes = CallSetup<Kernel, InputType>(ws, input);
               TypeInfo type;
               type.SetType<OutputType>(output_type_);
               output_desc[0] = {shapes, type};
@@ -57,6 +57,7 @@ void HsvGpu::RunImpl(workspace_t<GPUBackend> &ws) {
           {
               using Kernel = TheKernel<OutputType, InputType>;
               kernels::KernelContext ctx;
+              ctx.gpu.stream = ws.stream();
               auto tvin = view<const InputType, 3>(input);
               auto tvout = view<OutputType, 3>(output);
               kernel_manager_.Run<Kernel>(ws.thread_idx(), 0, ctx, tvout, tvin,

--- a/dali/operators/color/hsv.h
+++ b/dali/operators/color/hsv.h
@@ -211,10 +211,11 @@ class HsvGpu : public HsvOp<GPUBackend> {
 
  private:
   template <typename Kernel, typename InputType>
-  TensorListShape<> CallSetup(const TensorList<GPUBackend> &tl) {
+  const TensorListShape<> &CallSetup(const DeviceWorkspace &ws, const TensorList<GPUBackend> &tl) {
     kernels::KernelContext ctx;
+    ctx.gpu.stream = ws.stream();
     const auto tvin = view<const InputType, 3>(tl);
-    const auto reqs = kernel_manager_.Setup<Kernel>(0, ctx, tvin, make_cspan(tmatrices_));
+    const auto &reqs = kernel_manager_.Setup<Kernel>(0, ctx, tvin, make_cspan(tmatrices_));
     return reqs.output_shapes[0];
   }
 };


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one*
- It fixes a bug: not setting CUDA stream in HSV and BrighnessContrast operators

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
 - What is most important part that reviewers should focus on?
    * stream is now set in the context
 - What was changed, added, removed?
    * additionally, output shape doesn't get two (!) additional copies when it's already persistent and returned by reference
 - Was this PR tested? How?
    * old tests apply
 - Were docs and examples updated, if necessary?
    * N/A

**JIRA TASK**: N/A
