### PR TITLE
Add the possibility to skip individual samples when using daliOutputCopySamples

### DIFF
--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -574,7 +574,7 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
       output2.set_pinned(std::is_same<TypeParam, CPUBackend>::value);
       output2.Resize({out_size}, type_info);
       // Making sure data is cleared
-      // Somehow in debug mode I got the same raw pointer which happen to have
+      // Somehow in debug mode it can get the same raw pointer which happen to have
       // the right data in the second iteration
       Clear(output2);
 
@@ -606,7 +606,7 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
       output2.set_pinned(std::is_same<TypeParam, CPUBackend>::value);
       output2.Resize({out_size}, type_info);
       // Making sure data is cleared
-      // Somehow in debug mode I got the same raw pointer which happen to have
+      // Somehow in debug mode it can get the same raw pointer which happen to have
       // the right data in the second iteration
       Clear(output2);
 

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -519,6 +519,20 @@ TYPED_TEST(CApiTest, UseCopyKernel) {
   }
 }
 
+template <typename Backend>
+void Clear(Tensor<Backend>& tensor);
+
+template <>
+void Clear(Tensor<CPUBackend>& tensor) {
+  std::memset(tensor.raw_mutable_data(), 0, tensor.nbytes());
+}
+
+template <>
+void Clear(Tensor<GPUBackend>& tensor) {
+  cudaMemset(tensor.raw_mutable_data(), 0, tensor.nbytes());
+}
+
+
 TYPED_TEST(CApiTest, daliOutputCopySamples) {
   auto pipe_ptr = GetTestPipeline<TypeParam>(true, this->output_device_);
   auto serialized = pipe_ptr->SerializeToProtobuf();
@@ -554,11 +568,15 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
     Tensor<CPUBackend> output1_cpu;
     output1_cpu.Copy(output1, cuda_stream);
 
-    Tensor<TypeParam> output2;
-    Tensor<CPUBackend> output2_cpu;
-    {
-      output2.set_pinned(false);
+    for (bool use_copy_kernel : {false, true}) {
+      Tensor<TypeParam> output2;
+      Tensor<CPUBackend> output2_cpu;
+      output2.set_pinned(std::is_same<TypeParam, CPUBackend>::value);
       output2.Resize({out_size}, type_info);
+      // Making sure data is cleared
+      // Somehow in debug mode I got the same raw pointer which happen to have
+      // the right data in the second iteration
+      Clear(output2);
 
       std::vector<void*> sample_dsts(batch_size);
       int64_t offset = 0;
@@ -566,39 +584,63 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
         sample_dsts[sample_idx] = static_cast<uint8_t*>(output2.raw_mutable_data()) + offset;
         offset += sample_sizes[sample_idx] * type_info.size();
       }
+
+      unsigned int flags = DALI_ext_default;
+      if (use_copy_kernel)
+        flags |= DALI_use_copy_kernel;
+      if (std::is_same<TypeParam, CPUBackend>::value)
+        flags |= DALI_ext_pinned;
+
       daliOutputCopySamples(&handle, sample_dsts.data(), out_idx,
-                            backend_to_device_type<TypeParam>::value, 0, DALI_ext_default);
+                            backend_to_device_type<TypeParam>::value, cuda_stream, flags);
+
       // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
       output2_cpu.Copy(output2, cuda_stream);
+      CUDA_CALL(cudaDeviceSynchronize());
+      Check(view<uint8_t>(output1_cpu), view<uint8_t>(output2_cpu));
     }
 
-    Tensor<TypeParam> output3;
-    Tensor<CPUBackend> output3_cpu;
-    {
-      output3.set_pinned(std::is_same<TypeParam, CPUBackend>::value);
-      output3.Resize({out_size}, type_info);
+    for (bool use_copy_kernel : {false, true}) {
+      Tensor<TypeParam> output2;
+      Tensor<CPUBackend> output2_cpu;
+      output2.set_pinned(std::is_same<TypeParam, CPUBackend>::value);
+      output2.Resize({out_size}, type_info);
+      // Making sure data is cleared
+      // Somehow in debug mode I got the same raw pointer which happen to have
+      // the right data in the second iteration
+      Clear(output2);
 
-      std::vector<void*> sample_dsts(batch_size);
+      std::vector<void*> sample_dsts_even(batch_size);
+      std::vector<void*> sample_dsts_odd(batch_size);
       int64_t offset = 0;
       for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
-        sample_dsts[sample_idx] = static_cast<uint8_t*>(output3.raw_mutable_data()) + offset;
+        auto sample_ptr = static_cast<uint8_t*>(output2.raw_mutable_data()) + offset;
+        if (sample_idx % 2 == 0) {
+          sample_dsts_even[sample_idx] = sample_ptr;
+          sample_dsts_odd[sample_idx]  = nullptr;
+        } else {
+          sample_dsts_even[sample_idx] = nullptr;
+          sample_dsts_odd[sample_idx]  = sample_ptr;
+        }
         offset += sample_sizes[sample_idx] * type_info.size();
       }
 
-      unsigned int copy_kernel_flags = DALI_ext_default | DALI_use_copy_kernel;
+      unsigned int flags = DALI_ext_default;
+      if (use_copy_kernel)
+        flags |= DALI_use_copy_kernel;
       if (std::is_same<TypeParam, CPUBackend>::value)
-        copy_kernel_flags |= DALI_ext_pinned;
+        flags |= DALI_ext_pinned;
 
-      daliOutputCopySamples(&handle, sample_dsts.data(), out_idx,
-                            backend_to_device_type<TypeParam>::value, 0, copy_kernel_flags);
+      daliOutputCopySamples(&handle, sample_dsts_even.data(), out_idx,
+                            backend_to_device_type<TypeParam>::value, cuda_stream, flags);
+      daliOutputCopySamples(&handle, sample_dsts_odd.data(), out_idx,
+                            backend_to_device_type<TypeParam>::value, cuda_stream, flags);
 
       // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-      output3_cpu.Copy(output3, cuda_stream);
+      output2_cpu.Copy(output2, cuda_stream);
+      CUDA_CALL(cudaDeviceSynchronize());
+      Check(view<uint8_t>(output1_cpu), view<uint8_t>(output2_cpu));
     }
-
-    CUDA_CALL(cudaDeviceSynchronize());
-    Check(view<uint8_t>(output1_cpu), view<uint8_t>(output2_cpu));
-    Check(view<uint8_t>(output1_cpu), view<uint8_t>(output3_cpu));
   }
 }
 

--- a/dali/kernels/common/scatter_gather.h
+++ b/dali/kernels/common/scatter_gather.h
@@ -71,7 +71,7 @@ class DLL_PUBLIC ScatterGatherGPU {
    * @brief Adds one copy to the batch
    */
   void AddCopy(void *dst, const void *src, size_t size) {
-    if (size > 0) {
+    if (size > 0 && dst != nullptr && src != nullptr) {
       ranges_.push_back({
         static_cast<const char*>(src),
         static_cast<char*>(dst),

--- a/dali/kernels/common/scatter_gather.h
+++ b/dali/kernels/common/scatter_gather.h
@@ -71,7 +71,7 @@ class DLL_PUBLIC ScatterGatherGPU {
    * @brief Adds one copy to the batch
    */
   void AddCopy(void *dst, const void *src, size_t size) {
-    if (size > 0 && dst != nullptr && src != nullptr) {
+    if (size > 0) {
       ranges_.push_back({
         static_cast<const char*>(src),
         static_cast<char*>(dst),

--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -88,6 +88,9 @@ void TypeInfo::Copy(void *dst,
     const void *src, Index n, cudaStream_t stream, bool use_copy_kernel) const {
   constexpr bool is_host_to_host = std::is_same<DstBackend, CPUBackend>::value &&
                                    std::is_same<SrcBackend, CPUBackend>::value;
+  if (src == nullptr || dst == nullptr)
+    return;
+
   if (is_host_to_host) {
     // Call our copy function
     copier_(dst, src, n);

--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -88,7 +88,7 @@ void TypeInfo::Copy(void *dst,
     const void *src, Index n, cudaStream_t stream, bool use_copy_kernel) const {
   constexpr bool is_host_to_host = std::is_same<DstBackend, CPUBackend>::value &&
                                    std::is_same<SrcBackend, CPUBackend>::value;
-  if (src == nullptr || dst == nullptr)
+  if (n == 0)
     return;
 
   if (is_host_to_host) {

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -343,7 +343,8 @@ daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx, devic
  * @brief Copy the samples in output stored at position `output_idx` in the pipeline
  *        to scattered memory locations.
  * @param pipe_handle Pointer to pipeline handle
- * @param dsts Pointers to the destination buffers where each sample will be copied
+ * @param dsts Pointers to the destination buffers where each sample will be copied.
+ *             A nullptr dst pointer for a given sample will result in that sample not to be copied
  * @param output_idx index of the pipeline output
  * @param dst_type Device type associated with the destination buffer (0 - CPU, 1 - GPU)
  * @param stream CUDA stream to use when copying the data to/from the GPU.

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -344,7 +344,7 @@ daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx, devic
  *        to scattered memory locations.
  * @param pipe_handle Pointer to pipeline handle
  * @param dsts Pointers to the destination buffers where each sample will be copied.
- *             A nullptr dst pointer for a given sample will result in that sample not to be copied
+ *        A nullptr dst pointer for a sample will discard that sample.
  * @param output_idx index of the pipeline output
  * @param dst_type Device type associated with the destination buffer (0 - CPU, 1 - GPU)
  * @param stream CUDA stream to use when copying the data to/from the GPU.


### PR DESCRIPTION

Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed when copying output samples from a batch that contains repeated samples that we don't want to copy

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *daliOutputCopySamples to support nullptr as dst pointers, for those samples that should not be copied*
 - Affected modules and functionalities:
     *daliOutputCopySamples*
 - Key points relevant for the review:
     *Changes int TypeInfo, ScatterGather and tests*
 - Validation and testing:
     *Tests added*
 - Documentation (including examples):
     *Update doxygen*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
