### PR TITLE
Add discrete mode to Uniform operator

### DIFF
--- a/dali/operators/random/uniform.cc
+++ b/dali/operators/random/uniform.cc
@@ -56,8 +56,8 @@ DALI_REGISTER_OPERATOR(Uniform, Uniform, CPU);
 DALI_SCHEMA(Uniform)
   .DocStr(R"code(Produces random numbers following an uniform distribution.
 
-Both continuous and discrete uniform distributions can be defined by defining
-a continuous ``range`` or a discrete ``set`` of values, respectively.
+Both continuous and discrete uniform distributions can be defined by providing
+a continuous ``range`` or a discrete list of ``values``, respectively.
   
 )code")
   .NumInput(0)
@@ -65,12 +65,12 @@ a continuous ``range`` or a discrete ``set`` of values, respectively.
   .AddOptionalArg("range",
     R"code(Range (``[a, b)``) of produced random numbers.
 
-This argument is mutually exclusive with ``values``
+This argument is mutually exclusive with ``values``.
 )code", std::vector<float>({-1, 1}))
   .AddOptionalArg("values",
-    R"code(The discrete set of values from which the random numbers are picked.
+    R"code(The discrete list of values from which the random numbers are picked.
 
-This argument is mutually exclusive with ``range``
+This argument is mutually exclusive with ``range``.
 )code", std::vector<float>({}))
   .AddOptionalArg("shape",
     R"code(Shape of the samples.)code", std::vector<int>{1});

--- a/dali/operators/random/uniform.cc
+++ b/dali/operators/random/uniform.cc
@@ -54,14 +54,19 @@ void Uniform::RunImpl(HostWorkspace &ws) {
 DALI_REGISTER_OPERATOR(Uniform, Uniform, CPU);
 
 DALI_SCHEMA(Uniform)
-  .DocStr("Produces random numbers following a uniform distribution.")//TODO DOCS
+  .DocStr(R"code(Produces random numbers following an uniform distribution.
+
+``range`` and ``set`` arguments are mutually exclusive
+  
+)code")
   .NumInput(0)
   .NumOutput(1)
   .AddOptionalArg("range",
-    R"code(Range of produced random numbers.)code", std::vector<float>({-1, 1}))
+    R"code(Range (``[a, b)``) of produced random numbers.)code", std::vector<float>({-1, 1}))
   .AddOptionalArg("set",
-    R"code(Range of produced random numbers.)code", std::vector<float>({}))
+    R"code(Set, to pick random numbers from.)code", std::vector<float>({}))
   .AddOptionalArg("shape",
     R"code(Shape of the samples.)code", std::vector<int>{1});
+
 
 }  // namespace dali

--- a/dali/operators/random/uniform.cc
+++ b/dali/operators/random/uniform.cc
@@ -56,15 +56,22 @@ DALI_REGISTER_OPERATOR(Uniform, Uniform, CPU);
 DALI_SCHEMA(Uniform)
   .DocStr(R"code(Produces random numbers following an uniform distribution.
 
-``range`` and ``set`` arguments are mutually exclusive
+Both continuous and discrete uniform distributions can be defined by defining
+a continuous ``range`` or a discrete ``set`` of values, respectively.
   
 )code")
   .NumInput(0)
   .NumOutput(1)
   .AddOptionalArg("range",
-    R"code(Range (``[a, b)``) of produced random numbers.)code", std::vector<float>({-1, 1}))
-  .AddOptionalArg("set",
-    R"code(Set, to pick random numbers from.)code", std::vector<float>({}))
+    R"code(Range (``[a, b)``) of produced random numbers.
+
+This argument is mutually exclusive with ``values``
+)code", std::vector<float>({-1, 1}))
+  .AddOptionalArg("values",
+    R"code(The discrete set of values from which the random numbers are picked.
+
+This argument is mutually exclusive with ``range``
+)code", std::vector<float>({}))
   .AddOptionalArg("shape",
     R"code(Shape of the samples.)code", std::vector<int>{1});
 

--- a/dali/operators/random/uniform.cc
+++ b/dali/operators/random/uniform.cc
@@ -17,25 +17,50 @@
 
 namespace dali {
 
-void Uniform::RunImpl(HostWorkspace &ws) {
+void Uniform::AssignRange(HostWorkspace &ws) {
   auto &output = ws.OutputRef<CPUBackend>(0);
+  auto dist = std::uniform_real_distribution<float>(range_[0], range_[1]);
   for (int i = 0; i < batch_size_; ++i) {
     auto *sample_data = output[i].mutable_data<float>();
     auto sample_len = output[i].size();
     for (int k = 0; k < sample_len; ++k) {
-      sample_data[k] = dis_(rng_);
+      sample_data[k] = dist(rng_);
     }
+  }
+}
+
+
+void Uniform::AssignSet(HostWorkspace &ws) {
+  auto &output = ws.OutputRef<CPUBackend>(0);
+  auto dist = std::uniform_int_distribution<int>(0, set_.size());
+  for (int i = 0; i < batch_size_; ++i) {
+    auto *sample_data = output[i].mutable_data<float>();
+    auto sample_len = output[i].size();
+    for (int k = 0; k < sample_len; ++k) {
+      sample_data[k] = set_[dist(rng_)];
+    }
+  }
+}
+
+
+void Uniform::RunImpl(HostWorkspace &ws) {
+  if (discrete_mode_) {
+    AssignSet(ws);
+  } else {
+    AssignRange(ws);
   }
 }
 
 DALI_REGISTER_OPERATOR(Uniform, Uniform, CPU);
 
 DALI_SCHEMA(Uniform)
-  .DocStr("Produces random numbers following a uniform distribution.")
+  .DocStr("Produces random numbers following a uniform distribution.")//TODO DOCS
   .NumInput(0)
   .NumOutput(1)
   .AddOptionalArg("range",
     R"code(Range of produced random numbers.)code", std::vector<float>({-1, 1}))
+  .AddOptionalArg("set",
+    R"code(Range of produced random numbers.)code", std::vector<float>({}))
   .AddOptionalArg("shape",
     R"code(Shape of the samples.)code", std::vector<int>{1});
 

--- a/dali/operators/random/uniform.cc
+++ b/dali/operators/random/uniform.cc
@@ -32,7 +32,7 @@ void Uniform::AssignRange(HostWorkspace &ws) {
 
 void Uniform::AssignSet(HostWorkspace &ws) {
   auto &output = ws.OutputRef<CPUBackend>(0);
-  auto dist = std::uniform_int_distribution<int>(0, set_.size());
+  auto dist = std::uniform_int_distribution<int>(0, set_.size() - 1);
   for (int i = 0; i < batch_size_; ++i) {
     auto *sample_data = output[i].mutable_data<float>();
     auto sample_len = output[i].size();

--- a/dali/operators/random/uniform.h
+++ b/dali/operators/random/uniform.h
@@ -28,12 +28,12 @@ class Uniform : public Operator<CPUBackend> {
   inline explicit Uniform(const OpSpec &spec) :
           Operator<CPUBackend>(spec),
           rng_(spec.GetArgument<int64_t>("seed")),
-          discrete_mode_(spec.HasArgument("set")) {
-    DALI_ENFORCE(!(spec.HasArgument("range") && spec.HasArgument("set")),
+          discrete_mode_(spec.HasArgument("values")) {
+    DALI_ENFORCE(!(spec.HasArgument("range") && spec.HasArgument("values")),
             "`range` and `set` arguments are mutually exclusive");
 
     if (discrete_mode_) {
-      set_ = spec.GetRepeatedArgument<float>("set");
+      set_ = spec.GetRepeatedArgument<float>("values");
     } else {
       range_ = spec.GetRepeatedArgument<float>("range");
     }

--- a/dali/operators/random/uniform.h
+++ b/dali/operators/random/uniform.h
@@ -29,12 +29,13 @@ class Uniform : public Operator<CPUBackend> {
           Operator<CPUBackend>(spec),
           rng_(spec.GetArgument<int64_t>("seed")),
           discrete_mode_(spec.HasArgument("set")) {
-    DALI_ENFORCE(spec.HasArgument("range") != spec.HasArgument("set"), "asd");//TODO msg
+    DALI_ENFORCE(!(spec.HasArgument("range") && spec.HasArgument("set")),
+            "`range` and `set` arguments are mutually exclusive");
 
-    if (spec.HasArgument("range")) {
-      range_ = spec.GetRepeatedArgument<float>("range");
-    } else {
+    if (discrete_mode_) {
       set_ = spec.GetRepeatedArgument<float>("set");
+    } else {
+      range_ = spec.GetRepeatedArgument<float>("range");
     }
 
     std::vector<int> shape_arg{};

--- a/dali/test/python/test_operator_uniform.py
+++ b/dali/test/python/test_operator_uniform.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nvidia.dali as dali
+import nvidia.dali.ops as ops
+import nvidia.dali.types as types
+import numpy as np
+import scipy.stats as st
+import math
+
+
+def test_uniform_continuous():
+    pipe = dali.pipeline.Pipeline(1, 1, 0)
+    test_range = (-100 - 100) * np.random.random_sample(2) + 100  # 2 elems from [-100, 100] range
+    with pipe:
+        pipe.set_outputs(dali.fn.uniform(range=test_range.tolist(), shape=[1e6]))
+    pipe.build()
+    oo = pipe.run()
+    possibly_uniform_distribution = oo[0].as_array()[0]
+    _, pv = st.chisquare(possibly_uniform_distribution, axis=None)
+    assert pv < 1e-8, "`possibly_uniform_distribution` is not an uniform distribution"
+    for val in possibly_uniform_distribution:
+        assert test_range[0] <= val < test_range[1], \
+            "Value returned from the op is outside of requested range"
+
+
+def in_float_set(val, test_set):
+    for t in test_set:
+        if math.isclose(val, t, rel_tol=1e-2):
+            return True
+    print(val, test_set)
+    return False
+
+
+def test_uniform_discreet():
+    pipe = dali.pipeline.Pipeline(1, 1, 0)
+    test_set = (-100 - 100) * np.random.random_sample(10) + 100  # 10 elems from [-100, 100] range
+    with pipe:
+        pipe.set_outputs(dali.fn.uniform(set=test_set.tolist(), shape=[1e6]))
+    pipe.build()
+    oo = pipe.run()
+    possibly_uniform_distribution = oo[0].as_array()[0]
+    _, pv = st.chisquare(possibly_uniform_distribution, axis=None)
+    print(pv, test_set)
+    # if pv >1e-8:
+    #     import ipdb; ipdb.set_trace()
+    assert pv < 1e-8, "`possibly_uniform_distribution` is not an uniform distribution"
+    # import ipdb; ipdb.set_trace()
+    for val in possibly_uniform_distribution:
+        assert in_float_set(val, test_set), \
+            "Value returned from the op is outside of requested discrete set"
+
+if __name__ == '__main__':
+    test_uniform_continuous()

--- a/dali/test/python/test_operator_uniform.py
+++ b/dali/test/python/test_operator_uniform.py
@@ -57,6 +57,7 @@ def test_uniform_discrete():
     lo = -100
     hi = 100
     test_set = (hi - lo) * np.random.random_sample(10) + lo  # 10 elems from [-100, 100] range
+    test_set = test_set.astype('float32')
     with pipe:
         pipe.set_outputs(dali.fn.uniform(values=test_set.tolist(), shape=[1e6]))
     pipe.build()
@@ -65,6 +66,6 @@ def test_uniform_discrete():
     _, pv = st.kstest(rvs=possibly_uniform_distribution, cdf='uniform')
     assert pv < 1e-8, "`possibly_uniform_distribution` is not an uniform distribution"
     for val in possibly_uniform_distribution:
-        assert any(math.isclose(val, t, rel_tol=1e-6) for t in test_set), \
+        assert val in test_set, \
             "Value returned from the op is outside of requested discrete set"
 

--- a/dali/test/python/test_operator_uniform.py
+++ b/dali/test/python/test_operator_uniform.py
@@ -52,24 +52,19 @@ def test_uniform_continuous():
                 "Value returned from the op is outside of requested range"
 
 
-def in_float_set(val, test_set):
-    for t in test_set:
-        if math.isclose(val, t, rel_tol=1e-6):
-            return True
-    return False
-
-
-def test_uniform_discreet():
+def test_uniform_discrete():
     pipe = dali.pipeline.Pipeline(1, 1, 0)
-    test_set = (-100 - 100) * np.random.random_sample(10) + 100  # 10 elems from [-100, 100] range
+    lo = -100
+    hi = 100
+    test_set = (hi - lo) * np.random.random_sample(10) + lo  # 10 elems from [-100, 100] range
     with pipe:
-        pipe.set_outputs(dali.fn.uniform(set=test_set.tolist(), shape=[1e6]))
+        pipe.set_outputs(dali.fn.uniform(values=test_set.tolist(), shape=[1e6]))
     pipe.build()
     oo = pipe.run()
     possibly_uniform_distribution = oo[0].as_array()[0]
     _, pv = st.kstest(rvs=possibly_uniform_distribution, cdf='uniform')
     assert pv < 1e-8, "`possibly_uniform_distribution` is not an uniform distribution"
     for val in possibly_uniform_distribution:
-        assert in_float_set(val, test_set), \
+        assert any(math.isclose(val, t, rel_tol=1e-6) for t in test_set), \
             "Value returned from the op is outside of requested discrete set"
 

--- a/dali/test/python/test_operator_uniform.py
+++ b/dali/test/python/test_operator_uniform.py
@@ -20,6 +20,20 @@ import scipy.stats as st
 import math
 
 
+
+def test_uniform_default():
+    pipe = dali.pipeline.Pipeline(1, 1, 0)
+    with pipe:
+        pipe.set_outputs(dali.fn.uniform(shape=[1e6]))
+    pipe.build()
+    oo = pipe.run()
+    possibly_uniform_distribution = oo[0].as_array()[0]
+    _, pv = st.kstest(rvs=possibly_uniform_distribution, cdf='uniform')
+    assert pv < 1e-8, "`possibly_uniform_distribution` is not an uniform distribution"
+    for val in possibly_uniform_distribution:
+        assert -1 <= val < 1, "Value returned from the op is outside of requested range"
+
+
 def test_uniform_continuous():
     pipe = dali.pipeline.Pipeline(1, 1, 0)
     lo = -100


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature: uniformly distributed random numbers, picked from set of floats
