### PR TITLE
Make reader respect shard_id pipeline argument in tf.data.Dataset with multiple GPUs example

### DIFF
--- a/docs/examples/frameworks/tensorflow/tensorflow-dataset-multigpu.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-dataset-multigpu.ipynb
@@ -67,7 +67,7 @@
     "        super(MnistPipeline, self).__init__(\n",
     "            batch_size, num_threads, device_id, seed)\n",
     "        self.reader = ops.Caffe2Reader(\n",
-    "            path=data_path, random_shuffle=True, shard_id=0, num_shards=num_shards)\n",
+    "            path=data_path, random_shuffle=True, shard_id=shard_id, num_shards=num_shards)\n",
     "        self.decode = ops.ImageDecoder(\n",
     "            device='mixed',\n",
     "            output_type=types.GRAY)\n",


### PR DESCRIPTION

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug with the reader having a fixed value of shard_id  in tf.data.Dataset with multiple GPUs example

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     makes reader respect shard_id pipeline argument in tf.data.Dataset with multiple GPUs example
 - Affected modules and functionalities:
     tf.data.Dataset with multiple GPUs example
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     tf.data.Dataset with multiple GPUs example is updated

In response to https://github.com/NVIDIA/DALI/issues/1849
**JIRA TASK**: *[NA]*
