### PR TITLE
Add Convolution CPU kernel

### DIFF
--- a/dali/kernels/imgproc/convolution/CMakeLists.txt
+++ b/dali/kernels/imgproc/convolution/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,11 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-add_subdirectory(color_manipulation)
-add_subdirectory(convolution)
-add_subdirectory(pointwise)
-add_subdirectory(resample)
 
 # Get all the source files and dump test files
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)

--- a/dali/kernels/imgproc/convolution/convolution_cpu.h
+++ b/dali/kernels/imgproc/convolution/convolution_cpu.h
@@ -1,0 +1,309 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_IMGPROC_CONVOLUTION_CONVOLUTION_CPU_H_
+#define DALI_KERNELS_IMGPROC_CONVOLUTION_CONVOLUTION_CPU_H_
+
+#include "dali/core/boundary.h"
+#include "dali/core/convert.h"
+#include "dali/core/format.h"
+#include "dali/core/tensor_view.h"
+#include "dali/kernels/common/utils.h"
+#include "dali/kernels/kernel.h"
+#include "dali/pipeline/util/operator_impl_utils.h"
+
+namespace dali {
+namespace kernels {
+
+/**
+ * @brief Cyclic buffer used for storing input window for convolution.
+ *
+ * Wraps a pointer to a buffer of type T, with size equal to length * num_channels
+ * or just length if has_channels = false.
+ */
+template <typename T, bool has_channels = true>
+class CyclicPixelWrapper {
+ public:
+  CyclicPixelWrapper(T* ptr, int length, int num_channels = 1)
+      : data_(ptr),
+        start_(0),
+        end_(0),
+        elements_(0),
+        length_(length),
+        num_channels_(num_channels) {}
+
+  /**
+   * @brief Drop one pixel from the buffer, moving the start element.
+   */
+  void PopPixel() {
+    assert(elements_ > 0);
+    elements_--;
+    start_++;
+    WrapPosition(start_);
+  }
+
+  /**
+   * @brief Add a pixel, represented by contiguous `NumChannels()` elements and starting at `input`,
+   * to the buffer.
+   */
+  void PushPixel(const T* input) {
+    assert(elements_ < length_);
+    for (int c = 0; c < NumChannels(); c++) {
+      data_[end_ * NumChannels() + c] = *input;
+      input++;
+    }
+    elements_++;
+    end_++;
+    WrapPosition(end_);
+  }
+
+  /**
+   * @brief Add a pixel to the buffer
+   */
+  void PushPixel(span<const T> input) {
+    assert(elements_ < length_);
+    for (int c = 0; c < NumChannels(); c++) {
+      data_[end_ * NumChannels() + c] = input[c];
+    }
+    elements_++;
+    end_++;
+    WrapPosition(end_);
+  }
+
+  /**
+   * @brief Get pointer to the start of pixel `idx` in the buffer, taking into account the cyclic
+   * wrapping
+   */
+  T* GetPixelOffset(int idx) {
+    assert(idx < elements_);
+    if (start_ + idx < length_) {
+      return data_ + (start_ + idx) * NumChannels();
+    } else {
+      return data_ + (start_ + idx - length_) * NumChannels();
+    }
+  }
+
+  /**
+   * @brief Calculate dot product with 1-channel `window` length equal to the one specified
+   * at construction. The result is stored in pixel stored at `accum`.
+   */
+  template <typename W>
+  void CalculateDot(W* accum, const W* window) {
+    assert(elements_ == length_);
+    for (int c = 0; c < NumChannels(); c++) {
+      accum[c] = 0;
+    }
+    // TODO(klecki): the if from GetPixelOffset can be factored above the loop
+    for (int idx = 0; idx < length_; idx++) {
+      const auto* pixel = GetPixelOffset(idx);
+      for (int c = 0; c < NumChannels(); c++) {
+        accum[c] += window[idx] * pixel[c];
+      }
+    }
+  }
+
+  int Size() {
+    return elements_;
+  }
+
+  bool Empty() {
+    return elements_ == 0;
+  }
+
+ private:
+  void WrapPosition(int& pos) {
+    if (pos == length_) {
+      pos = 0;
+    }
+  }
+
+  template <bool has_channels_ = has_channels>
+  std::enable_if_t<has_channels_, int> NumChannels() {
+    return num_channels_;
+  }
+
+  template <bool has_channels_ = has_channels>
+  std::enable_if_t<!has_channels_, int> NumChannels() {
+    return 1;
+  }
+
+  T* data_ = nullptr;
+  int start_ = 0;
+  int end_ = 0;  ///< next empty element
+  int elements_ = 0;
+  int length_ = 0;
+  int num_channels_ = 0;
+};
+
+template <typename T, bool has_channels>
+void load_pixel_with_border(CyclicPixelWrapper<T, has_channels>& cpw, const T* in_ptr, int in_idx,
+                            int stride, int axis_size, span<const T> fill_value) {
+  cpw.PushPixel(in_ptr + boundary::idx_reflect_101(in_idx, axis_size) * stride);
+}
+
+template <typename T, bool has_channels>
+void load_pixel_no_border(CyclicPixelWrapper<T, has_channels>& cpw, const T* in_ptr, int in_idx,
+                          int stride) {
+  cpw.PushPixel(in_ptr + in_idx * stride);
+}
+
+constexpr bool is_convolution_inner_loop(int dim, int ndim, bool has_channels) {
+  if (has_channels) {
+    return dim == ndim - 1;
+  } else {
+    return dim == ndim;
+  }
+}
+template <int dim, int ndim, bool has_channels>
+using is_convolution_inner = std::enable_if_t<is_convolution_inner_loop(dim, ndim, has_channels)>;
+
+template <int dim, int ndim, bool has_channels>
+using is_convolution_outer = std::enable_if_t<!is_convolution_inner_loop(dim, ndim, has_channels)>;
+
+// we're in channel dim
+template <int axis, bool has_channels, int dim = 0, typename Out, typename In, typename W, int ndim>
+is_convolution_inner<dim, ndim, has_channels> ConvolutionCpuImpl(
+    Out* out, const In* in, const W* window, const TensorShape<ndim>& shape,
+    const TensorShape<ndim>& strides, int d, int64_t offset, span<const In> border_fill,
+    In* input_window_buffer, span<W> pixel_tmp, W scale = 1) {
+  auto pixel_stride = strides[axis];
+  auto axis_size = shape[axis];
+  auto num_channels = has_channels ? shape[ndim - 1] : 1;  // channel-last is assumed
+  int r = (d - 1) / 2;                                     // radius = (diameter - 1) / 2
+  // offset <- start of current axis
+  auto* out_ptr = out + offset;
+  auto* in_ptr = in + offset;
+
+  CyclicPixelWrapper<In, has_channels> input_window(input_window_buffer, d, num_channels);
+
+  int in_idx = -r, out_idx = 0;
+  for (in_idx = -r; in_idx < 0; in_idx++) {
+    load_pixel_with_border(input_window, in_ptr, in_idx, pixel_stride, axis_size, border_fill);
+  }
+  if (r < axis_size) {
+    // we load the window without the last element
+    for (; in_idx < r; in_idx++) {
+      load_pixel_no_border(input_window, in_ptr, in_idx, pixel_stride);
+    }
+    for (; out_idx < axis_size - r; out_idx++, in_idx++) {
+      // we load last element of the input window corresponding to the out_idx
+      load_pixel_no_border(input_window, in_ptr, in_idx, pixel_stride);
+      // we have both windows as almost-contiguous buffers
+      input_window.CalculateDot(pixel_tmp.data(), window);
+      for (int c = 0; c < num_channels; c++) {
+        out_ptr[out_idx * pixel_stride + c] = ConvertSat<Out>(pixel_tmp[c] * scale);
+      }
+      // remove one pixel, to make space for next out_idx and in_idx
+      input_window.PopPixel();
+    }
+  } else {
+    // we need to load the rest of the window, just handle all with border condition for simplicity
+    for (; in_idx < r; in_idx++) {
+      load_pixel_with_border(input_window, in_ptr, in_idx, pixel_stride, axis_size, border_fill);
+    }
+  }
+  // we need write out the rest of the outputs, the input window is full of data
+  for (; out_idx < axis_size; out_idx++, in_idx++) {
+    load_pixel_with_border(input_window, in_ptr, in_idx, pixel_stride, axis_size, border_fill);
+    input_window.CalculateDot(pixel_tmp.data(), window);
+    for (int c = 0; c < num_channels; c++) {
+      out_ptr[out_idx * pixel_stride + c] = ConvertSat<Out>(pixel_tmp[c] * scale);
+    }
+    input_window.PopPixel();
+  }
+}
+
+template <int axis, bool has_channels, int dim = 0, typename Out, typename In, typename W, int ndim>
+is_convolution_outer<dim, ndim, has_channels> ConvolutionCpuImpl(
+    Out* out, const In* in, const W* window, const TensorShape<ndim>& shape,
+    const TensorShape<ndim>& strides, int d, int64_t offset, span<const In> border_fill,
+    In* input_window_buffer, span<W> pixel_tmp, W scale = 1) {
+  if (dim == axis) {
+    ConvolutionCpuImpl<axis, has_channels, dim + 1>(out, in, window, shape, strides, d, offset,
+                                                    border_fill, input_window_buffer, pixel_tmp,
+                                                    scale);
+  } else if (dim != axis) {
+    for (int64_t i = 0; i < shape[dim]; i++) {
+      ConvolutionCpuImpl<axis, has_channels, dim + 1>(out, in, window, shape, strides, d, offset,
+                                                      border_fill, input_window_buffer, pixel_tmp,
+                                                      scale);
+      offset += strides[dim];
+    }
+  }
+}
+
+/**
+ * @brief Apply convolution with 1-channel `window` in specified axis.
+ *
+ * Cyclic sliding window is used when accessing the input, so when the pixels in given axis
+ * have big stride the convolution is calculated with basically contiguous buffers
+ */
+template <typename Out, typename In, typename W, int ndim, int axis, bool has_channels = true>
+struct ConvolutionCpu {
+  KernelRequirements Setup(KernelContext& ctx, const InTensorCPU<In, ndim>& in,
+                           const TensorView<StorageCPU, const W, 1>& window) {
+    KernelRequirements req;
+    ScratchpadEstimator se;
+    DALI_ENFORCE(
+        window.num_elements() % 2 == 1,
+        make_string("Kernel window should have odd length, got: ", window.num_elements(), "."));
+    se.add<In>(AllocType::Host, GetInputWindowBufSize(in, window));
+    se.add<In>(AllocType::Host, GetPixelSize(in));  // fill value
+    se.add<W>(AllocType::Host, GetPixelSize(in));   // tmp result
+    req.scratch_sizes = se.sizes;
+    req.output_shapes.push_back(uniform_list_shape<ndim>(1, in.shape));
+    return req;
+  }
+
+  void Run(KernelContext& ctx, const TensorView<StorageCPU, Out, ndim> out,
+           const TensorView<StorageCPU, const In, ndim>& in,
+           const TensorView<StorageCPU, const W, 1>& window, W scale = 1) {
+    int num_channels = GetPixelSize(in);
+    int input_window_buf_size = GetInputWindowBufSize(in, window);
+    auto* input_window_buffer =
+        ctx.scratchpad->Allocate<In>(AllocType::Host, input_window_buf_size);
+    auto* border_fill_buf = ctx.scratchpad->Allocate<In>(AllocType::Host, num_channels);
+    auto* pixel_tmp_buf = ctx.scratchpad->Allocate<W>(AllocType::Host, num_channels);
+    auto strides = GetStrides(in.shape);
+    auto diameter = window.num_elements();
+
+    auto border_fill = make_span(border_fill_buf, num_channels);
+    for (int c = 0; c < num_channels; c++) {
+      border_fill[c] = 0;
+    }
+    auto pixel_tmp = make_span(pixel_tmp_buf, num_channels);
+
+    ConvolutionCpuImpl<axis, has_channels, 0, Out, In, W, ndim>(
+        out.data, in.data, window.data, in.shape, strides, diameter, 0, border_fill,
+        input_window_buffer, pixel_tmp, scale);
+  }
+
+ private:
+  static_assert(0 <= axis && axis < (has_channels ? ndim - 1 : ndim),
+                "Selected axis must be in [0, ndim) when there is no channel axis, or in [0, ndim "
+                "- 1) for channel-last input");
+
+  int GetInputWindowBufSize(const TensorView<StorageCPU, const In, ndim>& in,
+                            const TensorView<StorageCPU, const W, 1>& window) {
+    return GetPixelSize(in) * window.num_elements();
+  }
+  int GetPixelSize(const TensorView<StorageCPU, const In, ndim>& in) {
+    return has_channels ? in.shape[ndim - 1] : 1;
+  }
+};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_IMGPROC_CONVOLUTION_CONVOLUTION_CPU_H_

--- a/dali/kernels/imgproc/convolution/convolution_cpu_test.cc
+++ b/dali/kernels/imgproc/convolution/convolution_cpu_test.cc
@@ -1,0 +1,293 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <complex>
+#include <tuple>
+#include <vector>
+
+#include "dali/core/boundary.h"
+#include "dali/kernels/common/utils.h"
+#include "dali/kernels/imgproc/convolution/convolution_cpu.h"
+#include "dali/kernels/scratch.h"
+#include "dali/test/tensor_test_utils.h"
+#include "dali/test/test_tensors.h"
+
+namespace dali {
+namespace kernels {
+
+template <typename T>
+struct CyclicPixelWrapperTest : public ::testing::Test {};
+
+TYPED_TEST_SUITE_P(CyclicPixelWrapperTest);
+
+template <int num_channels_, bool has_channels_>
+struct cpw_params {
+  static constexpr int num_channels = num_channels_;
+  static constexpr bool has_channels = has_channels_;
+};
+
+using CyclicPixelWrapperValues =
+    ::testing::Types<cpw_params<1, true>, cpw_params<3, true>, cpw_params<1, false>>;
+
+TYPED_TEST_P(CyclicPixelWrapperTest, FillAndCycle) {
+  constexpr int size = 6;
+  constexpr int num_channels = TypeParam::num_channels;
+  constexpr bool has_channels = TypeParam::has_channels;
+  int tmp_buffer[size * num_channels];  // NOLINT
+  int input_buffer[size * num_channels];  // NOLINT
+  for (int i = 0; i < size * num_channels; i++) {
+    input_buffer[i] = i;
+    tmp_buffer[i] = -1;
+  }
+  CyclicPixelWrapper<int, has_channels> cpw(tmp_buffer, size, num_channels);
+  EXPECT_EQ(0, cpw.Size());
+  for (int i = 0; i < size; i++) {
+    cpw.PushPixel(input_buffer + i * num_channels);
+    EXPECT_EQ(tmp_buffer + i * num_channels, cpw.GetPixelOffset(i));
+    for (int c = 0; c < num_channels; c++) {
+      EXPECT_EQ(input_buffer[i * num_channels + c], cpw.GetPixelOffset(i)[c]);
+    }
+  }
+  for (int i = 0; i < size; i++) {
+    cpw.PopPixel();
+    cpw.PushPixel(input_buffer + i * num_channels);
+    for (int j = 0; j < size; j++) {
+      // we're starting at i + 1 as we did already one Pop & Push operation
+      int element = (i + 1 + j) % size;
+      EXPECT_EQ(tmp_buffer + element * num_channels, cpw.GetPixelOffset(j));
+      for (int c = 0; c < num_channels; c++) {
+        EXPECT_EQ(input_buffer[element * num_channels + c], cpw.GetPixelOffset(j)[c]);
+      }
+    }
+  }
+}
+
+void baseline_dot(span<int> result, span<const int> input, span<const int> window, int in_offset) {
+  int num_channels = result.size();
+  int num_elements = window.size();
+  ASSERT_EQ(input.size(), num_channels * num_elements);
+  for (int c = 0; c < num_channels; c++) {
+    result[c] = 0;
+    for (int i = 0; i < num_elements; i++) {
+      int in_elem = (i + in_offset) % num_elements;
+      result[c] += window[i] * input[in_elem * num_channels + c];
+    }
+  }
+}
+
+TYPED_TEST_P(CyclicPixelWrapperTest, DotProduct) {
+  constexpr int size = 6;
+  constexpr int num_channels = TypeParam::num_channels;
+  constexpr bool has_channels = TypeParam::has_channels;
+  int tmp_buffer[size * num_channels];  // NOLINT
+  int input_buffer[size * num_channels];  // NOLINT
+  int window[size];  // NOLINT
+  for (int i = 0; i < size * num_channels; i++) {
+    input_buffer[i] = i;
+    tmp_buffer[i] = -1;
+  }
+  for (int i = 0; i < size; i++) {
+    window[i] = i;
+  }
+  int baseline[num_channels], result[num_channels];
+  for (int c = 0; c < num_channels; c++) {
+    baseline[c] = 0;
+    for (int i = 0; i < size; i++) {
+      baseline[c] += window[i] * input_buffer[i * num_channels + c];
+    }
+  }
+
+  CyclicPixelWrapper<int, has_channels> cpw(tmp_buffer, size, num_channels);
+  for (int i = 0; i < size; i++) {
+    cpw.PushPixel(input_buffer + i * num_channels);
+  }
+  cpw.CalculateDot(result, window);
+  baseline_dot(make_span(baseline), make_span(input_buffer), make_span(window), 0);
+  for (int c = 0; c < num_channels; c++) {
+    EXPECT_EQ(baseline[c], result[c]);
+  }
+  for (int i = 0; i < size; i++) {
+    cpw.PopPixel();
+    cpw.PushPixel(input_buffer + i * num_channels);
+    cpw.CalculateDot(result, window);
+    // again we start here at i + 1 offset
+    baseline_dot(make_span(baseline), make_span(input_buffer), make_span(window), i + 1);
+    for (int c = 0; c < num_channels; c++) {
+      EXPECT_EQ(baseline[c], result[c]);
+    }
+  }
+}
+
+REGISTER_TYPED_TEST_SUITE_P(CyclicPixelWrapperTest, FillAndCycle, DotProduct);
+
+INSTANTIATE_TYPED_TEST_SUITE_P(CyclicPixelWrapper, CyclicPixelWrapperTest,
+                               CyclicPixelWrapperValues);
+
+template <typename Out, typename In, typename W>
+void BaselineConvolveAxis(Out *out, const In *in, const W *window, int len, int r, int channel_num,
+                          int64_t stride) {
+  for (int i = 0; i < len; i++) {
+    for (int c = 0; c < channel_num; c++) {
+      out[i * stride + c] = 0;
+      for (int d = -r; d <= r; d++) {
+        if (i + d >= 0 && i + d < len) {
+          out[i * stride + c] += in[(i + d) * stride + c] * window[d + r];
+        } else {
+          out[i * stride + c] +=
+              in[boundary::idx_reflect_101(i + d, len) * stride + c] * window[d + r];
+        }
+      }
+    }
+  }
+}
+
+template <typename Out, typename In, typename W, int ndim>
+void BaselineConvolve(const TensorView<StorageCPU, Out, ndim> &out,
+                      const TensorView<StorageCPU, In, ndim> &in,
+                      const TensorView<StorageCPU, W, 1> &window, int axis, int r,
+                      int current_axis = 0, int64_t offset = 0) {
+  if (current_axis == ndim - 1) {
+    auto stride = GetStrides(out.shape)[axis];
+    BaselineConvolveAxis(out.data + offset, in.data + offset, window.data, out.shape[axis], r,
+                         in.shape[ndim - 1], stride);
+  } else if (current_axis == axis) {
+    BaselineConvolve(out, in, window, axis, r, current_axis + 1, offset);
+  } else {
+    for (int i = 0; i < out.shape[current_axis]; i++) {
+      auto stride = GetStrides(out.shape)[current_axis];
+      BaselineConvolve(out, in, window, axis, r, current_axis + 1, offset + i * stride);
+    }
+  }
+}
+
+template <int ndim_, bool has_channels_, int axis_, int window_size_>
+struct convolution_params {
+  static constexpr int ndim = ndim_;
+  static constexpr int baseline_ndim = ndim + (has_channels_ ? 0 : 1);
+  static constexpr bool has_channels = has_channels_;
+  static constexpr int axis = axis_;
+  static constexpr int window_size = window_size_;
+};
+
+template <typename T>
+struct ConvolutionCpuKernelTest : public ::testing::Test {
+  using Kernel = ConvolutionCpu<float, uint8_t, float, T::ndim, T::axis, T::has_channels>;
+
+  TensorShape<T::ndim> GetShape() {
+    if (T::has_channels) {
+      return shape_ch_.template last<T::ndim>();
+    } else {
+      return shape_noch_.template last<T::ndim>();
+    }
+  }
+
+  TensorShape<T::baseline_ndim> GetBaselineShape() {
+    if (T::has_channels) {
+      return shape_ch_.template last<T::baseline_ndim>();
+    } else {
+      return shape_noch1_.template last<T::baseline_ndim>();
+    }
+  }
+
+  void SetUp() override {
+    constexpr int window_size = T::window_size;
+    kernel_window_.reshape(uniform_list_shape<1>(1, {window_size}));
+    k_win_ = kernel_window_.cpu()[0];
+
+    // almost box filter, with raised center
+    for (int i = 0; i < window_size; i++) {
+      if (i < window_size / 2) {
+        k_win_.data[i] = 1;
+      } else if (i == window_size / 2) {
+        k_win_.data[i] = 2;
+      } else {
+        k_win_.data[i] = 1;
+      }
+    }
+
+    input_.reshape(uniform_list_shape<T::ndim>(1, GetShape()));
+    in_ = input_.cpu()[0];
+    baseline_in_ = {in_.data, GetBaselineShape()};
+
+    ConstantFill(in_, 0);
+
+    std::mt19937 rng;
+    UniformRandomFill(in_, rng, 0, 255);
+
+    output_.reshape(uniform_list_shape<T::ndim>(1, GetShape()));
+    baseline_output_.reshape(uniform_list_shape<T::baseline_ndim>(1, GetBaselineShape()));
+    out_ = output_.cpu()[0];
+    baseline_out_ = baseline_output_.cpu()[0];
+
+    ConstantFill(out_, -1);
+    ConstantFill(baseline_out_, -1);
+  }
+
+  void RunTest() {
+    KernelContext ctx;
+    Kernel kernel;
+
+    auto req = kernel.Setup(ctx, in_, k_win_);
+    // this is painful
+    ScratchpadAllocator scratch_alloc;
+    scratch_alloc.Reserve(req.scratch_sizes);
+    auto scratchpad = scratch_alloc.GetScratchpad();
+    ctx.scratchpad = &scratchpad;
+
+    kernel.Run(ctx, out_, in_, k_win_);
+    BaselineConvolve(baseline_out_, baseline_in_, k_win_, T::axis, T::window_size / 2);
+
+    // for validation we need the same shape
+    TensorView<StorageCPU, float, T::ndim> baseline_out_reshaped = {baseline_out_.data, out_.shape};
+    Check(out_, baseline_out_reshaped);
+  }
+
+  TestTensorList<float, 1> kernel_window_;
+  TestTensorList<uint8_t, T::ndim> input_;
+  TestTensorList<float, T::ndim> output_;
+  TestTensorList<float, T::baseline_ndim> baseline_output_;
+
+  TensorView<StorageCPU, float, 1> k_win_;
+  TensorView<StorageCPU, uint8_t, T::ndim> in_;
+  TensorView<StorageCPU, uint8_t, T::baseline_ndim> baseline_in_;
+  TensorView<StorageCPU, float, T::ndim> out_;
+  TensorView<StorageCPU, float, T::baseline_ndim> baseline_out_;
+
+  const TensorShape<> shape_ch_ = {13, 11, 21, 3};
+  const TensorShape<> shape_noch_ = {13, 11, 21};
+  const TensorShape<> shape_noch1_ = {13, 11, 21, 1};
+};
+
+TYPED_TEST_SUITE_P(ConvolutionCpuKernelTest);
+
+using ConvolutionTestValues =
+    ::testing::Types<convolution_params<1, false, 0, 3>, convolution_params<2, true, 0, 3>,
+                     convolution_params<2, false, 0, 3>, convolution_params<2, false, 1, 3>,
+                     convolution_params<3, true, 0, 3>, convolution_params<3, true, 1, 3>,
+                     convolution_params<3, false, 1, 3>, convolution_params<3, false, 1, 7>,
+                     convolution_params<3, false, 1, 11>, convolution_params<3, false, 1, 21>,
+                     convolution_params<3, false, 1, 101>>;
+
+TYPED_TEST_P(ConvolutionCpuKernelTest, DoConvolution) {
+  this->RunTest();
+}
+
+REGISTER_TYPED_TEST_SUITE_P(ConvolutionCpuKernelTest, DoConvolution);
+INSTANTIATE_TYPED_TEST_SUITE_P(ConvolutionCpuKernel, ConvolutionCpuKernelTest,
+                               ConvolutionTestValues);
+
+}  // namespace kernels
+}  // namespace dali


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
This is part of the effort for Gaussian Filter Operator

#### What happened in this PR?
 - What solution was applied:
     A DALI kernel was implemented, that can convolve a kernel window with n-dimenstional tensor in selected axis.
     The selected axis is traversed using a sliding window/cyclic buffer, adding only one new pixel for every output pixel - as we have the input in contiguous memory (almost) the convolution with kernel window should be fast even if the axis have bigger strides.
 - Affected modules and functionalities:
     Kernels
 - Key points relevant for the review:
     Sliding window cyclic buffer, are the proper strides used.
 - Validation and testing:
     Gtest test added
 - Documentation (including examples):
     A bit of docstrings


**JIRA TASK**: *[DALI-1425]*
