### PR TITLE
Allow Slice to silently assume absolute anchor and shape when those are represented by an integer

### DIFF
--- a/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_slice.h
@@ -33,7 +33,7 @@ class nvJPEGDecoderSlice : public nvJPEGDecoder {
  protected:
   using OperatorBase::Run;
   void Run(MixedWorkspace &ws) override {
-    slice_attr_.ProcessArguments(ws);
+    slice_attr_.ProcessArguments<MixedBackend>(ws);
     nvJPEGDecoder::Run(ws);
   }
 

--- a/dali/operators/generic/slice/slice.cc
+++ b/dali/operators/generic/slice/slice.cc
@@ -29,14 +29,14 @@ coordinates and ``WH`` order for the slice arguments.)code")
     .NumInput(3)
     .NumOutput(1)
     .InputDox(0, "data", "TensorList", "Batch containing input data")
-    .InputDox(1, "anchor", "1D TensorList of float",
-                 R"code(Input containing either normalized or absolute coordinates
-(depending on the value of `normalized_anchor`) for the starting point of the
-slice (x0, x1, x2, ...).)code")
-    .InputDox(2, "shape", "1D TensorList of float",
-                 R"code(Input containing either normalized or absolute coordinates
-(depending on the value of `normalized_shape`) for the dimensions of the slice
-(s0, s1, s2, ...).)code")
+    .InputDox(1, "anchor", "1D TensorList of float or int",
+                 R"code(Input that contains normalized or absolute coordinates for the starting point of
+ the slice (x0, x1, x2, …). Integer coordinates are interpreted as absolute coordinates, while float coordinates
+ can be interpreted as absolute or relative coordinates, depending on the value of ``normalized_anchor``.)code")
+    .InputDox(2, "shape", "1D TensorList of float or int",
+                 R"code(Input that contains normalized or absolute coordinates for the dimensions of the
+ slice (s0, s1, s2, …). Integer coordinates are interpreted as absolute coordinates, while float coordinates
+ can be interpreted as absolute or relative coordinates, depending on the value of ``normalized_shape``.)code")
     .AllowSequences()
     .SupportVolumetric()
     .DeprecateArg("image_type", true)  // deprecated since 0.24dev

--- a/dali/operators/generic/slice/slice.h
+++ b/dali/operators/generic/slice/slice.h
@@ -35,7 +35,7 @@ class Slice : public SliceBase<Backend> {
 
  protected:
   void ProcessCroppingAttrs(const workspace_t<Backend> &ws) override {
-    slice_attr_.ProcessArguments(ws);
+    slice_attr_.ProcessArguments<Backend>(ws);
   }
 
   const CropWindowGenerator& GetCropWindowGenerator(std::size_t data_idx) const override {

--- a/dali/operators/generic/slice/slice_attr.cc
+++ b/dali/operators/generic/slice/slice_attr.cc
@@ -22,19 +22,30 @@ namespace dali {
 DALI_SCHEMA(SliceAttr)
     .DocStr(R"code(Slice attributes placeholder)code")
     .AddOptionalArg("axes",
-        R"code(Order of dimensions used for anchor and shape slice inputs, as dimension indexes)code",
+        R"code(Order of dimensions used for the anchor and shape slice inputs as dimension
+indexes.)code",
         std::vector<int>{1, 0})
     .AddOptionalArg("axis_names",
-        R"code(Order of dimensions used for anchor and shape slice inputs, as described in layout.
-If provided, `axis_names` takes higher priority than `axes`)code",
+        R"code(Order of the dimensions used for the anchor and shape slice inputs,
+as described in layout.
+
+If a value is provided, ``axis_names`` will have a higher priority than ``axes``.)code",
         TensorLayout("WH"))
     .AddOptionalArg("normalized_anchor",
-        R"code(Whether or not the `anchor` input should be interpreted as normalized (range [0.0, 1.0])
-or absolute coordinates)code",
+        R"code(Determines whether the anchor input should be interpreted as normalized
+(range [0.0, 1.0]) or as absolute coordinates.
+
+.. note::
+    This argument is only relevant when anchor input is a float tensor. For integer types,
+ absolute coordinates are assumed.)code",
         true)
     .AddOptionalArg("normalized_shape",
-        R"code(Whether or not the `shape` input should be interpreted as normalized (range [0.0, 1.0])
-or absolute coordinates)code",
+        R"code(Determines whether the shape input should be interpreted as normalized
+(range [0.0, 1.0]) or as absolute coordinates.
+
+.. note::
+    This argument is only relevant when the shape input is a float tensor. For integer types,
+ absolute coordinates are assumed.)code",
         true);
 
 }  // namespace dali

--- a/dali/operators/generic/slice/slice_attr.cc
+++ b/dali/operators/generic/slice/slice_attr.cc
@@ -23,7 +23,7 @@ DALI_SCHEMA(SliceAttr)
     .DocStr(R"code(Slice attributes placeholder)code")
     .AddOptionalArg("axes",
         R"code(Order of dimensions used for the anchor and shape slice inputs as dimension
-indexes.)code",
+indices.)code",
         std::vector<int>{1, 0})
     .AddOptionalArg("axis_names",
         R"code(Order of the dimensions used for the anchor and shape slice inputs,
@@ -36,16 +36,16 @@ If a value is provided, ``axis_names`` will have a higher priority than ``axes``
 (range [0.0, 1.0]) or as absolute coordinates.
 
 .. note::
-    This argument is only relevant when anchor input is a float tensor. For integer types,
- absolute coordinates are assumed.)code",
+    This argument is only relevant when anchor data type is ``float``. For integer types,
+ the coordinates are always absolute..)code",
         true)
     .AddOptionalArg("normalized_shape",
         R"code(Determines whether the shape input should be interpreted as normalized
 (range [0.0, 1.0]) or as absolute coordinates.
 
 .. note::
-    This argument is only relevant when the shape input is a float tensor. For integer types,
- absolute coordinates are assumed.)code",
+    This argument is only relevant when anchor data type is ``float``. For integer types,
+ the coordinates are always absolute.)code",
         true);
 
 }  // namespace dali

--- a/dali/test/python/test_operator_resize_seq.py
+++ b/dali/test/python/test_operator_resize_seq.py
@@ -87,12 +87,11 @@ def create_dali_pipe(channel_first, seq_len, interp, dtype, w, h, batch_size = 2
         dali_resized_cpu, size_cpu = resize_cpu_out
         dali_resized_gpu, size_gpu = resize_gpu_out
         # extract just HW part from the input shape
-        shape_anchor = np.array([2 if channel_first else 1], dtype=np.float32)
-        shape_shape = np.array([2], dtype=np.float32)
+        shape_anchor = np.array([2 if channel_first else 1], dtype=np.int32)
+        shape_shape = np.array([2], dtype=np.int32)
         ext_size = fn.slice(fn.cast(fn.shapes(ext), dtype=types.INT32),
                             types.Constant(shape_anchor, device="cpu"),
                             types.Constant(shape_shape, device="cpu"),
-                            normalized_anchor=False,normalized_shape=False,
                             axes=[0])
         pipe.set_outputs(dali_resized_cpu, dali_resized_gpu, ext_size, size_cpu, size_gpu)
     return pipe

--- a/dali/test/python/test_torch_pipeline_rnnt.py
+++ b/dali/test/python/test_torch_pipeline_rnnt.py
@@ -212,8 +212,7 @@ class RnntTrainPipeline(nvidia.dali.pipeline.Pipeline):
                                     device="cpu")
 
         self.get_nonsilent_region = ops.NonsilentRegion(device="cpu", cutoff_db=silence_threshold)
-        self.trim_silence = ops.Slice(device="cpu", normalized_anchor=False, normalized_shape=False,
-                                      axes=[0])
+        self.trim_silence = ops.Slice(device="cpu", axes=[0])
         self.to_float = ops.Cast(dtype=types.FLOAT)
 
     @staticmethod
@@ -238,7 +237,7 @@ class RnntTrainPipeline(nvidia.dali.pipeline.Pipeline):
 
     def remove_silence(self, input):
         begin, len = self.get_nonsilent_region(input)
-        out = self.trim_silence(input, self.to_float(begin), self.to_float(len))
+        out = self.trim_silence(input, begin, len)
         return out
 
     def define_graph(self):


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to improve Slice API, so that we don't need to pass absolute coordinates as floats and add extra flags to say that the coordinates are actually absolute.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Detecting type of anchor and shape and assuming absolute coordinates if those are integers*
 - Affected modules and functionalities:
     *Slice, ImageDecoderSlice*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     *Some tests using Slice were updated*
 - Documentation (including examples):
     *Doc str updated*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
