### PR TITLE
Disable more dependencies for nodeps build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,8 @@ cmake_dependent_option(BUILD_NVDEC "Build with NVIDIA NVDEC support" ON
                        "NOT BUILD_DALI_NODEPS" OFF)  # Video support requires ffmpeg as well
 set(BUILD_FFMPEG ${BUILD_NVDEC})
 
-option(BUILD_NVJPEG "Build with nvJPEG support" ON)
+cmake_dependent_option(BUILD_NVJPEG "Build with nvJPEG support" ON
+                       "NOT BUILD_DALI_NODEPS" OFF)
 # if BUILD_NVJPEG2K is empty remove it and let is be default
 if ("${BUILD_NVJPEG2K}" STREQUAL "")
   unset(BUILD_NVJPEG2K CACHE)
@@ -80,12 +81,15 @@ endif()
 # nvjpeg2k is not available prior CUDA 11.0
 if(${CUDA_VERSION} VERSION_GREATER_EQUAL "11.0")
   if(NOT (${ARCH} MATCHES "aarch64"))
-    option(BUILD_NVJPEG2K "Build with nvJPEG2K support" ON)
+    cmake_dependent_option(BUILD_NVJPEG2K "Build with nvJPEG2K support" ON
+                           "NOT BUILD_DALI_NODEPS" OFF)
   endif()
 endif()
 
-option(BUILD_NVOF "Build with NVIDIA OPTICAL FLOW SDK support" ON)
-option(BUILD_NVML "Build with NVIDIA Management Library (NVML) support" ON)
+cmake_dependent_option(BUILD_NVOF "Build with NVIDIA OPTICAL FLOW SDK support" ON
+                       "NOT BUILD_DALI_NODEPS" OFF)
+cmake_dependent_option(BUILD_NVML "Build with NVIDIA Management Library (NVML) support" ON
+                       "NOT BUILD_DALI_NODEPS" OFF)
 
 if (BUILD_DALI_NODEPS)
   set(BUILD_OPENCV OFF)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes some more unnecessary dependencies on nodeps build

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *nodeps build: Removed dependencies with libraries that are only used in operators library*
 - Affected modules and functionalities:
     *Build system*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *Existing test*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1640]*
