### PR TITLE
Makes TF RN50 TL3 test to compile ahead of time

### DIFF
--- a/qa/TL3_RN50_convergence/test_tensorflow.sh
+++ b/qa/TL3_RN50_convergence/test_tensorflow.sh
@@ -22,6 +22,8 @@ LOG=dali.log
 OUT=${LOG%.log}.dir
 
 SECONDS=0
+export TF_XLA_FLAGS="--tf_xla_enable_lazy_compilation=false"
+
 mpiexec --allow-run-as-root --bind-to socket -np ${NUM_GPUS} \
     python -u resnet.py --layers=50 \
     --data_dir=$DATA_SET_DIR --data_idx_dir=idx-files/ \


### PR DESCRIPTION
- makes XLA compile ahead to the training to reduce the peak memory usage

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a OOM in TensorFlow RN50 test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     makes XLA compile ahead to the training to reduce the peak memory usage
 - Affected modules and functionalities:
     TL3 RN50 test
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI TL3 RN50 test
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
