### PR TITLE
Adds a separate option to preallocate nvjPEG2k memory

### DIFF
--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -61,8 +61,8 @@ The padding for nvJPEG2k's device memory allocations, in bytes. This parameter h
 reallocation in nvJPEG2k when a larger image is encountered, and the internal buffer needs to be
 reallocated to decode the image.
 
-If a value greater than 0 is provided, the operator preallocates one device buffer of the
-requested size per thread. If the value is correctly selected, no additional allocations
+If a value greater than 0 is provided, the operator preallocates the necessary number of buffers
+according to the hint provided. If the value is correctly selected, no additional allocations
 will occur during the pipeline execution. One way to find the ideal value is to do a complete
 run over the dataset with the ``memory_stats`` argument set to True and then copy the largest
 allocation value that was printed in the statistics.)code",
@@ -87,8 +87,8 @@ The padding for nvJPEG2k's host memory allocations, in bytes. This parameter hel
 the reallocation in nvJPEG2k when a larger image is encountered, and the internal buffer needs
 to be reallocated to decode the image.
 
-If a value greater than 0 is provided, the operator preallocates two (because of double-buffering)
-host-pinned buffers of the requested size per thread. If selected correctly, no additional
+If a value greater than 0 is provided, the operator preallocates the necessary number of buffers
+according to the hint provided. If the value is correctly selected, no additional
 allocations will occur during the pipeline execution. One way to find the ideal value is to
 do a complete run over the dataset with the ``memory_stats`` argument set to True, and then copy
 the largest allocation value that is printed in the statistics.)code",

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -54,6 +54,19 @@ will occur during the pipeline execution. One way to find the ideal value is to 
 run over the dataset with the ``memory_stats`` argument set to True and then copy the largest
 allocation value that was printed in the statistics.)code",
       16*1024*1024)
+  .AddOptionalArg("device_memory_padding_jpeg2k",
+      R"code(Applies **only** to the ``mixed`` backend type.
+
+The padding for nvJPEG2k's device memory allocations, in bytes. This parameter helps to avoid
+reallocation in nvJPEG2k when a larger image is encountered, and the internal buffer needs to be
+reallocated to decode the image.
+
+If a value greater than 0 is provided, the operator preallocates one device buffer of the
+requested size per thread. If the value is correctly selected, no additional allocations
+will occur during the pipeline execution. One way to find the ideal value is to do a complete
+run over the dataset with the ``memory_stats`` argument set to True and then copy the largest
+allocation value that was printed in the statistics.)code",
+      0)
   .AddOptionalArg("host_memory_padding",
       R"code(Applies **only** to the ``mixed`` backend type.
 
@@ -67,6 +80,19 @@ allocations will occur during the pipeline execution. One way to find the ideal 
 do a complete run over the dataset with the ``memory_stats`` argument set to True, and then copy
 the largest allocation value that is printed in the statistics.)code",
       8*1024*1024)  // based on ImageNet heuristics (8MB)
+  .AddOptionalArg("host_memory_padding_jpeg2k",
+      R"code(Applies **only** to the ``mixed`` backend type.
+
+The padding for nvJPEG2k's host memory allocations, in bytes. This parameter helps to prevent
+the reallocation in nvJPEG2k when a larger image is encountered, and the internal buffer needs
+to be reallocated to decode the image.
+
+If a value greater than 0 is provided, the operator preallocates two (because of double-buffering)
+host-pinned buffers of the requested size per thread. If selected correctly, no additional
+allocations will occur during the pipeline execution. One way to find the ideal value is to
+do a complete run over the dataset with the ``memory_stats`` argument set to True, and then copy
+the largest allocation value that is printed in the statistics.)code",
+      0)
   .AddOptionalArg("affine",
       R"code(Applies **only** to the ``mixed`` backend type.
 

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -112,10 +112,8 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     NVJPEG_CALL(nvjpegSetDeviceMemoryPadding(device_memory_padding, handle_));
     NVJPEG_CALL(nvjpegSetPinnedMemoryPadding(host_memory_padding, handle_));
 
-    nvjpegDevAllocator_t *device_allocator_ptr = device_memory_padding > 0 ?
-        &device_allocator_ : nullptr;
-    nvjpegPinnedAllocator_t *pinned_allocator_ptr = host_memory_padding > 0 ?
-        &pinned_allocator_ : nullptr;
+    nvjpegDevAllocator_t *device_allocator_ptr = &device_allocator_;
+    nvjpegPinnedAllocator_t *pinned_allocator_ptr = &pinned_allocator_ ;
 
     nvjpeg_memory::SetEnableMemStats(spec.GetArgument<bool>("memory_stats"));
 
@@ -176,9 +174,8 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::Pinned,
                                host_memory_padding_jpeg2k);
     }
-    nvjpeg2k_thread_.AddWork([this, device_memory_padding, host_memory_padding](int) {
-      nvjpeg2k_handle_ = NvJPEG2KHandle(device_memory_padding > 0 ? &nvjpeg2k_dev_alloc_ : nullptr,
-                                        host_memory_padding > 0 ? &nvjpeg2k_pin_alloc_ : nullptr);
+    nvjpeg2k_thread_.AddWork([this, device_memory_padding_jpeg2k, host_memory_padding_jpeg2k](int) {
+      nvjpeg2k_handle_ = NvJPEG2KHandle(&nvjpeg2k_dev_alloc_, &nvjpeg2k_pin_alloc_);
 
       nvjpeg2k_decoder_ = NvJPEG2KDecodeState(nvjpeg2k_handle_);
     });

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -113,7 +113,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     NVJPEG_CALL(nvjpegSetPinnedMemoryPadding(host_memory_padding, handle_));
 
     nvjpegDevAllocator_t *device_allocator_ptr = &device_allocator_;
-    nvjpegPinnedAllocator_t *pinned_allocator_ptr = &pinned_allocator_ ;
+    nvjpegPinnedAllocator_t *pinned_allocator_ptr = &pinned_allocator_;
 
     nvjpeg_memory::SetEnableMemStats(spec.GetArgument<bool>("memory_stats"));
 
@@ -174,7 +174,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::Pinned,
                                host_memory_padding_jpeg2k);
     }
-    nvjpeg2k_thread_.AddWork([this, device_memory_padding_jpeg2k, host_memory_padding_jpeg2k](int) {
+    nvjpeg2k_thread_.AddWork([this](int) {
       nvjpeg2k_handle_ = NvJPEG2KHandle(&nvjpeg2k_dev_alloc_, &nvjpeg2k_pin_alloc_);
 
       nvjpeg2k_decoder_ = NvJPEG2KDecodeState(nvjpeg2k_handle_);

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
@@ -66,8 +66,9 @@ struct Buffer {
   size_t size;
 };
 
-using BufferPool = std::map<std::thread::id,
-                            std::array<std::vector<Buffer>, static_cast<size_t>(AllocType::Count)>>;
+using MemoryPool = std::array<std::vector<Buffer>, static_cast<size_t>(AllocType::Count)>;
+using BufferPool = std::map<std::thread::id, MemoryPool>;
+
 BufferPool buffer_pool_;
 std::shared_timed_mutex buffer_pool_mutex_;
 
@@ -123,29 +124,32 @@ unique_ptr_t Allocate(std::thread::id thread_id, AllocType alloc_type, size_t si
 
 void* GetBuffer(std::thread::id thread_id, AllocType alloc_type, size_t size) {
   std::shared_lock<std::shared_timed_mutex> lock(buffer_pool_mutex_);
-  auto &buffer_set = buffer_pool_[thread_id];
+  auto it = buffer_pool_.find(thread_id);
+  auto end_it =  buffer_pool_.end();
   lock.unlock();
-
-  auto &buffers = buffer_set[static_cast<size_t>(alloc_type)];
-  auto best_fit = buffers.end();
-  auto smallest = buffers.end();
-  for (auto it = buffers.begin(); it != buffers.end(); ++it) {
-    if (smallest == buffers.end() || it->size < smallest->size) {
-      smallest = it;
+  // only if pool exits for given thread_id search it, otherwise just allocate
+  if (it != end_it) {
+    auto &buffers = it->second[static_cast<size_t>(alloc_type)];
+    auto best_fit = buffers.end();
+    auto smallest = buffers.end();
+    for (auto it = buffers.begin(); it != buffers.end(); ++it) {
+      if (smallest == buffers.end() || it->size < smallest->size) {
+        smallest = it;
+      }
+      if (it->size >= size && (best_fit == buffers.end() || it->size < best_fit->size)) {
+        best_fit = it;
+      }
     }
-    if (it->size >= size && (best_fit == buffers.end() || it->size < best_fit->size)) {
-      best_fit = it;
+    if (best_fit != buffers.end()) {
+      std::swap(*best_fit, buffers.back());
+      auto buffer = std::move(buffers.back());
+      buffers.pop_back();
+      return buffer.ptr.release();
     }
-  }
-  if (best_fit != buffers.end()) {
-    std::swap(*best_fit, buffers.back());
-    auto buffer = std::move(buffers.back());
-    buffers.pop_back();
-    return buffer.ptr.release();
-  }
-  if (smallest != buffers.end()) {
-    std::swap(*smallest, buffers.back());
-    buffers.pop_back();
+    if (smallest != buffers.end()) {
+      std::swap(*smallest, buffers.back());
+      buffers.pop_back();
+    }
   }
   // Couldn't find a preallocated buffer, proceed to allocate
   AddMemStats(alloc_type, size);
@@ -160,9 +164,18 @@ static int ReturnBufferToPool(void *raw_ptr) {
   info_lock.unlock();
   std::unique_ptr<char, Deleter> ptr(reinterpret_cast<char*>(raw_ptr), Deleter(info.alloc_type));
   std::shared_lock<std::shared_timed_mutex> lock(buffer_pool_mutex_);
-  auto &buffer_set = buffer_pool_[info.thread_id];
+  auto it = buffer_pool_.find(info.thread_id);
+  auto end_it =  buffer_pool_.end();
   lock.unlock();
-  auto &buffers = buffer_set[static_cast<size_t>(info.alloc_type)];
+  MemoryPool *pool;
+  if (it != end_it) {
+    pool = &(it->second);
+  } else {
+    // if nothing has been preallocated create a pool for given thread_id
+    std::unique_lock<std::shared_timed_mutex> lock(buffer_pool_mutex_);
+    pool = &(buffer_pool_[info.thread_id]);
+  }
+  auto &buffers = (*pool)[static_cast<size_t>(info.alloc_type)];
   buffers.emplace_back(std::move(ptr), info.alloc_type, info.size);
   return 0;
 }
@@ -180,7 +193,7 @@ void AddBuffer(std::thread::id thread_id, AllocType alloc_type, size_t size) {
 void DeleteAllBuffers(std::thread::id thread_id) {
   std::shared_lock<std::shared_timed_mutex> lock(buffer_pool_mutex_);
   auto it = buffer_pool_.find(thread_id);
-  // if no buffer have been preallocated
+  // no buffers have been preallocated/returned to the pool
   if (it == buffer_pool_.end()) {
     return;
   }


### PR DESCRIPTION
- decouples nvJPEG and nvJPEG2k options to preallocate decoder memory as usually user will have a pure JPEG or pure JPEG2k dataset and doesn't want to waste memory for both decoders

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It decouples nvJPEG and nvJPEG2k options to preallocate decoder memory as usually user will have a pure JPEG or pure JPEG2k dataset and doesn't want to waste memory for both decoders

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     decouples nvJPEG and nvJPEG2k options to preallocate decoder memory as usually user will have a pure JPEG or pure JPEG2k dataset and doesn't want to waste memory for both decoders
 - Affected modules and functionalities:
     image decoder
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
