### PR TITLE
Removes redundant copy in ExternalSource operator

### DIFF
--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -388,7 +388,9 @@ DLL_PUBLIC constexpr double Buffer<Backend>::kMaxGrowthFactor;
   using Buffer<Backend>::size_;        \
   using Buffer<Backend>::shares_data_; \
   using Buffer<Backend>::num_bytes_;   \
-  using Buffer<Backend>::device_
+  using Buffer<Backend>::device_;      \
+  using Buffer<Backend>::pinned_
+
 
 }  // namespace dali
 

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -490,6 +490,7 @@ class Tensor : public Buffer<Backend> {
       num_bytes_ = t.num_bytes_;
       device_ = t.device_;
       meta_ = std::move(t.meta_);
+      pinned_ = t.pinned_;
 
       t.shape_ = TensorShape<>();
       t.backend_ = Backend();

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -198,6 +198,7 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
 
     // copy metadata
     meta_ = other->meta_;
+    layout_ = other->layout_;
   }
 
   /**
@@ -288,6 +289,24 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     offsets_.clear();
     meta_.clear();
     tensor_views_.clear();
+  }
+
+  /**
+   * @brief Swaps the content of two TensorLists
+   */
+  DLL_PUBLIC inline void Swap(TensorList<Backend> *other) {
+    std::swap(data_, other->data_);
+    std::swap(shape_, other->shape_);
+    std::swap(size_, other->size_);
+    std::swap(offsets_, other->offsets_);
+    std::swap(type_, other->type_);
+    std::swap(num_bytes_, other->num_bytes_);
+    std::swap(device_, other->device_);
+    std::swap(tensor_views_, other->tensor_views_);
+    std::swap(shares_data_, other->shares_data_);
+    std::swap(Buffer<Backend>::pinned_, other->pinned_);
+    std::swap(meta_, other->meta_);
+    std::swap(layout_, other->layout_);
   }
 
   /**

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -351,7 +351,7 @@ class TensorVector {
   void ShareData(TensorVector<Backend> *tv) {
     DALI_ENFORCE(tv != nullptr, "Input TensorVector is nullptr");
     state_ = tv->state_;
-    pinned_ = tv->pinned_;
+    pinned_ = tv->is_pinned();
 
     if (tv->tl_->raw_data()) {
       tl_->ShareData(tv->tl_.get());
@@ -373,6 +373,24 @@ class TensorVector {
         tensors_[i]->ShareData(tv->tensors_[i].get());
       }
     }
+  }
+
+  void Swap(TensorVector<Backend> *tv) {
+    std::swap(state_, tv->state_);
+    std::swap(pinned_, tv->pinned_);
+    std::swap(tl_, tv->tl_);
+    std::swap(type_, tv->type_);
+    if (views_count_) {
+      tensors_.clear();
+      views_count_ = 0;
+    }
+    if (tv->views_count_) {
+      tv->tensors_.clear();
+      tv->views_count_ = 0;
+    }
+    std::swap(tensors_, tv->tensors_);
+    UpdateViews();
+    tv->UpdateViews();
   }
 
   void UpdateViews() {

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -25,13 +25,9 @@ void ExternalSource<CPUBackend>::RunImpl(HostWorkspace &ws) {
     tensor_vector_elm = tv_data_.PopFront();
     state_.pop_front();
   }
-  if (no_copy_) {
-    TensorVector<CPUBackend> &output = ws.template OutputRef<CPUBackend>(0);
-    output.ShareData(tensor_vector_elm.front().get());
-    // empty tensor_vector_elm
-    tensor_vector_elm.front()->Reset();
-    RecycleBuffer(tensor_vector_elm);
-  } else {
+  auto &output = ws.template OutputRef<CPUBackend>(0);
+  // if the output is pinned we need to copy
+  if (output.is_pinned()) {
     auto &thread_pool = ws.GetThreadPool();
     // sort by the work size
     sample_ids_.clear();
@@ -42,12 +38,13 @@ void ExternalSource<CPUBackend>::RunImpl(HostWorkspace &ws) {
       sample_ids_.emplace_back(volume(shapes[sample_id]), sample_id);
     }
     std::sort(sample_ids_.begin(), sample_ids_.end(), std::greater<VolumeSampleIdPair>());
+    output.Resize(shapes, tensor_vector_elm.front()->type());
     for (int data_idx = 0; data_idx < batch_size_; ++data_idx) {
       thread_pool.DoWorkWithID([&ws, data_idx, &tensor_vector_elm] (int tid) {
-        Tensor<CPUBackend> &output = ws.Output<CPUBackend>(0, data_idx);
+        Tensor<CPUBackend> &output_tensor = ws.Output<CPUBackend>(0, data_idx);
         // HostWorkspace doesn't have any stream
         cudaStream_t stream = 0;
-        output.Copy((*tensor_vector_elm.front())[data_idx], stream);
+        output_tensor.Copy((*tensor_vector_elm.front())[data_idx], stream);
       });
     }
     thread_pool.WaitForWork();
@@ -55,8 +52,11 @@ void ExternalSource<CPUBackend>::RunImpl(HostWorkspace &ws) {
     // for the whole output not each element(view)
     auto &output = ws.template OutputRef<CPUBackend>(0);
     output.SetLayout(tensor_vector_elm.front()->GetLayout());
-    RecycleBuffer(tensor_vector_elm);
+  } else {
+    // swap output with tensor_vector_elm content
+    output.Swap(tensor_vector_elm.front().get());
   }
+  RecycleBuffer(tensor_vector_elm);
 }
 
 DALI_REGISTER_OPERATOR(_ExternalSource, ExternalSource<CPUBackend>, CPU);
@@ -74,7 +74,7 @@ fail when it is not)code", true)
       R"code(Whether DALI should copy the buffer when feed_input is called
 If True, DALI passes the user memory directly to the Pipeline, instead of copying.
 It is the user's responsibility to keep the buffer alive and unmodified
-until it isconsumed by the pipeline.
+until it is consumed by the pipeline.
 
 The buffer can be modified or freed again after the relevant iteration output has been consumed.
 Effectively, it happens after ``prefetch_queue_depth`` or ``cpu_queue_depth * gpu_queue_depth``

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -26,28 +26,22 @@ void ExternalSource<CPUBackend>::RunImpl(HostWorkspace &ws) {
     state_.pop_front();
   }
   auto &output = ws.template OutputRef<CPUBackend>(0);
-  // if the output is pinned we need to copy
-  if (output.is_pinned()) {
+  // if the output is pinned and input not it needs to be copied
+  if (output.is_pinned() && !tensor_vector_elm.front()->is_pinned()) {
     auto &thread_pool = ws.GetThreadPool();
-    // sort by the work size
-    sample_ids_.clear();
-    sample_ids_.reserve(batch_size_);
-
     const auto &shapes = tensor_vector_elm.front()->shape();
-    for (int sample_id = 0; sample_id < batch_size_; sample_id++) {
-      sample_ids_.emplace_back(volume(shapes[sample_id]), sample_id);
-    }
-    std::sort(sample_ids_.begin(), sample_ids_.end(), std::greater<VolumeSampleIdPair>());
     output.Resize(shapes, tensor_vector_elm.front()->type());
-    for (int data_idx = 0; data_idx < batch_size_; ++data_idx) {
-      thread_pool.DoWorkWithID([&ws, data_idx, &tensor_vector_elm] (int tid) {
-        Tensor<CPUBackend> &output_tensor = ws.Output<CPUBackend>(0, data_idx);
+
+    for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
+      thread_pool.AddWork([&ws, sample_id, &tensor_vector_elm] (int tid) {
+        Tensor<CPUBackend> &output_tensor = ws.Output<CPUBackend>(0, sample_id);
         // HostWorkspace doesn't have any stream
         cudaStream_t stream = 0;
-        output_tensor.Copy((*tensor_vector_elm.front())[data_idx], stream);
-      });
+        output_tensor.Copy((*tensor_vector_elm.front())[sample_id], stream);
+      }, volume(shapes[sample_id]));
     }
-    thread_pool.WaitForWork();
+    thread_pool.RunAll();
+
     // as we copy element by element and the output is contiguous we need to set layout
     // for the whole output not each element(view)
     auto &output = ws.template OutputRef<CPUBackend>(0);

--- a/dali/pipeline/operator/builtin/external_source.cu
+++ b/dali/pipeline/operator/builtin/external_source.cu
@@ -20,40 +20,10 @@
 
 namespace dali {
 
-template <>
-struct ExternalSource<GPUBackend>::RecycleFunctor {
-  RecycleFunctor() = default;
-  RecycleFunctor(const RecycleFunctor &) {
-    assert(!"Should never happen");
-  }
-  RecycleFunctor(RecycleFunctor &&) = default;
-  RecycleFunctor& operator=(const RecycleFunctor&) = default;
-  RecycleFunctor& operator=(RecycleFunctor&&) = default;
-  ~RecycleFunctor() = default;
-
-
-  RecycleFunctor(ExternalSource<GPUBackend> *owner, std::list<uptr_cuda_event_type> event,
-                 std::list<uptr_tl_type> ptr, std::list<uptr_cuda_event_type> internal_copy_to_gpu)
-          : owner(owner), event(std::move(event)), copy_to_gpu(std::move(internal_copy_to_gpu)),
-            ptr(std::move(ptr)) {}
-
-  ExternalSource<GPUBackend> *owner;
-  std::list<uptr_cuda_event_type> event, copy_to_gpu;
-  std::list<uptr_tl_type> ptr;
-  void operator()() {
-    std::list<uptr_cuda_event_type> *event_ptr = nullptr;
-    std::list<uptr_cuda_event_type> *copy_to_gpu_ptr = nullptr;
-    if (event.size()) event_ptr = &event;
-    if (copy_to_gpu.size()) copy_to_gpu_ptr = &copy_to_gpu;
-
-    owner->RecycleBuffer(ptr, event_ptr, copy_to_gpu_ptr);
-  }
-};
-
 template<>
 void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   std::list<uptr_tl_type> tensor_list_elm;
-  std::list<uptr_cuda_event_type> cuda_event, internal_copy_to_storage;
+  std::list<uptr_cuda_event_type> internal_copy_to_storage;
   ExternalSourceState state_info;
   {
     std::unique_lock<std::mutex> busy_lock(busy_m_);
@@ -62,11 +32,8 @@ void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
     state_.pop_front();
     // even with no_copy we may have copied from TensorVector to TensorList and we
     // need to sync with that
-    if (!no_copy_ || !tensor_list_elm.front()->shares_data()) {
+    if (!no_copy_ || state_info.copied_shared_data) {
       internal_copy_to_storage = copy_to_storage_events_.PopFront();
-      if (!no_copy_) {
-        cuda_event = cuda_events_.GetEmpty();
-      }
     }
   }
 
@@ -76,34 +43,11 @@ void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
     CUDA_CALL(cudaStreamWaitEvent(stream_used, *internal_copy_to_storage.front(), 0));
   }
 
-  if (!no_copy_) {
-    output.Copy(*(tensor_list_elm.front()), stream_used);
-     // record an event so Recycle can synchronize on it
-    cudaEventRecord(*cuda_event.front(), stream_used);
-    sync_worker_.DoWork(RecycleFunctor{this, std::move(cuda_event), std::move(tensor_list_elm),
-                                       std::move(internal_copy_to_storage)});
-  } else if (state_info.copied_shared_data) {
-    // make a shared pointer which will recycle buffer upon destruction. So when pipeline
-    // no longer needs that buffer we can return it to the pool
-    void *ptr = tensor_list_elm.front()->raw_mutable_data();
-    int device_id = tensor_list_elm.front()->device_id();
+  output.Swap(tensor_list_elm.front().get());
 
-    auto tmp_capacity = tensor_list_elm.front()->capacity();
-    auto tmp_shape = tensor_list_elm.front()->shape();
-    auto tmp_type = tensor_list_elm.front()->type();
-    RecycleFunctor funct{this, std::move(cuda_event), std::move(tensor_list_elm),
-                            std::move(internal_copy_to_storage)};
-    auto tmp_shr_ptr = shared_ptr<void>(ptr, [functor = std::move(funct)] (void*) mutable {  // NOLINT (*)
-                                              functor();
-                                              });
-
-    output.ShareData(tmp_shr_ptr, tmp_capacity, tmp_shape, tmp_type);
-    output.set_device_id(device_id);
+  if (!no_copy_ || state_info.copied_shared_data) {
+    RecycleBuffer(tensor_list_elm, &internal_copy_to_storage);
   } else {
-    output.ShareData(tensor_list_elm.front().get());
-    // empty tensor_list_elm
-    tensor_list_elm.front()->Reset();
-    // recycle right away as tensor_list_elm is only sharing data
     RecycleBuffer(tensor_list_elm);
   }
 }

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -184,11 +184,13 @@ class ExternalSource : public Operator<Backend> {
       output_desc[0].shape = tv_data_.PeekFront()->shape();
       output_desc[0].type = tv_data_.PeekFront()->type();
     }
+    // unconditionally dissabled, still we can provide share but we don't want to allocate anything
     return false;
   }
 
   bool CanInferOutputs() const override {
-    // when it passes through no shape inference is needed, it happens for no_copy_ and CPUBackend
+    // shape inference during setup is disabled because it can be calculated during the runtime
+    // depending on the input and output
     return false;
   }
 
@@ -237,31 +239,32 @@ class ExternalSource : public Operator<Backend> {
   template<typename SrcBackend, template<typename> class SourceDataType>
   inline std::enable_if_t<std::is_same<SrcBackend, Backend>::value &&
                           std::is_same<SrcBackend, CPUBackend>::value>
-  ShareUserData(const SourceDataType<SrcBackend> &t, cudaStream_t /*stream = 0*/) {
+  ShareUserData(const SourceDataType<SrcBackend> &batch, cudaStream_t /*stream = 0*/) {
     std::lock_guard<std::mutex> busy_lock(busy_m_);
     state_.push_back({});
     auto tv_elm = tv_data_.GetEmpty();
-    // if it was not allocated already set_pinned to false
-    if (!tv_elm.front()->size()) {
-      tv_elm.front()->set_pinned(false);
+    // set pinned if needed
+    if (batch.is_pinned() !=  tv_elm.front()->is_pinned()) {
+      tv_elm.front()->Reset();
+      tv_elm.front()->set_pinned(batch.is_pinned());
     }
-    tv_elm.front()->ShareData(const_cast<SourceDataType<CPUBackend>*>(&t));
+    tv_elm.front()->ShareData(const_cast<SourceDataType<CPUBackend>*>(&batch));
     tv_data_.PushBack(tv_elm);
   }
 
   template<typename SrcBackend>
   inline std::enable_if_t<std::is_same<SrcBackend, Backend>::value &&
                           std::is_same<SrcBackend, GPUBackend>::value>
-  ShareUserData(const TensorVector<SrcBackend> &t, cudaStream_t stream = 0) {
+  ShareUserData(const TensorVector<SrcBackend> &batch, cudaStream_t stream = 0) {
     std::lock_guard<std::mutex> busy_lock(busy_m_);
     auto tl_elm = tl_data_.GetEmpty();
-    if (t.IsContiguous()) {
-      t.ShareWith(const_cast<TensorList<Backend>*>(tl_elm.front().get()));
+    if (batch.IsContiguous()) {
+      batch.ShareWith(const_cast<TensorList<Backend>*>(tl_elm.front().get()));
       zero_copy_noncontiguous_gpu_input_ = true;
       state_.push_back({});
     } else {
       // it is not contiguous so we need to copy
-      tl_elm.front()->Copy(t, stream);
+      tl_elm.front()->Copy(batch, stream);
 
       std::list<uptr_cuda_event_type> copy_to_storage_event;
       copy_to_storage_event = copy_to_storage_events_.GetEmpty();
@@ -281,11 +284,11 @@ class ExternalSource : public Operator<Backend> {
   template<typename SrcBackend>
   inline std::enable_if_t<std::is_same<SrcBackend, Backend>::value &&
                           std::is_same<SrcBackend, GPUBackend>::value>
-   ShareUserData(const TensorList<SrcBackend> &t, cudaStream_t /*stream = 0*/) {
+   ShareUserData(const TensorList<SrcBackend> &batch, cudaStream_t /*stream = 0*/) {
     std::lock_guard<std::mutex> busy_lock(busy_m_);
     state_.push_back({});
     auto tl_elm = tl_data_.GetEmpty();
-    tl_elm.front()->ShareData(const_cast<TensorList<Backend>*>(&t));
+    tl_elm.front()->ShareData(const_cast<TensorList<Backend>*>(&batch));
     tl_data_.PushBack(tl_elm);
     zero_copy_noncontiguous_gpu_input_ = true;
   }
@@ -298,9 +301,10 @@ class ExternalSource : public Operator<Backend> {
       std::lock_guard<std::mutex> busy_lock(busy_m_);
       tv_elm = tv_data_.GetEmpty();
     }
-    // if it was not allocated already set_pinned to false
-    if (!tv_elm.front()->size()) {
-      tv_elm.front()->set_pinned(false);
+    // set pinned if needed
+    if (batch.is_pinned() !=  tv_elm.front()->is_pinned()) {
+      tv_elm.front()->Reset();
+      tv_elm.front()->set_pinned(batch.is_pinned());
     }
     // HostWorkspace doesn't have any stream
     cudaStream_t stream = 0;
@@ -395,9 +399,6 @@ class ExternalSource : public Operator<Backend> {
   bool zero_copy_noncontiguous_gpu_input_ = false;
 
   WorkerThread sync_worker_;
-
-  using VolumeSampleIdPair = std::pair<int64_t, int>;  // volume, sample_idx
-  std::vector<VolumeSampleIdPair> sample_ids_;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -130,22 +130,22 @@ class ExternalSource : public Operator<Backend> {
   }
 
   /**
-   * @brief Sets the data that should be passed out of the op
-   * on the next iteration.
+   * @brief Sets the data that should be passed out of the op on the next iteration.
    */
   template<typename SrcBackend>
   inline void SetDataSource(const TensorList<SrcBackend> &tl, cudaStream_t stream = 0,
                             bool sync = false) {
+    TimeRange tr("[ExternalSource] SetDataSource", TimeRange::kViolet);
     SetDataSourceHelper(tl, stream, sync);
   }
 
   /**
-   * @brief Sets the data that should be passed out of the op
-   * on the next iteration.
+   * @brief Sets the data that should be passed out of the op on the next iteration.
    */
   template<typename SrcBackend>
   inline void SetDataSource(const vector<Tensor<SrcBackend>> &vect_of_tensors,
                             cudaStream_t stream = 0, bool sync = false) {
+    TimeRange tr("[ExternalSource] SetDataSource", TimeRange::kViolet);
     TensorVector<SrcBackend> tv(vect_of_tensors.size());
     for (size_t i = 0; i < tv.size(); ++i) {
       tv[i].ShareData(const_cast<Tensor<SrcBackend>*>(&vect_of_tensors[i]));
@@ -154,12 +154,12 @@ class ExternalSource : public Operator<Backend> {
   }
 
   /**
-   * @brief Sets the data that should be passed out of the op
-   * on the next iteration.
+   * @brief Sets the data that should be passed out of the op on the next iteration.
    */
   template<typename SrcBackend>
   inline void SetDataSource(const TensorVector<SrcBackend> &tv, cudaStream_t stream = 0,
                             bool sync = false) {
+    TimeRange tr("[ExternalSource] SetDataSource", TimeRange::kViolet);
     SetDataSourceHelper(tv, stream, sync);
   }
 
@@ -167,35 +167,29 @@ class ExternalSource : public Operator<Backend> {
 
  protected:
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
-    // for zero copy we don't want any shape inference to avoid any data allocation ahead
-    if (no_copy_) {
-      return false;
+    std::unique_lock<std::mutex> busy_lock(busy_m_);
+    if (blocking_) {
+      cv_.wait(busy_lock, [&data = state_] {return !data.empty(); });
+    } else {
+      if (state_.empty()) {
+        DALI_FAIL("No data was provided to the ExternalSource. Make sure to feed it properly.");
+      }
     }
     TensorListShape<> shape;
     output_desc.resize(1);
-    {
-      std::unique_lock<std::mutex> busy_lock(busy_m_);
-      if (blocking_) {
-        cv_.wait(busy_lock, [&data = state_] {return !data.empty(); });
-      } else {
-        if (state_.empty()) {
-          DALI_FAIL("No data was provided to the ExternalSource. Make sure to feed it properly.");
-        }
-      }
-      if (std::is_same<Backend, GPUBackend>::value) {
-        output_desc[0].shape = tl_data_.PeekFront()->shape();
-        output_desc[0].type = tl_data_.PeekFront()->type();
-      } else {
-        output_desc[0].shape = tv_data_.PeekFront()->shape();
-        output_desc[0].type = tv_data_.PeekFront()->type();
-      }
+    if (std::is_same<Backend, GPUBackend>::value) {
+      output_desc[0].shape = tl_data_.PeekFront()->shape();
+      output_desc[0].type = tl_data_.PeekFront()->type();
+    } else {
+      output_desc[0].shape = tv_data_.PeekFront()->shape();
+      output_desc[0].type = tv_data_.PeekFront()->type();
     }
-    return true;
+    return false;
   }
 
   bool CanInferOutputs() const override {
-    // when it passes through no shape inference is needed
-    return !no_copy_;
+    // when it passes through no shape inference is needed, it happens for no_copy_ and CPUBackend
+    return false;
   }
 
   /*
@@ -221,15 +215,9 @@ class ExternalSource : public Operator<Backend> {
   void RecycleBuffer(DataType &data,
                      std::list<uptr_cuda_event_type> *cuda_event = nullptr,
                      std::list<uptr_cuda_event_type> *copy_to_gpu = nullptr) {
-    if (cuda_event) {
-      cudaEventSynchronize(*cuda_event->front());
-    }
     // No need to synchronize on copy_to_gpu - it was already synchronized before
     std::lock_guard<std::mutex> busy_lock(busy_m_);
     RecycleBufferHelper(data);
-    if (cuda_event) {
-      cuda_events_.Recycle(*cuda_event);
-    }
     if (copy_to_gpu) {
       copy_to_storage_events_.Recycle(*copy_to_gpu);
     }
@@ -238,7 +226,12 @@ class ExternalSource : public Operator<Backend> {
   template<typename SrcBackend, template<typename> class SourceDataType>
   inline std::enable_if_t<!std::is_same<SrcBackend, Backend>::value>
   ShareUserData(const SourceDataType<SrcBackend> &t, cudaStream_t /*stream = 0*/) {
-    DALI_FAIL("no_copy is supported only for the same data source device type as operator.");
+    DALI_FAIL(make_string("no_copy is supported only for the same data source device type "
+                          "as operator. Received: ",
+                          std::is_same<SrcBackend, CPUBackend>::value? "CPU" : "GPU",
+                          " input for ",
+                          std::is_same<Backend, CPUBackend>::value? "CPU" : "GPU",
+                          " operator."));
   }
 
   template<typename SrcBackend, template<typename> class SourceDataType>
@@ -248,6 +241,10 @@ class ExternalSource : public Operator<Backend> {
     std::lock_guard<std::mutex> busy_lock(busy_m_);
     state_.push_back({});
     auto tv_elm = tv_data_.GetEmpty();
+    // if it was not allocated already set_pinned to false
+    if (!tv_elm.front()->size()) {
+      tv_elm.front()->set_pinned(false);
+    }
     tv_elm.front()->ShareData(const_cast<SourceDataType<CPUBackend>*>(&t));
     tv_data_.PushBack(tv_elm);
   }
@@ -332,9 +329,7 @@ class ExternalSource : public Operator<Backend> {
     if (std::is_same<SrcBackend, GPUBackend>::value || batch.is_pinned()) {
       cudaEventRecord(*copy_to_storage_event.front(), stream);
     }
-    // sync for pinned CPU -> GPU as well, because the user doesn't know when he can
-    // reuse provided memory anyway
-    if (sync || batch.is_pinned()) {
+    if (sync) {
       CUDA_CALL(cudaEventSynchronize(*copy_to_storage_event.front()));
     }
 
@@ -375,8 +370,7 @@ class ExternalSource : public Operator<Backend> {
   string output_name_;
   detail::CachingList<uptr_tl_type> tl_data_;
   detail::CachingList<uptr_tv_type> tv_data_;
-  detail::CachingList<uptr_cuda_event_type> cuda_events_, copy_to_storage_events_;
-  struct RecycleFunctor;
+  detail::CachingList<uptr_cuda_event_type> copy_to_storage_events_;
 
   std::mutex busy_m_;
   std::condition_variable cv_;

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -349,7 +349,7 @@ void ExposeTensor(py::module &m) {
 
           // Create the Tensor and wrap the data
           auto t = new Tensor<CPUBackend>;
-          t->set_pinned(false);
+          t->set_pinned(is_pinned);
           TypeInfo type = TypeFromFormatStr(info.format);
           t->ShareData(info.ptr, bytes, type);
           t->SetLayout(layout);
@@ -1077,7 +1077,8 @@ void FeedPipeline(Pipeline *p, const string &name, py::list list, cudaStream_t s
                   bool sync = false) {
   TensorVector<Backend> tv(list.size());
   for (size_t i = 0; i < list.size(); ++i) {
-    tv[i] = std::move(list[i].cast<Tensor<Backend>&>());
+    auto &t = list[i].cast<Tensor<Backend>&>();
+    tv[i] = std::move(t);
   }
   p->SetExternalInput(name, tv, stream, sync);
 }


### PR DESCRIPTION
- removes the redundant copy from CPU and GPU backend - now ExternalSource will just use data from staging buffer directly inside RunImpl
- adds NVTX range to SetDataSource so now it is possible to measure user thread time of feeding ExternalSource operator
- adds a more verbose message when operator and data backend doesn't match when zero_copy is used
- fixes lack of waiting for the inputs when zero-copy is set
- adds Swap method to TensorVector and TensorList
- ExternalSource doesn't always sync anymore when the pinned CPU buffer is provided for the GPU operator

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a lack of waiting for the inputs when zero-copy is set
- It removes the redundant copy from CPU and GPU backend - now ExternalSource will just use data from staging buffer directly inside RunImpl

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     removes the redundant copy from CPU backend - now ExternalSource will just use data from staging buffer directly inside RunImpl
     adds NVTX range to SetDataSource so now it is possible to measure user thread time of feeding ExternalSource operator
     adds a more verbose message when operator and data backend doesn't match when zero_copy is used
     fixes lack of waiting for the inputs when zero-copy is set
     ExternalSource doesn't always sync anymore when the pinned CPU buffer is provided for the GPU operator
 - Affected modules and functionalities:
     ExternalSource
     TensorList
     TensorVector
     Buffer
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
