### PR TITLE
Use new ThreadPool API to post work with priority

### DIFF
--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -178,7 +178,7 @@ void AudioDecoderCpu::DecodeBatch(workspace_t<Backend> &ws) {
   intermediate_buffers_.resize(tp.size());
 
   for (int i = 0; i < batch_size; i++) {
-    tp.DoWorkWithID([&, i](int thread_id) {
+    tp.AddWork([&, i](int thread_id) {
       try {
         DecodeSample<OutputType>(decoded_output[i], thread_id, i);
         sample_rate_output[i].data[0] = use_resampling_
@@ -188,10 +188,10 @@ void AudioDecoderCpu::DecodeBatch(workspace_t<Backend> &ws) {
         DALI_FAIL(make_string("Error decoding file.\nError: ", e.what(), "\nFile: ",
                               files_names_[i], "\n"));
       }
-    });
+    }, sample_meta_[i].length * sample_meta_[i].channels);
   }
 
-  tp.WaitForWork();
+  tp.RunAll();
 }
 
 

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -149,13 +149,6 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
   ~nvJPEGDecoder() override {
     try {
-      thread_pool_.WaitForWork();
-    } catch (const std::runtime_error &e) {
-      std::cerr << "An error occurred in nvJPEG worker thread:\n"
-                << e.what() << std::endl;
-    }
-
-    try {
       DeviceGuard g(device_id_);
 
       sample_data_.clear();

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -499,7 +499,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
           SampleWorker(sample->sample_idx, sample->file_name, in.size(), tid,
             in.data<uint8_t>(), output_data, streams_[tid]);
           CacheStore(sample->file_name, output_data, shape, streams_[tid]);
-        }, GetTaskPrioritySeq());
+        }, GetTaskPrioritySeq());  // FIFO order, since the samples were already ordered
     }
   }
 
@@ -515,7 +515,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
           HostFallback<StorageGPU>(in.data<uint8_t>(), in.size(), output_image_type_, output_data,
                                    streams_[tid], sample->file_name, sample->roi, use_fast_idct_);
           CacheStore(sample->file_name, output_data, shape, streams_[tid]);
-        }, GetTaskPrioritySeq());
+        }, GetTaskPrioritySeq());  // FIFO order, since the samples were already ordered
     }
   }
 

--- a/dali/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
+++ b/dali/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
@@ -369,8 +369,8 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
           }, -idx);  // -idx for FIFO order, since the samples were already ordered
       }
       LoadDeferred(ws.stream());
-      // Make sure work is finished being submitted
-      thread_pool_.WaitForWork();
+      // Make sure work is finished
+      thread_pool_.RunAll();
     }
 
     // ensure we're consistent with the main op stream

--- a/dali/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
+++ b/dali/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
@@ -313,7 +313,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
                                       output_data,
                                       streams_[0],
                                       file_name);
-            }, -i);  // -i for FIFO order
+            }, -i);  // -i for FIFO order, since the samples were already ordered
       }
       // Sync thread-based work, assemble outputs and call batched
       thread_pool_.RunAll();
@@ -366,7 +366,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
               file_name);
 
             CacheStore(file_name, output_data, output_shape, streams_[stream_idx]);
-          }, -idx);  // -idx for FIFO order
+          }, -idx);  // -idx for FIFO order, since the samples were already ordered
       }
       LoadDeferred(ws.stream());
       // Make sure work is finished being submitted

--- a/dali/operators/generic/erase/erase.cc
+++ b/dali/operators/generic/erase/erase.cc
@@ -178,7 +178,7 @@ void EraseImplCpu<T, Dims>::RunImpl(HostWorkspace &ws) {
   auto &output = ws.OutputRef<CPUBackend>(0);
   int nsamples = input.size();
   auto& thread_pool = ws.GetThreadPool();
-  auto out_shape = output.shape();
+  auto in_shape = input.shape();
   for (int i = 0; i < nsamples; i++) {
     thread_pool.AddWork(
       [this, &input, &output, i](int thread_id) {
@@ -186,7 +186,7 @@ void EraseImplCpu<T, Dims>::RunImpl(HostWorkspace &ws) {
         auto in_view = view<const T, Dims>(input[i]);
         auto out_view = view<T, Dims>(output[i]);
         kmgr_.Run<EraseKernel>(thread_id, i, ctx, out_view, in_view, args_[i]);
-      }, out_shape.tensor_size(i));
+      }, in_shape.tensor_size(i));
   }
   thread_pool.RunAll();
 }

--- a/dali/operators/image/color/brightness_contrast.cc
+++ b/dali/operators/image/color/brightness_contrast.cc
@@ -82,13 +82,14 @@ void BrightnessContrastCpu::RunImpl(workspace_t<CPUBackend> &ws) {
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto &output = ws.template OutputRef<CPUBackend>(0);
   output.SetLayout(InputLayout(ws, 0));
+  auto out_shape = output.shape();
   auto& tp = ws.GetThreadPool();
   TYPE_SWITCH(input.type().id(), type2id, InputType, (uint8_t, int16_t, int32_t, float), (
       TYPE_SWITCH(output_type_, type2id, OutputType, (uint8_t, int16_t, int32_t, float), (
           {
               using Kernel = TheKernel<OutputType, InputType>;
               for (int sample_id = 0; sample_id < input.shape().num_samples(); sample_id++) {
-                tp.DoWorkWithID([&, sample_id](int thread_id) {
+                tp.AddWork([&, sample_id](int thread_id) {
                     kernels::KernelContext ctx;
                     auto tvin = view<const InputType, 3>(input[sample_id]);
                     auto tvout = view<OutputType, 3>(output[sample_id]);
@@ -97,12 +98,12 @@ void BrightnessContrastCpu::RunImpl(workspace_t<CPUBackend> &ws) {
                       brightness_[sample_id], brightness_shift_[sample_id], contrast_[sample_id]);
                     kernel_manager_.Run<Kernel>(thread_id, sample_id, ctx, tvout, tvin,
                                                 add, mul);
-                });
+                }, out_shape.tensor_size(sample_id));
               }
           }
       ), DALI_FAIL("Unsupported output type"))  // NOLINT
   ), DALI_FAIL("Unsupported input type"))  // NOLINT
-  tp.WaitForWork();
+  tp.RunAll();
 }
 
 }  // namespace dali

--- a/dali/operators/image/remap/warp.h
+++ b/dali/operators/image/remap/warp.h
@@ -152,13 +152,13 @@ class WarpOpImpl : public OpImplInterface<Backend> {
 
     auto output = view<OutputType, tensor_ndim>(ws.template OutputRef<Backend>(0));
     input_ = view<const InputType,  tensor_ndim>(ws.template InputRef<Backend>(0));
-
+    auto out_shape = output.shape;
 
     ThreadPool &pool = ws.GetThreadPool();
     auto interp_types = param_provider_->InterpTypes();
 
     for (int i = 0; i < input_.num_samples(); i++) {
-      pool.DoWorkWithID([&, i](int tid) {
+      pool.AddWork([&, i](int tid) {
         DALIInterpType interp_type = interp_types.size() > 1 ? interp_types[i] : interp_types[0];
         auto context = GetContext(ws);
         kmgr_.Run<Kernel>(
@@ -169,9 +169,9 @@ class WarpOpImpl : public OpImplInterface<Backend> {
             param_provider_->OutputSizes()[i],
             interp_type,
             param_provider_->Border());
-      });
+      }, out_shape.tensor_size(i));
     }
-    pool.WaitForWork(true);
+    pool.RunAll();
   }
 
   void RunBackend(DeviceWorkspace &ws) {

--- a/dali/operators/image/remap/warp.h
+++ b/dali/operators/image/remap/warp.h
@@ -152,7 +152,6 @@ class WarpOpImpl : public OpImplInterface<Backend> {
 
     auto output = view<OutputType, tensor_ndim>(ws.template OutputRef<Backend>(0));
     input_ = view<const InputType,  tensor_ndim>(ws.template InputRef<Backend>(0));
-    auto out_shape = output.shape;
 
     ThreadPool &pool = ws.GetThreadPool();
     auto interp_types = param_provider_->InterpTypes();
@@ -169,7 +168,7 @@ class WarpOpImpl : public OpImplInterface<Backend> {
             param_provider_->OutputSizes()[i],
             interp_type,
             param_provider_->Border());
-      }, out_shape.tensor_size(i));
+      }, output.shape.tensor_size(i));
     }
     pool.RunAll();
   }

--- a/dali/operators/math/expressions/arithmetic.cc
+++ b/dali/operators/math/expressions/arithmetic.cc
@@ -36,7 +36,7 @@ void ArithmeticGenericOp<CPUBackend>::RunImpl(HostWorkspace &ws) {
                                        {extent_idx, extent_idx + 1});
         }
       }
-    }, -task_idx);  // Descending numbers for FIFO execution
+    }, -task_idx);  // FIFO order, since the work is already divided to similarly sized chunks
   }
   pool.RunAll();
 }

--- a/dali/operators/math/expressions/arithmetic.cc
+++ b/dali/operators/math/expressions/arithmetic.cc
@@ -26,8 +26,7 @@ void ArithmeticGenericOp<CPUBackend>::RunImpl(HostWorkspace &ws) {
   auto &pool = ws.GetThreadPool();
   ws.OutputRef<CPUBackend>(0).SetLayout(result_layout_);
   for (size_t task_idx = 0; task_idx < tile_range_.size(); task_idx++) {
-    // TODO(klecki): reduce lambda footprint
-    pool.DoWorkWithID([this, task_idx](int thread_idx) {
+    pool.AddWork([this, task_idx](int thread_idx) {
       auto range = tile_range_[task_idx];
       // Go over "tiles"
       for (int extent_idx = range.begin; extent_idx < range.end; extent_idx++) {
@@ -37,9 +36,9 @@ void ArithmeticGenericOp<CPUBackend>::RunImpl(HostWorkspace &ws) {
                                        {extent_idx, extent_idx + 1});
         }
       }
-    });
+    }, -task_idx);  // Descending numbers for FIFO execution
   }
-  pool.WaitForWork();
+  pool.RunAll();
 }
 
 DALI_SCHEMA(ArithmeticGenericOp)

--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -129,12 +129,13 @@ template <>
 void CopyOutputData(TensorVector<CPUBackend> &output, std::vector<DLMTensorPtr> &dl_tensors,
                    int batch_size, HostWorkspace &workspace) {
   auto &thread_pool = workspace.GetThreadPool();
+  auto out_shape = output.shape();
   for (int i = 0; i < batch_size; ++i) {
-    thread_pool.DoWorkWithID([&, i](int) {
+    thread_pool.AddWork([&, i](int) {
       CopyDlTensor<CPUBackend>(output[i].raw_mutable_data(), dl_tensors[i]);
-    });
+    }, out_shape.tensor_size(i));
   }
-  thread_pool.WaitForWork();
+  thread_pool.RunAll();
 }
 
 template <>

--- a/dali/operators/random/normal_distribution_op.cc
+++ b/dali/operators/random/normal_distribution_op.cc
@@ -71,12 +71,13 @@ void NormalDistributionCpu::AssignSingleValueToOutput(workspace_t<CPUBackend> &w
 
 void NormalDistributionCpu::AssignTensorToOutput(workspace_t<CPUBackend> &ws) {
   auto &output = ws.OutputRef<CPUBackend>(0);
+  auto out_shape = output.shape();
   auto &tp = ws.GetThreadPool();
   TYPE_SWITCH(dtype_, type2id, DType, NORM_TYPES, (
             for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
-              auto out_size = volume(output[sample_id].shape());
+              auto out_size = out_shape.tensor_size(sample_id);
               tp.AddWork(
-                  [&](int thread_id) {
+                  [&, out_size](int thread_id) {
                      distribution_t distribution(mean_[sample_id], stddev_[sample_id]);
                      auto ptr = output[sample_id].mutable_data<DType>();
                      for (int64_t j = 0; j < out_size; j++) {

--- a/dali/operators/random/normal_distribution_op.cc
+++ b/dali/operators/random/normal_distribution_op.cc
@@ -77,7 +77,7 @@ void NormalDistributionCpu::AssignTensorToOutput(workspace_t<CPUBackend> &ws) {
             for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
               auto out_size = out_shape.tensor_size(sample_id);
               tp.AddWork(
-                  [&, out_size](int thread_id) {
+                  [&, sample_id, out_size](int thread_id) {
                      distribution_t distribution(mean_[sample_id], stddev_[sample_id]);
                      auto ptr = output[sample_id].mutable_data<DType>();
                      for (int64_t j = 0; j < out_size; j++) {

--- a/dali/operators/signal/fft/spectrogram.cc
+++ b/dali/operators/signal/fft/spectrogram.cc
@@ -252,7 +252,7 @@ void SpectrogramImplCpu::RunImpl(workspace_t<CPUBackend> &ws) {
     }, out_shape.tensor_size(i));
   }
 
-  thread_pool.WaitForWork();
+  thread_pool.RunAll();
 }
 
 template <>

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -352,9 +352,6 @@ class ExternalSource : public Operator<Backend> {
   bool zero_copy_noncontiguous_gpu_input_ = false;
 
   WorkerThread sync_worker_;
-
-  using VolumeSampleIdPair = std::pair<int64_t, int>;  // volume, sample_idx
-  std::vector<VolumeSampleIdPair> sample_ids_;
 };
 
 template<>

--- a/dali/pipeline/util/thread_pool_test.cc
+++ b/dali/pipeline/util/thread_pool_test.cc
@@ -44,7 +44,7 @@ TEST(ThreadPool, DoWorkWithID) {
 }
 
 TEST(ThreadPool, AddWorkWithPriority) {
-  ThreadPool tp(2, 0, false);
+  ThreadPool tp(1, 0, false);  // only one thread to ensure deterministic behavior
   std::atomic<int> count{0};
   auto set_to_1 = [&count](int thread_id) {
     count = 1;

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -522,6 +522,13 @@ struct TensorListShapeBase {
   TensorListShape<DynamicDimensions> last(int count) const;
 
   /**
+   * @brief Return the total size or extent of `sample`
+   */
+  int64_t tensor_size(int64_t sample) const {
+    return volume(tensor_shape_span(sample));
+  }
+
+  /**
    * @brief Return a span containing the shape of `sample`
    */
   span<int64_t, sample_ndim == DynamicDimensions ?


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- Refactoring DALI operators to use the new way to post work to the thread pool according to the size of the task (typically volume of the sample is a good indicator of the size of the task)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Modified every use of thread_pool from DoWorkFromID/WaitForWork API to AddWork/RunAll pattern*
 - Affected modules and functionalities:
     *Mostly all CPU operators using thread pool*
 - Key points relevant for the review:
     *All of it*
 - Validation and testing:
     *Existing tests*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1473]*
