### PR TITLE
Allow passing a <= 0 values in the file list to allow more flexible frame indexing

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -95,7 +95,7 @@ inline void assemble_video_list(const std::string& path, const std::string& curr
       continue;
     }
 #endif
-    file_info.push_back(file_meta{full_path, label, -1, -1});
+    file_info.push_back(file_meta{full_path, label, 0, 0});
   }
   closedir(dir);
 }
@@ -153,30 +153,15 @@ std::vector<dali::file_meta> filesystem::get_file_label_pair(
     while (std::getline(s, line)) {
       line_num++;
       video_file.clear();
-      label = start_time = end_time = -1;
+      label = -1;
+      start_time = end_time = 0;
       std::istringstream file_line(line);
       file_line >> video_file >> label;
       if (video_file.empty()) continue;
       DALI_ENFORCE(label >= 0, "Label value should be >= 0 in file_list at line number: "
                    + to_string(line_num) + ", filename: "+ video_file);
       if (file_line >> start_time) {
-        DALI_ENFORCE(start_time >= 0, "Start time/frame should be >=0 at line number: "
-                     + to_string(line_num) + ", filename: "+ video_file);
-        if (file_line >> end_time) {
-          DALI_ENFORCE(start_time <= end_time || end_time < 0, "Start time/frame should be "
-                       "<= end or -1 time/frame at line number: " + to_string(line_num) +
-                       ", filename: "+ video_file);
-        } else {
-          DALI_FAIL("The allowed file list format is:\n"
-                    "file_name label(int) start_time(float) end_time(float)\n"
-                    "or\n"
-                    "file_name label(int)\n"
-                    "Example:\n"
-                    "/home/nvidia/salvador.mp4 0 5.2 10.5\n"
-                    "/home/nvidia/dali.mp4 1\n"
-                    "Error at line number: " + to_string(line_num)
-                    + ", filename: " + video_file);
-        }
+        file_line >> end_time;
       }
       file_info.push_back(file_meta{video_file, label, start_time, end_time});
     }
@@ -186,7 +171,7 @@ std::vector<dali::file_meta> filesystem::get_file_label_pair(
   } else {
     file_info.reserve(filenames.size());
     for (const auto & f : filenames) {
-      file_info.push_back(file_meta{f, 0, -1, -1});
+      file_info.push_back(file_meta{f, 0, 0, 0});
     }
   }
 

--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -161,7 +161,13 @@ std::vector<dali::file_meta> filesystem::get_file_label_pair(
       DALI_ENFORCE(label >= 0, "Label value should be >= 0 in file_list at line number: "
                    + to_string(line_num) + ", filename: "+ video_file);
       if (file_line >> start_time) {
-        file_line >> end_time;
+        if (file_line >> end_time) {
+          if (start_time == end_time) {
+            DALI_WARN("Start and end time/frame are the same, skipping the file, in file_list "
+                      "at line number: " + to_string(line_num) + ", filename: "+ video_file);
+            continue;
+          }
+        }
       }
       file_info.push_back(file_meta{video_file, label, start_time, end_time});
     }

--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -163,8 +163,9 @@ std::vector<dali::file_meta> filesystem::get_file_label_pair(
         DALI_ENFORCE(start_time >= 0, "Start time/frame should be >=0 at line number: "
                      + to_string(line_num) + ", filename: "+ video_file);
         if (file_line >> end_time) {
-          DALI_ENFORCE(start_time <= end_time, "Start time/frame should be <= end time/frame "
-                       "at line number: " + to_string(line_num) + ", filename: "+ video_file);
+          DALI_ENFORCE(start_time <= end_time || end_time < 0, "Start time/frame should be "
+                       "<= end or -1 time/frame at line number: " + to_string(line_num) +
+                       ", filename: "+ video_file);
         } else {
           DALI_FAIL("The allowed file list format is:\n"
                     "file_name label(int) start_time(float) end_time(float)\n"

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -231,8 +231,6 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
           }
           if (end > 0) {
             end_frame = end;
-          } else if (end == 0) {
-            end_frame = file.frame_count_;
           } else {
             end_frame = file.frame_count_ + end;
           }

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -168,6 +168,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       stats_({0, 0, 0, 0, 0}),
       current_frame_idx_(-1),
       stop_(false) {
+    DALI_ENFORCE(stride_ > 0, "Stride should be > 0");
     if (step_ < 0)
       step_ = count_ * stride_;
 
@@ -252,8 +253,6 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
           }
           if (end > 0) {
             end_frame = static_cast<int>(std::floor(end * av_q2d(frame_rate)));
-          } else if (end == 0) {
-            end_frame = file.frame_count_;
           } else {
             end_frame = file.frame_count_ + static_cast<int>(std::floor(end * av_q2d(frame_rate)));
           }

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -221,7 +221,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       int end_frame = file.frame_count_;
       float start = file_info_[i].start_time;
       float end = file_info_[i].end_time;
-      if (start != 0 && end != 0) {
+      if (start != 0 || end != 0) {
         if (file_list_frame_num_) {
           if (start >= 0) {
             start_frame = start;
@@ -235,8 +235,13 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
           } else {
             end_frame = file.frame_count_ + end;
           }
+
+          DALI_ENFORCE(start_frame <= end_frame, "Start frame number should be lesser or equal "
+                       "to end frame number for a file " + file_info_[i].video_file);
+          DALI_ENFORCE(start_frame <= file.frame_count_, "Start frame number is greater than "
+                       "total number of frames for file " + file_info_[i].video_file);
           DALI_ENFORCE(end_frame <= file.frame_count_, "End frame number is greater than "
-              "total number of frames for file " + file_info_[i].video_file);
+                       "total number of frames for file " + file_info_[i].video_file);
         } else {
           auto frame_rate = av_inv_q(file.frame_base_);
           if (start >= 0) {
@@ -253,6 +258,10 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
             end_frame = file.frame_count_ + static_cast<int>(std::floor(end * av_q2d(frame_rate)));
           }
 
+          DALI_ENFORCE(start_frame <= end_frame, "Start time number should be lesser or equal "
+                       "to end time for a file " + file_info_[i].video_file);
+          DALI_ENFORCE(start_frame <= file.frame_count_, "Start time is greater than video "
+                       "duration for file " + file_info_[i].video_file);
           DALI_ENFORCE(end_frame <= file.frame_count_, "End time is greater than video duration "
                        "for file " + file_info_[i].video_file);
         }

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -221,17 +221,37 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       int end_frame = file.frame_count_;
       float start = file_info_[i].start_time;
       float end = file_info_[i].end_time;
-      if (start != -1 && end != -1) {
+      if (start != 0 && end != 0) {
         if (file_list_frame_num_) {
-          start_frame = start;
-          end_frame = end >= 0 ? end : file.frame_count_;
+          if (start >= 0) {
+            start_frame = start;
+          } else {
+            start_frame = file.frame_count_ + start;
+          }
+          if (end > 0) {
+            end_frame = end;
+          } else if (end == 0) {
+            end_frame = file.frame_count_;
+          } else {
+            end_frame = file.frame_count_ + end;
+          }
           DALI_ENFORCE(end_frame <= file.frame_count_, "End frame number is greater than "
               "total number of frames for file " + file_info_[i].video_file);
         } else {
           auto frame_rate = av_inv_q(file.frame_base_);
-          start_frame = static_cast<int>(std::ceil(start * av_q2d(frame_rate)));
-          end_frame = end >= 0 ? static_cast<int>(std::floor(end * av_q2d(frame_rate))) :
-                                 file.frame_count_;
+          if (start >= 0) {
+            start_frame = static_cast<int>(std::ceil(start * av_q2d(frame_rate)));
+          } else {
+            start_frame = file.frame_count_ +
+                          static_cast<int>(std::ceil(start * av_q2d(frame_rate)));
+          }
+          if (end > 0) {
+            end_frame = static_cast<int>(std::floor(end * av_q2d(frame_rate)));
+          } else if (end == 0) {
+            end_frame = file.frame_count_;
+          } else {
+            end_frame = file.frame_count_ + static_cast<int>(std::floor(end * av_q2d(frame_rate)));
+          }
 
           DALI_ENFORCE(end_frame <= file.frame_count_, "End time is greater than video duration "
                        "for file " + file_info_[i].video_file);

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -224,13 +224,14 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       if (start != -1 && end != -1) {
         if (file_list_frame_num_) {
           start_frame = start;
-          end_frame = end;
+          end_frame = end >= 0 ? end : file.frame_count_;
           DALI_ENFORCE(end_frame <= file.frame_count_, "End frame number is greater than "
               "total number of frames for file " + file_info_[i].video_file);
         } else {
           auto frame_rate = av_inv_q(file.frame_base_);
           start_frame = static_cast<int>(std::ceil(start * av_q2d(frame_rate)));
-          end_frame = static_cast<int>(std::floor(end * av_q2d(frame_rate)));
+          end_frame = end >= 0 ? static_cast<int>(std::floor(end * av_q2d(frame_rate))) :
+                                 file.frame_count_;
 
           DALI_ENFORCE(end_frame <= file.frame_count_, "End time is greater than video duration "
                        "for file " + file_info_[i].video_file);

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -42,7 +42,8 @@ This option is mutually exclusive with `file_root` and `file_list`.)code",
 This option is mutually exclusive with `filenames` and `file_list`.)code",
       std::string())
   .AddOptionalArg("file_list",
-      R"code(Path to the file with a list of pairs ``file label``.
+      R"code(Path to the file with a list of ``file label [start_frame end_frame]`` (end frame
+could be set to -1 as the end frame).
 This option is mutually exclusive with `filenames` and `file_root`.)code",
       std::string())
   .AddOptionalArg("enable_frame_num",

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -27,10 +27,11 @@ DALI_REGISTER_OPERATOR(VideoReader, VideoReader, GPU);
 
 DALI_SCHEMA(VideoReader)
   .DocStr(R"code(
-Load and decode H264 video codec with FFmpeg and NVDECODE, NVIDIA GPU's hardware-accelerated video decoding.
-The video codecs can be contained in most of container file formats. FFmpeg is used to parse video containers.
-Returns a batch of sequences of `sequence_length` frames of shape [N, F, H, W, C] (N being the batch size and F the
-number of frames). Supports only constant frame rate videos.)code")
+Load and decode H264, VP9, MPEG4 and HVEC(h265) video codec with FFmpeg and NVDECODE, NVIDIA GPU's
+hardware-accelerated video decoding. The video codecs can be contained in most of container file
+formats. FFmpeg is used to parse video containers. Returns a batch of sequences of `sequence_length`
+frames of shape [N, F, H, W, C] (N being the batch size and F the number of frames). Supports only
+constant frame rate videos.)code")
   .NumInput(0)
   .OutputFn(detail::VideoReaderOutputFn)
   .AddOptionalArg("filenames",

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -42,8 +42,9 @@ This option is mutually exclusive with `file_root` and `file_list`.)code",
 This option is mutually exclusive with `filenames` and `file_list`.)code",
       std::string())
   .AddOptionalArg("file_list",
-      R"code(Path to the file with a list of ``file label [start_frame end_frame]`` (end frame
-could be set to -1 as the end frame).
+      R"code(Path to the file with a list of ``file label [start_frame [end_frame]]`` Fframe number
+equal to 0 mean first/last frame, positive value means the exact frame, negative counts as a
+Nth frame from the end (it follows python array indexing schema).
 This option is mutually exclusive with `filenames` and `file_root`.)code",
       std::string())
   .AddOptionalArg("enable_frame_num",

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -42,10 +42,10 @@ This option is mutually exclusive with `file_root` and `file_list`.)code",
 This option is mutually exclusive with `filenames` and `file_list`.)code",
       std::string())
   .AddOptionalArg("file_list",
-      R"code(Path to the file with a list of ``file label [start_frame [end_frame]]`` Fframe number
-equal to 0 mean first/last frame, positive value means the exact frame, negative counts as a
-Nth frame from the end (it follows python array indexing schema).
-This option is mutually exclusive with `filenames` and `file_root`.)code",
+      R"code(Path to the file with a list of ``file label [start_frame [end_frame]]`` Positive value
+means the exact frame, negative counts as a Nth frame from the end (it follows python array
+indexing schema), equal values for the start and end frame would yield an empty sequence and a
+warning. This option is mutually exclusive with `filenames` and `file_root`.)code",
       std::string())
   .AddOptionalArg("enable_frame_num",
       R"code(Return frame number output if file_list or file_root argument is passed)code",

--- a/qa/TL0_videoreader_test/test.sh
+++ b/qa/TL0_videoreader_test/test.sh
@@ -38,7 +38,7 @@ do_once() {
   done
 
   # generate file_list.txt from video_files directory
-  ls -d $TMP_VIDEO_FILES/*  | tr " " "\n" | awk '{print $0, NR, 0;}' > /tmp/file_list.txt
+  ls -d $TMP_VIDEO_FILES/*  | tr " " "\n" | awk '{print $0, NR;}' > /tmp/file_list.txt
 }
 
 test_body() {

--- a/qa/TL0_videoreader_test/test.sh
+++ b/qa/TL0_videoreader_test/test.sh
@@ -38,7 +38,7 @@ do_once() {
   done
 
   # generate file_list.txt from video_files directory
-  ls -d $TMP_VIDEO_FILES/*  | tr " " "\n" | awk '{print $0, NR, 0, -1;}' > /tmp/file_list.txt
+  ls -d $TMP_VIDEO_FILES/*  | tr " " "\n" | awk '{print $0, NR, 0;}' > /tmp/file_list.txt
 }
 
 test_body() {

--- a/qa/TL0_videoreader_test/test.sh
+++ b/qa/TL0_videoreader_test/test.sh
@@ -38,7 +38,7 @@ do_once() {
   done
 
   # generate file_list.txt from video_files directory
-  ls -d $TMP_VIDEO_FILES/*  | tr " " "\n" | awk '{print $0, NR;}' > /tmp/file_list.txt
+  ls -d $TMP_VIDEO_FILES/*  | tr " " "\n" | awk '{print $0, NR, 0, -1;}' > /tmp/file_list.txt
 }
 
 test_body() {


### PR DESCRIPTION
- allows passing <= 0 values in the file list to allow more flexible frame indexing. Positive value means the exact frame, negative is the number of frames from the end; equal start and end frame would yield an empty sequence and a warning

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It allow passing a default end frame in the video file list

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     allows passing <= 0 values in the file list to allow more flexible frame indexing. Positive value means the exact frame, negative is the number of frames from the end; equal start and end frame would yield an empty sequence and a warning
 - Affected modules and functionalities:
     video reader
 - Key points relevant for the review:
     NA
 - Validation and testing:
     video test is extended
 - Documentation (including examples):
     NA

In response https://github.com/NVIDIA/DALI/issues/2263

**JIRA TASK**: *[NA]*
