### PR TITLE
Use memory hint in the resize to allocate a buffer in the pipeline build phase 

### DIFF
--- a/dali/operators/image/resize/resize_base.cc
+++ b/dali/operators/image/resize/resize_base.cc
@@ -117,7 +117,6 @@ void ResizeBase::RunGPU(TensorList<GPUBackend> &output,
 
   auto out_view = view<uint8_t, 3>(output);
   SubdivideOutput(out_view);
-  kmgr_.ReserveMaxScratchpad(0);
 
   for (size_t b = 0; b < minibatches_.size(); b++) {
     MiniBatch &mb = minibatches_[b];
@@ -151,6 +150,7 @@ void ResizeBase::InitializeGPU(int batch_size, int mini_batch_size) {
   }
 
   kmgr_.SetMemoryHint(kernels::AllocType::GPU, temp_buffer_hint_);
+  kmgr_.ReserveMaxScratchpad(0);
 }
 
 void ResizeBase::RunCPU(Tensor<CPUBackend> &output,


### PR DESCRIPTION
#### Why we need this PR?
- It makes the resize operator use memory hint to allocate intermediate buffer in the initialization phase.

#### What happened in this PR?
 - What solution was applied:
     *Hint memory allocation was moved from `Run` to the operator construction.*
 - Affected modules and functionalities:
     *resize base*
 - Key points relevant for the review:
     *two lines that were changed*
 - Validation and testing:
     *All existing tests are passing. I've also verified with nvprof that now the intermediate buffer allocation happens within the `pipe.build()`*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *DALI-1420*
