### PR TITLE
Update example usage of DALIClassificationIterator in docs strings

### DIFF
--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -368,7 +368,7 @@ class DALIClassificationIterator(DALIGenericIterator):
 
     .. code-block:: python
 
-       DALIClassificationIterator(pipelines, size, data_name, label_name, data_layout)
+       DALIClassificationIterator(pipelines, reader_name, data_name, label_name, data_layout)
 
     is equivalent to calling
 
@@ -377,7 +377,7 @@ class DALIClassificationIterator(DALIGenericIterator):
        DALIGenericIterator(pipelines,
                            [(data_name, DALIClassificationIterator.DATA_TAG),
                             (label_name, DALIClassificationIterator.LABEL_TAG)],
-                           size,
+                           reader_name,
                            data_layout)
 
     Please keep in mind that NDArrays returned by the iterator are

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -374,13 +374,13 @@ class DALIClassificationIterator(DALIGenericIterator):
 
     .. code-block:: python
 
-       DALIClassificationIterator(pipelines, size)
+       DALIClassificationIterator(pipelines, reader_name)
 
     is equivalent to calling
 
     .. code-block:: python
 
-       DALIGenericIterator(pipelines, ["data", "label"], size)
+       DALIGenericIterator(pipelines, ["data", "label"], reader_name)
 
     Please keep in mind that Tensors returned by the iterator are
     still owned by DALI. They are valid till the next iterator call.

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -274,13 +274,13 @@ class DALIClassificationIterator(DALIGenericIterator):
 
     .. code-block:: python
 
-       DALIClassificationIterator(pipelines, size)
+       DALIClassificationIterator(pipelines, reader_name)
 
     is equivalent to calling
 
     .. code-block:: python
 
-       DALIGenericIterator(pipelines, ["data", "label"], size)
+       DALIGenericIterator(pipelines, ["data", "label"], reader_name)
 
     Please keep in mind that Tensors returned by the iterator are
     still owned by DALI. They are valid till the next iterator call.


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes an example usage of DALIClassificationIterator in docs strings

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     updated example usage of DALIClassificationIterator in docs strings
 - Affected modules and functionalities:
     FW plugins
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     docs are updated


**JIRA TASK**: *[NA]*
