### PR TITLE
Add a note how to set DALI_EXTRA_PATH to run jupyter examples

### DIFF
--- a/docs/examples/frameworks/mxnet/mxnet-various-readers.ipynb
+++ b/docs/examples/frameworks/mxnet/mxnet-various-readers.ipynb
@@ -24,7 +24,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let us start from defining some global constants"
+    "Let us start from defining some global constants\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -299,14 +301,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/paddle/paddle-basic_example.ipynb
+++ b/docs/examples/frameworks/paddle/paddle-basic_example.ipynb
@@ -18,7 +18,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let us start from defining some global constants"
+    "Let us start from defining some global constants\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {

--- a/docs/examples/frameworks/paddle/paddle-various-readers.ipynb
+++ b/docs/examples/frameworks/paddle/paddle-various-readers.ipynb
@@ -24,7 +24,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let us start from defining some global constants"
+    "Let us start from defining some global constants\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -297,14 +299,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/pytorch/pytorch-basic_example.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-basic_example.ipynb
@@ -18,7 +18,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let us start from defining some global constants"
+    "Let us start from defining some global constants\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -140,14 +142,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/pytorch/pytorch-various-readers.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-various-readers.ipynb
@@ -24,7 +24,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let us start from defining some global constants"
+    "Let us start from defining some global constants\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -297,14 +299,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/tensorflow/tensorflow-dataset-multigpu.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-dataset-multigpu.ipynb
@@ -10,7 +10,9 @@
     "\n",
     "This notebook is a comprehensive example on how to use DALI `tf.data.Dataset` with multiple GPUs. It is recommended to look into [single GPU example](tensorflow-dataset.ipynb) first to get up to speed with DALI dataset and how it can be used to train a neural network with custom model and training loop. This example is an extension of the single GPU version.\n",
     "\n",
-    "Initially we define some parameters of the training and to create a DALI pipeline to read [MNIST](http://yann.lecun.com/exdb/mnist/) converted to LMDB format. You can find it in [DALI_extra](https://github.com/NVIDIA/DALI_extra) dataset. This pipeline is able to shard dataset into multiple parts."
+    "Initially we define some parameters of the training and to create a DALI pipeline to read [MNIST](http://yann.lecun.com/exdb/mnist/) converted to LMDB format. You can find it in [DALI_extra](https://github.com/NVIDIA/DALI_extra) dataset. This pipeline is able to partition the dataset into multiple shards.\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -274,7 +276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/tensorflow/tensorflow-dataset.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-dataset.ipynb
@@ -10,7 +10,9 @@
     "\n",
     "DALI offers integration with [tf.data API](https://www.tensorflow.org/guide/data). Using this approach you can easily connect DALI pipeline with various TensorFlow APIs and use it as a data source for your model. This tutorial shows how to do it using well known [MNIST](http://yann.lecun.com/exdb/mnist/) converted to LMDB format. You can find it in [DALI_extra](https://github.com/NVIDIA/DALI_extra) - DALI test data repository.\n",
     "\n",
-    "We start with creating a DALI pipeline to read, decode and normalize MNIST images and read corresponding labels."
+    "We start with creating a DALI pipeline to read, decode and normalize MNIST images and read corresponding labels.\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -505,7 +507,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/tensorflow/tensorflow-plugin-sparse-tensor.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-plugin-sparse-tensor.ipynb
@@ -21,7 +21,9 @@
     "### Defining the data loading pipeline\n",
     "\n",
     "First, we start by defining some simple pipeline that will return data as a sparse tensor. To ochieve this, we will use well known COCO data set. Each image may have 0 or more bounding boxes with labels describing objects present in it.Wa want to return images in a normalized way, while labels and bounding boxes will be represented as sparse tensors.\n",
-    "At the begginig let us define some global parameters"
+    "At the beginning let us define some global parameters\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -123,8 +125,7 @@
    "source": [
     "import tensorflow as tf\n",
     "import nvidia.dali.plugin.tf as dali_tf\n",
-    "import time",
-    "\n",
+    "import time\n",
     "try:\n",
     "    from tensorflow.compat.v1 import GPUOptions\n",
     "    from tensorflow.compat.v1 import ConfigProto\n",
@@ -453,7 +454,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "version": "2.7.17"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/tensorflow/tensorflow-plugin-tutorial.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-plugin-tutorial.ipynb
@@ -25,7 +25,9 @@
     "\n",
     "First we start by defining some parameters for DALI and Tensorflow.\n",
     "\n",
-    "We will use a subsample of Imagenet stored in a MXNet's RecordIO for this tutorial. For details on how to use `MXNetReader` as well as other readers please see other [examples](../../index.rst)."
+    "In this tutorial, we will use a subsample of Imagenet stored in an MXNet's RecordIO. For details on how to use `MXNetReader`, as well as other readers, please see other [examples](../../index.rst).\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -155,8 +157,7 @@
    "source": [
     "import tensorflow as tf\n",
     "import nvidia.dali.plugin.tf as dali_tf\n",
-    "import time",
-    "\n",
+    "import time\n",
     "try:\n",
     "    from tensorflow.compat.v1 import GPUOptions\n",
     "    from tensorflow.compat.v1 import ConfigProto\n",
@@ -450,7 +451,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "version": "2.7.17"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/tensorflow/tensorflow-various-readers.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-various-readers.ipynb
@@ -24,7 +24,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let us start with defining some global constants"
+    "Let us start with defining some global constants\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -346,14 +348,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/examples/general/data_loading/coco_reader.ipynb
+++ b/docs/examples/general/data_loading/coco_reader.ipynb
@@ -6,7 +6,9 @@
    "source": [
     "# COCO Reader\n",
     "\n",
-    "Reader operator that reads a COCO dataset (or subset of COCO), which consists of an annotation file and the images directory."
+    "Reader operator that reads a COCO dataset (or subset of COCO), which consists of an annotation file and the images directory.\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -185,7 +187,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "version": "2.7.17"
   }
  },
  "nbformat": 4,

--- a/docs/examples/general/data_loading/dataloading_lmdb.ipynb
+++ b/docs/examples/general/data_loading/dataloading_lmdb.ipynb
@@ -14,7 +14,9 @@
     "\n",
     "In order to use data stored in LMDB in Caffe format, we need to use `CaffeReader` operator. Besides arguments common to all readers (like `random_shuffle`), it takes `path` argument - path to the directory where LMDB is stored.\n",
     "\n",
-    "Let us define a simple pipeline that takes images stored in Caffe format, decodes them and prepares them for ingestion in DL framework (crop, normalize and NHWC -> NCHW conversion)."
+    "Let us define a simple pipeline that takes images stored in Caffe format, decodes them and prepares them for ingestion in DL framework (crop, normalize and HWC -> CHW conversion).\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -305,7 +307,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "version": "2.7.17"
   }
  },
  "nbformat": 4,

--- a/docs/examples/general/data_loading/dataloading_recordio.ipynb
+++ b/docs/examples/general/data_loading/dataloading_recordio.ipynb
@@ -15,7 +15,9 @@
     "In order to use data stored in the recordIO format, we need to use `MXNetReader` operator. Besides arguments common to all readers (like `random_shuffle`), it takes `path` and `index_path` arguments.\n",
     "\n",
     "* `path` is a list of paths to recordIO files\n",
-    "* `index_path` is a list (of size 1) containing path to index file. Index file (with `.idx` extension) is automatically created when using MXNet's `im2rec.py` utility, and can also be obtained from recordIO file using `rec2idx` utility included with DALI."
+    "* `index_path` is a list (of size 1) containing path to index file. Index file (with `.idx` extension) is automatically created when using MXNet's `im2rec.py` utility, and can also be obtained from recordIO file using `rec2idx` utility included with DALI.\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -194,7 +196,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "version": "2.7.17"
   }
  },
  "nbformat": 4,

--- a/docs/examples/general/data_loading/dataloading_tfrecord.ipynb
+++ b/docs/examples/general/data_loading/dataloading_tfrecord.ipynb
@@ -16,7 +16,9 @@
     "\n",
     "* `path` is a list of paths to TFRecord files\n",
     "* `index_path` is a list containing paths to index files. Index files are used by DALI mainly to properly shard the dataset between multiple workers. The index for a given TFRecord file can be obtained from that file using `tfrecord2idx` utility included with DALI. Creating the index file is required only once per TFRecord file.\n",
-    "* `features` is a dictionary of pairs (name, feature), where feature (of type `dali.tfrecord.Feature`) describes the contents of the TFRecord. DALI features follow closely the TensorFlow types `tf.FixedLenFeature` and `tf.VarLenFeature`."
+    "* `features` is a dictionary of pairs (name, feature), where feature (of type `dali.tfrecord.Feature`) describes the contents of the TFRecord. DALI features follow closely the TensorFlow types `tf.FixedLenFeature` and `tf.VarLenFeature`.\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -213,7 +215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "version": "2.7.17"
   }
  },
  "nbformat": 4,

--- a/docs/examples/image_processing/augmentation_gallery.ipynb
+++ b/docs/examples/image_processing/augmentation_gallery.ipynb
@@ -6,7 +6,9 @@
    "source": [
     "# Augmentation Gallery\n",
     "\n",
-    "This example showcases different augmentations possible with DALI."
+    "This example showcases different augmentations possible with DALI.\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {

--- a/docs/examples/image_processing/warp.ipynb
+++ b/docs/examples/image_processing/warp.ipynb
@@ -46,7 +46,9 @@
     "\n",
     "## Usage example\n",
     "\n",
-    "First, let's import the necessary modules and define the location of the dataset."
+    "First, let's import the necessary modules and define the location of the dataset.\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {

--- a/docs/examples/sequence_processing/optical_flow_example.ipynb
+++ b/docs/examples/sequence_processing/optical_flow_example.ipynb
@@ -37,7 +37,9 @@
    "metadata": {},
    "source": [
     "Setting metaparameters.  \n",
-    "As an example we use [Sintel trailer](https://durian.blender.org/), included in [DALI_extra](https://github.com/NVIDIA/DALI_extra) repository. Feel free to verify against your own video data."
+    "As an example we use [Sintel trailer](https://durian.blender.org/), included in [DALI_extra](https://github.com/NVIDIA/DALI_extra) repository. Feel free to verify against your own video data.\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {
@@ -298,7 +300,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/examples/sequence_processing/video/video_file_list_outputs.ipynb
+++ b/docs/examples/sequence_processing/video/video_file_list_outputs.ipynb
@@ -83,7 +83,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The video we have used in this example is a 10 seconds long, 25fps, 512x512 resolution video with timestamp burned into the frame itself in the top half of the video and frame number in the bottom half. The burned text in the decoded frame can be easily used to verify that we are indeed returned the correct frame number and timestamp labels."
+    "The video we have used in this example is a 10 seconds long, 25fps, 512x512 resolution video with timestamp burned into the frame itself in the top half of the video and frame number in the bottom half. The burned text in the decoded frame can be easily used to verify that we are indeed returned the correct frame number and timestamp labels.\n",
+    "\n",
+    "`DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out."
    ]
   },
   {

--- a/docs/examples/sequence_processing/video/video_reader_label_example.ipynb
+++ b/docs/examples/sequence_processing/video/video_reader_label_example.ipynb
@@ -49,7 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need some video containers to process. We can use [Sintel](https://en.wikipedia.org/wiki/Sintel) trailer, which is a mp4 video container containing a h264 and under the Create Common license. We've split it into 5 second clips and divided the clips into labelled groups. This can be done easily with the `ffmpeg` standalone tool. Our prepared data can be found in [DALI_extra](https://github.com/NVIDIA/DALI_extra) repository. Snippet below verifies, that you have defined `DALI_extra` path as environment variable."
+    "We need some video containers to process. We can use [Sintel](https://en.wikipedia.org/wiki/Sintel) trailer, which is an mp4 container containing an h.264 video and distributed under the Create Common license. We've split it into 5 second clips and divided the clips into labelled groups. This can be done easily with the `ffmpeg` standalone tool. `DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out. The snippet below verifies, that you have defined `DALI_extra` path as an environment variable."
    ]
   },
   {
@@ -323,7 +323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/examples/sequence_processing/video/video_reader_simple_example.ipynb
+++ b/docs/examples/sequence_processing/video/video_reader_simple_example.ipynb
@@ -49,7 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need some video containers to process. We can use [Sintel](https://en.wikipedia.org/wiki/Sintel) trailer, which is a mp4 video container containing a h264 and under the Create Common license. Let's split it into 10s clips in order to check how `VideoReader` handles mutliple video files. This can be done easily with the `ffmpeg` standalone tool. Our prepared data can be found in [DALI_extra](https://github.com/NVIDIA/DALI_extra) repository. Snippet below verifies, that you have defined `DALI_extra` path as environment variable."
+    "We need some video containers to process. We can use [Sintel](https://en.wikipedia.org/wiki/Sintel) trailer, which is an mp4 container containing an h264 video and distributed under the Create Common license. Let's split it into 10s clips in order to check how `VideoReader` handles mutliple video files. This can be done easily with the `ffmpeg` standalone tool. `DALI_EXTRA_PATH` environment variable should point to the place where data from [DALI extra repository](https://github.com/NVIDIA/DALI_extra) is downloaded. Please make sure that the proper release tag is checked out. The snippet below verifies, that you have defined `DALI_extra` path as an environment variable."
    ]
   },
   {
@@ -295,7 +295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a note how to set DALI_EXTRA_PATH to run jupyter examples

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Adds an extra note how to set DALI_EXTRA_PATH in all examples using it
 - Affected modules and functionalities:
     docs examples
 - Key points relevant for the review:
     docs examples
 - Validation and testing:
     NA
 - Documentation (including examples):
     all examples using DALI_EXTRA_PATH


**JIRA TASK**: *[DALI-1262]*
