### PR TITLE
Add daliOutputCopySamples

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -91,6 +91,14 @@ void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
                              flags & DALI_use_copy_kernel);
 }
 
+dali::kernels::AllocType GetAllocType(device_type_t device_type, bool is_pinned) {
+  using dali::kernels::AllocType;
+  return device_type == device_type_t::GPU
+        ? AllocType::GPU
+        : (is_pinned ? AllocType::Pinned : AllocType::Host);
+}
+
+
 }  // namespace
 
 
@@ -396,11 +404,7 @@ void daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx,
   bool is_pinned = flags & DALI_ext_pinned;
   bool sync = flags & DALI_ext_force_sync;
   bool use_copy_kernel = flags & DALI_use_copy_kernel;
-
-  using dali::kernels::AllocType;
-  AllocType dst_alloc_type = dst_type == device_type_t::GPU
-        ? AllocType::GPU
-        : (is_pinned ? AllocType::Pinned : AllocType::Host);
+  auto dst_alloc_type = GetAllocType(dst_type, is_pinned);
 
   dali::DeviceWorkspace *ws = reinterpret_cast<dali::DeviceWorkspace *>(pipe_handle->ws);
   assert(ws != nullptr);
@@ -408,10 +412,13 @@ void daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx,
   auto &type_info = dali::TypeTable::GetTypeInfo(dali::DALIDataType::DALI_UINT8);
   if (ws->OutputIsType<dali::CPUBackend>(output_idx)) {
     CopyToExternal(dst, dst_alloc_type, ws->OutputRef<dali::CPUBackend>(output_idx),
-                   stream, sync, use_copy_kernel);
+                   stream, use_copy_kernel);
   } else {
     CopyToExternal(dst, dst_alloc_type, ws->OutputRef<dali::GPUBackend>(output_idx),
-                   stream, sync, use_copy_kernel);
+                   stream, use_copy_kernel);
+  }
+  if (sync) {
+    cudaStreamSynchronize(stream);
   }
 }
 
@@ -422,11 +429,7 @@ void daliOutputCopySamples(daliPipelineHandle *pipe_handle, void **dsts, int out
   bool is_pinned = flags & DALI_ext_pinned;
   bool sync = flags & DALI_ext_force_sync;
   bool use_copy_kernel = flags & DALI_use_copy_kernel;
-
-  using dali::kernels::AllocType;
-  AllocType dst_alloc_type = dst_type == device_type_t::GPU
-        ? AllocType::GPU
-        : (is_pinned ? AllocType::Pinned : AllocType::Host);
+  auto dst_alloc_type = GetAllocType(dst_type, is_pinned);
 
   dali::DeviceWorkspace *ws = reinterpret_cast<dali::DeviceWorkspace *>(pipe_handle->ws);
   assert(ws != nullptr);
@@ -434,10 +437,13 @@ void daliOutputCopySamples(daliPipelineHandle *pipe_handle, void **dsts, int out
   auto &type_info = dali::TypeTable::GetTypeInfo(dali::DALIDataType::DALI_UINT8);
   if (ws->OutputIsType<dali::CPUBackend>(output_idx)) {
     CopyToExternal(dsts, dst_alloc_type, ws->OutputRef<dali::CPUBackend>(output_idx),
-                   stream, sync, use_copy_kernel);
+                   stream, use_copy_kernel);
   } else {
     CopyToExternal(dsts, dst_alloc_type, ws->OutputRef<dali::GPUBackend>(output_idx),
-                   stream, sync, use_copy_kernel);
+                   stream, use_copy_kernel);
+  }
+  if (sync) {
+    cudaStreamSynchronize(stream);
   }
 }
 

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -519,4 +519,85 @@ TYPED_TEST(CApiTest, UseCopyKernel) {
   }
 }
 
+TYPED_TEST(CApiTest, daliOutputCopySamples) {
+  auto pipe_ptr = GetTestPipeline<TypeParam>(true, this->output_device_);
+  auto serialized = pipe_ptr->SerializeToProtobuf();
+
+  daliPipelineHandle handle;
+  daliDeserializeDefault(&handle, serialized.c_str(), serialized.size());
+  daliPrefetchUniform(&handle, prefetch_queue_depth);
+
+  daliRun(&handle);
+  daliOutput(&handle);
+  const int num_output = daliGetNumOutput(&handle);
+  for (int out_idx = 0; out_idx < num_output; out_idx++) {
+    std::vector<int64_t> sample_sizes(batch_size, 0);
+    EXPECT_EQ(daliNumTensors(&handle, out_idx), batch_size);
+    for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
+      auto *shape = daliShapeAtSample(&handle, out_idx, sample_idx);
+      int ndim = 0;
+      sample_sizes[sample_idx] = 1;
+      for (int d = 0; shape[d] > 0; d++) {
+        sample_sizes[sample_idx] *= shape[d];
+      }
+      free(shape);
+    }
+
+    DALIDataType type = static_cast<DALIDataType>(daliTypeAt(&handle, out_idx));
+    auto type_info = dali::TypeTable::GetTypeInfo(type);
+    int64_t out_size = daliNumElements(&handle, out_idx);
+    TensorList<TypeParam> output1;
+    output1.Resize({{out_size}}, type_info);
+    daliOutputCopy(&handle, output1.raw_mutable_data(), out_idx,
+                   backend_to_device_type<TypeParam>::value, 0, DALI_ext_default);
+    // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
+    TensorList<CPUBackend> output1_cpu;
+    output1_cpu.Copy(output1, cuda_stream);
+
+    TensorList<TypeParam> output2;
+    TensorList<CPUBackend> output2_cpu;
+    {
+      output2.Resize({{out_size}}, type_info);
+
+      std::vector<void*> sample_dsts(batch_size);
+      int64_t offset = 0;
+      for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
+        sample_dsts[sample_idx] = static_cast<uint8_t*>(output2.raw_mutable_data()) + offset;
+        offset += sample_sizes[sample_idx] * type_info.size();
+      }
+      daliOutputCopySamples(&handle, sample_dsts.data(), out_idx,
+                            backend_to_device_type<TypeParam>::value, 0, DALI_ext_default);
+      // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
+      output2_cpu.Copy(output2, cuda_stream);
+    }
+
+    TensorList<TypeParam> output3;
+    TensorList<CPUBackend> output3_cpu;
+    {
+      output3.Resize({{out_size}}, type_info);
+
+      std::vector<void*> sample_dsts(batch_size);
+      int64_t offset = 0;
+      for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
+        sample_dsts[sample_idx] = static_cast<uint8_t*>(output3.raw_mutable_data()) + offset;
+        offset += sample_sizes[sample_idx] * type_info.size();
+      }
+
+      unsigned int copy_kernel_flags = DALI_ext_default | DALI_use_copy_kernel;
+      if (std::is_same<TypeParam, CPUBackend>::value)
+        copy_kernel_flags |= DALI_ext_pinned;
+
+      daliOutputCopySamples(&handle, sample_dsts.data(), out_idx,
+                            backend_to_device_type<TypeParam>::value, 0, copy_kernel_flags);
+
+      // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
+      output3_cpu.Copy(output3, cuda_stream);
+    }
+
+    CUDA_CALL(cudaDeviceSynchronize());
+    Check(view<uint8_t>(output1_cpu), view<uint8_t>(output2_cpu));
+    Check(view<uint8_t>(output1_cpu), view<uint8_t>(output3_cpu));
+  }
+}
+
 }  // namespace dali

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -546,18 +546,19 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
     DALIDataType type = static_cast<DALIDataType>(daliTypeAt(&handle, out_idx));
     auto type_info = dali::TypeTable::GetTypeInfo(type);
     int64_t out_size = daliNumElements(&handle, out_idx);
-    TensorList<TypeParam> output1;
-    output1.Resize({{out_size}}, type_info);
+    Tensor<TypeParam> output1;
+    output1.Resize({out_size}, type_info);
     daliOutputCopy(&handle, output1.raw_mutable_data(), out_idx,
                    backend_to_device_type<TypeParam>::value, 0, DALI_ext_default);
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    TensorList<CPUBackend> output1_cpu;
+    Tensor<CPUBackend> output1_cpu;
     output1_cpu.Copy(output1, cuda_stream);
 
-    TensorList<TypeParam> output2;
-    TensorList<CPUBackend> output2_cpu;
+    Tensor<TypeParam> output2;
+    Tensor<CPUBackend> output2_cpu;
     {
-      output2.Resize({{out_size}}, type_info);
+      output2.set_pinned(false);
+      output2.Resize({out_size}, type_info);
 
       std::vector<void*> sample_dsts(batch_size);
       int64_t offset = 0;
@@ -571,10 +572,11 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
       output2_cpu.Copy(output2, cuda_stream);
     }
 
-    TensorList<TypeParam> output3;
-    TensorList<CPUBackend> output3_cpu;
+    Tensor<TypeParam> output3;
+    Tensor<CPUBackend> output3_cpu;
     {
-      output3.Resize({{out_size}}, type_info);
+      output3.set_pinned(std::is_same<TypeParam, CPUBackend>::value);
+      output3.Resize({out_size}, type_info);
 
       std::vector<void*> sample_dsts(batch_size);
       int64_t offset = 0;

--- a/dali/kernels/common/scatter_gather.cu
+++ b/dali/kernels/common/scatter_gather.cu
@@ -99,14 +99,14 @@ __global__ void BatchCopy(const ScatterGatherGPU::CopyRange *ranges) {
   }
 }
 
-void ScatterGatherGPU::Run(cudaStream_t stream, bool reset, ScatterGatherGPU::CopyMethod method,
+void ScatterGatherGPU::Run(cudaStream_t stream, bool reset, ScatterGatherGPU::Method method,
                            cudaMemcpyKind memcpyKind) {
   Coalesce();
 
   // TODO(michalz): Error handling
 
-  bool use_memcpy = (method == ScatterGatherGPU::CopyMethod::MemcpyAlways) ||
-    (method == ScatterGatherGPU::CopyMethod::Default && ranges_.size() <= 2);
+  bool use_memcpy = (method == ScatterGatherGPU::Method::Memcpy) ||
+    (method == ScatterGatherGPU::Method::Default && ranges_.size() <= 2);
 
   if (use_memcpy) {
     for (auto &r : ranges_) {

--- a/dali/kernels/common/scatter_gather.cu
+++ b/dali/kernels/common/scatter_gather.cu
@@ -99,13 +99,16 @@ __global__ void BatchCopy(const ScatterGatherGPU::CopyRange *ranges) {
   }
 }
 
-void ScatterGatherGPU::Run(cudaStream_t stream, bool reset, bool useMemcpyOnly,
+void ScatterGatherGPU::Run(cudaStream_t stream, bool reset, ScatterGatherGPU::CopyMethod method,
                            cudaMemcpyKind memcpyKind) {
   Coalesce();
 
   // TODO(michalz): Error handling
 
-  if (useMemcpyOnly || ranges_.size() <= 2) {
+  bool use_memcpy = (method == ScatterGatherGPU::CopyMethod::MemcpyAlways) ||
+    (method == ScatterGatherGPU::CopyMethod::Default && ranges_.size() <= 2);
+
+  if (use_memcpy) {
     for (auto &r : ranges_) {
       cudaMemcpyAsync(r.dst, r.src, r.size, memcpyKind, stream);
     }

--- a/dali/kernels/common/scatter_gather.h
+++ b/dali/kernels/common/scatter_gather.h
@@ -77,16 +77,23 @@ class DLL_PUBLIC ScatterGatherGPU {
     }
   }
 
+  enum class CopyMethod {
+    Default = 0,  // Uses scatter-gather kernel, unless there are 2 or fewer single effective copy
+                  // ranges, in that cases cudaMemcpyAsync is used
+    MemcpyAlways = 1,  // Always use cudaMemcpyAsync
+    MemcpyNever = 2,   // Always use scatter-gather kernel
+  };
+
   /**
    * @brief Executes the copies
-   * @param stream - the cudaStream on which the copies are scheduled
-   * @param reset - if true, calls Reset after processing is over
-   * @param useMemcpyOnly - if true, all copies are executed using cudaMemcpy;
-   *                        otherwise a batched kernel is used if there are more than 2 ranges
-   * @param memcpyKind    - determines the cudaMemcpyKind when using cudaMemcpy
+   * @param stream     - the cudaStream on which the copies are scheduled
+   * @param reset      - if true, calls Reset after processing is over
+   * @param method     - see ScatterGatherGPU::CopyMethod
+   * @param memcpyKind - determines the cudaMemcpyKind when using cudaMemcpy
    */
-  DLL_PUBLIC void Run(cudaStream_t stream, bool reset = true, bool useMemcpyOnly = false,
-                      cudaMemcpyKind memcpyKind = cudaMemcpyDefault);
+  DLL_PUBLIC void
+  Run(cudaStream_t stream, bool reset = true, CopyMethod method = CopyMethod::Default,
+      cudaMemcpyKind memcpyKind = cudaMemcpyDefault);
 
   using CopyRange = detail::CopyRange;
 

--- a/dali/kernels/common/scatter_gather.h
+++ b/dali/kernels/common/scatter_gather.h
@@ -59,6 +59,9 @@ class DLL_PUBLIC ScatterGatherGPU {
     ranges_.reserve(num_ranges);
   }
 
+  /**
+   * @brief Clear any registered range copies
+   */
   void Reset() {
     ranges_.clear();
     blocks_.clear();
@@ -77,11 +80,11 @@ class DLL_PUBLIC ScatterGatherGPU {
     }
   }
 
-  enum class CopyMethod {
+  enum class Method {
     Default = 0,  // Uses scatter-gather kernel, unless there are 2 or fewer single effective copy
                   // ranges, in that cases cudaMemcpyAsync is used
-    MemcpyAlways = 1,  // Always use cudaMemcpyAsync
-    MemcpyNever = 2,   // Always use scatter-gather kernel
+    Memcpy = 1,  // Always use cudaMemcpyAsync
+    Kernel = 2,   // Always use scatter-gather kernel
   };
 
   /**
@@ -92,7 +95,7 @@ class DLL_PUBLIC ScatterGatherGPU {
    * @param memcpyKind - determines the cudaMemcpyKind when using cudaMemcpy
    */
   DLL_PUBLIC void
-  Run(cudaStream_t stream, bool reset = true, CopyMethod method = CopyMethod::Default,
+  Run(cudaStream_t stream, bool reset = true, Method method = Method::Default,
       cudaMemcpyKind memcpyKind = cudaMemcpyDefault);
 
   using CopyRange = detail::CopyRange;

--- a/dali/kernels/test/scatter_gather_test.cc
+++ b/dali/kernels/test/scatter_gather_test.cc
@@ -105,13 +105,13 @@ TEST(ScatterGather, Copy) {
   // copy
   for (auto &r : ranges)
     sg.AddCopy(r.dst, r.src, r.size);
-  sg.Run(0, true, false);  // use Kernel
+  sg.Run(0, true, ScatterGatherGPU::CopyMethod::MemcpyNever);
 
   // copy back
   cudaMemset(in_ptr.get(), 0, in.size());
   for (auto &r : back_ranges)
     sg.AddCopy(r.dst, r.src, r.size);
-  sg.Run(0, true, true);  // use cudaMemcpyAsync
+  sg.Run(0, true, ScatterGatherGPU::CopyMethod::MemcpyAlways);
   cudaMemcpy(out.data(), in_ptr.get(), in.size(), cudaMemcpyDeviceToHost);
 
   EXPECT_EQ(in, out);

--- a/dali/kernels/test/scatter_gather_test.cc
+++ b/dali/kernels/test/scatter_gather_test.cc
@@ -105,13 +105,13 @@ TEST(ScatterGather, Copy) {
   // copy
   for (auto &r : ranges)
     sg.AddCopy(r.dst, r.src, r.size);
-  sg.Run(0, true, ScatterGatherGPU::CopyMethod::MemcpyNever);
+  sg.Run(0, true, ScatterGatherGPU::Method::Kernel);
 
   // copy back
   cudaMemset(in_ptr.get(), 0, in.size());
   for (auto &r : back_ranges)
     sg.AddCopy(r.dst, r.src, r.size);
-  sg.Run(0, true, ScatterGatherGPU::CopyMethod::MemcpyAlways);
+  sg.Run(0, true, ScatterGatherGPU::Method::Memcpy);
   cudaMemcpy(out.data(), in_ptr.get(), in.size(), cudaMemcpyDeviceToHost);
 
   EXPECT_EQ(in, out);

--- a/dali/operators/decoder/cache/cached_decoder_impl.cc
+++ b/dali/operators/decoder/cache/cached_decoder_impl.cc
@@ -71,9 +71,9 @@ void CachedDecoderImpl::LoadDeferred(cudaStream_t stream) {
     return;
 
   cache_->SyncToRead(stream);
-  using CopyMethod = kernels::ScatterGatherGPU::CopyMethod;
-  auto copy_method = use_batch_copy_kernel_ ? CopyMethod::Default
-                                            : CopyMethod::MemcpyAlways;
+  using Method = kernels::ScatterGatherGPU::Method;
+  auto copy_method = use_batch_copy_kernel_ ? Method::Default
+                                            : Method::Memcpy;
   CUDA_CALL((scatter_gather_->Run(stream, true, copy_method), cudaGetLastError()));
 }
 

--- a/dali/operators/decoder/cache/cached_decoder_impl.cc
+++ b/dali/operators/decoder/cache/cached_decoder_impl.cc
@@ -71,7 +71,10 @@ void CachedDecoderImpl::LoadDeferred(cudaStream_t stream) {
     return;
 
   cache_->SyncToRead(stream);
-  CUDA_CALL((scatter_gather_->Run(stream, true, !use_batch_copy_kernel_), cudaGetLastError()));
+  using CopyMethod = kernels::ScatterGatherGPU::CopyMethod;
+  auto copy_method = use_batch_copy_kernel_ ? CopyMethod::Default
+                                            : CopyMethod::MemcpyAlways;
+  CUDA_CALL((scatter_gather_->Run(stream, true, copy_method), cudaGetLastError()));
 }
 
 ImageCache::ImageShape CachedDecoderImpl::CacheImageShape(const std::string& file_name) {

--- a/dali/pipeline/data/copy_to_external.h
+++ b/dali/pipeline/data/copy_to_external.h
@@ -44,9 +44,35 @@ inline void CopyToExternal(void* dst, AllocType dst_alloc_type,
     use_copy_kernel &= (DstType == AllocType::GPU || DstType == AllocType::Pinned) &&
                        (std::is_same<SrcBackend, GPUBackend>::value || src.is_pinned());
     DeviceGuard d(src.device_id());
-    auto &type_info = TypeTable::GetTypeInfo(DALIDataType::DALI_UINT8);
-    type_info.template Copy<DstBackend, SrcBackend>(dst, src.raw_data(), src.nbytes(), stream,
+    const auto &type_info = src.type();
+    type_info.template Copy<DstBackend, SrcBackend>(dst, src.raw_data(), src.size(), stream,
                                                     use_copy_kernel);
+  ), ());  // NOLINT
+
+  if (sync)
+    CUDA_CALL(cudaStreamSynchronize(stream));
+}
+
+template <typename SrcBackend>
+inline void CopyToExternal(void** dsts, AllocType dst_alloc_type,
+                           const TensorList<SrcBackend> &src,
+                           cudaStream_t stream, bool sync, bool use_copy_kernel) {
+  VALUE_SWITCH(dst_alloc_type, DstType, (AllocType::Host, AllocType::Pinned, AllocType::GPU), (
+    using DstBackend = alloc_to_backend<DstType>::type;
+    use_copy_kernel &= (DstType == AllocType::GPU || DstType == AllocType::Pinned) &&
+                       (std::is_same<SrcBackend, GPUBackend>::value || src.is_pinned());
+    DeviceGuard d(src.device_id());
+
+    auto src_shape = src.shape();
+    SmallVector<int64_t, 256> sizes;
+    int nsamples = src_shape.size();
+    sizes.reserve(nsamples);
+    for (int i = 0; i < nsamples; i++) {
+      sizes.push_back(src_shape.tensor_size(i));
+    }
+    const auto &type_info = src.type();
+    type_info.template Copy<DstBackend, SrcBackend>(dsts, src.raw_data(), sizes.data(), nsamples,
+                                                    stream, use_copy_kernel);
   ), ());  // NOLINT
 
   if (sync)

--- a/dali/pipeline/data/copy_to_external.h
+++ b/dali/pipeline/data/copy_to_external.h
@@ -38,7 +38,7 @@ struct alloc_to_backend<AllocType::GPU> {
 template <typename SrcBackend>
 inline void CopyToExternal(void* dst, AllocType dst_alloc_type,
                            const Buffer<SrcBackend> &src,
-                           cudaStream_t stream, bool sync, bool use_copy_kernel) {
+                           cudaStream_t stream, bool use_copy_kernel) {
   VALUE_SWITCH(dst_alloc_type, DstType, (AllocType::Host, AllocType::Pinned, AllocType::GPU), (
     using DstBackend = alloc_to_backend<DstType>::type;
     use_copy_kernel &= (DstType == AllocType::GPU || DstType == AllocType::Pinned) &&
@@ -48,15 +48,12 @@ inline void CopyToExternal(void* dst, AllocType dst_alloc_type,
     type_info.template Copy<DstBackend, SrcBackend>(dst, src.raw_data(), src.size(), stream,
                                                     use_copy_kernel);
   ), ());  // NOLINT
-
-  if (sync)
-    CUDA_CALL(cudaStreamSynchronize(stream));
 }
 
 template <typename SrcBackend>
 inline void CopyToExternal(void** dsts, AllocType dst_alloc_type,
                            const TensorList<SrcBackend> &src,
-                           cudaStream_t stream, bool sync, bool use_copy_kernel) {
+                           cudaStream_t stream, bool use_copy_kernel) {
   VALUE_SWITCH(dst_alloc_type, DstType, (AllocType::Host, AllocType::Pinned, AllocType::GPU), (
     using DstBackend = alloc_to_backend<DstType>::type;
     use_copy_kernel &= (DstType == AllocType::GPU || DstType == AllocType::Pinned) &&
@@ -74,9 +71,6 @@ inline void CopyToExternal(void** dsts, AllocType dst_alloc_type,
     type_info.template Copy<DstBackend, SrcBackend>(dsts, src.raw_data(), sizes.data(), nsamples,
                                                     stream, use_copy_kernel);
   ), ());  // NOLINT
-
-  if (sync)
-    CUDA_CALL(cudaStreamSynchronize(stream));
 }
 
 }  // namespace dali

--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -49,7 +49,7 @@ void ScatterGatherCopy(void **dsts, const void **srcs, const Index *sizes, int n
   for (int i = 0; i < n; i++) {
     sc->AddCopy(dsts[i], srcs[i], sizes[i] * element_size);
   }
-  sc->Run(stream, true /*reset*/, kernels::ScatterGatherGPU::CopyMethod::MemcpyNever);
+  sc->Run(stream, true, kernels::ScatterGatherGPU::Method::Kernel);
 }
 
 void ScatterGatherCopy(void *dst, const void **srcs, const Index *sizes, int n, int element_size,
@@ -61,7 +61,7 @@ void ScatterGatherCopy(void *dst, const void **srcs, const Index *sizes, int n, 
     sc->AddCopy(sample_dst, srcs[i], nbytes);
     sample_dst += nbytes;
   }
-  sc->Run(stream, true /*reset*/, kernels::ScatterGatherGPU::CopyMethod::MemcpyNever);
+  sc->Run(stream, true, kernels::ScatterGatherGPU::Method::Kernel);
 }
 
 void ScatterGatherCopy(void **dsts, const void *src, const Index *sizes, int n, int element_size,
@@ -73,7 +73,7 @@ void ScatterGatherCopy(void **dsts, const void *src, const Index *sizes, int n, 
     sc->AddCopy(dsts[i], sample_src, nbytes);
     sample_src += nbytes;
   }
-  sc->Run(stream, true /*reset*/, kernels::ScatterGatherGPU::CopyMethod::MemcpyNever);
+  sc->Run(stream, true, kernels::ScatterGatherGPU::Method::Kernel);
 }
 
 }  // namespace detail
@@ -145,7 +145,7 @@ void TypeInfo::Copy(void *dst, const void** srcs, const Index* sizes, int n,
   if (!is_host_to_host && use_copy_kernel) {
     detail::ScatterGatherCopy(dst, srcs, sizes, n, size(), stream);
   } else {
-    auto sample_dst = reinterpret_cast<uint8_t*>(dst);
+    auto sample_dst = static_cast<uint8_t*>(dst);
     for (int i = 0; i < n; i++) {
       Copy<DstBackend, SrcBackend>(sample_dst, srcs[i], sizes[i], stream);
       sample_dst += sizes[i] * size();

--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -49,7 +49,7 @@ void ScatterGatherCopy(void **dsts, const void **srcs, const Index *sizes, int n
   for (int i = 0; i < n; i++) {
     sc->AddCopy(dsts[i], srcs[i], sizes[i] * element_size);
   }
-  sc->Run(stream, true /*reset*/, false /*useMemcpyOnly*/);
+  sc->Run(stream, true /*reset*/, kernels::ScatterGatherGPU::CopyMethod::MemcpyNever);
 }
 
 void ScatterGatherCopy(void *dst, const void **srcs, const Index *sizes, int n, int element_size,
@@ -61,7 +61,19 @@ void ScatterGatherCopy(void *dst, const void **srcs, const Index *sizes, int n, 
     sc->AddCopy(sample_dst, srcs[i], nbytes);
     sample_dst += nbytes;
   }
-  sc->Run(stream, true /*reset*/, false /*useMemcpyOnly*/);
+  sc->Run(stream, true /*reset*/, kernels::ScatterGatherGPU::CopyMethod::MemcpyNever);
+}
+
+void ScatterGatherCopy(void **dsts, const void *src, const Index *sizes, int n, int element_size,
+                       cudaStream_t stream) {
+  auto sc = ScatterGatherPoolInstance().Get(stream, kMaxSizePerBlock, n);
+  auto *sample_src = reinterpret_cast<const uint8_t*>(src);
+  for (int i = 0; i < n; i++) {
+    auto nbytes = sizes[i] * element_size;
+    sc->AddCopy(dsts[i], sample_src, nbytes);
+    sample_src += nbytes;
+  }
+  sc->Run(stream, true /*reset*/, kernels::ScatterGatherGPU::CopyMethod::MemcpyNever);
 }
 
 }  // namespace detail
@@ -133,7 +145,7 @@ void TypeInfo::Copy(void *dst, const void** srcs, const Index* sizes, int n,
   if (!is_host_to_host && use_copy_kernel) {
     detail::ScatterGatherCopy(dst, srcs, sizes, n, size(), stream);
   } else {
-    uint8_t *sample_dst = reinterpret_cast<uint8_t*>(dst);
+    auto sample_dst = reinterpret_cast<uint8_t*>(dst);
     for (int i = 0; i < n; i++) {
       Copy<DstBackend, SrcBackend>(sample_dst, srcs[i], sizes[i], stream);
       sample_dst += sizes[i] * size();
@@ -153,6 +165,36 @@ template void TypeInfo::Copy<GPUBackend, CPUBackend>(void *dst,
 
 template void TypeInfo::Copy<GPUBackend, GPUBackend>(void *dst,
     const void **src, const Index *sizes, int n, cudaStream_t stream, bool use_copy_kernel) const;
+
+
+template <typename DstBackend, typename SrcBackend>
+void TypeInfo::Copy(void **dsts, const void* src, const Index* sizes, int n,
+                    cudaStream_t stream, bool use_copy_kernel) const {
+  constexpr bool is_host_to_host = std::is_same<DstBackend, CPUBackend>::value &&
+                                   std::is_same<SrcBackend, CPUBackend>::value;
+  if (!is_host_to_host && use_copy_kernel) {
+    detail::ScatterGatherCopy(dsts, src, sizes, n, size(), stream);
+  } else {
+    auto sample_src = reinterpret_cast<const uint8_t*>(src);
+    for (int i = 0; i < n; i++) {
+      Copy<DstBackend, SrcBackend>(dsts[i], sample_src, sizes[i], stream);
+      sample_src += sizes[i] * size();
+    }
+  }
+}
+
+template void TypeInfo::Copy<CPUBackend, CPUBackend>(void **dsts,
+    const void *src, const Index *sizes, int n, cudaStream_t stream, bool use_copy_kernel) const;
+
+template void TypeInfo::Copy<CPUBackend, GPUBackend>(void **dsts,
+    const void *src, const Index *sizes, int n, cudaStream_t stream, bool use_copy_kernel) const;
+
+template void TypeInfo::Copy<GPUBackend, CPUBackend>(void **dsts,
+    const void *src, const Index *sizes, int n, cudaStream_t stream, bool use_copy_kernel) const;
+
+template void TypeInfo::Copy<GPUBackend, GPUBackend>(void **dsts,
+    const void *src, const Index *sizes, int n, cudaStream_t stream, bool use_copy_kernel) const;
+
 
 
 }  // namespace dali

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -225,8 +225,7 @@ class DLL_PUBLIC TypeInfo {
    * @param dst destination pointer
    * @param src source pointer
    * @param n number of elements to copy
-   * @param stream CUDA stream. Only used in copies to/from GPU backend or from/to Host
-   *        pinned memory when use_copy_kernel is true
+   * @param stream CUDA stream used to perform copy. Only relevant when copying from/to GPUBackend
    * @param use_copy_kernel If true, a copy kernel will be used instead of cudaMemcpyAsync when applicable 
    *        (only relevant for device and host pinned memory)
    */
@@ -240,8 +239,7 @@ class DLL_PUBLIC TypeInfo {
    * @param srcs source pointers
    * @param sizes number of elements for each of the pointers specified in srcs
    * @param n number of copies to process
-   * @param stream CUDA stream. Only used in copies to/from GPU backend or from/to Host
-   *        pinned memory when use_copy_kernel is true
+   * @param stream CUDA stream used to perform copy. Only relevant when copying from/to GPUBackend
    * @param use_copy_kernel If true, a copy kernel will be used instead of cudaMemcpyAsync when applicable 
    *        (only relevant for device and host pinned memory)
    */
@@ -255,8 +253,7 @@ class DLL_PUBLIC TypeInfo {
    * @param srcs source pointers
    * @param sizes number of elements for each of the pointers specified in srcs
    * @param n number of copies to process
-   * @param stream CUDA stream. Only used in copies to/from GPU backend or from/to Host
-   *        pinned memory when use_copy_kernel is true
+   * @param stream CUDA stream used to perform copy. Only relevant when copying from/to GPUBackend
    * @param use_copy_kernel If true, a copy kernel will be used instead of cudaMemcpyAsync when applicable 
    *        (only relevant for device and host pinned memory)
    */
@@ -270,8 +267,7 @@ class DLL_PUBLIC TypeInfo {
    * @param src source pointer
    * @param sizes number of elements for each of the pointers specified in dsts
    * @param n number of copies to process
-   * @param stream CUDA stream. Only used in copies to/from GPU backend or from/to Host
-   *        pinned memory when use_copy_kernel is true
+   * @param stream CUDA stream used to perform copy. Only relevant when copying from/to GPUBackend
    * @param use_copy_kernel If true, a copy kernel will be used instead of cudaMemcpyAsync when applicable
    *        (only relevant for device and host pinned memory)
    */

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -264,6 +264,21 @@ class DLL_PUBLIC TypeInfo {
   DLL_PUBLIC void Copy(void *dst, const void **srcs, const Index *sizes, int n, cudaStream_t stream,
                        bool use_copy_kernel = false) const;
 
+  /**
+   * @brief Copies from SrcBackend contiguous buffer to DstBackend scattered locations
+   * @param dsts destination pointers
+   * @param src source pointer
+   * @param sizes number of elements for each of the pointers specified in dsts
+   * @param n number of copies to process
+   * @param stream CUDA stream. Only used in copies to/from GPU backend or from/to Host
+   *        pinned memory when use_copy_kernel is true
+   * @param use_copy_kernel If true, a copy kernel will be used instead of cudaMemcpyAsync when applicable
+   *        (only relevant for device and host pinned memory)
+   */
+  template <typename DstBackend, typename SrcBackend>
+  DLL_PUBLIC void Copy(void **dsts, const void *src, const Index *sizes, int n, cudaStream_t stream,
+                       bool use_copy_kernel = false) const;
+
   DLL_PUBLIC inline DALIDataType id() const {
     return id_;
   }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -378,7 +378,7 @@ void ExposeTensor(py::module &m) {
     })
     .def("copy_to_external",
         [](Tensor<CPUBackend> &t, py::object p) {
-          CopyToExternal(ctypes_void_ptr(p), kernels::AllocType::Host, t, 0, false, false);
+          CopyToExternal(ctypes_void_ptr(p), kernels::AllocType::Host, t, 0, false);
         },
       "ptr"_a,
       R"code(
@@ -471,7 +471,10 @@ void ExposeTensor(py::module &m) {
           cudaStream_t stream = cuda_stream.is_none()
                 ? UserStream::Get()->GetStream(t)
                 : static_cast<cudaStream_t>(ctypes_void_ptr(cuda_stream));
-          CopyToExternal(ptr, kernels::AllocType::GPU, t, stream, !non_blocking, use_copy_kernel);
+          CopyToExternal(ptr, kernels::AllocType::GPU, t, stream, use_copy_kernel);
+          if (!non_blocking) {
+            cudaStreamSynchronize(stream);
+          }
         },
       "ptr"_a,
       "cuda_stream"_a = py::none(),
@@ -706,7 +709,7 @@ void ExposeTensorList(py::module &m) {
       )code")
     .def("copy_to_external",
         [](TensorList<CPUBackend> &tl, py::object p) {
-          CopyToExternal(ctypes_void_ptr(p), kernels::AllocType::Host, tl, 0, false, false);
+          CopyToExternal(ctypes_void_ptr(p), kernels::AllocType::Host, tl, 0, false);
         },
       R"code(
       Copy the contents of this `TensorList` to an external pointer
@@ -816,7 +819,10 @@ void ExposeTensorList(py::module &m) {
           cudaStream_t stream = cuda_stream.is_none()
                 ? UserStream::Get()->GetStream(t)
                 : static_cast<cudaStream_t>(ctypes_void_ptr(cuda_stream));
-          CopyToExternal(ptr, AllocType::GPU, t, stream, !non_blocking, use_copy_kernel);
+          CopyToExternal(ptr, AllocType::GPU, t, stream, use_copy_kernel);
+          if (!non_blocking) {
+            cudaStreamSynchronize(stream);
+          }
         },
       "ptr"_a,
       "cuda_stream"_a = py::none(),

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -328,12 +328,10 @@ DLL_PUBLIC device_type_t daliGetOutputDevice(daliPipelineHandle *pipe_handle, in
  * @brief Copy the output batch stored at position `output_idx` in the pipeline.
  * @remarks If the pipeline output is TensorList then it needs to be dense
  * @param pipe_handle Pointer to pipeline handle
- * @param device Device of the supplied memory.
  * @param dst Pointer to the destination buffer where the data will be copied
  * @param output_idx index of the pipeline output
  * @param dst_type Device type associated with the destination buffer (0 - CPU, 1 - GPU)
- * @param stream CUDA stream to use when copying the data onto GPU. Remember to synchronize on the
- *               provided stream.
+ * @param stream CUDA stream to use when copying the data to/from the GPU.
  * @param flags Extra flags, check DALI_ext_force_sync, DALI_use_copy_kernel
  */
 
@@ -345,12 +343,10 @@ daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx, devic
  * @brief Copy the samples in output stored at position `output_idx` in the pipeline
  *        to scattered memory locations.
  * @param pipe_handle Pointer to pipeline handle
- * @param device Device of the supplied memory.
  * @param dsts Pointers to the destination buffers where each sample will be copied
  * @param output_idx index of the pipeline output
  * @param dst_type Device type associated with the destination buffer (0 - CPU, 1 - GPU)
- * @param stream CUDA stream to use when copying the data onto GPU. Remember to synchronize on the
- *               provided stream.
+ * @param stream CUDA stream to use when copying the data to/from the GPU.
  * @param flags Extra flags, check DALI_ext_force_sync, DALI_use_copy_kernel
  */
 DLL_PUBLIC void daliOutputCopySamples(daliPipelineHandle *pipe_handle, void **dsts, int output_idx,

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -325,13 +325,12 @@ DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle);
 DLL_PUBLIC device_type_t daliGetOutputDevice(daliPipelineHandle *pipe_handle, int id);
 
 /**
- * @brief Copy the output tensor stored
- * at position `n` in the pipeline.
+ * @brief Copy the output batch stored at position `output_idx` in the pipeline.
  * @remarks If the pipeline output is TensorList then it needs to be dense
  * @param pipe_handle Pointer to pipeline handle
  * @param device Device of the supplied memory.
  * @param dst Pointer to the destination buffer where the data will be copied
- * @param output_id index of the pipeline output
+ * @param output_idx index of the pipeline output
  * @param dst_type Device type associated with the destination buffer (0 - CPU, 1 - GPU)
  * @param stream CUDA stream to use when copying the data onto GPU. Remember to synchronize on the
  *               provided stream.
@@ -339,8 +338,24 @@ DLL_PUBLIC device_type_t daliGetOutputDevice(daliPipelineHandle *pipe_handle, in
  */
 
 DLL_PUBLIC void
-daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int n, device_type_t dst_type,
+daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx, device_type_t dst_type,
                cudaStream_t stream, unsigned int flags);
+
+/**
+ * @brief Copy the samples in output stored at position `output_idx` in the pipeline
+ *        to scattered memory locations.
+ * @param pipe_handle Pointer to pipeline handle
+ * @param device Device of the supplied memory.
+ * @param dsts Pointers to the destination buffers where each sample will be copied
+ * @param output_idx index of the pipeline output
+ * @param dst_type Device type associated with the destination buffer (0 - CPU, 1 - GPU)
+ * @param stream CUDA stream to use when copying the data onto GPU. Remember to synchronize on the
+ *               provided stream.
+ * @param flags Extra flags, check DALI_ext_force_sync, DALI_use_copy_kernel
+ */
+DLL_PUBLIC void daliOutputCopySamples(daliPipelineHandle *pipe_handle, void **dsts, int output_idx,
+                                      device_type_t dst_type, cudaStream_t stream,
+                                      unsigned int flags);
 
 /**
  * @brief DEPRECATED API: use daliOutputCopy instead


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a new API daliOutputCopySamples that copies an output of a pipeline to scattered sample locations

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added daliOutputCopySamples*
     *Extended ScatterGatherGPU to never use cudaMemcpy if requested*
 - Affected modules and functionalities:
     *C-API, ScatterGatherGPU*
 - Key points relevant for the review:
     *daliOutputCopySamples and tests*
 - Validation and testing:
     *Tests added*
 - Documentation (including examples):
     *Doxygen added*


**JIRA TASK**: *[DALI-1546]*
