### PR TITLE
Makes sure that cuFile and nvJPEG2k are not possible to set when not supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,13 @@ if(${CUDA_VERSION} VERSION_GREATER_EQUAL "11.0")
   if(NOT (${ARCH} MATCHES "aarch64"))
     cmake_dependent_option(BUILD_NVJPEG2K "Build with nvJPEG2K support" ON
                            "NOT BUILD_DALI_NODEPS" OFF)
+  else()
+    # make sure that even is set by -DBUILD_NVJPEG2K it will be unset as not suppported
+    unset(BUILD_NVJPEG2K CACHE)
   endif()
+else()
+  # make sure that even is set by -DBUILD_NVJPEG2K it will be unset as not suppported
+  unset(BUILD_NVJPEG2K CACHE)
 endif()
 
 cmake_dependent_option(BUILD_NVOF "Build with NVIDIA OPTICAL FLOW SDK support" ON
@@ -94,6 +100,9 @@ cmake_dependent_option(BUILD_NVML "Build with NVIDIA Management Library (NVML) s
 if(NOT (${ARCH} MATCHES "aarch64"))
   cmake_dependent_option(BUILD_CUFILE "Build with cufile (GPU Direct Storage) support" OFF
                          "NOT BUILD_DALI_NODEPS" OFF)
+else()
+  # make sure that even is set by -DBUILD_CUFILE it will be unset as not suppported
+  unset(BUILD_CUFILE CACHE)
 endif()
 
 if (BUILD_DALI_NODEPS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,14 +80,9 @@ if ("${BUILD_NVJPEG2K}" STREQUAL "")
   unset(BUILD_NVJPEG2K CACHE)
 endif()
 # nvjpeg2k is not available prior CUDA 11.0
-if(${CUDA_VERSION} VERSION_GREATER_EQUAL "11.0")
-  if(NOT (${ARCH} MATCHES "aarch64"))
-    cmake_dependent_option(BUILD_NVJPEG2K "Build with nvJPEG2K support" ON
-                           "NOT BUILD_DALI_NODEPS" OFF)
-  else()
-    # make sure that even is set by -DBUILD_NVJPEG2K it will be unset as not suppported
-    unset(BUILD_NVJPEG2K CACHE)
-  endif()
+if(${CUDA_VERSION} VERSION_GREATER_EQUAL "11.0" AND NOT ${ARCH} MATCHES "aarch64" )
+  cmake_dependent_option(BUILD_NVJPEG2K "Build with nvJPEG2K support" ON
+                          "NOT BUILD_DALI_NODEPS" OFF)
 else()
   # make sure that even is set by -DBUILD_NVJPEG2K it will be unset as not suppported
   unset(BUILD_NVJPEG2K CACHE)


### PR DESCRIPTION
- even if cuFile and nvJPEG2k are not available as not supported for given platform the user can still set them by -D... and break the build. This change unsets these variables when they are not supposed to be supported

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It makes sure that cuFile and nvJPEG2k are not possible to set when not supported

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     unsets BUILD_CUFILE and BUILD_NVJPEG2K variables when they are not supposed to be supported
 - Affected modules and functionalities:
     main CMake
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
