### PR TITLE
Change locked version of numba to at most 0.49, as 0.47 is the last release for py35

### DIFF
--- a/qa/TL0_jupyter/test_nofw.sh
+++ b/qa/TL0_jupyter/test_nofw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 # lock numba version as 0.50 changed module location and librosa hasn't catched up in 7.2 yet
-pip_packages="jupyter numpy matplotlib pillow opencv-python librosa simpleaudio numba==0.49"
+pip_packages="jupyter numpy matplotlib pillow opencv-python librosa simpleaudio numba<=0.49"
 target_dir=./docs/examples
 
 do_once() {

--- a/qa/TL0_python-self-test/test_nofw.sh
+++ b/qa/TL0_python-self-test/test_nofw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 # lock numba version as 0.50 changed module location and librosa hasn't catched up in 7.2 yet
-pip_packages="nose numpy>=1.17 opencv-python pillow librosa numba==0.49"
+pip_packages="nose numpy>=1.17 opencv-python pillow librosa numba<=0.49"
 
 target_dir=./dali/test/python
 

--- a/qa/TL0_python_self_test_frameworks/test_pytorch.sh
+++ b/qa/TL0_python_self_test_frameworks/test_pytorch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 # lock numba version as 0.50 changed module location and librosa hasn't catched up in 7.2 yet
-pip_packages="nose numpy librosa torch numba==0.49"
+pip_packages="nose numpy librosa torch numba<=0.49"
 target_dir=./dali/test/python
 
 test_body() {

--- a/qa/TL1_jupyter_conda/test_nofw.sh
+++ b/qa/TL1_jupyter_conda/test_nofw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 # lock numba version as 0.50 changed module location and librosa hasn't catched up in 7.2 yet
-pip_packages="jupyter numpy matplotlib pillow opencv-python librosa simpleaudio numba==0.49"
+pip_packages="jupyter numpy matplotlib pillow opencv-python librosa simpleaudio numba<=0.49"
 target_dir=./docs/examples
 
 # populate epilog and prolog with variants to enable/disable conda

--- a/qa/TL1_python-self-test-slow/test.sh
+++ b/qa/TL1_python-self-test-slow/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 # lock numba version as 0.50 changed module location and librosa hasn't catched up in 7.2 yet
-pip_packages="nose numpy opencv-python pillow librosa numba==0.49"
+pip_packages="nose numpy opencv-python pillow librosa numba<=0.49"
 target_dir=./dali/test/python
 
 test_body() {

--- a/qa/TL1_python-self-test_conda/test_nofw.sh
+++ b/qa/TL1_python-self-test_conda/test_nofw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 # lock numba version as 0.50 changed module location and librosa hasn't catched up in 7.2 yet
-pip_packages="nose numpy>=1.17 opencv-python pillow librosa numba==0.49"
+pip_packages="nose numpy>=1.17 opencv-python pillow librosa numba<=0.49"
 target_dir=./dali/test/python
 
 # test_body definition is in separate file so it can be used without setup


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a lack of numba==0.49 not working for python 3.5

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     changes locked version of numba to at most 0.49, as 0.47 is the last release for py35
 - Affected modules and functionalities:
     QA tests
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA

**JIRA TASK**: *[NA]*
