### PR TITLE
Remove boost from the dependencies as it is no longer used anyway

### DIFF
--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -33,18 +33,6 @@
 #include "dali/core/error_handling.h"
 #include "dali/core/tensor_layout.h"
 
-// Workaround missing "is_trivially_copyable" in libstdc++ for g++ < 5.0.
-// We have to first include some standard library headers, so to have __GLIBCXX__ symbol,
-// and we have to exclude the specific version used in manylinux for our CI, because
-// clang always defines __GNUC__ to 4. __GLIBCXX__ is not a linear ordering based on
-// version of library but the date of the release so we can have 4.9.4 > 5.1.
-#if __GLIBCXX__ == 20150212 || (__cplusplus && __GNUC__ < 5 && !__clang__)
-#include <boost/type_traits/has_trivial_copy.hpp>
-#define IS_TRIVIALLY_COPYABLE(T) ::boost::has_trivial_copy<T>::value
-#else
-#define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
-#endif
-
 #ifdef DALI_BUILD_PROTO3
 #include "dali/operators/reader/parser/tf_feature.h"
 #endif  // DALI_BUILD_PROTO3
@@ -70,14 +58,14 @@ namespace detail {
 typedef void (*Copier)(void *, const void*, Index);
 
 template <typename T>
-inline std::enable_if_t<IS_TRIVIALLY_COPYABLE(T)>
+inline std::enable_if_t<std::is_trivially_copyable<T>::value>
 CopyFunc(void *dst, const void *src, Index n) {
   // T is trivially copyable, we can copy using raw memcopy
   std::memcpy(dst, src, n*sizeof(T));
 }
 
 template <typename T>
-inline std::enable_if_t<!IS_TRIVIALLY_COPYABLE(T)>
+inline std::enable_if_t<!std::is_trivially_copyable<T>::value>
 CopyFunc(void *dst, const void *src, Index n) {
   T *typed_dst = static_cast<T*>(dst);
   const T* typed_src = static_cast<const T*>(src);

--- a/docker/Dockerfile.build.aarch64-linux
+++ b/docker/Dockerfile.build.aarch64-linux
@@ -28,12 +28,6 @@ RUN wget https://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_
    && rm -rf /var/lib/apt/lists/* \
    && rm -rf /tmp/cuda-packages.txt
 
-# Boost
-RUN BOOST_VERSION=1_66_0 \
-   && cd /usr/local \
-   && curl -L https://dl.bintray.com/boostorg/release/1.66.0/source/boost_${BOOST_VERSION}.tar.gz | tar -xzf - \
-   && ln -s ../boost_${BOOST_VERSION}/boost include/boost
-
 # CMake
 RUN CMAKE_VERSION=3.13 && \
     CMAKE_BUILD=3.13.5 && \

--- a/docker/Dockerfile.build.aarch64-qnx
+++ b/docker/Dockerfile.build.aarch64-qnx
@@ -43,12 +43,6 @@ RUN dpkg -i $REPO_DEBS && \
    && rm -rf /var/lib/apt/lists/* \
    && rm -rf /tmp/cuda-packages.txt
 
-# Boost
-RUN BOOST_VERSION=1_66_0 \
-   && cd /usr/local \
-   && curl -L https://dl.bintray.com/boostorg/release/1.66.0/source/boost_${BOOST_VERSION}.tar.gz | tar -xzf - \
-   && ln -s ../boost_${BOOST_VERSION}/boost include/boost
-
 # CMake
 RUN CMAKE_VERSION=3.13 && \
     CMAKE_BUILD=3.13.5 && \

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -18,12 +18,6 @@ RUN yum install -y zip wget yasm doxygen graphviz zlib-devel
 # Don't want the short-unicode version for Python 2.7
 RUN rm -f /opt/python/cp27-cp27m
 
-# Boost
-RUN BOOST_VERSION=1.66.0 && \
-    cd /usr/local && \
-    curl -L https://github.com/boostorg/boost/archive/boost-${BOOST_VERSION}.tar.gz | tar -xzf - && \
-    ln -s /boost-${BOOST_VERSION}/boost include/boost
-
 # CMake
 RUN CMAKE_VERSION=3.13 && \
     CMAKE_BUILD=3.13.5 && \


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Remove boost from the dependencies as it is no longer used anyway

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Removes boost from the dependencies as it is no longer used anyway
 - Affected modules and functionalities:
     deps
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
