### PR TITLE
Specialize mul artihm op for bool

### DIFF
--- a/dali/operators/math/expressions/arithmetic_meta.h
+++ b/dali/operators/math/expressions/arithmetic_meta.h
@@ -366,6 +366,20 @@ REGISTER_UNARY_IMPL(ArithmeticOp::minus, -);
 REGISTER_BINARY_IMPL(ArithmeticOp::add, +);
 REGISTER_BINARY_IMPL(ArithmeticOp::sub, -);
 REGISTER_BINARY_IMPL(ArithmeticOp::mul, *);
+
+// Specialization for mul and bool so we use && instead of * so the compiler is happy
+template <>
+DALI_HOST_DEV constexpr binary_result_t<bool, bool>
+  arithm_meta<ArithmeticOp::mul, CPUBackend>::impl<bool, bool>(bool l, bool r) {
+  return l && r;
+}
+
+template <>
+DALI_HOST_DEV constexpr binary_result_t<bool, bool>
+  arithm_meta<ArithmeticOp::mul, GPUBackend>::impl<bool, bool>(bool l, bool r) {
+  return l && r;
+}
+
 REGISTER_BINARY_IMPL(ArithmeticOp::div, /);
 
 #define REGISTER_BINARY_BITWISE_IMPL_BACKEND(OP, EXPRESSION, BACKEND)                \


### PR DESCRIPTION
- the compiler complains about using `*` for bools
- fixes compiler warning by specializing mul arithm op for `*` and bool by using `&&`

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a compiler warning during arithm op compilation

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     fixes compiler warning by specializing mul arithm op for `*` and bool by using `&&`
 - Affected modules and functionalities:
     NA
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
