### PR TITLE
Fix `TensorListView::to_static`

### DIFF
--- a/dali/core/tensor_view_test.cc
+++ b/dali/core/tensor_view_test.cc
@@ -159,6 +159,24 @@ TEST(TensorListViewTest, ConstructorScattered) {
   }
 }
 
+TEST(TensorListViewTest, ToStatic) {
+  TensorListShape<3> static_shape({{4, 100, 50}, {2, 10, 5}, {4, 50, 25}, {4, 100, 50}});
+  TensorListShape<> dyn_shape = static_shape;
+  int a[4];
+  int *pointers[4] = { &a[2], &a[3], &a[0], &a[1] };
+  TensorListView<EmptyBackendTag, int> dyn_tlv(pointers, dyn_shape);
+  TensorListView<EmptyBackendTag, int, 3> static_copy = dyn_tlv.to_static<3>();
+  EXPECT_EQ(static_copy.data, dyn_tlv.data);
+  EXPECT_EQ(static_copy.shape, static_shape);
+  int **data_ptr = dyn_tlv.data.data();
+  auto *shape_ptr = dyn_tlv.shape.shapes.data();
+  TensorListView<EmptyBackendTag, int, 3> static_move = std::move(dyn_tlv).to_static<3>();
+  EXPECT_EQ(static_move.data.data(), data_ptr);
+  EXPECT_EQ(static_move.shape.shapes.data(), shape_ptr);
+  EXPECT_TRUE(dyn_tlv.data.empty());
+  EXPECT_TRUE(dyn_tlv.shape.shapes.empty());
+}
+
 TEST(TensorListViewTest, ConstructorMove) {
   int a[4];
   int *pointers[4] = { &a[2], &a[3], &a[0], &a[1] };

--- a/include/dali/core/tensor_view.h
+++ b/include/dali/core/tensor_view.h
@@ -473,6 +473,7 @@ template <typename Backend, typename DataType>
 struct TensorListView<Backend, DataType, DynamicDimensions>
     : TensorListViewBase<Backend, DataType, DynamicDimensions> {
   using Base = TensorListViewBase<Backend, DataType, DynamicDimensions>;
+  using typename Base::data_pointers_t;
   TensorListView() = default;
   TensorListView(const TensorListView &) = default;
   TensorListView(TensorListView &&) = default;
@@ -508,6 +509,14 @@ struct TensorListView<Backend, DataType, DynamicDimensions>
   template <int other_sample_ndim>
   TensorListView(DataType *const *data, TensorListShape<other_sample_ndim> &&shape)
       : Base(data, std::move(shape)) {}
+
+  template <int other_sample_ndim>
+  TensorListView(const data_pointers_t &data, const TensorListShape<other_sample_ndim> &shape)
+      : Base(data, shape) {}
+
+  template <int other_sample_ndim>
+  TensorListView(data_pointers_t &&data, TensorListShape<other_sample_ndim> &&shape)
+      : Base(std::move(data), std::move(shape)) {}
 
   //@}
 
@@ -584,6 +593,12 @@ struct TensorListView : TensorListViewBase<Backend, DataType, sample_ndim> {
   template <int other_sample_ndim>
   TensorListView(DataType *const *data, TensorListShape<other_sample_ndim> &&shape)
       : Base(data, std::move(shape)) {}
+
+  TensorListView(const data_pointers_t &data, const TensorListShape<sample_ndim> &shape)
+      : Base(data, shape) {}
+
+  TensorListView(data_pointers_t &&data, TensorListShape<sample_ndim> &&shape)
+      : Base(std::move(data), std::move(shape)) {}
 
   //@}
 


### PR DESCRIPTION

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug - compilation error when trying to use TensorListView::to_static

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
    - inherit vector copy/move constructors in TensorListView from TensorListViewBase
    - add test for `to_static`.
 - Affected modules and functionalities:
     * TensorListView classes
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Unit tests
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
