### PR TITLE
Make Nvjpeg2kTest more verbose

### DIFF
--- a/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api_test.cc
+++ b/dali/operators/decoder/nvjpeg/decoupled_api/nvjpeg_decoder_decoupled_api_test.cc
@@ -287,9 +287,11 @@ TEST_F(Nvjpeg2kTest, UtilizationTest) {
   auto nsamples_nvjpeg2k = node->op->GetDiagnostic<int64_t>("nsamples_nvjpeg2k");
   auto nsamples_host = node->op->GetDiagnostic<int64_t>("nsamples_host");
 #if NVJPEG2K_ENABLED
+  std::cout << "Using nvJPEG2k" << std::endl;
   EXPECT_EQ(nsamples_nvjpeg2k, 21);
   EXPECT_EQ(nsamples_host, 0);
 #else
+  std::cout << "Using CPU fallback" << std::endl;
   EXPECT_EQ(nsamples_nvjpeg2k, 0);
   EXPECT_EQ(nsamples_host, 21);
 #endif  // NVJPEG2K_ENABLED


### PR DESCRIPTION
- adds a log info if nvJPEG2K is used or the test checks a CPU fallback

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It makes Nvjpeg2kTest more verbose

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a log info if nvJPEG2K is used or the test checks a CPU fallback
 - Affected modules and functionalities:
     nvjpeg_decoder_decoupled_api_test.cc
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CUDA 10 and CUDA 11 build
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
