### PR TITLE
Remove the ColorTwist deprecation message

### DIFF
--- a/dali/operators/color/color_twist.cc
+++ b/dali/operators/color/color_twist.cc
@@ -15,10 +15,6 @@
 #include "dali/operators/color/color_twist.h"
 #include "dali/image/transform.h"
 
-/////////////////////////////////////////
-///// DEPRECATED, WILL BE REMOVED ///////
-/////////////////////////////////////////
-
 namespace dali {
 
 DALI_SCHEMA(ColorTransformBase)
@@ -38,7 +34,6 @@ Values >= 0 are accepted. For example:
 * `1` - no change
 * `2` - increase brightness twice)code", 1.f, true)
     .AddParent("ColorTransformBase")
-    .Deprecate("BrightnessContrast")
     .InputLayout(0, "HWC");
 
 DALI_SCHEMA(Contrast)
@@ -52,7 +47,6 @@ Values >= 0 are accepted. For example:
 * `0` - gray image,
 * `1` - no change
 * `2` - increase contrast twice)code", 1.f, true)
-    .Deprecate("BrightnessContrast")
     .AddParent("ColorTransformBase");
 
 DALI_SCHEMA(Hue)
@@ -62,7 +56,6 @@ DALI_SCHEMA(Hue)
     .AddOptionalArg("hue",
         R"code(Hue change, in degrees.)code", 0.f, true)
     .AddParent("ColorTransformBase")
-    .Deprecate("Hsv")
     .InputLayout(0, "HWC");
 
 DALI_SCHEMA(Saturation)
@@ -76,7 +69,6 @@ Values >= 0 are supported. For example:
 * `0` - completely desaturated image
 * `1` - no change to image's saturation)code", 1.f, true)
     .AddParent("ColorTransformBase")
-    .Deprecate("Hsv")
     .InputLayout(0, "HWC");
 
 DALI_SCHEMA(ColorTwist)
@@ -106,7 +98,6 @@ Values >= 0 are accepted. For example:
 * `1` - no change
 * `2` - increase brightness twice)code", 1.f, true)
     .AddParent("ColorTransformBase")
-    .Deprecate("Hsv/BrightnessContrast")
     .InputLayout(0, "HWC");
 
 template <>

--- a/dali/operators/color/color_twist.cu
+++ b/dali/operators/color/color_twist.cu
@@ -16,10 +16,6 @@
 #include "dali/util/npp.h"
 #include "dali/operators/color/color_twist.h"
 
-/////////////////////////////////////////
-///// DEPRECATED, WILL BE REMOVED ///////
-/////////////////////////////////////////
-
 namespace dali {
 
 typedef NppStatus (*colorTwistFunc)(const Npp8u *pSrc, int nSrcStep, Npp8u *pDst, int nDstStep,

--- a/dali/operators/color/color_twist.h
+++ b/dali/operators/color/color_twist.h
@@ -21,10 +21,6 @@
 #include <cmath>
 #include "dali/pipeline/operator/operator.h"
 
-/////////////////////////////////////////
-///// DEPRECATED, WILL BE REMOVED ///////
-/////////////////////////////////////////
-
 namespace dali {
 
 class ColorAugment {
@@ -176,9 +172,6 @@ class ColorTwistBase : public Operator<Backend> {
   inline explicit ColorTwistBase(const OpSpec &spec) : Operator<Backend>(spec),
                       C_(IsColor(spec.GetArgument<DALIImageType>("image_type")) ? 3 : 1) {
     DALI_ENFORCE(C_ == 3, "Color transformation is implemented only for RGB images");
-    DALI_WARN("The Operators: `ColorTwist`, `Hue`, `Saturation`, `Brightness`, `Contrast`, "
-              "are deprecated, not supported, and will be removed in version 0.20. "
-              "Please use `BrightnessContrast` and `Hsv` instead.");
   }
 
   ~ColorTwistBase() override {


### PR DESCRIPTION
- ColorTwist won't be removed in 0.20 but only when a new ColorTwist accepting an arbitrary transformation matrix is ready and replace the old one.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug with the presence of the DALI deprecation warning for the ColorTwist operator

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Remove the ColorTwist deprecation message
 - Affected modules and functionalities:
    ColorTwist operator
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
