### PR TITLE
Fix parameter name in data_node._check.

### DIFF
--- a/dali/python/nvidia/dali/data_node.py
+++ b/dali/python/nvidia/dali/data_node.py
@@ -113,4 +113,4 @@ def _check(maybe_node):
     if not isinstance(maybe_node, DataNode):
         raise TypeError(("Expected outputs of type compatible with \"DataNode\"."
                 " Received output type with name \"{}\" that does not match.")
-                .format(type(edge).__name__))
+                .format(type(maybe_node).__name__))


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug with undefined variable when attempting to raise an error with "not a DataNode"

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * fixed the variable name
 - Affected modules and functionalities:
     * dali/data_node
 - Validation and testing:
     * tested by hand by set_outputs with not a node, no automated testing (it only happend in a situation when we throw anyway)
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
