### PR TITLE
Generate signatures

### DIFF
--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -19,6 +19,7 @@ from functools import wraps
 
 from nvidia.dali.data_node import DataNode as _DataNode
 from nvidia.dali import internal as _internal
+from nvidia.dali import backend as _b
 
 def _call_signature(op_name, include_self, add_kwargs=False):
     schema = _b.GetSchema(op_name)
@@ -29,7 +30,7 @@ def _call_signature(op_name, include_self, add_kwargs=False):
         for i in range(schema.MinNumInput()):
             input_list.append(inspect.Parameter(schema.GetInputName(i), inspect.Parameter.POSITIONAL_OR_KEYWORD))
         for i in range(schema.MinNumInput(), schema.MaxNumInput()):
-            input_list.append(inspect.Parameter(schema.GetInputName(i), inspect.Parameter.POSITIONAL_OR_KEYWORD, default=inspect.Parameter.empty))
+            input_list.append(inspect.Parameter(schema.GetInputName(i), inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None))
     if add_kwargs:
         for arg in schema.GetArgumentNames():
             # providing any defult changes DALI semantics
@@ -98,7 +99,7 @@ def _to_snake_case(pascal):
     return out
 
 def _wrap_op_fn(op_class, wrapper_name):
-    @decorate_signature(op_class.__name__)
+    @decorate_signature(getattr(op_class, 'schema_name', op_class.__name__))
     def op_wrapper(*inputs, **arguments):
         import nvidia.dali.ops
         def is_data_node(x):

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -207,7 +207,7 @@ def _call_signature(op_name, include_self, add_kwargs=False):
         for i in range(schema.MinNumInput()):
             input_list.append(inspect.Parameter(schema.GetInputName(i), inspect.Parameter.POSITIONAL_OR_KEYWORD))
         for i in range(schema.MinNumInput(), schema.MaxNumInput()):
-            input_list.append(inspect.Parameter(schema.GetInputName(i), inspect.Parameter.POSITIONAL_OR_KEYWORD, default=inspect.Parameter.empty))
+            input_list.append(inspect.Parameter(schema.GetInputName(i), inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None))
     if add_kwargs:
         for arg in schema.GetArgumentNames():
             # providing any defult changes DALI semantics


### PR DESCRIPTION
TODO: 

- [ ] deduplicate between modules
- [ ] See if explicit kwargs break something
- [ ] Does it help with IDE integration? 

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Set signatures of DALI calls.

#### What happened in this PR?
 - What solution was applied:
     Decorate the `__call__` or `fn.op` and set the signature explicitly. Bind the arguments to signature to group and reorder them as needed by the operator (between named positional args and kwargs).

Reference: https://www.python.org/dev/peps/pep-0362/

 - Affected modules and functionalities:
     ops and fn Python APIs.
 - Key points relevant for the review:
     *[ Describe here what is the most important part that reviewers should focus on. ]*
 - Validation and testing:
     *[ Describe here if and how this PR is tested. ]*
 - Documentation (including examples):
     *[ Describe here if documentation and examples were updated. ]*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
