### PR TITLE
Reduce GPU memory fraction in TF tests to 0.5.

### DIFF
--- a/dali/test/python/test_RN50_data_fw_iterators.py
+++ b/dali/test/python/test_RN50_data_fw_iterators.py
@@ -143,7 +143,7 @@ def test_fw_iter(IteratorClass, args):
                     dtypes = [out_type, tf.int32])
                 images.append(image)
                 labels.append(label)
-        gpu_options = GPUOptions(per_process_gpu_memory_fraction=0.8)
+        gpu_options = GPUOptions(per_process_gpu_memory_fraction=0.5)
         config = ConfigProto(gpu_options=gpu_options)
         sess = Session(config=config)
 

--- a/dali/test/python/test_dali_tf_plugin_run.py
+++ b/dali/test/python/test_dali_tf_plugin_run.py
@@ -84,7 +84,7 @@ def get_batch_dali(batch_size, pipe_type, label_type, num_gpus=1):
 
     return [images, labels]
 
-def test_dali_tf_op(pipe_type=CaffeReadPipeline, batch_size=32, iterations=32):
+def test_dali_tf_op(pipe_type=CaffeReadPipeline, batch_size=16, iterations=32):
     test_batch = get_batch_dali(batch_size, pipe_type, tf.int32)
     try:
         from tensorflow.compat.v1 import GPUOptions
@@ -96,7 +96,7 @@ def test_dali_tf_op(pipe_type=CaffeReadPipeline, batch_size=32, iterations=32):
         from tensorflow import ConfigProto
         from tensorflow import Session
 
-    gpu_options = GPUOptions(per_process_gpu_memory_fraction=0.8)
+    gpu_options = GPUOptions(per_process_gpu_memory_fraction=0.5)
     config = ConfigProto(gpu_options=gpu_options)
     with Session(config=config) as sess:
         for i in range(iterations):


### PR DESCRIPTION
Reduce batch size to 16 in dali_tf_plugin_run.

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It helpe run the test on a desktop where the GPU is also used for display

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Reduced Tensorflow memory fraction from 0.8 to 0.5
     * Reduced batch size from 32 to 16
 - Affected modules and functionalities:
     * TF tests
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * N/A
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
