### PR TITLE
Fix build with all options off, relax libclang required version

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -19,6 +19,8 @@
 CUDA_find_library(CUDART_LIB cudart_static)
 list(APPEND DALI_EXCLUDES libcudart_static.a)
 
+include_directories(SYSTEM ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+
 # For NVJPEG
 if (BUILD_NVJPEG)
   find_package(NVJPEG 9.0 REQUIRED)

--- a/dali/core/CMakeLists.txt
+++ b/dali/core/CMakeLists.txt
@@ -30,15 +30,15 @@ separate_arguments(DEFAULT_COMPILER_INCLUDE UNIX_COMMAND  "${DEFAULT_COMPILER_IN
 set(CUDA_GENERATED_STUB "${CMAKE_CURRENT_BINARY_DIR}/dynlink_cuda_gen.cc")
 add_custom_command(
     OUTPUT ${CUDA_GENERATED_STUB}
-    COMMAND python ${CMAKE_SOURCE_DIR}/tools/stub_generator/stub_codegen.py --unique_prefix=Cuda --
-                "${CMAKE_SOURCE_DIR}/tools/stub_generator/cuda.json" ${CUDA_GENERATED_STUB}
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/stub_codegen.py --unique_prefix=Cuda --
+                "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/cuda.json" ${CUDA_GENERATED_STUB}
                 "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/cuda.h" "-I${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                 # for some reason QNX fails with 'too many errors emitted' is this is not set
                 "-ferror-limit=0"
                 ${DEFAULT_COMPILER_INCLUDE}
-    DEPENDS ${CMAKE_SOURCE_DIR}/tools/stub_generator/stub_codegen.py
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/stub_codegen.py
             "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/cuda.h"
-            "${CMAKE_SOURCE_DIR}/tools/stub_generator/cuda.json"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/cuda.json"
     COMMENT "Running cuda.h stub generator"
     VERBATIM)
 

--- a/dali/kernels/CMakeLists.txt
+++ b/dali/kernels/CMakeLists.txt
@@ -37,7 +37,7 @@ collect_test_sources(DALI_KERNEL_TEST_SRCS)
 add_library(dali_kernels ${LIBTYPE} ${DALI_KERNEL_SRCS})
 target_link_libraries(dali_kernels PUBLIC dali_core)
 target_link_libraries(dali_kernels PRIVATE ${CUDA_cufft_static_LIBRARY})
-target_link_libraries(dali_kernels PRIVATE ${DALI_LIBS})
+target_link_libraries(dali_kernels PRIVATE ${DALI_LIBS} dynlink_cuda)
 target_link_libraries(dali_kernels PRIVATE "-Wl,--exclude-libs,${exclude_libs}")
 set_target_properties(dali_kernels PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${DALI_LIBRARY_OUTPUT_DIR}")

--- a/dali/operators/reader/nvdecoder/CMakeLists.txt
+++ b/dali/operators/reader/nvdecoder/CMakeLists.txt
@@ -29,17 +29,17 @@ separate_arguments(DEFAULT_COMPILER_INCLUDE UNIX_COMMAND  "${DEFAULT_COMPILER_IN
 set(NVCUVID_GENERATED_STUB "${CMAKE_CURRENT_BINARY_DIR}/dynlink_nvcuvid_gen.cc")
 add_custom_command(
     OUTPUT ${NVCUVID_GENERATED_STUB}
-    COMMAND python ${CMAKE_SOURCE_DIR}/tools/stub_generator/stub_codegen.py --unique_prefix=Nvcuvid --
-                "${CMAKE_SOURCE_DIR}/tools/stub_generator/nvcuvid.json" ${NVCUVID_GENERATED_STUB}
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/stub_generator/stub_codegen.py --unique_prefix=Nvcuvid --
+                "${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/stub_generator/nvcuvid.json" ${NVCUVID_GENERATED_STUB}
                 "${CMAKE_CURRENT_SOURCE_DIR}/nvcuvid.h" "-I${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                 "-I${CMAKE_SOURCE_DIR}/include" "-I${CMAKE_SOURCE_DIR}"
                 # for some reason QNX fails with 'too many errors emitted' is this is not set
                 "-ferror-limit=0"
                 ${DEFAULT_COMPILER_INCLUDE}
-    DEPENDS ${CMAKE_SOURCE_DIR}/tools/stub_generator/stub_codegen.py
+    DEPENDS  ${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/stub_generator/stub_codegen.py
             "${CMAKE_CURRENT_SOURCE_DIR}/nvcuvid.h"
             "${CMAKE_CURRENT_SOURCE_DIR}/cuviddec.h"
-            "${CMAKE_SOURCE_DIR}/tools/stub_generator/nvcuvid.json"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/stub_generator/nvcuvid.json"
     COMMENT "Running nvcuvid.h stub generator"
     VERBATIM)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,8 +21,8 @@ ENV PATH=/opt/python/cp36-cp36/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-c
 RUN ln -s /opt/python/cp${PYV}* /opt/python/v
 
 # in aarch64 pip install libclang will fail
-RUN pip install future setuptools wheel clang==11.0.0 && \
-    pip install libclang==11.0.0 || true && \
+RUN pip install future setuptools wheel clang && \
+    pip install libclang || true && \
     rm -rf /root/.cache/pip/
 
 # install clang for aarch64 from llvm-toolset-7.0, and patch clang pip package to use it

--- a/qa/TL1_nodeps_build/test.sh
+++ b/qa/TL1_nodeps_build/test.sh
@@ -9,7 +9,7 @@ do_once() {
     rm cmake-3.18.4-Linux-x86_64.sh
     # for stub generation
     pip install clang
-    pip isntall libclang
+    pip install libclang
 }
 
 test_body() {

--- a/qa/TL1_nodeps_build/test.sh
+++ b/qa/TL1_nodeps_build/test.sh
@@ -3,10 +3,13 @@
 pip_packages=""
 
 do_once() {
-  apt-get update && apt-get -y install wget wget
-  wget https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-Linux-x86_64.sh
-  bash cmake-3.18.4-Linux-x86_64.sh --skip-license --prefix=/
-  rm cmake-3.18.4-Linux-x86_64.sh
+    apt-get update && apt-get -y install wget wget
+    wget https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-Linux-x86_64.sh
+    bash cmake-3.18.4-Linux-x86_64.sh --skip-license --prefix=/
+    rm cmake-3.18.4-Linux-x86_64.sh
+    # for stub generation
+    pip install clang
+    pip isntall libclang
 }
 
 test_body() {


### PR DESCRIPTION
- DALI doesn't have to pin libclang version, any can be used
- cuda.h cannot be found in the build configuration with all options set to off

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes build with all options off, relax libclang required version

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     DALI doesn't have to pin libclang version, any can be used
     cuda.h cannot be found in the build configuration with all options set to off
 - Affected modules and functionalities:
     build system
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
