### PR TITLE
Fix a leak of the last created DALI pipeline instance

### DIFF
--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -212,7 +212,6 @@ Parameters
             pipeline_tls.pipeline_stack = [prev]
         else:
             stack.append(prev)
-        pipeline_tls.prev_pipeline = pipeline
         return prev
 
     @staticmethod


### PR DESCRIPTION
- removes unsused `pipeline_tls.prev_pipeline = pipeline` that keeps an unnecessary reference to the current pipeline
- adds test for this case

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a leak of the last created DALI pipeline instance

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     removes unsused `pipeline_tls.prev_pipeline = pipeline` that keeps an unnecessary reference to the current pipeline
 - Affected modules and functionalities:
     pipeline
 - Key points relevant for the review:
     NA
 - Validation and testing:
     test is added
 - Documentation (including examples):
     NA

In response to https://github.com/NVIDIA/DALI/issues/1842

**JIRA TASK**: *[NA]*
