### PR TITLE
Fix QNX build

### DIFF
--- a/dali/operators/image/resize/resize.cc
+++ b/dali/operators/image/resize/resize.cc
@@ -36,7 +36,7 @@ template<typename Backend>
 Resize<Backend>::Resize(const OpSpec &spec)
     : Operator<Backend>(spec)
     , ResizeBase<Backend>(spec) {
-  save_attrs_ = spec_.HasArgument("save_attrs");
+  save_attrs_ = this->spec_.HasArgument("save_attrs");
   resample_params_.resize(num_threads_);
   InitializeBackend();
 }


### PR DESCRIPTION
- fixes the lack of spec_ base class member visibility inside Resize operator

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a QNX build

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     fixes the lack of spec_ base class member visibility inside Resize operator
 - Affected modules and functionalities:
     Resize
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
