### PR TITLE
Use Slice kernel to implement Pad operator (instead of SliceFlipNormalizePermutePad)

### DIFF
--- a/dali/operators/generic/pad.cc
+++ b/dali/operators/generic/pad.cc
@@ -17,7 +17,7 @@
 
 #include "dali/core/static_switch.h"
 #include "dali/core/tensor_layout.h"
-#include "dali/kernels/slice/slice_flip_normalize_permute_pad_cpu.h"
+#include "dali/kernels/slice/slice_cpu.h"
 #include "dali/operators/generic/pad.h"
 #include "dali/pipeline/data/views.h"
 
@@ -168,8 +168,8 @@ bool Pad<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
 
   TYPE_SWITCH(input.type().id(), type2id, T, PAD_SUPPORTED_TYPES, (
     VALUE_SWITCH(ndim, Dims, PAD_SUPPORTED_NDIMS, (
-      using Kernel = kernels::SliceFlipNormalizePermutePadCpu<T, T, Dims>;
-      using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
+      using Kernel = kernels::SliceCPU<T, T, Dims>;
+      using Args = kernels::SliceArgs<T, Dims>;
 
       kmgr_.Resize<Kernel>(nthreads, nsamples);
       output_desc[0].type = TypeInfo::Create<T>();
@@ -198,8 +198,8 @@ void Pad<CPUBackend>::RunImpl(workspace_t<CPUBackend> &ws) {
 
   TYPE_SWITCH(input.type().id(), type2id, T, PAD_SUPPORTED_TYPES, (
     VALUE_SWITCH(ndim, Dims, PAD_SUPPORTED_NDIMS, (
-      using Kernel = kernels::SliceFlipNormalizePermutePadCpu<T, T, Dims>;
-      using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
+      using Kernel = kernels::SliceCPU<T, T, Dims>;
+      using Args = kernels::SliceArgs<T, Dims>;
 
       for (int i = 0; i < nsamples; i++) {
         thread_pool.DoWorkWithID(

--- a/dali/operators/generic/pad.cu
+++ b/dali/operators/generic/pad.cu
@@ -17,7 +17,7 @@
 #include "dali/operators/generic/pad.h"
 #include "dali/core/static_switch.h"
 #include "dali/pipeline/data/views.h"
-#include "dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h"
+#include "dali/kernels/slice/slice_gpu.cuh"
 
 namespace dali {
 
@@ -33,8 +33,8 @@ bool Pad<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
 
   TYPE_SWITCH(input.type().id(), type2id, T, PAD_SUPPORTED_TYPES, (
     VALUE_SWITCH(ndim, Dims, PAD_SUPPORTED_NDIMS, (
-      using Kernel = kernels::SliceFlipNormalizePermutePadGpu<T, T, Dims>;
-      using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
+      using Kernel = kernels::SliceGPU<T, T, Dims>;
+      using Args = kernels::SliceArgs<T, Dims>;
 
       kernels::KernelContext ctx;
       ctx.gpu.stream = ws.stream();
@@ -60,8 +60,8 @@ void Pad<GPUBackend>::RunImpl(workspace_t<GPUBackend> &ws) {
   int ndim = input.shape().sample_dim();
   TYPE_SWITCH(input.type().id(), type2id, T, PAD_SUPPORTED_TYPES, (
     VALUE_SWITCH(ndim, Dims, PAD_SUPPORTED_NDIMS, (
-      using Kernel = kernels::SliceFlipNormalizePermutePadGpu<T, T, Dims>;
-      using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
+      using Kernel = kernels::SliceGPU<T, T, Dims>;
+      using Args = kernels::SliceArgs<T, Dims>;
 
       auto in_view = view<const T, Dims>(input);
       auto out_view = view<T, Dims>(output);

--- a/dali/operators/generic/pad.h
+++ b/dali/operators/generic/pad.h
@@ -144,7 +144,8 @@ class Pad : public Operator<Backend> {
         sample_args.anchor[d] = 0;
         sample_args.shape[d] = sample_shape[d];
       }
-      sample_args.fill_values.push_back(fill_value_);
+      sample_args.fill_values.resize(1);
+      sample_args.fill_values[0] = fill_value_;
 
       for (int i = 0; i < naxes; i++) {
         auto axis = axes_[i];

--- a/dali/operators/generic/pad.h
+++ b/dali/operators/generic/pad.h
@@ -78,17 +78,6 @@ class Pad : public Operator<Backend> {
   template <typename Args>
   std::vector<Args>& FillArgs(TensorListShape<> in_shape, TensorLayout in_layout) {
     int nsamples = in_shape.num_samples();
-    if (!kernel_sample_args_.has_value()) {
-      kernel_sample_args_ = std::vector<Args>();
-    }
-
-    auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
-    kernel_sample_args.clear();
-    kernel_sample_args.reserve(nsamples);
-    for (int i = 0; i < nsamples; i++) {
-      kernel_sample_args.emplace_back(in_shape[i]);
-    }
-
     int ndim = in_shape.sample_dim();
 
     for (auto axis : axes_) {
@@ -140,13 +129,26 @@ class Pad : public Operator<Backend> {
       }
     }
 
+    if (!kernel_sample_args_.has_value()) {
+      kernel_sample_args_ = std::vector<Args>();
+    }
+
+    auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
+    kernel_sample_args.clear();
+    kernel_sample_args.resize(nsamples);
+
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
       auto &sample_args = kernel_sample_args[sample_idx];
       const auto &sample_shape = in_shape[sample_idx];
-      sample_args.padding_val = fill_value_;
+      for (int d = 0; d < sample_args.anchor.size(); d++) {
+        sample_args.anchor[d] = 0;
+        sample_args.shape[d] = sample_shape[d];
+      }
+      sample_args.fill_values.push_back(fill_value_);
+
       for (int i = 0; i < naxes; i++) {
         auto axis = axes_[i];
-        auto &extent = sample_args.padded_shape[axis];
+        auto &extent = sample_args.shape[axis];
         // Adjust padded extent only if it is bigger than the sample's extent
         // That is, we are not cropping the image
         if (padded_shape[axis] > extent)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>


#### Why we need this PR?
*Pick one, remove the rest*
- It replaces the kernel used to implement Pad operator, from SliceFlipNormalizePermutePad to Slice). Slice now supports padding as well and it should be more efficient than the implementation supporting normalize/permute/flip.

Note: To be merged after https://github.com/NVIDIA/DALI/pull/2056

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Replace the kernel used to implement Pad operator*
 - Affected modules and functionalities:
     *Pad operator*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
