### PR TITLE
Make DataIter a base class for MXNet DALIGenericIterator

### DIFF
--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -51,7 +51,7 @@ def feed_ndarray(dali_tensor, arr):
     # Copy data from DALI tensor to ptr
     dali_tensor.copy_to_external(ptr)
 
-class DALIGenericIterator(object):
+class DALIGenericIterator(mx.io.DataIter):
     """
     General DALI iterator for MXNet. It can return any number of
     outputs from the DALI pipeline in the form of MXNet's DataBatch


### PR DESCRIPTION
- MXNet model function expects NDArray or DataIter so DALIGenericIterator  fails to work in that case

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- It fixes a bug that MXNet DALIGenericIterator is not descendant of DataIter and model function expecting NDArray or DataIter fails to work with DALI

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Make DataIter a base class for MXNet DALIGenericIterator
    Relates to https://github.com/NVIDIA/DALI/issues/1663
 - Affected modules and functionalities:
     plugin/mxnet.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     A test is added
 - Documentation (including examples):
     No


**JIRA TASK**: *[NA]*
