### PR TITLE
Remove VideoReader scale parameter

### DIFF
--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -69,9 +69,6 @@ This option is mutually exclusive with `filenames` and `file_root`.)code",
   .AddOptionalArg("step",
       R"code(Frame interval between each sequence (if `step` < 0, `step` is set to `sequence_length`).)code",
       -1)
-  .AddOptionalArg("scale",
-      R"code(Rescaling factor of height and width.)code",
-      1.f)
   .AddOptionalArg("channels",
       R"code(Number of channels.)code",
       3)

--- a/dali/operators/reader/video_reader_op.h
+++ b/dali/operators/reader/video_reader_op.h
@@ -34,7 +34,6 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
     enable_timestamps_(spec.GetArgument<bool>("enable_timestamps")),
     count_(spec.GetArgument<int>("sequence_length")),
     channels_(spec.GetArgument<int>("channels")),
-    output_scale_(spec.GetArgument<float>("scale")),
     tl_shape_(batch_size_, sequence_dim),
     dtype_(spec.GetArgument<DALIDataType>("dtype")) {
     DALIImageType image_type(spec.GetArgument<DALIImageType>("image_type"));
@@ -161,8 +160,6 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
   bool enable_timestamps_;
   int count_;
   int channels_;
-
-  float output_scale_;
 
   TensorListShape<> tl_shape_;
   TensorListShape<> label_shape_;


### PR DESCRIPTION
The `scale` parameter for ops.VideoReader is available but [not yet implemented](https://github.com/NVIDIA/DALI/blob/master/dali/operators/reader/video_reader_op.h#L62).

This commit removes the parameter.

#### Why we need this PR?
- The existence of a parameter that does nothing is potentially confusing.

#### What happened in this PR?
- This `scale` parameter was removed from ops.VideoReader.