### PR TITLE
Update VideoReader testcase, use nvmlSystemGetDriverVersion

### DIFF
--- a/dali/util/nvml_wrap.cc
+++ b/dali/util/nvml_wrap.cc
@@ -35,6 +35,7 @@ static nvmlReturn_t (*nvmlInternalDeviceGetIndex)(nvmlDevice_t device, unsigned*
 
 static nvmlReturn_t (*nvmlInternalDeviceSetCpuAffinity)(nvmlDevice_t device);
 static nvmlReturn_t (*nvmlInternalDeviceClearCpuAffinity)(nvmlDevice_t device);
+static nvmlReturn_t (*nvmlInternalSystemGetDriverVersion)(char* name, unsigned int length);
 static nvmlReturn_t (*nvmlInternalDeviceGetCpuAffinity)(nvmlDevice_t device,
                                                         unsigned int cpuSetSize,
                                                         unsigned long* cpuSet);  // NOLINT(*)
@@ -73,6 +74,7 @@ DALIError_t wrapSymbols(void) {
   LOAD_SYM(nvmlhandle, "nvmlDeviceGetIndex", nvmlInternalDeviceGetIndex);
   LOAD_SYM(nvmlhandle, "nvmlDeviceSetCpuAffinity", nvmlInternalDeviceSetCpuAffinity);
   LOAD_SYM(nvmlhandle, "nvmlDeviceClearCpuAffinity", nvmlInternalDeviceClearCpuAffinity);
+  LOAD_SYM(nvmlhandle, "nvmlSystemGetDriverVersion", nvmlInternalSystemGetDriverVersion);
   LOAD_SYM(nvmlhandle, "nvmlDeviceGetCpuAffinity", nvmlInternalDeviceGetCpuAffinity);
   LOAD_SYM(nvmlhandle, "nvmlErrorString", nvmlInternalErrorString);
 
@@ -173,6 +175,20 @@ DALIError_t wrapNvmlDeviceClearCpuAffinity(nvmlDevice_t device) {
   nvmlReturn_t ret = nvmlInternalDeviceClearCpuAffinity(device);
   if (ret != NVML_SUCCESS) {
     DALI_FAIL("nvmlDeviceClearCpuAffinity() failed: " +
+      nvmlInternalErrorString(ret));
+    return DALIError;
+  }
+  return DALISuccess;
+}
+
+DALIError_t wrapNvmlSystemGetDriverVersion(char* name, unsigned int length) {
+  if (nvmlInternalInit == NULL) {
+    DALI_FAIL("lib wrapper not initialized.");
+    return DALIError;
+  }
+  nvmlReturn_t ret = nvmlInternalSystemGetDriverVersion(name, length);
+  if (ret != NVML_SUCCESS) {
+    DALI_FAIL("nvmlSystemGetDriverVersion() failed: " +
       nvmlInternalErrorString(ret));
     return DALIError;
   }

--- a/dali/util/nvml_wrap.h
+++ b/dali/util/nvml_wrap.h
@@ -39,6 +39,7 @@ DLL_PUBLIC DALIError_t wrapNvmlDeviceGetHandleByIndex(const int device_id,
                                                       nvmlDevice_t* device);
 DLL_PUBLIC DALIError_t wrapNvmlDeviceGetIndex(nvmlDevice_t device, unsigned* index);
 DLL_PUBLIC DALIError_t wrapNvmlDeviceSetCpuAffinity(nvmlDevice_t device);
+DLL_PUBLIC DALIError_t wrapNvmlSystemGetDriverVersion(char* name, unsigned int length);
 DLL_PUBLIC DALIError_t wrapNvmlDeviceGetCpuAffinity(nvmlDevice_t device,
                                                     unsigned int cpuSetSize,
                                                     unsigned long* cpuSet);  // NOLINT(runtime/int)


### PR DESCRIPTION
Description: Use nvmlSystemGetDriverVersion instead of
cudaDriverGetVersion to get driver version.

Signed-off-by: Abhishek Sansanwal <asansanwal@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug *bug description*
Use nvmlSystemGetDriverVersion. cudaDriverGetVersion returns
cuda toolkit version instead. Previous check didnt skip the testcase
when running with older driver.

- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *[ Explain solution of the problem, a new feature added here. ]*
 - Affected modules and functionalities:
     *[ Describe here what was changed, added, removed. ]*
 - Key points relevant for the review:
     *[ Describe here what is the most important part that reviewers should focus on. ]*
 - Validation and testing:
     *[ Describe here if and how this PR is tested. ]*
 - Documentation (including examples):
     *[ Describe here if documentation and examples were updated. ]*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
