### PR TITLE
Fix multi-channel fill value check in Erase operator

### DIFF
--- a/dali/operators/generic/erase/erase_utils.h
+++ b/dali/operators/generic/erase/erase_utils.h
@@ -83,7 +83,7 @@ std::vector<kernels::EraseArgs<T, Dims>> GetEraseArgs(const OpSpec &spec,
 
   auto fill_value = spec.template GetRepeatedArgument<float>("fill_value");
   auto channels_dim = in_layout.find('C');
-  DALI_ENFORCE(channels_dim >= 0,
+  DALI_ENFORCE(channels_dim >= 0 || fill_value.size() <= 1,
     "If a multi channel fill value is provided, the input layout must have a 'C' dimension");
 
   auto axes = detail::GetAxes(spec, in_layout);


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in erase operator

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Fix multi-channel `fill_value` argument check. `fill_value` can have more than 1 value only if the input layout has a 'C' (channel) dimension*
 - Affected modules and functionalities:
     *Erase operator*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     N/A
 - Documentation (including examples):
     N/A

**JIRA TASK**: *[Use DALI-XXXX or NA]*
