### PR TITLE
Enable automatic python modules for operator

### DIFF
--- a/dali/operators/geometry/affine_transforms/transform_crop.cc
+++ b/dali/operators/geometry/affine_transforms/transform_crop.cc
@@ -17,7 +17,7 @@
 
 namespace dali {
 
-DALI_SCHEMA(transforms_Crop)
+DALI_SCHEMA(transforms__Crop)
   .DocStr(R"code(Produces an affine transform matrix that maps a reference coordinate space to another one.
 
 This transform can be used to adjust coordinates after a crop operation so that a ``from_start`` point will
@@ -164,6 +164,6 @@ class TransformCropCPU
   bool absolute_ = false;
 };
 
-DALI_REGISTER_OPERATOR(transforms_Crop, TransformCropCPU, CPU);
+DALI_REGISTER_OPERATOR(transforms__Crop, TransformCropCPU, CPU);
 
 }  // namespace dali

--- a/dali/operators/geometry/affine_transforms/transform_crop.cc
+++ b/dali/operators/geometry/affine_transforms/transform_crop.cc
@@ -17,7 +17,7 @@
 
 namespace dali {
 
-DALI_SCHEMA(TransformCrop)
+DALI_SCHEMA(transforms_Crop)
   .DocStr(R"code(Produces an affine transform matrix that maps a reference coordinate space to another one.
 
 This transform can be used to adjust coordinates after a crop operation so that a ``from_start`` point will
@@ -164,6 +164,6 @@ class TransformCropCPU
   bool absolute_ = false;
 };
 
-DALI_REGISTER_OPERATOR(TransformCrop, TransformCropCPU, CPU);
+DALI_REGISTER_OPERATOR(transforms_Crop, TransformCropCPU, CPU);
 
 }  // namespace dali

--- a/dali/operators/geometry/affine_transforms/transform_rotation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_rotation.cc
@@ -19,7 +19,7 @@
 
 namespace dali {
 
-DALI_SCHEMA(transforms_Rotation)
+DALI_SCHEMA(transforms__Rotation)
   .DocStr(R"code(Produces a rotation affine transform matrix.
 
 If another transform matrix is passed as an input, the operator applies rotation to the matrix provided.
@@ -137,6 +137,6 @@ class TransformRotationCPU
   Argument<std::vector<float>> center_;
 };
 
-DALI_REGISTER_OPERATOR(transforms_Rotation, TransformRotationCPU, CPU);
+DALI_REGISTER_OPERATOR(transforms__Rotation, TransformRotationCPU, CPU);
 
 }  // namespace dali

--- a/dali/operators/geometry/affine_transforms/transform_rotation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_rotation.cc
@@ -19,7 +19,7 @@
 
 namespace dali {
 
-DALI_SCHEMA(TransformRotation)
+DALI_SCHEMA(transforms_Rotation)
   .DocStr(R"code(Produces a rotation affine transform matrix.
 
 If another transform matrix is passed as an input, the operator applies rotation to the matrix provided.
@@ -137,6 +137,6 @@ class TransformRotationCPU
   Argument<std::vector<float>> center_;
 };
 
-DALI_REGISTER_OPERATOR(TransformRotation, TransformRotationCPU, CPU);
+DALI_REGISTER_OPERATOR(transforms_Rotation, TransformRotationCPU, CPU);
 
 }  // namespace dali

--- a/dali/operators/geometry/affine_transforms/transform_scale.cc
+++ b/dali/operators/geometry/affine_transforms/transform_scale.cc
@@ -17,7 +17,7 @@
 
 namespace dali {
 
-DALI_SCHEMA(transforms_Scale)
+DALI_SCHEMA(transforms__Scale)
   .DocStr(R"code(Produces a scale affine transform matrix.
 
 If another transform matrix is passed as an input, the operator applies scaling to the matrix provided.
@@ -101,6 +101,6 @@ class TransformScaleCPU
   Argument<std::vector<float>> center_;
 };
 
-DALI_REGISTER_OPERATOR(transforms_Scale, TransformScaleCPU, CPU);
+DALI_REGISTER_OPERATOR(transforms__Scale, TransformScaleCPU, CPU);
 
 }  // namespace dali

--- a/dali/operators/geometry/affine_transforms/transform_scale.cc
+++ b/dali/operators/geometry/affine_transforms/transform_scale.cc
@@ -17,7 +17,7 @@
 
 namespace dali {
 
-DALI_SCHEMA(TransformScale)
+DALI_SCHEMA(transforms_Scale)
   .DocStr(R"code(Produces a scale affine transform matrix.
 
 If another transform matrix is passed as an input, the operator applies scaling to the matrix provided.
@@ -101,6 +101,6 @@ class TransformScaleCPU
   Argument<std::vector<float>> center_;
 };
 
-DALI_REGISTER_OPERATOR(TransformScale, TransformScaleCPU, CPU);
+DALI_REGISTER_OPERATOR(transforms_Scale, TransformScaleCPU, CPU);
 
 }  // namespace dali

--- a/dali/operators/geometry/affine_transforms/transform_shear.cc
+++ b/dali/operators/geometry/affine_transforms/transform_shear.cc
@@ -19,7 +19,7 @@
 
 namespace dali {
 
-DALI_SCHEMA(transforms_Shear)
+DALI_SCHEMA(transforms__Shear)
   .DocStr(R"code(Produces a shear affine transform matrix.
 
 If another transform matrix is passed as an input, the operator applies the shear mapping to the matrix provided.
@@ -175,6 +175,6 @@ class TransformShearCPU
   Argument<std::vector<float>> center_;
 };
 
-DALI_REGISTER_OPERATOR(transforms_Shear, TransformShearCPU, CPU);
+DALI_REGISTER_OPERATOR(transforms__Shear, TransformShearCPU, CPU);
 
 }  // namespace dali

--- a/dali/operators/geometry/affine_transforms/transform_shear.cc
+++ b/dali/operators/geometry/affine_transforms/transform_shear.cc
@@ -19,7 +19,7 @@
 
 namespace dali {
 
-DALI_SCHEMA(TransformShear)
+DALI_SCHEMA(transforms_Shear)
   .DocStr(R"code(Produces a shear affine transform matrix.
 
 If another transform matrix is passed as an input, the operator applies the shear mapping to the matrix provided.
@@ -175,6 +175,6 @@ class TransformShearCPU
   Argument<std::vector<float>> center_;
 };
 
-DALI_REGISTER_OPERATOR(TransformShear, TransformShearCPU, CPU);
+DALI_REGISTER_OPERATOR(transforms_Shear, TransformShearCPU, CPU);
 
 }  // namespace dali

--- a/dali/operators/geometry/affine_transforms/transform_translation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_translation.cc
@@ -17,7 +17,7 @@
 
 namespace dali {
 
-DALI_SCHEMA(transforms_Translation)
+DALI_SCHEMA(transforms__Translation)
   .DocStr(R"code(Produces a translation affine transform matrix.
 
 If another transform matrix is passed as an input, the operator applies translation to the matrix provided.
@@ -75,6 +75,6 @@ class TransformTranslationCPU
   Argument<std::vector<float>> offset_;
 };
 
-DALI_REGISTER_OPERATOR(transforms_Translation, TransformTranslationCPU, CPU);
+DALI_REGISTER_OPERATOR(transforms__Translation, TransformTranslationCPU, CPU);
 
 }  // namespace dali

--- a/dali/operators/geometry/affine_transforms/transform_translation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_translation.cc
@@ -75,6 +75,6 @@ class TransformTranslationCPU
   Argument<std::vector<float>> offset_;
 };
 
-DALI_REGISTER_OPERATOR(TransformTranslation, TransformTranslationCPU, CPU);
+DALI_REGISTER_OPERATOR(transforms_Translation, TransformTranslationCPU, CPU);
 
 }  // namespace dali

--- a/dali/operators/geometry/affine_transforms/transform_translation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_translation.cc
@@ -17,11 +17,7 @@
 
 namespace dali {
 
-<<<<<<< HEAD:dali/operators/geometry/affine_transforms/transform_translation.cc
-DALI_SCHEMA(TransformTranslation)
-=======
-DALI_SCHEMA(TranslateTransform, "transforms.Translation")
->>>>>>> [WIP]:dali/operators/geometry/affine_transforms/translate_transform.cc
+DALI_SCHEMA(transforms_Translation)
   .DocStr(R"code(Produces a translation affine transform matrix.
 
 If another transform matrix is passed as an input, the operator applies translation to the matrix provided.

--- a/dali/operators/geometry/affine_transforms/transform_translation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_translation.cc
@@ -17,7 +17,11 @@
 
 namespace dali {
 
+<<<<<<< HEAD:dali/operators/geometry/affine_transforms/transform_translation.cc
 DALI_SCHEMA(TransformTranslation)
+=======
+DALI_SCHEMA(TranslateTransform, "transforms.Translation")
+>>>>>>> [WIP]:dali/operators/geometry/affine_transforms/translate_transform.cc
   .DocStr(R"code(Produces a translation affine transform matrix.
 
 If another transform matrix is passed as an input, the operator applies translation to the matrix provided.

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -911,14 +911,14 @@ inline T OpSchema::GetDefaultValueForArgument(const std::string &s) const {
   return vT->Get();
 }
 
-#define DALI_SCHEMA_REG(OpName      \
+#define DALI_SCHEMA_REG(OpName)      \
   int DALI_OPERATOR_SCHEMA_REQUIRED_FOR_##OpName() {        \
     return 42;                                              \
   }                                                         \
-  static ::dali::OpSchema* ANONYMIZE_VARIABLE(OpName) =              \
-    &::dali::SchemaRegistry::RegisterSchema((#OpName))
+  static ::dali::OpSchema* ANONYMIZE_VARIABLE(OpName) =             \
+    &::dali::SchemaRegistry::RegisterSchema(#OpName)
 
-#define DALI_SCHEMA(OpName \
+#define DALI_SCHEMA(OpName)                            \
       DALI_SCHEMA_REG(OpName)
 
 }  // namespace dali

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -911,14 +911,14 @@ inline T OpSchema::GetDefaultValueForArgument(const std::string &s) const {
   return vT->Get();
 }
 
-#define DALI_SCHEMA_REG(OpName)      \
+#define DALI_SCHEMA_REG(OpName      \
   int DALI_OPERATOR_SCHEMA_REQUIRED_FOR_##OpName() {        \
     return 42;                                              \
   }                                                         \
-  static ::dali::OpSchema* ANONYMIZE_VARIABLE(OpName) =             \
-    &::dali::SchemaRegistry::RegisterSchema(#OpName)
+  static ::dali::OpSchema* ANONYMIZE_VARIABLE(OpName) =              \
+    &::dali::SchemaRegistry::RegisterSchema((#OpName))
 
-#define DALI_SCHEMA(OpName)                            \
+#define DALI_SCHEMA(OpName \
       DALI_SCHEMA_REG(OpName)
 
 }  // namespace dali

--- a/dali/pipeline/operator/operator_factory.h
+++ b/dali/pipeline/operator/operator_factory.h
@@ -60,7 +60,7 @@ class OperatorRegistry {
     for (const auto &pair : registry_) {
       auto& schema = SchemaRegistry::GetSchema(pair.first);
       if (internal_ops || !schema.IsInternal())
-        names.push_back(pair.first);
+        names.push_back(schema.name().length() ? schema.name() : pair.first);
     }
     return names;
   }

--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -97,7 +97,7 @@ def _wrap_op(op_class, submodule):
         wrap_func = _wrap_op_fn(op_class, wrapper_name)
         setattr(module, wrapper_name, wrap_func)
         if submodule:
-            setattr(fn_module, '.'.join(submodule + [wrapper_name]), wrap_func)
+            wrap_func.__module__ = module.__name__
 
 
 from nvidia.dali.external_source import external_source

--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -91,9 +91,14 @@ Got {1} instead when calling operator {2}.""".format(idx, type(inp).__name__, op
 
 def _wrap_op(op_class, submodule):
     wrapper_name = _to_snake_case(op_class.__name__)
-    module = _internal.get_submodule(sys.modules[__name__], submodule)
+    fn_module = sys.modules[__name__]
+    module = _internal.get_submodule(fn_module, submodule)
     if not hasattr(module, wrapper_name):
-        setattr(module, wrapper_name, _wrap_op_fn(op_class, wrapper_name))
+        wrap_func = _wrap_op_fn(op_class, wrapper_name)
+        setattr(module, wrapper_name, wrap_func)
+        if submodule:
+            setattr(fn_module, '.'.join(submodule + [wrapper_name]), wrap_func)
+
 
 from nvidia.dali.external_source import external_source
 external_source.__module__ = __name__

--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -15,6 +15,7 @@
 #pylint: disable=no-member
 import sys
 from nvidia.dali.data_node import DataNode as _DataNode
+from nvidia.dali import internal as _internal
 
 _special_case_mapping = {
     "b_box" : "bbox",
@@ -88,10 +89,11 @@ Got {1} instead when calling operator {2}.""".format(idx, type(inp).__name__, op
     op_wrapper.__doc__ = "see :class:`nvidia.dali.ops.{0}`".format(op_class.__name__)
     return op_wrapper
 
-def _wrap_op(op_class):
+def _wrap_op(op_class, submodule):
     wrapper_name = _to_snake_case(op_class.__name__)
-    if not hasattr(sys.modules[__name__], wrapper_name):
-        setattr(sys.modules[__name__], wrapper_name, _wrap_op_fn(op_class, wrapper_name))
+    module = _internal.get_submodule(sys.modules[__name__], submodule)
+    if not hasattr(module, wrapper_name):
+        setattr(module, wrapper_name, _wrap_op_fn(op_class, wrapper_name))
 
 from nvidia.dali.external_source import external_source
 external_source.__module__ = __name__

--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -86,7 +86,7 @@ Got {1} instead when calling operator {2}.""".format(idx, type(inp).__name__, op
         return op_class(**scalar_args)(*inputs, **tensor_args)
 
     op_wrapper.__name__ = wrapper_name
-    op_wrapper.__doc__ = "see :class:`nvidia.dali.ops.{0}`".format(op_class.__name__)
+    op_wrapper.__doc__ = "see :class:`{0}.{1}`".format(op_class.__module__, op_class.__name__)
     return op_wrapper
 
 def _wrap_op(op_class, submodule):

--- a/dali/python/nvidia/dali/internal.py
+++ b/dali/python/nvidia/dali/internal.py
@@ -23,10 +23,12 @@ Parameters
             return root
         path = path.split('.')
 
+    module_name = root.__name__
     for part in path:
         m = getattr(root, part, None)
+        module_name += '.' + part
         if m is None:
-            m = types.ModuleType(part)
+            m = sys.modules[module_name] = types.ModuleType(module_name)
             setattr(root, part, m)
         elif not isinstance(m, types.ModuleType):
             raise RuntimeError("The module {} already contains an attribute \"{}\", which is not a module, but {}".format(

--- a/dali/python/nvidia/dali/internal.py
+++ b/dali/python/nvidia/dali/internal.py
@@ -1,0 +1,35 @@
+import sys
+import types
+
+def get_submodule(root, path):
+    """Gets or creates sumbodule(s) of `root`.
+If the module path contains multiple parts, multiple modules are traversed or created
+
+Parameters
+----------
+    `root`
+        module object or name of the root module
+    `path`
+        period-separated path of the submodule or a list/tuple of submodule names"""
+
+    if isinstance(root, str):
+        root = sys.modules[root]
+
+    if not path:
+        return root
+
+    if isinstance(path, str):
+        if str == '':
+            return root
+        path = path.split('.')
+
+    for part in path:
+        m = getattr(root, part, None)
+        if m is None:
+            m = types.ModuleType(part)
+            setattr(root, part, m)
+        elif not isinstance(m, types.ModuleType):
+            raise RuntimeError("The module {} already contains an attribute \"{}\", which is not a module, but {}".format(
+                root, part, m))
+        root = m
+    return root

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -742,8 +742,6 @@ class PythonFunction(PythonFunctionBase):
     _cpu_ops = _cpu_ops.union({'PythonFunction'})
     _gpu_ops = _gpu_ops.union({'PythonFunction'})
 
-    __doc__ = "Some documentation here"
-
     @staticmethod
     def current_stream():
         """Gets DALI's current CUDA stream."""

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -77,13 +77,15 @@ def _get_kwargs(schema, only_tensor = False):
             ret += '\n'
     return ret
 
+def _schema_name(cls):
+    return getattr(cls, 'schema_name', cls.__name__)
+
 def _docstring_generator(cls):
     """
         Generate docstring for the class obtaining it from schema based on cls.__name__
-
         This lists all the Keyword args that can be used when creating operator
     """
-    op_name = cls.schema_name or cls.__name__
+    op_name = _schema_name(cls)
     schema = _b.GetSchema(op_name)
     ret = '\n'
 
@@ -364,7 +366,7 @@ class _DaliOperatorMeta(type):
 def python_op_factory(name, schema_name = None, op_device = "cpu"):
     class Operator(metaclass=_DaliOperatorMeta):
         def __init__(self, **kwargs):
-            schema_name = type(self).schema_name
+            schema_name = _schema_name(type(self))
             self._spec = _b.OpSpec(schema_name)
             self._schema = _b.GetSchema(schema_name)
 
@@ -739,6 +741,8 @@ class PythonFunction(PythonFunctionBase):
     global _gpu_ops
     _cpu_ops = _cpu_ops.union({'PythonFunction'})
     _gpu_ops = _gpu_ops.union({'PythonFunction'})
+
+    __doc__ = "Some documentation here"
 
     @staticmethod
     def current_stream():

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -546,10 +546,9 @@ def python_op_factory(name, schema_name = None, op_device = "cpu"):
     Operator.__call__.__doc__ = _docstring_generator_call(Operator.schema_name)
     return Operator
 
-def _process_op_name(op_full_name):
-    if not op_full_name.startswith('_'):
-        namespace_delim = "__"  # Two underscores (reasoning: we might want to have single underscores in the namespace itself)
-        op_full_name = op_full_name.replace(namespace_delim, '.')
+def _process_op_name(op_schema_name):
+    namespace_delim = "__"  # Two underscores (reasoning: we might want to have single underscores in the namespace itself)
+    op_full_name = op_schema_name.replace(namespace_delim, '.')
     *submodule, op_name = op_full_name.split('.')
     return op_full_name, submodule, op_name
 
@@ -569,7 +568,7 @@ def _load_ops():
     for op_reg_name in _cpu_gpu_ops:
         op_full_name, submodule, op_name = _process_op_name(op_reg_name)
         module = _internal.get_submodule(ops_module, submodule)
-        if not hasattr(module, op_full_name):
+        if not hasattr(module, op_name):
             op_class = python_op_factory(op_name, op_reg_name, op_device = "cpu")
             op_class.__module__ = module.__name__
             setattr(module, op_name, op_class)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -546,6 +546,13 @@ def python_op_factory(name, schema_name = None, op_device = "cpu"):
     Operator.__call__.__doc__ = _docstring_generator_call(Operator.schema_name)
     return Operator
 
+def _process_op_name(op_full_name):
+    if not op_full_name.startswith('_'):
+        namespace_delim = "__"  # Two underscores (reasoning: we might want to have single underscores in the namespace itself)
+        op_full_name = op_full_name.replace(namespace_delim, '.')
+    *submodule, op_name = op_full_name.split('.')
+    return op_full_name, submodule, op_name
+
 def _wrap_op(op_class, submodule = []):
     return _functional._wrap_op(op_class, submodule)
 
@@ -560,12 +567,9 @@ def _load_ops():
     ops_module = sys.modules[__name__]
 
     for op_reg_name in _cpu_gpu_ops:
-        op_full_name = op_reg_name
-        if not op_full_name.startswith('_'):
-            op_full_name = op_full_name.replace('_', '.')
-        *submodule, op_name = op_full_name.split('.')
+        op_full_name, submodule, op_name = _process_op_name(op_reg_name)
         module = _internal.get_submodule(ops_module, submodule)
-        if not hasattr(ops_module, op_full_name):
+        if not hasattr(module, op_full_name):
             op_class = python_op_factory(op_name, op_reg_name, op_device = "cpu")
             op_class.__module__ = module.__name__
             setattr(module, op_name, op_class)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -567,8 +567,9 @@ def _load_ops():
         module = _internal.get_submodule(ops_module, submodule)
         if not hasattr(ops_module, op_full_name):
             op_class = python_op_factory(op_name, op_reg_name, op_device = "cpu")
-            setattr(ops_module, op_full_name, op_class)
+            op_class.__module__ = module.__name__
             setattr(module, op_name, op_class)
+
             if op_name not in ["ExternalSource"]:
                 _wrap_op(op_class, submodule)
 

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -632,19 +632,19 @@ def test_sequence_reader_cpu():
         pipe.run()
 
 def test_affine_translate_cpu():
-    check_no_input(fn.transform_translation, offset=(2, 3))
+    check_no_input(fn.transforms.translation, offset=(2, 3))
 
 def test_affine_scale_cpu():
-    check_no_input(fn.transform_scale, scale=(2, 3))
+    check_no_input(fn.transforms.scale, scale=(2, 3))
 
 def test_affine_rotate_cpu():
-    check_no_input(fn.transform_rotation, angle=30.0)
+    check_no_input(fn.transforms.rotation, angle=30.0)
 
 def test_affine_shear_cpu():
-    check_no_input(fn.transform_shear, shear=(2., 1.))
+    check_no_input(fn.transforms.shear, shear=(2., 1.))
 
 def test_affine_crop_cpu():
-    check_no_input(fn.transform_crop,
+    check_no_input(fn.transforms.crop,
         from_start=(0., 1.), from_end=(1., 1.), to_start=(0.2, 0.3), to_end=(0.8, 0.5))
 
 # ToDo add tests for DLTensorPythonFunction if easily possible

--- a/dali/test/python/test_operator_affine_transforms.py
+++ b/dali/test/python/test_operator_affine_transforms.py
@@ -50,10 +50,10 @@ def check_transform_translation_op(offset, has_input = False, reverse_order=Fals
     with pipe:
         if has_input:
             T0 = fn.uniform(range=(-1, 1), shape=(ndim, ndim+1), seed = 1234)
-            T1 = fn.transform_translation(T0, device='cpu', offset=offset, reverse_order=reverse_order)
+            T1 = fn.transforms.translation(T0, device='cpu', offset=offset, reverse_order=reverse_order)
             pipe.set_outputs(T1, T0)
         else:
-            T1 = fn.transform_translation(device='cpu', offset=offset)
+            T1 = fn.transforms.translation(device='cpu', offset=offset)
             pipe.set_outputs(T1)
     pipe.build()
     outs = pipe.run()
@@ -94,10 +94,10 @@ def check_transform_scale_op(scale, center=None, has_input = False, reverse_orde
     with pipe:
         if has_input:
             T0 = fn.uniform(range=(-1, 1), shape=(ndim, ndim+1), seed = 1234)
-            T1 = fn.transform_scale(T0, device='cpu', scale=scale, center=center, reverse_order=reverse_order)
+            T1 = fn.transforms.scale(T0, device='cpu', scale=scale, center=center, reverse_order=reverse_order)
             pipe.set_outputs(T1, T0)
         else:
-            T1 = fn.transform_scale(device='cpu', scale=scale, center=center)
+            T1 = fn.transforms.scale(device='cpu', scale=scale, center=center)
             pipe.set_outputs(T1)
     pipe.build()
     outs = pipe.run()
@@ -150,10 +150,10 @@ def check_transform_rotation_op(angle, axis=None, center=None, has_input = False
     with pipe:
         if has_input:
             T0 = fn.uniform(range=(-1, 1), shape=(ndim, ndim+1), seed = 1234)
-            T1 = fn.transform_rotation(T0, device='cpu', angle=angle, axis=axis, center=center, reverse_order=reverse_order)
+            T1 = fn.transforms.rotation(T0, device='cpu', angle=angle, axis=axis, center=center, reverse_order=reverse_order)
             pipe.set_outputs(T1, T0)
         else:
-            T1 = fn.transform_rotation(device='cpu', angle=angle, axis=axis, center=center)
+            T1 = fn.transforms.rotation(device='cpu', angle=angle, axis=axis, center=center)
             pipe.set_outputs(T1)
     pipe.build()
     outs = pipe.run()
@@ -217,10 +217,10 @@ def check_transform_shear_op(shear=None, angles=None, center=None, has_input = F
     with pipe:
         if has_input:
             T0 = fn.uniform(range=(-1, 1), shape=(ndim, ndim+1), seed = 1234)
-            T1 = fn.transform_shear(T0, device='cpu', shear=shear, angles=angles, center=center, reverse_order=reverse_order)
+            T1 = fn.transforms.shear(T0, device='cpu', shear=shear, angles=angles, center=center, reverse_order=reverse_order)
             pipe.set_outputs(T1, T0)
         else:
-            T1 = fn.transform_shear(device='cpu', shear=shear, angles=angles, center=center)
+            T1 = fn.transforms.shear(device='cpu', shear=shear, angles=angles, center=center)
             pipe.set_outputs(T1)
     pipe.build()
     outs = pipe.run()
@@ -283,14 +283,14 @@ def check_transform_crop_op(from_start = None, from_end = None, to_start = None,
     with pipe:
         if has_input:
             T0 = fn.uniform(range=(-1, 1), shape=(ndim, ndim+1), seed = 1234)
-            T1 = fn.transform_crop(T0, device='cpu',
+            T1 = fn.transforms.crop(T0, device='cpu',
                                    from_start=from_start, from_end=from_end,
                                    to_start=to_start, to_end=to_end,
                                    absolute=absolute,
                                    reverse_order=reverse_order)
             pipe.set_outputs(T1, T0)
         else:
-            T1 = fn.transform_crop(device='cpu',
+            T1 = fn.transforms.crop(device='cpu',
                                    from_start=from_start, from_end=from_end,
                                    to_start=to_start, to_end=to_end,
                                    absolute=absolute)

--- a/dali/test/python/test_operator_affine_transforms.py
+++ b/dali/test/python/test_operator_affine_transforms.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops.transforms as T  # Just here to verify that import works as expected
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
 import nvidia.dali.fn as fn

--- a/docs/autodoc_submodules.py
+++ b/docs/autodoc_submodules.py
@@ -1,0 +1,33 @@
+from nvidia.dali import backend as b
+import nvidia.dali.ops as ops
+import nvidia.dali.plugin.pytorch
+import sys
+import inspect
+
+# Dictionary with modules that can have registered Ops
+ops_modules = {
+    'nvidia.dali.ops': nvidia.dali.ops,
+    'nvidia.dali.plugin.pytorch': nvidia.dali.plugin.pytorch
+}
+
+exclude_members = {
+    'nvidia.dali.ops': ["PythonFunctionBase"]
+}
+
+def main(argv):
+    s = ""
+    for module in sys.modules.keys():
+        for doc_module in ops_modules:
+            if module.startswith(doc_module):
+                s += ".. automodule:: {}\n".format(module)
+                s += "   :members:\n"
+                s += "   :special-members: __call__\n"
+                if module in exclude_members:
+                    for excluded in exclude_members[module]:
+                        s += "   :exclude-members: {}\n".format(excluded)
+                s += "\n"
+    with open(argv[0], 'w') as f:
+        f.write(s)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/docs/autodoc_submodules.py
+++ b/docs/autodoc_submodules.py
@@ -9,11 +9,18 @@ ops_modules = {
     'nvidia.dali.ops': nvidia.dali.ops,
 }
 
-exclude_members = {
+exclude_ops_members = {
     'nvidia.dali.ops': ["PythonFunctionBase"]
 }
 
-def main(argv):
+fn_modules = {
+    'nvidia.dali.fn': nvidia.dali.fn
+}
+
+exclude_fn_members = {
+}
+
+def op_autodoc(out_filename):
     s = ""
     for module in sys.modules.keys():
         for doc_module in ops_modules:
@@ -21,12 +28,29 @@ def main(argv):
                 s += ".. automodule:: {}\n".format(module)
                 s += "   :members:\n"
                 s += "   :special-members: __call__\n"
-                if module in exclude_members:
-                    for excluded in exclude_members[module]:
+                if module in exclude_ops_members:
+                    for excluded in exclude_ops_members[module]:
                         s += "   :exclude-members: {}\n".format(excluded)
                 s += "\n"
-    with open(argv[0], 'w') as f:
+    with open(out_filename, 'w') as f:
+        f.write(s)
+
+def fn_autodoc(out_filename):
+    s = ""
+    for module in sys.modules.keys():
+        for doc_module in fn_modules:
+            if module.startswith(doc_module):
+                s += ".. automodule:: {}\n".format(module)
+                s += "   :members:\n"
+                s += "   :undoc-members:\n"
+                if module in exclude_fn_members:
+                    for excluded in exclude_fn_members[module]:
+                        s += "   :exclude-members: {}\n".format(excluded)
+                s += "\n"
+    with open(out_filename, 'w') as f:
         f.write(s)
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    assert(len(sys.argv) == 3)
+    op_autodoc(sys.argv[1])
+    fn_autodoc(sys.argv[2])

--- a/docs/autodoc_submodules.py
+++ b/docs/autodoc_submodules.py
@@ -25,6 +25,8 @@ def op_autodoc(out_filename):
     for module in sys.modules.keys():
         for doc_module in ops_modules:
             if module.startswith(doc_module):
+                s += module + "\n"
+                s += "~" * len(module) + "\n"
                 s += ".. automodule:: {}\n".format(module)
                 s += "   :members:\n"
                 s += "   :special-members: __call__\n"

--- a/docs/autodoc_submodules.py
+++ b/docs/autodoc_submodules.py
@@ -7,7 +7,6 @@ import inspect
 # Dictionary with modules that can have registered Ops
 ops_modules = {
     'nvidia.dali.ops': nvidia.dali.ops,
-    'nvidia.dali.plugin.pytorch': nvidia.dali.plugin.pytorch
 }
 
 exclude_members = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,9 +52,10 @@ release = str(version_long)
 with mock(["torch"]):
     sys.path.insert(0, os.path.abspath('./'))
     import supported_op_devices
-    supported_op_devices.main(["op_inclusion"])
+    supported_op_devices.main("op_inclusion")
     import autodoc_submodules
-    autodoc_submodules.main(["op_autodoc"])
+    autodoc_submodules.op_autodoc("op_autodoc")
+    autodoc_submodules.fn_autodoc("fn_autodoc")
 
 # Uncomment to keep warnings in the output. Useful for verbose build and output debugging.
 # keep_warnings = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,8 @@ with mock(["torch"]):
     sys.path.insert(0, os.path.abspath('./'))
     import supported_op_devices
     supported_op_devices.main(["op_inclusion"])
+    import autodoc_submodules
+    autodoc_submodules.main(["op_autodoc"])
 
 # Uncomment to keep warnings in the output. Useful for verbose build and output debugging.
 # keep_warnings = True

--- a/docs/functional_api.rst
+++ b/docs/functional_api.rst
@@ -55,6 +55,4 @@ using object API to pre-configure a file reader and a resize operator::
 Functions
 ---------
 
-.. automodule:: nvidia.dali.fn
-   :members:
-   :undoc-members:
+.. include:: fn_autodoc

--- a/docs/supported_op_devices.py
+++ b/docs/supported_op_devices.py
@@ -9,7 +9,7 @@ ops_modules = {
     'nvidia.dali.plugin.pytorch': nvidia.dali.plugin.pytorch
 }
 
-def main(argv):
+def main(out_filename):
     cpu_ops = ops.cpu_ops()
     gpu_ops = ops.gpu_ops()
     mix_ops = ops.mixed_ops()
@@ -28,10 +28,7 @@ def main(argv):
     doc_table += formater.format('', '', '', '', '', '', op_name_max_len = op_name_max_len, c='=')
     for op in sorted(all_ops, key=lambda v: str(v).lower()):
         schema = b.GetSchema(op)
-        op_full_name = op
-        if not op_full_name.startswith('_'):
-            op_full_name = op_full_name.replace('_', '.')
-        *submodule, op_name = op_full_name.split('.')
+        op_full_name, submodule, op_name = ops._process_op_name(op)
         is_cpu = '|v|' if op in cpu_ops else ''
         is_gpu = '|v|' if op in gpu_ops else ''
         is_mixed = '|v|' if op in mix_ops else ''
@@ -49,8 +46,9 @@ def main(argv):
         op_doc = formater.format(op_string, is_cpu, is_gpu, is_mixed, supports_seq, volumetric, op_name_max_len = op_name_max_len, c=' ')
         doc_table += op_doc
     doc_table += formater.format('', '', '', '', '', '', op_name_max_len = op_name_max_len, c='=')
-    with open(argv[0], 'w') as f:
+    with open(out_filename, 'w') as f:
         f.write(doc_table)
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    assert(len(sys.argv) == 2)
+    main(sys.argv[1])

--- a/docs/supported_op_devices.py
+++ b/docs/supported_op_devices.py
@@ -9,6 +9,10 @@ ops_modules = {
     'nvidia.dali.plugin.pytorch': nvidia.dali.plugin.pytorch
 }
 
+def name_sort(op_name):
+    _, module, name = ops._process_op_name(op_name)
+    return '.'.join(module + [name.upper()])
+
 def main(out_filename):
     cpu_ops = ops.cpu_ops()
     gpu_ops = ops.gpu_ops()
@@ -26,7 +30,7 @@ def main(out_filename):
     doc_table += formater.format('', '', '', '', '', '', op_name_max_len = op_name_max_len, c='=')
     doc_table += formater.format('Operator name', 'CPU', 'GPU', 'Mixed', 'Sequences', 'Volumetric', op_name_max_len = op_name_max_len, c=' ')
     doc_table += formater.format('', '', '', '', '', '', op_name_max_len = op_name_max_len, c='=')
-    for op in sorted(all_ops, key=lambda v: str(v).lower()):
+    for op in sorted(all_ops, key=name_sort):
         schema = b.GetSchema(op)
         op_full_name, submodule, op_name = ops._process_op_name(op)
         is_cpu = '|v|' if op in cpu_ops else ''

--- a/docs/supported_ops.rst
+++ b/docs/supported_ops.rst
@@ -58,6 +58,9 @@ Operators Documentation
 
 .. include:: op_autodoc
 
+
+nvidia.dali.plugin.pytorch
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autoclass:: nvidia.dali.plugin.pytorch.TorchPythonFunction
    :members:
 

--- a/docs/supported_ops.rst
+++ b/docs/supported_ops.rst
@@ -58,6 +58,9 @@ Operators Documentation
 
 .. include:: op_autodoc
 
+.. autoclass:: nvidia.dali.plugin.pytorch.TorchPythonFunction
+   :members:
+
 .. _arithmetic expressions:
 
 Arithmetic expressions

--- a/docs/supported_ops.rst
+++ b/docs/supported_ops.rst
@@ -56,14 +56,7 @@ The following table lists all available operators and devices on which they can 
 Operators Documentation
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automodule:: nvidia.dali.ops
-   :members:
-   :special-members: __call__
-   :exclude-members: PythonFunctionBase
-
-.. autoclass:: nvidia.dali.plugin.pytorch.TorchPythonFunction
-   :members:
-
+.. include:: op_autodoc
 
 .. _arithmetic expressions:
 


### PR DESCRIPTION
#### Why we need this PR?
- It adds a new feature needed to place several operators inside a python module. Example:
```
transforms.Translation
transforms.Rotation
...
```

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added python logic to interpret double underscores ("__") as a module delimiter so naming an operator `transforms_Translation` at the schema level would result in a module `transforms`, containing an operator `Translation`*
     *Added tools to auto-document sub-modules of `ops` and `fn`.*
 - Affected modules and functionalities:
     *Python ops, documentation*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     *Documentation output*
 - Documentation (including examples):
     *Documentation updated*

co-author: Michal Zientkiewicz <michalz@nvidia.com>

**JIRA TASK**: *[DALI-1643]*
