### PR TITLE
Remove of usage of internal Sphinx _MockImporter method

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@
 import os
 import sys
 import sphinx_rtd_theme
-from sphinx.ext.autodoc.importer import mock, _MockImporter
+from sphinx.ext.autodoc.mock import mock
 from builtins import str
 import re
 import subprocess
@@ -49,12 +49,10 @@ release = str(version_long)
 
 # generate table of supported operators and their devices
 # mock torch required by supported_op_devices
-importer = _MockImporter(["torch"])
-importer.load_module("torch")
-sys.path.insert(0, os.path.abspath('./'))
-import supported_op_devices
-
-supported_op_devices.main(["op_inclusion"])
+with mock(["torch"]):
+    sys.path.insert(0, os.path.abspath('./'))
+    import supported_op_devices
+    supported_op_devices.main(["op_inclusion"])
 
 # Uncomment to keep warnings in the output. Useful for verbose build and output debugging.
 # keep_warnings = True


### PR DESCRIPTION
- adds support for proper module mocking in sphinx using `mock` method

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds support for proper module mocking in sphinx using `mock` method

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds support for proper module mocking in sphinx using `mock` method
     removes of usage of internal Sphinx _MockImporter method
 - Affected modules and functionalities:
     docs generation
 - Key points relevant for the review:
     module mocking inside sphinx
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
