### PR TITLE
Add support for UINT8 and INT8 outputs in CMN + scale and shift arguments

### DIFF
--- a/dali/operators/image/crop/crop_mirror_normalize.cc
+++ b/dali/operators/image/crop/crop_mirror_normalize.cc
@@ -60,11 +60,11 @@ If not set, the input type is used.)code", DALI_FLOAT)
     std::vector<float>{1.0f})
   .AddOptionalArg("scale", R"(The value by which the result is multiplied.
 
-This argument is useful when using integer outputs to improve dynamic range utiliztion.)",
+This argument is useful when using integer outputs to improve dynamic range utilization.)",
     1.0f)
   .AddOptionalArg("shift", R"(The value added to the (scaled) result.
 
-This argument is useful when using unsigned integer outputs to improve dynamic range utiliztion.)",
+This argument is useful when using unsigned integer outputs to improve dynamic range utilization.)",
     0.0f)
   .AddParent("CropAttr")
   .AddParent("OutOfBoundsAttr");

--- a/dali/operators/image/crop/crop_mirror_normalize.cc
+++ b/dali/operators/image/crop/crop_mirror_normalize.cc
@@ -27,7 +27,7 @@ DALI_SCHEMA(CropMirrorNormalize)
 
 Normalization takes the input images and produces the output by using the following formula::
 
-  output = (input - mean) / std
+  output = scale * (input - mean) / std + shift
 
 .. note::
     If no cropping arguments are specified, only mirroring and normalization will occur.
@@ -41,7 +41,7 @@ Normalization takes the input images and produces the output by using the follow
   .AddOptionalArg("dtype",
        R"code(Output data type.
 
-Supported types: ``FLOAT``, ``FLOAT16``, and ``UINT8``.
+Supported types: ``FLOAT``, ``FLOAT16``, ``INT8``, ``UINT8``.
 
 If not set, the input type is used.)code", DALI_FLOAT)
   .DeprecateArgInFavorOf("output_dtype", "dtype")  // deprecated since 0.24dev
@@ -58,6 +58,14 @@ If not set, the input type is used.)code", DALI_FLOAT)
   .AddOptionalArg("std",
     R"code(Standard deviation values for image normalization.)code",
     std::vector<float>{1.0f})
+  .AddOptionalArg("scale", R"(The value by which the result is multiplied.
+
+This argument is useful when using integer outputs to improve dynamic range utiliztion.)",
+    1.0f)
+  .AddOptionalArg("shift", R"(The value added to the (scaled) result.
+
+This argument is useful when using unsigned integer outputs to improve dynamic range utiliztion.)",
+    0.0f)
   .AddParent("CropAttr")
   .AddParent("OutOfBoundsAttr");
 

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -22,7 +22,7 @@ from nose.tools import assert_equals, raises
 from nose.plugins.attrib import attr
 import itertools
 
-from test_utils import check_batch, np_types_to_dali
+from test_utils import check_batch, np_type_to_dali
 
 def list_product(*args):
     return list(itertools.product(*args))
@@ -266,7 +266,7 @@ class ExprOpPipeline(Pipeline):
 
     def get_operand(self, operand, kind, operand_type):
         if kind == "const":
-            return types.Constant(magic_number, np_types_to_dali(operand_type))
+            return types.Constant(magic_number, np_type_to_dali(operand_type))
         elif "cpu" in kind:
             return operand
         elif "gpu" in kind:

--- a/dali/test/python/test_operator_peek_image_shape.py
+++ b/dali/test/python/test_operator_peek_image_shape.py
@@ -18,7 +18,7 @@ from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.types as types
 import os
 import numpy as np
-from test_utils import get_dali_extra_path, dali_types_to_np
+from test_utils import get_dali_extra_path, dali_type_to_np
 
 test_data_root = get_dali_extra_path()
 path = 'db/single'
@@ -41,7 +41,7 @@ def run_decode(data_path, out_type):
         for i in range(batch_size):
             # as we are asking for a particular color space it may differ from the source image, so don't compare it
             image = images.at(i)
-            shape_type = dali_types_to_np(out_type)
+            shape_type = dali_type_to_np(out_type)
             for d in range(len(image.shape) - 1):
                 assert image.shape[d] == decoded_shape.at(i)[d], "{} vs {}".format(image.shape[d], decoded_shape.at(i)[d])
                 assert image.shape[d] == raw_shape.at(i)[d], "{} vs {}".format(image.shape[d], raw_shape.at(i)[d])

--- a/dali/test/python/test_operator_reduce.py
+++ b/dali/test/python/test_operator_reduce.py
@@ -5,7 +5,7 @@ from nvidia.dali.pipeline import Pipeline
 
 import numpy as np
 
-from test_utils import np_types_to_dali
+from test_utils import np_type_to_dali
 
 
 class Batch:
@@ -25,7 +25,7 @@ class Batch:
         return 2 * len(self._data)
 
     def reset(self):
-        self._index = 0    
+        self._index = 0
 
 
 class Batch1D(Batch):
@@ -99,7 +99,7 @@ def run_dali(reduce_fn, batch_fn, keep_dims, axes, output_type, add_mean_input =
 
     args = { 'keep_dims': keep_dims, 'axes': axes}
     if output_type is not None:
-        args['dtype'] = np_types_to_dali(output_type)
+        args['dtype'] = np_type_to_dali(output_type)
 
     with pipe:
         input = fn.external_source(source = get_batch)
@@ -121,7 +121,7 @@ def run_dali(reduce_fn, batch_fn, keep_dims, axes, output_type, add_mean_input =
         reduced_gpu = output[1].as_cpu().as_array()
         result_cpu.append(reduced_cpu)
         result_gpu.append(reduced_gpu)
-    
+
     return result_cpu, result_gpu
 
 
@@ -130,7 +130,7 @@ def run_numpy(reduce_fn, batch_fn, keep_dims, axes, output_type, ddof = None):
     args = { 'keepdims': keep_dims, 'axis': axes}
     if output_type is not None:
         args['dtype'] = output_type
-    
+
     if ddof is not None:
         args['ddof'] = ddof
 
@@ -166,7 +166,7 @@ def run_reduce(keep_dims, reduce_fns, batch_gen, input_type, output_type = None)
 
         np_res = run_numpy(
             numpy_reduce_fn, batch_fn, keep_dims = keep_dims, axes = axes, output_type = output_type)
-        
+
         for iteration in range(batch_fn.num_iter()):
             compare(dali_res_cpu[iteration], np_res[iteration])
             compare(dali_res_gpu[iteration], np_res[iteration])
@@ -262,7 +262,7 @@ def run_reduce_with_mean_input(keep_dims, reduce_fns, batch_gen, input_type, out
 
             np_res = run_numpy(
                 numpy_reduce_fn, batch_fn, keep_dims = keep_dims, axes = axes, output_type = output_type, ddof = ddof)
-            
+
             for iteration in range(batch_fn.num_iter()):
                 compare(dali_res_cpu[iteration], np_res[iteration])
                 compare(dali_res_gpu[iteration], np_res[iteration])
@@ -271,7 +271,7 @@ def run_reduce_with_mean_input(keep_dims, reduce_fns, batch_gen, input_type, out
 def test_reduce_with_mean_input():
     reductions = [
         (fn.reductions.std_dev, np.std),
-        (fn.reductions.variance, np.var)]    
+        (fn.reductions.variance, np.var)]
 
     batch_gens = [Batch1D, Batch2D, Batch3D]
     types = [np.uint8, np.int8, np.uint16, np.int16, np.uint32, np.int32, np.uint64, np.int64, np.float32]

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -383,7 +383,7 @@ class check_output_pattern():
         assert pattern_found, \
             "Pattern: ``{}`` \n not found in out: \n``{}`` \n and in err: \n ```{}```".format(self.pattern_, our_data, err_data)
 
-def dali_types_to_np(type):
+def dali_type_to_np(type):
     import_numpy()
 
     dali_types_to_np_dict = {
@@ -402,7 +402,7 @@ def dali_types_to_np(type):
     }
     return dali_types_to_np_dict[type]
 
-def np_types_to_dali(type):
+def np_type_to_dali(type):
     import_numpy()
 
     np_types_to_dali_dict = {


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed for inference in quantized networks(?)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added u8/i8 to supported type list
     * Added scale and shift arguments and preprocessing of mean and stddev.
     * Extended tests to support scale and shift arguments as well as the new types
     * Reduced the number of tested argument combinations
 - Affected modules and functionalities:
     * CropMirrorNormalize
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python tests
 - Documentation (including examples):
     * For the new arguments

**JIRA TASK**: N/A
