### PR TITLE
Fixes problems in the weekly build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,8 @@ endif()
 # nvjpeg2k is not available prior CUDA 11.0
 if(${CUDA_VERSION} VERSION_GREATER_EQUAL "11.0")
   if(NOT (${ARCH} MATCHES "aarch64"))
-    cmake_dependent_option(BUILD_NVJPEG2K "Build with nvJPEG2K support" ON
+    # due to some decoding problems disable nvJPEG2K support for now by the default
+    cmake_dependent_option(BUILD_NVJPEG2K "Build with nvJPEG2K support" OFF
                            "NOT BUILD_DALI_NODEPS" OFF)
   endif()
 endif()

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -215,6 +215,14 @@ class DALIGenericIterator(_DaliBaseIterator):
                  last_batch_padded=False,
                  last_batch_policy=LastBatchPolicy.FILL):
 
+        normalized_map = {}
+        for v in output_map:
+            if isinstance(v, str):
+                normalized_map[v] = 0
+            else:
+                normalized_map[v[0]] = v[1]
+        self.normalized_map = normalized_map
+
         # check the assert first as _DaliBaseIterator would run the prefetch
         output_map = [isinstance(v, str) and v or v[0] for v in output_map]
         assert len(set(output_map)) == len(output_map), \
@@ -227,14 +235,6 @@ class DALIGenericIterator(_DaliBaseIterator):
         # Use double-buffering of data batches
         self._data_batches = [None for i in range(self._num_gpus)]
         self._counter = 0
-
-        normalized_map = {}
-        for v in output_map:
-            if isinstance(v, str):
-                normalized_map[v] = 0
-            else:
-                normalized_map[v[0]] = v[1]
-        self.normalized_map = normalized_map
 
         self._first_batch = None
         try:

--- a/docker/Dockerfile.build.aarch64-linux
+++ b/docker/Dockerfile.build.aarch64-linux
@@ -301,7 +301,6 @@ CMD WERROR=ON           \
     BUILD_NVJPEG=OFF    \
     BUILD_NVJPEG2K=OFF  \
     BUILD_NVOF=OFF      \
-    BUILD_FFMPEG=OFF    \
     BUILD_NVDEC=OFF     \
     BUILD_NVML=OFF      \
     VERBOSE_LOGS=OFF    \

--- a/docs/examples/frameworks/paddle/paddle-external_input.ipynb
+++ b/docs/examples/frameworks/paddle/paddle-external_input.ipynb
@@ -181,7 +181,7 @@
    ],
    "source": [
     "from nvidia.dali.plugin.paddle import DALIClassificationIterator as PaddleIterator\n",
-    "from nvidia.dali.plugin.mxnet import LastBatchPolicy \n",
+    "from nvidia.dali.plugin.paddle import LastBatchPolicy \n",
     "\n",
     "eii = ExternalInputIterator(batch_size, 0, 1)\n",
     "pipe = ExternalSourcePipeline(batch_size=batch_size, num_threads=2, device_id = 0,\n",


### PR DESCRIPTION
- changes wrong MXNet import to PaddlePaddle one in the PaddlePaddle jupyter example
- removes unnecessary BUILD_FFMPEG from Dockerfile.build.aarch64-linux
- fixes the wrong login in paddle DALI plugin
- makes nvJPEG2k disabled by default due to a bug in the library

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes problems in the weekly build

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     changes wrong MXNet import to PaddlePaddle one in the PaddlePaddle jupyter example
     removes unnecessary BUILD_FFMPEG from Dockerfile.build.aarch64-linux
     fixes the wrong login in paddle DALI plugin
    makes nvJPEG2k disabled by default due to a bug in the library
 - Affected modules and functionalities:
     jupyter examples
     CMake
     paddle plugin
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     example has been updated

**JIRA TASK**: *[NA]*
