### PR TITLE
Reduce kernel CPU rename

### DIFF
--- a/dali/kernels/reduce/online_reducer.h
+++ b/dali/kernels/reduce/online_reducer.h
@@ -15,7 +15,7 @@
 #ifndef DALI_KERNELS_REDUCE_ONLINE_REDUCER_H_
 #define DALI_KERNELS_REDUCE_ONLINE_REDUCER_H_
 
-#include "dali/kernels/reduce/reduce.h"
+#include "dali/kernels/reduce/reductions.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/reduce/reduce_all_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_all_gpu_impl.cuh
@@ -17,7 +17,7 @@
 
 
 #include "dali/core/util.h"
-#include "dali/kernels/reduce/reduce.h"
+#include "dali/kernels/reduce/reductions.h"
 #include "dali/kernels/reduce/reduce_common.cuh"
 
 namespace dali {

--- a/dali/kernels/reduce/reduce_all_kernel_gpu.h
+++ b/dali/kernels/reduce/reduce_all_kernel_gpu.h
@@ -22,7 +22,7 @@
 #include "dali/core/format.h"
 #include "dali/core/util.h"
 #include "dali/kernels/kernel.h"
-#include "dali/kernels/reduce/reduce.h"
+#include "dali/kernels/reduce/reductions.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
@@ -17,7 +17,7 @@
 
 
 #include "dali/core/util.h"
-#include "dali/kernels/reduce/reduce.h"
+#include "dali/kernels/reduce/reductions.h"
 #include "dali/kernels/reduce/reduce_all_gpu_impl.cuh"
 #include "dali/kernels/reduce/reduce_common.cuh"
 #include "dali/kernels/reduce/online_reducer.h"

--- a/dali/kernels/reduce/reduce_axes_gpu_test.cu
+++ b/dali/kernels/reduce/reduce_axes_gpu_test.cu
@@ -22,6 +22,7 @@
 #include "dali/kernels/alloc.h"
 #include "dali/test/test_tensors.h"
 #include "dali/test/tensor_test_utils.h"
+#include "dali/core/format.h"
 #include "dali/core/tensor_shape_print.h"
 #include "dali/core/cuda_event.h"
 

--- a/dali/kernels/reduce/reduce_cpu.h
+++ b/dali/kernels/reduce/reduce_cpu.h
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_REDUCE_REDUCE_H_
-#define DALI_KERNELS_REDUCE_REDUCE_H_
+#ifndef DALI_KERNELS_REDUCE_REDUCE_CPU_H_
+#define DALI_KERNELS_REDUCE_REDUCE_CPU_H_
 
 #include <cassert>
 #include <utility>
 #include <vector>
 #include "dali/kernels/kernel.h"
 #include "dali/kernels/common/utils.h"
-#include "dali/core/convert.h"
+#include "dali/kernels/reduce/reductions.h"
 #include "dali/core/format.h"
 #include "dali/core/small_vector.h"
 #include "dali/core/span.h"
@@ -31,87 +31,6 @@
 
 namespace dali {
 namespace kernels {
-namespace reductions {
-
-struct square {
-  template <typename T>
-  DALI_HOST_DEV DALI_FORCEINLINE
-  auto operator()(const T &x) const noexcept {
-    return x * x;
-  }
-
-  DALI_HOST_DEV DALI_FORCEINLINE
-  int64_t operator()(int32_t x) const noexcept {
-    return static_cast<int64_t>(x) * x;
-  }
-
-  DALI_HOST_DEV DALI_FORCEINLINE
-  uint64_t operator()(uint32_t x) const noexcept {
-    return static_cast<uint64_t>(x) * x;
-  }
-};
-
-template <typename Mean>
-struct variance {
-  Mean mean = 0;
-  template <typename T>
-  DALI_HOST_DEV DALI_FORCEINLINE
-  auto operator()(const T &x) const noexcept {
-    auto d = x - mean;
-    return d * d;
-  }
-};
-
-struct sum {
-  template <typename Acc, typename Addend>
-  DALI_HOST_DEV DALI_FORCEINLINE
-  void operator()(Acc &acc, const Addend &val) const noexcept {
-    acc += val;
-  }
-
-  template <typename T>
-  DALI_HOST_DEV DALI_FORCEINLINE
-  static constexpr T neutral() noexcept { return 0; }
-};
-
-struct min {
-  template <typename T, typename U>
-  DALI_HOST_DEV DALI_FORCEINLINE
-  void operator()(T &min_val, const U &val) const noexcept {
-    if (val < min_val)
-      min_val = val;
-  }
-
-  template <typename T>
-  DALI_HOST_DEV DALI_FORCEINLINE
-  static constexpr T neutral() noexcept { return max_value<T>(); }
-};
-
-struct max {
-  template <typename T, typename U>
-  DALI_HOST_DEV DALI_FORCEINLINE
-  void operator()(T &min_val, const U &val) const noexcept {
-    if (val > min_val)
-      min_val = val;
-  }
-
-  template <typename T>
-  DALI_HOST_DEV DALI_FORCEINLINE
-  static constexpr T neutral() noexcept { return min_value<T>(); }
-};
-
-template <typename Reduction>
-struct is_accurate : std::false_type {};
-
-template <>
-struct is_accurate<min> : std::true_type {};
-template <>
-struct is_accurate<max> : std::true_type {};
-
-template <typename Reduction>
-constexpr bool IsAccurate(const Reduction &) { return is_accurate<Reduction>::value; }
-
-}  // namespace reductions
 
 namespace reduce_impl {
 
@@ -219,7 +138,7 @@ void reduce(Dst &reduced, const StridedTensor<StorageCPU, Src> &in,
  *
  */
 template <typename Dst, typename Src, typename Actual>
-struct ReduceBase {
+struct ReduceBaseCPU {
   void Setup(const OutTensorCPU<Dst, -1> &out,
              const InTensorCPU<Src, -1> &in,
              span<const int> axes) {
@@ -248,8 +167,8 @@ struct ReduceBase {
   }
 
   void PostprocessAll() {
-    if (reinterpret_cast<decltype(&ReduceBase::Postprocess)>(&Actual::Postprocess) ==
-        &ReduceBase::Postprocess)
+    if (reinterpret_cast<decltype(&ReduceBaseCPU::Postprocess)>(&Actual::Postprocess) ==
+        &ReduceBaseCPU::Postprocess)
       return;  // trivial postprocessing, nothing to do
 
     int64_t v = output.num_elements();
@@ -389,11 +308,11 @@ struct ReduceBase {
 };
 
 template <typename Dst, typename Src>
-struct Sum : ReduceBase<Dst, Src, Sum<Dst, Src>> {
+struct SumCPU : ReduceBaseCPU<Dst, Src, SumCPU<Dst, Src>> {
 };
 
 template <typename Dst, typename Src>
-struct Mean : ReduceBase<Dst, Src, Mean<Dst, Src>> {
+struct MeanCPU : ReduceBaseCPU<Dst, Src, MeanCPU<Dst, Src>> {
   void PostSetup() {
     int64_t v = 1;
     for (auto a : this->axes)
@@ -411,8 +330,8 @@ struct Mean : ReduceBase<Dst, Src, Mean<Dst, Src>> {
 
 
 template <typename Dst, typename Src>
-struct MeanSquare : ReduceBase<Dst, Src, MeanSquare<Dst, Src>> {
-  using Base = ReduceBase<Dst, Src, MeanSquare<Dst, Src>>;
+struct MeanSquareCPU : ReduceBaseCPU<Dst, Src, MeanSquareCPU<Dst, Src>> {
+  using Base = ReduceBaseCPU<Dst, Src, MeanSquareCPU<Dst, Src>>;
 
   void PostSetup() {
     int64_t v = 1;
@@ -432,8 +351,8 @@ struct MeanSquare : ReduceBase<Dst, Src, MeanSquare<Dst, Src>> {
 
 
 template <typename Dst, typename Src>
-struct RootMeanSquare : ReduceBase<Dst, Src, RootMeanSquare<Dst, Src>> {
-  using Base = ReduceBase<Dst, Src, RootMeanSquare<Dst, Src>>;
+struct RootMeanSquareCPU : ReduceBaseCPU<Dst, Src, RootMeanSquareCPU<Dst, Src>> {
+  using Base = ReduceBaseCPU<Dst, Src, RootMeanSquareCPU<Dst, Src>>;
 
   void PostSetup() {
     int64_t v = 1;
@@ -452,8 +371,8 @@ struct RootMeanSquare : ReduceBase<Dst, Src, RootMeanSquare<Dst, Src>> {
 };
 
 template <typename Dst, typename Src, typename MeanType = Dst>
-struct Variance : ReduceBase<Dst, Src, Variance<Dst, Src, MeanType>> {
-  using Base = ReduceBase<Dst, Src, Variance<Dst, Src, MeanType>>;
+struct VarianceCPU : ReduceBaseCPU<Dst, Src, VarianceCPU<Dst, Src, MeanType>> {
+  using Base = ReduceBaseCPU<Dst, Src, VarianceCPU<Dst, Src, MeanType>>;
   InTensorCPU<MeanType, -1> mean;
 
   void Setup(const OutTensorCPU<Dst, -1> &out,
@@ -481,8 +400,8 @@ struct Variance : ReduceBase<Dst, Src, Variance<Dst, Src, MeanType>> {
 };
 
 template <typename Dst, typename Src, typename MeanType = Dst>
-struct StdDev : ReduceBase<Dst, Src, StdDev<Dst, Src, MeanType>> {
-  using Base = ReduceBase<Dst, Src, StdDev<Dst, Src, MeanType>>;
+struct StdDevCPU : ReduceBaseCPU<Dst, Src, StdDevCPU<Dst, Src, MeanType>> {
+  using Base = ReduceBaseCPU<Dst, Src, StdDevCPU<Dst, Src, MeanType>>;
   InTensorCPU<MeanType, -1> mean;
 
   void Setup(const OutTensorCPU<Dst, -1> &out,
@@ -517,4 +436,4 @@ struct StdDev : ReduceBase<Dst, Src, StdDev<Dst, Src, MeanType>> {
 }  // namespace kernels
 }  // namespace dali
 
-#endif  // DALI_KERNELS_REDUCE_REDUCE_H_
+#endif  // DALI_KERNELS_REDUCE_REDUCE_CPU_H_

--- a/dali/kernels/reduce/reduce_cpu_test.cc
+++ b/dali/kernels/reduce/reduce_cpu_test.cc
@@ -15,7 +15,7 @@
 #include <gtest/gtest.h>
 #include <random>
 #include <chrono>
-#include "dali/kernels/reduce/reduce.h"
+#include "dali/kernels/reduce/reduce_cpu.h"
 
 namespace dali {
 namespace kernels {
@@ -28,7 +28,7 @@ inline Out microseconds(std::chrono::duration<R, P> d) {
 }
 
 TEST(ReduceTest, Mean2D) {
-  Mean<float, int> mean;
+  MeanCPU<float, int> mean;
 
   const int W = 11, H = 7;
   float xmean = (W-1)/2;
@@ -136,21 +136,21 @@ void TestStatelessReduction3D(bool mean, Preprocess pre, Postprocess post) {
 }
 
 TEST(ReduceTest, Sum3D) {
-  TestStatelessReduction3D<Sum<float, int>>(
+  TestStatelessReduction3D<SumCPU<float, int>>(
     false,
     dali::identity(),
     dali::identity());
 }
 
 TEST(ReduceTest, Mean3D) {
-  TestStatelessReduction3D<Mean<float, int>>(
+  TestStatelessReduction3D<MeanCPU<float, int>>(
     true,
     dali::identity(),
     dali::identity());
 }
 
 TEST(ReduceTest, MeanSquare3D) {
-  TestStatelessReduction3D<MeanSquare<float, int>>(
+  TestStatelessReduction3D<MeanSquareCPU<float, int>>(
     true,
     reductions::square(),
     dali::identity());
@@ -158,15 +158,15 @@ TEST(ReduceTest, MeanSquare3D) {
 
 TEST(ReduceTest, RootMeanSquare3D) {
   auto sqrt = [](auto x) { return std::sqrt(x); };
-  TestStatelessReduction3D<RootMeanSquare<float, int>>(
+  TestStatelessReduction3D<RootMeanSquareCPU<float, int>>(
     true,
     reductions::square(),
     sqrt);
 }
 
 TEST(ReduceTest, StdDev) {
-  Mean<float, float> mean;
-  StdDev<float, float> stddev;
+  MeanCPU<float, float> mean;
+  StdDevCPU<float, float> stddev;
 
   std::mt19937_64 rng(1337);
   std::normal_distribution<float> dist(10, 42);

--- a/dali/kernels/reduce/reductions.h
+++ b/dali/kernels/reduce/reductions.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_REDUCE_REDUCTIONS_H_
+#define DALI_KERNELS_REDUCE_REDUCTIONS_H_
+
+#include <cassert>
+#include <utility>
+#include <vector>
+#include "dali/kernels/kernel.h"
+#include "dali/kernels/common/utils.h"
+#include "dali/core/util.h"
+#include "dali/core/convert.h"
+
+namespace dali {
+namespace kernels {
+namespace reductions {
+
+struct square {
+  template <typename T>
+  DALI_HOST_DEV DALI_FORCEINLINE
+  auto operator()(const T &x) const noexcept {
+    return x * x;
+  }
+
+  DALI_HOST_DEV DALI_FORCEINLINE
+  int64_t operator()(int32_t x) const noexcept {
+    return static_cast<int64_t>(x) * x;
+  }
+
+  DALI_HOST_DEV DALI_FORCEINLINE
+  uint64_t operator()(uint32_t x) const noexcept {
+    return static_cast<uint64_t>(x) * x;
+  }
+};
+
+template <typename Mean>
+struct variance {
+  Mean mean = 0;
+  template <typename T>
+  DALI_HOST_DEV DALI_FORCEINLINE
+  auto operator()(const T &x) const noexcept {
+    auto d = x - mean;
+    return d * d;
+  }
+};
+
+struct sum {
+  template <typename Acc, typename Addend>
+  DALI_HOST_DEV DALI_FORCEINLINE
+  void operator()(Acc &acc, const Addend &val) const noexcept {
+    acc += val;
+  }
+
+  template <typename T>
+  DALI_HOST_DEV DALI_FORCEINLINE
+  static constexpr T neutral() noexcept { return 0; }
+};
+
+struct min {
+  template <typename T, typename U>
+  DALI_HOST_DEV DALI_FORCEINLINE
+  void operator()(T &min_val, const U &val) const noexcept {
+    if (val < min_val)
+      min_val = val;
+  }
+
+  template <typename T>
+  DALI_HOST_DEV DALI_FORCEINLINE
+  static constexpr T neutral() noexcept { return max_value<T>(); }
+};
+
+struct max {
+  template <typename T, typename U>
+  DALI_HOST_DEV DALI_FORCEINLINE
+  void operator()(T &min_val, const U &val) const noexcept {
+    if (val > min_val)
+      min_val = val;
+  }
+
+  template <typename T>
+  DALI_HOST_DEV DALI_FORCEINLINE
+  static constexpr T neutral() noexcept { return min_value<T>(); }
+};
+
+template <typename Reduction>
+struct is_accurate : std::false_type {};
+
+template <>
+struct is_accurate<min> : std::true_type {};
+template <>
+struct is_accurate<max> : std::true_type {};
+
+template <typename Reduction>
+constexpr bool IsAccurate(const Reduction &) { return is_accurate<Reduction>::value; }
+
+}  // namespace reductions
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_REDUCE_REDUCTIONS_H_

--- a/dali/operators/math/normalize/normalize.cc
+++ b/dali/operators/math/normalize/normalize.cc
@@ -16,7 +16,7 @@
 #include "dali/core/math_util.h"
 #include "dali/core/tensor_layout.h"
 #include "dali/kernels/normalize/normalize_cpu.h"
-#include "dali/kernels/reduce/reduce.h"
+#include "dali/kernels/reduce/reduce_cpu.h"
 #include "dali/operators/math/normalize/normalize_utils.h"
 
 namespace dali {
@@ -221,7 +221,7 @@ void Normalize<CPUBackend>::RunTyped(HostWorkspace &ws) {
     if (ShouldCalcMean()) {
       for (int i = 0; i < nsamples; i++) {
         tp.DoWorkWithID([&, i](int thread_idx) {
-          kernels::Mean<float, InputType> mean;
+          kernels::MeanCPU<float, InputType> mean;
           mean.Setup(mutable_mean[i], in_view[i], make_span(axes_));
           // Reset per-sample values, but don't postprocess
           mean.Run(true, false);
@@ -236,7 +236,7 @@ void Normalize<CPUBackend>::RunTyped(HostWorkspace &ws) {
       auto sample_mean = mean_view[0];
       for (int i = 0; i < nsamples; i++) {
         tp.DoWorkWithID([&, i](int thread_idx) {
-          kernels::Variance<float, InputType> stddev;
+          kernels::VarianceCPU<float, InputType> stddev;
           stddev.Setup(mutable_stddev[i], in_view[i], make_span(axes_), sample_mean);
           // Reset per-sample values, but don't postprocess
           stddev.Run(true, false);
@@ -264,7 +264,7 @@ void Normalize<CPUBackend>::RunTyped(HostWorkspace &ws) {
 
       if (!batch_norm_) {
         if (ShouldCalcMean()) {
-          kernels::Mean<float, InputType> mean;
+          kernels::MeanCPU<float, InputType> mean;
           mean.Setup(mutable_mean[i], in_view[i], make_span(axes_));
           // Reset per-sample values and preprocess
           mean.Run(true, true);
@@ -272,7 +272,7 @@ void Normalize<CPUBackend>::RunTyped(HostWorkspace &ws) {
         }
 
         if (ShouldCalcStdDev()) {
-          kernels::Variance<float, InputType> stddev;
+          kernels::VarianceCPU<float, InputType> stddev;
           stddev.Setup(mutable_stddev[i], in_view[i], make_span(axes_), sample_mean);
           // Reset per-sample values, but don't postprocess
           stddev.Run(true, false);


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to make room for GPU reductions.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Reductions from CPU renamed with -CPU suffix
     * Moved pairwise reduction primitives to a standalone header.
 - Affected modules and functionalities:
     * Reductions, normalize operator.
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * N/A
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-1250 (sort of)

