### PR TITLE
Constant operator and Python wrapper.

### DIFF
--- a/dali/operators/generic/constant.cc
+++ b/dali/operators/generic/constant.cc
@@ -41,17 +41,25 @@ to 32-bit.
 )code")
   .NumInput(0)
   .NumOutput(1)
-  .AddOptionalArg<int>("shape", "The desired shape of the output. "
-                                 "If not set, the data is assumed to be 1D",
+  .AddOptionalArg("shape",
+                  "The desired shape of the output. If not set, the data is assumed to be 1D",
                   std::vector<int>())
-  .AddOptionalArg<float>("fdata", "Contents of the constant produced (for floating point types).",
-                                 std::vector<float>())
-  .AddOptionalArg<int>("idata", "Contents of the constant produced (for integer types).",
-                                 std::vector<int>())
-  .AddOptionalArg("dtype", "Type of the output data. If not set, the output is float if `fdata` "
-                           "argument is used and int if `idata` is used.", DALI_NO_TYPE)
-  .AddOptionalArg("layout", "Layout info. If set and not empty, the layout must match the "
-                            "dimensionality of the output.", "");
+  .AddOptionalArg("fdata",
+                  "Contents of the constant produced (for floating point types). "
+                  "`fdata` and `idata` are mutually exclusive and one of them is required",
+                  std::vector<float>())
+  .AddOptionalArg("idata",
+                  "Contents of the constant produced (for integer types). "
+                  "`fdata` and `idata` are mutually exclusive and one of them is required",
+                  std::vector<int>())
+  .AddOptionalArg("dtype",
+                  "Type of the output data. If not set, the output is float if `fdata` "
+                  "argument is used and int if `idata` is used.",
+                  DALI_NO_TYPE)
+  .AddOptionalArg("layout",
+                  "Layout info. If set and not empty, the layout must match the "
+                  "dimensionality of the output.",
+                  TensorLayout());
 
 namespace {
 template <typename Dst, typename Src>
@@ -90,7 +98,7 @@ void Constant<CPUBackend>::RunImpl(HostWorkspace &ws) {
           assert(!idata_.empty());
           FillTensorVector<type>(output_, output_shape_, idata_);
         }
-      ), (DALI_FAIL("Unsupported type")));  // NOLINT
+      ), (DALI_FAIL(make_string("Unsupported type: ", to_string(output_type_)))));  // NOLINT
   }
   auto &out = ws.OutputRef<CPUBackend>(0);
 

--- a/dali/operators/generic/constant.cc
+++ b/dali/operators/generic/constant.cc
@@ -1,0 +1,107 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/generic/constant.h"
+
+#include <vector>
+#include "dali/core/convert.h"
+#include "dali/core/static_switch.h"
+#include "dali/pipeline/data/views.h"
+
+namespace dali {
+
+DALI_SCHEMA(Constant)
+  .DocStr(R"code(Produces a batch of constant tensors.
+
+The floating point input data should be placed in `fdata` argument and integer data in `idata`.
+The data is a flat vector of values or a single scalar. The data is then reshaped according
+to the `shape` argument. If the data is scalar, it will be broadcast to fill the entire shape.
+
+The operator only performs meaningful work at first invocation - subsequent calls will return
+a reference to the same memory.
+
+The operator can be automatically instantiated in Python with a call to
+`dali.types.Constant(value, dtype, shape, layout)`. The value can be a scalar, a tuple, a list or
+a numpy array, in which case the `shape` and `dtype` (if not explicitly overridden), will be
+taken from that array.
+
+64-bit integer and double precision arrays are not supported and will be silently downgraded
+to 32-bit.
+)code")
+  .NumInput(0)
+  .NumOutput(1)
+  .AddOptionalArg<int>("shape", "The desired shape of the output. "
+                                 "If not set, the data is assumed to be 1D",
+                  std::vector<int>())
+  .AddOptionalArg<float>("fdata", "Contents of the constant produced (for floating point types).",
+                                 std::vector<float>())
+  .AddOptionalArg<int>("idata", "Contents of the constant produced (for integer types).",
+                                 std::vector<int>())
+  .AddOptionalArg("dtype", "Type of the output data. If not set, the output is float if `fdata` "
+                           "argument is used and int if `idata` is used.", DALI_NO_TYPE)
+  .AddOptionalArg("layout", "Layout info. If set and not empty, the layout must match the "
+                            "dimensionality of the output.", "");
+
+namespace {
+template <typename Dst, typename Src>
+void FillTensorVector(
+  TensorVector<CPUBackend> &dst, const TensorListShape<> &shape, const std::vector<Src> &src) {
+  dst.SetContiguous(false);
+  dst.Resize(shape);
+  assert(is_uniform(shape));
+  int64_t n = shape[0].num_elements();
+  assert(src.size() == static_cast<size_t>(n) || src.size() == 1);
+  Dst *out = dst[0].mutable_data<Dst>();
+  if (src.size() == 1) {
+    Dst val = ConvertSat<Dst>(src[0]);
+    for (int64_t i = 0; i < n; i++) {
+      out[i] = val;
+    }
+  } else {
+    for (int64_t i = 0; i < n; i++) {
+      out[i] = ConvertSat<Dst>(src[i]);
+    }
+  }
+  for (int i = 1; i < shape.num_samples(); i++) {
+    dst[i].ShareData(&dst[0]);
+  }
+}
+}  // namespace
+
+template <>
+void Constant<CPUBackend>::RunImpl(HostWorkspace &ws) {
+  if (output_.ntensor() == 0) {
+    TYPE_SWITCH(output_type_, type2id, type, CONSTANT_OP_SUPPORTED_TYPES,
+      (
+        if (!fdata_.empty()) {
+          FillTensorVector<type>(output_, output_shape_, fdata_);
+        } else {
+          assert(!idata_.empty());
+          FillTensorVector<type>(output_, output_shape_, idata_);
+        }
+      ), (DALI_FAIL("Unsupported type")));  // NOLINT
+  }
+  auto &out = ws.OutputRef<CPUBackend>(0);
+
+  out.ShareData(&output_);
+  int N = output_shape_.num_samples();
+  for (int i = 0; i < N; i++) {
+    assert(out[i].raw_data() == output_[i].raw_data());
+  }
+  out.SetLayout(layout_);
+}
+
+DALI_REGISTER_OPERATOR(Constant, Constant<CPUBackend>, CPU);
+
+}  // namespace dali

--- a/dali/operators/generic/constant.cu
+++ b/dali/operators/generic/constant.cu
@@ -1,0 +1,86 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/generic/constant.h"
+
+#include <cuda_runtime.h>
+#include <vector>
+#include "dali/core/convert.h"
+#include "dali/core/static_switch.h"
+#include "dali/pipeline/data/views.h"
+
+namespace dali {
+
+namespace {
+
+template <typename T>
+__global__ void Fill(T *data, size_t count, T value) {
+  auto i = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (i < count)
+    data[i] = value;
+}
+
+template <typename Dst, typename Src>
+void FillTensorList(
+      TensorList<GPUBackend> &dst, const TensorListShape<> &shape, const std::vector<Src> &src,
+      cudaStream_t stream) {
+  dst.Resize(shape);
+  if (src.size() == 1) {
+    int64_t size = shape.num_elements();
+    int64_t threads = 1024;
+    int64_t blocks = div_ceil(size, threads);
+    Dst *data = dst.mutable_data<Dst>();
+    Fill<<<dim3(blocks), dim3(threads), 0, stream>>>(data, size, ConvertSat<Dst>(src[0]));
+  } else {
+    SmallVector<Dst, 64> tmp;
+    tmp.resize(src.size());
+    for (size_t i = 0; i < tmp.size(); i++)
+      tmp[i] = ConvertSat<Dst>(src[i]);
+
+    int n = tmp.size() * sizeof(Dst);
+    for (int i = 0; i < shape.num_samples(); i++)
+      cudaMemcpyAsync(dst.mutable_tensor<Dst>(i), tmp.data(), n, cudaMemcpyHostToDevice, stream);
+  }
+}
+
+}  // namespace
+
+template <>
+void Constant<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
+  if (output_.ntensor() == 0) {
+    TYPE_SWITCH(output_type_, type2id, type, CONSTANT_OP_SUPPORTED_TYPES,
+      (
+        if (!fdata_.empty()) {
+          FillTensorList<type>(output_, output_shape_, fdata_, ws.stream());
+        } else {
+          assert(!idata_.empty());
+          FillTensorList<type>(output_, output_shape_, idata_, ws.stream());
+        }
+      ), (DALI_FAIL("Unsupported type")));  // NOLINT
+  }
+  auto &out = ws.OutputRef<GPUBackend>(0);
+
+  out.Reset();
+  out.ShareData(&output_);
+  out.Resize(output_shape_);
+  int N = output_shape_.num_samples();
+  for (int i = 0; i < N; i++) {
+    assert(out.raw_tensor(i) == output_.raw_tensor(i));
+  }
+  out.SetLayout(layout_);
+}
+
+DALI_REGISTER_OPERATOR(Constant, Constant<GPUBackend>, GPU);
+
+}  // namespace dali

--- a/dali/operators/generic/constant.h
+++ b/dali/operators/generic/constant.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_GENERIC_CONSTANT_H_
+#define DALI_OPERATORS_GENERIC_CONSTANT_H_
+
+#include <vector>
+
+#include "dali/pipeline/operator/operator.h"
+#include "dali/core/tensor_view.h"
+#include "dali/core/static_switch.h"
+
+#define CONSTANT_OP_SUPPORTED_TYPES \
+  (bool, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float)
+
+namespace dali {
+
+template <typename Backend>
+class Constant : public Operator<Backend> {
+ public:
+  using Base = Operator<Backend>;
+  using Workspace = workspace_t<Backend>;
+
+  explicit Constant(const OpSpec &spec) : Operator<Backend>(spec) {
+    spec.TryGetRepeatedArgument<int>(shape_arg_, "shape");
+    output_type_ = spec.GetArgument<DALIDataType>("dtype");
+    if (spec.HasArgument("fdata")) {
+      DALI_ENFORCE(!spec.HasArgument("idata"), "Constant node: `fdata` and `idata` arguments are "
+        "mutually exclusive");
+      fdata_ = spec.GetRepeatedArgument<float>("fdata");
+      if (shape_arg_.empty()) {
+        shape_arg_.push_back(fdata_.size());
+      } else {
+        DALI_ENFORCE(fdata_.size() == static_cast<size_t>(volume(shape_arg_)) || fdata_.size() == 1,
+          "The number of values does not match the shape specified");
+      }
+
+      if (!spec.HasArgument("dtype"))
+        output_type_ = DALI_FLOAT;
+    } else {
+      DALI_ENFORCE(spec.HasArgument("idata"),
+          "Constant node: either `fdata` or `idata` must be present.");
+
+      if (!spec.HasArgument("dtype"))
+        output_type_ = DALI_INT32;
+
+      idata_ = spec.GetRepeatedArgument<int>("idata");
+      if (shape_arg_.empty()) {
+        shape_arg_.push_back(idata_.size());
+      } else {
+        DALI_ENFORCE(idata_.size() == static_cast<size_t>(volume(shape_arg_)) || idata_.size() == 1,
+          "The number of values does not match the shape specified");
+      }
+    }
+    layout_ = spec.GetArgument<TensorLayout>("layout");
+    if (!layout_.empty()) {
+      DALI_ENFORCE(layout_.size() == static_cast<int>(shape_arg_.size()), make_string(
+        "Constant node: The requested layout \"", layout_, "\" has dimensionalilty which is "
+        "incompatible with the requested output shape."));
+    }
+  }
+
+  bool CanInferOutputs() const override {
+    // Return false, because we specifically don't want the executor to allocate
+    // the storage for the output - even though we can infer the shape.
+    return false;
+  }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
+    output_desc.resize(1);
+    if (output_shape_.empty()) {
+      int batch_size = this->spec_.template GetArgument<int>("batch_size");
+      output_shape_ = uniform_list_shape(batch_size, shape_arg_);
+    }
+    output_desc[0] = { output_shape_, TypeTable::GetTypeInfo(output_type_) };
+    return false;
+  }
+
+  void RunImpl(Workspace &ws) override;
+
+ private:
+  std::vector<int> shape_arg_;
+  std::vector<int> idata_;
+  std::vector<float> fdata_;
+  TensorListShape<> output_shape_;
+  TensorLayout layout_;
+  DALIDataType output_type_;
+  using storage_t = std::conditional_t<std::is_same<Backend, CPUBackend>::value,
+    TensorVector<CPUBackend>, TensorList<GPUBackend>>;
+
+  storage_t output_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_GENERIC_CONSTANT_H_

--- a/dali/operators/generic/constant.h
+++ b/dali/operators/generic/constant.h
@@ -22,7 +22,7 @@
 #include "dali/core/static_switch.h"
 
 #define CONSTANT_OP_SUPPORTED_TYPES \
-  (bool, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float)
+  (bool, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, float, float16)
 
 namespace dali {
 

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -270,7 +270,7 @@ class TensorVector {
       tl_->Reset();
       tl_->ResizeLike(*tv->tl_);
     }
-    int N = tl_->ntensor();
+    int N = tv->ntensor();
     tensors_.clear();
     views_count_ = 0;
     allocate_tensors(N);

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -21,7 +21,7 @@ import threading
 from nvidia.dali import backend as b
 from nvidia.dali.types import _type_name_convert_to_string, _type_convert_value, \
         _vector_element_type, _bool_types, _int_types, _int_like_types, _float_types, \
-        DALIDataType, CUDAStream, ScalarConstant as _Constant
+        DALIDataType, CUDAStream, ScalarConstant as _ScalarConstant
 from nvidia.dali.pipeline import Pipeline
 from future.utils import with_metaclass
 import nvidia.dali.libpython_function_plugin
@@ -320,7 +320,7 @@ class _OperatorInstance(object):
                 arg_inp = kwargs[k]
                 if arg_inp is None:
                     continue
-                if type(arg_inp) is _Constant:
+                if isinstance(type(arg_inp), _ScalarConstant):
                     arg_inp = instantiate_constant_node(arg_inp)
                 if not isinstance(arg_inp, _EdgeReference):
                     raise TypeError(
@@ -871,7 +871,7 @@ def _choose_device(inputs):
 def _is_boolean_like(input):
     if type(input) == bool:
         return True
-    if isinstance(input, _Constant):
+    if isinstance(input, _ScalarConstant):
         if input.dtype in _bool_types:
             return True
     return False
@@ -882,7 +882,7 @@ def _is_integer_like(input):
         return True
     if type(input) == int:
         return True
-    if isinstance(input, _Constant):
+    if isinstance(input, _ScalarConstant):
         if input.dtype in _int_like_types:
             return True
     return False
@@ -890,7 +890,7 @@ def _is_integer_like(input):
 def _is_real_like(input):
     if type(input) == float:
         return True
-    if isinstance(input, _Constant):
+    if isinstance(input, _ScalarConstant):
         if input.dtype in _float_types:
             return True
     return False
@@ -903,7 +903,7 @@ def _to_type_desc(input):
         return "int32"
     if type(input) == float:
         return "float32" # TODO(klecki): current DALI limitation
-    if isinstance(input, _Constant):
+    if isinstance(input, _ScalarConstant):
         dtype_to_desc = {
             DALIDataType.BOOL:    "bool",
             DALIDataType.INT8:    "int8",

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -325,17 +325,34 @@ def ConstantNode(device, value, dtype, shape, layout, **kwargs):
         data = value.flatten().tolist()
     else:
         def _type_from_value_or_list(v):
-            if isinstance(v, (list, tuple)):
-                for x in v:
-                    if isinstance(x, float):
-                        return DALIDataType.FLOAT
-                return DALIDataType.INT32
+            if not isinstance(v, (list, tuple)):
+                v = [v]
 
-            if isinstance(v, float):
+            has_floats = False
+            has_ints = False
+            has_bools = False
+            for x in v:
+                if isinstance(x, float):
+                    has_floats = True
+                elif isinstance(x, bool):
+                    has_bools = True
+                elif isinstance(x, int):
+                    has_ints = True
+                else:
+                    raise TypeError("Unexpected type: " + str(type(x)))
+
+            if has_floats:
                 return DALIDataType.FLOAT
-            return DALIDataType.INT32
+            if has_ints:
+                return DALIDataType.INT32
+            if has_bools:
+                return DALIDataType.BOOL
+            # empty list defaults to float
+            return DALIDataType.FLOAT
 
         actual_type = _type_from_value_or_list(value)
+        if dtype is None:
+            dtype = actual_type
 
     import nvidia.dali.ops as ops
 

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -113,12 +113,13 @@ _float_types = [DALIDataType.FLOAT16, DALIDataType.FLOAT, DALIDataType.FLOAT64]
 _int_like_types = _bool_types + _int_types
 _all_types = _bool_types + _int_types + _float_types
 
-class Constant(object):
+
+class ScalarConstant(object):
     """Wrapper for a constant value that can be used in DALI arithmetic expressions
     and applied element-wise to the results of DALI Operators representing Tensors in
     :meth:`nvidia.dali.pipeline.Pipeline.define_graph` step.
 
-    Constant indicates what type should the value be treated as with respect
+    ScalarConstant indicates what type should the value be treated as with respect
     to type promotions. The actual values passed to the backend from python
     would be `int32` for integer values and `float32` for floating point values.
     Python builtin types `bool`, `int` and `float` will be marked to indicate
@@ -134,8 +135,10 @@ class Constant(object):
     """
     def __init__(self, value, dtype=None):
         if not isinstance(value, (bool, int, float)):
-            raise TypeError("Expected scalar value of type 'bool', int' or 'float', got {}."
-                    .format(str(type(value))))
+            raise TypeError(
+                "Expected scalar value of type 'bool', 'int' or 'float', got {}."
+                .format(str(type(value))))
+
         if dtype:
             self.dtype = dtype
             if self.dtype in _bool_types:
@@ -145,7 +148,7 @@ class Constant(object):
             elif self.dtype in _float_types:
                 self.value = float(value)
             else:
-                raise TypeError("DALI Constant can only hold one of: {} types."
+                raise TypeError("DALI ScalarConstant can only hold one of: {} types."
                         .format(_all_types))
         elif isinstance(value, bool):
             self.value = value
@@ -157,50 +160,52 @@ class Constant(object):
             self.value = value
             self.dtype = DALIDataType.FLOAT
 
+
+
     def bool(self):
-        return Constant(self.value, DALIDataType.BOOL)
+        return ScalarConstant(self.value, DALIDataType.BOOL)
 
     def int8(self):
-        return Constant(self.value, DALIDataType.INT8)
+        return ScalarConstant(self.value, DALIDataType.INT8)
 
     def int16(self):
-        return Constant(self.value, DALIDataType.INT16)
+        return ScalarConstant(self.value, DALIDataType.INT16)
 
     def int32(self):
-        return Constant(self.value, DALIDataType.INT32)
+        return ScalarConstant(self.value, DALIDataType.INT32)
 
     def int64(self):
-        return Constant(self.value, DALIDataType.INT64)
+        return ScalarConstant(self.value, DALIDataType.INT64)
 
     def uint8(self):
-        return Constant(self.value, DALIDataType.UINT8)
+        return ScalarConstant(self.value, DALIDataType.UINT8)
 
     def uint16(self):
-        return Constant(self.value, DALIDataType.UINT16)
+        return ScalarConstant(self.value, DALIDataType.UINT16)
 
     def uint32(self):
-        return Constant(self.value, DALIDataType.UINT32)
+        return ScalarConstant(self.value, DALIDataType.UINT32)
 
     def uint64(self):
-        return Constant(self.value, DALIDataType.UINT64)
+        return ScalarConstant(self.value, DALIDataType.UINT64)
 
     def float16(self):
-        return Constant(self.value, DALIDataType.FLOAT16)
+        return ScalarConstant(self.value, DALIDataType.FLOAT16)
 
     def float32(self):
-        return Constant(self.value, DALIDataType.FLOAT)
+        return ScalarConstant(self.value, DALIDataType.FLOAT)
 
     def float64(self):
-        return Constant(self.value, DALIDataType.FLOAT64)
+        return ScalarConstant(self.value, DALIDataType.FLOAT64)
 
     def __eq__(self, other):
-        if isinstance(other, Constant):
+        if isinstance(other, ScalarConstant):
             return self.value == other.value and self.dtype == other.dtype
         # Delegate the call to the `__eq__` of other object, most probably an `_EdgeReference`
         return other.__eq__(self)
 
     def __ne__(self, other):
-        if isinstance(other, Constant):
+        if isinstance(other, ScalarConstant):
             return self.value != other.value or self.dtype != other.dtype
         # Delegate the call to the `__ne__` of other object, most probably an `_EdgeReference`
         return other.__ne__(self)
@@ -208,19 +213,19 @@ class Constant(object):
     def __bool__(self):
         if self.dtype in _int_like_types:
             return bool(self.value)
-        raise TypeError(("DALI Constant must be converted to one of bool or int types: ({}) "
+        raise TypeError(("DALI ScalarConstant must be converted to one of bool or int types: ({}) "
                 "explicitly before casting to builtin `bool`.").format(_int_like_types))
 
     def __int__(self):
         if self.dtype in _int_like_types:
             return int(self.value)
-        raise TypeError(("DALI Constant must be converted to one of bool or int types: ({}) "
+        raise TypeError(("DALI ScalarConstant must be converted to one of bool or int types: ({}) "
                 "explicitly before casting to builtin `int`.").format(_int_like_types))
 
     def __float__(self):
         if self.dtype in _float_types:
             return self.value
-        raise TypeError(("DALI Constant must be converted to one of the float types: ({}) "
+        raise TypeError(("DALI ScalarConstant must be converted to one of the float types: ({}) "
                 "explicitly before casting to builtin `float`.").format(_float_types))
 
     def __str__(self):
@@ -228,3 +233,105 @@ class Constant(object):
 
     def __repr__(self):
         return "{}".format(self.value)
+
+def _is_scalar_shape(shape):
+    return shape is None or shape == 1 or shape == [1]
+
+def _is_numpy_array(value):
+    if 'numpy.ndarray' in str(type(value)):
+        return True
+
+def ConstantNode(device, value, dtype, shape, layout):
+    data = value
+    if _is_numpy_array(value):
+        import numpy as np
+
+        # 64-bit types are not supported - downgrade the input
+        if value.dtype == np.float64:
+            value = value.astype(np.float32)
+        if value.dtype == np.int64:
+            value = value.astype(np.int32)
+        if value.dtype == np.uint64:
+            value = value.astype(np.uint32)
+
+        def _numpy_to_dali_type(t):
+            if t is None:
+                return None
+            import numpy as np
+            if t == np.bool:
+                return DALIDataType.BOOL
+
+            if t == np.float16:
+                return DALIDataType.FLOAT16
+            if t == np.float32:
+                return DALIDataType.FLOAT
+            if t == np.float64:
+                return DALIDataType.FLOAT64
+
+            if t == np.uint8:
+                return DALIDataType.UINT8
+            if t == np.int8:
+                return DALIDataType.INT8
+            if t == np.uint16:
+                return DALIDataType.UINT16
+            if t == np.int16:
+                return DALIDataType.INT16
+            if t == np.uint32:
+                return DALIDataType.UINT32
+            if t == np.int32:
+                return DALIDataType.INT32
+            if t == np.uint64:
+                return DALIDataType.UINT64
+            if t == np.int64:
+                return DALIDataType.INT64
+            raise TypeError("Unsupported type: " + str(t))
+
+        actual_type = _numpy_to_dali_type(value.dtype)
+        if dtype is None:
+            dtype = actual_type
+        if shape is not None:
+            value = np.copy(value.reshape(shape), order='C')
+        else:
+            value = np.copy(value, order='C')
+            shape = value.shape
+        data = value.flatten().tolist()
+    else:
+        def _type_from_value_or_list(v):
+            if isinstance(v, (list, tuple)):
+                for x in v:
+                    if isinstance(x, float):
+                        return DALIDataType.FLOAT
+                return DALIDataType.INT32
+
+            if isinstance(v, float):
+                return DALIDataType.FLOAT
+            return DALIDataType.INT32
+
+        actual_type = _type_from_value_or_list(value)
+
+    import nvidia.dali.ops as ops
+
+    def _convert(x, type):
+        if isinstance(x, (list, tuple)):
+            return [type(y) for y in x]
+        return type(x)
+
+    isint = actual_type in _int_like_types
+    idata = _convert(data, int) if isint else None
+    fdata = None if isint else data
+    if device is None:
+        device = "cpu"
+
+    op = ops.Constant(device = device, fdata = fdata, idata = idata,
+                      shape = shape, dtype = dtype, layout = layout)
+    return op()
+
+def Constant(value, dtype = None, shape = None, layout = None, device = None):
+    if device is not None or \
+        _is_numpy_array(value) or \
+        isinstance(value, (list, tuple)) or \
+        not _is_scalar_shape(shape) or \
+        layout is not None:
+        return ConstantNode(device, value, dtype, shape, layout)
+    else:
+        return ScalarConstant(value, dtype)

--- a/dali/test/python/test_operator_constant.py
+++ b/dali/test/python/test_operator_constant.py
@@ -47,9 +47,7 @@ class ConstantFnPipeline(Pipeline):
         ]
 
 def check(a1, a2):
-    print(a1.dtype, a2.dtype)
     assert(a1.dtype == a2.dtype)
-    print(a1, a2)
     assert(np.array_equal(a1, a2))
 
 

--- a/dali/test/python/test_operator_constant.py
+++ b/dali/test/python/test_operator_constant.py
@@ -44,10 +44,12 @@ class ConstantPipeline(Pipeline):
         self.const4 = ops.Constant(device = device, fdata = (0.25,1.25,2.25,3.25,4.25), dtype=types.FLOAT16)
         self.const5 = ops.Constant(device = device, fdata = 5.5, shape=(100,100))
         self.const6 = ops.Constant(device = device, idata = -4, shape=(10,20))
+        self.const7 = ops.Constant(device = device, idata = [0, 1, 0], dtype=types.BOOL)
 
 
     def define_graph(self):
-        return (self.const1(), self.const2(), self.const3(), self.const4(), self.const5(), self.const6())
+        return (self.const1(), self.const2(), self.const3(), self.const4(),
+                self.const5(), self.const6(), self.const7())
 
 class ConstantFnPipeline(Pipeline):
     def __init__(self, device, array_interface):
@@ -66,7 +68,8 @@ class ConstantFnPipeline(Pipeline):
             types.Constant(device = device, value = self.array([0,1,2,3,4], dtype=self.dtype('uint8'))),
             types.Constant(device = device, value = self.array([0.25,1.25,2.25,3.25,4.25], dtype=self.dtype('float16'))),
             types.Constant(device = device, value = 5.5, shape=(100,100), name="large"),
-            types.Constant(device = device, value = -4, shape=(10,20))
+            types.Constant(device = device, value = -4, shape=(10,20)),
+            types.Constant(device = device, value = [False, True, False])
         ]
 
 
@@ -100,7 +103,8 @@ ref = [
     np.array([0,1,2,3,4], dtype=np.uint8),
     np.array([0.25,1.25,2.25,3.25,4.25], dtype=np.float16),
     np.full([100, 100], 5.5, dtype=np.float32),
-    np.full([10, 20], -4, dtype=np.int32)
+    np.full([10, 20], -4, dtype=np.int32),
+    np.array([False, True, False], dtype=np.bool)
 ]
 
 

--- a/dali/test/python/test_operator_constant.py
+++ b/dali/test/python/test_operator_constant.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops as ops
+import nvidia.dali.types as types
+import numpy as np
+import os
+
+class ConstantPipeline(Pipeline):
+    def __init__(self, device):
+        super(ConstantPipeline, self).__init__(10, 3, device_id = 0, exec_async=True, exec_pipelined=True)
+        self.const1 = ops.Constant(device = device, fdata = (1.25,2.5,3))
+        self.const2 = ops.Constant(device = device, idata = (1,2,3,4), shape=(2,1,2))
+        self.const3 = ops.Constant(device = device, idata = (-1,1,2,3,4), dtype=types.UINT8)
+        self.const4 = ops.Constant(device = device, fdata = 5.5, shape=(100,100))
+        self.const5 = ops.Constant(device = device, idata = -4, shape=(10,20))
+
+
+    def define_graph(self):
+        return (self.const1(), self.const2(), self.const3(), self.const4(), self.const5())
+
+class ConstantFnPipeline(Pipeline):
+    def __init__(self, device):
+        super(ConstantFnPipeline, self).__init__(10, 3, device_id = 0, exec_async=True, exec_pipelined=True)
+        self.device = device
+
+    def define_graph(self):
+        device = self.device
+        return [
+            types.Constant(device = device, value = (1.25,2.5,3)),
+            types.Constant(device = device, value = np.array([[[1,2]],[[3,4]]], dtype=np.int32)),
+            types.Constant(device = device, value = np.array([0,1,2,3,4], dtype=np.uint8)),
+            types.Constant(device = device, value = 5.5, shape=(100,100)),
+            types.Constant(device = device, value = -4, shape=(10,20))
+        ]
+
+def check(a1, a2):
+    print(a1.dtype, a2.dtype)
+    assert(a1.dtype == a2.dtype)
+    print(a1, a2)
+    assert(np.array_equal(a1, a2))
+
+
+ref = [
+    np.array([1.25, 2.5, 3], dtype=np.float32),
+    np.array([[[1,2]],[[3,4]]], dtype=np.int32),
+    np.array([0,1,2,3,4], dtype=np.uint8),
+    np.full([100, 100], 5.5, dtype=np.float32),
+    np.full([10, 20], -4, dtype=np.int32)
+]
+
+def _test_op(device):
+    pipe = ConstantPipeline(device)
+    pipe.build()
+    for iter in range(3):
+        out = pipe.run()
+        if device == "gpu":
+            out = [o.as_cpu() for o in out]
+
+        for o in range(len(ref)):
+            for i in range(len(out[o])):
+                check(out[o].at(i), ref[o])
+
+def _test_func(device):
+    pipe = ConstantFnPipeline(device)
+    pipe.build()
+    for iter in range(3):
+        out = pipe.run()
+        if device == "gpu":
+            out = [o.as_cpu() for o in out]
+
+        for o in range(len(ref)):
+            for i in range(len(out[o])):
+                check(out[o].at(i), ref[o])
+
+def test_constant_op():
+    yield _test_op, "cpu"
+    yield _test_op, "gpu"
+
+def test_constant_fn():
+    yield _test_func, "cpu"
+    yield _test_func, "gpu"
+
+def main():
+    _test_op("cpu")
+    _test_op("gpu")
+    _test_func("cpu")
+    _test_func("gpu")
+
+if __name__ == '__main__':
+  main()

--- a/dali/test/python/test_operator_constant.py
+++ b/dali/test/python/test_operator_constant.py
@@ -65,7 +65,7 @@ class ConstantFnPipeline(Pipeline):
             types.Constant(device = device, value = self.array([[[1,2]],[[3,4]]], dtype=self.dtype('int32'))),
             types.Constant(device = device, value = self.array([0,1,2,3,4], dtype=self.dtype('uint8'))),
             types.Constant(device = device, value = self.array([0.25,1.25,2.25,3.25,4.25], dtype=self.dtype('float16'))),
-            types.Constant(device = device, value = 5.5, shape=(100,100)),
+            types.Constant(device = device, value = 5.5, shape=(100,100), name="large"),
             types.Constant(device = device, value = -4, shape=(10,20))
         ]
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,9 +41,9 @@ Types
 
 Constant
 ^^^^^^^^
-.. autoclass:: nvidia.dali.types.Constant
+.. autofunction:: nvidia.dali.types.Constant
+.. autoclass:: nvidia.dali.types.ScalarConstant
    :members:
-
 
 Enums
 -----


### PR DESCRIPTION
Add constant operator and unify it in Python with types.Constant.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature to make operators like Slice and writing tests easier and more productive.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added an operator which returns same data all the time, without copying
     * Renamed `dali.types.Constant` to `dali.types.ScalarConstant` and added a new `dali.types.Constant` function which can produce the new Constant node.
 - Affected modules and functionalities:
     * Python wrapper (ops, types)
 - Key points relevant for the review:
     * The python wrapper mostly
 - Validation and testing:
     * Python tests *
 - Documentation (including examples):
     * Not yet *

**JIRA TASK**: N/A
