### PR TITLE
Reenable nvJPEG2000

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,7 @@ endif()
 # nvjpeg2k is not available prior CUDA 11.0
 if(${CUDA_VERSION} VERSION_GREATER_EQUAL "11.0")
   if(NOT (${ARCH} MATCHES "aarch64"))
-    # due to some decoding problems disable nvJPEG2K support for now by the default
-    cmake_dependent_option(BUILD_NVJPEG2K "Build with nvJPEG2K support" OFF
+    cmake_dependent_option(BUILD_NVJPEG2K "Build with nvJPEG2K support" ON
                            "NOT BUILD_DALI_NODEPS" OFF)
   endif()
 endif()

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg2k_helper.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg2k_helper.h
@@ -15,7 +15,7 @@
 #ifndef DALI_OPERATORS_DECODER_NVJPEG_DECOUPLED_API_NVJPEG2K_HELPER_H_
 #define DALI_OPERATORS_DECODER_NVJPEG_DECOUPLED_API_NVJPEG2K_HELPER_H_
 
-#ifdef BUILD_NVJPEG2K_ENABLED
+#ifdef NVJPEG2K_ENABLED
 
 #include <nvjpeg2k.h>
 #include <string>
@@ -95,6 +95,6 @@ struct NvJPEG2KDecodeState : public UniqueHandle<nvjpeg2kDecodeState_t, NvJPEG2K
 
 }  // namespace dali
 
-#endif  // BUILD_NVJPEG2K_ENABLED
+#endif  // NVJPEG2K_ENABLED
 
 #endif  // DALI_OPERATORS_DECODER_NVJPEG_DECOUPLED_API_NVJPEG2K_HELPER_H_

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api_test.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api_test.cc
@@ -287,8 +287,8 @@ TEST_F(Nvjpeg2kTest, UtilizationTest) {
   auto nsamples_nvjpeg2k = node->op->GetDiagnostic<int64_t>("nsamples_nvjpeg2k");
   auto nsamples_host = node->op->GetDiagnostic<int64_t>("nsamples_host");
 #ifdef BUILD_NVJPEG2K_ENABLED
-  EXPECT_EQ(nsamples_nvjpeg2k, 14);
-  EXPECT_EQ(nsamples_host, 7);
+  EXPECT_EQ(nsamples_nvjpeg2k, 21);
+  EXPECT_EQ(nsamples_host, 0);
 #else
   EXPECT_EQ(nsamples_nvjpeg2k, 0);
   EXPECT_EQ(nsamples_host, 21);

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api_test.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api_test.cc
@@ -286,13 +286,13 @@ TEST_F(Nvjpeg2kTest, UtilizationTest) {
   auto node = this->pipeline_.GetOperatorNode(this->decoder_name_);
   auto nsamples_nvjpeg2k = node->op->GetDiagnostic<int64_t>("nsamples_nvjpeg2k");
   auto nsamples_host = node->op->GetDiagnostic<int64_t>("nsamples_host");
-#ifdef BUILD_NVJPEG2K_ENABLED
+#ifdef NVJPEG2K_ENABLED
   EXPECT_EQ(nsamples_nvjpeg2k, 21);
   EXPECT_EQ(nsamples_host, 0);
 #else
   EXPECT_EQ(nsamples_nvjpeg2k, 0);
   EXPECT_EQ(nsamples_host, 21);
-#endif  // BUILD_NVJPEG2K_ENABLED
+#endif  // NVJPEG2K_ENABLED
 }
 
 

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.cc
@@ -257,7 +257,7 @@ nvjpegPinnedAllocator_t GetPinnedAllocator() {
   return allocator;
 }
 
-#ifdef BUILD_NVJPEG2K_ENABLED
+#ifdef NVJPEG2K_ENABLED
 nvjpeg2kDeviceAllocator_t GetDeviceAllocatorNvJpeg2k() {
   nvjpeg2kDeviceAllocator_t allocator;
   allocator.device_malloc = &DeviceNew;
@@ -271,7 +271,7 @@ nvjpeg2kPinnedAllocator_t GetPinnedAllocatorNvJpeg2k() {
   allocator.pinned_free = &ReturnBufferToPool;
   return allocator;
 }
-#endif  // BUILD_NVJPEG2K_ENABLED
+#endif  // NVJPEG2K_ENABLED
 
 }  // namespace nvjpeg_memory
 

--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_memory.h
@@ -59,10 +59,10 @@ void PrintMemStats();
 nvjpegDevAllocator_t GetDeviceAllocator();
 nvjpegPinnedAllocator_t GetPinnedAllocator();
 
-#ifdef BUILD_NVJPEG2K_ENABLED
+#ifdef NVJPEG2K_ENABLED
 nvjpeg2kDeviceAllocator_t GetDeviceAllocatorNvJpeg2k();
 nvjpeg2kPinnedAllocator_t GetPinnedAllocatorNvJpeg2k();
-#endif  // BUILD_NVJPEG2K_ENABLED
+#endif  // NVJPEG2K_ENABLED
 
 }  // namespace nvjpeg_memory
 

--- a/docker/Dockerfile.cuda110.x86_64.deps
+++ b/docker/Dockerfile.cuda110.x86_64.deps
@@ -9,7 +9,8 @@ RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.0.3/local_ins
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;
 
-RUN apt-get update && \
+RUN NVJPEG2K_VERSION=0.1.0 && \
+    apt-get update && \
     apt-get install wget software-properties-common -y && \
     wget -qO - https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
     add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /" && \

--- a/docker/Dockerfile.cuda111.x86_64.deps
+++ b/docker/Dockerfile.cuda111.x86_64.deps
@@ -9,7 +9,8 @@ RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.1.1/local_ins
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;
 
-RUN apt-get update && \
+RUN NVJPEG2K_VERSION=0.1.0 && \
+    apt-get update && \
     apt-get install wget software-properties-common -y && \
     wget -qO - https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
     add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /" && \


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It reenables nvJPEG2000

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     updates nvJPEG2000 version in the dependencies
     switch nvJPEG2000 support to be on by default
 - Affected modules and functionalities:
     build system
     deps docker image
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI - current tests applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
