### PR TITLE
Use prebuild cupy for TL0_jupyter test

### DIFF
--- a/qa/TL0_jupyter/test_cupy.sh
+++ b/qa/TL0_jupyter/test_cupy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="jupyter numpy matplotlib cupy"
+pip_packages="jupyter numpy matplotlib cupy-cuda{cuda_v}"
 target_dir=./docs/examples
 
 test_body() {


### PR DESCRIPTION
- changes cupy to cupy-cuda package to use prebuild cupy

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes cupy package usage in TL0_jupyter test test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     changes cupy to cupy-cuda package to use prebuild cupy
 - Affected modules and functionalities:
     Tests
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
