### PR TITLE
Fix the test failure in affine transforms generators

### DIFF
--- a/dali/test/python/test_operator_affine_transforms.py
+++ b/dali/test/python/test_operator_affine_transforms.py
@@ -357,7 +357,7 @@ def check_combine_transforms(num_transforms = 2, ndim = 2, reverse_order = False
         for mat in mats:
             ref_mat = np.dot(mat, ref_mat)
 
-        assert np.allclose(outs[0].at(idx), ref_mat[:ndim,:], rtol=1e-5)
+        assert np.allclose(outs[0].at(idx), ref_mat[:ndim,:], atol=1e-6)
 
 def test_combine_transforms(batch_size=3, num_threads=4, device_id=0):
     for num_transforms in [2, 3, 10]:
@@ -379,5 +379,5 @@ def test_combine_transforms_correct_order(batch_size=3, num_threads=4, device_id
     pipe.build()
     outs = pipe.run()
     for idx in range(batch_size):
-        assert np.allclose(outs[0].at(idx), outs[1].at(idx), rtol=1e-5)
-        assert np.allclose(outs[2].at(idx), outs[3].at(idx), rtol=1e-5)
+        assert np.allclose(outs[0].at(idx), outs[1].at(idx), atol=1e-6)
+        assert np.allclose(outs[2].at(idx), outs[3].at(idx), atol=1e-6)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It fixes a failing test in arm.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Switched from rtol to atol
 - Affected modules and functionalities:
     transforms.combine_transforms tests
 - Key points relevant for the review:
     N/A 
- Validation and testing:
     N/A
 - Documentation (including examples):
     N/A


**JIRA TASK**: *[Use DALI-XXXX or NA]*
