### PR TITLE
Add proper error handling where there are no valid sequences in the VideoReader

### DIFF
--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -242,6 +242,9 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
                                    codecpar(stream)->height, codecpar(stream)->width});
       }
     }
+    DALI_ENFORCE(frame_starts_.size() != 0, "There are no valid sequences in the provided "
+                 "dataset, check the length of the available videos and the requested sequence "
+                 "length.");
 
 
     const auto& file = get_or_open_file(file_info_[0].video_file);

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -242,7 +242,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
                                    codecpar(stream)->height, codecpar(stream)->width});
       }
     }
-    DALI_ENFORCE(frame_starts_.size() != 0, "There are no valid sequences in the provided "
+    DALI_ENFORCE(!frame_starts_.empty(), "There are no valid sequences in the provided "
                  "dataset, check the length of the available videos and the requested sequence "
                  "length.");
 

--- a/dali/operators/reader/video_reader_op.h
+++ b/dali/operators/reader/video_reader_op.h
@@ -65,30 +65,32 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
     DALI_ENFORCE(dtype_ == DALI_FLOAT || dtype_ == DALI_UINT8,
                  "Data type must be FLOAT or UINT8.");
 
-     enable_label_output_ = !file_root_.empty() || !file_list_.empty();
-     DALI_ENFORCE(enable_label_output_ || !enable_frame_num_,
-                  "frame numbers can be enabled only when "
-                  "`file_list` or `file_root` argument is passed");
-     DALI_ENFORCE(enable_label_output_ || !enable_timestamps_,
-                  "timestamps can be enabled only when "
-                  "`file_list` or `file_root` argument is passed");
+    enable_label_output_ = !file_root_.empty() || !file_list_.empty();
+    DALI_ENFORCE(enable_label_output_ || !enable_frame_num_,
+                "frame numbers can be enabled only when "
+                "`file_list` or `file_root` argument is passed");
+    DALI_ENFORCE(enable_label_output_ || !enable_timestamps_,
+                "timestamps can be enabled only when "
+                "`file_list` or `file_root` argument is passed");
 
     // TODO(spanev): Factor out the constructor body to make VideoReader compatible with lazy_init.
-      try {
-        loader_ = InitLoader<VideoLoader>(spec, filenames_);
-      } catch (std::exception &e) {
-        DALI_WARN(std::string(e.what()));
-        throw;
-      }
+    try {
+      loader_ = InitLoader<VideoLoader>(spec, filenames_);
+    } catch (dali::DALIException &e) {
+      throw e;
+    } catch (std::exception &e) {
+      DALI_WARN(std::string(e.what()));
+      throw;
+    }
 
-      if (enable_label_output_) {
-        label_shape_ = uniform_list_shape(batch_size_, {1});
+    if (enable_label_output_) {
+      label_shape_ = uniform_list_shape(batch_size_, {1});
 
-        if (enable_frame_num_)
-          frame_num_shape_ = label_shape_;
-        if (enable_timestamps_)
-          timestamp_shape_ = uniform_list_shape(batch_size_, {count_});
-      }
+      if (enable_frame_num_)
+        frame_num_shape_ = label_shape_;
+      if (enable_timestamps_)
+        timestamp_shape_ = uniform_list_shape(batch_size_, {count_});
+    }
   }
 
   inline ~VideoReader() override = default;

--- a/dali/operators/reader/video_reader_op.h
+++ b/dali/operators/reader/video_reader_op.h
@@ -74,14 +74,7 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
                 "`file_list` or `file_root` argument is passed");
 
     // TODO(spanev): Factor out the constructor body to make VideoReader compatible with lazy_init.
-    try {
-      loader_ = InitLoader<VideoLoader>(spec, filenames_);
-    } catch (dali::DALIException &e) {
-      throw e;
-    } catch (std::exception &e) {
-      DALI_WARN(std::string(e.what()));
-      throw;
-    }
+    loader_ = InitLoader<VideoLoader>(spec, filenames_);
 
     if (enable_label_output_) {
       label_shape_ = uniform_list_shape(batch_size_, {1});

--- a/dali/test/python/test_video_pipeline.py
+++ b/dali/test/python/test_video_pipeline.py
@@ -75,15 +75,19 @@ def test_simple_videopipeline():
     pipe.build()
     for i in range(ITER):
         print("Iter " + str(i))
-        pipe_out = pipe.run()
+        _ = pipe.run()
     del pipe
+
+def test_wrong_length_sequence_videopipeline():
+    pipe = VideoPipe(batch_size=BATCH_SIZE, data=VIDEO_FILES, sequence_length=100000)
+    assert_raises(RuntimeError, pipe.build)
 
 def check_videopipeline_supported_type(dtype):
     pipe = VideoPipe(batch_size=BATCH_SIZE, data=VIDEO_FILES, dtype=dtype)
     pipe.build()
     for i in range(ITER):
         print("Iter " + str(i))
-        pipe_out = pipe.run()
+        _ = pipe.run()
     del pipe
 
 SUPPORTED_TYPES = [types.DALIDataType.FLOAT, types.DALIDataType.UINT8]
@@ -102,7 +106,7 @@ def test_file_list_videopipeline():
     pipe.build()
     for i in range(ITER):
         print("Iter " + str(i))
-        pipe_out = pipe.run()
+        _ = pipe.run()
     del pipe
 
 def test_step_video_pipeline():
@@ -110,7 +114,7 @@ def test_step_video_pipeline():
     pipe.build()
     for i in range(ITER):
         print("Iter " + str(i))
-        pipe_out = pipe.run()
+        _ = pipe.run()
     del pipe
 
 def test_stride_video_pipeline():
@@ -118,7 +122,7 @@ def test_stride_video_pipeline():
     pipe.build()
     for i in range(ITER):
         print("Iter " + str(i))
-        pipe_out = pipe.run()
+        _ = pipe.run()
     del pipe
 
 def test_multiple_resolution_videopipeline():
@@ -127,7 +131,7 @@ def test_multiple_resolution_videopipeline():
         pipe.build()
         for i in range(ITER):
             print("Iter " + str(i))
-            pipe_out = pipe.run()
+            _ = pipe.run()
     except Exception as e:
         if str(e) == "Decoder reconfigure feature not supported":
             print("Multiple resolution test skipped")


### PR DESCRIPTION
- adds an enforce to check if there is any valid sequence in the VideoReader
- adds a test

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a crash when there are no valid sequences in the VideoReader

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds an enforce to check if there is any valid sequence in the VideoReader
     adds a test
 - Affected modules and functionalities:
     VideoReader
 - Key points relevant for the review:
    NA
 - Validation and testing:
     test is added
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1554]*
