### PR TITLE
Improved Reshape

### DIFF
--- a/dali/operators/util/reshape.cc
+++ b/dali/operators/util/reshape.cc
@@ -23,28 +23,32 @@
 namespace dali {
 
 DALI_SCHEMA(Reshape)
-  .DocStr(R"code(Treats content of the input as if it had a different shape and layout.)code")
+  .DocStr(R"code(Treats content of the input as if it had a different shape and/or layout.)code")
   .NumInput(1, 2)
   .NumOutput(1)
+  .InputDox(0, "data", "TensorList", "Data to be reshaped")
+  .InputDox(1, "shape", "1D TensorList of integers", "Same as `shape` argument")
   .AllowSequences()
   .SupportVolumetric()
-  .AddOptionalArg<int>("shape", "The desired shape of the output. Number of elements in "
-                                "each sample must match that of the input sample. There can be "
-                                "one negative extent which receives the size required to match "
-                                "the input volume.\nNOTE: `shape` and `rel_shape` are mutually "
-                                "exclusive.",
-                                std::vector<int>(), true)
+  .AddOptionalArg<int>("shape", "The desired shape of the output. Number of dimensions "
+                  "must not exceed the number of dimensions of the input. There can be one "
+                  "negative extent which receives the size required to match the input volume, "
+                  "e.g. input of shape `[480, 640, 3]` and `rel_shape = [240, -1]` would get the "
+                  "shape [240, 3840].\n"
+                  "NOTE: `rel_shape` and `shape` are mutually exclusive.",
+                  std::vector<int>(), true)
   .AddOptionalArg<float>("rel_shape", "The relative shape of the output. Number of dimensions "
                   "must not exceed the number of dimensions of the input. There can be one "
-                  "negative value which means all remaining extents, e.g. input of shape "
-                  "`[480, 640, 3]` and `rel_shape = [0.5, -1]` would get the shape [240, 3840].\n"
+                  "negative extent which receives the size required to match the input volume, "
+                  "e.g. input of shape `[480, 640, 3]` and `rel_shape = [0.5, -1]` would get the "
+                  "shape [240, 3840].\n"
                   "NOTE: `rel_shape` and `shape` are mutually exclusive.",
                                 std::vector<float>(), true)
-  .AddOptionalArg("layout", "New layout for the data. If not specified, the output layout "
-                            "is preserved if number of dimension matches existing layout "
-                            "or reset to empty otherwise. If set and not empty, the layout must "
-                            "match the dimesnionality of the output.",
-                            "");
+  .AddOptionalArg("layout", "New layout for the data. If not specified, the output layout is "
+                  "preserved if number of dimension matches existing layout or reset to empty "
+                  "otherwise. If set and not empty, the layout must match the dimesnionality of "
+                  "the output.",
+                  "");
 
 
 template <typename Backend>
@@ -205,12 +209,12 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
       break;
     case ShapeSource::ArgInput:
       if (use_rel_shape_)
-        ShapeFromInput(ws.ArgumentInput("shape"), false);
+        ShapeFromInput(ws.ArgumentInput("rel_shape"), true);
       else
-        ShapeFromInput(ws.ArgumentInput("rel_shape"), false);
+        ShapeFromInput(ws.ArgumentInput("shape"), false);
       break;
     case ShapeSource::Input:
-      ShapeFromInput(ws.template InputRef<CPUBackend>(1), use_rel_shape_);
+      ShapeFromInput(ws.template InputRef<CPUBackend>(1), false);
       break;
     case ShapeSource::None:
       output_shape_ = input_shape_;

--- a/dali/operators/util/reshape.h
+++ b/dali/operators/util/reshape.h
@@ -45,6 +45,7 @@ class Reshape : public Operator<Backend> {
   TensorShape<> uniform_shape_;
   std::vector<float> rel_uniform_shape_;
   TensorLayout layout_;
+  bool use_layout_ = false;
 
   enum class ShapeSource {
     None,

--- a/dali/operators/util/reshape.h
+++ b/dali/operators/util/reshape.h
@@ -43,6 +43,7 @@ class Reshape : public Operator<Backend> {
  private:
   TensorListShape<> input_shape_, output_shape_;
   TensorShape<> uniform_shape_;
+  std::vector<float> rel_uniform_shape_;
   TensorLayout layout_;
 
   enum class ShapeSource {
@@ -53,14 +54,16 @@ class Reshape : public Operator<Backend> {
   };
 
   ShapeSource shape_source_ = ShapeSource::None;
+  bool use_rel_shape_ = false;
+  int wildcard_dim_ = -1;
 
   void CalculateOutputShape(const Workspace &ws);
 
   template <typename TensorListLike>
-  void ShapeFromInput(const TensorListLike &tl);
+  void ShapeFromInput(const TensorListLike &tl, bool relative);
 
-  template <typename Integer>
-  void ShapeFromInput(const TensorListView<StorageCPU, Integer> &shape);
+  template <typename Extent>
+  void ShapeFromInput(const TensorListView<StorageCPU, Extent> &shape);
 
   TensorLayout GetOutputLayout(const Workspace &ws) const;
 };

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -202,6 +202,7 @@ class DLL_PUBLIC OpSchema {
     min_num_input_ = min;
     max_num_input_ = max;
     input_layouts_.resize(max);
+    input_dox_.resize(max);
     return *this;
   }
 

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -82,6 +82,45 @@ class ReshapeWithInput(Pipeline):
 
         return [images, reshaped]
 
+def MakeTallFunc(relative, wildcard):
+  def func(image):
+    if relative:
+        return np.array([ -1 if wildcard else 2, 0.5, 1]).astype(np.float32)
+    else:
+        h, w, c = image.shape
+        return np.array([ -1 if wildcard else 2*h, w/2, c]).astype(np.int)
+  return func
+
+class ReshapeWithArgInput(Pipeline):
+    def __init__(self, device, batch_size, relative, use_wildcard, num_threads=3, device_id=0, num_gpus=1):
+        super(ReshapeWithArgInput, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=False, exec_pipelined=False)
+        self.device = device
+        self.input = ops.CaffeReader(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
+        self.resize = ops.Resize(device = "cpu");
+        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.gen_shapes = ops.PythonFunction(function=MakeTallFunc(relative, use_wildcard))
+        self.reshape = ops.Reshape(device = device);
+        self.relative = relative
+
+    def define_graph(self):
+        jpegs, labels = self.input(name = "Reader")
+        images_cpu = self.decode(jpegs)
+
+        rng = ops.Uniform(range=[100,128])
+        cast = ops.Cast(dtype=types.INT32)
+        widths = cast(rng()) * 2.0
+        heights = cast(rng()) * 2.0
+        images_cpu = self.resize(images_cpu, resize_x = widths, resize_y = heights)
+
+        shapes = self.gen_shapes(images_cpu)
+        images = images_cpu.gpu() if self.device == "gpu" else images_cpu
+        if self.relative:
+            reshaped = self.reshape(images, rel_shape = shapes)
+        else:
+            reshaped = self.reshape(images, shape = shapes)
+
+        return [images, reshaped]
+
 def verify_tensor_layouts(imgs, reshaped):
   assert imgs.layout() == "HWC"
   assert reshaped.layout() == "ab"
@@ -89,7 +128,7 @@ def verify_tensor_layouts(imgs, reshaped):
     assert imgs.at(i).layout() == "HWC"
     assert reshaped.at(i).layout() == "ab"
 
-def verify(imgs, reshaped, src_shape = None):
+def verify_flatten(imgs, reshaped, src_shape = None):
   assert imgs.layout() == "HWC"
   assert reshaped.layout() == "ab"
   for i in range(len(imgs)):
@@ -98,6 +137,18 @@ def verify(imgs, reshaped, src_shape = None):
     img_shape = imgs.at(i).shape
     # collapse width and channels
     ref_shape = (img_shape[0], img_shape[1] * img_shape[2])
+    assert reshaped.at(i).shape == ref_shape
+    assert_array_equal(imgs.at(i).flatten(), reshaped.at(i).flatten())
+
+def verify_make_tall(imgs, reshaped, src_shape = None):
+  assert imgs.layout() == "HWC"
+  assert reshaped.layout() == "HWC"
+  for i in range(len(imgs)):
+    if src_shape is not None:
+      assert imgs.at(i).shape == src_shape
+    img_shape = imgs.at(i).shape
+    # collapse width and channels
+    ref_shape = (img_shape[0] * 2, img_shape[1] // 2, 3)
     assert reshaped.at(i).shape == ref_shape
     assert_array_equal(imgs.at(i).flatten(), reshaped.at(i).flatten())
 
@@ -111,7 +162,7 @@ def check_reshape(device, batch_size, relative, use_wildcard):
       verify_tensor_layouts(imgs, reshaped)
       imgs = imgs.as_cpu()
       reshaped = reshaped.as_cpu()
-    verify(imgs, reshaped, (224, 320, 3))
+    verify_flatten(imgs, reshaped, (224, 320, 3))
 
 def check_reshape_with_input(device, batch_size, use_wildcard):
   pipe = ReshapeWithInput(device, batch_size, use_wildcard)
@@ -122,7 +173,17 @@ def check_reshape_with_input(device, batch_size, use_wildcard):
       verify_tensor_layouts(imgs, reshaped)
       imgs = imgs.as_cpu()
       reshaped = reshaped.as_cpu()
-    verify(imgs, reshaped)
+    verify_flatten(imgs, reshaped)
+
+def check_reshape_with_arg_input(device, batch_size, relative, use_wildcard):
+  pipe = ReshapeWithArgInput(device, batch_size, relative, use_wildcard)
+  pipe.build()
+  for iter in range(2):
+    imgs, reshaped = pipe.run()
+    if device == "gpu":
+      imgs = imgs.as_cpu()
+      reshaped = reshaped.as_cpu()
+    verify_make_tall(imgs, reshaped)
 
 def test_reshape_arg():
   for device in ["cpu", "gpu"]:
@@ -137,10 +198,19 @@ def test_reshape_input():
       for use_wildcard in [False, True]:
         yield check_reshape_with_input, device, batch_size, use_wildcard
 
+def test_reshape_arg_input():
+  for device in ["cpu", "gpu"]:
+    for batch_size in [16]:
+      for relative in [False, True]:
+        for use_wildcard in [False, True]:
+           yield check_reshape_with_arg_input, device, batch_size, relative, use_wildcard
+
 def main():
   for test in test_reshape_arg():
     test[0](*test[1:])
   for test in test_reshape_input():
+    test[0](*test[1:])
+  for test in test_reshape_arg_input():
     test[0](*test[1:])
 
 if __name__ == '__main__':

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -31,13 +31,20 @@ caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
 
 
 class ReshapePipeline(Pipeline):
-    def __init__(self, device, batch_size, num_threads=3, device_id=0, num_gpus=1):
+    def __init__(self, device, batch_size, relative, use_wildcard, num_threads=3, device_id=0, num_gpus=1):
         super(ReshapePipeline, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=True, exec_pipelined=True)
         self.device = device
         self.input = ops.CaffeReader(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
         self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
-        self.resize = ops.Resize(device = "cpu", resize_x = 224, resize_y = 224);
-        self.reshape = ops.Reshape(device = device, shape = (224, 224 * 3), layout = "ab");
+        W = 320
+        H = 224
+        self.resize = ops.Resize(device = "cpu", resize_x = W, resize_y = H);
+        WC = -1 if use_wildcard else W * 3
+        if relative:
+            rel_shape = (-1, 3) if use_wildcard else (1, 3)
+            self.reshape = ops.Reshape(device = device, rel_shape = rel_shape, layout = "ab");
+        else:
+            self.reshape = ops.Reshape(device = device, shape = (H, WC), layout = "ab");
 
     def define_graph(self):
         jpegs, labels = self.input(name = "Reader")
@@ -52,13 +59,18 @@ def CollapseChannels(image):
   new_shape = np.array([ image.shape[0], image.shape[1] * image.shape[2] ]).astype(np.int)
   return new_shape
 
+def CollapseChannelsWildcard(image):
+  new_shape = np.array([ image.shape[0], -1 ]).astype(np.int)
+  return new_shape
+
 class ReshapeWithInput(Pipeline):
-    def __init__(self, device, batch_size, num_threads=3, device_id=0, num_gpus=1):
+    def __init__(self, device, batch_size, use_wildcard, num_threads=3, device_id=0, num_gpus=1):
         super(ReshapeWithInput, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=False, exec_pipelined=False)
         self.device = device
         self.input = ops.CaffeReader(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
         self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
-        self.gen_shapes = ops.PythonFunction(function=CollapseChannels)
+        fn = CollapseChannelsWildcard if use_wildcard else CollapseChannels
+        self.gen_shapes = ops.PythonFunction(function=fn)
         self.reshape = ops.Reshape(device = device, layout = "ab");
 
     def define_graph(self):
@@ -90,8 +102,8 @@ def verify(imgs, reshaped, src_shape = None):
     assert_array_equal(imgs.at(i).flatten(), reshaped.at(i).flatten())
 
 
-def check_reshape(device, batch_size):
-  pipe = ReshapePipeline(device, batch_size)
+def check_reshape(device, batch_size, relative, use_wildcard):
+  pipe = ReshapePipeline(device, batch_size, relative, use_wildcard)
   pipe.build()
   for iter in range(10):
     imgs, reshaped = pipe.run()
@@ -99,12 +111,12 @@ def check_reshape(device, batch_size):
       verify_tensor_layouts(imgs, reshaped)
       imgs = imgs.as_cpu()
       reshaped = reshaped.as_cpu()
-    verify(imgs, reshaped, (224, 224, 3))
+    verify(imgs, reshaped, (224, 320, 3))
 
-def check_reshape_with_input(device, batch_size):
-  pipe = ReshapeWithInput(device, batch_size)
+def check_reshape_with_input(device, batch_size, use_wildcard):
+  pipe = ReshapeWithInput(device, batch_size, use_wildcard)
   pipe.build()
-  for iter in range(10):
+  for iter in range(2):
     imgs, reshaped = pipe.run()
     if device == "gpu":
       verify_tensor_layouts(imgs, reshaped)
@@ -115,12 +127,15 @@ def check_reshape_with_input(device, batch_size):
 def test_reshape_arg():
   for device in ["cpu", "gpu"]:
     for batch_size in [16]:
-      yield check_reshape, device, batch_size
+        for relative in [False, True]:
+            for use_wildcard in [False, True]:
+                yield check_reshape, device, batch_size, relative, use_wildcard
 
 def test_reshape_input():
   for device in ["cpu", "gpu"]:
     for batch_size in [16]:
-      yield check_reshape_with_input, device, batch_size
+      for use_wildcard in [False, True]:
+        yield check_reshape_with_input, device, batch_size, use_wildcard
 
 def main():
   for test in test_reshape_arg():


### PR DESCRIPTION
* Add relative extents
* Add "remaining volume" extent (-1) support

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed for RNN-t feature frame splicing

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Add rel_shape to Reshape parameter which accepts (floating point) relative shapes
     * Interpret negative extent as "all remaining volume" - it's calculated as a ratio of source tensor volume to the product of explicitly defined extents
 - Affected modules and functionalities:
     * Reshape operator
 - Key points relevant for the review:
     * reshape.cc
 - Validation and testing:
     * Python test
 - Documentation (including examples):
     * Parameter docstrings

**JIRA TASK**: N/A

