### PR TITLE
Make volume return 1 for 0-dim shape.

### DIFF
--- a/dali/core/tensor_shape_test.cc
+++ b/dali/core/tensor_shape_test.cc
@@ -463,8 +463,8 @@ TEST(TensorShapeTest, ConcatenationMixed) {
 }
 
 TEST(VolumeTest, Result) {
-  EXPECT_EQ(volume(std::vector<int64_t>{}), 0);
-  EXPECT_EQ(volume(std::vector<int64_t>{1}), 1);
+  EXPECT_EQ(volume(std::vector<int64_t>{}), 1);
+  EXPECT_EQ(volume(std::vector<int64_t>{2}), 2);
   EXPECT_EQ(volume(std::vector<int64_t>{1, 2}), 2);
   EXPECT_EQ(volume(std::vector<int64_t>{1, 2, 3, 4, 5}), 1 * 2 * 3 * 4 * 5);
 }

--- a/dali/kernels/reduce/reduce_cpu.h
+++ b/dali/kernels/reduce/reduce_cpu.h
@@ -89,8 +89,6 @@ void reduce(Dst &reduced, const StridedTensor<StorageCPU, Src> &in,
     R(reduced, tmp);
   } else {
     int64_t sub_v = volume(in.size.begin() + axis + 1, in.size.end());
-    if (sub_v == 0)
-      sub_v = 1;
     if (extent >= 2 && extent * sub_v > kTreeReduceThreshold) {
       Dst tmp1 = neutral, tmp2 = neutral;
       int64_t mid = extent / 2;

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -35,7 +35,7 @@ void DoOneHot(kernels::OutTensorCPU<Out, DynamicDimensions> output,
   auto in = input.data;
   auto out = output.data;
   for (int i = 0; i < volume(output.shape); ++i) out[i] = off_value;
-  int64_t inner = axis == ndims ? 1 : volume(input.shape.last(ndims - axis));
+  int64_t inner = volume(input.shape.last(ndims - axis));
   for (int64_t i = 0, n = input.num_elements(); i < n; i++) {
     int cls = in[i];
     if (cls < 0 || cls >= num_classes)

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -330,7 +330,7 @@ class Tensor : public Buffer<Backend> {
    * in use by the Tensor.
    */
   inline void ShareData(void *ptr, size_t bytes) {
-    ShareData(ptr, bytes, {});
+    ShareData(ptr, bytes, {{ 0 }});
   }
 
   /**
@@ -395,7 +395,7 @@ class Tensor : public Buffer<Backend> {
 
   inline void Reset() {
     reset();  // free the underlying buffer
-    shape_ = {};
+    shape_ = {{ 0 }};
     meta_ = {};
   }
 
@@ -533,7 +533,7 @@ class Tensor : public Buffer<Backend> {
   }
 
  protected:
-  TensorShape<> shape_;
+  TensorShape<> shape_ = {{ 0 }};
   DALIMeta meta_;
   USE_BUFFER_MEMBERS();
 };

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -330,7 +330,7 @@ class Tensor : public Buffer<Backend> {
    * in use by the Tensor.
    */
   inline void ShareData(void *ptr, size_t bytes) {
-    ShareData(ptr, bytes, {{ 0 }});
+    ShareData(ptr, bytes, { 0 });
   }
 
   /**
@@ -395,7 +395,7 @@ class Tensor : public Buffer<Backend> {
 
   inline void Reset() {
     reset();  // free the underlying buffer
-    shape_ = {{ 0 }};
+    shape_ = { 0 };
     meta_ = {};
   }
 
@@ -533,7 +533,7 @@ class Tensor : public Buffer<Backend> {
   }
 
  protected:
-  TensorShape<> shape_ = {{ 0 }};
+  TensorShape<> shape_ = { 0 };
   DALIMeta meta_;
   USE_BUFFER_MEMBERS();
 };

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -254,7 +254,7 @@ TYPED_TEST(TensorListTest, TestMultipleZeroSizeResize) {
   TensorList<TypeParam> tensor_list;
 
   int num_tensor = this->RandInt(0, 128);
-  auto shape = uniform_list_shape(num_tensor, TensorShape<>{});
+  auto shape = uniform_list_shape(num_tensor, TensorShape<>{{ 0 }});
   tensor_list.Resize(shape);
 
   ASSERT_EQ(tensor_list.template mutable_data<float>(), nullptr);
@@ -265,7 +265,7 @@ TYPED_TEST(TensorListTest, TestMultipleZeroSizeResize) {
 
   ASSERT_EQ(tensor_list.ntensor(), num_tensor);
   for (int i = 0; i < num_tensor; ++i) {
-    ASSERT_EQ(tensor_list.tensor_shape(i), TensorShape<>{});
+    ASSERT_EQ(tensor_list.tensor_shape(i), TensorShape<>{{ 0 }});
     ASSERT_EQ(tensor_list.tensor_offset(i), 0);
   }
 }
@@ -284,6 +284,24 @@ TYPED_TEST(TensorListTest, TestScalarResize) {
 
   for (int i = 0; i < num_scalar; ++i) {
     ASSERT_EQ(tensor_list.tensor_shape(i), TensorShape<>{1});
+    ASSERT_EQ(tensor_list.tensor_offset(i), i);
+  }
+}
+
+TYPED_TEST(TensorListTest, TestTrueScalarResize) {
+  TensorList<TypeParam> tensor_list;
+
+  int num_scalar = this->RandInt(1, 128);
+  auto shape = uniform_list_shape(num_scalar, TensorShape<>{});
+  tensor_list.Resize(shape);
+
+  ASSERT_NE(tensor_list.template mutable_data<float>(), nullptr);
+  ASSERT_EQ(tensor_list.nbytes(), num_scalar*sizeof(float));
+  ASSERT_EQ(tensor_list.size(), num_scalar);
+  ASSERT_FALSE(tensor_list.shares_data());
+
+  for (int i = 0; i < num_scalar; ++i) {
+    ASSERT_EQ(tensor_list.tensor_shape(i), TensorShape<>{});
     ASSERT_EQ(tensor_list.tensor_offset(i), i);
   }
 }

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -254,7 +254,7 @@ TYPED_TEST(TensorListTest, TestMultipleZeroSizeResize) {
   TensorList<TypeParam> tensor_list;
 
   int num_tensor = this->RandInt(0, 128);
-  auto shape = uniform_list_shape(num_tensor, TensorShape<>{{ 0 }});
+  auto shape = uniform_list_shape(num_tensor, TensorShape<>{ 0 });
   tensor_list.Resize(shape);
 
   ASSERT_EQ(tensor_list.template mutable_data<float>(), nullptr);
@@ -265,7 +265,7 @@ TYPED_TEST(TensorListTest, TestMultipleZeroSizeResize) {
 
   ASSERT_EQ(tensor_list.ntensor(), num_tensor);
   for (int i = 0; i < num_tensor; ++i) {
-    ASSERT_EQ(tensor_list.tensor_shape(i), TensorShape<>{{ 0 }});
+    ASSERT_EQ(tensor_list.tensor_shape(i), TensorShape<>{ 0 });
     ASSERT_EQ(tensor_list.tensor_offset(i), 0);
   }
 }

--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -25,6 +25,10 @@
 
 namespace dali {
 
+inline TensorShape<> empty_tensor_shape() {
+  return {{ 0 }};
+}
+
 template <typename Backend>
 class TensorTest : public DALITest {
  public:
@@ -135,7 +139,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeNoAlloc) {
   // Verify internals
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>{});
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<NoType>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
@@ -144,7 +148,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeNoAlloc) {
   ASSERT_EQ(t.raw_data(), source_data.data());
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>{});
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<int16>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
@@ -152,7 +156,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeNoAlloc) {
   ASSERT_EQ(t.raw_data(), source_data.data());
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>{});
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<int16>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
@@ -170,7 +174,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeNoAlloc) {
   ASSERT_EQ(t.raw_data(), nullptr);
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>());
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<NoType>(t.type()));
   ASSERT_FALSE(t.shares_data());
 }
@@ -189,7 +193,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeAlloc) {
   // Verify internals
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>{});
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<NoType>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
@@ -199,7 +203,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeAlloc) {
   ASSERT_EQ(t.raw_data(), source_data.data());
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>{});
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<double>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
@@ -209,7 +213,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeAlloc) {
   ASSERT_EQ(t.raw_data(), source_data.data());
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>{});
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<double>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
@@ -227,7 +231,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeAlloc) {
   ASSERT_EQ(t.raw_data(), nullptr);
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>());
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<NoType>(t.type()));
   ASSERT_FALSE(t.shares_data());
 }
@@ -246,7 +250,7 @@ TYPED_TEST(TensorTest, TestGetBytesSizeTypeNoAlloc) {
   // Verify internals
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>{});
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<NoType>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
@@ -280,7 +284,7 @@ TYPED_TEST(TensorTest, TestGetBytesSizeTypeNoAlloc) {
   ASSERT_EQ(t.raw_data(), nullptr);
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>());
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<NoType>(t.type()));
   ASSERT_FALSE(t.shares_data());
 }
@@ -299,7 +303,7 @@ TYPED_TEST(TensorTest, TestGetBytesSizeTypeAlloc) {
   // Verify internals
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>{});
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<NoType>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
@@ -334,7 +338,7 @@ TYPED_TEST(TensorTest, TestGetBytesSizeTypeAlloc) {
   ASSERT_EQ(t.raw_data(), nullptr);
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), TensorShape<>());
+  ASSERT_EQ(t.shape(), empty_tensor_shape());
   ASSERT_TRUE(IsType<NoType>(t.type()));
   ASSERT_FALSE(t.shares_data());
 }
@@ -480,11 +484,24 @@ TYPED_TEST(TensorTest, TestMultipleResize) {
   }
 }
 
+TYPED_TEST(TensorTest, TestResizeTrueScalar) {
+  Tensor<TypeParam> tensor;
+
+  // Get shape
+  TensorShape<> shape = {};
+  tensor.Resize(shape);
+
+  // Verify the settings
+  ASSERT_NE(tensor.template mutable_data<float>(), nullptr);
+  ASSERT_EQ(tensor.size(), volume(shape));
+  ASSERT_EQ(tensor.ndim(), shape.size());
+}
+
 TYPED_TEST(TensorTest, TestResizeScalar) {
   Tensor<TypeParam> tensor;
 
   // Get shape
-  TensorShape<> shape = {1};
+  TensorShape<> shape = {{ 1 }};
   tensor.Resize(shape);
 
   // Verify the settings
@@ -497,7 +514,7 @@ TYPED_TEST(TensorTest, TestResizeZeroSize) {
   Tensor<TypeParam> tensor;
 
   // Get shape
-  TensorShape<> shape = {};
+  TensorShape<> shape = {{ 0 }};
   tensor.Resize(shape);
 
   // Verify the settings

--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -26,7 +26,7 @@
 namespace dali {
 
 inline TensorShape<> empty_tensor_shape() {
-  return {{ 0 }};
+  return { 0 };
 }
 
 template <typename Backend>
@@ -501,7 +501,7 @@ TYPED_TEST(TensorTest, TestResizeScalar) {
   Tensor<TypeParam> tensor;
 
   // Get shape
-  TensorShape<> shape = {{ 1 }};
+  TensorShape<> shape = { 1 };
   tensor.Resize(shape);
 
   // Verify the settings
@@ -514,7 +514,7 @@ TYPED_TEST(TensorTest, TestResizeZeroSize) {
   Tensor<TypeParam> tensor;
 
   // Get shape
-  TensorShape<> shape = {{ 0 }};
+  TensorShape<> shape = { 0 };
   tensor.Resize(shape);
 
   // Verify the settings

--- a/include/dali/core/dev_array.h
+++ b/include/dali/core/dev_array.h
@@ -129,7 +129,7 @@ class DeviceArray<T, 0> {
 
 template <typename T>
 constexpr DALI_HOST_DEV volume_t<T> volume(const DeviceArray<T, 0> &) {
-  return 0;
+  return 1;
 }
 
 template <typename T, size_t N>

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -256,7 +256,7 @@ DALI_HOST_DEV
 inline volume_t<decltype(*std::declval<Iter>())>
 volume(Iter shape_begin, Iter shape_end) {
   if (shape_begin == shape_end)
-    return 0;  // perhaps we should return 1 as a neutral element of multiplication?
+    return 1;
   auto it = shape_begin;
   volume_t<decltype(*shape_begin)> v = *it;
   for (++it; it != shape_end; ++it)


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes bugs in many places where volume of remaining inner dimensions is used a s stride
- It simplifies code by removing edge cases
- It is a step torwards proper scalar handling

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Changed default Volume function and a specialization for DeviceArray<0>
     * Removed some conditional code guarding against 0-volume
 - Affected modules and functionalities:
     * Everything!
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests apply
 - Documentation (including examples):
     * N/A


**JIRA TASK**: DALI-1359
