### PR TITLE
Fix the problem of output outliving the pipeline in python

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1254,30 +1254,30 @@ PYBIND11_MODULE(backend_impl, m) {
           DeviceWorkspace ws;
           p->Outputs(&ws);
 
-          py::list list;
+          py::tuple outs(ws.NumOutput());
           for (int i = 0; i < ws.NumOutput(); ++i) {
             if (ws.OutputIsType<CPUBackend>(i)) {
-              list.append(ws.OutputPtr<CPUBackend>(i));
+              outs[i] = ws.OutputPtr<CPUBackend>(i);
             } else {
-              list.append(ws.OutputPtr<GPUBackend>(i));
+              outs[i] = ws.OutputPtr<GPUBackend>(i);
             }
           }
-          return py::cast<py::tuple>(list);
+          return outs;
         }, py::return_value_policy::take_ownership)
     .def("ShareOutputs",
         [](Pipeline *p) {
           DeviceWorkspace ws;
           p->ShareOutputs(&ws);
 
-          py::list list;
+          py::tuple outs(ws.NumOutput());
           for (int i = 0; i < ws.NumOutput(); ++i) {
             if (ws.OutputIsType<CPUBackend>(i)) {
-              list.append(ws.OutputPtr<CPUBackend>(i));
+              outs[i] = ws.OutputPtr<CPUBackend>(i);
             } else {
-              list.append(ws.OutputPtr<GPUBackend>(i));
+              outs[i] = ws.OutputPtr<GPUBackend>(i);
             }
           }
-          return py::cast<py::tuple>(list);
+          return outs;
         }, py::return_value_policy::take_ownership)
     .def("ReleaseOutputs",
         [](Pipeline *p) {

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1055,7 +1055,7 @@ class CachedPipeline(Pipeline):
                                             cache_batch_copy=is_cached_batch_copy)
         else:
             # hw_decoder_load=0.0 for deterministic results
-            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB, hw_decoder_load = 0.0)  
+            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB, hw_decoder_load = 0.0)
     def define_graph(self):
         if self.reader_type == "TFRecordReader":
             inputs = self.input()
@@ -1696,3 +1696,14 @@ def test_epoch_size():
     assert(pipe.epoch_size("caffe2_reader") != 0)
     assert(pipe.epoch_size("file_reader") != 0)
     assert(len(pipe.epoch_size()) == 4)
+
+def test_pipeline_out_of_scope():
+    def get_output():
+        pipe = dali.pipeline.Pipeline(1, 1, 0)
+        with pipe:
+            pipe.set_outputs(dali.fn.uniform())
+        pipe.build()
+        return pipe.run()
+    data = get_output()
+    out = data[0].as_array()[0]
+    print(out)

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1701,9 +1701,9 @@ def test_pipeline_out_of_scope():
     def get_output():
         pipe = dali.pipeline.Pipeline(1, 1, 0)
         with pipe:
-            pipe.set_outputs(dali.fn.uniform())
+            pipe.set_outputs(dali.fn.external_source(source=[[np.array([-0.5, 1.25])]]))
         pipe.build()
         return pipe.run()
-    data = get_output()
-    out = data[0].as_array()[0]
-    print(out)
+    out = get_output()[0].at(0)
+    assert out[0] == -0.5 and out[1] == 1.25
+


### PR DESCRIPTION
- fixes the problem when the Python gcs pipeline object but there are still outputs that reference to the underlying memory

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes the problem when the Python gcs pipeline object but there are still outputs that reference to the underlying memory

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     bound lifetime of the pipeline to the returned outputs
 - Affected modules and functionalities:
     backend_impl
 - Key points relevant for the review:
     NA
 - Validation and testing:
     test case has been added
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1657]*
