### PR TITLE
Reduce Paddle RN50 test gpu mem fraction to 80%

### DIFF
--- a/qa/TL3_RN50_convergence/test_paddle.sh
+++ b/qa/TL3_RN50_convergence/test_paddle.sh
@@ -26,7 +26,7 @@ LOG=dali.log
 
 SECONDS=0
 EPOCHS=25  # limiting to 25 epochs to save time
-export FLAGS_fraction_of_gpu_memory_to_use=.85
+export FLAGS_fraction_of_gpu_memory_to_use=.80
 python -m paddle.distributed.launch --selected_gpus $(echo $GPUS | tr ' ' ',') \
     main.py -b 128 -j 4 --lr=0.4 --epochs ${EPOCHS} ./ 2>&1 | tee $LOG
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Reduce size of test that gets OOM for some CI configurations


#### What happened in this PR?

**JIRA TASK**: *[Use DALI-1508 or NA]*
