### PR TITLE
QA tests: Fix nvidia-dali-tf-plugin to uninstall weekly and nightly packages

### DIFF
--- a/qa/TL0_tensorflow_plugin/test.sh
+++ b/qa/TL0_tensorflow_plugin/test.sh
@@ -9,9 +9,8 @@ prolog=(: enable_conda enable_virtualenv)
 epilog=(: disable_conda disable_virtualenv)
 
 test_body() {
-    # Manually removing the supported plugin so that it fails
-    lib_dir=$(python -c 'import nvidia.dali.sysconfig as sc; print(sc.get_lib_dir())')
-    pip uninstall -y nvidia-dali-tf-plugin
+    # The package name can be nvidia-dali-tf-plugin,  nvidia-dali-tf-plugin-weekly or  nvidia-dali-tf-plugin-nightly
+    pip uninstall -y `pip list | grep nvidia-dali-tf-plugin | cut -d " " -f1` || true
 
     # No plugin installed, should fail
     nosetests --verbose test_dali_tf_plugin.py:TestDaliTfPluginLoadFail

--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -15,7 +15,9 @@ do_once() {
     # install any for CUDA 9 and the 1.15 for CUDA 10
     pip install $($topdir/qa/setup_packages.py -i 0 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
 
-    pip uninstall -y nvidia-dali-tf-plugin || true
+    # The package name can be nvidia-dali-tf-plugin,  nvidia-dali-tf-plugin-weekly or  nvidia-dali-tf-plugin-nightly
+    pip uninstall -y `pip list | grep nvidia-dali-tf-plugin | cut -d " " -f1` || true
+
     pip install /opt/dali/nvidia-dali-tf-plugin*.tar.gz
 
     export PATH=$PATH:/usr/local/mpi/bin

--- a/qa/TL1_tensorflow_dataset/test.sh
+++ b/qa/TL1_tensorflow_dataset/test.sh
@@ -9,9 +9,9 @@ prolog=(: enable_conda enable_virtualenv)
 epilog=(: disable_conda disable_virtualenv)
 
 test_body() {
-    # Manually removing the supported plugin so that it fails
-    lib_dir=$(python -c 'import nvidia.dali.sysconfig as sc; print(sc.get_lib_dir())')
-    pip uninstall -y nvidia-dali-tf-plugin
+    # The package name can be nvidia-dali-tf-plugin,  nvidia-dali-tf-plugin-weekly or  nvidia-dali-tf-plugin-nightly
+    pip uninstall -y `pip list | grep nvidia-dali-tf-plugin | cut -d " " -f1` || true
+
 
     # Installing "current" dali tf (built against installed TF)
     pip install ../../../nvidia-dali-tf-plugin*.tar.gz

--- a/qa/TL1_tensorflow_plugin/test.sh
+++ b/qa/TL1_tensorflow_plugin/test.sh
@@ -4,15 +4,15 @@ pip_packages="nose tensorflow-gpu"
 target_dir=./dali/test/python
 
 test_body() {
-    # Manually removing the supported plugin so that it fails
-    lib_dir=$(python -c 'import nvidia.dali.sysconfig as sc; print(sc.get_lib_dir())')
-    pip uninstall -y nvidia-dali-tf-plugin
+    # The package name can be nvidia-dali-tf-plugin,  nvidia-dali-tf-plugin-weekly or  nvidia-dali-tf-plugin-nightly
+    pip uninstall -y `pip list | grep nvidia-dali-tf-plugin | cut -d " " -f1` || true
+
 
     # No plugin installed, should fail
     nosetests --verbose test_dali_tf_plugin.py:TestDaliTfPluginLoadFail
 
     # Remove the old and installing "current" dali tf (built against installed TF)
-    pip uninstall -y nvidia-dali-tf-plugin
+    pip uninstall -y `pip list | grep nvidia-dali-tf-plugin | cut -d " " -f1` || true
 
     pip install --upgrade ../../../nvidia-dali-tf-plugin*.tar.gz
     nosetests --verbose test_dali_tf_plugin.py:TestDaliTfPluginLoadOk

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -53,7 +53,8 @@ do
 
             # If we just installed tensorflow, we need to reinstall DALI TF plugin
             if [[ "$inst" == *tensorflow* ]]; then
-                pip uninstall -y nvidia-dali-tf-plugin || true
+                # The package name can be nvidia-dali-tf-plugin,  nvidia-dali-tf-plugin-weekly or  nvidia-dali-tf-plugin-nightly
+                pip uninstall -y `pip list | grep nvidia-dali-tf-plugin | cut -d " " -f1` || true
                 pip install /opt/dali/nvidia-dali-tf-plugin*.tar.gz
             fi
         fi


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in nightly/weekly QA tests, where the proper nvidia-dali-tf-plugin package name was not used

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Uninstall every package matching partially matching nvidia-dali-tf-plugin, rather than only nvidia-dali-tf-plugin during QA tests*
 - Affected modules and functionalities:
     *QA tests*
 - Key points relevant for the review:
     *pip uninstall line*
 - Validation and testing:
     *QA tests*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-1353]*
