### PR TITLE
Add epsilon and ddof (delta degrees of freedom) arguments to Normalize.

### DIFF
--- a/dali/operators/math/normalize/normalize.cc
+++ b/dali/operators/math/normalize/normalize.cc
@@ -206,7 +206,11 @@ void Normalize<CPUBackend>::RunTyped(HostWorkspace &ws) {
   }
 
   if (has_scalar_stddev_) {
-    scalar_inv_stddev = scale_ / spec_.GetArgument<float>("stddev");
+    float scalar_stddev = spec_.GetArgument<float>("stddev");
+    if (epsilon_)
+      scalar_inv_stddev = scale_ * rsqrt(scalar_stddev*scalar_stddev + epsilon_);
+    else
+      scalar_inv_stddev = scale_ / scalar_stddev;
     if (!IsFullReduction()) {
       UniformFill(inv_stddev_, scalar_inv_stddev);
       inv_stddev_view = view<const float>(inv_stddev_);

--- a/dali/operators/math/normalize/normalize.cc
+++ b/dali/operators/math/normalize/normalize.cc
@@ -207,7 +207,7 @@ void Normalize<CPUBackend>::RunTyped(HostWorkspace &ws) {
 
   if (has_scalar_stddev_) {
     float scalar_stddev = spec_.GetArgument<float>("stddev");
-    if (epsilon_)
+    if (epsilon_)  // add epsilon to variance
       scalar_inv_stddev = scale_ * rsqrt(scalar_stddev*scalar_stddev + epsilon_);
     else
       scalar_inv_stddev = scale_ / scalar_stddev;

--- a/dali/operators/math/normalize/normalize.cc
+++ b/dali/operators/math/normalize/normalize.cc
@@ -92,6 +92,11 @@ samples in the batch.
     "unsigned output types.", 0.0f, false)
   .AddOptionalArg("scale", "The scaling factor applied to the output. Useful for integral "
     "output types", 1.0f, false)
+  .AddOptionalArg("epsilon", "A value added to the variance to avoid division by small numbers",
+    0.0f, false)
+  .AddOptionalArg("ddof", "Delta Degrees of Freedom for Bessel's correction. "
+    "The variance is estimated as ``sum(Xi - mean)**2 / (N - ddof)``. "
+    "This argument is ignored when externally supplied standard deviation is used.", 0, false)
   .AddOptionalArg("dtype", "Output type. When using integral types, use *shift* and *scale* to "
     "improve usage of the output type's dynamic range. If dtype is an integral type, out of range "
     "values are clamped, and non-integer values are rounded to nearest integer.", DALI_FLOAT);
@@ -142,10 +147,19 @@ void Normalize<CPUBackend>::FoldStdDev() {
   if (v == 0) {
     return;
   }
-  float rdiv = static_cast<float>(1.0 / v);
+  float rdiv = 0;
+  float scale = scale_;
+  if (v > degrees_of_freedom_) {
+    rdiv = static_cast<float>(1.0 / (v - degrees_of_freedom_));
+  } else {
+    if (epsilon_ == 0) {
+      rdiv = 1;
+      scale = 0;
+    }
+  }
   auto sample0 = make_tensor_cpu(inv_stddev_.mutable_tensor<float>(0), inv_stddev_.shape()[0]);
   auto elems = sample0.num_elements();
-  ScaleRSqrtKeepZero(sample0.data, elems, rdiv, scale_);
+  ScaleRSqrtKeepZero(sample0.data, elems, epsilon_, rdiv, scale);
 }
 
 template <>
@@ -206,7 +220,7 @@ void Normalize<CPUBackend>::RunTyped(HostWorkspace &ws) {
   } else if (has_tensor_stddev_) {
     inv_stddev_.Resize(param_shape_);
     mutable_stddev = view<float>(inv_stddev_);
-    CalcInvStdDev(mutable_stddev, stddev_input_, scale_);
+    CalcInvStdDev(mutable_stddev, stddev_input_, epsilon_, scale_);
     inv_stddev_view = mutable_stddev;
   } else {
     assert(ShouldCalcStdDev());
@@ -277,7 +291,8 @@ void Normalize<CPUBackend>::RunTyped(HostWorkspace &ws) {
           // Reset per-sample values, but don't postprocess
           stddev.Run(true, false);
           // Fused postprocessing with inverse square root.
-          SumSquare2InvStdDev(mutable_stddev[i], data_shape_[i], scale_);
+          SumSquare2InvStdDev(mutable_stddev[i], data_shape_[i],
+                              degrees_of_freedom_, epsilon_, scale_);
           assert(sample_inv_stddev.data == mutable_stddev[i].data);
         }
       }

--- a/dali/operators/math/normalize/normalize.h
+++ b/dali/operators/math/normalize/normalize.h
@@ -46,6 +46,8 @@ class Normalize : public Operator<Backend> {
     has_axis_names_arg_ = spec.HasArgument("axis_names");
     shift_ = spec.GetArgument<float>("shift");
     scale_ = spec.GetArgument<float>("scale");
+    epsilon_ = spec.GetArgument<float>("epsilon");
+    degrees_of_freedom_ = spec.GetArgument<int>("ddof");
     output_type_ = spec.GetArgument<DALIDataType>("dtype");
 
     DALI_ENFORCE(!has_axes_arg_ || !has_axis_names_arg_,
@@ -318,6 +320,8 @@ class Normalize : public Operator<Backend> {
   bool has_axis_names_arg_ = false;
   float shift_ = 0;
   float scale_ = 1;
+  float epsilon_ = 0;  //!< Added to variance for regularization
+  int degrees_of_freedom_ = 0;  //!< For Bessel's correction
   DALIDataType input_type_ = DALI_NO_TYPE, output_type_ = DALI_FLOAT;
   std::vector<int> axes_;
   int axis_mask_ = 0;


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature (degrees of freedom) needed to maintain compatibility with parameters of stddev in PyTorch and in numpy
- It adds regularizing term to normalization (added to variance)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
    * Add `epsilon` added to variance
    * And `ddof` (delta degrees of freedom), subtracted from variance's denominator
    * Improve normalization precision on CPU (Newton-Raphson step)
   * Add ddof and epsilon to tests
 - Affected modules and functionalities:
     * Normalize operator
 - Key points relevant for the review:
     * ?
 - Validation and testing:
     * End-to-end python test
 - Documentation (including examples):
     * New arguments documented in schema

**JIRA TASK**: N/A
