### PR TITLE
Add layout support to OneHot operator

### DIFF
--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -87,13 +87,13 @@ TensorShape<> determine_shape(TensorShape<> in_shape, int num_classes, int axis,
 
 TensorLayout OneHot::GetOutputLayout(const HostWorkspace &ws, int placement_axis,
                                      int output_sample_dim) const {
+  if (!new_axis_name_) {
+    return {};
+  }
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto in_layout = input.GetLayout();
   // .size method returns uint_8 which doesn't work well when 0 is printed in error message
   int in_layout_size = in_layout.size();
-  if (!new_axis_name_) {
-    return {};
-  }
   // Handles the legacy 'multi-dimensional' scalars-like
   if (output_sample_dim == 1) {
     return TensorLayout(&new_axis_name_, 1);

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -59,7 +59,7 @@ class in the corresponding input coordinate.
 
 This value will be cast to the ``dtype`` type.)code", 0.f)
   .AddOptionalArg<std::string>("axis_name",
-                  R"code(Single character that will be used as a name for newly added
+                  R"code(Single character that will be used as a name for the newly added
 dimension in the output layout. If no character is provided, the output layout will be
 empty.)code", nullptr);
 
@@ -104,7 +104,7 @@ TensorLayout OneHot::GetOutputLayout(const HostWorkspace &ws, int placement_axis
   }
   DALI_FAIL(make_string("Input layout mismatch - expected input layout to be of size ",
                         output_sample_dim - 1, " but instead got \"", in_layout,
-                        "\" that is of size ", in_layout_size, "."));
+                        "\", which is of size ", in_layout_size, "."));
 }
 
 bool OneHot::SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) {

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -89,7 +89,8 @@ TensorLayout OneHot::GetOutputLayout(const HostWorkspace &ws, int placement_axis
                                      int output_sample_dim) const {
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto in_layout = input.GetLayout();
-  auto in_layout_size = in_layout.size();
+  // .size method returns uint_8 which doesn't work well when 0 is printed in error message
+  int in_layout_size = in_layout.size();
   if (!new_axis_name_) {
     return {};
   }

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -63,7 +63,7 @@ class OneHot : public Operator<CPUBackend> {
       auto axis_name = spec.GetArgument<std::string>("axis_name");
       DALI_ENFORCE(axis_name.length() == 1,
                    make_string("Unsupported axis_name value. It must be a single "
-                               "character, got \"", axis_name, "\" instead"));
+                               "character, got \"", axis_name, "\" instead."));
       new_axis_name_ = axis_name[0];
     }
   }

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -57,7 +57,20 @@ class OneHot : public Operator<CPUBackend> {
         axis_(spec.GetArgument<int>("axis")),
         output_type_(spec.GetArgument<DALIDataType>(arg_names::kDtype)),
         on_value_(spec.GetArgument<float>("on_value")),
-        off_value_(spec.GetArgument<float>("off_value")) {}
+        off_value_(spec.GetArgument<float>("off_value")),
+        layout_axis_name_(spec.GetArgument<std::string>("layout_axis_name")) {
+    auto axis_name_len = layout_axis_name_.length();
+    unsigned char ch;
+    if (axis_name_len > 1 ||
+        (axis_name_len == 1 &&
+         (!std::isupper(ch = static_cast<unsigned char>(layout_axis_name_[0])) &&
+          !std::isdigit(ch)))) {
+      DALI_FAIL(
+          make_string("Unsupported layout_axis_name value. It must be either a single upper case "
+                      "character, a digit, or it must be an empty string. Got \"",
+                      layout_axis_name_, "\" instead"));
+    }
+  }
 
   inline ~OneHot() override = default;
 
@@ -74,12 +87,14 @@ class OneHot : public Operator<CPUBackend> {
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override;
   void RunImpl(HostWorkspace &ws) override;
 
+  TensorLayout GetOutputLayout(const HostWorkspace &ws, int placement_axis) const;
 
   int num_classes_;
   int axis_;
   const DALIDataType output_type_;
   float on_value_;
   float off_value_;
+  const std::string layout_axis_name_;
 };
 
 }  // namespace dali

--- a/dali/test/python/test_operator_one_hot.py
+++ b/dali/test/python/test_operator_one_hot.py
@@ -170,13 +170,16 @@ def test_one_hot_custom_layout_axis_name():
 @raises(RuntimeError)
 def test_too_long_axis_name():
     np.random.seed(42)
-    premade_batch = random_3d_tensors_batch()
-    check_one_hot_operator(premade_batch, axis=-1,
-                           initial_layout="ABC", axis_name="CD")
+    check_one_hot_operator(random_3d_tensors_batch, axis=-1, initial_layout="ABC", axis_name="CD")
 
 
 @raises(RuntimeError)
 def test_empty_string_axis_name():
     np.random.seed(42)
-    premade_batch = random_3d_tensors_batch()
-    check_one_hot_operator(premade_batch, axis=-1, initial_layout="ABC", axis_name="")
+    check_one_hot_operator(random_3d_tensors_batch, axis=-1, initial_layout="ABC", axis_name="")
+
+
+@raises(RuntimeError)
+def test_axis_name_no_initial_layout_multi_dim():
+    np.random.seed(42)
+    check_one_hot_operator(random_3d_tensors_batch, axis=-1, axis_name="O")

--- a/dali/test/python/test_operator_one_hot.py
+++ b/dali/test/python/test_operator_one_hot.py
@@ -11,13 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from functools import partial
 
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
 from test_utils import check_batch
 
+from nose.tools import raises
+
 import numpy as np
+
 
 num_classes = 20
 batch_size = 10
@@ -26,18 +30,54 @@ batch_size = 10
 def insert_as_axis(target, value, axis, total_axes):
     return target[0:axis] + (value,) + target[axis:total_axes]
 
+
+def get_initial_layout(sample_dim=0, insert_at=None, new_axis_name='O', base="ABCD"):
+    return base[0:sample_dim]
+
+
+def modify_layout(layout, output_dim, axis=None, layout_axis_name='O'):
+    if layout_axis_name is not None:
+        layout_axis_name = str(layout_axis_name)
+    if not layout_axis_name or (not layout and output_dim > 1):
+        return ""
+    if axis is None:
+        return layout_axis_name
+    if axis < 0:
+        axis = len(layout)
+    return layout[:axis] + layout_axis_name + layout[axis:]
+
+
+def random_3d_tensors_batch():
+    return [
+        np.random.randint(0, num_classes, size=np.random.randint(2, 8, size=(3,)), dtype=np.int32)
+        for _ in range(batch_size)
+    ]
+
+
+def random_scalars_batch():
+    return np.random.randint(0, num_classes, size=batch_size, dtype=np.int32)
+
+
+def random_scalar_like_tensors_batch(nested_level):
+    return [
+        np.array([np.random.randint(0, num_classes)], dtype=np.int32).reshape((1, ) * nested_level)
+        for x in range(batch_size)
+    ]
+
+
 class OneHotPipeline(Pipeline):
-    def __init__(self, num_classes, input, axis=-1, num_threads=1):
+    def __init__(self, num_classes, input, axis=-1, num_threads=1, layout=None, layout_axis_name="O"):
         super(OneHotPipeline, self).__init__(batch_size,
                                              num_threads,
                                              0)
-        sample_dim = len(input[0].shape)
-        self.ext_src = ops.ExternalSource(source=[input], cycle=True, layout="ABCD"[0:sample_dim])
-        self.one_hot = ops.OneHot(num_classes=num_classes, axis=axis, dtype=types.INT32, device="cpu")
+        self.ext_src = ops.ExternalSource(source=[input], cycle=True, layout=layout)
+        self.one_hot = ops.OneHot(num_classes=num_classes, axis=axis,
+                                  dtype=types.INT32, device="cpu", layout_axis_name=layout_axis_name)
 
     def define_graph(self):
         self.data = self.ext_src()
         return self.one_hot(self.data)
+
 
 def one_hot_3_axes(input, axis):
     total_axes = len(input[0].shape)
@@ -58,6 +98,7 @@ def one_hot_3_axes(input, axis):
         results.append(result)
     return results
 
+
 def one_hot(input):
     outp = np.zeros([batch_size, num_classes], dtype=np.int32)
     for i in range(batch_size):
@@ -66,37 +107,85 @@ def one_hot(input):
 
 
 
-def check_one_hot_operator(premade_batch, axis=-1):
-    pipeline = OneHotPipeline(num_classes=num_classes, input=premade_batch, axis=axis)
+def check_one_hot_operator(premade_batch, axis=-1, expected_output_dim=None, layout_axis_name="O", initial_layout=None):
+    pipeline = OneHotPipeline(
+        num_classes=num_classes, input=premade_batch, axis=axis,
+        layout=initial_layout, layout_axis_name=layout_axis_name)
     pipeline.build()
-    outputs = pipeline.run()
-    sample_dim = len(premade_batch[0].shape)
-    reference = one_hot_3_axes(premade_batch, axis) if sample_dim == 3 else one_hot(premade_batch)
-    new_layout = None # TODO(klecki): add layout handling
-    check_batch(outputs[0], reference, batch_size, max_allowed_error=0, expected_layout=new_layout)
+    (outputs,) = pipeline.run()
+    sample_dim = expected_output_dim or len(premade_batch[0].shape)
+    reference = one_hot_3_axes(
+        premade_batch, axis) if sample_dim == 3 else one_hot(premade_batch)
+    expected_layout = modify_layout(initial_layout, sample_dim, axis, layout_axis_name)
+    check_batch(
+        outputs, reference, batch_size, max_allowed_error=0, expected_layout=expected_layout)
 
 
 def test_one_hot_scalar():
     np.random.seed(42)
     for i in range(10):
-        premade_batch = np.random.randint(0, num_classes, size=batch_size, dtype=np.int32)
-        yield check_one_hot_operator, premade_batch
+        premade_batch = random_scalars_batch()
+        yield partial(check_one_hot_operator, initial_layout=""), premade_batch
 
 
 def test_one_hot_legacy():
     np.random.seed(42)
-    for i in range(10):
-        premade_batch = [np.array([np.random.randint(0, num_classes)], dtype=np.int32)
-                         for x in range(batch_size)]
-        yield check_one_hot_operator, premade_batch, None
+    for j in range(1, 5):  # test 1..4 levels of nested 'multi-dimensional' scalars
+        layout = get_initial_layout(j)
+        for i in range(5):
+            premade_batch = random_scalar_like_tensors_batch(j)
+            yield partial(check_one_hot_operator, axis=None, expected_output_dim=1, initial_layout=layout), premade_batch
 
 
-def test_one_hot ():
+def test_one_hot():
     np.random.seed(42)
+    layout = get_initial_layout(3)
     for i in range(10):
         for axis in [-1, 0, 1, 2, 3]:
-            premade_batch = [
-                np.random.randint(
-                    0, num_classes, size=np.random.randint(2, 8, size=(3,)),
-                    dtype=np.int32) for _ in range(batch_size)]
-            yield check_one_hot_operator, premade_batch, axis
+            expected_layout = modify_layout(layout, axis)
+            premade_batch = random_3d_tensors_batch()
+            yield partial(check_one_hot_operator, initial_layout=layout), premade_batch, axis
+
+
+def test_multi_dim_one_hot_no_initial_layout():
+    np.random.seed(42)
+    for axis in [-1, 0, 1, 2, 3]:
+        premade_batch = random_3d_tensors_batch()
+        yield partial(check_one_hot_operator, axis=axis, initial_layout=""), premade_batch
+
+
+def test_one_hot_reset_layout():
+    np.random.seed(42)
+    layout = get_initial_layout(3)
+    for axis in [-1, 0, 1, 2, 3]:
+        premade_batch = random_3d_tensors_batch()
+        yield partial(check_one_hot_operator, axis=axis, initial_layout=layout, layout_axis_name=""), premade_batch
+    premade_batch = random_scalars_batch()
+    yield partial(check_one_hot_operator, initial_layout="", layout_axis_name=""), premade_batch
+    premade_batch = random_scalar_like_tensors_batch(3)
+    yield partial(check_one_hot_operator, axis=None, expected_output_dim=1, initial_layout=layout, layout_axis_name=""), premade_batch
+
+
+def test_one_hot_custom_layout_axis_name():
+    np.random.seed(42)
+    layout = get_initial_layout(3)
+    premade_batch = random_3d_tensors_batch()
+    yield partial(check_one_hot_operator, axis=-1, initial_layout=layout, layout_axis_name="X"), premade_batch
+    yield partial(check_one_hot_operator, axis=-1, initial_layout=layout, layout_axis_name=0), premade_batch
+    yield partial(check_one_hot_operator, axis=-1, initial_layout=layout, layout_axis_name=1), premade_batch
+
+
+@raises(RuntimeError)
+def test_too_long_axis_name():
+    np.random.seed(42)
+    premade_batch = random_3d_tensors_batch()
+    check_one_hot_operator(premade_batch, axis=-1,
+                           initial_layout="ABC", layout_axis_name="CD")
+
+
+@raises(RuntimeError)
+def test_lowercase_axis_name():
+    np.random.seed(42)
+    premade_batch = random_3d_tensors_batch()
+    check_one_hot_operator(premade_batch, axis=-1,
+                           initial_layout="ABC", layout_axis_name="q")


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

#### Why we need this PR?
- For OneHot operator to handle layout properly.

#### What happened in this PR?
 - What solution was applied:
    Added new parameter layout_axis_name that is used as name in the layout for dimension introduced by operator
 - Affected modules and functionalities:
    Only one hot operator is affected
 - Key points relevant for the review:
    Take a look on dimension naming restrictions for the layouts. By default dimension is labeled with 'O'. If you want the operator to return output without layout you need to explicitly pass empty string in layout_axis_name. Output layout is going to be empty also if the output is more than one dimensional and the input has no layout.
 - Validation and testing:
    Added relevant tests in test_operator_one_hot.py file.
 - Documentation (including examples):
    There's new parameter in OneHot operator documentation.

```
import nvidia.dali as dali
import numpy as np

pipe = dali.pipeline.Pipeline(batch_size = 2, num_threads = 3, device_id = 0,)
with pipe:
    src = dali.ops.ExternalSource(source=[np.array([[[1, 2], [2, 1]], [[3, 0], [0, 3]]]).reshape((2, 2, 2, 1, 1))], layout="ABCD")
    one_hot = dali.fn.one_hot(src(), num_classes=4)
    pipe.set_outputs(one_hot)
pipe.build()
(out,) = pipe.run()
out.layout()
```



**DALI-1659**
