### PR TITLE
Add data source info to error message in TFRecord and Caffe parsers

### DIFF
--- a/dali/operators/reader/parser/caffe2_parser.h
+++ b/dali/operators/reader/parser/caffe2_parser.h
@@ -189,7 +189,10 @@ class Caffe2Parser : public Parser<Tensor<CPUBackend>> {
     caffe2::TensorProtos protos;
     int consumed_inputs = 0;
 
-    DALI_ENFORCE(protos.ParseFromArray(data.data<uint8_t>(), data.size()));
+    DALI_ENFORCE(protos.ParseFromArray(data.data<uint8_t>(), data.size()),
+      make_string("Error parsing Caffe2 file: ", data.GetSourceInfo(),
+                  " (raw data length ", data.size(), ")"));
+
 
     if (image_available_) {
       auto& image = ws->Output<CPUBackend>(consumed_inputs);

--- a/dali/operators/reader/parser/caffe2_parser.h
+++ b/dali/operators/reader/parser/caffe2_parser.h
@@ -190,8 +190,8 @@ class Caffe2Parser : public Parser<Tensor<CPUBackend>> {
     int consumed_inputs = 0;
 
     DALI_ENFORCE(protos.ParseFromArray(data.data<uint8_t>(), data.size()),
-      make_string("Error parsing Caffe2 file: ", data.GetSourceInfo(),
-                  " (raw data length ", data.size(), ")"));
+      make_string("Error while parsing Caffe2 file: ", data.GetSourceInfo(),
+                  " (raw data length: ", data.size(), " bytes)."));
 
 
     if (image_available_) {

--- a/dali/operators/reader/parser/caffe_parser.h
+++ b/dali/operators/reader/parser/caffe_parser.h
@@ -31,8 +31,8 @@ class CaffeParser : public Parser<Tensor<CPUBackend>> {
     caffe::Datum datum;
     int out_tensors = 0;
     DALI_ENFORCE(datum.ParseFromArray(data.raw_data(), data.size()),
-      make_string("Error Caffe file: ", data.GetSourceInfo(),
-                  " (raw data length ", data.size(), ")"));
+      make_string("Error while parsing Caffe file: ", data.GetSourceInfo(),
+                  " (raw data length: ", data.size(), " bytes)."));
 
     if (image_available_ && datum.has_data()) {
       bool encoded_data = true;

--- a/dali/operators/reader/parser/caffe_parser.h
+++ b/dali/operators/reader/parser/caffe_parser.h
@@ -30,7 +30,9 @@ class CaffeParser : public Parser<Tensor<CPUBackend>> {
   void Parse(const Tensor<CPUBackend>& data, SampleWorkspace* ws) override {
     caffe::Datum datum;
     int out_tensors = 0;
-    DALI_ENFORCE(datum.ParseFromArray(data.raw_data(), data.size()));
+    DALI_ENFORCE(datum.ParseFromArray(data.raw_data(), data.size()),
+      make_string("Error Caffe file: ", data.GetSourceInfo(),
+                  " (raw data length ", data.size(), ")"));
 
     if (image_available_ && datum.has_data()) {
       bool encoded_data = true;

--- a/dali/operators/reader/parser/tfrecord_parser.h
+++ b/dali/operators/reader/parser/tfrecord_parser.h
@@ -58,13 +58,9 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
 
     // Omit length and crc
     raw_data = raw_data + sizeof(length) + sizeof(crc);
-    try {
-      DALI_ENFORCE(example.ParseFromArray(raw_data, length),
-          "Error in parsing - invalid TFRecord file!");
-    } catch (std::exception& e) {
-      std::string str = "Error while parsing TFRecord: " + std::string(e.what());
-      DALI_FAIL(str);
-    }
+    DALI_ENFORCE(example.ParseFromArray(raw_data, length),
+      make_string("Error parsing TFRecord file: ", data.GetSourceInfo(),
+                  " (raw data length ", length, ")"));
 
     for (size_t i = 0; i < features_.size(); ++i) {
       auto& output = ws->Output<CPUBackend>(i);

--- a/dali/operators/reader/parser/tfrecord_parser.h
+++ b/dali/operators/reader/parser/tfrecord_parser.h
@@ -59,8 +59,8 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
     // Omit length and crc
     raw_data = raw_data + sizeof(length) + sizeof(crc);
     DALI_ENFORCE(example.ParseFromArray(raw_data, length),
-      make_string("Error parsing TFRecord file: ", data.GetSourceInfo(),
-                  " (raw data length ", length, ")"));
+      make_string("Error while parsing TFRecord file: ", data.GetSourceInfo(),
+                  " (raw data length: ", length, "bytes)."));
 
     for (size_t i = 0; i < features_.size(); ++i) {
       auto& output = ws->Output<CPUBackend>(i);


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds additional info to an error message, which will be helpful to identify problems in a dataset

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
Print the source information of the sample and the total length of the raw data.
 - Affected modules and functionalities:
TFRecordParser/CaffeParser/Caffe2Parser 
- Key points relevant for the review:
All of it
 - Validation and testing:
N/A
 - Documentation (including examples):
N/A

**JIRA TASK**: *[Use DALI-XXXX or NA]*
