### PR TITLE
Add support to UINT8 data type in SequenceWrapper

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -629,7 +629,7 @@ void VideoLoader::PrepareEmpty(SequenceWrapper &tensor) {
 void VideoLoader::ReadSample(SequenceWrapper& tensor) {
     // TODO(spanev) remove the async between the 2 following methods?
     auto& seq_meta = frame_starts_[current_frame_idx_];
-    tensor.initialize(count_, seq_meta.height, seq_meta.width, channels_);
+    tensor.initialize(count_, seq_meta.height, seq_meta.width, channels_, dtype_);
 
     push_sequence_to_read(file_info_[seq_meta.filename_idx].video_file,
                           seq_meta.frame_idx, count_);

--- a/dali/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/operators/reader/nvdecoder/nvdecoder.cc
@@ -26,6 +26,7 @@
 #include <string>
 #include <utility>
 
+#include "dali/core/static_switch.h"
 #include "dali/operators/reader/nvdecoder/cuvideoparser.h"
 #include "dali/core/dynlink_cuda.h"
 #include "dali/core/error_handling.h"
@@ -442,19 +443,14 @@ void NvDecoder::convert_frame(const MappedFrame& frame, SequenceWrapper& sequenc
                                       input_width,
                                       input_height,
                                       ScaleMethod_Linear);
-  if (dtype_ == DALI_UINT8) {
-    process_frame<uint8>(textures.chroma, textures.luma,
+  TYPE_SWITCH(dtype_, type2id, OutputType, NVDECODER_SUPPORTED_TYPES, (
+      process_frame<OutputType>(textures.chroma, textures.luma,
                   sequence,
                   output_idx, stream_,
                   input_width, input_height,
                   rgb_, normalized_);
-  } else {  // dtype_ == DALI_FLOAT
-    process_frame<float>(textures.chroma, textures.luma,
-                  sequence,
-                  output_idx, stream_,
-                  input_width, input_height,
-                  rgb_, normalized_);
-  }
+    ), DALI_FAIL(make_string("Not supported output type:", dtype_, // NOLINT
+        "Only DALI_UINT8 and DALI_FLOAT are supported as the decoder outputs.")););
 
   frame_in_use_[frame.disp_info->picture_index] = false;
 }

--- a/dali/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/operators/reader/nvdecoder/nvdecoder.h
@@ -51,6 +51,8 @@ using CodecParameters = AVCodecContext;
 
 namespace dali {
 
+#define NVDECODER_SUPPORTED_TYPES (float, uint8_t)
+
 struct FrameReq {
   std::string filename;
   int frame;


### PR DESCRIPTION
- SequenceWrapper assumes dtype to by float32 even if VideoReader  is asked for uint8 data - it leads to unnecessary memory consumption
- add support for float32 and int8 in SequenceWrapper
- adds appropriate tests

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- It fixes a bug unnecessary memory consumption in VideoReader when requested output type is uint8
- addresses https://github.com/NVIDIA/DALI/issues/1599

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     add support for float32 and uint8 in SequenceWrapper
 - Affected modules and functionalities:
     SequenceWrapper, VideoReader 
 - Key points relevant for the review:
     NA
 - Validation and testing:
     new tests has been added
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA*
