### PR TITLE
ToDecibels GPU operator

### DIFF
--- a/dali/kernels/reduce/reduce_all_gpu_test.cu
+++ b/dali/kernels/reduce/reduce_all_gpu_test.cu
@@ -207,11 +207,11 @@ void ReduceAllGPUTest<Reduction>::TestReduceAllKernel(int min_size, int max_size
     total_size += size;
   }
 
-  TestTensorList<In, ndim> in;
+  TestTensorList<In> in;
   in.reshape(data_shape);
   UniformRandomFill(in.cpu(), rng, 0.0, 1.0);
 
-  kernels::reduce::ReduceAllGPU<Out, In, ndim, Reduction> kernel;
+  kernels::reduce::ReduceAllGPU<Out, In, Reduction> kernel;
 
   auto out_shape = TensorListShape<1>::make_uniform(nsamples, TensorShape<1>{1});
   TestTensorList<Out, 1> out;

--- a/dali/kernels/reduce/reduce_all_kernel_gpu.h
+++ b/dali/kernels/reduce/reduce_all_kernel_gpu.h
@@ -29,7 +29,7 @@ namespace dali {
 namespace kernels {
 namespace reduce {
 
-template <typename Out, typename In, int ndim, typename Reduction, typename Preprocessor = identity>
+template <typename Out, typename In, typename Reduction, typename Preprocessor = identity>
 class DLL_PUBLIC ReduceAllGPU {
  public:
   // TODO(janton): remove this when implemented
@@ -39,7 +39,7 @@ class DLL_PUBLIC ReduceAllGPU {
   DLL_PUBLIC ~ReduceAllGPU() = default;
 
   DLL_PUBLIC KernelRequirements Setup(KernelContext &context,
-                                      const InListGPU<In, ndim> &in) {
+                                      const InListGPU<In, DynamicDimensions> &in) {
     auto num_samples = in.size();
     ScratchpadEstimator se;
 
@@ -68,7 +68,7 @@ class DLL_PUBLIC ReduceAllGPU {
 
   DLL_PUBLIC void Run(KernelContext &context,
                       const OutListGPU<Out, 1> &out,
-                      const InListGPU<In, ndim> &in) {
+                      const InListGPU<In, DynamicDimensions> &in) {
     DALI_ENFORCE(out.is_contiguous(), "Reduce all kernel expects the output to be contiguous");
     auto* out_start = out[0].data;
 

--- a/dali/kernels/reduce/reduce_all_kernel_gpu.h
+++ b/dali/kernels/reduce/reduce_all_kernel_gpu.h
@@ -23,6 +23,7 @@
 #include "dali/core/util.h"
 #include "dali/kernels/kernel.h"
 #include "dali/kernels/reduce/reductions.h"
+#include "dali/kernels/reduce/reduce_all_gpu_impl.cuh"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/signal/decibel/to_decibels_cpu.cc
+++ b/dali/kernels/signal/decibel/to_decibels_cpu.cc
@@ -26,13 +26,13 @@ namespace dali {
 namespace kernels {
 namespace signal {
 
-template <typename T, int Dims>
-ToDecibelsCpu<T, Dims>::~ToDecibelsCpu() = default;
+template <typename T>
+ToDecibelsCpu<T>::~ToDecibelsCpu() = default;
 
-template <typename T, int Dims>
-KernelRequirements ToDecibelsCpu<T, Dims>::Setup(
+template <typename T>
+KernelRequirements ToDecibelsCpu<T>::Setup(
     KernelContext &context,
-    const InTensorCPU<T, Dims> &in,
+    const InTensorCPU<T, DynamicDimensions> &in,
     const ToDecibelsArgs<T> &args) {
   auto out_shape = in.shape;
   std::vector<TensorShape<DynamicDimensions>> tmp = {out_shape};  // workaround for clang-6 bug
@@ -41,11 +41,11 @@ KernelRequirements ToDecibelsCpu<T, Dims>::Setup(
   return req;
 }
 
-template <typename T, int Dims>
-void ToDecibelsCpu<T, Dims>::Run(
+template <typename T>
+void ToDecibelsCpu<T>::Run(
     KernelContext &context,
-    const OutTensorCPU<T, Dims> &out,
-    const InTensorCPU<T, Dims> &in,
+    const OutTensorCPU<T, DynamicDimensions> &out,
+    const InTensorCPU<T, DynamicDimensions> &in,
     const ToDecibelsArgs<T> &args) {
   auto in_size = volume(in.shape);
   auto out_size = volume(out.shape);
@@ -69,15 +69,8 @@ void ToDecibelsCpu<T, Dims>::Run(
   }
 }
 
-template class ToDecibelsCpu<float, 1>;
-template class ToDecibelsCpu<float, 2>;
-template class ToDecibelsCpu<float, 3>;
-template class ToDecibelsCpu<float, 4>;
-
-template class ToDecibelsCpu<double, 1>;
-template class ToDecibelsCpu<double, 2>;
-template class ToDecibelsCpu<double, 3>;
-template class ToDecibelsCpu<double, 4>;
+template class ToDecibelsCpu<float>;
+template class ToDecibelsCpu<double>;
 
 }  // namespace signal
 }  // namespace kernels

--- a/dali/kernels/signal/decibel/to_decibels_cpu.h
+++ b/dali/kernels/signal/decibel/to_decibels_cpu.h
@@ -27,7 +27,7 @@ namespace dali {
 namespace kernels {
 namespace signal {
 
-template <typename T = float, int Dims = 1>
+template <typename T = float>
 class DLL_PUBLIC ToDecibelsCpu {
  public:
   static_assert(std::is_floating_point<T>::value,
@@ -36,12 +36,12 @@ class DLL_PUBLIC ToDecibelsCpu {
   DLL_PUBLIC ~ToDecibelsCpu();
 
   DLL_PUBLIC KernelRequirements Setup(KernelContext &context,
-                                      const InTensorCPU<T, Dims> &in,
+                                      const InTensorCPU<T, DynamicDimensions> &in,
                                       const ToDecibelsArgs<T> &args);
 
   DLL_PUBLIC void Run(KernelContext &context,
-                      const OutTensorCPU<T, Dims> &out,
-                      const InTensorCPU<T, Dims> &in,
+                      const OutTensorCPU<T, DynamicDimensions> &out,
+                      const InTensorCPU<T, DynamicDimensions> &in,
                       const ToDecibelsArgs<T> &args);
 };
 

--- a/dali/kernels/signal/decibel/to_decibels_cpu_test.cc
+++ b/dali/kernels/signal/decibel/to_decibels_cpu_test.cc
@@ -53,18 +53,18 @@ class ToDecibelsCpuTest : public::testing::TestWithParam<
     std::mt19937 rng;
     UniformRandomFill(in_view_, rng, 0.0, data_max_);
   }
-  TensorShape<2> data_shape_;
+  TensorShape<> data_shape_;
   float mul_ = 10.0;
   float s_ref_ = 1.0;
   float min_ratio_ = 1e-8;
   float data_max_ = 1.0;
   bool ref_max_ = false;
   std::vector<float> data_;
-  OutTensorCPU<float, 2> in_view_;
+  OutTensorCPU<float, DynamicDimensions> in_view_;
 };
 
 template <typename T>
-void print_data(const OutTensorCPU<T, 2>& data_view) {
+void print_data(const OutTensorCPU<T, DynamicDimensions>& data_view) {
   auto sh = data_view.shape;
   for (int i0 = 0; i0 < sh[0]; i0++) {
     for (int i1 = 0; i1 < sh[1]; i1++) {
@@ -77,8 +77,7 @@ void print_data(const OutTensorCPU<T, 2>& data_view) {
 
 TEST_P(ToDecibelsCpuTest, ToDecibelsCpuTest) {
   using T = float;
-  constexpr int Dims = 2;
-  ToDecibelsCpu<T, Dims> kernel;
+  ToDecibelsCpu<T> kernel;
   check_kernel<decltype(kernel)>();
 
   KernelContext ctx;
@@ -99,7 +98,8 @@ TEST_P(ToDecibelsCpuTest, ToDecibelsCpuTest) {
 
   auto out_size = volume(out_shape);
   std::vector<T> expected_out(out_size);
-  auto expected_out_view = OutTensorCPU<T, Dims>(expected_out.data(), out_shape.to_static<Dims>());
+  auto expected_out_view =
+      OutTensorCPU<T, DynamicDimensions>(expected_out.data(), out_shape);
 
   if (ref_max_) {
     s_ref_ = 0.0;
@@ -124,7 +124,7 @@ TEST_P(ToDecibelsCpuTest, ToDecibelsCpuTest) {
   LOG_LINE << "ref_max: " << s_ref_ << std::endl;
 
   std::vector<T> out(out_size);
-  auto out_view = OutTensorCPU<T, Dims>(out.data(), out_shape.to_static<Dims>());
+  auto out_view = OutTensorCPU<T, DynamicDimensions>(out.data(), out_shape);
   kernel.Run(ctx, out_view, in_view_, args);
 
   LOG_LINE << "out:\n";

--- a/dali/kernels/signal/decibel/to_decibels_gpu.cu
+++ b/dali/kernels/signal/decibel/to_decibels_gpu.cu
@@ -51,12 +51,12 @@ __global__ void ToDecibelsKernel(const SampleDesc<T>* sample_data,
   }
 }
 
-template <typename T, int Dims>
-ToDecibelsGpu<T, Dims>::~ToDecibelsGpu() = default;
+template <typename T>
+ToDecibelsGpu<T>::~ToDecibelsGpu() = default;
 
-template <typename T, int Dims>
-KernelRequirements ToDecibelsGpu<T, Dims>::Setup(KernelContext &context,
-                                                 const InListGPU<T, Dims> &in) {
+template <typename T>
+KernelRequirements ToDecibelsGpu<T>::Setup(KernelContext &context,
+                                           const InListGPU<T, DynamicDimensions> &in) {
   auto out_shape = in.shape;
   const size_t num_samples = in.size();
   ScratchpadEstimator se;
@@ -68,10 +68,10 @@ KernelRequirements ToDecibelsGpu<T, Dims>::Setup(KernelContext &context,
   return req;
 }
 
-template <typename T, int Dims>
-void ToDecibelsGpu<T, Dims>::Run(KernelContext &context, const OutListGPU<T, Dims> &out,
-                                 const InListGPU<T, Dims> &in, const ToDecibelsArgs<T> &args,
-                                 InListGPU<T, 1> max_values) {
+template <typename T>
+void ToDecibelsGpu<T>::Run(KernelContext &context, const OutListGPU<T, DynamicDimensions> &out,
+                           const InListGPU<T, DynamicDimensions> &in, const ToDecibelsArgs<T> &args,
+                           InListGPU<T, 1> max_values) {
   DALI_ENFORCE(max_values.empty() || max_values.is_contiguous(),
       "Reduce all kernel expects the output to be contiguous");
   const T* max_values_data = max_values.empty() ? nullptr : max_values[0].data;
@@ -99,15 +99,8 @@ void ToDecibelsGpu<T, Dims>::Run(KernelContext &context, const OutListGPU<T, Dim
       sample_data_gpu, args, max_values_data);
 }
 
-template class ToDecibelsGpu<float, 1>;
-template class ToDecibelsGpu<float, 2>;
-template class ToDecibelsGpu<float, 3>;
-template class ToDecibelsGpu<float, 4>;
-
-template class ToDecibelsGpu<double, 1>;
-template class ToDecibelsGpu<double, 2>;
-template class ToDecibelsGpu<double, 3>;
-template class ToDecibelsGpu<double, 4>;
+template class ToDecibelsGpu<float>;
+template class ToDecibelsGpu<double>;
 
 }  // namespace signal
 }  // namespace kernels

--- a/dali/kernels/signal/decibel/to_decibels_gpu.h
+++ b/dali/kernels/signal/decibel/to_decibels_gpu.h
@@ -27,7 +27,7 @@ namespace dali {
 namespace kernels {
 namespace signal {
 
-template <typename T = float, int Dims = 1>
+template <typename T = float>
 class DLL_PUBLIC ToDecibelsGpu {
  public:
   static_assert(std::is_floating_point<T>::value,
@@ -36,11 +36,11 @@ class DLL_PUBLIC ToDecibelsGpu {
   DLL_PUBLIC ~ToDecibelsGpu();
 
   DLL_PUBLIC KernelRequirements Setup(KernelContext &context,
-                                      const InListGPU<T, Dims> &in);
+                                      const InListGPU<T, DynamicDimensions> &in);
 
   DLL_PUBLIC void Run(KernelContext &context,
-                      const OutListGPU<T, Dims> &out,
-                      const InListGPU<T, Dims> &in,
+                      const OutListGPU<T, DynamicDimensions> &out,
+                      const InListGPU<T, DynamicDimensions> &in,
                       const ToDecibelsArgs<T> &args,
                       InListGPU<T, 1> max_values = {});
 };

--- a/dali/kernels/signal/decibel/to_decibels_gpu.h
+++ b/dali/kernels/signal/decibel/to_decibels_gpu.h
@@ -42,7 +42,7 @@ class DLL_PUBLIC ToDecibelsGpu {
                       const OutListGPU<T, Dims> &out,
                       const InListGPU<T, Dims> &in,
                       const ToDecibelsArgs<T> &args,
-                      InTensorGPU<T, 1> max_values = {});
+                      InListGPU<T, 1> max_values = {});
 };
 
 }  // namespace signal

--- a/dali/kernels/signal/decibel/to_decibels_gpu_test.cc
+++ b/dali/kernels/signal/decibel/to_decibels_gpu_test.cc
@@ -93,7 +93,7 @@ TEST_P(ToDecibelsGpuTest, ToDecibelsGpuTest) {
 
   std::vector<T> max_values(batch_size, 0.0);
   memory::KernelUniquePtr<T> max_values_gpu;
-  InTensorGPU<T, 1> max_values_arg;
+  InListGPU<T, 1> max_values_arg;
   if (args.ref_max) {
     for (int b = 0; b < batch_size; ++b) {
       int64_t sz = volume(data_shape_[b]);
@@ -106,7 +106,8 @@ TEST_P(ToDecibelsGpuTest, ToDecibelsGpuTest) {
     max_values_gpu = memory::alloc_unique<T>(AllocType::GPU, batch_size);
     cudaMemcpy(max_values_gpu.get(), max_values.data(), batch_size * sizeof(T),
                cudaMemcpyHostToDevice);
-    max_values_arg = {max_values_gpu.get(), TensorShape<1>{batch_size}};
+    max_values_arg = {max_values_gpu.get(),
+                      TensorListShape<1>::make_uniform(batch_size, TensorShape<1>{1})};
   }
 
   kernel.Run(ctx, out.gpu(), in_.gpu(), args, max_values_arg);

--- a/dali/kernels/signal/decibel/to_decibels_gpu_test.cc
+++ b/dali/kernels/signal/decibel/to_decibels_gpu_test.cc
@@ -27,11 +27,10 @@ namespace kernels {
 namespace signal {
 namespace test {
 
-static constexpr int ndim = 2;
 using T = float;
 
 using TestBase = ::testing::TestWithParam<
-  std::tuple<std::vector<TensorShape<ndim>>,  // data shape
+  std::tuple<std::vector<TensorShape<>>,  // data shape
              T /* mul */,
              T /* s_ref */,
              T /* min_ratio */,
@@ -57,13 +56,13 @@ class ToDecibelsGpuTest : public TestBase {
     std::mt19937 rng;
     UniformRandomFill(in_.cpu(), rng, 0.0, 1.0);
   }
-  TensorListShape<ndim> data_shape_;
+  TensorListShape<> data_shape_;
   T mul_ = 10.0;
   T s_ref_ = 1.0;
   T min_ratio_ = 1e-8;
   T data_max_ = 1.0;
   bool ref_max_ = false;
-  TestTensorList<T, ndim> in_;
+  TestTensorList<T> in_;
 };
 
 TEST_P(ToDecibelsGpuTest, ToDecibelsGpuTest) {
@@ -77,7 +76,7 @@ TEST_P(ToDecibelsGpuTest, ToDecibelsGpuTest) {
   args.min_ratio = min_ratio_;
   args.ref_max = ref_max_;
 
-  kernels::signal::ToDecibelsGpu<T, ndim> kernel;
+  kernels::signal::ToDecibelsGpu<T> kernel;
   auto req = kernel.Setup(ctx, in_.gpu());
 
   ScratchpadAllocator scratch_alloc;
@@ -86,7 +85,7 @@ TEST_P(ToDecibelsGpuTest, ToDecibelsGpuTest) {
   ctx.scratchpad = &scratchpad;
 
   ASSERT_EQ(data_shape_, req.output_shapes[0]);
-  TestTensorList<T, ndim> out;
+  TestTensorList<T> out;
   out.reshape(data_shape_);
 
   auto in_view_cpu = in_.cpu();
@@ -128,8 +127,8 @@ TEST_P(ToDecibelsGpuTest, ToDecibelsGpuTest) {
 }
 
 INSTANTIATE_TEST_SUITE_P(ToDecibelsGpuTest, ToDecibelsGpuTest, testing::Combine(
-    testing::Values(std::vector<TensorShape<2>>{TensorShape<2>{10, 1}},
-                    std::vector<TensorShape<2>>{TensorShape<2>{1, 10}}),  // shape
+    testing::Values(std::vector<TensorShape<>>{TensorShape<>{10, 1}},
+                    std::vector<TensorShape<>>{TensorShape<>{1, 10}}),  // shape
     testing::Values(10.0, 20.0),     // mul
     testing::Values(1.0, 1e-6),      // s_ref
     testing::Values(1e-8, 1e-20),    // min_ratio

--- a/dali/operators/generic/erase/erase.cc
+++ b/dali/operators/generic/erase/erase.cc
@@ -132,7 +132,7 @@ resulting in centered erased regions at the specified *anchor*.)code",
   .SupportVolumetric();
 
 template <typename T, int Dims>
-class EraseImplCpu : public detail::OpImplBase<CPUBackend> {
+class EraseImplCpu : public OpImplBase<CPUBackend> {
  public:
   using EraseKernel = kernels::EraseCpu<T, Dims>;
 

--- a/dali/operators/generic/erase/erase.h
+++ b/dali/operators/generic/erase/erase.h
@@ -25,6 +25,7 @@
 #include "dali/kernels/scratch.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/util/operator_impl_utils.h"
 
 namespace dali {
 
@@ -45,7 +46,7 @@ class Erase : public Operator<Backend> {
 
   USE_OPERATOR_MEMBERS();
 
-  std::unique_ptr<detail::OpImplBase<Backend>> impl_;
+  std::unique_ptr<OpImplBase<Backend>> impl_;
 };
 
 }  // namespace dali

--- a/dali/operators/image/crop/bbox_crop.cc
+++ b/dali/operators/image/crop/bbox_crop.cc
@@ -252,7 +252,7 @@ Note: If left empty, ``"WH"`` or ``"WHD"`` will be assumed, depending on the num
         TensorLayout{""});
 
 template <int ndim>
-class RandomBBoxCropImpl : public detail::OpImplBase<CPUBackend> {
+class RandomBBoxCropImpl : public OpImplBase<CPUBackend> {
  public:
   static constexpr int coords_size = ndim * 2;
 

--- a/dali/operators/image/crop/bbox_crop.h
+++ b/dali/operators/image/crop/bbox_crop.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
-
+#include "dali/pipeline/util/operator_impl_utils.h"
 
 namespace dali {
 
@@ -34,7 +34,7 @@ class RandomBBoxCrop : public Operator<Backend> {
   void RunImpl(Workspace<Backend> &ws) override;
 
  private:
-  std::unique_ptr<detail::OpImplBase<Backend>> impl_;
+  std::unique_ptr<OpImplBase<Backend>> impl_;
   int impl_ndim_ = -1;
   OpSpec spec_;
 };

--- a/dali/operators/signal/decibel/to_decibels_op.h
+++ b/dali/operators/signal/decibel/to_decibels_op.h
@@ -26,9 +26,6 @@
 #include "dali/pipeline/operator/operator.h"
 #include "dali/pipeline/util/operator_impl_utils.h"
 
-#define TO_DB_SUPPORTED_TYPES (float)
-#define TO_DB_SUPPORTED_NDIMS (1, 2, 3, 4)
-
 static constexpr int kNumInputs = 1;
 static constexpr int kNumOutputs = 1;
 
@@ -64,7 +61,6 @@ class ToDecibels : public Operator<Backend> {
 
   std::unique_ptr<OpImplBase<Backend>> impl_;
   DALIDataType type_;
-  int ndim_;
 };
 
 }  // namespace dali

--- a/dali/operators/signal/decibel/to_decibels_op.h
+++ b/dali/operators/signal/decibel/to_decibels_op.h
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_OPERATORS_SIGNAL_DECIBEL_TO_DECIBELS_H_
-#define DALI_OPERATORS_SIGNAL_DECIBEL_TO_DECIBELS_H_
+#ifndef DALI_OPERATORS_SIGNAL_DECIBEL_TO_DECIBELS_OP_H_
+#define DALI_OPERATORS_SIGNAL_DECIBEL_TO_DECIBELS_OP_H_
 
 #include <cmath>
+#include <memory>
 #include <string>
 #include <vector>
 #include "dali/core/common.h"
@@ -23,6 +24,13 @@
 #include "dali/kernels/signal/decibel/to_decibels_args.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/util/operator_impl_utils.h"
+
+#define TO_DB_SUPPORTED_TYPES (float)
+#define TO_DB_SUPPORTED_NDIMS (1, 2, 3, 4)
+
+static constexpr int kNumInputs = 1;
+static constexpr int kNumOutputs = 1;
 
 namespace dali {
 
@@ -46,15 +54,19 @@ class ToDecibels : public Operator<Backend> {
  protected:
   bool CanInferOutputs() const override { return true; }
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override;
-  void RunImpl(workspace_t<CPUBackend> &ws) override;
+  void RunImpl(workspace_t<Backend> &ws) override;
 
   USE_OPERATOR_MEMBERS();
   using Operator<Backend>::RunImpl;
 
   kernels::KernelManager kmgr_;
   kernels::signal::ToDecibelsArgs<float> args_;
+
+  std::unique_ptr<OpImplBase<Backend>> impl_;
+  DALIDataType type_;
+  int ndim_;
 };
 
 }  // namespace dali
 
-#endif  // DALI_OPERATORS_SIGNAL_DECIBEL_TO_DECIBELS_H_
+#endif  // DALI_OPERATORS_SIGNAL_DECIBEL_TO_DECIBELS_OP_H_

--- a/dali/operators/signal/decibel/to_decibels_op_cpu.cc
+++ b/dali/operators/signal/decibel/to_decibels_op_cpu.cc
@@ -12,16 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/operators/signal/decibel/to_decibels.h"
+#include "dali/operators/signal/decibel/to_decibels_op.h"
 #include "dali/core/static_switch.h"
 #include "dali/kernels/signal/decibel/to_decibels_cpu.h"
 #include "dali/pipeline/data/views.h"
-
-#define TO_DB_SUPPORTED_TYPES (float)
-#define TO_DB_SUPPORTED_NDIMS (1, 2, 3, 4)
-
-static constexpr int kNumInputs = 1;
-static constexpr int kNumOutputs = 1;
 
 namespace dali {
 

--- a/dali/operators/signal/decibel/to_decibels_op_cpu.cc
+++ b/dali/operators/signal/decibel/to_decibels_op_cpu.cc
@@ -51,19 +51,16 @@ bool ToDecibels<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
   int nsamples = input.size();
   auto nthreads = ws.GetThreadPool().size();
 
-  TYPE_SWITCH(input.type().id(), type2id, T, TO_DB_SUPPORTED_TYPES, (
-    VALUE_SWITCH(in_shape.sample_dim(), Dims, TO_DB_SUPPORTED_NDIMS, (
-      using ToDbKernel = kernels::signal::ToDecibelsCpu<T, Dims>;
-      kmgr_.Initialize<ToDbKernel>();
-      kmgr_.Resize<ToDbKernel>(nthreads, nsamples);
-      output_desc[0].type = TypeInfo::Create<T>();
-      output_desc[0].shape.resize(nsamples, Dims);
-      for (int i = 0; i < nsamples; i++) {
-        const auto in_view = view<const T, Dims>(input[i]);
-        auto &req = kmgr_.Setup<ToDbKernel>(i, ctx, in_view, args_);
-        output_desc[0].shape.set_tensor_shape(i, req.output_shapes[0][0].shape);
-      }
-    ), DALI_FAIL(make_string("Unsupported number of dimensions ", in_shape.size())));  // NOLINT
+  TYPE_SWITCH(input.type().id(), type2id, T, (float), (
+    using ToDbKernel = kernels::signal::ToDecibelsCpu<T>;
+    kmgr_.Initialize<ToDbKernel>();
+    kmgr_.Resize<ToDbKernel>(nthreads, nsamples);
+    output_desc[0].shape = in_shape;
+    output_desc[0].type = TypeInfo::Create<T>();
+    for (int i = 0; i < nsamples; i++) {
+      const auto in_view = view<const T>(input[i]);
+      auto &req = kmgr_.Setup<ToDbKernel>(i, ctx, in_view, args_);
+    }
   ), DALI_FAIL(make_string("Unsupported data type: ", input.type().id())));  // NOLINT
   return true;
 }
@@ -76,19 +73,17 @@ void ToDecibels<CPUBackend>::RunImpl(workspace_t<CPUBackend> &ws) {
   int nsamples = input.size();
   auto& thread_pool = ws.GetThreadPool();
 
-  TYPE_SWITCH(input.type().id(), type2id, T, TO_DB_SUPPORTED_TYPES, (
-    VALUE_SWITCH(in_shape.sample_dim(), Dims, TO_DB_SUPPORTED_NDIMS, (
-      using ToDbKernel = kernels::signal::ToDecibelsCpu<T, Dims>;
-      for (int i = 0; i < input.shape().num_samples(); i++) {
-        thread_pool.DoWorkWithID(
-          [this, &input, &output, i](int thread_id) {
-            kernels::KernelContext ctx;
-            auto in_view = view<const T, Dims>(input[i]);
-            auto out_view = view<T, Dims>(output[i]);
-            kmgr_.Run<ToDbKernel>(thread_id, i, ctx, out_view, in_view, args_);
-          });
-      }
-    ), DALI_FAIL(make_string("Unsupported number of dimensions ", in_shape.size())));  // NOLINT
+  TYPE_SWITCH(input.type().id(), type2id, T, (float), (
+    using ToDbKernel = kernels::signal::ToDecibelsCpu<T>;
+    for (int i = 0; i < input.shape().num_samples(); i++) {
+      thread_pool.DoWorkWithID(
+        [this, &input, &output, i](int thread_id) {
+          kernels::KernelContext ctx;
+          auto in_view = view<const T>(input[i]);
+          auto out_view = view<T>(output[i]);
+          kmgr_.Run<ToDbKernel>(thread_id, i, ctx, out_view, in_view, args_);
+        });
+    }
   ), DALI_FAIL(make_string("Unsupported data type: ", input.type().id())));  // NOLINT
 
   thread_pool.WaitForWork();

--- a/dali/operators/signal/decibel/to_decibels_op_gpu.cu
+++ b/dali/operators/signal/decibel/to_decibels_op_gpu.cu
@@ -57,15 +57,13 @@ class ToDecibelsImpl : public OpImplBase<GPUBackend> {
 template <typename T, int Dims>
 bool ToDecibelsImpl<T, Dims>::SetupImpl(std::vector<OutputDesc> &output_desc,
                                         const workspace_t<GPUBackend> &ws) {
-  kernels::KernelContext ctx;
-  ctx.gpu.stream = ws.stream();
-
   const auto &input = ws.InputRef<GPUBackend>(0);
   auto in_view = view<const T, Dims>(input);
   auto nsamples = input.size();
 
   auto type = TypeInfo::Create<T>();
 
+  kernels::KernelContext ctx;
   if (args_.ref_max) {
     auto& req_max = kmgr_max_.Setup<MaxKernel>(0, ctx, in_view);
     max_out_desc_.resize(1);

--- a/dali/operators/signal/fft/spectrogram.cc
+++ b/dali/operators/signal/fft/spectrogram.cc
@@ -61,7 +61,7 @@ true, the signal is mirrored with respect to the boundary, otherwise the signal 
 zeros. Note: This option is ignored when `center_windows` is set to false.)code",
     true);
 
-struct SpectrogramImplCpu : detail::OpImplBase<CPUBackend> {
+struct SpectrogramImplCpu : OpImplBase<CPUBackend> {
   using OutputType = float;
   using InputType = float;
 

--- a/dali/operators/signal/fft/spectrogram.h
+++ b/dali/operators/signal/fft/spectrogram.h
@@ -20,6 +20,7 @@
 #include "dali/core/common.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/util/operator_impl_utils.h"
 
 namespace dali {
 
@@ -48,7 +49,7 @@ class DLL_PUBLIC Spectrogram : public Operator<Backend> {
  private:
   OpSpec spec__;
 
-  std::unique_ptr<detail::OpImplBase<Backend>> impl_;
+  std::unique_ptr<OpImplBase<Backend>> impl_;
 };
 
 }  // namespace dali

--- a/dali/operators/signal/fft/spectrogram_gpu.cc
+++ b/dali/operators/signal/fft/spectrogram_gpu.cc
@@ -30,7 +30,7 @@ using kernels::KernelContext;
 using kernels::signal::Padding;
 using namespace kernels::signal::fft;  // NOLINT
 
-struct SpectrogramOpImplGPU : public detail::OpImplBase<GPUBackend> {
+struct SpectrogramOpImplGPU : public OpImplBase<GPUBackend> {
   explicit SpectrogramOpImplGPU(const OpSpec &spec) {
     args.window_length = spec.GetArgument<int>("window_length");
     args.window_step = spec.GetArgument<int>("window_step");

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -395,34 +395,6 @@ DALI_DECLARE_OPTYPE_REGISTRY(MixedOperator, OperatorBase);
 
 DLL_PUBLIC std::unique_ptr<OperatorBase> InstantiateOperator(const OpSpec &spec);
 
-namespace detail {
-
-template <typename Backend>
-class OpImplBase {
- public:
-  virtual ~OpImplBase() = default;
-  virtual bool SetupImpl(std::vector<OutputDesc> &output_desc,
-                         const workspace_t<Backend> &ws) = 0;
-  virtual void RunImpl(workspace_t<Backend> &ws) = 0;
-};
-
-template <>
-class OpImplBase<CPUBackend> {
- public:
-  virtual ~OpImplBase() = default;
-  virtual bool SetupImpl(std::vector<OutputDesc> &output_desc,
-                         const workspace_t<CPUBackend> &ws) = 0;
-  virtual void RunImpl(HostWorkspace &ws) {
-    assert(false);
-  }
-  virtual void RunImpl(SampleWorkspace &ws) {
-    assert(false);
-  }
-};
-
-}  // namespace detail
-
-
 }  // namespace dali
 
 #endif  // DALI_PIPELINE_OPERATOR_OPERATOR_H_

--- a/dali/pipeline/util/operator_impl_utils.h
+++ b/dali/pipeline/util/operator_impl_utils.h
@@ -18,7 +18,7 @@
 #include <vector>
 #include "dali/core/common.h"
 #include "dali/pipeline/data/backend.h"
-#include "dali/pipeline/operator/workspace.h"
+#include "dali/pipeline/workspace/workspace.h"
 #include "dali/pipeline/util/backend2workspace_map.h"
 #include "dali/pipeline/workspace/device_workspace.h"
 #include "dali/pipeline/workspace/sample_workspace.h"


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to convert signal magnitude to decibel scale on the GPU

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Introduced ToDecibels GPU operator, based on ToDecibels kernel and ReduceAll kernel (to calculate maximum)*
     *Remove some leftover OpImplBase that should have been removed in a previous commit*
 - Affected modules and functionalities:
     *ToDecibels operator*
 - Key points relevant for the review:
     *The operator*
 - Validation and testing:
     *Python tests added*
 - Documentation (including examples):
     *Operator documentation already present from the CPU implementation*


**JIRA TASK**: *[DALI-1345]*
