### PR TITLE
Remove usage of __future__ from DALI

### DIFF
--- a/dali/python/__init__.py.in
+++ b/dali/python/__init__.py.in
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 # we need to have that defined and accessible before any other DALI import
 __version__ = '@DALI_VERSION@'
 __cuda_version__ = int('@CUDA_VERSION@'.replace('.', ''))

--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 #pylint: disable=no-member
-from __future__ import division
 import sys
 from nvidia.dali.data_node import DataNode as _DataNode
 

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from nvidia.dali.backend import TensorGPU, TensorListGPU
 from nvidia.dali import types
 from nvidia.dali.plugin.base_iterator import _DaliBaseIterator

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -13,10 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import ctypes
 import math
 

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from nvidia.dali.backend import TensorGPU, TensorListGPU
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops

--- a/dali/python/setup.py.in
+++ b/dali/python/setup.py.in
@@ -40,8 +40,5 @@ setup(name='nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@',
               'rec2idx = rec2idx:main',
               ],
           },
-      install_requires = [
-          'future',
-          ],
      )
 

--- a/dali/test/python/test_RN50_data_fw_iterators.py
+++ b/dali/test/python/test_RN50_data_fw_iterators.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types

--- a/dali/test/python/test_RN50_data_pipeline.py
+++ b/dali/test/python/test_RN50_data_pipeline.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types

--- a/dali/test/python/test_coco_tfrecord.py
+++ b/dali/test/python/test_coco_tfrecord.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from __future__ import division
-
 import argparse
 import os
 from math import ceil, sqrt

--- a/dali/test/python/test_data_containers.py
+++ b/dali/test/python/test_data_containers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types

--- a/dali/test/python/test_detection_pipeline.py
+++ b/dali/test/python/test_detection_pipeline.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from __future__ import division
-
 import argparse
 import itertools
 import os

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from __future__ import division
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types

--- a/dali/test/python/test_operator_audio_decoder.py
+++ b/dali/test/python/test_operator_audio_decoder.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import division
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types

--- a/dali/test/python/test_operator_decoder.py
+++ b/dali/test/python/test_operator_decoder.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types

--- a/dali/test/python/test_operator_index_reader.py
+++ b/dali/test/python/test_operator_index_reader.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division
 import math
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops

--- a/dali/test/python/test_operator_normal_distribution.py
+++ b/dali/test/python/test_operator_normal_distribution.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types

--- a/dali/test/python/test_operator_normalize.py
+++ b/dali/test/python/test_operator_normalize.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import division
 from nvidia.dali.pipeline import Pipeline
 from nvidia.dali import backend
 import nvidia.dali.ops as ops

--- a/dali/test/python/test_operator_power_spectrum.py
+++ b/dali/test/python/test_operator_power_spectrum.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import division
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types

--- a/dali/test/python/test_operator_preemph.py
+++ b/dali/test/python/test_operator_preemph.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types

--- a/dali/test/python/test_operator_python_function.py
+++ b/dali/test/python/test_operator_python_function.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from nvidia.dali.pipeline import Pipeline
 from nvidia.dali.ops import _DataNode
 import nvidia.dali.ops as ops

--- a/dali/test/python/test_operator_reader_shuffling.py
+++ b/dali/test/python/test_operator_reader_shuffling.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division
 import math
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops

--- a/dali/test/python/test_optical_flow.py
+++ b/dali/test/python/test_optical_flow.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from __future__ import division
 import os
 import numpy as np
 import shutil

--- a/dali/test/python/test_pytorch_operator.py
+++ b/dali/test/python/test_pytorch_operator.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types

--- a/dali/test/python/test_video_pipeline.py
+++ b/dali/test/python/test_video_pipeline.py
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
-
 import os
 import math
 from test_utils import get_gpu_num

--- a/docs/examples/custom_operations/custom_operator/create_a_custom_operator.ipynb
+++ b/docs/examples/custom_operations/custom_operator/create_a_custom_operator.ipynb
@@ -196,7 +196,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "import nvidia.dali.sysconfig as sysconfig"
    ]
   },

--- a/docs/examples/frameworks/mxnet/gluon.ipynb
+++ b/docs/examples/frameworks/mxnet/gluon.ipynb
@@ -19,7 +19,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "import os.path\n",
     "import matplotlib as mpl\n",
     "import tarfile\n",

--- a/docs/examples/frameworks/mxnet/mxnet-external_input.ipynb
+++ b/docs/examples/frameworks/mxnet/mxnet-external_input.ipynb
@@ -19,7 +19,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "import types\n",
     "import collections\n",
     "import numpy as np\n",

--- a/docs/examples/frameworks/mxnet/mxnet-various-readers.ipynb
+++ b/docs/examples/frameworks/mxnet/mxnet-various-readers.ipynb
@@ -258,7 +258,6 @@
     }
    ],
    "source": [
-    "from __future__ import print_function\n",
     "import numpy as np\n",
     "from nvidia.dali.plugin.mxnet import DALIGenericIterator\n",
     "\n",

--- a/docs/examples/frameworks/paddle/paddle-basic_example.ipynb
+++ b/docs/examples/frameworks/paddle/paddle-basic_example.ipynb
@@ -107,7 +107,6 @@
     }
    ],
    "source": [
-    "from __future__ import print_function\n",
     "import numpy as np\n",
     "from nvidia.dali.plugin.paddle import DALIGenericIterator\n",
     "\n",

--- a/docs/examples/frameworks/paddle/paddle-external_input.ipynb
+++ b/docs/examples/frameworks/paddle/paddle-external_input.ipynb
@@ -19,7 +19,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "import types\n",
     "import collections\n",
     "import numpy as np\n",

--- a/docs/examples/frameworks/paddle/paddle-various-readers.ipynb
+++ b/docs/examples/frameworks/paddle/paddle-various-readers.ipynb
@@ -258,7 +258,6 @@
     }
    ],
    "source": [
-    "from __future__ import print_function\n",
     "import numpy as np\n",
     "from nvidia.dali.plugin.paddle import DALIGenericIterator\n",
     "\n",

--- a/docs/examples/frameworks/pytorch/pytorch-basic_example.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-basic_example.ipynb
@@ -107,7 +107,6 @@
     }
    ],
    "source": [
-    "from __future__ import print_function\n",
     "import numpy as np\n",
     "from nvidia.dali.plugin.pytorch import DALIGenericIterator\n",
     "\n",

--- a/docs/examples/frameworks/pytorch/pytorch-external_input.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-external_input.ipynb
@@ -19,7 +19,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "import types\n",
     "import collections\n",
     "import numpy as np\n",

--- a/docs/examples/frameworks/pytorch/pytorch-various-readers.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-various-readers.ipynb
@@ -258,7 +258,6 @@
     }
    ],
    "source": [
-    "from __future__ import print_function\n",
     "import numpy as np\n",
     "from nvidia.dali.plugin.pytorch import DALIGenericIterator\n",
     "\n",

--- a/docs/examples/frameworks/tensorflow/tensorflow-plugin-sparse-tensor.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-plugin-sparse-tensor.ipynb
@@ -32,7 +32,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",
@@ -418,7 +417,6 @@
     }
    ],
    "source": [
-    "from __future__ import division\n",
     "import matplotlib.gridspec as gridspec\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",

--- a/docs/examples/frameworks/tensorflow/tensorflow-plugin-tutorial.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-plugin-tutorial.ipynb
@@ -246,8 +246,6 @@
     }
    ],
    "source": [
-    "from __future__ import print_function\n",
-    "\n",
     "gpu_options = GPUOptions(per_process_gpu_memory_fraction=0.8)\n",
     "config = ConfigProto(gpu_options=gpu_options)\n",
     "\n",
@@ -300,7 +298,6 @@
     }
    ],
    "source": [
-    "from __future__ import division\n",
     "import matplotlib.gridspec as gridspec\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",

--- a/docs/examples/frameworks/tensorflow/tensorflow-various-readers.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-various-readers.ipynb
@@ -310,7 +310,6 @@
     }
    ],
    "source": [
-    "from __future__ import print_function\n",
     "import numpy as np\n",
     "\n",
     "pipe_types = [[MXNetReaderPipeline, tf.float32, (0, 999)], \n",

--- a/docs/examples/general/data_loading/coco_reader.ipynb
+++ b/docs/examples/general/data_loading/coco_reader.ipynb
@@ -17,7 +17,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",

--- a/docs/examples/general/data_loading/dataloading_lmdb.ipynb
+++ b/docs/examples/general/data_loading/dataloading_lmdb.ipynb
@@ -104,7 +104,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "import matplotlib.gridspec as gridspec\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",
@@ -244,7 +243,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "import matplotlib.gridspec as gridspec\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",

--- a/docs/examples/general/data_loading/dataloading_recordio.ipynb
+++ b/docs/examples/general/data_loading/dataloading_recordio.ipynb
@@ -134,7 +134,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "import matplotlib.gridspec as gridspec\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",

--- a/docs/examples/general/data_loading/dataloading_tfrecord.ipynb
+++ b/docs/examples/general/data_loading/dataloading_tfrecord.ipynb
@@ -144,7 +144,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "import matplotlib.gridspec as gridspec\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",

--- a/docs/examples/general/data_loading/external_input.ipynb
+++ b/docs/examples/general/data_loading/external_input.ipynb
@@ -182,7 +182,6 @@
     }
    ],
    "source": [
-    "from __future__ import print_function\n",
     "import matplotlib.pyplot as plt\n",
     "img = batch_cpu.at(2)\n",
     "print(img.shape)\n",

--- a/docs/examples/general/expressions/expr_blend_image.ipynb
+++ b/docs/examples/general/expressions/expr_blend_image.ipynb
@@ -33,7 +33,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",

--- a/docs/examples/general/expressions/expr_conditional_and_masking.ipynb
+++ b/docs/examples/general/expressions/expr_conditional_and_masking.ipynb
@@ -30,7 +30,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",

--- a/docs/examples/general/expressions/expr_examples.ipynb
+++ b/docs/examples/general/expressions/expr_examples.ipynb
@@ -23,7 +23,6 @@
     "\n",
     "First, we will prepare the helper code, so we can easily manipulate the types and values that will appear as tensors in the DALI pipeline.\n",
     "\n",
-    "We use `from __future__ import division` to allow `/` and `//` as true division and floor division operators.\n",
     "We will be using numpy as source for the custom provided data and we also need to import several things from DALI needed to create Pipeline and use ExternalSource Operator. "
    ]
   },
@@ -33,7 +32,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "import numpy as np\n",
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops            \n",

--- a/docs/examples/general/expressions/expr_type_promotions.ipynb
+++ b/docs/examples/general/expressions/expr_type_promotions.ipynb
@@ -17,7 +17,6 @@
     "\n",
     "First, we will prepare the helper code, so we can easily manipulate the types and values that will appear as tensors in the DALI pipeline.\n",
     "\n",
-    "We use `from __future__ import division` to allow `/` and `//` as true division and floor division operators.\n",
     "We will be using numpy as source for the custom provided data and we also need to import several things from DALI, needed to create Pipeline and use ExternalSource Operator. "
    ]
   },
@@ -27,7 +26,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "import numpy as np\n",
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops            \n",

--- a/docs/examples/general/multigpu.ipynb
+++ b/docs/examples/general/multigpu.ipynb
@@ -83,7 +83,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "import matplotlib.gridspec as gridspec\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline\n",

--- a/docs/examples/image_processing/augmentation_gallery.ipynb
+++ b/docs/examples/image_processing/augmentation_gallery.ipynb
@@ -17,7 +17,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",

--- a/docs/examples/image_processing/color_space_conversion.ipynb
+++ b/docs/examples/image_processing/color_space_conversion.ipynb
@@ -22,7 +22,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",
     "from nvidia.dali.pipeline import Pipeline\n",

--- a/docs/examples/image_processing/warp.ipynb
+++ b/docs/examples/image_processing/warp.ipynb
@@ -57,7 +57,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",

--- a/docs/examples/image_processing/warp_3D.ipynb
+++ b/docs/examples/image_processing/warp_3D.ipynb
@@ -87,7 +87,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import division\n",
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",

--- a/docs/examples/sequence_processing/optical_flow_example.ipynb
+++ b/docs/examples/sequence_processing/optical_flow_example.ipynb
@@ -21,8 +21,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
-    "from __future__ import division\n",
     "import os.path\n",
     "import numpy as np\n",
     "\n",

--- a/docs/examples/sequence_processing/video/video_reader_label_example.ipynb
+++ b/docs/examples/sequence_processing/video/video_reader_label_example.ipynb
@@ -35,8 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
-    "from __future__ import division\n",
     "import os\n",
     "import numpy as np\n",
     "\n",

--- a/docs/examples/sequence_processing/video/video_reader_simple_example.ipynb
+++ b/docs/examples/sequence_processing/video/video_reader_simple_example.ipynb
@@ -35,8 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
-    "from __future__ import division\n",
     "import os\n",
     "import numpy as np\n",
     "\n",

--- a/docs/examples/use_cases/detection_pipeline.ipynb
+++ b/docs/examples/use_cases/detection_pipeline.ipynb
@@ -15,7 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",

--- a/docs/examples/use_cases/mxnet/mxnet-resnet50.ipynb
+++ b/docs/examples/use_cases/mxnet/mxnet-resnet50.ipynb
@@ -21,7 +21,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",

--- a/docs/examples/use_cases/paddle/resnet50/main.py
+++ b/docs/examples/use_cases/paddle/resnet50/main.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from __future__ import division
-
 import argparse
 import math
 import os

--- a/docs/examples/use_cases/paddle/ssd/ssd.py
+++ b/docs/examples/use_cases/paddle/ssd/ssd.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 from paddle import fluid
 from paddle.fluid.param_attr import ParamAttr
 

--- a/docs/examples/use_cases/paddle/ssd/train.py
+++ b/docs/examples/use_cases/paddle/ssd/train.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from __future__ import division
-
 import argparse
 import os
 import shutil

--- a/docs/examples/use_cases/paddle/ssd/utils.py
+++ b/docs/examples/use_cases/paddle/ssd/utils.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import errno
 import os
 import shutil

--- a/docs/examples/use_cases/paddle/tsm/infer.py
+++ b/docs/examples/use_cases/paddle/tsm/infer.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from __future__ import division
-
 import argparse
 import json
 import os

--- a/docs/examples/use_cases/paddle/tsm/tsm.py
+++ b/docs/examples/use_cases/paddle/tsm/tsm.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import division
-
 import math
 import paddle.fluid as fluid
 

--- a/docs/examples/use_cases/paddle/tsm/utils.py
+++ b/docs/examples/use_cases/paddle/tsm/utils.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import errno
 import os
 import shutil

--- a/docs/examples/use_cases/tensorflow/resnet-n/nvutils/optimizers.py
+++ b/docs/examples/use_cases/tensorflow/resnet-n/nvutils/optimizers.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import print_function
 from builtins import range
 import tensorflow as tf
 

--- a/docs/examples/use_cases/tensorflow/resnet-n/nvutils/runner.py
+++ b/docs/examples/use_cases/tensorflow/resnet-n/nvutils/runner.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import print_function
 from builtins import range
 import nvutils
 import tensorflow as tf

--- a/docs/examples/use_cases/tensorflow/resnet-n/resnet.py
+++ b/docs/examples/use_cases/tensorflow/resnet-n/resnet.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from __future__ import print_function
 from builtins import range
 import nvutils
 import tensorflow as tf

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function, division
 import argparse
 import sys
 # use packaging from PIP as it is always present on system we are testing on

--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -8,7 +8,7 @@ then
     # early exit
     return 0
 fi
-PYTHON_VERSION=$(python -c "from __future__ import print_function; import sys; print(\"{}.{}\".format(sys.version_info[0],sys.version_info[1]))")
+PYTHON_VERSION=$(python -c "import sys; print(\"{}.{}\".format(sys.version_info[0],sys.version_info[1]))")
 PYTHON_VERSION_SHORT=${PYTHON_VERSION/\./}
 
 NVIDIA_SMI_DRIVER_VERSION=$(nvidia-smi | grep -Po '(?<=Driver Version: )\d+.\d+')

--- a/tools/rec2idx.py
+++ b/tools/rec2idx.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from __future__ import print_function
 import os
 import time
 import ctypes

--- a/tools/test_bundled_libs.py
+++ b/tools/test_bundled_libs.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from sys import argv
 import subprocess
 


### PR DESCRIPTION
- as DALI doesn't support python 2.7 and all futures that it uses are Python >=3.5 compatible there is no need to use `from __future__`

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes usage of __future__ from DALI

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     as DALI doesn't support python 2.7 and all futures that it uses are Python >=3.5 compatible there is no need to use `from __future__`
 - Affected modules and functionalities:
     all python files
     whl requirements
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     Examples are updates as well


**JIRA TASK**: *[NA]*
