### PR TITLE
Fix build for Jetson platform

### DIFF
--- a/dali/operators/reader/loader/coco_loader.h
+++ b/dali/operators/reader/loader/coco_loader.h
@@ -67,6 +67,8 @@ inline bool HasSavePreprocessedAnnotationsDir(const OpSpec &spec) {
 struct RLEMask : public UniqueHandle<RLE, RLEMask> {
   DALI_INHERIT_UNIQUE_HANDLE(RLE, RLEMask)
 
+  constexpr inline RLEMask() : UniqueHandle() {}
+
   RLEMask(siz h, siz w, siz m) {
     rleInit(&handle_, h, w, m, nullptr);
   }

--- a/docker/Dockerfile.build.aarch64-linux
+++ b/docker/Dockerfile.build.aarch64-linux
@@ -33,7 +33,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get install -y python3.9 python3.9-dev && \
     rm -rf /var/lib/apt/lists/* && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm get-pip.py && \
-    pip install clang libclang && \
+    # decouple libclang and clang installation so libclang changes are not overriden by clang
+    pip install clang && pip install libclang && \
     rm -rf /root/.cache/pip/ && \
     cd /tmp && git clone https://github.com/NixOS/patchelf && cd patchelf && \
     ./bootstrap.sh && ./configure --prefix=/usr/ && make -j install && cd / && rm -rf /tmp/patchelf && \

--- a/docker/Dockerfile.build.aarch64-qnx
+++ b/docker/Dockerfile.build.aarch64-qnx
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py && rm get-pip.py && \
-    pip install clang libclang && \
+    # decouple libclang and clang installation so libclang changes are not overriden by clang
+    pip install clang && pip install libclang && \
     rm -rf /root/.cache/pip/
 
 COPY --from=qnx_cuda_tools /qnx /qnx


### PR DESCRIPTION
- as libclang overwrites clang default path and library name when clang is installed as the last one it will change back what libclang did. This change makes sure that libclang is installed as the last one
- adds a default constructor to RLEMask class to make QNX compiler happy

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes python clang error in builds for Jetson platform

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     as libclang overwrites clang default path and library name when clang is installed as the last one it will change back what libclang did. This change makes sure that libclang is installed as the last one
     adds a default constructor to RLEMask class to make QNX compiler happy
 - Affected modules and functionalities:
     Dockerfile.build.aarch64-linux
     Dockerfile.build.aarch64-qnx
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
