### PR TITLE
Temporarily freeze protobuf packages versions in Conda

### DIFF
--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -62,8 +62,8 @@ requirements:
   host:
     - python
     - future >=0.17.1
-    - protobuf >=3.11.2
-    - libprotobuf-static >=3.11.2
+    - protobuf =3.12.4
+    - libprotobuf-static =3.12.4
     - libjpeg-turbo >=2.0.3
     - tensorflow-gpu =2.2.0
     - tensorflow-estimator =2.2.0
@@ -82,7 +82,7 @@ requirements:
   run:
     - python
     - future >=0.17.1
-    - protobuf >=3.11.2
+    - protobuf =3.12.4
     - libjpeg-turbo >=2.0.3
     - tensorflow-gpu =2.2.0
     - tensorflow-estimator =2.2.0


### PR DESCRIPTION
Fixes mismatch between protobuf and libprotobuf-static
which weren't updated in unison in conda-forge

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fixes conda builds not building
libprotobuf conda-forge got 3.13.0 version but protobuf is still 3.12.4, waiting for https://github.com/conda-forge/protobuf-feedstock/pull/95 to be merged.

#### What happened in this PR?
 - What solution was applied:
     Set the version of all protobuf packages to 3.12.4.
 - Affected modules and functionalities:
	Conda build
 - Key points relevant for the review:
     If there is a good way to take minimum compatible version of those packes than I would accept such suggestion. Otherwise just check for typos
 - Validation and testing:
     CI and local build
 - Documentation (including examples):
    Na


**JIRA TASK**: *[Use DALI-XXXX or NA]*
