### PR TITLE
MXNet Iterator: Revert to squeeze_labels=True behavior by default

### DIFF
--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -214,7 +214,7 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
                  data_layout='NCHW',
                  fill_last_batch=None,
                  auto_reset=False,
-                 squeeze_labels=None,
+                 squeeze_labels=True,
                  dynamic_shape=False,
                  last_batch_padded=False,
                  last_batch_policy=LastBatchPolicy.FILL):
@@ -238,8 +238,6 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
             auto_reset,
             last_batch_policy)
         self._squeeze_labels = squeeze_labels
-        if self._squeeze_labels is not None:
-            print("Warning: ``squeeze_labels`` is now deprecated. Any manipulation of the tensor shapes should be done explicitly in the DALI pipeline.")
         self._dynamic_shape = dynamic_shape
         # Use double-buffering of data batches
         self._data_batches = [[None] for i in range(self._num_gpus)]
@@ -422,7 +420,7 @@ class DALIClassificationIterator(DALIGenericIterator):
     auto_reset : bool, optional, default = False
                  Whether the iterator resets itself for the next epoch
                  or it requires reset() to be called separately.
-    squeeze_labels: (DEPRECATED) bool, optional, default = False
+    squeeze_labels: (DEPRECATED) bool, optional, default = True
                  Whether the iterator should squeeze the labels before
                  copying them to the ndarray.
                  This argument is deprecated and will be removed from future releases.
@@ -479,7 +477,7 @@ class DALIClassificationIterator(DALIGenericIterator):
                  data_layout='NCHW',
                  fill_last_batch=None,
                  auto_reset=False,
-                 squeeze_labels=None,
+                 squeeze_labels=True,
                  dynamic_shape=False,
                  last_batch_padded=False,
                  last_batch_policy=LastBatchPolicy.FILL):

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -143,7 +143,7 @@ def test_mxnet_iterator_last_batch_no_pad_last_batch():
                                     size=pipes[0].epoch_size("Reader"), last_batch_policy=LastBatchPolicy.FILL)
 
     img_ids_list, img_ids_list_set, mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x.data[0].squeeze().asnumpy(), lambda x: x.pad, data_size)
+        gather_ids(dali_train_iter, lambda x: x.data[0].squeeze(-1).asnumpy(), lambda x: x.pad, data_size)
 
     assert len(img_ids_list) > data_size
     assert len(img_ids_list_set) == data_size
@@ -211,7 +211,7 @@ def test_mxnet_iterator_last_batch_pad_last_batch():
                                     size=pipes[0].epoch_size("Reader"), last_batch_policy=LastBatchPolicy.FILL)
 
     img_ids_list, img_ids_list_set, mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x.data[0].squeeze().asnumpy(), lambda x: x.pad, data_size)
+        gather_ids(dali_train_iter, lambda x: x.data[0].squeeze(-1).asnumpy(), lambda x: x.pad, data_size)
 
     assert len(img_ids_list) > data_size
     assert len(img_ids_list_set) == data_size
@@ -219,7 +219,7 @@ def test_mxnet_iterator_last_batch_pad_last_batch():
 
     dali_train_iter.reset()
     next_img_ids_list, next_img_ids_list_set, next_mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x.data[0].squeeze().asnumpy(), lambda x: x.pad, data_size)
+        gather_ids(dali_train_iter, lambda x: x.data[0].squeeze(-1).asnumpy(), lambda x: x.pad, data_size)
 
     assert len(next_img_ids_list) > data_size
     assert len(next_img_ids_list_set) == data_size
@@ -238,7 +238,7 @@ def test_mxnet_iterator_not_fill_last_batch_pad_last_batch():
                                     last_batch_policy=LastBatchPolicy.PARTIAL)
 
     img_ids_list, img_ids_list_set, mirrored_data, pad, remainder = \
-        gather_ids(dali_train_iter, lambda x: x.data[0].squeeze().asnumpy(), lambda x: x.pad, data_size)
+        gather_ids(dali_train_iter, lambda x: x.data[0].squeeze(-1).asnumpy(), lambda x: x.pad, data_size)
 
     assert pad == remainder
     assert len(img_ids_list) - pad == data_size
@@ -247,7 +247,7 @@ def test_mxnet_iterator_not_fill_last_batch_pad_last_batch():
 
     dali_train_iter.reset()
     next_img_ids_list, next_img_ids_list_set, next_mirrored_data, pad, remainder = \
-        gather_ids(dali_train_iter, lambda x: x.data[0].squeeze().asnumpy(), lambda x: x.pad, data_size)
+        gather_ids(dali_train_iter, lambda x: x.data[0].squeeze(-1).asnumpy(), lambda x: x.pad, data_size)
 
     assert pad == remainder
     assert len(next_img_ids_list) - pad == data_size
@@ -341,7 +341,7 @@ def check_mxnet_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
         img_ids_list = [[] for _ in range(pipes_number)]
         for it in iter(dali_train_iter):
             for id in range(pipes_number):
-                tmp = it[id].data[0].squeeze().asnumpy().copy()
+                tmp = it[id].data[0].squeeze(-1).asnumpy().copy()
                 if it[id].pad:
                     tmp = tmp[0:-it[id].pad]
                 img_ids_list[id].append(tmp)
@@ -378,7 +378,7 @@ def test_gluon_iterator_last_batch_no_pad_last_batch():
     dali_train_iter = GluonIterator(pipes, size=pipes[0].epoch_size("Reader"), last_batch_policy=LastBatchPolicy.FILL)
 
     img_ids_list, img_ids_list_set, mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x[0].squeeze().asnumpy(), lambda x: 0, data_size)
+        gather_ids(dali_train_iter, lambda x: x[0].squeeze(-1).asnumpy(), lambda x: 0, data_size)
 
     assert len(img_ids_list) > data_size
     assert len(img_ids_list_set) == data_size
@@ -397,7 +397,7 @@ def test_gluon_iterator_last_batch_pad_last_batch():
                                     size=pipes[0].epoch_size("Reader"), last_batch_policy=LastBatchPolicy.FILL)
 
     img_ids_list, img_ids_list_set, mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x[0].squeeze().asnumpy(), lambda x: 0, data_size)
+        gather_ids(dali_train_iter, lambda x: x[0].squeeze(-1).asnumpy(), lambda x: 0, data_size)
 
     assert len(img_ids_list) > data_size
     assert len(img_ids_list_set) == data_size
@@ -405,7 +405,7 @@ def test_gluon_iterator_last_batch_pad_last_batch():
 
     dali_train_iter.reset()
     next_img_ids_list, next_img_ids_list_set, next_mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x[0].squeeze().asnumpy(), lambda x: 0, data_size)
+        gather_ids(dali_train_iter, lambda x: x[0].squeeze(-1).asnumpy(), lambda x: 0, data_size)
 
     assert len(next_img_ids_list) > data_size
     assert len(next_img_ids_list_set) == data_size
@@ -424,7 +424,7 @@ def test_gluon_iterator_not_fill_last_batch_pad_last_batch():
                                     last_batch_policy=LastBatchPolicy.PARTIAL)
 
     img_ids_list, img_ids_list_set, mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x[0].squeeze().asnumpy(), lambda x: 0, data_size)
+        gather_ids(dali_train_iter, lambda x: x[0].squeeze(-1).asnumpy(), lambda x: 0, data_size)
 
     assert len(img_ids_list) == data_size
     assert len(img_ids_list_set) == data_size
@@ -433,7 +433,7 @@ def test_gluon_iterator_not_fill_last_batch_pad_last_batch():
 
     dali_train_iter.reset()
     next_img_ids_list, next_img_ids_list_set, next_mirrored_data, pad, remainder = \
-        gather_ids(dali_train_iter, lambda x: x[0].squeeze().asnumpy(), lambda x: 0, data_size)
+        gather_ids(dali_train_iter, lambda x: x[0].squeeze(-1).asnumpy(), lambda x: 0, data_size)
 
     assert len(next_img_ids_list) == data_size
     assert len(next_img_ids_list_set) == data_size
@@ -492,7 +492,7 @@ def check_gluon_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
         for it in iter(dali_train_iter):
             for id in range(pipes_number):
                 if len(it[id][0]):
-                    tmp = it[id][0].squeeze().asnumpy().copy()
+                    tmp = it[id][0].squeeze(-1).asnumpy().copy()
                 else:
                     tmp = np.empty([0])
                 img_ids_list[id].append(tmp)
@@ -535,7 +535,7 @@ def test_pytorch_iterator_last_batch_no_pad_last_batch():
     dali_train_iter = PyTorchIterator(pipes, output_map=["data"], size=pipes[0].epoch_size("Reader"), last_batch_policy=LastBatchPolicy.FILL)
 
     img_ids_list, img_ids_list_set, mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x["data"].squeeze().numpy(), lambda x: 0, data_size)
+        gather_ids(dali_train_iter, lambda x: x["data"].squeeze(-1).numpy(), lambda x: 0, data_size)
 
     assert len(img_ids_list) > data_size
     assert len(img_ids_list_set) == data_size
@@ -553,7 +553,7 @@ def test_pytorch_iterator_last_batch_pad_last_batch():
     dali_train_iter = PyTorchIterator(pipes, output_map=["data"], size=pipes[0].epoch_size("Reader"), last_batch_policy=LastBatchPolicy.FILL)
 
     img_ids_list, img_ids_list_set, mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x["data"].squeeze().numpy(), lambda x: 0, data_size)
+        gather_ids(dali_train_iter, lambda x: x["data"].squeeze(-1).numpy(), lambda x: 0, data_size)
 
     assert len(img_ids_list) > data_size
     assert len(img_ids_list_set) == data_size
@@ -561,7 +561,7 @@ def test_pytorch_iterator_last_batch_pad_last_batch():
 
     dali_train_iter.reset()
     next_img_ids_list, next_img_ids_list_set, next_mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x["data"].squeeze().numpy(), lambda x: 0, data_size)
+        gather_ids(dali_train_iter, lambda x: x["data"].squeeze(-1).numpy(), lambda x: 0, data_size)
 
     assert len(next_img_ids_list) > data_size
     assert len(next_img_ids_list_set) == data_size
@@ -580,7 +580,7 @@ def test_pytorch_iterator_not_fill_last_batch_pad_last_batch():
     dali_train_iter = PyTorchIterator(pipes, output_map=["data"], size=pipes[0].epoch_size("Reader"), last_batch_policy=LastBatchPolicy.PARTIAL, last_batch_padded=True)
 
     img_ids_list, img_ids_list_set, mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x["data"].squeeze().numpy(), lambda x: 0, data_size)
+        gather_ids(dali_train_iter, lambda x: x["data"].squeeze(-1).numpy(), lambda x: 0, data_size)
 
     assert len(img_ids_list) == data_size
     assert len(img_ids_list_set) == data_size
@@ -588,7 +588,7 @@ def test_pytorch_iterator_not_fill_last_batch_pad_last_batch():
 
     dali_train_iter.reset()
     next_img_ids_list, next_img_ids_list_set, next_mirrored_data, _, _ = \
-        gather_ids(dali_train_iter, lambda x: x["data"].squeeze().numpy(), lambda x: 0, data_size)
+        gather_ids(dali_train_iter, lambda x: x["data"].squeeze(-1).numpy(), lambda x: 0, data_size)
 
     # there is no mirroring as data in the output is just cut off,
     # in the mirrored_data there is real data

--- a/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
@@ -250,7 +250,7 @@
     "    \n",
     "    def process_batch(self, batch):\n",
     "        x = batch[0][\"data\"]\n",
-    "        y = batch[0][\"label\"].squeeze().cuda().long()\n",
+    "        y = batch[0][\"label\"].squeeze(-1).cuda().long()\n",
     "        return (x, y)"
    ]
   },

--- a/docs/examples/use_cases/pytorch/resnet50/main.py
+++ b/docs/examples/use_cases/pytorch/resnet50/main.py
@@ -382,7 +382,7 @@ def train(train_loader, model, criterion, optimizer, epoch):
 
     for i, data in enumerate(train_loader):
         input = data[0]["data"]
-        target = data[0]["label"].squeeze().cuda().long()
+        target = data[0]["label"].squeeze(-1).cuda().long()
         train_loader_len = int(math.ceil(train_loader._size / args.batch_size))
 
         if args.prof >= 0 and i == args.prof:
@@ -478,7 +478,7 @@ def validate(val_loader, model, criterion):
 
     for i, data in enumerate(val_loader):
         input = data[0]["data"]
-        target = data[0]["label"].squeeze().cuda().long()
+        target = data[0]["label"].squeeze(-1).cuda().long()
         val_loader_len = int(val_loader._size / args.batch_size)
 
         # compute output


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Reverts an unintended breaking change
- Fixes a bug

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *[Restored default behavior of MXNet iterator, regarding squeezing the last dimension of labels]*
     *Bugfix: [Changed example/tests regarding label squeezing to squeeze only the last dimension]*
 - Affected modules and functionalities:
     *MXNet iterator, PyTorch iterator tests and examples*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     *CI*
 - Documentation (including examples):
     *Updated docstr*


**JIRA TASK**: *[DALI-1736]*
