### PR TITLE
Reworks setup_packages script

### DIFF
--- a/qa/TL0_FW_iterators/test_mxnet.sh
+++ b/qa/TL0_FW_iterators/test_mxnet.sh
@@ -2,7 +2,7 @@
 # used pip packages
 
 
-pip_packages="nose numpy opencv-python mxnet-cu{cuda_v}"
+pip_packages="nose numpy opencv-python mxnet"
 target_dir=./dali/test/python
 
 one_config_only=true

--- a/qa/TL0_framework_imports/test_mxnet.sh
+++ b/qa/TL0_framework_imports/test_mxnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 
-pip_packages="mxnet-cu{cuda_v}"
+pip_packages="mxnet"
 
 test_body() {
     # test code

--- a/qa/TL0_jupyter/test_cupy.sh
+++ b/qa/TL0_jupyter/test_cupy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="jupyter numpy matplotlib cupy-cuda{cuda_v}"
+pip_packages="jupyter numpy matplotlib cupy"
 target_dir=./docs/examples
 
 test_body() {

--- a/qa/TL0_python-self-test/test_cupy.sh
+++ b/qa/TL0_python-self-test/test_cupy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy cupy-cuda{cuda_v}"
+pip_packages="nose numpy cupy"
 target_dir=./dali/test/python
 
 # test_body definition is in separate file so it can be used without setup

--- a/qa/TL0_python_self_test_frameworks/test_cupy.sh
+++ b/qa/TL0_python_self_test_frameworks/test_cupy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy cupy-cuda{cuda_v}"
+pip_packages="nose numpy cupy"
 target_dir=./dali/test/python
 
 test_body() {

--- a/qa/TL0_python_self_test_frameworks/test_mxnet.sh
+++ b/qa/TL0_python_self_test_frameworks/test_mxnet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy mxnet-cu{cuda_v}"
+pip_packages="nose numpy mxnet"
 target_dir=./dali/test/python
 
 test_body() {

--- a/qa/TL1_jupyter_plugins/test_mxnet.sh
+++ b/qa/TL1_jupyter_plugins/test_mxnet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # used pip packages
-pip_packages="jupyter matplotlib mxnet-cu{cuda_v}"
+pip_packages="jupyter matplotlib mxnet"
 target_dir=./docs/examples/
 
 do_once() {

--- a/qa/TL1_separate_executor/test_mxnet.sh
+++ b/qa/TL1_separate_executor/test_mxnet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="torch mxnet-cu{cuda_v}"
+pip_packages="torch mxnet"
 target_dir=./dali/test/python
 one_config_only=true
 

--- a/qa/TL2_FW_iterators_perf/test.sh
+++ b/qa/TL2_FW_iterators_perf/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 # TODO(janton): remove explicit pillow version installation when torch fixes the issue with PILLOW_VERSION not being defined
-pip_packages="pillow==6.2.2 tensorflow-gpu torchvision mxnet-cu{cuda_v} torch paddle"
+pip_packages="pillow==6.2.2 tensorflow-gpu torchvision mxnet torch paddle"
 target_dir=./dali/test/python
 one_config_only=true
 


### PR DESCRIPTION
- decomposes convoluted set of dictionaries and logic behind it to a
  list of classes with appropriate methods that behave differently
  for a different type of package - plain, depending on CUDA version,
  direct Http links

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to improve setup_packages script to be more flexible and extensible

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     decomposes convoluted set of dictionaries and logic behind it to a list of classes with appropriate methods that behave differently for a different type of package - plain, depending on CUDA version, direct Http links
 - Affected modules and functionalities:
     setup_packages 
 - Key points relevant for the review:
     whole approach
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
