### PR TITLE
Fix Slice pad support when last dimension is padded

### DIFF
--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -30,29 +30,6 @@ namespace kernels {
 namespace detail {
 
 /**
- * @brief Fills output with nchannel values repeatedly
- */
-template <typename T>
-void Fill(T *output, const T *fill_values, int64_t npixels, int64_t nchannels) {
-  int64_t n = npixels * nchannels;
-  int64_t i = 0;
-  for (; i < nchannels; i++)
-    output[i] = fill_values[i];
-  for (; i < n; i++)
-    output[i] = output[i - nchannels];
-}
-
-inline std::tuple<int64_t, int64_t, int64_t> CalcPadCopyExtents(int64_t anchor,
-                                                                int64_t in_extent,
-                                                                int64_t out_extent) {
-  int64_t pad_before = std::min(out_extent, std::max<int64_t>(0, -anchor));
-  int64_t to_copy = std::max<int64_t>(
-      0, std::min(in_extent - std::max<int64_t>(0, anchor), out_extent - pad_before));
-  int64_t pad_after = out_extent - pad_before - to_copy;
-  return std::tuple<int64_t, int64_t, int64_t>{pad_before, to_copy, pad_after};
-}
-
-/**
  * @brief Optimized special case for the last two dimensions whith channel-last configuration
  */
 template <typename OutputType, typename InputType, bool OutOfBounds, bool NeedPad>
@@ -76,7 +53,7 @@ void SliceKernelImplChannelLast(OutputType *output,
   if (NeedPad) {
     // If the whole row is out of bounds, just fill
     if (OutOfBounds) {
-      Fill(output, fill_values, npixels, out_nchannels);
+      PadFill(output, fill_values, npixels, out_nchannels);
       return;
     }
 
@@ -88,7 +65,7 @@ void SliceKernelImplChannelLast(OutputType *output,
 
     // Padding pixels on the left, if needed
     if (pad_pixels_before > 0) {
-      Fill(output, fill_values, pad_pixels_before, out_nchannels);
+      PadFill(output, fill_values, pad_pixels_before, out_nchannels);
       output += pad_pixels_before * out_strides[d];
     }
 
@@ -128,7 +105,7 @@ void SliceKernelImplChannelLast(OutputType *output,
 
     // Padding pixels on the right, if needed
     if (pad_pixels_after > 0) {
-      Fill(output, fill_values, pad_pixels_after, out_nchannels);
+      PadFill(output, fill_values, pad_pixels_after, out_nchannels);
       output += pad_pixels_after * out_strides[d];
     }
   } else {  // NeedPad = false

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -38,15 +38,16 @@ struct SliceSampleDesc {
   void *__restrict__ out;
   const void *__restrict__ in;
 
+  TensorShape<Dims> out_shape;
+  TensorShape<Dims> in_shape;
+  TensorShape<Dims> anchor;
+
   const void *__restrict__ fill_values;
   int channel_dim;
   bool need_pad;
 
-  TensorShape<Dims> in_strides;
   fast_div<uint64_t> out_strides[Dims];
-
-  TensorShape<Dims> anchor;
-  TensorShape<Dims> in_shape;
+  TensorShape<Dims> in_strides;
 };
 
 struct BlockDesc {
@@ -100,15 +101,15 @@ DALI_HOST_DEV DALI_FORCEINLINE bool is_out_of_bounds(int64_t idx, int64_t data_e
 template <int Dims, typename OutputType, typename InputType, bool AllDims = true>
 __device__ void SliceFunc(OutputType *__restrict__ out, const InputType *__restrict__ in,
                           const fast_div<uint64_t> *out_strides, const int64_t *in_strides,
-                          const int64_t *anchor, const int64_t *in_shape,
+                          const int64_t *out_shape, const int64_t *in_shape, const int64_t *anchor,
                           const OutputType *__restrict__ fill_values, int channel_dim,
                           uint64_t offset, uint64_t block_end) {
-  if (Dims > 1 && out_strides[Dims - 1] == in_strides[Dims - 1] && anchor[Dims - 1] == 0 &&
+  if (Dims > 1 && anchor[Dims - 1] == 0 && in_shape[Dims - 1] == out_shape[Dims - 1] &&
       channel_dim != Dims - 1) {
     const int NextDims = Dims > 1 ? Dims - 1 : 1;
-    SliceFunc<NextDims, OutputType, InputType, false>(
-        out, in, out_strides, in_strides, anchor, in_shape, fill_values, channel_dim, offset,
-        block_end);
+    SliceFunc<NextDims, OutputType, InputType, false>(out, in, out_strides, in_strides, out_shape,
+                                                      in_shape, anchor, fill_values, channel_dim,
+                                                      offset, block_end);
     return;
   }
 
@@ -167,10 +168,11 @@ __global__ void SliceKernel(const SliceSampleDesc<Dims> *samples, const BlockDes
   if (SupportPad && sample.need_pad) {
     auto *anchor = sample.anchor.data();
     auto *in_shape = sample.in_shape.data();
+    auto *out_shape = sample.out_shape.data();
     auto *fill_values = static_cast<const OutputType*>(sample.fill_values);
     auto channel_dim = sample.channel_dim;
-    SliceFunc<Dims>(out, in, out_strides, in_strides, anchor, in_shape, fill_values, channel_dim,
-                    offset, block_end);
+    SliceFunc<Dims>(out, in, out_strides, in_strides, out_shape, in_shape, anchor, fill_values,
+                    channel_dim, offset, block_end);
   } else {
     SliceFuncNoPad<Dims>(out, in, out_strides, in_strides, offset, block_end);
   }
@@ -282,6 +284,7 @@ class SliceGPU {
       CalcStrides(sample_desc.out_strides, out_shape);
       sample_desc.anchor = anchor;
       sample_desc.in_shape = in_shape;
+      sample_desc.out_shape = out_shape;
 
       const InputType *in_data = in.tensor_data(i);
       // `sample_desc.in` is expected to point to the slice anchor

--- a/dali/kernels/slice/slice_kernel_test.h
+++ b/dali/kernels/slice/slice_kernel_test.h
@@ -301,6 +301,22 @@ struct ArgsGen_PadAlsoChDim {
     args.shape[0] = 2 * input_shape[0];
     args.shape[1] = 2 * input_shape[1];
     args.shape[2] = input_shape[2] + 1;
+    args.fill_values = {100};
+    args.channel_dim = -1;
+    return args;
+  }
+};
+
+template <typename OutputType, int Dims = 3>
+struct ArgsGen_PadAlsoChDim_MultiChannelFillValues {
+  SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceArgs<OutputType, 3> args;
+    args.anchor[0] = -input_shape[0] / 2;
+    args.anchor[1] = -input_shape[1] / 2;
+    args.anchor[2] = 0;
+    args.shape[0] = 2 * input_shape[0];
+    args.shape[1] = 2 * input_shape[1];
+    args.shape[2] = input_shape[2] + 1;
     args.fill_values = {100, 110, 120, 128};
     args.channel_dim = 2;
     return args;
@@ -308,7 +324,39 @@ struct ArgsGen_PadAlsoChDim {
 };
 
 template <typename OutputType, int Dims = 3>
+struct ArgsGen_PadOnlyChDim {
+  SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceArgs<OutputType, 3> args;
+    args.anchor[0] = 0;
+    args.anchor[1] = 0;
+    args.anchor[2] = 0;
+    args.shape[0] = input_shape[0];
+    args.shape[1] = input_shape[1];
+    args.shape[2] = input_shape[2] + 1;
+    args.fill_values = {100};
+    args.channel_dim = -1;
+    return args;
+  }
+};
+
+template <typename OutputType, int Dims = 3>
 struct ArgsGen_PadAlsoChDim_ChFirst {
+  SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceArgs<OutputType, 3> args;
+    args.anchor[0] = 0;
+    args.anchor[1] = -input_shape[1] / 2;
+    args.anchor[2] = -input_shape[2] / 2;
+    args.shape[0] = input_shape[0] + 1;
+    args.shape[1] = 2 * input_shape[1];
+    args.shape[2] = 2 * input_shape[2];
+    args.fill_values = {100};
+    args.channel_dim = -1;
+    return args;
+  }
+};
+
+template <typename OutputType, int Dims = 3>
+struct ArgsGen_PadAlsoChDim_ChFirst_MultiChannelFillValues {
   SliceArgs<OutputType, Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceArgs<OutputType, 3> args;
     args.anchor[0] = 0;
@@ -352,8 +400,12 @@ using SLICE_TEST_TYPES = ::testing::Types<
     SliceTestArgs<int, int, 3, 1, 20, ArgsGen_MultiChannelPad<int, 3>, 20, 20, 3>,
     SliceTestArgs<int, int, 3, 1, 20, ArgsGen_MultiChannelPad_ChFirst<int, 3>, 3, 20, 20>,
     SliceTestArgs<int, int, 3, 1, 20, ArgsGen_PadAlsoChDim<int, 3>, 20, 20, 3>,
+    SliceTestArgs<int, int, 3, 1, 20, ArgsGen_PadAlsoChDim_MultiChannelFillValues<int, 3>, 20, 20, 3>,  // NOLINT
+    SliceTestArgs<int, int, 3, 1, 20, ArgsGen_PadOnlyChDim<int, 3>, 20, 20, 3>,
     SliceTestArgs<int, int, 3, 1, 20, ArgsGen_PadAlsoChDim_ChFirst<int, 3>, 3, 20, 20>,
-    SliceTestArgs<int, int, 3, 10, 20, ArgsGen_PadAlsoChDim_ChFirst<int, 3>, 3, 20, 20>
+    SliceTestArgs<int, int, 3, 1, 20, ArgsGen_PadAlsoChDim_ChFirst_MultiChannelFillValues<int, 3>, 3, 20, 20>,  // NOLINT
+    SliceTestArgs<int, int, 3, 10, 20, ArgsGen_PadAlsoChDim_ChFirst<int, 3>, 3, 20, 20>,
+    SliceTestArgs<int, int, 3, 10, 20, ArgsGen_PadAlsoChDim_ChFirst_MultiChannelFillValues<int, 3>, 3, 20, 20>  // NOLINT
 >;
 
 using SLICE_TEST_TYPES_CPU_ONLY = ::testing::Types<

--- a/dali/kernels/slice/slice_kernel_utils.h
+++ b/dali/kernels/slice/slice_kernel_utils.h
@@ -16,6 +16,7 @@
 #define DALI_KERNELS_SLICE_SLICE_KERNEL_UTILS_H_
 
 #include <vector>
+#include <tuple>
 #include <utility>
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
@@ -38,11 +39,6 @@ void CheckValidOutputShape(const TensorShape<Dims>& in_sample_shape,
                            const TensorShape<Dims>& out_sample_shape,
                            const Args& args) {
   for (size_t d = 0; d < Dims; d++) {
-    DALI_ENFORCE(
-      args.anchor[d] >= 0 && (args.anchor[d] + args.shape[d]) <= in_sample_shape[d],
-      "Slice dimension " + std::to_string(d) + " is out of bounds : anchor["
-      + std::to_string(args.anchor[d]) + "] size[" + std::to_string(args.shape[d])
-      + "] input dimension size[" + std::to_string(in_sample_shape[d]) + "]");
     DALI_ENFORCE(args.shape[d] <= out_sample_shape[d],
       "Output shape dimension " + std::to_string(d) + " is too small");
   }
@@ -78,6 +74,29 @@ inline bool NeedPad(int ndim,
   for (int d = 0; d < ndim && !need_pad; d++)
     need_pad = (anchor[d] < 0) || ((anchor[d] + out_shape[d]) > in_shape[d]);
   return need_pad;
+}
+
+/**
+ * @brief Fills output with nchannel values repeatedly
+ */
+template <typename T>
+void PadFill(T *output, const T *fill_values, int64_t npixels, int64_t nchannels) {
+  int64_t n = npixels * nchannels;
+  int64_t i = 0;
+  for (; i < nchannels; i++)
+    output[i] = fill_values[i];
+  for (; i < n; i++)
+    output[i] = output[i - nchannels];
+}
+
+inline std::tuple<int64_t, int64_t, int64_t> CalcPadCopyExtents(int64_t anchor,
+                                                                int64_t in_extent,
+                                                                int64_t out_extent) {
+  int64_t pad_before = std::min(out_extent, std::max<int64_t>(0, -anchor));
+  int64_t to_copy = std::max<int64_t>(
+      0, std::min(in_extent - std::max<int64_t>(0, anchor), out_extent - pad_before));
+  int64_t pad_after = out_extent - pad_before - to_copy;
+  return std::tuple<int64_t, int64_t, int64_t>{pad_before, to_copy, pad_after};
 }
 
 }  // namespace kernels


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug when padding last dimension in Slice GPU

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *strides were used to fuse dimensions before. However, for the last dimension strides are the same so we ended up fusing a dimension that needed to be padded. To solve that, we switch to checking shapes instead of strides (out_shape had to be added)*
 - Affected modules and functionalities:
     *Slice GPU kernel*
 - Key points relevant for the review:
     *Changes in the kernel*
 - Validation and testing:
     *Unit tests added*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
