### PR TITLE
Fix TL1_nodeps_build and TL0_cpu_only

### DIFF
--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -240,7 +240,7 @@ def test_mfcc_cpu():
     spectrum = fn.spectrogram(data, nfft = 60, window_length = 50, window_step = 25)
     mel = fn.mel_filter_bank(spectrum)
     dec = fn.to_decibels(mel)
-    processed = fn.mfc(dec)
+    processed = fn.mfcc(dec)
     pipe.set_outputs(processed)
     pipe.build()
     for _ in range(3):

--- a/qa/TL1_nodeps_build/main.cc
+++ b/qa/TL1_nodeps_build/main.cc
@@ -8,9 +8,5 @@ int main(int argc, char **argv) {
     auto mem = dali::kernels::memory::alloc_unique<float>(dali::kernels::AllocType::Host, 30);
   }
 
-  {
-    auto mem = dali::kernels::memory::alloc_unique<float>(dali::kernels::AllocType::GPU, 30);
-  }
-
   return 0;
 }


### PR DESCRIPTION
- mfcc test on CPU only test doesn't work because mfcc was misspelled
- remove TL1_nodeps_build GPU dependency - we don't need to run any GPU code to test it

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes TL1_nodeps_build and TL0_cpu_only

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     mfcc test on CPU only test doesn't work because mfcc was misspelled
     remove TL1_nodeps_build GPU dependency - we don't need to run any GPU code to test it
 - Affected modules and functionalities:
     qa tests
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
