### PR TITLE
Enable compatibility layer in tests for CUDA 11

### DIFF
--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2\3/')
-CUDA_VERSION=${CUDA_VERSION:-90}
+CUDA_VERSION=${CUDA_VERSION:-100}
 
 if [ -n "$gather_pip_packages" ]
 then
@@ -17,6 +17,13 @@ function version_gt() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" 
 function version_le() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" == "$1"; }
 function version_lt() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1"; }
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
+
+# If driver version is less than 450 and CUDA version is 11,
+# add /usr/local/cuda/compat to LD_LIBRARY_PATH
+version_ge "$CUDA_VERSION" "110" && \
+version_lt "$NVIDIA_SMI_DRIVER_VERSION" "450.0" && \
+export LD_LIBRARY_PATH="/usr/local/cuda/compat:$LD_LIBRARY_PATH"
+echo "LD_LIBRARY_PATH is $LD_LIBRARY_PATH"
 
 enable_conda() {
     echo "Activate conda"


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It enables compatibility layer in tests for CUDA 11

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     enable compatibility layer in tests for CUDA 11
 - Affected modules and functionalities:
     setup_test_common.sh
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
