### PR TITLE
TensorListView generalized reshape and reinterpret

### DIFF
--- a/include/dali/core/tensor_view.h
+++ b/include/dali/core/tensor_view.h
@@ -780,12 +780,14 @@ TensorListView<StorageBackend, DataType, output_ndim> sample_range(
 
 
 /**
- * @brief Uses existing data and a new shape to construct a new TensorListView.
+ * @brief Uses existing data and a new shape and type to construct a new TensorListView.
  *
- * The function combines existing list a new shape to build a new TensorListView.
- * If the existing list is contiguous, only the total size must be preserved.
- * Otherwise, non-contiguous input samples must not contribute to one output sample.
+ * The function combines existing list with a new shape to build a new TensorListView,
+ * possibly with different element type.
+ * Non-contiguous input samples must not contribute to one output sample;
+ * merging contiguous samples and splitting is still possible.
  *
+ * @tparam U    new element type
  * @param list  original tensor list
  * @param shape the desired shape
  * @param check if true, exception is thrown when the list cannot be reshaped
@@ -850,9 +852,9 @@ TensorListView<Storage, U, out_dim> reinterpret(
 /**
  * @brief Uses existing data and a new shape to construct a new TensorListView.
  *
- * The function combines existing list a new shape to build a new TensorListView.
- * If the existing list is contiguous, only the total size must be preserved.
- * Otherwise, non-contiguous input samples must not contribute to one output sample.
+ * The function combines existing list with a new shape to build a new TensorListView.
+ * Non-contiguous input samples must not contribute to one output sample;
+ * merging contiguous samples and splitting is still possible.
  *
  * @param list  original tensor list
  * @param shape the desired shape


### PR DESCRIPTION
Add TensorListView reinterpret and reshape with sample split/merge even for non-contiguous lists.

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to split sequences into separate frames for VideoResize

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * `reshape` is now a special case of `reinterpret` with output type same as input type
     * `reinterpret` advances a pointer and splits/merges samples as necessary; error is raised only if the input discontinuity
       appears inside an output sample
 - Affected modules and functionalities:
     * reshape function and its users (spectrogram, reductions)
 - Key points relevant for the review:
     * Try to find some corner cases not handled by the algorithm?
 - Validation and testing:
     * GTest (tests include error cases)
 - Documentation (including examples):
     * Doxygen

**JIRA TASK**: N/A
