### PR TITLE
Add Erase GPU Kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,8 @@ CUDA_get_gencode_args(CUDA_gencode_flags ${CUDA_targeted_archs})
 message(STATUS "Generated gencode flags: ${CUDA_gencode_flags}")
 
 # Add ptx & bin flags for cuda
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${CUDA_gencode_flags} --compiler-options -fvisibility=hidden")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${CUDA_gencode_flags} --compiler-options -fvisibility=hidden -Xptxas -v")
+
 
 # Include directories
 include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ CUDA_get_gencode_args(CUDA_gencode_flags ${CUDA_targeted_archs})
 message(STATUS "Generated gencode flags: ${CUDA_gencode_flags}")
 
 # Add ptx & bin flags for cuda
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${CUDA_gencode_flags} --compiler-options -fvisibility=hidden -Xptxas -v")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${CUDA_gencode_flags} --compiler-options -fvisibility=hidden")
 
 
 # Include directories

--- a/dali/core/geom_vec_test.cu
+++ b/dali/core/geom_vec_test.cu
@@ -179,6 +179,34 @@ TEST(Vec, Func) {
   EXPECT_EQ(f, ivec3(-1, 0, 2));
 }
 
+TEST(Vec, DivCeil) {
+  ivec3 a = {3, 5, 6};
+  ivec3 b = {2, 2, 2};
+  auto a_b = div_ceil(a, b);
+  ivec3 a_b_expected = {2, 3, 3};
+  EXPECT_EQ(a_b, a_b_expected);
+
+  ivec3 c = {3, 5, 6};
+  uvec3 d = {2, 2, 2};
+  auto c_d = div_ceil(c, d);
+  ivec3 c_d_expected = {2, 3, 3};
+  EXPECT_EQ(c_d, c_d_expected);
+}
+
+DEVICE_TEST(Dev_Vec, DivCeil, 1, 1) {
+  ivec3 a = {3, 5, 6};
+  ivec3 b = {2, 2, 2};
+  auto a_b = div_ceil(a, b);
+  ivec3 a_b_expected = {2, 3, 3};
+  DEV_EXPECT_EQ(a_b, a_b_expected);
+
+  ivec3 c = {3, 5, 6};
+  uvec3 d = {2, 2, 2};
+  auto c_d = div_ceil(c, d);
+  ivec3 c_d_expected = {2, 3, 3};
+  DEV_EXPECT_EQ(c_d, c_d_expected);
+}
+
 DEVICE_TEST(Dev_Vec, Func, 1, 1) {
   vec3 in = { -0.6f, 0.1f, 1.7f };
   vec3 a = floor(in);

--- a/dali/kernels/erase/erase_cpu.h
+++ b/dali/kernels/erase/erase_cpu.h
@@ -82,6 +82,9 @@ void EraseKernel(T *data,
   for (int d = 0; d < Dims; d++) {
     data += strides[d] * anchor[d];
   }
+  if (channels_dim != -1) {
+    fill_values += anchor[channels_dim];
+  }
   detail::EraseKernelImpl(data, strides, shape, fill_values, channels_dim,
                           std::integral_constant<int, Dims>());
 }

--- a/dali/kernels/erase/erase_gpu.h
+++ b/dali/kernels/erase/erase_gpu.h
@@ -383,11 +383,10 @@ struct EraseGpu {
     const int num_samples = in.num_samples();
 
     if (channel_dim == -1) {
-      DALI_ENFORCE(
-          fill_values.size() == 1 || fill_values.size() == 0,
-          make_string(
-              "Kernel is unaware of channel dimension, exactly 0 or 1 fill value is expected, got: ",
-              fill_values.size(), "."));
+      DALI_ENFORCE(fill_values.size() == 1 || fill_values.size() == 0,
+                   make_string("Kernel is unaware of channel dimension, exactly 0 or 1 fill value "
+                               "is expected, got: ",
+                               fill_values.size(), "."));
     } else {
       // ensure that dim `channel_dim` in every sample matches fill_values.size();
       for (int i = 0; i < num_samples; i++) {
@@ -522,7 +521,6 @@ struct EraseGpu {
 
     erase_gpu_impl<channel_dim><<<grid_dim, block_dim, 0, stream>>>(
         sample_desc_gpu, region_dim, erase_regions_count, fill_values_span);
-
   }
 };
 

--- a/dali/kernels/erase/erase_gpu.h
+++ b/dali/kernels/erase/erase_gpu.h
@@ -1,0 +1,526 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_ERASE_ERASE_GPU_H_
+#define DALI_KERNELS_ERASE_ERASE_GPU_H_
+
+#include <vector>
+
+#include "dali/core/tensor_view.h"
+#include "dali/kernels/kernel.h"
+
+#include "dali/core/geom/vec.h"
+#include "dali/core/geom/box.h"
+#include "dali/kernels/common/utils.h"
+
+#include "dali/core/cuda_event.h"
+#include "dali/core/format.h"
+
+namespace dali {
+namespace kernels {
+
+/**
+ * We divide the work in following way:
+ *
+ * We cover every n-dimensional sample by n-dimensional cubes (in fact a hyperrectangle)
+ * of one selected size. We call such a hyperrectangle a region.
+ *
+ * The size of such region is suitable for traversal of block of threads of dimension (32, 32, 1)
+ *
+ *
+ * Grid: (number of cubes, number of samples, 1)
+ * - the number of cubes is the max over the numbers of cubes to cover each sample
+ *
+ * Block: (32, 32, 1) - the dimensions of thread block are fixed. We use such "physical block"
+ * to traverse every region - the hyperrectangle.
+ *
+ * Steps:
+ * 1. In every block we first look for intersections with erased regions, to filter out only
+ * the ones that we actually need.
+ * 2. We check if the hyperrectangle is fully covered by erase region or not covered at all
+ * to delegate to special cases - fill only or memcopy
+ * 3. If we have mixed cover, we check each coordinate and either copy the input or the fill value
+ *
+ * The processing of hyperrectangle of n-dims is done by n-nested for loop from outer to innermost
+ * dimension.
+ * The two innermost dimensions (omitting the channel) are traversed by the block of parallel
+ * threads.
+ * The loop is implemented as template based recursion.
+ * Possible optimization/obfuscation - factor out checks over dimension to specific level of
+ * the loop nest (for the mixed cover case).
+ *
+ */
+
+template <typename T, int ndim>
+using box = Box<ndim, T>;
+
+template <int ndim>
+using ibox = box<int32_t, ndim>;
+
+template <typename T, int ndim>
+struct erase_sample_desc {
+  const T *in = nullptr;
+  T* out = nullptr;
+  const ibox<ndim> *erase_regions = nullptr;
+  ivec<ndim> sample_shape;
+  ivec<ndim> sample_stride;
+};
+
+template <int ndim>
+DALI_HOST_DEV ivec<ndim> get_region_cover(ivec<ndim> region_dims, ivec<ndim> sample_dims) {
+  // let's calculate how many regions cover given axes:
+  auto region_cover_shape = (sample_dims + region_dims - 1) / region_dims;
+  return region_cover_shape;
+}
+
+// Hope that SROA is strong in this one
+template <int ndim>
+DALI_HOST_DEV ivec<ndim> get_region_start(int region_idx, ivec<ndim> region_dims,
+                                          ivec<ndim> sample_dims) {
+  // let's calculate how many regions cover given axes:
+  auto region_cover_shape = (sample_dims + region_dims - 1) / region_dims;
+  // this introduces the same ordering of regions as data layout
+  auto region_cover_strides = GetStrides(region_cover_shape);
+  ivec<ndim> region_position{};  // n-dim index of region among other regions
+  region_position[0] = region_idx / region_cover_strides[0];
+  for (int i = 1; i < ndim; i++) {
+    region_idx -= region_position[i - 1] * region_cover_strides[i - 1];
+    region_position[i] = region_idx / region_cover_strides[i];
+  }
+  return region_position * region_dims;
+}
+
+template <int ndim>
+__device__ ibox<ndim> get_region(int region_idx, ivec<ndim> region_dims, ivec<ndim> sample_dims) {
+  auto anchor = get_region_start(region_idx, region_dims, sample_dims);
+  return {anchor, anchor + region_dims};
+}
+
+constexpr unsigned FULL_MASK = 0xffffffffu;
+
+/**
+ * @brief Returns true if that parameter configuration is just outer layer of recursive loop call
+ */
+constexpr bool select_outer_loops(int ndim, int current_dim, int channel_dim) {
+  // channel_dim is not one of the 2 last dimensions
+  if (channel_dim < ndim - 2) {
+    return ndim - current_dim > 2;  // true if we are not in the last two dimensions
+  } else {
+    return ndim - current_dim > 3;  // we have to select a variant that accommodates channel dim
+  }
+}
+
+
+/**
+ * @brief Outer layer of recursive loop over current region
+ */
+template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
+__device__ std::enable_if_t<select_outer_loops(ndim, current_dim, channel_dim)>
+erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill_values = {},
+              span<ibox<ndim>> erase_regions = {}, ivec<ndim> coordinate = {},
+              int64_t offset_base = 0) {
+  constexpr int d = current_dim;
+  int boundary = ::min(region.hi[d], sample.sample_shape[d]);
+  for (int i = region.lo[d]; i < boundary; i++) {
+    coordinate[d] = i;
+    int64_t offset = offset_base + i * sample.sample_stride[d];
+    erase_generic<Worker, channel_dim, d + 1>(sample, region, fill_values, erase_regions,
+                                              coordinate, offset);
+  }
+}
+
+/**
+ * We have 2 full most inner loops, channel_dim is somewhere on the way here, or doesn't exist
+ *
+ * We handle this by covering the innermost dimensions by:
+ * for (y : blockDim.y)
+ *   for (x : blockDim.x)
+ *     process {coordinate[0], coordinate[1], ..., coordinate[current_dim - 1], y, x}
+ */
+template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
+__device__ std::enable_if_t<ndim - current_dim == 2 && channel_dim < ndim - 2>
+erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill_values = {},
+              span<ibox<ndim>> erase_regions = {}, ivec<ndim> coordinate = {},
+              int64_t offset_base = 0) {
+  constexpr int d = current_dim;
+  constexpr int dY = d;
+  constexpr int dX = d + 1;
+  int boundary_y = ::min(region.hi[dY], sample.sample_shape[dY]);
+  int boundary_x = ::min(region.hi[dX], sample.sample_shape[dX]);
+
+  for (int y = region.lo[dY] + threadIdx.y; y < boundary_y; y += blockDim.y) {
+    coordinate[dY] = y;
+    int64_t offset_y = offset_base + y * sample.sample_stride[dY];
+    for (int x = region.lo[dX] + threadIdx.x; x < boundary_x; x += blockDim.x) {
+      coordinate[dX] = x;
+      int64_t offset_x = offset_y + x * sample.sample_stride[dX];
+      Worker::template copy_or_erase<channel_dim>(sample, erase_regions, coordinate, offset_x,
+                                                  fill_values);
+    }
+  }
+}
+
+/**
+ * Channel dim is the one of the last two dimensions
+ *
+ * We loop with thread block over ndim-3 and fused (ndim-2, ndim-1) dims
+ * for (y : blockDim.y)
+ *   for (idx : blockDim.x * numChannels) // fused loop for last two dimensions
+ *     x = idx / stride_x
+ *     c = idx % stride_x
+ *       process {coordinate[0], coordinate[1], ..., coordinate[current_dim - 1], y, x, c}
+ *
+ * Note: naming follows {..., y, x, c}, but it can also be {..., y, c, x}
+ */
+template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
+__device__ std::enable_if_t<ndim - current_dim == 3 && channel_dim >= ndim - 2>
+erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill_values = {},
+              span<ibox<ndim>> erase_regions = {}, ivec<ndim> coordinate = {},
+              int64_t offset_base = 0) {
+  constexpr int d = current_dim;
+  constexpr int dY = d;
+  constexpr int dX = d + 1;
+  constexpr int dC = d + 2;
+  int boundary_y = ::min(region.hi[dY], sample.sample_shape[dY]);
+  int boundary_x = ::min(region.hi[dX], sample.sample_shape[dX]);
+  int boundary_c = ::min(region.hi[dC], sample.sample_shape[dC]);
+
+  for (int y = region.lo[dY] + threadIdx.y; y < boundary_y; y += blockDim.y) {
+    coordinate[dY] = y;
+    int64_t offset_y = offset_base + y * sample.sample_stride[dY];
+    int flattened_start = region.lo[dX] * sample.sample_stride[dX] + region.lo[dC] + threadIdx.x;
+    int flattened_end = region.hi[dX] * sample.sample_stride[dX] + region.hi[dC];
+    for (int x = flattened_start; x < flattened_end; x += blockDim.x) {
+      coordinate[dX] = x / sample.sample_stride[dX];
+      coordinate[dC] = x % sample.sample_stride[dX];
+      if (region.lo[dX] <= coordinate[dX] && coordinate[dX] < boundary_x &&
+          region.lo[dC] <= coordinate[dC] && coordinate[dC] < boundary_c) {
+        int64_t offset_x = offset_y + x;
+        Worker::template copy_or_erase<channel_dim>(sample, erase_regions, coordinate,
+                                                             offset_x, fill_values);
+      }
+    }
+  }
+}
+
+/**
+ * @brief Edge case kernel, 1D case
+ */
+template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
+__device__ std::enable_if_t<ndim == 1 && current_dim == 0> erase_generic(
+    erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill_values = {},
+    span<ibox<ndim>> erase_regions = {}, ivec<ndim> coordinate = {}, int64_t offset_base = 0) {
+  constexpr int d = current_dim;
+  int boundary = ::min(region.hi[d], sample.sample_shape[d]);
+
+  for (int idx = region.lo[d] + threadIdx.y * blockDim.x + threadIdx.x; idx < boundary;
+       idx += blockDim.y * blockDim.x) {
+    coordinate[d] = idx;
+    Worker::template copy_or_erase<channel_dim>(sample, erase_regions, coordinate,
+                                                offset_base + idx, fill_values);
+  }
+}
+
+/**
+ * @brief Edge case kernel, 2D case with channels
+ *
+ * TODO(klecki): fuse the loops
+ */
+template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
+__device__ std::enable_if_t<(ndim == 2 && current_dim == 0 && channel_dim >= 0)> erase_generic(
+    erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill_values = {},
+    span<ibox<ndim>> erase_regions = {}, ivec<ndim> coordinate = {}, int64_t offset_base = 0) {
+  constexpr int d = current_dim;
+  constexpr int dC = d + 1;
+  int boundary = ::min(region.hi[d], sample.sample_shape[d]);
+  int boundary_c = ::min(region.hi[dC], sample.sample_shape[dC]);
+
+  for (int idx = region.lo[d] + threadIdx.y * blockDim.x + threadIdx.x; idx < boundary;
+       idx += blockDim.y * blockDim.x) {
+    coordinate[d] = idx;
+    int64_t offset = offset_base + idx * sample.sample_stride[d];
+    for (int c = region.lo[dC]; c < boundary_c; c++) {
+      coordinate[dC] = c;
+      Worker::template copy_or_erase<channel_dim>(sample, erase_regions, coordinate, offset + c,
+                                                  fill_values);
+    }
+  }
+}
+
+
+struct do_copy {
+  template <int channel_dim, typename T, int ndim>
+  __device__ static void copy_or_erase(erase_sample_desc<T, ndim> sample,
+                                       span<ibox<ndim>> erase_regions, ivec<ndim> coordinate,
+                                       int64_t offset, span<T> fill_values) {
+    (void)erase_regions;
+    (void)coordinate;
+    (void)fill_values;
+    sample.out[offset] = sample.in[offset];
+  }
+};
+
+struct do_erase {
+  template <int channel_dim, typename T, int ndim>
+  __device__ static void copy_or_erase(erase_sample_desc<T, ndim> sample,
+                                       span<ibox<ndim>> erase_regions, ivec<ndim> coordinate,
+                                       int64_t offset, span<T> fill_values) {
+    (void)erase_regions;
+    if (channel_dim == -1) {
+      sample.out[offset] = fill_values[0];
+    } else {
+      sample.out[offset] = fill_values[coordinate[channel_dim]];
+    }
+  }
+};
+
+struct do_copy_or_erase {
+  template <int channel_dim, typename T, int ndim>
+  __device__ static void copy_or_erase(erase_sample_desc<T, ndim> sample,
+                                       span<ibox<ndim>> erase_regions, ivec<ndim> coordinate,
+                                       int64_t offset, span<T> fill_values) {
+    auto fill_value = channel_dim == -1 ? fill_values[0] : fill_values[coordinate[channel_dim]];
+    copy_or_erase<channel_dim>(sample, erase_regions, coordinate, offset, fill_value);
+  }
+
+  template <int channel_dim, typename T, int ndim>
+  __device__ static void copy_or_erase(erase_sample_desc<T, ndim> sample,
+                                       span<ibox<ndim>> erase_regions, ivec<ndim> coordinate,
+                                       int64_t offset, T fill_value) {
+    bool copy = true;
+    for (auto &region : erase_regions) {
+      if (region.contains(coordinate)) {
+        copy = false;
+      }
+    }
+    if (copy) {
+      sample.out[offset] = sample.in[offset];
+    } else {
+      sample.out[offset] = fill_value;
+    }
+  }
+};
+
+template <int channel_dim = -1, typename T, int ndim = 2>
+__global__ void erase_gpu_impl(erase_sample_desc<T, ndim> *samples, ivec<ndim> region_dims,
+                               int erase_regions_count, span<T> fill_values) {
+  const auto region_idx = blockIdx.x;
+  const auto sample_idx = blockIdx.y;
+
+  const auto &sample = samples[sample_idx];
+  ivec<ndim> sample_dims = sample.sample_shape;
+
+  auto region_box = get_region(region_idx, region_dims, sample_dims);
+
+  const auto *erase_regions_ptrs = sample.erase_regions;
+  constexpr int max_regions = 1024;
+  __shared__ ibox<ndim> erase_regions[max_regions];
+  __shared__ int filtered_region_idx;
+
+  filtered_region_idx = 0;
+  __syncthreads();
+  int full_cover = false;
+
+  // check which erase_regions overlap with current region_box
+  for (int i = threadIdx.y * blockDim.x + threadIdx.x; i < erase_regions_count;
+       i += blockDim.y * blockDim.x) {
+    if (erase_regions_ptrs[i].overlaps(region_box)) {
+      erase_regions[atomicAdd(&filtered_region_idx, 1)] = erase_regions_ptrs[i];
+      if (erase_regions_ptrs[i].contains(region_box)) {
+        full_cover = true;
+        break;
+      }
+    }
+  }
+  __syncthreads();
+
+  //  Check if we have full or no cover at all
+  int total_erase_regions = filtered_region_idx;
+  __syncthreads();
+  int is_fully_erased = __any_sync(FULL_MASK, full_cover);
+
+  if (total_erase_regions == 0) {
+    // do a full copy
+    erase_generic<do_copy, channel_dim>(sample, region_box, fill_values);
+    return;
+  } else if (is_fully_erased) {
+    // do a total erase
+    erase_generic<do_erase, channel_dim>(sample, region_box, fill_values,
+                                         make_span(erase_regions, total_erase_regions));
+    return;
+  } else {
+    erase_generic<do_copy_or_erase, channel_dim>(sample, region_box, fill_values,
+                                                 make_span(erase_regions, total_erase_regions));
+  }
+}
+
+template <int ndim>
+ivec<ndim> to_ivec(TensorShape<ndim> shape) {
+  ivec<ndim> result;
+  for (int d = 0; d < ndim; d++) {
+    result[d] = shape[d];
+  }
+  return result;
+}
+
+template <typename T, int ndim, int channel_dim = -1>
+struct EraseGpu {
+  static_assert(
+      -1 <= channel_dim && channel_dim < ndim,
+      "Channel dim can either be ignored (for channel_dim = -1) or must be in [0, ndim) interval.");
+  using sample_t = erase_sample_desc<T, ndim>;
+
+  KernelRequirements Setup(KernelContext &context,
+                          //  const TensorListView<StorageGPU, const T, ndim> &in
+                           const InListGPU<T, ndim> &in,
+                           const InListGPU<ibox<ndim>, 1> &erased_regions,
+                           const std::vector<T> &fill_values = {0}) {
+    const int num_samples = in.num_samples();
+
+    if (channel_dim == -1) {
+      DALI_ENFORCE(
+          fill_values.size() == 1,
+          make_string(
+              "Kernel is unaware of channel dimension, exactly 1 fill value is expected, got: ",
+              fill_values.size(), "."));
+    } else {
+      // ensure that dim `channel_dim` in every sample matches fill_values.size();
+      for (int i = 0; i < num_samples; i++) {
+        DALI_ENFORCE(in.shape.tensor_shape_span(i)[channel_dim] == fill_values.size() ||
+                         fill_values.size() == 1,
+                     make_string("Channel dimension in all samples must match the number of number "
+                                 "of elements provided in `fill_values` or there need to be "
+                                 "exactly 1 fill value provied. Sample ",
+                                 i, " has ", in.shape.tensor_shape_span(i)[channel_dim],
+                                 " elements, but there are ", fill_values.size(), " fill values."));
+      }
+    }
+
+    KernelRequirements req;
+
+    ScratchpadEstimator se;
+
+    se.add<erase_sample_desc<T, ndim>>(AllocType::Host, num_samples);
+    se.add<T>(AllocType::Host, fill_values.size());
+    se.add<erase_sample_desc<T, ndim>>(AllocType::GPU, num_samples);
+    se.add<T>(AllocType::GPU, fill_values.size());
+    req.output_shapes = {in.shape};
+    req.scratch_sizes = se.sizes;
+    return req;
+  }
+
+  void Run(KernelContext &ctx,
+           OutListGPU<T, ndim> &out,
+           const InListGPU<T, ndim> &in,
+           const InListGPU<ibox<ndim>, 1> &erased_regions,
+           const std::vector<T> &fill_values = {0}) {
+    auto stream = ctx.gpu.stream;  // MAYBE some runtime check if it's not used?
+    const int num_samples = in.num_samples();
+    const int num_fill_values = fill_values.size();
+
+
+    ivec<ndim> region_dim;
+    int erase_regions_count = erased_regions.shape[0][0];
+
+    // Prepare Dim {2, 2, ..., 2, 64, 64}
+    for (int d = 0; d < ndim - 2; d++) {
+      region_dim[d] = 2;
+    }
+    if (ndim > 2) {
+      region_dim[ndim - 2] = 64;
+      region_dim[ndim - 1] = 128;
+      if (channel_dim >= 0) {
+        const int channels = in.shape[0][channel_dim];
+        if (channel_dim == ndim - 1) {
+          region_dim[ndim - 3] = region_dim[ndim - 2];
+          region_dim[ndim - 2] = region_dim[ndim - 1];
+          region_dim[ndim - 1] = channels;
+        } else if (channel_dim == ndim - 2) {
+          region_dim[ndim - 3] = region_dim[ndim - 2];
+          region_dim[ndim - 2] = channels;
+        } else {
+          region_dim[channel_dim] = channels;
+        }
+      }
+    } else if (ndim == 2) {
+      region_dim[0] = 64;
+      region_dim[1] = 128;
+      if (channel_dim >= 0) {
+        const int channels = in.shape[0][channel_dim];
+        region_dim[channels] = channels;
+      }
+    } else {
+      region_dim[0] = 32 * 32;
+    }
+
+
+    int max_regions = 1;
+    for (int i = 0; i < in.num_samples(); i++) {
+      auto region_cover = get_region_cover(region_dim, to_ivec(in.shape[i]));
+      auto total_regions = volume(region_cover);
+      // std::max was complaining
+      max_regions = max_regions >= total_regions ? max_regions : total_regions;
+    }
+    dim3 grid_dim = {(uint32_t)max_regions, (uint32_t)num_samples, 1};
+    dim3 block_dim = {32, 32, 1};  // fixed block dim
+    auto* sample_desc_cpu = ctx.scratchpad->Allocate<sample_t>(AllocType::Host, num_samples);
+    auto* fill_values_cpu = ctx.scratchpad->Allocate<T>(AllocType::Host, num_fill_values);
+    auto* sample_desc_gpu = ctx.scratchpad->Allocate<sample_t>(AllocType::GPU, num_samples);
+    auto* fill_values_gpu = ctx.scratchpad->Allocate<T>(AllocType::GPU, num_fill_values);
+
+    for (int i = 0; i < num_samples; i++) {
+      sample_desc_cpu[i].in = in.data[i];
+      sample_desc_cpu[i].out = out.data[i];
+      sample_desc_cpu[i].erase_regions = erased_regions.data[i];
+      for (int dim = 0; dim < ndim; dim++) {
+        sample_desc_cpu[i].sample_shape[dim] = in.tensor_shape_span(i)[dim];
+      }
+      sample_desc_cpu[i].sample_stride = GetStrides(sample_desc_cpu[i].sample_shape);
+    }
+    memcpy(fill_values_cpu, fill_values.data(), num_fill_values * sizeof(T));
+
+    CUDA_CALL(
+      cudaMemcpyAsync(sample_desc_gpu, sample_desc_cpu, num_samples * sizeof(sample_t),
+                      cudaMemcpyHostToDevice, stream));
+    CUDA_CALL(
+      cudaMemcpyAsync(fill_values_gpu, fill_values_cpu, num_fill_values * sizeof(T),
+                      cudaMemcpyHostToDevice, stream));
+
+    // auto start = CUDAEvent::CreateWithFlags(0);
+    // auto end =   CUDAEvent::CreateWithFlags(0);
+    // cudaEventRecord(start);
+
+    erase_gpu_impl<channel_dim><<<grid_dim, block_dim, 0, stream>>>(sample_desc_gpu, region_dim,
+                                                       erase_regions_count,
+                                                       make_span(fill_values_gpu, num_fill_values));
+
+    // cudaEventRecord(end);
+    // CUDA_CALL(cudaDeviceSynchronize());
+    // CUDA_CALL(cudaGetLastError());
+    // float t = 0;
+    // cudaEventElapsedTime(&t, start, end);
+    // int64_t read = in.num_elements() * sizeof(T)
+    //                + erased_regions.num_elements() * sizeof(ibox<ndim>);
+    // int64_t written = out.num_elements() * sizeof(T);
+    // int64_t total_transferred = read + written;
+
+    // std::cerr << "Transferred " << total_transferred << " in " << t << "[ms] with "
+    //           << total_transferred / t * 1e-6 << " GB/s" << endl;
+  }
+};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_ERASE_ERASE_GPU_H_

--- a/dali/kernels/erase/erase_gpu_test.cu
+++ b/dali/kernels/erase/erase_gpu_test.cu
@@ -1,0 +1,390 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <complex>
+#include <tuple>
+#include <vector>
+
+#include "dali/kernels/common/utils.h"
+#include "dali/kernels/erase/erase_gpu.h"
+#include "dali/kernels/scratch.h"
+#include "dali/pipeline/data/tensor_list.h"
+#include "dali/test/tensor_test_utils.h"
+#include "dali/test/test_tensors.h"
+
+#include "dali/kernels/erase/erase_cpu.h"
+
+#include "dali/core/cuda_event.h"
+
+namespace dali {
+namespace kernels {
+
+template <int ndim>
+void debug_print(TensorListView<StorageCPU, uint8_t, ndim> tlv, int height, int width) {
+  for (int y = 0; y < height; y++) {
+    for (int x = 0; x < width; x++) {
+      std::cout << std::setw(2) << int(*tlv[0](y, x)) % 100;
+    }
+    std::cout << endl;
+  }
+}
+
+void verify_regions(ivec<4> region_dims, ivec<4> sample_dims, ivec<4> expected_cover) {
+  auto cover = get_region_cover(region_dims, sample_dims);
+  EXPECT_EQ(cover, expected_cover);
+  int idx = 0;
+  for (int d0 = 0; d0 < expected_cover[0]; d0++) {
+    for (int d1 = 0; d1 < expected_cover[1]; d1++) {
+      for (int d2 = 0; d2 < expected_cover[2]; d2++) {
+        for (int d3 = 0; d3 < expected_cover[3]; d3++) {
+          auto regions_start = get_region_start(idx, region_dims, sample_dims);
+          ivec<4> region_start_expected = {d0 * region_dims[0], d1 * region_dims[1],
+                                           d2 * region_dims[2], d3 * region_dims[3]};
+          EXPECT_EQ(regions_start, region_start_expected);
+          idx++;
+        }
+      }
+    }
+  }
+}
+
+TEST(EraseGpuKernelTest, CheckUtils) {
+  {
+    ivec<4> region_dims = {2, 2, 32, 32};
+    ivec<4> sample_dims = {16, 8, 64, 64};
+    ivec<4> expected_cover = {8, 4, 2, 2};
+    verify_regions(region_dims, sample_dims, expected_cover);
+  }
+  {
+    ivec<4> region_dims = {2, 2, 32, 32};
+    ivec<4> sample_dims = {16, 8, 32, 64};
+    ivec<4> expected_cover = {8, 4, 1, 2};
+    verify_regions(region_dims, sample_dims, expected_cover);
+  }
+  {
+    ivec<4> region_dims = {2, 2, 32, 32};
+    ivec<4> sample_dims = {16, 8, 64, 32};
+    ivec<4> expected_cover = {8, 4, 2, 1};
+    verify_regions(region_dims, sample_dims, expected_cover);
+  }
+  {
+    ivec<4> region_dims = {2, 2, 32, 32};
+    ivec<4> sample_dims = {16, 8, 32, 32};
+    ivec<4> expected_cover = {8, 4, 1, 1};
+    verify_regions(region_dims, sample_dims, expected_cover);
+  }
+}
+
+template <typename T, int ndim, int channel_dim = -1>
+struct EraseGpuKernelTest :
+    public testing::TestWithParam<std::tuple<
+      int,  // num erase regions
+      int,  // region generation scheme
+      int,  // default fill or full channel fill
+      TensorShape<ndim>>> {  // shape of input
+  void SetUp() override {
+    auto params = this->GetParam();
+    num_erase_regions_ = std::get<0>(params);
+    region_generation_ = std::get<1>(params);
+    full_fill_ = std::get<2>(params);
+    shape_ = std::get<3>(params);
+    test_shape = uniform_list_shape<ndim>(batch_size, shape_);
+
+    input.reshape(test_shape);
+    output.reshape(test_shape);
+    baseline.reshape(test_shape);
+    auto cpu_input_view = input.cpu();
+    SequentialFill(cpu_input_view);
+    if (full_fill_) {
+      fill_values.resize(shape_[channel_dim]);
+      int value = 0;
+      for (auto &elem : fill_values) {
+        elem = value++;
+      }
+    } else {
+      fill_values.resize(1);
+      fill_values[0] = 0;
+    }
+  }
+
+  void RunTest() {
+    if (region_generation_ == 0) {
+      std::cerr << ">> No cover" << std::endl;
+    } else if (region_generation_ == 1) {
+      std::cerr << ">> Full cover" << std::endl;
+    } else if (region_generation_ == 2) {
+      std::cerr << ">> Random cover of size: " << num_erase_regions_ << std::endl;
+    }
+    EraseGpu<T, ndim, channel_dim> kernel;
+    KernelContext ctx;
+    ctx.gpu.stream = 0;  // I need to know about this, it's really obfuscated
+    // we really should have a nice way of creating the contexts.
+
+    CreateRegions();
+
+    auto regions_gpu = regions.gpu();
+
+    auto in_view = input.gpu();
+
+    auto req = kernel.Setup(ctx, in_view, regions_gpu, fill_values);
+
+    auto out_view = output.gpu();
+
+     // AND THIS IS NO BETTER:
+    ScratchpadAllocator scratch_alloc;
+    scratch_alloc.Reserve(req.scratch_sizes);
+    auto scratchpad = scratch_alloc.GetScratchpad();
+    ctx.scratchpad = &scratchpad;
+
+    // auto start = CUDAEvent::CreateWithFlags(0);
+    // auto end =   CUDAEvent::CreateWithFlags(0);
+    // cudaEventRecord(start);
+
+    kernel.Run(ctx, out_view, in_view, regions_gpu, fill_values);
+
+    // cudaEventRecord(end);
+    CUDA_CALL(cudaDeviceSynchronize());
+    CUDA_CALL(cudaGetLastError());
+
+    // float t = 0;
+    // cudaEventElapsedTime(&t, start, end);
+    // int64_t read =
+    //     in_view.num_elements() * sizeof(T) + regions_gpu.num_elements() * sizeof(ibox<ndim>);
+    // int64_t written = out_view.num_elements() * sizeof(T);
+    // int64_t total_transferred = read + written;
+
+    // std::cerr << "Transferred " << total_transferred << " in " << t << "[ms] with "
+    //           << total_transferred / t * 1e-6 << " GB/s" << endl;
+
+    RepackAndCalcCpu();
+    Verify();
+  }
+
+  void Verify() {
+    auto cpu_out_view = output.cpu();
+    auto cpu_baseline_view = baseline.cpu();
+    Check(cpu_out_view, cpu_baseline_view);
+  }
+
+  void RepackAndCalcCpu() {
+    auto input_tlv = input.cpu();
+    auto baseline_tlv = baseline.cpu();
+    auto regions_tlv = regions.cpu();
+    for (int i = 0; i < batch_size; i++) {
+      auto baseline_tv = baseline_tlv[i];
+      auto input_tv = input_tlv[i];
+
+      EraseArgs<float, ndim> args;
+      args.rois.resize(num_erase_regions_);
+      for (int j = 0; j < num_erase_regions_; j++) {
+        for (int d = 0; d < ndim; d++) {
+          args.rois[j].anchor[d] = regions_tlv[i](j)->lo[d];
+          args.rois[j].shape[d] = regions_tlv[i](j)->hi[d] - regions_tlv[i](j)->lo[d];
+          args.rois[j].fill_values = fill_values;
+          args.rois[j].channels_dim = channel_dim;
+        }
+      }
+
+      EraseCpu<T, ndim> cpu_kernel;
+      KernelContext ctx;
+      cpu_kernel.Run(ctx, baseline_tv, input_tv, args);
+    }
+  }
+
+  void CreateRegions() {
+    if (region_generation_ == 0) {
+      num_erase_regions_ = 0;
+      // no cover
+    } else if (region_generation_ == 1) {
+      // full cover
+      num_erase_regions_ = 1;
+    }
+    TensorListShape<1> regions_shape = uniform_list_shape<1>(batch_size, {num_erase_regions_});
+    regions.reshape(regions_shape);
+    auto regions_cpu = regions.cpu();
+    if (region_generation_ == 1) {
+      // full cover
+      for (int i = 0; i < batch_size; i++) {
+        auto regions_tv = regions_cpu[i];
+        *regions_tv(0) = ibox<ndim>({0}, to_ivec(shape_));
+      }
+    } else if (region_generation_ == 2) {
+      std::mt19937 gen(0);
+      for (int i = 0; i < batch_size; i++) {
+        auto regions_tv = regions_cpu[i];
+        for (int j = 0; j < num_erase_regions_; j ++) {
+          ibox<ndim> region_box;
+          for (int d = 0; d < ndim; d++) {
+            std::uniform_int_distribution<>  start_dim(0, shape_[d] - 1);
+            region_box.lo[d] = start_dim(gen);
+            std::uniform_int_distribution<>  end_dim(region_box.lo[d] + 1, shape_[d]);
+            region_box.hi[d] = end_dim(gen);
+          }
+          *regions_tv(j) = region_box;
+        }
+      }
+    }
+  }
+
+  int num_erase_regions_;
+  int region_generation_;
+  bool full_fill_;
+  std::vector<T> fill_values;
+  TensorShape<ndim> shape_;
+  TensorListShape<ndim> test_shape;
+  // constexpr static int batch_size = 10;
+  constexpr static int batch_size = 16;
+  TestTensorList<T, ndim> input, output, baseline;
+  TestTensorList<ibox<ndim>, 1> regions;
+};
+
+using EraseGpuKernel1fTest = EraseGpuKernelTest<float, 1>;
+using EraseGpuKernel2fTest = EraseGpuKernelTest<float, 2>;
+using EraseGpuKernel2NCfTest = EraseGpuKernelTest<float, 2, 1>;
+using EraseGpuKernel3fTest = EraseGpuKernelTest<float, 3>;
+using EraseGpuKernel3fHWCTest = EraseGpuKernelTest<float, 3, 2>;
+using EraseGpuKernel3fCHWTest = EraseGpuKernelTest<float, 3, 0>;
+using EraseGpuKernel4fDHCWTest = EraseGpuKernelTest<float, 4, 2>;
+using EraseGpuKernel4fDHWCTest = EraseGpuKernelTest<float, 4, 3>;
+using EraseGpuKernel5fTest = EraseGpuKernelTest<float, 5>;
+
+#define ERASE_TEST_P(TEST) \
+  TEST_P(TEST, RunAndVerify) { \
+    this->RunTest(); \
+  }
+
+ERASE_TEST_P(EraseGpuKernel1fTest)
+ERASE_TEST_P(EraseGpuKernel2fTest)
+ERASE_TEST_P(EraseGpuKernel2NCfTest)
+ERASE_TEST_P(EraseGpuKernel3fTest)
+ERASE_TEST_P(EraseGpuKernel3fHWCTest)
+ERASE_TEST_P(EraseGpuKernel3fCHWTest)
+ERASE_TEST_P(EraseGpuKernel4fDHCWTest)
+ERASE_TEST_P(EraseGpuKernel4fDHWCTest)
+ERASE_TEST_P(EraseGpuKernel5fTest)
+
+// Parameters for tests are:
+// <number of erase regions>, <generation scheme>, <0 - single elem, 1 - per channel fill>, <shape>
+// generation scheme:
+// 0 - only copy, no erase
+// 1 - full, 1-element cover, only erase
+// 2 - random cover
+
+std::vector<std::tuple<int, int, int, TensorShape<1>>> values_1 = {
+    {0, 0, 0, {512 * 1024}},
+    {1, 1, 0, {512 * 1024}},
+    {1, 2, 0, {512 * 1024}},
+    {10, 2, 0, {512 * 1024}},
+    {100, 2, 0, {512 * 1024}},
+};
+
+std::vector<std::tuple<int, int, int, TensorShape<2>>> values_2 = {
+    {0, 0, 0, {512, 1024}},
+    {1, 1, 0, {512, 1024}},
+    {1, 2, 0, {512, 1024}},
+    {10, 2, 0, {512, 1024}},
+    {100, 2, 0, {512, 1024}},
+};
+
+std::vector<std::tuple<int, int, int, TensorShape<2>>> values_2NC = {
+    {0, 0, 0, {512 * 1024, 3}},
+    {1, 1, 0, {512 * 1024, 3}},
+    {1, 2, 0, {512 * 1024, 3}},
+    {10, 2, 1, {512 * 1024, 3}},
+    {100, 2, 0, {512 * 1024, 3}},
+};
+
+std::vector<std::tuple<int, int, int, TensorShape<3>>> values_3 = {
+    {0, 0, 0, {256, 256, 256}},
+    {1, 1, 0, {256, 256, 256}},
+    {1, 2, 0, {256, 256, 256}},
+    {10, 2, 0, {256, 256, 256}},
+    {100, 2, 0, {256, 256, 256}},
+    {1000, 2, 0, {256, 256, 256}},
+};
+
+std::vector<std::tuple<int, int, int, TensorShape<3>>> values_3HWC = {
+    {0, 0, 0, {256, 256, 1}},    {0, 0, 0, {256, 256, 3}},    {0, 0, 0, {256, 256, 4}},
+    {0, 0, 0, {256, 256, 8}},    {0, 0, 0, {256, 256, 16}},   {0, 0, 0, {256, 256, 64}},
+    {1, 1, 0, {256, 256, 1}},    {1, 1, 0, {256, 256, 3}},    {1, 1, 0, {256, 256, 4}},
+    {1, 1, 0, {256, 256, 8}},    {1, 1, 0, {256, 256, 16}},   {1, 1, 0, {256, 256, 64}},
+
+    {0, 0, 1, {256, 256, 1}},    {0, 0, 1, {256, 256, 3}},    {0, 0, 1, {256, 256, 4}},
+    {0, 0, 1, {256, 256, 8}},    {0, 0, 1, {256, 256, 16}},   {0, 0, 1, {256, 256, 64}},
+    {1, 1, 1, {256, 256, 1}},    {1, 1, 1, {256, 256, 3}},    {1, 1, 1, {256, 256, 4}},
+    {1, 1, 1, {256, 256, 8}},    {1, 1, 1, {256, 256, 16}},   {1, 1, 1, {256, 256, 64}},
+
+    {1, 2, 1, {256, 256, 1}},    {10, 2, 1, {256, 256, 1}},   {100, 2, 1, {256, 256, 1}},
+    {1000, 2, 1, {256, 256, 1}},
+    {1, 2, 1, {256, 256, 3}},    {10, 2, 1, {256, 256, 3}},   {100, 2, 1, {256, 256, 3}},
+    {1000, 2, 1, {256, 256, 3}},
+    {1, 2, 1, {256, 256, 16}},    {10, 2, 1, {256, 256, 16}}, {100, 2, 1, {256, 256, 16}},
+    {1000, 2, 1, {256, 256, 16}},
+};
+
+std::vector<std::tuple<int, int, int, TensorShape<3>>> values_3CHW = {
+    {0, 0, 0, {3, 256, 256}},
+    {1, 1, 0, {3, 256, 256}},
+    {0, 0, 0, {16, 256, 256}},
+    {1, 1, 0, {16, 256, 256}},
+    {1, 2, 0, {3, 256, 256}},
+    {10, 2, 0, {3, 256, 256}},
+    {100, 2, 0, {3, 256, 256}},
+    {1000, 2, 0, {3, 256, 256}},
+};
+
+std::vector<std::tuple<int, int, int, TensorShape<4>>> values_4DHCW = {
+    {0, 0, 0, {64, 64, 3, 64}},     {0, 0, 0, {64, 64, 4, 64}},    {0, 0, 0, {64, 64, 8, 64}},
+    {1, 1, 0, {64, 64, 3, 64}},     {1, 1, 0, {64, 64, 4, 64}},    {1, 1, 0, {64, 64, 8, 64}},
+    {0, 0, 1, {64, 64, 3, 64}},     {0, 0, 1, {64, 64, 4, 64}},    {0, 0, 1, {64, 64, 8, 64}},
+    {1, 1, 1, {64, 64, 3, 64}},     {1, 1, 1, {64, 64, 4, 64}},    {1, 1, 1, {64, 64, 8, 64}},
+    {1, 2, 1, {64, 64, 3, 64}},     {10, 2, 1, {64, 64, 3, 64}},   {100, 2, 1, {64, 64, 3, 64}},
+    {100, 2, 1, {64, 256, 3, 256}}, {1000, 2, 1, {64, 64, 3, 64}}, {1000, 2, 1, {64, 256, 3, 256}},
+};
+
+std::vector<std::tuple<int, int, int, TensorShape<4>>> values_4DHWC = {
+    {0, 0, 0, {64, 64, 64, 3}},     {0, 0, 0, {64, 64, 64, 4}},    {0, 0, 0, {64, 64, 64, 8}},
+    {1, 1, 0, {64, 64, 64, 3}},     {1, 1, 0, {64, 64, 64, 4}},    {1, 1, 0, {64, 64, 64, 8}},
+    {0, 0, 1, {64, 64, 64, 3}},     {0, 0, 1, {64, 64, 64, 4}},    {0, 0, 1, {64, 64, 64, 8}},
+    {1, 1, 1, {64, 64, 64, 3}},     {1, 1, 1, {64, 64, 64, 4}},    {1, 1, 1, {64, 64, 64, 8}},
+    {1, 2, 1, {64, 64, 64, 3}},     {10, 2, 1, {64, 64, 64, 3}},   {100, 2, 1, {64, 64, 64, 3}},
+    {100, 2, 1, {64, 256, 256, 3}}, {1000, 2, 1, {64, 64, 64, 3}}, {1000, 2, 1, {64, 256, 256, 3}},
+};
+
+std::vector<std::tuple<int, int, int, TensorShape<5>>> values_5 = {
+    {0, 0, 0, {4, 6, 64, 64, 64}},     {1, 1, 0, {4, 6, 64, 64, 64}},
+    {0, 0, 0, {2, 32, 16, 256, 256}},  {1, 1, 0, {2, 4, 16, 256, 256}},
+    {1, 2, 0, {4, 6, 32, 32, 32}},     {1, 2, 0, {4, 6, 64, 64, 64}},
+    {1, 2, 0, {4, 6, 16, 256, 256}},   {10, 2, 0, {4, 6, 16, 256, 256}},
+    {100, 2, 0, {4, 6, 16, 256, 256}}, {1000, 2, 0, {4, 6, 16, 256, 256}},
+};
+
+#define INSTANTIATE_ERASE_SUITE(TEST, VALUES) \
+  INSTANTIATE_TEST_SUITE_P(EraseGpuKernelSuite, TEST, testing::ValuesIn(VALUES));
+
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel1fTest, values_1);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel2fTest, values_2);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel2NCfTest, values_2NC);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel3fTest, values_3);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel3fHWCTest, values_3HWC);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel3fCHWTest, values_3CHW);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel4fDHCWTest, values_4DHCW);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel4fDHWCTest, values_4DHWC);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel5fTest, values_5);
+
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/erase/erase_gpu_test.cu
+++ b/dali/kernels/erase/erase_gpu_test.cu
@@ -97,8 +97,7 @@ struct EraseTestParams {
 };
 
 template <int ndim>
-std::ostream& operator<<(std::ostream& os, const EraseTestParams<ndim>& p)
-{
+std::ostream& operator<<(std::ostream& os, const EraseTestParams<ndim>& p) {
   os << "Num erase regions: " << p.num_erase_regions << ", region generation: "
      << p.region_generation << ", fill type: " << p.fill_type << ", shape: " << p.shape;
   return os;

--- a/dali/kernels/erase/erase_gpu_test.cu
+++ b/dali/kernels/erase/erase_gpu_test.cu
@@ -42,17 +42,17 @@ void debug_print(TensorListView<StorageCPU, uint8_t, ndim> tlv, int height, int 
   }
 }
 
-void verify_regions(ivec<4> region_dims, ivec<4> sample_dims, ivec<4> expected_cover) {
-  auto cover = get_region_cover(region_dims, sample_dims);
+void verify_regions(ivec<4> region_shape, ivec<4> sample_shape, ivec<4> expected_cover) {
+  auto cover = div_ceil(sample_shape, region_shape);
   EXPECT_EQ(cover, expected_cover);
   int idx = 0;
   for (int d0 = 0; d0 < expected_cover[0]; d0++) {
     for (int d1 = 0; d1 < expected_cover[1]; d1++) {
       for (int d2 = 0; d2 < expected_cover[2]; d2++) {
         for (int d3 = 0; d3 < expected_cover[3]; d3++) {
-          auto regions_start = get_region_start(idx, region_dims, sample_dims);
-          ivec<4> region_start_expected = {d0 * region_dims[0], d1 * region_dims[1],
-                                           d2 * region_dims[2], d3 * region_dims[3]};
+          auto regions_start = get_region_start(idx, region_shape, sample_shape);
+          ivec<4> region_start_expected = {d0 * region_shape[0], d1 * region_shape[1],
+                                           d2 * region_shape[2], d3 * region_shape[3]};
           EXPECT_EQ(regions_start, region_start_expected);
           idx++;
         }
@@ -63,60 +63,74 @@ void verify_regions(ivec<4> region_dims, ivec<4> sample_dims, ivec<4> expected_c
 
 TEST(EraseGpuKernelTest, CheckUtils) {
   {
-    ivec<4> region_dims = {2, 2, 32, 32};
-    ivec<4> sample_dims = {16, 8, 64, 64};
+    ivec<4> region_shape = {2, 2, 32, 32};
+    ivec<4> sample_shape = {16, 8, 64, 64};
     ivec<4> expected_cover = {8, 4, 2, 2};
-    verify_regions(region_dims, sample_dims, expected_cover);
+    verify_regions(region_shape, sample_shape, expected_cover);
   }
   {
-    ivec<4> region_dims = {2, 2, 32, 32};
-    ivec<4> sample_dims = {16, 8, 32, 64};
+    ivec<4> region_shape = {2, 2, 32, 32};
+    ivec<4> sample_shape = {16, 8, 32, 64};
     ivec<4> expected_cover = {8, 4, 1, 2};
-    verify_regions(region_dims, sample_dims, expected_cover);
+    verify_regions(region_shape, sample_shape, expected_cover);
   }
   {
-    ivec<4> region_dims = {2, 2, 32, 32};
-    ivec<4> sample_dims = {16, 8, 64, 32};
+    ivec<4> region_shape = {2, 2, 32, 32};
+    ivec<4> sample_shape = {16, 8, 64, 32};
     ivec<4> expected_cover = {8, 4, 2, 1};
-    verify_regions(region_dims, sample_dims, expected_cover);
+    verify_regions(region_shape, sample_shape, expected_cover);
   }
   {
-    ivec<4> region_dims = {2, 2, 32, 32};
-    ivec<4> sample_dims = {16, 8, 32, 32};
+    ivec<4> region_shape = {2, 2, 32, 32};
+    ivec<4> sample_shape = {16, 8, 32, 32};
     ivec<4> expected_cover = {8, 4, 1, 1};
-    verify_regions(region_dims, sample_dims, expected_cover);
+    verify_regions(region_shape, sample_shape, expected_cover);
   }
+}
+
+template <int ndim>
+struct EraseTestParams {
+  int num_erase_regions;
+  int region_generation;
+  int fill_type;
+  TensorShape<ndim> shape;
+};
+
+template <int ndim>
+std::ostream& operator<<(std::ostream& os, const EraseTestParams<ndim>& p)
+{
+  os << "Num erase regions: " << p.num_erase_regions << ", region generation: "
+     << p.region_generation << ", fill type: " << p.fill_type << ", shape: " << p.shape;
+  return os;
 }
 
 template <typename T, int ndim, int channel_dim = -1>
 struct EraseGpuKernelTest :
-    public testing::TestWithParam<std::tuple<
-      int,  // num erase regions
-      int,  // region generation scheme
-      int,  // default fill or full channel fill
-      TensorShape<ndim>>> {  // shape of input
+    public testing::TestWithParam<EraseTestParams<ndim>> {
   void SetUp() override {
     auto params = this->GetParam();
-    num_erase_regions_ = std::get<0>(params);
-    region_generation_ = std::get<1>(params);
-    full_fill_ = std::get<2>(params);
-    shape_ = std::get<3>(params);
-    test_shape = uniform_list_shape<ndim>(batch_size, shape_);
+    num_erase_regions_ = params.num_erase_regions;
+    region_generation_ = params.region_generation;
+    fill_type_ = params.fill_type;
+    shape_ = params.shape;
+    test_shape_ = uniform_list_shape<ndim>(batch_size_, shape_);
 
-    input.reshape(test_shape);
-    output.reshape(test_shape);
-    baseline.reshape(test_shape);
-    auto cpu_input_view = input.cpu();
+    input_.reshape(test_shape_);
+    output_.reshape(test_shape_);
+    baseline_.reshape(test_shape_);
+    auto cpu_input_view = input_.cpu();
     SequentialFill(cpu_input_view);
-    if (full_fill_) {
-      fill_values.resize(shape_[channel_dim]);
+    if (fill_type_ == 2) {
+      fill_values_.resize(0);
+    } else if (fill_type_ == 1) {
+      fill_values_.resize(shape_[channel_dim]);
       int value = 0;
-      for (auto &elem : fill_values) {
+      for (auto &elem : fill_values_) {
         elem = value++;
       }
-    } else {
-      fill_values.resize(1);
-      fill_values[0] = 0;
+    } else if (fill_type_ == 0) {
+      fill_values_.resize(1);
+      fill_values_[0] = 42;
     }
   }
 
@@ -130,70 +144,53 @@ struct EraseGpuKernelTest :
     }
     EraseGpu<T, ndim, channel_dim> kernel;
     KernelContext ctx;
-    ctx.gpu.stream = 0;  // I need to know about this, it's really obfuscated
-    // we really should have a nice way of creating the contexts.
+    ctx.gpu.stream = 0;
 
     CreateRegions();
 
-    auto regions_gpu = regions.gpu();
+    auto regions_gpu = regions_.gpu();
 
-    auto in_view = input.gpu();
+    auto in_view = input_.gpu();
 
-    auto req = kernel.Setup(ctx, in_view, regions_gpu, fill_values);
+    auto req = kernel.Setup(ctx, in_view, regions_gpu, make_span(fill_values_));
 
-    auto out_view = output.gpu();
+    auto out_view = output_.gpu();
 
-     // AND THIS IS NO BETTER:
     ScratchpadAllocator scratch_alloc;
     scratch_alloc.Reserve(req.scratch_sizes);
     auto scratchpad = scratch_alloc.GetScratchpad();
     ctx.scratchpad = &scratchpad;
 
-    // auto start = CUDAEvent::CreateWithFlags(0);
-    // auto end =   CUDAEvent::CreateWithFlags(0);
-    // cudaEventRecord(start);
+    kernel.Run(ctx, out_view, in_view, regions_gpu, make_span(fill_values_));
 
-    kernel.Run(ctx, out_view, in_view, regions_gpu, fill_values);
-
-    // cudaEventRecord(end);
     CUDA_CALL(cudaDeviceSynchronize());
     CUDA_CALL(cudaGetLastError());
-
-    // float t = 0;
-    // cudaEventElapsedTime(&t, start, end);
-    // int64_t read =
-    //     in_view.num_elements() * sizeof(T) + regions_gpu.num_elements() * sizeof(ibox<ndim>);
-    // int64_t written = out_view.num_elements() * sizeof(T);
-    // int64_t total_transferred = read + written;
-
-    // std::cerr << "Transferred " << total_transferred << " in " << t << "[ms] with "
-    //           << total_transferred / t * 1e-6 << " GB/s" << endl;
 
     RepackAndCalcCpu();
     Verify();
   }
 
   void Verify() {
-    auto cpu_out_view = output.cpu();
-    auto cpu_baseline_view = baseline.cpu();
+    auto cpu_out_view = output_.cpu();
+    auto cpu_baseline_view = baseline_.cpu();
     Check(cpu_out_view, cpu_baseline_view);
   }
 
   void RepackAndCalcCpu() {
-    auto input_tlv = input.cpu();
-    auto baseline_tlv = baseline.cpu();
-    auto regions_tlv = regions.cpu();
-    for (int i = 0; i < batch_size; i++) {
+    auto input_tlv = input_.cpu();
+    auto baseline_tlv = baseline_.cpu();
+    auto regions_tlv = regions_.cpu();
+    for (int i = 0; i < batch_size_; i++) {
       auto baseline_tv = baseline_tlv[i];
       auto input_tv = input_tlv[i];
 
-      EraseArgs<float, ndim> args;
+      EraseArgs<T, ndim> args;
       args.rois.resize(num_erase_regions_);
       for (int j = 0; j < num_erase_regions_; j++) {
         for (int d = 0; d < ndim; d++) {
           args.rois[j].anchor[d] = regions_tlv[i](j)->lo[d];
           args.rois[j].shape[d] = regions_tlv[i](j)->hi[d] - regions_tlv[i](j)->lo[d];
-          args.rois[j].fill_values = fill_values;
+          args.rois[j].fill_values = fill_values_;
           args.rois[j].channels_dim = channel_dim;
         }
       }
@@ -212,18 +209,18 @@ struct EraseGpuKernelTest :
       // full cover
       num_erase_regions_ = 1;
     }
-    TensorListShape<1> regions_shape = uniform_list_shape<1>(batch_size, {num_erase_regions_});
-    regions.reshape(regions_shape);
-    auto regions_cpu = regions.cpu();
+    TensorListShape<1> regions_shape = uniform_list_shape<1>(batch_size_, {num_erase_regions_});
+    regions_.reshape(regions_shape);
+    auto regions_cpu = regions_.cpu();
     if (region_generation_ == 1) {
       // full cover
-      for (int i = 0; i < batch_size; i++) {
+      for (int i = 0; i < batch_size_; i++) {
         auto regions_tv = regions_cpu[i];
         *regions_tv(0) = ibox<ndim>({0}, to_ivec(shape_));
       }
     } else if (region_generation_ == 2) {
       std::mt19937 gen(0);
-      for (int i = 0; i < batch_size; i++) {
+      for (int i = 0; i < batch_size_; i++) {
         auto regions_tv = regions_cpu[i];
         for (int j = 0; j < num_erase_regions_; j ++) {
           ibox<ndim> region_box;
@@ -241,14 +238,13 @@ struct EraseGpuKernelTest :
 
   int num_erase_regions_;
   int region_generation_;
-  bool full_fill_;
-  std::vector<T> fill_values;
+  bool fill_type_;
+  std::vector<T> fill_values_;
   TensorShape<ndim> shape_;
-  TensorListShape<ndim> test_shape;
-  // constexpr static int batch_size = 10;
-  constexpr static int batch_size = 16;
-  TestTensorList<T, ndim> input, output, baseline;
-  TestTensorList<ibox<ndim>, 1> regions;
+  TensorListShape<ndim> test_shape_;
+  constexpr static int batch_size_ = 16;
+  TestTensorList<T, ndim> input_, output_, baseline_;
+  TestTensorList<ibox<ndim>, 1> regions_;
 };
 
 using EraseGpuKernel1fTest = EraseGpuKernelTest<float, 1>;
@@ -277,21 +273,30 @@ ERASE_TEST_P(EraseGpuKernel4fDHWCTest)
 ERASE_TEST_P(EraseGpuKernel5fTest)
 
 // Parameters for tests are:
-// <number of erase regions>, <generation scheme>, <0 - single elem, 1 - per channel fill>, <shape>
+// <number of erase regions>, <generation scheme>, <fill_type>, <shape>
 // generation scheme:
-// 0 - only copy, no erase
-// 1 - full, 1-element cover, only erase
-// 2 - random cover
+// * 0 - only copy, no erase
+// * 1 - full, 1-element cover, only erase
+// * 2 - random cover
+// fill_type:
+// * 0 - one element `42` fill
+// * 1 - per channel, consecutive values
+// * 2 - default `0` fill
 
-std::vector<std::tuple<int, int, int, TensorShape<1>>> values_1 = {
+std::vector<EraseTestParams<1>> values_1 = {
     {0, 0, 0, {512 * 1024}},
     {1, 1, 0, {512 * 1024}},
     {1, 2, 0, {512 * 1024}},
     {10, 2, 0, {512 * 1024}},
     {100, 2, 0, {512 * 1024}},
+    {0, 0, 2, {512 * 1024}},
+    {1, 1, 2, {512 * 1024}},
+    {1, 2, 2, {512 * 1024}},
+    {10, 2, 2, {512 * 1024}},
+    {100, 2, 2, {512 * 1024}},
 };
 
-std::vector<std::tuple<int, int, int, TensorShape<2>>> values_2 = {
+std::vector<EraseTestParams<2>> values_2 = {
     {0, 0, 0, {512, 1024}},
     {1, 1, 0, {512, 1024}},
     {1, 2, 0, {512, 1024}},
@@ -299,15 +304,15 @@ std::vector<std::tuple<int, int, int, TensorShape<2>>> values_2 = {
     {100, 2, 0, {512, 1024}},
 };
 
-std::vector<std::tuple<int, int, int, TensorShape<2>>> values_2NC = {
+std::vector<EraseTestParams<2>> values_2NC = {
     {0, 0, 0, {512 * 1024, 3}},
     {1, 1, 0, {512 * 1024, 3}},
     {1, 2, 0, {512 * 1024, 3}},
     {10, 2, 1, {512 * 1024, 3}},
-    {100, 2, 0, {512 * 1024, 3}},
+    {100, 2, 2, {512 * 1024, 3}},
 };
 
-std::vector<std::tuple<int, int, int, TensorShape<3>>> values_3 = {
+std::vector<EraseTestParams<3>> values_3 = {
     {0, 0, 0, {256, 256, 256}},
     {1, 1, 0, {256, 256, 256}},
     {1, 2, 0, {256, 256, 256}},
@@ -316,7 +321,7 @@ std::vector<std::tuple<int, int, int, TensorShape<3>>> values_3 = {
     {1000, 2, 0, {256, 256, 256}},
 };
 
-std::vector<std::tuple<int, int, int, TensorShape<3>>> values_3HWC = {
+std::vector<EraseTestParams<3>> values_3HWC = {
     {0, 0, 0, {256, 256, 1}},    {0, 0, 0, {256, 256, 3}},    {0, 0, 0, {256, 256, 4}},
     {0, 0, 0, {256, 256, 8}},    {0, 0, 0, {256, 256, 16}},   {0, 0, 0, {256, 256, 64}},
     {1, 1, 0, {256, 256, 1}},    {1, 1, 0, {256, 256, 3}},    {1, 1, 0, {256, 256, 4}},
@@ -327,6 +332,11 @@ std::vector<std::tuple<int, int, int, TensorShape<3>>> values_3HWC = {
     {1, 1, 1, {256, 256, 1}},    {1, 1, 1, {256, 256, 3}},    {1, 1, 1, {256, 256, 4}},
     {1, 1, 1, {256, 256, 8}},    {1, 1, 1, {256, 256, 16}},   {1, 1, 1, {256, 256, 64}},
 
+    {0, 0, 2, {256, 256, 1}},    {0, 0, 2, {256, 256, 3}},    {0, 0, 2, {256, 256, 4}},
+    {0, 0, 2, {256, 256, 8}},    {0, 0, 2, {256, 256, 16}},   {0, 0, 2, {256, 256, 64}},
+    {1, 1, 2, {256, 256, 1}},    {1, 1, 2, {256, 256, 3}},    {1, 1, 2, {256, 256, 4}},
+    {1, 1, 2, {256, 256, 8}},    {1, 1, 2, {256, 256, 16}},   {1, 1, 2, {256, 256, 64}},
+
     {1, 2, 1, {256, 256, 1}},    {10, 2, 1, {256, 256, 1}},   {100, 2, 1, {256, 256, 1}},
     {1000, 2, 1, {256, 256, 1}},
     {1, 2, 1, {256, 256, 3}},    {10, 2, 1, {256, 256, 3}},   {100, 2, 1, {256, 256, 3}},
@@ -335,7 +345,7 @@ std::vector<std::tuple<int, int, int, TensorShape<3>>> values_3HWC = {
     {1000, 2, 1, {256, 256, 16}},
 };
 
-std::vector<std::tuple<int, int, int, TensorShape<3>>> values_3CHW = {
+std::vector<EraseTestParams<3>> values_3CHW = {
     {0, 0, 0, {3, 256, 256}},
     {1, 1, 0, {3, 256, 256}},
     {0, 0, 0, {16, 256, 256}},
@@ -346,7 +356,7 @@ std::vector<std::tuple<int, int, int, TensorShape<3>>> values_3CHW = {
     {1000, 2, 0, {3, 256, 256}},
 };
 
-std::vector<std::tuple<int, int, int, TensorShape<4>>> values_4DHCW = {
+std::vector<EraseTestParams<4>> values_4DHCW = {
     {0, 0, 0, {64, 64, 3, 64}},     {0, 0, 0, {64, 64, 4, 64}},    {0, 0, 0, {64, 64, 8, 64}},
     {1, 1, 0, {64, 64, 3, 64}},     {1, 1, 0, {64, 64, 4, 64}},    {1, 1, 0, {64, 64, 8, 64}},
     {0, 0, 1, {64, 64, 3, 64}},     {0, 0, 1, {64, 64, 4, 64}},    {0, 0, 1, {64, 64, 8, 64}},
@@ -355,7 +365,7 @@ std::vector<std::tuple<int, int, int, TensorShape<4>>> values_4DHCW = {
     {100, 2, 1, {64, 256, 3, 256}}, {1000, 2, 1, {64, 64, 3, 64}}, {1000, 2, 1, {64, 256, 3, 256}},
 };
 
-std::vector<std::tuple<int, int, int, TensorShape<4>>> values_4DHWC = {
+std::vector<EraseTestParams<4>> values_4DHWC = {
     {0, 0, 0, {64, 64, 64, 3}},     {0, 0, 0, {64, 64, 64, 4}},    {0, 0, 0, {64, 64, 64, 8}},
     {1, 1, 0, {64, 64, 64, 3}},     {1, 1, 0, {64, 64, 64, 4}},    {1, 1, 0, {64, 64, 64, 8}},
     {0, 0, 1, {64, 64, 64, 3}},     {0, 0, 1, {64, 64, 64, 4}},    {0, 0, 1, {64, 64, 64, 8}},
@@ -364,7 +374,7 @@ std::vector<std::tuple<int, int, int, TensorShape<4>>> values_4DHWC = {
     {100, 2, 1, {64, 256, 256, 3}}, {1000, 2, 1, {64, 64, 64, 3}}, {1000, 2, 1, {64, 256, 256, 3}},
 };
 
-std::vector<std::tuple<int, int, int, TensorShape<5>>> values_5 = {
+std::vector<EraseTestParams<5>> values_5 = {
     {0, 0, 0, {4, 6, 64, 64, 64}},     {1, 1, 0, {4, 6, 64, 64, 64}},
     {0, 0, 0, {2, 32, 16, 256, 256}},  {1, 1, 0, {2, 4, 16, 256, 256}},
     {1, 2, 0, {4, 6, 32, 32, 32}},     {1, 2, 0, {4, 6, 64, 64, 64}},
@@ -373,17 +383,17 @@ std::vector<std::tuple<int, int, int, TensorShape<5>>> values_5 = {
 };
 
 #define INSTANTIATE_ERASE_SUITE(TEST, VALUES) \
-  INSTANTIATE_TEST_SUITE_P(EraseGpuKernelSuite, TEST, testing::ValuesIn(VALUES));
+  INSTANTIATE_TEST_SUITE_P(TEST, TEST ## Test, testing::ValuesIn(VALUES));
 
-INSTANTIATE_ERASE_SUITE(EraseGpuKernel1fTest, values_1);
-INSTANTIATE_ERASE_SUITE(EraseGpuKernel2fTest, values_2);
-INSTANTIATE_ERASE_SUITE(EraseGpuKernel2NCfTest, values_2NC);
-INSTANTIATE_ERASE_SUITE(EraseGpuKernel3fTest, values_3);
-INSTANTIATE_ERASE_SUITE(EraseGpuKernel3fHWCTest, values_3HWC);
-INSTANTIATE_ERASE_SUITE(EraseGpuKernel3fCHWTest, values_3CHW);
-INSTANTIATE_ERASE_SUITE(EraseGpuKernel4fDHCWTest, values_4DHCW);
-INSTANTIATE_ERASE_SUITE(EraseGpuKernel4fDHWCTest, values_4DHWC);
-INSTANTIATE_ERASE_SUITE(EraseGpuKernel5fTest, values_5);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel1f, values_1);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel2f, values_2);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel2NCf, values_2NC);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel3f, values_3);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel3fHWC, values_3HWC);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel3fCHW, values_3CHW);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel4fDHCW, values_4DHCW);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel4fDHWC, values_4DHWC);
+INSTANTIATE_ERASE_SUITE(EraseGpuKernel5f, values_5);
 
 
 }  // namespace kernels

--- a/dali/operators/generic/erase/erase.cc
+++ b/dali/operators/generic/erase/erase.cc
@@ -33,7 +33,7 @@ The region is specified by an *anchor* (starting point) and a *shape* (dimension
 Only the relevant dimensions are specified.
 Non-specified dimensions are treated as if the whole range of the axis was provided.
 To specify multiple regions, *anchor* and *shape* represent multiple points consecutively
-(e.g. *anchor* = (y0, x0, y0, y1,...) and *shape* = (h0, w0, h1, w1,...)).
+(e.g. *anchor* = (y0, x0, y1, x1, ...) and *shape* = (h0, w0, h1, w1, ...)).
 The arguments anchor and shape are interpreted according to the value of the argument *axis_names*
 (or alternatively the value of the argument *axes*). If no *axis_names*/*axes* arguments are provided,
 all the dimensions except 'C' (channels) must be specified.

--- a/include/dali/core/geom/vec.h
+++ b/include/dali/core/geom/vec.h
@@ -545,6 +545,13 @@ DALI_HOST_DEV ivec<N> ceil_int(const vec<N> &a) {
   IMPL_VEC_ELEMENTWISE(ceil_int(a[i]));
 }
 
+template <int N, typename T, typename U>
+DALI_HOST_DEV std::enable_if_t<std::is_integral<T>::value && std::is_integral<U>::value,
+                               vec<N, decltype(div_ceil(T{}, U{}))>>
+div_ceil(const vec<N, T> &a, const vec<N, U> &b) {
+  IMPL_VEC_ELEMENTWISE(div_ceil(a[i], b[i]));
+}
+
 template <typename T, int size0, int size1>
 DALI_HOST_DEV DALI_FORCEINLINE
 constexpr auto cat(const vec<size0, T> &v0, const vec<size1, T> &v1) {

--- a/include/dali/core/tensor_view.h
+++ b/include/dali/core/tensor_view.h
@@ -57,7 +57,8 @@ bool ContainsCoords(const Shape &shape, const Position &pos) {
  */
 DALI_NO_EXEC_CHECK
 template <typename Shape, typename Position>
-DALI_HOST_DEV if_array_like<Position, ptrdiff_t> CalcOffset(const Shape &shape, const Position &pos) {
+DALI_HOST_DEV if_array_like<Position, ptrdiff_t> CalcOffset(const Shape &shape,
+                                                            const Position &pos) {
   ptrdiff_t ofs = pos[0];
   const int pos_dim = size(pos);
   const int shape_dim = size(shape);

--- a/include/dali/core/tensor_view.h
+++ b/include/dali/core/tensor_view.h
@@ -55,8 +55,9 @@ bool ContainsCoords(const Shape &shape, const Position &pos) {
  * @brief Calculates flat index of a given element in the tensor
  * @remarks If pos has fewer dimensions than shape, the remaining offsets are assumed to be 0
  */
+DALI_NO_EXEC_CHECK
 template <typename Shape, typename Position>
-if_array_like<Position, ptrdiff_t> CalcOffset(const Shape &shape, const Position &pos) {
+DALI_HOST_DEV if_array_like<Position, ptrdiff_t> CalcOffset(const Shape &shape, const Position &pos) {
   ptrdiff_t ofs = pos[0];
   const int pos_dim = size(pos);
   const int shape_dim = size(shape);
@@ -75,7 +76,7 @@ if_array_like<Position, ptrdiff_t> CalcOffset(const Shape &shape, const Position
  * @brief Calculates the offset to a slice of the tensor
  */
 template <typename Shape>
-ptrdiff_t CalcOffset(const Shape &shape, const ptrdiff_t &index) {
+DALI_HOST_DEV ptrdiff_t CalcOffset(const Shape &shape, const ptrdiff_t &index) {
   ptrdiff_t ofs = index;
   const int shape_dim = size(shape);
   for (int i = 1; i < shape_dim; i++) {


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Add Erase GPU kernel implementation

#### What happened in this PR?
 - What solution was applied:
     Kernel was implemented, there is a lengthy comment describing the approach. 
     There was also fix for CPU Kernel that appeared when I used it for tests.
 - Affected modules and functionalities:
     Dali Kernels
 - Key points relevant for the review:
     GPU Kernel
 - Validation and testing:
     Validation using CPU kernel which was fixed for that purpose.
 - Documentation (including examples):
     Docstring with explanation.


**JIRA TASK**: *[Use DALI-1367]*
