### PR TITLE
Fix the dimensionality of labels in SSDRandomCrop.

### DIFF
--- a/dali/operators/ssd/random_crop.cc
+++ b/dali/operators/ssd/random_crop.cc
@@ -281,7 +281,7 @@ void SSDRandomCrop<CPUBackend>::RunImpl(SampleWorkspace &ws) {
       bbox_out.Resize({valid_bboxes, 4});
       auto *bbox_out_data = bbox_out.mutable_data<float>();
 
-      label_out.Resize({valid_bboxes, 1});
+      label_out.Resize({valid_bboxes});
       auto *label_out_data = label_out.mutable_data<int>();
 
       // copy valid bboxes to output and transform them


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: assert raised when using SSDRandomCrop, detected in debug build.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Remove the trailing dimension
 - Affected modules and functionalities:
     * SSDRandomCrop
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
