### PR TITLE
Update clang to 10.0

### DIFF
--- a/dali/operators/image/color/brightness_contrast.h
+++ b/dali/operators/image/color/brightness_contrast.h
@@ -34,7 +34,7 @@ namespace detail {
 template <typename T>
 constexpr float FullRange() {
   return std::is_integral<T>::value
-    ? std::numeric_limits<T>::max()
+    ? static_cast<float>(std::numeric_limits<T>::max())
     : 1.0f;
 }
 

--- a/dali/operators/image/resize/resize_attr.cc
+++ b/dali/operators/image/resize/resize_attr.cc
@@ -216,7 +216,8 @@ void ResizeAttr::PrepareResizeParams(const OpSpec &spec, const ArgumentWorkspace
     GetShapeLikeArgument<float>(size_arg_, spec, "size", ws, spatial_ndim_, N);
   }
 
-  max_size_.resize(spatial_ndim_, static_cast<float>(std::numeric_limits<int>::max()));
+  max_size_.resize(spatial_ndim_,
+                   std::nextafter(static_cast<float>(std::numeric_limits<int>::max()), 0.0f));
   if (has_max_size_) {
     GetSingleOrRepeatedArg(spec, max_size_, "max_size", spatial_ndim_);
   }

--- a/dali/operators/image/resize/resize_attr.cc
+++ b/dali/operators/image/resize/resize_attr.cc
@@ -216,7 +216,7 @@ void ResizeAttr::PrepareResizeParams(const OpSpec &spec, const ArgumentWorkspace
     GetShapeLikeArgument<float>(size_arg_, spec, "size", ws, spatial_ndim_, N);
   }
 
-  max_size_.resize(spatial_ndim_, std::numeric_limits<int>::max());
+  max_size_.resize(spatial_ndim_, static_cast<float>(std::numeric_limits<int>::max()));
   if (has_max_size_) {
     GetSingleOrRepeatedArg(spec, max_size_, "max_size", spatial_ndim_);
   }

--- a/dali/operators/math/expressions/expression_impl_factory.h
+++ b/dali/operators/math/expressions/expression_impl_factory.h
@@ -79,10 +79,12 @@ DALI_HOST_DEV std::enable_if_t<as_ptr, const void*> Pass(const void* ptr, DALIDa
  */
 template <bool as_ptr, typename T>
 DALI_HOST_DEV std::enable_if_t<!as_ptr, T> Pass(const void* ptr, DALIDataType type_id) {
+  T result = {};
   TYPE_SWITCH(type_id, type2id, AccessType, ARITHMETIC_ALLOWED_TYPES, (
     const auto *access = reinterpret_cast<const AccessType*>(ptr);
     return static_cast<T>(*access);
-  ), return {}; );  // NOLINT(whitespace/parens)
+  ), );  // NOLINT(whitespace/parens)
+  return result;
 }
 
 template <typename T>
@@ -97,10 +99,12 @@ DALI_HOST_DEV T Access(T value, int64_t) {
 
 template <typename T>
 DALI_HOST_DEV T Access(const void* ptr, int64_t idx, DALIDataType type_id) {
+  T result = {};
   TYPE_SWITCH(type_id, type2id, AccessType, ARITHMETIC_ALLOWED_TYPES, (
     const auto *access = reinterpret_cast<const AccessType*>(ptr);
     return static_cast<T>(access[idx]);
-  ), return {}; );  // NOLINT(whitespace/parens)
+  ), );  // NOLINT(whitespace/parens)
+  return result;
 }
 
 template <typename T>

--- a/dali/operators/math/expressions/expression_impl_factory.h
+++ b/dali/operators/math/expressions/expression_impl_factory.h
@@ -79,11 +79,11 @@ DALI_HOST_DEV std::enable_if_t<as_ptr, const void*> Pass(const void* ptr, DALIDa
  */
 template <bool as_ptr, typename T>
 DALI_HOST_DEV std::enable_if_t<!as_ptr, T> Pass(const void* ptr, DALIDataType type_id) {
-  T result = {};
+  T result;
   TYPE_SWITCH(type_id, type2id, AccessType, ARITHMETIC_ALLOWED_TYPES, (
     const auto *access = reinterpret_cast<const AccessType*>(ptr);
-    return static_cast<T>(*access);
-  ), );  // NOLINT(whitespace/parens)
+    result = static_cast<T>(*access);
+  ), result = {};);  // NOLINT(whitespace/parens)
   return result;
 }
 
@@ -99,11 +99,11 @@ DALI_HOST_DEV T Access(T value, int64_t) {
 
 template <typename T>
 DALI_HOST_DEV T Access(const void* ptr, int64_t idx, DALIDataType type_id) {
-  T result = {};
+  T result;
   TYPE_SWITCH(type_id, type2id, AccessType, ARITHMETIC_ALLOWED_TYPES, (
     const auto *access = reinterpret_cast<const AccessType*>(ptr);
-    return static_cast<T>(access[idx]);
-  ), );  // NOLINT(whitespace/parens)
+    result = static_cast<T>(access[idx]);
+  ), result = {};);  // NOLINT(whitespace/parens)
   return result;
 }
 

--- a/dali/pipeline/proto/dali_proto_intern.cc
+++ b/dali/pipeline/proto/dali_proto_intern.cc
@@ -76,7 +76,7 @@ namespace dali {
   }
 
   std::vector<int64> DaliProtoPriv::ints(void) const {
-    std::vector<int64> tmp{intern_->ints().begin(), intern_->ints().end()};
+    std::vector<int64> tmp(intern_->ints().begin(), intern_->ints().end());
     return tmp;
   }
 
@@ -85,7 +85,7 @@ namespace dali {
   }
 
   std::vector<float> DaliProtoPriv::floats(void) const {
-    std::vector<float> tmp{intern_->floats().begin(), intern_->floats().end()};
+    std::vector<float> tmp(intern_->floats().begin(), intern_->floats().end());
     return tmp;
   }
 
@@ -94,7 +94,7 @@ namespace dali {
   }
 
   std::vector<bool> DaliProtoPriv::bools(void) const {
-    std::vector<bool> tmp{intern_->bools().begin(), intern_->bools().end()};
+    std::vector<bool> tmp(intern_->bools().begin(), intern_->bools().end());
     return tmp;
   }
 
@@ -103,7 +103,7 @@ namespace dali {
   }
 
   std::vector<string> DaliProtoPriv::strings(void) const {
-    std::vector<string> tmp{intern_->strings().begin(), intern_->strings().end()};
+    std::vector<string> tmp(intern_->strings().begin(), intern_->strings().end());
     return tmp;
   }
 

--- a/dali/test/dali_operator_test.h
+++ b/dali/test/dali_operator_test.h
@@ -78,7 +78,7 @@ inline std::ostream& operator<<(std::ostream& os, const Arguments& args) {
     indent = "    ";
   }
 
-  for (const auto arg : args) {
+  for (const auto &arg : args) {
     os << indent << "\"" << arg.first << "\" : " << arg.second << separator;
   }
 

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -115,10 +115,11 @@ RUN OPENCV_VERSION=4.4.0 && \
     rm -rf /opencv-${OPENCV_VERSION}
 
 # Clang
-RUN cd /usr/local && \
-    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-sles11.3.tar.xz && \
-    tar -xJf clang+llvm-10.0.0-x86_64-linux-sles11.3.tar.xz --strip 1 && \
-    rm clang+llvm-10.0.0-x86_64-linux-sles11.3.tar.xz
+RUN CLANG_VERSION=10.0.0 && \
+    cd /usr/local && \
+    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
+    tar -xJf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --strip 1 && \
+    rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
 
 ENV NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
 

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -115,11 +115,10 @@ RUN OPENCV_VERSION=4.4.0 && \
     rm -rf /opencv-${OPENCV_VERSION}
 
 # Clang
-RUN CLANG_VERSION=8.0.1 && \
-    cd /usr/local && \
-    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
-    tar -xJf clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz --strip 1 && \
-    rm clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz
+RUN cd /usr/local && \
+    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-sles11.3.tar.xz && \
+    tar -xJf clang+llvm-10.0.0-x86_64-linux-sles11.3.tar.xz --strip 1 && \
+    rm clang+llvm-10.0.0-x86_64-linux-sles11.3.tar.xz
 
 ENV NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
 

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -85,8 +85,8 @@ DALI_HOST_DEV constexpr std::enable_if_t<
     needs_clamp<U, T>::value && std::is_signed<U>::value && std::is_signed<T>::value,
     T>
 clamp(U value, ret_type<T>) {
-  return value <= min_value<T>() ? min_value<T>() :
-         value >= max_value<T>() ? max_value<T>() :
+  return value <= static_cast<U>(min_value<T>()) ? min_value<T>() :
+         value >= static_cast<U>(max_value<T>()) ? max_value<T>() :
          static_cast<T>(value);
 }
 
@@ -96,8 +96,8 @@ DALI_HOST_DEV constexpr std::enable_if_t<
         && std::is_unsigned<T>::value,
     T>
 clamp(U value, ret_type<T>) {
-  return value <= min_value<T>() ? min_value<T>() :
-         value >= max_value<T>() ? max_value<T>() :
+  return value <= static_cast<U>(min_value<T>()) ? min_value<T>() :
+         value >= static_cast<U>(max_value<T>()) ? max_value<T>() :
          static_cast<T>(value);
 }
 
@@ -333,7 +333,7 @@ struct ConverterBase<Out, In, false, true> {
       ? clamp<Out>(detail::cuda_round_helper(value * max_value<Out>(), Out()))
       : detail::cuda_round_helper(max_value<Out>() * __saturatef(value), Out());
 #else
-    return clamp<Out>(std::round(value * max_value<Out>()));
+    return clamp<Out>(std::round(value * static_cast<In>(max_value<Out>())));
 #endif
   }
 };


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Update to newer clang in deps to use the newest clang that's works with the build image.
11.0 requires newer libc.

#### What happened in this PR? 
 - What solution was applied:
     Update deps
 - Affected modules and functionalities:
     Docker
 - Key points relevant for the review:
      
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[Use DALI-XXXX or NA]*
