### PR TITLE
Mock imports when building docs where possible

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,14 +12,14 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
 # sys.path.insert(0, os.path.abspath('..'))
+import os
+import sys
 import sphinx_rtd_theme
+from sphinx.ext.autodoc.importer import mock, _MockImporter
 from builtins import str
 import re
 import subprocess
-import os
 
 # -- Project information -----------------------------------------------------
 
@@ -48,7 +48,13 @@ version = str(version_long + u"-" + git_sha)
 release = str(version_long)
 
 # generate table of supported operators and their devices
-subprocess.call(["python", "supported_op_devices.py", "op_inclusion"])
+# mock torch required by supported_op_devices
+importer = _MockImporter(["torch"])
+importer.load_module("torch")
+sys.path.insert(0, os.path.abspath('./'))
+import supported_op_devices
+
+supported_op_devices.main(["op_inclusion"])
 
 # Uncomment to keep warnings in the output. Useful for verbose build and output debugging.
 # keep_warnings = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,6 +117,10 @@ exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# Mock some of the dependencies for building docs. tf-plugin doc check tf version before loading,
+# so we do not mock tensorflow so we do not need to extend the logic there.
+autodoc_mock_imports = ['mxnet', 'paddle', 'torch', 'torchvision']
+
 # -- Options for Napoleon ----------------------------------------------------
 
 napoleon_custom_sections = ['Supported backends']

--- a/docs/supported_op_devices.py
+++ b/docs/supported_op_devices.py
@@ -3,13 +3,21 @@ import nvidia.dali.ops as ops
 import nvidia.dali.plugin.pytorch
 import sys
 
+# Dictionary with modules that can have registered Ops
+ops_modules = {
+    'nvidia.dali.ops': nvidia.dali.ops,
+    'nvidia.dali.plugin.pytorch': nvidia.dali.plugin.pytorch
+}
+
 def main(argv):
     cpu_ops = ops.cpu_ops()
     gpu_ops = ops.gpu_ops()
     mix_ops = ops.mixed_ops()
     all_ops = cpu_ops.union(gpu_ops).union(mix_ops)
-    link_formatter = ':meth:`{op} <nvidia.dali.ops.{op}>`'
-    op_name_max_len = len(link_formatter.format(op = "")) + 2 * len(max(all_ops, key=len))
+    longest_module = max(ops_modules.keys(), key = len)
+    link_formatter = ':meth:`{op} <{module}.{op}>`'
+    op_name_max_len = len(link_formatter.format(op = "", module = longest_module)) + \
+                      2 * len(max(all_ops, key=len))
     name_bar = op_name_max_len * '='
     formater = '{:{c}<{op_name_max_len}} {:{c}^6}  {:{c}^6}  {:{c}^7} {:{c}^9} {:{c}^10}\n'
     doc_table = ''
@@ -26,7 +34,9 @@ def main(argv):
         is_mixed = '|v|' if op in mix_ops else ''
         supports_seq = '|v|' if schema.AllowsSequences() or schema.IsSequenceOperator() else ''
         volumetric = '|v|' if schema.SupportsVolumetric() else ''
-        op_string = link_formatter.format(op = op)
+        for (module_name, module) in ops_modules.items():
+            if hasattr(module, op):
+                op_string = link_formatter.format(op = op, module = module_name)
         op_doc = formater.format(op_string, is_cpu, is_gpu, is_mixed, supports_seq, volumetric, op_name_max_len = op_name_max_len, c=' ')
         doc_table += op_doc
     doc_table += formater.format('', '', '', '', '', '', op_name_max_len = op_name_max_len, c='=')


### PR DESCRIPTION
#### Why we need this PR?
- It removes the necessity to have some packages installed when building docs

#### What happened in this PR?
 - What solution was applied:

Imports needed by docs are automatically mocked by sphinx.
Mock torch when doing ops discovery for support table.

List all possible modules and check from which
the op comes, so the links are properly
rendered.

 - Affected modules and functionalities:

Docs build

 - Key points relevant for the review:

NA

 - Validation and testing:

CI run, TODO: **diff the docs build and see if it is the same.** 

 - Documentation (including examples):

Change how docs are built, the outcome should not change.


**JIRA TASK**: *[NA]*
