### PR TITLE
Normalize GPU - pImpl + Bessel's corrections

### DIFF
--- a/dali/kernels/normalize/normalize_gpu.cu
+++ b/dali/kernels/normalize/normalize_gpu.cu
@@ -83,20 +83,7 @@ void NormalizeGPU<Out, In>::Run(
 
 // instantiate explicitly
 
-template class NormalizeGPU<float, int8_t>;
-template class NormalizeGPU<float, int16_t>;
-template class NormalizeGPU<float, int32_t>;
-template class NormalizeGPU<float, uint8_t>;
-template class NormalizeGPU<float, uint16_t>;
-template class NormalizeGPU<float, uint32_t>;
-template class NormalizeGPU<float, float>;
-
-template class NormalizeGPU<int8_t, int8_t>;
-template class NormalizeGPU<int16_t, int16_t>;
-template class NormalizeGPU<int32_t, int32_t>;
-template class NormalizeGPU<uint8_t, uint8_t>;
-template class NormalizeGPU<uint16_t, uint16_t>;
-template class NormalizeGPU<uint32_t, uint32_t>;
+DALI_INSTANTIATE_NORMALIZE_GPU()
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/normalize/normalize_gpu.cu
+++ b/dali/kernels/normalize/normalize_gpu.cu
@@ -1,0 +1,102 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/kernels/normalize/normalize_gpu.h"
+#include <memory>
+#include "dali/kernels/normalize/normalize_gpu_impl.cuh"
+
+namespace dali {
+namespace kernels {
+
+template <typename Out, typename In>
+struct NormalizeGPU<Out, In>::Impl : normalize_impl::NormalizeImplGPU<Out, In, Base, Scale> {};
+
+template <typename Out, typename In>
+NormalizeGPU<Out, In>::NormalizeGPU() = default;
+
+template <typename Out, typename In>
+NormalizeGPU<Out, In>::~NormalizeGPU() = default;
+
+template <typename Out, typename In>
+KernelRequirements NormalizeGPU<Out, In>::Setup(
+      KernelContext &ctx,
+      const TensorListShape<> &data_shape,
+      const TensorListShape<> &param_shape,
+      bool scalar_base,
+      bool scalar_scale,
+      bool scale_is_stddev) {
+  if (!impl_)
+    impl_ = std::make_unique<Impl>();
+  return impl_->Setup(ctx, data_shape, param_shape, scalar_base, scalar_scale, scale_is_stddev);
+}
+
+template <typename Out, typename In>
+void NormalizeGPU<Out, In>::Run(
+      KernelContext &ctx,
+      const OutListGPU<Out> &out, const InListGPU<In> &in,
+      const InListGPU<Base> &base, const InListGPU<Scale> &scale,
+      float global_scale, float shift, float epsilon) {
+  assert(impl_ && "Call setup first");
+  impl_->Run(ctx, out, in, base, scale, global_scale, shift, epsilon);
+}
+
+template <typename Out, typename In>
+void NormalizeGPU<Out, In>::Run(
+      KernelContext &ctx,
+      const OutListGPU<Out> &out, const InListGPU<In> &in,
+      float base, const InListGPU<Scale> &scale,
+      float global_scale, float shift, float epsilon) {
+  assert(impl_ && "Call setup first");
+  impl_->Run(ctx, out, in, base, scale, global_scale, shift, epsilon);
+}
+
+template <typename Out, typename In>
+void NormalizeGPU<Out, In>::Run(
+      KernelContext &ctx,
+      const OutListGPU<Out> &out, const InListGPU<In> &in,
+      const InListGPU<Base> &base, float scale,
+      float global_scale, float shift, float epsilon) {
+  assert(impl_ && "Call setup first");
+  impl_->Run(ctx, out, in, base, scale, global_scale, shift, epsilon);
+}
+
+template <typename Out, typename In>
+void NormalizeGPU<Out, In>::Run(
+      KernelContext &ctx,
+      const OutListGPU<Out> &out, const InListGPU<In> &in,
+      float base, float scale,
+      float global_scale, float shift, float epsilon) {
+  assert(impl_ && "Call setup first");
+  impl_->Run(ctx, out, in, base, scale, global_scale, shift, epsilon);
+}
+
+// instantiate explicitly
+
+template class NormalizeGPU<float, int8_t>;
+template class NormalizeGPU<float, int16_t>;
+template class NormalizeGPU<float, int32_t>;
+template class NormalizeGPU<float, uint8_t>;
+template class NormalizeGPU<float, uint16_t>;
+template class NormalizeGPU<float, uint32_t>;
+template class NormalizeGPU<float, float>;
+
+template class NormalizeGPU<int8_t, int8_t>;
+template class NormalizeGPU<int16_t, int16_t>;
+template class NormalizeGPU<int32_t, int32_t>;
+template class NormalizeGPU<uint8_t, uint8_t>;
+template class NormalizeGPU<uint16_t, uint16_t>;
+template class NormalizeGPU<uint32_t, uint32_t>;
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/normalize/normalize_gpu.h
+++ b/dali/kernels/normalize/normalize_gpu.h
@@ -1,0 +1,153 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_NORMALIZE_NORMALIZE_GPU_H_
+#define DALI_KERNELS_NORMALIZE_NORMALIZE_GPU_H_
+
+/**
+ * @file
+ *
+ * This file contains the GPU kernel for directional data normalization.
+ */
+
+#include <memory>
+#include "dali/kernels/kernel.h"
+
+namespace dali {
+namespace kernels {
+
+/**
+ * @brief Normalizes data
+ *
+ * Data normalization is done using externally provided base (typically: mean or min) and scale
+ * (typically reciprocal of standard deviation or 1/(max-min)).
+ * The normalization follows the formula:
+ * ```
+ * out[data_idx] = (in[data_idx] - base[param_idx]) * scale[param_idx] * global_scale + shift
+ * ```
+ * Where `data_idx` is a position in the data tensor (in, out) and `param_idx` is a position
+ * in the base and scale tensors. The two additional constants, `global_scale` and `shift` can
+ * be used to adjust the result to the ynamic range and resolution of the output type.
+ *
+ * The `scale` parameter may also be interpreted as standard deviation - in that case, its
+ * reciprocal is used and optionally, a regularizing term is added to the variance.
+ * ```
+ * m = 1 / sqrt(square(stddev[param_idx]) + epsilon)
+ * out[data_idx] = (in[data_idx] - mean[param_idx]) * m * global_scale + shift
+ * ```
+ *
+ * The shapes of the input/output data and of the parameters (base/scale) can be different - some
+ * dimensions in the parameter tensors may have extent 1, in which case the values are broadcast
+ * along this axis, as they would in numpy when operating on arrays of different shape.
+ *
+ * The parameter tensor list can contain either as many tensors as the input/output data or just
+ * one sample - in which case the sample is used for normalization of all input tensors.
+ *
+ * One or both of the parameters can be scalars.
+ *
+ * @tparam In   type of elements in the input tensor
+ * @tparam Out  type of elements in the output tensor; if it's an integral type, the results
+ *              are rounded to the nearest integer and clamped to avoid overflow
+ *
+ */
+template <typename Out, typename In>
+class DLL_PUBLIC NormalizeGPU {
+ public:
+  NormalizeGPU();
+  ~NormalizeGPU();
+
+  using Base = float;
+  using Scale = float;
+
+  /**
+   * @brief Sets up the normalization
+   *
+   * @param data_shape      shape of the input and output tensor lists
+   * @param param_shape     shape of the parameters (base, scale)
+   *                        it must have the same number of dimsensions as data_shape and the
+   *                        extents must be either equal to respective extents in data_shape or 1;
+   *                        it can have either the same number of samples as data_shape
+   *                        or one sample;
+   *                        if both scalar_base and scalar_scale are true, param_shape is ignored
+   * @param scalar_base     if true, the Run overload with scalar `base` parameter must be used
+   * @param scalar_scale    if true, the Run overload with scalar `scale` parameter must be used
+   * @param scale_is_stddev if true, scale is interpreted as standard deviation and it's regularized
+   *                        and its reciprocal is used when scaling
+   */
+  KernelRequirements Setup(KernelContext &ctx,
+                           const TensorListShape<> &data_shape,
+                           const TensorListShape<> &param_shape,
+                           bool scalar_base,
+                           bool scalar_scale,
+                           bool scale_is_stddev);
+
+  ///@{
+  /**
+   * @brief Normalizes the data with base and scale given as tensor lists
+   *
+   * @param ctx   kernel's execution context - scratchpad and CUDA stream
+   * @param out   output tensor list, must match data_shape
+   * @param in    input tensor list, must match data_shape
+   * @param base  value(s) subtracted from input elements; must match param_shape
+   * @param scale value(s) of values of scales (or standard deviations), must match param_shape
+   * @param global_scale  additional scaling factor, used e.g. when output is of integral type
+   * @param shift         additional bias value, used e.g. when output is of unsigned type
+   * @param epsilon       regularizing term added to variance; only used if scale_is_stddev = true
+   *                      was specified in Setup
+   */
+  void Run(KernelContext &ctx,
+           const OutListGPU<Out> &out, const InListGPU<In> &in,
+           const InListGPU<Base> &base, const InListGPU<Scale> &scale,
+           float global_scale = 1, float shift = 0, float epsilon = 0);
+
+  void Run(KernelContext &ctx,
+           const OutListGPU<Out> &out, const InListGPU<In> &in,
+           float base, const InListGPU<Scale> &scale,
+           float global_scale = 1, float shift = 0, float epsilon = 0);
+
+  void Run(KernelContext &ctx,
+           const OutListGPU<Out> &out, const InListGPU<In> &in,
+           const InListGPU<Base> &base, float scale,
+           float global_scale = 1, float shift = 0, float epsilon = 0);
+
+  void Run(KernelContext &ctx,
+           const OutListGPU<Out> &out, const InListGPU<In> &in,
+           float base, float scale,
+           float global_scale = 1, float shift = 0, float epsilon = 0);
+  ///@}
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+extern template class NormalizeGPU<float, int8_t>;
+extern template class NormalizeGPU<float, int16_t>;
+extern template class NormalizeGPU<float, int32_t>;
+extern template class NormalizeGPU<float, uint8_t>;
+extern template class NormalizeGPU<float, uint16_t>;
+extern template class NormalizeGPU<float, uint32_t>;
+extern template class NormalizeGPU<float, float>;
+
+extern template class NormalizeGPU<int8_t, int8_t>;
+extern template class NormalizeGPU<int16_t, int16_t>;
+extern template class NormalizeGPU<int32_t, int32_t>;
+extern template class NormalizeGPU<uint8_t, uint8_t>;
+extern template class NormalizeGPU<uint16_t, uint16_t>;
+extern template class NormalizeGPU<uint32_t, uint32_t>;
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_NORMALIZE_NORMALIZE_GPU_H_

--- a/dali/kernels/normalize/normalize_gpu.h
+++ b/dali/kernels/normalize/normalize_gpu.h
@@ -37,8 +37,9 @@ namespace kernels {
  * out[data_idx] = (in[data_idx] - base[param_idx]) * scale[param_idx] * global_scale + shift
  * ```
  * Where `data_idx` is a position in the data tensor (in, out) and `param_idx` is a position
- * in the base and scale tensors. The two additional constants, `global_scale` and `shift` can
- * be used to adjust the result to the ynamic range and resolution of the output type.
+ * in the base and scale tensors (see below for details). The two additional constants,
+ * `global_scale` and `shift` can be used to adjust the result to the dynamic range and resolution
+ * of the output type.
  *
  * The `scale` parameter may also be interpreted as standard deviation - in that case, its
  * reciprocal is used and optionally, a regularizing term is added to the variance.
@@ -50,9 +51,13 @@ namespace kernels {
  * The shapes of the input/output data and of the parameters (base/scale) can be different - some
  * dimensions in the parameter tensors may have extent 1, in which case the values are broadcast
  * along this axis, as they would in numpy when operating on arrays of different shape.
+ * `param_idx` is calculated as follows:
+ * ```
+ * param_idx[axis] = param_shape[axis] == 1 ? 0 : data_idx[axis]
+ * ```
  *
- * The parameter tensor list can contain either as many tensors as the input/output data or just
- * one sample - in which case the sample is used for normalization of all input tensors.
+ * The parameter batch can be of the same length as the data batch or have length == 1 - in which
+ * case the first sample is used for normalization of all input tensors.
  *
  * One or both of the parameters can be scalars.
  *

--- a/dali/kernels/normalize/normalize_gpu.h
+++ b/dali/kernels/normalize/normalize_gpu.h
@@ -132,20 +132,25 @@ class DLL_PUBLIC NormalizeGPU {
   std::unique_ptr<Impl> impl_;
 };
 
-extern template class NormalizeGPU<float, int8_t>;
-extern template class NormalizeGPU<float, int16_t>;
-extern template class NormalizeGPU<float, int32_t>;
-extern template class NormalizeGPU<float, uint8_t>;
-extern template class NormalizeGPU<float, uint16_t>;
-extern template class NormalizeGPU<float, uint32_t>;
-extern template class NormalizeGPU<float, float>;
+#define DALI_INSTANTIATE_NORMALIZE_GPU_OUT(linkage, output_type)\
+  linkage template class NormalizeGPU<output_type, int8_t>;\
+  linkage template class NormalizeGPU<output_type, int16_t>;\
+  linkage template class NormalizeGPU<output_type, int32_t>;\
+  linkage template class NormalizeGPU<output_type, uint8_t>;\
+  linkage template class NormalizeGPU<output_type, uint16_t>;\
+  linkage template class NormalizeGPU<output_type, uint32_t>;\
+  linkage template class NormalizeGPU<output_type, float>;\
 
-extern template class NormalizeGPU<int8_t, int8_t>;
-extern template class NormalizeGPU<int16_t, int16_t>;
-extern template class NormalizeGPU<int32_t, int32_t>;
-extern template class NormalizeGPU<uint8_t, uint8_t>;
-extern template class NormalizeGPU<uint16_t, uint16_t>;
-extern template class NormalizeGPU<uint32_t, uint32_t>;
+#define DALI_INSTANTIATE_NORMALIZE_GPU(linkage)\
+  DALI_INSTANTIATE_NORMALIZE_GPU_OUT(linkage, int8_t)\
+  DALI_INSTANTIATE_NORMALIZE_GPU_OUT(linkage, int16_t)\
+  DALI_INSTANTIATE_NORMALIZE_GPU_OUT(linkage, int32_t)\
+  DALI_INSTANTIATE_NORMALIZE_GPU_OUT(linkage, uint8_t)\
+  DALI_INSTANTIATE_NORMALIZE_GPU_OUT(linkage, uint16_t)\
+  DALI_INSTANTIATE_NORMALIZE_GPU_OUT(linkage, uint32_t)\
+  DALI_INSTANTIATE_NORMALIZE_GPU_OUT(linkage, float)
+
+DALI_INSTANTIATE_NORMALIZE_GPU(extern)
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/normalize/normalize_gpu_impl.cuh
+++ b/dali/kernels/normalize/normalize_gpu_impl.cuh
@@ -177,7 +177,7 @@ struct NormalizeInvStdDevScalarMean {
 
 template <typename NormalizeParams>
 __global__ void NormalizeKernel(const NormalizeParams *sample_params,
-                          float scale, float shift) {
+                                float scale, float shift) {
   auto params = sample_params[blockIdx.y];
   int64_t start_ofs = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   int64_t grid_stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
@@ -454,9 +454,9 @@ class NormalizeImplGPU {
 
   template <typename Desc, typename BaseParam, typename ScaleParam>
   void RunInvStdDev(KernelContext &ctx,
-                const OutListGPU<Out> &out, const InListGPU<In> &in,
-                const BaseParam &base, const ScaleParam &scale,
-                float epsilon, float global_scale, float shift) {
+                    const OutListGPU<Out> &out, const InListGPU<In> &in,
+                    const BaseParam &base, const ScaleParam &scale,
+                    float epsilon, float global_scale, float shift) {
     Desc *cpu_descs = ctx.scratchpad->Allocate<Desc>(AllocType::Host, num_samples_);
     FillDescs(cpu_descs, out, in, base, scale);
     Desc *gpu_descs = ctx.scratchpad->ToGPU(ctx.gpu.stream, make_span(cpu_descs, num_samples_));

--- a/dali/kernels/normalize/normalize_gpu_impl.cuh
+++ b/dali/kernels/normalize/normalize_gpu_impl.cuh
@@ -21,6 +21,7 @@
 #include "dali/core/convert.h"
 #include "dali/core/format.h"
 #include "dali/core/small_vector.h"
+#include "dali/core/tensor_shape_print.h"
 #include "dali/kernels/reduce/reduce_drop_dims.h"
 #include "dali/kernels/kernel.h"
 

--- a/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
@@ -330,7 +330,8 @@ class RegularizedInvRMS {
     int64_t reduced_elems = reduce_batch ? This().TotalReducedElements()
                                          : This().ReducedElements(sample_index);
     DALI_ENFORCE(reduced_elems > 0, "Cannot calculate a mean from 0 elements");
-    return { param_t(1.0 / (reduced_elems - ddof_)), regularization_ };
+    param_t scale = reduced_elems > ddof_ ? param_t(1.0 / (reduced_elems - ddof_)) : 0;
+    return { scale, regularization_ };
   }
 };
 

--- a/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl.cuh
@@ -62,13 +62,19 @@ class MeanImplBase {
   Actual &This() { return static_cast<Actual&>(*this); }
   const Actual &This() const { return static_cast<const Actual&>(*this); }
 
+  using postprocessor_t = Postprocessor;
   using scale_t = typename Postprocessor::scale_t;
 
   Postprocessor GetPostprocessorImpl(int sample_index, bool reduce_batch) const {
     int64_t reduced_elems = reduce_batch ? This().TotalReducedElements()
                                          : This().ReducedElements(sample_index);
+    return GetPostprocessorImpl(reduced_elems, 0);
+  }
+
+  Postprocessor GetPostprocessorImpl(int64_t reduced_elems, int ddof) const {
     DALI_ENFORCE(reduced_elems > 0, "Cannot calculate a mean from 0 elements");
-    return { scale_t(1.0 / reduced_elems) };
+    auto denominator = reduced_elems - ddof;
+    return { denominator > 0 ? scale_t(1.0 / denominator) : 0 };
   }
 };
 
@@ -263,16 +269,29 @@ class StdDevImplGPU : public ReduceImplGPU<Out, In, Acc, StdDevImplGPU<Out, In, 
                       public RootMeanImplBase<Out, In, StdDevImplGPU<Out, In, Mean, Acc>> {
  public:
   using ReduceBase = ReduceImplGPU<Out, In, Acc, StdDevImplGPU<Out, In, Mean, Acc>>;
+  using RMSBase = RootMeanImplBase<Out, In, StdDevImplGPU<Out, In, Mean, Acc>>;
 
   reductions::sum GetReduction() const { return {}; }
+
+  typename RMSBase::postprocessor_t
+  GetPostprocessorImpl(int sample_index, bool reduce_batch) const {
+    int64_t reduced_elems = reduce_batch ? this->TotalReducedElements()
+                                         : this->ReducedElements(sample_index);
+    return RMSBase::GetPostprocessorImpl(reduced_elems, ddof_);
+  }
 
   void Run(KernelContext &kctx,
            const OutListGPU<Out> &out,
            const InListGPU<In> &in,
-           const InListGPU<Mean> &mean) {
+           const InListGPU<Mean> &mean,
+           int ddof = 0) {
+    ddof_ = ddof;
     this->InitMean(mean);
     ReduceBase::Run(kctx, out, in);
   }
+
+ private:
+  int ddof_ = 0;
 };
 
 template <typename Out, typename ScaleAndReg>
@@ -295,19 +314,23 @@ class RegularizedInvRMS {
   using param_t = std::conditional_t<std::is_same<Out, double>::value, double, float>;
   using Postprocessor = RegularizedInvSqrt<Out, param_t>;
 
-  void SetRegularizationTerm(param_t reg) {
-    if (!(reg >= 0))  // >= 0 and not NaN
+  void SetStdDevParams(int ddof, param_t epsilon) {
+    if (!(epsilon >= 0))  // >= 0 and not NaN
       throw std::range_error("The regularizing term must be a non-negative number.");
-    regularization_ = reg;
+    if (ddof < 0)
+      throw std::range_error("Delta Degrees of Freedom must be a non-negative number.");
+    regularization_ = epsilon;
+    ddof_ = ddof;
   }
 
   param_t regularization_ = 0.0f;
+  int     ddof_ = 0;
 
   Postprocessor GetPostprocessorImpl(int sample_index, bool reduce_batch) const {
     int64_t reduced_elems = reduce_batch ? This().TotalReducedElements()
                                          : This().ReducedElements(sample_index);
     DALI_ENFORCE(reduced_elems > 0, "Cannot calculate a mean from 0 elements");
-    return { param_t(1.0 / reduced_elems), regularization_ };
+    return { param_t(1.0 / (reduced_elems - ddof_)), regularization_ };
   }
 };
 
@@ -324,13 +347,17 @@ class InvStdDevImplGPU :
 
   reductions::sum GetReduction() const { return {}; }
 
+  /**
+   *
+   */
   void Run(KernelContext &kctx,
            const OutListGPU<Out> &out,
            const InListGPU<In> &in,
            const InListGPU<Mean> &mean,
-           float reg = 0.0f) {
+           int ddof = 0,
+           float epsilon = 0.0f) {
     this->InitMean(mean);
-    this->SetRegularizationTerm(reg);
+    this->SetStdDevParams(ddof, epsilon);
     ReduceBase::Run(kctx, out, in);
   }
 };

--- a/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
+++ b/dali/kernels/reduce/mean_stddev_gpu_impl_test.cu
@@ -75,6 +75,7 @@ TestTensorList<Out> CenterAndSquare(const InListCPU<In> &in,
 template <typename Out = float, typename In, typename Mean>
 TestTensorList<Out> RefStdDev(const TensorListView<StorageCPU, In> &in,
                               const TensorListView<StorageCPU, Mean> &mean,
+                              int ddof = 0,
                               double reg = 0, bool inv = false) {
   SmallVector<int, 6> axes;
   for (int d = 0; d < mean.sample_dim(); d++) {
@@ -112,7 +113,7 @@ TestTensorList<Out> RefStdDev(const TensorListView<StorageCPU, In> &in,
     out_tl.reshape(out_shape);
     auto out = out_tl.cpu();
     int64_t n = out_shape.num_elements();
-    double ratio = in.num_elements() / n;
+    double ratio = in.num_elements() / n - ddof;
     for (int j = 0; j < n; j++) {
       double sum = 0;
       for (int i = 0; i < N; i++)
@@ -126,7 +127,7 @@ TestTensorList<Out> RefStdDev(const TensorListView<StorageCPU, In> &in,
     for (int i = 0; i < N; i++) {
       int64_t n = out[i].num_elements();
       int64_t n_in = in[i].num_elements();
-      double ratio = n_in / n;
+      double ratio = n_in / n - ddof;
       RefReduce(out[i], centered_squared_cpu[i], make_span(axes), true, reductions::sum());
       for (int j = 0; j < n; j++) {
         double x = out.data[i][j] / ratio + reg;
@@ -347,9 +348,9 @@ TEST(InvStdDevImplGPU, Outer_Batch_Regularized) {
   EXPECT_GE(test.kernel.GetNumStages(), 2);  // both reduced axes must be split
   test.FillData(-100, 100);
 
-  test.Run(fake_mean.gpu(), 12000);
+  test.Run(fake_mean.gpu(), 1, 12000);
 
-  test.ref = RefStdDev(test.in.cpu(), mean_cpu, 12000, true);
+  test.ref = RefStdDev(test.in.cpu(), mean_cpu, 1, 12000, true);
 
   test.Check(EqualEpsRel(1e-5, 1e-6));
 }

--- a/dali/kernels/reduce/reduce_drop_dims.h
+++ b/dali/kernels/reduce/reduce_drop_dims.h
@@ -43,7 +43,7 @@ namespace reduce_impl {
  * When calculating variance in F, we still see HWC as the (fused) inner dimension, but it is
  * different than HW1 in the tensor of means. This class implements this kind of reindexing.
  *
- * The reindexing is done by either dividing and multiplying by old/new strides or by takind modulo.
+ * The reindexing is done by either dividing and multiplying by old/new strides or by taking modulo.
  */
 template <int max_dims>
 struct DropDims {

--- a/dali/kernels/reduce/reduce_gpu.h
+++ b/dali/kernels/reduce/reduce_gpu.h
@@ -286,9 +286,11 @@ class DLL_PUBLIC StdDevGPU {
 
   /**
    * @brief Performs the reduction, according to the parameters specified in Setup.
+   *
+   * @param ddof delta degrees of freedom for Bessel's correction
    */
   void Run(KernelContext &ctx, const OutListGPU<Out> &out,
-           const InListGPU<In> &in, const InListGPU<Mean> &mean);
+           const InListGPU<In> &in, const InListGPU<Mean> &mean, int ddof = 0);
 
  private:
   class Impl;
@@ -364,8 +366,8 @@ class DLL_PUBLIC InvStdDevGPU {
    * The output values are calculated as:
    * ```
    * s = sum( (in[pos] - mean[reduced_pos])^2 )
-   * out[reduced_pos] = s > 0 || reg > 0
-   *                    ? 1/sqrt(s / reduction_factor + reg)
+   * out[reduced_pos] = (s > 0 || reg > 0) && reduction_factor - ddof > 0
+   *                    ? 1/sqrt(s / (reduction_factor - ddof) + reg)
    *                    : 0
    * ```
    * where `reduction_factor` is the number of input elements contributing to a single output.
@@ -374,14 +376,15 @@ class DLL_PUBLIC InvStdDevGPU {
    * @param out     (regularized) inverse standard deviation
    * @param in      input tensor
    * @param mean    mean, used for centering the data
+   * @param ddof    delta degrees of freedom, for Bessel's correction
    * @param reg     regularizing term to avoid division by zero (or small numbers);
-   *                its added to the sum of squares in variance calculation, preventing
+   *                it's added to the sum of squares in variance calculation, preventing
    *                it from being close to zero; if reg = 0, the results that would
    *                cause division by zero are forced to 0, but small denominators
    *                may still cause problems
    */
   void Run(KernelContext &ctx, const OutListGPU<Out> &out,
-           const InListGPU<In> &in, const InListGPU<Mean> &mean, param_t reg = 0);
+           const InListGPU<In> &in, const InListGPU<Mean> &mean, int ddof = 0, param_t epsilon = 0);
 
  private:
   class Impl;

--- a/dali/kernels/reduce/stddev_gpu.cu
+++ b/dali/kernels/reduce/stddev_gpu.cu
@@ -41,9 +41,10 @@ KernelRequirements StdDevGPU<Out, In, Mean>::Setup(
 
 template <typename Out, typename In, typename Mean>
 void StdDevGPU<Out, In, Mean>::Run(KernelContext &ctx, const OutListGPU<Out> &out,
-                             const InListGPU<In> &in, const InListGPU<Mean> &mean) {
+                             const InListGPU<In> &in, const InListGPU<Mean> &mean,
+                             int ddof) {
   assert(impl_ != nullptr);
-  impl_->Run(ctx, out, in, mean);
+  impl_->Run(ctx, out, in, mean, ddof);
 }
 
 
@@ -88,9 +89,9 @@ KernelRequirements InvStdDevGPU<Out, In, Mean>::Setup(
 template <typename Out, typename In, typename Mean>
 void InvStdDevGPU<Out, In, Mean>::Run(
     KernelContext &ctx, const OutListGPU<Out> &out,
-    const InListGPU<In> &in, const InListGPU<Mean> &mean, param_t reg) {
+    const InListGPU<In> &in, const InListGPU<Mean> &mean, int ddof, param_t epsilon) {
   assert(impl_ != nullptr);
-  impl_->Run(ctx, out, in, mean, reg);
+  impl_->Run(ctx, out, in, mean, ddof, epsilon);
 }
 
 template class InvStdDevGPU<float, uint8_t>;


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds the following features:
    * pImpl front-end for Normalize
    * Bessel's corrections in StdDev / InvStdDev

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * pImpl + template implementation in source file + explicit instantiation + extern templates
     * change postprocessing for stddev to subtract degrees of freedom from reduction factor
 - Affected modules and functionalities:
     * Normalize GPU
     * StdDev GPU
 - Key points relevant for the review:
     * Bessel's correction - check parameter forwarding (easy to miss because of default values)
 - Validation and testing:
     * Unit tests modified to use pImpl for some cases
 - Documentation (including examples):
     * Doxygen

**JIRA TASK**: DALI-1267
