### PR TITLE
Use current class __next__ implementation in __init__, to avoid special handling of first batch in child classes

### DIFF
--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -230,7 +230,7 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
             with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.schedule_run()
         self._first_batch = None
-        self._first_batch = self.next()
+        self._first_batch = DALIGenericIterator.next(self)
         # Set data descriptors for MXNet
         self.provide_data = []
         self.provide_label = []

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -230,7 +230,7 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
             with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.schedule_run()
         self._first_batch = None
-        self._first_batch = DALIGenericIterator.next(self)
+        self._first_batch = DALIGenericIterator.__next__(self)
         # Set data descriptors for MXNet
         self.provide_data = []
         self.provide_label = []

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -233,7 +233,7 @@ class DALIGenericIterator(_DaliBaseIterator):
             with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.schedule_run()
         self._first_batch = None
-        self._first_batch = self.next()
+        self._first_batch = DALIGenericIterator.next(self)
 
     def __next__(self):
         if self._first_batch is not None:

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -233,7 +233,7 @@ class DALIGenericIterator(_DaliBaseIterator):
             with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.schedule_run()
         self._first_batch = None
-        self._first_batch = DALIGenericIterator.next(self)
+        self._first_batch = DALIGenericIterator.__next__(self)
 
     def __next__(self):
         if self._first_batch is not None:

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -157,7 +157,7 @@ class DALIGenericIterator(_DaliBaseIterator):
             with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.schedule_run()
         self._first_batch = None
-        self._first_batch = DALIGenericIterator.next(self)
+        self._first_batch = DALIGenericIterator.__next__(self)
 
     def __next__(self):
         if self._first_batch is not None:

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -157,7 +157,7 @@ class DALIGenericIterator(_DaliBaseIterator):
             with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
                 p.schedule_run()
         self._first_batch = None
-        self._first_batch = self.next()
+        self._first_batch = DALIGenericIterator.next(self)
 
     def __next__(self):
         if self._first_batch is not None:


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- Refactoring to improve custom iterator writing.
Currently, custom iterators that override __next__() function need to be aware that the first batch was produced during __init__, which invokes the child class __next__, therefore the first iteration produces a "wrapped" batch while the following don't.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Use current class next function in DALIGenericIterator*
 - Affected modules and functionalities:
     *FW iterators*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1635]*
