### PR TITLE
Remove deprecated use of ltrb in BboxRandomCrop

### DIFF
--- a/docs/examples/use_cases/detection_pipeline.ipynb
+++ b/docs/examples/use_cases/detection_pipeline.ipynb
@@ -68,7 +68,7 @@
     "            aspect_ratio=[0.5, 2.0],\n",
     "            thresholds=[0.1, 0.3, 0.5],\n",
     "            scaling=[0.8, 1.0],\n",
-    "            ltrb=True)\n",
+    "            bbox_layout=\"xyXY\")\n",
     "        self.slice = ops.Slice(device=\"gpu\")\n",
     "\n",
     "    def define_graph(self):\n",

--- a/docs/examples/use_cases/paddle/ssd/train.py
+++ b/docs/examples/use_cases/paddle/ssd/train.py
@@ -62,7 +62,7 @@ class HybridTrainPipe(Pipeline):
             aspect_ratio=[0.5, 2.0],
             thresholds=[0, 0.1, 0.3, 0.5, 0.7, 0.9],
             scaling=[0.3, 1.0],
-            ltrb=True,
+            bbox_layout="xyXY",
             allow_no_crop=True,
             num_attempts=50)
         self.bbflip = ops.BbFlip(device="cpu", ltrb=True)

--- a/docs/examples/use_cases/pytorch/single_stage_detector/src/coco_pipeline.py
+++ b/docs/examples/use_cases/pytorch/single_stage_detector/src/coco_pipeline.py
@@ -53,7 +53,7 @@ class COCOPipeline(Pipeline):
             aspect_ratio=[0.5, 2.0],
             thresholds=[0, 0.1, 0.3, 0.5, 0.7, 0.9],
             scaling=[0.3, 1.0],
-            ltrb=True,
+            bbox_layout="xyXY",
             allow_no_crop=True,
             num_attempts=1)
         self.slice = ops.Slice(device="cpu")


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes usage of a deprecated argument in the documentation

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Updated the documentation to use `bbox_layout="xyXY"` instead of `ltrb=True`*
 - Affected modules and functionalities:
     *some jupyter docs*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *Changes are in documentation*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
