### PR TITLE
Update ExternalSource framework examples

### DIFF
--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -436,8 +436,8 @@ void TensorVector<Backend>::update_view(int idx) {
 }
 
 
-template class TensorVector<CPUBackend>;
-template class TensorVector<GPUBackend>;
+template class DLL_PUBLIC TensorVector<CPUBackend>;
+template class DLL_PUBLIC TensorVector<GPUBackend>;
 template void TensorVector<CPUBackend>::Copy<CPUBackend>(const TensorVector<CPUBackend>&, cudaStream_t);  // NOLINT
 template void TensorVector<CPUBackend>::Copy<GPUBackend>(const TensorVector<GPUBackend>&, cudaStream_t);  // NOLINT
 template void TensorVector<GPUBackend>::Copy<CPUBackend>(const TensorVector<CPUBackend>&, cudaStream_t);  // NOLINT

--- a/docs/examples/frameworks/mxnet/mxnet-external_input.ipynb
+++ b/docs/examples/frameworks/mxnet/mxnet-external_input.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,8 +24,9 @@
     "import numpy as np\n",
     "from random import shuffle\n",
     "from nvidia.dali.pipeline import Pipeline\n",
-    "import nvidia.dali.ops as ops            \n",
-    "import nvidia.dali.types as types\n",
+    "import nvidia.dali as dali\n",
+    "import nvidia.dali.fn as fn\n",
+    "import mxnet\n",
     "\n",
     "batch_size = 3\n",
     "epochs = 3"
@@ -40,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,17 +73,15 @@
     "\n",
     "        for _ in range(self.batch_size):\n",
     "            jpeg_filename, label = self.files[self.i].split(' ')\n",
-    "            f = open(self.images_dir + jpeg_filename, 'rb')\n",
-    "            batch.append(np.frombuffer(f.read(), dtype = np.uint8))\n",
-    "            labels.append(np.array([label], dtype = np.uint8))\n",
+    "            batch.append(np.fromfile(self.images_dir + jpeg_filename, dtype = np.uint8))  # we can use numpy\n",
+    "            labels.append(mxnet.ndarray.array([int(label)], dtype = 'uint8')) # or MXNet native arrays\n",
     "            self.i = (self.i + 1) % self.n\n",
     "        return (batch, labels)\n",
     "\n",
-    "    @property\n",
-    "    def size(self,):\n",
+    "    def __len__(self):\n",
     "        return self.data_set_len\n",
     "\n",
-    "    next = __next__\n"
+    "    next = __next__"
    ]
   },
   {
@@ -91,46 +90,24 @@
    "source": [
     "### Defining the pipeline\n",
     "\n",
-    "Now the pipeline itself will be defined. First of all, a framework iterator will be used so we need to make sure that images and the output of the pipeline are uniforms in size, so resize operator is used. Also, `iter_setup` will raise the StopIteration exception when the AdvancedExternalInputIterator run of data. Worth notice is that iterator needs to be recreated so next time `iter_setup` is called it has ready data to consume."
+    "Now let's define our pipeline. We need an instance of ``Pipeline`` class and some operators which will define the processing graph. Our external source provides 2 outpus which we can conveniently unpack by specifying ``num_outputs=2`` in the external source operator."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "class ExternalSourcePipeline(Pipeline):\n",
-    "    def __init__(self, batch_size, num_threads, device_id, external_data):\n",
-    "        super(ExternalSourcePipeline, self).__init__(batch_size,\n",
-    "                                      num_threads,\n",
-    "                                      device_id,\n",
-    "                                      seed=12)\n",
-    "        self.input = ops.ExternalSource()\n",
-    "        self.input_label = ops.ExternalSource()\n",
-    "        self.decode = ops.ImageDecoder(device = \"mixed\", output_type = types.RGB)\n",
-    "        self.res = ops.Resize(device=\"gpu\", resize_x=240, resize_y=240)\n",
-    "        self.cast = ops.Cast(device = \"gpu\",\n",
-    "                             dtype = types.UINT8)\n",
-    "        self.external_data = external_data\n",
-    "        self.iterator = iter(self.external_data)\n",
-    "\n",
-    "    def define_graph(self):\n",
-    "        self.jpegs = self.input()\n",
-    "        self.labels = self.input_label()\n",
-    "        images = self.decode(self.jpegs)\n",
-    "        images = self.res(images)\n",
-    "        output = self.cast(images)\n",
-    "        return (output, self.labels)\n",
-    "\n",
-    "    def iter_setup(self):\n",
-    "        try:\n",
-    "            (images, labels) = self.iterator.next()\n",
-    "            self.feed_input(self.jpegs, images)\n",
-    "            self.feed_input(self.labels, labels)\n",
-    "        except StopIteration:\n",
-    "            self.iterator = iter(self.external_data)\n",
-    "            raise StopIteration"
+    "def ExternalSourcePipeline(batch_size, num_threads, device_id, external_data):\n",
+    "    pipe = Pipeline(batch_size, num_threads, device_id)\n",
+    "    with pipe:\n",
+    "        jpegs, labels = fn.external_source(source=external_data, num_outputs=2)\n",
+    "        images = fn.image_decoder(jpegs, device=\"mixed\")\n",
+    "        images = fn.resize(images, resize_x=240, resize_y=240)\n",
+    "        output = fn.cast(images, dtype=dali.types.UINT8)\n",
+    "        pipe.set_outputs(output, labels)\n",
+    "    return pipe"
    ]
   },
   {
@@ -148,17 +125,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.6/dist-packages/nvidia/dali/plugin/base_iterator.py:124: Warning: Please set `reader_name` and don't set last_batch_padded and size manually  whenever possible. This may lead, in some situations, to miss some  samples or return duplicated ones. Check the Sharding section of the documentation for more details.\n",
-      "  _iterator_deprecation_warning()\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -194,7 +163,7 @@
     "eii = ExternalInputIterator(batch_size, 0, 1)\n",
     "pipe = ExternalSourcePipeline(batch_size=batch_size, num_threads=2, device_id = 0,\n",
     "                              external_data = eii)\n",
-    "pii = MXNetIterator(pipe, size=eii.size, last_batch_padded=True, last_batch_policy=LastBatchPolicy.PARTIAL)\n",
+    "pii = MXNetIterator(pipe, size=len(eii), last_batch_padded=True, last_batch_policy=LastBatchPolicy.PARTIAL)\n",
     "\n",
     "for e in range(epochs):\n",
     "    for i, data in enumerate(pii):\n",
@@ -219,7 +188,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/mxnet/mxnet-external_input.ipynb
+++ b/docs/examples/frameworks/mxnet/mxnet-external_input.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {

--- a/docs/examples/frameworks/paddle/paddle-external_input.ipynb
+++ b/docs/examples/frameworks/paddle/paddle-external_input.ipynb
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {

--- a/docs/examples/frameworks/paddle/paddle-external_input.ipynb
+++ b/docs/examples/frameworks/paddle/paddle-external_input.ipynb
@@ -24,8 +24,8 @@
     "import numpy as np\n",
     "from random import shuffle\n",
     "from nvidia.dali.pipeline import Pipeline\n",
-    "import nvidia.dali.ops as ops            \n",
-    "import nvidia.dali.types as types\n",
+    "import nvidia.dali as dali\n",
+    "import nvidia.dali.fn as fn\n",
     "\n",
     "batch_size = 3\n",
     "epochs = 3"
@@ -72,17 +72,15 @@
     "\n",
     "        for _ in range(self.batch_size):\n",
     "            jpeg_filename, label = self.files[self.i].split(' ')\n",
-    "            f = open(self.images_dir + jpeg_filename, 'rb')\n",
-    "            batch.append(np.frombuffer(f.read(), dtype = np.uint8))\n",
-    "            labels.append(np.array([label], dtype = np.uint8))\n",
+    "            batch.append(np.fromfile(self.images_dir + jpeg_filename, dtype = np.uint8))\n",
+    "            labels.append(np.uint8([int(label)]))\n",
     "            self.i = (self.i + 1) % self.n\n",
     "        return (batch, labels)\n",
     "\n",
-    "    @property\n",
-    "    def size(self,):\n",
+    "    def __len__(self):\n",
     "        return self.data_set_len\n",
     "\n",
-    "    next = __next__\n"
+    "    next = __next__"
    ]
   },
   {
@@ -91,7 +89,7 @@
    "source": [
     "### Defining the pipeline\n",
     "\n",
-    "Now the pipeline itself will be defined. First of all, a framework iterator will be used so we need to make sure that images and the output of the pipeline are uniforms in size, so resize operator is used. Also, `iter_setup` will raise the StopIteration exception when the AdvancedExternalInputIterator run of data. Worth notice is that iterator needs to be recreated so next time `iter_setup` is called it has ready data to consume."
+    "Now let's define our pipeline. We need an instance of ``Pipeline`` class and some operators which will define the processing graph. Our external source provides 2 outpus which we can conveniently unpack by specifying ``num_outputs=2`` in the external source operator."
    ]
   },
   {
@@ -100,37 +98,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class ExternalSourcePipeline(Pipeline):\n",
-    "    def __init__(self, batch_size, num_threads, device_id, external_data):\n",
-    "        super(ExternalSourcePipeline, self).__init__(batch_size,\n",
-    "                                      num_threads,\n",
-    "                                      device_id,\n",
-    "                                      seed=12)\n",
-    "        self.input = ops.ExternalSource()\n",
-    "        self.input_label = ops.ExternalSource()\n",
-    "        self.decode = ops.ImageDecoder(device = \"mixed\", output_type = types.RGB)\n",
-    "        self.res = ops.Resize(device=\"gpu\", resize_x=240, resize_y=240)\n",
-    "        self.cast = ops.Cast(device = \"gpu\",\n",
-    "                             dtype = types.UINT8)\n",
-    "        self.external_data = external_data\n",
-    "        self.iterator = iter(self.external_data)\n",
-    "\n",
-    "    def define_graph(self):\n",
-    "        self.jpegs = self.input()\n",
-    "        self.labels = self.input_label()\n",
-    "        images = self.decode(self.jpegs)\n",
-    "        images = self.res(images)\n",
-    "        output = self.cast(images)\n",
-    "        return (output, self.labels)\n",
-    "\n",
-    "    def iter_setup(self):\n",
-    "        try:\n",
-    "            (images, labels) = self.iterator.next()\n",
-    "            self.feed_input(self.jpegs, images)\n",
-    "            self.feed_input(self.labels, labels)\n",
-    "        except StopIteration:\n",
-    "            self.iterator = iter(self.external_data)\n",
-    "            raise StopIteration"
+    "def ExternalSourcePipeline(batch_size, num_threads, device_id, external_data):\n",
+    "    pipe = Pipeline(batch_size, num_threads, device_id)\n",
+    "    with pipe:\n",
+    "        jpegs, labels = fn.external_source(source=external_data, num_outputs=2)\n",
+    "        images = fn.image_decoder(jpegs, device=\"mixed\")\n",
+    "        images = fn.resize(images, resize_x=240, resize_y=240)\n",
+    "        output = fn.cast(images, dtype=dali.types.UINT8)\n",
+    "        pipe.set_outputs(output, labels)\n",
+    "    return pipe"
    ]
   },
   {
@@ -148,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -186,7 +162,7 @@
     "eii = ExternalInputIterator(batch_size, 0, 1)\n",
     "pipe = ExternalSourcePipeline(batch_size=batch_size, num_threads=2, device_id = 0,\n",
     "                              external_data = eii)\n",
-    "pii = PaddleIterator(pipe, size=eii.size, last_batch_padded=True, last_batch_policy=LastBatchPolicy.PARTIAL)\n",
+    "pii = PaddleIterator(pipe, size=len(eii), last_batch_padded=True, last_batch_policy=LastBatchPolicy.PARTIAL)\n",
     "\n",
     "for e in range(epochs):\n",
     "    for i, data in enumerate(pii):\n",
@@ -197,21 +173,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15+"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/pytorch/pytorch-external_input.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-external_input.ipynb
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {

--- a/docs/examples/frameworks/pytorch/pytorch-external_input.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-external_input.ipynb
@@ -81,7 +81,7 @@
     "    def __len__(self):\n",
     "        return self.data_set_len\n",
     "\n",
-    "    next = __next__\n"
+    "    next = __next__"
    ]
   },
   {
@@ -188,7 +188,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/docs/examples/frameworks/pytorch/pytorch-external_input.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-external_input.ipynb
@@ -24,8 +24,9 @@
     "import numpy as np\n",
     "from random import shuffle\n",
     "from nvidia.dali.pipeline import Pipeline\n",
-    "import nvidia.dali.ops as ops            \n",
     "import nvidia.dali.types as types\n",
+    "import nvidia.dali.fn as fn\n",
+    "import torch\n",
     "\n",
     "batch_size = 3\n",
     "epochs = 3"
@@ -72,14 +73,12 @@
     "\n",
     "        for _ in range(self.batch_size):\n",
     "            jpeg_filename, label = self.files[self.i].split(' ')\n",
-    "            f = open(self.images_dir + jpeg_filename, 'rb')\n",
-    "            batch.append(np.frombuffer(f.read(), dtype = np.uint8))\n",
-    "            labels.append(np.array([label], dtype = np.uint8))\n",
+    "            batch.append(np.fromfile(self.images_dir + jpeg_filename, dtype = np.uint8))  # we can use numpy\n",
+    "            labels.append(torch.tensor([int(label)], dtype = torch.uint8)) # or PyTorch's native tensors\n",
     "            self.i = (self.i + 1) % self.n\n",
     "        return (batch, labels)\n",
     "\n",
-    "    @property\n",
-    "    def size(self,):\n",
+    "    def __len__(self):\n",
     "        return self.data_set_len\n",
     "\n",
     "    next = __next__\n"
@@ -91,7 +90,7 @@
    "source": [
     "### Defining the pipeline\n",
     "\n",
-    "Now the pipeline itself will be defined. First of all, a framework iterator will be used so we need to make sure that images and the output of the pipeline are uniforms in size, so resize operator is used. Also, `iter_setup` will raise the StopIteration exception when the AdvancedExternalInputIterator run of data. Worth notice is that iterator needs to be recreated so next time `iter_setup` is called it has ready data to consume."
+    "Now let's define our pipeline. We need an instance of ``Pipeline`` class and some operators which will define the processing graph. Our external source provides 2 outpus which we can conveniently unpack by specifying ``num_outputs=2`` in the external source operator."
    ]
   },
   {
@@ -100,37 +99,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class ExternalSourcePipeline(Pipeline):\n",
-    "    def __init__(self, batch_size, num_threads, device_id, external_data):\n",
-    "        super(ExternalSourcePipeline, self).__init__(batch_size,\n",
-    "                                      num_threads,\n",
-    "                                      device_id,\n",
-    "                                      seed=12)\n",
-    "        self.input = ops.ExternalSource()\n",
-    "        self.input_label = ops.ExternalSource()\n",
-    "        self.decode = ops.ImageDecoder(device = \"mixed\", output_type = types.RGB)\n",
-    "        self.res = ops.Resize(device=\"gpu\", resize_x=240, resize_y=240)\n",
-    "        self.cast = ops.Cast(device = \"gpu\",\n",
-    "                             dtype = types.UINT8)\n",
-    "        self.external_data = external_data\n",
-    "        self.iterator = iter(self.external_data)\n",
-    "\n",
-    "    def define_graph(self):\n",
-    "        self.jpegs = self.input()\n",
-    "        self.labels = self.input_label()\n",
-    "        images = self.decode(self.jpegs)\n",
-    "        images = self.res(images)\n",
-    "        output = self.cast(images)\n",
-    "        return (output, self.labels)\n",
-    "\n",
-    "    def iter_setup(self):\n",
-    "        try:\n",
-    "            (images, labels) = self.iterator.next()\n",
-    "            self.feed_input(self.jpegs, images)\n",
-    "            self.feed_input(self.labels, labels)\n",
-    "        except StopIteration:\n",
-    "            self.iterator = iter(self.external_data)\n",
-    "            raise StopIteration"
+    "def ExternalSourcePipeline(batch_size, num_threads, device_id, external_data):\n",
+    "    pipe = Pipeline(batch_size, num_threads, device_id)\n",
+    "    with pipe:\n",
+    "        jpegs, labels = fn.external_source(source=external_data, num_outputs=2)\n",
+    "        images = fn.image_decoder(jpegs, device=\"mixed\")\n",
+    "        images = fn.resize(images, resize_x=240, resize_y=240)\n",
+    "        output = fn.cast(images, dtype=types.UINT8)\n",
+    "        pipe.set_outputs(output, labels)\n",
+    "    return pipe"
    ]
   },
   {
@@ -148,17 +125,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.6/dist-packages/nvidia/dali/plugin/base_iterator.py:124: Warning: Please set `reader_name` and don't set last_batch_padded and size manually  whenever possible. This may lead, in some situations, to miss some  samples or return duplicated ones. Check the Sharding section of the documentation for more details.\n",
-      "  _iterator_deprecation_warning()\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -194,7 +163,7 @@
     "eii = ExternalInputIterator(batch_size, 0, 1)\n",
     "pipe = ExternalSourcePipeline(batch_size=batch_size, num_threads=2, device_id = 0,\n",
     "                              external_data = eii)\n",
-    "pii = PyTorchIterator(pipe, size=eii.size, last_batch_padded=True, last_batch_policy=LastBatchPolicy.PARTIAL)\n",
+    "pii = PyTorchIterator(pipe, size=len(eii), last_batch_padded=True, last_batch_policy=LastBatchPolicy.PARTIAL)\n",
     "\n",
     "for e in range(epochs):\n",
     "    for i, data in enumerate(pii):\n",


### PR DESCRIPTION
* use functional API
* use modern external source (with source arg)
* use more efficient way of reading files
* showcase direct usage of PyTorch and MXNet tensors
* use multi-output external source

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It uses up-to-date techniques in PyTorch/ExternalSource example
- It fixes a build issue with clang 6

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
      * use functional API
      * use modern external source (with source arg)
      * use more efficient way of reading files
      * showcase direct usage of PyTorch tensors
      * use multi-output external source
 - Affected modules and functionalities:
     * ExternalSource examples in PyTorch, MXNet and PaddlePaddle
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * N/A
 - Documentation (including examples):
     * It's the documentation

**JIRA TASK**: N/A
