### PR TITLE
Update aarch64_linux build to Jetpack 4.4 and CUDA 10.2

### DIFF
--- a/docker/Dockerfile.build.aarch64-linux
+++ b/docker/Dockerfile.build.aarch64-linux
@@ -1,4 +1,6 @@
-FROM nvidia/cuda:10.0-devel-ubuntu16.04
+ARG AARCH64_CUDA_TOOL_IMAGE_NAME
+FROM ${AARCH64_CUDA_TOOL_IMAGE_NAME} as aarch64_cuda_tools
+FROM nvidia/cuda:10.2-devel-ubuntu18.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -16,12 +18,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libtool-bin \
     && rm -rf /var/lib/apt/lists/*
 
-ENV REPO_DEBS="cuda-repo-ubuntu1604-10-0-local-10.0.117-410.38_1.0-1_amd64.deb"
-ENV CUDA_CROSS_VERSION=10-0
-ENV CUDA_CROSS_PACKAGES="cublas cudart cufft curand cusolver cusparse driver misc-headers npp"
+COPY --from=aarch64_cuda_tools *.deb ./
 
-RUN wget https://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/4.1.1/xddsn.im/JetPackL4T_4.1.1_b57/16.04/cuda-repo-ubuntu1604-10-0-local-10.0.117-410.38_1.0-1_amd64.deb && \
-    dpkg -i $REPO_DEBS && \
+ENV CUDA_CROSS_VERSION=10.2
+ENV CUDA_CROSS_PACKAGES="cudart cufft curand driver misc-headers npp"
+RUN dpkg -i *.deb && \
     echo "for i in \$CUDA_CROSS_PACKAGES; do echo \"cuda-\$i-cross-aarch64-\${CUDA_CROSS_VERSION}\";done" | bash > /tmp/cuda-packages.txt && \
     apt-get update \
    && apt-get install -y $(cat /tmp/cuda-packages.txt) \
@@ -193,7 +194,7 @@ VOLUME /dali
 WORKDIR /dali
 
 
-ENV PATH=/usr/local/cuda-10.0/bin:$PATH
+ENV PATH=/usr/local/cuda-10.2/bin:$PATH
 
 ARG DALI_BUILD_DIR=build_aarch64_linux
 
@@ -205,9 +206,9 @@ CMD cmake \
   -DCMAKE_COLOR_MAKEFILE=ON \
   -DCMAKE_INSTALL_PREFIX=./install \
   -DARCH=aarch64-linux \
-  -DCMAKE_CUDA_COMPILER=/usr/local/cuda-10.0/bin/nvcc \
-  -DCUDA_HOST=/usr/local/cuda-10.0 \
-  -DCUDA_TARGET=/usr/local/cuda-10.0/targets/aarch64-linux \
+  -DCMAKE_CUDA_COMPILER=/usr/local/cuda-10.2/bin/nvcc \
+  -DCUDA_HOST=/usr/local/cuda-10.2 \
+  -DCUDA_TARGET=/usr/local/cuda-10.2/targets/aarch64-linux \
   -DBUILD_TEST=ON \
   -DBUILD_BENCHMARK=OFF \
   -DBUILD_NVTX=OFF \

--- a/docker/Dockerfile.cuda_aarch64.deps
+++ b/docker/Dockerfile.cuda_aarch64.deps
@@ -1,0 +1,4 @@
+FROM scratch
+
+COPY cuda-repo-ubuntu1804-10-2-local-10.2.89-440.40_1.0-1_amd64.deb cuda-repo-ubuntu1804-10-2-local-10.2.89-440.40_1.0-1_amd64.deb
+COPY cuda-repo-cross-aarch64-10-2-local-10.2.89_1.0-1_all.deb cuda-repo-cross-aarch64-10-2-local-10.2.89_1.0-1_all.deb

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -341,11 +341,12 @@ Cross-compiling DALI C++ API for aarch64 Linux (Docker)
 
 Setup
 ^^^^^
-Using the SDK Manager for NVIDIA Jetson as the product category adn JetPack 4.4.
+Download the JetPack 4.4 SDK for NVIDIA Jetson using the SDK Manager, following the instruction
+provided here: https://developer.nvidia.com/embedded/jetpack.
 Then select CUDA for the host. After download process has been completed move
 ``cuda-repo-ubuntu1804-10-2-local-10.2.89-440.40_1.0-1_amd64.deb`` and
 ``cuda-repo-cross-aarch64-10-2-local-10.2.89_1.0-1_all.deb`` from the download folder
-to main DALI folder.
+to main DALI folder (they are required for cross build).
 
 Build the aarch64 Linux Build Container
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -339,12 +339,21 @@ Cross-compiling DALI C++ API for aarch64 Linux (Docker)
   x86-64 target and they are turned off in this build. There is no support for DALI Python library
   on aarch64 yet. Some Operators may not work as intended due to x86-64 specific implementations.
 
+Setup
+^^^^^
+Using the SDK Manager for NVIDIA Jetson as the product category adn JetPack 4.4.
+Then select CUDA for the host. After download process has been completed move
+``cuda-repo-ubuntu1804-10-2-local-10.2.89-440.40_1.0-1_amd64.deb`` and
+``cuda-repo-cross-aarch64-10-2-local-10.2.89_1.0-1_all.deb`` from the download folder
+to main DALI folder.
+
 Build the aarch64 Linux Build Container
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
-    docker build -t nvidia/dali:builder_aarch64-linux -f docker/Dockerfile.build.aarch64-linux .
+    docker build -t nvidia/dali:tools_aarch64-linux -f docker/Dockerfile.cuda_aarch64.deps .
+    docker build -t nvidia/dali:builder_aarch64-linux --build-arg "AARCH64_CUDA_TOOL_IMAGE_NAME=nvidia/dali:tools_aarch64-linux" -f docker/Dockerfile.build.aarch64-linux .
 
 Compile
 ^^^^^^^


### PR DESCRIPTION
- changes the build image for aarch64_linux to Ubuntu 18.03 and CUDA 10.2
- updates Jetpack version to 4.4
- Jetpack 4.4 is in the registration-required zone so ask user to download it first before the build - similar to QNX

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It updates aarch64_linux build to Jetpack 4.4 and CUDA 10.2

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     changes the build image for aarch64_linux to Ubuntu 18.03 and CUDA 10.2
     updates Jetpack version to 4.4
    Jetpack 4.4 is in the registration-required zone so ask user to download it first before the build - similar to QNX
 - Affected modules and functionalities:
     docker build for aarch64_linux
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     build procedure docs


**JIRA TASK**: *[NA]*
