### PR TITLE
Fix lack of proper loading of best_prec1 from the checkpoint

### DIFF
--- a/docs/examples/use_cases/pytorch/resnet50/main.py
+++ b/docs/examples/use_cases/pytorch/resnet50/main.py
@@ -285,6 +285,7 @@ def main():
                 print("=> loading checkpoint '{}'".format(args.resume))
                 checkpoint = torch.load(args.resume, map_location = lambda storage, loc: storage.cuda(args.gpu))
                 args.start_epoch = checkpoint['epoch']
+                global best_prec1
                 best_prec1 = checkpoint['best_prec1']
                 model.load_state_dict(checkpoint['state_dict'])
                 optimizer.load_state_dict(checkpoint['optimizer'])


### PR DESCRIPTION
- resume() is a nested function and when it loads best_prec1 it creates a local variable that hides the one from the parent function. This PR adds `nonlocal` to modify the parent function variable as intended

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a lack of proper loading of best_prec1 from the checkpoint

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds `nonlocal` to modify the parent function variable as intended
 - Affected modules and functionalities:
     RN50 PyTorch example
 - Key points relevant for the review:
     NA
 - Validation and testing:
     local test
 - Documentation (including examples):
     RN50 PyTorch example has been updated

Relates to https://github.com/NVIDIA/DALI/issues/2465
**JIRA TASK**: *[NA]*
