### PR TITLE
Fix jitter operator illegal memory access

### DIFF
--- a/dali/operators/image/remap/jitter.h
+++ b/dali/operators/image/remap/jitter.h
@@ -30,7 +30,7 @@ class JitterAugment {
  public:
   explicit JitterAugment(const OpSpec& spec) :
         nDegree_(spec.GetArgument<int>("nDegree")),
-        rnd_(spec.GetArgument<int64_t>("seed"), 128*256) {}
+        rnd_(spec.GetArgument<int64_t>("seed"), rnd_size_) {}
 
   DALI_HOST_DEV ivec2 operator()(int y, int x, int c, int H, int W, int C) {
     // JITTER_PREAMBLE
@@ -45,8 +45,8 @@ class JitterAugment {
     const int idx = 0;
 #endif
 
-    const int newX = rnd_.rand(idx) % degr - nHalf + x;
-    const int newY = rnd_.rand(idx) % degr - nHalf + y;
+    const int newX = rnd_.rand(idx % rnd_size_) % degr - nHalf + x;
+    const int newY = rnd_.rand(idx % rnd_size_) % degr - nHalf + y;
 
     return { cuda_min(cuda_max(0, newX), W), cuda_min(cuda_max(0, newY), H) };
   }
@@ -58,6 +58,7 @@ class JitterAugment {
  private:
   const size_t nDegree_;
   Randomizer<Backend> rnd_;
+  static constexpr unsigned rnd_size_ = 128 * 256;
 };
 
 template <typename Backend>

--- a/dali/operators/util/randomizer.h
+++ b/dali/operators/util/randomizer.h
@@ -36,6 +36,7 @@ class Randomizer {
     void *states_;
     size_t len_;
     int device_;
+    static constexpr int block_size_ = 256;
 };
 
 }  // namespace dali

--- a/dali/operators/util/randomizer_impl_gpu.cuh
+++ b/dali/operators/util/randomizer_impl_gpu.cuh
@@ -17,6 +17,7 @@
 
 #include "dali/operators/util/randomizer.h"
 
+#include <math.h>
 #include <curand.h>
 #include <curand_kernel.h>
 
@@ -38,7 +39,8 @@ Randomizer<GPUBackend>::Randomizer(int seed, size_t len) {
   len_ = len;
   cudaGetDevice(&device_);
   states_ = GPUBackend::New(sizeof(curandState) * len, true);
-  initializeStates<<<128, 256>>>(len_, seed, reinterpret_cast<curandState*>(states_));
+  initializeStates<<<div_ceil(len, block_size_), block_size_>>>
+                  (len_, seed, reinterpret_cast<curandState*>(states_));
 }
 
 template <>


### PR DESCRIPTION
- JitterAugment accesses random generator on the GPU beyond allowed range
- added a fix to make sure that access to random generator is inside allowed range

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug of jitter operator illegal memory access

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     added a fix to make sure that access to random generator is inside allowed range
 - Affected modules and functionalities:
     jitter
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA

In response to https://github.com/NVIDIA/DALI/issues/966

**JIRA TASK**: *[NA]*
