### PR TITLE
Automatic constant-to-input promotion.

### DIFF
--- a/dali/operators/generic/slice/slice.cc
+++ b/dali/operators/generic/slice/slice.cc
@@ -33,6 +33,7 @@ must provide as many dimensions as are specified with the ``axis_names`` or ``ax
 By default, the :meth:`nvidia.dali.ops.Slice` operator uses normalized coordinates and ``WH``
 order for the slice arguments.)code")
     .NumInput(3)
+    .InputDevice(1, 3, InputDevice::CPU)
     .NumOutput(1)
     .InputDox(0, "data", "TensorList", R"code(Batch that contains the input data.)code")
     .InputDox(1, "anchor", "1D TensorList of float or int",

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -53,6 +53,12 @@ struct DeprecatedArgDef {
   bool removed;
 };
 
+enum class InputDevice : uint8_t {
+  MatchBackend = 0,
+  CPU = 1,
+  GPU = 2,
+};
+
 class DLL_PUBLIC OpSchema {
  public:
   typedef std::function<int(const OpSpec &spec)> SpecFunc;
@@ -199,6 +205,7 @@ graph even if its outputs are not used.)code", false);
     min_num_input_ = n;
     input_dox_.resize(n);
     input_layouts_.resize(n);
+    input_devices_.resize(n);
     return *this;
   }
 
@@ -213,7 +220,32 @@ graph even if its outputs are not used.)code", false);
     max_num_input_ = max;
     input_layouts_.resize(max);
     input_dox_.resize(max);
+    input_devices_.resize(max);
     return *this;
+  }
+
+  /**
+   * @brief Sets the input device for given range of inputs
+   */
+  DLL_PUBLIC inline OpSchema& InputDevice(int first, int one_past, dali::InputDevice device) {
+    for (int i = first; i < one_past; i++)
+      input_devices_[i] = device;
+    return *this;
+  }
+
+  /**
+   * @brief Sets the input device for given range of input
+   */
+  DLL_PUBLIC inline OpSchema& InputDevice(int index, dali::InputDevice device) {
+    input_devices_[index] = device;
+    return *this;
+  }
+
+  /**
+   * @brief Gets the supported input device for ginen input
+   */
+  DLL_PUBLIC dali::InputDevice GetInputDevice(int index) const {
+    return input_devices_[index];
   }
 
   /**
@@ -882,6 +914,7 @@ graph even if its outputs are not used.)code", false);
   std::vector<std::unique_ptr<Value> > optional_arguments_unq_;
   std::vector<std::unique_ptr<Value> > internal_arguments_unq_;
   std::vector<std::vector<TensorLayout>> input_layouts_;
+  std::vector<dali::InputDevice> input_devices_;
 
   std::set<std::string> tensor_arguments_;
 };

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1429,6 +1429,16 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("GetCallSignatureInputs", &OpSchema::GetCallSignatureInputs)
     .def("GetInputName", &OpSchema::GetInputName)
     .def("GetInputType", &OpSchema::GetInputType)
+    .def("GetInputDevice", [](OpSchema *schema, int index)->py::object {
+      switch (schema->GetInputDevice(index)) {
+        case InputDevice::CPU:
+          return py::str("cpu");
+        case InputDevice::GPU:
+          return py::str("gpu");
+        default:
+          return py::none();
+      }
+    })
     .def("GetInputDox", &OpSchema::GetInputDox)
     .def("MaxNumInput", &OpSchema::MaxNumInput)
     .def("MinNumInput", &OpSchema::MinNumInput)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -242,8 +242,8 @@ class _OperatorInstance(object):
         self._spec = op.spec.copy()
         self._relation_id = self._counter.id
 
-        default_input_device = "gpu" if op.device == "gpu" else "cpu"
         if inputs is not None:
+            default_input_device = "gpu" if op.device == "gpu" else "cpu"
             inputs = list(inputs)
             for i in range(len(inputs)):
                 inp = inputs[i]
@@ -866,8 +866,8 @@ def _preprocess_inputs(inputs, op_name, device, schema=None):
                 all(isinstance(y, (_DataNode, nvidia.dali.types.ScalarConstant)) for y in x)
 
     for idx, inp in enumerate(inputs):
-        input_device = schema.GetInputDevice(idx) or device if schema else device
         if not is_input(inp):
+            input_device = schema.GetInputDevice(idx) or device if schema else device
             if not isinstance(inp, nvidia.dali.types.ScalarConstant):
                 try:
                     inp = nvidia.dali.types.Constant(inp, device=input_device)
@@ -879,10 +879,6 @@ Attempt to convert it to a constant node failed."""
 
             if not isinstance(inp, _DataNode):
                 inp = nvidia.dali.ops._instantiate_constant_node(input_device, inp)
-
-# Should we?
-#        if inp.device != input_device and input_device == "gpu":
-#            inp = inp.gpu()
 
         inputs[idx] = inp
     return inputs
@@ -952,6 +948,8 @@ def _group_inputs(inputs):
     integers = []
     reals = []
     for input in inputs:
+        if not isinstance(input, (_DataNode, _ScalarConstant)):
+            input = nvidia.dali.types.Constant(input)
         if isinstance(input, _DataNode):
             categories_idxs.append(("edge", len(edges)))
             edges.append(input)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -948,7 +948,7 @@ def _group_inputs(inputs):
     integers = []
     reals = []
     for input in inputs:
-        if not isinstance(input, (_DataNode, _ScalarConstant)):
+        if not isinstance(input, (_DataNode, _ScalarConstant, int, float)):
             input = nvidia.dali.types.Constant(input)
         if isinstance(input, _DataNode):
             categories_idxs.append(("edge", len(edges)))

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -249,7 +249,8 @@ dtype: DALIDataType, optional
         return "{}".format(self.value)
 
 def _is_scalar_shape(shape):
-    return shape is None or shape == 1 or shape == [1] or shape == (1,)
+    return shape is None or shape == () or shape == [] or shape == 1 or \
+           shape == [1] or shape == (1,)  # legacy pseudo-scalars
 
 def _is_mxnet_array(value):
     return 'mxnet.ndarray.ndarray.NDArray' in str(type(value))

--- a/dali/test/python/test_operator_input_promotion.py
+++ b/dali/test/python/test_operator_input_promotion.py
@@ -1,0 +1,65 @@
+import nvidia.dali as dali
+import nvidia.dali.fn as fn
+import numpy as np
+
+def test_cat_numpy_array():
+    pipe = dali.pipeline.Pipeline(1,1,0)
+    src = fn.external_source([[np.array([[10,11],[12,13]], dtype=np.float32)]])
+    pipe.set_outputs(fn.cat(src, np.array([[20],[21]], dtype=np.float32), axis=1))
+    pipe.build()
+    o = pipe.run()
+    assert np.array_equal(o[0].at(0), np.array([[10,11,20],[12,13,21]]))
+
+def test_slice_fn():
+    pipe = dali.pipeline.Pipeline(1,1,0)
+    src = fn.external_source([[np.array([[10,11,12],[13,14,15],[16,17,18]], dtype=np.float32)]])
+    out_cpu = fn.slice(src, np.array([1,1]), np.array([2,1]), axes=[0,1])
+    out_gpu = fn.slice(src.gpu(), np.array([1,1]), np.array([2,1]), axes=[0,1])
+    pipe.set_outputs(out_cpu, out_gpu)
+    pipe.build()
+    o = pipe.run()
+    assert np.array_equal(o[0].at(0), np.array([[14],[17]]))
+    assert np.array_equal(o[1].as_cpu().at(0), np.array([[14],[17]]))
+
+
+def test_slice_ops():
+    pipe = dali.pipeline.Pipeline(1,1,0)
+    src = fn.external_source([[np.array([[10,11,12],[13,14,15],[16,17,18]], dtype=np.float32)]])
+    slice_cpu = dali.ops.Slice(axes=[0,1], device="cpu")
+    slice_gpu = dali.ops.Slice(axes=[0,1], device="gpu")
+    out_cpu = slice_cpu(src, np.array([1,1]), np.array([2,1]))
+    out_gpu = slice_gpu(src.gpu(), np.array([1,1]), np.array([2,1]))
+    pipe.set_outputs(out_cpu, out_gpu)
+    pipe.build()
+    o = pipe.run()
+    assert np.array_equal(o[0].at(0), np.array([[14],[17]]))
+    assert np.array_equal(o[1].as_cpu().at(0), np.array([[14],[17]]))
+
+
+def test_python_function():
+    pipe = dali.pipeline.Pipeline(3,1,0, exec_async=False, exec_pipelined=False)
+    with pipe:
+        def func(inp):
+            ret = [x*x for x in inp]
+            return [ret]
+        out_cpu = fn.python_function(np.array([[1,2],[3,4]]), function=func, batch_processing=True)
+        out_gpu = fn.python_function(np.array([[1,2],[3,4]]), function=func, batch_processing=True, device="gpu")
+        pipe.set_outputs(out_cpu, out_gpu)
+    pipe.build()
+    o = pipe.run()
+    assert np.array_equal(o[0].at(0), np.array([[1,4],[9,16]]))
+    assert np.array_equal(o[1].as_cpu().at(0), np.array([[1,4],[9,16]]))
+
+
+def test_arithm_ops():
+    pipe = dali.pipeline.Pipeline(1,1,0)
+    with pipe:
+        def func(inp):
+            ret = [x*x for x in inp]
+            return [ret]
+        in1 = fn.external_source([[np.array([[1,2],[3,4]])]])
+        pipe.set_outputs(in1 + np.array([[10,20],[30,40]]), in1 + np.array(5))
+    pipe.build()
+    o = pipe.run()
+    assert np.array_equal(o[0].at(0), np.array([[11,22],[33,44]]))
+    assert np.array_equal(o[1].at(0), np.array([[6,7],[8,9]]))

--- a/dali/test/python/test_operator_input_promotion.py
+++ b/dali/test/python/test_operator_input_promotion.py
@@ -43,12 +43,10 @@ def test_python_function():
             ret = [x*x for x in inp]
             return [ret]
         out_cpu = fn.python_function(np.array([[1,2],[3,4]]), function=func, batch_processing=True)
-        out_gpu = fn.python_function(np.array([[1,2],[3,4]]), function=func, batch_processing=True, device="gpu")
-        pipe.set_outputs(out_cpu, out_gpu)
+        pipe.set_outputs(out_cpu)
     pipe.build()
     o = pipe.run()
     assert np.array_equal(o[0].at(0), np.array([[1,4],[9,16]]))
-    assert np.array_equal(o[1].as_cpu().at(0), np.array([[1,4],[9,16]]))
 
 
 def test_arithm_ops():

--- a/dali/test/python/test_operator_input_promotion.py
+++ b/dali/test/python/test_operator_input_promotion.py
@@ -54,9 +54,6 @@ def test_python_function():
 def test_arithm_ops():
     pipe = dali.pipeline.Pipeline(1,1,0)
     with pipe:
-        def func(inp):
-            ret = [x*x for x in inp]
-            return [ret]
         in1 = fn.external_source([[np.array([[1,2],[3,4]])]])
         pipe.set_outputs(in1 + np.array([[10,20],[30,40]]), in1 + np.array(5))
     pipe.build()

--- a/dali/test/python/test_operator_resize_seq.py
+++ b/dali/test/python/test_operator_resize_seq.py
@@ -87,12 +87,8 @@ def create_dali_pipe(channel_first, seq_len, interp, dtype, w, h, batch_size = 2
         dali_resized_cpu, size_cpu = resize_cpu_out
         dali_resized_gpu, size_gpu = resize_gpu_out
         # extract just HW part from the input shape
-        shape_anchor = np.array([2 if channel_first else 1], dtype=np.int32)
-        shape_shape = np.array([2], dtype=np.int32)
         ext_size = fn.slice(fn.cast(fn.shapes(ext), dtype=types.INT32),
-                            types.Constant(shape_anchor, device="cpu"),
-                            types.Constant(shape_shape, device="cpu"),
-                            axes=[0])
+                            2 if channel_first else 1, 2, axes=[0])
         pipe.set_outputs(dali_resized_cpu, dali_resized_gpu, ext_size, size_cpu, size_gpu)
     return pipe
 


### PR DESCRIPTION
Add automatic constant-to-input promotion.
Add input device to operator schema (for Slice).
Add tests that cover regular ops, slice and PythonFunction.

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed because it's so useful!

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * In operator's `__call__`, find non-DataNode objects:
         * promote ScalarConstant directly to Constant Node
         * try to convert other types to ScalarConstant first
     * Add InputDevice to OpSchema for the sake of Slice, which requires 1st argument in the bakcend device, but 2nd and 3rd in host memory
 - Affected modules and functionalities:
     * python bindings, op schema
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python tests
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
