### PR TITLE
Remove gif as supported extension

### DIFF
--- a/dali/operators/reader/loader/utils.h
+++ b/dali/operators/reader/loader/utils.h
@@ -25,7 +25,7 @@ namespace dali {
  * When adding new vector here,
  * make sure to add it also in `bool HasKnownExtension(const std::string &filepath);`
  */
-static const std::vector<std::string> kKnownImageExtensions = {".jpg", ".jpeg", ".png", ".gif",
+static const std::vector<std::string> kKnownImageExtensions = {".jpg", ".jpeg", ".png",
                                                                ".bmp", ".tif", ".tiff",
                                                                ".pnm", ".ppm", ".pgm", ".pbm"};
 


### PR DESCRIPTION
Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

`gif` supported extension was added while ago by mistake. This PR removes it.

* Currently OpenCV up to 4.2 version doesn't support gif format. ([opencv doc](https://docs.opencv.org/4.2.0/d4/da8/group__imgcodecs.html#ga288b8b3da0892bd651fce07b3bbd3a56)). To support it we'd need to implement our own decoding and `PeekDims` function.
* As there were no tests for gif format, it wasn't noticed before (no `*.gif` files in both DALI_extra and old-school local test data)
* I'm removing gif format from supported ones
* I don't anticipate any problems to end users, since it's impossible for gif images to be working up to this point (`GenericDecoder::DecodeImpl` would throw fatal error)
