### PR TITLE
Pad operator: Add support for per-sample shape and alignment requirements

### DIFF
--- a/dali/core/tensor_shape_test.cc
+++ b/dali/core/tensor_shape_test.cc
@@ -463,6 +463,23 @@ TEST(TensorShapeTest, ConcatenationMixed) {
             TensorShape<DynamicDimensions>(1, 2, 1, 2, 3));
 }
 
+TEST(TensorShapeTest, ConstructorFromIntegerCollection) {
+  TensorShape<> ref{1, 2, 3, 4, 5};
+  std::vector<int> vec_i{1, 2, 3, 4, 5};
+
+  EXPECT_EQ(ref, TensorShape<>(vec_i));
+  EXPECT_EQ(ref, TensorShape<>(vec_i.begin(), vec_i.end()));
+  TensorShape<> sh1;
+  sh1 = vec_i;
+  EXPECT_EQ(ref, sh1);
+
+  EXPECT_EQ(ref, TensorShape<5>(vec_i));
+  EXPECT_EQ(ref, TensorShape<5>(vec_i.begin(), vec_i.end()));
+  TensorShape<5> sh2;
+  sh2 = vec_i;
+  EXPECT_EQ(ref, sh2);
+}
+
 TEST(VolumeTest, Result) {
   EXPECT_EQ(volume(std::vector<int64_t>{}), 1);
   EXPECT_EQ(volume(std::vector<int64_t>{2}), 2);

--- a/dali/core/tensor_shape_test.cu
+++ b/dali/core/tensor_shape_test.cu
@@ -101,3 +101,30 @@ TEST(TensorShapeDev, KernelArg) {
   dali::TensorShape<4> a = { 2, 3, 4, 5 };
   DEVICE_TEST_CASE_BODY(TensorShapeDev, KernelArg, 1, 4, a);
 }
+
+
+TEST(TensorShapeDev, ConstructorFromIntegerCollectionHost) {
+  using dali::TensorShape;
+  using dali::DeviceArray;
+  TensorShape<5> ref{1, 2, 3, 4, 5};
+  DeviceArray<int, 5> vec_i{1, 2, 3, 4, 5};
+
+  EXPECT_EQ(ref, TensorShape<5>(vec_i));
+  EXPECT_EQ(ref, TensorShape<5>(vec_i.begin(), vec_i.end()));
+  TensorShape<5> sh;
+  sh = vec_i;
+  EXPECT_EQ(ref, sh);
+}
+
+DEVICE_TEST(TensorShapeDev, ConstructorFromIntegerCollectionDevice, 1, 1) {
+  using dali::TensorShape;
+  using dali::DeviceArray;
+  TensorShape<5> ref{1, 2, 3, 4, 5};
+  DeviceArray<int, 5> vec_i{1, 2, 3, 4, 5};
+
+  DEV_EXPECT_EQ(ref, TensorShape<5>(vec_i));
+  DEV_EXPECT_EQ(ref, TensorShape<5>(vec_i.begin(), vec_i.end()));
+  TensorShape<5> sh;
+  sh = vec_i;
+  DEV_EXPECT_EQ(ref, sh);
+}

--- a/dali/operators/generic/pad.cc
+++ b/dali/operators/generic/pad.cc
@@ -170,7 +170,7 @@ If an integer value is provided, the alignment restrictions are applied to all t
 
 To use alignment only, that is without any default or explicit padding behavior,
 set the minimum ``shape`` to 1 for the specified axis.)code",
-    std::vector<int>())
+    std::vector<int>(), true)
   .AddOptionalArg<int>("shape",
     R"code(The extents of the output shape in the axes specified by the ``axes`` or ``axis_names``.
 
@@ -180,7 +180,7 @@ the aligned size of the largest sample in the batch.
 If the provided extent is smaller than the one of the samples, padding will be applied
 only to match the required alignment. For example, to disable padding in an axis, except
 for the necessary for alignment, you can specify a value of 1.)code",
-    vector<int>());
+    std::vector<int>(), true);
 
 template <>
 bool Pad<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
@@ -192,6 +192,8 @@ bool Pad<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
   int ndim = in_shape.sample_dim();
   int nsamples = in_shape.num_samples();
   auto nthreads = ws.GetThreadPool().size();
+
+  ReadArguments(spec_, ws);
 
   TYPE_SWITCH(input.type().id(), type2id, T, PAD_SUPPORTED_TYPES, (
     VALUE_SWITCH(ndim, Dims, PAD_SUPPORTED_NDIMS, (

--- a/dali/operators/generic/pad.cu
+++ b/dali/operators/generic/pad.cu
@@ -31,6 +31,8 @@ bool Pad<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
   int ndim = in_shape.sample_dim();
   int nsamples = in_shape.num_samples();
 
+  this->ReadArguments(spec_, ws);
+
   TYPE_SWITCH(input.type().id(), type2id, T, PAD_SUPPORTED_TYPES, (
     VALUE_SWITCH(ndim, Dims, PAD_SUPPORTED_NDIMS, (
       using Kernel = kernels::SliceGPU<T, T, Dims>;

--- a/dali/operators/generic/pad.h
+++ b/dali/operators/generic/pad.h
@@ -60,30 +60,6 @@ class Pad : public Operator<Backend> {
   }
 
  private:
-  void ReadShapeListArg(std::vector<TensorShape<>> &out, const std::string &arg_name,
-                        const OpSpec &spec, const ArgumentWorkspace &ws,
-                        int nsamples) {
-    out.clear();
-    out.resize(nsamples);
-    if (spec.HasTensorArgument(arg_name)) {
-      auto &arg_in = ws.ArgumentInput(arg_name);
-      DALI_ENFORCE(nsamples == static_cast<int>(arg_in.size()),
-        make_string("Expected ", nsamples, ", got ", arg_in.size()));
-      int nsamples = arg_in.size();
-      auto arg_view = view<const int>(arg_in);
-      for (int i = 0; i < nsamples; i++) {
-        out[i] = TensorShape<>(make_cspan(arg_view[i].data, arg_view[i].shape[0]));
-      }
-    } else if (spec.HasArgument(arg_name)) {
-      auto arg = spec.GetRepeatedArgument<int>(arg_name);
-      TensorShape<> sh(make_cspan(arg));
-      for (int i = 0; i < nsamples; i++) {
-        out[i] = sh;
-      }
-    }
-    assert(static_cast<int>(out.size()) == nsamples);
-  }
-
   void ReadArguments(const OpSpec &spec, const workspace_t<Backend> &ws) {
     const auto &input = ws.template InputRef<Backend>(0);
     auto in_shape = input.shape();
@@ -106,23 +82,20 @@ class Pad : public Operator<Backend> {
       std::iota(axes_.begin(), axes_.end(), 0);
     }
 
-    ReadShapeListArg(shape_, "shape", spec, ws, nsamples);
-    ReadShapeListArg(align_, "align", spec, ws, nsamples);
+    GetShapeArgument(shape_, spec_, "shape", ws);
+    GetShapeArgument(align_, spec_, "align", ws);
+
+    if (shape_.empty())
+      shape_ = uniform_list_shape(nsamples, TensorShape<>(std::vector<int64_t>(axes_.size(), -1)));
 
     // If a single *align* value is provided, use this value for all the axes
     for (int i = 0; i < nsamples; i++) {
-      auto &align = align_[i];
-      for (auto &a : align) {
-        DALI_ENFORCE(a > 0, "Values of `align` argument must be positive.");
+      if (!align_.empty()) {
+        for (auto &a : align_.tensor_shape_span(i)) {
+          DALI_ENFORCE(a > 0, "Values of `align` argument must be positive.");
+        }
       }
-      if (align.size() == 1 && axes_.size() > 1) {
-        align = std::vector<int64_t>(axes_.size(), align[0]);
-      }
-      auto &shape = shape_[i];
-      // If no shape arg is provided, mark all axis as -1 (automatic shape)
-      if (shape.empty()) {
-        shape = std::vector<int64_t>(axes_.size(), -1);
-      }
+      auto shape = shape_.tensor_shape_span(i);
       DALI_ENFORCE(
           static_cast<int>(axes_.size()) == shape.size(),
           make_string(
@@ -166,8 +139,7 @@ class Pad : public Operator<Backend> {
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
       auto &sample_args = kernel_sample_args[sample_idx];
       const auto &sample_shape = in_shape.tensor_shape_span(sample_idx);
-      const auto &req_shape = shape_[sample_idx];
-      const auto &req_align = align_[sample_idx];
+      auto req_shape = shape_.tensor_shape_span(sample_idx);
       for (int d = 0; d < sample_args.anchor.size(); d++) {
         sample_args.anchor[d] = 0;
         sample_args.shape[d] = sample_shape[d];
@@ -176,18 +148,21 @@ class Pad : public Operator<Backend> {
       sample_args.fill_values[0] = fill_value_;
 
       for (int i = 0; i < naxes; i++) {
+        auto req_extent = req_shape[i];
         auto axis = axes_[i];
         auto &extent = sample_args.shape[axis];
         // Adjust padded extent only if it is bigger than the sample's extent
         // That is, we are not cropping the image
-        if (req_shape[axis] > 0) {  // explicitly requested padded shape
-          extent = std::max(req_shape[axis], extent);
+        if (req_extent > 0) {  // explicitly requested padded shape
+          extent = std::max(req_extent, extent);
         } else {  // pad to largest
           extent = std::max(largest_shape[axis], extent);
         }
         // Adjust alignment if required
-        if (!req_align.empty())
-          extent = aligned_extent(extent, req_align[i]);
+        if (!align_.empty() && !align_.tensor_shape_span(sample_idx).empty()) {
+          auto align = align_.tensor_shape_span(sample_idx);
+          extent = aligned_extent(extent, align.size() == 1 ? align[0] : align[i]);
+        }
       }
     }
 
@@ -197,8 +172,8 @@ class Pad : public Operator<Backend> {
   float fill_value_;
   TensorLayout axis_names_;
   std::vector<int> axes_;
-  std::vector<TensorShape<>> align_;
-  std::vector<TensorShape<>> shape_;
+  TensorListShape<> align_;
+  TensorListShape<> shape_;
   kernels::KernelManager kmgr_;
   any kernel_sample_args_;
 

--- a/dali/operators/generic/pad.h
+++ b/dali/operators/generic/pad.h
@@ -82,12 +82,13 @@ class Pad : public Operator<Backend> {
       std::iota(axes_.begin(), axes_.end(), 0);
     }
 
-    GetShapeArgument(shape_, spec_, "shape", ws);
-    GetShapeArgument(align_, spec_, "align", ws);
+    if (spec_.ArgumentDefined("shape"))
+      GetShapeArgument(shape_, spec_, "shape", ws);
+    if (spec_.ArgumentDefined("align"))
+      GetShapeArgument(align_, spec_, "align", ws);
 
     if (shape_.empty())
       shape_ = uniform_list_shape(nsamples, TensorShape<>(std::vector<int64_t>(axes_.size(), -1)));
-
     // If a single *align* value is provided, use this value for all the axes
     for (int i = 0; i < nsamples; i++) {
       if (!align_.empty()) {
@@ -96,8 +97,7 @@ class Pad : public Operator<Backend> {
         }
       }
       auto shape = shape_.tensor_shape_span(i);
-      DALI_ENFORCE(
-          static_cast<int>(axes_.size()) == shape.size(),
+      DALI_ENFORCE(static_cast<int>(axes_.size()) == shape.size(),
           make_string(
               "If explicit shape is provided, there should be a value per axis to be padded. "
               "Expected ",

--- a/dali/operators/random/uniform.cc
+++ b/dali/operators/random/uniform.cc
@@ -75,7 +75,7 @@ This argument is mutually exclusive with ``values``.
 This argument is mutually exclusive with ``range``.
 )code", std::vector<float>({}))
   .AddOptionalArg("shape",
-    R"code(Shape of the samples.)code", std::vector<int>{1}, true);
+    R"code(Shape of the samples.)code", std::vector<int>{}, true);
 
 
 }  // namespace dali

--- a/dali/operators/random/uniform.cc
+++ b/dali/operators/random/uniform.cc
@@ -75,7 +75,7 @@ This argument is mutually exclusive with ``values``.
 This argument is mutually exclusive with ``range``.
 )code", std::vector<float>({}))
   .AddOptionalArg("shape",
-    R"code(Shape of the samples.)code", std::vector<int>{1});
+    R"code(Shape of the samples.)code", std::vector<int>{1}, true);
 
 
 }  // namespace dali

--- a/dali/operators/random/uniform.h
+++ b/dali/operators/random/uniform.h
@@ -61,7 +61,7 @@ class Uniform : public Operator<CPUBackend> {
     if (spec_.ArgumentDefined("shape")) {
       GetShapeArgument(output_desc[0].shape, spec_, "shape", ws, -1, batch_size_);
     } else {
-      output_desc[0].shape = uniform_list_shape(batch_size_, TensorShape<>{1});
+      output_desc[0].shape = uniform_list_shape(batch_size_, TensorShape<0>());
     }
     return true;
   }

--- a/dali/pipeline/operator/common.h
+++ b/dali/pipeline/operator/common.h
@@ -99,7 +99,7 @@ void GetPerSampleArgument(std::vector<T> &output,
  * TODO(klecki): we may want to make this a generic utility and propagate the span-approach to
  * the rest of the related argument gettters
  *
- * TODO(michalz): rework it somehow to avoig going through this logic for each sample
+ * TODO(michalz): rework it somehow to avoid going through this logic for each sample
  */
 template <typename T>
 void GetGeneralizedArg(span<T> result, const std::string name, int sample_idx, const OpSpec& spec,
@@ -207,8 +207,9 @@ int GetShapeArgument(TensorListShape<out_ndim> &out_tls,
                       const ArgumentWorkspace &ws,
                       int ndim = out_ndim,
                       int batch_size = -1 /* -1 = get from "batch_size" arg */) {
-  ndim = GetShapeLikeArgument<ArgumentType>(out_tls.shape, spec, argument_name, ndim, batch_size);
-  out_tls.resize(out_tls.shape().num_samples / ndim, ndim);
+  ndim = GetShapeLikeArgument<ArgumentType>(out_tls.shapes, spec, argument_name,
+                                            ws, ndim, batch_size);
+  out_tls.resize(ndim == 0 ? 0 : out_tls.shapes.size() / ndim, ndim);
   return ndim;
 }
 

--- a/dali/pipeline/operator/common_test.cc
+++ b/dali/pipeline/operator/common_test.cc
@@ -27,7 +27,8 @@ TEST(PipelineCommon, GetShapeLikeArgumentScalar) {
   ArgumentWorkspace ws;
   spec.AddArg("size", 1.5f);
   vector<float> shape;
-  int D = GetShapeLikeArgument<float>(shape, spec, "size", ws, 3, 5);
+  int nsamples, D;
+  std::tie(nsamples, D) = GetShapeLikeArgument<float>(shape, spec, "size", ws, 3, 5);
   EXPECT_EQ(D, 3);
   ASSERT_EQ(shape.size(), 15);
   for (size_t i = 0; i < 15; i++) {
@@ -44,7 +45,8 @@ TEST(PipelineCommon, GetShapeLikeArgumentVector) {
   spec.SetArg("batch_size", 3);
 
   vector<float> shape;
-  int D = GetShapeLikeArgument<float>(shape, spec, "size", ws);
+  int nsamples, D;
+  std::tie(nsamples, D) = GetShapeLikeArgument<float>(shape, spec, "size", ws);
   EXPECT_EQ(D, 4);
   ASSERT_EQ(shape.size(), 12);
   for (int i = 0; i < 3; i++) {
@@ -56,7 +58,7 @@ TEST(PipelineCommon, GetShapeLikeArgumentVector) {
   vector<int> ishape;
   spec.SetArg("size", src_shape);
   spec.SetArg("batch_size", 3);
-  D = GetShapeLikeArgument<float>(ishape, spec, "size", ws);
+  std::tie(nsamples, D) = GetShapeLikeArgument<float>(ishape, spec, "size", ws);
   EXPECT_EQ(D, 4);
   ASSERT_EQ(shape.size(), 12);
   for (int i = 0; i < 3; i++) {
@@ -84,8 +86,8 @@ TEST(PipelineCommon, GetShapeLikeArgumentInput) {
   ws.AddArgumentInput("size", input);
 
   vector<float> shape;
-
-  int out_d = GetShapeLikeArgument<float>(shape, spec, "size", ws, -1, -1);
+  int nsamples, out_d;
+  std::tie(nsamples, out_d) = GetShapeLikeArgument<float>(shape, spec, "size", ws, -1, -1);
   EXPECT_EQ(out_d, D) << "Dimensionality should match the size of the tensors in the list.";
   ASSERT_EQ(shape.size(), N * D) << "Total size of the shape should be batch x ndim";
   for (int i = 0; i < N; i++) {
@@ -106,7 +108,7 @@ TEST(PipelineCommon, GetShapeLikeArgumentInput) {
   ws.AddArgumentInput("size", input);
 
   vector<int> ishape;
-  out_d = GetShapeLikeArgument<float>(ishape, spec, "size", ws, D, -1);
+  std::tie(nsamples, out_d) = GetShapeLikeArgument<float>(ishape, spec, "size", ws, D, -1);
   EXPECT_EQ(out_d, D) << "A list of scalars can be broadcast to any number of dimensions.";
   ASSERT_EQ(shape.size(), N * D) << "Total size of the shape should be batch x ndim";
   for (int i = 0; i < N; i++) {
@@ -116,7 +118,7 @@ TEST(PipelineCommon, GetShapeLikeArgumentInput) {
 
   shape.clear();
   // if the extent is not know, a list of scalars indicates 1D shapes
-  out_d = GetShapeLikeArgument<float>(shape, spec, "size", ws, -1, -1);
+  std::tie(nsamples, out_d) = GetShapeLikeArgument<float>(shape, spec, "size", ws, -1, -1);
   EXPECT_EQ(out_d, 1) << "A list of scalars should be interpreted as a 1D shape";
   D = 1;
   ASSERT_EQ(shape.size(), N * D) << "Total size of the shape should be batch x ndim";

--- a/dali/test/python/test_operator_pad.py
+++ b/dali/test/python/test_operator_pad.py
@@ -14,6 +14,7 @@
 
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
+import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 import nvidia.dali as dali
 from nvidia.dali.backend_impl import TensorListGPU
@@ -46,7 +47,7 @@ class PadSynthDataPipeline(Pipeline):
         self.feed_input(self.data, data, layout=self.layout)
 
 
-def check_pad_synth_data(device, batch_size, input_max_shape, axes, axis_names, align, shape_arg):
+def check_pad(device, batch_size, input_max_shape, axes, axis_names, align, shape_arg):
     eii = RandomlyShapedDataIterator(batch_size, max_shape=input_max_shape)
     layout = "HWC"
     pipe = PadSynthDataPipeline(device, batch_size, iter(eii), axes=axes, axis_names=axis_names,
@@ -107,7 +108,7 @@ def check_pad_synth_data(device, batch_size, input_max_shape, axes, axis_names, 
                     expected_extent = expected_extent - remainder + align_val
                 assert(output_shape[dim] == expected_extent)
 
-def test_slice_synth_data_vs_numpy():
+def test_pad():
     for device in ["cpu", "gpu"]:
         for batch_size in {1, 8}:
             for input_max_shape, axes, axis_names, align, shape_arg in \
@@ -131,9 +132,9 @@ def test_slice_synth_data_vs_numpy():
                  ((200, 400, 3), None, None, None, (-1, -1, 4)),
                  ((25, 100, 3), (0,), None, None, (25,)),
                  ((200, 400, 3), (0, 1), None, (4, 16), (1, 200))]:
-                yield check_pad_synth_data, device, batch_size, input_max_shape, axes, axis_names, align, shape_arg
+                yield check_pad, device, batch_size, input_max_shape, axes, axis_names, align, shape_arg
 
-def test_pad_fail():
+def test_pad_error():
     batch_size = 2
     input_max_shape = (5, 5, 3)
     device = "cpu"
@@ -149,3 +150,46 @@ def test_pad_fail():
 
     pipe.build()
     assert_raises(RuntimeError, pipe.run)
+
+def is_aligned(sh, align):
+    assert len(sh) == len(align)
+    for i in range(len(sh)):
+        if sh[i] % align[i] > 0:
+            return False
+    return True
+
+def check_pad_per_sample_shapes_and_alignment(device='cpu', batch_size=3, ndim=2, num_iter=3):
+    pipe = Pipeline(batch_size=batch_size, num_threads=3, device_id=0, seed=1234)
+    with pipe:
+        in_shape = fn.cast(fn.uniform(range=(10, 20), shape=(ndim,)), dtype=types.INT32)
+        in_data = fn.uniform(range=(0., 1.), shape=in_shape)
+        req_shape = fn.cast(fn.uniform(range=(21, 30), shape=(ndim,)), dtype=types.INT32)
+        req_align = fn.cast(fn.uniform(range=(3, 5), shape=(ndim,)), dtype=types.INT32)
+        out_pad_shape = fn.pad(in_data, axes=[0, 1], axis_names=None, align=None, shape=req_shape)
+        out_pad_align = fn.pad(in_data, axes=[0, 1], axis_names=None, align=req_align, shape=None)
+        out_pad_both = fn.pad(in_data, axes=[0, 1], axis_names=None, align=req_align, shape=req_shape)
+        pipe.set_outputs(in_shape, in_data, req_shape, req_align, out_pad_shape, out_pad_align, out_pad_both)
+    pipe.build()
+    for _ in range(num_iter):
+        outs = pipe.run()
+        for i in range(batch_size):
+            in_shape, in_data, req_shape, req_align, out_pad_shape, out_pad_align, out_pad_both = \
+                [outs[out_idx].at(i) for out_idx in range(len(outs))]
+            assert (in_shape == in_data.shape).all()
+
+            # Pad to explicit shape
+            assert (out_pad_shape.shape >= in_shape).all()
+            assert (req_shape == out_pad_shape.shape).all()
+
+            # Alignment only
+            assert (out_pad_align.shape >= in_shape).all()
+            assert is_aligned(out_pad_align.shape, req_align)
+
+            # Explicit shape + alignment
+            assert (out_pad_both.shape >= in_shape).all()
+            assert (req_shape <= out_pad_both.shape).all()
+            assert is_aligned(out_pad_both.shape, req_align)
+
+def test_pad_per_sample_shapes_and_alignment():
+    yield check_pad_per_sample_shapes_and_alignment, 'cpu'
+    yield check_pad_per_sample_shapes_and_alignment, 'gpu'

--- a/include/dali/core/small_vector.h
+++ b/include/dali/core/small_vector.h
@@ -135,6 +135,7 @@ class SmallVector : SmallVectorAlloc<T, allocator>, SmallVectorBase<T> {
     copy_assign(data, count);
   }
 
+  DALI_NO_EXEC_CHECK
   template <typename Iterator>
   DALI_HOST_DEV SmallVector(Iterator begin, Iterator end) : SmallVector() {
     copy_assign(begin, end);
@@ -208,6 +209,7 @@ class SmallVector : SmallVectorAlloc<T, allocator>, SmallVectorBase<T> {
     return *this;
   }
 
+  DALI_NO_EXEC_CHECK
   template <typename Iterator>
   DALI_HOST_DEV void copy_assign(Iterator begin, Iterator end) {
     auto n = end - begin;

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -190,8 +190,15 @@ struct TensorShape<DynamicDimensions>
     : public TensorShapeBase<DynamicTensorShapeContainer, DynamicDimensions> {
   using Base = TensorShapeBase<DynamicTensorShapeContainer, DynamicDimensions>;
 
+  TensorShape(span<const int64_t> s)  // NOLINT
+  : Base(DynamicTensorShapeContainer(s.begin(), s.end())) {}
+
+  TensorShape(span<const int> s)  // NOLINT
+  : Base(DynamicTensorShapeContainer(s.begin(), s.end())) {}
+
   TensorShape(const std::vector<int64_t> &s)  // NOLINT
   : Base(DynamicTensorShapeContainer(s.data(), s.size())) {}
+
   TensorShape(const DynamicTensorShapeContainer &s) : Base(s) {}  // NOLINT
 
   template <size_t N>

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -172,6 +172,14 @@ template <typename Collection, typename T = void>
 using if_array_like = if_indexable<Collection,
                                    if_istype<decltype(size(std::declval<Collection>())), T>>;
 
+template <typename It>
+using is_integer_iterator = std::is_integral<
+  std::remove_reference_t<decltype(*std::declval<It>())>>;
+
+template <typename C>
+using is_integer_collection = is_integer_iterator<
+  decltype(dali::begin(std::declval<C>()))>;
+
 template <typename C>
 struct element_type {
   using type = typename C::value_type;


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It adds new feature needed to support different `Pad` shape/align requirements per sample

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Pad operator: `shape`/`align` to support argument inputs*
     *(Bonus, needed for testing) Uniform operator: `shape` to support argument inputs*
 - Affected modules and functionalities:
     *Pad, Uniform*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *Tests added*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1669]*
