### PR TITLE
Update clang version to 8.0.1 in deps image

### DIFF
--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -90,9 +90,9 @@ RUN OPENCV_VERSION=4.3.0 && \
     rm -rf /opencv-${OPENCV_VERSION}
 
 # Clang
-RUN CLANG_VERSION=6.0.1 && \
+RUN CLANG_VERSION=8.0.1 && \
     cd /usr/local && \
-    wget http://releases.llvm.org/${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
+    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
     tar -xJf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --strip 1 && \
     rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
 


### PR DESCRIPTION
- link to 6.0 clang image doesn't work anymore. Switches to the 8.0.1 version available on the GitHub

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It updates clang version to 8.0.1 in deps image

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     link to 6.0 clang image doesn't work anymore. Switches to the 8.0.1 version available on the GitHub
 - Affected modules and functionalities:
     deps
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     CI

**JIRA TASK**: *[NA]*
