### PR TITLE
Make DALI tests to be fPIE

### DIFF
--- a/dali/CMakeLists.txt
+++ b/dali/CMakeLists.txt
@@ -68,13 +68,15 @@ target_link_libraries(dali PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
 ################################################
 if (BUILD_TEST)
   add_subdirectory(test)
-  add_executable(dali_test.bin "${DALI_TEST_SRCS}")
+  add_executable(dali_test "${DALI_TEST_SRCS}")
 
-  target_link_libraries(dali_test.bin PUBLIC dali dali_core dali_kernels dali_operators ${DALI_LIBS} gtest)
-  target_link_libraries(dali_test.bin PRIVATE dynlink_cuda ${CUDART_LIB})
-  set_target_properties(dali_test.bin PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TEST_BINARY_DIR})
+  target_link_libraries(dali_test PUBLIC dali dali_core dali_kernels dali_operators ${DALI_LIBS} gtest)
+  target_link_libraries("dali_test" PRIVATE dynlink_cuda ${CUDART_LIB})
+  set_target_properties(dali_test PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TEST_BINARY_DIR})
+  set_target_properties(dali_test PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(dali_test PROPERTIES OUTPUT_NAME "dali_test.bin")
 
-  add_check_gtest_target("check-dali-gtest" dali_test.bin ${TEST_BINARY_DIR})
+  add_check_gtest_target("check-dali-gtest" dali_test ${TEST_BINARY_DIR})
 endif()
 
 

--- a/dali/benchmark/CMakeLists.txt
+++ b/dali/benchmark/CMakeLists.txt
@@ -36,12 +36,13 @@ if (BUILD_BENCHMARK)
     list(APPEND DALI_BENCHMARK_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/caffe2_alexnet_bench.cc")
   endif()
 
-  set(benchmark_bin "dali_benchmark.bin")
-  add_executable(${benchmark_bin} "${DALI_BENCHMARK_SRCS}")
+  add_executable(dali_benchmark "${DALI_BENCHMARK_SRCS}")
 
-  target_link_libraries(${benchmark_bin} PRIVATE dali dali_operators benchmark ${DALI_LIBS})
+  target_link_libraries(dali_benchmark PRIVATE dali dali_operators benchmark ${DALI_LIBS})
+  set_target_properties(dali_benchmark PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(dali_benchmark PROPERTIES OUTPUT_NAME "dali_benchmark.bin")
 
-  set_target_properties(${benchmark_bin} PROPERTIES
+  set_target_properties(dali_benchmark PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${DALI_WHEEL_DIR}/test")
 
 endif()

--- a/dali/core/CMakeLists.txt
+++ b/dali/core/CMakeLists.txt
@@ -35,14 +35,15 @@ configure_file("${DALI_ROOT}/cmake/${lib_exports}.in" "${CMAKE_BINARY_DIR}/${lib
 target_link_libraries(dali_core PRIVATE -Wl,--version-script=${CMAKE_BINARY_DIR}/${lib_exports})
 
 if (BUILD_TEST)
-  set(test_bin "dali_core_test.bin")
-  add_executable(${test_bin} "${DALI_CORE_TEST_SRCS}")
-  target_link_libraries(${test_bin} PUBLIC dali_core)
-  target_link_libraries(${test_bin} PRIVATE gtest dynlink_cuda ${DALI_LIBS})
-  target_link_libraries(${test_bin} PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
+  add_executable(dali_core_test "${DALI_CORE_TEST_SRCS}")
+  target_link_libraries(dali_core_test PUBLIC dali_core)
+  target_link_libraries(dali_core_test PRIVATE gtest dynlink_cuda ${DALI_LIBS})
+  target_link_libraries(dali_core_test PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
+  set_target_properties(dali_core_test PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(dali_core_test PROPERTIES OUTPUT_NAME "dali_core_test.bin")
 
-  set_target_properties(${test_bin} PROPERTIES
+  set_target_properties(dali_core_test PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${TEST_BINARY_DIR})
 
-  add_check_gtest_target("check-core-gtest" ${test_bin} ${TEST_BINARY_DIR})
+  add_check_gtest_target("check-core-gtest" dali_core_test ${TEST_BINARY_DIR})
 endif()

--- a/dali/kernels/CMakeLists.txt
+++ b/dali/kernels/CMakeLists.txt
@@ -45,18 +45,19 @@ configure_file("${DALI_ROOT}/cmake/${lib_exports}.in" "${CMAKE_BINARY_DIR}/${lib
 target_link_libraries(dali_kernels PRIVATE  -Wl,--version-script=${CMAKE_BINARY_DIR}/${lib_exports})
 
 if (BUILD_TEST)
-  set(test_bin "dali_kernel_test.bin")
   # TODO(janton): create a test_utils_lib with dali_test_config.cc and other common utilities
-  add_executable(${test_bin}
+  add_executable(dali_kernel_test
     ${DALI_KERNEL_TEST_SRCS}
     ${DALI_ROOT}/dali/test/dali_test_config.cc)
 
   # TODO(janton): Remove dependency with target `dali`
-  target_link_libraries(${test_bin} PUBLIC dali_kernels dali)
-  target_link_libraries(${test_bin} PRIVATE gtest dynlink_cuda ${DALI_LIBS})
-  target_link_libraries(${test_bin} PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
-  set_target_properties(${test_bin} PROPERTIES
+  target_link_libraries(dali_kernel_test PUBLIC dali_kernels dali)
+  target_link_libraries(dali_kernel_test PRIVATE gtest dynlink_cuda ${DALI_LIBS})
+  target_link_libraries(dali_kernel_test PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
+  set_target_properties(dali_kernel_test PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(dali_kernel_test PROPERTIES OUTPUT_NAME "dali_kernel_test.bin")
+  set_target_properties(dali_kernel_test PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${TEST_BINARY_DIR})
 
-  add_check_gtest_target("check-kernel-gtest" ${test_bin} ${TEST_BINARY_DIR})
+  add_check_gtest_target("check-kernel-gtest" dali_kernel_test ${TEST_BINARY_DIR})
 endif()

--- a/dali/operators/CMakeLists.txt
+++ b/dali/operators/CMakeLists.txt
@@ -61,18 +61,19 @@ configure_file("${DALI_ROOT}/cmake/${lib_exports}.in" "${CMAKE_BINARY_DIR}/${lib
 target_link_libraries(dali_operators PRIVATE -Wl,--version-script=${CMAKE_BINARY_DIR}/${lib_exports})
 
 if (BUILD_TEST)
-  set(test_bin "dali_operator_test.bin")
   # TODO(janton): create a test_utils_lib with dali_test_config.cc and other common utilities
-  add_executable(${test_bin}
+  add_executable(dali_operator_test
     ${DALI_OPERATOR_TEST_SRCS}
     ${DALI_ROOT}/dali/test/dali_test_config.cc
     ${DALI_ROOT}/dali/test/dali_operator_test_utils.cc)
 
-  target_link_libraries(${test_bin} PUBLIC dali_operators)
-  target_link_libraries(${test_bin} PRIVATE gtest dynlink_cuda ${DALI_LIBS})
-  target_link_libraries(${test_bin} PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
-  set_target_properties(${test_bin} PROPERTIES
+  target_link_libraries(dali_operator_test PUBLIC dali_operators)
+  target_link_libraries(dali_operator_test PRIVATE gtest dynlink_cuda ${DALI_LIBS})
+  target_link_libraries(dali_operator_test PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
+  set_target_properties(dali_operator_test PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(dali_operator_test PROPERTIES OUTPUT_NAME "dali_operator_test.bin")
+  set_target_properties(dali_operator_test PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${TEST_BINARY_DIR})
 
-  add_check_gtest_target("check-operator-gtest" ${test_bin} ${TEST_BINARY_DIR})
+  add_check_gtest_target("check-operator-gtest" dali_operator_test ${TEST_BINARY_DIR})
 endif()


### PR DESCRIPTION
- makes DALI test binaries to be compiled as position-independent

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a fPIE option to DALI compiled test binaries

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     makes DALI test binaries to be compiled as position-independent
 - Affected modules and functionalities:
     tests CMake files
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI build
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1416]*
