### PR TITLE
Fix test for Xavier

### DIFF
--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -112,9 +112,12 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
     tl_.set_type(TypeInfo::Create<int>());
     TensorListShape<> shape = uniform_list_shape(this->batch_size_, {10, 10});
     tl_.Resize(shape);
+    std::cout<<"FeedWithList"<<std::endl;
     for (int j = 0; j < this->batch_size_; ++j) {
       auto data = tl_.template mutable_tensor<int>(j);
       for (int i = 0; i < volume(tl_.tensor_shape(j)); ++i) {
+        std::cout<<"j "<<j<<"\ti "<<i<<"\tdata[i] "<<data[i]
+                 << "\tfillcnt "<<fill_counter_<<std::endl;
         data[i] = fill_counter_;
       }
       ++fill_counter_;
@@ -134,11 +137,14 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
     auto &tensor_gpu_list = ws.Output<GPUBackend>(0);
     TensorList<CPUBackend> tensor_cpu_list;
     tensor_cpu_list.Copy(tensor_gpu_list, (ws.has_stream() ? ws.stream() : 0));
-    cudaStreamSynchronize(ws.has_stream() ? ws.stream() : 0);
-
+//    cudaStreamSynchronize(ws.has_stream() ? ws.stream() : 0);
+    cudaDeviceSynchronize();
+    std::cout<<"RunOutputs"<<std::endl;
     for (int j = 0; j < this->batch_size_; ++j) {
       auto data = tensor_cpu_list.template mutable_tensor<int>(j);
       for (int i = 0; i < volume(tensor_cpu_list.tensor_shape(j)); ++i) {
+        std::cout<<"j "<<j<<"\ti "<<i<<"\tdata[i] "<<data[i]
+                 << "\tfillcnt "<<check_counter_<<std::endl;
         if (data[i] != check_counter_) {
           return false;
         }

--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -112,12 +112,9 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
     tl_.set_type(TypeInfo::Create<int>());
     TensorListShape<> shape = uniform_list_shape(this->batch_size_, {10, 10});
     tl_.Resize(shape);
-    std::cout << "FeedWithList" << std::endl;
     for (int j = 0; j < this->batch_size_; ++j) {
       auto data = tl_.template mutable_tensor<int>(j);
       for (int i = 0; i < volume(tl_.tensor_shape(j)); ++i) {
-        std::cout << "j " << j << "\ti " << i << "\tdata[i] " << data[i]
-                  << "\tfillcnt " << fill_counter_ << std::endl;
         data[i] = fill_counter_;
       }
       ++fill_counter_;
@@ -137,14 +134,10 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
     auto &tensor_gpu_list = ws.Output<GPUBackend>(0);
     TensorList<CPUBackend> tensor_cpu_list;
     tensor_cpu_list.Copy(tensor_gpu_list, (ws.has_stream() ? ws.stream() : 0));
-//    cudaStreamSynchronize(ws.has_stream() ? ws.stream() : 0);
     cudaDeviceSynchronize();
-    std::cout << "RunOutputs" << std::endl;
     for (int j = 0; j < this->batch_size_; ++j) {
       auto data = tensor_cpu_list.template mutable_tensor<int>(j);
       for (int i = 0; i < volume(tensor_cpu_list.tensor_shape(j)); ++i) {
-        std::cout << "j " << j << "\ti " << i << "\tdata[i] " << data[i]
-                  << "\tfillcnt " << check_counter_ << std::endl;
         if (data[i] != check_counter_) {
           return false;
         }

--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -112,12 +112,12 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
     tl_.set_type(TypeInfo::Create<int>());
     TensorListShape<> shape = uniform_list_shape(this->batch_size_, {10, 10});
     tl_.Resize(shape);
-    std::cout<<"FeedWithList"<<std::endl;
+    std::cout << "FeedWithList" << std::endl;
     for (int j = 0; j < this->batch_size_; ++j) {
       auto data = tl_.template mutable_tensor<int>(j);
       for (int i = 0; i < volume(tl_.tensor_shape(j)); ++i) {
-        std::cout<<"j "<<j<<"\ti "<<i<<"\tdata[i] "<<data[i]
-                 << "\tfillcnt "<<fill_counter_<<std::endl;
+        std::cout << "j " << j << "\ti " << i << "\tdata[i] " << data[i]
+                  << "\tfillcnt " << fill_counter_ << std::endl;
         data[i] = fill_counter_;
       }
       ++fill_counter_;
@@ -139,12 +139,12 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
     tensor_cpu_list.Copy(tensor_gpu_list, (ws.has_stream() ? ws.stream() : 0));
 //    cudaStreamSynchronize(ws.has_stream() ? ws.stream() : 0);
     cudaDeviceSynchronize();
-    std::cout<<"RunOutputs"<<std::endl;
+    std::cout << "RunOutputs" << std::endl;
     for (int j = 0; j < this->batch_size_; ++j) {
       auto data = tensor_cpu_list.template mutable_tensor<int>(j);
       for (int i = 0; i < volume(tensor_cpu_list.tensor_shape(j)); ++i) {
-        std::cout<<"j "<<j<<"\ti "<<i<<"\tdata[i] "<<data[i]
-                 << "\tfillcnt "<<check_counter_<<std::endl;
+        std::cout << "j " << j << "\ti " << i << "\tdata[i] " << data[i]
+                  << "\tfillcnt " << check_counter_ << std::endl;
         if (data[i] != check_counter_) {
           return false;
         }


### PR DESCRIPTION
Signed-off-by: szalpal <mszolucha@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug *bug description*
Xavier fails on 2 tests:
```
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] ExternalSourceTest/2.FeedThenConsumeGPU, where TypeParam = dali::FeedCount<4>
[  FAILED  ] ExternalSourceTest/3.FeedThenConsumeGPU, where TypeParam = dali::FeedCount<10>
```
Since there are actually 4 configurations of this test, it points to synchronization problems. I added `cudaDeviceSynchronize` instead of `cudaStreamSynchronize` inside test, and it seems to be passing, which prooves the hipothesis.


#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     `cudaDeviceSynchronize`
 - Affected modules and functionalities:
     na
 - Key points relevant for the review:
     na
 - Validation and testing:
     na
 - Documentation (including examples):
     na


**JIRA TASK**: *[Use DALI-XXXX or NA]*
