### PR TITLE
Reductions: position-dependent preprocessing, kernels for unhandled edge cases

### DIFF
--- a/dali/kernels/reduce/reduce_drop_dims.h
+++ b/dali/kernels/reduce/reduce_drop_dims.h
@@ -1,0 +1,185 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_REDUCE_REDUCE_DROP_DIMS_H_
+#define DALI_KERNELS_REDUCE_REDUCE_DROP_DIMS_H_
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+#include "dali/core/util.h"
+#include "dali/core/host_dev.h"
+
+namespace dali {
+namespace kernels {
+namespace reduce_impl {
+
+struct DropDims {
+  static constexpr int kMaxDims = 4;
+
+  int64_t div[kMaxDims];
+  int64_t mul[kMaxDims];
+  int64_t mod[kMaxDims];
+  int start = 2 * kMaxDims;
+
+  DropDims() = default;
+
+  template <typename Indices>
+  static int simplify(int64_t *out_shape, unsigned &out_mask,
+                      const Indices &in_shape, unsigned axis_mask) {
+    int dims = size(in_shape);
+    int d = 0;
+    out_shape[0] = in_shape[0];
+    bool prev = axis_mask & 1;
+    out_mask = prev ? 1u : 0u;
+    for (int i = 1; i < dims; i++) {
+      if (in_shape[i] == 1)
+        continue;
+      bool flag = (axis_mask >> i) & 1;
+      if (flag != prev) {
+        d++;
+        if (d > 2*kMaxDims)
+          throw std::out_of_range("Maximum number of dimension groups exceeded");
+        out_shape[d] = in_shape[i];
+        out_mask |= (flag ? 1u : 0u) << d;
+      } else {
+        out_shape[d] *= in_shape[i];
+      }
+      prev = flag;
+    }
+    d++;
+    if (d > 2*kMaxDims)
+      throw std::out_of_range("Maximum number of dimension groups exceeded");
+
+    return d;
+  }
+
+  /**
+   * @brief Initializes reindexing given shape and mask.
+   */
+  template <typename Indices>
+  DropDims(const Indices &in_shape, unsigned axis_mask) {
+    int64_t shape[kMaxDims];
+    int d = simplify(shape, axis_mask, in_shape, axis_mask);
+    start = 2 * kMaxDims;
+
+    if (d == 1) {
+      if (axis_mask == 1)
+        start = -1;
+      return;
+    }
+
+    int nmod = 0;
+    int ndiv = 0;
+
+    int64_t volumes[2*kMaxDims];
+    int64_t kept_volumes[2*kMaxDims];
+    int64_t vol_total = 1, vol_kept = 1;
+    int reduced_dims = 0;
+    int kept_dims = 0;
+    for (int i = d - 1; i >= 0; i--) {
+      volumes[i] = vol_total;
+      kept_volumes[i] = vol_kept;
+      vol_total *= shape[i];
+      if ((axis_mask & (1 << i)) == 0) {
+        vol_kept *= shape[i];
+        kept_dims++;
+      } else {
+        reduced_dims++;
+      }
+    }
+
+    bool mod_first = (axis_mask & 1);
+
+    for (int i = 0; i < d; i++) {
+      if (volumes[i] == 1)
+        break;
+      if (axis_mask & (1 << i)) {
+        mod[nmod++] = volumes[i];
+        continue;
+      }
+      div[ndiv] = volumes[i];
+      mul[ndiv] = kept_volumes[i];
+      ndiv++;
+    }
+
+    assert(abs(ndiv - nmod) <= 1);
+
+    // Now we move the divisors/moduli to the end of the arrays, so we can use the unrolled loop
+    // with fixed indices.
+
+    int div_ofs = !mod_first && ndiv < nmod ? 1 : 0;
+    int mod_ofs = nmod < ndiv || (nmod == ndiv && mod_first) ? 1 : 0;
+
+    if (ndiv + div_ofs > kMaxDims)
+      throw std::out_of_range("Maximum number of dimension groups exceeded");
+
+    if (nmod + mod_ofs > kMaxDims)
+      throw std::out_of_range("Maximum number of dimension groups exceeded");
+
+    if (div_ofs) {
+      div[kMaxDims - 1] = 1;
+      mul[kMaxDims - 1] = 0;
+    }
+    if (mod_ofs || !nmod)
+      mod[kMaxDims - 1] = 1;
+    for (int i = ndiv-1; i >= 0; i--) {
+      div[kMaxDims - ndiv + i - div_ofs] = div[i];
+      mul[kMaxDims - ndiv + i - div_ofs] = mul[i];
+    }
+    for (int i = nmod-1; i >= 0; i--) {
+      mod[kMaxDims - nmod + i - mod_ofs] = mod[i];
+    }
+
+    start = std::min(2*(kMaxDims - ndiv - div_ofs), 2*(kMaxDims - nmod - mod_ofs)) + mod_first;
+  }
+
+  DALI_HOST_DEV int64_t reindex(int64_t index) const {
+    int64_t out = 0;
+
+    // This is an unrolled loop over dimensions.
+    // We can start either at modulo or at division, depending on whether
+    // the outermost dimension is reduced or not.
+    switch (start) {
+      case -1:
+        return 0;  // special case - reduced down to a scalar!
+
+    // Warning: intentional fall-through!
+    #define REINDEX_CASE(idx)\
+      case 2*idx:\
+        out += index / div[idx] * mul[idx];\
+      case 2*idx+1:\
+        if (mod[idx] == 1) {\
+          index = 0;\
+          break;\
+        }\
+        index = index % mod[idx]
+
+      REINDEX_CASE(0);
+      REINDEX_CASE(1);
+      REINDEX_CASE(2);
+      REINDEX_CASE(3);
+    }
+
+    out += index;
+
+    return out;
+  }
+};
+}  // namespace reduce_impl
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_REDUCE_REDUCE_DROP_DIMS_H_

--- a/dali/kernels/reduce/reduce_drop_dims_test.cc
+++ b/dali/kernels/reduce/reduce_drop_dims_test.cc
@@ -1,0 +1,196 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/kernels/reduce/reduce_drop_dims.h"
+
+namespace dali {
+namespace kernels {
+namespace reduce_impl {
+
+TEST(DropDims, Simplify) {
+  DropDims dd;
+  unsigned in_mask = 0b10011, out_mask = 0xffffffffu;
+  int64_t in_shape[5] = { 2, 3, 4, 5, 6 };
+  int64_t out_shape[5];
+  int d = dd.simplify(out_shape, out_mask, in_shape, in_mask);
+  EXPECT_EQ(d, 3);
+  EXPECT_EQ(out_mask, 0b101);
+  EXPECT_EQ(out_shape[0], 2*3);
+  EXPECT_EQ(out_shape[1], 4*5);
+  EXPECT_EQ(out_shape[2], 6);
+
+  in_mask = 0b00110;
+  out_mask = 0xffffffffu;
+  d = dd.simplify(out_shape, out_mask, in_shape, in_mask);
+  EXPECT_EQ(d, 3);
+  EXPECT_EQ(out_mask, 0b010);
+  EXPECT_EQ(out_shape[0], 2);
+  EXPECT_EQ(out_shape[1], 3*4);
+  EXPECT_EQ(out_shape[2], 5*6);
+
+  in_mask = 0;
+  out_mask = 0xffffffffu;
+  d = dd.simplify(out_shape, out_mask, in_shape, in_mask);
+  EXPECT_EQ(d, 1);
+  EXPECT_EQ(out_mask, 0);
+  EXPECT_EQ(out_shape[0], 2*3*4*5*6);
+}
+
+TEST(DropDims, NoOp) {
+  DropDims dd;
+  for (int i = 0; i < 10; i++)
+    EXPECT_EQ(dd.reindex(i), i);
+}
+
+TEST(DropDims, Outer) {
+  int h = 32;
+  int w = 40;
+  int shape[] = { h, w };
+  DropDims dd(shape, 0b01);
+  for (int y = 0, idx = 0; y < h; y++) {
+    for (int x = 0; x < w; x++, idx++) {
+      EXPECT_EQ(dd.reindex(idx), x);
+    }
+  }
+}
+
+TEST(DropDims, Inner) {
+  int h = 32;
+  int w = 40;
+  int shape[] = { h, w };
+  DropDims dd(shape, 0b10);
+  for (int y = 0, idx = 0; y < h; y++) {
+    for (int x = 0; x < w; x++, idx++) {
+      EXPECT_EQ(dd.reindex(idx), y);
+    }
+  }
+}
+
+TEST(DropDims, Middle) {
+  int d = 3;
+  int h = 4;
+  int w = 5;
+  int shape[] = { d, h, w };
+  DropDims dd(shape, 0b010);
+  for (int z = 0, idx = 0; z < d; z++) {
+    for (int y = 0; y < h; y++) {
+      for (int x = 0; x < w; x++, idx++) {
+        EXPECT_EQ(dd.reindex(idx), z * w + x);
+      }
+    }
+  }
+}
+
+TEST(DropDims, TwoOuter) {
+  int d = 3;
+  int h = 4;
+  int w = 5;
+  int shape[] = { d, h, w };
+  DropDims dd(shape, 0b101);
+  for (int z = 0, idx = 0; z < d; z++) {
+    for (int y = 0; y < h; y++) {
+      for (int x = 0; x < w; x++, idx++) {
+        EXPECT_EQ(dd.reindex(idx), y);
+      }
+    }
+  }
+}
+
+TEST(DropDims, Multi4Odd) {
+  int shape[] = { 3, 4, 5, 6 };
+  DropDims dd(shape, 0b1010);
+  for (int i = 0, idx = 0; i < shape[0]; i++)
+    for (int j = 0; j < shape[1]; j++)
+      for (int k = 0; k < shape[2]; k++)
+        for (int l = 0; l < shape[3]; l++, idx++) {
+            int ridx = i * shape[2] + k;
+            EXPECT_EQ(dd.reindex(idx), ridx);
+          }
+}
+
+TEST(DropDims, Multi4Even) {
+  int shape[] = { 3, 4, 5, 6 };
+  DropDims dd(shape, 0b0101);
+  for (int i = 0, idx = 0; i < shape[0]; i++)
+    for (int j = 0; j < shape[1]; j++)
+      for (int k = 0; k < shape[2]; k++)
+        for (int l = 0; l < shape[3]; l++, idx++) {
+            int ridx = j * shape[3] + l;
+            EXPECT_EQ(dd.reindex(idx), ridx);
+          }
+}
+
+TEST(DropDims, TrailingOne) {
+  int shape[] = { 3, 4, 5, 6, 1 };
+  DropDims dd(shape, 0b01010);
+  for (int i = 0, idx = 0; i < shape[0]; i++)
+    for (int j = 0; j < shape[1]; j++)
+      for (int k = 0; k < shape[2]; k++)
+        for (int l = 0; l < shape[3]; l++, idx++) {
+            int ridx = (i * shape[2] + k) * shape[4];
+            EXPECT_EQ(dd.reindex(idx), ridx);
+        }
+}
+
+TEST(DropDims, Multi5All) {
+  int shape[] = { 3, 4, 5, 6, 7 };
+  int rshape[5];
+  for (unsigned mask = 0; mask <= 0b11111u; mask++) {
+    for (int d = 0; d < 5; d++) {
+      rshape[d] = mask & (1u << d) ? 1 : shape[d];
+    }
+    DropDims dd(shape, mask);
+    for (int i = 0, idx = 0; i < shape[0]; i++) {
+      int ri = mask & 0b00001 ? 0 : i;
+      for (int j = 0; j < shape[1]; j++) {
+        int rj = mask & 0b00010 ? 0 : j;
+        for (int k = 0; k < shape[2]; k++) {
+          int rk = mask & 0b00100 ? 0 : k;
+          for (int l = 0; l < shape[3]; l++) {
+            int rl = mask & 0b01000 ? 0 : l;
+            for (int m = 0; m < shape[4]; m++, idx++) {
+              int rm = mask & 0b10000 ? 0 : m;
+              int ridx =
+                ((((ri * rshape[1] + rj) * rshape[2]) + rk) * rshape[3] + rl) * rshape[4] + rm;
+              EXPECT_EQ(dd.reindex(idx), ridx);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+
+TEST(DropDims, CollapseUnitDims) {
+  int shape[] = { 3, 4, 5, 1, 1, 6, 7 };
+  // reduce:      ^     ^^^^        ^
+  //
+  // collapse unit dims, with different reduce/non-reduce flag
+
+  DropDims dd(shape, 0b1001101);
+  for (int i = 0, idx = 0; i < shape[0]; i++)
+    for (int j = 0; j < shape[1]; j++)
+      for (int k = 0; k < shape[2]; k++)
+        for (int l = 0; l < shape[5]; l++)
+          for (int m = 0; m < shape[6]; m++, idx++) {
+            int ridx = j * shape[5] + l;
+            EXPECT_EQ(dd.reindex(idx), ridx);
+          }
+}
+
+}  // namespace reduce_impl
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/reduce/reduce_drop_dims_test.cc
+++ b/dali/kernels/reduce/reduce_drop_dims_test.cc
@@ -145,26 +145,32 @@ TEST(DropDims, TrailingOne) {
 }
 
 TEST(DropDims, Multi5All) {
-  int shape[] = { 3, 4, 5, 6, 7 };
-  int rshape[5];
-  for (unsigned mask = 0; mask <= 0b11111u; mask++) {
+  int base_shape[] = { 3, 4, 5, 6, 7 };
+  for (unsigned degeneracy = 0; degeneracy <= 0b11111u; degeneracy++) {
+    int shape[5];
     for (int d = 0; d < 5; d++) {
-      rshape[d] = mask & (1u << d) ? 1 : shape[d];
+      shape[d] = degeneracy & (1u << d) ? 1 : base_shape[d];
     }
-    DropDims dd(shape, mask);
-    for (int i = 0, idx = 0; i < shape[0]; i++) {
-      int ri = mask & 0b00001 ? 0 : i;
-      for (int j = 0; j < shape[1]; j++) {
-        int rj = mask & 0b00010 ? 0 : j;
-        for (int k = 0; k < shape[2]; k++) {
-          int rk = mask & 0b00100 ? 0 : k;
-          for (int l = 0; l < shape[3]; l++) {
-            int rl = mask & 0b01000 ? 0 : l;
-            for (int m = 0; m < shape[4]; m++, idx++) {
-              int rm = mask & 0b10000 ? 0 : m;
-              int ridx =
-                ((((ri * rshape[1] + rj) * rshape[2]) + rk) * rshape[3] + rl) * rshape[4] + rm;
-              EXPECT_EQ(dd.reindex(idx), ridx);
+    int rshape[5];
+    for (unsigned mask = 0; mask <= 0b11111u; mask++) {
+      for (int d = 0; d < 5; d++) {
+        rshape[d] = mask & (1u << d) ? 1 : shape[d];
+      }
+      DropDims dd(shape, mask);
+      for (int i = 0, idx = 0; i < shape[0]; i++) {
+        int ri = mask & 0b00001 ? 0 : i;
+        for (int j = 0; j < shape[1]; j++) {
+          int rj = mask & 0b00010 ? 0 : j;
+          for (int k = 0; k < shape[2]; k++) {
+            int rk = mask & 0b00100 ? 0 : k;
+            for (int l = 0; l < shape[3]; l++) {
+              int rl = mask & 0b01000 ? 0 : l;
+              for (int m = 0; m < shape[4]; m++, idx++) {
+                int rm = mask & 0b10000 ? 0 : m;
+                int ridx =
+                  ((((ri * rshape[1] + rj) * rshape[2]) + rk) * rshape[3] + rl) * rshape[4] + rm;
+                EXPECT_EQ(dd.reindex(idx), ridx);
+              }
             }
           }
         }


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new features:
    * position-dependent preprocessing in reduction kernels
    * pointwise reduction across samples
    * no-op reduction (just pre- and postprocessing)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added `PreprocessorBank` concept which can be used to obtain a per-output preprocessor - used in mean subtraction
     * Added `DropDims` helper which converts a flat index in non- or partially-reduced to an index in fully reduced tensor.
 - Affected modules and functionalities:
     * Reduction kernels
 - Key points relevant for the review:
     * DropDims?
 - Validation and testing:
     * Unit tests
 - Documentation (including examples):
     * Doxygen

**JIRA TASK**: DALI-1250
