### PR TITLE
Remove confusing `main` from nosetest files

### DIFF
--- a/dali/test/python/test_operator_audio_decoder.py
+++ b/dali/test/python/test_operator_audio_decoder.py
@@ -138,10 +138,3 @@ def test_decoded_vs_generated():
       assert np.allclose(res_mix, rosa3, rtol = 0, atol=3e-3)
 
       idx = (idx + 1) % len(names)
-
-def main():
-  test_decoded_vs_generated()
-
-
-if __name__ == '__main__':
-  main()

--- a/dali/test/python/test_operator_constant.py
+++ b/dali/test/python/test_operator_constant.py
@@ -162,14 +162,3 @@ def test_constant_fn():
 def test_scalar_constant_promotion():
     yield _test_scalar_constant_promotion, "cpu"
     yield _test_scalar_constant_promotion, "gpu"
-
-def main():
-    _test_op("cpu")
-    _test_op("gpu")
-    for test in test_constant_fn():
-        test[0](*test[1:])
-    _test_scalar_constant_promotion("cpu")
-    _test_scalar_constant_promotion("gpu")
-
-if __name__ == '__main__':
-  main()

--- a/dali/test/python/test_operator_coord_flip.py
+++ b/dali/test/python/test_operator_coord_flip.py
@@ -97,9 +97,3 @@ def test_operator_coord_flip():
                 for center_x, center_y, center_z in [(0.5, 0.5, 0.5), (0.0, 1.0, -0.5)]:
                     yield check_operator_coord_flip, device, batch_size, layout, shape, center_x, center_y, center_z
 
-def main():
-  for test in test_operator_coord_flip():
-      test[0](*test[1:])
-
-if __name__ == '__main__':
-  main()

--- a/dali/test/python/test_operator_mel_filter_bank.py
+++ b/dali/test/python/test_operator_mel_filter_bank.py
@@ -125,7 +125,3 @@ def test_operator_mel_filter_bank_vs_python():
                         (128, 44100.0, 1000.0, 22050.0, (513, 100))]:
                         yield check_operator_mel_filter_bank_vs_python, device, batch_size, shape, \
                             nfilter, sample_rate, freq_low, freq_high, normalize, mel_formula
-
-if __name__ == "__main__":
-    for fun, *args in test_operator_mel_filter_bank_vs_python():
-        fun(*args)

--- a/dali/test/python/test_operator_normalize.py
+++ b/dali/test/python/test_operator_normalize.py
@@ -393,13 +393,3 @@ def test_types():
                 yield _run_test, device, batch_size, dim, axes, None, False, out_type, in_type, shift, scale
 
 import nvidia.dali.fn as fn
-
-def main():
-    for test in test_cpu_up_to_5D_all_axis_combinations():
-        test[0](*test[1:])
-
-    for test in test_types():
-        test[0](*test[1:])
-
-if __name__ == '__main__':
-    main()

--- a/dali/test/python/test_operator_pad.py
+++ b/dali/test/python/test_operator_pad.py
@@ -149,10 +149,3 @@ def test_pad_fail():
 
     pipe.build()
     assert_raises(RuntimeError, pipe.run)
-
-def main():
-  for test in test_slice_synth_data_vs_numpy():
-    test[0](*test[1:])
-
-if __name__ == '__main__':
-  main()

--- a/dali/test/python/test_operator_power_spectrum.py
+++ b/dali/test/python/test_operator_power_spectrum.py
@@ -101,6 +101,3 @@ def test_operator_power_spectrum():
                                       (8, 1, (2, 8, 2))]:
                 yield check_operator_power_spectrum, device, batch_size, shape, nfft, axis
 
-if __name__ == "__main__":
-    check_operator_power_spectrum(device='cpu', batch_size=3, input_shape=(2, 1024),
-                                      nfft=1024, axis=1)

--- a/dali/test/python/test_operator_random_bbox_crop.py
+++ b/dali/test/python/test_operator_random_bbox_crop.py
@@ -127,7 +127,7 @@ def crop_contains(crop_anchor, crop_shape, point):
     assert(len(crop_shape) == ndim)
     assert(len(point) == ndim)
 
-    point = np.array(point)    
+    point = np.array(point)
     crop_anchor = np.array(crop_anchor)
     crop_shape = np.array(crop_shape)
 
@@ -333,16 +333,3 @@ def test_random_bbox_crop_overlap():
                     for use_labels in [True, False]:
                         yield check_random_bbox_crop_overlap, \
                                 batch_size, ndim, crop_shape, input_shape, use_labels
-
-def main():
-    for test in test_random_bbox_crop_fixed_shape():
-        test[0](*test[1:])
-
-    for test in test_random_bbox_crop_variable_shape():
-        test[0](*test[1:])
-
-    for test in test_random_bbox_crop_overlap():
-        test[0](*test[1:])
-
-if __name__ == '__main__':
-  main()

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -289,19 +289,3 @@ def _test_reinterpret_wildcard_shape(device):
 def test_reinterpret_wildcard_shape():
     for device in ["cpu", "gpu"]:
         yield _test_reinterpret_wildcard_shape, device
-
-
-def main():
-  for test in test_reshape_arg():
-    test[0](*test[1:])
-  for test in test_reshape_input():
-    test[0](*test[1:])
-  for test in test_reshape_arg_input():
-    test[0](*test[1:])
-  for test in test_reinterpret_default_shape():
-    test[0](*test[1:])
-  for test in test_reinterpret_wildcard_shape():
-    test[0](*test[1:])
-
-if __name__ == '__main__':
-  main()

--- a/dali/test/python/test_operator_rotate.py
+++ b/dali/test/python/test_operator_rotate.py
@@ -179,10 +179,3 @@ def test_gpu_vs_cpu():
   for test in run_cases("gpu", "cpu", 1):
     yield test
 
-def main():
-  test_cpu_vs_cv()
-  test_gpu_vs_cv()
-  test_gpu_vs_cpu()
-
-if __name__ == '__main__':
-  main()

--- a/dali/test/python/test_operator_to_decibels.py
+++ b/dali/test/python/test_operator_to_decibels.py
@@ -158,13 +158,3 @@ def test_operator_natural_logarithm():
 @raises(RuntimeError)
 def test_invalid_reference():
     NLDaliPipeline(None, 1, 0.0).build()
-
-def main():
-  for test in test_operator_to_decibels_vs_python():
-      test[0](*test[1:])
-
-  for test in test_operator_natural_logarithm():
-      test[0](*test[1:])
-
-if __name__ == '__main__':
-  main()

--- a/dali/test/python/test_operator_transpose.py
+++ b/dali/test/python/test_operator_transpose.py
@@ -137,8 +137,3 @@ def test_transpose_layout():
                     yield check_transpose_layout, device, batch_size, shape, \
                         in_layout, permutation, transpose_layout, out_layout_arg
 
-if __name__ == "__main__":
-    for f, *args in test_transpose_vs_numpy():
-        f(*args)
-    for f, *args in test_transpose_layout():
-        f(*args)

--- a/dali/test/python/test_operator_warp.py
+++ b/dali/test/python/test_operator_warp.py
@@ -207,13 +207,3 @@ def test_gpu_vs_cpu():
         gpu_pipeline.build();
 
         compare(cpu_pipeline, gpu_pipeline, 1)
-
-
-
-def main():
-  test_cpu_vs_cv()
-  test_gpu_vs_cv()
-  test_gpu_vs_cpu()
-
-if __name__ == '__main__':
-  main()


### PR DESCRIPTION
Test should be invoked through nosetest.
The `main` function was not used and was not
kept up to date with the test definitions
leading to errors.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
It removes not-maintained part of the tests that can lead to errors.

#### What happened in this PR?
 - What solution was applied:
     All __main__ and main() definitions removed from test_operator_*
 - Affected modules and functionalities:
     Python nose tests
 - Key points relevant for the review:
     Look for more?
 - Validation and testing:
     CI
 - Documentation (including examples):
     N/A


**JIRA TASK**: *[NA]*
