### PR TITLE
Change ambigous `here` in docs developer version

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,11 @@ NVIDIA DALI documentation
 .. ifconfig:: "dev" in release
 
    .. warning::
-      You are currently viewing unstable developer preview of the documentation. To see the documentation for the latest stable release click `here <https://docs.nvidia.com/deeplearning/sdk/index.html#data-loading>`_
+      You are currently viewing unstable developer preview of the documentation.
+      To see the documentation for the latest stable release, refer to:
+        * `Release Notes <https://docs.nvidia.com/deeplearning/sdk/dali-release-notes/index.html>`_
+        * `Installation Guide <https://docs.nvidia.com/deeplearning/sdk/dali-install-guide/index.html>`_
+        * `Developer Guide <https://docs.nvidia.com/deeplearning/sdk/dali-developer-guide/docs/index.html>`_ (stable version of this page)
 
 .. include:: ../README.rst
    :start-after: overview-begin-marker-do-not-remove


### PR DESCRIPTION
Extend it to more verbose options.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- It improves the docs clarity

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *[ the `here` pointed to Data Loading section of Deep Learning docs which might have been confusing. It was changed to more descriptive links. ]*
 - Affected modules and functionalities:
     *[ Developer docs. ]*
 - Key points relevant for the review:
     *[ - ]*
 - Validation and testing:
     *[ Visual confirmation. ]*
 - Documentation (including examples):
     *[ It's developer docs update. ]*


**JIRA TASK**: *[]*
