### PR TITLE
Docs cleanup

### DIFF
--- a/dali/operators/audio/preemphasis_filter_op.cc
+++ b/dali/operators/audio/preemphasis_filter_op.cc
@@ -21,7 +21,8 @@ namespace dali {
 DALI_SCHEMA(PreemphasisFilter)
                 .DocStr(R"code(This operator performs preemphasis filter on the input data.
 This filter in simple form can be expressed by the formula:
-`Y(t) = X(t) - X(t-1)*coeff`)code")
+
+  ``Y(t) = X(t) - X(t-1)*coeff``)code")
                 .NumInput(1)
                 .NumOutput(detail::kNumOutputs)
                 .AddOptionalArg(detail::kCoeff, R"code(Preemphasis coefficient `coeff`)code", 0.97f)

--- a/dali/operators/audio/preemphasis_filter_op.cc
+++ b/dali/operators/audio/preemphasis_filter_op.cc
@@ -20,9 +20,9 @@ namespace dali {
 
 DALI_SCHEMA(PreemphasisFilter)
                 .DocStr(R"code(This operator performs preemphasis filter on the input data.
-This filter in simple form can be expressed by the formula:
+This filter in simple form can be expressed by the formula::
 
-  ``Y(t) = X(t) - X(t-1)*coeff``)code")
+  Y(t) = X(t) - X(t-1)*coeff)code")
                 .NumInput(1)
                 .NumOutput(detail::kNumOutputs)
                 .AddOptionalArg(detail::kCoeff, R"code(Preemphasis coefficient `coeff`)code", 0.97f)

--- a/dali/operators/color/brightness_contrast.cc
+++ b/dali/operators/color/brightness_contrast.cc
@@ -25,9 +25,9 @@ using TheKernel = kernels::MultiplyAddCpu<Out, In, 3>;
 
 
 DALI_SCHEMA(BrightnessContrast)
-    .DocStr(R"code(Adhust the brightness and contrast of the image according to the formula:
+    .DocStr(R"code(Adhust the brightness and contrast of the image according to the formula::
 
-``out = brightness_shift * output_range + brightness * (grey + contrast * (in - grey))``
+  out = brightness_shift * output_range + brightness * (grey + contrast * (in - grey))
 
 where output_range is 1 for float outputs or the maximum positive value for integral types;
 grey denotes the value of 0.5 for float, 128 for `uint8`, 16384 for `int16`, etc.

--- a/dali/operators/color/brightness_contrast.cc
+++ b/dali/operators/color/brightness_contrast.cc
@@ -25,7 +25,7 @@ using TheKernel = kernels::MultiplyAddCpu<Out, In, 3>;
 
 
 DALI_SCHEMA(BrightnessContrast)
-    .DocStr(R"code(Adhust the brightness and contrast of the image according to the formula::
+    .DocStr(R"code(Adjust the brightness and contrast of the image according to the formula::
 
   out = brightness_shift * output_range + brightness * (grey + contrast * (in - grey))
 

--- a/dali/operators/color/color_twist.cc
+++ b/dali/operators/color/color_twist.cc
@@ -36,8 +36,7 @@ Values >= 0 are accepted. For example:
 
 * `0` - black image,
 * `1` - no change
-* `2` - increase brightness twice
-)code", 1.f, true)
+* `2` - increase brightness twice)code", 1.f, true)
     .AddParent("ColorTransformBase")
     .Deprecate("BrightnessContrast")
     .InputLayout(0, "HWC");
@@ -52,8 +51,7 @@ Values >= 0 are accepted. For example:
 
 * `0` - gray image,
 * `1` - no change
-* `2` - increase contrast twice
-)code", 1.f, true)
+* `2` - increase contrast twice)code", 1.f, true)
     .Deprecate("BrightnessContrast")
     .AddParent("ColorTransformBase");
 
@@ -76,8 +74,7 @@ DALI_SCHEMA(Saturation)
 Values >= 0 are supported. For example:
 
 * `0` - completely desaturated image
-* `1` - no change to image's saturation
-)code", 1.f, true)
+* `1` - no change to image's saturation)code", 1.f, true)
     .AddParent("ColorTransformBase")
     .Deprecate("Hsv")
     .InputLayout(0, "HWC");
@@ -93,25 +90,21 @@ DALI_SCHEMA(ColorTwist)
 Values >= 0 are supported. For example:
 
 * `0` - completely desaturated image
-* `1` - no change to image's saturation
-)code", 1.f, true)
+* `1` - no change to image's saturation)code", 1.f, true)
     .AddOptionalArg("contrast",
         R"code(Contrast change factor.
 Values >= 0 are accepted. For example:
 
 * `0` - gray image,
 * `1` - no change
-* `2` - increase contrast twice
-)code", 1.f, true)
+* `2` - increase contrast twice)code", 1.f, true)
     .AddOptionalArg("brightness",
         R"code(Brightness change factor.
 Values >= 0 are accepted. For example:
 
 * `0` - black image,
 * `1` - no change
-* `2` - increase brightness twice
-
-)code", 1.f, true)
+* `2` - increase brightness twice)code", 1.f, true)
     .AddParent("ColorTransformBase")
     .Deprecate("Hsv/BrightnessContrast")
     .InputLayout(0, "HWC");

--- a/dali/operators/color_space/color_space_conversion.cc
+++ b/dali/operators/color_space/color_space_conversion.cc
@@ -19,7 +19,7 @@
 namespace dali {
 
 DALI_SCHEMA(ColorSpaceConversion)
-    .DocStr(R"code(Converts between various image color models)code")
+    .DocStr(R"code(Converts between various image color models.)code")
     .NumInput(1)
     .NumOutput(1)
     .InputLayout("HWC")

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -23,8 +23,9 @@ This operator is a generic way of handling encoded data in DALI.
 It supports most of well-known audio formats (wav, flac, ogg).
 
 This operator produces two outputs:
-output[0]: batch of decoded data
-output[1]: batch of sampling rates [Hz]
+
+* output[0]: batch of decoded data
+* output[1]: batch of sampling rates [Hz]
 
 Sample rate (output[1]) at index `i` corresponds to sample (output[0]) at index `i`.
 On the event more metadata will appear, we reserve a right to change this behaviour.)code")

--- a/dali/operators/detection/box_encoder.cc
+++ b/dali/operators/detection/box_encoder.cc
@@ -185,14 +185,14 @@ DALI_REGISTER_OPERATOR(BoxEncoder, BoxEncoder<CPUBackend>, CPU);
 
 DALI_SCHEMA(BoxEncoder)
     .DocStr(
-        R"code("Encodes input bounding boxes and labels using set of default boxes (anchors) passed
+        R"code(Encodes input bounding boxes and labels using set of default boxes (anchors) passed
 during op construction. Follows algorithm described in https://arxiv.org/abs/1512.02325 and
 implemented in https://github.com/mlperf/training/tree/master/single_stage_detector/ssd
 Inputs must be supplied as two Tensors: `BBoxes` containing bounding boxes represented as
 `[l,t,r,b]`, and `Labels` containing the corresponding label for each bounding box.
 Results are two tensors: `EncodedBBoxes` containing M encoded bounding boxes as `[l,t,r,b]`,
 where M is number of anchors and `EncodedLabels` containing the corresponding label for each
-encoded box.")code")
+encoded box.)code")
     .NumInput(2)
     .NumOutput(2)
     .AddArg("anchors",
@@ -205,7 +205,7 @@ encoded box.")code")
     .AddOptionalArg(
         "offset",
         R"code(Returns normalized offsets `((encoded_bboxes*scale - anchors*scale) - mean) / stds`
-               in `EncodedBBoxes` using `std`, `mean` and `scale` arguments (default values are transparent).)code",
+in `EncodedBBoxes` using `std`, `mean` and `scale` arguments (default values are transparent).)code",
         false)
     .AddOptionalArg("scale",
             R"code(Rescale the box and anchors values before offset calculation (e.g. to get back to absolute values).)code",

--- a/dali/operators/fused/crop_mirror_normalize.cc
+++ b/dali/operators/fused/crop_mirror_normalize.cc
@@ -23,7 +23,7 @@ namespace dali {
 DALI_SCHEMA(CropMirrorNormalize)
   .DocStr(R"code(Perform fused cropping, normalization, format conversion
 (NHWC to NCHW) if desired, and type casting.
-Normalization takes input image and produces output using formula:
+Normalization takes input image and produces output using formula::
 
   output = (input - mean) / std
 

--- a/dali/operators/geometric/bb_flip.cc
+++ b/dali/operators/geometric/bb_flip.cc
@@ -26,8 +26,8 @@ DALI_REGISTER_OPERATOR(BbFlip, BbFlip<CPUBackend>, CPU);
 
 DALI_SCHEMA(BbFlip)
     .DocStr(R"code(Operator for horizontal flip (mirror) of bounding box.
-Input: Bounding box coordinates; in either [x, y, w, h]
-or [left, top, right, bottom] format. All coordinates are
+Input: Bounding box coordinates; in either `[x, y, w, h]`
+or `[left, top, right, bottom]` format. All coordinates are
 in the image coordinate system (i.e. 0.0-1.0))code")
     .NumInput(1)
     .NumOutput(1)

--- a/dali/operators/paste/bbox_paste.cc
+++ b/dali/operators/paste/bbox_paste.cc
@@ -22,17 +22,20 @@ DALI_SCHEMA(BBoxPaste)
     .DocStr(
         R"code(Transforms bounding boxes so that they are in the same place in the image after pasting it onto a larger canvas.
 
-Corner coordinates:
+Corner coordinates::
+
   (x', y') = (x/ratio + paste_x', y/ratio + paste_y')
 
-Box sizes:
+Box sizes::
+
   (w', h') = (w/ratio, h/ratio)
 
-Where:
+Where::
+
   paste_x' = paste_x * (ratio - 1)/ratio
   paste_y' = paste_y * (ratio - 1)/ratio
 
-Paste coordinates are normalized so that (0,0) aligns the image to top-left of the canvas and (1,1) aligns it to bottom-right.
+Paste coordinates are normalized so that `(0,0)` aligns the image to top-left of the canvas and `(1,1)` aligns it to bottom-right.
 )code")
   .NumInput(1)
   .NumOutput(1)

--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -32,7 +32,7 @@ with the `synchronize_stream` flag (true by default) and then making sure
 the scheduled device tasks are finished within the operator call.
 Alternatively, the gpu code can be done on the DALI's stream
 which may be determined by calling the `current_dali_stream()` function.
-In this case, the `synchronize_stream` flag can be set to false.')code")
+In this case, the `synchronize_stream` flag can be set to false.)code")
     .AddOptionalArg("synchronize_stream",
         R"code(Make DALI synchronize its CUDA stream before calling the python function.
 Should be set to false only if the called function schedules the device job

--- a/dali/operators/python_function/python_function.cc
+++ b/dali/operators/python_function/python_function.cc
@@ -39,7 +39,7 @@ DALI_SCHEMA(PythonFunctionBase)
         .MakeInternal();
 
 DALI_SCHEMA(PythonFunction)
-        .DocStr("Executes a python function")
+        .DocStr("Executes a python function.")
         .NumInput(0, 256)
         .AllowSequences()
         .SupportVolumetric()
@@ -47,7 +47,7 @@ DALI_SCHEMA(PythonFunction)
         .AddParent("PythonFunctionBase");
 
 DALI_SCHEMA(TorchPythonFunction)
-        .DocStr("Executes a function operating on Torch tensors")
+        .DocStr("Executes a function operating on Torch tensors.")
         .NumInput(0, 256)
         .AllowSequences()
         .SupportVolumetric()

--- a/dali/operators/reader/caffe_reader_op.cc
+++ b/dali/operators/reader/caffe_reader_op.cc
@@ -19,7 +19,7 @@ namespace dali {
 DALI_REGISTER_OPERATOR(CaffeReader, CaffeReader, CPU);
 
 DALI_SCHEMA(CaffeReader)
-  .DocStr("Read (Image, label) pairs from a Caffe LMDB")
+  .DocStr("Read (Image, label) pairs from a Caffe LMDB.")
   .NumInput(0)
   .OutputFn([](const OpSpec& spec) {
     auto image_available = spec.GetArgument<bool>("image_available");

--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -21,8 +21,8 @@ DALI_SCHEMA(COCOReader)
   .NumInput(0)
   .NumOutput(3)
   .DocStr(R"code(Read data from a COCO dataset composed of directory with images
-and an annotation files. For each image, with `m` bboxes, returns its bboxes as (m,4)
-Tensor (`m` * `[x, y, w, h] or `m` * [left, top, right, bottom]`) and labels as `(m,1)` Tensor (`m` * `category_id`).)code")
+and an annotation files. For each image, with `m` bboxes, returns its bboxes as `(m,4)`
+Tensor (``m * [x, y, w, h]`` or ``m * [left, top, right, bottom]``) and labels as `(m,1)` Tensor (``m * category_id``).)code")
   .AddOptionalArg(
     "meta_files_path",
     "Path to directory with meta files containing preprocessed COCO annotations.",
@@ -43,8 +43,10 @@ Tensor (`m` * `[x, y, w, h] or `m` * [left, top, right, bottom]`) and labels as 
       R"code(If true, segmentation masks are read and returned as polygons.
 Each mask can be one or more polygons. A polygon is a list of points (2 floats).
 For a given sample, the polygons are represented by two tensors:
-  `masks_meta` -> list of tuples (mask_idx, start_idx, count)
-  `masks_coords`-> list of (x,y) coordinates
+
+- `masks_meta` -> list of tuples (mask_idx, start_idx, count)
+- `masks_coords`-> list of (x,y) coordinates
+
 One mask can have one or more `masks_meta` having the same `mask_idx`, which means that the mask for that given
 index consists of several polygons).
 `start_idx` indicates the index of the first coords in `masks_coords`.

--- a/dali/operators/reader/mxnet_reader_op.cc
+++ b/dali/operators/reader/mxnet_reader_op.cc
@@ -20,7 +20,7 @@ namespace dali {
 DALI_REGISTER_OPERATOR(MXNetReader, MXNetReader, CPU);
 
 DALI_SCHEMA(MXNetReader)
-  .DocStr("Read sample data from a MXNet RecordIO")
+  .DocStr("Read sample data from a MXNet RecordIO.")
   .NumInput(0)
   .NumOutput(2)
   .AddArg("path",

--- a/dali/operators/reader/sequence_reader_op.cc
+++ b/dali/operators/reader/sequence_reader_op.cc
@@ -31,42 +31,27 @@ Expects file_root to contain set of directories, each of them represents one ext
 stream. Extracted video stream is represented by one file for each frame, sorting the paths to
 frames lexicographically should give the original order of frames.
 Sequences do not cross stream boundary and only full sequences are considered - there is no padding.
-Example:
 
-> file_root
+Example directory structure::
 
-  > 0
+  - file_root
+    - 0
+      - 00001.png
+      - 00002.png
+      - 00003.png
+      - 00004.png
+      - 00005.png
+      - 00006.png
+      ....
 
-    > 00001.png
-
-    > 00002.png
-
-    > 00003.png
-
-    > 00004.png
-
-    > 00005.png
-
-    > 00006.png
-
-    ....
-
-  > 1
-
-    > 00001.png
-
-    > 00002.png
-
-    > 00003.png
-
-    > 00004.png
-
-    > 00005.png
-
-    > 00006.png
-
-    ....
-)code")
+    - 1
+      - 00001.png
+      - 00002.png
+      - 00003.png
+      - 00004.png
+      - 00005.png
+      - 00006.png
+      ....)code")
     .NumInput(0)
     .NumOutput(1)  // ([Frames])
     .AddArg("file_root",

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -77,9 +77,9 @@ This option is mutually exclusive with `filenames` and `file_root`.)code",
       3)
   .AddOptionalArg("additional_decode_surfaces",
       R"code(Additional decode surfaces to use beyond minimum required.
-      This is ignored when decoder is not able to determine minimum
-      number of decode surfaces, which may happen when using an older driver.
-      This parameter can be used trade off memory usage with performance.)code",
+This is ignored when decoder is not able to determine minimum
+number of decode surfaces, which may happen when using an older driver.
+This parameter can be used trade off memory usage with performance.)code",
       2)
   .AddOptionalArg("normalized",
       R"code(Get output as normalized data.)code",
@@ -96,8 +96,8 @@ This option is mutually exclusive with `filenames` and `file_root`.)code",
       R"code(Skips check for variable frame rate on videos. This is useful when heuristic fails.)code", false)
   .AddOptionalArg("file_list_frame_num",
       R"code(If start/end timestamps are provided in file_list, interpret them as frame
-      numbers instead of timestamp. If floating point values are given, then
-      start frame number is ceiling of the number and end frame number is floor of
-      the number. Frame numbers start from 0.)code", false)
+numbers instead of timestamp. If floating point values are given, then
+start frame number is ceiling of the number and end frame number is floor of
+the number. Frame numbers start from 0.)code", false)
   .AddParent("LoaderBase");
 }  // namespace dali

--- a/dali/operators/resize/random_resized_crop.cc
+++ b/dali/operators/resize/random_resized_crop.cc
@@ -25,7 +25,7 @@ namespace dali {
 DALI_SCHEMA(RandomResizedCrop)
   .DocStr("Perform a crop with randomly chosen area and aspect ratio,"
 " then resize it to given size. Expects a 3-dimensional input with samples"
-" in HWC layout (height, width, channels)")
+" in HWC layout `(height, width, channels)`.")
   .NumInput(1)
   .NumOutput(1)
   .AddArg("size",

--- a/dali/operators/resize/resize.cc
+++ b/dali/operators/resize/resize.cc
@@ -39,18 +39,18 @@ The op will keep the aspect ratio of the original image.)code", 0.f, true)
   .AddOptionalArg("max_size", R"code(Maximum size of the longer dimension when resizing with `resize_shorter`.
 When set with `resize_shorter`, the shortest dimension will be resized to `resize_shorter` iff
 the longest dimension is smaller or equal to `max_size`. If not, the shortest dimension is resized to
-satisfy the constraint "longest_dim == `max_size`.
+satisfy the constraint ``longest_dim == max_size``.
 Can be also an array of size 2, where the two elements are maximum size per dimension (H, W).
 
 Example:
 
-Original image = "400x1200".
+Original image = ``400x1200``.
 
 Resized with:
 
-* `resize_shorter`="200"  (`max_size` not set) => "200x600"
-* `resize_shorter`="200", `max_size`="400      => "132x400"
-* `resize_shorter`="200", `max_size`=1000      => "200x600")code", std::vector<float>{0.f, 0.f}, false);
+* ``resize_shorter = 200``  (``max_size`` not set) => ``200x600``
+* ``resize_shorter = 200``, ``max_size =  400``    => ``132x400``
+* ``resize_shorter = 200``, ``max_size = 1000``    => ``200x600``)code", std::vector<float>{0.f, 0.f}, false);
 
 DALI_SCHEMA(Resize)
   .DocStr(R"code(Resize images.)code")

--- a/dali/operators/resize/resize_base.cc
+++ b/dali/operators/resize/resize_base.cc
@@ -40,7 +40,7 @@ DALI_SCHEMA(ResamplingFilterAttr)
   .DocStr(R"code(Resampling filter attribute placeholder)code")
   .AddOptionalArg("interp_type",
       R"code(Type of interpolation used. Use `min_filter` and `mag_filter` to specify
-      different filtering for downscaling and upscaling.)code",
+different filtering for downscaling and upscaling.)code",
       DALI_INTERP_LINEAR)
   .AddOptionalArg("mag_filter", "Filter used when scaling up",
       DALI_INTERP_LINEAR)

--- a/dali/operators/sequence/element_extract.cc
+++ b/dali/operators/sequence/element_extract.cc
@@ -18,7 +18,7 @@
 namespace dali {
 
 DALI_SCHEMA(ElementExtract)
-    .DocStr(R"code(Extracts one or more elements from input)code")
+    .DocStr(R"code(Extracts one or more elements from input.)code")
     .NumInput(1)
     .NumOutput(1)
     .SequenceOperator()

--- a/dali/operators/signal/decibel/to_decibels.cc
+++ b/dali/operators/signal/decibel/to_decibels.cc
@@ -27,11 +27,10 @@ namespace dali {
 
 DALI_SCHEMA(ToDecibels)
     .DocStr(R"code(Converts a magnitude (real, positive) to the decibel scale, according to the
-formula:
-```
-    min_ratio = pow(10, cutoff_db / multiplier)
-    out[i] = multiplier * log10( max(min_ratio, input[i] / reference) )
-```)code")
+formula::
+
+  min_ratio = pow(10, cutoff_db / multiplier)
+  out[i] = multiplier * log10( max(min_ratio, input[i] / reference) ))code")
     .NumInput(kNumInputs)
     .NumOutput(kNumOutputs)
     .AddOptionalArg("multiplier",

--- a/dali/operators/signal/fft/spectrogram.cc
+++ b/dali/operators/signal/fft/spectrogram.cc
@@ -28,7 +28,7 @@ namespace dali {
 
 DALI_SCHEMA(Spectrogram)
   .DocStr(R"code(Produces a spectrogram from a 1D signal (e.g. audio). Input data is expected
-to be single channel (1D shape `(time)`) or multi channel in planar layout (channel, time) 32 bit
+to be single channel (1D shape `(time)`) or multi channel in planar layout `(channel, time)` 32 bit
 float tensor.)code")
   .NumInput(1)
   .NumOutput(1)

--- a/dali/operators/signal/fft/spectrogram.cc
+++ b/dali/operators/signal/fft/spectrogram.cc
@@ -44,8 +44,8 @@ float tensor.)code")
     256)
   .AddOptionalArg("window_fn",
     R"code(Samples of the window function that will be multiplied to each extracted window when
-  calculating the STFT. If provided it should be a list of floating point numbers of size
-  `window_length`. If not provided, a Hann window will be used.)code",
+calculating the STFT. If provided it should be a list of floating point numbers of size
+`window_length`. If not provided, a Hann window will be used.)code",
     std::vector<float>{})
   .AddOptionalArg("power",
     R"code(Exponent of the magnitude of the spectrum. Supported values are 1 for energy and 2 for
@@ -53,7 +53,7 @@ power.)code",
     2)
   .AddOptionalArg("center_windows",
     R"code(Indicates whether extracted windows should be padded so that window function is centered
-at multiples of `window_step`. If set to false, the signal will not be padded, that is only windows 
+at multiples of `window_step`. If set to false, the signal will not be padded, that is only windows
 within the input range will be extracted.)code",
     true)
   .AddOptionalArg("reflect_padding",

--- a/dali/operators/util/cast.cc
+++ b/dali/operators/util/cast.cc
@@ -37,7 +37,7 @@ void Cast<CPUBackend>::RunImpl(SampleWorkspace &ws) {
 DALI_REGISTER_OPERATOR(Cast, Cast<CPUBackend>, CPU);
 
 DALI_SCHEMA(Cast)
-  .DocStr("Cast tensor to a different type")
+  .DocStr("Cast tensor to a different type.")
   .NumInput(1)
   .NumOutput(1)
   .AllowSequences()

--- a/dali/operators/util/lookup_table.cc
+++ b/dali/operators/util/lookup_table.cc
@@ -53,29 +53,28 @@ DALI_SCHEMA(LookupTable)
   .DocStr(R"code(Maps input to output by using a lookup table specified by `keys` and `values`
 and a `default_value` for non specified keys.
 
-`keys` and `values` are used to define the lookup table:
-```
-   keys[] =   {0,     2,   3,   4,   5,    3}
-   values[] = {0.2, 0.4, 0.5, 0.6, 0.7, 0.10}
-   default_value = 0.99
-```
-yielding
-```
-   lut[] = {0.2, 0.99, 0.4, 0.10, 0.6, 0.7}  // only last occurrence of a key is considered
-```
-producing the output according to the formula
-```
+`keys` and `values` are used to define the lookup table::
+
+  keys[] =   {0,     2,   3,   4,   5,    3}
+  values[] = {0.2, 0.4, 0.5, 0.6, 0.7, 0.10}
+  default_value = 0.99
+
+
+yielding::
+
+  lut[] = {0.2, 0.99, 0.4, 0.10, 0.6, 0.7}  // only last occurrence of a key is considered
+
+producing the output according to the formula::
+
    Output[i] = lut[Input[i]]   if 0 <= Input[i] <= len(lut)
    Output[i] = default_value   otherwise
-```
-  Example:
+
+Example::
+
   Input[] =  {1,      4,    1,   0,  100,   2,     3,   4}
   Output[] = {0.99, 0.6, 0.99, 0.2, 0.99, 0.4,  0.10, 0.6}
-```
 
-Note: Only integer types can be used as input to this operator
-
-)code")
+Note: Only integer types can be used as input to this operator.)code")
   .NumInput(1)
   .NumOutput(1)
   .AllowSequences()

--- a/dali/operators/util/pad.cu
+++ b/dali/operators/util/pad.cu
@@ -25,15 +25,24 @@ DALI_SCHEMA(Pad)
 to match the size of the biggest dimension on those axes in the batch.
 The element padding axes is specified with the argument `axes`.
 Supported types: int, float.
+
 Examples:
-- Batch of 3 1-d samples, fill_value=-1, axes=(0,)
+
+- Batch of 3 `1-D` samples, `fill_value` = -1, `axes` = (0,)
+
+::
+
   input  = [{3, 4, 2, 5, 4},
             {2, 2},
             {3, 199, 5}};
   output = [{3, 4, 2, 5, 4},
             {2, 2, -1, -1, -1},
             {3, 199, 5, -1, -1}]
-- Batch of 2 2-d samples, fill_value=42, axes=(1,)
+
+- Batch of 2 `2-D` samples, `fill_value` = 42, `axes` = (1,)
+
+::
+
   input  = [{{1, 2 , 3, 4},
              {5, 6, 7, 8}},
             {{1, 2},
@@ -41,8 +50,7 @@ Examples:
   output = [{{1,  2,  3,  4},
              {5,  6,  7,  8}},
             {{1,  2, 42, 42},
-             {4,  5, 42, 42}}]
-)code")
+             {4,  5, 42, 42}}])code")
     .NumInput(1)
     .NumOutput(1)
     .AddOptionalArg("fill_value",

--- a/dali/pipeline/operator/builtin/copy.cc
+++ b/dali/pipeline/operator/builtin/copy.cc
@@ -33,7 +33,7 @@ void Copy<CPUBackend>::RunImpl(SampleWorkspace &ws) {
 DALI_REGISTER_OPERATOR(Copy, Copy<CPUBackend>, CPU);
 
 DALI_SCHEMA(Copy)
-  .DocStr("Make a copy of the input tensor")
+  .DocStr("Make a copy of the input tensor.")
   .NumInput(1)
   .NumOutput(1)
   .AllowSequences()

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -79,8 +79,17 @@ def _docstring_generator(cls):
     schema = b.GetSchema(op_name)
     # insert tag to easily link to the operator
     ret = '.. _' + op_name + ':\n\n'
+
+    if schema.IsDeprecated():
+        use_instead = schema.DeprecatedInFavorOf()
+        ret += ".. warning::\n\n   This operator is now deprecated"
+        if use_instead:
+            ret +=". Use `" + use_instead + "` instead."
+        ret += "\n\n"
+
     ret += schema.Dox()
     ret += '\n'
+
     if schema.IsSequenceOperator():
         ret += "\nThis operator expects sequence inputs.\n"
     elif schema.AllowsSequences():
@@ -88,13 +97,6 @@ def _docstring_generator(cls):
 
     if schema.SupportsVolumetric():
         ret += "\nThis operator supports volumetric data.\n"
-
-    if schema.IsDeprecated():
-        use_instead = schema.DeprecatedInFavorOf()
-        ret += "\n.. warning::\n\n   This operator is now deprecated"
-        if use_instead:
-            ret +=". Use `" + use_instead + "` instead."
-        ret += "\n"
 
     if schema.IsNoPrune():
         ret += "\nThis operator will **not** be optimized out of the graph.\n"

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -82,18 +82,18 @@ def _docstring_generator(cls):
     ret += schema.Dox()
     ret += '\n'
     if schema.IsSequenceOperator():
-        ret += "\nThis operator expects sequence inputs\n"
+        ret += "\nThis operator expects sequence inputs.\n"
     elif schema.AllowsSequences():
-        ret += "\nThis operator allows sequence inputs\n"
+        ret += "\nThis operator allows sequence inputs.\n"
 
     if schema.SupportsVolumetric():
-        ret += "\nThis operator supports volumetric data\n"
+        ret += "\nThis operator supports volumetric data.\n"
 
     if schema.IsDeprecated():
         use_instead = schema.DeprecatedInFavorOf()
         ret += "\n.. warning::\n\n   This operator is now deprecated"
         if use_instead:
-            ret +=". Use `" + use_instead + "` instead"
+            ret +=". Use `" + use_instead + "` instead."
         ret += "\n"
 
     if schema.IsNoPrune():
@@ -106,7 +106,7 @@ def _docstring_generator(cls):
         op_dev.append("'gpu'")
     if op_name in _mixed_ops:
         op_dev.append("'mixed'")
-    ret += "\nSupported backends: " + ", ".join(op_dev) + "\n"
+    ret += "\nSupported backends: " + ", ".join(op_dev) + ".\n"
 
     ret += """
 Parameters

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -v
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = NVIDIADALI
 SOURCEDIR     = .

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -v
+SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = NVIDIADALI
 SOURCEDIR     = .

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -150,92 +150,97 @@ Prerequisites
 
 .. note::
 
-   This software uses the FFmpeg licensed code under the LGPLv2.1. Its source can be downloaded `from here. <https://developer.download.nvidia.com/compute/redist/nvidia-dali/ffmpeg-4.2.1.tar.bz2>`_
+  This software uses the FFmpeg licensed code under the LGPLv2.1. Its source can be downloaded `from here`__.
 
-   FFmpeg was compiled using the following command line:
+  .. __: `ffmpeg link`_
 
-.. code-block:: bash
+  FFmpeg was compiled using the following command line:
+
+  .. code-block:: bash
 
     ./configure \
-     --prefix=/usr/local \
-     --disable-static \
-     --disable-all \
-     --disable-autodetect \
-     --disable-iconv \
-     --enable-shared \
-     --enable-avformat \
-     --enable-avcodec \
-     --enable-avfilter \
-     --enable-protocol=file \
-     --enable-demuxer=mov,matroska,avi \
-     --enable-bsf=h264_mp4toannexb,hevc_mp4toannexb,mpeg4_unpack_bframes  && \
-     make
+    --prefix=/usr/local \
+    --disable-static \
+    --disable-all \
+    --disable-autodetect \
+    --disable-iconv \
+    --enable-shared \
+    --enable-avformat \
+    --enable-avcodec \
+    --enable-avfilter \
+    --enable-protocol=file \
+    --enable-demuxer=mov,matroska,avi \
+    --enable-bsf=h264_mp4toannexb,hevc_mp4toannexb,mpeg4_unpack_bframes  && \
+    make
 
 .. note::
 
-   This software uses the libsnd licensed under the LGPLv2.1. Its source can be downloaded `from here. <https://developer.download.nvidia.com/compute/redist/nvidia-dali/libsndfile-1.0.28.tar.gz>`_
+  This software uses the libsnd licensed under the LGPLv2.1. Its source can be downloaded `from here`__.
 
-   libsnd was compiled using the following command line:
+  .. __: `libsnd link`_
 
-.. code-block:: bash
+  libsnd was compiled using the following command line:
+
+  .. code-block:: bash
 
     ./configure && make
 
 
 Get the DALI source
-^^^^^^^^^^^^^^^^^^^
++++++++++++++++++++
 
 .. code-block:: bash
 
-    git clone --recursive https://github.com/NVIDIA/dali
-    cd dali
+  git clone --recursive https://github.com/NVIDIA/dali
+  cd dali
 
 Make the build directory
-^^^^^^^^^^^^^^^^^^^^^^^^
+++++++++++++++++++++++++
 
 .. code-block:: bash
 
-    mkdir build
-    cd build
+  mkdir build
+  cd build
 
 
 Compile DALI
 ^^^^^^^^^^^^
 
 Building DALI without LMDB support:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
++++++++++++++++++++++++++++++++++++
 
 .. code-block:: bash
 
-    cmake ..
-    make -j"$(nproc)"
+  cmake ..
+  make -j"$(nproc)"
 
 
 Building DALI with LMDB support:
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+++++++++++++++++++++++++++++++++
 
 .. code-block:: bash
 
-    cmake -DBUILD_LMDB=ON ..
-    make -j"$(nproc)"
+  cmake -DBUILD_LMDB=ON ..
+  make -j"$(nproc)"
 
 
 Building DALI using Clang (experimental):
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
++++++++++++++++++++++++++++++++++++++++++
 
 .. note::
 
-   This build is experimental. It is neither maintained nor tested. It is not guaranteed to work.
-   We recommend using GCC for production builds.
+  This build is experimental. It is neither maintained nor tested. It is not guaranteed to work.
+  We recommend using GCC for production builds.
 
 
 .. code-block:: bash
 
-    cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang  ..
-    make -j"$(nproc)"
+  cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang  ..
+  make -j"$(nproc)"
 
 
-**Optional CMake build parameters**:
+Optional CMake build parameters:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -  ``BUILD_PYTHON`` - build Python bindings (default: ON)
 -  ``BUILD_TEST`` - include building test suite (default: ON)
@@ -253,11 +258,13 @@ Building DALI using Clang (experimental):
 -  ``WERROR`` - treat all build warnings as errors (default: OFF)
 -  ``BUILD_WITH_ASAN`` - build with ASAN support (default: OFF). To run issue:
 
-   LD_LIBRARY_PATH=. ASAN_OPTIONS=symbolize=1:protect_shadow_gap=0 ASAN_SYMBOLIZER_PATH=$(shell which llvm-symbolizer)
-   LD_PRELOAD= *PATH_TO_LIB_ASAN* /libasan.so. *X* *PATH_TO_BINARY*
+.. code-block:: bash
 
-   Where *X* depends on used compiler version, for example GCC 7.x uses 4. Tested with GCC 7.4, CUDA 10.0
-   and libasan.4. Any earlier version may not work.
+  LD_LIBRARY_PATH=. ASAN_OPTIONS=symbolize=1:protect_shadow_gap=0 ASAN_SYMBOLIZER_PATH=$(shell which llvm-symbolizer)
+  LD_PRELOAD= *PATH_TO_LIB_ASAN* /libasan.so. *X* *PATH_TO_BINARY*
+
+  Where *X* depends on used compiler version, for example GCC 7.x uses 4. Tested with GCC 7.4, CUDA 10.0
+  and libasan.4. Any earlier version may not work.
 
 -  ``DALI_BUILD_FLAVOR`` - Allow to specify custom name sufix (i.e. 'nightly') for nvidia-dali whl package
 -  *(Unofficial)* ``BUILD_JPEG_TURBO`` - build with ``libjpeg-turbo`` (default: ON)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,8 @@ release = str(version_long)
 # generate table of supported operators and their devices
 subprocess.call(["python", "supported_op_devices.py", "op_inclusion"])
 
+keep_warnings = True
+
 # hack: version is used for html creation, so put the version picker
 # link here as well:
 option_on = " selected"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,8 @@ release = str(version_long)
 # generate table of supported operators and their devices
 subprocess.call(["python", "supported_op_devices.py", "op_inclusion"])
 
-keep_warnings = True
+# Uncomment to keep warnings in the output. Useful for verbose build and output debugging.
+# keep_warnings = True
 
 # hack: version is used for html creation, so put the version picker
 # link here as well:
@@ -139,7 +140,8 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# We remove the `_static` as we do not use it
+html_static_path = []
 
 # Download favicon and set it (the variable `html_favicon`) for this project.
 # It must be relative path.

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -19,3 +19,6 @@ Tutorials
    python_operator/python_operator.ipynb
    expressions/index
    audio/index
+   audio_decoder.ipynb
+   hsv_example.ipynb
+   brightness_contrast_example.ipynb

--- a/docs/examples/paddle/paddle-basic_example.ipynb
+++ b/docs/examples/paddle/paddle-basic_example.ipynb
@@ -11,7 +11,7 @@
     "This example shows how to use DALI in PaddlePaddle.\n",
     "\n",
     "This example uses CaffeReader.\n",
-    "See other [examples](...) for details on how to use different data formats."
+    "See other [examples](..) for details on how to use different data formats."
    ]
   },
   {
@@ -140,14 +140,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/examples/pytorch/pytorch-basic_example.ipynb
+++ b/docs/examples/pytorch/pytorch-basic_example.ipynb
@@ -11,7 +11,7 @@
     "This example shows how to use DALI in PyTorch.\n",
     "\n",
     "This example uses CaffeReader.\n",
-    "See other [examples](...) for details on how to use different data formats."
+    "See other [examples](..) for details on how to use different data formats."
    ]
   },
   {


### PR DESCRIPTION
There is still warning from notebooks which I don't know how to handle:
```
/dali/docs/examples/mxnet/mxnet-various-readers.ipynb:23: WARNING: File not found: 'examples'            
/dali/docs/examples/paddle/paddle-basic_example.ipynb:16: WARNING: File not found: 'examples/paddle/...' 
/dali/docs/examples/paddle/paddle-various-readers.ipynb:23: WARNING: File not found: 'examples'          
/dali/docs/examples/pytorch/pytorch-basic_example.ipynb:16: WARNING: File not found: 'examples/pytorch/..
/dali/docs/examples/pytorch/pytorch-various-readers.ipynb:23: WARNING: File not found: 'examples'        
/dali/docs/examples/serialization.ipynb:21: WARNING: File not found: 'examples'                          
/dali/docs/examples/tensorflow/tensorflow-plugin-tutorial.ipynb:32: WARNING: File not found: 'examples'  
/dali/docs/examples/tensorflow/tensorflow-various-readers.ipynb:23: WARNING: File not found: 'examples'  
```

#### Why we need this PR?
It cleans the formatting in docs and clears most of the warnings.

#### What happened in this PR?
 - Explain solution of the problem, new feature added.

The docs were formatted according to https://numpydoc.readthedocs.io/en/latest/format.html
and rst guide (which they use to be rendered). 

 - What was changed, added, removed?

Mostly adjust indents & insert new lines to allow sphinx to properly pick-up paragraphs, use `::` for blocks of code/formula, introduce next level of headings in compilation.rst, adjust conf.py to not use `_static`.

Inserted a lot of `.` at the end of the class docstrings, but didn't touch the kwargs docstrings which still miss them.

 - What is most important part that reviewers should focus on?

Mostly on formatting of `supported operations` page in docs.

 - Was this PR tested? How?

Local make html, should be validated with CI build for docs.

 - Were docs and examples updated, if necessary?

This updates the formatting of the docs, not the contents.

**JIRA TASK**: [DALI-1191]