### PR TITLE
Fix conda build after TensorFlow 2.2 release

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -64,7 +64,9 @@ requirements:
     - future >=0.17.1
     - protobuf >=3.11.2
     - libjpeg-turbo >=2.0.3
-    - tensorflow-gpu =2.1.0
+    - tensorflow-gpu =2.2.0
+    - tensorflow-estimator =2.2.0
+    - tensorboard =2.2.2
     - dali-opencv
     - dali-ffmpeg
     - boost >=1.67
@@ -81,7 +83,9 @@ requirements:
     - future >=0.17.1
     - protobuf >=3.11.2
     - libjpeg-turbo >=2.0.3
-    - tensorflow-gpu =2.1.0
+    - tensorflow-gpu =2.2.0
+    - tensorflow-estimator =2.2.0
+    - tensorboard =2.2.2
     - lmdb >=0.9.22
     - libtiff >=4.1.0
     - libsndfile >=1.0.28


### PR DESCRIPTION
- TensorFlow 2.2 release updated packages, and TensorFlow 2.1 install some packages in version 2.2 what leads to incompatibility
- moves the whole TensorFlow DALI conda dependency to 2.2.x version

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a conda build after TensorFlow 2.2 release

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     moves the whole TensorFlow DALI conda dependency to 2.2.x version
 - Affected modules and functionalities:
     conda build
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI conda build
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
