### PR TITLE
Fix lack of input type checking in GPU variant of Spectrogram operator

### DIFF
--- a/dali/operators/signal/fft/spectrogram.cc
+++ b/dali/operators/signal/fft/spectrogram.cc
@@ -28,7 +28,8 @@ namespace dali {
 
 DALI_SCHEMA(Spectrogram)
   .DocStr(R"code(Produces a spectrogram from a 1D signal (e.g. audio). Input data is expected
-to be single channel (shape being `(nsamples,)`, `(nsamples, 1)` or `(1, nsamples)`).)code")
+to be single channel (shape being `(nsamples,)`, `(nsamples, 1)` or `(1, nsamples)`) of type
+float32.)code")
   .NumInput(1)
   .NumOutput(1)
   .AddOptionalArg("nfft",

--- a/dali/operators/signal/fft/spectrogram_gpu.cc
+++ b/dali/operators/signal/fft/spectrogram_gpu.cc
@@ -128,10 +128,10 @@ struct SpectrogramOpImplGPU : public OpImplBase<GPUBackend> {
   }
 
   void RunImpl(DeviceWorkspace &ws) override {
-    auto &in = ws.InputRef<GPUBackend>(0);
+    const auto &in = ws.InputRef<GPUBackend>(0);
     auto &out = ws.OutputRef<GPUBackend>(0);
     auto kernel_output_shape = kmgr.GetRequirements(0).output_shapes[0].to_static<2>();
-    auto in_view_1D = reshape(view<float>(in), in_shape_1D);
+    const auto in_view_1D = reshape(view<const float>(in), in_shape_1D);
     auto out_view_2D = view<float, 2>(out);
     KernelContext ctx;
     ctx.gpu.stream = ws.stream();


### PR DESCRIPTION
- view creation inside the GPU variant of Spectrogram casts input data to float32 instead of doing a type check
- adding const to input and view type enforces the type check
- add info in the docs regarding expected input data type

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes lack of input type checking in GPU variant of Spectrogram operator

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adding const to input and view type enforces the type check
     add info in the docs regarding expected input data type
 - Affected modules and functionalities:
     Spectrogram operator
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     Docs are udpated

Ad https://github.com/NVIDIA/DALI/issues/2191
**JIRA TASK**: *[DALI-1558]*
