### PR TITLE
Fix Transpose bugs - degenerate dims and non-uniform GPU

### DIFF
--- a/dali/operators/generic/transpose/transpose.cc
+++ b/dali/operators/generic/transpose/transpose.cc
@@ -75,16 +75,7 @@ which is equivalent to:
 
 .. math:: dst(x_{perm[0]}, x_{perm[1]}, x_{perm[2]}) = src(x_0, x_1, x_2)
 
-for all valid coordinates:
-
-.. math ::
-
-  x_0 \in [0, 100)
-
-  x_1 \in [0, 200)
-
-  x_3 \in [0, 3)
-
+for all valid coordinates.
 )code")
     .NumInput(1)
     .NumOutput(1)

--- a/dali/operators/generic/transpose/transpose.cc
+++ b/dali/operators/generic/transpose/transpose.cc
@@ -62,7 +62,30 @@ class TransposeCPU : public Transpose<CPUBackend> {
 DALI_REGISTER_OPERATOR(Transpose, TransposeCPU, CPU);
 
 DALI_SCHEMA(Transpose)
-    .DocStr("Transpose tensor dimension to a new permutated dimension specified by `perm`.")
+    .DocStr(R"code(Transpose tensor by reordering the dimensions according to the `perm` parameter.
+Destination dimension ``i`` is obtained from source dimension ``perm[i]``.
+
+For example, with `src` image in `HWC` layout, ``shape = (100, 200, 3)``, and ``perm = [2, 0, 1]``
+Transpose Operator would produce a `dst` image of layout `CHW` and ``shape = (3, 100, 200)``,
+holding the euqality:
+
+.. math:: dst(x_2, x_0, x_1) = src(x_0, x_1, x_2)
+
+which is equivalent to:
+
+.. math:: dst(x_{perm[0]}, x_{perm[1]}, x_{perm[2]}) = src(x_0, x_1, x_2)
+
+for all valid coordinates:
+
+.. math ::
+
+  x_0 \in [0, 100)
+
+  x_1 \in [0, 200)
+
+  x_3 \in [0, 3)
+
+)code")
     .NumInput(1)
     .NumOutput(1)
     .AllowSequences()

--- a/dali/operators/generic/transpose/transpose.h
+++ b/dali/operators/generic/transpose/transpose.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include <utility>
 
 #include "dali/kernels/common/utils.h"
 #include "dali/operators/generic/transpose/cutt/cutt.h"

--- a/dali/operators/generic/transpose/transpose.h
+++ b/dali/operators/generic/transpose/transpose.h
@@ -75,7 +75,7 @@ void PrepareArguments(SmallVector<ShapeT, kStaticShapeElements> &shape, VecInt &
 
   VecInt tmp_perm;
   for (int i = 0; i < N; i++) {
-    // We need to skip those elements of permutation, that correspond to dimensions = 1.
+    // We need to skip the elements of permutation which correspond to dimensions with extent = 1
     if (shape[perm[i]] == 1) {
       continue;
     }

--- a/dali/operators/generic/transpose/transpose.h
+++ b/dali/operators/generic/transpose/transpose.h
@@ -48,34 +48,53 @@ template <typename ShapeT = int>
 void PrepareArguments(SmallVector<ShapeT, kStaticShapeElements> &shape, VecInt &perm,
                       bool transpose = false) {
   DALI_ENFORCE(shape.size() == perm.size());
+  const int N = shape.size();
 
-  // cuTT does not handle dimensions with size 1 so we remove them
-  // (H, W, 1) is equivalent to (H, W)
-  auto it_shape = shape.begin();
-  auto it_perm = perm.begin();
-  SmallVector<ShapeT, kStaticShapeElements> erased;
-  while (it_shape != shape.end()) {
-    if (*it_shape == 1) {
-      erased.push_back(*it_perm);
-      it_shape = shape.erase(it_shape);
-      it_perm = perm.erase(it_perm);
+  // This will be oterwise reduced to empty shape, and we still want to have some
+  // notion of non-empty shape left
+  if (volume(shape) == 1) {
+    shape = {1};
+    perm = {0};
+    return;
+  }
+
+  SmallVector<int, kStaticShapeElements> ones_pos;
+  for (int i = 0; i < N; i++) {
+    if (shape[i] == 1) {
+      ones_pos.push_back(i);
+    }
+  }
+  SmallVector<ShapeT, kStaticShapeElements> tmp_shape;
+  tmp_shape.reserve(N - ones_pos.size());
+  // shape_idx holds index of original shape (already processed dimensions),
+  // ones_ids - holds indexes in array of degenerate (1-sized) dimensions
+  for (int shape_idx = 0, ones_idx = 0; shape_idx < N; shape_idx++) {
+    if (ones_idx < static_cast<int>(ones_pos.size()) && shape_idx == ones_pos[ones_idx]) {
+      ones_idx++;
     } else {
-      ++it_shape;
-      ++it_perm;
+      tmp_shape.push_back(shape[shape_idx]);
     }
   }
-  // when some permutation element is erased all elements positions after it should be decreased
-  // by one like it doesn't exist at all
-  // sort elements to erase in descending order so we avoid situations like
-  // erased(0, 2), perm(3, 1) -> perm(2, 0) while it should be (1, 0)
-  std::sort(erased.begin(), erased.end(), std::greater<int>());
-  for (auto &pos : erased) {
-    for (auto &elm : perm) {
-       if (elm > pos) {
-         --elm;
-       }
+  VecInt tmp_perm;
+  tmp_perm.reserve(N - ones_pos.size());
+  for (int i = 0; i < N; i++) {
+    // this element was removed
+    if (!std::binary_search(ones_pos.begin(), ones_pos.end(), perm[i])) {
+      tmp_perm.push_back(perm[i]);
     }
   }
+  // Reduce the dimension values in perm. We go over all elements that were left,
+  // and reduce it as many times, as there were smaller elements that were removed
+  for (int i = ones_pos.size() - 1; i >= 0; i--) {
+    for (auto &elem : tmp_perm) {
+      if (elem > ones_pos[i]) {
+        elem--;
+      }
+    }
+  }
+  shape = tmp_shape;
+  perm = tmp_perm;
+
   if (transpose) {
     RowToColumnMajor(shape.data(), perm.data(), shape.size());
   }

--- a/dali/operators/generic/transpose/transpose_test.cc
+++ b/dali/operators/generic/transpose/transpose_test.cc
@@ -133,8 +133,8 @@ static constexpr auto kUniform = "_uniform";
  */
 std::vector<testing::Arguments> GetOneMasks(int rank) {
   std::vector<testing::Arguments> masks;
-  masks.reserve(1 << rank);
-  for (unsigned int mask = 0; mask < (1 << rank); mask++) {
+  masks.reserve(1u << rank);
+  for (unsigned int mask = 0; mask < (1u << rank); mask++) {
     masks.push_back({{kOnesMask, mask}});
   }
   return masks;
@@ -270,10 +270,10 @@ INSTANTIATE_TEST_SUITE_P(TransposeRank5Suite, TransposeTestRank5,
                                                        one_masks_reduced, uniform)));
 
 TEST(TransposeTest, PrepareArgumentsNoOnes) {
-  using dtype = SmallVector<int, 6>;
+  using array = SmallVector<int, 6>;
   {
-    auto shape = dtype{2};
-    auto perm = dtype{0};
+    auto shape = array{2};
+    auto perm = array{0};
     auto shape_expected = shape;
     auto perm_expected = perm;
     transpose_detail::PrepareArguments(shape, perm);
@@ -281,8 +281,8 @@ TEST(TransposeTest, PrepareArgumentsNoOnes) {
     EXPECT_EQ(perm, perm_expected);
   }
   {
-    auto shape = dtype{2, 4, 6, 8};
-    auto perm = dtype{0, 1, 2, 3};
+    auto shape = array{2, 4, 6, 8};
+    auto perm = array{0, 1, 2, 3};
     auto shape_expected = shape;
     auto perm_expected = perm;
     transpose_detail::PrepareArguments(shape, perm);
@@ -293,66 +293,66 @@ TEST(TransposeTest, PrepareArgumentsNoOnes) {
 
 
 TEST(TransposeTest, PrepareArgumentsSingleDimRemoval) {
-  using dtype = SmallVector<int, 6>;
+  using array = SmallVector<int, 6>;
   {
-    auto shape = dtype{2, 1};
-    auto perm = dtype{0, 1};
-    auto shape_expected = dtype{2};
-    auto perm_expected = dtype{0};
+    auto shape = array{2, 1};
+    auto perm = array{0, 1};
+    auto shape_expected = array{2};
+    auto perm_expected = array{0};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);
   }
   {
-    auto shape = dtype{1, 8, 6};
-    auto perm = dtype{1, 2, 0};
-    auto shape_expected = dtype{8, 6};
-    auto perm_expected = dtype{0, 1};
+    auto shape = array{1, 8, 6};
+    auto perm = array{1, 2, 0};
+    auto shape_expected = array{8, 6};
+    auto perm_expected = array{0, 1};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);
   }
   {
-    auto shape = dtype{1, 8, 6};
-    auto perm = dtype{0, 2, 1};
-    auto shape_expected = dtype{8, 6};
-    auto perm_expected = dtype{1, 0};
+    auto shape = array{1, 8, 6};
+    auto perm = array{0, 2, 1};
+    auto shape_expected = array{8, 6};
+    auto perm_expected = array{1, 0};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);
   }
   {
-    auto shape = dtype{8, 1, 6};
-    auto perm = dtype{1, 2, 0};
-    auto shape_expected = dtype{8, 6};
-    auto perm_expected = dtype{1, 0};
+    auto shape = array{8, 1, 6};
+    auto perm = array{1, 2, 0};
+    auto shape_expected = array{8, 6};
+    auto perm_expected = array{1, 0};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);
   }
   {
-    auto shape = dtype{8, 1, 6};
-    auto perm = dtype{0, 1, 2};
-    auto shape_expected = dtype{8, 6};
-    auto perm_expected = dtype{0, 1};
+    auto shape = array{8, 1, 6};
+    auto perm = array{0, 1, 2};
+    auto shape_expected = array{8, 6};
+    auto perm_expected = array{0, 1};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);
   }
   {
-    auto shape = dtype{8, 6, 1};
-    auto perm = dtype{1, 2, 0};
-    auto shape_expected = dtype{8, 6};
-    auto perm_expected = dtype{1, 0};
+    auto shape = array{8, 6, 1};
+    auto perm = array{1, 2, 0};
+    auto shape_expected = array{8, 6};
+    auto perm_expected = array{1, 0};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);
   }
   {
-    auto shape = dtype{8, 6, 1};
-    auto perm = dtype{0, 1, 2};
-    auto shape_expected = dtype{8, 6};
-    auto perm_expected = dtype{0, 1};
+    auto shape = array{8, 6, 1};
+    auto perm = array{0, 1, 2};
+    auto shape_expected = array{8, 6};
+    auto perm_expected = array{0, 1};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);
@@ -360,30 +360,30 @@ TEST(TransposeTest, PrepareArgumentsSingleDimRemoval) {
 }
 
 TEST(TransposeTest, PrepareArgumentsManyDimRemoval) {
-  using dtype = SmallVector<int, 6>;
+  using array = SmallVector<int, 6>;
   {
-    auto shape = dtype{2, 1, 1, 1, 1};
-    auto perm = dtype{0, 1, 2, 3, 4};
-    auto shape_expected = dtype{2};
-    auto perm_expected = dtype{0};
+    auto shape = array{2, 1, 1, 1, 1};
+    auto perm = array{0, 1, 2, 3, 4};
+    auto shape_expected = array{2};
+    auto perm_expected = array{0};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);
   }
   {
-    auto shape = dtype{1, 8, 1, 6, 1, 1};
-    auto perm = dtype{0, 1, 2, 3, 4, 5};
-    auto shape_expected = dtype{8, 6};
-    auto perm_expected = dtype{0, 1};
+    auto shape = array{1, 8, 1, 6, 1, 1};
+    auto perm = array{0, 1, 2, 3, 4, 5};
+    auto shape_expected = array{8, 6};
+    auto perm_expected = array{0, 1};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);
   }
   {
-    auto shape = dtype{1, 8, 1, 6, 1, 1};
-    auto perm = dtype{0, 3, 2, 1, 4, 5};
-    auto shape_expected = dtype{8, 6};
-    auto perm_expected = dtype{1, 0};
+    auto shape = array{1, 8, 1, 6, 1, 1};
+    auto perm = array{0, 3, 2, 1, 4, 5};
+    auto shape_expected = array{8, 6};
+    auto perm_expected = array{1, 0};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);
@@ -391,21 +391,21 @@ TEST(TransposeTest, PrepareArgumentsManyDimRemoval) {
 }
 
 TEST(TransposeTest, PrepareArgumentsOnlyOnes) {
-  using dtype = SmallVector<int, 6>;
+  using array = SmallVector<int, 6>;
   {
-    auto shape = dtype{1, 1, 1, 1};
-    auto perm = dtype{0, 1, 2, 3};
-    auto shape_expected = dtype{1};
-    auto perm_expected = dtype{0};
+    auto shape = array{1, 1, 1, 1};
+    auto perm = array{0, 1, 2, 3};
+    auto shape_expected = array{1};
+    auto perm_expected = array{0};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);
   }
   {
-    auto shape = dtype{1, 1, 1, 1};
-    auto perm = dtype{3, 2, 1, 0};
-    auto shape_expected = dtype{1};
-    auto perm_expected = dtype{0};
+    auto shape = array{1, 1, 1, 1};
+    auto perm = array{3, 2, 1, 0};
+    auto shape_expected = array{1};
+    auto perm_expected = array{0};
     transpose_detail::PrepareArguments(shape, perm);
     EXPECT_EQ(shape, shape_expected);
     EXPECT_EQ(perm, perm_expected);


### PR DESCRIPTION
cuTT which is used as backend for DALI Transpose
cannot handle degenerate dimensions equal 1,
so they are removed from shape description
together with the corresponding entries from permutation.

As the permutation describes transformation:
Destination dimension i <- source dimension perm[i]

If we remove dimension `i` from the shape,
we need to remove entry of a value `i` from perm,
and reduce the netries that are bigger.

It was done the other way round, removing the
entry at position `i` in perm.

Additionaly, cuTT cannot handle a permutation
with only one dimension - we now fall back
to a cudaMemcpyAsync.

In case of shape = {1, 1, ..., 1}, the preparation
step reduced it to empty shape -> this is now
special cased to always reduce to shape equal {1}
and perm = {0}, which fixes a bug in CPU Transpose
that didn't check for an empty case.

Non-uniform batch case for GPU was also fixed,
as it was not accesing the elements of the batch,
but only the first element.

GTest test were extended with additional checks
for the shape & perm reduction (for degenerate dims = 1),
and for non-unfiorm batch shapes.

Additional docstrings were added to Permutation CPU Impl.

Docstring was extended.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fixes several bugs in Transpose and adds test coverage for those cases.

#### What happened in this PR?
 - What solution was applied:
     *[ Tests for cases with degenerate dims = 1 were added, which allowed to find the bugs.
The PrepareArgs was adjusted to remove the entries containing removed dimensions `dim` instead of removing elements at position `dim` in perm. Special cases for 1-dim was added.
Non-uniform batch case got new tests and the GPU variant was fixed (although it still has sync). ]*
 - Affected modules and functionalities:
     *[ Transpose Op ]*
 - Key points relevant for the review:
     *[ PrepareArguments ]*
 - Validation and testing:
     *[ GTest ]*
 - Documentation (including examples):
     *[ Docstring for Transpose was extended with description how it actually works. I used TeX, please check if you're ok with this  ]*


**JIRA TASK**: *[DALI-1310]*
