### PR TITLE
Fix TL3_RN50_convergence test for PaddlePaddle

### DIFF
--- a/qa/TL3_RN50_convergence/test_paddle.sh
+++ b/qa/TL3_RN50_convergence/test_paddle.sh
@@ -10,7 +10,7 @@ function CLEAN_AND_EXIT {
 
 export USE_CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*) | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1\2/')
 # rarfile>= 3.2 breaks python 3.5 compatibility
-pip install "$(python /opt/dali/qa/setup_packages.py -i 0 -u paddle --cuda ${USE_CUDA_VERSION}) rarfile<=3.1"
+pip install $(python /opt/dali/qa/setup_packages.py -i 0 -u paddle --cuda ${USE_CUDA_VERSION}) "rarfile<=3.1"
 
 cd /opt/dali/docs/examples/use_cases/paddle/resnet50
 


### PR DESCRIPTION
- fix the incorrect placement of `" "` in the test script during dependency installation

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes TL3_RN50_convergence test for PaddlePaddle

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     fix the incorrect placement of `" "` in the test script during dependency installation
 - Affected modules and functionalities:
     TL3_RN50_convergence test for PaddlePaddle
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
