### PR TITLE
"Fix" (remove) Optical flow test bug

### DIFF
--- a/dali/test/cv_mat_utils.h
+++ b/dali/test/cv_mat_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 #define DALI_TEST_CV_MAT_UTILS_H_
 
 #include <opencv2/opencv.hpp>
+#include <utility>
+#include <tuple>
 #include "dali/core/geom/box.h"
 #include "dali/test/mat2tensor.h"
 
@@ -44,6 +46,41 @@ cv::Mat_<cv::Vec<T, nchannels>> copy_to_mat(Box<2, int> roi, T *base, int rows, 
   mat(rect).copyTo(out_copy);
   assert(out_copy.isContinuous());
   return out_copy;
+}
+
+
+/**
+ * @brief Creates a copy of cv::Mat, accessible as TensorView. Main reason to use this function,
+ *        is when you want to transfer cv::Mat to the GPU.
+ *
+ * Outputs a pair, which has ownership of the data underneath. The first element of the pair
+ * shall be used to access the data. The second is just an ownership entity, should be kept
+ * in scope as long as the first is used.
+ *
+ * In most of the cases you won't need to overload default template arguments.
+ * Be mindful, that it was created for 1- or 3- channel images,
+ * so the `ndims` values are restricted to those.
+ *
+ * @tparam DstAlloc Type of allocation. Default value guarantees access from both CPU and GPU
+ * @tparam T Data type of the image.
+ * @tparam ndims Number of channels in the image. Typically 3 or 1
+ * @param mat
+ * @return A tuple, which has ownership of the data underneath
+ */
+template<kernels::AllocType DstAlloc = kernels::AllocType::Unified,
+        typename T = uint8_t, int ndims = 3>
+// I <3 function declarations in C++
+std::tuple<
+        TensorView<kernels::AllocBackend<DstAlloc>, T, ndims>,
+        kernels::memory::KernelUniquePtr<T>
+          >
+mat_to_tensor(const cv::Mat &mat) {
+  static_assert(ndims == 1 || ndims == 3, "`ndims` is restricted to 1 or 3");
+  auto tvcpu = kernels::view_as_tensor<T, ndims>(mat);
+  auto mem = kernels::memory::alloc_unique<T>(DstAlloc, mat.cols * mat.rows * mat.channels());
+  auto tvgpu = make_tensor_gpu<ndims>(mem.get(), {mat.rows, mat.cols, mat.channels()});
+  kernels::copy(tvgpu, tvcpu);
+  return std::forward_as_tuple(tvgpu, std::move(mem));
 }
 
 }  // namespace testing


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug - test failing for OF

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     There was a test for OF, that used pregenerated data to verify the correctness of API implementation. The problem with this test was, that it, well, used pregenerated data. Therefore, when driver got updated, result has changed (for better or for worse, hard to tell), pregenerated data got outdated and the test was failing. This test should be fixed not to use pregenerated data, or removed. I propose to remove this test. This behaviour is actually already tested in OF's Nosetest. To refactor the test, I'd need to mimic the testing approach from Nosetest, however IMHO it would be too much effort for the effect we achieve, without all the numpy's utilities. Alternatively, I'd need to figure out some other testing scenario, but again, I feel that Nosetest handles everything that should be handled

How do I know it was a problem with test, not with OF algorithm?
Because GTest failed, while Nosetest succeeded, and they basically test the same thing (Nosetest is even broader)

As the result, I removed the test. Also, there was one function, that might come in handy in future (copying `cv::Mat` onto GPU), I put it in `cv_mat_utils` file, where it belongs 
 - Affected modules and functionalities:
     NA
 - Key points relevant for the review:
     NA
 - Validation and testing:
     L0 and L1
 - Documentation (including examples):
     NA


**JIRA TASK**: *[Use DALI-1394 or NA]*




