### PR TITLE
Add interdoc link to define_graph, fix note

### DIFF
--- a/docs/supported_ops.rst
+++ b/docs/supported_ops.rst
@@ -10,20 +10,21 @@ How to read this doc
 ^^^^^^^^^^^^^^^^^^^^
 
 DALI Operators are used in two steps - creating the parametrized Operator instance using
-its constructor and later invoking its `__call__` operator in `define_graph` method of the Pipeline.
+its constructor and later invoking its `__call__` operator
+in :meth:`~nvidia.dali.pipeline.Pipeline.define_graph` method of the Pipeline.
 
 Documentation of every DALI Operator lists **Keyword Arguments** supported by the class constructor.
 
 The documentation for `__call__` operator lists the positional arguments (**Parameters**) and additional **Keyword Arguments**.
-`__call__` should be only used in the `define_graph`. The inputs to the `__call__` operator represent
-Tensors processed by DALI, which are returned by other DALI Operators.
+`__call__` should be only used in the :meth:`~nvidia.dali.pipeline.Pipeline.define_graph`.
+The inputs to the `__call__` operator represent Tensors processed by DALI, which are returned by other DALI Operators.
 
 The **Keyword Arguments** listed in `__call__` operator accept Tensor argument inputs. They should be
 produced by other 'cpu' Operators.
 
 .. note::
     The names of positional arguments for `__call__` operator (**Parameters**) are only for the
-    documentation purposes and should not be used as positional arguments.
+    documentation purposes and should not be used as keyword arguments.
 
 .. note::
     Some **Keyword Arguments** can be listed twice - once for class constructor and once for `__call__` operator.


### PR DESCRIPTION
#### Why we need this PR?
- It fixes a mistake in docs

#### What happened in this PR?
 - What solution was applied:

The note in supported_ops now prohibits using
the names of Parameters as **keyword** arguments
instead of positional arguments which was a mistake.

Interdoc reference of define_graph for better clarity.

 - Affected modules and functionalities:

Only docs

 - Key points relevant for the review:

Check if the paragraphs are ok and look at the rendered docs. 

 - Validation and testing:

Only docs build was checked

 - Documentation (including examples):

Docs update only


**JIRA TASK**: *[NA]*
