### PR TITLE
Late initialization of torch_gpu_device in pytorch plugin

### DIFF
--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -199,12 +199,14 @@ class DALIGenericIterator(_DaliBaseIterator):
             if self._data_batches[i] is None:
                 category_torch_type = dict()
                 category_device = dict()
-                torch_gpu_device = torch.device('cuda', dev_id)
+                torch_gpu_device = None
                 torch_cpu_device = torch.device('cpu')
                 # check category and device
                 for category in self._output_categories:
                     category_torch_type[category] = to_torch_type[np.dtype(category_tensors[category].dtype())]
                     if type(category_tensors[category]) is TensorGPU:
+                        if not torch_gpu_device:
+                            torch.device('cuda', dev_id)
                         category_device[category] = torch_gpu_device
                     else:
                         category_device[category] = torch_cpu_device

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -206,7 +206,7 @@ class DALIGenericIterator(_DaliBaseIterator):
                     category_torch_type[category] = to_torch_type[np.dtype(category_tensors[category].dtype())]
                     if type(category_tensors[category]) is TensorGPU:
                         if not torch_gpu_device:
-                            torch.device('cuda', dev_id)
+                            torch_gpu_device = torch.device('cuda', dev_id)
                         category_device[category] = torch_gpu_device
                     else:
                         category_device[category] = torch_cpu_device

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -16,6 +16,7 @@ from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 import nvidia.dali.tfrecord as tfrec
+from nvidia.dali.plugin.pytorch import DALIGenericIterator
 from test_utils import get_dali_extra_path, check_batch, RandomlyShapedDataIterator, dali_type
 from PIL import Image, ImageEnhance
 
@@ -676,5 +677,11 @@ def test_arithm_ops_cpu():
     pipe.build()
     for _ in range(3):
         pipe.run()
+
+def test_pytorch_plugin_cpu():
+    pipe = Pipeline(batch_size=batch_size, num_threads=3, device_id=None)
+    outs = fn.external_source(source = get_data, layout = "HWC")
+    pipe.set_outputs(outs)
+    pii = DALIGenericIterator([pipe], ["data"])
 
 # ToDo add tests for DLTensorPythonFunction if easily possible

--- a/qa/TL0_cpu_only/test.sh
+++ b/qa/TL0_cpu_only/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy>=1.17 pillow"
+pip_packages="nose numpy>=1.17 pillow torch"
 
 target_dir=./dali/test/python
 


### PR DESCRIPTION
Allows to run pytorch plugin `DALIGenericIterator` on systems without gpu.

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug where pytorch plugin couldn't  work on systems without gpu. It tried to find cuda device and failed.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Late initialization of torch_gpu_device variable, only when it is first needed.
 - Affected modules and functionalities:
    Pytorch plugin
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA


**JIRA TASK**: *[Use DALI-XXXX or NA]*
