### PR TITLE
Add missing  and a pratial check in linter for this include file.

### DIFF
--- a/dali/core/per_stream_pool_test.cu
+++ b/dali/core/per_stream_pool_test.cu
@@ -14,6 +14,7 @@
 
 #include "dali/core/per_stream_pool.h"  // NOLINT
 #include <gtest/gtest.h>
+#include <atomic>
 #include <chrono>
 #include <iostream>
 #include <thread>

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -15,6 +15,7 @@
 #ifndef DALI_PIPELINE_EXECUTOR_EXECUTOR_H_
 #define DALI_PIPELINE_EXECUTOR_EXECUTOR_H_
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <queue>

--- a/third_party/cpplint.py
+++ b/third_party/cpplint.py
@@ -5331,6 +5331,7 @@ def ExpectingFunctionArgs(clean_lines, linenum):
 
 
 _HEADERS_CONTAINING_TEMPLATES = (
+    ('<atomic>', ('atomic',)),
     ('<deque>', ('deque',)),
     ('<functional>', ('unary_function', 'binary_function',
                       'plus', 'minus', 'multiplies', 'divides', 'modulus',


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug - missing `#include <atomic>`
- It adds a test for that include in linter (but it only catches `std::atomic<>`, not `atomic_flag`)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added the include
     * Added the check in the linter
     * Added missing include where improved linter detected lacking include
 - Affected modules and functionalities:
     * per-stream pool test
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * N/A
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A\
