### PR TITLE
Test that verifies using DALI as a submodule

### DIFF
--- a/qa/TL1_git_submodule/test.sh
+++ b/qa/TL1_git_submodule/test.sh
@@ -21,7 +21,7 @@ target_link_libraries(test_lib PUBLIC DALI::dali DALI::dali_core DALI::dali_kern
 " > CMakeLists.txt
     mkdir build
     pushd build
-    cmake ..
+    cmake -D CUDA_TARGET_ARCHS=60 -D CMAKE_BUILD_TYPE=Debug ..
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 }
 

--- a/qa/TL1_git_submodule/test.sh
+++ b/qa/TL1_git_submodule/test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+test_body() {
+    mkdir -p /tmp/repo_that_uses_dali
+    cd /tmp/repo_that_uses_dali
+    git init
+    git submodule add -b dali_as_submodule https://github.com/AlexBula/DALI
+    cd DALI
+    git submodule sync --recursive
+    git submodule update --init --recursive
+    cd -
+    echo "
+cmake_minimum_required(VERSION 3.13)
+project(UsingDali)
+
+add_subdirectory(DALI)
+" > CMakeLists.txt
+    mkdir build
+    cd build
+    cmake ..
+    make 
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL1_git_submodule/test.sh
+++ b/qa/TL1_git_submodule/test.sh
@@ -2,23 +2,27 @@
 
 test_body() {
     mkdir -p /tmp/repo_that_uses_dali
-    cd /tmp/repo_that_uses_dali
+    pushd /tmp/repo_that_uses_dali
     git init
-    git submodule add -b dali_as_submodule https://github.com/AlexBula/DALI
-    cd DALI
+    git submodule add https://github.com/NVIDIA/DALI
+    pushd DALI
     git submodule sync --recursive
     git submodule update --init --recursive
-    cd -
+    popd
+    touch main_stub.cc
     echo "
 cmake_minimum_required(VERSION 3.13)
 project(UsingDali)
 
 add_subdirectory(DALI)
+
+add_library(test_lib SHARED main_stub.cc)
+target_link_libraries(test_lib PUBLIC DALI::dali DALI::dali_core DALI::dali_kernels DALI::dali_operators)
 " > CMakeLists.txt
     mkdir build
-    cd build
+    pushd build
     cmake ..
-    make 
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 }
 
 pushd ../..


### PR DESCRIPTION
TODO
- [x] wait for existing changes to be applied in the CI
- [x] Verify locally
- [x] Update CI
- [x] `prolog`, `epilog` sections: are they needed?

#### Why we need this PR?
*Pick one, remove the rest*
Test, that verifies whether DALI builds as a submodule in different project. We need this to track regressions, when we tweak the cmakes is DALI. This test is L1, since assumes master branch, so it’s rather pointless to test it in every PR. This assumption is imperfect with regards to fact, that manually triggering it for given PR would also test master branch, instead of tested PR branch. If you happen to have some idea, how to tackle this problem, I’m open to any suggestions.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Added L1 test
 - Affected modules and functionalities:
     `qa/`
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA

