### PR TITLE
Add SeprableConvolutionGPU kernel

### DIFF
--- a/dali/kernels/imgproc/convolution/baseline_convolution.h
+++ b/dali/kernels/imgproc/convolution/baseline_convolution.h
@@ -24,6 +24,16 @@ namespace dali {
 namespace kernels {
 namespace testing {
 
+template <typename T>
+void InitTriangleWindow(const TensorView<StorageCPU, T, 1> &window) {
+  int radius = window.num_elements() / 2;
+  for (int i = 0; i < radius; i++) {
+    *window(i) = i + 1;
+    *window(window.num_elements() - i - 1) = i + 1;
+  }
+  *window(radius) = radius + 1;
+}
+
 template <typename Out, typename In, typename W>
 void BaselineConvolveAxis(Out *out, const In *in, const W *window, int len, int r, int channel_num,
                           int64_t stride) {

--- a/dali/kernels/imgproc/convolution/separable_convolution_cpu.h
+++ b/dali/kernels/imgproc/convolution/separable_convolution_cpu.h
@@ -175,11 +175,11 @@ struct SeparableConvolutionCpu<Out, In, W, 3, has_channels> {
     sub_ctx.scratchpad = &sub_scratch;
 
     // Clear the scratchpad for sub-kernels to reuse memory
-    conv_innermost_.Run(ctx, intermediate, in, windows[2]);
+    conv_innermost_.Run(sub_ctx, intermediate, in, windows[2]);
     sub_scratch.Clear();
-    conv_middle_.Run(ctx, intermediate, intermediate, windows[1]);
+    conv_middle_.Run(sub_ctx, intermediate, intermediate, windows[1]);
     sub_scratch.Clear();
-    conv_outermost_.Run(ctx, out, intermediate, windows[0], scale);
+    conv_outermost_.Run(sub_ctx, out, intermediate, windows[0], scale);
   }
 
   scratch_sizes_t sub_scratch_sizes_;

--- a/dali/kernels/imgproc/convolution/separable_convolution_cpu_test.cc
+++ b/dali/kernels/imgproc/convolution/separable_convolution_cpu_test.cc
@@ -28,16 +28,6 @@
 namespace dali {
 namespace kernels {
 
-template <typename T>
-void InitTriangleWindow(const TensorView<StorageCPU, T, 1> &window) {
-  int radius = window.num_elements() / 2;
-  for (int i = 0; i < radius; i++) {
-    *window(i) = i + 1;
-    *window(window.num_elements() - i - 1) = i + 1;
-  }
-  *window(radius) = radius + 1;
-}
-
 TEST(SeparableConvolutionTest, Axes1WithChannels) {
   std::array<int, 1> window_dims = {5};
   TestTensorList<float, 1> kernel_window;
@@ -58,7 +48,7 @@ TEST(SeparableConvolutionTest, Axes1WithChannels) {
 
   std::mt19937 rng;
   UniformRandomFill(in_v, rng, 0, 255);
-  InitTriangleWindow(kernel_window_v);
+  testing::InitTriangleWindow(kernel_window_v);
 
   SeparableConvolutionCpu<int, float, float, 1, true> kernel;
   KernelContext ctx;
@@ -98,7 +88,7 @@ TEST(SeparableConvolutionTest, Axes1NoChannels) {
 
   std::mt19937 rng;
   UniformRandomFill(in_v, rng, 0, 255);
-  InitTriangleWindow(kernel_window_v);
+  testing::InitTriangleWindow(kernel_window_v);
 
   SeparableConvolutionCpu<int, float, float, 1, false> kernel;
   KernelContext ctx;
@@ -142,8 +132,8 @@ TEST(SeparableConvolutionTest, Axes2WithChannels) {
 
   std::mt19937 rng;
   UniformRandomFill(in_v, rng, 0, 255);
-  InitTriangleWindow(kernel_window_0_v);
-  InitTriangleWindow(kernel_window_1_v);
+  testing::InitTriangleWindow(kernel_window_0_v);
+  testing::InitTriangleWindow(kernel_window_1_v);
 
   SeparableConvolutionCpu<int, int, float, 2, true> kernel;
   static_assert(
@@ -192,8 +182,8 @@ TEST(SeparableConvolutionTest, Axes2NoChannels) {
 
   std::mt19937 rng;
   UniformRandomFill(in_v, rng, 0, 255);
-  InitTriangleWindow(kernel_window_0_v);
-  InitTriangleWindow(kernel_window_1_v);
+  testing::InitTriangleWindow(kernel_window_0_v);
+  testing::InitTriangleWindow(kernel_window_1_v);
 
   SeparableConvolutionCpu<int, int, float, 2, false> kernel;
   static_assert(
@@ -245,9 +235,9 @@ TEST(SeparableConvolutionTest, Axes3WithChannels) {
 
   std::mt19937 rng;
   UniformRandomFill(in_v, rng, 0, 255);
-  InitTriangleWindow(kernel_window_0_v);
-  InitTriangleWindow(kernel_window_1_v);
-  InitTriangleWindow(kernel_window_2_v);
+  testing::InitTriangleWindow(kernel_window_0_v);
+  testing::InitTriangleWindow(kernel_window_1_v);
+  testing::InitTriangleWindow(kernel_window_2_v);
 
   SeparableConvolutionCpu<int16_t, int16_t, uint16_t, 3, true> kernel;
   static_assert(
@@ -303,9 +293,9 @@ TEST(SeparableConvolutionTest, Axes3NoChannels) {
 
   std::mt19937 rng;
   UniformRandomFill(in_v, rng, 0, 255);
-  InitTriangleWindow(kernel_window_0_v);
-  InitTriangleWindow(kernel_window_1_v);
-  InitTriangleWindow(kernel_window_2_v);
+  testing::InitTriangleWindow(kernel_window_0_v);
+  testing::InitTriangleWindow(kernel_window_1_v);
+  testing::InitTriangleWindow(kernel_window_2_v);
 
   SeparableConvolutionCpu<float, int, float, 3, false> kernel;
   static_assert(

--- a/dali/kernels/imgproc/convolution/separable_convolution_gpu.h
+++ b/dali/kernels/imgproc/convolution/separable_convolution_gpu.h
@@ -1,0 +1,179 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_IMGPROC_CONVOLUTION_SEPARABLE_CONVOLUTION_GPU_H_
+#define DALI_KERNELS_IMGPROC_CONVOLUTION_SEPARABLE_CONVOLUTION_GPU_H_
+
+#include "dali/core/convert.h"
+#include "dali/core/format.h"
+#include "dali/core/tensor_view.h"
+#include "dali/kernels/common/utils.h"
+#include "dali/kernels/imgproc/convolution/convolution_gpu.h"
+#include "dali/kernels/kernel.h"
+#include "dali/pipeline/util/operator_impl_utils.h"
+
+namespace dali {
+namespace kernels {
+
+/**
+ * @brief Apply convolution in all spatial axes, starting from the innermost to outermost.
+ *        If channel axis is pressent, the convolution is not applied there.
+ *        If it is marqed as sequence, the first data axis is considered as temporal axis
+ *
+ * Sequence convolutions require one less window to be specified
+ *
+ * `W` is currently assumed to be float
+ *
+ * `windows` and `scales` are specified per axis.
+ *
+ * Specialized for 1, 2 or 3 axes, to not go overboard with TMP for generic solutions
+ *
+ * Here be boilerplate.
+ */
+template <typename Out, typename In, typename W, int axes, bool has_channels = false,
+          bool is_sequence = false>
+struct SeparableConvolutionGpu;
+
+template <typename Out, typename In, typename W, bool has_channels, bool is_sequence>
+struct SeparableConvolutionGpu<Out, In, W, 1, has_channels, is_sequence> {
+  static constexpr int axes = 1;
+  static constexpr int sequence_axes = static_cast<int>(is_sequence);
+  static constexpr int channel_axes = static_cast<int>(has_channels);
+  static constexpr int ndim = sequence_axes + axes + channel_axes;
+
+  KernelRequirements Setup(KernelContext& ctx, const TensorListShape<ndim>& in_shape,
+                           const std::array<TensorListShape<1>, axes>& window_sizes) {
+    KernelRequirements req;
+    req.output_shapes.push_back(in_shape);
+
+    auto req_conv = conv_.Setup(ctx, in_shape, window_sizes[0]);
+    req.AddInputSet(req_conv, false);
+
+    return req;
+  }
+
+  void Run(KernelContext& ctx, const TensorListView<StorageGPU, Out, ndim> out,
+           const TensorListView<StorageGPU, const In, ndim>& in,
+           const std::array<TensorListView<StorageCPU, const W, 1>, axes>& windows,
+           const std::array<span<const int>, 1> anchors = {},
+           float scale = 1) {
+    conv_.Run(ctx, out, in, windows[0], anchors[0], scale);
+  }
+
+  ConvolutionGpu<Out, In, W, ndim, sequence_axes + 0, has_channels> conv_;
+};
+
+template <typename Out, typename In, typename W, bool has_channels, bool is_sequence>
+struct SeparableConvolutionGpu<Out, In, W, 2, has_channels, is_sequence> {
+  static constexpr int axes = 2;
+  static constexpr int sequence_axes = static_cast<int>(is_sequence);
+  static constexpr int channel_axes = static_cast<int>(has_channels);
+  static constexpr int ndim = sequence_axes + axes + channel_axes;
+  using Intermediate = decltype(std::declval<W>() * std::declval<In>());
+
+  KernelRequirements Setup(KernelContext& ctx, const TensorListShape<ndim>& in_shape,
+                           const std::array<TensorListShape<1>, axes>& window_sizes) {
+    KernelRequirements req;
+
+    ScratchpadEstimator se;
+    se.add<Intermediate>(AllocType::GPU, in_shape.num_elements());
+    req.scratch_sizes = se.sizes;
+    req.output_shapes.push_back(in_shape);
+
+    auto req_inner = conv_innermost_.Setup(ctx, in_shape, window_sizes[1]);
+    auto req_outer = conv_outermost_.Setup(ctx, in_shape, window_sizes[0]);
+
+    req.AddInputSet(req_inner, false);
+    req.AddInputSet(req_outer, false);
+
+    return req;
+  }
+
+  void Run(KernelContext& ctx, const TensorListView<StorageGPU, Out, ndim> out,
+           const TensorListView<StorageGPU, const In, ndim>& in,
+           const std::array<TensorListView<StorageCPU, const W, 1>, axes>& windows,
+           const std::array<span<const int>, 2> anchors = {},
+           float scale = 1) {
+    auto *tmp = ctx.scratchpad->Allocate<Intermediate>(AllocType::GPU, in.shape.num_elements());
+    auto intermediate = TensorListView<StorageGPU, Intermediate, ndim>(tmp, in.shape);
+
+    conv_innermost_.Run(ctx, intermediate, in, windows[1], anchors[1]);
+    conv_outermost_.Run(ctx, out, intermediate, windows[0], anchors[0], scale);
+  }
+
+  ConvolutionGpu<Intermediate, In, W, ndim, sequence_axes + 1, has_channels> conv_innermost_;
+  ConvolutionGpu<Out, Intermediate, W, ndim, sequence_axes + 0, has_channels> conv_outermost_;
+};
+
+template <typename Out, typename In, typename W, bool has_channels, bool is_sequence>
+struct SeparableConvolutionGpu<Out, In, W, 3, has_channels, is_sequence> {
+  static constexpr int axes = 3;
+  static constexpr int sequence_axes = static_cast<int>(is_sequence);
+  static constexpr int channel_axes = static_cast<int>(has_channels);
+  static constexpr int ndim = sequence_axes + axes + channel_axes;
+  using Intermediate = decltype(std::declval<W>() * std::declval<In>());
+  static constexpr bool kUseOutAsIntermediate = sizeof(Intermediate) == sizeof(Out);
+
+  KernelRequirements Setup(KernelContext& ctx, const TensorListShape<ndim>& in_shape,
+                           const std::array<TensorListShape<1>, axes>& window_sizes) {
+    KernelRequirements req;
+
+    ScratchpadEstimator se;
+    int intermediate_count = kUseOutAsIntermediate ? 1 : 2;
+    se.add<Intermediate>(AllocType::GPU, in_shape.num_elements() * intermediate_count);
+    req.scratch_sizes = se.sizes;
+    req.output_shapes.push_back(in_shape);
+
+    auto req_inner = conv_innermost_.Setup(ctx, in_shape, window_sizes[2]);
+    auto req_middle = conv_middle_.Setup(ctx, in_shape, window_sizes[1]);
+    auto req_outer = conv_outermost_.Setup(ctx, in_shape, window_sizes[0]);
+
+    req.AddInputSet(req_inner, false);
+    req.AddInputSet(req_middle, false);
+    req.AddInputSet(req_outer, false);
+
+    return req;
+  }
+
+  void Run(KernelContext& ctx, const TensorListView<StorageGPU, Out, ndim> out,
+           const TensorListView<StorageGPU, const In, ndim>& in,
+           const std::array<TensorListView<StorageCPU, const W, 1>, axes>& windows,
+           const std::array<span<const int>, 3> anchors = {},
+           float scale = 1) {
+    int intermediate_count = kUseOutAsIntermediate ? 1 : 2;
+    auto* tmp = ctx.scratchpad->Allocate<Intermediate>(
+        AllocType::GPU, in.shape.num_elements() * intermediate_count);
+    TensorListView<StorageGPU, Intermediate, ndim> intermediate_inner, intermediate_outer;
+    if (kUseOutAsIntermediate) {
+      intermediate_inner = reinterpret<Intermediate>(out, in.shape);
+      intermediate_outer = {tmp, in.shape};
+    } else {
+      intermediate_inner = {tmp, in.shape};
+      intermediate_outer = {tmp + in.shape.num_elements(), in.shape};
+    }
+
+    conv_innermost_.Run(ctx, intermediate_inner, in, windows[2], anchors[2]);
+    conv_middle_.Run(ctx, intermediate_outer, intermediate_inner, windows[1], anchors[1]);
+    conv_outermost_.Run(ctx, out, intermediate_outer, windows[0], anchors[0], scale);
+  }
+
+  ConvolutionGpu<Intermediate, In, W, ndim, sequence_axes + 2, has_channels> conv_innermost_;
+  ConvolutionGpu<Intermediate, Intermediate, W, ndim, sequence_axes + 1, has_channels> conv_middle_;
+  ConvolutionGpu<Out, Intermediate, W, ndim, sequence_axes + 0, has_channels> conv_outermost_;
+};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_IMGPROC_CONVOLUTION_SEPARABLE_CONVOLUTION_GPU_H_

--- a/dali/kernels/imgproc/convolution/separable_convolution_gpu.h
+++ b/dali/kernels/imgproc/convolution/separable_convolution_gpu.h
@@ -63,8 +63,7 @@ struct SeparableConvolutionGpu<Out, In, W, 1, has_channels, is_sequence> {
 
     auto req_conv = conv_.Setup(ctx, in_shape, window_sizes[0]);
 
-    sub_scratch_sizes_ = req_conv.scratch_sizes;
-    req.scratch_sizes = GetSumScratch(req.scratch_sizes, sub_scratch_sizes_);
+    req.scratch_sizes = GetSumScratch(req.scratch_sizes, req_conv.scratch_sizes);
 
     return req;
   }
@@ -77,7 +76,6 @@ struct SeparableConvolutionGpu<Out, In, W, 1, has_channels, is_sequence> {
     conv_.Run(ctx, out, in, windows[0], anchors[0], scale);
   }
 
-  scratch_sizes_t sub_scratch_sizes_;
   ConvolutionGpu<Out, In, W, ndim, sequence_axes + 0, has_channels> conv_;
 };
 

--- a/dali/kernels/imgproc/convolution/separable_convolution_gpu.h
+++ b/dali/kernels/imgproc/convolution/separable_convolution_gpu.h
@@ -63,7 +63,7 @@ struct SeparableConvolutionGpu<Out, In, W, 1, has_channels, is_sequence> {
 
     auto req_conv = conv_.Setup(ctx, in_shape, window_sizes[0]);
 
-    req.scratch_sizes = GetSumScratch(req.scratch_sizes, req_conv.scratch_sizes);
+    req.scratch_sizes = AppendScratchSize(req.scratch_sizes, req_conv.scratch_sizes);
 
     return req;
   }
@@ -100,8 +100,8 @@ struct SeparableConvolutionGpu<Out, In, W, 2, has_channels, is_sequence> {
     auto req_outer = conv_outermost_.Setup(ctx, in_shape, window_sizes[0]);
 
     // Calculate max scratch memory required by sub-kernels
-    sub_scratch_sizes_ = GetMaxScratch(req_inner.scratch_sizes, req_outer.scratch_sizes);
-    req.scratch_sizes = GetSumScratch(req.scratch_sizes, sub_scratch_sizes_);
+    sub_scratch_sizes_ = MaxScratchSize(req_inner.scratch_sizes, req_outer.scratch_sizes);
+    req.scratch_sizes = AppendScratchSize(req.scratch_sizes, sub_scratch_sizes_);
 
     return req;
   }
@@ -119,7 +119,7 @@ struct SeparableConvolutionGpu<Out, In, W, 2, has_channels, is_sequence> {
     for (size_t i = 0; i < sub_scratch_sizes_.size(); i++) {
       auto sz = sub_scratch_sizes_[i];
       auto alloc_type = static_cast<AllocType>(i);
-      sub_scratch.allocs[i] = BumpAllocator(ctx.scratchpad->Allocate<char>(alloc_type, sz), sz);
+      sub_scratch.allocs[i] = BumpAllocator(ctx.scratchpad->Allocate<char>(alloc_type, sz, 64), sz);
     }
 
     KernelContext sub_ctx = ctx;
@@ -160,9 +160,9 @@ struct SeparableConvolutionGpu<Out, In, W, 3, has_channels, is_sequence> {
     auto req_outer = conv_outermost_.Setup(ctx, in_shape, window_sizes[0]);
 
     // Calculate max scratch memory required by sub-kernels
-    sub_scratch_sizes_ = GetMaxScratch(req_inner.scratch_sizes, req_middle.scratch_sizes);
-    sub_scratch_sizes_ = GetMaxScratch(sub_scratch_sizes_, req_outer.scratch_sizes);
-    req.scratch_sizes = GetSumScratch(req.scratch_sizes, sub_scratch_sizes_);
+    sub_scratch_sizes_ = MaxScratchSize(req_inner.scratch_sizes, req_middle.scratch_sizes);
+    sub_scratch_sizes_ = MaxScratchSize(sub_scratch_sizes_, req_outer.scratch_sizes);
+    req.scratch_sizes = AppendScratchSize(req.scratch_sizes, sub_scratch_sizes_);
 
     return req;
   }
@@ -189,7 +189,7 @@ struct SeparableConvolutionGpu<Out, In, W, 3, has_channels, is_sequence> {
     for (size_t i = 0; i < sub_scratch_sizes_.size(); i++) {
       auto sz = sub_scratch_sizes_[i];
       auto alloc_type = static_cast<AllocType>(i);
-      sub_scratch.allocs[i] = BumpAllocator(ctx.scratchpad->Allocate<char>(alloc_type, sz), sz);
+      sub_scratch.allocs[i] = BumpAllocator(ctx.scratchpad->Allocate<char>(alloc_type, sz, 64), sz);
     }
 
     KernelContext sub_ctx = ctx;

--- a/dali/kernels/imgproc/convolution/separable_convolution_gpu_test.cu
+++ b/dali/kernels/imgproc/convolution/separable_convolution_gpu_test.cu
@@ -1,0 +1,172 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <complex>
+#include <tuple>
+#include <vector>
+
+#include "dali/kernels/common/utils.h"
+#include "dali/kernels/imgproc/convolution/baseline_convolution.h"
+#include "dali/kernels/imgproc/convolution/separable_convolution_gpu.h"
+#include "dali/kernels/imgproc/convolution/separable_convolution_cpu.h"
+#include "dali/kernels/scratch.h"
+#include "dali/test/tensor_test_utils.h"
+#include "dali/test/test_tensors.h"
+
+namespace dali {
+namespace kernels {
+
+/**
+ * @brief Simple sanity test for SeparableConvolutionGPU
+ */
+template <int Axes, bool Channels, bool Frames>
+class SepearableConvolutionGpuTestImpl {
+  constexpr static int kAxes = Axes;
+  constexpr static int kChannels = Channels;
+  constexpr static int kFrames = Frames;
+  constexpr static int kNdim = kFrames + kAxes + kChannels;
+
+  // Predefined window shape per axis
+  int win_sizes[3] = {3, 5, 7};
+
+  std::array<TestTensorList<float, 1>, kAxes> kernel_window_;
+  std::array<TensorListShape<1>, kAxes> window_dims_;
+  TestTensorList<float, kNdim> input_;
+  TestTensorList<float, kNdim> output_;
+  TestTensorList<float, kNdim> baseline_output_;
+  TensorListShape<kNdim> data_shape_;
+  int num_samples_;
+
+  void SetDataShape() {
+    TensorShape<> target_shape = {64, 64, 64};
+    target_shape = target_shape.last(kAxes);
+    if (kChannels)
+      target_shape = shape_cat(target_shape, 3);
+    if (kFrames)
+      target_shape = shape_cat(20, target_shape);
+    data_shape_ = uniform_list_shape<kNdim>(1, target_shape.to_static<kNdim>());
+  }
+
+  void ReshapeData() {
+    SetDataShape();
+    int num_samples_ = data_shape_.size();
+
+    for (int i = 0; i < kAxes; i++) {
+      window_dims_[i] = uniform_list_shape<1>(num_samples_, {win_sizes[i]});
+      kernel_window_[i].reshape(window_dims_[i]);
+    }
+
+    input_.reshape(data_shape_);
+    output_.reshape(data_shape_);
+    baseline_output_.reshape(data_shape_);
+  }
+
+  void FillData() {
+    ConstantFill(input_.cpu(), 1);
+    for (int i = 0; i < kAxes; i++) {
+      ConstantFill(kernel_window_[i].cpu(), 1);
+    }
+
+    // Calculate the baseline, windows are filled with ones.
+    int result = 1;
+    for (int i = kAxes - 1; i >= 0; i--) {
+      result *= win_sizes[i];
+    }
+    ConstantFill(baseline_output_.cpu(), result);
+  }
+
+ public:
+  void RunTest() {
+    ReshapeData();
+    FillData();
+
+    auto baseline_out_v = baseline_output_.cpu();
+    auto in_gpu_v = input_.gpu();
+    auto out_gpu_v = output_.gpu();
+    std::array<TensorListView<StorageCPU, const float, 1>, kAxes> window_v;
+
+    for (int i = 0; i < kAxes; i++) {
+      window_v[i] = kernel_window_[i].cpu();
+    }
+
+    SeparableConvolutionGpu<float, float, float, kAxes, kChannels, kFrames> kernel_gpu;
+    KernelContext ctx_gpu;
+
+    ctx_gpu.gpu.stream = 0;
+
+    auto req = kernel_gpu.Setup(ctx_gpu, data_shape_, window_dims_);
+
+    ScratchpadAllocator scratch_alloc;
+    scratch_alloc.Reserve(req.scratch_sizes);
+    auto scratchpad = scratch_alloc.GetScratchpad();
+    ctx_gpu.scratchpad = &scratchpad;
+
+    kernel_gpu.Run(ctx_gpu, out_gpu_v, in_gpu_v, window_v);
+
+    auto out_cpu_v = output_.cpu(0);
+    cudaDeviceSynchronize();
+    CUDA_CALL(cudaGetLastError());
+    Check(out_cpu_v, baseline_out_v);
+  }
+};
+
+TEST(SeparableConvolutionGpuTest, Axes1NoChannels) {
+  SepearableConvolutionGpuTestImpl<1, false, false> impl;
+  impl.RunTest();
+}
+
+TEST(SeparableConvolutionGpuTest, Axes1Channels) {
+  SepearableConvolutionGpuTestImpl<1, true, false> impl;
+  impl.RunTest();
+}
+
+TEST(SeparableConvolutionGpuTest, FramesAxes1Channels) {
+  SepearableConvolutionGpuTestImpl<1, true, true> impl;
+  impl.RunTest();
+}
+
+TEST(SeparableConvolutionGpuTest, Axes2NoChannels) {
+  SepearableConvolutionGpuTestImpl<2, false, false> impl;
+  impl.RunTest();
+}
+
+TEST(SeparableConvolutionGpuTest, Axes2Channels) {
+  SepearableConvolutionGpuTestImpl<2, true, false> impl;
+  impl.RunTest();
+}
+
+TEST(SeparableConvolutionGpuTest, FramesAxes2Channels) {
+  SepearableConvolutionGpuTestImpl<2, true, true> impl;
+  impl.RunTest();
+}
+
+TEST(SeparableConvolutionGpuTest, Axes3NoChannels) {
+  SepearableConvolutionGpuTestImpl<3, false, false> impl;
+  impl.RunTest();
+}
+
+TEST(SeparableConvolutionGpuTest, Axes3Channels) {
+  SepearableConvolutionGpuTestImpl<3, true, false> impl;
+  impl.RunTest();
+}
+
+TEST(SeparableConvolutionGpuTest, FramesAxes3Channels) {
+  SepearableConvolutionGpuTestImpl<3, true, true> impl;
+  impl.RunTest();
+}
+
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/kernel_req.h
+++ b/dali/kernels/kernel_req.h
@@ -25,13 +25,31 @@
 namespace dali {
 namespace kernels {
 
+using scratch_sizes_t = std::array<size_t, static_cast<size_t>(AllocType::Count)>;
+
+inline scratch_sizes_t GetMaxScratch(const scratch_sizes_t &a, const scratch_sizes_t &b) {
+  scratch_sizes_t result;
+  for (size_t i = 0; i < result.size(); i++) {
+    result[i] = std::max(a[i], b[i]);
+  }
+  return result;
+}
+
+inline scratch_sizes_t GetSumScratch(const scratch_sizes_t &a, const scratch_sizes_t &b) {
+  scratch_sizes_t result;
+  for (size_t i = 0; i < result.size(); i++) {
+    result[i] = a[i] + b[i];
+  }
+  return result;
+}
+
 /**
  * @brief Represents requirements for kernel to do its job for given inputs and arguments.
  */
 struct KernelRequirements {
   std::vector<TensorListShape<DynamicDimensions>> output_shapes;
 
-  std::array<size_t, (size_t)AllocType::Count> scratch_sizes = {};
+  scratch_sizes_t scratch_sizes = {};
 
   /**
    * @param reuse_scratch  - if true, scratch size is taken to be maximum from that for
@@ -80,7 +98,7 @@ struct ScratchpadEstimator {
     return sizes[(size_t)alloc_type];
   }
 
-  std::array<size_t, (size_t)AllocType::Count> sizes = {};
+  scratch_sizes_t sizes = {};
 };
 
 }  // namespace kernels


### PR DESCRIPTION
Supports Frames-first, Channel-last, wraps
ConvolutionGPU applying several passes,
for number of data axes in [1, 3].
Simple sanity test, convolution already tested.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
It adds new kernel, that will be used in GaussianBlur GPU

#### What happened in this PR? 
 - What solution was applied:
     Same as CPU, wrap the ConvolutionGpu kernel and apply several passes
 - Affected modules and functionalities:
     Kernels
 - Key points relevant for the review:
     Nothing special
 - Validation and testing:
     Simple sanity gtest
 - Documentation (including examples):
      NA


**JIRA TASK**: *[Use DALI-1588 or NA]*
