### PR TITLE
Bump protobuf version to 3.11 in conda build

### DIFF
--- a/conda/install_requirements.sh
+++ b/conda/install_requirements.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-conda install --yes -c conda-forge 'protobuf >=3.5'
+conda install --yes -c conda-forge 'protobuf >=3.11.2'
 conda install --yes -c conda-forge 'libjpeg-turbo >=1.5'
 conda install --yes -c conda-forge 'ffmpeg >=4.1'
 conda install --yes -c conda-forge 'opencv >=3.4.1'

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -59,7 +59,7 @@ requirements:
   host:
     - python
     - future >=0.17.1
-    - protobuf >=3.5
+    - protobuf >=3.11.2
     - libjpeg-turbo >=1.5
     - ffmpeg >=4.1
     - tensorflow-gpu
@@ -72,7 +72,7 @@ requirements:
   run:
     - python
     - future >=0.17.1
-    - protobuf >=3.5
+    - protobuf >=3.11.2
     - libjpeg-turbo >=1.5
     - ffmpeg >=4.1
     - tensorflow-gpu


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It fixes a bug
Fixes conda build

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
Bumped up the protobuf version in the conda build to match current requirements
 - Affected modules and functionalities:
Conda build meta yaml
 - Key points relevant for the review:
Everything
 - Validation and testing:
N/A
 - Documentation (including examples):
N/A

**JIRA TASK**: *[NA]*
