### PR TITLE
Enforce recordio indices are not empty

### DIFF
--- a/dali/operators/reader/loader/recordio_loader.h
+++ b/dali/operators/reader/loader/recordio_loader.h
@@ -52,6 +52,10 @@ class RecordIOLoader : public IndexedFileLoader {
     while (index_file >> index >> offset) {
       temp.push_back(offset);
     }
+    DALI_ENFORCE(!temp.empty(),
+      make_string("RecordIO index file doesn't contain any indices. Provided path: \"",
+                  path, "\""));
+
     std::sort(temp.begin(), temp.end());
     size_t file_offset_index = 0;
     for (size_t i = 0; i < temp.size() - 1; ++i) {


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug (segfault) in RecordIO loader when using an empty file

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a check for empty indices*
 - Affected modules and functionalities:
     *MXNet reader*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1545]*
