### PR TITLE
Assertion is always true, remove parentheses

### DIFF
--- a/dali/test/python/test_RN50_data_fw_iterators.py
+++ b/dali/test/python/test_RN50_data_fw_iterators.py
@@ -220,7 +220,7 @@ Iterators = {
     "paddle": [import_paddle]
 }
 
-assert(args.framework in Iterators, "Error, framework {} not supported".format(args.framework))
+assert args.framework in Iterators, "Error, framework {} not supported".format(args.framework)
 for imports in Iterators[args.framework]:
     IteratorClass = imports()
     test_fw_iter(IteratorClass, args)


### PR DESCRIPTION
Signed-off-by: cclauss <cclauss@me.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug SyntaxWarning on Python >= 3.8
% `python3.8`
```
>>> assert(True is False, "Really?")
<stdin>:1: SyntaxWarning: assertion is always true, perhaps remove parentheses?
```

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *[ Explain solution of the problem, a new feature added here. ]*
 - Affected modules and functionalities:
     *[ Describe here what was changed, added, removed. ]*
 - Key points relevant for the review:
     *[ Describe here what is the most important part that reviewers should focus on. ]*
 - Validation and testing:
     *[ Describe here if and how this PR is tested. ]*
 - Documentation (including examples):
     *[ Describe here if documentation and examples were updated. ]*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
