### PR TITLE
Add Reinterpret operator as a flavor of Reshape

### DIFF
--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -51,6 +51,20 @@ DALI_SCHEMA(Reshape)
                   "the output.",
                   "");
 
+DALI_SCHEMA(Reinterpret)
+  .DocStr(R"code(Treats content of the input as if it had a different type, shape or layout.)code")
+  .NumInput(1, 2)
+  .NumOutput(1)
+  .InputDox(0, "data", "TensorList", "Data to be reshaped")
+  .InputDox(1, "shape", "1D TensorList of integers", "Same as `shape` keyword argument")
+  .PassThrough({{0, 0}})
+  .AllowSequences()
+  .SupportVolumetric()
+  .AddOptionalArg("dtype", "The desired output type. The total size in bytes of the output "
+                  "must match the input. If no shape is provided, the innermost dimension is "
+                  "adjusted accordingly. If the byte size of the innermost dimension is not "
+                  "divisible by the size of the target type, an error is thrown.", DALI_NO_TYPE)
+  .AddParent("Reshape");
 
 template <typename Backend>
 Reshape<Backend>::Reshape(const OpSpec &spec) : Base(spec) {
@@ -58,10 +72,22 @@ Reshape<Backend>::Reshape(const OpSpec &spec) : Base(spec) {
   bool has_shape_arg = spec.HasArgument("shape") || spec.HasTensorArgument("shape");
   bool has_layout_arg = spec.HasArgument("layout");
   bool has_rel_shape_arg = spec.HasArgument("rel_shape") || spec.HasTensorArgument("rel_shape");
-  DALI_ENFORCE(has_shape_input + has_shape_arg + has_rel_shape_arg <= 1,
-    "Reshape: shape input, `shape` argument and `rel_shape` argument are mutually exclusive");
-  DALI_ENFORCE(has_shape_input || has_shape_arg || has_rel_shape_arg || has_layout_arg,
-    "Reshape is no-op: arguments specify neither new shape nor layout.");
+  if (spec.HasArgument("dtype"))
+    output_type_ = spec.GetArgument<DALIDataType>("dtype");
+  DALI_ENFORCE(has_shape_input + has_shape_arg + has_rel_shape_arg <= 1, make_string(OpName(),
+    ": shape input, `shape` argument and `rel_shape` argument are mutually exclusive"));
+
+  bool does_reshape = has_shape_input || has_shape_arg || has_rel_shape_arg || has_layout_arg;
+  if (!has_shape_input && !has_shape_arg && !has_rel_shape_arg && !has_layout_arg) {
+    bool can_have_dtype = spec.GetSchema().HasArgument("dtype");
+    if (can_have_dtype) {
+      DALI_ENFORCE(output_type_ != DALI_NO_TYPE, make_string(OpName(),
+                   " is no-op: arguments specify neither new shape, layout nor type."));
+    } else {
+      DALI_FAIL(make_string(OpName(),
+                " is no-op: arguments specify neither new shape nor layout."));
+    }
+  }
   use_layout_ = has_layout_arg;
   use_rel_shape_ = false;
   if (has_shape_arg) {
@@ -69,18 +95,20 @@ Reshape<Backend>::Reshape(const OpSpec &spec) : Base(spec) {
       shape_source_ = ShapeSource::ArgInput;
     } else {
       auto shape_vec = spec.GetRepeatedArgument<int>("shape");
-      DALI_ENFORCE(!shape_vec.empty(), "Reshape: `shape` specified as an empty list");
+      DALI_ENFORCE(!shape_vec.empty(),
+                   make_string(OpName(), ": `shape` specified as an empty list"));
+
       uniform_shape_.resize(shape_vec.size());
       int num_negative = 0;
       for (int i = 0; i < uniform_shape_.sample_dim(); i++) {
         if (shape_vec[i] < 0) {
-          DALI_ENFORCE(++num_negative == 1, make_string(
-            "Reshape: Only one negative extent is allowed; got: ", uniform_shape_));
+          DALI_ENFORCE(++num_negative == 1, make_string(OpName(),
+            ": Only one negative extent is allowed; got: ", uniform_shape_));
           uniform_shape_[i] = 0;
           wildcard_dim_ = i;
         } else {
-          DALI_ENFORCE(shape_vec[i] != 0, "Reshape: extent of 0 is illegal; got: " +
-              to_string(uniform_shape_));
+          DALI_ENFORCE(shape_vec[i] != 0, make_string(OpName(), ": extent of 0 is illegal; got: ",
+              uniform_shape_));
           uniform_shape_[i] = shape_vec[i];
         }
       }
@@ -92,22 +120,25 @@ Reshape<Backend>::Reshape(const OpSpec &spec) : Base(spec) {
       shape_source_ = ShapeSource::ArgInput;
     } else {
       rel_uniform_shape_ = spec.GetRepeatedArgument<float>("rel_shape");
-      DALI_ENFORCE(!rel_uniform_shape_.empty(), "Reshape: `rel_shape` specified as an empty list");
+      DALI_ENFORCE(!rel_uniform_shape_.empty(), make_string(OpName(),
+                   ": `rel_shape` specified as an empty list"));
       int num_negative = 0;
       int out_dims = rel_uniform_shape_.size();
       for (int i = 0; i < out_dims; i++) {
         if (rel_uniform_shape_[i] < 0) {
-          DALI_ENFORCE(++num_negative == 1, make_string(
-            "Reshape: Only one negative extent is allowed; got: ", uniform_shape_));
+          DALI_ENFORCE(++num_negative == 1, make_string(OpName(),
+            ": Only one negative extent is allowed; got: ", uniform_shape_));
           wildcard_dim_ = i;
         } else {
-          DALI_ENFORCE(rel_uniform_shape_[i] != 0, "Reshape: zero extent is illegal");
+          DALI_ENFORCE(rel_uniform_shape_[i] != 0,
+                       make_string(OpName(), ": zero extent is illegal"));
         }
       }
       shape_source_ = ShapeSource::Arg;
     }
   } else if (has_shape_input) {
-    DALI_ENFORCE(spec.InputDevice(1) == "cpu", "Output shapes must be provided as a CPU input");
+    DALI_ENFORCE(spec.InputDevice(1) == "cpu",
+                 make_string(OpName(), ": Output shapes must be provided as a CPU input"));
     shape_source_ = ShapeSource::Input;
   }
   if (has_layout_arg) {
@@ -132,13 +163,13 @@ void Reshape<Backend>::ShapeFromInput(
       const TensorListView<StorageCPU, Extent> &shape) {
   constexpr bool relative = std::is_floating_point<Extent>::value;
   DALI_ENFORCE(shape.sample_dim() == 1 || (shape.sample_dim() == 2 && shape.num_samples() == 1),
-    "Reshape: shape input must be a list of 1D tensors or a single 2D tensor");
+    make_string(OpName(), ": shape input must be a list of 1D tensors or a single 2D tensor"));
   if (shape.sample_dim() == 2) {
     auto shape_tensor = shape[0];
     int N = shape_tensor.shape[0];
-    DALI_ENFORCE(N == input_shape_.num_samples(),
-      "Reshape: the new shape mush have same number of samples. Got " +
-      to_string(output_shape_.num_samples()) + ", expected " + to_string(N));
+    DALI_ENFORCE(N == input_shape_.num_samples(), make_string(OpName(),
+      ": the new shape mush have same number of samples. Got ",
+      output_shape_.num_samples(), ", expected ", N));
     int dim = shape_tensor.shape[1];
     output_shape_.resize(N, dim);
     for (int i = 0; i < N; i++) {
@@ -151,8 +182,8 @@ void Reshape<Backend>::ShapeFromInput(
   } else {
     int N = shape.num_samples();
     DALI_ENFORCE(N == input_shape_.num_samples(),
-      "Reshape: the new shape mush have same number of samples. Got " +
-      to_string(output_shape_.num_samples()) + ", expected " + to_string(N));
+      make_string(OpName(), ": the new shape mush have same number of samples. Got ",
+      output_shape_.num_samples(), ", expected ", N));
     int sample_dim;
     for (int i = 0; i < N; i++) {
       int current_sample_dim = shape.tensor_shape_span(i)[0];
@@ -161,7 +192,7 @@ void Reshape<Backend>::ShapeFromInput(
         output_shape_.resize(N, sample_dim);
       } else {
         DALI_ENFORCE(current_sample_dim == sample_dim,
-          "Reshape: all samples must have the same number of dimensions");
+          make_string(OpName(), ": all samples must have the same number of dimensions"));
       }
 
       for (int d = 0; d < sample_dim; d++) {
@@ -182,15 +213,16 @@ void Reshape<Backend>::ShapeFromInput(const TensorListLike &tl, bool relative) {
     TYPE_SWITCH(tl.type().id(), type2id, type,
       (int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t),
       (this->ShapeFromInput(view<const type>(tl));),
-      (DALI_FAIL("Reshape: shape input must have integral type; got: " + tl.type().name() +
-                " (id = " + to_string(static_cast<int>(tl.type().id())) + ")");)
+      (DALI_FAIL(make_string(OpName(), ": shape input must have integral type; got: ",
+                 tl.type().name(), " (id = ", static_cast<int>(tl.type().id()), ")"));)
     );  // NOLINT
   }
 }
 
 template <typename Backend>
 void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
-  input_shape_ = ws.template InputRef<Backend>(0).shape();
+  auto &in = ws.template InputRef<Backend>(0);
+  input_shape_ = in.shape();
   const int N = input_shape_.num_samples();
   switch (shape_source_) {
     case ShapeSource::Arg:
@@ -219,8 +251,13 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
       break;
     case ShapeSource::None:
       output_shape_ = input_shape_;
-      return;
+      break;
   }
+
+  int64_t input_element_size = in.type().size();
+  int64_t output_element_size = output_type_ != DALI_NO_TYPE
+      ? TypeTable::GetTypeInfo(output_type_).size()
+      : in.type().size();
 
   if (shape_source_ != ShapeSource::None) {
     for (int i = 0; i < N; i++) {
@@ -230,7 +267,8 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
       if (shape_source_ != ShapeSource::Arg) {
         for (int d = 0; d < out_sample_shape.size(); d++)
           if (out_sample_shape[d] < 0) {
-            DALI_ENFORCE(wildcard_dim < 0, "Only one dimension can have negative extent");
+            DALI_ENFORCE(wildcard_dim < 0,
+                         make_string(OpName(), ": Only one dimension can have negative extent"));
             wildcard_dim = d;
           }
       }
@@ -240,17 +278,29 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
         auto other_dims_volume = volume(out_sample_shape);
         // try to make wildcard dim match the input volume - if it fails,
         // volume comparison will fail
-        out_sample_shape[wildcard_dim] = actual_volume / other_dims_volume;
+        out_sample_shape[wildcard_dim] = (actual_volume * input_element_size) /
+                                         (other_dims_volume * output_element_size);
       }
 
       auto requested_volume = volume(out_sample_shape);
-      DALI_ENFORCE(actual_volume == requested_volume,
-        make_string(
-          "Reshape: Input and output samples should have the same number of elements."
+      DALI_ENFORCE(actual_volume * input_element_size == requested_volume * output_element_size,
+        make_string(OpName(),
+          ": Input and output samples must occupy the same size in bytes."
           "\nSample index:     ", i,
           "\nActual volume:    ", actual_volume,
+          "\n     in bytes:    ", actual_volume * input_element_size,
           "\nRequested volume: ", requested_volume,
+          "\n     in bytes:    ", requested_volume * output_element_size,
           "\nRequested shape:  ", output_shape_[i]));
+    }
+  } else if (output_element_size != input_element_size) {
+    for (int i = 0; i < N; i++) {
+      auto out_sample_shape = output_shape_.tensor_shape_span(i);
+      auto &innermost = out_sample_shape[output_shape_.sample_dim()-1];
+      DALI_ENFORCE((innermost * input_element_size) % output_element_size == 0,
+        make_string(OpName(), ": the size, in bytes, of the innermost dimension is not divisible "
+        "by the sizes of the requested output type."));
+      innermost = innermost * input_element_size / output_element_size;
     }
   }
 }
@@ -258,9 +308,9 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
 template <typename Backend>
 TensorLayout Reshape<Backend>::GetOutputLayout(const Workspace &ws) const {
   if (!layout_.empty()) {
-    DALI_ENFORCE(output_shape_.sample_dim() == layout_.ndim(), "Reshape: requested layout '" +
-      layout_.str() + "' is not compatible with a " +
-      to_string(output_shape_.sample_dim()) + "D shape");
+    DALI_ENFORCE(output_shape_.sample_dim() == layout_.ndim(), make_string(OpName(),
+      ": requested layout '", layout_, "' is not compatible with a ",
+      output_shape_.sample_dim(), "D shape"));
     return layout_;
   } else if (use_layout_) {
     // layout was explicitly cleared
@@ -276,7 +326,10 @@ void Reshape<CPUBackend>::RunImpl(HostWorkspace &ws) {
   auto &in = ws.InputRef<CPUBackend>(0);
   TensorLayout layout = GetOutputLayout(ws);
   out.ShareData(&in);
-  out.Resize(output_shape_);
+  const TypeInfo &type = output_type_ != DALI_NO_TYPE
+      ? TypeTable::GetTypeInfo(output_type_)
+      : in.type();
+  out.Resize(output_shape_, type);
   int N = output_shape_.num_samples();
   for (int i = 0; i < N; i++) {
     assert(out[i].raw_data() == in[i].raw_data());
@@ -292,7 +345,10 @@ void Reshape<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   TensorLayout layout = GetOutputLayout(ws);
   out.Reset();
   out.ShareData(&in);
-  out.Resize(output_shape_);
+  const TypeInfo &type = output_type_ != DALI_NO_TYPE
+      ? TypeTable::GetTypeInfo(output_type_)
+      : in.type();
+  out.Resize(output_shape_, type);
   int N = output_shape_.num_samples();
   for (int i = 0; i < N; i++) {
     assert(out.raw_tensor(i) == in.raw_tensor(i));
@@ -302,6 +358,7 @@ void Reshape<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
 
 DALI_REGISTER_OPERATOR(Reshape, Reshape<CPUBackend>, CPU);
 DALI_REGISTER_OPERATOR(Reshape, Reshape<GPUBackend>, GPU);
-
+DALI_REGISTER_OPERATOR(Reinterpret, Reshape<CPUBackend>, CPU);
+DALI_REGISTER_OPERATOR(Reinterpret, Reshape<GPUBackend>, GPU);
 
 }  // namespace namespace dali

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -61,7 +61,8 @@ class Reshape : public Operator<Backend> {
   ShapeSource shape_source_ = ShapeSource::None;
   bool use_rel_shape_ = false;
   int wildcard_dim_ = -1;
-  DALIDataType output_type_ = DALI_NO_TYPE;
+  DALIDataType output_type_id_ = DALI_NO_TYPE;
+  const TypeInfo *output_type_ = nullptr;
 
   void CalculateOutputShape(const Workspace &ws);
 

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -15,6 +15,7 @@
 #ifndef DALI_OPERATORS_GENERIC_RESHAPE_H_
 #define DALI_OPERATORS_GENERIC_RESHAPE_H_
 
+#include <string>
 #include <vector>
 
 #include "dali/pipeline/operator/operator.h"
@@ -46,6 +47,9 @@ class Reshape : public Operator<Backend> {
   std::vector<float> rel_uniform_shape_;
   TensorLayout layout_;
   bool use_layout_ = false;
+  inline const std::string &OpName() const {
+    return this->spec_.name();
+  }
 
   enum class ShapeSource {
     None,
@@ -57,6 +61,7 @@ class Reshape : public Operator<Backend> {
   ShapeSource shape_source_ = ShapeSource::None;
   bool use_rel_shape_ = false;
   int wildcard_dim_ = -1;
+  DALIDataType output_type_ = DALI_NO_TYPE;
 
   void CalculateOutputShape(const Workspace &ws);
 

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -297,10 +297,15 @@ class DLL_PUBLIC Buffer {
 
   // Helper to resize the underlying allocation
   inline void ResizeHelper(Index new_size) {
+    ResizeHelper(new_size, type_);
+  }
+
+  // Helper to resize the underlying allocation
+  inline void ResizeHelper(Index new_size, const TypeInfo &new_type) {
     DALI_ENFORCE(new_size >= 0, "Input size less than zero not supported.");
 
     // If we use NoType the result will always be 0
-    size_t new_num_bytes = new_size * type_.size();
+    size_t new_num_bytes = new_size * new_type.size();
 
     if (shares_data_) {
       DALI_ENFORCE(new_num_bytes <= num_bytes_,
@@ -309,6 +314,10 @@ class DLL_PUBLIC Buffer {
     }
 
     size_ = new_size;
+    type_ = new_type;
+
+    if (shares_data_)
+      return;
 
     if (new_size == 0) {
       if (std::is_same<Backend, GPUBackend>::value && device_ == -1) {

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -179,7 +179,7 @@ class DLL_PUBLIC Buffer {
    * @brief Returns the TypeInfo object that keeps track of the
    * datatype of the underlying storage.
    */
-  inline TypeInfo type() const {
+  inline const TypeInfo &type() const {
     return type_;
   }
 

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -43,10 +43,6 @@ template <typename Backend>
 class Tensor : public Buffer<Backend> {
  public:
   inline Tensor() {}
-  explicit inline Tensor(int batch_size) {
-    // We only set the size, but not the type. Pinned status can still be set
-    Resize({batch_size});
-  }
   inline ~Tensor() override = default;
 
 
@@ -147,6 +143,18 @@ class Tensor : public Buffer<Backend> {
   inline void Resize(const TensorShape<> &shape) {
     Index new_size = volume(shape);
     ResizeHelper(new_size);
+    shape_ = shape;
+  }
+
+  /**
+   * @brief Resizes the buffer to fit `volume(shape)` of new_type elements.
+   * The underlying storage is only reallocated in the case that
+   * the current buffer is not large enough for the requested
+   * number of elements.
+   */
+  inline void Resize(const TensorShape<> &shape, const TypeInfo &new_type) {
+    Index new_size = volume(shape);
+    ResizeHelper(new_size, new_type);
     shape_ = shape;
   }
 

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -128,6 +128,15 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
    * list.
    */
   DLL_PUBLIC inline void Resize(const TensorListShape<> &new_shape) {
+    Resize(new_shape, type_);
+  }
+
+  /**
+   * @brief Resize function to allocate a list of tensors. The input vector
+   * contains a set of dimensions for each tensor to be allocated in the
+   * list.
+   */
+  DLL_PUBLIC inline void Resize(const TensorListShape<> &new_shape, const TypeInfo &new_type) {
     if (new_shape == shape_) return;
 
     // Calculate the new size
@@ -143,7 +152,7 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     DALI_ENFORCE(new_size >= 0, "Invalid negative buffer size.");
 
     // Resize the underlying allocation and save the new shape
-    ResizeHelper(new_size);
+    ResizeHelper(new_size, new_type);
     shape_ = new_shape;
 
     // Tensor views of this TensorList is no longer valid

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -162,7 +162,7 @@ class TensorVector {
     }
   }
 
-  inline TypeInfo type() const {
+  inline const TypeInfo &type() const {
     if (state_ == State::contiguous) {
       return tl_->type();
     }

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -128,6 +128,10 @@ class TensorVector {
   }
 
   DLL_PUBLIC inline void Resize(const TensorListShape<> &new_shape) {
+    return Resize(new_shape, type());
+  }
+
+  DLL_PUBLIC inline void Resize(const TensorListShape<> &new_shape, const TypeInfo &new_type) {
     // N.B. There probably is nothing wrong with adjusting batchsize for give TensorVector
     // (sparse tensor list), but the semantics of what type and pinned status should
     // the new elements have or having some of them allocated and the new ones not
@@ -138,12 +142,12 @@ class TensorVector {
       allocate_tensors(new_shape.size());
     }
     if (state_ == State::contiguous) {
-      tl_->Resize(new_shape);
+      tl_->Resize(new_shape, new_type);
       UpdateViews();
       return;
     }
     for (int i = 0; i < new_shape.size(); i++) {
-      tensors_[i]->Resize(new_shape[i]);
+      tensors_[i]->Resize(new_shape[i], new_type);
     }
   }
 
@@ -153,7 +157,9 @@ class TensorVector {
     for (auto t : tensors_) {
       t->set_type(new_type);
     }
-    UpdateViews();
+    if (state_ == State::contiguous) {
+      UpdateViews();
+    }
   }
 
   inline TypeInfo type() const {

--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -41,7 +41,7 @@ TypeTable &TypeTable::instance() {
 
 template <>
 void TypeInfo::Copy<CPUBackend, CPUBackend>(void *dst,
-    const void *src, Index n, cudaStream_t /* unused */) {
+    const void *src, Index n, cudaStream_t /* unused */) const {
   // Call our copy function
   copier_(dst, src, n);
 }
@@ -49,19 +49,19 @@ void TypeInfo::Copy<CPUBackend, CPUBackend>(void *dst,
 // For any GPU related copy, we do a plain memcpy
 template <>
 void TypeInfo::Copy<CPUBackend, GPUBackend>(void *dst,
-    const void *src, Index n, cudaStream_t stream) {
+    const void *src, Index n, cudaStream_t stream) const {
   MemCopy(dst, src, n*size(), stream);
 }
 
 template <>
 void TypeInfo::Copy<GPUBackend, CPUBackend>(void *dst,
-    const void *src, Index n, cudaStream_t stream) {
+    const void *src, Index n, cudaStream_t stream) const {
   MemCopy(dst, src, n*size(), stream);
 }
 
 template <>
 void TypeInfo::Copy<GPUBackend, GPUBackend>(void *dst,
-    const void *src, Index n, cudaStream_t stream) {
+    const void *src, Index n, cudaStream_t stream) const {
   MemCopy(dst, src, n*size(), stream);
 }
 

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -232,7 +232,7 @@ class DLL_PUBLIC TypeInfo {
   DLL_PUBLIC inline void SetType(DALIDataType dtype = DALI_NO_TYPE);
 
   template <typename DstBackend, typename SrcBackend>
-  DLL_PUBLIC void Copy(void *dst, const void *src, Index n, cudaStream_t stream);
+  DLL_PUBLIC void Copy(void *dst, const void *src, Index n, cudaStream_t stream) const;
 
   DLL_PUBLIC inline DALIDataType id() const {
     return id_;

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -207,9 +207,9 @@ def test_reshape_arg_input():
         for use_wildcard in [False, True]:
            yield check_reshape_with_arg_input, device, batch_size, relative, use_wildcard
 
-class ReinterpretPipeline1(Pipeline):
+class ReinterpretPipelineWithDefaultShape(Pipeline):
     def __init__(self, device, batch_size, num_threads=3, device_id=0, num_gpus=1):
-        super(ReinterpretPipeline1, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=True, exec_pipelined=True)
+        super(ReinterpretPipelineWithDefaultShape, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=True, exec_pipelined=True)
         self.device = device
         self.ext_src = ops.ExternalSource()
         self.reinterpret = ops.Reinterpret(device = device, dtype = types.INT32)
@@ -233,10 +233,10 @@ class ReinterpretPipeline1(Pipeline):
         self.feed_input(self.input, data)
 
 
-def _test_reinterpret_default(device):
+def _test_reinterpret_default_shape(device):
     np.random.seed(31337)
     batch_size = 4
-    pipe = ReinterpretPipeline1(device, batch_size)
+    pipe = ReinterpretPipelineWithDefaultShape(device, batch_size)
     pipe.build()
     pipe_outs = pipe.run()
     in_batch = pipe_outs[0].as_cpu() if device == "gpu" else pipe_outs[0]
@@ -246,14 +246,14 @@ def _test_reinterpret_default(device):
         out = out_batch.at(i)
         assert_array_equal(ref, out)
 
-def test_reinterpret_default():
+def test_reinterpret_default_shape():
     for device in ["cpu", "gpu"]:
-        yield _test_reinterpret_default, device
+        yield _test_reinterpret_default_shape, device
 
 
-class ReinterpretPipeline2(Pipeline):
+class ReinterpretPipelineWildcardDim(Pipeline):
     def __init__(self, device, batch_size, num_threads=3, device_id=0, num_gpus=1):
-        super(ReinterpretPipeline2, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=True, exec_pipelined=True)
+        super(ReinterpretPipelineWildcardDim, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=True, exec_pipelined=True)
         self.device = device
         self.ext_src = ops.ExternalSource()
         self.reinterpret = ops.Reinterpret(device = device, shape = (20, 2), dtype = types.INT32)
@@ -273,10 +273,10 @@ class ReinterpretPipeline2(Pipeline):
         self.feed_input(self.input, data)
 
 
-def _test_reinterpret_with_wildcard_shape(device):
+def _test_reinterpret_wildcard_shape(device):
     np.random.seed(31337)
     batch_size = 4
-    pipe = ReinterpretPipeline2(device, batch_size)
+    pipe = ReinterpretPipelineWildcardDim(device, batch_size)
     pipe.build()
     pipe_outs = pipe.run()
     in_batch = pipe_outs[0].as_cpu() if device == "gpu" else pipe_outs[0]
@@ -286,9 +286,9 @@ def _test_reinterpret_with_wildcard_shape(device):
         out = out_batch.at(i)
         assert_array_equal(ref, out)
 
-def test_reinterpret_with_wildcard_shape():
+def test_reinterpret_wildcard_shape():
     for device in ["cpu", "gpu"]:
-        yield _test_reinterpret_with_wildcard_shape, device
+        yield _test_reinterpret_wildcard_shape, device
 
 
 def main():

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -233,7 +233,7 @@ class ReinterpretPipeline1(Pipeline):
         self.feed_input(self.input, data)
 
 
-def _test_reinterpret1(device):
+def _test_reinterpret_default(device):
     np.random.seed(31337)
     batch_size = 4
     pipe = ReinterpretPipeline1(device, batch_size)
@@ -248,7 +248,7 @@ def _test_reinterpret1(device):
 
 def test_reinterpret_default():
     for device in ["cpu", "gpu"]:
-        yield _test_reinterpret1, device
+        yield _test_reinterpret_default, device
 
 
 class ReinterpretPipeline2(Pipeline):
@@ -288,7 +288,7 @@ def _test_reinterpret_with_wildcard_shape(device):
 
 def test_reinterpret_with_wildcard_shape():
     for device in ["cpu", "gpu"]:
-        yield _test_reinterpret1, device
+        yield _test_reinterpret_with_wildcard_shape, device
 
 
 def main():

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -207,12 +207,100 @@ def test_reshape_arg_input():
         for use_wildcard in [False, True]:
            yield check_reshape_with_arg_input, device, batch_size, relative, use_wildcard
 
+class ReinterpretPipeline1(Pipeline):
+    def __init__(self, device, batch_size, num_threads=3, device_id=0, num_gpus=1):
+        super(ReinterpretPipeline1, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=True, exec_pipelined=True)
+        self.device = device
+        self.ext_src = ops.ExternalSource()
+        self.reinterpret = ops.Reinterpret(device = device, dtype = types.INT32)
+
+    def define_graph(self):
+        input = self.input = self.ext_src()
+        if self.device == "gpu":
+          input = input.gpu()
+        reinterpreted = self.reinterpret(input)
+
+        # `input+0` creates a (no-op) arithmetic expression node - this prevents the
+        # original `input` node from being marked as pipeline output
+        return [input, reinterpreted]
+
+    def iter_setup(self):
+        data = []
+        for i in range(self.batch_size):
+            shape = np.random.randint(4, 20, size = [2])
+            shape[1] &= -4  # align to 4
+            data.append(np.random.randint(0, 255, shape, dtype = np.uint8))
+        self.feed_input(self.input, data)
+
+
+def _test_reinterpret1(device):
+    np.random.seed(31337)
+    batch_size = 4
+    pipe = ReinterpretPipeline1(device, batch_size)
+    pipe.build()
+    pipe_outs = pipe.run()
+    in_batch = pipe_outs[0].as_cpu() if device == "gpu" else pipe_outs[0]
+    out_batch = pipe_outs[1].as_cpu() if device == "gpu" else pipe_outs[1]
+    for i in range(batch_size):
+        ref = in_batch.at(i).view(dtype = np.int32)
+        out = out_batch.at(i)
+        assert_array_equal(ref, out)
+
+def test_reinterpret_default():
+    for device in ["cpu", "gpu"]:
+        yield _test_reinterpret1, device
+
+
+class ReinterpretPipeline2(Pipeline):
+    def __init__(self, device, batch_size, num_threads=3, device_id=0, num_gpus=1):
+        super(ReinterpretPipeline2, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=True, exec_pipelined=True)
+        self.device = device
+        self.ext_src = ops.ExternalSource()
+        self.reinterpret = ops.Reinterpret(device = device, shape = (20, 2), dtype = types.INT32)
+
+    def define_graph(self):
+        input = self.input = self.ext_src()
+        if self.device == "gpu":
+          input = input.gpu()
+        reinterpreted = self.reinterpret(input)
+
+        # `input+0` creates a (no-op) arithmetic expression node - this prevents the
+        # original `input` node from being marked as pipeline output
+        return [input, reinterpreted]
+
+    def iter_setup(self):
+        data = [np.random.randint(0, 255, [10, 16], dtype = np.uint8) for i in range(self.batch_size)]
+        self.feed_input(self.input, data)
+
+
+def _test_reinterpret_with_wildcard_shape(device):
+    np.random.seed(31337)
+    batch_size = 4
+    pipe = ReinterpretPipeline2(device, batch_size)
+    pipe.build()
+    pipe_outs = pipe.run()
+    in_batch = pipe_outs[0].as_cpu() if device == "gpu" else pipe_outs[0]
+    out_batch = pipe_outs[1].as_cpu() if device == "gpu" else pipe_outs[1]
+    for i in range(batch_size):
+        ref = in_batch.at(i).view(dtype = np.int32).reshape([20, 2])
+        out = out_batch.at(i)
+        assert_array_equal(ref, out)
+
+def test_reinterpret_with_wildcard_shape():
+    for device in ["cpu", "gpu"]:
+        yield _test_reinterpret1, device
+
+
 def main():
   for test in test_reshape_arg():
     test[0](*test[1:])
   for test in test_reshape_input():
     test[0](*test[1:])
   for test in test_reshape_arg_input():
+    test[0](*test[1:])
+  for test in test_reinterpret_default():
+    test[0](*test[1:])
+  for test in test_reinterpret_with_wildcard_shape():
     test[0](*test[1:])
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add Reinterpret operator as a flavor of Reshape
* `dtype` argument specifies target type
* Output shape is adjusted by default in the innermost dimension
* Wildcard shape calculation includes the type size ratio
* Add tests

Changes required to make it work:
* Add `Resize(new_shape, new_type)` to TensorList, TensorVector and Tensor and Buffer

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to reinterpret TFRecord data

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
    Add Reinterpret operator as a flavor of Reshape
      * `dtype` argument specifies target type
      * Output shape is adjusted by default in the innermost dimension
      * Wildcard shape calculation includes the type size ratio
      * Add tests
    Changes required to make it work:
      * Add `Resize(new_shape, new_type)` to TensorList, TensorVector and Tensor and Buffer
       - Affected modules and functionalities:
 - Key points relevant for the review:
     * ?
 - Validation and testing:
     * python test
 - Documentation (including examples):
     * docstring

**JIRA TASK**: DALI-1301
