### PR TITLE
Fix NVTX annotations

### DIFF
--- a/include/dali/core/common.h
+++ b/include/dali/core/common.h
@@ -164,7 +164,7 @@ struct TimeRange {
 
   TimeRange(std::string name, const uint32_t rgb = kBlue) {  // NOLINT
 #if NVTX_ENABLED
-    nvtxEventAttributes_t att;
+    nvtxEventAttributes_t att = {};
     att.version = NVTX_VERSION;
     att.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
     att.colorType = NVTX_COLOR_ARGB;


### PR DESCRIPTION
Zero-initialize variables of type `nvtxEventAttributes_t`.

The `nvtxEventAttributes_t` type is trivial. When defined on the stack,
all non-initialized fields of a variable of this type will be set to
unexpected values. This might cause various bugs in tools as Nsight
Systems trying to interpret those random values.

Signed-off-by: Antoine Froger <afroger@nvidia.com>

#### Why we need this PR?

To generate correct NVTX annotations.

#### What happened in this PR?
 - What solution was applied:
     *[Zero-initialize variables of type `nvtxEventAttributes_t`]*
 - Affected modules and functionalities:
     *[NVTX annotations generated by the `TimeRange` objects when NVTX is enabled in the build]*
 - Validation and testing:
     *[Nsight Systems can now trace the NVTX annotations generated by DALI without throwing a runtime exception]*

**JIRA TASK**: *[DALI-1573]*