### PR TITLE
Allow align-only behavior in Pad operator by treating shape argument as minimum shape

### DIFF
--- a/dali/operators/generic/pad.cc
+++ b/dali/operators/generic/pad.cc
@@ -23,8 +23,9 @@ namespace dali {
 
 DALI_SCHEMA(Pad)
   .DocStr(R"code(Pads all samples with `fill_value` in the given `axes`,
-to match the size of the biggest dimension on those axes in the batch.
-The element padding axes is specified with the argument `axes`.
+to match the biggest extent in the batch for those axes, or to match the minimum `shape`
+specified.
+
 Supported types are integer and floating point numeric types.
 
 Examples:
@@ -129,15 +130,15 @@ Arguments *axis_names* and *axes* are mutually exclusive.
 If *axes* and *axis_names* are empty or not provided, the output will be padded on all the axes)code",
     "")
   .AddOptionalArg<int>("align",
-    R"code(If specified, determines the alignment on those dimensions that are padded. That is,
-the padded length on `axis = axes[i]` should be a multiple of `align[i]`. If a single integer value
-is provided, the alignment restrictions are applied to all the padded axes.
-If a non-negative value for *shape* is specified, the alignment shall be ignored on that axis)code",
+    R"code(If specified, determines the alignment on those dimensions specified by *axes* or
+*axis_names*. That is, the extent on `axis = axes[i]` will be adjusted to be a multiple of `align[i]`.
+If a single integer value is provided, the alignment restrictions are applied to all the padded axes.)code",
     std::vector<int>())
   .AddOptionalArg<int>("shape",
-    R"code(The extents of the output shape in the axes specified by *axes* or *axis_names*;
-specifying -1 for an axis restores the default behavior of extending the axis to accommodate the
-(aligned) size of the largest sample in the batch)code",
+    R"code(The extents of the output shape in the axes specified by *axes* or *axis_names*.
+Specifying -1 for an axis restores the default behavior of extending the axis to accommodate the
+(aligned) size of the largest sample in the batch. If the provided extent is smaller than the one
+of the sample, no padding will be applied.)code",
     vector<int>());
 
 template <>

--- a/dali/operators/generic/pad.cc
+++ b/dali/operators/generic/pad.cc
@@ -47,10 +47,12 @@ Examples:
 
   input  = [[3,   4,   2,   5,   4],
             [2,   2],
-            [3, 199,   5]];
+            [3, 199,   5],
+            [1,   2,   3,   4,   5,   6,   7,   8]];
   output = [[3,   4,   2,   5,   4,  -1,  -1],
             [2,   2,  -1,  -1,  -1,  -1,  -1],
-            [3, 199,   5,  -1,  -1,  -1,  -1]]
+            [3, 199,   5,  -1,  -1,  -1,  -1],
+            [1,   2,   3,   4,   5,   6,   7,   8]]
 
 - `1-D` samples, `fill_value` = -1, `axes` = (0,), `align` = (4,)
 
@@ -63,6 +65,16 @@ Examples:
             [2,   2,  -1,  -1,  -1,  -1,  -1,  -1],
             [3, 199,   5,  -1,  -1,  -1,  -1,  -1]]
 
+- `1-D` samples, `fill_value` = -1, `axes` = (0,), `shape` = (1,), `align` = (2,)
+
+::
+
+  input  = [[3,   4,   2,   5,   4],
+            [2,   2],
+            [3, 199,   5]];
+  output = [[3,   4,   2,   5,   4,  -1],
+            [2,   2],
+            [3, 199,   5,  -1]]
 
 - `2-D` samples, `fill_value` = 42, `axes` = (1,)
 
@@ -138,7 +150,7 @@ If a single integer value is provided, the alignment restrictions are applied to
     R"code(The extents of the output shape in the axes specified by *axes* or *axis_names*.
 Specifying -1 for an axis restores the default behavior of extending the axis to accommodate the
 (aligned) size of the largest sample in the batch. If the provided extent is smaller than the one
-of the sample, no padding will be applied.)code",
+of the sample, no padding will be applied, except what is needed to match required alignment.)code",
     vector<int>());
 
 template <>


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to allow Pad operator to pad each sample independently to match a specified alignment configuration without having to pad all the samples to the same shape

Example:
input shape: [ 4x5, 5x11 ]
axes [1]
align [3]
Old behavior output shape  [ 4x12, 5x12 ]
New behavior output shape [4x6, 5x12]

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Changed the meaning of the `shape` argument to be interpreted as minimum shape. That is, if a given sample has a larger shape than the one specified by this argument, no padding shall be applied to that sample. The user can then use shape=(1,) and align=(4,) to achieve per sample alignment without the need to pad all samples to match the shape of the largest*

 - Affected modules and functionalities:
     *Pad operator*
 - Key points relevant for the review:
     *Pad operator logic and tests*
 - Validation and testing:
     *Test adjusted, new test case added*
 - Documentation (including examples):
     *Adjusted documentation of the operator*

**JIRA TASK**: *[Use DALI-1280]*
