### PR TITLE
Bump up OpenCV version to 4.3.0, libturbo-jpeg to 2.0.4, libtiff to 4.1.0, FFmpeg to 4.2.2

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -60,7 +60,7 @@ requirements:
     - python
     - future >=0.17.1
     - protobuf >=3.11.2
-    - libjpeg-turbo >=1.5
+    - libjpeg-turbo >=2.0.3
     - ffmpeg >=4.1
     - tensorflow-gpu
     - libopencv >=3.4.1
@@ -73,7 +73,7 @@ requirements:
     - python
     - future >=0.17.1
     - protobuf >=3.11.2
-    - libjpeg-turbo >=1.5
+    - libjpeg-turbo >=2.0.3
     - ffmpeg >=4.1
     - tensorflow-gpu
     - libopencv >=3.4.1

--- a/docker/Dockerfile.build.aarch64-linux
+++ b/docker/Dockerfile.build.aarch64-linux
@@ -61,7 +61,7 @@ RUN cd /protobuf-${PROTOBUF_VERSION} && make clean \
 
 
 # libjpeg-turbo
-RUN JPEG_TURBO_VERSION=2.0.2 && \
+RUN JPEG_TURBO_VERSION=2.0.4 && \
     curl -L https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${JPEG_TURBO_VERSION}.tar.gz | tar -xzf - && \
     cd libjpeg-turbo-${JPEG_TURBO_VERSION} && \
     echo "set(CMAKE_SYSTEM_NAME  Linux)" > toolchain.cmake && \
@@ -79,9 +79,8 @@ RUN JPEG_TURBO_VERSION=2.0.2 && \
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install 2>&1 >/dev/null && \
     rm -rf /libjpeg-turbo-${JPEG_TURBO_VERSION}
 
-
 # libtiff
-RUN LIBTIFF_VERSION=4.0.10 && \
+RUN LIBTIFF_VERSION=4.1.0 && \
     cd /tmp && \
     curl -L http://download.osgeo.org/libtiff/tiff-${LIBTIFF_VERSION}.tar.gz | tar -xzf - && \
     cd tiff-${LIBTIFF_VERSION} && \
@@ -99,8 +98,8 @@ RUN LIBTIFF_VERSION=4.0.10 && \
     rm -rf /tmp/tiff-${LIBTIFF_VERSION}
 
 # OpenCV
-ENV OPENCV_VERSION=3.4.3
-RUN curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf - && \
+RUN OPENCV_VERSION=4.3.0 && \
+    curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf - && \
     cd /opencv-${OPENCV_VERSION} && mkdir build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_TOOLCHAIN_FILE=$PWD/../platforms/linux/aarch64-gnu.toolchain.cmake \
@@ -112,7 +111,9 @@ RUN curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | 
           -DBUILD_TBB=OFF \
           -DBUILD_WEBP=OFF \
           -DBUILD_JPEG=OFF \
+          -DBUILD_TIFF=OFF \
           -DWITH_JPEG=ON \
+          -DWITH_TIFF=ON \
           -DBUILD_JASPER=OFF \
           -DBUILD_ZLIB=ON \
           -DBUILD_EXAMPLES=OFF \

--- a/docker/Dockerfile.build.aarch64-qnx
+++ b/docker/Dockerfile.build.aarch64-qnx
@@ -77,7 +77,7 @@ RUN cd /protobuf-${PROTOBUF_VERSION} && make clean \
     rm -rf /protobuf-${PROTOBUF_VERSION}
 
 # libjpeg-turbo
-RUN JPEG_TURBO_VERSION=2.0.2 && \
+RUN JPEG_TURBO_VERSION=2.0.4 && \
     curl -L https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${JPEG_TURBO_VERSION}.tar.gz | tar -xzf - && \
     cd libjpeg-turbo-${JPEG_TURBO_VERSION} && \
     echo "set(CMAKE_SYSTEM_NAME  Linux)" > toolchain.cmake && \
@@ -96,7 +96,7 @@ RUN JPEG_TURBO_VERSION=2.0.2 && \
     rm -rf /libjpeg-turbo-${JPEG_TURBO_VERSION}
 
 # libtiff
-RUN LIBTIFF_VERSION=4.0.10 && \
+RUN LIBTIFF_VERSION=4.1.0 && \
     cd /tmp && \
     curl -L http://download.osgeo.org/libtiff/tiff-${LIBTIFF_VERSION}.tar.gz | tar -xzf - && \
     cd tiff-${LIBTIFF_VERSION} && \
@@ -114,9 +114,9 @@ RUN LIBTIFF_VERSION=4.0.10 && \
     rm -rf /tmp/tiff-${LIBTIFF_VERSION}
 
 # OpenCV
-ENV OPENCV_VERSION=3.4.3
 COPY docker/opencv-qnx.patch /opencv-qnx.patch
-RUN curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf - && \
+RUN OPENCV_VERSION=4.3.0 && \
+    curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf - && \
     cd /opencv-${OPENCV_VERSION} && git apply /opencv-qnx.patch \
     && mkdir build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release \

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -53,7 +53,7 @@ RUN LMDB_VERSION=0.9.22 && \
     rm -rf /lmdb
 
 # libjpeg-turbo
-RUN JPEG_TURBO_VERSION=2.0.2 && \
+RUN JPEG_TURBO_VERSION=2.0.4 && \
     curl -L https://github.com/libjpeg-turbo/libjpeg-turbo/archive/${JPEG_TURBO_VERSION}.tar.gz | tar -xzf - && \
     cd libjpeg-turbo-${JPEG_TURBO_VERSION} && \
     cmake -G"Unix Makefiles" -DENABLE_SHARED=TRUE -DCMAKE_INSTALL_PREFIX=/usr/local . 2>&1 >/dev/null && \
@@ -63,7 +63,7 @@ RUN JPEG_TURBO_VERSION=2.0.2 && \
 # libtiff
 # Note: libtiff should be built with support for zlib. If running this step alone on a custom
 #       system, zlib should be installed first
-RUN LIBTIFF_VERSION=4.0.10 && \
+RUN LIBTIFF_VERSION=4.1.0 && \
     cd /tmp && \
     curl -L http://download.osgeo.org/libtiff/tiff-${LIBTIFF_VERSION}.tar.gz | tar -xzf - && \
     cd tiff-${LIBTIFF_VERSION} && \
@@ -75,7 +75,7 @@ RUN LIBTIFF_VERSION=4.0.10 && \
     rm -rf /tmp/tiff-${LIBTIFF_VERSION}
 
 # OpenCV
-RUN OPENCV_VERSION=3.4.3 && \
+RUN OPENCV_VERSION=4.3.0 && \
     curl -L https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.tar.gz | tar -xzf - && \
     cd /opencv-${OPENCV_VERSION} && mkdir build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=/usr/local \
@@ -99,7 +99,7 @@ RUN CLANG_VERSION=6.0.1 && \
 ENV NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
 
 # FFmpeg
-RUN FFMPEG_VERSION=4.2.1 && \
+RUN FFMPEG_VERSION=4.2.2 && \
     cd /tmp && wget https://developer.download.nvidia.com/compute/redist/nvidia-dali/ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
     tar xf ffmpeg-$FFMPEG_VERSION.tar.bz2 && \
     rm ffmpeg-$FFMPEG_VERSION.tar.bz2 && \

--- a/docker/opencv-qnx.patch
+++ b/docker/opencv-qnx.patch
@@ -1,8 +1,21 @@
+diff --git a/3rdparty/libjasper/jasper/jas_stream.h b/3rdparty/libjasper/jasper/jas_stream.h
+index 6862329921..a3cfac504b 100644
+--- a/3rdparty/libjasper/jasper/jas_stream.h
++++ b/3rdparty/libjasper/jasper/jas_stream.h
+@@ -254,6 +254,8 @@ typedef struct {
+     int flags;
+ #if defined _WIN32 && !defined __MINGW__ && !defined __MINGW32__
+     char pathname[MAX_PATH + 1];
++#elif defined __AARCH64_QNX__
++    char pathname[_POSIX_PATH_MAX + 1];
+ #else
+     char pathname[PATH_MAX + 1];
+ #endif
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6c53bf8..c58514b 100644
+index 4c0b3880fc..999b9127fd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -588,6 +588,8 @@ if(UNIX)
+@@ -635,6 +635,8 @@ if(UNIX)
        set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} m pthread)
      elseif(EMSCRIPTEN)
        # no need to link to system libs with emscripten
@@ -11,9 +24,44 @@ index 6c53bf8..c58514b 100644
      else()
        set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} dl m pthread rt)
      endif()
+diff --git a/modules/core/src/parallel.cpp b/modules/core/src/parallel.cpp
+index 09ee3bb6de..af87a69116 100644
+--- a/modules/core/src/parallel.cpp
++++ b/modules/core/src/parallel.cpp
+@@ -946,7 +946,7 @@ int getNumberOfCPUs_()
+ 
+ #endif
+ 
+-#if !defined(_WIN32) && !defined(__APPLE__)
++#if !defined(_WIN32) && !defined(__APPLE__) && !defined(__AARCH64_QNX__)
+ 
+     static unsigned cpu_count_sysconf = (unsigned)sysconf( _SC_NPROCESSORS_ONLN );
+     ncpus = minNonZero(ncpus, cpu_count_sysconf);
+diff --git a/modules/core/src/system.cpp b/modules/core/src/system.cpp
+index 872019dd9e..06dc32ae82 100644
+--- a/modules/core/src/system.cpp
++++ b/modules/core/src/system.cpp
+@@ -787,7 +787,7 @@ int64 getTickCount(void)
+     LARGE_INTEGER counter;
+     QueryPerformanceCounter( &counter );
+     return (int64)counter.QuadPart;
+-#elif defined __linux || defined __linux__
++#elif defined __linux || defined __linux__ || defined __AARCH64_QNX__
+     struct timespec tp;
+     clock_gettime(CLOCK_MONOTONIC, &tp);
+     return (int64)tp.tv_sec*1000000000 + tp.tv_nsec;
+@@ -806,7 +806,7 @@ double getTickFrequency(void)
+     LARGE_INTEGER freq;
+     QueryPerformanceFrequency(&freq);
+     return (double)freq.QuadPart;
+-#elif defined __linux || defined __linux__
++#elif defined __linux || defined __linux__ || defined __AARCH64_QNX__
+     return 1e9;
+ #elif defined __MACH__ && defined __APPLE__
+     static double freq = 0;
 diff --git a/platforms/qnx/aarch64-qnx.toolchain.cmake b/platforms/qnx/aarch64-qnx.toolchain.cmake
 new file mode 100644
-index 0000000..efbf4a0
+index 0000000000..eeb8f71a6d
 --- /dev/null
 +++ b/platforms/qnx/aarch64-qnx.toolchain.cmake
 @@ -0,0 +1,58 @@
@@ -75,26 +123,3 @@ index 0000000..efbf4a0
 +  message(WARNING "You use obsolete variable USE_VFPV3 to enable VFPV3 instruction set. Use -DENABLE_VFPV3=ON instead." )
 +  set(ENABLE_VFPV3 TRUE)
 +endif()
-diff --git a/modules/core/src/system.cpp b/modules/core/src/system.cpp
-index 1ebd993a2..a745f8fa2 100644
---- a/modules/core/src/system.cpp
-+++ b/modules/core/src/system.cpp
-@@ -702,7 +702,7 @@ int64 getTickCount(void)
-     LARGE_INTEGER counter;
-     QueryPerformanceCounter( &counter );
-     return (int64)counter.QuadPart;
--#elif defined __linux || defined __linux__
-+#elif defined __linux || defined __linux__ || defined __AARCH64_QNX__
-     struct timespec tp;
-     clock_gettime(CLOCK_MONOTONIC, &tp);
-     return (int64)tp.tv_sec*1000000000 + tp.tv_nsec;
-@@ -722,7 +722,7 @@ double getTickFrequency(void)
-     LARGE_INTEGER freq;
-     QueryPerformanceFrequency(&freq);
-     return (double)freq.QuadPart;
--#elif defined __linux || defined __linux__
-+#elif defined __linux || defined __linux__ || defined __AARCH64_QNX__
-     return 1e9;
- #elif defined __MACH__ && defined __APPLE__
-     static double freq = 0;
-

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -76,28 +76,28 @@ Prerequisites
 .. _protobuf link: https://github.com/google/protobuf
 .. |cmake link| replace:: **CMake 3.12**
 .. _cmake link: https://cmake.org
-.. |jpegturbo link| replace:: **libjpeg-turbo 1.5.x**
+.. |jpegturbo link| replace:: **libjpeg-turbo 2.0.4 (2.0.3 for conda due to availability)**
 .. _jpegturbo link: https://github.com/libjpeg-turbo/libjpeg-turbo
-.. |libtiff link| replace:: **libtiff 4.0.x**
+.. |libtiff link| replace:: **libtiff 4.1.0**
 .. _libtiff link: http://libtiff.org/
-.. |ffmpeg link| replace:: **FFmpeg 4.2.1**
-.. _ffmpeg link: https://developer.download.nvidia.com/compute/redist/nvidia-dali/ffmpeg-4.2.1.tar.bz2
+.. |ffmpeg link| replace:: **FFmpeg 4.2.2**
+.. _ffmpeg link: https://developer.download.nvidia.com/compute/redist/nvidia-dali/ffmpeg-4.2.2.tar.bz2
 .. |libsnd link| replace:: **libsnd 1.0.28**
 .. _libsnd link: https://developer.download.nvidia.com/compute/redist/nvidia-dali/libsndfile-1.0.28.tar.gz
-.. |opencv link| replace:: **OpenCV 3**
+.. |opencv link| replace:: **OpenCV 4**
 .. _opencv link: https://opencv.org
 .. |lmdb link| replace:: **liblmdb 0.9.x**
 .. _lmdb link: https://github.com/LMDB/lmdb
-.. |gcc link| replace:: **GCC 5.3**
+.. |gcc link| replace:: **GCC 5.3.1**
 .. _gcc link: https://www.gnu.org/software/gcc/
 .. |boost link| replace:: **Boost 1.66**
 .. _boost link: https://www.boost.org/
 
-.. |mxnet link| replace:: **MXNet 1.3**
+.. |mxnet link| replace:: **MXNet 1.5**
 .. _mxnet link: http://mxnet.incubator.apache.org
-.. |pytorch link| replace:: **PyTorch 0.4**
+.. |pytorch link| replace:: **PyTorch 1.1**
 .. _pytorch link: https://pytorch.org
-.. |tf link| replace:: **TensorFlow 1.7**
+.. |tf link| replace:: **TensorFlow 1.12**
 .. _tf link: https://www.tensorflow.org
 
 
@@ -126,11 +126,11 @@ Prerequisites
    | |libtiff link|_ or later               | *This can be unofficially disabled. See below.*                                             |
    |                                        | Note: libtiff should be built with zlib support                                             |
    +----------------------------------------+---------------------------------------------------------------------------------------------+
-   | |ffmpeg link|_ or later                | We recommend using version 4.2.1 compiled following the *instructions below*.               |
+   | |ffmpeg link|_ or later                | We recommend using version 4.2.2 compiled following the *instructions below*.               |
    +----------------------------------------+---------------------------------------------------------------------------------------------+
    | |libsnd link|_ or later                | We recommend using version 1.0.28 compiled following the *instructions below*.              |
    +----------------------------------------+---------------------------------------------------------------------------------------------+
-   | |opencv link|_ or later                | Supported version: 3.4                                                                      |
+   | |opencv link|_ or later                | Supported version: 4.3.0                                                                    |
    +----------------------------------------+---------------------------------------------------------------------------------------------+
    | (Optional) |lmdb link|_ or later       |                                                                                             |
    +----------------------------------------+---------------------------------------------------------------------------------------------+


### PR DESCRIPTION
- bumps up OpenCV to the latest version 4.3.0
- conda build is not updated as prebuild OpenCV (4.2.0 at most) binaries
  don't have bug opencv/opencv#16265 fixed
- updates docs regarding libturbo-jpeg and OpenCV version
- bumps libturbo-jpeg to 2.0.4 (2.0.3 for conda due to availability)
- bumps libtiff to 4.1.0
- bumps FFmpeg to 4.2.2

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
- It fixes a bug with the wrong version of required libturbo-jpeg in docs
- It adds new feature needed because of we want to have latest OpenCV, libtiff, libturbo-jpeg and FFmpeg

#### What happened in this PR?
 - What solution was applied:
     bumps up OpenCV,  libturbo-jpeg, libtiff and FFmpeg to the latest version
     updates docs regarding libturbo-jepeg, libtiff, OpenCV and FFmpeg version
 - Affected modules and functionalities:
     compilation of deps for x86, aarch64-linux and aarch64-qnx
 - Key points relevant for the review:
     NA
 - Validation and testing:
     test build in CI
 - Documentation (including examples):
     compilation doc is updated

**JIRA TASK**: [NA]
