### PR TITLE
Remove not supported python versions from manylinux build

### DIFF
--- a/docker/0001-An-approximate-manylinux3_x86_64.patch
+++ b/docker/0001-An-approximate-manylinux3_x86_64.patch
@@ -181,7 +181,7 @@ index 4cc15b9..c64f4b4 100644
  
  PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
 -CPYTHON_VERSIONS="2.7.15 3.4.8 3.5.5 3.6.5 3.7.0rc1"
-+CPYTHON_VERSIONS="2.7.15 3.4.8 3.5.5 3.6.5 3.7.0"
++CPYTHON_VERSIONS="3.5.5 3.6.5 3.7.0"
  
  # openssl version to build, with expected sha256 hash of .tar.gz
  # archive.


### PR DESCRIPTION
- the recent version of pip doesn't support python 3.4 which is still installed in DALI manylinux and it breaks a build
- removes python 2.7 and 3.4 from manylinux  builds

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a local build of manylinux

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     - the recent version of pip doesn't support python 3.4 which is still installed in DALI manylinux and it breaks a build
- removes python 2.7 and 3.4 from manylinux  builds
 - Affected modules and functionalities:
     local build of manylinux
 - Key points relevant for the review:
     NA
 - Validation and testing:
     local build
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
