### PR TITLE
Add synchronization to read/write operations in image decoder cache

### DIFF
--- a/dali/operators/decoder/cache/cached_decoder_impl.cc
+++ b/dali/operators/decoder/cache/cached_decoder_impl.cc
@@ -67,8 +67,11 @@ bool CachedDecoderImpl::DeferCacheLoad(const std::string& file_name, uint8_t *ou
 }
 
 void CachedDecoderImpl::LoadDeferred(cudaStream_t stream) {
-  if (scatter_gather_)
-    CUDA_CALL((scatter_gather_->Run(stream, true, !use_batch_copy_kernel_), cudaGetLastError()));
+  if (!scatter_gather_)
+    return;
+
+  cache_->SyncToRead(stream);
+  CUDA_CALL((scatter_gather_->Run(stream, true, !use_batch_copy_kernel_), cudaGetLastError()));
 }
 
 ImageCache::ImageShape CachedDecoderImpl::CacheImageShape(const std::string& file_name) {

--- a/dali/operators/decoder/cache/image_cache.h
+++ b/dali/operators/decoder/cache/image_cache.h
@@ -80,7 +80,8 @@ class DLL_PUBLIC ImageCache {
   /**
    * @brief Synchronizes internal cache CUDA stream with a provided stream before a cache reading
    *        operation
-   * @remarks To be called before launching a memory copy from a pointer provided by Get
+   * @remarks To be called before launching a memory copy from a pointer provided by Get.
+   *          Read/Add calls are already synchronized and don't require using this API
    */
   DLL_PUBLIC virtual void SyncToRead(cudaStream_t stream) const = 0;
 };

--- a/dali/operators/decoder/cache/image_cache.h
+++ b/dali/operators/decoder/cache/image_cache.h
@@ -76,6 +76,13 @@ class DLL_PUBLIC ImageCache {
    *          images from the cache.
    */
   DLL_PUBLIC virtual DecodedImage Get(const ImageKey &image_key) const = 0;
+
+  /**
+   * @brief Synchronizes internal cache CUDA stream with a provided stream before a cache reading
+   *        operation
+   * @remarks To be called before launching a memory copy from a pointer provided by Get
+   */
+  DLL_PUBLIC virtual void SyncToRead(cudaStream_t stream) const = 0;
 };
 
 }  // namespace dali

--- a/dali/operators/decoder/cache/image_cache_blob.cc
+++ b/dali/operators/decoder/cache/image_cache_blob.cc
@@ -40,7 +40,6 @@ ImageCacheBlob::ImageCacheBlob(std::size_t cache_size,
   CUDA_CALL(cudaStreamCreateWithPriority(&cache_stream_, cudaStreamNonBlocking, 0));
   CUDA_CALL(cudaEventCreate(&cache_read_event_));
   CUDA_CALL(cudaEventCreate(&cache_write_event_));
-
 }
 
 ImageCacheBlob::~ImageCacheBlob() {

--- a/dali/operators/decoder/cache/image_cache_blob.cc
+++ b/dali/operators/decoder/cache/image_cache_blob.cc
@@ -36,10 +36,20 @@ ImageCacheBlob::ImageCacheBlob(std::size_t cache_size,
   tail_ = buffer_.get();
   buffer_end_ = buffer_.get() + cache_size_;
   LOG_LINE << "cache size is " << cache_size_ / (1024 * 1024) << " MB" << std::endl;
+
+  CUDA_CALL(cudaStreamCreateWithPriority(&cache_stream_, cudaStreamNonBlocking, 0));
+  CUDA_CALL(cudaEventCreate(&cache_read_event_));
+  CUDA_CALL(cudaEventCreate(&cache_write_event_));
+
 }
 
 ImageCacheBlob::~ImageCacheBlob() {
   try {
+    CUDA_CALL(cudaStreamSynchronize(cache_stream_));
+    CUDA_CALL(cudaEventDestroy(cache_read_event_));
+    CUDA_CALL(cudaEventDestroy(cache_write_event_));
+    CUDA_CALL(cudaStreamDestroy(cache_stream_));
+
     if (stats_enabled_ && images_seen() > 0) print_stats();
   } catch (...) {
     std::terminate();
@@ -72,7 +82,10 @@ bool ImageCacheBlob::Read(const ImageKey& image_key,
   DALI_ENFORCE(data.data < tail_);
   const auto n = data.num_elements();
   DALI_ENFORCE(data.data + n <= tail_);
+
+  SyncToRead(stream);
   MemCopy(destination_buffer, data.data, n, stream);
+
   if (stats_enabled_) stats_[image_key].reads++;
   return true;
 }
@@ -106,11 +119,26 @@ void ImageCacheBlob::Add(const ImageKey& image_key, const uint8_t* data,
     if (stats_enabled_) is_full = true;
     return;
   }
+
   MemCopy(tail_, data, data_size, stream);
+  SyncAfterWrite(stream);
+
   cache_[image_key] = {tail_, data_shape};
   tail_ += data_size;
 
   if (stats_enabled_) stats_[image_key].is_cached = true;
+}
+
+void ImageCacheBlob::SyncToRead(cudaStream_t stream) const {
+  // synchronizing with cache instance stream with provided stream
+  CUDA_CALL(cudaEventRecord(cache_read_event_, cache_stream_));
+  CUDA_CALL(cudaStreamWaitEvent(stream, cache_read_event_, 0));
+}
+
+void ImageCacheBlob::SyncAfterWrite(cudaStream_t stream) const {
+  // synchronizing with cache instance stream with provided stream
+  CUDA_CALL(cudaEventRecord(cache_write_event_, stream));
+  CUDA_CALL(cudaStreamWaitEvent(cache_stream_, cache_write_event_, 0));
 }
 
 void ImageCacheBlob::print_stats() const {

--- a/dali/operators/decoder/cache/image_cache_blob.h
+++ b/dali/operators/decoder/cache/image_cache_blob.h
@@ -50,7 +50,11 @@ class DLL_PUBLIC ImageCacheBlob : public ImageCache {
 
     DecodedImage Get(const ImageKey &image_key) const override;
 
+    void SyncToRead(cudaStream_t stream) const override;  // part of the API
+
  protected:
+    void SyncAfterWrite(cudaStream_t stream) const;       // internal impl only
+
     void print_stats() const;
 
     inline std::size_t images_seen() const {
@@ -81,6 +85,10 @@ class DLL_PUBLIC ImageCacheBlob : public ImageCache {
     mutable std::unordered_map<ImageKey, Stats> stats_;
     bool is_full = false;
     std::size_t total_seen_images_ = 0;
+
+    cudaStream_t cache_stream_;
+    cudaEvent_t cache_read_event_;
+    cudaEvent_t cache_write_event_;
 };
 
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in ImageDecoder

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Introduced an internal cache stream that it is used to synchronize read/write access
 - Affected modules and functionalities:
ImageDecoder with cached enabled
 - Key points relevant for the review:
Usage of CUDA streams/events
 - Validation and testing:
Existing tests
 - Documentation (including examples):
NA

**JIRA TASK**: *[Use DALI-XXXX or NA]*
