### PR TITLE
Enable CUDA 11 builds

### DIFF
--- a/cmake/CUDA_utils.cmake
+++ b/cmake/CUDA_utils.cmake
@@ -17,7 +17,7 @@
 if (${ARCH} MATCHES "aarch64")
   set(CUDA_known_archs "53" "62" "72" "75")
 else()
-  set(CUDA_known_archs "35" "50" "52" "60" "61" "70" "75")
+  set(CUDA_known_archs "35" "50" "52" "60" "61" "70" "75" "80")
 endif()
 
 set(CUDA_TARGET_ARCHS ${CUDA_known_archs} CACHE STRING "List of target CUDA architectures")

--- a/docker/Dockerfile.cuda10.deps
+++ b/docker/Dockerfile.cuda10.deps
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine as cuda
 
 # CUDA toolkit needs gcc to be callable during installation even if it does nothing
 RUN apk add curl perl && ln -s /bin/ls /bin/gcc
@@ -15,5 +15,8 @@ RUN CUDA_VERSION=10.0 && \
     CUDA_BUILD=10.0.130.1 && \
     curl -LO  https://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/Prod/patches/${CUDA_PATCH}/cuda_${CUDA_BUILD}_linux.run && \
     chmod +x cuda_${CUDA_BUILD}_linux.run && \
-    ./cuda_${CUDA_BUILD}_linux.run --silent --accept-eula --installdir=/usr/local/cuda-10.0 && \
+    ./cuda_${CUDA_BUILD}_linux.run --silent --accept-eula && \
     rm -f cuda_${CUDA_BUILD}_linux-run;
+
+FROM scratch
+COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.cuda11.deps
+++ b/docker/Dockerfile.cuda11.deps
@@ -1,0 +1,11 @@
+FROM ubuntu:18.04 as cuda
+
+RUN apt update && apt install -y libxml2 curl perl gcc
+
+RUN curl -LO http://developer.download.nvidia.com/compute/cuda/11.0.1/local_installers/cuda_11.0.1_450.36.06_linux.run && \
+    chmod +x cuda_*.run && \
+    ./cuda_*.run --silent --no-opengl-libs --toolkit && \
+    rm -f cuda_*.run;
+
+FROM scratch
+COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.cuda9.deps
+++ b/docker/Dockerfile.cuda9.deps
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine as cuda
 
 # CUDA toolkit needs gcc to be callable during installation even if it does nothing
 RUN apk add curl perl && ln -s /bin/ls /bin/gcc
@@ -17,3 +17,6 @@ RUN CUDA_VERSION=9.0 && \
     mv lib64/libnvjpeg*.a* /usr/local/cuda/lib64/ && \
     mv include/nvjpeg.h /usr/local/cuda/include/ && \
     rm -rf /cuda-linux64-nvjpeg;
+
+FROM scratch
+COPY --from=cuda /usr/local/cuda /usr/local/cuda


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a lack of CUDA 11 based build env

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     enables CUDA 11 builds
 - Affected modules and functionalities:
     cmake, docker image
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1459]*
