### PR TITLE
COCOReader to output relative mask polygon coordinates when the option ratio is set to True

### DIFF
--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -74,7 +74,7 @@ The value is represented as an absolute value.)code",
       0.1f,
       false)
   .AddOptionalArg("ratio",
-      R"code(If set to True, the returned bbox coordinates are relative to the image size.)code",
+      R"code(If set to True, the returned bbox and masks coordinates are relative to the image size.)code",
       false)
   .AddOptionalArg("file_list",
       R"code(Path to the file that contains a list of whitespace separated ``file id`` pairs.

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -428,9 +428,17 @@ void CocoLoader::ParseJsonAnnotations() {
               sample_mask_meta.push_back(obj_coords_offset + annotation.poly_.segm_meta_[i]);
               sample_mask_meta.push_back(obj_coords_offset + annotation.poly_.segm_meta_[i + 1]);
             }
-            sample_mask_coords.insert(sample_mask_coords.end(),
-                                      annotation.poly_.segm_coords_.begin(),
-                                      annotation.poly_.segm_coords_.end());
+            if (ratio) {
+              auto *coords = annotation.poly_.segm_coords_.data();
+              for (size_t i = 0; i < annotation.poly_.segm_coords_.size(); i += 2) {
+                sample_mask_coords.push_back(coords[i] / image_info.width_);
+                sample_mask_coords.push_back(coords[i + 1] / image_info.height_);
+              }
+            } else {
+              sample_mask_coords.insert(sample_mask_coords.end(),
+                                        annotation.poly_.segm_coords_.begin(),
+                                        annotation.poly_.segm_coords_.end());
+            }
             break;
           }
           case detail::Annotation::RLE: {


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to output consistent bounding box and mask coordinate data in COCOReader.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Add normalization to mask coordinates, when requested by `ratio` option*
 - Affected modules and functionalities:
     *COCOReader*
 - Key points relevant for the review:
     *[All]*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *Updated*


**JIRA TASK**: *[DALI-1633]*
