### PR TITLE
transforms.Rotation to accept scalar inputs

### DIFF
--- a/dali/operators/geometry/affine_transforms/transform_base_op.h
+++ b/dali/operators/geometry/affine_transforms/transform_base_op.h
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 #include "dali/core/format.h"
+#include "dali/core/error_handling.h"
 #include "dali/core/geom/mat.h"
 #include "dali/core/static_switch.h"
 #include "dali/kernels/kernel_manager.h"
@@ -50,10 +51,13 @@ void ReadArgInput(std::vector<T> &out, const std::string &arg_name,
                   const OpSpec &spec, const workspace_t<CPUBackend> &ws) {
   const auto& arg_in = ws.ArgumentInput(arg_name);
   auto arg_in_view = view<const float>(arg_in);
-  DALI_ENFORCE(is_uniform(arg_in_view.shape),
-    make_string("All samples in argument ``", arg_name, "`` should have the same shape"));
-  DALI_ENFORCE(arg_in_view.shape.sample_dim() <= 1,
-    make_string("``", arg_name, "`` must be a scalar or a 1D tensor"));
+  DALI_ENFORCE(is_uniform(arg_in_view.shape) && volume(arg_in_view.shape[0]) == 1,
+    make_string("``", arg_name, "`` must be a scalar or a 1D tensor with a single element"));
+  if (arg_in_view.shape.sample_dim() > 0) {
+    DALI_WARN_ONCE("Warning: \"", arg_name, "\""
+                   " expected a scalar but received a 1D tensor with a single "
+                   "element. Please use a scalar instead.");
+  }
 
   auto nsamples = arg_in_view.size();
   out.resize(nsamples);

--- a/dali/operators/geometry/affine_transforms/transform_base_op.h
+++ b/dali/operators/geometry/affine_transforms/transform_base_op.h
@@ -52,8 +52,8 @@ void ReadArgInput(std::vector<T> &out, const std::string &arg_name,
   auto arg_in_view = view<const float>(arg_in);
   DALI_ENFORCE(is_uniform(arg_in_view.shape),
     make_string("All samples in argument ``", arg_name, "`` should have the same shape"));
-  DALI_ENFORCE(arg_in_view.shape.sample_dim() == 1,
-    make_string("``", arg_name, "`` must be a 1D tensor"));
+  DALI_ENFORCE(arg_in_view.shape.sample_dim() <= 1,
+    make_string("``", arg_name, "`` must be a scalar or a 1D tensor"));
 
   auto nsamples = arg_in_view.size();
   out.resize(nsamples);

--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -124,9 +124,9 @@ void ThreadPool::ThreadMain(int thread_id, int device_id, bool set_affinity) {
         if ((size_t)thread_id < vec.size()) {
           core = std::stoi(vec[thread_id]);
         } else {
-          DALI_WARN("DALI_AFFINITY_MASK environment variable is set, " +
-                    "but does not have enough entries: " + "thread_id (" + to_string(thread_id) +
-                    ") vs #entries (" + to_string(vec.size()) + "). Ignoring...");
+          DALI_WARN("DALI_AFFINITY_MASK environment variable is set, "
+                    "but does not have enough entries: thread_id (", thread_id,
+                    ") vs #entries (", vec.size(), "). Ignoring...");
         }
       }
       nvml::SetCPUAffinity(core);

--- a/dali/test/python/test_operator_affine_transforms.py
+++ b/dali/test/python/test_operator_affine_transforms.py
@@ -25,22 +25,24 @@ from nose.tools import raises
 
 from scipy.spatial.transform import Rotation as scipy_rotate
 
-def check_results(T1, batch_size, mat_ref, T0=None, reverse=False, rtol=1e-7):
+def check_results_sample(T1, mat_ref, T0=None, reverse=False, rtol=1e-7):
     ndim = mat_ref.shape[0] - 1
+    ref_T1 = None
     if T0 is not None:
-        for idx in range(batch_size):
-            mat_T0 = np.identity(ndim+1)
-            mat_T0[:ndim, :] = T0.at(idx)
-            if reverse:
-                mat_T1 = np.dot(mat_T0, mat_ref)
-            else:
-                mat_T1 = np.dot(mat_ref, mat_T0)
-            ref_T1 = mat_T1[:ndim, :]
-            assert np.allclose(T1.at(idx), ref_T1, rtol=rtol)
+        mat_T0 = np.identity(ndim+1)
+        mat_T0[:ndim, :] = T0
+        if reverse:
+            mat_T1 = np.dot(mat_T0, mat_ref)
+        else:
+            mat_T1 = np.dot(mat_ref, mat_T0)
+        ref_T1 = mat_T1[:ndim, :]
     else:
         ref_T1 = mat_ref[:ndim, :]
-        for idx in range(batch_size):
-            assert np.allclose(T1.at(idx), ref_T1, rtol=rtol)
+    assert np.allclose(T1, ref_T1, rtol=rtol)
+
+def check_results(T1, batch_size, mat_ref, T0=None, reverse=False, rtol=1e-7):
+    for idx in range(batch_size):
+        check_results_sample(T1.at(idx), mat_ref, T0.at(idx) if T0 is not None else None, reverse, rtol)
 
 def translate_affine_mat(offset):
     ndim = len(offset)
@@ -145,31 +147,56 @@ def rotate_affine_mat(angle, axis = None, center = None):
 
     return affine_mat
 
-def check_transform_rotation_op(angle, axis=None, center=None, has_input = False, reverse_order=False, batch_size=1, num_threads=4, device_id=0):
+def check_transform_rotation_op(angle=None, axis=None, center=None, has_input = False,
+                                reverse_order=False, batch_size=1, num_threads=4, device_id=0):
     assert axis is None or len(axis) == 3
     ndim = 3 if axis is not None else 2
     assert center is None or len(center) == ndim
+    random_angle = angle is None
 
-    pipe = Pipeline(batch_size=batch_size, num_threads=num_threads, device_id=device_id)
+    pipe = Pipeline(batch_size=batch_size, num_threads=num_threads, device_id=device_id, seed=12345)
     with pipe:
+        outputs = []
+        if random_angle:
+            angle = fn.uniform(range=(-90, 90))
+
         if has_input:
             T0 = fn.uniform(range=(-1, 1), shape=(ndim, ndim+1), seed = 1234)
             T1 = fn.transforms.rotation(T0, device='cpu', angle=angle, axis=axis, center=center, reverse_order=reverse_order)
-            pipe.set_outputs(T1, T0)
+            outputs = [T1, T0]
         else:
             T1 = fn.transforms.rotation(device='cpu', angle=angle, axis=axis, center=center)
-            pipe.set_outputs(T1)
+            outputs = [T1]
+
+        if random_angle:
+            outputs.append(angle)
+
+        pipe.set_outputs(*outputs)
     pipe.build()
     outs = pipe.run()
-    ref_mat = rotate_affine_mat(angle=angle, axis=axis, center=center)
-    T0 = outs[1] if has_input else None
-    check_results(outs[0], batch_size, ref_mat, T0, reverse_order, rtol=1e-5)
+    out_idx = 1
+    out_T0 = None
+    out_angle = None
+    if has_input:
+        out_T0 = outs[out_idx]
+        out_idx = out_idx + 1
+    if random_angle:
+        out_angle = outs[out_idx]
+        out_idx = out_idx + 1
+    for idx in range(batch_size):
+        T0 = out_T0.at(idx) if has_input else None
+        angle = out_angle.at(idx) if random_angle else angle
+        ref_mat = rotate_affine_mat(angle=angle, axis=axis, center=center)
+        check_results_sample(outs[0].at(idx), ref_mat, T0, reverse_order, rtol=1e-5)
 
 def test_transform_rotation_op(batch_size=3, num_threads=4, device_id=0):
-    for angle, axis, center in [(30.0, None, None),
+    for angle, axis, center in [(None, None, None),
+                                (30.0, None, None),
+                                (None, None, (1.0, 0.5)),
                                 (30.0, None, (1.0, 0.5)),
                                 (40.0, (0.4, 0.3, 0.1), None),
-                                (40.0, (0.4, 0.3, 0.1), (1.0, -0.4, 10.0))]:
+                                (40.0, (0.4, 0.3, 0.1), (1.0, -0.4, 10.0)),
+                                (None, (0.4, 0.3, 0.1), (1.0, -0.4, 10.0))]:
         for has_input in [False, True]:
             for reverse_order in [False, True] if has_input else [False]:
                 yield check_transform_rotation_op, angle, axis, center, has_input, reverse_order, \

--- a/dali/util/nvml_wrap.cc
+++ b/dali/util/nvml_wrap.cc
@@ -67,7 +67,7 @@ nvmlReturn_t nvmlInitChecked() {
   symbolsLoaded = true;
   nvmlReturn_t ret = nvmlInit();
   if (ret != NVML_SUCCESS) {
-    DALI_WARN("nvmlInitChecked failed: " + nvmlErrorString(ret));
+    DALI_WARN("nvmlInitChecked failed: ", nvmlErrorString(ret));
   }
   return ret;
 }

--- a/include/dali/core/error_handling.h
+++ b/include/dali/core/error_handling.h
@@ -15,6 +15,8 @@
 #ifndef DALI_CORE_ERROR_HANDLING_H_
 #define DALI_CORE_ERROR_HANDLING_H_
 
+#include "dali/core/format.h"
+
 #ifndef _MSC_VER
   #if defined(__AARCH64_QNX__) || defined(__AARCH64_GNU__) || defined(__aarch64__)
      #define DALI_USE_STACKTRACE 0
@@ -245,9 +247,15 @@ inline dali::string GetStacktrace() {
     std::cerr << DALI_MESSAGE_WITH_STACKTRACE(str) << std::endl; \
   } while (0)
 
-#define DALI_WARN(str)                           \
-  do {                                           \
-    std::cerr << DALI_MESSAGE(str) << std::endl; \
+#define DALI_WARN(...)                                                      \
+  do {                                                                      \
+    std::cerr << DALI_MESSAGE(dali::make_string(__VA_ARGS__)) << std::endl; \
+  } while (0)
+
+#define DALI_WARN_ONCE(...)                                                          \
+  do {                                                                               \
+    static int dummy =                                                               \
+        (std::cerr << DALI_MESSAGE(dali::make_string(__VA_ARGS__)) << std::endl, 0); \
   } while (0)
 
 void DALIReportFatalProblem(const char *file, int line, const char *pComment);


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in ``transforms.Rotation`` to be able to accept scalar as an ``angle`` argument input

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Remove ndim == 1 constraint*
 - Affected modules and functionalities:
     *transforms.Rotation*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *Tests added*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1747]*
