### PR TITLE
Mitigate the OS file-max limit in the VideoReader

### DIFF
--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -31,6 +31,7 @@ extern "C" {
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <list>
 
 #include "dali/core/common.h"
 #include "dali/operators/reader/loader/loader.h"
@@ -283,6 +284,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   VideoLoaderStats stats_;
 
   std::unordered_map<std::string, OpenFile> open_files_;
+  std::list<std::string> recently_opened_;
   nvdecDriverHandle lib_handle_;
   std::unique_ptr<NvDecoder> vid_decoder_;
 
@@ -295,6 +297,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
 
   volatile bool stop_;
   std::vector<file_meta> file_info_;
+
+  constexpr static size_t kMaxOpenFiles = 200;
 };
 
 }  // namespace dali

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -73,15 +73,26 @@ std::vector<dali::file_meta> get_file_label_pair(const std::string& path,
 
 }  // namespace filesystem
 
-struct OpenFile {
-  bool open = false;
+struct VideoFileDesc {
+  FILE *file_stream = nullptr;
+  uint64_t file_position = 0;
+  std::string filename;
+  ~VideoFileDesc() {
+    if (file_stream) {
+      fclose(file_stream);
+      file_stream = nullptr;
+    }
+  }
+};
+
+struct VideoFile {
   AVRational frame_base_;
   AVRational stream_base_;
-  int64_t start_time_;
-  int frame_count_;
+  int64_t start_time_ = 0;
+  int frame_count_ = -1;
 
-  int vid_stream_idx_;
-  int last_frame_;
+  int vid_stream_idx_ = -1;
+  int last_frame_ = -1;
 
 #if HAVE_AVBSFCONTEXT
   av_unique_ptr<AVBSFContext> bsf_ctx_;
@@ -93,9 +104,12 @@ struct OpenFile {
   };
   using bsf_ptr = std::unique_ptr<AVBitStreamFilterContext, BSFDeleter>;
   bsf_ptr bsf_ctx_;
-  AVCodecContext* codec;
+  AVCodecContext* codec = nullptr;
 #endif
   av_unique_ptr<AVFormatContext> fmt_ctx_;
+
+  VideoFileDesc file_desc;
+  bool empty() const noexcept { return file_desc.filename.empty(); }
 };
 
 struct VideoLoaderStats {
@@ -186,8 +200,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   void PrepareEmpty(SequenceWrapper &tensor) override;
   void ReadSample(SequenceWrapper &tensor) override;
 
-  OpenFile& get_or_open_file(const std::string &filename);
-  void seek(OpenFile& file, int frame);
+  VideoFile& get_or_open_file(const std::string &filename);
+  void seek(VideoFile& file, int frame);
   void read_file();
   void push_sequence_to_read(std::string filename, int frame, int count);
   void receive_frames(SequenceWrapper& sequence);
@@ -283,8 +297,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   bool file_list_frame_num_;
   VideoLoaderStats stats_;
 
-  std::unordered_map<std::string, OpenFile> open_files_;
-  std::list<std::string> recently_opened_;
+  std::unordered_map<std::string, VideoFile> open_files_;
+  std::string last_opened_;
   nvdecDriverHandle lib_handle_;
   std::unique_ptr<NvDecoder> vid_decoder_;
 
@@ -297,8 +311,6 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
 
   volatile bool stop_;
   std::vector<file_meta> file_info_;
-
-  constexpr static size_t kMaxOpenFiles = 200;
 };
 
 }  // namespace dali

--- a/dali/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/operators/reader/nvdecoder/nvdecoder.h
@@ -101,7 +101,8 @@ class NvDecoder {
   static int handle_decode(void* user_data, CUVIDPICPARAMS* pic_params);
   static int handle_display(void* user_data, CUVIDPARSERDISPINFO* disp_info);
 
-  int decode_packet(AVPacket* pkt, int64_t start_time, AVRational stream_base);
+  int decode_packet(AVPacket* pkt, int64_t start_time, AVRational stream_base,
+                    const CodecParameters*);
 
   void push_req(FrameReq req);
 
@@ -173,7 +174,6 @@ class NvDecoder {
 
   const int device_id_;
   CUStream stream_;
-  const CodecParameters* codecpar_;
 
   bool rgb_;
   DALIDataType dtype_;

--- a/dali/test/python/test_video_pipeline.py
+++ b/dali/test/python/test_video_pipeline.py
@@ -27,14 +27,14 @@ import re
 
 from nose.tools import assert_raises
 
-VIDEO_DIRECTORY = "video_files"
-PLENTY_VIDEO_DIRECTORY = "many_video_files"
+VIDEO_DIRECTORY = "/tmp/video_files"
+PLENTY_VIDEO_DIRECTORY = "/tmp/many_video_files"
 VIDEO_FILES = os.listdir(VIDEO_DIRECTORY)
 PLENTY_VIDEO_FILES=  os.listdir(PLENTY_VIDEO_DIRECTORY)
 VIDEO_FILES = [VIDEO_DIRECTORY + '/' + f for f in VIDEO_FILES]
 PLENTY_VIDEO_FILES = [PLENTY_VIDEO_DIRECTORY + '/' + f for f in PLENTY_VIDEO_FILES]
-FILE_LIST = "file_list.txt"
-MUTLIPLE_RESOLUTION_ROOT = 'video_resolution/'
+FILE_LIST = "/tmp/file_list.txt"
+MUTLIPLE_RESOLUTION_ROOT = '/tmp/video_resolution/'
 
 ITER=6
 BATCH_SIZE=4

--- a/qa/TL0_videoreader_test/test.sh
+++ b/qa/TL0_videoreader_test/test.sh
@@ -7,11 +7,14 @@ do_once() {
   apt-get update
   apt-get install -y wget ffmpeg
 
+  TMP_VIDEO_FILES=/tmp/video_files
+  TMP_MANY_VIDEO_FILES=/tmp/many_video_files
+  TMP_LABLED_VIDEO_FILES=/tmp/labelled_videos
 
-  mkdir -p video_files
-  mkdir -p many_video_files
-  mkdir -p labelled_videos/{0..2}
-  cp -r ${DALI_EXTRA_PATH}/db/video_resolution .
+  mkdir -p $TMP_VIDEO_FILES
+  mkdir -p $TMP_MANY_VIDEO_FILES
+  mkdir -p $TMP_LABLED_VIDEO_FILES/{0..2}
+  cp -r ${DALI_EXTRA_PATH}/db/video_resolution /tmp/
 
   container_path=${DALI_EXTRA_PATH}/db/optical_flow/sintel_trailer/sintel_trailer.mp4
 
@@ -20,22 +23,22 @@ do_once() {
 
   for i in {0..4};
   do
-      ffmpeg -ss 00:00:${i}0 -t 00:00:10 -i $container_path -vcodec copy -acodec copy -y video_files/${split[0]}_$i.${split[1]}
+      ffmpeg -ss 00:00:${i}0 -t 00:00:10 -i $container_path -vcodec copy -acodec copy -y $TMP_VIDEO_FILES/${split[0]}_$i.${split[1]}
   done
 
   #create dummy files for max_opened_file_test
   for i in {0..1400};
   do
-      ln -s ../video_files/${split[0]}_0.${split[1]} many_video_files/${split[0]}_$i.${split[1]}
+      ln -s ../video_files/${split[0]}_0.${split[1]} $TMP_MANY_VIDEO_FILES/${split[0]}_$i.${split[1]}
   done
 
   for i in {0..9};
   do
-      ffmpeg -ss 00:00:$((i*5)) -t 00:00:05 -i $container_path -vcodec copy -acodec copy -y labelled_videos/$((i % 3))//${split[0]}_$i.${split[1]}
+      ffmpeg -ss 00:00:$((i*5)) -t 00:00:05 -i $container_path -vcodec copy -acodec copy -y $TMP_LABLED_VIDEO_FILES/$((i % 3))/${split[0]}_$i.${split[1]}
   done
 
   # generate file_list.txt from video_files directory
-  ls -d video_files/*  | tr " " "\n" | awk '{print $0, NR;}' > file_list.txt
+  ls -d $TMP_VIDEO_FILES/*  | tr " " "\n" | awk '{print $0, NR;}' > /tmp/file_list.txt
 }
 
 test_body() {

--- a/qa/TL0_videoreader_test/test.sh
+++ b/qa/TL0_videoreader_test/test.sh
@@ -9,6 +9,7 @@ do_once() {
 
 
   mkdir -p video_files
+  mkdir -p many_video_files
   mkdir -p labelled_videos/{0..2}
   cp -r ${DALI_EXTRA_PATH}/db/video_resolution .
 
@@ -20,6 +21,12 @@ do_once() {
   for i in {0..4};
   do
       ffmpeg -ss 00:00:${i}0 -t 00:00:10 -i $container_path -vcodec copy -acodec copy -y video_files/${split[0]}_$i.${split[1]}
+  done
+
+  #create dummy files for max_opened_file_test
+  for i in {0..1400};
+  do
+      ln -s ../video_files/${split[0]}_0.${split[1]} many_video_files/${split[0]}_$i.${split[1]}
   done
 
   for i in {0..9};


### PR DESCRIPTION
- uses the custom read-write-seek libav API that allows providing custom accessing function. This function opens the required file on demand. The previously accessed file is closed automatically.
- it is faster than calling avformat_open_input after each file reopen
- add test to check if DALI can handle more than 1024 video files at once

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed because of VideoReader can easily hit the OS file-max limit of opened files (usually 1024)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Uses the custom read-write-seek libav API that allows providing custom accessing function. This function opens the required file on demand. The previously accessed file is closed automatically.
     It is faster than calling avformat_open_input after each file reopen
 - Affected modules and functionalities:
     VideoReader
 - Key points relevant for the review:
     get_or_open_file function 
 - Validation and testing:
     Test is added
 - Documentation (including examples):
     NA

Related to https://github.com/NVIDIA/DALI/issues/1651

**JIRA TASK**: *[]*
