### PR TITLE
Add support for N-dim tensors to OneHot

### DIFF
--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -29,8 +29,8 @@ will fail.)code")
   .NumInput(1)
   .NumOutput(1)
   .AddOptionalArg("num_classes", R"code(Number of all classes in the data.)code", 0)
-  .AddOptionalArg<int>("axis", R"code(On which axis place the on-hot encoding axis of `num_classes`
-size. By default it's appended as the last dimension for non-scalar inputs, for scalar inputs,
+  .AddOptionalArg<int>("axis", R"code(Dimension to place the one-hot encoding axis of `num_classes`
+size. By default it's appended as the last dimension for non-scalar inputs. For scalar inputs,
 it becomes the only dimension.)code", -1)
   .AddOptionalArg(arg_names::kDtype, R"code(Output data type.)code", DALI_FLOAT)
   .AddOptionalArg("on_value",
@@ -59,8 +59,7 @@ TensorShape<> determine_shape(TensorShape<> in_shape, int num_classes, int axis,
   int inner_axes = in_shape.sample_dim() - axis;
   auto outer =  in_shape.first(outer_axes);
   auto inner = in_shape.last(inner_axes);
-  auto tmp = shape_cat(outer, num_classes);
-  return shape_cat(tmp, inner);
+  return shape_cat(shape_cat(outer, num_classes), inner);
 }
 
 }  // namespace

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -26,24 +26,21 @@ DALI_SCHEMA(OneHot)
 
 Adds a new axis or converts scalar input into an axis of ``num_classes`` elements.
 
-For given input coordinate ``(x0, x1, ..., xn)``, and ``axis=k``, the output sample is specified as::
+For given input coordinate ``(x0, x1, ..., xn)``, and ``axis = k``, the output sample is specified as::
 
   cls = input[x0, x1, ..., xn]
-  output[x0, x1, ..., xk-1, :, xk+1, ..., xn] = off_value
-  output[x0, x1, ..., xk-1, cls, xk+1, ..., xn] = on_value
+  output[x0, x1, ..., xk-1, xk, xk+1, ..., xn] = on_value if xk == cls else off_value
 
-for all ``cls`` values in range ``[0, num_classes)``. The ``k-th`` axis will have ``num_classes`` elements.
+for all ``xk`` in range ``[0, num_classes)``.
 
-For scalars, for given input sample::
+For scalars, the output is set to ``on_value`` at the index taken from ``input`` and
+``off_value`` elsewhere::
 
-  output[:] = off_value
-  output[input] = on_value
+  output[i] = on_value if i == input else off_value
 
-The output will have 1 dimension of ``num_classes`` elements.
-
-For legacy support any input in which all tensors have volume equal to 1 is considered
-a scalar input (each of them have only one element). Legacy interpretation of tensors as scalars
-is not supported if ``axis`` argument is specified.)code")
+For backward compatibility, any input in which all tensors have only one element
+(regardless of the number of dimensions) is considered scalar. Legacy interpretation of tensors
+as scalars is not supported if ``axis`` argument is specified.)code")
   .NumInput(1)
   .NumOutput(1)
   .AddOptionalArg("num_classes", R"code(Number of all classes in the data.)code", 0)

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -29,9 +29,9 @@ Adds a new axis or converts scalar input into an axis of ``num_classes`` element
 For given input coordinate ``(x0, x1, ..., xn)``, and ``axis = k``, the output sample is specified as::
 
   cls = input[x0, x1, ..., xn]
-  output[x0, x1, ..., xk-1, xk, xk+1, ..., xn] = on_value if xk == cls else off_value
+  output[x0, x1, ..., xk-1, i, xk, ..., xn] = on_value if i == cls else off_value
 
-for all ``xk`` in range ``[0, num_classes)``.
+for all ``i`` in range ``[0, num_classes)``.
 
 For scalars, the output is set to ``on_value`` at the index taken from ``input`` and
 ``off_value`` elsewhere::

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -29,6 +29,9 @@ will fail.)code")
   .NumInput(1)
   .NumOutput(1)
   .AddOptionalArg("num_classes", R"code(Number of all classes in the data.)code", 0)
+  .AddOptionalArg<int>("axis", R"code(On which axis place the on-hot encoding axis of `num_classes`
+size. By default it's appended as the last dimension for non-scalar inputs, for scalar inputs,
+it becomes the only dimension.)code", -1)
   .AddOptionalArg(arg_names::kDtype, R"code(Output data type.)code", DALI_FLOAT)
   .AddOptionalArg("on_value",
                   R"code(Value that will be used to fill the output when ``input[j] = i``.
@@ -46,22 +49,45 @@ bool is_scalar(TensorShape<ndims> shape) {
   return volume(shape) == 1;
 }
 
-
-TensorShape<DynamicDimensions>
-determine_shape(TensorShape<DynamicDimensions> in_shape, int nclasses) {
-  if (is_scalar(in_shape)) {
-    return {nclasses};
+TensorShape<> determine_shape(TensorShape<> in_shape, int num_classes, int axis,
+                              int output_sample_dim) {
+  if (output_sample_dim == 1) {
+    return {num_classes};
   }
-  return shape_cat(in_shape, nclasses);
+  axis = axis < 0 ? in_shape.sample_dim() : axis;
+  int outer_axes = axis;
+  int inner_axes = in_shape.sample_dim() - axis;
+  auto outer =  in_shape.first(outer_axes);
+  auto inner = in_shape.last(inner_axes);
+  auto tmp = shape_cat(outer, num_classes);
+  return shape_cat(tmp, inner);
 }
 
 }  // namespace
 
 bool OneHot::SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) {
   const auto &input = ws.template InputRef<CPUBackend>(0);
+  int input_sample_dim = input.shape().sample_dim();
+  int num_samples = input.shape().num_samples();
+  DALI_ENFORCE(-1 <= axis_ && axis_ <= input_sample_dim,
+               make_string("Provided axis is outside of allowed range, got: ", axis_,
+                           ", expected to be in range: [-1, ", input_sample_dim, "]."));
+
+  // Legacy scalar-like support
+  // TODO(klecki): It was already buggy, maybe drop it
+  bool all_scalars = true;
+  for (int i = 0; i < num_samples; i++) {
+    all_scalars = all_scalars && is_scalar(input.shape()[i]);
+  }
+
+  int output_sample_dim = all_scalars ? 1 : input_sample_dim + 1;
   output_desc.resize(1);
-  output_desc[0].shape = uniform_list_shape(batch_size_,
-                                            determine_shape(input[0].shape(), num_classes_));
+
+  output_desc[0].shape.resize(num_samples, output_sample_dim);
+  for (int i = 0; i < num_samples; i++) {
+    output_desc[0].shape.set_tensor_shape(
+        i, determine_shape(input[i].shape(), num_classes_, axis_, output_sample_dim));
+  }
   TYPE_SWITCH(output_type_, type2id, DType, ONE_HOT_TYPES, (
           {
             TypeInfo type;
@@ -72,6 +98,7 @@ bool OneHot::SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace
   return true;
 }
 
+// TODO(klecki): Handle layout, maybe introduce a parameter for how to name the new axis
 void OneHot::RunImpl(HostWorkspace &ws) {
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto &output = ws.template OutputRef<CPUBackend>(0);
@@ -87,8 +114,7 @@ void OneHot::RunImpl(HostWorkspace &ws) {
                     [&, sample_id](int thread_id) {
                         auto in = in_tensor[sample_id];
                         auto out = out_tensor[sample_id];
-                        detail::DoOneHot(out, in, num_classes_, on_value_, off_value_,
-                                         0 ? is_scalar(in.shape) : in.shape.sample_dim(), 0);
+                        detail::DoOneHot(out, in, num_classes_, on_value_, off_value_, axis_);
                     }, in_shape.tensor_size(sample_id));
           }
           tp.RunAll();

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -34,11 +34,8 @@ void DoOneHot(kernels::OutTensorCPU<Out, DynamicDimensions> output,
               same_as_t<Out> on_value, same_as_t<Out> off_value, int axis) {
   auto in = input.data;
   auto out = output.data;
-  axis = axis < 0 ? output.shape.sample_dim() - 1 : axis;
-  auto outer = output.shape.first(axis);
-  auto inner = output.shape.last(output.shape.sample_dim() - axis - 1);
-  auto volume_outer = volume(outer);
-  auto volume_inner = volume(inner);
+  auto volume_outer = volume(output.shape.begin(), output.shape.begin() + axis);
+  auto volume_inner = volume(output.shape.begin() + axis + 1, output.shape.end());
   for (int i = 0; i < volume(output.shape); ++i) {
     out[i] = off_value;
   }

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -31,17 +31,24 @@ namespace detail {
 template<typename Out, typename In>
 void DoOneHot(kernels::OutTensorCPU<Out, DynamicDimensions> output,
               kernels::InTensorCPU<In, DynamicDimensions> input, int num_classes,
-              same_as_t<Out> on_value, same_as_t<Out> off_value, int ndims, int axis = 0) {
+              same_as_t<Out> on_value, same_as_t<Out> off_value, int axis) {
   auto in = input.data;
   auto out = output.data;
-  for (int i = 0; i < volume(output.shape); ++i) out[i] = off_value;
-  int64_t inner = volume(input.shape.last(ndims - axis));
-  for (int64_t i = 0, n = input.num_elements(); i < n; i++) {
-    int cls = in[i];
-    if (cls < 0 || cls >= num_classes)
-      continue;
-    int64_t out_idx = (i % inner) + cls * inner + (i / inner) * (inner * num_classes);
-    out[out_idx] = on_value;
+  axis = axis < 0 ? output.shape.sample_dim() - 1 : axis;
+  auto outer = output.shape.first(axis);
+  auto inner = output.shape.last(output.shape.sample_dim() - axis - 1);
+  auto volume_outer = volume(outer);
+  auto volume_inner = volume(inner);
+  for (int i = 0; i < volume(output.shape); ++i) {
+    out[i] = off_value;
+  }
+  for (int64_t outer_coord = 0; outer_coord < volume_outer; outer_coord++) {
+    for (int64_t inner_coord = 0; inner_coord < volume_inner; inner_coord++) {
+      int cls = in[outer_coord * volume_inner + inner_coord];
+      if (cls < 0 || cls >= num_classes)
+        continue;
+      out[outer_coord * volume_inner * num_classes + cls * volume_inner + inner_coord] = on_value;
+    }
   }
 }
 }  // namespace detail
@@ -50,6 +57,7 @@ class OneHot : public Operator<CPUBackend> {
  public:
   inline explicit OneHot(const OpSpec &spec)
       : Operator<CPUBackend>(spec), num_classes_(spec.GetArgument<int64_t>("num_classes")),
+        axis_(spec.GetArgument<int>("axis")),
         output_type_(spec.GetArgument<DALIDataType>(arg_names::kDtype)),
         on_value_(spec.GetArgument<float>("on_value")),
         off_value_(spec.GetArgument<float>("off_value")) {}
@@ -71,6 +79,7 @@ class OneHot : public Operator<CPUBackend> {
 
 
   int num_classes_;
+  int axis_;
   const DALIDataType output_type_;
   float on_value_;
   float off_value_;

--- a/dali/operators/generic/one_hot_test.cc
+++ b/dali/operators/generic/one_hot_test.cc
@@ -50,7 +50,7 @@ TYPED_TEST(OneHotOpTest, TestVariousTypes) {
     for (int sample = 0; sample < this->buffer_length_; ++sample) {
         auto input = make_tensor_cpu(this->input_.data() + sample, this->input_shape_);
         auto output = make_tensor_cpu(this->output_.data(), this->output_shape_);
-        dali::detail::DoOneHot<Out, In>(output, input, 20, 1, 0, 0, 0);
+        dali::detail::DoOneHot<Out, In>(output, input, 20, 1, 0, 0);
         for (int i = 0; i < this->num_classes_; ++i) {
             if (i == this->input_.data()[sample]) {
                 ASSERT_EQ(output.data[i], 1);

--- a/dali/test/python/test_operator_one_hot.py
+++ b/dali/test/python/test_operator_one_hot.py
@@ -88,7 +88,7 @@ def test_one_hot_legacy():
     for i in range(10):
         premade_batch = [np.array([np.random.randint(0, num_classes)], dtype=np.int32)
                          for x in range(batch_size)]
-        yield check_one_hot_operator, premade_batch
+        yield check_one_hot_operator, premade_batch, None
 
 
 def test_one_hot ():

--- a/dali/test/python/test_operator_one_hot.py
+++ b/dali/test/python/test_operator_one_hot.py
@@ -15,39 +15,88 @@
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
+from test_utils import check_batch
 
 import numpy as np
 
-sample_size = 20
+num_classes = 20
+batch_size = 10
+
+
+def insert_as_axis(target, value, axis, total_axes):
+    return target[0:axis] + (value,) + target[axis:total_axes]
 
 class OneHotPipeline(Pipeline):
-    def __init__(self, num_classes, input, num_threads=1):
-        super(OneHotPipeline, self).__init__(sample_size,
+    def __init__(self, num_classes, input, axis=-1, num_threads=1):
+        super(OneHotPipeline, self).__init__(batch_size,
                                              num_threads,
                                              0)
-        self.ext_src = ops.ExternalSource(source=[input], cycle=True)
-        self.one_hot = ops.OneHot(num_classes=num_classes, dtype=types.INT32, device="cpu")
+        sample_dim = len(input[0].shape)
+        self.ext_src = ops.ExternalSource(source=[input], cycle=True, layout="ABCD"[0:sample_dim])
+        self.one_hot = ops.OneHot(num_classes=num_classes, axis=axis, dtype=types.INT32, device="cpu")
 
     def define_graph(self):
         self.data = self.ext_src()
         return self.one_hot(self.data)
 
+def one_hot_3_axes(input, axis):
+    total_axes = len(input[0].shape)
+    assert total_axes == 3
+    axis = axis if axis >= 0 else total_axes
+    shapes = []
+    results = []
+    for i in range(batch_size):
+        shape = insert_as_axis(input[i].shape, num_classes, axis, total_axes)
+        result = np.zeros(shape, dtype=np.int32)
+        shapes.append(shape)
+        for i0 in range(input[i].shape[0]):
+            for i1 in range(input[i].shape[1]):
+                for i2 in range(input[i].shape[2]):
+                    in_coord = (i0, i1, i2)
+                    out_coord = insert_as_axis(in_coord, input[i][in_coord], axis, total_axes)
+                    result[out_coord] = 1
+        results.append(result)
+    return results
+
 def one_hot(input):
-    outp = np.zeros([sample_size, sample_size], dtype=np.int32)
-    for i in range(sample_size):
+    outp = np.zeros([batch_size, num_classes], dtype=np.int32)
+    for i in range(batch_size):
         outp[i, int(input[i])] = 1
     return outp
 
-def check_one_hot_operator(premade_batch):
-    pipeline = OneHotPipeline(num_classes=sample_size, input=premade_batch)
+
+
+def check_one_hot_operator(premade_batch, axis=-1):
+    pipeline = OneHotPipeline(num_classes=num_classes, input=premade_batch, axis=axis)
     pipeline.build()
     outputs = pipeline.run()
-    reference = one_hot(premade_batch)
-    outputs = outputs[0].as_array()
-    assert(np.array_equal(outputs, reference))
+    sample_dim = len(premade_batch[0].shape)
+    reference = one_hot_3_axes(premade_batch, axis) if sample_dim == 3 else one_hot(premade_batch)
+    new_layout = None # TODO(klecki): add layout handling
+    check_batch(outputs[0], reference, batch_size, max_allowed_error=0, expected_layout=new_layout)
 
-def test_one_hot_operator():
-    np.random.seed(42);
+
+def test_one_hot_scalar():
+    np.random.seed(42)
     for i in range(10):
-        premade_batch = [np.array([np.random.randint(0, sample_size)], dtype=np.int32) for x in range(sample_size)]
+        premade_batch = np.random.randint(0, num_classes, size=batch_size, dtype=np.int32)
         yield check_one_hot_operator, premade_batch
+
+
+def test_one_hot_legacy():
+    np.random.seed(42)
+    for i in range(10):
+        premade_batch = [np.array([np.random.randint(0, num_classes)], dtype=np.int32)
+                         for x in range(batch_size)]
+        yield check_one_hot_operator, premade_batch
+
+
+def test_one_hot ():
+    np.random.seed(42)
+    for i in range(10):
+        for axis in [-1, 0, 1, 2, 3]:
+            premade_batch = [
+                np.random.randint(
+                    0, num_classes, size=np.random.randint(2, 8, size=(3,)),
+                    dtype=np.int32) for _ in range(batch_size)]
+            yield check_one_hot_operator, premade_batch, axis


### PR DESCRIPTION
Handle true scalar inputs
Extend tests a bit
TODO: Layout support

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Improve One Hot CPU implementation

#### What happened in this PR? 
 - What solution was applied:
     Added axis, loop over outer and inner flattened coordinate and fill the axis.
 - Affected modules and functionalities:
     OneHot CPU
 - Key points relevant for the review:
  N/A
 - Validation and testing:
  nosetest   
 - Documentation (including examples):
     Yes


**JIRA TASK**: *[DALI-1658]*
