### PR TITLE
Fix PaddlePaddle test broken by rarfile update not compatible with Python 3.5

### DIFF
--- a/qa/TL0_FW_iterators/test_paddle.sh
+++ b/qa/TL0_FW_iterators/test_paddle.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -e
 # used pip packages
-
-
-pip_packages="nose numpy opencv-python paddle"
+# rarfile>= 3.2 breaks python 3.5 compatibility
+pip_packages="nose numpy opencv-python paddle rarfile<=3.1"
 target_dir=./dali/test/python
 
 one_config_only=true

--- a/qa/TL1_jupyter_plugins/test_paddle.sh
+++ b/qa/TL1_jupyter_plugins/test_paddle.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 
 # used pip packages
-pip_packages="jupyter matplotlib paddle"
+# rarfile>= 3.2 breaks python 3.5 compatibility
+pip_packages="jupyter matplotlib paddle rarfile<=3.1"
 target_dir=./docs/examples/
 
 do_once() {

--- a/qa/TL1_paddle_ssd/test.sh
+++ b/qa/TL1_paddle_ssd/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="numpy paddle"
+# rarfile>= 3.2 breaks python 3.5 compatibility
+pip_packages="numpy paddle rarfile<=3.1"
 target_dir=./docs/examples/use_cases/paddle/ssd/
 
 test_body() {

--- a/qa/TL1_paddle_tsm/test.sh
+++ b/qa/TL1_paddle_tsm/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="numpy paddle"
+# rarfile>= 3.2 breaks python 3.5 compatibility
+pip_packages="numpy paddle rarfile<=3.1"
 target_dir=./docs/examples/use_cases/paddle/tsm/
 
 do_once() {

--- a/qa/TL1_separate_executor/test_paddle.sh
+++ b/qa/TL1_separate_executor/test_paddle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
-# used pip packages
-pip_packages="paddle"
+# used pip packages# rarfile>= 3.2 breaks python 3.5 compatibility
+pip_packages="paddle rarfile<=3.1"
 target_dir=./dali/test/python
 one_config_only=true
 

--- a/qa/TL2_FW_iterators_perf/test.sh
+++ b/qa/TL2_FW_iterators_perf/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 # used pip packages
 # TODO(janton): remove explicit pillow version installation when torch fixes the issue with PILLOW_VERSION not being defined
-pip_packages="pillow==6.2.2 tensorflow-gpu torchvision mxnet torch paddle"
+# rarfile>= 3.2 breaks python 3.5 compatibility
+pip_packages="pillow==6.2.2 tensorflow-gpu torchvision mxnet torch paddle rarfile<=3.1"
 target_dir=./dali/test/python
 one_config_only=true
 

--- a/qa/TL3_RN50_convergence/test_paddle.sh
+++ b/qa/TL3_RN50_convergence/test_paddle.sh
@@ -9,7 +9,8 @@ function CLEAN_AND_EXIT {
 }
 
 export USE_CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*) | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1\2/')
-pip install $(python /opt/dali/qa/setup_packages.py -i 0 -u paddle --cuda ${USE_CUDA_VERSION})
+# rarfile>= 3.2 breaks python 3.5 compatibility
+pip install "$(python /opt/dali/qa/setup_packages.py -i 0 -u paddle --cuda ${USE_CUDA_VERSION}) rarfile<=3.1"
 
 cd /opt/dali/docs/examples/use_cases/paddle/resnet50
 


### PR DESCRIPTION
- with the recent release of rarfile version 3.2, PaddlePaddle depends on Python 3.5 support is broken so DALI need to pin version to <=3.1 to keep the compatibility as long as we support Python 3.5

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes PaddlePaddle test broken by rarfile update not compatible with Python 3.5

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     pins rarfile version to <=3.1
 - Affected modules and functionalities:
     PaddlePaddle tests
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
