### PR TITLE
Update supported TF versions

### DIFF
--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -29,8 +29,8 @@ packages = {
                         "90" : ["1.5.0"],
                         "100" : ["1.5.0"]},
             "tensorflow-gpu" : {
-                "90": ["1.12.0", "1.11", "1.7"],
-                "100": ["1.13.1", "1.14.0", "1.15.0", "2.0.0"]},
+                "90": ["1.12.0",],
+                "100": ["1.14.0", "1.15.2", "2.0.1", "2.1.0"]},
             "torch" : {"90": ["http://download.pytorch.org/whl/{cuda_v}/torch-1.1.0-{0}.whl"],
                        "100": ["http://download.pytorch.org/whl/{cuda_v}/torch-1.2.0-{0}.whl"]},
             "torchvision" : {"90": ["https://download.pytorch.org/whl/{cuda_v}/torchvision-0.3.0-{0}.whl"],


### PR DESCRIPTION
- uses only one 1.12.0 version of TF for CUDA 9
- removes 1.13.1 for CUDA 10 and adds 2.1.0

#### Why we need this PR?
- It updates supported by DALI TensorFlow versions 

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     uses only one 1.12.0 version of TF for CUDA 9
     removes 1.13.1 for CUDA 10 and adds 2.1.0
 - Affected modules and functionalities:
     qa/setup_packages.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
