### PR TITLE
Add one hot encoding operator (CPU backend)

### DIFF
--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -1,0 +1,46 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/generic/one_hot.h"
+
+namespace dali {
+
+void OneHot::RunImpl(HostWorkspace &ws) {
+  auto &output = ws.OutputRef<CPUBackend>(0);
+  auto &input = ws.InputRef<CPUBackend>(0);
+  // check
+  for (int i = 0; i < batch_size_; ++i) {
+    auto &inptr = input[i];
+    auto cls = inptr.template mutable_data<int>();
+    // DALI_ENFORCE(*cls < nclasses_, "Value ", cls,
+    //     " is bigger than specified number of classes");
+    auto &outptr = output[i];
+    auto one_hot = outptr.template mutable_data<int>();
+    one_hot[*cls] = 1;
+  }
+}
+
+// Check
+DALI_REGISTER_OPERATOR(OneHot, OneHot, CPU);
+
+// Check
+DALI_SCHEMA(OneHot)
+    .DocStr(
+        "Produce tensor representing one hot encoding "
+        " of the given input")
+    .NumInput(1)
+    .NumOutput(1)
+    .AddOptionalArg("nclasses", R"code(Number of all classes)code", 0);
+
+}  // namespace dali

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,22 +19,18 @@ namespace dali {
 void OneHot::RunImpl(HostWorkspace &ws) {
   auto &output = ws.OutputRef<CPUBackend>(0);
   auto &input = ws.InputRef<CPUBackend>(0);
-  // check
   for (int i = 0; i < batch_size_; ++i) {
     auto &inptr = input[i];
     auto cls = inptr.template mutable_data<int>();
-    // DALI_ENFORCE(*cls < nclasses_, "Value ", cls,
-    //     " is bigger than specified number of classes");
+    DALI_ENFORCE(*cls < nclasses_, "Values are bigger than specified number of classes");
     auto &outptr = output[i];
     auto one_hot = outptr.template mutable_data<int>();
     one_hot[*cls] = 1;
   }
 }
 
-// Check
 DALI_REGISTER_OPERATOR(OneHot, OneHot, CPU);
 
-// Check
 DALI_SCHEMA(OneHot)
     .DocStr(
         "Produce tensor representing one hot encoding "

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "dali/operators/generic/one_hot.h"
+#include "dali/core/tensor_shape.h"
 #include <iostream>
 
 namespace dali {
@@ -33,7 +34,8 @@ DALI_SCHEMA(OneHot)
 
 bool OneHot::SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) {
   output_desc.resize(1);
-  output_desc[0].shape = uniform_list_shape(batch_size_, {depth_});
+  const auto &input = ws.template InputRef<CPUBackend>(0);
+  output_desc[0].shape = uniform_list_shape(batch_size_, (shape_cat(input[0].shape(), depth_)));
   TYPE_SWITCH(output_type_, type2id, DType, ONE_HOT_TYPES, (
     {
       TypeInfo type;

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -67,9 +67,9 @@ void OneHot::RunImpl(HostWorkspace &ws) {
                                                   off_value_);
         });
       }
+      tp.WaitForWork();
     ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
   ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())))  // NOLINT
-  tp.WaitForWork();
 }
 
 }  // namespace dali

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -14,7 +14,6 @@
 
 #include "dali/operators/generic/one_hot.h"
 #include "dali/core/tensor_shape.h"
-#include <iostream>
 
 namespace dali {
 
@@ -29,8 +28,8 @@ DALI_SCHEMA(OneHot)
     .AddOptionalArg("depth", R"code(Number of all classes)code", 0)
     .AddOptionalArg(arg_names::kDtype, R"code(Data type for the output)code",
                     DALI_FLOAT)
-    .AddOptionalArg("on_value", R"code(Value that will be used to fill the output when input[j] = i)code", 1)
-    .AddOptionalArg("off_value", R"code(Value that will be used to fill the output when input[j] != i)code", 0);
+    .AddOptionalArg("on_value", R"code(Value that will be used to fill the output when input[j] = i)code", 1.f)
+    .AddOptionalArg("off_value", R"code(Value that will be used to fill the output when input[j] != i)code", 0.f);
 
 bool OneHot::SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) {
   output_desc.resize(1);
@@ -59,10 +58,10 @@ void OneHot::RunImpl(HostWorkspace &ws) {
           auto &out = output[sample_id];
           auto in_tensor = make_tensor_cpu(in.template data<InputType>(), in.shape());
           auto out_tensor = make_tensor_cpu(out.template mutable_data<OutputType>(), out.shape());
-          detail::DoOneHot<OutputType, InputType>(out_tensor, 
-                                                  in_tensor, 
-                                                  depth_, 
-                                                  on_value_, 
+          detail::DoOneHot<OutputType, InputType>(out_tensor,
+                                                  in_tensor,
+                                                  depth_,
+                                                  on_value_,
                                                   off_value_);
         });
       }

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -20,27 +20,51 @@ namespace dali {
 
 DALI_REGISTER_OPERATOR(OneHot, OneHot, CPU);
 
+
 DALI_SCHEMA(OneHot)
-    .DocStr(
-        "Produce tensor representing one hot encoding "
-        " of the given input. Input must be a Scalar, otherwise the operator will fail.")
-    .NumInput(1)
-    .NumOutput(1)
-    .AddOptionalArg("num_classes", R"code(Number of all classes in the data)code", 0)
-    .AddOptionalArg(arg_names::kDtype, R"code(Data type for the output)code",
-                    DALI_FLOAT)
-    .AddOptionalArg("on_value", R"code(Value that will be used to fill the output when ``input[j] = i``. It will be cast to ``dtype`` type)code", 1.f)
-    .AddOptionalArg("off_value", R"code(Value that will be used to fill the output when ``input[j] != i``. It will be cast to ``dtype`` type)code", 0.f);
+  .DocStr(
+          "Produce tensor representing one hot encoding "
+          " of the given input. Input must be a Scalar, otherwise the operator will fail.")
+  .NumInput(1)
+  .NumOutput(1)
+  .AddOptionalArg("num_classes", R"code(Number of all classes in the data)code", 0)
+  .AddOptionalArg(arg_names::kDtype, R"code(Data type for the output)code", DALI_FLOAT)
+  .AddOptionalArg("on_value",
+                  R"code(Value that will be used to fill the output when ``input[j] = i``.
+                         It will be cast to ``dtype`` type)code", 1.f)
+  .AddOptionalArg("off_value",
+                  R"code(Value that will be used to fill the output when ``input[j] != i``.
+                         It will be cast to ``dtype`` type)code", 0.f);
+
+namespace {
+
+template<int ndims>
+bool is_scalar(TensorShape<ndims> shape) {
+  return volume(shape) == 1;
+}
+
+
+TensorShape<DynamicDimensions>
+determine_shape(TensorShape<DynamicDimensions> in_shape, int nclasses) {
+  if (is_scalar(in_shape)) {
+    return {nclasses};
+  }
+  return shape_cat(in_shape, nclasses);
+}
+
+}  // namespace
 
 bool OneHot::SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) {
+  const auto &input = ws.template InputRef<CPUBackend>(0);
   output_desc.resize(1);
-  output_desc[0].shape = uniform_list_shape(batch_size_, {num_classes_});
+  output_desc[0].shape = uniform_list_shape(batch_size_,
+                                            determine_shape(input[0].shape(), num_classes_));
   TYPE_SWITCH(output_type_, type2id, DType, ONE_HOT_TYPES, (
-    {
-      TypeInfo type;
-      type.SetType<DType>(output_type_);
-      output_desc[0].type = type;
-    }
+          {
+            TypeInfo type;
+            type.SetType<DType>(output_type_);
+            output_desc[0].type = type;
+          }
   ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
   return true;
 }
@@ -50,25 +74,21 @@ void OneHot::RunImpl(HostWorkspace &ws) {
   auto &output = ws.template OutputRef<CPUBackend>(0);
   auto &tp = ws.GetThreadPool();
   TYPE_SWITCH(input.type().id(), type2id, InputType, ONE_HOT_TYPES, (
-    TYPE_SWITCH(output_type_, type2id, OutputType, ONE_HOT_TYPES, (
-      auto in_tensor = view<const InputType, 1>(input);
-      auto out_tensor = view<OutputType, 1>(output);
-      for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
-        DALI_ENFORCE(input[sample_id].shape().sample_dim() == 1 && input[sample_id].shape()[0] == 1,
-                     "Input must be a scalar.");
-        tp.DoWorkWithID(
-              [&, sample_id](int thread_id) {
-          auto in = in_tensor[sample_id];
-          auto out = out_tensor[sample_id];
-          detail::DoOneHot<OutputType, InputType>(out.to_static<1>(),
-                                                  in.to_static<1>(),
-                                                  num_classes_,
-                                                  on_value_,
-                                                  off_value_);
-        });
-      }
-      tp.WaitForWork();
-    ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
+          TYPE_SWITCH(output_type_, type2id, OutputType, ONE_HOT_TYPES, (
+
+          auto in_tensor = view<const InputType, DynamicDimensions>(input);
+          auto out_tensor = view<OutputType, DynamicDimensions>(output);
+          for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
+            tp.DoWorkWithID(
+                    [&, sample_id](int thread_id) {
+                        auto in = in_tensor[sample_id];
+                        auto out = out_tensor[sample_id];
+                        detail::DoOneHot(out, in, num_classes_, on_value_, off_value_,
+                                         0 ? is_scalar(in.shape) : in.shape.sample_dim(), 0);
+                    });
+          }
+          tp.WaitForWork();
+  ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
   ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())))  // NOLINT
 }
 

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_RANDOM_ONE_HOT_H
+#define DALI_OPERATORS_RANDOM_ONE_HOT_H
+
+#include <vector>
+
+#include "dali/pipeline/operator/operator.h"
+
+namespace dali {
+
+class OneHot : public Operator<CPUBackend> {
+ public:
+  inline explicit OneHot(const OpSpec &spec)
+      : Operator<CPUBackend>(spec), nclasses_(spec.GetArgument<int64_t>("nclasses")) {}
+
+  inline ~OneHot() override = default;
+
+  DISABLE_COPY_MOVE_ASSIGN(OneHot);
+
+  USE_OPERATOR_MEMBERS();
+  using Operator<CPUBackend>::RunImpl;
+
+ protected:
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    output_desc.resize(1);
+    output_desc[0].shape = uniform_list_shape(batch_size_, {nclasses_});
+    output_desc[0].type = TypeTable::GetTypeInfo(DALI_INT32);
+    return true;
+  }
+
+  void RunImpl(HostWorkspace &ws) override;
+
+ private:
+  int nclasses_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_RANDOM_ONE_HOT_H

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_OPERATORS_RANDOM_ONE_HOT_H
-#define DALI_OPERATORS_RANDOM_ONE_HOT_H
+#ifndef DALI_OPERATORS_GENERIC_ONE_HOT_H_
+#define DALI_OPERATORS_GENERIC_ONE_HOT_H_
 
 #include <vector>
-#include <iostream>
 
 #include "dali/pipeline/operator/operator.h"
 #include "dali/kernels/kernel_params.h"
@@ -29,7 +28,7 @@ namespace dali {
 
 namespace detail {
 template <typename Out, typename In, int ndims = 1>
-void DoOneHot(kernels::OutTensorCPU<Out, ndims> out, 
+void DoOneHot(kernels::OutTensorCPU<Out, ndims> out,
               kernels::InTensorCPU<In, ndims> in,
               int depth, int on_value, int off_value) {
   auto input = in.data;
@@ -46,7 +45,7 @@ void DoOneHot(kernels::OutTensorCPU<Out, ndims> out,
     }
   }
 }
-} // namespace detail
+}  // namespace detail
 
 class OneHot : public Operator<CPUBackend> {
  public:
@@ -80,4 +79,4 @@ class OneHot : public Operator<CPUBackend> {
 
 }  // namespace dali
 
-#endif  // DALI_OPERATORS_RANDOM_ONE_HOT_H
+#endif  // DALI_OPERATORS_GENERIC_ONE_HOT_H_

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -41,13 +41,19 @@ class OneHot : public Operator<CPUBackend> {
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
     output_desc.resize(1);
     output_desc[0].shape = uniform_list_shape(batch_size_, {nclasses_});
-    output_desc[0].type = TypeTable::GetTypeInfo(DALI_INT32);
+    TYPE_SWITCH(output_type_, type2id, DType, PREEMPH_TYPES, (
+            {
+              TypeInfo type;
+              type.SetType<DType>(output_type_);
+              output_desc[0].type = type;
+            }
+    ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
     return true;
   }
 
   void RunImpl(HostWorkspace &ws) override;
 
- private:
+  const DALIDataType output_type_;
   int nclasses_;
 };
 

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -34,7 +34,10 @@ void DoOneHot(kernels::OutTensorCPU<Out, 1> out,
   auto input = in.data;
   auto output = out.data;
   for (int i = 0; i < num_classes; ++i) output[i] = off_value;
-  output[static_cast<int>(input[0])] = on_value;
+  int cls = static_cast<int>(input[0]);
+  if (cls >= 0 && cls < num_classes) {
+    output[cls] = on_value;
+  }
 }
 }  // namespace detail
 

--- a/dali/operators/generic/one_hot_test.cc
+++ b/dali/operators/generic/one_hot_test.cc
@@ -20,7 +20,7 @@ class OneHotOpTest : public ::testing::Test {
 
   protected:
     void SetUp() final {
-        for (int i = 0; i < nclasses_; ++i) output_.push_back(0);
+        output_.resize(nclasses_, 0);
     }
 
     int buffer_length_ = 10;
@@ -34,7 +34,7 @@ class OneHotOpTest : public ::testing::Test {
 using TestTypes = std::tuple<uint8_t, int8_t, uint16_t, int16_t, int32_t, int64_t, float>;
 INPUT_OUTPUT_TYPED_TEST_SUITE(OneHotOpTest, TestTypes);
 
-TYPED_TEST(OneHotOpTest, test_various_types) {
+TYPED_TEST(OneHotOpTest, TestVariousTypes) {
     using In = typename TypeParam::In;
     using Out = typename TypeParam::Out;
     for (auto it = this->input_.begin(); it != this->input_.end(); ++it) {

--- a/dali/operators/generic/one_hot_test.cc
+++ b/dali/operators/generic/one_hot_test.cc
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+#include "dali/operators/generic/one_hot.h"
+#include "dali/kernels/kernel_params.h"
+#include "utility"
+#include "dali/test/tensor_test_utils.h"
+
+#include <iostream>
+
+namespace dali {
+namespace testing {
+
+class OneHotOpTest : public ::testing::Test {
+  protected:
+    void SetUp() final {
+        for (int i = 0; i < nclasses_; ++i) output_.push_back(0);
+    }
+
+    int buffer_length_ = 10;
+    int nclasses_ = 20;
+    std::vector<float> input_{1, 3, 5, 0, 1, 2, 10, 15, 7, 6};
+    std::vector<float> output_;
+    TensorShape<1> input_shape_ = {1};
+    TensorShape<1> output_shape_ = {nclasses_};
+};
+
+TEST_F(OneHotOpTest, TestDoOneHotForFloats) {
+
+    for (auto it = input_.begin(); it != input_.end(); ++it) {
+        auto input = make_tensor_cpu(reinterpret_cast<const float*>(&(*it)), 
+                                                                this->input_shape_);
+        auto output = make_tensor_cpu(reinterpret_cast<float*>(this->output_.data()), 
+                                                                  this->output_shape_);
+        detail::DoOneHot(output, input, 20, 1, 0);
+        auto ptr = output.data;
+        for (int i = 0; i < nclasses_; ++i) {
+            if (i == *it) ASSERT_EQ(ptr[i], 1);
+            else ASSERT_EQ(ptr[i], 0);
+        }
+    }
+}
+
+} // namespace testing
+} // namespace dali

--- a/dali/operators/generic/one_hot_test.cc
+++ b/dali/operators/generic/one_hot_test.cc
@@ -30,35 +30,34 @@ class OneHotOpTest : public ::testing::Test {
 
  protected:
     void SetUp() final {
-        output_.resize(nclasses_, 0);
+        output_.resize(num_classes_, 0);
     }
 
     int buffer_length_ = 10;
-    int nclasses_ = 20;
+    int num_classes_ = 20;
     std::vector<In> input_{1, 3, 5, 0, 1, 2, 10, 15, 7, 6};
     std::vector<Out> output_;
     TensorShape<1> input_shape_ = {1};
-    TensorShape<1> output_shape_ = {nclasses_};
+    TensorShape<1> output_shape_ = {num_classes_};
 };
 
 using TestTypes = std::tuple<uint8_t, int8_t, uint16_t, int16_t, int32_t, int64_t, float>;
 INPUT_OUTPUT_TYPED_TEST_SUITE(OneHotOpTest, TestTypes);
 
 TYPED_TEST(OneHotOpTest, TestVariousTypes) {
-    using In = typename TypeParam::In;
     using Out = typename TypeParam::Out;
-    for (auto it = this->input_.begin(); it != this->input_.end(); ++it) {
-        auto input = make_tensor_cpu(reinterpret_cast<const In*>(&(*it)),
+    using In = typename TypeParam::In;
+    for (int sample = 0; sample < this->buffer_length_; ++sample) {
+        auto input = make_tensor_cpu(this->input_.data() + sample,
                                      this->input_shape_);
-        auto output = make_tensor_cpu(reinterpret_cast<Out*>(this->output_.data()),
+        auto output = make_tensor_cpu(this->output_.data(),
                                       this->output_shape_);
-        dali::detail::DoOneHot(output, input, 20, 1, 0);
-        auto ptr = output.data;
-        for (int i = 0; i < this->nclasses_; ++i) {
-            if (i == *it) {
-                ASSERT_EQ(ptr[i], 1);
+        dali::detail::DoOneHot<Out, In>(output, input, 20, 1, 0);
+        for (int i = 0; i < this->num_classes_; ++i) {
+            if (i == this->input_.data()[sample]) {
+                ASSERT_EQ(output.data[i], 1);
             } else {
-                ASSERT_EQ(ptr[i], 0);
+                ASSERT_EQ(output.data[i], 0);
             }
         }
     }

--- a/dali/operators/generic/one_hot_test.cc
+++ b/dali/operators/generic/one_hot_test.cc
@@ -14,10 +14,10 @@
 
 #include <gtest/gtest.h>
 #include <tuple>
+#include <utility>
 #include "dali/operators/generic/one_hot.h"
 #include "dali/kernels/kernel_params.h"
 #include "dali/kernels/test/kernel_test_utils.h"
-#include "utility"
 #include "dali/test/tensor_test_utils.h"
 
 namespace dali {

--- a/dali/operators/generic/one_hot_test.cc
+++ b/dali/operators/generic/one_hot_test.cc
@@ -37,8 +37,8 @@ class OneHotOpTest : public ::testing::Test {
     int num_classes_ = 20;
     std::vector<In> input_{1, 3, 5, 0, 1, 2, 10, 15, 7, 6};
     std::vector<Out> output_;
-    TensorShape<1> input_shape_ = {1};
-    TensorShape<1> output_shape_ = {num_classes_};
+    TensorShape<DynamicDimensions> input_shape_ = {1};
+    TensorShape<DynamicDimensions> output_shape_ = {num_classes_};
 };
 
 using TestTypes = std::tuple<uint8_t, int8_t, uint16_t, int16_t, int32_t, int64_t, float>;
@@ -48,11 +48,9 @@ TYPED_TEST(OneHotOpTest, TestVariousTypes) {
     using Out = typename TypeParam::Out;
     using In = typename TypeParam::In;
     for (int sample = 0; sample < this->buffer_length_; ++sample) {
-        auto input = make_tensor_cpu(this->input_.data() + sample,
-                                     this->input_shape_);
-        auto output = make_tensor_cpu(this->output_.data(),
-                                      this->output_shape_);
-        dali::detail::DoOneHot<Out, In>(output, input, 20, 1, 0);
+        auto input = make_tensor_cpu(this->input_.data() + sample, this->input_shape_);
+        auto output = make_tensor_cpu(this->output_.data(), this->output_shape_);
+        dali::detail::DoOneHot<Out, In>(output, input, 20, 1, 0, 0, 0);
         for (int i = 0; i < this->num_classes_; ++i) {
             if (i == this->input_.data()[sample]) {
                 ASSERT_EQ(output.data[i], 1);

--- a/dali/operators/generic/one_hot_test.cc
+++ b/dali/operators/generic/one_hot_test.cc
@@ -1,24 +1,34 @@
+// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gtest/gtest.h>
+#include <tuple>
 #include "dali/operators/generic/one_hot.h"
 #include "dali/kernels/kernel_params.h"
 #include "dali/kernels/test/kernel_test_utils.h"
 #include "utility"
 #include "dali/test/tensor_test_utils.h"
-#include <tuple>
-
-#include <iostream>
-
 
 namespace dali {
 namespace testing {
 
 template <class InputOutputTypes>
 class OneHotOpTest : public ::testing::Test {
-
   using In = typename InputOutputTypes::In;
   using Out = typename InputOutputTypes::Out;
 
-  protected:
+ protected:
     void SetUp() final {
         output_.resize(nclasses_, 0);
     }
@@ -38,18 +48,21 @@ TYPED_TEST(OneHotOpTest, TestVariousTypes) {
     using In = typename TypeParam::In;
     using Out = typename TypeParam::Out;
     for (auto it = this->input_.begin(); it != this->input_.end(); ++it) {
-        auto input = make_tensor_cpu(reinterpret_cast<const In*>(&(*it)), 
+        auto input = make_tensor_cpu(reinterpret_cast<const In*>(&(*it)),
                                      this->input_shape_);
-        auto output = make_tensor_cpu(reinterpret_cast<Out*>(this->output_.data()), 
+        auto output = make_tensor_cpu(reinterpret_cast<Out*>(this->output_.data()),
                                       this->output_shape_);
         dali::detail::DoOneHot(output, input, 20, 1, 0);
         auto ptr = output.data;
         for (int i = 0; i < this->nclasses_; ++i) {
-            if (i == *it) ASSERT_EQ(ptr[i], 1);
-            else ASSERT_EQ(ptr[i], 0);
+            if (i == *it) {
+                ASSERT_EQ(ptr[i], 1);
+            } else {
+                ASSERT_EQ(ptr[i], 0);
+            }
         }
     }
 }
 
-} // namespace testing
-} // namespace dali
+}  // namespace testing
+}  // namespace dali

--- a/dali/test/python/test_operator_one_hot.py
+++ b/dali/test/python/test_operator_one_hot.py
@@ -18,8 +18,7 @@ import nvidia.dali.types as types
 
 import numpy as np
 
-sample_size = 10
-premade_batch = [np.array(x, dtype=np.int32) for x in range(sample_size)]
+sample_size = 20
 
 
 class OneHotPipeline(Pipeline):
@@ -42,13 +41,20 @@ def one_hot(input):
     return outp
 
 
-def test_one_hot_operator():
+def check_one_hot_operator(premade_batch):
     pipeline = OneHotPipeline(nclasses=sample_size)
     pipeline.build()
     outputs = pipeline.run()
     reference = one_hot(premade_batch)
     outputs = outputs[0].as_array()
-    assert(np.array_equal(outputs, reference))
+    # import ipdb; ipdb.set_trace();
+    assert np.array_equal(outputs, reference) == True
+
+def test_one_hot_operator():
+    for i in range(10):
+        premade_batch = [np.array([np.random.randint(0, sample_size)], dtype=np.int32) for x in range(sample_size)]
+        yield check_one_hot_operator, premade_batch
 
 if __name__ == "__main__":
-    test_one_hot_operator()
+    res = test_one_hot_operator()
+

--- a/dali/test/python/test_operator_one_hot.py
+++ b/dali/test/python/test_operator_one_hot.py
@@ -1,0 +1,50 @@
+
+
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops as ops
+import nvidia.dali.types as types
+
+import numpy as np
+
+sample_size = 5
+premade_batch = [np.array(x) for x in range(sample_size)]
+
+class OneHotPipeline(Pipeline):
+    def __init__(self, no_classes, num_threads=1):
+        super(OneHotPipeline, self).__init__(sample_size,
+                                            num_threads,
+                                            0)
+        self.ext_src = ops.ExternalSource() 
+        self.one_hot = ops.OneHot(nclasses=no_classes, device="cpu")
+
+
+    def define_graph(self):
+        self.data = self.ext_src()
+        return self.one_hot(self.data)
+
+    def iter_setup(self):
+        self.feed_input(self.data, premade_batch);
+
+
+def one_hot(input):
+    outp = np.zeros([sample_size, sample_size], dtype=int)
+    for i in range(sample_size):
+        outp[i,input[i]] = 1
+    return outp
+
+def check_one_hot_operator():
+    pipeline = OneHotPipeline(no_classes=sample_size)
+    pipeline.build()
+    outputs = pipeline.run()
+    reference = one_hot(premade_batch)
+    outputs = outputs[0]
+    for i in range(sample_size):
+        out_array = outputs.at(i)
+        for j in range(sample_size):
+            # compare onehot encoding with python implementation
+            assert(out_array[j] == reference[i,j])
+
+    
+
+if __name__ == "__main__":
+    check_one_hot_operator()

--- a/dali/test/python/test_operator_one_hot.py
+++ b/dali/test/python/test_operator_one_hot.py
@@ -21,25 +21,25 @@ import numpy as np
 sample_size = 20
 
 class OneHotPipeline(Pipeline):
-    def __init__(self, nclasses, input, num_threads=1):
+    def __init__(self, num_classes, input, num_threads=1):
         super(OneHotPipeline, self).__init__(sample_size,
                                              num_threads,
                                              0)
         self.ext_src = ops.ExternalSource(source=[input], cycle=True)
-        self.one_hot = ops.OneHot(depth=nclasses, dtype=types.INT32, device="cpu")
+        self.one_hot = ops.OneHot(num_classes=num_classes, dtype=types.INT32, device="cpu")
 
     def define_graph(self):
         self.data = self.ext_src()
         return self.one_hot(self.data)
 
 def one_hot(input):
-    outp = np.zeros([sample_size, 1, sample_size], dtype=np.int32)
+    outp = np.zeros([sample_size, sample_size], dtype=np.int32)
     for i in range(sample_size):
-        outp[i, 0, int(input[i])] = 1
+        outp[i, int(input[i])] = 1
     return outp
 
 def check_one_hot_operator(premade_batch):
-    pipeline = OneHotPipeline(nclasses=sample_size, input=premade_batch)
+    pipeline = OneHotPipeline(num_classes=sample_size, input=premade_batch)
     pipeline.build()
     outputs = pipeline.run()
     reference = one_hot(premade_batch)
@@ -51,4 +51,3 @@ def test_one_hot_operator():
     for i in range(10):
         premade_batch = [np.array([np.random.randint(0, sample_size)], dtype=np.int32) for x in range(sample_size)]
         yield check_one_hot_operator, premade_batch
-

--- a/dali/test/python/test_operator_one_hot.py
+++ b/dali/test/python/test_operator_one_hot.py
@@ -47,6 +47,7 @@ def check_one_hot_operator(premade_batch):
     assert(np.array_equal(outputs, reference))
 
 def test_one_hot_operator():
+    np.random.seed(42);
     for i in range(10):
         premade_batch = [np.array([np.random.randint(0, sample_size)], dtype=np.int32) for x in range(sample_size)]
         yield check_one_hot_operator, premade_batch

--- a/dali/test/python/test_operator_one_hot.py
+++ b/dali/test/python/test_operator_one_hot.py
@@ -1,4 +1,16 @@
-
+# Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
@@ -6,45 +18,45 @@ import nvidia.dali.types as types
 
 import numpy as np
 
-sample_size = 5
+sample_size = 10
 premade_batch = [np.array(x) for x in range(sample_size)]
 
-class OneHotPipeline(Pipeline):
-    def __init__(self, no_classes, num_threads=1):
-        super(OneHotPipeline, self).__init__(sample_size,
-                                            num_threads,
-                                            0)
-        self.ext_src = ops.ExternalSource() 
-        self.one_hot = ops.OneHot(nclasses=no_classes, device="cpu")
 
+class OneHotPipeline(Pipeline):
+    def __init__(self, nclasses, num_threads=1):
+        super(OneHotPipeline, self).__init__(sample_size,
+                                             num_threads,
+                                             0)
+        self.ext_src = ops.ExternalSource()
+        self.one_hot = ops.OneHot(nclasses=nclasses, device="cpu")
 
     def define_graph(self):
         self.data = self.ext_src()
         return self.one_hot(self.data)
 
     def iter_setup(self):
-        self.feed_input(self.data, premade_batch);
+        self.feed_input(self.data, premade_batch)
 
 
 def one_hot(input):
     outp = np.zeros([sample_size, sample_size], dtype=int)
     for i in range(sample_size):
-        outp[i,input[i]] = 1
+        outp[i, input[i]] = 1
     return outp
 
+
 def check_one_hot_operator():
-    pipeline = OneHotPipeline(no_classes=sample_size)
+    pipeline = OneHotPipeline(nclasses=sample_size)
     pipeline.build()
     outputs = pipeline.run()
     reference = one_hot(premade_batch)
     outputs = outputs[0]
     for i in range(sample_size):
-        out_array = outputs.at(i)
+        output_row = outputs.at(i)
         for j in range(sample_size):
-            # compare onehot encoding with python implementation
-            assert(out_array[j] == reference[i,j])
+            # compare operator encoding with python implementation
+            assert(output_row[j] == reference[i, j])
 
-    
 
 if __name__ == "__main__":
     check_one_hot_operator()

--- a/dali/test/python/test_operator_one_hot.py
+++ b/dali/test/python/test_operator_one_hot.py
@@ -27,15 +27,12 @@ class OneHotPipeline(Pipeline):
         super(OneHotPipeline, self).__init__(sample_size,
                                              num_threads,
                                              0)
-        self.ext_src = ops.ExternalSource()
+        self.ext_src = ops.ExternalSource(source=[premade_batch], cycle=True)
         self.one_hot = ops.OneHot(depth=nclasses, dtype=types.INT32, device="cpu")
 
     def define_graph(self):
         self.data = self.ext_src()
         return self.one_hot(self.data)
-
-    def iter_setup(self):
-        self.feed_input(self.data, premade_batch)
 
 
 def one_hot(input):


### PR DESCRIPTION
#### Why we need this PR?
- It adds new feature needed because of *one-hot encoding is a commonly used encoding that our pipeline was missing*

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *One-hot operator was added and can be now used in the pipeline*
 - Affected modules and functionalities:
     *Added .cc and .h file for one-hot operator and a single file with unit tests*
 - Key points relevant for the review:
     *Implementation of the RunImpl and SetupImpl*
 - Validation and testing:
     *It was tested with a single unit test. Addition of more tests should be considered*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *DALI-1268*
