### PR TITLE
Fix TL1_jupyter_conda test

### DIFF
--- a/qa/TL1_jupyter_conda/test_cupy.sh
+++ b/qa/TL1_jupyter_conda/test_cupy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="jupyter numpy matplotlib cupy"
+pip_packages="jupyter numpy matplotlib cupy imageio"
 target_dir=./docs/examples
 
 # populate epilog and prolog with variants to enable/disable conda
@@ -9,9 +9,15 @@ prolog=(enable_conda)
 epilog=(disable_conda)
 
 test_body() {
-    jupyter nbconvert --to notebook --inplace --execute \
-                      --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
-                      --ExecutePreprocessor.timeout=300 custom_operations/gpu_python_operator.ipynb
+    test_files=(
+        "custom_operations/gpu_python_operator.ipynb"
+        "general/data_loading/external_input.ipynb"
+    )
+    for f in ${test_files[@]}; do
+        jupyter nbconvert --to notebook --inplace --execute \
+                        --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
+                        --ExecutePreprocessor.timeout=300 $f;
+    done
 }
 
 pushd ../..

--- a/qa/TL1_jupyter_conda/test_nofw.sh
+++ b/qa/TL1_jupyter_conda/test_nofw.sh
@@ -21,7 +21,7 @@ test_body() {
     # test all jupyters except one related to a particular FW,
     # and one requiring a dedicated HW (multiGPU and OF)
     # optical flow requires TU102 architecture whilst this test can be run on any GPU
-    black_list_files="multigpu\|mxnet*\|tensorflow*\|pytorch*\|paddle*\|optical_flow*\|python_operator*\|#"
+    black_list_files="multigpu\|mxnet\|tensorflow\|pytorch\|paddle\|external_input.ipynb\|optical_flow\|python_operator\|#"
 
     find * -name "*.ipynb" | sed "/${black_list_files}/d" | xargs -i jupyter nbconvert \
                     --to notebook --inplace --execute \


### PR DESCRIPTION
- changes introduced by https://github.com/NVIDIA/DALI/pull/1997 were not applied to conda based test
- ExternalSource jupyter example is extended by GPU case and requires cupy and imageio to run, this PR fixes this

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes TL1_jupyter_conda test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     ExternalSource jupyter example is extended by GPU case and requires cupy and imageio to run, this PR fixes this
 - Affected modules and functionalities:
     TL1_jupyter_conda 
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
    NA


**JIRA TASK**: *[NA]*
