### PR TITLE
Add pass-through info to OpSchema to add shared data to stage outputs.

### DIFF
--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -28,6 +28,7 @@ DALI_SCHEMA(Reshape)
   .NumOutput(1)
   .InputDox(0, "data", "TensorList", "Data to be reshaped")
   .InputDox(1, "shape", "1D TensorList of integers", "Same as `shape` keyword argument")
+  .PassThrough({{0, 0}})
   .AllowSequences()
   .SupportVolumetric()
   .AddOptionalArg<int>("shape", "The desired shape of the output. Number of dimensions "

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -625,7 +625,7 @@ std::vector<int> Executor<WorkspacePolicy, QueuePolicy>::GetTensorQueueSizes(con
   std::vector<int> result;
   // By default we need one vector
   result.resize(graph.NumTensor(), 1);
-  auto output_ids = graph.GetOutputs(output_names_);
+  auto output_ids = graph.GetOutputs(output_names_, true);
   for (auto id : output_ids) {
     auto &tensor = graph.Tensor(id);
     auto parent_type =  graph.Node(tensor.producer.node).op_type;

--- a/dali/pipeline/graph/graph_descr.cc
+++ b/dali/pipeline/graph/graph_descr.cc
@@ -558,7 +558,7 @@ bool OpGraph::HasConsumersInOtherStage(const TensorNode &tensor, OpType this_sta
     }
     const OpSchema &schema = cons_op.spec.GetSchema();
     int out_idx = schema.GetPassThroughOutputIdx(cons_edge.index);
-    while (out_idx >= 0) {
+    if (out_idx >= 0) {
       if (HasConsumersInOtherStage(Tensor(cons_op.children_tensors[out_idx]), this_stage))
         return true;
     }

--- a/dali/pipeline/graph/graph_descr.cc
+++ b/dali/pipeline/graph/graph_descr.cc
@@ -165,7 +165,6 @@ void OpGraph::AddOp(const OpSpec &spec, const std::string &op_name) {
     TensorMeta meta;
     meta.node = new_node.id;
     meta.index = i;
-    meta.is_support = spec.IsArgumentInput(i);
     meta.storage_device = ParseStorageDevice(spec.InputDevice(i));
 
     // Insert new tensor consumer
@@ -179,7 +178,6 @@ void OpGraph::AddOp(const OpSpec &spec, const std::string &op_name) {
     TensorMeta meta;
     meta.node = new_node.id;
     meta.index = i;
-    meta.is_support = false;
     meta.storage_device = ParseStorageDevice(spec.OutputDevice(i));
 
     string name = spec.Output(i);
@@ -514,12 +512,58 @@ void OpGraph::GenerateDOTFromGraph(const TensorNode &current_node, std::ofstream
   }
 }
 
-std::vector<TensorNodeId> OpGraph::GetOutputs(const std::vector<string>& output_names) const {
+std::vector<TensorNodeId> OpGraph::GetOutputs(const std::vector<string>& output_names,
+                                              bool follow_pass_through) const {
   std::vector<TensorNodeId> result;
-  for (const auto& out : output_names) {
-    result.push_back(TensorId(out));
+  if (!follow_pass_through) {
+    for (const auto& out : output_names) {
+      result.push_back(TensorId(out));
+    }
+  } else {
+    std::vector<bool> visited(tensor_nodes_.size());
+    std::vector<TensorNodeId> q;
+    for (const auto& out : output_names) {
+      q.push_back(TensorId(out));
+    }
+    while (!q.empty()) {
+      TensorNodeId tid = q.back();
+      q.pop_back();
+      if (visited[tid])
+        continue;
+      visited[tid] = true;
+      result.push_back(tid);
+      auto output = Tensor(tid).producer;
+      auto &schema = Node(output.node).spec.GetSchema();
+      if (schema.HasPassThrough()) {
+        for (TensorNodeId parent_tid : Node(output.node).parent_tensors) {
+          for (TensorMeta input : Tensor(parent_tid).consumers) {
+            if (input.node == output.node &&
+                schema.GetPassThroughOutputIdx(input.index) == output.index) {
+                q.push_back(parent_tid);
+            }
+          }
+        }
+      }
+    }
   }
   return result;
+}
+
+bool OpGraph::HasConsumersInOtherStage(const TensorNode &tensor, OpType this_stage) const {
+  for (auto cons_edge : tensor.consumers) {
+    // We found a consumer from different stage, this tensor is a stage output
+    const OpNode &cons_op = Node(cons_edge.node);
+    if (cons_op.op_type != this_stage) {
+      return true;
+    }
+    const OpSchema &schema = cons_op.spec.GetSchema();
+    int out_idx = schema.GetPassThroughOutputIdx(cons_edge.index);
+    while (out_idx >= 0) {
+      if (HasConsumersInOtherStage(Tensor(cons_op.children_tensors[out_idx]), this_stage))
+        return true;
+    }
+  }
+  return false;
 }
 
 std::vector<TensorNodeId> OpGraph::GetStageOutputs(OpType stage) const {
@@ -527,13 +571,8 @@ std::vector<TensorNodeId> OpGraph::GetStageOutputs(OpType stage) const {
   for (const auto& tensor : tensor_nodes_) {
     // Check if the tensor is produced in current stage
     if (Node(tensor.producer.node).op_type == stage) {
-      for (auto cons_edge : tensor.consumers) {
-        // We found a consumer from different stage, this tensor is a stage output
-        if (Node(cons_edge.node).op_type != stage) {
-          result.push_back(tensor.id);
-          break;
-        }
-      }
+      if (HasConsumersInOtherStage(tensor, stage))
+        result.push_back(tensor.id);
     }
   }
   return result;

--- a/dali/pipeline/graph/op_graph.h
+++ b/dali/pipeline/graph/op_graph.h
@@ -88,7 +88,6 @@ struct TensorMeta {
   OpNodeId node;
   Index index;
   StorageDevice storage_device;
-  bool is_support;
 };
 
 using producer_edge_t = TensorMeta;
@@ -321,7 +320,8 @@ class DLL_PUBLIC OpGraph {
     ofs << "}\n";
   }
 
-  DLL_PUBLIC std::vector<TensorNodeId> GetOutputs(const std::vector<string>& output_names) const;
+  DLL_PUBLIC std::vector<TensorNodeId> GetOutputs(const std::vector<string>& output_names,
+                                                  bool follow_pass_through = false) const;
   DLL_PUBLIC std::vector<TensorNodeId> GetStageOutputs(OpType stage) const;
 
   DISABLE_COPY_MOVE_ASSIGN(OpGraph);
@@ -330,6 +330,9 @@ class DLL_PUBLIC OpGraph {
   // Should be called only once for each tensor
   void GenerateDOTFromGraph(const TensorNode& current_node, std::ofstream& ofs, bool show_tensors,
                             bool show_ids);
+
+  bool HasConsumersInOtherStage(const TensorNode &tensor, OpType this_stage) const;
+
 
   /**
    * @brief Recalculate OpNodes partitioning

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -459,6 +459,18 @@ class DLL_PUBLIC OpSchema {
   /**
    * @brief Informs that the data passes though this operator unchanged, only
    *        the metadata is affected.
+   *
+   * If the operator _can_ pass an input buffer as-is to the output (possibly
+   * changing the associated metadata), this property of should be set accordingly
+   * in the operator's OpSchema. The purpose of this property is to inform the
+   * pipeline and the executor that a particular output of the operator doesn't
+   * own the storage and the associated input should be included in double-buffering
+   * whenever the output should.
+   *
+   * @param inout - tells which inputs are passed through to which outputs.
+   *                Multiple inputs can be passed through to one output (at
+   *                least potentially, e.g. when conditionally forwarding
+   *                one of inputs to the output), but not vice versa.
    */
   DLL_PUBLIC inline OpSchema &PassThrough(const std::map<int, int> &inout) {
     passthrough_map_ = inout;

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -456,6 +456,15 @@ class DLL_PUBLIC OpSchema {
     return *this;
   }
 
+  /**
+   * @brief Informs that the data passes though this operator unchanged, only
+   *        the metadata is affected.
+   */
+  DLL_PUBLIC inline OpSchema &PassThrough(const std::map<int, int> &inout) {
+    passthrough_map_ = inout;
+    return *this;
+  }
+
   DLL_PUBLIC inline const vector<std::string>& GetParents() const {
     return parents_;
   }
@@ -595,6 +604,21 @@ class DLL_PUBLIC OpSchema {
     return no_prune_;
   }
 
+  /**
+   * @brief Returns the index of the output to which the input is passed.
+   * @return Output index or -1 if given input is not passed through.
+   */
+  DLL_PUBLIC inline int GetPassThroughOutputIdx(int input_idx) const {
+    auto it = passthrough_map_.find(input_idx);
+    if (it == passthrough_map_.end())
+      return -1;
+    return it->second;
+  }
+
+  DLL_PUBLIC inline bool HasPassThrough() const {
+    return !passthrough_map_.empty();
+  }
+
   DLL_PUBLIC int CalculateOutputs(const OpSpec &spec) const;
 
   DLL_PUBLIC int CalculateAdditionalOutputs(const OpSpec &spec) const {
@@ -689,6 +713,8 @@ class DLL_PUBLIC OpSchema {
   bool is_internal_ = false;
 
   bool no_prune_ = false;
+
+  std::map<int, int> passthrough_map_;
 
   bool is_deprecated_ = false;
   string deprecated_in_favor_of_;

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -117,7 +117,6 @@ class DLL_PUBLIC Pipeline {
     meta.has_cpu = true;
     meta.has_gpu = false;
     meta.has_contiguous = false;
-    meta.is_support = false;
     DALI_ENFORCE(edge_names_.insert({name, meta}).second,
         "ExternalInput name insertion failure.");
 
@@ -381,7 +380,7 @@ class DLL_PUBLIC Pipeline {
             QueueSizes prefetch_queue_depth = QueueSizes{2});
 
   using EdgeMeta = struct {
-    bool has_cpu, has_gpu, has_contiguous, is_support;
+    bool has_cpu, has_gpu, has_contiguous;
   };
 
   // Return the nearest multiple of 8 that is >= base_ptr_offset
@@ -401,7 +400,6 @@ class DLL_PUBLIC Pipeline {
     edge.has_cpu = false;
     edge.has_gpu = false;
     edge.has_contiguous = false;
-    edge.is_support = false;
     if (device == "cpu") {
       edge.has_cpu = true;
     } else if (device == "gpu") {

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -53,7 +53,7 @@ class ReshapePipeline(Pipeline):
           images = images.gpu()
         reshaped = self.reshape(images)
 
-        return [images, reshaped]
+        return [images+0, reshaped]
 
 def CollapseChannels(image):
   new_shape = np.array([ image.shape[0], image.shape[1] * image.shape[2] ]).astype(np.int)

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -53,6 +53,8 @@ class ReshapePipeline(Pipeline):
           images = images.gpu()
         reshaped = self.reshape(images)
 
+        # `images+0` creates a (no-op) arithmetic expression node - this prevents the
+        # original `images` node from being marked as pipeline output
         return [images+0, reshaped]
 
 def CollapseChannels(image):


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added pass-through info to OpSchema (mapping from inputs to outputs)
     * Track pass-through tensors in graph
 - Affected modules and functionalities:
     * OpGraph, Executor
 - Key points relevant for the review:
     * Allocation of multiple buffers
 - Validation and testing:
     * ReshapeTest sort-of should do
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
