### PR TITLE
Add error handling when trying to serialize Python Operators

### DIFF
--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -28,10 +28,13 @@ DALI_SCHEMA(DLTensorPythonFunctionImpl)
     .NumInput(0, 256)
     .OutputFn([](const OpSpec &spec) {return spec.GetArgument<int>("num_outputs");})
     .NoPrune()
+    .Unserializable()
     .MakeInternal();
 
 DALI_SCHEMA(DLTensorPythonFunction)
     .DocStr(R"code(Execute a python function that operates on DLPack tensors.
+The function should not modify input tensors.
+
 In case of the GPU operator it is a user's responsibility to synchronize the device code with DALI.
 This can be accomplished by synchronizing DALI's work before the operator call
 with the `synchronize_stream` flag (true by default) and then making sure

--- a/dali/operators/python_function/python_function.cc
+++ b/dali/operators/python_function/python_function.cc
@@ -31,9 +31,10 @@ DALI_SCHEMA(PythonFunction)
                 "The called function will get tensors' data as NumPy arrays for CPU operators"
                 " or as CuPy arrays for GPU operators and should return results in the same format"
                 " (for more universal data format see `DLTensorPythonFunction`). "
+                "The function should not modify input tensors. \n\n"
                 "For now, this operator can be used only in pipelines with "
                 "`exec_async=False` and `exec_pipelined=False` specified. Due to "
-                "inferior performance, it is intended mostly for prototyping and debugging.\n")
+                "inferior performance, it is intended mostly for prototyping and debugging.")
         .NumInput(0, 256)
         .AllowSequences()
         .SupportVolumetric()

--- a/dali/operators/python_function/python_function.cc
+++ b/dali/operators/python_function/python_function.cc
@@ -34,7 +34,7 @@ DALI_SCHEMA(PythonFunction)
                 "The function should not modify input tensors. \n\n"
                 "For now, this operator can be used only in pipelines with "
                 "`exec_async=False` and `exec_pipelined=False` specified. Due to "
-                "inferior performance, it is intended mostly for prototyping and debugging.")
+                "inferior performance, it is intended for prototyping and debugging.")
         .NumInput(0, 256)
         .AllowSequences()
         .SupportVolumetric()

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -77,7 +77,6 @@ supported in TensorFlow. It is worth noting that fed inputs should match the num
 expected by the next operator in the pipeline (e.g. NHWC will expect 3-dimensional tensors
 where the last dimension represents the different channels).)code")
   .NumInput(0)
-  .NumOutput(1)
-  .Unserializable();
+  .NumOutput(1);
 
 }  // namespace dali

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -77,6 +77,7 @@ supported in TensorFlow. It is worth noting that fed inputs should match the num
 expected by the next operator in the pipeline (e.g. NHWC will expect 3-dimensional tensors
 where the last dimension represents the different channels).)code")
   .NumInput(0)
-  .NumOutput(1);
+  .NumOutput(1)
+  .Unserializable();
 
 }  // namespace dali

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -276,6 +276,14 @@ class DLL_PUBLIC OpSchema {
   }
 
   /**
+   * @brief Notes that this operator cannot be serialized
+   */
+  DLL_PUBLIC inline OpSchema& Unserializable() {
+    serializable_ = false;
+    return *this;
+  }
+
+  /**
    * @brief Adds a required argument to op with its type
    */
   DLL_PUBLIC inline OpSchema& AddArg(const std::string &s,
@@ -616,6 +624,10 @@ class DLL_PUBLIC OpSchema {
     return no_prune_;
   }
 
+  DLL_PUBLIC inline bool IsSerializable() const {
+    return serializable_;
+  }
+
   /**
    * @brief Returns the index of the output to which the input is passed.
    * @return Output index or -1 if given input is not passed through.
@@ -725,6 +737,8 @@ class DLL_PUBLIC OpSchema {
   bool is_internal_ = false;
 
   bool no_prune_ = false;
+
+  bool serializable_ = true;
 
   std::map<int, int> passthrough_map_;
 

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -694,6 +694,9 @@ string Pipeline::SerializeToProtobuf() const {
     const auto& p = this->op_specs_for_serialization_[i];
     const OpSpec& spec = p.spec;
 
+    DALI_ENFORCE(spec.GetSchema().IsSerializable(), "Could not serialize the operator: "
+                                                     + spec.name());
+
     // As long as spec isn't an ExternalSource node, serialize
     if (spec.name() != "ExternalSource") {
       dali::SerializeToProtobuf(op_def, p.instance_name, spec, p.logical_id);

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -682,6 +682,11 @@ string Pipeline::SerializeToProtobuf() const {
   pipe.set_device_id(this->device_id());
   pipe.set_seed(this->original_seed_);
 
+  // loop over external inputs
+  for (auto &name : external_inputs_) {
+    pipe.add_external_inputs(name);
+  }
+
   // loop over ops, create messages and append
   for (size_t i = 0; i < this->op_specs_for_serialization_.size(); ++i) {
     dali_proto::OpDef *op_def = pipe.add_op();
@@ -691,7 +696,10 @@ string Pipeline::SerializeToProtobuf() const {
 
     DALI_ENFORCE(spec.GetSchema().IsSerializable(), "Could not serialize the operator: "
                                                     + spec.name());
-    dali::SerializeToProtobuf(op_def, p.instance_name, spec, p.logical_id);
+    // As long as spec isn't an ExternalSource node, serialize
+    if (spec.name() != "ExternalSource") {
+      dali::SerializeToProtobuf(op_def, p.instance_name, spec, p.logical_id);
+    }
   }
 
   // loop over outputs used to create the graph

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -682,11 +682,6 @@ string Pipeline::SerializeToProtobuf() const {
   pipe.set_device_id(this->device_id());
   pipe.set_seed(this->original_seed_);
 
-  // loop over external inputs
-  for (auto &name : external_inputs_) {
-    pipe.add_external_inputs(name);
-  }
-
   // loop over ops, create messages and append
   for (size_t i = 0; i < this->op_specs_for_serialization_.size(); ++i) {
     dali_proto::OpDef *op_def = pipe.add_op();
@@ -695,12 +690,8 @@ string Pipeline::SerializeToProtobuf() const {
     const OpSpec& spec = p.spec;
 
     DALI_ENFORCE(spec.GetSchema().IsSerializable(), "Could not serialize the operator: "
-                                                     + spec.name());
-
-    // As long as spec isn't an ExternalSource node, serialize
-    if (spec.name() != "ExternalSource") {
-      dali::SerializeToProtobuf(op_def, p.instance_name, spec, p.logical_id);
-    }
+                                                    + spec.name());
+    dali::SerializeToProtobuf(op_def, p.instance_name, spec, p.logical_id);
   }
 
   // loop over outputs used to create the graph

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -51,6 +51,14 @@ _dali_tf.__doc__ = _dali_tf.__doc__ + """
     differ based on your use case.
 """
 
+def serialize_pipeline(pipeline):
+  try:
+    return pipeline.serialize()
+  except:
+    print("Error during pipeline initialization. Note that some operators (e.g. Python Operators) "
+          "cannot be used with tensorflow data set API and DALIIterator.")
+    raise
+
 def DALIIteratorWrapper(pipeline = None, serialized_pipeline = None, sparse = [],
                         shapes = [], dtypes = [], batch_size = -1, prefetch_queue_depth = 2, **kwargs):
   """
@@ -68,7 +76,7 @@ This operator works in the same way as DALI TensorFlow plugin, with the exceptio
       gpu_prefetch_queue_depth = prefetch_queue_depth
 
   if serialized_pipeline is None:
-    serialized_pipeline = pipeline.serialize()
+    serialized_pipeline = serialize_pipeline(pipeline)
 
   # if batch_size is not provided we need to extract if from the shape arg
   if (not isinstance(shapes, Iterable) or len(shapes) == 0) and batch_size == -1:
@@ -160,7 +168,7 @@ if dataset_compatible_tensorflow():
 
       output_classes = tuple(ops.Tensor for shape in shapes)
 
-      self._pipeline = pipeline.serialize()
+      self._pipeline = serialize_pipeline(pipeline)
       self._batch_size = batch_size
       self._num_threads = num_threads
       self._device_id = device_id

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -54,10 +54,11 @@ _dali_tf.__doc__ = _dali_tf.__doc__ + """
 def serialize_pipeline(pipeline):
   try:
     return pipeline.serialize()
-  except:
-    print("Error during pipeline initialization. Note that some operators (e.g. Python Operators) "
-          "cannot be used with tensorflow data set API and DALIIterator.")
-    raise
+  except RuntimeError as e:
+    raise RuntimeError("Error during pipeline initialization. Note that some operators "
+                       "(e.g. Python Operators) cannot be used with "
+                       "tensorflow data set API and DALIIterator.") from e
+
 
 def DALIIteratorWrapper(pipeline = None, serialized_pipeline = None, sparse = [],
                         shapes = [], dtypes = [], batch_size = -1, prefetch_queue_depth = 2, **kwargs):

--- a/dali/test/python/test_dali_tf_dataset.py
+++ b/dali/test/python/test_dali_tf_dataset.py
@@ -244,22 +244,18 @@ def _test_tf_dataset_multigpu():
                 dataset_results[batch_id][device_id][2])
 
 
-class ExternalInputPipeline(Pipeline):
+class PythonOperatorPipeline(Pipeline):
     def __init__(self):
-        super(ExternalInputPipeline, self).__init__(1, 1, 0, 0)
-        self.source = ops.ExternalSource()
+        super(PythonOperatorPipeline, self).__init__(1, 1, 0, 0)
+        self.python_op = ops.PythonFunction(function=lambda: np.zeros((3, 3, 3)))
 
     def define_graph(self):
-        self.inp = self.source()
-        return self.inp
-
-    def iter_setup(self):
-        self.feed_input(self.inp, [np.zeros((3, 3))])
+        return self.python_op()
 
 
 @raises(RuntimeError)
 def test_python_operator_error():
-    dataset_pipeline = ExternalInputPipeline()
+    dataset_pipeline = PythonOperatorPipeline()
     shapes = [(1, 3, 3, 3)]
     dtypes = [tf.float32]
 

--- a/dali/test/python/test_dali_tf_dataset.py
+++ b/dali/test/python/test_dali_tf_dataset.py
@@ -244,18 +244,22 @@ def _test_tf_dataset_multigpu():
                 dataset_results[batch_id][device_id][2])
 
 
-class PythonOperatorPipeline(Pipeline):
+class ExternalInputPipeline(Pipeline):
     def __init__(self):
-        super(PythonOperatorPipeline, self).__init__(1, 1, 0, 0)
-        self.python_op = ops.PythonFunction(function=lambda: np.zeros(3, 3, 3))
+        super(ExternalInputPipeline, self).__init__(1, 1, 0, 0)
+        self.source = ops.ExternalSource()
 
     def define_graph(self):
-        return self.python_op()
+        self.inp = self.source()
+        return self.inp
+
+    def iter_setup(self):
+        self.feed_input(self.inp, [np.zeros((3, 3))])
 
 
 @raises(RuntimeError)
 def test_python_operator_error():
-    dataset_pipeline = PythonOperatorPipeline
+    dataset_pipeline = ExternalInputPipeline()
     shapes = [(1, 3, 3, 3)]
     dtypes = [tf.float32]
 

--- a/dali/test/python/test_dali_tf_dataset.py
+++ b/dali/test/python/test_dali_tf_dataset.py
@@ -243,3 +243,27 @@ def _test_tf_dataset_multigpu():
                 standalone_results[it_id][2],
                 dataset_results[batch_id][device_id][2])
 
+
+class PythonOperatorPipeline(Pipeline):
+    def __init__(self):
+        super(PythonOperatorPipeline, self).__init__(1, 1, 0, 0)
+        self.python_op = ops.PythonFunction(function=lambda: np.zeros(3, 3, 3))
+
+    def define_graph(self):
+        return self.python_op()
+
+
+@raises(RuntimeError)
+def test_python_operator_error():
+    dataset_pipeline = PythonOperatorPipeline
+    shapes = [(1, 3, 3, 3)]
+    dtypes = [tf.float32]
+
+    with tf.device('/cpu:0'):
+        daliset = dali_tf.DALIDataset(
+            pipeline=dataset_pipeline,
+            batch_size=1,
+            shapes=shapes,
+            dtypes=dtypes,
+            num_threads=1,
+            device_id=0)

--- a/dali/test/python/test_dali_tf_plugin_run.py
+++ b/dali/test/python/test_dali_tf_plugin_run.py
@@ -113,7 +113,7 @@ def test_dali_tf_op(pipe_type=CaffeReadPipeline, batch_size=32, iterations=32):
 class PythonOperatorPipeline(Pipeline):
     def __init__(self):
         super(PythonOperatorPipeline, self).__init__(1, 1, 0, 0)
-        self.python_op = ops.PythonFunction(function=lambda: np.zeros(3, 3, 3))
+        self.python_op = ops.PythonFunction(function=lambda: np.zeros((3, 3, 3)))
 
     def define_graph(self):
         return self.python_op()

--- a/dali/test/python/test_dali_tf_plugin_run.py
+++ b/dali/test/python/test_dali_tf_plugin_run.py
@@ -22,6 +22,7 @@ import nvidia.dali.tfrecord as tfrec
 import tensorflow as tf
 import nvidia.dali.plugin.tf as dali_tf
 from test_utils import get_dali_extra_path
+from nose.tools import raises
 
 try:
     tf.compat.v1.disable_eager_execution()
@@ -107,3 +108,20 @@ def test_dali_tf_op(pipe_type=CaffeReadPipeline, batch_size=32, iterations=32):
                 assert(np.equal(np.mod(label, 1), 0).all())
                 assert((label >= 0).all())
                 assert((label <= 999).all())
+
+
+class PythonOperatorPipeline(Pipeline):
+    def __init__(self):
+        super(PythonOperatorPipeline, self).__init__(1, 1, 0, 0)
+        self.python_op = ops.PythonFunction(function=lambda: np.zeros(3, 3, 3))
+
+    def define_graph(self):
+        return self.python_op()
+
+
+@raises(RuntimeError)
+def test_python_operator_error():
+    daliop = dali_tf.DALIIterator()
+    pipe = PythonOperatorPipeline()
+    with tf.device('/cpu:0'):
+        output = daliop(pipeline=pipe, shapes=[(1, 3, 3, 3)], dtypes=[tf.float32], device_id=0)


### PR DESCRIPTION
#### Why we need this PR?
- Refactoring to improve error handling when a user wants to use Python Operators with TF plugin

#### What happened in this PR?
 - What solution was applied:
     *Added `serializable_` field to OpSchema. pipeline.serialize() throws an error when the pipeline contains an op that is not serializable. Also, verbose description of the error was added to TF plugin.* 
 - Affected modules and functionalities:
     *OpSchema, TF plugin, Pipeline*
 - Key points relevant for the review:
     *TF plugin, OpSchema*
 - Validation and testing:
     *Extended TF plugin tests to expect an error when trying to wrap a pipeline containing PythonFunction*
 - Documentation (including examples):
     *Small Python Operators docs change*


**JIRA TASK**: *NA*
