### PR TITLE
Fixing numpy version to 1.17.0 in SSD test

### DIFF
--- a/qa/TL1_ssd_training/test.sh
+++ b/qa/TL1_ssd_training/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="numpy torch torchvision mlperf_compliance matplotlib Cython"
+# Fixing numpy to 1.17.0 version to avoid the error about not being able to implicitly convert from float64 to integer
+pip_packages="numpy==1.17.0 torch torchvision mlperf_compliance matplotlib Cython"
 target_dir=./docs/examples/pytorch/single_stage_detector/
 
 test_body() {


### PR DESCRIPTION
...to avoid error in pycocotools/cocoeval due to implicit conversion from float64 to integer

Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug, due to a wrong numpy API usage in pycocotools that started to be treated as an error starting from numpy 1.18.0

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
Fix numpy version to 1.17 in SSD training test
 - Affected modules and functionalities:
QA test script
 - Key points relevant for the review:
N/A
 - Validation and testing:
Existing QA test, CI
 - Documentation (including examples):
N/A

**JIRA TASK**: *[NA]*
