### PR TITLE
Allow nvJPEG to pre-allocate pinned and device buffers during construction

### DIFF
--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -39,12 +39,22 @@ N.B.: Hybrid Huffman decoder still uses mostly the CPU.)code",
   .AddOptionalArg("device_memory_padding",
       R"code(**`mixed` backend only** Padding for nvJPEG's device memory allocations in bytes.
 This parameter helps to avoid reallocation in nvJPEG whenever a bigger image
-is encountered and internal buffer needs to be reallocated to decode it.)code",
+is encountered and the internal buffer needs to be reallocated to decode it.
+
+If a value bigger than 0 is provided, the operator will pre-allocate one device buffer of the
+requested size per thread. If chosen correctly, no more allocations will occur during the pipeline
+execution. One way to find the ideal value is to do a full run over the dataset with the argument
+``memory_stats`` set to True and then copy the "biggest" allocation value printed in the statistics.)code",
       16*1024*1024)
   .AddOptionalArg("host_memory_padding",
       R"code(**`mixed` backend only** Padding for nvJPEG's host memory allocations in bytes.
 This parameter helps to avoid reallocation in nvJPEG whenever a bigger image
-is encountered and internal buffer needs to be reallocated to decode it.)code",
+is encountered and internal buffer needs to be reallocated to decode it.
+
+If a value bigger than 0 is provided, the operator will pre-allocate two (because of double-buffering)
+host pinned buffers of the requested size per thread. If chosen correctly, no more allocations will occur
+during the pipeline execution. One way to find the ideal value is to do a full run over the dataset with the
+argument ``memory_stats`` set to True and then copy the "biggest" allocation value printed in the statistics.)code",
       8*1024*1024)  // based on ImageNet heuristics (8MB)
   .AddOptionalArg("affine",
       R"code(**`mixed` backend only** If internal threads should be affined to CPU cores)code",
@@ -67,7 +77,8 @@ loss in quality.)code",
 The information about the largest allocation might be useful to determine suitable values for
 `device_memory_padding` and `host_memory_padding` for a given dataset.
 
-Note: The statistics are global for the whole process (and not per operator instance).)code",
+Note: The statistics are global for the whole process (and not per operator instance) and include
+the allocations made during construction (when the padding hints are non-zero).)code",
       false);
 
 DALI_SCHEMA(ImageDecoder)

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -61,6 +61,13 @@ in runtime. Ignored when `split_stages` is false.)code",
       R"code(Enables fast IDCT in CPU based decompressor when GPU implementation cannot handle given image.
 According to libjpeg-turbo documentation, decompression performance is improved by 4-14% with very little
 loss in quality.)code",
+      false)
+  .AddOptionalArg("memory_stats",
+      R"code(**`mixed` backend only** Print debug information about nvJPEG allocations.
+The information about the largest allocation might be useful to determine suitable values for
+`device_memory_padding` and `host_memory_padding` for a given dataset.
+
+Note: The statistics are global for the whole process (and not per operator instance).)code",
       false);
 
 DALI_SCHEMA(ImageDecoder)

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -23,7 +23,6 @@
 #include <memory>
 #include <numeric>
 #include <atomic>
-#include <shared_mutex>
 #include "dali/pipeline/operator/operator.h"
 #include "dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_helper.h"
 #include "dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h"
@@ -98,8 +97,10 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     NVJPEG_CALL(nvjpegSetDeviceMemoryPadding(device_memory_padding, handle_));
     NVJPEG_CALL(nvjpegSetPinnedMemoryPadding(host_memory_padding, handle_));
 
-    nvjpegDevAllocator_t* device_allocator_ptr = device_memory_padding > 0 ? &device_allocator_ : nullptr;
-    nvjpegPinnedAllocator_t* pinned_allocator_ptr = host_memory_padding > 0 ? &pinned_allocator_ : nullptr;
+    nvjpegDevAllocator_t *device_allocator_ptr = device_memory_padding > 0 ?
+        &device_allocator_ : nullptr;
+    nvjpegPinnedAllocator_t *pinned_allocator_ptr = host_memory_padding > 0 ?
+        &pinned_allocator_ : nullptr;
 
     nvjpeg_memory::SetEnableMemStats(spec.GetArgument<bool>("memory_stats"));
 

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -101,8 +101,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     nvjpegDevAllocator_t* device_allocator_ptr = device_memory_padding > 0 ? &device_allocator_ : nullptr;
     nvjpegPinnedAllocator_t* pinned_allocator_ptr = host_memory_padding > 0 ? &pinned_allocator_ : nullptr;
 
-    if (device_memory_padding > 0 || host_memory_padding > 0)
-      nvjpeg_memory::SetEnableMemStats(spec.GetArgument<bool>("memory_stats"));
+    nvjpeg_memory::SetEnableMemStats(spec.GetArgument<bool>("memory_stats"));
 
     for (auto thread_id : thread_pool_.GetThreadIds()) {
       if (device_memory_padding > 0) {

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "nvjpeg_memory.h"
+#include "dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h"
 #include <nvjpeg.h>
+#include <shared_mutex>
 #include <atomic>
 #include <cassert>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <map>
-#include <vector>
 #include <mutex>
-#include <shared_mutex>
-#include "dali/kernels/alloc.h"
+#include <utility>
+#include <vector>
 #include "dali/core/cuda_error.h"
+#include "dali/kernels/alloc.h"
 
 namespace dali {
 

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
@@ -1,0 +1,123 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "nvjpeg_memory.h"
+#include <nvjpeg.h>
+#include <cassert>
+#include <iostream> // TODO(janton) remove
+#include <map>
+#include <vector>
+#include <mutex>
+#include <shared_mutex>
+#include "dali/kernels/alloc.h"
+#include "dali/core/cuda_error.h"
+
+namespace dali {
+
+using kernels::memory::KernelUniquePtr;
+using kernels::AllocType;
+using kernels::memory::alloc_unique;
+using kernels::memory::Allocate;
+
+namespace nvjpeg_memory {
+
+struct Buffer {
+  Buffer(KernelUniquePtr<char> unq_ptr, AllocType type, size_t sz)
+      : ptr(std::move(unq_ptr)), alloc_type(type), size(sz) {}
+  KernelUniquePtr<char> ptr;
+  AllocType alloc_type;
+  size_t size;
+};
+
+using BufferPool = std::map<std::thread::id, std::map<AllocType, std::vector<Buffer>>>;
+std::shared_timed_mutex buffer_pool_mutex_;
+BufferPool buffer_pool_;
+
+void* GetBuffer(std::thread::id thread_id, AllocType alloc_type, size_t size) {
+  std::shared_lock<std::shared_timed_mutex> lock(buffer_pool_mutex_);
+  auto it = buffer_pool_.find(thread_id);
+  assert(it != buffer_pool_.end());
+  lock.unlock();
+
+  auto &buffers = it->second[alloc_type];
+  if (!buffers.empty()) {
+    auto buf = std::move(buffers.back());
+    buffers.pop_back();
+    if (size <= buf.size)
+      return buf.ptr.release();
+  }
+  // Couldn't find a preallocated buffer, proceed to allocate
+  return kernels::memory::Allocate(alloc_type, size);
+}
+
+void AddBuffer(std::thread::id thread_id, AllocType alloc_type, size_t size) {
+  std::unique_lock<std::shared_timed_mutex> lock(buffer_pool_mutex_);
+  auto& thread_buffer_pool = buffer_pool_[thread_id];
+  lock.unlock();
+
+  auto &buffers = thread_buffer_pool[alloc_type];
+  buffers.emplace_back(kernels::memory::alloc_unique<char>(alloc_type, size), alloc_type, size);
+}
+
+void DeleteAllBuffers(std::thread::id thread_id) {
+  buffer_pool_.erase(thread_id);
+}
+
+static int DeviceNew(void **ptr, size_t size) {
+  std::thread::id this_id = std::this_thread::get_id();
+  std::cout << "Requesting device memory for Thread " << this_id << ": " << size << " bytes, ptr = ";
+  *ptr = GetBuffer(this_id, AllocType::GPU, size);
+  std::cout << *ptr << "\n";
+  return 0;
+}
+
+static int DeviceDelete(void *ptr) {
+  std::thread::id this_id = std::this_thread::get_id();
+  std::cout << "Thread " << this_id << " deleting device memory: ptr = " << ptr << "\n";
+  CUDA_CALL(cudaFree(ptr));
+  return 0;
+}
+
+static int PinnedNew(void **ptr, size_t size, unsigned int flags) {
+  std::thread::id this_id = std::this_thread::get_id();
+  std::cout << "Requesting pinned memory for Thread " << this_id << ": " << size << " bytes, ptr = ";
+  *ptr = GetBuffer(this_id, AllocType::Pinned, size);
+  std::cout << *ptr << "\n";
+  return 0;
+}
+
+static int PinnedDelete(void *ptr) {
+  std::thread::id this_id = std::this_thread::get_id();
+  std::cout << "Thread " << this_id << " deleting pinned memory: ptr = " << ptr << "\n";
+  CUDA_CALL(cudaFreeHost(ptr));
+  return 0;
+}
+
+nvjpegDevAllocator_t GetDeviceAllocator() {
+  nvjpegDevAllocator_t allocator;
+  allocator.dev_malloc = &DeviceNew;
+  allocator.dev_free = &DeviceDelete;
+  return allocator;
+}
+
+nvjpegPinnedAllocator_t GetPinnedAllocator() {
+  nvjpegPinnedAllocator_t allocator;
+  allocator.pinned_malloc = &PinnedNew;
+  allocator.pinned_free = &PinnedDelete;
+  return allocator;
+}
+
+}  // namespace nvjpeg_memory
+
+}  // namespace dali

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
@@ -23,12 +23,35 @@ namespace dali {
 
 namespace nvjpeg_memory {
 
+/**
+ * @brief Returns a buffer of at least the requested size, preferrably from the preallocated pool
+ *        If no buffer that satisfies the requested arguments, an allocation will take place
+ */
 void* GetBuffer(std::thread::id thread_id, kernels::AllocType alloc_type, size_t size);
+
+/**
+ * @brief Adds a new buffer to the pool of a given thread id, to be consumed later by ``GetBuffer``
+ */
 void AddBuffer(std::thread::id thread_id, kernels::AllocType alloc_type, size_t size);
+
+/**
+ * @brief Deletes all the buffers associated with a given thread id
+ */
 void DeleteAllBuffers(std::thread::id thread_id);
 
+/**
+ * @brief Enables/disables nvJPEG allocation statistics collection
+ */
 void SetEnableMemStats(bool enabled);
+
+/**
+ * @brief Adds an allocation to the statistics
+ */
 void AddMemStats(kernels::AllocType alloc_type, size_t size);
+
+/**
+ * @brief Prints nvJPEG memory allocation statistics
+ */
 void PrintMemStats();
 
 nvjpegDevAllocator_t GetDeviceAllocator();

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_DECODER_NVJPEG_NVJPEG_MEMORY_H_
+#define DALI_OPERATORS_DECODER_NVJPEG_NVJPEG_MEMORY_H_
+
+#include <nvjpeg.h>
+#include <thread>
+#include "dali/kernels/alloc_type.h"
+
+namespace dali {
+
+namespace nvjpeg_memory {
+
+void* GetBuffer(std::thread::id thread_id, kernels::AllocType alloc_type, size_t size);
+void AddBuffer(std::thread::id thread_id, kernels::AllocType alloc_type, size_t size);
+void DeleteAllBuffers(std::thread::id thread_id);
+
+nvjpegDevAllocator_t GetDeviceAllocator();
+nvjpegPinnedAllocator_t GetPinnedAllocator();
+
+}  // namespace nvjpeg_memory
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_DECODER_NVJPEG_NVJPEG_MEMORY_H_

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
@@ -27,6 +27,10 @@ void* GetBuffer(std::thread::id thread_id, kernels::AllocType alloc_type, size_t
 void AddBuffer(std::thread::id thread_id, kernels::AllocType alloc_type, size_t size);
 void DeleteAllBuffers(std::thread::id thread_id);
 
+void SetEnableMemStats(bool enabled);
+void AddMemStats(kernels::AllocType alloc_type, size_t size);
+void PrintMemStats();
+
 nvjpegDevAllocator_t GetDeviceAllocator();
 nvjpegPinnedAllocator_t GetPinnedAllocator();
 

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_OPERATORS_DECODER_NVJPEG_NVJPEG_MEMORY_H_
-#define DALI_OPERATORS_DECODER_NVJPEG_NVJPEG_MEMORY_H_
+#ifndef DALI_OPERATORS_DECODER_NVJPEG_DECOUPLED_API_NVJPEG_MEMORY_H_
+#define DALI_OPERATORS_DECODER_NVJPEG_DECOUPLED_API_NVJPEG_MEMORY_H_
 
 #include <nvjpeg.h>
 #include <thread>
@@ -61,4 +61,4 @@ nvjpegPinnedAllocator_t GetPinnedAllocator();
 
 }  // namespace dali
 
-#endif  // DALI_OPERATORS_DECODER_NVJPEG_NVJPEG_MEMORY_H_
+#endif  // DALI_OPERATORS_DECODER_NVJPEG_DECOUPLED_API_NVJPEG_MEMORY_H_

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
@@ -25,12 +25,13 @@ namespace nvjpeg_memory {
 
 /**
  * @brief Returns a buffer of at least the requested size, preferrably from the preallocated pool
- *        If no buffer that satisfies the requested arguments, an allocation will take place
+ *        If no buffer that satisfies the requested arguments already exists in the pool, an allocation
+ *        will take place
  */
 void* GetBuffer(std::thread::id thread_id, kernels::AllocType alloc_type, size_t size);
 
 /**
- * @brief Adds a new buffer to the pool of a given thread id, to be consumed later by ``GetBuffer``
+ * @brief Adds a new buffer to the pool for a given thread id, to be consumed later by ``GetBuffer``
  */
 void AddBuffer(std::thread::id thread_id, kernels::AllocType alloc_type, size_t size);
 

--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -91,6 +91,15 @@ int ThreadPool::size() const {
   return threads_.size();
 }
 
+std::vector<std::thread::id> ThreadPool::GetThreadIds() const {
+  std::vector<std::thread::id> tids;
+  tids.reserve(threads_.size());
+  for (const auto &thread : threads_)
+    tids.emplace_back(thread.get_id());
+  return tids;
+}
+
+
 void ThreadPool::ThreadMain(int thread_id, int device_id, bool set_affinity) {
   DeviceGuard g(device_id);
   try {

--- a/dali/pipeline/util/thread_pool.h
+++ b/dali/pipeline/util/thread_pool.h
@@ -44,6 +44,8 @@ class DLL_PUBLIC ThreadPool {
 
   DLL_PUBLIC int size() const;
 
+  DLL_PUBLIC std::vector<std::thread::id> GetThreadIds() const;
+
   DISABLE_COPY_MOVE_ASSIGN(ThreadPool);
 
  private:

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -295,9 +295,6 @@ class check_output_pattern():
         self.is_regexp_ = is_regexp
 
     def __enter__(self):
-        print(sys.stdout)
-        print(type(sys.stdout))
-        print(dir(sys.stdout))
         self.bucket_out_ = tempfile.TemporaryFile(mode='w+')
         self.bucket_err_ = tempfile.TemporaryFile(mode='w+')
         self.stdout_fileno_ = 1
@@ -317,7 +314,6 @@ class check_output_pattern():
 
         pattern_found = False
         if self.is_regexp_:
-            print(our_data)
             pattern = re.compile(self.pattern_)
             pattern_found = pattern.search(our_data) or pattern.search(err_data)
         else:

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -20,10 +20,12 @@ import nvidia.dali.types as types
 import nvidia.dali as dali
 from nvidia.dali.backend_impl import TensorListGPU
 
+import tempfile
 import subprocess
 import os
 import sys
 import random
+import re
 
 def get_dali_extra_path():
   try:
@@ -286,3 +288,40 @@ def py_buffer_from_address(address, shape, dtype, gpu = False):
         global cp
         import cupy as cp
         return cp.asanyarray(holder)
+
+class check_output_pattern():
+    def __init__(self, pattern, is_regexp=True):
+        self.pattern_ = pattern
+        self.is_regexp_ = is_regexp
+
+    def __enter__(self):
+        print(sys.stdout)
+        print(type(sys.stdout))
+        print(dir(sys.stdout))
+        self.bucket_out_ = tempfile.TemporaryFile(mode='w+')
+        self.bucket_err_ = tempfile.TemporaryFile(mode='w+')
+        self.stdout_fileno_ = 1
+        self.stderr_fileno_ = 2
+        self.old_stdout_ = os.dup(self.stdout_fileno_)
+        self.old_stderr_ = os.dup(self.stderr_fileno_)
+        os.dup2(self.bucket_out_.fileno(), self.stdout_fileno_)
+        os.dup2(self.bucket_err_.fileno(), self.stderr_fileno_)
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        self.bucket_out_.seek(0)
+        self.bucket_err_.seek(0)
+        os.dup2(self.old_stdout_, self.stdout_fileno_)
+        os.dup2(self.old_stderr_, self.stderr_fileno_)
+        our_data = self.bucket_out_.read()
+        err_data = self.bucket_err_.read()
+
+        pattern_found = False
+        if self.is_regexp_:
+            print(our_data)
+            pattern = re.compile(self.pattern_)
+            pattern_found = pattern.search(our_data) or pattern.search(err_data)
+        else:
+            pattern_found = self.pattern_ in our_data or self.pattern_ in err_data,
+
+        assert pattern_found, \
+            "Pattern: ``{}`` \n not found in out: \n``{}`` \n and in err: \n ```{}```".format(self.pattern_, our_data, err_data)


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds a new feature needed because we want to be able to preallocate enough pinned and device memory during nvJPEG operator construction to avoid reallocation during the pipeline iterations

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Added a custom allocator to nvJPEG that uses preallocated memory when possible
     Added a mechanism to print nvJPEG memory statistics during the pipeline destruction
 - Affected modules and functionalities:
     ImageDecoder (mixed backend)
 - Key points relevant for the review:
     nvjpeg_memory.*
 - Validation and testing:
     Test cases added
 - Documentation (including examples):
     `memory_stats` argument documented in OpSchema


**JIRA TASK**: *[DALI-1419]*
