### PR TITLE
Fix layout usage in ExternalSource example

### DIFF
--- a/docs/examples/general/data_loading/external_input.ipynb
+++ b/docs/examples/general/data_loading/external_input.ipynb
@@ -118,7 +118,7 @@
     "\n",
     "    def iter_setup(self):\n",
     "        (images, labels) = iterator.next()\n",
-    "        self.feed_input(self.jpegs, images, layout=\"HWC\")\n",
+    "        self.feed_input(self.jpegs, images)\n",
     "        self.feed_input(self.labels, labels)"
    ]
   },


### PR DESCRIPTION
- ExternalSource example is loading raw images and should not use layout for this

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a layout usage in ExternalSource example

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
    ExternalSource example is loading raw images and should not use layout for this
 - Affected modules and functionalities:
     ExternalSource example
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     ExternalSource example is updated

In response to https://github.com/NVIDIA/DALI/issues/1795

**JIRA TASK**: *[NA]*
