### PR TITLE
Add an option to use a copy kernel to feed external input

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -381,20 +381,6 @@ unsigned daliGetNumOutput(daliPipelineHandle* pipe_handle) {
   return ws->NumOutput();
 }
 
-void daliOutputPtr(daliPipelineHandle* pipe_handle, int n, const void **out_ptr, size_t *out_len) {
-  dali::TimeRange tr("daliOutputPtr", dali::TimeRange::kGreen);
-  dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
-  if (ws->OutputIsType<dali::CPUBackend>(n)) {
-    auto &out = ws->Output<dali::CPUBackend>(n);
-    *out_ptr = out.raw_data();
-    *out_len = out.nbytes();
-  } else {
-    auto &out = ws->Output<dali::GPUBackend>(n);
-    *out_ptr = out.raw_data();
-    *out_len = out.nbytes();
-  }
-}
-
 template <typename T>
 static void daliCopyTensorListNToHelper(dali::DeviceWorkspace* ws, void* dst, int n,
                                         device_type_t dst_type, cudaStream_t stream,

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -472,4 +472,47 @@ TYPED_TEST(CApiTest, TestExecutorMeta) {
   daliFreeExecutorMetadata(meta, N);
 }
 
+TYPED_TEST(CApiTest, ExternalSourcePinnedMemoryUseCopyKernel) {
+  TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
+                                   {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
+                                   {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
+  TensorList<CPUBackend> input_cpu;
+  TensorList<TypeParam> input;
+  input_cpu.Resize(input_shape, TypeInfo::Create<uint8_t>());
+  auto pipe_ptr = GetTestPipeline<TypeParam>(false, this->output_device_);
+  auto serialized = pipe_ptr->SerializeToProtobuf();
+
+  pipe_ptr->Build();
+
+  daliPipelineHandle handle;
+  daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
+                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     prefetch_queue_depth, false);
+
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    SequentialFill(view<uint8_t>(input_cpu), 42 * i);
+    // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
+    input.Copy(input_cpu, cuda_stream);
+    pipe_ptr->SetExternalInput(input_name, input);
+
+    unsigned int flags = DALI_ext_default | DALI_ext_force_sync | DALI_use_copy_kernel;
+    if (std::is_same<TypeParam, CPUBackend>::value)
+      flags |= DALI_ext_pinned;
+    daliSetExternalInputAsync(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
+                              input.raw_data(), dali_data_type_t::DALI_UINT8, input_shape.data(),
+                              input_shape.sample_dim(), nullptr, cuda_stream, flags);
+  }
+
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    pipe_ptr->RunCPU();
+    pipe_ptr->RunGPU();
+  }
+  daliPrefetchUniform(&handle, prefetch_queue_depth);
+
+  dali::DeviceWorkspace ws;
+  for (int i = 0; i < prefetch_queue_depth; i++) {
+    ComparePipelinesOutputs<TypeParam>(handle, *pipe_ptr);
+  }
+}
+
 }  // namespace dali

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -477,8 +477,12 @@ TYPED_TEST(CApiTest, ExternalSourcePinnedMemoryUseCopyKernel) {
                                    {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
   TensorList<CPUBackend> input_cpu;
-  TensorList<TypeParam> input;
   input_cpu.Resize(input_shape, TypeInfo::Create<uint8_t>());
+
+  TensorList<TypeParam> input;
+  if (std::is_same<TypeParam, CPUBackend>::value)
+    input.set_pinned(true);
+
   auto pipe_ptr = GetTestPipeline<TypeParam>(false, this->output_device_);
   auto serialized = pipe_ptr->SerializeToProtobuf();
 

--- a/dali/core/cuda_event.cc
+++ b/dali/core/cuda_event.cc
@@ -30,7 +30,7 @@ CUDAEvent CUDAEvent::CreateWithFlags(unsigned flags, int device_id) {
 }
 
 void CUDAEvent::DestroyHandle(cudaEvent_t event) {
-  CUDA_CALL(cudaEventDestroy(event));
+  CUDA_DTOR_CALL(cudaEventDestroy(event));
 }
 
 }  // namespace dali

--- a/dali/core/cuda_stream.cc
+++ b/dali/core/cuda_stream.cc
@@ -35,7 +35,7 @@ CUDAStream CUDAStream::CreateWithPriority(bool non_blocking, int priority, int d
 }
 
 void CUDAStream::DestroyHandle(cudaStream_t stream) {
-  CUDA_CALL(cudaStreamDestroy(stream));
+  CUDA_DTOR_CALL(cudaStreamDestroy(stream));
 }
 
 }  // namespace dali

--- a/dali/core/per_stream_pool_test.cu
+++ b/dali/core/per_stream_pool_test.cu
@@ -15,6 +15,7 @@
 #include "dali/core/per_stream_pool.h"  // NOLINT
 #include <gtest/gtest.h>
 #include <atomic>
+#include <algorithm>
 #include <chrono>
 #include <iostream>
 #include <thread>

--- a/dali/kernels/alloc.cc
+++ b/dali/kernels/alloc.cc
@@ -38,7 +38,7 @@ struct Allocator<AllocType::Host> {
 template <>
 struct Allocator<AllocType::Pinned> {
   static void Deallocate(void *ptr, int device) noexcept {
-    (void) device;
+    (void) device;  // TODO(janton): remove device argument
     CUDA_DTOR_CALL(cudaFreeHost(ptr));
   }
 
@@ -52,7 +52,7 @@ struct Allocator<AllocType::Pinned> {
 template <>
 struct Allocator<AllocType::GPU> {
   static void Deallocate(void *ptr, int device) noexcept {
-    (void) device;
+    (void) device;  // TODO(janton): remove device argument
     CUDA_DTOR_CALL(cudaFree(ptr));
   }
 
@@ -67,7 +67,7 @@ struct Allocator<AllocType::GPU> {
 template <>
 struct Allocator<AllocType::Unified> {
   static void Deallocate(void *ptr, int device) noexcept {
-    (void) device;
+    (void) device;  // TODO(janton): remove device argument
     CUDA_DTOR_CALL(cudaFree(ptr));
   }
 

--- a/dali/kernels/alloc.cc
+++ b/dali/kernels/alloc.cc
@@ -29,7 +29,6 @@ struct Allocator;
 template <>
 struct Allocator<AllocType::Host> {
   static void Deallocate(void *ptr, int device) noexcept {
-    (void)device;
     free(ptr);
   }
 
@@ -39,12 +38,8 @@ struct Allocator<AllocType::Host> {
 template <>
 struct Allocator<AllocType::Pinned> {
   static void Deallocate(void *ptr, int device) noexcept {
-    try {
-      DeviceGuard guard(device);
-    } catch (...) {
-      std::terminate();
-    }
-    cudaFreeHost(ptr);
+    (void) device;
+    CUDA_DTOR_CALL(cudaFreeHost(ptr));
   }
 
   static void *Allocate(size_t bytes) noexcept {
@@ -57,12 +52,8 @@ struct Allocator<AllocType::Pinned> {
 template <>
 struct Allocator<AllocType::GPU> {
   static void Deallocate(void *ptr, int device) noexcept {
-    try {
-      DeviceGuard guard(device);
-    } catch (...) {
-      std::terminate();
-    }
-    cudaFree(ptr);
+    (void) device;
+    CUDA_DTOR_CALL(cudaFree(ptr));
   }
 
   static void *Allocate(size_t bytes) noexcept {
@@ -76,12 +67,8 @@ struct Allocator<AllocType::GPU> {
 template <>
 struct Allocator<AllocType::Unified> {
   static void Deallocate(void *ptr, int device) noexcept {
-    try {
-      DeviceGuard guard(device);
-    } catch (...) {
-      std::terminate();
-    }
-    cudaFree(ptr);
+    (void) device;
+    CUDA_DTOR_CALL(cudaFree(ptr));
   }
 
   static void *Allocate(size_t bytes) noexcept {

--- a/dali/kernels/common/scatter_gather.cu
+++ b/dali/kernels/common/scatter_gather.cu
@@ -99,14 +99,15 @@ __global__ void BatchCopy(const ScatterGatherGPU::CopyRange *ranges) {
   }
 }
 
-void ScatterGatherGPU::Run(cudaStream_t stream, bool reset, bool useMemcpyOnly) {
+void ScatterGatherGPU::Run(cudaStream_t stream, bool reset, bool useMemcpyOnly,
+                           cudaMemcpyKind memcpyKind) {
   Coalesce();
 
   // TODO(michalz): Error handling
 
   if (useMemcpyOnly || ranges_.size() <= 2) {
     for (auto &r : ranges_) {
-      cudaMemcpyAsync(r.dst, r.src, r.size, cudaMemcpyDeviceToDevice, stream);
+      cudaMemcpyAsync(r.dst, r.src, r.size, memcpyKind, stream);
     }
   } else {
     MakeBlocks();

--- a/dali/kernels/common/scatter_gather.h
+++ b/dali/kernels/common/scatter_gather.h
@@ -83,8 +83,10 @@ class DLL_PUBLIC ScatterGatherGPU {
    * @param reset - if true, calls Reset after processing is over
    * @param useMemcpyOnly - if true, all copies are executed using cudaMemcpy;
    *                        otherwise a batched kernel is used if there are more than 2 ranges
+   * @param memcpyKind    - determines the cudaMemcpyKind when using cudaMemcpy
    */
-  DLL_PUBLIC void Run(cudaStream_t stream, bool reset = true, bool useMemcpyOnly = false);
+  DLL_PUBLIC void Run(cudaStream_t stream, bool reset = true, bool useMemcpyOnly = false,
+                      cudaMemcpyKind memcpyKind = cudaMemcpyDefault);
 
   using CopyRange = detail::CopyRange;
 

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -22,6 +22,7 @@
 #include <list>
 #include <memory>
 #include <utility>
+#include "dali/kernels/common/scatter_gather.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/buffer.h"
@@ -34,6 +35,8 @@ class Tensor;
 
 template <typename Backend>
 class TensorVector;
+
+DLL_PUBLIC void LaunchCopyKernel(void *dst, const void *src, int64_t n, cudaStream_t stream);
 
 /**
  * @brief Stores a number of Tensors in a contiguous buffer.
@@ -108,7 +111,18 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     this->SetLayout(other.GetLayout());
     ResizeLike(other);
     type_.template Copy<Backend, SrcBackend>(this->raw_mutable_data(),
-        other.raw_data(), this->size(), stream);
+      other.raw_data(), this->size(), stream);
+  }
+
+  template <typename SrcBackend>
+  DLL_PUBLIC inline void CopyWithKernel(const TensorList<SrcBackend> &other, cudaStream_t stream) {
+    if (IsValidType(other.type())) {
+      this->set_type(other.type());
+    }
+    this->meta_ = other.meta_;
+    this->SetLayout(other.GetLayout());
+    ResizeLike(other);
+    LaunchCopyKernel(this->raw_mutable_data(), other.raw_data(), this->size() * type_.size(), stream);
   }
 
   template <typename SrcBackend>
@@ -143,6 +157,43 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
       this->meta_[i].SetSourceInfo(other[i].GetSourceInfo());
       this->meta_[i].SetSkipSample(other[i].ShouldSkipSample());
     }
+  }
+
+ private:
+  kernels::ScatterGatherGPU scatter_gather_;
+ public:
+  template <typename SrcBackend>
+  DLL_PUBLIC inline void CopyWithKernel(const TensorVector<SrcBackend> &other,
+                                        cudaStream_t stream) {
+    auto type = other[0].type();
+    auto layout = other[0].GetLayout();
+
+    int dim = other[0].shape().sample_dim();
+    TensorListShape<> new_shape(other.size(), dim);
+    for (size_t i = 0; i < other.size(); ++i) {
+      DALI_ENFORCE(other[i].shape().sample_dim() == dim,
+         "TensorList can only have uniform dimensions across all samples, mismatch at index "
+         + std::to_string(i) + " expected Tensor with dim = " + to_string(dim)
+         + " found Tensor with dim = " + to_string(other[i].shape().sample_dim()));
+      assert(type == other[i].type());
+      assert(layout == other[i].GetLayout());
+      new_shape.set_tensor_shape(i, other[i].shape());
+    }
+
+    this->Resize(new_shape);
+    if (IsValidType(type)) {
+      this->set_type(type);
+    }
+    this->SetLayout(layout);
+
+    scatter_gather_.Reset();
+    auto type_sz = type.size();
+    for (size_t i = 0; i < other.size(); ++i) {
+      scatter_gather_.AddCopy(raw_mutable_tensor(i), other[i].raw_data(), other[i].size() * type.size());
+      this->meta_[i].SetSourceInfo(other[i].GetSourceInfo());
+      this->meta_[i].SetSkipSample(other[i].ShouldSkipSample());
+    }
+    scatter_gather_.Run(stream);
   }
 
   using Buffer<Backend>::reserve;

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -143,7 +143,7 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     std::vector<const void*> srcs(nsamples, nullptr);
     std::vector<Index> sizes(nsamples, 0);
     for (size_t i = 0; i < nsamples; i++) {
-      srcs[i] = raw_mutable_tensor(i);
+      srcs[i] = other[i].raw_data();
       sizes[i] = other[i].size();
       this->meta_[i].SetSourceInfo(other[i].GetSourceInfo());
       this->meta_[i].SetSkipSample(other[i].ShouldSkipSample());

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -109,7 +109,7 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     this->SetLayout(other.GetLayout());
     ResizeLike(other);
 
-    use_copy_kernel &= (std::is_same<SrcBackend, GPUBackend>::value || other.is_pinned()) ||
+    use_copy_kernel &= (std::is_same<SrcBackend, GPUBackend>::value || other.is_pinned()) &&
                        (std::is_same<Backend, GPUBackend>::value || pinned_);
     type_.template Copy<Backend, SrcBackend>(this->raw_mutable_data(), other.raw_data(),
                                              this->size(), stream, use_copy_kernel);
@@ -149,7 +149,7 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
       this->meta_[i].SetSkipSample(other[i].ShouldSkipSample());
     }
 
-    use_copy_kernel &= (std::is_same<SrcBackend, GPUBackend>::value || other.is_pinned()) ||
+    use_copy_kernel &= (std::is_same<SrcBackend, GPUBackend>::value || other.is_pinned()) &&
                        (std::is_same<Backend, GPUBackend>::value || pinned_);
     type.template Copy<SrcBackend, Backend>(this->raw_mutable_data(), srcs.data(), sizes.data(),
                                             nsamples, stream, use_copy_kernel);

--- a/dali/pipeline/data/tensor_list_gpu.cu
+++ b/dali/pipeline/data/tensor_list_gpu.cu
@@ -26,7 +26,7 @@ void LaunchCopyKernel(void *dst, const void *src, int64_t nbytes, cudaStream_t s
   size_t block = cuda_min(nbytes, 1024l);
   size_t grid = std::min(32l, div_ceil(nbytes, block));
   CopyKernel<<<grid, block, 0, stream>>>(reinterpret_cast<uint8_t*>(dst), reinterpret_cast<const uint8_t*>(src), nbytes);
-  cudaGetLastError();
+  CUDA_CALL(cudaGetLastError());
 }
 
 }  // namespace dali

--- a/dali/pipeline/data/tensor_list_gpu.cu
+++ b/dali/pipeline/data/tensor_list_gpu.cu
@@ -1,0 +1,32 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/data/tensor_list.h"
+
+namespace dali {
+
+__global__ void CopyKernel(uint8_t *dst, const uint8_t *src, int64_t n) {
+  for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
+    dst[i] = src[i];
+  }
+}
+
+void LaunchCopyKernel(void *dst, const void *src, int64_t n, cudaStream_t stream) {
+  size_t block = cuda_min(n, 1024l);
+  size_t grid = std::min(32l, div_ceil(n, block));
+  CopyKernel<<<grid, block, 0, stream>>>(reinterpret_cast<uint8_t*>(dst), reinterpret_cast<const uint8_t*>(src), n);
+  cudaGetLastError();
+}
+
+}  // namespace dali

--- a/dali/pipeline/data/tensor_list_gpu.cu
+++ b/dali/pipeline/data/tensor_list_gpu.cu
@@ -22,10 +22,10 @@ __global__ void CopyKernel(uint8_t *dst, const uint8_t *src, int64_t n) {
   }
 }
 
-void LaunchCopyKernel(void *dst, const void *src, int64_t n, cudaStream_t stream) {
-  size_t block = cuda_min(n, 1024l);
-  size_t grid = std::min(32l, div_ceil(n, block));
-  CopyKernel<<<grid, block, 0, stream>>>(reinterpret_cast<uint8_t*>(dst), reinterpret_cast<const uint8_t*>(src), n);
+void LaunchCopyKernel(void *dst, const void *src, int64_t nbytes, cudaStream_t stream) {
+  size_t block = cuda_min(nbytes, 1024l);
+  size_t grid = std::min(32l, div_ceil(nbytes, block));
+  CopyKernel<<<grid, block, 0, stream>>>(reinterpret_cast<uint8_t*>(dst), reinterpret_cast<const uint8_t*>(src), nbytes);
   cudaGetLastError();
 }
 

--- a/dali/pipeline/data/types.cu
+++ b/dali/pipeline/data/types.cu
@@ -24,8 +24,8 @@ __global__ void CopyKernel(uint8_t *dst, const uint8_t *src, int64_t n) {
 }
 
 void LaunchCopyKernel(void *dst, const void *src, int64_t nbytes, cudaStream_t stream) {
-  size_t block = cuda_min(nbytes, 1024l);
-  size_t grid = std::min(32l, div_ceil(nbytes, block));
+  unsigned block = std::min<int64_t>(nbytes, 1024);
+  unsigned grid = std::min<int64_t>(32, div_ceil(static_cast<unsigned>(nbytes), block));
   CopyKernel<<<grid, block, 0, stream>>>(reinterpret_cast<uint8_t*>(dst),
                                          reinterpret_cast<const uint8_t*>(src),
                                          nbytes);

--- a/dali/pipeline/data/types.cu
+++ b/dali/pipeline/data/types.cu
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/pipeline/data/tensor_list.h"
+#include "dali/pipeline/data/types.h"
 
 namespace dali {
+namespace detail {
 
 __global__ void CopyKernel(uint8_t *dst, const uint8_t *src, int64_t n) {
   for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
     dst[i] = src[i];
   }
 }
-
+  
 void LaunchCopyKernel(void *dst, const void *src, int64_t nbytes, cudaStream_t stream) {
   size_t block = cuda_min(nbytes, 1024l);
   size_t grid = std::min(32l, div_ceil(nbytes, block));
@@ -29,4 +30,5 @@ void LaunchCopyKernel(void *dst, const void *src, int64_t nbytes, cudaStream_t s
   CUDA_CALL(cudaGetLastError());
 }
 
+}  // namespace detail
 }  // namespace dali

--- a/dali/pipeline/data/types.cu
+++ b/dali/pipeline/data/types.cu
@@ -22,11 +22,13 @@ __global__ void CopyKernel(uint8_t *dst, const uint8_t *src, int64_t n) {
     dst[i] = src[i];
   }
 }
-  
+
 void LaunchCopyKernel(void *dst, const void *src, int64_t nbytes, cudaStream_t stream) {
   size_t block = cuda_min(nbytes, 1024l);
   size_t grid = std::min(32l, div_ceil(nbytes, block));
-  CopyKernel<<<grid, block, 0, stream>>>(reinterpret_cast<uint8_t*>(dst), reinterpret_cast<const uint8_t*>(src), nbytes);
+  CopyKernel<<<grid, block, 0, stream>>>(reinterpret_cast<uint8_t*>(dst),
+                                         reinterpret_cast<const uint8_t*>(src),
+                                         nbytes);
   CUDA_CALL(cudaGetLastError());
 }
 

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -235,6 +235,21 @@ class DLL_PUBLIC TypeInfo {
                        bool use_copy_kernel = false) const;
 
   /**
+   * @brief Copies from scattered locations from SrcBackend to DstBackend
+   * @param dst destination pointers
+   * @param srcs source pointers
+   * @param sizes number of elements for each of the pointers specified in srcs
+   * @param n number of copies to process
+   * @param stream CUDA stream. Only used in copies to/from GPU backend or from/to Host
+   *        pinned memory when use_copy_kernel is true
+   * @param use_copy_kernel If true, a copy kernel will be used instead of cudaMemcpyAsync when applicable 
+   *        (only relevant for device and host pinned memory)
+   */
+  template <typename DstBackend, typename SrcBackend>
+  DLL_PUBLIC void Copy(void **dst, const void **srcs, const Index *sizes, int n,
+                       cudaStream_t stream, bool use_copy_kernel = false) const;
+
+  /**
    * @brief Copies from SrcBackend scattered locations to a contiguous DstBackend buffer
    * @param dst destination pointer
    * @param srcs source pointers

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -144,9 +144,10 @@ class ExternalSource : public Operator<Backend> {
   /**
    * @brief Sets the data that should be passed out of the op on the next iteration.
    */
-  template<typename SrcBackend>
+  template <typename SrcBackend>
   inline void SetDataSource(const vector<Tensor<SrcBackend>> &vect_of_tensors,
-                            cudaStream_t stream = 0, bool sync = false, bool use_copy_kernel = false) {
+                            cudaStream_t stream = 0, bool sync = false,
+                            bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
     TimeRange tr("[ExternalSource] SetDataSource", TimeRange::kViolet);
     TensorVector<SrcBackend> tv(vect_of_tensors.size());

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -162,7 +162,7 @@ class ExternalSource : public Operator<Backend> {
    */
   template<typename SrcBackend>
   inline void SetDataSource(const TensorVector<SrcBackend> &tv, cudaStream_t stream = 0,
-                              bool sync = false, bool use_copy_kernel = false) {
+                            bool sync = false, bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
     TimeRange tr("[ExternalSource] SetDataSource", TimeRange::kViolet);
     SetDataSourceHelper(tv, stream, sync, use_copy_kernel);

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -135,10 +135,10 @@ class ExternalSource : public Operator<Backend> {
    */
   template<typename SrcBackend>
   inline void SetDataSource(const TensorList<SrcBackend> &tl, cudaStream_t stream = 0,
-                            bool sync = false) {
+                            bool sync = false, bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
     TimeRange tr("[ExternalSource] SetDataSource", TimeRange::kViolet);
-    SetDataSourceHelper(tl, stream, sync);
+    SetDataSourceHelper(tl, stream, sync, use_copy_kernel);
   }
 
   /**
@@ -146,14 +146,14 @@ class ExternalSource : public Operator<Backend> {
    */
   template<typename SrcBackend>
   inline void SetDataSource(const vector<Tensor<SrcBackend>> &vect_of_tensors,
-                            cudaStream_t stream = 0, bool sync = false) {
+                            cudaStream_t stream = 0, bool sync = false, bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
     TimeRange tr("[ExternalSource] SetDataSource", TimeRange::kViolet);
     TensorVector<SrcBackend> tv(vect_of_tensors.size());
     for (size_t i = 0; i < tv.size(); ++i) {
       tv[i].ShareData(const_cast<Tensor<SrcBackend>*>(&vect_of_tensors[i]));
     }
-    SetDataSourceHelper(tv, stream, sync);
+    SetDataSourceHelper(tv, stream, sync, use_copy_kernel);
   }
 
   /**
@@ -161,10 +161,10 @@ class ExternalSource : public Operator<Backend> {
    */
   template<typename SrcBackend>
   inline void SetDataSource(const TensorVector<SrcBackend> &tv, cudaStream_t stream = 0,
-                            bool sync = false) {
+                              bool sync = false, bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
     TimeRange tr("[ExternalSource] SetDataSource", TimeRange::kViolet);
-    SetDataSourceHelper(tv, stream, sync);
+    SetDataSourceHelper(tv, stream, sync, use_copy_kernel);
   }
 
   DISABLE_COPY_MOVE_ASSIGN(ExternalSource);
@@ -358,7 +358,7 @@ class ExternalSource : public Operator<Backend> {
 
   template<typename SrcBackend, template<typename> class SourceDataType>
   inline void SetDataSourceHelper(const SourceDataType<SrcBackend> &batch, cudaStream_t stream = 0,
-                                  bool sync = false) {
+                                  bool sync = false, bool use_copy_kernel = false) {
     bool is_gpu_src = std::is_same<SrcBackend, GPUBackend>::value;
     bool is_gpu_dst = std::is_same<Backend, GPUBackend>::value;
     if (is_gpu_src && !is_gpu_dst) {
@@ -377,7 +377,7 @@ class ExternalSource : public Operator<Backend> {
     if (no_copy_) {
       ShareUserData(batch, stream);
     } else {
-      CopyUserData(batch, stream, sync);
+      CopyUserData(batch, stream, sync, use_copy_kernel);
     }
     cv_.notify_one();
   }

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -300,7 +300,7 @@ class ExternalSource : public Operator<Backend> {
   template<typename SrcBackend, template<typename> class SourceDataType, typename B = Backend>
   inline std::enable_if_t<std::is_same<B, CPUBackend>::value>
   CopyUserData(const SourceDataType<SrcBackend> &batch,
-               cudaStream_t /*stream*/, bool /*sync*/, bool /*use_copy_kernel*/) {
+               cudaStream_t stream, bool /* sync */, bool /* use_copy_kernel */) {
     std::list<uptr_tv_type> tv_elm;
     {
       std::lock_guard<std::mutex> busy_lock(busy_m_);

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -299,7 +299,8 @@ class ExternalSource : public Operator<Backend> {
 
   template<typename SrcBackend, template<typename> class SourceDataType, typename B = Backend>
   inline std::enable_if_t<std::is_same<B, CPUBackend>::value>
-  CopyUserData(const SourceDataType<SrcBackend> &batch, cudaStream_t stream, bool /*sync*/) {
+  CopyUserData(const SourceDataType<SrcBackend> &batch,
+               cudaStream_t /*stream*/, bool /*sync*/, bool /*use_copy_kernel*/) {
     std::list<uptr_tv_type> tv_elm;
     {
       std::lock_guard<std::mutex> busy_lock(busy_m_);
@@ -325,7 +326,8 @@ class ExternalSource : public Operator<Backend> {
 
   template<typename SrcBackend, template<typename> class SourceDataType, typename B = Backend>
   inline std::enable_if_t<std::is_same<B, GPUBackend>::value>
-  CopyUserData(const SourceDataType<SrcBackend> &batch, cudaStream_t stream, bool sync) {
+  CopyUserData(const SourceDataType<SrcBackend> &batch,
+               cudaStream_t stream, bool sync, bool use_copy_kernel) {
     std::list<uptr_cuda_event_type> copy_to_storage_event;
     std::list<uptr_tl_type> tl_elm;
     {
@@ -333,7 +335,7 @@ class ExternalSource : public Operator<Backend> {
       tl_elm = tl_data_.GetEmpty();
       copy_to_storage_event = copy_to_storage_events_.GetEmpty();
     }
-    tl_elm.front()->Copy(batch, stream);
+    tl_elm.front()->Copy(batch, stream, use_copy_kernel);
     // record event for:
     // - GPU -> GPU
     // - pinned CPU -> GPU

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -134,10 +134,10 @@ class DLL_PUBLIC Pipeline {
     return logical_id;
   }
 
-
-  template<typename T, typename OperatorBackend>
+  template <typename T, typename OperatorBackend>
   void SetDataSourceHelper(const string &name, const T &tl, OperatorBase *op_ptr,
-                           cudaStream_t stream = 0, bool sync = false, bool use_copy_kernel = false) {
+                           cudaStream_t stream = 0, bool sync = false,
+                           bool use_copy_kernel = false) {
     // Note: we have 2 different Backends here - OperatorBackend and T's Backend (StorageBackend).
     // The StorageBackend is hidden under `T` type.
     auto *source = dynamic_cast<ExternalSource<OperatorBackend> *>(op_ptr);
@@ -145,7 +145,6 @@ class DLL_PUBLIC Pipeline {
                  "Input name '" + name + "' is not marked as an external input.");
     source->SetDataSource(tl, stream, sync, use_copy_kernel);
   }
-
 
   /**
    * @brief Helper function for the SetExternalInput.

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -137,13 +137,13 @@ class DLL_PUBLIC Pipeline {
 
   template<typename T, typename OperatorBackend>
   void SetDataSourceHelper(const string &name, const T &tl, OperatorBase *op_ptr,
-                           cudaStream_t stream = 0, bool sync = false) {
+                           cudaStream_t stream = 0, bool sync = false, bool use_copy_kernel = false) {
     // Note: we have 2 different Backends here - OperatorBackend and T's Backend (StorageBackend).
     // The StorageBackend is hidden under `T` type.
     auto *source = dynamic_cast<ExternalSource<OperatorBackend> *>(op_ptr);
     DALI_ENFORCE(source != nullptr,
                  "Input name '" + name + "' is not marked as an external input.");
-    source->SetDataSource(tl, stream, sync);
+    source->SetDataSource(tl, stream, sync, use_copy_kernel);
   }
 
 
@@ -159,7 +159,7 @@ class DLL_PUBLIC Pipeline {
    */
   template<typename TL>
   inline void SetExternalInputHelper(const string &name, const TL &tl, cudaStream_t stream = 0,
-                                     bool sync = false) {
+                                     bool sync = false, bool use_copy_kernel = false) {
     bool is_cpu_node = true;
     OpNodeId node_id;
 
@@ -180,9 +180,9 @@ class DLL_PUBLIC Pipeline {
     OperatorBase *op_ptr = &node.InstantiateOperator();
 
     if (is_cpu_node) {
-      SetDataSourceHelper<TL, CPUBackend>(name, tl, op_ptr, stream, sync);
+      SetDataSourceHelper<TL, CPUBackend>(name, tl, op_ptr, stream, sync, use_copy_kernel);
     } else {
-      SetDataSourceHelper<TL, GPUBackend>(name, tl, op_ptr, stream, sync);
+      SetDataSourceHelper<TL, GPUBackend>(name, tl, op_ptr, stream, sync, use_copy_kernel);
     }
   }
 
@@ -199,8 +199,8 @@ class DLL_PUBLIC Pipeline {
   template<typename Backend>
   DLL_PUBLIC inline void
   SetExternalInput(const string &name, const TensorList<Backend> &tl, cudaStream_t stream = 0,
-                   bool sync = false) {
-    SetExternalInputHelper(name, tl, stream, sync);
+                   bool sync = false, bool use_copy_kernel = false) {
+    SetExternalInputHelper(name, tl, stream, sync, use_copy_kernel);
   }
 
 
@@ -216,8 +216,8 @@ class DLL_PUBLIC Pipeline {
   template<typename Backend>
   DLL_PUBLIC inline void
   SetExternalInput(const string &name, const TensorVector<Backend> &tv, cudaStream_t stream = 0,
-                   bool sync = false) {
-    SetExternalInputHelper(name, tv, stream, sync);
+                   bool sync = false, bool use_copy_kernel = false) {
+    SetExternalInputHelper(name, tv, stream, sync, use_copy_kernel);
   }
 
   /**

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1074,13 +1074,13 @@ py::dict ExecutorMetaToDict(const ExecutorMetaMap &meta) {
 
 template <typename Backend>
 void FeedPipeline(Pipeline *p, const string &name, py::list list, cudaStream_t stream,
-                  bool sync = false) {
+                  bool sync = false, bool use_copy_kernel = false) {
   TensorVector<Backend> tv(list.size());
   for (size_t i = 0; i < list.size(); ++i) {
     auto &t = list[i].cast<Tensor<Backend>&>();
     tv[i] = std::move(t);
   }
-  p->SetExternalInput(name, tv, stream, sync);
+  p->SetExternalInput(name, tv, stream, sync, use_copy_kernel);
 }
 
 PYBIND11_MODULE(backend_impl, m) {

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1294,12 +1294,13 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("device_id", &Pipeline::device_id)
     .def("SetExternalTLInput",
         [](Pipeline *p, const string &name, const TensorList<CPUBackend> &tl,
-           py::object /*cuda_stream*/) {
+           py::object /*cuda_stream*/, bool /*use_copy_kernel*/) {
           p->SetExternalInput(name, tl, 0, true);
         },
         "name"_a,
         "list"_a,
-        "cuda_stream"_a = py::none())
+        "cuda_stream"_a = py::none(),
+        "use_copy_kernel"_a = false)
     .def("SetExternalTLInput",
         [](Pipeline *p, const string &name, const TensorList<GPUBackend> &tl,
            py::object cuda_stream, bool use_copy_kernel) {
@@ -1313,7 +1314,8 @@ PYBIND11_MODULE(backend_impl, m) {
         "cuda_stream"_a = py::none(),
         "use_copy_kernel"_a = false)
     .def("SetExternalTensorInput",
-        [](Pipeline *p, const string &name, py::list list, py::object cuda_stream, bool use_copy_kernel) {
+        [](Pipeline *p, const string &name, py::list list, py::object cuda_stream,
+           bool use_copy_kernel) {
           // Note: This is a hack to get around weird casting
           // issues w/ pybind and a non-copyable type (dali::Tensor).
           // We cannot use pybind::cast<Tensor<CPUBackend>>

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -279,7 +279,7 @@ fail when it is not
             if layout is not None:
                 raise RuntimeError("`layout` already specified in constructor.")
             else:
-                layout = self.layout
+                layout = self._layout
 
         if self._cuda_stream is not None:
             if cuda_stream is not None:

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -53,7 +53,7 @@ class _CycleGenFunc():
             return next(self.it)
 
 class _ExternalSourceGroup(object):
-    def __init__(self, callback, is_multioutput, instances = [], cuda_stream = None, use_copy_kernel = False):
+    def __init__(self, callback, is_multioutput, instances = [], cuda_stream = None, use_copy_kernel = None):
         self.instances = list(instances)  # we need a copy!
         self.is_multioutput = is_multioutput
         self.callback = callback
@@ -218,7 +218,7 @@ fail when it is not
 """
 
     def __init__(self, source = None, num_outputs = None, *, cycle = None, layout = None, name = None, device = "cpu", 
-                 cuda_stream = None, use_copy_kernel = False, **kwargs):
+                 cuda_stream = None, use_copy_kernel = None, **kwargs):
         self._schema = _b.GetSchema("_ExternalSource")
         self._spec = _b.OpSpec("_ExternalSource")
         self._device = device
@@ -256,7 +256,7 @@ fail when it is not
         return False
 
     def __call__(self, *, source = None, cycle = None, name = None, layout = None, cuda_stream = None, 
-                 use_copy_kernel = False, **kwargs):
+                 use_copy_kernel = None, **kwargs):
         ""
         from nvidia.dali.ops import _OperatorInstance
 
@@ -342,7 +342,7 @@ def _is_external_source_with_callback(op_instance):
     return isinstance(op_instance._op, ExternalSource) and op_instance._callback is not None
 
 def external_source(source = None, num_outputs = None, *, cycle = None, name = None, device = "cpu", layout = None,
-                    cuda_stream = None, use_copy_kernel = False, **kwargs):
+                    cuda_stream = None, use_copy_kernel = None, **kwargs):
     """Creates a data node which is populated with data from a Python source.
 The data can be provided by the ``source`` function or iterable, or it can be provided by
 ``pipeline.feed_input(name, data, layout, cuda_stream)`` inside ``pipeline.iter_setup``.

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -478,7 +478,7 @@ Parameters
         self._pipe.Build(self._names_and_devices)
         self._built = True
 
-    def feed_input(self, data_node, data, layout="", cuda_stream = None):
+    def feed_input(self, data_node, data, layout="", cuda_stream = None, use_copy_kernel = False):
         """Pass a mutlidimensional array or DLPack (or a list thereof) to an output of ExternalSource.
         In the case of the GPU input, the data must be modified on the same stream as the one
         used by feed_input. See ``cuda_stream`` parameter for details.
@@ -519,6 +519,10 @@ Parameters
             If internal stream is used, the call to ``feed_input`` will block until the copy to
             internal buffer is complete, since there's no way to synchronize with this stream to
             prevent overwriting the array with new data in another stream.
+
+        use_copy_kernel : optional, `bool`
+            If set to True, DALI will use a CUDA kernel to feed the data (only applicable when copying
+            data to/from GPU memory) instead of cudaMemcpyAsync (default).
         """
         if not self._built:
             raise RuntimeError("Pipeline must be built first.")
@@ -567,7 +571,7 @@ Parameters
                 inputs.append(inp)
             assert all(isinstance(inp, type(inputs[0])) for inp in inputs), \
                    "Mixed input types are not support, all need to reside on the CPU or GPU"
-            self._pipe.SetExternalTensorInput(name, inputs, ctypes.c_void_p(cuda_stream))
+            self._pipe.SetExternalTensorInput(name, inputs, ctypes.c_void_p(cuda_stream), use_copy_kernel)
         else:
             info = CheckDLPackCapsule(data)
             if not info[0]:

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -583,7 +583,7 @@ Parameters
             else:
                 data = to_numpy(data)
                 inp = Tensors.TensorListCPU(data, layout)
-            self._pipe.SetExternalTLInput(name, inp, ctypes.c_void_p(cuda_stream))
+            self._pipe.SetExternalTLInput(name, inp, ctypes.c_void_p(cuda_stream), use_copy_kernel)
 
     def _run_cpu(self):
         """Run CPU portion of the pipeline."""

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -347,17 +347,6 @@ DLL_PUBLIC void
 daliCopyTensorNTo(daliPipelineHandle *pipe_handle, void *dst, int n, device_type_t dst_type,
                   cudaStream_t stream, int non_blocking);
 
-
-/**
- * @brief Gets direct access to the output tensor stored
- * at position `n` in the pipeline.
- * @remarks The memory is managed by DALI and will be valid until the next call
- * to daliOutputRelease (or daliOutput since it calls daliOutputRelease before waiting
- * for the next iteration)
- */
-DLL_PUBLIC void daliOutputPtr(daliPipelineHandle* pipe_handle, int n,
-                              const void **out_ptr, size_t *out_len);
-
 /**
  * @brief Delete the pipeline object.
  */

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -135,7 +135,13 @@ enum {
   /**
    * If provided CPU memory is page-locked
    */
-  DALI_ext_pinned = (1<<1)
+  DALI_ext_pinned = (1<<1),
+
+  /**
+   * If provided, a CUDA copy kernel will be used to feed external source instead of cudaMemcpyAsync
+   * Only relevant when the input is either pinned host memory or device memory
+   */
+  DALI_use_copy_kernel = (1<<2),
 };
 
 /**
@@ -331,7 +337,7 @@ DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle);
  * @brief Copy the output tensor stored
  * at position `n` in the pipeline.
  * dst_type (0 - CPU, 1 - GPU)
- * @remarks If the output is tensor list then it need to be dense
+ * @remarks If the output is tensor list then it needs to be dense
  *
  * If you call this function with non_blocking != 0, make sure to
  * synchronize on provided stream before reading the data.
@@ -340,6 +346,13 @@ DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle);
 DLL_PUBLIC void
 daliCopyTensorNTo(daliPipelineHandle *pipe_handle, void *dst, int n, device_type_t dst_type,
                   cudaStream_t stream, int non_blocking);
+
+
+/**
+ * @brief Gets direct access to the dali buffer containing an output of the pipeline
+ */
+DLL_PUBLIC void daliOutputPtr(daliPipelineHandle* pipe_handle, int n,
+                              const void **out_ptr, size_t *out_len);
 
 /**
  * @brief Delete the pipeline object.

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -349,7 +349,11 @@ daliCopyTensorNTo(daliPipelineHandle *pipe_handle, void *dst, int n, device_type
 
 
 /**
- * @brief Gets direct access to the dali buffer containing an output of the pipeline
+ * @brief Gets direct access to the output tensor stored
+ * at position `n` in the pipeline.
+ * @remarks The memory is managed by DALI and will be valid until the next call
+ * to daliOutputRelease (or daliOutput since it calls daliOutputRelease before waiting
+ * for the next iteration)
  */
 DLL_PUBLIC void daliOutputPtr(daliPipelineHandle* pipe_handle, int n,
                               const void **out_ptr, size_t *out_len);

--- a/include/dali/core/cuda_error.h
+++ b/include/dali/core/cuda_error.h
@@ -119,11 +119,44 @@ inline void cudaResultCheck<CUresult>(CUresult status) {
     throw dali::CUDAError(status);
   }
 }
+
+template <typename Code>
+inline void cudaResultDtorCheck(Code code) {
+  static_assert(!std::is_same<Code, Code>::value,
+    "cudaResultDtorCheck not implemented for this type of status code");
+}
+
+template <>
+inline void cudaResultDtorCheck<cudaError_t>(cudaError_t status) {
+  switch (status) {
+  case cudaErrorCudartUnloading:
+    return;
+  default:
+    cudaResultCheck(status);
+  }
+}
+
+template <>
+inline void cudaResultDtorCheck<CUresult>(CUresult status) {
+  switch (status) {
+  case CUDA_ERROR_DEINITIALIZED:
+    return;
+  default:
+    cudaResultCheck(status);
+  }
+}
+
 }  // namespace dali
 
 template <typename T>
 inline void CUDA_CALL(T status) {
   return dali::cudaResultCheck(status);
 }
+
+template <typename T>
+inline void CUDA_DTOR_CALL(T status) {
+  return dali::cudaResultDtorCheck(status);
+}
+
 
 #endif  // DALI_CORE_CUDA_ERROR_H_

--- a/include/dali/core/cuda_error.h
+++ b/include/dali/core/cuda_error.h
@@ -121,7 +121,7 @@ inline void cudaResultCheck<CUresult>(CUresult status) {
 }
 
 template <typename Code>
-inline void cudaResultDestructorCheck(Code code) {
+inline void cudaResultDestructorCheck(Code status) {
   cudaResultCheck(status);
 }
 

--- a/include/dali/core/cuda_error.h
+++ b/include/dali/core/cuda_error.h
@@ -121,13 +121,12 @@ inline void cudaResultCheck<CUresult>(CUresult status) {
 }
 
 template <typename Code>
-inline void cudaResultDtorCheck(Code code) {
-  static_assert(!std::is_same<Code, Code>::value,
-    "cudaResultDtorCheck not implemented for this type of status code");
+inline void cudaResultDestructorCheck(Code code) {
+  cudaResultCheck(status);
 }
 
 template <>
-inline void cudaResultDtorCheck<cudaError_t>(cudaError_t status) {
+inline void cudaResultDestructorCheck<cudaError_t>(cudaError_t status) {
   switch (status) {
   case cudaErrorCudartUnloading:
     return;
@@ -137,7 +136,7 @@ inline void cudaResultDtorCheck<cudaError_t>(cudaError_t status) {
 }
 
 template <>
-inline void cudaResultDtorCheck<CUresult>(CUresult status) {
+inline void cudaResultDestructorCheck<CUresult>(CUresult status) {
   switch (status) {
   case CUDA_ERROR_DEINITIALIZED:
     return;
@@ -155,7 +154,7 @@ inline void CUDA_CALL(T status) {
 
 template <typename T>
 inline void CUDA_DTOR_CALL(T status) {
-  return dali::cudaResultDtorCheck(status);
+  return dali::cudaResultDestructorCheck(status);
 }
 
 

--- a/include/dali/core/per_stream_pool.h
+++ b/include/dali/core/per_stream_pool.h
@@ -41,9 +41,12 @@ namespace dali {
  * If there are no available objects for current device, a new object is created and leased
  * immediately - it will be returned to the pool when the lease is over.
  *
+<<<<<<< HEAD
  * If reuse of objects on same stream is not wanted, use the alias PerDevicePool, which prevents
  * this behavior.
  *
+=======
+>>>>>>> Per-stream/per-device object pool.
  * Example:
  * ```
  * class MyClass {
@@ -67,7 +70,11 @@ namespace dali {
  *   cls.DoSomeJob(stream2);  // if the previous job has not finished, create a new GPUWorker
  *   cls.DoSomeJob(stream2);  // reuse the second worker
  *   cudaDeviceSynchronize();
+<<<<<<< HEAD
  *   cls.DoSomeJob(stream2);  // associated work is finished, reuses any of the two workers
+=======
+ *   cla.DoSomeJob(stream2);  // associated work is finished, reuses any of the two workers
+>>>>>>> Per-stream/per-device object pool.
  * ```
  *
  * Possible future extensions:
@@ -102,6 +109,10 @@ class PerStreamPool {
     }
 
     ~ListNode() {
+<<<<<<< HEAD
+=======
+      event.reset();
+>>>>>>> Per-stream/per-device object pool.
       DeleteNonRecursive(std::move(next));
     }
 
@@ -174,7 +185,10 @@ class PerStreamPool {
 
     ListNodeUPtr ptr = std::move(dev_pools_[idx]);
     dev_pools_[idx] = std::move(ptr->next);
+<<<<<<< HEAD
     ptr->stream = stream;
+=======
+>>>>>>> Per-stream/per-device object pool.
     return ptr;
   }
 
@@ -184,7 +198,11 @@ class PerStreamPool {
         pptr = &(*pptr)->next;
       } else {  // otherwise it's finished (or an error; we still recycle)
         int idx = (*pptr)->device_id + 1;
+<<<<<<< HEAD
         if (idx >= static_cast<int>(dev_pools_.size()))
+=======
+        if (idx >= dev_pools_.size())
+>>>>>>> Per-stream/per-device object pool.
           dev_pools_.resize(idx + 1);
 
         auto to_recycle = std::move(*pptr);  // remove from pending_ list
@@ -202,6 +220,7 @@ class PerStreamPool {
   mutex_type lock_;
 };
 
+<<<<<<< HEAD
 /**
  * @brief This pre-configured pool object does not reuse objects for which there is outstanding
  *        work, regardless of the stream.
@@ -242,6 +261,8 @@ class PerStreamPool {
  *
  * @see PerStreamPool for detailed description.
  */
+=======
+>>>>>>> Per-stream/per-device object pool.
 template <typename T, typename mutex_type = std::mutex>
 using PerDevicePool = PerStreamPool<T, mutex_type, false>;
 

--- a/include/dali/core/per_stream_pool.h
+++ b/include/dali/core/per_stream_pool.h
@@ -41,12 +41,9 @@ namespace dali {
  * If there are no available objects for current device, a new object is created and leased
  * immediately - it will be returned to the pool when the lease is over.
  *
-<<<<<<< HEAD
  * If reuse of objects on same stream is not wanted, use the alias PerDevicePool, which prevents
  * this behavior.
  *
-=======
->>>>>>> Per-stream/per-device object pool.
  * Example:
  * ```
  * class MyClass {
@@ -70,11 +67,7 @@ namespace dali {
  *   cls.DoSomeJob(stream2);  // if the previous job has not finished, create a new GPUWorker
  *   cls.DoSomeJob(stream2);  // reuse the second worker
  *   cudaDeviceSynchronize();
-<<<<<<< HEAD
  *   cls.DoSomeJob(stream2);  // associated work is finished, reuses any of the two workers
-=======
- *   cla.DoSomeJob(stream2);  // associated work is finished, reuses any of the two workers
->>>>>>> Per-stream/per-device object pool.
  * ```
  *
  * Possible future extensions:
@@ -109,10 +102,6 @@ class PerStreamPool {
     }
 
     ~ListNode() {
-<<<<<<< HEAD
-=======
-      event.reset();
->>>>>>> Per-stream/per-device object pool.
       DeleteNonRecursive(std::move(next));
     }
 
@@ -185,10 +174,7 @@ class PerStreamPool {
 
     ListNodeUPtr ptr = std::move(dev_pools_[idx]);
     dev_pools_[idx] = std::move(ptr->next);
-<<<<<<< HEAD
     ptr->stream = stream;
-=======
->>>>>>> Per-stream/per-device object pool.
     return ptr;
   }
 
@@ -198,11 +184,7 @@ class PerStreamPool {
         pptr = &(*pptr)->next;
       } else {  // otherwise it's finished (or an error; we still recycle)
         int idx = (*pptr)->device_id + 1;
-<<<<<<< HEAD
         if (idx >= static_cast<int>(dev_pools_.size()))
-=======
-        if (idx >= dev_pools_.size())
->>>>>>> Per-stream/per-device object pool.
           dev_pools_.resize(idx + 1);
 
         auto to_recycle = std::move(*pptr);  // remove from pending_ list
@@ -220,7 +202,6 @@ class PerStreamPool {
   mutex_type lock_;
 };
 
-<<<<<<< HEAD
 /**
  * @brief This pre-configured pool object does not reuse objects for which there is outstanding
  *        work, regardless of the stream.
@@ -261,8 +242,6 @@ class PerStreamPool {
  *
  * @see PerStreamPool for detailed description.
  */
-=======
->>>>>>> Per-stream/per-device object pool.
 template <typename T, typename mutex_type = std::mutex>
 using PerDevicePool = PerStreamPool<T, mutex_type, false>;
 


### PR DESCRIPTION
#### Why we need this PR?
- It adds an option to use a copy kernel (or scatter-gather kernel) to feed external sources instead of cudaMemcpyAsync. In some cases, it might be beneficial, since it will allow other cudaMemcpyAsync to happen at the same time.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a flag to daliSetExternalInputTensorsAsync and daliSetExternalInputAsync that will replace cudaMemcpyAsync calls by a scatter-gather kernel or a copy kernel respectively.
 - Affected modules and functionalities:
     *C-API / external source*
 - Key points relevant for the review:
     *Changes in external source*
 - Validation and testing:
     *Test case added*
 - Documentation (including examples):
     *Doxygen*


**JIRA TASK**: *[DALI-1497]*
