### PR TITLE
Ops rework to prepare iter-to-iter batch size variability

### DIFF
--- a/dali/benchmark/color_twist_bench.cc
+++ b/dali/benchmark/color_twist_bench.cc
@@ -36,7 +36,7 @@ BENCHMARK_DEFINE_F(OperatorBench, ColorTwistGPU)(benchmark::State& st) {
   this->RunGPU<uint8_t>(
     st,
     OpSpec("ColorTwist")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", 1)
       .AddArg("device", "gpu")
       .AddArg("output_type", DALI_RGB)
@@ -56,7 +56,7 @@ BENCHMARK_DEFINE_F(OperatorBench, OldColorTwistGPU)(benchmark::State& st) {
   this->RunGPU<uint8_t>(
     st,
     OpSpec("OldColorTwist")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", 1)
       .AddArg("device", "gpu")
       .AddArg("output_type", DALI_RGB)

--- a/dali/benchmark/crop_bench.cc
+++ b/dali/benchmark/crop_bench.cc
@@ -39,7 +39,7 @@ BENCHMARK_DEFINE_F(OperatorBench, CropCPU)(benchmark::State& st) {
   this->RunCPU<uint8_t>(
     st,
     OpSpec("Crop")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", 1)
       .AddArg("device", "cpu")
       .AddArg("output_type", DALI_RGB)
@@ -76,7 +76,7 @@ BENCHMARK_DEFINE_F(OperatorBench, CropGPU)(benchmark::State& st) {
   this->RunGPU<uint8_t>(
     st,
     OpSpec("Crop")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", 1)
       .AddArg("device", "gpu")
       .AddArg("output_type", DALI_RGB)

--- a/dali/benchmark/crop_mirror_normalize_bench.cc
+++ b/dali/benchmark/crop_mirror_normalize_bench.cc
@@ -56,7 +56,7 @@ BENCHMARK_DEFINE_F(OperatorBench, CropMirrorNormalizeCPU)(benchmark::State& st) 
   this->RunCPU<uint8_t>(
     st,
     OpSpec("CropMirrorNormalize")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", 1)
       .AddArg("device", "cpu")
       .AddArg("output_type", DALI_RGB)
@@ -115,7 +115,7 @@ BENCHMARK_DEFINE_F(OperatorBench, CropMirrorNormalizeGPU)(benchmark::State& st) 
   this->RunGPU<uint8_t>(
     st,
     OpSpec("CropMirrorNormalize")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", 1)
       .AddArg("device", "gpu")
       .AddArg("output_type", DALI_RGB)

--- a/dali/benchmark/displacement_cpu_bench.cc
+++ b/dali/benchmark/displacement_cpu_bench.cc
@@ -66,7 +66,7 @@ void DisplacementBench(benchmark::State& st) {//NOLINT
   // but they are not used in this benchmark
   const int dummy_batch_size = 128;
   const int dummy_num_thread = 1;
-  op.AddArg("batch_size", dummy_batch_size).AddArg("num_threads", dummy_num_thread);
+  op.AddArg("max_batch_size", dummy_batch_size).AddArg("num_threads", dummy_num_thread);
 
   // Create Operator and pass its arguments via OpSpec
   // We get partially-specified OpSpec, added remaining arguments,

--- a/dali/benchmark/normal_distribution_gpu_bench.cc
+++ b/dali/benchmark/normal_distribution_gpu_bench.cc
@@ -23,7 +23,7 @@ BENCHMARK_DEFINE_F(OperatorBench, NormalDistributionGPU)(benchmark::State& st) {
   const bool single_value = st.range(2);
 
   auto spec = OpSpec("NormalDistribution")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", 1)
       .AddArg("device", "gpu")
       .AddArg("dtype", DALI_FLOAT)
@@ -51,7 +51,7 @@ BENCHMARK_DEFINE_F(OperatorBench, NormalDistributionGPU_NonUniform)(benchmark::S
   }
 
   auto spec = OpSpec("NormalDistribution")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", 1)
       .AddArg("device", "gpu")
       .AddArg("dtype", DALI_FLOAT)

--- a/dali/benchmark/preemphasis_bench.cc
+++ b/dali/benchmark/preemphasis_bench.cc
@@ -25,7 +25,7 @@ BENCHMARK_DEFINE_F(OperatorBench, PreemphasisGPU)(benchmark::State& st) {
   this->RunGPU<uint8_t>(
     st,
     OpSpec("PreemphasisFilter")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", 1)
       .AddArg("device", "gpu"),
     batch_size, TensorShape<1>{N, }, "t");

--- a/dali/benchmark/warp_affine_bench.cc
+++ b/dali/benchmark/warp_affine_bench.cc
@@ -41,7 +41,7 @@ BENCHMARK_DEFINE_F(OperatorBench, WarpAffineCPU)(benchmark::State& st) {
   this->RunCPU<uint8_t>(
     st,
     OpSpec("WarpAffine")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", 4)
       .AddArg("device", "cpu")
       .AddArg("matrix", mtx)
@@ -78,7 +78,7 @@ BENCHMARK_DEFINE_F(OperatorBench, WarpAffineGPU)(benchmark::State& st) {
   this->RunGPU<uint8_t>(
     st,
     OpSpec("WarpAffine")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", 1)
       .AddArg("device", "gpu")
       .AddArg("matrix", mtx)

--- a/dali/operators/audio/nonsilence_op.cc
+++ b/dali/operators/audio/nonsilence_op.cc
@@ -67,10 +67,11 @@ bool NonsilenceOperatorCpu::SetupImpl(std::vector<OutputDesc> &output_desc,
   TypeInfo output_type;
   output_type.SetType<int>(TypeTable::GetTypeID<int>());
   TensorShape<> scalar_shape = {};
+  auto curr_batch_size = ws.GetInputBatchSize(0);
 
   output_desc.resize(detail::kNumOutputs);
   for (int i = 0; i < detail::kNumOutputs; i++) {
-    output_desc[i].shape = uniform_list_shape(batch_size_, scalar_shape);
+    output_desc[i].shape = uniform_list_shape(curr_batch_size, scalar_shape);
     output_desc[i].type = output_type;
   }
   return true;

--- a/dali/operators/audio/preemphasis_filter_op.h
+++ b/dali/operators/audio/preemphasis_filter_op.h
@@ -57,8 +57,9 @@ class PreemphasisFilter : public Operator<Backend> {
   }
 
  protected:
-  void AcquireArguments(const ArgumentWorkspace &ws) {
-    this->GetPerSampleArgument(preemph_coeff_, detail::kCoeff, ws);
+  void AcquireArguments(const workspace_t<Backend> &ws) {
+    auto curr_batch_size = ws.GetInputBatchSize(0);
+    this->GetPerSampleArgument(preemph_coeff_, detail::kCoeff, ws, curr_batch_size);
   }
 
   USE_OPERATOR_MEMBERS();

--- a/dali/operators/bbox/bb_flip.cc
+++ b/dali/operators/bbox/bb_flip.cc
@@ -52,19 +52,20 @@ BbFlip<CPUBackend>::BbFlip(const dali::OpSpec &spec)
 
 void BbFlip<CPUBackend>::RunImpl(dali::SampleWorkspace &ws) {
   const auto &input = ws.Input<CPUBackend>(0);
+
+  DALI_ENFORCE(
+      input.type().id() == DALI_FLOAT,
+      make_string("Bounding box in wrong format. Expected `float`; actual: ", input.type().name()));
+
   const auto input_data = input.data<float>();
 
-  DALI_ENFORCE(input.type().id() == DALI_FLOAT, "Bounding box in wrong format");
+  const auto vertical = vflip_is_tensor_
+                            ? spec_.GetArgument<int>(kVerticalArgName, &ws, ws.data_idx())
+                            : spec_.GetArgument<int>(kVerticalArgName);
 
-  const auto vertical =
-      vflip_is_tensor_
-          ? spec_.GetArgument<int>(kVerticalArgName, &ws, ws.data_idx())
-          : spec_.GetArgument<int>(kVerticalArgName);
-
-  const auto horizontal =
-      hflip_is_tensor_
-          ? spec_.GetArgument<int>(kHorizontalArgName, &ws, ws.data_idx())
-          : spec_.GetArgument<int>(kHorizontalArgName);
+  const auto horizontal = hflip_is_tensor_
+                              ? spec_.GetArgument<int>(kHorizontalArgName, &ws, ws.data_idx())
+                              : spec_.GetArgument<int>(kHorizontalArgName);
 
   auto &output = ws.Output<CPUBackend>(0);
   // XXX: Setting type of output (i.e. Buffer -> buffer.h)

--- a/dali/operators/bbox/bb_flip.h
+++ b/dali/operators/bbox/bb_flip.h
@@ -44,21 +44,6 @@ class BbFlip<CPUBackend> : public Operator<CPUBackend> {
 
  private:
   /**
-   * Checks, if argument provided by user is a scalar and,
-   * in such case, extends this scalar to entire tensor
-   * @tparam TensorDataType Underlying data type in tensor
-   */
-  template <typename TensorDataType>
-  void ExtendScalarToTensor(std::string argument_name, const OpSpec &spec,
-                            Tensor<CPUBackend> *tensor) {
-    tensor->Resize({batch_size_});
-    for (int i = 0; i < batch_size_; i++) {
-      tensor->mutable_data<TensorDataType>()[i] =
-          spec.GetArgument<TensorDataType>(argument_name);
-    }
-  }
-
-  /**
    * Bounding box can be represented in two ways:
    * 1. Upper-left corner, width, height (`wh_type`)
    *    (x1, y1,  w,  h)

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -50,9 +50,9 @@ DALI_REGISTER_OPERATOR(AudioDecoder, AudioDecoderCpu, CPU);
 
 bool
 AudioDecoderCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) {
-  GetPerSampleArgument<float>(target_sample_rates_, "sample_rate", ws);
   auto &input = ws.template InputRef<Backend>(0);
   const auto batch_size = input.shape().num_samples();
+  GetPerSampleArgument<float>(target_sample_rates_, "sample_rate", ws, batch_size);
 
   for (int i = 0; i < batch_size; i++) {
     DALI_ENFORCE(input.shape()[i].size() == 1, "Raw input must be 1D encoded byte data");

--- a/dali/operators/decoder/cache/cached_decoder_impl.cc
+++ b/dali/operators/decoder/cache/cached_decoder_impl.cc
@@ -39,7 +39,7 @@ CachedDecoderImpl::CachedDecoderImpl(const OpSpec& spec)
         device_id_, cache_type, cache_size, cache_debug, cache_threshold);
 
       use_batch_copy_kernel_ = spec.GetArgument<bool>("cache_batch_copy");
-      auto batch_size = spec.GetArgument<int>("batch_size");
+      auto batch_size = spec.GetArgument<int>("max_batch_size");
       const size_t kMaxSizePerBlock = 1<<18;  // 256 kB per block
       scatter_gather_.reset(new kernels::ScatterGatherGPU(
         kMaxSizePerBlock, cache_size, batch_size));

--- a/dali/operators/decoder/host/fused/host_decoder_random_crop_test.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_random_crop_test.cc
@@ -25,7 +25,7 @@ class ImageDecoderRandomCropTest_CPU : public DecodeTestBase<ImgType> {
   ImageDecoderRandomCropTest_CPU()
     : random_crop_attr(
       OpSpec("RandomCropAttr")
-        .AddArg("batch_size", this->batch_size_)
+        .AddArg("max_batch_size", this->batch_size_)
         .AddArg("seed", kSeed)) {}
 
  protected:

--- a/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_random_crop_test.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_random_crop_test.cc
@@ -25,7 +25,7 @@ class ImageDecoderRandomCropTest_GPU : public DecodeTestBase<ImgType> {
   ImageDecoderRandomCropTest_GPU()
     : random_crop_attr(
       OpSpec("RandomCropAttr")
-        .AddArg("batch_size", this->batch_size_)
+        .AddArg("max_batch_size", this->batch_size_)
         .AddArg("seed", kSeed)) {}
 
  protected:

--- a/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_random_crop_test.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/fused/nvjpeg_decoder_split_random_crop_test.cc
@@ -25,7 +25,7 @@ class ImageDecoderSplitRandomCropTest_GPU : public DecodeTestBase<ImgType> {
   ImageDecoderSplitRandomCropTest_GPU()
     : random_crop_attr(
       OpSpec("RandomCropAttr")
-        .AddArg("batch_size", this->batch_size_)
+        .AddArg("max_batch_size", this->batch_size_)
         .AddArg("seed", kSeed)) {}
 
  protected:

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_gpu.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_gpu.h
@@ -68,11 +68,11 @@ class nvJPEGDecoderGPUStage : public Operator<MixedBackend> {
 
   using dali::OperatorBase::Run;
   void Run(MixedWorkspace &ws) override {
-    std::vector<std::vector<Index>> output_shape(batch_size_);
+    std::vector<std::vector<Index>> output_shape(max_batch_size_);
     // Creating output shape and setting the order of images so the largest are processed first
     // (for load balancing)
-    std::vector<std::pair<size_t, size_t>> image_order(batch_size_);
-    for (int i = 0; i < batch_size_; i++) {
+    std::vector<std::pair<size_t, size_t>> image_order(max_batch_size_);
+    for (int i = 0; i < max_batch_size_; i++) {
       const auto& info_tensor = ws.Input<CPUBackend>(0, i);
       const ImageInfo* info = info_tensor.data<ImageInfo>();
       int c = NumberOfChannels(output_image_type_);

--- a/dali/operators/generic/constant.h
+++ b/dali/operators/generic/constant.h
@@ -81,10 +81,12 @@ class Constant : public Operator<Backend> {
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
     output_desc.resize(1);
     auto curr_batch_size = ws.GetRequestedBatchSize(0);
-    if (output_shape_.empty() || output_shape_ .num_elements() < curr_batch_size) {
+    DALI_ENFORCE(curr_batch_size == max_batch_size_,
+                 "This operator does not doesn't support batch smaller than maximum");
+    if (output_shape_.empty() || output_shape_.num_elements() != curr_batch_size) {
       output_shape_ = uniform_list_shape(curr_batch_size, shape_arg_);
     }
-    output_desc[0] = { output_shape_, TypeTable::GetTypeInfo(output_type_) };
+    output_desc[0] = {output_shape_, TypeTable::GetTypeInfo(output_type_)};
     return false;
   }
 

--- a/dali/operators/generic/constant.h
+++ b/dali/operators/generic/constant.h
@@ -80,9 +80,9 @@ class Constant : public Operator<Backend> {
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
     output_desc.resize(1);
-    if (output_shape_.empty()) {
-      int batch_size = this->spec_.template GetArgument<int>("batch_size");
-      output_shape_ = uniform_list_shape(batch_size, shape_arg_);
+    auto curr_batch_size = ws.GetRequestedBatchSize(0);
+    if (output_shape_.empty() || output_shape_ .num_elements() < curr_batch_size) {
+      output_shape_ = uniform_list_shape(curr_batch_size, shape_arg_);
     }
     output_desc[0] = { output_shape_, TypeTable::GetTypeInfo(output_type_) };
     return false;
@@ -91,6 +91,7 @@ class Constant : public Operator<Backend> {
   void RunImpl(Workspace &ws) override;
 
  private:
+  USE_OPERATOR_MEMBERS();
   std::vector<int> shape_arg_;
   std::vector<int> idata_;
   std::vector<float> fdata_;

--- a/dali/operators/generic/erase/erase.cc
+++ b/dali/operators/generic/erase/erase.cc
@@ -163,15 +163,13 @@ class EraseImplCpu : public OpImplBase<CPUBackend> {
  public:
   using EraseKernel = kernels::EraseCpu<T, Dims>;
 
-  explicit EraseImplCpu(const OpSpec& spec)
-      : spec_(spec), batch_size_(spec.GetArgument<int>("batch_size")) {}
+  explicit EraseImplCpu(const OpSpec &spec) : spec_(spec) {}
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<CPUBackend> &ws) override;
   void RunImpl(workspace_t<CPUBackend> &ws) override;
 
  private:
   OpSpec spec_;
-  int batch_size_ = 0;
   std::vector<int> axes_;
   std::vector<kernels::EraseArgs<T, Dims>> args_;
   kernels::KernelManager kmgr_;

--- a/dali/operators/generic/flip.cu
+++ b/dali/operators/generic/flip.cu
@@ -47,9 +47,10 @@ void Flip<GPUBackend>::RunImpl(Workspace<GPUBackend> &ws) {
   output.SetLayout(input.GetLayout());
   output.set_type(input.type());
   output.ResizeLike(input);
-  auto horizontal = GetHorizontal(ws);
-  auto vertical = GetVertical(ws);
-  auto depthwise = GetDepthwise(ws);
+  auto curr_batch_size = ws.GetInputBatchSize(0);
+  auto horizontal = GetHorizontal(ws, curr_batch_size);
+  auto vertical = GetVertical(ws, curr_batch_size);
+  auto depthwise = GetDepthwise(ws, curr_batch_size);
   RunKernel(output, input, depthwise, horizontal, vertical, ws.stream());
 }
 

--- a/dali/operators/generic/flip.h
+++ b/dali/operators/generic/flip.h
@@ -58,23 +58,26 @@ class Flip: public Operator<Backend> {
     return this->spec_.template GetArgument<int>("depthwise", &ws, idx);
   }
 
-  std::vector<int> GetHorizontal(const ArgumentWorkspace &ws) {
+  std::vector<int> GetHorizontal(const workspace_t<Backend> &ws, int curr_batch_size) {
     std::vector<int> result;
-    OperatorBase::GetPerSampleArgument(result, "horizontal", ws);
+    OperatorBase::GetPerSampleArgument(result, "horizontal", ws, curr_batch_size);
     return result;
   }
 
-  std::vector<int> GetVertical(const ArgumentWorkspace &ws) {
+  std::vector<int> GetVertical(const workspace_t<Backend> &ws, int curr_batch_size) {
     std::vector<int> result;
-    OperatorBase::GetPerSampleArgument(result, "vertical", ws);
+    OperatorBase::GetPerSampleArgument(result, "vertical", ws, curr_batch_size);
     return result;
   }
 
-  std::vector<int> GetDepthwise(const ArgumentWorkspace &ws) {
+  std::vector<int> GetDepthwise(const workspace_t<Backend> &ws, int curr_batch_size) {
     std::vector<int> result;
-    OperatorBase::GetPerSampleArgument(result, "depthwise", ws);
+    OperatorBase::GetPerSampleArgument(result, "depthwise", ws, curr_batch_size);
     return result;
   }
+
+ private:
+  USE_OPERATOR_MEMBERS();
 };
 
 }  // namespace dali

--- a/dali/operators/generic/pad.h
+++ b/dali/operators/generic/pad.h
@@ -62,6 +62,7 @@ class Pad : public Operator<Backend> {
  private:
   void ReadArguments(const OpSpec &spec, const workspace_t<Backend> &ws) {
     const auto &input = ws.template InputRef<Backend>(0);
+    auto curr_batch_size = ws.GetInputBatchSize(0);
     auto in_shape = input.shape();
     auto in_layout = input.GetLayout();
     int ndim = in_shape.sample_dim();
@@ -82,10 +83,12 @@ class Pad : public Operator<Backend> {
       std::iota(axes_.begin(), axes_.end(), 0);
     }
 
-    if (spec.ArgumentDefined("shape"))
-      GetShapeArgument(shape_, spec, "shape", ws);
-    if (spec.ArgumentDefined("align"))
-      GetShapeArgument(align_, spec, "align", ws);
+    if (spec.ArgumentDefined("shape")) {
+      GetShapeArgument(shape_, spec, "shape", ws, -1, curr_batch_size);
+    }
+    if (spec.ArgumentDefined("align")) {
+      GetShapeArgument(align_, spec, "align", ws, -1, curr_batch_size);
+    }
 
     if (shape_.empty())
       shape_ = uniform_list_shape(nsamples, TensorShape<>(std::vector<int64_t>(axes_.size(), -1)));

--- a/dali/operators/generic/permute_batch.h
+++ b/dali/operators/generic/permute_batch.h
@@ -29,13 +29,14 @@ class PermuteBatchBase : public Operator<Backend> {
   }
 
   bool SetupImpl(vector<OutputDesc> &outputs, const workspace_t<Backend> &ws) override {
+    auto curr_batch_size = ws.GetInputBatchSize(0);
     outputs.resize(1);
     auto &input = ws.template InputRef<Backend>(0);
     const auto &in_shape = input.shape();
     outputs[0].type = input.type();
 
     if (has_indices_input_) {
-      GetPerSampleArgument<int>(indices_, "indices", this->spec_, ws);
+      GetPerSampleArgument<int>(indices_, "indices", this->spec_, ws, curr_batch_size);
     } else {
       this->spec_.TryGetRepeatedArgument(indices_, "indices");
     }
@@ -81,7 +82,7 @@ class PermuteBatch<GPUBackend> : public PermuteBatchBase<GPUBackend> {
  public:
   explicit PermuteBatch(const OpSpec &spec)
   : PermuteBatchBase<GPUBackend>(spec)
-  , sg_(1<<18, spec.GetArgument<int>("batch_size")) {}
+  , sg_(1<<18, spec.GetArgument<int>("max_batch_size")) {}
 
 
   void RunImpl(DeviceWorkspace &ws) override;

--- a/dali/operators/geometry/affine_transforms/transform_base_op.h
+++ b/dali/operators/geometry/affine_transforms/transform_base_op.h
@@ -121,6 +121,7 @@ class TransformBaseOp : public Operator<Backend> {
 
   bool SetupImpl(std::vector<OutputDesc> &output_descs, const workspace_t<Backend> &ws) override {
     has_input_ = ws.NumInput() > 0;
+    auto curr_batch_size = has_input_ ? ws.GetInputBatchSize(0) : ws.GetRequestedBatchSize(0);
     if (has_input_) {
       auto &input = ws.template InputRef<Backend>(0);
       const auto &shape = input.shape();
@@ -136,7 +137,7 @@ class TransformBaseOp : public Operator<Backend> {
           "(ndim, ndim+1) representing an affine transform. Got: ", shape));
       nsamples_ = shape.num_samples();
     } else {
-      nsamples_ = spec_.template GetArgument<int>("batch_size");
+      nsamples_ = curr_batch_size;
     }
 
     This().ProcessArgs(spec_, ws);
@@ -280,6 +281,7 @@ class TransformBaseOp : public Operator<Backend> {
   }
 
  protected:
+  USE_OPERATOR_MEMBERS();
   DALIDataType dtype_ = DALI_FLOAT;
   int ndim_ = -1;  // will be inferred from the arguments or the input
   int nsamples_ = -1;
@@ -287,8 +289,6 @@ class TransformBaseOp : public Operator<Backend> {
   bool reverse_order_ = false;
 
   Tensor<CPUBackend> matrix_data_;
-
-  using Operator<Backend>::spec_;
 };
 
 

--- a/dali/operators/geometry/coord_flip.cc
+++ b/dali/operators/geometry/coord_flip.cc
@@ -64,8 +64,9 @@ void CoordFlipCPU::RunImpl(workspace_t<CPUBackend> &ws) {
   const auto &input = ws.InputRef<CPUBackend>(0);
   auto &output = ws.OutputRef<CPUBackend>(0);
   auto &thread_pool = ws.GetThreadPool();
+  auto curr_batch_size = ws.GetInputBatchSize(0);
 
-  for (int sample_id = 0; sample_id < batch_size_; sample_id++) {
+  for (int sample_id = 0; sample_id < curr_batch_size; sample_id++) {
     std::array<bool, 3> flip_dim = {false, false, false};
     flip_dim[x_dim_] = spec_.GetArgument<int>("flip_x", &ws, sample_id);
     flip_dim[y_dim_] = spec_.GetArgument<int>("flip_y", &ws, sample_id);

--- a/dali/operators/image/color/brightness_contrast.cc
+++ b/dali/operators/image/color/brightness_contrast.cc
@@ -64,6 +64,7 @@ DALI_REGISTER_OPERATOR(BrightnessContrast, BrightnessContrastCpu, CPU)
 
 bool BrightnessContrastCpu::SetupImpl(std::vector<OutputDesc> &output_desc,
                                       const workspace_t<CPUBackend> &ws) {
+  KMgrResize(num_threads_, max_batch_size_);
   const auto &input = ws.template InputRef<CPUBackend>(0);
   const auto &output = ws.template OutputRef<CPUBackend>(0);
   output_desc.resize(1);

--- a/dali/operators/image/color/brightness_contrast.cu
+++ b/dali/operators/image/color/brightness_contrast.cu
@@ -29,6 +29,7 @@ DALI_REGISTER_OPERATOR(BrightnessContrast, BrightnessContrastGpu, GPU)
 
 bool BrightnessContrastGpu::SetupImpl(std::vector<OutputDesc> &output_desc,
                                       const workspace_t<GPUBackend> &ws) {
+  KMgrResize(num_threads_, max_batch_size_);
   const auto &input = ws.template InputRef<GPUBackend>(0);
   const auto &output = ws.template OutputRef<GPUBackend>(0);
   output_desc.resize(1);

--- a/dali/operators/image/color/color_twist.cc
+++ b/dali/operators/image/color/color_twist.cc
@@ -176,6 +176,7 @@ DALI_REGISTER_OPERATOR(Saturation, ColorTwistCpu, CPU);
 DALI_REGISTER_OPERATOR(ColorTwist, ColorTwistCpu, CPU);
 
 bool ColorTwistCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) {
+  KMgrResize(num_threads_, max_batch_size_);
   const auto &input = ws.template InputRef<CPUBackend>(0);
   output_desc.resize(1);
   DetermineTransformation(ws);

--- a/dali/operators/image/color/color_twist.cu
+++ b/dali/operators/image/color/color_twist.cu
@@ -32,6 +32,7 @@ DALI_REGISTER_OPERATOR(Saturation, ColorTwistGpu, GPU);
 DALI_REGISTER_OPERATOR(ColorTwist, ColorTwistGpu, GPU);
 
 bool ColorTwistGpu::SetupImpl(std::vector<OutputDesc> &output_desc, const DeviceWorkspace &ws) {
+  KMgrResize(num_threads_, max_batch_size_);
   const auto &input = ws.template InputRef<GPUBackend>(0);
   output_desc.resize(1);
   DetermineTransformation(ws);

--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -122,7 +122,7 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
   static constexpr int ndim = Kernel::ndim;
 
   explicit GaussianBlurOpCpu(const OpSpec& spec, const DimDesc& dim_desc)
-      : spec_(spec), batch_size_(spec.GetArgument<int>("batch_size")), dim_desc_(dim_desc) {}
+      : spec_(spec), dim_desc_(dim_desc) {}
 
   bool SetupImpl(std::vector<OutputDesc>& output_desc, const workspace_t<CPUBackend>& ws) override {
     const auto& input = ws.template InputRef<CPUBackend>(0);
@@ -189,7 +189,6 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
 
  private:
   OpSpec spec_;
-  int batch_size_ = 0;
   DimDesc dim_desc_;
 
   kernels::KernelManager kmgr_;

--- a/dali/operators/image/convolution/gaussian_blur_gpu.h
+++ b/dali/operators/image/convolution/gaussian_blur_gpu.h
@@ -45,7 +45,7 @@ class GaussianBlurOpGpu : public OpImplBase<GPUBackend> {
   static constexpr int ndim = Kernel::ndim;
 
   explicit GaussianBlurOpGpu(const OpSpec& spec, const DimDesc& dim_desc)
-      : spec_(spec), batch_size_(spec.GetArgument<int>("batch_size")), dim_desc_(dim_desc) {}
+      : spec_(spec), dim_desc_(dim_desc) {}
 
   bool SetupImpl(std::vector<OutputDesc>& output_desc, const workspace_t<GPUBackend>& ws) override {
     ctx_.gpu.stream = ws.stream();
@@ -108,7 +108,6 @@ class GaussianBlurOpGpu : public OpImplBase<GPUBackend> {
 
  private:
   OpSpec spec_;
-  int batch_size_ = 0;
   DimDesc dim_desc_;
 
   kernels::KernelManager kmgr_;

--- a/dali/operators/image/crop/bbox_crop.cc
+++ b/dali/operators/image/crop/bbox_crop.cc
@@ -43,7 +43,7 @@ void CollectShape(std::vector<TensorShape<>> &v,
                   const OpSpec& spec,
                   const workspace_t<CPUBackend>& ws,
                   int ndim) {
-  int batch_size = spec.GetArgument<int>("batch_size");
+  int batch_size = spec.GetArgument<int>("max_batch_size");
   v.clear();
   v.reserve(batch_size);
 
@@ -362,7 +362,7 @@ class RandomBBoxCropImpl : public OpImplBase<CPUBackend> {
         shape_layout_(spec.GetArgument<TensorLayout>("shape_layout")),
         all_boxes_above_threshold_(spec.GetArgument<bool>("all_boxes_above_threshold")),
         output_bbox_indices_(spec.GetArgument<bool>("output_bbox_indices")),
-        rngs_(spec.GetArgument<int64_t>("seed"), spec.GetArgument<int>("batch_size")) {
+        rngs_(spec.GetArgument<int64_t>("seed"), spec.GetArgument<int>("max_batch_size")) {
     auto scaling_arg = spec.GetRepeatedArgument<float>("scaling");
     DALI_ENFORCE(scaling_arg.size() == 2,
                  make_string("`scaling` must be a range `[min, max]`. Got ",

--- a/dali/operators/image/crop/crop_mirror_normalize.cu
+++ b/dali/operators/image/crop/crop_mirror_normalize.cu
@@ -24,6 +24,7 @@ namespace dali {
 template <>
 bool CropMirrorNormalize<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
                                                 const DeviceWorkspace &ws) {
+  auto curr_batch_size = ws.GetInputBatchSize(0);
   output_desc.resize(1);
   SetupCommonImpl(ws);
   const auto &input = ws.InputRef<GPUBackend>(0);
@@ -35,7 +36,7 @@ bool CropMirrorNormalize<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
         using Args = kernels::SliceFlipNormalizePermutePadArgs<Dims>;
         auto &kernel_sample_args = any_cast<std::vector<Args>&>(kernel_sample_args_);
         output_desc[0].type = TypeInfo::Create<OutputType>();
-        output_desc[0].shape.resize(batch_size_, Dims);
+        output_desc[0].shape.resize(curr_batch_size, Dims);
         kmgr_.Resize<Kernel>(1, 1);
 
         kernels::KernelContext ctx;

--- a/dali/operators/image/crop/random_crop_attr.h
+++ b/dali/operators/image/crop/random_crop_attr.h
@@ -48,14 +48,14 @@ class RandomCropAttr {
 
     int64_t seed = spec.GetArgument<int64_t>("seed");
     std::seed_seq seq{seed};
-    int batch_size = spec.GetArgument<int>("batch_size");
-    DALI_ENFORCE(batch_size > 0, "batch_size should be greater than 0");
-    std::vector<int> seeds(batch_size);
+    int max_batch_size = spec.GetArgument<int>("max_batch_size");
+    DALI_ENFORCE(max_batch_size > 0, "max_batch_size should be greater than 0");
+    std::vector<int> seeds(max_batch_size);
     seq.generate(seeds.begin(), seeds.end());
 
-    crop_window_generators_.resize(batch_size);
+    crop_window_generators_.resize(max_batch_size);
 
-    for (int i = 0; i < batch_size; i++) {
+    for (int i = 0; i < max_batch_size; i++) {
       std::shared_ptr<RandomCropGenerator> random_crop_generator(
         new RandomCropGenerator(
           {aspect_ratio[0], aspect_ratio[1]}, {area[0], area[1]}, seeds[i], num_attempts));

--- a/dali/operators/image/remap/displacement_filter_impl_gpu.cuh
+++ b/dali/operators/image/remap/displacement_filter_impl_gpu.cuh
@@ -253,10 +253,11 @@ class DisplacementFilter<GPUBackend, Displacement,
 
   template <typename U = Displacement>
   std::enable_if_t<HasParam<U>::value> PrepareDisplacement(DeviceWorkspace *ws) {
-    params_.Resize({batch_size_});
+    auto curr_batch_size = ws->GetInputBatchSize(0);
+    params_.Resize({curr_batch_size});
     params_.mutable_data<typename U::Param>();
 
-    for (int i = 0; i < batch_size_; ++i) {
+    for (int i = 0; i < curr_batch_size; ++i) {
       typename U::Param &p = params_.mutable_data<typename U::Param>()[i];
       displace_.Prepare(&p, spec_, ws, i);
     }

--- a/dali/operators/image/resize/resize_attr_test.cc
+++ b/dali/operators/image/resize/resize_attr_test.cc
@@ -103,7 +103,7 @@ TEST(ResizeAttr, ResizeSeparate) {
       TensorShape<3>{ 768, 1024, 3 },
       TensorShape<3>{ 320, 240, 1 }
     }};
-    spec.AddArg("batch_size", shape.num_samples());
+    spec.AddArg("max_batch_size", shape.num_samples());
 
     ResizeAttr attr;
     attr.PrepareResizeParams(spec, ws, shape, "HWC");
@@ -118,7 +118,7 @@ TEST(ResizeAttr, ResizeSeparate) {
       TensorShape<3>{ 768, 1024, 3 },
       TensorShape<3>{ 320, 240, 1 }
     }};
-    spec.AddArg("batch_size", shape.num_samples());
+    spec.AddArg("max_batch_size", shape.num_samples());
 
     ResizeAttr attr;
     attr.PrepareResizeParams(spec, ws, shape, "HWC");
@@ -133,7 +133,7 @@ TEST(ResizeAttr, ResizeSeparate) {
       TensorShape<4>{ 3, 512, 768, 1024 },
       TensorShape<4>{ 1, 400, 320, 240 }
     }};
-    spec.AddArg("batch_size", shape.num_samples());
+    spec.AddArg("max_batch_size", shape.num_samples());
 
     ResizeAttr attr;
     attr.PrepareResizeParams(spec, ws, shape, "CDHW");
@@ -160,7 +160,7 @@ TEST(ResizeAttr, Resize3DSeparateArgs) {
     OpSpec spec("Resize");
     spec.AddArg("resize_x", 120.0f);
     spec.AddArg("resize_y", 130.0f);
-    spec.AddArg("batch_size", shape.num_samples());
+    spec.AddArg("max_batch_size", shape.num_samples());
     spec.AddArgumentInput("resize_z", "resize_z");
 
     ResizeAttr attr;
@@ -188,7 +188,7 @@ TEST(ResizeAttr, Resize3DSubpixelScale) {
   // Configure ResizeAttr with missing Y coordinate
   OpSpec spec("Resize");
   spec.AddArg("resize_x", 120.0f);
-  spec.AddArg("batch_size", shape.num_samples());
+  spec.AddArg("max_batch_size", shape.num_samples());
   spec.AddArgumentInput("resize_z", "resize_z");
 
   ResizeAttr attr;
@@ -246,7 +246,7 @@ TEST(ResizeAttr, Resize3DStretch) {
   // the mode is now "stretch", so the missing dimension (H) should be left unscaled.
   OpSpec spec("Resize");
   spec.AddArg("resize_x", 120.0f);
-  spec.AddArg("batch_size", shape.num_samples());
+  spec.AddArg("max_batch_size", shape.num_samples());
   spec.AddArg("mode", "stretch");
   spec.AddArgumentInput("resize_z", "resize_z");
 
@@ -278,7 +278,7 @@ TEST(ResizeAttr, Resize3DSizeArg) {
   }};
   OpSpec spec("Resize");
   spec.AddArgumentInput("size", "size");
-  spec.AddArg("batch_size", shape.num_samples());
+  spec.AddArg("max_batch_size", shape.num_samples());
   spec.AddArg("subpixel_scale", false);
 
   {
@@ -343,7 +343,7 @@ TEST(ResizeAttr, Resize3DNotLarger) {
       TensorShape<3>{ 1536, 768, 1024 },
       TensorShape<3>{ 32, 320, 240 }
     }};
-    spec.AddArg("batch_size", shape.num_samples());
+    spec.AddArg("max_batch_size", shape.num_samples());
 
     {
       ResizeAttr attr;
@@ -376,7 +376,7 @@ TEST(ResizeAttr, Resize3DNotSmaller) {
       TensorShape<3>{ 1536, 768, 1024 },
       TensorShape<3>{ 32, 320, 240 }
     }};
-    spec.AddArg("batch_size", shape.num_samples());
+    spec.AddArg("max_batch_size", shape.num_samples());
 
     {
       ResizeAttr attr;
@@ -431,7 +431,7 @@ TEST(ResizeAttr, ResizeShorter) {
       TensorShape<4>{ 20, 400, 800, 3 },
       TensorShape<4>{ 30, 500, 250, 3 }
     }};
-    spec.AddArg("batch_size", shape.num_samples());
+    spec.AddArg("max_batch_size", shape.num_samples());
 
     {
       ResizeAttr attr;
@@ -462,7 +462,7 @@ TEST(ResizeAttr, ResizeLonger) {
       TensorShape<4>{ 20, 3, 400, 800 },
       TensorShape<4>{ 30, 3, 500, 250 }
     }};
-    spec.AddArg("batch_size", shape.num_samples());
+    spec.AddArg("max_batch_size", shape.num_samples());
 
     {
       ResizeAttr attr;
@@ -497,7 +497,7 @@ TEST(ResizeAttr, RoI) {
       TensorShape<3>{ 3, 400, 800 },
       TensorShape<3>{ 3, 100, 250 }
     }};
-    spec.AddArg("batch_size", shape.num_samples());
+    spec.AddArg("max_batch_size", shape.num_samples());
 
     ResizeAttr attr;
     attr.PrepareResizeParams(spec, ws, shape, "CHW");
@@ -532,7 +532,7 @@ TEST(ResizeAttr, RoI) {
       TensorShape<3>{ 3, 400, 800 },
       TensorShape<3>{ 3, 100, 250 }
     }};
-    spec.AddArg("batch_size", shape.num_samples());
+    spec.AddArg("max_batch_size", shape.num_samples());
 
     ResizeAttr attr;
     attr.PrepareResizeParams(spec, ws, shape, "CHW");

--- a/dali/operators/math/expressions/arithmetic.h
+++ b/dali/operators/math/expressions/arithmetic.h
@@ -313,6 +313,10 @@ class ArithmeticGenericOp : public Operator<Backend> {
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
     output_desc.resize(1);
+    for (int i = 1; i < ws.NumInput(); i++) {
+      assert(ws.GetRequestedBatchSize(i) == ws.GetRequestedBatchSize(0));
+    }
+    auto curr_batch_size = ws.GetRequestedBatchSize(0);
 
     if (!types_layout_inferred_) {
       result_type_id_ = PropagateTypes<Backend>(*expr_, ws);
@@ -324,7 +328,7 @@ class ArithmeticGenericOp : public Operator<Backend> {
       types_layout_inferred_ = true;
     }
 
-    result_shape_ = PropagateShapes<Backend>(*expr_, ws, batch_size_);
+    result_shape_ = PropagateShapes<Backend>(*expr_, ws, curr_batch_size);
     AllocateIntermediateNodes();
     exec_order_ = CreateExecutionTasks<Backend>(*expr_, cache_, ws.has_stream() ? ws.stream() : 0);
 

--- a/dali/operators/math/expressions/arithmetic.h
+++ b/dali/operators/math/expressions/arithmetic.h
@@ -93,7 +93,7 @@ DLL_PUBLIC TensorLayout GetCommonLayout(ExprNode &expr, const workspace_t<Backen
     }
     DALI_ENFORCE(
         result_layout == next_layout,
-        make_string("Layouts of subexpressions ", i - 1, " and ", i, " for atihmetic operation",
+        make_string("Layouts of subexpressions ", i - 1, " and ", i, " for arithmetic operation",
                     func.GetFuncName(), " do not match. Expected ", result_layout, " got ",
                     next_layout, "."));
   }
@@ -314,9 +314,10 @@ class ArithmeticGenericOp : public Operator<Backend> {
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
     output_desc.resize(1);
     for (int i = 1; i < ws.NumInput(); i++) {
-      assert(ws.GetRequestedBatchSize(i) == ws.GetRequestedBatchSize(0));
+      DALI_ENFORCE(ws.GetInputBatchSize(i) == ws.GetInputBatchSize(0),
+                   "Every input shall have the same batch size");
     }
-    auto curr_batch_size = ws.GetRequestedBatchSize(0);
+    auto curr_batch_size = ws.GetInputBatchSize(0);
 
     if (!types_layout_inferred_) {
       result_type_id_ = PropagateTypes<Backend>(*expr_, ws);

--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -77,7 +77,7 @@ py::list PrepareDLTensorInputs<CPUBackend>(HostWorkspace &ws) {
   py::list input_tuple;
   for (Index idx = 0; idx < ws.NumInput(); ++idx) {
     py::list dl_tensor_list;
-    for (Index i = 0; i < ws.NumInputAtIdx(idx); ++i) {
+    for (Index i = 0; i < ws.GetInputBatchSize(idx); ++i) {
       auto &t = ws.Input<CPUBackend>(idx, i);
       auto dl_capsule = TensorToDLPackView(const_cast<Tensor<CPUBackend>&>(t));
       dl_tensor_list.append(dl_capsule);
@@ -102,7 +102,7 @@ template <>
 py::list PrepareDLTensorInputsPerSample<CPUBackend>(HostWorkspace &ws) {
   py::list input_tuples;
   if (ws.NumInput() == 0) return input_tuples;
-  auto batch_size = ws.NumInputAtIdx(0);
+  auto batch_size = ws.GetInputBatchSize(0);
   for (Index s = 0; s < batch_size; ++s) {
     py::list tuple;
     for (Index idx = 0; idx < ws.NumInput(); ++idx) {

--- a/dali/operators/python_function/dltensor_function.h
+++ b/dali/operators/python_function/dltensor_function.h
@@ -193,6 +193,7 @@ class DLTensorPythonFunctionImpl : public Operator<Backend> {
     std::lock_guard<std::mutex> operator_guard(operator_lock);
     py::gil_scoped_acquire interpreter_guard{};
     py::object output_o = py::none();
+    auto curr_batch_size = ws.GetInputBatchSize(0);
     try {
       detail::StreamSynchronizer<Backend> sync(ws, synchronize_stream_);
       if (batch_processing) {
@@ -207,7 +208,7 @@ class DLTensorPythonFunctionImpl : public Operator<Backend> {
             if (!output.is_none()) out_batch.append(output);
           }
         } else {
-          for (int s = 0; s < batch_size_; ++s) {
+          for (int s = 0; s < curr_batch_size; ++s) {
             py::object output = python_function();
             if (!output.is_none()) out_batch.append(output);
           }
@@ -219,9 +220,9 @@ class DLTensorPythonFunctionImpl : public Operator<Backend> {
     }
     if (!output_o.is_none()) {
       if (batch_processing) {
-        detail::PrepareOutputs<Backend>(ws, output_o, batch_size_);
+        detail::PrepareOutputs<Backend>(ws, output_o, curr_batch_size);
       } else {
-        detail::PrepareOutputsPerSample<Backend>(ws, output_o, batch_size_);
+        detail::PrepareOutputsPerSample<Backend>(ws, output_o, curr_batch_size);
       }
     } else {
       DALI_ENFORCE(ws.NumOutput() == 0, "Python function returned 0 outputs and "

--- a/dali/operators/random/batch_permutation.cc
+++ b/dali/operators/random/batch_permutation.cc
@@ -32,7 +32,7 @@ points, that is ``out[i] != i``. This argument is ignored when batch size is 1.)
 
 void BatchPermutation::RunImpl(HostWorkspace &ws) {
   auto &output = ws.OutputRef<CPUBackend>(0);
-  int N = GetBatchSize(ws);
+  int N = ws.GetRequestedBatchSize(0);
   if (N < 1)
     return;
   auto out_view = view<int, 0>(output);

--- a/dali/operators/random/batch_permutation.h
+++ b/dali/operators/random/batch_permutation.h
@@ -26,13 +26,9 @@ class BatchPermutation : public Operator<CPUBackend> {
   explicit BatchPermutation(const OpSpec &spec)
   : Operator<CPUBackend>(spec), rng_(spec.GetArgument<int64_t>("seed")) {}
 
-  int GetBatchSize(const HostWorkspace &) {
-    return spec_.GetArgument<int>("batch_size");
-  }
-
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
     output_desc.resize(1);
-    output_desc[0].shape = TensorListShape<0>(GetBatchSize(ws));
+    output_desc[0].shape = TensorListShape<0>(ws.GetRequestedBatchSize(0));
     output_desc[0].type = TypeTable::GetTypeInfo(DALI_INT32);
     return true;
   }

--- a/dali/operators/random/coin_flip.cc
+++ b/dali/operators/random/coin_flip.cc
@@ -19,7 +19,7 @@ namespace dali {
 
 void CoinFlip::RunImpl(HostWorkspace &ws) {
   auto &output = ws.OutputRef<CPUBackend>(0);
-  for (int i = 0; i < batch_size_; ++i) {
+  for (int i = 0; i < max_batch_size_; ++i) {
     output[i].mutable_data<int>()[0] = dis_(rng_) ? 1 : 0;
   }
 }

--- a/dali/operators/random/coin_flip.h
+++ b/dali/operators/random/coin_flip.h
@@ -43,7 +43,7 @@ class CoinFlip : public Operator<CPUBackend> {
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
     output_desc.resize(1);
-    output_desc[0].shape = TensorListShape<0>(batch_size_);
+    output_desc[0].shape = TensorListShape<0>(max_batch_size_);
     output_desc[0].type = TypeTable::GetTypeInfo(DALI_INT32);
     return true;
   }

--- a/dali/operators/random/normal_distribution_op.cc
+++ b/dali/operators/random/normal_distribution_op.cc
@@ -47,7 +47,7 @@ void NormalDistributionCpu::AssignSingleValueToOutput(workspace_t<CPUBackend> &w
   auto &output = ws.OutputRef<CPUBackend>(0);
   distribution_t distribution(mean_[0], stddev_[0]);
   TYPE_SWITCH(dtype_, type2id, DType, DALI_NORMDIST_TYPES, (
-          for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
+          for (int sample_id = 0; sample_id < max_batch_size_; ++sample_id) {
             auto ptr = output[sample_id].mutable_data<DType>();
             *ptr = ConvertSat<DType>(distribution(rng_));
           }
@@ -60,7 +60,7 @@ void NormalDistributionCpu::AssignTensorToOutput(workspace_t<CPUBackend> &ws) {
   auto out_shape = output.shape();
   auto &tp = ws.GetThreadPool();
   TYPE_SWITCH(dtype_, type2id, DType, DALI_NORMDIST_TYPES, (
-            for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
+            for (int sample_id = 0; sample_id < max_batch_size_; ++sample_id) {
               auto out_size = out_shape.tensor_size(sample_id);
               tp.AddWork(
                   [&, sample_id, out_size](int thread_id) {

--- a/dali/operators/random/normal_distribution_op.cu
+++ b/dali/operators/random/normal_distribution_op.cu
@@ -74,7 +74,7 @@ std::pair<std::vector<int>, int> DistributeBlocksPerSample(
 
 NormalDistributionGpu::NormalDistributionGpu(const OpSpec &spec)
       : NormalDistribution(spec), randomizer_(seed_, block_size_ * max_blocks_) {
-  DALI_ENFORCE(batch_size_ <= max_blocks_,
+  DALI_ENFORCE(max_batch_size_ <= max_blocks_,
                "Batch size must be smaller than " + std::to_string(max_blocks_));
   block_descs_gpu_ = mem::alloc_unique<BlockDesc>(kernels::AllocType::GPU, max_blocks_);
   block_descs_cpu_ = mem::alloc_unique<BlockDesc>(kernels::AllocType::Pinned, max_blocks_);

--- a/dali/operators/random/uniform.cc
+++ b/dali/operators/random/uniform.cc
@@ -19,8 +19,9 @@ namespace dali {
 
 void Uniform::AssignRange(HostWorkspace &ws) {
   auto &output = ws.OutputRef<CPUBackend>(0);
+  auto curr_batch_size = ws.GetRequestedBatchSize(0);
   auto dist = std::uniform_real_distribution<float>(range_[0], range_[1]);
-  for (int i = 0; i < batch_size_; ++i) {
+  for (int i = 0; i < curr_batch_size; ++i) {
     auto *sample_data = output[i].mutable_data<float>();
     auto sample_len = output[i].size();
     for (int k = 0; k < sample_len; ++k) {
@@ -34,8 +35,9 @@ void Uniform::AssignRange(HostWorkspace &ws) {
 
 void Uniform::AssignSet(HostWorkspace &ws) {
   auto &output = ws.OutputRef<CPUBackend>(0);
+  auto curr_batch_size = ws.GetRequestedBatchSize(0);
   auto dist = std::uniform_int_distribution<int>(0, set_.size() - 1);
-  for (int i = 0; i < batch_size_; ++i) {
+  for (int i = 0; i < curr_batch_size; ++i) {
     auto *sample_data = output[i].mutable_data<float>();
     auto sample_len = output[i].size();
     for (int k = 0; k < sample_len; ++k) {

--- a/dali/operators/random/uniform.h
+++ b/dali/operators/random/uniform.h
@@ -57,11 +57,12 @@ class Uniform : public Operator<CPUBackend> {
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
     output_desc.resize(1);
+    auto curr_batch_size = ws.GetRequestedBatchSize(0);
     output_desc[0].type = TypeTable::GetTypeInfo(DALI_FLOAT);
     if (spec_.ArgumentDefined("shape")) {
-      GetShapeArgument(output_desc[0].shape, spec_, "shape", ws, -1, batch_size_);
+      GetShapeArgument(output_desc[0].shape, spec_, "shape", ws, -1, curr_batch_size);
     } else {
-      output_desc[0].shape = uniform_list_shape(batch_size_, TensorShape<0>());
+      output_desc[0].shape = uniform_list_shape(curr_batch_size, TensorShape<0>());
     }
     return true;
   }

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -57,7 +57,7 @@ class Loader {
     : shuffle_(options.GetArgument<bool>("random_shuffle")),
       initial_buffer_fill_(shuffle_ ? options.GetArgument<int>("initial_fill") : 1),
       initial_empty_size_(2 * options.GetArgument<int>("prefetch_queue_depth")
-                          * options.GetArgument<int>("batch_size")),
+                          * options.GetArgument<int>("max_batch_size")),
       tensor_init_bytes_(options.GetArgument<int>("tensor_init_bytes")),
       seed_(options.GetArgument<Index>("seed")),
       shard_id_(options.GetArgument<int>("shard_id")),

--- a/dali/operators/reader/loader/loader_test.cc
+++ b/dali/operators/reader/loader/loader_test.cc
@@ -49,7 +49,7 @@ TYPED_TEST(DataLoadStoreTest, LMDBTest) {
   shared_ptr<dali::LMDBLoader> reader(
       new LMDBLoader(
           OpSpec("CaffeReader")
-          .AddArg("batch_size", 32)
+          .AddArg("max_batch_size", 32)
           .AddArg("path", testing::dali_extra_path() + "/db/c2lmdb/")
           .AddArg("device_id", 0)));
 
@@ -70,7 +70,7 @@ TYPED_TEST(DataLoadStoreTest, FileLabelLoaderMmmap) {
         new FileLabelLoader(
             OpSpec("FileReader")
             .AddArg("file_root", loader_test_image_folder)
-            .AddArg("batch_size", 32)
+            .AddArg("max_batch_size", 32)
             .AddArg("device_id", 0)
             .AddArg("dont_use_mmap", dont_use_mmap)));
 
@@ -89,7 +89,7 @@ TYPED_TEST(DataLoadStoreTest, RecordIOLoaderMmmap) {
             OpSpec("MXNetReader")
             .AddArg("path", path)
             .AddArg("index_path", index_path)
-            .AddArg("batch_size", 32)
+            .AddArg("max_batch_size", 32)
             .AddArg("device_id", 0)
             .AddArg("dont_use_mmap", dont_use_mmap)));
 
@@ -108,7 +108,7 @@ TYPED_TEST(DataLoadStoreTest, TFRecordLoaderMmmap) {
             OpSpec("TFRecordReader")
             .AddArg("path", path)
             .AddArg("index_path", index_path)
-            .AddArg("batch_size", 32)
+            .AddArg("max_batch_size", 32)
             .AddArg("device_id", 0)
             .AddArg("dont_use_mmap", dont_use_mmap)));
 
@@ -125,7 +125,7 @@ TYPED_TEST(DataLoadStoreTest, CocoLoaderMmmap) {
     auto coco_spec = OpSpec("COCOReader")
                       .AddArg("file_root", file_root)
                       .AddArg("annotations_file", annotations_file)
-                      .AddArg("batch_size", 32)
+                      .AddArg("max_batch_size", 32)
                       .AddArg("device_id", 0)
                       .AddArg("dont_use_mmap", dont_use_mmap);
     shared_ptr<dali::CocoLoader> reader(new CocoLoader(coco_spec));
@@ -140,7 +140,7 @@ TYPED_TEST(DataLoadStoreTest, LoaderTest) {
       new FileLabelLoader(
           OpSpec("FileReader")
           .AddArg("file_root", loader_test_image_folder)
-          .AddArg("batch_size", 32)
+          .AddArg("max_batch_size", 32)
           .AddArg("device_id", 0)));
 
   reader->PrepareMetadata();
@@ -157,7 +157,7 @@ TYPED_TEST(DataLoadStoreTest, LoaderTestFail) {
   shared_ptr<dali::FileLabelLoader> reader(
       new FileLabelLoader(OpSpec("FileReader")
                          .AddArg("file_root", loader_test_image_folder + "/does_not_exist")
-                         .AddArg("batch_size", 32)
+                         .AddArg("max_batch_size", 32)
                          .AddArg("device_id", 0)));
   ASSERT_THROW(reader->PrepareMetadata(), std::runtime_error);
 }
@@ -167,7 +167,7 @@ TYPED_TEST(DataLoadStoreTest, CachedLMDBTest) {
   shared_ptr<dali::LMDBLoader> reader(
       new LMDBLoader(
           OpSpec("CaffeReader")
-          .AddArg("batch_size", 32)
+          .AddArg("max_batch_size", 32)
           .AddArg("enable_cache", true)
           .AddArg("path", string(path))));
 

--- a/dali/operators/reader/loader/nemo_asr_loader_test.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader_test.cc
@@ -113,7 +113,7 @@ TEST(NemoAsrLoaderTest, ParseNonAsciiTransript) {
 TEST(NemoAsrLoaderTest, WrongManifestPath) {
   auto spec = OpSpec("NemoAsrReader")
                   .AddArg("manifest_filepaths", std::vector<std::string>{"./wrong/file.txt"})
-                  .AddArg("batch_size", 32)
+                  .AddArg("max_batch_size", 32)
                   .AddArg("device_id", -1);
   NemoAsrLoader loader(spec);
   ASSERT_THROW(loader.PrepareMetadata(), std::runtime_error);
@@ -135,7 +135,7 @@ TEST(NemoAsrLoaderTest, ParseManifestContent) {
 
   auto spec = OpSpec("NemoAsrReader")
                   .AddArg("manifest_filepaths", std::vector<std::string>{manifest_filepath})
-                  .AddArg("batch_size", 32)
+                  .AddArg("max_batch_size", 32)
                   .AddArg("device_id", -1);
 
   {
@@ -207,7 +207,7 @@ TEST(NemoAsrLoaderTest, ReadSample) {
                     .AddArg("downmix", false)
                     .AddArg("dtype", DALI_INT16)
                     .AddArg("num_threads", 4)
-                    .AddArg("batch_size", 32)
+                    .AddArg("max_batch_size", 32)
                     .AddArg("device_id", -1);
 
     NemoAsrLoader loader(spec);
@@ -234,7 +234,7 @@ TEST(NemoAsrLoaderTest, ReadSample) {
                     .AddArg("downmix", true)
                     .AddArg("dtype", DALI_FLOAT)
                     .AddArg("num_threads", 4)
-                    .AddArg("batch_size", 32)
+                    .AddArg("max_batch_size", 32)
                     .AddArg("device_id", -1);
 
     NemoAsrLoader loader(spec);
@@ -263,7 +263,7 @@ TEST(NemoAsrLoaderTest, ReadSample) {
                       .AddArg("sample_rate", sr_out)
                       .AddArg("dtype", DALI_FLOAT)
                       .AddArg("num_threads", 4)
-                      .AddArg("batch_size", 32)
+                      .AddArg("max_batch_size", 32)
                       .AddArg("device_id", -1);
       NemoAsrLoader loader(spec);
       loader.PrepareMetadata();
@@ -295,7 +295,7 @@ TEST(NemoAsrLoaderTest, ReadSample) {
                     .AddArg("sample_rate", static_cast<float>(sr_out))
                     .AddArg("dtype", DALI_INT16)
                     .AddArg("num_threads", 4)
-                    .AddArg("batch_size", 32)
+                    .AddArg("max_batch_size", 32)
                     .AddArg("device_id", -1);
       NemoAsrLoader loader(spec);
       loader.PrepareMetadata();
@@ -354,7 +354,7 @@ TEST(NemoAsrLoaderTest, ReadSample_OffsetAndDuration) {
           .AddArg("downmix", false)
           .AddArg("dtype", DALI_INT16)
           .AddArg("num_threads", 4)
-          .AddArg("batch_size", 32)
+          .AddArg("max_batch_size", 32)
           .AddArg("device_id", -1);
 
     NemoAsrLoader loader(spec);

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -88,7 +88,7 @@ void PermuteHelper(const TensorShape<> &plain_shapes, std::vector<int64_t> &perm
 }
 
 void NumpyReaderGPU::RunImpl(DeviceWorkspace &ws) {
-  TensorListShape<> shape(batch_size_);
+  TensorListShape<> shape(max_batch_size_);
   // use vector for temporarily storing shapes
   std::vector<TensorShape<>> tmp_shapes;
   std::vector<TensorShape<>> transpose_shapes;
@@ -98,7 +98,7 @@ void NumpyReaderGPU::RunImpl(DeviceWorkspace &ws) {
   perm.reserve(GetSampleShape(0).size());
   perm_shape.resize(GetSampleShape(0).size());
 
-  for (int sample_idx = 0; sample_idx < batch_size_; sample_idx++) {
+  for (int sample_idx = 0; sample_idx < max_batch_size_; sample_idx++) {
     const auto& imfile = GetSample(sample_idx);
     auto plain_shape = GetSampleShape(sample_idx);
     if (imfile.transpose_fortan_order) {
@@ -116,19 +116,19 @@ void NumpyReaderGPU::RunImpl(DeviceWorkspace &ws) {
   auto &image_output = ws.Output<GPUBackend>(0);
 
   SmallVector<int64_t, 256> copy_sizes;
-  copy_sizes.reserve(batch_size_);
+  copy_sizes.reserve(max_batch_size_);
   SmallVector<const void *, 256> copy_from;
-  copy_from.reserve(batch_size_);
+  copy_from.reserve(max_batch_size_);
   SmallVector<void *, 256> copy_to;
-  copy_to.reserve(batch_size_);
+  copy_to.reserve(max_batch_size_);
 
   SmallVector<const void *, 256> transpose_from;
-  transpose_from.reserve(batch_size_);
+  transpose_from.reserve(max_batch_size_);
   SmallVector<void *, 256> transpose_to;
-  transpose_to.reserve(batch_size_);
+  transpose_to.reserve(max_batch_size_);
 
 
-  for (int data_idx = 0; data_idx < batch_size_; ++data_idx) {
+  for (int data_idx = 0; data_idx < max_batch_size_; ++data_idx) {
     const auto& imfile = GetSample(data_idx);
     if (imfile.transpose_fortan_order) {
       transpose_from.push_back(GetSampleRawData(data_idx));

--- a/dali/operators/reader/reader_op_test.cc
+++ b/dali/operators/reader/reader_op_test.cc
@@ -285,7 +285,7 @@ TYPED_TEST(ReaderTest, ResetLoaderTestWrap) {
       .AddArg("shard_id", 0)
       .AddArg("num_shards", 2)
       .AddArg("stick_to_shard", false)
-      .AddArg("batch_size", 2)
+      .AddArg("max_batch_size", 2)
       .AddArg("device_id", 0));
   tl.PrepareMetadata();
 
@@ -326,7 +326,7 @@ TYPED_TEST(ReaderTest, ResetLoaderTestStickToShard) {
       .AddArg("shard_id", 0)
       .AddArg("num_shards", 2)
       .AddArg("stick_to_shard", true)
-      .AddArg("batch_size", 2)
+      .AddArg("max_batch_size", 2)
       .AddArg("device_id", 0));
   tl.PrepareMetadata();
 
@@ -367,7 +367,7 @@ TYPED_TEST(ReaderTest, ResetLoaderTestStickToShard2) {
       .AddArg("shard_id", 1)
       .AddArg("num_shards", 2)
       .AddArg("stick_to_shard", true)
-      .AddArg("batch_size", 2)
+      .AddArg("max_batch_size", 2)
       .AddArg("device_id", 0));
   tl.PrepareMetadata();
 
@@ -403,7 +403,7 @@ TYPED_TEST(ReaderTest, ResetLoaderTestNoPad) {
       .AddArg("shard_id", 1)
       .AddArg("num_shards", 2)
       .AddArg("stick_to_shard", true)
-      .AddArg("batch_size", 2)
+      .AddArg("max_batch_size", 2)
       .AddArg("device_id", 0)
       .AddArg("pad_last_batch", false));
   tl_even.PrepareMetadata();
@@ -414,7 +414,7 @@ TYPED_TEST(ReaderTest, ResetLoaderTestNoPad) {
       .AddArg("shard_id", 1)
       .AddArg("num_shards", 3)
       .AddArg("stick_to_shard", true)
-      .AddArg("batch_size", 2)
+      .AddArg("max_batch_size", 2)
       .AddArg("device_id", 0)
       .AddArg("pad_last_batch", false));
   tl_odd.PrepareMetadata();
@@ -435,7 +435,7 @@ TYPED_TEST(ReaderTest, ResetLoaderTestPad) {
       .AddArg("shard_id", 1)
       .AddArg("num_shards", 2)
       .AddArg("stick_to_shard", true)
-      .AddArg("batch_size", 2)
+      .AddArg("max_batch_size", 2)
       .AddArg("device_id", 0)
       .AddArg("pad_last_batch", true));
   tl_even.PrepareMetadata();
@@ -446,7 +446,7 @@ TYPED_TEST(ReaderTest, ResetLoaderTestPad) {
       .AddArg("shard_id", 1)
       .AddArg("num_shards", 3)
       .AddArg("stick_to_shard", true)
-      .AddArg("batch_size", 2)
+      .AddArg("max_batch_size", 2)
       .AddArg("device_id", 0)
       .AddArg("pad_last_batch", true));
   tl_odd.PrepareMetadata();

--- a/dali/operators/reader/video_reader_op.h
+++ b/dali/operators/reader/video_reader_op.h
@@ -95,11 +95,11 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
     // TODO(spanev): Factor out the constructor body to make VideoReader compatible with lazy_init.
     loader_ = InitLoader<VideoLoader>(spec, filenames_);
 
-    label_shape_ = uniform_list_shape(batch_size_, {1});
+    label_shape_ = uniform_list_shape(max_batch_size_, {1});
 
     if (can_use_frames_timestamps_) {
       if (enable_frame_num_) frame_num_shape_ = label_shape_;
-      if (enable_timestamps_) timestamp_shape_ = uniform_list_shape(batch_size_, {count_});
+      if (enable_timestamps_) timestamp_shape_ = uniform_list_shape(max_batch_size_, {count_});
     }
   }
 

--- a/dali/operators/reader/video_reader_resize_op.h
+++ b/dali/operators/reader/video_reader_resize_op.h
@@ -44,7 +44,7 @@ class VideoReaderResize : public VideoReader,
     input_shape_ = prefetched_batch_tensors_[curr_batch_consumer_].shape();
 
     resize_attr_.PrepareResizeParams(spec_, ws, input_shape_, "FHWC");
-    resampling_attr_.PrepareFilterParams(spec_, ws, batch_size_);
+    resampling_attr_.PrepareFilterParams(spec_, ws, max_batch_size_);
     resample_params_.resize(resize_attr_.params_.size());
     resampling_attr_.GetResamplingParams(make_span(resample_params_),
                                          make_cspan(resize_attr_.params_));

--- a/dali/operators/segmentation/random_mask_pixel.cc
+++ b/dali/operators/segmentation/random_mask_pixel.cc
@@ -78,7 +78,7 @@ class RandomMaskPixelCPU : public Operator<CPUBackend> {
 
 RandomMaskPixelCPU::RandomMaskPixelCPU(const OpSpec &spec)
     : Operator<CPUBackend>(spec),
-      rngs_(spec.GetArgument<int64_t>("seed"), spec.GetArgument<int64_t>("batch_size")),
+      rngs_(spec.GetArgument<int64_t>("seed"), spec.GetArgument<int64_t>("max_batch_size")),
       has_value_(spec.ArgumentDefined("value")) {
   if (has_value_) {
     DALI_ENFORCE(!spec.ArgumentDefined("threshold"),

--- a/dali/operators/sequence/sequence_rearrange.cc
+++ b/dali/operators/sequence/sequence_rearrange.cc
@@ -74,8 +74,9 @@ void SequenceRearrange<CPUBackend>::RunImpl(workspace_t<CPUBackend> &ws) {
   auto &output = ws.OutputRef<CPUBackend>(0);
   auto &thread_pool = ws.GetThreadPool();
   auto out_shape = output.shape();
+  auto curr_batch_size = ws.GetInputBatchSize(0);
 
-  for (int sample_idx = 0; sample_idx < batch_size_; ++sample_idx) {
+  for (int sample_idx = 0; sample_idx < curr_batch_size; ++sample_idx) {
     thread_pool.AddWork([this, &ws, &input, &output, sample_idx](int tid) {
       TypeInfo type = input.type();
       const auto *in_sample = reinterpret_cast<const char *>(input[sample_idx].raw_data());

--- a/dali/operators/sequence/sequence_rearrange.cu
+++ b/dali/operators/sequence/sequence_rearrange.cu
@@ -26,8 +26,9 @@ void SequenceRearrange<GPUBackend>::RunImpl(workspace_t<GPUBackend> &ws) {
   const auto &input = ws.InputRef<GPUBackend>(0);
   auto &output = ws.OutputRef<GPUBackend>(0);
   TypeInfo type = input.type();
+  auto curr_batch_size = ws.GetInputBatchSize(0);
 
-  for (int sample_idx = 0; sample_idx < batch_size_; ++sample_idx) {
+  for (int sample_idx = 0; sample_idx < curr_batch_size; ++sample_idx) {
     auto *out_sample = reinterpret_cast<char *>(output.raw_mutable_tensor(sample_idx));
     const auto *in_sample = reinterpret_cast<const char *>(input.raw_tensor(sample_idx));
     const auto &in_shape = input.shape()[sample_idx];

--- a/dali/operators/sequence/sequence_rearrange.h
+++ b/dali/operators/sequence/sequence_rearrange.h
@@ -72,16 +72,17 @@ class SequenceRearrange : public Operator<Backend> {
     output_desc.resize(1);
     output_desc[0].type = input.type();
     output_desc[0].shape = TensorListShape<>(in_shape.num_samples(), in_shape.sample_dim());
+    auto curr_batch_size = ws.GetInputBatchSize(0);
     if (single_order_) {
       TensorView<StorageCPU, const int, 1> new_order(new_order_.data(),
                                                      TensorShape<1>(new_order_.size()));
-      for (int i = 0; i < batch_size_; i++) {
+      for (int i = 0; i < curr_batch_size; i++) {
         ValidateSeqRearrange(in_shape[i], new_order, i);
         output_desc[0].shape.set_tensor_shape(i, GetSeqRearrangedShape(in_shape[i], new_order));
       }
     } else {
       const auto& new_orders = ws.ArgumentInput("new_order");
-      for (int i = 0; i < batch_size_; i++) {
+      for (int i = 0; i < curr_batch_size; i++) {
         auto new_order = view<const int, 1>(new_orders[i]);
         ValidateSeqRearrange(in_shape[i], new_order, i);
         output_desc[0].shape.set_tensor_shape(i, GetSeqRearrangedShape(in_shape[i], new_order));

--- a/dali/operators/ssd/box_encoder.h
+++ b/dali/operators/ssd/box_encoder.h
@@ -35,7 +35,8 @@ class BoxEncoder<CPUBackend>: public Operator<CPUBackend> {
   using BoundingBox = Box<2, float>;
 
   explicit BoxEncoder(const OpSpec &spec)
-      : Operator<CPUBackend>(spec), criteria_(spec.GetArgument<float>("criteria")),
+      : Operator<CPUBackend>(spec),
+        criteria_(spec.GetArgument<float>("criteria")),
         offset_(spec.GetArgument<bool>("offset")),
         scale_(spec.GetArgument<float>("scale")) {
     DALI_ENFORCE(

--- a/dali/operators/ssd/random_crop.cc
+++ b/dali/operators/ssd/random_crop.cc
@@ -33,7 +33,8 @@ As an input, the operator accepts image, bounding boxes and labels. At the outpu
 cropped and valid bounding boxes and valid labels are returned.)code")
   .NumInput(3)   // [img, bbox, label]
   .NumOutput(3)  // [img, bbox, label]
-  .AddOptionalArg("num_attempts", R"code(Number of attempts.)code", 1);
+  .AddOptionalArg("num_attempts", R"code(Number of attempts.)code", 1)
+  .Deprecate("RandomBBoxCrop");
 
 /*
  * # This function is from https://github.com/kuangliu/pytorch-ssd.

--- a/dali/operators/ssd/random_crop.h
+++ b/dali/operators/ssd/random_crop.h
@@ -34,7 +34,7 @@ class SSDRandomCrop : public Operator<Backend> {
   explicit inline SSDRandomCrop(const OpSpec &spec) :
     Operator<Backend>(spec),
     num_attempts_(spec.GetArgument<int>("num_attempts")),
-    rngs_(spec.GetArgument<int64_t>("seed"), batch_size_),
+    rngs_(spec.GetArgument<int64_t>("seed"), max_batch_size_),
     int_dis_(0, 6),        // sample option
     float_dis_(0.3, 1.) {  // w, h generation
     // setup all possible sample types

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -123,6 +123,15 @@ class DLL_PUBLIC TensorVector {
 
   DLL_PUBLIC void Resize(const TensorListShape<> &new_shape, const TypeInfo &new_type);
 
+  /**
+   * Change the number of tensors in the TensorVector, without the need of
+   * specifying the shape of every such tensor. When setting the new size,
+   * this function will retain the shapes that already exist. New tensors
+   * are given a shape of 0-volume and appropriate dimension.
+   * @param new_size
+   */
+  void SetSize(int new_size);
+
   void set_type(const TypeInfo &new_type);
 
   const TypeInfo &type() const;

--- a/dali/pipeline/data/tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_vector_test.cc
@@ -151,6 +151,12 @@ namespace {
 template <typename T, typename U>
 ::testing::AssertionResult Compare(const char *rhs_expr, const char *lhs_expr, const T &rhs,
                                    const U &lhs) {
+  static_assert(std::is_same<T, TensorList<CPUBackend>>::value ||
+                    std::is_same<T, TensorVector<CPUBackend>>::value,
+                "T must be either TensorList<CPUBackend> or TensorVector<CPUBackend>");
+  static_assert(std::is_same<U, TensorList<CPUBackend>>::value ||
+                    std::is_same<U, TensorVector<CPUBackend>>::value,
+                "U must be either TensorList<CPUBackend> or TensorVector<CPUBackend>");
   std::string testing_values = make_string(rhs_expr, ", ", lhs_expr);
   if (rhs.ntensor() != lhs.ntensor()) {
     ::testing::AssertionFailure() << make_string("[Testing: ", testing_values,

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -867,12 +867,12 @@ void Executor<WorkspacePolicy, QueuePolicy>::PresizeData(
     return hint;
   };
 
-  auto reserve_batch = [](auto &storage, const OperatorBase &op, Index hint, int batch_size_) {
+  auto reserve_batch = [](auto &storage, const OperatorBase &op, Index hint, int batch_size) {
     // If the Op Can Infer Outputs we want to do one contiguous pre-allocation
     if (op.CanInferOutputs()) {
-      storage->reserve(hint * batch_size_);
+      storage->reserve(hint * batch_size);
     } else {
-      storage->reserve(hint, batch_size_);
+      storage->reserve(hint, batch_size);
     }
   };
 

--- a/dali/pipeline/executor/executor_test.cc
+++ b/dali/pipeline/executor/executor_test.cc
@@ -45,7 +45,7 @@ class ExecutorTest : public GenericDecoderTest<RGB> {
   inline void set_batch_size(int size) { batch_size_ = size; }
 
   inline OpSpec& PrepareSpec(OpSpec &spec) const {
-    spec.AddArg("batch_size", batch_size_)
+    spec.AddArg("max_batch_size", batch_size_)
       .AddArg("num_threads", num_threads_);
     return spec;
   }
@@ -374,14 +374,14 @@ TYPED_TEST(ExecutorTest, DISABLED_TestDataSetup) {
     HostWorkspace &hws = host_workspaces[0];
     ASSERT_EQ(hws.NumInput(), 0);
     ASSERT_EQ(hws.NumOutput(), 1);
-    ASSERT_EQ(hws.NumOutputAtIdx(0), this->batch_size_);
+    ASSERT_EQ(hws.GetRequestedBatchSize(0), this->batch_size_);
     ASSERT_TRUE(hws.OutputIsType<CPUBackend>(0));
 
     auto mixed_workspaces = this->MixedData(exe.get(), i);
     ASSERT_EQ(mixed_workspaces.size(), 1);
     MixedWorkspace &mws = mixed_workspaces[0];
     ASSERT_EQ(mws.NumInput(), 1);
-    ASSERT_EQ(mws.NumInputAtIdx(0), this->batch_size_);
+    ASSERT_EQ(mws.GetInputBatchSize(0), this->batch_size_);
     ASSERT_TRUE(mws.InputIsType<CPUBackend>(0));
     ASSERT_EQ(mws.NumOutput(), 1);
     ASSERT_TRUE(mws.OutputIsType<GPUBackend>(0));

--- a/dali/pipeline/graph/op_graph_test.cc
+++ b/dali/pipeline/graph/op_graph_test.cc
@@ -23,7 +23,7 @@ namespace dali {
 class OpGraphTest : public DALITest {
  public:
   inline OpSpec& PrepareSpec(OpSpec &spec) {
-    spec.AddArg("batch_size", 1)
+    spec.AddArg("max_batch_size", 1)
       .AddArg("num_threads", 1)
       .AddArg("cuda_stream", 0)
       .AddArg("pixels_per_image_hint", 0);

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -30,9 +30,10 @@ void ExternalSource<CPUBackend>::RunImpl(HostWorkspace &ws) {
   if (output.is_pinned() && !tensor_vector_elm.front()->is_pinned()) {
     auto &thread_pool = ws.GetThreadPool();
     const auto &shapes = tensor_vector_elm.front()->shape();
+    auto curr_batch_size = shapes.num_samples();
     output.Resize(shapes, tensor_vector_elm.front()->type());
 
-    for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
+    for (int sample_id = 0; sample_id < curr_batch_size; ++sample_id) {
       thread_pool.AddWork([&ws, sample_id, &tensor_vector_elm] (int tid) {
         Tensor<CPUBackend> &output_tensor = ws.Output<CPUBackend>(0, sample_id);
         // HostWorkspace doesn't have any stream

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -377,13 +377,14 @@ class ExternalSource : public Operator<Backend> {
     bool is_gpu_src = std::is_same<SrcBackend, GPUBackend>::value;
     bool is_gpu_dst = std::is_same<Backend, GPUBackend>::value;
     if (is_gpu_src && !is_gpu_dst) {
-      DALI_WARN("Warning: Loading GPU-originated data into CPU "
-                "ExternalSource operator is discouraged and might be inefficient.");
+      DALI_WARN(
+          "Warning: Loading GPU-originated data into CPU ExternalSource operator is discouraged "
+          "and might be inefficient.");
     }
-    DALI_ENFORCE(OperatorBase::batch_size_ == static_cast<int>(batch.ntensor()),
-                 make_string("Data list provided to ExternalSource needs to have batch_size = ",
-                             OperatorBase::batch_size_, " length, found ", batch.ntensor(),
-                             " samples."));
+    DALI_ENFORCE(
+        OperatorBase::max_batch_size_ >= static_cast<int>(batch.ntensor()),
+        make_string("Data list provided to ExternalSource needs to have batch_size <= ",
+                    OperatorBase::max_batch_size_, ", found ", batch.ntensor(), " samples."));
     // Note: If we create a GPU source, we will need to figure
     // out what stream we want to do this copy in. CPU we can
     // pass anything as it is ignored.

--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -57,7 +57,7 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
   inline void set_batch_size(int size) { batch_size_ = size; }
 
   inline OpSpec& PrepareSpec(OpSpec &spec) const {
-    spec.AddArg("batch_size", batch_size_)
+    spec.AddArg("max_batch_size", batch_size_)
       .AddArg("num_threads", num_threads_);
     return spec;
   }
@@ -461,7 +461,7 @@ TEST(ExternalSourceTestNoInput, Throw) {
       .AddArg("device", "cpu")
       .AddArg("device_id", 0)
       .AddOutput("data_out", "cpu")
-      .AddArg("batch_size", batch_size)
+      .AddArg("max_batch_size", batch_size)
       .AddArg("num_threads", num_threads), "");
 
   vector<string> outputs = {"data_out_cpu"};

--- a/dali/pipeline/operator/common_test.cc
+++ b/dali/pipeline/operator/common_test.cc
@@ -40,25 +40,25 @@ TEST(PipelineCommon, GetShapeLikeArgumentScalar) {
 TEST(PipelineCommon, GetShapeLikeArgumentVector) {
   OpSpec spec("PipelineCommonTest");
   ArgumentWorkspace ws;
-  vector<float> src_shape = { -0.75f, 1, 2.75f, 3.25f };
+  vector<float> src_shape = {-0.75f, 1, 2.75f, 3.25f};
   spec.SetArg("size", src_shape);
-  spec.SetArg("batch_size", 3);
+  int max_batch_size = 3;
+  spec.SetArg("max_batch_size", max_batch_size);
 
   vector<float> shape;
   int nsamples, D;
-  std::tie(nsamples, D) = GetShapeLikeArgument<float>(shape, spec, "size", ws);
+  std::tie(nsamples, D) = GetShapeLikeArgument<float>(shape, spec, "size", ws, -1, max_batch_size);
   EXPECT_EQ(D, 4);
   ASSERT_EQ(shape.size(), 12);
   for (int i = 0; i < 3; i++) {
-    for (int d = 0; d < 4; d++)
-      EXPECT_EQ(shape[i * 4 + d], src_shape[d]);
+    for (int d = 0; d < 4; d++) EXPECT_EQ(shape[i * 4 + d], src_shape[d]);
   }
 
   vector<int> ref_ishape = { -1, 1, 3, 3 };
   vector<int> ishape;
   spec.SetArg("size", src_shape);
   spec.SetArg("batch_size", 3);
-  std::tie(nsamples, D) = GetShapeLikeArgument<float>(ishape, spec, "size", ws);
+  std::tie(nsamples, D) = GetShapeLikeArgument<float>(ishape, spec, "size", ws, -1, max_batch_size);
   EXPECT_EQ(D, 4);
   ASSERT_EQ(shape.size(), 12);
   for (int i = 0; i < 3; i++) {
@@ -81,13 +81,13 @@ TEST(PipelineCommon, GetShapeLikeArgumentInput) {
   for (int i = 0; i < D*N; i++)
     shape_data[i] = i * 1.1f;
 
-  spec.SetArg("batch_size", N);
+  spec.SetArg("max_batch_size", N);
   spec.AddArgumentInput("size", "size");
   ws.AddArgumentInput("size", input);
 
   vector<float> shape;
   int nsamples, out_d;
-  std::tie(nsamples, out_d) = GetShapeLikeArgument<float>(shape, spec, "size", ws, -1, -1);
+  std::tie(nsamples, out_d) = GetShapeLikeArgument<float>(shape, spec, "size", ws, -1, N);
   EXPECT_EQ(out_d, D) << "Dimensionality should match the size of the tensors in the list.";
   ASSERT_EQ(shape.size(), N * D) << "Total size of the shape should be batch x ndim";
   for (int i = 0; i < N; i++) {
@@ -108,7 +108,7 @@ TEST(PipelineCommon, GetShapeLikeArgumentInput) {
   ws.AddArgumentInput("size", input);
 
   vector<int> ishape;
-  std::tie(nsamples, out_d) = GetShapeLikeArgument<float>(ishape, spec, "size", ws, D, -1);
+  std::tie(nsamples, out_d) = GetShapeLikeArgument<float>(ishape, spec, "size", ws, D, N);
   EXPECT_EQ(out_d, D) << "A list of scalars can be broadcast to any number of dimensions.";
   ASSERT_EQ(shape.size(), N * D) << "Total size of the shape should be batch x ndim";
   for (int i = 0; i < N; i++) {
@@ -118,7 +118,7 @@ TEST(PipelineCommon, GetShapeLikeArgumentInput) {
 
   shape.clear();
   // if the extent is not know, a list of scalars indicates 1D shapes
-  std::tie(nsamples, out_d) = GetShapeLikeArgument<float>(shape, spec, "size", ws, -1, -1);
+  std::tie(nsamples, out_d) = GetShapeLikeArgument<float>(shape, spec, "size", ws, -1, N);
   EXPECT_EQ(out_d, 1) << "A list of scalars should be interpreted as a 1D shape";
   D = 1;
   ASSERT_EQ(shape.size(), N * D) << "Total size of the shape should be batch x ndim";

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -71,7 +71,7 @@ class DLL_PUBLIC OpSchema {
   DLL_PUBLIC explicit inline OpSchema(const std::string &name): name_(name) {
     // Fill internal arguments
     AddInternalArg("num_threads", "Number of CPU threads in a thread pool", -1);
-    AddInternalArg("batch_size", "Batch size", -1);
+    AddInternalArg("max_batch_size", "Max batch size", -1);
     AddInternalArg("device", "Device on which the Op is run", std::string("cpu"));
     AddInternalArg("inplace", "Whether Op can be run in place", false);
     AddInternalArg("default_cuda_stream_priority", "Default cuda stream priority", 0);

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -488,7 +488,7 @@ inline T OpSpec::GetArgumentImpl(
   if (this->HasTensorArgument(name)) {
     DALI_ENFORCE(ws != nullptr, "Tensor value is unexpected for argument \"" + name + "\".");
     const auto &value = ws->ArgumentInput(name);
-    CheckScalarArgumentShape(value.shape(), GetArgument<int>("batch_size"), name, true);
+    CheckScalarArgumentShape(value.shape(), GetArgument<int>("max_batch_size"), name, true);
     DALI_ENFORCE(IsType<T>(value.type()),
         "Unexpected type of argument \"" + name + "\". Expected " +
         TypeTable::GetTypeName<T>() + " and got " + value.type().name());
@@ -517,7 +517,7 @@ inline bool OpSpec::TryGetArgumentImpl(
     if (ws == nullptr)
       return false;
     const auto& value = ws->ArgumentInput(name);
-    if (!CheckScalarArgumentShape(value.shape(), GetArgument<int>("batch_size"), name, false)) {
+    if (!CheckScalarArgumentShape(value.shape(), GetArgument<int>("max_batch_size"), name, false)) {
       return false;
     }
     if (!IsType<T>(value.type()))

--- a/dali/pipeline/operator/operator.cc
+++ b/dali/pipeline/operator/operator.cc
@@ -16,6 +16,18 @@
 
 namespace dali {
 
+template <typename Backend>
+void OperatorBase::EnforceConstantBatchSize(const workspace_t<Backend> &ws) const {
+  for (int i = 0; i < ws.NumInput(); i++) {
+    DALI_ENFORCE(ws.GetInputBatchSize(i) == max_batch_size_,
+                 "Batch size has to be constant throughout the processing");
+  }
+}
+
+template void OperatorBase::EnforceConstantBatchSize<CPUBackend>(const workspace_t<CPUBackend>&w) const;  // NOLINT
+template void OperatorBase::EnforceConstantBatchSize<GPUBackend>(const workspace_t<GPUBackend>&w) const;  // NOLINT
+template void OperatorBase::EnforceConstantBatchSize<MixedBackend>(const workspace_t<MixedBackend>&w) const;  // NOLINT
+
 DALI_DEFINE_OPTYPE_REGISTRY(CPUOperator, OperatorBase);
 DALI_DEFINE_OPTYPE_REGISTRY(GPUOperator, OperatorBase);
 DALI_DEFINE_OPTYPE_REGISTRY(MixedOperator, OperatorBase);

--- a/dali/pipeline/operator/operator_test.cc
+++ b/dali/pipeline/operator/operator_test.cc
@@ -22,7 +22,7 @@ namespace testing {
 OpSpec MakeOpSpec(const std::string& operator_name) {
   return OpSpec(operator_name)
     .AddArg("num_threads", 1)
-    .AddArg("batch_size", 32)
+    .AddArg("max_batch_size", 32)
     .AddArg("device", "cpu");
 }
 
@@ -57,7 +57,7 @@ class OperatorDiagnosticsTest : public ::testing::Test {
  protected:
   void SetUp() final {
     assign_value();
-    auto op_spec = OpSpec("CoinFlip").AddArg("num_threads", 1).AddArg("batch_size", 1);
+    auto op_spec = OpSpec("CoinFlip").AddArg("num_threads", 1).AddArg("max_batch_size", 1);
     operator_ = std::make_unique<OperatorBase>(op_spec);
   }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -65,7 +65,7 @@ class DLL_PUBLIC Pipeline {
    * to the true amount of memory that will be needed by the largest image to
    * be processed.
    *
-   * @param batch_size the size of the batch that should be produced.
+   * @param max_batch_size the maximum size of the batch that can be produced.
    * @param num_threads the number of threads to use in the prefetch stage.
    * @param device_id id of the GPU to operate on.
    * @param seed used for random number generation. Leaving the default value
@@ -84,18 +84,18 @@ class DLL_PUBLIC Pipeline {
    * @param default_cuda_stream_priority  CUDA stream priority used by DALI.
    * See `cudaStreamCreateWithPriority` in CUDA documentation
    */
-  DLL_PUBLIC inline Pipeline(int batch_size, int num_threads, int device_id, int64_t seed = -1,
+  DLL_PUBLIC inline Pipeline(int max_batch_size, int num_threads, int device_id, int64_t seed = -1,
                              bool pipelined_execution = true, int prefetch_queue_depth = 2,
                              bool async_execution = true, size_t bytes_per_sample_hint = 0,
                              bool set_affinity = false, int max_num_stream = -1,
                              int default_cuda_stream_priority = 0)
       : built_(false), separated_execution_{false} {
-    Init(batch_size, num_threads, device_id, seed, pipelined_execution, separated_execution_,
+    Init(max_batch_size, num_threads, device_id, seed, pipelined_execution, separated_execution_,
          async_execution, bytes_per_sample_hint, set_affinity, max_num_stream,
          default_cuda_stream_priority, QueueSizes{prefetch_queue_depth});
   }
 
-  DLL_PUBLIC Pipeline(const string &serialized_pipe, int batch_size = -1, int num_threads = -1,
+  DLL_PUBLIC Pipeline(const string &serialized_pipe, int max_batch_size = -1, int num_threads = -1,
                       int device_id = -1, bool pipelined_execution = true,
                       int prefetch_queue_depth = 2, bool async_execution = true,
                       size_t bytes_per_sample_hint = 0, bool set_affinity = false,
@@ -394,10 +394,13 @@ class DLL_PUBLIC Pipeline {
   DLL_PUBLIC void SaveGraphToDotFile(const std::string &filename, bool show_tensors = false,
                                      bool show_ids = false, bool use_colors = false);
 
+  /// @{
   /**
-   * @brief Returns the batch size that will be produced by the pipeline.
+   * @brief Returns the maximum batch size that can be processed by the Pipeline
    */
-  DLL_PUBLIC inline int batch_size() const { return batch_size_; }
+  DLL_PUBLIC inline int batch_size() const { return max_batch_size_; }
+  DLL_PUBLIC inline int max_batch_size() const { return max_batch_size_; }
+  /// @}
 
   /**
    * @brief Returns the map of (node name, reader meta) for all nodes that return a valid meta
@@ -495,7 +498,7 @@ class DLL_PUBLIC Pipeline {
   const int MAX_SEEDS = 1024;
 
   bool built_;
-  int batch_size_, num_threads_, device_id_;
+  int max_batch_size_, num_threads_, device_id_;
   bool pipelined_execution_;
   bool separated_execution_;
   bool async_execution_;

--- a/dali/pipeline/workspace/host_workspace.cc
+++ b/dali/pipeline/workspace/host_workspace.cc
@@ -43,24 +43,6 @@ void HostWorkspace::GetSample(SampleWorkspace* ws, int data_idx, int thread_idx)
   }
 }
 
-int HostWorkspace::NumInputAtIdx(int idx) const {
-  DALI_ENFORCE_VALID_INDEX(idx, input_index_map_.size());
-  auto tensor_meta = input_index_map_[idx];
-  if (tensor_meta.storage_device == StorageDevice::CPU) {
-    return cpu_inputs_[tensor_meta.index]->size();
-  }
-  return gpu_inputs_[tensor_meta.index]->size();
-}
-
-int HostWorkspace::NumOutputAtIdx(int idx) const {
-  DALI_ENFORCE_VALID_INDEX(idx, output_index_map_.size());
-  auto tensor_meta = output_index_map_[idx];
-  if (tensor_meta.storage_device == StorageDevice::CPU) {
-    return cpu_inputs_[tensor_meta.index]->size();
-  }
-  return gpu_outputs_[tensor_meta.index]->size();
-}
-
 template <>
 const Tensor<CPUBackend>& HostWorkspace::Input(int idx, int data_idx) const {
   return InputRef<CPUBackend>(idx)[data_idx];

--- a/dali/pipeline/workspace/host_workspace.h
+++ b/dali/pipeline/workspace/host_workspace.h
@@ -55,18 +55,6 @@ class DLL_PUBLIC HostWorkspace : public WorkspaceBase<HostInputType, HostOutputT
   DLL_PUBLIC void GetSample(SampleWorkspace *ws, int data_idx, int thread_idx);
 
   /**
-   * @brief Returns the number of Tensors in the input set of
-   * tensors at the given index.
-   */
-  DLL_PUBLIC int NumInputAtIdx(int idx) const;
-
-  /**
-   * @brief Returns the number of Tensors in the output set of
-   * tensors at the given index.
-   */
-  DLL_PUBLIC int NumOutputAtIdx(int idx) const;
-
-  /**
    * @brief Returns the Tensor at index `data_idx` in the input
    * Tensors at index `idx`.
    *

--- a/dali/pipeline/workspace/mixed_workspace.cc
+++ b/dali/pipeline/workspace/mixed_workspace.cc
@@ -18,15 +18,6 @@
 
 namespace dali {
 
-int MixedWorkspace::NumInputAtIdx(int idx) const {
-  DALI_ENFORCE_VALID_INDEX(idx, input_index_map_.size());
-  auto tensor_meta = input_index_map_[idx];
-  if (tensor_meta.storage_device == StorageDevice::CPU) {
-    return cpu_inputs_[tensor_meta.index]->size();
-  }
-  return gpu_inputs_[tensor_meta.index]->size();
-}
-
 template <>
 const Tensor<CPUBackend>& MixedWorkspace::Input(int idx, int data_idx) const {
   return InputRef<CPUBackend>(idx)[data_idx];

--- a/dali/pipeline/workspace/mixed_workspace.h
+++ b/dali/pipeline/workspace/mixed_workspace.h
@@ -48,12 +48,6 @@ class DLL_PUBLIC MixedWorkspace : public WorkspaceBase<MixedInputType, MixedOutp
 
 
   /**
-   * @brief Returns the number of Tensors in the input set of
-   * tensors at the given index.
-   */
-  DLL_PUBLIC int NumInputAtIdx(int idx) const;
-
-  /**
    * @brief Returns the input Tensor at index `data_idx` in the input
    * set of Tensors at index `idx`.
    *

--- a/dali/pipeline/workspace/sample_workspace.h
+++ b/dali/pipeline/workspace/sample_workspace.h
@@ -72,6 +72,18 @@ class DLL_PUBLIC SampleWorkspace : public WorkspaceBase<SampleInputType, SampleO
   template <typename Backend>
   DLL_PUBLIC Tensor<Backend>& Output(int idx);
 
+  int GetInputBatchSize(int) const {
+    DALI_FAIL(
+        "Impossible function: "
+        "Sample workspace is not aware, that there exists such thing as a batch");
+  }
+
+  int GetRequestedBatchSize(int) const {
+    DALI_FAIL(
+        "Impossible function: "
+        "Sample workspace is not aware, that there exists such thing as a batch");
+  }
+
   /**
    * @brief Returns the index of the sample that this workspace stores
    * in the input/output batch.

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -21,7 +21,8 @@ def _check_data_batch(data, batch_size, layout):
     shape, uniform = _get_batch_shape(data)
     if len(shape) != batch_size:
         raise RuntimeError("The external source callback returned an unexpected batch "
-        "size: {} instead of {}".format(len(shape), batch_size))
+                           "size. Expected batch_size == {}, actual: {}".format(batch_size,
+                                                                                len(shape)))
 
     if len(shape) > 0:
         dim = len(shape[0])

--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -76,6 +76,7 @@ def _wrap_op_fn(op_class, wrapper_name):
         return op_class(**init_args)(*inputs, **call_args)
 
     op_wrapper.__name__ = wrapper_name
+    op_wrapper.__qualname__ = wrapper_name
     op_wrapper.__doc__ = "see :class:`{0}.{1}`".format(op_class.__module__, op_class.__name__)
     return op_wrapper
 

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -488,7 +488,7 @@ def test_ssd_random_crop_cpu():
     def get_boxes():
         out = [(np.random.randint(0, 255, size = test_box_shape, dtype = np.uint8) / 255).astype(dtype = np.float32) for _ in range(batch_size)]
         return out
-    test_lables_shape = [200, 1]
+    test_lables_shape = [200]
     def get_lables():
         out = [np.random.randint(0, 255, size = test_lables_shape, dtype = np.int32) for _ in range(batch_size)]
         return out

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -114,7 +114,7 @@ def check_batch(
         batch2 = batch2.as_cpu()
 
     def _verify_batch_size(batch):
-        if isinstance(batch, dali.backend.TensorListCPU):
+        if isinstance(batch, dali.backend.TensorListCPU) or isinstance(batch, list):
             tested_batch_size = len(batch)
         else:
             tested_batch_size = batch.shape[0]

--- a/dali_tf_plugin/daliop.cc
+++ b/dali_tf_plugin/daliop.cc
@@ -101,7 +101,7 @@ class DaliOp : public tf::OpKernel {
 
     int num_threads;
     int device_id;
-    int batch_size;
+    int max_batch_size;
     bool exec_separated;
     int cpu_prefetch_queue_depth;
 
@@ -113,7 +113,7 @@ class DaliOp : public tf::OpKernel {
     // In exec_separated==false case, gpu_prefetch_queue_depth is the global prefetch_queue_depth_
     OP_REQUIRES_OK(context, context->GetAttr("gpu_prefetch_queue_depth", &prefetch_queue_depth_));
     OP_REQUIRES_OK(context, context->GetAttr("sparse", &sparse_));
-    OP_REQUIRES_OK(context, context->GetAttr("batch_size", &batch_size));
+    OP_REQUIRES_OK(context, context->GetAttr("batch_size", &max_batch_size));
     OP_REQUIRES_OK(context, context->GetAttr("cpu_prefetch_queue_depth",
                                              &cpu_prefetch_queue_depth));
     OP_REQUIRES_OK(context, context->GetAttr("enable_memory_stats", &enable_memory_stats_));
@@ -129,14 +129,14 @@ class DaliOp : public tf::OpKernel {
     this->device_id_ = device_id;
     LOG_LINE << "Initializing...\n";
 
-    if (batch_size < 0) {
-      batch_size = shapes_[0].dim_size(0);
+    if (max_batch_size < 0) {
+      max_batch_size = shapes_[0].dim_size(0);
     }
 
     TF_DALI_CALL(daliCreatePipeline(&pipe_handle_,
                    serialized_pipeline.c_str(),
                    serialized_pipeline.length(),
-                   batch_size,
+                   max_batch_size,
                    num_threads,
                    device_id,
                    exec_separated,


### PR DESCRIPTION


### What happens in this PR:
This is a PR that prepares ground to allow iter-to-iter batch size variability in DALI. This is a situation, where a single `Pipeline` object can be ran with various batch sizes of the input data, but assuming that the batch size remains constant throughout a single iteration.
In order to allow such behaviour, I assumed that whatever user was passing up until now to the `Pipeline` ctor as the `batch_size` argument, now will denote maximum batch size which can be handled by `Pipeline`. This is not a hard assumption, meaning there are places it is not necessary to have such.

To explain what happens here, I'll firstly describe how it used to work:
`batch_size` typically was acquired in one 3 ways: from an input itself, from the field in `Operator` superclass and using `GetArgument("batch_size")` function. The first one is fine. I went through every such usage and changed the latter two:
1. I've decided whether this particular usage shall be `curr_batch_size` or `max_batch_size`. 
1. `max_batch_size` is set in the `Operator` superclass in a way the old `batch_size` was
1. For the `curr_batch_size`, I've used the new function in the workspace (`WorskpaceBase::get_batch_size(int)`, snake_case, because `GetBatchSize` is already taken; and I believe this name should be unique, in case someone in future want to implement fully variable batch size). This is a utility function, which acquires batch size from an input. 

Handling inputless operators is done in `get_batch_size` as well.

Not every operator is reworked so far. I've decided that the Decoders are too complex (please mind, that not only the rework matters, but also testing it) to be a part of this PR. The same goes for `NormalDistribution` and other random ops, which need the change in `BatchRng` to work. Those will be reworked in next PRs. 
Additionally, there are ops that aren't needed for Triton use case, which are Readers and BoxEncoder.
The ops that are not reworked still work, ofc. It's just assumed, that they always work on `max_batch_size`, therefore they won't work with anything smaller.

#### Testing
Approach to testing is described in `test_dali_variable_batch_size.py`. Please check #2481 

### Remarks
1. Operators, that are not reworked yet, assume that they always work on `max_batch_size`.
1. This PR doesn't suffice Triton use case. The operators, that are also required are `HostDecoder` and `NormalDistribution`. Reworking of these will happen in next PR(s).
1. The `SampleWorkspace` and the `get_batch_size`: generally, `SampleWorkspace` doesn't have a clue, that there exists such thing as a batch. I've added an explicit fail, if someone tries to call this function in the `SampleWorkspace`. I believe it would be incorrect to completely omit this one, since in this case the `OperatorBase`'s function would be called. Which actually might return meaningful value.


### Relevant for the reviewer:
1. The first commit retains previous behaviour, but just splits using `batch_size` into 2: `max_batch_size` and `curr_batch_size`. If you find the amount of files overwhelming, turn this one off
1. Please double-check, if I didn't miss any operator, that should be included in the variable_bs test in this PR.
Operators that are not and should not be included in this PR:
    - Readers
    - Decoders (except `AudioDecoder`)
    - Random ops
    - `transforms` module, since it doesn't really rely on batch size
    - `BoxEncoder`


#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     See above
 - Affected modules and functionalities:
     everything.
 - Key points relevant for the review:
     See section above
 - Validation and testing:
     `test_dali_variable_batch_size.py`
 - Documentation (including examples):
     j/w
