### PR TITLE
Extract a DecodeAudio implementation from Audio decoder operator

### DIFF
--- a/dali/kernels/signal/resampling.h
+++ b/dali/kernels/signal/resampling.h
@@ -74,7 +74,7 @@ struct ResamplingWindow {
   std::vector<float> lookup;
 };
 
-void windowed_sinc(ResamplingWindow &window,
+inline void windowed_sinc(ResamplingWindow &window,
     int coeffs, int lobes, std::function<double(double)> envelope = Hann) {
   assert(coeffs > 1 && lobes > 0 && "Degenerate parameters specified.");
   float scale = 2.0f * lobes / (coeffs - 1);

--- a/dali/operators/decoder/audio/audio_decoder.h
+++ b/dali/operators/decoder/audio/audio_decoder.h
@@ -16,6 +16,7 @@
 #define DALI_OPERATORS_DECODER_AUDIO_AUDIO_DECODER_H_
 
 #include <memory>
+#include <string>
 #include "dali/core/span.h"
 
 namespace dali {
@@ -36,11 +37,14 @@ class AudioDecoderBase {
     return OpenImpl(encoded);
   }
 
+  AudioMetadata OpenFromFile(const std::string &filepath) {
+    Close();
+    return OpenFromFileImpl(filepath);
+  }
 
   void Close() {
     CloseImpl();
   }
-
 
   /**
    * @brief Decode audio data and store it in the supplied buffer
@@ -52,7 +56,7 @@ class AudioDecoderBase {
 
  private:
   virtual AudioMetadata OpenImpl(span<const char> encoded) = 0;
-
+  virtual AudioMetadata OpenFromFileImpl(const std::string &filepath) = 0;
   virtual void CloseImpl() = 0;
 };
 

--- a/dali/operators/decoder/audio/audio_decoder_impl.cc
+++ b/dali/operators/decoder/audio/audio_decoder_impl.cc
@@ -33,10 +33,10 @@ TensorShape<> DecodedAudioShape(const AudioMetadata &meta, float target_sample_r
   return downmix ? TensorShape<>{len} : TensorShape<>{len, channels};
 }
 
-template <typename T, typename DecoderType = int16_t>
+template <typename T, typename DecoderOutputType>
 void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio, AudioDecoderBase &decoder,
                  const AudioMetadata &meta, kernels::signal::resampling::Resampler &resampler,
-                 span<DecoderType> decode_scratch_mem,
+                 span<DecoderOutputType> decode_scratch_mem,
                  span<float> resample_scratch_mem,
                  float target_sample_rate, bool downmix,
                  const char *audio_filepath) {  // audio_filepath for debug purposes
@@ -45,7 +45,7 @@ void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio, AudioDecode
   bool should_downmix = meta.channels > 1 && downmix;
   int64_t num_samples = meta.length * meta.channels;
 
-  if (!should_resample && !should_downmix && std::is_same<T, DecoderType>::value) {
+  if (!should_resample && !should_downmix && std::is_same<T, DecoderOutputType>::value) {
     int64_t ret = decoder.Decode(as_raw_span(audio.data, num_samples));
     DALI_ENFORCE(ret == num_samples, make_string("Error decoding audio file ", audio_filepath));
     return;
@@ -56,11 +56,19 @@ void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio, AudioDecode
                            decode_scratch_mem.size(), ", need: ", num_samples));
 
   const int64_t out_channels = should_downmix ? 1 : meta.channels;
+  constexpr bool is_float_decoder = std::is_same<DecoderOutputType, float>::value;
   if (should_resample) {
-    int64_t req_resample_scratch = meta.length * out_channels;
-    DALI_ENFORCE(resample_scratch_mem.size() >= req_resample_scratch,
-                 make_string("Resample scratch memory provided is not big enough. Got: ",
-                             resample_scratch_mem.size(), ", need: ", req_resample_scratch));
+    // If not downmixing, we expect the decoder output type to be float so that it can be
+    // directly fed into the resampling kernel
+    DALI_ENFORCE(should_downmix || is_float_decoder,
+      "Audio should be decoded in float when resampling is required and downmixing is not");
+
+    if (should_downmix) {  // need extra buffer for the input of resampling
+      int64_t req_resample_scratch = meta.length * out_channels;
+      DALI_ENFORCE(resample_scratch_mem.size() >= req_resample_scratch,
+                  make_string("Resample scratch memory provided is not big enough. Got: ",
+                              resample_scratch_mem.size(), ", need: ", req_resample_scratch));
+    }
   }
 
   int64_t ret = decoder.Decode(as_raw_span(decode_scratch_mem.data(), num_samples));
@@ -68,38 +76,49 @@ void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio, AudioDecode
 
   const int64_t in_len = meta.length * meta.channels;
   if (should_resample) {
-    float *resample_in = resample_scratch_mem.data();
     if (should_downmix) {
       assert(resample_scratch_mem.size() == meta.length);
+      float *resample_in = resample_scratch_mem.data();
       kernels::signal::Downmix(resample_in, decode_scratch_mem.data(), meta.length, meta.channels);
-    } else {  // just cast (resampling kernel expects float)
-      assert(resample_scratch_mem.size() == in_len);
-      for (int64_t ofs = 0; ofs < in_len; ofs++) {
-        resample_in[ofs] = ConvertSatNorm<float>(decode_scratch_mem[ofs]);
-      }
+      resampler.Resample(audio.data, 0, audio.shape[0], target_sample_rate,
+                         resample_scratch_mem.data(), meta.length,
+                         meta.sample_rate, out_channels);
+    } else {  // No downmix, enforcing the output of the decoder is float (resampling kernel expects
+              // float)
+      assert(decode_scratch_mem.size() == meta.length * meta.channels);
+      assert(is_float_decoder);  // logic sanity check
+      resampler.Resample(audio.data, 0, audio.shape[0], target_sample_rate,
+                         reinterpret_cast<float *>(decode_scratch_mem.data()), meta.length,
+                         meta.sample_rate, meta.channels);
     }
-    resampler.Resample(audio.data, 0, audio.shape[0], target_sample_rate, resample_in, meta.length,
-                       meta.sample_rate, out_channels);
   } else if (should_downmix) {  // downmix only
     kernels::signal::Downmix(audio.data, decode_scratch_mem.data(), meta.length, meta.channels);
   } else {
-    // convert or copy only
+    // convert or copy only. Should not happen if DecoderOutputType is selected properly
     for (int64_t ofs = 0; ofs < in_len; ofs++) {
       audio.data[ofs] = ConvertSatNorm<T>(decode_scratch_mem[ofs]);
     }
   }
 }
 
-#define DECLARE_IMPL(OutType, DecoderType)                                                  \
-  template void DecodeAudio<OutType, DecoderType>(                                          \
+#define DECLARE_IMPL(OutType, DecoderOutputType)                                                  \
+  template void DecodeAudio<OutType, DecoderOutputType>(                                          \
       TensorView<StorageCPU, OutType, DynamicDimensions> audio, AudioDecoderBase & decoder, \
       const AudioMetadata &meta, kernels::signal::resampling::Resampler &resampler,         \
-      span<DecoderType> decode_scratch_mem, span<float> resample_scratch_mem,               \
+      span<DecoderOutputType> decode_scratch_mem, span<float> resample_scratch_mem,               \
       float target_sample_rate, bool downmix, const char *audio_filepath)
 
 DECLARE_IMPL(float, int16_t);
 DECLARE_IMPL(int16_t, int16_t);
 DECLARE_IMPL(int32_t, int16_t);
+
+DECLARE_IMPL(float, float);
+DECLARE_IMPL(int16_t, float);
+DECLARE_IMPL(int32_t, float);
+
+DECLARE_IMPL(float, int32_t);
+DECLARE_IMPL(int16_t, int32_t);
+DECLARE_IMPL(int32_t, int32_t);
 
 #undef DECLARE_IMPL
 

--- a/dali/operators/decoder/audio/audio_decoder_impl.cc
+++ b/dali/operators/decoder/audio/audio_decoder_impl.cc
@@ -1,0 +1,106 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/decoder/audio/audio_decoder_impl.h"
+#include "dali/kernels/signal/downmixing.h"
+
+namespace dali {
+
+template <typename T>
+span<char> as_raw_span(T *buffer, ptrdiff_t length) {
+  return make_span(reinterpret_cast<char*>(buffer), length*sizeof(T));
+}
+
+TensorShape<> DecodedAudioShape(const AudioMetadata &meta, float target_sample_rate,
+                                bool downmix) {
+  bool should_resample = target_sample_rate > 0 && meta.sample_rate != target_sample_rate;
+  bool should_downmix = meta.channels > 1 && downmix;
+  int channels = meta.channels == 1 || downmix ? 1 : meta.channels;
+  int64_t len = should_resample ? kernels::signal::resampling::resampled_length(
+                                      meta.length, meta.sample_rate, target_sample_rate)
+                                : meta.length;
+  return downmix ? TensorShape<>{len} : TensorShape<>{len, channels};
+}
+
+template <typename T, typename DecoderType = int16_t>
+void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio, AudioDecoderBase &decoder,
+                 const AudioMetadata &meta, kernels::signal::resampling::Resampler &resampler,
+                 span<DecoderType> decode_scratch_mem,
+                 span<float> resample_scratch_mem,
+                 float target_sample_rate, bool downmix,
+                 const char *audio_filepath) {  // audio_filepath for debug purposes
+  DALI_ENFORCE(meta.sample_rate > 0, "Invalid sampling rate");
+  bool should_resample = target_sample_rate > 0 && meta.sample_rate != target_sample_rate;
+  bool should_downmix = meta.channels > 1 && downmix;
+  int64_t num_samples = meta.length * meta.channels;
+
+  if (!should_resample && !should_downmix && std::is_same<T, DecoderType>::value) {
+    int64_t ret = decoder.Decode(as_raw_span(audio.data, num_samples));
+    DALI_ENFORCE(ret == num_samples, make_string("Error decoding audio file ", audio_filepath));
+    return;
+  }
+
+  DALI_ENFORCE(decode_scratch_mem.size() >= num_samples,
+               make_string("Decoder scratch memory provided is not big enough. Got: ",
+                           decode_scratch_mem.size(), ", need: ", num_samples));
+
+  const int64_t out_channels = should_downmix ? 1 : meta.channels;
+  if (should_resample) {
+    int64_t req_resample_scratch = meta.length * out_channels;
+    DALI_ENFORCE(resample_scratch_mem.size() >= req_resample_scratch,
+                 make_string("Resample scratch memory provided is not big enough. Got: ",
+                             resample_scratch_mem.size(), ", need: ", req_resample_scratch));
+  }
+
+  int64_t ret = decoder.Decode(as_raw_span(decode_scratch_mem.data(), num_samples));
+  DALI_ENFORCE(ret == num_samples, make_string("Error decoding audio file ", audio_filepath));
+
+  const int64_t in_len = meta.length * meta.channels;
+  if (should_resample) {
+    float *resample_in = resample_scratch_mem.data();
+    if (should_downmix) {
+      assert(resample_scratch_mem.size() == meta.length);
+      kernels::signal::Downmix(resample_in, decode_scratch_mem.data(), meta.length, meta.channels);
+    } else {  // just cast (resampling kernel expects float)
+      assert(resample_scratch_mem.size() == in_len);
+      for (int64_t ofs = 0; ofs < in_len; ofs++) {
+        resample_in[ofs] = ConvertSatNorm<float>(decode_scratch_mem[ofs]);
+      }
+    }
+    resampler.Resample(audio.data, 0, audio.shape[0], target_sample_rate, resample_in, meta.length,
+                       meta.sample_rate, out_channels);
+  } else if (should_downmix) {  // downmix only
+    kernels::signal::Downmix(audio.data, decode_scratch_mem.data(), meta.length, meta.channels);
+  } else {
+    // convert or copy only
+    for (int64_t ofs = 0; ofs < in_len; ofs++) {
+      audio.data[ofs] = ConvertSatNorm<T>(decode_scratch_mem[ofs]);
+    }
+  }
+}
+
+#define DECLARE_IMPL(OutType, DecoderType)                                                  \
+  template void DecodeAudio<OutType, DecoderType>(                                          \
+      TensorView<StorageCPU, OutType, DynamicDimensions> audio, AudioDecoderBase & decoder, \
+      const AudioMetadata &meta, kernels::signal::resampling::Resampler &resampler,         \
+      span<DecoderType> decode_scratch_mem, span<float> resample_scratch_mem,               \
+      float target_sample_rate, bool downmix, const char *audio_filepath)
+
+DECLARE_IMPL(float, int16_t);
+DECLARE_IMPL(int16_t, int16_t);
+DECLARE_IMPL(int32_t, int16_t);
+
+#undef DECLARE_IMPL
+
+}  // namespace dali

--- a/dali/operators/decoder/audio/audio_decoder_impl.h
+++ b/dali/operators/decoder/audio/audio_decoder_impl.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_DECODER_AUDIO_AUDIO_DECODER_IMPL_H_
+#define DALI_OPERATORS_DECODER_AUDIO_AUDIO_DECODER_IMPL_H_
+
+#include "dali/operators/decoder/audio/audio_decoder.h"
+#include "dali/operators/decoder/audio/generic_decoder.h"
+#include "dali/pipeline/data/backend.h"
+#include "dali/kernels/signal/resampling.h"
+#include "dali/core/tensor_view.h"
+
+namespace dali {
+
+TensorShape<> DecodedAudioShape(const AudioMetadata &meta, float target_sample_rate = -1,
+                                bool downmix = true);
+
+template <typename T, typename DecoderType>
+void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio, AudioDecoderBase &decoder,
+                 const AudioMetadata &meta, kernels::signal::resampling::Resampler &resampler,
+                 span<DecoderType> decode_scratch_mem, span<float> resample_scratch_mem,
+                 float target_sample_rate, bool downmix, const char *audio_filepath);
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_DECODER_AUDIO_AUDIO_DECODER_IMPL_H_

--- a/dali/operators/decoder/audio/audio_decoder_impl.h
+++ b/dali/operators/decoder/audio/audio_decoder_impl.h
@@ -26,10 +26,10 @@ namespace dali {
 TensorShape<> DecodedAudioShape(const AudioMetadata &meta, float target_sample_rate = -1,
                                 bool downmix = true);
 
-template <typename T, typename DecoderType>
+template <typename T, typename DecoderOutputType>
 void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio, AudioDecoderBase &decoder,
                  const AudioMetadata &meta, kernels::signal::resampling::Resampler &resampler,
-                 span<DecoderType> decode_scratch_mem, span<float> resample_scratch_mem,
+                 span<DecoderOutputType> decode_scratch_mem, span<float> resample_scratch_mem,
                  float target_sample_rate, bool downmix, const char *audio_filepath);
 
 }  // namespace dali

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 #include "dali/operators/decoder/audio/audio_decoder_op.h"
+#include "dali/operators/decoder/audio/audio_decoder_impl.h"
 #include "dali/pipeline/operator/op_schema.h"
 #include "dali/pipeline/data/views.h"
 
 namespace dali {
+
+using DecoderType = int16_t;
 
 DALI_SCHEMA(AudioDecoder)
   .DocStr(R"code(Decodes waveforms from encoded audio data.
@@ -47,7 +50,6 @@ the highest.
 
 DALI_REGISTER_OPERATOR(AudioDecoder, AudioDecoderCpu, CPU);
 
-
 bool
 AudioDecoderCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) {
   GetPerSampleArgument<float>(target_sample_rates_, "sample_rate", ws);
@@ -59,16 +61,12 @@ AudioDecoderCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace
   }
   DALI_ENFORCE(IsType<uint8_t>(input.type()), "Raw files must be stored as uint8 data.");
   decoders_.resize(batch_size);
-  intermediate_buffers_.resize(batch_size);
   sample_meta_.resize(batch_size);
   files_names_.resize(batch_size);
 
-  decode_type_ = use_resampling_ || downmix_ ? DALI_FLOAT : output_type_;
-  TYPE_SWITCH(decode_type_, type2id, OutputType, (int16_t, int32_t, float), (
-      for (int i=0; i < batch_size; i++)
-        decoders_[i] = std::make_unique<GenericAudioDecoder<OutputType>>();
-  ), DALI_FAIL(make_string("Unsupported output type: ", decode_type_)))  // NOLINT
-
+  for (int i=0; i < batch_size; i++) {
+    decoders_[i] = std::make_unique<GenericAudioDecoder<DecoderType>>();
+  }
   output_desc.resize(2);
 
   // Currently, metadata is only the sampling rate.
@@ -82,13 +80,8 @@ AudioDecoderCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace
                                     input[i].shape().num_elements()});
     sample_meta_[i] = meta;
     int64_t out_length = OutputLength(meta.length, meta.sample_rate, i);
-    TensorShape<> data_sample_shape;
-    if (downmix_) {
-      data_sample_shape = {out_length};
-    } else {
-      data_sample_shape = {out_length, meta.channels};
-    }
-
+    TensorShape<> data_sample_shape = DecodedAudioShape(
+        meta, use_resampling_ ? target_sample_rates_[i] : -1.0f, downmix_);
     shape_data.set_tensor_shape(i, data_sample_shape);
     shape_rate.set_tensor_shape(i, {1});
     files_names_[i] = input[i].GetSourceInfo();
@@ -99,74 +92,40 @@ AudioDecoderCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace
   return true;
 }
 
-
-template <typename T>
-span<char> as_raw_span(T *buffer, ptrdiff_t length) {
-  return make_span(reinterpret_cast<char*>(buffer), length*sizeof(T));
-}
-
-
 template<typename OutputType>
 void
 AudioDecoderCpu::DecodeSample(const TensorView<StorageCPU, OutputType, DynamicDimensions> &audio,
                               int thread_idx, int sample_idx) {
-  const AudioMetadata &meta = sample_meta_[sample_idx];
-
-  auto &tmp_buf = intermediate_buffers_[thread_idx];
-  double output_rate = meta.sample_rate;
-  if (use_resampling_) {
-    output_rate = target_sample_rates_[sample_idx];
-    DALI_ENFORCE(meta.sample_rate > 0, make_string("Unknown or invalid input sampling rate."));
-    DALI_ENFORCE(output_rate > 0, make_string(
-        "Output sampling rate must be positive; got ", output_rate));
-  }
-  bool should_resample = meta.sample_rate != output_rate;
+  auto &meta = sample_meta_[sample_idx];
+  float target_sr = use_resampling_ ? target_sample_rates_[sample_idx] : meta.sample_rate;
+  bool should_resample = target_sr != meta.sample_rate;
   bool should_downmix = meta.channels > 1 && downmix_;
-  if (should_resample || should_downmix || output_type_ != decode_type_) {
-    assert(decode_type_ == DALI_FLOAT);
-    int64_t tmp_size = should_downmix && should_resample
-      ? meta.length * (meta.channels + 1)   // downmix to intermediate buffer, then resample
-      : meta.length * meta.channels;        // decode to intermediate, then resample or downmix
-                                            // directly to the output
+  int64_t decode_scratch_sz = 0;
+  int64_t resample_scratch_sz = 0;
+  if (should_resample || should_downmix || !std::is_same<OutputType, DecoderType>::value)
+    decode_scratch_sz = meta.length * meta.channels;
 
-    tmp_buf.resize(tmp_size);
-    size_t num_samples = meta.length * meta.channels;
-    size_t ret = decoders_[sample_idx]->Decode(as_raw_span(tmp_buf.data(), num_samples));
-    DALI_ENFORCE(ret == num_samples,
-                 make_string("Error decoding audio file: ", files_names_[sample_idx]));
+  // resample scratch is used to prepare a single or multiple (depending if
+  // downmixing is needed) channel float input, required by the resampling
+  // kernel
+  int64_t out_channels = should_downmix ? 1 : meta.channels;
+  if (should_resample)
+    resample_scratch_sz = meta.length * out_channels;
 
-    if (should_downmix) {
-      if (should_resample) {
-        // downmix and resample
-        float *downmixed = tmp_buf.data() + meta.length * meta.channels;
-        assert(downmixed + meta.length <= tmp_buf.data() + tmp_buf.size());
-        kernels::signal::Downmix(downmixed, tmp_buf.data(), meta.length, meta.channels);
-        resampler_.Resample(audio.data, 0, audio.shape[0], output_rate,
-                            downmixed, meta.length, meta.sample_rate);
-      } else {
-        // downmix only
-        kernels::signal::Downmix(audio.data, tmp_buf.data(), meta.length, meta.channels);
-      }
-    } else if (should_resample) {
-      // multi-channel resample
-      resampler_.Resample(audio.data, 0, audio.shape[0], output_rate,
-                          tmp_buf.data(), meta.length, meta.sample_rate, meta.channels);
+  int64_t total_scratch_sz =
+      decode_scratch_sz * sizeof(DecoderType) + resample_scratch_sz * sizeof(float);
+  scratch_[thread_idx].resize(total_scratch_sz);
+  uint8_t* scratch_mem = scratch_[thread_idx].data();
 
-    } else {
-      // convert or copy only - this will only happen if resampling is specified, but this
-      // recording's sampling rate and number of channels coincides with the target
-      int64_t len = std::min<int64_t>(volume(audio.shape), meta.length*meta.channels);
-      for (int64_t ofs = 0; ofs < len; ofs++) {
-        audio.data[ofs] = ConvertSatNorm<OutputType>(tmp_buf[ofs]);
-      }
-    }
-  } else {
-    assert(!should_downmix && !should_resample);
-    size_t num_samples = volume(audio.shape);
-    size_t ret = decoders_[sample_idx]->Decode(as_raw_span(audio.data, num_samples));
-    DALI_ENFORCE(ret == num_samples,
-                 make_string("Error decoding audio file: ", files_names_[sample_idx]));
-  }
+  span<DecoderType> decoder_scratch_mem(reinterpret_cast<DecoderType *>(scratch_mem),
+                                        decode_scratch_sz);
+  span<float> resample_scratch_mem(
+        reinterpret_cast<float *>(scratch_mem + decode_scratch_sz * sizeof(DecoderType)),
+        resample_scratch_sz);
+
+  DecodeAudio<OutputType>(audio, *decoders_[sample_idx], meta, resampler_,
+                          decoder_scratch_mem, resample_scratch_mem, target_sr, downmix_,
+                          files_names_[sample_idx].c_str());
 }
 
 template <typename OutputType>
@@ -176,7 +135,7 @@ void AudioDecoderCpu::DecodeBatch(workspace_t<Backend> &ws) {
   int batch_size = decoded_output.shape.num_samples();
   auto &tp = ws.GetThreadPool();
 
-  intermediate_buffers_.resize(tp.size());
+  scratch_.resize(tp.size());
 
   for (int i = 0; i < batch_size; i++) {
     tp.AddWork([&, i](int thread_id) {
@@ -186,8 +145,7 @@ void AudioDecoderCpu::DecodeBatch(workspace_t<Backend> &ws) {
           ? target_sample_rates_[i]
           : sample_meta_[i].sample_rate;
       } catch (const DALIException &e) {
-        DALI_FAIL(make_string("Error decoding file.\nError: ", e.what(), "\nFile: ",
-                              files_names_[i], "\n"));
+        DALI_FAIL(make_string("Error decoding file ", files_names_[i], ". Error: ", e.what()));
       }
     }, sample_meta_[i].length * sample_meta_[i].channels);
   }

--- a/dali/operators/decoder/audio/audio_decoder_op.h
+++ b/dali/operators/decoder/audio/audio_decoder_op.h
@@ -88,7 +88,8 @@ class AudioDecoderCpu : public Operator<CPUBackend> {
   const float quality_ = 50.0f;
   std::vector<std::string> files_names_;
   std::vector<AudioMetadata> sample_meta_;
-  std::vector<std::vector<uint8_t>> scratch_;
+  std::vector<Tensor<CPUBackend>> scratch_decoder_;
+  std::vector<Tensor<CPUBackend>> scratch_resampler_;
   std::vector<std::unique_ptr<AudioDecoderBase>> decoders_;
 };
 

--- a/dali/operators/decoder/audio/audio_decoder_op.h
+++ b/dali/operators/decoder/audio/audio_decoder_op.h
@@ -51,7 +51,6 @@ class AudioDecoderCpu : public Operator<CPUBackend> {
     }
   }
 
-
   inline ~AudioDecoderCpu() override = default;
 
  protected:
@@ -89,7 +88,7 @@ class AudioDecoderCpu : public Operator<CPUBackend> {
   const float quality_ = 50.0f;
   std::vector<std::string> files_names_;
   std::vector<AudioMetadata> sample_meta_;
-  std::vector<std::vector<float>> intermediate_buffers_;
+  std::vector<std::vector<uint8_t>> scratch_;
   std::vector<std::unique_ptr<AudioDecoderBase>> decoders_;
 };
 

--- a/dali/operators/decoder/audio/audio_decoder_op.h
+++ b/dali/operators/decoder/audio/audio_decoder_op.h
@@ -88,8 +88,8 @@ class AudioDecoderCpu : public Operator<CPUBackend> {
   const float quality_ = 50.0f;
   std::vector<std::string> files_names_;
   std::vector<AudioMetadata> sample_meta_;
-  std::vector<Tensor<CPUBackend>> scratch_decoder_;
-  std::vector<Tensor<CPUBackend>> scratch_resampler_;
+  std::vector<vector<uint8_t>> scratch_decoder_;
+  std::vector<vector<float>> scratch_resampler_;
   std::vector<std::unique_ptr<AudioDecoderBase>> decoders_;
 };
 

--- a/dali/operators/decoder/audio/audio_decoder_op.h
+++ b/dali/operators/decoder/audio/audio_decoder_op.h
@@ -65,11 +65,11 @@ class AudioDecoderCpu : public Operator<CPUBackend> {
 
 
  private:
-  template<typename OutputType>
+  template<typename OutputType, typename DecoderOutputType>
   void DecodeSample(const TensorView<StorageCPU, OutputType, DynamicDimensions> &audio,
                     int thread_idx, int sample_idx);
 
-  template <typename OutputType>
+  template <typename OutputType, typename DecoderOutputType>
   void DecodeBatch(workspace_t<Backend> &ws);
 
   int64_t OutputLength(int64_t in_length, double in_rate, int sample_idx) const {

--- a/dali/operators/decoder/audio/generic_decoder.cc
+++ b/dali/operators/decoder/audio/generic_decoder.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string>
 #include "dali/operators/decoder/audio/generic_decoder.h"
 
 namespace dali {
@@ -139,6 +140,18 @@ sf_count_t Tell(void *self) {
   return static_cast<MemoryStream *>(self)->Tell();
 }
 
+/**
+ * @brief Produce audio metadata instace from SF_INFO
+ */
+AudioMetadata GetAudioMetadata(SF_INFO &sf_info) {
+  AudioMetadata ret;
+  ret.length = sf_info.frames;
+  ret.channels = sf_info.channels;
+  ret.sample_rate = sf_info.samplerate;
+  ret.channels_interleaved = true;
+  return ret;
+}
+
 }  // namespace
 
 
@@ -153,6 +166,10 @@ AudioMetadata GenericAudioDecoder<SampleType>::OpenImpl(span<const char> encoded
   return impl_->OpenImpl(encoded);
 }
 
+template<typename SampleType>
+AudioMetadata GenericAudioDecoder<SampleType>::OpenFromFileImpl(const std::string &filepath) {
+  return impl_->OpenFromFileImpl(filepath);
+}
 
 template<typename SampleType>
 void GenericAudioDecoder<SampleType>::CloseImpl() {
@@ -169,7 +186,6 @@ GenericAudioDecoder<SampleType>::GenericAudioDecoder() :
         impl_(std::make_unique<Impl>()) {
 }
 
-
 template<typename SampleType>
 struct GenericAudioDecoder<SampleType>::Impl {
   ptrdiff_t DecodeTyped(span<SampleType> output) {
@@ -182,9 +198,7 @@ struct GenericAudioDecoder<SampleType>::Impl {
 
   AudioMetadata OpenImpl(span<const char> encoded) {
     assert(!encoded.empty());
-    AudioMetadata ret;
     sf_info_ = {};
-    sf_info_.format = 0;
     mem_stream_ = {encoded.data(), static_cast<int>(encoded.size())};
     SF_VIRTUAL_IO sf_virtual_io = {
             &GetFileLen,
@@ -197,14 +211,19 @@ struct GenericAudioDecoder<SampleType>::Impl {
     if (!sound_) {
       throw DALIException(make_string("Failed to open encoded data: ", sf_strerror(sound_)));
     }
-
-    ret.length = sf_info_.frames;
-    ret.channels = sf_info_.channels;
-    ret.sample_rate = sf_info_.samplerate;
-    ret.channels_interleaved = true;
-    return ret;
+    return GetAudioMetadata(sf_info_);
   }
 
+  AudioMetadata OpenFromFileImpl(const std::string &filepath) {
+    DALI_ENFORCE(!filepath.empty(), "filepath is empty");
+    sf_info_ = {};
+    sound_ = sf_open(filepath.c_str(), SFM_READ, &sf_info_);
+    if (!sound_) {
+      throw DALIException(make_string("Failed to open encoded data: ", sf_strerror(sound_),
+                                      ", filepath: ", filepath));
+    }
+    return GetAudioMetadata(sf_info_);
+  }
 
   void CloseImpl() {
     if (sound_) {

--- a/dali/operators/decoder/audio/generic_decoder.cc
+++ b/dali/operators/decoder/audio/generic_decoder.cc
@@ -186,6 +186,13 @@ GenericAudioDecoder<SampleType>::GenericAudioDecoder() :
         impl_(std::make_unique<Impl>()) {
 }
 
+template <typename SampleType>
+GenericAudioDecoder<SampleType>::GenericAudioDecoder(GenericAudioDecoder &&decoder) = default;
+
+template <typename SampleType>
+GenericAudioDecoder<SampleType> &GenericAudioDecoder<SampleType>::operator=(
+    GenericAudioDecoder &&decoder) = default;
+
 template<typename SampleType>
 struct GenericAudioDecoder<SampleType>::Impl {
   ptrdiff_t DecodeTyped(span<SampleType> output) {

--- a/dali/operators/decoder/audio/generic_decoder.cc
+++ b/dali/operators/decoder/audio/generic_decoder.cc
@@ -143,7 +143,7 @@ sf_count_t Tell(void *self) {
 /**
  * @brief Produce audio metadata instace from SF_INFO
  */
-AudioMetadata GetAudioMetadata(SF_INFO &sf_info) {
+AudioMetadata GetAudioMetadata(const SF_INFO &sf_info) {
   AudioMetadata ret;
   ret.length = sf_info.frames;
   ret.channels = sf_info.channels;

--- a/dali/operators/decoder/audio/generic_decoder.h
+++ b/dali/operators/decoder/audio/generic_decoder.h
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <cstring>
 #include <memory>
+#include <string>
 #include <vector>
 #include "dali/core/format.h"
 #include "dali/core/error_handling.h"
@@ -41,7 +42,7 @@ class DLL_PUBLIC GenericAudioDecoder : public TypedAudioDecoderBase<SampleType> 
 
  private:
   AudioMetadata OpenImpl(span<const char> encoded) override;
-
+  AudioMetadata OpenFromFileImpl(const std::string &filepath) override;
   void CloseImpl() override;
 
   struct Impl;

--- a/dali/operators/decoder/audio/generic_decoder.h
+++ b/dali/operators/decoder/audio/generic_decoder.h
@@ -36,6 +36,9 @@ class DLL_PUBLIC GenericAudioDecoder : public TypedAudioDecoderBase<SampleType> 
  public:
   DLL_PUBLIC GenericAudioDecoder();
 
+  DLL_PUBLIC GenericAudioDecoder(GenericAudioDecoder&&);
+  DLL_PUBLIC GenericAudioDecoder& operator=(GenericAudioDecoder&&);
+
   DLL_PUBLIC ptrdiff_t DecodeTyped(span<SampleType> output) override;
 
   DLL_PUBLIC ~GenericAudioDecoder() override;


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to improve code reusability. Extracting a DecodeAudio function from the AudioDecoder implementation, that will be later used in a NemoASRReader that performs audio decoding as well.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Extracted the logic of audio decoder to a stand-alone function that can be reused*
 - Affected modules and functionalities:
     *Audio decoder*
 - Key points relevant for the review:
     *Audio decoder changes, DecodeAudio implementation*
 - Validation and testing:
     *Already existing tests*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1613]*
