### PR TITLE
Add GetDimIndices utility to tensor_layout.h

### DIFF
--- a/dali/operators/crop/slice_attr.h
+++ b/dali/operators/crop/slice_attr.h
@@ -36,7 +36,7 @@ class SliceAttr {
       , crop_window_generators_(batch_size__) {
     const bool has_axes_arg = spec.HasArgument("axes");
     const bool has_axis_names_arg = spec.HasArgument("axis_names");
-    // Process `axis_names` if provided, or if neither `dir_names` nor `axes` are
+    // Process `axis_names` if provided, or if neither `axis_names` nor `axes` are
     if (has_axis_names_arg || !has_axes_arg) {
       axis_names_ = spec.GetArgument<TensorLayout>("axis_names");
       axes_ = {};
@@ -97,14 +97,7 @@ class SliceAttr {
 
         auto axes = axes_;
         if (!axis_names_.empty()) {
-          axes = {};
-          for (auto axis_name : axis_names_) {
-            auto dim_idx = shape_layout.find(axis_name);
-            DALI_ENFORCE(dim_idx >= 0,
-              make_string("Requested to slice dimension ", axis_name,
-                " which is not present in the shape layout ", shape_layout));
-            axes.push_back(dim_idx);
-          }
+          axes = GetDimIndices(shape_layout, axis_names_).to_vector();
         }
 
         for (size_t i = 0; i < axes.size(); i++) {

--- a/dali/operators/erase/erase_utils.h
+++ b/dali/operators/erase/erase_utils.h
@@ -31,15 +31,10 @@ namespace dali {
 
 namespace detail {
 
-SmallVector<int, 3> GetAxes(const OpSpec &spec, TensorLayout layout) {
-  SmallVector<int, 3> axes;
+SmallVector<int, 6> GetAxes(const OpSpec &spec, TensorLayout layout) {
+  SmallVector<int, 6> axes;
   if (spec.HasArgument("axis_names")) {
-    for (auto axis_name : spec.GetArgument<TensorLayout>("axis_names")) {
-      int d = layout.find(axis_name);
-      DALI_ENFORCE(d >= 0,
-        make_string("Axis '", axis_name, "' is not present in the input layout"));
-      axes.push_back(d);
-    }
+    axes = GetDimIndices(layout, spec.GetArgument<TensorLayout>("axis_names"));
   } else if (spec.HasArgument("axes")) {
     axes = spec.GetRepeatedArgument<int>("axes");
   } else {

--- a/include/dali/core/tensor_layout.h
+++ b/include/dali/core/tensor_layout.h
@@ -22,7 +22,9 @@
 #include <string>
 #include <stdexcept>
 #include "dali/core/error_handling.h"
+#include "dali/core/format.h"
 #include "dali/core/host_dev.h"
+#include "dali/core/small_vector.h"
 
 namespace dali {
 
@@ -544,6 +546,18 @@ inline std::array<int, Dims> GetLayoutMapping(const TensorLayout &in_layout,
 
 inline std::ostream &operator<<(std::ostream &os, const TensorLayout &tl) {
   return os << tl.c_str();
+}
+
+inline SmallVector<int, 6> GetDimIndices(const TensorLayout &layout,
+                                         const TensorLayout &dim_names) {
+  SmallVector<int, 6> dims;
+  dims.reserve(dim_names.size());
+  for (auto dim_name : dim_names) {
+    int d = layout.find(dim_name);
+    DALI_ENFORCE(d >= 0, make_string("Axis '", dim_name, "' is not present in the input layout"));
+    dims.push_back(d);
+  }
+  return dims;
 }
 
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to improve code reuse:
Transforming a set of axis names to axis indices for a given layout (e.g. axis_names="WH" `layout="HWC"` `axes=(1, 0)`) is becoming a recurrent pattern

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
Added a utility function GetDimIndices that calculates the indices of the axis (`axes`) specified by `axis_names` given a `layout`
Removed copies of the same utility in Slice and Erase operator
 - Affected modules and functionalities:
Erase and Slice operators
 - Key points relevant for the review:
The function
 - Validation and testing:
Pre-existing Slice and Erase tests
 - Documentation (including examples):
N/A

**JIRA TASK**: *[Use DALI-XXXX or NA]*
