### PR TITLE
Update CUDA version detection for Conda

### DIFF
--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -12,7 +12,7 @@ nvidia-smi
 
 # If driver version is less than 410 and CUDA version is 10,
 # add /usr/local/cuda/compat to LD_LIBRARY_PATH
-CUDA_VERSION=$(cat /usr/local/cuda/version.txt | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
+CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1\2/')
 CUDA_VERSION=${CUDA_VERSION:-90}
 
 NVIDIA_SMI_DRIVER_VERSION=$(nvidia-smi | grep -Po '(?<=Driver Version: )\d+.\d+')


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- Refactoring to improve how Conda build detects CUDA version

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     utilizes libcudart.so version to detect the CUDA toolkit version for Conda
 - Affected modules and functionalities:
     Conda build
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI build
 - Documentation (including examples):
     NA

**JIRA TASK**: *[NA]*
