### PR TITLE
Remove allocation-dependent tast assert

### DIFF
--- a/dali/kernels/test/test_utils_test.cc
+++ b/dali/kernels/test/test_utils_test.cc
@@ -89,11 +89,7 @@ TEST(TestTensorList, Transfer) {
 
   ttl.invalidate_cpu();
 
-  std::vector<int> dummy(1024);  // allocate 1024 ints to (hopefully) prevent
-                                 // same address from being allocated to the tensor list
-
   auto cpu = ttl.cpu(0);
-  EXPECT_NE(cpu.data[0], ptr) << "It's highly unlikely that we get exactly the same pointer";
   for (int i = 0; i < 1024; i++) {
     ASSERT_EQ(cpu.data[0][i], i+1);
   }


### PR DESCRIPTION
It turns out that new allocation after dummy allocation
still returns the same pointer.
It may be that the allocation is optimized out.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug that assumed that this test is always true

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *[ Remove offending test as this condition may actually happen in practice ]*
 - Affected modules and functionalities:
     *[ Tests ]*
 - Key points relevant for the review:
     *[  ]*
 - Validation and testing:
     *[ CI ]*
 - Documentation (including examples):
     *[ NA ]*


**JIRA TASK**: *[NA]*
