### PR TITLE
Fix problem with TensorFlow and cupy tests

### DIFF
--- a/qa/TL0_python_self_test_frameworks/test_cupy.sh
+++ b/qa/TL0_python_self_test_frameworks/test_cupy.sh
@@ -4,10 +4,7 @@ pip_packages="nose numpy cupy"
 target_dir=./dali/test/python
 
 test_body() {
-    if [[ ${PYTHON_VERSION} != 2.7 ]]
-    then
-        nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*cupy' test_dltensor_operator.py
-    fi
+    nosetests --verbose -m '(?:^|[\b_\./-])[Tt]est.*cupy' test_dltensor_operator.py
 }
 
 pushd ../..

--- a/qa/TL1_tensorflow_dataset/test.sh
+++ b/qa/TL1_tensorflow_dataset/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose jupyter tensorflow-gpu"
+pip_packages="nose jupyter tensorflow-gpu ipykernel<5.0.0 ipython<7.0.0"
 target_dir=./dali/test/python
 
 # populate epilog and prolog with variants to enable/disable conda and virtual env

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -22,6 +22,7 @@ except ImportError:
 
 packages = {
             "opencv-python" : ["4.1.0.25"],
+            "cupy" : ["6.6.0"],
             "mxnet-cu{cuda_v}" : {
                         "90" : ["1.5.0"],
                         "100" : ["1.5.0"]},


### PR DESCRIPTION
- when tensorflow-gpu v1.15.0 is installed in the conda environment
  some strange dependency leads to `ModuleNotFoundError: No module
  named 'prompt_toolkit.formatted_text'` error
- according to https://github.com/jupyter/notebook/issues/4050 installing
  `ipykernel<5.0.0 ipython<7.0.0` helps
- fixes cupy version to 6.6.0 as this the last one supporting python 2.7

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- fix problem with TensorFlow and cupy tests
  - when tensorflow-gpu v1.15.0 is installed in the conda environment
  some strange dependency leads to `ModuleNotFoundError: No module
  named 'prompt_toolkit.formatted_text'` error
  - fixes cupy version to 6.6.0 as this the last one supporting python 2.7

#### What happened in this PR?
 - uses solution from according to https://github.com/jupyter/notebook/issues/4050 to `ModuleNotFoundError: No module named 'prompt_toolkit.formatted_text'` problem
 - fixes cupy version to 6.6.0 as this the last one supporting python 2.7
 - reenables cupy test for python 2.7
 - What is most important part that reviewers should focus on?
 - test was reenabled
 - no docs update necessary

**JIRA TASK**: [NA]