### PR TITLE
Fix layout propagation in Gaussian Blur

### DIFF
--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -214,6 +214,7 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
   void RunImpl(workspace_t<CPUBackend>& ws) override {
     const auto& input = ws.template InputRef<CPUBackend>(0);
     auto& output = ws.template OutputRef<CPUBackend>(0);
+    output.SetLayout(input.GetLayout());
     auto in_shape = input.shape();
     auto& thread_pool = ws.GetThreadPool();
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- It fixes a bug where input layout was not propagated to outputs

#### What happened in this PR?
 - What solution was applied:
     SetLayout added
 - Affected modules and functionalities:
     Gaussian Blur
 - Key points relevant for the review:
     Nothing special
 - Validation and testing:
     Added a test that based on #2116 that was not working previously (output of GaussianBlur is consumed by operator checking the layout).
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1507]*
