### PR TITLE
Fix error when VideoReader is prematurely terminated

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -687,14 +687,10 @@ void VideoLoader::receive_frames(SequenceWrapper& sequence) {
     frames_since_warn = 0;
     frames_used_warned = true;
     LOG_LINE << "\e[1mThe video loader is performing suboptimally due to reading "
-                << std::setprecision(2) << ratio_used << "x as many packets as "
-                << "frames being used.\e[0m  Consider reencoding the video with a "
-                << "smaller key frame interval (GOP length).";
+             << std::setprecision(2) << ratio_used << "x as many packets as "
+             << "frames being used.\e[0m  Consider reencoding the video with a "
+             << "smaller key frame interval (GOP length).";
   }
-  // We have to wait for all kernel recorded in sequence's event are completed
-  LOG_LINE << "Waiting for sequence..";
-  sequence.wait();
-  LOG_LINE << ".got sequence\n";
 }
 
 void VideoLoader::PrepareEmpty(SequenceWrapper &tensor) {}

--- a/dali/operators/reader/nvdecoder/sequencewrapper.h
+++ b/dali/operators/reader/nvdecoder/sequencewrapper.h
@@ -48,9 +48,7 @@ struct SequenceWrapper {
     timestamps.reserve(count);
 
     if (!event_) {
-      int dev;
-      CUDA_CALL(cudaGetDevice(&dev));
-      event_ = CUDAEvent::CreateWithFlags(cudaEventBlockingSync | cudaEventDisableTiming, dev);
+      event_ = CUDAEvent::CreateWithFlags(cudaEventBlockingSync | cudaEventDisableTiming);
     }
   }
 
@@ -83,11 +81,11 @@ struct SequenceWrapper {
   int label = -1;
   vector<double> timestamps;
   int first_frame_idx = -1;
-  DALIDataType dtype = {};
+  DALIDataType dtype = DALI_NO_TYPE;
   std::function<void(void)> read_sample_f;
 
  private:
-  CUDAEvent event_ = {};
+  CUDAEvent event_;
 };
 
 }  // namespace dali

--- a/dali/operators/reader/nvdecoder/sequencewrapper.h
+++ b/dali/operators/reader/nvdecoder/sequencewrapper.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "dali/core/common.h"
+#include "dali/core/cuda_event.h"
 #include "dali/core/static_switch.h"
 #include "dali/core/error_handling.h"
 #include "dali/pipeline/operator/argument.h"
@@ -34,8 +35,7 @@ namespace dali {
 // Struct that Loader::ReadOne will read
 struct SequenceWrapper {
  public:
-  SequenceWrapper()
-  : started_(false) {}
+  SequenceWrapper() = default;
 
   void initialize(int count, int height, int width, int channels, DALIDataType dtype) {
     this->count = count;
@@ -47,44 +47,23 @@ struct SequenceWrapper {
     timestamps.clear();
     timestamps.reserve(count);
 
-    int dev;
-    CUDA_CALL(cudaGetDevice(&dev));
-    std::unique_lock<std::mutex> lock{started_lock_};
-    if (started_) {
-      CUDA_CALL(cudaEventDestroy(event_));
-    }
-    CUDA_CALL(cudaEventCreateWithFlags(&event_, cudaEventBlockingSync | cudaEventDisableTiming));
-    started_ = false;
-  }
-
-  ~SequenceWrapper() {
-    std::unique_lock<std::mutex> lock{started_lock_};
-    if (started_) {
-      try {
-        CUDA_CALL(cudaEventDestroy(event_));
-      } catch (const std::exception &) {
-        // Something went wrong with releasing resources. We'd better die now.
-        std::terminate();
-      }
+    if (!event_) {
+      int dev;
+      CUDA_CALL(cudaGetDevice(&dev));
+      event_ = CUDAEvent::CreateWithFlags(cudaEventBlockingSync | cudaEventDisableTiming, dev);
     }
   }
 
   void set_started(cudaStream_t stream) {
     CUDA_CALL(cudaEventRecord(event_, stream));
-    LOG_LINE << event_ << " recorded with stream " << stream << std::endl;
-    {
-      std::unique_lock<std::mutex> lock{started_lock_};
-      started_ = true;
-    }
-    started_cv_.notify_one();
   }
 
   void wait() const {
-    LOG_LINE << event_ << " wait to start" << std::endl;
-    wait_until_started_();
-    LOG_LINE << event_ << " waiting for sequence event" << std::endl;
-    CUDA_CALL(cudaEventSynchronize(event_));
-    LOG_LINE << event_ << " synchronized!" << std::endl;
+    if (event_) {
+      LOG_LINE << event_ << " waiting for sequence event" << std::endl;
+      CUDA_CALL(cudaEventSynchronize(event_));
+      LOG_LINE << event_ << " synchronized!" << std::endl;
+    }
   }
 
   TensorShape<3> frame_shape() const {
@@ -97,26 +76,18 @@ struct SequenceWrapper {
 
   Tensor<GPUBackend> sequence;
 
-  int count;
-  int height;
-  int width;
-  int channels;
-  int label;
+  int count = -1;
+  int height = -1;
+  int width = -1;
+  int channels = -1;
+  int label = -1;
   vector<double> timestamps;
-  int first_frame_idx;
-  DALIDataType dtype;
+  int first_frame_idx = -1;
+  DALIDataType dtype = {};
   std::function<void(void)> read_sample_f;
 
  private:
-  void wait_until_started_() const {
-    std::unique_lock<std::mutex> lock{started_lock_};
-    started_cv_.wait(lock, [&](){return started_;});
-  }
-
-  mutable std::mutex started_lock_;
-  mutable std::condition_variable started_cv_;
-  cudaEvent_t event_;
-  bool started_;
+  CUDAEvent event_ = {};
 };
 
 }  // namespace dali

--- a/dali/operators/reader/video_reader_op.h
+++ b/dali/operators/reader/video_reader_op.h
@@ -85,7 +85,10 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
   }
 
   inline ~VideoReader() {
-    // when this destructor is called some kernels can still be scheduled to work on the meory
+    // stop prefetching so we are not scheduling any more work from here on so we are safe to remove
+    // the underlying memory
+    DataReader<GPUBackend, SequenceWrapper>::StopPrefetchThread();
+    // when this destructor is called some kernels can still be scheduled to work on the memory
     // that is present in the prefetched_batch_tensors_
     // prefetched_batch_queue_ keeps the relevant cuda events recorded that are associated with
     // this memory. Calling wait makes sure that no more work is pending and we can free the GPU

--- a/dali/operators/reader/video_reader_op_test.cc
+++ b/dali/operators/reader/video_reader_op_test.cc
@@ -269,7 +269,7 @@ TEST_F(VideoReaderTest, Vp9Profile2) {
   Pipeline pipe(1, 1, 0);
   const int sequence_length = 60;
   const string unsupported_exception_msg = "Decoder hardware does not support this video codec"
-                                          " and/or chroma format";
+                                           " and/or chroma format";
 
   pipe.AddOperator(
     OpSpec("VideoReader")


### PR DESCRIPTION
- simplifies the SequenceWrapper by removing unnecessary locking
- removes the false assumption that SequenceWrapper is thread-safe
- make sure that no prefetching is happening when VideoReader ends, and no memory access happens to the underlying VideoReader memory

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes problem in hand in VideoReader destructor when there is an error

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     simplifies the SequenceWrapper by removing unnecessary locking
     removes the false assumption that SequenceWrapper is thread-safe
     make sure that no prefetching is happening when VideoReader ends, and no memory access happens to the underlying VideoReader memory
 - Affected modules and functionalities:
     VideoReader
     SequenceWrapper
 - Key points relevant for the review:
     SequenceWrapper changes
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
