### PR TITLE
Change StrictVersion to LooseVersion in TensorFlow plugin

### DIFF
--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -20,7 +20,7 @@ import os
 import glob
 from collections import Iterable
 import re
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 import warnings
 
 
@@ -139,12 +139,12 @@ def DALIRawIterator():
 
 
 def _get_tf_version():
-  return StrictVersion(tf.__version__)
+  return LooseVersion(tf.__version__)
 
 
-MIN_TENSORFLOW_VERSION = StrictVersion('1.15')
+MIN_TENSORFLOW_VERSION = LooseVersion('1.15')
 def dataset_compatible_tensorflow():
-    return StrictVersion(tf.__version__) >= MIN_TENSORFLOW_VERSION
+    return LooseVersion(tf.__version__) >= MIN_TENSORFLOW_VERSION
 
 
 if dataset_compatible_tensorflow():
@@ -256,7 +256,7 @@ if dataset_compatible_tensorflow():
         output_dtypes = self._output_dtypes)
 
 
-  if _get_tf_version() < StrictVersion('2.0'):
+  if _get_tf_version() < LooseVersion('2.0'):
     class DALIDataset(dataset_ops.DatasetV1Adapter):
       @functools.wraps(_DALIDatasetV2.__init__)
       def __init__(self, pipeline, **kwargs):


### PR DESCRIPTION
- StrictVersion doesn't handle properly "-rcX" inside the version string.
  LooseVersion, according to the docs `When comparing version numbers,
  the numeric components will be compared numerically, and the alphabetic
  components lexically`

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug that TF plugin cannot handle properly "-rcX" in the TF version string

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     change StrictVersion to LooseVersion in TensorFlow plugin
 - Affected modules and functionalities:
     TF plugin
 - Key points relevant for the review:
     NA
 - Validation and testing:
     Tested locally with TF 2.0.0rc2
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
