### PR TITLE
Introduce priorities in ThreadPool

### DIFF
--- a/dali/benchmark/CMakeLists.txt
+++ b/dali/benchmark/CMakeLists.txt
@@ -32,6 +32,7 @@ if (BUILD_BENCHMARK)
     "${CMAKE_CURRENT_SOURCE_DIR}/slice_kernel_bench.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/slice_kernel_bench.cu"
     "${CMAKE_CURRENT_SOURCE_DIR}/preemphasis_bench.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/thread_pool_bench.cc"
   )
 
   if (BUILD_LMDB)

--- a/dali/benchmark/thread_pool_bench.cc
+++ b/dali/benchmark/thread_pool_bench.cc
@@ -1,0 +1,106 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/benchmark/dali_bench.h"
+#include "dali/pipeline/util/thread_pool.h"
+
+namespace dali {
+
+class ThreadPoolBench : public DALIBenchmark {};
+
+static void ThreadPoolArgs(benchmark::internal::Benchmark *b) {
+  int batch_size = 64;
+  int work_size_min = 400;
+  int work_size_max = 10000;
+  int nthreads = 4;
+  b->Args({batch_size, work_size_min, work_size_max, nthreads});
+}
+
+BENCHMARK_DEFINE_F(ThreadPoolBench, DoWorkWithID)(benchmark::State& st) {
+  int batch_size = st.range(0);
+  int work_size_min = st.range(1);
+  int work_size_max = st.range(2);
+  int nthreads = st.range(3);
+
+  ThreadPool thread_pool(nthreads, 0, false);
+
+  std::vector<uint8_t> data(2000, 0xFF);
+  std::atomic<int64_t> total_count(0);
+  while (st.KeepRunning()) {
+    for (int i = 0; i < batch_size; i++) {
+        auto size = this->RandInt(work_size_min, work_size_max);
+        thread_pool.DoWorkWithID(
+          [this, &data, size, &total_count](int thread_id){
+            std::vector<uint8_t> other_data;
+            for (int i = 0; i < size; i++) {
+              other_data.push_back(data[i%data.size()]);
+            }
+            std::this_thread::sleep_for(std::chrono::nanoseconds(size * 10));
+            total_count += size;
+          });
+    }
+    thread_pool.WaitForWork();
+
+    int num_batches = st.iterations() + 1;
+    st.counters["FPS"] = benchmark::Counter(batch_size*num_batches,
+        benchmark::Counter::kIsRate);
+  }
+  std::cout << total_count << std::endl;
+}
+
+BENCHMARK_REGISTER_F(ThreadPoolBench, DoWorkWithID)->Iterations(1000)
+->Unit(benchmark::kMicrosecond)
+->UseRealTime()
+->Apply(ThreadPoolArgs);
+
+
+BENCHMARK_DEFINE_F(ThreadPoolBench, AddWork)(benchmark::State& st) {
+  int batch_size = st.range(0);
+  int work_size_min = st.range(1);
+  int work_size_max = st.range(2);
+  int nthreads = st.range(3);
+
+  ThreadPool thread_pool(nthreads, 0, false);
+  std::vector<uint8_t> data(2000, 0xFF);
+
+  std::atomic<int64_t> total_count(0);
+  while (st.KeepRunning()) {
+    for (int i = 0; i < batch_size; i++) {
+        auto size = this->RandInt(work_size_min, work_size_max);
+        thread_pool.AddWork(
+          [this, &data, size, &total_count](int thread_id){
+            std::vector<uint8_t> other_data;
+            for (int i = 0; i < size; i++) {
+              other_data.push_back(data[i%data.size()]);
+            }
+            std::this_thread::sleep_for(std::chrono::nanoseconds(size * 10));
+            total_count += size;
+          }, size);
+    }
+    thread_pool.RunAll();
+
+    int num_batches = st.iterations() + 1;
+    st.counters["FPS"] = benchmark::Counter(batch_size*num_batches,
+        benchmark::Counter::kIsRate);
+  }
+  std::cout << total_count << std::endl;
+}
+
+
+BENCHMARK_REGISTER_F(ThreadPoolBench, AddWork)->Iterations(1000)
+->Unit(benchmark::kMicrosecond)
+->UseRealTime()
+->Apply(ThreadPoolArgs);
+
+}  // namespace dali

--- a/dali/benchmark/thread_pool_bench.cc
+++ b/dali/benchmark/thread_pool_bench.cc
@@ -41,7 +41,7 @@ BENCHMARK_DEFINE_F(ThreadPoolBench, DoWorkWithID)(benchmark::State& st) {
     for (int i = 0; i < batch_size; i++) {
         auto size = this->RandInt(work_size_min, work_size_max);
         thread_pool.DoWorkWithID(
-          [this, &data, size, &total_count](int thread_id){
+          [&data, size, &total_count](int thread_id){
             std::vector<uint8_t> other_data;
             for (int i = 0; i < size; i++) {
               other_data.push_back(data[i%data.size()]);
@@ -79,7 +79,7 @@ BENCHMARK_DEFINE_F(ThreadPoolBench, AddWork)(benchmark::State& st) {
     for (int i = 0; i < batch_size; i++) {
         auto size = this->RandInt(work_size_min, work_size_max);
         thread_pool.AddWork(
-          [this, &data, size, &total_count](int thread_id){
+          [&data, size, &total_count](int thread_id){
             std::vector<uint8_t> other_data;
             for (int i = 0; i < size; i++) {
               other_data.push_back(data[i%data.size()]);

--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -96,7 +96,7 @@ void ThreadPool::RunAll(bool wait) {
     std::lock_guard<std::mutex> lock(mutex_);
     adding_work_ = false;
   }
-  condition_.notify_all();
+  condition_.notify_one();  // other threads will be waken up if needed
   if (wait) {
     WaitForWork();
   }

--- a/dali/pipeline/util/thread_pool.h
+++ b/dali/pipeline/util/thread_pool.h
@@ -42,9 +42,12 @@ class DLL_PUBLIC ThreadPool {
    * @brief Adds work to the queue with optional priority.
    *        The work only gets queued and it will only start after invoking
    *        `RunAll` (wakes up all threads to complete all remaining works) or
-   *        `RunWork` (wakes up a single thread to complete one work unit).
+   *        `DoWorkWithID` (wakes up a single thread to complete one work unit).
+   * @remarks if finished_adding_work == true, the thread pool will proceed picking
+   *          tasks from its queue, otherwise it will hold execution until `RunAll`
+   *          is invoked.
    */
-  DLL_PUBLIC void AddWork(Work work, int64_t priority = 0);
+  DLL_PUBLIC void AddWork(Work work, int64_t priority = 0, bool finished_adding_work = false);
 
   /**
    * @brief Adds work to the queue with optional priority and wakes up a single
@@ -81,7 +84,6 @@ class DLL_PUBLIC ThreadPool {
       return a.first < b.first;
     }
   };
-  std::queue<Work> work_queue__;
   std::priority_queue<PrioritizedWork, std::vector<PrioritizedWork>, SortByPriority> work_queue_;
 
   bool running_;

--- a/dali/pipeline/util/thread_pool.h
+++ b/dali/pipeline/util/thread_pool.h
@@ -16,6 +16,7 @@
 #define DALI_PIPELINE_UTIL_THREAD_POOL_H_
 
 #include <cstdlib>
+#include <utility>
 #include <condition_variable>
 #include <functional>
 #include <mutex>
@@ -37,9 +38,30 @@ class DLL_PUBLIC ThreadPool {
 
   DLL_PUBLIC ~ThreadPool();
 
-  DLL_PUBLIC void DoWorkWithID(Work work);
+  /**
+   * @brief Adds work to the queue with optional priority.
+   *        The work only gets queued and it will only start after invoking
+   *        `RunAll` (wakes up all threads to complete all remaining works) or
+   *        `RunWork` (wakes up a single thread to complete one work unit).
+   */
+  DLL_PUBLIC void AddWork(Work work, int64_t priority = 0);
 
-  // Blocks until all work issued to the thread pool is complete
+  /**
+   * @brief Adds work to the queue with optional priority and wakes up a single
+   *        thread that will pick the task in the queue with highest priority.
+   */
+  DLL_PUBLIC void DoWorkWithID(Work work, int64_t priority = 0);
+
+  /**
+   * @brief Wakes up all the threads to complete all the queued work,
+   *        optionally not waiting for the work to be finished before return
+   *        (the default wait=true is equivalent to invoking WaitForWork after RunAll).
+   */
+  DLL_PUBLIC void RunAll(bool wait = true);
+
+  /**
+   * @brief Waits until all work issued to the thread pool is complete
+   */
   DLL_PUBLIC void WaitForWork(bool checkForErrors = true);
 
   DLL_PUBLIC int size() const;
@@ -52,10 +74,19 @@ class DLL_PUBLIC ThreadPool {
   DLL_PUBLIC void ThreadMain(int thread_id, int device_id, bool set_affinity);
 
   vector<std::thread> threads_;
-  std::queue<Work> work_queue_;
+
+  using PrioritizedWork = std::pair<int64_t, Work>;
+  struct SortByPriority {
+    bool operator() (const PrioritizedWork &a, const PrioritizedWork &b) {
+      return a.first < b.first;
+    }
+  };
+  std::queue<Work> work_queue__;
+  std::priority_queue<PrioritizedWork, std::vector<PrioritizedWork>, SortByPriority> work_queue_;
 
   bool running_;
   bool work_complete_;
+  bool adding_work_;
   int active_threads_;
   std::mutex mutex_;
   std::condition_variable condition_;

--- a/dali/pipeline/util/thread_pool_test.cc
+++ b/dali/pipeline/util/thread_pool_test.cc
@@ -1,0 +1,72 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/util/thread_pool.h"
+#include <gtest/gtest.h>
+#include <atomic>
+
+namespace dali {
+
+namespace test {
+
+TEST(ThreadPool, AddWork) {
+  ThreadPool tp(16, 0, false);
+  std::atomic<int> count{0};
+  auto increase = [&count](int thread_id) { count++; };
+  for (int i = 0; i < 64; i++) {
+    tp.AddWork(increase);
+  }
+  ASSERT_EQ(count, 0);
+  tp.RunAll();
+  ASSERT_EQ(count, 64);
+}
+
+TEST(ThreadPool, DoWorkWithID) {
+  ThreadPool tp(16, 0, false);
+  std::atomic<int> count{0};
+  auto increase = [&count](int thread_id) { count++; };
+  for (int i = 0; i < 64; i++) {
+    tp.DoWorkWithID(increase);
+  }
+  tp.WaitForWork();
+  ASSERT_EQ(count, 64);
+}
+
+TEST(ThreadPool, AddWorkWithPriority) {
+  ThreadPool tp(2, 0, false);
+  std::atomic<int> count{0};
+  auto set_to_1 = [&count](int thread_id) {
+    count = 1;
+  };
+  auto increase_by_1 = [&count](int thread_id) {
+    count++;
+  };
+  auto mult_by_2 = [&count](int thread_id) {
+    int val = count.load();
+    while (!count.compare_exchange_weak(val, val * 2)) {}
+  };
+  tp.AddWork(increase_by_1, 2);
+  tp.AddWork(mult_by_2, 7);
+  tp.AddWork(mult_by_2, 9);
+  tp.AddWork(mult_by_2, 8);
+  tp.AddWork(increase_by_1, 100);
+  tp.AddWork(set_to_1, 1000);
+
+  tp.RunAll();
+  ASSERT_EQ(((1+1) << 3) + 1, count);
+}
+
+}  // namespace test
+
+}  // namespace dali


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It adds new feature needed because of we want to be able to post work to a thread pool that will be executed according to its priority

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a priority queue in ThreadPool*
     *Added a new pattern of using ThreadPool: `AddWork` will add work to the queue but won't start processing it, and `RunAll` will wake up all the threads to process the remaining work, which will be picked in order according to the task priority*
 - Affected modules and functionalities:
     *Thread pool*
 - Key points relevant for the review:
     *Thread pool implementation*
 - Validation and testing:
     *Unit tests and benchmark added*
 - Documentation (including examples):
     *Doxygen*

TODO as a follow-up: Modify all uses of ThreadPool in DALI operators to use the new AddWork/RunAll pattern

**JIRA TASK**: *[DALI-1473]*
