### PR TITLE
Remove the need to have GPU available when DALI is just imported

### DIFF
--- a/dali/pipeline/data/backend.cc
+++ b/dali/pipeline/data/backend.cc
@@ -29,32 +29,35 @@ namespace dali {
 
 class AllocatorManager {
  public:
-  AllocatorManager(): cpu_allocator_{nullptr}, pinned_cpu_allocator_{nullptr} {
-    int dev_cout = 0;
-    CUDA_CALL(cudaGetDeviceCount(&dev_cout));
-    gpu_allocators_ = std::vector<std::atomic<GPUAllocator*>>(dev_cout);
+  AllocatorManager(): cpu_allocator_{nullptr}, pinned_cpu_allocator_{nullptr},
+                      gpu_allocators_(nullptr) {
   }
 
   ~AllocatorManager() {
     CPUAllocator* null_cpu_allocator = nullptr;
     GPUAllocator* null_gpu_allocator = nullptr;
+    std::vector<std::atomic<GPUAllocator*>>* null_alloc_vect = nullptr;
     delete std::atomic_exchange(&cpu_allocator_, null_cpu_allocator);
     delete std::atomic_exchange(&pinned_cpu_allocator_, null_cpu_allocator);
-    for (auto& gpu_alloc : gpu_allocators_) {
-      delete std::atomic_exchange(&gpu_alloc, null_gpu_allocator);
+    auto gpu_alloc_vect = std::atomic_exchange(&gpu_allocators_, null_alloc_vect);
+    if (gpu_alloc_vect) {
+      for (auto& gpu_alloc : *gpu_alloc_vect) {
+        delete std::atomic_exchange(&gpu_alloc, null_gpu_allocator);
+      }
+      delete gpu_alloc_vect;
     }
   }
 
   void SetAllocators(const OpSpec &cpu_allocator,
-                            const OpSpec &pinned_cpu_allocator,
-                            const OpSpec &gpu_allocator) {
+                     const OpSpec &pinned_cpu_allocator,
+                     const OpSpec &gpu_allocator) {
     DALI_ENFORCE(cpu_allocator_ == nullptr, "DALI CPU allocator already set");
     DALI_ENFORCE(pinned_cpu_allocator_ == nullptr, "DALI Pinned CPU allocator already set");
-    DALI_ENFORCE(gpu_allocators_[0] == nullptr, "DALI GPU allocator already set");
+    DALI_ENFORCE(!gpu_opspec_, "DALI GPU allocator already set");
     SetCPUAllocator(cpu_allocator);
     SetPinnedCPUAllocator(pinned_cpu_allocator);
     gpu_opspec_.reset(new OpSpec(gpu_allocator));
-    SetGPUAllocator(*gpu_opspec_);
+    // Don't set GPU allocator, it will be done in the first use
   }
 
   CPUAllocator& GetCPUAllocator() {
@@ -72,16 +75,17 @@ class AllocatorManager {
   GPUAllocator& GetGPUAllocator() {
     int dev;
     CUDA_CALL(cudaGetDevice(&dev));
-    auto alloc = gpu_allocators_[dev].load();
+    auto gpu_alloc_vect = GetGPUAllocatorsVect();
+    auto alloc = (*gpu_alloc_vect)[dev].load();
     if (alloc) {
       return *alloc;
     }
     std::lock_guard<std::mutex> lock(mutex_);
-    alloc = gpu_allocators_[dev].load();
+    alloc = (*gpu_alloc_vect)[dev].load();
     if (!alloc) {
       SetGPUAllocator(*gpu_opspec_);
     }
-    return *gpu_allocators_[dev].load();
+    return *(*gpu_alloc_vect)[dev].load();
   }
 
   void SetCPUAllocator(const OpSpec& allocator) {
@@ -102,13 +106,27 @@ class AllocatorManager {
   void SetGPUAllocator(std::unique_ptr<GPUAllocator> allocator) {
     int dev;
     CUDA_CALL(cudaGetDevice(&dev));
-    delete std::atomic_exchange(&(gpu_allocators_[dev]), allocator.release());
+    delete std::atomic_exchange(&((*GetGPUAllocatorsVect())[dev]), allocator.release());
   }
 
  private:
+  std::vector<std::atomic<GPUAllocator*>> *GetGPUAllocatorsVect() {
+    auto gpu_alloc_vect = gpu_allocators_.load();
+    if (!gpu_alloc_vect) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (!gpu_allocators_.load()) {
+        int dev_cout = 0;
+        CUDA_CALL(cudaGetDeviceCount(&dev_cout));
+        auto new_vect = new std::vector<std::atomic<GPUAllocator*>>(dev_cout);
+        delete std::atomic_exchange(&gpu_allocators_, new_vect);
+      }
+      gpu_alloc_vect = gpu_allocators_.load();
+    }
+    return gpu_alloc_vect;
+  }
   std::atomic<CPUAllocator*> cpu_allocator_;
   std::atomic<CPUAllocator*> pinned_cpu_allocator_;
-  std::vector<std::atomic<GPUAllocator*>> gpu_allocators_;
+  std::atomic<std::vector<std::atomic<GPUAllocator*>>*> gpu_allocators_;
   unique_ptr<const OpSpec> gpu_opspec_;
 
   std::mutex mutex_;

--- a/qa/TL0_framework_imports/test.sh
+++ b/qa/TL0_framework_imports/test.sh
@@ -2,3 +2,4 @@
 ./test_tf.sh
 ./test_mxnet.sh
 ./test_pytorch.sh
+./test_no_fw.sh

--- a/qa/TL0_framework_imports/test_no_fw.sh
+++ b/qa/TL0_framework_imports/test_no_fw.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+# used pip packages
+
+pip_packages=""
+
+test_body() {
+    # test code
+    export CUDA_VISIBLE_DEVICES=
+    echo "---------Testing DALI----------"
+    ( set -x && python -c "import nvidia.dali" )
+    unset CUDA_VISIBLE_DEVICES
+}
+
+pushd ../../
+source ./qa/test_template.sh
+popd
+


### PR DESCRIPTION
- makes the GPU allocators initialization fully lazy without any need to call to GPU unless it is used
- issuing `import nvidia.dali` doesn't make any call to the GPU any longer
- new DALI import test is added

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- It adds new feature needed because of DALI doesn't really use GPU when it is just imported so when `import nvidia.dali` is issues in python no call to GPU should be made

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     makes the GPU allocators initialization fully lazy without any need to call to GPU unless it is used
    issuing `import nvidia.dali` doesn't make any call to the GPU any longer
 - Affected modules and functionalities:
     AllocatorManager 
 - Key points relevant for the review:
     Check how allocators are lazy initialized
 - Validation and testing:
     Current tests in CI. A new DALI import test is added. Local stress test.
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
