### PR TITLE
Fix several explicitly defaulted is implicitly deleted warnings

### DIFF
--- a/dali/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/operators/reader/nvdecoder/nvdecoder.h
@@ -82,10 +82,14 @@ class NvDecoder {
             int max_width,
             int additional_decode_surfaces);
 
-  NvDecoder(const NvDecoder&) = default;
-  NvDecoder(NvDecoder&&) = default;
-  NvDecoder& operator=(const NvDecoder&) = default;
-  NvDecoder& operator=(NvDecoder&&) = default;
+  // Some of the members are non-movable or non-copyable so the constructors below still end up
+  // implicitly deleted, thus marking them explicitly deleted as this class in managed through
+  // unique_ptr.
+  // The culprits are: CUStream (non-copyable), ThreadSafeQueue (std::mutex) and const members.
+  NvDecoder(const NvDecoder&) = delete;
+  NvDecoder(NvDecoder&&) = delete;
+  NvDecoder& operator=(const NvDecoder&) = delete;
+  NvDecoder& operator=(NvDecoder&&) = delete;
   ~NvDecoder();
 
   bool initialized() const;

--- a/dali/test/dali_test_single_op.h
+++ b/dali/test/dali_test_single_op.h
@@ -84,11 +84,12 @@ typedef enum {
   t_decodeBmps  = (1<<7),
 } t_loadingFlags;
 
-typedef struct {
+struct OpArg {
+  OpArg() = default;
   const char *m_Name;
   std::string m_val;
-  const DALIDataType type;
-} OpArg;
+  DALIDataType type;
+};
 
 class opDescr {
  public:


### PR DESCRIPTION
Several constructors were implicitly deleted due to
the class members being explicitly deleted
in spite of explicit `=default`.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- It fixes the mentioned warning

#### What happened in this PR?
 - What solution was applied:
     *[ Explicitly delete or remove the cause of implicit delete ]*
 - Affected modules and functionalities:
     *[ - ]*
 - Key points relevant for the review:
     *[ - ]*
 - Validation and testing:
     *[ Tested on clang-9 which produces those warnings ]*
 - Documentation (including examples):
     *[ NA ]*


**JIRA TASK**: *[NA]*
