### PR TITLE
Fix shape comparison in C API tests.

### DIFF
--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -118,12 +118,11 @@ void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline) {
     EXPECT_EQ(daliNumTensors(&handle, output), batch_size);
     for (int elem = 0; elem < batch_size; elem++) {
       auto *shape = daliShapeAtSample(&handle, output, elem);
-      int idx = 0;
-      auto ref_shape = ws.Output<Backend>(output).shape()[idx];
-      for (; shape[idx] != 0; idx++) {
-        EXPECT_EQ(shape[idx], ref_shape[idx]);
-      }
-      EXPECT_EQ(idx, ref_shape.sample_dim());
+      auto ref_shape = ws.Output<Backend>(output).shape()[elem];
+      int D = ref_shape.size();
+      for (int d = 0; d < D; d++)
+        EXPECT_EQ(shape[d], ref_shape[d]);
+      EXPECT_EQ(shape[D], 0) << "Shapes in C API are 0-terminated";
       free(shape);
     }
 


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug - confused indices in C API test shape comparison

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Use sane indexing ;)
     * Compare `shape[D] == 0` to check than there are no more extra dimensions in C API
 - Affected modules and functionalities:
     * see above
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * N/A
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
