### PR TITLE
Ignore VS Code settings directory in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ wheelhouse
 compile
 compile_debug
 .idea
+.vscode
 cmake-build-*
 ./data
 qnx/
 docs/_build
+


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It rids git status of `.vscode` directory

#### What happened in this PR?
Added `.vscode` to `.gitignore`

**JIRA TASK**: N/A

