### PR TITLE
Add a specialized TF dataset for conda

### DIFF
--- a/qa/TL1_tensorflow_dataset_conda/test.sh
+++ b/qa/TL1_tensorflow_dataset_conda/test.sh
@@ -1,19 +1,15 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose jupyter tensorflow-gpu"
+# use TF that is installed from conda when DALI is installed
+pip_packages="nose jupyter"
 target_dir=./dali/test/python
 
-# populate epilog and prolog with variants to enable/disable virtual env
+# populate epilog and prolog with variants to enable/disable conda
 # every test will be executed for bellow configs
-prolog=(: enable_virtualenv)
-epilog=(: disable_virtualenv)
+prolog=(enable_conda)
+epilog=(disable_conda)
 
 test_body() {
-    # The package name can be nvidia-dali-tf-plugin,  nvidia-dali-tf-plugin-weekly or  nvidia-dali-tf-plugin-nightly
-    pip uninstall -y `pip list | grep nvidia-dali-tf-plugin | cut -d " " -f1` || true
-
-    # Installing "current" dali tf (built against installed TF)
-    pip install ../../../nvidia-dali-tf-plugin*.tar.gz
 
     is_compatible=$(python -c 'import nvidia.dali.plugin.tf as dali_tf; print(dali_tf.dataset_compatible_tensorflow())')
     if [ $is_compatible = 'True' ]; then


### PR DESCRIPTION
- installing DALI in conda installs TF as a dependency and there is no point in iterating over all TF versions DALI supports (as DALI supports only one TF version in conda)

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a TF dataset test with conda env
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
      installing DALI in conda installs TF as a dependency and there is no point in iterating over all TF versions DALI supports (as DALI supports only one TF version in conda)
 - Affected modules and functionalities:
     TL1_tensorflow_dataset and TL1_tensorflow_dataset _conda
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI L1 run
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
