### PR TITLE
Add *.cuh and *.inl to list of headers to bundle

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -206,7 +206,7 @@ cmake_parse_arguments(
   "" # multi value keywords
   ${ARGV})
 
-  file(GLOB collect_headers_tmp *.h *.hpp)
+  file(GLOB collect_headers_tmp *.h *.hpp *.cuh *.inl)
   set(${DALI_HEADERS_GROUP} ${${DALI_HEADERS_GROUP}} ${collect_headers_tmp})
   # We remove filenames containing substring test
   if(NOT COLLECT_HEADERS_INCLUDE_TEST)

--- a/dali/python/MANIFEST.in
+++ b/dali/python/MANIFEST.in
@@ -1,6 +1,8 @@
 include Acknowledgements.txt LICENSE COPYRIGHT
 recursive-include nvidia/dali/include *.h
 recursive-include nvidia/dali/include *.hpp
+recursive-include nvidia/dali/include *.cuh
+recursive-include nvidia/dali/include *.inl
 recursive-include nvidia/dali *.bin
 recursive-include nvidia/dali *.so
 recursive-include nvidia/dali/.libs *.so.*


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug, some headers (*.cuh), necessary to use DALI kernels were not bundled in the whl

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added cuh and inl files to the pattern*
 - Affected modules and functionalities:
     *build system*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
