### PR TITLE
Use prebuild cupy in tests

### DIFF
--- a/qa/TL0_python_self_test_frameworks/test_cupy.sh
+++ b/qa/TL0_python_self_test_frameworks/test_cupy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy cupy"
+pip_packages="nose numpy cupy-cuda{cuda_v}"
 target_dir=./dali/test/python
 
 test_body() {

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -22,7 +22,9 @@ except ImportError:
 
 packages = {
             "opencv-python" : ["4.1.0.25"],
-            "cupy" : ["6.6.0"],
+            "cupy-cuda{cuda_v}" : {
+                        "90" : ["6.6.0"],
+                        "100" : ["6.6.0"]},
             "mxnet-cu{cuda_v}" : {
                         "90" : ["1.5.0"],
                         "100" : ["1.5.0"]},


### PR DESCRIPTION
- save installation time during tests by using prebuild cupy package

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- it shortens setup time for tests by using prebuild cupy wheel

#### What happened in this PR?
 -  save installation time during tests by using prebuild cupy package
 - change is related to TL0_python_self_test_frameworks and qa/setup_packages.py
 - tested with the existing tests for cupy

**JIRA TASK**: [DALI-XXXX]