### PR TITLE
Improve PyTorch and MXNet ExternalSource examples

### DIFF
--- a/docs/examples/frameworks/mxnet/mxnet-external_input.ipynb
+++ b/docs/examples/frameworks/mxnet/mxnet-external_input.ipynb
@@ -139,7 +139,11 @@
    "source": [
     "### Using the pipeline\n",
     "\n",
-    "At the end let us see how it works. Please also notice the usage of `last_batch_padded` that tell iterator that the difference between data set size and batch size alignment is padded by real data that could be skipped at when provided to the framework (`fill_last_batch`):"
+    "In the end, let us see how it works.\n",
+    "\n",
+    "`last_batch_padded` and `fill_last_batch` are set here only for the demonstration purposes. The user may write any custom code and change the epoch size epoch to epoch. In that case, it is recommended to set `size` to -1 and let the iterator just wait for StopIteration exception from the `iter_setup`.\n",
+    "\n",
+    "The `last_batch_padded` here tells the iterator that the difference between data set size and batch size alignment is padded by real data that could be skipped when provided to the framework (`fill_last_batch`):"
    ]
   },
   {
@@ -147,6 +151,14 @@
    "execution_count": 4,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.6/dist-packages/nvidia/dali/plugin/base_iterator.py:124: Warning: Please set `reader_name` and don't set last_batch_padded and size manually  whenever possible. This may lead, in some situations, to miss some  samples or return duplicated ones. Check the Sharding section of the documentation for more details.\n",
+      "  _iterator_deprecation_warning()\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -192,21 +204,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/pytorch/pytorch-external_input.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-external_input.ipynb
@@ -139,7 +139,11 @@
    "source": [
     "### Using the pipeline\n",
     "\n",
-    "At the end let us see how it works. Please also notice the usage of `last_batch_padded` that tell iterator that the difference between data set size and batch size alignment is padded by real data that could be skipped at when provided to the framework (`fill_last_batch`):"
+    "In the end, let us see how it works.\n",
+    "\n",
+    "`last_batch_padded` and `fill_last_batch` are set here only for the demonstration purposes. The user may write any custom code and change the epoch size epoch to epoch. In that case, it is recommended to set `size` to -1 and let the iterator just wait for StopIteration exception from the `iter_setup`.\n",
+    "\n",
+    "The `last_batch_padded` here tells the iterator that the difference between data set size and batch size alignment is padded by real data that could be skipped when provided to the framework (`fill_last_batch`):"
    ]
   },
   {
@@ -147,6 +151,14 @@
    "execution_count": 4,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.6/dist-packages/nvidia/dali/plugin/base_iterator.py:124: Warning: Please set `reader_name` and don't set last_batch_padded and size manually  whenever possible. This may lead, in some situations, to miss some  samples or return duplicated ones. Check the Sharding section of the documentation for more details.\n",
+      "  _iterator_deprecation_warning()\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -192,21 +204,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- updates PyTorch and MXNet ExternalSource examples with the most recent recommendations regarding combining DALI iterators and ExternalSource input

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes PyTorch and MXNet ExternalSource examples

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     updates PyTorch and MXNet ExternalSource examples with the most recent recommendations regarding combining DALI iterators and ExternalSource input
 - Affected modules and functionalities:
     MXNet and PyTorch examples
 - Key points relevant for the review:
     wording?
 - Validation and testing:
     CI
 - Documentation (including examples):
     examples has been updated


**JIRA TASK**: *[NA]*
