### PR TITLE
Add out-of-bounds-policy (including pad support) to Slice/Crop 

### DIFF
--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -106,10 +106,18 @@ __device__ void SliceFunc(OutputType *__restrict__ out, const InputType *__restr
   if (Dims > 1 && out_strides[Dims - 1] == in_strides[Dims - 1] && anchor[Dims - 1] == 0 &&
       channel_dim != Dims - 1) {
     const int NextDims = Dims > 1 ? Dims - 1 : 1;
-    SliceFunc<NextDims, OutputType, InputType, false>(out, in, out_strides, in_strides, anchor,
-                                                      in_shape, fill_values, channel_dim, offset,
-                                                      block_end);
+    SliceFunc<NextDims, OutputType, InputType, false>(
+        out, in, out_strides, in_strides, anchor, in_shape, fill_values, channel_dim, offset,
+        block_end);
     return;
+  }
+
+  constexpr int LastDim = Dims - 1;
+  int64_t inner_in_anchor = anchor[LastDim];
+  int64_t inner_in_extent = in_shape[LastDim];
+  if (!AllDims) {  // if we fused dimensions, adjust inner dimension's anchor and extent
+    inner_in_anchor = anchor[LastDim] * in_strides[LastDim];
+    inner_in_extent = Dims > 1 ? in_strides[LastDim - 1] : in_shape[LastDim] * in_strides[LastDim];
   }
 
   for (; offset < block_end; offset += blockDim.x) {
@@ -124,7 +132,7 @@ __device__ void SliceFunc(OutputType *__restrict__ out, const InputType *__restr
     uint64_t in_idx = 0;
 
     #pragma unroll
-    for (int d = 0; d < Dims - AllDims; d++) {
+    for (int d = 0; d < Dims - 1; d++) {
       i_d = div_mod(idx, idx, out_strides[d]);
       if (d == channel_dim)
         i_c = i_d;
@@ -133,16 +141,15 @@ __device__ void SliceFunc(OutputType *__restrict__ out, const InputType *__restr
         in_idx += i_d * in_strides[d];
     }
 
-    // Here we handle the last dimension (if we didn't in the main loop)
+    constexpr int d = LastDim;
+    i_d = idx;  // We know that out_strides[d] is 1
     if (AllDims) {
-      constexpr int d = Dims - 1;
-      i_d = idx;  // We know that out_strides[d] is 1
       if (d == channel_dim)
         i_c = i_d;
-      out_of_bounds |= is_out_of_bounds(anchor[d] + i_d, in_shape[d]);
-      if (!out_of_bounds)
-        in_idx += i_d;  // We know that in_strides[d] is 1
     }
+    out_of_bounds |= is_out_of_bounds(inner_in_anchor + i_d, inner_in_extent);
+    if (!out_of_bounds)
+      in_idx += i_d;  // We know that in_strides[d] is 1
 
     // Fill values are reused a lot, so let's make sure they are cached (by using __ldg())
     out[out_idx] = out_of_bounds ? __ldg(&fill_values[i_c]) : clamp<OutputType>(in[in_idx]);

--- a/dali/kernels/slice/slice_kernel_test.h
+++ b/dali/kernels/slice/slice_kernel_test.h
@@ -243,6 +243,22 @@ struct ArgsGen_CompletelyOutOfBounds{
 };
 
 template <typename OutputType, int Dims = 3>
+struct ArgsGen_SingleValuePad {
+  SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceArgs<OutputType, 3> args;
+    args.anchor[0] = -input_shape[0] / 2;
+    args.anchor[1] = -input_shape[1] / 2;
+    args.anchor[2] = 0;
+    args.shape[0] = 2 * input_shape[0];
+    args.shape[1] = 2 * input_shape[1];
+    args.shape[2] = input_shape[2];
+    args.fill_values = {128};
+    args.channel_dim = -1;
+    return args;
+  }
+};
+
+template <typename OutputType, int Dims = 3>
 struct ArgsGen_MultiChannelPad {
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, 3> args;
@@ -332,6 +348,7 @@ using SLICE_TEST_TYPES = ::testing::Types<
     SliceTestArgs<int, int, 1, 1, 22, ArgsGen_RightSideOutOfBounds<int, 1>>,
     SliceTestArgs<int, int, 2, 1, 22, ArgsGen_RightSideOutOfBounds<int, 2>>,
     SliceTestArgs<int, int, 2, 1, 22, ArgsGen_CompletelyOutOfBounds<int, 2>>,
+    SliceTestArgs<int, int, 3, 1, 20, ArgsGen_SingleValuePad<int, 3>, 20, 20, 3>,
     SliceTestArgs<int, int, 3, 1, 20, ArgsGen_MultiChannelPad<int, 3>, 20, 20, 3>,
     SliceTestArgs<int, int, 3, 1, 20, ArgsGen_MultiChannelPad_ChFirst<int, 3>, 3, 20, 20>,
     SliceTestArgs<int, int, 3, 1, 20, ArgsGen_PadAlsoChDim<int, 3>, 20, 20, 3>,

--- a/dali/operators/generic/slice/out_of_bounds_attr.cc
+++ b/dali/operators/generic/slice/out_of_bounds_attr.cc
@@ -1,0 +1,35 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include "dali/pipeline/operator/common.h"
+#include "dali/pipeline/operator/operator.h"
+
+namespace dali {
+
+DALI_SCHEMA(OutOfBoundsAttr)
+    .DocStr(R"code(Out-of-bounds slicing attributes placeholder)code")
+    .AddOptionalArg("out_of_bounds_policy",
+        R"code(Determines the policy when slicing out of bounds of the input.
+Supported values are:
+- \"error\" (default) : Attempting to slice outside of the bounds of the image will produce an error.
+- \"pad\": The input will be padded as needed with zeros or any other value specified with ``fill_values`` argument.
+- \"trim_to_shape\": The slice window will be cut to the bounds of the input.
+a))code", "error")
+    .AddOptionalArg("fill_values",
+        R"code(Determines padding values, only relevant if ``out_of_bounds_policy`` is set to \"pad\".
+If a scalar is provided, it will be used for all the channels. If multiple values are given, there should be as many values as
+channels (extent of dimension 'C' in the layout) in the output slice.)code", std::vector<float>{0.f});
+
+}  // namespace dali

--- a/dali/operators/generic/slice/out_of_bounds_attr.cc
+++ b/dali/operators/generic/slice/out_of_bounds_attr.cc
@@ -23,12 +23,12 @@ DALI_SCHEMA(OutOfBoundsAttr)
     .AddOptionalArg("out_of_bounds_policy",
         R"code(Determines the policy when slicing out of bounds of the input.
 Supported values are:
-- \"error\" (default) : Attempting to slice outside of the bounds of the image will produce an error.
-- \"pad\": The input will be padded as needed with zeros or any other value specified with ``fill_values`` argument.
-- \"trim_to_shape\": The slice window will be cut to the bounds of the input.
-a))code", "error")
+
+- "error" (default) : Attempting to slice outside of the bounds of the image will produce an error.
+- "pad": The input will be padded as needed with zeros or any other value specified with ``fill_values`` argument.
+- "trim_to_shape": The slice window will be cut to the bounds of the input.))code", "error")
     .AddOptionalArg("fill_values",
-        R"code(Determines padding values, only relevant if ``out_of_bounds_policy`` is set to \"pad\".
+        R"code(Determines padding values, only relevant if ``out_of_bounds_policy`` is set to "pad".
 If a scalar is provided, it will be used for all the channels. If multiple values are given, there should be as many values as
 channels (extent of dimension 'C' in the layout) in the output slice.)code", std::vector<float>{0.f});
 

--- a/dali/operators/generic/slice/out_of_bounds_policy.h
+++ b/dali/operators/generic/slice/out_of_bounds_policy.h
@@ -61,8 +61,8 @@ inline OutOfBoundsPolicy GetOutOfBoundsPolicy(const OpSpec &spec) {
 }
 
 template <int Dims>
-void ProcessSliceArgs(OutOfBoundsPolicy policy, const TensorShape<Dims> &input_shape,
-                      TensorShape<Dims> &slice_anchor, TensorShape<Dims> &slice_shape) {
+void ApplySliceBoundsPolicy(OutOfBoundsPolicy policy, const TensorShape<Dims> &input_shape,
+                            TensorShape<Dims> &slice_anchor, TensorShape<Dims> &slice_shape) {
   DALI_ENFORCE(
       input_shape.size() == slice_anchor.size() && input_shape.size() == slice_shape.size(),
       "Slice arguments should have the same number of dimensions as the input");

--- a/dali/operators/generic/slice/out_of_bounds_policy.h
+++ b/dali/operators/generic/slice/out_of_bounds_policy.h
@@ -1,0 +1,91 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_GENERIC_SLICE_OUT_OF_BOUNDS_POLICY_H_
+#define DALI_OPERATORS_GENERIC_SLICE_OUT_OF_BOUNDS_POLICY_H_
+
+#include "dali/core/tensor_shape.h"
+#include "dali/core/tensor_shape_print.h"
+#include "dali/pipeline/operator/common.h"
+
+namespace dali {
+
+/**
+ * @brief Determines what to do if slice parameters point to outside of the input bounds
+ */
+enum class OutOfBoundsPolicy {
+  Error,        // sampling out of bounds will throw an error
+  TrimToShape,  // Slice shape will be trimmed to fit the input bounds (potentially empty output)
+  Pad,          // Slicing out of bounds will result in padding with zeroes or any other provided value(s)
+};
+
+inline OutOfBoundsPolicy GetOutOfBoundsPolicy(const OpSpec &spec) {
+  bool has_out_of_bounds_policy = spec.HasArgument("out_of_bounds_policy");
+  OutOfBoundsPolicy policy = OutOfBoundsPolicy::Error;
+  if (has_out_of_bounds_policy) {
+    auto policy_str = spec.GetArgument<std::string>("out_of_bounds_policy");
+    if (policy_str == "pad") {
+      policy = OutOfBoundsPolicy::Pad;
+    } else if (policy_str == "trim_to_shape") {
+      policy = OutOfBoundsPolicy::TrimToShape;
+    } else if (policy_str == "error") {
+      policy = OutOfBoundsPolicy::Error;
+    } else {
+      DALI_FAIL(
+          make_string("Not supported out_of_bounds_policy: ", policy_str,
+                      ". Supported values are \"pad\", \"trim_to_shape\", \"error\" (default)"));
+    }
+  }
+  return policy;
+}
+
+template <int Dims>
+void ProcessSliceArgs(OutOfBoundsPolicy policy, const TensorShape<Dims> &input_shape, 
+                      TensorShape<Dims> &slice_anchor, TensorShape<Dims> &slice_shape) {
+  DALI_ENFORCE(
+      input_shape.size() == slice_anchor.size() && input_shape.size() == slice_shape.size(),
+      "Slice arguments should have the same number of dimensions as the input");
+  switch (policy) {
+    case OutOfBoundsPolicy::Pad:
+      // nothing to do
+      break;
+
+    case OutOfBoundsPolicy::TrimToShape:
+      for (int d = 0; d < input_shape.size(); d++) {
+        if (slice_anchor[d] < 0)
+          slice_anchor[d] = 0;
+        if (slice_anchor[d] + slice_shape[d] >= input_shape[d])
+          slice_shape[d] = std::max(0l, input_shape[d] - slice_anchor[d]); 
+      }
+      break;
+
+    case OutOfBoundsPolicy::Error:
+    default:
+      for (int d = 0; d < input_shape.size(); d++) {
+        auto slice_end = slice_anchor[d] + slice_shape[d];
+        if (slice_anchor[d] < 0 || slice_anchor[d] > input_shape[d] || slice_end < 0 ||
+            slice_end > input_shape[d]) {
+          DALI_FAIL(make_string(
+              "Slice can't be place out of bounds with current policy. Got: input_shape={",
+              input_shape, "}, slice_anchor={", slice_anchor, "}, slice_shape={", slice_shape, "}"));
+        }
+      }
+
+    break;
+  }
+}
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_GENERIC_SLICE_OUT_OF_BOUNDS_POLICY_H_

--- a/dali/operators/generic/slice/out_of_bounds_policy.h
+++ b/dali/operators/generic/slice/out_of_bounds_policy.h
@@ -15,6 +15,7 @@
 #ifndef DALI_OPERATORS_GENERIC_SLICE_OUT_OF_BOUNDS_POLICY_H_
 #define DALI_OPERATORS_GENERIC_SLICE_OUT_OF_BOUNDS_POLICY_H_
 
+#include <string>
 #include "dali/core/tensor_shape.h"
 #include "dali/core/tensor_shape_print.h"
 #include "dali/pipeline/operator/common.h"
@@ -27,7 +28,7 @@ namespace dali {
 enum class OutOfBoundsPolicy {
   Error,        // sampling out of bounds will throw an error
   TrimToShape,  // Slice shape will be trimmed to fit the input bounds (potentially empty output)
-  Pad,          // Slicing out of bounds will result in padding with zeroes or any other provided value(s)
+  Pad,  // Slicing out of bounds will result in padding with zeroes or any other provided value(s)
 };
 
 inline OutOfBoundsPolicy GetOutOfBoundsPolicy(const OpSpec &spec) {
@@ -51,7 +52,7 @@ inline OutOfBoundsPolicy GetOutOfBoundsPolicy(const OpSpec &spec) {
 }
 
 template <int Dims>
-void ProcessSliceArgs(OutOfBoundsPolicy policy, const TensorShape<Dims> &input_shape, 
+void ProcessSliceArgs(OutOfBoundsPolicy policy, const TensorShape<Dims> &input_shape,
                       TensorShape<Dims> &slice_anchor, TensorShape<Dims> &slice_shape) {
   DALI_ENFORCE(
       input_shape.size() == slice_anchor.size() && input_shape.size() == slice_shape.size(),
@@ -66,7 +67,7 @@ void ProcessSliceArgs(OutOfBoundsPolicy policy, const TensorShape<Dims> &input_s
         if (slice_anchor[d] < 0)
           slice_anchor[d] = 0;
         if (slice_anchor[d] + slice_shape[d] >= input_shape[d])
-          slice_shape[d] = std::max(0l, input_shape[d] - slice_anchor[d]); 
+          slice_shape[d] = std::max(0l, input_shape[d] - slice_anchor[d]);
       }
       break;
 
@@ -78,7 +79,8 @@ void ProcessSliceArgs(OutOfBoundsPolicy policy, const TensorShape<Dims> &input_s
             slice_end > input_shape[d]) {
           DALI_FAIL(make_string(
               "Slice can't be place out of bounds with current policy. Got: input_shape={",
-              input_shape, "}, slice_anchor={", slice_anchor, "}, slice_shape={", slice_shape, "}"));
+              input_shape, "}, slice_anchor={", slice_anchor, "}, slice_shape={", slice_shape,
+              "}"));
         }
       }
 

--- a/dali/operators/generic/slice/out_of_bounds_policy.h
+++ b/dali/operators/generic/slice/out_of_bounds_policy.h
@@ -84,8 +84,9 @@ void ProcessSliceArgs(OutOfBoundsPolicy policy, const TensorShape<Dims> &input_s
     case OutOfBoundsPolicy::Error:
     default:
       for (int d = 0; d < input_shape.size(); d++) {
-        if (is_out_of_bounds<false>(slice_anchor[d], input_shape[d]) ||                  // start within [0, extent)
-            is_out_of_bounds<true>(slice_anchor[d] + slice_shape[d], input_shape[d])) {  // end   within [0, extent]
+        // start within [0, extent), and end within [0, extent]
+        if (is_out_of_bounds<false>(slice_anchor[d], input_shape[d]) ||
+            is_out_of_bounds<true>(slice_anchor[d] + slice_shape[d], input_shape[d])) {
           DALI_FAIL(make_string(
               "Slice can't be place out of bounds with current policy. Got: input_shape={",
               input_shape, "}, slice_anchor={", slice_anchor, "}, slice_shape={", slice_shape,

--- a/dali/operators/generic/slice/slice.cc
+++ b/dali/operators/generic/slice/slice.cc
@@ -18,21 +18,21 @@ namespace dali {
 
 DALI_SCHEMA(Slice)
     .DocStr(
-        R"code(Extract a subtensor or `slice` with a given shape and anchor.
-Inputs must be supplied as 3 separate tensors in a specific order: `data`, `anchor` and `shape`.
-Both `anchor` and `shape` coordinates must be within the interval
+        R"code(Extract a subtensor or ``slice`` with a given shape and anchor.
+Inputs must be supplied as 3 separate tensors in a specific order: ``data``, ``anchor`` and ``shape``.
+Both ``anchor`` and ``shape`` coordinates must be within the interval
 [0.0, 1.0] for normalized coordinates, or within the image shape for absolute
-coordinates. Both `anchor` and `shape` inputs will provide as many dimensions as specified
-with arguments `axis_names` or `axes`. By default `Slice` operator uses normalized
-coordinates and `WH` order for the slice arguments.)code")
+coordinates. Both ``anchor`` and ``shape`` inputs will provide as many dimensions as specified
+with arguments ``axis_names`` or ``axes``. By default ``Slice`` operator uses normalized
+coordinates and ``WH`` order for the slice arguments.)code")
     .NumInput(3)
     .NumOutput(1)
     .InputDox(0, "data", "TensorList", "Batch containing input data")
-    .InputDox(1, "anchor", "1D TensorList of floats",
+    .InputDox(1, "anchor", "1D TensorList of float",
                  R"code(Input containing either normalized or absolute coordinates
 (depending on the value of `normalized_anchor`) for the starting point of the
 slice (x0, x1, x2, ...).)code")
-    .InputDox(2, "shape", "1D TensorList of floats",
+    .InputDox(2, "shape", "1D TensorList of float",
                  R"code(Input containing either normalized or absolute coordinates
 (depending on the value of `normalized_shape`) for the dimensions of the slice
 (s0, s1, s2, ...).)code")
@@ -41,12 +41,24 @@ slice (x0, x1, x2, ...).)code")
     .AddOptionalArg("image_type",
       R"code(The color space of input and output image)code",
       DALI_RGB, false)
+    .AddOptionalArg("out_of_bounds_policy",  // TODO(janton): Move this to SliceAttr once we enable padding in ImageDecoderSlice
+        R"code(Determines the policy when slicing out of bounds of the input.
+Supported values are:
+- \"error\" (default) : Attempting to slice outside of the bounds of the image will produce an error.
+- \"pad\": The input will be padded as needed with zeros or any other value specified with ``fill_values`` argument.
+- \"trim_to_shape\": The slice window will be resized so that it stays within the bounds of the input.
+a))code", "error")
+    .AddOptionalArg("fill_values",  // TODO(janton): Move this to SliceAttr once we enable padding in ImageDecoderSlice
+        R"code(Determines padding values, only relevant if ``out_of_bounds_policy`` is set to \"pad\".
+If a scalar is provided, it will be used for all the channels. If multiple values are given, there should be as many values as
+channels (extent of dimension 'C' in the layout) in the output slice.)code", 0)
     .AddParent("SliceBase")
     .AddParent("SliceAttr");
 
 template <>
 void Slice<CPUBackend>::DataDependentSetup(SampleWorkspace &ws) {
   slice_attr_.ProcessArguments(ws);
+  fill_values_ = slice_attr_.GetFillValues();
   const auto &images = ws.Input<CPUBackend>(kImagesInId);
   auto data_idx = ws.data_idx();
   auto crop_window_generator = slice_attr_.GetCropWindowGenerator(data_idx);

--- a/dali/operators/generic/slice/slice.cc
+++ b/dali/operators/generic/slice/slice.cc
@@ -42,19 +42,9 @@ slice (x0, x1, x2, ...).)code")
     .AddOptionalArg("image_type",
       R"code(The color space of input and output image)code",
       DALI_RGB, false)
-    .AddOptionalArg("out_of_bounds_policy",
-        R"code(Determines the policy when slicing out of bounds of the input.
-Supported values are:
-- \"error\" (default) : Attempting to slice outside of the bounds of the image will produce an error.
-- \"pad\": The input will be padded as needed with zeros or any other value specified with ``fill_values`` argument.
-- \"trim_to_shape\": The slice window will be resized so that it stays within the bounds of the input.
-a))code", "error")
-    .AddOptionalArg("fill_values",
-        R"code(Determines padding values, only relevant if ``out_of_bounds_policy`` is set to \"pad\".
-If a scalar is provided, it will be used for all the channels. If multiple values are given, there should be as many values as
-channels (extent of dimension 'C' in the layout) in the output slice.)code", std::vector<float>{0.f})
     .AddParent("SliceBase")
-    .AddParent("SliceAttr");
+    .AddParent("SliceAttr")
+    .AddParent("OutOfBoundsAttr");
 
 DALI_REGISTER_OPERATOR(Slice, Slice<CPUBackend>, CPU);
 

--- a/dali/operators/generic/slice/slice.cc
+++ b/dali/operators/generic/slice/slice.cc
@@ -52,7 +52,7 @@ a))code", "error")
     .AddOptionalArg("fill_values",
         R"code(Determines padding values, only relevant if ``out_of_bounds_policy`` is set to \"pad\".
 If a scalar is provided, it will be used for all the channels. If multiple values are given, there should be as many values as
-channels (extent of dimension 'C' in the layout) in the output slice.)code", 0)
+channels (extent of dimension 'C' in the layout) in the output slice.)code", std::vector<float>{0.f})
     .AddParent("SliceBase")
     .AddParent("SliceAttr");
 

--- a/dali/operators/generic/slice/slice.cu
+++ b/dali/operators/generic/slice/slice.cu
@@ -12,28 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <vector>
 #include "dali/operators/generic/slice/slice.h"
+#include "dali/kernels/slice/slice_gpu.cuh"
 
 namespace dali {
-
-template <>
-void Slice<GPUBackend>::DataDependentSetup(DeviceWorkspace &ws) {
-  slice_attr_.ProcessArguments(ws);
-  fill_values_ = slice_attr_.GetFillValues();
-  const auto &images = ws.Input<GPUBackend>(kImagesInId);
-  for (int data_idx = 0; data_idx < batch_size_; data_idx++) {
-    const auto img_shape = images.tensor_shape(data_idx);
-    auto crop_window_generator = slice_attr_.GetCropWindowGenerator(data_idx);
-    DALI_ENFORCE(crop_window_generator);
-    auto layout = InputLayout(ws, 0);
-    if (layout.empty())
-      layout = GetDefaultLayout(img_shape.size());
-    CropWindow win = crop_window_generator(img_shape, layout);
-    slice_shapes_[data_idx] = std::vector<int64_t>(win.shape.begin(), win.shape.end());
-    slice_anchors_[data_idx] = std::vector<int64_t>(win.anchor.begin(), win.anchor.end());
-  }
-}
 
 DALI_REGISTER_OPERATOR(Slice, Slice<GPUBackend>, GPU);
 

--- a/dali/operators/generic/slice/slice.cu
+++ b/dali/operators/generic/slice/slice.cu
@@ -20,6 +20,7 @@ namespace dali {
 template <>
 void Slice<GPUBackend>::DataDependentSetup(DeviceWorkspace &ws) {
   slice_attr_.ProcessArguments(ws);
+  fill_values_ = slice_attr_.GetFillValues();
   const auto &images = ws.Input<GPUBackend>(kImagesInId);
   for (int data_idx = 0; data_idx < batch_size_; data_idx++) {
     const auto img_shape = images.tensor_shape(data_idx);

--- a/dali/operators/generic/slice/slice.h
+++ b/dali/operators/generic/slice/slice.h
@@ -34,38 +34,15 @@ class Slice : public SliceBase<Backend> {
     , slice_attr_(spec) {}
 
  protected:
-  using SliceBase<Backend>::input_type_;
-  using SliceBase<Backend>::output_type_;
-  using SliceBase<Backend>::slice_anchors_;
-  using SliceBase<Backend>::slice_shapes_;
-  using SliceBase<Backend>::fill_values_;
-
-  void RunImpl(Workspace<Backend> &ws) override {
-    SliceBase<Backend>::RunImpl(ws);
+  void DataDependentSetup(const workspace_t<Backend> &ws) override {
+    slice_attr_.ProcessArguments(ws);
   }
 
-  void SetupSharedSampleParams(Workspace<Backend> &ws) override {
-    DALI_ENFORCE(ws.NumInput() == 3,
-      "Expected 3 inputs. Received: " + std::to_string(ws.NumInput()));
-    SliceBase<Backend>::SetupSharedSampleParams(ws);
+  const CropWindowGenerator& GetCropWindowGenerator(std::size_t data_idx) const override {
+    return slice_attr_.GetCropWindowGenerator(data_idx);
   }
-
-  void DataDependentSetup(Workspace<Backend> &ws) override;
 
  private:
-  inline TensorLayout GetDefaultLayout(int ndims) {
-    switch (ndims) {
-      case 2:
-        return "HW";
-      case 3:
-        return "HWC";
-      case 4:
-        return "DHWC";
-      default:
-        return "";
-    }
-  }
-
   SliceAttr slice_attr_;
 
   static const int kImagesInId = 0;

--- a/dali/operators/generic/slice/slice.h
+++ b/dali/operators/generic/slice/slice.h
@@ -38,6 +38,7 @@ class Slice : public SliceBase<Backend> {
   using SliceBase<Backend>::output_type_;
   using SliceBase<Backend>::slice_anchors_;
   using SliceBase<Backend>::slice_shapes_;
+  using SliceBase<Backend>::fill_values_;
 
   void RunImpl(Workspace<Backend> &ws) override {
     SliceBase<Backend>::RunImpl(ws);

--- a/dali/operators/generic/slice/slice.h
+++ b/dali/operators/generic/slice/slice.h
@@ -34,7 +34,7 @@ class Slice : public SliceBase<Backend> {
     , slice_attr_(spec) {}
 
  protected:
-  void DataDependentSetup(const workspace_t<Backend> &ws) override {
+  void ProcessCroppingAttrs(const workspace_t<Backend> &ws) override {
     slice_attr_.ProcessArguments(ws);
   }
 

--- a/dali/operators/generic/slice/slice_attr.h
+++ b/dali/operators/generic/slice/slice_attr.h
@@ -72,7 +72,6 @@ class SliceAttr {
     }
   }
 
-
   void ProcessArguments(const MixedWorkspace &ws) {
     DALI_ENFORCE(ws.NumInput() == 3,
       "Expected 3 inputs. Received: " + std::to_string(ws.NumInput()));

--- a/dali/operators/generic/slice/slice_base.cc
+++ b/dali/operators/generic/slice/slice_base.cc
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <vector>
-#include <memory>
 #include "dali/operators/generic/slice/slice_base.h"
+#include <memory>
+#include <queue>
+#include <vector>
 #include "dali/kernels/slice/slice_cpu.h"
 
 namespace dali {
@@ -42,6 +43,12 @@ class SliceBaseCpu : public OpImplBase<CPUBackend> {
  private:
   std::vector<SliceArgs> args_;
   kernels::KernelManager kmgr_;
+
+  // Priority queue used to schedule larger samples first to maximize CPU utilization
+  // (avoid posting a big sample last and have all the other threads idle while it's processed)
+  using VolumeSampleIdPair = std::pair<int64_t, int>;  // volume(out_shape), sample_idx
+  using SampleQueue = std::priority_queue<VolumeSampleIdPair, std::vector<VolumeSampleIdPair>>;
+  SampleQueue sample_queue_;
 };
 
 template <typename OutputType, typename InputType, int Dims>
@@ -59,10 +66,14 @@ bool SliceBaseCpu<OutputType, InputType, Dims>::SetupImpl(std::vector<OutputDesc
   kmgr_.Resize<Kernel>(nthreads, nsamples);
   kernels::KernelContext ctx;
   auto in_view = view<const InputType, Dims>(input);
+  assert(sample_queue_.empty());
   for (int i = 0; i < nsamples; i++) {
     auto in_view = view<const InputType, Dims>(input[i]);
     auto req = kmgr_.Setup<Kernel>(i, ctx, in_view, args_[i]);
-    output_desc[0].shape.set_tensor_shape(i, req.output_shapes[0][0].shape);
+    auto out_shape = req.output_shapes[0][0].shape;
+    output_desc[0].shape.set_tensor_shape(i, out_shape);
+    // Larger samples will be scheduled first
+    sample_queue_.push({volume(out_shape), i});
   }
   return true;
 }
@@ -72,15 +83,16 @@ void SliceBaseCpu<OutputType, InputType, Dims>::RunImpl(workspace_t<CPUBackend> 
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto &output = ws.template OutputRef<CPUBackend>(0);
   int nsamples = input.size();
-
   auto& thread_pool = ws.GetThreadPool();
-  for (int i = 0; i < nsamples; i++) {
+  while(!sample_queue_.empty()) {
+    int sample_idx = sample_queue_.top().second;
+    sample_queue_.pop();
     thread_pool.DoWorkWithID(
-      [this, &input, &output, i](int thread_id) {
-        auto in_view = view<const InputType, Dims>(input[i]);
-        auto out_view = view<OutputType, Dims>(output[i]);
+      [this, &input, &output, sample_idx](int thread_id) {
+        auto in_view = view<const InputType, Dims>(input[sample_idx]);
+        auto out_view = view<OutputType, Dims>(output[sample_idx]);
         kernels::KernelContext ctx;
-        kmgr_.Run<Kernel>(thread_id, i, ctx, out_view, in_view, args_[i]);
+        kmgr_.Run<Kernel>(thread_id, sample_idx, ctx, out_view, in_view, args_[sample_idx]);
       });
   }
   thread_pool.WaitForWork();

--- a/dali/operators/generic/slice/slice_base.cc
+++ b/dali/operators/generic/slice/slice_base.cc
@@ -26,7 +26,9 @@ template <typename OutputType, typename InputType>
 void RunHelper(Tensor<CPUBackend> &output,
                const Tensor<CPUBackend> &input,
                const std::vector<int64_t> &slice_anchor,
-               const std::vector<int64_t> &slice_shape) {
+               const std::vector<int64_t> &slice_shape,
+               const std::vector<float> &fill_values,
+               int channel_dim) {
   std::size_t number_of_dims = input.shape().size();
   VALUE_SWITCH(number_of_dims, NumDims, (1, 2, 3, 4), (
     kernels::KernelContext ctx;
@@ -38,6 +40,13 @@ void RunHelper(Tensor<CPUBackend> &output,
     for (std::size_t d = 0; d < NumDims; d++) {
       anchor[d] = slice_anchor[d];
       shape[d] = slice_shape[d];
+    }
+
+    if (!fill_values.empty()) {
+      slice_args.fill_values.clear();
+      for (auto val : fill_values)
+        slice_args.fill_values.push_back(static_cast<OutputType>(val));
+      slice_args.channel_dim = channel_dim;
     }
 
     kernels::SliceCPU<OutputType, InputType, NumDims> kernel;

--- a/dali/operators/generic/slice/slice_base.cc
+++ b/dali/operators/generic/slice/slice_base.cc
@@ -84,7 +84,7 @@ void SliceBaseCpu<OutputType, InputType, Dims>::RunImpl(workspace_t<CPUBackend> 
   auto &output = ws.template OutputRef<CPUBackend>(0);
   int nsamples = input.size();
   auto& thread_pool = ws.GetThreadPool();
-  while(!sample_queue_.empty()) {
+  while (!sample_queue_.empty()) {
     int sample_idx = sample_queue_.top().second;
     sample_queue_.pop();
     thread_pool.DoWorkWithID(

--- a/dali/operators/generic/slice/slice_base.cu
+++ b/dali/operators/generic/slice/slice_base.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,92 +13,97 @@
 // limitations under the License.
 
 #include <vector>
-#include "dali/image/transform.h"
-#include "dali/kernels/slice/slice_gpu.cuh"
-#include "dali/core/static_switch.h"
+#include <memory>
 #include "dali/operators/generic/slice/slice_base.h"
-#include "dali/pipeline/data/views.h"
+#include "dali/kernels/slice/slice_gpu.cuh"
 
 namespace dali {
-namespace detail {
 
-template <typename OutputType, typename InputType>
-void RunHelper(TensorList<GPUBackend>& output,
-               const TensorList<GPUBackend>& input,
-               const std::vector<std::vector<int64_t>>& slice_anchors,
-               const std::vector<std::vector<int64_t>>& slice_shapes,
-               const std::vector<float> &fill_values,
-               int channel_dim,
-               cudaStream_t stream,
-               kernels::ScratchpadAllocator &scratch_alloc) {
-  std::size_t number_of_dims = input.tensor_shape(0).size();
-  VALUE_SWITCH(number_of_dims, NumDims, (1, 2, 3, 4), (
-    kernels::SliceGPU<OutputType, InputType, NumDims> kernel;
+template <typename OutputType, typename InputType, int Dims>
+class SliceBaseGpu : public OpImplBase<GPUBackend> {
+ public:
+  using Kernel = kernels::SliceGPU<OutputType, InputType, Dims>;
+  using Args = kernels::SliceArgs<OutputType, Dims>;
 
-    kernels::KernelContext ctx;
-    ctx.gpu.stream = stream;
-    auto in_view = view<const InputType, NumDims>(input);
+  explicit SliceBaseGpu(SliceBase<GPUBackend> &parent)
+    : parent_(parent) {}
 
-    std::vector<kernels::SliceArgs<OutputType, NumDims>> slice_args;
-    slice_args.reserve(slice_anchors.size());
-    for (std::size_t i = 0; i < slice_anchors.size(); i++) {
-      std::array<int64_t, NumDims> anchor, shape;
-      const auto& slice_anchor = slice_anchors[i];
-      const auto& slice_shape = slice_shapes[i];
-      for (std::size_t d = 0; d < NumDims; d++) {
-        anchor[d] = slice_anchor[d];
-        shape[d] = slice_shape[d];
-      }
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<GPUBackend> &ws) override;
+  void RunImpl(workspace_t<GPUBackend> &ws) override;
 
-      if (!fill_values.empty()) {
-        slice_args.fill_values.clear();
-        for (auto val : fill_values)
-          slice_args.fill_values.push_back(static_cast<OutputType>(val));
-        slice_args.channel_dim = channel_dim;
-      }
+ private:
+  SliceBase<GPUBackend> &parent_;
+  std::vector<Args> args_;
+  kernels::KernelManager kmgr_;
+};
 
-      slice_args.push_back({anchor, shape});
-    }
+template <typename OutputType, typename InputType, int Dims>
+bool SliceBaseGpu<OutputType, InputType, Dims>::SetupImpl(std::vector<OutputDesc> &output_desc,
+                                                          const workspace_t<GPUBackend> &ws) {
+  parent_.FillArgs(args_, ws);
+  const auto &input = ws.template InputRef<GPUBackend>(0);
+  auto in_shape = input.shape();
+  int nsamples = in_shape.num_samples();
 
-    kernels::KernelRequirements req = kernel.Setup(ctx, in_view, slice_args);
+  output_desc.resize(1);
+  output_desc[0].type = TypeInfo::Create<OutputType>();
+  output_desc[0].shape.resize(nsamples, Dims);
 
-    output.set_type(TypeInfo::Create<OutputType>());
-    output.Resize(req.output_shapes[0]);
-
-    scratch_alloc.Reserve(req.scratch_sizes);
-    auto scratchpad = scratch_alloc.GetScratchpad();
-    ctx.scratchpad = &scratchpad;
-
-    auto out_view = view<OutputType, NumDims>(output);
-    kernel.Run(ctx, out_view, in_view, slice_args);
-  ),  // NOLINT
-  (
-    DALI_FAIL("Not supported number of dimensions: " + std::to_string(number_of_dims));
-  ));  // NOLINT
+  kmgr_.Resize<Kernel>(1, 1);
+  auto in_view = view<const InputType, Dims>(input);
+  kernels::KernelContext ctx;
+  auto req = kmgr_.Setup<Kernel>(0, ctx, in_view, args_);
+  output_desc[0].shape = req.output_shapes[0];
+  return true;
 }
 
-}  // namespace detail
+template <typename OutputType, typename InputType, int Dims>
+void SliceBaseGpu<OutputType, InputType, Dims>::RunImpl(workspace_t<GPUBackend> &ws) {
+  const auto &input = ws.template InputRef<GPUBackend>(0);
+  auto &output = ws.template OutputRef<GPUBackend>(0);
 
+  auto in_view = view<const InputType, Dims>(input);
+  auto out_view = view<OutputType, Dims>(output);
+  kernels::KernelContext ctx;
+  ctx.gpu.stream = ws.stream();
+  kmgr_.Run<Kernel>(0, 0, ctx, out_view, in_view, args_);
+  output.SetLayout(input.GetLayout());
+}
 
 template <>
-void SliceBase<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
-  this->DataDependentSetup(ws);
-  const auto &input = ws.Input<GPUBackend>(0);
-  auto &output = ws.Output<GPUBackend>(0);
+bool SliceBase<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
+                                      const workspace_t<GPUBackend> &ws) {
+  const auto &input = ws.template InputRef<GPUBackend>(0);
+  auto input_type = input.type().id();
+  auto ndim = input.shape().sample_dim();
 
-  TYPE_SWITCH(input_type_, type2id, InputType, SLICE_TYPES, (
-    if (input_type_ == output_type_) {
-      detail::RunHelper<InputType, InputType>(
-        output, input, slice_anchors_, slice_shapes_, fill_values_, channel_dim, ws.stream(), scratch_alloc_);
-    } else {
-      TYPE_SWITCH(output_type_, type2id, OutputType, (float, float16, uint8_t), (
-        detail::RunHelper<OutputType, InputType>(
-          output, input, slice_anchors_, slice_shapes_, fill_values_, channel_dim, ws.stream(), scratch_alloc_);
-      ), DALI_FAIL(make_string("Not supported output type:", output_type_));); // NOLINT
-    }
-  ), DALI_FAIL(make_string("Not supported input type:", input_type_));); // NOLINT
+  if (!impl_ || input_type_ != input_type || ndim != ndim_) {
+    input_type_ = input_type;
+    ndim_ = ndim;
+    auto output_type = output_type_;
+    if (output_type_ == DALI_NO_TYPE)
+      output_type = input_type_;
+    VALUE_SWITCH(ndim_, Dims, SLICE_DIMS, (
+      TYPE_SWITCH(input_type_, type2id, InputType, SLICE_TYPES, (
+        if (input_type_ == output_type) {
+          using Impl = SliceBaseGpu<InputType, InputType, Dims>;
+          impl_ = std::make_unique<Impl>(*this);
+        } else {
+          TYPE_SWITCH(output_type, type2id, OutputType, (float, float16, uint8_t), (
+            using Impl = SliceBaseGpu<OutputType, InputType, Dims>;
+            impl_ = std::make_unique<Impl>(*this);
+          ), DALI_FAIL(make_string("Not supported output type:", output_type_));); // NOLINT
+        }
+      ), DALI_FAIL(make_string("Not supported input type: ", input_type_)););  // NOLINT
+    ), DALI_FAIL(make_string("Not supported number of dimensions: ", ndim)););  // NOLINT
+  }
+  return impl_->SetupImpl(output_desc, ws);
+}
 
-  output.SetLayout(InputLayout(ws, 0));
+template <>
+void SliceBase<GPUBackend>::RunImpl(workspace_t<GPUBackend> &ws) {
+  assert(impl_ != nullptr);
+  impl_->RunImpl(ws);
 }
 
 }  // namespace dali

--- a/dali/operators/generic/slice/slice_base.cu
+++ b/dali/operators/generic/slice/slice_base.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/operators/generic/slice/slice_base.h
+++ b/dali/operators/generic/slice/slice_base.h
@@ -59,7 +59,7 @@ class SliceBase : public Operator<Backend> {
     int nsamples = in_shape.num_samples();
     auto in_layout = input.GetLayout();
     if (in_layout.empty())
-      in_layout = GetDefaultLayout(in_shape.size());
+      in_layout = GetDefaultLayout(in_shape.sample_dim());
     auto channel_dim = in_layout.find('C');
 
     slice_args.clear();

--- a/dali/operators/generic/slice/slice_base.h
+++ b/dali/operators/generic/slice/slice_base.h
@@ -64,7 +64,6 @@ class SliceBase : public Operator<Backend> {
 
     slice_args.clear();
     slice_args.resize(nsamples);
-
     for (int i = 0; i < nsamples; i++) {
       auto crop_win_gen = this->GetCropWindowGenerator(i);
       assert(crop_win_gen);
@@ -75,18 +74,21 @@ class SliceBase : public Operator<Backend> {
       auto &args = slice_args[i];
       args.anchor = win.anchor.to_static<Dims>();
       args.shape = win.shape.to_static<Dims>();
-
+      args.channel_dim = -1;
       if (!fill_values_.empty()) {
         args.fill_values.clear();
         for (auto val : fill_values_)
           args.fill_values.push_back(static_cast<OutputType>(val));
-        DALI_ENFORCE((channel_dim >= 0 && channel_dim < Dims) || fill_values_.size() == 1,
-                     "Multi-channel fill_values was provided but channel dimension could not be "
-                     "found in layout");
-        args.channel_dim = channel_dim;
+        if (fill_values_.size() > 1) {
+          DALI_ENFORCE((channel_dim >= 0 && channel_dim < Dims),
+                        "Multi-channel fill_values was provided but channel dimension could not be "
+                        "found in layout");
+          args.channel_dim = channel_dim;
+        }
       }
     }
   }
+
 
  protected:
    /**

--- a/dali/operators/generic/slice/slice_base.h
+++ b/dali/operators/generic/slice/slice_base.h
@@ -69,7 +69,7 @@ class SliceBase : public Operator<Backend> {
       assert(crop_win_gen);
 
       CropWindow win = crop_win_gen(in_shape[i], in_layout);
-      ProcessSliceArgs(out_of_bounds_policy_, in_shape[i], win.anchor, win.shape);
+      ApplySliceBoundsPolicy(out_of_bounds_policy_, in_shape[i], win.anchor, win.shape);
 
       auto &args = slice_args[i];
       args.anchor = win.anchor.to_static<Dims>();

--- a/dali/operators/generic/slice/slice_base.h
+++ b/dali/operators/generic/slice/slice_base.h
@@ -52,11 +52,14 @@ class SliceBase : public Operator<Backend> {
     input_type_ = input.type().id();
     if (output_type_ == DALI_NO_TYPE)
       output_type_ = input_type_;
+    channel_dim_ = input.GetLayout().find('C');
   }
 
   virtual void DataDependentSetup(Workspace<Backend> &ws) = 0;
 
   std::vector<std::vector<int64_t>> slice_anchors_, slice_shapes_;
+  std::vector<float> fill_values_;
+  int channel_dim_ = -1;
   DALIDataType input_type_ = DALI_NO_TYPE;
   DALIDataType output_type_ = DALI_NO_TYPE;
 

--- a/dali/operators/generic/slice/slice_base.h
+++ b/dali/operators/generic/slice/slice_base.h
@@ -15,18 +15,25 @@
 #ifndef DALI_OPERATORS_GENERIC_SLICE_SLICE_BASE_H_
 #define DALI_OPERATORS_GENERIC_SLICE_SLICE_BASE_H_
 
+#include <memory>
 #include <tuple>
 #include <utility>
 #include <vector>
+#include "dali/core/any.h"
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
-#include "dali/kernels/scratch.h"
-#include "dali/operators/image/crop/crop_attr.h"
+#include "dali/core/static_switch.h"
+#include "dali/kernels/kernel_manager.h"
+#include "dali/kernels/slice/slice_kernel_utils.h"
+#include "dali/operators/generic/slice/out_of_bounds_policy.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/data/views.h"
+#include "dali/pipeline/util/operator_impl_utils.h"
+#include "dali/util/crop_window.h"
 
 #define SLICE_TYPES (uint8_t, int16_t, uint16_t, int32_t, float, float16)
-#define CMN_NDIMS (3, 4, 5)
+#define SLICE_DIMS (1, 2, 3, 4)
 
 namespace dali {
 
@@ -34,43 +41,90 @@ template <typename Backend>
 class SliceBase : public Operator<Backend> {
  public:
   explicit inline SliceBase(const OpSpec &spec)
-    : Operator<Backend>(spec)
-    , slice_anchors_(batch_size_)
-    , slice_shapes_(batch_size_)
-    , output_type_(spec.GetArgument<DALIDataType>("output_dtype")) {
+      : Operator<Backend>(spec),
+        output_type_(spec.GetArgument<DALIDataType>("output_dtype")),
+        out_of_bounds_policy_(GetOutOfBoundsPolicy(spec)) {
+    if (out_of_bounds_policy_ == OutOfBoundsPolicy::Pad) {
+      fill_values_ = spec.GetRepeatedArgument<float>("fill_values");
+    }
+  }
+
+  template <typename OutputType, int Dims>
+  void FillArgs(std::vector<kernels::SliceArgs<OutputType, Dims>>& slice_args,
+                const workspace_t<Backend> &ws) {
+    this->DataDependentSetup(ws);
+    const auto &input = ws.template InputRef<Backend>(0);
+    auto in_shape = input.shape();
+    int ndim = in_shape.sample_dim();
+    int nsamples = in_shape.num_samples();
+    auto in_layout = input.GetLayout();
+    if (in_layout.empty())
+      in_layout = GetDefaultLayout(in_shape.size());
+    auto channel_dim = in_layout.find('C');
+
+    slice_args.clear();
+    slice_args.resize(nsamples);
+
+    for (int i = 0; i < nsamples; i++) {
+      auto crop_win_gen = this->GetCropWindowGenerator(i);
+      assert(crop_win_gen);
+
+      CropWindow win = crop_win_gen(in_shape[i], in_layout);
+      ProcessSliceArgs(out_of_bounds_policy_, in_shape[i], win.anchor, win.shape);
+
+      auto &args = slice_args[i];
+      args.anchor = win.anchor.to_static<Dims>();
+      args.shape = win.shape.to_static<Dims>();
+
+      if (!fill_values_.empty()) {
+        args.fill_values.clear();
+        for (auto val : fill_values_)
+          args.fill_values.push_back(static_cast<OutputType>(val));
+        DALI_ENFORCE((channel_dim >= 0 && channel_dim < Dims) || fill_values_.size() == 1,
+                     "Multi-channel fill_values was provided but channel dimension could not be "
+                     "found in layout");
+        args.channel_dim = channel_dim;
+      }
+    }
   }
 
  protected:
-  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
-    return false;
+   /**
+   * @brief Implementation specific (Crop, Slice, ...)
+   */
+  virtual void DataDependentSetup(const workspace_t<Backend> &ws) = 0;
+  virtual const CropWindowGenerator& GetCropWindowGenerator(std::size_t data_idx) const = 0;
+
+  bool CanInferOutputs() const override {
+    return true;
   }
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override;
+  void RunImpl(workspace_t<Backend> &ws) override;
 
-  void RunImpl(Workspace<Backend> &ws) override;
-
-  void SetupSharedSampleParams(Workspace<Backend> &ws) override {
-    const auto &input = ws.template Input<Backend>(0);
-    input_type_ = input.type().id();
-    if (output_type_ == DALI_NO_TYPE)
-      output_type_ = input_type_;
-    channel_dim_ = input.GetLayout().find('C');
-  }
-
-  virtual void DataDependentSetup(Workspace<Backend> &ws) = 0;
-
-  std::vector<std::vector<int64_t>> slice_anchors_, slice_shapes_;
   std::vector<float> fill_values_;
-  int channel_dim_ = -1;
   DALIDataType input_type_ = DALI_NO_TYPE;
   DALIDataType output_type_ = DALI_NO_TYPE;
-
-  // In current implementation scratchpad memory is only used in the GPU kernel
-  // In case of using scratchpad in the CPU kernel a scratchpad allocator per thread
-  // should be instantiated
-  std::conditional_t<std::is_same<Backend, GPUBackend>::value,
-    kernels::ScratchpadAllocator, std::vector<kernels::ScratchpadAllocator>> scratch_alloc_;
+  int ndim_ = -1;
+  OutOfBoundsPolicy out_of_bounds_policy_ = OutOfBoundsPolicy::Error;
 
   USE_OPERATOR_MEMBERS();
   using Operator<Backend>::RunImpl;
+
+ private:
+  inline TensorLayout GetDefaultLayout(int ndims) {
+    switch (ndims) {
+      case 2:
+        return "HW";
+      case 3:
+        return "HWC";
+      case 4:
+        return "DHWC";
+      default:
+        return "";
+    }
+  }
+
+  std::unique_ptr<OpImplBase<Backend>> impl_;
 };
 
 }  // namespace dali

--- a/dali/operators/image/crop/crop.cc
+++ b/dali/operators/image/crop/crop.cc
@@ -42,7 +42,7 @@ a))code", "error")
     .AddOptionalArg("fill_values",
         R"code(Determines padding values, only relevant if ``out_of_bounds_policy`` is set to \"pad\".
 If a scalar is provided, it will be used for all the channels. If multiple values are given, there should be as many values as
-channels (extent of dimension 'C' in the layout) in the output slice.)code", 0)
+channels (extent of dimension 'C' in the layout) in the output slice.)code", std::vector<float>{0.f})
     .AddParent("CropAttr")
     .AddParent("SliceBase");
 

--- a/dali/operators/image/crop/crop.cc
+++ b/dali/operators/image/crop/crop.cc
@@ -32,26 +32,19 @@ DALI_SCHEMA(Crop)
         "image_type",
         R"code(The color space of input and output image)code",
         DALI_RGB, false)
+    .AddOptionalArg("out_of_bounds_policy",
+        R"code(Determines the policy when slicing out of bounds of the input.
+Supported values are:
+- \"error\" (default) : Attempting to slice outside of the bounds of the image will produce an error.
+- \"pad\": The input will be padded as needed with zeros or any other value specified with ``fill_values`` argument.
+- \"trim_to_shape\": The slice window will be resized so that it stays within the bounds of the input.
+a))code", "error")
+    .AddOptionalArg("fill_values",
+        R"code(Determines padding values, only relevant if ``out_of_bounds_policy`` is set to \"pad\".
+If a scalar is provided, it will be used for all the channels. If multiple values are given, there should be as many values as
+channels (extent of dimension 'C' in the layout) in the output slice.)code", 0)
     .AddParent("CropAttr")
     .AddParent("SliceBase");
-
-template <>
-void Crop<CPUBackend>::DataDependentSetup(SampleWorkspace &ws) {
-  const auto &input = ws.Input<CPUBackend>(0);
-
-  const TensorLayout in_layout = InputLayout(ws, 0);
-  DALI_ENFORCE(in_layout.ndim() == input.shape().sample_dim());
-  DALI_ENFORCE(ImageLayoutInfo::HasChannel(in_layout) &&
-    (ImageLayoutInfo::IsImage(in_layout) || VideoLayoutInfo::IsVideo(in_layout)),
-    "Unexpected data layout");
-  TensorLayout out_layout = in_layout;
-
-  auto data_idx = ws.data_idx();
-  SetupSample(data_idx, in_layout, input.shape());
-
-  auto &output = ws.Output<CPUBackend>(0);
-  output.SetLayout(out_layout);
-}
 
 // Register operator
 DALI_REGISTER_OPERATOR(Crop, Crop<CPUBackend>, CPU);

--- a/dali/operators/image/crop/crop.cc
+++ b/dali/operators/image/crop/crop.cc
@@ -32,18 +32,8 @@ DALI_SCHEMA(Crop)
         "image_type",
         R"code(The color space of input and output image)code",
         DALI_RGB, false)
-    .AddOptionalArg("out_of_bounds_policy",
-        R"code(Determines the policy when slicing out of bounds of the input.
-Supported values are:
-- \"error\" (default) : Attempting to slice outside of the bounds of the image will produce an error.
-- \"pad\": The input will be padded as needed with zeros or any other value specified with ``fill_values`` argument.
-- \"trim_to_shape\": The slice window will be resized so that it stays within the bounds of the input.
-a))code", "error")
-    .AddOptionalArg("fill_values",
-        R"code(Determines padding values, only relevant if ``out_of_bounds_policy`` is set to \"pad\".
-If a scalar is provided, it will be used for all the channels. If multiple values are given, there should be as many values as
-channels (extent of dimension 'C' in the layout) in the output slice.)code", std::vector<float>{0.f})
     .AddParent("CropAttr")
+    .AddParent("OutOfBoundsAttr")
     .AddParent("SliceBase");
 
 // Register operator

--- a/dali/operators/image/crop/crop.cu
+++ b/dali/operators/image/crop/crop.cu
@@ -21,24 +21,6 @@
 
 namespace dali {
 
-template <>
-void Crop<GPUBackend>::DataDependentSetup(DeviceWorkspace &ws) {
-  const auto &input = ws.Input<GPUBackend>(0);
-
-  const TensorLayout in_layout = input.GetLayout();
-  DALI_ENFORCE(in_layout.ndim() == input.shape().sample_dim());
-  DALI_ENFORCE(ImageLayoutInfo::HasChannel(in_layout) &&
-    (ImageLayoutInfo::IsImage(in_layout) || VideoLayoutInfo::IsVideo(in_layout)),
-    "Unexpected data layout");
-  TensorLayout out_layout = in_layout;
-
-  for (int i = 0; i < batch_size_; ++i) {
-    SetupSample(i, in_layout, input.tensor_shape(i));
-  }
-  auto &output = ws.Output<GPUBackend>(0);
-  output.SetLayout(out_layout);
-}
-
 // Register operator
 DALI_REGISTER_OPERATOR(Crop, Crop<GPUBackend>, GPU);
 

--- a/dali/operators/image/crop/crop.h
+++ b/dali/operators/image/crop/crop.h
@@ -37,7 +37,7 @@ class Crop : public SliceBase<Backend> {
     crop_attr_(spec) {}
 
  protected:
-  void DataDependentSetup(const workspace_t<Backend> &ws) override {
+  void ProcessCroppingAttrs(const workspace_t<Backend> &ws) override {
     const auto &input = ws.template InputRef<Backend>(0);
     const TensorLayout in_layout = input.GetLayout();
     DALI_ENFORCE(in_layout.ndim() == input.shape().sample_dim());

--- a/dali/operators/image/crop/crop_attr.h
+++ b/dali/operators/image/crop/crop_attr.h
@@ -106,6 +106,7 @@ class CropAttr {
         DALI_ENFORCE(input_shape.size() == shape_layout.size());
         CropWindow crop_window;
         auto crop_shape = input_shape;
+
         auto ndim = input_shape.size();
         int d_dim = shape_layout.find('D');
         int f_dim = shape_layout.find('F');
@@ -143,15 +144,13 @@ class CropAttr {
 
         crop_window.SetAnchor(CalculateAnchor(make_span(anchor_norm), crop_shape, input_shape));
         crop_window.SetShape(crop_shape);
-        // TODO(janton): allow padding
-        DALI_ENFORCE(crop_window.IsInRange(input_shape));
         return crop_window;
     };
   }
 
   TensorShape<> CalculateAnchor(const span<float>& anchor_norm,
-                                         const TensorShape<>& crop_shape,
-                                         const TensorShape<>& input_shape) {
+                                const TensorShape<>& crop_shape,
+                                const TensorShape<>& input_shape) {
     DALI_ENFORCE(anchor_norm.size() == crop_shape.size()
               && anchor_norm.size() == input_shape.size());
 
@@ -161,9 +160,6 @@ class CropAttr {
       DALI_ENFORCE(anchor_norm[dim] >= 0.0f && anchor_norm[dim] <= 1.0f,
         "Anchor for dimension " + std::to_string(dim) + " (" + std::to_string(anchor_norm[dim]) +
         ") is out of range [0.0, 1.0]");
-      DALI_ENFORCE(crop_shape[dim] > 0 && crop_shape[dim] <= input_shape[dim],
-        "Crop shape for dimension " + std::to_string(dim) + " (" + std::to_string(crop_shape[dim]) +
-        ") is out of range [0, " + std::to_string(input_shape[dim]) + "]");
       anchor[dim] = std::roundf(anchor_norm[dim] * (input_shape[dim] - crop_shape[dim]));
     }
 

--- a/dali/operators/image/crop/crop_attr.h
+++ b/dali/operators/image/crop/crop_attr.h
@@ -32,7 +32,7 @@ namespace dali {
  * Responsible for accessing image type, starting points and size of crop area.
  */
 class CropAttr {
- protected:
+ public:
   static constexpr int kNoCrop = -1;
   explicit inline CropAttr(const OpSpec &spec)
     : spec__(spec)
@@ -103,35 +103,47 @@ class CropAttr {
     crop_window_generators_[data_idx] =
       [this, data_idx](const TensorShape<>& input_shape,
                        const TensorLayout& shape_layout) {
-        DALI_ENFORCE(shape_layout == "HW" || shape_layout == "DHW",
-          make_string("Unexpected input shape layout: ", shape_layout,
-            " (expected HW or DHW)"));
+        DALI_ENFORCE(input_shape.size() == shape_layout.size());
         CropWindow crop_window;
-        if (input_shape.size() == 3) {
-          auto crop_d = has_crop_d_ && crop_depth_[data_idx] > 0 ?
-            crop_depth_[data_idx] : input_shape[0];
-          auto crop_h = crop_height_[data_idx] > 0 ? crop_height_[data_idx] : input_shape[1];
-          auto crop_w = crop_width_[data_idx]  > 0 ? crop_width_[data_idx]  : input_shape[2];
-          TensorShape<> crop_shape = {crop_d, crop_h, crop_w};
-          crop_window.SetShape(crop_shape);
+        auto crop_shape = input_shape;
+        auto ndim = input_shape.size();
+        int d_dim = shape_layout.find('D');
+        int f_dim = shape_layout.find('F');
+        int h_dim = shape_layout.find('H');
+        int w_dim = shape_layout.find('W');
 
-          float anchor_norm[3] =
-            {crop_z_norm_[data_idx], crop_y_norm_[data_idx], crop_x_norm_[data_idx]};
-          crop_window.SetAnchor(
-            CalculateAnchor(make_span(anchor_norm), crop_shape, input_shape));
-        } else if (input_shape.size() == 2) {
-          auto crop_h = crop_height_[data_idx] > 0 ? crop_height_[data_idx] : input_shape[0];
-          auto crop_w = crop_width_[data_idx]  > 0 ? crop_width_[data_idx]  : input_shape[1];
-          TensorShape<> crop_shape = {crop_h, crop_w};
-          crop_window.SetShape(crop_shape);
+        DALI_ENFORCE(h_dim >= 0 && w_dim >= 0,
+          "Height and Width must be present in the layout. Got: " + shape_layout.str());
 
-          float anchor_norm[2] = {crop_y_norm_[data_idx], crop_x_norm_[data_idx]};
-          crop_window.SetAnchor(
-            CalculateAnchor(make_span(anchor_norm), crop_shape, input_shape));
-        } else {
-          DALI_FAIL("not supported number of dimensions (" +
-                    std::to_string(input_shape.size()) + ")");
+        SmallVector<float, 4> anchor_norm;
+        anchor_norm.resize(ndim, 0.5f);
+
+        if (h_dim >= 0 && crop_height_[data_idx] > 0) {
+          crop_shape[h_dim] = crop_height_[data_idx];
+          anchor_norm[h_dim] = crop_y_norm_[data_idx];
         }
+
+        if (w_dim >= 0 && crop_width_[data_idx] > 0) {
+          crop_shape[w_dim] = crop_width_[data_idx];
+          anchor_norm[w_dim] = crop_x_norm_[data_idx];
+        }
+
+        if (has_crop_d_) {
+          if (d_dim >= 0 && crop_depth_[data_idx] > 0) {
+            crop_shape[d_dim] = crop_depth_[data_idx];
+            anchor_norm[d_dim] = crop_z_norm_[data_idx];
+          } else if (d_dim < 0 && f_dim >= 0 && crop_depth_[data_idx] > 0) {
+            // Special case.
+            // This allows using crop_d to crop on the sequence dimension,
+            // by treating video inputs as a volume instead of a sequence
+            crop_shape[f_dim] = crop_depth_[data_idx];
+            anchor_norm[f_dim] = crop_z_norm_[data_idx];
+          }
+        }
+
+        crop_window.SetAnchor(CalculateAnchor(make_span(anchor_norm), crop_shape, input_shape));
+        crop_window.SetShape(crop_shape);
+        // TODO(janton): allow padding
         DALI_ENFORCE(crop_window.IsInRange(input_shape));
         return crop_window;
     };

--- a/dali/operators/image/crop/crop_attr.h
+++ b/dali/operators/image/crop/crop_attr.h
@@ -113,7 +113,7 @@ class CropAttr {
         int w_dim = shape_layout.find('W');
 
         DALI_ENFORCE(h_dim >= 0 && w_dim >= 0,
-          "Height and Width must be present in the layout. Got: " + shape_layout.str());
+          "[H]eight and [W]idth must be present in the layout. Got: " + shape_layout.str());
 
         SmallVector<float, 4> anchor_norm;
         anchor_norm.resize(ndim, 0.5f);

--- a/dali/pipeline/operator/operator_test.cc
+++ b/dali/pipeline/operator/operator_test.cc
@@ -41,7 +41,7 @@ TEST(InstantiateOperator, InvalidOperatorName) {
 
 TEST(InstantiateOperator, RunMethodIsAccessible) {
   HostWorkspace ws;
-  auto op = InstantiateOperator(MakeOpSpec("Crop"));
+  auto op = InstantiateOperator(MakeOpSpec("ImageDecoder"));
   // We just want to test that Run method is visible (exported to the so file)
   // It is expected that the call throws as the worspace is empty
   ASSERT_THROW(op->Run(ws), std::runtime_error);

--- a/dali/test/python/test_operator_crop.py
+++ b/dali/test/python/test_operator_crop.py
@@ -20,38 +20,38 @@ from nvidia.dali.backend_impl import TensorListGPU
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 import os
-
+from nose.tools import assert_raises
 from test_utils import check_batch
 from test_utils import compare_pipelines
 from test_utils import RandomDataIterator
 from test_utils import get_dali_extra_path
+from test_operator_slice import check_slice_output, abs_slice_start_and_end
+
 
 test_data_root = get_dali_extra_path()
 caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
 test_data_video = os.path.join(test_data_root, 'db', 'optical_flow', 'sintel_trailer')
 
 class CropPipeline(Pipeline):
-    def __init__(self, device, batch_size, num_threads=1, device_id=0, num_gpus=1, is_fused_decoder=False):
-        super(CropPipeline, self).__init__(batch_size,
-                                           num_threads,
-                                           device_id)
+    def __init__(self, device, batch_size, num_threads=1, device_id=0, num_gpus=1, crop_shape=(224, 224), crop_x = 0.3, crop_y = 0.2,
+                 is_fused_decoder=False,):
+        super(CropPipeline, self).__init__(batch_size, num_threads, device_id)
         self.is_fused_decoder = is_fused_decoder
         self.device = device
         self.input = ops.CaffeReader(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
 
         if self.is_fused_decoder:
             self.decode = ops.ImageDecoderCrop(device = "cpu",
-                                              crop = (224, 224),
-                                              crop_pos_x = 0.3,
-                                              crop_pos_y = 0.2,
+                                              crop = crop_shape,
+                                              crop_pos_x = crop_x,
+                                              crop_pos_y = crop_y,
                                               output_type = types.RGB)
         else:
-            self.decode = ops.ImageDecoder(device = "cpu",
-                                          output_type = types.RGB)
+            self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
             self.crop = ops.Crop(device = self.device,
-                                 crop = (224, 224),
-                                 crop_pos_x = 0.3,
-                                 crop_pos_y = 0.2,
+                                 crop = crop_shape,
+                                 crop_pos_x = crop_x,
+                                 crop_pos_y = crop_y,
                                  image_type = types.RGB)
 
     def define_graph(self):
@@ -59,12 +59,13 @@ class CropPipeline(Pipeline):
 
         if self.is_fused_decoder:
             images = self.decode(inputs)
+            return images
         else:
             images = self.decode(inputs)
             if self.device == 'gpu':
                 images = images.gpu()
-            images = self.crop(images)
-        return images
+            out = self.crop(images)
+            return out
 
 def check_crop_vs_fused_decoder(device, batch_size):
     compare_pipelines(CropPipeline(device, batch_size, is_fused_decoder=True),
@@ -402,3 +403,113 @@ def test_cmn_crop_sequence_length():
                     assert len(input_layout) == len(input_shape)
                     yield check_crop_sequence_length, device, batch_size, output_dtype, \
                         input_layout, input_shape
+
+class CropSynthPipe(Pipeline):
+    def __init__(self, device, batch_size, data_iterator, num_threads=1, device_id=0, num_gpus=1, crop_shape=(224, 224), crop_x=0.3, crop_y=0.2,
+                 extra_outputs=False, out_of_bounds_policy=None, fill_values=None, layout="HWC"):
+        super(CropSynthPipe, self).__init__(
+            batch_size, num_threads, device_id)
+        self.device = device
+        self.extra_outputs = extra_outputs
+        self.inputs = ops.ExternalSource()
+        self.data_iterator = data_iterator
+        self.layout = layout
+
+        self.crop = ops.Crop(device = self.device,
+                                crop = crop_shape,
+                                crop_pos_x = crop_x,
+                                crop_pos_y = crop_y,
+                                image_type = types.RGB,
+                                out_of_bounds_policy = out_of_bounds_policy,
+                                fill_values = fill_values)
+
+    def define_graph(self):
+        self.data = self.inputs()
+        images = self.data.gpu() if self.device == 'gpu' else self.data
+        out = self.crop(images)
+        if self.extra_outputs:
+            return out, images
+        else:
+            return out
+
+    def iter_setup(self):
+        data = self.data_iterator.next()
+        self.feed_input(self.data, data, layout=self.layout)
+
+
+def check_crop_with_out_of_bounds_policy_support(device, batch_size, input_shape=(100, 200, 3),
+                                                 out_of_bounds_policy=None, fill_values=(0x76, 0xb9, 0x00)):
+    # This test case is written with HWC layout in mind and "HW" axes in slice arguments
+    layout = "HWC"
+    assert(len(input_shape) == 3)
+    if fill_values is not None and len(fill_values) > 1:
+        assert(input_shape[2] == len(fill_values))
+
+    eii = RandomDataIterator(batch_size, shape=input_shape)
+    crop_shape = tuple(extent * 2 for extent in input_shape[:2])
+    crop_y = 0.5
+    crop_x = 0.5
+    pipe = CropSynthPipe(device, batch_size, iter(eii),
+                         layout = layout,
+                         crop_shape = crop_shape,
+                         crop_x = crop_y, crop_y = crop_x,
+                         out_of_bounds_policy=out_of_bounds_policy,
+                         fill_values=fill_values,
+                         extra_outputs=True)
+    if fill_values is None:
+        fill_values = 0
+    pipe.build()
+    for k in range(3):
+        outs = pipe.run()
+        out = outs[0]
+        in_data = outs[1]
+        if isinstance(out, dali.backend_impl.TensorListGPU):
+            out = out.as_cpu()
+        if isinstance(in_data, dali.backend_impl.TensorListGPU):
+            in_data = in_data.as_cpu()
+
+        assert(batch_size == len(out))
+        for idx in range(batch_size):
+            sample_in = in_data.at(idx)
+            sample_out = out.at(idx)
+            in_shape = list(sample_in.shape)
+            out_shape = list(sample_out.shape)
+            crop_anchor_norm = [crop_y, crop_x]
+            crop_anchor_abs = [crop_anchor_norm[k] * (input_shape[k] - crop_shape[k]) for k in range(2)]
+            abs_start, abs_end, abs_slice_shape = abs_slice_start_and_end(in_shape[:2], crop_anchor_abs, crop_shape, False, False)
+            check_slice_output(sample_in, sample_out, crop_anchor_abs, abs_slice_shape, abs_start, abs_end, out_of_bounds_policy, fill_values)
+
+def test_crop_with_out_of_bounds_policy_support():
+    in_shape = (40, 80, 3)
+    for out_of_bounds_policy in ['pad', 'trim_to_shape']:
+        for device in ['gpu', 'cpu']:
+            for batch_size in [1, 3]:
+                for fill_values in [None, (0x76, 0xb0, 0x00)]:
+                    yield check_crop_with_out_of_bounds_policy_support, \
+                        device, batch_size, in_shape, out_of_bounds_policy, fill_values
+
+def check_crop_with_out_of_bounds_error(device, batch_size, input_shape=(100, 200, 3)):
+    # This test case is written with HWC layout in mind and "HW" axes in slice arguments
+    layout = "HWC"
+    assert(len(input_shape) == 3)
+
+    eii = RandomDataIterator(batch_size, shape=input_shape)
+    crop_shape = tuple(extent * 2 for extent in input_shape[:2])
+    crop_y = 0.5
+    crop_x = 0.5
+    pipe = CropSynthPipe(device, batch_size, iter(eii),
+                         layout = layout,
+                         crop_shape = crop_shape,
+                         crop_x = crop_x, crop_y = crop_y,
+                         out_of_bounds_policy="error")
+
+    pipe.build()
+    with assert_raises(RuntimeError):
+        outs = pipe.run()
+
+def test_slice_with_out_of_bounds_error():
+    in_shape = (40, 80, 3)
+    for device in ['gpu', 'cpu']:
+        for batch_size in [1, 3]:
+            yield check_crop_with_out_of_bounds_error, \
+                device, batch_size, in_shape

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -26,6 +26,7 @@ from test_utils import compare_pipelines
 from test_utils import get_dali_extra_path
 from test_utils import RandomDataIterator
 from math import floor
+from nose.tools import assert_raises
 
 test_data_root = get_dali_extra_path()
 caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
@@ -510,13 +511,8 @@ def check_slice_with_out_of_bounds_error(device, batch_size, input_shape=(100, 2
                                   out_of_bounds_policy="error")
 
     pipe.build()
-    exception_raised = False
-    try:
-        for k in range(3):
-            outs = pipe.run()
-    except:
-        exception_raised = True
-    assert(exception_raised)
+    with assert_raises(RuntimeError):
+        outs = pipe.run()
 
 def test_slice_with_out_of_bounds_error():
     in_shape = (40, 80, 3)

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -31,6 +31,28 @@ test_data_root = get_dali_extra_path()
 caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
 test_data_video = os.path.join(test_data_root, 'db', 'optical_flow', 'sintel_trailer')
 
+#std::round has different behaviour than np.round so manually add 0.5 and truncate to int
+def roundint(num):
+    return int(np.float32(num) + (0.5 if np.float32(num) >= 0 else -0.5))
+
+def abs_slice_start_and_end(in_shape, slice_anchor, slice_shape, normalized_anchor, normalized_shape):
+    ndim = len(in_shape)
+    if normalized_anchor and normalized_shape:
+        start = [roundint(np.float32(in_shape[i]) * np.float32(slice_anchor[i])) for i in range(ndim)]
+        end = [roundint(np.float32(in_shape[i]) * np.float32(slice_anchor[i]+slice_shape[i])) for i in range(ndim)]
+    else:
+        if normalized_anchor:
+            start = [roundint(np.float32(in_shape[i]) * np.float32(slice_anchor[i])) for i in range(ndim)]
+        else:
+            start = [roundint(np.float32(slice_anchor[i])) for i in range(ndim)]
+
+        if normalized_shape:
+            end = [start[i] + roundint(np.float32(in_shape[i]) * np.float32(slice_shape[i])) for i in range(ndim)]
+        else:
+            end = [start[i] + roundint(np.float32(slice_shape[i])) for i in range(ndim)]
+    out_shape = [end[i]-start[i] for i in range(ndim)]
+    return start, end, out_shape
+
 class SliceSynthDataPipeline(Pipeline):
     def __init__(self, device, batch_size, layout, iterator, pos_size_iter,
                  num_threads=1, device_id=0, num_gpus=1,
@@ -47,12 +69,12 @@ class SliceSynthDataPipeline(Pipeline):
         self.input_crop_size = ops.ExternalSource()
         self.extra_outputs = extra_outputs
         self.slice = ops.Slice(device = self.device,
-                                normalized_anchor=normalized_anchor,
-                                normalized_shape=normalized_shape,
+                                normalized_anchor = normalized_anchor,
+                                normalized_shape = normalized_shape,
                                 axes = axes,
                                 axis_names = axis_names,
-                                out_of_bounds_policy=out_of_bounds_policy,
-                                fill_values=fill_values)
+                                out_of_bounds_policy = out_of_bounds_policy,
+                                fill_values = fill_values)
 
     def define_graph(self):
         self.data = self.inputs()
@@ -87,40 +109,20 @@ class SlicePipeline(Pipeline):
         self.input_crop_size = ops.ExternalSource()
 
         if self.is_fused_decoder:
-            if axis_names:
-                self.decode = ops.ImageDecoderSlice(device = "cpu",
-                                                    output_type = types.RGB,
-                                                    normalized_anchor=normalized_anchor,
-                                                    normalized_shape=normalized_shape,
-                                                    axis_names = axis_names)
-            elif axes:
-                self.decode = ops.ImageDecoderSlice(device = "cpu",
-                                                    output_type = types.RGB,
-                                                    normalized_anchor=normalized_anchor,
-                                                    normalized_shape=normalized_shape,
-                                                    axes = axes)
-            else:
-                self.decode = ops.ImageDecoderSlice(device = "cpu",
-                                                    output_type = types.RGB,
-                                                    normalized_anchor=normalized_anchor,
-                                                    normalized_shape=normalized_shape)
+            self.decode = ops.ImageDecoderSlice(device = "cpu",
+                                                output_type = types.RGB,
+                                                normalized_anchor=normalized_anchor,
+                                                normalized_shape=normalized_shape,
+                                                axis_names = axis_names,
+                                                axes = axes)
         else:
             self.decode = ops.ImageDecoder(device = "cpu",
                                            output_type = types.RGB)
-            if axis_names:
-                self.slice = ops.Slice(device = self.device,
-                                       normalized_anchor=normalized_anchor,
-                                       normalized_shape=normalized_shape,
-                                       axis_names = axis_names)
-            elif axes:
-                self.slice = ops.Slice(device = self.device,
-                                       normalized_anchor=normalized_anchor,
-                                       normalized_shape=normalized_shape,
-                                       axes = axes)
-            else:
-                self.slice = ops.Slice(device = self.device,
-                                       normalized_anchor=normalized_anchor,
-                                       normalized_shape=normalized_shape)
+            self.slice = ops.Slice(device = self.device,
+                                   normalized_anchor=normalized_anchor,
+                                   normalized_shape=normalized_shape,
+                                   axis_names = axis_names,
+                                   axes = axes)
 
     def define_graph(self):
         inputs, labels = self.input(name="Reader")
@@ -233,26 +235,7 @@ def slice_func_helper(axes, axis_names, layout, normalized_anchor, normalized_sh
         full_slice_anchor[axis] = slice_anchor[idx]
         full_slice_shape[axis] = slice_shape[idx]
 
-    #std::round has different behaviour than np.round so manually add 0.5 and truncate to int
-    if normalized_anchor and normalized_shape:
-        start = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]) + 0.5)
-                 for i in range(len(shape))]
-        end = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]+full_slice_shape[i]) + 0.5)
-               for i in range(len(shape))]
-    else:
-        if normalized_anchor:
-            start = [int(np.float32(shape[i]) * np.float32(full_slice_anchor[i]) + 0.5)
-                    for i in range(len(shape))]
-        else:
-            start = [int(np.float32(full_slice_anchor[i]) + 0.5)
-                    for i in range(len(shape))]
-
-        if normalized_shape:
-            end = [start[i] + int(np.float32(shape[i]) * np.float32(full_slice_shape[i]) + 0.5)
-                for i in range(len(shape))]
-        else:
-            end = [start[i] + int(np.float32(full_slice_shape[i]) + 0.5)
-                for i in range(len(shape))]
+    start, end, _ = abs_slice_start_and_end(shape, full_slice_anchor, full_slice_shape, normalized_anchor, normalized_shape)
 
     if len(full_slice_anchor) == 1:
         return image[start[0]:end[0]]
@@ -415,12 +398,19 @@ def test_slice_vs_numpy():
                 ((1,0), None), ((0,1), None)]:
                 yield check_slice_vs_numpy, device, batch_size, axes, axis_names
 
-def check_slice_with_pad_support(device, batch_size, axes, axis_names,
-                                 input_shape=(100, 200, 3), layout="HWC",
-                                 fill_values=(0x76, 0xb9, 0x00),
-                                 normalized_anchor=False, normalized_shape=False):
-    normalized_anchor = False
-    normalized_shape = False
+
+def check_slice_with_out_of_bounds_policy_support(device, batch_size, input_shape=(100, 200, 3),
+                                                  out_of_bounds_policy=None, fill_values=(0x76, 0xb9, 0x00),
+                                                  normalized_anchor=False, normalized_shape=False):
+    # This test case is written with HWC layout in mind and "HW" axes in slice arguments
+    axis_names = "HW"
+    naxes = len(axis_names)
+    axes = None
+    layout = "HWC"
+    assert(len(input_shape) == 3)
+    if fill_values is not None and len(fill_values) > 1:
+        assert(input_shape[2] == len(fill_values))
+
     eii = RandomDataIterator(batch_size, shape=input_shape)
     eii_arg = SliceArgsIterator(batch_size, len(input_shape), image_shape=input_shape,
                                 image_layout=layout, axes=axes, axis_names=axis_names,
@@ -432,7 +422,7 @@ def check_slice_with_pad_support(device, batch_size, axes, axis_names,
                                   axes=axes, axis_names=axis_names,
                                   normalized_anchor=normalized_anchor,
                                   normalized_shape=normalized_shape,
-                                  out_of_bounds_policy='pad',
+                                  out_of_bounds_policy=out_of_bounds_policy,
                                   fill_values=fill_values,
                                   extra_outputs=True)
     if fill_values is None:
@@ -452,46 +442,47 @@ def check_slice_with_pad_support(device, batch_size, axes, axis_names,
             sample_out = out.at(idx)
             anchor = anchor_data.at(idx)
             shape = shape_data.at(idx)
+            in_shape = sample_in.shape
+            out_shape = sample_out.shape
 
-            i_pad_before = 0
-            i_slice = 0
-            i_pad_after = 0
-            if anchor[0] < 0:
-                i_pad_before = -anchor[0]
-            elif anchor[0] >= sample_in.shape[0]:
-                i_pad_before = sample_out.shape[0]
-            if i_pad_before + sample_in.shape[0] < shape[0]:
-                i_pad_after = shape[0] - i_pad_before - sample_in.shape[0]
-            i_slice = sample_out.shape[0] - i_pad_before - i_pad_after
+            abs_start, abs_end, abs_slice_shape = abs_slice_start_and_end(in_shape[:2], anchor, shape, normalized_anchor, normalized_shape)
+            if out_of_bounds_policy == 'pad':
+                assert(all([abs_slice_shape[i] == out_shape[i] for i in range(naxes)]))
+            elif out_of_bounds_policy == 'trim_to_shape':
+                assert(all([out_shape[i] <= in_shape[i] for i in range(naxes)]))
+                for i in range(naxes):
+                    if abs_start[i] < 0:
+                        abs_start[i] = 0
+                    if abs_end[i] > in_shape[i]:
+                        abs_end[i] = in_shape[i]
+                    abs_slice_shape[i] = abs_end[i] - abs_start[i]
+                assert(all([abs_slice_shape[i] == out_shape[i] for i in range(naxes)]))
+            else:
+                assert(False) # Wrong out_of_bounds_policy
 
-            j_pad_before = 0
-            j_slice = 0
-            j_pad_after = 0
-            if anchor[1] < 0:
-                j_pad_before = -anchor[1]
-            elif anchor[0] >= sample_in.shape[1]:
-                j_pad_before = sample_out.shape[1]
-            if j_pad_before + sample_in.shape[1] < shape[1]:
-                j_pad_after = shape[1] - j_pad_before - sample_in.shape[1]
-            j_slice = sample_out.shape[1] - j_pad_before - j_pad_after
+            pad_before = [-abs_start[i] if abs_start[i] < 0 else 0 for i in range(naxes)]
+            pad_after = [abs_end[i] - in_shape[i] if in_shape[i] < abs_end[i] else 0 for i in range(naxes)]
+            sliced = [abs_slice_shape[i] - pad_before[i] - pad_after[i] for i in range(naxes)]
 
-            for i in range(sample_out.shape[0]):
-                for j in range(sample_out.shape[1]):
-                    if (i >= i_pad_before and j >= j_pad_before and i < i_pad_before + i_slice and j < j_pad_before + j_slice):
-                        assert((sample_out[i, j, :] == sample_in[int(anchor[0] + i), int(anchor[1] + j), :]).all())
+            if out_of_bounds_policy == 'trim_to_shape':
+                assert(all([pad_before[i] == 0 for i in range(naxes)]))
+                assert(all([pad_after[i] == 0 for i in range(naxes)]))
+                assert(all([sliced[i] == out_shape[i] for i in range(naxes)]))
+
+            for i in range(out_shape[0]):
+                for j in range(out_shape[1]):
+                    if (i >= pad_before[0] and j >= pad_before[1] and i < pad_before[0] + sliced[0] and j < pad_before[1] + sliced[1]):
+                        assert((sample_out[i, j, :] == sample_in[abs_start[0] + i, abs_start[1] + j, :]).all())
                     else:
                         assert((sample_out[i, j, :] == fill_values).all())
 
-def test_slice_with_pad_support():
-    in_shape = (100, 200, 3)
-    axis_names = "HW"
-    axes = None
-    layout = "HWC"
-    out_of_bounds_policy = "pad"
-    for device in ['gpu', 'cpu']:
-        for batch_size in [1, 3]:
-            for normalized_anchor, normalized_shape in [(False, False), (True, True)]:
-                for fill_values in [None, (0x76, 0xb0, 0x00)]:
-                    yield check_slice_with_pad_support, \
-                        device, batch_size, axes, axis_names, in_shape, \
-                        layout, fill_values, normalized_anchor, normalized_shape
+def test_slice_with_out_of_bounds_policy_support():
+    in_shape = (40, 80, 3)
+    for out_of_bounds_policy in ['pad', 'trim_to_shape']:
+        for device in ['gpu', 'cpu']:
+            for batch_size in [1, 3]:
+                for normalized_anchor, normalized_shape in [(False, False), (True, True)]:
+                    for fill_values in [None, (0x76, 0xb0, 0x00)]:
+                        yield check_slice_with_out_of_bounds_policy_support, \
+                            device, batch_size, in_shape, out_of_bounds_policy, fill_values, \
+                            normalized_anchor, normalized_shape


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to allow cropping windows that are larger than the input shape, or are anchored outside of bounds

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Slice and Crop operators has two new arguments: `out_of_bounds_policy` and `fill_values`. Out of bounds policy determines how the operator should behave when attempting to slice outside of the input region. Valid arguments are `"error"` (not allowed), `"pad"` (the output will be padded), `"trim_to_shape"` the output will be resized to fit the input bounds. If `"pad"` is provided, `fill_values` will determine the value (or values) to use when padding*
     *Bug fix in Slice GPU kernel for the case where padding is needed, channel dimension is last last and there is no channel slicing*
 - Affected modules and functionalities:
     *Slice and Crop operators (They share SliceBase implementation)*
 - Key points relevant for the review:
     *Bug fix correctness*
     *Python tests logic*
 - Validation and testing:
     *Python tests added*
 - Documentation (including examples):
     *Operator schema documentation updated*

**JIRA TASK**: *[DALI-1409]*
