### PR TITLE
add Lab color space conversion

### DIFF
--- a/dali/operators/image/color/color_space_conversion_test.cc
+++ b/dali/operators/image/color/color_space_conversion_test.cc
@@ -28,32 +28,42 @@ class ColorSpaceConversionToGrayTest : public GenericConversionTest<InputImgType
 template <typename InputImgType>
 class ColorSpaceConversionToYCbCrTest : public GenericConversionTest<InputImgType, YCbCr> {};
 
-typedef ::testing::Types<RGB, Gray, YCbCr> ConvertibleToBGR;
+template <typename InputImgType>
+class ColorSpaceConversionToLabTest : public GenericConversionTest<InputImgType, Lab> {};
+
+typedef ::testing::Types<RGB, Gray, YCbCr, Lab> ConvertibleToBGR;
 TYPED_TEST_SUITE(ColorSpaceConversionToBGRTest, ConvertibleToBGR);
 
 TYPED_TEST(ColorSpaceConversionToBGRTest, test) {
   this->RunTest("ColorSpaceConversion");
 }
 
-typedef ::testing::Types<BGR, Gray, YCbCr> ConvertibleToRGB;
+typedef ::testing::Types<BGR, Gray, YCbCr, Lab> ConvertibleToRGB;
 TYPED_TEST_SUITE(ColorSpaceConversionToRGBTest, ConvertibleToRGB);
 
 TYPED_TEST(ColorSpaceConversionToRGBTest, test) {
   this->RunTest("ColorSpaceConversion");
 }
 
-typedef ::testing::Types<RGB, BGR, YCbCr> ConvertibleToGray;
+typedef ::testing::Types<RGB, BGR, YCbCr, Lab> ConvertibleToGray;
 TYPED_TEST_SUITE(ColorSpaceConversionToGrayTest, ConvertibleToGray);
 
 TYPED_TEST(ColorSpaceConversionToGrayTest, test) {
   this->RunTest("ColorSpaceConversion");
 }
 
-typedef ::testing::Types<RGB, BGR, Gray> ConvertibleToYCbCr;
+typedef ::testing::Types<RGB, BGR, Gray, Lab> ConvertibleToYCbCr;
 TYPED_TEST_SUITE(ColorSpaceConversionToYCbCrTest, ConvertibleToYCbCr);
 
 TYPED_TEST(ColorSpaceConversionToYCbCrTest, test) {
   this->RunTest("ColorSpaceConversion", nullptr, 0, false, 0.002);
+}
+
+typedef ::testing::Types<RGB, BGR, Gray, YCbCr> ConvertibleToLab;
+TYPED_TEST_SUITE(ColorSpaceConversionToLabTest, ConvertibleToLab);
+
+TYPED_TEST(ColorSpaceConversionToLabTest, test) {
+  this->RunTest("ColorSpaceConversion");
 }
 
 }  // namespace dali

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1126,11 +1126,12 @@ PYBIND11_MODULE(backend_impl, m) {
 
   // DALIImageType
   py::enum_<DALIImageType>(types_m, "DALIImageType", "Image type")
+    .value("ANY_DATA", DALI_ANY_DATA)
     .value("RGB", DALI_RGB)
     .value("BGR", DALI_BGR)
     .value("GRAY", DALI_GRAY)
     .value("YCbCr", DALI_YCbCr)
-    .value("ANY_DATA", DALI_ANY_DATA)
+    .value("Lab", DALI_Lab)
     .export_values();
 
   // DALIInterpType

--- a/dali/test/dali_test.h
+++ b/dali/test/dali_test.h
@@ -53,6 +53,9 @@ struct Gray {
 struct YCbCr {
   static const DALIImageType type = DALI_YCbCr;
 };
+struct Lab {
+  static const DALIImageType type = DALI_Lab;
+};
 
 // Main testing fixture to provide common functionality across tests
 class DALITest : public ::testing::Test {

--- a/include/dali/core/common.h
+++ b/include/dali/core/common.h
@@ -115,11 +115,12 @@ enum DALIInterpType {
  * @brief Supported image formats
  */
 enum DALIImageType {
+  DALI_ANY_DATA     = -1,
   DALI_RGB          = 0,
   DALI_BGR          = 1,
   DALI_GRAY         = 2,
   DALI_YCbCr        = 3,
-  DALI_ANY_DATA     = 4
+  DALI_Lab          = 4,
 };
 
 


### PR DESCRIPTION
Signed-off-by: ijpq <tangke0320@hotmail.com>

Why we need this PR?
Pick one, remove the rest

It adds new feature needed because of issue # 1829
What happened in this PR?
Fill relevant points, put NA otherwise. Replace anything inside []

What solution was applied:
[ on CPU side, impl conversion between lab and others through cvtcolor. ; as for GPU side, impl conversion between lab and others through defined cudakernel or npp api]
Affected modules and functionalities:
[ amend DALI_ANY_DATA to -1. ]
Key points relevant for the review:
[ on CPU side, if it is elegant first declare a temp cv::mat ]
Validation and testing:
[ finish /dali/docker/build.sh and pass linter check.]
Documentation (including examples):
[ nothing ]