### PR TITLE
TensorJoin kernel for CPU

### DIFF
--- a/dali/kernels/common/join/CMakeLists.txt
+++ b/dali/kernels/common/join/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(join)
-
 # Get all the source files and dump test files
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(DALI_KERNEL_SRCS PARENT_SCOPE)
 collect_test_sources(DALI_KERNEL_TEST_SRCS PARENT_SCOPE)
+

--- a/dali/kernels/common/join/tensor_join_cpu.h
+++ b/dali/kernels/common/join/tensor_join_cpu.h
@@ -79,7 +79,7 @@ TensorShape<> DetermineShape<false>(span<const TensorShape<>> in_shapes, int axi
  * The kernel works in 2 modes: STACK and CONCAT. In CONCAT mode, kernel creates a new tensor,
  * with joined values along given dimension, e.g.
  *
- * arr0 = [[1, 2, 4, 2], [1, 1, 7, 6], [6, 8, 8, 4]])
+ * arr0 = [[1, 2, 4, 2], [1, 1, 7, 6], [6, 8, 8, 4]]
  * shape = (3, 4)
  *
  * arr1 = [[3, 8, 8, 6], [8, 1, 5, 7], [6, 2, 7, 5]]
@@ -109,17 +109,16 @@ struct TensorJoinCpu {
   ///@{
   /**
    * @param in_shapes Shapes of input tensors.
-   * @param axis Axis, along which tensors will be joined. Accepts positive and negative values
-   *             (e.g. axis: -1 <=> ndims-1)
+   * @param axis Axis, along which tensors will be joined.
    */
   KernelRequirements Setup(KernelContext &ctx, span<const TensorShape<dims>> in_shapes, int axis) {
     n_input_tensors_ = in_shapes.size();
     auto ndims = in_shapes[0].sample_dim();
-    DALI_ENFORCE(axis >= -ndims + !new_axis && axis <= ndims - !new_axis,
-                 make_string("Incorrect axis. Actual: ", axis, ". Expected in [",
-                             -ndims + !new_axis, ", ", ndims - !new_axis, "] interval (",
-                             new_axis ? "STACK" : "CONCAT", " mode)"));
-    axis_ = axis >= 0 ? axis : ndims + axis + new_axis;
+    DALI_ENFORCE(axis >= 0 && axis <= ndims - !new_axis,
+                 make_string("Incorrect axis. Actual: ", axis, ". Expected in [0, ",
+                             ndims - !new_axis, "] range (", new_axis ? "STACK" : "CONCAT",
+                             " mode)"));
+    axis_ = axis;
 
     {
       const auto &ref = in_shapes[0];
@@ -187,7 +186,7 @@ struct TensorJoinCpu {
   }
 
 
-  int axis_, n_input_tensors_;
+  int axis_ = -1, n_input_tensors_ = -1;
   TensorShape<dims> output_shape_;
 };
 

--- a/dali/kernels/common/join/tensor_join_cpu.h
+++ b/dali/kernels/common/join/tensor_join_cpu.h
@@ -25,14 +25,15 @@ namespace kernels {
 namespace impl {
 
 template<typename T>
-void ConcatenateTensors(span<T> output, const TensorShape<> &output_shape,
-                        span<TensorView<StorageCPU, const T>> inputs, int axis) {
+void
+ConcatenateTensors(TensorView<StorageCPU, T> output, span<TensorView<StorageCPU, const T>> inputs,
+                   int axis) {
   SmallVector<int64_t, 8> copy_sizes;
   for (int t = 0; t < inputs.size(); t++) {
     copy_sizes[t] = volume(inputs[t].shape.begin() + axis, inputs[t].shape.end());
   }
-  auto nouter = volume(output_shape.begin(), output_shape.end());
-  auto *out = output.data();
+  auto nouter = volume(output.shape.begin(), output.shape.end());
+  auto *out = output.data;
   for (ptrdiff_t outer = 0; outer < nouter; outer++) {
     for (int t = 0; t < inputs.size(); t++) {
       auto *src = inputs[t].data + outer * copy_sizes[t];

--- a/dali/kernels/common/join/tensor_join_cpu.h
+++ b/dali/kernels/common/join/tensor_join_cpu.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_TENSOR_STACK_CPU_H
-#define DALI_TENSOR_STACK_CPU_H
+#ifndef DALI_TENSOR_JOIN_CPU_H
+#define DALI_TENSOR_JOIN_CPU_H
 
 #include "dali/kernels/kernel.h"
 #include "dali/core/tensor_shape_print.h"
@@ -151,5 +151,5 @@ struct TensorJoinCpu {
 
 }
 }
-#endif //DALI_TENSOR_STACK_CPU_H
+#endif //DALI_TENSOR_JOIN_CPU_H
 

--- a/dali/kernels/common/join/tensor_join_cpu.h
+++ b/dali/kernels/common/join/tensor_join_cpu.h
@@ -29,7 +29,8 @@ void
 ConcatenateTensors(TensorView<StorageCPU, T> output,
                    span<const TensorView<StorageCPU, const T>> inputs,
                    int axis) {
-  SmallVector<int64_t, 8> copy_sizes;
+  SmallVector<int64_t, 64> copy_sizes;
+  copy_sizes.resize(inputs.size());
   for (int t = 0; t < inputs.size(); t++) {
     copy_sizes[t] = volume(inputs[t].shape.begin() + axis, inputs[t].shape.end());
   }

--- a/dali/kernels/common/join/tensor_join_cpu.h
+++ b/dali/kernels/common/join/tensor_join_cpu.h
@@ -127,9 +127,8 @@ struct TensorJoinCpu {
         for (int j = 0; j < ref.size(); j++) {
           if (!new_axis) {
             DALI_ENFORCE(in_shapes[i][j] == ref.shape[j] || j == axis_, make_string(
-                    "Number of samples in every dimension "
-                    "(but the one along which concatenation occurs) must be the same "
-                    "(CONCAT mode). 0-th shape at index ", j, " has dimension ",
+                    "Number of samples in every dimension (except the concatenated one) "
+                    "must be the same (CONCAT mode). 0-th shape at index ", j, " has dimension ",
                     ref.shape[j], ", while ", i, "-th shape at index ", j,
                     " has dimension ", in_shapes[i][j]));
           } else {

--- a/dali/kernels/common/join/tensor_join_cpu_test.cc
+++ b/dali/kernels/common/join/tensor_join_cpu_test.cc
@@ -87,14 +87,14 @@ TEST(TensorJoinCpuTest, TransferBufferTest) {
   for (size_t ax = 0; ax < ref_arr.size(); ax++) {
     auto outsh = impl::DetermineShape<true>(make_span(sh), ax);
     vector<int> outbuf(volume(outsh));
-    impl::ConcatenateTensors(make_span(outbuf), outsh, make_span(in), ax);
+    impl::ConcatenateTensors({outbuf.data(), outsh}, make_span(in), ax);
     EXPECT_EQ(outbuf, ref_arr[ax]);
   }
 
   for (size_t ax = 0; ax < ref_arr.size() - 1; ax++) {
     auto outsh = impl::DetermineShape<false>(make_span(sh), ax);
     vector<int> outbuf(volume(outsh));
-    impl::ConcatenateTensors(make_span(outbuf), outsh, make_span(in), ax);
+    impl::ConcatenateTensors({outbuf.data(), outsh}, make_span(in), ax);
     EXPECT_EQ(outbuf, ref_arr[ax]);
   }
 }

--- a/dali/kernels/common/join/tensor_join_cpu_test.cc
+++ b/dali/kernels/common/join/tensor_join_cpu_test.cc
@@ -13,42 +13,53 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include "tensor_join_cpu.h"
+#include <vector>
+#include "dali/kernels/common/join/tensor_join_cpu.h"
 
 namespace dali {
 namespace kernels {
 namespace test {
 
 TEST(TensorJoinCpuTest, DetermineShapeStack) {
-  std::vector<TensorShape<>> shin = {{4, 5, 7, 8}, 2};
+  std::vector<TensorShape<>> shin = {{4, 5, 7, 8},
+                                     {4, 5, 7, 8}};
   TensorShape<> sh0 = {2, 4, 5, 7, 8};
   TensorShape<> sh1 = {4, 2, 5, 7, 8};
   TensorShape<> sh2 = {4, 5, 2, 7, 8};
   TensorShape<> sh3 = {4, 5, 7, 2, 8};
   TensorShape<> sh4 = {4, 5, 7, 8, 2};
-  EXPECT_EQ(detail::DetermineShape<STACK>(make_span(shin), 0), sh0);
-  EXPECT_EQ(detail::DetermineShape<STACK>(make_span(shin), 1), sh1);
-  EXPECT_EQ(detail::DetermineShape<STACK>(make_span(shin), 2), sh2);
-  EXPECT_EQ(detail::DetermineShape<STACK>(make_span(shin), 3), sh3);
-  EXPECT_EQ(detail::DetermineShape<STACK>(make_span(shin), 4), sh4);
+  EXPECT_EQ(impl::DetermineShape<true>(make_span(shin), 0), sh0);
+  EXPECT_EQ(impl::DetermineShape<true>(make_span(shin), 1), sh1);
+  EXPECT_EQ(impl::DetermineShape<true>(make_span(shin), 2), sh2);
+  EXPECT_EQ(impl::DetermineShape<true>(make_span(shin), 3), sh3);
+  EXPECT_EQ(impl::DetermineShape<true>(make_span(shin), 4), sh4);
 }
 
 
-TEST(TensorJoinCpuTest, DetermineShapeConcat) {
-  std::vector<TensorShape<>> shin = {{4, 5, 7, 8}, 2};
+TEST(TensorJoinCpuTest, DetermineShapeConcatConstantExtent) {
+  std::vector<TensorShape<>> shin = {{4, 5, 7, 8},
+                                     {4, 5, 7, 8}};
   TensorShape<> sh0 = {8, 5, 7, 8};
   TensorShape<> sh1 = {4, 10, 7, 8};
   TensorShape<> sh2 = {4, 5, 14, 8};
   TensorShape<> sh3 = {4, 5, 7, 16};
-  EXPECT_EQ(detail::DetermineShape<CONCAT>(make_span(shin), 0), sh0);
-  EXPECT_EQ(detail::DetermineShape<CONCAT>(make_span(shin), 1), sh1);
-  EXPECT_EQ(detail::DetermineShape<CONCAT>(make_span(shin), 2), sh2);
-  EXPECT_EQ(detail::DetermineShape<CONCAT>(make_span(shin), 3), sh3);
+  EXPECT_EQ(impl::DetermineShape<false>(make_span(shin), 0), sh0);
+  EXPECT_EQ(impl::DetermineShape<false>(make_span(shin), 1), sh1);
+  EXPECT_EQ(impl::DetermineShape<false>(make_span(shin), 2), sh2);
+  EXPECT_EQ(impl::DetermineShape<false>(make_span(shin), 3), sh3);
+}
+
+
+TEST(TensorJoinCpuTest, DetermineShapeConcatVaryingExtent) {
+  std::vector<TensorShape<>> shin = {{4, 5, 7, 8},
+                                     {4, 5, 3, 8}};
+  TensorShape<> shout = {4, 5, 10, 8};
+  EXPECT_EQ(impl::DetermineShape<false>(make_span(shin), 2), shout);
 }
 
 
 TEST(TensorJoinCpuTest, TransferBufferTest) {
-  using namespace std;
+  using namespace std;  // NOLINT
 
   vector<vector<int>> arr = {{6, 8, 5, 1, 3, 5, 1, 6, 8, 3, 7, 5},
                              {4, 5, 1, 8, 4, 4, 1, 4, 1, 7, 6, 6}};
@@ -74,52 +85,19 @@ TEST(TensorJoinCpuTest, TransferBufferTest) {
   ref_arr.emplace_back(arr2);
 
   for (size_t ax = 0; ax < ref_arr.size(); ax++) {
-    auto outsh = detail::DetermineShape<STACK>(make_span(sh), ax);
+    auto outsh = impl::DetermineShape<true>(make_span(sh), ax);
     vector<int> outbuf(volume(outsh));
-    detail::TransferBuffers(make_span(outbuf), outsh, make_span(in), ax);
+    impl::ConcatenateTensors(make_span(outbuf), outsh, make_span(in), ax);
     EXPECT_EQ(outbuf, ref_arr[ax]);
   }
 
   for (size_t ax = 0; ax < ref_arr.size() - 1; ax++) {
-    auto outsh = detail::DetermineShape<CONCAT>(make_span(sh), ax);
+    auto outsh = impl::DetermineShape<false>(make_span(sh), ax);
     vector<int> outbuf(volume(outsh));
-    detail::TransferBuffers(make_span(outbuf), outsh, make_span(in), ax);
+    impl::ConcatenateTensors(make_span(outbuf), outsh, make_span(in), ax);
     EXPECT_EQ(outbuf, ref_arr[ax]);
   }
 }
-
-//TEST(TensorStackCpuTest, KernelTest) {
-//  using namespace std;
-//
-//  vector<vector<int>> arr = {{6, 8, 5, 1, 3, 5, 1, 6, 8, 3, 7, 5},
-//                             {4, 5, 1, 8, 4, 4, 1, 4, 1, 7, 6, 6}};
-//  vector<TensorShape<>> sh = {{3, 4},
-//                              {3, 4}};
-//  vector<TensorView<StorageCPU, const int>> in;
-//  for (size_t i = 0; i < arr.size(); i++) {
-//    in.emplace_back(arr[i].data(), sh[i]);
-//  }
-//
-//  // Output shape for this buffer: {2, 3, 4} (STACK) or {6, 4} (CONCAT)
-//  vector<int> arr0 = {6, 8, 5, 1, 3, 5, 1, 6, 8, 3, 7, 5, 4, 5, 1, 8, 4, 4, 1, 4, 1, 7, 6, 6};
-//
-//  // Output shape for this buffer: {3, 2, 4} (STACK) or {3, 8} (CONCAT)
-//  vector<int> arr1 = {6, 8, 5, 1, 4, 5, 1, 8, 3, 5, 1, 6, 4, 4, 1, 4, 8, 3, 7, 5, 1, 7, 6, 6};
-//
-//  // Output shape for this buffer: {4, 3, 2} (STACK), CONCAT unavailable
-//  vector<int> arr2 = {6, 4, 8, 5, 5, 1, 1, 8, 3, 4, 5, 4, 1, 1, 6, 4, 8, 1, 3, 7, 7, 6, 5, 6};
-//
-//  vector<vector<int>> ref_arr;
-//  ref_arr.emplace_back(arr0);
-//  ref_arr.emplace_back(arr1);
-//  ref_arr.emplace_back(arr2);
-//
-//  TensorStackCpu<int, int> kernel;
-//  KernelContext ctx;
-//  auto kr = kernel.Setup(ctx, make_cspan(in), 0);
-//
-//
-//}
 
 
 }  // namespace test

--- a/dali/kernels/common/join/tensor_join_cpu_test.cc
+++ b/dali/kernels/common/join/tensor_join_cpu_test.cc
@@ -1,5 +1,19 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gtest/gtest.h>
-#include "dali/kernels/common/tensor_stack_cpu.h"
+#include "tensor_join_cpu.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/common/join/tensor_join_cpu_test.cc
+++ b/dali/kernels/common/join/tensor_join_cpu_test.cc
@@ -59,7 +59,7 @@ TEST(TensorJoinCpuTest, DetermineShapeConcatVaryingExtent) {
 
 
 TEST(TensorJoinCpuTest, ConcatenateTensorsTest) {
-  using namespace std;  // NOLINT
+  using std::vector;
 
   vector<vector<int>> arr = {{6, 8, 5, 1, 3, 5, 1, 6, 8, 3, 7, 5},
                              {4, 5, 1, 8, 4, 4, 1, 4, 1, 7, 6, 6}};
@@ -127,7 +127,7 @@ KernelRunAndVerify(TensorView<StorageCPU, T> ref, span<const TensorView<StorageC
 
 
 TEST(TensorJoinCpuTest, StackKernelTest) {
-  using namespace std;  // NOLINT
+  using std::vector;
   vector<vector<int>> arr = {{100, 101, 102, 110, 111, 112, 120, 121, 122, 130, 131, 132},
                              {200, 201, 202, 210, 211, 212, 220, 221, 222, 230, 231, 232}};
   vector<TensorShape<>> sh = {{4, 3},
@@ -149,19 +149,15 @@ TEST(TensorJoinCpuTest, StackKernelTest) {
                          221, 122, 222, 130, 230, 131, 231, 132, 232};
   TensorShape<> sh_st2 = {4, 3, 2};
 
-  KernelRunAndVerify<TensorStackCpu>({arr_st1.data(), sh_st1}, make_cspan(in), -2);
-  KernelRunAndVerify<TensorStackCpu>({arr_st2.data(), sh_st2}, make_cspan(in), -1);
   KernelRunAndVerify<TensorStackCpu>({arr_st0.data(), sh_st0}, make_cspan(in), 0);
   KernelRunAndVerify<TensorStackCpu>({arr_st1.data(), sh_st1}, make_cspan(in), 1);
   KernelRunAndVerify<TensorStackCpu>({arr_st2.data(), sh_st2}, make_cspan(in), 2);
-  ASSERT_ANY_THROW(
-          KernelRunAndVerify<TensorStackCpu>({arr_st2.data(), sh_st2}, make_cspan(in), -3));
   ASSERT_ANY_THROW(KernelRunAndVerify<TensorStackCpu>({arr_st2.data(), sh_st2}, make_cspan(in), 3));
 }
 
 
 TEST(TensorJoinCpuTest, ConcatKernelTest) {
-  using namespace std;  // NOLINT
+  using std::vector;
   vector<vector<int>> arr = {{100, 101, 102, 110, 111, 112, 120, 121, 122, 130, 131, 132},
                              {200, 201, 202, 210, 211, 212, 220, 221, 222, 230, 231, 232}};
   vector<TensorShape<>> sh = {{4, 3},
@@ -179,18 +175,15 @@ TEST(TensorJoinCpuTest, ConcatKernelTest) {
                           220, 221, 222, 130, 131, 132, 230, 231, 232};
   TensorShape<> sh_cat1 = {4, 6};
 
-  KernelRunAndVerify<TensorConcatCpu>({arr_cat1.data(), sh_cat1}, make_cspan(in), -1);
   KernelRunAndVerify<TensorConcatCpu>({arr_cat0.data(), sh_cat0}, make_cspan(in), 0);
   KernelRunAndVerify<TensorConcatCpu>({arr_cat1.data(), sh_cat1}, make_cspan(in), 1);
-  ASSERT_ANY_THROW(
-          KernelRunAndVerify<TensorConcatCpu>({arr_cat0.data(), sh_cat0}, make_cspan(in), -2));
   ASSERT_ANY_THROW(
           KernelRunAndVerify<TensorConcatCpu>({arr_cat0.data(), sh_cat0}, make_cspan(in), 2));
 }
 
 
 TEST(TensorJoinCpuTest, ConcatKernelDifferentExtentTest) {
-  using namespace std;  // NOLINT
+  using std::vector;
   vector<vector<int>> arr = {{100, 101, 102, 110, 111, 112, 120, 121, 122, 130, 131, 132},
                              {200, 201, 202, 210, 211, 212, 220, 221, 222}};
   vector<TensorShape<>> sh = {{4, 3},
@@ -205,8 +198,6 @@ TEST(TensorJoinCpuTest, ConcatKernelDifferentExtentTest) {
   TensorShape<> sh_cat0 = {7, 3};
 
   KernelRunAndVerify<TensorConcatCpu>({arr_cat0.data(), sh_cat0}, make_cspan(in), 0);
-  ASSERT_ANY_THROW(
-          KernelRunAndVerify<TensorConcatCpu>({arr_cat0.data(), sh_cat0}, make_cspan(in), -1));
   ASSERT_ANY_THROW(
           KernelRunAndVerify<TensorConcatCpu>({arr_cat0.data(), sh_cat0}, make_cspan(in), 1));
 }

--- a/dali/kernels/common/tensor_stack_cpu.h
+++ b/dali/kernels/common/tensor_stack_cpu.h
@@ -1,0 +1,112 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_TENSOR_STACK_CPU_H
+#define DALI_TENSOR_STACK_CPU_H
+
+#include "dali/kernels/kernel.h"
+#include "dali/core/tensor_shape_print.h"
+
+namespace dali {
+namespace kernels {
+
+enum JoinMode {
+  STACK,
+  CONCAT
+};
+
+namespace detail {
+template<typename Out, typename In, int ndims = -1>
+void StackTensors(const OutTensorCPU<Out, ndims> &out,
+                  span<const InTensorCPU<In, ndims>> in, int axis) {
+
+}
+
+
+template<typename T>
+void TransferBuffers(span<T> output, const TensorShape<> &output_shape,
+                     span<TensorView<StorageCPU, const T>> inputs, int axis) {
+  vector<int64_t> copy_sizes(inputs.size());
+  for (int t = 0; t < inputs.size(); t++) {
+    copy_sizes[t] = volume(inputs[t].shape.begin() + axis, inputs[t].shape.end());
+  }
+  auto nouter = volume(output_shape.begin(), output_shape.end());
+  auto *out = output.data();
+  for (ptrdiff_t outer = 0; outer < nouter; outer++) {
+    for (int t = 0; t < inputs.size(); t++) {
+      auto *src = inputs[t].data + outer * copy_sizes[t];
+      for (ptrdiff_t inner = 0; inner < copy_sizes[t]; inner++) {
+        *out++ = src[inner];
+      }
+    }
+  }
+}
+
+
+template<JoinMode mode=STACK>
+TensorShape<> DetermineShape(span<const TensorShape<>> in_shapes, int axis) {
+  TensorShape<> ret;
+  auto &insh = in_shapes[0];
+  ret.resize(insh.size() + 1);
+  for (int i = 0; i < axis; i++) {
+    ret[i] = insh[i];
+  }
+  ret[axis] = in_shapes.size();
+  for (int i = axis + 1; i < ret.size(); i++) {
+    ret[i] = insh[i - 1];
+  }
+  return ret;
+}
+
+
+template<>
+TensorShape<> DetermineShape<CONCAT>(span<const TensorShape<>> in_shapes, int axis) {
+  TensorShape<> ret = in_shapes[0];
+  ret[axis] *= in_shapes.size();
+  return ret;
+}
+
+}  // namespace detail
+
+template<typename Out, typename In, int ndims = -1>
+struct TensorStackCpu {
+  KernelRequirements Setup(KernelContext &ctx, span<const TensorShape<ndims>> in_shapes, int axis) {
+    n_input_tensors_ = in_shapes.size();
+    orig_shapes_ = in_shapes;
+  }
+
+
+  void Run(KernelContext &ctx, const OutTensorCPU<Out, ndims> &out,
+           span<const InTensorCPU<In, ndims>> in, int axis) {
+    DALI_ENFORCE(in.size() == n_input_tensors_, make_string(
+            "Input must have the same number of tensors as was specified in call to Setup. Expected: ",
+            n_input_tensors_, "Actual: ", in.size()));
+    for (int i = 0; i < n_input_tensors_; i++) {
+      DALI_ENFORCE(in[i].shape == orig_shapes_[i], make_string(
+              "Input must have the same shapes as was specified in call to Setup. Expected: ",
+              orig_shapes_[i], "Actual: ", in[i].shape));
+    }
+
+
+  }
+
+
+  size_t n_input_tensors_;
+  std::vector<TensorShape<ndims>> orig_shapes_;
+};
+
+}
+}
+#endif //DALI_TENSOR_STACK_CPU_H
+

--- a/dali/kernels/common/tensor_stack_cpu_test.cc
+++ b/dali/kernels/common/tensor_stack_cpu_test.cc
@@ -5,7 +5,7 @@ namespace dali {
 namespace kernels {
 namespace test {
 
-TEST(TensorStackCpuTest, DetermineShapeStack) {
+TEST(TensorJoinCpuTest, DetermineShapeStack) {
   std::vector<TensorShape<>> shin = {{4, 5, 7, 8}, 2};
   TensorShape<> sh0 = {2, 4, 5, 7, 8};
   TensorShape<> sh1 = {4, 2, 5, 7, 8};
@@ -20,7 +20,7 @@ TEST(TensorStackCpuTest, DetermineShapeStack) {
 }
 
 
-TEST(TensorStackCpuTest, DetermineShapeConcat) {
+TEST(TensorJoinCpuTest, DetermineShapeConcat) {
   std::vector<TensorShape<>> shin = {{4, 5, 7, 8}, 2};
   TensorShape<> sh0 = {8, 5, 7, 8};
   TensorShape<> sh1 = {4, 10, 7, 8};
@@ -33,7 +33,7 @@ TEST(TensorStackCpuTest, DetermineShapeConcat) {
 }
 
 
-TEST(TensorStackCpuTest, TransferBufferTest) {
+TEST(TensorJoinCpuTest, TransferBufferTest) {
   using namespace std;
 
   vector<vector<int>> arr = {{6, 8, 5, 1, 3, 5, 1, 6, 8, 3, 7, 5},
@@ -74,19 +74,39 @@ TEST(TensorStackCpuTest, TransferBufferTest) {
   }
 }
 
-
-//template<typename T>
-//class TensorStackCpuTypedTest : public ::testing::Test {
+//TEST(TensorStackCpuTest, KernelTest) {
+//  using namespace std;
 //
-//};
+//  vector<vector<int>> arr = {{6, 8, 5, 1, 3, 5, 1, 6, 8, 3, 7, 5},
+//                             {4, 5, 1, 8, 4, 4, 1, 4, 1, 7, 6, 6}};
+//  vector<TensorShape<>> sh = {{3, 4},
+//                              {3, 4}};
+//  vector<TensorView<StorageCPU, const int>> in;
+//  for (size_t i = 0; i < arr.size(); i++) {
+//    in.emplace_back(arr[i].data(), sh[i]);
+//  }
 //
-//TYPED_TEST(TensorStackCpuTypedTest, Test) {
+//  // Output shape for this buffer: {2, 3, 4} (STACK) or {6, 4} (CONCAT)
+//  vector<int> arr0 = {6, 8, 5, 1, 3, 5, 1, 6, 8, 3, 7, 5, 4, 5, 1, 8, 4, 4, 1, 4, 1, 7, 6, 6};
+//
+//  // Output shape for this buffer: {3, 2, 4} (STACK) or {3, 8} (CONCAT)
+//  vector<int> arr1 = {6, 8, 5, 1, 4, 5, 1, 8, 3, 5, 1, 6, 4, 4, 1, 4, 8, 3, 7, 5, 1, 7, 6, 6};
+//
+//  // Output shape for this buffer: {4, 3, 2} (STACK), CONCAT unavailable
+//  vector<int> arr2 = {6, 4, 8, 5, 5, 1, 1, 8, 3, 4, 5, 4, 1, 1, 6, 4, 8, 1, 3, 7, 7, 6, 5, 6};
+//
+//  vector<vector<int>> ref_arr;
+//  ref_arr.emplace_back(arr0);
+//  ref_arr.emplace_back(arr1);
+//  ref_arr.emplace_back(arr2);
+//
+//  TensorStackCpu<int, int> kernel;
+//  KernelContext ctx;
+//  auto kr = kernel.Setup(ctx, make_cspan(in), 0);
+//
 //
 //}
-//
-//
-//using TensorStackCpuTypes = ::testing::Types<int>;
-//TYPED_TEST_SUITE(TensorStackCpuTypedTest, TensorStackCpuTypes);
+
 
 }  // namespace test
 }  // namespace kernels

--- a/dali/kernels/common/tensor_stack_cpu_test.cc
+++ b/dali/kernels/common/tensor_stack_cpu_test.cc
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+#include "dali/kernels/common/tensor_stack_cpu.h"
+
+namespace dali {
+namespace kernels {
+namespace test {
+
+TEST(TensorStackCpuTest, DetermineShapeStack) {
+  std::vector<TensorShape<>> shin = {{4, 5, 7, 8}, 2};
+  TensorShape<> sh0 = {2, 4, 5, 7, 8};
+  TensorShape<> sh1 = {4, 2, 5, 7, 8};
+  TensorShape<> sh2 = {4, 5, 2, 7, 8};
+  TensorShape<> sh3 = {4, 5, 7, 2, 8};
+  TensorShape<> sh4 = {4, 5, 7, 8, 2};
+  EXPECT_EQ(detail::DetermineShape<STACK>(make_span(shin), 0), sh0);
+  EXPECT_EQ(detail::DetermineShape<STACK>(make_span(shin), 1), sh1);
+  EXPECT_EQ(detail::DetermineShape<STACK>(make_span(shin), 2), sh2);
+  EXPECT_EQ(detail::DetermineShape<STACK>(make_span(shin), 3), sh3);
+  EXPECT_EQ(detail::DetermineShape<STACK>(make_span(shin), 4), sh4);
+}
+
+
+TEST(TensorStackCpuTest, DetermineShapeConcat) {
+  std::vector<TensorShape<>> shin = {{4, 5, 7, 8}, 2};
+  TensorShape<> sh0 = {8, 5, 7, 8};
+  TensorShape<> sh1 = {4, 10, 7, 8};
+  TensorShape<> sh2 = {4, 5, 14, 8};
+  TensorShape<> sh3 = {4, 5, 7, 16};
+  EXPECT_EQ(detail::DetermineShape<CONCAT>(make_span(shin), 0), sh0);
+  EXPECT_EQ(detail::DetermineShape<CONCAT>(make_span(shin), 1), sh1);
+  EXPECT_EQ(detail::DetermineShape<CONCAT>(make_span(shin), 2), sh2);
+  EXPECT_EQ(detail::DetermineShape<CONCAT>(make_span(shin), 3), sh3);
+}
+
+
+TEST(TensorStackCpuTest, TransferBufferTest) {
+  using namespace std;
+
+  vector<vector<int>> arr = {{6, 8, 5, 1, 3, 5, 1, 6, 8, 3, 7, 5},
+                             {4, 5, 1, 8, 4, 4, 1, 4, 1, 7, 6, 6}};
+  vector<TensorShape<>> sh = {{3, 4},
+                              {3, 4}};
+  vector<TensorView<StorageCPU, const int>> in;
+  for (size_t i = 0; i < arr.size(); i++) {
+    in.emplace_back(arr[i].data(), sh[i]);
+  }
+
+  // Output shape for this buffer: {2, 3, 4} (STACK) or {6, 4} (CONCAT)
+  vector<int> arr0 = {6, 8, 5, 1, 3, 5, 1, 6, 8, 3, 7, 5, 4, 5, 1, 8, 4, 4, 1, 4, 1, 7, 6, 6};
+
+  // Output shape for this buffer: {3, 2, 4} (STACK) or {3, 8} (CONCAT)
+  vector<int> arr1 = {6, 8, 5, 1, 4, 5, 1, 8, 3, 5, 1, 6, 4, 4, 1, 4, 8, 3, 7, 5, 1, 7, 6, 6};
+
+  // Output shape for this buffer: {4, 3, 2} (STACK), CONCAT unavailable
+  vector<int> arr2 = {6, 4, 8, 5, 5, 1, 1, 8, 3, 4, 5, 4, 1, 1, 6, 4, 8, 1, 3, 7, 7, 6, 5, 6};
+
+  vector<vector<int>> ref_arr;
+  ref_arr.emplace_back(arr0);
+  ref_arr.emplace_back(arr1);
+  ref_arr.emplace_back(arr2);
+
+  for (size_t ax = 0; ax < ref_arr.size(); ax++) {
+    auto outsh = detail::DetermineShape<STACK>(make_span(sh), ax);
+    vector<int> outbuf(volume(outsh));
+    detail::TransferBuffers(make_span(outbuf), outsh, make_span(in), ax);
+    EXPECT_EQ(outbuf, ref_arr[ax]);
+  }
+
+  for (size_t ax = 0; ax < ref_arr.size() - 1; ax++) {
+    auto outsh = detail::DetermineShape<CONCAT>(make_span(sh), ax);
+    vector<int> outbuf(volume(outsh));
+    detail::TransferBuffers(make_span(outbuf), outsh, make_span(in), ax);
+    EXPECT_EQ(outbuf, ref_arr[ax]);
+  }
+}
+
+
+//template<typename T>
+//class TensorStackCpuTypedTest : public ::testing::Test {
+//
+//};
+//
+//TYPED_TEST(TensorStackCpuTypedTest, Test) {
+//
+//}
+//
+//
+//using TensorStackCpuTypes = ::testing::Types<int>;
+//TYPED_TEST_SUITE(TensorStackCpuTypedTest, TensorStackCpuTypes);
+
+}  // namespace test
+}  // namespace kernels
+}  // namespace dali


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature: Stacking or Concatenating tensors

Concatenation operation creates a new tensor, with joined values along some dimension, e.g.
```python
arr0 = [[1, 2, 4, 2], [1, 1, 7, 6], [6, 8, 8, 4]])
shape = (3, 4)

arr1 = [[3, 8, 8, 6], [8, 1, 5, 7], [6, 2, 7, 5]]
shape = (3, 4)

concatenate([arr0, arr1], axis=1) ->
[[1, 2, 4, 2, 3, 8, 8, 6],
 [1, 1, 7, 6, 8, 1, 5, 7],
 [6, 8, 8, 4, 6, 2, 7, 5]])
shape = (3, 8)
```

Stacking, OTOH, creates new tensor with added dimension, where `axis` points. 
```python
stack([arr0, arr1], axis=1) ->
[[[1, 2, 4, 2],
  [3, 8, 8, 6]],

 [[1, 1, 7, 6],
  [8, 1, 5, 7]],

 [[6, 8, 8, 4],
  [6, 2, 7, 5]]]
shape = (3, 2, 4)
```

Note, that memory layout is the same in both modes, only output shape changes.

