### PR TITLE
Load libnvcuvid before we test if cuvidReconfigureDecoder symbol exists

### DIFF
--- a/dali/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/operators/reader/nvdecoder/nvdecoder.cc
@@ -70,13 +70,6 @@ NvDecoder::NvDecoder(int device_id,
   LOG_LINE << "Using device: " << device_name << std::endl;
   DeviceGuard g(device_id_);
 
-  lib_handle_ = nvdecDriverHandle(cuvidInitChecked(0), cuvidDeinit);
-
-  DALI_ENFORCE(lib_handle_,
-    "Failed to load libnvcuvid.so, needed by the VideoReader operator. "
-    "If you are running in a Docker container, please refer "
-    "to https://github.com/NVIDIA/nvidia-docker/wiki/Usage");
-
   auto codec = Codec::H264;
   switch (codecpar->codec_id) {
     case AV_CODEC_ID_H264:

--- a/dali/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/operators/reader/nvdecoder/nvdecoder.h
@@ -21,7 +21,6 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 
 #include <condition_variable>
-#include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -114,10 +113,6 @@ class NvDecoder {
   int handle_sequence_(CUVIDEOFORMAT* format);
   int handle_decode_(CUVIDPICPARAMS* pic_params);
   int handle_display_(CUVIDPARSERDISPINFO* disp_info);
-
-  using nvdecDriverHandle = std::unique_ptr<std::remove_pointer<DLLDRIVER>::type,
-                                         std::function< void(DLLDRIVER) >>;
-  nvdecDriverHandle lib_handle_;
 
   class MappedFrame {
    public:


### PR DESCRIPTION
Signed-off-by: Abhishek Sansanwal <asansanwal@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug *bug description*
Check for cuvidReconfigureDecoder would always fail because
libnvcuvid was being loaded after the check. Consequently, we
would always fail to decode if we encountered two different resolution
videos in a VideoReader pipeline, even though the gtest case would pass because
we skip test in case of older drivers where libnvcuvid is missing cuvidReconfigureDecoder.

https://github.com/NVIDIA/DALI/blob/8816aae2a53c44b741cabb66b8df9d1d6e125644/dali/operators/reader/loader/video_loader.cc#L266

- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *[ Explain solution of the problem, a new feature added here. ]*
 - Affected modules and functionalities:
     *[ Describe here what was changed, added, removed. ]*
 - Key points relevant for the review:
     *[ Describe here what is the most important part that reviewers should focus on. ]*
 - Validation and testing:
     *[ Describe here if and how this PR is tested. ]*
 - Documentation (including examples):
     *[ Describe here if documentation and examples were updated. ]*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
