### PR TITLE
Fix reference counting issue in the PythonFunction operator

### DIFF
--- a/dali/operators/python_function/dltensor_function.h
+++ b/dali/operators/python_function/dltensor_function.h
@@ -18,6 +18,7 @@
 #include <pybind11/embed.h>
 #include <pybind11/stl.h>
 #include <vector>
+#include <utility>
 #include "dali/pipeline/operator/operator.h"
 #include "dali/pipeline/util/copy_with_stride.h"
 


### PR DESCRIPTION
#### Why we need this PR?
- It fixes a segfault that appeared in the Slice operator test.

#### What happened in this PR?
 - What solution was applied:
    Segfault was caused by wrong handling of reference counting on Python objects. The pybind's `reinterpret_steal` was misused in the following function:
```C++
template <typename Backend>
void PrepareOutputsPerSample(workspace_t<Backend> &ws, const py::object &output_o, int batch_size) {
  py::list output = output_o;
  std::vector<py::list> output_tuple(ws.NumOutput());
  for (auto &sample_out : output) {
    // (...) - insignificant 
  }
  py::tuple t(ws.NumOutput());
  for (Index idx = 0; idx < ws.NumOutput(); ++idx) {
    t[idx] = py::reinterpret_steal<py::list>(output_tuple[idx]); 
    // `reinterpret_steal` above creates a new Python object without increasing 
    // the reference count on `output_tuple[idx]` 
    // It's a misuse of this casting method.
  }
  PrepareOutputs<Backend>(ws, t, batch_size);
  // t is destructed here. 
  // It decreases ref count of its elements, potentially deleting them.
  // output_tuple is destructed here. 
  // It tries to decrease ref count on objects that might be already deleted by the `t` destructor.
}
```
What hints that it is the issue causing the crash is its stacktrace:
```
#0  0x00007f8191f05049 in pybind11::handle::dec_ref() const & (this=<optimized out>)
#2  pybind11::list::~list (this=<optimized out>, __in_chrg=<optimized out>)
#7  std::vector<pybind11::list, std::allocator<pybind11::list> >::~vector
#8  0x00007f8191f30ab9 in dali::detail::PrepareOutputsPerSample<dali::CPUBackend> (ws=..., output_o=..., batch_size=8)
```
The segfault appears exactly when the destructor of `output_tuple` tries to decrease ref count of its elements.
The intention behind using `reinterpret_steal`  was to move object ownership, so now the `std::move` is used. I've also revisited all uses of `reinterpret_borrow` and `reinterpret_steal` in our code. 
 - Affected modules and functionalities:
     PythonFunction implementation.
 - Key points relevant for the review:
     *Bug explanation*
 - Validation and testing:
     *Existing tests of PythonFunction operator*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *DALI-1421*
