### PR TITLE
Removes redundant copy in ExternalSource operator 

### DIFF
--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -388,7 +388,9 @@ DLL_PUBLIC constexpr double Buffer<Backend>::kMaxGrowthFactor;
   using Buffer<Backend>::size_;        \
   using Buffer<Backend>::shares_data_; \
   using Buffer<Backend>::num_bytes_;   \
-  using Buffer<Backend>::device_
+  using Buffer<Backend>::device_;      \
+  using Buffer<Backend>::pinned_
+
 
 }  // namespace dali
 

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -490,6 +490,7 @@ class Tensor : public Buffer<Backend> {
       num_bytes_ = t.num_bytes_;
       device_ = t.device_;
       meta_ = std::move(t.meta_);
+      pinned_ = t.pinned_;
 
       t.shape_ = TensorShape<>();
       t.backend_ = Backend();

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -198,6 +198,7 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
 
     // copy metadata
     meta_ = other->meta_;
+    layout_ = other->layout_;
   }
 
   /**
@@ -288,6 +289,24 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     offsets_.clear();
     meta_.clear();
     tensor_views_.clear();
+  }
+
+  /**
+   * @brief Swaps the content of two TensorLists
+   */
+  DLL_PUBLIC inline void Swap(TensorList<Backend> *other) {
+    std::swap(data_, other->data_);
+    std::swap(shape_, other->shape_);
+    std::swap(size_, other->size_);
+    std::swap(offsets_, other->offsets_);
+    std::swap(type_, other->type_);
+    std::swap(num_bytes_, other->num_bytes_);
+    std::swap(device_, other->device_);
+    std::swap(tensor_views_, other->tensor_views_);
+    std::swap(shares_data_, other->shares_data_);
+    std::swap(Buffer<Backend>::pinned_, other->pinned_);
+    std::swap(meta_, other->meta_);
+    std::swap(layout_, other->layout_);
   }
 
   /**

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -53,6 +53,38 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     Resize(TensorListShape<>(batch_size));
   }
 
+  DLL_PUBLIC TensorList<Backend>(const TensorList<Backend>&) = delete;
+  DLL_PUBLIC TensorList<Backend>& operator=(const TensorList<Backend>&) = delete;
+
+  DLL_PUBLIC TensorList<Backend>(TensorList<Backend> &&other) noexcept {
+    // Steal all data and set input to default state
+    data_ = other.data_;
+    shape_ = std::move(other.shape_);
+    backend_ = other.backend_;
+    size_ = other.size_;
+    offsets_ = std::move(other.offsets_);
+    type_ = other.type_;
+    num_bytes_ = other.num_bytes_;
+    device_ = other.device_;
+    tensor_views_ = std::move(other.tensor_views_);
+    shares_data_ = other.shares_data_;
+    pinned_ = other.pinned_;
+    meta_ = std::move(other.meta_);
+    layout_ = std::move(other.layout_);
+
+    other.data_ = nullptr;
+    other.shape_ = {};
+    other.backend_ = Backend();
+    other.size_ = 0;
+    other.offsets_ = {};
+    other.type_ = TypeInfo::Create<NoType>();
+    other.num_bytes_ = 0;
+    other.tensor_views_.clear();
+    other.shares_data_ = false;
+    other.meta_ = {};
+    other.layout_ = {};
+  }
+
   DLL_PUBLIC ~TensorList() = default;
 
   /**
@@ -291,22 +323,36 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     tensor_views_.clear();
   }
 
-  /**
-   * @brief Swaps the content of two TensorLists
-   */
-  DLL_PUBLIC inline void Swap(TensorList<Backend> *other) {
-    std::swap(data_, other->data_);
-    std::swap(shape_, other->shape_);
-    std::swap(size_, other->size_);
-    std::swap(offsets_, other->offsets_);
-    std::swap(type_, other->type_);
-    std::swap(num_bytes_, other->num_bytes_);
-    std::swap(device_, other->device_);
-    std::swap(tensor_views_, other->tensor_views_);
-    std::swap(shares_data_, other->shares_data_);
-    std::swap(Buffer<Backend>::pinned_, other->pinned_);
-    std::swap(meta_, other->meta_);
-    std::swap(layout_, other->layout_);
+  DLL_PUBLIC inline TensorList<Backend>& operator=(TensorList<Backend> &&other) noexcept {
+    if (&other != this) {
+      // Steal all data and set input to default state
+      data_ = other.data_;
+      shape_ = std::move(other.shape_);
+      backend_ = other.backend_;
+      size_ = other.size_;
+      offsets_ = std::move(other.offsets_);
+      type_ = other.type_;
+      num_bytes_ = other.num_bytes_;
+      device_ = other.device_;
+      tensor_views_ = std::move(other.tensor_views_);
+      shares_data_ = other.shares_data_;
+      pinned_ = other.pinned_;
+      meta_ = std::move(other.meta_);
+      layout_ = std::move(other.layout_);
+
+      other.data_ = nullptr;
+      other.shape_ = {};
+      other.backend_ = Backend();
+      other.size_ = 0;
+      other.offsets_ = {};
+      other.type_ = TypeInfo::Create<NoType>();
+      other.num_bytes_ = 0;
+      other.tensor_views_.clear();
+      other.shares_data_ = false;
+      other.meta_ = {};
+      other.layout_ = {};
+    }
+    return *this;
   }
 
   /**
@@ -514,8 +560,6 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
   // with different template types
   template <typename InBackend>
   friend class TensorList;
-
-  DISABLE_COPY_MOVE_ASSIGN(TensorList);
 
   inline std::string GetSourceInfo(int idx) const {
     return meta_[idx].GetSourceInfo();

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -351,7 +351,7 @@ class TensorVector {
   void ShareData(TensorVector<Backend> *tv) {
     DALI_ENFORCE(tv != nullptr, "Input TensorVector is nullptr");
     state_ = tv->state_;
-    pinned_ = tv->pinned_;
+    pinned_ = tv->is_pinned();
 
     if (tv->tl_->raw_data()) {
       tl_->ShareData(tv->tl_.get());
@@ -373,6 +373,24 @@ class TensorVector {
         tensors_[i]->ShareData(tv->tensors_[i].get());
       }
     }
+  }
+
+  void Swap(TensorVector<Backend> *tv) {
+    std::swap(state_, tv->state_);
+    std::swap(pinned_, tv->pinned_);
+    std::swap(tl_, tv->tl_);
+    std::swap(type_, tv->type_);
+    if (views_count_) {
+      tensors_.clear();
+      views_count_ = 0;
+    }
+    if (tv->views_count_) {
+      tv->tensors_.clear();
+      tv->views_count_ = 0;
+    }
+    std::swap(tensors_, tv->tensors_);
+    UpdateViews();
+    tv->UpdateViews();
   }
 
   void UpdateViews() {

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -65,6 +65,22 @@ class TensorVector {
   TensorVector(const TensorVector &) = delete;
   TensorVector &operator=(const TensorVector &) = delete;
 
+  DLL_PUBLIC TensorVector<Backend>(TensorVector<Backend> &&other) noexcept {
+    state_ = other.state_;
+    pinned_ = other.pinned_;
+    tl_ = std::move(other.tl_);
+    type_ = other.type_;
+    views_count_ = other.views_count_.load();
+    tensors_ = std::move(other.tensors_);
+    for (auto &t : tensors_) {
+      if (auto *del = std::get_deleter<ViewRefDeleter>(t)) del->ref = &views_count_;
+    }
+
+    other.tl_->Reset();
+    other.views_count_ = 0;
+    tensors_.clear();
+  }
+
   Tensor<Backend>& operator[](size_t pos) {
     return *(tensors_[pos]);
   }
@@ -375,22 +391,23 @@ class TensorVector {
     }
   }
 
-  void Swap(TensorVector<Backend> *tv) {
-    std::swap(state_, tv->state_);
-    std::swap(pinned_, tv->pinned_);
-    std::swap(tl_, tv->tl_);
-    std::swap(type_, tv->type_);
-    if (views_count_) {
+  inline TensorVector<Backend>& operator=(TensorVector<Backend> &&other) noexcept {
+    if (&other != this) {
+      state_ = other.state_;
+      pinned_ = other.pinned_;
+      tl_ = std::move(other.tl_);
+      type_ = other.type_;
+      views_count_ = other.views_count_.load();
+      tensors_ = std::move(other.tensors_);
+      for (auto &t : tensors_) {
+        if (auto *del = std::get_deleter<ViewRefDeleter>(t)) del->ref = &views_count_;
+      }
+
+      other.tl_->Reset();
+      other.views_count_ = 0;
       tensors_.clear();
-      views_count_ = 0;
     }
-    if (tv->views_count_) {
-      tv->tensors_.clear();
-      tv->views_count_ = 0;
-    }
-    std::swap(tensors_, tv->tensors_);
-    UpdateViews();
-    tv->UpdateViews();
+    return *this;
   }
 
   void UpdateViews() {
@@ -429,6 +446,11 @@ class TensorVector {
     }
   }
 
+  struct ViewRefDeleter {
+    void operator()(void*) { --*ref; }
+    std::atomic<int> *ref;
+  };
+
   void update_view(int idx) {
     if (!tensors_[idx]) {
       tensors_[idx] = create_tensor();
@@ -441,7 +463,7 @@ class TensorVector {
     // tensors_[i]->ShareData(tl_.get(), static_cast<int>(idx));
     if (tensors_[idx]->raw_data() != ptr || tensors_[idx]->shape() != shape) {
       tensors_[idx]->ShareData(
-          std::shared_ptr<void>(ptr, [&views_count = views_count_](void *) { views_count--; }),
+          std::shared_ptr<void>(ptr, ViewRefDeleter{&views_count_}),
           volume(tl_->tensor_shape(idx)) * tl_->type().size(), shape);
     }
     tensors_[idx]->SetMeta(tl_->GetMeta(idx));
@@ -460,6 +482,10 @@ class TensorVector {
   // with different template types
   template <typename InBackend>
   friend class TensorVector;
+
+  // So we can access data_ of the tensor directly
+  template <typename InBackend>
+  friend class Tensor;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -38,7 +38,7 @@ void ExternalSource<CPUBackend>::RunImpl(HostWorkspace &ws) {
         // HostWorkspace doesn't have any stream
         cudaStream_t stream = 0;
         output_tensor.Copy((*tensor_vector_elm.front())[sample_id], stream);
-      }, volume(shapes[sample_id]));
+      }, shapes.tensor_size(sample_id));
     }
     thread_pool.RunAll();
     // as we copy element by element and the output is contiguous we need to set layout
@@ -47,7 +47,7 @@ void ExternalSource<CPUBackend>::RunImpl(HostWorkspace &ws) {
     output.SetLayout(tensor_vector_elm.front()->GetLayout());
   } else {
     // swap output with tensor_vector_elm content
-    output.Swap(tensor_vector_elm.front().get());
+    std::swap(output, *tensor_vector_elm.front());
   }
   RecycleBuffer(tensor_vector_elm);
 }

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -25,30 +25,34 @@ void ExternalSource<CPUBackend>::RunImpl(HostWorkspace &ws) {
     tensor_vector_elm = tv_data_.PopFront();
     state_.pop_front();
   }
-  if (no_copy_) {
-    TensorVector<CPUBackend> &output = ws.template OutputRef<CPUBackend>(0);
-    output.ShareData(tensor_vector_elm.front().get());
-    // empty tensor_vector_elm
-    tensor_vector_elm.front()->Reset();
-    RecycleBuffer(tensor_vector_elm);
-  } else {
+  auto &output = ws.template OutputRef<CPUBackend>(0);
+  // if the output is pinned we need to copy
+  if (output.is_pinned()) {
     auto &thread_pool = ws.GetThreadPool();
     const auto &shapes = tensor_vector_elm.front()->shape();
+    for (int sample_id = 0; sample_id < batch_size_; sample_id++) {
+      sample_ids_.emplace_back(volume(shapes[sample_id]), sample_id);
+    }
+    std::sort(sample_ids_.begin(), sample_ids_.end(), std::greater<VolumeSampleIdPair>());
+    output.Resize(shapes, tensor_vector_elm.front()->type());
     for (int data_idx = 0; data_idx < batch_size_; ++data_idx) {
-      thread_pool.AddWork([&ws, data_idx, &tensor_vector_elm] (int tid) {
-        Tensor<CPUBackend> &output = ws.Output<CPUBackend>(0, data_idx);
+      thread_pool.DoWorkWithID([&ws, data_idx, &tensor_vector_elm] (int tid) {
+        Tensor<CPUBackend> &output_tensor = ws.Output<CPUBackend>(0, data_idx);
         // HostWorkspace doesn't have any stream
         cudaStream_t stream = 0;
-        output.Copy((*tensor_vector_elm.front())[data_idx], stream);
-      }, shapes.tensor_size(data_idx));
+        output_tensor.Copy((*tensor_vector_elm.front())[data_idx], stream);
+      });
     }
     thread_pool.RunAll();
     // as we copy element by element and the output is contiguous we need to set layout
     // for the whole output not each element(view)
     auto &output = ws.template OutputRef<CPUBackend>(0);
     output.SetLayout(tensor_vector_elm.front()->GetLayout());
-    RecycleBuffer(tensor_vector_elm);
+  } else {
+    // swap output with tensor_vector_elm content
+    output.Swap(tensor_vector_elm.front().get());
   }
+  RecycleBuffer(tensor_vector_elm);
 }
 
 DALI_REGISTER_OPERATOR(_ExternalSource, ExternalSource<CPUBackend>, CPU);
@@ -66,7 +70,7 @@ fail when it is not)code", true)
       R"code(Whether DALI should copy the buffer when feed_input is called
 If True, DALI passes the user memory directly to the Pipeline, instead of copying.
 It is the user's responsibility to keep the buffer alive and unmodified
-until it isconsumed by the pipeline.
+until it is consumed by the pipeline.
 
 The buffer can be modified or freed again after the relevant iteration output has been consumed.
 Effectively, it happens after ``prefetch_queue_depth`` or ``cpu_queue_depth * gpu_queue_depth``

--- a/dali/pipeline/operator/builtin/external_source.cu
+++ b/dali/pipeline/operator/builtin/external_source.cu
@@ -43,7 +43,7 @@ void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
     CUDA_CALL(cudaStreamWaitEvent(stream_used, *internal_copy_to_storage.front(), 0));
   }
 
-  output.Swap(tensor_list_elm.front().get());
+  std::swap(output, *tensor_list_elm.front());
 
   if (!no_copy_ || state_info.copied_shared_data) {
     RecycleBuffer(tensor_list_elm, &internal_copy_to_storage);

--- a/dali/pipeline/operator/builtin/external_source.cu
+++ b/dali/pipeline/operator/builtin/external_source.cu
@@ -20,40 +20,10 @@
 
 namespace dali {
 
-template <>
-struct ExternalSource<GPUBackend>::RecycleFunctor {
-  RecycleFunctor() = default;
-  RecycleFunctor(const RecycleFunctor &) {
-    assert(!"Should never happen");
-  }
-  RecycleFunctor(RecycleFunctor &&) = default;
-  RecycleFunctor& operator=(const RecycleFunctor&) = default;
-  RecycleFunctor& operator=(RecycleFunctor&&) = default;
-  ~RecycleFunctor() = default;
-
-
-  RecycleFunctor(ExternalSource<GPUBackend> *owner, std::list<uptr_cuda_event_type> event,
-                 std::list<uptr_tl_type> ptr, std::list<uptr_cuda_event_type> internal_copy_to_gpu)
-          : owner(owner), event(std::move(event)), copy_to_gpu(std::move(internal_copy_to_gpu)),
-            ptr(std::move(ptr)) {}
-
-  ExternalSource<GPUBackend> *owner;
-  std::list<uptr_cuda_event_type> event, copy_to_gpu;
-  std::list<uptr_tl_type> ptr;
-  void operator()() {
-    std::list<uptr_cuda_event_type> *event_ptr = nullptr;
-    std::list<uptr_cuda_event_type> *copy_to_gpu_ptr = nullptr;
-    if (event.size()) event_ptr = &event;
-    if (copy_to_gpu.size()) copy_to_gpu_ptr = &copy_to_gpu;
-
-    owner->RecycleBuffer(ptr, event_ptr, copy_to_gpu_ptr);
-  }
-};
-
 template<>
 void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   std::list<uptr_tl_type> tensor_list_elm;
-  std::list<uptr_cuda_event_type> cuda_event, internal_copy_to_storage;
+  std::list<uptr_cuda_event_type> internal_copy_to_storage;
   ExternalSourceState state_info;
   {
     std::unique_lock<std::mutex> busy_lock(busy_m_);
@@ -62,11 +32,8 @@ void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
     state_.pop_front();
     // even with no_copy we may have copied from TensorVector to TensorList and we
     // need to sync with that
-    if (!no_copy_ || !tensor_list_elm.front()->shares_data()) {
+    if (!no_copy_ || state_info.copied_shared_data) {
       internal_copy_to_storage = copy_to_storage_events_.PopFront();
-      if (!no_copy_) {
-        cuda_event = cuda_events_.GetEmpty();
-      }
     }
   }
 
@@ -76,34 +43,11 @@ void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
     CUDA_CALL(cudaStreamWaitEvent(stream_used, *internal_copy_to_storage.front(), 0));
   }
 
-  if (!no_copy_) {
-    output.Copy(*(tensor_list_elm.front()), stream_used);
-     // record an event so Recycle can synchronize on it
-    cudaEventRecord(*cuda_event.front(), stream_used);
-    sync_worker_.DoWork(RecycleFunctor{this, std::move(cuda_event), std::move(tensor_list_elm),
-                                       std::move(internal_copy_to_storage)});
-  } else if (state_info.copied_shared_data) {
-    // make a shared pointer which will recycle buffer upon destruction. So when pipeline
-    // no longer needs that buffer we can return it to the pool
-    void *ptr = tensor_list_elm.front()->raw_mutable_data();
-    int device_id = tensor_list_elm.front()->device_id();
+  output.Swap(tensor_list_elm.front().get());
 
-    auto tmp_capacity = tensor_list_elm.front()->capacity();
-    auto tmp_shape = tensor_list_elm.front()->shape();
-    auto tmp_type = tensor_list_elm.front()->type();
-    RecycleFunctor funct{this, std::move(cuda_event), std::move(tensor_list_elm),
-                            std::move(internal_copy_to_storage)};
-    auto tmp_shr_ptr = shared_ptr<void>(ptr, [functor = std::move(funct)] (void*) mutable {  // NOLINT (*)
-                                              functor();
-                                              });
-
-    output.ShareData(tmp_shr_ptr, tmp_capacity, tmp_shape, tmp_type);
-    output.set_device_id(device_id);
+  if (!no_copy_ || state_info.copied_shared_data) {
+    RecycleBuffer(tensor_list_elm, &internal_copy_to_storage);
   } else {
-    output.ShareData(tensor_list_elm.front().get());
-    // empty tensor_list_elm
-    tensor_list_elm.front()->Reset();
-    // recycle right away as tensor_list_elm is only sharing data
     RecycleBuffer(tensor_list_elm);
   }
 }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -349,7 +349,7 @@ void ExposeTensor(py::module &m) {
 
           // Create the Tensor and wrap the data
           auto t = new Tensor<CPUBackend>;
-          t->set_pinned(false);
+          t->set_pinned(is_pinned);
           TypeInfo type = TypeFromFormatStr(info.format);
           t->ShareData(info.ptr, bytes, type);
           t->SetLayout(layout);
@@ -1077,7 +1077,8 @@ void FeedPipeline(Pipeline *p, const string &name, py::list list, cudaStream_t s
                   bool sync = false) {
   TensorVector<Backend> tv(list.size());
   for (size_t i = 0; i < list.size(); ++i) {
-    tv[i] = std::move(list[i].cast<Tensor<Backend>&>());
+    auto &t = list[i].cast<Tensor<Backend>&>();
+    tv[i] = std::move(t);
   }
   p->SetExternalInput(name, tv, stream, sync);
 }


### PR DESCRIPTION
- removes the redundant copy from CPU and GPU backend - now ExternalSource will just use data from staging buffer directly inside RunImpl
- adds NVTX range to SetDataSource so now it is possible to measure user thread time of feeding ExternalSource operator
- adds a more verbose message when operator and data backend doesn't match when zero_copy is used
- fixes lack of waiting for the inputs when zero-copy is set
- adds Swap method to TensorVector and TensorList
- ExternalSource doesn't always sync anymore when the pinned CPU buffer is provided for the GPU operator

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a lack of waiting for the inputs when zero-copy is set
- It removes the redundant copy from CPU and GPU backend - now ExternalSource will just use data from staging buffer directly inside RunImpl

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     removes the redundant copy from CPU backend - now ExternalSource will just use data from staging buffer directly inside RunImpl
     adds NVTX range to SetDataSource so now it is possible to measure user thread time of feeding ExternalSource operator
     adds a more verbose message when operator and data backend doesn't match when zero_copy is used
     fixes lack of waiting for the inputs when zero-copy is set
     ExternalSource doesn't always sync anymore when the pinned CPU buffer is provided for the GPU operator
 - Affected modules and functionalities:
     ExternalSource
     TensorList
     TensorVector
     Buffer
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*