### PR TITLE
Adjust test sizes for Erase GPU Kernel

### DIFF
--- a/dali/kernels/erase/erase_gpu.h
+++ b/dali/kernels/erase/erase_gpu.h
@@ -102,7 +102,7 @@ constexpr unsigned FULL_MASK = 0xffffffffu;
 /**
  * @brief Returns true if that parameter configuration is just outer layer of recursive loop call
  */
-constexpr bool select_outer_loops(int ndim, int current_dim, int channel_dim) {
+constexpr bool is_outer_loops(int ndim, int current_dim, int channel_dim) {
   // channel_dim is not one of the 2 last dimensions
   if (channel_dim < ndim - 2) {
     return ndim - current_dim > 2;  // true if we are not in the last two dimensions
@@ -116,7 +116,7 @@ constexpr bool select_outer_loops(int ndim, int current_dim, int channel_dim) {
  * @brief Outer layer of recursive loop over current region
  */
 template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
-__device__ std::enable_if_t<select_outer_loops(ndim, current_dim, channel_dim)>
+__device__ std::enable_if_t<is_outer_loops(ndim, current_dim, channel_dim)>
 erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill_values,
               span<ibox<ndim>> erase_regions = {}, ivec<ndim> coordinate = {},
               int64_t offset_base = 0) {
@@ -217,9 +217,9 @@ erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill
  * @brief Edge case kernel, 1D case
  */
 template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
-__device__ std::enable_if_t<ndim == 1 && current_dim == 0> erase_generic(
-    erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill_values,
-    span<ibox<ndim>> erase_regions = {}, ivec<ndim> coordinate = {}, int64_t offset_base = 0) {
+__device__ std::enable_if_t<ndim == 1> erase_generic(erase_sample_desc<T, ndim> sample,
+    ibox<ndim> region, span<T> fill_values, span<ibox<ndim>> erase_regions = {},
+    ivec<ndim> coordinate = {}, int64_t offset_base = 0) {
   constexpr int d = current_dim;
   int boundary = ::min(region.hi[d], sample.sample_shape[d]);
 

--- a/dali/kernels/erase/erase_gpu_test.cu
+++ b/dali/kernels/erase/erase_gpu_test.cu
@@ -88,13 +88,57 @@ TEST(EraseGpuKernelTest, CheckUtils) {
   }
 }
 
+enum class RegionGen {
+  NO_ERASE,  ///< only copy, no erase
+  FULL_ERASE,  ///< full, 1-element cover, only erase
+  RANDOM_ERASE  ///< randomly generated cover
+};
+
+enum class FillType {
+  MAGIC_42,  ///< use single value `42` for erase
+  CHANNEL_CONSECUTIVE,  ///< use consecutive values to erase channels
+  DEFAULT  ///< do not pass a value, use default `0`
+};
+
 template <int ndim>
 struct EraseTestParams {
   int num_erase_regions;
-  int region_generation;
-  int fill_type;
+  RegionGen region_generation;
+  FillType fill_type;
   TensorShape<ndim> shape;
 };
+
+
+std::ostream& operator<<(std::ostream& os, RegionGen p) {
+  switch (p) {
+    case RegionGen::NO_ERASE:
+      os << "RegionGen::NO_ERASE";
+      break;
+    case RegionGen::FULL_ERASE:
+      os << "RegionGen::FULL_ERASE";
+      break;
+    case RegionGen::RANDOM_ERASE:
+      os << "RegionGen::RANDOM_ERASE";
+      break;
+  }
+  return os;
+}
+
+
+std::ostream& operator<<(std::ostream& os, FillType p) {
+  switch (p) {
+    case FillType::MAGIC_42:
+      os << "FillType::MAGIC_42";
+      break;
+    case FillType::CHANNEL_CONSECUTIVE:
+      os << "FillType::CHANNEL_CONSECUTIVE";
+      break;
+    case FillType::DEFAULT:
+      os << "FillType::DEFAULT";
+      break;
+  }
+  return os;
+}
 
 template <int ndim>
 std::ostream& operator<<(std::ostream& os, const EraseTestParams<ndim>& p) {
@@ -119,26 +163,26 @@ struct EraseGpuKernelTest :
     baseline_.reshape(test_shape_);
     auto cpu_input_view = input_.cpu();
     SequentialFill(cpu_input_view);
-    if (fill_type_ == 2) {
+    if (fill_type_ == FillType::DEFAULT) {
       fill_values_.resize(0);
-    } else if (fill_type_ == 1) {
+    } else if (fill_type_ == FillType::CHANNEL_CONSECUTIVE) {
       fill_values_.resize(shape_[channel_dim]);
       int value = 0;
       for (auto &elem : fill_values_) {
         elem = value++;
       }
-    } else if (fill_type_ == 0) {
+    } else if (fill_type_ == FillType::MAGIC_42) {
       fill_values_.resize(1);
       fill_values_[0] = 42;
     }
   }
 
   void RunTest() {
-    if (region_generation_ == 0) {
+    if (region_generation_ == RegionGen::NO_ERASE) {
       std::cerr << ">> No cover" << std::endl;
-    } else if (region_generation_ == 1) {
+    } else if (region_generation_ == RegionGen::FULL_ERASE) {
       std::cerr << ">> Full cover" << std::endl;
-    } else if (region_generation_ == 2) {
+    } else if (region_generation_ == RegionGen::RANDOM_ERASE) {
       std::cerr << ">> Random cover of size: " << num_erase_regions_ << std::endl;
     }
     EraseGpu<T, ndim, channel_dim> kernel;
@@ -201,23 +245,23 @@ struct EraseGpuKernelTest :
   }
 
   void CreateRegions() {
-    if (region_generation_ == 0) {
+    if (region_generation_ == RegionGen::NO_ERASE) {
       num_erase_regions_ = 0;
       // no cover
-    } else if (region_generation_ == 1) {
+    } else if (region_generation_ == RegionGen::FULL_ERASE) {
       // full cover
       num_erase_regions_ = 1;
     }
     TensorListShape<1> regions_shape = uniform_list_shape<1>(batch_size_, {num_erase_regions_});
     regions_.reshape(regions_shape);
     auto regions_cpu = regions_.cpu();
-    if (region_generation_ == 1) {
+    if (region_generation_ == RegionGen::FULL_ERASE) {
       // full cover
       for (int i = 0; i < batch_size_; i++) {
         auto regions_tv = regions_cpu[i];
         *regions_tv(0) = ibox<ndim>({0}, to_ivec(shape_));
       }
-    } else if (region_generation_ == 2) {
+    } else if (region_generation_ == RegionGen::RANDOM_ERASE) {
       std::mt19937 gen(0);
       for (int i = 0; i < batch_size_; i++) {
         auto regions_tv = regions_cpu[i];
@@ -236,8 +280,8 @@ struct EraseGpuKernelTest :
   }
 
   int num_erase_regions_;
-  int region_generation_;
-  bool fill_type_;
+  RegionGen region_generation_;
+  FillType fill_type_;
   std::vector<T> fill_values_;
   TensorShape<ndim> shape_;
   TensorListShape<ndim> test_shape_;
@@ -273,112 +317,165 @@ ERASE_TEST_P(EraseGpuKernel5fTest)
 
 // Parameters for tests are:
 // <number of erase regions>, <generation scheme>, <fill_type>, <shape>
-// generation scheme:
-// * 0 - only copy, no erase
-// * 1 - full, 1-element cover, only erase
-// * 2 - random cover
-// fill_type:
-// * 0 - one element `42` fill
-// * 1 - per channel, consecutive values
-// * 2 - default `0` fill
 
 std::vector<EraseTestParams<1>> values_1 = {
-    {0, 0, 0, {512 * 1024}},
-    {1, 1, 0, {512 * 1024}},
-    {1, 2, 0, {512 * 1024}},
-    {10, 2, 0, {512 * 1024}},
-    {100, 2, 0, {512 * 1024}},
-    {0, 0, 2, {512 * 1024}},
-    {1, 1, 2, {512 * 1024}},
-    {1, 2, 2, {512 * 1024}},
-    {10, 2, 2, {512 * 1024}},
-    {100, 2, 2, {512 * 1024}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {512 * 1024}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {512 * 1024}},
+    {1, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {512 * 1024}},
+    {10, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {512 * 1024}},
+    {100, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {512 * 1024}},
+    {0, RegionGen::NO_ERASE, FillType::DEFAULT, {512 * 1024}},
+    {1, RegionGen::FULL_ERASE, FillType::DEFAULT, {512 * 1024}},
+    {1, RegionGen::RANDOM_ERASE, FillType::DEFAULT, {512 * 1024}},
+    {10, RegionGen::RANDOM_ERASE, FillType::DEFAULT, {512 * 1024}},
+    {100, RegionGen::RANDOM_ERASE, FillType::DEFAULT, {512 * 1024}},
 };
 
 std::vector<EraseTestParams<2>> values_2 = {
-    {0, 0, 0, {512, 1024}},
-    {1, 1, 0, {512, 1024}},
-    {1, 2, 0, {512, 1024}},
-    {10, 2, 0, {512, 1024}},
-    {100, 2, 0, {512, 1024}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {512, 1024}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {512, 1024}},
+    {1, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {512, 1024}},
+    {10, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {512, 1024}},
+    {100, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {512, 1024}},
 };
 
 std::vector<EraseTestParams<2>> values_2NC = {
-    {0, 0, 0, {512 * 1024, 3}},
-    {1, 1, 0, {512 * 1024, 3}},
-    {1, 2, 0, {512 * 1024, 3}},
-    {10, 2, 1, {512 * 1024, 3}},
-    {100, 2, 2, {512 * 1024, 3}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {512 * 1024, 3}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {512 * 1024, 3}},
+    {1, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {512 * 1024, 3}},
+    {10, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {512 * 1024, 3}},
+    {100, RegionGen::RANDOM_ERASE, FillType::DEFAULT, {512 * 1024, 3}},
 };
 
 std::vector<EraseTestParams<3>> values_3 = {
-    {0, 0, 0, {256, 256, 256}},
-    {1, 1, 0, {256, 256, 256}},
-    {1, 2, 0, {256, 256, 256}},
-    {10, 2, 0, {256, 256, 256}},
-    {100, 2, 0, {256, 256, 256}},
-    {1000, 2, 0, {256, 256, 256}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {16, 256, 256}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {16, 256, 256}},
+    {1, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {16, 256, 256}},
+    {10, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {16, 256, 256}},
+    {100, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {16, 256, 256}},
+    {1000, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {16, 256, 256}},
 };
 
 std::vector<EraseTestParams<3>> values_3HWC = {
-    {0, 0, 0, {256, 256, 1}},    {0, 0, 0, {256, 256, 3}},    {0, 0, 0, {256, 256, 4}},
-    {0, 0, 0, {256, 256, 8}},    {0, 0, 0, {256, 256, 16}},   {0, 0, 0, {256, 256, 64}},
-    {1, 1, 0, {256, 256, 1}},    {1, 1, 0, {256, 256, 3}},    {1, 1, 0, {256, 256, 4}},
-    {1, 1, 0, {256, 256, 8}},    {1, 1, 0, {256, 256, 16}},   {1, 1, 0, {256, 256, 64}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {256, 256, 1}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {256, 256, 3}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {256, 256, 4}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {256, 256, 8}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {256, 256, 16}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {256, 256, 64}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {256, 256, 1}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {256, 256, 3}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {256, 256, 4}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {256, 256, 8}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {256, 256, 16}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {256, 256, 64}},
 
-    {0, 0, 1, {256, 256, 1}},    {0, 0, 1, {256, 256, 3}},    {0, 0, 1, {256, 256, 4}},
-    {0, 0, 1, {256, 256, 8}},    {0, 0, 1, {256, 256, 16}},   {0, 0, 1, {256, 256, 64}},
-    {1, 1, 1, {256, 256, 1}},    {1, 1, 1, {256, 256, 3}},    {1, 1, 1, {256, 256, 4}},
-    {1, 1, 1, {256, 256, 8}},    {1, 1, 1, {256, 256, 16}},   {1, 1, 1, {256, 256, 64}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 1}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 3}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 4}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 8}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 16}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 64}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 1}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 3}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 4}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 8}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 16}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 64}},
 
-    {0, 0, 2, {256, 256, 1}},    {0, 0, 2, {256, 256, 3}},    {0, 0, 2, {256, 256, 4}},
-    {0, 0, 2, {256, 256, 8}},    {0, 0, 2, {256, 256, 16}},   {0, 0, 2, {256, 256, 64}},
-    {1, 1, 2, {256, 256, 1}},    {1, 1, 2, {256, 256, 3}},    {1, 1, 2, {256, 256, 4}},
-    {1, 1, 2, {256, 256, 8}},    {1, 1, 2, {256, 256, 16}},   {1, 1, 2, {256, 256, 64}},
+    {0, RegionGen::NO_ERASE, FillType::DEFAULT, {256, 256, 1}},
+    {0, RegionGen::NO_ERASE, FillType::DEFAULT, {256, 256, 3}},
+    {0, RegionGen::NO_ERASE, FillType::DEFAULT, {256, 256, 4}},
+    {0, RegionGen::NO_ERASE, FillType::DEFAULT, {256, 256, 8}},
+    {0, RegionGen::NO_ERASE, FillType::DEFAULT, {256, 256, 16}},
+    {0, RegionGen::NO_ERASE, FillType::DEFAULT, {256, 256, 64}},
+    {1, RegionGen::FULL_ERASE, FillType::DEFAULT, {256, 256, 1}},
+    {1, RegionGen::FULL_ERASE, FillType::DEFAULT, {256, 256, 3}},
+    {1, RegionGen::FULL_ERASE, FillType::DEFAULT, {256, 256, 4}},
+    {1, RegionGen::FULL_ERASE, FillType::DEFAULT, {256, 256, 8}},
+    {1, RegionGen::FULL_ERASE, FillType::DEFAULT, {256, 256, 16}},
+    {1, RegionGen::FULL_ERASE, FillType::DEFAULT, {256, 256, 64}},
 
-    {1, 2, 1, {256, 256, 1}},    {10, 2, 1, {256, 256, 1}},   {100, 2, 1, {256, 256, 1}},
-    {1000, 2, 1, {256, 256, 1}},
-    {1, 2, 1, {256, 256, 3}},    {10, 2, 1, {256, 256, 3}},   {100, 2, 1, {256, 256, 3}},
-    {1000, 2, 1, {256, 256, 3}},
-    {1, 2, 1, {256, 256, 16}},    {10, 2, 1, {256, 256, 16}}, {100, 2, 1, {256, 256, 16}},
-    {1000, 2, 1, {256, 256, 16}},
+    {1, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 1}},
+    {10, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 1}},
+    {100, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 1}},
+    {1000, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 1}},
+    {1, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 3}},
+    {10, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 3}},
+    {100, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 3}},
+    {1000, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 3}},
+    {1, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 16}},
+    {10, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 16}},
+    {100, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 16}},
+    {1000, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {256, 256, 16}},
 };
 
 std::vector<EraseTestParams<3>> values_3CHW = {
-    {0, 0, 0, {3, 256, 256}},
-    {1, 1, 0, {3, 256, 256}},
-    {0, 0, 0, {16, 256, 256}},
-    {1, 1, 0, {16, 256, 256}},
-    {1, 2, 0, {3, 256, 256}},
-    {10, 2, 0, {3, 256, 256}},
-    {100, 2, 0, {3, 256, 256}},
-    {1000, 2, 0, {3, 256, 256}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {3, 256, 256}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {3, 256, 256}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {16, 256, 256}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {16, 256, 256}},
+    {1, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {3, 256, 256}},
+    {10, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {3, 256, 256}},
+    {100, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {3, 256, 256}},
+    {1000, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {3, 256, 256}},
 };
 
 std::vector<EraseTestParams<4>> values_4DHCW = {
-    {0, 0, 0, {64, 64, 3, 64}},     {0, 0, 0, {64, 64, 4, 64}},    {0, 0, 0, {64, 64, 8, 64}},
-    {1, 1, 0, {64, 64, 3, 64}},     {1, 1, 0, {64, 64, 4, 64}},    {1, 1, 0, {64, 64, 8, 64}},
-    {0, 0, 1, {64, 64, 3, 64}},     {0, 0, 1, {64, 64, 4, 64}},    {0, 0, 1, {64, 64, 8, 64}},
-    {1, 1, 1, {64, 64, 3, 64}},     {1, 1, 1, {64, 64, 4, 64}},    {1, 1, 1, {64, 64, 8, 64}},
-    {1, 2, 1, {64, 64, 3, 64}},     {10, 2, 1, {64, 64, 3, 64}},   {100, 2, 1, {64, 64, 3, 64}},
-    {100, 2, 1, {64, 256, 3, 256}}, {1000, 2, 1, {64, 64, 3, 64}}, {1000, 2, 1, {64, 256, 3, 256}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {64, 64, 3, 64}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {64, 64, 4, 64}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {64, 64, 8, 64}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {64, 64, 3, 64}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {64, 64, 4, 64}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {64, 64, 8, 64}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 3, 64}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 4, 64}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 8, 64}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 3, 64}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 4, 64}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 8, 64}},
+    {1, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 3, 64}},
+    {10, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 3, 64}},
+    {100, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 3, 64}},
+    {100, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {16, 128, 3, 256}},
+    {1000, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 3, 64}},
+    {1000, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {16, 128, 3, 256}},
 };
 
 std::vector<EraseTestParams<4>> values_4DHWC = {
-    {0, 0, 0, {64, 64, 64, 3}},     {0, 0, 0, {64, 64, 64, 4}},    {0, 0, 0, {64, 64, 64, 8}},
-    {1, 1, 0, {64, 64, 64, 3}},     {1, 1, 0, {64, 64, 64, 4}},    {1, 1, 0, {64, 64, 64, 8}},
-    {0, 0, 1, {64, 64, 64, 3}},     {0, 0, 1, {64, 64, 64, 4}},    {0, 0, 1, {64, 64, 64, 8}},
-    {1, 1, 1, {64, 64, 64, 3}},     {1, 1, 1, {64, 64, 64, 4}},    {1, 1, 1, {64, 64, 64, 8}},
-    {1, 2, 1, {64, 64, 64, 3}},     {10, 2, 1, {64, 64, 64, 3}},   {100, 2, 1, {64, 64, 64, 3}},
-    {100, 2, 1, {64, 256, 256, 3}}, {1000, 2, 1, {64, 64, 64, 3}}, {1000, 2, 1, {64, 256, 256, 3}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {64, 64, 64, 3}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {64, 64, 64, 4}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {64, 64, 64, 8}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {64, 64, 64, 3}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {64, 64, 64, 4}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {64, 64, 64, 8}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 64, 3}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 64, 4}},
+    {0, RegionGen::NO_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 64, 8}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 64, 3}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 64, 4}},
+    {1, RegionGen::FULL_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 64, 8}},
+    {1, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 64, 3}},
+    {10, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 64, 3}},
+    {100, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 64, 3}},
+    {100, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {16, 128, 256, 3}},
+    {1000, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {64, 64, 64, 3}},
+    {1000, RegionGen::RANDOM_ERASE, FillType::CHANNEL_CONSECUTIVE, {16, 128, 256, 3}},
 };
 
 std::vector<EraseTestParams<5>> values_5 = {
-    {0, 0, 0, {4, 6, 64, 64, 64}},     {1, 1, 0, {4, 6, 64, 64, 64}},
-    {0, 0, 0, {2, 32, 16, 256, 256}},  {1, 1, 0, {2, 4, 16, 256, 256}},
-    {1, 2, 0, {4, 6, 32, 32, 32}},     {1, 2, 0, {4, 6, 64, 64, 64}},
-    {1, 2, 0, {4, 6, 16, 256, 256}},   {10, 2, 0, {4, 6, 16, 256, 256}},
-    {100, 2, 0, {4, 6, 16, 256, 256}}, {1000, 2, 0, {4, 6, 16, 256, 256}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {4, 6, 5, 64, 64}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {4, 6, 5, 64, 64}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {2, 3, 3, 256, 256}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {2, 3, 3, 256, 256}},
+    {1, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {4, 6, 32, 32, 32}},
+    {1, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {4, 6, 5, 64, 64}},
+    {0, RegionGen::NO_ERASE, FillType::MAGIC_42, {2, 3, 3, 256, 16}},
+    {1, RegionGen::FULL_ERASE, FillType::MAGIC_42, {2, 3, 3, 256, 16}},
+    {1, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {2, 3, 3, 256, 16}},
+    {10, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {2, 3, 3, 256, 16}},
+    {100, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {2, 3, 3, 256, 16}},
+    {1000, RegionGen::RANDOM_ERASE, FillType::MAGIC_42, {2, 3, 3, 256, 16}},
 };
 
 #define INSTANTIATE_ERASE_SUITE(TEST, VALUES) \


### PR DESCRIPTION
Significantly reduce the size of some allocations
Change the tests to use enums for driving the
data generation.

Additional readability fixes for enable_ifs.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Improves the tests, makes them a bit shorter.

#### What happened in this PR?
 - What solution was applied:
     Find&Replace, reduce the shape sizes in some tests.
 - Affected modules and functionalities:
     Erase GPU kernel, tests mostly
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI, local cuda-memcheck run
 - Documentation (including examples):
     N/A


**JIRA TASK**: *[Use DALI-XXXX or NA]*
