### PR TITLE
Preserve shape of psuedoscalars in arithmetic ops.

### DIFF
--- a/dali/operators/math/expressions/arithmetic_test.cc
+++ b/dali/operators/math/expressions/arithmetic_test.cc
@@ -82,6 +82,23 @@ TEST(ArithmeticOpsTest, PropagateScalarInput) {
   EXPECT_EQ(result_shape, expected_shpe);
 }
 
+TEST(ArithmeticOpsTest, PreservePseudoScalarInput) {
+  std::string expr_str = "sub(&0 $1:int32))";
+  auto expr = ParseExpressionString(expr_str);
+  auto &expr_ref = *expr;
+  HostWorkspace ws;
+  std::shared_ptr<TensorVector<CPUBackend>> in[1];
+  for (auto &ptr : in) {
+    ptr = std::make_shared<TensorVector<CPUBackend>>();
+    ptr->Resize({{1}, {1}});
+  }
+  ws.AddInput(in[0]);
+
+  auto result_shape = PropagateShapes<CPUBackend>(expr_ref, ws, 2);
+  auto expected_shpe = TensorListShape<>{{1}, {1}};
+  EXPECT_EQ(result_shape, expected_shpe);
+}
+
 TEST(ArithmeticOpsTest, TreePropagationError) {
   std::string expr_str = "div(sub(&0 &1) &2)";
   auto expr = ParseExpressionString(expr_str);


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: psuedoscalars "magically" converted to true scalars

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Go through all inputs and choose either the shape of the non-scalar or highest dimensionality pseudoscalar
 - Affected modules and functionalities:
     * Arithmetic ops
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Added a test that checks that the psudoscalar shape i preserved
 - Documentation (including examples):
     * N/A

**JIRA TASK**:  N/A
