### PR TITLE
Deprecate squeeze_labels option from MXNet iterator and enhance .squeeze function to match numpy style interface

### DIFF
--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -428,14 +428,33 @@ class Tensor : public Buffer<Backend> {
   }
 
   /**
-   * @brief Remove single-dimensional entries from the shape
-   * of a Tensor
+   * @brief Remove any single-dimensional entries from the shape
+   * of a Tensor.
    */
   inline void Squeeze() {
-    std::vector<Index> shape(shape_.begin(), shape_.end());
+    SmallVector<int64_t, 6> shape(shape_.begin(), shape_.end());
     shape.erase(std::remove(shape.begin(), shape.end(), 1), shape.end());
     if (shape.empty()) {
       shape.push_back(1);
+    }
+    shape_ = shape;
+  }
+
+  /**
+   * @brief Removes the specified dimension from the shape, if its extent is
+   * equal to 1.
+   * @param dim Dimension to be squeezed. Negative indexing is also supported
+   */
+  inline void Squeeze(int dim) {
+    SmallVector<int64_t, 6> shape(shape_.begin(), shape_.end());
+    int ndim = shape_.size();
+    DALI_ENFORCE(dim >= -ndim && dim <= (ndim - 1),
+                 make_string("axis ", dim, " is out of bound for a tensor with ", shape_.size(),
+                             " dimensions."));
+    if (dim < 0)
+      dim += shape_.size();
+    if (shape_[dim] == 1) {
+      shape.erase(shape.begin() + dim);
     }
     shape_ = shape;
   }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -379,7 +379,7 @@ void ExposeTensor(py::module &m) {
       Remove single-dimensional entries from the shape of the Tensor.
 
       dim : int
-            If >= 0, specifies a single dimension to be squeezed.
+            If specified, it represents the axis of a single dimension to be squeezed.
       )code")
     .def("layout", [](Tensor<CPUBackend> &t) {
       return t.GetLayout().str();
@@ -482,9 +482,8 @@ void ExposeTensor(py::module &m) {
       Remove single-dimensional entries from the shape of the Tensor.
 
       dim : int
-            If >= 0, specifies a single dimension to be squeezed.
+            If specified, it represents the axis of a single dimension to be squeezed.
       )code")
-
     .def("copy_to_external",
         [](Tensor<GPUBackend> &t, py::object p, py::object cuda_stream,
            bool non_blocking, bool use_copy_kernel) {

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -365,10 +365,22 @@ void ExposeTensor(py::module &m) {
          R"code(
          Shape of the tensor.
          )code")
-    .def("squeeze", &Tensor<CPUBackend>::Squeeze,
-         R"code(
-         Remove single-dimensional entries from the shape of the Tensor.
-         )code")
+    .def("squeeze",
+      [](Tensor<CPUBackend> &t, py::object dim_arg) {
+        if (!dim_arg.is_none()) {
+          int dim = dim_arg.cast<int>();
+          t.Squeeze(dim);
+        } else {
+          t.Squeeze();
+        }
+      },
+      "dim"_a = py::none(),
+      R"code(
+      Remove single-dimensional entries from the shape of the Tensor.
+
+      dim : int
+            If >= 0, specifies a single dimension to be squeezed.
+      )code")
     .def("layout", [](Tensor<CPUBackend> &t) {
       return t.GetLayout().str();
     })
@@ -456,10 +468,23 @@ void ExposeTensor(py::module &m) {
       Returns a `TensorCPU` object being a copy of this `TensorGPU`.
       )code",
       py::return_value_policy::take_ownership)
-    .def("squeeze", &Tensor<GPUBackend>::Squeeze,
-         R"code(
-         Remove single-dimensional entries from the shape of the Tensor.
-         )code")
+    .def("squeeze",
+      [](Tensor<GPUBackend> &t, py::object dim_arg) {
+        if (!dim_arg.is_none()) {
+          int dim = dim_arg.cast<int>();
+          t.Squeeze(dim);
+        } else {
+          t.Squeeze();
+        }
+      },
+      "dim"_a = py::none(),
+      R"code(
+      Remove single-dimensional entries from the shape of the Tensor.
+
+      dim : int
+            If >= 0, specifies a single dimension to be squeezed.
+      )code")
+
     .def("copy_to_external",
         [](Tensor<GPUBackend> &t, py::object p, py::object cuda_stream,
            bool non_blocking, bool use_copy_kernel) {

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -366,17 +366,17 @@ void ExposeTensor(py::module &m) {
          Shape of the tensor.
          )code")
     .def("squeeze",
-      [](Tensor<CPUBackend> &t, py::object dim_arg) {
+      [](Tensor<CPUBackend> &t, py::object dim_arg) -> bool {
         if (!dim_arg.is_none()) {
           int dim = dim_arg.cast<int>();
-          t.Squeeze(dim);
-        } else {
-          t.Squeeze();
+          return t.Squeeze(dim);
         }
+        return t.Squeeze();
       },
       "dim"_a = py::none(),
       R"code(
-      Remove single-dimensional entries from the shape of the Tensor.
+      Remove single-dimensional entries from the shape of the Tensor and it returns true
+      if the shape changed or false if it remained unchanged.
 
       dim : int
             If specified, it represents the axis of a single dimension to be squeezed.
@@ -469,17 +469,17 @@ void ExposeTensor(py::module &m) {
       )code",
       py::return_value_policy::take_ownership)
     .def("squeeze",
-      [](Tensor<GPUBackend> &t, py::object dim_arg) {
+      [](Tensor<GPUBackend> &t, py::object dim_arg) -> bool {
         if (!dim_arg.is_none()) {
           int dim = dim_arg.cast<int>();
-          t.Squeeze(dim);
-        } else {
-          t.Squeeze();
+          return t.Squeeze(dim);
         }
+        return t.Squeeze();
       },
       "dim"_a = py::none(),
       R"code(
-      Remove single-dimensional entries from the shape of the Tensor.
+      Remove single-dimensional entries from the shape of the Tensor and it returns true
+      if the shape changed or false if it remained unchanged.
 
       dim : int
             If specified, it represents the axis of a single dimension to be squeezed.

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -158,9 +158,11 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
     auto_reset : bool, optional, default = False
                  Whether the iterator resets itself for the next epoch
                  or it requires reset() to be called separately.
-    squeeze_labels: bool, optional, default = True
+    squeeze_labels: (DEPRECATED) bool, optional, default = False
                  Whether the iterator should squeeze the labels before
                  copying them to the ndarray.
+                 This argument is deprecated and will be removed from future releases
+                 without further notice.
     dynamic_shape: bool, optional, default = False
                  Whether the shape of the output of the DALI pipeline can
                  change during execution. If True, the mxnet.ndarray will be resized accordingly
@@ -213,7 +215,7 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
                  data_layout='NCHW',
                  fill_last_batch=None,
                  auto_reset=False,
-                 squeeze_labels=True,
+                 squeeze_labels=None,
                  dynamic_shape=False,
                  last_batch_padded=False,
                  last_batch_policy=LastBatchPolicy.FILL):
@@ -237,6 +239,8 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
             auto_reset,
             last_batch_policy)
         self._squeeze_labels = squeeze_labels
+        if self._squeeze_labels is not None:
+            print("``squeeze_labels`` is now deprecated. Any manipulation of the tensor shapes should be done explicitly in the DALI pipeline.")
         self._dynamic_shape = dynamic_shape
         # Use double-buffering of data batches
         self._data_batches = [[None] for i in range(self._num_gpus)]
@@ -292,7 +296,8 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
                 [x.as_tensor() for x in category_outputs[DALIGenericIterator.LABEL_TAG]]
             if self._squeeze_labels:
                 for label in category_tensors[DALIGenericIterator.LABEL_TAG]:
-                    label.squeeze()
+                    if label.shape()[-1] == 1:
+                        label.squeeze(-1)
             category_info[DALIGenericIterator.LABEL_TAG] = \
                 [(x.shape(), np.dtype(x.dtype())) for x in category_tensors[DALIGenericIterator.LABEL_TAG]]
 
@@ -419,9 +424,11 @@ class DALIClassificationIterator(DALIGenericIterator):
     auto_reset : bool, optional, default = False
                  Whether the iterator resets itself for the next epoch
                  or it requires reset() to be called separately.
-    squeeze_labels: bool, optional, default = True
+    squeeze_labels: (DEPRECATED) bool, optional, default = False
                  Whether the iterator should squeeze the labels before
                  copying them to the ndarray.
+                 This argument is deprecated and will be removed from future releases
+                 without further notice.
     dynamic_shape: bool, optional, default = False
                  Whether the shape of the output of the DALI pipeline can
                  change during execution. If True, the mxnet.ndarray will be resized accordingly
@@ -475,7 +482,7 @@ class DALIClassificationIterator(DALIGenericIterator):
                  data_layout='NCHW',
                  fill_last_batch=None,
                  auto_reset=False,
-                 squeeze_labels=True,
+                 squeeze_labels=None,
                  dynamic_shape=False,
                  last_batch_padded=False,
                  last_batch_policy=LastBatchPolicy.FILL):

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -161,8 +161,7 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
     squeeze_labels: (DEPRECATED) bool, optional, default = False
                  Whether the iterator should squeeze the labels before
                  copying them to the ndarray.
-                 This argument is deprecated and will be removed from future releases
-                 without further notice.
+                 This argument is deprecated and will be removed from future releases.
     dynamic_shape: bool, optional, default = False
                  Whether the shape of the output of the DALI pipeline can
                  change during execution. If True, the mxnet.ndarray will be resized accordingly
@@ -427,8 +426,7 @@ class DALIClassificationIterator(DALIGenericIterator):
     squeeze_labels: (DEPRECATED) bool, optional, default = False
                  Whether the iterator should squeeze the labels before
                  copying them to the ndarray.
-                 This argument is deprecated and will be removed from future releases
-                 without further notice.
+                 This argument is deprecated and will be removed from future releases.
     dynamic_shape: bool, optional, default = False
                  Whether the shape of the output of the DALI pipeline can
                  change during execution. If True, the mxnet.ndarray will be resized accordingly

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -239,7 +239,7 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
             last_batch_policy)
         self._squeeze_labels = squeeze_labels
         if self._squeeze_labels is not None:
-            print("``squeeze_labels`` is now deprecated. Any manipulation of the tensor shapes should be done explicitly in the DALI pipeline.")
+            print("Warning: ``squeeze_labels`` is now deprecated. Any manipulation of the tensor shapes should be done explicitly in the DALI pipeline.")
         self._dynamic_shape = dynamic_shape
         # Use double-buffering of data batches
         self._data_batches = [[None] for i in range(self._num_gpus)]
@@ -295,8 +295,7 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
                 [x.as_tensor() for x in category_outputs[DALIGenericIterator.LABEL_TAG]]
             if self._squeeze_labels:
                 for label in category_tensors[DALIGenericIterator.LABEL_TAG]:
-                    if label.shape()[-1] == 1:
-                        label.squeeze(-1)
+                    label.squeeze(-1)  # Squeeze last dimension if necessary
             category_info[DALIGenericIterator.LABEL_TAG] = \
                 [(x.shape(), np.dtype(x.dtype())) for x in category_tensors[DALIGenericIterator.LABEL_TAG]]
 

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -100,3 +100,27 @@ def test_array_interface_types():
 #    two_first_tensors = tensorlist[0:2]
 #    assert(type(two_first_tensors) == tuple)
 #    assert(type(two_first_tensors[0]) == TensorCPU)
+
+def test_squeeze():
+    def check_squeeze(shape, dim=None):
+        arr = np.random.rand(*shape)
+        t = TensorCPU(arr, "")
+        t.squeeze(dim)
+        arr_squeeze = arr.squeeze(dim)
+        t_shape = tuple(t.shape())
+        assert t_shape == arr_squeeze.shape, f"{t_shape} != {arr_squeeze.shape}"
+        assert_array_equal(arr_squeeze, np.array(t))
+
+    for dim, shape in [(None, (3, 5, 6)),
+                       (None, (3, 1, 6)),
+                       (1, (3, 1, 6)),
+                       (-2, (3, 1, 6)),
+                       (None, (1, 1, 6)),
+                       (1, (1, 1, 6)),
+                       #(None, (1, 1, 1)),  # Numpy produces a scalar in this case (probably we should too)
+                       (None, (1, 5, 1)),
+                       (-1, (1, 5, 1)),
+                       (0, (1, 5, 1)),
+                       (None, (3, 5, 1)),
+                       ]:
+        yield check_squeeze, shape, dim

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -101,26 +101,28 @@ def test_array_interface_types():
 #    assert(type(two_first_tensors) == tuple)
 #    assert(type(two_first_tensors[0]) == TensorCPU)
 
-def test_squeeze():
-    def check_squeeze(shape, dim=None):
+
+def test_tensor_cpu_squeeze():
+    def check_squeeze(shape, dim, in_layout, expected_out_layout):
         arr = np.random.rand(*shape)
-        t = TensorCPU(arr, "")
+        t = TensorCPU(arr, in_layout)
         t.squeeze(dim)
         arr_squeeze = arr.squeeze(dim)
         t_shape = tuple(t.shape())
         assert t_shape == arr_squeeze.shape, f"{t_shape} != {arr_squeeze.shape}"
-        assert_array_equal(arr_squeeze, np.array(t))
+        assert t.layout() == expected_out_layout, f"{t.layout()} != {expected_out_layout}"
+        assert np.allclose(arr_squeeze, np.array(t))
 
-    for dim, shape in [(None, (3, 5, 6)),
-                       (None, (3, 1, 6)),
-                       (1, (3, 1, 6)),
-                       (-2, (3, 1, 6)),
-                       (None, (1, 1, 6)),
-                       (1, (1, 1, 6)),
-                       #(None, (1, 1, 1)),  # Numpy produces a scalar in this case (probably we should too)
-                       (None, (1, 5, 1)),
-                       (-1, (1, 5, 1)),
-                       (0, (1, 5, 1)),
-                       (None, (3, 5, 1)),
-                       ]:
-        yield check_squeeze, shape, dim
+    for dim, shape, in_layout, expected_out_layout in \
+            [(None, (3, 5, 6), "ABC", "ABC"),
+             (None, (3, 1, 6), "ABC", "AC"),
+             (1, (3, 1, 6), "ABC", "AC"),
+             (-2, (3, 1, 6), "ABC", "AC"),
+             (None, (1, 1, 6), "ABC", "C"),
+             (1, (1, 1, 6), "ABC", "AC"),
+             (None, (1, 1, 1), "ABC", ""),
+             (None, (1, 5, 1), "ABC", "B"),
+             (-1, (1, 5, 1), "ABC", "AB"),
+             (0, (1, 5, 1), "ABC", "BC"),
+             (None, (3, 5, 1), "ABC", "AB")]:
+        yield check_squeeze, shape, dim, in_layout, expected_out_layout

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -106,12 +106,14 @@ def test_tensor_cpu_squeeze():
     def check_squeeze(shape, dim, in_layout, expected_out_layout):
         arr = np.random.rand(*shape)
         t = TensorCPU(arr, in_layout)
-        t.squeeze(dim)
+        is_squeezed = t.squeeze(dim)
+        should_squeeze = (len(expected_out_layout) < len(in_layout))
         arr_squeeze = arr.squeeze(dim)
         t_shape = tuple(t.shape())
         assert t_shape == arr_squeeze.shape, f"{t_shape} != {arr_squeeze.shape}"
         assert t.layout() == expected_out_layout, f"{t.layout()} != {expected_out_layout}"
         assert np.allclose(arr_squeeze, np.array(t))
+        assert is_squeezed == should_squeeze, f"{is_squeezed} != {should_squeeze}"
 
     for dim, shape, in_layout, expected_out_layout in \
             [(None, (3, 5, 6), "ABC", "ABC"),

--- a/dali/test/python/test_backend_impl_gpu.py
+++ b/dali/test/python/test_backend_impl_gpu.py
@@ -194,12 +194,14 @@ def test_tensor_gpu_squeeze():
     def check_squeeze(shape, dim, in_layout, expected_out_layout):
         arr = cp.random.rand(*shape)
         t = TensorGPU(arr, in_layout)
-        t.squeeze(dim)
+        is_squeezed = t.squeeze(dim)
+        should_squeeze = (len(expected_out_layout) < len(in_layout))
         arr_squeeze = arr.squeeze(dim)
         t_shape = tuple(t.shape())
         assert t_shape == arr_squeeze.shape, f"{t_shape} != {arr_squeeze.shape}"
         assert t.layout() == expected_out_layout, f"{t.layout()} != {expected_out_layout}"
         assert cp.allclose(arr_squeeze, cp.asanyarray(t))
+        assert is_squeezed == should_squeeze, f"{is_squeezed} != {should_squeeze}"
 
     for dim, shape, in_layout, expected_out_layout in \
             [(None, (3, 5, 6), "ABC", "ABC"),

--- a/dali/test/python/test_backend_impl_gpu.py
+++ b/dali/test/python/test_backend_impl_gpu.py
@@ -188,3 +188,27 @@ def test_cuda_array_interface_tensor_gpu_create_from_numpy():
 def test_cuda_array_interface_tensor_list_gpu_create_from_numpy():
     arr = np.random.rand(3, 5, 6)
     tensor = TensorGPU(arr, "NHWC")
+
+
+def test_squeeze():
+    def check_squeeze(shape, dim=None):
+        arr = cp.random.rand(*shape)
+        t = TensorGPU(arr, "")
+        t.squeeze(dim)
+        arr_squeeze = arr.squeeze(dim)
+        t_shape = tuple(t.shape())
+        assert t_shape == arr_squeeze.shape, f"{t_shape} != {arr_squeeze.shape}"
+        assert cp.allclose(arr_squeeze, cp.asanyarray(t))
+
+    for dim, shape in [(None, (3, 5, 6)),
+                       (None, (3, 1, 6)),
+                       (1, (3, 1, 6)),
+                       (-2, (3, 1, 6)),
+                       (None, (1, 1, 6)),
+                       (1, (1, 1, 6)),
+                       #(None, (1, 1, 1)),  # Numpy produces a scalar in this case (probably we should too)
+                       (None, (1, 5, 1)),
+                       (-1, (1, 5, 1)),
+                       (0, (1, 5, 1)),
+                       (None, (3, 5, 1))]:
+        yield check_squeeze, shape, dim

--- a/include/dali/core/tensor_layout.h
+++ b/include/dali/core/tensor_layout.h
@@ -283,14 +283,20 @@ class TensorLayout {
     return TensorLayout(end() - n, n);
   }
 
-  DALI_HOST_DEV TensorLayout& operator+=(const TensorLayout &oth) {
+  DALI_HOST_DEV TensorLayout& operator+=(const TensorLayout &oth) noexcept {
     *this = *this + oth;
     return *this;
   }
 
-  DALI_HOST_DEV TensorLayout& operator+=(char oth) {
+  DALI_HOST_DEV TensorLayout& operator+=(char oth) noexcept {
     *this = *this + oth;
     return *this;
+  }
+
+  DALI_HOST_DEV
+  void erase(int index) noexcept {
+    assert(index >= 0 && index < ndim());
+    *this = first(index) + sub(index + 1);
   }
 
   static constexpr int max_ndim = 16-1;
@@ -313,14 +319,14 @@ class TensorLayout {
   DALI_HOST_DEV
   friend constexpr TensorLayout operator+(const TensorLayout &a, const TensorLayout &b);
   DALI_HOST_DEV
-  friend constexpr TensorLayout operator+(const TensorLayout &a, const char &b);
+  friend constexpr TensorLayout operator+(const TensorLayout &a, char b);
 };
 
 static_assert(sizeof(TensorLayout) == 16, "Tensor layout size should be exactly 16B");
 
 /** @brief Appends a single element to the layout string */
 DALI_HOST_DEV
-constexpr TensorLayout operator+(const TensorLayout &a, const char &b) {
+constexpr TensorLayout operator+(const TensorLayout &a, char b) {
   assert(a.size() + 1 < TensorLayout::max_ndim);
   TensorLayout result = a;
   int i = result.ndim();

--- a/include/dali/core/tensor_layout.h
+++ b/include/dali/core/tensor_layout.h
@@ -283,6 +283,16 @@ class TensorLayout {
     return TensorLayout(end() - n, n);
   }
 
+  DALI_HOST_DEV TensorLayout& operator+=(const TensorLayout &oth) {
+    *this = *this + oth;
+    return *this;
+  }
+
+  DALI_HOST_DEV TensorLayout& operator+=(char oth) {
+    *this = *this + oth;
+    return *this;
+  }
+
   static constexpr int max_ndim = 16-1;
 
  private:
@@ -302,9 +312,28 @@ class TensorLayout {
 
   DALI_HOST_DEV
   friend constexpr TensorLayout operator+(const TensorLayout &a, const TensorLayout &b);
+  DALI_HOST_DEV
+  friend constexpr TensorLayout operator+(const TensorLayout &a, const char &b);
 };
 
 static_assert(sizeof(TensorLayout) == 16, "Tensor layout size should be exactly 16B");
+
+/** @brief Appends a single element to the layout string */
+DALI_HOST_DEV
+constexpr TensorLayout operator+(const TensorLayout &a, const char &b) {
+  assert(a.size() + 1 < TensorLayout::max_ndim);
+  TensorLayout result = a;
+  int i = result.ndim();
+  result[i++] = b;
+  result[i] = '\0';
+
+  /* Cannot use
+   *   result.set_size(i);
+   * because it's not constexpr
+   */
+  result.data_[TensorLayout::max_ndim] = TensorLayout::max_ndim - i;
+  return result;
+}
 
 /** @brief Concatenates the layout strings */
 DALI_HOST_DEV


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in MxNet generic iterator, when batch_size is 1

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     The option squeeze_labels=True caused the batch dimension to disappear when batch_size=1
 - Affected modules and functionalities:
     *MXNet generic iterator*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     *Existing tests*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
