### PR TITLE
Fix unchecked CUDA API calls in utility functions

### DIFF
--- a/dali/kernels/common/scatter_gather.cu
+++ b/dali/kernels/common/scatter_gather.cu
@@ -121,7 +121,7 @@ void ScatterGatherGPU::Run(cudaStream_t stream, bool reset, ScatterGatherGPU::Me
     dim3 grid(blocks_.size());
     dim3 block(std::min<size_t>(size_per_block_, 1024));
     BatchCopy<<<grid, block, 0, stream>>>(blocks_dev_.get());
-    cudaGetLastError();
+    CUDA_CALL(cudaGetLastError());
   }
 
   if (reset)

--- a/dali/kernels/common/scatter_gather.cu
+++ b/dali/kernels/common/scatter_gather.cu
@@ -14,6 +14,8 @@
 
 #include <algorithm>
 #include <cassert>
+
+#include "dali/core/cuda_error.h"
 #include "dali/kernels/common/scatter_gather.h"
 
 namespace dali {

--- a/dali/kernels/context.h
+++ b/dali/kernels/context.h
@@ -99,7 +99,7 @@ class Scratchpad {
   if_array_like<Collection, T*>
   ToGPU(cudaStream_t stream, const Collection &c) {
     T *ptr = Allocate<T>(AllocType::GPU, size(c));
-    cudaMemcpyAsync(ptr, &c[0], size(c) * sizeof(T), cudaMemcpyHostToDevice, stream);
+    CUDA_CALL(cudaMemcpyAsync(ptr, &c[0], size(c) * sizeof(T), cudaMemcpyHostToDevice, stream));
     return ptr;
   }
 

--- a/dali/kernels/scratch_copy_impl.h
+++ b/dali/kernels/scratch_copy_impl.h
@@ -146,7 +146,7 @@ ToContiguousGPUMem(Scratchpad &scratchpad, cudaStream_t stream, const Collection
   detail::copy_to_buffer(tmp, &offsets[0], c...);
   void *out_ptr = scratchpad.Alloc(AllocType::GPU, total_size, alignment);
 
-  cudaMemcpyAsync(out_ptr, tmp, total_size, cudaMemcpyHostToDevice, stream);
+  CUDA_CALL(cudaMemcpyAsync(out_ptr, tmp, total_size, cudaMemcpyHostToDevice, stream));
   return detail::GetCollectionPtrs(out_ptr, &offsets[0], c...);
 }
 

--- a/dali/operators/audio/mfcc/mfcc.cu
+++ b/dali/operators/audio/mfcc/mfcc.cu
@@ -69,7 +69,7 @@ bool MFCC<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
     output_desc = detail::SetupKernel<T>(kmgr_, ctx_, input, make_cspan(args_), axis_);
   ), DALI_FAIL(make_string("Unsupported data type: ", input.type().id())));  // NOLINT
   int64_t max_ndct = 0;
-  for (int i = 0; i < input.ntensor(); ++i) {
+  for (int i = 0; i < output_desc[0].shape.num_samples(); ++i) {
     int64_t ndct = output_desc[0].shape[i][axis_];
     if (ndct > max_ndct)
       max_ndct = ndct;

--- a/dali/operators/audio/mfcc/mfcc.cu
+++ b/dali/operators/audio/mfcc/mfcc.cu
@@ -69,7 +69,7 @@ bool MFCC<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
     output_desc = detail::SetupKernel<T>(kmgr_, ctx_, input, make_cspan(args_), axis_);
   ), DALI_FAIL(make_string("Unsupported data type: ", input.type().id())));  // NOLINT
   int64_t max_ndct = 0;
-  for (int i = 0; i < nsamples_; ++i) {
+  for (int i = 0; i < input.ntensor(); ++i) {
     int64_t ndct = output_desc[0].shape[i][axis_];
     if (ndct > max_ndct)
       max_ndct = ndct;

--- a/dali/operators/audio/mfcc/mfcc.h
+++ b/dali/operators/audio/mfcc/mfcc.h
@@ -86,7 +86,7 @@ class MFCC : public Operator<Backend> {
   using Operator<Backend>::RunImpl;
 
   void GetArguments(const workspace_t<Backend> &ws) {
-    nsamples_ = ws.template InputRef<Backend>(0).shape().size();
+    auto nsamples = ws.template InputRef<Backend>(0).shape().size();
     DctArgs arg;
     arg.ndct = spec_.template GetArgument<int>("n_mfcc");
     DALI_ENFORCE(arg.ndct > 0, "number of MFCCs should be > 0");
@@ -105,10 +105,9 @@ class MFCC : public Operator<Backend> {
 
     lifter_ = spec_.template GetArgument<float>("lifter");
     args_.clear();
-    args_.resize(nsamples_, arg);
+    args_.resize(nsamples, arg);
   }
 
-  int64_t nsamples_;
   kernels::KernelManager kmgr_;
   kernels::KernelContext ctx_;
   std::vector<DctArgs> args_;

--- a/dali/pipeline/executor/queue_policy.h
+++ b/dali/pipeline/executor/queue_policy.h
@@ -23,6 +23,7 @@
 #include <queue>
 #include <vector>
 
+#include "dali/core/cuda_error.h"
 #include "dali/pipeline/executor/queue_metadata.h"
 
 namespace dali {
@@ -284,7 +285,7 @@ struct SeparateQueuePolicy {
     if (stage == OpType::MIXED) {
       auto &command = cpu_release_commands_[idxs[OpType::CPU]];
       command = detail::ReleaseCommand{this, OpType::CPU, idxs[OpType::CPU]};
-      cudaStreamAddCallback(stage_stream, &detail::release_callback, &command, 0);
+      CUDA_CALL(cudaStreamAddCallback(stage_stream, &detail::release_callback, &command, 0));
     }
     {
       std::lock_guard<std::mutex> ready_current_lock(stage_ready_mutex_[current_stage]);

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -284,7 +284,7 @@ class ExternalSource : public Operator<Backend> {
 
       std::list<uptr_cuda_event_type> copy_to_storage_event;
       copy_to_storage_event = copy_to_storage_events_.GetEmpty();
-      cudaEventRecord(*copy_to_storage_event.front(), stream);
+      CUDA_CALL(cudaEventRecord(*copy_to_storage_event.front(), stream));
       copy_to_storage_events_.PushBack(copy_to_storage_event);
 
       if (zero_copy_noncontiguous_gpu_input_) {
@@ -327,7 +327,7 @@ class ExternalSource : public Operator<Backend> {
     tv_elm.front()->Copy(batch, stream);
     // if copying from GPU to CPU always synchronize
     if (std::is_same<SrcBackend, GPUBackend>::value) {
-      cudaStreamSynchronize(stream);
+      CUDA_CALL(cudaStreamSynchronize(stream));
     }
 
     {
@@ -353,11 +353,11 @@ class ExternalSource : public Operator<Backend> {
     // - GPU -> GPU
     // - pinned CPU -> GPU
     if (std::is_same<SrcBackend, GPUBackend>::value || batch.is_pinned()) {
-      cudaEventRecord(*copy_to_storage_event.front(), stream);
+      CUDA_CALL(cudaEventRecord(*copy_to_storage_event.front(), stream));
     }
     // if copying from non pinned CPU it happens on the stream 0
     if (std::is_same<SrcBackend, CPUBackend>::value && !batch.is_pinned()) {
-      cudaEventRecord(*copy_to_storage_event.front(), 0);
+      CUDA_CALL(cudaEventRecord(*copy_to_storage_event.front(), 0));
     }
     if (sync) {
       CUDA_CALL(cudaEventSynchronize(*copy_to_storage_event.front()));

--- a/dali/pipeline/util/stream_pool.h
+++ b/dali/pipeline/util/stream_pool.h
@@ -61,7 +61,7 @@ class StreamPool {
       cudaStream_t new_stream;
       // Note: Why is device tracked? Is StreamPool intended to be used across devices?
       int dev;
-      cudaGetDevice(&dev);
+      CUDA_CALL(cudaGetDevice(&dev));
       int flags = non_blocking_ ? cudaStreamNonBlocking : cudaStreamDefault;
       CUDA_CALL(cudaStreamCreateWithPriority(&new_stream, flags, default_cuda_stream_priority_));
       streams_.push_back(new_stream);

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -493,7 +493,7 @@ void ExposeTensor(py::module &m) {
                 : static_cast<cudaStream_t>(ctypes_void_ptr(cuda_stream));
           CopyToExternal(ptr, kernels::AllocType::GPU, t, stream, use_copy_kernel);
           if (!non_blocking) {
-            cudaStreamSynchronize(stream);
+            CUDA_CALL(cudaStreamSynchronize(stream));
           }
         },
       "ptr"_a,
@@ -871,7 +871,7 @@ void ExposeTensorList(py::module &m) {
                 : static_cast<cudaStream_t>(ctypes_void_ptr(cuda_stream));
           CopyToExternal(ptr, AllocType::GPU, t, stream, use_copy_kernel);
           if (!non_blocking) {
-            cudaStreamSynchronize(stream);
+            CUDA_CALL(cudaStreamSynchronize(stream));
           }
         },
       "ptr"_a,

--- a/dali/test/test_tensors.h
+++ b/dali/test/test_tensors.h
@@ -54,7 +54,7 @@ class TestTensorList {
       char *ptr = new char[size];
       cpumem_ = { ptr, CPUDeleter };
       if (gpumem_)
-        cudaMemcpyAsync(ptr, gpumem_.get(), size, cudaMemcpyDeviceToHost, stream);
+        CUDA_CALL(cudaMemcpyAsync(ptr, gpumem_.get(), size, cudaMemcpyDeviceToHost, stream));
     }
     auto out_shape = convert_dim<out_dim>(shape_);
     return { reinterpret_cast<T*>(cpumem_.get()), std::move(out_shape) };
@@ -69,7 +69,7 @@ class TestTensorList {
       CUDA_CALL(cudaMalloc(reinterpret_cast<void**>(&ptr), size));
       gpumem_ = { ptr, GPUDeleter };
       if (cpumem_)
-        cudaMemcpyAsync(ptr, cpumem_.get(), size, cudaMemcpyHostToDevice, stream);
+        CUDA_CALL(cudaMemcpyAsync(ptr, cpumem_.get(), size, cudaMemcpyHostToDevice, stream));
     }
     auto out_shape = convert_dim<out_dim>(shape_);
     return { reinterpret_cast<T*>(gpumem_.get()), std::move(out_shape) };
@@ -98,10 +98,10 @@ class TestTensorList {
     delete [] mem;
   }
   static void PinnedDeleter(char *mem) {
-    cudaFreeHost(mem);
+    CUDA_CALL(cudaFreeHost(mem));
   }
   static void GPUDeleter(char *mem) {
-    cudaFree(mem);
+    CUDA_CALL(cudaFree(mem));
   }
 
   std::unique_ptr<char, Deleter> cpumem_{nullptr, CPUDeleter}, gpumem_{nullptr, GPUDeleter};

--- a/include/dali/core/cuda_utils.h
+++ b/include/dali/core/cuda_utils.h
@@ -84,7 +84,7 @@ int MaxThreadsPerBlock(KernelFunction *f) {
   static constexpr int kMaxDevices = 1024;
   static int max_block_size[kMaxDevices] = {};
   int device = 0;
-  cudaGetDevice(&device);
+  CUDA_CALL(cudaGetDevice(&device));
   assert(device >= 0 && device < kMaxDevices);
   if (!max_block_size[device]) {
     cudaFuncAttributes attr = {};

--- a/include/dali/core/dev_buffer.h
+++ b/include/dali/core/dev_buffer.h
@@ -148,7 +148,7 @@ struct DeviceBuffer {
 
   static std::unique_ptr<T, std::function<void(T*)>> allocate(size_t count) {
     T *ptr = nullptr;
-    cudaMalloc(reinterpret_cast<void**>(&ptr), count * sizeof(T));
+    CUDA_CALL(cudaMalloc(reinterpret_cast<void**>(&ptr), count * sizeof(T)));
     if (!ptr)
       throw std::bad_alloc();
     return { ptr, [](T* ptr) { cudaFree(ptr); } };


### PR DESCRIPTION
16512016, 16512037, 16512220, 16512041, ....

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Sprinkle the utility functions with CUDA_CALL(...);

#### What happened in this PR?
 - What solution was applied: CUDA_CALL(...) when sensible
 - Affected modules and functionalities:
     only utils, the `*_test.*` and `operators/**` are checked already and `kernels/**` are the responsibility of the user  
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NO

**JIRA TASK**: *[Use DALI-1724 or NA]*
