### PR TITLE
Add support in CropMirrorNormalize for uneven sizes of mean and std

### DIFF
--- a/dali/operators/image/crop/crop_mirror_normalize.h
+++ b/dali/operators/image/crop/crop_mirror_normalize.h
@@ -113,6 +113,11 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
     DALI_ENFORCE(!mean_vec_.empty() && !inv_std_vec_.empty(),
       "mean and standard deviation can't be empty");
 
+    DALI_ENFORCE(
+      mean_vec_.size() == inv_std_vec_.size() || mean_vec_.size() == 1 || inv_std_vec_.size() == 1,
+      "`mean` and `stddev` must either be of the same size, be scalars, or one of them can be a "
+      "vector and the other a scalar.");
+
     // Inverse the std-deviation
     for (auto &element : inv_std_vec_) {
       element = 1.f / element;
@@ -120,15 +125,12 @@ class CropMirrorNormalize : public Operator<Backend>, protected CropAttr {
 
     // Handle irregular mean/std argument lengths
     auto args_size = std::max(mean_vec_.size(), inv_std_vec_.size());
-    if (args_size > 0 && mean_vec_.size() != inv_std_vec_.size()) {
+    if (mean_vec_.size() != inv_std_vec_.size()) {
       if (mean_vec_.size() == 1)
         mean_vec_.resize(args_size, mean_vec_[0]);
 
       if (inv_std_vec_.size() == 1)
         inv_std_vec_.resize(args_size, inv_std_vec_[0]);
-
-      DALI_ENFORCE(mean_vec_.size() == args_size && inv_std_vec_.size() == args_size,
-        "mean and stddev should have same size or be a scalar");
     }
 
     if (std::is_same<Backend, GPUBackend>::value) {

--- a/dali/test/python/test_operator_crop_mirror_normalize.py
+++ b/dali/test/python/test_operator_crop_mirror_normalize.py
@@ -197,9 +197,16 @@ def crop_mirror_normalize_func(crop_z, crop_y, crop_x,
         out = image[:, start_z:end_z, start_y:end_y, start_x:end_x, :]
         D, H, W = out.shape[1], out.shape[2], out.shape[3]
 
+    if not mean:
+        mean = [0.0]
+    if not std:
+        std = [1.0]
+
     if len(mean) == 1:
         mean = C * mean
+    if len(std) == 1:
         std = C * std
+
     assert len(mean) == C and len(std) == C
     inv_std = [np.float32(1.0) / np.float32(std[c]) for c in range(C)]
     mean = np.float32(mean)
@@ -369,7 +376,11 @@ def check_cmn_random_data_vs_numpy(device, batch_size, output_dtype, input_layou
 
 def test_cmn_random_data_vs_numpy():
     norm_data = [ ([0., 0., 0.], [1., 1., 1.]),
-                  ([0.485 * 255, 0.456 * 255, 0.406 * 255], [0.229 * 255, 0.224 * 255, 0.225 * 255]) ]
+                  ([0.485 * 255, 0.456 * 255, 0.406 * 255], [0.229 * 255, 0.224 * 255, 0.225 * 255]),
+                  ([0.485 * 255, 0.456 * 255, 0.406 * 255], None),
+                  ([0.485 * 255, 0.456 * 255, 0.406 * 255], [255.0,]),
+                  (None, [0.229 * 255, 0.224 * 255, 0.225 * 255]),
+                  ([128,], [0.229 * 255, 0.224 * 255, 0.225 * 255]) ]
     output_layouts = {
         "HWC" : ["HWC", "CHW"],
         "FHWC" : ["FHWC", "FCHW"],


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to support normalization with uneven length of the arguments in CropMirrorNormalize

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Handle the case when either one of the arguments (mean/std) is a scalar or is not provided and the other one is a multivalue argument*
 - Affected modules and functionalities:
     *CropMirrorNormalize*
 - Key points relevant for the review:
     *Everything*
 - Validation and testing:
     *New tests added*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[NA]*
