### PR TITLE
Check libjpeg return codes

### DIFF
--- a/dali/image/jpeg_mem.cc
+++ b/dali/image/jpeg_mem.cc
@@ -173,7 +173,7 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
     return nullptr;
   }
 
-  jpeg_start_decompress(&cinfo);
+  DALI_ENFORCE(jpeg_start_decompress(&cinfo));
 
   JDIMENSION target_output_width = cinfo.output_width;
   JDIMENSION target_output_height = cinfo.output_height;
@@ -369,8 +369,8 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
 #if defined(LIBJPEG_TURBO_VERSION)
   if (flags.crop && cinfo.output_scanline < cinfo.output_height) {
     // Skip the rest of scanlines, required by jpeg_destroy_decompress.
-    jpeg_skip_scanlines(&cinfo,
-                        cinfo.output_height - flags.crop_y - flags.crop_height);
+    JDIMENSION skip_count = cinfo.output_height - flags.crop_y - flags.crop_height;
+    DALI_ENFORCE(jpeg_skip_scanlines(&cinfo, skip_count) == skip_count);
     // After this, cinfo.output_height must be equal to cinfo.output_height;
     // otherwise, jpeg_destroy_decompress would fail.
   }
@@ -437,7 +437,7 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
   // Handle errors in JPEG
   switch (error) {
     case JPEGERRORS_OK:
-      jpeg_finish_decompress(&cinfo);
+      DALI_ENFORCE(jpeg_finish_decompress(&cinfo));
       break;
     case JPEGERRORS_UNEXPECTED_END_OF_DATA:
     case JPEGERRORS_BAD_PARAM:
@@ -591,8 +591,8 @@ bool GetImageInfo(const void* srcdata, int datasize, int* width, int* height,
   jpeg_create_decompress(&cinfo);
   SetSrc(&cinfo, srcdata, datasize, false);
 
-  jpeg_read_header(&cinfo, TRUE);
-  jpeg_start_decompress(&cinfo);  // required to transfer image size to cinfo
+  DALI_ENFORCE(jpeg_read_header(&cinfo, TRUE) == JPEG_HEADER_OK);
+  DALI_ENFORCE(jpeg_start_decompress(&cinfo));  // required to transfer image size to cinfo
   if (width) *width = cinfo.output_width;
   if (height) *height = cinfo.output_height;
   if (components) *components = cinfo.output_components;

--- a/dali/image/jpeg_mem.cc
+++ b/dali/image/jpeg_mem.cc
@@ -370,9 +370,10 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
   if (flags.crop && cinfo.output_scanline < cinfo.output_height) {
     // Skip the rest of scanlines, required by jpeg_destroy_decompress.
     JDIMENSION skip_count = cinfo.output_height - flags.crop_y - flags.crop_height;
-    DALI_ENFORCE(jpeg_skip_scanlines(&cinfo, skip_count) == skip_count);
-    // After this, cinfo.output_height must be equal to cinfo.output_height;
+    jpeg_skip_scanlines(&cinfo, skip_count);
+    // After this, cinfo.output_height must be equal to cinfo.output_scanline;
     // otherwise, jpeg_destroy_decompress would fail.
+    DALI_ENFORCE(cinfo.output_height == cinfo.output_scanline);
   }
 #endif
 


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds error checking to external library calls

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added error checking to those API calls that return error codes*
 - Affected modules and functionalities:
     *Host jpeg decoder*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
