### PR TITLE
Allow seed to be set for serialized pipeline

### DIFF
--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -63,9 +63,9 @@ namespace dali {
 
 
 Pipeline::Pipeline(const string &serialized_pipe, int batch_size, int num_threads, int device_id,
-                   int64_t seed, bool pipelined_execution, int prefetch_queue_depth,
-                   bool async_execution, size_t bytes_per_sample_hint, bool set_affinity,
-                   int max_num_stream, int default_cuda_stream_priority)
+                   bool pipelined_execution, int prefetch_queue_depth, bool async_execution,
+                   size_t bytes_per_sample_hint, bool set_affinity, int max_num_stream,
+                   int default_cuda_stream_priority, int64_t seed)
         : built_(false), separated_execution_(false) {
     dali_proto::PipelineDef def;
     //  Reading Protobuf file has a limitation of 64 MB

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -121,7 +121,8 @@ void Pipeline::Init(int batch_size, int num_threads, int device_id, int64_t seed
     this->batch_size_ = batch_size;
     this->num_threads_ = num_threads;
     this->device_id_ = device_id;
-    this->original_seed_ = seed;
+    using Clock = std::chrono::high_resolution_clock;
+    this->original_seed_ = seed < 0 ? Clock::now().time_since_epoch().count() : seed;
     this->pipelined_execution_ = pipelined_execution;
     this->separated_execution_ = separated_execution;
     this->async_execution_ = async_execution;
@@ -150,11 +151,7 @@ void Pipeline::Init(int batch_size, int num_threads, int device_id, int64_t seed
 
     seed_.resize(MAX_SEEDS);
     current_seed_ = 0;
-    if (seed < 0) {
-      using Clock = std::chrono::high_resolution_clock;
-      seed = Clock::now().time_since_epoch().count();
-    }
-    std::seed_seq ss{seed};
+    std::seed_seq ss{this->original_seed_};
     ss.generate(seed_.begin(), seed_.end());
   }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -96,7 +96,7 @@ class DLL_PUBLIC Pipeline {
   }
 
   DLL_PUBLIC Pipeline(const string &serialized_pipe, int batch_size = -1, int num_threads = -1,
-                      int device_id = -1, bool pipelined_execution = true,
+                      int device_id = -1, int64_t seed = -1, bool pipelined_execution = true,
                       int prefetch_queue_depth = 2, bool async_execution = true,
                       size_t bytes_per_sample_hint = 0, bool set_affinity = false,
                       int max_num_stream = -1, int default_cuda_stream_priority = 0);

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -95,11 +95,13 @@ class DLL_PUBLIC Pipeline {
          default_cuda_stream_priority, QueueSizes{prefetch_queue_depth});
   }
 
+
   DLL_PUBLIC Pipeline(const string &serialized_pipe, int batch_size = -1, int num_threads = -1,
-                      int device_id = -1, int64_t seed = -1, bool pipelined_execution = true,
+                      int device_id = -1, bool pipelined_execution = true,
                       int prefetch_queue_depth = 2, bool async_execution = true,
                       size_t bytes_per_sample_hint = 0, bool set_affinity = false,
-                      int max_num_stream = -1, int default_cuda_stream_priority = 0);
+                      int max_num_stream = -1, int default_cuda_stream_priority = 0,
+                      int64_t seed = -1);
 
   DLL_PUBLIC ~Pipeline() = default;
 


### PR DESCRIPTION
Similarly to other Pipeline params (refer the other ctor), this PR allows `seed` to be set for ctor with serialized pipeline.

Few comments required:

I'm aware, that `-1` might be legitimate seed value, thus prolly shouldn't be a default value, but not in our code:
```
    if (seed < 0) {
      using Clock = std::chrono::high_resolution_clock;
      seed = Clock::now().time_since_epoch().count();
    }
```
Without `optional` there's no clean way to handle default seed in this case. I could go with `int64_t* seed = nullptr`, but alongside the rest of parameters, it would be obscure. `using optional = std::pair<T, bool>` also looks questinably compliated. Plus, we go with `-1` as default seed anyway: in the other ctor.

I have an impression, that the seed was used incorrectly. Let's say, that `-1` is passed to the `Init(...)`. `original_seed_` is set to `-1`. Then, in the snippet I pasted above, `seed` is set according to clock. Finally, when somebody serializes the pipeline (`SerializeToProtobuf`), the `-1` is set as the `original_seed_`, instead of the clock-wise value assigned before. It might be intentional though, please double-check.

Signed-off-by: Michał Szołucha <szal@szal-mbp.local>
