### PR TITLE
fixed file list support

### DIFF
--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -55,11 +55,14 @@ DALI_SCHEMA(NumpyReader)
   .AddArg("file_root",
       R"code(Path to a directory containing data files.
 `NumpyReader` supports flat directory structure. `file_root` directory should contain
-directories with numpy files in them.)code",
-      DALI_STRING)
+directories with numpy files in them.)code", DALI_STRING)
   .AddOptionalArg("file_filter",
       R"code(If specified, the string will be interpreted as glob string to filter
 the list of files in the sub-directories of `file_root`.)code", "*.npy")
+  .AddOptionalArg("file_list",
+      R"code(Path to a text file containing rows of ``filename label`` pairs, where the filenames are
+relative to ``file_root``. If left empty, ``file_root`` is traversed for subdirectories (only those at one level deep from
+``file_root``).)code", std::string())
   .AddOptionalArg("shuffle_after_epoch",
       R"code(If true, reader shuffles whole dataset after each epoch. It is exclusive with
 ``stick_to_shard`` and ``random_shuffle``.)code",

--- a/dali/test/python/test_operator_numpy_reader.py
+++ b/dali/test/python/test_operator_numpy_reader.py
@@ -23,22 +23,16 @@ import tempfile
 import nose.tools
 
 class NumpyReaderPipeline(Pipeline):
-    def __init__(self, path, batch_size, file_list=None,
+    def __init__(self, path, batch_size, file_list="",
                  path_filter="*.npy", num_threads=1, device_id=0, num_gpus=1):
         super(NumpyReaderPipeline, self).__init__(batch_size,
                                                   num_threads,
                                                   device_id)
         
-        if file_list is not None:
-            self.input = ops.NumpyReader(file_root = path,
-                                         file_list = file_list,
-                                         shard_id = device_id,
-                                         num_shards = num_gpus)
-        else:
-            self.input = ops.NumpyReader(file_root = path,
-                                         file_filter = path_filter,
-                                         shard_id = device_id,
-                                         num_shards = num_gpus)
+        self.input = ops.NumpyReader(file_root = path,
+                                     file_list = file_list,
+                                     shard_id = device_id,
+                                     num_shards = num_gpus)
 
     def define_graph(self):
         inputs = self.input(name="Reader")


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed because of *why we need this feature*
 it adds file list support to numpy reader, as requested by a user

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - enabled file_list support. If file_list is specified, the numpy reader will only pick the files specified, otherwise it will all files which pass the file_filter argument. I also added a corresponding test to test_operator_numpy_reader.


**JIRA TASK**: *[Use DALI-XXXX or NA]*
NA