### PR TITLE
Fix test_plugin_manager

### DIFF
--- a/dali/test/python/test_plugin_manager.py
+++ b/dali/test/python/test_plugin_manager.py
@@ -20,6 +20,7 @@ import nvidia.dali.plugin_manager as plugin_manager
 import unittest
 import os
 import numpy as np
+import tempfile
 
 test_bin_dir = os.path.dirname(dali.__file__) + "/test"
 batch_size = 4
@@ -79,8 +80,13 @@ class TestLoadedPlugin(unittest.TestCase):
             plugin_manager.load_library("not_a_dali_plugin.so")
 
     def test_load_existing_but_not_a_library(self):
+        tmp = tempfile.NamedTemporaryFile(delete = False)
+        for _ in range(10):
+            tmp.write(b"0xdeadbeef\n")
+        tmp.close()
         with self.assertRaises(RuntimeError):
-            plugin_manager.load_library( test_bin_dir + "/dali_test.bin" )
+            plugin_manager.load_library( tmp.name )
+        os.remove(tmp.name)
 
     def test_load_custom_operator_plugin(self):
         with self.assertRaises(AttributeError):


### PR DESCRIPTION
- fixes test_plugin_manager test case that tries to load an existing file that is not a valid dynamic library. So far it was loading dali_test.bin which on some system is a valid loadable library what is not expected by the test
- uses dummy temp file as a test binary that should not load at all

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in test_plugin_manager

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
    fixes test_plugin_manager test case that tries to load an existing file that is not a valid dynamic library. So far it was loading dali_test.bin which on some system is a valid loadable library what is not expected by the test
   uses dummy temp file as a test binary that should not load at all
 - Affected modules and functionalities:
      test_plugin_manager test
 - Key points relevant for the review:
     test
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA

Related to https://github.com/NVIDIA/DALI/issues/1748

**JIRA TASK**: *[NA]*
