### PR TITLE
[WIP]Bump up OpenCV version to 4.1.2

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -60,7 +60,7 @@ requirements:
     - python
     - future >=0.17.1
     - protobuf >=3.11.2
-    - libjpeg-turbo >=1.5
+    - libjpeg-turbo >=2.0.3
     - ffmpeg >=4.1
     - tensorflow-gpu
     - libopencv >=3.4.1
@@ -73,7 +73,7 @@ requirements:
     - python
     - future >=0.17.1
     - protobuf >=3.11.2
-    - libjpeg-turbo >=1.5
+    - libjpeg-turbo >=2.0.3
     - ffmpeg >=4.1
     - tensorflow-gpu
     - libopencv >=3.4.1

--- a/docker/Dockerfile.build.aarch64-linux
+++ b/docker/Dockerfile.build.aarch64-linux
@@ -61,7 +61,7 @@ RUN cd /protobuf-${PROTOBUF_VERSION} && make clean \
 
 
 # libjpeg-turbo
-RUN JPEG_TURBO_VERSION=2.0.2 && \
+RUN JPEG_TURBO_VERSION=2.0.4 && \
     curl -L https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${JPEG_TURBO_VERSION}.tar.gz | tar -xzf - && \
     cd libjpeg-turbo-${JPEG_TURBO_VERSION} && \
     echo "set(CMAKE_SYSTEM_NAME  Linux)" > toolchain.cmake && \
@@ -79,9 +79,8 @@ RUN JPEG_TURBO_VERSION=2.0.2 && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install 2>&1 >/dev/null && \
     rm -rf /libjpeg-turbo-${JPEG_TURBO_VERSION}
 
-
 # libtiff
-RUN LIBTIFF_VERSION=4.0.10 && \
+RUN LIBTIFF_VERSION=4.1.0 && \
     cd /tmp && \
     curl -L http://download.osgeo.org/libtiff/tiff-${LIBTIFF_VERSION}.tar.gz | tar -xzf - && \
     cd tiff-${LIBTIFF_VERSION} && \
@@ -99,9 +98,10 @@ RUN LIBTIFF_VERSION=4.0.10 && \
     rm -rf /tmp/tiff-${LIBTIFF_VERSION}
 
 # OpenCV
-ENV OPENCV_VERSION=3.4.3
+ENV OPENCV_VERSION=4.1.2
+COPY docker/fix_ocv_4.1.2.patch /fix_ocv_4.1.2.patch
 RUN curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf - && \
-    cd /opencv-${OPENCV_VERSION} && mkdir build && cd build && \
+    cd /opencv-${OPENCV_VERSION} && git apply /fix_ocv_4.1.2.patch && mkdir build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_TOOLCHAIN_FILE=$PWD/../platforms/linux/aarch64-gnu.toolchain.cmake \
           -DCMAKE_INSTALL_PREFIX=/usr/aarch64-linux-gnu/ \
@@ -112,7 +112,9 @@ RUN curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | 
           -DBUILD_TBB=OFF \
           -DBUILD_WEBP=OFF \
           -DBUILD_JPEG=OFF \
+          -DBUILD_TIFF=OFF \
           -DWITH_JPEG=ON \
+          -DWITH_TIFF=ON \
           -DBUILD_JASPER=OFF \
           -DBUILD_ZLIB=ON \
           -DBUILD_EXAMPLES=OFF \
@@ -165,7 +167,7 @@ RUN OGG_VERSION=1.3.4 && cd /tmp                                                
                                              --host=aarch64-unknown-linux-gnu --prefix=/usr/aarch64-linux-gnu/ && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install && \
     cd /tmp && rm -rf libogg-$OGG_VERSION
-    
+
 # libvorbis
 # Install after libogg
 RUN VORBIS_VERSION=1.3.6 && cd /tmp                                                   && \

--- a/docker/Dockerfile.build.aarch64-qnx
+++ b/docker/Dockerfile.build.aarch64-qnx
@@ -77,7 +77,7 @@ RUN cd /protobuf-${PROTOBUF_VERSION} && make clean \
     rm -rf /protobuf-${PROTOBUF_VERSION}
 
 # libjpeg-turbo
-RUN JPEG_TURBO_VERSION=2.0.2 && \
+RUN JPEG_TURBO_VERSION=2.0.4 && \
     curl -L https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${JPEG_TURBO_VERSION}.tar.gz | tar -xzf - && \
     cd libjpeg-turbo-${JPEG_TURBO_VERSION} && \
     echo "set(CMAKE_SYSTEM_NAME  Linux)" > toolchain.cmake && \
@@ -96,7 +96,7 @@ RUN JPEG_TURBO_VERSION=2.0.2 && \
     rm -rf /libjpeg-turbo-${JPEG_TURBO_VERSION}
 
 # libtiff
-RUN LIBTIFF_VERSION=4.0.10 && \
+RUN LIBTIFF_VERSION=4.1.0 && \
     cd /tmp && \
     curl -L http://download.osgeo.org/libtiff/tiff-${LIBTIFF_VERSION}.tar.gz | tar -xzf - && \
     cd tiff-${LIBTIFF_VERSION} && \
@@ -114,10 +114,11 @@ RUN LIBTIFF_VERSION=4.0.10 && \
     rm -rf /tmp/tiff-${LIBTIFF_VERSION}
 
 # OpenCV
-ENV OPENCV_VERSION=3.4.3
 COPY docker/opencv-qnx.patch /opencv-qnx.patch
-RUN curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf - && \
-    cd /opencv-${OPENCV_VERSION} && git apply /opencv-qnx.patch \
+COPY docker/fix_ocv_4.1.2.patch /fix_ocv_4.1.2.patch
+RUN OPENCV_VERSION=4.1.2 && \
+    curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf - && \
+    cd /opencv-${OPENCV_VERSION} && git apply /opencv-qnx.patch && git apply /fix_ocv_4.1.2.patch \
     && mkdir build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DVIBRANTE_PDK:STRING=/ \

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -53,7 +53,7 @@ RUN LMDB_VERSION=0.9.22 && \
     rm -rf /lmdb
 
 # libjpeg-turbo
-RUN JPEG_TURBO_VERSION=2.0.2 && \
+RUN JPEG_TURBO_VERSION=2.0.4 && \
     curl -L https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${JPEG_TURBO_VERSION}.tar.gz | tar -xzf - && \
     cd libjpeg-turbo-${JPEG_TURBO_VERSION} && \
     cmake -G"Unix Makefiles" -DENABLE_SHARED=TRUE -DCMAKE_INSTALL_PREFIX=/usr/local . 2>&1 >/dev/null && \
@@ -63,7 +63,7 @@ RUN JPEG_TURBO_VERSION=2.0.2 && \
 # libtiff
 # Note: libtiff should be built with support for zlib. If running this step alone on a custom
 #       system, zlib should be installed first
-RUN LIBTIFF_VERSION=4.0.10 && \
+RUN LIBTIFF_VERSION=4.1.0 && \
     cd /tmp && \
     curl -L http://download.osgeo.org/libtiff/tiff-${LIBTIFF_VERSION}.tar.gz | tar -xzf - && \
     cd tiff-${LIBTIFF_VERSION} && \
@@ -75,9 +75,10 @@ RUN LIBTIFF_VERSION=4.0.10 && \
     rm -rf /tmp/tiff-${LIBTIFF_VERSION}
 
 # OpenCV
-RUN OPENCV_VERSION=3.4.3 && \
+COPY docker/fix_ocv_4.1.2.patch /fix_ocv_4.1.2.patch
+RUN OPENCV_VERSION=4.1.2 && \
     curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf - && \
-    cd /opencv-${OPENCV_VERSION} && mkdir build && cd build && \
+    cd /opencv-${OPENCV_VERSION} && git apply /fix_ocv_4.1.2.patch && mkdir build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=/usr/local \
           -DBUILD_SHARED_LIBS=OFF \
           -DWITH_CUDA=OFF -DWITH_1394=OFF -DWITH_IPP=OFF -DWITH_OPENCL=OFF -DWITH_GTK=OFF \

--- a/docker/fix_ocv_4.1.2.patch
+++ b/docker/fix_ocv_4.1.2.patch
@@ -1,0 +1,91 @@
+diff --git a/modules/imgcodecs/src/utils.cpp b/modules/imgcodecs/src/utils.cpp
+index 8ce1b14..0962ebe 100644
+--- a/modules/imgcodecs/src/utils.cpp
++++ b/modules/imgcodecs/src/utils.cpp
+@@ -56,65 +56,65 @@ int validateToInt(size_t sz)
+ #define  cG  (int)(0.587*(1 << SCALE) + 0.5)
+ #define  cB  ((1 << SCALE) - cR - cG)
+ 
+-void icvCvt_BGR2Gray_8u_C3C1R( const uchar* rgb, int rgb_step,
++void icvCvt_BGR2Gray_8u_C3C1R( const uchar* bgr, int bgr_step,
+                                uchar* gray, int gray_step,
+                                Size size, int _swap_rb )
+ {
+     int i;
+     for( ; size.height--; gray += gray_step )
+     {
+-        short cRGB0 = cR;
+-        short cRGB2 = cB;
+-        if (_swap_rb) std::swap(cRGB0, cRGB2);
+-        for( i = 0; i < size.width; i++, rgb += 3 )
++        short cBGR0 = cB;
++        short cBGR2 = cR;
++        if (_swap_rb) std::swap(cBGR0, cBGR2);
++        for( i = 0; i < size.width; i++, bgr += 3 )
+         {
+-            int t = descale( rgb[0]*cRGB0 + rgb[1]*cG + rgb[2]*cRGB2, SCALE );
++            int t = descale( bgr[0]*cBGR0 + bgr[1]*cG + bgr[2]*cBGR2, SCALE );
+             gray[i] = (uchar)t;
+         }
+ 
+-        rgb += rgb_step - size.width*3;
++        bgr += bgr_step - size.width*3;
+     }
+ }
+ 
+ 
+-void icvCvt_BGRA2Gray_16u_CnC1R( const ushort* rgb, int rgb_step,
++void icvCvt_BGRA2Gray_16u_CnC1R( const ushort* bgr, int bgr_step,
+                                 ushort* gray, int gray_step,
+                                 Size size, int ncn, int _swap_rb )
+ {
+     int i;
+     for( ; size.height--; gray += gray_step )
+     {
+-        short cRGB0 = cR;
+-        short cRGB2 = cB;
+-        if (_swap_rb) std::swap(cRGB0, cRGB2);
+-        for( i = 0; i < size.width; i++, rgb += ncn )
++        short cBGR0 = cB;
++        short cBGR2 = cR;
++        if (_swap_rb) std::swap(cBGR0, cBGR2);
++        for( i = 0; i < size.width; i++, bgr += ncn )
+         {
+-            int t = descale( rgb[0]*cRGB0 + rgb[1]*cG + rgb[2]*cRGB2, SCALE );
++            int t = descale( bgr[0]*cBGR0 + bgr[1]*cG + bgr[2]*cBGR2, SCALE );
+             gray[i] = (ushort)t;
+         }
+ 
+-        rgb += rgb_step - size.width*ncn;
++        bgr += bgr_step - size.width*ncn;
+     }
+ }
+ 
+ 
+-void icvCvt_BGRA2Gray_8u_C4C1R( const uchar* rgba, int rgba_step,
++void icvCvt_BGRA2Gray_8u_C4C1R( const uchar* bgra, int rgba_step,
+                                 uchar* gray, int gray_step,
+                                 Size size, int _swap_rb )
+ {
+     int i;
+     for( ; size.height--; gray += gray_step )
+     {
+-        short cRGB0 = cR;
+-        short cRGB2 = cB;
+-        if (_swap_rb) std::swap(cRGB0, cRGB2);
+-        for( i = 0; i < size.width; i++, rgba += 4 )
++        short cBGR0 = cB;
++        short cBGR2 = cR;
++        if (_swap_rb) std::swap(cBGR0, cBGR2);
++        for( i = 0; i < size.width; i++, bgra += 4 )
+         {
+-            int t = descale( rgba[0]*cRGB0 + rgba[1]*cG + rgba[2]*cRGB2, SCALE );
++            int t = descale( bgra[0]*cBGR0 + bgra[1]*cG + bgra[2]*cBGR2, SCALE );
+             gray[i] = (uchar)t;
+         }
+ 
+-        rgba += rgba_step - size.width*4;
++        bgra += rgba_step - size.width*4;
+     }
+ }
+ 

--- a/docker/opencv-qnx.patch
+++ b/docker/opencv-qnx.patch
@@ -1,3 +1,16 @@
+diff --git a/3rdparty/libjasper/jasper/jas_stream.h b/3rdparty/libjasper/jasper/jas_stream.h
+index 6862329..a3cfac5 100644
+--- a/3rdparty/libjasper/jasper/jas_stream.h
++++ b/3rdparty/libjasper/jasper/jas_stream.h
+@@ -254,6 +254,8 @@ typedef struct {
+     int flags;
+ #if defined _WIN32 && !defined __MINGW__ && !defined __MINGW32__
+     char pathname[MAX_PATH + 1];
++#elif defined __AARCH64_QNX__
++    char pathname[_POSIX_PATH_MAX + 1];
+ #else
+     char pathname[PATH_MAX + 1];
+ #endif
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 6c53bf8..c58514b 100644
 --- a/CMakeLists.txt

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -74,28 +74,28 @@ Prerequisites
 .. _protobuf link: https://github.com/google/protobuf
 .. |cmake link| replace:: **CMake 3.11**
 .. _cmake link: https://cmake.org
-.. |jpegturbo link| replace:: **libjpeg-turbo 1.5.x**
+.. |jpegturbo link| replace:: **libjpeg-turbo 2.0.4 (2.0.3 for conda due to availability)**
 .. _jpegturbo link: https://github.com/libjpeg-turbo/libjpeg-turbo
-.. |libtiff link| replace:: **libtiff 4.0.x**
+.. |libtiff link| replace:: **libtiff 4.1.0**
 .. _libtiff link: http://libtiff.org/
 .. |ffmpeg link| replace:: **FFmpeg 4.2.1**
 .. _ffmpeg link: https://developer.download.nvidia.com/compute/redist/nvidia-dali/ffmpeg-4.2.1.tar.bz2
 .. |libsnd link| replace:: **libsnd 1.0.28**
 .. _libsnd link: https://developer.download.nvidia.com/compute/redist/nvidia-dali/libsndfile-1.0.28.tar.gz
-.. |opencv link| replace:: **OpenCV 3**
+.. |opencv link| replace:: **OpenCV 4**
 .. _opencv link: https://opencv.org
 .. |lmdb link| replace:: **liblmdb 0.9.x**
 .. _lmdb link: https://github.com/LMDB/lmdb
-.. |gcc link| replace:: **GCC 4.9.2**
+.. |gcc link| replace:: **GCC 5.3.1**
 .. _gcc link: https://www.gnu.org/software/gcc/
 .. |boost link| replace:: **Boost 1.66**
 .. _boost link: https://www.boost.org/
 
-.. |mxnet link| replace:: **MXNet 1.3**
+.. |mxnet link| replace:: **MXNet 1.5**
 .. _mxnet link: http://mxnet.incubator.apache.org
-.. |pytorch link| replace:: **PyTorch 0.4**
+.. |pytorch link| replace:: **PyTorch 1.1**
 .. _pytorch link: https://pytorch.org
-.. |tf link| replace:: **TensorFlow 1.7**
+.. |tf link| replace:: **TensorFlow 1.12**
 .. _tf link: https://www.tensorflow.org
 
 
@@ -128,7 +128,7 @@ Prerequisites
    +----------------------------------------+---------------------------------------------------------------------------------------------+
    | |libsnd link|_ or later                | We recommend using version 1.0.28 compiled following the *instructions below*.              |
    +----------------------------------------+---------------------------------------------------------------------------------------------+
-   | |opencv link|_ or later                | Supported version: 3.4                                                                      |
+   | |opencv link|_ or later                | Supported version: 4.1.2                                                                    |
    +----------------------------------------+---------------------------------------------------------------------------------------------+
    | (Optional) |lmdb link|_ or later       |                                                                                             |
    +----------------------------------------+---------------------------------------------------------------------------------------------+


### PR DESCRIPTION
- bumps up OpenCV to the latest version
- updates docs regarding libturbo-jpeg and OpenCV version
- fixes BGR* conversion function in OpenCV  (https://github.com/opencv/opencv/issues/16215)
- conda build is not updated as prebuild OpenCV binaries have  above bug https://github.com/opencv/opencv/pull/16265
- bumps libturbo-jpeg to 2.0.4 (2.0.3 for conda due to availability)
- bumps libtiff to 4.1.0

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- It fixes a bug with the wrong version of required libturbo-jpeg in docs
- It adds new feature needed because of we want to have latest OpenCV, libtiff and libturbo-jpeg

#### What happened in this PR?
 - What solution was applied:
     bumps up OpenCV,  libturbo-jpeg and libtiff to the latest version
     updates docs regarding libturbo-jepeg, libtiff and OpenCV version
 - Affected modules and functionalities:
     compilation of deps for x86, aarch64-linux and aarch64-qnx
 - Key points relevant for the review:
     NA
 - Validation and testing:
     test build in CI
 - Documentation (including examples):
     compilation doc is updated

**JIRA TASK**: [NA]
