### PR TITLE
Reenable VP9 video tests after driver update

### DIFF
--- a/qa/TL0_self-test/test.sh
+++ b/qa/TL0_self-test/test.sh
@@ -40,7 +40,7 @@ test_body() {
         exit 1
     fi
 
-    "$FULLPATH" --gtest_filter="*:-*Vp9*"
+    "$FULLPATH"
   done
 }
 


### PR DESCRIPTION
- CI GPU driver was updated to the version that no longer has a problem with VP9 video codec, so reenable that test in CI

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It renables VP9 video tests after driver update

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     renables VP9 video tests after driver update
 - Affected modules and functionalities:
     TL0 gtest video test
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA

**JIRA TASK**: *[NA]*
