### PR TITLE
Copy out core* files if the test_body fails

### DIFF
--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -62,12 +62,12 @@ do
         set +e
         RV=0
         test_body || RV=$?
-        set -e
         if [ $RV -gt 0 ] ; then
             mkdir -p $topdir/core_artifacts
             cp core* $topdir/core_artifacts
             exit ${RV}
         fi
+        set -e
         # remove packages
         remove=$($topdir/qa/setup_packages.py -r  -u $pip_packages --cuda ${CUDA_VERSION})
         if [ -n "$remove" ]; then

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -59,8 +59,15 @@ do
             fi
         fi
         # test code
-        test_body
-
+        set +e
+        RV=0
+        test_body || RV=$?
+        set -e
+        if [ $RV -gt 0 ] ; then
+            mkdir -p $topdir/core_artifacts
+            cp core* $topdir/core_artifacts
+            exit ${RV}
+        fi
         # remove packages
         remove=$($topdir/qa/setup_packages.py -r  -u $pip_packages --cuda ${CUDA_VERSION})
         if [ -n "$remove" ]; then


### PR DESCRIPTION
Copy them to top DALI directory from test working directory
for unified location
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
To capture core dumps in the CI

#### What happened in this PR?
 - What solution was applied:
	Run the test body without exiting when the test fails, copy the core* files to predefined location and report the error.
 - Affected modules and functionalities:
     QA tests
 - Key points relevant for the review: N/A
 - Validation and testing:	CI
 - Documentation (including examples): N/A


**JIRA TASK**: *[Use DALI-XXXX or NA]*
