### PR TITLE
Tune Arithmetic Op launch specification

### DIFF
--- a/dali/operators/math/expressions/arithmetic.h
+++ b/dali/operators/math/expressions/arithmetic.h
@@ -363,7 +363,8 @@ class ArithmeticGenericOp : public Operator<Backend> {
   ExprImplCache cache_;
   // For CPU we limit the tile size to limit the sizes of intermediate buffers
   // For GPU it's better to execute more at one time.
-  static constexpr int kTileSize = std::is_same<Backend, CPUBackend>::value ? 4096 : 16384;
+  static constexpr int kTileSize =
+      std::is_same<Backend, CPUBackend>::value ? 4096 : 65536;
   // CPU packs up to 64 tiles in one task, GPU porcesses all of them in one task
   static constexpr int kTaskSize =
       std::is_same<Backend, CPUBackend>::value ? 64 : std::numeric_limits<int>::max();

--- a/dali/operators/math/expressions/arithmetic_test.cc
+++ b/dali/operators/math/expressions/arithmetic_test.cc
@@ -159,7 +159,10 @@ void FillBatch(TensorList<CPUBackend> &batch, const TensorListShape<> shape) {
   }
 }
 
+
 }  // namespace
+
+
 
 template <typename T>
 using bin_op_pointer = T (*)(T, T);
@@ -650,6 +653,4 @@ TEST(ArithmeticOpsTest, UnaryPipeline) {
   }
 }
 
-
 }  // namespace dali
-

--- a/dali/operators/math/expressions/arithmetic_test.cu
+++ b/dali/operators/math/expressions/arithmetic_test.cu
@@ -1,0 +1,241 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "dali/core/cuda_event.h"
+#include "dali/core/cuda_stream.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/test/dali_operator_test.h"
+#include "dali/test/tensor_test_utils.h"
+#include "dali/test/test_tensors.h"
+
+namespace dali {
+
+template <ArithmeticOp op_ = ArithmeticOp::add, typename Result_ = float, typename Left_ = float,
+          typename Right_ = float, int IsLeftTensor_ = true, int IsRightTensor_ = false,
+          int blocks_x_ = 128, int thread_num_ = 32, int batch_size_ = 256, int tile_size_ = 65536,
+          int sample_size_ = 1024 * 1024>
+struct ArithmOpParams {
+  static constexpr ArithmeticOp op = op_;
+  using Result = Result_;
+  using Left = Left_;
+  using Right = Right_;
+  static constexpr int IsLeftTensor = IsLeftTensor_;
+  static constexpr int IsRightTensor = IsRightTensor_;
+  static constexpr int blocks_x = blocks_x_;
+  static constexpr int thread_num = thread_num_;
+  static constexpr int batch_size = batch_size_;
+  static constexpr int tile_size = tile_size_;
+  static constexpr int sample_size = sample_size_;
+  static constexpr int tiles_per_sample = sample_size / tile_size;
+  static constexpr int num_tiles = batch_size * tiles_per_sample;
+  static_assert(sample_size >= tile_size, "This test doesn't support samples smaller than tiles.");
+};
+
+template <typename TestConfig>
+struct BinaryArithmeticOpGpuPerfTest : public ::testing::Test {
+  void SetUp() override {
+    stream = CUDAStream::Create(true);
+
+    /// Fill tile descriptors (shapes)
+    tile_descs.resize(TestConfig::num_tiles);
+    for (int sample_id = 0; sample_id < TestConfig::batch_size; sample_id++) {
+      for (int extent_id = 0; extent_id < TestConfig::tiles_per_sample; extent_id++) {
+        int tile_id = sample_id * TestConfig::tiles_per_sample + extent_id;
+        tile_descs[tile_id].sample_idx = sample_id;
+        tile_descs[tile_id].extent_idx = extent_id;
+        tile_descs[tile_id].tile_size = TestConfig::tile_size;
+        tile_descs[tile_id].extent_size = TestConfig::tile_size;
+      }
+    }
+
+    // Reshape memory for those tiles
+    result.reshape(uniform_list_shape<1>(TestConfig::batch_size,
+                                         {TestConfig::tile_size * TestConfig::tiles_per_sample}));
+    if (TestConfig::IsLeftTensor) {
+      left.reshape(uniform_list_shape<1>(TestConfig::batch_size,
+                                         {TestConfig::tile_size * TestConfig::tiles_per_sample}));
+    } else {
+      left.reshape(uniform_list_shape<1>(TestConfig::batch_size, {1}));
+    }
+    if (TestConfig::IsRightTensor) {
+      right.reshape(uniform_list_shape<1>(TestConfig::batch_size,
+                                          {TestConfig::tile_size * TestConfig::tiles_per_sample}));
+    } else {
+      right.reshape(uniform_list_shape<1>(TestConfig::batch_size, {1}));
+    }
+
+    Left l{};
+    Right r{};
+    auto fill_left = [&l]() { return l += 1; };
+    auto fill_right = [&r]() { return r += 1; };
+    Fill(left.cpu(), fill_left);
+    Fill(right.cpu(), fill_right);
+
+    // Fill pointers for tiles
+    tiles_data.reshape(uniform_list_shape<1>(1, {TestConfig::num_tiles}));
+    auto tiles_cpu = tiles_data.cpu()[0];
+    for (int sample_id = 0; sample_id < TestConfig::batch_size; sample_id++) {
+      for (int extent_id = 0; extent_id < TestConfig::tiles_per_sample; extent_id++) {
+        int tile_id = sample_id * TestConfig::tiles_per_sample + extent_id;
+        tiles_cpu(tile_id)->desc = tile_descs[tile_id];
+        tiles_cpu(tile_id)->output =
+            result.gpu(stream)[sample_id].data + extent_id * TestConfig::tile_size;
+        tiles_cpu(tile_id)->args[0] =
+            left.gpu(stream)[sample_id].data +
+            (TestConfig::IsLeftTensor ? extent_id * TestConfig::tile_size : 0);
+        tiles_cpu(tile_id)->args[1] =
+            right.gpu(stream)[sample_id].data +
+            (TestConfig::IsRightTensor ? extent_id * TestConfig::tile_size : 0);
+      }
+    }
+
+    tiles_gpu = tiles_data.gpu(stream)[0].data;
+  }
+
+  void MeasurePerf() {
+    ExecuteTiledBinOp<TestConfig::op, Result, Left, Right, TestConfig::IsLeftTensor,
+                      TestConfig::IsRightTensor><<<grid, block, 0, stream>>>(tiles_gpu);
+
+    CUDAEvent start = CUDAEvent::CreateWithFlags(0);
+    CUDAEvent end = CUDAEvent::CreateWithFlags(0);
+
+    cudaEventRecord(start, stream);
+    constexpr int kIters = 100;
+    for (int i = 0; i < kIters; i++) {
+      ExecuteTiledBinOp<TestConfig::op, Result, Left, Right, TestConfig::IsLeftTensor,
+                        TestConfig::IsRightTensor><<<grid, block, 0, stream>>>(tiles_gpu);
+    }
+    cudaEventRecord(end, stream);
+    cudaDeviceSynchronize();
+    float time;
+    CUDA_CALL(cudaEventElapsedTime(&time, start, end));
+
+    time *= (1e+6f / kIters);  // convert to nanoseconds / 100 samples
+    int64_t data_size = 0;
+    data_size +=
+        static_cast<int64_t>(TestConfig::num_tiles) * TestConfig::tile_size * sizeof(Result);
+    if (TestConfig::IsLeftTensor)
+      data_size +=
+          static_cast<int64_t>(TestConfig::num_tiles) * TestConfig::tile_size * sizeof(Left);
+    if (TestConfig::IsRightTensor)
+      data_size +=
+          static_cast<int64_t>(TestConfig::num_tiles) * TestConfig::tile_size * sizeof(Right);
+    std::cerr << "Throughput: " << data_size / time << " GB/s\n";
+  }
+
+  using Result = typename TestConfig::Result;
+  using Left = typename TestConfig::Left;
+  using Right = typename TestConfig::Right;
+
+  // For kernel launch
+  dim3 grid = dim3(TestConfig::blocks_x, TestConfig::num_tiles, 1);
+  dim3 block = dim3(TestConfig::thread_num, 1, 1);
+
+  // Tiles and data
+  std::vector<TileDesc> tile_descs;
+  kernels::TestTensorList<ExtendedTileDesc, 1> tiles_data;
+
+  kernels::TestTensorList<Result, 1> result;
+  kernels::TestTensorList<Left, 1> left;
+  kernels::TestTensorList<Right, 1> right;
+
+  CUDAStream stream;
+  const ExtendedTileDesc *tiles_gpu;
+};
+
+TYPED_TEST_SUITE_P(BinaryArithmeticOpGpuPerfTest);
+
+TYPED_TEST_P(BinaryArithmeticOpGpuPerfTest, Perf) {
+  std::cerr << "Blocks_x: " << TypeParam::blocks_x << ", thread_num: " << TypeParam::thread_num
+            << ", tile_size: " << TypeParam::tile_size / 1024.f
+            << "KB, sample_size: " << TypeParam::sample_size / 1048576.f << "MB" << std::endl;
+  // TypeParam n = 0;
+  this->MeasurePerf();
+}
+
+REGISTER_TYPED_TEST_SUITE_P(BinaryArithmeticOpGpuPerfTest, Perf);
+
+using TestConfigs = ::testing::Types<
+    // op, Result, Left, Right, IsLeftTensor, IsRightTensor, blocks_x, thread_num, batch, tile,
+    // sample Test Tensor op Constant
+    ArithmOpParams<  // old config
+        ArithmeticOp::add, float, float, float, true, false, 128, 256, 256, 16384, 1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 256, 256, 32768,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 256, 256, 65536,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 256, 256, 131072,
+                   1024 * 1024>,
+    // test small input data, forcing 1 tile per sample, a bit bigger batch,
+    // to measure how performs with smaller inputs
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 256, 512, 16384,
+                   16384>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 256, 512, 32768,
+                   32768>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 256, 512, 65536,
+                   65536>,
+
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 64, 256, 256, 16384,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 64, 256, 256, 32768,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 64, 256, 256, 65536,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 64, 256, 256, 131072,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 64, 256, 512, 16384, 16384>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 64, 256, 512, 32768, 32768>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 64, 256, 512, 65536, 65536>,
+
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 128, 256, 16384,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 128, 256, 32768,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 128, 256, 65536,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 128, 256, 131072,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 128, 512, 16384,
+                   16384>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 128, 512, 32768,
+                   32768>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, false, 128, 128, 512, 65536,
+                   65536>,
+
+    // Test Tensor op Tensor
+    ArithmOpParams<  // old config
+        ArithmeticOp::add, float, float, float, true, true, 128, 256, 256, 16384, 1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, true, 128, 256, 256, 65536,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, true, 128, 256, 512, 16384, 16384>,
+
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, true, 64, 256, 256, 65536,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, true, 64, 256, 512, 16384, 16384>,
+
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, true, 128, 128, 256, 65536,
+                   1024 * 1024>,
+    ArithmOpParams<ArithmeticOp::add, float, float, float, true, true, 128, 128, 512, 16384,
+                   16384>>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(BinaryArithmeticOpGpu, BinaryArithmeticOpGpuPerfTest, TestConfigs);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_impl_factory.h
+++ b/dali/operators/math/expressions/expression_impl_factory.h
@@ -126,7 +126,7 @@ void TransformDescs(std::vector<ExtendedTileDesc> &extended_tiles,
  * @brief Prepare vector of ExtendedTiles for every task that we have to execute, filling
  * the pointers to data.
  *
- * @param tiles_per_task  Output vectors of ExtendedTiles per evry tast to execute
+ * @param tiles_per_task  Output vectors of ExtendedTiles per every task to execute
  */
 template <typename Backend>
 void PrepareTilesForTasks(std::vector<std::vector<ExtendedTileDesc>> &tiles_per_task,

--- a/dali/operators/math/expressions/expression_impl_gpu.cuh
+++ b/dali/operators/math/expressions/expression_impl_gpu.cuh
@@ -33,12 +33,15 @@ namespace dali {
 template <ArithmeticOp op, typename Result, typename Input>
 __device__ void ExecuteUnOp(Result *result, const Input *in, int64_t extent) {
   using meta = arithm_meta<op, GPUBackend>;
-  result += blockIdx.x * blockDim.x + threadIdx.x;
-  in += blockIdx.x * blockDim.x + threadIdx.x;
-  for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < extent; i += blockDim.x * gridDim.x) {
+  int64_t start_ofs = static_cast<int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  auto *tile_end = result + extent;
+  result += start_ofs;
+  in += start_ofs;
+  while (result < tile_end) {
     *result = meta::impl(*in);
-    result += blockDim.x * gridDim.x;
-    in += blockDim.x * gridDim.x;
+    result += stride;
+    in += stride;
   }
 }
 
@@ -48,14 +51,17 @@ __device__ void ExecuteUnOp(Result *result, const Input *in, int64_t extent) {
 template <ArithmeticOp op, typename Result, typename Left, typename Right>
 __device__ void ExecuteBinOp(Result *result, const Left *l, const Right *r, int64_t extent) {
   using meta = arithm_meta<op, GPUBackend>;
-  result += blockIdx.x * blockDim.x + threadIdx.x;
-  l += blockIdx.x * blockDim.x + threadIdx.x;
-  r += blockIdx.x * blockDim.x + threadIdx.x;
-  for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < extent; i += blockDim.x * gridDim.x) {
+  int64_t start_ofs = static_cast<int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  auto *tile_end = result + extent;
+  result += start_ofs;
+  l += start_ofs;
+  r += start_ofs;
+  while (result < tile_end) {
     *result = meta::impl(*l, *r);
-    result += blockDim.x * gridDim.x;
-    l += blockDim.x * gridDim.x;
-    r += blockDim.x * gridDim.x;
+    result += stride;
+    l += stride;
+    r += stride;
   }
 }
 
@@ -65,12 +71,15 @@ __device__ void ExecuteBinOp(Result *result, const Left *l, const Right *r, int6
 template <ArithmeticOp op, typename Result, typename Left, typename Right>
 __device__ void ExecuteBinOp(Result *result, Left l, const Right *r, int64_t extent) {
   using meta = arithm_meta<op, GPUBackend>;
-  result += blockIdx.x * blockDim.x + threadIdx.x;
-  r += blockIdx.x * blockDim.x + threadIdx.x;
-  for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < extent; i += blockDim.x * gridDim.x) {
+  int64_t start_ofs = static_cast<int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  auto *tile_end = result + extent;
+  result += start_ofs;
+  r += start_ofs;
+  while (result < tile_end) {
     *result = meta::impl(l, *r);
-    result += blockDim.x * gridDim.x;
-    r += blockDim.x * gridDim.x;
+    result += stride;
+    r += stride;
   }
 }
 
@@ -80,12 +89,15 @@ __device__ void ExecuteBinOp(Result *result, Left l, const Right *r, int64_t ext
 template <ArithmeticOp op, typename Result, typename Left, typename Right>
 __device__ void ExecuteBinOp(Result *result, const Left *l, Right r, int64_t extent) {
   using meta = arithm_meta<op, GPUBackend>;
-  result += blockIdx.x * blockDim.x + threadIdx.x;
-  l += blockIdx.x * blockDim.x + threadIdx.x;
-  for (int64_t i = blockIdx.x * blockDim.x + threadIdx.x; i < extent; i += blockDim.x * gridDim.x) {
+  int64_t start_ofs = static_cast<int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  auto *tile_end = result + extent;
+  result += start_ofs;
+  l += start_ofs;
+  while (result < tile_end) {
     *result = meta::impl(*l, r);
-    result += blockDim.x * gridDim.x;
-    l += blockDim.x * gridDim.x;
+    result += stride;
+    l += stride;
   }
 }
 

--- a/dali/operators/math/expressions/expression_impl_gpu.cuh
+++ b/dali/operators/math/expressions/expression_impl_gpu.cuh
@@ -51,8 +51,8 @@ __device__ void ExecuteUnOp(Result *result, const Input *in, int64_t extent) {
 template <ArithmeticOp op, typename Result, typename Left, typename Right>
 __device__ void ExecuteBinOp(Result *result, const Left *l, const Right *r, int64_t extent) {
   using meta = arithm_meta<op, GPUBackend>;
-  uint32_t start_ofs = (blockDim.x) * blockIdx.x + threadIdx.x;
-  uint32_t stride = (blockDim.x) * gridDim.x;
+  int64_t start_ofs = static_cast<int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
   auto *tile_end = result + extent;
   result += start_ofs;
   l += start_ofs;
@@ -71,8 +71,8 @@ __device__ void ExecuteBinOp(Result *result, const Left *l, const Right *r, int6
 template <ArithmeticOp op, typename Result, typename Left, typename Right>
 __device__ void ExecuteBinOp(Result *result, Left l, const Right *r, int64_t extent) {
   using meta = arithm_meta<op, GPUBackend>;
-  uint32_t start_ofs = (blockDim.x) * blockIdx.x + threadIdx.x;
-  uint32_t stride = (blockDim.x) * gridDim.x;
+  int64_t start_ofs = static_cast<int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
   auto *tile_end = result + extent;
   result += start_ofs;
   r += start_ofs;
@@ -89,8 +89,8 @@ __device__ void ExecuteBinOp(Result *result, Left l, const Right *r, int64_t ext
 template <ArithmeticOp op, typename Result, typename Left, typename Right>
 __device__ void ExecuteBinOp(Result *result, const Left *l, Right r, int64_t extent) {
   using meta = arithm_meta<op, GPUBackend>;
-  uint32_t start_ofs = (blockDim.x) * blockIdx.x + threadIdx.x;
-  uint32_t stride = (blockDim.x) * gridDim.x;
+  int64_t start_ofs = static_cast<int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
   auto *tile_end = result + extent;
   result += start_ofs;
   l += start_ofs;

--- a/dali/operators/math/expressions/expression_impl_gpu.cuh
+++ b/dali/operators/math/expressions/expression_impl_gpu.cuh
@@ -51,8 +51,8 @@ __device__ void ExecuteUnOp(Result *result, const Input *in, int64_t extent) {
 template <ArithmeticOp op, typename Result, typename Left, typename Right>
 __device__ void ExecuteBinOp(Result *result, const Left *l, const Right *r, int64_t extent) {
   using meta = arithm_meta<op, GPUBackend>;
-  int64_t start_ofs = static_cast<int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
-  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  uint32_t start_ofs = (blockDim.x) * blockIdx.x + threadIdx.x;
+  uint32_t stride = (blockDim.x) * gridDim.x;
   auto *tile_end = result + extent;
   result += start_ofs;
   l += start_ofs;
@@ -71,8 +71,8 @@ __device__ void ExecuteBinOp(Result *result, const Left *l, const Right *r, int6
 template <ArithmeticOp op, typename Result, typename Left, typename Right>
 __device__ void ExecuteBinOp(Result *result, Left l, const Right *r, int64_t extent) {
   using meta = arithm_meta<op, GPUBackend>;
-  int64_t start_ofs = static_cast<int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
-  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  uint32_t start_ofs = (blockDim.x) * blockIdx.x + threadIdx.x;
+  uint32_t stride = (blockDim.x) * gridDim.x;
   auto *tile_end = result + extent;
   result += start_ofs;
   r += start_ofs;
@@ -89,8 +89,8 @@ __device__ void ExecuteBinOp(Result *result, Left l, const Right *r, int64_t ext
 template <ArithmeticOp op, typename Result, typename Left, typename Right>
 __device__ void ExecuteBinOp(Result *result, const Left *l, Right r, int64_t extent) {
   using meta = arithm_meta<op, GPUBackend>;
-  int64_t start_ofs = static_cast<int64_t>(blockDim.x) * blockIdx.x + threadIdx.x;
-  int64_t stride = static_cast<int64_t>(blockDim.x) * gridDim.x;
+  uint32_t start_ofs = (blockDim.x) * blockIdx.x + threadIdx.x;
+  uint32_t stride = (blockDim.x) * gridDim.x;
   auto *tile_end = result + extent;
   result += start_ofs;
   l += start_ofs;
@@ -138,9 +138,9 @@ template <ArithmeticOp op, typename Result, typename Left, typename Right, bool 
           bool IsRightTensor>
 __global__ void ExecuteTiledBinOp(const ExtendedTileDesc *tiles) {
   const auto &tile = tiles[blockIdx.y];
-  auto *output = static_cast<Result *>(tile.output);
-  const auto *left = static_cast<const Left *>(tile.args[0]);
-  const auto *right = static_cast<const Right *>(tile.args[1]);
+  auto output = static_cast<Result *>(tile.output);
+  auto left = static_cast<const Left *>(tile.args[0]);
+  auto right = static_cast<const Right *>(tile.args[1]);
   ExecuteBinOp<op>(output, argument<IsLeftTensor>::pass(left), argument<IsRightTensor>::pass(right),
                    tile.desc.extent_size);
 }

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -30,7 +30,7 @@ from test_utils import check_batch
 batch_size = 4
 
 # Shape of the samples, currently forces the sample to have be covered by more than 1 tile
-shape_big = [(256, 256)] * batch_size
+shape_big = [(1024, 1024)] * batch_size
 # For the coverage of all type combinations we use smaller batch
 shape_small = [(42, 3), (4, 16), (8, 2), (1, 64)]
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Arithmetic Op is not fast enough, GPU was underutilized due to not big enough tiles.

#### What happened in this PR?
 - What solution was applied:
     Tile was made bigger, grid was made smaller to allow for few more iterations for given thread.
     Pointer usage was adjusted a bit, it helps with small inputs a bit.
     Benchmark was added
 - Affected modules and functionalities:
     Arithmetic Ops
 - Key points relevant for the review:
     
 - Validation and testing:
     Benchmark
 - Documentation (including examples):
     NA


OLD:
```
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'const'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f5fd44f6ae8>, [(1024, 1024)] * 256, '*') ... Throughput: 377.034 GB/s
Throughput: 375.006 GB/s
ok
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'const'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f5fd44f6ae8>, [(16384, 1024)] * 64, '*') ... Throughput: 391.476 GB/s
Throughput: 405.331 GB/s
ok
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'const'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f5fd44f6ae8>, [(400, 400)] * 64, '*') ... Throughput: 334.448 GB/s
Throughput: 353.607 GB/s
ok
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'gpu'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f5fd3e962f0>, [(1024, 1024)] * 256, '*') ... Throughput: 490.778 GB/s
Throughput: 490.198 GB/s
ok
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'gpu'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f5fd3e962f0>, [(16384, 1024)] * 64, '*') ... Throughput: 499.623 GB/s
Throughput: 507.385 GB/s
ok
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'gpu'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f5fd3e962f0>, [(400, 400)] * 64, '*') ... Throughput: 358.166 GB/s
Throughput: 402.577 GB/s
ok

----------------------------------------------------------------------
Ran 6 tests in 10.587s

OK
```
NEW:
```
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'const'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f96c80bbae8>, [(1024, 1024)] * 256, '*') ... Throughput: 533.855 GB/s
Throughput: 531.948 GB/s
ok
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'const'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f96c80bbae8>, [(16384, 1024)] * 64 '*') ... Throughput: 576.293 GB/s
Throughput: 576.419 GB/s
ok
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'const'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f96c80bbae8>, [(400, 400)] * 64, '*') ... Throughput: 462.535 GB/s
Throughput: 498.008 GB/s
ok
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'gpu'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f96c7a5c2f0>, [(1024, 1024)] * 256, '*') ... Throughput: 571.668 GB/s
Throughput: 572.734 GB/s
ok
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'gpu'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f96c7a5c2f0>, [(16384, 1024)] * 64, '*') ... Throughput: 604.232 GB/s
Throughput: 603.718 GB/s
ok
test_operator_arithmetic_ops.test_arithmetic_ops_perf(('gpu', 'gpu'), (<class 'numpy.float32'>, <class 'numpy.float32'>), <function test_arithmetic_ops_perf.<locals>.<lambda> at 0x7f96c7a5c2f0>, [(400, 400)] * 64, '*') ... Throughput: 447.778 GB/s
Throughput: 459.841 GB/s
ok

----------------------------------------------------------------------
Ran 6 tests in 10.426s

OK
```



**JIRA TASK**: *[Use DALI-1514 or NA]*
