### PR TITLE
Fix TL1_python-nvjpeg_test test dependency

### DIFF
--- a/qa/TL1_python-nvjpeg_test/test.sh
+++ b/qa/TL1_python-nvjpeg_test/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages=""
+pip_packages="numpy"
 target_dir=./dali/test/python
 
 do_once() {


### PR DESCRIPTION
- after https://github.com/NVIDIA/DALI/pull/1909 test_data_containers.py needs NumPy to be installed which is a missing dependency in  TL1_python-nvjpeg_test. This PR adds NumPy to TL1_python-nvjpeg_test

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a TL1_python-nvjpeg_test test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     after https://github.com/NVIDIA/DALI/pull/1909 test_data_containers.py needs NumPy to be installed which is a missing dependency in  TL1_python-nvjpeg_test. This PR adds NumPy to TL1_python-nvjpeg_test
 - Affected modules and functionalities:
     TL1_python-nvjpeg_test
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
