### PR TITLE
Strip more unneeded info from DALI wheel

### DIFF
--- a/docker/build_helper.sh
+++ b/docker/build_helper.sh
@@ -100,7 +100,7 @@ if [ "${BUILD_PYTHON}" = "ON" ]; then
         export UNZIP_PATH="$(mktemp -d)"
         unzip $WHEEL -d $UNZIP_PATH
         for f in $(find $UNZIP_PATH -iname *.so); do
-            strip --strip-debug $f
+            strip --strip-unneeded $f
         done
         rm -f $WHEEL
         pushd $UNZIP_PATH


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds more aggressive striping of DALI binaries to shrink its size

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     changed strip argument from `--strip-debug` to `--strip-unneeded`
 - Affected modules and functionalities:
     DALI wheel and binaries
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
