### PR TITLE
Add dependency to dali_kernels to dali lib

### DIFF
--- a/dali/CMakeLists.txt
+++ b/dali/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(dali PRIVATE -Wl,--version-script=${CMAKE_BINARY_DIR}/${da
 
 # Link in dali's dependencies
 message(STATUS "Adding dependencies to target `dali`: '${DALI_LIBS}'")
-target_link_libraries(dali PUBLIC dali_core)
+target_link_libraries(dali PUBLIC dali_core dali_kernels)
 target_link_libraries(dali PRIVATE ${DALI_LIBS} dynlink_cuda)
 # Exclude (most) statically linked dali dependencies from the exports of libdali.so
 target_link_libraries(dali PRIVATE "-Wl,--exclude-libs,${exclude_libs}")


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a missing library dependency

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Made libdali depend on libdali_kernels, since we use allocators and  scatter gather*
 - Affected modules and functionalities:
     *Build system*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
