### PR TITLE
Fix docker/build.sh to use Python 3 for TF plugin

### DIFF
--- a/docker/Docker_run_cuda
+++ b/docker/Docker_run_cuda
@@ -11,13 +11,16 @@ ENV PYV=${PYV}
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         git \
+        python3-distutils \
         python$PYVER \
         python$PYVER-dev && \
     rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONIOENCODING utf-8
 ENV LC_ALL C.UTF-8
-RUN ln -s /usr/bin/python$PYVER /usr/bin/python && \
+RUN rm -f /usr/bin/python && \
+    rm -f /usr/bin/python`echo $PYVER | cut -c1-1` && \
+    ln -s /usr/bin/python$PYVER /usr/bin/python && \
     ln -s /usr/bin/python$PYVER /usr/bin/python`echo $PYVER | cut -c1-1`
 
 # If installing multiple pips, install pip2 last so that pip == pip2 when done.
@@ -25,7 +28,7 @@ RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
 
-COPY --from=builder /wheelhouse/nvidia_dali-* /opt/dali/
+COPY --from=builder /wheelhouse/nvidia_dali_* /opt/dali/
 COPY --from=builder /wheelhouse/nvidia-dali-tf-plugin-*.tar.gz /opt/dali/
 
 RUN pip install /opt/dali/*.whl

--- a/docker/Dockerfile.customopbuilder.clean
+++ b/docker/Dockerfile.customopbuilder.clean
@@ -7,9 +7,9 @@ FROM ${TF_CUSTOM_OP_IMAGE}
 # TF_CUSTOM_OP_IMAGE=tensorflow/tensorflow:custom-op-gpu-ubuntu16 for manylinux2010 tagged TF pip artifacts
 # More info here: https://github.com/tensorflow/custom-op
 
-ARG PYVER=2.7
+ARG PYVER=3.6
 ENV PYVER=${PYVER}
-ARG PYV=27
+ARG PYV=36
 ENV PYV=${PYV}
 
 # Python 3.6 and 3.7 are not available in Ubuntu 14

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,7 +4,7 @@ usage="ENV1=VAL1 ENV2=VAL2 [...] $(basename "$0") [-h] -- this is simple, one cl
 a build environment
 
 To change build configuration please export appropriate env variables (for exact meaning please check the README):
-PYVER=[default 3.6]
+PYVER=[default 3.6, required only by Run image]
 CUDA_VERSION=[default 11.0, accepts also 10.0]
 NVIDIA_BUILD_ID=[default 12345]
 CREATE_WHL=[default YES]
@@ -72,15 +72,32 @@ export DEPS_IMAGE=nvidia/dali:cu${CUDA_VER}_${ARCH}.deps
 export CUDA_DEPS_IMAGE=nvidia/dali:cuda${CUDA_VER}_${ARCH}.toolkit
 export BUILDER=nvidia/dali:cu${CUDA_VER}_${ARCH}.build
 export BUILDER_WHL=nvidia/dali:cu${CUDA_VER}_${ARCH}.build_whl
-export BUILDER_DALI_TF_BASE_MANYLINUX1=nvidia/dali:cu${CUDA_VER}.build_tf_base_manylinux1
 export BUILDER_DALI_TF_BASE_MANYLINUX2010=nvidia/dali:cu${CUDA_VER}.build_tf_base_manylinux2010
 export BUILDER_DALI_TF_BASE_WITH_WHEEL=nvidia/dali:cu${CUDA_VER}.build_tf_base_with_whl
-export BUILDER_DALI_TF_MANYLINUX1=nvidia/dali:cu${CUDA_VER}.build_tf_manylinux1
 export BUILDER_DALI_TF_MANYLINUX2010=nvidia/dali:cu${CUDA_VER}.build_tf_manylinux2010
 export BUILDER_DALI_TF_SDIST=nvidia/dali:cu${CUDA_VER}_${ARCH}.build_tf_sdist
 export RUN_IMG=nvidia/dali:py${PYV}_cu${CUDA_VER}.run
 export GIT_SHA=$(git rev-parse HEAD)
 export DALI_TIMESTAMP=$(date +%Y%m%d)
+
+# Find out which CLI options to use for NVIDIA Container Toolkit needed for TF PLUGIN build
+if [[ "$BUILD_TF_PLUGIN" = "YES" ]]; then
+  if docker run --gpus all nvidia/cuda:${CUDA_VERSION}-base nvidia-smi ; then
+    export NVDOCKER_COMMAND="docker run --gpus all"
+  elif docker run --runtime nvidia nvidia/cuda:${CUDA_VERSION}-base nvidia-smi ; then
+    export NVDOCKER_COMMAND="docker run --runtime nvidia"
+  elif nvidia-docker run nvidia/cuda:${CUDA_VERSION}-base nvidia-smi ; then
+    export NVDOCKER_COMMAND="nvidia-docker run"
+  else
+    echo "Unable to use NVIDIA Container Toolkit."
+    echo "which is required when BUILD_TF_PLUGIN = YES"
+    echo "Unable to use deprecated nvidia-docker2."
+    echo "Make sure one of them is installed."
+    exit 1
+  fi
+fi
+
+echo $NVDOCKER_COMMAND
 
 set -o errexit
 
@@ -100,20 +117,13 @@ if [[ "$REBUILD_BUILDERS" != "NO" || "$(docker images -q ${BUILDER} 2> /dev/null
                                --build-arg "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" --target builder -f docker/Dockerfile .
 fi
 
-if [[ "$BUILD_TF_PLUGIN" == "YES" && "${PREBUILD_TF_PLUGINS}" == "YES" && ("$REBUILD_BUILDERS" != "NO" || "$(docker images -q ${BUILDER_DALI_TF_BASE_MANYLINUX1} 2> /dev/null)" == "" || "$(docker images -q ${BUILDER_DALI_TF_BASE_MANYLINUX2010} 2> /dev/null)"  == "") ]]; then
-    echo "Build DALI TF base (manylinux1)"
-    TF_CUSTOM_OP_IMAGE_MANYLINUX1="tensorflow/tensorflow:custom-op-gpu-ubuntu14"
-    docker build -t ${BUILDER_DALI_TF_BASE_MANYLINUX1} \
-           --build-arg "TF_CUSTOM_OP_IMAGE=${TF_CUSTOM_OP_IMAGE_MANYLINUX1}" \
-           --build-arg "CUDA_IMAGE=${CUDA_DEPS_IMAGE}" \
-           -f docker/Dockerfile.customopbuilder.clean .
+if [[ "$BUILD_TF_PLUGIN" == "YES" && "${PREBUILD_TF_PLUGINS}" == "YES" && ("$REBUILD_BUILDERS" != "NO" || "$(docker images -q ${BUILDER_DALI_TF_BASE_MANYLINUX2010} 2> /dev/null)"  == "") ]]; then
     echo "Build DALI TF base (manylinux2010)"
     TF_CUSTOM_OP_IMAGE_MANYLINUX2010="tensorflow/tensorflow:custom-op-gpu-ubuntu16"
     docker build -t ${BUILDER_DALI_TF_BASE_MANYLINUX2010} \
            --build-arg "TF_CUSTOM_OP_IMAGE=${TF_CUSTOM_OP_IMAGE_MANYLINUX2010}" \
            --build-arg "CUDA_IMAGE=${CUDA_DEPS_IMAGE}" \
            -f docker/Dockerfile.customopbuilder.clean .
-
 fi
 
 if [ "$BUILD_INHOST" == "YES" ]; then
@@ -181,38 +191,6 @@ else
                                    -f docker/Dockerfile .
 fi
 
-
-if [ "$CREATE_RUNNER" == "YES" ]; then
-    echo "Runner image:" ${RUN_IMG}
-    echo "You can run this image with DALI installed inside, keep in mind to install neccessary FW package as well"
-    if [ ${CUDA_VER} == "100" ] ; then
-        export CUDA_IMAGE_NAME="nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04"
-    elif [ ${CUDA_VER} == "111" ] ; then
-        export CUDA_IMAGE_NAME="nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
-    else
-        echo "**************************************************************"
-        echo "Not supported CUDA version"
-        echo "**************************************************************"
-    fi
-    echo ${CUDA_VER}
-    echo ${CUDA_IMAGE_NAME}
-    export BUILDER_TMP=${BUILDER_WHL}
-    # for intree build we don't have docker image with whl inside so create one
-    if [ "$BUILD_INHOST" = "YES" ]; then
-        export BUILDER_TMP=${BUILDER}_tmp
-        DOCKER_FILE_TMP=$(mktemp)
-        echo -e "FROM scratch\n"          \
-                "COPY ./${DALI_BUILD_DIR}/nvidia* /wheelhouse/\n" > ${DOCKER_FILE_TMP}
-        docker build -t ${BUILDER_TMP} -f ${DOCKER_FILE_TMP} .
-        rm ${DOCKER_FILE_TMP}
-    fi
-    docker build -t ${RUN_IMG} --build-arg "BUILD_IMAGE_NAME=${BUILDER_TMP}" --build-arg "CUDA_IMAGE_NAME=${CUDA_IMAGE_NAME}" --build-arg "PYVER=${PYVER}" --build-arg "PYV=${PYV}" -f Docker_run_cuda .
-    # remove scratch image
-    if [ "$BUILD_INHOST" = "YES" ]; then
-        docker rmi ${BUILDER_TMP}
-    fi
-fi
-
 mkdir -p ./wheelhouse/
 
 if [ "$CREATE_WHL" == "YES" ]; then
@@ -240,7 +218,7 @@ if [[ "$CREATE_WHL" == "YES" && "$BUILD_TF_PLUGIN" = "YES" ]]; then
 #            -f docker/Dockerfile_dali_tf \
 #            --target base_with_wheel \
 #            .
-#     nvidia-docker run --name ${DALI_TF_BUILDER_CONTAINER} \
+#     $NVDOCKER_COMMAND --name ${DALI_TF_BUILDER_CONTAINER} \
 #            --user root -v $(pwd):/opt/dali -v ${tmp_wheelhouse}:/dali_tf_sdist \
 #            ${BUILDER_DALI_TF_BASE_WITH_WHEEL} /bin/bash -c \
 #            "cd /opt/dali/dali_tf_plugin &&                \
@@ -253,26 +231,17 @@ if [[ "$CREATE_WHL" == "YES" && "$BUILD_TF_PLUGIN" = "YES" ]]; then
 
     mkdir -p ./dali_tf_plugin/prebuilt/;
     if [ "${PREBUILD_TF_PLUGINS}" == "YES" ]; then
-        echo "Build image:" ${BUILDER_DALI_TF_MANYLINUX1}
-        docker build -t ${BUILDER_DALI_TF_MANYLINUX1} -f docker/Dockerfile_dali_tf \
-            --build-arg "TF_CUSTOM_OP_BUILDER_IMAGE=${BUILDER_DALI_TF_BASE_MANYLINUX1}" \
-            .
-        export DALI_TF_BUILDER_CONTAINER_MANYLINUX1="extract_dali_tf_prebuilt_manylinux1"
-        nvidia-docker run --name ${DALI_TF_BUILDER_CONTAINER_MANYLINUX1} ${BUILDER_DALI_TF_MANYLINUX1} /bin/bash -c 'source /opt/dali/dali_tf_plugin/build_in_custom_op_docker.sh'
-        docker cp "${DALI_TF_BUILDER_CONTAINER_MANYLINUX1}:/prebuilt/." "prebuilt_manylinux1"
-        docker rm -f "${DALI_TF_BUILDER_CONTAINER_MANYLINUX1}"
-
         echo "Build image:" ${BUILDER_DALI_TF_MANYLINUX2010}
         docker build -t ${BUILDER_DALI_TF_MANYLINUX2010} -f docker/Dockerfile_dali_tf \
             --build-arg "TF_CUSTOM_OP_BUILDER_IMAGE=${BUILDER_DALI_TF_BASE_MANYLINUX2010}" \
             .
         export DALI_TF_BUILDER_CONTAINER_MANYLINUX2010="extract_dali_tf_prebuilt_manylinux2010"
-        nvidia-docker run --name ${DALI_TF_BUILDER_CONTAINER_MANYLINUX2010} ${BUILDER_DALI_TF_MANYLINUX2010} /bin/bash -c 'source /opt/dali/dali_tf_plugin/build_in_custom_op_docker.sh'
+        $NVDOCKER_COMMAND --name ${DALI_TF_BUILDER_CONTAINER_MANYLINUX2010} ${BUILDER_DALI_TF_MANYLINUX2010} /bin/bash -c 'source /opt/dali/dali_tf_plugin/build_in_custom_op_docker.sh'
         docker cp "${DALI_TF_BUILDER_CONTAINER_MANYLINUX2010}:/prebuilt/." "prebuilt_manylinux2010"
         docker rm -f "${DALI_TF_BUILDER_CONTAINER_MANYLINUX2010}"
 
-        cp -r ./prebuilt_manylinux1/* ./prebuilt_manylinux2010/* ./dali_tf_plugin/prebuilt/;
-        rm -rf ./prebuilt_manylinux2010/ ./prebuilt_manylinux1/
+        cp -r ./prebuilt_manylinux2010/* ./dali_tf_plugin/prebuilt/;
+        rm -rf ./prebuilt_manylinux2010/
     fi
 
     docker build -t ${BUILDER_DALI_TF_SDIST} \
@@ -284,7 +253,7 @@ if [[ "$CREATE_WHL" == "YES" && "$BUILD_TF_PLUGIN" = "YES" ]]; then
            --build-arg "DALI_TIMESTAMP=${DALI_TIMESTAMP}" \
            . ;
     export DALI_TF_BUILDER_CONTAINER_SDIST="extract_dali_tf_sdist"
-    nvidia-docker run --name "${DALI_TF_BUILDER_CONTAINER_SDIST}" "${BUILDER_DALI_TF_SDIST}" /bin/bash -c \
+    $NVDOCKER_COMMAND --name "${DALI_TF_BUILDER_CONTAINER_SDIST}" "${BUILDER_DALI_TF_SDIST}" /bin/bash -c \
         'cd /opt/dali/dali_tf_plugin && source make_dali_tf_sdist.sh'
     docker cp "${DALI_TF_BUILDER_CONTAINER_SDIST}:/dali_tf_sdist/." "dali_tf_sdist"
     cp dali_tf_sdist/*.tar.gz wheelhouse/
@@ -295,5 +264,37 @@ if [[ "$CREATE_WHL" == "YES" && "$BUILD_TF_PLUGIN" = "YES" ]]; then
     rm -rf dali_tf_sdist/
 # fi
 fi
+
+if [ "$CREATE_RUNNER" == "YES" ]; then
+    echo "Runner image:" ${RUN_IMG}
+    echo "You can run this image with DALI installed inside, keep in mind to install neccessary FW package as well"
+    if [ ${CUDA_VER} == "100" ] ; then
+        export CUDA_IMAGE_NAME="nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04"
+    elif [ ${CUDA_VER} == "110" ] ; then
+        export CUDA_IMAGE_NAME="nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
+    else
+        echo "**************************************************************"
+        echo "Not supported CUDA version"
+        echo "**************************************************************"
+    fi
+    echo ${CUDA_VER}
+    echo ${CUDA_IMAGE_NAME}
+    export BUILDER_TMP=${BUILDER_WHL}
+    # for intree build we don't have docker image with whl inside so create one
+    if [ "$BUILD_INHOST" = "YES" ]; then
+        export BUILDER_TMP=${BUILDER}_tmp
+        DOCKER_FILE_TMP=$(mktemp)
+        echo -e "FROM scratch\n"          \
+                "COPY ./wheelhouse/nvidia* /wheelhouse/\n" > ${DOCKER_FILE_TMP}
+        docker build -t ${BUILDER_TMP} -f ${DOCKER_FILE_TMP} .
+        rm ${DOCKER_FILE_TMP}
+    fi
+    docker build -t ${RUN_IMG} --build-arg "BUILD_IMAGE_NAME=${BUILDER_TMP}" --build-arg "CUDA_IMAGE_NAME=${CUDA_IMAGE_NAME}" --build-arg "PYVER=${PYVER}" --build-arg "PYV=${PYV}" -f docker/Docker_run_cuda .
+    # remove scratch image
+    if [ "$BUILD_INHOST" = "YES" ]; then
+        docker rmi ${BUILDER_TMP}
+    fi
+fi
+
 
 popd

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -13,6 +13,8 @@ Prerequisites
 
 .. |docker link| replace:: **Docker**
 .. _docker link: https://docs.docker.com/install/
+.. |nvidia_docker| replace:: **NVIDIA Container Toolkit**
+.. _nvidia_docker: https://github.com/NVIDIA/nvidia-docker
 
 .. table::
    :align: center
@@ -22,6 +24,12 @@ Prerequisites
    +----------------------------------------+---------------------------------------------------------------------------------------------+
    | |docker link|_                         | Follow installation guide and manual at the link (version 17.05 or later is required).      |
    +----------------------------------------+---------------------------------------------------------------------------------------------+
+   | |nvidia_docker|_                       | Follow installation guide and manual at the link.                                           |
+   |                                        | Using NVIDIA Container Toolkit is recommended as  vidia-docker2 is deprecated               |
+   |                                        | but both are supported.                                                                     |
+   |                                        |                                                                                             |
+   |                                        | Required for building DALI TensorFlow Plugin.                                               |
+   +----------------------------------------+---------------------------------------------------------------------------------------------+
 
 Building Python wheel and (optionally) Docker image
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -29,8 +37,6 @@ Building Python wheel and (optionally) Docker image
 Change directory (``cd``) into ``docker`` directory and run ``./build.sh``. If needed,
 set the following environment variables:
 
-* | PYVER - Python version used to create a docker image with DALI installed inside.
-  | The default is ``3.6``.
 * | CUDA_VERSION - CUDA toolkit version (10.0 or 11.0).
   | The default is ``11.0``. If the value of the version is prefixed with `.` then any value
     ``.XX.Y`` can be passed, script check for the supported version is bypased and the user needs
@@ -51,8 +57,11 @@ set the following environment variables:
     installation of DALI TensorFlow plugin package. If is BUILD_TF_PLUGIN is set to ``NO``
     PREBUILD_TF_PLUGINS value is disregarded. The default is ``YES``.
 * | CREATE_RUNNER - Create Docker image with cuDNN, CUDA and DALI installed inside.
-  | It will create the ``Docker_run_cuda`` image, which needs to be run using ``nvidia-docker``
-    and DALI wheel in the ``wheelhouse`` directory under$
+  | It will create the ``Docker_run_cuda`` image, which needs to be run using |nvidia_docker|_
+    and DALI wheel in the ``/opt/dali`` directory.
+  | The default is ``NO``.
+* | PYVER - Python version used to create the runner image with DALI installed inside mentioned above.
+  | The default is ``3.6``.
 * DALI_BUILD_FLAVOR - adds a suffix to DALI package name and put a note about it in the whl package description,
   i.e. `nightly` will result in the `nvidia-dali-nightly`
 * | CMAKE_BUILD_TYPE - build type, available options: Debug, DevDebug, Release, RelWithDebInfo.
@@ -74,7 +83,7 @@ set the following environment variables:
     (SBSA - Server Base System Architecture) are supported.
   | The default is ``x86_64``.
 * | WHL_PLATFORM_NAME - the name of the Python wheel platform tag.
-  | The default is ``manylinux1_x86_64``.
+  | The default is ``manylinux2014_x86_64``.
 
 It is worth to mention that build.sh should accept the same set of environment variables as the project CMake.
 
@@ -82,15 +91,16 @@ The recommended command line is:
 
 .. code-block:: bash
 
-  PYVER=X.Y CUDA_VERSION=Z ./build.sh
+  CUDA_VERSION=Z ./build.sh
 
 For example:
 
 .. code-block:: bash
 
-  PYVER=3.6 CUDA_VERSION=11.0 ./build.sh
+  CUDA_VERSION=11.0 ./build.sh
 
-Will build CUDA 11.0 based DALI for Python 3.6 and place relevant Python wheel inside DALI_root/wheelhouse
+Will build CUDA 11.0 based DALI for Python 3 and place relevant Python wheel inside DALI_root/wheelhouse
+The produced DALI wheel and TensorFlow Plugin are compatible with all Python versions supported by DALI.
 
 ----
 


### PR DESCRIPTION
Adjust docs to mention that Python version is needed only for runner.
Add requirement for NVIDIA Container Toolkit when building TF plugin
with build.sh
Update build.sh to all 3 possible nvidia-docker commands.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fixes a bug reported in #2213. 

#### What happened in this PR?
 - What solution was applied:
     TF plugin builder now uses Python 3 instead Python 2.
     Update build.sh to all 3 possible nvidia-docker commands.
 - Affected modules and functionalities:
     docker/build.sh and compilation docs.
	 Additional fixes for runner image
 - Key points relevant for the review:
      
 - Validation and testing:
     Local workstation
 - Documentation (including examples):
     Compilation docs mention that the wheel is minor version agnostic.


**JIRA TASK**: *[NA]*
