### PR TITLE
Update docs layout template after sphinx_rtd_theme update

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -46,7 +46,7 @@
     color: #8c0;
   }
 
-  .rst-content dl:not(.docutils) dt {
+  html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple)>dt {
     background: rgba(118, 185, 0, 0.1);
     color: rgba(59,93,0,1);
     border-top: solid 3px rgba(59,93,0,1);


### PR DESCRIPTION
- the most recent version of sphinx_rtd_theme changes template a bit, this PR updates DALI style template to match it

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes wrong look of the documentation caused by the update of sphinx_rtd_theme package

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     the most recent version of sphinx_rtd_theme changes template a bit, this PR updates DALI style template to match it
 - Affected modules and functionalities:
     docs
 - Key points relevant for the review:
     NA
 - Validation and testing:
     docs build
 - Documentation (including examples):
     docs style updated


**JIRA TASK**: *[NA]*
