### PR TITLE
Fix DALI TF plugin build

### DIFF
--- a/docker/Dockerfile.customopbuilder.clean
+++ b/docker/Dockerfile.customopbuilder.clean
@@ -15,8 +15,10 @@ ENV PYV=${PYV}
 # Python 3.6 and 3.7 are not available in Ubuntu 14
 # Python 3.7 can't be installed with PPA method in this Ubuntu 14
 # NOTE: jonathonf has removed his PPAs, but TensorFlow still has the repo in its docker image
-RUN rm -rf /etc/apt/sources.list.d/jonathonf-* \
-    apt-get update && \
+# NOTE: Ubuntu 14.04 doesn't support cyphers used by developer.download.nvidia.com, and update returns warning on them
+#       so "update; do_something" instead of "update && do_something"
+RUN rm -rf /etc/apt/sources.list.d/jonathonf-* && \
+    apt-get update; \
     apt-get install -y --no-install-recommends curl && \
     if [ "${PYVER}" = "3.7" ]; then \
         apt-get install -y --no-install-recommends libffi-dev && \


### PR DESCRIPTION
- it seems that developer.download.nvidia.com no longer accepts supported cyphering methods in ubuntu 14.04 which is still used by us to build DALI TF plugins
- removes all references to developer.download.nvidia.com from the source list to make `apt-get update` working again

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a DALI TF plugin build

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     removes all references to developer.download.nvidia.com from the source list to make `apt-get update` working again
 - Affected modules and functionalities:
     DALI TF plugin build
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CUDA 10 build
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
