### PR TITLE
Make SSDRandomCrop calculate crop window in double precision

### DIFF
--- a/dali/operators/ssd/random_crop.cc
+++ b/dali/operators/ssd/random_crop.cc
@@ -225,11 +225,11 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace &ws) {
 
       // need RNG generators for left, top
       std::uniform_real_distribution<float> l_dis(0., 1. - w), t_dis(0., 1. - h);
-      auto left = l_dis(rngs_[sample]);
-      auto top = t_dis(rngs_[sample]);
+      double left = l_dis(rngs_[sample]);
+      double top = t_dis(rngs_[sample]);
 
-      auto right = left + w;
-      auto bottom = top + h;
+      double right = left + w;
+      double bottom = top + h;
 
       crop_ptr[0] = left;
       crop_ptr[1] = top;
@@ -306,10 +306,10 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace &ws) {
       }  // end bbox copy
 
       // everything is good, generate the crop parameters
-      const int left_idx = std::lround(left * wtot);
-      const int top_idx = std::lround(top * htot);
-      const int right_idx = std::lround(right * wtot);
-      const int bottom_idx = std::lround(bottom * htot);
+      const int left_idx = std::llround(left * wtot);
+      const int top_idx = std::llround(top * htot);
+      const int right_idx = std::llround(right * wtot);
+      const int bottom_idx = std::llround(bottom * htot);
 
       // perform the crop
       detail::crop(img, {left_idx, top_idx, right_idx, bottom_idx},


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug resulting in misalignment of crop window calculation between SSDRandomCrop  and BBoxRandomCraop

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Made SSDRandomCrop calculate images in double precision
 - Affected modules and functionalities:
     SSDRandomCrop 
 - Key points relevant for the review:
     NA
 - Validation and testing:
     run failing test case ` python test_detection_pipeline.py -s 2634774052 -i 300`
 - Documentation (including examples):
     NA

**JIRA TASK**: *[NA]*
