### PR TITLE
Add Gaussian window calculation for Gaussian Op

### DIFF
--- a/dali/operators/image/convolution/CMakeLists.txt
+++ b/dali/operators/image/convolution/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,6 @@
 # limitations under the License.
 
 # Get all the source files and dump test files
-
-add_subdirectory(color)
-add_subdirectory(crop)
-add_subdirectory(convolution)
-add_subdirectory(resize)
-add_subdirectory(paste)
-add_subdirectory(remap)
-
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
 collect_test_sources(DALI_OPERATOR_TEST_SRCS PARENT_SCOPE)

--- a/dali/operators/image/convolution/gaussian_blur_params.h
+++ b/dali/operators/image/convolution/gaussian_blur_params.h
@@ -1,0 +1,140 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_IMAGE_CONVOLUTION_GAUSSIAN_BLUR_PARAMS_H_
+#define DALI_OPERATORS_IMAGE_CONVOLUTION_GAUSSIAN_BLUR_PARAMS_H_
+
+#include <vector>
+
+#include "dali/pipeline/data/views.h"
+#include "dali/pipeline/operator/common.h"
+
+namespace dali {
+
+int GaussianSigmaToDiameter(float sigma) {
+  return 2 * ceilf(sigma * 3) + 1;
+}
+
+float GaussianDiameterToSigma(int diameter) {
+  // Based on OpenCV
+  int radius = (diameter - 1) / 2;
+  return (radius - 1) * 0.3 + 0.8;
+}
+
+struct GaussianDimDesc {
+  int usable_axes_start;
+  int usable_axes_count;
+  bool has_channels;
+  bool is_sequence;
+};
+
+template <int axes>
+struct GaussianSampleParams {
+  std::array<int, axes> window_sizes;
+  std::array<float, axes> sigmas;
+
+  bool IsUniform() const {
+    for (int i = 1; i < axes; i++) {
+      if (sigmas[i - 1] != sigmas[i] || window_sizes[i - 1] != window_sizes[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool operator==(const GaussianSampleParams<axes> &other) const {
+    return window_sizes == other.window_sizes && sigmas == other.sigmas;
+  }
+
+  bool operator!=(const GaussianSampleParams<axes> &other) const {
+    return !(*this == other);
+  }
+};
+
+void FillGaussian(const TensorView<StorageCPU, float, 1> &window, float sigma) {
+  int r = (window.num_elements() - 1) / 2;
+  // 1 / sqrt(2 * pi * sigma^2) * exp(-(x^2) / (2 * sigma^2))
+  // the 1 / sqrt(2 * pi * sigma^2) coefficient disappears as we normalize the sum to 1.
+  double exp_scale = 0.5 / (sigma * sigma);
+  double sum = 0.;
+  // Calculate first half
+  for (int x = -r; x < 0; x++) {
+    *window(x + r) = exp(-(x * x * exp_scale));
+    sum += *window(x + r);
+  }
+  // Total sum, it's symmetric with `1` in the center.
+  sum *= 2.;
+  sum += 1.0;
+  double scale = 1. / sum;
+  // place center, scaled element
+  *window(r) = scale;
+  // scale all elements so they sum up to 1, duplicate the second half
+  for (int x = 0; x < r; x++) {
+    *window(x) *= scale;
+    *window(2 * r - x) = *window(x);
+  }
+}
+
+template <int axes>
+class GaussianWindows {
+ public:
+  GaussianWindows() {
+    previous.sigmas = uniform_array<axes>(-1.f);
+    previous.window_sizes = uniform_array<axes>(0);
+  }
+
+  void PrepareWindows(const GaussianSampleParams<axes> &params) {
+    bool changed = previous != params;
+    if (!changed)
+      return;
+
+    // Reallocate if necessary and fill the windows
+    bool is_uniform = params.IsUniform();
+    if (is_uniform) {
+      int required_elements = params.window_sizes[0];
+      memory.resize(required_elements);
+      TensorView<StorageCPU, float, 1> tmp_view = {memory.data(), {required_elements}};
+      FillGaussian(tmp_view, params.sigmas[0]);
+      precomputed_window = uniform_array<axes>(
+          TensorView<StorageCPU, const float, 1>{memory.data(), {params.window_sizes[0]}});
+    } else {
+      int required_elements = 0;
+      for (int i = 0; i < axes; i++) {
+        required_elements += params.window_sizes[i];
+      }
+      memory.resize(required_elements);
+      int offset = 0;
+      for (int i = 0; i < axes; i++) {
+        TensorView<StorageCPU, float, 1> tmp_view = {&memory[offset], {params.window_sizes[i]}};
+        offset += params.window_sizes[i];
+        FillGaussian(tmp_view, params.sigmas[i]);
+        precomputed_window[i] = tmp_view;
+      }
+    }
+  }
+
+  // Return the already filled windows
+  std::array<TensorView<StorageCPU, const float, 1>, axes> GetWindows() {
+    return precomputed_window;
+  }
+
+ private:
+  std::array<TensorView<StorageCPU, const float, 1>, axes> precomputed_window;
+  GaussianSampleParams<axes> previous;
+  std::vector<float> memory;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_IMAGE_CONVOLUTION_GAUSSIAN_BLUR_PARAMS_H_

--- a/dali/operators/image/convolution/gaussian_blur_params.h
+++ b/dali/operators/image/convolution/gaussian_blur_params.h
@@ -42,7 +42,7 @@ struct DimDesc {
 };
 
 template <int axes>
-struct GaussianSampleParams {
+struct GaussianBlurParams {
   DeviceArray<int, axes> window_sizes;
   DeviceArray<float, axes> sigmas;
 
@@ -55,11 +55,11 @@ struct GaussianSampleParams {
     return true;
   }
 
-  bool operator==(const GaussianSampleParams<axes> &other) const {
+  bool operator==(const GaussianBlurParams<axes> &other) const {
     return window_sizes == other.window_sizes && sigmas == other.sigmas;
   }
 
-  bool operator!=(const GaussianSampleParams<axes> &other) const {
+  bool operator!=(const GaussianBlurParams<axes> &other) const {
     return !(*this == other);
   }
 };
@@ -96,7 +96,7 @@ class GaussianWindows {
     previous.window_sizes = uniform_array<axes>(0);
   }
 
-  void PrepareWindows(const GaussianSampleParams<axes> &params) {
+  void PrepareWindows(const GaussianBlurParams<axes> &params) {
     bool changed = previous != params;
     if (!changed)
       return;
@@ -133,7 +133,7 @@ class GaussianWindows {
 
  private:
   std::array<TensorView<StorageCPU, const float, 1>, axes> precomputed_window;
-  GaussianSampleParams<axes> previous;
+  GaussianBlurParams<axes> previous;
   std::vector<float> memory;
 };
 

--- a/dali/operators/image/convolution/gaussian_blur_params_test.cc
+++ b/dali/operators/image/convolution/gaussian_blur_params_test.cc
@@ -1,0 +1,182 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <opencv2/imgproc.hpp>
+
+#include <cmath>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "dali/kernels/common/utils.h"
+#include "dali/kernels/scratch.h"
+#include "dali/test/tensor_test_utils.h"
+#include "dali/test/test_tensors.h"
+
+#include "dali/operators/image/convolution/gaussian_blur_params.h"
+
+namespace dali {
+namespace kernels {
+
+// TODO(klecki): OpenCV have special cases of precomputed values for for kernels of sizes 1-7 and
+// sigma = 0
+TEST(GaussianBlurTest, FillGaussian) {
+  std::vector<std::pair<int, float>> size_sigma_pairs = {
+      {1, 0},     {3, 0},    {5, 0},      {7, 0},     {9, 0},    {11, 0},    {13, 0},
+      {15, 0},    {101, 0},  {0, 0.025f}, {0, 0.25f}, {0, 0.5f}, {0, 0.75f}, {0, 1.f},
+      {0, 1.25f}, {0, 1.5f}, {0, 2.f},    {0, 3.f},   {0, 5.f},  {0, 16.f}};
+  TestTensorList<float, 1> window;
+  for (const auto &size_sigma : size_sigma_pairs) {
+    int size;
+    float sigma;
+    std::tie(size, sigma) = size_sigma;
+    if (size == 0) {
+      size = GaussianSigmaToDiameter(sigma);
+    } else if (sigma == 0.f) {
+      sigma = GaussianDiameterToSigma(size);
+    }
+    TensorListShape<1> shape({TensorShape<1>{size}});
+    window.reshape(shape);
+    auto window_view = window.cpu()[0];
+    FillGaussian(window_view, sigma);
+    auto mat = cv::getGaussianKernel(size, sigma, CV_32F);
+    for (int i = 0; i < size; i++) {
+      EXPECT_NEAR(window_view.data[i], mat.at<float>(i), 1e-7f)
+          << "size: " << size << ", sigma: " << sigma;
+    }
+  }
+}
+
+template <size_t axes>
+void CheckUniformWindows(const std::array<TensorView<StorageCPU, const float, 1>, axes> &views) {
+  for (size_t i = 1; i < axes; i++) {
+    EXPECT_EQ(views[i - 1].data, views[i].data);
+    EXPECT_EQ(views[i - 1].shape, views[i].shape);
+  }
+}
+
+template <size_t axes>
+void CheckNonUniformWindows(const std::array<TensorView<StorageCPU, const float, 1>, axes> &views) {
+  for (size_t i = 0; i < axes; i++) {
+    for (size_t j = i + 1; j < axes; j++) {
+      EXPECT_NE(views[i].data, views[j].data);
+    }
+  }
+}
+
+template <size_t axes, int axes_params = axes>
+void CheckMatchingShapes(const std::array<TensorView<StorageCPU, const float, 1>, axes> &views,
+                         const GaussianSampleParams<axes_params> &params) {
+  for (size_t i = 0; i < axes; i++) {
+    EXPECT_EQ(params.window_sizes[i], views[i].shape[0]);
+  }
+}
+
+TEST(GaussianWindowsTest, InitUniform) {
+  constexpr int axes = 2;
+  GaussianWindows<axes> windows;
+  GaussianSampleParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
+  windows.PrepareWindows(params_uniform);
+  auto views = windows.GetWindows();
+  CheckUniformWindows(views);
+  CheckMatchingShapes(views, params_uniform);
+}
+
+TEST(GaussianWindowsTest, InitNonUniformSigma) {
+  constexpr int axes = 2;
+  GaussianWindows<axes> windows;
+  GaussianSampleParams<axes> params = {{7, 7}, {1.0f, 2.0f}};
+  windows.PrepareWindows(params);
+  auto views = windows.GetWindows();
+  CheckNonUniformWindows(views);
+  CheckMatchingShapes(views, params);
+}
+
+TEST(GaussianWindowsTest, InitNonUniformShape) {
+  constexpr int axes = 2;
+  GaussianWindows<axes> windows;
+  GaussianSampleParams<axes> params = {{7, 9}, {1.0f, 1.0f}};
+  windows.PrepareWindows(params);
+  auto views = windows.GetWindows();
+  CheckNonUniformWindows(views);
+  CheckMatchingShapes(views, params);
+}
+
+TEST(GaussianWindowsTest, Uniform2NonUniform) {
+  constexpr int axes = 2;
+  GaussianWindows<axes> windows;
+  GaussianSampleParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
+  GaussianSampleParams<axes> params_non_uniform = {{7, 14}, {2.0f, 1.0f}};
+
+  windows.PrepareWindows(params_uniform);
+  auto views_uniform = windows.GetWindows();
+  CheckUniformWindows(views_uniform);
+  CheckMatchingShapes(views_uniform, params_uniform);
+
+  windows.PrepareWindows(params_non_uniform);
+  auto views_non_uniform = windows.GetWindows();
+  CheckNonUniformWindows(views_non_uniform);
+  CheckMatchingShapes(views_non_uniform, params_non_uniform);
+}
+
+TEST(GaussianWindowsTest, NonUniform2Uniform) {
+  constexpr int axes = 2;
+  GaussianWindows<axes> windows;
+  GaussianSampleParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
+  GaussianSampleParams<axes> params_non_uniform = {{7, 14}, {2.0f, 1.0f}};
+
+  windows.PrepareWindows(params_non_uniform);
+  auto views_non_uniform = windows.GetWindows();
+  CheckNonUniformWindows(views_non_uniform);
+  CheckMatchingShapes(views_non_uniform, params_non_uniform);
+
+  windows.PrepareWindows(params_uniform);
+  auto views_uniform = windows.GetWindows();
+  CheckUniformWindows(views_uniform);
+  CheckMatchingShapes(views_uniform, params_uniform);
+}
+
+TEST(GaussianWindowsTest, NoChangeUniform) {
+  constexpr int axes = 2;
+  GaussianWindows<axes> windows;
+  GaussianSampleParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
+
+  windows.PrepareWindows(params_uniform);
+  auto views_uniform_0 = windows.GetWindows();
+  windows.PrepareWindows(params_uniform);
+  auto views_uniform_1 = windows.GetWindows();
+  for (int i = 0; i < axes; i++) {
+    EXPECT_EQ(views_uniform_0[i].data, views_uniform_1[i].data);
+    EXPECT_EQ(views_uniform_0[i].shape, views_uniform_1[i].shape);
+  }
+}
+
+TEST(GaussianWindowsTest, NoChangeNonUniform) {
+  constexpr int axes = 2;
+  GaussianWindows<axes> windows;
+  GaussianSampleParams<axes> params_non_uniform = {{7, 14}, {2.0f, 1.0f}};
+
+  windows.PrepareWindows(params_non_uniform);
+  auto views_non_uniform_0 = windows.GetWindows();
+  windows.PrepareWindows(params_non_uniform);
+  auto views_non_uniform_1 = windows.GetWindows();
+  for (int i = 0; i < axes; i++) {
+    EXPECT_EQ(views_non_uniform_0[i].data, views_non_uniform_1[i].data);
+    EXPECT_EQ(views_non_uniform_0[i].shape, views_non_uniform_1[i].shape);
+  }
+}
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/operators/image/convolution/gaussian_blur_params_test.cc
+++ b/dali/operators/image/convolution/gaussian_blur_params_test.cc
@@ -28,7 +28,7 @@
 #include "dali/operators/image/convolution/gaussian_blur_params.h"
 
 namespace dali {
-namespace kernels {
+namespace gaussian_blur {
 
 // TODO(klecki): OpenCV have special cases of precomputed values for for kernels of sizes 1-7 and
 // sigma = 0
@@ -37,15 +37,15 @@ TEST(GaussianBlurTest, FillGaussian) {
       {1, 0},     {3, 0},    {5, 0},      {7, 0},     {9, 0},    {11, 0},    {13, 0},
       {15, 0},    {101, 0},  {0, 0.025f}, {0, 0.25f}, {0, 0.5f}, {0, 0.75f}, {0, 1.f},
       {0, 1.25f}, {0, 1.5f}, {0, 2.f},    {0, 3.f},   {0, 5.f},  {0, 16.f}};
-  TestTensorList<float, 1> window;
+  kernels::TestTensorList<float, 1> window;
   for (const auto &size_sigma : size_sigma_pairs) {
     int size;
     float sigma;
     std::tie(size, sigma) = size_sigma;
     if (size == 0) {
-      size = GaussianSigmaToDiameter(sigma);
+      size = SigmaToDiameter(sigma);
     } else if (sigma == 0.f) {
-      sigma = GaussianDiameterToSigma(size);
+      sigma = DiameterToSigma(size);
     }
     TensorListShape<1> shape({TensorShape<1>{size}});
     window.reshape(shape);
@@ -178,5 +178,5 @@ TEST(GaussianWindowsTest, NoChangeNonUniform) {
   }
 }
 
-}  // namespace kernels
+}  // namespace gaussian_blur
 }  // namespace dali

--- a/dali/operators/image/convolution/gaussian_blur_params_test.cc
+++ b/dali/operators/image/convolution/gaussian_blur_params_test.cc
@@ -78,7 +78,7 @@ void CheckNonUniformWindows(const std::array<TensorView<StorageCPU, const float,
 
 template <size_t axes, int axes_params = axes>
 void CheckMatchingShapes(const std::array<TensorView<StorageCPU, const float, 1>, axes> &views,
-                         const GaussianSampleParams<axes_params> &params) {
+                         const GaussianBlurParams<axes_params> &params) {
   for (size_t i = 0; i < axes; i++) {
     EXPECT_EQ(params.window_sizes[i], views[i].shape[0]);
   }
@@ -87,7 +87,7 @@ void CheckMatchingShapes(const std::array<TensorView<StorageCPU, const float, 1>
 TEST(GaussianWindowsTest, InitUniform) {
   constexpr int axes = 2;
   GaussianWindows<axes> windows;
-  GaussianSampleParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
+  GaussianBlurParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
   windows.PrepareWindows(params_uniform);
   auto views = windows.GetWindows();
   CheckUniformWindows(views);
@@ -97,7 +97,7 @@ TEST(GaussianWindowsTest, InitUniform) {
 TEST(GaussianWindowsTest, InitNonUniformSigma) {
   constexpr int axes = 2;
   GaussianWindows<axes> windows;
-  GaussianSampleParams<axes> params = {{7, 7}, {1.0f, 2.0f}};
+  GaussianBlurParams<axes> params = {{7, 7}, {1.0f, 2.0f}};
   windows.PrepareWindows(params);
   auto views = windows.GetWindows();
   CheckNonUniformWindows(views);
@@ -107,7 +107,7 @@ TEST(GaussianWindowsTest, InitNonUniformSigma) {
 TEST(GaussianWindowsTest, InitNonUniformShape) {
   constexpr int axes = 2;
   GaussianWindows<axes> windows;
-  GaussianSampleParams<axes> params = {{7, 9}, {1.0f, 1.0f}};
+  GaussianBlurParams<axes> params = {{7, 9}, {1.0f, 1.0f}};
   windows.PrepareWindows(params);
   auto views = windows.GetWindows();
   CheckNonUniformWindows(views);
@@ -117,8 +117,8 @@ TEST(GaussianWindowsTest, InitNonUniformShape) {
 TEST(GaussianWindowsTest, Uniform2NonUniform) {
   constexpr int axes = 2;
   GaussianWindows<axes> windows;
-  GaussianSampleParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
-  GaussianSampleParams<axes> params_non_uniform = {{7, 14}, {2.0f, 1.0f}};
+  GaussianBlurParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
+  GaussianBlurParams<axes> params_non_uniform = {{7, 14}, {2.0f, 1.0f}};
 
   windows.PrepareWindows(params_uniform);
   auto views_uniform = windows.GetWindows();
@@ -134,8 +134,8 @@ TEST(GaussianWindowsTest, Uniform2NonUniform) {
 TEST(GaussianWindowsTest, NonUniform2Uniform) {
   constexpr int axes = 2;
   GaussianWindows<axes> windows;
-  GaussianSampleParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
-  GaussianSampleParams<axes> params_non_uniform = {{7, 14}, {2.0f, 1.0f}};
+  GaussianBlurParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
+  GaussianBlurParams<axes> params_non_uniform = {{7, 14}, {2.0f, 1.0f}};
 
   windows.PrepareWindows(params_non_uniform);
   auto views_non_uniform = windows.GetWindows();
@@ -151,7 +151,7 @@ TEST(GaussianWindowsTest, NonUniform2Uniform) {
 TEST(GaussianWindowsTest, NoChangeUniform) {
   constexpr int axes = 2;
   GaussianWindows<axes> windows;
-  GaussianSampleParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
+  GaussianBlurParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
 
   windows.PrepareWindows(params_uniform);
   auto views_uniform_0 = windows.GetWindows();
@@ -166,7 +166,7 @@ TEST(GaussianWindowsTest, NoChangeUniform) {
 TEST(GaussianWindowsTest, NoChangeNonUniform) {
   constexpr int axes = 2;
   GaussianWindows<axes> windows;
-  GaussianSampleParams<axes> params_non_uniform = {{7, 14}, {2.0f, 1.0f}};
+  GaussianBlurParams<axes> params_non_uniform = {{7, 14}, {2.0f, 1.0f}};
 
   windows.PrepareWindows(params_non_uniform);
   auto views_non_uniform_0 = windows.GetWindows();


### PR DESCRIPTION
Needed for #2038.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Needed for Gausian Blur CPU op to be used with Convolution Kernels.

#### What happened in this PR?
 - What solution was applied:
     Calculate half of Gaussian Kernel window, duplicate for second half (symmetric) and normalize so it sums up to 1.
     Keep the state of the several windows based on provided params
 - Affected modules and functionalities:
     Operator utilites
 - Key points relevant for the review:
    
 - Validation and testing:
     Gtest test added, compared with OpenCV.

 - Documentation (including examples):
     


**JIRA TASK**: *[DALI-1425]*
