### PR TITLE
Slice CPU kernel pad support

### DIFF
--- a/dali/benchmark/CMakeLists.txt
+++ b/dali/benchmark/CMakeLists.txt
@@ -29,6 +29,7 @@ if (BUILD_BENCHMARK)
     "${CMAKE_CURRENT_SOURCE_DIR}/warp_affine_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/transpose_cpu_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/color_twist_bench.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/slice_cpu_kernel_bench.cc"
   )
 
   if (BUILD_LMDB)

--- a/dali/benchmark/slice_cpu_kernel_bench.cc
+++ b/dali/benchmark/slice_cpu_kernel_bench.cc
@@ -1,0 +1,118 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+#include "dali/benchmark/dali_bench.h"
+#include "dali/kernels/slice/slice_cpu.h"
+#include "dali/test/tensor_test_utils.h"
+#include "dali/test/test_tensors.h"
+
+namespace dali {
+
+constexpr int Dims = 3;
+using InputType = float;
+using OutputType = float;
+
+class SliceBench : public DALIBenchmark {
+ public:
+  using Kernel = kernels::SliceCPU<OutputType, InputType, Dims>;
+  Kernel kernel;
+
+  kernels::TestTensorList<InputType, Dims> test_data;
+  kernels::TestTensorList<OutputType, Dims> out_data;
+
+  void Setup(const TensorShape<Dims> &in_shape,
+             const TensorShape<Dims> &out_shape) {
+    test_data.reshape(uniform_list_shape<Dims>(1, in_shape));
+    InputType num = 0;
+    auto seq_gen = [&num]() { return num++; };
+    Fill(test_data.cpu(), seq_gen);
+    out_data.reshape(uniform_list_shape<Dims>(1, out_shape));
+  }
+
+  void Run(benchmark::State& st) {
+    int H = st.range(0);
+    int W = st.range(1);
+    int C = st.range(2);
+    int anchor_h = st.range(3);
+    int anchor_w = st.range(4);
+    int anchor_c = st.range(5);
+    int crop_h = st.range(6);
+    int crop_w = st.range(7);
+    int crop_c = st.range(8);
+
+    TensorShape<Dims> in_shape{H, W, C};
+    TensorShape<Dims> anchor{anchor_h, anchor_w, anchor_c};
+    TensorShape<Dims> out_shape{crop_h, crop_w, crop_c};
+    Setup(in_shape, out_shape);
+
+    using Kernel = kernels::SliceCPU<OutputType, InputType, Dims>;
+    Kernel kernel;
+
+    kernels::SliceArgs<OutputType, Dims> args;
+    args.anchor = out_shape;
+    args.shape = anchor;
+
+    auto out_tv = out_data.cpu()[0];
+    auto in_tv = test_data.cpu()[0];
+
+    for (auto _ : st) {
+      kernels::KernelContext ctx;
+      auto kernel_req = kernel.Setup(ctx, in_tv, args);
+      kernel.Run(ctx, out_tv, in_tv, args);
+      st.counters["FPS"] = benchmark::Counter(st.iterations() + 1,
+        benchmark::Counter::kIsRate);
+    }
+  }
+};
+
+static void SliceKernelCPUArgs_OnlySlice(benchmark::internal::Benchmark *b) {
+  for (int H = 1000; H >= 500; H /= 2) {
+    int W = H, C = 3;
+    int crop_h = 9 * H / 10;
+    int crop_w = 9 * W / 10;
+    b->Args({H, W, C, 0, 0, 0, crop_h, crop_w, C});
+  }
+}
+
+BENCHMARK_DEFINE_F(SliceBench, SliceCPU_OnlySlice)(benchmark::State& st) {
+  this->Run(st);
+}
+
+BENCHMARK_REGISTER_F(SliceBench, SliceCPU_OnlySlice)->Iterations(1000)
+->Unit(benchmark::kMicrosecond)
+->UseRealTime()
+->Apply(SliceKernelCPUArgs_OnlySlice);
+
+static void SliceKernelCPUArgs_OnlyPad(benchmark::internal::Benchmark *b) {
+  for (int H = 1000; H >= 500; H /= 2) {
+    int W = H, C = 3;
+    int crop_h = 9 * H / 10;
+    int crop_w = 9 * W / 10;
+    int anchor_h = H;
+    int anchor_w = W;
+    b->Args({H, W, C, anchor_h, anchor_w, 0, crop_h, crop_w, C});
+  }
+}
+
+BENCHMARK_DEFINE_F(SliceBench, SliceCPU_OnlyPad)(benchmark::State& st) {
+  this->Run(st);
+}
+
+BENCHMARK_REGISTER_F(SliceBench, SliceCPU_OnlyPad)->Iterations(1000)
+->Unit(benchmark::kMicrosecond)
+->UseRealTime()
+->Apply(SliceKernelCPUArgs_OnlyPad);
+
+}  // namespace dali

--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -45,7 +45,7 @@ void Fill(T *output, const T *fill_values, int64_t npixels, int64_t nchannels) {
 inline std::tuple<int64_t, int64_t, int64_t> CalcPadCopyExtents(int64_t anchor,
                                                                 int64_t in_extent,
                                                                 int64_t out_extent) {
-  int64_t pad_before = std::max<int64_t>(0, std::min(out_extent, -anchor));
+  int64_t pad_before = std::min(out_extent, std::max<int64_t>(0, -anchor));
   int64_t to_copy = std::max<int64_t>(
       0, std::min(in_extent - std::max<int64_t>(0, anchor), out_extent - pad_before));
   int64_t pad_after = out_extent - pad_before - to_copy;

--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -17,6 +17,7 @@
 
 #include <vector>
 #include <utility>
+#include <type_traits>
 #include "dali/kernels/slice/slice_kernel_utils.h"
 #include "dali/core/common.h"
 #include "dali/core/convert.h"
@@ -28,30 +29,82 @@ namespace kernels {
 
 namespace detail {
 
-template <typename OutputType, typename InputType, int Dims>
+template <typename OutputType, typename InputType, int Dims, bool OutOfBounds>
 void SliceKernelImpl(OutputType *output,
                      const InputType *input,
                      const TensorShape<Dims> &in_strides,
                      const TensorShape<Dims> &out_strides,
+                     const TensorShape<Dims> &anchor,
+                     const TensorShape<Dims> &in_shape,
                      const TensorShape<Dims> &out_shape,
-                     std::integral_constant<int, 1>) {
-  for (int i = 0; i < out_shape[Dims - 1]; i++) {
-    output[i] = clamp<OutputType>(input[i]);
+                     std::integral_constant<int, 1>,
+                     std::integral_constant<bool, OutOfBounds>) {
+  constexpr auto d = Dims - 1;  // NOLINT
+  if (OutOfBounds) {
+    for (int i = 0; i < out_shape[d]; i++) {
+      output[i] = OutputType(0);  // TODO(janton): allow multichannel padding
+    }
+  } else {
+    int in_idx = anchor[d];
+    int out_idx = 0;
+
+    // out of bounds (left side)
+    for (; in_idx < 0 && out_idx < out_shape[d]; in_idx++, out_idx++) {
+      output[out_idx] = OutputType(0);  // TODO(janton): allow multichannel padding
+    }
+
+    // within input bounds
+    for (; in_idx < in_shape[d] && out_idx < out_shape[d]; in_idx++, out_idx++) {
+      output[out_idx] = clamp<OutputType>(input[in_idx]);
+    }
+
+    // out of bounds (right side)
+    for (; out_idx < out_shape[d]; in_idx++, out_idx++) {
+      output[out_idx] = OutputType(0);  // TODO(janton): allow multichannel padding
+    }
   }
 }
 
-template <typename OutputType, typename InputType, int Dims, int DimsLeft>
+template <typename OutputType, typename InputType, int Dims, bool OutOfBounds, int DimsLeft>
 void SliceKernelImpl(OutputType *output,
                      const InputType *input,
                      const TensorShape<Dims> &in_strides,
                      const TensorShape<Dims> &out_strides,
+                     const TensorShape<Dims> &anchor,
+                     const TensorShape<Dims> &in_shape,
                      const TensorShape<Dims> &out_shape,
-                     std::integral_constant<int, DimsLeft>) {
+                     std::integral_constant<int, DimsLeft>,
+                     std::integral_constant<bool, OutOfBounds>) {
   constexpr auto d = Dims - DimsLeft;  // NOLINT
-  for (int i = 0; i < out_shape[d]; i++) {
-    SliceKernelImpl(output, input, in_strides, out_strides, out_shape,
-                    std::integral_constant<int, DimsLeft - 1>());
-    input += in_strides[d];
+  int in_idx = anchor[d];
+  int out_idx = 0;
+
+  if (anchor[d] > 0 && anchor[d] < in_shape[d])
+    input += anchor[d] * in_strides[d];
+
+  // out of bounds (left side)
+  for (; in_idx < 0 && out_idx < out_shape[d]; in_idx++, out_idx++) {
+    SliceKernelImpl(output, input, in_strides, out_strides, anchor, in_shape, out_shape,
+                    std::integral_constant<int, DimsLeft - 1>(),
+                    std::integral_constant<bool, true>());
+    output += out_strides[d];
+  }
+
+  // within input bounds
+  for (; in_idx < in_shape[d] && out_idx < out_shape[d]; in_idx++, out_idx++) {
+    SliceKernelImpl(output, input, in_strides, out_strides, anchor, in_shape, out_shape,
+                    std::integral_constant<int, DimsLeft - 1>(),
+                    std::integral_constant<bool, OutOfBounds>());
+    output += out_strides[d];
+    if (!OutOfBounds)
+      input += in_strides[d];
+  }
+
+  // out of bounds (right side)
+  for (; out_idx < out_shape[d]; in_idx++, out_idx++) {
+    SliceKernelImpl(output, input, in_strides, out_strides, anchor, in_shape, out_shape,
+                    std::integral_constant<int, DimsLeft - 1>(),
+                    std::integral_constant<bool, true>());
     output += out_strides[d];
   }
 }
@@ -65,12 +118,11 @@ void SliceKernel(OutputType *output,
                  const TensorShape<Dims> &in_strides,
                  const TensorShape<Dims> &out_strides,
                  const TensorShape<Dims> &anchor,
+                 const TensorShape<Dims> &in_shape,
                  const TensorShape<Dims> &out_shape) {
-  for (int d = 0; d < Dims; d++) {
-    input += in_strides[d] * anchor[d];
-  }
-  detail::SliceKernelImpl(output, input, in_strides, out_strides, out_shape,
-                          std::integral_constant<int, Dims>());
+  detail::SliceKernelImpl(output, input, in_strides, out_strides, anchor, in_shape, out_shape,
+                          std::integral_constant<int, Dims>(),
+                          std::integral_constant<bool, false>());
 }
 
 template <typename OutputType, typename InputType, int Dims>
@@ -97,7 +149,36 @@ class SliceCPU {
     const InputType *in_ptr = in.data;
     OutputType *out_ptr = out.data;
 
-    SliceKernel(out_ptr, in_ptr, in_strides, out_strides, anchor, out_shape);
+    auto inptr2 = in_ptr;
+    for (int i = 0; i < in_shape[0]; i++) {
+      for (int j = 0; j < in_shape[1]; j++) {
+        std::cout << " " << *(inptr2);
+        inptr2++; 
+      }
+      std::cout << "\n";
+    }
+
+    std::cout << "anchor: ";
+    for (int d = 0; d < Dims; d++)
+      std::cout << " " << anchor[d];
+    std::cout << "\n";
+
+    std::cout << "shape: ";
+    for (int d = 0; d < Dims; d++)
+      std::cout << " " << out_shape[d];
+    std::cout << "\n";
+
+    SliceKernel(out_ptr, in_ptr, in_strides, out_strides, anchor, in_shape, out_shape);
+
+    std::cout << "slice: \n";
+    auto ptr = out_ptr;
+    for (int i = 0; i < out_shape[0]; i++) {
+      for (int j = 0; j < out_shape[1]; j++) {
+        std::cout << " " << *(ptr + i * out_strides[0] + j * out_strides[1]);
+      }
+      std::cout << "\n";
+    }
+
   }
 };
 

--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -68,7 +68,7 @@ void SliceKernelImplChannelLast(OutputType *output,
                                 std::integral_constant<bool, OutOfBounds>,
                                 std::integral_constant<bool, NeedPad>) {
   constexpr int DimsLeft = 2;
-  constexpr auto d = 0;  // NOLINT
+  constexpr int d = 0;
   assert(channel_dim == 1);
   int64_t out_nchannels = out_shape[channel_dim];
   int64_t in_nchannels = in_shape[channel_dim];
@@ -133,13 +133,13 @@ void SliceKernelImplChannelLast(OutputType *output,
       output += pad_pixels_after * out_strides[d];
     }
   } else {  // NeedPad = false
-    assert(out_strides[1] == 1);
-    assert(in_strides[1] == 1);
-    for (int64_t i = 0; i < out_shape[0]; i++) {
-      auto *out_row = output + i * out_strides[0];
-      auto *in_row = input + (anchor[d] + i) * in_strides[0];
-      for (int64_t j = 0; j < out_shape[1]; j++) {
-        out_row[j] = clamp<OutputType>(in_row[anchor[1] + j]);
+    assert(out_strides[d + 1] == 1);
+    assert(in_strides[d + 1] == 1);
+    for (int64_t i = 0; i < out_shape[d]; i++) {
+      auto *out_row = output + i * out_strides[d];
+      auto *in_row = input + (anchor[d] + i) * in_strides[d];
+      for (int64_t j = 0; j < out_shape[d + 1]; j++) {
+        out_row[j] = clamp<OutputType>(in_row[anchor[d + 1] + j]);
       }
     }
   }
@@ -158,7 +158,7 @@ void SliceKernelImpl(OutputType *output,
                      std::integral_constant<int, 1>,
                      std::integral_constant<bool, OutOfBounds>,
                      std::integral_constant<bool, NeedPad>) {
-  constexpr auto d = 0;  // NOLINT
+  constexpr int d = 0;
   if (OutOfBounds) {
     for (int i = 0; i < out_shape[d]; i++) {
       output[i] = *fill_values;
@@ -218,7 +218,7 @@ void SliceKernelImpl(OutputType *output,
     return;
   }
 
-  constexpr auto d = 0;  // NOLINT
+  constexpr int d = 0;
   int in_idx = anchor[d];
   int out_idx = 0;
 

--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -64,7 +64,7 @@ void SliceKernelImplChannelLast(OutputType *output,
                                 const int64_t* in_shape,
                                 const int64_t* out_shape,
                                 const OutputType *fill_values,
-                                int channel_dim,
+                                int channel_dim,  // negative if no channel dim or already processed
                                 std::integral_constant<bool, OutOfBounds>,
                                 std::integral_constant<bool, NeedPad>) {
   constexpr int DimsLeft = 2;
@@ -154,7 +154,7 @@ void SliceKernelImpl(OutputType *output,
                      const int64_t* in_shape,
                      const int64_t* out_shape,
                      const OutputType *fill_values,
-                     int channel_dim,
+                     int channel_dim,  // negative if no channel dim or already processed
                      std::integral_constant<int, 1>,
                      std::integral_constant<bool, OutOfBounds>,
                      std::integral_constant<bool, NeedPad>) {
@@ -205,7 +205,7 @@ void SliceKernelImpl(OutputType *output,
                      const int64_t* in_shape,
                      const int64_t* out_shape,
                      const OutputType *fill_values,
-                     int channel_dim,
+                     int channel_dim,  // negative if no channel dim or already processed
                      std::integral_constant<int, DimsLeft>,
                      std::integral_constant<bool, OutOfBounds>,
                      std::integral_constant<bool, NeedPad>) {
@@ -229,7 +229,7 @@ void SliceKernelImpl(OutputType *output,
     // out of bounds (left side)
     for (; in_idx < 0 && out_idx < out_shape[d]; in_idx++, out_idx++) {
       SliceKernelImpl(output, input, in_strides + 1, out_strides + 1, anchor + 1, in_shape + 1,
-                      out_shape + 1, fill_values, channel_dim > 0 ? channel_dim - 1 : channel_dim,
+                      out_shape + 1, fill_values, channel_dim - 1,
                       std::integral_constant<int, DimsLeft - 1>(),
                       std::integral_constant<bool, true>(),
                       std::integral_constant<bool, NeedPad>());
@@ -242,7 +242,7 @@ void SliceKernelImpl(OutputType *output,
   // within input bounds
   for (; in_idx < in_shape[d] && out_idx < out_shape[d]; in_idx++, out_idx++) {
     SliceKernelImpl(output, input, in_strides + 1, out_strides + 1, anchor + 1, in_shape + 1,
-                    out_shape + 1, fill_values, channel_dim > 0 ? channel_dim - 1 : channel_dim,
+                    out_shape + 1, fill_values, channel_dim - 1,
                     std::integral_constant<int, DimsLeft - 1>(),
                     std::integral_constant<bool, OutOfBounds>(),
                     std::integral_constant<bool, NeedPad>());
@@ -257,7 +257,7 @@ void SliceKernelImpl(OutputType *output,
     // out of bounds (right side)
     for (; out_idx < out_shape[d]; in_idx++, out_idx++) {
       SliceKernelImpl(output, input, in_strides + 1, out_strides + 1, anchor + 1, in_shape + 1,
-                      out_shape + 1, fill_values, channel_dim > 0 ? channel_dim - 1 : channel_dim,
+                      out_shape + 1, fill_values, channel_dim - 1,
                       std::integral_constant<int, DimsLeft - 1>(),
                       std::integral_constant<bool, true>(),
                       std::integral_constant<bool, NeedPad>());
@@ -280,7 +280,7 @@ void SliceKernel(OutputType *output,
                  const TensorShape<Dims> &in_shape,
                  const TensorShape<Dims> &out_shape,
                  const OutputType *fill_values,
-                 int channel_dim = -1) {
+                 int channel_dim = -1) {  // negative if no channel dim or already processed
   bool need_pad = false;
   for (int d = 0; d < Dims && !need_pad; d++) {
     need_pad = (anchor[d] < 0) || ((anchor[d] + out_shape[d]) > in_shape[d]);

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -93,7 +93,7 @@ class SliceGPU {
  public:
   KernelRequirements Setup(KernelContext &context,
                            const InListGPU<InputType, Dims> &in,
-                           const std::vector<SliceArgs<Dims>> &slice_args) {
+                           const std::vector<SliceArgs<OutputType, Dims>> &slice_args) {
     KernelRequirements req;
     ScratchpadEstimator se;
     const size_t num_samples = in.size();
@@ -123,7 +123,7 @@ class SliceGPU {
   void Run(KernelContext &context,
            OutListGPU<OutputType, Dims> &out,
            const InListGPU<InputType, Dims> &in,
-           const std::vector<SliceArgs<Dims>> &slice_args) {
+           const std::vector<SliceArgs<OutputType, Dims>> &slice_args) {
     const auto num_samples = in.size();
 
     detail::SliceSampleDesc<Dims>* sample_descs_cpu =

--- a/dali/kernels/slice/slice_kernel_test.h
+++ b/dali/kernels/slice/slice_kernel_test.h
@@ -105,12 +105,12 @@ class SliceTest : public ::testing::Test {
       auto in_strides = GetStrides(in_shape);
       auto out_strides = GetStrides(out_shape);
 
-      size_t total_size = volume(out_shape);
+      int64_t total_size = volume(out_shape);
 
       int i_c = 0;
-      for (size_t out_idx = 0; out_idx < total_size; out_idx++) {
-        size_t idx = out_idx;
-        size_t in_idx = 0;
+      for (int64_t out_idx = 0; out_idx < total_size; out_idx++) {
+        int64_t idx = out_idx;
+        int64_t in_idx = 0;
         bool out_of_bounds = false;
         for (int d = 0; d < Dims; d++) {
           int i_d = idx / out_strides[d];

--- a/dali/kernels/slice/slice_kernel_test.h
+++ b/dali/kernels/slice/slice_kernel_test.h
@@ -147,7 +147,7 @@ class SliceTest : public ::testing::Test {
 };
 
 template <typename OutputType, int Dims>
-struct SliceArgsGenerator_WholeTensor {
+struct ArgsGen_WholeTensor {
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, Dims> args;
     for (int d = 0; d < Dims; d++) {
@@ -159,7 +159,7 @@ struct SliceArgsGenerator_WholeTensor {
 };
 
 template <typename OutputType, int Dims>
-struct SliceArgsGenerator_HalfAllDims {
+struct ArgsGen_HalfAllDims {
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, Dims> args;
     for (int d = 0; d < Dims; d++) {
@@ -171,7 +171,7 @@ struct SliceArgsGenerator_HalfAllDims {
 };
 
 template <typename OutputType, int Dims, int ExtractDim>
-struct SliceArgsGenerator_HalfOneDim {
+struct ArgsGen_HalfOneDim {
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, Dims> args;
     for (int d = 0; d < Dims; d++) {
@@ -183,7 +183,7 @@ struct SliceArgsGenerator_HalfOneDim {
 };
 
 template <typename OutputType, int Dims>
-struct SliceArgsGenerator_ExtractCenterElement {
+struct ArgsGen_ExtractCenterElement {
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, Dims> args;
     for (int d = 0; d < Dims; d++) {
@@ -195,7 +195,7 @@ struct SliceArgsGenerator_ExtractCenterElement {
 };
 
 template <typename OutputType, int Dims>
-struct SliceArgsGenerator_BiggerThanInputSlice {
+struct ArgsGen_BiggerThanInputSlice {
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, Dims> args;
     for (int d = 0; d < Dims; d++) {
@@ -207,7 +207,7 @@ struct SliceArgsGenerator_BiggerThanInputSlice {
 };
 
 template <typename OutputType, int Dims>
-struct SliceArgsGenerator_LeftSideOutOfBounds{
+struct ArgsGen_LeftSideOutOfBounds{
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, Dims> args;
     for (int d = 0; d < Dims; d++) {
@@ -219,7 +219,7 @@ struct SliceArgsGenerator_LeftSideOutOfBounds{
 };
 
 template <typename OutputType, int Dims>
-struct SliceArgsGenerator_RightSideOutOfBounds{
+struct ArgsGen_RightSideOutOfBounds{
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, Dims> args;
     for (int d = 0; d < Dims; d++) {
@@ -231,7 +231,7 @@ struct SliceArgsGenerator_RightSideOutOfBounds{
 };
 
 template <typename OutputType, int Dims>
-struct SliceArgsGenerator_CompletelyOutOfBounds{
+struct ArgsGen_CompletelyOutOfBounds{
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, Dims> args;
     for (int d = 0; d < Dims; d++) {
@@ -243,7 +243,7 @@ struct SliceArgsGenerator_CompletelyOutOfBounds{
 };
 
 template <typename OutputType, int Dims = 3>
-struct SliceArgsGenerator_MultiChannelPad {
+struct ArgsGen_MultiChannelPad {
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, 3> args;
     args.anchor[0] = -input_shape[0] / 2;
@@ -258,8 +258,25 @@ struct SliceArgsGenerator_MultiChannelPad {
   }
 };
 
+
 template <typename OutputType, int Dims = 3>
-struct SliceArgsGenerator_PadAlsoChannelDim {
+struct ArgsGen_MultiChannelPad_ChFirst {
+  SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceArgs<OutputType, 3> args;
+    args.anchor[0] = 0;
+    args.anchor[1] = -input_shape[1] / 2;
+    args.anchor[2] = -input_shape[2] / 2;
+    args.shape[0] = input_shape[0];
+    args.shape[1] = 2 * input_shape[1];
+    args.shape[2] = 2 * input_shape[2];
+    args.fill_values = {100, 110, 120};
+    args.channel_dim = 0;
+    return args;
+  }
+};
+
+template <typename OutputType, int Dims = 3>
+struct ArgsGen_PadAlsoChDim {
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, 3> args;
     args.anchor[0] = -input_shape[0] / 2;
@@ -274,41 +291,59 @@ struct SliceArgsGenerator_PadAlsoChannelDim {
   }
 };
 
+template <typename OutputType, int Dims = 3>
+struct ArgsGen_PadAlsoChDim_ChFirst {
+  SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceArgs<OutputType, 3> args;
+    args.anchor[0] = 0;
+    args.anchor[1] = -input_shape[1] / 2;
+    args.anchor[2] = -input_shape[2] / 2;
+    args.shape[0] = input_shape[0] + 1;
+    args.shape[1] = 2 * input_shape[1];
+    args.shape[2] = 2 * input_shape[2];
+    args.fill_values = {100, 110, 120, 128};
+    args.channel_dim = 0;
+    return args;
+  }
+};
+
 using SLICE_TEST_TYPES = ::testing::Types<
-    SliceTestArgs<int, int, 3, 1, 2, SliceArgsGenerator_WholeTensor<int, 3>>,
-    SliceTestArgs<int, int, 2, 1, 6, SliceArgsGenerator_HalfAllDims<int, 2>>,
-    SliceTestArgs<int, int, 4, 1, 2, SliceArgsGenerator_HalfAllDims<int, 4>>,
-    SliceTestArgs<int, int, 3, 1, 2, SliceArgsGenerator_HalfOneDim<int, 3, 0>>,
-    SliceTestArgs<int, int, 3, 1, 2, SliceArgsGenerator_HalfOneDim<int, 3, 1>>,
-    SliceTestArgs<int, int, 3, 1, 2, SliceArgsGenerator_HalfOneDim<int, 3, 2>>,
-    SliceTestArgs<float, float, 3, 1, 2, SliceArgsGenerator_HalfOneDim<float, 3, 2>>,
-    SliceTestArgs<int, float, 3, 1, 2, SliceArgsGenerator_HalfOneDim<float, 3, 2>>,
-    SliceTestArgs<float, int, 3, 1, 2, SliceArgsGenerator_HalfOneDim<int, 3, 2>>,
-    SliceTestArgs<int, int, 3, 10, 2, SliceArgsGenerator_HalfOneDim<int, 3, 2>>,
-    SliceTestArgs<int, int, 10, 1, 2, SliceArgsGenerator_HalfAllDims<int, 10>>,
-    SliceTestArgs<uint8_t, uint8_t, 3, 1, 2, SliceArgsGenerator_HalfAllDims<uint8_t, 3>>,
-    SliceTestArgs<uint8_t, uint8_t, 1, 1, 2, SliceArgsGenerator_HalfAllDims<uint8_t, 1>>,
-    SliceTestArgs<uint8_t, uint8_t, 2, 1, 1024, SliceArgsGenerator_HalfAllDims<uint8_t, 2>>,
-    SliceTestArgs<uint8_t, uint8_t, 2, 100, 1024, SliceArgsGenerator_HalfAllDims<uint8_t, 2>>,
-    SliceTestArgs<uint8_t, uint8_t, 3, 3, 256, SliceArgsGenerator_HalfAllDims<uint8_t, 3>>,
-    SliceTestArgs<int, int, 2, 1, 3, SliceArgsGenerator_ExtractCenterElement<int, 2>>
+    SliceTestArgs<int, int, 3, 1, 2, ArgsGen_WholeTensor<int, 3>>,
+    SliceTestArgs<int, int, 2, 1, 6, ArgsGen_HalfAllDims<int, 2>>,
+    SliceTestArgs<int, int, 4, 1, 2, ArgsGen_HalfAllDims<int, 4>>,
+    SliceTestArgs<int, int, 3, 1, 2, ArgsGen_HalfOneDim<int, 3, 0>>,
+    SliceTestArgs<int, int, 3, 1, 2, ArgsGen_HalfOneDim<int, 3, 1>>,
+    SliceTestArgs<int, int, 3, 1, 2, ArgsGen_HalfOneDim<int, 3, 2>>,
+    SliceTestArgs<float, float, 3, 1, 2, ArgsGen_HalfOneDim<float, 3, 2>>,
+    SliceTestArgs<int, float, 3, 1, 2, ArgsGen_HalfOneDim<float, 3, 2>>,
+    SliceTestArgs<float, int, 3, 1, 2, ArgsGen_HalfOneDim<int, 3, 2>>,
+    SliceTestArgs<int, int, 3, 10, 2, ArgsGen_HalfOneDim<int, 3, 2>>,
+    SliceTestArgs<int, int, 10, 1, 2, ArgsGen_HalfAllDims<int, 10>>,
+    SliceTestArgs<uint8_t, uint8_t, 3, 1, 2, ArgsGen_HalfAllDims<uint8_t, 3>>,
+    SliceTestArgs<uint8_t, uint8_t, 1, 1, 2, ArgsGen_HalfAllDims<uint8_t, 1>>,
+    SliceTestArgs<uint8_t, uint8_t, 2, 1, 1024, ArgsGen_HalfAllDims<uint8_t, 2>>,
+    SliceTestArgs<uint8_t, uint8_t, 2, 100, 1024, ArgsGen_HalfAllDims<uint8_t, 2>>,
+    SliceTestArgs<uint8_t, uint8_t, 3, 3, 256, ArgsGen_HalfAllDims<uint8_t, 3>>,
+    SliceTestArgs<int, int, 2, 1, 3, ArgsGen_ExtractCenterElement<int, 2>>
 >;
 
 using SLICE_TEST_TYPES_CPU_ONLY = ::testing::Types<
-    SliceTestArgs<int, float16, 3, 1, 2, SliceArgsGenerator_WholeTensor<float16, 3>>,
-    SliceTestArgs<float16, int, 3, 1, 2, SliceArgsGenerator_WholeTensor<int, 3>>,
-    SliceTestArgs<float16, float16, 3, 1, 2, SliceArgsGenerator_WholeTensor<float16, 3>>,
+    SliceTestArgs<int, float16, 3, 1, 2, ArgsGen_WholeTensor<float16, 3>>,
+    SliceTestArgs<float16, int, 3, 1, 2, ArgsGen_WholeTensor<int, 3>>,
+    SliceTestArgs<float16, float16, 3, 1, 2, ArgsGen_WholeTensor<float16, 3>>,
 
     // TODO(janton): Move to SLICE_TEST_TYPES once GPU implementation supports out of bounds slicing
-    SliceTestArgs<int, int, 1, 1, 20, SliceArgsGenerator_BiggerThanInputSlice<int, 1>>,
-    SliceTestArgs<int, int, 2, 1, 20, SliceArgsGenerator_BiggerThanInputSlice<int, 2>>,
-    SliceTestArgs<int, int, 1, 1, 21, SliceArgsGenerator_LeftSideOutOfBounds<int, 1>>,
-    SliceTestArgs<int, int, 2, 1, 21, SliceArgsGenerator_LeftSideOutOfBounds<int, 2>>,
-    SliceTestArgs<int, int, 1, 1, 22, SliceArgsGenerator_RightSideOutOfBounds<int, 1>>,
-    SliceTestArgs<int, int, 2, 1, 22, SliceArgsGenerator_RightSideOutOfBounds<int, 2>>,
-    SliceTestArgs<int, int, 2, 1, 22, SliceArgsGenerator_CompletelyOutOfBounds<int, 2>>,
-    SliceTestArgs<int, int, 3, 1, 20, SliceArgsGenerator_MultiChannelPad<int, 3>, 20, 20, 3>,
-    SliceTestArgs<int, int, 3, 1, 20, SliceArgsGenerator_PadAlsoChannelDim<int, 3>, 20, 20, 3>
+    SliceTestArgs<int, int, 1, 1, 20, ArgsGen_BiggerThanInputSlice<int, 1>>,
+    SliceTestArgs<int, int, 2, 1, 20, ArgsGen_BiggerThanInputSlice<int, 2>>,
+    SliceTestArgs<int, int, 1, 1, 21, ArgsGen_LeftSideOutOfBounds<int, 1>>,
+    SliceTestArgs<int, int, 2, 1, 21, ArgsGen_LeftSideOutOfBounds<int, 2>>,
+    SliceTestArgs<int, int, 1, 1, 22, ArgsGen_RightSideOutOfBounds<int, 1>>,
+    SliceTestArgs<int, int, 2, 1, 22, ArgsGen_RightSideOutOfBounds<int, 2>>,
+    SliceTestArgs<int, int, 2, 1, 22, ArgsGen_CompletelyOutOfBounds<int, 2>>,
+    SliceTestArgs<int, int, 3, 1, 20, ArgsGen_MultiChannelPad<int, 3>, 20, 20, 3>,
+    SliceTestArgs<int, int, 3, 1, 20, ArgsGen_MultiChannelPad_ChFirst<int, 3>, 3, 20, 20>,
+    SliceTestArgs<int, int, 3, 1, 20, ArgsGen_PadAlsoChDim<int, 3>, 20, 20, 3>,
+    SliceTestArgs<int, int, 3, 1, 20, ArgsGen_PadAlsoChDim_ChFirst<int, 3>, 3, 20, 20>
 >;
 
 }  // namespace kernels

--- a/dali/kernels/slice/slice_kernel_test.h
+++ b/dali/kernels/slice/slice_kernel_test.h
@@ -98,7 +98,7 @@ class SliceTest : public ::testing::Test {
       auto *fill_values = slice_args[i].fill_values.data();
       int fill_values_size = slice_args[i].fill_values.size();
       if (fill_values_size > 1) {
-        ASSERT_NE(-1, channel_dim);
+        ASSERT_GE(channel_dim, 0);
         ASSERT_EQ(fill_values_size, out_shape[channel_dim]);
       }
 

--- a/dali/kernels/slice/slice_kernel_test.h
+++ b/dali/kernels/slice/slice_kernel_test.h
@@ -230,6 +230,18 @@ struct SliceArgsGenerator_RightSideOutOfBounds{
   }
 };
 
+template <typename OutputType, int Dims>
+struct SliceArgsGenerator_CompletelyOutOfBounds{
+  SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceArgs<OutputType, Dims> args;
+    for (int d = 0; d < Dims; d++) {
+      args.anchor[d] = 4 * input_shape[d];
+      args.shape[d] = input_shape[d] / 2;
+    }
+    return args;
+  }
+};
+
 template <typename OutputType, int Dims = 3>
 struct SliceArgsGenerator_MultiChannelPad {
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
@@ -288,9 +300,13 @@ using SLICE_TEST_TYPES_CPU_ONLY = ::testing::Types<
     SliceTestArgs<float16, float16, 3, 1, 2, SliceArgsGenerator_WholeTensor<float16, 3>>,
 
     // TODO(janton): Move to SLICE_TEST_TYPES once GPU implementation supports out of bounds slicing
+    SliceTestArgs<int, int, 1, 1, 20, SliceArgsGenerator_BiggerThanInputSlice<int, 1>>,
     SliceTestArgs<int, int, 2, 1, 20, SliceArgsGenerator_BiggerThanInputSlice<int, 2>>,
+    SliceTestArgs<int, int, 1, 1, 21, SliceArgsGenerator_LeftSideOutOfBounds<int, 1>>,
     SliceTestArgs<int, int, 2, 1, 21, SliceArgsGenerator_LeftSideOutOfBounds<int, 2>>,
+    SliceTestArgs<int, int, 1, 1, 22, SliceArgsGenerator_RightSideOutOfBounds<int, 1>>,
     SliceTestArgs<int, int, 2, 1, 22, SliceArgsGenerator_RightSideOutOfBounds<int, 2>>,
+    SliceTestArgs<int, int, 2, 1, 22, SliceArgsGenerator_CompletelyOutOfBounds<int, 2>>,
     SliceTestArgs<int, int, 3, 1, 20, SliceArgsGenerator_MultiChannelPad<int, 3>, 20, 20, 3>,
     SliceTestArgs<int, int, 3, 1, 20, SliceArgsGenerator_PadAlsoChannelDim<int, 3>, 20, 20, 3>
 >;

--- a/dali/kernels/slice/slice_kernel_utils.h
+++ b/dali/kernels/slice/slice_kernel_utils.h
@@ -52,7 +52,6 @@ template <int Dims, typename Args>
 TensorShape<Dims> GetOutputShape(const TensorShape<Dims>& in_sample_shape,
                                  const Args& args) {
   TensorShape<Dims> out_sample_shape(args.shape);
-  //CheckValidOutputShape(in_sample_shape, out_sample_shape, args);
   return out_sample_shape;
 }
 

--- a/dali/kernels/slice/slice_kernel_utils.h
+++ b/dali/kernels/slice/slice_kernel_utils.h
@@ -25,10 +25,12 @@
 namespace dali {
 namespace kernels {
 
-template <int Dims>
+template <typename T, int Dims>
 struct SliceArgs {
   TensorShape<Dims> anchor;
   TensorShape<Dims> shape;
+  SmallVector<T, 3> fill_values = {0, };
+  int channel_dim = -1;
 };
 
 template <int Dims, typename Args>

--- a/dali/kernels/slice/slice_kernel_utils.h
+++ b/dali/kernels/slice/slice_kernel_utils.h
@@ -50,7 +50,7 @@ template <int Dims, typename Args>
 TensorShape<Dims> GetOutputShape(const TensorShape<Dims>& in_sample_shape,
                                  const Args& args) {
   TensorShape<Dims> out_sample_shape(args.shape);
-  CheckValidOutputShape(in_sample_shape, out_sample_shape, args);
+  //CheckValidOutputShape(in_sample_shape, out_sample_shape, args);
   return out_sample_shape;
 }
 

--- a/dali/operators/generic/slice/slice_base.cc
+++ b/dali/operators/generic/slice/slice_base.cc
@@ -32,7 +32,7 @@ void RunHelper(Tensor<CPUBackend> &output,
     kernels::KernelContext ctx;
     auto in_view = view<const InputType, NumDims>(input);
 
-    kernels::SliceArgs<NumDims> slice_args;
+    kernels::SliceArgs<OutputType, NumDims> slice_args;
     auto &anchor = slice_args.anchor;
     auto &shape = slice_args.shape;
     for (std::size_t d = 0; d < NumDims; d++) {

--- a/dali/operators/generic/slice/slice_base.cu
+++ b/dali/operators/generic/slice/slice_base.cu
@@ -37,7 +37,7 @@ void RunHelper(TensorList<GPUBackend>& output,
     ctx.gpu.stream = stream;
     auto in_view = view<const InputType, NumDims>(input);
 
-    std::vector<kernels::SliceArgs<NumDims>> slice_args;
+    std::vector<kernels::SliceArgs<OutputType, NumDims>> slice_args;
     slice_args.reserve(slice_anchors.size());
     for (std::size_t i = 0; i < slice_anchors.size(); i++) {
       std::array<int64_t, NumDims> anchor, shape;


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds pad capabilities to Slice CPU kernel needed to allow for bigger crop windows than the input

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added special out-of-bounds treatment to left and right of each dimension*
 - Affected modules and functionalities:
     *Slice CPU kernel*
 - Key points relevant for the review:
     *The changes in the kernel*
 - Validation and testing:
     *gtests added*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1409]*
