### PR TITLE
Add missing `#include <cstdint>` to util and math_util.

### DIFF
--- a/include/dali/core/math_util.h
+++ b/include/dali/core/math_util.h
@@ -23,6 +23,7 @@
 #else
 #include <cmath>
 #endif
+#include <cstdint>
 #include "dali/core/host_dev.h"
 #include "dali/core/force_inline.h"
 

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -16,6 +16,7 @@
 #define DALI_CORE_UTIL_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <initializer_list>
 


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug with missing int32_t which broke some builds depending on inclusion order.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added missing include directives
 - Validation and testing:
     * Build
 - Documentation (including examples):
     * N/A

**JIRA TASK**:  N/A
