### PR TITLE
Fix CPU only mode in C API

### DIFF
--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -644,4 +644,14 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
   }
 }
 
+TYPED_TEST(CApiTest, CpuOnlyTest) {
+  dali::Pipeline pipe(1, 1, dali::CPU_ONLY_DEVICE_ID);
+  pipe.AddExternalInput("dummy");
+  std::vector<std::pair<std::string, std::string>> outputs = {{"dummy", "cpu"}};
+  pipe.SetOutputNames(outputs);
+  std::string ser = pipe.SerializeToProtobuf();
+  daliPipelineHandle handle;
+  daliDeserializeDefault(&handle, ser.c_str(), ser.size());
+}
+
 }  // namespace dali

--- a/qa/TL0_cpu_only/test.sh
+++ b/qa/TL0_cpu_only/test.sh
@@ -9,6 +9,30 @@ test_body() {
   export LD_LIBRARY_PATH=""
   export PATH=${PATH/cuda/}
   nosetests --verbose test_dali_cpu_only.py
+
+  for BINNAME in \
+    "dali_core_test.bin" \
+    "dali_kernel_test.bin" \
+    "dali_test.bin" \
+    "dali_operator_test.bin"
+  do
+    for DIRNAME in \
+      "../../build/dali/python/nvidia/dali" \
+      "$(python -c 'import os; from nvidia import dali; print(os.path.dirname(dali.__file__))' 2>/dev/null || echo '')"
+    do
+        if [ -x "$DIRNAME/test/$BINNAME" ]; then
+            FULLPATH="$DIRNAME/test/$BINNAME"
+            break
+        fi
+    done
+
+    if [[ -z "$FULLPATH" ]]; then
+        echo "ERROR: $BINNAME not found"
+        exit 1
+    fi
+
+    "$FULLPATH" --gtest_filter="*CpuOnlyTest*"
+  done
 }
 
 pushd ../..


### PR DESCRIPTION
- remove stream creation for the CPU only mode in C API

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a CPU only mode in C API

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
      remove stream creation for the CPU only mode in C API
 - Affected modules and functionalities:
     C API
 - Key points relevant for the review:
     NA
 - Validation and testing:
     a test case is added
 - Documentation (including examples):
     NA

Fixes https://github.com/NVIDIA/DALI/issues/2495

**JIRA TASK**: *[NA]*
