### PR TITLE
Silence CUDA 11 compute 35 and 50 deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ CUDA_get_gencode_args(CUDA_gencode_flags ${CUDA_targeted_archs})
 message(STATUS "Generated gencode flags: ${CUDA_gencode_flags}")
 
 # Add ptx & bin flags for cuda
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${CUDA_gencode_flags} --compiler-options -fvisibility=hidden")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} ${CUDA_gencode_flags} --compiler-options -fvisibility=hidden --Wno-deprecated-gpu-targets")
 
 
 # Include directories


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It silences a CUDA 11 compute 35 and 50 deprecation warning

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds `--Wno-deprecated-gpu-targets` flag to CUDA compilation
 - Affected modules and functionalities:
     CMake
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA

**JIRA TASK**: *[DALI-1459]*
