### PR TITLE
Change default value in ToDecibels, add one test

### DIFF
--- a/dali/operators/signal/decibel/to_decibels.cc
+++ b/dali/operators/signal/decibel/to_decibels.cc
@@ -40,7 +40,7 @@ are dealing with a squared magnitude or not).)code",
     .AddOptionalArg("reference",
       R"code(Reference magnitude. If not provided, the maximum of the input will be used as
 reference. Note: The maximum of the input will be calculated on a per-sample basis.)code",
-      1.0f)
+      0.0f)
     .AddOptionalArg("cutoff_db",
       R"code(Minimum or cut-off ratio in dB. Any value below this value will saturate. Example:
 A value of `cutoff_db=-80` corresponds to a minimum ratio of `1e-8`.)code",

--- a/dali/operators/signal/decibel/to_decibels.h
+++ b/dali/operators/signal/decibel/to_decibels.h
@@ -33,8 +33,10 @@ class ToDecibels : public Operator<Backend> {
       : Operator<Backend>(spec) {
     args_.multiplier = spec.GetArgument<float>("multiplier");
     args_.ref_max = !spec.HasArgument("reference");
-    if (!args_.ref_max)
+    if (!args_.ref_max) {
       args_.s_ref = spec.GetArgument<float>("reference");
+      DALI_ENFORCE(args_.s_ref != 0, "`reference` argument can't be zero");
+    }
     auto cutoff_db = spec.GetArgument<float>("cutoff_db");
     args_.min_ratio = std::pow(10.0f, cutoff_db / args_.multiplier);
   }

--- a/dali/test/python/test_operator_to_decibels.py
+++ b/dali/test/python/test_operator_to_decibels.py
@@ -23,6 +23,7 @@ from test_utils import check_batch
 from test_utils import compare_pipelines
 from test_utils import RandomDataIterator
 import math
+from nose.tools import *
 
 class ToDecibelsPipeline(Pipeline):
     def __init__(self, device, batch_size, iterator, multiplier, reference, cutoff_db,
@@ -119,9 +120,9 @@ class NaturalLogarithmPipeline(Pipeline):
 
 
 class NLDaliPipeline(NaturalLogarithmPipeline):
-    def __init__(self, iterator, batch_size):
+    def __init__(self, iterator, batch_size, reference=1.0):
         super().__init__(iterator, batch_size)
-        self.log = ops.ToDecibels(device="cpu", multiplier=np.log(10), reference=1.0)
+        self.log = ops.ToDecibels(device="cpu", multiplier=np.log(10), reference=reference)
 
 
 def log_tensor(tensor):
@@ -151,3 +152,7 @@ def test_operator_natural_logarithm():
     device = "cpu"
     for sh in shapes:
         yield check_natural_logarithm, device, batch_size, sh
+
+@raises(RuntimeError)
+def test_invalid_reference():
+    NLDaliPipeline(None, 1, 0.0).build()


### PR DESCRIPTION
Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

#### Why we need this PR?
After seeing in the `ToDecibels` documentation:
> reference (float, optional, default = 1.0)

I've spent half of Thursday on figuring out, why this doesn't give me good results. Turns out, that this is utterly not true: the default value in this case **is not** 1.0, it's max of signal instead.
Thus I propose to change the default value to 0.0. I know, that this value is incorrect and makes no sense, thus I'm introducing `ENFORCE` to secure runtime in this case.
Thanks to this change, user won't be mislead, that default value is 1.0, since it is not.

Additionally, I'm including a test that I wrote when "debugging" the problem.
