### PR TITLE
Fix build for LMDB disabled

### DIFF
--- a/dali/operators/reader/loader/loader_test.cc
+++ b/dali/operators/reader/loader/loader_test.cc
@@ -25,7 +25,10 @@
 #include "dali/operators/reader/loader/recordio_loader.h"
 #include "dali/operators/reader/loader/indexed_file_loader.h"
 #include "dali/operators/reader/loader/coco_loader.h"
+
+#if BUILD_LMDB_ENABLED
 #include "dali/operators/reader/loader/lmdb.h"
+#endif
 
 namespace dali {
 
@@ -41,6 +44,7 @@ string loader_test_image_folder = testing::dali_extra_path() + "/db/single/jpeg"
 
 TYPED_TEST_SUITE(DataLoadStoreTest, TestTypes);
 
+#if BUILD_LMDB_ENABLED
 TYPED_TEST(DataLoadStoreTest, LMDBTest) {
   shared_ptr<dali::LMDBLoader> reader(
       new LMDBLoader(
@@ -58,6 +62,7 @@ TYPED_TEST(DataLoadStoreTest, LMDBTest) {
     auto sample = reader->ReadOne(false);
   }
 }
+#endif
 
 TYPED_TEST(DataLoadStoreTest, FileLabelLoaderMmmap) {
   for (bool dont_use_mmap : {true, false}) {

--- a/dali/operators/reader/loader/nemo_asr_loader_test.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader_test.cc
@@ -106,8 +106,9 @@ TEST(NemoAsrLoaderTest, WrongManifestPath) {
 void tempfile(std::string& filename, std::string content = "") {
   int fd = mkstemp(&filename[0]);
   ASSERT_NE(-1, fd);
-  if (!content.empty())
-    write(fd, content.c_str(), content.size());
+  if (!content.empty()) {
+    ASSERT_EQ(write(fd, content.c_str(), content.size()), content.size());
+  }
   close(fd);
 }
 


### PR DESCRIPTION
- adds a proper #if guard in loader_test for LMDB disabled
- adds additional check for write result in nemo_asr_loader_test

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes build for LMDB disabled

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a proper #if guard in loader_test for LMDB disabled
     adds additional check for write result in nemo_asr_loader_test
 - Affected modules and functionalities:
     loader_test
     nemo_asr_loader_test
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
