### PR TITLE
Add data layouts documentation

### DIFF
--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -358,9 +358,10 @@ class DLL_PUBLIC OpSchema {
   DLL_PUBLIC inline const TensorLayout &GetInputLayout(int index, int sample_ndim,
                                                        const TensorLayout &layout = {}) const {
     CheckInputIndex(index);
+    DALI_ENFORCE(layout.empty() || layout.ndim() == sample_ndim, make_string(
+      "The layout '", layout, "' is not valid for ", sample_ndim, "-dimensional tensor"));
+
     if (input_layouts_[index].empty()) {
-      DALI_ENFORCE(layout.empty() || layout.ndim() == sample_ndim,
-        "The layout for the input has different number of dimensions than actual input");
       return layout;
     }
 
@@ -385,6 +386,11 @@ class DLL_PUBLIC OpSchema {
         ss << l.c_str() << "\n";
       DALI_FAIL(ss.str());
     }
+  }
+
+  DLL_PUBLIC inline const std::vector<TensorLayout> &GetSupportedLayouts(int input_idx) const {
+    CheckInputIndex(input_idx);
+    return input_layouts_[input_idx];
   }
 
   /**

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1015,7 +1015,8 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("IsInternal", &OpSchema::IsInternal)
     .def("IsNoPrune", &OpSchema::IsNoPrune)
     .def("IsDeprecated", &OpSchema::IsDeprecated)
-    .def("DeprecatedInFavorOf", &OpSchema::DeprecatedInFavorOf);
+    .def("DeprecatedInFavorOf", &OpSchema::DeprecatedInFavorOf)
+    .def("GetSupportedLayouts", &OpSchema::GetSupportedLayouts);
 
   ExposeTensorLayout(types_m);
   ExposeTensor(m);

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -206,6 +206,11 @@ Keyword args
     ret += _get_kwargs(schema)
     return ret
 
+def _supported_layouts_str(supported_layouts):
+    if len(supported_layouts) == 0:
+        return ""
+    return " (" + ", ".join(["\'" + str(layout) + "\'" for layout in supported_layouts]) + ")"
+
 def _docstring_prefix_from_inputs(op_name):
     """
         Generate start of the docstring for `__call__` of Operator `op_name`
@@ -225,7 +230,8 @@ Args
 """
     for i in range(schema.MaxNumInput()):
         optional = i >= schema.MinNumInput()
-        ret += _numpydoc_formatter(schema.GetInputName(i), schema.GetInputType(i), schema.GetInputDox(i), optional)
+        input_type_str = schema.GetInputType(i) + _supported_layouts_str(schema.GetSupportedLayouts(i))
+        ret += _numpydoc_formatter(schema.GetInputName(i), input_type_str, schema.GetInputDox(i), optional)
         ret += "\n"
     ret += "\n"
     return ret
@@ -242,15 +248,17 @@ def _docstring_prefix_auto(op_name):
 Operator call to be used in `define_graph` step. This operator does not accept any TensorList inputs.
 """
     elif schema.MaxNumInput() == 1:
-        return """__call__(data, **kwargs)
+        ret = """__call__(data, **kwargs)
 
 Operator call to be used in `define_graph` step.
 
 Args
 ----
-`data`: TensorList
-    Input to the operator.
 """
+        dox = "Input to the operator.\n"
+        fmt  = "TensorList" + _supported_layouts_str(schema.GetSupportedLayouts(0))
+        ret += _numpydoc_formatter("data", fmt, dox, optional=False)
+        return ret
     return ""
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -37,6 +37,10 @@ TensorListGPU
    :special-members: __getitem__
 
 
+.. _layout_str_doc:
+Data Layouts
+------------
+.. include:: data_layout.rst
 
 Types
 -----
@@ -79,4 +83,3 @@ PipelineAPIType
 .. autoclass:: nvidia.dali.types.PipelineAPIType
    :members:
    :undoc-members:
-

--- a/docs/data_layout.rst
+++ b/docs/data_layout.rst
@@ -1,0 +1,57 @@
+Tensor Layout String format
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+DALI uses short strings (Python `str` type) to describe data layout in tensors, by assigning a
+character to each of the dimensions present in the tensor shape. For example, shape=(400, 300, 3),
+layout="HWC" means that the data is an image with 3 interleaved channels, 400 pixels of height and
+300 pixels of width.
+
+For TensorLists, the index in the list is not treated as a dimension (the number of sample in the
+batch) and is not included in the layout.
+
+Interpreting Tensor Layout Strings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+DALI allows you to process data of different nature (e.g. image, video, audio, volumetric images)
+as well as different formats (e.g. RGB image in planar configuration vs. interleaved channels).
+Typically, DALI operators can deal with different data formats and will behave in different way
+depending on the nature of the input.
+
+While we do not restrict the valid characters to be used in a tensor layout, DALI operators
+assume a certain naming convention. Here is a list of commonly used dimension names:
+
+============== ==============
+   Name           Meaning
+============== ==============
+   H              Height
+   W              Width
+   C              Channels
+   F              Frames
+   D              Depth
+============== ==============
+
+Here are some examples of typically used layouts:
+
+============== ======================
+   Layout         Description
+============== ======================
+   HWC            Image (interleaved)
+   CHW            Image (planar)
+   DHWC           Volumetric Image (interleaved)
+   CDHW           Volumetric Image (planar)
+   FHWC           Video
+============== ======================
+
+For instance, a crop operation (`Crop` operator) receiving an input with interleaved layout
+(`"HWC"`) will infer that it should crop on the first and second dimensions `(H, W)`. On the
+other hand, if the input has a planar layout (`"CHW"`) the crop will take place on the second and
+third dimensions instead.
+
+Some operators inherently modify the layout of the data (e.g. `Transpose`), while others
+propagate the same data layout to the output (e.g. `Normalize`).
+
+The layout restrictions (if any) for each operator are available through the operator's
+documentation.
+
+It is worth to note that the user is responsible to explicitly fill in the layout information
+when using `ExternalSource` API.


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It adds documentation to TensorLayout and its usage in DALI

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added expected input data layout information to each operator documentation*
 - Affected modules and functionalities:
     *Docs of all operators*
 - Key points relevant for the review:
     *Changes in the documentation*
 - Validation and testing:
     *Pre-existing tests*
 - Documentation (including examples):
     *TODO*


**JIRA TASK**: *[DALI-1278]*
