### PR TITLE
Fix bug in the COCOReader with masks

### DIFF
--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -184,10 +184,6 @@ void parse_annotations(
     bool to_add = true;
     parser.EnterObject();
     while (const char* internal_key = parser.NextObjectKey()) {
-      if (!to_add) {
-        parser.SkipValue();
-        continue;
-      }
       if (0 == detail::safe_strcmp(internal_key, "image_id")) {
         annotation.image_id_ = parser.GetInt();
       } else if (0 == detail::safe_strcmp(internal_key, "category_id")) {
@@ -205,8 +201,8 @@ void parse_annotations(
         // which is not needed for instance segmentation
         if (parser.PeekType() != kArrayType) {
           to_add = false;
-          parser.SkipValue();
-          continue;
+          parser.SkipObject();
+          break;
         }
 
         int coord_offset = 0;


### PR DESCRIPTION
Signed-off-by: Serge Panev <spanev@nvidia.com>

#### Why we need this PR?
- It fixes a bug the reader would stop the annotation file parsing whenever it parses a RLE annotation.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *[ Explain solution of the problem, a new feature added here. ]*
 - Affected modules and functionalities:
     *[ Describe here what was changed, added, removed. ]*
 - Key points relevant for the review:
     *[ Describe here what is the most important part that reviewers should focus on. ]*
 - Validation and testing:
     *[ Describe here if and how this PR is tested. ]*
 - Documentation (including examples):
     *[ Describe here if documentation and examples were updated. ]*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
