### PR TITLE
Add deprecation message about CUDA 9

### DIFF
--- a/dali/python/__init__.py.in
+++ b/dali/python/__init__.py.in
@@ -14,6 +14,11 @@
 
 from __future__ import absolute_import
 
+# we need to have that defined and accessible before any other DALI import
+__version__ = '@DALI_VERSION@'
+__cuda_version__ = int('@CUDA_VERSION@'.replace('.', ''))
+__git_sha__ = '@GIT_SHA@'
+
 from . import ops
 from . import pipeline
 from . import tensors
@@ -22,5 +27,3 @@ from . import tfrecord
 from . import types
 from . import plugin_manager
 from . import sysconfig
-
-__version__ = '@DALI_VERSION@'

--- a/dali/python/nvidia/dali/backend.py
+++ b/dali/python/nvidia/dali/backend.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from nvidia.dali.backend_impl import *
+from . import __cuda_version__
 import warnings
 import os
 import sys
@@ -24,6 +25,12 @@ default_plugins = [
     'libpython_function_plugin.so'
 ]
 
+def deprecation_warning(what):
+    # show only this warning
+    with warnings.catch_warnings():
+        warnings.simplefilter("default")
+        warnings.warn(what, Warning, stacklevel=2)
+
 initialized = False
 if not initialized:
     Init(OpSpec("CPUAllocator"), OpSpec("PinnedCPUAllocator"), OpSpec("GPUAllocator"))
@@ -31,12 +38,13 @@ if not initialized:
 
     # py27 deprecation
     if sys.version_info[0] < 3:
-        # show only this warning
-        with warnings.catch_warnings():
-            warnings.simplefilter("default")
-            warnings.warn("DALI 0.17 is the last official release for Python 2.7, which "
-                          "reaches the end of life on January 1st, 2020. To stay up to date with "
-                          "DALI, please upgrade to Python 3.5 or later.", Warning, stacklevel=2)
+        deprecation_warning("DALI 0.17 is the last official release for Python 2.7, which "
+                            "reaches the end of life on January 1st, 2020. To stay up to date with "
+                            "DALI, please upgrade to Python 3.5 or later.")
+    if __cuda_version__ < 100:
+        deprecation_warning("Support for CUDA versions older than 10.0 will soon be dropped "
+                            "and DALI build won't be provided. Please update your environment "
+                            "to CUDA version 10 or newer.")
 
     for lib in default_plugins:
         LoadLibrary(os.path.join(os.path.dirname(__file__), lib))


### PR DESCRIPTION
- makes CUDA 9 builds of DALI deprecated and advises the user to move to CUDA 10 or later
- defines __cuda_version__ and __git_sha__ python DALI variables

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed because of want to slowly deprecate CUDA 9

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     makes CUDA 9 builds of DALI deprecated and advises the user to move to CUDA 10 or later
 - Affected modules and functionalities:
     backend.py, __init__.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     Visual testing
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
