### PR TITLE
Use inverse (source-to-destination) matrix in WarpAffine operator

### DIFF
--- a/dali/core/geom_mat_test.cu
+++ b/dali/core/geom_mat_test.cu
@@ -450,6 +450,10 @@ TEST(MatTest, SolveGauss) {
 }
 
 TEST(MatTest, Inverse) {
+  #define EXPECT_MAT_EQ(m1, m2) \
+  for (int r = 0; r < m1.rows; ++r)  \
+    for (int c = 0; c < m1.cols; ++c)  \
+      EXPECT_FLOAT_EQ(m1(r, c), m2(r, c));
   mat2 two_by_two = {{
     {3, 5},
     {4, 7}
@@ -471,6 +475,69 @@ TEST(MatTest, Inverse) {
     {-1,  1,  0}
   }};
   EXPECT_EQ(inverse(three_by_three), inv3x3);
+
+  mat3 three_by_three2 = {{
+    {1, 5, 7},
+    {1, 3, 6},
+    {2, 4, 1}
+  }};
+
+  mat3 inv3x3_2 = {{
+    {-1.05,  1.15, 0.45},
+    { 0.55, -0.65, 0.05},
+    {-0.1,   0.3, -0.1 }
+  }};
+  EXPECT_MAT_EQ(inverse(three_by_three2), inv3x3_2);
+}
+
+DEVICE_TEST(MatTest, DevInverse, 1, 1) {
+  #define DEV_EXPECT_MAT_EQ(m1, m2) \
+  for (int r = 0; r < m1.rows; ++r)  \
+    for (int c = 0; c < m1.cols; ++c)  \
+      DEV_EXPECT_LT(abs(m1(r, c) - m2(r, c)), 1e-6f);
+
+  mat2 two_by_two = {{
+    {3, 5},
+    {4, 7}
+  }};
+  mat2 inv2x2 = {{
+    {7, -5},
+    {-4, 3}
+  }};
+  DEV_EXPECT_MAT_EQ(inverse(two_by_two), inv2x2);
+
+  mat3 three_by_three = {{
+    {0.5, 0.5, 0  },
+    {0.5, 0.5, 1  },
+    {0.5, 0,   0.5}
+  }};
+  mat3 inv3x3 = {{
+    { 1, -1,  2},
+    { 1,  1, -2},
+    {-1,  1,  0}
+  }};
+  DEV_EXPECT_MAT_EQ(inverse(three_by_three), inv3x3);
+
+  mat3 three_by_three2 = {{
+    {1, 5, 7},
+    {1, 3, 6},
+    {2, 4, 1}
+  }};
+
+  mat3 inv3x3_2 = {{
+    {-1.05,  1.15, 0.45},
+    { 0.55, -0.65, 0.05},
+    {-0.1,   0.3, -0.1 }
+  }};
+  DEV_EXPECT_MAT_EQ(inverse(three_by_three2), inv3x3_2);
+}
+
+TEST(MatTest, InverseFail) {
+  mat2 m = {{
+    {1, 2},
+    {1, 2}
+  }};
+  EXPECT_THROW(inverse(m), std::range_error);
 }
 
 TEST(MatTest, Print) {

--- a/dali/core/geom_mat_test.cu
+++ b/dali/core/geom_mat_test.cu
@@ -431,6 +431,48 @@ TEST(MatTest, IdentityMatrix) {
   EXPECT_EQ(m3, three_by_two);
 }
 
+TEST(MatTest, SolveGauss) {
+  mat4 system_l = {{
+    {0, 1, 2, 1},
+    {1, 0, 1, 0},
+    {1, 1, 0, 1},
+    {1, 1, 1, 0}
+  }};
+  mat4x1 system_r = {{
+    {3}, {3}, {3}, {3}
+  }};
+  const mat4x1 solution = {{
+    {2}, {0}, {1}, {1}
+  }};
+  solve_gauss(system_l, system_r);
+  EXPECT_EQ(system_l, mat4::eye());
+  EXPECT_EQ(system_r, solution);
+}
+
+TEST(MatTest, Inverse) {
+  mat2 two_by_two = {{
+    {3, 5},
+    {4, 7}
+  }};
+  mat2 inv2x2 = {{
+    {7, -5},
+    {-4, 3}
+  }};
+  EXPECT_EQ(inverse(two_by_two), inv2x2);
+
+  mat3 three_by_three = {{
+    {0.5, 0.5, 0  },
+    {0.5, 0.5, 1  },
+    {0.5, 0,   0.5}
+  }};
+  mat3 inv3x3 = {{
+    { 1, -1,  2},
+    { 1,  1, -2},
+    {-1,  1,  0}
+  }};
+  EXPECT_EQ(inverse(three_by_three), inv3x3);
+}
+
 TEST(MatTest, Print) {
   mat4x3 m = {{
     { 1, 2, 3 },

--- a/dali/kernels/imgproc/warp/affine.h
+++ b/dali/kernels/imgproc/warp/affine.h
@@ -34,7 +34,7 @@ struct AffineMapping {
   }
 
   DALI_HOST_DEV
-  AffineMapping invert() const {
+  AffineMapping inv() const {
     return AffineMapping<dim>(affine_mat_inv(transform));;
   }
 };

--- a/dali/kernels/imgproc/warp/affine.h
+++ b/dali/kernels/imgproc/warp/affine.h
@@ -32,6 +32,11 @@ struct AffineMapping {
   inline vec<dim> operator()(const vec<dim> &v) const {
     return affine(transform, v);
   }
+
+  DALI_HOST_DEV
+  AffineMapping invert() const {
+    return AffineMapping<dim>(affine_mat_inv(transform));;
+  }
 };
 
 using AffineMapping2D = AffineMapping<2>;

--- a/dali/operators/image/remap/warp_affine.cc
+++ b/dali/operators/image/remap/warp_affine.cc
@@ -23,15 +23,22 @@ DALI_SCHEMA(WarpAffine)
   .InputLayout(0, { "HWC", "DHWC" })
   .SupportVolumetric()
   .AddOptionalArg<float>("matrix",
-      R"code(Transform matrix (dst -> src).
+      R"code(Transform matrix.
 
+When the ``inverse_map`` option is set to true (default), the matrix represents a destination to source mapping. 
 With a list of values ``(M11, M12, M13, M21, M22, M23)``, this operation produces a new image
 by using the following formula::
 
   dst(x,y) = src(M11 * x + M12 * y + M13, M21 * x + M22 * y + M23)
 
-It is equivalent to OpenCV's ``warpAffine`` operation with the ``WARP_INVERSE_MAP`` flag set.)code",
+If the ``inverse_map`` option is set to false, the matrix represents a source to destination 
+transform and it is inverted before applying to the formula above.
+
+It is equivalent to OpenCV's ``warpAffine`` operation with the ``inverse_map`` argument being 
+analog to the ``WARP_INVERSE_MAP`` flag.)code",
       vector<float>(), true)
+  .AddOptionalArg<bool>("inverse_map", "Set to ``False`` if the given transform is a "
+                        "destination to source mapping, ``True`` otherwise.", false, true)
   .AddParent("WarpAttr");
 
 DALI_REGISTER_OPERATOR(WarpAffine, WarpAffine<CPUBackend>, CPU);

--- a/dali/operators/image/remap/warp_affine.cc
+++ b/dali/operators/image/remap/warp_affine.cc
@@ -38,7 +38,7 @@ It is equivalent to OpenCV's ``warpAffine`` operation with the ``inverse_map`` a
 analog to the ``WARP_INVERSE_MAP`` flag.)code",
       vector<float>(), true)
   .AddOptionalArg<bool>("inverse_map", "Set to ``False`` if the given transform is a "
-                        "destination to source mapping, ``True`` otherwise.", false, true)
+                        "destination to source mapping, ``True`` otherwise.", true, false)
   .AddParent("WarpAttr");
 
 DALI_REGISTER_OPERATOR(WarpAffine, WarpAffine<CPUBackend>, CPU);

--- a/dali/operators/image/remap/warp_affine_params.cu
+++ b/dali/operators/image/remap/warp_affine_params.cu
@@ -1,0 +1,51 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/image/remap/warp_affine_params.h"
+#include <cuda_runtime.h>
+
+namespace dali {
+namespace {
+
+template <int ndims>
+__global__ void InvertTransformsK(WarpAffineParams<ndims> *output,
+                                  const WarpAffineParams<ndims> *input, int count) {
+  for (auto i = blockIdx.x * blockDim.x + threadIdx.x; i < count; i += blockDim.x * gridDim.x)
+    output[i] = input[i].invert();
+}
+
+template <int ndims>
+void InvertTransforms(WarpAffineParams<ndims> *output, const WarpAffineParams<ndims> *input,
+                      int count, cudaStream_t stream) {
+  auto blocks = div_ceil(count, 512);
+  auto threads = count < 512 ? count : 512;
+  InvertTransformsK<ndims><<<blocks, threads, 0, stream>>>(output, input, count);
+}
+
+}  // namespace
+
+
+template <>
+void InvertTransformsGPU<2>(WarpAffineParams<2> *output, const WarpAffineParams<2> *input,
+                         int count, cudaStream_t stream) {
+  InvertTransforms<2>(output, input, count, stream);
+}
+
+template <>
+void InvertTransformsGPU<3>(WarpAffineParams<3> *output, const WarpAffineParams<3> *input,
+                         int count, cudaStream_t stream) {
+  InvertTransforms<3>(output, input, count, stream);
+}
+
+}  // namespace dali

--- a/dali/operators/image/remap/warp_affine_params.cu
+++ b/dali/operators/image/remap/warp_affine_params.cu
@@ -19,18 +19,18 @@ namespace dali {
 namespace {
 
 template <int ndims>
-__global__ void InvertTransformsK(WarpAffineParams<ndims> *output,
-                                  const WarpAffineParams<ndims> *input, int count) {
-  for (auto i = blockIdx.x * blockDim.x + threadIdx.x; i < count; i += blockDim.x * gridDim.x)
-    output[i] = input[i].invert();
+__global__ void InvertTransformsKernel(WarpAffineParams<ndims> *output,
+                                       const WarpAffineParams<ndims> *input, int count) {
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < count; i += blockDim.x * gridDim.x)
+    output[i] = input[i].inv();
 }
 
 template <int ndims>
 void InvertTransforms(WarpAffineParams<ndims> *output, const WarpAffineParams<ndims> *input,
                       int count, cudaStream_t stream) {
-  auto blocks = div_ceil(count, 512);
-  auto threads = count < 512 ? count : 512;
-  InvertTransformsK<ndims><<<blocks, threads, 0, stream>>>(output, input, count);
+  int blocks = div_ceil(count, 512);
+  int threads = std::min(count, 512);
+  InvertTransformsKernel<ndims><<<blocks, threads, 0, stream>>>(output, input, count);
 }
 
 }  // namespace
@@ -38,13 +38,13 @@ void InvertTransforms(WarpAffineParams<ndims> *output, const WarpAffineParams<nd
 
 template <>
 void InvertTransformsGPU<2>(WarpAffineParams<2> *output, const WarpAffineParams<2> *input,
-                         int count, cudaStream_t stream) {
+                            int count, cudaStream_t stream) {
   InvertTransforms<2>(output, input, count, stream);
 }
 
 template <>
 void InvertTransformsGPU<3>(WarpAffineParams<3> *output, const WarpAffineParams<3> *input,
-                         int count, cudaStream_t stream) {
+                            int count, cudaStream_t stream) {
   InvertTransforms<3>(output, input, count, stream);
 }
 

--- a/dali/operators/image/remap/warp_affine_params.h
+++ b/dali/operators/image/remap/warp_affine_params.h
@@ -73,7 +73,8 @@ class WarpAffineParamProvider
       for (int i = 0; i < spatial_ndim; i++)
         for (int j = 0; j < spatial_ndim+1; j++, k++)
           M.transform(i, j) = matrix[k];
-      if (invert) M = M.invert();
+      if (invert)
+        M = M.inv();
       auto *params = this->AllocParams(kernels::AllocType::Host);
       for (int i = 0; i < num_samples_; i++)
         params[i] = M;
@@ -121,8 +122,7 @@ class WarpAffineParamProvider
     if (invert) {
       auto *params = this->AllocParams(kernels::AllocType::Host);
       for (int i = 0; i < num_samples_; i++) {
-        if (invert)
-          params[i] = static_cast<const MappingParams *>(input.raw_tensor(i))->invert();
+        params[i] = static_cast<const MappingParams *>(input.raw_tensor(i))->inv();
       }
     } else {
       params_cpu_.data = static_cast<const MappingParams *>(input.raw_data());
@@ -141,7 +141,7 @@ class WarpAffineParamProvider
       auto *params = this->AllocParams(kernels::AllocType::Host);
       for (int i = 0; i < num_samples_; i++) {
         if (invert)
-          params[i] = static_cast<const MappingParams *>(input[i].raw_data())->invert();
+          params[i] = static_cast<const MappingParams *>(input[i].raw_data())->inv();
         else
           params[i] = *static_cast<const MappingParams *>(input[i].raw_data());
       }

--- a/dali/test/python/test_operator_warp.py
+++ b/dali/test/python/test_operator_warp.py
@@ -25,9 +25,12 @@ import cv2
 from test_utils import check_batch
 from test_utils import compare_pipelines
 from test_utils import RandomDataIterator
+import random
 
 test_data_root = os.environ['DALI_EXTRA_PATH']
 caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
+
+random.seed(1009)
 
 def gen_transform(angle, zoom, dst_cx, dst_cy, src_cx, src_cy):
     t1 = np.array([[1, 0, -dst_cx], [0, 1, -dst_cy], [0, 0, 1]])
@@ -56,14 +59,14 @@ def ToCVMatrix(matrix):
   result[1][2] = offset[1] - 0.5
   return result
 
-def CVWarp(output_type, input_type, warp_matrix = None, inverted = False):
+def CVWarp(output_type, input_type, warp_matrix = None, inv_map = False):
   def warp_fn(img, matrix):
     size = (320, 240)
     matrix = ToCVMatrix(matrix)
     if output_type == dali.types.FLOAT or input_type == dali.types.FLOAT:
       img = np.float32(img)
     out = cv2.warpAffine(img, matrix, size, borderMode = cv2.BORDER_CONSTANT, borderValue = [42,42,42],
-      flags = (cv2.INTER_LINEAR|cv2.WARP_INVERSE_MAP) if inverted else cv2.INTER_LINEAR);
+      flags = (cv2.INTER_LINEAR|cv2.WARP_INVERSE_MAP) if inv_map else cv2.INTER_LINEAR);
     if output_type == dali.types.UINT8 and input_type == dali.types.FLOAT:
       out = np.uint8(np.clip(out, 0, 255))
     return out
@@ -78,7 +81,7 @@ def CVWarp(output_type, input_type, warp_matrix = None, inverted = False):
 
 
 class WarpPipeline(Pipeline):
-    def __init__(self, device, batch_size, output_type, input_type, use_input, num_threads=3, device_id=0, num_gpus=1, inverted=False):
+    def __init__(self, device, batch_size, output_type, input_type, use_input, num_threads=3, device_id=0, num_gpus=1, inv_map=False):
         super(WarpPipeline, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=False, exec_pipelined=False)
         self.use_input = use_input
         self.use_dynamic_size = use_input  # avoid Cartesian product
@@ -94,10 +97,10 @@ class WarpPipeline(Pipeline):
 
         if use_input:
           self.transform_source = ops.ExternalSource(lambda: gen_transforms(self.batch_size, 10))
-          self.warp = ops.WarpAffine(device = device, size=static_size, fill_value = 42, dtype = output_type, inverse_map=inverted)
+          self.warp = ops.WarpAffine(device = device, size=static_size, fill_value = 42, dtype = output_type, inverse_map=inv_map)
         else:
           warp_matrix = (0.1, 0.9, 10, 0.8, -0.2, -20)
-          self.warp = ops.WarpAffine(device = device, size=static_size, matrix = warp_matrix, fill_value = 42, dtype = output_type, inverse_map=inverted)
+          self.warp = ops.WarpAffine(device = device, size=static_size, matrix = warp_matrix, fill_value = 42, dtype = output_type, inverse_map=inv_map)
 
         self.iter = 0
 
@@ -120,7 +123,7 @@ class WarpPipeline(Pipeline):
 
 
 class CVPipeline(Pipeline):
-    def __init__(self, batch_size, output_type, input_type, use_input, num_threads=3, device_id=0, num_gpus=1, inverted=False):
+    def __init__(self, batch_size, output_type, input_type, use_input, num_threads=3, device_id=0, num_gpus=1, inv_map=False):
         super(CVPipeline, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=False, exec_pipelined=False)
         self.use_input = use_input
         self.name = "cv"
@@ -128,9 +131,9 @@ class CVPipeline(Pipeline):
         self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
         if self.use_input:
           self.transform_source = ops.ExternalSource(lambda: gen_transforms(self.batch_size, 10))
-          self.warp = ops.PythonFunction(function=CVWarp(output_type, input_type, inverted=inverted))
+          self.warp = ops.PythonFunction(function=CVWarp(output_type, input_type, inv_map=inv_map))
         else:
-          self.warp = ops.PythonFunction(function=CVWarp(output_type, input_type, [[0.1, 0.9, 10], [0.8, -0.2, -20]], inverted))
+          self.warp = ops.PythonFunction(function=CVWarp(output_type, input_type, [[0.1, 0.9, 10], [0.8, -0.2, -20]], inv_map))
         self.set_layout = ops.Reshape(layout="HWC")
         self.iter = 0
 
@@ -163,53 +166,55 @@ def test_cpu_vs_cv():
   for batch_size in [1, 4, 19]:
     for use_input in [False, True]:
       for (itype, otype) in io_types:
-        for inverted in [False, True]:
-          print("Testing cpu vs cv",
-                "\nbatch size: ", batch_size,
-                " matrix as input: ", use_input,
-                " input_type: ", itype,
-                " output_type: ", otype,
-                " map_inverse:", inverted)
-          cv_pipeline = CVPipeline(batch_size, otype, itype, use_input, inverted=inverted);
-          cv_pipeline.build();
+        inv_map = random.choice([False, True])
+        print("Testing cpu vs cv",
+              "\nbatch size: ", batch_size,
+              " matrix as input: ", use_input,
+              " input_type: ", itype,
+              " output_type: ", otype,
+              " map_inverse:", inv_map)
+        cv_pipeline = CVPipeline(batch_size, otype, itype, use_input, inv_map=inv_map);
+        cv_pipeline.build();
 
-          cpu_pipeline = WarpPipeline("cpu", batch_size, otype, itype, use_input, inverted=inverted);
-          cpu_pipeline.build();
+        cpu_pipeline = WarpPipeline("cpu", batch_size, otype, itype, use_input, inv_map=inv_map);
+        cpu_pipeline.build();
 
-          compare(cv_pipeline, cpu_pipeline, 8)
+        compare(cv_pipeline, cpu_pipeline, 8)
 
 def test_gpu_vs_cv():
   for batch_size in [1, 4, 19]:
     for use_input in [False, True]:
       for (itype, otype) in io_types:
-        for inverted in [False, True]:
-          print("Testing gpu vs cv",
-                "\nbatch size: ", batch_size,
-                " matrix as input: ", use_input,
-                " input_type: ", itype,
-                " output_type: ", otype,
-                " map_inverse:", inverted)
-          cv_pipeline = CVPipeline(batch_size, otype, itype, use_input, inverted=inverted);
-          cv_pipeline.build();
+        inv_map = random.choice([False, True])
+        print("Testing gpu vs cv",
+              "\nbatch size: ", batch_size,
+              " matrix as input: ", use_input,
+              " input_type: ", itype,
+              " output_type: ", otype,
+              " map_inverse:", inv_map)
+        cv_pipeline = CVPipeline(batch_size, otype, itype, use_input, inv_map=inv_map);
+        cv_pipeline.build();
 
-          gpu_pipeline = WarpPipeline("gpu", batch_size, otype, itype, use_input, inverted=inverted);
-          gpu_pipeline.build();
+        gpu_pipeline = WarpPipeline("gpu", batch_size, otype, itype, use_input, inv_map=inv_map);
+        gpu_pipeline.build();
 
-          compare(cv_pipeline, gpu_pipeline, 8)
+        compare(cv_pipeline, gpu_pipeline, 8)
 
 def test_gpu_vs_cpu():
   for batch_size in [1, 4, 19]:
     for use_input in [False, True]:
       for (itype, otype) in io_types:
+        inv_map = random.choice([False, True])
         print("Testing gpu vs cpu",
               "\nbatch size: ", batch_size,
               " matrix as input: ", use_input,
               " input_type: ", itype,
-              " output_type: ", otype)
-        cpu_pipeline = WarpPipeline("cpu", batch_size, otype, itype, use_input);
+              " output_type: ", otype,
+              " map_inverse:", inv_map)
+        cpu_pipeline = WarpPipeline("cpu", batch_size, otype, itype, use_input, inv_map=inv_map);
         cpu_pipeline.build();
 
-        gpu_pipeline = WarpPipeline("gpu", batch_size, otype, itype, use_input);
+        gpu_pipeline = WarpPipeline("gpu", batch_size, otype, itype, use_input, inv_map=inv_map);
         gpu_pipeline.build();
 
         compare(cpu_pipeline, gpu_pipeline, 1)

--- a/dali/test/python/test_operator_warp.py
+++ b/dali/test/python/test_operator_warp.py
@@ -56,14 +56,14 @@ def ToCVMatrix(matrix):
   result[1][2] = offset[1] - 0.5
   return result
 
-def CVWarp(output_type, input_type, warp_matrix = None):
+def CVWarp(output_type, input_type, warp_matrix = None, inverted = False):
   def warp_fn(img, matrix):
     size = (320, 240)
     matrix = ToCVMatrix(matrix)
     if output_type == dali.types.FLOAT or input_type == dali.types.FLOAT:
       img = np.float32(img)
     out = cv2.warpAffine(img, matrix, size, borderMode = cv2.BORDER_CONSTANT, borderValue = [42,42,42],
-      flags = (cv2.INTER_LINEAR|cv2.WARP_INVERSE_MAP));
+      flags = (cv2.INTER_LINEAR|cv2.WARP_INVERSE_MAP) if inverted else cv2.INTER_LINEAR);
     if output_type == dali.types.UINT8 and input_type == dali.types.FLOAT:
       out = np.uint8(np.clip(out, 0, 255))
     return out
@@ -78,7 +78,7 @@ def CVWarp(output_type, input_type, warp_matrix = None):
 
 
 class WarpPipeline(Pipeline):
-    def __init__(self, device, batch_size, output_type, input_type, use_input, num_threads=3, device_id=0, num_gpus=1):
+    def __init__(self, device, batch_size, output_type, input_type, use_input, num_threads=3, device_id=0, num_gpus=1, inverted=False):
         super(WarpPipeline, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=False, exec_pipelined=False)
         self.use_input = use_input
         self.use_dynamic_size = use_input  # avoid Cartesian product
@@ -94,10 +94,10 @@ class WarpPipeline(Pipeline):
 
         if use_input:
           self.transform_source = ops.ExternalSource(lambda: gen_transforms(self.batch_size, 10))
-          self.warp = ops.WarpAffine(device = device, size=static_size, fill_value = 42, dtype = output_type)
+          self.warp = ops.WarpAffine(device = device, size=static_size, fill_value = 42, dtype = output_type, inverse_map=inverted)
         else:
           warp_matrix = (0.1, 0.9, 10, 0.8, -0.2, -20)
-          self.warp = ops.WarpAffine(device = device, size=static_size, matrix = warp_matrix, fill_value = 42, dtype = output_type)
+          self.warp = ops.WarpAffine(device = device, size=static_size, matrix = warp_matrix, fill_value = 42, dtype = output_type, inverse_map=inverted)
 
         self.iter = 0
 
@@ -120,7 +120,7 @@ class WarpPipeline(Pipeline):
 
 
 class CVPipeline(Pipeline):
-    def __init__(self, batch_size, output_type, input_type, use_input, num_threads=3, device_id=0, num_gpus=1):
+    def __init__(self, batch_size, output_type, input_type, use_input, num_threads=3, device_id=0, num_gpus=1, inverted=False):
         super(CVPipeline, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=False, exec_pipelined=False)
         self.use_input = use_input
         self.name = "cv"
@@ -128,9 +128,9 @@ class CVPipeline(Pipeline):
         self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
         if self.use_input:
           self.transform_source = ops.ExternalSource(lambda: gen_transforms(self.batch_size, 10))
-          self.warp = ops.PythonFunction(function=CVWarp(output_type, input_type))
+          self.warp = ops.PythonFunction(function=CVWarp(output_type, input_type, inverted=inverted))
         else:
-          self.warp = ops.PythonFunction(function=CVWarp(output_type, input_type, [[0.1, 0.9, 10], [0.8, -0.2, -20]]))
+          self.warp = ops.PythonFunction(function=CVWarp(output_type, input_type, [[0.1, 0.9, 10], [0.8, -0.2, -20]], inverted))
         self.set_layout = ops.Reshape(layout="HWC")
         self.iter = 0
 
@@ -163,35 +163,39 @@ def test_cpu_vs_cv():
   for batch_size in [1, 4, 19]:
     for use_input in [False, True]:
       for (itype, otype) in io_types:
-        print("Testing cpu vs cv",
-              "\nbatch size: ", batch_size,
-              " matrix as input: ", use_input,
-              " input_type: ", itype,
-              " output_type: ", otype)
-        cv_pipeline = CVPipeline(batch_size, otype, itype, use_input);
-        cv_pipeline.build();
+        for inverted in [False, True]:
+          print("Testing cpu vs cv",
+                "\nbatch size: ", batch_size,
+                " matrix as input: ", use_input,
+                " input_type: ", itype,
+                " output_type: ", otype,
+                " map_inverse:", inverted)
+          cv_pipeline = CVPipeline(batch_size, otype, itype, use_input, inverted=inverted);
+          cv_pipeline.build();
 
-        cpu_pipeline = WarpPipeline("cpu", batch_size, otype, itype, use_input);
-        cpu_pipeline.build();
+          cpu_pipeline = WarpPipeline("cpu", batch_size, otype, itype, use_input, inverted=inverted);
+          cpu_pipeline.build();
 
-        compare(cv_pipeline, cpu_pipeline, 8)
+          compare(cv_pipeline, cpu_pipeline, 8)
 
 def test_gpu_vs_cv():
   for batch_size in [1, 4, 19]:
     for use_input in [False, True]:
       for (itype, otype) in io_types:
-        print("Testing gpu vs cv",
-              "\nbatch size: ", batch_size,
-              " matrix as input: ", use_input,
-              " input_type: ", itype,
-              " output_type: ", otype)
-        cv_pipeline = CVPipeline(batch_size, otype, itype, use_input);
-        cv_pipeline.build();
+        for inverted in [False, True]:
+          print("Testing gpu vs cv",
+                "\nbatch size: ", batch_size,
+                " matrix as input: ", use_input,
+                " input_type: ", itype,
+                " output_type: ", otype,
+                " map_inverse:", inverted)
+          cv_pipeline = CVPipeline(batch_size, otype, itype, use_input, inverted=inverted);
+          cv_pipeline.build();
 
-        gpu_pipeline = WarpPipeline("gpu", batch_size, otype, itype, use_input);
-        gpu_pipeline.build();
+          gpu_pipeline = WarpPipeline("gpu", batch_size, otype, itype, use_input, inverted=inverted);
+          gpu_pipeline.build();
 
-        compare(cv_pipeline, gpu_pipeline, 8)
+          compare(cv_pipeline, gpu_pipeline, 8)
 
 def test_gpu_vs_cpu():
   for batch_size in [1, 4, 19]:

--- a/dali/test/python/test_operator_warp.py
+++ b/dali/test/python/test_operator_warp.py
@@ -30,8 +30,6 @@ import random
 test_data_root = os.environ['DALI_EXTRA_PATH']
 caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
 
-random.seed(1009)
-
 def gen_transform(angle, zoom, dst_cx, dst_cy, src_cx, src_cy):
     t1 = np.array([[1, 0, -dst_cx], [0, 1, -dst_cy], [0, 0, 1]])
     cosa = math.cos(angle)/zoom
@@ -163,6 +161,7 @@ io_types = [
 
 
 def test_cpu_vs_cv():
+  random.seed(1009)
   for batch_size in [1, 4, 19]:
     for use_input in [False, True]:
       for (itype, otype) in io_types:
@@ -182,6 +181,7 @@ def test_cpu_vs_cv():
         compare(cv_pipeline, cpu_pipeline, 8)
 
 def test_gpu_vs_cv():
+  random.seed(1007)
   for batch_size in [1, 4, 19]:
     for use_input in [False, True]:
       for (itype, otype) in io_types:
@@ -201,6 +201,7 @@ def test_gpu_vs_cv():
         compare(cv_pipeline, gpu_pipeline, 8)
 
 def test_gpu_vs_cpu():
+  random.seed(1005)
   for batch_size in [1, 4, 19]:
     for use_input in [False, True]:
       for (itype, otype) in io_types:

--- a/include/dali/core/geom/mat.h
+++ b/include/dali/core/geom/mat.h
@@ -23,6 +23,7 @@
 #include "dali/core/util.h"
 #include "dali/core/tuple_helpers.h"
 #include "dali/core/geom/vec.h"
+#include "dali/core/cuda_utils.h"
 
 #ifndef MAT_LAYOUT_ROW_MAJOR
 #define MAT_LAYOUT_ROW_MAJOR 1
@@ -537,6 +538,82 @@ std::ostream &operator<<(std::ostream &os, const dali::mat<rows, cols, T> &m) {
   }
 
   return os;
+}
+
+template <int n, int m, typename T>
+DALI_HOST_DEV
+inline void solve_gauss(mat<n, n, T> &A, mat<n, m, T> &B) {
+  for (int v = 0; v < n; v++) {
+    T max = std::abs(A(v, v));
+    int maxr = v;
+    for (int i = v + 1; i < n; i++) {
+      T q = std::abs(A(i, v));
+      if (q > max) {
+        max = q;
+        maxr = i;
+      }
+    }
+    if (!max) {
+      #ifdef __CUDA_ARCH__
+        continue;
+      #else
+        throw std::range_error("Cannot solve the system with a singlular matrix.");
+      #endif
+    }
+    if (maxr != v) {
+      for (int j = 0; j < n; j++)
+        cuda_swap(A(v, j), A(maxr, j));
+      for (int j = 0; j < m; j++)
+        cuda_swap(B(v, j), B(maxr, j));
+    }
+    T x = A(v, v);
+    x = 1/x;
+    A(v, v) = 1;
+    for (int j = v + 1; j < n; j++)
+      A(v, j) *= x;
+    for (int j = 0; j < n; j++)
+      B(v, j) *= x;
+    for (int i = 0; i < n; i++) {
+       if (i == v)
+        continue;
+#ifndef __CUDA_ARCH__
+      using std::fma;
+#endif
+      T c = -A(i, v);
+      A(i, v) = 0;
+      for (int j = v + 1; j < n; j++)
+        A(i, j) = fma(c, A(v, j), A(i, j));
+      for (int j = 0; j < m; j++)
+        B(i, j) = fma(c, B(v, j), B(i, j));
+    }
+  }
+}
+
+template <int n, typename T, typename U = decltype(1.0f + T())>
+DALI_HOST_DEV
+inline mat<n, n, U> inverse(mat<n, n, T> A) {
+  mat<n, n, U> O = 1;
+  if (std::is_floating_point<T>::value) {
+    solve_gauss(A, O);
+  } else {
+    mat<n, n, U> tmp = A;
+    solve_gauss(tmp, O);
+  }
+  return O;
+}
+
+template<typename T, typename U = decltype(1.0f + T())>
+DALI_HOST_DEV
+inline mat<2, 2, U> inverse(mat<2, 2, T> A) {
+  auto det = A(0, 0)*A(1, 1) - A(0, 1)*A(1, 0);
+  if (!det) {
+    #ifdef __CUDA_ARCH__
+      return mat<2, 2, U>::eye();
+    #else
+      throw std::range_error("Cannot solve the system with a singlular matrix.");
+    #endif
+  }
+  return mat<2, 2, U>({{A(1, 1), -A(0, 1)}, {-A(1, 0), A(0, 0)}}) / det;
 }
 
 }  // namespace dali

--- a/include/dali/core/geom/transform.h
+++ b/include/dali/core/geom/transform.h
@@ -163,6 +163,16 @@ constexpr vec3 affine<3, 3>(const mat<3, 4> &transform, const vec3 &v) {
   };
 }
 
+template <int ndim, typename T, typename U = decltype(1.0f + T())>
+DALI_HOST_DEV
+constexpr mat<ndim, ndim+1, U> affine_mat_inv(const mat<ndim, ndim+1, T> &affine_m) {
+  auto m = sub<ndim, ndim>(affine_m);
+  auto t = affine_m.col(ndim);
+  m = inverse(m);
+  t = -m * t;
+  return cat_cols(m, t);
+}
+
 }  // namespace dali
 
 #endif  // DALI_CORE_GEOM_TRANSFORM_H_


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds an option to use inverse matrix in WarpAffine

#### What happened in this PR?
 - What solution was applied:
     *Transform matrix is inverted in the ParamProvider if the `inverse_map` option is set to false.*
 - Affected modules and functionalities:
     *mat.h, WarpAffineParamProvider*
 - Key points relevant for the review:
     *mat.h, WarpAffineParamProvide*
 - Validation and testing:
     *I extended the tests for WarpAffine operator*
 - Documentation (including examples):
     *The operator docs were modified.*


**JIRA TASK**: *DALI-1625*
