### PR TITLE
GPU reduction kernels part 1 - non-directional batched and global reductions

### DIFF
--- a/dali/kernels/reduce/reduce_all_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_all_gpu_impl.cuh
@@ -1,0 +1,106 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _DALI_KERNELS_REDUCE_REDUCE_ALL_GPU_IMPL_CUH
+#define _DALI_KERNELS_REDUCE_REDUCE_ALL_GPU_IMPL_CUH
+
+
+#include "dali/core/util.h"
+#include "dali/kernels/reduce/reduce.h"
+
+namespace dali {
+namespace kernels {
+
+template <typename Acc, typename Reduction, typename OutputIdxFn>
+__device__ void BlockReduce(Acc *out, Acc val, Reduction reduce, OutputIdxFn get_output_idx) {
+  // First, `val` is reduced using warp shuffle.
+  // The block is square and the thread 0 in each warp stores its result in shared memory.
+  // After block synchronization, only the first warp does anything - it loads the stored
+  // 32 values into respective lanes and does one more warp reduction.
+  // Finally, the thread (0, 0) stores thre result at given index.
+  constexpr unsigned FULL_MASK = 0xffffffffu;
+  __shared__ Acc tmp[32];
+  reduce(val, __shfl_down_sync(FULL_MASK, val, 16));
+  reduce(val, __shfl_down_sync(FULL_MASK, val, 8));
+  reduce(val, __shfl_down_sync(FULL_MASK, val, 4));
+  reduce(val, __shfl_down_sync(FULL_MASK, val, 2));
+  reduce(val, __shfl_down_sync(FULL_MASK, val, 1));
+  if (threadIdx.x == 0)
+    tmp[threadIdx.y] = val;
+  __syncthreads();
+
+  if (threadIdx.y == 0) {
+    val = tmp[threadIdx.x];
+
+    reduce(val, __shfl_down_sync(FULL_MASK, val, 16));
+    reduce(val, __shfl_down_sync(FULL_MASK, val, 8));
+    reduce(val, __shfl_down_sync(FULL_MASK, val, 4));
+    reduce(val, __shfl_down_sync(FULL_MASK, val, 2));
+    reduce(val, __shfl_down_sync(FULL_MASK, val, 1));
+    if (threadIdx.x == 0)
+      out[get_output_idx()] = val;
+  }
+}
+
+
+template <typename Acc, typename In,
+          typename Reduction = reductions::sum,
+          typename Preprocess = dali::identity>
+__global__ void ReduceAllKernel(Acc *out, const In *in, int64_t n,
+                                Reduction reduce = {}, Preprocess pp = {}) {
+  // This kernel processes 1024-element blocks laid out as 32x32.
+  // Grid is flat 1D and blockIdx.x corresponds to an output bin.
+  // First, each thread goes with grid-sized stride over the data and iteratively reduces
+  // in a local variable.
+  // Then the local variable is reduced over the block.
+  const int64_t blk_size = blockDim.x * blockDim.y;
+  const int64_t grid_size = gridDim.x * blk_size;
+  const int flat_tid = threadIdx.x + threadIdx.y * blockDim.x;
+  int64_t idx = blockIdx.x * blk_size + flat_tid;
+  Acc val = idx < n ? pp(in[idx]) : 0;
+  for (idx += grid_size; idx < n; idx += grid_size) {
+    reduce(val, pp(in[idx]));
+  }
+  BlockReduce(out, val, reduce, []() { return blockIdx.x; });
+}
+
+
+template <typename Acc, typename In,
+          typename Reduction = reductions::sum,
+          typename Preprocess = dali::identity>
+__global__ void ReduceAllBatchedKernel(Acc *out, const In *const *in, const int64_t *in_sizes,
+                                       Reduction reduce = {}, Preprocess pp = {}) {
+  // This kernel processes 1024-element blocks laid out as 32x32.
+  // Grid is flat 2D and blockIdx.x corresponds to an output bin and blockIdx.y corresponds to
+  // sample in the batch.
+  // First, each thread goes with x-grid-sized stride over the data and iteratively reduces
+  // in a local variable.
+  // Then the local variable is reduced over the block.
+  const int64_t blk_size = blockDim.x * blockDim.y;
+  const int64_t grid_size = gridDim.x * blk_size;
+  const int sample = blockIdx.y;
+  const int64_t n = in_sizes[sample];
+  const int flat_tid = threadIdx.x + threadIdx.y * blockDim.x;
+  int64_t idx = blockIdx.x * blk_size + flat_tid;
+  Acc val = idx < n ? pp(in[sample][idx]) : 0;
+  for (idx += grid_size; idx < n; idx += grid_size) {
+    reduce(val, pp(in[sample][idx]));
+  }
+  BlockReduce(out, val, reduce, []() { return blockIdx.x + blockIdx.y * gridDim.x; });
+}
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // _DALI_KERNELS_REDUCE_REDUCE_ALL_GPU_IMPL_CUH

--- a/dali/kernels/reduce/reduce_all_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_all_gpu_impl.cuh
@@ -104,14 +104,17 @@ __global__ void ReduceAllBatchedKernel(Acc *out, const In *const *in, const int6
  * @brief Reduce evenly-spaced, contiguous blocks in `in` and store blockwise results in `out`.
  *
  * This kernel treats `in` as a group of contiguously stored, but independent, chunks of data,
- * each of `sanoke_size` elements.
+ * each of `sample_size` elements.
  * The partial result for each chunk is stored in out.
  *
  * `blockDim = 32, 32` (fixed!)
  * `gridDim = (outputs_per_block, number_of_blocks)`
  *
- * @param out the result
- * @param in  input data, in blocks `sample_size` elements each
+ * @param out         the result
+ * @param in          input data, in blocks `sample_size` elements each
+ * @param sample_size number of elements in each block
+ * @param reduce      the reduction functor
+ * @param pp          preprocessing to be applied to each value fetched from `in` before reducing
  */
 template <typename Acc, typename In,
           typename Reduction = reductions::sum,

--- a/dali/kernels/reduce/reduce_all_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_all_gpu_impl.cuh
@@ -68,7 +68,7 @@ __global__ void ReduceAllKernel(Acc *out, const In *in, int64_t n,
   const int64_t grid_size = gridDim.x * blk_size;
   const int flat_tid = threadIdx.x + threadIdx.y * blockDim.x;
   int64_t idx = blockIdx.x * blk_size + flat_tid;
-  Acc val = idx < n ? pp(in[idx]) : 0;
+  Acc val = idx < n ? pp(in[idx]) : reduce.template neutral<Acc>();
   for (idx += grid_size; idx < n; idx += grid_size) {
     reduce(val, pp(in[idx]));
   }
@@ -93,7 +93,7 @@ __global__ void ReduceAllBatchedKernel(Acc *out, const In *const *in, const int6
   const int64_t n = in_sizes[sample];
   const int flat_tid = threadIdx.x + threadIdx.y * blockDim.x;
   int64_t idx = blockIdx.x * blk_size + flat_tid;
-  Acc val = idx < n ? pp(in[sample][idx]) : 0;
+  Acc val = idx < n ? pp(in[sample][idx]) : reduce.template neutral<Acc>();
   for (idx += grid_size; idx < n; idx += grid_size) {
     reduce(val, pp(in[sample][idx]));
   }
@@ -128,7 +128,7 @@ __global__ void ReduceAllBlockwiseKernel(Acc *out, const In *in, int64_t sample_
   const int64_t grid_size = gridDim.x * blk_size;
   const int flat_tid = threadIdx.x + threadIdx.y * blockDim.x;
   int64_t offset = blockIdx.x * blk_size + flat_tid;
-  Acc val = offset < sample_size ? pp(in[offset]) : 0;
+  Acc val = offset < sample_size ? pp(in[offset]) : reduce.template neutral<Acc>();
   for (offset += grid_size; offset < sample_size; offset += grid_size) {
     reduce(val, pp(in[offset]));
   }

--- a/dali/kernels/reduce/reduce_all_gpu_test.cu
+++ b/dali/kernels/reduce/reduce_all_gpu_test.cu
@@ -1,0 +1,146 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <random>
+#include <vector>
+#include "dali/kernels/reduce/reduce_all_gpu_impl.cuh"
+#include "dali/core/util.h"
+#include "dali/kernels/alloc.h"
+#include "dali/core/span.h"
+#include "dali/core/cuda_event.h"
+
+namespace dali {
+namespace kernels {
+
+template <typename T>
+double RefSum(span<T> in) {
+  switch (in.size()) {
+    case 0:
+      return 0;
+    case 1:
+      return in[0];
+    default: {
+      int m = in.size() / 2;
+      int n = in.size() - m;
+      return RefSum(make_span(in.data(), m)) + RefSum(make_span(in.data() + m, n));
+    }
+  }
+}
+
+TEST(ReduceGPU, ReduceAllKernel) {
+  std::mt19937_64 rng(1234);
+  std::uniform_real_distribution<float> dist(0, 1);
+
+  int n_in = 1<<24;  // 16M numbers
+  dim3 block(32, 32);
+  int nblock = 1024;
+  int n_out = std::min<int>(div_ceil(n_in, nblock), 1024);
+  auto in_data = memory::alloc_unique<float>(AllocType::GPU, n_in);
+  auto out_data = memory::alloc_unique<float>(AllocType::GPU, n_out);
+  std::vector<float> in_cpu(n_in), out_cpu(n_out);
+  for (auto &x : in_cpu)
+    x = dist(rng);
+  double ref_sum = RefSum(make_cspan(in_cpu));
+
+  cudaMemcpy(in_data.get(), in_cpu.data(), n_in * sizeof(*in_data), cudaMemcpyHostToDevice);
+
+  dim3 grid = n_out;
+  ReduceAllKernel<<<1, block>>>(out_data.get(), in_data.get(), n_in);
+  cudaDeviceSynchronize();
+  auto start = CUDAEvent::CreateWithFlags(0);
+  auto end =   CUDAEvent::CreateWithFlags(0);
+  cudaEventRecord(start);
+  ReduceAllKernel<<<grid, block>>>(out_data.get(), in_data.get(), n_in);
+  cudaEventRecord(end);
+  cudaMemcpy(out_cpu.data(), out_data.get(), n_out * sizeof(*out_data), cudaMemcpyDeviceToHost);
+  cudaDeviceSynchronize();
+  float t = 0;
+  cudaEventElapsedTime(&t, start, end);
+  double out_sum = RefSum(make_cspan(out_cpu));
+  EXPECT_NEAR(out_sum, ref_sum, ref_sum * 1e-7 + 1e-7);
+
+  t /= 1000;
+  std::cout << n_in * sizeof(*in_data) / t * 1e-9 << " GB/s" << std::endl;
+}
+
+TEST(ReduceGPU, ReduceAllBatchedKernel) {
+  std::mt19937_64 rng(1234);
+  std::uniform_real_distribution<float> dist(0, 1);
+  std::uniform_int_distribution<int> size_dist(10000, 1000000);
+
+  int64_t n_in = 0;
+  int samples = 35;
+  std::vector<int64_t> sizes(samples);
+  for (auto &size : sizes) {
+    size = size_dist(rng);
+    n_in += size;
+  }
+
+  dim3 block(32, 32);
+  int nout_per_sample = 32;
+  int n_out = samples * nout_per_sample;
+  dim3 grid(nout_per_sample, samples);
+  auto in_data = memory::alloc_unique<float>(AllocType::GPU, n_in);
+  auto out_data = memory::alloc_unique<float>(AllocType::GPU, n_out);
+  std::vector<float> in_cpu(n_in), out_cpu(n_out);
+  for (auto &x : in_cpu)
+    x = dist(rng);
+
+  auto gpu_dev_ptrs = memory::alloc_unique<const float*>(AllocType::GPU, samples);
+  auto gpu_sizes = memory::alloc_unique<int64_t>(AllocType::GPU, samples);
+  vector<const float *> host_ptrs(samples);
+  vector<const float *> cpu_dev_ptrs(samples);
+  int64_t offset = 0;
+  for (int i = 0; i < samples; i++) {
+    host_ptrs[i] = in_cpu.data() + offset;
+    cpu_dev_ptrs[i] = in_data.get() + offset;
+    offset += sizes[i];
+  }
+
+  // data
+  cudaMemcpy(in_data.get(), in_cpu.data(), n_in * sizeof(*in_data), cudaMemcpyHostToDevice);
+  // pointers to sample data
+  cudaMemcpy(gpu_dev_ptrs.get(), cpu_dev_ptrs.data(), samples * sizeof(*gpu_dev_ptrs),
+             cudaMemcpyHostToDevice);
+  // sample sizes
+  cudaMemcpy(gpu_sizes.get(), sizes.data(), samples * sizeof(*gpu_sizes), cudaMemcpyHostToDevice);
+
+  // warm-up
+  ReduceAllBatchedKernel<<<1, block>>>(out_data.get(), gpu_dev_ptrs.get(), gpu_sizes.get());
+  cudaDeviceSynchronize();
+  auto start = CUDAEvent::CreateWithFlags(0);
+  auto end =   CUDAEvent::CreateWithFlags(0);
+  cudaEventRecord(start);
+  ReduceAllBatchedKernel<<<grid, block>>>(out_data.get(), gpu_dev_ptrs.get(), gpu_sizes.get());
+  cudaEventRecord(end);
+  cudaMemcpy(out_cpu.data(), out_data.get(), n_out * sizeof(*out_data), cudaMemcpyDeviceToHost);
+  cudaDeviceSynchronize();
+  float t = 0;
+  cudaEventElapsedTime(&t, start, end);
+
+  offset = 0;
+  for (int i = 0; i < samples; i++) {
+    double ref_sum = RefSum(make_span(host_ptrs[i], sizes[i]));
+    double out_sum = RefSum(make_span(&out_cpu[i*nout_per_sample], nout_per_sample));
+    EXPECT_NEAR(ref_sum, out_sum, ref_sum * 1e-7 + 1e-7);
+    offset += sizes[i];
+  }
+
+  t /= 1000;
+  std::cout << n_in * sizeof(*in_data) / t * 1e-9 << " GB/s" << std::endl;
+}
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/reduce/reduce_all_gpu_test.cu
+++ b/dali/kernels/reduce/reduce_all_gpu_test.cu
@@ -32,6 +32,12 @@ double RefSum(span<T> in) {
     case 1:
       return in[0];
     default: {
+      if (in.size() <= 128) {
+        double acc = 0;
+        for (auto &x : in)
+          acc += x;
+        return acc;
+      }
       int m = in.size() / 2;
       int n = in.size() - m;
       return RefSum(make_span(in.data(), m)) + RefSum(make_span(in.data() + m, n));
@@ -43,10 +49,11 @@ TEST(ReduceGPU, ReduceAllKernel) {
   std::mt19937_64 rng(1234);
   std::uniform_real_distribution<float> dist(0, 1);
 
-  int n_in = 1<<24;  // 16M numbers
+  int n_in = 1<<23;  // 8M numbers
   dim3 block(32, 32);
   int nblock = 1024;
-  int n_out = std::min<int>(div_ceil(n_in, nblock), 1024);
+  int n_out0 = std::min<int>(div_ceil(n_in, nblock), 1024);
+  int n_out = n_out0 + 1;
   auto in_data = memory::alloc_unique<float>(AllocType::GPU, n_in);
   auto out_data = memory::alloc_unique<float>(AllocType::GPU, n_out);
   std::vector<float> in_cpu(n_in), out_cpu(n_out);
@@ -56,19 +63,20 @@ TEST(ReduceGPU, ReduceAllKernel) {
 
   cudaMemcpy(in_data.get(), in_cpu.data(), n_in * sizeof(*in_data), cudaMemcpyHostToDevice);
 
-  dim3 grid = n_out;
+  dim3 grid = n_out0;
   ReduceAllKernel<<<1, block>>>(out_data.get(), in_data.get(), n_in);
   cudaDeviceSynchronize();
   auto start = CUDAEvent::CreateWithFlags(0);
   auto end =   CUDAEvent::CreateWithFlags(0);
   cudaEventRecord(start);
-  ReduceAllKernel<<<grid, block>>>(out_data.get(), in_data.get(), n_in);
+  ReduceAllKernel<<<grid, block>>>(out_data.get() + 1, in_data.get(), n_in);
+  ReduceAllKernel<<<1, block>>>(out_data.get(), out_data.get() + 1, n_out0);
   cudaEventRecord(end);
   cudaMemcpy(out_cpu.data(), out_data.get(), n_out * sizeof(*out_data), cudaMemcpyDeviceToHost);
   cudaDeviceSynchronize();
   float t = 0;
   cudaEventElapsedTime(&t, start, end);
-  double out_sum = RefSum(make_cspan(out_cpu));
+  double out_sum = out_cpu[0];
   EXPECT_NEAR(out_sum, ref_sum, ref_sum * 1e-7 + 1e-7);
 
   t /= 1000;
@@ -90,7 +98,8 @@ TEST(ReduceGPU, ReduceAllBatchedKernel) {
 
   dim3 block(32, 32);
   int nout_per_sample = 32;
-  int n_out = samples * nout_per_sample;
+  int n_out0 = samples * nout_per_sample;
+  int n_out = n_out0 + samples;
   dim3 grid(nout_per_sample, samples);
   auto in_data = memory::alloc_unique<float>(AllocType::GPU, n_in);
   auto out_data = memory::alloc_unique<float>(AllocType::GPU, n_out);
@@ -123,7 +132,12 @@ TEST(ReduceGPU, ReduceAllBatchedKernel) {
   auto start = CUDAEvent::CreateWithFlags(0);
   auto end =   CUDAEvent::CreateWithFlags(0);
   cudaEventRecord(start);
-  ReduceAllBatchedKernel<<<grid, block>>>(out_data.get(), gpu_dev_ptrs.get(), gpu_sizes.get());
+  ReduceAllBatchedKernel<<<grid, block>>>(out_data.get() + samples,
+                                          gpu_dev_ptrs.get(), gpu_sizes.get());
+
+  dim3 grid2(1, samples);
+  ReduceAllBlockwiseKernel<<<grid2, block>>>(out_data.get(),
+                                             out_data.get() + samples, nout_per_sample);
   cudaEventRecord(end);
   cudaMemcpy(out_cpu.data(), out_data.get(), n_out * sizeof(*out_data), cudaMemcpyDeviceToHost);
   cudaDeviceSynchronize();
@@ -133,7 +147,7 @@ TEST(ReduceGPU, ReduceAllBatchedKernel) {
   offset = 0;
   for (int i = 0; i < samples; i++) {
     double ref_sum = RefSum(make_span(host_ptrs[i], sizes[i]));
-    double out_sum = RefSum(make_span(&out_cpu[i*nout_per_sample], nout_per_sample));
+    double out_sum = out_cpu[i];
     EXPECT_NEAR(ref_sum, out_sum, ref_sum * 1e-7 + 1e-7);
     offset += sizes[i];
   }


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
- It adds new feature required for normalization and calculating maximum-relative conversion to decibels.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * two-stage warp reduction with intermediate transposition in shared memory
 - Affected modules and functionalities:
     * kernels/reduce - new functionality, header only
 - Key points relevant for the review:
     * Not much, really
 - Validation and testing:
     * Unit tests
 - Documentation (including examples):
     * None

**JIRA TASK**: DALI-1250

