### PR TITLE
Rename Tensor to TensorList in Supported Ops doc

### DIFF
--- a/dali/operators/crop/slice.cc
+++ b/dali/operators/crop/slice.cc
@@ -27,13 +27,13 @@ with arguments `axis_names` or `axes`. By default `Slice` operator uses normaliz
 coordinates and `WH` order for the slice arguments.)code")
     .NumInput(3)
     .NumOutput(1)
-    .InputDox(0, "data", "Tensor", "Tensor containing input data")
-    .InputDox(1, "anchor", "1D tensor of floats",
-                 R"code(Tensor containing either normalized or absolute coordinates
+    .InputDox(0, "data", "TensorList", "Batch containing input data")
+    .InputDox(1, "anchor", "1D TensorList of floats",
+                 R"code(Input containing either normalized or absolute coordinates
 (depending on the value of `normalized_anchor`) for the starting point of the
 slice (x0, x1, x2, ...).)code")
-    .InputDox(2, "shape", "1D tensor of floats",
-                 R"code(containing either normalized or absolute coordinates
+    .InputDox(2, "shape", "1D TensorList of floats",
+                 R"code(Input containing either normalized or absolute coordinates
 (depending on the value of `normalized_shape`) for the dimensions of the slice
 (s0, s1, s2, ...).)code")
     .AllowSequences()

--- a/dali/operators/util/reshape.cc
+++ b/dali/operators/util/reshape.cc
@@ -27,7 +27,7 @@ DALI_SCHEMA(Reshape)
   .NumInput(1, 2)
   .NumOutput(1)
   .InputDox(0, "data", "TensorList", "Data to be reshaped")
-  .InputDox(1, "shape", "1D TensorList of integers", "Same as `shape` argument")
+  .InputDox(1, "shape", "1D TensorList of integers", "Same as `shape` keyword argument")
   .AllowSequences()
   .SupportVolumetric()
   .AddOptionalArg<int>("shape", "The desired shape of the output. Number of dimensions "

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -129,9 +129,9 @@ class DLL_PUBLIC OpSchema {
    * ----
    * `input0`: Type of input
    *     This is the first input
-   * `input1`: Tensor of some kind
+   * `input1`: TensorList of some kind
    *     This is second input
-   * `optional_input`: Tensor, optional
+   * `optional_input`: TensorList, optional
    *     This is optional input
    *
    * If the `append_kwargs_section` is true, the docstring generator will append the Keyword args
@@ -152,8 +152,8 @@ class DLL_PUBLIC OpSchema {
   }
 
   /**
-   * @brief Sets a funtion that infers the number of outputs this
-   * op will produce from the ops specfication. This is required
+   * @brief Sets a function that infers the number of outputs this
+   * op will produce from the ops specification. This is required
    * to expose the op to the python interface.
    *
    * If the ops has a fixed number of outputs, this function

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -108,8 +108,10 @@ _cpu_ops = set({})
 _gpu_ops = set({})
 _mixed_ops = set({})
 
-def _numpydoc_formatter(name, type, doc):
+def _numpydoc_formatter(name, type, doc, optional = False):
     indent = "\n" + " " * 4
+    if optional:
+        type += ", optional"
     return "`{}` : {}{}{}".format(name, type, indent, doc.replace("\n", indent))
 
 def _get_kwargs(schema, only_tensor = False):
@@ -119,9 +121,9 @@ def _get_kwargs(schema, only_tensor = False):
     `schema`
         the schema in which to lookup arguments
     `only_tensor`: bool
-        If True list only keyword arguments that can be passed as Tensors (argument inputs)
+        If True list only keyword arguments that can be passed as TensorLists (argument inputs)
         If False list all the arguments. False indicates that we list arguments to the
-        constructor of the operator which does not accept Tensors (argument inputs) - that
+        constructor of the operator which does not accept TensorLists (argument inputs) - that
         fact will be reflected in specified type
     """
     ret = ""
@@ -216,7 +218,8 @@ Args
 ----
 """
     for i in range(schema.MaxNumInput()):
-        ret += _numpydoc_formatter(schema.GetInputName(i), schema.GetInputType(i), schema.GetInputDox(i))
+        optional = i >= schema.MinNumInput()
+        ret += _numpydoc_formatter(schema.GetInputName(i), schema.GetInputType(i), schema.GetInputDox(i), optional)
         ret += "\n"
     ret += "\n"
     return ret
@@ -224,13 +227,13 @@ Args
 def _docstring_prefix_auto(op_name):
     """
         Generate start of the docstring for `__call__` of Operator `op_name`
-        with default values. Assumes ther will be 0 or 1 inputs
+        with default values. Assumes there will be 0 or 1 inputs
     """
     schema = b.GetSchema(op_name)
     if schema.MaxNumInput() == 0:
         return """__call__(**kwargs)
 
-Operator call to be used in `define_graph` step. This operator does not accept any Tensor inputs.
+Operator call to be used in `define_graph` step. This operator does not accept any TensorList inputs.
 """
     elif schema.MaxNumInput() == 1:
         return """__call__(data, **kwargs)
@@ -239,7 +242,7 @@ Operator call to be used in `define_graph` step.
 
 Args
 ----
-`data`: Tensor
+`data`: TensorList
     Input to the operator.
 """
     return ""

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -67,7 +67,7 @@ def _type_name_convert_to_string(dtype, is_tensor):
     if dtype in _known_types:
         ret = _known_types[dtype][0]
         if is_tensor:
-            ret = "Tensor of " + ret
+            ret = "TensorList of " + ret
         elif dtype in _vector_types:
             ret = ret + " or list of " + _known_types[dtype][0]
         return ret

--- a/docs/supported_ops.rst
+++ b/docs/supported_ops.rst
@@ -17,10 +17,10 @@ Documentation of every DALI Operator lists **Keyword Arguments** supported by th
 
 The documentation for `__call__` operator lists the positional arguments (**Parameters**) and additional **Keyword Arguments**.
 `__call__` should be only used in the :meth:`~nvidia.dali.pipeline.Pipeline.define_graph`.
-The inputs to the `__call__` operator represent Tensors (or rather batches of Tensors) processed by DALI,
+The inputs to the `__call__` operator represent batches of Tensors (TensorLists) processed by DALI,
 which are returned by other DALI Operators.
 
-The **Keyword Arguments** listed in `__call__` operator accept Tensor argument inputs. They should be
+The **Keyword Arguments** listed in `__call__` operator accept TensorList argument inputs. They should be
 produced by other 'cpu' Operators.
 
 .. note::
@@ -57,7 +57,7 @@ method on the values returned from invocations of other operators.
 The expressions used will be incorporated into the Pipeline without the need to explicitly instantiate operators
 and will describe element-wise operations on Tensors.
 
-At least one of the inputs must be a Tensor input that is returned by other DALI Operator.
+At least one of the inputs must be a TensorList input that is returned by other DALI Operator.
 The other can be :meth:`nvidia.dali.types.Constant` or regular Python value of type `bool`, `int` or `float`.
 
 As the operations performed are element-wise, the shapes of all operands must match.
@@ -78,9 +78,9 @@ Currently, DALI supports the following operations:
 
     Unary operators implementing `__pos__(self)` and `__neg__(self)`.
     The result of an unary arithmetic operation always keeps the input type.
-    Unary operators accept only Tensor inputs from other operators.
+    Unary operators accept only TensorList inputs from other operators.
 
-    :rtype: Tensor of the same type
+    :rtype: TensorList of the same type
 
 .. function:: Binary arithmetic operations: +, -, *, /, //
 
@@ -115,13 +115,13 @@ Currently, DALI supports the following operations:
     .. note::
         The only allowed arithmetic operation between two `bool` values is multiplication `*`.
 
-    :rtype: Tensor of type calculated based on type promotion rules.
+    :rtype: TensorList of type calculated based on type promotion rules.
 
 .. function:: Comparison operations: ==, !=, <, <=, >, >=
 
     Comparison operations.
 
-    :rtype: Tensor of `bool` type.
+    :rtype: TensorList of `bool` type.
 
 .. function:: Bitwise binary operations: &, |, ^
 
@@ -132,4 +132,4 @@ Currently, DALI supports the following operations:
         A bitwise operation can be applied to two boolean inputs. Those operations can be used
         to emulate element-wise logical operations on Tensors.
 
-    :rtype: Tensor of type calculated based on type promotion rules.
+    :rtype: TensorList of type calculated based on type promotion rules.


### PR DESCRIPTION


Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- it improves docs (again)

#### What happened in this PR?
 - What solution was applied:
      As we handle batches of data, specification of input as `Tensor` was changed to `TensorList`. Improve optional input docstrings by adding `, optional` in type spec as in similar places for keyword arguments. Fix mentions of Tensor in already specified docstrings, adjsut the defaults.
 - Affected modules and functionalities:
     *[ docs, supported_ops ]*
 - Key points relevant for the review:
     *[ If the explanation in the `How to read this doc` of supported_ops is clear enough. If the type specifications looks ok. ]*
 - Validation and testing:
     *[ CI & Read the manual ]*
 - Documentation (including examples):
     *[ This is a doc update ]*


**JIRA TASK**: *[NA]*
