### PR TITLE
Hide hidden ops and improve Enum docs quality

### DIFF
--- a/dali/operators/random/batch_permutation.cc
+++ b/dali/operators/random/batch_permutation.cc
@@ -27,8 +27,8 @@ indexing samples in the batch.)")
   .NumOutput(1)
   .AddOptionalArg("allow_repetitions",
       R"(If true, the output can contain repetitions and omissions.)", false)
-  .AddOptionalArg("no_fixed_points", R"(If true, the the output permutation cannot contain fixed "
-  "points, that is ``out[i] != i``. This argument is ignored when batch size is 1.)", false);
+  .AddOptionalArg("no_fixed_points", R"(If true, the the output permutation cannot contain fixed
+points, that is ``out[i] != i``. This argument is ignored when batch size is 1.)", false);
 
 void BatchPermutation::RunImpl(HostWorkspace &ws) {
   auto &output = ws.OutputRef<CPUBackend>(0);

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1099,7 +1099,7 @@ PYBIND11_MODULE(backend_impl, m) {
   types_m.add_object("CPU_ONLY_DEVICE_ID", PyLong_FromLong(CPU_ONLY_DEVICE_ID));
 
   // DALIDataType
-  py::enum_<DALIDataType>(types_m, "DALIDataType", "Data type of image")
+  py::enum_<DALIDataType>(types_m, "DALIDataType", "Data type of image.\n<SPHINX_IGNORE>")
     .value("NO_TYPE",       DALI_NO_TYPE)
     .value("UINT8",         DALI_UINT8)
     .value("UINT16",        DALI_UINT16)
@@ -1131,7 +1131,7 @@ PYBIND11_MODULE(backend_impl, m) {
     .export_values();
 
   // DALIImageType
-  py::enum_<DALIImageType>(types_m, "DALIImageType", "Image type")
+  py::enum_<DALIImageType>(types_m, "DALIImageType", "Image type\n<SPHINX_IGNORE>")
     .value("RGB", DALI_RGB)
     .value("BGR", DALI_BGR)
     .value("GRAY", DALI_GRAY)
@@ -1140,7 +1140,7 @@ PYBIND11_MODULE(backend_impl, m) {
     .export_values();
 
   // DALIInterpType
-  py::enum_<DALIInterpType>(types_m, "DALIInterpType", "Interpolation mode")
+  py::enum_<DALIInterpType>(types_m, "DALIInterpType", "Interpolation mode\n<SPHINX_IGNORE>")
     .value("INTERP_NN", DALI_INTERP_NN)
     .value("INTERP_LINEAR", DALI_INTERP_LINEAR)
     .value("INTERP_CUBIC", DALI_INTERP_CUBIC)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -599,12 +599,6 @@ def python_op_factory(name, schema_name = None, op_device = "cpu"):
 
     Operator.__name__ = str(name)
     Operator.schema_name = schema_name or Operator.__name__
-    # The autodoc doesn't generate doc for something that doesn't match the module name
-    # TODO(klecki): For some reason it's no longer working
-    schema = _b.GetSchema(Operator.schema_name)
-    if schema.IsInternal() or schema.IsDocHidden():
-        Operator.__module__ = Operator.__module__ + ".internal"
-
     Operator.__call__.__doc__ = _docstring_generator_call(Operator.schema_name)
     return Operator
 

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -18,7 +18,6 @@ import copy
 from itertools import count
 import threading
 import warnings
-import importlib
 from nvidia.dali import backend as _b
 from nvidia.dali.types import \
         _type_name_convert_to_string, _type_convert_value, _default_converter, \

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -93,6 +93,13 @@ def _vector_element_type(dtype):
         raise RuntimeError(str(dtype) + " is not a vector type.")
     return _vector_types[dtype]
 
+def _default_converter(dtype, default_value):
+    if dtype in _enum_types:
+        return str(_type_convert_value(dtype, default_value))
+    else:
+        return repr(_type_convert_value(dtype, default_value))
+
+
 @unique
 class PipelineAPIType(Enum):
     """Pipeline API type
@@ -119,6 +126,8 @@ _float_types = [DALIDataType.FLOAT16, DALIDataType.FLOAT, DALIDataType.FLOAT64]
 
 _int_like_types = _bool_types + _int_types
 _all_types = _bool_types + _int_types + _float_types
+
+_enum_types = [DALIDataType.IMAGE_TYPE, DALIDataType.DATA_TYPE, DALIDataType.INTERP_TYPE]
 
 
 class ScalarConstant(object):

--- a/docs/autodoc_submodules.py
+++ b/docs/autodoc_submodules.py
@@ -10,7 +10,7 @@ ops_modules = {
 }
 
 exclude_ops_members = {
-    'nvidia.dali.ops': ["PythonFunctionBase", "TransformTranslation"]
+    'nvidia.dali.ops': ["PythonFunctionBase"]
 }
 
 fn_modules = {
@@ -18,14 +18,13 @@ fn_modules = {
 }
 
 exclude_fn_members = {
-    'nvidia.dali.fn': ["transform_translation"]
 }
 
 def op_autodoc(out_filename):
     s = ""
     for module in sys.modules.keys():
         for doc_module in ops_modules:
-            if module.startswith(doc_module):
+            if module.startswith(doc_module) and not module.endswith('hidden'):
                 s += module + "\n"
                 s += "~" * len(module) + "\n"
                 s += ".. automodule:: {}\n".format(module)
@@ -42,7 +41,7 @@ def fn_autodoc(out_filename):
     s = ""
     for module in sys.modules.keys():
         for doc_module in fn_modules:
-            if module.startswith(doc_module):
+            if module.startswith(doc_module) and not module.endswith('hidden'):
                 s += ".. automodule:: {}\n".format(module)
                 s += "   :members:\n"
                 s += "   :undoc-members:\n"

--- a/docs/autodoc_submodules.py
+++ b/docs/autodoc_submodules.py
@@ -10,7 +10,7 @@ ops_modules = {
 }
 
 exclude_ops_members = {
-    'nvidia.dali.ops': ["PythonFunctionBase"]
+    'nvidia.dali.ops': ["PythonFunctionBase", "TransformTranslation"]
 }
 
 fn_modules = {
@@ -18,6 +18,7 @@ fn_modules = {
 }
 
 exclude_fn_members = {
+    'nvidia.dali.fn': ["transform_translation"]
 }
 
 def op_autodoc(out_filename):
@@ -31,8 +32,8 @@ def op_autodoc(out_filename):
                 s += "   :members:\n"
                 s += "   :special-members: __call__\n"
                 if module in exclude_ops_members:
-                    for excluded in exclude_ops_members[module]:
-                        s += "   :exclude-members: {}\n".format(excluded)
+                    excluded = exclude_ops_members[module]
+                    s += "   :exclude-members: {}\n".format(", ".join(excluded))
                 s += "\n"
     with open(out_filename, 'w') as f:
         f.write(s)
@@ -46,8 +47,8 @@ def fn_autodoc(out_filename):
                 s += "   :members:\n"
                 s += "   :undoc-members:\n"
                 if module in exclude_fn_members:
-                    for excluded in exclude_fn_members[module]:
-                        s += "   :exclude-members: {}\n".format(excluded)
+                    excluded = exclude_fn_members[module]
+                    s += "   :exclude-members: {}\n".format(", ".join(excluded))
                 s += "\n"
     with open(out_filename, 'w') as f:
         f.write(s)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -256,12 +256,11 @@ class EnumDocumenter(ClassDocumenter):
     # Produce .. py:class:: fields in the RST doc
     directivetype = 'class'
 
-    def __init__(self, *args: Any) -> None:
+    def __init__(self, *args):
         super().__init__(*args)
 
     @classmethod
-    def can_document_member(cls, member: Any, membername: str, isattr: bool, parent: Any
-                            ) -> bool:
+    def can_document_member(cls, member, membername, isattr, parent):
         """Verify that we handle only the registered DALI enums. Pybind doesn't subclass Enum class,
         so we need an explicit list.
         """
@@ -287,35 +286,28 @@ class EnumDocumenter(ClassDocumenter):
 
     def sort_members(self, documenters, order):
         """Ignore the order. Here we have access only to documenters that carry the name
-        and not the object. We need to sort based on the enum values and we du it in
+        and not the object. We need to sort based on the enum values and we do it in
         self.filter_members()
         """
         return documenters
 
 class EnumAttributeDocumenter(AttributeDocumenter):
-    # Give us higher priority over Sphinx native AttributeDocumenter
+    # Give us higher priority over Sphinx native AttributeDocumenter which is 10, or 11 in case
+    # of more specialized attributes.
     priority = 12
 
     @classmethod
-    def can_document_member(cls, member: Any, membername: str, isattr: bool, parent: Any
-                            ) -> bool:
+    def can_document_member(cls, member, membername, isattr, parent):
         """Run only for the Enums supported by DALI
         """
         return isinstance(parent, EnumDocumenter)
 
-    def add_directive_header(self, sig: str) -> None:
+    def add_directive_header(self, sig):
         """Greatly simplified AttributeDocumenter.add_directive_header()
         as we know we're dealing with only specific enums here, we can append a line of doc
         with just their value.
         """
         super(AttributeDocumenter, self).add_directive_header(sig)
-        # To customize the values of the enums use:
-        # sourcename = self.get_sourcename()
-        # if isinstance(self.object, Enum):
-        #     objrepr = str(self.object)
-        # else:
-        #     objrepr = str(self.object)
-        # self.add_line('   :value: ' + objrepr, sourcename)
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ import os
 import sys
 import sphinx_rtd_theme
 from sphinx.ext.autodoc.mock import mock
+from sphinx.ext.autodoc import between
 from builtins import str
 import re
 import subprocess
@@ -242,3 +243,7 @@ def setup(app):
     count_unique_visitor_script = os.getenv("ADD_NVIDIA_VISITS_COUNTING_SCRIPT")
     if count_unique_visitor_script:
         app.add_js_file(count_unique_visitor_script)
+    # Register a sphinx.ext.autodoc.between listener to ignore everything
+    # between lines that contain the word <SPHINX_IGNORE>
+    app.connect('autodoc-process-docstring', between('^.*<SPHINX_IGNORE>.*$', exclude=True))
+    return app

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,8 +17,10 @@ import os
 import sys
 import sphinx_rtd_theme
 from sphinx.ext.autodoc.mock import mock
-from sphinx.ext.autodoc import between
+from sphinx.ext.autodoc import between, ClassDocumenter, AttributeDocumenter
+from sphinx.util import inspect
 from builtins import str
+from enum import Enum
 import re
 import subprocess
 
@@ -239,6 +241,84 @@ extlinks = {'issue': ('https://github.com/NVIDIA/DALI/issues/%s',
                       'issue '),
             'fileref': ('https://github.com/NVIDIA/DALI/tree/' + (git_sha if git_sha != u'0000000' else "master") + '/%s', ''),}
 
+
+from typing import (
+    Any, Callable, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
+)
+from typing import get_type_hints
+
+
+_dali_enums = ["DALIDataType", "DALIIterpType", "DALIImageType", "PipelineAPIType"]
+
+class EnumDocumenter(ClassDocumenter):
+    # Register as .. autoenum::
+    objtype = 'enum'
+    # Produce .. py:class:: fields in the RST doc
+    directivetype = 'class'
+    # priority = 10
+
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+
+    @classmethod
+    def can_document_member(cls, member: Any, membername: str, isattr: bool, parent: Any
+                            ) -> bool:
+        """Verify that we handle only the registered DALI enums. Pybind doesn't subclass Enum class,
+        so we need an explicit list.
+        """
+        return membername in _dali_enums and isinstance(parent, ClassDocumenter)
+
+    def filter_members(self, members, want_all):
+        """After self.get_object_members() obtained all members, this function filters only
+        the ones we're interested in.
+        We can do the sorting here based on the values, and pass through in self.sort_members()
+        """
+        filtered = super().filter_members(members, want_all)
+
+        # sort by the actual value of enum - this is a tuple of (name, value, boolean)
+        def get_member_value(member_desc):
+            _, member_value, _ = member_desc
+            if isinstance(member_value, Enum):
+                return member_value.value
+            else:
+                return int(member_value)
+        filtered.sort(key = get_member_value)
+
+        return filtered
+
+    def sort_members(self, documenters, order):
+        """Ignore the order. Here we have access only to documenters that carry the name
+        and not the object. We need to sort based on the enum values and we du it in
+        self.filter_members()
+        """
+        return documenters
+
+class EnumAttributeDocumenter(AttributeDocumenter):
+    # Give us higher priority over Sphinx native AttributeDocumenter
+    priority = 12
+
+    @classmethod
+    def can_document_member(cls, member: Any, membername: str, isattr: bool, parent: Any
+                            ) -> bool:
+        """Run only for the Enums supported by DALI
+        """
+        return isinstance(parent, EnumDocumenter)
+
+    def add_directive_header(self, sig: str) -> None:
+        """Greatly simplified AttributeDocumenter.add_directive_header()
+        as we know we're dealing with only specific enums here, we can append a line of doc
+        with just their value.
+        """
+        super(AttributeDocumenter, self).add_directive_header(sig)
+        # sourcename = self.get_sourcename()
+        # # print(self.object)
+        # if isinstance(self.object, Enum):
+        #     objrepr = str(self.object)
+        # else:
+        #     objrepr = str(self.object)
+        # self.add_line('   :value: ' + objrepr, sourcename)
+
+
 def setup(app):
     count_unique_visitor_script = os.getenv("ADD_NVIDIA_VISITS_COUNTING_SCRIPT")
     if count_unique_visitor_script:
@@ -246,4 +326,6 @@ def setup(app):
     # Register a sphinx.ext.autodoc.between listener to ignore everything
     # between lines that contain the word <SPHINX_IGNORE>
     app.connect('autodoc-process-docstring', between('^.*<SPHINX_IGNORE>.*$', exclude=True))
+    app.add_autodocumenter(EnumDocumenter)
+    app.add_autodocumenter(EnumAttributeDocumenter)
     return app

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -255,7 +255,6 @@ class EnumDocumenter(ClassDocumenter):
     objtype = 'enum'
     # Produce .. py:class:: fields in the RST doc
     directivetype = 'class'
-    # priority = 10
 
     def __init__(self, *args: Any) -> None:
         super().__init__(*args)
@@ -310,8 +309,8 @@ class EnumAttributeDocumenter(AttributeDocumenter):
         with just their value.
         """
         super(AttributeDocumenter, self).add_directive_header(sig)
+        # To customize the values of the enums use:
         # sourcename = self.get_sourcename()
-        # # print(self.object)
         # if isinstance(self.object, Enum):
         #     objrepr = str(self.object)
         # else:

--- a/docs/data_types.rst
+++ b/docs/data_types.rst
@@ -65,21 +65,22 @@ Enums
 
 DALIDataType
 ^^^^^^^^^^^^
-.. autoclass:: DALIDataType
+.. autoenum:: DALIDataType
    :members:
    :undoc-members:
+   :member-order: bysource
    :exclude-members: name
 
 DALIIterpType
 ^^^^^^^^^^^^^
-.. autoclass:: DALIInterpType
+.. autoenum:: DALIInterpType
    :members:
    :undoc-members:
    :exclude-members: name
 
 DALIImageType
 ^^^^^^^^^^^^^
-.. autoclass:: DALIImageType
+.. autoenum:: DALIImageType
    :members:
    :undoc-members:
    :exclude-members: name
@@ -92,7 +93,7 @@ TensorLayout
 
 PipelineAPIType
 ^^^^^^^^^^^^^^^
-.. autoclass:: PipelineAPIType
+.. autoenum:: PipelineAPIType
    :members:
    :undoc-members:
 

--- a/docs/data_types.rst
+++ b/docs/data_types.rst
@@ -68,18 +68,21 @@ DALIDataType
 .. autoclass:: DALIDataType
    :members:
    :undoc-members:
+   :exclude-members: name
 
 DALIIterpType
 ^^^^^^^^^^^^^
 .. autoclass:: DALIInterpType
    :members:
    :undoc-members:
+   :exclude-members: name
 
 DALIImageType
 ^^^^^^^^^^^^^
 .. autoclass:: DALIImageType
    :members:
    :undoc-members:
+   :exclude-members: name
 
 TensorLayout
 ^^^^^^^^^^^^

--- a/docs/supported_op_devices.py
+++ b/docs/supported_op_devices.py
@@ -39,6 +39,8 @@ def main(out_filename):
         if schema:
             supports_seq = '|v|' if schema.AllowsSequences() or schema.IsSequenceOperator() else ''
             volumetric = '|v|' if schema.SupportsVolumetric() else ''
+            if schema.IsDocHidden():
+                continue
         else:
             supports_seq = ''
             volumetric = ''


### PR DESCRIPTION
#### Why we need this PR?
- Improve the docs quality (mostly for Enums)
- Truly hide hidden ops 

#### What happened in this PR? 
 - What solution was applied:
     Custom documenter for enums was registered in Sphinx generator to bridge the gap between PyBind Enums and true Python Enums.
     Used mechanism to skip part of auto generated docstring that listed py::enum_ members as plain text.
	Ops that have hidden docs are now imported under true .hidden module and appear as "reimported" into parent module. Sphinx skips them from listing.
 - Affected modules and functionalities:
     Sphinx doc generator
     ops.py, fn.py for loading hidden Ops.
 - Key points relevant for the review:
    The API for hiding and how it is used     
 - Validation and testing:
     PLZ :eyes:
     Local experiments with loading DALI.
 - Documentation (including examples):
     Yes


**JIRA TASK**: *[DALI-1725]*
