### PR TITLE
One hot gpu

### DIFF
--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -74,11 +74,12 @@ class OneHotCPU : public OneHot<CPUBackend> {
   USE_OPERATOR_MEMBERS();
 };
 
-void OneHotCPU::RunImpl(Workspace &ws) {
+void OneHotCPU::RunImpl(workspace_t<CPUBackend> &ws) {
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto &output = ws.template OutputRef<CPUBackend>(0);
   auto &tp = ws.GetThreadPool();
   auto in_shape = input.shape();
+  auto num_samples = in_shape.num_samples();
   int output_sample_dim = output.shape().sample_dim();
   int placement_axis = get_placement_axis(output_sample_dim);
   output.SetLayout(GetOutputLayout(ws, placement_axis, output_sample_dim));
@@ -87,7 +88,7 @@ void OneHotCPU::RunImpl(Workspace &ws) {
 
     auto in_tensor = view<const InputType, DynamicDimensions>(input);
     auto out_tensor = view<OutputType, DynamicDimensions>(output);
-    for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
+    for (int sample_id = 0; sample_id < num_samples; ++sample_id) {
       tp.AddWork(
               [&, sample_id](int thread_id) {
                   auto in = in_tensor[sample_id];

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -18,8 +18,6 @@
 
 namespace dali {
 
-DALI_REGISTER_OPERATOR(OneHot, OneHot, CPU);
-
 
 DALI_SCHEMA(OneHot)
   .DocStr(R"code(Produces a one-hot encoding of the input.
@@ -63,89 +61,26 @@ This value will be cast to the ``dtype`` type.)code", 0.f)
 dimension in the output layout. If no character is provided, the output layout will be
 empty.)code", nullptr);
 
-namespace {
+class OneHotCPU : public OneHot<CPUBackend> {
+ public:
+  explicit OneHotCPU(const OpSpec &spec)
+      : OneHot<CPUBackend>(spec) {}
 
-template<int ndims>
-bool is_scalar(TensorShape<ndims> shape) {
-  return volume(shape) == 1;
-}
+  ~OneHotCPU() override = default;
+  DISABLE_COPY_MOVE_ASSIGN(OneHotCPU);
 
-TensorShape<> determine_shape(TensorShape<> in_shape, int num_classes, int axis,
-                              int output_sample_dim) {
-  if (output_sample_dim == 1) {
-    return {num_classes};
-  }
-  axis = axis < 0 ? in_shape.sample_dim() : axis;
-  int outer_axes = axis;
-  int inner_axes = in_shape.sample_dim() - axis;
-  auto outer = in_shape.first(outer_axes);
-  auto inner = in_shape.last(inner_axes);
-  return shape_cat(shape_cat(outer, num_classes), inner);
-}
+  void RunImpl(workspace_t<CPUBackend> &ws) override;
 
-}  // namespace
+  USE_OPERATOR_MEMBERS();
+};
 
-TensorLayout OneHot::GetOutputLayout(const HostWorkspace &ws, int placement_axis,
-                                     int output_sample_dim) const {
-  if (!new_axis_name_) {
-    return {};
-  }
-  const auto &input = ws.template InputRef<CPUBackend>(0);
-  auto in_layout = input.GetLayout();
-  // .size method returns uint_8 which doesn't work well when 0 is printed in error message
-  int in_layout_size = in_layout.size();
-  // Handles the legacy 'multi-dimensional' scalars-like
-  if (output_sample_dim == 1) {
-    return TensorLayout(&new_axis_name_, 1);
-  }
-  if (in_layout_size + 1 == output_sample_dim) {
-    return in_layout.first(placement_axis) + TensorLayout(&new_axis_name_, 1) +
-           in_layout.last(in_layout_size - placement_axis);
-  }
-  DALI_FAIL(make_string("Input layout mismatch - expected input layout to be of size ",
-                        output_sample_dim - 1, " but instead got \"", in_layout,
-                        "\", which is of size ", in_layout_size, "."));
-}
-
-bool OneHot::SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) {
-  const auto &input = ws.template InputRef<CPUBackend>(0);
-  int input_sample_dim = input.shape().sample_dim();
-  int num_samples = input.shape().num_samples();
-  DALI_ENFORCE(-1 <= axis_ && axis_ <= input_sample_dim,
-               make_string("Provided axis is outside of allowed range, got: ", axis_,
-                           ", expected to be in range: [-1, ", input_sample_dim, "]."));
-
-  // Legacy scalar-like support only if the `axis` parameter was not provided
-  bool all_scalars = !spec_.ArgumentDefined("axis");
-  for (int i = 0; all_scalars && i < num_samples; i++) {
-    all_scalars = all_scalars && is_scalar(input.shape()[i]);
-  }
-
-  int output_sample_dim = all_scalars ? 1 : input_sample_dim + 1;
-  output_desc.resize(1);
-
-  output_desc[0].shape.resize(num_samples, output_sample_dim);
-  for (int i = 0; i < num_samples; i++) {
-    output_desc[0].shape.set_tensor_shape(
-        i, determine_shape(input[i].shape(), num_classes_, axis_, output_sample_dim));
-  }
-  TYPE_SWITCH(output_type_, type2id, DType, ONE_HOT_TYPES, (
-          {
-            TypeInfo type;
-            type.SetType<DType>(output_type_);
-            output_desc[0].type = type;
-          }
-  ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
-  return true;
-}
-
-void OneHot::RunImpl(HostWorkspace &ws) {
+void OneHotCPU::RunImpl(Workspace &ws) {
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto &output = ws.template OutputRef<CPUBackend>(0);
   auto &tp = ws.GetThreadPool();
   auto in_shape = input.shape();
   int output_sample_dim = output.shape().sample_dim();
-  int placement_axis = axis_ < 0 ? output_sample_dim - 1 : axis_;
+  int placement_axis = get_placement_axis(output_sample_dim);
   output.SetLayout(GetOutputLayout(ws, placement_axis, output_sample_dim));
   TYPE_SWITCH(input.type().id(), type2id, InputType, ONE_HOT_TYPES, (
     TYPE_SWITCH(output_type_, type2id, OutputType, ONE_HOT_TYPES, (
@@ -164,5 +99,7 @@ void OneHot::RunImpl(HostWorkspace &ws) {
   ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
   ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())))  // NOLINT
 }
+
+DALI_REGISTER_OPERATOR(OneHot, OneHotCPU, CPU);
 
 }  // namespace dali

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -67,7 +67,6 @@ class OneHotCPU : public OneHot<CPUBackend> {
       : OneHot<CPUBackend>(spec) {}
 
   ~OneHotCPU() override = default;
-  DISABLE_COPY_MOVE_ASSIGN(OneHotCPU);
 
   void RunImpl(workspace_t<CPUBackend> &ws) override;
 

--- a/dali/operators/generic/one_hot.cu
+++ b/dali/operators/generic/one_hot.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/operators/generic/one_hot.cu
+++ b/dali/operators/generic/one_hot.cu
@@ -1,0 +1,123 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include "dali/operators/generic/one_hot.h"
+
+namespace dali {
+
+namespace detail {
+
+struct SampleDesc {
+  uint64_t outer_vol, inner_vol, output_vol, inner_vol_classes;
+  void *out = nullptr;
+  const void *in = nullptr;
+};
+
+template <typename OutputType, typename InputType>
+__global__ void PopulateOneHot(OutputType on_value, OutputType off_value,
+                               const SampleDesc *samples) {
+  uint64_t out_index = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto &sample = samples[blockIdx.y];
+  if (out_index >= sample.output_vol) {
+    return;
+  }
+  auto *out = static_cast<OutputType*>(sample.out);
+  auto *in = static_cast<const InputType*>(sample.in);
+  uint64_t i = out_index / sample.inner_vol_classes;
+  uint64_t j = out_index % sample.inner_vol;
+  uint64_t in_index = i * sample.inner_vol + j;
+  unsigned int in_val = in[in_index];
+  uint64_t on_out_index = i * sample.inner_vol_classes + in_val * sample.inner_vol + j;
+  out[out_index] = on_out_index == out_index ? on_value : off_value;
+}
+
+}  // namespace detail
+
+class OneHotGPU : public OneHot<GPUBackend> {
+ public:
+  explicit OneHotGPU(const OpSpec &spec) : OneHot<GPUBackend>(spec) {
+    int64_t samples_size = batch_size_ * sizeof(detail::SampleDesc);
+    scratch_mem_.set_type(TypeTable::GetTypeInfo(DALI_UINT8));
+    scratch_mem_.Resize({samples_size});
+  }
+
+  ~OneHotGPU() override = default;
+  DISABLE_COPY_MOVE_ASSIGN(OneHotGPU);
+
+  void RunImpl(workspace_t<GPUBackend> &ws) override;
+
+  template<typename OutputType, typename InputType>
+  void RunImplTyped(workspace_t<GPUBackend> &ws, int placement_axis);
+
+  USE_OPERATOR_MEMBERS();
+
+ private:
+  std::vector<detail::SampleDesc> sample_descs_;
+  Tensor<GPUBackend> scratch_mem_;
+};
+
+void OneHotGPU::RunImpl(Workspace &ws) {
+  const auto &input = ws.InputRef<GPUBackend>(0);
+  auto &output = ws.OutputRef<GPUBackend>(0);
+  int output_sample_dim = output.shape().sample_dim();
+  int placement_axis = get_placement_axis(output_sample_dim);
+  output.SetLayout(GetOutputLayout(ws, placement_axis, output_sample_dim));
+  TYPE_SWITCH(input.type().id(), type2id, InputType, ONE_HOT_TYPES, (
+    TYPE_SWITCH(output_type_, type2id, OutputType, ONE_HOT_TYPES, (
+      RunImplTyped<OutputType, InputType>(ws, placement_axis);
+    ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)); );       // NOLINT
+  ), DALI_FAIL(make_string("Unsupported input type: ", input.type().id())); );     // NOLINT
+}
+
+template <typename OutputType, typename InputType>
+void OneHotGPU::RunImplTyped(workspace_t<GPUBackend> &ws, int axis) {
+  const auto &input = ws.InputRef<GPUBackend>(0);
+  auto &output = ws.OutputRef<GPUBackend>(0);
+
+  sample_descs_.clear();
+  sample_descs_.reserve(batch_size_);
+
+  uint64_t max_out_vol = 1;
+  const auto &shape = output.shape();
+  for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
+    detail::SampleDesc sample;
+    auto output_shape = shape[sample_id];
+    sample.outer_vol = volume(output_shape.begin(), output_shape.begin() + axis);
+    sample.inner_vol = volume(output_shape.begin() + axis + 1, output_shape.end());
+    sample.inner_vol_classes = sample.inner_vol * num_classes_;
+    sample.output_vol = sample.outer_vol * sample.inner_vol_classes;
+    sample.out = output.mutable_tensor<OutputType>(sample_id);
+    sample.in = input.tensor<InputType>(sample_id);
+    sample_descs_.push_back(sample);
+    max_out_vol = std::max(max_out_vol, sample.output_vol);
+  }
+
+  auto stream = ws.stream();
+
+  scratch_mem_.Copy(sample_descs_, stream);
+  const auto scratch_mem_gpu = scratch_mem_.data<detail::SampleDesc>();
+
+  const int block = 256;
+  auto block_size = (max_out_vol + (block - 1)) / block;
+  dim3 grid(block_size, batch_size_);
+
+  OutputType on_value = on_value_, off_value = off_value_;
+  detail::PopulateOneHot<OutputType, InputType><<<grid, block>>>(
+    on_value, off_value, scratch_mem_gpu);
+}
+
+DALI_REGISTER_OPERATOR(OneHot, OneHotGPU, GPU);
+
+}  // namespace dali

--- a/dali/operators/generic/one_hot.cu
+++ b/dali/operators/generic/one_hot.cu
@@ -67,10 +67,10 @@ void OneHotGPU::RunImplTyped(workspace_t<GPUBackend> &ws, int axis) {
   for (int sample_id = 0; sample_id < batch_size_; ++sample_id) {
     detail::SampleDesc sample;
     auto output_shape = shape[sample_id];
-    sample.outer_vol = volume(output_shape.begin(), output_shape.begin() + axis);
+    auto outer_vol = volume(output_shape.begin(), output_shape.begin() + axis);
     sample.inner_vol = volume(output_shape.begin() + axis + 1, output_shape.end());
     sample.inner_vol_classes = sample.inner_vol * num_classes_;
-    sample.output_vol = sample.outer_vol * sample.inner_vol_classes;
+    sample.output_vol = outer_vol * sample.inner_vol_classes;
     sample.out = output.mutable_tensor<OutputType>(sample_id);
     sample.in = input.tensor<InputType>(sample_id);
     sample_descs_.push_back(sample);

--- a/dali/operators/generic/one_hot.cu
+++ b/dali/operators/generic/one_hot.cu
@@ -25,7 +25,6 @@ class OneHotGPU : public OneHot<GPUBackend> {
   }
 
   ~OneHotGPU() override = default;
-  DISABLE_COPY_MOVE_ASSIGN(OneHotGPU);
 
   USE_OPERATOR_MEMBERS();
 

--- a/dali/operators/generic/one_hot.cuh
+++ b/dali/operators/generic/one_hot.cuh
@@ -43,7 +43,7 @@ __global__ void PopulateOneHot(OutputType on_value, OutputType off_value,
   }
 }
 
-dim3 gridHelper(uint64_t output_vol, int batch_size, int block = 32,
+dim3 gridHelper(uint64_t output_vol, int batch_size, int block = 256,
                 uint64_t max_block_size = 65535) {
   auto block_size = std::min((output_vol + (block - 1)) / block, max_block_size);
   return dim3(block_size, batch_size);

--- a/dali/operators/generic/one_hot.cuh
+++ b/dali/operators/generic/one_hot.cuh
@@ -1,0 +1,47 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+
+namespace dali {
+
+namespace detail {
+
+struct SampleDesc {
+  uint64_t outer_vol, inner_vol, output_vol, inner_vol_classes;
+  void *out = nullptr;
+  const void *in = nullptr;
+};
+
+template <typename OutputType, typename InputType>
+__global__ void PopulateOneHot(OutputType on_value, OutputType off_value,
+                               const SampleDesc *samples) {
+  uint64_t out_index = static_cast<uint64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const auto &sample = samples[blockIdx.y];
+  if (out_index >= sample.output_vol) {
+    return;
+  }
+  auto *out = static_cast<OutputType*>(sample.out);
+  auto *in = static_cast<const InputType*>(sample.in);
+  uint64_t i = out_index / sample.inner_vol_classes;
+  uint64_t j = out_index % sample.inner_vol;
+  uint64_t in_index = i * sample.inner_vol + j;
+  uint64_t in_val = in[in_index];
+  uint64_t on_out_index = i * sample.inner_vol_classes + in_val * sample.inner_vol + j;
+  out[out_index] = on_out_index == out_index ? on_value : off_value;
+}
+
+}  // namespace detail
+
+}  // namespace dali

--- a/dali/operators/generic/one_hot.cuh
+++ b/dali/operators/generic/one_hot.cuh
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <algorithm>
+#include "dali/core/util.h"
 
 namespace dali {
 
@@ -45,7 +46,7 @@ __global__ void PopulateOneHot(OutputType on_value, OutputType off_value,
 
 dim3 gridHelper(uint64_t output_vol, int batch_size, int block = 256,
                 uint64_t max_block_size = 65535) {
-  auto block_size = std::min((output_vol + (block - 1)) / block, max_block_size);
+  auto block_size = std::min(div_ceil(output_vol, block), max_block_size);
   return dim3(block_size, batch_size);
 }
 

--- a/dali/operators/generic/one_hot.cuh
+++ b/dali/operators/generic/one_hot.cuh
@@ -19,7 +19,7 @@ namespace dali {
 namespace detail {
 
 struct SampleDesc {
-  uint64_t outer_vol, inner_vol, output_vol, inner_vol_classes;
+  uint64_t inner_vol, output_vol, inner_vol_classes;
   void *out = nullptr;
   const void *in = nullptr;
 };

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -49,12 +49,16 @@ void DoOneHot(kernels::OutTensorCPU<Out, DynamicDimensions> output,
     }
   }
 }
+
 }  // namespace detail
 
-class OneHot : public Operator<CPUBackend> {
+template <typename Backend>
+class OneHot : public Operator<Backend> {
  public:
-  inline explicit OneHot(const OpSpec &spec)
-      : Operator<CPUBackend>(spec), num_classes_(spec.GetArgument<int64_t>("num_classes")),
+  using Workspace = workspace_t<Backend>;
+
+  explicit OneHot(const OpSpec &spec)
+      : Operator<Backend>(spec), num_classes_(spec.GetArgument<int64_t>("num_classes")),
         axis_(spec.GetArgument<int>("axis")),
         output_type_(spec.GetArgument<DALIDataType>(arg_names::kDtype)),
         on_value_(spec.GetArgument<float>("on_value")),
@@ -68,23 +72,89 @@ class OneHot : public Operator<CPUBackend> {
     }
   }
 
-  inline ~OneHot() override = default;
-
   DISABLE_COPY_MOVE_ASSIGN(OneHot);
 
   USE_OPERATOR_MEMBERS();
-  using Operator<CPUBackend>::RunImpl;
+  // using Operator<CPUBackend>::RunImpl;
 
  protected:
   bool CanInferOutputs() const override {
     return true;
   }
 
-  bool SetupImpl(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override;
-  void RunImpl(HostWorkspace &ws) override;
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
+    const auto &input = ws.template InputRef<Backend>(0);
+    int input_sample_dim = input.shape().sample_dim();
+    int num_samples = input.shape().num_samples();
+    DALI_ENFORCE(-1 <= axis_ && axis_ <= input_sample_dim,
+                 make_string("Provided axis is outside of allowed range, got: ", axis_,
+                             ", expected to be in range: [-1, ", input_sample_dim, "]."));
 
-  TensorLayout GetOutputLayout(const HostWorkspace &ws, int placement_axis,
-                               int output_sample_dim) const;
+    // Legacy scalar-like support only if the `axis` parameter was not provided
+    bool all_scalars = !spec_.ArgumentDefined("axis");
+    for (int i = 0; all_scalars && i < num_samples; i++) {
+      all_scalars = all_scalars && is_scalar(input.shape()[i]);
+    }
+
+    int output_sample_dim = all_scalars ? 1 : input_sample_dim + 1;
+    output_desc.resize(1);
+
+    output_desc[0].shape.resize(num_samples, output_sample_dim);
+
+    const auto& shape = input.shape();
+    for (int i = 0; i < num_samples; i++) {
+      output_desc[0].shape.set_tensor_shape(i, determine_shape(shape[i], output_sample_dim));
+    }
+    TYPE_SWITCH(output_type_, type2id, DType, ONE_HOT_TYPES, ({
+                  TypeInfo type;
+                  type.SetType<DType>(output_type_);
+                  output_desc[0].type = type;
+                }),
+                DALI_FAIL(make_string("Unsupported output type: ", output_type_))) // NOLINT
+    return true;
+  };
+
+  TensorLayout GetOutputLayout(const Workspace &ws, int placement_axis, int output_sample_dim) {
+    if (!new_axis_name_) {
+      return {};
+    }
+    const auto &input = ws.template InputRef<Backend>(0);
+    auto in_layout = input.GetLayout();
+    // .size method returns uint_8 which doesn't work well when 0 is printed in error message
+    int in_layout_size = in_layout.size();
+    // Handles the legacy 'multi-dimensional' scalars-like
+    if (output_sample_dim == 1) {
+      return TensorLayout(&new_axis_name_, 1);
+    }
+    if (in_layout_size + 1 == output_sample_dim) {
+      return in_layout.first(placement_axis) + TensorLayout(&new_axis_name_, 1) +
+             in_layout.last(in_layout_size - placement_axis);
+    }
+    DALI_FAIL(make_string("Input layout mismatch - expected input layout to be of size ",
+                          output_sample_dim - 1, " but instead got \"", in_layout,
+                          "\", which is of size ", in_layout_size, "."));
+  }
+
+  inline int get_placement_axis(int output_sample_dim) {
+    return axis_ < 0 ? output_sample_dim - 1 : axis_;
+  }
+
+  template <int ndims>
+  bool is_scalar(TensorShape<ndims> shape) {
+    return volume(shape) == 1;
+  }
+
+  TensorShape<> determine_shape(TensorShape<> in_shape, int output_sample_dim) {
+    if (output_sample_dim == 1) {
+      return {num_classes_};
+    }
+    auto placement_axis = get_placement_axis(output_sample_dim);
+    int outer_axes = placement_axis;
+    int inner_axes = in_shape.sample_dim() - placement_axis;
+    auto outer = in_shape.first(outer_axes);
+    auto inner = in_shape.last(inner_axes);
+    return shape_cat(shape_cat(outer, num_classes_), inner);
+  }
 
   int num_classes_;
   int axis_;

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -138,11 +138,11 @@ class OneHot : public Operator<Backend> {
   }
 
   template <int ndims>
-  bool is_scalar(TensorShape<ndims> shape) {
+  bool is_scalar(const TensorShape<ndims> &shape) {
     return volume(shape) == 1;
   }
 
-  TensorShape<> determine_shape(TensorShape<> in_shape, int output_sample_dim) {
+  TensorShape<> determine_shape(const TensorShape<> &in_shape, int output_sample_dim) {
     if (output_sample_dim == 1) {
       return {num_classes_};
     }

--- a/dali/operators/generic/one_hot.h
+++ b/dali/operators/generic/one_hot.h
@@ -55,8 +55,6 @@ void DoOneHot(kernels::OutTensorCPU<Out, DynamicDimensions> output,
 template <typename Backend>
 class OneHot : public Operator<Backend> {
  public:
-  using Workspace = workspace_t<Backend>;
-
   explicit OneHot(const OpSpec &spec)
       : Operator<Backend>(spec), num_classes_(spec.GetArgument<int64_t>("num_classes")),
         axis_(spec.GetArgument<int>("axis")),
@@ -75,14 +73,13 @@ class OneHot : public Operator<Backend> {
   DISABLE_COPY_MOVE_ASSIGN(OneHot);
 
   USE_OPERATOR_MEMBERS();
-  // using Operator<CPUBackend>::RunImpl;
 
  protected:
   bool CanInferOutputs() const override {
     return true;
   }
 
-  bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
     const auto &input = ws.template InputRef<Backend>(0);
     int input_sample_dim = input.shape().sample_dim();
     int num_samples = input.shape().num_samples();
@@ -114,7 +111,8 @@ class OneHot : public Operator<Backend> {
     return true;
   };
 
-  TensorLayout GetOutputLayout(const Workspace &ws, int placement_axis, int output_sample_dim) {
+  TensorLayout GetOutputLayout(const workspace_t<Backend> &ws, int placement_axis,
+                               int output_sample_dim) {
     if (!new_axis_name_) {
       return {};
     }

--- a/dali/operators/generic/one_hot_test.cu
+++ b/dali/operators/generic/one_hot_test.cu
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include <vector>
 
 #include "dali/core/cuda_event.h"
 #include "dali/core/cuda_stream.h"
@@ -67,7 +66,6 @@ struct OneHotOpGpuPerfTest : public ::testing::Test {
     auto input_gpu = input_.gpu(stream_);
     auto output_gpu = output_.gpu(stream_);
     for (int sample_id = 0; sample_id < config_.batch_size; ++sample_id) {
-      samples_cpu(sample_id)->outer_vol = outer_vol;
       samples_cpu(sample_id)->inner_vol = inner_vol;
       samples_cpu(sample_id)->inner_vol_classes = inner_vol_classes;
       samples_cpu(sample_id)->output_vol = output_vol;

--- a/dali/operators/generic/one_hot_test.cu
+++ b/dali/operators/generic/one_hot_test.cu
@@ -80,8 +80,7 @@ struct OneHotOpGpuPerfTest : public ::testing::Test {
     auto output_vol = input_vol * config_.num_classes;
 
     const int block = 256;
-    auto block_size = (output_vol + (block - 1)) / block;
-    dim3 grid(block_size, config_.batch_size);
+    auto grid = detail::gridHelper(output_vol, config_.batch_size, block);
 
     Out on_value = 1, off_value = 0;
     detail::PopulateOneHot<Out, In><<<grid, block, 0, stream_>>>(on_value, off_value, samples_gpu_);
@@ -130,9 +129,9 @@ using TestConfigs = ::testing::Types<
 OneHotTestParams<int, int, 1, 256, 0, 1024, 1024>,
 OneHotTestParams<int, int, 1, 256, 1, 1024, 1024>,
 OneHotTestParams<int, int, 1, 256, 2, 1024, 1024>,
-OneHotTestParams<int, int64_t, 1, 256, 0, 1024, 1024>,
-OneHotTestParams<int, int64_t, 1, 256, 1, 1024, 1024>,
-OneHotTestParams<int, int64_t, 1, 256, 2, 1024, 1024>,
+OneHotTestParams<int64_t, int, 1, 256, 0, 1024, 1024>,
+OneHotTestParams<int64_t, int, 1, 256, 1, 1024, 1024>,
+OneHotTestParams<int64_t, int, 1, 256, 2, 1024, 1024>,
 OneHotTestParams<int64_t, int64_t, 1, 256, 0, 1024, 1024>,
 OneHotTestParams<int64_t, int64_t, 1, 256, 1, 1024, 1024>,
 OneHotTestParams<int64_t, int64_t, 1, 256, 2, 1024, 1024>,

--- a/dali/operators/generic/one_hot_test.cu
+++ b/dali/operators/generic/one_hot_test.cu
@@ -1,0 +1,159 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "dali/core/cuda_event.h"
+#include "dali/core/cuda_stream.h"
+#include "dali/test/dali_operator_test.h"
+#include "dali/test/tensor_test_utils.h"
+#include "dali/test/test_tensors.h"
+#include "dali/operators/generic/one_hot.cuh"
+
+
+namespace dali {
+
+template <typename OutputType, typename InputType, int batch_size_, int64_t num_classes_, int axis_,
+          int64_t... Dims>
+struct OneHotTestParams {
+  using Out = OutputType;
+  using In = InputType;
+  static constexpr int batch_size = batch_size_;
+  static constexpr int64_t num_classes = num_classes_;
+  static constexpr int axis = axis_;
+  static constexpr int ndim = sizeof...(Dims);
+  TensorShape<ndim> shape = {Dims...};
+};
+
+template <typename TestConfig>
+struct OneHotOpGpuPerfTest : public ::testing::Test {
+  using Out = typename TestConfig::Out;
+  using In = typename TestConfig::In;
+  void SetUp() override {
+    stream_ = CUDAStream::Create(true);
+
+    auto &input_shape = config_.shape;
+    sample_descs_tensor_.reshape(uniform_list_shape<1>(1, {config_.batch_size}));
+    auto samples_cpu = sample_descs_tensor_.cpu()[0];
+    auto outer = input_shape.first(config_.axis);
+    auto inner = input_shape.last(input_shape.size() - config_.axis);
+    auto out_shape = shape_cat(shape_cat(outer, config_.num_classes), inner);
+    auto input_list_shape = uniform_list_shape<TestConfig::ndim>(config_.batch_size, input_shape);
+    auto out_list_shape = uniform_list_shape<TestConfig::ndim + 1>(config_.batch_size, out_shape);
+    input_.reshape(input_list_shape);
+    output_.reshape(out_list_shape);
+    int num;
+    auto seq_gen = [&num]() { return num = (num + 1) % TestConfig::num_classes; };
+    Fill(input_.cpu(), seq_gen);
+
+    auto outer_vol = volume(input_shape.begin(), input_shape.begin() + config_.axis);
+    auto inner_vol = volume(input_shape.begin() + config_.axis, input_shape.end());
+    auto inner_vol_classes = inner_vol * config_.num_classes;
+    auto output_vol = outer_vol * inner_vol_classes;
+
+    memset(samples_cpu.data, 0, TestConfig::batch_size * sizeof(detail::SampleDesc));
+    auto input_gpu = input_.gpu(stream_);
+    auto output_gpu = output_.gpu(stream_);
+    for (int sample_id = 0; sample_id < config_.batch_size; ++sample_id) {
+      samples_cpu(sample_id)->outer_vol = outer_vol;
+      samples_cpu(sample_id)->inner_vol = inner_vol;
+      samples_cpu(sample_id)->inner_vol_classes = inner_vol_classes;
+      samples_cpu(sample_id)->output_vol = output_vol;
+      samples_cpu(sample_id)->out = output_gpu[sample_id].data;
+      samples_cpu(sample_id)->in = input_gpu[sample_id].data;
+    }
+    samples_gpu_ = sample_descs_tensor_.gpu(stream_)[0].data;
+  }
+
+  void MeasurePerf() {
+    auto input_vol = volume(config_.shape);
+    auto output_vol = input_vol * config_.num_classes;
+
+    const int block = 256;
+    auto block_size = (output_vol + (block - 1)) / block;
+    dim3 grid(block_size, config_.batch_size);
+
+    Out on_value = 1, off_value = 0;
+    detail::PopulateOneHot<Out, In><<<grid, block, 0, stream_>>>(on_value, off_value, samples_gpu_);
+
+    CUDAEvent start = CUDAEvent::CreateWithFlags(0);
+    CUDAEvent end = CUDAEvent::CreateWithFlags(0);
+
+    cudaEventRecord(start, stream_);
+    constexpr int kIters = 100;
+    for (int i = 0; i < kIters; i++) {
+      detail::PopulateOneHot<Out, In><<<grid, block, 0, stream_>>>(
+        on_value, off_value, samples_gpu_);
+    }
+    cudaEventRecord(end, stream_);
+    cudaDeviceSynchronize();
+    float time;
+    CUDA_CALL(cudaEventElapsedTime(&time, start, end));
+
+    time *= (1e+6f / kIters);  // convert to nanoseconds / 100 samples
+    int64_t data_size = (input_vol * sizeof(In) + output_vol * sizeof(Out)) * config_.batch_size;
+    std::cerr << "Throughput: " << data_size / time << " GB/s" << std::endl;
+  }
+
+  TestConfig config_{};
+  CUDAStream stream_;
+
+  kernels::TestTensorList<In, TestConfig::ndim> input_;
+  kernels::TestTensorList<Out, TestConfig::ndim + 1> output_;
+  kernels::TestTensorList<typename detail::SampleDesc, 1> sample_descs_tensor_;
+
+  const detail::SampleDesc *samples_gpu_;
+};
+
+TYPED_TEST_SUITE_P(OneHotOpGpuPerfTest);
+
+TYPED_TEST_P(OneHotOpGpuPerfTest, Perf) {
+  std::cerr << "batch_size: " << this->config_.batch_size << ", num_classes: "
+            << this->config_.num_classes << ", sample_dim: " << this->config_.shape
+            << std::endl;
+  this->MeasurePerf();
+}
+
+REGISTER_TYPED_TEST_SUITE_P(OneHotOpGpuPerfTest, Perf);
+
+using TestConfigs = ::testing::Types<
+OneHotTestParams<int, int, 1, 256, 0, 1024, 1024>,
+OneHotTestParams<int, int, 1, 256, 1, 1024, 1024>,
+OneHotTestParams<int, int, 1, 256, 2, 1024, 1024>,
+OneHotTestParams<int, int64_t, 1, 256, 0, 1024, 1024>,
+OneHotTestParams<int, int64_t, 1, 256, 1, 1024, 1024>,
+OneHotTestParams<int, int64_t, 1, 256, 2, 1024, 1024>,
+OneHotTestParams<int64_t, int64_t, 1, 256, 0, 1024, 1024>,
+OneHotTestParams<int64_t, int64_t, 1, 256, 1, 1024, 1024>,
+OneHotTestParams<int64_t, int64_t, 1, 256, 2, 1024, 1024>,
+OneHotTestParams<int8_t, int8_t, 1, 256, 0, 1024, 1024>,
+OneHotTestParams<int8_t, int8_t, 1, 256, 1, 1024, 1024>,
+OneHotTestParams<int8_t, int8_t, 1, 256, 2, 1024, 1024>,
+OneHotTestParams<int, int, 4, 8, 0, 32, 32, 32, 32, 32>,
+OneHotTestParams<int, int, 4, 8, 1, 32, 32, 32, 32, 32>,
+OneHotTestParams<int, int, 4, 8, 2, 32, 32, 32, 32, 32>,
+OneHotTestParams<int, int, 4, 8, 3, 32, 32, 32, 32, 32>,
+OneHotTestParams<int, int, 4, 8, 4, 32, 32, 32, 32, 32>,
+OneHotTestParams<int, int, 4, 8, 5, 32, 32, 32, 32, 32>,
+OneHotTestParams<int, int, 4, 1024 * 256, 0, 1024>,
+OneHotTestParams<int, int, 4, 1024 * 256, 1, 1024>,
+OneHotTestParams<int, int, 16, 64, 0, 1024, 128>,
+OneHotTestParams<int, int, 16, 64, 1, 1024, 128>,
+OneHotTestParams<int, int, 16, 64, 2, 1024, 128>
+>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(OneHotOpGpu, OneHotOpGpuPerfTest, TestConfigs);
+
+}  // namespace dali

--- a/dali/test/test_tensors.h
+++ b/dali/test/test_tensors.h
@@ -66,7 +66,7 @@ class TestTensorList {
     if (!gpumem_) {
       auto size = shape_.num_elements() * sizeof(T);
       char *ptr = nullptr;
-      cudaMalloc(reinterpret_cast<void**>(&ptr), size);
+      CUDA_CALL(cudaMalloc(reinterpret_cast<void**>(&ptr), size));
       gpumem_ = { ptr, GPUDeleter };
       if (cpumem_)
         cudaMemcpyAsync(ptr, cpumem_.get(), size, cudaMemcpyHostToDevice, stream);


### PR DESCRIPTION
#### Why we need this PR?
It adds GPU support to OneHot operator.

#### What happened in this PR?
 - What solution was applied:
     Added GPUBackend specialization to OneHot operator, cuda kernel and perf tests, moved some of the common functionalities from the CPU implementation file to the common header.
 - Affected modules and functionalities:
     OneHot operator
 - Key points relevant for the review:
     N/A
 - Validation and testing:
     Prepared perf tests and extended python tests to test both backends. Tried to utilize fast_div but performance turned out to be slightly worse than the straightforward approach.
 - Documentation (including examples):
     N/A


**JIRA TASK**: DALI-1647