### PR TITLE
Mean and Standard Deviation GPU kernels

### DIFF
--- a/dali/kernels/reduce/mean_gpu.cu
+++ b/dali/kernels/reduce/mean_gpu.cu
@@ -40,7 +40,8 @@ KernelRequirements MeanGPU<Out, In>::Setup(
 }
 
 template <typename Out, typename In>
-void MeanGPU<Out, In>::Run(KernelContext &ctx, const OutListGPU<Out> &out, const InListGPU<In> &in) {
+void MeanGPU<Out, In>::Run(
+    KernelContext &ctx, const OutListGPU<Out> &out, const InListGPU<In> &in) {
   assert(impl_ != nullptr);
   impl_->Run(ctx, out, in);
 }
@@ -82,7 +83,8 @@ KernelRequirements RootMeanSquareGPU<Out, In>::Setup(
 }
 
 template <typename Out, typename In>
-void RootMeanSquareGPU<Out, In>::Run(KernelContext &ctx, const OutListGPU<Out> &out, const InListGPU<In> &in) {
+void RootMeanSquareGPU<Out, In>::Run(
+    KernelContext &ctx, const OutListGPU<Out> &out, const InListGPU<In> &in) {
   assert(impl_ != nullptr);
   impl_->Run(ctx, out, in);
 }

--- a/dali/kernels/reduce/mean_gpu.cu
+++ b/dali/kernels/reduce/mean_gpu.cu
@@ -1,0 +1,105 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include "dali/kernels/reduce/reduce_gpu.h"
+#include "dali/kernels/reduce/mean_stddev_gpu_impl.cuh"
+
+namespace dali {
+namespace kernels {
+
+template <typename Out, typename In>
+class MeanGPU<Out, In>::Impl : public reduce_impl::MeanImplGPU<Out, In> {
+};
+
+template <typename Out, typename In>
+MeanGPU<Out, In>::MeanGPU() = default;
+
+template <typename Out, typename In>
+MeanGPU<Out, In>::~MeanGPU() = default;
+
+template <typename Out, typename In>
+KernelRequirements MeanGPU<Out, In>::Setup(
+    KernelContext &ctx,
+    const TensorListShape<> &in_shape, span<const int> axes, bool keep_dims, bool reduce_batch) {
+  if (!impl_) {
+    impl_ = std::make_unique<Impl>();
+  }
+  return impl_->Setup(ctx, in_shape, axes, keep_dims, reduce_batch);
+}
+
+template <typename Out, typename In>
+void MeanGPU<Out, In>::Run(KernelContext &ctx, const OutListGPU<Out> &out, const InListGPU<In> &in) {
+  assert(impl_ != nullptr);
+  impl_->Run(ctx, out, in);
+}
+
+template class MeanGPU<uint8_t, uint8_t>;
+template class MeanGPU<float, uint8_t>;
+template class MeanGPU<int8_t, int8_t>;
+template class MeanGPU<float, int8_t>;
+template class MeanGPU<uint16_t, uint16_t>;
+template class MeanGPU<float, uint16_t>;
+template class MeanGPU<int16_t, int16_t>;
+template class MeanGPU<float, int16_t>;
+template class MeanGPU<int32_t, int32_t>;
+template class MeanGPU<float, int32_t>;
+template class MeanGPU<uint32_t, uint32_t>;
+template class MeanGPU<float, uint32_t>;
+template class MeanGPU<float, float>;
+
+
+
+template <typename Out, typename In>
+class RootMeanSquareGPU<Out, In>::Impl : public reduce_impl::RootMeanSquareImplGPU<Out, In> {
+};
+
+template <typename Out, typename In>
+RootMeanSquareGPU<Out, In>::RootMeanSquareGPU() = default;
+
+template <typename Out, typename In>
+RootMeanSquareGPU<Out, In>::~RootMeanSquareGPU() = default;
+
+template <typename Out, typename In>
+KernelRequirements RootMeanSquareGPU<Out, In>::Setup(
+    KernelContext &ctx,
+    const TensorListShape<> &in_shape, span<const int> axes, bool keep_dims, bool reduce_batch) {
+  if (!impl_) {
+    impl_ = std::make_unique<Impl>();
+  }
+  return impl_->Setup(ctx, in_shape, axes, keep_dims, reduce_batch);
+}
+
+template <typename Out, typename In>
+void RootMeanSquareGPU<Out, In>::Run(KernelContext &ctx, const OutListGPU<Out> &out, const InListGPU<In> &in) {
+  assert(impl_ != nullptr);
+  impl_->Run(ctx, out, in);
+}
+
+template class RootMeanSquareGPU<uint8_t, uint8_t>;
+template class RootMeanSquareGPU<float, uint8_t>;
+template class RootMeanSquareGPU<int8_t, int8_t>;
+template class RootMeanSquareGPU<float, int8_t>;
+template class RootMeanSquareGPU<uint16_t, uint16_t>;
+template class RootMeanSquareGPU<float, uint16_t>;
+template class RootMeanSquareGPU<int16_t, int16_t>;
+template class RootMeanSquareGPU<float, int16_t>;
+template class RootMeanSquareGPU<int32_t, int32_t>;
+template class RootMeanSquareGPU<float, int32_t>;
+template class RootMeanSquareGPU<uint32_t, uint32_t>;
+template class RootMeanSquareGPU<float, uint32_t>;
+template class RootMeanSquareGPU<float, float>;
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
@@ -310,7 +310,7 @@ class RegularizedInvRMS {
 };
 
 /**
- * @brief Implements regularize inverse standard  deviation reduction with externally provided mean
+ * @brief Implements regularized inverse standard  deviation reduction with externally provided mean
  */
 template <typename Out, typename In, typename Mean = Out, typename Acc = Out>
 class InvStdDevImplGPU :

--- a/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
@@ -311,7 +311,7 @@ struct RegularizedInvSqrt {
 
   template <typename T>
   DALI_HOST_DEV Out operator()(T x) const {
-    float s = scale * (x + reg);
+    float s = scale * x + reg;
     return s ? ConvertSat<Out>(rsqrt(s)) : Out(0);
   }
 };

--- a/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
@@ -1,0 +1,227 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_REDUCE_MEAN_STDDEV_GPU_IMPL_CUH_
+#define DALI_KERNELS_REDUCE_MEAN_STDDEV_GPU_IMPL_CUH_
+
+#include "dali/kernels/reduce/reduce_gpu_impl.cuh"
+#include "dali/kernels/reduce/reduce_drop_dims.h"
+
+namespace dali {
+namespace kernels {
+namespace reduce_impl {
+
+template <typename Out, typename In, typename Actual>
+class MeanImplBase {
+ public:
+  Actual &This() { return static_cast<Actual&>(*this); }
+  const Actual &This() const { return static_cast<const Actual&>(*this); }
+
+  struct Postprocessor {
+    std::conditional_t<std::is_same<Out, double>::value, double, float> inv_div = 1;
+
+    template <typename T>
+    DALI_HOST_DEV Out operator()(T x) const {
+      return ConvertSat<Out>(x * inv_div);
+    }
+  };
+
+  Postprocessor *GetPostprocessorsImpl(WorkArea &wa) const {
+    assert(!This().ReduceBatch());
+    int n = This().SimplifiedOutputShape().num_samples();
+    Postprocessor *pp = wa.ParamBuffer<Postprocessor>(n);
+    for (int i = 0; i < n; i++) {
+      DALI_ENFORCE(This().ReducedElements(i) > 0, "Cannot calculate a mean from 0 elements");
+      pp[i].inv_div = 1.0 / This().ReducedElements(i);
+    }
+    return pp;
+  }
+
+  Postprocessor GetPostprocessorImpl() const {
+    assert(This().ReduceBatch());
+    DALI_ENFORCE(This().TotalReducedElements() > 0, "Cannot calculate a mean from 0 elements");
+    return { static_cast<float>(1.0 / This().TotalReducedElements()) };
+  }
+};
+
+template <typename Out, typename In, typename Acc = Out>
+class MeanImplGPU : public ReduceImplGPU<Out, In, Acc, MeanImplGPU<Out, In, Acc>>,
+                    public MeanImplBase<Out, In, MeanImplGPU<Out, In, Acc>> {
+ public:
+  using MeanBase = MeanImplBase<Out, In, MeanImplGPU<Out, In, Acc>>;
+  using typename MeanBase::Postprocessor;
+  reductions::sum GetReduction() const { return {}; }
+};
+
+template <typename Out, typename In, typename Mean, typename Actual>
+class VarianceImplBase {
+ public:
+  Actual &This() { return static_cast<Actual&>(*this); }
+  const Actual &This() const { return static_cast<const Actual&>(*this); }
+
+  void SetMean(const InListGPU<Mean> &mean, cudaStream_t stream) {
+    mean_ = mean;
+    mean_.reshape(This().SimplifiedOutputShape());
+  }
+
+  InListGPU<Mean> mean_;
+
+  struct Preprocessor {
+    const Mean *__restrict__ mean = nullptr;
+    template <typename T>
+    DALI_HOST_DEV DALI_FORCEINLINE
+    auto operator()(const T &x) const noexcept {
+      #ifdef __CUDA_ARCH__
+        auto d = x - __ldg(mean);
+      #else
+        auto d = x - *mean;
+      #endif
+        return d * d;
+    }
+  };
+
+  static_assert(sizeof(Preprocessor) == sizeof(Mean*),
+    "A variance functor must carry only a pointer to the mean");
+
+  template <int non_reduced_dims>
+  using PreprocessorBank = VariancePreprocessor<non_reduced_dims, Mean>;
+
+  void InitMean(const InListGPU<Mean> &mean) {
+    mean_ = reshape(mean, This().SimplifiedOutputShape());
+  }
+
+  Preprocessor GetPreprocessorImpl() const {
+    assert(This().SimplifiedOutputShape().num_elements() == 1);
+    return Preprocessor { mean_.data[0] };
+  }
+
+  Preprocessor *GetPreprocessorsImpl(WorkArea &wa) const {
+    int n = This().SimplifiedOutputShape().num_samples();
+    assert(This().SimplifiedOutputShape().num_elements() == n);
+    Preprocessor *pp = wa.ParamBuffer<Preprocessor>(n);
+    for (int i = 0; i < n; i++) {
+      pp[i] = { mean_.data[i] };
+    }
+    return pp;
+  }
+
+  PreprocessorBank<1> *
+  GetPreprocessorBanks(WorkArea &wa, int axis, std::integral_constant<int, 1>) const {
+    using Bank = PreprocessorBank<1>;
+    int n = This().SimplifiedOutputShape().num_samples();
+    Bank *banks = wa.ParamBuffer<Bank>(n);
+
+    for (int i = 0; i < n; i++) {
+      auto shape = This().SimplifiedOutputShape().tensor_shape_span(i);
+      auto &bank = banks[i];
+      bank.mean = mean_.data[i];
+      bank.stride[0] = volume(shape.begin() + axis, shape.end());  // outer stride
+    }
+    return banks;
+  }
+
+  PreprocessorBank<2> *
+  GetPreprocessorBanks(WorkArea &wa, int axis, std::integral_constant<int, 2>) const {
+    using Bank = PreprocessorBank<2>;
+    int n = This().SimplifiedOutputShape().num_samples();
+    Bank *banks = wa.ParamBuffer<Bank>(n);
+
+    SmallVector<int, 6> remaining_axes;
+    for (int a : This().SimplifiedAxes())
+      if (a > axis)
+        remaining_axes.push_back(a - axis - 1);
+    int mask = to_bit_mask(remaining_axes);
+
+    for (int i = 0; i < n; i++) {
+      auto &bank = banks[i];
+      auto shape = This().SimplifiedInputShape().tensor_shape_span(i);
+      auto inner_shape = span<const int64_t>(shape.begin() + axis + 1, shape.end());
+      bank.mean = mean_.data[i];
+      bank.stride[0] = volume(shape.begin() + axis, shape.end());  // outer stride
+      bank.stride[1] = 1;  // inner stride, always 1?
+      bank.inner_dims = DropDims(inner_shape, mask);  // reindexing, if necessary
+    }
+    return banks;
+  }
+
+  template <int non_reduced_dims>
+  PreprocessorBank<non_reduced_dims> *
+  GetPreprocessorBanksImpl(WorkArea &wa, int axis) const {
+    return GetPreprocessorBanks(wa, axis, std::integral_constant<int, non_reduced_dims>());
+  }
+};
+
+template <typename Out, typename In, typename Actual>
+class RootMeanImplBase {
+ public:
+  Actual &This() { return static_cast<Actual&>(*this); }
+  const Actual &This() const { return static_cast<const Actual&>(*this); }
+
+  struct Postprocessor {
+    std::conditional_t<std::is_same<Out, double>::value, double, float> inv_div = 1;
+
+    template <typename T>
+    DALI_HOST_DEV Out operator()(T x) const {
+      return ConvertSat<Out>(sqrt(x * inv_div));
+    }
+  };
+
+  Postprocessor *GetPostprocessorsImpl(WorkArea &wa) const {
+    assert(!This().ReduceBatch());
+    int n = This().SimplifiedOutputShape().num_samples();
+    Postprocessor *pp = wa.ParamBuffer<Postprocessor>(n);
+    for (int i = 0; i < n; i++) {
+      DALI_ENFORCE(This().ReducedElements(i) > 0, "Cannot calculate a mean from 0 elements");
+      pp[i].inv_div = 1.0 / This().ReducedElements(i);
+    }
+    return pp;
+  }
+
+  Postprocessor GetPostprocessorImpl() const {
+    assert(This().ReduceBatch());
+    DALI_ENFORCE(This().TotalReducedElements() > 0, "Cannot calculate a mean from 0 elements");
+    return { static_cast<float>(1.0 / This().TotalReducedElements()) };
+  }
+};
+
+template <typename Out, typename In, typename Mean = Out, typename Acc = Out>
+class StdDevImplGPU : public ReduceImplGPU<Out, In, Acc, StdDevImplGPU<Out, In, Mean, Acc>>,
+                      public VarianceImplBase<Out, In, Mean, StdDevImplGPU<Out, In, Mean, Acc>>,
+                      public RootMeanImplBase<Out, In, StdDevImplGPU<Out, In, Mean, Acc>> {
+ public:
+  using ReduceBase = ReduceImplGPU<Out, In, Acc, StdDevImplGPU<Out, In, Mean, Acc>>;
+  using VarBase = VarianceImplBase<Out, In, Mean, StdDevImplGPU<Out, In, Mean, Acc>>;
+  using MeanBase = RootMeanImplBase<Out, In, StdDevImplGPU<Out, In, Mean, Acc>>;
+
+  using Preprocessor = typename VarBase::Preprocessor;
+  template <int non_reduced_dims>
+  using PreprocessorBank = typename VarBase::template PreprocessorBank<non_reduced_dims>;
+
+  using Postprocessor = typename MeanBase::Postprocessor;
+  reductions::sum GetReduction() const { return {}; }
+
+  void Run(KernelContext &kctx,
+           const OutListGPU<Out> &out,
+           const InListGPU<In> &in,
+           const InListGPU<Mean> &mean) {
+    this->InitMean(mean);
+    ReduceBase::Run(kctx, out, in);
+  }
+};
+
+}  // namespace reduce_impl
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_REDUCE_MEAN_STDDEV_GPU_IMPL_CUH_

--- a/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
@@ -320,9 +320,10 @@ class RegularizedInvRMS {
 };
 
 template <typename Out, typename In, typename Mean = Out, typename Acc = Out>
-class InvStdDevImplGPU : public ReduceImplGPU<Out, In, Acc, InvStdDevImplGPU<Out, In, Mean, Acc>>,
-                      public VarianceImplBase<Out, In, Mean, InvStdDevImplGPU<Out, In, Mean, Acc>>,
-                      public RegularizedInvRMS<Out, In, InvStdDevImplGPU<Out, In, Mean, Acc>> {
+class InvStdDevImplGPU :
+      public ReduceImplGPU<Out, In, Acc, InvStdDevImplGPU<Out, In, Mean, Acc>>,
+      public VarianceImplBase<Out, In, Mean, InvStdDevImplGPU<Out, In, Mean, Acc>>,
+      public RegularizedInvRMS<Out, In, InvStdDevImplGPU<Out, In, Mean, Acc>> {
  public:
   using ReduceBase = ReduceImplGPU<Out, In, Acc, InvStdDevImplGPU<Out, In, Mean, Acc>>;
   using VarBase = VarianceImplBase<Out, In, Mean, InvStdDevImplGPU<Out, In, Mean, Acc>>;

--- a/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
@@ -15,6 +15,13 @@
 #ifndef DALI_KERNELS_REDUCE_MEAN_STDDEV_GPU_IMPL_CUH_
 #define DALI_KERNELS_REDUCE_MEAN_STDDEV_GPU_IMPL_CUH_
 
+/**
+ * @file
+ *
+ * This file contains the classes needed to implement reductions with pre-
+ * and postprocessing: mean, root mean square, standard deviation (and its reciprocal).
+ */
+
 #include "dali/kernels/reduce/reduce_gpu_impl.cuh"
 #include "dali/kernels/reduce/reduce_drop_dims.h"
 

--- a/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
@@ -118,7 +118,7 @@ class VarianceImplBase {
   using PreprocessorBank = VariancePreprocessor<non_reduced_dims, Mean>;
 
   void InitMean(const InListGPU<Mean> &mean) {
-    mean_ = reshape(mean, This().SimplifiedOutputShape());
+    mean_ = reshape(mean, This().SimplifiedOutputShape(), true);
   }
 
   Preprocessor GetPreprocessorImpl() const {

--- a/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
@@ -68,10 +68,10 @@ class MeanImplGPU : public ReduceImplGPU<Out, In, Acc, MeanImplGPU<Out, In, Acc>
 };
 
 /**
- * @brief Subtracts a mean value stored in specified memory location
+ * @brief Subtracts a mean value stored in specified memory location and squares the difference
  */
 template <class Mean>
-struct SubtractMeanIndirect {
+struct VarianceIndirect {
   const Mean *__restrict__ mean = nullptr;
   template <typename T>
   DALI_HOST_DEV DALI_FORCEINLINE
@@ -86,7 +86,7 @@ struct SubtractMeanIndirect {
 };
 
 /**
- * @brief Calculates variance, given a tensor of means.
+ * @brief Returns a `reduce::variance` functor with mean value taken from a tensor
  */
 template <int non_reduced_ndim, typename Mean>
 struct VariancePreprocessor;
@@ -112,6 +112,7 @@ template <typename Mean>
 struct VariancePreprocessor<2, Mean> {
   const Mean *mean;
   i64vec<2> stride;
+  /// Calculates the fully reduced inner offset based on non-reduced `pos[1]`
   DropDims inner_dims;
 
   DALI_HOST_DEV DALI_FORCEINLINE
@@ -139,7 +140,7 @@ class VarianceImplBase {
 
   InListGPU<Mean> mean_;
 
-  using Preprocessor = SubtractMeanIndirect<Mean>;
+  using Preprocessor = VarianceIndirect<Mean>;
 
   static_assert(sizeof(Preprocessor) == sizeof(Mean*),
     "A variance functor must carry only a pointer to the mean");

--- a/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
@@ -434,10 +434,10 @@ TEST(InvStdDevImplGPU, Outer_Batch_Regularized) {
 
   TestTensorList<float> out;
   out.reshape(req.output_shapes[0]);
-  stddev.Run(ctx, out.gpu(), in.gpu(), fake_mean.gpu(), 100000);
+  stddev.Run(ctx, out.gpu(), in.gpu(), fake_mean.gpu(), 100);
   auto out_cpu = out.cpu(ctx.gpu.stream);
 
-  TestTensorList<float> ref = RefStdDev(in_cpu, mean_cpu, 100000, true);
+  TestTensorList<float> ref = RefStdDev(in_cpu, mean_cpu, 100, true);
 
   Check(out_cpu, ref.cpu(), EqualEpsRel(1e-5, 1e-6));
 }

--- a/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
@@ -1,0 +1,272 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <random>
+#include <utility>
+#include "dali/kernels/reduce/mean_stddev_gpu_impl.cuh"
+#include "dali/kernels/scratch.h"
+#include "dali/test/test_tensors.h"
+#include "dali/test/tensor_test_utils.h"
+#include "dali/core/tensor_shape_print.h"
+#include "dali/kernels/reduce/reduce_test.h"
+
+namespace dali {
+namespace kernels {
+namespace reduce_impl {
+
+template <typename T, int ndim>
+std::ostream &operator<<(std::ostream &os, const TensorView<StorageCPU, T, ndim> &t) {
+  if (!t.data) {
+    return os << "[data is null, shape = " << t.shape << "]";
+  }
+  if (t.dim() == 0) {
+    return os << *t.data;
+  }
+
+  const char *sep = t.num_elements() > 16 ? ",\n " : ", ";
+  os << "[";
+  if (t.dim() == 1) {
+    for (int64_t i = 0; i < t.num_elements(); i++) {
+      if (i)
+        os << sep;
+      os << t.data[i];
+    }
+  } else {
+    for (int64_t i = 0; i < t.shape[0]; i++) {
+      if (i)
+        os << sep;
+      os << subtensor(t, i);
+    }
+  }
+
+  return os << "]";
+}
+
+template <typename T, int ndim>
+std::ostream &operator<<(std::ostream &os, const TensorListView<StorageCPU, T, ndim> &tl) {
+  if (tl.data.empty() || !tl.data[0]) {
+    return os << "{ data is null, shape = " << tl.shape << " }";
+  }
+  os << "{ ";
+  const char *sep = tl.num_elements() > 16 ? ",\n " : ", ";
+  for (int i = 0; i < tl.num_samples(); i++) {
+    if (i)
+      os << sep;
+    os << tl[i];
+  }
+  return os << " }";
+}
+
+
+
+TEST(MeanImplGPU, SplitStage) {
+  TensorListShape<> in_shape = {{
+    { 32, 2, 64000 },
+    { 15, 4, 128000 },
+    { 72000, 1, 7 }
+  }};
+  int axes[] = { 0, 2 };
+  MeanImplGPU<float, uint8_t> mean;
+  KernelContext ctx = {};
+  auto req = mean.Setup(ctx, in_shape, make_span(axes), true, false);
+  TensorListShape<> ref_out_shape = {{
+    { 1, 2, 1 },
+    { 1, 4, 1 },
+    { 1, 1, 1 }
+  }};
+  EXPECT_EQ(req.output_shapes[0], ref_out_shape);
+  EXPECT_GE(mean.GetNumStages(), 4);  // both reduced axes must be split due to large max extent
+
+  ScratchpadAllocator sa;
+  sa.Reserve(req.scratch_sizes);
+  auto scratchpad = sa.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+
+  std::mt19937_64 rng(12345);
+
+  TestTensorList<uint8_t> in;
+  in.reshape(in_shape);
+  auto in_cpu = in.cpu();
+  UniformRandomFill(in_cpu, rng, 0, 255);
+
+  TestTensorList<float> out;
+  out.reshape(req.output_shapes[0]);
+  mean.Run(ctx, out.gpu(), in.gpu());
+
+  auto out_cpu = out.cpu(ctx.gpu.stream);
+  TestTensorList<float> ref;
+  ref.reshape(ref_out_shape);
+  auto ref_cpu = ref.cpu();
+  for (int i = 0; i < ref_cpu.num_samples(); i++) {
+    int64_t n = ref_cpu[i].num_elements();
+    int64_t n_in = in_cpu[i].num_elements();
+    int64_t ratio = n_in / n;
+    RefReduce(ref_cpu[i], in_cpu[i], make_span(axes), reductions::sum());
+    for (int j = 0; j < n; j++)
+      ref_cpu.data[i][j] /= ratio;
+  }
+
+  Check(out_cpu, ref_cpu, EqualEpsRel(1e-5, 1e-6));
+}
+
+
+
+TEST(MeanImplGPU, BatchMean) {
+  TensorListShape<> in_shape = {{
+    { 32, 3, 64000 },
+    { 15, 3, 128000 },
+    { 72000, 3, 7 }
+  }};
+  int axes[] = { 0, 2 };
+  MeanImplGPU<float, uint8_t> mean;
+  KernelContext ctx = {};
+  auto req = mean.Setup(ctx, in_shape, make_span(axes), false, true);
+  TensorListShape<> ref_out_shape = {{
+    TensorShape<>{3}
+  }};
+  EXPECT_EQ(req.output_shapes[0], ref_out_shape);
+  EXPECT_GE(mean.GetNumStages(), 4);  // both reduced axes must be split due to large max extent
+
+  ScratchpadAllocator sa;
+  sa.Reserve(req.scratch_sizes);
+  auto scratchpad = sa.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+
+  std::mt19937_64 rng(12345);
+
+  TestTensorList<uint8_t> in;
+  in.reshape(in_shape);
+  auto in_cpu = in.cpu();
+  UniformRandomFill(in_cpu, rng, 0, 255);
+
+  TestTensorList<float> out;
+  out.reshape(req.output_shapes[0]);
+  mean.Run(ctx, out.gpu(), in.gpu());
+
+  auto out_cpu = out.cpu(ctx.gpu.stream);
+  TestTensorList<float> ref;
+  TestTensorList<int64_t> ref_samples;
+  TensorListShape<> ref_samples_shape = {{
+    { 1, 3, 1 },
+    { 1, 3, 1 },
+    { 1, 3, 1 }
+  }};
+  ref.reshape(ref_out_shape);
+  ref_samples.reshape(ref_samples_shape);
+  auto ref_cpu = ref.cpu();
+  auto ref_samples_cpu = ref_samples.cpu();
+  int N = ref_samples_shape.num_samples();
+  for (int i = 0; i < N; i++) {
+    RefReduce(ref_samples_cpu[i], in_cpu[i], make_span(axes), reductions::sum());
+  }
+  int64_t n = ref_out_shape.num_elements();
+  double ratio = in_cpu.num_elements() / n;
+  for (int j = 0; j < n; j++) {
+    int64_t sum = 0;
+    for (int i = 0; i < N; i++)
+      sum += ref_samples_cpu.data[i][j];
+    ref_cpu.data[0][j] = sum / ratio;
+  }
+
+  Check(out_cpu, ref_cpu, EqualEpsRel(1e-5, 1e-6));
+}
+
+
+TEST(StdDevImplGPU, SplitStage) {
+  TensorListShape<> in_shape = {{
+    { 32, 2, 64000 },
+    { 15, 4, 128000 },
+    { 72000, 1, 7 }
+  }};
+  int axes[] = { 0, 2 };
+  StdDevImplGPU<float, int16_t> stddev;
+  KernelContext ctx = {};
+  auto req = stddev.Setup(ctx, in_shape, make_span(axes), true, false);
+  TensorListShape<> ref_out_shape = {{
+    { 1, 2, 1 },
+    { 1, 4, 1 },
+    { 1, 1, 1 }
+  }};
+  int N = in_shape.num_samples();
+  EXPECT_EQ(req.output_shapes[0], ref_out_shape);
+  EXPECT_GE(stddev.GetNumStages(), 4);  // both reduced axes must be split due to large max extent
+
+  ScratchpadAllocator sa;
+  sa.Reserve(req.scratch_sizes);
+  auto scratchpad = sa.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+
+  std::mt19937_64 rng(12345);
+
+  TestTensorList<int16_t> in;
+  in.reshape(in_shape);
+  auto in_cpu = in.cpu();
+  UniformRandomFill(in_cpu, rng, -100, 100);
+
+  TestTensorList<float> fake_mean;
+  fake_mean.reshape(ref_out_shape);
+  auto mean_cpu = fake_mean.cpu();
+  *mean_cpu[0](0, 0, 0) = 10;
+  *mean_cpu[0](0, 1, 0) = 20;
+  *mean_cpu[1](0, 0, 0) = 30;
+  *mean_cpu[1](0, 1, 0) = 40;
+  *mean_cpu[1](0, 2, 0) = 50;
+  *mean_cpu[1](0, 3, 0) = 60;
+  *mean_cpu[2](0, 0, 0) = 70;
+
+
+  TestTensorList<float> out;
+  out.reshape(req.output_shapes[0]);
+  stddev.Run(ctx, out.gpu(), in.gpu(), fake_mean.gpu());
+
+  TestTensorList<float> centered_square;
+  centered_square.reshape(in_shape);
+  auto centered_square_cpu = centered_square.cpu();
+  for (int i = 0; i < N; i++) {
+    auto in_tv = in_cpu[i];
+    auto out_tv = centered_square_cpu[i];
+    auto mean_tv = mean_cpu[i];
+    for (int z = 0; z < in_tv.shape[0]; z++) {
+      for (int y = 0; y < in_tv.shape[1]; y++) {
+        for (int x = 0; x < in_tv.shape[2]; x++) {
+          double d = *in_tv(z, y, x) - *mean_tv(0, y, 0);
+          *out_tv(z, y, x) = d * d;
+        }
+      }
+    }
+  }
+
+  auto out_cpu = out.cpu(ctx.gpu.stream);
+  TestTensorList<float> ref;
+  ref.reshape(ref_out_shape);
+  auto ref_cpu = ref.cpu();
+  for (int i = 0; i < N; i++) {
+    int64_t n = ref_cpu[i].num_elements();
+    int64_t n_in = in_cpu[i].num_elements();
+    double ratio = n_in / n;
+    RefReduce(ref_cpu[i], centered_square_cpu[i], make_span(axes), reductions::sum());
+    for (int j = 0; j < n; j++)
+      ref_cpu.data[i][j] = std::sqrt(ref_cpu.data[i][j] / ratio);
+  }
+
+  Check(out_cpu, ref_cpu, EqualEpsRel(1e-5, 1e-6));
+}
+
+
+
+
+}  // namespace reduce_impl
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
@@ -183,8 +183,115 @@ TEST(MeanImplGPU, BatchMean) {
   Check(out_cpu, ref_cpu, EqualEpsRel(1e-5, 1e-6));
 }
 
+template <typename Out, typename In, typename Mean>
+void CenterAndSquare(const OutTensorCPU<Out> &out,
+                     const InTensorCPU<In> &in,
+                     const InTensorCPU<Mean> mean,
+                     TensorShape<> &in_pos,
+                     TensorShape<> &mean_pos,
+                     int dim = 0) {
+  int extent = in.shape[dim];
+  int dj = mean.shape[dim] > 1 ? 1 : 0;
+  if (dim == in.dim() - 1) {
+    const Mean *mean_ptr = mean(mean_pos);
+    const In *in_ptr = in(in_pos);
+    Out *out_ptr = out(in_pos);
+    for (int i = 0, j = 0; i < extent; i++, j += dj) {
+      double d = in_ptr[i] - mean_ptr[j];
+      out_ptr[i] = static_cast<Out>(d * d);
+    }
+  } else {
+    for (int i = 0, j = 0; i < extent; i++, j += dj) {
+      in_pos[dim] = i;
+      mean_pos[dim] = j;
+      CenterAndSquare(out, in, mean, in_pos, mean_pos, dim + 1);
+    }
+  }
+}
 
-TEST(StdDevImplGPU, SplitStage) {
+template <typename Out = float, typename In, typename Mean>
+TestTensorList<Out> CenterAndSquare(const InListCPU<In> &in,
+                                    const InListCPU<Mean> &mean) {
+  TestTensorList<Out> out_tl;
+  out_tl.reshape(in.shape);
+  auto out = out_tl.cpu();
+  int N = in.num_samples();
+  for (int i = 0; i < N; i++) {
+    auto in_tv = in[i];
+    auto out_tv = out[i];
+    auto mean_tv = mean.num_samples() > 1 ? mean[i] : mean[0];
+    TensorShape<> in_pos, mean_pos;
+    in_pos.resize(in_tv.shape.size());
+    mean_pos.resize(in_tv.shape.size());
+    CenterAndSquare(out_tv, in_tv, mean_tv, in_pos, mean_pos);
+  }
+  return out_tl;
+}
+
+template <typename Out = float, typename In, typename Mean>
+TestTensorList<Out> RefStdDev(const TensorListView<StorageCPU, In> &in,
+                              const TensorListView<StorageCPU, Mean> &mean) {
+  SmallVector<int, 6> axes;
+  for (int d = 0; d < mean.sample_dim(); d++) {
+    for (int i = 0; i < mean.num_samples(); i++) {
+      if (mean.tensor_shape_span(i)[d] > 1)
+        goto non_reduced;
+    }
+    axes.push_back(d);
+  non_reduced:;  // NOLINT
+  }
+
+  bool reduce_batch = mean.num_samples() == 1 && in.num_samples() > 1;
+
+  using tmp_t = decltype(In() - Mean());
+  auto centered_squared = CenterAndSquare<tmp_t, In, Mean>(in, mean);
+  auto centered_squared_cpu = centered_squared.cpu();
+  TestTensorList<Out> reduced_samples;
+
+  const auto &out_shape = mean.shape;
+
+  int N = in.num_samples();
+
+  if (reduce_batch) {
+    assert(is_uniform(out_shape));
+    TensorListShape<> reduced_sample_shapes = uniform_list_shape(in.num_samples(), mean.shape[0]);
+    reduced_samples.reshape(reduced_sample_shapes);
+    auto reduced_samples_cpu = reduced_samples.cpu();
+
+    for (int i = 0; i < N; i++) {
+      RefReduce(reduced_samples_cpu[i], centered_squared_cpu[i],
+                make_span(axes), reductions::sum());
+    }
+
+    TestTensorList<Out> out_tl;
+    out_tl.reshape(out_shape);
+    auto out = out_tl.cpu();
+    int64_t n = out_shape.num_elements();
+    double ratio = in.num_elements() / n;
+    for (int j = 0; j < n; j++) {
+      double sum = 0;
+      for (int i = 0; i < N; i++)
+        sum += reduced_samples_cpu.data[i][j];
+      out.data[0][j] = std::sqrt(sum / ratio);
+    }
+    return out_tl;
+  } else {
+    reduced_samples.reshape(out_shape);
+    auto out = reduced_samples.cpu();
+    for (int i = 0; i < N; i++) {
+      int64_t n = out[i].num_elements();
+      int64_t n_in = in[i].num_elements();
+      double ratio = n_in / n;
+      RefReduce(out[i], centered_squared_cpu[i], make_span(axes), reductions::sum());
+      for (int j = 0; j < n; j++)
+        out.data[i][j] = std::sqrt(out.data[i][j] / ratio);
+    }
+    return reduced_samples;
+  }
+}
+
+
+TEST(StdDevImplGPU, Outer_Inner_SplitStage) {
   TensorListShape<> in_shape = {{
     { 32, 2, 64000 },
     { 15, 4, 128000 },
@@ -230,42 +337,104 @@ TEST(StdDevImplGPU, SplitStage) {
   TestTensorList<float> out;
   out.reshape(req.output_shapes[0]);
   stddev.Run(ctx, out.gpu(), in.gpu(), fake_mean.gpu());
-
-  TestTensorList<float> centered_square;
-  centered_square.reshape(in_shape);
-  auto centered_square_cpu = centered_square.cpu();
-  for (int i = 0; i < N; i++) {
-    auto in_tv = in_cpu[i];
-    auto out_tv = centered_square_cpu[i];
-    auto mean_tv = mean_cpu[i];
-    for (int z = 0; z < in_tv.shape[0]; z++) {
-      for (int y = 0; y < in_tv.shape[1]; y++) {
-        for (int x = 0; x < in_tv.shape[2]; x++) {
-          double d = *in_tv(z, y, x) - *mean_tv(0, y, 0);
-          *out_tv(z, y, x) = d * d;
-        }
-      }
-    }
-  }
-
   auto out_cpu = out.cpu(ctx.gpu.stream);
-  TestTensorList<float> ref;
-  ref.reshape(ref_out_shape);
-  auto ref_cpu = ref.cpu();
-  for (int i = 0; i < N; i++) {
-    int64_t n = ref_cpu[i].num_elements();
-    int64_t n_in = in_cpu[i].num_elements();
-    double ratio = n_in / n;
-    RefReduce(ref_cpu[i], centered_square_cpu[i], make_span(axes), reductions::sum());
-    for (int j = 0; j < n; j++)
-      ref_cpu.data[i][j] = std::sqrt(ref_cpu.data[i][j] / ratio);
-  }
 
-  Check(out_cpu, ref_cpu, EqualEpsRel(1e-5, 1e-6));
+  TestTensorList<float> ref = RefStdDev(in_cpu, mean_cpu);
+
+  Check(out.cpu(), ref.cpu(), EqualEpsRel(1e-5, 1e-6));
 }
 
 
+TEST(StdDevImplGPU, Middle_Inner_Sample) {
+  TensorListShape<> in_shape = {{
+    { 4, 32, 1, 6400 },
+    { 3, 15, 2, 12800 },
+    { 2, 7200, 3, 7 }
+  }};
+  int axes[] = { 1, 3 };
+  StdDevImplGPU<float, int16_t> stddev;
+  KernelContext ctx = {};
+  auto req = stddev.Setup(ctx, in_shape, make_span(axes), true, false);
+  TensorListShape<> ref_out_shape = {{
+    { 4, 1, 1, 1 },
+    { 3, 1, 2, 1 },
+    { 2, 1, 3, 1 }
+  }};
 
+  ScratchpadAllocator sa;
+  sa.Reserve(req.scratch_sizes);
+  auto scratchpad = sa.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+
+  std::mt19937_64 rng(12345);
+
+  TestTensorList<int16_t> in;
+  in.reshape(in_shape);
+  auto in_cpu = in.cpu();
+  UniformRandomFill(in_cpu, rng, -100, 100);
+
+  TestTensorList<float> fake_mean;
+  fake_mean.reshape(ref_out_shape);
+  auto mean_cpu = fake_mean.cpu();
+  for (int i = 0, n = mean_cpu.num_elements(); i < n; i++) {
+    mean_cpu.data[0][i] = 10 * (i+1);
+  }
+
+  TestTensorList<float> out;
+  out.reshape(req.output_shapes[0]);
+  stddev.Run(ctx, out.gpu(), in.gpu(), fake_mean.gpu());
+  auto out_cpu = out.cpu(ctx.gpu.stream);
+
+  TestTensorList<float> ref = RefStdDev(in_cpu, mean_cpu);
+
+  Check(out_cpu, ref.cpu(), EqualEpsRel(1e-5, 1e-6));
+}
+
+TEST(StdDevImplGPU, Middle_Inner_Batch) {
+  TensorListShape<> in_shape = {{
+    { 2, 32, 3, 6400 },
+    { 2, 15, 3, 12800 },
+    { 2, 7200, 3, 7 }
+  }};
+  int axes[] = { 1, 3 };
+  StdDevImplGPU<float, int16_t> stddev;
+  KernelContext ctx = {};
+  auto req = stddev.Setup(ctx, in_shape, make_span(axes), true, true);
+  TensorListShape<> ref_out_shape = {{
+    { 2, 1, 3, 1 }
+  }};
+
+  ScratchpadAllocator sa;
+  sa.Reserve(req.scratch_sizes);
+  auto scratchpad = sa.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+
+  std::mt19937_64 rng(12345);
+
+  TestTensorList<int16_t> in;
+  in.reshape(in_shape);
+  auto in_cpu = in.cpu();
+  UniformRandomFill(in_cpu, rng, -100, 100);
+
+  TestTensorList<float> fake_mean;
+  fake_mean.reshape(ref_out_shape);
+  auto mean_cpu = fake_mean.cpu();
+  *mean_cpu[0](0, 0, 0, 0) = 10;
+  *mean_cpu[0](0, 0, 1, 0) = 20;
+  *mean_cpu[0](0, 0, 2, 0) = 30;
+  *mean_cpu[0](1, 0, 0, 0) = 40;
+  *mean_cpu[0](1, 0, 1, 0) = 50;
+  *mean_cpu[0](1, 0, 2, 0) = 60;
+
+  TestTensorList<float> out;
+  out.reshape(req.output_shapes[0]);
+  stddev.Run(ctx, out.gpu(), in.gpu(), fake_mean.gpu());
+  auto out_cpu = out.cpu(ctx.gpu.stream);
+
+  TestTensorList<float> ref = RefStdDev(in_cpu, mean_cpu);
+
+  Check(out_cpu, ref.cpu(), EqualEpsRel(1e-5, 1e-6));
+}
 
 }  // namespace reduce_impl
 }  // namespace kernels

--- a/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
@@ -229,10 +229,10 @@ TestTensorList<Out> RefStdDev(const TensorListView<StorageCPU, In> &in,
     int64_t n = out_shape.num_elements();
     double ratio = in.num_elements() / n;
     for (int j = 0; j < n; j++) {
-      double sum = reg;
+      double sum = 0;
       for (int i = 0; i < N; i++)
         sum += reduced_samples_cpu.data[i][j];
-      out.data[0][j] = inv ? rsqrt(sum / ratio) : std::sqrt(sum / ratio);
+      out.data[0][j] = inv ? rsqrt(sum / ratio + reg) : std::sqrt(sum / ratio + reg);
     }
     return out_tl;
   } else {
@@ -244,7 +244,7 @@ TestTensorList<Out> RefStdDev(const TensorListView<StorageCPU, In> &in,
       double ratio = n_in / n;
       RefReduce(out[i], centered_squared_cpu[i], make_span(axes), reductions::sum());
       for (int j = 0; j < n; j++) {
-        double x = (out.data[i][j] + reg) / ratio;
+        double x = out.data[i][j] / ratio + reg;
         out.data[i][j] = inv ? rsqrt(x) : std::sqrt(x);
       }
     }

--- a/dali/kernels/reduce/reduce_all_gpu_test.cu
+++ b/dali/kernels/reduce/reduce_all_gpu_test.cu
@@ -69,13 +69,13 @@ void ReduceAllGPUTest<Reduction>::TestReduceAll() {
   cudaMemcpy(in_data.get(), in_cpu.data(), n_in * sizeof(*in_data), cudaMemcpyHostToDevice);
 
   dim3 grid = n_out0;
-  ReduceAllKernel<<<1, block>>>(out_data.get(), in_data.get(), n_in);
+  ReduceAllKernel<float><<<1, block>>>(out_data.get(), in_data.get(), n_in);
   cudaDeviceSynchronize();
   auto start = CUDAEvent::CreateWithFlags(0);
   auto end =   CUDAEvent::CreateWithFlags(0);
   cudaEventRecord(start);
-  ReduceAllKernel<<<grid, block>>>(out_data.get() + 1, in_data.get(), n_in, R);
-  ReduceAllKernel<<<1, block>>>(out_data.get(), out_data.get() + 1, n_out0, R);
+  ReduceAllKernel<float><<<grid, block>>>(out_data.get() + 1, in_data.get(), n_in, R);
+  ReduceAllKernel<float><<<1, block>>>(out_data.get(), out_data.get() + 1, n_out0, R);
   cudaEventRecord(end);
   cudaMemcpy(out_cpu.data(), out_data.get(), n_out * sizeof(*out_data), cudaMemcpyDeviceToHost);
   cudaDeviceSynchronize();
@@ -146,18 +146,18 @@ void ReduceAllGPUTest<Reduction>::TestReduceBatched() {
   cudaMemcpy(gpu_sizes.get(), sizes.data(), samples * sizeof(*gpu_sizes), cudaMemcpyHostToDevice);
 
   // warm-up
-  ReduceAllBatchedKernel<<<1, block>>>(out_data.get(), gpu_dev_ptrs.get(), gpu_sizes.get(), R);
+  ReduceAllBatchedKernel<float><<<1, block>>>(out_data.get(), gpu_dev_ptrs.get(), gpu_sizes.get(), R);
   cudaDeviceSynchronize();
   auto start = CUDAEvent::CreateWithFlags(0);
   auto end =   CUDAEvent::CreateWithFlags(0);
   cudaEventRecord(start);
-  ReduceAllBatchedKernel<<<grid, block>>>(out_data.get() + samples,
-                                          gpu_dev_ptrs.get(), gpu_sizes.get(), R);
+  ReduceAllBatchedKernel<float><<<grid, block>>>(out_data.get() + samples,
+                                                 gpu_dev_ptrs.get(), gpu_sizes.get(), R);
 
   dim3 grid2(1, samples);
-  ReduceAllBlockwiseKernel<<<grid2, block>>>(out_data.get(),
-                                             out_data.get() + samples, n_out_per_sample,
-                                             R);
+  ReduceAllBlockwiseKernel<float><<<grid2, block>>>(out_data.get(),
+                                                    out_data.get() + samples, n_out_per_sample,
+                                                    R);
   cudaEventRecord(end);
   cudaMemcpy(out_cpu.data(), out_data.get(), n_out * sizeof(*out_data), cudaMemcpyDeviceToHost);
   cudaDeviceSynchronize();

--- a/dali/kernels/reduce/reduce_all_gpu_test.cu
+++ b/dali/kernels/reduce/reduce_all_gpu_test.cu
@@ -146,7 +146,8 @@ void ReduceAllGPUTest<Reduction>::TestReduceBatched() {
   cudaMemcpy(gpu_sizes.get(), sizes.data(), samples * sizeof(*gpu_sizes), cudaMemcpyHostToDevice);
 
   // warm-up
-  ReduceAllBatchedKernel<float><<<1, block>>>(out_data.get(), gpu_dev_ptrs.get(), gpu_sizes.get(), R);
+  ReduceAllBatchedKernel<float><<<1, block>>>(
+      out_data.get(), gpu_dev_ptrs.get(), gpu_sizes.get(), R);
   cudaDeviceSynchronize();
   auto start = CUDAEvent::CreateWithFlags(0);
   auto end =   CUDAEvent::CreateWithFlags(0);

--- a/dali/kernels/reduce/reduce_all_kernel_gpu.h
+++ b/dali/kernels/reduce/reduce_all_kernel_gpu.h
@@ -35,6 +35,7 @@ class DLL_PUBLIC ReduceAllGPU {
   // TODO(janton): remove this when implemented
   static_assert(std::is_same<Preprocessor, identity>::value,
                 "Preprocessing is not yet implemented");
+  using Acc = Out;
 
   DLL_PUBLIC ~ReduceAllGPU() = default;
 
@@ -100,14 +101,14 @@ class DLL_PUBLIC ReduceAllGPU {
 
     if (blocks_per_sample_ == 1) {
       // For small inputs, we reduce in one step
-      ReduceAllBatchedKernel<<<grid, block, 0, context.gpu.stream>>>(
+      ReduceAllBatchedKernel<Acc><<<grid, block, 0, context.gpu.stream>>>(
           out_start, sample_data_gpu, sample_size_gpu, reduction);
     } else {
-      ReduceAllBatchedKernel<<<grid, block, 0, context.gpu.stream>>>(
+      ReduceAllBatchedKernel<Acc><<<grid, block, 0, context.gpu.stream>>>(
           buffer_gpu, sample_data_gpu, sample_size_gpu, reduction);
 
       dim3 grid2(1, num_samples);
-      ReduceAllBlockwiseKernel<<<grid2, block, 0, context.gpu.stream>>>(
+      ReduceAllBlockwiseKernel<Acc><<<grid2, block, 0, context.gpu.stream>>>(
           out_start, buffer_gpu, blocks_per_sample_, reduction);
     }
   }

--- a/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
@@ -51,43 +51,13 @@ struct IdentityPreprocessor {
 };
 
 /**
- * @brief Calculates variance, given a tensor of means.
+ * @brief A position-independent bank, wrapping a functor
  */
-template <int non_reduced_ndim, typename Mean>
-struct VariancePreprocessor;
-
-template <typename Mean>
-struct VariancePreprocessor<1, Mean> {
-  const Mean *__restrict__ mean;
-  i64vec<1> stride;
-
+template <int non_reduced_ndim, typename Functor>
+struct UniformPreprocessorBank {
   DALI_HOST_DEV DALI_FORCEINLINE
-  reductions::variance<Mean> Get(const i64vec<1> &pos) const {
-    auto offset = dot(pos, stride);
-  #ifdef __CUDA_ARCH__
-    Mean m = __ldg(mean + offset);
-  #else
-    Mean m = mean[offset];
-  #endif
-    return { m };
-  }
-};
-
-template <typename Mean>
-struct VariancePreprocessor<2, Mean> {
-  const Mean *mean;
-  i64vec<2> stride;
-  DropDims inner_dims;
-
-  DALI_HOST_DEV DALI_FORCEINLINE
-  reductions::variance<Mean> Get(const i64vec<2> &pos) const {
-    auto offset = dot(i64vec2(pos[0], inner_dims.reindex(pos[1])), stride);
-  #ifdef __CUDA_ARCH__
-    Mean m = __ldg(mean + offset);
-  #else
-    Mean m = mean[offset];
-  #endif
-    return { m };
+  Functor Get(const i64vec<non_reduced_ndim> &) const {
+    return {};
   }
 };
 

--- a/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
@@ -65,9 +65,9 @@ struct VariancePreprocessor<1, Mean> {
   reductions::variance<Mean> Get(const i64vec<1> &pos) const {
     auto offset = dot(pos, stride);
   #ifdef __CUDA_ARCH__
-    float m = __ldg(mean + offset);
+    Mean m = __ldg(mean + offset);
   #else
-    float m = mean[offset];
+    Mean m = mean[offset];
   #endif
     return { m };
   }
@@ -83,9 +83,9 @@ struct VariancePreprocessor<2, Mean> {
   reductions::variance<Mean> Get(const i64vec<2> &pos) const {
     auto offset = dot(i64vec2(pos[0], inner_dims.reindex(pos[1])), stride);
   #ifdef __CUDA_ARCH__
-    float m = __ldg(mean + offset);
+    Mean m = __ldg(mean + offset);
   #else
-    float m = mean[offset];
+    Mean m = mean[offset];
   #endif
     return { m };
   }
@@ -219,7 +219,7 @@ __device__ void ReduceInnerSmall(Out *out, const In *in, int64_t n_outer, int n_
  * The reduction is done by a warp.
  * After sequential step, warp reduction is performed.
  */
-template <typename Acc, typename Out,typename In,
+template <typename Acc, typename Out, typename In,
           typename Reduction, typename PreprocessorBank, typename Postprocessor>
 __device__ void ReduceInnerMedium(Out *out, const In *in, int64_t n_outer, int n_inner,
                                   Reduction reduce,

--- a/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
@@ -104,8 +104,8 @@ struct VariancePreprocessor<2, Mean> {
  *                      per output sample
  * @param post          posptprocessing unary functor
  */
-template <typename Acc, typename In, typename PreprocessorBank, typename Postprocessor>
-__device__ void ReduceNone(Acc *out, const In *in, int64_t n,
+template <typename Out, typename In, typename PreprocessorBank, typename Postprocessor>
+__device__ void ReduceNone(Out *out, const In *in, int64_t n,
                            PreprocessorBank pre_bank, Postprocessor post) {
   const int64_t blk_size = blockDim.x * blockDim.y;  // no restriction on block size
   const int64_t grid_stride = static_cast<int64_t>(gridDim.x) * blk_size;
@@ -113,7 +113,7 @@ __device__ void ReduceNone(Acc *out, const In *in, int64_t n,
   int64_t base_idx = static_cast<int64_t>(blockIdx.x) * blk_size + flat_tid;
   for (int64_t index = base_idx; index < n; index += grid_stride) {
     auto pre = pre_bank.Get({index});
-    out[index] = post(pre(in[index]));
+    out[index] = ConvertSat<Out>(post(pre(in[index])));
   }
 }
 
@@ -130,10 +130,10 @@ __device__ void ReduceNone(Acc *out, const In *in, int64_t n,
  *                      per output sample
  * @param post          posptprocessing unary functor
  */
-template <typename Acc, typename In,
+template <typename Out, typename In,
           typename PreprocessorBank = reduce_impl::IdentityPreprocessor<1>,
           typename Postprocessor = identity>
-__global__ void ReduceNoneKernel(Acc *const *out, const In *const *in, const int64_t *lengths,
+__global__ void ReduceNoneKernel(Out *const *out, const In *const *in, const int64_t *lengths,
                                  PreprocessorBank *pre = nullptr,
                                  Postprocessor *post = nullptr) {
   int sample_idx = blockIdx.y;
@@ -153,11 +153,11 @@ __global__ void ReduceNoneKernel(Acc *const *out, const In *const *in, const int
  *                      per output coordinate per input sample
  * @param post          posptprocessing unary functor
  */
-template <typename Acc, typename In,
+template <typename Acc, typename Out, typename In,
           typename Reduction,
           typename PreprocessorBank = reduce_impl::IdentityPreprocessor<1>,
           typename Postprocessor = identity>
-__global__ void ReduceSamplesKernel(Acc *out, const In *const *in,
+__global__ void ReduceSamplesKernel(Out *out, const In *const *in,
                                     int64_t sample_size, int num_samples,
                                     Reduction R = {},
                                     PreprocessorBank *pre = nullptr,
@@ -178,7 +178,7 @@ __global__ void ReduceSamplesKernel(Acc *out, const In *const *in,
         red.add(pp(in[i][ofs]), R);
       }
     }
-    out[ofs] = post(red.result());
+    out[ofs] = ConvertSat<Out>(post(red.result()));
   }
 }
 
@@ -193,9 +193,9 @@ __global__ void ReduceSamplesKernel(Acc *out, const In *const *in,
  *                      per output sample
  * @param post          posptprocessing unary functor
  */
-template <typename Acc, typename In,
+template <typename Acc, typename Out, typename In,
           typename Reduction, typename PreprocessorBank, typename Postprocessor>
-__device__ void ReduceInnerSmall(Acc *out, const In *in, int64_t n_outer, int n_inner,
+__device__ void ReduceInnerSmall(Out *out, const In *in, int64_t n_outer, int n_inner,
                                  Reduction reduce,
                                  PreprocessorBank pre_bank, Postprocessor post) {
   const int64_t blk_size = blockDim.x * blockDim.y;  // no restriction on block size
@@ -209,7 +209,7 @@ __device__ void ReduceInnerSmall(Acc *out, const In *in, int64_t n_outer, int n_
     red.reset();
     for (int i = 0; i < n_inner; i++)
       red.add(pre(__ldg(base + i)), reduce);
-    out[outer] = post(red.result());
+    out[outer] = ConvertSat<Out>(post(red.result()));
   }
 }
 
@@ -219,9 +219,9 @@ __device__ void ReduceInnerSmall(Acc *out, const In *in, int64_t n_outer, int n_
  * The reduction is done by a warp.
  * After sequential step, warp reduction is performed.
  */
-template <typename Acc, typename In,
+template <typename Acc, typename Out,typename In,
           typename Reduction, typename PreprocessorBank, typename Postprocessor>
-__device__ void ReduceInnerMedium(Acc *out, const In *in, int64_t n_outer, int n_inner,
+__device__ void ReduceInnerMedium(Out *out, const In *in, int64_t n_outer, int n_inner,
                                   Reduction reduce,
                                   PreprocessorBank pre_bank, Postprocessor post) {
   const int64_t grid_stride = static_cast<int64_t>(gridDim.x) * blockDim.y;
@@ -236,7 +236,7 @@ __device__ void ReduceInnerMedium(Acc *out, const In *in, int64_t n_outer, int n
     Acc v = red.result();
     WarpReduce(v, reduce);
     if (threadIdx.x == 0) {
-      out[outer] = post(v);
+      out[outer] = ConvertSat<Out>(post(v));
     }
   }
 }
@@ -250,9 +250,9 @@ __device__ void ReduceInnerMedium(Acc *out, const In *in, int64_t n_outer, int n
  * After this function is used, another level of reduction may be necessary,
  * depending on the value num_macroblocks.
  */
-template <typename Acc, typename In,
+template <typename Acc, typename Out, typename In,
           typename Reduction, typename PreprocessorBank, typename Postprocessor>
-__device__ void ReduceInnerLarge(Acc *out, const In *in, int64_t n_outer, int64_t n_inner,
+__device__ void ReduceInnerLarge(Out *out, const In *in, int64_t n_outer, int64_t n_inner,
                                  int num_macroblocks, int macroblock_size,
                                  Reduction reduce,
                                  PreprocessorBank pre_bank, Postprocessor post) {
@@ -292,7 +292,7 @@ __device__ void ReduceInnerLarge(Acc *out, const In *in, int64_t n_outer, int64_
       __syncthreads();      // make sure that the shared memory used by BlockReduce is ready
 
     if (BlockReduce(val, reduce))
-      out[idx] = post(val);
+      out[idx] = ConvertSat<Out>(post(val));
   }
 }
 
@@ -315,39 +315,39 @@ struct ReduceSampleDesc {
 };
 
 
-template <typename Acc, typename In,
+template <typename Acc, typename Out, typename In,
           typename Reduction, typename PreprocessorBank, typename Postprocessor>
-__device__ void ReduceInner(const ReduceSampleDesc<Acc, In> &sample,
+__device__ void ReduceInner(const ReduceSampleDesc<Out, In> &sample,
                             Reduction reduce,
                             PreprocessorBank pre_bank, Postprocessor post) {
   int64_t n_outer = sample.n_outer;
   int64_t n_reduced = sample.n_reduced;
-  Acc *out = sample.out;
+  Out *out = sample.out;
   const In *in = sample.in;
 
   if (n_reduced == 1) {
     ReduceNone(out, in, n_outer, pre_bank, post);
   } else if (n_reduced < 32 && sample.num_macroblocks == 1) {
-    ReduceInnerSmall(out, in, n_outer, n_reduced, reduce, pre_bank, post);
+    ReduceInnerSmall<Acc>(out, in, n_outer, n_reduced, reduce, pre_bank, post);
   } else if (n_reduced < 1024 && sample.num_macroblocks == 1) {
-    ReduceInnerMedium(out, in, n_outer, n_reduced, reduce, pre_bank, post);
+    ReduceInnerMedium<Acc>(out, in, n_outer, n_reduced, reduce, pre_bank, post);
   } else {
-    ReduceInnerLarge(out, in, n_outer, n_reduced,
+    ReduceInnerLarge<Acc>(out, in, n_outer, n_reduced,
                      sample.num_macroblocks, sample.macroblock_size,
                      reduce, pre_bank, post);
   }
 }
 
-template <typename Acc, typename In,
+template <typename Acc, typename Out, typename In,
           typename Reduction = reductions::sum,
           typename PreprocessorBank = reduce_impl::IdentityPreprocessor<1>,
           typename Postprocessor = identity>
-__global__ void ReduceInnerKernel(const ReduceSampleDesc<Acc, In> *samples,
+__global__ void ReduceInnerKernel(const ReduceSampleDesc<Out, In> *samples,
                                   Reduction reduce = {}, const PreprocessorBank *pre = nullptr,
                                   const Postprocessor *post = nullptr) {
   PreprocessorBank pre_bank = pre ? pre[blockIdx.y] : PreprocessorBank();
   Postprocessor postprocessor = post ? post[blockIdx.y] : Postprocessor();
-  ReduceInner(samples[blockIdx.y], reduce, pre_bank, postprocessor);
+  ReduceInner<Acc>(samples[blockIdx.y], reduce, pre_bank, postprocessor);
 }
 
 // Reduction over other dimensions (non-innermost)
@@ -355,10 +355,10 @@ __global__ void ReduceInnerKernel(const ReduceSampleDesc<Acc, In> *samples,
 /**
  * Each *thread* performs independent, full reduction
  */
-template <typename Acc, typename In,
+template <typename Acc, typename Out, typename In,
           typename Reduction, typename PreprocessorBank, typename Postprocessor>
 __device__
-void ReduceMiddleSmall(const ReduceSampleDesc<Acc, In> &sample,
+void ReduceMiddleSmall(const ReduceSampleDesc<Out, In> &sample,
                        Reduction reduce,
                        PreprocessorBank pre_bank, Postprocessor post) {
   int64_t n_outer = sample.n_outer;
@@ -367,7 +367,7 @@ void ReduceMiddleSmall(const ReduceSampleDesc<Acc, In> &sample,
   int64_t n_non_reduced = n_inner * n_outer;
   int64_t outer_stride = n_inner * n_reduced;
 
-  Acc *out = sample.out;
+  Out *out = sample.out;
   const In *in = sample.in;
   const int64_t blk_size = blockDim.x * blockDim.y;  // no restriction on block size
   const int64_t grid_stride = static_cast<int64_t>(gridDim.x) * blk_size;
@@ -383,7 +383,7 @@ void ReduceMiddleSmall(const ReduceSampleDesc<Acc, In> &sample,
     red.reset();
     for (int i = 0; i < n_reduced; i++)
       red.add(pre(__ldg(base + i * n_inner)), reduce);
-    out[idx] = post(red.result());
+    out[idx] = ConvertSat<Out>(post(red.result()));
   }
 }
 
@@ -400,14 +400,14 @@ namespace reduce_shared {
  * This function CANNOT work for inner extensts >32.
  * The macroblock size in reduced dimension is limited - see OnlineReducer for limits.
  */
-template <typename Acc, typename In,
+template <typename Acc, typename Out, typename In,
           typename Reduction, typename PreprocessorBank, typename Postprocessor>
-__device__ void ReduceMiddleLargeInnerSmall(const ReduceSampleDesc<Acc, In> &sample,
+__device__ void ReduceMiddleLargeInnerSmall(const ReduceSampleDesc<Out, In> &sample,
                                             Reduction r,
                                             PreprocessorBank pre_bank, Postprocessor post) {
   Acc (*shared_tmp)[33] = reinterpret_cast<Acc (*)[33]>(reduce_shared::shared_tmp);
 
-  Acc *out = sample.out;
+  Out *out = sample.out;
   const In *in = sample.in;
 
   const int n_inner = sample.n_inner;
@@ -529,7 +529,7 @@ __device__ void ReduceMiddleLargeInnerSmall(const ReduceSampleDesc<Acc, In> &sam
       // combine warps' partial results
       WarpReduce(acc, r);
       if (lane == 0) {
-        out[macroblock * n_inner + inner] = post(acc);
+        out[macroblock * n_inner + inner] = ConvertSat<Out>(post(acc));
       }
     }
   }
@@ -545,14 +545,14 @@ __device__ void ReduceMiddleLargeInnerSmall(const ReduceSampleDesc<Acc, In> &sam
  * This function is not indented for use with small inner extent.
  * The macroblock size in reduced dimension is limited - see OnlineReducer for limits.
  */
-template <typename Acc, typename In,
+template <typename Acc, typename Out, typename In,
           typename Reduction, typename PreprocessorBank, typename Postprocessor>
-__device__ void ReduceMiddleLargeInnerMedium(const ReduceSampleDesc<Acc, In> &sample,
+__device__ void ReduceMiddleLargeInnerMedium(const ReduceSampleDesc<Out, In> &sample,
                                              Reduction r,
                                              PreprocessorBank pre_bank, Postprocessor post) {
   Acc (*shared_tmp)[33] = reinterpret_cast<Acc (*)[33]>(reduce_shared::shared_tmp);
 
-  Acc *out = sample.out;
+  Out *out = sample.out;
   const In *in = sample.in;
 
   const int n_inner = sample.n_inner;
@@ -627,18 +627,18 @@ __device__ void ReduceMiddleLargeInnerMedium(const ReduceSampleDesc<Acc, In> &sa
       WarpReduce(v, r);
       if (lane == 0) {
         int inner = i + inner_base;
-        out[macroblock * n_inner + inner] = post(v);
+        out[macroblock * n_inner + inner] = ConvertSat<Out>(post(v));
       }
     }
   }
 }
 
 
-template <typename Acc, typename In,
+template <typename Acc, typename Out, typename In,
           typename Reduction = reductions::sum,
           typename PreprocessorBank = reduce_impl::IdentityPreprocessor<2>,
           typename Postprocessor = identity>
-__global__ void ReduceMiddleKernel(const ReduceSampleDesc<Acc, In> *samples,
+__global__ void ReduceMiddleKernel(const ReduceSampleDesc<Out, In> *samples,
                                   Reduction reduce = {},
                                   const PreprocessorBank *pre = nullptr,
                                   const Postprocessor *post = nullptr) {
@@ -648,11 +648,11 @@ __global__ void ReduceMiddleKernel(const ReduceSampleDesc<Acc, In> *samples,
   Postprocessor postprocessor = post ? post[blockIdx.y] : Postprocessor();
 
   if (sample.n_reduced < 1024 && sample.num_macroblocks == 1) {
-    ReduceMiddleSmall(sample, reduce, pre_bank, postprocessor);
+    ReduceMiddleSmall<Acc>(sample, reduce, pre_bank, postprocessor);
   } else if (sample.n_inner < 32) {
-    ReduceMiddleLargeInnerSmall(sample, reduce, pre_bank, postprocessor);
+    ReduceMiddleLargeInnerSmall<Acc>(sample, reduce, pre_bank, postprocessor);
   } else {
-    ReduceMiddleLargeInnerMedium(sample, reduce, pre_bank, postprocessor);
+    ReduceMiddleLargeInnerMedium<Acc>(sample, reduce, pre_bank, postprocessor);
   }
 }
 

--- a/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
@@ -37,6 +37,10 @@ namespace reduce_impl {
  *  };
  *  ```
  *  where SingleValuePreprocessor is a unary functor.
+ *
+ * non_recuced_dims is either 1 or 2; if it's 1, the dimension 0 is outer (wrt reduced dime)
+ * and dimesnion 1 is inner.
+ * If non_reduced_dims is 1, then `pos` is the outer dimension.
  */
 
 /**

--- a/dali/kernels/reduce/reduce_axes_gpu_test.cu
+++ b/dali/kernels/reduce/reduce_axes_gpu_test.cu
@@ -112,7 +112,7 @@ class ReduceInnerGPUTest : public ::testing::Test {
     auto end =   CUDAEvent::CreateWithFlags(0);
     gpu_descs.from_host(cpu_descs);
     cudaEventRecord(start);
-    ReduceInnerKernel<<<grid, block>>>(gpu_descs.data(), reduction);
+    ReduceInnerKernel<float><<<grid, block>>>(gpu_descs.data(), reduction);
     cudaEventRecord(end);
     CUDA_CALL(cudaDeviceSynchronize());
     float t = 0;
@@ -137,7 +137,7 @@ class ReduceInnerGPUTest : public ::testing::Test {
       int64_t outer = ts[0];
       int64_t inner = ts[1];
       ref_out.resize(outer);
-      RefReduceInner(ref_out.data(), cpu_in.data[i], outer, inner, reduction);
+      RefReduceInner<float>(ref_out.data(), cpu_in.data[i], outer, inner, reduction);
       auto out = cpu_out[i];
       if (out.shape[1] > 1) {
         full_out.resize(outer);
@@ -253,7 +253,7 @@ class ReduceMiddleGPUTest : public ::testing::Test {
     auto start = CUDAEvent::CreateWithFlags(0);
     auto end =   CUDAEvent::CreateWithFlags(0);
     cudaEventRecord(start);
-    ReduceMiddleKernel<<<grid, block, sizeof(float)*32*33>>>(gpu_descs.data(), reduction);
+    ReduceMiddleKernel<float><<<grid, block, sizeof(float)*32*33>>>(gpu_descs.data(), reduction);
     CUDA_CALL(cudaGetLastError());
     cudaEventRecord(end);
     CUDA_CALL(cudaDeviceSynchronize());
@@ -378,7 +378,7 @@ TEST(ReduceSamples, Sum) {
   auto end =   CUDAEvent::CreateWithFlags(0);
   sample_ptrs.from_host(gpu_in.data);
   cudaEventRecord(start);
-  ReduceSamplesKernel<<<256, 1024>>>(gpu_out.data[0], sample_ptrs.data(), n, N, R);
+  ReduceSamplesKernel<float><<<256, 1024>>>(gpu_out.data[0], sample_ptrs.data(), n, N, R);
   cudaEventRecord(end);
   auto cpu_out = out.cpu();
   float t = 0;

--- a/dali/kernels/reduce/reduce_drop_dims.h
+++ b/dali/kernels/reduce/reduce_drop_dims.h
@@ -51,7 +51,7 @@ struct DropDims {
   int64_t mod[kMaxDims];
   int start = 2 * kMaxDims;
 
-  DropDims() = default;
+  DALI_HOST_DEV DropDims() {}
 
   /**
    * Collapses adjacent groups of reduced/non-reduced dimensions.
@@ -260,6 +260,7 @@ struct DropDims {
     return out;
   }
 };
+
 }  // namespace reduce_impl
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/reduce/reduce_gpu.cu
+++ b/dali/kernels/reduce/reduce_gpu.cu
@@ -55,6 +55,8 @@ template class SumGPU<int64_t, int16_t>;
 template class SumGPU<float, int16_t>;
 template class SumGPU<int64_t, int32_t>;
 template class SumGPU<float, int32_t>;
+template class SumGPU<uint64_t, uint32_t>;
+template class SumGPU<float, uint32_t>;
 template class SumGPU<float, float>;
 
 }  // namespace kernels

--- a/dali/kernels/reduce/reduce_gpu.h
+++ b/dali/kernels/reduce/reduce_gpu.h
@@ -299,6 +299,18 @@ class DLL_PUBLIC InvStdDevGPU {
 };
 
 
+extern template class InvStdDevGPU<float, uint8_t>;
+extern template class InvStdDevGPU<float, int8_t>;
+
+extern template class InvStdDevGPU<float, uint16_t>;
+extern template class InvStdDevGPU<float, int16_t>;
+
+extern template class InvStdDevGPU<float, uint32_t>;
+extern template class InvStdDevGPU<float, int32_t>;
+
+extern template class InvStdDevGPU<float, float>;
+
+
 }  // namespace kernels
 }  // namespace dali
 

--- a/dali/kernels/reduce/reduce_gpu.h
+++ b/dali/kernels/reduce/reduce_gpu.h
@@ -275,7 +275,7 @@ class DLL_PUBLIC InvStdDevGPU {
    * ```
    * s = sum( (in[pos] - mean[reduced_pos])^2
    * out[reduced_pos] = s > 0 || reg > 0
-   *                    ? 1/sqrt((s + reg^2) / reduction_factor)
+   *                    ? 1/sqrt(s / reduction_factor + reg^2)
    *                    : 0
    * ```
    * where `reduction_factor` is the number of input elements contributing to a single output.

--- a/dali/kernels/reduce/reduce_gpu.h
+++ b/dali/kernels/reduce/reduce_gpu.h
@@ -62,13 +62,242 @@ extern template class SumGPU<uint64_t, uint8_t>;
 extern template class SumGPU<float, uint8_t>;
 extern template class SumGPU<int64_t, int8_t>;
 extern template class SumGPU<float, int8_t>;
+
 extern template class SumGPU<uint64_t, uint16_t>;
 extern template class SumGPU<float, uint16_t>;
 extern template class SumGPU<int64_t, int16_t>;
 extern template class SumGPU<float, int16_t>;
+
+extern template class SumGPU<uint64_t, uint32_t>;
+extern template class SumGPU<float, uint32_t>;
 extern template class SumGPU<int64_t, int32_t>;
 extern template class SumGPU<float, int32_t>;
+
 extern template class SumGPU<float, float>;
+
+
+template <typename Out, typename In>
+class DLL_PUBLIC MeanGPU {
+ public:
+  MeanGPU();
+  ~MeanGPU();
+
+  /**
+   * @brief Sets up the reduction
+   *
+   * Sets up the reduction according to the parameters. The indices of dimensions to be reduced
+   * are provided in `axes` parameter.
+   * For a successful batch reduction, the reduced shape of all samples must be equal (but the
+   * input may have non-uniform shape, as long as the non-uniform dimensions are reduced).
+   *
+   * @param ctx          the execution environment
+   * @param in_shape     shape of the input tensor list
+   * @param axes         indices of axes to reduce along
+   * @param keep_dims    if true, the reduced dimensions are kept in the output shape, with the
+   *                     extent of 1
+   * @param reduce_batch if true, reduces respective output values of all samples in the batch
+   *                     and outputs a single tensor
+   */
+  KernelRequirements Setup(KernelContext &ctx,
+                           const TensorListShape<> &in_shape,
+                           span<const int> axes, bool keep_dims, bool reduce_batch);
+
+  /**
+   * @brief Performs the reduction, according to the parameters specified in Setup.
+   */
+  void Run(KernelContext &ctx, const OutListGPU<Out> &out, const InListGPU<In> &in);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+
+extern template class MeanGPU<uint8_t, uint8_t>;
+extern template class MeanGPU<float, uint8_t>;
+extern template class MeanGPU<int8_t, int8_t>;
+extern template class MeanGPU<float, int8_t>;
+
+extern template class MeanGPU<uint16_t, uint16_t>;
+extern template class MeanGPU<float, uint16_t>;
+extern template class MeanGPU<int16_t, int16_t>;
+extern template class MeanGPU<float, int16_t>;
+
+extern template class MeanGPU<uint32_t, uint32_t>;
+extern template class MeanGPU<float, uint32_t>;
+extern template class MeanGPU<int32_t, int32_t>;
+extern template class MeanGPU<float, int32_t>;
+
+extern template class MeanGPU<float, float>;
+
+
+template <typename Out, typename In>
+class DLL_PUBLIC RootMeanSquareGPU {
+ public:
+  RootMeanSquareGPU();
+  ~RootMeanSquareGPU();
+
+  /**
+   * @brief Sets up the reduction
+   *
+   * Sets up the reduction according to the parameters. The indices of dimensions to be reduced
+   * are provided in `axes` parameter.
+   * For a successful batch reduction, the reduced shape of all samples must be equal (but the
+   * input may have non-uniform shape, as long as the non-uniform dimensions are reduced).
+   *
+   * @param ctx          the execution environment
+   * @param in_shape     shape of the input tensor list
+   * @param axes         indices of axes to reduce along
+   * @param keep_dims    if true, the reduced dimensions are kept in the output shape, with the
+   *                     extent of 1
+   * @param reduce_batch if true, reduces respective output values of all samples in the batch
+   *                     and outputs a single tensor
+   */
+  KernelRequirements Setup(KernelContext &ctx,
+                           const TensorListShape<> &in_shape,
+                           span<const int> axes, bool keep_dims, bool reduce_batch);
+
+  /**
+   * @brief Performs the reduction, according to the parameters specified in Setup.
+   */
+  void Run(KernelContext &ctx, const OutListGPU<Out> &out, const InListGPU<In> &in);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+extern template class RootMeanSquareGPU<uint8_t, uint8_t>;
+extern template class RootMeanSquareGPU<float, uint8_t>;
+extern template class RootMeanSquareGPU<int8_t, int8_t>;
+extern template class RootMeanSquareGPU<float, int8_t>;
+
+extern template class RootMeanSquareGPU<uint16_t, uint16_t>;
+extern template class RootMeanSquareGPU<float, uint16_t>;
+extern template class RootMeanSquareGPU<int16_t, int16_t>;
+extern template class RootMeanSquareGPU<float, int16_t>;
+
+extern template class RootMeanSquareGPU<uint32_t, uint32_t>;
+extern template class RootMeanSquareGPU<float, uint32_t>;
+extern template class RootMeanSquareGPU<int32_t, int32_t>;
+extern template class RootMeanSquareGPU<float, int32_t>;
+
+extern template class RootMeanSquareGPU<float, float>;
+
+
+template <typename Out, typename In, typename Mean = Out>
+class DLL_PUBLIC StdDevGPU {
+ public:
+  StdDevGPU();
+  ~StdDevGPU();
+
+  /**
+   * @brief Sets up the reduction
+   *
+   * Sets up the reduction according to the parameters. The indices of dimensions to be reduced
+   * are provided in `axes` parameter.
+   * For a successful batch reduction, the reduced shape of all samples must be equal (but the
+   * input may have non-uniform shape, as long as the non-uniform dimensions are reduced).
+   *
+   * @param ctx          the execution environment
+   * @param in_shape     shape of the input tensor list
+   * @param axes         indices of axes to reduce along
+   * @param keep_dims    if true, the reduced dimensions are kept in the output shape, with the
+   *                     extent of 1
+   * @param reduce_batch if true, reduces respective output values of all samples in the batch
+   *                     and outputs a single tensor
+   */
+  KernelRequirements Setup(KernelContext &ctx,
+                           const TensorListShape<> &in_shape,
+                           span<const int> axes, bool keep_dims, bool reduce_batch);
+
+  /**
+   * @brief Performs the reduction, according to the parameters specified in Setup.
+   */
+  void Run(KernelContext &ctx, const OutListGPU<Out> &out,
+           const InListGPU<In> &in, const InListGPU<Mean> &mean);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+extern template class StdDevGPU<uint8_t, uint8_t>;
+extern template class StdDevGPU<float, uint8_t>;
+extern template class StdDevGPU<int8_t, int8_t>;
+extern template class StdDevGPU<float, int8_t>;
+
+extern template class StdDevGPU<uint16_t, uint16_t>;
+extern template class StdDevGPU<float, uint16_t>;
+extern template class StdDevGPU<int16_t, int16_t>;
+extern template class StdDevGPU<float, int16_t>;
+
+extern template class StdDevGPU<uint32_t, uint32_t>;
+extern template class StdDevGPU<float, uint32_t>;
+extern template class StdDevGPU<int32_t, int32_t>;
+extern template class StdDevGPU<float, int32_t>;
+
+extern template class StdDevGPU<float, float>;
+
+
+template <typename Out, typename In, typename Mean = In>
+class DLL_PUBLIC InvStdDevGPU {
+ public:
+  InvStdDevGPU();
+  ~InvStdDevGPU();
+
+  /**
+   * @brief Sets up the reduction
+   *
+   * Sets up the reduction according to the parameters. The indices of dimensions to be reduced
+   * are provided in `axes` parameter.
+   * For a successful batch reduction, the reduced shape of all samples must be equal (but the
+   * input may have non-uniform shape, as long as the non-uniform dimensions are reduced).
+   *
+   * @param ctx          the execution environment
+   * @param in_shape     shape of the input tensor list
+   * @param axes         indices of axes to reduce along
+   * @param keep_dims    if true, the reduced dimensions are kept in the output shape, with the
+   *                     extent of 1
+   * @param reduce_batch if true, reduces respective output values of all samples in the batch
+   *                     and outputs a single tensor
+   */
+  KernelRequirements Setup(KernelContext &ctx,
+                           const TensorListShape<> &in_shape,
+                           span<const int> axes, bool keep_dims, bool reduce_batch);
+
+  using param_t = std::conditional_t<std::is_same<Out, double>::value, double, float>;
+
+  /**
+   * @brief Caluclates regularized inverse standard deviation
+   *
+   * The output values are calculated as:
+   * ```
+   * s = sum( (in[pos] - mean[reduced_pos])^2
+   * out[reduced_pos] = s > 0 || reg > 0
+   *                    ? 1/sqrt((s + reg^2) / reduction_factor)
+   *                    : 0
+   * ```
+   * where `reduction_factor` is the number of input elements contributing to a single output.
+   *
+   * @param ctx     the execution environment
+   * @param out     (regularized) inverse standard deviation
+   * @param in      input tensor
+   * @param mean    mean, used for centering the data
+   * @param reg     regularizing term to avoid division by zero (or small numbers);
+   *                its squared and added to the sum of squares in variance calculation,
+   *                preventing it from being zero; if reg = 0, the results that would
+   *                cause division by zero are forced to 0, but small denominators
+   *                may still cause problems
+   */
+  void Run(KernelContext &ctx, const OutListGPU<Out> &out,
+           const InListGPU<In> &in, const InListGPU<Mean> &mean, param_t reg = 0);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/reduce/reduce_gpu.h
+++ b/dali/kernels/reduce/reduce_gpu.h
@@ -269,11 +269,11 @@ class DLL_PUBLIC InvStdDevGPU {
   using param_t = std::conditional_t<std::is_same<Out, double>::value, double, float>;
 
   /**
-   * @brief Caluclates regularized inverse standard deviation
+   * @brief Calculates regularized inverse standard deviation
    *
    * The output values are calculated as:
    * ```
-   * s = sum( (in[pos] - mean[reduced_pos])^2
+   * s = sum( (in[pos] - mean[reduced_pos])^2 )
    * out[reduced_pos] = s > 0 || reg > 0
    *                    ? 1/sqrt(s / reduction_factor + reg^2)
    *                    : 0

--- a/dali/kernels/reduce/reduce_gpu.h
+++ b/dali/kernels/reduce/reduce_gpu.h
@@ -298,7 +298,6 @@ class DLL_PUBLIC InvStdDevGPU {
   std::unique_ptr<Impl> impl_;
 };
 
-
 extern template class InvStdDevGPU<float, uint8_t>;
 extern template class InvStdDevGPU<float, int8_t>;
 
@@ -309,7 +308,6 @@ extern template class InvStdDevGPU<float, uint32_t>;
 extern template class InvStdDevGPU<float, int32_t>;
 
 extern template class InvStdDevGPU<float, float>;
-
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/reduce/reduce_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_gpu_impl.cuh
@@ -344,12 +344,10 @@ class ReduceImplGPU {
 
   /*
    * The functions below get the preprocessors and postprocessors.
-   * Note the is_first/is_last compile-time parameters. Overload resolution will pick the
-   * right function with distinct return type.
    * The function uses a helper class and have a default template arugment Derived = Actual
    * to make the return type a depenedent type.
    * To specialize these, define GetPreprocessorImpl, GetPostprocessorsImpl, etc in the
-   * Actual class. These functions don't need the std::true_type argument.
+   * Actual class. See `StdDevImplGPU` for usage example.
    */
 
   template <bool do_preprocess, int non_reduced_dim, typename Derived = Actual>

--- a/dali/kernels/reduce/reduce_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_gpu_impl.cuh
@@ -277,6 +277,34 @@ GetPreprocessorBanksHelper(bool_const<do_preprocess>, ...) {
   return nullptr;
 }
 
+/**
+ * @brief This is the base class for implementing reductions
+ *
+ * Implementing reductions:
+ * 1. Create a CRTP derived class MyReduction
+ * ```~~~~~~~~~~cpp
+ * template <typename In>
+ * class MyReduction : public ReduceImplGPU<float, In, float, MyReduction<In>>
+ * ```
+ * 2. Define your reduction function (to your class), e.g.:
+ * ```~~~~~~~~~~cpp
+ * reductions::sum GetReduction() const { return {}; }
+ * ```~~~~~~~~~~cpp
+ * 3. Add your pre/postprocessing functions:
+ * ```~~~~~~~~~~cpp
+ * MyPostprocessor GetPortprocessor(int sample_idx, bool reduce_batch) const { ... };
+ *
+ * MyPreprocessor GetPreprocessor(int sample_idx, bool reduce_batch) const { ... };
+ *
+ * template <int non_reduced_dims>
+ * MyPreprocessorBank<non_reduced_dims> *GetPreprocessorBanksImpl(WorkArea &wa) const { ... };
+ * ```
+ *
+ * You may need to add extra arguments to Run/Setup, in which case just shadow the original
+ * function(s) - you should call them at some point in your customized Run/Setup.
+ *
+ * See mean_stddev_gpu_impl.cuh for usage examples.
+ */
 template <typename Out, typename In, typename Acc, typename Actual>
 class ReduceImplGPU {
  public:

--- a/dali/kernels/reduce/reduce_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_gpu_impl.cuh
@@ -242,6 +242,9 @@ struct WorkArea {
 template <bool value>
 using bool_const = std::integral_constant<bool, value>;
 
+template <int value>
+using int_const = std::integral_constant<int, value>;
+
 
 template <typename ReduceImpl>
 auto GetPreprocessorHelper(std::true_type, const ReduceImpl *impl)
@@ -258,8 +261,8 @@ auto GetPreprocessorsHelper(std::true_type, const ReduceImpl *impl, WorkArea *wa
 template <int non_reduced_dims, typename ReduceImpl>
 auto GetPreprocessorBanksHelper(
       std::true_type, const ReduceImpl *impl, WorkArea *wa, int reduced_axis)
-      ->decltype(impl->template GetPreprocessorBanksImpl<non_reduced_dims>(*wa, reduced_axis)) {
-  return impl->template GetPreprocessorBanksImpl<non_reduced_dims>(*wa, reduced_axis);
+      ->decltype(impl->GetPreprocessorBanksImpl(*wa, reduced_axis, int_const<non_reduced_dims>())) {
+  return impl->GetPreprocessorBanksImpl(*wa, reduced_axis, int_const<non_reduced_dims>());
 }
 
 template <typename ReduceImpl>

--- a/dali/kernels/reduce/reduce_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_gpu_impl.cuh
@@ -319,7 +319,7 @@ class ReduceImplGPU {
   /// Get number of stages - for testing
   int GetNumStages() const { return stages_.size(); }
 
-  /// Trye, if reduction across input tensors was requested
+  /// True, if reduction across input tensors was requested
   bool ReduceBatch() const { return reduce_batch_; }
 
   /// Input shape after simplification (with merged dimensions)

--- a/dali/kernels/reduce/reduce_gpu_impl_test.cu
+++ b/dali/kernels/reduce/reduce_gpu_impl_test.cu
@@ -77,7 +77,7 @@ TEST(ReduceImplGPU, ReducedShape_SomeAxes_NoKeepDims_Batch) {
   TensorListShape<> ref = {{
     { 3, 5 }
   }};
-  int axes[] = { 1 };
+  int axes[] = { 1, 3 };
   TensorListShape<> out;
   CalculateReducedShape(out, in, make_span(axes), false, true);
   EXPECT_EQ(out, ref);

--- a/dali/kernels/reduce/reduce_gpu_test.cc
+++ b/dali/kernels/reduce/reduce_gpu_test.cc
@@ -21,6 +21,7 @@
 #include "dali/test/test_tensors.h"
 #include "dali/test/tensor_test_utils.h"
 #include "dali/core/tensor_shape_print.h"
+#include "dali/kernels/reduce/reduce_gpu_test.h"
 
 namespace dali {
 namespace kernels {
@@ -31,56 +32,19 @@ TEST(SumGPU, SplitStageBatch) {
     { 15, 3, 128000 },
     { 72000, 3, 7 }
   }};
-  int axes[] = { 0, 2 };
-  SumGPU<uint64_t, uint8_t> sum;
-  KernelContext ctx = {};
-  auto req = sum.Setup(ctx, in_shape, make_span(axes), false, true);
   TensorListShape<> ref_out_shape = {{
     TensorShape<>{3}
   }};
-  EXPECT_EQ(req.output_shapes[0], ref_out_shape);
+  int axes[] = { 0, 2 };
 
-  ScratchpadAllocator sa;
-  sa.Reserve(req.scratch_sizes);
-  auto scratchpad = sa.GetScratchpad();
-  ctx.scratchpad = &scratchpad;
+  testing::ReductionKernelTest<SumGPU<uint64_t, uint8_t>, uint64_t, uint8_t> test;
+  test.Setup(in_shape, ref_out_shape, make_span(axes), false, true);
+  test.FillData(0, 255);
+  test.Run();
 
-  std::mt19937_64 rng(12345);
+  RefReduce(test.ref.cpu(), test.in.cpu(), make_span(axes), false, true, reductions::sum());
 
-  TestTensorList<uint8_t> in;
-  in.reshape(in_shape);
-  auto in_cpu = in.cpu();
-  UniformRandomFill(in_cpu, rng, 0, 255);
-
-  TestTensorList<uint64_t> out;
-  out.reshape(req.output_shapes[0]);
-  sum.Run(ctx, out.gpu(), in.gpu());
-
-  auto out_cpu = out.cpu(ctx.gpu.stream);
-  TestTensorList<uint64_t> ref_samples, ref;
-  TensorListShape<> ref_samples_shape = {{
-    { 1, 3, 1 },
-    { 1, 3, 1 },
-    { 1, 3, 1 }
-  }};
-
-  ref.reshape(ref_out_shape);
-  ref_samples.reshape(ref_samples_shape);
-  auto ref_cpu = ref.cpu();
-  auto ref_samples_cpu = ref_samples.cpu();
-  int N = ref_samples_shape.num_samples();
-  for (int i = 0; i < N; i++) {
-    RefReduce(ref_samples_cpu[i], in_cpu[i], make_span(axes), reductions::sum());
-  }
-  int64_t n = ref_out_shape.num_elements();
-  for (int j = 0; j < n; j++) {
-    int64_t sum = 0;
-    for (int i = 0; i < N; i++)
-      sum += ref_samples_cpu.data[i][j];
-    ref_cpu.data[0][j] = sum;
-  }
-
-  Check(out_cpu, ref_cpu);
+  test.Check();
 }
 
 }  // namespace kernels

--- a/dali/kernels/reduce/reduce_gpu_test.h
+++ b/dali/kernels/reduce/reduce_gpu_test.h
@@ -1,0 +1,90 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_REDUCE_REDUCE_GPU_TEST_H_
+#define DALI_KERNELS_REDUCE_REDUCE_GPU_TEST_H_
+
+#include <gtest/gtest.h>
+#include <random>
+#include <utility>
+#include "dali/core/tensor_view.h"
+#include "dali/kernels/kernel_req.h"
+#include "dali/kernels/scratch.h"
+#include "dali/kernels/reduce/online_reducer.h"
+#include "dali/kernels/reduce/reduce_test.h"
+#include "dali/test/test_tensors.h"
+#include "dali/test/tensor_test_utils.h"
+
+namespace dali {
+namespace kernels {
+namespace testing {
+
+template <typename Kernel, typename Out, typename In>
+struct ReductionKernelTest {
+  Kernel kernel;
+  TestTensorList<In> in;
+  TestTensorList<Out> out, ref;
+
+  KernelContext ctx;
+  ScratchpadAllocator sa;
+  std::mt19937_64 rng{12345};
+
+
+  template <typename... Args>
+  KernelRequirements Setup(
+      const TensorListShape<> &in_shape,
+      const TensorListShape<> &ref_out_shape,
+      span<const int> axes, bool keep_dims, bool batch,
+      Args &&...args) {
+    in.reshape(in_shape);
+    ref.reshape(ref_out_shape);
+    auto req = kernel.Setup(ctx, in_shape, axes, keep_dims, batch, std::forward<Args>(args)...);
+    ASSERT_EQ(req.output_shapes.size(), 1), req;
+    ASSERT_EQ(req.output_shapes[0], ref_out_shape), req;
+    out.reshape(ref_out_shape);
+    sa.Reserve(req.scratch_sizes);
+    return req;
+  }
+
+  void FillData(In min_value, In max_value) {
+    UniformRandomFill(in.cpu(), rng, 0, 255);
+    cudaMemsetAsync(out.gpu().data[0], -1, sizeof(Out) * out.gpu().num_elements(), stream());
+  }
+
+  template <typename... Args>
+  void Run(Args &&...args) {
+    auto scratchpad = sa.GetScratchpad();
+    ctx.scratchpad = &scratchpad;
+    kernel.Run(ctx, out.gpu(stream()), in.gpu(stream()), std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  void Check(Args &&...args) {
+    auto out_cpu = out.cpu(stream());
+    CUDA_CALL(cudaStreamSynchronize(stream()));
+    dali::Check(out_cpu, ref.cpu(), std::forward<Args>(args)...);
+  }
+
+  cudaStream_t stream() const {
+    return ctx.gpu.stream;
+  }
+};
+
+
+}  // namespace testing
+}  // namespace kernels
+}  // namespace dali
+
+
+#endif  // DALI_KERNELS_REDUCE_REDUCE_GPU_TEST_H_

--- a/dali/kernels/reduce/reduce_setup_utils.h
+++ b/dali/kernels/reduce/reduce_setup_utils.h
@@ -191,10 +191,8 @@ inline void CalculateReducedShape(TensorListShape<> &out_shape,
   int out_dim = keep_dims ? in_dim : in_dim - axes.size();
   assert(out_dim >= 0);
 
-  if (out_dim == 0) {  // workaround until we have proper scalars
-    out_shape.resize(out_samples, 1);
-    for (int i = 0; i < out_samples; i++)
-      out_shape.tensor_shape_span(i)[0] = 1;
+  if (out_dim == 0) {
+    out_shape.resize(out_samples, 0);
     return;
   }
   out_shape.resize(out_samples, out_dim);

--- a/dali/kernels/reduce/reduce_setup_utils.h
+++ b/dali/kernels/reduce/reduce_setup_utils.h
@@ -204,11 +204,11 @@ inline void CalculateReducedShape(TensorListShape<> &out_shape,
     int out_d = 0;
     for (int d = 0; d < in_dim; d++) {
       if (mask & (1ul << d)) {
-      assert(out_d < out_dim);
         if (keep_dims)
           out_sample_shape[out_d++] = 1;
         continue;  // skip reduced axes
       }
+      assert(out_d < out_dim);
       out_sample_shape[out_d++] = in_sample_shape[d];
     }
     assert(out_d == out_dim);

--- a/dali/kernels/reduce/reduce_test.h
+++ b/dali/kernels/reduce/reduce_test.h
@@ -164,7 +164,7 @@ void RefReduce(const TensorListView<StorageCPU, Out> &out,
     }
   } else {
     assert(out.num_samples() == in.num_samples());
-    for (int i =0; i < in.num_samples(); i++) {
+    for (int i = 0; i < in.num_samples(); i++) {
       RefReduce(out[i], in[i], axes, keep_dims, R);
     }
   }

--- a/dali/kernels/reduce/stddev_gpu.cu
+++ b/dali/kernels/reduce/stddev_gpu.cu
@@ -93,18 +93,15 @@ void InvStdDevGPU<Out, In, Mean>::Run(
   impl_->Run(ctx, out, in, mean, reg);
 }
 
-template class InvStdDevGPU<uint8_t, uint8_t>;
 template class InvStdDevGPU<float, uint8_t>;
-template class InvStdDevGPU<int8_t, int8_t>;
 template class InvStdDevGPU<float, int8_t>;
-template class InvStdDevGPU<uint16_t, uint16_t>;
+
 template class InvStdDevGPU<float, uint16_t>;
-template class InvStdDevGPU<int16_t, int16_t>;
 template class InvStdDevGPU<float, int16_t>;
-template class InvStdDevGPU<int32_t, int32_t>;
-template class InvStdDevGPU<float, int32_t>;
-template class InvStdDevGPU<uint32_t, uint32_t>;
+
 template class InvStdDevGPU<float, uint32_t>;
+template class InvStdDevGPU<float, int32_t>;
+
 template class InvStdDevGPU<float, float>;
 
 }  // namespace kernels

--- a/dali/kernels/reduce/stddev_gpu.cu
+++ b/dali/kernels/reduce/stddev_gpu.cu
@@ -1,0 +1,111 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include "dali/kernels/reduce/reduce_gpu.h"
+#include "dali/kernels/reduce/mean_stddev_gpu_impl.cuh"
+
+namespace dali {
+namespace kernels {
+
+template <typename Out, typename In, typename Mean>
+class StdDevGPU<Out, In, Mean>::Impl : public reduce_impl::StdDevImplGPU<Out, In, Mean> {
+};
+
+template <typename Out, typename In, typename Mean>
+StdDevGPU<Out, In, Mean>::StdDevGPU() = default;
+
+template <typename Out, typename In, typename Mean>
+StdDevGPU<Out, In, Mean>::~StdDevGPU() = default;
+
+template <typename Out, typename In, typename Mean>
+KernelRequirements StdDevGPU<Out, In, Mean>::Setup(
+    KernelContext &ctx,
+    const TensorListShape<> &in_shape, span<const int> axes, bool keep_dims, bool reduce_batch) {
+  if (!impl_) {
+    impl_ = std::make_unique<Impl>();
+  }
+  return impl_->Setup(ctx, in_shape, axes, keep_dims, reduce_batch);
+}
+
+template <typename Out, typename In, typename Mean>
+void StdDevGPU<Out, In, Mean>::Run(KernelContext &ctx, const OutListGPU<Out> &out,
+                             const InListGPU<In> &in, const InListGPU<Mean> &mean) {
+  assert(impl_ != nullptr);
+  impl_->Run(ctx, out, in, mean);
+}
+
+
+template class StdDevGPU<uint8_t, uint8_t>;
+template class StdDevGPU<float, uint8_t>;
+template class StdDevGPU<int8_t, int8_t>;
+template class StdDevGPU<float, int8_t>;
+
+template class StdDevGPU<uint16_t, uint16_t>;
+template class StdDevGPU<float, uint16_t>;
+template class StdDevGPU<int16_t, int16_t>;
+template class StdDevGPU<float, int16_t>;
+
+template class StdDevGPU<uint32_t, uint32_t>;
+template class StdDevGPU<float, uint32_t>;
+template class StdDevGPU<int32_t, int32_t>;
+template class StdDevGPU<float, int32_t>;
+
+template class StdDevGPU<float, float>;
+
+
+template <typename Out, typename In, typename Mean>
+class InvStdDevGPU<Out, In, Mean>::Impl : public reduce_impl::InvStdDevImplGPU<Out, In, Mean> {
+};
+
+template <typename Out, typename In, typename Mean>
+InvStdDevGPU<Out, In, Mean>::InvStdDevGPU() = default;
+
+template <typename Out, typename In, typename Mean>
+InvStdDevGPU<Out, In, Mean>::~InvStdDevGPU() = default;
+
+template <typename Out, typename In, typename Mean>
+KernelRequirements InvStdDevGPU<Out, In, Mean>::Setup(
+    KernelContext &ctx,
+    const TensorListShape<> &in_shape, span<const int> axes, bool keep_dims, bool reduce_batch) {
+  if (!impl_) {
+    impl_ = std::make_unique<Impl>();
+  }
+  return impl_->Setup(ctx, in_shape, axes, keep_dims, reduce_batch);
+}
+
+template <typename Out, typename In, typename Mean>
+void InvStdDevGPU<Out, In, Mean>::Run(
+    KernelContext &ctx, const OutListGPU<Out> &out,
+    const InListGPU<In> &in, const InListGPU<Mean> &mean, param_t reg) {
+  assert(impl_ != nullptr);
+  impl_->Run(ctx, out, in, mean, reg);
+}
+
+template class InvStdDevGPU<uint8_t, uint8_t>;
+template class InvStdDevGPU<float, uint8_t>;
+template class InvStdDevGPU<int8_t, int8_t>;
+template class InvStdDevGPU<float, int8_t>;
+template class InvStdDevGPU<uint16_t, uint16_t>;
+template class InvStdDevGPU<float, uint16_t>;
+template class InvStdDevGPU<int16_t, int16_t>;
+template class InvStdDevGPU<float, int16_t>;
+template class InvStdDevGPU<int32_t, int32_t>;
+template class InvStdDevGPU<float, int32_t>;
+template class InvStdDevGPU<uint32_t, uint32_t>;
+template class InvStdDevGPU<float, uint32_t>;
+template class InvStdDevGPU<float, float>;
+
+}  // namespace kernels
+}  // namespace dali


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed because we want to have (directional) normalization.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added classes which implement pre- and post-processors
     * Added pre- and post-processing for mean, variance, root mean square and inverse, regularized root mean square
     * Added pImpl facades and instantiations thereof.
 - Affected modules and functionalities:
     * ReduceGPU
 - Key points relevant for the review:
     * the contents of `mean_stddev_gpu_impl.cuh`
 - Validation and testing:
     * Unit tests
 - Documentation (including examples):
     * Comments, Doxygen


**JIRA TASK**: DALI-1250
