### PR TITLE
Add support for array and cuda_array interface for DALI tensor

### DIFF
--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -74,6 +74,14 @@ def test_data_ptr_tensor_list_cpu():
     from_tensor_list = py_buffer_from_address(tensorlist.data_ptr(), tensor.shape(), tensor.dtype())
     assert(np.array_equal(arr, from_tensor_list))
 
+def test_array_interface_tensor_cpu():
+    arr = np.random.rand(3, 5, 6)
+    tensorlist = TensorListCPU(arr, "NHWC")
+    assert tensorlist[0].__array_interface__['data'][0] == tensorlist[0].data_ptr()
+    assert tensorlist[0].__array_interface__['data'][1] == True
+    assert np.array_equal(tensorlist[0].__array_interface__['shape'], tensorlist[0].shape())
+    assert tensorlist[0].__array_interface__['typestr'] == tensorlist[0].dtype()
+
 #if 0  // TODO(spanev): figure out which return_value_policy to choose
 #def test_tensorlist_getitem_slice():
 #    arr = np.random.rand(3, 5, 6)

--- a/dali/test/python/test_backend_impl_gpu.py
+++ b/dali/test/python/test_backend_impl_gpu.py
@@ -67,3 +67,14 @@ def test_data_ptr_tensor_list_gpu():
     from_tensor = py_buffer_from_address(tensor_list.data_ptr(), tensor.shape(), tensor.dtype(), gpu=True)
     # from_tensor is cupy array, convert arr to cupy as well
     assert(cp.allclose(cp.array(arr), from_tensor))
+
+def test_cuda_array_interface_tensor_gpu():
+    arr = np.random.rand(3, 5, 6)
+    pipe = ExternalSourcePipe(arr.shape[0], arr)
+    pipe.build()
+    tensor_list = pipe.run()[0]
+    assert tensor_list[0].__cuda_array_interface__['data'][0] == tensor_list[0].data_ptr()
+    assert tensor_list[0].__cuda_array_interface__['data'][1] == True
+    assert np.array_equal(tensor_list[0].__cuda_array_interface__['shape'], tensor_list[0].shape())
+    assert tensor_list[0].__cuda_array_interface__['typestr'] == tensor_list[0].dtype()
+    assert(cp.allclose(cp.array(arr[0]), cp.asanyarray(tensor_list[0])))


### PR DESCRIPTION
- adds an ability to expose CPUTensor and GPUTensor using `__array_interface__`
  and `__cuda_array_interface__` making interoperability with CuPy and Numpy
  even smoother
- makes possible to make non owning Tensor from DALI memory- PyTorch, CuPy and Numba support it

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds an ability to expose CPUTensor and GPUTensor using `__array_interface__`  and `__cuda_array_interface__` making interoperability with CuPy and Numpy even smoother

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds an ability to expose CPUTensor and GPUTensor using `__array_interface__`  and `__cuda_array_interface__` making interoperability with CuPy and Numpy even smoother
 - Affected modules and functionalities:
       backend_impl
 - Key points relevant for the review:
     NA
 - Validation and testing:
     new tests are added
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
