### PR TITLE
C API ExternalSource for GPU input

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -137,13 +137,13 @@ void daliSetExternalInput(daliPipelineHandle *pipe_handle, const char *name, dev
                           int sample_dim, const char *layout_str) {
   cudaStream_t stream;
   CUDA_CALL(cudaStreamCreate(&stream));
-  daliSetExternalInputCudaStream(pipe_handle, name, device, data_ptr, data_type, shapes, sample_dim,
+  daliSetExternalInputAsync(pipe_handle, name, device, data_ptr, data_type, shapes, sample_dim,
                                  layout_str, stream);
   CUDA_CALL(cudaStreamSynchronize(stream));
 }
 
 
-void daliSetExternalInputCudaStream(daliPipelineHandle *pipe_handle, const char *name,
+void daliSetExternalInputAsync(daliPipelineHandle *pipe_handle, const char *name,
                                     device_type_t device, const void *data_ptr,
                                     dali_data_type_t data_type, const int64_t *shapes,
                                     int sample_dim, const char *layout_str, cudaStream_t stream) {
@@ -168,13 +168,13 @@ void daliSetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *na
                                  int64_t sample_dim, const char *layout_str) {
   cudaStream_t stream;
   CUDA_CALL(cudaStreamCreate(&stream));
-  daliSetExternalInputTensorsCudaStream(pipe_handle, name, device, data_ptr, data_type, shapes,
+  daliSetExternalInputTensorsAsync(pipe_handle, name, device, data_ptr, data_type, shapes,
                                         sample_dim, layout_str, stream);
   CUDA_CALL(cudaStreamSynchronize(stream));
 }
 
 
-void daliSetExternalInputTensorsCudaStream(daliPipelineHandle *pipe_handle, const char *name,
+void daliSetExternalInputTensorsAsync(daliPipelineHandle *pipe_handle, const char *name,
                                            device_type_t device, const void *const *data_ptr,
                                            dali_data_type_t data_type, const int64_t *shapes,
                                            int64_t sample_dim, const char *layout_str,

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -135,8 +135,11 @@ void daliPrefetchSeparate(daliPipelineHandle* pipe_handle,
 void daliSetExternalInput(daliPipelineHandle *pipe_handle, const char *name, device_type_t device,
                           const void *data_ptr, dali_data_type_t data_type, const int64_t *shapes,
                           int sample_dim, const char *layout_str) {
+  cudaStream_t stream;
+  CUDA_CALL(cudaStreamCreate(&stream));
   daliSetExternalInputCudaStream(pipe_handle, name, device, data_ptr, data_type, shapes, sample_dim,
-                                 layout_str, 0);
+                                 layout_str, stream);
+  CUDA_CALL(cudaStreamSynchronize(stream));
 }
 
 
@@ -163,8 +166,11 @@ void daliSetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *na
                                  device_type_t device, const void *const *data_ptr,
                                  dali_data_type_t data_type, const int64_t *shapes,
                                  int64_t sample_dim, const char *layout_str) {
+  cudaStream_t stream;
+  CUDA_CALL(cudaStreamCreate(&stream));
   daliSetExternalInputTensorsCudaStream(pipe_handle, name, device, data_ptr, data_type, shapes,
-                                        sample_dim, layout_str, 0);
+                                        sample_dim, layout_str, stream);
+  CUDA_CALL(cudaStreamSynchronize(stream));
 }
 
 

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -135,15 +135,15 @@ void daliPrefetchSeparate(daliPipelineHandle* pipe_handle,
 void daliSetExternalInput(daliPipelineHandle *pipe_handle, const char *name, device_type_t device,
                           const void *data_ptr, dali_data_type_t data_type, const int64_t *shapes,
                           int sample_dim, const char *layout_str) {
-  daliSetExternalInputStream(pipe_handle, name, device, data_ptr, data_type, shapes, sample_dim,
-                             layout_str, 0);
+  daliSetExternalInputCudaStream(pipe_handle, name, device, data_ptr, data_type, shapes, sample_dim,
+                                 layout_str, 0);
 }
 
 
-void
-daliSetExternalInputStream(daliPipelineHandle *pipe_handle, const char *name, device_type_t device,
-                           const void *data_ptr, dali_data_type_t data_type, const int64_t *shapes,
-                           int sample_dim, const char *layout_str, cudaStream_t stream) {
+void daliSetExternalInputCudaStream(daliPipelineHandle *pipe_handle, const char *name,
+                                    device_type_t device, const void *data_ptr,
+                                    dali_data_type_t data_type, const int64_t *shapes,
+                                    int sample_dim, const char *layout_str, cudaStream_t stream) {
   switch (device) {
     case device_type_t::CPU:
       SetExternalInput<dali::CPUBackend>(pipe_handle, name, data_ptr, data_type, shapes, sample_dim,
@@ -163,16 +163,16 @@ void daliSetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *na
                                  device_type_t device, const void *const *data_ptr,
                                  dali_data_type_t data_type, const int64_t *shapes,
                                  int64_t sample_dim, const char *layout_str) {
-  daliSetExternalInputTensorsStream(pipe_handle, name, device, data_ptr, data_type, shapes,
-                                    sample_dim, layout_str, 0);
+  daliSetExternalInputTensorsCudaStream(pipe_handle, name, device, data_ptr, data_type, shapes,
+                                        sample_dim, layout_str, 0);
 }
 
 
-void daliSetExternalInputTensorsStream(daliPipelineHandle *pipe_handle, const char *name,
-                                       device_type_t device, const void *const *data_ptr,
-                                       dali_data_type_t data_type, const int64_t *shapes,
-                                       int64_t sample_dim, const char *layout_str,
-                                       cudaStream_t stream) {
+void daliSetExternalInputTensorsCudaStream(daliPipelineHandle *pipe_handle, const char *name,
+                                           device_type_t device, const void *const *data_ptr,
+                                           dali_data_type_t data_type, const int64_t *shapes,
+                                           int64_t sample_dim, const char *layout_str,
+                                           cudaStream_t stream) {
   switch (device) {
     case device_type_t::CPU:
       SetExternalInputTensors<dali::CPUBackend>(pipe_handle, name, data_ptr, data_type, shapes,

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -109,7 +109,7 @@ void daliCreatePipeline(daliPipelineHandle* pipe_handle,
   pipe->Build();
   pipe_handle->pipe = reinterpret_cast<void*>(pipe);
   pipe_handle->ws = new dali::DeviceWorkspace();
-  CUDA_CALL(cudaStreamCreate(&pipe_handle->copy_stream));
+  CUDA_CALL(cudaStreamCreateWithFlags(&pipe_handle->copy_stream, cudaStreamNonBlocking));
 }
 
 void daliPrefetchUniform(daliPipelineHandle* pipe_handle, int queue_depth) {

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -49,8 +49,7 @@ void SetExternalInput(daliPipelineHandle *pipe_handle, const char *name, const v
   data.ShareData(const_cast<void *>(data_ptr), tl_shape.num_elements() * elem_sizeof);
   data.Resize(tl_shape, type_info);
   data.SetLayout(layout);
-  const auto &cdata = data;
-  pipeline->SetExternalInput(name, cdata, stream);
+  pipeline->SetExternalInput(name, data, stream);
 }
 
 
@@ -77,8 +76,7 @@ void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
     data[i].Resize(tl_shape[i], type_info);
     data[i].SetLayout(layout);
   }
-  const auto &cdata = data;
-  pipeline->SetExternalInput(name, cdata, stream);
+  pipeline->SetExternalInput(name, data, stream);
 }
 
 }  // namespace

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -25,6 +25,63 @@
 #include "dali/pipeline/data/tensor_list.h"
 #include "dali/pipeline/data/backend.h"
 
+namespace {
+
+template<typename Backend>
+void SetExternalInput(daliPipelineHandle* pipe_handle, const char* name, device_type_t device,
+                          const void* data_ptr, dali_data_type_t data_type, const int64_t* shapes,
+                          int sample_dim, const char* layout_str) {
+  DALI_ENFORCE(device == CPU, "GPU data cannot be passed as external source");
+  dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
+  std::vector<int64_t> shapes_tmp(shapes, shapes + sample_dim * pipeline->batch_size());
+  dali::TensorListShape<> tl_shape(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
+  dali::TensorLayout layout{};
+  if (layout_str != nullptr) {
+    layout = dali::TensorLayout(layout_str);
+  }
+  dali::TensorList<Backend> data;
+  const auto& type_info = dali::TypeTable::GetTypeInfo(static_cast<dali::DALIDataType>(data_type));
+  auto elem_sizeof = type_info.size();
+  // We cast away the const from data_ptr, as there is no other way of passing it to the
+  // TensorList, as we must also set the shape and type metadata.
+  // It is passed further as const TensorList, so it's data cannot be modified.
+  data.ShareData(const_cast<void*>(data_ptr), tl_shape.num_elements() * elem_sizeof);
+  data.Resize(tl_shape, type_info);
+  data.SetLayout(layout);
+  const auto& cdata = data;
+  pipeline->SetExternalInput(name, cdata);
+}
+
+template<typename Backend>
+void SetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* name,
+                                 device_type_t device, const void* const* data_ptr,
+                                 dali_data_type_t data_type, const int64_t* shapes,
+                                 int64_t sample_dim, const char* layout_str) {
+  DALI_ENFORCE(device == CPU, "GPU data cannot be passed as external source");
+  dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
+  std::vector<int64_t> shapes_tmp(shapes, shapes + sample_dim * pipeline->batch_size());
+  dali::TensorListShape<> tl_shape(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
+  dali::TensorLayout layout{};
+  if (layout_str != nullptr) {
+    layout = dali::TensorLayout(layout_str);
+  }
+  std::vector<dali::Tensor<Backend>> data(pipeline->batch_size());
+  const auto& type_info = dali::TypeTable::GetTypeInfo(static_cast<dali::DALIDataType>(data_type));
+  auto elem_sizeof = type_info.size();
+  for (int i = 0; i < pipeline->batch_size(); i++) {
+    // We cast away the const from data_ptr, as there is no other way of passing it to the
+    // Tensor as we must also set the shape and type metadata.
+    // The vector that we pass to pipeline is const.
+    data[i].ShareData(const_cast<void*>(data_ptr[i]), tl_shape[i].num_elements() * elem_sizeof);
+    data[i].Resize(tl_shape[i], type_info);
+    data[i].SetLayout(layout);
+  }
+  const auto& cdata = data;
+  pipeline->SetExternalInput(name, cdata);
+}
+
+}  // namespace
+
 void daliCreatePipeline(daliPipelineHandle* pipe_handle,
     const char *serialized_pipeline,
     int length,
@@ -76,52 +133,14 @@ void daliPrefetchSeparate(daliPipelineHandle* pipe_handle,
 void daliSetExternalInput(daliPipelineHandle* pipe_handle, const char* name, device_type_t device,
                           const void* data_ptr, dali_data_type_t data_type, const int64_t* shapes,
                           int sample_dim, const char* layout_str) {
-  DALI_ENFORCE(device == CPU, "GPU data cannot be passed as external source");
-  dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
-  std::vector<int64_t> shapes_tmp(shapes, shapes + sample_dim * pipeline->batch_size());
-  dali::TensorListShape<> tl_shape(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
-  dali::TensorLayout layout{};
-  if (layout_str != nullptr) {
-    layout = dali::TensorLayout(layout_str);
-  }
-  dali::TensorList<dali::CPUBackend> data;
-  const auto& type_info = dali::TypeTable::GetTypeInfo(static_cast<dali::DALIDataType>(data_type));
-  auto elem_sizeof = type_info.size();
-  // We cast away the const from data_ptr, as there is no other way of passing it to the
-  // TensorList, as we must also set the shape and type metadata.
-  // It is passed further as const TensorList, so it's data cannot be modified.
-  data.ShareData(const_cast<void*>(data_ptr), tl_shape.num_elements() * elem_sizeof);
-  data.Resize(tl_shape, type_info);
-  data.SetLayout(layout);
-  const auto& cdata = data;
-  pipeline->SetExternalInput(name, cdata);
+  SetExternalInput<dali::CPUBackend>(pipe_handle, name, device, data_ptr, data_type, shapes, sample_dim, layout_str);
 }
 
 void daliSetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* name,
                                  device_type_t device, const void* const* data_ptr,
                                  dali_data_type_t data_type, const int64_t* shapes,
                                  int64_t sample_dim, const char* layout_str) {
-  DALI_ENFORCE(device == CPU, "GPU data cannot be passed as external source");
-  dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
-  std::vector<int64_t> shapes_tmp(shapes, shapes + sample_dim * pipeline->batch_size());
-  dali::TensorListShape<> tl_shape(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
-  dali::TensorLayout layout{};
-  if (layout_str != nullptr) {
-    layout = dali::TensorLayout(layout_str);
-  }
-  std::vector<dali::Tensor<dali::CPUBackend>> data(pipeline->batch_size());
-  const auto& type_info = dali::TypeTable::GetTypeInfo(static_cast<dali::DALIDataType>(data_type));
-  auto elem_sizeof = type_info.size();
-  for (int i = 0; i < pipeline->batch_size(); i++) {
-    // We cast away the const from data_ptr, as there is no other way of passing it to the
-    // Tensor as we must also set the shape and type metadata.
-    // The vector that we pass to pipeline is const.
-    data[i].ShareData(const_cast<void*>(data_ptr[i]), tl_shape[i].num_elements() * elem_sizeof);
-    data[i].Resize(tl_shape[i], type_info);
-    data[i].SetLayout(layout);
-  }
-  const auto& cdata = data;
-  pipeline->SetExternalInput(name, cdata);
+  SetExternalInputTensors<dali::CPUBackend>(pipe_handle, name, device, data_ptr, data_type, shapes, sample_dim, layout_str);
 }
 
 void daliRun(daliPipelineHandle* pipe_handle) {

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -30,9 +30,9 @@
 namespace {
 
 template<typename Backend>
-void SetExternalInput(daliPipelineHandle *pipe_handle, const char *name, device_type_t device,
-                      const void *data_ptr, dali_data_type_t data_type, const int64_t *shapes,
-                      int sample_dim, const char *layout_str, cudaStream_t stream = 0) {
+void SetExternalInput(daliPipelineHandle *pipe_handle, const char *name, const void *data_ptr,
+                      dali_data_type_t data_type, const int64_t *shapes, int sample_dim,
+                      const char *layout_str, cudaStream_t stream = 0) {
   dali::Pipeline *pipeline = reinterpret_cast<dali::Pipeline *>(pipe_handle->pipe);
   std::vector<int64_t> shapes_tmp(shapes, shapes + sample_dim * pipeline->batch_size());
   dali::TensorListShape<> tl_shape(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
@@ -56,9 +56,9 @@ void SetExternalInput(daliPipelineHandle *pipe_handle, const char *name, device_
 
 template<typename Backend>
 void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
-                             device_type_t device, const void *const *data_ptr,
-                             dali_data_type_t data_type, const int64_t *shapes, int64_t sample_dim,
-                             const char *layout_str, cudaStream_t stream = 0) {
+                             const void *const *data_ptr, dali_data_type_t data_type,
+                             const int64_t *shapes, int64_t sample_dim, const char *layout_str,
+                             cudaStream_t stream = 0) {
   dali::Pipeline *pipeline = reinterpret_cast<dali::Pipeline *>(pipe_handle->pipe);
   std::vector<int64_t> shapes_tmp(shapes, shapes + sample_dim * pipeline->batch_size());
   dali::TensorListShape<> tl_shape(std::move(shapes_tmp), pipeline->batch_size(), sample_dim);
@@ -146,12 +146,12 @@ daliSetExternalInputStream(daliPipelineHandle *pipe_handle, const char *name, de
                            int sample_dim, const char *layout_str, cudaStream_t stream) {
   switch (device) {
     case device_type_t::CPU:
-      SetExternalInput<dali::CPUBackend>(pipe_handle, name, device, data_ptr, data_type, shapes,
-                                         sample_dim, layout_str, stream);
+      SetExternalInput<dali::CPUBackend>(pipe_handle, name, data_ptr, data_type, shapes, sample_dim,
+                                         layout_str, stream);
       return;
     case device_type_t::GPU:
-      SetExternalInput<dali::GPUBackend>(pipe_handle, name, device, data_ptr, data_type, shapes,
-                                         sample_dim, layout_str, stream);
+      SetExternalInput<dali::GPUBackend>(pipe_handle, name, data_ptr, data_type, shapes, sample_dim,
+                                         layout_str, stream);
       return;
     default:
       DALI_FAIL(dali::make_string("Unknown device: ", device));
@@ -175,12 +175,12 @@ void daliSetExternalInputTensorsStream(daliPipelineHandle *pipe_handle, const ch
                                        cudaStream_t stream) {
   switch (device) {
     case device_type_t::CPU:
-      SetExternalInputTensors<dali::CPUBackend>(pipe_handle, name, device, data_ptr, data_type,
-                                                shapes, sample_dim, layout_str, stream);
+      SetExternalInputTensors<dali::CPUBackend>(pipe_handle, name, data_ptr, data_type, shapes,
+                                                sample_dim, layout_str, stream);
       return;
     case device_type_t::GPU:
-      SetExternalInputTensors<dali::GPUBackend>(pipe_handle, name, device, data_ptr, data_type,
-                                                shapes, sample_dim, layout_str, stream);
+      SetExternalInputTensors<dali::GPUBackend>(pipe_handle, name, data_ptr, data_type, shapes,
+                                                sample_dim, layout_str, stream);
       return;
     default:
       DALI_FAIL(dali::make_string("Unknown device: ", device));

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "dali/c_api.h"  // NOLINT [build/include]
+
 #include <algorithm>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "dali/c_api.h"
 #include "dali/core/format.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/pipeline/pipeline.h"

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -127,6 +127,7 @@ void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline) {
                           backend_to_device_type<Backend>::value, 0, false);
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
     output2.Copy(c_api_output, cuda_stream);
+    CUDA_CALL(cudaDeviceSynchronize());
     Check(view<uint8_t>(output1), view<uint8_t>(output2));
   }
 }

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -204,10 +204,9 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
     input.Copy(input_cpu, cuda_stream);
     pipe_ptr->SetExternalInput(input_name, input);
-    daliSetExternalInputCudaStream(&handle, input_name.c_str(),
-                                   backend_to_device_type<TypeParam>::value, input.raw_data(),
-                                   dali_data_type_t::DALI_UINT8, input_shape.data(),
-                                   input_shape.sample_dim(), nullptr, cuda_stream);
+    daliSetExternalInputAsync(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
+                              input.raw_data(), dali_data_type_t::DALI_UINT8, input_shape.data(),
+                              input_shape.sample_dim(), nullptr, cuda_stream);
   }
 
   for (int i = 0; i < prefetch_queue_depth; i++) {
@@ -225,10 +224,9 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
   // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
   input.Copy(input_cpu, cuda_stream);
   pipe_ptr->SetExternalInput(input_name, input);
-  daliSetExternalInputCudaStream(&handle, input_name.c_str(),
-                                 backend_to_device_type<TypeParam>::value, input.raw_data(),
-                                 dali_data_type_t::DALI_UINT8, input_shape.data(),
-                                 input_shape.sample_dim(), "HWC", cuda_stream);
+  daliSetExternalInputAsync(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
+                            input.raw_data(), dali_data_type_t::DALI_UINT8, input_shape.data(),
+                            input_shape.sample_dim(), "HWC", cuda_stream);
   daliRun(&handle);
   pipe_ptr->RunCPU();
   pipe_ptr->RunGPU();
@@ -263,11 +261,10 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
     input.Copy(input_cpu, cuda_stream);
     pipe_ptr->SetExternalInput(input_name, input, cuda_stream);
-    daliSetExternalInputTensorsCudaStream(&handle, input_name.c_str(),
-                                          backend_to_device_type<TypeParam>::value,
-                                          data_ptrs.data(), dali_data_type_t::DALI_UINT8,
-                                          input_shape.data(), input_shape.sample_dim(), nullptr,
-                                          cuda_stream);
+    daliSetExternalInputTensorsAsync(&handle, input_name.c_str(),
+                                     backend_to_device_type<TypeParam>::value, data_ptrs.data(),
+                                     dali_data_type_t::DALI_UINT8, input_shape.data(),
+                                     input_shape.sample_dim(), nullptr, cuda_stream);
   }
 
   for (int i = 0; i < prefetch_queue_depth; i++) {
@@ -285,10 +282,10 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
   // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
   input.Copy(input_cpu, cuda_stream);
   pipe_ptr->SetExternalInput(input_name, input, cuda_stream);
-  daliSetExternalInputTensorsCudaStream(&handle, input_name.c_str(),
-                                        backend_to_device_type<TypeParam>::value, data_ptrs.data(),
-                                        dali_data_type_t::DALI_UINT8, input_shape.data(),
-                                        input_shape.sample_dim(), "HWC", cuda_stream);
+  daliSetExternalInputTensorsAsync(&handle, input_name.c_str(),
+                                   backend_to_device_type<TypeParam>::value, data_ptrs.data(),
+                                   dali_data_type_t::DALI_UINT8, input_shape.data(),
+                                   input_shape.sample_dim(), "HWC", cuda_stream);
   daliRun(&handle);
   pipe_ptr->RunCPU();
   pipe_ptr->RunGPU();

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -31,6 +31,8 @@ namespace dali {
 
 namespace {
 
+using BACKEND = CPUBackend; // TODO remove
+
 constexpr int batch_size = 12;
 constexpr int num_thread = 4;
 constexpr int device_id = 0;
@@ -41,37 +43,50 @@ constexpr bool async = true;
 constexpr float output_size = 20.f;
 const std::string input_name = "inputs"s;  // NOLINT
 
+template<typename Backend>
+struct backend_to_device_type {
+  static constexpr device_type_t value = CPU;
+};
+
+template<>
+struct backend_to_device_type<GPUBackend> {
+  static constexpr device_type_t value = GPU;
+};
+
+
+template<typename Backend, device_type_t execution_device = backend_to_device_type<Backend>::value>
 std::unique_ptr<Pipeline> GetTestPipeline(bool is_file_reader, const std::string &output_device) {
   auto pipe_ptr = std::make_unique<Pipeline>(batch_size, num_thread, device_id, seed, pipelined,
                                              prefetch_queue_depth, async);
   auto &pipe = *pipe_ptr;
-  TensorList<CPUBackend> data;
+  std::string exec_device = execution_device == CPU ? "cpu" : "gpu";
+  TensorList<Backend> data;
   if (is_file_reader) {
     std::string file_root = testing::dali_extra_path() + "/db/single/jpeg/";
     std::string file_list = file_root + "image_list.txt";
     pipe.AddOperator(OpSpec("FileReader")
-                         .AddArg("device", "cpu")
-                         .AddArg("file_root", file_root)
-                         .AddArg("file_list", file_list)
-                         .AddOutput("compressed_images", "cpu")
-                         .AddOutput("labels", "cpu"));
+                             .AddArg("device", execution_device == CPU ? "cpu"s : "mixed"s)
+                             .AddArg("file_root", file_root)
+                             .AddArg("file_list", file_list)
+                             .AddOutput("compressed_images",exec_device)
+                             .AddOutput("labels", exec_device));
 
     pipe.AddOperator(OpSpec("ImageDecoder")
-                         .AddArg("device", "cpu")
-                         .AddArg("output_type", DALI_RGB)
-                         .AddInput("compressed_images", "cpu")
-                         .AddOutput(input_name, "cpu"));
+                             .AddArg("device", exec_device)
+                             .AddArg("output_type", DALI_RGB)
+                             .AddInput("compressed_images", exec_device)
+                             .AddOutput(input_name, exec_device));
   } else {
     pipe.AddExternalInput(input_name);
   }
   //  Some Op
   pipe.AddOperator(OpSpec("Resize")
-                       .AddArg("device", "cpu")
-                       .AddArg("image_type", DALI_RGB)
-                       .AddArg("resize_x", output_size)
-                       .AddArg("resize_y", output_size)
-                       .AddInput(input_name, "cpu")
-                       .AddOutput("outputs", "cpu"));
+                           .AddArg("device", exec_device)
+                           .AddArg("image_type", DALI_RGB)
+                           .AddArg("resize_x", output_size)
+                           .AddArg("resize_y", output_size)
+                           .AddInput(input_name, exec_device)
+                           .AddOutput("outputs", exec_device));
 
   vector<std::pair<string, string>> outputs = {{"outputs", output_device}};
 
@@ -79,8 +94,10 @@ std::unique_ptr<Pipeline> GetTestPipeline(bool is_file_reader, const std::string
   return pipe_ptr;
 }
 
+
 // Takes Outptus from baseline and handle and compares them
-// Allows only for uint8_t CPU output data to be compared
+// Allows only for uint8_t CPU/GPU output data to be compared
+template<typename Backend>
 void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline) {
   dali::DeviceWorkspace ws;
   baseline.Outputs(&ws);
@@ -88,13 +105,13 @@ void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline) {
 
   EXPECT_EQ(daliGetNumOutput(&handle), ws.NumOutput());
   const int num_output = ws.NumOutput();
-  TensorList<CPUBackend> c_output;
+  TensorList<Backend> c_output;
   for (int output = 0; output < num_output; output++) {
     EXPECT_EQ(daliNumTensors(&handle, output), batch_size);
     for (int elem = 0; elem < batch_size; elem++) {
       auto *shape = daliShapeAtSample(&handle, output, elem);
       int idx = 0;
-      auto ref_shape = ws.Output<CPUBackend>(output).shape()[idx];
+      auto ref_shape = ws.Output<Backend>(output).shape()[idx];
       for (; shape[idx] != 0; idx++) {
         EXPECT_EQ(shape[idx], ref_shape[idx]);
       }
@@ -102,10 +119,11 @@ void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline) {
       free(shape);
     }
 
-    TensorList<CPUBackend> c_output;
-    auto &regular_output = ws.Output<CPUBackend>(0);
+    TensorList<Backend> c_output;
+    auto &regular_output = ws.Output<Backend>(0);
     c_output.Resize(regular_output.shape(), TypeInfo::Create<uint8_t>());
-    daliCopyTensorListNTo(&handle, c_output.raw_mutable_data(), 0, device_type_t::CPU, 0, false);
+    daliCopyTensorListNTo(&handle, c_output.raw_mutable_data(), 0,
+                          backend_to_device_type<Backend>::value, 0, false);
     Check(view<uint8_t>(c_output), view<uint8_t>(regular_output));
   }
 }
@@ -113,7 +131,7 @@ void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline) {
 }  // namespace
 
 TEST(CApiTest, FileReaderPipe) {
-  auto pipe_ptr = GetTestPipeline(true, "cpu");
+  auto pipe_ptr = GetTestPipeline<BACKEND>(true, "cpu");
   auto serialized = pipe_ptr->SerializeToProtobuf();
 
   pipe_ptr->Build();
@@ -130,23 +148,23 @@ TEST(CApiTest, FileReaderPipe) {
 
   dali::DeviceWorkspace ws;
   for (int i = 0; i < prefetch_queue_depth; i++) {
-    ComparePipelinesOutputs(handle, *pipe_ptr);
+    ComparePipelinesOutputs<BACKEND>(handle, *pipe_ptr);
   }
 
   daliRun(&handle);
   pipe_ptr->RunCPU();
   pipe_ptr->RunGPU();
 
-  ComparePipelinesOutputs(handle, *pipe_ptr);
+  ComparePipelinesOutputs<BACKEND>(handle, *pipe_ptr);
 }
 
 TEST(CApiTest, ExternalSourceSingleAllocPipe) {
   TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
                                    {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
-  TensorList<CPUBackend> input;
+  TensorList<BACKEND> input;
   input.Resize(input_shape, TypeInfo::Create<uint8_t>());
-  auto pipe_ptr = GetTestPipeline(false, "cpu");
+  auto pipe_ptr = GetTestPipeline<BACKEND>(false, "cpu");
   auto serialized = pipe_ptr->SerializeToProtobuf();
 
   pipe_ptr->Build();
@@ -159,7 +177,7 @@ TEST(CApiTest, ExternalSourceSingleAllocPipe) {
   for (int i = 0; i < prefetch_queue_depth; i++) {
     SequentialFill(view<uint8_t>(input), 42 * i);
     pipe_ptr->SetExternalInput(input_name, input);
-    daliSetExternalInput(&handle, input_name.c_str(), device_type_t::CPU, input.raw_data(),
+    daliSetExternalInput(&handle, input_name.c_str(), backend_to_device_type<BACKEND>::value, input.raw_data(),
                          dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(),
                          nullptr);
   }
@@ -172,32 +190,32 @@ TEST(CApiTest, ExternalSourceSingleAllocPipe) {
 
   dali::DeviceWorkspace ws;
   for (int i = 0; i < prefetch_queue_depth; i++) {
-    ComparePipelinesOutputs(handle, *pipe_ptr);
+    ComparePipelinesOutputs<BACKEND>(handle, *pipe_ptr);
   }
 
   SequentialFill(view<uint8_t>(input), 42 * prefetch_queue_depth);
   pipe_ptr->SetExternalInput(input_name, input);
-  daliSetExternalInput(&handle, input_name.c_str(), device_type_t::CPU, input.raw_data(),
+  daliSetExternalInput(&handle, input_name.c_str(), backend_to_device_type<CPUBackend>::value, input.raw_data(),
                        dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(),
                        "HWC");
   daliRun(&handle);
   pipe_ptr->RunCPU();
   pipe_ptr->RunGPU();
 
-  ComparePipelinesOutputs(handle, *pipe_ptr);
+  ComparePipelinesOutputs<BACKEND>(handle, *pipe_ptr);
 }
 
 TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
   TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
                                    {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
-  TensorList<CPUBackend> input;
+  TensorList<BACKEND> input;
   input.Resize(input_shape, TypeInfo::Create<uint8_t>());
   std::vector<const void *> data_ptrs(batch_size);
   for (int i = 0; i < batch_size; i++) {
     data_ptrs[i] = input.raw_tensor(i);
   }
-  auto pipe_ptr = GetTestPipeline(false, "cpu");
+  auto pipe_ptr = GetTestPipeline<BACKEND>(false, "cpu");
   auto serialized = pipe_ptr->SerializeToProtobuf();
 
   pipe_ptr->Build();
@@ -224,7 +242,7 @@ TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
 
   dali::DeviceWorkspace ws;
   for (int i = 0; i < prefetch_queue_depth; i++) {
-    ComparePipelinesOutputs(handle, *pipe_ptr);
+    ComparePipelinesOutputs<BACKEND>(handle, *pipe_ptr);
   }
 
   SequentialFill(view<uint8_t>(input), 42 * prefetch_queue_depth);
@@ -236,7 +254,7 @@ TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
   pipe_ptr->RunCPU();
   pipe_ptr->RunGPU();
 
-  ComparePipelinesOutputs(handle, *pipe_ptr);
+  ComparePipelinesOutputs<BACKEND>(handle, *pipe_ptr);
 }
 
 }  // namespace dali

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -297,6 +297,9 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
 TYPED_TEST(CApiTest, ExternalSourceSingleAllocDifferentBackendsTest) {
   using OpBackend = TypeParam;
   using DataBackend = typename the_other_backend<TypeParam>::type;
+  if (std::is_same<OpBackend, CPUBackend>::value && std::is_same<DataBackend, GPUBackend>::value) {
+    GTEST_SKIP();  // GPU data -> CPU op   is currently not supported. Might be added later.
+  }
   TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8,  8,  3},
                                    {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
@@ -354,6 +357,9 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocDifferentBackendsTest) {
 TYPED_TEST(CApiTest, ExternalSourceMultipleAllocDifferentBackendsTest) {
   using OpBackend = TypeParam;
   using DataBackend = typename the_other_backend<TypeParam>::type;
+  if (std::is_same<OpBackend, CPUBackend>::value && std::is_same<DataBackend, GPUBackend>::value) {
+    GTEST_SKIP();  // GPU data -> CPU op   is currently not supported. Might be added later.
+  }
   TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8,  8,  3},
                                    {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -177,9 +177,9 @@ TEST(CApiTest, ExternalSourceSingleAllocPipe) {
   for (int i = 0; i < prefetch_queue_depth; i++) {
     SequentialFill(view<uint8_t>(input), 42 * i);
     pipe_ptr->SetExternalInput(input_name, input);
-    daliSetExternalInput(&handle, input_name.c_str(), backend_to_device_type<BACKEND>::value, input.raw_data(),
-                         dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(),
-                         nullptr);
+    daliSetExternalInput(&handle, input_name.c_str(), backend_to_device_type<BACKEND>::value,
+                         input.raw_data(), dali_data_type_t::DALI_UINT8, input_shape.data(),
+                         input_shape.sample_dim(), nullptr);
   }
 
   for (int i = 0; i < prefetch_queue_depth; i++) {
@@ -195,9 +195,9 @@ TEST(CApiTest, ExternalSourceSingleAllocPipe) {
 
   SequentialFill(view<uint8_t>(input), 42 * prefetch_queue_depth);
   pipe_ptr->SetExternalInput(input_name, input);
-  daliSetExternalInput(&handle, input_name.c_str(), backend_to_device_type<CPUBackend>::value, input.raw_data(),
-                       dali_data_type_t::DALI_UINT8, input_shape.data(), input_shape.sample_dim(),
-                       "HWC");
+  daliSetExternalInput(&handle, input_name.c_str(), backend_to_device_type<BACKEND>::value,
+                       input.raw_data(), dali_data_type_t::DALI_UINT8, input_shape.data(),
+                       input_shape.sample_dim(), "HWC");
   daliRun(&handle);
   pipe_ptr->RunCPU();
   pipe_ptr->RunGPU();
@@ -229,8 +229,8 @@ TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
     SequentialFill(view<uint8_t>(input), 42 * i);
 
     pipe_ptr->SetExternalInput(input_name, input);
-    daliSetExternalInputTensors(&handle, input_name.c_str(), device_type_t::CPU, data_ptrs.data(),
-                                dali_data_type_t::DALI_UINT8, input_shape.data(),
+    daliSetExternalInputTensors(&handle, input_name.c_str(), backend_to_device_type<BACKEND>::value,
+                                data_ptrs.data(), dali_data_type_t::DALI_UINT8, input_shape.data(),
                                 input_shape.sample_dim(), nullptr);
   }
 
@@ -247,8 +247,8 @@ TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
 
   SequentialFill(view<uint8_t>(input), 42 * prefetch_queue_depth);
   pipe_ptr->SetExternalInput(input_name, input);
-  daliSetExternalInputTensors(&handle, input_name.c_str(), device_type_t::CPU, data_ptrs.data(),
-                              dali_data_type_t::DALI_UINT8, input_shape.data(),
+  daliSetExternalInputTensors(&handle, input_name.c_str(), backend_to_device_type<BACKEND>::value,
+                              data_ptrs.data(), dali_data_type_t::DALI_UINT8, input_shape.data(),
                               input_shape.sample_dim(), "HWC");
   daliRun(&handle);
   pipe_ptr->RunCPU();

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -193,10 +193,10 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
     input.Copy(input_cpu, cuda_stream);
     pipe_ptr->SetExternalInput(input_name, input);
-    daliSetExternalInputStream(&handle, input_name.c_str(),
-                               backend_to_device_type<TypeParam>::value, input.raw_data(),
-                               dali_data_type_t::DALI_UINT8, input_shape.data(),
-                               input_shape.sample_dim(), nullptr, cuda_stream);
+    daliSetExternalInputCudaStream(&handle, input_name.c_str(),
+                                   backend_to_device_type<TypeParam>::value, input.raw_data(),
+                                   dali_data_type_t::DALI_UINT8, input_shape.data(),
+                                   input_shape.sample_dim(), nullptr, cuda_stream);
   }
 
   for (int i = 0; i < prefetch_queue_depth; i++) {
@@ -214,9 +214,10 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
   // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
   input.Copy(input_cpu, cuda_stream);
   pipe_ptr->SetExternalInput(input_name, input);
-  daliSetExternalInputStream(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
-                             input.raw_data(), dali_data_type_t::DALI_UINT8, input_shape.data(),
-                             input_shape.sample_dim(), "HWC", cuda_stream);
+  daliSetExternalInputCudaStream(&handle, input_name.c_str(),
+                                 backend_to_device_type<TypeParam>::value, input.raw_data(),
+                                 dali_data_type_t::DALI_UINT8, input_shape.data(),
+                                 input_shape.sample_dim(), "HWC", cuda_stream);
   daliRun(&handle);
   pipe_ptr->RunCPU();
   pipe_ptr->RunGPU();
@@ -251,10 +252,11 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
     input.Copy(input_cpu, cuda_stream);
     pipe_ptr->SetExternalInput(input_name, input, cuda_stream);
-    daliSetExternalInputTensorsStream(&handle, input_name.c_str(),
-                                      backend_to_device_type<TypeParam>::value, data_ptrs.data(),
-                                      dali_data_type_t::DALI_UINT8, input_shape.data(),
-                                      input_shape.sample_dim(), nullptr, cuda_stream);
+    daliSetExternalInputTensorsCudaStream(&handle, input_name.c_str(),
+                                          backend_to_device_type<TypeParam>::value,
+                                          data_ptrs.data(), dali_data_type_t::DALI_UINT8,
+                                          input_shape.data(), input_shape.sample_dim(), nullptr,
+                                          cuda_stream);
   }
 
   for (int i = 0; i < prefetch_queue_depth; i++) {
@@ -272,10 +274,10 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
   // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
   input.Copy(input_cpu, cuda_stream);
   pipe_ptr->SetExternalInput(input_name, input, cuda_stream);
-  daliSetExternalInputTensorsStream(&handle, input_name.c_str(),
-                                    backend_to_device_type<TypeParam>::value, data_ptrs.data(),
-                                    dali_data_type_t::DALI_UINT8, input_shape.data(),
-                                    input_shape.sample_dim(), "HWC", cuda_stream);
+  daliSetExternalInputTensorsCudaStream(&handle, input_name.c_str(),
+                                        backend_to_device_type<TypeParam>::value, data_ptrs.data(),
+                                        dali_data_type_t::DALI_UINT8, input_shape.data(),
+                                        input_shape.sample_dim(), "HWC", cuda_stream);
   daliRun(&handle);
   pipe_ptr->RunCPU();
   pipe_ptr->RunGPU();

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -117,18 +117,18 @@ void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline) {
       free(shape);
     }
 
-    TensorList<CPUBackend> output1, output2;
+    TensorList<CPUBackend> pipeline_output_cpu, c_api_output_cpu;
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    output1.Copy(ws.Output<Backend>(0), cuda_stream);
+    pipeline_output_cpu.Copy(ws.Output<Backend>(0), cuda_stream);
 
     TensorList<Backend> c_api_output;
-    c_api_output.Resize(output1.shape(), TypeInfo::Create<uint8_t>());
+    c_api_output.Resize(pipeline_output_cpu.shape(), TypeInfo::Create<uint8_t>());
     daliCopyTensorListNTo(&handle, c_api_output.raw_mutable_data(), 0,
                           backend_to_device_type<Backend>::value, 0, false);
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    output2.Copy(c_api_output, cuda_stream);
+    c_api_output_cpu.Copy(c_api_output, cuda_stream);
     CUDA_CALL(cudaDeviceSynchronize());
-    Check(view<uint8_t>(output1), view<uint8_t>(output2));
+    Check(view<uint8_t>(pipeline_output_cpu), view<uint8_t>(c_api_output_cpu));
   }
 }
 

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -192,9 +192,10 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
     input.Copy(input_cpu, cuda_stream);
     pipe_ptr->SetExternalInput(input_name, input);
-    daliSetExternalInputStream(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
-                         input.raw_data(), dali_data_type_t::DALI_UINT8, input_shape.data(),
-                         input_shape.sample_dim(), nullptr, cuda_stream);
+    daliSetExternalInputStream(&handle, input_name.c_str(),
+                               backend_to_device_type<TypeParam>::value, input.raw_data(),
+                               dali_data_type_t::DALI_UINT8, input_shape.data(),
+                               input_shape.sample_dim(), nullptr, cuda_stream);
   }
 
   for (int i = 0; i < prefetch_queue_depth; i++) {

--- a/dali/pipeline/operator/builtin/external_source.cu
+++ b/dali/pipeline/operator/builtin/external_source.cu
@@ -62,7 +62,7 @@ void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
 
   auto &output = ws.Output<GPUBackend>(0);
   cudaStream_t stream_used = ws.has_stream() ? ws.stream() : 0;
-  CUDA_CALL(cudaStreamWaitEvent(stream_used,*internal_copy_to_storage.front(), 0));
+  CUDA_CALL(cudaStreamWaitEvent(stream_used, *internal_copy_to_storage.front(), 0));
   output.Copy(*(data.front()), stream_used);
   // record an event so Recycle can synchronize on it
   cudaEventRecord(*cuda_event.front(), stream_used);

--- a/dali/pipeline/operator/builtin/external_source.cu
+++ b/dali/pipeline/operator/builtin/external_source.cu
@@ -48,7 +48,7 @@ struct ExternalSource<GPUBackend>::RecycleFunctor {
 template<>
 void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   std::list<uptr_tl_type> data;
-  std::list<uptr_cuda_event_type> cuda_event, internal_copy_to_gpu;
+  std::list<uptr_cuda_event_type> cuda_event, internal_copy_to_storage;
   {
     std::unique_lock<std::mutex> busy_lock(busy_m_);
     cv_.wait(busy_lock, [&data = data_in_tl_]{return !data.empty();});
@@ -56,18 +56,18 @@ void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
     data_in_tl_.pop_front();
     DALI_ENFORCE(is_data_in_tl, "Cannot feed non-contiguous data to GPU op.");
     data = tl_data_.PopFront();
-    internal_copy_to_gpu = copy_to_gpu_events_.PopFront();
+    internal_copy_to_storage = copy_to_storage_events_.PopFront();
     cuda_event = cuda_events_.GetEmpty();
   }
 
-  cudaEventSynchronize(*internal_copy_to_gpu.front());
   auto &output = ws.Output<GPUBackend>(0);
   cudaStream_t stream_used = ws.has_stream() ? ws.stream() : 0;
+  CUDA_CALL(cudaStreamWaitEvent(stream_used,*internal_copy_to_storage.front(), 0));
   output.Copy(*(data.front()), stream_used);
   // record an event so Recycle can synchronize on it
   cudaEventRecord(*cuda_event.front(), stream_used);
   sync_worker_.DoWork(RecycleFunctor{this, std::move(cuda_event), std::move(data),
-                                     std::move(internal_copy_to_gpu)});
+                                     std::move(internal_copy_to_storage)});
 }
 
 DALI_REGISTER_OPERATOR(_ExternalSource, ExternalSource<GPUBackend>, GPU);

--- a/dali/pipeline/operator/builtin/external_source.cu
+++ b/dali/pipeline/operator/builtin/external_source.cu
@@ -27,25 +27,28 @@ struct ExternalSource<GPUBackend>::RecycleFunctor {
     assert(!"Should never happen");
   }
   RecycleFunctor(RecycleFunctor &&) = default;
+  RecycleFunctor& operator=(const RecycleFunctor&) = default;
+  RecycleFunctor& operator=(RecycleFunctor&&) = default;
+  ~RecycleFunctor() = default;
 
-  RecycleFunctor(
-      ExternalSource<GPUBackend> *owner,
-      std::list<uptr_cuda_event_type> event,
-      std::list<uptr_tl_type> ptr)
-  : owner(owner), event(std::move(event)), ptr(std::move(ptr)) {}
+
+  RecycleFunctor(ExternalSource<GPUBackend> *owner, std::list<uptr_cuda_event_type> event,
+                 std::list<uptr_tl_type> ptr, std::list<uptr_cuda_event_type> internal_copy_to_gpu)
+          : owner(owner), event(std::move(event)), copy_to_gpu(std::move(internal_copy_to_gpu)),
+            ptr(std::move(ptr)) {}
 
   ExternalSource<GPUBackend> *owner;
-  std::list<uptr_cuda_event_type> event;
+  std::list<uptr_cuda_event_type> event, copy_to_gpu;
   std::list<uptr_tl_type> ptr;
   void operator()() {
-    owner->RecycleBuffer(ptr, &event);
+    owner->RecycleBuffer(ptr, &event, &copy_to_gpu);
   }
 };
 
 template<>
 void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   std::list<uptr_tl_type> data;
-  std::list<uptr_cuda_event_type> cuda_event;
+  std::list<uptr_cuda_event_type> cuda_event, internal_copy_to_gpu;
   {
     std::unique_lock<std::mutex> busy_lock(busy_m_);
     cv_.wait(busy_lock, [&data = data_in_tl_]{return !data.empty();});
@@ -53,15 +56,18 @@ void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
     data_in_tl_.pop_front();
     DALI_ENFORCE(is_data_in_tl, "Cannot feed non-contiguous data to GPU op.");
     data = tl_data_.PopFront();
+    internal_copy_to_gpu = copy_to_gpu_events_.PopFront();
     cuda_event = cuda_events_.GetEmpty();
   }
 
+  cudaEventSynchronize(*internal_copy_to_gpu.front());
   auto &output = ws.Output<GPUBackend>(0);
   cudaStream_t stream_used = ws.has_stream() ? ws.stream() : 0;
   output.Copy(*(data.front()), stream_used);
   // record an event so Recycle can synchronize on it
-  cudaEventRecord(cuda_event.front()->event, stream_used);
-  sync_worker_.DoWork(RecycleFunctor{ this, std::move(cuda_event), std::move(data) });
+  cudaEventRecord(*cuda_event.front(), stream_used);
+  sync_worker_.DoWork(RecycleFunctor{this, std::move(cuda_event), std::move(data),
+                                     std::move(internal_copy_to_gpu)});
 }
 
 DALI_REGISTER_OPERATOR(_ExternalSource, ExternalSource<GPUBackend>, GPU);

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -116,8 +116,8 @@ class CachingList {
  */
 template <typename Backend>
 class ExternalSource : public Operator<Backend> {
-  using uptr_tl_type = std::unique_ptr<TensorList<CPUBackend>>;
-  using uptr_vt_type = std::unique_ptr<std::vector<Tensor<CPUBackend>>>;
+  using uptr_tl_type = std::unique_ptr<TensorList<Backend>>;
+  using uptr_vt_type = std::unique_ptr<std::vector<Tensor<Backend>>>;
   using uptr_cuda_event_type = std::unique_ptr<detail::CudaEventWrapper>;
 
  public:

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -136,10 +136,12 @@ class DLL_PUBLIC Pipeline {
   }
 
 
-  template<typename T, typename Backend>
+  template<typename T, typename OperatorBackend>
   void SetDataSourceHelper(const string &name, const T &tl, OperatorBase *op_ptr,
                            cudaStream_t stream = 0) {
-    auto *source = dynamic_cast<ExternalSource<Backend> *>(op_ptr);
+    // Note: we have 2 different Backends here - OperatorBackend and T's Backend (StorageBackend).
+    // The StorageBackend is hidden under `T` type.
+    auto *source = dynamic_cast<ExternalSource<OperatorBackend> *>(op_ptr);
     DALI_ENFORCE(source != nullptr,
                  "Input name '" + name + "' is not marked as an external input.");
     source->SetDataSource(tl, stream);
@@ -154,11 +156,8 @@ class DLL_PUBLIC Pipeline {
    * @param tl data
    * @param stream CUDA stream to use in case of GPUBackend
    */
-  template<typename Backend, typename TL>
+  template<typename TL>
   inline void SetExternalInputHelper(const string &name, const TL &tl, cudaStream_t stream = 0) {
-    static_assert(std::is_same<TL, TensorList<Backend>>::value ||
-                  std::is_same<TL, std::vector<Tensor<Backend>>>::value,
-                  "TL can be either TensorList<> or std::vector<Tensor<>>");
     bool is_cpu_node = true;
     OpNodeId node_id;
 
@@ -196,7 +195,7 @@ class DLL_PUBLIC Pipeline {
   template<typename Backend>
   DLL_PUBLIC inline void
   SetExternalInput(const string &name, const TensorList<Backend> &tl, cudaStream_t stream = 0) {
-    SetExternalInputHelper<Backend>(name, tl, stream);
+    SetExternalInputHelper(name, tl, stream);
   }
 
 
@@ -210,7 +209,7 @@ class DLL_PUBLIC Pipeline {
   template<typename Backend>
   DLL_PUBLIC inline void
   SetExternalInput(const string &name, const vector<Tensor<Backend>> &tl, cudaStream_t stream = 0) {
-    SetExternalInputHelper<Backend>(name, tl, stream);
+    SetExternalInputHelper(name, tl, stream);
   }
 
   /**

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -16,7 +16,7 @@
 #define DALI_C_API_H_
 
 #include <cuda_runtime_api.h>
-#include <cinttypes>
+#include <inttypes.h>
 #include "dali/core/api_helper.h"
 
 // Trick to bypass gcc4.9 old ABI name mangling used by TF

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -16,7 +16,7 @@
 #define DALI_C_API_H_
 
 #include <cuda_runtime_api.h>
-#include <inttypes.h>
+#include <cinttypes>
 #include "dali/core/api_helper.h"
 
 // Trick to bypass gcc4.9 old ABI name mangling used by TF
@@ -41,19 +41,19 @@ typedef enum {
 } device_type_t;
 
 typedef enum {
-  DALI_NO_TYPE = -1,
-  DALI_UINT8 = 0,
-  DALI_UINT16 = 1,
-  DALI_UINT32 = 2,
-  DALI_UINT64 = 3,
-  DALI_INT8 = 4,
-  DALI_INT16 = 5,
-  DALI_INT32 = 6,
-  DALI_INT64 = 7,
-  DALI_FLOAT16 = 8,
-  DALI_FLOAT = 9,
-  DALI_FLOAT64 = 10,
-  DALI_BOOL = 11
+  DALI_NO_TYPE  = -1,
+  DALI_UINT8    =  0,
+  DALI_UINT16   =  1,
+  DALI_UINT32   =  2,
+  DALI_UINT64   =  3,
+  DALI_INT8     =  4,
+  DALI_INT16    =  5,
+  DALI_INT32    =  6,
+  DALI_INT64    =  7,
+  DALI_FLOAT16  =  8,
+  DALI_FLOAT    =  9,
+  DALI_FLOAT64  =  10,
+  DALI_BOOL     =  11,
 } dali_data_type_t;
 
 /**

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -86,7 +86,7 @@ DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle,
  * @param pipe_handle Pointer to pipeline handle
  * @param name Pointer to a null-terminated byte string with the name of the External Source
  *             to be fed
- * @param device Device of the supplied memory. Only CPU is supported.
+ * @param device Device of the supplied memory.
  * @param data_ptr Pointer to contiguous buffer containing all samples
  * @param data_type Type of the provided data
  * @param shapes Pointer to an array containing shapes of all samples concatenated one after
@@ -118,7 +118,7 @@ DLL_PUBLIC void daliSetExternalInput(daliPipelineHandle *pipe_handle, const char
  * @param pipe_handle Pointer to pipeline handle
  * @param name Pointer to a null-terminated byte string with the name of the External Source
  *             to be fed
- * @param device Device of the supplied memory. Only CPU is supported.
+ * @param device Device of the supplied memory.
  * @param data_ptr Pointer to an array containing batch_size pointers to separate Tensors.
  * @param data_type Type of the provided data
  * @param shapes Pointer to an array containing shapes of all samples concatenated one after
@@ -142,7 +142,6 @@ daliSetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
                             dali_data_type_t data_type, const int64_t *shapes,
                             int64_t sample_dim, const char *layout_str);
 ///@}
-
 
 /**
  * @brief Start the execution of the pipeline.

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -23,214 +23,243 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  /**
-   * @brief Handle for DALI C-like API.
-   *
-   * @note Beware, the C API is just C-like API for handling some mangling issues and
-   * it can throw exceptions.
-   */
-  typedef struct {
-    void* pipe;
-    void* ws;
-  } daliPipelineHandle;
 
-  typedef enum {
-    CPU = 0,
-    GPU = 1
-  } device_type_t;
+/**
+ * @brief Handle for DALI C-like API.
+ *
+ * @note Beware, the C API is just C-like API for handling some mangling issues and
+ * it can throw exceptions.
+ */
+typedef struct {
+  void *pipe;
+  void *ws;
+} daliPipelineHandle;
 
-  typedef enum {
-    DALI_NO_TYPE         = -1,
-    DALI_UINT8           =  0,
-    DALI_UINT16          =  1,
-    DALI_UINT32          =  2,
-    DALI_UINT64          =  3,
-    DALI_INT8            =  4,
-    DALI_INT16           =  5,
-    DALI_INT32           =  6,
-    DALI_INT64           =  7,
-    DALI_FLOAT16         =  8,
-    DALI_FLOAT           =  9,
-    DALI_FLOAT64         = 10,
-    DALI_BOOL            = 11
-  } dali_data_type_t;
+typedef enum {
+  CPU = 0,
+  GPU = 1
+} device_type_t;
 
-  /**
-   * @brief Create DALI pipeline. Setting batch_size,
-   * num_threads or device_id here overrides
-   * values stored in the serialized pipeline.
-   * When separated_execution is false, prefetch_queue_depth is considered,
-   * gpu_prefetch_queue_depth and cpu_prefetch_queue_depth are ignored.
-   * When separated_execution is true, cpu_prefetch_queue_depth and
-   * gpu_prefetch_queue_depth are considered and prefetch_queue_depth is ignored.
-   */
-  DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle* pipe_handle,
-      const char *serialized_pipeline,
-      int length,
-      int batch_size,
-      int num_threads,
-      int device_id,
-      bool separated_execution,
-      int prefetch_queue_depth,
-      int cpu_prefetch_queue_depth,
-      int gpu_prefetch_queue_depth);
+typedef enum {
+  DALI_NO_TYPE = -1,
+  DALI_UINT8 = 0,
+  DALI_UINT16 = 1,
+  DALI_UINT32 = 2,
+  DALI_UINT64 = 3,
+  DALI_INT8 = 4,
+  DALI_INT16 = 5,
+  DALI_INT32 = 6,
+  DALI_INT64 = 7,
+  DALI_FLOAT16 = 8,
+  DALI_FLOAT = 9,
+  DALI_FLOAT64 = 10,
+  DALI_BOOL = 11
+} dali_data_type_t;
 
-  /**
-   * @brief Feed the data to ExternalSource as contiguous memory.
-   *
-   * @param pipe_handle Pointer to pipeline handle
-   * @param name Pointer to a null-terminated byte string with the name of the External Source
-   *             to be fed
-   * @param device Device of the supplied memory. Only CPU is supported.
-   * @param data_ptr Pointer to contiguous buffer containing all samples
-   * @param data_type Type of the provided data
-   * @param shapes Pointer to an array containing shapes of all samples concatenated one after
-   *              another. Should contain batch_size * sample_dim elements.
-   * @param sample_dim The dimensionality of a single sample.
-   * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
-   *                   Can be set to NULL.
-   */
-  DLL_PUBLIC void daliSetExternalInput(daliPipelineHandle* pipe_handle, const char* name,
-                                       device_type_t device, const void* data_ptr,
-                                       dali_data_type_t data_type, const int64_t* shapes,
-                                       int sample_dim, const char* layout_str);
+typedef enum {
+  DALI_SUCCESS = 0,
+  DALI_GENERAL_ERROR=1,
+  DALI_UNKNOWN_DEVICE = 2,
+} dali_error_t;
 
-  /**
-   * @brief Feed the data to ExternalSource as a set of separate buffers.
-   *
-   * @param pipe_handle Pointer to pipeline handle
-   * @param name Pointer to a null-terminated byte string with the name of the External Source
-   *             to be fed
-   * @param device Device of the supplied memory. Only CPU is supported.
-   * @param data_ptr Pointer to an array containing batch_size pointers to separate Tensors.
-   * @param data_type Type of the provided data
-   * @param shapes Pointer to an array containing shapes of all samples concatenated one after
-   *              another. Should contain batch_size * sample_dim elements.
-   * @param sample_dim The dimensionality of a single sample.
-   * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
-   *                   Can be set to NULL.
-   */
-  DLL_PUBLIC void daliSetExternalInputTensors(daliPipelineHandle* pipe_handle, const char* name,
-                                              device_type_t device, const void* const* data_ptr,
-                                              dali_data_type_t data_type, const int64_t* shapes,
-                                              int64_t sample_dim, const char* layout_str);
+/**
+ * @brief Create DALI pipeline. Setting batch_size,
+ * num_threads or device_id here overrides
+ * values stored in the serialized pipeline.
+ * When separated_execution is false, prefetch_queue_depth is considered,
+ * gpu_prefetch_queue_depth and cpu_prefetch_queue_depth are ignored.
+ * When separated_execution is true, cpu_prefetch_queue_depth and
+ * gpu_prefetch_queue_depth are considered and prefetch_queue_depth is ignored.
+ */
+DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle,
+                                   const char *serialized_pipeline,
+                                   int length,
+                                   int batch_size,
+                                   int num_threads,
+                                   int device_id,
+                                   bool separated_execution,
+                                   int prefetch_queue_depth,
+                                   int cpu_prefetch_queue_depth,
+                                   int gpu_prefetch_queue_depth);
 
-  /**
-   * @brief Start the execution of the pipeline.
-   */
-  DLL_PUBLIC void daliRun(daliPipelineHandle* pipe_handle);
+/**
+ * @brief Feed the data to ExternalSource as contiguous memory.
+ *
+ * An alternative function exists to specify also a CUDA stream to use
+ * when copying the data onto GPU. If used with `device == CPU`, this value will be ignored
+ *
+ * @param pipe_handle Pointer to pipeline handle
+ * @param name Pointer to a null-terminated byte string with the name of the External Source
+ *             to be fed
+ * @param device Device of the supplied memory. Only CPU is supported.
+ * @param data_ptr Pointer to contiguous buffer containing all samples
+ * @param data_type Type of the provided data
+ * @param shapes Pointer to an array containing shapes of all samples concatenated one after
+ *              another. Should contain batch_size * sample_dim elements.
+ * @param sample_dim The dimensionality of a single sample.
+ * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
+ *                   Can be set to NULL.
+ * @param stream CUDA stream to use when copying the data onto GPU. If used with `device == CPU`,
+ *               this value will be ignored
+ */
+DLL_PUBLIC void daliSetExternalInput(daliPipelineHandle *pipe_handle, const char *name,
+                                     device_type_t device, const void *data_ptr,
+                                     dali_data_type_t data_type, const int64_t *shapes,
+                                     int sample_dim, const char *layout_str);
 
-  /**
-   * @brief Schedule first runs to fill buffers for Executor with UniformQueue policy.
-   */
-  DLL_PUBLIC void daliPrefetchUniform(daliPipelineHandle* pipe_handle, int queue_depth);
+DLL_PUBLIC void daliSetExternalInputStream(daliPipelineHandle *pipe_handle, const char *name,
+                                           device_type_t device, const void *data_ptr,
+                                           dali_data_type_t data_type, const int64_t *shapes,
+                                           int sample_dim, const char *layout_str,
+                                           cudaStream_t stream);
 
-  /**
-   * @brief Schedule first runs to fill buffers for Executor with SeparateQueue policy.
-   */
-  DLL_PUBLIC void daliPrefetchSeparate(daliPipelineHandle* pipe_handle,
-                                       int cpu_queue_depth, int gpu_queue_depth);
+/**
+ * @brief Feed the data to ExternalSource as a set of separate buffers.
+ *
+ * An alternative function exists to specify also a CUDA stream to use
+ * when copying the data onto GPU. If used with `device == CPU`, this value will be ignored
+ *
+ * @param pipe_handle Pointer to pipeline handle
+ * @param name Pointer to a null-terminated byte string with the name of the External Source
+ *             to be fed
+ * @param device Device of the supplied memory. Only CPU is supported.
+ * @param data_ptr Pointer to an array containing batch_size pointers to separate Tensors.
+ * @param data_type Type of the provided data
+ * @param shapes Pointer to an array containing shapes of all samples concatenated one after
+ *              another. Should contain batch_size * sample_dim elements.
+ * @param sample_dim The dimensionality of a single sample.
+ * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
+ *                   Can be set to NULL.
+ * @param stream CUDA stream to use when copying the data onto GPU. If used with `device == CPU`,
+ *               this value will be ignored
+ */
+DLL_PUBLIC void daliSetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
+                                            device_type_t device, const void *const *data_ptr,
+                                            dali_data_type_t data_type, const int64_t *shapes,
+                                            int64_t sample_dim, const char *layout_str);
 
-  /**
-   * @brief Wait until the output of the pipeline is ready.
-   * Releases previously returned buffers.
-   */
-  DLL_PUBLIC void daliOutput(daliPipelineHandle* pipe_handle);
+DLL_PUBLIC void daliSetExternalInputTensorsStream(daliPipelineHandle *pipe_handle, const char *name,
+                                                  device_type_t device, const void *const *data_ptr,
+                                                  dali_data_type_t data_type, const int64_t *shapes,
+                                                  int64_t sample_dim, const char *layout_str,
+                                                  cudaStream_t stream);
 
-  /**
-   * @brief Wait until the output of the pipeline is ready.
-   * Doesn't release previously returned buffers.
-   */
-  DLL_PUBLIC void daliShareOutput(daliPipelineHandle* pipe_handle);
+/**
+ * @brief Start the execution of the pipeline.
+ */
+DLL_PUBLIC void daliRun(daliPipelineHandle *pipe_handle);
 
-  /**
-   * @brief Releases buffer returned by last daliOutput call.
-   */
-  DLL_PUBLIC void daliOutputRelease(daliPipelineHandle* pipe_handle);
+/**
+ * @brief Schedule first runs to fill buffers for Executor with UniformQueue policy.
+ */
+DLL_PUBLIC void daliPrefetchUniform(daliPipelineHandle *pipe_handle, int queue_depth);
 
-  /**
-   * @brief Return the shape of the output tensor
-   * stored at position `n` in the pipeline.
-   * This function may only be called after
-   * calling Output function.
-   * @remarks Caller is responsible to 'free' the memory returned
-   */
-  DLL_PUBLIC int64_t* daliShapeAt(daliPipelineHandle* pipe_handle, int n);
+/**
+ * @brief Schedule first runs to fill buffers for Executor with SeparateQueue policy.
+ */
+DLL_PUBLIC void daliPrefetchSeparate(daliPipelineHandle *pipe_handle,
+                                     int cpu_queue_depth, int gpu_queue_depth);
 
-  /**
-   * @brief Return the type of the output tensor
-   * stored at position `n` in the pipeline.
-   * This function may only be called after
-   * calling Output function.
-   */
-  DLL_PUBLIC dali_data_type_t daliTypeAt(daliPipelineHandle* pipe_handle, int n);
+/**
+ * @brief Wait until the output of the pipeline is ready.
+ * Releases previously returned buffers.
+ */
+DLL_PUBLIC void daliOutput(daliPipelineHandle *pipe_handle);
 
-  /**
-   * @brief Return the shape of the 'k' output tensor from tensor list
-   * stored at position `n` in the pipeline.
-   * This function may only be called after
-   * calling Output function.
-   * @remarks Caller is responsible to 'free' the memory returned
-   */
-  DLL_PUBLIC int64_t* daliShapeAtSample(daliPipelineHandle* pipe_handle, int n, int k);
+/**
+ * @brief Wait until the output of the pipeline is ready.
+ * Doesn't release previously returned buffers.
+ */
+DLL_PUBLIC void daliShareOutput(daliPipelineHandle *pipe_handle);
 
-  /**
-   * @brief Return the number of tensors in the tensor list
-   * stored at position `n` in the pipeline.
-   */
-  DLL_PUBLIC size_t daliNumTensors(daliPipelineHandle* pipe_handle, int n);
+/**
+ * @brief Releases buffer returned by last daliOutput call.
+ */
+DLL_PUBLIC void daliOutputRelease(daliPipelineHandle *pipe_handle);
 
-  /**
-   * @brief Return the number of all elements in the tensor list
-   * stored at position `n` in the pipeline.
-   */
-  DLL_PUBLIC size_t daliNumElements(daliPipelineHandle* pipe_handle, int n);
+/**
+ * @brief Return the shape of the output tensor
+ * stored at position `n` in the pipeline.
+ * This function may only be called after
+ * calling Output function.
+ * @remarks Caller is responsible to 'free' the memory returned
+ */
+DLL_PUBLIC int64_t *daliShapeAt(daliPipelineHandle *pipe_handle, int n);
 
-  /**
-   * @brief Return the size of the tensor list
-   * stored at position `n` in the pipeline.
-   */
-  DLL_PUBLIC size_t daliTensorSize(daliPipelineHandle* pipe_handle, int n);
+/**
+ * @brief Return the type of the output tensor
+ * stored at position `n` in the pipeline.
+ * This function may only be called after
+ * calling Output function.
+ */
+DLL_PUBLIC dali_data_type_t daliTypeAt(daliPipelineHandle *pipe_handle, int n);
 
-  /**
-   * @brief Return maximum number of dimensions from all tensors
-   * from the tensor list stored at position `n` in the pipeline.
-   */
-  DLL_PUBLIC size_t daliMaxDimTensors(daliPipelineHandle* pipe_handle, int n);
+/**
+ * @brief Return the shape of the 'k' output tensor from tensor list
+ * stored at position `n` in the pipeline.
+ * This function may only be called after
+ * calling Output function.
+ * @remarks Caller is responsible to 'free' the memory returned
+ */
+DLL_PUBLIC int64_t *daliShapeAtSample(daliPipelineHandle *pipe_handle, int n, int k);
 
-  /**
-   * @brief Copy the output tensor list stored
-   * at position `n` in the pipeline.
-   * dst_type (0 - CPU, 1 - GPU)
-   * @remarks Tensor list doesn't need to be dense
-   */
-  DLL_PUBLIC void daliCopyTensorListNTo(daliPipelineHandle* pipe_handle, void* dst, int n,
-                                        device_type_t dst_type, cudaStream_t stream,
-                                        bool non_blocking);
+/**
+ * @brief Return the number of tensors in the tensor list
+ * stored at position `n` in the pipeline.
+ */
+DLL_PUBLIC size_t daliNumTensors(daliPipelineHandle *pipe_handle, int n);
 
-  /**
-   * @brief Returns number of DALI pipeline outputs
-   */
-  DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle* pipe_handle);
-  /**
-   * @brief Copy the output tensor stored
-   * at position `n` in the pipeline.
-   * dst_type (0 - CPU, 1 - GPU)
-   * @remarks If the output is tensor list then it need to be dense
-   */
-  DLL_PUBLIC void daliCopyTensorNTo(daliPipelineHandle* pipe_handle, void* dst, int n,
-                                    device_type_t dst_type, cudaStream_t stream,
-                                    bool non_blocking);
+/**
+ * @brief Return the number of all elements in the tensor list
+ * stored at position `n` in the pipeline.
+ */
+DLL_PUBLIC size_t daliNumElements(daliPipelineHandle *pipe_handle, int n);
 
-  /**
-   * @brief Delete the pipeline object.
-   */
-  DLL_PUBLIC void daliDeletePipeline(daliPipelineHandle* pipe_handle);
+/**
+ * @brief Return the size of the tensor list
+ * stored at position `n` in the pipeline.
+ */
+DLL_PUBLIC size_t daliTensorSize(daliPipelineHandle *pipe_handle, int n);
 
-  /**
-   * @brief Load plugin library
-   */
-  DLL_PUBLIC void daliLoadLibrary(const char* lib_path);
+/**
+ * @brief Return maximum number of dimensions from all tensors
+ * from the tensor list stored at position `n` in the pipeline.
+ */
+DLL_PUBLIC size_t daliMaxDimTensors(daliPipelineHandle *pipe_handle, int n);
+
+/**
+ * @brief Copy the output tensor list stored
+ * at position `n` in the pipeline.
+ * dst_type (0 - CPU, 1 - GPU)
+ * @remarks Tensor list doesn't need to be dense
+ */
+DLL_PUBLIC void daliCopyTensorListNTo(daliPipelineHandle *pipe_handle, void *dst, int n,
+                                      device_type_t dst_type, cudaStream_t stream,
+                                      bool non_blocking);
+
+/**
+ * @brief Returns number of DALI pipeline outputs
+ */
+DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle);
+/**
+ * @brief Copy the output tensor stored
+ * at position `n` in the pipeline.
+ * dst_type (0 - CPU, 1 - GPU)
+ * @remarks If the output is tensor list then it need to be dense
+ */
+DLL_PUBLIC void daliCopyTensorNTo(daliPipelineHandle *pipe_handle, void *dst, int n,
+                                  device_type_t dst_type, cudaStream_t stream,
+                                  bool non_blocking);
+
+/**
+ * @brief Delete the pipeline object.
+ */
+DLL_PUBLIC void daliDeletePipeline(daliPipelineHandle *pipe_handle);
+
+/**
+ * @brief Load plugin library
+ */
+DLL_PUBLIC void daliLoadLibrary(const char *lib_path);
 
 #ifdef __cplusplus
 }

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -76,12 +76,12 @@ DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle,
                                    int cpu_prefetch_queue_depth,
                                    int gpu_prefetch_queue_depth);
 
+/// @{
 /**
  * @brief Feed the data to ExternalSource as contiguous memory.
  *
- * When calling this function for GPU device, default stream (0) will be used when copying data
- * onto GPU. An alternative function exists to specify also a CUDA stream.
- * If used with CPU device, stream value will be ignored
+ * When calling this function, you need to provide a CUDA stream, which will be used when
+ * copying data onto GPU. A convenience alternative function exists to use default (0) stream.
  *
  * @param pipe_handle Pointer to pipeline handle
  * @param name Pointer to a null-terminated byte string with the name of the External Source
@@ -94,26 +94,26 @@ DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle,
  * @param sample_dim The dimensionality of a single sample.
  * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
  *                   Can be set to NULL.
- * @param stream CUDA stream to use when copying the data onto GPU. If used with `device == CPU`,
+ * @param stream CUDA stream to use when copying the data onto GPU. If used with CPU device code,
  *               this value will be ignored
  */
+DLL_PUBLIC void daliSetExternalInputCudaStream(daliPipelineHandle *pipe_handle, const char *name,
+                                               device_type_t device, const void *data_ptr,
+                                               dali_data_type_t data_type, const int64_t *shapes,
+                                               int sample_dim, const char *layout_str,
+                                               cudaStream_t stream);
+
 DLL_PUBLIC void daliSetExternalInput(daliPipelineHandle *pipe_handle, const char *name,
                                      device_type_t device, const void *data_ptr,
                                      dali_data_type_t data_type, const int64_t *shapes,
                                      int sample_dim, const char *layout_str);
-
-DLL_PUBLIC void daliSetExternalInputStream(daliPipelineHandle *pipe_handle, const char *name,
-                                           device_type_t device, const void *data_ptr,
-                                           dali_data_type_t data_type, const int64_t *shapes,
-                                           int sample_dim, const char *layout_str,
-                                           cudaStream_t stream);
-
+///@}
+///@{
 /**
  * @brief Feed the data to ExternalSource as a set of separate buffers.
  *
- * When calling this function for GPU device, default stream (0) will be used when copying data
- * onto GPU. An alternative function exists to specify also a CUDA stream.
- * If used with CPU device, stream value will be ignored
+ * When calling this function, you need to provide a CUDA stream, which will be used when
+ * copying data onto GPU. A convenience alternative function exists to use default (0) stream.
  *
  * @param pipe_handle Pointer to pipeline handle
  * @param name Pointer to a null-terminated byte string with the name of the External Source
@@ -126,19 +126,23 @@ DLL_PUBLIC void daliSetExternalInputStream(daliPipelineHandle *pipe_handle, cons
  * @param sample_dim The dimensionality of a single sample.
  * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
  *                   Can be set to NULL.
- * @param stream CUDA stream to use when copying the data onto GPU. If used with `device == CPU`,
+ * @param stream CUDA stream to use when copying the data onto GPU. If used with CPU device code,
  *               this value will be ignored.
  */
-DLL_PUBLIC void daliSetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
-                                            device_type_t device, const void *const *data_ptr,
-                                            dali_data_type_t data_type, const int64_t *shapes,
-                                            int64_t sample_dim, const char *layout_str);
+DLL_PUBLIC void
+daliSetExternalInputTensorsCudaStream(daliPipelineHandle *pipe_handle, const char *name,
+                                      device_type_t device, const void *const *data_ptr,
+                                      dali_data_type_t data_type, const int64_t *shapes,
+                                      int64_t sample_dim, const char *layout_str,
+                                      cudaStream_t stream);
 
-DLL_PUBLIC void daliSetExternalInputTensorsStream(daliPipelineHandle *pipe_handle, const char *name,
-                                                  device_type_t device, const void *const *data_ptr,
-                                                  dali_data_type_t data_type, const int64_t *shapes,
-                                                  int64_t sample_dim, const char *layout_str,
-                                                  cudaStream_t stream);
+DLL_PUBLIC void
+daliSetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
+                            device_type_t device, const void *const *data_ptr,
+                            dali_data_type_t data_type, const int64_t *shapes,
+                            int64_t sample_dim, const char *layout_str);
+///@}
+
 
 /**
  * @brief Start the execution of the pipeline.

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -56,12 +56,6 @@ typedef enum {
   DALI_BOOL = 11
 } dali_data_type_t;
 
-typedef enum {
-  DALI_SUCCESS = 0,
-  DALI_GENERAL_ERROR=1,
-  DALI_UNKNOWN_DEVICE = 2,
-} dali_error_t;
-
 /**
  * @brief Create DALI pipeline. Setting batch_size,
  * num_threads or device_id here overrides
@@ -85,8 +79,9 @@ DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle,
 /**
  * @brief Feed the data to ExternalSource as contiguous memory.
  *
- * An alternative function exists to specify also a CUDA stream to use
- * when copying the data onto GPU. If used with `device == CPU`, this value will be ignored
+ * When calling this function for GPU device, default stream (0) will be used when copying data
+ * onto GPU. An alternative function exists to specify also a CUDA stream.
+ * If used with CPU device, stream value will be ignored
  *
  * @param pipe_handle Pointer to pipeline handle
  * @param name Pointer to a null-terminated byte string with the name of the External Source
@@ -116,8 +111,9 @@ DLL_PUBLIC void daliSetExternalInputStream(daliPipelineHandle *pipe_handle, cons
 /**
  * @brief Feed the data to ExternalSource as a set of separate buffers.
  *
- * An alternative function exists to specify also a CUDA stream to use
- * when copying the data onto GPU. If used with `device == CPU`, this value will be ignored
+ * When calling this function for GPU device, default stream (0) will be used when copying data
+ * onto GPU. An alternative function exists to specify also a CUDA stream.
+ * If used with CPU device, stream value will be ignored
  *
  * @param pipe_handle Pointer to pipeline handle
  * @param name Pointer to a null-terminated byte string with the name of the External Source
@@ -131,7 +127,7 @@ DLL_PUBLIC void daliSetExternalInputStream(daliPipelineHandle *pipe_handle, cons
  * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
  *                   Can be set to NULL.
  * @param stream CUDA stream to use when copying the data onto GPU. If used with `device == CPU`,
- *               this value will be ignored
+ *               this value will be ignored.
  */
 DLL_PUBLIC void daliSetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
                                             device_type_t device, const void *const *data_ptr,

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -33,6 +33,7 @@ extern "C" {
 typedef struct {
   void *pipe;
   void *ws;
+  cudaStream_t copy_stream;  /// Stream to perform copy operations on
 } daliPipelineHandle;
 
 typedef enum {

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -81,7 +81,15 @@ DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle,
  * @brief Feed the data to ExternalSource as contiguous memory.
  *
  * When calling this function, you need to provide a CUDA stream, which will be used when
- * copying data onto GPU. A convenience alternative function exists to use default (0) stream.
+ * copying data onto GPU. This function is asynchronous, so it's your responsibility to
+ * synchronize on a provided CUDA stream.
+ *
+ * Keep in mind, that for the special case, where the data exists on the CPU and the
+ * ExternalSource's Backend in also a CPU, stream is not needed - feel free to pass
+ * the default stream.
+ *
+ * A convenience, synchronous, overload function is provided,
+ * which handles the stream synchronization.
  *
  * @param pipe_handle Pointer to pipeline handle
  * @param name Pointer to a null-terminated byte string with the name of the External Source
@@ -94,8 +102,8 @@ DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle,
  * @param sample_dim The dimensionality of a single sample.
  * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
  *                   Can be set to NULL.
- * @param stream CUDA stream to use when copying the data onto GPU. If used with CPU device code,
- *               this value will be ignored
+ * @param stream CUDA stream to use when copying the data onto GPU. Remember to synchronize on the
+ *               provided stream.
  */
 DLL_PUBLIC void daliSetExternalInputCudaStream(daliPipelineHandle *pipe_handle, const char *name,
                                                device_type_t device, const void *data_ptr,
@@ -113,7 +121,15 @@ DLL_PUBLIC void daliSetExternalInput(daliPipelineHandle *pipe_handle, const char
  * @brief Feed the data to ExternalSource as a set of separate buffers.
  *
  * When calling this function, you need to provide a CUDA stream, which will be used when
- * copying data onto GPU. A convenience alternative function exists to use default (0) stream.
+ * copying data onto GPU. This function is asynchronous, so it's your responsibility to
+ * synchronize on a provided CUDA stream.
+ *
+ * Keep in mind, that for the special case, where the data exists on the CPU and the
+ * ExternalSource's Backend in also a CPU, stream is not needed - feel free to pass
+ * the default stream.
+ *
+ * A convenience, synchronous, overload function is provided,
+ * which handles the stream synchronization.
  *
  * @param pipe_handle Pointer to pipeline handle
  * @param name Pointer to a null-terminated byte string with the name of the External Source
@@ -126,8 +142,8 @@ DLL_PUBLIC void daliSetExternalInput(daliPipelineHandle *pipe_handle, const char
  * @param sample_dim The dimensionality of a single sample.
  * @param layout_str Optional layout provided as a pointer to null-terminated byte string.
  *                   Can be set to NULL.
- * @param stream CUDA stream to use when copying the data onto GPU. If used with CPU device code,
- *               this value will be ignored.
+ * @param stream CUDA stream to use when copying the data onto GPU. Remember to synchronize on the
+ *               provided stream.
  */
 DLL_PUBLIC void
 daliSetExternalInputTensorsCudaStream(daliPipelineHandle *pipe_handle, const char *name,

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -105,16 +105,18 @@ DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle,
  * @param stream CUDA stream to use when copying the data onto GPU. Remember to synchronize on the
  *               provided stream.
  */
-DLL_PUBLIC void daliSetExternalInputCudaStream(daliPipelineHandle *pipe_handle, const char *name,
-                                               device_type_t device, const void *data_ptr,
-                                               dali_data_type_t data_type, const int64_t *shapes,
-                                               int sample_dim, const char *layout_str,
-                                               cudaStream_t stream);
+DLL_PUBLIC void
+daliSetExternalInputAsync(daliPipelineHandle *pipe_handle, const char *name,
+                          device_type_t device, const void *data_ptr,
+                          dali_data_type_t data_type, const int64_t *shapes,
+                          int sample_dim, const char *layout_str,
+                          cudaStream_t stream);
 
-DLL_PUBLIC void daliSetExternalInput(daliPipelineHandle *pipe_handle, const char *name,
-                                     device_type_t device, const void *data_ptr,
-                                     dali_data_type_t data_type, const int64_t *shapes,
-                                     int sample_dim, const char *layout_str);
+DLL_PUBLIC void
+daliSetExternalInput(daliPipelineHandle *pipe_handle, const char *name,
+                     device_type_t device, const void *data_ptr,
+                     dali_data_type_t data_type, const int64_t *shapes,
+                     int sample_dim, const char *layout_str);
 ///@}
 ///@{
 /**
@@ -146,11 +148,11 @@ DLL_PUBLIC void daliSetExternalInput(daliPipelineHandle *pipe_handle, const char
  *               provided stream.
  */
 DLL_PUBLIC void
-daliSetExternalInputTensorsCudaStream(daliPipelineHandle *pipe_handle, const char *name,
-                                      device_type_t device, const void *const *data_ptr,
-                                      dali_data_type_t data_type, const int64_t *shapes,
-                                      int64_t sample_dim, const char *layout_str,
-                                      cudaStream_t stream);
+daliSetExternalInputTensorsAsync(daliPipelineHandle *pipe_handle, const char *name,
+                                 device_type_t device, const void *const *data_ptr,
+                                 dali_data_type_t data_type, const int64_t *shapes,
+                                 int64_t sample_dim, const char *layout_str,
+                                 cudaStream_t stream);
 
 DLL_PUBLIC void
 daliSetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,

--- a/include/dali/core/common.h
+++ b/include/dali/core/common.h
@@ -135,6 +135,13 @@ inline int NumberOfChannels(DALIImageType type) {
   name(name&&) = delete;                 \
   name& operator=(name&&) = delete
 
+// Helper to declare copy constructor & copy-assignment operator default
+#define DEFAULT_COPY_MOVE_ASSIGN(name)    \
+  name(const name&) = default;            \
+  name& operator=(const name&) = default; \
+  name(name&&) = default;                 \
+  name& operator=(name&&) = default
+
 // Util to declare anonymous variable
 #define CONCAT_1(var1, var2) var1##var2
 #define CONCAT_2(var1, var2) CONCAT_1(var1, var2)


### PR DESCRIPTION
As the title suggests.

What shall deserve a remark is that I introduced additional functions for ExternalSource: `daliSetExternalInputStream` and `daliSetExternalInputTensorsStream`. This is because, in case of GPU source, user might want to specify the stream which is used to copy the data. If a regular function is used, default stream is used (`0`)

Great thanks to @klecki for writing tests for ExternalSource. Thanks to them this went smooothly. I changed them to TYPED, so that it's parameterized by Backend

I know I reformatted whole `c_api.h`. It has been indented, while I believe, that `extern "C" {}` block should follow rules of `namespace {}` block, thus do not impose indentation. In case you can't spot the differences, take a look at lines `80 - 140` in this file. That's the only difference.

In this reformatting frenzy I might have reformatted also other parts of code. Sorry for that, if anyone will have some great complaints, I'll fix this.

EDIT: There were lots of discussions on this topic, so I'll summarize it here.
Generally the problem is how to provide synchronization in 2 points - user API call and ExternalSource RunImpl. I decided for a following solution. User provides a stream, on which the `user storage -> ext src storage` copy will be conducted. He has to synchronize on this stream. After scheduling the copies on this stream, event is also recorded. Using this event, RunImpl will synchronize its own copy. This way we achieve following benefits:
1. API call is used the same way, regardless of operator and data backends
2. ExternalSource doesn't require separate storages for CPU and GPU backends
3. There is a slight "problem" - user will need to provide stream also in 1 case (out of 4), in which it's redundant: CPU op and CPU data. However, I decided, that he'll live with it - the API assumes CUDA is available.

I created also a convenience, blocking function, which will handle the stream for the user, if he doesn't care about it. It's somewhat response for point 3 above