### PR TITLE
Slice enhancement: trim the input

### DIFF
--- a/dali/operators/generic/slice/slice.cc
+++ b/dali/operators/generic/slice/slice.cc
@@ -18,24 +18,27 @@ namespace dali {
 
 DALI_SCHEMA(Slice)
     .DocStr(
-        R"code(Extract a subtensor or `slice` with a given shape and anchor.
-Inputs must be supplied as 3 separate tensors in a specific order: `data`, `anchor` and `shape`.
-Both `anchor` and `shape` coordinates must be within the interval
-[0.0, 1.0] for normalized coordinates, or within the image shape for absolute
-coordinates. Both `anchor` and `shape` inputs will provide as many dimensions as specified
-with arguments `axis_names` or `axes`. By default `Slice` operator uses normalized
-coordinates and `WH` order for the slice arguments.)code")
+        R"code(Extract a subtensor or ``slice`` with a given shape and anchor.
+Inputs must be supplied as 3 separate tensors in a specific order: ``data``, ``anchor`` and ``shape``.
+
+Both ``anchor`` and ``shape`` coordinates shall be within the ``[0.0, 1.0]`` interval
+for normalized coordinates, or within the tensor shape for absolute coordinates. In case the values
+for given dimension exceed the shape values, they will be trimmed to the limit determined by the shape.
+
+Both ``anchor`` and ``shape`` inputs will provide as many dimensions as specified
+with arguments ``axis_names`` or ``axes``. By default ``Slice`` operator uses normalized
+coordinates and ``WH`` order for the slice arguments.)code")
     .NumInput(3)
     .NumOutput(1)
     .InputDox(0, "data", "TensorList", "Batch containing input data")
-    .InputDox(1, "anchor", "1D TensorList of floats",
+    .InputDox(1, "anchor", "1D TensorList of float",
                  R"code(Input containing either normalized or absolute coordinates
-(depending on the value of `normalized_anchor`) for the starting point of the
-slice (x0, x1, x2, ...).)code")
-    .InputDox(2, "shape", "1D TensorList of floats",
+(depending on the value of ``normalized_anchor``) for the starting point of the
+slice ``(x0, x1, x2, ...)``.)code")
+    .InputDox(2, "shape", "1D TensorList of float",
                  R"code(Input containing either normalized or absolute coordinates
-(depending on the value of `normalized_shape`) for the dimensions of the slice
-(s0, s1, s2, ...).)code")
+(depending on the value of ``normalized_shape``) for the dimensions of the slice
+``(s0, s1, s2, ...)``.)code")
     .AllowSequences()
     .SupportVolumetric()
     .AddOptionalArg("image_type",

--- a/dali/operators/generic/slice/slice_attr.h
+++ b/dali/operators/generic/slice/slice_attr.h
@@ -134,7 +134,6 @@ class SliceAttr {
           DALI_ENFORCE(slice.anchor[dim] + slice.shape[dim] <= shape[dim],
                        make_string("Something went wrong while calculating slice parameters: ",
                                    slice.anchor[dim], " + ", slice.shape[dim], " <= ", shape[dim]));
-
         }
         slice.IsInRange(shape);
         return slice;

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -349,7 +349,7 @@ def check_slice_synth_data_vs_numpy(device, batch_size, input_shape, layout, axe
             for k in range(2)]
     eii_args = [SliceArgsIterator(batch_size, len(input_shape), image_shape=input_shape,
                 image_layout=layout, axes=axes, axis_names=axis_names, normalized_anchor=normalized_anchor,
-                normalized_shape=normalized_shape)
+                normalized_shape=normalized_shape, max_norm_anchor=1.3, max_norm_shape=1.3)
                 for k in range(2)]
 
     compare_pipelines(


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
If the input to the slice (i.e. `anchor` or `shape`) was exceeding the limit provided by the shape (or `> 1.0` in case of normalized coors), the exception was thrown. This way it was impossible to implement max-size trimming, since `GetShape` operator couldn't be used with element-extraction for acquiring shape value. This PR introduces the ability to perform max-size trimming, since the shape can be trimmed at the level of acquiring arguments to the Slice operator.

Additionally, some refactoring of documentation.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     NA
 - Affected modules and functionalities:
     Slice op
 - Key points relevant for the review:
     NA
 - Validation and testing:
     nose
 - Documentation (including examples):
     yes


**JIRA TASK**: *[Use DALI-XXXX or NA]*
