### PR TITLE
Use only ImportError in setup_packages

### DIFF
--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -7,10 +7,10 @@ from pip._vendor.packaging.version import parse
 import urllib.parse
 try:
     import pip._internal.utils.compatibility_tags as p
-except (ModuleNotFoundError, ImportError):
+except ImportError:
     try:
         import pip._internal.pep425tags as p
-    except (ModuleNotFoundError, ImportError):
+    except ImportError:
         import pip.pep425tags as p
 try:
     # For Python 3.0 and later


### PR DESCRIPTION
ModuleNotFoundError does not exist in Python 3.5

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fix CI compatibility with different Python versions.

#### What happened in this PR?
 - What solution was applied:
     Removed unsupported exception type
 - Affected modules and functionalities:
     QA tests
 - Key points relevant for the review:
	N/a
 - Validation and testing:
     CI
 - Documentation (including examples):
     NO


**JIRA TASK**: *[NA]*
