### PR TITLE
Proper DALI initialization in process & daliInitialize function

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -160,8 +160,8 @@ macro(collect_sources DALI_SRCS_GROUP)
     "" # multi value keywords
     ${ARGV})
 
-  file(GLOB collect_sources_tmp *.cc *.cu)
-  file(GLOB collect_sources_tmp_test *_test.cc *_test.cu)
+  file(GLOB collect_sources_tmp *.cc *.cu *.c)
+  file(GLOB collect_sources_tmp_test *_test.cc *_test.cu *_test.c)
   remove(collect_sources_tmp "${collect_sources_tmp}" ${collect_sources_tmp_test})
   set(${DALI_SRCS_GROUP} ${${DALI_SRCS_GROUP}} ${collect_sources_tmp})
   if (COLLECT_SOURCES_PARENT_SCOPE)
@@ -183,7 +183,7 @@ macro(collect_test_sources DALI_TEST_SRCS_GROUP)
     "" # multi value keywords
     ${ARGV})
 
-  file(GLOB collect_test_sources_tmp_test *_test.cc *_test.cu)
+  file(GLOB collect_test_sources_tmp_test *_test.cc *_test.cu *_test.c)
   set(${DALI_TEST_SRCS_GROUP} ${${DALI_TEST_SRCS_GROUP}} ${collect_test_sources_tmp_test})
   if (COLLECT_TEST_SOURCES_PARENT_SCOPE)
     set(${DALI_TEST_SRCS_GROUP} ${${DALI_TEST_SRCS_GROUP}} PARENT_SCOPE)

--- a/dali/benchmark/dali_bench.cc
+++ b/dali/benchmark/dali_bench.cc
@@ -19,7 +19,7 @@
 #include "dali/core/common.h"
 #include "dali/pipeline/data/allocator.h"
 #include "dali/pipeline/init.h"
-#include "dali/operators/operators.h"
+#include "dali/operators.h"
 #include "dali/pipeline/operator/op_spec.h"
 
 int main(int argc, char **argv) {

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@
 #include "dali/core/cuda_stream.h"
 #include "dali/core/format.h"
 #include "dali/core/tensor_shape.h"
+#include "dali/operators/operators.h"
+#include "dali/pipeline/init.h"
 #include "dali/pipeline/pipeline.h"
 #include "dali/plugin/copy.h"
 #include "dali/plugin/plugin_manager.h"
@@ -29,6 +31,9 @@
 #include "dali/pipeline/data/backend.h"
 
 namespace {
+
+bool dali_initialized = false;
+
 
 template<typename Backend>
 void SetExternalInput(daliPipelineHandle *pipe_handle, const char *name, const void *data_ptr,
@@ -82,21 +87,35 @@ void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
 
 }  // namespace
 
+daliPipelineHandle *daliInitialize() {
+  if (dali_initialized) {
+    return nullptr;
+  }
+  dali::InitOperatorsLib();
+  dali::DALIInit(dali::OpSpec("CPUAllocator"),
+                 dali::OpSpec("PinnedCPUAllocator"),
+                 dali::OpSpec("GPUAllocator"));
+  dali_initialized = true;
+  return new daliPipelineHandle;
+}
+
+
 void daliCreatePipeline(daliPipelineHandle *pipe_handle,
                         const char *serialized_pipeline,
                         int length,
                         int batch_size,
                         int num_threads,
                         int device_id,
-                        bool separated_execution,
+                        int separated_execution,
                         int prefetch_queue_depth,
                         int cpu_prefetch_queue_depth,
                         int gpu_prefetch_queue_depth) {
+  bool se = separated_execution > 0;
   auto pipeline = std::make_unique<dali::Pipeline>(std::string(serialized_pipeline, length),
                                                    batch_size, num_threads, device_id, true,
                                                    prefetch_queue_depth, true);
-  pipeline->SetExecutionTypes(true, separated_execution, true);
-  if (separated_execution) {
+  pipeline->SetExecutionTypes(true, se, true);
+  if (se) {
     pipeline->SetQueueSizes(cpu_prefetch_queue_depth, gpu_prefetch_queue_depth);
   }
   pipeline->Build();
@@ -363,13 +382,14 @@ static void daliCopyTensorListNToHelper(dali::DeviceWorkspace* ws, void* dst, in
 }
 
 void daliCopyTensorListNTo(daliPipelineHandle* pipe_handle, void* dst, int n,
-                           device_type_t dst_type, cudaStream_t stream, bool non_blocking) {
+                           device_type_t dst_type, cudaStream_t stream, int non_blocking) {
+  bool nb = non_blocking > 0;
   dali::TimeRange tr("daliCopyTensorNTo", dali::TimeRange::kGreen);
   dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
   if (ws->OutputIsType<dali::CPUBackend>(n)) {
-    daliCopyTensorListNToHelper<dali::CPUBackend>(ws, dst, n, dst_type, stream, non_blocking);
+    daliCopyTensorListNToHelper<dali::CPUBackend>(ws, dst, n, dst_type, stream, nb);
   } else {
-    daliCopyTensorListNToHelper<dali::GPUBackend>(ws, dst, n, dst_type, stream, non_blocking);
+    daliCopyTensorListNToHelper<dali::GPUBackend>(ws, dst, n, dst_type, stream, nb);
   }
 }
 
@@ -383,13 +403,14 @@ static void daliCopyTensorNToHelper(dali::DeviceWorkspace* ws, void* dst, int n,
 }
 
 void daliCopyTensorNTo(daliPipelineHandle* pipe_handle, void* dst, int n, device_type_t dst_type,
-                       cudaStream_t stream, bool non_blocking) {
+                       cudaStream_t stream, int non_blocking) {
+  bool nb = non_blocking > 0;
   dali::TimeRange tr("daliCopyTensorNTo", dali::TimeRange::kGreen);
   dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
   if (ws->OutputIsType<dali::CPUBackend>(n)) {
-    daliCopyTensorNToHelper<dali::CPUBackend>(ws, dst, n, dst_type, stream, non_blocking);
+    daliCopyTensorNToHelper<dali::CPUBackend>(ws, dst, n, dst_type, stream, nb);
   } else {
-    daliCopyTensorNToHelper<dali::GPUBackend>(ws, dst, n, dst_type, stream, non_blocking);
+    daliCopyTensorNToHelper<dali::GPUBackend>(ws, dst, n, dst_type, stream, nb);
   }
 }
 
@@ -403,6 +424,8 @@ void daliDeletePipeline(daliPipelineHandle* pipe_handle) {
   delete pipeline;
   pipe_handle->ws = nullptr;
   pipe_handle->pipe = nullptr;
+  pipe_handle = nullptr;
+  dali_initialized = false;
 }
 
 void daliLoadLibrary(const char* lib_path) {

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -22,7 +22,6 @@
 #include "dali/core/cuda_stream.h"
 #include "dali/core/format.h"
 #include "dali/core/tensor_shape.h"
-#include "dali/operators.h"
 #include "dali/pipeline/init.h"
 #include "dali/pipeline/pipeline.h"
 #include "dali/plugin/copy.h"
@@ -108,7 +107,7 @@ void daliCreatePipeline(daliPipelineHandle *pipe_handle,
                         int prefetch_queue_depth,
                         int cpu_prefetch_queue_depth,
                         int gpu_prefetch_queue_depth) {
-  bool se = separated_execution > 0;
+  bool se = separated_execution != 0;
   auto pipeline = std::make_unique<dali::Pipeline>(std::string(serialized_pipeline, length),
                                                    batch_size, num_threads, device_id, true,
                                                    prefetch_queue_depth, true);
@@ -381,7 +380,7 @@ static void daliCopyTensorListNToHelper(dali::DeviceWorkspace* ws, void* dst, in
 
 void daliCopyTensorListNTo(daliPipelineHandle* pipe_handle, void* dst, int n,
                            device_type_t dst_type, cudaStream_t stream, int non_blocking) {
-  bool nb = non_blocking > 0;
+  bool nb = non_blocking != 0;
   dali::TimeRange tr("daliCopyTensorNTo", dali::TimeRange::kGreen);
   dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
   if (ws->OutputIsType<dali::CPUBackend>(n)) {

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -88,12 +88,14 @@ void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
 
 
 void daliInitialize() {
-  if (!dali_initialized) {
-    dali::DALIInit(dali::OpSpec("CPUAllocator"),
-                   dali::OpSpec("PinnedCPUAllocator"),
-                   dali::OpSpec("GPUAllocator"));
-    dali_initialized = true;
-  }
+  static std::once_flag init_flag;
+  auto init = [&] {
+      dali::DALIInit(dali::OpSpec("CPUAllocator"),
+                     dali::OpSpec("PinnedCPUAllocator"),
+                     dali::OpSpec("GPUAllocator"));
+      dali_initialized = true;
+  };
+  std::call_once(init_flag, init);
 }
 
 

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -89,7 +89,7 @@ void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
 
 void daliInitialize() {
   static std::once_flag init_flag;
-  auto init = [&dali_initialized] {
+  auto init = [&] {
       dali::DALIInit(dali::OpSpec("CPUAllocator"),
                      dali::OpSpec("PinnedCPUAllocator"),
                      dali::OpSpec("GPUAllocator"));

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -89,7 +89,7 @@ void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
 
 void daliInitialize() {
   static std::once_flag init_flag;
-  auto init = [&] {
+  auto init = [&dali_initialized] {
       dali::DALIInit(dali::OpSpec("CPUAllocator"),
                      dali::OpSpec("PinnedCPUAllocator"),
                      dali::OpSpec("GPUAllocator"));
@@ -403,7 +403,7 @@ static void daliCopyTensorNToHelper(dali::DeviceWorkspace* ws, void* dst, int n,
 
 void daliCopyTensorNTo(daliPipelineHandle* pipe_handle, void* dst, int n, device_type_t dst_type,
                        cudaStream_t stream, int non_blocking) {
-  bool nb = non_blocking > 0;
+  bool nb = non_blocking != 0;
   dali::TimeRange tr("daliCopyTensorNTo", dali::TimeRange::kGreen);
   dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
   if (ws->OutputIsType<dali::CPUBackend>(n)) {

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -87,16 +87,15 @@ void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
 
 }  // namespace
 
-daliPipelineHandle *daliInitialize() {
-  if (dali_initialized) {
-    return nullptr;
+
+void daliInitialize() {
+  if (!dali_initialized) {
+    dali::InitOperatorsLib();
+    dali::DALIInit(dali::OpSpec("CPUAllocator"),
+                   dali::OpSpec("PinnedCPUAllocator"),
+                   dali::OpSpec("GPUAllocator"));
+    dali_initialized = true;
   }
-  dali::InitOperatorsLib();
-  dali::DALIInit(dali::OpSpec("CPUAllocator"),
-                 dali::OpSpec("PinnedCPUAllocator"),
-                 dali::OpSpec("GPUAllocator"));
-  dali_initialized = true;
-  return new daliPipelineHandle;
 }
 
 
@@ -424,9 +423,6 @@ void daliDeletePipeline(daliPipelineHandle* pipe_handle) {
   delete pipeline;
   pipe_handle->ws = nullptr;
   pipe_handle->pipe = nullptr;
-  delete pipe_handle;
-  pipe_handle = nullptr;
-  dali_initialized = false;
 }
 
 void daliLoadLibrary(const char* lib_path) {

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -424,6 +424,7 @@ void daliDeletePipeline(daliPipelineHandle* pipe_handle) {
   delete pipeline;
   pipe_handle->ws = nullptr;
   pipe_handle->pipe = nullptr;
+  delete pipe_handle;
   pipe_handle = nullptr;
   dali_initialized = false;
 }

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -22,7 +22,7 @@
 #include "dali/core/cuda_stream.h"
 #include "dali/core/format.h"
 #include "dali/core/tensor_shape.h"
-#include "dali/operators/operators.h"
+#include "dali/operators.h"
 #include "dali/pipeline/init.h"
 #include "dali/pipeline/pipeline.h"
 #include "dali/plugin/copy.h"
@@ -90,7 +90,6 @@ void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
 
 void daliInitialize() {
   if (!dali_initialized) {
-    dali::InitOperatorsLib();
     dali::DALIInit(dali::OpSpec("CPUAllocator"),
                    dali::OpSpec("PinnedCPUAllocator"),
                    dali::OpSpec("GPUAllocator"));

--- a/dali/c_api/c_api_test.c
+++ b/dali/c_api/c_api_test.c
@@ -12,5 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/c_api.h" 
-
+#include "dali/c_api.h"

--- a/dali/c_api/c_api_test.c
+++ b/dali/c_api/c_api_test.c
@@ -1,0 +1,16 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/c_api.h" 
+

--- a/dali/operators/operators.cc
+++ b/dali/operators/operators.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,18 @@
 // limitations under the License.
 
 #include "dali/core/api_helper.h"
-#include "dali/operators/operators.h"
+#include "dali/operators.h"
 
+/*
+ * The point of these functions is to force the linker to link against dali_operators lib
+ * and not optimize-out symbols from dali_operators
+ */
+
+#ifdef __cplusplus
 namespace dali {
 DLL_PUBLIC void InitOperatorsLib() {}
 }  // namespace dali
+DLL_PUBLIC void daliInitOperators() {}
+#else
+DLL_PUBLIC void daliInitOperators() {}
+#endif

--- a/dali/operators/operators.cc
+++ b/dali/operators/operators.cc
@@ -18,6 +18,9 @@
 /*
  * The point of these functions is to force the linker to link against dali_operators lib
  * and not optimize-out symbols from dali_operators
+ *
+ * The functions to reference, when one needs to make sure DALI operators
+ * shared object is actually linked against.
  */
 
 namespace dali {

--- a/dali/operators/operators.cc
+++ b/dali/operators/operators.cc
@@ -20,11 +20,8 @@
  * and not optimize-out symbols from dali_operators
  */
 
-#ifdef __cplusplus
 namespace dali {
 DLL_PUBLIC void InitOperatorsLib() {}
 }  // namespace dali
-DLL_PUBLIC void daliInitOperators() {}
-#else
-DLL_PUBLIC void daliInitOperators() {}
-#endif
+
+extern "C" DLL_PUBLIC void daliInitOperators() {}

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -28,7 +28,7 @@
 #include "dali/util/half.hpp"
 #include "dali/core/device_guard.h"
 #include "dali/core/python_util.h"
-#include "dali/operators/operators.h"
+#include "dali/operators.h"
 
 namespace dali {
 namespace python {

--- a/dali/test/dali_test.cc
+++ b/dali/test/dali_test.cc
@@ -18,7 +18,7 @@
 #include "dali/pipeline/data/allocator.h"
 #include "dali/pipeline/operator/op_spec.h"
 #include "dali/test/dali_test_config.h"
-#include "dali/operators/operators.h"
+#include "dali/operators.h"
 
 int main(int argc, char **argv) {
   dali::DALIInit(dali::OpSpec("CPUAllocator"),

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 
 #include <cuda_runtime_api.h>
 #include <inttypes.h>
-#include <stdbool.h>
 #include "dali/core/api_helper.h"
 
 // Trick to bypass gcc4.9 old ABI name mangling used by TF
@@ -58,6 +57,13 @@ typedef enum {
   DALI_BOOL     =  11,
 } dali_data_type_t;
 
+
+/**
+ * @brief DALI initialization
+ * @return The handle object
+ */
+DLL_PUBLIC daliPipelineHandle *daliInitialize();
+
 /// @{
 /**
  * @brief Create DALI pipeline. Setting batch_size,
@@ -74,7 +80,7 @@ DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle,
                                    int batch_size,
                                    int num_threads,
                                    int device_id,
-                                   bool separated_execution,
+                                   int separated_execution,
                                    int prefetch_queue_depth,
                                    int cpu_prefetch_queue_depth,
                                    int gpu_prefetch_queue_depth);
@@ -261,23 +267,24 @@ DLL_PUBLIC size_t daliMaxDimTensors(daliPipelineHandle *pipe_handle, int n);
  * dst_type (0 - CPU, 1 - GPU)
  * @remarks Tensor list doesn't need to be dense
  */
-DLL_PUBLIC void daliCopyTensorListNTo(daliPipelineHandle *pipe_handle, void *dst, int n,
-                                      device_type_t dst_type, cudaStream_t stream,
-                                      bool non_blocking);
+DLL_PUBLIC void
+daliCopyTensorListNTo(daliPipelineHandle *pipe_handle, void *dst, int n, device_type_t dst_type,
+                      cudaStream_t stream, int non_blocking);
 
 /**
  * @brief Returns number of DALI pipeline outputs
  */
 DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle);
+
 /**
  * @brief Copy the output tensor stored
  * at position `n` in the pipeline.
  * dst_type (0 - CPU, 1 - GPU)
  * @remarks If the output is tensor list then it need to be dense
  */
-DLL_PUBLIC void daliCopyTensorNTo(daliPipelineHandle *pipe_handle, void *dst, int n,
-                                  device_type_t dst_type, cudaStream_t stream,
-                                  bool non_blocking);
+DLL_PUBLIC void
+daliCopyTensorNTo(daliPipelineHandle *pipe_handle, void *dst, int n, device_type_t dst_type,
+                  cudaStream_t stream, int non_blocking);
 
 /**
  * @brief Delete the pipeline object.

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -61,9 +61,11 @@ typedef enum {
 /**
  * @brief DALI initialization
  *
- * Call this function to initialize DALI. It shall be called once per process.
- * Along with this, you'll need to call @see daliInitOperatorsLib function from
- * `operators.h` file.
+ * Call this function to initialize DALI backend. It shall be called once per process.
+ * Along with this, you'll need to call @see daliInitOperatorsLib() function from
+ * `operators.h` file, to initialize whole DALI.
+ * In the unlikely event you'd like to use only Pipeline and Executor (no Operators),
+ * you may pass on calling @see daliInitOperatorsLib()
  */
 DLL_PUBLIC void daliInitialize();
 

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -17,6 +17,7 @@
 
 #include <cuda_runtime_api.h>
 #include <inttypes.h>
+#include <stdbool.h>
 #include "dali/core/api_helper.h"
 
 // Trick to bypass gcc4.9 old ABI name mangling used by TF

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -273,7 +273,7 @@ DLL_PUBLIC size_t daliMaxDimTensors(daliPipelineHandle *pipe_handle, int n);
  * @remarks Tensor list doesn't need to be dense
  *
  * If you call this function with non_blocking != 0, make sure to
- * synchronize on provided stream before reading the data.
+ * synchronize with the provided stream before reading the data.
  * If non_blocking == 0, function will do it for you
  */
 DLL_PUBLIC void

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -60,7 +60,10 @@ typedef enum {
 
 /**
  * @brief DALI initialization
- * @return The handle object
+ *
+ * Call this function to initialize DALI. It shall be called once per process.
+ * Along with this, you'll need to call @see daliInitOperatorsLib function from
+ * `operators.h` file.
  */
 DLL_PUBLIC void daliInitialize();
 
@@ -69,9 +72,9 @@ DLL_PUBLIC void daliInitialize();
  * @brief Create DALI pipeline. Setting batch_size,
  * num_threads or device_id here overrides
  * values stored in the serialized pipeline.
- * When separated_execution is false, prefetch_queue_depth is considered,
+ * When separated_execution is equal to 0, prefetch_queue_depth is considered,
  * gpu_prefetch_queue_depth and cpu_prefetch_queue_depth are ignored.
- * When separated_execution is true, cpu_prefetch_queue_depth and
+ * When separated_execution is not equal to 0, cpu_prefetch_queue_depth and
  * gpu_prefetch_queue_depth are considered and prefetch_queue_depth is ignored.
  */
 DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle,
@@ -266,6 +269,10 @@ DLL_PUBLIC size_t daliMaxDimTensors(daliPipelineHandle *pipe_handle, int n);
  * at position `n` in the pipeline.
  * dst_type (0 - CPU, 1 - GPU)
  * @remarks Tensor list doesn't need to be dense
+ *
+ * If you call this function with non_blocking != 0, make sure to
+ * synchronize on provided stream before reading the data.
+ * If non_blocking == 0, function will do it for you
  */
 DLL_PUBLIC void
 daliCopyTensorListNTo(daliPipelineHandle *pipe_handle, void *dst, int n, device_type_t dst_type,
@@ -281,6 +288,10 @@ DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle);
  * at position `n` in the pipeline.
  * dst_type (0 - CPU, 1 - GPU)
  * @remarks If the output is tensor list then it need to be dense
+ *
+ * If you call this function with non_blocking != 0, make sure to
+ * synchronize on provided stream before reading the data.
+ * If non_blocking == 0, function will do it for you
  */
 DLL_PUBLIC void
 daliCopyTensorNTo(daliPipelineHandle *pipe_handle, void *dst, int n, device_type_t dst_type,

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -62,7 +62,7 @@ typedef enum {
  * @brief DALI initialization
  * @return The handle object
  */
-DLL_PUBLIC daliPipelineHandle *daliInitialize();
+DLL_PUBLIC void daliInitialize();
 
 /// @{
 /**

--- a/include/dali/operators.h
+++ b/include/dali/operators.h
@@ -21,9 +21,10 @@ namespace dali {
 /**
  * @brief Functions to initialize operators in DALI
  *
- * You should call this function once per process.
- * Remember to also call @see daliInitialize() from `c_api.h` to initialize DALI.
- * Use either InitOperatorsLib or daliInitOperators, depending whether you use C++ or C API
+ * Remember to also call @see daliInitialize() from `c_api.h` to initialize whole DALI backend.
+ * Use either InitOperatorsLib or daliInitOperators, depending whether you use C++ or C API.
+ * This function initializes operators' library. In case you use only Operators
+ * (no Executor or Pipeline), you may pass on @see daliInitialize().
  */
 void InitOperatorsLib();
 }  // namespace dali
@@ -31,10 +32,12 @@ extern "C" void daliInitOperators();
 ///@}
 #else
 /**
- * @brief Function to initialize operators in DALI
+ * @brief Functions to initialize operators in DALI
  *
- * You should call this function once per process.
- * Remember to also call @see daliInitialize() from `c_api.h` to initialize DALI.
+ * Remember to also call @see daliInitialize() from `c_api.h` to initialize whole DALI backend.
+ * Use either InitOperatorsLib or daliInitOperators, depending whether you use C++ or C API.
+ * This function initializes operators' library. In case you use only Operators
+ * (no Executor or Pipeline), you may pass on @see daliInitialize().
  */
 void daliInitOperators();
 #endif

--- a/include/dali/operators.h
+++ b/include/dali/operators.h
@@ -16,10 +16,10 @@
 #define DALI_OPERATORS_H_
 
 #ifdef __cplusplus
-namespace dali {
 ///@{
+namespace dali {
 /**
- * @brief Function to initialize operators in DALI
+ * @brief Functions to initialize operators in DALI
  *
  * You should call this function once per process.
  * Remember to also call @see daliInitialize() from `c_api.h` to initialize DALI.
@@ -28,9 +28,16 @@ namespace dali {
 void InitOperatorsLib();
 }  // namespace dali
 extern "C" void daliInitOperators();
+///@}
 #else
+/**
+ * @brief Function to initialize operators in DALI
+ *
+ * You should call this function once per process.
+ * Remember to also call @see daliInitialize() from `c_api.h` to initialize DALI.
+ */
 void daliInitOperators();
 #endif
-///@}
+
 
 #endif  // DALI_OPERATORS_H_

--- a/include/dali/operators.h
+++ b/include/dali/operators.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_OPERATORS_OPERATORS_H_
-#define DALI_OPERATORS_OPERATORS_H_
+#ifndef DALI_OPERATORS_H_
+#define DALI_OPERATORS_H_
 
+#ifdef __cplusplus
 namespace dali {
 /**
  * @brief The function to reference, when one needs to make sure DALI operators shared
  *        object is actually linked against.
  */
-DLL_PUBLIC void InitOperatorsLib();
+void InitOperatorsLib();
 }  // namespace dali
+extern "C" void daliInitOperators();
+#else
+void daliInitOperators();
+#endif
 
-#endif  // DALI_OPERATORS_OPERATORS_H_
+#endif  // DALI_OPERATORS_H_

--- a/include/dali/operators.h
+++ b/include/dali/operators.h
@@ -17,9 +17,13 @@
 
 #ifdef __cplusplus
 namespace dali {
+///@{
 /**
- * @brief The function to reference, when one needs to make sure DALI operators shared
- *        object is actually linked against.
+ * @brief Function to initialize operators in DALI
+ *
+ * You should call this function once per process.
+ * Remember to also call @see daliInitialize() from `c_api.h` to initialize DALI.
+ * Use either InitOperatorsLib or daliInitOperators, depending whether you use C++ or C API
  */
 void InitOperatorsLib();
 }  // namespace dali
@@ -27,5 +31,6 @@ extern "C" void daliInitOperators();
 #else
 void daliInitOperators();
 #endif
+///@}
 
 #endif  // DALI_OPERATORS_H_


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds a new test, that verifies if `c_api.h` build for C compiler
- Add `daliInitialize` as a enhancement to C API
- Add function to initialize operators library for C API. From now on, there are 2 includes required for C API: `c_api.h` and `operators.h`



