### PR TITLE
Span-of-arrays flattening + minor layout utils

### DIFF
--- a/dali/core/utils_test.cu
+++ b/dali/core/utils_test.cu
@@ -73,4 +73,23 @@ TEST(CoreUtilsDev, Span) {
   CUDA_CALL(cudaFree(dev_data));
 }
 
+TEST(CoreUtils, SpanFlatten) {
+  std::array<std::array<std::array<int, 4>, 3>, 2> arr;
+  for (int i = 0, n = 1; i < 2; i++) {
+    for (int j = 0; j < 3; j++) {
+      for (int k = 0; k < 4; k++, n++) {
+        arr[i][j][k] = n;
+      }
+    }
+  }
+
+  span<int, 24> flat = flatten(make_span(arr));
+  for (int i = 0; i < 24; i++)
+    EXPECT_EQ(flat[i], i+1);
+
+  span<const int> cflat = flatten(make_cspan(&arr[0], 2));
+  for (int i = 0; i < 24; i++)
+    EXPECT_EQ(cflat[i], i+1);
+}
+
 }  // namespace dali

--- a/include/dali/core/span.h
+++ b/include/dali/core/span.h
@@ -192,6 +192,7 @@ DALI_HOST_DEV constexpr auto make_span(Collection &&c) {
   return make_span(c.data(), c.size());
 }
 
+DALI_NO_EXEC_CHECK
 template <typename T, size_t N>
 DALI_HOST_DEV constexpr span<T, N> make_span(std::array<T, N> &a) {
   return { a.data() };

--- a/include/dali/core/tensor_layout.h
+++ b/include/dali/core/tensor_layout.h
@@ -366,6 +366,23 @@ struct LayoutInfo {
  */
 struct ImageLayoutInfo : LayoutInfo {
   /**
+   * @brief Returns true, if the dimension name describes a spatial extent.
+   *
+   * Spatial dimensions are: 'D'epth, 'H'eight and 'W'idth
+   */
+  DALI_HOST_DEV
+  static bool IsSpatialDim(char dim_name) {
+    switch (dim_name) {
+      case 'D':
+      case 'H':
+      case 'W':
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /**
    * @brief Counts spatial dimensions in the layout.
    *
    * Spatial dimensions are: 'D'epth, 'H'eight and 'W'idth
@@ -374,15 +391,7 @@ struct ImageLayoutInfo : LayoutInfo {
   static int NumSpatialDims(const TensorLayout &tl) {
     int s = 0;
     for (int i = 0; i < tl.ndim(); i++) {
-      switch (tl[i]) {
-      case 'D':
-      case 'H':
-      case 'W':
-        s++;
-        break;
-      default:
-        break;
-      }
+      s += IsSpatialDim(tl[i]) ? 1 :0;
     }
     return s;
   }

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -23,6 +23,7 @@
 
 #include "dali/core/host_dev.h"
 #include "dali/core/force_inline.h"
+#include "dali/core/span.h"
 
 namespace dali {
 
@@ -351,6 +352,27 @@ std::array<T, N> uniform_array(const T& t) {
   std::array<T, N> result;
   result.fill(t);
   return result;
+}
+
+// flattening of spans of statically-sized arrays
+
+template <typename T, span_extent_t extent>
+inline span<T, extent> flatten(span<T, extent> in) {
+  return in;
+}
+
+template <size_t N, typename T, span_extent_t extent>
+inline auto flatten(span<std::array<T, N>, extent> in) {
+  const span_extent_t next_extent = extent == dynamic_extent
+    ? dynamic_extent : extent*span_extent_t(N);
+  return flatten(span<T, next_extent>(&in[0][0], in.size() * N));
+}
+
+template <size_t N, typename T, span_extent_t extent>
+inline auto flatten(span<const std::array<T, N>, extent> in) {
+  const span_extent_t next_extent = extent == dynamic_extent
+    ? dynamic_extent : extent*span_extent_t(N);
+  return flatten(span<const T, next_extent>(&in[0][0], in.size() * N));
 }
 
 }  // namespace dali


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature: span flattening; expose IsSpatialDim and implement NumSpatialDims in terms of it.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * utils: flatten - recursive flattening with no-op tail call; statically calculate new span extent, if possible
     * TensorLayout - factor out IsSpatialDim
 - Affected modules and functionalities:
     * core/util, TensorLayout
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * GTest
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
