### PR TITLE
Add explicit file list support to FileReader.

### DIFF
--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -78,11 +78,6 @@ The value is represented as an absolute value.)code",
   .AddOptionalArg("ratio",
       R"code(If set to True, the returned bbox and masks coordinates are relative to the image size.)code",
       false)
-  .AddOptionalArg<string>("file_list",
-      R"code(Path to the file that contains a list of whitespace separated ``file id`` pairs.
-
-To traverse the file_root directory and obtain files and labels, skip this argument.)code",
-      nullptr)
   .AddOptionalArg("save_img_ids",
       R"code(If set to True, the image IDs are also returned.)code",
       false)

--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -36,9 +36,11 @@ Tensor (``m * category_id``).)code")
   .AddOptionalArg("shuffle_after_epoch",
       R"code(If set to True, the reader shuffles the entire  dataset after each epoch.)code",
       false)
-  .AddArg("file_root",
-      R"code(Path to a directory that contains the data files.)code",
-      DALI_STRING)
+  .AddOptionalArg<string>("file_root",
+      R"code(Path to a directory that contains the data files.
+
+If a file list is not provided, this argument is required.)code",
+      nullptr)
   .AddOptionalArg("ltrb",
       R"code(If set to True, bboxes are returned as [left, top, right, bottom].
 
@@ -76,11 +78,11 @@ The value is represented as an absolute value.)code",
   .AddOptionalArg("ratio",
       R"code(If set to True, the returned bbox and masks coordinates are relative to the image size.)code",
       false)
-  .AddOptionalArg("file_list",
+  .AddOptionalArg<string>("file_list",
       R"code(Path to the file that contains a list of whitespace separated ``file id`` pairs.
 
-To traverse the file_root directory and obtain files and labels, leave this value empty.)code",
-      std::string())
+To traverse the file_root directory and obtain files and labels, skip this argument.)code",
+      nullptr)
   .AddOptionalArg("save_img_ids",
       R"code(If set to True, the image IDs are also returned.)code",
       false)

--- a/dali/operators/reader/file_reader_op.cc
+++ b/dali/operators/reader/file_reader_op.cc
@@ -21,35 +21,73 @@ namespace dali {
 DALI_REGISTER_OPERATOR(FileReader, FileReader, CPU);
 
 DALI_SCHEMA(FileReader)
-  .DocStr("Reads (file, label) pairs from a directory.")
+  .DocStr(R"(Reads file contents and returns file-label pairs.
+
+This operator can be used in the following modes:
+
+1. Listing files from a directory, assigning labels based on subdirectory structure.
+
+In this mode, the directory indicated in ``file_root`` argument should contain one or more
+subdirectories. The files in these subdirectories are listed and assigned labels based on
+lexicographical order of the subdirectory.
+
+For example, this directory structure::
+
+  <file_root>/0/image0.jpg
+  <file_root>/0/world_map.jpg
+  <file_root>/0/antarctic.png
+  <file_root>/1/cat.jpeg
+  <file_root>/1/dog.tif
+  <file_root>/2/car.jpeg
+  <file_root>/2/truck.jp2
+
+will yield the following outputs::
+
+  <contents of 0/image0.jpg>        0
+  <contents of 0/world_map.jpg>     0
+  <contents of 0/antarctic.png>     0
+  <contents of 1/cat.jpeg>          1
+  <contents of 1/dog.tif>           1
+  <contents of 2/car.jpeg>          2
+  <contents of 2/truck.jp2>         2
+
+2. Use file names and labels stored in a text file.
+
+``file_list`` argument points to a file containing a list of entries containing
+file paths and labels.
+
+3. Use file names and labels provided as a list of strings and integers, respectively.
+
+As with other readers, the (file, label) pairs returned by this operator can be randomly shuffled
+and various sharding strageies can be applied. See documentation of this operator's arguments
+for details.
+)")
   .NumInput(0)
   .NumOutput(2)  // (Images, Labels)
-  .AddOptionalArg<std::string>("file_root",
-      R"code(Path to a directory that contains the data files.
+  .AddOptionalArg<string>("file_root",
+      R"(Path to a directory that contains the data files.
 
-``FileReader`` supports a flat directory structure. The ``file_root`` directory must contain
-directories with data files. To obtain the labels, ``FileReader`` sorts directories in ``file_root``
-in alphabetical order and takes an index in this order as a class label.)code",
+If not using ``file_list`` or ``files``, this directory is traversed to discover the files.
+``file_root`` is required in this mode of operation.)",
       nullptr)
-  .AddOptionalArg("file_list",
-      R"code(Path to a text file that contains the rows of ``filename label`` pairs,
-where the filenames are relative to ``file_root``.
+  .AddOptionalArg<string>("file_list",
+      R"(Path to a text file that contains the rows of ``filename label`` pairs,
+where the filenames are relative to the location of that file or to ``file_root``, if specified.
 
-If left empty, ``file_root`` is traversed for subdirectories, which are only at one level
-down from ``file_root``, and contain files that are associated with the same label.
-When traversing subdirectories, the labels are assigned consecutive numbers.)code",
-      std::string())
+This argument is mutually exclusive with ``files``.)", nullptr)
 .AddOptionalArg("shuffle_after_epoch",
-      R"code(If set to True, the reader shuffles the entire dataset after each epoch.
+      R"(If set to True, the reader shuffles the entire dataset after each epoch.
 
-``stick_to_shard`` and ``random_shuffle`` cannot be used when this argument is set to True.)code",
+``stick_to_shard`` and ``random_shuffle`` cannot be used when this argument is set to True.)",
       false)
   .AddOptionalArg<vector<string>>("files", R"(A list of file paths to read the data from.
 
-If ``file_root`` is provided, it is prepended to the file paths.).
+If ``file_root`` is provided, the paths are treated as being relative to it.
 When using ``files``, the labels are taken from ``labels`` argument or, if it was not supplied,
-contain indices at which given file appeared in the ``files`` list.)", nullptr)
-  .AddOptionalArg<vector<int>>("labels", R"(Labels acoompanying contents of files listed in
+contain indices at which given file appeared in the ``files`` list.
+
+This argument is mutually exclusive with ``file_list``.)", nullptr)
+  .AddOptionalArg<vector<int>>("labels", R"(Labels accompanying contents of files listed in
 ``files`` argument.
 
 If not used, sequential 0-based indices are used as labels)", nullptr)

--- a/dali/operators/reader/file_reader_op.cc
+++ b/dali/operators/reader/file_reader_op.cc
@@ -24,13 +24,13 @@ DALI_SCHEMA(FileReader)
   .DocStr("Reads (file, label) pairs from a directory.")
   .NumInput(0)
   .NumOutput(2)  // (Images, Labels)
-  .AddArg("file_root",
+  .AddOptionalArg<std::string>("file_root",
       R"code(Path to a directory that contains the data files.
 
 ``FileReader`` supports a flat directory structure. The ``file_root`` directory must contain
 directories with data files. To obtain the labels, ``FileReader`` sorts directories in ``file_root``
 in alphabetical order and takes an index in this order as a class label.)code",
-      DALI_STRING)
+      nullptr)
   .AddOptionalArg("file_list",
       R"code(Path to a text file that contains the rows of ``filename label`` pairs,
 where the filenames are relative to ``file_root``.
@@ -44,6 +44,15 @@ When traversing subdirectories, the labels are assigned consecutive numbers.)cod
 
 ``stick_to_shard`` and ``random_shuffle`` cannot be used when this argument is set to True.)code",
       false)
+  .AddOptionalArg<vector<string>>("files", R"(A list of file paths to read the data from.
+
+If ``file_root`` is provided, it is prepended to the file paths.).
+When using ``files``, the labels are taken from ``labels`` argument or, if it was not supplied,
+contain indices at which given file appeared in the ``files`` list.)", nullptr)
+  .AddOptionalArg<vector<int>>("labels", R"(Labels acoompanying contents of files listed in
+``files`` argument.
+
+If not used, sequential 0-based indices are used as labels)", nullptr)
   .AddParent("LoaderBase");
 
 }  // namespace dali

--- a/dali/operators/reader/file_reader_op.cc
+++ b/dali/operators/reader/file_reader_op.cc
@@ -53,13 +53,19 @@ will yield the following outputs::
 
 2. Use file names and labels stored in a text file.
 
-``file_list`` argument points to a file containing a list of entries containing
-file paths and labels.
+``file_list`` argument points to a file which contains one file name and label per line.
+Example::
+
+  dog.jpg 0
+  cute kitten.jpg 1
+  doge.png 0
+
+The file names can contain spaces in the middle, but cannot contain trailing whitespace.
 
 3. Use file names and labels provided as a list of strings and integers, respectively.
 
 As with other readers, the (file, label) pairs returned by this operator can be randomly shuffled
-and various sharding strageies can be applied. See documentation of this operator's arguments
+and various sharding strategies can be applied. See documentation of this operator's arguments
 for details.
 )")
   .NumInput(0)
@@ -71,8 +77,9 @@ If not using ``file_list`` or ``files``, this directory is traversed to discover
 ``file_root`` is required in this mode of operation.)",
       nullptr)
   .AddOptionalArg<string>("file_list",
-      R"(Path to a text file that contains the rows of ``filename label`` pairs,
-where the filenames are relative to the location of that file or to ``file_root``, if specified.
+      R"(Path to a text file that contains one whitespace-separated ``filename label``
+pair per line. The filenames are relative to the location of that file or to ``file_root``,
+if specified.
 
 This argument is mutually exclusive with ``files``.)", nullptr)
 .AddOptionalArg("shuffle_after_epoch",

--- a/dali/operators/reader/file_reader_op.h
+++ b/dali/operators/reader/file_reader_op.h
@@ -28,8 +28,7 @@ class FileReader : public DataReader<CPUBackend, ImageLabelWrapper> {
   explicit FileReader(const OpSpec& spec)
     : DataReader<CPUBackend, ImageLabelWrapper>(spec) {
     bool shuffle_after_epoch = spec.GetArgument<bool>("shuffle_after_epoch");
-    loader_ = InitLoader<FileLabelLoader>(spec, std::vector<std::pair<string, int>>(),
-                                          shuffle_after_epoch);
+    loader_ = InitLoader<FileLabelLoader>(spec, shuffle_after_epoch);
   }
 
   void RunImpl(SampleWorkspace &ws) override {

--- a/dali/operators/reader/loader/CMakeLists.txt
+++ b/dali/operators/reader/loader/CMakeLists.txt
@@ -16,6 +16,7 @@
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 
 set(DALI_OPERATOR_SRCS ${DALI_OPERATOR_SRCS}
+  "${CMAKE_CURRENT_SOURCE_DIR}/filesystem.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/file_loader.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/file_label_loader.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/coco_loader.cc"

--- a/dali/operators/reader/loader/coco_loader.h
+++ b/dali/operators/reader/loader/coco_loader.h
@@ -47,7 +47,7 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
     bool save_img_ids,
     std::vector<int> &original_ids,
     bool shuffle_after_epoch = false) :
-      FileLabelLoader(spec, std::vector<std::pair<string, int>>(), shuffle_after_epoch),
+      FileLabelLoader(spec, shuffle_after_epoch),
       spec_(spec),
       parse_meta_files_(spec.HasArgument("meta_files_path")),
       heights_(heights),

--- a/dali/operators/reader/loader/file_label_loader.h
+++ b/dali/operators/reader/loader/file_label_loader.h
@@ -33,15 +33,8 @@
 namespace dali {
 
 namespace filesystem {
-
-#ifdef WINVER
-constexpr char dir_sep = '\\';
-#else
-constexpr char dir_sep = '/';
-#endif
-
 vector<std::pair<string, int>> traverse_directories(const std::string& path);
-
+std::string join_path(const std::string &dir, const std::string &path);
 }  // namespace filesystem
 
 struct ImageLabelWrapper {
@@ -79,8 +72,14 @@ class DLL_PUBLIC FileLabelLoader : public Loader<CPUBackend, ImageLabelWrapper> 
 
       if (has_file_list_arg_) {
         file_list_ = spec.GetArgument<string>("file_list");
+        DALI_ENFORCE(!file_list_.empty(), "``file_list`` argument cannot be empty");
         if (!has_file_root_arg_) {
-          auto idx = file_list_.rfind(filesystem::dir_sep);
+#ifdef WINVER
+          constexpr char dir_sep = '\\';
+#else
+          constexpr char dir_sep = '/';
+#endif
+          auto idx = file_list_.rfind(dir_sep);
           if (idx != string::npos) {
             file_root_ = file_list_.substr(0, idx);
           }

--- a/dali/operators/reader/loader/file_label_loader.h
+++ b/dali/operators/reader/loader/file_label_loader.h
@@ -28,14 +28,10 @@
 
 #include "dali/core/common.h"
 #include "dali/operators/reader/loader/loader.h"
+#include "dali/operators/reader/loader/filesystem.h"
 #include "dali/util/file.h"
 
 namespace dali {
-
-namespace filesystem {
-vector<std::pair<string, int>> traverse_directories(const std::string& path);
-std::string join_path(const std::string &dir, const std::string &path);
-}  // namespace filesystem
 
 struct ImageLabelWrapper {
   Tensor<CPUBackend> image;
@@ -73,12 +69,7 @@ class DLL_PUBLIC FileLabelLoader : public Loader<CPUBackend, ImageLabelWrapper> 
       if (has_file_list_arg_) {
         DALI_ENFORCE(!file_list_.empty(), "``file_list`` argument cannot be empty");
         if (!has_file_root_arg_) {
-#ifdef WINVER
-          constexpr char dir_sep = '\\';
-#else
-          constexpr char dir_sep = '/';
-#endif
-          auto idx = file_list_.rfind(dir_sep);
+          auto idx = file_list_.rfind(filesystem::dir_sep);
           if (idx != string::npos) {
             file_root_ = file_list_.substr(0, idx);
           }
@@ -136,7 +127,7 @@ class DLL_PUBLIC FileLabelLoader : public Loader<CPUBackend, ImageLabelWrapper> 
     if (image_label_pairs_.empty()) {
       if (!has_file_list_arg_ && !has_files_arg_) {
         image_label_pairs_ = filesystem::traverse_directories(file_root_);
-      } else {
+      } else if (has_file_list_arg_) {
         // load (path, label) pairs from list
         std::ifstream s(file_list_);
         DALI_ENFORCE(s.is_open(), "Cannot open: " + file_list_);

--- a/dali/operators/reader/loader/file_loader.cc
+++ b/dali/operators/reader/loader/file_loader.cc
@@ -91,7 +91,7 @@ vector<std::string> filesystem::traverse_directories(const std::string& file_roo
   while ((entry = readdir(dir))) {
     struct stat s;
     std::string entry_name(entry->d_name);
-    std::string full_path = file_root + "/" + entry_name;
+    std::string full_path = filesystem::join_path(file_root, entry_name);
     int ret = stat(full_path.c_str(), &s);
     DALI_ENFORCE(ret == 0,
         "Could not access " + full_path + " during directory traversal.");
@@ -142,7 +142,7 @@ void FileLoader::ReadSample(ImageFileWrapper& imfile) {
     return;
   }
 
-  auto current_image = FileStream::Open(file_root_ + "/" + image_file, read_ahead_,
+  auto current_image = FileStream::Open(filesystem::join_path(file_root_, image_file), read_ahead_,
                                         !copy_read_data_);
   Index image_size = current_image->Size();
 
@@ -169,7 +169,7 @@ void FileLoader::ReadSample(ImageFileWrapper& imfile) {
   imfile.image.SetMeta(meta);
 
   // set string
-  imfile.filename = file_root_ + "/" + image_file;
+  imfile.filename = filesystem::join_path(file_root_, image_file);
 }
 
 Index FileLoader::SizeImpl() {

--- a/dali/operators/reader/loader/file_loader.h
+++ b/dali/operators/reader/loader/file_loader.h
@@ -28,13 +28,10 @@
 
 #include "dali/core/common.h"
 #include "dali/operators/reader/loader/loader.h"
+#include "dali/operators/reader/loader/filesystem.h"
 #include "dali/util/file.h"
 
 namespace dali {
-namespace filesystem {
-vector<std::string> traverse_directories(const std::string& path, const std::string& filter);
-std::string join_path(const std::string &dir, const std::string &path);
-}  // namespace filesystem
 
 struct ImageFileWrapper {
   Tensor<CPUBackend> image;
@@ -69,12 +66,7 @@ class FileLoader : public Loader< CPUBackend, ImageFileWrapper > {
     if (has_file_list_arg_) {
       DALI_ENFORCE(!file_list_.empty(), "``file_list`` argument cannot be empty");
       if (!has_file_root_arg_) {
-#ifdef WINVER
-        constexpr char dir_sep = '\\';
-#else
-        constexpr char dir_sep = '/';
-#endif
-        auto idx = file_list_.rfind(dir_sep);
+        auto idx = file_list_.rfind(filesystem::dir_sep);
         if (idx != string::npos) {
           file_root_ = file_list_.substr(0, idx);
         }

--- a/dali/operators/reader/loader/file_loader.h
+++ b/dali/operators/reader/loader/file_loader.h
@@ -129,9 +129,11 @@ class FileLoader : public Loader< CPUBackend, ImageFileWrapper > {
         std::ifstream s(file_list_);
         DALI_ENFORCE(s.is_open(), "Cannot open: " + file_list_);
 
-        string image_file;
-        while (s >> image_file) {
-          images_.push_back(image_file);
+        vector<char> line_buf(16 << 10);  // 16 kB should be more than enough for a line
+        char *line = line_buf.data();
+        while (s.getline(line, line_buf.size())) {
+          if (line[0])  // skip empty lines
+            images_.emplace_back(line);
         }
         DALI_ENFORCE(s.eof(), "Wrong format of file_list: " + file_list_);
       }

--- a/dali/operators/reader/loader/file_loader.h
+++ b/dali/operators/reader/loader/file_loader.h
@@ -32,7 +32,8 @@
 
 namespace dali {
 namespace filesystem {
-  vector<std::string> traverse_directories(const std::string& path, const std::string& filter);
+vector<std::string> traverse_directories(const std::string& path, const std::string& filter);
+std::string join_path(const std::string &dir, const std::string &path);
 }  // namespace filesystem
 
 struct ImageFileWrapper {
@@ -46,16 +47,45 @@ class FileLoader : public Loader< CPUBackend, ImageFileWrapper > {
  public:
   explicit inline FileLoader(
     const OpSpec& spec,
-    vector<std::string> images = std::vector<std::string>(),
     bool shuffle_after_epoch = false)
     : Loader<CPUBackend, ImageFileWrapper >(spec),
-      file_list_(spec.GetArgument<string>("file_list")),
-      file_root_(spec.GetArgument<string>("file_root")),
       file_filter_(spec.GetArgument<string>("file_filter")),
-      images_(std::move(images)),
       shuffle_after_epoch_(shuffle_after_epoch),
       current_index_(0),
       current_epoch_(0) {
+
+    vector<string> files;
+
+    has_files_arg_ = spec.TryGetRepeatedArgument(files, "files");
+    has_file_list_arg_ = spec.TryGetArgument(file_list_, "file_list");
+    has_file_root_arg_ = spec.TryGetArgument(file_root_, "file_root");
+
+    DALI_ENFORCE(has_file_root_arg_ || has_files_arg_ || has_file_list_arg_,
+      "``file_root`` argument is required when not using ``files`` or ``file_list``.");
+
+    DALI_ENFORCE(has_files_arg_ + has_file_list_arg_ <= 1,
+      "File paths can be provided through ``files`` or ``file_list`` but not both.");
+
+    if (has_file_list_arg_) {
+      DALI_ENFORCE(!file_list_.empty(), "``file_list`` argument cannot be empty");
+      if (!has_file_root_arg_) {
+#ifdef WINVER
+        constexpr char dir_sep = '\\';
+#else
+        constexpr char dir_sep = '/';
+#endif
+        auto idx = file_list_.rfind(dir_sep);
+        if (idx != string::npos) {
+          file_root_ = file_list_.substr(0, idx);
+        }
+      }
+    }
+
+    if (has_files_arg_) {
+      DALI_ENFORCE(files.size() > 0, "``files`` specified an empty list.");
+      images_ = std::move(files);
+    }
+
     /*
     * Those options are mutually exclusive as `shuffle_after_epoch` will make every shard looks differently
     * after each epoch so coexistence with `stick_to_shard` doesn't make any sense
@@ -92,9 +122,9 @@ class FileLoader : public Loader< CPUBackend, ImageFileWrapper > {
 
   void PrepareMetadataImpl() override {
     if (images_.empty()) {
-      if (file_list_ == "") {
+      if (!has_files_arg_ && !has_file_list_arg_) {
         images_ = filesystem::traverse_directories(file_root_, file_filter_);
-      } else {
+      } else if (has_file_list_arg_) {
         // load paths from list
         std::ifstream s(file_list_);
         DALI_ENFORCE(s.is_open(), "Cannot open: " + file_list_);
@@ -137,6 +167,11 @@ class FileLoader : public Loader< CPUBackend, ImageFileWrapper > {
 
   string file_list_, file_root_, file_filter_;
   vector<std::string> images_;
+
+  bool has_files_arg_     = false;
+  bool has_file_list_arg_ = false;
+  bool has_file_root_arg_ = false;
+
   bool shuffle_after_epoch_;
   Index current_index_;
   int current_epoch_;

--- a/dali/operators/reader/loader/filesystem.cc
+++ b/dali/operators/reader/loader/filesystem.cc
@@ -1,0 +1,206 @@
+// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <dirent.h>
+#include <errno.h>
+#include <glob.h>
+#include <sys/stat.h>
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+#include "dali/operators/reader/loader/filesystem.h"
+#include "dali/operators/reader/loader/utils.h"
+#include "dali/core/error_handling.h"
+
+namespace dali {
+namespace filesystem {
+
+std::string join_path(const std::string &dir, const std::string &path) {
+  if (dir.empty())
+    return path;
+  if (path.empty())
+    return dir;
+  if (path[0] == dir_sep)  // absolute path
+    return path;
+#ifdef WINVER
+  if (path[1] == ':')
+    return path;
+#endif
+  if (dir[dir.length()-1] == dir_sep)
+    return dir + path;
+  else
+    return dir + dir_sep + path;
+}
+
+
+
+inline void assemble_file_list(std::vector<std::pair<std::string, int>>& file_label_pairs,
+                               const std::string &path, const std::string &curr_entry, int label) {
+  std::string curr_dir_path = path + dir_sep + curr_entry;
+  DIR *dir = opendir(curr_dir_path.c_str());
+
+  dirent *entry;
+
+  while ((entry = readdir(dir))) {
+#ifdef _DIRENT_HAVE_D_TYPE
+    /*
+     * we support only regular files and symlinks, if FS returns DT_UNKNOWN
+     * it doesn't mean anything and let us validate filename itself
+     */
+    if (entry->d_type != DT_REG && entry->d_type != DT_LNK &&
+        entry->d_type != DT_UNKNOWN) {
+      continue;
+    }
+#endif
+    std::string rel_path = curr_entry + dir_sep + std::string{entry->d_name};
+    if (HasKnownExtension(std::string(entry->d_name))) {
+      file_label_pairs.push_back(std::make_pair(rel_path, label));
+    }
+  }
+  closedir(dir);
+}
+
+vector<std::pair<string, int>> traverse_directories(const std::string &file_root) {
+  // open the root
+  DIR *dir = opendir(file_root.c_str());
+
+  DALI_ENFORCE(dir != nullptr,
+      "Directory " + file_root + " could not be opened.");
+
+  struct dirent *entry;
+
+  std::vector<std::pair<std::string, int>> file_label_pairs;
+  std::vector<std::string> entry_name_list;
+
+  while ((entry = readdir(dir))) {
+    struct stat s;
+    std::string entry_name(entry->d_name);
+    std::string full_path = join_path(file_root, entry_name);
+    int ret = stat(full_path.c_str(), &s);
+    DALI_ENFORCE(ret == 0,
+        "Could not access " + full_path + " during directory traversal.");
+    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) continue;
+    if (S_ISDIR(s.st_mode)) {
+      entry_name_list.push_back(entry_name);
+    }
+  }
+  // sort directories to preserve class alphabetic order, as readdir could
+  // return unordered dir list. Otherwise file reader for training and validation
+  // could return directories with the same names in completely different order
+  std::sort(entry_name_list.begin(), entry_name_list.end());
+  for (unsigned dir_count = 0; dir_count < entry_name_list.size(); ++dir_count) {
+    assemble_file_list(file_label_pairs, file_root, entry_name_list[dir_count], dir_count);
+  }
+  // sort file names as well
+  std::sort(file_label_pairs.begin(), file_label_pairs.end());
+  printf("read %lu files from %lu directories\n", file_label_pairs.size(), entry_name_list.size());
+
+  closedir(dir);
+
+  return file_label_pairs;
+}
+
+
+inline void assemble_file_list(std::vector<std::string>& file_list,
+                               const std::string &path, const std::string &curr_entry,
+                               const std::string &filter) {
+  std::string curr_dir_path = path + dir_sep + curr_entry;
+  DIR *dir = opendir(curr_dir_path.c_str());
+
+  dirent *entry;
+
+  if (filter.empty()) {
+    while ((entry = readdir(dir))) {
+      std::string full_path = curr_dir_path + dir_sep + std::string{entry->d_name};
+
+#ifdef _DIRENT_HAVE_D_TYPE
+    /*
+     * we support only regular files and symlinks, if FS returns DT_UNKNOWN
+     * it doesn't mean anything and let us validate filename itself
+     */
+      if (entry->d_type != DT_REG && entry->d_type != DT_LNK &&
+         entry->d_type != DT_UNKNOWN) {
+        continue;
+      }
+#endif
+      std::string rel_path = curr_entry + dir_sep + std::string{entry->d_name};
+      if (HasKnownExtension(std::string(entry->d_name))) {
+         file_list.push_back(rel_path);
+      }
+    }
+  } else {
+    // use glob to do the file search
+    glob_t pglob;
+    std::string pattern = curr_dir_path + dir_sep + filter;
+    if (glob(pattern.c_str(), GLOB_TILDE, NULL, &pglob) == 0) {
+      // iterate through the matched files
+      for (unsigned int count = 0; count < pglob.gl_pathc; ++count) {
+        std::string match(pglob.gl_pathv[count]);
+        std::string rel_path = curr_entry + dir_sep + match.substr(match.find_last_of(dir_sep)+1);
+        file_list.push_back(rel_path);
+      }
+      // clean up
+      globfree(&pglob);
+    }
+  }
+  closedir(dir);
+}
+
+
+vector<std::string> traverse_directories(const std::string &file_root, const std::string &filter) {
+  // open the root
+  DIR *dir = opendir(file_root.c_str());
+
+  DALI_ENFORCE(dir != nullptr,
+      "Directory " + file_root + " could not be opened.");
+
+  struct dirent *entry;
+
+  std::vector<std::string> file_list;
+  std::vector<std::string> entry_name_list;
+
+  // always append the root current directory
+  entry_name_list.push_back(".");
+
+  // now traverse sub-directories
+  while ((entry = readdir(dir))) {
+    struct stat s;
+    std::string entry_name(entry->d_name);
+    std::string full_path = join_path(file_root, entry_name);
+    int ret = stat(full_path.c_str(), &s);
+    DALI_ENFORCE(ret == 0,
+        "Could not access " + full_path + " during directory traversal.");
+    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) continue;
+    if (S_ISDIR(s.st_mode)) {
+      entry_name_list.push_back(entry_name);
+    }
+  }
+
+  // sort directories
+  std::sort(entry_name_list.begin(), entry_name_list.end());
+  for (unsigned dir_count = 0; dir_count < entry_name_list.size(); ++dir_count) {
+    assemble_file_list(file_list, file_root, entry_name_list[dir_count], filter);
+  }
+  // sort file names as well
+  std::sort(file_list.begin(), file_list.end());
+  printf("read %lu files from %lu directories\n", file_list.size(), entry_name_list.size());
+
+  closedir(dir);
+
+  return file_list;
+}
+
+}  // namespace filesystem
+}  // namespace dali

--- a/dali/operators/reader/loader/filesystem.h
+++ b/dali/operators/reader/loader/filesystem.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_READER_LOADER_FILESYSTEM_H_
+#define DALI_OPERATORS_READER_LOADER_FILESYSTEM_H_
+
+#include <string>
+#include <utility>
+#include <vector>
+#include "dali/core/common.h"
+
+namespace dali {
+namespace filesystem {
+
+DLL_PUBLIC vector<string> traverse_directories(const string &path, const string &filter);
+
+// TODO(michalz): Make it a more generic utility; support filters.
+DLL_PUBLIC vector<std::pair<string, int>> traverse_directories(const string &file_root);
+
+/**
+ * @brief Prepends dir to a relative path and keeps absolute path unchanged.
+ */
+DLL_PUBLIC string join_path(const string &dir, const string &path);
+
+DLL_PUBLIC string dir_path(const string &path);
+
+#ifdef WINVER
+constexpr char dir_sep = '\\';
+#else
+constexpr char dir_sep = '/';
+#endif
+
+}  // namespace filesystem
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_READER_LOADER_FILESYSTEM_H_

--- a/dali/operators/reader/loader/numpy_loader.h
+++ b/dali/operators/reader/loader/numpy_loader.h
@@ -56,9 +56,8 @@ class NumpyLoader : public FileLoader {
  public:
   explicit inline NumpyLoader(
     const OpSpec& spec,
-    vector<std::string> images = std::vector<std::string>(),
     bool shuffle_after_epoch = false)
-    : FileLoader(spec, images, shuffle_after_epoch),
+    : FileLoader(spec, shuffle_after_epoch),
     header_regex_(R"###(^\{'descr': \'(.*?)\', 'fortran_order': (.*?), 'shape': \((.*?)\), \})###") {}
 
   // we want to make it possible to override this function as well

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -54,7 +54,7 @@ DALI_SCHEMA(NumpyReader)
 This operator can be used in the following modes:
 
 1. Read all files from a directory indicated by ``file_root`` that match given ``file_filter``.
-2. Read file names from a text file.
+2. Read file names from a text file indicated in ``file_list`` argument.
 3. Read files listed in ``files`` argument.
 )")
   .NumInput(0)

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -49,28 +49,42 @@ void NumpyReader::TransposeHelper(Tensor<CPUBackend>& output, const Tensor<CPUBa
 DALI_REGISTER_OPERATOR(NumpyReader, NumpyReader, CPU);
 
 DALI_SCHEMA(NumpyReader)
-  .DocStr("Reads Numpy arrays from a directory.")
+  .DocStr(R"(Reads Numpy arrays from a directory.
+
+This operator can be used in the following modes:
+
+1. Read all files from a directory indicated by ``file_root`` that match given ``file_filter``.
+2. Read file names from a text file.
+3. Read files listed in ``files`` argument.
+)")
   .NumInput(0)
   .NumOutput(1)  // (Arrays)
-  .AddArg("file_root",
-      R"code(Path to a directory containing the data files.
+  .AddOptionalArg<string>("file_root",
+      R"(Path to a directory that contains the data files.
 
-Supports flat directory structure. The ``file_root`` directory should contain directories
-with numpy files in them.)code", DALI_STRING)
+If not using ``file_list`` or ``files``, this directory is traversed to discover the files.
+``file_root`` is required in this mode of operation.)",
+      nullptr)
   .AddOptionalArg("file_filter",
-      R"code(If a value is specified, the string is interpreted as glob string to filter the
-list of files in the sub-directories of the ``file_root``.)code", "*.npy")
-  .AddOptionalArg("file_list",
-            R"code(Path to a text file that contains the rows of ``filename`` entries,
-where the filenames are relative to ``file_root``.
+      R"(If a value is specified, the string is interpreted as glob string to filter the
+list of files in the sub-directories of the ``file_root``.
 
-If left empty, ``file_root`` is traversed for subdirectories, which are only at one level
-down from ``file_root``.)code", std::string())
-  .AddOptionalArg("shuffle_after_epoch",
-      R"code(If set to True, the reader shuffles the entire dataset after each epoch.
+This argument is ignored when file paths are taken from ``file_list`` or ``files``.)", "*.npy")
+  .AddOptionalArg<string>("file_list",
+      R"(Path to a text file that contains filenames (one per line)
+where the filenames are relative to the location of that file or to ``file_root``, if specified.
 
-Using this argument is mutually exclusive with using ``stick_to_shard``
-and ``random_shuffle``.)code", false)
+This argument is mutually exclusive with ``files``.)", nullptr)
+.AddOptionalArg("shuffle_after_epoch",
+      R"(If set to True, the reader shuffles the entire dataset after each epoch.
+
+``stick_to_shard`` and ``random_shuffle`` cannot be used when this argument is set to True.)",
+      false)
+  .AddOptionalArg<vector<string>>("files", R"(A list of file paths to read the data from.
+
+If ``file_root`` is provided, the paths are treated as being relative to it.
+
+This argument is mutually exclusive with ``file_list``.)", nullptr)
   .AddParent("LoaderBase");
 
 }  // namespace dali

--- a/dali/operators/reader/numpy_reader_op.h
+++ b/dali/operators/reader/numpy_reader_op.h
@@ -29,8 +29,7 @@ class NumpyReader : public DataReader<CPUBackend, ImageFileWrapper > {
   explicit NumpyReader(const OpSpec& spec)
     : DataReader< CPUBackend, ImageFileWrapper >(spec) {
     bool shuffle_after_epoch = spec.GetArgument<bool>("shuffle_after_epoch");
-    loader_ = InitLoader<NumpyLoader>(spec, std::vector<string>(),
-                                      shuffle_after_epoch);
+    loader_ = InitLoader<NumpyLoader>(spec, shuffle_after_epoch);
   }
 
   void RunImpl(SampleWorkspace &ws) override {

--- a/dali/test/python/test_operator_file_reader.py
+++ b/dali/test/python/test_operator_file_reader.py
@@ -24,7 +24,7 @@ def setup_module():
 
     g_tmpdir = tempfile.TemporaryDirectory()
     g_root = g_tmpdir.__enter__()
-    g_files = [str(i)+'.dat' for i in range(10)]
+    g_files = [str(i)+' x.dat' for i in range(10)]  # name with a space in the middle!
     populate(g_root, g_files)
 
 def teardown_module():
@@ -32,11 +32,6 @@ def teardown_module():
     global g_files
     global g_tmpdir
 
-    for f in g_files:
-        try:
-            os.remove(os.path.join(g_root, f))
-        except:
-            pass
     g_tmpdir.__exit__(None, None, None)
     g_tmpdir = None
     g_root = None

--- a/dali/test/python/test_operator_file_reader.py
+++ b/dali/test/python/test_operator_file_reader.py
@@ -6,27 +6,45 @@ from nvidia.dali.pipeline import Pipeline
 
 def ref_contents(path):
     fname = path[path.rfind('/')+1:]
-    return "Contents of " + fname + ".\n";l
+    return "Contents of " + fname + ".\n"
 
 def populate(root, files):
     for fname in files:
         with open(os.path.join(root, fname), "w") as f:
-            f.write(ref_contents(fname));
+            f.write(ref_contents(fname))
 
-def _test_env(func):
-    with tempfile.TemporaryDirectory() as root:
-        files = [str(i)+'.dat' for i in range(10)]
-        populate(root, files)
+g_root = None
+g_tmpdir = None
+g_files = None
+
+def setup_module():
+    global g_root
+    global g_files
+    global g_tmpdir
+
+    g_tmpdir = tempfile.TemporaryDirectory()
+    g_root = g_tmpdir.__enter__()
+    g_files = [str(i)+'.dat' for i in range(10)]
+    populate(g_root, g_files)
+
+def teardown_module():
+    global g_root
+    global g_files
+    global g_tmpdir
+
+    for f in g_files:
         try:
-            func(root, files)
-        finally:
-            for f in files:
-                try:
-                    os.remove(os.path.join(root, f))
-                except:
-                    pass
+            os.remove(os.path.join(g_root, f))
+        except:
+            pass
+    g_tmpdir.__exit__(None, None, None)
+    g_tmpdir = None
+    g_root = None
+    g_files = None
 
-def _test_file_reader_body(root, fnames, *, use_root, use_labels, shuffle):
+def _test_reader_files_arg(use_root, use_labels, shuffle):
+    root = g_root
+    fnames = g_files
     if not use_root:
         fnames = [os.path.join(root, f) for f in fnames]
         root = None
@@ -35,26 +53,64 @@ def _test_file_reader_body(root, fnames, *, use_root, use_labels, shuffle):
     if use_labels:
         lbl = [10000 + i for i in range(len(fnames))]
 
-    batch_size = 3;
+    batch_size = 3
     pipe = Pipeline(batch_size, 1, 0)
     files, labels = fn.file_reader(file_root=root, files=fnames, labels=lbl, random_shuffle=shuffle)
     pipe.set_outputs(files, labels)
     pipe.build()
 
-    num_iters = (len(fnames) + 2 * batch_size) // batch_size;
+    num_iters = (len(fnames) + 2 * batch_size) // batch_size
     for i in range(num_iters):
         out_f, out_l = pipe.run()
         for j in range(batch_size):
             contents = bytes(out_f.at(j)).decode('utf-8')
             label = out_l.at(j)[0]
             index = label - 10000 if use_labels else label
-            assert(contents == ref_contents(fnames[index]))
-
-def _test_file_reader(use_root, use_labels, shuffle):
-    _test_env(partial(_test_file_reader_body, use_root=use_root, use_labels=use_labels, shuffle=shuffle))
+            assert contents == ref_contents(fnames[index])
 
 def test_file_reader():
     for use_root in [False, True]:
         for use_labels in [False, True]:
             for shuffle in [False, True]:
-                yield _test_file_reader, use_root, use_labels, shuffle
+                yield _test_reader_files_arg, use_root, use_labels, shuffle
+
+def test_file_reader_relpath():
+    batch_size = 3
+    rel_root = os.path.relpath(g_root, os.getcwd())
+    fnames = [os.path.join(rel_root, f) for f in g_files]
+
+    pipe = Pipeline(batch_size, 1, 0)
+    files, labels = fn.file_reader(files=fnames, random_shuffle=True)
+    pipe.set_outputs(files, labels)
+    pipe.build()
+
+    num_iters = (len(fnames) + 2 * batch_size) // batch_size
+    for i in range(num_iters):
+        out_f, out_l = pipe.run()
+        for j in range(batch_size):
+            contents = bytes(out_f.at(j)).decode('utf-8')
+            index = out_l.at(j)[0]
+            assert contents == ref_contents(fnames[index])
+
+def test_file_reader_relpath_file_list():
+    batch_size = 3
+    fnames = g_files
+
+    list_file = os.path.join(g_root, "list.txt")
+    with open(list_file, "w") as f:
+        for i, name in enumerate(fnames):
+            f.write("{0} {1}\n".format(name, 10000 - i))
+
+    pipe = Pipeline(batch_size, 1, 0)
+    files, labels = fn.file_reader(file_list=list_file, random_shuffle=True)
+    pipe.set_outputs(files, labels)
+    pipe.build()
+
+    num_iters = (len(fnames) + 2 * batch_size) // batch_size
+    for i in range(num_iters):
+        out_f, out_l = pipe.run()
+        for j in range(batch_size):
+            contents = bytes(out_f.at(j)).decode('utf-8')
+            label = out_l.at(j)[0]
+            index = 10000 - label
+            assert contents == ref_contents(fnames[index])

--- a/dali/test/python/test_operator_file_reader.py
+++ b/dali/test/python/test_operator_file_reader.py
@@ -1,0 +1,60 @@
+import tempfile
+import os
+import nvidia.dali.fn as fn
+from functools import partial
+from nvidia.dali.pipeline import Pipeline
+
+def ref_contents(path):
+    fname = path[path.rfind('/')+1:]
+    return "Contents of " + fname + ".\n";l
+
+def populate(root, files):
+    for fname in files:
+        with open(os.path.join(root, fname), "w") as f:
+            f.write(ref_contents(fname));
+
+def _test_env(func):
+    with tempfile.TemporaryDirectory() as root:
+        files = [str(i)+'.dat' for i in range(10)]
+        populate(root, files)
+        try:
+            func(root, files)
+        finally:
+            for f in files:
+                try:
+                    os.remove(os.path.join(root, f))
+                except:
+                    pass
+
+def _test_file_reader_body(root, fnames, *, use_root, use_labels, shuffle):
+    if not use_root:
+        fnames = [os.path.join(root, f) for f in fnames]
+        root = None
+
+    lbl = None
+    if use_labels:
+        lbl = [10000 + i for i in range(len(fnames))]
+
+    batch_size = 3;
+    pipe = Pipeline(batch_size, 1, 0)
+    files, labels = fn.file_reader(file_root=root, files=fnames, labels=lbl, random_shuffle=shuffle)
+    pipe.set_outputs(files, labels)
+    pipe.build()
+
+    num_iters = (len(fnames) + 2 * batch_size) // batch_size;
+    for i in range(num_iters):
+        out_f, out_l = pipe.run()
+        for j in range(batch_size):
+            contents = bytes(out_f.at(j)).decode('utf-8')
+            label = out_l.at(j)[0]
+            index = label - 10000 if use_labels else label
+            assert(contents == ref_contents(fnames[index]))
+
+def _test_file_reader(use_root, use_labels, shuffle):
+    _test_env(partial(_test_file_reader_body, use_root=use_root, use_labels=use_labels, shuffle=shuffle))
+
+def test_file_reader():
+    for use_root in [False, True]:
+        for use_labels in [False, True]:
+            for shuffle in [False, True]:
+                yield _test_file_reader, use_root, use_labels, shuffle


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a long cried for feature: explicitly provided file list in FileReader

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added arguments `files` and `labels`
     * Add handling of `files` to NumPy reader
     * Generate sequential labels if none provided
     * Handle relative paths, if no root is provided
     * Interpret file paths as relative to the list file, if no file_root is provided.
 - Affected modules and functionalities:
     * FileReader, FileLabelLoader, COCOReader
 - Key points relevant for the review:
     * FileLoader constructor
 - Validation and testing:
     * Existing tests + python test for new functionality
 - Documentation (including examples):
     * Docstrings


**JIRA TASK**: N/A
