### PR TITLE
Add TransformTranslation deprecation placeholder Op

### DIFF
--- a/dali/operators/geometry/affine_transforms/transform_translation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_translation.cc
@@ -35,13 +35,13 @@ The number of dimensions of the transform is inferred from this argument.)code",
   .NumOutput(1)
   .AddParent("TransformAttr");
 
-DALI_SCHEMA(TransformTranslation)
-  .DocStr(R"code(Produces a translation affine transform matrix.
+DALI_SCHEMA(TransformTranslation)  // Deprecated in 0.28.0dev
+  .DocStr(R"code(
+.. warning::
 
-If another transform matrix is passed as an input, the operator applies translation to the matrix provided.
+   This operator was renamed and moved to dedicated submodule.
+   Please use :class:`transforms.Translation` instead.
 
-.. note::
-    The output of this operator can be fed directly to the ``MT`` argument of ``CoordTransform`` operator.
 )code")
   .AddArg(
     "offset",
@@ -49,6 +49,7 @@ If another transform matrix is passed as an input, the operator applies translat
 
 The number of dimensions of the transform is inferred from this argument.)code",
     DALI_FLOAT_VEC, true)
+  .MakeDocHidden()
   .Deprecate("transforms.Translation")
   .NumInput(0, 1)
   .NumOutput(1)

--- a/dali/operators/geometry/affine_transforms/transform_translation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_translation.cc
@@ -35,6 +35,25 @@ The number of dimensions of the transform is inferred from this argument.)code",
   .NumOutput(1)
   .AddParent("TransformAttr");
 
+DALI_SCHEMA(TransformTranslation)
+  .DocStr(R"code(Produces a translation affine transform matrix.
+
+If another transform matrix is passed as an input, the operator applies translation to the matrix provided.
+
+.. note::
+    The output of this operator can be fed directly to the ``MT`` argument of ``CoordTransform`` operator.
+)code")
+  .AddArg(
+    "offset",
+    R"code(The translation vector.
+
+The number of dimensions of the transform is inferred from this argument.)code",
+    DALI_FLOAT_VEC, true)
+  .Deprecate("transforms.Translation")
+  .NumInput(0, 1)
+  .NumOutput(1)
+  .AddParent("TransformAttr");
+
 /**
  * @brief Translation transformation.
  */
@@ -76,5 +95,6 @@ class TransformTranslationCPU
 };
 
 DALI_REGISTER_OPERATOR(transforms__Translation, TransformTranslationCPU, CPU);
+DALI_REGISTER_OPERATOR(TransformTranslation, TransformTranslationCPU, CPU);
 
 }  // namespace dali

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -309,6 +309,14 @@ graph even if its outputs are not used.)code", false);
   }
 
   /**
+   * @brief Notes that this operator doc should not be visible (but the Op is exposed in Python API)
+   */
+  DLL_PUBLIC inline OpSchema& MakeDocHidden() {
+    is_doc_hidden_ = true;
+    return *this;
+  }
+
+  /**
    * @brief Notes that this operator is deprecated and optionally specifies the operator to be used instead
    */
   DLL_PUBLIC inline OpSchema& Deprecate(const std::string &in_favor_of) {
@@ -707,6 +715,10 @@ graph even if its outputs are not used.)code", false);
     return is_internal_;
   }
 
+  DLL_PUBLIC inline bool IsDocHidden() const {
+    return is_doc_hidden_;
+  }
+
   DLL_PUBLIC inline bool IsDeprecated() const {
     return is_deprecated_;
   }
@@ -897,6 +909,7 @@ graph even if its outputs are not used.)code", false);
   bool is_sequence_operator_ = false;
 
   bool is_internal_ = false;
+  bool is_doc_hidden_ = false;
 
   bool no_prune_ = false;
 

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1465,6 +1465,7 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("AllowsSequences", &OpSchema::AllowsSequences)
     .def("SupportsVolumetric", &OpSchema::SupportsVolumetric)
     .def("IsInternal", &OpSchema::IsInternal)
+    .def("IsDocHidden", &OpSchema::IsDocHidden)
     .def("IsNoPrune", &OpSchema::IsNoPrune)
     .def("IsDeprecated", &OpSchema::IsDeprecated)
     .def("DeprecatedInFavorOf", &OpSchema::DeprecatedInFavorOf)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -350,7 +350,9 @@ class _OperatorInstance(object):
             msg = "WARNING: `{}` is now deprecated".format(type(self._op).__name__)
             if use_instead:
                 msg +=". Use `" + use_instead + "` instead"
-            print(msg)
+            with warnings.catch_warnings():
+                warnings.simplefilter("default")
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
     def check_args(self):
         self._op.schema.CheckArgs(self._spec)
@@ -597,7 +599,8 @@ def python_op_factory(name, schema_name = None, op_device = "cpu"):
     Operator.__name__ = str(name)
     Operator.schema_name = schema_name or Operator.__name__
     # The autodoc doesn't generate doc for something that doesn't match the module name
-    if _b.GetSchema(Operator.schema_name).IsInternal():
+    schema = _b.GetSchema(Operator.schema_name)
+    if schema.IsInternal() or schema.IsDocHidden():
         Operator.__module__ = Operator.__module__ + ".internal"
 
     Operator.__call__.__doc__ = _docstring_generator_call(Operator.schema_name)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -93,7 +93,7 @@ def _docstring_generator(cls):
         use_instead = schema.DeprecatedInFavorOf()
         ret += ".. warning::\n\n   This operator is now deprecated"
         if use_instead:
-            ret +=". Use `" + use_instead + "` instead."
+            ret +=". Use :class:`" + use_instead + "` instead."
         ret += "\n\n"
 
     ret += schema.Dox()


### PR DESCRIPTION
The Op was moved to transforms module, but as it was
a part of previous release, we need to retain it for
backward compatibility.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fix backward compatibility

#### What happened in this PR? 
 - What solution was applied:
     Register the op under old name with Depracte option.
	 Added `:class:` in the deprecation message so it generates a link in the docs.
 - Affected modules and functionalities:
     transform ops
 - Key points relevant for the review:
     NA
 - Validation and testing:
     :eyes: 
 - Documentation (including examples):
     Yes


**JIRA TASK**: *[DALI-1692]*
