### PR TITLE
Enable nvJPEG2k build for CUDA 11.1

### DIFF
--- a/docker/Dockerfile.cuda111.x86_64.deps
+++ b/docker/Dockerfile.cuda111.x86_64.deps
@@ -7,5 +7,16 @@ RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.1.0/local_ins
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;
 
+RUN apt-get update && \
+    apt-get install wget software-properties-common -y && \
+    wget -qO - https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
+    add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /" && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub && \
+    apt-get update && \
+    apt-get install libnvjpeg2k0 libnvjpeg2k-dev -y && \
+    cp /usr/include/nvjpeg2k* /usr/local/cuda/include/ && \
+    cp /usr/lib/x86_64-linux-gnu/libnvjpeg2k* /usr/local/cuda/lib64/ && \
+    rm -rf /var/lib/apt/lists/*
+
 FROM scratch
 COPY --from=cuda /usr/local/cuda /usr/local/cuda


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It enables nvJPEG2k build for CUDA 11.1

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     deps docker image update
 - Affected modules and functionalities:
     Dockerfile.cuda111.x86_64.deps
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
