### PR TITLE
Add better return value/error status checks

### DIFF
--- a/dali/image/tiff_libtiff.cc
+++ b/dali/image/tiff_libtiff.cc
@@ -240,6 +240,7 @@ TiffImage_Libtiff::TiffImage_Libtiff(const uint8_t *encoded_buffer,
                    &detail::BufDecoderHelper::size,
                    &detail::BufDecoderHelper::map,
                    /*unmap=*/0));
+  DALI_ENFORCE(tif_, "Cannot open TIFF file.");
 
   LIBTIFF_CALL(
     TIFFGetField(tif_.get(), TIFFTAG_IMAGELENGTH, &shape_[0]));

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
@@ -165,8 +165,9 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
         info->crop_window = crop_generator(shape, "HW");
         auto &crop_window = info->crop_window;
         DALI_ENFORCE(crop_window.IsInRange(shape));
-        nvjpegDecodeParamsSetROI(decode_params_[data_idx],
-          crop_window.anchor[1], crop_window.anchor[0], crop_window.shape[1], crop_window.shape[0]);
+        NVJPEG_CALL(nvjpegDecodeParamsSetROI(decode_params_[data_idx],
+                                             crop_window.anchor[1], crop_window.anchor[0],
+                                             crop_window.shape[1], crop_window.shape[0]));
         info->widths[0] = crop_window.shape[1];
         info->heights[0] = crop_window.shape[0];
       }

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -380,9 +380,11 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
         bool hw_decode = false;
 #if NVJPEG_VER_MAJOR >= 11
         if (!crop_generator && state_hw_batched_ != nullptr) {
-          nvjpegJpegStreamParseHeader(handle_, input_data, in_size, hw_decoder_jpeg_stream_);
+          NVJPEG_CALL(nvjpegJpegStreamParseHeader(handle_, input_data, in_size,
+                                                  hw_decoder_jpeg_stream_));
           int is_supported = -1;
-          nvjpegDecodeBatchedSupported(handle_, hw_decoder_jpeg_stream_, &is_supported);
+          NVJPEG_CALL(nvjpegDecodeBatchedSupported(handle_, hw_decoder_jpeg_stream_,
+                                                   &is_supported));
           hw_decode = is_supported == 0;
           if (!hw_decode) {
             LOG_LINE << "Sample \"" << data.file_name
@@ -422,7 +424,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
                                              data.roi.shape[1], data.roi.shape[0]));
       } else {
         output_shape_.set_tensor_shape(i, data.shape);
-        nvjpegDecodeParamsSetROI(data.params, 0, 0, -1, -1);
+        NVJPEG_CALL(nvjpegDecodeParamsSetROI(data.params, 0, 0, -1, -1));
       }
 
       data.is_progressive = IsProgressiveJPEG(input_data, in_size);

--- a/dali/operators/image/color/color_space_conversion.cu
+++ b/dali/operators/image/color/color_space_conversion.cu
@@ -115,7 +115,7 @@ void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
 
   cudaStream_t old_stream = nppGetStream();
   auto stream = ws.stream();
-  nppSetStream(stream);
+  DALI_CHECK_NPP(nppSetStream(stream));
 
   if (InputLayout(ws, 0) == "HWC") {
     // RGB -> BGR || BGR -> RGB
@@ -215,7 +215,7 @@ void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
     }
   }
 
-  nppSetStream(old_stream);
+  DALI_CHECK_NPP(nppSetStream(old_stream));
 }
 
 DALI_REGISTER_OPERATOR(ColorSpaceConversion, ColorSpaceConversion<GPUBackend>, GPU);

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -143,6 +143,7 @@ void parse_image_infos(LookaheadParser &parser, std::vector<ImageInfo> &image_in
     }
     image_infos.emplace_back(std::move(image_info));
   }
+  DALI_ENFORCE(parser.IsValid(), "Error parsing JSON file.");
 }
 
 void parse_categories(LookaheadParser &parser, std::map<int, int> &category_ids) {

--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -410,7 +410,9 @@ VideoFile& VideoLoader::get_or_open_file(const std::string &filename) {
         DALI_FAIL("Error initializing BSF.");
       }
 
-      avcodec_parameters_copy(codecpar(stream), file.bsf_ctx_->par_out);
+      if (avcodec_parameters_copy(codecpar(stream), file.bsf_ctx_->par_out) < 0) {
+        DALI_FAIL("Cannot save BSF parameters.");
+      }
 #else
       auto raw_bsf_ctx_ = av_bitstream_filter_init(filtername);
       if (!raw_bsf_ctx_) {


### PR DESCRIPTION
- adds TIFF decoder creation status
- adds a couple of NVJPEG_CALL to ImageDecoder where nvJPEG library calls return values were not checked
- adds rapidjson parsing status check
- adds missing FFmpeg function return value checks

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds better return value/error status checks

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     added missing return value/error status checks when calling an external library
 - Affected modules and functionalities:
     COCOreader
     ImageDecoder GPU
     VideoDecoder
     TIFF decoder
 - Key points relevant for the review:
     If any unchecked value didn't slip out
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1180]*
