### PR TITLE
Temporary fix due to missing PILLOW_VERSION symbol when using torchvision

### DIFF
--- a/qa/TL0_FW_iterators/test_pytorch.sh
+++ b/qa/TL0_FW_iterators/test_pytorch.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 # used pip packages
 
-
-pip_packages="nose numpy opencv-python torch torchvision"
+# TODO(janton): remove explicit pillow version installation when torch fixes the issue with PILLOW_VERSION not being defined
+pip_packages="pillow==6.2.2 nose numpy opencv-python torch torchvision"
 target_dir=./dali/test/python
 
 one_config_only=true

--- a/qa/TL0_framework_imports/test_pytorch.sh
+++ b/qa/TL0_framework_imports/test_pytorch.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 # used pip packages
 
-pip_packages="torchvision torch"
+# TODO(janton): remove explicit pillow version installation when torch fixes the issue with PILLOW_VERSION not being defined
+pip_packages="pillow==6.2.2 torchvision torch"
 
 test_body() {
     # test code

--- a/qa/TL1_jupyter_plugins/test_pytorch.sh
+++ b/qa/TL1_jupyter_plugins/test_pytorch.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 
 # used pip packages
-pip_packages="jupyter matplotlib torchvision torch"
+# TODO(janton): remove explicit pillow version installation when torch fixes the issue with PILLOW_VERSION not being defined
+pip_packages="pillow==6.2.2 jupyter matplotlib torchvision torch"
 target_dir=./docs/examples
 
 do_once() {

--- a/qa/TL1_separate_executor/test_pytorch.sh
+++ b/qa/TL1_separate_executor/test_pytorch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 # TODO(janton): remove explicit pillow version installation when torch fixes the issue with PILLOW_VERSION not being defined
-pip_packages="pillow=6.2.2 torchvision torch"
+pip_packages="pillow==6.2.2 torchvision torch"
 target_dir=./dali/test/python
 one_config_only=true
 

--- a/qa/TL1_separate_executor/test_pytorch.sh
+++ b/qa/TL1_separate_executor/test_pytorch.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="torchvision torch"
+# TODO(janton): remove explicit pillow version installation when torch fixes the issue with PILLOW_VERSION not being defined
+pip_packages="pillow=6.2.2 torchvision torch"
 target_dir=./dali/test/python
 one_config_only=true
 

--- a/qa/TL1_ssd_training/test.sh
+++ b/qa/TL1_ssd_training/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 # used pip packages
 # Fixing numpy to 1.17.0 version to avoid the error about not being able to implicitly convert from float64 to integer
-pip_packages="numpy==1.17.0 torch torchvision mlperf_compliance matplotlib Cython"
+# TODO(janton): remove explicit pillow version installation when torch fixes the issue with PILLOW_VERSION not being defined
+pip_packages="numpy==1.17.0 pillow==6.2.2 torch torchvision mlperf_compliance matplotlib Cython"
 target_dir=./docs/examples/pytorch/single_stage_detector/
 
 test_body() {

--- a/qa/TL1_superres_pytorch/test.sh
+++ b/qa/TL1_superres_pytorch/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
-
-pip_packages="numpy torch torchvision scikit-image tensorboardX"
+# TODO(janton): remove explicit pillow version installation when torch fixes the issue with PILLOW_VERSION not being defined
+pip_packages="pillow==6.2.2 numpy torch torchvision scikit-image tensorboardX"
 target_dir=./docs/examples/video
 
 do_once() {

--- a/qa/TL2_FW_iterators_perf/test.sh
+++ b/qa/TL2_FW_iterators_perf/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="tensorflow-gpu torchvision mxnet-cu{cuda_v} torch paddle"
+# TODO(janton): remove explicit pillow version installation when torch fixes the issue with PILLOW_VERSION not being defined
+pip_packages="pillow==6.2.2 tensorflow-gpu torchvision mxnet-cu{cuda_v} torch paddle"
 target_dir=./dali/test/python
 one_config_only=true
 


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug caused by a deprecated symbol in *pillow* PILLOW_VERSION while importing torchvision
https://pillow.readthedocs.io/en/stable/releasenotes/7.0.0.html

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
Fixed pillow version to 6.2.2 (the symbol was removed in the next version 7.0.0)
 - Affected modules and functionalities:
QA test scripts
 - Key points relevant for the review:
Everything
 - Validation and testing:
CI
 - Documentation (including examples):
N/A

**JIRA TASK**: *[Use DALI-XXXX or NA]*
