### PR TITLE
Add operators for batch reordering

### DIFF
--- a/dali/operators/generic/permute_batch.cc
+++ b/dali/operators/generic/permute_batch.cc
@@ -1,0 +1,77 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include "dali/operators/generic/permute_batch.h"
+
+namespace dali {
+
+DALI_SCHEMA(PermuteBatch)
+  .DocStr(R"(Returns a batch of tensors constructed by selecting tensors from the input based
+on indices given in ``indices`` argument::
+
+  out_tensor[i] = in_tensor[indices[i]]
+
+)")
+  .NumInput(1)
+  .NumOutput(1)
+  .AddArg("indices", R"(List of indices, matching current batch size, or a batch
+of scalars representing indices of the tensors in the input batch.
+
+The indices must be within ``[0..batch_size)`` range. Repetitions and omissions are allowed.)",
+    DALI_INT_VEC, true);
+
+void PermuteBatch<CPUBackend>::RunImpl(HostWorkspace &ws) {
+  auto &input = ws.InputRef<CPUBackend>(0);
+  auto &output = ws.OutputRef<CPUBackend>(0);
+  const auto &output_shape = output.shape();
+  output.SetLayout(input.GetLayout());
+
+  auto &tp = ws.GetThreadPool();
+  int N = indices_.size();
+  int element_size = output.type().size();
+  for (int i = 0; i < N; i++) {
+    auto size = volume(output_shape.tensor_shape_span(i)) * element_size;
+    int src = indices_[i];
+    tp.AddWork([&, i, src, size](int tid) {
+      output.SetMeta(i, input.GetMeta(i));
+      memcpy(output[i].raw_mutable_data(), input[src].raw_data(), size);
+    }, size);
+  }
+  tp.RunAll();
+}
+
+void PermuteBatch<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
+  auto &input = ws.InputRef<GPUBackend>(0);
+  auto &output = ws.OutputRef<GPUBackend>(0);
+
+  output.SetLayout(input.GetLayout());
+  int N = indices_.size();
+  for (int i = 0; i < N; i++)
+    output.SetMeta(i, input.GetMeta(i));
+
+  const auto &out_shape = output.shape();
+  int element_size = output.type().size();
+
+  for (int i = 0; i < N; i++) {
+    auto size = volume(out_shape.tensor_shape_span(i)) * element_size;
+    sg_.AddCopy(output.raw_mutable_tensor(i), input.raw_tensor(indices_[i]), size);
+  }
+  sg_.Run(ws.stream());
+}
+
+DALI_REGISTER_OPERATOR(PermuteBatch, PermuteBatch<CPUBackend>, CPU);
+DALI_REGISTER_OPERATOR(PermuteBatch, PermuteBatch<GPUBackend>, GPU);
+
+}  // namespace dali

--- a/dali/operators/generic/permute_batch.h
+++ b/dali/operators/generic/permute_batch.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_GENERIC_PERMUTE_BATCH_H_
+#define DALI_OPERATORS_GENERIC_PERMUTE_BATCH_H_
+
+#include <vector>
+#include "dali/pipeline/operator/operator.h"
+#include "dali/kernels/common/scatter_gather.h"
+
+namespace dali {
+
+template <typename Backend>
+class PermuteBatchBase : public Operator<Backend> {
+ public:
+  explicit PermuteBatchBase(const OpSpec &spec) : Operator<Backend>(spec) {}
+
+  bool SetupImpl(vector<OutputDesc> &outputs, const workspace_t<Backend> &ws) override {
+    outputs.resize(1);
+    auto &input = ws.template InputRef<Backend>(0);
+    const auto &in_shape = input.shape();
+    outputs[0].type = input.type();
+    GetPerSampleArgument<int>(indices_, "indices", this->spec_, ws);
+    auto &out_shape = outputs[0].shape;
+    int D = in_shape.sample_dim();
+    out_shape.resize(indices_.size(), D);
+    for (int i = 0; i < out_shape.num_samples(); i++) {
+      auto out_ts = out_shape.tensor_shape_span(i);
+      DALI_ENFORCE(indices_[i] >= 0 && indices_[i] < in_shape.num_samples(), make_string(
+        "Sample index out of range. indices[", i, "] = ", indices_[i], " is not a valid index for "
+        "an input batch of ", in_shape.num_samples(), " tensors."));
+      auto in_ts = in_shape.tensor_shape_span(indices_[i]);
+      for (int d = 0; d < D; d++)
+        out_ts[d] = in_ts[d];
+    }
+    return true;
+  }
+
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
+
+ protected:
+  vector<int> indices_;
+};
+
+template <class Backend>
+class PermuteBatch;
+
+template <>
+class PermuteBatch<CPUBackend> : public PermuteBatchBase<CPUBackend> {
+ public:
+  using PermuteBatchBase::PermuteBatchBase;
+
+  void RunImpl(HostWorkspace &ws) override;
+};
+
+template <>
+class PermuteBatch<GPUBackend> : public PermuteBatchBase<GPUBackend> {
+ public:
+  explicit PermuteBatch(const OpSpec &spec)
+  : PermuteBatchBase<GPUBackend>(spec)
+  , sg_(1<<18, spec.GetArgument<int>("batch_size")) {}
+
+
+  void RunImpl(DeviceWorkspace &ws) override;
+
+ private:
+  kernels::ScatterGatherGPU sg_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_GENERIC_PERMUTE_BATCH_H_

--- a/dali/operators/random/batch_permutation.cc
+++ b/dali/operators/random/batch_permutation.cc
@@ -1,0 +1,62 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <random>
+#include <vector>
+#include "dali/operators/random/batch_permutation.h"
+
+namespace dali {
+
+DALI_SCHEMA(BatchPermutation)
+  .DocStr(R"(Produces a batch of random integers which can be used as indices for
+indexing samples in the batch.)")
+  .NumInput(0)
+  .NumOutput(1)
+  .AddOptionalArg("allow_repetitions",
+      R"(If true, the output can contain repetitions and omissions.)", false);
+
+void BatchPermutation::NoRepetitions(int N) {
+  tmp_out_.resize(N);
+  std::iota(tmp_out_.begin(), tmp_out_.end(), 0);
+  std::shuffle(tmp_out_.begin(), tmp_out_.end(), rng_);
+}
+
+void BatchPermutation::WithRepetitions(int N) {
+  std::uniform_int_distribution<int> dis(0, N-1);
+  tmp_out_.resize(N);
+  for (auto &x : tmp_out_)
+    x = dis(rng_);
+}
+
+void BatchPermutation::RunImpl(HostWorkspace &ws) {
+  auto &output = ws.OutputRef<CPUBackend>(0);
+  int N = GetBatchSize(ws);
+  if (N < 1)
+    return;
+  auto out_view = view<int, 0>(output);
+
+  if (spec_.GetArgument<bool>("allow_repetitions"))
+    WithRepetitions(N);
+  else
+    NoRepetitions(N);
+  for (int i = 0; i < N; ++i) {
+    out_view.data[i][0] = tmp_out_[i];
+  }
+}
+
+DALI_REGISTER_OPERATOR(BatchPermutation, BatchPermutation, CPU);
+
+}  // namespace dali
+

--- a/dali/operators/random/batch_permutation.h
+++ b/dali/operators/random/batch_permutation.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_RANDOM_BATCH_PERMUTATION_H_
+#define DALI_OPERATORS_RANDOM_BATCH_PERMUTATION_H_
+
+#include <random>
+#include <vector>
+#include "dali/pipeline/operator/operator.h"
+
+namespace dali {
+
+class BatchPermutation : public Operator<CPUBackend> {
+ public:
+  explicit BatchPermutation(const OpSpec &spec)
+  : Operator<CPUBackend>(spec), rng_(spec.GetArgument<int64_t>("seed")) {}
+
+  int GetBatchSize(const HostWorkspace &) {
+    return spec_.GetArgument<int>("batch_size");
+  }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
+    output_desc.resize(1);
+    output_desc[0].shape = TensorListShape<0>(GetBatchSize(ws));
+    output_desc[0].type = TypeTable::GetTypeInfo(DALI_INT32);
+    return true;
+  }
+  void RunImpl(HostWorkspace &ws) override;
+  bool CanInferOutputs() const override { return true; }
+ private:
+  void NoRepetitions(int N);
+  void WithRepetitions(int N);
+  std::mt19937_64 rng_;
+  vector<int> tmp_out_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_RANDOM_BATCH_PERMUTATION_H_

--- a/dali/test/python/test_operator_batch_permute.py
+++ b/dali/test/python/test_operator_batch_permute.py
@@ -1,0 +1,53 @@
+import nvidia.dali as dali
+import nvidia.dali.fn as fn
+from nvidia.dali.pipeline import Pipeline
+import numpy as np
+from test_utils import check_batch
+
+def _test_permutation_generator(allow_repetitions):
+    batch_size = 10
+    pipe = Pipeline(batch_size, 1, None)
+    perm = fn.batch_permutation(allow_repetitions=allow_repetitions)
+    pipe.set_outputs(perm)
+
+    pipe.build()
+    idxs, = pipe.run()
+    for i in range(batch_size):
+        assert idxs.at(i).shape == ()
+    idxs = [int(idxs.at(i)) for i in range(batch_size)]
+    if allow_repetitions:
+        assert all(x >= 0 and x < batch_size for x in idxs)
+    else:
+        assert list(sorted(idxs)) == list(range(batch_size))
+
+def test_permutation_generator():
+    for allow_repetitions in [None, False, True]:
+        yield _test_permutation_generator, allow_repetitions
+
+def random_sample():
+    shape = np.random.randint(1, 50, [3])
+    return np.random.randint(-1000000, 1000000, shape)
+
+def gen_data(batch_size, type):
+    return [random_sample().astype(type) for _ in range(batch_size)]
+
+def _test_permute_batch(device, type):
+    batch_size = 10
+    pipe = Pipeline(batch_size, 4, 0)
+    data = fn.external_source(source=lambda: gen_data(batch_size, type), device=device, layout="abc")
+    perm = fn.batch_permutation()
+    pipe.set_outputs(data, fn.permute_batch(data, indices=perm), perm)
+    pipe.build()
+
+    for i in range(10):
+        orig, permuted, idxs = pipe.run()
+        idxs = [int(idxs.at(i)) for i in range(batch_size)]
+        if isinstance(orig, dali.backend.TensorListGPU):
+            orig = orig.as_cpu()
+        ref = [orig.at(idx) for idx in idxs]
+        check_batch(permuted, ref, len(ref), 0, 0, "abc")
+
+def test_permute_batch():
+    for type in [np.uint8, np.int16, np.uint32, np.int64, np.float32]:
+        for device in ["cpu", "gpu"]:
+            yield _test_permute_batch, device, type


### PR DESCRIPTION
- BatchPermutation - obtains random indices of samples
- PermuteBatch - reorders tensors within a batch according to given list of indices.

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed for mosaicing, soft-labels, etc

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * BatchPermutation operator - generate a batch of scalars ranged from 0 to batch_size-1
     * PermuteBatch operator - copies tensors from input at given index
 - Affected modules and functionalities:
     * N/A
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python test
 - Documentation (including examples):
     * Docstrings, no examples.

**JIRA TASK**: DALI-1706
