### PR TITLE
Fix ToContiguousXXX for >2 inputs.

### DIFF
--- a/dali/kernels/scratch_copy_impl.h
+++ b/dali/kernels/scratch_copy_impl.h
@@ -71,8 +71,8 @@ auto GetCollectionPtrs(void *base, const size_t *offsets,
                        const Collections &...tail) {
   using T = std::remove_cv_t<element_t<Collection>>;
   return std::tuple_cat(
-    std::make_tuple(static_cast<T*>(base)),
-    GetCollectionPtrs(static_cast<char *>(base) + offsets[1], offsets+1, tail...));
+    std::make_tuple(reinterpret_cast<T*>(static_cast<char *>(base) + offsets[0])),
+    GetCollectionPtrs(base, offsets+1, tail...));
 }
 
 


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one*
- It fixes a bug: ToContiguousXXX produced wrong result for more than 2 inputs

#### What happened in this PR?
 - Explain solution of the problem, new feature added.
 - What was changed, added, removed?
 - What is most important part that reviewers should focus on?
    * Fixed calculating pointers - offset was added twice, resulting in wrong offsets for all inputs above 2nd
 - Was this PR tested? How?
    * Existing test modified to use 3 inputs
 - Were docs and examples updated, if necessary?
    * Not necessary

**JIRA TASK**: N/A
