### PR TITLE
RandomBBoxCrop to optionally output the indices of the bounding boxes that passed the centroid filter

### DIFF
--- a/dali/operators/image/crop/bbox_crop.cc
+++ b/dali/operators/image/crop/bbox_crop.cc
@@ -523,7 +523,6 @@ class RandomBBoxCropImpl : public OpImplBase<CPUBackend> {
       const auto &labels_in = ws.Input<CPUBackend>(1);
       auto &labels_out = ws.Output<CPUBackend>(next_out_idx++);
       labels_out.Resize({static_cast<Index>(prospective_crop.bbox_indices.size()), 1});
-      int64_t i = 0;
       const auto* labels_in_data = labels_in.data<int>();
       auto *labels_out_data = labels_out.mutable_data<int>();
       for (auto bbox_idx : prospective_crop.bbox_indices) {

--- a/dali/operators/image/crop/bbox_crop.h
+++ b/dali/operators/image/crop/bbox_crop.h
@@ -31,7 +31,7 @@ class RandomBBoxCrop : public Operator<Backend> {
 
  protected:
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override;
-  void RunImpl(Workspace<Backend> &ws) override;
+  void RunImpl(workspace_t<Backend> &ws) override;
 
  private:
   std::unique_ptr<OpImplBase<Backend>> impl_;


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It adds new feature needed to effectively handle segmentation masks together with bounding boxes

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added an optional output to RandomBBoxCrop with the indices of the filtered bounding boxes, so that it can be used to select the relevant masks associated with those (in a different operator)*
 - Affected modules and functionalities:
     *RandomBBoxCrop*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     *Existing tests*
 - Documentation (including examples):
     *Docstr updated*


**JIRA TASK**: *[DALI-1633]*
