### PR TITLE
Bump up Nvidia TF version to 20.10 and update RN50 PyTorch example

### DIFF
--- a/docs/examples/use_cases/pytorch/resnet50/main.py
+++ b/docs/examples/use_cases/pytorch/resnet50/main.py
@@ -575,7 +575,7 @@ def accuracy(output, target, topk=(1,)):
 
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+        correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
         res.append(correct_k.mul_(100.0 / batch_size))
     return res
 

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -366,7 +366,7 @@ all_packages = [PlainPackage("opencv-python", ["4.4.0.42"]),
                               PckgVer("1.15.4",  python_max_ver="3.7"),
                               "2.2.1",
                               "2.3.1",
-                              PckgVer("1.15.3+nv20.9", python_min_ver="3.6", python_max_ver="3.6", alias="nvidia-tensorflow")]
+                              PckgVer("1.15.4+nv20.10", python_min_ver="3.6", python_max_ver="3.6", alias="nvidia-tensorflow")]
                         }),
                 CudaHttpPackage("torch",
                         { "100" : ["http://download.pytorch.org/whl/cu{cuda_v}/torch-1.4.0+cu{cuda_v}-{platform}.whl"] }),


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It bumps up Nvidia TF version to 20.10 and updates RN50 PyTorch example

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     bumps up Nvidia TF version to 20.10
     updates RN50 PyTorch example to use reshape instead of view due to
    `RuntimeError: view size is not compatible with input tensor's size and stride`
 - Affected modules and functionalities:
     QA tests
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
