### PR TITLE
Add a missing include in filesystem.cc

### DIFF
--- a/dali/operators/reader/loader/filesystem.cc
+++ b/dali/operators/reader/loader/filesystem.cc
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 #include <algorithm>
 #include <string>
+#include <cstring>
 #include <utility>
 #include <vector>
 #include "dali/operators/reader/loader/filesystem.h"


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes compilation for xavier

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a missing include in filesystem.cc
 - Affected modules and functionalities:
     filesystem.cc
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
