### PR TITLE
Fix warnings reported by static analysis tool:

### DIFF
--- a/dali/benchmark/CMakeLists.txt
+++ b/dali/benchmark/CMakeLists.txt
@@ -17,6 +17,7 @@ if (BUILD_BENCHMARK)
   # Get basic benchmark sources that don't depend on any other options
   set(DALI_BENCHMARK_SRCS
     #"${CMAKE_CURRENT_SOURCE_DIR}/makecontiguous_bench.cc"
+    "${CMAKE_SOURCE_DIR}/dali/test/dali_test_config.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/resnet50_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/resnet50_nvjpeg_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/dali_bench.cc"

--- a/dali/benchmark/caffe2_alexnet_bench.cc
+++ b/dali/benchmark/caffe2_alexnet_bench.cc
@@ -17,6 +17,7 @@
 #include "dali/benchmark/dali_bench.h"
 #include "dali/pipeline/pipeline.h"
 #include "dali/util/image.h"
+#include "dali/test/dali_test_config.h"
 
 namespace dali {
 
@@ -40,7 +41,7 @@ BENCHMARK_DEFINE_F(C2Alexnet, Caffe2Pipe)(benchmark::State& st) { // NOLINT
       0, -1, pipelined, 2,
       async);
 
-  dali::string path(std::getenv("DALI_TEST_CAFFE2_LMDB_PATH"));
+  dali::string path(testing::dali_extra_path() + "/db/c2lmdb");
   pipe.AddOperator(
       OpSpec("Caffe2Reader")
       .AddArg("device", "cpu")

--- a/dali/benchmark/caffe_alexnet_bench.cc
+++ b/dali/benchmark/caffe_alexnet_bench.cc
@@ -17,6 +17,7 @@
 #include "dali/benchmark/dali_bench.h"
 #include "dali/pipeline/pipeline.h"
 #include "dali/util/image.h"
+#include "dali/test/dali_test_config.h"
 
 namespace dali {
 
@@ -40,7 +41,7 @@ BENCHMARK_DEFINE_F(Alexnet, CaffePipe)(benchmark::State& st) { // NOLINT
       0, -1, pipelined, 2,
       async);
 
-  dali::string path(std::getenv("DALI_TEST_CAFFE_LMDB_PATH"));
+  dali::string path(testing::dali_extra_path() + "/db/lmdb");
   pipe.AddOperator(
       OpSpec("CaffeReader")
       .AddArg("device", "cpu")

--- a/dali/benchmark/file_reader_alexnet_bench.cc
+++ b/dali/benchmark/file_reader_alexnet_bench.cc
@@ -17,6 +17,7 @@
 #include "dali/benchmark/dali_bench.h"
 #include "dali/pipeline/pipeline.h"
 #include "dali/util/image.h"
+#include "dali/test/dali_test_config.h"
 
 namespace dali {
 
@@ -39,7 +40,7 @@ BENCHMARK_DEFINE_F(FileReaderAlexnet, CaffePipe)(benchmark::State& st) { // NOLI
       0, -1, pipelined, 2,
       async);
 
-  dali::string list_root(std::getenv("DALI_TEST_FILE_READER_LIST_ROOT"));
+  dali::string list_root(testing::dali_extra_path() + "/db/single/jpeg/image_list.txt");
   pipe.AddOperator(
       OpSpec("FileReader")
       .AddArg("device", "cpu")

--- a/dali/kernels/reduce/reduce.h
+++ b/dali/kernels/reduce/reduce.h
@@ -270,7 +270,7 @@ struct ReduceBase {
   }
 
   void CheckOutput() {
-    if (axis_mask == static_cast<uint64_t>((1 << ndim()) - 1)) {
+    if (axis_mask == (static_cast<uint64_t>(1) << ndim()) - 1) {
       DALI_ENFORCE((output.dim() == 1 || output.dim() == input.dim()) && output.num_elements() == 1,
         make_string("Full reduction produces a single value (possibly keeping reduced dimensions)."
         "\nOutput shape provided: ", output.shape));

--- a/dali/operators/decoder/audio/audio_decoder_op.h
+++ b/dali/operators/decoder/audio/audio_decoder_op.h
@@ -84,7 +84,7 @@ class AudioDecoderCpu : public Operator<CPUBackend> {
 
   std::vector<float> target_sample_rates_;
   kernels::signal::resampling::Resampler resampler_;
-  DALIDataType output_type_, decode_type_;
+  DALIDataType output_type_ = DALI_NO_TYPE, decode_type_ = DALI_NO_TYPE;
   const bool downmix_ = false, use_resampling_ = false;
   const float quality_ = 50.0f;
   std::vector<std::string> files_names_;

--- a/dali/operators/math/normalize/normalize.cc
+++ b/dali/operators/math/normalize/normalize.cc
@@ -120,7 +120,11 @@ void Normalize<CPUBackend>::FoldMeans() {
   assert(mean_.ntensor() > 0);
   SumSamples(view<float>(mean_));
   // calculate the normalization factor in double, then cast to float
-  float den = static_cast<float>(1.0 / ReducedVolume(data_shape_, make_span(axes_)));
+  auto v = ReducedVolume(data_shape_, make_span(axes_));
+  if (v == 0) {
+    return;
+  }
+  float den = static_cast<float>(1.0 / v);
   auto sample0 = make_tensor_cpu(mean_.mutable_tensor<float>(0), mean_.shape()[0]);
   auto elems = sample0.num_elements();
   for (int i = 0; i < elems; i++) {
@@ -134,6 +138,9 @@ void Normalize<CPUBackend>::FoldStdDev() {
   SumSamples(view<float>(inv_stddev_));
   // calculate the normalization factor in double, then cast to float
   auto v = ReducedVolume(data_shape_, make_span(axes_));
+  if (v == 0) {
+    return;
+  }
   float rdiv = static_cast<float>(1.0 / v);
   auto sample0 = make_tensor_cpu(inv_stddev_.mutable_tensor<float>(0), inv_stddev_.shape()[0]);
   auto elems = sample0.num_elements();

--- a/dali/operators/math/normalize/normalize_utils.h
+++ b/dali/operators/math/normalize/normalize_utils.h
@@ -136,6 +136,11 @@ static void ScaleRSqrtKeepZero(const TensorView<StorageCPU, float> &inout, float
 static void SumSquare2InvStdDev(const TensorView<StorageCPU, float> &inout,
                                 const TensorShape<> &data_shape,
                                 double scale) {
+  if (inout.num_elements() == 0) {
+    return;
+  }
+  assert(data_shape.num_elements() >= inout.num_elements());
+
   int64_t v = data_shape.num_elements() / inout.num_elements();
   float rdiv = static_cast<float>(1.0 / v);  // reciprocal in double precision
   ScaleRSqrtKeepZero(inout, rdiv, scale);

--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -219,7 +219,8 @@ static int read_packet(void *opaque, uint8_t *buf, int buf_size) {
   if (!file_data->file_stream) {
     file_data->file_stream = fopen(file_data->filename.c_str(), "r");
     DALI_ENFORCE(file_data->file_stream, make_string("Could not open file ", file_data->filename));
-    fseek(file_data->file_stream, file_data->file_position, SEEK_SET);
+    int ret = fseek(file_data->file_stream, file_data->file_position, SEEK_SET);
+    DALI_ENFORCE(ret == 0, make_string("Could not open file ", file_data->filename));
   }
   return fread(buf, 1, buf_size, file_data->file_stream);
 }
@@ -231,7 +232,8 @@ static int64_t seek_file(void *opaque, int64_t offset, int whence) {
   if (!file_data->file_stream) {
     file_data->file_stream = fopen(file_data->filename.c_str(), "r");
     DALI_ENFORCE(file_data->file_stream, make_string("Could not open file ", file_data->filename));
-    fseek(file_data->file_stream, file_data->file_position, SEEK_SET);
+    int ret = fseek(file_data->file_stream, file_data->file_position, SEEK_SET);
+    DALI_ENFORCE(ret == 0, make_string("Could not open file ", file_data->filename));
   }
   int ret = -1;
   switch (whence) {

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -163,7 +163,8 @@ class DLL_PUBLIC Executor : public ExecutorBase, public WorkspacePolicy, public 
 
   int batch_size_, device_id_;
   size_t bytes_per_sample_hint_;
-  cudaEvent_t mixed_stage_event_, gpu_stage_event_;
+  cudaEvent_t mixed_stage_event_ = {};
+  cudaEvent_t gpu_stage_event_ = {};
 
   vector<string> output_names_;
 


### PR DESCRIPTION
- fixes division by 0 in reducing
- fixes lack of return value check in VideoReader
- adds a default initialization to some class members

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug issues reported by static analysis tool

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     - fixes division by 0 in reducing
     - fixes lack of return value check in VideoReader
     - adds a default initialization to some class members
 - Affected modules and functionalities:
     NA
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1271]*
