### PR TITLE
Fix precision loss in CropWindowGenerator

### DIFF
--- a/dali/operators/decoder/host/fused/host_decoder_slice_test.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_slice_test.cc
@@ -57,10 +57,10 @@ class ImageDecoderSliceTest_CPU : public DecodeTestBase<ImgType> {
       DALI_ENFORCE(shape_layout == "HW",
         make_string("Unexpected input shape layout: ", shape_layout, " vs HW"));
       CropWindow crop_window;
-      crop_window.anchor[0] = crop_y * shape[0];
-      crop_window.anchor[1] = crop_x * shape[1];
-      crop_window.shape[0] = (crop_h + crop_y) * shape[0] - crop_window.anchor[0];
-      crop_window.shape[1] = (crop_w + crop_x) * shape[1] - crop_window.anchor[1];
+      crop_window.anchor[0] = std::lround(crop_y * shape[0]);
+      crop_window.anchor[1] = std::lround(crop_x * shape[1]);
+      crop_window.shape[0] = std::lround((crop_h + crop_y) * shape[0] - crop_window.anchor[0]);
+      crop_window.shape[1] = std::lround((crop_w + crop_x) * shape[1] - crop_window.anchor[1]);
       return crop_window;
     };
   }

--- a/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice_test.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice_test.cc
@@ -61,10 +61,10 @@ class ImageDecoderSliceTest_GPU : public DecodeTestBase<ImgType> {
       DALI_ENFORCE(shape_layout == "HW",
         make_string("Unexpected input shape layout: ", shape_layout, " vs HW"));
       CropWindow crop_window;
-      crop_window.anchor[0] = crop_y * shape[0];
-      crop_window.anchor[1] = crop_x * shape[1];
-      crop_window.shape[0] = (crop_h + crop_y) * shape[0] - crop_window.anchor[0];
-      crop_window.shape[1] = (crop_w + crop_x) * shape[1] - crop_window.anchor[1];
+      crop_window.anchor[0] = std::lround(crop_y * shape[0]);
+      crop_window.anchor[1] = std::lround(crop_x * shape[1]);
+      crop_window.shape[0] = std::lround((crop_h + crop_y) * shape[0] - crop_window.anchor[0]);
+      crop_window.shape[1] = std::lround((crop_w + crop_x) * shape[1] - crop_window.anchor[1]);
       return crop_window;
     };
   }

--- a/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_slice_test.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_slice_test.cc
@@ -62,10 +62,10 @@ class ImageDecoderSplitSliceTest_GPU : public DecodeTestBase<ImgType> {
       DALI_ENFORCE(shape_layout == "HW",
         make_string("Unexpected input shape layout: ", shape_layout, " vs HW"));
       CropWindow crop_window;
-      crop_window.anchor[0] = crop_y * shape[0];
-      crop_window.anchor[1] = crop_x * shape[1];
-      crop_window.shape[0] = (crop_h + crop_y) * shape[0] - crop_window.anchor[0];
-      crop_window.shape[1] = (crop_w + crop_x) * shape[1] - crop_window.anchor[1];
+      crop_window.anchor[0] = std::lround(crop_y * shape[0]);
+      crop_window.anchor[1] = std::lround(crop_x * shape[1]);
+      crop_window.shape[0] = std::lround((crop_h + crop_y) * shape[0] - crop_window.anchor[0]);
+      crop_window.shape[1] = std::lround((crop_w + crop_x) * shape[1] - crop_window.anchor[1]);
       return crop_window;
     };
   }

--- a/dali/operators/ssd/random_crop.cc
+++ b/dali/operators/ssd/random_crop.cc
@@ -295,21 +295,21 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace &ws) {
         label_out_data[j] = label_data[idx];
 
         // scaling
-        float minus[] = {left, top, left, top};
-        float scale[] = {w, h, w, h};
+        double minus[] = {left, top, left, top};
+        double scale[] = {w, h, w, h};
         for (int k = 0; k < 4; ++k) {
           // scale and translate the input box
-          float coord = (bbox_i[k] - minus[k]) / scale[k];;
+          double coord = (bbox_i[k] - minus[k]) / scale[k];;
           // ..and clamp it to 0..1 range
-          bbox_o[k] = std::min(std::max(coord, 0.0f), 1.0f);
+          bbox_o[k] = std::min(std::max(coord, 0.0), 1.0);
         }
       }  // end bbox copy
 
       // everything is good, generate the crop parameters
-      const int left_idx = static_cast<int>(left * wtot);
-      const int top_idx = static_cast<int>(top * htot);
-      const int right_idx = static_cast<int>(right * wtot);
-      const int bottom_idx = static_cast<int>(bottom * htot);
+      const int left_idx = std::lround(left * wtot);
+      const int top_idx = std::lround(top * htot);
+      const int right_idx = std::lround(right * wtot);
+      const int bottom_idx = std::lround(bottom * htot);
 
       // perform the crop
       detail::crop(img, {left_idx, top_idx, right_idx, bottom_idx},

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -238,24 +238,25 @@ def slice_func_helper(axes, axis_names, layout, normalized_anchor, normalized_sh
         full_slice_anchor[axis] = slice_anchor[idx]
         full_slice_shape[axis] = slice_shape[idx]
 
+    #std::round has different behaviour than np.round so manually add 0.5 and truncate to int
     if normalized_anchor and normalized_shape:
-        start = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]))
+        start = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]) + 0.5)
                  for i in range(len(shape))]
-        end = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]+full_slice_shape[i]))
+        end = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]+full_slice_shape[i]) + 0.5)
                for i in range(len(shape))]
     else:
         if normalized_anchor:
-            start = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]))
+            start = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]) + 0.5)
                     for i in range(len(shape))]
         else:
-            start = [int(np.float32(full_slice_anchor[i]))
+            start = [int(np.float32(full_slice_anchor[i]) + 0.5)
                     for i in range(len(shape))]
 
         if normalized_shape:
-            end = [start[i] + int(np.float32(shape[i]) * np.float32(full_slice_shape[i]))
+            end = [start[i] + int(np.float32(shape[i]) * np.float32(full_slice_shape[i]) + 0.5)
                 for i in range(len(shape))]
         else:
-            end = [start[i] + int(np.float32(full_slice_shape[i]))
+            end = [start[i] + int(np.float32(full_slice_shape[i]) + 0.5)
                 for i in range(len(shape))]
 
     if len(full_slice_anchor) == 3:


### PR DESCRIPTION
- CropWindowGenerator computes anchor and shapes as a rel_anch * shape, rel_shape * shape. To be more accurate it should be rel_anch * shape, (rel_anch + rel_shape) * shape - (rel_anch * shape)
- adds a special case when anchors and shapes are relative. When only one or none is then the old code path is used
- adds rounding in place of truncation
- updates tests

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in CropWindowGenerator that was caused by float point operation error accumulation

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a special case when anchors and shapes are relative. When only one or none is then the old code path is used
     adds rounding in place of truncation
 - Affected modules and functionalities:
     slice_attr
 - Key points relevant for the review:
     NA
 - Validation and testing:
     Updated tests are run on CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
