### PR TITLE
Skips the building of prebuilt DALI package for nvidia-tensorflow

### DIFF
--- a/dali_tf_plugin/build_in_custom_op_docker.sh
+++ b/dali_tf_plugin/build_in_custom_op_docker.sh
@@ -18,11 +18,7 @@ mkdir -p $PREBUILT_DIR/$COMPILER_SUBDIR_NAME
 
 for i in `seq 0 $LAST_CONFIG_INDEX`; do
     INST=$(python ../qa/setup_packages.py -i $i -u tensorflow-gpu --cuda ${CUDA_VERSION})
-    PREFIX=${INST%nvidia-tensorflow*}
-    SUFIX=${INST#*nvidia-tensorflow}
-    PARTIAL=${INST#$PREFIX}
-    FINAL=${PARTIAL%$SUFIX}
-    if [ "${FINAL}" == "nvidia-tensorflow" ]; then \
+    if [[ "${INST}" == *"nvidia-tensorflow"* ]]; then \
         continue
     fi
     echo "Building DALI TF plugin for TF version ${INST}"

--- a/dali_tf_plugin/build_in_custom_op_docker.sh
+++ b/dali_tf_plugin/build_in_custom_op_docker.sh
@@ -18,6 +18,13 @@ mkdir -p $PREBUILT_DIR/$COMPILER_SUBDIR_NAME
 
 for i in `seq 0 $LAST_CONFIG_INDEX`; do
     INST=$(python ../qa/setup_packages.py -i $i -u tensorflow-gpu --cuda ${CUDA_VERSION})
+    PREFIX=${INST%nvidia-tensorflow*}
+    SUFIX=${INST#*nvidia-tensorflow}
+    PARTIAL=${INST#$PREFIX}
+    FINAL=${PARTIAL%$SUFIX}
+    if [ "${FINAL}" == "nvidia-tensorflow" ]; then \
+        continue
+    fi
     echo "Building DALI TF plugin for TF version ${INST}"
     pip install ${INST} -f /pip-packages
 

--- a/docker/Dockerfile.customopbuilder.clean
+++ b/docker/Dockerfile.customopbuilder.clean
@@ -75,15 +75,12 @@ COPY qa/setup_packages.py qa/setup_packages.py
 
 # get current CUDA version, ask setup_packages.py which TensorFlow we need to support and loop over all version downloading
 # them to /pip-packages dir one by one. In effect all TF versions are stored in only one place setup_packages.py
+SHELL ["/bin/bash", "-c"]
 RUN export USE_CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*) | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1\2/') && \
     export last_config_index=$(python qa/setup_packages.py -n -u tensorflow-gpu --cuda ${USE_CUDA_VERSION}) && \
     for i in `seq 0 $last_config_index`; do \
         package=$(python qa/setup_packages.py -i $i -u tensorflow-gpu --cuda ${USE_CUDA_VERSION}); \
-        prefix=${package%nvidia-tensorflow*}; \
-        sufix=${package#*nvidia-tensorflow};  \
-        partial=${package#$prefix};           \
-        final=${partial%$sufix};              \
-        if [ "${final}" != "nvidia-tensorflow" ]; then \
+        if [[ "${package}" != *"nvidia-tensorflow"* ]]; then \
             pip download ${package} -d /pip-packages; \
         fi \
     done

--- a/docker/Dockerfile.customopbuilder.clean
+++ b/docker/Dockerfile.customopbuilder.clean
@@ -78,5 +78,12 @@ COPY qa/setup_packages.py qa/setup_packages.py
 RUN export USE_CUDA_VERSION=$(echo $(ls /usr/local/cuda/lib64/libcudart.so*) | sed 's/.*\.\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1\2/') && \
     export last_config_index=$(python qa/setup_packages.py -n -u tensorflow-gpu --cuda ${USE_CUDA_VERSION}) && \
     for i in `seq 0 $last_config_index`; do \
-        pip download $(python qa/setup_packages.py -i $i -u tensorflow-gpu --cuda ${USE_CUDA_VERSION}) -d /pip-packages; \
+        package=$(python qa/setup_packages.py -i $i -u tensorflow-gpu --cuda ${USE_CUDA_VERSION}); \
+        prefix=${package%nvidia-tensorflow*}; \
+        sufix=${package#*nvidia-tensorflow};  \
+        partial=${package#$prefix};           \
+        final=${partial%$sufix};              \
+        if [ "${final}" != "nvidia-tensorflow" ]; then \
+            pip download ${package} -d /pip-packages; \
+        fi \
     done

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -82,11 +82,11 @@ export DALI_TIMESTAMP=$(date +%Y%m%d)
 
 # Find out which CLI options to use for NVIDIA Container Toolkit needed for TF PLUGIN build
 if [[ "$BUILD_TF_PLUGIN" = "YES" ]]; then
-  if docker run --gpus all nvidia/cuda:${CUDA_VERSION}-base nvidia-smi ; then
+  if docker run --rm --gpus all nvidia/cuda:${CUDA_VERSION}-base nvidia-smi ; then
     export NVDOCKER_COMMAND="docker run --gpus all"
-  elif docker run --runtime nvidia nvidia/cuda:${CUDA_VERSION}-base nvidia-smi ; then
+  elif docker run --rm --runtime nvidia nvidia/cuda:${CUDA_VERSION}-base nvidia-smi ; then
     export NVDOCKER_COMMAND="docker run --runtime nvidia"
-  elif nvidia-docker run nvidia/cuda:${CUDA_VERSION}-base nvidia-smi ; then
+  elif nvidia-docker run --rm nvidia/cuda:${CUDA_VERSION}-base nvidia-smi ; then
     export NVDOCKER_COMMAND="nvidia-docker run"
   else
     echo "Unable to use NVIDIA Container Toolkit."


### PR DESCRIPTION
- building of DALI TF plugin for nvidia-0tesnorflow doesn't work in the tensorflow/tensorflow:custom-op-gpu-ubuntu16 as nvidia-tensorflow requires Ubuntu 18.04 or newer so skip it in the build.sh user build
- when the nvidia-tensorflow can be installed DALI plugin can be usually installed on the fly after that as well as Ubuntu 18.04 is the system used to build it

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It skips the building of prebuild DALI package for nvidia-tensorflow

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
      building of DALI TF plugin for nvidia-0tesnorflow doesn't work in the tensorflow/tensorflow:custom-op-gpu-ubuntu16 as nvidia-tensorflow requires Ubuntu 18.04 or newer so skip it in the build.sh user build
 - Affected modules and functionalities:
     user manual build
 - Key points relevant for the review:
     NA
 - Validation and testing:
    manual build `REBUILD_BUILDERS=YES CUDA_VERSION=11.0 BUILD_TF_PLUGIN=YES CREATE_RUNNER=YES ./build.sh`     
 - Documentation (including examples):
     NA

Relates to https://github.com/NVIDIA/DALI/issues/2448 and https://github.com/NVIDIA/DALI/pull/2449
**JIRA TASK**: *[NA]*
