### PR TITLE
Add support for int8 and uint8 in CropMirrorNormalize operator

### DIFF
--- a/dali/operators/image/crop/crop_mirror_normalize.cc
+++ b/dali/operators/image/crop/crop_mirror_normalize.cc
@@ -41,7 +41,7 @@ Normalization takes the input images and produces the output by using the follow
   .AddOptionalArg("dtype",
        R"code(Output data type.
 
-Supported types: ``FLOAT``, ``FLOAT16``, and ``UINT8``.
+Supported types: ``FLOAT``, ``FLOAT16``, ``UINT8``, and ``INT8``.
 
 If not set, the input type is used.)code", DALI_FLOAT)
   .DeprecateArgInFavorOf("output_dtype", "dtype")  // deprecated since 0.24dev

--- a/dali/operators/image/crop/crop_mirror_normalize.h
+++ b/dali/operators/image/crop/crop_mirror_normalize.h
@@ -33,7 +33,7 @@
 #include "dali/pipeline/operator/operator.h"
 
 #define CMN_IN_TYPES (uint8_t, int16_t, uint16_t, int32_t, float, float16)
-#define CMN_OUT_TYPES (float, float16)
+#define CMN_OUT_TYPES (float, float16, uint8_t, int8_t)
 #define CMN_NDIMS (3, 4, 5)
 
 namespace dali {


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds support for int8 and uint8 in CropMirrorNormalize operator

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds support for int8 and uint8 in CropMirrorNormalize operator
 - Affected modules and functionalities:
     CropMirrorNormalize ops
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     Docs updated

Relates to https://github.com/NVIDIA/DALI/issues/2453
**JIRA TASK**: *[NA]*
