### PR TITLE
Add an information about the faulty image to CreateImage invocation in nvjpeg_decoder_decoupled_api.h

### DIFF
--- a/dali/operators/decoder/host/host_decoder.cc
+++ b/dali/operators/decoder/host/host_decoder.cc
@@ -38,7 +38,7 @@ void HostDecoder::RunImpl(SampleWorkspace &ws) {
     img->SetUseFastIdct(use_fast_idct_);
     img->Decode();
   } catch (std::exception &e) {
-    DALI_FAIL(e.what() + "File: " + file_name);
+    DALI_FAIL(e.what() + ". File: " + file_name);
   }
   const auto decoded = img->GetImage();
   const auto shape = img->GetShape();

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_cpu.h
@@ -151,7 +151,7 @@ class nvJPEGDecoderCPUStage : public Operator<CPUBackend> {
         HostFallback<StorageCPU>(input_data, in_size, output_image_type_, output_data, 0,
                                           file_name, info->crop_window, use_fast_idct_);
       } catch (const std::runtime_error& e) {
-        DALI_FAIL(e.what() + "File: " + file_name);
+        DALI_FAIL(e.what() + ". File: " + file_name);
       }
     } else {
       NVJPEG_CALL(nvjpegJpegStreamGetFrameDimensions(state_nvjpeg->jpeg_stream,

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -428,10 +428,14 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
           samples_single_.push_back(&data);
         }
       } else {
-        data.method = DecodeMethod::Host;
-        auto image = ImageFactory::CreateImage(input_data, in_size, output_image_type_);
-        data.shape = image->PeekShape();
-        samples_host_.push_back(&data);
+        try {
+          data.method = DecodeMethod::Host;
+          auto image = ImageFactory::CreateImage(input_data, in_size, output_image_type_);
+          data.shape = image->PeekShape();
+          samples_host_.push_back(&data);
+        } catch (const std::runtime_error &e) {
+          DALI_FAIL(e.what() + ". File: " + data.file_name);
+        }
       }
 
       if (output_image_type_ != DALI_ANY_DATA)

--- a/dali/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
+++ b/dali/operators/decoder/nvjpeg/legacy_api/nvjpeg_decoder.h
@@ -242,7 +242,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
             nchannels = shape[2];
           info.nvjpeg_support = false;
         } catch (const std::runtime_error &e) {
-          DALI_FAIL(e.what() + "File: " + file_name);
+          DALI_FAIL(e.what() + ". File: " + file_name);
         }
       } else {
         // Handle errors

--- a/dali/operators/reader/parser/sequence_parser.cc
+++ b/dali/operators/reader/parser/sequence_parser.cc
@@ -36,7 +36,7 @@ void SequenceParser::Parse(const TensorSequence& data, SampleWorkspace* ws) {
         data.tensors[0].data<uint8_t>(), data.tensors[0].size(), image_type_);
       img->Decode();
     } catch (std::exception &e) {
-      DALI_FAIL(e.what() + " File: " + file_name);
+      DALI_FAIL(e.what() + ". File: " + file_name);
     }
     const auto decoded = img->GetImage();
 
@@ -64,7 +64,7 @@ void SequenceParser::Parse(const TensorSequence& data, SampleWorkspace* ws) {
                                       data.tensors[frame].size(), image_type_);
       img->Decode();
     } catch (std::exception &e) {
-      DALI_FAIL(e.what() + " File: " + file_name);
+      DALI_FAIL(e.what() + ". File: " + file_name);
     }
     img->GetImage(view_tensor.mutable_data<uint8_t>());
     DALI_ENFORCE(view_tensor.shares_data(),


### PR DESCRIPTION
- CreateImage invocation in nvjpeg_decoder_decoupled_api.h doesn't provide any info
  about the image that failed to be decoded. This PR adds this missing file name in the
  error message

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a missing file name in the error message from nvjpeg_decoder_decoupled_api.h

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds an information about the faulty image to CreateImage invocation in nvjpeg_decoder_decoupled_api.h
 - Affected modules and functionalities:
     nvjpeg_decoder_decoupled_api.h
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA

Related to https://github.com/NVIDIA/DALI/issues/2172

**JIRA TASK**: *[NA]*
