### PR TITLE
Add NemoAsrReader handling of UTF8 text

### DIFF
--- a/dali/operators/reader/loader/nemo_asr_loader.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader.cc
@@ -75,7 +75,7 @@ void NemoAsrLoader::PrepareMetadataImpl() {
     std::ifstream fstream(manifest_filepath);
     DALI_ENFORCE(fstream,
                  make_string("Could not open NEMO ASR manifest file: \"", manifest_filepath, "\""));
-    detail::ParseManifest(entries_, fstream, max_duration_);
+    detail::ParseManifest(entries_, fstream, min_duration_, max_duration_);
   }
   shuffled_indices_.resize(entries_.size());
   std::iota(shuffled_indices_.begin(), shuffled_indices_.end(), 0);

--- a/dali/operators/reader/loader/nemo_asr_loader.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader.cc
@@ -30,27 +30,8 @@ namespace dali {
 
 namespace detail {
 
-std::string trim(const std::string& str,
-                 const std::string& whitespace = " \t\f\n\r\v") {
-  const auto str_begin = str.find_first_not_of(whitespace);
-  if (str_begin == std::string::npos)
-    return {};  // no content
-  const auto str_end = str.find_last_not_of(whitespace);
-  const auto str_len = str_end - str_begin + 1;
-  return str.substr(str_begin, str_len);
-}
-
-std::string NormalizeText(const std::string& text) {
-  // Remove trailing and leading whitespace
-  auto norm_text = trim(text);
-  // TODO(janton): Handle non-ascii
-  std::transform(norm_text.begin(), norm_text.end(), norm_text.begin(),
-    [](char c){ return std::tolower(c); });
-  return norm_text;
-}
-
 void ParseManifest(std::vector<NemoAsrEntry> &entries, std::istream& manifest_file,
-                   double min_duration, double max_duration, bool normalize_text) {
+                   double min_duration, double max_duration) {
   std::string line;
   while (std::getline(manifest_file, line)) {
     detail::LookaheadParser parser(const_cast<char*>(line.c_str()));
@@ -69,8 +50,6 @@ void ParseManifest(std::vector<NemoAsrEntry> &entries, std::istream& manifest_fi
         entry.offset = parser.GetDouble();
       } else if (0 == std::strcmp(key, "text")) {
         entry.text = parser.GetString();
-        if (normalize_text)
-          entry.text = NormalizeText(entry.text);
       } else {
         parser.SkipValue();
       }
@@ -96,7 +75,7 @@ void NemoAsrLoader::PrepareMetadataImpl() {
     std::ifstream fstream(manifest_filepath);
     DALI_ENFORCE(fstream,
                  make_string("Could not open NEMO ASR manifest file: \"", manifest_filepath, "\""));
-    detail::ParseManifest(entries_, fstream, max_duration_, normalize_text_);
+    detail::ParseManifest(entries_, fstream, max_duration_);
   }
   shuffled_indices_.resize(entries_.size());
   std::iota(shuffled_indices_.begin(), shuffled_indices_.end(), 0);

--- a/dali/operators/reader/loader/nemo_asr_loader.h
+++ b/dali/operators/reader/loader/nemo_asr_loader.h
@@ -89,8 +89,7 @@ namespace detail {
 
 DLL_PUBLIC void ParseManifest(std::vector<NemoAsrEntry> &entries, std::istream &manifest_file,
                               double min_duration = kDefaultDuration,
-                              double max_duration = kDefaultDuration,
-                              bool normalize_text = false);
+                              double max_duration = kDefaultDuration);
 
 }  // namespace detail
 
@@ -105,7 +104,6 @@ class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
         downmix_(spec.GetArgument<bool>("downmix")),
         dtype_(spec.GetArgument<DALIDataType>("dtype")),
         max_duration_(spec.GetArgument<float>("max_duration")),
-        normalize_text_(spec.GetArgument<bool>("normalize_text")),
         num_threads_(std::max(1, spec.GetArgument<int>("num_threads"))),
         decode_scratch_(num_threads_),
         resample_scratch_(num_threads_) {
@@ -164,7 +162,6 @@ class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
   bool downmix_;
   DALIDataType dtype_;
   double max_duration_;
-  bool normalize_text_;
   int num_threads_;
   kernels::signal::resampling::Resampler resampler_;
   std::vector<std::vector<float>> decode_scratch_;

--- a/dali/operators/reader/loader/nemo_asr_loader.h
+++ b/dali/operators/reader/loader/nemo_asr_loader.h
@@ -103,6 +103,7 @@ class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
         quality_(spec.GetArgument<float>("quality")),
         downmix_(spec.GetArgument<bool>("downmix")),
         dtype_(spec.GetArgument<DALIDataType>("dtype")),
+        min_duration_(spec.GetArgument<float>("min_duration")),
         max_duration_(spec.GetArgument<float>("max_duration")),
         num_threads_(std::max(1, spec.GetArgument<int>("num_threads"))),
         decode_scratch_(num_threads_),
@@ -161,6 +162,7 @@ class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
   float quality_;
   bool downmix_;
   DALIDataType dtype_;
+  double min_duration_;
   double max_duration_;
   int num_threads_;
   kernels::signal::resampling::Resampler resampler_;

--- a/dali/operators/reader/loader/nemo_asr_loader_test.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader_test.cc
@@ -76,7 +76,7 @@ TEST(NemoAsrLoaderTest, ParseManifest) {
   EXPECT_EQ("path/to/audio1.wav", entries[0].audio_filepath);
 }
 
-TEST(NemoAsrLoaderTest, ParseNonAsciiTransript) {  
+TEST(NemoAsrLoaderTest, ParseNonAsciiTransript) {
   {
     std::stringstream ss;
     ss << R"code({"audio_filepath": "path/to/audio1.wav", "duration": 1.45, "text": "это проверка"})code" << std::endl;

--- a/dali/operators/reader/nemo_asr_reader_op.cc
+++ b/dali/operators/reader/nemo_asr_reader_op.cc
@@ -85,6 +85,7 @@ in seconds, of the audio samples.
 
 Samples with a duration longer than this value will be ignored.)code",
     0.0f)
+  .DeprecateArg("normalize_text", true)  // deprecated since 0.28dev
   .AdditionalOutputsFn([](const OpSpec& spec) {
     return static_cast<int>(spec.GetArgument<bool>("read_sample_rate"))
          + static_cast<int>(spec.GetArgument<bool>("read_text"));

--- a/dali/operators/reader/nemo_asr_reader_op.cc
+++ b/dali/operators/reader/nemo_asr_reader_op.cc
@@ -85,14 +85,6 @@ in seconds, of the audio samples.
 
 Samples with a duration longer than this value will be ignored.)code",
     0.0f)
-  .AddOptionalArg("normalize_text",
-    R"code(If set to True, the text transcript will be stripped of leading and trailing whitespace
-and converted to lowercase.
-
-.. warning::
-    Non-ASCII strings are not yet supported.
-)code",
-    false)
   .AdditionalOutputsFn([](const OpSpec& spec) {
     return static_cast<int>(spec.GetArgument<bool>("read_sample_rate"))
          + static_cast<int>(spec.GetArgument<bool>("read_text"));
@@ -173,7 +165,7 @@ void NemoAsrReader::RunImpl(SampleWorkspace &ws) {
     auto &text_out = ws.Output<CPUBackend>(next_out_idx++);
     text_out.set_type(TypeTable::GetTypeInfo(DALI_UINT8));
     const auto &text = sample.text();
-    int64_t text_sz = text.length() + 1;  // +1 for null character
+    int64_t text_sz = text.length();
     text_out.Resize({text_sz});
     std::memcpy(text_out.mutable_data<uint8_t>(), text.c_str(), text_sz);
     text_out.SetMeta(meta);

--- a/dali/test/python/test_operator_nemo_asr_reader.py
+++ b/dali/test/python/test_operator_nemo_asr_reader.py
@@ -174,5 +174,3 @@ def test_decoded_vs_generated(batch_size=3):
       # String comparison (utf-8)
       assert text_non_ascii_str == ref_text_non_ascii_literal[idx], \
           f"'{text_non_ascii_str}' != '{ref_text_non_ascii_literal[idx]}'"
-
- 

--- a/dali/test/python/test_operator_nemo_asr_reader.py
+++ b/dali/test/python/test_operator_nemo_asr_reader.py
@@ -11,6 +11,20 @@ import tempfile
 import os
 from test_audio_decoder_utils import generate_waveforms, rosa_resample
 
+def create_manifest_file(manifest_file, names, lengths, rates, texts):
+  assert(len(names) == len(lengths) == len(rates) == len(texts))
+  data = []
+  for idx in range(len(names)):
+    entry_i = {}
+    entry_i['audio_filepath'] = names[idx]
+    entry_i['duration'] = lengths[idx] * (1.0 / rates[idx])
+    entry_i["text"] = texts[idx]
+    data.append(entry_i)
+  with open(manifest_file, 'w') as f:
+    for entry in data:
+      json.dump(entry, f)
+      f.write('\n')
+
 tmp_dir = tempfile.TemporaryDirectory()
 
 names = [
@@ -37,41 +51,29 @@ def create_ref():
 
 ref_i = create_ref()
 
-ref_text = [
-  np.array([100, 97, 108, 105, 32, 116, 101, 115, 116, 32, 49, 67, 0], dtype=np.uint8),
-  np.array([100, 97, 108, 105, 32, 116, 101, 115, 116, 32, 50, 67, 0], dtype=np.uint8),
-  np.array([100, 97, 108, 105, 32, 116, 101, 115, 116, 32, 52, 67, 0], dtype=np.uint8)
-]
-
 def create_wav_files():
   for i in range(len(names)):
     scipy.io.wavfile.write(names[i], rates[i], ref_i[i])
 
 create_wav_files()
 
+ref_text_literal = [
+  "dali test 1C",
+  "dali test 2C",
+  "dali test 4C",
+]
 nemo_asr_manifest = os.path.join(tmp_dir.name, "nemo_asr_manifest.json")
+create_manifest_file(nemo_asr_manifest, names, lengths, rates, ref_text_literal)
+ref_text = [np.frombuffer(bytes(s, "utf8"), dtype=np.uint8).reshape(-1) for s in ref_text_literal]
 
-def create_manifest_file():
-  entry0 = {}
-  entry0["audio_filepath"] = names[0]
-  entry0["duration"] = lengths[0] * (1.0 / rates[0])
-  entry0["text"] = "dali test 1C"
-  entry1 = {}
-  entry1["audio_filepath"] = names[1]
-  entry1["duration"] = lengths[1] * (1.0 / rates[1])
-  entry1["text"] = "dali test 2C"
-  entry2 = {}
-  entry2["audio_filepath"] = names[2]
-  entry2["duration"] = lengths[2] * (1.0 / rates[2])
-  entry2["text"] = "dali test 4C"
-
-  data = [entry0, entry1, entry2]
-  with open(nemo_asr_manifest, 'w') as f:
-    for entry in data:
-      json.dump(entry, f)
-      f.write('\n')
-
-create_manifest_file()
+ref_text_non_ascii_literal = [
+  u"dzień dobry",
+  u"доброе утро",
+  u"这是一个测试",
+]
+nemo_asr_manifest_non_ascii = os.path.join(tmp_dir.name, "nemo_asr_manifest_non_ascii.json")
+create_manifest_file(nemo_asr_manifest_non_ascii, names, lengths, rates, ref_text_non_ascii_literal)
+ref_text_non_ascii = [np.frombuffer(bytes(s, "utf8"), dtype=np.uint8) for s in ref_text_non_ascii_literal]
 
 rate1 = 16000
 rate2 = 44100
@@ -101,9 +103,11 @@ class NemoAsrReaderPipeline(Pipeline):
                                                    sample_rate=rate2, read_sample_rate=True, read_text=False, seed=fixed_seed)
     _, _, text = fn.nemo_asr_reader(manifest_filepaths = [nemo_asr_manifest], dtype = types.INT16, downmix = True,
                                     read_sample_rate=True, read_text=True, seed=fixed_seed)
+    _, _, text_non_ascii = fn.nemo_asr_reader(manifest_filepaths = [nemo_asr_manifest_non_ascii], dtype = types.INT16, downmix = True,
+                                              read_sample_rate=True, read_text=True, seed=fixed_seed)
     return audio_plain_i, audio_plain_f, audio_downmix_i, audio_downmix_f, \
            audio_resampled1_i, audio_resampled1_f, audio_resampled2_i, audio_resampled2_f, \
-           text
+           text, text_non_ascii
 
 def test_decoded_vs_generated(batch_size=3):
   pipeline = NemoAsrReaderPipeline(batch_size=batch_size)
@@ -121,6 +125,7 @@ def test_decoded_vs_generated(batch_size=3):
       audio_resampled2_i = out[6].at(idx)
       audio_resampled2_f = out[7].at(idx)
       text = out[8].at(idx)
+      text_non_ascii = out[9].at(idx)
 
       ref_plain_i = ref_i[idx]
       np.testing.assert_allclose(audio_plain_i, ref_plain_i, rtol = 1e-7)
@@ -157,3 +162,17 @@ def test_decoded_vs_generated(batch_size=3):
       np.testing.assert_allclose(audio_resampled2_f, ref_resampled2_f, atol=1e-3)
 
       np.testing.assert_equal(text, ref_text[idx])
+
+      np.testing.assert_equal(text_non_ascii, ref_text_non_ascii[idx])
+      text_non_ascii_str = str(text_non_ascii.tobytes(), encoding='utf8')
+
+      # Checking that we don't have any trailing zeros (those won't be caught by the string comparison)
+      ref_text_non_ascii_literal_bytes = bytes(ref_text_non_ascii_literal[idx], 'utf8')
+      assert text_non_ascii.tobytes() == ref_text_non_ascii_literal_bytes, \
+          f"'{text_non_ascii.tobytes()}' != '{ref_text_non_ascii_literal_bytes}'"
+
+      # String comparison (utf-8)
+      assert text_non_ascii_str == ref_text_non_ascii_literal[idx], \
+          f"'{text_non_ascii_str}' != '{ref_text_non_ascii_literal[idx]}'"
+
+ 

--- a/dali/test/python/test_operator_nemo_asr_reader.py
+++ b/dali/test/python/test_operator_nemo_asr_reader.py
@@ -64,7 +64,7 @@ ref_text_literal = [
 ]
 nemo_asr_manifest = os.path.join(tmp_dir.name, "nemo_asr_manifest.json")
 create_manifest_file(nemo_asr_manifest, names, lengths, rates, ref_text_literal)
-ref_text = [np.frombuffer(bytes(s, "utf8"), dtype=np.uint8).reshape(-1) for s in ref_text_literal]
+ref_text = [np.frombuffer(bytes(s, "utf8"), dtype=np.uint8) for s in ref_text_literal]
 
 ref_text_non_ascii_literal = [
   u"dzień dobry",


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It adds new feature needed to integrate with NeMo ASR training on non-english datasets.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *NeMo manifests are encoded in utf8. Made sure that the output of the reader is the expected utf8 encoded string*
     *Tests added*
     *Removed trailing 0 in text outputs*
     *Removed text normalization, which will be left to the python code*
 - Affected modules and functionalities:
     *NemoAsrReader*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *New tests added*
 - Documentation (including examples):
     *Docstr updated*


**JIRA TASK**: *[DALI-1635]*
