### PR TITLE
Make the custom nvJPEG allocator not throw and return only the status

### DIFF
--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
@@ -212,9 +212,14 @@ static int DeviceNew(void **ptr, size_t size) {
   try {
     *ptr = GetBuffer(std::this_thread::get_id(), AllocType::GPU, size);
     return *ptr != nullptr ? cudaSuccess : cudaErrorMemoryAllocation;
-  } catch (...) {
+  } catch (const std::bad_alloc &) {
     *ptr = nullptr;
     return cudaErrorMemoryAllocation;
+  } catch (const CUDAError &e) {
+    return e.is_rt_api() ? e.rt_error() : cudaErrorUnknown;
+  } catch (...) {
+    *ptr = nullptr;
+    return cudaErrorUnknown;
   }
 }
 
@@ -227,9 +232,14 @@ static int PinnedNew(void **ptr, size_t size, unsigned int flags) {
   try {
     *ptr = GetBuffer(std::this_thread::get_id(), AllocType::Pinned, size);
     return *ptr != nullptr ? cudaSuccess : cudaErrorMemoryAllocation;
-  } catch (...) {
+  } catch (const std::bad_alloc &) {
     *ptr = nullptr;
     return cudaErrorMemoryAllocation;
+  } catch (const CUDAError &e) {
+    return e.is_rt_api() ? e.rt_error() : cudaErrorUnknown;
+  } catch (...) {
+    *ptr = nullptr;
+    return cudaErrorUnknown;
   }
 }
 

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
@@ -208,8 +208,14 @@ static int DeviceNew(void **ptr, size_t size) {
     *ptr = nullptr;
     return cudaSuccess;
   }
-  *ptr = GetBuffer(std::this_thread::get_id(), AllocType::GPU, size);
-  return *ptr != nullptr ? cudaSuccess : cudaErrorMemoryAllocation;
+  // this function should not throw, but return a proper result
+  try {
+    *ptr = GetBuffer(std::this_thread::get_id(), AllocType::GPU, size);
+    return *ptr != nullptr ? cudaSuccess : cudaErrorMemoryAllocation;
+  } catch (...) {
+    *ptr = nullptr;
+    return cudaErrorMemoryAllocation;
+  }
 }
 
 static int PinnedNew(void **ptr, size_t size, unsigned int flags) {
@@ -217,8 +223,14 @@ static int PinnedNew(void **ptr, size_t size, unsigned int flags) {
     *ptr = nullptr;
     return cudaSuccess;
   }
-  *ptr = GetBuffer(std::this_thread::get_id(), AllocType::Pinned, size);
-  return *ptr != nullptr ? cudaSuccess : cudaErrorMemoryAllocation;
+  // this function should not throw, but return a proper result
+  try {
+    *ptr = GetBuffer(std::this_thread::get_id(), AllocType::Pinned, size);
+    return *ptr != nullptr ? cudaSuccess : cudaErrorMemoryAllocation;
+  } catch (...) {
+    *ptr = nullptr;
+    return cudaErrorMemoryAllocation;
+  }
 }
 
 nvjpegDevAllocator_t GetDeviceAllocator() {


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It makes the custom nvJPEG allocator not throw and return only the status

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     make the custom nvJPEG allocator not throw and return only the status
 - Affected modules and functionalities:
     nvJPEG based decoder
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[Use DALI-1721]*
