### PR TITLE
Allow empty arrays in MXNet iterator

### DIFF
--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -135,6 +135,12 @@ def non_empty(shape):
     return True
 
 def get_mx_array(shape, ctx=None, dtype=None):
+    # WAR
+    # ToDo (jlisiecki) - fix when upstream MXNet fixes this
+    # mx.nd.empty doesn't support np.longlong as mx.nd.zeros does, but it does np.int64
+    # which from our point of view is the same
+    if dtype == np.longlong:
+        dtype = np.int64
     if non_empty(shape):
         return mx.nd.zeros(shape, ctx, dtype)
     else:
@@ -339,7 +345,6 @@ class DALIGenericIterator(_DALIIteratorBase):
                         d[j] = get_mx_array(shape, d[j].context, dtype = dtype)
                 for j, (shape, dtype) in enumerate(category_info[DALIGenericIterator.LABEL_TAG]):
                     if list(l[j].shape) != shape:
-                        l[j] = get_mx_array(shape, l[j].context, dtype = dtype)
                         l[j] = get_mx_array(shape, l[j].context, dtype = dtype)
 
             for j, d_arr in enumerate(d):

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -126,6 +126,21 @@ class _DALIIteratorBase(mx.io.DataIter):
                 self.reset()
             raise StopIteration
 
+
+def non_empty(shape):
+    for s in shape:
+        if s == 0:
+            return False
+
+    return True
+
+def get_mx_array(shape, ctx=None, dtype=None):
+    if non_empty(shape):
+        return mx.nd.zeros(shape, ctx, dtype)
+    else:
+        return mx.nd.empty(shape, ctx, dtype)
+
+
 ###################################################
 ###################################################
 ################## MXNet Sym API ##################
@@ -309,9 +324,9 @@ class DALIGenericIterator(_DALIIteratorBase):
                 d = []
                 l = []
                 for j, (shape, dtype) in enumerate(category_info[DALIGenericIterator.DATA_TAG]):
-                    d.append(mx.nd.zeros(shape, category_device[DALIGenericIterator.DATA_TAG][j], dtype = dtype))
+                    d.append(get_mx_array(shape, category_device[DALIGenericIterator.DATA_TAG][j], dtype = dtype))
                 for j, (shape, dtype) in enumerate(category_info[DALIGenericIterator.LABEL_TAG]):
-                    l.append(mx.nd.zeros(shape, category_device[DALIGenericIterator.LABEL_TAG][j], dtype = dtype))
+                    l.append(get_mx_array(shape, category_device[DALIGenericIterator.LABEL_TAG][j], dtype = dtype))
 
                 self._data_batches[i][self._current_data_batch] = mx.io.DataBatch(data=d, label=l)
 
@@ -321,10 +336,11 @@ class DALIGenericIterator(_DALIIteratorBase):
             if self._dynamic_shape:
                 for j, (shape, dtype) in enumerate(category_info[DALIGenericIterator.DATA_TAG]):
                     if list(d[j].shape) != shape:
-                        d[j] = mx.nd.zeros(shape, d[j].context, dtype = dtype)
+                        d[j] = get_mx_array(shape, d[j].context, dtype = dtype)
                 for j, (shape, dtype) in enumerate(category_info[DALIGenericIterator.LABEL_TAG]):
                     if list(l[j].shape) != shape:
-                        l[j] = mx.nd.zeros(shape, l[j].context, dtype = dtype)
+                        l[j] = get_mx_array(shape, l[j].context, dtype = dtype)
+                        l[j] = get_mx_array(shape, l[j].context, dtype = dtype)
 
             for j, d_arr in enumerate(d):
                 feed_ndarray(category_tensors[DALIGenericIterator.DATA_TAG][j], d_arr)

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -154,7 +154,7 @@ def test_mxnet_iterator_empty_array():
     from nvidia.dali.plugin.mxnet import DALIGenericIterator as MXNetIterator
 
     batch_size = 4
-    size = 100
+    size = 5
 
     def get_data():
         images = [np.empty((1, 224, 224, 3), dtype = np.float)] * batch_size

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -166,9 +166,9 @@ def test_mxnet_iterator_empty_array():
             bboxes = []
             labels = []
             for _ in range(batch_size):
-                batch.append(np.empty((224, 224, 3), dtype = np.uint8))
+                batch.append(np.empty((224, 224, 3), dtype = np.float))
                 bboxes.append(np.empty((0, 4), dtype = np.uint8))
-                labels.append(np.array((0, 1), dtype = np.uint8))
+                labels.append(np.array((0, 1), dtype = np.longlong))
                 self.i = (self.i + 1) % self.n
 
             return (batch, bboxes, labels)
@@ -198,6 +198,10 @@ def test_mxnet_iterator_empty_array():
 
     for i, batch in enumerate(iterator):
         bboxes_shape = batch[0].label[0].asnumpy().shape
+
+        assert batch[0].data[0].asnumpy().dtype == np.float64
+        assert batch[0].label[0].asnumpy().dtype == np.uint8
+        assert batch[0].label[1].asnumpy().dtype == np.int64
 
         assert bboxes_shape[0] == batch_size
         assert bboxes_shape[1] == 0


### PR DESCRIPTION
Signed-off-by: Albert Wolant <awolant@nvidia.com>

#### Why we need this PR?
- It fixes a bug in MXNet iterator with empty array returned

#### What happened in this PR?
 - What solution was applied:
     *When shape contains 0 we use `empty` since `zeros` doesn't allow that*
 - Affected modules and functionalities:
     *MXNet plugin*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *Added test for this scenario*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[NA]*
