### PR TITLE
Fix MelFilterBank bug: setup block descriptors when changing shape between iterations

### DIFF
--- a/dali/test/python/test_operator_mel_filter_bank.py
+++ b/dali/test/python/test_operator_mel_filter_bank.py
@@ -22,6 +22,7 @@ from functools import partial
 from test_utils import check_batch
 from test_utils import compare_pipelines
 from test_utils import RandomDataIterator
+from test_utils import RandomlyShapedDataIterator
 import math
 import librosa as librosa
 
@@ -94,11 +95,12 @@ class MelFilterBankPythonPipeline(Pipeline):
         data = self.iterator.next()
         self.feed_input(self.data, data)
 
-def check_operator_mel_filter_bank_vs_python(device, batch_size, input_shape,
+def check_operator_mel_filter_bank_vs_python(device, batch_size, max_shape,
                                              nfilter, sample_rate, freq_low, freq_high,
                                              normalize, mel_formula):
-    eii1 = RandomDataIterator(batch_size, shape=input_shape, dtype=np.float32)
-    eii2 = RandomDataIterator(batch_size, shape=input_shape, dtype=np.float32)
+    min_shape = [max_shape[0], 1]
+    eii1 = RandomlyShapedDataIterator(batch_size, min_shape=min_shape, max_shape=max_shape, dtype=np.float32)
+    eii2 = RandomlyShapedDataIterator(batch_size, min_shape=min_shape, max_shape=max_shape, dtype=np.float32)
     compare_pipelines(
         MelFilterBankPipeline(device, batch_size, iter(eii1),
                               nfilter=nfilter, sample_rate=sample_rate, freq_low=freq_low, freq_high=freq_high,
@@ -123,3 +125,7 @@ def test_operator_mel_filter_bank_vs_python():
                         (128, 44100.0, 1000.0, 22050.0, (513, 100))]:
                         yield check_operator_mel_filter_bank_vs_python, device, batch_size, shape, \
                             nfilter, sample_rate, freq_low, freq_high, normalize, mel_formula
+
+if __name__ == "__main__":
+    for fun, *args in test_operator_mel_filter_bank_vs_python():
+        fun(*args)


### PR DESCRIPTION

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: memory corruption in MelFilterBank when shape changes between iterations

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Separated setup from construction of `MelFilterImpl`
     * Added tests for varying input shape
     * Extended RandomlyShapedDataIterator to also accepts `min_shape` and `dtype`
 - Affected modules and functionalities:
     * MelFilterBank for GPU
     * test_utils
 - Key points relevant for the review:
     * ?
 - Validation and testing:
     * Python tests
 - Documentation (including examples):
     * N/A


**JIRA TASK**: DALI-1457
