### PR TITLE
Tensor concatenation and stacking

### DIFF
--- a/dali/kernels/common/join/tensor_join_gpu_impl.h
+++ b/dali/kernels/common/join/tensor_join_gpu_impl.h
@@ -30,7 +30,7 @@ class DLL_PUBLIC TensorJoinImplGPU {
  public:
   static_assert(std::is_same<T, type_of_size<sizeof(T)>>::value,
                 "This class must be used with a type proudced by `type_of_size<size>`");
-  static_assert(sizeof(T) >= 1 && sizeof(T) <= 16 && (sizeof(T)&sizeof(T)-1) == 0,
+  static_assert(sizeof(T) >= 1 && sizeof(T) <= 16 && (sizeof(T)&(sizeof(T)-1)) == 0,
                 "TensorJoin works only for types of size 1, 2, 4, 8 and 16 bytes.");
 
   /**

--- a/dali/operators/generic/constant.cc
+++ b/dali/operators/generic/constant.cc
@@ -106,7 +106,6 @@ void Constant<CPUBackend>::RunImpl(HostWorkspace &ws) {
         if (!fdata_.empty()) {
           FillTensorVector<type>(output_, output_shape_, fdata_);
         } else {
-          assert(!idata_.empty());
           FillTensorVector<type>(output_, output_shape_, idata_);
         }
       ), (DALI_FAIL(make_string("Unsupported type: ", output_type_))));  // NOLINT

--- a/dali/operators/generic/constant.cu
+++ b/dali/operators/generic/constant.cu
@@ -90,7 +90,6 @@ void Constant<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
         if (!fdata_.empty()) {
           FillTensorList<type>(output_, output_shape_, fdata_, ws.stream());
         } else {
-          assert(!idata_.empty());
           FillTensorList<type>(output_, output_shape_, idata_, ws.stream());
         }
       ), (DALI_FAIL(make_string("Unsupported type: ", output_type_))));  // NOLINT

--- a/dali/operators/generic/join.cc
+++ b/dali/operators/generic/join.cc
@@ -1,0 +1,30 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/generic/join.h"
+
+namespace dali {
+
+template <typename Backend, bool new_axis>
+void TensorJoin<Backend, new_axis>::CollectInputs(const workspace_t<Backend> &ws) {
+  int njoin = ws.NumRegularInput()
+  inputs_.resize(njoin);
+  output_type_ = ws.template InputRef<Backend>(i).type();
+  for (int i = 1; i < njoin; i++) {
+    DALI_ENFORCE(ws.template InputRef<Backend>(i).type().id() == output_type_.
+  }
+}
+
+
+}  // namespace dali

--- a/dali/operators/generic/join.cc
+++ b/dali/operators/generic/join.cc
@@ -12,18 +12,135 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
+#include <utility>
+#include "dali/core/format.h"
+#include "dali/core/static_switch.h"
+#include "dali/pipeline/data/views.h"
 #include "dali/operators/generic/join.h"
+#include "dali/kernels/common/join/tensor_join_cpu.h"
+#include "dali/kernels/common/join/tensor_join_gpu.h"
 
 namespace dali {
 
+#define TENSOR_JOIN_TYPES (bool, uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, \
+                          uint64_t, int64_t, float16, float, double)
+
 template <typename Backend, bool new_axis>
-void TensorJoin<Backend, new_axis>::CollectInputs(const workspace_t<Backend> &ws) {
-  int njoin = ws.NumRegularInput()
-  inputs_.resize(njoin);
-  output_type_ = ws.template InputRef<Backend>(i).type();
+bool TensorJoin<Backend, new_axis>::SetupImpl(
+        vector<OutputDesc> &outputs, const workspace_t<Backend> &ws) {
+  int njoin = ws.NumRegularInput();
+  outputs.resize(1);
+  outputs[0].type = ws.template InputRef<Backend>(0).type();
+  auto &output_shape = outputs[0].shape;
+
+  // Check that all inputs have the same type
+  DALIDataType out_type = outputs[0].type.id();
   for (int i = 1; i < njoin; i++) {
-    DALI_ENFORCE(ws.template InputRef<Backend>(i).type().id() == output_type_.
+    DALIDataType type_id = ws.template InputRef<Backend>(i).type().id();
+    DALI_ENFORCE(type_id == out_type, make_string(
+        "All inputs must have the same type.\nType of input #0: ", out_type,
+        "\nType of input #", i, ": ", type_id));
   }
+
+  // Get the join axis index
+  axis_ = this->spec_.template GetArgument<int>("axis");
+
+  // Run ove inputs and store them in a vector
+  TYPE_SWITCH(out_type, type2id, T, TENSOR_JOIN_TYPES, (
+    SetupTyped<T>(output_shape, ws);
+  ), (DALI_FAIL(make_string("The element type ", out_type, " is not supported."))));  // NOLINT
+}
+
+template <typename Backend, bool new_axis>
+template <typename T>
+void TensorJoin<Backend, new_axis>::SetupTyped(
+      TensorListShape<> &output_shape, const workspace_t<Backend> &ws) {
+  auto &inputs = this->template inputs<T>();
+  inputs.clear();
+  int njoin = ws.NumRegularInput();
+  for (int i = 0; i < njoin; i++) {
+    auto tlv = view<T>(ws.template InputRef<Backend>(i));
+    if (tlv.num_elements() > 0) {
+      inputs.push_back(std::move(tlv));
+    }
+  }
+
+  JoinedShape(output_shape, [&](int index) {
+    return &inputs[index].shape;
+  }, axis_);
+  DALI_ENFORCE(axis_ < output_shape.sample_dim(), make_string("Invalid axis index: ", axis_));
+}
+
+template <typename Backend, bool new_axis>
+TensorLayout TensorJoin<Backend, new_axis>::GetLayout(const workspace_t<Backend> &ws) {
+  if (new_axis)
+    return {};
+  int njoin = ws.NumRegularInput();
+  for (int i = 0; i < njoin; i++) {
+    auto &in = ws.template InputRef<Backend>(0).GetLayout();
+    TensorLayout tl = in.GetLayout();
+    if (!tl.empty())
+        return tl;
+  }
+  return {};
+}
+
+
+template <typename Backend, bool new_axis>
+void TensorJoin<Backend, new_axis>::RunImpl(workspace_t<Backend> &ws) {
+  auto &out = ws.template OutputRef<Backend>(0);
+  out.SetLayout(GetLayout(ws));
+  TYPE_SWITCH(out.type().id(), type2id, T, TENSOR_JOIN_TYPES, (
+    RunTyped(view<T>(out, ws));
+  ), (DALI_FAIL("Internal error: unsupported type reached RunImpl function")));  // NOLINT
+}
+
+template <typename Backend, bool new_axis>
+template <typename T>
+void TensorJoin<Backend, new_axis>::RunTyped(
+    const TensorListView<Storage, T> &out, HostWorkspace &ws) {
+  using Kernel = kernels::TensorJoinCPU<T, new_axis>;
+  ThreadPool &tp = ws.GetThreadPool();
+  int num_threads = tp.size();
+  kmgr_.Resize<Kernel>(num_threads, num_threads);
+  auto &inputs = this->template inputs<T>();
+  SmallVector<kernels::InTensorCPU<T>, 128> in_tensors;
+  SmallVector<TensorShape<>, 128> in_shapes;
+
+  int N = out.num_samples();
+  int njoin = inputs.size();
+  in_tensors.resize(num_threads * njoin);
+  in_shapes.resize(num_threads * njoin);
+
+  for (int i = 0; i < N; i++) {
+    tp.AddWork([&, i](int tid) {
+      kernels::KernelContext ctx;
+      auto sample_in_tensors = make_cspan(&in_tensors[tid * njoin], njoin);
+      auto sample_in_shapes = make_cspan(&in_shapes[tid * njoin], njoin);
+      for (int t = 0; t < njoin; t++) {
+        sample_in_tensors[t] = inputs[t][i];
+        sample_in_shapes[t] = sample_in_tensors[t].shape;
+      }
+      kmgr_.Setup<Kernel>(ctx, sample_in_shapes, axis_);
+      kmgr_.Run<Kernel>(ctx, out[i], sample_in_tensors);
+    }, volume(out.tensor_shape_span[i]));
+  }
+}
+
+template <typename Backend, bool new_axis>
+template <typename T>
+void TensorJoin<Backend, new_axis>::RunTyped(
+    const TensorListView<Storage, T> &out, DeviceWorkspace &ws) {
+  using Kernel = kernels::TensorJoinGPU<T, new_axis>;
+  kernels::KernelContext ctx;
+  ctx.gpu.stream = ws.stream();
+
+  auto &inputs = this->template inputs<T>();
+
+  kmgr_.Resize<Kernel>(1);
+  kmgr_.Setup(ctx, make_span(inputs), axis_);
+  kmgr_.Run(ctx, out, make_span(inputs));
 }
 
 

--- a/dali/operators/generic/join.h
+++ b/dali/operators/generic/join.h
@@ -51,7 +51,7 @@ class TensorJoin : public Operator<Backend> {
   using Operator<Backend>::Operator;
 
   bool CanInferOutputs() const override { return true; }
-  void RunImpl(workspace_t<Backend> &ws);
+  void RunImpl(workspace_t<Backend> &ws) override;
   bool SetupImpl(vector<OutputDesc> &outputs, const workspace_t<Backend> &ws) override;
 
  protected:

--- a/dali/operators/generic/join.h
+++ b/dali/operators/generic/join.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_GENERIC_JOIN_H_
+#define DALI_OPERATORS_GENERIC_JOIN_H_
+
+#include "dali/kernels/common/join/tensor_join_cpu.h"
+#include "dali/kernels/common/join/tensor_join_gpu.h"
+
+namespace dali {
+
+template <typename Backend, bool new_axis>
+class TensorJoin<Backend> : public Operator<Backend> {
+ public:
+  using Operator<Backend>::Operator;
+  bool SetupImpl()
+  bool CanInferOutputs() const override { return true; }
+ protected:
+  void CollectInputs(const workspace_t<Backend> &ws);
+
+  SmallVector<TensorListView<void>> inputs_;
+  TypeInfo output_type_;
+  KernelManager mgr_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_GENERIC_JOIN_H_

--- a/dali/operators/generic/join.h
+++ b/dali/operators/generic/join.h
@@ -15,6 +15,8 @@
 #ifndef DALI_OPERATORS_GENERIC_JOIN_H_
 #define DALI_OPERATORS_GENERIC_JOIN_H_
 
+#include <string>
+#include <vector>
 #include "dali/core/any.h"
 #include "dali/pipeline/operator/operator.h"
 #include "dali/kernels/kernel_manager.h"
@@ -26,6 +28,24 @@ namespace dali {
 template <typename Backend, bool new_axis>
 class TensorJoin : public Operator<Backend> {
  public:
+  explicit TensorJoin(const OpSpec &spec) : Operator<Backend>(spec) {
+    has_axis_ = spec.HasArgument("axis");
+    has_axis_name_ = spec.HasArgument("axis_name");
+    if (!new_axis) {
+      DALI_ENFORCE(!(has_axis_ && has_axis_name_),
+        "Arguments ``axis`` and ``axis_name`` cannot be used together.");
+    }
+
+    if (has_axis_)
+      axis_arg_ = spec.GetArgument<int>("axis");
+    if (has_axis_name_) {
+      auto axis_name_str = spec.GetArgument<std::string>("axis_name");
+      DALI_ENFORCE(axis_name_str.length() == 1, make_string("``axis_name``"
+        " must be a single character; got ", axis_name_str));
+      axis_name_arg_ = axis_name_str[0];
+    }
+  }
+
   using Storage = detail::storage_tag_map_t<Backend>;
 
   using Operator<Backend>::Operator;
@@ -33,13 +53,14 @@ class TensorJoin : public Operator<Backend> {
   bool CanInferOutputs() const override { return true; }
   void RunImpl(workspace_t<Backend> &ws);
   bool SetupImpl(vector<OutputDesc> &outputs, const workspace_t<Backend> &ws) override;
- protected:
 
+ protected:
   template <typename T>
   auto &inputs() {
-    using RetType = vector<const TensorListView<Storage, const T>>;
-    if (!inputs_.is_type<RetType>())
-        inputs_ = RetType();
+    using RetType = vector<TensorListView<Storage, const T>>;
+    if (RetType *inp = any_cast<RetType>(&inputs_))
+      return *inp;
+    inputs_ = RetType();
     return any_cast<RetType&>(inputs_);
   }
 
@@ -52,11 +73,19 @@ class TensorJoin : public Operator<Backend> {
   template <typename T>
   void RunTyped(const TensorListView<Storage, T> &out, DeviceWorkspace &ws);
 
-  int axis_ = -1;
-  TensorLayout GetLayout(const workspace_t<Backend> &ws);
+  void GetInputLayout(const workspace_t<Backend> &ws);
+  void SetupAxis();
+  void SetOutputLayout(const workspace_t<Backend> &ws);
 
   any inputs_;
   kernels::KernelManager kmgr_;
+  int axis_ = -1;
+  TensorLayout input_layout_, output_layout_;
+
+  bool has_axis_ = false, has_axis_name_ = false;
+  int axis_arg_ = 0;
+  int copy_idx_ = -1;
+  char axis_name_arg_ = 0;
 };
 
 }  // namespace dali

--- a/dali/test/python/test_operator_join.py
+++ b/dali/test/python/test_operator_join.py
@@ -1,0 +1,195 @@
+import nvidia.dali as dali
+import nvidia.dali.fn as fn
+import numpy as np
+import math
+from test_utils import check_batch
+
+np.random.seed(1234)
+
+def input_generator(num_inputs, batch_size, ndim, variable_axis = None):
+    max_extent = int(math.ceil(math.pow(1e+6 / (batch_size * num_inputs), 1 / ndim))) if ndim > 0 else 1
+    def gen():
+        if ndim == 0:
+            inputs = []
+            for i in range(num_inputs):
+                inputs.append([np.float32(np.random.random()) for _ in range(batch_size)])
+            return inputs
+
+        inputs = [[] for _ in range(num_inputs)]
+        for i in range(batch_size):
+            base_shape = np.random.randint(1,max_extent,[ndim])
+            for j in range(num_inputs):
+                shape = list(base_shape)
+                if variable_axis is not None:
+                    shape[variable_axis] = np.random.randint(1, 10)
+                inputs[j].append(np.random.random(shape).astype(np.float32))
+        return inputs
+    return gen
+
+def test_cat_different_length():
+    pipe = dali.pipeline.Pipeline(batch_size = 1, num_threads = 3, device_id = 0)
+    with pipe:
+        src1 = dali.types.Constant(np.array(
+            [[1, 2, 3 ,4],
+             [5, 6, 7, 8],
+             [9,10,11,12]]))
+        src2 = dali.types.Constant(np.array(
+            [[13,14,15],
+             [16,17,18],
+             [19,20,21]]))
+        out_cpu = fn.cat(src1, src2, axis = 1)
+        out_gpu = fn.cat(src1.gpu(), src2.gpu(), axis = 1)
+        pipe.set_outputs(out_cpu, out_gpu)
+
+    pipe.build()
+    o = pipe.run()
+
+    o = list(o)
+    o[1] = o[1].as_cpu();
+
+    ref = np.array([[1, 2, 3, 4,13,14,15],
+                    [5, 6, 7, 8,16,17,18],
+                    [9,10,11,12,19,20,21]])
+    assert np.array_equal(o[0].at(0), ref)
+    assert np.array_equal(o[1].at(0), ref)
+
+
+def test_cat_empty_input():
+    pipe = dali.pipeline.Pipeline(batch_size = 1, num_threads = 3, device_id = 0)
+    with pipe:
+        src1 = dali.types.Constant(np.array(
+            [[1, 2, 3 ,4],
+             [5, 6, 7, 8],
+             [9,10,11,12]]))
+        src2 = dali.types.Constant(np.array(
+            [[],
+             [],
+             []], dtype=np.int32))
+        src3 = dali.types.Constant(np.array(
+            [[13,14,15],
+             [16,17,18],
+             [19,20,21]]))
+        out_cpu = fn.cat(src1, src2, src3, axis = 1)
+        out_gpu = fn.cat(src1.gpu(), src2.gpu(), src3.gpu(), axis = 1)
+        pipe.set_outputs(out_cpu, out_gpu)
+
+    pipe.build()
+    o = pipe.run()
+
+    o = list(o)
+    o[1] = o[1].as_cpu();
+
+    ref = np.array([[1, 2, 3, 4,13,14,15],
+                    [5, 6, 7, 8,16,17,18],
+                    [9,10,11,12,19,20,21]])
+    assert np.array_equal(o[0].at(0), ref)
+    assert np.array_equal(o[1].at(0), ref)
+
+
+def test_cat_all_empty():
+    pipe = dali.pipeline.Pipeline(batch_size = 1, num_threads = 3, device_id = 0)
+    with pipe:
+        src1 = dali.types.Constant(np.array(
+            [[],
+             [],
+             []], dtype=np.int32))
+        out_cpu = fn.cat(src1, src1, src1, axis = 1)
+        out_gpu = fn.cat(src1.gpu(), src1.gpu(), src1.gpu(), axis = 1)
+        pipe.set_outputs(out_cpu, out_gpu)
+
+    pipe.build()
+    o = pipe.run()
+
+    o = list(o)
+    o[1] = o[1].as_cpu();
+
+    ref = np.array([[], [], []], dtype=np.int32)
+    assert np.array_equal(o[0].at(0), ref)
+    assert np.array_equal(o[1].at(0), ref)
+
+
+def ref_cat(input_batches, axis):
+    N = len(input_batches[0])
+    out = []
+    for i in range(N):
+        inputs = [x[i] for x in input_batches]
+        out.append(np.concatenate(inputs, axis=axis))
+    return out
+
+def ref_stack(input_batches, axis):
+    N = len(input_batches[0])
+    out = []
+    for i in range(N):
+        inputs = [x[i] for x in input_batches]
+        out.append(np.stack(inputs, axis=axis))
+    return out
+
+def _run_test_cat(num_inputs, layout, ndim, axis, axis_name):
+    num_iter=3
+    batch_size=4
+    if ndim is None:
+        ndim = len(layout)
+
+    ref_axis = layout.find(axis_name) if axis_name is not None else axis if axis is not None else 0
+    assert ref_axis >= 0
+
+    axis_arg = None if axis_name else axis
+
+    pipe = dali.pipeline.Pipeline(batch_size=batch_size, num_threads = 3, device_id = 0)
+    with pipe:
+        inputs = fn.external_source(input_generator(num_inputs, batch_size, ndim, ref_axis), num_outputs=num_inputs, layout=layout)
+        out_cpu = fn.cat(*inputs,                    axis=axis_arg, axis_name=axis_name)
+        out_gpu = fn.cat(*(x.gpu() for x in inputs), axis=axis_arg, axis_name=axis_name)
+        pipe.set_outputs(out_cpu, out_gpu, *inputs);
+    pipe.build()
+
+    for iter in range(num_iter):
+        o_cpu, o_gpu, *inputs = pipe.run()
+        ref = ref_cat(inputs, ref_axis)
+        check_batch(o_cpu, ref, batch_size, eps=0, expected_layout=layout)
+        check_batch(o_gpu, ref, batch_size, eps=0, expected_layout=layout)
+
+
+def _run_test_stack(num_inputs, layout, ndim, axis, axis_name):
+    num_iter=3
+    batch_size=4
+    if ndim is None:
+        ndim = len(layout)
+
+    ref_axis = axis if axis is not None else 0
+
+    if axis_name:
+        ref_layout = layout[:axis] + axis_name + layout[axis:] if layout else axis_name
+    else:
+        ref_layout = ""
+
+    pipe = dali.pipeline.Pipeline(batch_size=batch_size, num_threads = 3, device_id = 0)
+    with pipe:
+        inputs  = fn.external_source(input_generator(num_inputs, batch_size, ndim), num_outputs=num_inputs, layout=layout)
+        out_cpu = fn.stack(*inputs,                    axis=axis, axis_name=axis_name)
+        out_gpu = fn.stack(*(x.gpu() for x in inputs), axis=axis, axis_name=axis_name)
+        pipe.set_outputs(out_cpu, out_gpu, *inputs);
+    pipe.build()
+
+    for iter in range(num_iter):
+        o_cpu, o_gpu, *inputs = pipe.run()
+        ref = ref_stack(inputs, ref_axis)
+        check_batch(o_cpu, ref, batch_size, eps=0, expected_layout=ref_layout)
+        check_batch(o_gpu, ref, batch_size, eps=0, expected_layout=ref_layout)
+
+
+def test_cat():
+    for num_inputs in [1, 2, 3, 100]:
+        for layout, ndim in [(None, 0), (None, 1), ('A', 1), (None, 2), ('HW', 2), (None, 3), ('DHW', 3)]:
+            for axis in range(ndim):
+                axis_name = layout[axis] if layout else None
+                yield _run_test_cat, num_inputs, layout, ndim, axis, axis_name
+
+def test_stack():
+    for num_inputs in [1, 2, 3, 100]:
+        for layout, ndim in [(None, 0), (None, 1), ('A', 1), (None, 2), ('HW', 2), (None, 3), ('DHW', 3)]:
+            for axis in range(ndim+1):
+                axis_names = [None] if layout is None and ndim > 0 else [None, 'C']
+                for axis_name in axis_names:
+                    yield _run_test_stack, num_inputs, layout, ndim, axis, axis_name
+

--- a/docs/examples/general/index.rst
+++ b/docs/examples/general/index.rst
@@ -9,3 +9,4 @@ General
    multigpu.ipynb
    erase.ipynb
    normalize.ipynb
+   tensor_join.ipynb

--- a/docs/examples/general/tensor_join.ipynb
+++ b/docs/examples/general/tensor_join.ipynb
@@ -1,0 +1,404 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tensor joining\n",
+    "\n",
+    "This notebook demonstrates two metbhods of joining tensors: stacking and concatenation.\n",
+    "\n",
+    "Both of these operations take multiple inputs and produce the output by joining the input tensors.\n",
+    "The difference between these methods is that concatenation joins the tensors along an existing axis, whereas stacking inserts a new axis.\n",
+    "Stacking can be used, for example, to combine separate combine separate coordinates into vectors, or to combine color planes into color images.\n",
+    "Concatenation can be used, among other applications, for joining tiles into a larger image or appending lists."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Concatenation\n",
+    "In this section we'll demonstrate concatenation along different axes. Since we'll be concatenating the same tensors along different axes, it is required that the tensors have identical shapes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nvidia.dali as dali\n",
+    "import nvidia.dali.fn as fn\n",
+    "import numpy as np\n",
+    "\n",
+    "np.random.seed(1234)\n",
+    "\n",
+    "arr = np.array([\n",
+    "    [[1,2,3,4],\n",
+    "     [5,6,7,8],\n",
+    "     [9,10,11,12]],\n",
+    "    [[13,14,15,16],\n",
+    "     [17,18,19,20],\n",
+    "     [21,22,23,24]]\n",
+    "])\n",
+    "\n",
+    "src1 = dali.types.Constant(arr)\n",
+    "src2 = dali.types.Constant(arr + 100)\n",
+    "src3 = dali.types.Constant(arr + 200)    \n",
+    "\n",
+    "pipe_cat = dali.pipeline.Pipeline(batch_size = 1, num_threads = 3, device_id = 0)\n",
+    "with pipe_cat:\n",
+    "    cat_outer = fn.cat(src1, src2, src3, axis = 0)\n",
+    "    cat_middle = fn.cat(src1, src2, src3, axis = 1)\n",
+    "    cat_inner = fn.cat(src1, src2, src3, axis = 2)\n",
+    "    pipe_cat.set_outputs(cat_outer, cat_middle, cat_inner)\n",
+    "    \n",
+    "pipe_cat.build()\n",
+    "o = pipe_cat.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Concatenation along outer axis:\n",
+      "[[[  1   2   3   4]\n",
+      "  [  5   6   7   8]\n",
+      "  [  9  10  11  12]]\n",
+      "\n",
+      " [[ 13  14  15  16]\n",
+      "  [ 17  18  19  20]\n",
+      "  [ 21  22  23  24]]\n",
+      "\n",
+      " [[101 102 103 104]\n",
+      "  [105 106 107 108]\n",
+      "  [109 110 111 112]]\n",
+      "\n",
+      " [[113 114 115 116]\n",
+      "  [117 118 119 120]\n",
+      "  [121 122 123 124]]\n",
+      "\n",
+      " [[201 202 203 204]\n",
+      "  [205 206 207 208]\n",
+      "  [209 210 211 212]]\n",
+      "\n",
+      " [[213 214 215 216]\n",
+      "  [217 218 219 220]\n",
+      "  [221 222 223 224]]]\n",
+      "Shape:  (6, 3, 4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Concatenation along outer axis:\")\n",
+    "print(o[0].at(0))\n",
+    "print(\"Shape: \", o[0].at(0).shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Concatenation along middle axis:\n",
+      "[[[  1   2   3   4]\n",
+      "  [  5   6   7   8]\n",
+      "  [  9  10  11  12]\n",
+      "  [101 102 103 104]\n",
+      "  [105 106 107 108]\n",
+      "  [109 110 111 112]\n",
+      "  [201 202 203 204]\n",
+      "  [205 206 207 208]\n",
+      "  [209 210 211 212]]\n",
+      "\n",
+      " [[ 13  14  15  16]\n",
+      "  [ 17  18  19  20]\n",
+      "  [ 21  22  23  24]\n",
+      "  [113 114 115 116]\n",
+      "  [117 118 119 120]\n",
+      "  [121 122 123 124]\n",
+      "  [213 214 215 216]\n",
+      "  [217 218 219 220]\n",
+      "  [221 222 223 224]]]\n",
+      "Shape:  (2, 9, 4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Concatenation along middle axis:\")\n",
+    "print(o[1].at(0))\n",
+    "print(\"Shape: \", o[1].at(0).shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Concatenation along inner axis:\n",
+      "[[[  1   2   3   4 101 102 103 104 201 202 203 204]\n",
+      "  [  5   6   7   8 105 106 107 108 205 206 207 208]\n",
+      "  [  9  10  11  12 109 110 111 112 209 210 211 212]]\n",
+      "\n",
+      " [[ 13  14  15  16 113 114 115 116 213 214 215 216]\n",
+      "  [ 17  18  19  20 117 118 119 120 217 218 219 220]\n",
+      "  [ 21  22  23  24 121 122 123 124 221 222 223 224]]]\n",
+      "Shape:  (2, 3, 12)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Concatenation along inner axis:\")\n",
+    "print(o[2].at(0))\n",
+    "print(\"Shape: \", o[2].at(0).shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Stacking\n",
+    "\n",
+    "When stacking, a new axis is inserted. It can be inserted _after_ the innermost axis, in which case the values from the input tensors are interleaved.\n",
+    "\n",
+    "Let's apply stacking to the same inputs which were used for concatenation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe_stack = dali.pipeline.Pipeline(batch_size = 1, num_threads = 3, device_id = 0)\n",
+    "with pipe_stack:\n",
+    "    st_outermost = fn.stack(src1, src2, src3, axis = 0)\n",
+    "    st_1         = fn.stack(src1, src2, src3, axis = 1)\n",
+    "    st_2         = fn.stack(src1, src2, src3, axis = 2)\n",
+    "    st_new_inner = fn.stack(src1, src2, src3, axis = 3)\n",
+    "    pipe_stack.set_outputs(st_outermost, st_1, st_2, st_new_inner)\n",
+    "    \n",
+    "pipe_stack.build()\n",
+    "o = pipe_stack.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stacking - insert outermost axis:\n",
+      "[[[[  1   2   3   4]\n",
+      "   [  5   6   7   8]\n",
+      "   [  9  10  11  12]]\n",
+      "\n",
+      "  [[ 13  14  15  16]\n",
+      "   [ 17  18  19  20]\n",
+      "   [ 21  22  23  24]]]\n",
+      "\n",
+      "\n",
+      " [[[101 102 103 104]\n",
+      "   [105 106 107 108]\n",
+      "   [109 110 111 112]]\n",
+      "\n",
+      "  [[113 114 115 116]\n",
+      "   [117 118 119 120]\n",
+      "   [121 122 123 124]]]\n",
+      "\n",
+      "\n",
+      " [[[201 202 203 204]\n",
+      "   [205 206 207 208]\n",
+      "   [209 210 211 212]]\n",
+      "\n",
+      "  [[213 214 215 216]\n",
+      "   [217 218 219 220]\n",
+      "   [221 222 223 224]]]]\n",
+      "Shape:  (3, 2, 3, 4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Stacking - insert outermost axis:\")\n",
+    "print(o[0].at(0))\n",
+    "print(\"Shape: \", o[0].at(0).shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stacking - new axis before 1:\n",
+      "[[[[  1   2   3   4]\n",
+      "   [  5   6   7   8]\n",
+      "   [  9  10  11  12]]\n",
+      "\n",
+      "  [[101 102 103 104]\n",
+      "   [105 106 107 108]\n",
+      "   [109 110 111 112]]\n",
+      "\n",
+      "  [[201 202 203 204]\n",
+      "   [205 206 207 208]\n",
+      "   [209 210 211 212]]]\n",
+      "\n",
+      "\n",
+      " [[[ 13  14  15  16]\n",
+      "   [ 17  18  19  20]\n",
+      "   [ 21  22  23  24]]\n",
+      "\n",
+      "  [[113 114 115 116]\n",
+      "   [117 118 119 120]\n",
+      "   [121 122 123 124]]\n",
+      "\n",
+      "  [[213 214 215 216]\n",
+      "   [217 218 219 220]\n",
+      "   [221 222 223 224]]]]\n",
+      "Shape:  (2, 3, 3, 4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Stacking - new axis before 1:\")\n",
+    "print(o[1].at(0))\n",
+    "print(\"Shape: \", o[1].at(0).shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stacking - new axis before 2:\n",
+      "[[[[  1   2   3   4]\n",
+      "   [101 102 103 104]\n",
+      "   [201 202 203 204]]\n",
+      "\n",
+      "  [[  5   6   7   8]\n",
+      "   [105 106 107 108]\n",
+      "   [205 206 207 208]]\n",
+      "\n",
+      "  [[  9  10  11  12]\n",
+      "   [109 110 111 112]\n",
+      "   [209 210 211 212]]]\n",
+      "\n",
+      "\n",
+      " [[[ 13  14  15  16]\n",
+      "   [113 114 115 116]\n",
+      "   [213 214 215 216]]\n",
+      "\n",
+      "  [[ 17  18  19  20]\n",
+      "   [117 118 119 120]\n",
+      "   [217 218 219 220]]\n",
+      "\n",
+      "  [[ 21  22  23  24]\n",
+      "   [121 122 123 124]\n",
+      "   [221 222 223 224]]]]\n",
+      "Shape:  (2, 3, 3, 4)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Stacking - new axis before 2:\")\n",
+    "print(o[2].at(0))\n",
+    "print(\"Shape: \", o[2].at(0).shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stacking - new innermost axis:\n",
+      "[[[[  1 101 201]\n",
+      "   [  2 102 202]\n",
+      "   [  3 103 203]\n",
+      "   [  4 104 204]]\n",
+      "\n",
+      "  [[  5 105 205]\n",
+      "   [  6 106 206]\n",
+      "   [  7 107 207]\n",
+      "   [  8 108 208]]\n",
+      "\n",
+      "  [[  9 109 209]\n",
+      "   [ 10 110 210]\n",
+      "   [ 11 111 211]\n",
+      "   [ 12 112 212]]]\n",
+      "\n",
+      "\n",
+      " [[[ 13 113 213]\n",
+      "   [ 14 114 214]\n",
+      "   [ 15 115 215]\n",
+      "   [ 16 116 216]]\n",
+      "\n",
+      "  [[ 17 117 217]\n",
+      "   [ 18 118 218]\n",
+      "   [ 19 119 219]\n",
+      "   [ 20 120 220]]\n",
+      "\n",
+      "  [[ 21 121 221]\n",
+      "   [ 22 122 222]\n",
+      "   [ 23 123 223]\n",
+      "   [ 24 124 224]]]]\n",
+      "Shape:  (2, 3, 4, 3)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Stacking - new innermost axis:\")\n",
+    "print(o[3].at(0))\n",
+    "print(\"Shape: \", o[3].at(0).shape)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/examples/general/tensor_join.ipynb
+++ b/docs/examples/general/tensor_join.ipynb
@@ -6,11 +6,11 @@
    "source": [
     "# Tensor joining\n",
     "\n",
-    "This notebook demonstrates two metbhods of joining tensors: stacking and concatenation.\n",
+    "This notebook demonstrates two methods of joining tensors: stacking and concatenation.\n",
     "\n",
     "Both of these operations take multiple inputs and produce the output by joining the input tensors.\n",
     "The difference between these methods is that concatenation joins the tensors along an existing axis, whereas stacking inserts a new axis.\n",
-    "Stacking can be used, for example, to combine separate combine separate coordinates into vectors, or to combine color planes into color images.\n",
+    "Stacking can be used, for example, to combine separate coordinates into vectors, or to combine color planes into color images.\n",
     "Concatenation can be used, among other applications, for joining tiles into a larger image or appending lists."
    ]
   },


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature: tensor concatenation and stacking operators

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Use TensorJoinCPU/TenosrJoinGPU kernels in the operator
     * Use a simple copy/reshaed copy when there's just 1 input
     * Use `any` to store type-specific data in the operator and avoid writing full-blown pImpl
     * Use function overloads to provide backend-specific RunImpl and have just one class
     * Register the operator with different template arguments (backend and new_axis) as Cat/Stack CPU/GPU
 - Affected modules and functionalities:
     * TensorJoin operator
     * Constant operator (minor fix)
 - Key points relevant for the review:
     * Axis handling
     * Use of `any` for inputs
 - Validation and testing:
     * Python tests
 - Documentation (including examples):
     * Docstrings
     * Jupyter

**JIRA TASK**: DALI-1620
