### PR TITLE
Add bitwise operators: &, |, ^

### DIFF
--- a/dali/operators/expressions/arithmetic.h
+++ b/dali/operators/expressions/arithmetic.h
@@ -219,6 +219,24 @@ inline void GetConstantNodes(ExprNode &expr, std::vector<ExprConstant *> &nodes)
   }
 }
 
+
+/**
+ * @brief Provide an error when the node is an bitwise operator that has any floating point
+ *        inputs
+ */
+inline void CheckBitwise(ExprFunc &func) {
+  auto op = NameToOp(func.GetFuncName());
+  if (IsBitwise(op)) {
+    bool inputs_are_integral = true;
+    for (int i = 0; i < func.GetSubexpressionCount(); i++) {
+      inputs_are_integral = inputs_are_integral && IsIntegral(func[i].GetTypeId());
+    }
+    DALI_ENFORCE(inputs_are_integral, make_string("Inputs to bitwise operator `", to_string(op),
+                                                  "` must be of integral type."));
+  }
+}
+
+
 /**
  * @brief Provide an error when the node is an arithmetic operator (other than `*`)
  *        that has only boolean inputs.
@@ -256,6 +274,7 @@ inline void CheckAllowedOperations(ExprNode &expr) {
   }
   auto &func = dynamic_cast<ExprFunc &>(expr);
   CheckArithmeticOnBooleans(func);
+  CheckBitwise(func);
   for (int i = 0; i < func.GetSubexpressionCount(); i++) {
     CheckAllowedOperations(func[i]);
   }

--- a/dali/operators/expressions/expression_factory_instances/expression_factory_bit_and.cc
+++ b/dali/operators/expressions/expression_factory_instances/expression_factory_bit_and.cc
@@ -1,0 +1,24 @@
+
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/operators/expressions/expression_impl_cpu.h"
+#include "dali/operators/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_BINARY(bit_and);
+
+}  // namespace dali

--- a/dali/operators/expressions/expression_factory_instances/expression_factory_bit_and.cu
+++ b/dali/operators/expressions/expression_factory_instances/expression_factory_bit_and.cu
@@ -1,0 +1,25 @@
+
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/operators/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_BINARY(bit_and);
+
+}  // namespace dali

--- a/dali/operators/expressions/expression_factory_instances/expression_factory_bit_or.cc
+++ b/dali/operators/expressions/expression_factory_instances/expression_factory_bit_or.cc
@@ -1,0 +1,24 @@
+
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/operators/expressions/expression_impl_cpu.h"
+#include "dali/operators/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_BINARY(bit_or);
+
+}  // namespace dali

--- a/dali/operators/expressions/expression_factory_instances/expression_factory_bit_or.cu
+++ b/dali/operators/expressions/expression_factory_instances/expression_factory_bit_or.cu
@@ -1,0 +1,25 @@
+
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/operators/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_BINARY(bit_or);
+
+}  // namespace dali

--- a/dali/operators/expressions/expression_factory_instances/expression_factory_bit_xor.cc
+++ b/dali/operators/expressions/expression_factory_instances/expression_factory_bit_xor.cc
@@ -1,0 +1,24 @@
+
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/operators/expressions/expression_impl_cpu.h"
+#include "dali/operators/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_BINARY(bit_xor);
+
+}  // namespace dali

--- a/dali/operators/expressions/expression_factory_instances/expression_factory_bit_xor.cu
+++ b/dali/operators/expressions/expression_factory_instances/expression_factory_bit_xor.cu
@@ -1,0 +1,25 @@
+
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/expressions/arithmetic_meta.h"
+#include "dali/operators/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_BINARY(bit_xor);
+
+}  // namespace dali

--- a/dali/operators/expressions/expression_factory_instances/expression_impl_factory.h
+++ b/dali/operators/expressions/expression_factory_instances/expression_impl_factory.h
@@ -247,6 +247,30 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::gt, CPUBackend
 std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::geq, CPUBackend>,
                                         const ExprFunc &expr);
 
+/**
+ * @brief Factory function returning proper variant of implementation for `bit_and`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::bit_and, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `bit_or`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::bit_or, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `bit_xor`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::bit_xor, CPUBackend>,
+                                        const ExprFunc &expr);
+
 
 
 /**
@@ -361,6 +385,30 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::gt, GPUBackend
  *        specified in `expr`.
  */
 std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::geq, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `bit_and`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::bit_and, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `bit_or`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::bit_or, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `bit_xor`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::bit_xor, GPUBackend>,
                                         const ExprFunc &expr);
 
 

--- a/dali/operators/expressions/expression_impl_factory.h
+++ b/dali/operators/expressions/expression_impl_factory.h
@@ -39,7 +39,8 @@ namespace dali {
 #define ALLOWED_BIN_OPS                                                                            \
   (ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div, ArithmeticOp::fdiv, \
       ArithmeticOp::mod, ArithmeticOp::eq, ArithmeticOp::neq, ArithmeticOp::lt, ArithmeticOp::leq, \
-      ArithmeticOp::gt, ArithmeticOp::geq)
+      ArithmeticOp::gt, ArithmeticOp::geq, ArithmeticOp::bit_and, ArithmeticOp::bit_or,            \
+      ArithmeticOp::bit_xor)
 
 struct ExprImplTask {
   ExprImplBase *impl;

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -89,6 +89,21 @@ class _EdgeReference(object):
     def __ge__(self, other):
         return _arithm_op("geq", self, other)
 
+    def __and__(self, other):
+        return _arithm_op("bitand", self, other)
+    def __rand__(self, other):
+        return _arithm_op("bitand", other, self)
+
+    def __or__(self, other):
+        return _arithm_op("bitor", self, other)
+    def __ror__(self, other):
+        return _arithm_op("bitor", other, self)
+
+    def __xor__(self, other):
+        return _arithm_op("bitxor", self, other)
+    def __rxor__(self, other):
+        return _arithm_op("bitxor", other, self)
+
 _cpu_ops = set({})
 _gpu_ops = set({})
 _mixed_ops = set({})


### PR DESCRIPTION
#### Why we need this PR?
- It adds new feature needed because we want to support more python operators

#### What happened in this PR?
 - What solution was applied:

Support bitwise operators in backend and python wrapper.

Bitwise operators follow the same type promotions
as other binary operators.
The type promotions are applied first.
The are disallowed for non-integral types.

 - Affected modules and functionalities:

expressions

 - Key points relevant for the review:

 - Validation and testing:

Test were updated.

 - Documentation (including examples):

WIll do in a follow up.


**JIRA TASK**: *[required by 1190]*
