### PR TITLE
Add SearchableRLEMask utility

### DIFF
--- a/dali/operators/segmentation/utils/CMakeLists.txt
+++ b/dali/operators/segmentation/utils/CMakeLists.txt
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(utils)
-
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)
 collect_test_sources(DALI_OPERATOR_TEST_SRCS PARENT_SCOPE)
+

--- a/dali/operators/segmentation/utils/searchable_rle_mask.h
+++ b/dali/operators/segmentation/utils/searchable_rle_mask.h
@@ -1,0 +1,111 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_SEGMENTATION_UTILS_SEARCHABLE_RLE_MASK_H_
+#define DALI_OPERATORS_SEGMENTATION_UTILS_SEARCHABLE_RLE_MASK_H_
+
+#include <vector>
+#include "dali/core/tensor_view.h"
+#include "dali/core/span.h"
+
+namespace dali {
+
+/**
+ * @brief Encodes a segmentation mask in a way that is easy to access to
+ *        know how many foreground pixels are there and get the flat index
+ *        to an arbitrary i-th foreground pixel, as they appear in the mask.
+ */
+class SearchableRLEMask {
+ public:
+  struct Group {
+    int64_t ith;    // The group begins with the i-th pixel
+    int64_t start;  // The group starts at this flat position
+  };
+
+  /**
+   * @brief Any value above threshold is consider foreground
+   */
+  template <typename T>
+  explicit SearchableRLEMask(span<const T> mask_view, T threshold = T(0)) {
+    int64_t idx = 0;
+    int64_t sz = mask_view.size();
+    while (idx < sz) {
+      while (idx < sz && mask_view[idx] <= threshold) {
+        idx++;
+      }
+      if (idx < sz) {  // found a foreground pixel
+        groups_.push_back({count_++, idx++});
+        while (idx < sz && mask_view[idx] > threshold) {
+          idx++;
+          count_++;
+        }
+      }
+    }
+  }
+
+  template <typename T>
+  explicit SearchableRLEMask(TensorView<StorageCPU, T> mask_view, T threshold = T(0))
+    : SearchableRLEMask(span<const T>{mask_view.data, volume(mask_view.shape)}, threshold) {}
+
+  /**
+   * @brief Returns the position of the i-th foreground pixel.
+   *        If ith is an invalid index, -1 is returned
+   */
+  int64_t find(int64_t ith) {
+    if (ith < 0 || ith >= count_) {
+      return -1;
+    }
+
+    int64_t start = 0;
+    int64_t end = groups_.size();
+    int64_t last_idx = groups_.size() - 1;
+    while (end != start) {
+      int64_t pos = (end + start) / 2;
+      const auto &curr = groups_[pos];
+      int64_t next_ith = pos == last_idx ? count_ : groups_[pos + 1].ith;
+      if (curr.ith <= ith && ith < next_ith) {
+        return curr.start + (ith - curr.ith);
+      } else if (ith >= next_ith) {
+        start = next_ith;
+      } else {  // curr.ith > ith
+        end = curr.ith;
+      }
+    }
+    // We should always succeed if it was in range
+    assert(false);
+    return -1;
+  }
+
+  /**
+   * @brief returns the number of foreground pixels in the mask
+   */
+  int64_t count() const {
+    return count_;
+  }
+
+  /** 
+   * @brief returns the internal RLE representation of the mask
+   */
+  span<const Group> encoded() const {
+    return make_cspan(groups_);
+  }
+
+ private:
+  int64_t count_ = 0;
+  std::vector<Group> groups_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_SEGMENTATION_UTILS_SEARCHABLE_RLE_MASK_H_

--- a/dali/operators/segmentation/utils/searchable_rle_mask_test.cc
+++ b/dali/operators/segmentation/utils/searchable_rle_mask_test.cc
@@ -100,14 +100,14 @@ TEST(SearchableRLEMask, handcrafted_mask2) {
 
 TEST(SearchableRLEMask, all_background) {
   std::vector<float> all_bg(10, 0.0f);
-  SearchableRLEMask all_bg_mask(make_cspan(all_bg), 0.0f);
+  SearchableRLEMask all_bg_mask(make_cspan(all_bg));
   ASSERT_EQ(0, all_bg_mask.count());
   ASSERT_EQ(-1, all_bg_mask.find(0));
 }
 
 TEST(SearchableRLEMask, all_foreground) {
   std::vector<float> all_fg(10, 1.0f);
-  SearchableRLEMask all_fg_mask(make_cspan(all_fg), 0.0f);
+  SearchableRLEMask all_fg_mask(make_cspan(all_fg));
   ASSERT_EQ(all_fg.size(), all_fg_mask.count());
   for (size_t i = 0; i < all_fg.size(); i++)
     ASSERT_EQ(i, all_fg_mask.find(i));
@@ -117,7 +117,7 @@ TEST(SearchableRLEMask, alternative_pattern) {
   std::vector<float> pattern(10, 0.0f);
   for (size_t i = 1; i < pattern.size(); i+=2)
     pattern[i] = 1.0f;
-  SearchableRLEMask pattern_mask(make_cspan(pattern), 0.0f);
+  SearchableRLEMask pattern_mask(make_cspan(pattern));
   ASSERT_EQ(pattern.size() / 2, pattern_mask.count());
   for (int i = 0; i < pattern_mask.count(); i++)
     ASSERT_EQ(2 * i + 1, pattern_mask.find(i));

--- a/dali/operators/segmentation/utils/searchable_rle_mask_test.cc
+++ b/dali/operators/segmentation/utils/searchable_rle_mask_test.cc
@@ -1,0 +1,77 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/operators/segmentation/utils/searchable_rle_mask.h"
+
+namespace dali {
+
+TEST(SearchableRLEMask, tests) {
+  uint8_t mask[] = {
+    0, 0, 1, 0, 0, 0,
+    0, 0, 1, 1, 0, 0,
+    0, 1, 1, 0, 0, 0,
+    0, 0, 1, 1, 0, 0,
+    0, 0, 0, 0, 0, 0};
+  TensorView<StorageCPU, uint8_t> mask_view(mask, TensorShape<>{6, 5});
+  SearchableRLEMask search_mask(mask_view);
+  ASSERT_EQ(7, search_mask.count());
+
+  auto rle = search_mask.encoded();
+  ASSERT_EQ(4, rle.size());  // 4 groups of foreground pixels
+
+  // First group has 1 pixel
+  ASSERT_EQ(0, rle[0].ith);    // First group starts with the 0-th foreground pixel
+  ASSERT_EQ(2, rle[0].start);  // Starting at position 2
+
+  // Second group has 2 pixels
+  ASSERT_EQ(1, rle[1].ith);    // Second group starts with the 1-th foreground pixel
+  ASSERT_EQ(8, rle[1].start);  // Starting at position 8
+
+  // Third group has 2 pixels
+  ASSERT_EQ(3,  rle[2].ith);    // First group starts with the 3-th foreground pixel
+  ASSERT_EQ(13, rle[2].start);  // Starting at position 13
+
+  // Fourth group has 2 pixels
+  ASSERT_EQ(5,  rle[3].ith);    // First group starts with the 5-th foreground pixel
+  ASSERT_EQ(20, rle[3].start);  // Starting at position 20
+
+  ASSERT_EQ(-1, search_mask.find(7));  // doesn't exist
+  ASSERT_EQ(-1, search_mask.find(-1));  // doesn't exist
+  ASSERT_EQ(2, search_mask.find(0));  // first of first group
+  ASSERT_EQ(8, search_mask.find(1));  // first of second group
+  ASSERT_EQ(9, search_mask.find(2));  // second of second group
+  ASSERT_EQ(14, search_mask.find(4));  // 4-th pixel is at position 14
+
+  std::vector<float> all_bg(10, 0.0f);
+  SearchableRLEMask all_bg_mask(make_cspan(all_bg), 0.0f);
+  ASSERT_EQ(0, all_bg_mask.count());
+  ASSERT_EQ(-1, all_bg_mask.find(0));
+
+  std::vector<float> all_fg(10, 1.0f);
+  SearchableRLEMask all_fg_mask(make_cspan(all_fg), 0.0f);
+  ASSERT_EQ(all_fg.size(), all_fg_mask.count());
+  for (size_t i = 0; i < all_fg.size(); i++)
+    ASSERT_EQ(i, all_fg_mask.find(i));
+
+  std::vector<float> pattern(10, 0.0f);
+  for (size_t i = 1; i < pattern.size(); i+=2)
+    pattern[i] = 1.0f;
+  SearchableRLEMask pattern_mask(make_cspan(pattern), 0.0f);
+  ASSERT_EQ(pattern.size() / 2, pattern_mask.count());
+  for (int i = 0; i < pattern_mask.count(); i++)
+    ASSERT_EQ(2 * i + 1, pattern_mask.find(i));
+}
+
+}  // namespace dali


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a new feature needed to implement a random crop center generator with certain probability to get a foreground pixel center.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a class that encodes a mask in a run-length-encoding format that is designed to be easy to search. A user of this class can know how many foreground pixels are in the mask and can get the flat index for an arbitrary i-th foreground pixel, as they appear in the mask*
 - Affected modules and functionalities:
     *No existing functionality is affected*
 - Key points relevant for the review:
     *RLE table construction and search algorithm*
 - Validation and testing:
     *Unit tests*
 - Documentation (including examples):
     *Doxygen and documented tests*


**JIRA TASK**: *[DALI-1723]*
