### PR TITLE
Generator support in ExternalSource

### DIFF
--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -82,10 +82,15 @@ class _ExternalSourceGroup(object):
             pipeline.feed_input(op._name, data, op._layout)
 
 def _is_generator_function(x):
+    """Checks whether x is a generator function or a callable object
+    where __call__ is a generator function"""
     import inspect
     if inspect.isgeneratorfunction(x):
         return True
-    return _is_generator_function(getattr(x, "__call__", None))
+    if x is None or inspect.isfunction(x):
+        return False
+    call = getattr(x, "__call__", None)
+    return _is_generator_function(call)
 
 def _get_callback_from_source(source, cycle):
     iterable = False

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -1,5 +1,6 @@
 # custom wrappers around ops
 from nvidia.dali import backend as _b
+import inspect
 
 def _check_data_batch(data, batch_size, layout):
     if isinstance(data, (list, tuple)):
@@ -84,7 +85,6 @@ class _ExternalSourceGroup(object):
 def _is_generator_function(x):
     """Checks whether x is a generator function or a callable object
     where __call__ is a generator function"""
-    import inspect
     if inspect.isgeneratorfunction(x):
         return True
     if x is None or inspect.isfunction(x):
@@ -95,7 +95,6 @@ def _is_generator_function(x):
 def _get_callback_from_source(source, cycle):
     iterable = False
     if source is not None:
-        import inspect
         try:
             if cycle:
                 if inspect.isgenerator(source):
@@ -117,7 +116,7 @@ def _get_callback_from_source(source, cycle):
             if cycle is not None:
                 raise ValueError("The argument `cycle` can only be specified if `source` is iterable")
             if not callable(source):
-                raise TypeError("Source must be callable, iterable or a perameterless generator function")
+                raise TypeError("Source must be callable, iterable or a parameterless generator function")
             callback = source
     else:
         callback = None
@@ -141,15 +140,15 @@ Args
 ----
 
 `source` : callable or iterable
-    The source of the data. The source is polled for data (via a call `source()` or `next(source)`
+    The source of the data. The source is polled for data (via a call ``source()`` or ``next(source)``
     whenever the pipeline needs input for the next iteration. The source can supply one or more data
-    batches, depending on the value of `num_outputs`. If `num_outputs` is not set, the `source` is
+    batches, depending on the value of ``num_outputs``. If ``num_outputs`` is not set, the ``source`` is
     expected to return a single batch. If it's specified, the data is expected to a be tuple or list
     where each element corresponds to respective return value of the external_source.
     If the source is a callable and has a positional argument, it is assumed to be the current
-    iteration number and consecutive calls will be `source(0)`, `source(1)`, etc.
+    iteration number and consecutive calls will be ``source(0)``, ``source(1)``, etc.
     If the source is a generator function, it is invoked and treated as an iterable - however,
-    unlike a gnerator, it can be used with `cycle`, in which case the function will be called
+    unlike a gnerator, it can be used with ``cycle``, in which case the function will be called
     again when the generator reaches end of iteration.
 
 `num_outputs` : int, optional
@@ -159,19 +158,19 @@ Keyword Args
 ------------
 
 `cycle`: bool
-    If `True`, the source will be wrapped. Otherwise, StopIteration error wil be raised
-    when end of data is reached. This flag requires that `source` is either a collection, i.e. an
-    iteratble object where ``iter(source)`` will return a fresh iterator on each call or a
+    If ``True``, the source will be wrapped. Otherwise, StopIteration will be raised
+    when end of data is reached. This flag requires that ``source`` is either a collection, i.e. an
+    iterable object where ``iter(source)`` will return a fresh iterator on each call or a
     generator function. In the latter case, the generator function will be called again when more
-    data is requried than was yielded by the function.
+    data is requested than was yielded by the function.
 
 `name` : str, optional
-    The name of the data node - used when feeding the data in `iter_setup`; can be omitted if
-    the data is provided by `source`.
+    The name of the data node - used when feeding the data in ``iter_setup``; can be omitted if
+    the data is provided by ``source``.
 
 `layout` : :ref:`layout str<layout_str_doc>` or list/tuple thereof
-    If provided, sets the layout of the data. When `num_outputs` > 1, layout can be a list
-    containing a distinct layout for each output. If the list has fewer elements than `num_outputs`,
+    If provided, sets the layout of the data. When ``num_outputs > 1``, layout can be a list
+    containing a distinct layout for each output. If the list has fewer elements than ``num_outputs``,
     only the first outputs have the layout set, the reset have it cleared.
 """
 
@@ -280,8 +279,8 @@ def _is_external_source_with_callback(op_instance):
 
 def external_source(source = None, num_outputs = None, *, cycle = None, name = None, device = "cpu", layout = None):
     """Creates a data node which is populated with data from a Python source.
-The data can be provided by the `source` function or iterable, or it can be provided by
-`pipeline.feed_input(name, data, layout)` inside `pipeline.iter_setup`.
+The data can be provided by the ``source`` function or iterable, or it can be provided by
+``pipeline.feed_input(name, data, layout)`` inside ``pipeline.iter_setup``.
 
 .. note::
     To return a batch of copies of the same tensor, use :func:`nvidia.dali.types.Constant`,

--- a/dali/test/python/test_operator_external_source.py
+++ b/dali/test/python/test_operator_external_source.py
@@ -235,3 +235,30 @@ def test_external_source_with_iter():
 
     for i in range(10):
         check_output(pipe.run(), [np.array([i + 1.5], dtype=np.float32)])
+
+def test_external_source_generator():
+    pipe = Pipeline(1, 3, 0)
+
+    def gen():
+        for i in range(5):
+            yield [np.array([i + 1.5], dtype=np.float32)]
+
+    pipe.set_outputs(fn.external_source(gen()))
+    pipe.build()
+
+    for i in range(5):
+        check_output(pipe.run(), [np.array([i + 1.5], dtype=np.float32)])
+
+def test_external_source_gen_function_cycle():
+    pipe = Pipeline(1, 3, 0)
+
+    def gen():
+        for i in range(5):
+            yield [np.array([i + 1.5], dtype=np.float32)]
+
+    pipe.set_outputs(fn.external_source(gen, cycle = True))
+    pipe.build()
+
+    for cycle in range(3):
+        for i in range(5):
+            check_output(pipe.run(), [np.array([i + 1.5], dtype=np.float32)])

--- a/dali/test/python/test_operator_external_source.py
+++ b/dali/test/python/test_operator_external_source.py
@@ -262,3 +262,14 @@ def test_external_source_gen_function_cycle():
     for cycle in range(3):
         for i in range(5):
             check_output(pipe.run(), [np.array([i + 1.5], dtype=np.float32)])
+
+def test_external_source_generator_cycle_error():
+    pipe = Pipeline(1, 3, 0)
+
+    def gen():
+        for i in range(5):
+            yield [np.array([i + 1.5], dtype=np.float32)]
+
+    fn.external_source(gen(), cycle = False)     # no cycle - OK
+    with assert_raises(TypeError):
+        fn.external_source(gen(), cycle = True)  # cycle over generator - error expected


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed because apparently some people use generators

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added special handling of generator functions as sources - they will be re-invoked when cycling
     * Added specific test that the iterator is _not_ a generator when cycle is attempted - the error message points to a possible solution
     * Updated documentation for cycle and source
 - Affected modules and functionalities:
     * external source python module
 - Key points relevant for the review:
     * look at documentation and error messages, if they are clear enough
     * `_get_callback_from_source` - see if there's some use case not handled or badly handled
 - Validation and testing:
     * added test with a non-cycled generator and a cycled generator function
 - Documentation (including examples):
     * autodocs

**JIRA TASK**: N/A
