### PR TITLE
Use HostWorkspace in CropMirrorNormalize

### DIFF
--- a/dali/benchmark/crop_mirror_normalize_bench.cc
+++ b/dali/benchmark/crop_mirror_normalize_bench.cc
@@ -21,7 +21,7 @@ namespace dali {
 static void CropMirrorNormalizeCPUArgs(benchmark::internal::Benchmark *b) {
   int batch_size = 8;
   int mean = 128, std = 1;
-  for (auto &output_dtype : {DALI_FLOAT}) {
+  for (auto &dtype : {DALI_FLOAT}) {
     for (auto nchw : {0, 1}) {
       for (int mirror : {0, 1}) {
         for (int pad : {0, 1}) {
@@ -29,7 +29,7 @@ static void CropMirrorNormalizeCPUArgs(benchmark::internal::Benchmark *b) {
             int W = H, C = 3;
             int crop_h = static_cast<float>(9 * H / 10);
             int crop_w = static_cast<float>(9 * W / 10);
-            b->Args({output_dtype, nchw, mirror, pad,
+            b->Args({dtype, nchw, mirror, pad,
                      batch_size, H, W, C, crop_h, crop_w,
                      mean, std});
           }
@@ -40,7 +40,7 @@ static void CropMirrorNormalizeCPUArgs(benchmark::internal::Benchmark *b) {
 }
 
 BENCHMARK_DEFINE_F(OperatorBench, CropMirrorNormalizeCPU)(benchmark::State& st) {
-  DALIDataType output_dtype = static_cast<DALIDataType>(st.range(0));
+  DALIDataType dtype = static_cast<DALIDataType>(st.range(0));
   int nchw = static_cast<int>(st.range(1));
   int mirror = st.range(2);
   int pad = st.range(3);
@@ -61,7 +61,7 @@ BENCHMARK_DEFINE_F(OperatorBench, CropMirrorNormalizeCPU)(benchmark::State& st) 
       .AddArg("device", "cpu")
       .AddArg("output_type", DALI_RGB)
       .AddArg("output_layout", nchw ? "CHW" : "HWC")
-      .AddArg("dtype", output_dtype)
+      .AddArg("dtype", dtype)
       .AddArg("crop", std::vector<float>{static_cast<float>(crop_h), static_cast<float>(crop_w)})
       .AddArg("crop_pos_x", 0.5f)
       .AddArg("crop_pos_y", 0.5f)
@@ -83,12 +83,12 @@ static void CropMirrorNormalizeGPUArgs(benchmark::internal::Benchmark *b) {
       int W = H, C = 3;
       int crop_h = static_cast<float>(9 * H / 10);
       int crop_w = static_cast<float>(9 * W / 10);
-      for (auto &output_dtype : {DALI_FLOAT}) {
+      for (auto &dtype : {DALI_FLOAT}) {
         for (auto nchw : {0, 1}) {
           for (int mirror : {0, 1}) {
             for (int pad : {0, 1}) {
               b->Args({batch_size, H, W, C, crop_h, crop_w,
-                       output_dtype, nchw, mirror,
+                       dtype, nchw, mirror,
                        pad, mean, std});
             }
           }
@@ -105,7 +105,7 @@ BENCHMARK_DEFINE_F(OperatorBench, CropMirrorNormalizeGPU)(benchmark::State& st) 
   int C = st.range(3);
   int crop_h = st.range(4);
   int crop_w = st.range(5);
-  DALIDataType output_dtype = static_cast<DALIDataType>(st.range(6));
+  DALIDataType dtype = static_cast<DALIDataType>(st.range(6));
   int nchw = static_cast<int>(st.range(7));
   int mirror = st.range(8);
   int pad = st.range(9);
@@ -120,7 +120,7 @@ BENCHMARK_DEFINE_F(OperatorBench, CropMirrorNormalizeGPU)(benchmark::State& st) 
       .AddArg("device", "gpu")
       .AddArg("output_type", DALI_RGB)
       .AddArg("output_layout", nchw ? "CHW" : "HWC")
-      .AddArg("dtype", output_dtype)
+      .AddArg("dtype", dtype)
       .AddArg("crop", std::vector<float>{static_cast<float>(crop_h), static_cast<float>(crop_w)})
       .AddArg("crop_pos_x", 0.5f)
       .AddArg("crop_pos_y", 0.5f)

--- a/dali/operators/image/crop/crop_mirror_normalize.cc
+++ b/dali/operators/image/crop/crop_mirror_normalize.cc
@@ -53,7 +53,10 @@ normalization only.
   .AddOptionalArg("std",
     R"code(Standard deviation values for image normalization.)code",
     std::vector<float>{1.0f})
-  .AddParent("Crop");
+  .AddOptionalArg("image_type",
+    R"code(The color space of input and output image)code",
+    DALI_RGB, false)
+  .AddParent("CropAttr");
 
 DALI_REGISTER_OPERATOR(CropMirrorNormalize, CropMirrorNormalize<CPUBackend>, CPU);
 
@@ -63,25 +66,27 @@ bool CropMirrorNormalize<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
   output_desc.resize(1);
   SetupAndInitialize(ws);
   const auto &input = ws.InputRef<CPUBackend>(0);
-  auto &output = ws.OutputRef<CPUBackend>(0);
-  std::size_t number_of_dims = input.shape().sample_dim();
+  auto in_shape = input.shape();
+  int ndim = in_shape.sample_dim();
+  int nsamples = in_shape.size();
+  auto nthreads = ws.GetThreadPool().size();
   TYPE_SWITCH(input_type_, type2id, InputType, CMN_IN_TYPES, (
     TYPE_SWITCH(output_type_, type2id, OutputType, CMN_OUT_TYPES, (
-      VALUE_SWITCH(number_of_dims, Dims, CMN_NDIMS, (
+      VALUE_SWITCH(ndim, Dims, CMN_NDIMS, (
         using Kernel = kernels::SliceFlipNormalizePermutePadCpu<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
         output_desc[0].type = TypeInfo::Create<OutputType>();
-        output_desc[0].shape.resize(batch_size_, Dims);
-        kmgr_.Initialize<Kernel>();
+        output_desc[0].shape.resize(nsamples, Dims);
+        kmgr_.Resize<Kernel>(nthreads, nsamples);
         // Do the kernel setup
         auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
-        for (int sample_idx = 0; sample_idx < batch_size_; sample_idx++) {
+        for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
           auto in_view = view<const InputType, Dims>(input[sample_idx]);
           kernels::KernelContext ctx;
           auto &req = kmgr_.Setup<Kernel>(sample_idx, ctx, in_view, kernel_sample_args[sample_idx]);
           output_desc[0].shape.set_tensor_shape(sample_idx, req.output_shapes[0][0].shape);
         }
-      ), DALI_FAIL(make_string("Not supported number of dimensions:", number_of_dims));); // NOLINT
+      ), DALI_FAIL(make_string("Not supported number of dimensions:", ndim));); // NOLINT
     ), DALI_FAIL(make_string("Not supported output type:", output_type_));); // NOLINT
   ), DALI_FAIL(make_string("Not supported input type:", input_type_));); // NOLINT
 
@@ -89,26 +94,31 @@ bool CropMirrorNormalize<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
 }
 
 template <>
-void CropMirrorNormalize<CPUBackend>::RunImpl(SampleWorkspace &ws) {
-  const auto &input = ws.Input<CPUBackend>(0);
-  auto &output = ws.Output<CPUBackend>(0);
-  auto data_idx = ws.data_idx();
-  auto sample_idx = data_idx;
-  std::size_t number_of_dims = input.shape().sample_dim();
-
+void CropMirrorNormalize<CPUBackend>::RunImpl(HostWorkspace &ws) {
+  const auto &input = ws.InputRef<CPUBackend>(0);
+  auto &output = ws.OutputRef<CPUBackend>(0);
+  output.SetLayout(output_layout_);
+  auto in_shape = input.shape();
+  int ndim = in_shape.sample_dim();
+  int nsamples = in_shape.size();
+  auto& thread_pool = ws.GetThreadPool();
   TYPE_SWITCH(input_type_, type2id, InputType, CMN_IN_TYPES, (
     TYPE_SWITCH(output_type_, type2id, OutputType, CMN_OUT_TYPES, (
-      VALUE_SWITCH(number_of_dims, Dims, CMN_NDIMS, (
+      VALUE_SWITCH(ndim, Dims, CMN_NDIMS, (
         using Kernel = kernels::SliceFlipNormalizePermutePadCpu<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
-        auto in_view = view<const InputType, Dims>(input);
-        auto out_view = view<OutputType, Dims>(output);
         auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
-        auto &args = kernel_sample_args[sample_idx];
-        kernels::KernelContext ctx;
-        kmgr_.Run<Kernel>(ws.thread_idx(), sample_idx, ctx, out_view, in_view, args);
-
-      ), DALI_FAIL(make_string("Not supported number of dimensions:", number_of_dims));); // NOLINT
+        for (int sample_id = 0; sample_id < nsamples; sample_id++) {
+          thread_pool.DoWorkWithID(
+            [this, &input, &output, &kernel_sample_args, sample_id](int thread_id) {
+              auto in_view = view<const InputType, Dims>(input[sample_id]);
+              auto out_view = view<OutputType, Dims>(output[sample_id]);
+              auto &args = kernel_sample_args[sample_id];
+              kernels::KernelContext ctx;
+              kmgr_.Run<Kernel>(thread_id, sample_id, ctx, out_view, in_view, args);
+            });
+        }
+      ), DALI_FAIL(make_string("Not supported number of dimensions:", ndim));); // NOLINT
     ), DALI_FAIL(make_string("Not supported output type:", output_type_));); // NOLINT
   ), DALI_FAIL(make_string("Not supported input type:", input_type_));); // NOLINT
 }

--- a/dali/operators/image/crop/crop_mirror_normalize.cu
+++ b/dali/operators/image/crop/crop_mirror_normalize.cu
@@ -26,25 +26,24 @@ bool CropMirrorNormalize<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
                                                 const DeviceWorkspace &ws) {
   output_desc.resize(1);
   SetupAndInitialize(ws);
-  const auto &input = ws.Input<GPUBackend>(0);
-  auto &output = ws.OutputRef<GPUBackend>(0);
-  std::size_t number_of_dims = input.shape().sample_dim();
+  const auto &input = ws.InputRef<GPUBackend>(0);
+  int ndim = input.shape().sample_dim();
   TYPE_SWITCH(input_type_, type2id, InputType, CMN_IN_TYPES, (
     TYPE_SWITCH(output_type_, type2id, OutputType, CMN_OUT_TYPES, (
-      VALUE_SWITCH(number_of_dims, Dims, CMN_NDIMS, (
+      VALUE_SWITCH(ndim, Dims, CMN_NDIMS, (
         using Kernel = kernels::SliceFlipNormalizePermutePadGpu<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
         auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
         output_desc[0].type = TypeInfo::Create<OutputType>();
         output_desc[0].shape.resize(batch_size_, Dims);
-        kmgr_.Initialize<Kernel>();
+        kmgr_.Resize<Kernel>(1, 1);
 
         kernels::KernelContext ctx;
         ctx.gpu.stream = ws.stream();
         auto in_view = view<const InputType, Dims>(input);
         auto &req = kmgr_.Setup<Kernel>(0, ctx, in_view, kernel_sample_args);
         output_desc[0].shape = req.output_shapes[0];
-      ), DALI_FAIL(make_string("Not supported number of dimensions:", number_of_dims));); // NOLINT
+      ), DALI_FAIL(make_string("Not supported number of dimensions:", ndim));); // NOLINT
     ), DALI_FAIL(make_string("Not supported output type:", output_type_));); // NOLINT
   ), DALI_FAIL(make_string("Not supported input type:", input_type_));); // NOLINT
   return true;
@@ -52,13 +51,13 @@ bool CropMirrorNormalize<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
 
 template<>
 void CropMirrorNormalize<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
-  const auto &input = ws.Input<GPUBackend>(0);
-  auto &output = ws.Output<GPUBackend>(0);
-
-  std::size_t number_of_dims = input.shape().sample_dim();
+  const auto &input = ws.InputRef<GPUBackend>(0);
+  auto &output = ws.OutputRef<GPUBackend>(0);
+  output.SetLayout(output_layout_);
+  int ndim = input.shape().sample_dim();
   TYPE_SWITCH(input_type_, type2id, InputType, CMN_IN_TYPES, (
     TYPE_SWITCH(output_type_, type2id, OutputType, CMN_OUT_TYPES, (
-      VALUE_SWITCH(number_of_dims, Dims, CMN_NDIMS, (
+      VALUE_SWITCH(ndim, Dims, CMN_NDIMS, (
         using Kernel = kernels::SliceFlipNormalizePermutePadGpu<OutputType, InputType, Dims>;
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
         auto in_view = view<const InputType, Dims>(input);
@@ -67,7 +66,7 @@ void CropMirrorNormalize<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
         ctx.gpu.stream = ws.stream();
         auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
         kmgr_.Run<Kernel>(0, 0, ctx, out_view, in_view, kernel_sample_args);
-      ), DALI_FAIL(make_string("Not supported number of dimensions:", number_of_dims));); // NOLINT
+      ), DALI_FAIL(make_string("Not supported number of dimensions:", ndim));); // NOLINT
     ), DALI_FAIL(make_string("Not supported output type:", output_type_));); // NOLINT
   ), DALI_FAIL(make_string("Not supported input type:", input_type_));); // NOLINT
 }


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It changes CropMirrorNormalize operator to use HostWorkspace instead of SampleWorkspace. Needed as a pre-step for the pad support rework, and to fix the benchmark

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Adjusted CropMirrorNormalize operator to use HostWorkspace instead of SampleWorkspace*
     *Adjusted CropMirrorNormalize operator to avoid accessing Outputs during SetupImpl step*
 - Affected modules and functionalities:
     *CropMirrorNormalize operator and benchmarks*
 - Key points relevant for the review:
     *Operator changes*
 - Validation and testing:
     *No new tests added*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
