### PR TITLE
Fix two bugs:

### DIFF
--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -276,10 +276,11 @@ void Reshape<CPUBackend>::RunImpl(HostWorkspace &ws) {
   auto &in = ws.InputRef<CPUBackend>(0);
   TensorLayout layout = GetOutputLayout(ws);
   out.ShareData(&in);
+  out.Resize(output_shape_);
   int N = output_shape_.num_samples();
   for (int i = 0; i < N; i++) {
-    out[i].Resize(output_shape_[i]);
     assert(out[i].raw_data() == in[i].raw_data());
+    assert(out[i].shape() == output_shape_[i]);
   }
   out.SetLayout(layout);
 }

--- a/dali/pipeline/data/buffer.cc
+++ b/dali/pipeline/data/buffer.cc
@@ -1,0 +1,24 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/data/buffer.h"
+#include "dali/pipeline/data/backend.h"
+
+namespace dali {
+
+// this is to make debug builds happy about kMaxGrowthFactor
+template class Buffer<CPUBackend>;
+template class Buffer<GPUBackend>;
+
+}  // namespace dali

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -350,10 +350,15 @@ class DLL_PUBLIC Buffer {
 };
 
 template <typename Backend>
-double Buffer<Backend>::growth_factor_ = 1.0;
+DLL_PUBLIC double Buffer<Backend>::growth_factor_ = 1.0;
 
 template <typename Backend>
-double Buffer<Backend>::shrink_threshold_ = std::is_same<Backend, CPUBackend>::value ? 0.9 : 0;
+DLL_PUBLIC double Buffer<Backend>::shrink_threshold_ =
+  std::is_same<Backend, CPUBackend>::value ? 0.9 : 0;
+
+template <typename Backend>
+DLL_PUBLIC constexpr double Buffer<Backend>::kMaxGrowthFactor;
+
 
 // Macro so we don't have to list these in all
 // classes that derive from Buffer


### PR DESCRIPTION
1. Buffer linkage - in debug builds, the static fields require external linkage (and explicit instantiation).
2. Reshape - the tensors inside were reshaped, but the tensor list was not. Fixed now, using native TensorVector::Resize.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes two bugs:
1. Buffer linkage - in debug builds, the static fields require external linkage (and explicit instantiation).
2. Reshape - the tensors inside were reshaped, but the tensor list was not. Fixed now, using native TensorVector::Resize.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added explicit instantiation and out-of-class repetition of constexpr variable.
     * reshape.cc uses TensorVector::Reshap now
 - Affected modules and functionalities:
     * reshape.cc
     * buffer.h, added buffer.cc
 - Key points relevant for the review:
     ?
 - Validation and testing:
     * Old tests apply
 - Documentation (including examples):
     N/A

**JIRA TASK**: N/A
