### PR TITLE
Fix RN50 example compatibility with the most recent PyTorch version

### DIFF
--- a/docs/examples/use_cases/pytorch/resnet50/main.py
+++ b/docs/examples/use_cases/pytorch/resnet50/main.py
@@ -575,7 +575,7 @@ def accuracy(output, target, topk=(1,)):
 
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+        correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
         res.append(correct_k.mul_(100.0 / batch_size))
     return res
 


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes RN50 example compatibility with the most recent PyTorch version

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     changes `view` to `reshape` call inside the script to handle `RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.` error
 - Affected modules and functionalities:
     RN50 pytorch example
 - Key points relevant for the review:
     NA
 - Validation and testing:
     Manual testing
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
