### PR TITLE
Fix Transpose operator for batch size 1 as well as 1 channel images

### DIFF
--- a/dali/test/python/test_operator_transpose.py
+++ b/dali/test/python/test_operator_transpose.py
@@ -114,15 +114,16 @@ def check_transpose_layout(device, batch_size, shape, in_layout, permutation,
 
 def test_transpose_layout():
     batch_size = 3
-    shape = (600, 400, 3)
     in_layout = "HWC"
     for device in {'gpu'}:
-        for permutation, transpose_layout, out_layout_arg in \
-            [((2, 0, 1), True, None),
-             ((2, 0, 1), True, "CHW"),
-             ((2, 0, 1), False, "CHW"),
-             ((1, 0, 2), False, None),
-             ((1, 0, 2), True, None),
-             ((1, 0, 2), True, "HWC")]:
-            yield check_transpose_layout, device, batch_size, shape, \
-                in_layout, permutation, transpose_layout, out_layout_arg
+        for batch_size in (1, 3):
+            for shape in [(600, 400, 3), (600, 400, 1)]:
+                for permutation, transpose_layout, out_layout_arg in \
+                    [((2, 0, 1), True, None),
+                     ((2, 0, 1), True, "CHW"),
+                     ((2, 0, 1), False, "CHW"),
+                     ((1, 0, 2), False, None),
+                     ((1, 0, 2), True, None),
+                     ((1, 0, 2), True, "HWC")]:
+                    yield check_transpose_layout, device, batch_size, shape, \
+                        in_layout, permutation, transpose_layout, out_layout_arg


### PR DESCRIPTION
- Transpose has a special code path for transposing data with one or more
  dimensions shapes equal 1 as cuTT doesn't handle this situation. However,
  this code path is wrong
- Corrects the logic removing shapes equal to 1 and permutation connected to it.
- Add logic to update the remaining permutation elements after removal of the one
  corresponding to shapes equal to 1
- Adds more test to permutation operator

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- It fixes a bug in the Transpose operator for batch size 1 as well as 1 channel images

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Transpose has a special code path for transposing data with one or more dimensions shapes equal 1 as cuTT doesn't handle this situation. However, this code path is wrong
    Corrects the logic removing shapes equal to 1 and permutation connected to it.
    Add logic to update the remaining permutation elements after removal of the one corresponding to shapes equal to 1
 - Affected modules and functionalities:
     Transpose operator
 - Key points relevant for the review:
     NA
 - Validation and testing:
     Adds more test to permutation operator
 - Documentation (including examples):
     No


**JIRA TASK**: *[NA]*
