### PR TITLE
Use user stream by default in copy_to_external/feed_ndarray

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -323,13 +323,13 @@ void ExposeTensor(py::module &m) {
     .def("copy_to_external",
         [](Tensor<GPUBackend> &t, py::object p, py::object cuda_stream, bool non_blocking) {
           void *ptr = ctypes_void_ptr(p);
-          cudaStream_t stream = static_cast<cudaStream_t>(
-            ctypes_void_ptr(cuda_stream));
-
+          cudaStream_t stream = cuda_stream.is_none()
+                ? UserStream::Get()->GetStream(t)
+                : static_cast<cudaStream_t>(ctypes_void_ptr(cuda_stream));
           CopyToExternalTensor(t, ptr, GPU, stream, non_blocking);
         },
       "ptr"_a,
-      "cuda_stream"_a = 0,
+      "cuda_stream"_a = py::none(),
       "non_blocking"_a = false,
       R"code(
       Copy to external pointer in the GPU memory.
@@ -656,12 +656,13 @@ void ExposeTensorList(py::module &m) {
     .def("copy_to_external",
         [](TensorList<GPUBackend> &t, py::object p, py::object cuda_stream, bool non_blocking) {
           void *ptr = ctypes_void_ptr(p);
-          cudaStream_t stream = static_cast<cudaStream_t>(
-            ctypes_void_ptr(cuda_stream));
+          cudaStream_t stream = cuda_stream.is_none()
+                ? UserStream::Get()->GetStream(t)
+                : static_cast<cudaStream_t>(ctypes_void_ptr(cuda_stream));
           CopyToExternalTensor(&t, ptr, GPU, stream, non_blocking);
         },
       "ptr"_a,
-      "cuda_stream"_a = 0,
+      "cuda_stream"_a = py::none(),
       "non_blocking"_a = false,
       R"code(
       Copy the contents of this `TensorList` to an external pointer

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from nvidia.dali.backend import TensorGPU, TensorListGPU
 from nvidia.dali.pipeline import Pipeline
 from nvidia.dali import types
 import mxnet as mx
@@ -60,7 +61,7 @@ def feed_ndarray(dali_tensor, arr, cuda_stream = None):
     ptr = ctypes.c_void_p()
     mx.base._LIB.MXNDArrayGetData(arr.handle, ctypes.byref(ptr))
     # Copy data from DALI tensor to ptr
-    if isinstance(dali_tensor, nvidia.dali.backend.TensorGPU):
+    if isinstance(dali_tensor, (TensorGPU, TensorListGPU)):
         dali_tensor.copy_to_external(ptr, cuda_stream)
     else:
         dali_tensor.copy_to_external(ptr)
@@ -325,7 +326,6 @@ class DALIGenericIterator(_DALIIteratorBase):
             if self._data_batches[i][self._current_data_batch] is None:
                 mx_gpu_device = mx.gpu(self._pipes[i].device_id)
                 mx_cpu_device = mx.cpu(0)
-                from nvidia.dali.backend import TensorGPU
                 category_device = {key : [] for key in self._output_categories}
                 for category in self._output_categories:
                     for t in category_tensors[category]:
@@ -683,7 +683,6 @@ class DALIGluonIterator(_DALIIteratorBase):
     def _create_data_batch(self, output_elements, shapes, device_id):
         mx_gpu_device = mx.gpu(device_id)
         mx_cpu_device = mx.cpu(0)
-        from nvidia.dali.backend import TensorGPU
         new_batch = []
         for j, output_el in enumerate(output_elements):
             first_t = output_el if self._outputs_types is None or self._outputs_types[j] == DALIGluonIterator.DENSE_TAG else output_el[0]

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -51,6 +51,8 @@ def feed_ndarray(dali_tensor, arr, cuda_stream = None):
     `cuda_stream` : Any value that can be casted to cudaStream_t
                     CUDA stream to be used for the copy
                     (if not provided, an internal user stream will be selected)
+                    In most cases, using the default internal user stream or stream 0
+                    is expected.
     """
     # Wait until arr is no longer used by the engine
     _wait_to_write(arr)

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -75,7 +75,7 @@ def feed_ndarray(dali_tensor, ptr, cuda_stream = None):
                     (if not provided, an internal user stream will be selected)
     """
     c_type_pointer = ctypes.c_void_p(ptr)
-    if isinstance(dali_tensor, nvidia.dali.backend.TensorGPU):
+    if isinstance(dali_tensor, (TensorGPU, TensorListGPU)):
         dali_tensor.copy_to_external(c_type_pointer, cuda_stream)
     else:
         dali_tensor.copy_to_external(c_type_pointer)

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -60,7 +60,7 @@ def to_paddle_type(tensor):
     return dtype_map[dtype]
 
 
-def feed_ndarray(dali_tensor, ptr):
+def feed_ndarray(dali_tensor, ptr, cuda_stream = None):
     """
     Copy contents of DALI tensor to Paddle's Tensor.
 
@@ -70,9 +70,15 @@ def feed_ndarray(dali_tensor, ptr):
                     Tensor from which to copy
     `ptr` : LoDTensor data pointer
             Destination of the copy
+    `cuda_stream` : Any value that can be casted to cudaStream_t
+                    CUDA stream to be used for the copy
+                    (if not provided, an internal user stream will be selected)
     """
     c_type_pointer = ctypes.c_void_p(ptr)
-    dali_tensor.copy_to_external(c_type_pointer)
+    if isinstance(dali_tensor, nvidia.dali.backend.TensorGPU):
+        dali_tensor.copy_to_external(c_type_pointer, cuda_stream)
+    else:
+        dali_tensor.copy_to_external(c_type_pointer)
     return ptr
 
 

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -51,6 +51,8 @@ def feed_ndarray(dali_tensor, arr, cuda_stream = None):
     `cuda_stream` : torch.cuda.Stream or any value that can be casted to cudaStream_t
                     CUDA stream to be used for the copy
                     (if not provided, an internal user stream will be selected)
+                    In most cases, using pytorch's current stream is expected (for example,
+                    if we are copying to a tensor allocated with torch.zeros(...))
     """
     assert dali_tensor.shape() == list(arr.size()), \
             ("Shapes do not match: DALI tensor has size {0}"


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to have the possibility to use DALI's internal user stream by default (instead of using default CUDA stream) while keeping the possibility to specify the stream manually

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Change default CUDA stream to `py::none` which means "use the internal user stream". The user can always specify cuda_stream=0 explicitly to use the CUDA default stream, or specify any other stream*
 - Affected modules and functionalities:
     *copy_to_external*
 - Key points relevant for the review:
     *Everything*
 - Validation and testing:
     *Existing tests*
 - Documentation (including examples):
     *Doc str updated*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
