### PR TITLE
Fix typo in TensorListGPU docs, show __getitem__ docs

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -330,11 +330,12 @@ void ExposeTensorList(py::module &m) {
       ----------
       )code")
       .def("__getitem__",
-        [](TensorList<CPUBackend> &t, Index id) -> std::unique_ptr<Tensor<CPUBackend>> {
-          return TensorListGetItemImpl(t, id);
+        [](TensorList<CPUBackend> &t, Index i) -> std::unique_ptr<Tensor<CPUBackend>> {
+          return TensorListGetItemImpl(t, i);
         },
+      "i"_a,
       R"code(
-      Returns a tensor at given position in the list.
+      Returns a tensor at given position `i` in the list.
 
       Parameters
       ----------
@@ -493,7 +494,7 @@ void ExposeTensorList(py::module &m) {
       "non_blocking"_a = false,
       R"code(
       Copy the contents of this `TensorList` to an external pointer
-      residing in CPU memory.
+      residing in GPU memory.
 
       This function is used internally by plugins to interface with
       tensors from supported Deep Learning frameworks.
@@ -508,11 +509,12 @@ void ExposeTensorList(py::module &m) {
             Asynchronous copy.
       )code")
     .def("__getitem__",
-        [](TensorList<GPUBackend> &t, Index id) -> std::unique_ptr<Tensor<GPUBackend>> {
-          return TensorListGetItemImpl(t, id);
+        [](TensorList<GPUBackend> &t, Index i) -> std::unique_ptr<Tensor<GPUBackend>> {
+          return TensorListGetItemImpl(t, i);
         },
+      "i"_a,
       R"code(
-      Returns a tensor at given position in the list.
+      Returns a tensor at given position `i` in the list.
 
       Parameters
       ----------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,11 +28,13 @@ TensorListCPU
 ^^^^^^^^^^^^^
 .. autoclass:: nvidia.dali.backend.TensorListCPU
    :members:
+   :special-members: __getitem__
 
 TensorListGPU
 ^^^^^^^^^^^^^
 .. autoclass:: nvidia.dali.backend.TensorListGPU
    :members:
+   :special-members: __getitem__
 
 
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fix typo in TensorListGPU and __getitem__ not being listed in docs

#### What happened in this PR?
 - What solution was applied:
NA

 - Affected modules and functionalities:
docs

 - Key points relevant for the review:
docs

 - Validation and testing:
CI, local docs

 - Documentation (including examples):
YES


**JIRA TASK**: *[NA]*
