### PR TITLE
Fix layout propagation in Erase

### DIFF
--- a/dali/operators/generic/erase/erase.cc
+++ b/dali/operators/generic/erase/erase.cc
@@ -176,6 +176,7 @@ template <typename T, int Dims>
 void EraseImplCpu<T, Dims>::RunImpl(HostWorkspace &ws) {
   const auto &input = ws.InputRef<CPUBackend>(0);
   auto &output = ws.OutputRef<CPUBackend>(0);
+  output.SetLayout(input.GetLayout());
   int nsamples = input.size();
   auto& thread_pool = ws.GetThreadPool();
   auto in_shape = input.shape();

--- a/dali/operators/generic/erase/erase.cu
+++ b/dali/operators/generic/erase/erase.cu
@@ -68,8 +68,11 @@ class EraseImplGpu : public OpImplBase<GPUBackend> {
   };
 
   void RunImpl(workspace_t<GPUBackend> &ws) override {
-    auto input = view<const T, Dims>(ws.template InputRef<GPUBackend>(0));
-    auto output = view<T, Dims>(ws.template OutputRef<GPUBackend>(0));
+    const auto &input_ref = ws.template InputRef<GPUBackend>(0);
+    auto &output_ref = ws.template OutputRef<GPUBackend>(0);
+    output_ref.SetLayout(input_ref.GetLayout());
+    auto input = view<const T, Dims>(input_ref);
+    auto output = view<T, Dims>(output_ref);
     auto regions_view = view<kernels::ibox<Dims>, 1>(regions_gpu_);
     kmgr_.Run<EraseKernel>(0, 0, ctx_, output, input, regions_view, make_cspan(fill_values_));
   }

--- a/dali/test/python/test_operator_erase.py
+++ b/dali/test/python/test_operator_erase.py
@@ -124,10 +124,12 @@ class ErasePythonPipeline(Pipeline):
         function = partial(erase_func, anchor, shape, axis_names, axes, data_layout, fill_value)
 
         self.erase = ops.PythonFunction(function=function)
+        self.set_layout = ops.Reshape(layout=data_layout)
 
     def define_graph(self):
         self.data = self.inputs()
         out = self.erase(self.data)
+        out = self.set_layout(out)
         return out
 
     def iter_setup(self):
@@ -144,7 +146,7 @@ def check_operator_erase_vs_python(device, batch_size, input_shape,
                       shape=shape, axis_names=axis_names, axes=axes, fill_value=fill_value),
         ErasePythonPipeline(device, batch_size, input_layout, iter(eii2), anchor=anchor,
                             shape=shape, axis_names=axis_names, axes=axes, fill_value=fill_value),
-        batch_size=batch_size, N_iterations=5, eps=1e-04)
+        batch_size=batch_size, N_iterations=5, eps=1e-04, expected_layout=input_layout)
 
 
 def test_operator_erase_vs_python():

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -78,7 +78,22 @@ def get_gpu_num():
 
 
 # If the `max_allowed_error` is not None, it's checked instead of comparing mean error with `eps`.
-def check_batch(batch1, batch2, batch_size, eps=1e-07, max_allowed_error=None, expected_layout=None):
+def check_batch(
+        batch1, batch2, batch_size, eps=1e-07, max_allowed_error=None, expected_layout=None,
+        compare_layouts=False):
+    """Compare two batches of data, be it dali TensorList or list of numpy arrays.
+
+    Args:
+        batch1: input batch
+        batch2: input batch
+        batch_size
+        eps (float, optional): Used for mean error validation. Defaults to 1e-07.
+        max_allowed_error (int or float optional): If provided the max diff between elements.
+        expected_layout (str, optional): If provided, the batches that are DALI types will be checked
+            to match this layout. If None, there will be no check
+        compare_layouts (bool, optional): Whether to compare layouts between two batches.
+            Checked only if both inputs are DALI types. Defaults to False.
+    """
 
     def is_error(mean_err, max_err, eps, max_allowed_error):
         if max_allowed_error is not None:
@@ -99,14 +114,20 @@ def check_batch(batch1, batch2, batch_size, eps=1e-07, max_allowed_error=None, e
             assert batch.layout() == expected_layout, \
                 'Unexpected layout, expected "{}", got "{}".'.format(expected_layout, batch.layout())
 
+    if compare_layouts and \
+            isinstance(batch1, dali.backend.TensorListCPU) and \
+            isinstance(batch2, dali.backend.TensorListCPU):
+        assert batch1.layout() == batch2.layout(), \
+            'Layout mismatch "{}" != "{}"'.format(batch1.layout(), batch2.layout())
+
     for i in range(batch_size):
         # This allows to handle list of Tensors, list of np arrays and TensorLists
         left = np.array(batch1[i])
         right = np.array(batch2[i])
         is_failed = False
-        assert(left.shape == right.shape), \
+        assert left.shape == right.shape, \
             "Shape mismatch {} != {}".format(left.shape, right.shape)
-        assert(left.size == right.size), \
+        assert left.size == right.size, \
             "Size mismatch {} != {}".format(left.size, right.size)
         if left.size != 0:
             try:
@@ -133,7 +154,24 @@ def check_batch(batch1, batch2, batch_size, eps=1e-07, max_allowed_error=None, e
                     print(right)
                 assert False, error_msg
 
-def compare_pipelines(pipe1, pipe2, batch_size, N_iterations, eps=1e-07, expected_layout=None):
+
+def compare_pipelines(
+        pipe1, pipe2, batch_size, N_iterations, eps=1e-07, expected_layout=None,
+        compare_layouts=False):
+    """Compare the outputs of two pipelines across several iterations.
+
+    Args:
+        pipe1: input pipeline object
+        pipe2: input pipeline object
+        batch_size (int): batch size
+        N_iterations (int): Number of iterations used for comparison
+        eps (float, optional): Allowed mean error between samples. Defaults to 1e-07.
+        expected_layout (str or tuple of str, optional): If provided the outputs of both pipelines
+            will be matched with provided layouts and error will be raised if there is mismatch.
+            Defaults to None.
+        compare_layouts (bool, optional): Whether to compare layouts of outputs between pipelines.
+            Defaults to False.
+    """
     pipe1.build()
     pipe2.build()
     for _ in range(N_iterations):
@@ -147,7 +185,8 @@ def compare_pipelines(pipe1, pipe2, batch_size, N_iterations, eps=1e-07, expecte
                 current_expected_layout = expected_layout[i]
             else:
                 current_expected_layout = expected_layout
-            check_batch(out1_data, out2_data, batch_size, eps, expected_layout=current_expected_layout)
+            check_batch(out1_data, out2_data, batch_size, eps,
+                        expected_layout=current_expected_layout, compare_layouts=compare_layouts)
     print("OK: ({} iterations)".format(N_iterations))
 
 class RandomDataIterator(object):


### PR DESCRIPTION


Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fix layout propagation in Erase

#### What happened in this PR?
 - What solution was applied:
    SetLayout(GetLayout())
	Fixes both Erase CPU and GPU.
	Adjust compare_pipelines and check_batch to allow layout checking,
	the former can accept tuple of layouts or single value,
	the check is optional.
	Adjust Erase Python tests.	

 - Affected modules and functionalities:
     Erase, Python test utils.
 - Key points relevant for the review:
     NA
 - Validation and testing:
     Test adjusted
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1515]*
