### PR TITLE
Propagate layout in Cast operator

### DIFF
--- a/dali/operators/generic/cast.cc
+++ b/dali/operators/generic/cast.cc
@@ -26,6 +26,7 @@ void Cast<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   DALIDataType itype = input.type().id();
 
   TYPE_SWITCH(output_type_, type2id, OType, CAST_ALLOWED_TYPES, (
+    output.SetLayout(input.GetLayout());
     output.mutable_data<OType>();
     output.ResizeLike(input);
     TYPE_SWITCH(itype, type2id, IType, CAST_ALLOWED_TYPES, (

--- a/dali/operators/generic/cast.cu
+++ b/dali/operators/generic/cast.cu
@@ -49,8 +49,10 @@ void Cast<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
 
   DALIDataType itype = input.type().id();
   TYPE_SWITCH(output_type_, type2id, OType, CAST_ALLOWED_TYPES, (
+    output.SetLayout(input.GetLayout());
     output.mutable_data<OType>();
     output.ResizeLike(input);
+
     TYPE_SWITCH(itype, type2id, IType, CAST_ALLOWED_TYPES, (
       BatchedCast(output.mutable_data<OType>(), input.data<IType>(), input.size(), ws.stream());
     ), DALI_FAIL("Invalid input type"););  // NOLINT(whitespace/parens)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in Cast operator

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Cast operator was not propagating the layout of the input to its output. This PR fixes that*
 - Affected modules and functionalities:
     *Cast operator*
 - Key points relevant for the review:
     *Everything*
 - Validation and testing:
     *Tests in another PR were used to find this error*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
