### PR TITLE
Change PipelineAPIType to Enum

### DIFF
--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -186,12 +186,13 @@ class Pipeline(object):
         pipeline_tls.current_pipeline = pipeline
         return prev
 
-    # Graph edges that are not connected to the output must be manually added to a pipeline
     def add_sink(self, edge):
+        """Allows to manual add of graph edges to the pipeline which are not connected to the output and all pruned
+        """
         self._sinks.append(edge)
 
     def _set_api_type(self, type):
-        if not types.PipelineAPIType._is_member(type):
+        if not type in types.PipelineAPIType:
             raise RuntimeError("Wrong pipeline API set!"
                                "check available values in :meth:`nvidia.dali.types.PipelineAPIType`")
         self._api_type = type
@@ -358,7 +359,7 @@ class Pipeline(object):
         If the pipeline is executed asynchronously, this function blocks
         until the results become available. It rises StopIteration if data set
         reached its end - usually when iter_setup cannot produce any more data"""
-        with self._check_api_type_scope(types.PipelineAPIType.SCHEDULED) as check:
+        with self._check_api_type_scope(types.PipelineAPIType.SCHEDULED):
             if self._batches_to_consume == 0 or self._gpu_batches_to_consume == 0:
                 raise StopIteration
             self._batches_to_consume -= 1
@@ -376,7 +377,7 @@ class Pipeline(object):
         Needs to be used together with :meth:`nvidia.dali.pipeline.Pipeline.release_outputs`
         and :meth:`nvidia.dali.pipeline.Pipeline.share_outputs`.
         Should not be mixed with :meth:`nvidia.dali.pipeline.Pipeline.run` in the same pipeline"""
-        with self._check_api_type_scope(types.PipelineAPIType.SCHEDULED) as check:
+        with self._check_api_type_scope(types.PipelineAPIType.SCHEDULED):
             if self._first_iter and self._exec_pipelined:
                 self._prefetch()
             else:

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 #pylint: disable=no-name-in-module,unused-import
+from enum import Enum, unique
+
 from nvidia.dali.backend_impl.types import *
 try:
     from nvidia.dali import tfrecord as tfrec
@@ -84,12 +86,10 @@ def _vector_element_type(dtype):
         raise RuntimeError(str(dtype) + " is not a vector type.")
     return _vector_types[dtype]
 
-class PipelineAPIType(object):
+@unique
+class PipelineAPIType(Enum):
     """Pipeline API type
     """
-    @staticmethod
-    def _is_member(self):
-        return PipelineAPIType.__dict__.keys()
     BASIC = 0
     ITERATOR = 1
     SCHEDULED = 2


### PR DESCRIPTION
- make docs for PipelineAPIType to have meaningful values instead of plain ints

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to use Python3 enum class for PipelineAPIType

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     make docs for PipelineAPIType to have meaningful values instead of plain ints
 - Affected modules and functionalities:
     types.py, pipeline.py
 - Key points relevant for the review:
     PipelineAPIType
 - Validation and testing:
     Current tests are sufficient
 - Documentation (including examples):
     It should remain unchanged. Error message should be more meaningful


**JIRA TASK**: *[Use DALI-XXXX or NA]*
