### PR TITLE
Allow extra dimensions with extent 1 in Spectrogram operator & AudioDecoder changes

### DIFF
--- a/dali/operators/decoder/audio/audio_decoder_op.h
+++ b/dali/operators/decoder/audio/audio_decoder_op.h
@@ -64,12 +64,11 @@ class AudioDecoderCpu : public Operator<CPUBackend> {
     return true;
   }
 
+
  private:
-  template <typename OutputType>
-  void DecodeSample(
-    const TensorView<StorageCPU, OutputType, 2> &audio,
-    int thread_idx,
-    int sample_idx);
+  template<typename OutputType>
+  void DecodeSample(const TensorView<StorageCPU, OutputType, DynamicDimensions> &audio,
+                    int thread_idx, int sample_idx);
 
   template <typename OutputType>
   void DecodeBatch(workspace_t<Backend> &ws);

--- a/dali/test/python/test_operator_audio_decoder.py
+++ b/dali/test/python/test_operator_audio_decoder.py
@@ -98,8 +98,8 @@ def test_decoded_vs_generated():
     for i in range(len(out[0])):
       plain = out[0].at(i)
       res = out[1].at(i)
-      mix = out[2].at(i)
-      res_mix = out[3].at(i)
+      mix = out[2].at(i)[:,np.newaxis]
+      res_mix = out[3].at(i)[:,np.newaxis]
 
       ref_len = [0,0,0,0]
       ref_len[0] = lengths[idx]

--- a/dali/test/python/test_operator_spectrogram.py
+++ b/dali/test/python/test_operator_spectrogram.py
@@ -58,10 +58,9 @@ def spectrogram_func_librosa(nfft, win_len, win_step, input_data):
             hann[t] = 0.5 * (1.0 - math.cos(phase))
         return hann
 
-    has_channels_dim = len(input_data.shape) == 2
-
-    if has_channels_dim:
-        input_data = np.squeeze(input_data, axis=0)
+    # Squeeze to 1d
+    if len(input_data.shape) > 1:
+        input_data = np.squeeze(input_data)
 
     out = np.abs(
         librosa.stft(y=input_data, n_fft=nfft, hop_length=win_step, window=hann_win))**2
@@ -69,9 +68,6 @@ def spectrogram_func_librosa(nfft, win_len, win_step, input_data):
     # Alternative way to calculate the spectrogram:
     # out, _ = librosa.core.spectrum._spectrogram(
     #     y=input_data, n_fft=nfft, hop_length=win_step, window=hann_win, power=2)
-
-    if has_channels_dim:
-        out = np.expand_dims(out, axis=0)
 
     return out
 
@@ -113,6 +109,8 @@ def test_operator_spectrogram_vs_python():
         for batch_size in [3]:
             for nfft, window_length, window_step, shape in [(256, 256, 128, (1, 4096)),
                                                             (256, 256, 128, (4096,)),
+                                                            (256, 256, 128, (4096, 1)),
+                                                            (256, 256, 128, (1, 1, 4096, 1)),
                                                             (16, 16, 8, (1, 1000)),
                                                             (10, 10, 5, (1, 1000)),
                                                             ]:


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to handle empty dimensions in Spectrogram operator

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * In Spectrogram operator, check that the input shape is 1-D or only one dimension of the shape has an extent greater than 1. If so, we can squeeze the shape into a 1D tensor
 - Affected modules and functionalities:
     * Spectrogram operator
 - Key points relevant for the review:
     * Changes in Spectrogram
 - Validation and testing:
     * Python tests
 - Documentation (including examples):
     * Updated docstr


**JIRA TASK**: *[Use DALI-XXXX or NA]*
