### PR TITLE
Fixes crash in RandomBBoxCrop when no labels are provided

### DIFF
--- a/dali/operators/image/crop/bbox_crop.cc
+++ b/dali/operators/image/crop/bbox_crop.cc
@@ -233,7 +233,7 @@ can't be statisfied.)code",
     .AddOptionalArg(
         "all_boxes_above_threshold",
          R"code(If true, all bounding boxes in a sample should overlap with the cropping window as specified by
-``thresholds``, otherwise the cropping window is considered invalid. If false, a cropping window will be considered 
+``thresholds``, otherwise the cropping window is considered invalid. If false, a cropping window will be considered
 valid if any bounding box overlaps it sufficiently.)code",
          true)
     .AddOptionalArg(
@@ -493,14 +493,15 @@ class RandomBBoxCropImpl : public OpImplBase<CPUBackend> {
     ProspectiveCrop(bool success,
                     const Box<ndim, float>& crop,
                     span<const Box<ndim, float>> boxes_data,
-                    span<const int> labels_data)
+                    span<const int> labels_data,
+                    bool has_labels)
         : success(success), crop(crop) {
-      assert(boxes_data.size() == labels_data.size());
+      assert(boxes_data.size() == labels_data.size() || !has_labels);
       boxes.resize(boxes_data.size());
       labels.resize(labels_data.size());
       for (int i = 0; i < boxes_data.size(); i++) {
         boxes[i] = boxes_data[i];
-        labels[i] = labels_data[i];
+        if (has_labels) labels[i] = labels_data[i];
       }
     }
     ProspectiveCrop() = default;
@@ -581,7 +582,7 @@ class RandomBBoxCropImpl : public OpImplBase<CPUBackend> {
           for (int d = 0; d < ndim; d++)
             no_crop.hi[d] *= input_shape[d];
         }
-        crop = ProspectiveCrop(true, no_crop, bounding_boxes, labels);
+        crop = ProspectiveCrop(true, no_crop, bounding_boxes, labels, has_labels_);
         break;
       }
 

--- a/dali/test/python/test_operator_erase.py
+++ b/dali/test/python/test_operator_erase.py
@@ -25,7 +25,6 @@ from functools import partial
 from test_utils import check_batch
 from test_utils import compare_pipelines
 from test_utils import RandomDataIterator
-from test_utils import get_dali_extra_path
 
 class ErasePipeline(Pipeline):
     def __init__(self, device, batch_size, layout, iterator,

--- a/dali/test/python/test_operator_random_bbox_crop.py
+++ b/dali/test/python/test_operator_random_bbox_crop.py
@@ -334,7 +334,7 @@ def test_random_bbox_crop_overlap():
                         yield check_random_bbox_crop_overlap, \
                                 batch_size, ndim, crop_shape, input_shape, use_labels
 
-def test_random_bbox_crop_no_lables():
+def test_random_bbox_crop_no_labels():
     batch_size = 3
     pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0)
     test_box_shape = [200, 4]
@@ -343,10 +343,10 @@ def test_random_bbox_crop_no_lables():
         return out
     boxes = fn.external_source(source = get_boxes)
     processed = fn.random_bbox_crop(boxes,
-                                          aspect_ratio=[0.5, 2.0],
-                                          thresholds=[0.1, 0.3, 0.5],
-                                          scaling=[0.8, 1.0],
-                                          bbox_layout="xyXY")
+                                    aspect_ratio=[0.5, 2.0],
+                                    thresholds=[0.1, 0.3, 0.5],
+                                    scaling=[0.8, 1.0],
+                                    bbox_layout="xyXY")
     pipe.set_outputs(*processed)
     pipe.build()
     for _ in range(3):

--- a/dali/test/python/test_operator_random_bbox_crop.py
+++ b/dali/test/python/test_operator_random_bbox_crop.py
@@ -59,7 +59,7 @@ class BBoxDataIterator():
             if self.batch_size > 1:
                 boxes.append(np.array([bboxes[2], bboxes[1]], dtype=np.float32))
                 labels.append(np.array([2, 1], dtype=np.int32))
-                for i in range(self.batch_size - 2):
+                for _ in range(self.batch_size - 2):
                     boxes.append(np.array([bboxes[2]], dtype=np.float32))
                     labels.append(np.array([3], dtype=np.int32))
         else:
@@ -293,7 +293,7 @@ def check_random_bbox_crop_overlap(batch_size, ndim, crop_shape, input_shape, us
                                            input_shape=input_shape, crop_shape=crop_shape,
                                            all_boxes_above_threshold = False)
     pipe.build()
-    for i in range(100):
+    for _ in range(100):
         outputs = pipe.run()
         for sample in range(batch_size):
             out_crop_anchor = outputs[1].at(sample)
@@ -333,3 +333,21 @@ def test_random_bbox_crop_overlap():
                     for use_labels in [True, False]:
                         yield check_random_bbox_crop_overlap, \
                                 batch_size, ndim, crop_shape, input_shape, use_labels
+
+def test_random_bbox_crop_no_lables():
+    batch_size = 3
+    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+    test_box_shape = [200, 4]
+    def get_boxes():
+        out = [(np.random.randint(0, 255, size = test_box_shape, dtype = np.uint8) / 255).astype(dtype = np.float32) for _ in range(batch_size)]
+        return out
+    boxes = fn.external_source(source = get_boxes)
+    processed = fn.random_bbox_crop(boxes,
+                                          aspect_ratio=[0.5, 2.0],
+                                          thresholds=[0.1, 0.3, 0.5],
+                                          scaling=[0.8, 1.0],
+                                          bbox_layout="xyXY")
+    pipe.set_outputs(*processed)
+    pipe.build()
+    for _ in range(3):
+        pipe.run()


### PR DESCRIPTION
- ProspectiveCrop assumed that labels are always provided and there  the number is equal to the number of bboxes
- extends logic to support has_labels variable

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a crash in RandomBBoxCrop when no labels are provided

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     extends logic to support has_labels variable in ProspectiveCrop 
 - Affected modules and functionalities:
     RandomBBoxCrop 
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     test case has been added

Relates to https://github.com/NVIDIA/DALI/issues/2262
**JIRA TASK**: *[NA]*
