### PR TITLE
Erase GPU operator 

### DIFF
--- a/dali/kernels/erase/erase_gpu.h
+++ b/dali/kernels/erase/erase_gpu.h
@@ -71,7 +71,7 @@ template <typename T, int ndim>
 struct erase_sample_desc {
   const T *in = nullptr;
   T* out = nullptr;
-  span<ibox<ndim>> erase_regions = {};
+  span<const ibox<ndim>> erase_regions = {};
   ivec<ndim> sample_shape;
   ivec<ndim> sample_stride;
 };
@@ -379,10 +379,15 @@ struct EraseGpu {
 
   KernelRequirements Setup(KernelContext &context,
                            const InListGPU<T, ndim> &in,
-                           const std::vector<std::vector<ibox<ndim>>> &erased_regions,
-                           const span<const T> fill_values = {}) {
+                           const InListGPU<int32_t, 3> &erased_regions,
+                           span<const T> fill_values = {}) {
     const int num_samples = in.num_samples();
-
+    for (int i = 0; i < num_samples; ++i) {
+      auto tshape = erased_regions.tensor_shape(i);
+      DALI_ENFORCE(tshape[1] == 2 && tshape[2] == ndim, "The `erased_regions` has to be a "
+                                                        "TensorList of shape "
+                                                        "(regions count, 2, ndims).");
+    }
     if (channel_dim == -1) {
       DALI_ENFORCE(fill_values.size() == 1 || fill_values.size() == 0,
                    make_string("Kernel is unaware of channel dimension, exactly 0 or 1 fill value "
@@ -416,10 +421,6 @@ struct EraseGpu {
       se.add<T>(AllocType::GPU, 1);
     }
 
-    for (auto &regions : erased_regions) {
-      se.add<ibox<ndim>>(AllocType::GPU, regions.size());
-    }
-
     req.output_shapes = {in.shape};
     req.scratch_sizes = se.sizes;
     return req;
@@ -437,7 +438,7 @@ struct EraseGpu {
   void Run(KernelContext &ctx,
            OutListGPU<T, ndim> &out,
            const InListGPU<T, ndim> &in,
-           const std::vector<std::vector<ibox<ndim>>> &erased_regions,
+           const InListGPU<int32_t, 3> &erased_regions,
            span<const T> fill_values = {}) {
     auto stream = ctx.gpu.stream;  // MAYBE some runtime check if it's not used?
     const int num_samples = in.num_samples();
@@ -505,8 +506,9 @@ struct EraseGpu {
       auto &sample = sample_desc_cpu[i];
       sample.in = in.data[i];
       sample.out = out.data[i];
-      auto *regions_ptr = ctx.scratchpad->ToGPU(stream, erased_regions[i]);
-      sample.erase_regions = make_span(regions_ptr, erased_regions[i].size());
+      const auto *box_ptr = reinterpret_cast<const ibox<ndim>*>(erased_regions.tensor_data(i));
+      auto n_boxes = erased_regions.tensor_shape(i)[0];
+      sample.erase_regions = make_cspan(box_ptr, n_boxes);
       for (int dim = 0; dim < ndim; dim++) {
         sample.sample_shape[dim] = in.tensor_shape_span(i)[dim];
       }

--- a/dali/kernels/erase/erase_gpu_test.cu
+++ b/dali/kernels/erase/erase_gpu_test.cu
@@ -267,7 +267,7 @@ struct EraseGpuKernelTest :
       // full cover
       for (int i = 0; i < batch_size_; i++) {
         auto regions_tv = regions_cpu[i];
-         *regions_tv(0) = ibox<ndim>({0}, to_ivec(shape_));
+        *regions_tv(0) = ibox<ndim>({0}, to_ivec(shape_));
       }
     } else if (region_generation_ == RegionGen::RANDOM_ERASE) {
       for (int i = 0; i < batch_size_; i++) {

--- a/dali/kernels/scratch_copy_impl.h
+++ b/dali/kernels/scratch_copy_impl.h
@@ -102,8 +102,8 @@ std::tuple<std::remove_cv_t<element_t<Collections>>*...>
 ToContiguousHostMem(Scratchpad &scratchpad, const Collections &... c) {
   const size_t N = sizeof...(Collections);
   static_assert(
-    all_of<std::is_pod<std::remove_cv_t<element_t<Collections>>>::value...>::value,
-    "ToContiguousHostMem must be used with collections of POD types");
+    all_of<std::is_trivially_copyable<std::remove_cv_t<element_t<Collections>>>::value...>::value,
+    "ToContiguousHostMem must be used with collections of trivially copyable types");
 
   std::array<size_t, N + 1> offsets;
   detail::GetCollectionOffsets(0, &offsets[0], c...);

--- a/dali/kernels/scratch_copy_impl.h
+++ b/dali/kernels/scratch_copy_impl.h
@@ -126,8 +126,8 @@ std::tuple<std::remove_cv_t<element_t<Collections>>*...>
 ToContiguousGPUMem(Scratchpad &scratchpad, cudaStream_t stream, const Collections &... c) {
   const size_t N = sizeof...(Collections);
   static_assert(
-    all_of<std::is_pod<std::remove_cv_t<element_t<Collections>>>::value...>::value,
-    "ToContiguousGPUMem must be used with collections of POD types");
+    all_of<std::is_trivially_copyable<std::remove_cv_t<element_t<Collections>>>::value...>::value,
+    "ToContiguousGPUMem must be used with collections of trivially copyable types");
 
   std::array<size_t, N + 1> offsets;
   detail::GetCollectionOffsets(0, &offsets[0], c...);

--- a/dali/operators/generic/erase/erase.cu
+++ b/dali/operators/generic/erase/erase.cu
@@ -46,6 +46,26 @@ void fill_with_box(kernels::OutTensorCPU<int32_t, 3> regions,
   }
 }
 
+template <int ndim, typename Storage>
+TensorListView<Storage, kernels::ibox<ndim>, 1>
+as_boxes(TensorListView<Storage, int32_t, 3> tlv) {
+  TensorListShape<1> new_shape(tlv.shape.size());
+  for (int i = 0; i < tlv.shape.size(); ++i)
+    new_shape.set_tensor_shape(i, {tlv.shape[i][0]});
+  using ptrs_t = kernels::ibox<ndim>* const*;
+  return {reinterpret_cast<ptrs_t>(tlv.data.data()), new_shape};
+}
+
+template <int ndim, typename Storage>
+TensorListView<Storage, const kernels::ibox<ndim>, 1>
+as_boxes(TensorListView<Storage, const int32_t, 3> tlv) {
+  TensorListShape<1> new_shape(tlv.shape.size());
+  for (int i = 0; i < tlv.shape.size(); ++i)
+    new_shape.set_tensor_shape(i, {tlv.shape[i][0]});
+  using ptrs_t = const kernels::ibox<ndim>* const*;
+  return {reinterpret_cast<ptrs_t>(tlv.data.data()), new_shape};
+}
+
 }  // namespace detail
 
 template <typename T, int Dims, int channel_dim>
@@ -70,7 +90,7 @@ class EraseImplGpu : public OpImplBase<GPUBackend> {
     auto in_view = view<const T, Dims>(input);
     kmgr_.Initialize<EraseKernel>();
     ctx_.gpu.stream = ws.stream();
-    auto regions_view = view<const int32_t, 3>(regions_gpu_);
+    auto regions_view = detail::as_boxes<Dims>(view<const int32_t, 3>(regions_gpu_));
     kmgr_.Setup<EraseKernel>(0, ctx_, in_view, regions_view, make_cspan(fill_values_));
 
     output_desc.resize(1);
@@ -81,7 +101,7 @@ class EraseImplGpu : public OpImplBase<GPUBackend> {
   void RunImpl(workspace_t<GPUBackend> &ws) override {
     auto input = view<const T, Dims>(ws.template InputRef<GPUBackend>(0));
     auto output = view<T, Dims>(ws.template OutputRef<GPUBackend>(0));
-    auto regions_view = view<const int32_t, 3>(regions_gpu_);
+    auto regions_view = detail::as_boxes<Dims>(view<const int32_t, 3>(regions_gpu_));
     kmgr_.Run<EraseKernel>(0, 0, ctx_, output, input, regions_view, make_cspan(fill_values_));
   }
 
@@ -97,12 +117,12 @@ class EraseImplGpu : public OpImplBase<GPUBackend> {
     TensorList<CPUBackend> regions_cpu;
     regions_cpu.set_type(TypeTable::GetTypeInfo(TypeTable::GetTypeID<int32_t>()));
     regions_cpu.Resize(regions_shape);
-    auto regions_tlv = view<int32_t, 3>(regions_cpu);
+    auto regions_tlv = detail::as_boxes<Dims>(view<int32_t, 3>(regions_cpu));
     for (int i = 0; i < batch_size_; ++i) {
       auto regions_tv = regions_tlv[i];
       for (int j = 0; j < regions_tv.shape[0]; ++j) {
         auto box = detail::make_box(args[i].rois[j].anchor, args[i].rois[j].shape);
-        detail::fill_with_box(regions_tv, box, j);
+        *regions_tv(j) = box;
       }
     }
     regions_gpu_.Copy(regions_cpu, ws.stream());

--- a/dali/operators/generic/erase/erase.cu
+++ b/dali/operators/generic/erase/erase.cu
@@ -1,0 +1,162 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <vector>
+#include "dali/core/static_switch.h"
+#include "dali/kernels/erase/erase_gpu.h"
+#include "dali/kernels/kernel_manager.h"
+#include "dali/operators/generic/erase/erase.h"
+#include "dali/operators/generic/erase/erase_utils.h"
+#include "dali/pipeline/data/views.h"
+
+#define ERASE_SUPPORTED_NDIMS (1, 2, 3, 4, 5)
+#define ERASE_SUPPORTED_TYPES (uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, \
+                               uint64_t, int64_t, float)
+namespace dali {
+
+namespace detail {
+
+template <int ndim>
+ivec<ndim> to_ivec(const TensorShape<ndim> &shape) {
+  ivec<ndim> result;
+  for (int d = 0; d < ndim; d++) {
+    result[d] = shape[d];
+  }
+  return result;
+}
+
+template <int ndim>
+kernels::ibox<ndim> make_box(const TensorShape<ndim> &lcorner, const TensorShape<ndim> &shape) {
+  auto lc = to_ivec(lcorner);
+  return Box<ndim, int>(lc, lc + to_ivec(shape));
+}
+
+}  // namespace detail
+
+template <typename T, int Dims, int channel_dim>
+class EraseImplGpu : public OpImplBase<GPUBackend> {
+ public:
+  using EraseKernel = kernels::EraseGpu<T, Dims, channel_dim>;
+
+  explicit EraseImplGpu(const OpSpec &spec)
+      : spec_(spec), batch_size_(spec.GetArgument<int>("batch_size")) {
+        kmgr_.Resize<EraseKernel>(1, 1);
+      }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc,
+                 const workspace_t<GPUBackend> &ws) override {
+    const auto &input = ws.template InputRef<GPUBackend>(0);
+    auto layout = input.GetLayout();
+    auto type = input.type();
+    auto shape = input.shape();
+    AcquireArgs(ws, shape, layout);
+
+    auto in_view = view<const T, Dims>(input);
+    kmgr_.Initialize<EraseKernel>();
+    ctx_.gpu.stream = ws.stream();
+    kmgr_.Setup<EraseKernel>(0, ctx_, in_view, regions_, make_cspan(fill_values_));
+
+    output_desc.resize(1);
+    output_desc[0] = {shape, input.type()};
+    return true;
+  };
+
+  void RunImpl(workspace_t<GPUBackend> &ws) override {
+    auto input = view<const T, Dims>(ws.template InputRef<GPUBackend>(0));
+    auto output = view<T, Dims>(ws.template OutputRef<GPUBackend>(0));
+    kmgr_.Run<EraseKernel>(0, 0, ctx_, output, input, regions_, make_cspan(fill_values_));
+  }
+
+  void AcquireArgs(const ArgumentWorkspace &ws, TensorListShape<> in_shape,
+                   TensorLayout in_layout) {
+    fill_values_ = spec_.template GetRepeatedArgument<float>("fill_value");
+    DALI_ENFORCE(channel_dim >= 0 || fill_values_.size() <= 1,
+      "If a multi channel fill value is provided, the input layout must have a 'C' dimension");
+    regions_.resize(batch_size_);
+    auto args = detail::GetEraseArgs<T, Dims>(spec_, ws, in_shape, in_layout);
+    for (int i = 0; i < batch_size_; ++i) {
+      regions_[i].reserve(args[i].rois.size());
+      const auto &rois = args[i].rois;
+      for (const auto &roi : args[i].rois) {
+        regions_[i].push_back(detail::make_box(roi.anchor, roi.shape));
+      }
+    }
+  }
+
+ private:
+  OpSpec spec_;
+  int batch_size_ = 0;
+  std::vector<int> axes_;
+  std::vector<kernels::EraseArgs<T, Dims>> args_;
+  std::vector<std::vector<kernels::ibox<Dims>>> regions_;
+  SmallVector<T, 3> fill_values_;
+  kernels::KernelManager kmgr_;
+  kernels::KernelContext ctx_;
+};
+
+namespace detail {
+
+template <typename T, int Dims, int... ChDims>
+struct select_impl {};
+
+template <typename T, int Dims, int ChDim, int... ChDims>
+struct select_impl<T, Dims, ChDim, ChDims...> {
+  static std::unique_ptr<OpImplBase<GPUBackend>> make(int channel_dim, const OpSpec &spec) {
+    if (channel_dim == ChDim) {
+      return std::make_unique<EraseImplGpu<T, Dims, ChDim>>(spec);
+    } else {
+      return select_impl<T, Dims, ChDims...>::make(channel_dim, spec);
+    }
+  }
+};
+
+template <typename T, int Dims, int ChDim>
+struct select_impl<T, Dims, ChDim> {
+  static std::unique_ptr<OpImplBase<GPUBackend>> make(int channel_dim, const OpSpec &spec) {
+    if (channel_dim == ChDim) {
+      return std::make_unique<EraseImplGpu<T, Dims, ChDim>>(spec);
+    } else {
+      DALI_FAIL("Unsopported layout. Only channel-first and channel-last layouts are supported.");
+    }
+  }
+};
+
+}  // namespace detail
+
+template <>
+bool Erase<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
+                                  const workspace_t<GPUBackend> &ws) {
+  const auto &input = ws.InputRef<GPUBackend>(0);
+  auto in_shape = input.shape();
+  auto channel_dim = input.GetLayout().find('C');
+  TYPE_SWITCH(input.type().id(), type2id, T, ERASE_SUPPORTED_TYPES, (
+    VALUE_SWITCH(in_shape.sample_dim(), Dims, ERASE_SUPPORTED_NDIMS, (
+      impl_ = detail::select_impl<T, Dims, -1, 0, Dims-1>::make(channel_dim, spec_);
+    ), DALI_FAIL(make_string("Unsupported number of dimensions ", in_shape.size())));  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported data type: ", input.type().id())));  // NOLINT
+
+  assert(impl_ != nullptr);
+  return impl_->SetupImpl(output_desc, ws);
+}
+
+template <>
+void Erase<GPUBackend>::RunImpl(workspace_t<GPUBackend> &ws) {
+  assert(impl_ != nullptr);
+  impl_->RunImpl(ws);
+}
+
+DALI_REGISTER_OPERATOR(Erase, Erase<GPUBackend>, GPU);
+
+}  // namespace dali

--- a/dali/operators/generic/erase/erase.cu
+++ b/dali/operators/generic/erase/erase.cu
@@ -35,17 +35,6 @@ kernels::ibox<ndim> make_box(const TensorShape<ndim> &lcorner, const TensorShape
   return kernels::ibox<ndim>(lc, lc + kernels::to_ivec(shape));
 }
 
-template <int ndim>
-void fill_with_box(kernels::OutTensorCPU<int32_t, 3> regions,
-                   const kernels::ibox<ndim> &box, int idx) {
-  auto *lo = regions(idx, 0);
-  auto *hi = regions(idx, 1);
-  for (int d = 0; d < ndim; ++d) {
-    lo[d] = box.lo[d];
-    hi[d] = box.hi[d];
-  }
-}
-
 template <int ndim, typename Storage>
 TensorListView<Storage, kernels::ibox<ndim>, 1>
 as_boxes(TensorListView<Storage, int32_t, 3> tlv) {

--- a/dali/operators/generic/erase/erase_utils.h
+++ b/dali/operators/generic/erase/erase_utils.h
@@ -31,7 +31,7 @@ namespace dali {
 
 namespace detail {
 
-SmallVector<int, 6> GetAxes(const OpSpec &spec, TensorLayout layout) {
+static SmallVector<int, 6> GetAxes(const OpSpec &spec, TensorLayout layout) {
   SmallVector<int, 6> axes;
   if (spec.HasArgument("axis_names")) {
     axes = GetDimIndices(layout, spec.GetArgument<TensorLayout>("axis_names"));

--- a/dali/test/python/test_operator_erase.py
+++ b/dali/test/python/test_operator_erase.py
@@ -208,7 +208,7 @@ def test_operator_erase_with_normalized_coords():
             ("HWC", (60, 80, 1), "WH", (10, 4), (50, 40), (10/80.0, 4/60.0), (50/80.0, 40/60.0), 0),
             ("XYZ", (60, 80, 3), "X", (4,), (7,), (4/60.0,), (7/60.0,), -10),]
 
-    for device in ['cpu']:
+    for device in ['cpu', 'gpu']:
         for batch_size in [1, 8]:
             for input_layout, input_shape, axis_names, anchor, shape, anchor_norm, shape_norm, fill_value in rois:
                 assert len(input_layout) == len(input_shape)


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds a GPU erase operator needed for audio support. 

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *The gpu erase kernel was modified to support different number of erase regions for each sample. The operator implementation is mostly just instantiating the kernel.*
 - Affected modules and functionalities:
     *GPU erase kernel and a new file with GPU operator.*
 - Key points relevant for the review:
     *Instantiating the kernel.*
 - Validation and testing:
     *Existing python test was extended to GPU. Kernel test was extended to cover different number of erase regions per sample.*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1245]*
