### PR TITLE
Fix sharding.png image link in multigpu example

### DIFF
--- a/docs/examples/general/multigpu.ipynb
+++ b/docs/examples/general/multigpu.ipynb
@@ -129,7 +129,7 @@
     "\n",
     "It is not enough to run pipelines on different GPUs. During the training we want each GPU to handle different samples at the same time. This technique is called sharding. We divide the dataset into multiple parts or shards. Then, each GPU gets its own shard to process.\n",
     "\n",
-    "![sharding.png](../../../images/sharding.png)\n",
+    "![sharding.png](../../images/sharding.png)\n",
     "\n",
     "In DALI sharding is controlled by two parameters of every reader op: `shard_id` and `num_shards`. Let's take a quick look at those parameters in the documentation for `FileReader`."
    ]


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a sharding.png image link in multigpu example

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Fixes sharding.png image link in multigpu example
 - Affected modules and functionalities:
      multigpu example
 - Key points relevant for the review:
     NA
 - Validation and testing:
     docs build
 - Documentation (including examples):
      multigpu example


**JIRA TASK**: *[NA]*
