### PR TITLE
Add an ability to read noncontinuous RecordIO and TFRecord files

### DIFF
--- a/dali/operators/reader/loader/indexed_file_loader.h
+++ b/dali/operators/reader/loader/indexed_file_loader.h
@@ -66,10 +66,11 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
       return;
     }
 
-    if (should_seek_) {
+    if (should_seek_ || next_seek_pos_ != seek_pos) {
       current_file_->Seek(seek_pos);
       should_seek_ = false;
     }
+    next_seek_pos_ = seek_pos + size;
 
     if (!copy_read_data_) {
       auto p = current_file_->Get(size);
@@ -157,6 +158,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
   FileStream::FileStreamMappinReserver mmap_reserver;
   static constexpr int INVALID_INDEX = -1;
   bool should_seek_ = false;
+  int64 next_seek_pos_;
 };
 
 }  // namespace dali

--- a/dali/test/python/test_operator_index_reader.py
+++ b/dali/test/python/test_operator_index_reader.py
@@ -1,0 +1,87 @@
+from __future__ import print_function, division
+import math
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops as ops
+import nvidia.dali.tfrecord as tfrec
+import os.path
+import tempfile
+import numpy as np
+
+test_data_root = os.environ['DALI_EXTRA_PATH']
+
+def skip_second(src, dst):
+    with open(src, 'r') as tmp_f:
+        with open(dst, 'w') as f:
+            second = False
+            for l in tmp_f:
+                if not second:
+                    f.write(l)
+                second = not second
+
+def test_tfrecord():
+    class TFRecordPipeline(Pipeline):
+        def __init__(self, batch_size, num_threads, device_id, num_gpus, data, data_idx):
+            super(TFRecordPipeline, self).__init__(batch_size, num_threads, device_id)
+            self.input = ops.TFRecordReader(path = data,
+                                            index_path = data_idx,
+                                            features = {"image/encoded" : tfrec.FixedLenFeature((), tfrec.string, ""),
+                                                        "image/class/label": tfrec.FixedLenFeature([1], tfrec.int64,  -1)
+                                            })
+
+        def define_graph(self):
+            inputs = self.input(name="Reader")
+            images = inputs["image/encoded"]
+            return images
+
+    tfrecord = os.path.join(test_data_root, 'db', 'tfrecord', 'train')
+    tfrecord_idx_org = os.path.join(test_data_root, 'db', 'tfrecord', 'train.idx')
+    tfrecord_idx = "tfr_train.idx"
+
+    idx_files_dir = tempfile.TemporaryDirectory()
+    idx_file = os.path.join(idx_files_dir.name, tfrecord_idx)
+
+    skip_second(tfrecord_idx_org, idx_file)
+
+    pipe = TFRecordPipeline(1, 1, 0, 1, tfrecord, idx_file)
+    pipe_org = TFRecordPipeline(1, 1, 0, 1, tfrecord, tfrecord_idx_org)
+    pipe.build()
+    pipe_org.build()
+    iters = pipe.epoch_size("Reader")
+    for _ in  range(iters):
+        out = pipe.run()
+        out_ref = pipe_org.run()
+        for a, b in zip(out, out_ref):
+            assert np.array_equal(a.as_array(), b.as_array())
+        _ = pipe_org.run()
+
+def test_recordio():
+    class MXNetReaderPipeline(Pipeline):
+        def __init__(self, batch_size, num_threads, device_id, num_gpus, data, data_idx):
+            super(MXNetReaderPipeline, self).__init__(batch_size, num_threads, device_id)
+            self.input = ops.MXNetReader(path = [data], index_path=[data_idx],
+                                        shard_id = device_id, num_shards = num_gpus)
+
+        def define_graph(self):
+            images, _ = self.input(name="Reader")
+            return images
+
+    recordio = os.path.join(test_data_root, 'db', 'recordio', 'train.rec')
+    recordio_idx_org = os.path.join(test_data_root, 'db', 'recordio', 'train.idx')
+    recordio_idx = "rio_train.idx"
+
+    idx_files_dir = tempfile.TemporaryDirectory()
+    idx_file = os.path.join(idx_files_dir.name, recordio_idx)
+
+    skip_second(recordio_idx_org, idx_file)
+
+    pipe = MXNetReaderPipeline(1, 1, 0, 1, recordio, idx_file)
+    pipe_org = MXNetReaderPipeline(1, 1, 0, 1, recordio, recordio_idx_org)
+    pipe.build()
+    pipe_org.build()
+    iters = pipe.epoch_size("Reader")
+    for _ in  range(iters):
+        out = pipe.run()
+        out_ref = pipe_org.run()
+        for a, b in zip(out, out_ref):
+            assert np.array_equal(a.as_array(), b.as_array())
+        _ = pipe_org.run()


### PR DESCRIPTION
- adds an ability to seek to index file loader if the next entry is not next to the previous one
- adds a test

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds an ability to seek to index file loader if the next entry is not next to the previous one

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds an ability to seek to index file loader if the next entry is not next to the previous one
 - Affected modules and functionalities:
     index_file loader
 - Key points relevant for the review:
     NA
 - Validation and testing:
     new test added
 - Documentation (including examples):
     No

In response to https://github.com/NVIDIA/DALI/issues/1744

**JIRA TASK**: *[NA]*
