### PR TITLE
Add support for TensorFlow 2.2.0rc2

### DIFF
--- a/docs/examples/frameworks/tensorflow/tensorflow-dataset-multigpu.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-dataset-multigpu.ipynb
@@ -105,12 +105,12 @@
     "options.experimental_optimization.autotune = False\n",
     "\n",
     "\n",
-    "shapes = [\n",
+    "shapes = (\n",
     "    (BATCH_SIZE, IMAGE_SIZE, IMAGE_SIZE),\n",
-    "    (BATCH_SIZE)]\n",
-    "dtypes = [\n",
+    "    (BATCH_SIZE))\n",
+    "dtypes = (\n",
     "    tf.float32,\n",
-    "    tf.int32]"
+    "    tf.int32)"
    ]
   },
   {
@@ -177,8 +177,8 @@
     "                pipeline=MnistPipeline(\n",
     "                    BATCH_SIZE, device_id=i, shard_id=i, num_shards=NUM_DEVICES),\n",
     "                batch_size=BATCH_SIZE,\n",
-    "                shapes=shapes,\n",
-    "                dtypes=dtypes,\n",
+    "                output_shapes=shapes,\n",
+    "                output_dtypes=dtypes,\n",
     "                device_id=i).with_options(options)\n",
     "\n",
     "            iterator = tf.data.make_initializable_iterator(daliset)\n",
@@ -230,12 +230,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Step 0, accuracy: 0.109375\n",
-      "Step 100, accuracy: 0.875\n",
-      "Step 200, accuracy: 0.84375\n",
-      "Step 300, accuracy: 0.953125\n",
+      "Step 0, accuracy: 0.171875\n",
+      "Step 100, accuracy: 0.9375\n",
+      "Step 200, accuracy: 0.859375\n",
+      "Step 300, accuracy: 0.921875\n",
       "Step 400, accuracy: 0.90625\n",
-      "Final accuracy:  0.915\n"
+      "Final accuracy:  0.92015625\n"
      ]
     }
    ],
@@ -276,7 +276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/tensorflow/tensorflow-dataset.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-dataset.ipynb
@@ -39,7 +39,7 @@
     "        self.device = device\n",
     "        self.reader = ops.Caffe2Reader(path=data_path, random_shuffle=True)\n",
     "        self.decode = ops.ImageDecoder(\n",
-    "            device='mixed' if device is 'gpu' else 'cpu',\n",
+    "            device='mixed' if device == 'gpu' else 'cpu',\n",
     "            output_type=types.GRAY)\n",
     "        self.cmn = ops.CropMirrorNormalize(\n",
     "            device=device,\n",
@@ -51,7 +51,7 @@
     "    def define_graph(self):\n",
     "        inputs, labels = self.reader(name=\"Reader\")\n",
     "        images = self.decode(inputs)\n",
-    "        if self.device is 'gpu':\n",
+    "        if self.device == 'gpu':\n",
     "            labels = labels.gpu()\n",
     "        images = self.cmn(images)\n",
     "\n",
@@ -103,19 +103,19 @@
     "mnist_pipeline = MnistPipeline(BATCH_SIZE, device='cpu', device_id=0)\n",
     "\n",
     "# Define shapes and types of the outputs\n",
-    "shapes = [\n",
+    "shapes = (\n",
     "    (BATCH_SIZE, IMAGE_SIZE, IMAGE_SIZE),\n",
-    "    (BATCH_SIZE)]\n",
-    "dtypes = [\n",
+    "    (BATCH_SIZE))\n",
+    "dtypes = (\n",
     "    tf.float32,\n",
-    "    tf.int32]\n",
+    "    tf.int32)\n",
     "\n",
     "# Create dataset\n",
     "mnist_set = dali_tf.DALIDataset(\n",
     "    pipeline=mnist_pipeline,\n",
     "    batch_size=BATCH_SIZE,\n",
-    "    shapes=shapes,\n",
-    "    dtypes=dtypes,\n",
+    "    output_shapes=shapes,\n",
+    "    output_dtypes=dtypes,\n",
     "    device_id=0)"
    ]
   },
@@ -141,21 +141,21 @@
      "text": [
       "Train on 100 steps\n",
       "Epoch 1/5\n",
-      "100/100 [==============================] - 1s 6ms/step - loss: 0.8921 - accuracy: 0.7462\n",
+      "100/100 [==============================] - 0s 2ms/step - loss: 0.9089 - accuracy: 0.7437\n",
       "Epoch 2/5\n",
-      "100/100 [==============================] - 0s 4ms/step - loss: 0.4115 - accuracy: 0.8847\n",
+      "100/100 [==============================] - 0s 2ms/step - loss: 0.4085 - accuracy: 0.8841\n",
       "Epoch 3/5\n",
-      "100/100 [==============================] - 0s 3ms/step - loss: 0.3235 - accuracy: 0.9062\n",
+      "100/100 [==============================] - 0s 2ms/step - loss: 0.3223 - accuracy: 0.9078\n",
       "Epoch 4/5\n",
-      "100/100 [==============================] - 0s 4ms/step - loss: 0.2926 - accuracy: 0.9202\n",
+      "100/100 [==============================] - 0s 2ms/step - loss: 0.2839 - accuracy: 0.9180\n",
       "Epoch 5/5\n",
-      "100/100 [==============================] - 0s 4ms/step - loss: 0.2617 - accuracy: 0.9245\n"
+      "100/100 [==============================] - 0s 2ms/step - loss: 0.2543 - accuracy: 0.9284\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<tensorflow.python.keras.callbacks.History at 0x7fc3a4955518>"
+       "<tensorflow.python.keras.callbacks.History at 0x7fe5a82e60d0>"
       ]
      },
      "execution_count": 4,
@@ -208,8 +208,8 @@
     "    mnist_set = dali_tf.DALIDataset(\n",
     "        pipeline=mnist_pipeline,\n",
     "        batch_size=BATCH_SIZE,\n",
-    "        shapes=shapes,\n",
-    "        dtypes=dtypes,\n",
+    "        output_shapes=shapes,\n",
+    "        output_dtypes=dtypes,\n",
     "        device_id=0)\n",
     "    model = tf.keras.models.Sequential([\n",
     "        tf.keras.layers.Input(shape=(IMAGE_SIZE, IMAGE_SIZE), name='images'),\n",
@@ -244,15 +244,15 @@
      "text": [
       "Train on 100 steps\n",
       "Epoch 1/5\n",
-      "100/100 [==============================] - 1s 7ms/step - loss: 0.9235 - accuracy: 0.7381\n",
+      "100/100 [==============================] - 0s 3ms/step - loss: 0.8987 - accuracy: 0.7414\n",
       "Epoch 2/5\n",
-      "100/100 [==============================] - 1s 6ms/step - loss: 0.4115 - accuracy: 0.8856\n",
+      "100/100 [==============================] - 0s 3ms/step - loss: 0.4121 - accuracy: 0.8775\n",
       "Epoch 3/5\n",
-      "100/100 [==============================] - 1s 6ms/step - loss: 0.3243 - accuracy: 0.9050\n",
+      "100/100 [==============================] - 0s 3ms/step - loss: 0.3193 - accuracy: 0.9028\n",
       "Epoch 4/5\n",
-      "100/100 [==============================] - 0s 5ms/step - loss: 0.2932 - accuracy: 0.9166\n",
+      "100/100 [==============================] - 0s 3ms/step - loss: 0.2877 - accuracy: 0.9183\n",
       "Epoch 5/5\n",
-      "100/100 [==============================] - 1s 7ms/step - loss: 0.2606 - accuracy: 0.9212\n"
+      "100/100 [==============================] - 0s 3ms/step - loss: 0.2611 - accuracy: 0.9237\n"
      ]
     }
    ],
@@ -331,8 +331,8 @@
     "        mnist_set = dali_tf.DALIDataset(\n",
     "            pipeline=mnist_pipeline,\n",
     "            batch_size=BATCH_SIZE,\n",
-    "            shapes=shapes,\n",
-    "            dtypes=dtypes,\n",
+    "            output_shapes=shapes,\n",
+    "            output_dtypes=dtypes,\n",
     "            device_id=0)\n",
     "        mnist_set = mnist_set.map(\n",
     "            lambda features, labels: ({'images': features}, labels))\n",
@@ -355,7 +355,7 @@
     {
      "data": {
       "text/plain": [
-       "<tensorflow_estimator.python.estimator.canned.dnn.DNNClassifier at 0x7fc3a6ad8b70>"
+       "<tensorflow_estimator.python.estimator.canned.dnn.DNNClassifier at 0x7fe5a81950d0>"
       ]
      },
      "execution_count": 9,
@@ -376,10 +376,10 @@
     {
      "data": {
       "text/plain": [
-       "{'accuracy': 0.87921876,\n",
-       " 'average_loss': 0.49361104,\n",
-       " 'loss': 31.591106,\n",
-       " 'global_step': 17500}"
+       "{'accuracy': 0.90046877,\n",
+       " 'average_loss': 0.46437886,\n",
+       " 'loss': 29.720247,\n",
+       " 'global_step': 2500}"
       ]
      },
      "execution_count": 10,
@@ -419,8 +419,8 @@
     "    mnist_set = dali_tf.DALIDataset(\n",
     "        pipeline=MnistPipeline(BATCH_SIZE, device='gpu', device_id=0),\n",
     "        batch_size=BATCH_SIZE,\n",
-    "        shapes=shapes,\n",
-    "        dtypes=dtypes,\n",
+    "        output_shapes=shapes,\n",
+    "        output_dtypes=dtypes,\n",
     "        device_id=0).with_options(options)\n",
     "\n",
     "    iterator = tf.data.make_initializable_iterator(mnist_set)\n",
@@ -462,12 +462,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Step 0, accuracy: 0.109375\n",
-      "Step 100, accuracy: 0.828125\n",
-      "Step 200, accuracy: 0.828125\n",
-      "Step 300, accuracy: 0.96875\n",
-      "Step 400, accuracy: 0.890625\n",
-      "Final accuracy:  0.90734375\n"
+      "Step 0, accuracy: 0.15625\n",
+      "Step 100, accuracy: 0.90625\n",
+      "Step 200, accuracy: 0.84375\n",
+      "Step 300, accuracy: 0.953125\n",
+      "Step 400, accuracy: 0.90625\n",
+      "Final accuracy:  0.91171875\n"
      ]
     }
    ],
@@ -507,7 +507,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/qa/TL1_tensorflow_dataset/test.sh
+++ b/qa/TL1_tensorflow_dataset/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose jupyter tensorflow-gpu ipykernel<5.0.0 ipython<7.0.0"
+pip_packages="nose jupyter tensorflow-gpu"
 target_dir=./dali/test/python
 
 # populate epilog and prolog with variants to enable/disable conda and virtual env

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -322,8 +322,8 @@ all_packages = [PlainPackage("opencv-python", ["4.2.0.32"]),
                         "mxnet-cu{cuda_v}"),
                 CudaPackage("tensorflow-gpu",
                         { "90"  : [PckgVer("1.12.0", python_max_ver="3.7")],
-                          "100" : [PckgVer("1.14.0",  python_max_ver="3.7"), PckgVer("1.15.2",  python_max_ver="3.7"), \
-                                   PckgVer("2.0.1",  python_max_ver="3.7"), PckgVer("2.1.0",  python_max_ver="3.7")] }),
+                          "100" : [PckgVer("1.15.2",  python_max_ver="3.7"), PckgVer("2.1.0",  python_max_ver="3.7"), \
+                                   "2.2.0rc2"] }),
                 CudaHttpPackage("torch",
                         { "90"  : ["http://download.pytorch.org/whl/cu{cuda_v}/torch-1.1.0-{platform}.whl"],
                           "100" : ["http://download.pytorch.org/whl/cu{cuda_v}/torch-1.4.0+cu{cuda_v}-{platform}.whl"] }),


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds support for TensorFlow 2.2.0rc2

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds TensorFlow 2.2.0rc2 to setup_packages.py
     removes TensorFlow support for 1.14.0 and 2.0.1 which are not that popular anymore
     remove changes from #1568, TensorFlow 1.15 seems to work again with the latest ipykernel and ipython
 - Affected modules and functionalities:
     setup_packages.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1363]*
