### PR TITLE
Fix a race condition in ExternalSourceTest test

### DIFF
--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -38,6 +38,12 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
     DALISingleOpTest::SetUp();
     set_batch_size(10);
     vt_.resize(this->batch_size_);
+    for (auto &vt : vt_) {
+      vt.Reset();
+      vt.set_pinned(false);
+    }
+    tl_.Reset();
+    tl_.set_pinned(false);
     fill_counter_ = 0;
     check_counter_ = 0;
   }


### PR DESCRIPTION
- all DALI CPU buffers are pinned by default, so in the ExternalSourceTest test copying the data from CPU pinned buffer to a GPU buffer in SetDataSource causes a race condition as the CPU buffer is reused before the copying has ended
- reworks test to make the CPU buffer not pinned

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a race condition in ExternalSourceTest test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     reworks ExternalSourceTest  test to make the CPU buffer not pinned
 - Affected modules and functionalities:
     ExternalSourceTest  
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA

**JIRA TASK**: *[NA]*
