### PR TITLE
Fix how DALI handles StopIteration from the ExternalSource

### DIFF
--- a/dali/python/nvidia/dali/plugin/base_iterator.py
+++ b/dali/python/nvidia/dali/plugin/base_iterator.py
@@ -167,7 +167,7 @@ class _DaliBaseIterator(object):
 
         # We need data about the batches (like shape information),
         # so we need to run a single batch as part of setup to get that info
-        self._schedule_runs()
+        self._schedule_runs(False)
 
     def _calculate_shard_sizes(self, shard_nums):
         shards_beg = np.floor(shard_nums * self._size_no_pad / self._shards_num).astype(np.int)
@@ -236,7 +236,7 @@ class _DaliBaseIterator(object):
         """
         Checks iterator stop condition, gets DALI outputs and perform reset in case of StopIteration
         """
-        if self._counter >= self._size and self._size > 0:
+        if self._size > 0 and self._counter >= self._size:
             if self._auto_reset:
                 self.reset()
             raise StopIteration
@@ -253,7 +253,7 @@ class _DaliBaseIterator(object):
             raise e
         return outputs
 
-    def _schedule_runs(self):
+    def _schedule_runs(self, release_outputs=True):
         """
         Schedule DALI runs
         """

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -268,12 +268,10 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
             batch = self._first_batch
             self._first_batch = None
             return batch
-        self._check_stop()
+
         # Gather outputs
-        outputs = []
-        for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
-                outputs.append(p.share_outputs())
+        outputs = self._get_outputs()
+
         for i in range(self._num_gpus):
             # MXNet wants batches with clear distinction between
             # data and label entries, so segregate outputs into
@@ -334,10 +332,7 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
             for j, l_arr in enumerate(l):
                 feed_ndarray(category_tensors[DALIGenericIterator.LABEL_TAG][j], l_arr)
 
-        for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
-                p.release_outputs()
-                p.schedule_run()
+        self._schedule_runs()
 
         self._advance_and_check_drop_last()
 
@@ -646,12 +641,9 @@ class DALIGluonIterator(_DALIMXNetIteratorBase):
             self._first_batch = None
             return batch
 
-        self._check_stop()
         # Gather outputs
-        dali_outputs = []
-        for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
-                dali_outputs.append(p.share_outputs())
+        dali_outputs = self._get_outputs()
+
         for i in range(self._num_gpus):
             output_elements = []
             shapes = []
@@ -682,10 +674,7 @@ class DALIGluonIterator(_DALIMXNetIteratorBase):
                     for output_el in batch]
                    for batch in self._data_batches]
 
-        for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
-                p.release_outputs()
-                p.schedule_run()
+        self._schedule_runs()
 
         self._advance_and_check_drop_last()
 

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -247,16 +247,9 @@ class DALIGenericIterator(_DaliBaseIterator):
             batch = self._first_batch
             self._first_batch = None
             return batch
-        if self._counter >= self._size and self._size > 0:
-            if self._auto_reset:
-                self.reset()
-            raise StopIteration
 
         # Gather outputs
-        outputs = []
-        for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
-               outputs.append(p.share_outputs())
+        outputs = self._get_outputs()
 
         for i in range(self._num_gpus):
             dev_id = self._pipes[i].device_id
@@ -327,10 +320,7 @@ class DALIGenericIterator(_DaliBaseIterator):
                                                category_pd_type[cat])
                 feed_ndarray(tensor, ptr)
 
-        for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
-                p.release_outputs()
-                p.schedule_run()
+        self._schedule_runs()
 
         self._advance_and_check_drop_last()
 

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -177,13 +177,9 @@ class DALIGenericIterator(_DaliBaseIterator):
             self._first_batch = None
             return batch
 
-        self._check_stop()
-
         # Gather outputs
-        outputs = []
-        for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
-               outputs.append(p.share_outputs())
+        outputs = self._get_outputs()
+
         for i in range(self._num_gpus):
             dev_id = self._pipes[i].device_id
             # initialize dict for all output categories
@@ -236,10 +232,7 @@ class DALIGenericIterator(_DaliBaseIterator):
                 else:
                     feed_ndarray(tensor, pyt_tensors[category])
 
-        for p in self._pipes:
-            with p._check_api_type_scope(types.PipelineAPIType.ITERATOR):
-                p.release_outputs()
-                p.schedule_run()
+        self._schedule_runs()
 
         self._advance_and_check_drop_last()
 

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -880,7 +880,7 @@ class TestIterator():
 
     def __next__(self):
         batch = []
-        # setting -1 means that no total iteration limmit is set
+        # setting -1 means that no total iteration limit is set
         if self.i < self.n and self.total_n != 0:
             batch = [np.arange(0, 10 , dtype=np.uint8) for _ in range(self.batch_size)]
             self.i += 1
@@ -927,7 +927,7 @@ def check_stop_iter(fw_iter, iterator_name, batch_size, epochs, iter_num, total_
     loader = fw_iter(pipe, iter_size, auto_reset)
     count = 0
     for _ in range(epochs):
-        for __ in enumerate(loader):
+        for _ in enumerate(loader):
             count += 1
         if not auto_reset:
             loader.reset()


### PR DESCRIPTION
- DALI doesn't handle StopIteration from the ExternalSource and
  doesn't allow to automatically reset the iterator. This PR fixes that.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes how DALI handles StopIteration from the ExternalSource

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     moves StopIteration exception handling to base_iterator and add autoreset handling there
 - Affected modules and functionalities:
     FW iterators
 - Key points relevant for the review:
     NA
 - Validation and testing:
     test added
 - Documentation (including examples):
     NA

Relates to https://github.com/NVIDIA/DALI/issues/2371

**JIRA TASK**: *[ NA]*
