### PR TITLE
Nonsilence operator

### DIFF
--- a/dali/operators/audio/nonsilence_op.cc
+++ b/dali/operators/audio/nonsilence_op.cc
@@ -19,27 +19,27 @@
 namespace dali {
 
 DALI_SCHEMA(NonsilenceRegion)
-                .DocStr(R"code(The operator performs leading and trailing silence detection in an audio buffer.<br>
-This operators' behaviour can be described as:
-```
-def nonsilence(buffer, cutoff_value):
-    begin = 0
-    end = 0
-    for i in range(len(buffer)):
-        if buffer[i] > cutoff_value:
-            begin = i
-            break
-    for i in range(len(buffer) - 1, -1, -1):
-        if buffer[i] > cutoff_value:
-            end = i
-            break
-    length = end - begin + 1
-    return begin, length
-```
-`Input`: 1-D audio buffer
-`Output[0]`: Begin index of nonsilent region
-`Output[1] >= 0`: Length of nonsilent region<br>
-If `Output[1] == 0`, `Output[0]` value is undefined
+                .DocStr(R"code(The operator performs leading and trailing silence
+detection in an audio buffer. This operators' behaviour can be described as::
+
+  def nonsilence(buffer, cutoff_value):
+      begin = 0
+      end = 0
+      for i in range(len(buffer)):
+          if buffer[i] > cutoff_value:
+              begin = i
+              break
+      for i in range(len(buffer) - 1, -1, -1):
+          if buffer[i] > cutoff_value:
+              end = i
+              break
+      length = end - begin + 1
+      return begin, length
+
+- ``Input``: 1-D audio buffer
+- ``Output[0]``: Begin index of nonsilent region
+- ``Output[1] >= 0``: Length of nonsilent region
+- If ``Output[1] == 0``, ``Output[0]`` value is undefined
 )code")
                 .NumInput(1)
                 .NumOutput(detail::kNumOutputs)

--- a/dali/operators/audio/nonsilence_op.cc
+++ b/dali/operators/audio/nonsilence_op.cc
@@ -1,0 +1,95 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/audio/nonsilence_op.h"
+#include "dali/core/static_switch.h"
+#include "dali/core/convert.h"
+
+namespace dali {
+
+
+DALI_SCHEMA(NonsilenceRegion)
+                .DocStr(R"code(The operator performs leading and trailing nonsilence detection on an audio buffer.<br>
+This operators' behaviour can be described as:
+```
+def nonsilence(buffer, cutoff_value):
+    begin = 0
+    end = 0
+    for i in range(len(buffer)):
+        if buffer[i] > cutoff_value:
+            begin = i
+            break
+    for i in range(len(buffer) - 1, -1, -1):
+        if buffer[i] > cutoff_value:
+            end = i
+            break
+    length = end - begin + 1
+    return begin, length
+```
+`Input`: 1-D buffer
+`Output[0]`: Begin index of nonsilent region
+`Output[1] >= 0`: Length of nonsilent region<br>
+If `Output[1] == 0`, `Output[0]` value is undefined
+)code")
+                .NumInput(1)
+                .NumOutput(detail::kNumOutputs)
+                .AddArg(detail::kCutoff, R"code()code", DALI_FLOAT);
+
+DALI_REGISTER_OPERATOR(NonsilenceRegion, NonsilenceOperatorCpu, CPU);
+
+#define NONSILENCE_TYPES (uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float, double)  // NOLINT
+
+
+bool NonsilenceOperatorCpu::SetupImpl(std::vector<OutputDesc> &output_desc,
+                                      const workspace_t<CPUBackend> &ws) {
+  TypeInfo output_type;
+  output_type.SetType<detail::OutputType>(TypeTable::GetTypeID<detail::OutputType>());
+  TensorShape<> scalar_shape = {1};
+
+  output_desc.resize(detail::kNumOutputs);
+  for (int i = 0; i < detail::kNumOutputs; i++) {
+    output_desc[i].shape = uniform_list_shape(batch_size_, scalar_shape);
+    output_desc[i].type = output_type;
+  }
+  return true;
+}
+
+
+void NonsilenceOperatorCpu::RunImpl(workspace_t<CPUBackend> &ws) {
+  const auto &input = ws.template InputRef<CPUBackend>(0);
+  auto &output_begin = ws.OutputRef<CPUBackend>(0);
+  auto &output_length = ws.OutputRef<CPUBackend>(1);
+  auto &tp = ws.GetThreadPool();
+  TYPE_SWITCH(input.type().id(), type2id, InputType, NONSILENCE_TYPES, (
+      for (int sample_id = 0; sample_id < batch_size_; sample_id++) {
+        tp.DoWorkWithID(
+            [&, sample_id](int thread_id) {
+              const auto in_ptr = input[sample_id].data<InputType>();
+              auto num_samples = volume(input[sample_id].shape());
+              auto res = detail::DetectNonsilenceRegion
+                      (make_cspan(in_ptr, num_samples), ConvertSat<InputType>(cutoff_));
+              auto beg_ptr = output_begin[sample_id].mutable_data<detail::OutputType>();
+              auto len_ptr = output_length[sample_id].mutable_data<detail::OutputType>();
+              *beg_ptr = res.first;
+              *len_ptr = res.second;
+            });
+      }
+  ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())))  // NOLINT
+  tp.WaitForWork();
+}
+
+
+#undef NONSILENCE_TYPES
+
+}  // namespace dali

--- a/dali/operators/audio/nonsilence_op.cc
+++ b/dali/operators/audio/nonsilence_op.cc
@@ -18,9 +18,8 @@
 
 namespace dali {
 
-
 DALI_SCHEMA(NonsilenceRegion)
-                .DocStr(R"code(The operator performs leading and trailing nonsilence detection on an audio buffer.<br>
+                .DocStr(R"code(The operator performs leading and trailing silence detection in an audio buffer.<br>
 This operators' behaviour can be described as:
 ```
 def nonsilence(buffer, cutoff_value):
@@ -37,14 +36,14 @@ def nonsilence(buffer, cutoff_value):
     length = end - begin + 1
     return begin, length
 ```
-`Input`: 1-D buffer
+`Input`: 1-D audio buffer
 `Output[0]`: Begin index of nonsilent region
 `Output[1] >= 0`: Length of nonsilent region<br>
 If `Output[1] == 0`, `Output[0]` value is undefined
 )code")
                 .NumInput(1)
                 .NumOutput(detail::kNumOutputs)
-                .AddArg(detail::kCutoff, R"code()code", DALI_FLOAT);
+                .AddArg(detail::kCutoff, R"code(Everything below this value will be regarded as silence)code", DALI_FLOAT);
 
 DALI_REGISTER_OPERATOR(NonsilenceRegion, NonsilenceOperatorCpu, CPU);
 
@@ -88,7 +87,6 @@ void NonsilenceOperatorCpu::RunImpl(workspace_t<CPUBackend> &ws) {
   ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())))  // NOLINT
   tp.WaitForWork();
 }
-
 
 #undef NONSILENCE_TYPES
 

--- a/dali/operators/audio/nonsilence_op.h
+++ b/dali/operators/audio/nonsilence_op.h
@@ -30,11 +30,9 @@ static_assert(std::is_integral<OutputType>::value,
               "Operator return indices, thus OutputType shall be integral");
 
 /**
- *
- * @tparam T
- * @param buffer
- * @param cutoff
- * @return (begin, length)
+ * Detects nonsilence region in provided 1-D audio buffer
+ * @param cutoff Everything below this value will be reagrded as silence
+ * @return (begin index, length)
  */
 template<typename T>
 std::pair<int, int> DetectNonsilenceRegion(span<const T> buffer, T cutoff) {

--- a/dali/operators/audio/nonsilence_op.h
+++ b/dali/operators/audio/nonsilence_op.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_AUDIO_NONSILENCE_OP_H_
+#define DALI_OPERATORS_AUDIO_NONSILENCE_OP_H_
+
+#include <utility>
+#include <vector>
+#include "dali/core/convert.h"
+#include "dali/pipeline/operator/operator.h"
+
+namespace dali {
+namespace detail {
+
+const std::string kCutoff = "cutoff_value";  // NOLINT
+const int kNumOutputs = 2;
+using OutputType = int;
+static_assert(std::is_integral<OutputType>::value,
+              "Operator return indices, thus OutputType shall be integral");
+
+/**
+ *
+ * @tparam T
+ * @param buffer
+ * @param cutoff
+ * @return (begin, length)
+ */
+template<typename T>
+std::pair<int, int> DetectNonsilenceRegion(span<const T> buffer, T cutoff) {
+  int begin = -1;
+  int end = buffer.size();
+  while (begin < end && buffer[++begin] < cutoff);  // NOLINT
+  if (begin == end) return {-1, 0};
+  while (buffer[--end] < cutoff);  // NOLINT
+  return {begin, end - begin + 1};
+}
+
+}  // namespace detail
+
+template<typename Backend>
+class NonsilenceOperator : public Operator<Backend> {
+ public:
+  ~NonsilenceOperator() override = default;
+
+  DISABLE_COPY_MOVE_ASSIGN(NonsilenceOperator);
+
+ protected:
+  explicit NonsilenceOperator(const OpSpec &spec) :
+          Operator<Backend>(spec),
+          cutoff_(spec.GetArgument<float>(detail::kCutoff)) {}
+
+
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
+
+  USE_OPERATOR_MEMBERS();
+  const float cutoff_;
+};
+
+
+class NonsilenceOperatorCpu : public NonsilenceOperator<CPUBackend> {
+ public:
+  explicit NonsilenceOperatorCpu(const OpSpec &spec) : NonsilenceOperator<CPUBackend>(spec) {}
+
+
+  ~NonsilenceOperatorCpu() override = default;
+
+  DISABLE_COPY_MOVE_ASSIGN(NonsilenceOperatorCpu);
+
+ protected:
+  bool SetupImpl(std::vector<::dali::OutputDesc> &output_desc,
+                 const workspace_t<CPUBackend> &ws) override;
+
+  void RunImpl(workspace_t<CPUBackend> &ws) override;
+};
+
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_AUDIO_NONSILENCE_OP_H_

--- a/dali/operators/audio/nonsilence_op_test.cc
+++ b/dali/operators/audio/nonsilence_op_test.cc
@@ -1,0 +1,40 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <utility>
+#include "dali/operators/audio/nonsilence_op.h"
+
+namespace dali {
+namespace testing {
+
+TEST(NonsilenceOpTest, DetectNonsilenceRegion) {
+  std::vector<float> t0 = {0, 0, 0, 0, 0, 1.5, -100, 1.5};
+  EXPECT_EQ(detail::DetectNonsilenceRegion(make_cspan(t0), .5f), std::make_pair(5, 3));
+
+  std::vector<float> t1 = {1.5, -100, 1.5, 0, 0, 0, 0};
+  EXPECT_EQ(detail::DetectNonsilenceRegion(make_cspan(t1), .5f), std::make_pair(0, 3));
+
+  std::vector<float> t2 = {0, 0, 0, 0, 0, 1.5, -100, -100, 1.5, 0, 0, 0, 0};
+  EXPECT_EQ(detail::DetectNonsilenceRegion(make_cspan(t2), 1.5f), std::make_pair(5, 4));
+
+  std::vector<int> t3 = {23, 62, 46, 12, 53};
+  EXPECT_EQ(detail::DetectNonsilenceRegion(make_cspan(t3), 100).second, 0);
+
+  std::vector<int64_t> t4 = {623, 45, 62, 46, 23};
+  EXPECT_EQ(detail::DetectNonsilenceRegion(make_cspan(t4), 10L), std::make_pair(0, 5));
+}
+
+}  // namespace testing
+}  // namespace dali

--- a/dali/test/python/test_operator_nonsilence.py
+++ b/dali/test/python/test_operator_nonsilence.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops as ops
+import numpy as np
+
+sample_size = 10
+batch_size = 5
+premade_batch = [np.random.rand(sample_size) for i in range(batch_size)]
+
+
+def nonsilence(buffer, cutoff_value):
+    begin = 0
+    end = 0
+    for i in range(len(buffer)):
+        if buffer[i] > cutoff_value:
+            begin = i
+            break
+    for i in range(len(buffer) - 1, -1, -1):
+        if buffer[i] > cutoff_value:
+            end = i
+            break
+    length = 0 if begin == end else end - begin + 1
+    return begin, length
+
+
+class NonsilencePipeline(Pipeline):
+    def __init__(self, cutoff_value, num_threads=1):
+        super(NonsilencePipeline, self).__init__(batch_size, num_threads, 0)
+        self.ext_src = ops.ExternalSource()
+        self.nonsilence = ops.NonsilenceRegion(cutoff_value=cutoff_value, device="cpu")
+
+    def define_graph(self):
+        self.data = self.ext_src()
+        return self.nonsilence(self.data)
+
+    def iter_setup(self):
+        self.feed_input(self.data, premade_batch)
+
+
+def check_nonsilence_operator(cutoff_value):
+    pipeline = NonsilencePipeline(cutoff_value=cutoff_value)
+    pipeline.build()
+    outputs = pipeline.run()
+    for i in range(batch_size):
+        ref_begin, ref_length = nonsilence(premade_batch[i], cutoff_value)
+        assert ref_length == outputs[1].at(i)
+        if ref_length > 0:
+            assert ref_begin == outputs[0].at(i)
+
+
+def test_nonsilence_operator():
+    print(premade_batch)
+    for coef in [.0, .5, 1.]:
+        yield check_nonsilence_operator, coef


### PR DESCRIPTION
This operator is required for RNN-T support in Dali.
Operator performs silence detection in an audio buffer. It returns begin index of nonsilent region and its length.

#### Why we need this PR?
*Pick one, remove the rest*
- To support RNN-T in Dali

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added new operator*
 - Validation and testing:
     *Python and GTest unit tests*
 - Documentation (including examples):
     *Documentation in tests*


**JIRA TASK**: *NA*
