### PR TITLE
Add GTest Event Listener with CUDA validation after TEST

### DIFF
--- a/dali/core/dali_core_test.cc
+++ b/dali/core/dali_core_test.cc
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include "dali/test/dali_cuda_finalize_test.h"
+
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_core_test_force_tls_align;
@@ -25,5 +27,11 @@ void __dali_core_test_force_tls_align_fun(void) {
 int main(int argc, char **argv) {
   __dali_core_test_force_tls_align_fun();
   ::testing::InitGoogleTest(&argc, argv);
+
+  // Gets hold of the event listener list.
+  ::testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+  // Adds a listener to the end.  googletest takes the ownership.
+  listeners.Append(new dali::CudaFinalizeEventListener);
+
   return RUN_ALL_TESTS();
 }

--- a/dali/kernels/dali_kernel_test.cc
+++ b/dali/kernels/dali_kernel_test.cc
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include "dali/test/dali_cuda_finalize_test.h"
+
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_kernel_test_force_tls_align;
@@ -25,5 +27,11 @@ void __dali_kernel_test_force_tls_align_fun(void) {
 int main(int argc, char **argv) {
   __dali_kernel_test_force_tls_align_fun();
   ::testing::InitGoogleTest(&argc, argv);
+
+  // Gets hold of the event listener list.
+  ::testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+  // Adds a listener to the end.  googletest takes the ownership.
+  listeners.Append(new dali::CudaFinalizeEventListener);
+
   return RUN_ALL_TESTS();
 }

--- a/dali/operators/dali_operator_test.cc
+++ b/dali/operators/dali_operator_test.cc
@@ -17,6 +17,7 @@
 #include "dali/pipeline/init.h"
 #include "dali/pipeline/data/allocator.h"
 #include "dali/pipeline/operator/op_spec.h"
+#include "dali/test/dali_cuda_finalize_test.h"
 #include "dali/test/dali_test_config.h"
 
 // add this alignment to work around a patchelf bug/feature which
@@ -34,6 +35,11 @@ int main(int argc, char **argv) {
                  dali::OpSpec("PinnedCPUAllocator"),
                  dali::OpSpec("GPUAllocator"));
   ::testing::InitGoogleTest(&argc, argv);
+
+  // Gets hold of the event listener list.
+  ::testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+  // Adds a listener to the end.  googletest takes the ownership.
+  listeners.Append(new dali::CudaFinalizeEventListener);
 
   return RUN_ALL_TESTS();
 }

--- a/dali/test/dali_cuda_finalize_test.h
+++ b/dali/test/dali_cuda_finalize_test.h
@@ -17,6 +17,8 @@
 
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
+#include <cstring>
+
 #include "dali/core/cuda_utils.h"
 
 namespace dali {
@@ -33,12 +35,14 @@ namespace dali {
  */
 class CudaFinalizeEventListener : public ::testing::EmptyTestEventListener {
   void OnTestEnd(const ::testing::TestInfo& test_info) override {
-    auto sync_result = cudaDeviceSynchronize();
-    EXPECT_EQ(sync_result, cudaSuccess) << "CUDA error: \"" << cudaGetErrorName(sync_result)
-                                        << "\" - " << cudaGetErrorString(sync_result);
-    auto err = cudaGetLastError();
-    EXPECT_EQ(err, cudaSuccess) << "CUDA error: \"" << cudaGetErrorName(err) << "\" - "
-                                << cudaGetErrorString(err);
+    if (std::strstr(test_info.test_suite_name(), "CpuOnlyTest") == nullptr) {
+      auto sync_result = cudaDeviceSynchronize();
+      EXPECT_EQ(sync_result, cudaSuccess) << "CUDA error: \"" << cudaGetErrorName(sync_result)
+                                          << "\" - " << cudaGetErrorString(sync_result);
+      auto err = cudaGetLastError();
+      EXPECT_EQ(err, cudaSuccess) << "CUDA error: \"" << cudaGetErrorName(err) << "\" - "
+                                  << cudaGetErrorString(err);
+    }
   }
 };
 

--- a/dali/test/dali_cuda_finalize_test.h
+++ b/dali/test/dali_cuda_finalize_test.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_TEST_DALI_CUDA_FINALIZE_TEST_H_
+#define DALI_TEST_DALI_CUDA_FINALIZE_TEST_H_
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include "dali/core/cuda_utils.h"
+
+namespace dali {
+
+/**
+ * @brief GoogleTest Event Listener, that checks after every Test Case if there were
+ * no CUDA related errors.
+ *
+ * We don't want to use TearDown methods that would need to be either injected into every
+ * Fixture or defined globally and would run once. Events allow us to define additional
+ * checks with any granularity we want.
+ *
+ * We can use GTest assertion macros in the events with exception of OnTestPartResult.
+ */
+class CudaFinalizeEventListener : public ::testing::EmptyTestEventListener {
+  void OnTestEnd(const ::testing::TestInfo& test_info) override {
+    auto sync_result = cudaDeviceSynchronize();
+    EXPECT_EQ(sync_result, cudaSuccess) << "CUDA error: \"" << cudaGetErrorName(sync_result)
+                                        << "\" - " << cudaGetErrorString(sync_result);
+    auto err = cudaGetLastError();
+    EXPECT_EQ(err, cudaSuccess) << "CUDA error: \"" << cudaGetErrorName(err) << "\" - "
+                                << cudaGetErrorString(err);
+  }
+};
+
+}  // namespace dali
+
+#endif  // DALI_TEST_DALI_CUDA_FINALIZE_TEST_H_

--- a/dali/test/dali_cuda_finalize_test.h
+++ b/dali/test/dali_cuda_finalize_test.h
@@ -34,6 +34,8 @@ namespace dali {
  */
 class CudaFinalizeEventListener : public ::testing::EmptyTestEventListener {
   void OnTestEnd(const ::testing::TestInfo& test_info) override {
+    // Check if the driver wrapper is initialized preventing CPU-only tests from
+    // using CUDA calls.
     if (cuInitChecked()) {
       auto sync_result = cudaDeviceSynchronize();
       EXPECT_EQ(sync_result, cudaSuccess) << "CUDA error: \"" << cudaGetErrorName(sync_result)

--- a/dali/test/dali_cuda_finalize_test.h
+++ b/dali/test/dali_cuda_finalize_test.h
@@ -17,7 +17,6 @@
 
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
-#include <cstring>
 
 #include "dali/core/cuda_utils.h"
 
@@ -35,7 +34,7 @@ namespace dali {
  */
 class CudaFinalizeEventListener : public ::testing::EmptyTestEventListener {
   void OnTestEnd(const ::testing::TestInfo& test_info) override {
-    if (std::strstr(test_info.test_suite_name(), "CpuOnlyTest") == nullptr) {
+    if (cuInitChecked()) {
       auto sync_result = cudaDeviceSynchronize();
       EXPECT_EQ(sync_result, cudaSuccess) << "CUDA error: \"" << cudaGetErrorName(sync_result)
                                           << "\" - " << cudaGetErrorString(sync_result);

--- a/dali/test/dali_test.cc
+++ b/dali/test/dali_test.cc
@@ -17,6 +17,7 @@
 #include "dali/pipeline/init.h"
 #include "dali/pipeline/data/allocator.h"
 #include "dali/pipeline/operator/op_spec.h"
+#include "dali/test/dali_cuda_finalize_test.h"
 #include "dali/test/dali_test_config.h"
 #include "dali/operators.h"
 
@@ -34,6 +35,11 @@ int main(int argc, char **argv) {
                  dali::OpSpec("PinnedCPUAllocator"),
                  dali::OpSpec("GPUAllocator"));
   ::testing::InitGoogleTest(&argc, argv);
+
+  // Gets hold of the event listener list.
+  ::testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+  // Adds a listener to the end.  googletest takes the ownership.
+  listeners.Append(new dali::CudaFinalizeEventListener);
 
   dali::InitOperatorsLib();
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- It fixes a bug/It adds new feature: Automatic error checking for CUDA after each Test Case.

#### What happened in this PR?
 - What solution was applied:
	Used event listener to allow per test case error checking without the need to modify code.
 - Affected modules and functionalities:
     GTest
 - Key points relevant for the review:
     N/A
 - Validation and testing:
     CI, adjustment in the testing framework
 - Documentation (including examples):
     N/A


**JIRA TASK**: *[Use DALI-1724 or NA]*
