### PR TITLE
Split Slice benchmarks into CPU and GPU

### DIFF
--- a/dali/benchmark/CMakeLists.txt
+++ b/dali/benchmark/CMakeLists.txt
@@ -29,6 +29,7 @@ if (BUILD_BENCHMARK)
     "${CMAKE_CURRENT_SOURCE_DIR}/warp_affine_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/transpose_cpu_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/color_twist_bench.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/slice_kernel_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/slice_kernel_bench.cu"
   )
 

--- a/dali/benchmark/slice_kernel_bench.cc
+++ b/dali/benchmark/slice_kernel_bench.cc
@@ -15,7 +15,7 @@
 #include <benchmark/benchmark.h>
 #include <vector>
 #include "dali/benchmark/dali_bench.h"
-#include "dali/kernels/slice/slice_gpu.cuh"
+#include "dali/kernels/slice/slice_cpu.h"
 #include "dali/test/tensor_test_utils.h"
 #include "dali/test/test_tensors.h"
 #include "dali/kernels/scratch.h"
@@ -26,7 +26,7 @@ constexpr int Dims = 3;
 using InputType = float;
 using OutputType = float;
 
-class SliceBenchGPU : public DALIBenchmark {
+class SliceBenchCPU : public DALIBenchmark {
  public:
   kernels::TestTensorList<InputType, Dims> test_data;
   kernels::TestTensorList<OutputType, Dims> out_data;
@@ -41,7 +41,7 @@ class SliceBenchGPU : public DALIBenchmark {
     out_data.reshape(uniform_list_shape<Dims>(batch_size, out_shape));
   }
 
-  void RunGPU(benchmark::State& st) {
+  void RunCPU(benchmark::State& st) {
     int H = st.range(0);
     int W = st.range(1);
     int C = st.range(2);
@@ -51,64 +51,51 @@ class SliceBenchGPU : public DALIBenchmark {
     int crop_h = st.range(6);
     int crop_w = st.range(7);
     int crop_c = st.range(8);
-    int batch_size = st.range(9);
 
     TensorShape<Dims> in_shape{H, W, C};
     TensorShape<Dims> anchor{anchor_h, anchor_w, anchor_c};
     TensorShape<Dims> out_shape{crop_h, crop_w, crop_c};
-    Setup(in_shape, out_shape, batch_size);
+    Setup(in_shape, out_shape);
 
-    using Kernel = kernels::SliceGPU<OutputType, InputType, Dims>;
+    using Kernel = kernels::SliceCPU<OutputType, InputType, Dims>;
     Kernel kernel;
 
-    std::vector<kernels::SliceArgs<OutputType, Dims>> args_vec(batch_size);
-    for (auto &args : args_vec) {
-      args.anchor = anchor;
-      args.shape = out_shape;
-    }
+    kernels::SliceArgs<OutputType, Dims> args;
+    args.anchor = anchor;
+    args.shape = out_shape;
 
-    auto out_tv = out_data.gpu();
-    auto in_tv = test_data.gpu();
+    auto out_tv = out_data.cpu()[0];
+    auto in_tv = test_data.cpu()[0];
 
     for (auto _ : st) {
       kernels::KernelContext ctx;
-      ctx.gpu.stream = 0;
-
-      auto req = kernel.Setup(ctx, in_tv, args_vec);
-
-      kernels::ScratchpadAllocator scratch_alloc;
-      scratch_alloc.Reserve(req.scratch_sizes);
-      auto scratchpad = scratch_alloc.GetScratchpad();
-      ctx.scratchpad = &scratchpad;
-
-      kernel.Run(ctx, out_tv, in_tv, args_vec);
-      cudaStreamSynchronize(ctx.gpu.stream);
+      auto kernel_req = kernel.Setup(ctx, in_tv, args);
+      kernel.Run(ctx, out_tv, in_tv, args);
       st.counters["FPS"] = benchmark::Counter(st.iterations() + 1,
         benchmark::Counter::kIsRate);
     }
   }
 };
 
-static void SliceKernelArgs_GPU_OnlySlice(benchmark::internal::Benchmark *b) {
+static void SliceKernelArgs_OnlySlice_CPU(benchmark::internal::Benchmark *b) {
   for (int H = 1000; H >= 500; H /= 2) {
     int W = H, C = 3;
     int crop_h = 9 * H / 10;
     int crop_w = 9 * W / 10;
     b->Args({H, W, C, 0, 0, 0, crop_h, crop_w, C, 1});
-    b->Args({H, W, C, 0, 0, 0, crop_h, crop_w, C, 10});
   }
 }
 
-BENCHMARK_DEFINE_F(SliceBenchGPU, Slice_GPU_OnlySlice)(benchmark::State& st) {
-  this->RunGPU(st);
+BENCHMARK_DEFINE_F(SliceBenchCPU, Slice_CPU_OnlySlice)(benchmark::State& st) {
+  this->RunCPU(st);
 }
 
-BENCHMARK_REGISTER_F(SliceBenchGPU, Slice_GPU_OnlySlice)->Iterations(1000)
+BENCHMARK_REGISTER_F(SliceBenchCPU, Slice_CPU_OnlySlice)->Iterations(1000)
 ->Unit(benchmark::kMicrosecond)
 ->UseRealTime()
-->Apply(SliceKernelArgs_GPU_OnlySlice);
+->Apply(SliceKernelArgs_OnlySlice_CPU);
 
-static void SliceKernelArgs_GPU_OnlyPad(benchmark::internal::Benchmark *b) {
+static void SliceKernelArgs_OnlyPad_CPU(benchmark::internal::Benchmark *b) {
   for (int H = 1000; H >= 500; H /= 2) {
     int W = H, C = 3;
     int crop_h = 9 * H / 10;
@@ -116,20 +103,19 @@ static void SliceKernelArgs_GPU_OnlyPad(benchmark::internal::Benchmark *b) {
     int anchor_h = H;
     int anchor_w = W;
     b->Args({H, W, C, anchor_h, anchor_w, 0, crop_h, crop_w, C, 1});
-    b->Args({H, W, C, anchor_h, anchor_w, 0, crop_h, crop_w, C, 10});
   }
 }
 
-BENCHMARK_DEFINE_F(SliceBenchGPU, Slice_GPU_OnlyPad)(benchmark::State& st) {
-  this->RunGPU(st);
+BENCHMARK_DEFINE_F(SliceBenchCPU, Slice_OnlyPad_CPU)(benchmark::State& st) {
+  this->RunCPU(st);
 }
 
-BENCHMARK_REGISTER_F(SliceBenchGPU, Slice_GPU_OnlyPad)->Iterations(1000)
+BENCHMARK_REGISTER_F(SliceBenchCPU, Slice_OnlyPad_CPU)->Iterations(1000)
 ->Unit(benchmark::kMicrosecond)
 ->UseRealTime()
-->Apply(SliceKernelArgs_GPU_OnlyPad);
+->Apply(SliceKernelArgs_OnlyPad_CPU);
 
-static void SliceKernelArgs_GPU_SliceAndPad(benchmark::internal::Benchmark *b) {
+static void SliceKernelArgs_SliceAndPad_CPU(benchmark::internal::Benchmark *b) {
   for (int H = 1000; H >= 500; H /= 2) {
     int W = H, C = 3;
     int crop_h = 9 * H / 10;
@@ -141,14 +127,14 @@ static void SliceKernelArgs_GPU_SliceAndPad(benchmark::internal::Benchmark *b) {
   }
 }
 
-BENCHMARK_DEFINE_F(SliceBenchGPU, Slice_GPU_SliceAndPad)(benchmark::State& st) {
-  this->RunGPU(st);
+BENCHMARK_DEFINE_F(SliceBenchCPU, Slice_SliceAndPad_CPU)(benchmark::State& st) {
+  this->RunCPU(st);
 }
 
-BENCHMARK_REGISTER_F(SliceBenchGPU, Slice_GPU_SliceAndPad)->Iterations(1000)
+BENCHMARK_REGISTER_F(SliceBenchCPU, Slice_SliceAndPad_CPU)->Iterations(1000)
 ->Unit(benchmark::kMicrosecond)
 ->UseRealTime()
-->Apply(SliceKernelArgs_GPU_SliceAndPad);
+->Apply(SliceKernelArgs_SliceAndPad_CPU);
 
 
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a compiler warning caused by including SliceCPU header from a *.cu file (benchmark)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Split CPU and GPU Slice benchmarks *
 - Affected modules and functionalities:
     *Slice kernel benchmarks*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
