### PR TITLE
Enhance error messages in case of not supported data types in operators

### DIFF
--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -66,7 +66,7 @@ AudioDecoderCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace
   TYPE_SWITCH(decode_type_, type2id, OutputType, (int16_t, int32_t, float), (
       for (int i=0; i < batch_size; i++)
         decoders_[i] = std::make_unique<GenericAudioDecoder<OutputType>>();
-  ), DALI_FAIL("Unsupported output type"))  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported output type: ", decode_type_)))  // NOLINT
 
   output_desc.resize(2);
 
@@ -198,7 +198,7 @@ void AudioDecoderCpu::DecodeBatch(workspace_t<Backend> &ws) {
 void AudioDecoderCpu::RunImpl(workspace_t<Backend> &ws) {
   TYPE_SWITCH(output_type_, type2id, OutputType, (int16_t, int32_t, float), (
       DecodeBatch<OutputType>(ws);
-  ), DALI_FAIL("Unsupported output type"))  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
 }
 
 }  // namespace dali

--- a/dali/operators/generic/cast.cc
+++ b/dali/operators/generic/cast.cc
@@ -31,8 +31,8 @@ void Cast<CPUBackend>::RunImpl(SampleWorkspace &ws) {
     output.ResizeLike(input);
     TYPE_SWITCH(itype, type2id, IType, CAST_ALLOWED_TYPES, (
       CPUHelper<OType, IType>(output.mutable_data<OType>(), input.data<IType>(), input.size());
-    ), DALI_FAIL("Invalid input type"););  // NOLINT(whitespace/parens)
-  ), DALI_FAIL("Invalid output type"););  // NOLINT(whitespace/parens)
+    ), DALI_FAIL(make_string("Invalid input type: ", itype)););  // NOLINT(whitespace/parens)
+  ), DALI_FAIL(make_string("Invalid output type", output_type_)););  // NOLINT(whitespace/parens)
 }
 
 DALI_REGISTER_OPERATOR(Cast, Cast<CPUBackend>, CPU);

--- a/dali/operators/generic/cast.cu
+++ b/dali/operators/generic/cast.cu
@@ -55,8 +55,8 @@ void Cast<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
 
     TYPE_SWITCH(itype, type2id, IType, CAST_ALLOWED_TYPES, (
       BatchedCast(output.mutable_data<OType>(), input.data<IType>(), input.size(), ws.stream());
-    ), DALI_FAIL("Invalid input type"););  // NOLINT(whitespace/parens)
-  ), DALI_FAIL("Invalid output type"););  // NOLINT(whitespace/parens)
+    ), DALI_FAIL(make_string("Invalid input type: ", itype)););  // NOLINT(whitespace/parens)
+  ), DALI_FAIL(make_string("Invalid output type: ", output_type_)););  // NOLINT(whitespace/parens)
 }
 
 DALI_REGISTER_OPERATOR(Cast, Cast<GPUBackend>, GPU);

--- a/dali/operators/generic/constant.cc
+++ b/dali/operators/generic/constant.cc
@@ -99,7 +99,7 @@ void Constant<CPUBackend>::RunImpl(HostWorkspace &ws) {
           assert(!idata_.empty());
           FillTensorVector<type>(output_, output_shape_, idata_);
         }
-      ), (DALI_FAIL(make_string("Unsupported type: ", to_string(output_type_)))));  // NOLINT
+      ), (DALI_FAIL(make_string("Unsupported type: ", output_type_))));  // NOLINT
   }
   auto &out = ws.OutputRef<CPUBackend>(0);
 

--- a/dali/operators/generic/constant.cu
+++ b/dali/operators/generic/constant.cu
@@ -93,7 +93,7 @@ void Constant<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
           assert(!idata_.empty());
           FillTensorList<type>(output_, output_shape_, idata_, ws.stream());
         }
-      ), (DALI_FAIL(make_string("Unsupported type: ", to_string(output_type_)))));  // NOLINT
+      ), (DALI_FAIL(make_string("Unsupported type: ", output_type_))));  // NOLINT
   }
   auto &out = ws.OutputRef<GPUBackend>(0);
 

--- a/dali/operators/generic/lookup_table.cc
+++ b/dali/operators/generic/lookup_table.cc
@@ -45,7 +45,7 @@ void LookupTable<CPUBackend>::RunImpl(SampleWorkspace &ws) {
         }
       }
     )
-  ), DALI_FAIL("Unsupported input type"); );     // NOLINT
+  ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())); );     // NOLINT
 }
 
 DALI_REGISTER_OPERATOR(LookupTable, LookupTable<CPUBackend>, CPU);

--- a/dali/operators/generic/lookup_table.cu
+++ b/dali/operators/generic/lookup_table.cu
@@ -77,7 +77,7 @@ void LookupTable<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
         out_data, in_data, data_size,
         lookup_table, default_value);
     )
-  ), DALI_FAIL("Unsupported input type"); );     // NOLINT
+  ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())); ); // NOLINT
 }
 
 DALI_REGISTER_OPERATOR(LookupTable, LookupTable<GPUBackend>, GPU);

--- a/dali/operators/generic/lookup_table.h
+++ b/dali/operators/generic/lookup_table.h
@@ -73,8 +73,8 @@ class LookupTable : public Operator<Backend> {
         for (size_t i = 0; i < keys_size; i++) {
           values[keys[i]] = ConvertSat<OutputType>(values_f[i]);
         }
-      ), DALI_FAIL("Unsupported output type");   // NOLINT
-    );                                           // NOLINT
+      ), DALI_FAIL(make_string("Unsupported output type: ", output_type_));  // NOLINT
+    );  // NOLINT
   }
 
   ~LookupTable() override = default;

--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -223,7 +223,7 @@ void Reshape<Backend>::ShapeFromInput(const TensorListLike &tl, bool relative) {
       (int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t),
       (this->ShapeFromInput(view<const type>(tl));),
       (DALI_FAIL(make_string(OpName(), ": shape input must have integral type; got: ",
-                 tl.type().name(), " type: ", tl.type().id()));)
+                 tl.type().id()));)
     );  // NOLINT
   }
 }

--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -223,7 +223,7 @@ void Reshape<Backend>::ShapeFromInput(const TensorListLike &tl, bool relative) {
       (int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t),
       (this->ShapeFromInput(view<const type>(tl));),
       (DALI_FAIL(make_string(OpName(), ": shape input must have integral type; got: ",
-                 tl.type().name(), " (id = ", static_cast<int>(tl.type().id()), ")"));)
+                 tl.type().name(), " type: ", tl.type().id()));)
     );  // NOLINT
   }
 }

--- a/dali/operators/generic/shapes.h
+++ b/dali/operators/generic/shapes.h
@@ -90,7 +90,7 @@ class Shapes : public Operator<Backend> {
     TYPE_SWITCH(output_type_, type2id, type,
                 (int32_t, uint32_t, int64_t, uint64_t, float, double),
       (ConvertShape<type>(out, shape);),
-      (DALI_FAIL("Unsupported type for Shapes")));
+      (DALI_FAIL(make_string("Unsupported type for Shapes: ", output_type_))));
   }
 
   void RunBackend(DeviceWorkspace &ws) {

--- a/dali/operators/generic/slice/slice_base.h
+++ b/dali/operators/generic/slice/slice_base.h
@@ -32,9 +32,7 @@
 #include "dali/pipeline/util/operator_impl_utils.h"
 #include "dali/util/crop_window.h"
 
-#define SLICE_TYPES (uint8_t, uint16_t, uint32_t, uint64_t, \
-                     int8_t,  int16_t,  int32_t,  int64_t, \
-                     float16, float, double)
+#define SLICE_TYPES (uint8_t, int16_t, uint16_t, int32_t, float, float16)
 #define SLICE_DIMS (1, 2, 3, 4)
 
 namespace dali {

--- a/dali/operators/generic/slice/slice_base.h
+++ b/dali/operators/generic/slice/slice_base.h
@@ -34,7 +34,7 @@
 
 #define SLICE_TYPES (uint8_t, uint16_t, uint32_t, uint64_t, \
                      int8_t,  int16_t,  int32_t,  int64_t, \
-                     float, float16)
+                     float16, float, double)
 #define SLICE_DIMS (1, 2, 3, 4)
 
 namespace dali {

--- a/dali/operators/generic/slice/slice_base.h
+++ b/dali/operators/generic/slice/slice_base.h
@@ -32,7 +32,9 @@
 #include "dali/pipeline/util/operator_impl_utils.h"
 #include "dali/util/crop_window.h"
 
-#define SLICE_TYPES (uint8_t, int16_t, uint16_t, int32_t, float, float16)
+#define SLICE_TYPES (uint8_t, uint16_t, uint32_t, uint64_t, \
+                     int8_t,  int16_t,  int32_t,  int64_t, \
+                     float, float16)
 #define SLICE_DIMS (1, 2, 3, 4)
 
 namespace dali {

--- a/dali/operators/generic/transpose/transpose.cc
+++ b/dali/operators/generic/transpose/transpose.cc
@@ -50,7 +50,7 @@ class TransposeCPU : public Transpose<CPUBackend> {
                 TensorView<StorageCPU, const T>{input[i].data<T>(), src_ts}, make_cspan(perm_));
           }, out_shape.tensor_size(i));
       }
-    ), DALI_FAIL(make_string("Input type not supported: ", input_type)));  // NOLINT
+    ), DALI_FAIL(make_string("Unsupported input type: ", input_type)));  // NOLINT
     thread_pool.RunAll();
   }
 };

--- a/dali/operators/generic/transpose/transpose.cc
+++ b/dali/operators/generic/transpose/transpose.cc
@@ -50,7 +50,7 @@ class TransposeCPU : public Transpose<CPUBackend> {
                 TensorView<StorageCPU, const T>{input[i].data<T>(), src_ts}, make_cspan(perm_));
           }, out_shape.tensor_size(i));
       }
-    ), DALI_FAIL("Input type not supported."));  // NOLINT(whitespace/parens)
+    ), DALI_FAIL(make_string("Input type not supported: ", input_type)));  // NOLINT
     thread_pool.RunAll();
   }
 };

--- a/dali/operators/image/color/brightness_contrast.cc
+++ b/dali/operators/image/color/brightness_contrast.cc
@@ -101,8 +101,8 @@ void BrightnessContrastCpu::RunImpl(workspace_t<CPUBackend> &ws) {
                 }, out_shape.tensor_size(sample_id));
               }
           }
-      ), DALI_FAIL("Unsupported output type"))  // NOLINT
-  ), DALI_FAIL("Unsupported input type"))  // NOLINT
+      ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())))  // NOLINT
   tp.RunAll();
 }
 

--- a/dali/operators/image/color/brightness_contrast.cu
+++ b/dali/operators/image/color/brightness_contrast.cu
@@ -71,8 +71,8 @@ void BrightnessContrastGpu::RunImpl(workspace_t<GPUBackend> &ws) {
               kernel_manager_.Run<Kernel>(ws.thread_idx(), 0, ctx, tvout, tvin,
                                           addends_, multipliers_);
           }
-      ), DALI_FAIL(make_string("Unsupported output type: ", input.type().id())))  // NOLINT
-  ), DALI_FAIL(make_string("Unsupported input type: ", output_type_)))  // NOLINT
+      ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())))  // NOLINT
 }
 
 }  // namespace dali

--- a/dali/operators/image/color/brightness_contrast.cu
+++ b/dali/operators/image/color/brightness_contrast.cu
@@ -71,8 +71,8 @@ void BrightnessContrastGpu::RunImpl(workspace_t<GPUBackend> &ws) {
               kernel_manager_.Run<Kernel>(ws.thread_idx(), 0, ctx, tvout, tvin,
                                           addends_, multipliers_);
           }
-      ), DALI_FAIL("Unsupported output type"))  // NOLINT
-  ), DALI_FAIL("Unsupported input type"))  // NOLINT
+      ), DALI_FAIL(make_string("Unsupported output type: ", input.type().id())))  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported input type: ", output_type_)))  // NOLINT
 }
 
 }  // namespace dali

--- a/dali/operators/image/color/color_twist.cc
+++ b/dali/operators/image/color/color_twist.cc
@@ -184,8 +184,8 @@ void ColorTwistCpu::RunImpl(workspace_t<CPUBackend> &ws) {
                 }, out_shape.tensor_size(i));
               }
           }
-      ), DALI_FAIL("Unsupported output type"))  // NOLINT
-  ), DALI_FAIL("Unsupported input type"))  // NOLINT
+      ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())))  // NOLINT
   tp.RunAll();
 }
 

--- a/dali/operators/image/color/color_twist.cu
+++ b/dali/operators/image/color/color_twist.cu
@@ -66,8 +66,8 @@ void ColorTwistGpu::RunImpl(workspace_t<GPUBackend> &ws) {
               kernel_manager_.Run<Kernel>(ws.thread_idx(), 0, ctx, tvout, tvin,
                                           make_cspan(tmatrices_), make_cspan(toffsets_));
           }
-      ), DALI_FAIL("Unsupported output type"))  // NOLINT
-  ), DALI_FAIL("Unsupported input type"))  // NOLINT
+      ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())))  // NOLINT
 }
 
 

--- a/dali/operators/image/peek_shape/peek_image_shape.h
+++ b/dali/operators/image/peek_shape/peek_image_shape.h
@@ -88,7 +88,7 @@ class PeekImageShape : public Operator<CPUBackend> {
         TYPE_SWITCH(output_type_, type2id, type,
                 (int32_t, uint32_t, int64_t, uint64_t, float, double),
           (WriteShape<type>(output[sample_id], shape);),
-          (DALI_FAIL("Unsupported type for Shapes")));
+          (DALI_FAIL(make_string("Unsupported type for Shapes: ", output_type_))));
       }, 0);
       // the amount of work depends on the image format and exact sample which is unknown here
     }

--- a/dali/operators/image/remap/warp_param_provider.h
+++ b/dali/operators/image/remap/warp_param_provider.h
@@ -265,7 +265,7 @@ class WarpParamProvider : public InterpTypeProvider, public BorderTypeProvider<B
       (int16_t, int32_t, int64_t, uint16_t, uint32_t, uint64_t, float),
       (GetTypedPerSampleSize(out_sizes, view<const shape_t>(tensor_vector))),
       (DALI_FAIL(make_string("Warp: Unsupported argument type for \"", size_arg_name_, "\": ",
-        to_string(tensor_vector.type().id()))))
+        tensor_vector.type().id())))
     );  // NOLINT
   }
 

--- a/dali/operators/math/expressions/arithmetic_meta.h
+++ b/dali/operators/math/expressions/arithmetic_meta.h
@@ -655,19 +655,12 @@ inline std::string to_string(ArithmeticOp op) {
  */
 inline DALIDataType BinaryTypePromotion(DALIDataType left, DALIDataType right) {
   DALIDataType result = DALIDataType::DALI_NO_TYPE;
-  TYPE_SWITCH(left, type2id, Left_t, ARITHMETIC_ALLOWED_TYPES,
-    (
-      TYPE_SWITCH(right, type2id, Right_t, ARITHMETIC_ALLOWED_TYPES,
-        (
-          using Result_t = binary_result_t<Left_t, Right_t>;
-          result = TypeInfo::Create<Result_t>().id();
-        ),  // NOLINT(whitespace/parens)
-        (DALI_FAIL("Right operand data type not supported, DALIDataType: " +
-            std::to_string(right));)
-      );   // NOLINT(whitespace/parens)
-    ),  // NOLINT(whitespace/parens)
-    (DALI_FAIL("Left operand data type not supported, DALIDataType: " + std::to_string(left));)
-  );  // NOLINT(whitespace/parens)
+  TYPE_SWITCH(left, type2id, Left_t, ARITHMETIC_ALLOWED_TYPES, (
+    TYPE_SWITCH(right, type2id, Right_t, ARITHMETIC_ALLOWED_TYPES, (
+        using Result_t = binary_result_t<Left_t, Right_t>;
+        result = TypeInfo::Create<Result_t>().id();
+    ), (DALI_FAIL(make_string("Right operand data type not supported, DALIDataType: ", right));))  // NOLINT
+  ), (DALI_FAIL(make_string("Left operand data type not supported, DALIDataType: ", left));));  // NOLINT
   return result;
 }
 

--- a/dali/operators/math/expressions/constant_storage.h
+++ b/dali/operators/math/expressions/constant_storage.h
@@ -103,7 +103,7 @@ class ConstantStorage {
           auto idx = node->GetConstIndex();
           auto *ptr = reinterpret_cast<Type *>(data + idx * kPaddingSize);
           *ptr = static_cast<Type>(constants[idx]);
-        ), DALI_FAIL(make_string("Invalid type: ", node->GetTypeId())););  // NOLINT
+        ), DALI_FAIL(make_string("Unsupported type: ", node->GetTypeId())););  // NOLINT
     }
   }
 

--- a/dali/operators/math/expressions/constant_storage.h
+++ b/dali/operators/math/expressions/constant_storage.h
@@ -103,7 +103,7 @@ class ConstantStorage {
           auto idx = node->GetConstIndex();
           auto *ptr = reinterpret_cast<Type *>(data + idx * kPaddingSize);
           *ptr = static_cast<Type>(constants[idx]);
-        ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
+        ), DALI_FAIL(make_string("Invalid type: ", node->GetTypeId())););  // NOLINT
     }
   }
 

--- a/dali/operators/math/expressions/constant_storage_test.cc
+++ b/dali/operators/math/expressions/constant_storage_test.cc
@@ -72,7 +72,7 @@ TEST_F(ConstantStorageTest, CpuValid) {
           } else {
             EXPECT_EQ(*ptr, static_cast<Type>(reals_[idx]));
           }
-      ), DALI_FAIL(make_string("Invalid type: ", type_id)););  // NOLINT(whitespace/parens)
+      ), DALI_FAIL(make_string("Unsupported type: ", type_id)););  // NOLINT(whitespace/parens)
   }
 }
 
@@ -92,7 +92,7 @@ TEST_F(ConstantStorageTest, GpuValid) {
           } else {
             EXPECT_EQ(*ptr, static_cast<Type>(reals_[idx]));
           }
-      ), DALI_FAIL(make_string("Invalid type: ", type_id)););  // NOLINT(whitespace/parens)
+      ), DALI_FAIL(make_string("Unsupported type: ", type_id)););  // NOLINT(whitespace/parens)
   }
 }
 

--- a/dali/operators/math/expressions/constant_storage_test.cc
+++ b/dali/operators/math/expressions/constant_storage_test.cc
@@ -72,7 +72,7 @@ TEST_F(ConstantStorageTest, CpuValid) {
           } else {
             EXPECT_EQ(*ptr, static_cast<Type>(reals_[idx]));
           }
-      ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
+      ), DALI_FAIL(make_string("Invalid type: ", type_id)););  // NOLINT(whitespace/parens)
   }
 }
 
@@ -92,7 +92,7 @@ TEST_F(ConstantStorageTest, GpuValid) {
           } else {
             EXPECT_EQ(*ptr, static_cast<Type>(reals_[idx]));
           }
-      ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
+      ), DALI_FAIL(make_string("Invalid type: ", type_id)););  // NOLINT(whitespace/parens)
   }
 }
 

--- a/dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h
@@ -48,7 +48,7 @@ std::unique_ptr<ExprImplBase> ExprImplFactoryUnOp(const ExprFunc &expr) {
     } else {
       DALI_FAIL("Expression cannot have a constant operand");
     }
-  ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
+  ), DALI_FAIL(make_string("Invalid type: ", input_type)););  // NOLINT(whitespace/parens)
   return result;
 }
 
@@ -94,14 +94,14 @@ std::unique_ptr<ExprImplBase> ExprImplFactoryBinOp(const ExprFunc &expr) {
       } else if (IsScalarLike(expr[0]) && expr[1].GetNodeType() == NodeType::Tensor) {
         result.reset( new ImplConstantTensor<op, Out_t, Left_t, Right_t>());
       } else if (expr[0].GetNodeType() == NodeType::Tensor &&
-                  expr[1].GetNodeType() == NodeType::Tensor) {
+                 expr[1].GetNodeType() == NodeType::Tensor) {
         // Both are non-scalar tensors
         result.reset(new ImplTensorTensor<op, Out_t, Left_t, Right_t>());
       } else {
         DALI_FAIL("Expression cannot have two scalar operands");
       }
-    ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
-  ), DALI_FAIL("No suitable type found"););  // NOLINT(whitespace/parens)
+    ), DALI_FAIL(make_string("Invalid type (right operand): ", right_type)););  // NOLINT
+  ), DALI_FAIL(make_string("Invalid type (left operarand): ", left_type)););  // NOLINT
   return result;
 }
 

--- a/dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h
@@ -48,7 +48,7 @@ std::unique_ptr<ExprImplBase> ExprImplFactoryUnOp(const ExprFunc &expr) {
     } else {
       DALI_FAIL("Expression cannot have a constant operand");
     }
-  ), DALI_FAIL(make_string("Invalid type: ", input_type)););  // NOLINT(whitespace/parens)
+  ), DALI_FAIL(make_string("Unsupported type: ", input_type)););  // NOLINT(whitespace/parens)
   return result;
 }
 

--- a/dali/operators/math/normalize/normalize.h
+++ b/dali/operators/math/normalize/normalize.h
@@ -86,8 +86,8 @@ class NormalizeBase : public Operator<Backend> {
     TYPE_SWITCH(input_type_, type2id, InputType, DALI_NORMALIZE_INPUT_TYPES, (
       TYPE_SWITCH(output_type_, type2id, OutputType, DALI_NORMALIZE_OUTPUT_TYPES, (
         This().template SetupTyped<OutputType, InputType>(ws);
-      ), (DALI_FAIL("Normalize: unsupported output type")))  // NOLINT
-    ), (DALI_FAIL("Normalize: unsupported input type")));    // NOLINT
+      ), (DALI_FAIL(make_string("Normalize: unsupported output type: ", output_type_))))  // NOLINT
+    ), (DALI_FAIL(make_string("Normalize: unsupported input type: ", input_type_))));    // NOLINT
     return true;
   }
 

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -42,7 +42,8 @@ void NumpyReader::TransposeHelper(Tensor<CPUBackend>& output, const Tensor<CPUBa
     kernels::Transpose(
       TensorView<StorageCPU, InputType>{output.mutable_data<InputType>(), out_ts},
       TensorView<StorageCPU, const InputType>{input.data<InputType>(), in_ts},
-      make_cspan(perm));), DALI_FAIL("Input type not supported."));
+      make_cspan(perm));
+  ), DALI_FAIL(make_string("Input type not supported: ", input_type)));  // NOLINT
 }
 
 DALI_REGISTER_OPERATOR(NumpyReader, NumpyReader, CPU);

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -43,7 +43,7 @@ void NumpyReader::TransposeHelper(Tensor<CPUBackend>& output, const Tensor<CPUBa
       TensorView<StorageCPU, InputType>{output.mutable_data<InputType>(), out_ts},
       TensorView<StorageCPU, const InputType>{input.data<InputType>(), in_ts},
       make_cspan(perm));
-  ), DALI_FAIL(make_string("Input type not supported: ", input_type)));  // NOLINT
+  ), DALI_FAIL(make_string("Unsupported input type: ", input_type)));  // NOLINT
 }
 
 DALI_REGISTER_OPERATOR(NumpyReader, NumpyReader, CPU);

--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -12,18 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#define DALI_TYPENAME_REGISTERER(TypeString) \
-{                                            \
-  return TypeString;                         \
-}
-
 #define DALI_TYPEID_REGISTERER(Type, dtype)                                      \
 {                                                                                \
   static DALIDataType type_id = TypeTable::instance().RegisterType<Type>(dtype); \
   return type_id;                                                                \
 }
 
-#define DALI_REGISTER_TYPE_IMPL(Type, Name, Id) \
+#define DALI_REGISTER_TYPE_IMPL(Type, Id) \
 const auto &_type_info_##Id = TypeTable::GetTypeID<Type>()
 
 #include "dali/pipeline/data/types.h"
@@ -197,7 +192,5 @@ template void TypeInfo::Copy<GPUBackend, CPUBackend>(void **dsts,
 
 template void TypeInfo::Copy<GPUBackend, GPUBackend>(void **dsts,
     const void *src, const Index *sizes, int n, cudaStream_t stream, bool use_copy_kernel) const;
-
-
 
 }  // namespace dali

--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#define DALI_TYPENAME_REGISTERER(Type, dtype)                                    \
+{                                                                                \
+  return to_string(dtype);                                                       \
+}
+
 #define DALI_TYPEID_REGISTERER(Type, dtype)                                      \
 {                                                                                \
   static DALIDataType type_id = TypeTable::instance().RegisterType<Type>(dtype); \

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -36,10 +36,6 @@
 #include "dali/operators/reader/parser/tf_feature.h"
 #endif  // DALI_BUILD_PROTO3
 
-#ifndef DALI_TYPENAME_REGISTERER
-#define DALI_TYPENAME_REGISTERER(...)
-#endif
-
 #ifndef DALI_TYPEID_REGISTERER
 #define DALI_TYPEID_REGISTERER(...)
 #endif
@@ -119,6 +115,103 @@ enum DALIDataType : int {
   DALI_PYTHON_OBJECT   = 24,
   DALI_DATATYPE_END    = 1000
 };
+
+inline std::ostream &operator<<(std::ostream &os, DALIDataType t) {
+  switch (t) {
+    case DALI_NO_TYPE:
+      os << "undefined";
+      break;
+    case DALI_UINT8:
+      os << "uint8";
+      break;
+    case DALI_UINT16:
+      os << "uint16";
+      break;
+    case DALI_UINT32:
+      os << "uint32";
+      break;
+    case DALI_UINT64:
+      os << "uint64";
+      break;
+    case DALI_INT8:
+      os << "int8";
+      break;
+    case DALI_INT16:
+      os << "int16";
+      break;
+    case DALI_INT32:
+      os << "int32";
+      break;
+    case DALI_INT64:
+      os << "int64";
+      break;
+    case DALI_FLOAT16:
+      os << "float16";
+      break;
+    case DALI_FLOAT:
+      os << "float";
+      break;
+    case DALI_FLOAT64:
+      os << "float64";
+      break;
+    case DALI_BOOL:
+      os << "bool";
+      break;
+    case DALI_STRING:
+      os << "string";
+      break;
+    case DALI_BOOL_VEC:
+      os << "vector<bool>";
+      break;
+    case DALI_INT_VEC:
+      os << "vector<int>";
+      break;
+    case DALI_STRING_VEC:
+      os << "vector<string>";
+      break;
+    case DALI_FLOAT_VEC:
+      os << "vector<float>";
+      break;
+#ifdef DALI_BUILD_PROTO3
+    case DALI_TF_FEATURE:
+      os << "TFUtil::Feature";
+      break;
+    case DALI_TF_FEATURE_VEC:
+      os << "vector<TFUtil::Feature>";
+      break;
+    case DALI_TF_FEATURE_DICT:
+      os << "TFUtil::Feature dictionary";
+      break;
+#endif  // DALI_BUILD_PROTO3
+    case DALI_IMAGE_TYPE:
+      os << "DALIImageType";
+      break;
+    case DALI_DATA_TYPE:
+      os << "DALIDataType";
+      break;
+    case DALI_INTERP_TYPE:
+      os << "DALIInterpType";
+      break;
+    case DALI_TENSOR_LAYOUT:
+      os << "TensorLayout";
+      break;
+    case DALI_PYTHON_OBJECT:
+      os << "Python object";
+      break;
+    case DALI_DATATYPE_END:  // fall through
+    default:
+      os << "Invalid type";
+      break;
+  }
+  os << "(type id " << static_cast<int>(t) << ")";
+  return os;
+}
+
+inline std::string to_string(DALIDataType dtype) {
+  std::stringstream ss;
+  ss << dtype;
+  return ss.str();
+}
 
 constexpr bool IsFloatingPoint(DALIDataType type) {
   switch (type) {
@@ -288,17 +381,11 @@ class DLL_PUBLIC TypeInfo {
   }
 
   DLL_PUBLIC inline bool operator==(const TypeInfo &rhs) const {
-    if ((rhs.id_ == id_) &&
-        (rhs.type_size_ == type_size_) &&
-        (rhs.name_ == name_)) {
-      return true;
-    }
-    return false;
+    return rhs.id_ == id_ && rhs.type_size_ == type_size_;
   }
 
  private:
   detail::Copier copier_;
-
 
   DALIDataType id_;
   size_t type_size_;
@@ -326,7 +413,7 @@ class DLL_PUBLIC TypeTable {
 
   template <typename T>
   DLL_PUBLIC static string GetTypeName() {
-    return TypeNameHelper<T>::GetTypeName();
+    return to_string(GetTypeID<T>());
   }
 
   DLL_PUBLIC static const TypeInfo& GetTypeInfo(DALIDataType dtype) {
@@ -334,7 +421,7 @@ class DLL_PUBLIC TypeTable {
     std::lock_guard<spinlock> guard(inst.lock_);
     auto id_it = inst.type_info_map_.find(dtype);
     DALI_ENFORCE(id_it != inst.type_info_map_.end(),
-        "Type with id " + to_string((size_t)dtype) + " was not registered.");
+        "Type with id " + to_string(dtype) + " was not registered.");
     return id_it->second;
   }
 
@@ -374,21 +461,6 @@ class DLL_PUBLIC TypeTable {
   DLL_PUBLIC static TypeTable &instance();
 };
 
-
-template <typename T, typename A>
-struct TypeNameHelper<std::vector<T, A> > {
-  static string GetTypeName() {
-    return "list of " + TypeTable::GetTypeName<T>();
-  }
-};
-
-template <typename T, size_t N>
-struct TypeNameHelper<std::array<T, N> > {
-  static string GetTypeName() {
-    return "list of " + TypeTable::GetTypeName<T>();
-  }
-};
-
 template <typename T>
 void TypeInfo::SetType(DALIDataType dtype) {
   // Note: We enforce the fact that NoType is invalid by
@@ -399,14 +471,10 @@ void TypeInfo::SetType(DALIDataType dtype) {
   } else {
     id_ = DALI_NO_TYPE;
   }
-  name_ = TypeTable::GetTypeName<T>();
+  name_ = to_string(dtype);
 
   // Get copier for this type
   copier_ = detail::GetCopier<T>();
-}
-
-inline std::string to_string(const DALIDataType& dtype) {
-  return TypeTable::GetTypeInfo(dtype).name();
 }
 
 /**
@@ -429,37 +497,31 @@ DLL_PUBLIC inline bool IsValidType(const TypeInfo &type) {
 // the type as a string. This does not work for non-fundamental types,
 // as we do not have any mechanism for calling the constructor of the
 // type when the buffer allocates the memory.
-#define DALI_REGISTER_TYPE_WITH_NAME(Type, TypeString, dtype)       \
-  template <> DLL_PUBLIC string TypeTable::GetTypeName<Type>()      \
-    DALI_TYPENAME_REGISTERER(TypeString);                           \
+#define DALI_REGISTER_TYPE(Type, dtype)                             \
   template <> DLL_PUBLIC DALIDataType TypeTable::GetTypeID<Type>()  \
     DALI_TYPEID_REGISTERER(Type, dtype);                            \
   DALI_STATIC_TYPE_MAPPING(Type, dtype);                            \
-  DALI_REGISTER_TYPE_IMPL(Type, TypeString, dtype);
-
-#define DALI_REGISTER_TYPE(Type, dtype) \
-  DALI_REGISTER_TYPE_WITH_NAME(Type, #Type, dtype)
+  DALI_REGISTER_TYPE_IMPL(Type, dtype);
 
 // Instantiate some basic types
-DALI_REGISTER_TYPE_WITH_NAME(NoType,   "NoType", DALI_NO_TYPE);
-DALI_REGISTER_TYPE_WITH_NAME(uint8_t,  "uint8",  DALI_UINT8);
-DALI_REGISTER_TYPE_WITH_NAME(uint16_t, "uint16", DALI_UINT16);
-DALI_REGISTER_TYPE_WITH_NAME(uint32_t, "uint32", DALI_UINT32);
-DALI_REGISTER_TYPE_WITH_NAME(uint64_t, "uint64", DALI_UINT64);
-DALI_REGISTER_TYPE_WITH_NAME(int8_t,   "int8",   DALI_INT8);
-DALI_REGISTER_TYPE_WITH_NAME(int16_t,  "int16",  DALI_INT16);
-DALI_REGISTER_TYPE_WITH_NAME(int32_t,  "int32",  DALI_INT32);
-DALI_REGISTER_TYPE_WITH_NAME(int64_t,  "int64",  DALI_INT64);
-
-DALI_REGISTER_TYPE(float16,          DALI_FLOAT16);
-DALI_REGISTER_TYPE(float,            DALI_FLOAT);
-DALI_REGISTER_TYPE(double,           DALI_FLOAT64);
-DALI_REGISTER_TYPE(bool,             DALI_BOOL);
-DALI_REGISTER_TYPE(string,           DALI_STRING);
-DALI_REGISTER_TYPE(DALIImageType,    DALI_IMAGE_TYPE);
-DALI_REGISTER_TYPE(DALIDataType,     DALI_DATA_TYPE);
-DALI_REGISTER_TYPE(DALIInterpType,   DALI_INTERP_TYPE);
-DALI_REGISTER_TYPE(TensorLayout,     DALI_TENSOR_LAYOUT);
+DALI_REGISTER_TYPE(NoType,         DALI_NO_TYPE);
+DALI_REGISTER_TYPE(uint8_t,        DALI_UINT8);
+DALI_REGISTER_TYPE(uint16_t,       DALI_UINT16);
+DALI_REGISTER_TYPE(uint32_t,       DALI_UINT32);
+DALI_REGISTER_TYPE(uint64_t,       DALI_UINT64);
+DALI_REGISTER_TYPE(int8_t,         DALI_INT8);
+DALI_REGISTER_TYPE(int16_t,        DALI_INT16);
+DALI_REGISTER_TYPE(int32_t,        DALI_INT32);
+DALI_REGISTER_TYPE(int64_t,        DALI_INT64);
+DALI_REGISTER_TYPE(float16,        DALI_FLOAT16);
+DALI_REGISTER_TYPE(float,          DALI_FLOAT);
+DALI_REGISTER_TYPE(double,         DALI_FLOAT64);
+DALI_REGISTER_TYPE(bool,           DALI_BOOL);
+DALI_REGISTER_TYPE(string,         DALI_STRING);
+DALI_REGISTER_TYPE(DALIImageType,  DALI_IMAGE_TYPE);
+DALI_REGISTER_TYPE(DALIDataType,   DALI_DATA_TYPE);
+DALI_REGISTER_TYPE(DALIInterpType, DALI_INTERP_TYPE);
+DALI_REGISTER_TYPE(TensorLayout,   DALI_TENSOR_LAYOUT);
 
 
 #ifdef DALI_BUILD_PROTO3

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -161,26 +161,26 @@ inline std::ostream &operator<<(std::ostream &os, DALIDataType t) {
       os << "string";
       break;
     case DALI_BOOL_VEC:
-      os << "vector<bool>";
+      os << "list of bool";
       break;
     case DALI_INT_VEC:
-      os << "vector<int>";
+      os << "list of int";
       break;
     case DALI_STRING_VEC:
-      os << "vector<string>";
+      os << "list of string";
       break;
     case DALI_FLOAT_VEC:
-      os << "vector<float>";
+      os << "list of float";
       break;
 #ifdef DALI_BUILD_PROTO3
     case DALI_TF_FEATURE:
       os << "TFUtil::Feature";
       break;
     case DALI_TF_FEATURE_VEC:
-      os << "vector<TFUtil::Feature>";
+      os << "list of TFUtil::Feature";
       break;
     case DALI_TF_FEATURE_DICT:
-      os << "TFUtil::Feature dictionary";
+      os << "dictionary of TFUtil::Feature";
       break;
 #endif  // DALI_BUILD_PROTO3
     case DALI_IMAGE_TYPE:

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -591,7 +591,7 @@ DALI_REGISTER_TYPE(std::vector<float>, DALI_FLOAT_VEC);
       }                                              \
       break;                                         \
     default:                                         \
-      DALI_FAIL("Unknown type");                     \
+      DALI_FAIL(make_string("Unknown type: ", type)); \
   }
 
 #define DALI_TYPE_SWITCH(type, DType, ...)           \
@@ -641,7 +641,7 @@ DALI_REGISTER_TYPE(std::vector<float>, DALI_FLOAT_VEC);
       }                                              \
       break;                                         \
     default:                                         \
-      DALI_FAIL("Unknown type");                     \
+      DALI_FAIL(make_string("Unknown type: ", type)); \
   }
 }  // namespace dali
 

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -119,7 +119,7 @@ enum DALIDataType : int {
 inline std::ostream &operator<<(std::ostream &os, DALIDataType t) {
   switch (t) {
     case DALI_NO_TYPE:
-      os << "undefined";
+      os << "no_type";
       break;
     case DALI_UINT8:
       os << "uint8";
@@ -200,10 +200,9 @@ inline std::ostream &operator<<(std::ostream &os, DALIDataType t) {
       break;
     case DALI_DATATYPE_END:  // fall through
     default:
-      os << "Invalid type";
+      os << "Unknown type (type id " << static_cast<int>(t) << ")";
       break;
   }
-  os << "(type id " << static_cast<int>(t) << ")";
   return os;
 }
 

--- a/dali/pipeline/data/types_test.cc
+++ b/dali/pipeline/data/types_test.cc
@@ -102,7 +102,7 @@ TYPED_TEST(TypesTest, TestRegisteredType) {
   TypeInfo type;
 
   // Verify we start with no type
-  ASSERT_EQ(type.name(), "NoType");
+  ASSERT_EQ(type.name(), "no_type");
   ASSERT_EQ(type.size(), 0);
 
   type.SetType<T>();

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1380,7 +1380,7 @@ PYBIND11_MODULE(backend_impl, m) {
          [](OpSpec *spec, const string &name, DALIDataType data_type) -> OpSpec & {
            TYPE_SWITCH(data_type, type2id, T, (std::string, bool, int32_t, int64_t, float),
              (spec->AddArg(name, std::vector<T>());),
-             (DALI_FAIL("Unsupported data type: " + to_string(data_type))));
+             (DALI_FAIL(make_string("Unsupported data type: ", data_type))));
            return *spec;
          }, py::return_value_policy::reference_internal);
 

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -175,11 +175,6 @@ DALI_HOST_DEV inline float16 clamp(int64_t value, ret_type<float16>) {
   return static_cast<float16>(static_cast<long long int>(value));  // NOLINT
 }
 
-// __half does not have a constructor for uint64_t, use unsigned long long
-DALI_HOST_DEV inline float16 clamp(uint64_t value, ret_type<float16>) {
-  return static_cast<float16>(static_cast<unsigned long long int>(value));  // NOLINT
-}
-
 template <typename T>
 DALI_HOST_DEV constexpr T clamp(float16 value, ret_type<T>) {
   return clamp(static_cast<float>(value), ret_type<T>());

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -175,6 +175,11 @@ DALI_HOST_DEV inline float16 clamp(int64_t value, ret_type<float16>) {
   return static_cast<float16>(static_cast<long long int>(value));  // NOLINT
 }
 
+// __half does not have a constructor for uint64_t, use unsigned long long
+DALI_HOST_DEV inline float16 clamp(uint64_t value, ret_type<float16>) {
+  return static_cast<float16>(static_cast<unsigned long long int>(value));  // NOLINT
+}
+
 template <typename T>
 DALI_HOST_DEV constexpr T clamp(float16 value, ret_type<T>) {
   return clamp(static_cast<float>(value), ret_type<T>());


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It improves error message in type switch 

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added DALIDataType string conversion*
     *Adjusted every TYPE_SWITCH instance that was not printing the invalid type*
 - Affected modules and functionalities:
     *Several ops*
 - Key points relevant for the review:
     *Changes in the way we handle type names*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
