### PR TITLE
Enable CUDA 11 compatibility mode

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -273,10 +273,20 @@ function(parse_cuda_version CUDA_VERSION CUDA_VERSION_MAJOR_VAR CUDA_VERSION_MIN
   set(${CUDA_VERSION_MAJOR_VAR} "${${CUDA_VERSION_MAJOR_VAR}}" PARENT_SCOPE)
   set(${CUDA_VERSION_MINOR_VAR} "${${CUDA_VERSION_MINOR_VAR}}" PARENT_SCOPE)
   set(${CUDA_VERSION_PATCH_VAR} "${${CUDA_VERSION_PATCH_VAR}}" PARENT_SCOPE)
+  message(STATUS "CUDA version: ${CUDA_VERSION}, major: ${${CUDA_VERSION_MAJOR_VAR}}, minor: ${${CUDA_VERSION_MINOR_VAR}}, patch: ${${CUDA_VERSION_PATCH_VAR}}, short: ${${CUDA_VERSION_SHORT_VAR}}, digit-only: ${${CUDA_VERSION_SHORT_DIGIT_ONLY_VAR}}")
+
+  # when building for any version >= 11.0 use CUDA compatibility mode and claim it is a CUDA 110 package
+  # TF build image uses cmake 3.5 with not GREATER_EQUAL so split it to GREATER OR EQUAL
+  if ((${${CUDA_VERSION_MAJOR_VAR}} GREATER "11" OR ${${CUDA_VERSION_MAJOR_VAR}} EQUAL "11") AND ${${CUDA_VERSION_MINOR_VAR}} GREATER "0")
+     set(${CUDA_VERSION_MINOR_VAR} "0")
+     set(${CUDA_VERSION_PATCH_VAR} "0")
+     set(${CUDA_VERSION_MINOR_VAR} "0" PARENT_SCOPE)
+     set(${CUDA_VERSION_PATCH_VAR} "0" PARENT_SCOPE)
+  endif()
   set(${CUDA_VERSION_SHORT_VAR} "${${CUDA_VERSION_MAJOR_VAR}}.${${CUDA_VERSION_MINOR_VAR}}" PARENT_SCOPE)
   set(${CUDA_VERSION_SHORT_DIGIT_ONLY_VAR} "${${CUDA_VERSION_MAJOR_VAR}}${${CUDA_VERSION_MINOR_VAR}}" PARENT_SCOPE)
 
-  message(STATUS "CUDA version: ${CUDA_VERSION}, major: ${${CUDA_VERSION_MAJOR_VAR}}, minor: ${${CUDA_VERSION_MINOR_VAR}}, patch: ${${CUDA_VERSION_PATCH_VAR}}, short: ${${CUDA_VERSION_SHORT_VAR}}, digit-only: ${${CUDA_VERSION_SHORT_DIGIT_ONLY_VAR}}")
+  message(STATUS "CUDA version compatibile: major: ${${CUDA_VERSION_MAJOR_VAR}}, minor: ${${CUDA_VERSION_MINOR_VAR}}, patch: ${${CUDA_VERSION_PATCH_VAR}}, short: ${${CUDA_VERSION_SHORT_VAR}}, digit-only: ${${CUDA_VERSION_SHORT_DIGIT_ONLY_VAR}}")
 endfunction()
 
 # Build a .so library variant for each python version provided in PYTHON_VERSIONS variable

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -286,7 +286,7 @@ function(parse_cuda_version CUDA_VERSION CUDA_VERSION_MAJOR_VAR CUDA_VERSION_MIN
   set(${CUDA_VERSION_SHORT_VAR} "${${CUDA_VERSION_MAJOR_VAR}}.${${CUDA_VERSION_MINOR_VAR}}" PARENT_SCOPE)
   set(${CUDA_VERSION_SHORT_DIGIT_ONLY_VAR} "${${CUDA_VERSION_MAJOR_VAR}}${${CUDA_VERSION_MINOR_VAR}}" PARENT_SCOPE)
 
-  message(STATUS "CUDA version compatibile: major: ${${CUDA_VERSION_MAJOR_VAR}}, minor: ${${CUDA_VERSION_MINOR_VAR}}, patch: ${${CUDA_VERSION_PATCH_VAR}}, short: ${${CUDA_VERSION_SHORT_VAR}}, digit-only: ${${CUDA_VERSION_SHORT_DIGIT_ONLY_VAR}}")
+  message(STATUS "Compatible CUDA version: major: ${${CUDA_VERSION_MAJOR_VAR}}, minor: ${${CUDA_VERSION_MINOR_VAR}}, patch: ${${CUDA_VERSION_PATCH_VAR}}, short: ${${CUDA_VERSION_SHORT_VAR}}, digit-only: ${${CUDA_VERSION_SHORT_DIGIT_ONLY_VAR}}")
 endfunction()
 
 # Build a .so library variant for each python version provided in PYTHON_VERSIONS variable

--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -10,6 +10,11 @@ fi
 
 export CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1.\2/')
 
+# when building for any version >= 11.0 use CUDA compatibility mode and claim it is a CUDA 110 package
+if [ $CUDA_VERSION gt 110 ]; then
+  export CUDA_VERSION=$((CUDA_VERSION/10*10))
+fi
+
 # Adding conda-forge channel for dependencies
 conda config --add channels conda-forge
 

--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -8,10 +8,10 @@ if [ -z $PYVER ]; then
     exit 1
 fi
 
-export CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\\([0-9]\+\)/\1.\2/')
+export CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1.\2/')
 
 # when building for any version >= 11.0 use CUDA compatibility mode and claim it is a CUDA 110 package
-if [ $CUDA_VERSION gt 110 ]; then
+if [ "${CUDA_VERSION/./}" -gt 110 ]; then
   export CUDA_VERSION="${CUDA_VERSION%?}0"
 fi
 

--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -8,7 +8,7 @@ if [ -z $PYVER ]; then
     exit 1
 fi
 
-export CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1.\2/')
+export CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\\([0-9]\+\)/\1.\2/')
 
 # when building for any version >= 11.0 use CUDA compatibility mode and claim it is a CUDA 110 package
 if [ $CUDA_VERSION gt 110 ]; then

--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -12,7 +12,7 @@ export CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*)  | sed 's/.
 
 # when building for any version >= 11.0 use CUDA compatibility mode and claim it is a CUDA 110 package
 if [ $CUDA_VERSION gt 110 ]; then
-  export CUDA_VERSION=$((CUDA_VERSION/10*10))
+  export CUDA_VERSION="${CUDA_VERSION%?}0"
 fi
 
 # Adding conda-forge channel for dependencies

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 package:
-  name: nvidia-dali-cuda{{ environ.get('CUDA_VERSION', '') | replace(".","") }}
+  name: nvidia-dali-cuda{{ environ.get('CUDA_VERSION', '') }}
   version: {{ environ.get('DALI_CONDA_BUILD_VERSION', '') }}
 
 source:

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 package:
-  name: nvidia-dali-cuda{{ environ.get('CUDA_VERSION', '') }}
+  name: nvidia-dali-cuda{{ environ.get('CUDA_VERSION', '') | replace(".","") }}
   version: {{ environ.get('DALI_CONDA_BUILD_VERSION', '') }}
 
 source:

--- a/dali_tf_plugin/build_in_custom_op_docker.sh
+++ b/dali_tf_plugin/build_in_custom_op_docker.sh
@@ -6,11 +6,7 @@ set -e
 PYTHON_DIST_PACKAGES=( $(python -c "import site; print(site.getsitepackages()[0])") )
 DALI_TOPDIR="${PYTHON_DIST_PACKAGES}/nvidia/dali"
 
-CUDA_VERSION=$(cat /usr/local/cuda/version.txt | head -1 | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
-# when building for any version >= 11.0 use CUDA compatibility mode and claim it is a CUDA 110 package
-if [ $CUDA_VERSION gt 110 ]; then
-  export CUDA_VERSION="${CUDA_VERSION%?}0"
-fi
+CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2\3/')
 
 LAST_CONFIG_INDEX=$(python ../qa/setup_packages.py -n -u tensorflow-gpu --cuda ${CUDA_VERSION})
 

--- a/dali_tf_plugin/build_in_custom_op_docker.sh
+++ b/dali_tf_plugin/build_in_custom_op_docker.sh
@@ -7,6 +7,11 @@ PYTHON_DIST_PACKAGES=( $(python -c "import site; print(site.getsitepackages()[0]
 DALI_TOPDIR="${PYTHON_DIST_PACKAGES}/nvidia/dali"
 
 CUDA_VERSION=$(cat /usr/local/cuda/version.txt | head -1 | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
+# when building for any version >= 11.0 use CUDA compatibility mode and claim it is a CUDA 110 package
+if [ $CUDA_VERSION gt 110 ]; then
+  export CUDA_VERSION=$((CUDA_VERSION/10*10))
+fi
+
 LAST_CONFIG_INDEX=$(python ../qa/setup_packages.py -n -u tensorflow-gpu --cuda ${CUDA_VERSION})
 
 PREBUILT_DIR=/prebuilt

--- a/dali_tf_plugin/build_in_custom_op_docker.sh
+++ b/dali_tf_plugin/build_in_custom_op_docker.sh
@@ -9,7 +9,7 @@ DALI_TOPDIR="${PYTHON_DIST_PACKAGES}/nvidia/dali"
 CUDA_VERSION=$(cat /usr/local/cuda/version.txt | head -1 | sed 's/.*Version \([0-9]\+\)\.\([0-9]\+\).*/\1\2/')
 # when building for any version >= 11.0 use CUDA compatibility mode and claim it is a CUDA 110 package
 if [ $CUDA_VERSION gt 110 ]; then
-  export CUDA_VERSION=$((CUDA_VERSION/10*10))
+  export CUDA_VERSION="${CUDA_VERSION%?}0"
 fi
 
 LAST_CONFIG_INDEX=$(python ../qa/setup_packages.py -n -u tensorflow-gpu --cuda ${CUDA_VERSION})

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -40,10 +40,11 @@ set the following environment variables:
 
 * | CUDA_VERSION - CUDA toolkit version (10.0, 11.0 and 11.1).
   | The default is ``11.1``. Thanks to CUDA extended compatibility mode CUDA 11.1 wheel is named as
-    CUDA 11.0 because it can work with the CUDA 11.0 R450.x driver family (please update to the
-    latest recommended driver version in that family). If the value of the version is prefixed with
-    `.` then any value ``.XX.Y`` can be passed, script check for the supported version is bypassed
-    and the user needs to make sure that Dockerfile.cudaXXY.deps is present in `docker/` directory.
+    CUDA 11.0 because it can work with the CUDA 11.0 R450.x driver family. Please update to the
+    latest recommended driver version in that family. If the value of the version is prefixed with
+    `.` then any value ``.XX.Y`` can be passed, and in that case the supported version check is
+    and the user needs to make sure that Dockerfile.cudaXXY.deps is present in the `docker/`
+    directory.
 * | NVIDIA_BUILD_ID - Custom ID of the build.
   | The default is ``1234``.
 * | CREATE_WHL - Create a standalone wheel.
@@ -61,12 +62,13 @@ set the following environment variables:
     PREBUILD_TF_PLUGINS value is disregarded. The default is ``YES``.
 * | CREATE_RUNNER - Create Docker image with cuDNN, CUDA and DALI installed inside.
   | It will create the ``Docker_run_cuda`` image, which needs to be run using |nvidia_docker|_
-    and place the DALI wheel (and optionally the TensorFlow plugin if compiled) in the ``/opt/dali`` directory.
+    and place the DALI wheel (and optionally the TensorFlow plugin if compiled) in the ``/opt/dali``
+    directory.
   | The default is ``NO``.
 * | PYVER - Python version used to create the runner image with DALI installed inside mentioned above.
   | The default is ``3.6``.
-* DALI_BUILD_FLAVOR - adds a suffix to DALI package name and put a note about it in the whl package description,
-  i.e. `nightly` will result in the `nvidia-dali-nightly`
+* DALI_BUILD_FLAVOR - adds a suffix to DALI package name and put a note about it in the whl package
+  description, i.e. `nightly` will result in the `nvidia-dali-nightly`
 * | CMAKE_BUILD_TYPE - build type, available options: Debug, DevDebug, Release, RelWithDebInfo.
   | The default is ``Release``.
 * | STRIP_BINARY - when used with CMAKE_BUILD_TYPE equal to Debug, DevDebug, or RelWithDebInfo it

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -41,10 +41,10 @@ set the following environment variables:
 * | CUDA_VERSION - CUDA toolkit version (10.0, 11.0 and 11.1).
   | The default is ``11.1``. Thanks to CUDA extended compatibility mode CUDA 11.1 wheel is named as
     CUDA 11.0 because it can work with the CUDA 11.0 R450.x driver family. Please update to the
-    latest recommended driver version in that family. If the value of the version is prefixed with
-    `.` then any value ``.XX.Y`` can be passed, and in that case the supported version check is
-    and the user needs to make sure that Dockerfile.cudaXXY.deps is present in the `docker/`
-    directory.
+    latest recommended driver version in that family.
+  | If the value of the CUDA_VERSION is prefixed with `.` then any value ``.XX.Y`` can be passed,
+    the supported version check is suppressed, and the user needs to make sure that
+    Dockerfile.cudaXXY.deps is present in the `docker/` directory.
 * | NVIDIA_BUILD_ID - Custom ID of the build.
   | The default is ``1234``.
 * | CREATE_WHL - Create a standalone wheel.

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -39,9 +39,11 @@ Change directory (``cd``) into ``docker`` directory and run ``./build.sh``. If n
 set the following environment variables:
 
 * | CUDA_VERSION - CUDA toolkit version (10.0, 11.0 and 11.1).
-  | The default is ``11.1``. If the value of the version is prefixed with `.` then any value
-    ``.XX.Y`` can be passed, script check for the supported version is bypased and the user needs
-    to make sure that Dockerfile.cudaXXY.deps is present in `docker/` directory.
+  | The default is ``11.1``. Thanks to CUDA extended compatibility mode CUDA 11.1 wheel is named as
+    CUDA 11.0 because it can work with the CUDA 11.0 R450.x driver family (please update to the
+    latest recommended driver version in that family). If the value of the version is prefixed with
+    `.` then any value ``.XX.Y`` can be passed, script check for the supported version is bypassed
+    and the user needs to make sure that Dockerfile.cudaXXY.deps is present in `docker/` directory.
 * | NVIDIA_BUILD_ID - Custom ID of the build.
   | The default is ``1234``.
 * | CREATE_WHL - Create a standalone wheel.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,7 +55,7 @@ Execute the following command to install the latest DALI for specified CUDA vers
   .. note::
     CUDA 11.0 build uses CUDA toolkit enhanced compatibility. It is built with the latest CUDA 11.x
     toolkit while it can run on the latest, stable CUDA 11.0 capable drivers (450.80 or later).
-    Using the newest driver (455.x for example) may enable additional functionalities.
+    Using the newest driver (455.x, for example) may enable additional functionalities.
 
 .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,7 +55,7 @@ Execute the following command to install the latest DALI for specified CUDA vers
   .. note::
     CUDA 11.0 build uses CUDA toolkit enhanced compatibility. It is built with the latest CUDA 11.x
     toolkit while it can run on the latest, stable CUDA 11.0 capable drivers (450.80 or later).
-    Using the newest driver (455.x, for example) may enable additional functionalities.
+    Using the latest driver may enable additional functionality.
 
 .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -52,20 +52,14 @@ Execute the following command to install the latest DALI for specified CUDA vers
 
 * for CUDA 11.0:
 
+  .. note::
+    CUDA 11.0 build uses CUDA toolkit enhanced compatibility. It is built with the latest CUDA 11.x
+    toolkit while it can run on the latest, stable CUDA 11.0 capable drivers (450.80 or later).
+    Using the newest driver (455.x for example) may enable additional functionalities.
+
 .. code-block:: bash
 
    pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda110
-
-* for CUDA 11.1:
-
-  .. note::
-    CUDA 11.1 build uses CUDA toolkit enhanced compatibility. It is built with the latest CUDA 11.x
-    toolkit while it can run on CUDA 11.0 capable drivers 450.80 or later. Using the newest driver may enable
-    additional functionalities.
-
-.. code-block:: bash
-
-   pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda111
 
 DALI TensorFlow plugin (nvidia-dali-tf-plugin)
 """"""""""""""""""""""""""""""""""""""""""""""
@@ -84,12 +78,6 @@ which will be built against the currently installed version of TensorFlow:
 .. code-block:: bash
 
    pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-tf-plugin-cuda110
-
-* for CUDA 11.1:
-
-.. code-block:: bash
-
-   pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-tf-plugin-cuda111
 
 
 Installing this package will install ``nvidia-dali-cudaXXX`` and its dependencies, if they are not already installed. The package ``tensorflow-gpu`` must be installed before attempting to install ``nvidia-dali-tf-plugin-cudaXXX``.
@@ -171,12 +159,6 @@ To access most recent nightly builds please use flowing release channel:
 .. code-block:: bash
 
   pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly nvidia-dali-nightly-cuda110 nvidia-dali-tf-plugin-nightly-cuda110
-
-* for CUDA 11.1:
-
-.. code-block:: bash
-
-  pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly nvidia-dali-nightly-cuda111 nvidia-dali-tf-plugin-nightly-cuda111
 
 
 Weekly builds


### PR DESCRIPTION
- makes CUDA 11.1 builds to be named as CUDA 11.0 because due to the CUDA enhanced compatibility of the build with the latest toolkit version will run on the latest CUDA 11.0 capable driver

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It enables CUDA 11 compatibility mode

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     makes CUDA 11.1 builds to be named as CUDA 11.0 because due to the CUDA enhanced compatibility of the build with the latest toolkit version will run on the latest CUDA 11.0 capable driver
 - Affected modules and functionalities:
     plain and conda build
 - Key points relevant for the review:
     if it is the right way?
 - Validation and testing:
     CI
 - Documentation (including examples):
     compilation/installation instruction is updated


**JIRA TASK**: *[NA]*
