### PR TITLE
C API function: inherit parameters from serialized pipeline

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -18,8 +18,8 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <include/dali/core/cuda_stream.h>
 
+#include "dali/core/cuda_stream.h"
 #include "dali/core/format.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/pipeline/pipeline.h"

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -105,7 +105,7 @@ void daliCreatePipeline(daliPipelineHandle* pipe_handle,
     pipe->SetQueueSizes(cpu_prefetch_queue_depth, gpu_prefetch_queue_depth);
   }
   pipe->Build();
-  pipe_handle->pipe = reinterpret_cast<void *>(pipe);
+  pipe_handle->pipe = pipe;
   pipe_handle->ws = new dali::DeviceWorkspace();
   CUDA_CALL(cudaStreamCreateWithFlags(&pipe_handle->copy_stream, cudaStreamNonBlocking));
 }

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -113,11 +113,11 @@ void daliCreatePipeline(daliPipelineHandle* pipe_handle,
 
 void daliDeserializeDefault(daliPipelineHandle *pipe_handle, const char *serialized_pipeline,
                             int length) {
-  dali::Pipeline *pipe = new dali::Pipeline(std::string(serialized_pipeline, length));
-  pipe->Build();
-  pipe_handle->pipe = reinterpret_cast<void *>(pipe);
-  pipe_handle->ws = new dali::DeviceWorkspace();
+  auto pipeline = std::make_unique<dali::Pipeline>(std::string(serialized_pipeline, length));
+  pipeline->Build();
   CUDA_CALL(cudaStreamCreateWithFlags(&pipe_handle->copy_stream, cudaStreamNonBlocking));
+  pipe_handle->ws = new dali::DeviceWorkspace();
+  pipe_handle->pipe = pipeline.release();
 }
 
 

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -57,6 +57,7 @@ typedef enum {
   DALI_BOOL     =  11,
 } dali_data_type_t;
 
+/// @{
 /**
  * @brief Create DALI pipeline. Setting batch_size,
  * num_threads or device_id here overrides
@@ -77,6 +78,14 @@ DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle,
                                    int cpu_prefetch_queue_depth,
                                    int gpu_prefetch_queue_depth);
 
+/**
+ * Convenient overload. Use it, if the Pipeline should inherit its parameters
+ * from serialized pipeline.
+ */
+DLL_PUBLIC void daliDeserializeDefault(daliPipelineHandle *pipe_handle,
+                                       const char *serialized_pipeline,
+                                       int length);
+/// }@
 /// @{
 /**
  * @brief Feed the data to ExternalSource as contiguous memory.

--- a/include/dali/core/unique_handle.h
+++ b/include/dali/core/unique_handle.h
@@ -107,9 +107,9 @@ class UniqueHandle {
    * @returns The old handle value, no longer managed by UniqueHandle
    * @remarks The null value to replace the handle with, is taken from `Actual::null_value()`.
    */
-  inline handle_type release() {
+  inline handle_type release() noexcept {
     handle_type old = handle_;
-    handle_ = Actual::null_value();
+    handle_ = Actual::null_handle();
     return old;
   }
 


### PR DESCRIPTION
Signed-off-by: szalpal <mszolucha@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a new function to the C API - allow pipeline to inherit default parameters, which were saved in serialized pipeline, without the need of explicitly providing them.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Added new function
 - Affected modules and functionalities:
     C API
 - Key points relevant for the review:
     NA
 - Validation and testing:
     GTest
 - Documentation (including examples):
     doxygen


