### PR TITLE
Fix missing layouts in operators

### DIFF
--- a/dali/benchmark/operator_bench.h
+++ b/dali/benchmark/operator_bench.h
@@ -29,7 +29,8 @@ class OperatorBench : public DALIBenchmark {
   template <typename OutputContainer, typename OperatorPtr, typename Workspace>
   void Setup(OperatorPtr &op_ptr, const OpSpec &spec, Workspace &ws, int batch_size) {
     std::vector<OutputDesc> outputs;
-    if (op_ptr->CanInferOutputs() && op_ptr->Setup(outputs, ws)) {
+    bool can_infer_outs = op_ptr->CanInferOutputs();
+    if (op_ptr->Setup(outputs, ws) && can_infer_outs) {
       int num_out = outputs.size();
       for (int i = 0; i < num_out; i++) {
         auto data_out = std::make_shared<OutputContainer>(batch_size);

--- a/dali/core/tensor_layout_test.cc
+++ b/dali/core/tensor_layout_test.cc
@@ -273,4 +273,21 @@ TEST(TensorLayout, GetLayoutMapping) {
   }
 }
 
+TEST(TensorLayout, Resize) {
+  TensorLayout layout;
+  EXPECT_EQ(layout, "");
+
+  layout.resize(3);
+  EXPECT_EQ(layout, "???");
+
+  layout = "HW";
+  EXPECT_EQ(layout, "HW");
+
+  layout.resize(3);
+  EXPECT_EQ(layout, "HW?");
+
+  layout.resize(4, '#');
+  EXPECT_EQ(layout, "HW?#");
+}
+
 }  // namespace dali

--- a/dali/operators/generic/flip.cc
+++ b/dali/operators/generic/flip.cc
@@ -66,7 +66,7 @@ void Flip<CPUBackend>::RunImpl(Workspace<CPUBackend> &ws) {
   auto _horizontal = GetHorizontal(ws, ws.data_idx());
   auto _vertical = GetVertical(ws, ws.data_idx());
   auto _depthwise = GetDepthwise(ws, ws.data_idx());
-  if (!_horizontal && !_vertical) {
+  if (!_horizontal && !_vertical && !_depthwise) {
     output.Copy(input, nullptr);
   } else {
     RunFlip(output, input, InputLayout(ws, 0), _horizontal, _vertical, _depthwise);

--- a/dali/operators/generic/flip.cc
+++ b/dali/operators/generic/flip.cc
@@ -60,7 +60,8 @@ template <>
 void Flip<CPUBackend>::RunImpl(Workspace<CPUBackend> &ws) {
   const auto &input = ws.Input<CPUBackend>(0);
   auto &output = ws.Output<CPUBackend>(0);
-  output.SetLayout(input.GetLayout());
+  auto layout = input.GetLayout();
+  output.SetLayout(layout);
   output.set_type(input.type());
   output.ResizeLike(input);
   auto _horizontal = GetHorizontal(ws, ws.data_idx());
@@ -69,7 +70,7 @@ void Flip<CPUBackend>::RunImpl(Workspace<CPUBackend> &ws) {
   if (!_horizontal && !_vertical && !_depthwise) {
     output.Copy(input, nullptr);
   } else {
-    RunFlip(output, input, InputLayout(ws, 0), _horizontal, _vertical, _depthwise);
+    RunFlip(output, input, layout, _horizontal, _vertical, _depthwise);
   }
 }
 

--- a/dali/operators/generic/lookup_table.cc
+++ b/dali/operators/generic/lookup_table.cc
@@ -20,6 +20,7 @@ template<>
 void LookupTable<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   const auto &input = ws.Input<CPUBackend>(0);
   auto &output = ws.Output<CPUBackend>(0);
+  output.SetLayout(input.GetLayout());
   auto data_size = input.size();
   TYPE_SWITCH(input.type().id(), dali::type2id, InputType,
               (uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t), (

--- a/dali/operators/generic/lookup_table.cu
+++ b/dali/operators/generic/lookup_table.cu
@@ -55,6 +55,7 @@ template<>
 void LookupTable<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   const auto &input = ws.Input<GPUBackend>(0);
   auto &output = ws.Output<GPUBackend>(0);
+  output.SetLayout(input.GetLayout());
   auto data_size = input.size();
   constexpr int kThreads = 512;
   const int blocks = (data_size + kThreads - 1) / kThreads;

--- a/dali/operators/generic/pad.cc
+++ b/dali/operators/generic/pad.cc
@@ -217,6 +217,7 @@ template <>
 void Pad<CPUBackend>::RunImpl(workspace_t<CPUBackend> &ws) {
   const auto &input = ws.InputRef<CPUBackend>(0);
   auto &output = ws.OutputRef<CPUBackend>(0);
+  output.SetLayout(input.GetLayout());
   int nsamples = input.size();
   int ndim = input.shape().sample_dim();
   auto& thread_pool = ws.GetThreadPool();

--- a/dali/operators/generic/pad.cu
+++ b/dali/operators/generic/pad.cu
@@ -57,6 +57,7 @@ template <>
 void Pad<GPUBackend>::RunImpl(workspace_t<GPUBackend> &ws) {
   const auto &input = ws.Input<GPUBackend>(0);
   auto &output = ws.Output<GPUBackend>(0);
+  output.SetLayout(input.GetLayout());
   int ndim = input.shape().sample_dim();
   TYPE_SWITCH(input.type().id(), type2id, T, PAD_SUPPORTED_TYPES, (
     VALUE_SWITCH(ndim, Dims, PAD_SUPPORTED_NDIMS, (

--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -324,7 +324,8 @@ TensorLayout Reshape<Backend>::GetOutputLayout(const Workspace &ws) const {
     // layout was explicitly cleared
     return TensorLayout();
   }
-  auto in_layout = this->InputLayout(ws, 0);
+  auto &in = ws.template InputRef<Backend>(0);
+  auto in_layout = in.GetLayout();
   return in_layout.ndim() == output_shape_.sample_dim() ? in_layout : TensorLayout();
 }
 

--- a/dali/operators/image/color/brightness_contrast.cc
+++ b/dali/operators/image/color/brightness_contrast.cc
@@ -81,7 +81,7 @@ bool BrightnessContrastCpu::SetupImpl(std::vector<OutputDesc> &output_desc,
 void BrightnessContrastCpu::RunImpl(workspace_t<CPUBackend> &ws) {
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto &output = ws.template OutputRef<CPUBackend>(0);
-  output.SetLayout(InputLayout(ws, 0));
+  output.SetLayout(input.GetLayout());
   auto out_shape = output.shape();
   auto& tp = ws.GetThreadPool();
   TYPE_SWITCH(input.type().id(), type2id, InputType, (uint8_t, int16_t, int32_t, float), (

--- a/dali/operators/image/color/brightness_contrast.cu
+++ b/dali/operators/image/color/brightness_contrast.cu
@@ -55,7 +55,7 @@ bool BrightnessContrastGpu::SetupImpl(std::vector<OutputDesc> &output_desc,
 void BrightnessContrastGpu::RunImpl(workspace_t<GPUBackend> &ws) {
   const auto &input = ws.template Input<GPUBackend>(0);
   auto &output = ws.template Output<GPUBackend>(0);
-  output.SetLayout(InputLayout(ws, 0));
+  output.SetLayout(input.GetLayout());
   TYPE_SWITCH(input.type().id(), type2id, InputType, (uint8_t, int16_t, int32_t, float), (
       TYPE_SWITCH(output_type_, type2id, OutputType, (uint8_t, int16_t, int32_t, float), (
           {

--- a/dali/operators/image/color/color_space_conversion.cc
+++ b/dali/operators/image/color/color_space_conversion.cc
@@ -36,6 +36,7 @@ void ColorSpaceConversion<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
   const auto &input_shape = input.shape();
   auto output_shape = input_shape;
+  output.SetLayout(input.GetLayout());
 
   const auto H = input_shape[0];
   const auto W = input_shape[1];

--- a/dali/operators/image/color/color_space_conversion.cu
+++ b/dali/operators/image/color/color_space_conversion.cu
@@ -96,6 +96,7 @@ void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   DALI_ENFORCE(IsType<uint8_t>(input.type()),
       "Color space conversion accept only uint8 tensors");
   auto &output = ws.Output<GPUBackend>(0);
+  output.SetLayout(input.GetLayout());
 
   TensorList<CPUBackend> attr_output_cpu;
 

--- a/dali/operators/image/color/color_space_conversion.cu
+++ b/dali/operators/image/color/color_space_conversion.cu
@@ -96,7 +96,8 @@ void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   DALI_ENFORCE(IsType<uint8_t>(input.type()),
       "Color space conversion accept only uint8 tensors");
   auto &output = ws.Output<GPUBackend>(0);
-  output.SetLayout(input.GetLayout());
+  auto layout = input.GetLayout();
+  output.SetLayout(layout);
 
   TensorList<CPUBackend> attr_output_cpu;
 
@@ -118,7 +119,7 @@ void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   auto stream = ws.stream();
   DALI_CHECK_NPP(nppSetStream(stream));
 
-  if (InputLayout(ws, 0) == "HWC") {
+  if (layout == "HWC") {
     // RGB -> BGR || BGR -> RGB
     for (unsigned int i = 0; i < input.ntensor(); ++i) {
       // image dimensions

--- a/dali/operators/image/color/color_twist.cc
+++ b/dali/operators/image/color/color_twist.cc
@@ -168,7 +168,7 @@ void ColorTwistCpu::RunImpl(workspace_t<CPUBackend> &ws) {
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto &output = ws.template OutputRef<CPUBackend>(0);
   auto out_shape = output.shape();
-  output.SetLayout(InputLayout(ws, 0));
+  output.SetLayout(input.GetLayout());
   auto &tp = ws.GetThreadPool();
   TYPE_SWITCH(input.type().id(), type2id, InputType, (uint8_t, int16_t, int32_t, float, float16), (
       TYPE_SWITCH(output_type_, type2id, OutputType, (uint8_t, int16_t, int32_t, float, float16), (

--- a/dali/operators/image/color/color_twist.cu
+++ b/dali/operators/image/color/color_twist.cu
@@ -54,7 +54,7 @@ bool ColorTwistGpu::SetupImpl(std::vector<OutputDesc> &output_desc, const Device
 void ColorTwistGpu::RunImpl(workspace_t<GPUBackend> &ws) {
   const auto &input = ws.template Input<GPUBackend>(0);
   auto &output = ws.template Output<GPUBackend>(0);
-  output.SetLayout(InputLayout(ws, 0));
+  output.SetLayout(input.GetLayout());
   TYPE_SWITCH(input.type().id(), type2id, InputType, (uint8_t, int16_t, int32_t, float), (
       TYPE_SWITCH(output_type_, type2id, OutputType, (uint8_t, int16_t, int32_t, float), (
           {

--- a/dali/operators/image/color/old_color_twist.cc
+++ b/dali/operators/image/color/old_color_twist.cc
@@ -217,7 +217,7 @@ void OldColorTwistBase<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   DALI_ENFORCE(IsType<uint8_t>(input.type()), "Color augmentations accept only uint8 tensors");
   auto &output = ws.Output<GPUBackend>(0);
   output.ResizeLike(input);
-  output.SetLayout(InputLayout(ws, 0));
+  output.SetLayout(input.GetLayout());
 
   cudaStream_t old_stream = nppGetStream();
   nppSetStream(ws.stream());
@@ -259,7 +259,7 @@ void OldColorTwistBase<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   const auto C = input_shape[2];
 
   output.ResizeLike(input);
-  output.SetLayout(InputLayout(ws, 0));
+  output.SetLayout(input.GetLayout());
 
   auto pImgInp = input.template data<uint8>();
   auto pImgOut = output.template mutable_data<uint8>();

--- a/dali/operators/image/crop/crop_mirror_normalize.h
+++ b/dali/operators/image/crop/crop_mirror_normalize.h
@@ -164,7 +164,7 @@ class CropMirrorNormalize : public Operator<Backend> {
       output_type_ = input_type_;
 
     auto in_shape = input.shape();
-    input_layout_ = this->InputLayout(ws, 0);
+    input_layout_ = input.GetLayout();
     DALI_ENFORCE(ImageLayoutInfo::IsImage(input_layout_),
       ("Unsupported layout: '" + input_layout_.str() + "' for input 0 '" +
       this->spec_.InputName(0) + "'"));

--- a/dali/operators/image/remap/displacement_filter_impl_cpu.h
+++ b/dali/operators/image/remap/displacement_filter_impl_cpu.h
@@ -165,7 +165,7 @@ class DisplacementFilter<CPUBackend, Displacement, per_channel_transform>
     auto &input = ws.Input<CPUBackend>(0);
     auto &output = ws.Output<CPUBackend>(0);
     output.ResizeLike(input);
-    output.SetLayout(InputLayout(ws, 0));
+    output.SetLayout(input.GetLayout());
   }
 
   void SetupSharedSampleParams(SampleWorkspace &ws) override {

--- a/dali/operators/image/remap/displacement_filter_impl_gpu.cuh
+++ b/dali/operators/image/remap/displacement_filter_impl_gpu.cuh
@@ -248,7 +248,7 @@ class DisplacementFilter<GPUBackend, Displacement,
     auto &input = ws.Input<GPUBackend>(0);
     auto &output = ws.Output<GPUBackend>(0);
     output.ResizeLike(input);
-    output.SetLayout(InputLayout(ws, 0));
+    output.SetLayout(input.GetLayout());
   }
 
   template <typename U = Displacement>

--- a/dali/operators/image/remap/warp.h
+++ b/dali/operators/image/remap/warp.h
@@ -331,7 +331,9 @@ class Warp : public Operator<Backend> {
   void RunImpl(Workspace &ws) override {
     assert(impl_);
     impl_->Run(ws);
-    ws.template OutputRef<Backend>(0).SetLayout(this->InputLayout(ws, 0));
+    auto &out = ws.template OutputRef<Backend>(0);
+    auto &in = ws.template InputRef<Backend>(0);
+    out.SetLayout(in.GetLayout());
   }
 
  protected:

--- a/dali/operators/image/resize/random_resized_crop.cc
+++ b/dali/operators/image/resize/random_resized_crop.cc
@@ -56,7 +56,7 @@ void RandomResizedCrop<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
 
   RunCPU(output, input, ws.thread_idx());
-  output.SetLayout(InputLayout(ws, 0));
+  output.SetLayout(input.GetLayout());
 }
 
 template<>

--- a/dali/operators/image/resize/random_resized_crop.cu
+++ b/dali/operators/image/resize/random_resized_crop.cu
@@ -38,7 +38,7 @@ void RandomResizedCrop<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
 
   auto &output = ws.Output<GPUBackend>(0);
   RunGPU(output, input, ws.stream());
-  output.SetLayout(InputLayout(ws, 0));
+  output.SetLayout(input.GetLayout());
 }
 
 template<>

--- a/dali/operators/image/resize/resize.cc
+++ b/dali/operators/image/resize/resize.cc
@@ -112,7 +112,7 @@ void Resize<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   }
 
   RunCPU(output, input, thread_idx);
-  output.SetLayout(InputLayout(ws, 0));
+  output.SetLayout(input.GetLayout());
 
   if (save_attrs_) {
     auto &attr_output = ws.Output<CPUBackend>(1);

--- a/dali/operators/image/resize/resize.cu
+++ b/dali/operators/image/resize/resize.cu
@@ -62,7 +62,7 @@ void Resize<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   auto &output = ws.Output<GPUBackend>(0);
 
   RunGPU(output, input, ws.stream());
-  output.SetLayout(InputLayout(ws, 0));
+  output.SetLayout(input.GetLayout());
 
   // Setup and output the resize attributes if necessary
   if (save_attrs_) {

--- a/dali/operators/image/resize/resize_crop_mirror.h
+++ b/dali/operators/image/resize/resize_crop_mirror.h
@@ -239,7 +239,7 @@ class ResizeCropMirror : public Operator<CPUBackend>, protected ResizeCropMirror
     // Resize the output & run
     output.Resize(
         std::vector<Index>{crop_height_[ws.data_idx()], crop_width_[ws.data_idx()], meta.C});
-    output.SetLayout(this->InputLayout(ws, 0));
+    output.SetLayout(input.GetLayout());
 
     tl_workspace_[ws.thread_idx()].resize(meta.rsz_h*meta.rsz_w*meta.C);
     DALI_CALL((*func)(

--- a/dali/operators/math/normalize/normalize.cc
+++ b/dali/operators/math/normalize/normalize.cc
@@ -236,6 +236,7 @@ void Normalize<CPUBackend>::RunTyped(HostWorkspace &ws) {
 
   auto &output = ws.OutputRef<CPUBackend>(0);
   TensorListView<StorageCPU, OutputType> out_view = view<OutputType>(output);
+  output.SetLayout(input.GetLayout());
 
   int nsamples = input.ntensor();
   int nthreads = ws.GetThreadPool().size();

--- a/dali/operators/math/normalize/normalize.h
+++ b/dali/operators/math/normalize/normalize.h
@@ -132,7 +132,8 @@ class NormalizeBase : public Operator<Backend> {
         GetParamShapeFromAxes();
     } else if (has_axis_names_arg_) {
       TensorLayout names = spec.GetArgument<TensorLayout>("axis_names");
-      auto dim_idx = GetDimIndices(this->InputLayout(ws, 0), names);
+      const auto &input = ws.template InputRef<Backend>(0);
+      auto dim_idx = GetDimIndices(input.GetLayout(), names);
       axes_ = dim_idx.to_vector();
       SetAxisMask();
       if (!has_tensor_mean_ && !has_tensor_stddev_)

--- a/dali/operators/math/normalize/normalize_gpu.cu
+++ b/dali/operators/math/normalize/normalize_gpu.cu
@@ -207,6 +207,7 @@ void Normalize<GPUBackend>::RunTyped(DeviceWorkspace &ws) {
 
   auto &output = ws.OutputRef<GPUBackend>(0);
   TensorListView<StorageGPU, OutputType> out_view = view<OutputType>(output);
+  output.SetLayout(input.GetLayout());
 
   int nsamples = input.ntensor();
 

--- a/dali/operators/random/normal_distribution_op.h
+++ b/dali/operators/random/normal_distribution_op.h
@@ -141,6 +141,7 @@ class NormalDistributionCpu : public NormalDistribution<CPUBackend> {
 
  protected:
   void RunImpl(workspace_t<CPUBackend> &ws) override;
+  using NormalDistribution<CPUBackend>::RunImpl;
 
  private:
   void AssignTensorToOutput(workspace_t<CPUBackend> &ws);

--- a/dali/operators/sequence/optical_flow/optical_flow.cc
+++ b/dali/operators/sequence/optical_flow/optical_flow.cc
@@ -69,7 +69,7 @@ void OpticalFlow<GPUBackend>::RunImpl(Workspace<GPUBackend> &ws) {
     const auto &input = ws.Input<GPUBackend>(0);
     const auto &hints = ws.Input<GPUBackend>(1);
     auto &output = ws.Output<GPUBackend>(0);
-
+    output.SetLayout("HWC");  // Channels represent the two flow vector components (x and y)
     // Extract calculation params
     ExtractParams(input, hints);
 

--- a/dali/operators/sequence/optical_flow/optical_flow.cc
+++ b/dali/operators/sequence/optical_flow/optical_flow.cc
@@ -109,7 +109,7 @@ void OpticalFlow<GPUBackend>::RunImpl(Workspace<GPUBackend> &ws) {
     // Input is a TensorList, where every Tensor is a sequence
     const auto &input = ws.Input<GPUBackend>(0);
     auto &output = ws.Output<GPUBackend>(0);
-
+    output.SetLayout(input.GetLayout());
 
     // Extract calculation params
     ExtractParams(input);

--- a/dali/operators/ssd/random_crop.cc
+++ b/dali/operators/ssd/random_crop.cc
@@ -273,6 +273,7 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace &ws) {
       // now we know how many output bboxes there will be, we can allocate
       // the output.
       auto &img_out = ws.Output<CPUBackend>(0);
+      img_out.SetLayout(img.GetLayout());
       auto &bbox_out = ws.Output<CPUBackend>(1);
       auto &label_out = ws.Output<CPUBackend>(2);
 
@@ -312,7 +313,7 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace &ws) {
 
       // perform the crop
       detail::crop(img, {left_idx, top_idx, right_idx, bottom_idx},
-                   ws.Output<CPUBackend>(0));
+                   img_out);
 
       return;
     }  // end num_attempts loop

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -226,10 +226,15 @@ class TensorVector {
 
   inline TensorLayout GetLayout() const {
     if (state_ == State::contiguous) {
-      return tl_->GetLayout();
+      auto layout = tl_->GetLayout();
+      if (!layout.empty())
+        return layout;
     }
     if (tensors_.size() > 0) {
-      return tensors_[0]->GetLayout();
+      auto layout = tensors_[0]->GetLayout();
+      for (size_t i = 1; i < tensors_.size(); i++)
+        assert(layout == tensors_[i]->GetLayout());
+      return layout;
     }
     return {};
   }

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -339,6 +339,17 @@ class DLL_PUBLIC Executor : public ExecutorBase, public WorkspacePolicy, public 
   std::mutex gpu_memory_stats_mutex_;
 
  private:
+  template <typename InputRef>
+  static bool SetDefaultLayoutIfNeeded(InputRef &in, const OpSchema &schema, int in_idx) {
+    if (!in.GetLayout().empty())
+      return false;
+    auto default_layout = schema.GetInputLayout(in_idx, in.shape().sample_dim(), in.GetLayout());
+    if (default_layout.empty())
+      return false;
+    in.SetLayout(default_layout);
+    return true;
+  }
+
   template <typename Workspace>
   void RunHelper(OpNode &op_node, Workspace &ws) {
     auto &output_desc = op_node.output_desc;
@@ -348,23 +359,14 @@ class DLL_PUBLIC Executor : public ExecutorBase, public WorkspacePolicy, public 
     const auto &schema = spec.GetSchema();
     SmallVector<int, 16> empty_layout_in_idxs;
     for (int i = 0; i < spec.NumRegularInput(); i++) {
+      bool had_empty_layout = false;
       if (ws.template InputIsType<CPUBackend>(i)) {
-        auto &in = ws.template InputRef<CPUBackend>(i);
-        bool empty_in_layout = in.GetLayout().empty();
-        auto layout = schema.GetInputLayout(i, in.shape().sample_dim(), in.GetLayout());
-        if (!empty_in_layout || layout.empty())
-          continue;
-        in.SetLayout(layout);
-        empty_layout_in_idxs.push_back(i);
+        had_empty_layout = SetDefaultLayoutIfNeeded(ws.template InputRef<CPUBackend>(i), schema, i);
       } else {
-        auto &in = ws.template InputRef<GPUBackend>(i);
-        bool empty_in_layout = in.GetLayout().empty();
-        auto layout = schema.GetInputLayout(i, in.shape().sample_dim(), in.GetLayout());
-        if (!empty_in_layout || layout.empty())
-          continue;
-        in.SetLayout(layout);
-        empty_layout_in_idxs.push_back(i);
+        had_empty_layout = SetDefaultLayoutIfNeeded(ws.template InputRef<GPUBackend>(i), schema, i);
       }
+      if (had_empty_layout)
+        empty_layout_in_idxs.push_back(i);
     }
 
     if (op.Setup(output_desc, ws)) {

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -316,9 +316,10 @@ class Operator<CPUBackend> : public OperatorBase {
       auto &out = ws.template OutputRef<CPUBackend>(0);
       auto in_layout = in.GetLayout();
       auto out_layout = out.GetLayout();
-      DALI_ENFORCE(!out_layout.empty() || in_layout.empty() || spec_.name() == "DLTensorPythonFunctionImpl",
-                   make_string("Operator: ", spec_.name(),
-                               " produced an empty layout. Input layout was ", in_layout));
+      DALI_ENFORCE(
+          !out_layout.empty() || in_layout.empty() || spec_.name() == "DLTensorPythonFunctionImpl",
+          make_string("Operator: ", spec_.name(), " produced an empty layout. Input layout was ",
+                      in_layout));
     }
   }
 
@@ -395,9 +396,10 @@ class Operator<GPUBackend> : public OperatorBase {
       auto &out = ws.template OutputRef<GPUBackend>(0);
       auto in_layout = in.GetLayout();
       auto out_layout = out.GetLayout();
-      DALI_ENFORCE(!out_layout.empty() || in_layout.empty(),
-                   make_string("Operator: ", spec_.name(),
-                               " produced an empty layout. Input layout was ", in_layout));
+      DALI_ENFORCE(
+          !out_layout.empty() || in_layout.empty() || spec_.name() == "DLTensorPythonFunctionImpl",
+          make_string("Operator: ", spec_.name(), " produced an empty layout. Input layout was ",
+                      in_layout));
     }
   }
 

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -316,7 +316,7 @@ class Operator<CPUBackend> : public OperatorBase {
       auto &out = ws.template OutputRef<CPUBackend>(0);
       auto in_layout = in.GetLayout();
       auto out_layout = out.GetLayout();
-      DALI_ENFORCE(!out_layout.empty() || in_layout.empty(),
+      DALI_ENFORCE(!out_layout.empty() || in_layout.empty() || spec_.name() == "DLTensorPythonFunctionImpl",
                    make_string("Operator: ", spec_.name(),
                                " produced an empty layout. Input layout was ", in_layout));
     }

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -310,6 +310,16 @@ class Operator<CPUBackend> : public OperatorBase {
     SetupSharedSampleParams(ws);
     RunImpl(ws);
     ws.GetThreadPool().WaitForWork();
+
+    if (ws.NumInput() > 0 && ws.NumOutput() > 0) {
+      auto &in = ws.template InputRef<CPUBackend>(0);
+      auto &out = ws.template OutputRef<CPUBackend>(0);
+      auto in_layout = in.GetLayout();
+      auto out_layout = out.GetLayout();
+      DALI_ENFORCE(!out_layout.empty() || in_layout.empty(),
+                   make_string("Operator: ", spec_.name(),
+                               " produced an empty layout. Input layout was ", in_layout));
+    }
   }
 
   /**
@@ -380,6 +390,15 @@ class Operator<GPUBackend> : public OperatorBase {
     CheckInputLayouts(ws, spec_);
     SetupSharedSampleParams(ws);
     RunImpl(ws);
+    if (ws.NumInput() > 0 && ws.NumOutput() > 0) {
+      auto &in = ws.template InputRef<CPUBackend>(0);
+      auto &out = ws.template OutputRef<CPUBackend>(0);
+      auto in_layout = in.GetLayout();
+      auto out_layout = out.GetLayout();
+      DALI_ENFORCE(!out_layout.empty() || in_layout.empty(),
+                   make_string("Operator: ", spec_.name(),
+                               " produced an empty layout. Input layout was ", in_layout));
+    }
   }
 
   /**

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -172,9 +172,8 @@ class DLL_PUBLIC OperatorBase {
     return {};
   }
 
-  template <typename Workspace>
-  TensorLayout InputLayout(const Workspace &ws, int index) const {
-    return GetInputLayout(ws, spec_.GetSchema(), index);
+  DLL_PUBLIC const OpSpec& GetSpec() const {
+    return spec_;
   }
 
   DLL_PUBLIC bool CanBePruned() const {

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -319,15 +319,6 @@ class Operator<CPUBackend> : public OperatorBase {
     SetupSharedSampleParams(ws);
     RunImpl(ws);
     ws.GetThreadPool().WaitForWork();
-
-    if (ws.NumInput() > 0 && ws.NumOutput() > 0) {
-      auto in_layout = GetInputLayout(ws, 0);
-      auto out_layout = GetOutputLayout(ws, 0);
-      DALI_ENFORCE(
-          !out_layout.empty() || in_layout.empty() || spec_.name() == "DLTensorPythonFunctionImpl",
-          make_string("Operator: ", spec_.name(), " produced an empty layout. Input layout was ",
-                      in_layout));
-    }
   }
 
   /**
@@ -398,14 +389,6 @@ class Operator<GPUBackend> : public OperatorBase {
     CheckInputLayouts(ws, spec_);
     SetupSharedSampleParams(ws);
     RunImpl(ws);
-    if (ws.NumInput() > 0 && ws.NumOutput() > 0) {
-      auto in_layout = GetInputLayout(ws, 0);
-      auto out_layout = GetOutputLayout(ws, 0);
-      DALI_ENFORCE(
-          !out_layout.empty() || in_layout.empty() || spec_.name() == "DLTensorPythonFunctionImpl",
-          make_string("Operator: ", spec_.name(), " produced an empty layout. Input layout was ",
-                      in_layout));
-    }
   }
 
   /**

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -391,8 +391,8 @@ class Operator<GPUBackend> : public OperatorBase {
     SetupSharedSampleParams(ws);
     RunImpl(ws);
     if (ws.NumInput() > 0 && ws.NumOutput() > 0) {
-      auto &in = ws.template InputRef<CPUBackend>(0);
-      auto &out = ws.template OutputRef<CPUBackend>(0);
+      auto &in = ws.template InputRef<GPUBackend>(0);
+      auto &out = ws.template OutputRef<GPUBackend>(0);
       auto in_layout = in.GetLayout();
       auto out_layout = out.GetLayout();
       DALI_ENFORCE(!out_layout.empty() || in_layout.empty(),

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -431,8 +431,8 @@ def python_op_factory(name, op_device = "cpu"):
             if (len(inputs) > self._schema.MaxNumInput() or
                     len(inputs) < self._schema.MinNumInput()):
                 raise ValueError(
-                    ("Operator {} expects [{}, " +
-                    "{}] inputs, but received {}")
+                    ("Operator {} expects from {} to " +
+                    "{} inputs, but received {}.")
                     .format(type(self).__name__,
                             self._schema.MinNumInput(),
                             self._schema.MaxNumInput(),
@@ -599,8 +599,8 @@ class TFRecordReader(metaclass=_DaliOperatorMeta):
         if (len(inputs) > self._schema.MaxNumInput() or
                 len(inputs) < self._schema.MinNumInput()):
             raise ValueError(
-                ("Operator {} expects [{}, " +
-                "{}] inputs, but received {}")
+                ("Operator {} expects from {} to " +
+                "{} inputs, but received {}.")
                 .format(type(self).__name__,
                         self._schema.MinNumInput(),
                         self._schema.MaxNumInput(),
@@ -668,8 +668,8 @@ class PythonFunctionBase(metaclass=_DaliOperatorMeta):
         if (len(inputs) > self._schema.MaxNumInput() or
                 len(inputs) < self._schema.MinNumInput()):
             raise ValueError(
-                ("Operator {} expects [{}, " +
-                 "{}] inputs, but received {}")
+                ("Operator {} expects from {} to " +
+                 "{} inputs, but received {}.")
                 .format(type(self).__name__,
                         self._schema.MinNumInput(),
                         self._schema.MaxNumInput(),

--- a/dali/test/plugins/dummy/dummy.cc
+++ b/dali/test/plugins/dummy/dummy.cc
@@ -22,6 +22,7 @@ void Dummy<::dali::CPUBackend>::RunImpl(::dali::SampleWorkspace &ws) {
   auto &output = ws.Output<::dali::CPUBackend>(0);
   output.set_type(input.type());
   output.ResizeLike(input);
+  output.SetLayout(input.GetLayout());
 
   ::dali::TypeInfo type = input.type();
   type.Copy<::dali::CPUBackend, ::dali::CPUBackend>(

--- a/dali/test/plugins/dummy/dummy.cu
+++ b/dali/test/plugins/dummy/dummy.cu
@@ -23,6 +23,7 @@ void Dummy<::dali::GPUBackend>::RunImpl(::dali::DeviceWorkspace &ws) {
   auto &output = ws.Output<::dali::GPUBackend>(0);
   output.set_type(input.type());
   output.ResizeLike(input);
+  output.SetLayout(input.GetLayout());
   CUDA_CALL(cudaMemcpyAsync(
           output.raw_mutable_data(),
           input.raw_data(),

--- a/dali/test/python/test_operator_crop.py
+++ b/dali/test/python/test_operator_crop.py
@@ -119,11 +119,13 @@ class CropSequencePythonOpPipeline(Pipeline):
         self.layout = layout
         self.iterator = iterator
         self.inputs = ops.ExternalSource()
-        self.crop = ops.PythonFunction(function=function)
+        self.crop = ops.PythonFunction(function = function)
+        self.set_layout = ops.Reshape(layout = layout)
 
     def define_graph(self):
         self.data = self.inputs()
         out = self.crop(self.data)
+        out = self.set_layout(out)
         return out
 
     def iter_setup(self):
@@ -290,11 +292,13 @@ class Crop3dPythonOpPipeline(Pipeline):
         def crop_func(image):
             return function(image, layout=self.data_layout, shape=self.data_shape)
 
-        self.crop = ops.PythonFunction(function=crop_func)
+        self.crop = ops.PythonFunction(function = crop_func)
+        self.set_layout = ops.Reshape(layout = data_layout)
 
     def define_graph(self):
         self.data = self.inputs()
         out = self.crop(self.data)
+        out = self.set_layout(out)
         return out
 
     def iter_setup(self):

--- a/dali/test/python/test_operator_flip.py
+++ b/dali/test/python/test_operator_flip.py
@@ -110,10 +110,12 @@ class SynthPythonFlipPipeline(Pipeline):
         h_dim, v_dim, d_dim = find_dims(layout)
         fun = lambda d, hor, ver, depth: numpy_flip(d, h_dim, v_dim, d_dim, hor, ver, depth)
         self.python_flip = ops.PythonFunction(function=fun)
+        self.set_layout = ops.Reshape(layout=layout)
 
     def define_graph(self):
         self.data = self.input()
         flipped = self.python_flip(self.data, self.coin(), self.coin(), self.coin())
+        flipped = self.set_layout(flipped)
         return flipped
 
     def iter_setup(self):

--- a/dali/test/python/test_operator_lookup_table.py
+++ b/dali/test/python/test_operator_lookup_table.py
@@ -80,10 +80,12 @@ class LookupTablePythonOpPipeline(Pipeline):
                             dictionary=dictionary,
                             default_value=default_value)
         self.lookup = ops.PythonFunction(function=lookup_table_func)
+        self.set_layout = ops.Reshape(layout = data_layout)
 
     def define_graph(self):
         self.data = self.inputs()
         out = self.lookup(self.data)
+        out = self.set_layout(out)
         return out
 
     def iter_setup(self):

--- a/dali/test/python/test_operator_rotate.py
+++ b/dali/test/python/test_operator_rotate.py
@@ -125,14 +125,16 @@ class CVPipeline(Pipeline):
         self.input = ops.CaffeReader(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
         self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
         self.rotate = ops.PythonFunction(function=CVRotate(output_type, input_type, fixed_size))
-        self.uniform = ops.Uniform(range = (-180.0, 180.0), seed = 42);
+        self.set_layout = ops.Reshape(layout="HWC")
+        self.uniform = ops.Uniform(range = (-180.0, 180.0), seed = 42)
         self.iter = 0
 
     def define_graph(self):
         self.jpegs, self.labels = self.input(name = "Reader")
         images = self.decode(self.jpegs)
         angles = self.uniform()
-        outputs = self.rotate(images, angles);
+        outputs = self.rotate(images, angles)
+        outputs = self.set_layout(outputs)
         return outputs
 
 

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -269,12 +269,14 @@ class SliceSynthDataPipelinePythonOp(Pipeline):
             slice_func_helper, axes, axis_names, self.layout,
             normalized_anchor, normalized_shape)
         self.slice = ops.PythonFunction(function=function)
+        self.set_layout = ops.Reshape(layout=layout)
 
     def define_graph(self):
         self.data = self.inputs()
         self.crop_pos = self.input_crop_pos()
         self.crop_size = self.input_crop_size()
         out = self.slice(self.data, self.crop_pos, self.crop_size)
+        out = self.set_layout(out)
         return out
 
     def iter_setup(self):
@@ -308,6 +310,7 @@ class SlicePythonOp(Pipeline):
             slice_func_helper, axes, axis_names, self.layout,
             normalized_anchor, normalized_shape)
         self.slice = ops.PythonFunction(function=function)
+        self.set_layout = ops.Reshape(layout="HWC")
 
     def define_graph(self):
         imgs, _ = self.input()
@@ -315,6 +318,7 @@ class SlicePythonOp(Pipeline):
         self.crop_pos = self.input_crop_pos()
         self.crop_size = self.input_crop_size()
         out = self.slice(imgs, self.crop_pos, self.crop_size)
+        out = self.set_layout(out)
         return out
 
     def iter_setup(self):

--- a/dali/test/python/test_operator_warp.py
+++ b/dali/test/python/test_operator_warp.py
@@ -131,6 +131,7 @@ class CVPipeline(Pipeline):
           self.warp = ops.PythonFunction(function=CVWarp(output_type, input_type))
         else:
           self.warp = ops.PythonFunction(function=CVWarp(output_type, input_type, [[0.1, 0.9, 10], [0.8, -0.2, -20]]))
+        self.set_layout = ops.Reshape(layout="HWC")
         self.iter = 0
 
     def define_graph(self):
@@ -141,6 +142,7 @@ class CVPipeline(Pipeline):
           outputs = self.warp(images, self.transform)
         else:
           outputs = self.warp(images)
+        outputs = self.set_layout(outputs)
         return outputs
 
 def compare(pipe1, pipe2, eps):

--- a/dali/test/python/test_operator_water.py
+++ b/dali/test/python/test_operator_water.py
@@ -73,6 +73,7 @@ class WaterPythonPipeline(Pipeline):
         self.input = ops.CaffeReader(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
         self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
         self.water = ops.PythonFunction(function=function)
+        self.set_layout = ops.Reshape(layout="HWC")
 
 
     def define_graph(self):
@@ -80,6 +81,7 @@ class WaterPythonPipeline(Pipeline):
 
         images = self.decode(inputs)
         images = self.water(images)
+        images = self.set_layout(images)
         return images
 
 def check_water_cpu_vs_gpu(batch_size):

--- a/dali/test/python/test_pipeline_multichannel.py
+++ b/dali/test/python/test_pipeline_multichannel.py
@@ -135,10 +135,12 @@ class MultichannelSynthPythonOpPipeline(Pipeline):
         self.iterator = iterator
         self.inputs = ops.ExternalSource()
         self.oper = ops.PythonFunction(function=function)
+        self.set_layout = ops.Reshape(layout=layout)
 
     def define_graph(self):
         self.data = self.inputs()
         out = self.oper(self.data)
+        out = self.set_layout(out)
         return out
 
     def iter_setup(self):
@@ -224,11 +226,13 @@ class MultichannelPythonOpPipeline(Pipeline):
         self.reader = ops.FileReader(file_root=multichannel_tiff_root)
         self.decoder = ops.ImageDecoder(device = 'cpu', output_type = types.ANY_DATA)
         self.oper = ops.PythonFunction(function=function)
+        self.set_layout = ops.Reshape(layout="HWC")
 
     def define_graph(self):
         encoded_data, _ = self.reader()
         decoded_data = self.decoder(encoded_data)
         out = self.oper(decoded_data)
+        out = self.set_layout(out)
         return out
 
 

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -80,7 +80,7 @@ def get_gpu_num():
 # If the `max_allowed_error` is not None, it's checked instead of comparing mean error with `eps`.
 def check_batch(
         batch1, batch2, batch_size, eps=1e-07, max_allowed_error=None, expected_layout=None,
-        compare_layouts=False):
+        compare_layouts=True):
     """Compare two batches of data, be it dali TensorList or list of numpy arrays.
 
     Args:
@@ -92,7 +92,7 @@ def check_batch(
         expected_layout (str, optional): If provided, the batches that are DALI types will be checked
             to match this layout. If None, there will be no check
         compare_layouts (bool, optional): Whether to compare layouts between two batches.
-            Checked only if both inputs are DALI types. Defaults to False.
+            Checked only if both inputs are DALI types. Defaults to True.
     """
 
     def is_error(mean_err, max_err, eps, max_allowed_error):
@@ -157,7 +157,7 @@ def check_batch(
 
 def compare_pipelines(
         pipe1, pipe2, batch_size, N_iterations, eps=1e-07, expected_layout=None,
-        compare_layouts=False):
+        compare_layouts=True):
     """Compare the outputs of two pipelines across several iterations.
 
     Args:
@@ -170,7 +170,7 @@ def compare_pipelines(
             will be matched with provided layouts and error will be raised if there is mismatch.
             Defaults to None.
         compare_layouts (bool, optional): Whether to compare layouts of outputs between pipelines.
-            Defaults to False.
+            Defaults to True.
     """
     pipe1.build()
     pipe2.build()

--- a/include/dali/core/tensor_layout.h
+++ b/include/dali/core/tensor_layout.h
@@ -193,6 +193,15 @@ class TensorLayout {
   DALI_HOST_DEV
   constexpr bool empty() const noexcept { return size() == 0; }
 
+  void resize(size_t new_size, char value = '?') noexcept {
+    assert(new_size < max_ndim);
+    auto prev_size = size();
+    set_size(new_size);
+    for (size_t i = prev_size; i < new_size; i++) {
+      data_[i] = value;
+    }
+  }
+
   DALI_HOST_DEV
   bool is_permutation_of(TensorLayout b) const {
     // argument passed by value, because we'll reorder it to match *this

--- a/include/dali/core/tensor_layout.h
+++ b/include/dali/core/tensor_layout.h
@@ -193,12 +193,12 @@ class TensorLayout {
   DALI_HOST_DEV
   constexpr bool empty() const noexcept { return size() == 0; }
 
-  void resize(size_t new_size, char value = '?') noexcept {
+  void resize(size_t new_size, char fill_value = '?') noexcept {
     assert(new_size < max_ndim);
     auto prev_size = size();
     set_size(new_size);
     for (size_t i = prev_size; i < new_size; i++) {
-      data_[i] = value;
+      data_[i] = fill_value;
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a missing tensor layouts in operator's outputs (few of them did not set the layout)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *SetLayout in a few operators that didn't*
     *Added a `resize` function to TensorLayout (permute didn't work properly without it)*
     *TensorVector::GetLayout will check the sample layouts if the layout for the whole TensorVector was not set*
 - Affected modules and functionalities:
     *Several operators, TensorLayout, TensorVector*
 - Key points relevant for the review:
     *Correctness of output layouts, Implementation of TensorLayout::resize and TensorVector::GetLayout*
 - Validation and testing:
     *TensorLayout::resize tests added*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1517]*
