### PR TITLE
Bundle all python versions into one wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,9 @@ option(BUILD_NVML "Build with NVIDIA Management Library (NVML) support" ON)
 option(BUILD_FFTS "Build with ffts support" ON)
 option(VERBOSE_LOGS "Adds verbose loging to DALI" OFF)
 
-option(WERROR "Threat all warnings as errors" OFF)
+option(WERROR "Treat all warnings as errors" OFF)
 
+# ; creates a list here
 set (PYTHON_VERSIONS "3.5;3.6;3.7;3.8")
 
 # FFmpeg is required when we are using NVDEC for video reader

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ option(VERBOSE_LOGS "Adds verbose loging to DALI" OFF)
 
 option(WERROR "Threat all warnings as errors" OFF)
 
+set (PYTHON_VERSIONS "3.5;3.6;3.7;3.8")
+
 # FFmpeg is required when we are using NVDEC for video reader
 set(BUILD_FFMPEG ${BUILD_NVDEC})
 

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -283,11 +283,15 @@ endfunction()
 # if it is accesible during the build time. The library sufix is provided and specific for each python version
 #
 # supported options:
-# TARGET_NAME - umbrella target name used for this build. Two more targets are created TARGET_NAME_public and
-#               TARGET_NAME_private which can be used to set flags and additonal linking commands to all
-#               targets created by this function (these targets support only INTERFACE type of property)
+# <TARGET_NAME> - umbrella target name used for this set of libraries; two additional targets are created,
+#              which can be used to set PUBLIC and PRIVATE target properties, respectively:
+#              TARGET_NAME_public
+#              TARGET_NAME_private.
+#              Properties for these targets, such as link dependencies, includes or compilation flags,
+#              must be set with INTERFACE keyword, but they are propagated as PUBLIC/PRIVATE
+#              properties to all version-specific libraries.
 # OUTPUT_NAME - library name used for this build
-# PREFIX - library prefix, if no provided there library will be named as ${TARGET_NAME}.python_specific_extension
+# PREFIX - library prefix, if none is provided, the library will be named ${TARGET_NAME}.python_specific_extension
 # OUTPUT_DIR - ouptut directory of the build library
 # PUBLIC_LIBS - list of libraries that should be linked in as a public one
 # PRIV_LIBS - list of libraries that should be linked in as a private one
@@ -295,8 +299,10 @@ endfunction()
 function(build_per_python_lib)
     set(oneValueArgs TARGET_NAME OUTPUT_NAME OUTPUT_DIR PREFIX)
     set(multiValueArgs PRIV_LIBS PUBLIC_LIBS SRC EXCLUDE_LIBS)
-    cmake_parse_arguments(PARSE_ARGV 0 PYTHON_LIB_ARG "${options}" "${oneValueArgs}" "${multiValueArgs}")
 
+    cmake_parse_arguments(PARSE_ARGV 1 PYTHON_LIB_ARG "${options}" "${oneValueArgs}" "${multiValueArgs}")
+
+    set(PYTHON_LIB_ARG_TARGET_NAME ${ARGV0})
     add_custom_target(${PYTHON_LIB_ARG_TARGET_NAME} ALL)
 
     # global per target interface library, common for all python variants

--- a/dali/operators/python_function/CMakeLists.txt
+++ b/dali/operators/python_function/CMakeLists.txt
@@ -16,47 +16,10 @@ collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(PYTHON_FUNCTION_SRCS PARENT_SCOPE)
 collect_test_sources(DALI_OPERATOR_TEST_SRCS PARENT_SCOPE)
 
-add_custom_target(${dali_python_function_lib} ALL)
-
-foreach(PYVER ${PYTHON_VERSIONS})
-
-    # check if listed python versions are accesible
-    execute_process(
-        COMMAND python${PYVER} -c "print('test', end='')"
-        OUTPUT_VARIABLE PYTHON_EXISTS)
-
-    if ("${PYTHON_EXISTS}" STREQUAL "test")
-        execute_process(
-            COMMAND python${PYVER}-config --extension-suffix
-            OUTPUT_VARIABLE PYTHON_SUFIX)
-        # remove newline and the extension
-        string(REPLACE ".so\n" "" PYTHON_SUFIX ${PYTHON_SUFIX})
-
-        execute_process(
-            COMMAND python${PYVER}-config --includes
-            OUTPUT_VARIABLE PYTHON_INCLUDES)
-        # split and make it a list
-        string(REPLACE "-I" "" PYTHON_INCLUDES ${PYTHON_INCLUDES})
-        string(REPLACE "\n" "" PYTHON_INCLUDES ${PYTHON_INCLUDES})
-        separate_arguments(PYTHON_INCLUDES)
-
-        add_library(${dali_python_function_lib}_${PYVER} SHARED ${PYTHON_FUNCTION_SRCS})
-        target_link_libraries(${dali_python_function_lib}_${PYVER} PUBLIC dali)
-        target_link_libraries(${dali_python_function_lib}_${PYVER} PRIVATE ${DALI_LIBS})
-        target_link_libraries(${dali_python_function_lib}_${PYVER} PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
-
-        set_target_properties(${dali_python_function_lib}_${PYVER}
-                                PROPERTIES
-                                LIBRARY_OUTPUT_DIRECTORY ${DALI_LIBRARY_OUTPUT_DIR}
-                                PREFIX ""
-                                OUTPUT_NAME ${dali_python_function_lib}${PYTHON_SUFIX})
-        target_include_directories(${dali_python_function_lib}_${PYVER} PRIVATE "${CMAKE_SOURCE_DIR}/third_party/pybind11/include")
-        # add includes
-        foreach(incl_dir ${PYTHON_INCLUDES})
-            target_include_directories(${dali_python_function_lib}_${PYVER} PRIVATE ${incl_dir})
-        endforeach(incl_dir)
-
-        add_dependencies(${dali_python_function_lib} ${dali_python_function_lib}_${PYVER})
-    endif()
-
-endforeach(PYVER)
+build_per_python_lib(TARGET_NAME ${dali_python_function_lib}
+                     OUTPUT_NAME ${dali_python_function_lib}
+                     OUTPUT_DIR ${DALI_LIBRARY_OUTPUT_DIR}
+                     PUBLIC_LIBS dali
+                     PRIV_LIBS ${DALI_LIBS}
+                     EXCLUDE_LIBS ${exclude_libs}
+                     SRC ${PYTHON_FUNCTION_SRCS})

--- a/dali/operators/python_function/CMakeLists.txt
+++ b/dali/operators/python_function/CMakeLists.txt
@@ -16,16 +16,47 @@ collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(PYTHON_FUNCTION_SRCS PARENT_SCOPE)
 collect_test_sources(DALI_OPERATOR_TEST_SRCS PARENT_SCOPE)
 
-add_library(${dali_python_function_lib} SHARED ${PYTHON_FUNCTION_SRCS})
-target_link_libraries(${dali_python_function_lib} PUBLIC dali)
-target_link_libraries(${dali_python_function_lib} PRIVATE ${DALI_LIBS})
-target_link_libraries(${dali_python_function_lib} PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
+add_custom_target(${dali_python_function_lib} ALL)
 
-target_include_directories(${dali_python_function_lib} PRIVATE
-        ${PYBIND11_INCLUDE_DIR}  # from project CMakeLists.txt
-        ${pybind11_INCLUDE_DIR}  # from pybind11Config
-        ${PYTHON_INCLUDE_DIRS})
+foreach(PYVER ${PYTHON_VERSIONS})
 
-# Install python operator plugin to the wheel directory
-set_target_properties(${dali_python_function_lib} PROPERTIES
-        LIBRARY_OUTPUT_DIRECTORY "${DALI_LIBRARY_OUTPUT_DIR}")
+    # check if listed python versions are accesible
+    execute_process(
+        COMMAND python${PYVER} -c "print('test', end='')"
+        OUTPUT_VARIABLE PYTHON_EXISTS)
+
+    if ("${PYTHON_EXISTS}" STREQUAL "test")
+        execute_process(
+            COMMAND python${PYVER}-config --extension-suffix
+            OUTPUT_VARIABLE PYTHON_SUFIX)
+        # remove newline and the extension
+        string(REPLACE ".so\n" "" PYTHON_SUFIX ${PYTHON_SUFIX})
+
+        execute_process(
+            COMMAND python${PYVER}-config --includes
+            OUTPUT_VARIABLE PYTHON_INCLUDES)
+        # split and make it a list
+        string(REPLACE "-I" "" PYTHON_INCLUDES ${PYTHON_INCLUDES})
+        string(REPLACE "\n" "" PYTHON_INCLUDES ${PYTHON_INCLUDES})
+        separate_arguments(PYTHON_INCLUDES)
+
+        add_library(${dali_python_function_lib}_${PYVER} SHARED ${PYTHON_FUNCTION_SRCS})
+        target_link_libraries(${dali_python_function_lib}_${PYVER} PUBLIC dali)
+        target_link_libraries(${dali_python_function_lib}_${PYVER} PRIVATE ${DALI_LIBS})
+        target_link_libraries(${dali_python_function_lib}_${PYVER} PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
+
+        set_target_properties(${dali_python_function_lib}_${PYVER}
+                                PROPERTIES
+                                LIBRARY_OUTPUT_DIRECTORY ${DALI_LIBRARY_OUTPUT_DIR}
+                                PREFIX ""
+                                OUTPUT_NAME ${dali_python_function_lib}${PYTHON_SUFIX})
+        target_include_directories(${dali_python_function_lib}_${PYVER} PRIVATE "${CMAKE_SOURCE_DIR}/third_party/pybind11/include")
+        # add includes
+        foreach(incl_dir ${PYTHON_INCLUDES})
+            target_include_directories(${dali_python_function_lib}_${PYVER} PRIVATE ${incl_dir})
+        endforeach(incl_dir)
+
+        add_dependencies(${dali_python_function_lib} ${dali_python_function_lib}_${PYVER})
+    endif()
+
+endforeach(PYVER)

--- a/dali/operators/python_function/CMakeLists.txt
+++ b/dali/operators/python_function/CMakeLists.txt
@@ -16,7 +16,7 @@ collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(PYTHON_FUNCTION_SRCS PARENT_SCOPE)
 collect_test_sources(DALI_OPERATOR_TEST_SRCS PARENT_SCOPE)
 
-build_per_python_lib(TARGET_NAME ${dali_python_function_lib}
+build_per_python_lib(${dali_python_function_lib}
                      OUTPUT_NAME ${dali_python_function_lib}
                      OUTPUT_DIR ${DALI_LIBRARY_OUTPUT_DIR}
                      PUBLIC_LIBS dali

--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -191,7 +191,7 @@ struct DLTensorNumpyResource: public DLTensorResource {
   ~DLTensorNumpyResource() override = default;
 };
 
-PYBIND11_MODULE(libpython_function_plugin, m) {
+PYBIND11_MODULE(python_function_plugin, m) {
   m.def("current_dali_stream", []() { return reinterpret_cast<uint64_t>(GetCurrentStream()); });
 
   m.def("DLTensorToArray", [](py::capsule dl_capsule) {

--- a/dali/python/CMakeLists.txt
+++ b/dali/python/CMakeLists.txt
@@ -16,15 +16,51 @@
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(DALI_PYTHON_BACKEND_SRCS)
 
-pybind11_add_module(dali_python MODULE ${DALI_PYTHON_BACKEND_SRCS})
-target_link_libraries(dali_python PUBLIC dali dali_operators dali_kernels dali_core ${CUDART_LIB})
-target_link_libraries(dali_python PRIVATE ${CUDA_LIBRARIES})
-target_link_libraries(dali_python PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
+add_custom_target(dali_python ALL)
 
-set_target_properties(dali_python
-        PROPERTIES
-          LIBRARY_OUTPUT_DIRECTORY ${DALI_LIBRARY_OUTPUT_DIR}
-          OUTPUT_NAME backend_impl)
+foreach(PYVER ${PYTHON_VERSIONS})
+
+    # check if listed python versions are accesible
+    execute_process(
+        COMMAND python${PYVER} -c "print('test', end='')"
+        OUTPUT_VARIABLE PYTHON_EXISTS)
+
+    if ("${PYTHON_EXISTS}" STREQUAL "test")
+        execute_process(
+            COMMAND python${PYVER}-config --extension-suffix
+            OUTPUT_VARIABLE PYTHON_SUFIX)
+        # remove newline and the extension
+        string(REPLACE ".so\n" "" PYTHON_SUFIX ${PYTHON_SUFIX})
+
+        execute_process(
+            COMMAND python${PYVER}-config --includes
+            OUTPUT_VARIABLE PYTHON_INCLUDES)
+        # split and make it a list
+        string(REPLACE "-I" "" PYTHON_INCLUDES ${PYTHON_INCLUDES})
+        string(REPLACE "\n" "" PYTHON_INCLUDES ${PYTHON_INCLUDES})
+        separate_arguments(PYTHON_INCLUDES)
+
+        add_library(dali_python_${PYVER} SHARED ${DALI_PYTHON_BACKEND_SRCS})
+        target_link_libraries(dali_python_${PYVER} PUBLIC dali dali_operators dali_kernels dali_core ${CUDART_LIB})
+        target_link_libraries(dali_python_${PYVER} PRIVATE ${CUDA_LIBRARIES})
+        target_link_libraries(dali_python_${PYVER} PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
+
+        set_target_properties(dali_python_${PYVER}
+                              PROPERTIES
+                              LIBRARY_OUTPUT_DIRECTORY ${DALI_LIBRARY_OUTPUT_DIR}
+                              PREFIX ""
+                              OUTPUT_NAME backend_impl${PYTHON_SUFIX})
+        target_compile_definitions(dali_python_${PYVER} PRIVATE "-Ddali_python_EXPORTS")
+        target_include_directories(dali_python_${PYVER} PRIVATE "${CMAKE_SOURCE_DIR}/third_party/pybind11/include")
+        # add includes
+        foreach(incl_dir ${PYTHON_INCLUDES})
+            target_include_directories(dali_python_${PYVER} PRIVATE ${incl_dir})
+        endforeach(incl_dir)
+
+        add_dependencies(dali_python dali_python_${PYVER})
+    endif()
+
+endforeach(PYVER)
 
 if (DALI_BUILD_FLAVOR)
   set(DALI_FLAVOR "${DALI_BUILD_FLAVOR} ")

--- a/dali/python/CMakeLists.txt
+++ b/dali/python/CMakeLists.txt
@@ -16,51 +16,13 @@
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(DALI_PYTHON_BACKEND_SRCS)
 
-add_custom_target(dali_python ALL)
-
-foreach(PYVER ${PYTHON_VERSIONS})
-
-    # check if listed python versions are accesible
-    execute_process(
-        COMMAND python${PYVER} -c "print('test', end='')"
-        OUTPUT_VARIABLE PYTHON_EXISTS)
-
-    if ("${PYTHON_EXISTS}" STREQUAL "test")
-        execute_process(
-            COMMAND python${PYVER}-config --extension-suffix
-            OUTPUT_VARIABLE PYTHON_SUFIX)
-        # remove newline and the extension
-        string(REPLACE ".so\n" "" PYTHON_SUFIX ${PYTHON_SUFIX})
-
-        execute_process(
-            COMMAND python${PYVER}-config --includes
-            OUTPUT_VARIABLE PYTHON_INCLUDES)
-        # split and make it a list
-        string(REPLACE "-I" "" PYTHON_INCLUDES ${PYTHON_INCLUDES})
-        string(REPLACE "\n" "" PYTHON_INCLUDES ${PYTHON_INCLUDES})
-        separate_arguments(PYTHON_INCLUDES)
-
-        add_library(dali_python_${PYVER} SHARED ${DALI_PYTHON_BACKEND_SRCS})
-        target_link_libraries(dali_python_${PYVER} PUBLIC dali dali_operators dali_kernels dali_core ${CUDART_LIB})
-        target_link_libraries(dali_python_${PYVER} PRIVATE ${CUDA_LIBRARIES})
-        target_link_libraries(dali_python_${PYVER} PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
-
-        set_target_properties(dali_python_${PYVER}
-                              PROPERTIES
-                              LIBRARY_OUTPUT_DIRECTORY ${DALI_LIBRARY_OUTPUT_DIR}
-                              PREFIX ""
-                              OUTPUT_NAME backend_impl${PYTHON_SUFIX})
-        target_compile_definitions(dali_python_${PYVER} PRIVATE "-Ddali_python_EXPORTS")
-        target_include_directories(dali_python_${PYVER} PRIVATE "${CMAKE_SOURCE_DIR}/third_party/pybind11/include")
-        # add includes
-        foreach(incl_dir ${PYTHON_INCLUDES})
-            target_include_directories(dali_python_${PYVER} PRIVATE ${incl_dir})
-        endforeach(incl_dir)
-
-        add_dependencies(dali_python dali_python_${PYVER})
-    endif()
-
-endforeach(PYVER)
+build_per_python_lib(TARGET_NAME dali_python
+                     OUTPUT_NAME backend_impl
+                     OUTPUT_DIR ${DALI_LIBRARY_OUTPUT_DIR}
+                     PUBLIC_LIBS dali dali_operators dali_kernels dali_core ${CUDART_LIB}
+                     PRIV_LIBS ${CUDA_LIBRARIES}
+                     EXCLUDE_LIBS ${exclude_libs}
+                     SRC ${DALI_PYTHON_BACKEND_SRCS})
 
 if (DALI_BUILD_FLAVOR)
   set(DALI_FLAVOR "${DALI_BUILD_FLAVOR} ")

--- a/dali/python/CMakeLists.txt
+++ b/dali/python/CMakeLists.txt
@@ -16,7 +16,7 @@
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(DALI_PYTHON_BACKEND_SRCS)
 
-build_per_python_lib(TARGET_NAME dali_python
+build_per_python_lib(dali_python
                      OUTPUT_NAME backend_impl
                      OUTPUT_DIR ${DALI_LIBRARY_OUTPUT_DIR}
                      PUBLIC_LIBS dali dali_operators dali_kernels dali_core ${CUDART_LIB}

--- a/dali/python/nvidia/dali/backend.py
+++ b/dali/python/nvidia/dali/backend.py
@@ -22,7 +22,6 @@ import sys
 # for importing the DALI c++ extensions, we can do it here
 
 default_plugins = [
-    'libpython_function_plugin.so'
 ]
 
 def deprecation_warning(what):

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -30,7 +30,7 @@ from nvidia.dali.types import \
 from nvidia.dali.pipeline import Pipeline as _Pipeline
 from nvidia.dali import fn as _functional
 from future.utils import with_metaclass
-import nvidia.dali.libpython_function_plugin
+import nvidia.dali.python_function_plugin
 from nvidia.dali.data_node import DataNode as _DataNode
 
 cupy = None
@@ -738,11 +738,11 @@ class PythonFunctionBase(with_metaclass(_DaliOperatorMeta, object)):
 
 
 def _dlpack_to_array(dlpack):
-    return nvidia.dali.libpython_function_plugin.DLTensorToArray(dlpack)
+    return nvidia.dali.python_function_plugin.DLTensorToArray(dlpack)
 
 
 def _dlpack_from_array(array):
-    return nvidia.dali.libpython_function_plugin.ArrayToDLTensor(array)
+    return nvidia.dali.python_function_plugin.ArrayToDLTensor(array)
 
 
 class PythonFunction(PythonFunctionBase):
@@ -754,7 +754,7 @@ class PythonFunction(PythonFunctionBase):
     @staticmethod
     def current_stream():
         """Get DALI's current CUDA stream."""
-        return _CUDAStream(nvidia.dali.libpython_function_plugin.current_dali_stream())
+        return _CUDAStream(nvidia.dali.python_function_plugin.current_dali_stream())
 
     @staticmethod
     def function_wrapper_per_sample(function, from_dlpack, to_dlpack, *dlpack_inputs):

--- a/dali/python/setup.py.in
+++ b/dali/python/setup.py.in
@@ -23,6 +23,12 @@ setup(name='nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,
+      classifiers=[
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
+          ],
       py_modules = [
           'rec2idx',
           ],

--- a/docker/Docker_run_cuda
+++ b/docker/Docker_run_cuda
@@ -1,5 +1,5 @@
 ARG BUILD_IMAGE_NAME
-ARG CUDA_IMAGE_NAME=nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
+ARG CUDA_IMAGE_NAME=nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04
 FROM ${BUILD_IMAGE_NAME} AS builder
 FROM ${CUDA_IMAGE_NAME}
 
@@ -25,7 +25,7 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
 
-COPY --from=builder /wheelhouse/nvidia_dali-*${PYV}-* /opt/dali/
+COPY --from=builder /wheelhouse/nvidia_dali-* /opt/dali/
 COPY --from=builder /wheelhouse/nvidia-dali-tf-plugin-*.tar.gz /opt/dali/
 
 RUN pip install /opt/dali/*.whl

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,17 +5,17 @@ ARG DEPS_IMAGE_NAME
 # clean builder without source code inside
 FROM ${DEPS_IMAGE_NAME} as builder
 
-ARG PYVER=2.7
-ARG PYV=27
+ARG PYVER=3.7
+ARG PYV=37
 
 ENV PYVER=${PYVER} PYV=${PYV} PYTHONPATH=/opt/python/v
 
 ENV PYBIN=${PYTHONPATH}/bin \
     PYLIB=${PYTHONPATH}/lib
 
-ENV PATH=/usr/local/cuda/bin:${PYBIN}:${PATH} \
-    LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:/opt/dali/${DALI_BUILD_DIR}:${PYLIB}:${LD_LIBRARY_PATH} \
-    LIBRARY_PATH=/usr/local/cuda/lib64/stubs:/opt/dali/${DALI_BUILD_DIR}:${PYLIB}:${LIBRARY_PATH}
+ENV PATH=/opt/python/cp35-cp35m/bin:/opt/python/cp36-cp36/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/usr/local/cuda/bin:${PYBIN}:${PATH} \
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp35-cp35m/lib:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:${PYLIB}:${LD_LIBRARY_PATH} \
+    LIBRARY_PATH=/usr/local/cuda/lib64/stubs:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp35-cp35m/lib:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:${PYLIB}:${LIBRARY_PATH}
 
 RUN ln -s /opt/python/cp${PYV}* /opt/python/v
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,8 @@ ARG DEPS_IMAGE_NAME
 # clean builder without source code inside
 FROM ${DEPS_IMAGE_NAME} as builder
 
-ARG PYVER=3.7
-ARG PYV=37
+ARG PYVER=3.6
+ARG PYV=36
 
 ENV PYVER=${PYVER} PYV=${PYV} PYTHONPATH=/opt/python/v
 

--- a/docker/Dockerfile_dali_tf
+++ b/docker/Dockerfile_dali_tf
@@ -22,6 +22,6 @@ COPY cmake ./cmake
 COPY dali_tf_plugin ./dali_tf_plugin
 
 COPY dali_tf_plugin/whl whl
-RUN pip install whl/*cp${PYV}*.whl && rm -rf whl
+RUN pip install whl/*.whl && rm -rf whl
 
 WORKDIR /opt/dali/dali_tf_plugin

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -95,7 +95,7 @@ fi
 # build builder image if needed
 if [[ "$REBUILD_BUILDERS" != "NO" || "$(docker images -q ${BUILDER} 2> /dev/null)" == "" ]]; then
     echo "Build light image:" ${BUILDER}
-    docker build -t ${BUILDER} --build-arg "DEPS_IMAGE_NAME=${DEPS_IMAGE}" --build-arg "PYVER=${PYVER}" --build-arg "PYV=${PYV}" --build-arg "NVIDIA_BUILD_ID=${NVIDIA_BUILD_ID}" \
+    docker build -t ${BUILDER} --build-arg "DEPS_IMAGE_NAME=${DEPS_IMAGE}" --build-arg "NVIDIA_BUILD_ID=${NVIDIA_BUILD_ID}" \
                                --build-arg "NVIDIA_DALI_BUILD_FLAVOR=${DALI_BUILD_FLAVOR}" --build-arg "GIT_SHA=${GIT_SHA}" --build-arg "DALI_TIMESTAMP=${DALI_TIMESTAMP}" \
                                --build-arg "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" --target builder -f docker/Dockerfile .
 fi
@@ -106,14 +106,12 @@ if [[ "$BUILD_TF_PLUGIN" == "YES" && "${PREBUILD_TF_PLUGINS}" == "YES" && ("$REB
     docker build -t ${BUILDER_DALI_TF_BASE_MANYLINUX1} \
            --build-arg "TF_CUSTOM_OP_IMAGE=${TF_CUSTOM_OP_IMAGE_MANYLINUX1}" \
            --build-arg "CUDA_IMAGE=${CUDA_DEPS_IMAGE}" \
-           --build-arg "PYVER=${PYVER}" --build-arg "PYV=${PYV}" \
            -f docker/Dockerfile.customopbuilder.clean .
     echo "Build DALI TF base (manylinux2010)"
     TF_CUSTOM_OP_IMAGE_MANYLINUX2010="tensorflow/tensorflow:custom-op-gpu-ubuntu16"
     docker build -t ${BUILDER_DALI_TF_BASE_MANYLINUX2010} \
            --build-arg "TF_CUSTOM_OP_IMAGE=${TF_CUSTOM_OP_IMAGE_MANYLINUX2010}" \
            --build-arg "CUDA_IMAGE=${CUDA_DEPS_IMAGE}" \
-           --build-arg "PYVER=${PYVER}" --build-arg "PYV=${PYV}" \
            -f docker/Dockerfile.customopbuilder.clean .
 
 fi
@@ -154,7 +152,6 @@ if [ "$BUILD_INHOST" == "YES" ]; then
 else
     echo "Build image:" ${BUILDER_WHL}
     docker build -t ${BUILDER_WHL} --build-arg "DEPS_IMAGE_NAME=${DEPS_IMAGE}"             \
-                                   --build-arg "PYVER=${PYVER}"                            \
                                    --build-arg "PYV=${PYV}"                                \
                                    --build-arg "ARCH=${ARCH}"                              \
                                    --build-arg "WHL_PLATFORM_NAME=${WHL_PLATFORM_NAME}"    \
@@ -189,10 +186,10 @@ fi
 if [ "$CREATE_RUNNER" == "YES" ]; then
     echo "Runner image:" ${RUN_IMG}
     echo "You can run this image with DALI installed inside, keep in mind to install neccessary FW package as well"
-    if [ ${CUDA_VERSION} == "9" ] ; then
-        export CUDA_IMAGE_NAME="nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04"
-    elif [ ${CUDA_VERSION} == "10" ] ; then
-        export CUDA_IMAGE_NAME="nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04"
+    if [ ${CUDA_VERSION} == "10" ] ; then
+        export CUDA_IMAGE_NAME="nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04"
+    elif [ ${CUDA_VERSION} == "11" ] ; then
+        export CUDA_IMAGE_NAME="nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
     else
         echo "**************************************************************"
         echo "Not supported CUDA version"

--- a/docker/build_helper.sh
+++ b/docker/build_helper.sh
@@ -51,6 +51,8 @@ export CUDA_TARGET_ARCHS=${CUDA_TARGET_ARCHS}
 export WHL_PLATFORM_NAME=${WHL_PLATFORM_NAME:-manylinux2014_x86_64}
 export PATH=/usr/local/cuda/bin:${PATH}
 
+# use all avialble pythons
+
 LD_LIBRARY_PATH="${PWD}:${LD_LIBRARY_PATH}" && \
 cmake ../ -DCMAKE_INSTALL_PREFIX=.                 \
       -DARCH=${ARCH}                               \
@@ -81,7 +83,7 @@ make -j"$(grep ^processor /proc/cpuinfo | wc -l)"
 
 if [ "${BUILD_PYTHON}" = "ON" ]; then
     pip wheel -v dali/python \
-        --build-option --python-tag=$(basename /opt/python/cp${PYV}-*) \
+        --build-option --python-tag=py3-none \
         --build-option --plat-name=${WHL_PLATFORM_NAME} \
         --build-option --build-number=${NVIDIA_BUILD_ID}
 

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -28,7 +28,7 @@ Building Python wheel and (optionally) Docker image
 
 Change directory (``cd``) into ``docker`` directory and run ``./build.sh``. If needed, set the following environment variables:
 
-* PYVER - Python version used to create docker image with DALI installed inside. The default is ``3.6``.
+* PYVER - Python version used to create a docker image with DALI installed inside. The default is ``3.6``.
 * CUDA_VERSION - CUDA toolkit version (10 for 10.0 or 11 for 11.0). The default is ``11``. If the version is prefixed with `.` then any value ``XX`` can be passed and the user needs to make sure that Dockerfile.cudaXX.deps is present in `docker/` directory.
 * NVIDIA_BUILD_ID - Custom ID of the build. The default is ``1234``.
 * CREATE_WHL - Create a standalone wheel. The default is ``YES``.

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -28,7 +28,7 @@ Building Python wheel and (optionally) Docker image
 
 Change directory (``cd``) into ``docker`` directory and run ``./build.sh``. If needed, set the following environment variables:
 
-* PYVER - Python version. The default is ``3.6``.
+* PYVER - Python version user to create docker image with DALI installed inside. The default is ``3.6``.
 * CUDA_VERSION - CUDA toolkit version (10 for 10.0 or 11 for 11.0). The default is ``11``. If the version is prefixed with `.` then any value ``XX`` can be passed and the user needs to make sure that Dockerfile.cudaXX.deps is present in `docker/` directory.
 * NVIDIA_BUILD_ID - Custom ID of the build. The default is ``1234``.
 * CREATE_WHL - Create a standalone wheel. The default is ``YES``.

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -28,7 +28,7 @@ Building Python wheel and (optionally) Docker image
 
 Change directory (``cd``) into ``docker`` directory and run ``./build.sh``. If needed, set the following environment variables:
 
-* PYVER - Python version user to create docker image with DALI installed inside. The default is ``3.6``.
+* PYVER - Python version used to create docker image with DALI installed inside. The default is ``3.6``.
 * CUDA_VERSION - CUDA toolkit version (10 for 10.0 or 11 for 11.0). The default is ``11``. If the version is prefixed with `.` then any value ``XX`` can be passed and the user needs to make sure that Dockerfile.cudaXX.deps is present in `docker/` directory.
 * NVIDIA_BUILD_ID - Custom ID of the build. The default is ``1234``.
 * CREATE_WHL - Create a standalone wheel. The default is ``YES``.


### PR DESCRIPTION
- builds all supported python backends in one go so there is only  one DALI whl for each supported Python versions

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It bundles all python versions into one wheel

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     builds all supported python backends in one go so there is only  one DALI whl for each supported Python versions
 - Affected modules and functionalities:
     cmake, build_helper.sh
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
