### PR TITLE
Fix wrong jupyter execution syntax

### DIFF
--- a/qa/TL1_tensorflow_dataset/test.sh
+++ b/qa/TL1_tensorflow_dataset/test.sh
@@ -27,11 +27,11 @@ test_body() {
         jupyter nbconvert tensorflow-dataset.ipynb \
                   --to notebook --inplace --execute \
                   --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
-                  --ExecutePreprocessor.timeout=600 {}
+                  --ExecutePreprocessor.timeout=600
         jupyter nbconvert tensorflow-dataset-multigpu.ipynb \
                   --to notebook --inplace --execute \
                   --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
-                  --ExecutePreprocessor.timeout=600 {}
+                  --ExecutePreprocessor.timeout=600
         popd
     fi
 }

--- a/qa/TL1_tensorflow_dataset_conda/test.sh
+++ b/qa/TL1_tensorflow_dataset_conda/test.sh
@@ -23,11 +23,11 @@ test_body() {
         jupyter nbconvert tensorflow-dataset.ipynb \
                   --to notebook --inplace --execute \
                   --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
-                  --ExecutePreprocessor.timeout=600 {}
+                  --ExecutePreprocessor.timeout=600
         jupyter nbconvert tensorflow-dataset-multigpu.ipynb \
                   --to notebook --inplace --execute \
                   --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
-                  --ExecutePreprocessor.timeout=600 {}
+                  --ExecutePreprocessor.timeout=600
         popd
     fi
 }


### PR DESCRIPTION
- removes trailing `{}` from TensorFlow jupyter tests

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes wrong jupyter execution syntax

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     removes trailing `{}` from TensorFlow jupyter tests
 - Affected modules and functionalities:
     qa/TensorFlow_dataset tests
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
