### PR TITLE
Making "Supported backend" title in docs appear correctly

### DIFF
--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -194,10 +194,9 @@ def _docstring_generator(cls):
         op_dev.append("'mixed'")
     ret += """
 Supported backends
-------------------
 """
     for dev in op_dev:
-        ret += "* " + dev + "\n"
+        ret += " * " + dev + "\n"
     ret += "\n"
 
     ret += """


### PR DESCRIPTION
Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

**Before:**
![image](https://user-images.githubusercontent.com/7101064/73531221-42df7280-441a-11ea-9af4-b532ad2e3a65.png)



**After:** 
![image](https://user-images.githubusercontent.com/7101064/73531246-4c68da80-441a-11ea-8568-28902d652c6c.png)



**This allows for more nice customizations in the docs, e.g. previously when I'd like to add some paragraphs to single operator documentation I'd get:**
![image](https://user-images.githubusercontent.com/7101064/73531314-76220180-441a-11ea-839b-7344b91b1300.png)


**Which isn't really consistent. Now everything will be better :)**
![image](https://user-images.githubusercontent.com/7101064/73531348-8afe9500-441a-11ea-85f5-34cb29ab4ad9.png)**




