### PR TITLE
Fix permission of files created during docker build

### DIFF
--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -115,11 +115,12 @@ RUN OPENCV_VERSION=4.4.0 && \
     rm -rf /opencv-${OPENCV_VERSION}
 
 # Clang
+# use --no-same-owner as extracted files have a weird premissions
 RUN CLANG_VERSION=8.0.1 && \
     cd /usr/local && \
     wget https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
-    tar -xJf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --strip 1 && \
-    rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
+    tar --no-same-owner -xJf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --strip 1 && \
+    rm -rf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
 
 ENV NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
 
@@ -189,3 +190,6 @@ RUN LIBSND_VERSION=1.0.28 && cd /tmp                                            
 
 # CUDA
 COPY --from=cuda /usr/local/cuda /usr/local/cuda
+
+# fix files permissions just in case
+RUN chown -R root:root / 2> /dev/null || true


### PR DESCRIPTION
- some files get strange 431982 ID - see https://circleci.com/docs/2.0/high-uid-error/#solution
- adds --no-same-owner to tar extraction as it seems that clang produces the offending permissions

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a permission of files created during docker build

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
      adds --no-same-owner to tar extraction as it seems that clang produces the offending permissions
 - Affected modules and functionalities:
     docker build
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
