### PR TITLE
Bump up the CuPy to one that supports CUDA 11.0

### DIFF
--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -231,7 +231,7 @@ class CudaPackage(BasePackage):
         ----------
         `key`: str
             Name this package should be queried for
-        `versions`: str or PckgVer class object
+        `versions`: dict or PckgVer class object
             Dictionary, where the key is a cuda version and vale, is the list of versions supported
         `name`: str, , optional, default = None
             Name of this package used during installation. If empty it is the same as the key.
@@ -352,7 +352,8 @@ class CudaHttpPackage(CudaPackage):
 
 all_packages = [PlainPackage("opencv-python", ["4.4.0.42"]),
                 CudaPackage("cupy",
-                        { "100" : ["7.8.0"] },
+                        { "100" : ["8.0.0"],
+                          "110" : ["8.0.0"] },
                         "cupy-cuda{cuda_v}"),
                 CudaPackage("mxnet",
                         { "100" : ["1.7.0"] },


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It bumps up the CuPy to one that supports CUDA 11.0

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     bumps up the CuPy to one that supports CUDA 11.0
 - Affected modules and functionalities:
     setup packages
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
