### PR TITLE
Fix lack of a proper include to set CUDART_VERSION inside nvml.h and nvml_wrap.h

### DIFF
--- a/dali/util/nvml.h
+++ b/dali/util/nvml.h
@@ -16,6 +16,8 @@
 #define DALI_UTIL_NVML_H_
 
 #include <nvml.h>
+#include <cuda_runtime_api.h>
+
 #include <pthread.h>
 #include <sys/sysinfo.h>
 

--- a/dali/util/nvml_wrap.h
+++ b/dali/util/nvml_wrap.h
@@ -21,6 +21,7 @@
 #ifndef DALI_UTIL_NVML_WRAP_H_
 #define DALI_UTIL_NVML_WRAP_H_
 #include <nvml.h>
+#include <cuda_runtime_api.h>
 
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"


### PR DESCRIPTION
- nvml.h and nvml_wrap.h uses CUDART_VERSION to determine the CUDA version DALI is compiled for, but when cuda_runtime_api.h is not included there directly CUDART_VERSION maybe not set properly in some compilation units

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a lack of a proper include to set CUDART_VERSION inside nvml.h and nvml_wrap.h

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     add cuda_runtime_api.h include to nvml.h and nvml_wrap.h
 - Affected modules and functionalities:
     nvml.h and nvml_wrap.h
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA

**JIRA TASK**: *[NA]*
