### PR TITLE
Add more supported types to SliceBase

### DIFF
--- a/dali/core/convert_test.cc
+++ b/dali/core/convert_test.cc
@@ -86,4 +86,12 @@ TEST(ConvertNorm, int2float) {
   EXPECT_NEAR((ConvertNorm<float, int8_t>(64)), 1.0f*64/127, 1e-7f);
 }
 
+TEST(Clamp, int64_2_float16) {
+  int64_t big_num = 0x0FFFFFFFFFFFFFFF;
+  EXPECT_EQ(static_cast<float>(clamp<float16>(big_num)), clamp<float16>(clamp<float>(big_num)));
+  EXPECT_EQ(65504.0f, clamp<float16>(big_num));
+  EXPECT_EQ(-65504.0f, clamp<float16>(-big_num));
+}
+
+
 }  // namespace dali

--- a/dali/operators/generic/slice/slice_base.h
+++ b/dali/operators/generic/slice/slice_base.h
@@ -34,7 +34,7 @@
 
 #define SLICE_TYPES (uint8_t, uint16_t, uint32_t, uint64_t, \
                      int8_t,  int16_t,  int32_t,  int64_t, \
-                     float, float16)
+                     float16, float, double)
 #define SLICE_DIMS (1, 2, 3, 4)
 
 namespace dali {

--- a/dali/operators/generic/slice/slice_base.h
+++ b/dali/operators/generic/slice/slice_base.h
@@ -32,7 +32,9 @@
 #include "dali/pipeline/util/operator_impl_utils.h"
 #include "dali/util/crop_window.h"
 
-#define SLICE_TYPES (uint8_t, int16_t, uint16_t, int32_t, float, float16)
+#define SLICE_TYPES (uint8_t, uint16_t, uint32_t, uint64_t, \
+                     int8_t,  int16_t,  int32_t,  int64_t, \
+                     float, float16)
 #define SLICE_DIMS (1, 2, 3, 4)
 
 namespace dali {

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -167,7 +167,7 @@ DALI_HOST_DEV constexpr bool clamp(T value, ret_type<bool>) {
 
 template <typename T>
 DALI_HOST_DEV constexpr float16 clamp(T value, ret_type<float16>) {
-  float f16_min = -65504.0f, f16_max = 65504.0f;
+  constexpr float f16_min = -65504.0f, f16_max = 65504.0f;
   float f = clamp(value, ret_type<float>());
   f = f < f16_min ? f16_min : f > f16_max ? f16_max : f;
   return static_cast<float16>(f);
@@ -175,7 +175,7 @@ DALI_HOST_DEV constexpr float16 clamp(T value, ret_type<float16>) {
 
 template <typename T>
 DALI_HOST_DEV constexpr T clamp(float16 value, ret_type<T>) {
-  return clamp(static_cast<float>(value), ret_type<T>{});
+  return clamp(static_cast<float>(value), ret_type<T>());
 }
 
 DALI_HOST_DEV constexpr float16 clamp(float16 value, ret_type<float16>) {

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -167,27 +167,21 @@ DALI_HOST_DEV constexpr bool clamp(T value, ret_type<bool>) {
 
 template <typename T>
 DALI_HOST_DEV constexpr float16 clamp(T value, ret_type<float16>) {
-  return static_cast<float16>(value);
-}
-
-// __half does not have a constructor for int64_t, use long long
-DALI_HOST_DEV inline float16 clamp(int64_t value, ret_type<float16>) {
-  return static_cast<float16>(static_cast<long long int>(value));  // NOLINT
-}
-
-// __half does not have a constructor for uint64_t, use unsigned long long
-DALI_HOST_DEV inline float16 clamp(uint64_t value, ret_type<float16>) {
-  return static_cast<float16>(static_cast<unsigned long long int>(value));  // NOLINT
+  float f16_min = -65504.0f, f16_max = 65504.0f;
+  float f = clamp(value, ret_type<float>());
+  f = f < f16_min ? f16_min : f > f16_max ? f16_max : f;
+  return static_cast<float16>(f);
 }
 
 template <typename T>
 DALI_HOST_DEV constexpr T clamp(float16 value, ret_type<T>) {
-  return clamp(static_cast<float>(value), ret_type<T>());
+  return clamp(static_cast<float>(value), ret_type<T>{});
 }
 
 DALI_HOST_DEV constexpr float16 clamp(float16 value, ret_type<float16>) {
   return value;
 }
+
 
 template <typename T, typename U>
 DALI_HOST_DEV constexpr T clamp(U value) {

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -175,6 +175,11 @@ DALI_HOST_DEV inline float16 clamp(int64_t value, ret_type<float16>) {
   return static_cast<float16>(static_cast<long long int>(value));  // NOLINT
 }
 
+// __half does not have a constructor for uint64_t, use unsigned long long
+DALI_HOST_DEV inline float16 clamp(uint64_t value, ret_type<float16>) {
+  return static_cast<float16>(static_cast<unsigned long long int>(value));  // NOLINT
+}
+
 template <typename T>
 DALI_HOST_DEV constexpr T clamp(float16 value, ret_type<T>) {
   return clamp(static_cast<float>(value), ret_type<T>());


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds more supported types to SliceBase operator, needed to be able to slice shapes which are typical int64

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added more types to SliceBase*
     *Added a clamp specialization for uint64, since half doesn't have the necessary conversion constructor*
 - Affected modules and functionalities:
     *Slice and Crop*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
