### PR TITLE
Use NVCC to detect cuda release version

### DIFF
--- a/dali/python/dummy/make_nvidia_dali_dummy.sh
+++ b/dali/python/dummy/make_nvidia_dali_dummy.sh
@@ -8,7 +8,7 @@ DST_DIR=${1:-"/nvidia_dali_dummy"}
 mkdir -p build
 pushd build
 
-CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1.\2/')
+CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2.\3/')
 
 cmake .. \
       -DCUDA_VERSION:STRING="${CUDA_VERSION}" \

--- a/dali_tf_plugin/make_dali_tf_sdist.sh
+++ b/dali_tf_plugin/make_dali_tf_sdist.sh
@@ -10,7 +10,7 @@ find . -name '*.so' || true
 mkdir -p dali_tf_sdist_build
 pushd dali_tf_sdist_build
 
-CUDA_VERSION_STR=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1.\2/')
+CUDA_VERSION_STR=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2.\3/')
 
 cmake .. \
       -DCUDA_VERSION:STRING="${CUDA_VERSION_STR}" \

--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -10,7 +10,7 @@ do_once() {
 
     NUM_GPUS=$(nvidia-smi -L | wc -l)
 
-    CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*) | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1\2/')
+    CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2\3/')
 
     # install any for CUDA 9 and the 1.15 for CUDA 10
     pip install $($topdir/qa/setup_packages.py -i 0 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages

--- a/qa/TL3_RN50_convergence/test_paddle.sh
+++ b/qa/TL3_RN50_convergence/test_paddle.sh
@@ -8,7 +8,7 @@ function CLEAN_AND_EXIT {
     exit $1
 }
 
-export USE_CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*) | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1\2/')
+export USE_CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2\3/')
 # rarfile>= 3.2 breaks python 3.5 compatibility
 pip install $(python /opt/dali/qa/setup_packages.py -i 0 -u paddle --cuda ${USE_CUDA_VERSION}) "rarfile<=3.1"
 

--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*) | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1\2/')
+CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2\3/')
 CUDA_VERSION=${CUDA_VERSION:-90}
 
 if [ -n "$gather_pip_packages" ]


### PR DESCRIPTION
- moves away from libcudart.so version name in favor of NVCC version

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It moves away from libcudart.so version name in favor of NVCC version

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     moves away from libcudart.so version name in favor of NVCC version
 - Affected modules and functionalities:
     tests, TF plugin build
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
