### PR TITLE
Fix failure when DALI runs on pre CUDA 11 driver using a compatibility layer

### DIFF
--- a/dali/util/nvml.h
+++ b/dali/util/nvml.h
@@ -63,8 +63,12 @@ inline void GetNVMLAffinityMask(cpu_set_t * mask, size_t num_cpus) {
   nvmlDevice_t device;
   DALI_CALL(wrapNvmlDeviceGetHandleByIndex(device_idx, &device));
   #if (CUDART_VERSION >= 11000)
-    DALI_CALL(wrapNvmlDeviceGetCpuAffinityWithinScope(device, cpu_set_size, nvml_mask,
-                                                      NVML_AFFINITY_SCOPE_SOCKET));
+    if (wrapHasCuda11NvmlFunctions()) {
+      DALI_CALL(wrapNvmlDeviceGetCpuAffinityWithinScope(device, cpu_set_size, nvml_mask,
+                                                        NVML_AFFINITY_SCOPE_SOCKET));
+    } else {
+      DALI_CALL(wrapNvmlDeviceGetCpuAffinity(device, cpu_set_size, nvml_mask));
+    }
   #else
     DALI_CALL(wrapNvmlDeviceGetCpuAffinity(device, cpu_set_size, nvml_mask));
   #endif


### PR DESCRIPTION
- fixes crash caused by missing nvml symbol nvmlDeviceGetCpuAffinityWithinScope when DALI CUDA 11 build runs on pre 450.x driver with the compatibility layer enabled

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a failure when DALI runs on pre CUDA 11 driver using a compatibility layer

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     fixes crash caused by missing nvml symbol nvmlDeviceGetCpuAffinityWithinScope when DALI CUDA 11 build runs on pre 450.x driver with the compatibility layer enabled
 - Affected modules and functionalities:
     nvml wraper
 - Key points relevant for the review:
     if `is_driver_sufficient` is safe
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
