### PR TITLE
Add Preemphasis GPU operator

### DIFF
--- a/dali/benchmark/CMakeLists.txt
+++ b/dali/benchmark/CMakeLists.txt
@@ -31,6 +31,7 @@ if (BUILD_BENCHMARK)
     "${CMAKE_CURRENT_SOURCE_DIR}/color_twist_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/slice_kernel_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/slice_kernel_bench.cu"
+    "${CMAKE_CURRENT_SOURCE_DIR}/preemphasis_bench.cc"
   )
 
   if (BUILD_LMDB)

--- a/dali/benchmark/preemphasis_bench.cc
+++ b/dali/benchmark/preemphasis_bench.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+#include "dali/benchmark/operator_bench.h"
+#include "dali/benchmark/dali_bench.h"
+
+namespace dali {
+
+BENCHMARK_DEFINE_F(OperatorBench, PreemphasisGPU)(benchmark::State& st) {
+  int batch_size = st.range(0);
+  int N = st.range(1);
+
+  this->RunGPU<uint8_t>(
+    st,
+    OpSpec("PreemphasisFilter")
+      .AddArg("batch_size", batch_size)
+      .AddArg("num_threads", 1)
+      .AddArg("device", "gpu"),
+    batch_size, {N, }, "t");
+}
+
+BENCHMARK_REGISTER_F(OperatorBench, PreemphasisGPU)->Iterations(1000)
+->Unit(benchmark::kMicrosecond)
+->UseRealTime()
+->Ranges({{1, 256}, {1000, 50000}});
+
+}  // namespace dali

--- a/dali/operators/audio/preemphasis_filter_op.cc
+++ b/dali/operators/audio/preemphasis_filter_op.cc
@@ -13,76 +13,52 @@
 // limitations under the License.
 
 #include "dali/operators/audio/preemphasis_filter_op.h"
-#include "dali/core/static_switch.h"
 
 namespace dali {
 
-
 DALI_SCHEMA(PreemphasisFilter)
-                .DocStr(R"code(This operator performs preemphasis filter on the input data.
+    .DocStr(R"code(This operator performs preemphasis filter on the input data.
 This filter in simple form can be expressed by the formula::
 
-  Y(t) = X(t) - X(t-1)*coeff)code")
-                .NumInput(1)
-                .NumOutput(detail::kNumOutputs)
-                .AddOptionalArg(detail::kCoeff, R"code(Preemphasis coefficient `coeff`)code", 0.97f)
-                .AddOptionalArg(arg_names::kDtype, R"code(Data type for the output)code",
-                                DALI_FLOAT);
+  Y(t) = X[t] - coeff * X[t-1])code")
+    .NumInput(1)
+    .NumOutput(detail::kNumOutputs)
+    .AddOptionalArg(detail::kCoeff, R"code(Preemphasis coefficient `coeff`)code", 0.97f, true)
+    .AddOptionalArg(arg_names::kDtype, R"code(Data type for the output)code", DALI_FLOAT);
 
-DALI_REGISTER_OPERATOR(PreemphasisFilter, PreemphasisFilterCpu, CPU);
-
-#define PREEMPH_TYPES (uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float, double)  // NOLINT
-
-
-bool PreemphasisFilterCpu::SetupImpl(std::vector <OutputDesc> &output_desc,
-                                     const workspace_t <CPUBackend> &ws) {
-  const auto &input = ws.template InputRef<CPUBackend>(0);
-  AcquireArguments(ws);
-  output_desc.resize(detail::kNumOutputs);
-  output_desc[0].shape = input.shape();
-  TYPE_SWITCH(output_type_, type2id, DType, PREEMPH_TYPES, (
-          {
-            TypeInfo type;
-            type.SetType<DType>(output_type_);
-            output_desc[0].type = type;
-          }
-  ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
-  return true;
-}
-
-
-void PreemphasisFilterCpu::RunImpl(workspace_t<CPUBackend> &ws) {
+template <>
+void PreemphasisFilter<CPUBackend>::RunImpl(workspace_t<CPUBackend> &ws) {
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto &output = ws.OutputRef<CPUBackend>(0);
   auto &tp = ws.GetThreadPool();
   TYPE_SWITCH(input.type().id(), type2id, InputType, PREEMPH_TYPES, (
     TYPE_SWITCH(output_type_, type2id, OutputType, PREEMPH_TYPES, (
-          for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
-            tp.DoWorkWithID(
-              [&, sample_id](int thread_id) {
-                const auto in_ptr = input[sample_id].data<InputType>();
-                auto out_ptr = output[sample_id].mutable_data<OutputType>();
-                auto num_samples = volume(output[sample_id].shape());
-                DALI_ENFORCE(input[sample_id].shape() == output[sample_id].shape(),
-                          "Input and output shapes don't match");
-                if (preemph_coeff_[sample_id] == 0.f) {
-                  for (long j = 0; j < num_samples; j++) {  // NOLINT (long)
-                    out_ptr[j] = ConvertSat<OutputType>(in_ptr[j]);
-                  }
-                } else {
-                  for (auto j = num_samples - 1; j > 0; j--) {
-                    out_ptr[j] = ConvertSat<OutputType>(
-                            in_ptr[j] - in_ptr[j - 1] * preemph_coeff_[sample_id]);
-                  }
-                  out_ptr[0] = ConvertSat<OutputType>(in_ptr[0] * preemph_coeff_[sample_id]);
-                }
-              });
-          }
-    ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
-  ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())))  // NOLINT
+      for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
+        tp.DoWorkWithID(
+          [this, &output, &input, sample_id](int thread_id) {
+            const auto in_ptr = input[sample_id].data<InputType>();
+            auto out_ptr = output[sample_id].mutable_data<OutputType>();
+            DALI_ENFORCE(input[sample_id].shape() == output[sample_id].shape(),
+                         "Input and output shapes don't match");
+            auto n = volume(output[sample_id].shape());
+            auto coeff = preemph_coeff_[sample_id];
+            if (coeff == 0.0f) {
+              for (int64_t j = 0; j < n; j++) {
+                out_ptr[j] = ConvertSat<OutputType>(in_ptr[j]);
+              }
+            } else {
+              out_ptr[0] = ConvertSat<OutputType>(in_ptr[0] - coeff * in_ptr[0]);
+              for (int64_t j = 1; j < n; j++) {
+                out_ptr[j] = ConvertSat<OutputType>(in_ptr[j] - coeff * in_ptr[j - 1]);
+              }
+            }
+          });
+      }
+    ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)));  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())));  // NOLINT
   tp.WaitForWork();
 }
 
-#undef PREEMPH_TYPES
+DALI_REGISTER_OPERATOR(PreemphasisFilter, PreemphasisFilter<CPUBackend>, CPU);
 
 }  // namespace dali

--- a/dali/operators/audio/preemphasis_filter_op.cc
+++ b/dali/operators/audio/preemphasis_filter_op.cc
@@ -33,7 +33,9 @@ void PreemphasisFilter<CPUBackend>::RunImpl(workspace_t<CPUBackend> &ws) {
   auto &tp = ws.GetThreadPool();
   TYPE_SWITCH(input.type().id(), type2id, InputType, PREEMPH_TYPES, (
     TYPE_SWITCH(output_type_, type2id, OutputType, PREEMPH_TYPES, (
-      for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
+      while (!sample_queue_.empty()) {
+        auto sample_id = sample_queue_.top().second;
+        sample_queue_.pop();
         tp.DoWorkWithID(
           [this, &output, &input, sample_id](int thread_id) {
             const auto in_ptr = input[sample_id].data<InputType>();

--- a/dali/operators/audio/preemphasis_filter_op.cc
+++ b/dali/operators/audio/preemphasis_filter_op.cc
@@ -36,11 +36,15 @@ class PreemphasisFilterCPU : public PreemphasisFilter<CPUBackend> {
   void RunImpl(workspace_t<CPUBackend> &ws) override;
 
  private:
+  template <typename OutputType, typename InputType>
+  void RunImplTyped(workspace_t<CPUBackend> &ws);
+
   using VolumeSampleIdPair = std::pair<int64_t, int>;  // volume(out_shape), sample_idx
   std::vector<VolumeSampleIdPair> sample_ids_;
 };
 
-void PreemphasisFilterCPU::RunImpl(workspace_t<CPUBackend> &ws) {
+template <typename OutputType, typename InputType>
+void PreemphasisFilterCPU::RunImplTyped(workspace_t<CPUBackend> &ws) {
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto &output = ws.OutputRef<CPUBackend>(0);
   auto &tp = ws.GetThreadPool();
@@ -53,33 +57,38 @@ void PreemphasisFilterCPU::RunImpl(workspace_t<CPUBackend> &ws) {
     sample_ids_.emplace_back(volume(shape[sample_id]), sample_id);
   std::sort(sample_ids_.begin(), sample_ids_.end(), std::greater<VolumeSampleIdPair>());
 
+  for (const auto &sample : sample_ids_) {
+    auto sample_id = sample.second;
+    tp.DoWorkWithID(
+      [this, &output, &input, sample_id](int thread_id) {
+        const auto in_ptr = input[sample_id].data<InputType>();
+        auto out_ptr = output[sample_id].mutable_data<OutputType>();
+        DALI_ENFORCE(input[sample_id].shape() == output[sample_id].shape(),
+                      "Input and output shapes don't match");
+        auto n = volume(output[sample_id].shape());
+        auto coeff = preemph_coeff_[sample_id];
+        if (coeff == 0.0f) {
+          for (int64_t j = 0; j < n; j++) {
+            out_ptr[j] = ConvertSat<OutputType>(in_ptr[j]);
+          }
+        } else {
+          out_ptr[0] = ConvertSat<OutputType>(in_ptr[0] - coeff * in_ptr[0]);
+          for (int64_t j = 1; j < n; j++) {
+            out_ptr[j] = ConvertSat<OutputType>(in_ptr[j] - coeff * in_ptr[j - 1]);
+          }
+        }
+      });
+  }
+  tp.WaitForWork();
+}
+
+void PreemphasisFilterCPU::RunImpl(workspace_t<CPUBackend> &ws) {
+  const auto &input = ws.template InputRef<CPUBackend>(0);
   TYPE_SWITCH(input.type().id(), type2id, InputType, PREEMPH_TYPES, (
     TYPE_SWITCH(output_type_, type2id, OutputType, PREEMPH_TYPES, (
-      for (const auto &sample : sample_ids_) {
-        auto sample_id = sample.second;
-        tp.DoWorkWithID(
-          [this, &output, &input, sample_id](int thread_id) {
-            const auto in_ptr = input[sample_id].data<InputType>();
-            auto out_ptr = output[sample_id].mutable_data<OutputType>();
-            DALI_ENFORCE(input[sample_id].shape() == output[sample_id].shape(),
-                         "Input and output shapes don't match");
-            auto n = volume(output[sample_id].shape());
-            auto coeff = preemph_coeff_[sample_id];
-            if (coeff == 0.0f) {
-              for (int64_t j = 0; j < n; j++) {
-                out_ptr[j] = ConvertSat<OutputType>(in_ptr[j]);
-              }
-            } else {
-              out_ptr[0] = ConvertSat<OutputType>(in_ptr[0] - coeff * in_ptr[0]);
-              for (int64_t j = 1; j < n; j++) {
-                out_ptr[j] = ConvertSat<OutputType>(in_ptr[j] - coeff * in_ptr[j - 1]);
-              }
-            }
-          });
-      }
+      RunImplTyped<OutputType, InputType>(ws);
     ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)));  // NOLINT
   ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())));  // NOLINT
-  tp.WaitForWork();
 }
 
 DALI_REGISTER_OPERATOR(PreemphasisFilter, PreemphasisFilterCPU, CPU);

--- a/dali/operators/audio/preemphasis_filter_op.cu
+++ b/dali/operators/audio/preemphasis_filter_op.cu
@@ -71,7 +71,7 @@ void PreemphasisFilter<GPUBackend>::RunImpl(workspace_t<GPUBackend> &ws) {
       CUDA_CALL(
         cudaMemcpyAsync(sample_descs_gpu, samples_cpu.data(), sz, cudaMemcpyHostToDevice, stream));
 
-      int block = 1024;
+      int block = 256;
       auto blocks_per_sample = std::max(32, 1024 / batch_size_);
       dim3 grid(blocks_per_sample, batch_size_);
       detail::PreemphasisFilterKernel<<<grid, block, 0, stream>>>(sample_descs_gpu);

--- a/dali/operators/audio/preemphasis_filter_op.cu
+++ b/dali/operators/audio/preemphasis_filter_op.cu
@@ -46,8 +46,16 @@ void __global__ PreemphasisFilterKernel(const SampleDescriptor<OutputType, Input
 
 }  // namespace detail
 
-template <>
-void PreemphasisFilter<GPUBackend>::RunImpl(workspace_t<GPUBackend> &ws) {
+class PreemphasisFilterGPU : public PreemphasisFilter<GPUBackend> {
+ public:
+  explicit PreemphasisFilterGPU(const OpSpec &spec) : PreemphasisFilter<GPUBackend>(spec) {}
+  void RunImpl(workspace_t<GPUBackend> &ws) override;
+
+ private:
+  Tensor<GPUBackend> scratchpad_;
+};
+
+void PreemphasisFilterGPU::RunImpl(workspace_t<GPUBackend> &ws) {
   const auto &input = ws.InputRef<GPUBackend>(0);
   auto &output = ws.OutputRef<GPUBackend>(0);
   TYPE_SWITCH(input.type().id(), type2id, InputType, PREEMPH_TYPES, (
@@ -80,6 +88,6 @@ void PreemphasisFilter<GPUBackend>::RunImpl(workspace_t<GPUBackend> &ws) {
   ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())));  // NOLINT
 }
 
-DALI_REGISTER_OPERATOR(PreemphasisFilter, PreemphasisFilter<GPUBackend>, GPU);
+DALI_REGISTER_OPERATOR(PreemphasisFilter, PreemphasisFilterGPU, GPU);
 
 }  // namespace dali

--- a/dali/operators/audio/preemphasis_filter_op.cu
+++ b/dali/operators/audio/preemphasis_filter_op.cu
@@ -1,0 +1,80 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/audio/preemphasis_filter_op.h"
+#include <vector>
+
+namespace dali {
+
+namespace detail {
+
+template <typename OutputType, typename InputType>
+struct SampleDescriptor {
+  const InputType *in;
+  OutputType *out;
+  float coeff;
+  int64_t size;
+};
+
+template <typename OutputType, typename InputType>
+void __global__ PreemphasisFilterKernel(const SampleDescriptor<OutputType, InputType> *samples) {
+  const auto &sample = samples[blockIdx.y];
+  int64_t block_size = blockDim.x;
+  int64_t block_start = block_size * blockIdx.x;
+  int64_t grid_stride = block_size * gridDim.x;
+  for (int64_t k = block_start + threadIdx.x; k < sample.size; k += grid_stride) {
+    auto prev = cuda_max(k-1, 0l);
+    sample.out[k] = sample.in[k] - sample.coeff * sample.in[prev];
+  }
+}
+
+}  // namespace detail
+
+template <>
+void PreemphasisFilter<GPUBackend>::RunImpl(workspace_t<GPUBackend> &ws) {
+  const auto &input = ws.InputRef<GPUBackend>(0);
+  auto &output = ws.OutputRef<GPUBackend>(0);
+  TYPE_SWITCH(input.type().id(), type2id, InputType, PREEMPH_TYPES, (
+    TYPE_SWITCH(output_type_, type2id, OutputType, PREEMPH_TYPES, (
+      using SampleDesc = detail::SampleDescriptor<OutputType, InputType>;
+
+      std::vector<SampleDesc> samples_cpu(batch_size_);
+      for (int sample_idx = 0; sample_idx < batch_size_; sample_idx++) {
+        auto &sample = samples_cpu[sample_idx];
+        sample.in = input.tensor<InputType>(sample_idx);
+        sample.out = output.mutable_tensor<OutputType>(sample_idx);
+        sample.size = volume(input.tensor_shape(sample_idx));
+        sample.coeff = preemph_coeff_[sample_idx];
+      }
+
+      scratchpad_.set_type(TypeInfo::Create<uint8_t>());
+      int64_t sz = batch_size_ * sizeof(SampleDesc);
+      scratchpad_.Resize({sz});
+      auto sample_descs_gpu = reinterpret_cast<SampleDesc*>(scratchpad_.mutable_data<uint8_t>());
+      auto stream = ws.stream();
+      CUDA_CALL(
+        cudaMemcpyAsync(sample_descs_gpu, samples_cpu.data(), sz, cudaMemcpyHostToDevice, stream));
+
+      int block = 1024;
+      auto blocks_per_sample = std::max(32, 1024 / batch_size_);
+      dim3 grid(blocks_per_sample, batch_size_);
+      detail::PreemphasisFilterKernel<<<grid, block, 0, stream>>>(sample_descs_gpu);
+
+    ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)));  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())));  // NOLINT
+}
+
+DALI_REGISTER_OPERATOR(PreemphasisFilter, PreemphasisFilter<GPUBackend>, GPU);
+
+}  // namespace dali

--- a/dali/operators/audio/preemphasis_filter_op.h
+++ b/dali/operators/audio/preemphasis_filter_op.h
@@ -18,6 +18,7 @@
 #include <random>
 #include <vector>
 #include <queue>
+#include <utility>
 #include "dali/core/convert.h"
 #include "dali/core/static_switch.h"
 #include "dali/pipeline/data/types.h"

--- a/dali/test/python/test_operator_preemph.py
+++ b/dali/test/python/test_operator_preemph.py
@@ -17,54 +17,83 @@ from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
 import numpy as np
+from functools import partial
+from test_utils import compare_pipelines
+from test_utils import RandomlyShapedDataIterator
 
-sample_size = 100
-premade_batch = [np.random.rand(sample_size)]
+SEED = 12345
 
-
-def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
-    """
-    Python2.7 doesn't have math.isclose()
-    """
-    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
-
-
-def preemph(signal, coeff=0.0):
-    ret = np.copy(signal)
-    if coeff == 0.0:
-        return ret
-    for i in range(sample_size - 1, 0, -1):
-        ret[i] -= coeff * ret[i - 1]
-    ret[0] -= coeff * ret[0]
-    return ret
-
+def preemph_func(coeff, signal):
+    in_shape = signal.shape
+    assert(len(in_shape) == 1)  # 1D
+    out = np.copy(signal)
+    out[0]  -= coeff * signal[0]
+    out[1:] -= coeff * signal[0:in_shape[0]-1]
+    return out
 
 class PreemphasisPipeline(Pipeline):
-    def __init__(self, preemph_coeff=0., num_threads=1):
-        super(PreemphasisPipeline, self).__init__(1, num_threads, 0)
+    def __init__(self, device, batch_size, iterator, preemph_coeff=0.97, per_sample_coeff=False, num_threads=4, device_id=0):
+        super(PreemphasisPipeline, self).__init__(batch_size, num_threads, device_id, seed=SEED)
+        self.device = device
+        self.iterator = iterator
         self.ext_src = ops.ExternalSource()
-        self.preemph = ops.PreemphasisFilter(preemph_coeff=preemph_coeff, device="cpu")
+        self.per_sample_coeff = per_sample_coeff
+        self.uniform = ops.Uniform(range=(0.5, 0.97), seed=1234)
+        if self.per_sample_coeff:
+            self.preemph = ops.PreemphasisFilter(device=device)
+        else:
+            self.preemph = ops.PreemphasisFilter(device=device, preemph_coeff=preemph_coeff)
 
     def define_graph(self):
         self.data = self.ext_src()
-        return self.preemph(self.data)
+        out = self.data.gpu() if self.device == 'gpu' else self.data
+        if self.per_sample_coeff:
+            preemph_coeff_arg = self.uniform()
+            return self.preemph(out, preemph_coeff=preemph_coeff_arg)
+        else:
+            return self.preemph(out)
 
     def iter_setup(self):
-        self.feed_input(self.data, premade_batch)
+        data = self.iterator.next()
+        self.feed_input(self.data, data)
 
+class PreemphasisPythonPipeline(Pipeline):
+    def __init__(self, device, batch_size, iterator, preemph_coeff=0.97, per_sample_coeff=False, num_threads=4, device_id=0):
+        super(PreemphasisPythonPipeline, self).__init__(batch_size, num_threads, device_id, seed=SEED,
+                                                        exec_async=False, exec_pipelined=False)
+        self.device = "cpu"
+        self.iterator = iterator
+        self.ext_src = ops.ExternalSource()
+        self.per_sample_coeff = per_sample_coeff
+        self.uniform = ops.Uniform(range=(0.5, 0.97), seed=1234)
+        if self.per_sample_coeff:
+            function = preemph_func
+        else:
+            function = partial(preemph_func, preemph_coeff)
+        self.preemph = ops.PythonFunction(function=function)
 
-def check_preemphasis_operator(preemph_coeff):
-    eps = 1e-5
-    pipeline = PreemphasisPipeline(preemph_coeff=preemph_coeff)
-    pipeline.build()
-    outputs = pipeline.run()
-    reference_signal = preemph(premade_batch[0], preemph_coeff)
-    for i in range(sample_size):
-        a = outputs[0].at(0)[i]
-        b = reference_signal[i]
-        assert isclose(a, b, abs_tol=eps)
+    def define_graph(self):
+        self.data = self.ext_src()
+        if self.per_sample_coeff:
+            coef = self.uniform()
+            return self.preemph(coef, self.data)
+        else:
+            return self.preemph(self.data)
 
+    def iter_setup(self):
+        data = self.iterator.next()
+        self.feed_input(self.data, data)
+
+def check_preemphasis_operator(device, batch_size, preemph_coeff, per_sample_coeff):
+    eii1 = RandomlyShapedDataIterator(batch_size, min_shape=(100, ), max_shape=(10000, ), dtype=np.float32)
+    eii2 = RandomlyShapedDataIterator(batch_size, min_shape=(100, ), max_shape=(10000, ), dtype=np.float32)
+    compare_pipelines(
+        PreemphasisPipeline(device, batch_size, iter(eii1), preemph_coeff=preemph_coeff, per_sample_coeff=per_sample_coeff),
+        PreemphasisPythonPipeline(device, batch_size, iter(eii2), preemph_coeff=preemph_coeff, per_sample_coeff=per_sample_coeff),
+        batch_size=batch_size, N_iterations=3)
 
 def test_preemphasis_operator():
-    for coef in [0.5, 0.0]:
-       yield check_preemphasis_operator, coef
+    for device in ['cpu', 'gpu']:
+        for batch_size in [1, 3, 128]:
+            for coef, per_sample_coeff in [(0.97, False), (0.0, False), (None, True)]:
+                yield check_preemphasis_operator, device, batch_size, coef, per_sample_coeff


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed because we need an implementation of Preemphasis filter for the GPU

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Fixed Preemphasis schema to show it supports per-sample preemphasis coefficient*
     *Added Preemphasis GPU operator*
     *Extended cases to cover variable sample size, bs>1 and multiple iterations*
     *Fixed calculation of sample 0 to match Kaldi implementation (`out[0] = in[0] - coef*in[0]`)
 - Affected modules and functionalities:
     *Preemphasis operator*
 - Key points relevant for the review:
     *Preemphasis GPU operator implementation and tests*
 - Validation and testing:
     *Operator tests added*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1461]*
