### PR TITLE
Add /usr/local/cuda/bin to PATH in the main Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ ENV PYVER=${PYVER} PYV=${PYV} PYTHONPATH=/opt/python/v
 ENV PYBIN=${PYTHONPATH}/bin \
     PYLIB=${PYTHONPATH}/lib
 
-ENV PATH=${PYBIN}:${PATH} \
+ENV PATH=/usr/local/cuda/bin:${PYBIN}:${PATH} \
     LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:/opt/dali/${DALI_BUILD_DIR}:${PYLIB}:${LD_LIBRARY_PATH} \
     LIBRARY_PATH=/usr/local/cuda/lib64/stubs:/opt/dali/${DALI_BUILD_DIR}:${PYLIB}:${LIBRARY_PATH}
 


### PR DESCRIPTION
- different build steps use images created from docker/Dockerfile
  so the path to nvcc should be set there instead of build-specific
  buil_helpers.sh

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a lack of setting path to NVCC in docker/Dockerfile. Static analysis was not working due to this

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     sets path to NVCC in docker/Dockerfile
 - Affected modules and functionalities:
     docker/Dockerfile
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI build
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
