### PR TITLE
Fix positional argument propagation in TF Dataset

### DIFF
--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -259,8 +259,8 @@ if dataset_compatible_tensorflow():
   if _get_tf_version() < StrictVersion('2.0'):
     class DALIDataset(dataset_ops.DatasetV1Adapter):
       @functools.wraps(_DALIDatasetV2.__init__)
-      def __init__(self, **kwargs):
-        wrapped = _DALIDatasetV2(**kwargs)
+      def __init__(self, pipeline, **kwargs):
+        wrapped = _DALIDatasetV2(pipeline, **kwargs)
         super(DALIDataset, self).__init__(wrapped)
   else:
     DALIDataset = _DALIDatasetV2

--- a/dali/test/python/test_dali_tf_dataset.py
+++ b/dali/test/python/test_dali_tf_dataset.py
@@ -158,7 +158,7 @@ def test_different_num_shapes_dtypes():
     dataset_pipeline = TestPipeline(batch_size, num_threads, 'cpu')
     shapes = (
         (batch_size, 3, 224, 224),
-        (batch_size, 1),
+        (batch_size, 1, 1),
         (batch_size, 1))
     dtypes = (
         tf.float32,
@@ -180,7 +180,7 @@ def _test_tf_dataset_multigpu():
 
     shapes = (
         (batch_size, 3, 224, 224),
-        (batch_size, 1),
+        (batch_size, 1, 1),
         (batch_size, 1))
     dtypes = (
         tf.float32,

--- a/dali/test/python/test_dali_tf_dataset.py
+++ b/dali/test/python/test_dali_tf_dataset.py
@@ -156,13 +156,13 @@ def test_different_num_shapes_dtypes():
     num_threads = 4
 
     dataset_pipeline = TestPipeline(batch_size, num_threads, 'cpu')
-    shapes = [
+    shapes = (
         (batch_size, 3, 224, 224),
         (batch_size, 1),
-        (batch_size, 1)]
-    dtypes = [
+        (batch_size, 1))
+    dtypes = (
         tf.float32,
-        tf.float32]
+        tf.float32)
 
     with tf.device('/cpu:0'):
         dali_tf.DALIDataset(
@@ -178,14 +178,14 @@ def _test_tf_dataset_multigpu():
     batch_size = 8
     num_threads = 4
 
-    shapes = [
+    shapes = (
         (batch_size, 3, 224, 224),
         (batch_size, 1),
-        (batch_size, 1)]
-    dtypes = [
+        (batch_size, 1))
+    dtypes = (
         tf.float32,
         tf.int32,
-        tf.int16]
+        tf.int16)
 
     dataset_results = []
     initializers = [tf.compat.v1.global_variables_initializer()]
@@ -255,14 +255,14 @@ class PythonOperatorPipeline(Pipeline):
 @raises(RuntimeError)
 def test_python_operator_error():
     dataset_pipeline = PythonOperatorPipeline()
-    shapes = [(1, 3, 3, 3)]
-    dtypes = [tf.float32]
+    shapes = ((1, 3, 3, 3))
+    dtypes = (tf.float32)
 
     with tf.device('/cpu:0'):
         daliset = dali_tf.DALIDataset(
             pipeline=dataset_pipeline,
             batch_size=1,
-            shapes=shapes,
-            dtypes=dtypes,
+            output_shapes=shapes,
+            output_dtypes=dtypes,
             num_threads=1,
             device_id=0)

--- a/dali/test/python/test_dali_tf_dataset_shape.py
+++ b/dali/test/python/test_dali_tf_dataset_shape.py
@@ -14,6 +14,12 @@ from nose.tools import assert_equals, raises
 import itertools
 import warnings
 
+try:
+    tf.compat.v1.enable_eager_execution()
+except:
+    pass
+
+
 data_path = os.path.join(os.environ['DALI_EXTRA_PATH'], 'db/single/jpeg/')
 file_list_path = os.path.join(data_path, 'image_list.txt')
 


### PR DESCRIPTION
The change was not propagated to versions < 2.0

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fixes a bug in TF Dataset

#### What happened in this PR?
 - What solution was applied:
	The constructor wrapper was adjusted to use one positional argument.
 - Affected modules and functionalities:
	TF Plugin/Dataset
 - Key points relevant for the review:
	As above
 - Validation and testing:
	CI
 - Documentation (including examples):
	NA


**JIRA TASK**: *[NA]*
