### PR TITLE
iter-to-iter variable batch size

### DIFF
--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -108,7 +108,8 @@ std::unique_ptr<Pipeline> GetTestPipeline(bool is_file_reader, const std::string
 // Allows only for uint8_t CPU/GPU output data to be compared
 template <typename Backend>
 void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline,
-                             unsigned int copy_output_flags = DALI_ext_default) {
+                             unsigned int copy_output_flags = DALI_ext_default,
+                             int batch_size = dali::batch_size) {
   dali::DeviceWorkspace ws;
   baseline.Outputs(&ws);
   daliOutput(&handle);
@@ -230,6 +231,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
     input.Copy(input_cpu, cuda_stream);
     pipe_ptr->SetExternalInput(input_name, input);
+    daliSetExternalInputBatchSize(&handle, input_name.c_str(), input_shape.num_samples());
     daliSetExternalInputAsync(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
                               input.raw_data(), dali_data_type_t::DALI_UINT8, input_shape.data(),
                               input_shape.sample_dim(), nullptr, cuda_stream, DALI_ext_default);
@@ -261,8 +263,62 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
 }
 
 
+TYPED_TEST(CApiTest, ExternalSourceSingleAllocVariableBatchSizePipe) {
+  TensorListShape<> reference_input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
+                                             {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
+                                             {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
+  int max_batch_size = reference_input_shape.num_samples();
+  std::vector<TensorListShape<>> trimmed_input_shapes = {
+      subshape(reference_input_shape, 0, max_batch_size / 2),
+      subshape(reference_input_shape, 0, max_batch_size / 4),
+      subshape(reference_input_shape, 0, max_batch_size),
+  };
+
+  auto pipe_ptr = GetTestPipeline<TypeParam>(false, this->output_device_);
+  auto serialized = pipe_ptr->SerializeToProtobuf();
+
+  daliPipelineHandle handle;
+  daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
+                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     prefetch_queue_depth, false);
+
+  for (auto &input_shape : trimmed_input_shapes) {
+    pipe_ptr = GetTestPipeline<TypeParam>(false, this->output_device_);
+    pipe_ptr->Build();
+
+    TensorList<CPUBackend> input_cpu;
+    TensorList<TypeParam> input;
+    input_cpu.Resize(input_shape, TypeInfo::Create<uint8_t>());
+
+    for (int i = 0; i < prefetch_queue_depth; i++) {
+      SequentialFill(view<uint8_t>(input_cpu), 42 * i);
+      // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
+      input.Copy(input_cpu, cuda_stream);
+      pipe_ptr->SetExternalInput(input_name, input);
+      daliSetExternalInputBatchSize(&handle, input_name.c_str(), input_shape.num_samples());
+      daliSetExternalInputAsync(&handle, input_name.c_str(),
+                                backend_to_device_type<TypeParam>::value, input.raw_data(),
+                                dali_data_type_t::DALI_UINT8, input_shape.data(),
+                                input_shape.sample_dim(), nullptr, cuda_stream, DALI_ext_default);
+    }
+
+    for (int i = 0; i < prefetch_queue_depth; i++) {
+      pipe_ptr->RunCPU();
+      pipe_ptr->RunGPU();
+    }
+    daliPrefetchUniform(&handle, prefetch_queue_depth);
+
+    dali::DeviceWorkspace ws;
+    for (int i = 0; i < prefetch_queue_depth; i++) {
+      ComparePipelinesOutputs<TypeParam>(handle, *pipe_ptr, DALI_ext_default,
+                                         input_shape.num_samples());
+    }
+  }
+}
+
+
 TYPED_TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
-  TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8,  8,  3},
+  TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
                                    {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
   TensorList<CPUBackend> input_cpu;

--- a/dali/core/tensor_shape_test.cc
+++ b/dali/core/tensor_shape_test.cc
@@ -1293,5 +1293,24 @@ TEST(AppendTest, AppendSingleTLS) {
   EXPECT_EQ(tls_tested_dyn, ref);
 }
 
+
+TEST(TensorListShapeTest, SubshapeTest) {
+  TensorListShape<> tls = {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 6}, {6, 7}, {7, 8}, {8, 9}};
+  TensorListShape<> ref091 = {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5},
+                              {5, 6}, {6, 7}, {7, 8}, {8, 9}};
+  TensorListShape<> ref081 = {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 6}, {6, 7}, {7, 8}};
+  TensorListShape<> ref052 = {{0, 1}, {2, 3}, {4, 5}};
+  TensorListShape<> ref183 = {{1, 2}, {4, 5}, {7, 8}};
+  TensorListShape<> ref092 = {{0, 1}, {2, 3}, {4, 5}, {6, 7}, {8, 9}};
+  TensorListShape<> ref192 = {{1, 2}, {3, 4}, {5, 6}, {7, 8}};
+
+  EXPECT_EQ(subshape(tls, 0, 9, 1), ref091);
+  EXPECT_EQ(subshape(tls, 0, 8, 1), ref081);
+  EXPECT_EQ(subshape(tls, 0, 5, 2), ref052);
+  EXPECT_EQ(subshape(tls, 1, 8, 3), ref183);
+  EXPECT_EQ(subshape(tls, 0, 9, 2), ref092);
+  EXPECT_EQ(subshape(tls, 1, 9, 2), ref192);
+}
+
 }  // namespace kernels
 }  // namespace dali

--- a/dali/operators/generic/constant.h
+++ b/dali/operators/generic/constant.h
@@ -81,10 +81,9 @@ class Constant : public Operator<Backend> {
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
     output_desc.resize(1);
     auto curr_batch_size = ws.GetRequestedBatchSize(0);
-    DALI_ENFORCE(curr_batch_size == max_batch_size_,
-                 "This operator does not doesn't support batch smaller than maximum");
-    if (output_shape_.empty() || output_shape_.num_elements() != curr_batch_size) {
+    if (output_shape_.empty() || output_shape_.num_samples() != curr_batch_size) {
       output_shape_ = uniform_list_shape(curr_batch_size, shape_arg_);
+      output_.Reset();
     }
     output_desc[0] = {output_shape_, TypeTable::GetTypeInfo(output_type_)};
     return false;

--- a/dali/operators/random/batch_permutation.cc
+++ b/dali/operators/random/batch_permutation.cc
@@ -41,7 +41,6 @@ void BatchPermutation::RunImpl(HostWorkspace &ws) {
   bool no_fixed = spec_.GetArgument<bool>("no_fixed_points") && N > 1;
 
   tmp_out_.resize(N);
-
   if (rep) {
     if (no_fixed)
       random_sequence_no_fixed_points(tmp_out_, 0, N, rng_);

--- a/dali/operators/ssd/random_crop.cc
+++ b/dali/operators/ssd/random_crop.cc
@@ -34,7 +34,7 @@ cropped and valid bounding boxes and valid labels are returned.)code")
   .NumInput(3)   // [img, bbox, label]
   .NumOutput(3)  // [img, bbox, label]
   .AddOptionalArg("num_attempts", R"code(Number of attempts.)code", 1)
-  .Deprecate("RandomBBoxCrop");
+  .Deprecate("RandomBBoxCrop");  // deprecated in DALI 0.30
 
 /*
  * # This function is from https://github.com/kuangliu/pytorch-ssd.

--- a/dali/pipeline/data/type_traits.h
+++ b/dali/pipeline/data/type_traits.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_DATA_TYPE_TRAITS_H_
+#define DALI_PIPELINE_DATA_TYPE_TRAITS_H_
+
+namespace dali {
+
+template <typename Backend>
+class TensorVector;
+
+template <typename Backend>
+class TensorList;
+
+class CPUBackend;
+class MixedBackend;
+class GPUBackend;
+
+template <typename Backend>
+struct is_backend {
+  static constexpr bool value = std::is_same<Backend, CPUBackend>::value ||
+                                std::is_same<Backend, MixedBackend>::value ||
+                                std::is_same<Backend, GPUBackend>::value;
+};
+
+template <template <typename> class MaybeTensorVector, typename Backend>
+struct is_tensor_vector {
+  static constexpr bool value =
+      std::is_same<MaybeTensorVector<Backend>, TensorVector<Backend>>::value;
+};
+
+template <template <typename> class MaybeTensorList, typename Backend>
+struct is_tensor_list {
+  static constexpr bool value = std::is_same<MaybeTensorList<Backend>, TensorList<Backend>>::value;
+};
+
+/**
+ * Verifies, that T is proper batch container for DALI
+ *
+ * Batch container is proper when it has a defined backend and is TensorVector or a TensorList
+ */
+template <template <typename Backend_> class T, typename Backend>
+struct is_batch_container {
+  static constexpr bool value =
+      is_backend<Backend>::value &&
+      (is_tensor_vector<T, Backend>::value || is_tensor_list<T, Backend>::value);
+};
+
+namespace test {
+static_assert(is_batch_container<TensorVector, CPUBackend>::value, "Test failed");
+static_assert(is_batch_container<TensorVector, GPUBackend>::value, "Test failed");
+static_assert(is_batch_container<TensorList, CPUBackend>::value, "Test failed");
+static_assert(is_batch_container<TensorList, GPUBackend>::value, "Test failed");
+}  // namespace test
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_DATA_TYPE_TRAITS_H_

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,305 @@
 
 namespace dali {
 
-template class Executor<AOT_WS_Policy<UniformQueuePolicy>, UniformQueuePolicy>;
+template class DLL_PUBLIC Executor<AOT_WS_Policy<UniformQueuePolicy>, UniformQueuePolicy>;
+template class DLL_PUBLIC Executor<AOT_WS_Policy<SeparateQueuePolicy>, SeparateQueuePolicy>;
+
+template <typename WorkspacePolicy, typename QueuePolicy>
+void Executor<WorkspacePolicy, QueuePolicy>::PreRun() {
+  auto batch_size = InferBatchSize(batch_size_providers_);
+  batch_sizes_cpu_.push(batch_size);
+  batch_sizes_mixed_.push(batch_size);
+  batch_sizes_gpu_.push(batch_size);
+}
+
+template <typename WorkspacePolicy, typename QueuePolicy>
+void Executor<WorkspacePolicy, QueuePolicy>::RunCPU() {
+  PreRun();
+
+  if (device_id_ < 0) {
+    DALI_ENFORCE(device_id_ == CPU_ONLY_DEVICE_ID,
+                 "Wrong device_id provided, it should be >= 0, "
+                 "or equal to CPU_ONLY_DEVICE_ID.");
+    DALI_ENFORCE(graph_->NumOp(OpType::GPU) == 0 && graph_->NumOp(OpType::MIXED) == 0,
+                 "Cannot run a pipeline with Mixed/GPU ops in CPU-only mode. Please provide "
+                 "valid device id or change the operators' device.");
+  }
+
+  DomainTimeRange tr("[DALI][Executor] RunCPU");
+
+  DeviceGuard g(device_id_);
+
+  auto cpu_idxs = QueuePolicy::AcquireIdxs(OpType::CPU);
+  if (exec_error_ || QueuePolicy::IsStopSignaled() || !QueuePolicy::AreValid(cpu_idxs)) {
+    QueuePolicy::ReleaseIdxs(OpType::CPU, cpu_idxs);
+    return;
+  }
+
+  auto batch_size = batch_sizes_cpu_.front();
+  batch_sizes_cpu_.pop();
+
+  // Run the cpu-ops in the thread
+  // Process each CPU Op in batch
+  for (int cpu_op_id = 0; cpu_op_id < graph_->NumOp(OpType::CPU) && !exec_error_; ++cpu_op_id) {
+    OpNode &op_node = graph_->Node(OpType::CPU, cpu_op_id);
+    typename WorkspacePolicy::template ws_t<OpType::CPU> ws =
+        WorkspacePolicy::template GetWorkspace<OpType::CPU>(cpu_idxs, *graph_, cpu_op_id);
+
+    ws.SetBatchSizes(batch_size);
+
+    DomainTimeRange tr("[DALI][CPU op] " + op_node.instance_name, DomainTimeRange::kBlue1);
+
+    try {
+      RunHelper(op_node, ws);
+      FillStats(cpu_memory_stats_, ws, "CPU_" + op_node.instance_name, cpu_memory_stats_mutex_);
+    } catch (std::exception &e) {
+      HandleError("CPU", op_node, e.what());
+    } catch (...) {
+      HandleError();
+    }
+  }
+
+  // Pass the work to the mixed stage
+  QueuePolicy::ReleaseIdxs(OpType::CPU, cpu_idxs);
+}
+
+
+template <typename WorkspacePolicy, typename QueuePolicy>
+void Executor<WorkspacePolicy, QueuePolicy>::RunMixed() {
+  DomainTimeRange tr("[DALI][Executor] RunMixed");
+  DeviceGuard g(device_id_);
+
+  auto mixed_idxs = QueuePolicy::AcquireIdxs(OpType::MIXED);
+  if (exec_error_ || QueuePolicy::IsStopSignaled() || !QueuePolicy::AreValid(mixed_idxs)) {
+    QueuePolicy::ReleaseIdxs(OpType::MIXED, mixed_idxs);
+    return;
+  }
+
+  // short path for pure CPU pipeline
+  if (device_id_ == CPU_ONLY_DEVICE_ID) {
+    if (callback_) {
+      callback_();
+    }
+    // We do not release, but handle to used outputs
+    QueuePolicy::ReleaseIdxs(OpType::MIXED, mixed_idxs, mixed_op_stream_);
+    return;
+  }
+
+  // Enforce our assumed dependency between consecutive
+  // iterations of a stage of the pipeline.
+
+  CUDA_CALL(cudaEventSynchronize(mixed_stage_event_));
+
+  auto batch_size = batch_sizes_mixed_.front();
+  batch_sizes_mixed_.pop();
+
+  for (int i = 0; i < graph_->NumOp(OpType::MIXED) && !exec_error_; ++i) {
+    OpNode &op_node = graph_->Node(OpType::MIXED, i);
+    try {
+      typename WorkspacePolicy::template ws_t<OpType::MIXED> ws =
+          WorkspacePolicy::template GetWorkspace<OpType::MIXED>(mixed_idxs, *graph_, i);
+
+      ws.SetBatchSizes(batch_size);
+
+      DomainTimeRange tr("[DALI][Mixed op] " + op_node.instance_name, DomainTimeRange::kOrange);
+      RunHelper(op_node, ws);
+      FillStats(mixed_memory_stats_, ws, "MIXED_" + op_node.instance_name,
+                mixed_memory_stats_mutex_);
+      if (ws.has_stream() && ws.has_event()) {
+        CUDA_CALL(cudaEventRecord(ws.event(), ws.stream()));
+      }
+      CUDA_CALL(cudaGetLastError());
+    } catch (std::exception &e) {
+      HandleError("Mixed", op_node, e.what());
+    } catch (...) {
+      HandleError();
+    }
+  }
+
+  if (callback_) {
+    // Record event that will allow to call the callback after whole run of this pipeline is
+    // finished.
+    CUDA_CALL(cudaEventRecord(mixed_callback_events_[mixed_idxs[OpType::MIXED]], mixed_op_stream_));
+  }
+
+  if (!mixed_output_events_.empty()) {
+    int queue_id = mixed_idxs[OpType::MIXED];
+    CUDA_CALL(cudaEventRecord(mixed_output_events_.GetEvent(queue_id), mixed_op_stream_));
+  }
+
+  // We know that this is the proper stream, we do not need to look it up in any workspace
+  CUDA_CALL(cudaEventRecord(mixed_stage_event_, mixed_op_stream_));
+
+  // Pass the work to the gpu stage
+  QueuePolicy::ReleaseIdxs(OpType::MIXED, mixed_idxs, mixed_op_stream_);
+}
+
+
+template <typename WorkspacePolicy, typename QueuePolicy>
+void Executor<WorkspacePolicy, QueuePolicy>::RunGPU() {
+  DomainTimeRange tr("[DALI][Executor] RunGPU");
+
+  auto gpu_idxs = QueuePolicy::AcquireIdxs(OpType::GPU);
+  if (exec_error_ || QueuePolicy::IsStopSignaled() || !QueuePolicy::AreValid(gpu_idxs)) {
+    QueuePolicy::ReleaseIdxs(OpType::GPU, gpu_idxs);
+    return;
+  }
+
+  // short path for pure CPU pipeline
+  if (device_id_ == CPU_ONLY_DEVICE_ID) {
+    // We do not release, but handle to used outputs
+    QueuePolicy::QueueOutputIdxs(gpu_idxs, gpu_op_stream_);
+    return;
+  }
+  DeviceGuard g(device_id_);
+
+  // Enforce our assumed dependency between consecutive
+  // iterations of a stage of the pipeline.
+  CUDA_CALL(cudaEventSynchronize(gpu_stage_event_));
+
+  auto batch_size = batch_sizes_gpu_.front();
+  batch_sizes_gpu_.pop();
+
+  for (int i = 0; i < graph_->NumOp(OpType::GPU) && !exec_error_; ++i) {
+    OpNode &op_node = graph_->Node(OpType::GPU, i);
+    try {
+      typename WorkspacePolicy::template ws_t<OpType::GPU> ws =
+          WorkspacePolicy::template GetWorkspace<OpType::GPU>(gpu_idxs, *graph_, i);
+
+      ws.SetBatchSizes(batch_size);
+
+      auto parent_events = ws.ParentEvents();
+
+      for (auto &event : parent_events) {
+        CUDA_CALL(cudaStreamWaitEvent(ws.stream(), event, 0));
+      }
+
+      DomainTimeRange tr("[DALI][GPU op] " + op_node.instance_name, DomainTimeRange::knvGreen);
+      RunHelper(op_node, ws);
+      FillStats(gpu_memory_stats_, ws, "GPU_" + op_node.instance_name, gpu_memory_stats_mutex_);
+      if (ws.has_event()) {
+        CUDA_CALL(cudaEventRecord(ws.event(), ws.stream()));
+      }
+      CUDA_CALL(cudaGetLastError());
+    } catch (std::exception &e) {
+      HandleError("GPU", op_node, e.what());
+    } catch (...) {
+      HandleError();
+    }
+  }
+
+  // Update the ready queue to signal that all the work
+  // in the `gpu_idxs` set of output buffers has been
+  // issued. Notify any waiting threads.
+
+  // If we have GPU outputs than
+  if (!gpu_output_events_.empty()) {
+    int queue_id = gpu_idxs[OpType::GPU];
+    CUDA_CALL(cudaEventRecord(gpu_output_events_.GetEvent(queue_id), gpu_op_stream_));
+  }
+
+  // Schedule the call to any callback registered previously
+  if (callback_) {
+    CUDA_CALL(
+        cudaStreamWaitEvent(gpu_op_stream_, mixed_callback_events_[gpu_idxs[OpType::MIXED]], 0));
+    CUDA_CALL(cudaStreamAddCallback(gpu_op_stream_, &detail::gpu_finished_callback,
+                                    static_cast<void *>(&callback_), 0));
+  }
+
+  // We know that this is the proper stream, we do not need to look it up in any workspace
+  CUDA_CALL(cudaEventRecord(gpu_stage_event_, gpu_op_stream_));
+
+  // We do not release, but handle to used outputs
+  QueuePolicy::QueueOutputIdxs(gpu_idxs, gpu_op_stream_);
+}
+
+
+template <typename WorkspacePolicy, typename QueuePolicy>
+template <typename Workspace>
+void Executor<WorkspacePolicy, QueuePolicy>::RunHelper(OpNode &op_node, Workspace &ws) {
+  auto &output_desc = op_node.output_desc;
+  auto &op = *op_node.op;
+  output_desc.clear();
+  const auto &spec = op.GetSpec();
+  const auto &schema = spec.GetSchema();
+  SmallVector<int, 16> empty_layout_in_idxs;
+
+  for (int i = 0; i < ws.NumInput(); i++) {
+    DALI_ENFORCE(
+        ws.GetInputBatchSize(i) <= max_batch_size_,
+        make_string("Expected batch size lower or equal to max batch size. Expected at most: ",
+                    max_batch_size_, ", got: ", ws.GetInputBatchSize(i)));
+  }
+  for (int i = 0; i < spec.NumOutput(); i++) {
+    DALI_ENFORCE(ws.GetRequestedBatchSize(i) <= max_batch_size_,
+                 make_string("Expected batch size lower or equal to max batch size. Actual: ",
+                             ws.GetRequestedBatchSize(i), " <= ", max_batch_size_));
+  }
+
+  for (int i = 0; i < spec.NumRegularInput(); i++) {
+    bool had_empty_layout = false;
+    if (ws.template InputIsType<CPUBackend>(i)) {
+      had_empty_layout = SetDefaultLayoutIfNeeded(ws.template InputRef<CPUBackend>(i), schema, i);
+    } else {
+      had_empty_layout = SetDefaultLayoutIfNeeded(ws.template InputRef<GPUBackend>(i), schema, i);
+    }
+    if (had_empty_layout) empty_layout_in_idxs.push_back(i);
+  }
+  if (op.Setup(output_desc, ws)) {
+    DALI_ENFORCE(
+        static_cast<size_t>(ws.NumOutput()) == output_desc.size(),
+        "Operator::Setup returned shape and type information for mismatched number of outputs");
+    DALI_ENFORCE(op.CanInferOutputs(),
+                 "Operator::Setup returned true indicating that it successfully calculated shape "
+                 "and type information for Operator outputs. In that case CanInferOutputs should "
+                 "always return true.");
+    for (int i = 0; i < ws.NumOutput(); i++) {
+      auto &desc = output_desc[i];
+      if (ws.template OutputIsType<CPUBackend>(i)) {
+        ws.template OutputRef<CPUBackend>(i).Resize(desc.shape);
+        ws.template OutputRef<CPUBackend>(i).set_type(desc.type);
+      } else {
+        ws.template OutputRef<GPUBackend>(i).Resize(desc.shape);
+        ws.template OutputRef<GPUBackend>(i).set_type(desc.type);
+      }
+    }
+  } else {
+    DALI_ENFORCE(!op.CanInferOutputs(),
+                 "Operator::Setup returned false indicating that it cannot calculate shape and "
+                 "type information for Operator outputs. In that case CanInferOutputs should "
+                 "always return false.");
+  }
+
+  op.Run(ws);
+
+  for (int i : empty_layout_in_idxs) {
+    if (ws.template InputIsType<CPUBackend>(i)) {
+      auto &in = ws.template InputRef<CPUBackend>(i);
+      in.SetLayout({});
+    } else {
+      auto &in = ws.template InputRef<GPUBackend>(i);
+      in.SetLayout({});
+    }
+  }
+}
+
+
+template <typename WorkspacePolicy, typename QueuePolicy>
+int Executor<WorkspacePolicy, QueuePolicy>::InferBatchSize(
+    const std::vector<BatchSizeProvider *> &bsps) const {
+  if (bsps.empty()) {
+    return max_batch_size_;
+  }
+  for (size_t i = 1; i < bsps.size(); i++) {
+    DALI_ENFORCE(bsps[0]->NextBatchSize() == bsps[i]->NextBatchSize(),
+                 "Batch size must be uniform across an iteration");
+  }
+  auto batch_size = bsps[0]->NextBatchSize();
+  assert(batch_size > 0);
+  for (auto &bsp : bsps) {
+    bsp->Advance();
+  }
+  return batch_size;
+}
 
 }  // namespace dali

--- a/dali/pipeline/operator/batch_size_provider.h
+++ b/dali/pipeline/operator/batch_size_provider.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATOR_BATCH_SIZE_PROVIDER_H_
+#define DALI_PIPELINE_OPERATOR_BATCH_SIZE_PROVIDER_H_
+
+namespace dali {
+
+/**
+ * BatchSizeProvider is an Operator, that determines the batch size used in
+ * a single iteration in the pipeline. In general, this Operator will also
+ * read data into the pipeline, like e.g. ExternalSource or any Reader.
+ *
+ * The usage is similar to a unidirectional iterator over a list of batch sizes
+ */
+class BatchSizeProvider {
+  /*
+   * Typically, you'll need to inherit from this interface virtually:
+   *
+   * template<typename Backend>
+   * class MyOperatorBsp : public OperatorBase<Backend>, virtual public BatchSizeProvider {};
+   */
+ public:
+  /**
+   * Returns next batch size.
+   *
+   * Implementation shall assure that it's possible to call NextBatchSize()
+   * multiple times for the same batch, before Advance() invocation.
+   *
+   * If invoking this function is illegal for any reason,
+   * implementation shall throw std::runtime_error.
+   */
+  virtual int NextBatchSize() = 0;
+
+  /**
+   * Advances to next batch.
+   *
+   * When there's no further data available, Advance() shall throw std::out_of_range
+   */
+  virtual void Advance() = 0;
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATOR_BATCH_SIZE_PROVIDER_H_

--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -448,7 +448,7 @@ TYPED_TEST(ExternalSourceTest, ConsumeOneThenFeedsGPU) {
   }
 }
 
-TEST(ExternalSourceTestNoInput, Throw) {
+TEST(ExternalSourceTestNoInput, ThrowCpu) {
   OpGraph graph;
   int batch_size = 1;
   int num_threads = 1;
@@ -467,11 +467,69 @@ TEST(ExternalSourceTestNoInput, Throw) {
   vector<string> outputs = {"data_out_cpu"};
 
   exe->Build(&graph, outputs);
-  exe->RunCPU();
-  exe->RunMixed();
-  exe->RunGPU();
-  DeviceWorkspace ws;
-  ASSERT_THROW(exe->Outputs(&ws), std::runtime_error);
+  ASSERT_THROW(exe->RunCPU(), std::exception);
+}
+
+namespace {
+template <typename T>
+struct TestType {
+  using element_type = T;
+  T val;
+  bool operator==(const T &other) const {
+    return other == val;
+  }
+};
+}  // namespace
+
+
+TEST(CachingListTest, ProphetTest) {
+  detail::CachingList<std::unique_ptr<TestType<int>>> cl;
+
+  auto push = [&](int val) {
+    auto elem = cl.GetEmpty();
+    elem.emplace_back(std::make_unique<TestType<int>>());
+    elem.front()->val = val;
+    cl.PushBack(elem);
+  };
+
+  ASSERT_THROW(cl.PeekProphet(), std::out_of_range);
+  push(6);
+  EXPECT_EQ(*cl.PeekProphet(), 6);
+  push(9);
+  EXPECT_EQ(*cl.PeekProphet(), 6);
+  cl.AdvanceProphet();
+  EXPECT_EQ(*cl.PeekProphet(), 9);
+  push(13);
+  EXPECT_EQ(*cl.PeekProphet(), 9);
+  cl.AdvanceProphet();
+  EXPECT_EQ(*cl.PeekProphet(), 13);
+  push(42);
+  EXPECT_EQ(*cl.PeekProphet(), 13);
+  push(69);
+  EXPECT_EQ(*cl.PeekProphet(), 13);
+  cl.AdvanceProphet();
+  EXPECT_EQ(*cl.PeekProphet(), 42);
+  cl.AdvanceProphet();
+  EXPECT_EQ(*cl.PeekProphet(), 69);
+  cl.AdvanceProphet();
+  ASSERT_THROW(cl.PeekProphet(), std::out_of_range);
+  push(666);
+  EXPECT_EQ(*cl.PeekProphet(), 666);
+  push(1337);
+  EXPECT_EQ(*cl.PeekProphet(), 666);
+  cl.AdvanceProphet();
+  EXPECT_EQ(*cl.PeekProphet(), 1337);
+  cl.AdvanceProphet();
+  ASSERT_THROW(cl.PeekProphet(), std::out_of_range);
+  push(1234);
+  EXPECT_EQ(*cl.PeekProphet(), 1234);
+  push(4321);
+  EXPECT_EQ(*cl.PeekProphet(), 1234);
+  cl.AdvanceProphet();
+  EXPECT_EQ(*cl.PeekProphet(), 4321);
+  cl.AdvanceProphet();
+  ASSERT_THROW(cl.PeekProphet(), std::out_of_range);
+  ASSERT_THROW(cl.AdvanceProphet(), std::out_of_range);
 }
 
 }  // namespace dali

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -441,14 +441,17 @@ class DLL_PUBLIC OpSpec {
                      "\" is not uniform. To access non-uniform argument inputs use "
                      "ArgumentWorkspace::ArgumentInput method directly.");
 
-    bool valid_shape =
-        shape.num_elements() == batch_size &&
-        (shape.num_samples() == batch_size || shape.num_samples() == 1);
+    bool valid_shape = true;
+    for (int i = 0; i < shape.num_samples() && valid_shape; i++) {
+      valid_shape = volume(shape[i]) == 1 || shape[i].empty();
+    }
+
     if (should_throw) {
-      DALI_ENFORCE(valid_shape, make_string(
-                   "Unexpected shape of argument \"", name, "\". Expected batch of ", batch_size,
-                   " scalars or a batch of tensors containing one element per sample or a single "
-                   "tensor with ", batch_size, " elements. Got:\n", shape));
+      DALI_ENFORCE(
+          valid_shape,
+          make_string(
+              "Unexpected shape of argument \"", name, "\". Expected batch of ", batch_size,
+              " scalars or a batch of tensors containing one element per sample. Got:\n", shape));
     }
     return valid_shape;
   }

--- a/dali/pipeline/operator/operator.cc
+++ b/dali/pipeline/operator/operator.cc
@@ -17,16 +17,56 @@
 namespace dali {
 
 template <typename Backend>
-void OperatorBase::EnforceConstantBatchSize(const workspace_t<Backend> &ws) const {
+void OperatorBase::EnforceUniformInputBatchSize(const workspace_t<Backend> &ws) const {
+  auto curr_batch_size = ws.NumInput() > 0 ? ws.GetInputBatchSize(0) : ws.GetRequestedBatchSize(0);
   for (int i = 0; i < ws.NumInput(); i++) {
-    DALI_ENFORCE(ws.GetInputBatchSize(i) == max_batch_size_,
-                 "Batch size has to be constant throughout the processing");
+    DALI_ENFORCE(curr_batch_size == ws.GetInputBatchSize(i),
+                 "Batch size has to be uniform across one iteration.");
+  }
+  auto argument_ws = dynamic_cast<const ArgumentWorkspace &>(ws);
+  for (const auto &arg : argument_ws) {
+    DALI_ENFORCE(
+        curr_batch_size == static_cast<decltype(curr_batch_size)>(arg.second.tvec->ntensor()),
+        "ArgumentInput has to have the same batch size as an input.");
   }
 }
 
-template void OperatorBase::EnforceConstantBatchSize<CPUBackend>(const workspace_t<CPUBackend>&w) const;  // NOLINT
-template void OperatorBase::EnforceConstantBatchSize<GPUBackend>(const workspace_t<GPUBackend>&w) const;  // NOLINT
-template void OperatorBase::EnforceConstantBatchSize<MixedBackend>(const workspace_t<MixedBackend>&w) const;  // NOLINT
+
+template <typename Backend>
+void OperatorBase::EnforceUniformOutputBatchSize(const workspace_t<Backend> &ws) const {
+  auto ref_batch_size = ws.NumInput() > 0 ? ws.GetInputBatchSize(0) : ws.GetRequestedBatchSize(0);
+  for (int i = 0; i < ws.NumOutput(); i++) {
+    auto output_batch_size = ws.template OutputRef<Backend>(i).shape().num_samples();
+    DALI_ENFORCE(ref_batch_size == output_batch_size,
+                 make_string("Batch size has to be uniform across one iteration. Expected: ",
+                             ref_batch_size, "; Actual: ", output_batch_size));
+  }
+}
+
+
+template <>
+void OperatorBase::EnforceUniformOutputBatchSize<MixedBackend>(
+    const workspace_t<MixedBackend> &ws) const {
+  auto ref_batch_size = ws.NumInput() > 0 ? ws.GetInputBatchSize(0) : ws.GetRequestedBatchSize(0);
+  for (int i = 0; i < ws.NumOutput(); i++) {
+    auto output_batch_size = const_cast<workspace_t<MixedBackend> &>(ws)
+                                 .template Output<GPUBackend>(i)
+                                 .shape()
+                                 .num_samples();
+    DALI_ENFORCE(ref_batch_size == output_batch_size,
+                 make_string("Batch size has to be uniform across one iteration. Expected: ",
+                             ref_batch_size, "; Actual: ", output_batch_size));
+  }
+}
+
+
+template void OperatorBase::EnforceUniformInputBatchSize<CPUBackend>(const workspace_t<CPUBackend> &w) const;  // NOLINT
+template void OperatorBase::EnforceUniformInputBatchSize<GPUBackend>(const workspace_t<GPUBackend> &w) const;  // NOLINT
+template void OperatorBase::EnforceUniformInputBatchSize<MixedBackend>(const workspace_t<MixedBackend> &w) const;  // NOLINT
+template void OperatorBase::EnforceUniformOutputBatchSize<CPUBackend>(const workspace_t<CPUBackend> &w) const;  // NOLINT
+template void OperatorBase::EnforceUniformOutputBatchSize<GPUBackend>(const workspace_t<GPUBackend> &w) const;  // NOLINT
+template void OperatorBase::EnforceUniformOutputBatchSize<MixedBackend>(const workspace_t<MixedBackend> &w) const;  // NOLINT
+
 
 DALI_DEFINE_OPTYPE_REGISTRY(CPUOperator, OperatorBase);
 DALI_DEFINE_OPTYPE_REGISTRY(GPUOperator, OperatorBase);

--- a/dali/pipeline/operator/operator.cc
+++ b/dali/pipeline/operator/operator.cc
@@ -65,7 +65,6 @@ template void OperatorBase::EnforceUniformInputBatchSize<GPUBackend>(const works
 template void OperatorBase::EnforceUniformInputBatchSize<MixedBackend>(const workspace_t<MixedBackend> &w) const;  // NOLINT
 template void OperatorBase::EnforceUniformOutputBatchSize<CPUBackend>(const workspace_t<CPUBackend> &w) const;  // NOLINT
 template void OperatorBase::EnforceUniformOutputBatchSize<GPUBackend>(const workspace_t<GPUBackend> &w) const;  // NOLINT
-template void OperatorBase::EnforceUniformOutputBatchSize<MixedBackend>(const workspace_t<MixedBackend> &w) const;  // NOLINT
 
 
 DALI_DEFINE_OPTYPE_REGISTRY(CPUOperator, OperatorBase);

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -218,9 +218,12 @@ class DLL_PUBLIC OperatorBase {
     dali::GetPerSampleArgument(output, argument_name, spec_, ws, batch_size);
   }
 
-  // TODO(mszolucha): remove to allow i2i variable batch size, when all ops are ready
+  // TODO(mszolucha): remove these two to allow i2i variable batch size, when all ops are ready
   template <typename Backend>
-  DLL_PUBLIC void EnforceConstantBatchSize(const workspace_t<Backend> &ws) const;
+  DLL_PUBLIC void EnforceUniformInputBatchSize(const workspace_t<Backend> &ws) const;
+
+  template <typename Backend>
+  DLL_PUBLIC void EnforceUniformOutputBatchSize(const workspace_t<Backend> &ws) const;
 
   const OpSpec spec_;
   int num_threads_;
@@ -284,7 +287,7 @@ class Operator<CPUBackend> : public OperatorBase {
   using OperatorBase::Run;
 
   bool Setup(std::vector<OutputDesc> &output_desc, const HostWorkspace &ws) override {
-    EnforceConstantBatchSize<CPUBackend>(ws);
+    EnforceUniformInputBatchSize<CPUBackend>(ws);
     return SetupImpl(output_desc, ws);
   }
 
@@ -293,6 +296,7 @@ class Operator<CPUBackend> : public OperatorBase {
     SetupSharedSampleParams(ws);
     RunImpl(ws);
     ws.GetThreadPool().WaitForWork();
+    EnforceUniformOutputBatchSize<CPUBackend>(ws);
   }
 
   /**
@@ -364,7 +368,7 @@ class Operator<GPUBackend> : public OperatorBase {
   using OperatorBase::Run;
 
   bool Setup(std::vector<OutputDesc> &output_desc, const DeviceWorkspace &ws) override {
-    EnforceConstantBatchSize<GPUBackend>(ws);
+    EnforceUniformInputBatchSize<GPUBackend>(ws);
     return SetupImpl(output_desc, ws);
   }
 
@@ -372,6 +376,7 @@ class Operator<GPUBackend> : public OperatorBase {
     CheckInputLayouts(ws, spec_);
     SetupSharedSampleParams(ws);
     RunImpl(ws);
+    EnforceUniformOutputBatchSize<GPUBackend>(ws);
   }
 
   /**
@@ -406,7 +411,7 @@ class Operator<MixedBackend> : public OperatorBase {
   using OperatorBase::Run;
 
   bool Setup(std::vector<OutputDesc> &output_desc, const MixedWorkspace &ws) override {
-    EnforceConstantBatchSize<MixedBackend>(ws);
+    EnforceUniformInputBatchSize<MixedBackend>(ws);
     return SetupImpl(output_desc, ws);
   }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <random>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -428,7 +429,7 @@ class DLL_PUBLIC Pipeline {
   DLL_PUBLIC int num_outputs() const;
 
   /**
-   * @brief Returns a string describing the type device type backing the output specified by given id.
+   * @brief Returns a string describing the device type backing the output specified by given id.
    */
   DLL_PUBLIC const std::string &output_device(int id) const;
 

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -75,7 +75,7 @@ class ArgumentWorkspace {
  protected:
   struct ArgumentInputDesc {
     shared_ptr<TensorVector<CPUBackend>> tvec;
-    // If true, the views in TensorBector are updated to reflect the underlying TensorList;
+    // If true, the views in TensorVector are updated to reflect the underlying TensorList;
     // this only happens if AddArgumentInput is called with a TensorList pointer - which for now
     // is only when passing an argument input to a GPU stage when using separated queue policy
     // (see queue_policy.h and pipeline.cc for details).
@@ -83,8 +83,27 @@ class ArgumentWorkspace {
   };
 
   // Argument inputs
-  std::unordered_map<std::string, ArgumentInputDesc> argument_inputs_;
+  using argument_input_storage_t = std::unordered_map<std::string, ArgumentInputDesc>;
+  argument_input_storage_t argument_inputs_;
+
+ public:
+  using const_iterator = argument_input_storage_t::const_iterator;
+  friend const_iterator begin(const ArgumentWorkspace&);
+  friend const_iterator end(const ArgumentWorkspace&);
 };
+
+/// @{
+/**
+ * Iterator-handling functions for ArgumentWorkspace
+ */
+inline ArgumentWorkspace::const_iterator begin(const ArgumentWorkspace& ws) {
+  return ws.argument_inputs_.begin();
+}
+
+inline ArgumentWorkspace::const_iterator end(const ArgumentWorkspace& ws) {
+  return ws.argument_inputs_.end();
+}
+/// @}
 
 /**
  * @brief WorkspaceBase is a base class of objects
@@ -189,7 +208,7 @@ class WorkspaceBase : public ArgumentWorkspace {
   /**
    * Set requested batch size for all outputs
    */
-  void set_batch_size(int batch_size) {
+  void SetBatchSizes(int batch_size) {
     batch_sizes_.clear();
     batch_sizes_.resize(NumOutput(), batch_size);
   }

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -19,9 +19,9 @@ def _get_batch_shape(data):
 
 def _check_data_batch(data, batch_size, layout):
     shape, uniform = _get_batch_shape(data)
-    if len(shape) != batch_size:
+    if len(shape) > batch_size:
         raise RuntimeError("The external source callback returned an unexpected batch "
-                           "size. Expected batch_size == {}, actual: {}".format(batch_size,
+                           "size. Expected batch_size <= {}, actual: {}".format(batch_size,
                                                                                 len(shape)))
 
     if len(shape) > 0:

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -51,10 +51,15 @@ encapsulates the data processing graph and the execution engine.
 Parameters
 ----------
 `batch_size` : int, optional, default = -1
-    Batch size of the pipeline. Negative values for this parameter
+    Maximum batch size of the pipeline. Negative values for this parameter
     are invalid - the default value may only be used with
     serialized pipeline (the value stored in serialized pipeline
-    is used instead).
+    is used instead). In most cases, the actual batch size of the pipeline
+    will be equal to the maximum one. Running the DALI Pipeline with a smaller batch size
+    is also supported. The batch size might change from iteration to iteration.
+
+    Please note, that DALI might perform memory preallocations according to this
+    parameter. Setting it too high might result in out-of-memory failure.
 `num_threads` : int, optional, default = -1
     Number of CPU threads used by the pipeline.
     Negative values for this parameter are invalid - the default
@@ -155,6 +160,12 @@ Parameters
     @property
     def batch_size(self):
         """Batch size."""
+        _show_deprecation_warning("batch_size", "max_batch_size")
+        return self._max_batch_size
+
+    @property
+    def max_batch_size(self):
+        """Maximum batch size."""
         return self._max_batch_size
 
     @property

--- a/dali/test/python/test_dali_variable_batch_size.py
+++ b/dali/test/python/test_dali_variable_batch_size.py
@@ -1,0 +1,699 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali.pipeline import Pipeline
+from segmentation_test_utils import make_batch_select_masks
+from PIL import Image
+from nose.tools import nottest
+import nvidia.dali as dali
+import nvidia.dali.ops as ops
+import nvidia.dali.fn as fn
+import nvidia.dali.types as types
+import numpy as np
+import test_utils
+import inspect
+import os
+import math
+import random
+
+"""
+How to test variable (iter-to-iter) batch size for a given op?
+-------------------------------------------------------------------------------
+The idea is to create a Pipeline that assumes i2i variability, run 2 iterations
+and compare them with ad-hoc created Pipelines for given (constant) batch sizes.
+This can be easily done using `check_batch` function below.
+
+On top of that, there are some utility functions and routines to help with some
+common cases:
+1. If the operator is typically processing image-like data (i.e. 3-dim, uint8,
+   0-255, with shape like [640, 480, 3]) and you want to test default arguments
+   only, please add a record to the `ops_image_default_args` list
+2. If the operator is typically processing image-like data (i.e. 3-dim, uint8,
+   0-255, with shape like [640, 480, 3]) and you want to specify any number of
+   its arguments, please add a record to the `ops_image_custom_args` list
+3. If the operator is typically processing audio-like data (i.e. 1-dim, float,
+   0.-1.) please add a record to the `float_array_ops` list
+4. If the operator supports sequences, please add a record to the
+   `sequence_ops` list
+5. If your operator case doesn't fit any of the above, please create a nosetest
+   function, in which you can define a function, that returns not yet built
+   pipeline, and pass it to the `check_batch` function.
+6. If your operator performs random operation, this approach won't provide
+   a comparable result. In this case, the best thing you can do is to check
+   whether the operator works, without qualitative comparison. Use `run_pipeline`
+   instead of `check_pipeline`. 
+"""
+
+
+def generate_data(max_batch_size, n_iter, sample_shape, lo=0., hi=1., dtype=np.float32):
+    """
+    Generates an epoch of data, that will be used for variable batch size verification.
+
+    :param max_batch_size: Actual sizes of every batch in the epoch will be less or equal to max_batch_size
+    :param n_iter: Number of iterations in the epoch
+    :param sample_shape: If sample_shape is callable, shape of every sample will be determined by
+                         calling sample_shape. In this case, every call to sample_shape has to
+                         return a tuple of integers. If sample_shape is a tuple, this will be a
+                         shape of every sample.
+    :param lo: Begin of the random range
+    :param hi: End of the random range
+    :param dtype: Numpy data type
+    :return: An epoch of data
+    """
+    batch_sizes = np.array([max_batch_size // 2, max_batch_size // 4, max_batch_size])
+
+    if isinstance(sample_shape, tuple):
+        size_fn = lambda: sample_shape
+    elif inspect.isfunction(sample_shape):
+        size_fn = sample_shape
+    else:
+        raise RuntimeError(
+            "`sample_shape` shall be either a tuple or a callable. Provide `(val,)` tuple for 1D shape")
+
+    if np.issubdtype(dtype, np.integer):
+        return [np.random.randint(lo, hi, size=(bs,) + size_fn(), dtype=dtype) for bs in
+                batch_sizes]
+    elif np.issubdtype(dtype, np.float):
+        ret = (np.random.random_sample(size=(bs,) + size_fn()) for bs in batch_sizes)
+        ret = map(lambda batch: (hi - lo) * batch + lo, ret)
+        ret = map(lambda batch: batch.astype(dtype), ret)
+        return list(ret)
+    else:
+        raise RuntimeError("Invalid type argument")
+
+
+def single_op_pipeline(max_batch_size, input_data, device, /, *, input_layout=None,
+                       operator_fn=None, **opfn_args):
+    pipe = Pipeline(batch_size=max_batch_size, num_threads=1, device_id=0)
+    with pipe:
+        input = fn.external_source(source=input_data, cycle=False, device=device,
+                                   layout=input_layout)
+        output = input if operator_fn is None else operator_fn(input, device=device, **opfn_args)
+        pipe.set_outputs(output)
+    return pipe
+
+
+def run_pipeline(input_epoch, pipeline_fn, *, devices: list = ['cpu', 'gpu'], **pipeline_fn_args):
+    """
+    Verifies, if given pipeline supports iter-to-iter variable batch size
+
+    This function verifies only if given pipeline runs without crashing.
+    There is no qualitative verification. Use this for checking pipelines
+    based on random operators (as they can't be verifies against one another).
+
+    :param input_epoch: List of numpy arrays, where every item is a single batch
+    :param pipeline_fn: Function, that returns created (but not built) pipeline.
+                        Its signature should be (at least):
+                        pipeline_fn(max_batch_size, input_data, device, /, ...)
+    :param devices: Devices to run the check on
+    :param pipeline_fn_args: Additional args to pipeline_fn
+    """
+    for device in devices:
+        n_iter = len(input_epoch)
+        max_bs = max(batch.shape[0] for batch in input_epoch)
+        var_pipe = pipeline_fn(max_bs, input_epoch, device, **pipeline_fn_args)
+        var_pipe.build()
+        for _ in range(n_iter):
+            var_pipe.run()
+
+
+def check_pipeline(input_epoch, pipeline_fn, *, devices: list = ['cpu', 'gpu'], eps=1e-7,
+                   **pipeline_fn_args):
+    """
+    Verifies, if given pipeline supports iter-to-iter variable batch size
+
+    This function conducts qualitative verification. It compares the result of
+    running multiple iterations of the same pipeline (with possible varying batch sizes,
+    accoring to `input_epoch`) with results of the ad-hoc created pipelines per iteration
+
+    :param input_epoch: List of numpy arrays, where every item is a single batch
+    :param pipeline_fn: Function, that returns created (but not built) pipeline.
+                        Its signature should be (at least):
+                        pipeline_fn(max_batch_size, input_data, device, /, ...)
+    :param devices: Devices to run the check on
+    :param eps: Epsilon for mean error
+    :param pipeline_fn_args: Additional args to pipeline_fn
+    """
+    for device in devices:
+        n_iter = len(input_epoch)
+        max_bs = max(batch.shape[0] for batch in input_epoch)
+        var_pipe = pipeline_fn(max_bs, input_epoch, device, **pipeline_fn_args)
+        var_pipe.build()
+
+        for iter_idx in range(n_iter):
+            iter_input = input_epoch[iter_idx]
+            batch_size = iter_input.shape[0]
+
+            const_pipe = pipeline_fn(batch_size, [iter_input], device, **pipeline_fn_args)
+            const_pipe.build()
+
+            test_utils.compare_pipelines(var_pipe, const_pipe, batch_size=batch_size,
+                                         N_iterations=1, eps=eps)
+
+
+def image_like_shape_generator():
+    return random.randint(160, 161), random.randint(80, 81), 3
+
+
+def array_1d_shape_generator():
+    return random.randint(300, 400),  # The coma is important
+
+
+def custom_shape_generator(*args):
+    """
+    Fully configurable shape generator.
+    Returns a callable which serves as a non-uniform & random shape generator to generate_epoch
+
+    Usage:
+    custom_shape_generator(dim1_lo, dim1_hi, dim2_lo, dim2_hi, etc...)
+    """
+    assert len(args) % 2 == 0, "Incorrect number of arguments"
+    ndims = len(args) // 2
+    gen_conf = [[args[2 * i], args[2 * i + 1]] for i in range(ndims)]
+    return lambda: tuple([random.randint(lohi[0], lohi[1]) for lohi in gen_conf])
+
+
+def image_data_helper(operator_fn, **opfn_args):
+    check_pipeline(generate_data(31, 13, image_like_shape_generator, lo=0, hi=255, dtype=np.uint8),
+                   pipeline_fn=single_op_pipeline, input_layout="HWC", operator_fn=operator_fn,
+                   **opfn_args)
+
+
+def float_array_helper(operator_fn, **opfn_args):
+    check_pipeline(generate_data(31, 13, array_1d_shape_generator), pipeline_fn=single_op_pipeline,
+                   operator_fn=operator_fn, **opfn_args)
+
+
+def sequence_op_helper(operator_fn, **opfn_args):
+    check_pipeline(
+        generate_data(31, 13, custom_shape_generator(3, 7, 160, 200, 80, 100, 3, 3), lo=0, hi=255,
+                      dtype=np.uint8),
+        pipeline_fn=single_op_pipeline, input_layout="FHWC", operator_fn=operator_fn, **opfn_args)
+
+
+def random_op_helper(operator_fn, **opfn_args):
+    run_pipeline(generate_data(31, 13, image_like_shape_generator, lo=0, hi=255, dtype=np.uint8),
+                 pipeline_fn=single_op_pipeline, operator_fn=operator_fn, **opfn_args)
+
+
+def test_external_source():
+    check_pipeline(generate_data(31, 13, custom_shape_generator(2, 4, 2, 4)), single_op_pipeline)
+
+
+ops_image_default_args = [
+    fn.brightness,
+    fn.brightness_contrast,
+    fn.cat,
+    fn.color_twist,
+    fn.contrast,
+    fn.copy,
+    fn.crop_mirror_normalize,
+    fn.dump_image,
+    fn.hsv,
+    fn.hue,
+    fn.old_color_twist,
+    fn.reductions.mean,
+    fn.reductions.mean_square,
+    fn.reductions.rms,
+    fn.reductions.min,
+    fn.reductions.max,
+    fn.reductions.sum,
+    fn.saturation,
+    fn.shapes,
+    fn.sphere,
+    fn.stack,
+    fn.water,
+]
+
+
+def test_ops_image_default_args():
+    for op in ops_image_default_args:
+        yield image_data_helper, op
+
+
+ops_image_custom_args = [
+    {'operator_fn': fn.cast, 'dtype': types.INT32},
+    {'operator_fn': fn.color_space_conversion, 'image_type': types.BGR, 'output_type': types.RGB},
+    {'operator_fn': fn.coord_transform, 'M': .5, 'T': 2},
+    {'operator_fn': fn.crop, 'crop': (5, 5)},
+    {'operator_fn': fn.erase, 'anchor': [0.3], 'axis_names': "H", 'normalized_anchor': True,
+     'shape': [0.1], 'normalized_shape': True},
+    {'operator_fn': fn.fast_resize_crop_mirror, 'crop': [5, 5], 'resize_shorter': 10,
+     'devices': ['cpu']},
+    {'operator_fn': fn.flip, 'horizontal': True},
+    {'operator_fn': fn.gaussian_blur, 'window_size': 5},
+    {'operator_fn': fn.normalize, 'batch': True},
+    {'operator_fn': fn.pad, 'fill_value': -1, 'axes': (0,), 'shape': (10,)},
+    {'operator_fn': fn.paste, 'fill_value': 69, 'ratio': 1, 'devices': ['gpu']},
+    {'operator_fn': fn.resize, 'resize_x': 50, 'resize_y': 50},
+    {'operator_fn': fn.resize_crop_mirror, 'crop': [5, 5], 'resize_shorter': 10,
+     'devices': ['cpu']},
+    {'operator_fn': fn.rotate, 'angle': 25},
+    {'operator_fn': fn.transpose, 'perm': [2, 0, 1]},
+    {'operator_fn': fn.warp_affine, 'matrix': (.1, .9, 10, .8, -.2, -20)},
+]
+
+
+def test_ops_image_custom_args():
+    for op in ops_image_custom_args:
+        print("\nTesting ", op)
+        image_data_helper(**op)
+
+
+float_array_ops = [
+    {'operator_fn': fn.power_spectrum, 'devices': ['cpu']},
+    {'operator_fn': fn.preemphasis_filter},
+    {'operator_fn': fn.spectrogram, 'nfft': 60, 'window_length': 50, 'window_step': 25},
+    {'operator_fn': fn.to_decibels},
+]
+
+
+def test_float_array_ops():
+    for op in float_array_ops:
+        print("\nTesting ", op)
+        float_array_helper(**op)
+
+
+random_ops = [
+    {'operator_fn': fn.jitter, 'devices': ['gpu']},
+    {'operator_fn': fn.random_resized_crop, 'size': 69},
+]
+
+
+def test_random_ops():
+    for op in random_ops:
+        print("\nTesting ", op)
+        random_op_helper(**op)
+
+
+sequence_ops = [
+    {'operator_fn': fn.cast, 'dtype': types.INT32},
+    {'operator_fn': fn.copy},
+    {'operator_fn': fn.crop, 'crop': (5, 5)},
+    {'operator_fn': fn.crop_mirror_normalize, 'mirror': 1, 'output_layout': 'FCHW'},
+    {'operator_fn': fn.erase, 'anchor': [0.3], 'axis_names': "H", 'normalized_anchor': True,
+     'shape': [0.1], 'normalized_shape': True},
+    {'operator_fn': fn.flip, 'horizontal': True},
+    {'operator_fn': fn.gaussian_blur, 'window_size': 5},
+    {'operator_fn': fn.normalize, 'batch': True},
+    {'operator_fn': fn.resize, 'resize_x': 50, 'resize_y': 50},
+]
+
+
+def test_sequence_ops():
+    for op in sequence_ops:
+        print("\nTesting ", op)
+        sequence_op_helper(**op)
+
+
+def test_batch_permute():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        perm = fn.batch_permutation(seed=420)
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        processed = fn.permute_batch(data, indices=perm)
+        pipe.set_outputs(processed)
+        return pipe
+
+    run_pipeline(generate_data(31, 13, image_like_shape_generator), pipeline_fn=pipe)
+
+
+
+def test_coin_flip():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        depthwise = fn.coin_flip()
+        horizontal = fn.coin_flip()
+        vertical = fn.coin_flip()
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        processed = fn.flip(data, depthwise=depthwise, horizontal=horizontal, vertical=vertical)
+        pipe.set_outputs(processed)
+        return pipe
+
+    run_pipeline(generate_data(31, 13, image_like_shape_generator), pipeline_fn=pipe,
+                 devices=['cpu'])
+
+
+def test_uniform():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        dist = fn.random.uniform()
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        processed = data * dist
+        pipe.set_outputs(processed)
+        return pipe
+
+    run_pipeline(generate_data(31, 13, array_1d_shape_generator), pipeline_fn=pipe)
+
+
+def test_normal_distribution():
+    def pipe_input(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        dist = fn.normal_distribution(data)
+        pipe.set_outputs(dist)
+        return pipe
+
+    def pipe_no_input(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        dist = data + fn.normal_distribution()
+        pipe.set_outputs(dist)
+        return pipe
+
+    run_pipeline(generate_data(31, 13, image_like_shape_generator), pipeline_fn=pipe_input)
+    run_pipeline(generate_data(31, 13, image_like_shape_generator), pipeline_fn=pipe_no_input)
+
+
+def test_constant():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        shape = fn.external_source(source=input_data, cycle=False, device='cpu')
+        data = fn.constant(fdata=3.1415, shape=shape, device=device)
+        pipe.set_outputs(data)
+        return pipe
+
+    check_pipeline(
+        generate_data(31, 13, custom_shape_generator(2, 4), lo=1, hi=255, dtype=np.uint8),
+        pipeline_fn=pipe)
+
+
+def test_reshape():
+    check_pipeline(generate_data(31, 13, (160, 80, 3), lo=0, hi=255, dtype=np.uint8),
+                   pipeline_fn=single_op_pipeline, operator_fn=fn.reshape,
+                   shape=(160 / 2, 80 * 2, 3))
+
+
+def test_slice():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        anch = fn.constant(fdata=.1, device='cpu')
+        sh = fn.constant(fdata=.5, device='cpu')
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        processed = fn.slice(data, anch, sh, axes=0, device=device)
+        pipe.set_outputs(processed)
+        return pipe
+
+    check_pipeline(generate_data(31, 13, image_like_shape_generator, lo=0, hi=255, dtype=np.uint8),
+                   pipeline_fn=pipe)
+
+
+def test_bb_flip():
+    check_pipeline(generate_data(31, 13, custom_shape_generator(150, 250, 4, 4)),
+                   single_op_pipeline, operator_fn=fn.bb_flip)
+
+
+def test_1_hot():
+    check_pipeline(generate_data(31, 13, array_1d_shape_generator, lo=0, hi=255, dtype=np.uint8),
+                   single_op_pipeline,
+                   operator_fn=fn.one_hot)
+
+
+def test_bbox_paste():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        paste_posx = fn.uniform(range=(0, 1))
+        paste_posy = fn.uniform(range=(0, 1))
+        paste_ratio = fn.uniform(range=(1, 2))
+        processed = fn.bbox_paste(data, paste_x=paste_posx, paste_y=paste_posy, ratio=paste_ratio)
+        pipe.set_outputs(processed)
+        return pipe
+
+    check_pipeline(generate_data(31, 13, custom_shape_generator(150, 250, 4, 4)), pipe, eps=.5,
+                   devices=['cpu'])
+
+
+def test_coord_flip():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        processed = fn.coord_flip(data)
+        pipe.set_outputs(processed)
+        return pipe
+
+    check_pipeline(generate_data(31, 13, custom_shape_generator(150, 250, 2, 2)), pipe)
+
+
+def test_lookup_table():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        processed = fn.lookup_table(data, keys=[1, 3], values=[10, 50])
+        pipe.set_outputs(processed)
+        return pipe
+
+    check_pipeline(generate_data(31, 13, array_1d_shape_generator, lo=0, hi=5, dtype=np.uint8),
+                   pipe)
+    # TODO sequence
+
+
+def test_reduce():
+    reduce_fns = [
+        fn.reductions.std_dev,
+        fn.reductions.variance
+    ]
+
+    def pipe(max_batch_size, input_data, device, /, reduce_fn):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        mean = fn.reductions.mean(data)
+        reduced = reduce_fn(data, mean)
+        pipe.set_outputs(reduced)
+        return pipe
+
+    for rf in reduce_fns:
+        check_pipeline(generate_data(31, 13, image_like_shape_generator), pipe, reduce_fn=rf)
+
+
+def test_arithm_ops():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        data = dali.math.clamp(data, 0.1, 0.9)
+        data = data * 2
+        dbl_data = data
+        data = data + 3
+        data = data - 4
+        data = data / 5
+        data = data // 6
+        data = -data
+        data = data + dbl_data
+        pipe.set_outputs(data)
+        return pipe
+
+    check_pipeline(generate_data(31, 13, custom_shape_generator(300, 400, 100, 200)), pipe)
+
+
+def test_sequence_rearrange():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device,
+                                  layout="FHWC")
+        processed = fn.sequence_rearrange(data, new_order=[0, 4, 1, 3, 2])
+        pipe.set_outputs(processed)
+        return pipe
+
+    check_pipeline(generate_data(31, 13, (5, 10, 20, 3), lo=0, hi=255, dtype=np.uint8), pipe)
+
+
+def test_element_extract():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device,
+                                  layout="FHWC")
+        processed, _ = fn.element_extract(data, element_map=[0, 3])
+        pipe.set_outputs(processed)
+        return pipe
+
+    check_pipeline(generate_data(31, 13, (5, 10, 20, 3), lo=0, hi=255, dtype=np.uint8), pipe)
+
+
+def test_nonsilent_region():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        processed, _ = fn.nonsilent_region(data)
+        pipe.set_outputs(processed)
+        return pipe
+
+    check_pipeline(generate_data(31, 13, array_1d_shape_generator, lo=0, hi=255, dtype=np.uint8),
+                   pipe, devices=['cpu'])
+
+
+def test_mel_filter_bank():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        with pipe:
+            data = fn.external_source(source=input_data, cycle=False, device=device)
+            spectrum = fn.spectrogram(data, nfft=60, window_length=50, window_step=25)
+            processed = fn.mel_filter_bank(spectrum)
+            pipe.set_outputs(processed)
+        return pipe
+
+    check_pipeline(generate_data(31, 13, array_1d_shape_generator), pipe)
+
+
+def test_mfcc():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device)
+        spectrum = fn.spectrogram(data, nfft=60, window_length=50, window_step=25)
+        mel = fn.mel_filter_bank(spectrum)
+        dec = fn.to_decibels(mel)
+        processed = fn.mfcc(dec)
+        pipe.set_outputs(processed)
+
+        return pipe
+
+    check_pipeline(generate_data(31, 13, array_1d_shape_generator), pipe)
+
+
+@nottest
+def generate_decoders_data(data_dir, data_extension):
+    # File reader won't work, so I need to load audio files into external_source manually
+    fnames = test_utils.filter_files(data_dir, data_extension)
+
+    nfiles = len(fnames)
+    _input_epoch = [
+        list(map(lambda fname: test_utils.read_file_bin(fname), fnames[:nfiles // 3])),
+        list(map(lambda fname: test_utils.read_file_bin(fname),
+                 fnames[nfiles // 3: nfiles // 2])),
+        list(map(lambda fname: test_utils.read_file_bin(fname), fnames[nfiles // 2:])),
+    ]
+
+    # Since we pack buffers into ndarray, we need to pad samples with 0.
+    input_epoch = []
+    for inp in _input_epoch:
+        max_len = max(sample.shape[0] for sample in inp)
+        inp = map(lambda sample: np.pad(sample, (0, max_len - sample.shape[0])), inp)
+        input_epoch.append(np.stack(list(inp)))
+    input_epoch = list(map(lambda batch: np.reshape(batch, batch.shape), input_epoch))
+
+    return input_epoch
+
+
+@nottest
+def test_decoders_check(pipeline_fn, data_dir, data_extension, devices=['cpu']):
+    check_pipeline(
+        generate_decoders_data(data_dir=data_dir, data_extension=data_extension),
+        pipeline_fn=pipeline_fn, devices=devices)
+
+
+@nottest
+def test_decoders_run(pipeline_fn, data_dir, data_extension, devices=['cpu']):
+    run_pipeline(
+        generate_decoders_data(data_dir=data_dir, data_extension=data_extension),
+        pipeline_fn=pipeline_fn, devices=devices)
+
+
+def test_audio_decoders():
+    def audio_decoder_pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        encoded = fn.external_source(source=input_data, cycle=False, device='cpu')
+        decoded, _ = fn.audio_decoder(encoded, downmix=True, sample_rate=12345, device=device)
+        pipe.set_outputs(decoded)
+        return pipe
+
+    yield test_decoders_check, audio_decoder_pipe, \
+          os.path.join(test_utils.get_dali_extra_path(), 'db', 'audio'), '.wav'
+
+
+def test_image_decoders():
+    def image_decoder_pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        encoded = fn.external_source(source=input_data, cycle=False, device='cpu')
+        decoded = fn.image_decoder(encoded, device=device)
+        pipe.set_outputs(decoded)
+        return pipe
+
+    def image_decoder_crop_pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        encoded = fn.external_source(source=input_data, cycle=False, device='cpu')
+        decoded = fn.image_decoder_crop(encoded, device=device)
+        pipe.set_outputs(decoded)
+        return pipe
+
+    def image_decoder_slice_pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        encoded = fn.external_source(source=input_data, cycle=False, device='cpu')
+        anch = fn.constant(fdata=.1)
+        sh = fn.constant(fdata=.4)
+        decoded = fn.image_decoder_slice(encoded, anch, sh, axes=0, device=device)
+        pipe.set_outputs(decoded)
+        return pipe
+
+    def image_decoder_rcrop_pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        encoded = fn.external_source(source=input_data, cycle=False, device='cpu')
+        decoded = fn.image_decoder_random_crop(encoded, device=device)
+        pipe.set_outputs(decoded)
+        return pipe
+
+    def peek_image_shape_pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        encoded = fn.external_source(source=input_data, cycle=False, device='cpu')
+        shape = fn.peek_image_shape(encoded, device=device)
+        pipe.set_outputs(shape)
+        return pipe
+
+    image_decoder_extensions = ['.jpg', '.bmp', '.png', '.pnm', '.jp2']
+    image_decoder_pipes = [image_decoder_pipe,
+                           image_decoder_crop_pipe,
+                           image_decoder_slice_pipe,
+                           ]
+
+    for ext in image_decoder_extensions:
+        for pipe in image_decoder_pipes:
+            yield test_decoders_check, pipe, \
+                  os.path.join(test_utils.get_dali_extra_path(), 'db', 'single'), \
+                  ext, ['cpu', 'mixed']
+        yield test_decoders_run, image_decoder_rcrop_pipe, \
+              os.path.join(test_utils.get_dali_extra_path(), 'db', 'single'), \
+              ext, ['cpu', 'mixed']
+
+    yield test_decoders_check, peek_image_shape_pipe, \
+          os.path.join(test_utils.get_dali_extra_path(), 'db', 'single'), '.jpg', ['cpu']
+
+
+def test_python_function():
+    def resize(data):
+        data += 13
+        return data
+
+    def pipe(max_batch_size, input_data, device, /):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0, exec_async=False,
+                        exec_pipelined=False)
+        with pipe:
+            data = fn.external_source(source=input_data, cycle=False, device=device)
+            processed = fn.python_function(data, function=resize, num_outputs=1)
+            pipe.set_outputs(processed)
+        return pipe
+
+    check_pipeline(generate_data(31, 13, image_like_shape_generator), pipe, devices=['cpu'])
+
+
+def test_reinterpret():
+    def pipe(max_batch_size, input_data, device, input_layout):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        data = fn.external_source(source=input_data, cycle=False, device=device,
+                                  layout=input_layout)
+        processed = fn.reinterpret(data, rel_shape=[.5, 1, -1])
+        pipe.set_outputs(processed)
+        return pipe
+
+    check_pipeline(generate_data(31, 13, (160, 80, 3), lo=0, hi=255, dtype=np.uint8),
+                   pipeline_fn=pipe, input_layout="HWC")
+    check_pipeline(generate_data(31, 13, (5, 160, 80, 3), lo=0, hi=255, dtype=np.uint8),
+                   pipeline_fn=pipe, input_layout="FHWC")

--- a/dali/test/python/test_external_source_impl.py
+++ b/dali/test/python/test_external_source_impl.py
@@ -462,26 +462,6 @@ def test_external_source():
             break
     assert(iter_num == i)
 
-def test_external_source_fail():
-    class ExternalSourcePipeline(Pipeline):
-        def __init__(self, batch_size, external_s_size, num_threads, device_id):
-            super(ExternalSourcePipeline, self).__init__(batch_size, num_threads, device_id)
-            self.input = ops.ExternalSource()
-            self.batch_size_ = batch_size
-            self.external_s_size_ = external_s_size
-
-        def define_graph(self):
-            self.batch = self.input()
-            return [self.batch]
-
-        def iter_setup(self):
-            batch = datapy.zeros([self.external_s_size_,4,5])
-            self.feed_input(self.batch, batch)
-
-    batch_size = 3
-    pipe = ExternalSourcePipeline(batch_size, batch_size - 1, 3, 0)
-    pipe.build()
-    assert_raises(RuntimeError, pipe.run)
 
 def test_external_source_fail_missing_output():
     class ExternalSourcePipeline(Pipeline):
@@ -507,28 +487,6 @@ def test_external_source_fail_missing_output():
     pipe.build()
     assert_raises(RuntimeError, pipe.run)
 
-def test_external_source_fail_list():
-    class ExternalSourcePipeline(Pipeline):
-        def __init__(self, batch_size, external_s_size, num_threads, device_id):
-            super(ExternalSourcePipeline, self).__init__(batch_size, num_threads, device_id)
-            self.input = ops.ExternalSource()
-            self.batch_size_ = batch_size
-            self.external_s_size_ = external_s_size
-
-        def define_graph(self):
-            self.batch = self.input()
-            return [self.batch]
-
-        def iter_setup(self):
-            batch = []
-            for _ in range(self.external_s_size_):
-                batch.append(datapy.zeros([3,4,5]))
-            self.feed_input(self.batch, batch)
-
-    batch_size = 3
-    pipe = ExternalSourcePipeline(batch_size, batch_size - 1, 3, 0)
-    pipe.build()
-    assert_raises(RuntimeError, pipe.run)
 
 def external_data_veri(external_data, batch_size):
     class ExternalSourcePipeline(Pipeline):

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -206,7 +206,6 @@ def compare_pipelines(pipe1, pipe2, batch_size, N_iterations, eps=1e-07, max_all
                 current_expected_layout = expected_layout
             check_batch(out1_data, out2_data, batch_size, eps, max_allowed_error,
                         expected_layout=current_expected_layout, compare_layouts=compare_layouts)
-    print("OK: ({} iterations)".format(N_iterations))
 
 
 class RandomDataIterator(object):
@@ -435,3 +434,28 @@ def np_type_to_dali(type):
         np.float64: types.FLOAT64,
     }
     return np_types_to_dali_dict[type]
+
+
+def read_file_bin(filename):
+    """
+    Read file as bytes and insert it into numpy array
+    :param filename: path to the file
+    :return: numpy array
+    """
+    import_numpy()
+    return np.fromfile(filename, dtype='uint8')
+
+
+def filter_files(dirpath, suffix):
+    """
+    Read all file names recursively from a directory and filter those, which end with given suffix
+    :param dirpath: Path to directory, from which the file names will be read
+    :param suffix: String, which will be used to filter the files
+    :return: List of file names
+    """
+    fnames = []
+    for dir_name, subdir_list, file_list in os.walk(dirpath):
+        flist = filter(lambda fname: fname.endswith(suffix), file_list)
+        flist = map(lambda fname: os.path.join(dir_name, fname), flist)
+        fnames.extend(flist)
+    return fnames

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -1434,6 +1434,27 @@ auto permute_dims(const TensorListShape<in_ndim> &in, const Permutation &axis_or
   return out;
 }
 
+/**
+ * Returns new shape, where samples are subset of samples in given TensorListShape.
+ *
+ * @param begin Start index, included in the output
+ * @param end End index, excluded from the output
+ */
+template <int ndims>
+TensorListShape<ndims> subshape(const TensorListShape<ndims> &in, int begin, int end,
+                                int step = 1) {
+  assert(step >= 1);
+  assert(end > begin);
+  assert(begin >= 0);
+  auto div_ceil = [](int x, int y) { return 1 + ((x - 1) / y); };
+  int nsamples = div_ceil(end - begin, step);
+  TensorListShape<ndims> ret(nsamples, in.sample_dim());
+  for (int i = begin, j = 0; j < nsamples; i += step, j++) {
+    ret.set_tensor_shape(j, in.tensor_shape(i));
+  }
+  return ret;
+}
+
 }  // namespace dali
 
 #endif  // DALI_CORE_TENSOR_SHAPE_H_


### PR DESCRIPTION
TODO:
- [x] Add deprecation warning to `pipeline.py::batch_size(self)` and add `@property max_batch_size()` 
- [x] Update documentation to `batch_size` arg in `pipeline.py`
- [x] Remove external_source tests that fail on variable batch size
- [x] Adjust `_check_data_batch` in `external_source.py`: expected batch size condition and error message (~L24)
- [x] https://github.com/NVIDIA/DALI/pull/2408#discussion_r537532851
- [x] https://github.com/NVIDIA/DALI/pull/2408#discussion_r537484299
- [x] figure out inputless ops
- [x] `ImageDecoder` rework
- [x] C API
- [x] Document, how `max_batch_size` setting might explode the memory consumption

Signed-off-by: szalpal <mszolucha@nvidia.com>

### What happened in this PR:
1. Update C API to support i2i variable batch size
2. Update nvJpegDecoder and its flavours to support variable BS
3. Update Constant op for the same reason
4. Partially split Executor into `h` and `cc` file, to make development convenient
5. Also add variable batch size routines to Executor (batch size queues, PreRun with BS inferring from the graph)
6. Introduce `BatchSizeProvider` interface and add it to `ExternalSource`
7. Add a feature to `CachingList` (inner `ExternalSource` memory), so that it can traverse over the data list asynchronously w.r.t current head and tail of this list
8. Modify constraint that stipulates constant batch size to stipulate uniform batch size within single iteration
9. Python API adjustment
10. Adding enormous test for i2i variable batch size (every op is tested)

#### Why we need this PR?
*Pick one, remove the rest*
- To enable the i2i variable batch size


**JIRA TASK**: *[Use DALI-XXXX or NA]*
