### PR TITLE
Fix semantics of the masks_meta field

### DIFF
--- a/dali/operators/reader/coco_reader_op_test.cc
+++ b/dali/operators/reader/coco_reader_op_test.cc
@@ -358,15 +358,19 @@ class CocoReaderTest : public ::testing::Test {
   const int number_of_polygons_ = 9;
 
   std::vector<int> masks_meta_gt_ {
+    // image 0
     0, 0, 10,
+    // image 1
     0, 0, 6,
-    0, 6, 6,
+    0, 6, 12,
+    // image 2
     0, 0, 12,
+    // image 3
     0, 0, 6,
     1, 6, 20,
     2, 20, 28,
     3, 28, 38,
-    3, 38, 34,
+    3, 38, 44,
   };
 
   std::vector<float> masks_coords_gt_ {

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -219,7 +219,7 @@ void parse_annotations(
             segm_coords.push_back(parser.GetDouble());
             coord_offset++;
           }
-          segm_meta.push_back(coord_offset - segm_meta.back());
+          segm_meta.push_back(coord_offset);
         }
       } else {
         parser.SkipValue();


### PR DESCRIPTION
As per the documentation of the COCOReader Ops, the masks_meta
output is defined as a list of tuples (mask_idx, start_idx, end_idx)
where start_idx indicates the index of the first coords in masks_coords.

Now it's not explicit what the meaning of end_idx is, but one could
reasonably expect it to be the index of the last coords in masks_coords.

It's not though, in the case where the annotation is not a polygon but a
list of polygons. This is actually reflected in the Reader's unit test :
for example the last annotation spans 2 polygons, and the masks_meta for
them is
3, 28, 38,
3, 38, 34,
where the end_idx of the second annotation is smaller than its
start_idx.

I took the liberty to align the semantics with the documentation, since
it seems to me that it's much easier to interpret that way.

Unit test updated to reflect the change.
