### PR TITLE
Replace usage of patchelf by LIEF

### DIFF
--- a/Acknowledgements.txt
+++ b/Acknowledgements.txt
@@ -2602,3 +2602,106 @@ Redistribution and use in source and binary forms, with or without modification,
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+========================
+The auditwheel package is covered by the MIT license.
+
+::
+
+  The MIT License
+
+  Copyright (c) 2016 Robert T. McGibbon <rmcgibbo@gmail.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
+
+3rd party code and data
+=======================
+
+Some code distributed within the auditwheel sources was developed by other
+projects. This code is distributed under its respective licenses that are
+listed below.
+
+delocate
+--------
+The files tools.py and wheeltools.py were copied from delocate
+(https://github.com/matthew-brett/delocate) with minor mindifications.
+
+Copyright (c) 2014-2015, Matthew Brett
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+nibabel
+-------
+The file tmpdirs.py was copied from nibabel (https://github.com/nipy/nibabel).
+
+Copyright (c) 2009-2014 Matthew Brett <matthew.brett@gmail.com>
+Copyright (c) 2010-2013 Stephan Gerhard <git@unidesign.ch>
+Copyright (c) 2006-2014 Michael Hanke <michael.hanke@gmail.com>
+Copyright (c) 2011 Christian Haselgrove <christian.haselgrove@umassmed.edu>
+Copyright (c) 2010-2011 Jarrod Millman <jarrod.millman@gmail.com>
+Copyright (c) 2011-2014 Yaroslav Halchenko <debian@onerussian.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+pax-utils
+---------
+Some of the ELF-handling code was copied from gentoo's pax-utils/lddtree.py,
+available at https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-projects/pax-utils/lddtree.py
+
+Copyright 2012-2014 Gentoo Foundation
+Copyright 2012-2014 Mike Frysinger <vapier@gentoo.org>
+Copyright 2012-2014 The Chromium OS Authors
+Use of this source code is governed by a BSD-style license (BSD-3)

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -58,7 +58,6 @@ requirements:
     - pkg-config
     - cmake >=3.12.4
     - make
-    - patchelf
   host:
     - python
     - future >=0.17.1

--- a/dali/python/patcher.py
+++ b/dali/python/patcher.py
@@ -1,0 +1,121 @@
+# based on https://github.com/pypa/auditwheel/pull/187 by László Kiss Kollár
+import argparse
+import lief
+import logging
+
+logger = logging.getLogger(__name__)
+
+class Lief():
+    def __init__(self, file_name):
+        self.file_name = file_name
+        self.elf = None
+        self.changed = False
+
+    def __enter__(self):
+        # see https://github.com/lief-project/LIEF/issues/416
+        self.elf = lief.ELF.parse(self.file_name, lief.ELF.DYNSYM_COUNT_METHODS.SECTION)
+        self.changed = False
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self.changed:
+            self.elf.write(self.file_name)
+        self.changed = False
+        self.elf = None
+
+    def replace_needed(self, so_name, new_so_name):
+        name_pairs = zip(so_name, new_so_name)
+        names_map = {names[0] : names[1] for names in name_pairs}
+
+        for lib in self.elf.dynamic_entries:
+            if lib.tag == lief.ELF.DYNAMIC_TAGS.NEEDED and lib.name in names_map.keys() \
+               and lib.name != names_map[lib.name]:
+                logger.info("Replacing needed library: %s with %s",
+                            lib.name, names_map[lib.name])
+                lib.name = names_map[lib.name]
+                self.changed = True
+
+        for sym in self.elf.symbols_version_requirement:
+            if sym.name in names_map.keys():
+                sym.name = names_map[sym.name]
+                self.changed = True
+
+    def print_needed(self):
+        for lib in self.elf.dynamic_entries:
+            if lib.tag == lief.ELF.DYNAMIC_TAGS.NEEDED:
+                print(lib.name)
+
+    def set_so_name(self, new_so_name):
+        self.changed = True
+        # TODO error handling (target might not be a library)
+        soname = self.elf.get(lief.ELF.DYNAMIC_TAGS.SONAME)
+        soname.name = new_so_name
+        logger.info("Setting SONAME to %s", soname)
+
+    def set_rpath(self, libdir):
+        self.changed = True
+        try:
+            rpath = self.elf.get(lief.ELF.DYNAMIC_TAGS.RPATH)
+            self.elf.remove(rpath)
+        except lief.not_found:
+            pass
+
+        try:
+            runpath = self.elf.get(lief.ELF.DYNAMIC_TAGS.RUNPATH)
+            logger.info("Current RUNPATH: %s", runpath)
+            runpath.runpath = libdir
+        except lief.not_found:
+            logger.info("No RUNPATH found, creating new entry")
+            runpath = lief.ELF.DynamicEntryRunPath(libdir)
+            self.elf.add(runpath)
+
+        logger.info("Setting new RUNPATH: %s", libdir)
+
+    def print_rpath(self):
+        rpath = ""
+        try:
+            rpath = self.elf.get(lief.ELF.DYNAMIC_TAGS.RUNPATH)
+        except lief.not_found:
+            pass
+        print(rpath)
+
+parser = argparse.ArgumentParser(description='Patchelf replacement based on LIEF')
+parser.add_argument('--replace-needed', nargs='*', type=str, metavar=('old_name_1, ..., new_name_1, ...'),
+                    help='Replaces a library name that lib links to')
+parser.add_argument('--print-needed', type=str, metavar=('target'),
+                    help='Print all libraries that target links to')
+parser.add_argument('--set-rpath',type=str, metavar=('new_rpath'),
+                    help='Sets rpath')
+parser.add_argument('--set-soname',type=str, metavar=('new_soname'),
+                    help='Sets new soname')
+parser.add_argument('--print-rpath', action='store_true',
+                    help='Print rpath')
+parser.add_argument('--file', type=str, metavar=('file name'),
+                    help='Target file')
+args = parser.parse_args()
+
+with Lief(args.file) as elf_file:
+    if args.replace_needed:
+        total_length = len(args.replace_needed)
+        if (total_length / 2).is_integer():
+            length = total_length // 2
+            old_names = args.replace_needed[0:length]
+            new_names = args.replace_needed[length:]
+            elf_file.replace_needed(old_names, new_names)
+        else:
+            print("Wrong number of arguments, it should be at least 2*N")
+            exit(1)
+
+    if args.print_needed:
+        elf_file.print_needed()
+
+    if args.set_rpath:
+        elf_file.set_rpath(args.set_rpath)
+
+    if args.set_soname:
+        elf_file.set_so_name(args.set_soname)
+
+    if args.print_rpath:
+        elf_file.print_rpath()
+
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,13 @@ RUN pip install future setuptools wheel && \
 RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     ldconfig
 
+# use LIEF master until a release with perf optimization is available
+RUN cd /tmp && git clone https://github.com/lief-project/LIEF && cd LIEF && \
+    mkdir build && cd build && \
+    cmake ../ && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && \
+    cp api/python/lief.so $(python -c "import sys; print(sys.path[-1])") && \
+    rm -rf /tmp/LIEF && cd /
+
 WORKDIR /opt/dali
 
 ARG CC

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -160,7 +160,7 @@ RUN LIBSND_VERSION=1.0.28 && cd /tmp                                            
     rm libsndfile-$LIBSND_VERSION.tar.gz                                                                       && \
     cd libsndfile-$LIBSND_VERSION                                                                              && \
     ./configure && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install                           && \
-    cd /tmp && rm -rf libsnd-$LIBSND_VERSION
+    cd /tmp && rm -rf libsndfile-$LIBSND_VERSION
 
 # CUDA
 COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/build_helper.sh
+++ b/docker/build_helper.sh
@@ -107,16 +107,7 @@ if [ "${BUILD_PYTHON}" = "ON" ]; then
         zip -rq $WHEEL *
         popd
         rm -rf $UNZIP_PATH
-        # rerun all things involving patchelf on striped binary
-        # we cannot strip after patchelf as according to the documentation
-        ###
-        ### The `strip' command from binutils generated broken executables when
-        ### applied to the output of patchelf (if `--set-rpath' or
-        ### `--set-interpreter' with a larger path than the original is used).
-        ### This appears to be a bug in binutils
-        ### (http://bugs.strategoxt.org/browse/NIXPKGS-85).
-
+        # rerun all things as we need to rebuild whl record anyway
         ../dali/python/bundle-wheel.sh nvidia_dali[_-]*.whl
     fi
 fi
-


### PR DESCRIPTION
- patchelf has numerous bugs and the pypa community considers leaving it behind in the favor of LIEF. In DALI it doesn't work well with stip and sometimes it can break TLS section alignment
- reworks bundle-wheel.sh and conda build to use patcher.py scrip based on LIEF
- depends on https://github.com/lief-project/LIEF/pull/413 to make the performance sufficient for our use

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It replaces usage of patchelf by LIEF

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     reworks bundle-wheel.sh and conda build to use patcher.py scrip based on LIEF
 - Affected modules and functionalities:
     bundle-wheel.sh and conda build script
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA

Based on https://github.com/pypa/auditwheel/pull/187

**JIRA TASK**: *[DALI-1416]*
