### PR TITLE
Concatenate TensorListShapes

### DIFF
--- a/dali/core/tensor_shape_test.cc
+++ b/dali/core/tensor_shape_test.cc
@@ -615,11 +615,6 @@ TEST(TensorListShapeTest, ConstructorsFromVector) {
   EXPECT_EQ(tls_static_2_3.shapes, shapes);
   EXPECT_EQ(tls_static_2_3.size(), 2);
   EXPECT_EQ(tls_static_2_3.sample_dim(), 3);
-
-  TensorListShape<> tls_dyn_3(shapes, 3);
-  EXPECT_EQ(tls_dyn_3.shapes, shapes);
-  EXPECT_EQ(tls_dyn_3.size(), 2);
-  EXPECT_EQ(tls_dyn_3.sample_dim(), 3);
 }
 
 TEST(TensorListShapeTest, IsUniform) {

--- a/dali/core/tensor_shape_test.cc
+++ b/dali/core/tensor_shape_test.cc
@@ -1249,12 +1249,12 @@ TEST(AppendTest, AppendTest) {
 }
 
 TEST(AppendTest, ZeroDim) {
-  TensorListShape<0> tls_tested_st = {{1, 1, 1, 1}, 4, 0};
-  TensorListShape<-1> tls_tested_dyn = {{1, 1, 1, 1}, 4, 0};
-  TensorListShape<0> tls1 = {{1, 1, 1, 1}, 4, 0};
-  TensorListShape<-1> tls2 = {{1, 1, 1, 1}, 4, 0};
-  TensorListShape<0> tls3 = {{1, 1, 1, 1}, 4, 0};
-  TensorListShape<0> ref = {{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 12, 0};
+  TensorListShape<0> tls_tested_st = {{}, 4, 0};
+  TensorListShape<-1> tls_tested_dyn = {{}, 4, 0};
+  TensorListShape<0> tls1 = {{}, 4, 0};
+  TensorListShape<-1> tls2 = {{}, 4, 0};
+  TensorListShape<0> tls3 = {{}, 4, 0};
+  TensorListShape<0> ref = {{}, 12, 0};
 
   tls_tested_st.append({tls2.to_static<0>(), tls3});
   tls_tested_dyn.append({tls2, tls3});

--- a/dali/core/tensor_shape_test.cc
+++ b/dali/core/tensor_shape_test.cc
@@ -620,11 +620,6 @@ TEST(TensorListShapeTest, ConstructorsFromVector) {
   EXPECT_EQ(tls_dyn_3.shapes, shapes);
   EXPECT_EQ(tls_dyn_3.size(), 2);
   EXPECT_EQ(tls_dyn_3.sample_dim(), 3);
-
-  TensorListShape<3> tls_static_3(shapes, 3);
-  EXPECT_EQ(tls_static_3.shapes, shapes);
-  EXPECT_EQ(tls_static_3.size(), 2);
-  EXPECT_EQ(tls_static_3.sample_dim(), 3);
 }
 
 TEST(TensorListShapeTest, IsUniform) {
@@ -1259,12 +1254,12 @@ TEST(AppendTest, AppendTest) {
 }
 
 TEST(AppendTest, ZeroDim) {
-  TensorListShape<0> tls_tested_st = {{1, 2, 3, 4}, 0};
-  TensorListShape<-1> tls_tested_dyn = {{1, 2, 3, 4}, 0};
-  TensorListShape<0> tls1 = {{5, 6, 7, 8}, 0};
-  TensorListShape<-1> tls2 = {{5, 6, 7, 8}, 0};
-  TensorListShape<0> tls3 = {{9, 10, 11, 12}, 0};
-  TensorListShape<0> ref = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, 0};
+  TensorListShape<0> tls_tested_st = {{1, 1, 1, 1}, 4, 0};
+  TensorListShape<-1> tls_tested_dyn = {{1, 1, 1, 1}, 4, 0};
+  TensorListShape<0> tls1 = {{1, 1, 1, 1}, 4, 0};
+  TensorListShape<-1> tls2 = {{1, 1, 1, 1}, 4, 0};
+  TensorListShape<0> tls3 = {{1, 1, 1, 1}, 4, 0};
+  TensorListShape<0> ref = {{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, 12, 0};
 
   tls_tested_st.append({tls2.to_static<0>(), tls3});
   tls_tested_dyn.append({tls2, tls3});

--- a/include/dali/core/span.h
+++ b/include/dali/core/span.h
@@ -218,10 +218,10 @@ DALI_HOST_DEV constexpr span<T, N> make_span(T (&a)[N]) {
 }
 
 template <span_extent_t Extent, typename T>
-DALI_HOST_DEV constexpr span<const T, Extent> make_cspan(T *data) { return { data }; }
+DALI_HOST_DEV constexpr span<const T, Extent> make_cspan(const T *data) { return { data }; }
 
 template <span_extent_t Extent = dynamic_extent, typename T>
-DALI_HOST_DEV constexpr span<const T, Extent> make_cspan(T *data, span_extent_t extent) {
+DALI_HOST_DEV constexpr span<const T, Extent> make_cspan(const T *data, span_extent_t extent) {
   return { data, extent };
 }
 
@@ -254,7 +254,7 @@ DALI_HOST_DEV constexpr span<const T, N> make_cspan(std::array<T, N> &&a) {
 }
 
 template <typename T, size_t N>
-DALI_HOST_DEV constexpr span<const T, N> make_cspan(T (&a)[N]) {
+DALI_HOST_DEV constexpr span<const T, N> make_cspan(const T (&a)[N]) {
   return { a };
 }
 

--- a/include/dali/core/span.h
+++ b/include/dali/core/span.h
@@ -218,7 +218,7 @@ DALI_HOST_DEV constexpr span<T, N> make_span(T (&a)[N]) {
 }
 
 template <span_extent_t Extent, typename T>
-DALI_HOST_DEV constexpr span<const T, Extent> make_cspan(const T *data) { return { data }; }
+DALI_HOST_DEV constexpr span<const T, Extent> make_cspan(T *data) { return { data }; }
 
 template <span_extent_t Extent = dynamic_extent, typename T>
 DALI_HOST_DEV constexpr span<const T, Extent> make_cspan(const T *data, span_extent_t extent) {
@@ -254,7 +254,7 @@ DALI_HOST_DEV constexpr span<const T, N> make_cspan(std::array<T, N> &&a) {
 }
 
 template <typename T, size_t N>
-DALI_HOST_DEV constexpr span<const T, N> make_cspan(const T (&a)[N]) {
+DALI_HOST_DEV constexpr span<const T, N> make_cspan(T (&a)[N]) {
   return { a };
 }
 

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -833,7 +833,7 @@ struct TensorListShape : TensorListShapeBase<TensorListShape<sample_ndim>, sampl
   TensorListShape(const std::vector<int64_t> &shapes, int num_samples, int sample_dim)
       : Base(shapes, num_samples) {
     assert(sample_dim == sample_ndim);
-    assert(num_samples * (sample_dim == 0 ? 1 : sample_dim) == static_cast<int>(shapes.size()));
+    assert(num_samples * sample_dim == static_cast<int>(shapes.size()));
   }
 
   TensorListShape(std::vector<int64_t> &&shapes, int num_samples, int sample_dim)

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -729,14 +729,6 @@ struct TensorListShape<DynamicDimensions>
       : Base(flatten_shapes(sample_shapes), sample_shapes.size()),
         ndim(get_dim_from_uniform(sample_shapes)) {}
 
-  TensorListShape(const std::vector<int64_t> &shapes, int sample_dim)
-      : Base(shapes, shapes.size() / (sample_dim == 0 ? 1 : sample_dim)),
-        ndim(sample_dim) {}
-
-  TensorListShape(std::vector<int64_t> &&shapes, int sample_dim)
-      : Base(std::move(shapes), shapes.size() / (sample_dim == 0 ? 1 : sample_dim)),
-        ndim(sample_dim) {}
-
   TensorListShape(const std::vector<int64_t> &shapes, int num_samples, int sample_dim)
       : Base(shapes, num_samples), ndim(sample_dim) {
     assert(num_samples * sample_dim == static_cast<int>(shapes.size()));
@@ -793,6 +785,7 @@ struct TensorListShape<DynamicDimensions>
   TensorListShape<other_ndim> to_static() const & {
     static_assert(other_ndim != DynamicDimensions,
                   "Conversion to static only allowed for static shape");
+    assert((num_samples() == 0 || sample_dim() == other_ndim) && "Cannot convert to other ndim");
     return { shapes, size(), other_ndim };
   }
 
@@ -800,6 +793,7 @@ struct TensorListShape<DynamicDimensions>
   TensorListShape<other_ndim> to_static() && {
     static_assert(other_ndim != DynamicDimensions,
                   "Conversion to static only allowed for static shape");
+    assert((num_samples() == 0 || sample_dim() == other_ndim) && "Cannot convert to other ndim");
     return { std::move(shapes), size(), other_ndim };
   }
 

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -831,20 +831,10 @@ struct TensorListShape : TensorListShapeBase<TensorListShape<sample_ndim>, sampl
   TensorListShape(const std::vector<TensorShape<sample_ndim>> &sample_shapes)  // NOLINT
       : Base(flatten_shapes(sample_shapes), sample_shapes.size()) {}
 
-  TensorListShape(const std::vector<int64_t> &shapes, int sample_dim)
-      : Base(shapes, shapes.size() / (sample_dim == 0 ? 1 : sample_dim)) {
-    assert(sample_dim == sample_ndim);
-  }
-
-  TensorListShape(std::vector<int64_t> &&shapes, int sample_dim)
-      : Base(std::move(shapes), shapes.size() / (sample_dim == 0 ? 1 : sample_dim)) {
-    assert(sample_dim == sample_ndim);
-  }
-
   TensorListShape(const std::vector<int64_t> &shapes, int num_samples, int sample_dim)
       : Base(shapes, num_samples) {
     assert(sample_dim == sample_ndim);
-    assert(num_samples * sample_dim == static_cast<int>(shapes.size()));
+    assert(num_samples * (sample_dim == 0 ? 1 : sample_dim) == static_cast<int>(shapes.size()));
   }
 
   TensorListShape(std::vector<int64_t> &&shapes, int num_samples, int sample_dim)


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature: concatenating TensorListShapes

Since TLS describes shape of a batch, on the event we would like to join multiple batches, we shall concatenate TLSs: append one with sample shapes from the others. Thanks to this function, it's not necessary to spawn unnecessary TS and TLS objects to do so.

