### PR TITLE
Normalize GPU kernel

### DIFF
--- a/dali/kernels/normalize/normalize_gpu_impl.cuh
+++ b/dali/kernels/normalize/normalize_gpu_impl.cuh
@@ -115,7 +115,7 @@ struct NormalizeScalar {
  *        be regularized and inversed.
  *
  * The output elements are calculated as:
- * mul = 1 / sqrt(sqr(stddev[param_offset]) + epsilon)
+ * mul = 1 / sqrt(square(stddev[param_offset]) + epsilon)
  * (in[offset] - mean[param_offset]) * mul * scale + shift
  */
 template <int max_dims, typename Out, typename In, typename Mean, typename StdDev>
@@ -148,7 +148,7 @@ struct NormalizeInvStdDevNonScalar {
  *        be regularized and inversed.
  *
  * The output elements are calculated as:
- * mul = 1 / sqrt(sqr(stddev[param_offset]) + epsilon)
+ * mul = 1 / sqrt(square(stddev[param_offset]) + epsilon)
  * (in[offset] - mean[param_offset]) * mul * scale + shift
  */
 template <int max_dims, typename Out, typename In, typename StdDev>

--- a/dali/kernels/normalize/normalize_gpu_impl.cuh
+++ b/dali/kernels/normalize/normalize_gpu_impl.cuh
@@ -1,0 +1,372 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_NORMALIZE_NORMALIZE_GPU_IMPL_CUH_
+#define DALI_KERNELS_NORMALIZE_NORMALIZE_GPU_IMPL_CUH_
+
+#include "dali/core/convert.h"
+#include "dali/core/small_vector.h"
+#include "dali/kernels/reduce/reduce_drop_dims.h"
+#include "dali/kernels/kernel.h"
+
+namespace dali {
+namespace kernels {
+
+namespace normalize_impl {
+
+template <int max_dims, typename Out, typename In>
+struct NormalizeNonScalar {
+  Out *__restrict__ out;
+  const In *__restrict__ in;
+  int64_t size;
+  const float *__restrict__ base;
+  const float *__restrict__ scale;
+  reduce_impl::DropDims<max_dims> dd;
+
+  DALI_HOST_DEV DALI_FORCEINLINE
+  void apply(int64_t offset, float global_scale, float global_shift) {
+    int64_t param_offset = dd.reindex(offset);
+  #ifdef __CUDA_ARCH__
+    float sub = __ldg(base + param_offset);
+    float mul = __ldg(scale + param_offset) * global_scale;
+  #else
+    float sub = base[param_offset];
+    float mul = scale[param_offset] * global_scale;
+  #endif
+    float v = ConvertSat<Out>((in[offset] - sub) * mul + global_shift);
+  }
+};
+
+template <int max_dims, typename Out, typename In>
+struct NormalizeScalarScale {
+  Out *__restrict__ out;
+  const In *__restrict__ in;
+  int64_t size;
+  const float *__restrict__ base;
+  reduce_impl::DropDims<max_dims> dd;
+  float scale;
+
+  DALI_HOST_DEV DALI_FORCEINLINE
+  void apply(int64_t offset, float global_scale, float global_shift) {
+    int64_t param_offset = dd.reindex(offset);
+  #ifdef __CUDA_ARCH__
+    float sub = __ldg(base + param_offset);
+  #else
+    float sub = base[param_offset];
+  #endif
+    float mul = scale * global_scale;
+    float v = ConvertSat<Out>((in[offset] - sub) * mul + global_shift);
+  }
+};
+
+template <int max_dims, typename Out, typename In>
+struct NormalizeScalarBase {
+  Out *__restrict__ out;
+  const In *__restrict__ in;
+  int64_t size;
+  const float *__restrict__ scale;
+  reduce_impl::DropDims<max_dims> dd;
+  float base;
+
+  DALI_HOST_DEV DALI_FORCEINLINE
+  void apply(int64_t offset, float global_scale, float global_shift) {
+    int64_t param_offset = dd.reindex(offset);
+  #ifdef __CUDA_ARCH__
+    float mul = __ldg(scale + param_offset) * global_scale;
+  #else
+    float mul = scale[param_offset] * global_scale;
+  #endif
+    float v = ConvertSat<Out>((in[offset] - base) * mul + global_shift);
+  }
+};
+
+template <typename Out, typename In>
+struct NormalizeScalar {
+  Out *__restrict__ out;
+  const In *__restrict__ in;
+  int64_t size;
+  float base, scale;
+
+  DALI_HOST_DEV DALI_FORCEINLINE
+  void apply(int64_t offset, float global_scale, float global_shift) {
+    float v = ConvertSat<Out>((in[offset] - base) * scale * global_scale + global_shift);
+  }
+};
+
+/**
+ * @brief This variant is used when standard deviation is externally provided and needs to
+ *        be regularized and inversed.
+ *
+ * The output elements are calculated as:
+ * mul = 1 / sqrt(sqr(stddev[param_offset]) + epsilon)
+ * (in[offset] - mean[param_offset]) * mul * scale + shift
+ */
+template <int max_dims, typename Out, typename In>
+struct NormalizeInvRegNonScalar {
+  Out *__restrict__ out;
+  const In *__restrict__ in;
+  int64_t size;
+  const float *__restrict__ base;
+  const float *__restrict__ scale;
+  reduce_impl::DropDims<max_dims> dd;
+
+  DALI_HOST_DEV DALI_FORCEINLINE
+  void apply(int64_t offset, float epsilon, float global_scale, float global_shift) {
+    int64_t param_offset = dd.reindex(offset);
+  #ifdef __CUDA_ARCH__
+    float mean = __ldg(base + param_offset);
+    float stddev = __ldg(scale + param_offset);
+  #else
+    float mean = base[param_offset];
+    float stddev = scale[param_offset];
+  #endif
+    float mul = rsqrt(stddev * stddev + epsilon);
+    float v = ConvertSat<Out>((in[offset] - mean) * mul + global_shift);
+  }
+};
+
+/**
+ * @brief This variant is used when standard deviation is externally provided and needs to
+ *        be regularized and inversed.
+ *
+ * The output elements are calculated as:
+ * mul = 1 / sqrt(sqr(stddev[param_offset]) + epsilon)
+ * (in[offset] - mean[param_offset]) * mul * scale + shift
+ */
+template <int max_dims, typename Out, typename In>
+struct NormalizeInvRegScalarBase {
+  Out *__restrict__ out;
+  const In *__restrict__ in;
+  int64_t size;
+  const float *__restrict__ scale;
+  reduce_impl::DropDims<max_dims> dd;
+  float base;
+
+  DALI_HOST_DEV DALI_FORCEINLINE
+  void apply(int64_t offset, float epsilon, float global_scale, float global_shift) {
+    int64_t param_offset = dd.reindex(offset);
+  #ifdef __CUDA_ARCH__
+    float stddev = __ldg(scale + param_offset);
+  #else
+    float stddev = scale[param_offset];
+  #endif
+    float mul = rsqrt(stddev * stddev + epsilon);
+    float v = ConvertSat<Out>((in[offset] - mul) * mul + global_shift);
+  }
+};
+
+template <typename NormalizeParams>
+__global__ void Normalize(const NormalizeParams *sample_params,
+                          float scale, float shift) {
+  auto params = sample_params[blockIdx.y];
+  int64_t start_ofs = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t grid_stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t ofs = start_ofs; ofs < params.size; ofs += grid_stride) {
+    params.apply(ofs, scale, shift);
+  }
+}
+
+template <typename NormalizeParams>
+__global__ void NormalizeEps(const NormalizeParams *sample_params,
+                             float epsilon, float scale, float shift) {
+  auto params = sample_params[blockIdx.y];
+  int64_t start_ofs = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  int64_t grid_stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t ofs = start_ofs; ofs < params.size; ofs += grid_stride) {
+    params.apply(ofs, epsilon, scale, shift);
+  }
+}
+
+template <typename Out, typename In, typename BaseParam, typename ScaleParam>
+class NormalizeImplGPU {
+  static constexpr const int kMaxDims = 4;
+
+  using Op_NonScalar = NormalizeNonScalar<kMaxDims, Out, In>;
+  using Op_ScalarBase = NormalizeScalarBase<kMaxDims, Out, In>;
+  using Op_ScalarScale = NormalizeScalarScale<kMaxDims, Out, In>;
+  using Op_Scalar = NormalizeScalar<Out, In>;
+  using Op_InvStdDevNonScalar = NormalizeInvRegNonScalar<kMaxDims, Out, In>;
+  using Op_InvStdDevScalarBase = NormalizeInvRegScalarBase<kMaxDims, Out, In>;
+
+ public:
+  KernelRequirements Setup(KernelContext &ctx,
+                           const TensorListShape<> &data_shape,
+                           const TensorListShape<> &param_shape,
+                           bool scalar_base,
+                           bool scalar_scale,
+                           bool scale_is_stddev) {
+    int ndim = data_shape.sample_dim();
+    if (!scalar_base || !scalar_scale) {
+      if (param_shape.sample_dim() != ndim) {
+        throw std::invalid_argument("Normalization parameters must have the same "
+          "dimensionality as the data");
+      }
+      if (param_shape.num_samples() != data_shape.num_samples() && param_shape.num_samples() != 1) {
+        throw std::invalid_argument("Normalization parameters must have either the same number "
+          "of samples as the input or just one sample.");
+      }
+
+      axes_.clear();
+      for (int d = 0; d < ndim; d++) {
+        if (is_degenerate_dim(param_shape_, d))
+          axes_.push_back(d);
+      }
+    } else {
+      if (param_shape.num_samples() > 0)
+        throw std::invalid_argument("`param_shape` must be empty when using scalar parameters");
+
+      axes_.resize(ndim);
+      for (int d = 0; d < ndim; d++)
+        axes_[d] = d;
+    }
+    return Setup(ctx, data_shape, make_span(axes_), scalar_base, scalar_scale, scale_is_stddev);
+  }
+
+  KernelRequirements Setup(KernelContext &ctx,
+                           const TensorListShape<> &data_shape,
+                           span<const int> axes,
+                           bool scalar_base,
+                           bool scalar_scale,
+                           bool scale_is_stddev) {
+    KernelRequirements req;
+    req.output_shapes = { data_shape };
+    ScratchpadEstimator se;
+
+    // this condition is false when the other Setup overload was used
+    if (axes_.data() != axes.data())
+      this->axes_ = { axes_.begin(), axes_.end() };
+
+    this->scale_is_stddev_ = scale_is_stddev_;
+    this->scalar_base_ = scalar_base_;
+    this->scalar_scale_ = scalar_scale_;
+    if (scalar_scale_) {
+      // scale is a scalar - it will be corrected before launch, in host code
+      if (scalar_base_) {
+        SetupScalar(se);
+      } else {
+        SetupScalarScale(se);
+      }
+    } else {
+      if (scale_is_stddev_) {
+        if (scalar_base_) {
+          SetupInvStddDvScalarBase(se);
+        } else {
+          SetupInvStdDevNonScalar(se);
+        }
+      } else {
+        if (scalar_base_) {
+          SetupScalarBase(se);
+        } else {
+          SetupNonScalar(se);
+        }
+      }
+    }
+
+    req.scratch_sizes = se.sizes;
+    return req;
+  }
+
+  void Run(KernelContext &ctx,
+           const OutListGPU<Out> &out, const InListGPU<In> &in,
+           const InListGPU<BaseParam> &base, const InListGPU<ScaleParam> &scale,
+           float epsilon = 0) {
+    assert(!scalar_base_ && !scalar_scale_);
+    if (!scalar_base_)
+      CheckParamShape(in.shape, base.shape);
+    if (!scalar_scale_)
+      CheckParamShape(in.shape, scale.shape);
+
+    if (scale_is_stddev_) {
+
+    }
+  }
+
+ private:
+  void CheckParamShape(const TensorListShape<> &data_shape, const TensorListShape<> &param_shape) {
+    bool broadcast_param = param_shape.num_samples() == 1;
+    int D = data_shape.sample_dim();
+    int N = data_shape.num_samples();
+    for (int i = 0; i < N; i++, o += !broadcast_param) {
+      auto dshape = data_shape[i];
+      auto pshape = param_shape[o];
+      for (int d = 0; d < D; d++) {
+        if (axis_mask_ & (1<<d)) {
+          if (pshape[d] != 1) {
+            throw std::invalid_argument(make_str("Parameter tensor must have extent 1 "
+              "in reduced axes. Got:"
+              "\nparameter shape: ", pshape,
+              "\nreduced axes:    ", axes_str()));
+          }
+        } else {
+          if (pshape[d] != dshape[d]) {
+            throw std::invalid_argument(make_str("Parameter tensor must have extent equal to input "
+              "shape in non reduced axes. Got:"
+              "\nparameter shape: ", pshape,
+              "\ndata shape: ", dshape,
+              "\nreduced axes:    ", axes_str()));
+          }
+        }
+      }
+    }
+  }
+
+  std::string axes_str() const {
+    std::stringstream ss;
+    ss << "{";
+    bool first = true;
+    for (auto a : axes_) {
+      if (first) first = false;
+      else ss << ", ";
+      ss << a;
+    }
+    ss << "}";
+    return ss.str();
+  }
+
+  void SetupScalar(ScratchpadEstimator &se) {
+    SetupImpl<Op_Scalar>(se);
+  }
+  void SetupScalarScale(ScratchpadEstimator &se) {
+    SetupImpl<Op_ScalarScale>(se);
+  }
+  void SetupInvStddDvScalarBase(ScratchpadEstimator &se) {
+    SetupImpl<Op_InvStdDevScalarBase>(se);
+  }
+  void SetupInvStdDevNonScalar(ScratchpadEstimator &se) {
+    SetupImpl<Op_InvStdDevNonScalar>(se);
+  }
+  void SetupScalarBase(ScratchpadEstimator &se) {
+    SetupImpl<Op_ScalarBase>(se);
+  }
+  void SetupNonScalar(ScratchpadEstimator &se) {
+    SetupImpl<Op_NonScalar>(se);
+  }
+
+  template <typename Desc>
+  void SetupImpl(ScratchpadEstimator &se) {
+
+  }
+
+  SmallVector<int, DynamicTensorShapeContainer::static_size> axes_;
+  uint64_t axis_mask_;
+  bool scale_is_stddev_;
+  bool scalar_base_;
+  bool scalar_scale_;
+};
+
+}  // namespace normalize_impl
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_NORMALIZE_NORMALIZE_GPU_IMPL_CUH_

--- a/dali/kernels/normalize/normalize_gpu_impl_test.cu
+++ b/dali/kernels/normalize/normalize_gpu_impl_test.cu
@@ -1,0 +1,22 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <random>
+#include "dali/test/device_test.h"
+#include "dali/kernels/normalize/normalize_gpu_impl.cuh"
+
+namespace dali {
+
+}  // namespace dali

--- a/dali/kernels/normalize/normalize_gpu_impl_test.cu
+++ b/dali/kernels/normalize/normalize_gpu_impl_test.cu
@@ -18,5 +18,125 @@
 #include "dali/kernels/normalize/normalize_gpu_impl.cuh"
 
 namespace dali {
+namespace kernels {
 
+template <bool calc_inv_stddev, typename Out, typename In>
+void RefNormalize(
+    const OutTensorCPU<Out> &out,
+    const InTensorCPU<In> &in, const InTensorCPU<float> &base,
+    const InTensorCPU<float> &scale,
+    float global_scale, float shift, float epsilon,
+    TensorShape<> &data_pos, TensorShape<> &base_pos, TensorShape<> &scale_pos, int dim) {
+
+  int db = 0, ds = 0;
+  int64_t extent = 0;
+  if (dim < in.dim()) {
+    db = base.shape[dim] > 1 ? 1 : 0;
+    ds = scale.shape[dim] > 1 ? 1 : 0;
+    extent = in.shape[dim];
+  }
+  if (dim >= in.dim() - 1) {  // handles both last dimension and degenerate case
+    Out *optr = out(data_pos);
+    const In *iptr = in(data_pos);
+    const float *sptr = scale(scale_pos);
+    const float *bptr = base(base_pos);
+    for (int64_t i = 0, b = 0, s = 0; i < extent; i++, b += db, s += ds) {
+      float mul;
+      if (calc_inv_stddev) {
+        float x = sptr[s] * sptr[s] + epsilon;
+        mul = x ? rsqrt(x) * global_scale : 0;
+      } else {
+        mul = sptr[s] * global_scale;
+      }
+      optr[i] = ConvertSat<Out>(fma(iptr[i] - bptr[b], mul, shift));
+    }
+  } else {
+    for (int64_t i = 0, b = 0, s = 0; i < extent; i++, b += db, s += ds) {
+      data_pos[dim] = i;
+      base_pos[dim] = b;
+      scale_pos[dim] = s;
+      RefNormalize<calc_inv_stddev>(out, in, base, scale, epsilon, global_scale, shift,
+                                    data_pos, base_pos, scale_pos, dim + 1);
+    }
+  }
+}
+
+
+
+template <typename Out, typename In>
+void RefNormalize(
+    const OutTensorCPU<Out> &out,
+    const InTensorCPU<In> &in, const InTensorCPU<float> &base,
+    const InTensorCPU<float> &scale,
+    float global_scale, float shift,
+    bool calc_inv_stddev, float epsilon) {
+  TensorShape<> data_pos, base_pos, scale_pos;
+  int D = in.dim();
+  data_pos.resize(D);
+  base_pos.resize(D);
+  scale_pos.resize(D);
+  if (calc_inv_stddev) {
+    RefNormalize<true>(out, in, base, scale, epsilon, global_scale, shift,
+                       data_pos, base_pos, scale_pos, 0);
+  } else {
+    RefNormalize<false>(out, in, base, scale, epsilon, global_scale, shift,
+                        data_pos, base_pos, scale_pos, 0);
+  }
+}
+
+
+template <typename Out, typename In>
+void RefNormalize(
+    const OutListCPU<Out> &out, const InListCPU<In> &in,
+    const InListCPU<float> &base, const InListCPU<float> &scale,
+    float global_scale, float shift,
+    bool calc_inv_stddev, float epsilon) {
+  assert(out.shape == in.shape);
+  int N = in.num_samples();
+  int db = base.num_samples() > 1;
+  int ds = scale.num_samples() > 1;
+  for (int i = 0, b = 0, s = 0; i < N; i++, b += db, s += ds) {
+    RefNormalize(out[i], in[i], base[b], scale[s], global_scale, shift, calc_inv_stddev, epsilon);
+  }
+}
+
+
+template <typename Out, typename In>
+void RefNormalize(
+    const OutListCPU<Out> &out, const InListCPU<In> &in,
+    const InListCPU<float> &base, float scale,
+    float global_scale, float shift,
+    bool calc_inv_stddev, float epsilon) {
+  assert(out.shape == in.shape);
+  int N = in.num_samples();
+  int db = base.num_samples() > 1;
+  TensorView<StorageCPU, float> scale_tv;
+  scale_tv.data = &scale;
+  for (int i = 0, b = 0; i < N; i++, b += db) {
+    RefNormalize(out[i], in[i], base[b], scale_tv, global_scale, shift, calc_inv_stddev, epsilon);
+  }
+}
+
+template <typename Out, typename In>
+void RefNormalize(
+    const OutListCPU<Out> &out, const InListCPU<In> &in,
+    float base, const InListCPU<float> &scale,
+    float global_scale, float shift,
+    bool calc_inv_stddev, float epsilon) {
+  assert(out.shape == in.shape);
+  int N = in.num_samples();
+  int ds = scale.num_samples() > 1;
+  TensorView<StorageCPU, float> base_tv;
+  base_tv.data = &base;
+  for (int i = 0, s = 0; i < N; i++, s += ds) {
+    RefNormalize(out[i], in[i], base_tv, scale[s], global_scale, shift, calc_inv_stddev, epsilon);
+  }
+}
+
+
+TEST(NormalizeKernel, NonScalar) {
+
+}
+
+}  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
@@ -161,7 +161,7 @@ struct VariancePreprocessorBank<2, Mean> {
   const Mean *mean;
   i64vec<2> stride;
   /// Calculates the fully reduced inner offset based on non-reduced `pos[1]`
-  DropDims inner_dims;
+  DropDims<3> inner_dims;
 
   DALI_HOST_DEV DALI_FORCEINLINE
   reductions::variance<Mean> Get(const i64vec<2> &pos) const {
@@ -242,7 +242,7 @@ class VarianceImplBase {
       bank.mean = mean_.data[o];
       bank.stride[0] = volume(out_shape.begin() + axis, out_shape.end());  // outer stride
       bank.stride[1] = 1;  // inner stride, always 1?
-      bank.inner_dims = DropDims(inner_shape, mask);  // reindexing, if necessary
+      bank.inner_dims = DropDims<3>(inner_shape, mask);  // reindexing, if necessary
     }
     return banks;
   }

--- a/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
@@ -296,7 +296,9 @@ class RegularizedInvRMS {
   using Postprocessor = RegularizedInvSqrt<Out, param_t>;
 
   void SetRegularizationTerm(param_t reg) {
-    regularization_ = reg * reg;
+    if (!(reg >= 0))  // >= 0 and not NaN
+      throw std::range_error("The regularizing term must be a non-negative number.");
+    regularization_ = reg;
   }
 
   param_t regularization_ = 0.0f;

--- a/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
@@ -76,7 +76,6 @@ template <typename Out = float, typename In, typename Mean>
 TestTensorList<Out> RefStdDev(const TensorListView<StorageCPU, In> &in,
                               const TensorListView<StorageCPU, Mean> &mean,
                               double reg = 0, bool inv = false) {
-  reg *= reg;
   SmallVector<int, 6> axes;
   for (int d = 0; d < mean.sample_dim(); d++) {
     for (int i = 0; i < mean.num_samples(); i++) {
@@ -348,9 +347,9 @@ TEST(InvStdDevImplGPU, Outer_Batch_Regularized) {
   EXPECT_GE(test.kernel.GetNumStages(), 2);  // both reduced axes must be split
   test.FillData(-100, 100);
 
-  test.Run(fake_mean.gpu(), 120);
+  test.Run(fake_mean.gpu(), 12000);
 
-  test.ref = RefStdDev(test.in.cpu(), mean_cpu, 120, true);
+  test.ref = RefStdDev(test.in.cpu(), mean_cpu, 12000, true);
 
   test.Check(EqualEpsRel(1e-5, 1e-6));
 }

--- a/dali/kernels/reduce/reduce_drop_dims_test.cc
+++ b/dali/kernels/reduce/reduce_drop_dims_test.cc
@@ -20,7 +20,7 @@ namespace kernels {
 namespace reduce_impl {
 
 TEST(DropDims, Simplify) {
-  DropDims dd;
+  DropDims<3> dd;
   unsigned in_mask = 0b10011, out_mask = 0xffffffffu;
   int64_t in_shape[5] = { 2, 3, 4, 5, 6 };
   int64_t out_shape[5];
@@ -49,7 +49,7 @@ TEST(DropDims, Simplify) {
 }
 
 TEST(DropDims, NoOp) {
-  DropDims dd;
+  DropDims<3> dd;
   for (int i = 0; i < 10; i++)
     EXPECT_EQ(dd.reindex(i), i);
 }
@@ -58,7 +58,7 @@ TEST(DropDims, Outer) {
   int h = 32;
   int w = 40;
   int shape[] = { h, w };
-  DropDims dd(shape, 0b01);
+  DropDims<3> dd(shape, 0b01);
   for (int y = 0, idx = 0; y < h; y++) {
     for (int x = 0; x < w; x++, idx++) {
       EXPECT_EQ(dd.reindex(idx), x);
@@ -70,7 +70,7 @@ TEST(DropDims, Inner) {
   int h = 32;
   int w = 40;
   int shape[] = { h, w };
-  DropDims dd(shape, 0b10);
+  DropDims<3> dd(shape, 0b10);
   for (int y = 0, idx = 0; y < h; y++) {
     for (int x = 0; x < w; x++, idx++) {
       EXPECT_EQ(dd.reindex(idx), y);
@@ -83,7 +83,7 @@ TEST(DropDims, Middle) {
   int h = 4;
   int w = 5;
   int shape[] = { d, h, w };
-  DropDims dd(shape, 0b010);
+  DropDims<3> dd(shape, 0b010);
   for (int z = 0, idx = 0; z < d; z++) {
     for (int y = 0; y < h; y++) {
       for (int x = 0; x < w; x++, idx++) {
@@ -98,7 +98,7 @@ TEST(DropDims, TwoOuter) {
   int h = 4;
   int w = 5;
   int shape[] = { d, h, w };
-  DropDims dd(shape, 0b101);
+  DropDims<3> dd(shape, 0b101);
   for (int z = 0, idx = 0; z < d; z++) {
     for (int y = 0; y < h; y++) {
       for (int x = 0; x < w; x++, idx++) {
@@ -110,7 +110,7 @@ TEST(DropDims, TwoOuter) {
 
 TEST(DropDims, Multi4Odd) {
   int shape[] = { 3, 4, 5, 6 };
-  DropDims dd(shape, 0b1010);
+  DropDims<3> dd(shape, 0b1010);
   for (int i = 0, idx = 0; i < shape[0]; i++)
     for (int j = 0; j < shape[1]; j++)
       for (int k = 0; k < shape[2]; k++)
@@ -122,7 +122,7 @@ TEST(DropDims, Multi4Odd) {
 
 TEST(DropDims, Multi4Even) {
   int shape[] = { 3, 4, 5, 6 };
-  DropDims dd(shape, 0b0101);
+  DropDims<3> dd(shape, 0b0101);
   for (int i = 0, idx = 0; i < shape[0]; i++)
     for (int j = 0; j < shape[1]; j++)
       for (int k = 0; k < shape[2]; k++)
@@ -134,7 +134,7 @@ TEST(DropDims, Multi4Even) {
 
 TEST(DropDims, TrailingOne) {
   int shape[] = { 3, 4, 5, 6, 1 };
-  DropDims dd(shape, 0b01010);
+  DropDims<3> dd(shape, 0b01010);
   for (int i = 0, idx = 0; i < shape[0]; i++)
     for (int j = 0; j < shape[1]; j++)
       for (int k = 0; k < shape[2]; k++)
@@ -156,7 +156,7 @@ TEST(DropDims, Multi5All) {
       for (int d = 0; d < 5; d++) {
         rshape[d] = mask & (1u << d) ? 1 : shape[d];
       }
-      DropDims dd(shape, mask);
+      DropDims<3> dd(shape, mask);
       for (int i = 0, idx = 0; i < shape[0]; i++) {
         int ri = mask & 0b00001 ? 0 : i;
         for (int j = 0; j < shape[1]; j++) {
@@ -169,7 +169,7 @@ TEST(DropDims, Multi5All) {
                 int rm = mask & 0b10000 ? 0 : m;
                 int ridx =
                   ((((ri * rshape[1] + rj) * rshape[2]) + rk) * rshape[3] + rl) * rshape[4] + rm;
-                EXPECT_EQ(dd.reindex(idx), ridx);
+                ASSERT_EQ(dd.reindex(idx), ridx);
               }
             }
           }
@@ -179,14 +179,13 @@ TEST(DropDims, Multi5All) {
   }
 }
 
-
 TEST(DropDims, CollapseUnitDims) {
   int shape[] = { 3, 4, 5, 1, 1, 6, 7 };
   // reduce:      ^     ^^^^        ^
   //
   // collapse unit dims, with different reduce/non-reduce flag
 
-  DropDims dd(shape, 0b1001101);
+  DropDims<3> dd(shape, 0b1001101);
   for (int i = 0, idx = 0; i < shape[0]; i++)
     for (int j = 0; j < shape[1]; j++)
       for (int k = 0; k < shape[2]; k++)

--- a/dali/kernels/reduce/reduce_gpu.h
+++ b/dali/kernels/reduce/reduce_gpu.h
@@ -321,7 +321,7 @@ extern template class StdDevGPU<float, float>;
  * ```
  * s = sum( (in[pos] - mean[reduced_pos])^2 )
  * out[reduced_pos] = s > 0 || reg > 0
- *                    ? 1/sqrt(s / reduction_factor + reg^2)
+ *                    ? 1/sqrt(s / reduction_factor + reg)
  *                    : 0
  * ```
  * where `reduction_factor` is the number of input elements contributing to a single output.
@@ -365,7 +365,7 @@ class DLL_PUBLIC InvStdDevGPU {
    * ```
    * s = sum( (in[pos] - mean[reduced_pos])^2 )
    * out[reduced_pos] = s > 0 || reg > 0
-   *                    ? 1/sqrt(s / reduction_factor + reg^2)
+   *                    ? 1/sqrt(s / reduction_factor + reg)
    *                    : 0
    * ```
    * where `reduction_factor` is the number of input elements contributing to a single output.
@@ -375,8 +375,8 @@ class DLL_PUBLIC InvStdDevGPU {
    * @param in      input tensor
    * @param mean    mean, used for centering the data
    * @param reg     regularizing term to avoid division by zero (or small numbers);
-   *                its squared and added to the sum of squares in variance calculation,
-   *                preventing it from being zero; if reg = 0, the results that would
+   *                its added to the sum of squares in variance calculation, preventing
+   *                it from being close to zero; if reg = 0, the results that would
    *                cause division by zero are forced to 0, but small denominators
    *                may still cause problems
    */


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds NormalizeImplGPU because we want a GPU-based normalization

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * DropDims as a way to recalculate data/param coordinates
     * trivial slicing by data chunks
     * broadcasting using DropDims
     * full broadcasting (from host-side scalars) is a special case
     * NOTE: pImpl front-end kernel is not a part of this PR, it's in #1981 
 - Affected modules and functionalities:
     * Reductions - ReduceDims now uses fast_div
 - Key points relevant for the review:
     * The kernel?
 - Validation and testing:
     * Unit tests (GTest)
 - Documentation (including examples):
     * Doxygen

**JIRA TASK**: DALI-1267
