### PR TITLE
Move all NVTX infrastructure into core and create DALI domain

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -399,7 +399,7 @@ device_type_t daliGetOutputDevice(daliPipelineHandle *pipe_handle, int id) {
 
 void daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx,
                     device_type_t dst_type, cudaStream_t stream, unsigned int flags) {
-  dali::DomainTimeRange tr("[DALI][C API] daliOutputCopy", dali::RangeBase::kGreen);
+  dali::DomainTimeRange tr("[DALI][C API] daliOutputCopy", dali::DomainTimeRange::kGreen);
 
   bool is_pinned = flags & DALI_ext_pinned;
   bool sync = flags & DALI_ext_force_sync;
@@ -424,7 +424,7 @@ void daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx,
 
 void daliOutputCopySamples(daliPipelineHandle *pipe_handle, void **dsts, int output_idx,
                            device_type_t dst_type, cudaStream_t stream, unsigned int flags) {
-  dali::DomainTimeRange tr("[DALI][C API] daliOutputCopySamples", dali::RangeBase::kGreen);
+  dali::DomainTimeRange tr("[DALI][C API] daliOutputCopySamples", dali::DomainTimeRange::kGreen);
 
   bool is_pinned = flags & DALI_ext_pinned;
   bool sync = flags & DALI_ext_force_sync;

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -399,7 +399,7 @@ device_type_t daliGetOutputDevice(daliPipelineHandle *pipe_handle, int id) {
 
 void daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx,
                     device_type_t dst_type, cudaStream_t stream, unsigned int flags) {
-  dali::TimeRange tr("daliOutputCopy", dali::TimeRange::kGreen);
+  dali::DomainTimeRange tr("[DALI][C API] daliOutputCopy", dali::RangeBase::kGreen);
 
   bool is_pinned = flags & DALI_ext_pinned;
   bool sync = flags & DALI_ext_force_sync;
@@ -424,7 +424,7 @@ void daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx,
 
 void daliOutputCopySamples(daliPipelineHandle *pipe_handle, void **dsts, int output_idx,
                            device_type_t dst_type, cudaStream_t stream, unsigned int flags) {
-  dali::TimeRange tr("daliOutputCopySamples", dali::TimeRange::kGreen);
+  dali::DomainTimeRange tr("[DALI][C API] daliOutputCopySamples", dali::RangeBase::kGreen);
 
   bool is_pinned = flags & DALI_ext_pinned;
   bool sync = flags & DALI_ext_force_sync;

--- a/dali/core/nvtx.cc
+++ b/dali/core/nvtx.cc
@@ -1,0 +1,64 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/nvtx.h"
+
+namespace dali {
+
+#if NVTX_ENABLED
+class DomainTimeRangeImpl {
+ public:
+  DomainTimeRangeImpl() {
+    dali_domain_ = nvtxDomainCreateA("DALI");
+  }
+
+  ~DomainTimeRangeImpl() {
+    nvtxDomainDestroy(dali_domain_);
+  }
+
+  void Start(const std::string name, const uint32_t rgb) {
+    nvtxEventAttributes_t att = {};
+    att.version = NVTX_VERSION;
+    att.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+    att.colorType = NVTX_COLOR_ARGB;
+    att.color = rgb | 0xff000000;
+    att.messageType = NVTX_MESSAGE_TYPE_ASCII;
+    att.message.ascii = name.c_str();
+    nvtxDomainRangePushEx(dali_domain_, &att);
+  }
+
+  void Stop() {
+    nvtxDomainRangePop(dali_domain_);
+  }
+
+ private:
+  nvtxDomainHandle_t dali_domain_;
+};
+#endif
+
+static DomainTimeRangeImpl range_impl;
+
+DLL_PUBLIC DomainTimeRange::DomainTimeRange(const std::string &name, const uint32_t rgb) {
+#if NVTX_ENABLED
+  range_impl.Start(name, rgb);
+#endif
+}
+
+DLL_PUBLIC DomainTimeRange::~DomainTimeRange() {
+#if NVTX_ENABLED
+  range_impl.Stop();
+#endif
+}
+
+}  // namespace dali

--- a/dali/core/nvtx.cc
+++ b/dali/core/nvtx.cc
@@ -17,7 +17,7 @@
 namespace dali {
 
 #if NVTX_ENABLED
-class DomainTimeRangeImpl {
+class DomainTimeRangeImpl : RangeBase {
  public:
   DomainTimeRangeImpl() {
     dali_domain_ = nvtxDomainCreateA("DALI");

--- a/dali/core/nvtx.cc
+++ b/dali/core/nvtx.cc
@@ -29,12 +29,7 @@ class DomainTimeRangeImpl {
 
   void Start(const std::string name, const uint32_t rgb) {
     nvtxEventAttributes_t att = {};
-    att.version = NVTX_VERSION;
-    att.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-    att.colorType = NVTX_COLOR_ARGB;
-    att.color = rgb | 0xff000000;
-    att.messageType = NVTX_MESSAGE_TYPE_ASCII;
-    att.message.ascii = name.c_str();
+    FillAtrbs(att, name, rgb);
     nvtxDomainRangePushEx(dali_domain_, &att);
   }
 

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api.h
@@ -417,7 +417,6 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
   bool ParseNvjpeg2k(SampleData &data, span<const uint8_t> input) {
 #ifdef BUILD_NVJPEG2K_ENABLED
     const auto &jpeg2k_stream = nvjpeg2k_streams_[data.sample_idx];
-    TimeRange tr("nvjpeg2k parse");
     auto ret = nvjpeg2kStreamParse(nvjpeg2k_handle_, input.data(), input.size(),
                                    0, 0, jpeg2k_stream);
     if (ret == NVJPEG2K_STATUS_SUCCESS) {

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -121,10 +121,10 @@ class Loader {
     if (!loading_flag_) {
       PrepareMetadata();
     }
-    DomainTimeRange tr("[DALI][Loader] ReadOne", RangeBase::kGreen1);
+    DomainTimeRange tr("[DALI][Loader] ReadOne", DomainTimeRange::kGreen1);
     // perform an initial buffer fill if it hasn't already happened
     if (!initial_buffer_filled_) {
-      DomainTimeRange tr("[DALI][Loader] Filling initial buffer", RangeBase::kBlue1);
+      DomainTimeRange tr("[DALI][Loader] Filling initial buffer", DomainTimeRange::kBlue1);
       shards_.push_back({0, 0});
 
       // Read an initial number of samples to fill our
@@ -139,7 +139,7 @@ class Loader {
       }
 
       // need some entries in the empty_tensors_ list
-      DomainTimeRange tr2("[DALI][Loader] Filling empty list", RangeBase::kOrange);
+      DomainTimeRange tr2("[DALI][Loader] Filling empty list", DomainTimeRange::kOrange);
       std::lock_guard<std::mutex> lock(empty_tensors_mutex_);
       for (int i = 0; i < initial_empty_size_; ++i) {
         auto tensor_ptr = LoadTargetUniquePtr(new LoadTarget());

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -121,10 +121,10 @@ class Loader {
     if (!loading_flag_) {
       PrepareMetadata();
     }
-    DomainTimeRange tr("[DALI][Loader] ReadOne", TimeRange::kGreen1);
+    DomainTimeRange tr("[DALI][Loader] ReadOne", RangeBase::kGreen1);
     // perform an initial buffer fill if it hasn't already happened
     if (!initial_buffer_filled_) {
-      DomainTimeRange tr("[DALI][Loader] Filling initial buffer", TimeRange::kBlue1);
+      DomainTimeRange tr("[DALI][Loader] Filling initial buffer", RangeBase::kBlue1);
       shards_.push_back({0, 0});
 
       // Read an initial number of samples to fill our
@@ -139,7 +139,7 @@ class Loader {
       }
 
       // need some entries in the empty_tensors_ list
-      DomainTimeRange tr2("[DALI][Loader] Filling empty list", TimeRange::kOrange);
+      DomainTimeRange tr2("[DALI][Loader] Filling empty list", RangeBase::kOrange);
       std::lock_guard<std::mutex> lock(empty_tensors_mutex_);
       for (int i = 0; i < initial_empty_size_; ++i) {
         auto tensor_ptr = LoadTargetUniquePtr(new LoadTarget());

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <deque>
 
+#include "dali/core/nvtx.h"
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
 #include "dali/pipeline/operator/op_spec.h"
@@ -120,10 +121,10 @@ class Loader {
     if (!loading_flag_) {
       PrepareMetadata();
     }
-    TimeRange tr("[Loader] ReadOne", TimeRange::kGreen1);
+    DomainTimeRange tr("[DALI][Loader] ReadOne", TimeRange::kGreen1);
     // perform an initial buffer fill if it hasn't already happened
     if (!initial_buffer_filled_) {
-      TimeRange tr("[Loader] Filling initial buffer", TimeRange::kBlue1);
+      DomainTimeRange tr("[DALI][Loader] Filling initial buffer", TimeRange::kBlue1);
       shards_.push_back({0, 0});
 
       // Read an initial number of samples to fill our
@@ -138,7 +139,7 @@ class Loader {
       }
 
       // need some entries in the empty_tensors_ list
-      TimeRange tr2("[Loader] Filling empty list", TimeRange::kOrange);
+      DomainTimeRange tr2("[DALI][Loader] Filling empty list", TimeRange::kOrange);
       std::lock_guard<std::mutex> lock(empty_tensors_mutex_);
       for (int i = 0; i < initial_empty_size_; ++i) {
         auto tensor_ptr = LoadTargetUniquePtr(new LoadTarget());

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <unordered_map>
 
+#include "dali/core/nvtx.h"
 #include "dali/operators/reader/loader/loader.h"
 #include "dali/operators/reader/parser/parser.h"
 #include "dali/pipeline/operator/operator.h"
@@ -80,7 +81,8 @@ class DataReader : public Operator<Backend> {
   // perform the prefetching operation
   virtual void Prefetch() {
     // We actually prepare the next batch
-    TimeRange tr("DataReader::Prefetch #" + to_string(curr_batch_producer_), TimeRange::kRed);
+    DomainTimeRange tr("[DALI] DataReader::Prefetch #" + to_string(curr_batch_producer_),
+                       TimeRange::kRed);
     auto &curr_batch = prefetched_batch_queue_[curr_batch_producer_];
     curr_batch.reserve(Operator<Backend>::batch_size_);
     curr_batch.clear();
@@ -135,7 +137,8 @@ class DataReader : public Operator<Backend> {
     ConsumerWait();
 
     // consume batch
-    TimeRange tr("DataReader::Run #" + to_string(curr_batch_consumer_), TimeRange::kViolet);
+    DomainTimeRange tr("[DALI] DataReader::Run #" + to_string(curr_batch_consumer_),
+                       TimeRange::kViolet);
 
     // This is synchronous call for CPU Backend
     Operator<Backend>::Run(ws);
@@ -258,7 +261,7 @@ class DataReader : public Operator<Backend> {
   }
 
   void ConsumerWait() {
-    TimeRange tr("DataReader::ConsumerWait #" + to_string(curr_batch_consumer_),
+    DomainTimeRange tr("[DALI] DataReader::ConsumerWait #" + to_string(curr_batch_consumer_),
                  TimeRange::kMagenta);
     std::unique_lock<std::mutex> prefetch_lock(prefetch_access_mutex_);
     consumer_.wait(prefetch_lock, [this]() { return finished_ || !IsPrefetchQueueEmpty(); });

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -82,7 +82,7 @@ class DataReader : public Operator<Backend> {
   virtual void Prefetch() {
     // We actually prepare the next batch
     DomainTimeRange tr("[DALI][DataReader] Prefetch #" + to_string(curr_batch_producer_),
-                       RangeBase::kRed);
+                       DomainTimeRange::kRed);
     auto &curr_batch = prefetched_batch_queue_[curr_batch_producer_];
     curr_batch.reserve(Operator<Backend>::batch_size_);
     curr_batch.clear();
@@ -138,7 +138,7 @@ class DataReader : public Operator<Backend> {
 
     // consume batch
     DomainTimeRange tr("[DALI][DataReader] Run #" + to_string(curr_batch_consumer_),
-                       RangeBase::kViolet);
+                       DomainTimeRange::kViolet);
 
     // This is synchronous call for CPU Backend
     Operator<Backend>::Run(ws);
@@ -262,7 +262,7 @@ class DataReader : public Operator<Backend> {
 
   void ConsumerWait() {
     DomainTimeRange tr("[DALI][DataReader] ConsumerWait #" + to_string(curr_batch_consumer_),
-                 RangeBase::kMagenta);
+                 DomainTimeRange::kMagenta);
     std::unique_lock<std::mutex> prefetch_lock(prefetch_access_mutex_);
     consumer_.wait(prefetch_lock, [this]() { return finished_ || !IsPrefetchQueueEmpty(); });
     if (prefetch_error_) std::rethrow_exception(prefetch_error_);

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -81,8 +81,8 @@ class DataReader : public Operator<Backend> {
   // perform the prefetching operation
   virtual void Prefetch() {
     // We actually prepare the next batch
-    DomainTimeRange tr("[DALI] DataReader::Prefetch #" + to_string(curr_batch_producer_),
-                       TimeRange::kRed);
+    DomainTimeRange tr("[DALI][DataReader] Prefetch #" + to_string(curr_batch_producer_),
+                       RangeBase::kRed);
     auto &curr_batch = prefetched_batch_queue_[curr_batch_producer_];
     curr_batch.reserve(Operator<Backend>::batch_size_);
     curr_batch.clear();
@@ -137,8 +137,8 @@ class DataReader : public Operator<Backend> {
     ConsumerWait();
 
     // consume batch
-    DomainTimeRange tr("[DALI] DataReader::Run #" + to_string(curr_batch_consumer_),
-                       TimeRange::kViolet);
+    DomainTimeRange tr("[DALI][DataReader] Run #" + to_string(curr_batch_consumer_),
+                       RangeBase::kViolet);
 
     // This is synchronous call for CPU Backend
     Operator<Backend>::Run(ws);
@@ -261,8 +261,8 @@ class DataReader : public Operator<Backend> {
   }
 
   void ConsumerWait() {
-    DomainTimeRange tr("[DALI] DataReader::ConsumerWait #" + to_string(curr_batch_consumer_),
-                 TimeRange::kMagenta);
+    DomainTimeRange tr("[DALI][DataReader] ConsumerWait #" + to_string(curr_batch_consumer_),
+                 RangeBase::kMagenta);
     std::unique_lock<std::mutex> prefetch_lock(prefetch_access_mutex_);
     consumer_.wait(prefetch_lock, [this]() { return finished_ || !IsPrefetchQueueEmpty(); });
     if (prefetch_error_) std::rethrow_exception(prefetch_error_);

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -26,6 +26,7 @@
 #include <mutex>
 
 #include "dali/core/common.h"
+#include "dali/core/nvtx.h"
 #include "dali/core/error_handling.h"
 #include "dali/pipeline/executor/queue_metadata.h"
 #include "dali/pipeline/executor/queue_policy.h"
@@ -496,7 +497,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunCPU() {
                  "valid device id or change the operators' device.");
   }
 
-  TimeRange tr("[Executor] RunCPU");
+  DomainTimeRange tr("[DALI][Executor] RunCPU");
 
   DeviceGuard g(device_id_);
 
@@ -512,7 +513,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunCPU() {
     OpNode &op_node = graph_->Node(OpType::CPU, cpu_op_id);
     typename WorkspacePolicy::template ws_t<OpType::CPU> ws =
         WorkspacePolicy::template GetWorkspace<OpType::CPU>(cpu_idxs, *graph_, cpu_op_id);
-    TimeRange tr("[Executor] Run CPU op " + op_node.instance_name, TimeRange::kBlue1);
+    DomainTimeRange tr("[DALI][Executor] Run CPU op " + op_node.instance_name, TimeRange::kBlue1);
 
     try {
       RunHelper(op_node, ws);
@@ -530,7 +531,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunCPU() {
 
 template <typename WorkspacePolicy, typename QueuePolicy>
 void Executor<WorkspacePolicy, QueuePolicy>::RunMixed() {
-  TimeRange tr("[Executor] RunMixed");
+  DomainTimeRange tr("[DALI][Executor] RunMixed");
   DeviceGuard g(device_id_);
 
   auto mixed_idxs = QueuePolicy::AcquireIdxs(OpType::MIXED);
@@ -559,7 +560,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunMixed() {
       try {
         typename WorkspacePolicy::template ws_t<OpType::MIXED> ws =
             WorkspacePolicy::template GetWorkspace<OpType::MIXED>(mixed_idxs, *graph_, i);
-        TimeRange tr("[Executor] Run Mixed op " + op_node.instance_name,
+        DomainTimeRange tr("[DALI][Executor] Run Mixed op " + op_node.instance_name,
             TimeRange::kOrange);
         RunHelper(op_node, ws);
         FillStats(mixed_memory_stats_, ws,  "MIXED_" + op_node.instance_name,
@@ -595,7 +596,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunMixed() {
 
 template <typename WorkspacePolicy, typename QueuePolicy>
 void Executor<WorkspacePolicy, QueuePolicy>::RunGPU() {
-  TimeRange tr("[Executor] RunGPU");
+  DomainTimeRange tr("[DALI][Executor] RunGPU");
 
   auto gpu_idxs = QueuePolicy::AcquireIdxs(OpType::GPU);
   if (exec_error_ || QueuePolicy::IsStopSignaled() || !QueuePolicy::AreValid(gpu_idxs)) {
@@ -626,7 +627,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunGPU() {
           CUDA_CALL(cudaStreamWaitEvent(ws.stream(), event, 0));
         }
 
-        TimeRange tr("[Executor] Run GPU op " + op_node.instance_name,
+        DomainTimeRange tr("[DALI][Executor] Run GPU op " + op_node.instance_name,
             TimeRange::knvGreen);
         RunHelper(op_node, ws);
         FillStats(gpu_memory_stats_, ws, "GPU_" + op_node.instance_name, gpu_memory_stats_mutex_);
@@ -854,7 +855,7 @@ template <typename WorkspacePolicy, typename QueuePolicy>
 void Executor<WorkspacePolicy, QueuePolicy>::PresizeData(
     std::vector<tensor_data_store_queue_t> &tensor_to_store_queue, const OpGraph &graph) {
   DeviceGuard g(device_id_);
-  TimeRange tr("[Executor] PresizeData");
+  DomainTimeRange tr("[DALI][Executor] PresizeData");
 
   auto should_reserve = [](auto &storage, Index hint, StorageDevice dev) -> bool {
     if (dev == StorageDevice::CPU) {

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -513,7 +513,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunCPU() {
     OpNode &op_node = graph_->Node(OpType::CPU, cpu_op_id);
     typename WorkspacePolicy::template ws_t<OpType::CPU> ws =
         WorkspacePolicy::template GetWorkspace<OpType::CPU>(cpu_idxs, *graph_, cpu_op_id);
-    DomainTimeRange tr("[DALI][Executor] Run CPU op " + op_node.instance_name, TimeRange::kBlue1);
+    DomainTimeRange tr("[DALI][CPU op] " + op_node.instance_name, RangeBase::kBlue1);
 
     try {
       RunHelper(op_node, ws);
@@ -560,8 +560,8 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunMixed() {
       try {
         typename WorkspacePolicy::template ws_t<OpType::MIXED> ws =
             WorkspacePolicy::template GetWorkspace<OpType::MIXED>(mixed_idxs, *graph_, i);
-        DomainTimeRange tr("[DALI][Executor] Run Mixed op " + op_node.instance_name,
-            TimeRange::kOrange);
+        DomainTimeRange tr("[DALI][Mixed op] " + op_node.instance_name,
+            RangeBase::kOrange);
         RunHelper(op_node, ws);
         FillStats(mixed_memory_stats_, ws,  "MIXED_" + op_node.instance_name,
                   mixed_memory_stats_mutex_);
@@ -627,8 +627,8 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunGPU() {
           CUDA_CALL(cudaStreamWaitEvent(ws.stream(), event, 0));
         }
 
-        DomainTimeRange tr("[DALI][Executor] Run GPU op " + op_node.instance_name,
-            TimeRange::knvGreen);
+        DomainTimeRange tr("[DALI][GPU op] " + op_node.instance_name,
+            RangeBase::knvGreen);
         RunHelper(op_node, ws);
         FillStats(gpu_memory_stats_, ws, "GPU_" + op_node.instance_name, gpu_memory_stats_mutex_);
         if (ws.has_event()) {

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -513,7 +513,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunCPU() {
     OpNode &op_node = graph_->Node(OpType::CPU, cpu_op_id);
     typename WorkspacePolicy::template ws_t<OpType::CPU> ws =
         WorkspacePolicy::template GetWorkspace<OpType::CPU>(cpu_idxs, *graph_, cpu_op_id);
-    DomainTimeRange tr("[DALI][CPU op] " + op_node.instance_name, RangeBase::kBlue1);
+    DomainTimeRange tr("[DALI][CPU op] " + op_node.instance_name, DomainTimeRange::kBlue1);
 
     try {
       RunHelper(op_node, ws);
@@ -561,7 +561,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunMixed() {
         typename WorkspacePolicy::template ws_t<OpType::MIXED> ws =
             WorkspacePolicy::template GetWorkspace<OpType::MIXED>(mixed_idxs, *graph_, i);
         DomainTimeRange tr("[DALI][Mixed op] " + op_node.instance_name,
-            RangeBase::kOrange);
+            DomainTimeRange::kOrange);
         RunHelper(op_node, ws);
         FillStats(mixed_memory_stats_, ws,  "MIXED_" + op_node.instance_name,
                   mixed_memory_stats_mutex_);
@@ -628,7 +628,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunGPU() {
         }
 
         DomainTimeRange tr("[DALI][GPU op] " + op_node.instance_name,
-            RangeBase::knvGreen);
+            DomainTimeRange::knvGreen);
         RunHelper(op_node, ws);
         FillStats(gpu_memory_stats_, ws, "GPU_" + op_node.instance_name, gpu_memory_stats_mutex_);
         if (ws.has_event()) {

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -133,7 +133,7 @@ class ExternalSource : public Operator<Backend> {
   inline void SetDataSource(const TensorList<SrcBackend> &tl, cudaStream_t stream = 0,
                             bool sync = false, bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
-    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", TimeRange::kViolet);
+    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", RangeBase::kViolet);
     SetDataSourceHelper(tl, stream, sync, use_copy_kernel);
   }
 
@@ -145,7 +145,7 @@ class ExternalSource : public Operator<Backend> {
                             cudaStream_t stream = 0, bool sync = false,
                             bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
-    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", TimeRange::kViolet);
+    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", RangeBase::kViolet);
     TensorVector<SrcBackend> tv(vect_of_tensors.size());
     for (size_t i = 0; i < tv.size(); ++i) {
       tv[i].ShareData(const_cast<Tensor<SrcBackend>*>(&vect_of_tensors[i]));
@@ -160,7 +160,7 @@ class ExternalSource : public Operator<Backend> {
   inline void SetDataSource(const TensorVector<SrcBackend> &tv, cudaStream_t stream = 0,
                             bool sync = false, bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
-    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", TimeRange::kViolet);
+    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", RangeBase::kViolet);
     SetDataSourceHelper(tv, stream, sync, use_copy_kernel);
   }
 

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -133,7 +133,7 @@ class ExternalSource : public Operator<Backend> {
   inline void SetDataSource(const TensorList<SrcBackend> &tl, cudaStream_t stream = 0,
                             bool sync = false, bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
-    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", RangeBase::kViolet);
+    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", DomainTimeRange::kViolet);
     SetDataSourceHelper(tl, stream, sync, use_copy_kernel);
   }
 
@@ -145,7 +145,7 @@ class ExternalSource : public Operator<Backend> {
                             cudaStream_t stream = 0, bool sync = false,
                             bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
-    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", RangeBase::kViolet);
+    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", DomainTimeRange::kViolet);
     TensorVector<SrcBackend> tv(vect_of_tensors.size());
     for (size_t i = 0; i < tv.size(); ++i) {
       tv[i].ShareData(const_cast<Tensor<SrcBackend>*>(&vect_of_tensors[i]));
@@ -160,7 +160,7 @@ class ExternalSource : public Operator<Backend> {
   inline void SetDataSource(const TensorVector<SrcBackend> &tv, cudaStream_t stream = 0,
                             bool sync = false, bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
-    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", RangeBase::kViolet);
+    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", DomainTimeRange::kViolet);
     SetDataSourceHelper(tv, stream, sync, use_copy_kernel);
   }
 

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -24,6 +24,7 @@
 #include <condition_variable>
 #include <utility>
 
+#include "dali/core/nvtx.h"
 #include "dali/core/cuda_event.h"
 #include "dali/pipeline/operator/operator.h"
 #include "dali/pipeline/util/worker_thread.h"
@@ -132,7 +133,7 @@ class ExternalSource : public Operator<Backend> {
   inline void SetDataSource(const TensorList<SrcBackend> &tl, cudaStream_t stream = 0,
                             bool sync = false, bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
-    TimeRange tr("[ExternalSource] SetDataSource", TimeRange::kViolet);
+    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", TimeRange::kViolet);
     SetDataSourceHelper(tl, stream, sync, use_copy_kernel);
   }
 
@@ -144,7 +145,7 @@ class ExternalSource : public Operator<Backend> {
                             cudaStream_t stream = 0, bool sync = false,
                             bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
-    TimeRange tr("[ExternalSource] SetDataSource", TimeRange::kViolet);
+    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", TimeRange::kViolet);
     TensorVector<SrcBackend> tv(vect_of_tensors.size());
     for (size_t i = 0; i < tv.size(); ++i) {
       tv[i].ShareData(const_cast<Tensor<SrcBackend>*>(&vect_of_tensors[i]));
@@ -159,7 +160,7 @@ class ExternalSource : public Operator<Backend> {
   inline void SetDataSource(const TensorVector<SrcBackend> &tv, cudaStream_t stream = 0,
                             bool sync = false, bool use_copy_kernel = false) {
     DeviceGuard g(device_id_);
-    TimeRange tr("[ExternalSource] SetDataSource", TimeRange::kViolet);
+    DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", TimeRange::kViolet);
     SetDataSourceHelper(tv, stream, sync, use_copy_kernel);
   }
 

--- a/dali/pipeline/operator/builtin/make_contiguous.cu
+++ b/dali/pipeline/operator/builtin/make_contiguous.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "dali/core/nvtx.h"
 #include "dali/pipeline/operator/builtin/make_contiguous.h"
 
 namespace dali {
@@ -35,11 +36,11 @@ void MakeContiguousMixed::Run(MixedWorkspace &ws) {
 
   auto &output = ws.Output<GPUBackend>(0);
   if (coalesced) {
-    TimeRange tm("coalesced", TimeRange::kBlue);
+    DomainTimeRange tr("[DALI][MakeContiguousMixed] coalesced", TimeRange::kBlue);
     cpu_output_buff.Copy(input, 0);
     output.Copy(cpu_output_buff, ws.stream());
   } else {
-    TimeRange tm("non coalesced", TimeRange::kGreen);
+    DomainTimeRange tr("[DALI][MakeContiguousMixed] non coalesced", TimeRange::kGreen);
       output.Copy(input, ws.stream());
   }
   coalesced = true;

--- a/dali/pipeline/operator/builtin/make_contiguous.cu
+++ b/dali/pipeline/operator/builtin/make_contiguous.cu
@@ -36,11 +36,11 @@ void MakeContiguousMixed::Run(MixedWorkspace &ws) {
 
   auto &output = ws.Output<GPUBackend>(0);
   if (coalesced) {
-    DomainTimeRange tr("[DALI][MakeContiguousMixed] coalesced", TimeRange::kBlue);
+    DomainTimeRange tr("[DALI][MakeContiguousMixed] coalesced", RangeBase::kBlue);
     cpu_output_buff.Copy(input, 0);
     output.Copy(cpu_output_buff, ws.stream());
   } else {
-    DomainTimeRange tr("[DALI][MakeContiguousMixed] non coalesced", TimeRange::kGreen);
+    DomainTimeRange tr("[DALI][MakeContiguousMixed] non coalesced", RangeBase::kGreen);
       output.Copy(input, ws.stream());
   }
   coalesced = true;

--- a/dali/pipeline/operator/builtin/make_contiguous.cu
+++ b/dali/pipeline/operator/builtin/make_contiguous.cu
@@ -36,11 +36,11 @@ void MakeContiguousMixed::Run(MixedWorkspace &ws) {
 
   auto &output = ws.Output<GPUBackend>(0);
   if (coalesced) {
-    DomainTimeRange tr("[DALI][MakeContiguousMixed] coalesced", RangeBase::kBlue);
+    DomainTimeRange tr("[DALI][MakeContiguousMixed] coalesced", DomainTimeRange::kBlue);
     cpu_output_buff.Copy(input, 0);
     output.Copy(cpu_output_buff, ws.stream());
   } else {
-    DomainTimeRange tr("[DALI][MakeContiguousMixed] non coalesced", RangeBase::kGreen);
+    DomainTimeRange tr("[DALI][MakeContiguousMixed] non coalesced", DomainTimeRange::kGreen);
       output.Copy(input, ws.stream());
   }
   coalesced = true;

--- a/include/dali/core/common.h
+++ b/include/dali/core/common.h
@@ -15,18 +15,6 @@
 #ifndef DALI_CORE_COMMON_H_
 #define DALI_CORE_COMMON_H_
 
-#if NVTX_ENABLED
-  // Just to get CUDART_VERSION value
-  #include <cuda_runtime_api.h>
-  #if (CUDART_VERSION >= 10000)
-    #include "nvtx3/nvToolsExt.h"
-  #elif (CUDART_VERSION < 10000) // NOLINT
-    #include "nvToolsExt.h"
-  #else
-    #error Unknown CUDART_VERSION!
-  #endif
-#endif
-
 #include <array>
 #include <cstdint>
 #include <iostream>
@@ -149,55 +137,6 @@ inline int NumberOfChannels(DALIImageType type) {
 #define CONCAT_1(var1, var2) var1##var2
 #define CONCAT_2(var1, var2) CONCAT_1(var1, var2)
 #define ANONYMIZE_VARIABLE(name) CONCAT_2(name, __LINE__)
-
-// Basic timerange for profiling
-struct TimeRange {
-  static const uint32_t kRed = 0xFF0000;
-  static const uint32_t kGreen = 0x00FF00;
-  static const uint32_t kBlue = 0x0000FF;
-  static const uint32_t kYellow = 0xB58900;
-  static const uint32_t kOrange = 0xCB4B16;
-  static const uint32_t kRed1 = 0xDC322F;
-  static const uint32_t kMagenta = 0xD33682;
-  static const uint32_t kViolet = 0x6C71C4;
-  static const uint32_t kBlue1 = 0x268BD2;
-  static const uint32_t kCyan = 0x2AA198;
-  static const uint32_t kGreen1 = 0x859900;
-  static const uint32_t knvGreen = 0x76B900;
-
-  TimeRange(std::string name, const uint32_t rgb = kBlue) {  // NOLINT
-#if NVTX_ENABLED
-    nvtxEventAttributes_t att = {};
-    att.version = NVTX_VERSION;
-    att.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-    att.colorType = NVTX_COLOR_ARGB;
-    att.color = rgb | 0xff000000;
-    att.messageType = NVTX_MESSAGE_TYPE_ASCII;
-    att.message.ascii = name.c_str();
-
-    nvtxRangePushEx(&att);
-    started = true;
-
-#endif
-  }
-
-  ~TimeRange() { stop(); }
-
-  void stop() {
-#if NVTX_ENABLED
-    if (started) {
-      started = false;
-      nvtxRangePop();
-    }
-#endif
-  }
-
-#if NVTX_ENABLED
-
- private:
-  bool started = false;
-#endif
-};
 
 using std::to_string;
 

--- a/include/dali/core/nvtx.h
+++ b/include/dali/core/nvtx.h
@@ -34,7 +34,18 @@
 
 namespace dali {
 
-struct RangeColors {
+inline void FillAtrbs(nvtxEventAttributes_t &att, const std::string &name, const uint32_t rgb) {
+#if NVTX_ENABLED
+  att.version = NVTX_VERSION;
+  att.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  att.colorType = NVTX_COLOR_ARGB;
+  att.color = rgb | 0xff000000;
+  att.messageType = NVTX_MESSAGE_TYPE_ASCII;
+  att.message.ascii = name.c_str();
+#endif
+}
+
+struct RangeBase {
   static const uint32_t kRed = 0xFF0000;
   static const uint32_t kGreen = 0x00FF00;
   static const uint32_t kBlue = 0x0000FF;
@@ -50,20 +61,13 @@ struct RangeColors {
 };
 
 // Basic timerange for profiling
-struct TimeRange : RangeColors {
-  TimeRange(std::string name, const uint32_t rgb = kBlue) {  // NOLINT
+struct TimeRange : RangeBase {
+  TimeRange(const std::string name, const uint32_t rgb = kBlue) {  // NOLINT
 #if NVTX_ENABLED
     nvtxEventAttributes_t att = {};
-    att.version = NVTX_VERSION;
-    att.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-    att.colorType = NVTX_COLOR_ARGB;
-    att.color = rgb | 0xff000000;
-    att.messageType = NVTX_MESSAGE_TYPE_ASCII;
-    att.message.ascii = name.c_str();
-
+    FillAtrbs(att, name, rgb);
     nvtxRangePushEx(&att);
     started = true;
-
 #endif
   }
 
@@ -82,7 +86,7 @@ struct TimeRange : RangeColors {
   bool started = false;
 };
 
-struct DomainTimeRange : RangeColors{
+struct DomainTimeRange : RangeBase {
   explicit DomainTimeRange(const std::string &name, const uint32_t rgb = kBlue);
   ~DomainTimeRange();
 };

--- a/include/dali/core/nvtx.h
+++ b/include/dali/core/nvtx.h
@@ -49,47 +49,55 @@ struct RangeBase {
   static const uint32_t kGreen1 = 0x859900;
   static const uint32_t knvGreen = 0x76B900;
 
-  inline void FillAtrbs(nvtxEventAttributes_t &att, const std::string &name, const uint32_t rgb) {
   #if NVTX_ENABLED
+  inline void FillAtrbs(nvtxEventAttributes_t &att, const char *name, const uint32_t rgb) {
     att.version = NVTX_VERSION;
     att.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
     att.colorType = NVTX_COLOR_ARGB;
     att.color = rgb | 0xff000000;
     att.messageType = NVTX_MESSAGE_TYPE_ASCII;
-    att.message.ascii = name.c_str();
-  #endif
+    att.message.ascii = name;
   }
+  #endif
 };
 
 // Basic timerange for profiling
 struct TimeRange : RangeBase {
-  TimeRange(const std::string name, const uint32_t rgb = kBlue) {  // NOLINT
-#if NVTX_ENABLED
+  explicit TimeRange(const std::string &name, const uint32_t rgb = kBlue)
+    : TimeRange(name.c_str(), rgb) {}
+  explicit TimeRange(const char *name, const uint32_t rgb = kBlue) {
+  #if NVTX_ENABLED
     nvtxEventAttributes_t att = {};
     FillAtrbs(att, name, rgb);
     nvtxRangePushEx(&att);
     started = true;
-#endif
+  #endif
   }
-
   ~TimeRange() { stop(); }
 
  private:
   void stop() {
-#if NVTX_ENABLED
+  #if NVTX_ENABLED
     if (started) {
       started = false;
       nvtxRangePop();
     }
-#endif
+  #endif
   }
 
   bool started = false;
 };
 
 struct DomainTimeRange : RangeBase {
-  explicit DomainTimeRange(const std::string &name, const uint32_t rgb = kBlue);
+  explicit DomainTimeRange(const std::string &name, const uint32_t rgb = kBlue)
+    : DomainTimeRange(name.c_str(), rgb) {}
+#if NVTX_ENABLED
+  explicit DomainTimeRange(const char *name, const uint32_t rgb = kBlue);
   ~DomainTimeRange();
+#else
+  explicit DomainTimeRange(const char *name, const uint32_t rgb = kBlue) {}
+  ~DomainTimeRange() {}
+#endif
 };
 
 }  // namespace dali

--- a/include/dali/core/nvtx.h
+++ b/include/dali/core/nvtx.h
@@ -1,0 +1,92 @@
+// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_NVTX_H_
+#define DALI_CORE_NVTX_H_
+
+#include <cstdint>
+#include <string>
+
+#if NVTX_ENABLED
+  // Just to get CUDART_VERSION value
+  #include <cuda_runtime_api.h>
+  #if (CUDART_VERSION >= 10000)
+    #include "nvtx3/nvToolsExt.h"
+  #elif (CUDART_VERSION < 10000) // NOLINT
+    #include "nvToolsExt.h"
+  #else
+    #error Unknown CUDART_VERSION!
+  #endif
+#endif
+
+#include "dali/core/api_helper.h"
+
+namespace dali {
+
+struct RangeColors {
+  static const uint32_t kRed = 0xFF0000;
+  static const uint32_t kGreen = 0x00FF00;
+  static const uint32_t kBlue = 0x0000FF;
+  static const uint32_t kYellow = 0xB58900;
+  static const uint32_t kOrange = 0xCB4B16;
+  static const uint32_t kRed1 = 0xDC322F;
+  static const uint32_t kMagenta = 0xD33682;
+  static const uint32_t kViolet = 0x6C71C4;
+  static const uint32_t kBlue1 = 0x268BD2;
+  static const uint32_t kCyan = 0x2AA198;
+  static const uint32_t kGreen1 = 0x859900;
+  static const uint32_t knvGreen = 0x76B900;
+};
+
+// Basic timerange for profiling
+struct TimeRange : RangeColors {
+  TimeRange(std::string name, const uint32_t rgb = kBlue) {  // NOLINT
+#if NVTX_ENABLED
+    nvtxEventAttributes_t att = {};
+    att.version = NVTX_VERSION;
+    att.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+    att.colorType = NVTX_COLOR_ARGB;
+    att.color = rgb | 0xff000000;
+    att.messageType = NVTX_MESSAGE_TYPE_ASCII;
+    att.message.ascii = name.c_str();
+
+    nvtxRangePushEx(&att);
+    started = true;
+
+#endif
+  }
+
+  ~TimeRange() { stop(); }
+
+ private:
+  void stop() {
+#if NVTX_ENABLED
+    if (started) {
+      started = false;
+      nvtxRangePop();
+    }
+#endif
+  }
+
+  bool started = false;
+};
+
+struct DomainTimeRange : RangeColors{
+  explicit DomainTimeRange(const std::string &name, const uint32_t rgb = kBlue);
+  ~DomainTimeRange();
+};
+
+}  // namespace dali
+
+#endif  // DALI_CORE_NVTX_H_

--- a/include/dali/core/nvtx.h
+++ b/include/dali/core/nvtx.h
@@ -34,16 +34,6 @@
 
 namespace dali {
 
-inline void FillAtrbs(nvtxEventAttributes_t &att, const std::string &name, const uint32_t rgb) {
-#if NVTX_ENABLED
-  att.version = NVTX_VERSION;
-  att.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-  att.colorType = NVTX_COLOR_ARGB;
-  att.color = rgb | 0xff000000;
-  att.messageType = NVTX_MESSAGE_TYPE_ASCII;
-  att.message.ascii = name.c_str();
-#endif
-}
 
 struct RangeBase {
   static const uint32_t kRed = 0xFF0000;
@@ -58,6 +48,17 @@ struct RangeBase {
   static const uint32_t kCyan = 0x2AA198;
   static const uint32_t kGreen1 = 0x859900;
   static const uint32_t knvGreen = 0x76B900;
+
+  inline void FillAtrbs(nvtxEventAttributes_t &att, const std::string &name, const uint32_t rgb) {
+  #if NVTX_ENABLED
+    att.version = NVTX_VERSION;
+    att.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+    att.colorType = NVTX_COLOR_ARGB;
+    att.color = rgb | 0xff000000;
+    att.messageType = NVTX_MESSAGE_TYPE_ASCII;
+    att.message.ascii = name.c_str();
+  #endif
+  }
 };
 
 // Basic timerange for profiling


### PR DESCRIPTION
- libdali_core now provides NVTX ranges functionality
- core is responsible for creating one DALI domain
- regular DALI code should use DomainTimeRange from core lib
- plain TimeRange is still header-only and should be used only for the development

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It moves all NVTX infrastructure into core and create DALI domain
#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     libdali_core now provides NVTX ranges functionality
 - Affected modules and functionalities:
     core
     all modules using NVTX ranges
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1728]*
