### PR TITLE
Add "no exec check" to SmallVector

### DIFF
--- a/dali/core/small_vector_test.cu
+++ b/dali/core/small_vector_test.cu
@@ -80,3 +80,18 @@ DEVICE_TEST(SmallVectorDev, Resize, 1, 1) {
   v.resize(6);
   DEV_EXPECT_EQ(v.size(), 6);
 }
+
+// NOTE: this test should compile without warnings
+TEST(SmallVector, TestNoExecCheck) {
+  struct X {
+    __host__ X(int x) : x(x) {}
+    __host__ X(const X &x) : x(x.x) {}
+    int x;
+  };
+
+  dali::SmallVector<X, 4> v1, v2;
+  v1.emplace_back(42);  // the constructor
+  v2 = v1;
+  EXPECT_EQ(v1[0].x, 42);
+  EXPECT_EQ(v2[0].x, 42);
+}


### PR DESCRIPTION
Add "no exec check" to SmallVector to prevent warnings in host-only functions.

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It prevents NVCC from spitting out nonsensical warnings in host-only code.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Add DALI_NO_EXEC_CHECK to functions that call potentially host-only code, but are marked as host/device
 - Affected modules and functionalities:
     * SmallVector - it's just adding pragmas; the code generatio is not affected, so the output should not change
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * SmallVector tests suffice
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
