### PR TITLE
Fix a memory leak in the audio decoder

### DIFF
--- a/dali/operators/decoder/audio/generic_decoder.cc
+++ b/dali/operators/decoder/audio/generic_decoder.cc
@@ -176,6 +176,9 @@ struct GenericAudioDecoder<SampleType>::Impl {
     return ReadSamples(sound_, output);
   }
 
+  ~Impl() {
+    CloseImpl();
+  }
 
   AudioMetadata OpenImpl(span<const char> encoded) {
     assert(!encoded.empty());


### PR DESCRIPTION
- fixes a lack of proper closing of audio decoder what has left a leaked resources

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a memory leak in the audio decoder

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     fixes a lack of proper closing of audio decoder what has left a leaked resources
 - Affected modules and functionalities:
     audio_decoder
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA

It response to https://github.com/NVIDIA/DALI/issues/2233.

**JIRA TASK**: *[NA]*
