### PR TITLE
Fix bug in TransposeCPU & ToDecibels operators

### DIFF
--- a/dali/operators/generic/transpose/transpose.h
+++ b/dali/operators/generic/transpose/transpose.h
@@ -134,7 +134,7 @@ class Transpose : public Operator<Backend> {
       auto permuted_dims = kernels::Permute(input.shape()[0], perm_);
       output_desc[0].shape = uniform_list_shape(batch_size_, permuted_dims);
     } else {
-      TensorListShape<> tl_shape(batch_size_);
+      TensorListShape<> tl_shape(batch_size_, input.shape().sample_dim());
       for (int i = 0; i < batch_size_; ++i) {
         auto in_shape = input.shape().tensor_shape(i);
         tl_shape.set_tensor_shape(i, kernels::Permute(in_shape, perm_));

--- a/dali/operators/signal/decibel/to_decibels.h
+++ b/dali/operators/signal/decibel/to_decibels.h
@@ -37,6 +37,8 @@ class ToDecibels : public Operator<Backend> {
       args_.s_ref = spec.GetArgument<float>("reference");
     auto cutoff_db = spec.GetArgument<float>("cutoff_db");
     args_.min_ratio = std::pow(10.0f, cutoff_db / args_.multiplier);
+    if (args_.min_ratio == 0)
+      args_.min_ratio = std::nextafter(0.0f, 1.0f);
   }
 
  protected:


### PR DESCRIPTION
Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

PR solves 2 problems:
1. ToDecibels: when multiplier is small, min_ratio_ will underflow to 0. Later we do `std::log(min_ratio_)`, so `0` isn't the best value there.
2. Tensor shape value for the case, when batch size isn't uniform
