### PR TITLE
Installation on the fly of DALI whl when building the TF plugin

### DIFF
--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -14,15 +14,38 @@
 
 from setuptools import setup, find_namespace_packages
 from dali_tf_plugin_install_tool import InstallerHelper
-from setuptools.command.build_ext import build_ext
 from setuptools.dist import Distribution
 from setuptools.extension import Extension
 import os
+import sys
+
+from setuptools.command.build_ext import build_ext
+from setuptools.command.egg_info import egg_info
+
+install_requires = [
+    'nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@==@DALI_VERSION@'
+]
 
 class CustomBuildExt(build_ext, object):
     def run(self):
         helper = InstallerHelper(plugin_dest_dir = os.path.join(self.build_lib, 'nvidia', 'dali_tf_plugin'))
         helper.install()
+
+class EggInfoCommand(egg_info):
+    """A class for setuptools egg_info command.
+    Handled by "python setup.py egg_info".
+    """
+    def run(self):
+        """Run egg_info command."""
+        if all([keyword in sys.argv for keyword in ["egg_info", "--egg-base"]]):
+            try:
+                from pip._internal.cli.main import main as pip
+                pip(["install"] + install_requires)
+            except:
+                from pip._internal.cli.main import main as pip
+                pip(["install", "--user"] + install_requires)
+
+        super(EggInfoCommand, self).run()
 
 class CustomDistribution(Distribution):
     def __init__(self, attrs=None):
@@ -43,12 +66,10 @@ setup(name='nvidia-dali-tf-plugin@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIG
       packages=find_namespace_packages(include=['nvidia.*']),
       include_package_data=True,
       zip_safe=False,
-      install_requires = [
-          'nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@==@DALI_VERSION@'
-          ],
-
+      install_requires=install_requires,
       cmdclass={
           'build_ext': CustomBuildExt,
+          'egg_info': EggInfoCommand,
       },
       distclass=CustomDistribution
      )

--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -41,7 +41,7 @@ def pip_install(pkg_req, user=False):
         pip_args.append("--user")
     pip_args.append(pkg_req)
 
-    from pip._internal import main as pip
+    from pip._internal.cli.main import main as pip 
     return pip(pip_args) == 0
 
 class CustomBuildExt(build_ext, object):

--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -40,7 +40,10 @@ class EggInfoCommand(egg_info):
         if all([keyword in sys.argv for keyword in ["egg_info", "--egg-base"]]):
             try:
                 from pip._internal.cli.main import main as pip
-                pip(["install"] + install_requires)
+                return_code = pip(["install"] + install_requires)
+
+                if return_code != 0:
+                    raise RuntimeError("Installation of requirements failed with code: %d" % return_code)
             except:
                 from pip._internal.cli.main import main as pip
                 pip(["install", "--user"] + install_requires)

--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -28,11 +28,11 @@ NVIDIA_INDEX_URL = "https://developer.download.nvidia.com/compute/redist/@DALI_F
 def is_dali_installed():
     try:
         import nvidia.dali
-        return True
     except:
         return False
+    return True
 
-def pip_install(pkg_req, user=False):
+def pip_install_dali(pkg_req, user=False):
     pip_args = [
         "install",
         "--index-url", NVIDIA_INDEX_URL
@@ -62,11 +62,11 @@ class EggInfoCommand(egg_info):
         """Installing DALI if not already installed during EggInfo command (first egg_info run)"""
         handle_deps = all([keyword in sys.argv for keyword in ["egg_info", "--egg-base"]]) 
         if handle_deps and not is_dali_installed():
-            ret = pip_install(DALI_PKG_REQ, user=False)
+            ret = pip_install_dali(DALI_PKG_REQ, user=False)
             if not ret:
-                ret = pip_install(DALI_PKG_REQ, user=True)
+                ret = pip_install_dali(DALI_PKG_REQ, user=True)
             if not ret:
-                raise RuntimeError("Could not install {}".format(DALI_PKG_REQ))
+                raise RuntimeError("Could not install {}. Please install it and try again".format(DALI_PKG_REQ))
             # For nvidia.dali to be importable, restart the program from scratch
             os.execl(sys.executable, sys.executable, *sys.argv)
 

--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -30,6 +30,8 @@ class CustomBuildExt(build_ext, object):
     def run(self):
         helper = InstallerHelper(plugin_dest_dir = os.path.join(self.build_lib, 'nvidia', 'dali_tf_plugin'))
         helper.install()
+        
+        
 class EggInfoCommand(egg_info):
     """A class for setuptools egg_info command.
     Handled by "python setup.py egg_info".

--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -30,7 +30,6 @@ class CustomBuildExt(build_ext, object):
     def run(self):
         helper = InstallerHelper(plugin_dest_dir = os.path.join(self.build_lib, 'nvidia', 'dali_tf_plugin'))
         helper.install()
-
 class EggInfoCommand(egg_info):
     """A class for setuptools egg_info command.
     Handled by "python setup.py egg_info".
@@ -38,15 +37,23 @@ class EggInfoCommand(egg_info):
     def run(self):
         """Run egg_info command."""
         if all([keyword in sys.argv for keyword in ["egg_info", "--egg-base"]]):
+            pip_args = [
+                "install",
+                "--index-url",
+                "https://developer.download.nvidia.com/compute/redist"
+            ]
             try:
                 from pip._internal.cli.main import main as pip
-                return_code = pip(["install"] + install_requires)
+                return_code = pip(pip_args + install_requires)
 
                 if return_code != 0:
-                    raise RuntimeError("Installation of requirements failed with code: %d" % return_code)
+                    raise RuntimeError(
+                        "Installation of requirements failed with code: %d" %
+                        return_code
+                    )
             except:
                 from pip._internal.cli.main import main as pip
-                pip(["install", "--user"] + install_requires)
+                pip(pip_args + ["--user"] + install_requires)
 
         super(EggInfoCommand, self).run()
 

--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -22,42 +22,50 @@ import sys
 from setuptools.command.build_ext import build_ext
 from setuptools.command.egg_info import egg_info
 
+
 install_requires = [
     'nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@==@DALI_VERSION@'
 ]
+
 
 class CustomBuildExt(build_ext, object):
     def run(self):
         helper = InstallerHelper(plugin_dest_dir = os.path.join(self.build_lib, 'nvidia', 'dali_tf_plugin'))
         helper.install()
-        
-        
+
+
 class EggInfoCommand(egg_info):
     """A class for setuptools egg_info command.
     Handled by "python setup.py egg_info".
     """
+
+    def pip_install(self, *args):
+        pip_args = [
+            "install",
+            "--index-url",
+            "https://developer.download.nvidia.com/compute/redist"
+        ]
+        from pip._internal.cli.main import main as pip
+        return_code = pip(pip_args + install_requires)
+
+        if return_code != 0:
+            raise RuntimeError(
+                "Installation of requirements failed with code: %d" %
+                return_code
+            )
+        else:
+            return return_code
+
     def run(self):
         """Run egg_info command."""
         if all([keyword in sys.argv for keyword in ["egg_info", "--egg-base"]]):
-            pip_args = [
-                "install",
-                "--index-url",
-                "https://developer.download.nvidia.com/compute/redist"
-            ]
             try:
-                from pip._internal.cli.main import main as pip
-                return_code = pip(pip_args + install_requires)
-
-                if return_code != 0:
-                    raise RuntimeError(
-                        "Installation of requirements failed with code: %d" %
-                        return_code
-                    )
+                assert(self.pip_install(install_requires) == 0)
             except:
-                from pip._internal.cli.main import main as pip
-                pip(pip_args + ["--user"] + install_requires)
+                assert(self.pip_install(["--user"] + install_requires) == 0)
 
         super(EggInfoCommand, self).run()
+
 
 class CustomDistribution(Distribution):
     def __init__(self, attrs=None):
@@ -68,6 +76,7 @@ class CustomDistribution(Distribution):
         # By filling this ext_modules we are signaling that this package needs
         # to be built for different platforms
         self.ext_modules = [Extension('nvidia.dali_tf_plugin', [])]
+
 
 setup(name='nvidia-dali-tf-plugin@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@',
       description='NVIDIA DALI @DALI_FLAVOR@ Tensorflow plugin for CUDA @CUDA_VERSION_SHORT@. Git SHA: @GIT_SHA@',

--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -22,51 +22,55 @@ import sys
 from setuptools.command.build_ext import build_ext
 from setuptools.command.egg_info import egg_info
 
+DALI_PKG_REQ = 'nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@==@DALI_VERSION@'
+NVIDIA_INDEX_URL = "https://developer.download.nvidia.com/compute/redist/@DALI_FLAVOR@"
 
-install_requires = [
-    'nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@==@DALI_VERSION@'
-]
+def is_dali_installed():
+    try:
+        import nvidia.dali
+        return True
+    except:
+        return False
 
+def pip_install(pkg_req, user=False):
+    pip_args = [
+        "install",
+        "--index-url", NVIDIA_INDEX_URL
+    ]
+    if user:
+        pip_args.append("--user")
+    pip_args.append(pkg_req)
+
+    from pip._internal import main as pip
+    return pip(pip_args) == 0
 
 class CustomBuildExt(build_ext, object):
     def run(self):
+        if not is_dali_installed():
+            raise RuntimeError("NVIDIA DALI should be installed at this point.")
         helper = InstallerHelper(plugin_dest_dir = os.path.join(self.build_lib, 'nvidia', 'dali_tf_plugin'))
         helper.install()
 
-
 class EggInfoCommand(egg_info):
     """A class for setuptools egg_info command.
-    Handled by "python setup.py egg_info".
+    DALI TF requires DALI to be installed when the package is built (not installed).
+    We are overriding egg_info command to install DALI package before build_ext command,
+    if it was not installed already.
     """
 
-    @staticmethod
-    def pip_install(*args):
-        pip_args = [
-            "install",
-            "--index-url",
-            "https://developer.download.nvidia.com/compute/redist"
-        ]
-        from pip._internal.cli.main import main as pip
-        return_code = pip(pip_args + install_requires)
-
-        if return_code != 0:
-            raise RuntimeError(
-                "Installation of requirements failed with code: %d" %
-                return_code
-            )
-        else:
-            return return_code
-
     def run(self):
-        """Run egg_info command."""
-        if all([keyword in sys.argv for keyword in ["egg_info", "--egg-base"]]):
-            try:
-                assert(EggInfoCommand.pip_install(install_requires) == 0)
-            except:
-                assert(EggInfoCommand.pip_install(["--user"] + install_requires) == 0)
+        """Installing DALI if not already installed during EggInfo command (first egg_info run)"""
+        handle_deps = all([keyword in sys.argv for keyword in ["egg_info", "--egg-base"]]) 
+        if handle_deps and not is_dali_installed():
+            ret = pip_install(DALI_PKG_REQ, user=False)
+            if not ret:
+                ret = pip_install(DALI_PKG_REQ, user=True)
+            if not ret:
+                raise RuntimeError("Could not install {}".format(DALI_PKG_REQ))
+            # For nvidia.dali to be importable, restart the program from scratch
+            os.execl(sys.executable, sys.executable, *sys.argv)
 
         super(EggInfoCommand, self).run()
-
 
 class CustomDistribution(Distribution):
     def __init__(self, attrs=None):
@@ -88,7 +92,7 @@ setup(name='nvidia-dali-tf-plugin@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIG
       packages=find_namespace_packages(include=['nvidia.*']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=install_requires,
+      install_requires=[DALI_PKG_REQ],
       cmdclass={
           'build_ext': CustomBuildExt,
           'egg_info': EggInfoCommand,

--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -32,7 +32,7 @@ def is_dali_installed():
         return False
     return True
 
-def pip_install_dali(pkg_req, user=False):
+def pip_install(pkg_req, user=False):
     pip_args = [
         "install",
         "--index-url", NVIDIA_INDEX_URL
@@ -62,9 +62,9 @@ class EggInfoCommand(egg_info):
         """Installing DALI if not already installed during EggInfo command (first egg_info run)"""
         handle_deps = all([keyword in sys.argv for keyword in ["egg_info", "--egg-base"]]) 
         if handle_deps and not is_dali_installed():
-            ret = pip_install_dali(DALI_PKG_REQ, user=False)
+            ret = pip_install(DALI_PKG_REQ, user=False)
             if not ret:
-                ret = pip_install_dali(DALI_PKG_REQ, user=True)
+                ret = pip_install(DALI_PKG_REQ, user=True)
             if not ret:
                 raise RuntimeError("Could not install {}. Please install it and try again".format(DALI_PKG_REQ))
             # For nvidia.dali to be importable, restart the program from scratch

--- a/dali_tf_plugin/setup.py.in
+++ b/dali_tf_plugin/setup.py.in
@@ -39,7 +39,8 @@ class EggInfoCommand(egg_info):
     Handled by "python setup.py egg_info".
     """
 
-    def pip_install(self, *args):
+    @staticmethod
+    def pip_install(*args):
         pip_args = [
             "install",
             "--index-url",
@@ -60,9 +61,9 @@ class EggInfoCommand(egg_info):
         """Run egg_info command."""
         if all([keyword in sys.argv for keyword in ["egg_info", "--egg-base"]]):
             try:
-                assert(self.pip_install(install_requires) == 0)
+                assert(EggInfoCommand.pip_install(install_requires) == 0)
             except:
-                assert(self.pip_install(["--user"] + install_requires) == 0)
+                assert(EggInfoCommand.pip_install(["--user"] + install_requires) == 0)
 
         super(EggInfoCommand, self).run()
 


### PR DESCRIPTION
co-author: @DEKHTIARJonathan 

#### Why we need this PR?
*Pick one, remove the rest*
- It allows DALI TF to resolve dependencies during package build, allowing the user to install DALI TF in a single pip install call

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a custom egg_info step that checks whether DALI is already installed and installs it using pip if not.*
     *After reinstall, the program needs to be relaunched to be able to import the package*
 - Affected modules and functionalities:
     *DALI TF setup.py.in*
 - Key points relevant for the review:
     *Custom dependency installation code*
 - Validation and testing:
     *TODO ?*
 - Documentation (including examples):
     *TODO ?*


**JIRA TASK**: *[DALI-1559]*
