### PR TITLE
Use a new nvmlDeviceGetCpuAffinityWithinScope API for thread binding

### DIFF
--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api_test.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api_test.cc
@@ -181,6 +181,7 @@ TYPED_TEST(nvjpegDecodeDecoupledAPITest, TestSingleTiffDecode4T) {
   this->TiffTestDecode(4);
 }
 
+#if NVJPEG_VER_MAJOR >= 11
 class HwDecoderUtilizationTest : public ::testing::Test {
  public:
   void SetUp() final {
@@ -233,6 +234,6 @@ TEST_F(HwDecoderUtilizationTest, UtilizationTest) {
   EXPECT_EQ(nsamples_host, 0)
                 << "Image decoding malfuntion: all images should've been decoded by CUDA or HW";
 }
-
+#endif
 
 }  // namespace dali

--- a/dali/util/nvml_wrap.h
+++ b/dali/util/nvml_wrap.h
@@ -44,11 +44,20 @@ DLL_PUBLIC DALIError_t wrapNvmlDeviceGetCpuAffinity(nvmlDevice_t device,
                                                     unsigned int cpuSetSize,
                                                     unsigned long* cpuSet);  // NOLINT(runtime/int)
 DLL_PUBLIC DALIError_t wrapNvmlDeviceClearCpuAffinity(nvmlDevice_t device);
+
+#if (CUDART_VERSION >= 11000)
+
+DLL_PUBLIC DALIError_t wrapNvmlDeviceGetCpuAffinityWithinScope(nvmlDevice_t device,
+                                                               unsigned int nodeSetSize,
+                                                               unsigned long *nodeSet,  // NOLINT(*)
+                                                               nvmlAffinityScope_t scope);
 DLL_PUBLIC DALIError_t wrapNvmlDeviceGetBrand(nvmlDevice_t device, nvmlBrandType_t* type);
 DLL_PUBLIC DALIError_t wrapNvmlDeviceGetCount_v2(unsigned int* deviceCount);
 DLL_PUBLIC DALIError_t wrapNvmlDeviceGetHandleByIndex_v2(unsigned int index, nvmlDevice_t* device);
 DLL_PUBLIC DALIError_t wrapNvmlDeviceGetCudaComputeCapability(nvmlDevice_t device,
                                                               int* major, int* minor);
+
+#endif
 
 /**
  * Checks, whether CUDA11-proper NVML functions have been successfully loaded


### PR DESCRIPTION
- new nvmlDeviceGetCpuAffinityWithinScope allows us to specify the cope of affinity. On some systems, like DGXA100 we need to consider socket scope to utilize cores that are not assigned to any GPU but are still fast working with it

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new nvmlDeviceGetCpuAffinityWithinScope API for thread binding

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a new nvmlDeviceGetCpuAffinityWithinScope API for thread binding
 - Affected modules and functionalities:
     nvml and nvml_wrap
 - Key points relevant for the review:
     Some API are not compile time checked against CUDA 11
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
