### PR TITLE
Add TensorGPU and TensorListGPU constructors based on cuda array interface

### DIFF
--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -205,6 +205,14 @@ class DLL_PUBLIC Buffer {
   }
 
   /**
+   * @brief Sets a device this buffer was allocated on
+   * If the backend is CPUBackend, should be -1
+   */
+  void set_device_id(int device) {
+    device_ = device;
+  }
+
+  /**
    * @brief Sets the type of the buffer. If the buffer has not been
    * allocated because it does not yet have a type, the calling type
    * is taken to be the type of the data and the memory is allocated.

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -82,6 +82,17 @@ def test_array_interface_tensor_cpu():
     assert np.array_equal(tensorlist[0].__array_interface__['shape'], tensorlist[0].shape())
     assert tensorlist[0].__array_interface__['typestr'] == tensorlist[0].dtype()
 
+def check_array_types(t):
+    arr = np.array([[-0.39, 1.5], [-1.5, 0.33]], dtype=t)
+    tensor = TensorCPU(arr, "NHWC")
+    assert(np.allclose(np.array(arr), np.asanyarray(tensor)))
+
+def test_array_interface_types():
+    for t in [np.bool_, np.int_, np.intc, np.intp, np.int8, np.int16, np.int32, np.int64,
+             np.uint8, np.uint16, np.uint32, np.uint64, np.float_, np.float32, np.float16,
+             np.short, np.long, np.longlong, np.ushort, np.ulonglong]:
+        yield check_array_types, t
+
 #if 0  // TODO(spanev): figure out which return_value_policy to choose
 #def test_tensorlist_getitem_slice():
 #    arr = np.random.rand(3, 5, 6)

--- a/dali/test/python/test_backend_impl_gpu.py
+++ b/dali/test/python/test_backend_impl_gpu.py
@@ -16,7 +16,7 @@ from nvidia.dali.backend_impl import *
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import numpy as np
-from nose.tools import assert_raises
+from nose.tools import assert_raises, raises
 import cupy as cp
 from test_utils import py_buffer_from_address
 
@@ -56,7 +56,7 @@ def test_data_ptr_tensor_gpu():
     tensor = pipe.run()[0][0]
     from_tensor = py_buffer_from_address(tensor.data_ptr(), tensor.shape(), tensor.dtype(), gpu=True)
     # from_tensor is cupy array, convert arr to cupy as well
-    assert(cp.allclose(cp.array(arr[0]), from_tensor))
+    assert(cp.allclose(arr[0], from_tensor))
 
 def test_data_ptr_tensor_list_gpu():
     arr = np.random.rand(3, 5, 6)
@@ -66,7 +66,7 @@ def test_data_ptr_tensor_list_gpu():
     tensor = tensor_list.as_tensor()
     from_tensor = py_buffer_from_address(tensor_list.data_ptr(), tensor.shape(), tensor.dtype(), gpu=True)
     # from_tensor is cupy array, convert arr to cupy as well
-    assert(cp.allclose(cp.array(arr), from_tensor))
+    assert(cp.allclose(arr, from_tensor))
 
 def test_cuda_array_interface_tensor_gpu():
     arr = np.random.rand(3, 5, 6)
@@ -77,4 +77,68 @@ def test_cuda_array_interface_tensor_gpu():
     assert tensor_list[0].__cuda_array_interface__['data'][1] == True
     assert np.array_equal(tensor_list[0].__cuda_array_interface__['shape'], tensor_list[0].shape())
     assert tensor_list[0].__cuda_array_interface__['typestr'] == tensor_list[0].dtype()
-    assert(cp.allclose(cp.array(arr[0]), cp.asanyarray(tensor_list[0])))
+    assert(cp.allclose(arr[0], cp.asanyarray(tensor_list[0])))
+
+def test_cuda_array_interface_tensor_gpu_create():
+    arr = np.random.rand(3, 5, 6)
+    pipe = ExternalSourcePipe(arr.shape[0], arr)
+    pipe.build()
+    tensor_list = pipe.run()[0]
+    assert(cp.allclose(arr[0], cp.asanyarray(tensor_list[0])))
+
+def test_cuda_array_interface_tensor_list_gpu_create():
+    arr = np.random.rand(3, 5, 6)
+    pipe = ExternalSourcePipe(arr.shape[0], arr)
+    pipe.build()
+    tensor_list = pipe.run()[0]
+    assert(cp.allclose(arr, cp.asanyarray(tensor_list.as_tensor())))
+
+def test_cuda_array_interface_tensor_gpu_direct_creation():
+    arr = cp.random.rand(3, 5, 6)
+    tensor = TensorGPU(arr, "NHWC")
+    assert(cp.allclose(arr, cp.asanyarray(tensor)))
+
+def test_cuda_array_interface_tensor_gpu_to_cpu():
+    arr = cp.random.rand(3, 5, 6)
+    tensor = TensorGPU(arr, "NHWC")
+    assert(np.allclose(arr.get(), tensor.as_cpu()))
+
+def test_cuda_array_interface_tensor_gpu_to_cpu_device_id():
+    arr = cp.random.rand(3, 5, 6)
+    tensor = TensorGPU(arr, "NHWC", 0)
+    assert(np.allclose(arr.get(), tensor.as_cpu()))
+
+def test_cuda_array_interface_tensor_list_gpu_direct_creation():
+    arr = cp.random.rand(3, 5, 6)
+    tensor_list = TensorListGPU(arr, "NHWC")
+    assert(cp.allclose(arr, cp.asanyarray(tensor_list.as_tensor())))
+
+def test_cuda_array_interface_tensor_list_gpu_to_cpu():
+    arr = cp.random.rand(3, 5, 6)
+    tensor_list = TensorListGPU(arr, "NHWC")
+    assert(np.allclose(arr.get(), tensor_list.as_cpu().as_tensor()))
+
+def test_cuda_array_interface_tensor_list_gpu_to_cpu_device_id():
+    arr = cp.random.rand(3, 5, 6)
+    tensor_list = TensorListGPU(arr, "NHWC", 0)
+    assert(np.allclose(arr.get(), tensor_list.as_cpu().as_tensor()))
+
+def check_cuda_array_types(t):
+    arr = cp.array([[-0.39, 1.5], [-1.5, 0.33]], dtype=t)
+    tensor = TensorGPU(arr, "NHWC")
+    assert(cp.allclose(arr, cp.asanyarray(tensor)))
+
+def test_cuda_array_interface_types():
+    for t in [cp.bool_, cp.int8, cp.int16, cp.int32, cp.int64, cp.uint8,
+              cp.uint16, cp.uint32, cp.uint64, cp.float32, cp.float16]:
+        yield check_cuda_array_types, t
+
+@raises(RuntimeError)
+def test_cuda_array_interface_tensor_gpu_create_from_numpy():
+    arr = np.random.rand(3, 5, 6)
+    tensor = TensorGPU(arr, "NHWC")
+
+@raises(RuntimeError)
+def test_cuda_array_interface_tensor_list_gpu_create_from_numpy():
+    arr = np.random.rand(3, 5, 6)
+    tensor = TensorGPU(arr, "NHWC")

--- a/dali/util/pybind.h
+++ b/dali/util/pybind.h
@@ -102,10 +102,14 @@ static std::string FormatStrFromType(const TypeInfo &type) {
 
 static TypeInfo TypeFromFormatStr(const std::string &format) {
   char format_letter;
+  int format_number = -1;
   if (format.size() == 1) {
     format_letter = format[0];
   } else if (format.size() > 1) {
     format_letter = format[1];
+    if (format.size() > 2) {
+      format_number = std::stoi(format.substr(2));
+    }
   } else {
     DALI_FAIL("Cannot create type for unknown format string: " + format);
   }
@@ -118,6 +122,17 @@ static TypeInfo TypeFromFormatStr(const std::string &format) {
   switch (format_letter) {
     case 'c':
       return TypeInfo::Create<char>();
+    // type supported by cupy
+    case 'u':
+      if (format_number == -1 || format_number == sizeof(uint8_t)) {
+        return TypeInfo::Create<uint8_t>();
+      } else if (format_number == sizeof(uint16_t)) {
+        return TypeInfo::Create<uint16_t>();
+      } else if (format_number == sizeof(uint32_t)) {
+        return TypeInfo::Create<uint32_t>();
+      } else if (format_number == sizeof(uint64_t)) {
+        return TypeInfo::Create<uint64_t>();
+      }
     case 'b':
       return TypeInfo::Create<int8_t>();
     case 'B':
@@ -127,7 +142,15 @@ static TypeInfo TypeFromFormatStr(const std::string &format) {
     case 'H':
       return TypeInfo::Create<uint16_t>();
     case 'i':
-      return TypeInfo::Create<int32_t>();
+      if (format_number == -1 || format_number == sizeof(int32_t)) {
+        return TypeInfo::Create<int32_t>();
+      } else if (format_number == sizeof(int64_t)) {
+        return TypeInfo::Create<int64_t>();
+      } else if (format_number == sizeof(int16_t)) {
+        return TypeInfo::Create<int16_t>();
+      } else if (format_number == sizeof(int8_t)) {
+        return TypeInfo::Create<int8_t>();
+      }
     case 'I':
       return TypeInfo::Create<uint32_t>();
     case 'l':
@@ -139,7 +162,13 @@ static TypeInfo TypeFromFormatStr(const std::string &format) {
     case 'Q':
       return TypeInfo::Create<uint64_t>();
     case 'f':
-      return TypeInfo::Create<float>();
+      if (format_number == -1 || format_number == sizeof(float)) {
+        return TypeInfo::Create<float>();
+      } else if (format_number == sizeof(double)) {
+        return TypeInfo::Create<double>();
+      } else if (format_number == sizeof(float16)) {
+        return TypeInfo::Create<float16>();
+      }
     case 'd':
       return TypeInfo::Create<double>();
     case '?':

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -313,8 +313,8 @@ class CudaHttpPackage(CudaPackage):
 
 all_packages = [PlainPackage("opencv-python", ["4.2.0.32"]),
                 CudaPackage("cupy",
-                        { "90"  : ["6.6.0"],
-                          "100" : ["6.6.0"] },
+                        { "90"  : ["7.3.0"],
+                          "100" : ["7.3.0"] },
                         "cupy-cuda{cuda_v}"),
                 CudaPackage("mxnet",
                         { "90"  : ["1.6.0"],


### PR DESCRIPTION
- adds an ability to construct TensorGPU and TensorListGPU from cupy arrays
- adjust numpy types handling for cupy
- adds a `as_cpu` method to TensorGPU
- adds an ability to set device_id in a buffer object
- bumps cupy to 7.3 in tests

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds an ability to construct TensorGPU and TensorListGPU from cupy arrays

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds an ability to construct TensorGPU and TensorListGPU from cupy arrays
     adjust numpy types handling for cupy
     adds a `as_cpu` method to TensorGPU
     adds an ability to set device_id in a buffer object
 - Affected modules and functionalities:
     backend_impl
     pybind11.h
     buffer.h
 - Key points relevant for the review:
     NA
 - Validation and testing:
     tests added
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
