### PR TITLE
Fix generation of Erase Region in kernel test

### DIFF
--- a/dali/kernels/erase/erase_gpu_test.cu
+++ b/dali/kernels/erase/erase_gpu_test.cu
@@ -246,20 +246,19 @@ struct EraseGpuKernelTest :
   }
 
   void CreateRegions() {
-    int min_erase_regions = 0;
+    TensorListShape<1> regions_shape(batch_size_);
+    std::mt19937 gen(0);
     if (region_generation_ == RegionGen::NO_ERASE) {
-      max_erase_regions_ = 0;
       // no cover
+      regions_shape = uniform_list_shape<1>(batch_size_, {0});
     } else if (region_generation_ == RegionGen::FULL_ERASE) {
       // full cover
-      min_erase_regions = 1;
-      max_erase_regions_ = 1;
-    }
-    std::mt19937 gen(0);
-    std::uniform_int_distribution<> n_regions(min_erase_regions, max_erase_regions_+1);
-    auto regions_shape = TensorListShape<1>(batch_size_);
-    for (int i = 0; i < batch_size_; ++i) {
-      regions_shape.set_tensor_shape(i, {n_regions(gen)});
+      regions_shape = uniform_list_shape<1>(batch_size_, {1});
+    } else {
+      std::uniform_int_distribution<> n_regions(0, max_erase_regions_);
+      for (int i = 0; i < batch_size_; ++i) {
+        regions_shape.set_tensor_shape(i, {n_regions(gen)});
+      }
     }
     regions_.reshape(regions_shape);
     auto regions_cpu = regions_.cpu();


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fix generating test data

#### What happened in this PR?
 - What solution was applied:
     The bug was fixed, duh.
     The number of erase regions was randomly sampled, and the bug was in assuming that uniform_int_distribution uses [a, b) interval (in fact it's closed [a, b]). So when there was 0 regions, we sampled [0, 1] interval and got 1 randomly initialized region. For full erase we sometime got 2 regions that probably also caused problem.
    Reshaping the regions was reworked a bit.
 - Affected modules and functionalities:
     Kernel Test
 - Key points relevant for the review:
     Check if now it's ok
 - Validation and testing:
     Run xavier several times, it fails there quite often?
 - Documentation (including examples):
     No


**JIRA TASK**: *[NA]*
