### PR TITLE
Add docs for arithmetic expressions

### DIFF
--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -114,12 +114,23 @@ _int_like_types = _bool_types + _int_types
 _all_types = _bool_types + _int_types + _float_types
 
 class Constant(object):
-    """Wrapper for a constant value that can be used in arithmetic operations
-    with the results of DALI Operators in `define_graph()` step.
+    """Wrapper for a constant value that can be used in DALI arithmetic expressions
+    and applied element-wise to the results of DALI Operators representing Tensors in
+    :meth:`nvidia.dali.pipeline.Pipeline.define_graph` step.
 
-    It indicates what type it should be treated as. The integers values
-    will be passed to DALI as `int32` and the floating point values as `float32`.
-    Python builtin types `bool`, `int` and `float` will also be treated as those types.
+    Constant indicates what type should the value be treated as with respect
+    to type promotions. The actual values passed to the backend from python
+    would be `int32` for integer values and `float32` for floating point values.
+    Python builtin types `bool`, `int` and `float` will be marked to indicate
+    :meth:`nvidia.dali.types.DALIDataType.BOOL`, :meth:`nvidia.dali.types.DALIDataType.INT32`,
+    and :meth:`nvidia.dali.types.DALIDataType.FLOAT` respectively.
+
+    Args
+    ----
+    value: bool or int or float
+        The constant value to be passed to DALI expression.
+    `dtype`: DALIDataType, optional
+        Target type of the constant to be used in types promotions.
     """
     def __init__(self, value, dtype=None):
         if not isinstance(value, (bool, int, float)):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,13 @@ TensorList
 .. autoclass:: nvidia.dali.backend.TensorListGPU
    :members:
 
+
+Types
+-----
+
+.. autoclass:: nvidia.dali.types.Constant
+   :members:
+
 Enums
 -----
 


### PR DESCRIPTION
#### Why we need this PR?
To have short, concise and explicit docs for supported arithmetic ops other than verbose examples.

#### What happened in this PR?
 - What solution was applied:

Add explicit documentation for arithmetic
expressions. As of now they are only
documented with verbose examples.

This commit adds short documentation for
existing operations as well as turns
on autodoc for dali.types.Constant.
It also adjust the docstring there.

The formatting is using a bit of a hack to introduce a section title and return type
with `.. function::` marker

 - Affected modules and functionalities:

Supported Operations & API docs.

 - Key points relevant for the review:

Look if the formatting is ok and the description is clear.

 - Validation and testing:

Local & CI docs build

 - Documentation (including examples):

Described above, this is a docs update.


**JIRA TASK**: *[1213]*
