### PR TITLE
Disable GPU numpy reader test form sm < 6.0

### DIFF
--- a/qa/TL0_python-self-test/test_nofw.sh
+++ b/qa/TL0_python-self-test/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy>=1.17 opencv-python pillow librosa scipy"
+pip_packages="nose numpy>=1.17 opencv-python pillow librosa scipy nvidia-ml-py==11.450.51"
 
 target_dir=./dali/test/python
 

--- a/qa/TL1_python-self-test-slow/test.sh
+++ b/qa/TL1_python-self-test-slow/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy opencv-python pillow librosa scipy"
+pip_packages="nose numpy opencv-python pillow librosa scipy nvidia-ml-py==11.450.51"
 target_dir=./dali/test/python
 
 test_body() {

--- a/qa/TL1_python-self-test_conda/test_nofw.sh
+++ b/qa/TL1_python-self-test_conda/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy>=1.17 opencv-python pillow librosa scipy"
+pip_packages="nose numpy>=1.17 opencv-python pillow librosa scipy nvidia-ml-py==11.450.51"
 target_dir=./dali/test/python
 
 # test_body definition is in separate file so it can be used without setup


### PR DESCRIPTION
- GDS beta is not supported for sm < 6.0 so disable GPU numpy reader test for that platform

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It disables GPU numpy reader test form sm < 6.0

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     GDS beta is not supported for sm < 6.0 so disable GPU numpy reader test for that platform
 - Affected modules and functionalities:
     tests
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
