### PR TITLE
Add deprecation handling in backend

### DIFF
--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -94,7 +94,7 @@ class DLL_PUBLIC OpSpec {
    */
   template <typename T>
   DLL_PUBLIC inline OpSpec& AddArg(const string &name, const T &val) {
-    VerifyRenamedAfterDeprecated(name);
+    EnforceNoAliasWithDeprecated(name);
     DALI_ENFORCE(arguments_.find(name) == arguments_.end(),
         "AddArg failed. Argument with name \"" + name +
         "\" already exists. ");
@@ -136,7 +136,7 @@ class DLL_PUBLIC OpSpec {
    * @brief Add an instantiated argument with given name
    */
   DLL_PUBLIC inline OpSpec& AddInitializedArg(const string& name, Argument* arg) {
-    VerifyRenamedAfterDeprecated(name);
+    EnforceNoAliasWithDeprecated(name);
     DALI_ENFORCE(arguments_.find(name) == arguments_.end(),
         "AddArg failed. Argument with name \"" + name +
         "\" already exists. ");
@@ -146,12 +146,12 @@ class DLL_PUBLIC OpSpec {
   /**
    * @brief Sets or adds an argument with given name
    *
-   * Routes the deprecated argument to appropriate name or drops them
+   * @remarks Deprecated arguments are renamed (or dropped, if no longer used).
    */
   DLL_PUBLIC inline OpSpec& SetInitializedArg(const string& arg_name, Argument* arg) {
     if (schema_ && schema_->IsDeprecatedArg(arg_name)) {
       const auto& deprecation_meta = schema_->DeprecatedArgMeta(arg_name);
-      // Argument is removed, and we can discard it
+      // Argument was removed, and we can discard it
       if (deprecation_meta.removed) {
         return *this;
       }
@@ -171,15 +171,15 @@ class DLL_PUBLIC OpSpec {
         return *this;
       }
     }
-    VerifyRenamedAfterDeprecated(arg_name);
+    EnforceNoAliasWithDeprecated(arg_name);
     arguments_[arg_name].reset(arg);
     return *this;
   }
 
   /**
-   * @brief Check if the `arg_name` was already set through deprecated argument
+   * @brief Check if the `arg_name` was already set through a deprecated argument
    */
-  DLL_PUBLIC inline void VerifyRenamedAfterDeprecated(const string& arg_name) {
+  DLL_PUBLIC inline void EnforceNoAliasWithDeprecated(const string& arg_name) {
     auto set_through = set_through_deprecated_arguments_.find(arg_name);
     DALI_ENFORCE(set_through == set_through_deprecated_arguments_.end(),
                  make_string("Operator ", name(), " got an unexpected '", set_through->second,

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -163,7 +163,11 @@ class DLL_PUBLIC OpSpec {
                         "' deprecated argument when '", new_arg_name, "' was already provided."));
 
         set_through_deprecated_arguments_[new_arg_name] = arg_name;
-        arguments_[deprecation_meta.renamed_to].reset(arg);
+        // Adjust the arg so it carries the proper name for serialization
+        if (arg->has_name()) {
+          arg->set_name(new_arg_name);
+        }
+        arguments_[new_arg_name].reset(arg);
         return *this;
       }
     }

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -149,8 +149,8 @@ class DLL_PUBLIC OpSpec {
    * Routes the deprecated argument to appropriate name or drops them
    */
   DLL_PUBLIC inline OpSpec& SetInitializedArg(const string& arg_name, Argument* arg) {
-    if (GetSchema().IsDeprecatedArg(arg_name)) {
-      const auto& deprecation_meta = GetSchema().DeprecatedArgMeta(arg_name);
+    if (schema_ && schema_->IsDeprecatedArg(arg_name)) {
+      const auto& deprecation_meta = schema_->DeprecatedArgMeta(arg_name);
       // Argument is removed, and we can discard it
       if (deprecation_meta.removed) {
         return *this;

--- a/dali/pipeline/operator/op_spec_test.cc
+++ b/dali/pipeline/operator/op_spec_test.cc
@@ -218,8 +218,39 @@ TEST(OpSpecTest, DeprecatedArgs) {
       .AddArg("batch_size", 2)
       .AddArg("deprecated_ignored_arg", 42);
 
-  ASSERT_FALSE(spec0.TryGetArgument<int>(result, "deprecated_arg"));
+  ASSERT_FALSE(spec0.TryGetArgument<int>(result, "deprecated_ignored_arg"));
+}
 
+TEST(OpSpecTest, DeserializeDeprecated) {
+  int num_thread = 2;
+  int batch_size = 2;
+
+  Pipeline pipe(batch_size, num_thread, 0);
+
+  pipe.AddOperator(
+      OpSpec("DummyOpForSpecTest")
+      .AddArg("device", "cpu")
+      .AddArg("preserve", true)
+      .AddArg("deprecated_arg", 1)
+      .AddArg("deprecated_ignored_arg", 1), "dummy_op_name");
+
+  vector<std::pair<string, string>> outputs = {
+      {"out0", "cpu"}};
+  pipe.AddExternalInput("out0");
+  pipe.Build(outputs);
+
+  auto serialized = pipe.SerializeToProtobuf();
+  auto *op_node0 = pipe.GetOperatorNode("dummy_op_name");
+  Pipeline deserialized_pipe(serialized);
+  std::cout << serialized << std::endl;
+  // auto *op_node = deserialized_pipe.GetOperatorNode("dummy_op_name");
+
+//   int result = 0;
+//   ASSERT_FALSE(op_node->spec.TryGetArgument<int>(result, "deprecated_arg"));
+//   ASSERT_TRUE(op_node->spec.TryGetArgument<int>(result, "replacing_arg"));
+//   ASSERT_EQ(result, 1);
+
+//   ASSERT_FALSE(op_node->spec.TryGetArgument<int>(result, "deprecated_ignored_arg"));
 }
 
 class TestArgumentInput_Producer : public Operator<CPUBackend> {

--- a/dali/pipeline/operator/op_spec_test.cc
+++ b/dali/pipeline/operator/op_spec_test.cc
@@ -183,12 +183,12 @@ TEST(OpSpecTest, GetArgumentVec) {
 TEST(OpSpecTest, GetArgumentNonExisting) {
   auto spec0 = OpSpec("DummyOpForSpecTest")
       .AddArg("batch_size", 2);
-  ASSERT_THROW(spec0.GetArgument<int>("<no_such_argument>"), std::runtime_error);
+  ASSERT_THROW(spec0.GetArgument<int>("<no_such_argument>"), DALIException);
   int result = 0;
   ASSERT_FALSE(spec0.TryGetArgument<int>(result, "<no_such_argument>"));
 
 
-  ASSERT_THROW(spec0.GetRepeatedArgument<int>("<no_such_argument>"), std::runtime_error);
+  ASSERT_THROW(spec0.GetRepeatedArgument<int>("<no_such_argument>"), DALIException);
   std::vector<int> result_vec;
   ASSERT_FALSE(spec0.TryGetRepeatedArgument<int>(result_vec, "<no_such_argument>"));
 }
@@ -197,7 +197,7 @@ TEST(OpSpecTest, DeprecatedArgs) {
   auto spec0 = OpSpec("DummyOpForSpecTest")
       .AddArg("batch_size", 2)
       .AddArg("deprecated_arg", 1);
-  ASSERT_THROW(spec0.GetArgument<int>("deprecated_arg"), std::runtime_error);
+  ASSERT_THROW(spec0.GetArgument<int>("deprecated_arg"), DALIException);
   ASSERT_EQ(spec0.GetArgument<int>("replacing_arg"), 1);
   int result = 0;
   ASSERT_FALSE(spec0.TryGetArgument<int>(result, "deprecated_arg"));
@@ -207,12 +207,12 @@ TEST(OpSpecTest, DeprecatedArgs) {
   ASSERT_THROW(OpSpec("DummyOpForSpecTest")
       .AddArg("batch_size", 2)
       .AddArg("deprecated_arg", 1)
-      .AddArg("replacing_arg", 2), std::runtime_error);
+      .AddArg("replacing_arg", 2), DALIException);
 
   ASSERT_THROW(OpSpec("DummyOpForSpecTest")
       .AddArg("batch_size", 2)
       .AddArg("replacing_arg", 1)
-      .AddArg("deprecated_arg", 2), std::runtime_error);
+      .AddArg("deprecated_arg", 2), DALIException);
 
   auto spec1 = OpSpec("DummyOpForSpecTest")
       .AddArg("batch_size", 2)

--- a/dali/pipeline/operator/op_spec_test.cc
+++ b/dali/pipeline/operator/op_spec_test.cc
@@ -221,38 +221,6 @@ TEST(OpSpecTest, DeprecatedArgs) {
   ASSERT_FALSE(spec0.TryGetArgument<int>(result, "deprecated_ignored_arg"));
 }
 
-TEST(OpSpecTest, DeserializeDeprecated) {
-  int num_thread = 2;
-  int batch_size = 2;
-
-  Pipeline pipe(batch_size, num_thread, 0);
-
-  pipe.AddOperator(
-      OpSpec("DummyOpForSpecTest")
-      .AddArg("device", "cpu")
-      .AddArg("preserve", true)
-      .AddArg("deprecated_arg", 1)
-      .AddArg("deprecated_ignored_arg", 1), "dummy_op_name");
-
-  vector<std::pair<string, string>> outputs = {
-      {"out0", "cpu"}};
-  pipe.AddExternalInput("out0");
-  pipe.Build(outputs);
-
-  auto serialized = pipe.SerializeToProtobuf();
-  auto *op_node0 = pipe.GetOperatorNode("dummy_op_name");
-  Pipeline deserialized_pipe(serialized);
-  std::cout << serialized << std::endl;
-  // auto *op_node = deserialized_pipe.GetOperatorNode("dummy_op_name");
-
-//   int result = 0;
-//   ASSERT_FALSE(op_node->spec.TryGetArgument<int>(result, "deprecated_arg"));
-//   ASSERT_TRUE(op_node->spec.TryGetArgument<int>(result, "replacing_arg"));
-//   ASSERT_EQ(result, 1);
-
-//   ASSERT_FALSE(op_node->spec.TryGetArgument<int>(result, "deprecated_ignored_arg"));
-}
-
 class TestArgumentInput_Producer : public Operator<CPUBackend> {
  public:
   explicit TestArgumentInput_Producer(const OpSpec &spec) : Operator<CPUBackend>(spec) {}

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -380,17 +380,6 @@ def python_op_factory(name, op_device = "cpu"):
                 if not self._schema.IsDeprecatedArg(arg_name):
                     continue
                 meta = self._schema.DeprecatedArgMeta(arg_name)
-                new_name = meta['renamed_to']
-                removed = meta['removed']
-                msg = meta['msg']
-                if new_name:
-                    if new_name in kwargs:
-                        raise TypeError("Operator {} got an unexpected '{}' deprecated argument when '{}' was already provided".format(
-                            type(self).__name__, arg_name, new_name))
-                    kwargs[new_name] = kwargs[arg_name]
-                    del kwargs[arg_name]
-                elif removed:
-                    del kwargs[arg_name]
 
                 with warnings.catch_warnings():
                     warnings.simplefilter("default")

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -380,6 +380,7 @@ def python_op_factory(name, op_device = "cpu"):
                 if not self._schema.IsDeprecatedArg(arg_name):
                     continue
                 meta = self._schema.DeprecatedArgMeta(arg_name)
+                msg = meta['msg']
 
                 with warnings.catch_warnings():
                     warnings.simplefilter("default")

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -380,7 +380,17 @@ def python_op_factory(name, op_device = "cpu"):
                 if not self._schema.IsDeprecatedArg(arg_name):
                     continue
                 meta = self._schema.DeprecatedArgMeta(arg_name)
+                new_name = meta['renamed_to']
+                removed = meta['removed']
                 msg = meta['msg']
+                if new_name:
+                    if new_name in kwargs:
+                        raise TypeError("Operator {} got an unexpected '{}' deprecated argument when '{}' was already provided".format(
+                            type(self).__name__, arg_name, new_name))
+                    kwargs[new_name] = kwargs[arg_name]
+                    del kwargs[arg_name]
+                elif removed:
+                    del kwargs[arg_name]
 
                 with warnings.catch_warnings():
                     warnings.simplefilter("default")


### PR DESCRIPTION
Keeps the deprecation warnings in Python.
Renaming and detecting double arguments handled in backend.
Skipping unused arguments done in backend.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- Refactoring to handle deprecations for all apis at once.

#### What happened in this PR? 
 - What solution was applied:
    Keeps the deprecation warnings in Python.
    Renaming and detecting double arguments handled in backend.
    Skipping unused arguments done in backend.

 - Affected modules and functionalities:
     OpSpec, ops.py
 - Key points relevant for the review:
	 Is this enough? Do we want warnings in C++?
 - Validation and testing:
     Test added. Can we add dummy operator for testing in Python?
     Should we cover serialization somehow? It requires some fake serialized data + deserialization + more complete, nontrivial pipeline for test. (probably buildable one to allow for verification).
 - Documentation (including examples): N/A


**JIRA TASK**: *[Use DALI-XXXX or NA]*
