### PR TITLE
Fixed the test failure on Power and x86

### DIFF
--- a/dali/test/python/test_operator_python_function.py
+++ b/dali/test/python/test_operator_python_function.py
@@ -425,7 +425,7 @@ SINK_PATH = tempfile.mkdtemp()
 
 
 def save(image):
-    Image.fromarray(image).save(SINK_PATH + '/sink_img' + str(time.clock()) + '.jpg', 'JPEG')
+    Image.fromarray(image).save(SINK_PATH + '/sink_img' + str(time.process_time()) + '.jpg', 'JPEG')
 
 
 def test_sink():


### PR DESCRIPTION
Fixes test_operator_python_function's test_sink test case that tries to process a few jpg images in a pipeline and saves into the temp directory. Test was failing because it was not saving the same  number of files as that of BATCH_SIZE which is 8.

Signed-off-by: 

It fixes a bug in test_operator_python_function

What solution was applied:
As a fix, I replaced time.clock() function with time.process_time() as the former one is warned as deprecated.

Affected modules and functionalities:
test_operator_python_function test
Key points relevant for the review:
test
Validation and testing:
CI
Documentation (including examples):
NA
Related to #1750 

JIRA TASK: [NA]
Fixes the issue -> https://github.com/NVIDIA/DALI/issues/1750