### PR TITLE
Move to TensorFlow 2.2.0 from 2.2.0-RC2

### DIFF
--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -326,7 +326,7 @@ all_packages = [PlainPackage("opencv-python", ["4.2.0.32"]),
                 CudaPackage("tensorflow-gpu",
                         { "90"  : [PckgVer("1.12.0", python_max_ver="3.7")],
                           "100" : [PckgVer("1.15.2",  python_max_ver="3.7"), PckgVer("2.1.0",  python_max_ver="3.7"), \
-                                   "2.2.0rc2"] }),
+                                   "2.2.0"] }),
                 CudaHttpPackage("torch",
                         { "90"  : ["http://download.pytorch.org/whl/cu{cuda_v}/torch-1.1.0-{platform}.whl"],
                           "100" : ["http://download.pytorch.org/whl/cu{cuda_v}/torch-1.4.0+cu{cuda_v}-{platform}.whl"] }),


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It moves to TensorFlow 2.2.0 from 2.2.0-RC2

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Changes one of TF versions from 2.2.0-RC2 to 2.2.0
 - Affected modules and functionalities:
     setup_packages.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI - current tests covers
 - Documentation (including examples):
     NA

**JIRA TASK**: *[NA]*
