### PR TITLE
Allow Crop and CropMirrorNormalize to crop sequences as if they were volumetric images

### DIFF
--- a/dali/operators/crop/crop.h
+++ b/dali/operators/crop/crop.h
@@ -86,7 +86,7 @@ class Crop : public SliceBase<Backend>, protected CropAttr {
     // Special case.
     // This allows using crop_d to crop on the sequence dimension,
     // by treating video inputs as a volume instead of a sequence
-    if (F > 1 && D == 1) {
+    if (has_crop_d_ && F > 1 && D == 1) {
       std::swap(d_dim, f_dim);
       std::swap(D, F);
       spatial_ndim++;

--- a/dali/operators/crop/crop.h
+++ b/dali/operators/crop/crop.h
@@ -83,6 +83,15 @@ class Crop : public SliceBase<Backend>, protected CropAttr {
     int spatial_ndim = ImageLayoutInfo::NumSpatialDims(layout);
     assert(spatial_ndim >= 2);  // bug-check: should never occur with h_dim, w_dim >= 0
 
+    // Special case.
+    // This allows using crop_d to crop on the sequence dimension,
+    // by treating video inputs as a volume instead of a sequence
+    if (F > 1 && D == 1) {
+      std::swap(d_dim, f_dim);
+      std::swap(D, F);
+      spatial_ndim++;
+    }
+
     auto crop_window_gen = GetCropWindowGenerator(data_idx);
     auto win = spatial_ndim == 3 ?
       crop_window_gen({D, H, W}, "DHW") : crop_window_gen({H, W}, "HW");

--- a/dali/operators/fused/crop_mirror_normalize.h
+++ b/dali/operators/fused/crop_mirror_normalize.h
@@ -215,7 +215,7 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
     // Special case.
     // This allows using crop_d to crop on the sequence dimension,
     // by treating video inputs as a volume instead of a sequence
-    if (F > 1 && D == 1) {
+    if (has_crop_d_ && F > 1 && D == 1) {
       std::swap(d_dim, f_dim);
       std::swap(D, F);
       spatial_ndim++;

--- a/dali/operators/fused/crop_mirror_normalize.h
+++ b/dali/operators/fused/crop_mirror_normalize.h
@@ -189,7 +189,7 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
     DALI_ENFORCE(shape.size() >= 3 || shape.size() <= 5,
       "Unexpected number of dimensions: " + std::to_string(shape.size()));
     DALI_ENFORCE(layout.ndim() == shape.size());
-    const int spatial_ndim = ImageLayoutInfo::NumSpatialDims(layout);
+    int spatial_ndim = ImageLayoutInfo::NumSpatialDims(layout);
     DALI_ENFORCE(spatial_ndim == 2 || spatial_ndim == 3,
       "Only 2D or 3D images and sequences of images are supported");
     DALI_ENFORCE(ImageLayoutInfo::HasChannel(layout),
@@ -211,6 +211,15 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
       F = shape[f_dim];
     if (d_dim >= 0)
       D = shape[d_dim];
+
+    // Special case.
+    // This allows using crop_d to crop on the sequence dimension,
+    // by treating video inputs as a volume instead of a sequence
+    if (F > 1 && D == 1) {
+      std::swap(d_dim, f_dim);
+      std::swap(D, F);
+      spatial_ndim++;
+    }
 
     auto crop_window_gen = GetCropWindowGenerator(data_idx);
     auto win = spatial_ndim == 3 ?

--- a/dali/test/python/test_operator_crop.py
+++ b/dali/test/python/test_operator_crop.py
@@ -240,7 +240,7 @@ def test_crop_no_cast_vs_cast_to_float_and_back():
             yield check_crop_no_cast_vs_cast_to_float_and_back, device, batch_size
 
 class Crop3dPipeline(Pipeline):
-    def __init__(self, device, batch_size, iterator, data_shape, data_layout, num_threads=1, device_id=0):
+    def __init__(self, device, batch_size, iterator, data_shape, data_layout, num_threads=1, device_id=0, crop_seq_as_depth=False):
         super(Crop3dPipeline, self).__init__(batch_size,
                                              num_threads,
                                              device_id)
@@ -254,6 +254,8 @@ class Crop3dPipeline(Pipeline):
             D, H, W = self.data_shape[0], self.data_shape[1], self.data_shape[2]
         elif self.data_layout == "CDHW":
             D, H, W = self.data_shape[1], self.data_shape[2], self.data_shape[3]
+        elif self.data_layout == "FHWC" and crop_seq_as_depth:
+            D, H, W = self.data_shape[0], self.data_shape[1], self.data_shape[2]
         else:
             assert(False)
 
@@ -352,3 +354,35 @@ def test_crop_3d_vs_python_op_crop():
                                   ("CDHW", (3, 300, 10, 100)),
                                   ("CDHW", (8, 30, 10, 50))}:
                yield check_crop_3d_vs_python_op_crop, device, batch_size, layout, shape
+
+
+def check_crop_sequence_length(device, batch_size, output_dtype, input_layout, input_shape):
+    crop_z, crop_y, crop_x = (0.1, 0.2, 0.3)
+    crop_shape=(int(0.91*input_shape[0]), int(0.85*input_shape[1]), int(0.75*input_shape[2]), 3)
+    eii1 = RandomDataIterator(batch_size, shape=input_shape)
+
+    pipe = Crop3dPipeline(device, batch_size, iter(eii1),
+                          data_shape=input_shape, data_layout=input_layout, crop_seq_as_depth=True)
+    pipe.build()
+    out = pipe.run()
+    out_data = out[0]
+
+    for i in range(batch_size):
+        assert(out_data.at(i).shape == crop_shape), \
+            "Shape mismatch {} != {}".format(out_data.at(i).shape, crop_shape)
+
+# Tests cropping along the sequence dimension as if it was depth
+def test_cmn_crop_sequence_length():
+    input_layout = "FHWC"
+    output_layouts = ["FHWC", "FCHW"]
+    input_shapes = {
+        "FHWC" : [(10, 60, 80, 3)],
+    }
+
+    for device in ['cpu']:
+        for batch_size in [8]:
+            for output_dtype in [types.FLOAT]:
+                for input_shape in input_shapes[input_layout]:
+                    assert len(input_layout) == len(input_shape)
+                    yield check_crop_sequence_length, device, batch_size, output_dtype, \
+                        input_layout, input_shape


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It adds new feature: 
Allows to use crop_d and crop_z in CropMirrorNormalize and Crop to crop on the sequence dimensions. That is, allows treating 'F' dimension as depth

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
Interpret 'F' dimension as 'D' when crop_d is provided but there is no 'D' dimension in the input layout.
 - Affected modules and functionalities:
Crop and CropMirrorNormalize operators
 - Key points relevant for the review:
Changes in the operators
 - Validation and testing:
New python tests added for both operators
 - Documentation (including examples):
N/A

**JIRA TASK**: *[NA]*
