### PR TITLE
Make custom nvJEPG allocator return a relevant allocation status

### DIFF
--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
@@ -204,11 +204,19 @@ void DeleteAllBuffers(std::thread::id thread_id) {
 }
 
 static int DeviceNew(void **ptr, size_t size) {
+  if (size == 0) {
+    *ptr = nullptr;
+    return cudaSuccess;
+  }
   *ptr = GetBuffer(std::this_thread::get_id(), AllocType::GPU, size);
   return *ptr != nullptr ? cudaSuccess : cudaErrorMemoryAllocation;
 }
 
 static int PinnedNew(void **ptr, size_t size, unsigned int flags) {
+  if (size == 0) {
+    *ptr = nullptr;
+    return cudaSuccess;
+  }
   *ptr = GetBuffer(std::this_thread::get_id(), AllocType::Pinned, size);
   return *ptr != nullptr ? cudaSuccess : cudaErrorMemoryAllocation;
 }

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
@@ -205,12 +205,12 @@ void DeleteAllBuffers(std::thread::id thread_id) {
 
 static int DeviceNew(void **ptr, size_t size) {
   *ptr = GetBuffer(std::this_thread::get_id(), AllocType::GPU, size);
-  return 0;
+  return *ptr != nullptr ? cudaSuccess : cudaErrorMemoryAllocation;
 }
 
 static int PinnedNew(void **ptr, size_t size, unsigned int flags) {
   *ptr = GetBuffer(std::this_thread::get_id(), AllocType::Pinned, size);
-  return 0;
+  return *ptr != nullptr ? cudaSuccess : cudaErrorMemoryAllocation;
 }
 
 nvjpegDevAllocator_t GetDeviceAllocator() {


### PR DESCRIPTION
- fixes lack of returning a proper allocation status in nvJPEG custom allocator. So far it always returns 0.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It  fixes lack of returning a proper allocation status in nvJPEG custom allocator. So far it always returns 0.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     make custom nvJEPG allocator return a relevant allocation status
 - Affected modules and functionalities:
     nvJPEG based decoder
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1721]*
