### PR TITLE
Enable XLA for TensorFlow RN50 tests

### DIFF
--- a/docs/examples/use_cases/tensorflow/resnet-n/nvutils/cmdline.py
+++ b/docs/examples/use_cases/tensorflow/resnet-n/nvutils/cmdline.py
@@ -93,6 +93,13 @@ def parse_cmdline(init_vals, custom_parser=None):
     p.add_argument('--dali_cpu', action='store_true',
                    default=False,
                    help="""Use CPU backend for DALI for input pipeline.""")
+    xgrp = p.add_mutually_exclusive_group()
+    xgrp.add_argument('--use_xla', action='store_const',
+                      default=True, const=True, dest='use_xla',
+                      help="""Enable xla execution.""")
+    xgrp.add_argument('--no_xla', action='store_const',
+                      const=False, dest='use_xla',
+                      help="""Disable xla execution.""")
     p.add_argument('--epoch_evaluation', action='store_true',
                    default=False,
                    help="""Additionally runs the evaluation after every epoch.""")
@@ -128,6 +135,8 @@ def parse_cmdline(init_vals, custom_parser=None):
     del FLAGS.precision
     vals['dali_cpu'] = FLAGS.dali_cpu
     del FLAGS.dali_cpu
+    vals['use_xla'] = FLAGS.use_xla
+    del FLAGS.use_xla
     vals['epoch_evaluation'] = FLAGS.epoch_evaluation
     del FLAGS.epoch_evaluation
 

--- a/docs/examples/use_cases/tensorflow/resnet-n/nvutils/runner.py
+++ b/docs/examples/use_cases/tensorflow/resnet-n/nvutils/runner.py
@@ -185,6 +185,7 @@ def train(infer_func, params):
     iter_unit = params['iter_unit']
     dali_cpu = params['dali_cpu']
     epoch_evaluation = params['epoch_evaluation']
+    use_xla = params['use_xla']
 
     # Determinism is not fully supported by all TF ops.
     # Disabling until remaining wrinkles can be ironed out.
@@ -224,6 +225,9 @@ def train(infer_func, params):
     # Horovod: pin GPU to be used to process local rank (one GPU per process)
     gpu_options = GPUOptions(per_process_gpu_memory_fraction=0.7)
     config = ConfigProto(gpu_options=gpu_options)
+    if use_xla:
+         config.graph_options.optimizer_options.global_jit_level = (
+             tf.OptimizerOptions.ON_1)
     #config.gpu_options.allow_growth = True
     config.gpu_options.visible_device_list = str(hvd.local_rank())
     config.gpu_options.force_gpu_compatible = True # Force pinned memory

--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -63,7 +63,7 @@ test_body() {
         python -u resnet.py --layers=18 \
         --data_dir=/data/imagenet/train-val-tfrecord-480-subset --data_idx_dir=idx-files/ \
         --precision=fp16 --num_iter=100  --iter_unit=batch --display_every=50 \
-        --batch=256 --dali_cpu --log_dir=dali_log
+        --batch=256 --dali_cpu --use_xla --log_dir=dali_log
 }
 
 pushd ../..

--- a/qa/TL3_RN50_convergence/test_mxnet.sh
+++ b/qa/TL3_RN50_convergence/test_mxnet.sh
@@ -8,7 +8,9 @@ NUM_GPUS=`nvidia-smi -L | wc -l`
 # Fix deprecations, we need to fix that for the older FW containers version
 sed -i "s/nvJPEGDecoder/ImageDecoder/" /opt/mxnet/example/image-classification/common/dali.py
 
-python /opt/mxnet/example/image-classification/train_imagenet_runner -b 208 -n $NUM_GPUS --seed 42 2>&1 | tee dali.log
+python /opt/mxnet/example/image-classification/train_imagenet_runner \
+       --data-root=/data/imagenet/train-val-recordio-passthrough/ -b 208 \
+       -n $NUM_GPUS --seed 42 2>&1 | tee dali.log
 
 cat dali.log  | grep -o "Validation-accuracy=0\.[0-9]*" > tmp2.log
 cat dali.log  | grep -o "Speed: [0-9]*\.[0-9]*" > tmp3.log

--- a/qa/TL3_RN50_convergence/test_tensorflow.sh
+++ b/qa/TL3_RN50_convergence/test_tensorflow.sh
@@ -25,8 +25,8 @@ SECONDS=0
 mpiexec --allow-run-as-root --bind-to socket -np ${NUM_GPUS} \
     python -u resnet.py --layers=50 \
     --data_dir=$DATA_SET_DIR --data_idx_dir=idx-files/ \
-    --precision=fp16   --num_iter=90  --iter_unit=epoch --display_every=50 \
-    --batch=256 --dali_cpu --log_dir=$OUT \
+    --precision=fp16 --num_iter=90 --iter_unit=epoch --display_every=50 \
+    --batch=256 --use_xla --log_dir=$OUT \
     2>&1 | tee $LOG
 
 RET=${PIPESTATUS[0]}
@@ -38,7 +38,7 @@ fi
 
 MIN_TOP1=75.0
 MIN_TOP5=92.0
-MIN_PERF=6000
+MIN_PERF=10000
 
 TOP1=$(grep "^Top-1" $LOG | awk '{print $3}')
 TOP5=$(grep "^Top-5" $LOG | awk '{print $3}')


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds XLA enable flag for RN50 DALI example for TensorFlow
- It makes MXNet RN50 test using passthrough ImageNet data

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     enables XLA for TensorFlow RN50 tests
     makes MXNet RN50 test using passthrough ImageNet data
 - Affected modules and functionalities:
    TensorFlow test and RN50 example
    MXNet RN50 test
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI test
 - Documentation (including examples):
     NA

**JIRA TASK**: *[DALI-1287]*
