### PR TITLE
Adds support to StopIteration raised inside framework iterators

### DIFF
--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -145,6 +145,10 @@ class DALIGenericIterator(object):
                  specifies the LoD level of the resulting LoDTensor.
     size : int
            Number of samples in the epoch (Usually the size of the dataset).
+           Providing -1 means that the iterator will work until StopIteration is raised
+           from the inside of iter_setup(). The options `fill_last_batch`, `last_batch_padded` and
+           `auto_reset` don't work in such case. It works with only one pipeline inside
+           the iterator.
     auto_reset : bool, optional, default = False
                  Whether the iterator resets itself for the next epoch
                  or it requires reset() to be called separately.
@@ -197,6 +201,12 @@ class DALIGenericIterator(object):
         self._dynamic_shape = dynamic_shape
         self._fill_last_batch = fill_last_batch
         self._last_batch_padded = last_batch_padded
+        assert self._size != 0, "Size cannot be 0"
+        assert self._size > 0 or (self._size < 0 and len(pipelines) == 1), "Negative size is supported only for a single pipeline"
+        if self._size < 0:
+            self._auto_reset = False
+            self._fill_last_batch = False
+            self._last_batch_padded = False
         self._pipes = pipelines
         # Build all pipelines
         for p in self._pipes:
@@ -232,7 +242,7 @@ class DALIGenericIterator(object):
             batch = self._first_batch
             self._first_batch = None
             return batch
-        if self._counter >= self._size:
+        if self._counter >= self._size and self._size > 0:
             if self._auto_reset:
                 self.reset()
             raise StopIteration
@@ -319,7 +329,7 @@ class DALIGenericIterator(object):
 
         self._counter += self._num_gpus * self.batch_size
 
-        if (not self._fill_last_batch) and (self._counter > self._size):
+        if (not self._fill_last_batch) and (self._counter > self._size) and self._size > 0:
             # First calculate how much data is required to
             # return exactly self._size entries.
             diff = self._num_gpus * self.batch_size - (self._counter
@@ -361,7 +371,7 @@ class DALIGenericIterator(object):
         DALI iterators do not support resetting before the end of the epoch
         and will ignore such request.
         """
-        if self._counter >= self._size:
+        if self._counter >= self._size or self._size < 0:
             if self._fill_last_batch and not self._last_batch_padded:
                 self._counter = self._counter % self._size
             else:
@@ -402,6 +412,10 @@ class DALIClassificationIterator(DALIGenericIterator):
                 List of pipelines to use
     size : int
            Number of samples in the epoch (Usually the size of the dataset).
+           Providing -1 means that the iterator will work until StopIteration is raised
+           from the inside of iter_setup(). The options `fill_last_batch`, `last_batch_padded` and
+           `auto_reset` don't work in such case. It works with only one pipeline inside
+           the iterator.
     auto_reset : bool, optional, default = False
                  Whether the iterator resets itself for the next epoch
                  or it requires reset() to be called separately.

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -77,6 +77,10 @@ class DALIGenericIterator(object):
                  Each name should be distinct
     size : int
            Number of samples in the epoch (Usually the size of the dataset).
+           Providing -1 means that the iterator will work until StopIteration is raised
+           from the inside of iter_setup(). The options `fill_last_batch`, `last_batch_padded` and
+           `auto_reset` don't work in such case. It works with only one pipeline inside
+           the iterator.
     auto_reset : bool, optional, default = False
                  Whether the iterator resets itself for the next epoch
                  or it requires reset() to be called separately.
@@ -127,6 +131,12 @@ class DALIGenericIterator(object):
         self._dynamic_shape = dynamic_shape
         self._fill_last_batch = fill_last_batch
         self._last_batch_padded = last_batch_padded
+        assert self._size != 0, "Size cannot be 0"
+        assert self._size > 0 or (self._size < 0 and len(pipelines) == 1), "Negative size is supported only for a single pipeline"
+        if self._size < 0:
+            self._auto_reset = False
+            self._fill_last_batch = False
+            self._last_batch_padded = False
         self._pipes = pipelines
         # Build all pipelines
         for p in self._pipes:
@@ -152,7 +162,7 @@ class DALIGenericIterator(object):
             batch = self._first_batch
             self._first_batch = None
             return batch
-        if self._counter >= self._size:
+        if self._counter >= self._size and self._size > 0:
             if self._auto_reset:
                 self.reset()
             raise StopIteration
@@ -216,7 +226,7 @@ class DALIGenericIterator(object):
 
         self._counter += self._num_gpus * self.batch_size
 
-        if (not self._fill_last_batch) and (self._counter > self._size):
+        if (not self._fill_last_batch) and (self._counter > self._size) and self._size > 0:
             # First calculate how much data is required to return exactly self._size entries.
             diff = self._num_gpus * self.batch_size - (self._counter - self._size)
             # Figure out how many GPUs to grab from.
@@ -253,7 +263,7 @@ class DALIGenericIterator(object):
         DALI iterators do not support resetting before the end of the epoch
         and will ignore such request.
         """
-        if self._counter >= self._size:
+        if self._counter >= self._size or self._size < 0:
             if self._fill_last_batch and not self._last_batch_padded:
                 self._counter = self._counter % self._size
             else:
@@ -293,6 +303,10 @@ class DALIClassificationIterator(DALIGenericIterator):
                 List of pipelines to use
     size : int
            Number of samples in the epoch (Usually the size of the dataset).
+           Providing -1 means that the iterator will work until StopIteration is raised
+           from the inside of iter_setup(). The options `fill_last_batch`, `last_batch_padded` and
+           `auto_reset` don't work in such case. It works with only one pipeline inside
+           the iterator.
     auto_reset : bool, optional, default = False
                  Whether the iterator resets itself for the next epoch
                  or it requires reset() to be called separately.


### PR DESCRIPTION
- adds proper support to StopIteration raised inside framework iterators
- adds an ability to provide negative FW iterator size so it only relies on the StopIteration raised from the iter_setup
- updates fw_iterators tests

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- It adds new feature that makes StopIteration raised inside framework iterators supported properly

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds proper support to StopIteration raised inside framework iterators
     adds an ability to provide negative FW iterator size so it only relies on the StopIteration raised from the iter_setup
 - Affected modules and functionalities:
     FW iterators 
 - Key points relevant for the review:
     tests and logic inside the FW iterators
 - Validation and testing:
     updates fw_iterators tests
 - Documentation (including examples):
     docs strings for the FW iterators are updated


**JIRA TASK**: *[NA]*
