### PR TITLE
Also check tensor argument to determine if resampling is needed.

### DIFF
--- a/dali/operators/decoder/audio/audio_decoder_op.h
+++ b/dali/operators/decoder/audio/audio_decoder_op.h
@@ -40,7 +40,7 @@ class AudioDecoderCpu : public Operator<CPUBackend> {
           Operator<Backend>(spec),
           output_type_(spec.GetArgument<DALIDataType>("dtype")),
           downmix_(spec.GetArgument<bool>("downmix")),
-          use_resampling_(spec.HasArgument("sample_rate")),
+          use_resampling_(spec.HasArgument("sample_rate") || spec.HasTensorArgument("sample_rate")),
           quality_(spec.GetArgument<float>("quality")) {
     if (use_resampling_) {
       double q = quality_;


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: resampling not used with tensor arguments.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Add additional check in operator's constructor
 - Affected modules and functionalities:
     * Audio Decoder
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Tested manually, but test not included
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
