### PR TITLE
Add ability to pass DALI TensorList or a list of DALI Tensors to exernal source

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -553,13 +553,16 @@ void ExposeTensorList(py::module &m) {
         layout : str
               Layout of the data
         )code")
-    .def(py::init([](TensorList<CPUBackend> *tl, std::string *layout) {
+    .def(py::init([](TensorList<CPUBackend> *tl, py::object layout) {
           if (!tl)
             throw py::value_error("The source object must not be null");
           auto t = std::make_unique<TensorList<CPUBackend>>();
           t->ShareData(tl);
-          if (layout)
-            t->SetLayout(*layout);
+          if (!layout.is_none()) {
+            if (!py::isinstance<py::str>(layout))
+              throw py::type_error("`layout` must be a string or None");
+            t->SetLayout(std::string(layout.cast<py::str>()));
+          }
           return t.release();
         }),
       "tl"_a,
@@ -768,13 +771,16 @@ void ExposeTensorList(py::module &m) {
         layout : str
               Layout of the data
         )code")
-    .def(py::init([](TensorList<GPUBackend> *tl, std::string *layout) {
+    .def(py::init([](TensorList<GPUBackend> *tl, py::object layout) {
           if (!tl)
             throw py::value_error("The source object must not be null");
           auto t = std::make_unique<TensorList<GPUBackend>>();
           t->ShareData(tl);
-          if (layout)
-            t->SetLayout(*layout);
+          if (!layout.is_none()) {
+            if (!py::isinstance<py::str>(layout))
+              throw py::type_error("`layout` must be a string or None");
+            t->SetLayout(std::string(layout.cast<py::str>()));
+          }
           return t.release();
         }),
       "tl"_a,

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -125,8 +125,8 @@ const TensorShape<> &ConvertShape(const TensorShape<> &shape,
 }
 
 template<typename TStrides, typename TShape>
-void CheckContiguousTensor(const TStrides &strides, size_t num_strides,
-                           const TShape &shape, size_t num_extents, size_t element_size) {
+void CheckContiguousTensor(const TStrides &strides, int num_strides,
+                           const TShape &shape, int num_extents, size_t element_size) {
   DALI_ENFORCE(num_strides == num_extents,
     "There should be exactly as many strides as there are extents in array shape.");
   int64_t stride_from_shape = element_size;
@@ -325,7 +325,7 @@ void ExposeTensor(py::module &m) {
               t.ndim(), shape, stride);
         })
     .def(py::init([](py::buffer b, string layout = "", bool is_pinned = false) {
-          // We need to verify that hte input data is c contiguous
+          // We need to verify that the input data is c contiguous
           // and of a type that we can work with in the backend
           __backend_impl_force_tls_align_fun();
           py::buffer_info info = b.request();
@@ -333,10 +333,6 @@ void ExposeTensor(py::module &m) {
           std::vector<Index> i_shape;
           for (auto &dim : info.shape) {
             i_shape.push_back(dim);
-          }
-          // scalar
-          if (info.shape.size() == 0) {
-            i_shape.push_back(1);
           }
           size_t bytes = volume(i_shape) * info.itemsize;
 

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -290,9 +290,9 @@ void ExposeTensor(py::module &m) {
 
   py::class_<Tensor<CPUBackend>>(m, "TensorCPU", py::buffer_protocol())
     .def(py::init([](py::capsule &capsule, string layout = "") {
-          auto t = new Tensor<CPUBackend>;
-          FillTensorFromDlPack(capsule, t, layout);
-          return t;
+          auto t = std::make_unique<Tensor<CPUBackend>>();
+          FillTensorFromDlPack(capsule, t.get(), layout);
+          return t.release();
         }),
       "object"_a,
       "layout"_a = "",
@@ -340,13 +340,13 @@ void ExposeTensor(py::module &m) {
           CheckContiguousTensor(info.strides, info.shape, info.itemsize);
 
           // Create the Tensor and wrap the data
-          auto t = new Tensor<CPUBackend>;
+          auto t = std::make_unique<Tensor<CPUBackend>>();
           t->set_pinned(is_pinned);
           TypeInfo type = TypeFromFormatStr(info.format);
           t->ShareData(info.ptr, bytes, type);
           t->SetLayout(layout);
           t->Resize(i_shape);
-          return t;
+          return t.release();
         }),
       "b"_a,
       "layout"_a = "",
@@ -403,9 +403,9 @@ void ExposeTensor(py::module &m) {
 
   py::class_<Tensor<GPUBackend>>(m, "TensorGPU")
     .def(py::init([](py::capsule &capsule, string layout = "") {
-          auto t = new Tensor<GPUBackend>;
-          FillTensorFromDlPack(capsule, t, layout);
-          return t;
+          auto t = std::make_unique<Tensor<GPUBackend>>();
+          FillTensorFromDlPack(capsule, t.get(), layout);
+          return t.release();
         }),
       "object"_a,
       "layout"_a = "",
@@ -418,9 +418,9 @@ void ExposeTensor(py::module &m) {
             Layout of the data
       )code")
     .def(py::init([](const py::object object, string layout = "", int device_id = -1) {
-          auto t = new Tensor<GPUBackend>;
-          FillTensorFromCudaArray(object, t, device_id, layout);
-          return t;
+          auto t = std::make_unique<Tensor<GPUBackend>>();
+          FillTensorFromCudaArray(object, t.get(), device_id, layout);
+          return t.release();
         }),
       "object"_a,
       "layout"_a = "",
@@ -443,14 +443,14 @@ void ExposeTensor(py::module &m) {
       return t.GetLayout().str();
     })
     .def("as_cpu", [](Tensor<GPUBackend> &t) -> Tensor<CPUBackend>* {
-          Tensor<CPUBackend> * ret = new Tensor<CPUBackend>();
+          auto ret = std::make_unique<Tensor<CPUBackend>>();
           ret->set_pinned(false);
           UserStream * us = UserStream::Get();
           cudaStream_t s = us->GetStream(t);
           DeviceGuard g(t.device_id());
           ret->Copy(t, s);
           us->Wait(t);
-          return ret;
+          return ret.release();
         },
       R"code(
       Returns a `TensorCPU` object being a copy of this `TensorGPU`.
@@ -515,7 +515,7 @@ std::unique_ptr<Tensor<Backend> > TensorListGetItemImpl(TensorList<Backend> &t, 
   if (id >= num_tensors || id < 0) {
       throw py::index_error("TensorListCPU index out of range");
   }
-  std::unique_ptr<Tensor<Backend>> ptr(new Tensor<Backend>());
+  auto ptr = std::make_unique<Tensor<Backend>>();
   ptr->ShareData(&t, id);
   return ptr;
 }
@@ -528,9 +528,9 @@ py::tuple TensorListGetItemSliceImpl(TensorList<Backend> &t, py::slice slice) {
       throw py::error_already_set();
   py::list list;
   for (; start < stop; start += step) {
-      auto ptr = new Tensor<Backend>();
+      auto ptr = make_uqnieu<Tensor<Backend>>();
       ptr->ShareData(&t, static_cast<int>(start));
-      list.append(ptr);
+      list.append(ptr.release());
   }
   return list;
 }
@@ -539,9 +539,9 @@ py::tuple TensorListGetItemSliceImpl(TensorList<Backend> &t, py::slice slice) {
 void ExposeTensorList(py::module &m) {
   py::class_<TensorList<CPUBackend>>(m, "TensorListCPU", py::buffer_protocol())
     .def(py::init([](py::capsule &capsule, string layout = "") {
-            auto t = new TensorList<CPUBackend>;
-            FillTensorFromDlPack(capsule, t, layout);
-            return t;
+            auto t = std::make_unique<TensorList<CPUBackend>>();
+            FillTensorFromDlPack(capsule, t.get(), layout);
+            return t.release();
           }),
         "object"_a,
         "layout"_a = "",
@@ -553,6 +553,17 @@ void ExposeTensorList(py::module &m) {
         layout : str
               Layout of the data
         )code")
+    .def(py::init([](TensorList<CPUBackend> *tl, std::string *layout) {
+          if (!tl)
+            throw py::value_error("The source object must not be null");
+          auto t = std::make_unique<TensorList<CPUBackend>>();
+          t->ShareData(tl);
+          if (layout)
+            t->SetLayout(*layout);
+          return t.release();
+        }),
+      "tl"_a,
+      "layout"_a = py::none())
     .def(py::init([](py::buffer b, string layout = "", bool is_pinned = false) {
         // We need to verify that the input data is C_CONTIGUOUS
         // and of a type that we can work with in the backend
@@ -572,13 +583,13 @@ void ExposeTensorList(py::module &m) {
         CheckContiguousTensor(info.strides, info.shape, info.itemsize);
 
         // Create the Tensor and wrap the data
-        auto t = new TensorList<CPUBackend>;
+        auto t = std::make_unique<TensorList<CPUBackend>>();
         t->set_pinned(false);
         TypeInfo type = TypeFromFormatStr(info.format);
         t->ShareData(info.ptr, bytes, type);
         t->SetLayout(layout);
         t->Resize(i_shape);
-        return t;
+        return t.release();
       }),
       "b"_a,
       "layout"_a = "",
@@ -743,9 +754,9 @@ void ExposeTensorList(py::module &m) {
 
   py::class_<TensorList<GPUBackend>>(m, "TensorListGPU", py::buffer_protocol())
     .def(py::init([](py::capsule &capsule, string layout = "") {
-            auto t = new TensorList<GPUBackend>;
-            FillTensorFromDlPack(capsule, t, layout);
-            return t;
+            auto t = std::make_unique<TensorList<GPUBackend>>();
+            FillTensorFromDlPack(capsule, t.get(), layout);
+            return t.release();
           }),
         "object"_a,
         "layout"_a = "",
@@ -757,10 +768,21 @@ void ExposeTensorList(py::module &m) {
         layout : str
               Layout of the data
         )code")
+    .def(py::init([](TensorList<GPUBackend> *tl, std::string *layout) {
+          if (!tl)
+            throw py::value_error("The source object must not be null");
+          auto t = std::make_unique<TensorList<GPUBackend>>();
+          t->ShareData(tl);
+          if (layout)
+            t->SetLayout(*layout);
+          return t.release();
+        }),
+      "tl"_a,
+      "layout"_a = py::none())
     .def(py::init([](const py::object object, string layout = "", int device_id = -1) {
-          auto t = new TensorList<GPUBackend>;
-          FillTensorFromCudaArray(object, t, device_id, layout);
-          return t;
+          auto t = std::make_unique<TensorList<GPUBackend>>();
+          FillTensorFromCudaArray(object, t.get(), device_id, layout);
+          return t.release();
         }),
       "object"_a,
       "layout"_a = "",
@@ -783,14 +805,14 @@ void ExposeTensorList(py::module &m) {
       List of tensors residing in the GPU memory.
       )code")
     .def("as_cpu", [](TensorList<GPUBackend> &t) -> TensorList<CPUBackend>* {
-          TensorList<CPUBackend> * ret = new TensorList<CPUBackend>();
+          auto ret = std::make_unique<TensorList<CPUBackend>>();
           ret->set_pinned(false);
           UserStream * us = UserStream::Get();
           cudaStream_t s = us->GetStream(t);
           DeviceGuard g(t.device_id());
           ret->Copy(t, s);
           us->Wait(t);
-          return ret;
+          return ret.release();
         },
       R"code(
       Returns a `TensorListCPU` object being a copy of this `TensorListGPU`.
@@ -1134,10 +1156,10 @@ PYBIND11_MODULE(backend_impl, m) {
                 bool async_execution = true, size_t bytes_per_sample_hint = 0,
                 bool set_affinity = false, int max_num_stream = -1,
                 int default_cuda_stream_priority = 0) {
-              return std::unique_ptr<Pipeline>(
-                  new Pipeline(batch_size, num_threads, device_id, seed, pipelined_execution,
+              return std::make_unique<Pipeline>(
+                      batch_size, num_threads, device_id, seed, pipelined_execution,
                       prefetch_queue_depth, async_execution, bytes_per_sample_hint, set_affinity,
-                      max_num_stream, default_cuda_stream_priority));
+                      max_num_stream, default_cuda_stream_priority);
             }),
         "batch_size"_a,
         "num_threads"_a,
@@ -1159,11 +1181,11 @@ PYBIND11_MODULE(backend_impl, m) {
              bool async_execution = true, size_t bytes_per_sample_hint = 0,
              bool set_affinity = false, int max_num_stream = -1,
              int default_cuda_stream_priority = 0) {
-              return std::unique_ptr<Pipeline>(
-                  new Pipeline(serialized_pipe,
+              return std::make_unique<Pipeline>(
+                               serialized_pipe,
                                batch_size, num_threads, device_id, pipelined_execution,
                                prefetch_queue_depth, async_execution, bytes_per_sample_hint,
-                               set_affinity, max_num_stream, default_cuda_stream_priority));
+                               set_affinity, max_num_stream, default_cuda_stream_priority);
             }),
         "serialized_pipe"_a,
         "batch_size"_a = -1,

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -169,6 +169,8 @@ Args
     provided GPU memory content only using provided stream (DALI schedules a copy on it
     and all work is properly queued). If no stream is provided, DALI will use a default, with
     best-effort approach at correctness (see ``cuda_stream`` argument documentation for details).
+    The data batch produced by ``source`` may be anything that's accepted by
+    :meth:`nvidia.dali.pipeline.Pipeline.feed_input`
 
 `num_outputs` : int, optional
     If specified, denotes the number of TensorLists produced by the source function

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -5,7 +5,7 @@ import inspect
 def _get_batch_shape(data):
     if isinstance(data, (list, tuple, _b.TensorListCPU, _b.TensorListGPU)):
         if len(data) == 0:
-            return []
+            return [], True
         if callable(data[0].shape):
             return [x.shape() for x in data], False
         else:
@@ -28,7 +28,7 @@ def _check_data_batch(data, batch_size, layout):
             for ts in shape:
                 if len(ts) != dim:
                     raise RuntimeError("All tensors in a batch must have the same number of dimensions")
-        if layout != "" and dim != len(layout):
+        if layout is not None and layout != "" and dim != len(layout):
             raise RuntimeError("The layout '{}' cannot describe {}-dimensional data".format(layout, dim))
 
 class _CycleIter():
@@ -329,7 +329,7 @@ Keyword Args
                     else:
                         op_instance._layout = layout
                 else:
-                    op_instance._layout = ""
+                    op_instance._layout = None
 
                 group.append(op_instance)
                 op_instance.generate_outputs()
@@ -344,7 +344,7 @@ Keyword Args
             op_instance._output_index = None
             op_instance._group = _ExternalSourceGroup(callback, False, [op_instance], cuda_stream=cuda_stream,
                                                       use_copy_kernel=use_copy_kernel)
-            op_instance._layout = layout if layout is not None else ""
+            op_instance._layout = layout
             op_instance.generate_outputs()
 
             return op_instance.unwrapped_outputs

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -497,6 +497,7 @@ Parameters
               * PyTorch tensor (CPU or GPU)
               * CuPy array (GPU)
               * objects implementing ``__cuda_array_interface__``
+              * DALI `TensorList` or list of DALI `Tensor` objects
 
             The data to be used as the output of the ExternalSource referred to by `data_node`.
 

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -479,7 +479,7 @@ Parameters
         self._pipe.Build(self._names_and_devices)
         self._built = True
 
-    def feed_input(self, data_node, data, layout="", cuda_stream = None, use_copy_kernel = False):
+    def feed_input(self, data_node, data, layout = None, cuda_stream = None, use_copy_kernel = False):
         """Pass a mutlidimensional array or DLPack (or a list thereof) to an output of ExternalSource.
         In the case of the GPU input, the data must be modified on the same stream as the one
         used by feed_input. See ``cuda_stream`` parameter for details.
@@ -501,11 +501,13 @@ Parameters
 
             The data to be used as the output of the ExternalSource referred to by `data_node`.
 
-        layout : str
+        layout : str or None
             The description of the data layout (or empty string, if not specified).
             It should be a string of the length that matches the dimensionality of the data, batch
             dimension excluded. For a batch of channel-first images, this should be "CHW", for
             channel-last video it's "FHWC" and so on.
+            If ``data`` is a DALI TensorList or a list of DALI Tensors and str is None, the layout
+            is taken from data argument.
 
         cuda_stream : optional, `cudaStream_t` or an object convertible to `cudaStream_t`, e.g. `cupy.cuda.Stream`, `torch.cuda.Stream`
             The CUDA stream, which is going to be used for copying data to GPU or from a GPU
@@ -557,10 +559,10 @@ Parameters
         # where the memory is located. It is assumed that the current device is the one that the memory belongs to,
         # unless the user sets the device explicitly creating TensorGPU/TensorListGPU
         if isinstance(data, (Tensors.TensorListCPU, Tensors.TensorListGPU)):
-            if layout:
+            if layout is not None:
                 _check_data_batch(data, self._batch_size, layout)
-            else:
-                layout = data.layout()
+                data = type(data)(data, layout)
+
             self._pipe.SetExternalTLInput(name, data, ctypes.c_void_p(cuda_stream), use_copy_kernel)
         elif isinstance(data, list):
             inputs = []
@@ -571,14 +573,14 @@ Parameters
                     _check_data_batch(data, self._batch_size, layout)
                     checked = True
                 if isinstance(datum, (Tensors.TensorCPU, Tensors.TensorGPU)):
-                    inp = type(datum)(datum, layout=layout) if layout else datum
+                    inp = type(datum)(datum, layout=layout) if layout is not None else datum
                 elif hasattr(datum, "__cuda_array_interface__") or (info[0] and info[1]):
                     if infer_stream:
                         cuda_stream = _get_default_stream_for_array(datum)
-                    inp = Tensors.TensorGPU(datum, layout)
+                    inp = Tensors.TensorGPU(datum, layout or "")
                 else:
                     datum = to_numpy(datum)
-                    inp = Tensors.TensorCPU(datum, layout)
+                    inp = Tensors.TensorCPU(datum, layout or "")
                 inputs.append(inp)
             assert all(isinstance(inp, type(inputs[0])) for inp in inputs), \
                    "Mixed input types are not support, all need to reside on the CPU or GPU"
@@ -590,10 +592,10 @@ Parameters
             if hasattr(data, "__cuda_array_interface__") or (info[0] and info[1]):
                 if infer_stream:
                     cuda_stream = _get_default_stream_for_array(data)
-                inp = Tensors.TensorListGPU(data, layout)
+                inp = Tensors.TensorListGPU(data, layout or "")
             else:
                 data = to_numpy(data)
-                inp = Tensors.TensorListCPU(data, layout)
+                inp = Tensors.TensorListCPU(data, layout or "")
             self._pipe.SetExternalTLInput(name, inp, ctypes.c_void_p(cuda_stream), use_copy_kernel)
 
     def _run_cpu(self):

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -555,7 +555,13 @@ Parameters
         # __cuda_array_interface__ doesn't provide any way to pass the information about the device
         # where the memory is located. It is assumed that the current device is the one that the memory belongs to,
         # unless the user sets the device explicitly creating TensorGPU/TensorListGPU
-        if isinstance(data, list):
+        if isinstance(data, (Tensors.TensorListCPU, Tensors.TensorListGPU)):
+            if layout:
+                _check_data_batch(data, self._batch_size, layout)
+            else:
+                layout = data.layout()
+            self._pipe.SetExternalTLInput(name, data, ctypes.c_void_p(cuda_stream), use_copy_kernel)
+        elif isinstance(data, list):
             inputs = []
             checked = False
             for datum in data:
@@ -563,7 +569,9 @@ Parameters
                 if not info[0] and not checked:
                     _check_data_batch(data, self._batch_size, layout)
                     checked = True
-                if hasattr(datum, "__cuda_array_interface__") or (info[0] and info[1]):
+                if isinstance(datum, (Tensors.TensorCPU, Tensors.TensorGPU)):
+                    inp = type(datum)(datum, layout=layout) if layout else datum
+                elif hasattr(datum, "__cuda_array_interface__") or (info[0] and info[1]):
                     if infer_stream:
                         cuda_stream = _get_default_stream_for_array(datum)
                     inp = Tensors.TensorGPU(datum, layout)

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -506,8 +506,8 @@ Parameters
             It should be a string of the length that matches the dimensionality of the data, batch
             dimension excluded. For a batch of channel-first images, this should be "CHW", for
             channel-last video it's "FHWC" and so on.
-            If ``data`` is a DALI TensorList or a list of DALI Tensors and str is None, the layout
-            is taken from data argument.
+            If ``data`` is a DALI `TensorList` or a list of DALI `Tensor` objects and ``layout``
+            is ``None``, the layout is taken from ``data``.
 
         cuda_stream : optional, `cudaStream_t` or an object convertible to `cudaStream_t`, e.g. `cupy.cuda.Stream`, `torch.cuda.Stream`
             The CUDA stream, which is going to be used for copying data to GPU or from a GPU

--- a/dali/test/python/test_external_source_dali.py
+++ b/dali/test/python/test_external_source_dali.py
@@ -1,0 +1,86 @@
+import nvidia.dali.fn as fn
+import nvidia.dali.types as types
+import numpy as np
+from nvidia.dali.pipeline import Pipeline
+from test_utils import check_batch
+
+def build_src_pipe(device, layout="XY"):
+    batches = [[
+        np.array([[1,2,3],[4,5,6]], dtype = np.float32),
+        np.array([[10,20], [30,40], [50,60]], dtype = np.float32)
+    ],
+    [
+        np.array([[9,10],[11,12]], dtype = np.float32),
+        np.array([[100,200,300,400,500]], dtype = np.float32)
+    ]]
+
+    src_pipe = Pipeline(len(batches), 1, 0)
+    src_pipe.set_outputs(fn.external_source(source=batches, device=device, cycle=True, layout=layout))
+    src_pipe.build()
+    return src_pipe, len(batches)
+
+def _test_feed_input(device):
+    src_pipe, batch_size = build_src_pipe(device)
+
+    dst_pipe = Pipeline(batch_size, 1, 0, exec_async=False, exec_pipelined=False)
+    dst_pipe.set_outputs(fn.external_source(name="ext", device=device))
+    dst_pipe.build()
+    for iter in range(3):
+        out1 = src_pipe.run()
+        dst_pipe.feed_input("ext", out1[0])
+        out2 = dst_pipe.run()
+        check_batch(out2[0], out1[0], batch_size, 0, 0, "XY")
+
+
+def test_feed_input():
+    for device in ["cpu", "gpu"]:
+        yield _test_feed_input, device
+
+
+def _test_callback(device, as_tensors):
+    src_pipe, batch_size = build_src_pipe(device)
+    ref_pipe, batch_size = build_src_pipe(device)
+
+    dst_pipe = Pipeline(batch_size, 1, 0)
+    def get_from_src():
+        tl = src_pipe.run()[0]
+        return [tl[i] for i in range(len(tl))] if as_tensors else tl
+
+    dst_pipe.set_outputs(fn.external_source(source=get_from_src, device=device))
+    dst_pipe.build()
+
+    for iter in range(3):
+        ref = ref_pipe.run()
+        out = dst_pipe.run()
+        check_batch(out[0], ref[0], batch_size, 0, 0, "XY")
+
+def test_callback():
+    for device in ["cpu", "gpu"]:
+        for as_tensors in [False, True]:
+            yield _test_callback, device, as_tensors
+
+def _test_scalar(device, as_tensors):
+    """Test propagation of scalars from external source"""
+    batch_size = 4
+    src_pipe = Pipeline(batch_size, 1, 0)
+    src_ext = fn.external_source(source=lambda i: [np.float32(i * 10 + i + 1) for i in range(batch_size)], device=device)
+    src_pipe.set_outputs(src_ext)
+
+    src_pipe.build()
+    dst_pipe = Pipeline(batch_size, 1, 0, exec_async=False, exec_pipelined=False)
+    dst_pipe.set_outputs(fn.external_source(name="ext", device=device))
+    dst_pipe.build()
+
+    for iter in range(3):
+        src = src_pipe.run()
+        data = src[0]
+        if as_tensors:
+            data = [data[i] for i in range(len(data))]
+        dst_pipe.feed_input("ext", data)
+        dst = dst_pipe.run()
+        check_batch(src[0], dst[0], batch_size, 0, 0, "")
+
+def test_scalar():
+    for device in ["cpu", "gpu"]:
+        for as_tensors in [False, True]:
+            yield _test_scalar, device, as_tensors

--- a/qa/TL0_python-self-test/test_body.sh
+++ b/qa/TL0_python-self-test/test_body.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 test_nose() {
-    for test_script in $(ls test_operator_*.py test_pipeline*.py test_external_source_numpy.py test_functional_api.py test_backend_impl.py); do
+    for test_script in $(ls test_operator_*.py test_pipeline*.py test_external_source_dali.py test_external_source_numpy.py test_functional_api.py test_backend_impl.py); do
         nosetests --verbose --attr '!slow' ${test_script}
     done
 }

--- a/qa/TL1_python-self-test_conda/test_body.sh
+++ b/qa/TL1_python-self-test_conda/test_body.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 test_nose() {
-    for test_script in $(ls test_operator_*.py test_pipeline*.py test_external_source_numpy.py test_functional_api.py test_backend_impl.py); do
+    for test_script in $(ls test_operator_*.py test_pipeline*.py test_external_source_dali.py test_external_source_numpy.py test_functional_api.py test_backend_impl.py); do
         nosetests --verbose --attr '!slow' ${test_script}
     done
 }


### PR DESCRIPTION
* Add ability to pass DALI TensorList or a list of DALI Tensors to exernal source
* Keep external scalars at 0D

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature: accept DALI Tensor/TenosrList needed for seamless chaining of DALI pipelines
- It fixes a bug: scalars silently extened to 1D 1-element tensors
- Refactoring: make shape validation from external data more robust (accept shape both as a property and as a function)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Add special case for DALI TensorListXPU and TenosrXPU in feed_input
     * Add special case for DALI TensorListXPU in _check_data_batch
     * Add handling for `shape` as a function in _check_data_batch
     * Split _check_data_batch into getting shape and validation of shape and layout
 - Affected modules and functionalities:
     * Python: pipeline, external source
     * C++: python backend
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python tests
 - Documentation (including examples):
     * Updated documentation for `Pipeline.feed_input` and `source` argument of ExternalSource

**JIRA TASK**: N/A
