### PR TITLE
Fix Reshape docstring typo

### DIFF
--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -33,7 +33,7 @@ DALI_SCHEMA(Reshape)
   .AddOptionalArg<int>("shape", "The desired shape of the output. Number of dimensions "
                   "must not exceed the number of dimensions of the input. There can be one "
                   "negative extent which receives the size required to match the input volume, "
-                  "e.g. input of shape `[480, 640, 3]` and `rel_shape = [240, -1]` would get the "
+                  "e.g. input of shape `[480, 640, 3]` and `shape = [240, -1]` would get the "
                   "shape [240, 3840].\n"
                   "NOTE: `rel_shape` and `shape` are mutually exclusive.",
                   std::vector<int>(), true)


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug typo in the Reshape operator docstring

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     NA
 - Affected modules and functionalities:
     Reshape operator
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     Reshape docs are updated


**JIRA TASK**: *[NA]*
