### PR TITLE
Add an option to use a copy kernel to feed external input

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -381,20 +381,6 @@ unsigned daliGetNumOutput(daliPipelineHandle* pipe_handle) {
   return ws->NumOutput();
 }
 
-void daliOutputPtr(daliPipelineHandle* pipe_handle, int n, const void **out_ptr, size_t *out_len) {
-  dali::TimeRange tr("daliOutputPtr", dali::TimeRange::kGreen);
-  dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
-  if (ws->OutputIsType<dali::CPUBackend>(n)) {
-    auto &out = ws->Output<dali::CPUBackend>(n);
-    *out_ptr = out.raw_data();
-    *out_len = out.nbytes();
-  } else {
-    auto &out = ws->Output<dali::GPUBackend>(n);
-    *out_ptr = out.raw_data();
-    *out_len = out.nbytes();
-  }
-}
-
 template <typename T>
 static void daliCopyTensorListNToHelper(dali::DeviceWorkspace* ws, void* dst, int n,
                                         device_type_t dst_type, cudaStream_t stream,

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -472,4 +472,47 @@ TYPED_TEST(CApiTest, TestExecutorMeta) {
   daliFreeExecutorMetadata(meta, N);
 }
 
+TYPED_TEST(CApiTest, ExternalSourcePinnedMemoryUseCopyKernel) {
+  TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
+                                   {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
+                                   {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
+  TensorList<CPUBackend> input_cpu;
+  TensorList<TypeParam> input;
+  input_cpu.Resize(input_shape, TypeInfo::Create<uint8_t>());
+  auto pipe_ptr = GetTestPipeline<TypeParam>(false, this->output_device_);
+  auto serialized = pipe_ptr->SerializeToProtobuf();
+
+  pipe_ptr->Build();
+
+  daliPipelineHandle handle;
+  daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
+                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     prefetch_queue_depth, false);
+
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    SequentialFill(view<uint8_t>(input_cpu), 42 * i);
+    // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
+    input.Copy(input_cpu, cuda_stream);
+    pipe_ptr->SetExternalInput(input_name, input);
+
+    unsigned int flags = DALI_ext_default | DALI_ext_force_sync | DALI_use_copy_kernel;
+    if (std::is_same<TypeParam, CPUBackend>::value)
+      flags |= DALI_ext_pinned;
+    daliSetExternalInputAsync(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
+                              input.raw_data(), dali_data_type_t::DALI_UINT8, input_shape.data(),
+                              input_shape.sample_dim(), nullptr, cuda_stream, flags);
+  }
+
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    pipe_ptr->RunCPU();
+    pipe_ptr->RunGPU();
+  }
+  daliPrefetchUniform(&handle, prefetch_queue_depth);
+
+  dali::DeviceWorkspace ws;
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    ComparePipelinesOutputs<TypeParam>(handle, *pipe_ptr);
+  }
+}
+
 }  // namespace dali

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -71,31 +71,26 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
    * changing the underlying data type if needed.
    */
   template <typename SrcBackend>
-  DLL_PUBLIC inline void Copy(const TensorList<SrcBackend> &other, cudaStream_t stream) {
+  DLL_PUBLIC inline void Copy(const TensorList<SrcBackend> &other, cudaStream_t stream,
+                              bool use_copy_kernel = false) {
     if (IsValidType(other.type())) {
       this->set_type(other.type());
     }
     this->meta_ = other.meta_;
     this->SetLayout(other.GetLayout());
     ResizeLike(other);
-    type_.template Copy<Backend, SrcBackend>(this->raw_mutable_data(),
-      other.raw_data(), this->size(), stream);
-  }
 
-  template <typename SrcBackend>
-  DLL_PUBLIC inline void CopyWithKernel(const TensorList<SrcBackend> &other, cudaStream_t stream) {
-    if (IsValidType(other.type())) {
-      this->set_type(other.type());
+    if (use_copy_kernel && (std::is_same<SrcBackend, GPUBackend>::value || other.is_pinned())) {
+      LaunchCopyKernel(this->raw_mutable_data(), other.raw_data(), this->size() * type_.size(), stream);
+    } else {
+      type_.template Copy<Backend, SrcBackend>(this->raw_mutable_data(),
+        other.raw_data(), this->size(), stream);
     }
-    this->meta_ = other.meta_;
-    this->SetLayout(other.GetLayout());
-    ResizeLike(other);
-    LaunchCopyKernel(this->raw_mutable_data(), other.raw_data(), this->size() * type_.size(), stream);
   }
 
   template <typename SrcBackend>
-  DLL_PUBLIC inline void Copy(const TensorVector<SrcBackend> &other,
-                              cudaStream_t stream) {
+  DLL_PUBLIC inline void Copy(const TensorVector<SrcBackend> &other, cudaStream_t stream,
+                              bool use_copy_kernel = false) {
     auto type = other[0].type();
     auto layout = other[0].GetLayout();
 
@@ -117,54 +112,29 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     }
     this->SetLayout(layout);
 
-    for (size_t i = 0; i < other.size(); ++i) {
-      type.template Copy<SrcBackend, Backend>(
-          raw_mutable_tensor(i),
-          other[i].raw_data(),
-          other[i].size(), stream);
-      this->meta_[i].SetSourceInfo(other[i].GetSourceInfo());
-      this->meta_[i].SetSkipSample(other[i].ShouldSkipSample());
+    if (use_copy_kernel && (std::is_same<SrcBackend, GPUBackend>::value || other.is_pinned())) {
+      if (!scatter_gather_) {
+        constexpr int kBlockSize = 1 << 19;  // 512kB per block
+        scatter_gather_.reset(new kernels::ScatterGatherGPU(kBlockSize, other.size()));
+      }
+      auto type_sz = type.size();
+      for (size_t i = 0; i < other.size(); ++i) {
+        scatter_gather_->AddCopy(raw_mutable_tensor(i), other[i].raw_data(),
+                                 other[i].size() * type.size());
+        this->meta_[i].SetSourceInfo(other[i].GetSourceInfo());
+        this->meta_[i].SetSkipSample(other[i].ShouldSkipSample());
+      }
+      scatter_gather_->Run(stream);
+    } else {
+      for (size_t i = 0; i < other.size(); ++i) {
+        type.template Copy<SrcBackend, Backend>(
+            raw_mutable_tensor(i),
+            other[i].raw_data(),
+            other[i].size(), stream);
+        this->meta_[i].SetSourceInfo(other[i].GetSourceInfo());
+        this->meta_[i].SetSkipSample(other[i].ShouldSkipSample());
+      }
     }
-  }
-
- private:
-  std::unique_ptr<kernels::ScatterGatherGPU> scatter_gather_;
- public:
-  template <typename SrcBackend>
-  DLL_PUBLIC inline void CopyWithKernel(const TensorVector<SrcBackend> &other,
-                                        cudaStream_t stream) {
-    auto type = other[0].type();
-    auto layout = other[0].GetLayout();
-
-    int dim = other[0].shape().sample_dim();
-    TensorListShape<> new_shape(other.size(), dim);
-    for (size_t i = 0; i < other.size(); ++i) {
-      DALI_ENFORCE(other[i].shape().sample_dim() == dim,
-         "TensorList can only have uniform dimensions across all samples, mismatch at index "
-         + std::to_string(i) + " expected Tensor with dim = " + to_string(dim)
-         + " found Tensor with dim = " + to_string(other[i].shape().sample_dim()));
-      assert(type == other[i].type());
-      assert(layout == other[i].GetLayout());
-      new_shape.set_tensor_shape(i, other[i].shape());
-    }
-
-    this->Resize(new_shape);
-    if (IsValidType(type)) {
-      this->set_type(type);
-    }
-    this->SetLayout(layout);
-
-    if (!scatter_gather_) {
-      constexpr int kBlockSize = 1 << 19;  // 512kB per block
-      scatter_gather_.reset(new kernels::ScatterGatherGPU(kBlockSize, other.size()));
-    }
-    auto type_sz = type.size();
-    for (size_t i = 0; i < other.size(); ++i) {
-      scatter_gather_->AddCopy(raw_mutable_tensor(i), other[i].raw_data(), other[i].size() * type.size());
-      this->meta_[i].SetSourceInfo(other[i].GetSourceInfo());
-      this->meta_[i].SetSkipSample(other[i].ShouldSkipSample());
-    }
-    scatter_gather_->Run(stream);
   }
 
   using Buffer<Backend>::reserve;
@@ -602,6 +572,8 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
   // Tensor that shares the data with this TensorList (valid only
   // if IsDenseTensor returns true)
   std::list<Tensor<Backend> > tensor_views_;
+
+  std::unique_ptr<kernels::ScatterGatherGPU> scatter_gather_;
 
   USE_BUFFER_MEMBERS();
 };

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -128,7 +128,7 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
   }
 
  private:
-  kernels::ScatterGatherGPU scatter_gather_;
+  std::unique_ptr<kernels::ScatterGatherGPU> scatter_gather_;
  public:
   template <typename SrcBackend>
   DLL_PUBLIC inline void CopyWithKernel(const TensorVector<SrcBackend> &other,
@@ -154,14 +154,17 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     }
     this->SetLayout(layout);
 
-    scatter_gather_.Reset();
+    if (!scatter_gather_) {
+      constexpr int kBlockSize = 1 << 19;  // 512kB per block
+      scatter_gather_.reset(new kernels::ScatterGatherGPU(kBlockSize, other.size()));
+    }
     auto type_sz = type.size();
     for (size_t i = 0; i < other.size(); ++i) {
-      scatter_gather_.AddCopy(raw_mutable_tensor(i), other[i].raw_data(), other[i].size() * type.size());
+      scatter_gather_->AddCopy(raw_mutable_tensor(i), other[i].raw_data(), other[i].size() * type.size());
       this->meta_[i].SetSourceInfo(other[i].GetSourceInfo());
       this->meta_[i].SetSkipSample(other[i].ShouldSkipSample());
     }
-    scatter_gather_.Run(stream);
+    scatter_gather_->Run(stream);
   }
 
   using Buffer<Backend>::reserve;

--- a/dali/pipeline/data/tensor_list_gpu.cu
+++ b/dali/pipeline/data/tensor_list_gpu.cu
@@ -26,7 +26,7 @@ void LaunchCopyKernel(void *dst, const void *src, int64_t nbytes, cudaStream_t s
   size_t block = cuda_min(nbytes, 1024l);
   size_t grid = std::min(32l, div_ceil(nbytes, block));
   CopyKernel<<<grid, block, 0, stream>>>(reinterpret_cast<uint8_t*>(dst), reinterpret_cast<const uint8_t*>(src), nbytes);
-  cudaGetLastError();
+  CUDA_CALL(cudaGetLastError());
 }
 
 }  // namespace dali

--- a/dali/pipeline/data/tensor_list_gpu.cu
+++ b/dali/pipeline/data/tensor_list_gpu.cu
@@ -1,0 +1,32 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/data/tensor_list.h"
+
+namespace dali {
+
+__global__ void CopyKernel(uint8_t *dst, const uint8_t *src, int64_t n) {
+  for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+    dst[i] = src[i];
+  }
+}
+
+void LaunchCopyKernel(void *dst, const void *src, int64_t n, cudaStream_t stream) {
+  size_t block = cuda_min(n, 1024l);
+  size_t grid = std::min(32l, div_ceil(n, block));
+  CopyKernel<<<grid, block, 0, stream>>>(reinterpret_cast<uint8_t*>(dst), reinterpret_cast<const uint8_t*>(src), n);
+  cudaGetLastError();
+}
+
+}  // namespace dali

--- a/dali/pipeline/data/tensor_list_gpu.cu
+++ b/dali/pipeline/data/tensor_list_gpu.cu
@@ -22,10 +22,10 @@ __global__ void CopyKernel(uint8_t *dst, const uint8_t *src, int64_t n) {
   }
 }
 
-void LaunchCopyKernel(void *dst, const void *src, int64_t n, cudaStream_t stream) {
-  size_t block = cuda_min(n, 1024l);
-  size_t grid = std::min(32l, div_ceil(n, block));
-  CopyKernel<<<grid, block, 0, stream>>>(reinterpret_cast<uint8_t*>(dst), reinterpret_cast<const uint8_t*>(src), n);
+void LaunchCopyKernel(void *dst, const void *src, int64_t nbytes, cudaStream_t stream) {
+  size_t block = cuda_min(nbytes, 1024l);
+  size_t grid = std::min(32l, div_ceil(nbytes, block));
+  CopyKernel<<<grid, block, 0, stream>>>(reinterpret_cast<uint8_t*>(dst), reinterpret_cast<const uint8_t*>(src), nbytes);
   cudaGetLastError();
 }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -137,13 +137,13 @@ class DLL_PUBLIC Pipeline {
 
   template<typename T, typename OperatorBackend>
   void SetDataSourceHelper(const string &name, const T &tl, OperatorBase *op_ptr,
-                           cudaStream_t stream = 0, bool sync = false) {
+                           cudaStream_t stream = 0, bool sync = false, bool use_copy_kernel = false) {
     // Note: we have 2 different Backends here - OperatorBackend and T's Backend (StorageBackend).
     // The StorageBackend is hidden under `T` type.
     auto *source = dynamic_cast<ExternalSource<OperatorBackend> *>(op_ptr);
     DALI_ENFORCE(source != nullptr,
                  "Input name '" + name + "' is not marked as an external input.");
-    source->SetDataSource(tl, stream, sync);
+    source->SetDataSource(tl, stream, sync, use_copy_kernel);
   }
 
 
@@ -159,7 +159,7 @@ class DLL_PUBLIC Pipeline {
    */
   template<typename TL>
   inline void SetExternalInputHelper(const string &name, const TL &tl, cudaStream_t stream = 0,
-                                     bool sync = false) {
+                                     bool sync = false, bool use_copy_kernel = false) {
     bool is_cpu_node = true;
     OpNodeId node_id;
 
@@ -180,9 +180,9 @@ class DLL_PUBLIC Pipeline {
     OperatorBase *op_ptr = &node.InstantiateOperator();
 
     if (is_cpu_node) {
-      SetDataSourceHelper<TL, CPUBackend>(name, tl, op_ptr, stream, sync);
+      SetDataSourceHelper<TL, CPUBackend>(name, tl, op_ptr, stream, sync, use_copy_kernel);
     } else {
-      SetDataSourceHelper<TL, GPUBackend>(name, tl, op_ptr, stream, sync);
+      SetDataSourceHelper<TL, GPUBackend>(name, tl, op_ptr, stream, sync, use_copy_kernel);
     }
   }
 
@@ -199,8 +199,8 @@ class DLL_PUBLIC Pipeline {
   template<typename Backend>
   DLL_PUBLIC inline void
   SetExternalInput(const string &name, const TensorList<Backend> &tl, cudaStream_t stream = 0,
-                   bool sync = false) {
-    SetExternalInputHelper(name, tl, stream, sync);
+                   bool sync = false, bool use_copy_kernel = false) {
+    SetExternalInputHelper(name, tl, stream, sync, use_copy_kernel);
   }
 
 
@@ -216,8 +216,8 @@ class DLL_PUBLIC Pipeline {
   template<typename Backend>
   DLL_PUBLIC inline void
   SetExternalInput(const string &name, const TensorVector<Backend> &tv, cudaStream_t stream = 0,
-                   bool sync = false) {
-    SetExternalInputHelper(name, tv, stream, sync);
+                   bool sync = false, bool use_copy_kernel = false) {
+    SetExternalInputHelper(name, tv, stream, sync, use_copy_kernel);
   }
 
   /**

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1074,12 +1074,12 @@ py::dict ExecutorMetaToDict(const ExecutorMetaMap &meta) {
 
 template <typename Backend>
 void FeedPipeline(Pipeline *p, const string &name, py::list list, cudaStream_t stream,
-                  bool sync = false) {
+                  bool sync = false, bool use_copy_kernel = false) {
   TensorVector<Backend> tv(list.size());
   for (size_t i = 0; i < list.size(); ++i) {
     tv[i] = std::move(list[i].cast<Tensor<Backend>&>());
   }
-  p->SetExternalInput(name, tv, stream, sync);
+  p->SetExternalInput(name, tv, stream, sync, use_copy_kernel);
 }
 
 PYBIND11_MODULE(backend_impl, m) {

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -347,17 +347,6 @@ DLL_PUBLIC void
 daliCopyTensorNTo(daliPipelineHandle *pipe_handle, void *dst, int n, device_type_t dst_type,
                   cudaStream_t stream, int non_blocking);
 
-
-/**
- * @brief Gets direct access to the output tensor stored
- * at position `n` in the pipeline.
- * @remarks The memory is managed by DALI and will be valid until the next call
- * to daliOutputRelease (or daliOutput since it calls daliOutputRelease before waiting
- * for the next iteration)
- */
-DLL_PUBLIC void daliOutputPtr(daliPipelineHandle* pipe_handle, int n,
-                              const void **out_ptr, size_t *out_len);
-
 /**
  * @brief Delete the pipeline object.
  */

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -135,7 +135,13 @@ enum {
   /**
    * If provided CPU memory is page-locked
    */
-  DALI_ext_pinned = (1<<1)
+  DALI_ext_pinned = (1<<1),
+
+  /**
+   * If provided, a CUDA copy kernel will be used to feed external source instead of cudaMemcpyAsync
+   * Only relevant when the input is either pinned host memory or device memory
+   */
+  DALI_use_copy_kernel = (1<<2),
 };
 
 /**
@@ -331,7 +337,7 @@ DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle);
  * @brief Copy the output tensor stored
  * at position `n` in the pipeline.
  * dst_type (0 - CPU, 1 - GPU)
- * @remarks If the output is tensor list then it need to be dense
+ * @remarks If the output is tensor list then it needs to be dense
  *
  * If you call this function with non_blocking != 0, make sure to
  * synchronize on provided stream before reading the data.
@@ -340,6 +346,13 @@ DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle);
 DLL_PUBLIC void
 daliCopyTensorNTo(daliPipelineHandle *pipe_handle, void *dst, int n, device_type_t dst_type,
                   cudaStream_t stream, int non_blocking);
+
+
+/**
+ * @brief Gets direct access to the dali buffer containing an output of the pipeline
+ */
+DLL_PUBLIC void daliOutputPtr(daliPipelineHandle* pipe_handle, int n,
+                              const void **out_ptr, size_t *out_len);
 
 /**
  * @brief Delete the pipeline object.

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -349,7 +349,11 @@ daliCopyTensorNTo(daliPipelineHandle *pipe_handle, void *dst, int n, device_type
 
 
 /**
- * @brief Gets direct access to the dali buffer containing an output of the pipeline
+ * @brief Gets direct access to the output tensor stored
+ * at position `n` in the pipeline.
+ * @remarks The memory is managed by DALI and will be valid until the next call
+ * to daliOutputRelease (or daliOutput since it calls daliOutputRelease before waiting
+ * for the next iteration)
  */
 DLL_PUBLIC void daliOutputPtr(daliPipelineHandle* pipe_handle, int n,
                               const void **out_ptr, size_t *out_len);


### PR DESCRIPTION
#### Why we need this PR?
- It adds an option to use a copy kernel (or scatter-gather kernel) to feed external sources instead of cudaMemcpyAsync. In some cases, it might be beneficial, since it will allow other cudaMemcpyAsync to happen at the same time.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a flag to daliSetExternalInputTensorsAsync and daliSetExternalInputAsync that will replace cudaMemcpyAsync calls by a scatter-gather kernel or a copy kernel respectively.
 - Affected modules and functionalities:
     *C-API / external source*
 - Key points relevant for the review:
     *Changes in external source*
 - Validation and testing:
     *Test case added*
 - Documentation (including examples):
     *Doxygen*


**JIRA TASK**: *[DALI-1497]*
