### PR TITLE
Fix lack of proper layout setting in the VideoReader

### DIFF
--- a/dali/operators/reader/video_reader_op.h
+++ b/dali/operators/reader/video_reader_op.h
@@ -104,7 +104,6 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
   virtual void SetOutputShapeType(TensorList<GPUBackend> &output, DeviceWorkspace &ws) {
     auto &curr_batch = prefetched_batch_tensors_[curr_batch_consumer_];
     output.Resize(curr_batch.shape(), curr_batch.type());
-    output.SetLayout("FHWC");
   }
 
   void PrepareAdditionalOutputs(DeviceWorkspace &ws) {
@@ -160,6 +159,9 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
     PrepareAdditionalOutputs(ws);
 
     ProcessVideo(video_output, curent_batch, ws);
+
+    // set layout here as ProcessVideo may have change it via Copy or other function
+    video_output.SetLayout("FHWC");
 
     for (size_t data_idx = 0; data_idx < curent_batch.ntensor(); ++data_idx) {
       auto &prefetched_video = GetSample(data_idx);

--- a/dali/operators/reader/video_reader_op.h
+++ b/dali/operators/reader/video_reader_op.h
@@ -129,6 +129,7 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
   virtual void ProcessVideo(TensorList<GPUBackend> &video_output,
                             TensorList<GPUBackend> &video_batch, DeviceWorkspace &ws) {
     video_output.Copy(video_batch, ws.stream());
+    video_output.SetLayout("FHWC");
   }
 
   void ProcessAdditionalOutputs(int data_idx, SequenceWrapper &prefetched_video,
@@ -159,9 +160,6 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
     PrepareAdditionalOutputs(ws);
 
     ProcessVideo(video_output, curent_batch, ws);
-
-    // set layout here as ProcessVideo may have change it via Copy or other function
-    video_output.SetLayout("FHWC");
 
     for (size_t data_idx = 0; data_idx < curent_batch.ntensor(); ++data_idx) {
       auto &prefetched_video = GetSample(data_idx);

--- a/dali/operators/reader/video_reader_resize_op.h
+++ b/dali/operators/reader/video_reader_resize_op.h
@@ -50,7 +50,6 @@ class VideoReaderResize : public VideoReader,
                                          make_cspan(resize_attr_.params_));
     resize_attr_.GetResizedShape(output_shape_, input_shape_);
     output.Resize(output_shape_, prefetched_batch_tensors_[curr_batch_consumer_].type());
-    output.SetLayout("FHWC");
   }
 
   void ShareSingleOutputAsTensorList(int data_idx, TensorList<GPUBackend> &batch_output,

--- a/dali/operators/reader/video_reader_resize_op.h
+++ b/dali/operators/reader/video_reader_resize_op.h
@@ -81,6 +81,7 @@ class VideoReaderResize : public VideoReader,
       assert(output_shape == output.shape());
       RunResize(ws, output, input);
     }
+    video_output.SetLayout("FHWC");
   }
 
   ResizeAttr resize_attr_;

--- a/dali/test/python/test_video_pipeline.py
+++ b/dali/test/python/test_video_pipeline.py
@@ -82,7 +82,8 @@ def test_simple_videopipeline():
     pipe.build()
     for i in range(ITER):
         print("Iter " + str(i))
-        _ = pipe.run()
+        out = pipe.run()
+        assert(out[0].layout() == "FHWC")
     del pipe
 
 def test_wrong_length_sequence_videopipeline():


### PR DESCRIPTION
- ProcessVideo overwrites the layout set in SetOutputShapeType so moved the layout set operation after it

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a lack of proper layout setting in the VideoReader

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     ProcessVideo overwrites the layout set in SetOutputShapeType so moved the layout set operation after it
 - Affected modules and functionalities:
     VideoReader
     VideoReaderResize
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
