### PR TITLE
Fix out of range detection in __get_item__ for TensorList

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -225,11 +225,12 @@ void ExposeTensor(py::module &m) {
 
 template <typename Backend>
 std::unique_ptr<Tensor<Backend> > TensorListGetItemImpl(TensorList<Backend> &t, Index id) {
+  int num_tensors = static_cast<int>(t.ntensor());
   if (id < 0) {
-    int num_tensors = static_cast<int>(t.ntensor());
-    if (id < -num_tensors)
-      throw py::index_error("TensorListCPU index out of range");
     id = num_tensors + id;
+  }
+  if (id >= num_tensors || id < 0) {
+      throw py::index_error("TensorListCPU index out of range");
   }
   std::unique_ptr<Tensor<Backend>> ptr(new Tensor<Backend>());
   ptr->ShareData(&t, id);

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -15,6 +15,7 @@
 from nvidia.dali.backend_impl import *
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
+from nose.tools import assert_raises
 
 def test_create_tensor():
     arr = np.random.rand(3, 5, 6)
@@ -43,11 +44,17 @@ def test_empty_tensor_tensorlist():
 def test_tensorlist_getitem():
     arr = np.random.rand(3, 5, 6)
     tensorlist = TensorListCPU(arr, "NHWC")
+    list_of_tensors = [x for x in tensorlist]
+
     assert(type(tensorlist.at(0)) == np.ndarray)
     assert(type(tensorlist[0]) != np.ndarray)
     assert(type(tensorlist[0]) == TensorCPU)
     assert(type(tensorlist[-3]) == TensorCPU)
-
+    assert(len(list_of_tensors) == len(tensorlist))
+    with assert_raises(IndexError):
+        tensorlist[len(tensorlist)]
+    with assert_raises(IndexError):
+        tensorlist[-len(tensorlist) - 1]
 
 #if 0  // TODO(spanev): figure out which return_value_policy to choose
 #def test_tensorlist_getitem_slice():


### PR DESCRIPTION
- __get_item__ was not checking the range for positive `i` values
- reworks the TensorListGetItemImpl logic to check it for any `i` value
- adds more tests to cover __get_item__

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a out of range detection in __get_item__ for TensorList

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     __get_item__ was not checking the range for positive `i` values
    reworks the TensorListGetItemImpl logic to check it for any `i` value
 - Affected modules and functionalities:
     backend_impl
 - Key points relevant for the review:
     index range check
 - Validation and testing:
     tests added
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
