### PR TITLE
Add libprotobuf-static as DALI conda build dependency

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -63,8 +63,7 @@ requirements:
     - python
     - future >=0.17.1
     - protobuf >=3.11.2
-    # h8b12597_1 misses static libs inside
-    - libprotobuf >=3.11.2 h8b12597_0
+    - libprotobuf-static >=3.11.2
     - libjpeg-turbo >=2.0.3
     - tensorflow-gpu =2.2.0
     - tensorflow-estimator =2.2.0


### PR DESCRIPTION
- static libprotobuf is reinstantiated inside libprotobuf-static so add it inside conda DALI build configuration

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds libprotobuf-static as DALI conda build dependency

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
      add libprotobuf-static inside conda DALI build configuration
 - Affected modules and functionalities:
     conda build
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA

AD https://github.com/conda-forge/libprotobuf-feedstock/issues/60

**JIRA TASK**: *[NA]*
