### PR TITLE
Fix CPU only mode for arithm operators

### DIFF
--- a/dali/operators/math/expressions/constant_storage.h
+++ b/dali/operators/math/expressions/constant_storage.h
@@ -66,6 +66,8 @@ class ConstantStorage {
         real_nodes.push_back(node);
       }
     }
+    integers_.set_pinned(false);
+    reals_.set_pinned(false);
     Rewrite(integers_, integers_vec, integer_nodes, stream);
     Rewrite(reals_, reals_vec, real_nodes, stream);
   }

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -668,4 +668,13 @@ def test_reduce_max_cpu():
 def test_reduce_sum_cpu():
     check_single_input(fn.reductions.sum)
 
+def test_arithm_ops_cpu():
+    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=None)
+    data = fn.external_source(source = get_data, layout = "HWC")
+    processed = [data * 2, data + 2,data - 2, data / 2, data // 2]
+    pipe.set_outputs(*processed)
+    pipe.build()
+    for _ in range(3):
+        pipe.run()
+test_arithm_ops_cpu()
 # ToDo add tests for DLTensorPythonFunction if easily possible

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -671,10 +671,10 @@ def test_reduce_sum_cpu():
 def test_arithm_ops_cpu():
     pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=None)
     data = fn.external_source(source = get_data, layout = "HWC")
-    processed = [data * 2, data + 2,data - 2, data / 2, data // 2]
+    processed = [data * 2, data + 2, data - 2, data / 2, data // 2]
     pipe.set_outputs(*processed)
     pipe.build()
     for _ in range(3):
         pipe.run()
-test_arithm_ops_cpu()
+
 # ToDo add tests for DLTensorPythonFunction if easily possible


### PR DESCRIPTION
- makes internal memory storage in arithmetic operators non-pinned for the CPU device

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a CPU only mode for arithm operators

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     makes internal memory storage in arithmetic operators non-pinned for the CPU device
 - Affected modules and functionalities:
     arithm ops
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI, new test is added
 - Documentation (including examples):
     NA

Relates to https://github.com/NVIDIA/DALI/issues/2396
**JIRA TASK**: *[NA]*
