### PR TITLE
Fix Pad operator bug

### DIFF
--- a/dali/operators/generic/pad.h
+++ b/dali/operators/generic/pad.h
@@ -73,15 +73,14 @@ class Pad : public Operator<Backend> {
     int nsamples = in_shape.num_samples();
     if (!kernel_sample_args_.has_value()) {
       kernel_sample_args_ = std::vector<Args>();
-      auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
-      kernel_sample_args.reserve(nsamples);
-      for (int i = 0; i < nsamples; i++) {
-        kernel_sample_args.emplace_back(in_shape[i]);
-      }
     }
 
     auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
-    assert(static_cast<int>(kernel_sample_args.size()) == nsamples);
+    kernel_sample_args.clear();
+    kernel_sample_args.reserve(nsamples);
+    for (int i = 0; i < nsamples; i++) {
+      kernel_sample_args.emplace_back(in_shape[i]);
+    }
 
     int ndim = in_shape.sample_dim();
 

--- a/dali/test/python/test_operator_pad.py
+++ b/dali/test/python/test_operator_pad.py
@@ -121,7 +121,8 @@ def test_slice_synth_data_vs_numpy():
                  ((200, 400, 3), None, "HW", (16, 64), None),
                  ((200, 400, 3), (0, 1), None, (256,), None),
                  ((200, 400, 3), None, "HW", (256,), None),
-                 ((200, 400, 3), None, None, None, (-1, -1, 4))]:
+                 ((200, 400, 3), None, None, None, (-1, -1, 4)),
+                 ((25, 100, 3), (0,), None, None, (25,))]:
                 yield check_pad_synth_data, device, batch_size, input_max_shape, axes, axis_names, align, shape_arg
 
 def main():

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -151,15 +151,11 @@ class RandomDataIterator(object):
 
 class RandomlyShapedDataIterator(object):
     import_numpy()
-    def __init__(self, batch_size, max_shape=(10, 600, 800, 3)):
+    def __init__(self, batch_size, max_shape=(10, 600, 800, 3), seed=12345):
         self.batch_size = batch_size
         self.test_data = []
-        for _ in range(self.batch_size):
-            np.random.seed(0)
-            # Scale between 0.5 and 1.0
-            shape = [int(max_shape[dim] * (0.5 + random.random()*0.5)) for dim in range(len(max_shape))]
-            self.test_data.append(np.array(np.random.rand(*shape) * 255,
-                                  dtype = np.uint8))
+        self.max_shape = max_shape
+        np.random.seed(seed)
 
     def __iter__(self):
         self.i = 0
@@ -167,6 +163,12 @@ class RandomlyShapedDataIterator(object):
         return self
 
     def __next__(self):
+        self.test_data = []
+        for _ in range(self.batch_size):
+            # Scale between 0.5 and 1.0
+            shape = [int(self.max_shape[dim] * (0.5 + random.random()*0.5)) for dim in range(len(self.max_shape))]
+            self.test_data.append(np.array(np.random.rand(*shape) * 255,
+                                  dtype = np.uint8))
         batch = self.test_data
         self.i = (self.i + 1) % self.n
         return (batch)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in Pad operator

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Adjusted kernel arguments in Pad operator to reflect on the new sample shapes*
     *Made RandomlyShapedDataIterator actually generate randomly shaped data*
 - Affected modules and functionalities:
     *Pad operator & RandomlyShapedDataIterator*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     *Existing tests*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1265]*
