### PR TITLE
Fix TL1 tests

### DIFF
--- a/docs/examples/use_cases/tensorflow/resnet-n/nvutils/optimizers.py
+++ b/docs/examples/use_cases/tensorflow/resnet-n/nvutils/optimizers.py
@@ -18,8 +18,13 @@ from __future__ import print_function
 from builtins import range
 import tensorflow as tf
 
+try:
+    from tensorflow.compat.v1.train import Optimizer
+except:
+    # Older TF versions don't have compat.v1 layer
+    from tensorflow.train import Optimizer
 
-class LarcOptimizer(tf.train.Optimizer):
+class LarcOptimizer(Optimizer):
     def __init__(self, optimizer, learning_rate, eta, clip=True, epsilon=1.,
                  name="LarcOptimizer", use_locking=False):
         super(LarcOptimizer, self).__init__(
@@ -57,7 +62,7 @@ class LarcOptimizer(tf.train.Optimizer):
         return self._optimizer.apply_gradients(gradvars, *args, **kwargs)
 
 
-class LossScalingOptimizer(tf.train.Optimizer):
+class LossScalingOptimizer(Optimizer):
     """An optimizer that scales loss and un-scales gradients."""
 
     def __init__(self, optimizer,

--- a/qa/TL1_ssd_training/test.sh
+++ b/qa/TL1_ssd_training/test.sh
@@ -12,7 +12,9 @@ test_body() {
     #install APEX
     git clone https://github.com/nvidia/apex
     pushd apex
+    export CUDA_HOME=/usr/local/cuda-$(python -c "import torch; print('.'.join(torch.version.cuda.split('.')[0:2]))")
     pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" .
+    unset CUDA_HOME
     popd
 
     python -m torch.distributed.launch --nproc_per_node=8 main.py --backbone resnet50 --warmup 300 --bs 64 --eval-batch-size 8 --epochs 4 --data /data/coco/coco-2017/coco2017/ --data_pipeline dali --target 0.085

--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -8,12 +8,10 @@ do_once() {
     NUM_GPUS=$(nvidia-smi -L | wc -l)
 
     CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1\2/')
-    # from 1.13.1 CUDA 10 is supported but not CUDA 9
-    if [ "${CUDA_VERSION}" -ge "100" ]; then
-        pip install tensorflow-gpu==1.13.1
-    else
-        pip install tensorflow-gpu==1.12
-    fi
+
+    # install any for CUDA 9 and the second for CUDA 10, 1.14 doesn't work so well with horovod
+    pip install $($topdir/qa/setup_packages.py -i 1 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
+
     pip uninstall -y nvidia-dali-tf-plugin || true
     pip install /opt/dali/nvidia-dali-tf-plugin*.tar.gz
 

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -77,7 +77,7 @@ def test_request(req, name, cuda):
     request = Request(req)
     request.get_method = lambda : 'HEAD'
     try:
-        response = urlopen(request)
+        _ = urlopen(request)
         return req
     except HTTPError:
         return None
@@ -178,7 +178,7 @@ def main():
         print(get_all_strings(args.use, args.cuda))
     elif args.install >= 0:
         if args.install > cal_num_of_configs(args.use, args.cuda):
-            args.install = 1
+            args.install = 0
         print (get_install_string(args.install, args.use, args.cuda))
 
 if __name__ == "__main__":


### PR DESCRIPTION
- removes hardcoded TensorFlow versions from TL1 tests and makes one using one from setup_packages.py
- sets CUDA_HOME in TL1_ssd_training to point to CUDA version used to compile particular PyTorch

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a problems in TL1 test in CI

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     removes hardcoded TensorFlow versions from TL1 tests and makes one using one from setup_packages.py
    sets CUDA_HOME in TL1_ssd_training to point to CUDA version used to compile particular PyTorch
 - Affected modules and functionalities:
     test setup
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
