### PR TITLE
Fix TL1_ssd_training test by freezing apex version

### DIFF
--- a/qa/TL1_ssd_training/test.sh
+++ b/qa/TL1_ssd_training/test.sh
@@ -12,6 +12,8 @@ test_body() {
     #install APEX
     git clone https://github.com/nvidia/apex
     pushd apex
+    # newer apex doexn't support Torch 1.1.0 we use for CUDA 9 tests
+    git checkout 2ec84ebdca59278eaf15e8ddf32476d9d6d8b904
     export CUDA_HOME=/usr/local/cuda-$(python -c "import torch; print('.'.join(torch.version.cuda.split('.')[0:2]))")
     pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" .
     unset CUDA_HOME


### PR DESCRIPTION
- the most recent apex version doesn't work with PyTorch 1.1.0 DALI uses in CUDA 9 test freeze it to one that works

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes the TL1_ssd_training test by freezing apex version

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     the most recent apex version doesn't work with PyTorch 1.1.0 DALI uses in CUDA 9 test freeze it to one that works
 - Affected modules and functionalities:
     TL1_ssd_training  test
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1390]*
