### PR TITLE
Separable convolution

### DIFF
--- a/dali/kernels/imgproc/convolution/baseline_convolution.h
+++ b/dali/kernels/imgproc/convolution/baseline_convolution.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_IMGPROC_CONVOLUTION_BASELINE_CONVOLUTION_H_
+#define DALI_KERNELS_IMGPROC_CONVOLUTION_BASELINE_CONVOLUTION_H_
+
+#include "dali/core/boundary.h"
+#include "dali/core/convert.h"
+#include "dali/core/format.h"
+#include "dali/core/tensor_view.h"
+
+namespace dali {
+namespace kernels {
+namespace testing {
+
+template <typename Out, typename In, typename W>
+void BaselineConvolveAxis(Out *out, const In *in, const W *window, int len, int r, int channel_num,
+                          int64_t stride) {
+  for (int i = 0; i < len; i++) {
+    for (int c = 0; c < channel_num; c++) {
+      W accum = {};
+      for (int d = -r; d <= r; d++) {
+        accum += in[boundary::idx_reflect_101(i + d, len) * stride + c] * window[d + r];
+      }
+      out[i * stride + c] = ConvertSat<Out>(accum);
+    }
+  }
+}
+
+/**
+ * @brief Convolve input with window of radius r, along specified axis. Used for testing
+ *
+ * Uses border reflect 101.
+ */
+template <typename Out, typename In, typename W, int ndim>
+void BaselineConvolve(const TensorView<StorageCPU, Out, ndim> &out,
+                      const TensorView<StorageCPU, In, ndim> &in,
+                      const TensorView<StorageCPU, W, 1> &window, int axis, int r,
+                      int current_axis = 0, int64_t offset = 0) {
+  if (current_axis == ndim - 1) {
+    auto stride = GetStrides(out.shape)[axis];
+    BaselineConvolveAxis(out.data + offset, in.data + offset, window.data, out.shape[axis], r,
+                         in.shape[ndim - 1], stride);
+  } else if (current_axis == axis) {
+    BaselineConvolve(out, in, window, axis, r, current_axis + 1, offset);
+  } else {
+    for (int i = 0; i < out.shape[current_axis]; i++) {
+      auto stride = GetStrides(out.shape)[current_axis];
+      BaselineConvolve(out, in, window, axis, r, current_axis + 1, offset + i * stride);
+    }
+  }
+}
+
+}  // namespace testing
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_IMGPROC_CONVOLUTION_BASELINE_CONVOLUTION_H_

--- a/dali/kernels/imgproc/convolution/separable_convolution_cpu.h
+++ b/dali/kernels/imgproc/convolution/separable_convolution_cpu.h
@@ -1,0 +1,202 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_IMGPROC_CONVOLUTION_SEPARABLE_CONVOLUTION_CPU_H_
+#define DALI_KERNELS_IMGPROC_CONVOLUTION_SEPARABLE_CONVOLUTION_CPU_H_
+
+#include "dali/core/convert.h"
+#include "dali/core/format.h"
+#include "dali/core/tensor_view.h"
+#include "dali/kernels/common/utils.h"
+#include "dali/kernels/imgproc/convolution/convolution_cpu.h"
+#include "dali/kernels/kernel.h"
+#include "dali/pipeline/util/operator_impl_utils.h"
+
+namespace dali {
+namespace kernels {
+
+/**
+ * @brief Apply convolution in all axes, starting from the innermost to outermost.
+ *        If channel axis is pressent, the convolution is not applied there.
+ *
+ * If `Out` is same as `W` the intermediate stages are written to out,
+ * otherwise the temporary buffer of `W` is required and allocated in scratchpad
+ *
+ * `W` is currently assumed to be float
+ *
+ * `windows` and `scales` are specified per axis.
+ *
+ * Specialized for 1, 2 or 3 axes, to not go overboard with TMP for generic solutions
+ *
+ * TODO(klecki): For more dimension, fusing a permute step when writing the result
+ * could allow for processing all steps with innermost, contiguous dimension.
+ * For example DHWC->DWHC->HWDC->DHWC, while applying convolutions for W, H, D respectively.
+ */
+template <typename Out, typename In, typename W, int ndim, bool has_channels = true>
+struct SeparableConvolutionCpu;
+
+template <typename Out, typename W, int ndim>
+std::enable_if_t<!std::is_same<Out, W>::value, TensorView<StorageCPU, W, ndim>> GetInterStageView(
+    const TensorView<StorageCPU, Out, ndim>& out, W* scratch) {
+  return {scratch, out.shape};
+}
+
+template <typename W, int ndim>
+TensorView<StorageCPU, W, ndim> GetInterStageView(const TensorView<StorageCPU, W, ndim>& out,
+                                                  W* scratch) {
+  return out;
+}
+
+template <typename Out, typename In, typename W, int axes, bool has_channels>
+struct SeparableConvolutionCpuImpl;
+
+
+template <typename Out, typename In, typename W, bool has_channels>
+struct SeparableConvolutionCpuImpl<Out, In, W, 1, has_channels> {
+  static constexpr int axes = 1;
+  static constexpr int ndim = has_channels ? 2 : 1;
+
+  KernelRequirements Setup(KernelContext& ctx, const TensorShape<ndim>& in_shape,
+                           const std::array<int, axes>& window_sizes) {
+    KernelRequirements req;
+    req.output_shapes.push_back(uniform_list_shape<ndim>(1, in_shape));
+
+    auto req_conv = conv_.Setup(ctx, in_shape, window_sizes[0]);
+    req.AddInputSet(req_conv, false);
+
+    return req;
+  }
+
+  void Run(KernelContext& ctx, const TensorView<StorageCPU, Out, ndim> out,
+           const TensorView<StorageCPU, const In, ndim>& in,
+           const std::array<TensorView<StorageCPU, const W, 1>, axes>& windows,
+           const std::array<W, axes>& scales = uniform_array<axes, W>(1.f)) {
+    conv_.Run(ctx, out, in, windows[0], scales[0]);
+  }
+
+  ConvolutionCpu<Out, In, W, ndim, 0, has_channels> conv_;
+  static_assert(std::is_same<W, float>::value,
+                "Only floats as intermediate values are currently supported.");
+};
+
+template <typename Out, typename In, typename W, bool has_channels>
+struct SeparableConvolutionCpuImpl<Out, In, W, 2, has_channels> {
+  static constexpr int axes = 2;
+  static constexpr int ndim = has_channels ? 3 : 2;
+
+  KernelRequirements Setup(KernelContext& ctx, const TensorShape<ndim>& in_shape,
+                           const std::array<int, axes>& window_sizes) {
+    KernelRequirements req;
+
+    ScratchpadEstimator se;
+    se.add<W>(AllocType::Host, volume(in_shape));
+    req.scratch_sizes = se.sizes;
+    req.output_shapes.push_back(uniform_list_shape<ndim>(1, in_shape));
+
+    auto req_inner = conv_innermost_.Setup(ctx, in_shape, window_sizes[1]);
+    auto req_outer = conv_outermost_.Setup(ctx, in_shape, window_sizes[0]);
+
+    req.AddInputSet(req_inner, false);
+    req.AddInputSet(req_outer, false);
+
+    return req;
+  }
+
+  void Run(KernelContext& ctx, const TensorView<StorageCPU, Out, ndim> out,
+           const TensorView<StorageCPU, const In, ndim>& in,
+           const std::array<TensorView<StorageCPU, const W, 1>, axes>& windows,
+           const std::array<W, axes>& scales = uniform_array<axes, W>(1.f)) {
+    auto *tmp = ctx.scratchpad->Allocate<W>(AllocType::Host, volume(in.shape));
+    auto intermediate = GetInterStageView(out, tmp);
+
+    conv_innermost_.Run(ctx, intermediate, in, windows[1], scales[1]);
+    conv_outermost_.Run(ctx, out, intermediate, windows[0], scales[0]);
+  }
+
+  ConvolutionCpu<W, In, W, ndim, 1, has_channels> conv_innermost_;
+  ConvolutionCpu<Out, W, W, ndim, 0, has_channels> conv_outermost_;
+  static_assert(std::is_same<W, float>::value,
+                "Only floats as intermediate values are currently supported.");
+};
+
+template <typename Out, typename In, typename W, bool has_channels>
+struct SeparableConvolutionCpuImpl<Out, In, W, 3, has_channels> {
+  static constexpr int axes = 3;
+  static constexpr int ndim = has_channels ? 4 : 3;
+
+  KernelRequirements Setup(KernelContext& ctx, const TensorShape<ndim>& in_shape,
+                           const std::array<int, axes>& window_sizes) {
+    KernelRequirements req;
+
+    ScratchpadEstimator se;
+    se.add<W>(AllocType::Host, volume(in_shape));
+    req.scratch_sizes = se.sizes;
+    req.output_shapes.push_back(uniform_list_shape<ndim>(1, in_shape));
+
+    auto req_inner = conv_innermost_.Setup(ctx, in_shape, window_sizes[2]);
+    auto req_middle = conv_middle_.Setup(ctx, in_shape, window_sizes[1]);
+    auto req_outer = conv_outermost_.Setup(ctx, in_shape, window_sizes[0]);
+
+    req.AddInputSet(req_inner, false);
+    req.AddInputSet(req_middle, false);
+    req.AddInputSet(req_outer, false);
+
+    return req;
+  }
+
+  void Run(KernelContext& ctx, const TensorView<StorageCPU, Out, ndim> out,
+           const TensorView<StorageCPU, const In, ndim>& in,
+           const std::array<TensorView<StorageCPU, const W, 1>, axes>& windows,
+           const std::array<W, axes>& scales = uniform_array<axes, W>(1.f)) {
+    auto* tmp = ctx.scratchpad->Allocate<W>(AllocType::Host, volume(in.shape));
+    auto intermediate = GetInterStageView(out, tmp);
+
+    conv_innermost_.Run(ctx, intermediate, in, windows[2], scales[2]);
+    conv_middle_.Run(ctx, intermediate, intermediate, windows[1], scales[1]);
+    conv_outermost_.Run(ctx, out, intermediate, windows[0], scales[0]);
+  }
+
+  ConvolutionCpu<W, In, W, ndim, 2, has_channels> conv_innermost_;
+  ConvolutionCpu<W, W, W, ndim, 1, has_channels> conv_middle_;
+  ConvolutionCpu<Out, W, W, ndim, 0, has_channels> conv_outermost_;
+};
+
+template <typename Out, typename In, typename W>
+struct SeparableConvolutionCpu<Out, In, W, 1, false>
+    : public SeparableConvolutionCpuImpl<Out, In, W, 1, false> {};
+
+template <typename Out, typename In, typename W>
+struct SeparableConvolutionCpu<Out, In, W, 2, true>
+    : public SeparableConvolutionCpuImpl<Out, In, W, 1, true> {};
+
+template <typename Out, typename In, typename W>
+struct SeparableConvolutionCpu<Out, In, W, 2, false>
+    : public SeparableConvolutionCpuImpl<Out, In, W, 2, false> {};
+
+template <typename Out, typename In, typename W>
+struct SeparableConvolutionCpu<Out, In, W, 3, true>
+    : public SeparableConvolutionCpuImpl<Out, In, W, 2, true> {};
+
+template <typename Out, typename In, typename W>
+struct SeparableConvolutionCpu<Out, In, W, 3, false>
+    : public SeparableConvolutionCpuImpl<Out, In, W, 3, false> {};
+
+template <typename Out, typename In, typename W>
+struct SeparableConvolutionCpu<Out, In, W, 4, true>
+    : public SeparableConvolutionCpuImpl<Out, In, W, 3, true> {};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_IMGPROC_CONVOLUTION_SEPARABLE_CONVOLUTION_CPU_H_

--- a/dali/kernels/imgproc/convolution/separable_convolution_cpu.h
+++ b/dali/kernels/imgproc/convolution/separable_convolution_cpu.h
@@ -44,12 +44,8 @@ namespace kernels {
  * For example DHWC->DWHC->HWDC->DHWC, while applying convolutions for W, H, D respectively.
  * This might be faster, but vectorization on outer dims would still probably win.
  */
-template <typename Out, typename In, typename W, int ndim, bool has_channels = true>
+template <typename Out, typename In, typename W, int axes, bool has_channels = false>
 struct SeparableConvolutionCpu;
-
-template <typename Out, typename In, typename W, int axes, bool has_channels>
-struct SeparableConvolutionCpu;
-
 
 template <typename Out, typename In, typename W, bool has_channels>
 struct SeparableConvolutionCpu<Out, In, W, 1, has_channels> {

--- a/dali/kernels/imgproc/convolution/separable_convolution_cpu.h
+++ b/dali/kernels/imgproc/convolution/separable_convolution_cpu.h
@@ -27,7 +27,7 @@ namespace dali {
 namespace kernels {
 
 /**
- * @brief Apply convolution in all axes, starting from the innermost to outermost.
+ * @brief Apply convolution in all spatial axes, starting from the innermost to outermost.
  *        If channel axis is pressent, the convolution is not applied there.
  *
  * If `Out` is same as `W` the intermediate stages are written to out,
@@ -48,11 +48,11 @@ template <typename Out, typename In, typename W, int ndim, bool has_channels = t
 struct SeparableConvolutionCpu;
 
 template <typename Out, typename In, typename W, int axes, bool has_channels>
-struct SeparableConvolutionCpuImpl;
+struct SeparableConvolutionCpu;
 
 
 template <typename Out, typename In, typename W, bool has_channels>
-struct SeparableConvolutionCpuImpl<Out, In, W, 1, has_channels> {
+struct SeparableConvolutionCpu<Out, In, W, 1, has_channels> {
   static constexpr int axes = 1;
   static constexpr int ndim = has_channels ? 2 : 1;
 
@@ -78,7 +78,7 @@ struct SeparableConvolutionCpuImpl<Out, In, W, 1, has_channels> {
 };
 
 template <typename Out, typename In, typename W, bool has_channels>
-struct SeparableConvolutionCpuImpl<Out, In, W, 2, has_channels> {
+struct SeparableConvolutionCpu<Out, In, W, 2, has_channels> {
   static constexpr int axes = 2;
   static constexpr int ndim = has_channels ? 3 : 2;
   using Intermediate = decltype(std::declval<W>() * std::declval<In>());
@@ -117,7 +117,7 @@ struct SeparableConvolutionCpuImpl<Out, In, W, 2, has_channels> {
 };
 
 template <typename Out, typename In, typename W, bool has_channels>
-struct SeparableConvolutionCpuImpl<Out, In, W, 3, has_channels> {
+struct SeparableConvolutionCpu<Out, In, W, 3, has_channels> {
   static constexpr int axes = 3;
   static constexpr int ndim = has_channels ? 4 : 3;
   using Intermediate = decltype(std::declval<W>() * std::declval<In>());
@@ -158,30 +158,6 @@ struct SeparableConvolutionCpuImpl<Out, In, W, 3, has_channels> {
   ConvolutionCpu<Intermediate, Intermediate, W, ndim, 1, has_channels> conv_middle_;
   ConvolutionCpu<Out, Intermediate, W, ndim, 0, has_channels> conv_outermost_;
 };
-
-template <typename Out, typename In, typename W>
-struct SeparableConvolutionCpu<Out, In, W, 1, false>
-    : public SeparableConvolutionCpuImpl<Out, In, W, 1, false> {};
-
-template <typename Out, typename In, typename W>
-struct SeparableConvolutionCpu<Out, In, W, 2, true>
-    : public SeparableConvolutionCpuImpl<Out, In, W, 1, true> {};
-
-template <typename Out, typename In, typename W>
-struct SeparableConvolutionCpu<Out, In, W, 2, false>
-    : public SeparableConvolutionCpuImpl<Out, In, W, 2, false> {};
-
-template <typename Out, typename In, typename W>
-struct SeparableConvolutionCpu<Out, In, W, 3, true>
-    : public SeparableConvolutionCpuImpl<Out, In, W, 2, true> {};
-
-template <typename Out, typename In, typename W>
-struct SeparableConvolutionCpu<Out, In, W, 3, false>
-    : public SeparableConvolutionCpuImpl<Out, In, W, 3, false> {};
-
-template <typename Out, typename In, typename W>
-struct SeparableConvolutionCpu<Out, In, W, 4, true>
-    : public SeparableConvolutionCpuImpl<Out, In, W, 3, true> {};
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/imgproc/convolution/separable_convolution_cpu_test.cc
+++ b/dali/kernels/imgproc/convolution/separable_convolution_cpu_test.cc
@@ -1,0 +1,317 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <complex>
+#include <tuple>
+#include <vector>
+
+#include "dali/kernels/common/utils.h"
+#include "dali/kernels/imgproc/convolution/baseline_convolution.h"
+#include "dali/kernels/imgproc/convolution/separable_convolution_cpu.h"
+#include "dali/kernels/scratch.h"
+#include "dali/test/tensor_test_utils.h"
+#include "dali/test/test_tensors.h"
+
+namespace dali {
+namespace kernels {
+
+void InitTriangleWindow(const TensorView<StorageCPU, float, 1> &window) {
+  int radius = window.num_elements() / 2;
+  for (int i = 0; i < radius; i++) {
+    *window(i) = i + 1;
+    *window(window.num_elements() - i - 1) = i + 1;
+  }
+  *window(radius) = radius + 1;
+}
+
+TEST(SeparableConvolutionTest, Dim1WithChannels) {
+  std::array<int, 1> window_dims = {5};
+  TestTensorList<float, 1> kernel_window;
+  TestTensorList<float, 2> input;
+  TestTensorList<int, 2> output, baseline_output;
+
+  TensorListShape<2> data_shape = uniform_list_shape<2>(1, {16, 3});
+
+  kernel_window.reshape(uniform_list_shape<1>(1, {window_dims[0]}));
+  input.reshape(data_shape);
+  output.reshape(data_shape);
+  baseline_output.reshape(data_shape);
+
+  auto kernel_window_v = kernel_window.cpu()[0];
+  auto in_v = input.cpu()[0];
+  auto out_v = output.cpu()[0];
+  auto baseline_out_v = baseline_output.cpu()[0];
+
+  std::mt19937 rng;
+  UniformRandomFill(in_v, rng, 0, 255);
+  InitTriangleWindow(kernel_window_v);
+
+  SeparableConvolutionCpu<int, float, float, 2, true> kernel;
+  KernelContext ctx;
+
+  auto req = kernel.Setup(ctx, data_shape[0], window_dims);
+
+  ScratchpadAllocator scratch_alloc;
+  scratch_alloc.Reserve(req.scratch_sizes);
+  auto scratchpad = scratch_alloc.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+
+  kernel.Run(ctx, out_v, in_v,
+             uniform_array<1, TensorView<StorageCPU, const float, 1>>(kernel_window_v));
+  testing::BaselineConvolve(baseline_out_v, in_v, kernel_window_v, 0, window_dims[0] / 2);
+  Check(out_v, baseline_out_v);
+}
+
+TEST(SeparableConvolutionTest, Dim1NoChannels) {
+  std::array<int, 1> window_dims = {5};
+  TestTensorList<float, 1> kernel_window;
+  TestTensorList<float, 2> input;
+  TestTensorList<int, 1> output;
+  TestTensorList<int, 2> baseline_output;
+
+  TensorListShape<2> data_shape = uniform_list_shape<2>(1, {16, 1});
+
+  kernel_window.reshape(uniform_list_shape<1>(1, {window_dims[0]}));
+  input.reshape(data_shape);
+  output.reshape(data_shape.first<1>());
+  baseline_output.reshape(data_shape);
+
+  auto kernel_window_v = kernel_window.cpu()[0];
+  auto baseline_in_v = input.cpu()[0];
+  TensorView<StorageCPU, float, 1> in_v = {baseline_in_v.data, baseline_in_v.shape.first<1>()};
+  auto out_v = output.cpu()[0];
+  auto baseline_out_v = baseline_output.cpu()[0];
+
+  std::mt19937 rng;
+  UniformRandomFill(in_v, rng, 0, 255);
+  InitTriangleWindow(kernel_window_v);
+
+  SeparableConvolutionCpu<int, float, float, 1, false> kernel;
+  KernelContext ctx;
+
+  auto req = kernel.Setup(ctx, data_shape[0].first<1>(), window_dims);
+
+  ScratchpadAllocator scratch_alloc;
+  scratch_alloc.Reserve(req.scratch_sizes);
+  auto scratchpad = scratch_alloc.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+
+  kernel.Run(ctx, out_v, in_v,
+             uniform_array<1, TensorView<StorageCPU, const float, 1>>(kernel_window_v));
+  testing::BaselineConvolve(baseline_out_v, baseline_in_v, kernel_window_v, 0, window_dims[0] / 2);
+  TensorView<StorageCPU, int, 1> compare_v = {baseline_out_v.data, baseline_out_v.shape.first<1>()};
+  Check(out_v, compare_v);
+}
+
+TEST(SeparableConvolutionTest, Dim2WithChannels) {
+  std::array<int, 2> window_dims = {5, 7};
+  TestTensorList<float, 1> kernel_window_0, kernel_window_1;
+  TestTensorList<int, 3> input;
+  TestTensorList<float, 3> intermediate;
+  TestTensorList<int, 3> output, baseline_output;
+
+  TensorListShape<3> data_shape = uniform_list_shape<3>(1, {20, 16, 3});
+
+  kernel_window_0.reshape(uniform_list_shape<1>(1, {window_dims[0]}));
+  kernel_window_1.reshape(uniform_list_shape<1>(1, {window_dims[1]}));
+  input.reshape(data_shape);
+  intermediate.reshape(data_shape);
+  output.reshape(data_shape);
+  baseline_output.reshape(data_shape);
+
+  auto kernel_window_0_v = kernel_window_0.cpu()[0];
+  auto kernel_window_1_v = kernel_window_1.cpu()[0];
+  auto in_v = input.cpu()[0];
+  auto interm_v = intermediate.cpu()[0];
+  auto out_v = output.cpu()[0];
+  auto baseline_out_v = baseline_output.cpu()[0];
+
+  std::mt19937 rng;
+  UniformRandomFill(in_v, rng, 0, 255);
+  InitTriangleWindow(kernel_window_0_v);
+  InitTriangleWindow(kernel_window_1_v);
+
+  SeparableConvolutionCpu<int, int, float, 3, true> kernel;
+  KernelContext ctx;
+
+  auto req = kernel.Setup(ctx, data_shape[0], window_dims);
+
+  ScratchpadAllocator scratch_alloc;
+  scratch_alloc.Reserve(req.scratch_sizes);
+  auto scratchpad = scratch_alloc.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+
+  kernel.Run(ctx, out_v, in_v, {kernel_window_0_v, kernel_window_1_v});
+  testing::BaselineConvolve(interm_v, in_v, kernel_window_1_v, 1, window_dims[1] / 2);
+  testing::BaselineConvolve(baseline_out_v, interm_v, kernel_window_0_v, 0, window_dims[0] / 2);
+  Check(out_v, baseline_out_v);
+}
+
+TEST(SeparableConvolutionTest, Dim2NoChannels) {
+  std::array<int, 2> window_dims = {5, 7};
+  TestTensorList<float, 1> kernel_window_0, kernel_window_1;
+  TestTensorList<int, 3> input;
+  TestTensorList<float, 3> intermediate;
+  TestTensorList<int, 2> output;
+  TestTensorList<int, 3> baseline_output;
+
+  TensorListShape<3> data_shape = uniform_list_shape<3>(1, {20, 16, 1});
+
+  kernel_window_0.reshape(uniform_list_shape<1>(1, {window_dims[0]}));
+  kernel_window_1.reshape(uniform_list_shape<1>(1, {window_dims[1]}));
+  input.reshape(data_shape);
+  intermediate.reshape(data_shape);
+  output.reshape(data_shape.first<2>());
+  baseline_output.reshape(data_shape);
+
+  auto kernel_window_0_v = kernel_window_0.cpu()[0];
+  auto kernel_window_1_v = kernel_window_1.cpu()[0];
+  auto baseline_in_v = input.cpu()[0];
+  TensorView<StorageCPU, int, 2> in_v = {baseline_in_v.data, baseline_in_v.shape.first<2>()};
+  auto interm_v = intermediate.cpu()[0];
+  auto out_v = output.cpu()[0];
+  auto baseline_out_v = baseline_output.cpu()[0];
+
+  std::mt19937 rng;
+  UniformRandomFill(in_v, rng, 0, 255);
+  InitTriangleWindow(kernel_window_0_v);
+  InitTriangleWindow(kernel_window_1_v);
+
+  SeparableConvolutionCpu<int, int, float, 2, false> kernel;
+  KernelContext ctx;
+
+  auto req = kernel.Setup(ctx, data_shape[0].first<2>(), window_dims);
+
+  ScratchpadAllocator scratch_alloc;
+  scratch_alloc.Reserve(req.scratch_sizes);
+  auto scratchpad = scratch_alloc.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+
+  kernel.Run(ctx, out_v, in_v, {kernel_window_0_v, kernel_window_1_v});
+  testing::BaselineConvolve(interm_v, baseline_in_v, kernel_window_1_v, 1, window_dims[1] / 2);
+  testing::BaselineConvolve(baseline_out_v, interm_v, kernel_window_0_v, 0, window_dims[0] / 2);
+  TensorView<StorageCPU, int, 2> compare_v = {baseline_out_v.data, baseline_out_v.shape.first<2>()};
+  Check(out_v, compare_v);
+}
+
+TEST(SeparableConvolutionTest, Dim3WithChannels) {
+  std::array<int, 3> window_dims = {5, 7, 3};
+  TestTensorList<float, 1> kernel_window_0, kernel_window_1, kernel_window_2;
+  TestTensorList<int, 4> input;
+  TestTensorList<float, 4> intermediate_0, intermediate_1;
+  TestTensorList<float, 4> output, baseline_output;
+
+  TensorListShape<4> data_shape = uniform_list_shape<4>(1, {14, 20, 16, 3});
+
+  kernel_window_0.reshape(uniform_list_shape<1>(1, {window_dims[0]}));
+  kernel_window_1.reshape(uniform_list_shape<1>(1, {window_dims[1]}));
+  kernel_window_2.reshape(uniform_list_shape<1>(1, {window_dims[2]}));
+  input.reshape(data_shape);
+  intermediate_0.reshape(data_shape);
+  intermediate_1.reshape(data_shape);
+  output.reshape(data_shape);
+  baseline_output.reshape(data_shape);
+
+  auto kernel_window_0_v = kernel_window_0.cpu()[0];
+  auto kernel_window_1_v = kernel_window_1.cpu()[0];
+  auto kernel_window_2_v = kernel_window_2.cpu()[0];
+  auto in_v = input.cpu()[0];
+  auto interm_0_v = intermediate_0.cpu()[0];
+  auto interm_1_v = intermediate_1.cpu()[0];
+  auto out_v = output.cpu()[0];
+  auto baseline_out_v = baseline_output.cpu()[0];
+
+  std::mt19937 rng;
+  UniformRandomFill(in_v, rng, 0, 255);
+  InitTriangleWindow(kernel_window_0_v);
+  InitTriangleWindow(kernel_window_1_v);
+  InitTriangleWindow(kernel_window_2_v);
+
+  SeparableConvolutionCpu<float, int, float, 4, true> kernel;
+  KernelContext ctx;
+
+  auto req = kernel.Setup(ctx, data_shape[0], window_dims);
+
+  ScratchpadAllocator scratch_alloc;
+  scratch_alloc.Reserve(req.scratch_sizes);
+  auto scratchpad = scratch_alloc.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+
+  kernel.Run(ctx, out_v, in_v, {kernel_window_0_v, kernel_window_1_v, kernel_window_2_v});
+
+  testing::BaselineConvolve(interm_0_v, in_v, kernel_window_2_v, 2, window_dims[2] / 2);
+  testing::BaselineConvolve(interm_1_v, interm_0_v, kernel_window_1_v, 1, window_dims[1] / 2);
+  testing::BaselineConvolve(baseline_out_v, interm_1_v, kernel_window_0_v, 0, window_dims[0] / 2);
+  Check(out_v, baseline_out_v);
+}
+
+TEST(SeparableConvolutionTest, Dim3NoChannels) {
+  std::array<int, 3> window_dims = {5, 7, 3};
+  TestTensorList<float, 1> kernel_window_0, kernel_window_1, kernel_window_2;
+  TestTensorList<int, 4> input;
+  TestTensorList<float, 4> intermediate_0, intermediate_1;
+  TestTensorList<float, 3> output;
+  TestTensorList<float, 4> baseline_output;
+
+  TensorListShape<4> data_shape = uniform_list_shape<4>(1, {14, 20, 16, 1});
+
+  kernel_window_0.reshape(uniform_list_shape<1>(1, {window_dims[0]}));
+  kernel_window_1.reshape(uniform_list_shape<1>(1, {window_dims[1]}));
+  kernel_window_2.reshape(uniform_list_shape<1>(1, {window_dims[2]}));
+  input.reshape(data_shape);
+  intermediate_0.reshape(data_shape);
+  intermediate_1.reshape(data_shape);
+  output.reshape(data_shape.first<3>());
+  baseline_output.reshape(data_shape);
+
+  auto kernel_window_0_v = kernel_window_0.cpu()[0];
+  auto kernel_window_1_v = kernel_window_1.cpu()[0];
+  auto kernel_window_2_v = kernel_window_2.cpu()[0];
+  auto baseline_in_v = input.cpu()[0];
+  TensorView<StorageCPU, int, 3> in_v = {baseline_in_v.data, baseline_in_v.shape.first<3>()};
+  auto interm_0_v = intermediate_0.cpu()[0];
+  auto interm_1_v = intermediate_1.cpu()[0];
+  auto out_v = output.cpu()[0];
+  auto baseline_out_v = baseline_output.cpu()[0];
+
+  std::mt19937 rng;
+  UniformRandomFill(in_v, rng, 0, 255);
+  InitTriangleWindow(kernel_window_0_v);
+  InitTriangleWindow(kernel_window_1_v);
+  InitTriangleWindow(kernel_window_2_v);
+
+  SeparableConvolutionCpu<float, int, float, 3, false> kernel;
+  KernelContext ctx;
+
+  auto req = kernel.Setup(ctx, data_shape[0].first<3>(), window_dims);
+
+  ScratchpadAllocator scratch_alloc;
+  scratch_alloc.Reserve(req.scratch_sizes);
+  auto scratchpad = scratch_alloc.GetScratchpad();
+  ctx.scratchpad = &scratchpad;
+
+  kernel.Run(ctx, out_v, in_v, {kernel_window_0_v, kernel_window_1_v, kernel_window_2_v});
+
+  testing::BaselineConvolve(interm_0_v, baseline_in_v, kernel_window_2_v, 2, window_dims[2] / 2);
+  testing::BaselineConvolve(interm_1_v, interm_0_v, kernel_window_1_v, 1, window_dims[1] / 2);
+  testing::BaselineConvolve(baseline_out_v, interm_1_v, kernel_window_0_v, 0, window_dims[0] / 2);
+  TensorView<StorageCPU, float, 3> compare_v = {baseline_out_v.data,
+                                                baseline_out_v.shape.first<3>()};
+  Check(out_v, compare_v);
+}
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/imgproc/convolution/separable_convolution_cpu_test.cc
+++ b/dali/kernels/imgproc/convolution/separable_convolution_cpu_test.cc
@@ -38,7 +38,7 @@ void InitTriangleWindow(const TensorView<StorageCPU, T, 1> &window) {
   *window(radius) = radius + 1;
 }
 
-TEST(SeparableConvolutionTest, Dim1WithChannels) {
+TEST(SeparableConvolutionTest, Axes1WithChannels) {
   std::array<int, 1> window_dims = {5};
   TestTensorList<float, 1> kernel_window;
   TestTensorList<float, 2> input;
@@ -60,7 +60,7 @@ TEST(SeparableConvolutionTest, Dim1WithChannels) {
   UniformRandomFill(in_v, rng, 0, 255);
   InitTriangleWindow(kernel_window_v);
 
-  SeparableConvolutionCpu<int, float, float, 2, true> kernel;
+  SeparableConvolutionCpu<int, float, float, 1, true> kernel;
   KernelContext ctx;
 
   auto req = kernel.Setup(ctx, data_shape[0], window_dims);
@@ -76,7 +76,7 @@ TEST(SeparableConvolutionTest, Dim1WithChannels) {
   Check(out_v, baseline_out_v);
 }
 
-TEST(SeparableConvolutionTest, Dim1NoChannels) {
+TEST(SeparableConvolutionTest, Axes1NoChannels) {
   std::array<int, 1> window_dims = {5};
   TestTensorList<float, 1> kernel_window;
   TestTensorList<float, 2> input;
@@ -117,7 +117,7 @@ TEST(SeparableConvolutionTest, Dim1NoChannels) {
   Check(out_v, compare_v);
 }
 
-TEST(SeparableConvolutionTest, Dim2WithChannels) {
+TEST(SeparableConvolutionTest, Axes2WithChannels) {
   std::array<int, 2> window_dims = {5, 7};
   TestTensorList<float, 1> kernel_window_0, kernel_window_1;
   TestTensorList<int, 3> input;
@@ -145,9 +145,9 @@ TEST(SeparableConvolutionTest, Dim2WithChannels) {
   InitTriangleWindow(kernel_window_0_v);
   InitTriangleWindow(kernel_window_1_v);
 
-  SeparableConvolutionCpu<int, int, float, 3, true> kernel;
+  SeparableConvolutionCpu<int, int, float, 2, true> kernel;
   static_assert(
-      std::is_same<typename SeparableConvolutionCpu<int, int, float, 3, true>::Intermediate,
+      std::is_same<typename SeparableConvolutionCpu<int, int, float, 2, true>::Intermediate,
                    float>::value,
       "Unexpected intermediate type");
   KernelContext ctx;
@@ -165,7 +165,7 @@ TEST(SeparableConvolutionTest, Dim2WithChannels) {
   Check(out_v, baseline_out_v);
 }
 
-TEST(SeparableConvolutionTest, Dim2NoChannels) {
+TEST(SeparableConvolutionTest, Axes2NoChannels) {
   std::array<int, 2> window_dims = {5, 7};
   TestTensorList<float, 1> kernel_window_0, kernel_window_1;
   TestTensorList<int, 3> input;
@@ -216,7 +216,7 @@ TEST(SeparableConvolutionTest, Dim2NoChannels) {
   Check(out_v, compare_v);
 }
 
-TEST(SeparableConvolutionTest, Dim3WithChannels) {
+TEST(SeparableConvolutionTest, Axes3WithChannels) {
   std::array<int, 3> window_dims = {5, 7, 3};
   TestTensorList<uint16_t, 1> kernel_window_0, kernel_window_1, kernel_window_2;
   TestTensorList<int16_t, 4> input;
@@ -249,10 +249,10 @@ TEST(SeparableConvolutionTest, Dim3WithChannels) {
   InitTriangleWindow(kernel_window_1_v);
   InitTriangleWindow(kernel_window_2_v);
 
-  SeparableConvolutionCpu<int16_t, int16_t, uint16_t, 4, true> kernel;
+  SeparableConvolutionCpu<int16_t, int16_t, uint16_t, 3, true> kernel;
   static_assert(
       std::is_same<
-          typename SeparableConvolutionCpu<int16_t, int16_t, uint16_t, 4, true>::Intermediate,
+          typename SeparableConvolutionCpu<int16_t, int16_t, uint16_t, 3, true>::Intermediate,
           int>::value,
       "Unexpected intermediate type");
   KernelContext ctx;
@@ -272,7 +272,7 @@ TEST(SeparableConvolutionTest, Dim3WithChannels) {
   Check(out_v, baseline_out_v);
 }
 
-TEST(SeparableConvolutionTest, Dim3NoChannels) {
+TEST(SeparableConvolutionTest, Axes3NoChannels) {
   std::array<int, 3> window_dims = {5, 7, 3};
   TestTensorList<float, 1> kernel_window_0, kernel_window_1, kernel_window_2;
   TestTensorList<int, 4> input;

--- a/dali/kernels/imgproc/convolution/separable_convolution_cpu_test.cc
+++ b/dali/kernels/imgproc/convolution/separable_convolution_cpu_test.cc
@@ -28,7 +28,8 @@
 namespace dali {
 namespace kernels {
 
-void InitTriangleWindow(const TensorView<StorageCPU, float, 1> &window) {
+template <typename T>
+void InitTriangleWindow(const TensorView<StorageCPU, T, 1> &window) {
   int radius = window.num_elements() / 2;
   for (int i = 0; i < radius; i++) {
     *window(i) = i + 1;
@@ -145,6 +146,10 @@ TEST(SeparableConvolutionTest, Dim2WithChannels) {
   InitTriangleWindow(kernel_window_1_v);
 
   SeparableConvolutionCpu<int, int, float, 3, true> kernel;
+  static_assert(
+      std::is_same<typename SeparableConvolutionCpu<int, int, float, 3, true>::Intermediate,
+                   float>::value,
+      "Unexpected intermediate type");
   KernelContext ctx;
 
   auto req = kernel.Setup(ctx, data_shape[0], window_dims);
@@ -191,6 +196,10 @@ TEST(SeparableConvolutionTest, Dim2NoChannels) {
   InitTriangleWindow(kernel_window_1_v);
 
   SeparableConvolutionCpu<int, int, float, 2, false> kernel;
+  static_assert(
+      std::is_same<typename SeparableConvolutionCpu<int, int, float, 2, false>::Intermediate,
+                   float>::value,
+      "Unexpected intermediate type");
   KernelContext ctx;
 
   auto req = kernel.Setup(ctx, data_shape[0].first<2>(), window_dims);
@@ -209,10 +218,10 @@ TEST(SeparableConvolutionTest, Dim2NoChannels) {
 
 TEST(SeparableConvolutionTest, Dim3WithChannels) {
   std::array<int, 3> window_dims = {5, 7, 3};
-  TestTensorList<float, 1> kernel_window_0, kernel_window_1, kernel_window_2;
-  TestTensorList<int, 4> input;
-  TestTensorList<float, 4> intermediate_0, intermediate_1;
-  TestTensorList<float, 4> output, baseline_output;
+  TestTensorList<uint16_t, 1> kernel_window_0, kernel_window_1, kernel_window_2;
+  TestTensorList<int16_t, 4> input;
+  TestTensorList<int, 4> intermediate_0, intermediate_1;
+  TestTensorList<int16_t, 4> output, baseline_output;
 
   TensorListShape<4> data_shape = uniform_list_shape<4>(1, {14, 20, 16, 3});
 
@@ -240,7 +249,12 @@ TEST(SeparableConvolutionTest, Dim3WithChannels) {
   InitTriangleWindow(kernel_window_1_v);
   InitTriangleWindow(kernel_window_2_v);
 
-  SeparableConvolutionCpu<float, int, float, 4, true> kernel;
+  SeparableConvolutionCpu<int16_t, int16_t, uint16_t, 4, true> kernel;
+  static_assert(
+      std::is_same<
+          typename SeparableConvolutionCpu<int16_t, int16_t, uint16_t, 4, true>::Intermediate,
+          int>::value,
+      "Unexpected intermediate type");
   KernelContext ctx;
 
   auto req = kernel.Setup(ctx, data_shape[0], window_dims);
@@ -294,6 +308,10 @@ TEST(SeparableConvolutionTest, Dim3NoChannels) {
   InitTriangleWindow(kernel_window_2_v);
 
   SeparableConvolutionCpu<float, int, float, 3, false> kernel;
+  static_assert(
+      std::is_same<typename SeparableConvolutionCpu<float, int, float, 3, false>::Intermediate,
+                   float>::value,
+      "Unexpected intermediate type");
   KernelContext ctx;
 
   auto req = kernel.Setup(ctx, data_shape[0].first<3>(), window_dims);

--- a/dali/kernels/kernel_manager.h
+++ b/dali/kernels/kernel_manager.h
@@ -88,23 +88,23 @@ class DLL_PUBLIC KernelManager {
   using ScratchSizes = std::array<size_t, NumAllocTypes>;
 
   /**
-   * @brief Creates `num_threads` scratcapads and `num_instances` slots for kernels
+   * @brief Creates `num_threads` scratchpads and `num_instances` slots for kernels
    *
    * @param num_threads -    number of threads that can concurrently use the kernels in the
    *                         manager, assuming that each threads uses its unique
-   *                         zero-based inde
+   *                         zero-based index
    * @param num_instances -  number of Kernel instances to be created; typically corresponds
    *                         to number of samples (for per-sample kernels) or minibatches
    */
   void Resize(size_t num_threads, size_t num_instances);
 
   /**
-   * @brief Creates `num_threads` scratcapads and `num_instances` kernels of type Kernel
+   * @brief Creates `num_threads` scratchpads and `num_instances` kernels of type Kernel
    *        constructed with `args...`.
    *
    * @param num_threads   -  number of threads that can concurrently use the kernels in the
    *                         manager, assuming that each threads uses its unique
-   *                         zero-based inde
+   *                         zero-based index
    * @param num_instances -  number of Kernel instances to be created; typically corresponds
    *                         to number of samples (for per-sample kernels) or minibatches
    * @param args           - arguments passed to Kernel's constructor upon creation.

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -15,6 +15,7 @@
 #ifndef DALI_CORE_UTIL_H_
 #define DALI_CORE_UTIL_H_
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <utility>
@@ -343,6 +344,14 @@ static_assert(all_of<true, true, true>::value,
               "Should return true_type when all the values are true.");
 static_assert(!all_of<true, false, true>::value,
               "Should return false_type when any of the values is false.");
+
+
+template <size_t N, typename T>
+std::array<T, N> uniform_array(const T& t) {
+  std::array<T, N> result;
+  result.fill(t);
+  return result;
+}
 
 }  // namespace dali
 


### PR DESCRIPTION
#### Why we need this PR?
Adds separable convolution using Convolution Kernel, passing over all axes.

#### What happened in this PR?
 - What solution was applied:
     SeparableConvolution kernel build by using several passes of ConvolutionKernel
 - Affected modules and functionalities:
     Kernels, kernels tests
 - Key points relevant for the review:
     Nothing fancy, mostly boilerplate
 - Validation and testing:
     Gtest for kernel, baseline implementation moved to separate file.
 - Documentation (including examples):
     *[ Describe here if documentation and examples were updated. ]*


**JIRA TASK**: *[DALI-1425]*
