### PR TITLE
Add a warning about the Python function incompatibility with TensorFlow

### DIFF
--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -41,7 +41,11 @@ To synchronize the device code with DALI, synchronize DALI's work before the ope
 with the ``synchronize_stream`` flag (enabled by default) and ensure that the scheduled device
 tasks are finished in the operator call. The GPU code can be executed on the CUDA stream used
 by DALI, which can be obtained by calling the ``current_dali_stream()`` function. In this case,
-the ``synchronize_stream`` flag can be set to False.)code")
+the ``synchronize_stream`` flag can be set to False.
+
+.. warning::
+  This operator is not compatible with TensorFlow integration.
+)code")
     .AddOptionalArg("synchronize_stream",
         R"code(Ensures that DALI synchronizes its CUDA stream before calling the Python function.
 

--- a/dali/operators/python_function/python_function.cc
+++ b/dali/operators/python_function/python_function.cc
@@ -37,7 +37,11 @@ The function should not modify input tensors.
 .. warning::
   Currently, this operator can be used only in pipelines with the
   ``exec_async=False`` and ``exec_pipelined=False`` values specified and should only be
-  used for prototyping and debugging.)code")
+  used for prototyping and debugging.
+
+.. warning::
+  This operator is not compatible with TensorFlow integration.
+)code")
         .NumInput(0, 256)
         .AllowSequences()
         .SupportVolumetric()

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -178,7 +178,8 @@ Args
 `num_outputs` : int, optional
     If specified, denotes the number of TensorLists that are produced by the source function.
 
-    If set the returned output would be a list.
+    If set, the operator returns a list of ``DataNode`` objects, otherwise a single ``DataNode``
+    object is returned.
 
 Keyword Args
 ------------

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -178,6 +178,8 @@ Args
 `num_outputs` : int, optional
     If specified, denotes the number of TensorLists that are produced by the source function.
 
+    If set the returned output would be a list.
+
 Keyword Args
 ------------
 


### PR DESCRIPTION
- adds a note when num_outputs is set in the ExternalSource operator the output would be a list

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a warning about the Python function incompatibility with TensorFlow

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a warning about the Python function incompatibility with TensorFlow
     adds a note when num_outputs is set in the ExternalSource operator the output would be a list
 - Affected modules and functionalities:
     Python function family docs
     ExternalSource docs
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     docs have been updated


**JIRA TASK**: *[NA]*
