### PR TITLE
COCOReader: Support for uncompressed RLE masks 

### DIFF
--- a/DALI_EXTRA_VERSION
+++ b/DALI_EXTRA_VERSION
@@ -1,1 +1,1 @@
-rle_uncompressed
+355734c4d6f2d3ec77fddf849adac2b812769712

--- a/DALI_EXTRA_VERSION
+++ b/DALI_EXTRA_VERSION
@@ -1,1 +1,1 @@
-fdd536addddc0f1a5bd52a15db708f95492c813e
+rle_uncompressed

--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -264,11 +264,12 @@ void COCOReader::PixelwiseMasks(int image_idx, int* mask) {
   RLE* R;
   rlesInit(&R, *labels.rbegin() + 1);
 
-  // Create a run-length encoding for each compressed string representation
+  // Mask was originally described in RLE format
   for (uint ann_id = 0 ; ann_id < masks_info.mask_indices.size(); ann_id++) {
+    const auto &rle = *masks_info.rles[ann_id];
     auto mask_idx = masks_info.mask_indices[ann_id];
     int label = labels_span[mask_idx];
-    rleFrString(&R[label], const_cast<char*>(masks_info.rles[ann_id].c_str()), h, w);
+    rleInit(&R[label], rle.h, rle.w, rle.m, rle.cnts);
   }
 
   // Merge each label (from multi-polygons annotations)

--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -266,10 +266,10 @@ void COCOReader::PixelwiseMasks(int image_idx, int* mask) {
 
   // Mask was originally described in RLE format
   for (uint ann_id = 0 ; ann_id < masks_info.mask_indices.size(); ann_id++) {
-    const auto &rle = *masks_info.rles[ann_id];
+    const auto &rle = masks_info.rles[ann_id];
     auto mask_idx = masks_info.mask_indices[ann_id];
     int label = labels_span[mask_idx];
-    rleInit(&R[label], rle.h, rle.w, rle.m, rle.cnts);
+    rleInit(&R[label], rle->h, rle->w, rle->m, rle->cnts);
   }
 
   // Merge each label (from multi-polygons annotations)

--- a/dali/operators/reader/coco_reader_op_test.cc
+++ b/dali/operators/reader/coco_reader_op_test.cc
@@ -34,7 +34,7 @@ void RemoveAll(const char *dir) {
   nftw(dir, Remove, 64, FTW_DEPTH | FTW_PHYS);
 }
 
-}
+}  // namespace
 
 namespace dali {
 

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -35,11 +35,6 @@ struct Polygons {
   std::vector<float> segm_coords_;
 };
 
-struct RunLengthEncoding {
-  int h_, w_;
-  std::string rle_;
-};
-
 struct Annotation {
   enum {POLYGON, RLE} tag_;
   int image_id_;
@@ -47,7 +42,7 @@ struct Annotation {
   std::array<float, 4> box_;
   // union
   Polygons poly_;
-  RunLengthEncoding rle_;
+  RLEMask rle_;
 
   void ToLtrb() {
     box_[2] += box_[0];
@@ -60,32 +55,55 @@ struct Annotation {
 };
 
 template <typename T>
-void SaveToFile(std::vector<T> &input, const std::string path) {
+void SaveToFile(const std::vector<T> &input, const std::string path) {
+  if (input.empty())
+    return;
   std::ofstream file(path, std::ios_base::binary | std::ios_base::out);
   DALI_ENFORCE(file, "CocoReader meta file error while saving: " + path);
 
   unsigned size = input.size();
-  file.write(reinterpret_cast<char*>(&size), sizeof(unsigned));
-  file.write(reinterpret_cast<char*>(input.data()), size * sizeof(T));
+  file.write(reinterpret_cast<const char*>(&size), sizeof(unsigned));
+  file.write(reinterpret_cast<const char*>(input.data()), size * sizeof(T));
   DALI_ENFORCE(file.good(), make_string("Error writing to path: ", path));
 }
 
-template <typename T>
-void SaveToFile(std::vector<std::vector<T> > &input, const std::string path) {
+template <>
+void SaveToFile(const std::vector<RLEMask> &input, const std::string path) {
+  if (input.empty())
+    return;
   std::ofstream file(path, std::ios_base::binary | std::ios_base::out);
   DALI_ENFORCE(file, "CocoReader meta file error while saving: " + path);
 
   unsigned size = input.size();
-  file.write(reinterpret_cast<char*>(&size), sizeof(unsigned));
-  for (auto& v : input) {
-    size = v.size();
-    file.write(reinterpret_cast<char*>(&size), sizeof(unsigned));
-    file.write(reinterpret_cast<char*>(v.data()), size * sizeof(T));
+  file.write(reinterpret_cast<const char*>(&size), sizeof(unsigned));
+  for (auto &rle : input) {
+    file.write(reinterpret_cast<const char*>(&rle->h), 3 * sizeof(siz));  // write h, w, m
+    file.write(reinterpret_cast<const char*>(rle->cnts), rle->m * sizeof(uint));
   }
   DALI_ENFORCE(file.good(), make_string("Error writing to path: ", path));
 }
 
-void SaveFilenamesToFile(const ImageIdPairs &image_id_pairs, const std::string path) {
+template <typename T>
+void SaveToFile(const std::vector<std::vector<T> > &input, const std::string path) {
+  if (input.empty())
+    return;
+  std::ofstream file(path, std::ios_base::binary | std::ios_base::out);
+  DALI_ENFORCE(file, "CocoReader meta file error while saving: " + path);
+
+  unsigned size = input.size();
+  file.write(reinterpret_cast<const char*>(&size), sizeof(unsigned));
+  for (auto& v : input) {
+    size = v.size();
+    file.write(reinterpret_cast<const char*>(&size), sizeof(unsigned));
+    file.write(reinterpret_cast<const char*>(v.data()), size * sizeof(T));
+  }
+  DALI_ENFORCE(file.good(), make_string("Error writing to path: ", path));
+}
+
+template <>
+void SaveToFile(const ImageIdPairs &image_id_pairs, const std::string path) {
+  if (image_id_pairs.empty())
+    return;
   std::ofstream file(path);
   DALI_ENFORCE(file, "CocoReader meta file error while saving: " + path);
   for (const auto &p : image_id_pairs) {
@@ -97,8 +115,9 @@ void SaveFilenamesToFile(const ImageIdPairs &image_id_pairs, const std::string p
 template <typename T>
 void LoadFromFile(std::vector<T> &output, const std::string path) {
   std::ifstream file(path);
-  DALI_ENFORCE(file.good(),
-               make_string("CocoReader failed to read preprocessed annotation data from ", path));
+  output.clear();
+  if (!file.good())
+    return;
 
   unsigned size;
   file.read(reinterpret_cast<char*>(&size), sizeof(unsigned));
@@ -106,11 +125,32 @@ void LoadFromFile(std::vector<T> &output, const std::string path) {
   file.read(reinterpret_cast<char*>(output.data()), size * sizeof(T));
 }
 
+template <>
+void LoadFromFile(std::vector<RLEMask> &output, const std::string path) {
+  std::ifstream file(path);
+  output.clear();
+  if (!file.good())
+    return;
+
+  unsigned size;
+  file.read(reinterpret_cast<char*>(&size), sizeof(unsigned));
+  output.clear();
+  output.resize(size);
+  for (auto &rle : output) {
+    siz dims[3];
+    file.read(reinterpret_cast<char*>(dims), 3 * sizeof(siz));  // read h, w, m
+    siz h = dims[0], w = dims[1], m = dims[2];
+    rleInit(rle.get(), h, w, m, nullptr);
+    file.read(reinterpret_cast<char*>(rle->cnts), m * sizeof(uint));
+  }
+}
+
 template <typename T>
 void LoadFromFile(std::vector<std::vector<T> > &output, const std::string path) {
   std::ifstream file(path);
-  DALI_ENFORCE(file.good(),
-               make_string("CocoReader failed to read preprocessed annotation data from ", path));
+  output.clear();
+  if (!file.good())
+    return;
 
   unsigned size;
   file.read(reinterpret_cast<char*>(&size), sizeof(unsigned));
@@ -122,10 +162,12 @@ void LoadFromFile(std::vector<std::vector<T> > &output, const std::string path) 
   }
 }
 
-void LoadFilenamesFromFile(ImageIdPairs &image_id_pairs, const std::string path) {
+template <>
+void LoadFromFile(ImageIdPairs &image_id_pairs, const std::string path) {
   std::ifstream file(path);
-  DALI_ENFORCE(file.good(),
-               make_string("CocoReader failed to read preprocessed annotation data from ", path));
+  image_id_pairs.clear();
+  if (!file.good())
+    return;
 
   int id = 0;
   std::string filename;
@@ -219,19 +261,25 @@ void ParseAnnotations(LookaheadParser &parser, std::vector<Annotation> &annotati
         if (parse_rle && parser.PeekType() == kObjectType) {
           annotation.tag_ = Annotation::RLE;
           parser.EnterObject();
+          std::string rle_str;
+          int h = -1, w = -1;
           while (const char* another_key = parser.NextObjectKey()) {
             if (0 == std::strcmp(another_key, "size")) {
               RAPIDJSON_ASSERT(parser.PeekType() == kArrayType);
               parser.EnterArray();
               parser.NextArrayValue();
-              annotation.rle_.h_ = parser.GetInt();
+              h = parser.GetInt();
               parser.NextArrayValue();
-              annotation.rle_.w_ = parser.GetInt();
+              w = parser.GetInt();
               parser.NextArrayValue();
             } else if (0 == std::strcmp(another_key, "counts")) {
-              annotation.rle_.rle_ = parser.GetString();
+              rle_str = parser.GetString();
             }
           }
+          assert(h > 0);
+          assert(w > 0);
+          assert(rle_str.length() > 0);
+          annotation.rle_ = RLEMask(rle_str.c_str(), h, w);
         } else if (parser.PeekType() == kArrayType) {
           annotation.tag_ = Annotation::POLYGON;
           int coord_offset = 0;
@@ -306,14 +354,13 @@ void ParseJsonFile(const OpSpec &spec, std::vector<detail::ImageInfo> &image_inf
 void CocoLoader::SavePreprocessedAnnotations(const std::string &path,
                                              const ImageIdPairs &image_id_pairs) {
   using detail::SaveToFile;
-  using detail::SaveFilenamesToFile;
   SaveToFile(offsets_, path + "/offsets.dat");
   SaveToFile(boxes_, path + "/boxes.dat");
   SaveToFile(labels_, path + "/labels.dat");
   SaveToFile(counts_, path + "/counts.dat");
-  SaveFilenamesToFile(image_id_pairs, path + "/filenames.dat");
+  SaveToFile(image_id_pairs, path + "/filenames.dat");
 
-  if (output_polygon_masks_) {
+  if (output_polygon_masks_ || output_pixelwise_masks_) {
     SaveToFile(polygon_data_, path + "/polygon_data.dat");
     SaveToFile(polygon_offset_, path + "/polygon_offset.dat");
     SaveToFile(polygon_count_, path + "/polygons_count.dat");
@@ -323,7 +370,13 @@ void CocoLoader::SavePreprocessedAnnotations(const std::string &path,
   }
 
   if (output_pixelwise_masks_) {
-    DALI_WARN("Warning: Saving preprocessed piwelwise masks is not supported");
+    SaveToFile(masks_rles_, path + "/masks_rles.dat");
+    SaveToFile(masks_rles_idx_, path + "/masks_rles_idx.dat");
+    SaveToFile(masks_offset_, path + "/masks_offset.dat");
+    SaveToFile(masks_count_, path + "/masks_count.dat");
+    SaveToFile(heights_, path + "/heights.dat");
+    SaveToFile(widths_, path + "/widths.dat");
+
   }
 
   if (output_image_ids_) {
@@ -336,15 +389,14 @@ void CocoLoader::ParsePreprocessedAnnotations() {
   const auto path = spec_.HasArgument("meta_files_path")
       ? spec_.GetArgument<string>("meta_files_path")
       : spec_.GetArgument<string>("preprocessed_annotations");
-  using detail::LoadFilenamesFromFile;
   using detail::LoadFromFile;
   LoadFromFile(offsets_, path + "/offsets.dat");
   LoadFromFile(boxes_, path + "/boxes.dat");
   LoadFromFile(labels_, path + "/labels.dat");
   LoadFromFile(counts_, path + "/counts.dat");
-  LoadFilenamesFromFile(image_label_pairs_, path + "/filenames.dat");
+  LoadFromFile(image_label_pairs_, path + "/filenames.dat");
 
-  if (output_polygon_masks_) {
+  if (output_polygon_masks_ || output_pixelwise_masks_) {
     LoadFromFile(polygon_data_, path + "/polygon_data.dat");
     LoadFromFile(polygon_offset_, path + "/polygon_offset.dat");
     LoadFromFile(polygon_count_, path + "/polygons_count.dat");
@@ -354,7 +406,12 @@ void CocoLoader::ParsePreprocessedAnnotations() {
   }
 
   if (output_pixelwise_masks_) {
-    DALI_WARN("Loading from preprocessed piwelwise masks is not supported");
+    LoadFromFile(masks_rles_, path + "/masks_rles.dat");
+    LoadFromFile(masks_rles_idx_, path + "/masks_rles_idx.dat");
+    LoadFromFile(masks_offset_, path + "/masks_offset.dat");
+    LoadFromFile(masks_count_, path + "/masks_count.dat");
+    LoadFromFile(heights_, path + "/heights.dat");
+    LoadFromFile(widths_, path + "/widths.dat");
   }
 
   if (output_image_ids_) {
@@ -392,14 +449,14 @@ void CocoLoader::ParseJsonAnnotations() {
 
   for (auto &image_info : image_infos) {
     int objects_in_sample = 0;
-    std::vector<int> sample_rles_idx;
-    std::vector<std::string> sample_rles;
     int64_t polygons_sample_offset = polygon_data_.size();
     int64_t polygons_sample_count = 0;
     int64_t vertices_sample_offset = vertices_data_.size();
     int64_t vertices_sample_count = 0;
+    int64_t masks_offset = masks_rles_.size();
+    int64_t masks_count = 0;
     while (annotations[annotation_id].image_id_ == image_info.original_id_) {
-      const auto &annotation = annotations[annotation_id];
+      auto &annotation = annotations[annotation_id];
       labels_.push_back(category_ids[annotation.category_id_]);
       if (ratio) {
         boxes_.push_back(annotation.box_[0] / image_info.width_);
@@ -445,8 +502,9 @@ void CocoLoader::ParseJsonAnnotations() {
             break;
           }
           case detail::Annotation::RLE: {
-            sample_rles_idx.push_back(objects_in_sample);
-            sample_rles.push_back(std::move(annotation.rle_.rle_));
+            masks_rles_idx_.push_back(objects_in_sample);
+            masks_rles_.emplace_back(std::move(annotation.rle_));
+            masks_count++;
             break;
           }
           default: {
@@ -470,13 +528,14 @@ void CocoLoader::ParseJsonAnnotations() {
         polygon_count_.push_back(polygons_sample_count);
         vertices_offset_.push_back(vertices_sample_offset);
         vertices_count_.push_back(vertices_sample_count);
-        masks_rles_.emplace_back(std::move(sample_rles));
-        masks_rles_idx_.emplace_back(std::move(sample_rles_idx));
+        if (output_pixelwise_masks_) {
+          masks_offset_.push_back(masks_offset);
+          masks_count_.push_back(masks_count);
+          heights_.push_back(image_info.height_);
+          widths_.push_back(image_info.width_);
+        }
       }
-      if (output_pixelwise_masks_) {
-        heights_.push_back(image_info.height_);
-        widths_.push_back(image_info.width_);
-      }
+
       image_label_pairs_.emplace_back(std::move(image_info.filename_), new_image_id);
       new_image_id++;
     }

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -140,7 +140,7 @@ void LoadFromFile(std::vector<RLEMask> &output, const std::string path) {
     siz dims[3];
     file.read(reinterpret_cast<char*>(dims), 3 * sizeof(siz));  // read h, w, m
     siz h = dims[0], w = dims[1], m = dims[2];
-    rleInit(rle.get(), h, w, m, nullptr);
+    rle = RLEMask(h, w, m);
     file.read(reinterpret_cast<char*>(rle->cnts), m * sizeof(uint));
   }
 }
@@ -292,9 +292,9 @@ void ParseAnnotations(LookaheadParser &parser, std::vector<Annotation> &annotati
           }
           DALI_ENFORCE(h > 0 && w > 0, "Invalid or missing mask sizes");
           if (!rle_str.empty()) {
-            annotation.rle_ = RLEMask(rle_str.c_str(), h, w);
+            annotation.rle_ = RLEMask(h, w, rle_str.c_str());
           } else if (!rle_uints.empty()) {
-            annotation.rle_ = RLEMask(make_cspan(rle_uints), h, w);
+            annotation.rle_ = RLEMask(h, w, make_cspan(rle_uints));
           } else {
             DALI_FAIL("Missing or invalid ``counts`` attribute.");
           }
@@ -394,7 +394,6 @@ void CocoLoader::SavePreprocessedAnnotations(const std::string &path,
     SaveToFile(masks_count_, path + "/masks_count.dat");
     SaveToFile(heights_, path + "/heights.dat");
     SaveToFile(widths_, path + "/widths.dat");
-
   }
 
   if (output_image_ids_) {

--- a/dali/operators/reader/loader/coco_loader.h
+++ b/dali/operators/reader/loader/coco_loader.h
@@ -79,7 +79,6 @@ struct RLEMask : public UniqueHandle<RLE, RLEMask> {
     rleFrString(&handle_, const_cast<char*>(str), h, w);
   }
 
-  static constexpr RLE null_handle() { return {0, 0, 0, nullptr}; }
   static constexpr bool is_null_handle(const RLE &handle) {
     return handle.cnts == nullptr;
   }
@@ -151,8 +150,8 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
     assert(output_pixelwise_masks_);
     return {
       {heights_[image_idx], widths_[image_idx], 1},
-      {masks_rles_.data() + masks_offset_[image_idx], masks_count_[image_idx]},
-      {masks_rles_idx_.data() + masks_offset_[image_idx], masks_count_[image_idx]}
+      {masks_rles_.data() + mask_offsets_[image_idx], mask_counts_[image_idx]},
+      {masks_rles_idx_.data() + mask_offsets_[image_idx], mask_counts_[image_idx]}
     };
   }
 
@@ -207,18 +206,18 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
 
   // polygons: (mask_idx, offset, size)
   std::vector<ivec3> polygon_data_;
-  std::vector<int64_t> polygon_offset_;  // per sample offset
-  std::vector<int64_t> polygon_count_;  // per sample size
+  std::vector<int64_t> polygon_offset_;  // per-sample offset of polygons
+  std::vector<int64_t> polygon_count_;   // number of polygon per sample
   // vertices: (all polygons concatenated)
   std::vector<vec2> vertices_data_;
-  std::vector<int64_t> vertices_offset_;  // per sample offset
-  std::vector<int64_t> vertices_count_;  // per sample size
+  std::vector<int64_t> vertices_offset_;  // per-sample offset of vertices
+  std::vector<int64_t> vertices_count_;   // number of vertices per sample
 
   // masks_rles: (run-length encodings)
   std::vector<RLEMask> masks_rles_;
   std::vector<int> masks_rles_idx_;
-  std::vector<int64_t> masks_offset_;  // per sample offset
-  std::vector<int64_t> masks_count_;  // per sample size
+  std::vector<int64_t> mask_offsets_;  // per-sample offsets of masks
+  std::vector<int64_t> mask_counts_;   // number of masks per sample
 
   bool output_polygon_masks_ = false;
   bool output_pixelwise_masks_ = false;

--- a/dali/operators/reader/loader/coco_loader.h
+++ b/dali/operators/reader/loader/coco_loader.h
@@ -149,9 +149,6 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
 
   PixelwiseMasksInfo pixelwise_masks_info(int image_idx) const {
     assert(output_pixelwise_masks_);
-    if (heights_.empty() || widths_.empty() || masks_rles_.empty() ||
-        masks_rles_idx_.empty() || masks_offset_.empty() || masks_count_.empty())
-      return {};
     return {
       {heights_[image_idx], widths_[image_idx], 1},
       {masks_rles_.data() + masks_offset_[image_idx], masks_count_[image_idx]},

--- a/dali/pipeline/util/lookahead_parser.h
+++ b/dali/pipeline/util/lookahead_parser.h
@@ -35,6 +35,7 @@ using rapidjson::kParseDefaultFlags;
 using rapidjson::kParseInsituFlag;
 using rapidjson::kArrayType;
 using rapidjson::kObjectType;
+using rapidjson::kStringType;
 
 // taken from https://github.com/Tencent/rapidjson/blob/master/example/lookaheadparser/lookaheadparser.cpp
 

--- a/include/dali/core/unique_handle.h
+++ b/include/dali/core/unique_handle.h
@@ -62,7 +62,7 @@ class UniqueHandle {
   UniqueHandle &operator=(const UniqueHandle &) = delete;
 
   inline UniqueHandle(UniqueHandle &&other) : handle_(other.handle_) {
-    other.handle_ = nullptr;
+    other.handle_ = Actual::null_handle();
   }
 
   inline UniqueHandle &operator=(UniqueHandle &&other) {
@@ -82,7 +82,7 @@ class UniqueHandle {
    * * The null value to replace the handle with, is taken from `Actual::null_value()`.
    */
   inline void reset() {
-    if (handle_ != Actual::null_handle()) {
+    if (!Actual::is_null_handle(handle_)) {
       Actual::DestroyHandle(handle_);
       handle_ = Actual::null_handle();
     }
@@ -115,10 +115,13 @@ class UniqueHandle {
 
   /// @brief Indicates whether the handle is non-null.
   constexpr explicit operator bool() const noexcept {
-    return handle_ != Actual::null_handle();
+    return !Actual::is_null_handle(handle_);
   }
 
   static constexpr handle_type null_handle() noexcept { return {}; }
+  static constexpr bool is_null_handle(const handle_type& handle) noexcept {
+    return handle == Actual::null_handle();
+  }
 
  protected:
   inline ~UniqueHandle() { reset(); }

--- a/qa/setup_dali_extra.sh
+++ b/qa/setup_dali_extra.sh
@@ -2,7 +2,7 @@
 
 # Fetch test data
 export DALI_EXTRA_PATH=${DALI_EXTRA_PATH:-/opt/dali_extra}
-export DALI_EXTRA_URL="https://github.com/jantonguirao/DALI_extra.git"
+export DALI_EXTRA_URL=${DALI_EXTRA_URL:-"https://github.com/NVIDIA/DALI_extra.git"}
 
 DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 DALI_EXTRA_VERSION_PATH="${DIR}/../DALI_EXTRA_VERSION"
@@ -13,5 +13,6 @@ if [ ! -d "$DALI_EXTRA_PATH" ] ; then
 fi
 
 pushd "$DALI_EXTRA_PATH"
-git checkout rle_uncompressed
+git fetch origin ${DALI_EXTRA_VERSION}
+git checkout ${DALI_EXTRA_VERSION}
 popd

--- a/qa/setup_dali_extra.sh
+++ b/qa/setup_dali_extra.sh
@@ -2,7 +2,7 @@
 
 # Fetch test data
 export DALI_EXTRA_PATH=${DALI_EXTRA_PATH:-/opt/dali_extra}
-export DALI_EXTRA_URL=${DALI_EXTRA_URL:-"https://github.com/NVIDIA/DALI_extra.git"}
+export DALI_EXTRA_URL=${DALI_EXTRA_URL:-"https://github.com/jantonguirao/DALI_extra.git"}
 
 DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 DALI_EXTRA_VERSION_PATH="${DIR}/../DALI_EXTRA_VERSION"

--- a/qa/setup_dali_extra.sh
+++ b/qa/setup_dali_extra.sh
@@ -2,7 +2,7 @@
 
 # Fetch test data
 export DALI_EXTRA_PATH=${DALI_EXTRA_PATH:-/opt/dali_extra}
-export DALI_EXTRA_URL=${DALI_EXTRA_URL:-"https://github.com/jantonguirao/DALI_extra.git"}
+export DALI_EXTRA_URL="https://github.com/jantonguirao/DALI_extra.git"
 
 DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 DALI_EXTRA_VERSION_PATH="${DIR}/../DALI_EXTRA_VERSION"
@@ -13,6 +13,5 @@ if [ ! -d "$DALI_EXTRA_PATH" ] ; then
 fi
 
 pushd "$DALI_EXTRA_PATH"
-git fetch origin ${DALI_EXTRA_VERSION}
-git checkout ${DALI_EXTRA_VERSION}
+git checkout rle_uncompressed
 popd


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a new feature needed to support uncompressed RLE counts
- It adds a new feature needed to support load from preprocessed annotations, including RLE masks

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added support for preprocessed annotation files describing RLE masks*
     *Using cocoapi RLE struct to store the RLE masks.*
 - Affected modules and functionalities:
     *COCOReader*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     *C++ Tests enhanced, new data added to DALI_extra*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1732]*
