### PR TITLE
Fix conda build after the new build of libprotobuf was released

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -63,6 +63,8 @@ requirements:
     - python
     - future >=0.17.1
     - protobuf >=3.11.2
+    # h8b12597_1 misses static libs inside
+    - libprotobuf >=3.11.2 h8b12597_0
     - libjpeg-turbo >=2.0.3
     - tensorflow-gpu =2.2.0
     - tensorflow-estimator =2.2.0


### PR DESCRIPTION
- the newest conda libprotobuf build misses static libraries DALI relies on
- freezes libprotobuf versionin conda build
- reported in https://github.com/conda-forge/protobuf-feedstock/issues/89

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a conda build after the new build of libprotobuf was released

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     freezes libprotobuf versionin conda build
 - Affected modules and functionalities:
     conda build yaml
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
