### PR TITLE
Add more error checking

### DIFF
--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -129,7 +129,10 @@ AudioDecoderCpu::DecodeSample(const TensorView<StorageCPU, OutputType, DynamicDi
                                             // directly to the output
 
     tmp_buf.resize(tmp_size);
-    decoders_[sample_idx]->Decode(as_raw_span(tmp_buf.data(), meta.length * meta.channels));
+    size_t num_samples = meta.length * meta.channels;
+    size_t ret = decoders_[sample_idx]->Decode(as_raw_span(tmp_buf.data(), num_samples));
+    DALI_ENFORCE(ret == num_samples,
+                 make_string("Error decoding audio file: ", files_names_[sample_idx]));
 
     if (should_downmix) {
       if (should_resample) {
@@ -158,7 +161,10 @@ AudioDecoderCpu::DecodeSample(const TensorView<StorageCPU, OutputType, DynamicDi
     }
   } else {
     assert(!should_downmix && !should_resample);
-    decoders_[sample_idx]->Decode(as_raw_span(audio.data, volume(audio.shape)));
+    size_t num_samples = volume(audio.shape);
+    size_t ret = decoders_[sample_idx]->Decode(as_raw_span(audio.data, num_samples));
+    DALI_ENFORCE(ret == num_samples,
+                 make_string("Error decoding audio file: ", files_names_[sample_idx]));
   }
 }
 

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -54,6 +54,7 @@ void dump_meta_file(std::vector<T> &input, const std::string path) {
   unsigned size = input.size();
   file.write(reinterpret_cast<char*>(&size), sizeof(unsigned));
   file.write(reinterpret_cast<char*>(input.data()), size * sizeof(T));
+  DALI_ENFORCE(file.good(), make_string("Error writing to path: ", path));
 }
 
 template <typename T>
@@ -68,6 +69,7 @@ void dump_meta_file(std::vector<std::vector<T> > &input, const std::string path)
     file.write(reinterpret_cast<char*>(&size), sizeof(unsigned));
     file.write(reinterpret_cast<char*>(v.data()), size * sizeof(T));
   }
+  DALI_ENFORCE(file.good(), make_string("Error writing to path: ", path));
 }
 
 void dump_filenames(const ImageIdPairs &image_id_pairs, const std::string path) {
@@ -76,12 +78,13 @@ void dump_filenames(const ImageIdPairs &image_id_pairs, const std::string path) 
   for (const auto &p : image_id_pairs) {
     file << p.first << std::endl;
   }
+  DALI_ENFORCE(file.good(), make_string("Error writing to path: ", path));
 }
 
 template <typename T>
 void load_meta_file(std::vector<T> &output, const std::string path) {
   std::ifstream file(path);
-  DALI_ENFORCE(file, "CocoReader meta file error while loading for path: " + path);
+  DALI_ENFORCE(file.good(), make_string("Error writing to path: ", path));
 
   unsigned size;
   file.read(reinterpret_cast<char*>(&size), sizeof(unsigned));

--- a/dali/operators/reader/loader/file_label_loader.cc
+++ b/dali/operators/reader/loader/file_label_loader.cc
@@ -127,9 +127,11 @@ void FileLabelLoader::ReadSample(ImageLabelWrapper &image_label) {
     }
     image_label.image.Resize({image_size});
     // copy the image
-    current_image->Read(image_label.image.mutable_data<uint8_t>(), image_size);
+    Index ret = current_image->Read(image_label.image.mutable_data<uint8_t>(), image_size);
+    DALI_ENFORCE(ret == image_size, make_string("Failed to read file: ", image_pair.first));
   } else {
     auto p = current_image->Get(image_size);
+    DALI_ENFORCE(p != nullptr, make_string("Failed to read file: ", image_pair.first));
     // Wrap the raw data in the Tensor object.
     image_label.image.ShareData(p, image_size, {image_size});
     image_label.image.set_type(TypeInfo::Create<uint8_t>());

--- a/dali/operators/reader/loader/file_loader.cc
+++ b/dali/operators/reader/loader/file_loader.cc
@@ -152,9 +152,11 @@ void FileLoader::ReadSample(ImageFileWrapper& imfile) {
     }
     imfile.image.Resize({image_size});
     // copy the image
-    current_image->Read(imfile.image.mutable_data<uint8_t>(), image_size);
+    Index ret = current_image->Read(imfile.image.mutable_data<uint8_t>(), image_size);
+    DALI_ENFORCE(ret == image_size, make_string("Failed to read file: ", image_file));
   } else {
     auto p = current_image->Get(image_size);
+    DALI_ENFORCE(p != nullptr, make_string("Failed to read file: ", image_file));
     // Wrap the raw data in the Tensor object.
     imfile.image.ShareData(p, image_size, {image_size});
     imfile.image.set_type(TypeInfo::Create<uint8_t>());

--- a/dali/operators/reader/loader/numpy_loader.cc
+++ b/dali/operators/reader/loader/numpy_loader.cc
@@ -162,9 +162,12 @@ void NumpyLoader::ReadSample(ImageFileWrapper& imfile) {
     }
     imfile.image.Resize(target.shape, target.type_info);
     // copy the image
-    current_image->Read(static_cast<uint8_t*>(imfile.image.raw_mutable_data()), image_bytes);
+    Index ret = current_image->Read(static_cast<uint8_t*>(imfile.image.raw_mutable_data()),
+                                    image_bytes);
+    DALI_ENFORCE(ret == image_bytes, make_string("Failed to read file: ", image_file));
   } else {
     auto p = current_image->Get(image_bytes);
+    DALI_ENFORCE(p != nullptr, make_string("Failed to read file: ", image_file));
     // Wrap the raw data in the Tensor object.
     imfile.image.ShareData(p, image_bytes, {image_bytes});
     imfile.image.Resize(target.shape, target.type_info);

--- a/dali/operators/reader/loader/sequence_loader.cc
+++ b/dali/operators/reader/loader/sequence_loader.cc
@@ -141,9 +141,11 @@ void SequenceLoader::LoadFrame(const std::vector<std::string> &s, Index frame_id
       target->Reset();
     }
     target->Resize({frame_size});
-    frame->Read(target->mutable_data<uint8_t>(), frame_size);
+    Index ret = frame->Read(target->mutable_data<uint8_t>(), frame_size);
+    DALI_ENFORCE(ret == frame_size, make_string("Failed to read file: ", frame_filename));
   } else {
     auto p = frame->Get(frame_size);
+    DALI_ENFORCE(p != nullptr, make_string("Failed to read file: ", frame_filename));
     // Wrap the raw data in the Tensor object.
     target->ShareData(p, frame_size, {frame_size});
     target->set_type(TypeInfo::Create<uint8_t>());

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -74,7 +74,8 @@ Pipeline::Pipeline(const string &serialized_pipe, int batch_size, int num_thread
     google::protobuf::io::CodedInputStream coded_input(
             reinterpret_cast<const uint8_t *>(serialized_pipe.c_str()), serialized_pipe.size());
     coded_input.SetTotalBytesLimit(serialized_pipe.size());
-    def.ParseFromCodedStream(&coded_input);
+    auto res = def.ParseFromCodedStream(&coded_input);
+    DALI_ENFORCE(res, "Error parsing serialized pipeline.");
 
     // If not given, take parameters from the serialized pipeline
     this->batch_size_ = batch_size == -1 ? def.batch_size() : batch_size;

--- a/dali/test/python/test_operator_audio_decoder.py
+++ b/dali/test/python/test_operator_audio_decoder.py
@@ -91,7 +91,7 @@ def rosa_resample(input, in_rate, out_rate):
 
 def test_decoded_vs_generated():
   pipeline = DecoderPipeline()
-  pipeline.build();
+  pipeline.build()
   idx = 0
   for iter in range(1):
     out = pipeline.run()
@@ -131,7 +131,7 @@ def test_decoded_vs_generated():
 
       rosa_in1 = plain.astype(np.float32)
       rosa1 = rosa_resample(rosa_in1, rates[idx], rate1)
-      rosa_in3 = rosa_in1 / 32767;
+      rosa_in3 = rosa_in1 / 32767
       rosa3 = rosa_resample(rosa_in3.mean(axis = 1, keepdims = 1), rates[idx], rate2)
 
       assert np.allclose(res, rosa1, rtol = 0, atol=32767 * 1e-3)

--- a/dali/util/image.h
+++ b/dali/util/image.h
@@ -118,6 +118,7 @@ void WriteImageScaleBias(const T *img, int h, int w,
     }
     file << endl;
   }
+  DALI_ENFORCE(file.good(), make_string("Error writing to file: ", file_name));
 }
 
 /**


### PR DESCRIPTION
- adds error checking to readers regarding data read
- adds error checking to parsing serialized pipeline
- adds error checking to audio decoding
- adds error checking to data write - coco metadata and dump image

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds more error checking

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a check if reads and writes succeed
     adds a check if audio decoding succeed
 - Affected modules and functionalities:
     readers, audio decoder, coco metadata write, image dump
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1180]*
