### PR TITLE
Fix bugs reported by static analysis

### DIFF
--- a/dali/kernels/signal/fft/fft_postprocess_test.cu
+++ b/dali/kernels/signal/fft/fft_postprocess_test.cu
@@ -106,7 +106,8 @@ class FFTPostprocessTest<FFTPostprocessArgs<Out, In, Convert>> : public ::testin
     auto cpu_in = in.cpu();
     UniformRandomFill(cpu_in, rng, -1, 1);
 
-    ToFreqMajorSpectrum<Out, In, Convert> tr;
+    Convert convert;
+    ToFreqMajorSpectrum<Out, In, Convert> tr(convert);
     KernelContext ctx;
     ScratchpadAllocator sa;
     KernelRequirements req = tr.Setup(ctx, in_shape);
@@ -123,7 +124,6 @@ class FFTPostprocessTest<FFTPostprocessArgs<Out, In, Convert>> : public ::testin
     ref.reshape(out_shape);
     auto cpu_ref = ref.cpu();
 
-    Convert convert;
     for (int i = 0; i < N; i++) {
       TensorView<StorageCPU, In, 2> in_tv = cpu_in[i];
       TensorView<StorageCPU, Out, 2> ref_tv = cpu_ref[i];

--- a/dali/kernels/signal/fft/fft_postprocess_test.cu
+++ b/dali/kernels/signal/fft/fft_postprocess_test.cu
@@ -106,8 +106,7 @@ class FFTPostprocessTest<FFTPostprocessArgs<Out, In, Convert>> : public ::testin
     auto cpu_in = in.cpu();
     UniformRandomFill(cpu_in, rng, -1, 1);
 
-    Convert convert;
-    ToFreqMajorSpectrum<Out, In, Convert> tr(convert);
+    ToFreqMajorSpectrum<Out, In, Convert> tr;
     KernelContext ctx;
     ScratchpadAllocator sa;
     KernelRequirements req = tr.Setup(ctx, in_shape);
@@ -124,6 +123,7 @@ class FFTPostprocessTest<FFTPostprocessArgs<Out, In, Convert>> : public ::testin
     ref.reshape(out_shape);
     auto cpu_ref = ref.cpu();
 
+    Convert convert;
     for (int i = 0; i < N; i++) {
       TensorView<StorageCPU, In, 2> in_tv = cpu_in[i];
       TensorView<StorageCPU, Out, 2> ref_tv = cpu_ref[i];

--- a/dali/operators/geometry/affine_transforms/transform_crop.cc
+++ b/dali/operators/geometry/affine_transforms/transform_crop.cc
@@ -126,9 +126,9 @@ class TransformCropCPU
     from_end_.Read(spec, ws, repeat);
     to_start_.Read(spec, ws, repeat);
     to_end_.Read(spec, ws, repeat);
-    auto sizes = {from_start_[0].size(), from_end_[0].size(),
-                  to_start_[0].size(), to_end_[0].size()};
-    ndim_ = std::max(sizes);
+    auto sizes = std::array<size_t, 4>{from_start_[0].size(), from_end_[0].size(),
+                                       to_start_[0].size(), to_end_[0].size()};
+    ndim_ = *std::max_element(sizes.begin(), sizes.end());
     DALI_ENFORCE(std::all_of(sizes.begin(), sizes.end(),
         [&](size_t sz){ return static_cast<int>(sz) == ndim_ || sz == 1; }),
       "Arguments ``from_start``, ``from_end``, ``to_start`` and ``to_end`` should"

--- a/dali/operators/sequence/optical_flow/optical_flow.h
+++ b/dali/operators/sequence/optical_flow/optical_flow.h
@@ -52,21 +52,15 @@ class OpticalFlow : public Operator<Backend> {
  public:
   explicit OpticalFlow(const OpSpec &spec)
       : Operator<Backend>(spec),
-        quality_factor_(spec.GetArgument<std::remove_const_t<decltype(this->quality_factor_)>>(
-            detail::kPresetArgName)),
-        grid_size_(spec.GetArgument<std::remove_const_t<decltype(this->grid_size_)>>(
-            detail::kOutputFormatArgName)),
-        enable_temporal_hints_(
-            spec.GetArgument<std::remove_const_t<decltype(this->enable_temporal_hints_)>>(
-                detail::kEnableTemporalHintsArgName)),
-        enable_external_hints_(
-            spec.GetArgument<std::remove_const_t<decltype(this->enable_external_hints_)>>(
-                detail::kEnableExternalHintsArgName)),
+        quality_factor_(spec.GetArgument<float>(detail::kPresetArgName)),
+        grid_size_(spec.GetArgument<int>(detail::kOutputFormatArgName)),
+        enable_temporal_hints_(spec.GetArgument<bool>(detail::kEnableTemporalHintsArgName)),
+        enable_external_hints_(spec.GetArgument<bool>(detail::kEnableExternalHintsArgName)),
         of_params_({quality_factor_, ConvertGridSize(grid_size_), enable_temporal_hints_,
                     enable_external_hints_}),
         optical_flow_(std::unique_ptr<optical_flow::OpticalFlowAdapter<ComputeBackend>>(
             new optical_flow::OpticalFlowStub<ComputeBackend>(of_params_))),
-        image_type_(spec.GetArgument<decltype(this->image_type_)>(detail::kImageTypeArgName)),
+        image_type_(spec.GetArgument<DALIImageType>(detail::kImageTypeArgName)),
         device_id_(spec.GetArgument<int>("device_id")) {
     // In case external hints are enabled, we need 2 inputs
     DALI_ENFORCE((enable_external_hints_ && spec.NumInput() == 2) || !enable_external_hints_,

--- a/dali/operators/sequence/optical_flow/optical_flow.h
+++ b/dali/operators/sequence/optical_flow/optical_flow.h
@@ -50,37 +50,29 @@ class OpticalFlow : public Operator<Backend> {
   using ComputeBackend = typename detail::backend_to_compute<Backend>::type;
 
  public:
-  explicit OpticalFlow(const OpSpec &spec) :
-          Operator<Backend>(spec),
-          quality_factor_(spec.GetArgument<std::remove_const_t<
-                  decltype(this->quality_factor_)>>(detail::kPresetArgName)),
-          grid_size_(spec.GetArgument<std::remove_const_t<
-                  decltype(this->grid_size_)>>(detail::kOutputFormatArgName)),
-          enable_temporal_hints_(spec.GetArgument<std::remove_const_t<
-                  decltype(this->enable_temporal_hints_)>>(
-                  detail::kEnableTemporalHintsArgName)),
-          enable_external_hints_(spec.GetArgument<std::remove_const_t<
-                  decltype(this->enable_external_hints_)>>(
-                  detail::kEnableExternalHintsArgName)),
-          optical_flow_(std::unique_ptr<optical_flow::OpticalFlowAdapter<ComputeBackend>>(
-                  new optical_flow::OpticalFlowStub<ComputeBackend>(of_params_))),
-          image_type_(spec.GetArgument<decltype(this->image_type_)>(detail::kImageTypeArgName)),
-          device_id_(spec.GetArgument<int>("device_id")) {
+  explicit OpticalFlow(const OpSpec &spec)
+      : Operator<Backend>(spec),
+        quality_factor_(spec.GetArgument<std::remove_const_t<decltype(this->quality_factor_)>>(
+            detail::kPresetArgName)),
+        grid_size_(spec.GetArgument<std::remove_const_t<decltype(this->grid_size_)>>(
+            detail::kOutputFormatArgName)),
+        enable_temporal_hints_(
+            spec.GetArgument<std::remove_const_t<decltype(this->enable_temporal_hints_)>>(
+                detail::kEnableTemporalHintsArgName)),
+        enable_external_hints_(
+            spec.GetArgument<std::remove_const_t<decltype(this->enable_external_hints_)>>(
+                detail::kEnableExternalHintsArgName)),
+        of_params_({quality_factor_, ConvertGridSize(grid_size_), enable_temporal_hints_,
+                    enable_external_hints_}),
+        optical_flow_(std::unique_ptr<optical_flow::OpticalFlowAdapter<ComputeBackend>>(
+            new optical_flow::OpticalFlowStub<ComputeBackend>(of_params_))),
+        image_type_(spec.GetArgument<decltype(this->image_type_)>(detail::kImageTypeArgName)),
+        device_id_(spec.GetArgument<int>("device_id")) {
     // In case external hints are enabled, we need 2 inputs
     DALI_ENFORCE((enable_external_hints_ && spec.NumInput() == 2) || !enable_external_hints_,
                  "Incorrect number of inputs. Expected: 2, Obtained: " +
                  std::to_string(spec.NumInput()));
-    optical_flow::VectorGridSize grid_size;
-    if (grid_size_ < 4) {
-      grid_size = optical_flow::VectorGridSize::UNDEF;
-    } else if (grid_size_ == 4) {
-      grid_size = optical_flow::VectorGridSize::SIZE_4;
-    } else {
-      grid_size = optical_flow::VectorGridSize::MAX;
-    }
-    of_params_ = {quality_factor_, grid_size, enable_temporal_hints_, enable_external_hints_};
   }
-
 
   ~OpticalFlow() = default;
   DISABLE_COPY_MOVE_ASSIGN(OpticalFlow);
@@ -112,6 +104,14 @@ class OpticalFlow : public Operator<Backend> {
                    });
   }
 
+  optical_flow::VectorGridSize ConvertGridSize(int grid_size) {
+    if (grid_size < 4) {
+      return optical_flow::VectorGridSize::UNDEF;
+    } else if (grid_size == 4) {
+      return optical_flow::VectorGridSize::SIZE_4;
+    }
+    return optical_flow::VectorGridSize::MAX;
+  }
 
   /**
    * Use input TensorList to extract calculation params

--- a/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.cc
+++ b/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.cc
@@ -184,14 +184,12 @@ void OpticalFlowTuring::SetInitParams(dali::optical_flow::OpticalFlowParams api_
 NV_OF_EXECUTE_INPUT_PARAMS OpticalFlowTuring::GenerateExecuteInParams
         (NvOFGPUBufferHandle in_handle, NvOFGPUBufferHandle ref_handle,
          NvOFGPUBufferHandle hints_handle) {
+  // zeroing required for padding, padding2 and hPrivData
   NV_OF_EXECUTE_INPUT_PARAMS params = {};
   params.inputFrame = in_handle;
   params.referenceFrame = ref_handle;
   params.disableTemporalHints = of_params_.enable_temporal_hints ? NV_OF_FALSE : NV_OF_TRUE;
   params.externalHints = hints_handle;
-  params.padding = 0;
-  params.padding2 = 0;
-  params.hPrivData = NULL;
   return params;
 }
 

--- a/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.cc
+++ b/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.cc
@@ -184,12 +184,13 @@ void OpticalFlowTuring::SetInitParams(dali::optical_flow::OpticalFlowParams api_
 NV_OF_EXECUTE_INPUT_PARAMS OpticalFlowTuring::GenerateExecuteInParams
         (NvOFGPUBufferHandle in_handle, NvOFGPUBufferHandle ref_handle,
          NvOFGPUBufferHandle hints_handle) {
-  NV_OF_EXECUTE_INPUT_PARAMS params;
+  NV_OF_EXECUTE_INPUT_PARAMS params = {};
   params.inputFrame = in_handle;
   params.referenceFrame = ref_handle;
   params.disableTemporalHints = of_params_.enable_temporal_hints ? NV_OF_FALSE : NV_OF_TRUE;
   params.externalHints = hints_handle;
   params.padding = 0;
+  params.padding2 = 0;
   params.hPrivData = NULL;
   return params;
 }

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -261,7 +261,6 @@ class DLL_PUBLIC Buffer {
   }
 
   void reset() {
-    backend_ = Backend();
     type_ = TypeInfo::Create<NoType>();
     data_.reset();
     size_ = 0;
@@ -355,8 +354,6 @@ class DLL_PUBLIC Buffer {
   // round to 1kB
   static constexpr size_t kPadding = 1024;
 
-  Backend backend_;
-
   TypeInfo type_ = {};               // Data type of underlying storage
   shared_ptr<void> data_ = nullptr;  // Pointer to underlying storage
   Index size_ = 0;                   // The number of elements in the buffer
@@ -382,7 +379,6 @@ DLL_PUBLIC constexpr double Buffer<Backend>::kMaxGrowthFactor;
 #define USE_BUFFER_MEMBERS()           \
   using Buffer<Backend>::ResizeHelper; \
   using Buffer<Backend>::reset;        \
-  using Buffer<Backend>::backend_;     \
   using Buffer<Backend>::type_;        \
   using Buffer<Backend>::data_;        \
   using Buffer<Backend>::size_;        \

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -64,7 +64,6 @@ class Tensor : public Buffer<Backend> {
     DALI_ENFORCE(0 <= x && x < dim(0), "'x' should be valid index to first dimension: [0, dim(0))");
     Tensor<Backend> view;
     view.shape_ = shape_.last(shape_.size() - 1);
-    view.backend_ = backend_;
     view.type_ = type_;
     view.size_ = size_ / shape_[0];
     view.num_bytes_ = view.type_.size() * view.size_;
@@ -497,7 +496,6 @@ class Tensor : public Buffer<Backend> {
   Tensor<Backend>(Tensor<Backend> &&t) noexcept {
     // Steal all data and set input to default state
     shape_ = std::move(t.shape_);
-    backend_ = t.backend_;
     type_ = t.type_;
     data_ = t.data_;
     size_ = t.size_;
@@ -507,7 +505,6 @@ class Tensor : public Buffer<Backend> {
     meta_ = std::move(t.meta_);
 
     t.shape_ = TensorShape<>();
-    t.backend_ = Backend();
     t.type_ = TypeInfo::Create<NoType>();
     t.data_.reset();
     t.size_ = 0;
@@ -519,7 +516,6 @@ class Tensor : public Buffer<Backend> {
   Tensor<Backend>& operator=(Tensor<Backend> &&t) noexcept {
     if (&t != this) {
       shape_ = std::move(t.shape_);
-      backend_ = t.backend_;
       type_ = t.type_;
       data_ = t.data_;
       size_ = t.size_;
@@ -530,7 +526,6 @@ class Tensor : public Buffer<Backend> {
       pinned_ = t.pinned_;
 
       t.shape_ = TensorShape<>();
-      t.backend_ = Backend();
       t.type_ = TypeInfo::Create<NoType>();
       t.data_.reset();
       t.size_ = 0;

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -60,7 +60,6 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
     // Steal all data and set input to default state
     data_ = other.data_;
     shape_ = std::move(other.shape_);
-    backend_ = other.backend_;
     size_ = other.size_;
     offsets_ = std::move(other.offsets_);
     type_ = other.type_;
@@ -74,7 +73,6 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
 
     other.data_ = nullptr;
     other.shape_ = {};
-    other.backend_ = Backend();
     other.size_ = 0;
     other.offsets_ = {};
     other.type_ = TypeInfo::Create<NoType>();
@@ -343,7 +341,6 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
       // Steal all data and set input to default state
       data_ = other.data_;
       shape_ = std::move(other.shape_);
-      backend_ = other.backend_;
       size_ = other.size_;
       offsets_ = std::move(other.offsets_);
       type_ = other.type_;
@@ -357,7 +354,6 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
 
       other.data_ = nullptr;
       other.shape_ = {};
-      other.backend_ = Backend();
       other.size_ = 0;
       other.offsets_ = {};
       other.type_ = TypeInfo::Create<NoType>();


### PR DESCRIPTION
16317403 - Initializer list has tricky lifetime
16358933 - unitialized padding2 in params + zero initialize
16358934 - Proper order of initialization in OptFlow
16512125 - Pass convert to constructor so it's initialized during run
16358935 remove unused Buffer::backend_

#### Why we need this PR?
Fixes reported bugs with high severity.

#### What happened in this PR? 
 - What solution was applied:
     Bugs fixed
 - Affected modules and functionalities:
     varous
 - Key points relevant for the review:
     Verify if actually fixed
 - Validation and testing:
     CI
 - Documentation (including examples):
     N/A


**JIRA TASK**: *[DALI-1724]*
