### PR TITLE
Fix a race condition in AsyncPipelinedExecutor destructor

### DIFF
--- a/dali/pipeline/executor/async_pipelined_executor.h
+++ b/dali/pipeline/executor/async_pipelined_executor.h
@@ -91,15 +91,15 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
       PipelinedExecutor::Outputs(ws);
     } catch (std::exception &e) {
       exec_error_ = true;
+      SignalStop();
       mixed_work_cv_.notify_all();
       gpu_work_cv_.notify_all();
-      SignalStop();
       throw;
     } catch (...) {
       exec_error_ = true;
+      SignalStop();
       mixed_work_cv_.notify_all();
       gpu_work_cv_.notify_all();
-      SignalStop();
       throw std::runtime_error("Unknown critical error in pipeline");
     }
   }
@@ -113,7 +113,6 @@ class DLL_PUBLIC AsyncPipelinedExecutor : public PipelinedExecutor {
 
   WorkerThread cpu_thread_, mixed_thread_, gpu_thread_;
   int cpu_work_counter_ = 0, mixed_work_counter_ = 0, gpu_work_counter_ = 0;
-  std::mutex cpu_mutex_, mixed_mutex_, gpu_mutex_;
   std::condition_variable mixed_work_cv_, gpu_work_cv_;
   int device_id_;
 };

--- a/dali/pipeline/executor/queue_policy.h
+++ b/dali/pipeline/executor/queue_policy.h
@@ -163,6 +163,10 @@ struct UniformQueuePolicy {
     free_cond_.notify_all();
   }
 
+  std::mutex& GetReadyMutex() {
+    return ready_mutex_;
+  }
+
   void SignalStop() {
     {
       std::lock_guard<std::mutex> lock(ready_mutex_);
@@ -346,6 +350,10 @@ struct SeparateQueuePolicy {
     }
   }
 
+  std::mutex& GetReadyMutex() {
+    return ready_output_mutex_;
+  }
+
   void SignalStop() {
     {
       std::lock_guard<std::mutex> lock(ready_output_mutex_);
@@ -414,7 +422,7 @@ struct SeparateQueuePolicy {
 
   std::condition_variable ready_output_cv_, free_cond_;
   // Output ready and in_use mutexes and queues
-  std::mutex ready_output_mutex_, in_use_mutex_;
+  std::mutex ready_output_mutex_;
 
   std::queue<OutputIdxs> ready_output_queue_;
   std::queue<OutputIdxs> in_use_queue_;


### PR DESCRIPTION
- there is a race condition in AsyncPipelinedExecutor which leads to signaling and notifying a conditional to stop a thread after the signal is checked and before the thread goes to sleep on this conditional. In effect, signal is missed as well as the notification so thread sleeps infinitely causing a hang
- adds common mutex guard to check of signal in the AsyncPipelinedExecutor
- removes cpu, mixed and gpu mutexes in the favor of one from QueuePolicy

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a a race condition in AsyncPipelinedExecutor destructor

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds common mutex guard to check of signal in the AsyncPipelinedExecutor
     removes cpu, mixed and gpu mutexes in the favor of one from QueuePolicy
 - Affected modules and functionalities:
     AsyncPipelinedExecutor
 - Key points relevant for the review:
     synchronization
 - Validation and testing:
     present tests applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[ NA]*
