### PR TITLE
Add GaussianBlur CPU Op

### DIFF
--- a/dali/core/tensor_layout_test.cc
+++ b/dali/core/tensor_layout_test.cc
@@ -213,11 +213,15 @@ TEST(TensorLayout, SampleLayout) {
 
 TEST(TensorLayout, VideoLayout) {
   EXPECT_TRUE(VideoLayoutInfo::IsVideo("NFCHW"));
+  EXPECT_TRUE(VideoLayoutInfo::IsVideo("FCHW"));
   EXPECT_FALSE(VideoLayoutInfo::IsStillImage("NFCHW"));
   EXPECT_TRUE(VideoLayoutInfo::IsChannelFirst("NFCHW"));
   EXPECT_FALSE(VideoLayoutInfo::IsChannelFirst("NFHWC"));
   EXPECT_EQ(VideoLayoutInfo::FrameDimIndex("NFCHW"), 1);
   EXPECT_FALSE(VideoLayoutInfo::IsSequence("NDCHW"));
+  EXPECT_TRUE(VideoLayoutInfo::IsSequence("FDCHW"));
+  EXPECT_FALSE(VideoLayoutInfo::IsSequence("DFCHW"));
+  EXPECT_TRUE(VideoLayoutInfo::HasSequence("DFCHW"));
   EXPECT_TRUE(VideoLayoutInfo::IsStillImage("NDCHW"));
   EXPECT_EQ(VideoLayoutInfo::GetFrameLayout("FCHW"), TensorLayout("CHW"));
   EXPECT_EQ(VideoLayoutInfo::GetFrameLayout("NFHWC"), TensorLayout("NHWC"));

--- a/dali/core/tensor_layout_test.cu
+++ b/dali/core/tensor_layout_test.cu
@@ -158,11 +158,15 @@ DEVICE_TEST(TensorLayout_Dev, SampleLayout, 1, 1) {
 
 DEVICE_TEST(TensorLayout_Dev, VideoLayout, 1, 1) {
   DEV_EXPECT_TRUE(VideoLayoutInfo::IsVideo("NFCHW"));
+  DEV_EXPECT_TRUE(VideoLayoutInfo::IsVideo("FCHW"));
   DEV_EXPECT_FALSE(VideoLayoutInfo::IsStillImage("NFCHW"));
   DEV_EXPECT_TRUE(VideoLayoutInfo::IsChannelFirst("NFCHW"));
   DEV_EXPECT_FALSE(VideoLayoutInfo::IsChannelFirst("NFHWC"));
   DEV_EXPECT_EQ(VideoLayoutInfo::FrameDimIndex("NFCHW"), 1);
   DEV_EXPECT_FALSE(VideoLayoutInfo::IsSequence("NDCHW"));
+  DEV_EXPECT_TRUE(VideoLayoutInfo::IsSequence("FDCHW"));
+  DEV_EXPECT_FALSE(VideoLayoutInfo::IsSequence("DFCHW"));
+  DEV_EXPECT_TRUE(VideoLayoutInfo::HasSequence("DFCHW"));
   DEV_EXPECT_TRUE(VideoLayoutInfo::IsStillImage("NDCHW"));
 }
 

--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -1,0 +1,272 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "dali/core/static_switch.h"
+#include "dali/kernels/imgproc/convolution/separable_convolution_cpu.h"
+#include "dali/kernels/kernel_manager.h"
+#include "dali/operators/image/convolution/gaussian_blur.h"
+#include "dali/operators/image/convolution/gaussian_blur_params.h"
+#include "dali/pipeline/data/views.h"
+#include "dali/pipeline/operator/common.h"
+
+namespace dali {
+
+constexpr static const char* kSigmaArgName = "sigma";
+constexpr static const char* kWindowSizeArgName = "window_size";
+
+DALI_SCHEMA(GaussianBlur)
+    .DocStr(R"code(Apply Gaussian Blur to the input.
+Separable convolution with Gaussian Kernel is used to calculate the output.
+
+User can specify the sigma or kernel window size.
+If only the sigma is provided, the radius is of kernel is calculated ``ceil(3 * sigma)``,
+thus the kernel window size is ``2 * ceil(3 * sigma) + 1``.
+
+If only the kernel window size is provided, the sigma is calculated using the following formula::
+
+  radius = (window_size - 1) / 2
+  sigma = (radius - 1) * 0.3 + 0.8
+
+Both sigma and kernel window size can be specified as single value for all data axes
+or per data axis.
+
+When specifying the sigma or window size per axis, they are provided same as layouts: from outermost
+to innermost.
+The channel ``C`` and frame ``F`` dimensions are not considered data axes.
+
+For example, with ``HWC`` input, user can provide ``sigma=1.0`` or ``sigma=(1.0, 2.0)`` as there
+are two data axes H and W.
+
+The same input can be provided as per-sample tensors.
+)code")
+    .NumInput(1)
+    .NumOutput(1)
+    .AllowSequences()
+    .SupportVolumetric()
+    .AddOptionalArg(kWindowSizeArgName, "The diameter of kernel.", std::vector<int>{0}, true)
+    .AddOptionalArg<float>(kSigmaArgName, R"code(Sigma value for Gaussian Kernel.)code",
+                           std::vector<float>{0.f}, true);
+
+/**
+ * @brief Fill the result span with the argument which can be provided as:
+ * * ArgumentInput - {result.size()}-shaped Tensor
+ * * ArgumentInput - {1}-shaped Tensor, the value will be replicated `result.size()` times
+ * * Vector input - single "repeated argument" of length {result.size()} or {1}
+ * * scalar argument - it will be replicated `result.size()` times
+ *
+ * TODO(klecki): we may want to make this a generic utility and propagate the span-approach to
+ * the rest of the related argument gettters
+ */
+template <typename T>
+void GetGeneralizedArg(span<T> result, const std::string name, int sample_idx, const OpSpec& spec,
+                       const ArgumentWorkspace& ws) {
+  int argument_length = result.size();
+  if (spec.HasTensorArgument(name)) {
+    const auto& tv = ws.ArgumentInput(name);
+    const auto& tensor = tv[sample_idx];
+    DALI_ENFORCE(tensor.shape().sample_dim() == 1,
+                 make_string("Argument ", name, " for sample ", sample_idx,
+                             " is expected to be 1D, got: ", tensor.shape().sample_dim(), "."));
+    DALI_ENFORCE(tensor.shape()[0] == 1 || tensor.shape()[0] == argument_length,
+                 make_string("Argument ", name, " for sample ", sample_idx,
+                             " is expected to have shape equal {1} or {", argument_length,
+                             "}, got: ", tensor.shape(), "."));
+    if (tensor.shape()[0] == 1) {
+      for (int i = 0; i < argument_length; i++) {
+        result[i] = tensor.data<T>()[0];
+      }
+    } else {
+      memcpy(result.data(), tensor.data<T>(), sizeof(T) * argument_length);
+    }
+    return;
+  }
+  std::vector<T> tmp;
+  // we already handled the argument input, this handles spec-related arguments only
+  GetSingleOrRepeatedArg(spec, tmp, name, argument_length);
+  memcpy(result.data(), tmp.data(), sizeof(T) * argument_length);
+}
+
+template <int axes>
+GaussianSampleParams<axes> GetSampleParams(int sample, const OpSpec& spec,
+                                           const ArgumentWorkspace& ws) {
+  GaussianSampleParams<axes> params;
+  GetGeneralizedArg<float>(make_span(params.sigmas), kSigmaArgName, sample, spec, ws);
+  GetGeneralizedArg<int>(make_span(params.window_sizes), kWindowSizeArgName, sample, spec, ws);
+  for (int i = 0; i < axes; i++) {
+    DALI_ENFORCE(
+        !(params.sigmas[i] == 0 && params.window_sizes[i] == 0),
+        make_string("`sigma` and `window_size` shouldn't be 0 at the same time for sample: ",
+                    sample, ", axis: ", i, "."));
+    DALI_ENFORCE(params.sigmas[i] >= 0,
+                 make_string("`sigma` must have non-negative values, got ", params.sigmas[i],
+                             " for sample: ", sample, ", axis: ", i, "."));
+    DALI_ENFORCE(params.window_sizes[i] >= 0,
+                 make_string("`window_size` must have non-negative values, got ",
+                             params.window_sizes[i], " for sample: ", sample, ", axis : ", i, "."));
+    if (params.window_sizes[i] == 0 && params.sigmas[i] > 0.f) {
+      params.window_sizes[i] = GaussianSigmaToDiameter(params.sigmas[i]);
+    } else if (params.sigmas[i] == 0.f && params.window_sizes[i] > 0) {
+      params.sigmas[i] = GaussianDiameterToSigma(params.window_sizes[i]);
+    }
+  }
+  return params;
+}
+
+GaussianDimDesc ParseAndValidateDim(int ndim, TensorLayout layout) {
+  static constexpr int kMaxDim = 3;
+  if (layout.empty()) {
+    // assuming plain data with no channels
+    DALI_ENFORCE(ndim <= kMaxDim,
+                 make_string("Input data with empty layout cannot have more than ", kMaxDim,
+                             " dimensions, got input with ", ndim, " dimensions."));
+    return {0, ndim, false, false};
+  }
+  // not-empty layout
+  int axes_start = 0;
+  int axes_count = ndim;
+  bool has_channels = ImageLayoutInfo::HasChannel(layout);
+  if (has_channels) {
+    axes_count--;
+    DALI_ENFORCE(ImageLayoutInfo::IsChannelLast(layout),
+                 "Only input data with no channels or channel-last is supported.");
+  }
+  bool is_sequence = layout.find('F') >= 0;
+  if (is_sequence) {
+    axes_start++;
+    axes_count--;
+    DALI_ENFORCE(
+        layout.find('F') == 0,
+        make_string("For sequence inputs frames 'F' should be the first dimension, got layout: \"",
+                    layout.str(), "\"."));
+  }
+  DALI_ENFORCE(axes_count <= kMaxDim,
+               make_string("Too many dimensions, found: ", axes_count,
+                           " data axes, maximum supported is: ", kMaxDim, "."));
+  return {axes_start, axes_count, has_channels, is_sequence};
+}
+
+// axes here is dimension of element processed by kernel - in case of sequence it's 1 less than the
+// actual dim
+template <typename T, int axes, bool has_channels>
+class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
+ public:
+  using Kernel = kernels::SeparableConvolutionCpu<T, T, float, axes, has_channels>;
+  static constexpr int ndim = Kernel::ndim;
+
+  explicit GaussianBlurOpCpu(const OpSpec& spec, const GaussianDimDesc& dim_desc)
+      : spec_(spec), batch_size_(spec.GetArgument<int>("batch_size")), dim_desc_(dim_desc) {}
+
+  bool SetupImpl(std::vector<OutputDesc>& output_desc, const workspace_t<CPUBackend>& ws) override {
+    const auto& input = ws.template InputRef<CPUBackend>(0);
+    int nsamples = input.size();
+    auto nthreads = ws.GetThreadPool().size();
+
+    output_desc.resize(1);
+    output_desc[0].type = input.type();
+    output_desc[0].shape.resize(nsamples, input.shape().sample_dim());
+
+    params_.resize(nsamples);
+    windows_.resize(nsamples);
+
+    kmgr_.template Initialize<Kernel>();
+    kmgr_.template Resize<Kernel>(nthreads, nsamples);
+
+    for (int i = 0; i < nsamples; i++) {
+      params_[i] = GetSampleParams<axes>(i, spec_, ws);
+      windows_[i].PrepareWindows(params_[i]);
+      // We take only last `ndim` siginificant dimensions to handle sequences as well
+      auto elem_shape = input[i].shape().template last<ndim>();
+      auto& req = kmgr_.Setup<Kernel>(i, ctx_, elem_shape, params_[i].window_sizes);
+      // The shape of data stays untouched
+      output_desc[0].shape.set_tensor_shape(i, input[i].shape());
+    }
+    return true;
+  }
+
+  void RunImpl(workspace_t<CPUBackend>& ws) override {
+    const auto& input = ws.template InputRef<CPUBackend>(0);
+    auto& output = ws.template OutputRef<CPUBackend>(0);
+    auto in_shape = input.shape();
+    auto& thread_pool = ws.GetThreadPool();
+
+    for (int i = 0; i < input.shape().num_samples(); i++) {
+      int seq_elements = 1;
+      int64_t stride = 0;
+      if (dim_desc_.is_sequence) {
+        auto shape = input[i].shape();
+        seq_elements = shape[0];
+        stride = volume(shape.begin() + 1, shape.end());
+      }
+      for (int elem_idx = 0; elem_idx < seq_elements; elem_idx++) {
+        thread_pool.DoWorkWithID([this, &input, &output, i, elem_idx, stride](int thread_id) {
+          auto gaussian_windows = windows_[i].GetWindows();
+          auto elem_shape = input[i].shape().template last<ndim>();
+          auto in_view = TensorView<StorageCPU, const T, ndim>{
+              input[i].template data<T>() + stride * elem_idx, elem_shape};
+          auto out_view = TensorView<StorageCPU, T, ndim>{
+              output[i].template mutable_data<T>() + stride * elem_idx, elem_shape};
+          // I need a context for that particular run (or rather matching the thread & scratchpad)
+          auto ctx = ctx_;
+          kmgr_.Run<Kernel>(thread_id, i, ctx, out_view, in_view, gaussian_windows);
+        });
+      }
+    }
+    thread_pool.WaitForWork();
+  }
+
+ private:
+  OpSpec spec_;
+  int batch_size_ = 0;
+
+  kernels::KernelManager kmgr_;
+  kernels::KernelContext ctx_;
+
+  GaussianDimDesc dim_desc_;
+  std::vector<GaussianSampleParams<axes>> params_;
+  std::vector<GaussianWindows<axes>> windows_;
+};
+
+template <>
+bool GaussianBlur<CPUBackend>::SetupImpl(std::vector<OutputDesc>& output_desc,
+                                         const workspace_t<CPUBackend>& ws) {
+  const auto& input = ws.template InputRef<CPUBackend>(0);
+  auto layout = input.GetLayout();
+  auto dim_desc = ParseAndValidateDim(input.shape().sample_dim(), layout);
+
+  // clang-format off
+  TYPE_SWITCH(input.type().id(), type2id, T, GAUSSIAN_BLUR_SUPPORTED_TYPES, (
+    VALUE_SWITCH(dim_desc.usable_axes_count, AXES, GAUSSIAN_BLUR_SUPPORTED_AXES, (
+      VALUE_SWITCH(static_cast<int>(dim_desc.has_channels), HAS_CHANNELS, (0, 1), (
+        constexpr bool has_channels = HAS_CHANNELS;
+        impl_ = std::make_unique<GaussianBlurOpCpu<T, AXES, has_channels>>(spec_, dim_desc);
+      ), (DALI_FAIL("Got value different than {0, 1} when converting bool to int."))); // NOLINT
+    ), DALI_FAIL("Axis count out of supported range."));  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported data type: ", input.type().id())));  // NOLINT
+  // clang-format on
+
+  return impl_->SetupImpl(output_desc, ws);
+}
+
+template <>
+void GaussianBlur<CPUBackend>::RunImpl(workspace_t<CPUBackend>& ws) {
+  impl_->RunImpl(ws);
+}
+
+DALI_REGISTER_OPERATOR(GaussianBlur, GaussianBlur<CPUBackend>, CPU);
+
+}  // namespace dali

--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -37,7 +37,7 @@ DALI_SCHEMA(GaussianBlur)
     .DocStr(R"code(Apply Gaussian Blur to the input.
 
 User can specify sigma, kernel window size or both.
-If only the sigma is provided, the radius is of kernel is calculated ``ceil(3 * sigma)``,
+If only the sigma is provided, the radius of kernel is calculated as ``ceil(3 * sigma)``,
 thus the kernel window size is ``2 * ceil(3 * sigma) + 1``.
 
 If only the kernel window size is provided, the sigma is calculated using the following formula::

--- a/dali/operators/image/convolution/gaussian_blur.h
+++ b/dali/operators/image/convolution/gaussian_blur.h
@@ -30,7 +30,8 @@ namespace dali {
 template <typename Backend>
 class GaussianBlur : public Operator<Backend> {
  public:
-  inline explicit GaussianBlur(const OpSpec& spec) : Operator<Backend>(spec) {}
+  inline explicit GaussianBlur(const OpSpec& spec)
+      : Operator<Backend>(spec), dtype_(spec.GetArgument<DALIDataType>("dtype")) {}
 
   DISABLE_COPY_MOVE_ASSIGN(GaussianBlur);
 
@@ -44,6 +45,7 @@ class GaussianBlur : public Operator<Backend> {
   void RunImpl(workspace_t<Backend>& ws) override;
 
  private:
+  DALIDataType dtype_ = DALI_NO_TYPE;
   USE_OPERATOR_MEMBERS();
   std::unique_ptr<OpImplBase<Backend>> impl_;
 };

--- a/dali/operators/image/convolution/gaussian_blur.h
+++ b/dali/operators/image/convolution/gaussian_blur.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_IMAGE_CONVOLUTION_GAUSSIAN_BLUR_H_
+#define DALI_OPERATORS_IMAGE_CONVOLUTION_GAUSSIAN_BLUR_H_
+
+#include <memory>
+#include <vector>
+
+#include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/util/operator_impl_utils.h"
+
+namespace dali {
+
+#define GAUSSIAN_BLUR_SUPPORTED_TYPES \
+  (uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float, float16)
+
+#define GAUSSIAN_BLUR_SUPPORTED_AXES (1, 2, 3)
+template <typename Backend>
+class GaussianBlur : public Operator<Backend> {
+ public:
+  inline explicit GaussianBlur(const OpSpec& spec) : Operator<Backend>(spec) {}
+
+  DISABLE_COPY_MOVE_ASSIGN(GaussianBlur);
+
+ protected:
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
+  bool SetupImpl(std::vector<OutputDesc>& output_desc, const workspace_t<Backend>& ws) override;
+
+  void RunImpl(workspace_t<Backend>& ws) override;
+
+ private:
+  USE_OPERATOR_MEMBERS();
+  std::unique_ptr<OpImplBase<Backend>> impl_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_IMAGE_CONVOLUTION_GAUSSIAN_BLUR_H_

--- a/dali/operators/image/convolution/gaussian_blur_params.h
+++ b/dali/operators/image/convolution/gaussian_blur_params.h
@@ -48,7 +48,7 @@ struct GaussianBlurParams {
 
   bool IsUniform() const {
     for (int i = 1; i < axes; i++) {
-      if (sigmas[i - 1] != sigmas[i] || window_sizes[i - 1] != window_sizes[i]) {
+      if (sigmas[0] != sigmas[i] || window_sizes[0] != window_sizes[i]) {
         return false;
       }
     }

--- a/dali/test/python/test_operator_gaussian_blur.py
+++ b/dali/test/python/test_operator_gaussian_blur.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.types as types
+import nvidia.dali.fn as fn
+
+import numpy as np
+import cv2
+from scipy.ndimage import convolve1d
+import os
+from nose.tools import raises
+
+from test_utils import get_dali_extra_path, check_batch, RandomlyShapedDataIterator, dali_type
+
+data_root = get_dali_extra_path()
+images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
+
+
+def to_batch(tl, batch_size):
+    return [np.array(tl[i]) for i in range(batch_size)]
+
+
+def to_cv_sigma(sigma, axes=2):
+    if sigma is None:
+        return (0,) * axes
+    elif isinstance(sigma, float):
+        return (sigma,) * axes
+    elif len(sigma) == 1:
+        return (sigma[0],) * axes
+    return tuple(reversed(sigma))
+
+
+def to_cv_win_size(window_size, axes=2, sigma=None):
+    if window_size is None:
+        # when using cv2.getGaussianKernel we need to always provide window size
+        if sigma is not None:
+            sigma = to_cv_sigma(sigma, axes)
+            return tuple([int(3 * s + 0.5) * 2 + 1 for s in sigma])
+        return (0,) * axes
+    elif isinstance(window_size, int):
+        return (window_size,) * axes
+    elif len(window_size) == 1:
+        return (window_size[0],) * axes
+    # OpenCV shape is the other way round: (width, height)
+    return tuple(reversed(window_size))
+
+
+def gaussian_cv(image, sigma, window_size):
+    sigma_x, sigma_y = to_cv_sigma(sigma)
+    window_size_cv = to_cv_win_size(window_size)
+    # compute on floats and round like a sane person (in mathematically complicit way)
+    blurred = cv2.GaussianBlur(np.float32(image), window_size_cv, sigmaX=sigma_x, sigmaY=sigma_y)
+    return np.uint8(blurred + 0.5)
+
+
+def gaussian_baseline(image, sigma, window_size, axes=2, is_sequence=False, dtype=np.uint8):
+    sigma_xyz = to_cv_sigma(sigma, axes)
+    win_xyz = to_cv_win_size(window_size, axes, sigma)
+    filters = [cv2.getGaussianKernel(win_xyz[i], sigma_xyz[i]) for i in range(axes)]
+    filters = [np.float32(f).squeeze() for f in filters]
+    filters.reverse()
+    for i in reversed(range(axes)):
+        axis = i if not is_sequence else i + 1
+        image = convolve1d(np.float32(image), filters[i], axis, mode="mirror")
+    if dtype == np.float32:
+        return image
+    else:
+        return dtype(image + 0.5)
+
+
+def check_gaussian_blur(batch_size, sigma, window_size, op_type="cpu"):
+    decoder_device = "cpu" if op_type == "cpu" else "mixed"
+    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+    with pipe:
+        input, _ = fn.file_reader(file_root=images_dir, shard_id=0, num_shards=1)
+        decoded = fn.image_decoder(input, device=decoder_device, output_type=types.RGB)
+        blurred = fn.gaussian_blur(decoded, sigma=sigma, window_size=window_size)
+        pipe.set_outputs(blurred, decoded)
+    pipe.build()
+
+    result, input = pipe.run()
+    if op_type == "gpu":
+        result = result.as_cpu()
+        input = input.as_cpu()
+    input = to_batch(input, batch_size)
+    baseline_cv = [gaussian_cv(img, sigma, window_size) for img in input]
+    check_batch(result, baseline_cv, batch_size, max_allowed_error=1)
+
+
+def test_image_gaussian_blur():
+    for dev in ["cpu"]:
+        for sigma in [1.0, [1.0, 2.0]]:
+            for window_size in [3, 5, [7, 5], [5, 9], None]:
+                if sigma is None and window_size is None:
+                    continue
+                yield check_gaussian_blur, 10, sigma, window_size, dev
+        # OpenCv uses fixed values for small windows that are different that Gaussian funcion
+        for window_size in [11, 15]:
+            yield check_gaussian_blur, 10, None, window_size, dev
+
+
+def check_generic_gaussian_blur(
+        batch_size, sigma, window_size, shape, layout, axes, op_type="cpu", dtype=np.uint8):
+    decoder_device = "cpu" if op_type == "cpu" else "mixed"
+    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+    data = RandomlyShapedDataIterator(batch_size, max_shape=shape, dtype=dtype)
+    with pipe:
+        input = fn.external_source(data, layout=layout)
+        blurred = fn.gaussian_blur(input, sigma=sigma, window_size=window_size)
+        pipe.set_outputs(blurred, input)
+    pipe.build()
+
+    result, input = pipe.run()
+    if op_type == "gpu":
+        result = result.as_cpu()
+        input = input.as_cpu()
+    input = to_batch(input, batch_size)
+    baseline = [gaussian_baseline(img, sigma, window_size, axes, "F" in layout, dtype=dtype) for img in input]
+    max_error = 1 if dtype != np.float32 else 1e-07
+    check_batch(result, baseline, batch_size, max_allowed_error=max_error)
+
+
+def test_generic_gaussian_blur():
+    for dev in ["cpu"]:
+        for t in [np.uint8, np.int32, np.float32]:
+            for shape, layout, axes in [((20, 20, 30, 3), "DHWC", 3), ((20, 20, 30), "", 3),
+                                        ((20, 30, 3), "HWC", 2), ((20, 30), "HW", 2),
+                                        ((5, 20, 30, 3), "FHWC", 2),
+                                        ((5, 10, 10, 7, 3), "FDHWC", 3)]:
+                for sigma in [1.0, [1.0, 2.0, 3.0]]:
+                    for window_size in [3, 5, [7, 5, 9], [3, 5, 9], None]:
+                        if isinstance(sigma, list):
+                            sigma = sigma[0:axes]
+                        if isinstance(window_size, list):
+                            window_size = window_size[0:axes]
+                        yield check_generic_gaussian_blur, 10, sigma, window_size, shape, layout, axes, dev, t
+                for window_size in [11, 15]:
+                    yield check_generic_gaussian_blur, 10, None, window_size, shape, layout, axes, dev, t
+
+
+def check_per_sample_gaussian_blur(
+        batch_size, sigma_dim, window_size_dim, shape, layout, axes, op_type="cpu"):
+    decoder_device = "cpu" if op_type == "cpu" else "mixed"
+    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+    data = RandomlyShapedDataIterator(batch_size, max_shape=shape)
+    with pipe:
+        if sigma_dim is not None:
+            sigma = fn.uniform(range=[0.5, 3], shape=[sigma_dim])
+            sigma_arg = sigma
+        else:
+            # placeholder, so we can return something
+            sigma = fn.coin_flip(probability=0)
+            sigma_arg = None
+
+        if window_size_dim is not None:
+            window_radius = fn.uniform(range=[5, 10], shape=[window_size_dim])
+            window_size = fn.cast(window_radius, dtype=types.INT32) * 2 + 1
+            window_arg = window_size
+        else:
+            window_size = fn.coin_flip(probability=0)
+            window_arg = None
+
+        input = fn.external_source(data, layout=layout)
+        blurred = fn.gaussian_blur(input, sigma=sigma_arg, window_size=window_arg)
+        pipe.set_outputs(blurred, input, sigma, window_size)
+    pipe.build()
+
+    result, input, sigma, window_size = pipe.run()
+    if op_type == "gpu":
+        result = result.as_cpu()
+        input = input.as_cpu()
+    input = to_batch(input, batch_size)
+    sigma = to_batch(sigma, batch_size)
+    window_size = to_batch(window_size, batch_size)
+    baseline = []
+    for i in range(batch_size):
+        sigma_arg = sigma[i] if sigma is not None else None
+        window_arg = window_size[i] if window_size_dim is not None else None
+        baseline.append(gaussian_baseline(input[i], sigma_arg, window_arg, axes, "F" in layout))
+    check_batch(result, baseline, batch_size, max_allowed_error=1)
+
+# TODO(klecki): consider checking mixed ArgumentInput/Scalar value cases
+def test_per_sample_gaussian_blur():
+    for dev in ["cpu"]:
+        for shape, layout, axes in [((20, 20, 30, 3), "DHWC", 3), ((20, 20, 30), "", 3),
+                                    ((20, 30, 3), "HWC", 2), ((20, 30), "HW", 2),
+                                    ((5, 20, 30, 3), "FHWC", 2), ((5, 10, 10, 7, 3), "FDHWC", 3)]:
+            for sigma_dim in [None, 1, axes]:
+                for window_size_dim in [None, 1, axes]:
+                    if sigma_dim is None and window_size_dim is None:
+                        continue
+                    yield check_per_sample_gaussian_blur, 10, sigma_dim, window_size_dim, shape, layout, axes, dev
+
+
+@raises(RuntimeError)
+def check_fail_gaussian_blur(batch_size, sigma, window_size, shape, layout, axes, op_type):
+    check_generic_gaussian_blur(batch_size, sigma, window_size, shape, layout, axes, op_type)
+
+def test_fail_gaussian_blur():
+    for dev in ["cpu"]:
+        # Check layout and channel placement errors
+        for shape, layout, axes in [((20, 20, 30, 3), "DHCW", 3), ((5, 20, 30, 3), "HFWC", 2),
+                                    ((5, 10, 10, 10, 7, 3), "FWXYZC", 4)]:
+            yield check_fail_gaussian_blur, 10, 1.0, 11, shape, layout, axes, dev
+        # Negative, disallowed or both unspecified values of sigma and window size
+        yield check_fail_gaussian_blur, 10, 0.0, 0, (100, 20, 3), "HWC", 3, dev
+        yield check_fail_gaussian_blur, 10, -1.0, 0, (100, 20, 3), "HWC", 3, dev
+        yield check_fail_gaussian_blur, 10, 0.0, -11, (100, 20, 3), "HWC", 3, dev
+        yield check_fail_gaussian_blur, 10, 0.0, 2, (100, 20, 3), "HWC", 3, dev

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -76,7 +76,18 @@ def get_gpu_num():
     out_list = [elm for elm in out_list if len(elm) > 0]
     return len(out_list)
 
-def check_batch(batch1, batch2, batch_size, eps = 1e-07):
+
+def check_batch(batch1, batch2, batch_size, eps=1e-07, max_allowed_error=None):
+
+    def is_error(mean_err, max_err, eps, max_allowed_error):
+        if max_allowed_error is not None:
+            if max_err > max_allowed_error:
+                return True
+        else:
+            if mean_err > eps:
+                return True
+        return False
+
     import_numpy()
     if isinstance(batch1, dali.backend_impl.TensorListGPU):
         batch1 = batch1.as_cpu()
@@ -84,33 +95,38 @@ def check_batch(batch1, batch2, batch_size, eps = 1e-07):
         batch2 = batch2.as_cpu()
 
     for i in range(batch_size):
+        # This allows to handle list of Tensors, list of np arrays and TensorLists
+        left = np.array(batch1[i])
+        right = np.array(batch2[i])
         is_failed = False
-        assert(batch1.at(i).shape == batch2.at(i).shape), \
-            "Shape mismatch {} != {}".format(batch1.at(i).shape, batch2.at(i).shape)
-        assert(batch1.at(i).size == batch2.at(i).size), \
-            "Size mismatch {} != {}".format(batch1.at(i).size, batch2.at(i).size)
-        if batch1.at(i).size != 0:
+        assert(left.shape == right.shape), \
+            "Shape mismatch {} != {}".format(left.shape, right.shape)
+        assert(left.size == right.size), \
+            "Size mismatch {} != {}".format(left.size, right.size)
+        if left.size != 0:
             try:
                 # abs doesn't handle overflow for uint8, so get minimal value of a-b and b-a
-                diff1 = np.abs(batch1.at(i) - batch2.at(i))
-                diff2 = np.abs(batch2.at(i) - batch1.at(i))
-                err = np.mean( np.minimum(diff2, diff1) )
-                max_err = np.max( np.minimum(diff2, diff1))
-                min_err = np.min( np.minimum(diff2, diff1))
+                diff1 = np.abs(left - right)
+                diff2 = np.abs(right - left)
+                absdiff = np.minimum(diff2, diff1)
+                err = np.mean(absdiff)
+                max_err = np.max(absdiff)
+                min_err = np.min(absdiff)
+                total_errors = np.sum(absdiff != 0)
             except:
                 is_failed = True
-            if is_failed or err > eps:
+            if is_failed or is_error(err, max_err, eps, max_allowed_error):
+                error_msg = ("Mean error: [{}], Min error: [{}], Max error: [{}]" +
+                                "\n Total error count: [{}], Tensor size: [{}], Error calculation failed: [{}]").format(
+                    err, min_err, max_err, total_errors, absdiff.size, is_failed)
                 try:
-
-                    print("failed[{}] mean_err[{}] min_err[{}] max_err[{}]".format(
-                        is_failed, err, min_err, max_err))
-                    save_image(batch1.at(i), "err_1.png")
-                    save_image(batch2.at(i), "err_2.png")
+                    save_image(left, "err_1.png")
+                    save_image(right, "err_2.png")
                 except:
                     print("Batch at {} can't be saved as an image".format(i))
-                    print(batch1.at(i))
-                    print(batch2.at(i))
-                assert(False)
+                    print(left)
+                    print(right)
+                assert False, error_msg
 
 def compare_pipelines(pipe1, pipe2, batch_size, N_iterations, eps = 1e-07):
     pipe1.build()

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -77,15 +77,15 @@ def get_gpu_num():
     return len(out_list)
 
 
+# If the `max_allowed_error` is not None, it's checked instead of comparing mean error with `eps`.
 def check_batch(batch1, batch2, batch_size, eps=1e-07, max_allowed_error=None):
 
     def is_error(mean_err, max_err, eps, max_allowed_error):
         if max_allowed_error is not None:
             if max_err > max_allowed_error:
                 return True
-        else:
-            if mean_err > eps:
-                return True
+        elif mean_err > eps:
+            return True
         return False
 
     import_numpy()

--- a/include/dali/core/tensor_layout.h
+++ b/include/dali/core/tensor_layout.h
@@ -446,9 +446,15 @@ struct VideoLayoutInfo : ImageLayoutInfo {
     return tl[FrameDimIndex(tl)+1] == 'C';
   }
 
-  /** @brief Returns true, if 'F' (frame) dimension is present */
+  /** @brief Returns true, if 'F' (frame) dimension is first */
   DALI_HOST_DEV
   static bool IsSequence(const TensorLayout &tl) {
+    return FrameDimIndex(tl) == 0;
+  }
+
+  /** @brief Returns true, if 'F' (frame) dimension is present */
+  DALI_HOST_DEV
+  static bool HasSequence(const TensorLayout &tl) {
     return tl.contains('F');
   }
 

--- a/include/dali/core/tensor_layout.h
+++ b/include/dali/core/tensor_layout.h
@@ -449,7 +449,7 @@ struct VideoLayoutInfo : ImageLayoutInfo {
   /** @brief Returns true, if 'F' (frame) dimension is first */
   DALI_HOST_DEV
   static bool IsSequence(const TensorLayout &tl) {
-    return FrameDimIndex(tl) == 0;
+    return FrameDimIndex(tl) == 0 || (HasSampleDim(tl) && FrameDimIndex(tl) == 1);
   }
 
   /** @brief Returns true, if 'F' (frame) dimension is present */


### PR DESCRIPTION
~Split into #2053 so it lands well below 1k lines.~
#2053 merged, this is ready again.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Add Gaussian Blur Op.

#### What happened in this PR?
 - What solution was applied:

Add small utility for holding the separated Gaussian windows
* No recalculation without parameter change
* If all axes are the same, keep only one window

Generated window normalized to sum = 1, comparable with OCV.

Use SeparableConvolution Kernel to implement Gaussian Blur.
Support for up to 3 data axes and optional sequence-first,
optional channel-last.

 - Affected modules and functionalities:
 
Operator implementation, python testing utilities.

 - Key points relevant for the review:

Window generation, argument gathering, sequence processing.

 - Validation and testing:

Gtest for window utlities

Tests in python, adjusted utilites for batch compare
to allow comparison with list of np arrays.

 - Documentation (including examples):
Schema, no examples

**JIRA TASK**: *[DALI-1425]*
