### PR TITLE
Add missing new line for section anchor in rst

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -38,6 +38,7 @@ TensorListGPU
 
 
 .. _layout_str_doc:
+
 Data Layouts
 ------------
 .. include:: data_layout.rst


### PR DESCRIPTION
Withouth that new line the cross-document links
do not work.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fix a bug in interdoc links

#### What happened in this PR?
 - What solution was applied:
     *[ Missing new line between section and label/anchor ]*
 - Affected modules and functionalities:
     *[ API doc ]*
 - Key points relevant for the review:
     *[ Don't forget to see if it works ]*
 - Validation and testing:
     *[ See if `layout str` in supported ops works. ]*
 - Documentation (including examples):
     *[ Yes ]*


**JIRA TASK**: *[NA]*
