### PR TITLE
Add SeekFrames to audio decoder. Redesign to allow deciding decoded data type at runtime.

### DIFF
--- a/dali/operators/decoder/audio/audio_decoder.h
+++ b/dali/operators/decoder/audio/audio_decoder.h
@@ -47,10 +47,34 @@ class AudioDecoderBase {
   }
 
   /**
-   * @brief Decode audio data and store it in the supplied buffer
-   * @return Number of (multi-channel) samples actually read
+   * @brief Determines whether the particular decoder can seek frames
    */
-  virtual ptrdiff_t Decode(span<char> raw_output) = 0;
+  virtual bool CanSeekFrames() const = 0;
+
+  /**
+   * @brief Seeks full frames, or multichannel samples, much like lseek in unistd.h
+   * @param nframes Number of full frames (1 frame is equivalent to nchannel samples)
+   * @param whence Like in lseek, SEEK_SET. SEEK_CUR, SEEK_END
+   */
+  virtual int64_t SeekFrames(int64_t nframes, int whence = SEEK_CUR) = 0;
+
+  /**
+   * @brief Decode audio samples.
+   * @remarks output length should include the number of channels
+   *          (audio_length * num_channels)
+   * @return Number of samples read
+   */
+  virtual ptrdiff_t Decode(span<float> output) = 0;
+  virtual ptrdiff_t Decode(span<int16_t> output) = 0;
+  virtual ptrdiff_t Decode(span<int32_t> output) = 0;
+
+  /**
+   * @brief Decode audio frames (1 frame is equivalent to nchannel samples)
+   * @return Number of frames read
+   */
+  virtual ptrdiff_t DecodeFrames(float* output, int64_t nframes) = 0;
+  virtual ptrdiff_t DecodeFrames(int16_t* output, int64_t nframes) = 0;
+  virtual ptrdiff_t DecodeFrames(int32_t* output, int64_t nframes) = 0;
 
   virtual ~AudioDecoderBase() = default;
 
@@ -59,20 +83,6 @@ class AudioDecoderBase {
   virtual AudioMetadata OpenFromFileImpl(const std::string &filepath) = 0;
   virtual void CloseImpl() = 0;
 };
-
-template<typename SampleType>
-class TypedAudioDecoderBase : public AudioDecoderBase {
- public:
-  ptrdiff_t Decode(span<char> raw_output) override {
-    int max_samples = static_cast<int>(raw_output.size() / sizeof(SampleType));
-    return DecodeTyped({reinterpret_cast<SampleType *>(raw_output.data()), max_samples});
-  }
-
-  virtual ptrdiff_t DecodeTyped(span<SampleType> typed_output) = 0;
-};
-
-
-
 
 }  // namespace dali
 

--- a/dali/operators/decoder/audio/audio_decoder.h
+++ b/dali/operators/decoder/audio/audio_decoder.h
@@ -27,7 +27,7 @@ struct AudioMetadata {
   /// @brief Sampling rate, in Hz
   int sample_rate;
   int channels;
-  bool channels_interleaved;
+  bool channels_interleaved = true;
 };
 
 class AudioDecoderBase {

--- a/dali/operators/decoder/audio/audio_decoder_impl.h
+++ b/dali/operators/decoder/audio/audio_decoder_impl.h
@@ -15,6 +15,7 @@
 #ifndef DALI_OPERATORS_DECODER_AUDIO_AUDIO_DECODER_IMPL_H_
 #define DALI_OPERATORS_DECODER_AUDIO_AUDIO_DECODER_IMPL_H_
 
+#include <utility>
 #include "dali/operators/decoder/audio/audio_decoder.h"
 #include "dali/operators/decoder/audio/generic_decoder.h"
 #include "dali/pipeline/data/backend.h"
@@ -23,15 +24,18 @@
 
 namespace dali {
 
-TensorShape<> DecodedAudioShape(const AudioMetadata &meta, float target_sample_rate = -1,
-                                bool downmix = true, float offset_sec = 0.0f, float duration_sec = 0.0f);
+DLL_PUBLIC std::pair<int64_t, int64_t> ProcessOffsetAndLength(const AudioMetadata &meta,
+                                                              double offset_sec, double length_sec);
+
+DLL_PUBLIC TensorShape<> DecodedAudioShape(const AudioMetadata &meta, float target_sample_rate = -1,
+                                           bool downmix = true);
 
 template <typename T>
-void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio, AudioDecoderBase &decoder,
-                 const AudioMetadata &meta, kernels::signal::resampling::Resampler &resampler,
-                 span<float> decode_scratch_mem, span<float> resample_scratch_mem,
-                 float target_sample_rate, bool downmix, const char *audio_filepath,
-                 float offset_sec = 0.0f, float duration_sec = 0.0f);
+DLL_PUBLIC void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio,
+                            AudioDecoderBase &decoder, const AudioMetadata &meta,
+                            kernels::signal::resampling::Resampler &resampler,
+                            span<float> decode_scratch_mem, span<float> resample_scratch_mem,
+                            float target_sample_rate, bool downmix, const char *audio_filepath);
 
 }  // namespace dali
 

--- a/dali/operators/decoder/audio/audio_decoder_impl.h
+++ b/dali/operators/decoder/audio/audio_decoder_impl.h
@@ -28,12 +28,12 @@ namespace dali {
  * @brief Converts offset and length in seconds to offset and lenght in number of samples
  *        according with the audio metadata
  * @param meta Audio metadata
- * @param offset_sec offset, in seconds. If a negative value is provided, zero offset is assumed
+ * @param offset_sec offset, in seconds (optional)
  * @param length_sec length, in seconds. If a negative value is provided, whole buffer is assumed
  * @returns pair containing offset and length in number of samples
  */
 DLL_PUBLIC std::pair<int64_t, int64_t> ProcessOffsetAndLength(const AudioMetadata &meta,
-                                                              double offset_sec = -1,
+                                                              double offset_sec = 0,
                                                               double length_sec = -1);
 
 /**

--- a/dali/operators/decoder/audio/audio_decoder_impl.h
+++ b/dali/operators/decoder/audio/audio_decoder_impl.h
@@ -24,13 +24,14 @@
 namespace dali {
 
 TensorShape<> DecodedAudioShape(const AudioMetadata &meta, float target_sample_rate = -1,
-                                bool downmix = true);
+                                bool downmix = true, float offset_sec = 0.0f, float duration_sec = 0.0f);
 
-template <typename T, typename DecoderOutputType>
+template <typename T>
 void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio, AudioDecoderBase &decoder,
                  const AudioMetadata &meta, kernels::signal::resampling::Resampler &resampler,
-                 span<DecoderOutputType> decode_scratch_mem, span<float> resample_scratch_mem,
-                 float target_sample_rate, bool downmix, const char *audio_filepath);
+                 span<float> decode_scratch_mem, span<float> resample_scratch_mem,
+                 float target_sample_rate, bool downmix, const char *audio_filepath,
+                 float offset_sec = 0.0f, float duration_sec = 0.0f);
 
 }  // namespace dali
 

--- a/dali/operators/decoder/audio/audio_decoder_impl.h
+++ b/dali/operators/decoder/audio/audio_decoder_impl.h
@@ -24,12 +24,47 @@
 
 namespace dali {
 
+/**
+ * @brief Converts offset and length in seconds to offset and lenght in number of samples
+ *        according with the audio metadata
+ * @param meta Audio metadata
+ * @param offset_sec offset, in seconds. If a negative value is provided, zero offset is assumed
+ * @param length_sec length, in seconds. If a negative value is provided, whole buffer is assumed
+ * @returns pair containing offset and length in number of samples
+ */
 DLL_PUBLIC std::pair<int64_t, int64_t> ProcessOffsetAndLength(const AudioMetadata &meta,
-                                                              double offset_sec, double length_sec);
+                                                              double offset_sec = -1,
+                                                              double length_sec = -1);
 
+/**
+ * @brief Returns the shape of the resulting decoded audio
+ * @param meta Audio metadata
+ * @param target_sample_rate If a positive number is provided, it represent the target sampling rate
+ *                           (the audio data is expected to be resampled if its original sampling rate differs)
+ * @param downmix If set to true, the audio channels are expected to be downmixed, resulting in a shape with 1
+ *                dimension ({nsamples,}), instead of 2 ({nsamples, nchannels})       
+ */
 DLL_PUBLIC TensorShape<> DecodedAudioShape(const AudioMetadata &meta, float target_sample_rate = -1,
                                            bool downmix = true);
 
+/**
+ * @brief Decodes audio data, with optional downmixing and resampling
+ * @param audio Destination buffer. The function will decode as many audio samples as the shape of this argument
+ * @param decoder Decoder object.
+ * @param meta Audio metadata.
+ * @param resampler Resampler instance used if resampling is required
+ * @param decode_scratch_mem Scratch memory used for decoding, when decoding can't be done directly to the output buffer.
+ *                           If downmixing or resampling is required, this buffer should have a positive length, representing
+ *                           decoded audio length at the original sampling rate: ``length * nchannels``
+ * @param resample_scratch_mem Scratch memory used for the input of resampling.
+ *                             If resampling is required, the buffer should have a positive length, representing the 
+ *                             decoded audio length, ``length`` if downmixing is enabled, or the decoded audio length including
+ *                             channels, ``length * nchannels``, otherwise.
+ * @param target_sample_rate If a positive value is provided, the signal will be resampled except when its original sampling rate
+ *                           is equal to the target.
+ * @param downmix If true, the audio channes will be downmixed to a single one
+ * @param audio_filepath Path to the audio file being decoded, only used for debugging purposes 
+ */
 template <typename T>
 DLL_PUBLIC void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio,
                             AudioDecoderBase &decoder, const AudioMetadata &meta,

--- a/dali/operators/decoder/audio/audio_decoder_impl_test.cc
+++ b/dali/operators/decoder/audio/audio_decoder_impl_test.cc
@@ -1,0 +1,56 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <utility>
+#include "dali/operators/decoder/audio/audio_decoder_impl.h"
+
+namespace dali {
+namespace test {
+
+TEST(AudioDecoderImpl, ProcessOffsetAndLength) {
+  int64_t start = 0;
+  int64_t total_length = static_cast<int64_t>(3.4 * 16000);
+  AudioMetadata meta{total_length, 16000, 1};  // 3.40s at 16kHz
+  {
+    int64_t offset = static_cast<int64_t>(0.5 * meta.sample_rate);
+    int64_t length = static_cast<int64_t>(1.0 * meta.sample_rate);
+    ASSERT_EQ(std::make_pair(offset, length), ProcessOffsetAndLength(meta, 0.5, 1.0));
+  }
+  {
+    ASSERT_EQ(std::make_pair(start, total_length), ProcessOffsetAndLength(meta, -1.0, 5.0));
+    ASSERT_EQ(std::make_pair(start, total_length), ProcessOffsetAndLength(meta, -1.0, -1.0));
+  }
+
+  {
+    int64_t offset = static_cast<int64_t>(2.0 * meta.sample_rate);
+    int64_t duration = total_length - offset;
+    ASSERT_EQ(std::make_pair(offset, duration), ProcessOffsetAndLength(meta, 2.0, 3.4));
+  }
+
+  {
+    int64_t offset = 0;
+    int64_t duration = static_cast<int64_t>(2.4 * meta.sample_rate);
+    ASSERT_EQ(std::make_pair(offset, duration), ProcessOffsetAndLength(meta, -1.0, 2.4));
+  }
+
+  {
+    int64_t offset = static_cast<int64_t>(0.45 * meta.sample_rate);
+    int64_t duration = total_length - offset;
+    ASSERT_EQ(std::make_pair(offset, duration), ProcessOffsetAndLength(meta, 0.45, -1.0));
+  }
+}
+
+}  // namespace test
+}  // namespace dali

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -63,10 +63,8 @@ AudioDecoderCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace
   files_names_.resize(batch_size);
 
   decode_type_ = use_resampling_ ? DALI_FLOAT : output_type_;
-  TYPE_SWITCH(decode_type_, type2id, DecoderOutputType, (int16_t, int32_t, float), (
-    for (int i = 0; i < batch_size; i++)
-      decoders_[i] = std::make_unique<GenericAudioDecoder<DecoderOutputType>>();
-  ), DALI_FAIL(make_string("Unsupported output type: ", decode_type_)))  // NOLINT
+  for (int i = 0; i < batch_size; i++)
+    decoders_[i] = make_generic_audio_decoder();
 
   output_desc.resize(2);
 
@@ -93,7 +91,7 @@ AudioDecoderCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace
   return true;
 }
 
-template<typename OutputType, typename DecoderOutputType>
+template<typename OutputType>
 void
 AudioDecoderCpu::DecodeSample(const TensorView<StorageCPU, OutputType, DynamicDimensions> &audio,
                               int thread_idx, int sample_idx) {
@@ -103,7 +101,7 @@ AudioDecoderCpu::DecodeSample(const TensorView<StorageCPU, OutputType, DynamicDi
   bool should_downmix = meta.channels > 1 && downmix_;
   int64_t decode_scratch_sz = 0;
   int64_t resample_scratch_sz = 0;
-  if (should_resample || should_downmix || !std::is_same<OutputType, DecoderOutputType>::value)
+  if (should_resample || should_downmix)
     decode_scratch_sz = meta.length * meta.channels;
 
   // resample scratch is used to prepare a single or multiple (depending if
@@ -114,20 +112,20 @@ AudioDecoderCpu::DecodeSample(const TensorView<StorageCPU, OutputType, DynamicDi
     resample_scratch_sz = meta.length * out_channels;
 
   auto &scratch_decoder = scratch_decoder_[thread_idx];
-  scratch_decoder.resize(decode_scratch_sz * sizeof(DecoderOutputType));
+  scratch_decoder.resize(decode_scratch_sz);
 
   auto &scratch_resampler = scratch_resampler_[thread_idx];
   scratch_resampler.resize(resample_scratch_sz);
 
-  DecodeAudio<OutputType, DecoderOutputType>(
+  DecodeAudio<OutputType>(
     audio, *decoders_[sample_idx], meta, resampler_,
-    {reinterpret_cast<DecoderOutputType*>(scratch_decoder.data()), decode_scratch_sz},
+    {scratch_decoder.data(), decode_scratch_sz},
     {scratch_resampler.data(), resample_scratch_sz},
     target_sr, downmix_,
     files_names_[sample_idx].c_str());
 }
 
-template <typename OutputType, typename DecoderOutputType>
+template <typename OutputType>
 void AudioDecoderCpu::DecodeBatch(workspace_t<Backend> &ws) {
   auto decoded_output = view<OutputType, DynamicDimensions>(ws.template OutputRef<Backend>(0));
   auto sample_rate_output = view<float, 0>(ws.template OutputRef<Backend>(1));
@@ -140,7 +138,7 @@ void AudioDecoderCpu::DecodeBatch(workspace_t<Backend> &ws) {
   for (int i = 0; i < batch_size; i++) {
     tp.AddWork([&, i](int thread_id) {
       try {
-        DecodeSample<OutputType, DecoderOutputType>(decoded_output[i], thread_id, i);
+        DecodeSample<OutputType>(decoded_output[i], thread_id, i);
         sample_rate_output[i].data[0] = use_resampling_
           ? target_sample_rates_[i]
           : sample_meta_[i].sample_rate;
@@ -156,9 +154,7 @@ void AudioDecoderCpu::DecodeBatch(workspace_t<Backend> &ws) {
 
 void AudioDecoderCpu::RunImpl(workspace_t<Backend> &ws) {
   TYPE_SWITCH(output_type_, type2id, OutputType, (int16_t, int32_t, float), (
-    TYPE_SWITCH(decode_type_, type2id, DecoderOutputType, (int16_t, int32_t, float), (
-      DecodeBatch<OutputType, DecoderOutputType>(ws);
-    ), DALI_FAIL(make_string("Unsupported decoder output type: ", decode_type_)))  // NOLINT
+    DecodeBatch<OutputType>(ws);
   ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
 }
 

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -68,17 +68,13 @@ AudioDecoderCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace
 
   output_desc.resize(2);
 
-  // Currently, metadata is only the sampling rate.
-  // On the event something else would emerge,
-  // this approach should be completely redefined
   TensorListShape<> shape_rate(batch_size, 0);
   TensorListShape<> shape_data(batch_size, downmix_ ? 1 : 2);
 
   for (int i = 0; i < batch_size; i++) {
-    auto meta = decoders_[i]->Open({reinterpret_cast<const char *>(input[i].raw_mutable_data()),
-                                    input[i].shape().num_elements()});
-    sample_meta_[i] = meta;
-    int64_t out_length = OutputLength(meta.length, meta.sample_rate, i);
+    auto &meta = sample_meta_[i] =
+        decoders_[i]->Open({reinterpret_cast<const char *>(input[i].raw_mutable_data()),
+                            input[i].shape().num_elements()});
     TensorShape<> data_sample_shape = DecodedAudioShape(
         meta, use_resampling_ ? target_sample_rates_[i] : -1.0f, downmix_);
     shape_data.set_tensor_shape(i, data_sample_shape);

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -107,9 +107,8 @@ AudioDecoderCpu::DecodeSample(const TensorView<StorageCPU, OutputType, DynamicDi
   // resample scratch is used to prepare a single or multiple (depending if
   // downmixing is needed) channel float input, required by the resampling
   // kernel
-  int64_t out_channels = should_downmix ? 1 : meta.channels;
   if (should_resample)
-    resample_scratch_sz = meta.length * out_channels;
+    resample_scratch_sz = should_downmix ? meta.length : meta.length * meta.channels;
 
   auto &scratch_decoder = scratch_decoder_[thread_idx];
   scratch_decoder.resize(decode_scratch_sz);

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -117,6 +117,8 @@ AudioDecoderCpu::DecodeSample(const TensorView<StorageCPU, OutputType, DynamicDi
   auto &scratch_resampler = scratch_resampler_[thread_idx];
   scratch_resampler.resize(resample_scratch_sz);
 
+  // TODO(janton): handle offset and duration
+
   DecodeAudio<OutputType>(
     audio, *decoders_[sample_idx], meta, resampler_,
     {scratch_decoder.data(), decode_scratch_sz},

--- a/dali/operators/decoder/audio/audio_decoder_op.h
+++ b/dali/operators/decoder/audio/audio_decoder_op.h
@@ -65,11 +65,11 @@ class AudioDecoderCpu : public Operator<CPUBackend> {
 
 
  private:
-  template<typename OutputType, typename DecoderOutputType>
+  template<typename OutputType>
   void DecodeSample(const TensorView<StorageCPU, OutputType, DynamicDimensions> &audio,
                     int thread_idx, int sample_idx);
 
-  template <typename OutputType, typename DecoderOutputType>
+  template <typename OutputType>
   void DecodeBatch(workspace_t<Backend> &ws);
 
   int64_t OutputLength(int64_t in_length, double in_rate, int sample_idx) const {
@@ -88,7 +88,7 @@ class AudioDecoderCpu : public Operator<CPUBackend> {
   const float quality_ = 50.0f;
   std::vector<std::string> files_names_;
   std::vector<AudioMetadata> sample_meta_;
-  std::vector<vector<uint8_t>> scratch_decoder_;
+  std::vector<vector<float>> scratch_decoder_;
   std::vector<vector<float>> scratch_resampler_;
   std::vector<std::unique_ptr<AudioDecoderBase>> decoders_;
 };

--- a/dali/operators/decoder/audio/audio_decoder_test.cc
+++ b/dali/operators/decoder/audio/audio_decoder_test.cc
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 #include <fstream>
 #include <string>
+#include <cstring>
 #include "dali/core/format.h"
 #include "dali/operators/decoder/audio/generic_decoder.h"
 #include "dali/test/dali_test_config.h"
@@ -60,7 +61,7 @@ bool CheckBuffers(const T *buf1, const T *buf2, int size) {
 
 TEST(AudioDecoderTest, WavDecoderTest) {
   using DataType = short;  // NOLINT
-  GenericAudioDecoder<DataType> decoder;
+  auto decoder = make_generic_audio_decoder();
 
   // Contains wav file to be decoded
   std::string wav_path = make_string(audio_data_root, "dziendobry.wav");
@@ -79,14 +80,37 @@ TEST(AudioDecoderTest, WavDecoderTest) {
            << "` to exist";
   }
 
-  auto meta = decoder.Open(make_cspan(bytes));
-  std::vector<DataType> output(meta.length * meta.channels);
-  decoder.DecodeTyped(make_span(output));
+  {
+    auto meta = decoder->Open(make_cspan(bytes));
+    EXPECT_EQ(meta.channels, expected_nchannels);
+    EXPECT_EQ(meta.channels_interleaved, true);
+    EXPECT_EQ(meta.sample_rate, expected_frequency);
+    decoder->Close();
+  }
 
-  EXPECT_EQ(meta.channels, expected_nchannels);
-  EXPECT_EQ(meta.channels_interleaved, true);
-  EXPECT_EQ(meta.sample_rate, expected_frequency);
-  EXPECT_PRED3(CheckBuffers<DataType>, output.data(), vec.data(), vec.size());
+  {
+    auto meta = decoder->Open(make_cspan(bytes));
+    std::vector<DataType> output(meta.length * meta.channels);
+    decoder->Decode(make_span(output));
+    EXPECT_PRED3(CheckBuffers<DataType>, output.data(), vec.data(), vec.size());
+  }
+
+  {
+    auto meta = decoder->Open(make_cspan(bytes));
+    std::vector<DataType> output(meta.length * meta.channels);
+    decoder->DecodeFrames(output.data(), meta.length);
+    EXPECT_PRED3(CheckBuffers<DataType>, output.data(), vec.data(), vec.size());
+  }
+
+  {
+    auto meta = decoder->Open(make_cspan(bytes));
+    int64_t offset = meta.length / 2;
+    int64_t length = meta.length - offset;
+    std::vector<DataType> output(length * meta.channels);
+    decoder->SeekFrames(offset, SEEK_CUR);
+    decoder->DecodeFrames(output.data(), length);
+    EXPECT_PRED3(CheckBuffers<DataType>, output.data(), vec.data() + offset * meta.channels, length * meta.channels);
+  }
 }
 
 }  // namespace dali

--- a/dali/operators/decoder/audio/generic_decoder.cc
+++ b/dali/operators/decoder/audio/generic_decoder.cc
@@ -15,13 +15,12 @@
 #include "dali/operators/decoder/audio/generic_decoder.h"
 #include <sndfile.h>
 #include <cassert>
-#include <string>
 #include <cstring>
 #include <memory>
 #include <string>
 #include <vector>
-#include "dali/core/format.h"
 #include "dali/core/error_handling.h"
+#include "dali/core/format.h"
 #include "dali/operators/decoder/audio/audio_decoder.h"
 
 namespace dali {
@@ -151,7 +150,7 @@ class GenericAudioDecoder : public AudioDecoderBase {
   };
 
   int64_t SeekFrames(int64_t nframes, int whence) override {
-    return sf_seek(sndfile_handle_, nframes, whence) ;
+    return sf_seek(sndfile_handle_, nframes, whence);
   }
 
   ptrdiff_t Decode(span<int16_t> output) override {

--- a/dali/operators/decoder/audio/generic_decoder.h
+++ b/dali/operators/decoder/audio/generic_decoder.h
@@ -15,42 +15,14 @@
 #ifndef DALI_OPERATORS_DECODER_AUDIO_GENERIC_DECODER_H_
 #define DALI_OPERATORS_DECODER_AUDIO_GENERIC_DECODER_H_
 
-#include <sndfile.h>
-#include <cassert>
-#include <cstring>
 #include <memory>
-#include <string>
-#include <vector>
-#include "dali/core/format.h"
-#include "dali/core/error_handling.h"
+#include "dali/core/api_helper.h"
 #include "dali/operators/decoder/audio/audio_decoder.h"
-
 
 namespace dali {
 
-/**
- * Generic decoder, that serves as a fallback to most of the formats we need.
- */
-template<typename SampleType>
-class DLL_PUBLIC GenericAudioDecoder : public TypedAudioDecoderBase<SampleType> {
- public:
-  DLL_PUBLIC GenericAudioDecoder();
+DLL_PUBLIC std::unique_ptr<AudioDecoderBase> make_generic_audio_decoder();
 
-  DLL_PUBLIC GenericAudioDecoder(GenericAudioDecoder&&);
-  DLL_PUBLIC GenericAudioDecoder& operator=(GenericAudioDecoder&&);
-
-  DLL_PUBLIC ptrdiff_t DecodeTyped(span<SampleType> output) override;
-
-  DLL_PUBLIC ~GenericAudioDecoder() override;
-
- private:
-  AudioMetadata OpenImpl(span<const char> encoded) override;
-  AudioMetadata OpenFromFileImpl(const std::string &filepath) override;
-  void CloseImpl() override;
-
-  struct Impl;
-  std::unique_ptr<Impl> impl_;
-};
 }  // namespace dali
 
 #endif  // DALI_OPERATORS_DECODER_AUDIO_GENERIC_DECODER_H_

--- a/dali/operators/reader/loader/nemo_asr_loader.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader.cc
@@ -138,7 +138,7 @@ void NemoAsrLoader::ReadAudio(Tensor<CPUBackend> &audio,
 
   int64_t decode_scratch_sz = 0;
   int64_t resample_scratch_sz = 0;
-  if (should_resample || should_downmix || dtype_ != DALI_INT16)
+  if (should_resample || should_downmix)
     decode_scratch_sz = audio_meta.length * audio_meta.channels;
 
   decode_scratch.resize(decode_scratch_sz);
@@ -151,6 +151,8 @@ void NemoAsrLoader::ReadAudio(Tensor<CPUBackend> &audio,
     resample_scratch_sz = audio_meta.length * out_channels;
 
   resample_scratch.resize(resample_scratch_sz);
+
+  // TODO(janton): handle offset and duration
 
   DecodeAudio<OutputType>(
     view<OutputType>(audio), decoder, audio_meta, resampler_,

--- a/dali/operators/reader/loader/nemo_asr_loader.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader.cc
@@ -137,19 +137,17 @@ void NemoAsrLoader::ReadAudio(Tensor<CPUBackend> &audio,
   bool should_downmix = audio_meta.channels > 1 && downmix_;
 
   int64_t decode_scratch_sz = 0;
-  int64_t resample_scratch_sz = 0;
   if (should_resample || should_downmix)
     decode_scratch_sz = audio_meta.length * audio_meta.channels;
-
   decode_scratch.resize(decode_scratch_sz);
 
   // resample scratch is used to prepare a single or multiple (depending if
   // downmixing is needed) channel float input, required by the resampling
   // kernel
-  int64_t out_channels = should_downmix ? 1 : audio_meta.channels;
+  int64_t resample_scratch_sz = 0;
   if (should_resample)
-    resample_scratch_sz = audio_meta.length * out_channels;
-
+    resample_scratch_sz =
+        should_downmix ? audio_meta.length : audio_meta.length * audio_meta.channels;
   resample_scratch.resize(resample_scratch_sz);
 
   // TODO(janton): handle offset and duration

--- a/dali/operators/reader/loader/nemo_asr_loader.h
+++ b/dali/operators/reader/loader/nemo_asr_loader.h
@@ -140,12 +140,12 @@ class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
   void Reset(bool wrap_to_shard) override;
 
  private:
-  template <typename OutputType, typename DecoderOutputType>
+  template <typename OutputType>
   void ReadAudio(Tensor<CPUBackend> &audio,
                  const AudioMetadata &audio_meta,
                  const NemoAsrEntry &entry,
                  AudioDecoderBase &decoder,
-                 std::vector<uint8_t> &decode_scratch,
+                 std::vector<float> &decode_scratch,
                  std::vector<float> &resample_scratch);
 
   std::vector<std::string> manifest_filepaths_;
@@ -164,7 +164,7 @@ class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
   bool normalize_text_;
   int num_threads_;
   kernels::signal::resampling::Resampler resampler_;
-  std::vector<std::vector<uint8_t>> decode_scratch_;
+  std::vector<std::vector<float>> decode_scratch_;
   std::vector<std::vector<float>> resample_scratch_;
 };
 

--- a/dali/operators/reader/loader/nemo_asr_loader.h
+++ b/dali/operators/reader/loader/nemo_asr_loader.h
@@ -33,10 +33,12 @@
 
 namespace dali {
 
+static constexpr double kDefaultDuration = -1.0;
+
 struct NemoAsrEntry {
   std::string audio_filepath;
-  float duration = 0.0;  // in seconds
-  float offset = 0.0;  // in seconds, optional
+  double duration = kDefaultDuration;  // in seconds, optional
+  double offset = 0.0;  // in seconds, optional
   std::string text;  // transcription
 };
 
@@ -86,7 +88,8 @@ class AsrSample {
 namespace detail {
 
 DLL_PUBLIC void ParseManifest(std::vector<NemoAsrEntry> &entries, std::istream &manifest_file,
-                              float min_duration = 0.0f, float max_duration = 0.0f,
+                              double min_duration = kDefaultDuration,
+                              double max_duration = kDefaultDuration,
                               bool normalize_text = false);
 
 }  // namespace detail
@@ -160,7 +163,7 @@ class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
   float quality_;
   bool downmix_;
   DALIDataType dtype_;
-  float max_duration_;
+  double max_duration_;
   bool normalize_text_;
   int num_threads_;
   kernels::signal::resampling::Resampler resampler_;


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It adds new feature needed to do partial decoding of audio files
- Refactoring to improve usability of Audio Decoder

#### What happened in this PR?
 - What solution was applied:
     *Make AudioDecoderBase instances type-agnostic. Decode function is overloaded to decode to different types*
     *Added SeekFrames to allow for partial decoding*
     *Added handling of offset and duration in audio_decoder_impl.cc*
     *Adjusted usage of audio decoder in AudioDecoder operator and NemoAsrReader*
 - Affected modules and functionalities:
     *AudioDecoder operator and NemoAsrReader*
 - Key points relevant for the review:
     *Design changes*
 - Validation and testing:
     *Tests added*
 - Documentation (including examples):
     *Docstr*


**JIRA TASK**: *[DALI-1634]*
**JIRA TASK**: *[DALI-1567]*
