### PR TITLE
Add ExternalSource to "C API"

### DIFF
--- a/dali/c_api/CMakeLists.txt
+++ b/dali/c_api/CMakeLists.txt
@@ -15,3 +15,4 @@
 # Get all the source files
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(DALI_SRCS PARENT_SCOPE)
+collect_test_sources(DALI_TEST_SRCS PARENT_SCOPE)

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -74,12 +74,12 @@ void daliPrefetchSeparate(daliPipelineHandle* pipe_handle,
 }
 
 void daliSetExternalInput(daliPipelineHandle* pipe_handle, const char* name, device_type_t device,
-                          const void* data_ptr, dali_data_type_t data_type, const int64_t* shape,
+                          const void* data_ptr, dali_data_type_t data_type, const int64_t* shapes,
                           int sample_dim, const char* layout_str) {
   DALI_ENFORCE(device == CPU, "GPU data cannot be passed as external source");
   dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
-  std::vector<int64_t> shapes_tmp(shape, shape + sample_dim * pipeline->batch_size());
-  dali::TensorListShape<> shapes(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
+  std::vector<int64_t> shapes_tmp(shapes, shapes + sample_dim * pipeline->batch_size());
+  dali::TensorListShape<> tl_shape(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
   dali::TensorLayout layout{};
   if (layout_str != nullptr) {
     layout = dali::TensorLayout(layout_str);
@@ -90,8 +90,8 @@ void daliSetExternalInput(daliPipelineHandle* pipe_handle, const char* name, dev
   // We cast away the const from data_ptr, as there is no other way of passing it to the
   // TensorList, as we must also set the shape and type metadata.
   // It is passed further as const TensorList, so it's data cannot be modified.
-  data.ShareData(const_cast<void*>(data_ptr), shapes.num_elements() * elem_sizeof);
-  data.Resize(shapes, type_info);
+  data.ShareData(const_cast<void*>(data_ptr), tl_shape.num_elements() * elem_sizeof);
+  data.Resize(tl_shape, type_info);
   data.SetLayout(layout);
   const auto& cdata = data;
   pipeline->SetExternalInput(name, cdata);
@@ -99,12 +99,12 @@ void daliSetExternalInput(daliPipelineHandle* pipe_handle, const char* name, dev
 
 void daliSetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* name,
                                  device_type_t device, const void* const* data_ptr,
-                                 dali_data_type_t data_type, const int64_t* shape,
+                                 dali_data_type_t data_type, const int64_t* shapes,
                                  int64_t sample_dim, const char* layout_str) {
   DALI_ENFORCE(device == CPU, "GPU data cannot be passed as external source");
   dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
-  std::vector<int64_t> shapes_tmp(shape, shape + sample_dim * pipeline->batch_size());
-  dali::TensorListShape<> shapes(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
+  std::vector<int64_t> shapes_tmp(shapes, shapes + sample_dim * pipeline->batch_size());
+  dali::TensorListShape<> tl_shape(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
   dali::TensorLayout layout{};
   if (layout_str != nullptr) {
     layout = dali::TensorLayout(layout_str);
@@ -116,8 +116,8 @@ void daliSetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* na
     // We cast away the const from data_ptr, as there is no other way of passing it to the
     // Tensor as we must also set the shape and type metadata.
     // The vector that we pass to pipeline is const.
-    data[i].ShareData(const_cast<void*>(data_ptr[i]), shapes[i].num_elements() * elem_sizeof);
-    data[i].Resize(shapes[i], type_info);
+    data[i].ShareData(const_cast<void*>(data_ptr[i]), tl_shape[i].num_elements() * elem_sizeof);
+    data[i].Resize(tl_shape[i], type_info);
     data[i].SetLayout(layout);
   }
   const auto& cdata = data;

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -80,7 +80,6 @@ void daliSetExternalInput(daliPipelineHandle* pipe_handle, const char* name, dev
   dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
   std::vector<int64_t> shapes_tmp(shape, shape + sample_dim * pipeline->batch_size());
   dali::TensorListShape<> shapes(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
-  std::string source_name(name);
   dali::TensorLayout layout{};
   if (layout_str != nullptr) {
     layout = dali::TensorLayout(layout_str);
@@ -95,7 +94,7 @@ void daliSetExternalInput(daliPipelineHandle* pipe_handle, const char* name, dev
   data.Resize(shapes, type_info);
   data.SetLayout(layout);
   const auto& cdata = data;
-  pipeline->SetExternalInput(source_name, cdata);
+  pipeline->SetExternalInput(name, cdata);
 }
 
 void daliSetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* name,
@@ -106,7 +105,6 @@ void daliSetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* na
   dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
   std::vector<int64_t> shapes_tmp(shape, shape + sample_dim * pipeline->batch_size());
   dali::TensorListShape<> shapes(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
-  std::string source_name(name);
   dali::TensorLayout layout{};
   if (layout_str != nullptr) {
     layout = dali::TensorLayout(layout_str);
@@ -123,7 +121,7 @@ void daliSetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* na
     data[i].SetLayout(layout);
   }
   const auto& cdata = data;
-  pipeline->SetExternalInput(source_name, cdata);
+  pipeline->SetExternalInput(name, cdata);
 }
 
 void daliRun(daliPipelineHandle* pipe_handle) {

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-#include <string>
-#include <vector>
 #include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "dali/c_api/c_api.h"
+#include "dali/core/tensor_shape.h"
 #include "dali/pipeline/pipeline.h"
 #include "dali/plugin/copy.h"
 #include "dali/plugin/plugin_manager.h"
+#include "dali/pipeline/data/tensor_list.h"
+#include "dali/pipeline/data/backend.h"
 
 void daliCreatePipeline(daliPipelineHandle* pipe_handle,
     const char *serialized_pipeline,
@@ -68,6 +71,64 @@ void daliPrefetchSeparate(daliPipelineHandle* pipe_handle,
   for (int i = 0; i < cpu_queue_depth; ++i) {
     pipeline->RunCPU();
   }
+}
+
+dali_result_t daliSetExternalInput(daliPipelineHandle* pipe_handle, const char* name,
+    device_type_t device, const void* data_ptr, dali_data_type_t data_type, int64_t* shape,
+    int sample_dim, const char* layout_str) {
+  if (device != CPU) {
+    return dali_result_t::DALI_FAILURE;  // "GPU data cannot be passed as external source"
+  }
+  dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
+  std::vector<int64_t> shapes_tmp(shape, shape + sample_dim * pipeline->batch_size());
+  dali::TensorListShape<> shapes(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
+  std::string source_name(name);
+  dali::TensorLayout layout{};
+  if (layout_str != nullptr) {
+    layout = dali::TensorLayout(layout_str);
+  }
+  dali::TensorList<dali::CPUBackend> data;
+  const auto &type_info = dali::TypeTable::GetTypeInfo(static_cast<dali::DALIDataType>(data_type));
+  auto elem_sizeof = type_info.size();
+  // We cast away the const from data_ptr, as there is no other way of passing it to the
+  // TensorList, as we must also set the shape and type metadata.
+  // It is passed further as const TensorList, so it's data cannot be modified.
+  data.ShareData(const_cast<void*>(data_ptr), shapes.num_elements() * elem_sizeof);
+  data.Resize(shapes, type_info);
+  data.SetLayout(layout);
+  const auto &cdata = data;
+  pipeline->SetExternalInput(source_name, cdata);
+  return dali_result_t::DALI_SUCCESS;
+}
+
+dali_result_t daliSetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* name,
+    device_type_t device, const void* const* data_ptr, dali_data_type_t data_type, int64_t* shape,
+    int64_t sample_dim, const char* layout_str) {
+  if (device != CPU) {
+    return dali_result_t::DALI_FAILURE;  // "GPU data cannot be passed as external source"
+  }
+  dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
+  std::vector<int64_t> shapes_tmp(shape, shape + sample_dim * pipeline->batch_size());
+  dali::TensorListShape<> shapes(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
+  std::string source_name(name);
+  dali::TensorLayout layout{};
+  if (layout_str != nullptr) {
+    layout = dali::TensorLayout(layout_str);
+  }
+  std::vector<dali::Tensor<dali::CPUBackend>> data(pipeline->batch_size());
+  const auto &type_info = dali::TypeTable::GetTypeInfo(static_cast<dali::DALIDataType>(data_type));
+  auto elem_sizeof = type_info.size();
+  for (int i = 0; i < pipeline->batch_size(); i++) {
+    // We cast away the const from data_ptr, as there is no other way of passing it to the
+    // Tensor as we must also set the shape and type metadata.
+    // The vector that we pass to pipeline is const.
+    data[i].ShareData(const_cast<void*>(data_ptr[i]), shapes[i].num_elements() * elem_sizeof);
+    data[i].Resize(shapes[i], type_info);
+    data[i].SetLayout(layout);
+  }
+  const auto &cdata = data;
+  pipeline->SetExternalInput(source_name, cdata);
+  return dali_result_t::DALI_SUCCESS;
 }
 
 void daliRun(daliPipelineHandle* pipe_handle) {

--- a/dali/c_api/c_api.h
+++ b/dali/c_api/c_api.h
@@ -79,14 +79,15 @@ extern "C" {
    * @brief Feed the data to ExternalSource as contiguous memory.
    *
    * @param pipe_handle Pointer to pipeline handle
-   * @param name Pointer to a null terminated string with the name of the External Source to be fed
+   * @param name Pointer to a null-terminated byte string with the name of the External Source
+   *             to be fed
    * @param device Device of the supplied memory. Only CPU is supported.
    * @param data_ptr Pointer to contiguous buffer containing all samples
    * @param data_type Type of the provided data
    * @param shape Pointer to an array containing shape of all samples concatenated one after
    *              another. Should contain batch_size * sample_dim elements.
-   * @param sample_dim The dimensionality of the data.
-   * @param layout_str Optional layout provided as a pointer null terminated string.
+   * @param sample_dim The dimensionality of a single sample.
+   * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
    *                   Can be set to NULL.
    */
   DLL_PUBLIC void daliSetExternalInput(daliPipelineHandle* pipe_handle, const char* name,
@@ -98,14 +99,15 @@ extern "C" {
    * @brief Feed the data to ExternalSource as a set of separate buffers.
    *
    * @param pipe_handle Pointer to pipeline handle
-   * @param name Pointer to a null terminated string with the name of the External Source to be fed
+   * @param name Pointer to a null-terminated byte string with the name of the External Source
+   *             to be fed
    * @param device Device of the supplied memory. Only CPU is supported.
    * @param data_ptr Pointer to an array containing batch_size pointers to separate Tensors.
    * @param data_type Type of the provided data
    * @param shape Pointer to an array containing shape of all samples concatenated one after
    *              another. Should contain batch_size * sample_dim elements.
-   * @param sample_dim The dimensionality of the data.
-   * @param layout_str Optional layout provided as a pointer null terminated string.
+   * @param sample_dim The dimensionality of a single sample.
+   * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
    *                   Can be set to NULL.
    */
   DLL_PUBLIC void daliSetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* name,

--- a/dali/c_api/c_api.h
+++ b/dali/c_api/c_api.h
@@ -23,17 +23,23 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  struct daliPipelineHandle {
+  /**
+   * @brief Handle for DALI C-like API.
+   *
+   * @note Beware, the C API is just C-like API for handling some mangling issues and
+   * it can throw exceptions.
+   */
+  typedef struct daliPipelineHandle {
     void* pipe;
     void* ws;
-  };
+  } daliPipelineHandle;
 
-  enum device_type_t {
+  typedef enum device_type_t {
     CPU = 0,
     GPU = 1
-  };
+  } device_type_t;
 
-  typedef enum {
+  typedef enum dali_data_type_t {
     DALI_NO_TYPE         = -1,
     DALI_UINT8           =  0,
     DALI_UINT16          =  1,
@@ -48,6 +54,11 @@ extern "C" {
     DALI_FLOAT64         = 10,
     DALI_BOOL            = 11
   } dali_data_type_t;
+
+  typedef enum dali_result_t {
+    DALI_SUCCESS = 0,
+    DALI_FAILURE = 1
+  } dali_result_t;
 
   /**
    * @brief Create DALI pipeline. Setting batch_size,
@@ -68,6 +79,42 @@ extern "C" {
       int prefetch_queue_depth,
       int cpu_prefetch_queue_depth,
       int gpu_prefetch_queue_depth);
+
+  /**
+   * @brief Feed the data to ExternalSource as contiguous allocation.
+   *
+   * @param pipe_handle Pointer to pipeline handle
+   * @param name Pointer to null terminated string with External Source name to be fed
+   * @param device Device of the supplied memory. Only CPU is supported.
+   * @param data_ptr Pointer to contiguous buffer containing all samples
+   * @param data_type Type of the provided data
+   * @param shape Pointer to an array containing shape of all samples concatenated one after
+   *              another. Should contain batch_size * sample_dim elements.
+   * @param sample_dim The dimensionality of the data.
+   * @param layout_str Optional layout provided as a pointer null terminated string.
+   *                   Can be set to NULL.
+   */
+  DLL_PUBLIC dali_result_t daliSetExternalInput(daliPipelineHandle *pipe_handle, const char *name,
+     device_type_t device, const void *data_ptr, dali_data_type_t data_type, int64_t *shape,
+     int sample_dim, const char *layout_str);
+
+  /**
+   * @brief Feed the data to ExternalSource as set of separate buffers.
+   *
+   * @param pipe_handle Pointer to pipeline handle
+   * @param name Pointer to null terminated string with External Source name to be fed
+   * @param device Device of the supplied memory. Only CPU is supported.
+   * @param data_ptr Pointer to an array containing batch_size pointers to separate Tensors.
+   * @param data_type Type of the provided data
+   * @param shape Pointer to an array containing shape of all samples concatenated one after
+   *              another. Should contain batch_size * sample_dim elements.
+   * @param sample_dim The dimensionality of the data.
+   * @param layout_str Optional layout provided as a pointer null terminated string.
+   *                   Can be set to NULL.
+   */
+  DLL_PUBLIC dali_result_t daliSetExternalInputTensors(daliPipelineHandle* pipe_handle,
+      const char* name, device_type_t device, const void* const* data_ptr,
+      dali_data_type_t data_type, int64_t* shape, int64_t sample_dim, const char* layout_str);
 
   /**
    * @brief Start the execution of the pipeline.

--- a/dali/c_api/c_api.h
+++ b/dali/c_api/c_api.h
@@ -84,7 +84,7 @@ extern "C" {
    * @param device Device of the supplied memory. Only CPU is supported.
    * @param data_ptr Pointer to contiguous buffer containing all samples
    * @param data_type Type of the provided data
-   * @param shape Pointer to an array containing shape of all samples concatenated one after
+   * @param shapes Pointer to an array containing shapes of all samples concatenated one after
    *              another. Should contain batch_size * sample_dim elements.
    * @param sample_dim The dimensionality of a single sample.
    * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
@@ -92,7 +92,7 @@ extern "C" {
    */
   DLL_PUBLIC void daliSetExternalInput(daliPipelineHandle* pipe_handle, const char* name,
                                        device_type_t device, const void* data_ptr,
-                                       dali_data_type_t data_type, const int64_t* shape,
+                                       dali_data_type_t data_type, const int64_t* shapes,
                                        int sample_dim, const char* layout_str);
 
   /**
@@ -104,7 +104,7 @@ extern "C" {
    * @param device Device of the supplied memory. Only CPU is supported.
    * @param data_ptr Pointer to an array containing batch_size pointers to separate Tensors.
    * @param data_type Type of the provided data
-   * @param shape Pointer to an array containing shape of all samples concatenated one after
+   * @param shapes Pointer to an array containing shapes of all samples concatenated one after
    *              another. Should contain batch_size * sample_dim elements.
    * @param sample_dim The dimensionality of a single sample.
    * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
@@ -112,7 +112,7 @@ extern "C" {
    */
   DLL_PUBLIC void daliSetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* name,
                                               device_type_t device, const void* const* data_ptr,
-                                              dali_data_type_t data_type, const int64_t* shape,
+                                              dali_data_type_t data_type, const int64_t* shapes,
                                               int64_t sample_dim, const char* layout_str);
 
   /**

--- a/dali/c_api/c_api.h
+++ b/dali/c_api/c_api.h
@@ -29,17 +29,17 @@ extern "C" {
    * @note Beware, the C API is just C-like API for handling some mangling issues and
    * it can throw exceptions.
    */
-  typedef struct daliPipelineHandle {
+  typedef struct {
     void* pipe;
     void* ws;
   } daliPipelineHandle;
 
-  typedef enum device_type_t {
+  typedef enum {
     CPU = 0,
     GPU = 1
   } device_type_t;
 
-  typedef enum dali_data_type_t {
+  typedef enum {
     DALI_NO_TYPE         = -1,
     DALI_UINT8           =  0,
     DALI_UINT16          =  1,
@@ -54,11 +54,6 @@ extern "C" {
     DALI_FLOAT64         = 10,
     DALI_BOOL            = 11
   } dali_data_type_t;
-
-  typedef enum dali_result_t {
-    DALI_SUCCESS = 0,
-    DALI_FAILURE = 1
-  } dali_result_t;
 
   /**
    * @brief Create DALI pipeline. Setting batch_size,
@@ -81,10 +76,10 @@ extern "C" {
       int gpu_prefetch_queue_depth);
 
   /**
-   * @brief Feed the data to ExternalSource as contiguous allocation.
+   * @brief Feed the data to ExternalSource as contiguous memory.
    *
    * @param pipe_handle Pointer to pipeline handle
-   * @param name Pointer to null terminated string with External Source name to be fed
+   * @param name Pointer to a null terminated string with the name of the External Source to be fed
    * @param device Device of the supplied memory. Only CPU is supported.
    * @param data_ptr Pointer to contiguous buffer containing all samples
    * @param data_type Type of the provided data
@@ -94,15 +89,16 @@ extern "C" {
    * @param layout_str Optional layout provided as a pointer null terminated string.
    *                   Can be set to NULL.
    */
-  DLL_PUBLIC dali_result_t daliSetExternalInput(daliPipelineHandle *pipe_handle, const char *name,
-     device_type_t device, const void *data_ptr, dali_data_type_t data_type, int64_t *shape,
-     int sample_dim, const char *layout_str);
+  DLL_PUBLIC void daliSetExternalInput(daliPipelineHandle* pipe_handle, const char* name,
+                                       device_type_t device, const void* data_ptr,
+                                       dali_data_type_t data_type, const int64_t* shape,
+                                       int sample_dim, const char* layout_str);
 
   /**
-   * @brief Feed the data to ExternalSource as set of separate buffers.
+   * @brief Feed the data to ExternalSource as a set of separate buffers.
    *
    * @param pipe_handle Pointer to pipeline handle
-   * @param name Pointer to null terminated string with External Source name to be fed
+   * @param name Pointer to a null terminated string with the name of the External Source to be fed
    * @param device Device of the supplied memory. Only CPU is supported.
    * @param data_ptr Pointer to an array containing batch_size pointers to separate Tensors.
    * @param data_type Type of the provided data
@@ -112,9 +108,10 @@ extern "C" {
    * @param layout_str Optional layout provided as a pointer null terminated string.
    *                   Can be set to NULL.
    */
-  DLL_PUBLIC dali_result_t daliSetExternalInputTensors(daliPipelineHandle* pipe_handle,
-      const char* name, device_type_t device, const void* const* data_ptr,
-      dali_data_type_t data_type, int64_t* shape, int64_t sample_dim, const char* layout_str);
+  DLL_PUBLIC void daliSetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* name,
+                                              device_type_t device, const void* const* data_ptr,
+                                              dali_data_type_t data_type, const int64_t* shape,
+                                              int64_t sample_dim, const char* layout_str);
 
   /**
    * @brief Start the execution of the pipeline.

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -1,0 +1,245 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "dali/c_api/c_api.h"
+#include "dali/pipeline/pipeline.h"
+#include "dali/pipeline/data/tensor_list.h"
+#include "dali/test/dali_test_config.h"
+#include "dali/pipeline/data/views.h"
+#include "dali/test/tensor_test_utils.h"
+
+using namespace std::string_literals;  // NOLINT(build/namespaces)
+
+namespace dali {
+
+namespace {
+  constexpr int batch_size = 12;
+  constexpr int num_thread = 4;
+  constexpr int device_id = 0;
+  constexpr int seed = 0;
+  constexpr bool pipelined = true;
+  constexpr int prefetch_queue_depth = 2;
+  constexpr bool async = true;
+  constexpr float output_size = 20.f;
+  std::string input_name = "inputs"s;
+
+  std::unique_ptr<Pipeline> GetTestPipeline(bool is_file_reader, const std::string &output_device) {
+    auto pipe_ptr = std::make_unique<Pipeline>(batch_size, num_thread, device_id, seed, pipelined,
+                                               prefetch_queue_depth, async);
+    auto &pipe = *pipe_ptr;
+      TensorList<CPUBackend> data;
+    if (is_file_reader) {
+      std::string file_root = testing::dali_extra_path() + "/db/single/jpeg/";
+      std::string file_list = file_root + "image_list.txt";
+      pipe.AddOperator(
+          OpSpec("FileReader")
+          .AddArg("device", "cpu")
+          .AddArg("file_root", file_root)
+          .AddArg("file_list", file_list)
+          .AddOutput("compressed_images", "cpu")
+          .AddOutput("labels", "cpu"));
+
+      pipe.AddOperator(
+          OpSpec("ImageDecoder")
+          .AddArg("device", "cpu")
+          .AddArg("output_type", DALI_RGB)
+          .AddInput("compressed_images", "cpu")
+          .AddOutput(input_name, "cpu"));
+    } else {
+      pipe.AddExternalInput(input_name);
+    }
+    //  Some Op
+    pipe.AddOperator(
+        OpSpec("Resize")
+        .AddArg("device", "cpu")
+        .AddArg("image_type", DALI_RGB)
+        .AddArg("resize_x", output_size)
+        .AddArg("resize_y", output_size)
+        .AddInput(input_name, "cpu")
+        .AddOutput("outputs", "cpu"));
+
+    vector<std::pair<string, string>> outputs = {{"outputs", output_device}};
+
+    pipe.SetOutputNames(outputs);
+    return pipe_ptr;
+  }
+
+  // Takes Outptus from baseline and handle and compares them
+  // Allows only for uint8_t CPU output data to be compared
+  void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline) {
+    dali::DeviceWorkspace ws;
+    baseline.Outputs(&ws);
+    daliOutput(&handle);
+
+    EXPECT_EQ(daliGetNumOutput(&handle), ws.NumOutput());
+    const int num_output = ws.NumOutput();
+    TensorList<CPUBackend> c_output;
+    for (int output = 0; output < num_output; output++) {
+      EXPECT_EQ(daliNumTensors(&handle, output), batch_size);
+      for (int elem = 0; elem < batch_size; elem++) {
+        auto *shape = daliShapeAtSample(&handle, output, elem);
+        int idx = 0;
+        auto ref_shape = ws.Output<CPUBackend>(output).shape()[idx];
+        for (; shape[idx] != 0; idx++) {
+          EXPECT_EQ(shape[idx], ref_shape[idx]);
+        }
+        EXPECT_EQ(idx, ref_shape.sample_dim());
+        free(shape);
+      }
+
+      TensorList<CPUBackend> c_output;
+      auto &regular_output = ws.Output<CPUBackend>(0);
+      c_output.Resize(regular_output.shape(), TypeInfo::Create<uint8_t>());
+      daliCopyTensorListNTo(&handle, c_output.raw_mutable_data(), 0, device_type_t::CPU, 0, false);
+      Check(view<uint8_t>(c_output), view<uint8_t>(regular_output));
+    }
+  }
+
+}  // namespace
+
+
+TEST(CApiTest, FileReaderPipe) {
+  auto pipe_ptr = GetTestPipeline(true, "cpu");
+  auto serialized = pipe_ptr->SerializeToProtobuf();
+
+  pipe_ptr->Build();
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    pipe_ptr->RunCPU();
+    pipe_ptr->RunGPU();
+  }
+
+  daliPipelineHandle handle;
+  daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
+                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     prefetch_queue_depth);
+  daliPrefetchUniform(&handle, prefetch_queue_depth);
+
+  dali::DeviceWorkspace ws;
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    ComparePipelinesOutputs(handle, *pipe_ptr);
+  }
+
+  daliRun(&handle);
+  pipe_ptr->RunCPU();
+  pipe_ptr->RunGPU();
+
+  ComparePipelinesOutputs(handle, *pipe_ptr);
+}
+
+TEST(CApiTest, ExternalSourceSingleAllocPipe) {
+  TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
+                                   {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
+                                   {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
+  TensorList<CPUBackend> input;
+  input.Resize(input_shape, TypeInfo::Create<uint8_t>());
+  auto pipe_ptr = GetTestPipeline(false, "cpu");
+  auto serialized = pipe_ptr->SerializeToProtobuf();
+
+  pipe_ptr->Build();
+
+  daliPipelineHandle handle;
+  daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
+                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     prefetch_queue_depth);
+
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    SequentialFill(view<uint8_t>(input), 42 * i);
+    pipe_ptr->SetExternalInput(input_name, input);
+    daliSetExternalInput(&handle, input_name.c_str(), device_type_t::CPU, input.raw_data(),
+        dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(), nullptr);
+  }
+
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    pipe_ptr->RunCPU();
+    pipe_ptr->RunGPU();
+  }
+  daliPrefetchUniform(&handle, prefetch_queue_depth);
+
+  dali::DeviceWorkspace ws;
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    ComparePipelinesOutputs(handle, *pipe_ptr);
+  }
+
+  SequentialFill(view<uint8_t>(input), 42 * prefetch_queue_depth);
+  pipe_ptr->SetExternalInput(input_name, input);
+  std::string layout = "HWC";
+  daliSetExternalInput(&handle, input_name.c_str(), device_type_t::CPU, input.raw_data(),
+      dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(), layout.c_str());
+  daliRun(&handle);
+  pipe_ptr->RunCPU();
+  pipe_ptr->RunGPU();
+
+  ComparePipelinesOutputs(handle, *pipe_ptr);
+}
+
+TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
+  TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
+                                   {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
+                                   {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
+  TensorList<CPUBackend> input;
+  input.Resize(input_shape, TypeInfo::Create<uint8_t>());
+  std::vector<const void *> data_ptrs(batch_size);
+  for (int i = 0; i < batch_size; i++) {
+    data_ptrs[i] = input.raw_tensor(i);
+  }
+  auto pipe_ptr = GetTestPipeline(false, "cpu");
+  auto serialized = pipe_ptr->SerializeToProtobuf();
+
+  pipe_ptr->Build();
+
+  daliPipelineHandle handle;
+  daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
+                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     prefetch_queue_depth);
+
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    SequentialFill(view<uint8_t>(input), 42 * i);
+
+    pipe_ptr->SetExternalInput(input_name, input);
+    daliSetExternalInputTensors(&handle, input_name.c_str(), device_type_t::CPU, data_ptrs.data(),
+        dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(), nullptr);
+  }
+
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    pipe_ptr->RunCPU();
+    pipe_ptr->RunGPU();
+  }
+  daliPrefetchUniform(&handle, prefetch_queue_depth);
+
+  dali::DeviceWorkspace ws;
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    ComparePipelinesOutputs(handle, *pipe_ptr);
+  }
+
+  SequentialFill(view<uint8_t>(input), 42 * prefetch_queue_depth);
+  pipe_ptr->SetExternalInput(input_name, input);
+  std::string layout = "HWC";
+  daliSetExternalInputTensors(&handle, input_name.c_str(), device_type_t::CPU, data_ptrs.data(),
+      dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(), layout.c_str());
+  daliRun(&handle);
+  pipe_ptr->RunCPU();
+  pipe_ptr->RunGPU();
+
+  ComparePipelinesOutputs(handle, *pipe_ptr);
+}
+
+
+
+}  // namespace dali

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -179,9 +179,8 @@ TEST(CApiTest, ExternalSourceSingleAllocPipe) {
 
   SequentialFill(view<uint8_t>(input), 42 * prefetch_queue_depth);
   pipe_ptr->SetExternalInput(input_name, input);
-  std::string layout = "HWC";
   daliSetExternalInput(&handle, input_name.c_str(), device_type_t::CPU, input.raw_data(),
-      dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(), layout.c_str());
+      dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(), "HWC");
   daliRun(&handle);
   pipe_ptr->RunCPU();
   pipe_ptr->RunGPU();
@@ -230,9 +229,8 @@ TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
 
   SequentialFill(view<uint8_t>(input), 42 * prefetch_queue_depth);
   pipe_ptr->SetExternalInput(input_name, input);
-  std::string layout = "HWC";
   daliSetExternalInputTensors(&handle, input_name.c_str(), device_type_t::CPU, data_ptrs.data(),
-      dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(), layout.c_str());
+      dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(), "HWC");
   daliRun(&handle);
   pipe_ptr->RunCPU();
   pipe_ptr->RunGPU();

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -39,7 +39,7 @@ constexpr bool pipelined = true;
 constexpr int prefetch_queue_depth = 2;
 constexpr bool async = true;
 constexpr float output_size = 20.f;
-std::string input_name = "inputs"s;
+const std::string input_name = "inputs"s;  // NOLINT
 
 std::unique_ptr<Pipeline> GetTestPipeline(bool is_file_reader, const std::string &output_device) {
   auto pipe_ptr = std::make_unique<Pipeline>(batch_size, num_thread, device_id, seed, pipelined,


### PR DESCRIPTION
#### Why we need this PR?
We want access for external source through simplified C[-like] API. 

#### What happened in this PR?
 - What solution was applied:
     Added new API calls for setting external source, corresponding to setting a TensorList or vector of Tensors.
 - Affected modules and functionalities:
    C API
 - Key points relevant for the review:
     The relevant changes
 - Validation and testing:
     Added a GTest test, that compares the C API created from serialized pipeline with the same Pipeline. Checks pipeline with regular file reader and two variants of setting external source.
 - Documentation (including examples):
     Docstrings for C API. 

**JIRA TASK**: *[DALI-1368]*
