### PR TITLE
Linter script change: from CMake to Python

### DIFF
--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -15,7 +15,7 @@
 add_custom_target(
           lint
         COMMAND
-          python ${PROJECT_SOURCE_DIR}/tools/lint.py ${PROJECT_SOURCE_DIR}
+          python ${PROJECT_SOURCE_DIR}/tools/lint.py ${PROJECT_SOURCE_DIR} --nproc=5
         COMMENT
           "Performing linter check"
 )

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -1,56 +1,21 @@
-# Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
-# Get the project dir - not set for this target
-get_filename_component(PROJECT_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
-set(LINT_COMMAND python ${PROJECT_SOURCE_DIR}/third_party/cpplint.py)
-set(DALI_SRC_DIR "${PROJECT_SOURCE_DIR}/dali")
-set(DALI_INC_DIR "${PROJECT_SOURCE_DIR}/include")
-file(GLOB_RECURSE LINT_SRC "${DALI_SRC_DIR}/*.cc" "${DALI_SRC_DIR}/*.h" "${DALI_SRC_DIR}/*.cu" "${DALI_SRC_DIR}/*.cuh")
-file(GLOB_RECURSE LINT_INC "${DALI_INC_DIR}/*.h" "${DALI_INC_DIR}/*.cuh" "${DALI_INC_DIR}/*.inc" "${DALI_SRC_DIR}/*.inl")
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# Excluded files
-
-# nvdecoder
-list(REMOVE_ITEM LINT_SRC
-    ${DALI_SRC_DIR}/core/dynlink_cuda.cc
-    ${DALI_SRC_DIR}/operators/reader/nvdecoder/nvcuvid.h
-    ${DALI_SRC_DIR}/operators/reader/nvdecoder/cuviddec.h
-    ${DALI_SRC_DIR}/operators/reader/nvdecoder/dynlink_nvcuvid.cc
-    ${DALI_SRC_DIR}/operators/reader/nvdecoder/dynlink_nvcuvid.h
+add_custom_target(
+          lint
+        COMMAND
+          python ${PROJECT_SOURCE_DIR}/tools/lint.py ${PROJECT_SOURCE_DIR}
+        COMMENT
+          "Performing linter check"
 )
-
-list(REMOVE_ITEM LINT_INC
-  ${DALI_INC_DIR}/dali/core/dynlink_cuda.h
-)
-
-# cuTT
-list(REMOVE_ITEM LINT_SRC
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/cutt.h
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/cutt.cc
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/cuttplan.h
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/cuttplan.cc
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/cuttkernel.cu
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/cuttkernel.h
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/calls.h
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/cuttGpuModel.h
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/cuttGpuModel.cc
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/cuttGpuModelKernel.h
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/cuttGpuModelKernel.cu
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/CudaMemcpy.h
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/CudaMemcpy.cu
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/CudaUtils.h
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/CudaUtils.cu
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/cuttTypes.h
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/int_vector.h
-    ${DALI_SRC_DIR}/operators/generic/transpose/cutt/LRUCache.h
-)
-
-# empty files
-list(REMOVE_ITEM LINT_SRC
-    ${DALI_SRC_DIR}/python/dummy.cu
-)
-
-set(LINT_TARGET lint)
-
-add_custom_target(${LINT_TARGET})
-add_sources_to_lint(${LINT_TARGET} "--quiet;--linelength=100;--root=${PROJECT_SOURCE_DIR}" "${LINT_SRC}")
-add_sources_to_lint(${LINT_TARGET} "--quiet;--linelength=100;--root=${PROJECT_SOURCE_DIR}/include" "${LINT_INC}")

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -19,6 +19,7 @@ import glob
 import itertools
 import re
 import argparse
+import sys
 
 # Linter script, that calls cpplint.py, specifically for DALI repo.
 # This comes in handy for specifying pre-push git hook, so that
@@ -99,8 +100,11 @@ def main(dali_root_dir):
                             ["*.cc", "*.h", "*.cu", "*.cuh"], negative_filters)
     inc_files = gather_files(os.path.join(dali_root_dir, "include"),
                              ["*.h", "*.cuh", "*.inc", "*.inl"], negative_filters)
-    os.system(gen_cmd(dali_root_dir=dali_root_dir, file_list=cc_files, process_includes=False))
-    os.system(gen_cmd(dali_root_dir=dali_root_dir, file_list=inc_files, process_includes=True))
+    cc_code = os.system(gen_cmd(dali_root_dir=dali_root_dir, file_list=cc_files, process_includes=False))
+    inc_code = os.system(gen_cmd(dali_root_dir=dali_root_dir, file_list=inc_files, process_includes=True))
+    if cc_code != 0 or inc_code !=0:
+        sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import glob
+import itertools
+import re
+import argparse
+
+# Linter script, that calls cpplint.py, specifically for DALI repo.
+# This comes in handy for specifying pre-push git hook, so that
+# linter is automatically applied.
+# To configure this hook, edit `.git/hooks
+
+# These filters are regexes, not typical unix-like path specification
+negative_filters = [
+    ".*core/dynlink_cuda.cc",
+    ".*operators/reader/nvdecoder/nvcuvid.h",
+    ".*operators/reader/nvdecoder/cuviddec.h",
+    ".*operators/reader/nvdecoder/dynlink_nvcuvid.cc",
+    ".*operators/reader/nvdecoder/dynlink_nvcuvid.h",
+    ".*dali/core/dynlink_cuda.h",
+    ".*operators/generic/transpose/cutt/cutt.h",
+    ".*operators/generic/transpose/cutt/cutt.cc",
+    ".*operators/generic/transpose/cutt/cuttplan.h",
+    ".*operators/generic/transpose/cutt/cuttplan.cc",
+    ".*operators/generic/transpose/cutt/cuttkernel.cu",
+    ".*operators/generic/transpose/cutt/cuttkernel.h",
+    ".*operators/generic/transpose/cutt/calls.h",
+    ".*operators/generic/transpose/cutt/cuttGpuModel.h",
+    ".*operators/generic/transpose/cutt/cuttGpuModel.cc",
+    ".*operators/generic/transpose/cutt/cuttGpuModelKernel.h",
+    ".*operators/generic/transpose/cutt/cuttGpuModelKernel.cu",
+    ".*operators/generic/transpose/cutt/CudaMemcpy.h",
+    ".*operators/generic/transpose/cutt/CudaMemcpy.cu",
+    ".*operators/generic/transpose/cutt/CudaUtils.h",
+    ".*operators/generic/transpose/cutt/CudaUtils.cu",
+    ".*operators/generic/transpose/cutt/cuttTypes.h",
+    ".*operators/generic/transpose/cutt/int_vector.h",
+    ".*operators/generic/transpose/cutt/LRUCache.h",
+    ".*python/dummy.cu"
+]
+
+
+def negative_filtering(patterns: list, file_list):
+    """
+    Patterns shall be a list of regex patterns
+    """
+    if len(patterns) == 0:
+        return file_list
+    prog = re.compile(patterns.pop())
+    it = (i for i in file_list if not prog.search(i))
+    return negative_filtering(patterns, it)
+
+
+def gather_files(path: str, patterns: list, antipatterns: list):
+    """
+    Gather files, based on `path`, that match `patterns` unix-like specification
+    and do not match `antipatterns` regexes
+    """
+    curr_path = os.getcwd()
+    os.chdir(path)
+    positive_iterators = [glob.iglob(os.path.join('**', pattern), recursive=True) for pattern in
+                          patterns]
+    linted_files = itertools.chain(*positive_iterators)
+    linted_files = (os.path.join(path, file) for file in linted_files)
+    linted_files = negative_filtering(antipatterns.copy(), linted_files)
+    ret = list(linted_files)
+    os.chdir(curr_path)
+    return ret
+
+
+def gen_cmd(dali_root_dir, file_list, process_includes=False):
+    """
+    Command for calling cpplint.py
+    """
+    return "python " + \
+           os.path.join(dali_root_dir, "third_party", "cpplint.py") + \
+           " --quiet --linelength=100 --root=" + \
+           os.path.join(dali_root_dir, "include" if process_includes else "") + \
+           " " + ' '.join(file_list)
+
+
+def main(dali_root_dir):
+    cc_files = gather_files(os.path.join(dali_root_dir, "dali"),
+                            ["*.cc", "*.h", "*.cu", "*.cuh"], negative_filters)
+    inc_files = gather_files(os.path.join(dali_root_dir, "include"),
+                             ["*.h", "*.cuh", "*.inc", "*.inl"], negative_filters)
+    os.system(gen_cmd(dali_root_dir=dali_root_dir, file_list=cc_files, process_includes=False))
+    os.system(gen_cmd(dali_root_dir=dali_root_dir, file_list=inc_files, process_includes=True))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Run linter check for DALI files")
+    parser.add_argument('dali_root_path', type=str,
+                        help='Root path of DALI repository (pointed directory should contain `.git` folder)')
+    args = parser.parse_args()
+    main(str(args.dali_root_path))

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -37,6 +37,7 @@ import sys
 # exit 0
 
 
+# Specifies, which files are to be excluded
 # These filters are regexes, not typical unix-like path specification
 negative_filters = [
     ".*core/dynlink_cuda.cc",
@@ -113,7 +114,7 @@ def main(dali_root_dir):
                              ["*.h", "*.cuh", "*.inc", "*.inl"], negative_filters)
     cc_code = os.system(gen_cmd(dali_root_dir=dali_root_dir, file_list=cc_files, process_includes=False))
     inc_code = os.system(gen_cmd(dali_root_dir=dali_root_dir, file_list=inc_files, process_includes=True))
-    if cc_code != 0 or inc_code !=0:
+    if cc_code != 0 or inc_code != 0:
         sys.exit(1)
     sys.exit(0)
 

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -22,9 +22,20 @@ import argparse
 import sys
 
 # Linter script, that calls cpplint.py, specifically for DALI repo.
-# This comes in handy for specifying pre-push git hook, so that
-# linter is automatically applied.
-# To configure this hook, edit `.git/hooks
+# This will be called in `make lint` cmake target
+
+# Q: How to configure git hook for pre-push linter check?
+# A: Create a file `.git/hooks/pre-push`:
+#
+# #!/bin/sh
+# DALI_ROOT_DIR=$(git rev-parse --show-toplevel)
+# python $DALI_ROOT_DIR/tools/lint.py $DALI_ROOT_DIR
+# ret=$?
+# if [ $ret -ne 0 ]; then
+#     exit 1
+# fi
+# exit 0
+
 
 # These filters are regexes, not typical unix-like path specification
 negative_filters = [

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -124,7 +124,7 @@ def lint(dali_root_dir, file_list, process_includes, n_subprocesses):
                     process_includes=process_includes)))
     subprocesses.append(subprocess.Popen(
         gen_cmd(dali_root_dir=dali_root_dir,
-                file_list=file_list[(n_subprocesses - 1) * diff: len(file_list)],
+                file_list=file_list[(n_subprocesses - 1) * diff:],
                 process_includes=process_includes)))
     ret = 0
     for sp in subprocesses:
@@ -133,6 +133,7 @@ def lint(dali_root_dir, file_list, process_includes, n_subprocesses):
 
 
 def main(dali_root_dir, n_subprocesses=1):
+    n_subprocesses = n_subprocesses if n_subprocesses >= 1 else 1
     cc_files = gather_files(os.path.join(dali_root_dir, "dali"),
                             ["*.cc", "*.h", "*.cu", "*.cuh"], negative_filters)
     inc_files = gather_files(os.path.join(dali_root_dir, "include"),

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -115,7 +115,6 @@ def lint(dali_root_dir, file_list, process_includes, n_subproc):
     n_subprocesses: how many subprocesses to use for linter processing
     Returns: 0 if lint passed, 1 otherwise
     """
-    assert n_subproc > 0
     if len(file_list)==0:
         return 0
     cmds = []
@@ -167,4 +166,5 @@ if __name__ == '__main__':
     parser.add_argument('--file-list', nargs='*',
                         help='List of files. This overrides the default scenario')
     args = parser.parse_args()
+    assert args.nproc > 0
     main(str(args.dali_root_path), args.nproc, file_list=args.file_list)

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -127,12 +127,13 @@ def lint(dali_root_dir, file_list, process_includes, n_subproc):
     cmds.append(gen_cmd(dali_root_dir=dali_root_dir,
                         file_list=file_list[(n_subproc - 1) * diff:],
                         process_includes=process_includes))
-    subprocesses = [subprocess.Popen(cmd, stdout=subprocess.PIPE) for cmd in cmds]
+    subprocesses = [subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) for cmd in cmds]
     success = True
     for subproc in subprocesses:
         stdout, stderr = subproc.communicate()
         success *= not bool(subproc.poll())
-        # print(stdout, stderr)
+        if len(stderr) > 0:
+            print(stderr.decode("utf-8"))
     return 0 if success else 1
 
 


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
This PR changes implementation of linter script, from CMake to python.

Why?
This change is helpful when using quite nice git's function: pre-push hooks (kudos to @AlexBula for the idea). I did get irritated sometimes, that my build fails at the linter stage. Therefore I'd like to use the git hook to verify pre-push linter compliance. This isn't stipulated for everyone - change `.git` directory however you want it.

Info, how to configure such pre-push hook is in `lint.py` file.

The downside of using this hook is that the linter takes some time, so push will take some time too. In those cases, you can go `git push --no-verify origin mybranch` - the pre-push hook won't be invoked. 

The new python script contains only system dependencies, so it will always work (didn't test that on python 2.7 though)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     NA
 - Affected modules and functionalities:
     NA
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA


**JIRA TASK**: *[Use DALI-XXXX or NA]*
