### PR TITLE
Fix setup_packages.py after pip update to 20.1 version

### DIFF
--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -6,9 +6,12 @@ import sys
 from pip._vendor.packaging.version import parse
 import urllib.parse
 try:
-    import pip._internal.pep425tags as p
-except:
-    import pip.pep425tags as p
+    import pip._internal.utils.compatibility_tags as p
+except ModuleNotFoundError:
+    try:
+        import pip._internal.pep425tags as p
+    except ModuleNotFoundError:
+        import pip.pep425tags as p
 try:
     # For Python 3.0 and later
     from urllib.request import urlopen, HTTPError, Request

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -7,10 +7,10 @@ from pip._vendor.packaging.version import parse
 import urllib.parse
 try:
     import pip._internal.utils.compatibility_tags as p
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     try:
         import pip._internal.pep425tags as p
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, ImportError):
         import pip.pep425tags as p
 try:
     # For Python 3.0 and later


### PR DESCRIPTION
- pip 20.1 moves _internal.pep425tags to _internal.utils.compatibility_tags
- as we are using pip internals this is unavoidable but there is no better way to get supported pip tags for the current platform

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes setup_packages.py after pip update to 20.1 version

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     moves _internal.pep425tags to _internal.utils.compatibility_tags
 - Affected modules and functionalities:
     setup_packages.py
 - Key points relevant for the review:
      NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
