### PR TITLE
Fix GPU spectrogram when window_length != nfft

### DIFF
--- a/dali/kernels/signal/fft/stft_gpu_impl.cu
+++ b/dali/kernels/signal/fft/stft_gpu_impl.cu
@@ -194,10 +194,6 @@ void StftImplGPU::ValidateParams(ExecutionContext &ctx) {
     DALI_ENFORCE(out_shape[i] == ts,
         make_string("Unexpected output shape at sample ", i, ": ", out_shape[i], " expected ", ts));
   }
-
-  DALI_ENFORCE(ctx.window().num_elements() == 0 ||
-               ctx.window().num_elements() == transform_size(),
-               "The window must be either empty or have a size equal to the transform size.");
 }
 
 void StftImplGPU::Run(KernelContext &ctx,

--- a/dali/test/python/test_operator_spectrogram.py
+++ b/dali/test/python/test_operator_spectrogram.py
@@ -80,8 +80,8 @@ def spectrogram_func_librosa(nfft, win_len, win_step, window, input_data):
     if window is None:
         window = hann_win
 
-    out = np.abs(
-        librosa.stft(y=input_data, n_fft=nfft, hop_length=win_step, window=window))**2
+    out = np.abs(librosa.stft(y=input_data, n_fft=nfft,
+                              win_length=win_len, hop_length=win_step, window=window))**2
 
     # Alternative way to calculate the spectrogram:
     # out, _ = librosa.core.spectrum._spectrogram(
@@ -158,7 +158,7 @@ def test_operator_spectrogram_vs_python_wave():
         for window in [None, hann_win, cos_win]:
             for batch_size in [3]:
                 for nfft, window_length, window_step, length in [(256, 256, 128, 4096),
-                                                                (16, 16, 8, 1000),
+                                                                (128, 100, 61, 1000),
                                                                 (10, 10, 5, 1000),
                                                                 ]:
                     yield check_operator_spectrogram_vs_python_wave_1d, device, batch_size, \


### PR DESCRIPTION
Remove excessive check from GPU spectrogram kernel.
Extend tests to `window_length != nfft`.

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: Assertion raised when window_length != nfft

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Excessive assertion removed
     * Tests extended to cover the case
 - Affected modules and functionalities:
     * Spectrogram GPU kernel
     * spectrogram operator tests
 - Key points relevant for the review:
     * Check if there's a remote possibility of breaking something?
 - Validation and testing:
     * Pythone end-to-end tests
 - Documentation (including examples):
     * N/A


**JIRA TASK**: DALI-1456
