### PR TITLE
Use empty tensors for DL FW plugins instead of zeroed one

### DIFF
--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -204,7 +204,7 @@ class DALIGenericIterator(_DaliBaseIterator):
 
                 pyt_tensors = dict()
                 for category in self._output_categories:
-                    pyt_tensors[category] = torch.zeros(category_shapes[category],
+                    pyt_tensors[category] = torch.empty(category_shapes[category],
                                                         dtype=category_torch_type[category],
                                                         device=category_device[category])
 
@@ -215,7 +215,7 @@ class DALIGenericIterator(_DaliBaseIterator):
             # Copy data from DALI Tensors to torch tensors
             for category, tensor in category_tensors.items():
                 if self._dynamic_shape and tensor.shape() != list(pyt_tensors[category].size()):
-                    pyt_tensors[category] = torch.zeros(category_shapes[category],
+                    pyt_tensors[category] = torch.empty(category_shapes[category],
                                                         dtype=pyt_tensors[category].dtype,
                                                         device=pyt_tensors[category].device)
                 if isinstance(tensor, (TensorGPU, TensorListGPU)):

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -430,7 +430,7 @@ def test_gluon_iterator_sparse_batch():
     for it in dali_train_iter:
         labels, ids = it[0] # gpu 0
         # labels should be a sparse batch: a list of per-sample NDArray's
-        # ids should be a dense batch: a single NDarray reprenseting the batch
+        # ids should be a dense batch: a single NDarray representing the batch
         assert isinstance(labels, (tuple,list))
         assert len(labels) == batch_size
         assert isinstance(labels[0], NDArray)


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- make the DL FW plugins to use empty tensors so it should save time on zeroing it

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     use empty tensors for DL FW plugins instead of zeroed one
 - Affected modules and functionalities:
     DL FW iterators
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA

**JIRA TASK**: *[NA]*