### PR TITLE
Add an ability to suppress _iterator_deprecation_warning

### DIFF
--- a/dali/python/nvidia/dali/plugin/base_iterator.py
+++ b/dali/python/nvidia/dali/plugin/base_iterator.py
@@ -19,14 +19,11 @@ import numpy as np
 import warnings
 
 def _iterator_deprecation_warning():
-    # show only this warning
-    with warnings.catch_warnings():
-        warnings.simplefilter("default")
-        warnings.warn("Please set `reader_name` and don't set last_batch_padded and size manually " +
-                      " whenever possible. This may lead, in some situations, to miss some " +
-                      " samples or return duplicated ones. Check the Sharding section of the "
-                      "documentation for more details.",
-                      Warning, stacklevel=2)
+    warnings.warn("Please set `reader_name` and don't set last_batch_padded and size manually " +
+                  " whenever possible. This may lead, in some situations, to miss some " +
+                  " samples or return duplicated ones. Check the Sharding section of the "
+                  "documentation for more details.",
+                  Warning, stacklevel=2)
 
 class _DaliBaseIterator(object):
     """


### PR DESCRIPTION
- adds an ability to suppress _iterator_deprecation_warning by removing  catch_warnings call
- there are still valid use cases when the user wants to use ExternalSource and use fill_last_batch and last_batch_padded parameters by providing expected data set size - like in case of validation when the exact number of relevant samples matters

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds an ability to suppress _iterator_deprecation_warning

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds an ability to suppress _iterator_deprecation_warning by removing  catch_warnings call
 - Affected modules and functionalities:
     FW base iterator
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA

Related https://github.com/NVIDIA/DALI/issues/2140

**JIRA TASK**: *[NA]*
