### PR TITLE
Generalized handling of operator arguments.

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -942,6 +942,10 @@ static const OpSchema &GetSchema(const string &name) {
   return SchemaRegistry::GetSchema(name);
 }
 
+static const OpSchema *TryGetSchema(const string &name) {
+  return SchemaRegistry::TryGetSchema(name);
+}
+
 static constexpr int GetCxx11AbiFlag() {
 #ifdef _GLIBCXX_USE_CXX11_ABI
   return _GLIBCXX_USE_CXX11_ABI;
@@ -1418,6 +1422,7 @@ PYBIND11_MODULE(backend_impl, m) {
 
   // Registry for OpSchema
   m.def("GetSchema", &GetSchema, py::return_value_policy::reference);
+  m.def("TryGetSchema", &TryGetSchema, py::return_value_policy::reference);
 
   py::class_<OpSchema>(m, "OpSchema")
     .def("Dox", &OpSchema::Dox)

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -259,6 +259,9 @@ Keyword Args
         self._cuda_stream = cuda_stream
         self._use_copy_kernel = use_copy_kernel
 
+        import nvidia.dali.ops
+        kwargs, self._call_args = nvidia.dali.ops._separate_kwargs(kwargs)
+
         callback = _get_callback_from_source(source, cycle)
 
         if name is not None and num_outputs is not None:

--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -14,7 +14,6 @@
 
 #pylint: disable=no-member
 import sys
-from nvidia.dali.data_node import DataNode as _DataNode
 from nvidia.dali import internal as _internal
 
 _special_case_mapping = {
@@ -64,31 +63,16 @@ def _to_snake_case(pascal):
 def _wrap_op_fn(op_class, wrapper_name):
     def op_wrapper(*inputs, **arguments):
         import nvidia.dali.ops
-        def is_data_node(x):
-            return isinstance(x, _DataNode)
-        def is_call_arg(name, value):
-            if name == "name" or is_data_node(value):
-                return True
-            if value is None:
-                return False
-            if isinstance(value, (bool, int, float, str, list, tuple, nvidia.dali.types.ScalarConstant)):
-                return False
-            return hasattr(value, "shape")
-
-        def to_scalar(scalar):
-            return scalar.value if isinstance(scalar, nvidia.dali.types.ScalarConstant) else scalar
-
-        scalar_args = { name:to_scalar(value) for (name, value) in arguments.items() if not is_call_arg(name, value) }
-        tensor_args = { name:value for (name, value) in arguments.items() if is_call_arg(name, value) }
+        init_args, call_args = nvidia.dali.ops._separate_kwargs(arguments)
 
         default_dev = nvidia.dali.ops._choose_device(inputs)
-        if default_dev == "gpu" and scalar_args.get("device") == "cpu":
+        if default_dev == "gpu" and init_args.get("device") == "cpu":
             raise ValueError("An operator with device='cpu' cannot accept GPU inputs.")
 
-        if "device" not in scalar_args:
-            scalar_args["device"] = default_dev
+        if "device" not in init_args:
+            init_args["device"] = default_dev
 
-        return op_class(**scalar_args)(*inputs, **tensor_args)
+        return op_class(**init_args)(*inputs, **call_args)
 
     op_wrapper.__name__ = wrapper_name
     op_wrapper.__doc__ = "see :class:`{0}.{1}`".format(op_class.__module__, op_class.__name__)

--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -67,7 +67,13 @@ def _wrap_op_fn(op_class, wrapper_name):
         def is_data_node(x):
             return isinstance(x, _DataNode)
         def is_call_arg(name, value):
-            return name == "name" or is_data_node(value)
+            if name == "name" or is_data_node(value):
+                return True
+            if value is None:
+                return False
+            if isinstance(value, (bool, int, float, str, list, tuple)):
+                return False
+            return hasattr(value, "shape")
 
         def to_scalar(scalar):
             return scalar.value if isinstance(scalar, nvidia.dali.types.ScalarConstant) else scalar

--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -71,7 +71,7 @@ def _wrap_op_fn(op_class, wrapper_name):
                 return True
             if value is None:
                 return False
-            if isinstance(value, (bool, int, float, str, list, tuple)):
+            if isinstance(value, (bool, int, float, str, list, tuple, nvidia.dali.types.ScalarConstant)):
                 return False
             return hasattr(value, "shape")
 

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -1083,11 +1083,11 @@ def register_gpu_op(name):
 from nvidia.dali.external_source import ExternalSource
 ExternalSource.__module__ = __name__
 
-class CompoundOp:
+class _CompoundOp:
     def __init__(self, op_list):
         self._ops = []
         for op in op_list:
-            if isinstance(op, CompoundOp):
+            if isinstance(op, _CompoundOp):
                 self._ops += op._ops
             else:
                 self._ops.append(op)
@@ -1114,6 +1114,9 @@ The return value is a callable object which, when called, performs::
 
     op_list[n-1](op_list([n-2](...  op_list[0](args))))
 
+Operators can be composed only when all outputs of the previous operator can be processed directly
+by the next operator in the list.
+
 The example below chains an image decoder and a Resize operation with random square size.
 The  ``decode_and_resize`` object can be called as if it was an operator::
 
@@ -1132,6 +1135,9 @@ example, ``Compose`` automatically arranges copying the data to GPU memory.
 .. note::
     This is an experimental feature, subject to change without notice.
 """
-    return op_list[0] if len(op_list) == 1 else CompoundOp(op_list)
+    return op_list[0] if len(op_list) == 1 else _CompoundOp(op_list)
+
+_cpu_ops = _cpu_ops.union({"Compose"})
+_gpu_ops = _gpu_ops.union({"Compose"})
 
 _load_ops()

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -275,11 +275,14 @@ class _OperatorInstance(object):
                 if isinstance(arg_inp, _ScalarConstant):
                     arg_inp = _instantiate_constant_node("cpu", arg_inp)
                 if not isinstance(arg_inp, _DataNode):
-                    raise TypeError(
-                            ("Expected inputs of type " +
-                            "`DataNode`. Received " +
-                            "input of type '{}'.")
-                            .format(type(arg_inp).__name__))
+                    try:
+                        arg_inp = _Constant(arg_inp, device="cpu")
+                    except Exception as e:
+                        raise TypeError(
+                                ("Expected inputs of type " +
+                                "`DataNode` or convertible to constant nodes. Received " +
+                                "input `{}` of type '{}'.")
+                                .format(k, type(arg_inp).__name__)) from e
                 self._spec.AddArgumentInput(k, arg_inp.name)
                 self._inputs = list(self._inputs) + [arg_inp]
 

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -234,11 +234,59 @@ class _OpCounter(object):
 def _instantiate_constant_node(device, constant):
     return _Constant(device=device, value=constant.value, dtype=constant.dtype, shape=constant.shape)
 
+
+def _separate_kwargs(kwargs):
+    """Separates arguments into ones that should go to operator's __init__ and to __call__.
+
+    Returns a pair of dictionaries of kwargs - the first for __init__, the second for __call__.
+    """
+    def is_data_node(x):
+        return isinstance(x, _DataNode)
+    def is_call_arg(name, value):
+        if name == "device":
+            return False
+        if name == "name" or is_data_node(value):
+            return True
+        if isinstance(value, (str, list, tuple, nvidia.dali.types.ScalarConstant)):
+            return False
+        return not nvidia.dali.types._is_scalar_value(value)
+
+    def to_scalar(scalar):
+        return scalar.value if isinstance(scalar, nvidia.dali.types.ScalarConstant) else scalar
+
+    init_args = {}
+    call_args = {}
+    for name, value in kwargs.items():
+        if value is None:
+            continue
+        if is_call_arg(name, value):
+            call_args[name] = value
+        else:
+            init_args[name] = to_scalar(value)
+
+    return init_args, call_args
+
+def _add_spec_args(schema, spec, kwargs):
+    for key, value in kwargs.items():
+        if value is None:
+            # None is not a valid value for any argument type, so treat it
+            # as if the argument was not supplied at all
+            continue
+
+        dtype = schema.GetArgumentType(key)
+        if isinstance(value, (list, tuple)):
+            if len(value) == 0:
+                spec.AddArgEmptyList(key, _vector_element_type(dtype))
+                continue
+        converted_value = _type_convert_value(dtype, value)
+        spec.AddArg(key, converted_value)
+
 class _OperatorInstance(object):
     def __init__(self, inputs, op, **kwargs):
         self._counter = _OpCounter()
         self._outputs = []
         self._op = op
+        self._default_call_args = op._call_args
         self._spec = op.spec.copy()
         self._relation_id = self._counter.id
 
@@ -253,7 +301,18 @@ class _OperatorInstance(object):
 
         self._inputs = inputs
 
-        name = kwargs.get("name", None)
+        spec_args, kwargs = _separate_kwargs(kwargs)
+        _add_spec_args(op._schema, self._spec, spec_args)
+
+        call_args = {**self._default_call_args}
+        for k, v in kwargs.items():
+            if v is None:
+                continue  # if an argument was specified in __init__ and in __call__ it is None, ignore it
+            if k in self._default_call_args:
+                raise ValueError("The argument `{}` was already specified in __init__.".format(k))
+            call_args[k] = v
+
+        name = call_args.get("name", None)
         if name is not None:
             self._name = name
         else:
@@ -267,9 +326,9 @@ class _OperatorInstance(object):
                         .format(type(inp).__name__))
                 self._spec.AddInput(inp.name, inp.device)
         # Argument inputs
-        for k in sorted(kwargs.keys()):
+        for k in sorted(call_args.keys()):
             if k not in ["name"]:
-                arg_inp = kwargs[k]
+                arg_inp = call_args[k]
                 if arg_inp is None:
                     continue
                 if isinstance(arg_inp, _ScalarConstant):
@@ -382,6 +441,8 @@ def python_op_factory(name, schema_name = None, op_device = "cpu"):
                 self._device = op_device
             self._spec.AddArg("device", self._device)
 
+            kwargs, self._call_args = _separate_kwargs(kwargs)
+
             if "preserve" in kwargs.keys():
                 self._preserve = kwargs["preserve"]
             else:
@@ -412,19 +473,7 @@ def python_op_factory(name, schema_name = None, op_device = "cpu"):
                     warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
             # Store the specified arguments
-            for key, value in kwargs.items():
-                if value is None:
-                  # None is not a valid value for any argument type, so treat it
-                  # as if the argument was not supplied at all
-                  continue
-
-                dtype = self._schema.GetArgumentType(key)
-                if isinstance(value, (list, tuple)):
-                    if len(value) == 0:
-                        self._spec.AddArgEmptyList(key, _vector_element_type(dtype))
-                        continue
-                converted_value = _type_convert_value(dtype, value)
-                self._spec.AddArg(key, converted_value)
+            _add_spec_args(self._schema, self._spec, kwargs)
 
         @property
         def spec(self):
@@ -608,6 +657,8 @@ class TFRecordReader(metaclass=_DaliOperatorMeta):
         self._spec.AddArg("path", self._path)
         self._spec.AddArg("index_path", self._index_path)
 
+        kwargs, self._call_args = _separate_kwargs(kwargs)
+
         for key, value in kwargs.items():
             self._spec.AddArg(key, value)
 
@@ -665,6 +716,8 @@ class PythonFunctionBase(metaclass=_DaliOperatorMeta):
         self._spec = _b.OpSpec(impl_name)
         self._device = device
         self._impl_name = impl_name
+
+        kwargs, self._call_args = _separate_kwargs(kwargs)
 
         for key, value in kwargs.items():
             self._spec.AddArg(key, value)
@@ -1030,5 +1083,31 @@ def register_gpu_op(name):
 from nvidia.dali.external_source import ExternalSource
 ExternalSource.__module__ = __name__
 
-_load_ops()
+class CompoundOp:
+    def __init__(self, op_list):
+        self.ops = op_list
 
+    def __call__(self, *inputs, **kwargs):
+        for op in self.ops:
+            inputs = op(*inputs, **kwargs)
+            kwargs = {}
+            if isinstance(inputs, _DataNode):
+                inputs = (inputs,)
+
+        return inputs[0] if len(inputs) == 1 else inputs
+
+def Compose(op_list):
+    """Returns a meta-operator that chains the operations in op_list.
+
+The return value is a callable object which, when called, performs::
+
+    op_list[n-1](op_list([n-2](...  op_list[0](args))))
+
+If ``op_list`` contains just one element, the function returns that element.
+
+.. note::
+    This is an experimental feature, subject to change without notice.
+"""
+    return op_list[0] if len(op_list) == 1 else CompoundOp(op_list)
+
+_load_ops()

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -393,6 +393,8 @@ Parameters
             if isinstance(outputs[i], types.ScalarConstant):
                 import nvidia.dali.ops
                 outputs[i] = nvidia.dali.ops._instantiate_constant_node("cpu", outputs[i])
+            elif not isinstance(outputs[i], DataNode):
+                outputs[i] = types.Constant(outputs[i], device="cpu")
             _data_node._check(outputs[i])
 
         # Backtrack to construct the graph

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -349,7 +349,7 @@ def ConstantNode(device, value, dtype, shape, layout, **kwargs):
     if _is_numpy_array(value):
         import numpy as np
 
-        # 64-bit types are not supported - downgrade the input
+        # 64-bit types require explicit dtype
         if value.dtype == np.float64:
             value = value.astype(np.float32)
         if value.dtype == np.int64:
@@ -423,6 +423,13 @@ def ConstantNode(device, value, dtype, shape, layout, **kwargs):
                       shape = shape, dtype = dtype, layout = layout,
                       **constructor_args)
     return op(**call_args)
+
+def _is_scalar_value(value):
+    if value is None:
+        return True
+    if isinstance(value, (bool, int, float)):
+        return True
+    return not _is_compatible_array_type(value) or _is_scalar_shape(value.shape)
 
 def Constant(value, dtype = None, shape = None, layout = None, device = None, **kwargs):
     """Wraps a constant value which can then be used in

--- a/dali/test/python/test_operator_compose.py
+++ b/dali/test/python/test_operator_compose.py
@@ -1,0 +1,56 @@
+import nvidia.dali as dali
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops as ops
+import numpy as np
+
+def test_unified_arg_placement():
+    batch_size = 30
+
+    pipe = Pipeline(batch_size,1,None)
+    with pipe:
+        u = ops.Uniform()(range=(1,2), shape=3)
+        tr = ops.transforms.Translation(offset=u, device="cpu")
+        pipe.set_outputs(tr(), u)
+    pipe.build()
+    matrices, offsets = pipe.run()
+    assert len(matrices) == batch_size
+    for i in range(len(matrices)):
+        offset = offsets.at(i)
+        matrix = matrices.at(i)
+        assert offset.shape == (3,)
+        for j in range(3):
+            assert offset[j] >= 1 and offset[j] < 2  # check that it's not all zeros or sth
+        T = offset[:,np.newaxis]  # convert to a columnn
+        assert np.array_equal(matrix, np.concatenate([np.identity(3), T], axis=1))
+
+def test_compose():
+    batch_size = 3
+    pipe = Pipeline(batch_size,1,None)
+
+    u = ops.Uniform()(range=(1,2), shape=3)
+    c1 = ops.Compose([
+        ops.transforms.Translation(offset=u),
+        ops.transforms.Scale(scale=[1,1,-1])
+    ])
+    c2 = ops.Compose([
+        c1,
+        ops.transforms.Rotation(angle=90, axis=[0,0,1])
+    ])
+    pipe.set_outputs(c2(dali.fn.transforms.scale(scale=[2,2,2])), u)
+    pipe.build()
+    matrices, offsets = pipe.run()
+    assert len(matrices) == batch_size
+    for i in range(len(matrices)):
+        offset = offsets.at(i)
+        matrix = matrices.at(i)
+        assert offset.shape == (3,)
+        for j in range(3):
+            assert offset[j] >= 1 and offset[j] < 2  # check that it's not all zeros or sth
+        mtx = np.float32([[0,-1, 0],
+                          [1, 0, 0],
+                          [0, 0, -1]])
+        T = offset[:,np.newaxis]  # convert to a columnn
+        T = np.dot(mtx, T)
+        mtx *= 2
+        assert np.allclose(matrix, np.concatenate([mtx, T], axis=1), rtol=1e-5, atol=1e-6)
+

--- a/dali/test/python/test_operator_compose.py
+++ b/dali/test/python/test_operator_compose.py
@@ -1,14 +1,17 @@
+import numpy as np
+import os
 import nvidia.dali as dali
+import nvidia.dali.fn as fn
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
-import numpy as np
+import test_utils
 
 def test_unified_arg_placement():
     batch_size = 30
 
-    pipe = Pipeline(batch_size,1,None)
+    pipe = Pipeline(batch_size, 1, None)
     with pipe:
-        u = ops.Uniform()(range=(1,2), shape=3)
+        u = ops.Uniform()(range=(1, 2), shape=3)
         tr = ops.transforms.Translation(offset=u, device="cpu")
         pipe.set_outputs(tr(), u)
     pipe.build()
@@ -25,18 +28,18 @@ def test_unified_arg_placement():
 
 def test_compose():
     batch_size = 3
-    pipe = Pipeline(batch_size,1,None)
+    pipe = Pipeline(batch_size, 1, None)
 
-    u = ops.Uniform()(range=(1,2), shape=3)
+    u = ops.Uniform()(range=(1, 2), shape=3)
     c1 = ops.Compose([
         ops.transforms.Translation(offset=u),
-        ops.transforms.Scale(scale=[1,1,-1])
+        ops.transforms.Scale(scale=[1, 1,-1])
     ])
     c2 = ops.Compose([
         c1,
-        ops.transforms.Rotation(angle=90, axis=[0,0,1])
+        ops.transforms.Rotation(angle=90, axis=[0, 0, 1])
     ])
-    pipe.set_outputs(c2(dali.fn.transforms.scale(scale=[2,2,2])), u)
+    pipe.set_outputs(c2(fn.transforms.scale(scale=[2, 2, 2])), u)
     pipe.build()
     matrices, offsets = pipe.run()
     assert len(matrices) == batch_size
@@ -46,11 +49,30 @@ def test_compose():
         assert offset.shape == (3,)
         for j in range(3):
             assert offset[j] >= 1 and offset[j] < 2  # check that it's not all zeros or sth
-        mtx = np.float32([[0,-1, 0],
-                          [1, 0, 0],
-                          [0, 0, -1]])
+        mtx = np.float32([[0, -1,  0],
+                          [1,  0,  0],
+                          [0,  0, -1]])
         T = offset[:,np.newaxis]  # convert to a columnn
         T = np.dot(mtx, T)
         mtx *= 2
         assert np.allclose(matrix, np.concatenate([mtx, T], axis=1), rtol=1e-5, atol=1e-6)
 
+test_data_root = os.environ['DALI_EXTRA_PATH']
+caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
+
+def test_compose_change_device():
+    batch_size = 3
+    pipe = Pipeline(batch_size, 1, 0)
+
+    size = fn.uniform(shape=2, range=(300,500))
+    c = ops.Compose([
+        ops.ImageDecoder(device="cpu"),
+        ops.Resize(size=size, device="gpu")
+    ])
+    files, labels = fn.caffe_reader(path=caffe_db_folder, seed=1)
+    pipe.set_outputs(c(files), fn.resize(fn.image_decoder(files).gpu(), size=size))
+
+    pipe.build()
+    out = pipe.run()
+    assert isinstance(out[0], dali.backend.TensorListGPU)
+    test_utils.check_batch(out[0], out[1], batch_size=batch_size)

--- a/dali/test/python/test_operator_input_promotion.py
+++ b/dali/test/python/test_operator_input_promotion.py
@@ -10,6 +10,15 @@ def test_cat_numpy_array():
     o = pipe.run()
     assert np.array_equal(o[0].at(0), np.array([[10,11,20],[12,13,21]]))
 
+
+def test_stack_numpy_scalar():
+    pipe = dali.pipeline.Pipeline(1,1,0)
+    src = fn.external_source([[np.array([[10,11],[12,13]], dtype=np.float32)]])
+    pipe.set_outputs(fn.cat(src, np.array([[20],[21]], dtype=np.float32), axis=1))
+    pipe.build()
+    o = pipe.run()
+    assert np.array_equal(o[0].at(0), np.array([[10,11,20],[12,13,21]]))
+
 def test_slice_fn():
     pipe = dali.pipeline.Pipeline(1,1,0)
     src = fn.external_source([[np.array([[10,11,12],[13,14,15],[16,17,18]], dtype=np.float32)]])
@@ -48,16 +57,16 @@ def test_python_function():
     o = pipe.run()
     assert np.array_equal(o[0].at(0), np.array([[1,4],[9,16]]))
 
-
 def test_arithm_ops():
     pipe = dali.pipeline.Pipeline(1,1,0)
     with pipe:
-        in1 = fn.external_source([[np.array([[1,2],[3,4]])]])
-        pipe.set_outputs(in1 + np.array([[10,20],[30,40]]), in1 + np.array(5))
+        in1 = fn.external_source([[np.uint8([[1,2],[3,4]])]])
+        pipe.set_outputs(in1 + np.array([[10,20],[30,40]]), in1 + np.array(5), in1 + np.uint8(100))
     pipe.build()
     o = pipe.run()
     assert np.array_equal(o[0].at(0), np.array([[11,22],[33,44]]))
     assert np.array_equal(o[1].at(0), np.array([[6,7],[8,9]]))
+    assert np.array_equal(o[2].at(0), np.array([[101,102],[103,104]]))
 
 def test_arg_input():
     pipe = dali.pipeline.Pipeline(1,1,0)

--- a/dali/test/python/test_operator_input_promotion.py
+++ b/dali/test/python/test_operator_input_promotion.py
@@ -58,3 +58,12 @@ def test_arithm_ops():
     o = pipe.run()
     assert np.array_equal(o[0].at(0), np.array([[11,22],[33,44]]))
     assert np.array_equal(o[1].at(0), np.array([[6,7],[8,9]]))
+
+def test_arg_input():
+    pipe = dali.pipeline.Pipeline(1,1,0)
+    with pipe:
+        in1 = fn.external_source([[np.float32([[1,2,3],[4,5,6]])]])
+        pipe.set_outputs(fn.transforms.translation(in1, offset=np.float32([10,20])))
+    pipe.build()
+    o = pipe.run()
+    assert np.array_equal(o[0].at(0), np.array([[1,2,13],[4,5,26]]))

--- a/dali/test/python/test_operator_input_promotion.py
+++ b/dali/test/python/test_operator_input_promotion.py
@@ -3,7 +3,7 @@ import nvidia.dali.fn as fn
 import numpy as np
 
 def test_cat_numpy_array():
-    pipe = dali.pipeline.Pipeline(1,1,0)
+    pipe = dali.pipeline.Pipeline(1,1,None)
     src = fn.external_source([[np.array([[10,11],[12,13]], dtype=np.float32)]])
     pipe.set_outputs(fn.cat(src, np.array([[20],[21]], dtype=np.float32), axis=1))
     pipe.build()
@@ -12,7 +12,7 @@ def test_cat_numpy_array():
 
 
 def test_stack_numpy_scalar():
-    pipe = dali.pipeline.Pipeline(1,1,0)
+    pipe = dali.pipeline.Pipeline(1,1,None)
     src = fn.external_source([[np.array([[10,11],[12,13]], dtype=np.float32)]])
     pipe.set_outputs(fn.cat(src, np.array([[20],[21]], dtype=np.float32), axis=1))
     pipe.build()
@@ -58,7 +58,7 @@ def test_python_function():
     assert np.array_equal(o[0].at(0), np.array([[1,4],[9,16]]))
 
 def test_arithm_ops():
-    pipe = dali.pipeline.Pipeline(1,1,0)
+    pipe = dali.pipeline.Pipeline(1,1,None)
     with pipe:
         in1 = fn.external_source([[np.uint8([[1,2],[3,4]])]])
         pipe.set_outputs(in1 + np.array([[10,20],[30,40]]), in1 + np.array(5), in1 + np.uint8(100))
@@ -69,7 +69,7 @@ def test_arithm_ops():
     assert np.array_equal(o[2].at(0), np.array([[101,102],[103,104]]))
 
 def test_arg_input():
-    pipe = dali.pipeline.Pipeline(1,1,0)
+    pipe = dali.pipeline.Pipeline(1,1,None)
     with pipe:
         in1 = fn.external_source([[np.float32([[1,2,3],[4,5,6]])]])
         pipe.set_outputs(fn.transforms.translation(in1, offset=np.float32([10,20])))

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1707,3 +1707,12 @@ def test_pipeline_out_of_scope():
     out = get_output()[0].at(0)
     assert out[0] == -0.5 and out[1] == 1.25
 
+def test_return_constants():
+    pipe = dali.pipeline.Pipeline(1, 1, 0)
+    pipe.set_outputs(np.array([[1,2],[3,4]]), 10, np.uint8(15))
+    pipe.build()
+    a, b, c = pipe.run()
+    assert np.array_equal(a.at(0), np.array([[1,2],[3,4]]))
+    assert b.at(0) == 10
+    assert c.at(0) == 15
+    assert c.at(0).dtype == np.uint8

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1708,11 +1708,13 @@ def test_pipeline_out_of_scope():
     assert out[0] == -0.5 and out[1] == 1.25
 
 def test_return_constants():
-    pipe = dali.pipeline.Pipeline(1, 1, 0)
-    pipe.set_outputs(np.array([[1,2],[3,4]]), 10, np.uint8(15))
+    pipe = dali.pipeline.Pipeline(1, 1, None)
+    types = [bool, np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.float32]
+    pipe.set_outputs(np.array([[1,2],[3,4]]), 10, *[t(42) for t in types])
     pipe.build()
-    a, b, c = pipe.run()
+    a, b, *other = pipe.run()
     assert np.array_equal(a.at(0), np.array([[1,2],[3,4]]))
     assert b.at(0) == 10
-    assert c.at(0) == 15
-    assert c.at(0).dtype == np.uint8
+    for i, o in enumerate(other):
+        assert o.at(0) == types[i](42)
+        assert o.at(0).dtype == types[i]

--- a/docs/supported_op_devices.py
+++ b/docs/supported_op_devices.py
@@ -31,13 +31,17 @@ def main(out_filename):
     doc_table += formater.format('Operator name', 'CPU', 'GPU', 'Mixed', 'Sequences', 'Volumetric', op_name_max_len = op_name_max_len, c=' ')
     doc_table += formater.format('', '', '', '', '', '', op_name_max_len = op_name_max_len, c='=')
     for op in sorted(all_ops, key=name_sort):
-        schema = b.GetSchema(op)
         op_full_name, submodule, op_name = ops._process_op_name(op)
         is_cpu = '|v|' if op in cpu_ops else ''
         is_gpu = '|v|' if op in gpu_ops else ''
         is_mixed = '|v|' if op in mix_ops else ''
-        supports_seq = '|v|' if schema.AllowsSequences() or schema.IsSequenceOperator() else ''
-        volumetric = '|v|' if schema.SupportsVolumetric() else ''
+        try:
+            schema = b.GetSchema(op)
+            supports_seq = '|v|' if schema.AllowsSequences() or schema.IsSequenceOperator() else ''
+            volumetric = '|v|' if schema.SupportsVolumetric() else ''
+        except:
+            supports_seq = ''
+            volumetric = ''
         for (module_name, module) in ops_modules.items():
             m = module
             for part in submodule:

--- a/docs/supported_op_devices.py
+++ b/docs/supported_op_devices.py
@@ -35,11 +35,11 @@ def main(out_filename):
         is_cpu = '|v|' if op in cpu_ops else ''
         is_gpu = '|v|' if op in gpu_ops else ''
         is_mixed = '|v|' if op in mix_ops else ''
-        try:
-            schema = b.GetSchema(op)
+        schema = b.TryGetSchema(op)
+        if schema:
             supports_seq = '|v|' if schema.AllowsSequences() or schema.IsSequenceOperator() else ''
             volumetric = '|v|' if schema.SupportsVolumetric() else ''
-        except:
+        else:
             supports_seq = ''
             volumetric = ''
         for (module_name, module) in ops_modules.items():


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed because it makes passing non-scalar constants to argument inputs easier

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Try to call Constant on unrecognized arguments in operator's `__call__`
     * Add more elaborate distinction between call and init arguments in `fn` wrappers.
     * Handle numpy scalars in types.Constant
     * Promote non-data-nodes to constant nodes on pipeline output
     * Add a function to separate keyword arguments to call/init args, use it in `__init__`, `__call__` and `fn` wrappers.
     * Add Compose function :)
 - Affected modules and functionalities:
     * ops, types, fn, pipeline
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Unit test in python + existing tests treated as regression test
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
