### PR TITLE
Cleanup warnings in CUDA code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,8 +235,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   if (DALI_CLANG_ONLY)
     # std::abs have no effect on unsigned value in a templated call
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-absolute-value")
-    #
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format")
     # convert.h when the bigger values are not representable
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-implicit-int-float-conversion")
     # Some aggregate constructors with inner object suggest double braces
@@ -245,7 +243,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch")
     # TYPE_SWITCH over bool exists in the wild
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch-bool")
-    # Build compatiblity with omp switches
+    # CUDA flags are passed to .cc files and are ignored
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,10 +233,20 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 
   # TODO(klecki): Plethora of warnings that should be adressed as a followup
   if (DALI_CLANG_ONLY)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch-bool -Wno-sign-compare -Wno-missing-braces -Wno-absolute-value")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format -Wno-inconsistent-missing-override -Wno-implicit-int-float-conversion")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-mismatched-tags -Wno-reorder-ctor -Wno-unused-command-line-argument")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-defaulted-function-deleted -Wno-switch -Wno-cuda-compat -Wno-unused-private-field")
+    # std::abs have no effect on unsigned value in a templated call
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-absolute-value")
+    #
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format")
+    # convert.h when the bigger values are not representable
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-implicit-int-float-conversion")
+    # Some aggregate constructors with inner object suggest double braces
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
+    # Reductions do not cover all enum values
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch")
+    # TYPE_SWITCH over bool exists in the wild
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch-bool")
+    # Build compatiblity with omp switches
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
   endif()
 
   # CUDA does not support current Clang as host compiler, we need use gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch-bool")
     # CUDA flags are passed to .cc files and are ignored
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
+    # Ignore warnings coming from cutlass
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --system-header-prefix=cutlass/")
   endif()
 
   # CUDA does not support current Clang as host compiler, we need use gcc

--- a/dali/core/convert_cuda_test.cu
+++ b/dali/core/convert_cuda_test.cu
@@ -47,7 +47,7 @@ DEVICE_TEST(ConvertSatCUDA_Dev, fp2int64, 1, 1) {
   DEV_EXPECT_EQ(ConvertSat<int64_t>(2e+20f), 0x7fffffffffffffffll);
   DEV_EXPECT_EQ(ConvertSat<int64_t>(-2e+20f), ~0x7fffffffffffffffll);
   DEV_EXPECT_EQ(ConvertSat<uint64_t>(2e+20f), 0xffffffffffffffffull);
-  DEV_EXPECT_EQ(ConvertSat<uint64_t>(-1.0f), 0);
+  DEV_EXPECT_EQ(ConvertSat<uint64_t>(-1.0f), 0u);
 }
 
 DEVICE_TEST(ConvertNormCUDA_Dev, float2int, 1, 1) {
@@ -85,7 +85,7 @@ DEVICE_TEST(ConvertSatNorm_Dev, float2int, 1, 1) {
 
   DEV_EXPECT_GE(ConvertSatNorm<int64_t>(2.0f),  0x7fffff8000000000);
   DEV_EXPECT_LE(ConvertSatNorm<int64_t>(-2.0f), -0x7fffff8000000000);
-  DEV_EXPECT_EQ(ConvertSatNorm<uint64_t>(-2.0f), 0);
+  DEV_EXPECT_EQ(ConvertSatNorm<uint64_t>(-2.0f), 0u);
 }
 
 TEST(ConvertNorm_CUDA_Host, int2float) {

--- a/dali/core/fast_div_test.cu
+++ b/dali/core/fast_div_test.cu
@@ -130,7 +130,7 @@ DEVICE_TEST(FastDiv, DISABLED_U64_GPU_Slow, dim3(1<<10, 1<<10), (1<<10)) {
     auto ref = value / divisor;
     auto result = value / fast;
     if (result != ref) {
-      printf("%lld / %lld   got %lld expected %lld\n", value, divisor, result, ref);
+      printf("%lu / %lu   got %lu expected %lu\n", value, divisor, result, ref);
       DEV_ASSERT_EQ(result, ref);
     }
   }
@@ -175,7 +175,7 @@ DEVICE_TEST(FastDiv, U64_GPU, dim3(1<<10, 11), (1<<10)) {
     auto ref = value / divisor;
     auto result = value / fast;
     if (result != ref) {
-      printf("%lld / %lld   got %lld expected %lld\n", value, divisor, result, ref);
+      printf("%lu / %lu   got %lu expected %lu\n", value, divisor, result, ref);
       DEV_ASSERT_EQ(result, ref);
     }
   }

--- a/dali/core/fast_div_test.cu
+++ b/dali/core/fast_div_test.cu
@@ -130,7 +130,10 @@ DEVICE_TEST(FastDiv, DISABLED_U64_GPU_Slow, dim3(1<<10, 1<<10), (1<<10)) {
     auto ref = value / divisor;
     auto result = value / fast;
     if (result != ref) {
-      printf("%lu / %lu   got %lu expected %lu\n", value, divisor, result, ref);
+      #pragma clang diagnostic push
+      #pragma clang diagnostic ignored "-Wformat"
+      printf("%llu / %llu   got %llu expected %llu\n", value, divisor, result, ref);
+      #pragma clang diagnostic pop
       DEV_ASSERT_EQ(result, ref);
     }
   }
@@ -175,7 +178,10 @@ DEVICE_TEST(FastDiv, U64_GPU, dim3(1<<10, 11), (1<<10)) {
     auto ref = value / divisor;
     auto result = value / fast;
     if (result != ref) {
-      printf("%lu / %lu   got %lu expected %lu\n", value, divisor, result, ref);
+      #pragma clang diagnostic push
+      #pragma clang diagnostic ignored "-Wformat"
+      printf("%llu / %llu   got %llu expected %llu\n", value, divisor, result, ref);
+      #pragma clang diagnostic pop
       DEV_ASSERT_EQ(result, ref);
     }
   }

--- a/dali/core/small_vector_test.cu
+++ b/dali/core/small_vector_test.cu
@@ -18,8 +18,8 @@
 
 DEVICE_TEST(SmallVectorDev, Test, dim3(1), dim3(1)) {
   dali::SmallVector<int, 3> v;
-  DEV_EXPECT_EQ(v.capacity(), 3);
-  DEV_EXPECT_EQ(v.size(), 0);
+  DEV_EXPECT_EQ(v.capacity(), 3u);
+  DEV_EXPECT_EQ(v.size(), 0u);
   v.push_back(1);
   v.push_back(3);
   v.push_back(5);
@@ -39,7 +39,7 @@ DEVICE_TEST(SmallVectorDev, Test, dim3(1), dim3(1)) {
   DEV_EXPECT_EQ(v[6], 7);
   DEV_EXPECT_EQ(v[7], 8);
   v.erase(v.begin()+2, v.end()-2);
-  DEV_ASSERT_EQ(v.size(), 4);
+  DEV_ASSERT_EQ(v.size(), 4u);
   DEV_EXPECT_EQ(v[0], 1);
   DEV_EXPECT_EQ(v[1], 2);
   DEV_EXPECT_EQ(v[2], 7);
@@ -69,16 +69,16 @@ DEVICE_TEST(SmallVectorDev, MovePoD, 1, 1) {
 DEVICE_TEST(SmallVectorDev, Resize, 1, 1) {
   dali::SmallVector<int32_t, 4> v;
   v.resize(3, 5);
-  DEV_ASSERT_EQ(v.size(), 3);
+  DEV_ASSERT_EQ(v.size(), 3u);
   DEV_EXPECT_EQ(v[0], 5);
   DEV_EXPECT_EQ(v[1], 5);
   DEV_EXPECT_EQ(v[2], 5);
   v.resize(16, 42);
-  DEV_ASSERT_EQ(v.size(), 16);
+  DEV_ASSERT_EQ(v.size(), 16u);
   for (int i = 3; i < 16; i++)
     DEV_EXPECT_EQ(v[i], 42);
   v.resize(6);
-  DEV_EXPECT_EQ(v.size(), 6);
+  DEV_EXPECT_EQ(v.size(), 6u);
 }
 
 // NOTE: this test should compile without warnings

--- a/dali/core/utils_test.cu
+++ b/dali/core/utils_test.cu
@@ -31,14 +31,14 @@ DEVICE_TEST(CoreUtilsDev, Volume, 1, 1) {
 
 DEVICE_TEST(CoreUtilsDev, Size, 1, 1) {
   int a0[] = { 42 };
-  DEV_EXPECT_EQ(size(a0), 1);
+  DEV_EXPECT_EQ(size(a0), 1u);
   int a1[] = { 2, 3, 4 };
-  DEV_EXPECT_EQ(size(a1), 3);
+  DEV_EXPECT_EQ(size(a1), 3u);
 
   SmallVector<int, 5> v;
   v.resize(10);
-  DEV_EXPECT_EQ(v.size(), 10);
-  DEV_EXPECT_EQ(size(v), 10);
+  DEV_EXPECT_EQ(v.size(), 10u);
+  DEV_EXPECT_EQ(size(v), 10u);
 }
 
 DEFINE_TEST_KERNEL(CoreUtilsDev, Span, span<float> data) {

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.cu
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.cu
@@ -222,7 +222,7 @@ class MelFilterBankGpu<T, Dims>::Impl : public MelFilterImplBase<T, Dims> {
   void FillBlockDescsInnerFft(const T* const* in_list, T **out_list) {
     int block_id = 0;
     int sample = 0;
-    while (block_id < block_descs_.size()) {
+    while (block_id < static_cast<int>(block_descs_.size())) {
       auto sample_size = block_descs_[block_id].out_frame_size;
       auto nblocks = div_ceil(sample_size, kBlockDim1);
       for (int i = 0; i < nblocks; ++i, ++block_id) {

--- a/dali/kernels/imgproc/convolution/cutlass/device/gemm.h
+++ b/dali/kernels/imgproc/convolution/cutlass/device/gemm.h
@@ -341,9 +341,9 @@ class Conv {
           ref_Window(ref_Window_),
           ref_C(ref_C_),
           ref_D(ref_D_),
+          epilogue(epilogue_),
           planes(planes_),
-          plane_stride(plane_stride_),
-          epilogue(epilogue_) {}
+          plane_stride(plane_stride_) {}
   };
 
   struct Arguments {

--- a/dali/kernels/imgproc/convolution/cutlass/kernel/gemm.h
+++ b/dali/kernels/imgproc/convolution/cutlass/kernel/gemm.h
@@ -117,10 +117,10 @@ struct Conv {
           sample_grid_tiled_shape(sample_grid_tiled_shape),
           params_In(ref_In.layout()),
           ref_In(ref_In),
-          params_Window(layout::RowMajor(kIsInnerConv ? problem_size.n() : problem_size.m()),
-                        window_size, window_anchor, channels),
           // do not pass explicit window, we construct it later
           ref_conv_Window(ref_conv_Window),
+          params_Window(layout::RowMajor(kIsInnerConv ? problem_size.n() : problem_size.m()),
+                        window_size, window_anchor, channels),
           params_C(ref_C.layout()),
           ref_C(ref_C),
           params_D(ref_D.layout()),

--- a/dali/kernels/imgproc/convolution/cutlass/threadblock/predicated_tile_iterator.h
+++ b/dali/kernels/imgproc/convolution/cutlass/threadblock/predicated_tile_iterator.h
@@ -339,10 +339,10 @@ class PositionPredicatedTileIterator<Shape_, Element_, layout::PitchLinear, Adva
     /// Construct the Params object given a pitch-linear tensor's layout
     CUTLASS_HOST_DEVICE
     Params(Layout const &layout, int window_size, int window_anchor, int channels)
-        : params_(layout),
-          window_size_(window_size),
+        : window_size_(window_size),
           window_anchor_(window_anchor),
-          channels_(channels) {}
+          channels_(channels),
+          params_(layout) {}
 
     CUTLASS_HOST_DEVICE
     Params() {}

--- a/dali/kernels/imgproc/flip_gpu.cuh
+++ b/dali/kernels/imgproc/flip_gpu.cuh
@@ -37,8 +37,8 @@ __global__ void FlipKernel(T *__restrict__ output, const T *__restrict__ input,
   size_t xc = blockIdx.x * blockDim.x + threadIdx.x;
   size_t y = blockIdx.y * blockDim.y + threadIdx.y;
   size_t fz = blockIdx.z * blockDim.z + threadIdx.z;
-  const Index seq_length = shape[0], depth = shape[1], height = shape[2],
-                           width = shape[3], channels = shape[4];
+  const size_t seq_length = shape[0], depth = shape[1], height = shape[2],
+                            width = shape[3], channels = shape[4];
   if (xc >= width * channels || y >= height || fz >= depth * seq_length) {
     return;
   }

--- a/dali/kernels/imgproc/warp_gpu.cuh
+++ b/dali/kernels/imgproc/warp_gpu.cuh
@@ -63,7 +63,7 @@ class WarpGPU {
                            span<const TensorShape<spatial_ndim>> output_sizes,
                            span<const DALIInterpType> interp,
                            BorderType border = {}) {
-    assert(in.size() == static_cast<size_t>(output_sizes.size()));
+    assert(in.size() == output_sizes.size());
     setup.SetBlockDim(dim3(32, 16, 1));
     auto out_shapes = setup.GetOutputShape(in.shape, output_sizes);
     return setup.Setup(out_shapes);

--- a/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_axes_gpu_impl.cuh
@@ -563,7 +563,7 @@ __device__ void ReduceMiddleLargeInnerMedium(const ReduceSampleDesc<Out, In> &sa
     shared_tmp[w][lane] = r.template neutral<Acc>();
 
   for (int out_block = blockIdx.x; out_block < total_out_blocks; out_block += gridDim.x) {
-    if (out_block != blockIdx.x)
+    if (out_block != static_cast<int>(blockIdx.x))
       __syncthreads();
 
     // Caution: fast approximate division ahead!

--- a/dali/kernels/signal/dct/dct_gpu.h
+++ b/dali/kernels/signal/dct/dct_gpu.h
@@ -63,7 +63,6 @@ class BlockSetupInner {
 
  private:
   std::vector<BlockDesc> blocks_{};
-  int64_t max_input_length_ = 0;
   const int64_t frames_per_block_ = 8;
 };
 

--- a/dali/kernels/signal/fft/stft_gpu_impl.cuh
+++ b/dali/kernels/signal/fft/stft_gpu_impl.cuh
@@ -37,7 +37,7 @@ namespace fft {
 class StftImplGPU {
  public:
   StftImplGPU() = default;
-  StftImplGPU(StftImplGPU &&) = default;
+  StftImplGPU(StftImplGPU &&) = delete;
   StftImplGPU(const StftImplGPU &) = delete;
 
 

--- a/dali/kernels/signal/window/extract_windows_gpu.cuh
+++ b/dali/kernels/signal/window/extract_windows_gpu.cuh
@@ -412,8 +412,8 @@ struct ExtractVerticalWindowsImplGPU : ExtractWindowsImplGPU<Dst, Src> {
   void Run(KernelContext &ctx,
            const OutListGPU<Dst, 2> &out,
            const InListGPU<Src, 1> &in,
-           const InTensorGPU<float, 1> &window) {
-    size_t b = 0;
+           const InTensorGPU<float, 1> &window) override {
+    int b = 0;
     int nblocks = grid_dim.x;
 
     int N = in.num_samples();

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -64,7 +64,7 @@ class SliceFlipNormalizePermutePadGpu {
 
     processed_args_.clear();
     processed_args_.reserve(args.size());
-    for (int i = 0; i < num_samples; i++) {
+    for (size_t i = 0; i < num_samples; i++) {
       auto in_shape = in.tensor_shape(i);
       processed_args_.emplace_back(detail::ProcessArgs(args[i], in_shape));
       auto &sample_args = processed_args_.back();
@@ -76,11 +76,11 @@ class SliceFlipNormalizePermutePadGpu {
         channel_dim_ = sample_args.channel_dim;
       } else {
         // Checking all the samples are consistent
-        if (norm_args_size_ != sample_args.mean.size() ||
-            norm_args_size_ != sample_args.inv_stddev.size())
+        if (norm_args_size_ != static_cast<int>(sample_args.mean.size()) ||
+            norm_args_size_ != static_cast<int>(sample_args.inv_stddev.size()))
           throw std::invalid_argument(
             "Normalization arguments should have the same size for all the samples");
-        if (nfill_values_ != sample_args.fill_values.size())
+        if (nfill_values_ != static_cast<int>(sample_args.fill_values.size()))
           throw std::invalid_argument("Fill values should have the same size for all the samples");
         if (channel_dim_ != sample_args.channel_dim)
           throw std::invalid_argument("channel dim should be the same for all the samples");
@@ -203,7 +203,8 @@ class SliceFlipNormalizePermutePadGpu {
       // 4. The last two dimensions are either both flipped or not flipped
       int last_dim = Dims - 1;
       while (last_dim > 0 &&
-             sample_desc.out_strides[last_dim] == sample_desc.in_strides[last_dim] &&
+             sample_desc.out_strides[last_dim] ==
+                 static_cast<uint64_t>(sample_desc.in_strides[last_dim]) &&
              sample_desc.anchor[last_dim] == 0 &&
              sample_desc.out_shape[last_dim] == sample_desc.in_shape[last_dim] &&
              sample_desc.channel_dim != last_dim &&

--- a/dali/kernels/transpose/transpose_gpu.cu
+++ b/dali/kernels/transpose/transpose_gpu.cu
@@ -218,7 +218,7 @@ class TransposeGPU::Impl {
   template <typename T>
   void RunGeneric(KernelContext &ctx, T *const *out, const T *const *in) {
     if (!generic_descs_.empty()) {
-      int64_t max_size = 0;
+      uint64_t max_size = 0;
       int block_size = 256;
       for (size_t i = 0; i < generic_descs_.size(); i++) {
         generic_descs_[i].out = out[idx_generic_[i]];

--- a/dali/kernels/transpose/transpose_gpu_impl.cuh
+++ b/dali/kernels/transpose/transpose_gpu_impl.cuh
@@ -148,11 +148,11 @@ __device__ void TransposeTiledStatic(TiledTransposeDesc<T> desc) {
     in_ofs  += desc.in_strides[ndim-2]  * in_y  + desc.in_strides[ndim-1]  * in_x;
     out_ofs += desc.out_strides[ndim-2] * out_y + desc.out_strides[ndim-1] * out_x;
 
-    int tile_w = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim-1] - pos[ndim-1]);
-    int tile_h = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim-2] - pos[ndim-2]);
+    unsigned int tile_w = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim-1] - pos[ndim-1]);
+    unsigned int tile_h = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim-2] - pos[ndim-2]);
     if (threadIdx.x < tile_w) {
-      for (int ty = threadIdx.y, dy = 0; ty < tile_h; ty += blockDim.y, dy += blockDim.y) {
-        #pragma unroll(4)
+      for (unsigned int ty = threadIdx.y, dy = 0; ty < tile_h; ty += blockDim.y, dy += blockDim.y) {
+        #pragma unroll 4
         for (int lane = 0; lane < lanes; lane++) {
           tmp[lane][ty][threadIdx.x] = __ldg(&in[in_ofs + desc.in_strides[ndim-2]*dy + lane]);
         }
@@ -161,8 +161,8 @@ __device__ void TransposeTiledStatic(TiledTransposeDesc<T> desc) {
     __syncthreads();
 
     if (threadIdx.x < tile_h) {
-      for (int ty = threadIdx.y, dy = 0; ty < tile_w; ty += blockDim.y, dy += blockDim.y) {
-        #pragma unroll(4)
+      for (unsigned int ty = threadIdx.y, dy = 0; ty < tile_w; ty += blockDim.y, dy += blockDim.y) {
+        #pragma unroll 4
         for (int lane = 0; lane < lanes; lane++)
           out[out_ofs + desc.out_strides[ndim-1]*dy + lane] = tmp[lane][threadIdx.x][ty];
       }

--- a/dali/kernels/transpose/transpose_gpu_impl.cuh
+++ b/dali/kernels/transpose/transpose_gpu_impl.cuh
@@ -148,10 +148,10 @@ __device__ void TransposeTiledStatic(TiledTransposeDesc<T> desc) {
     in_ofs  += desc.in_strides[ndim-2]  * in_y  + desc.in_strides[ndim-1]  * in_x;
     out_ofs += desc.out_strides[ndim-2] * out_y + desc.out_strides[ndim-1] * out_x;
 
-    unsigned int tile_w = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim-1] - pos[ndim-1]);
-    unsigned int tile_h = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim-2] - pos[ndim-2]);
+    unsigned tile_w = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim-1] - pos[ndim-1]);
+    unsigned tile_h = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim-2] - pos[ndim-2]);
     if (threadIdx.x < tile_w) {
-      for (unsigned int ty = threadIdx.y, dy = 0; ty < tile_h; ty += blockDim.y, dy += blockDim.y) {
+      for (unsigned ty = threadIdx.y, dy = 0; ty < tile_h; ty += blockDim.y, dy += blockDim.y) {
         #pragma unroll 4
         for (int lane = 0; lane < lanes; lane++) {
           tmp[lane][ty][threadIdx.x] = __ldg(&in[in_ofs + desc.in_strides[ndim-2]*dy + lane]);
@@ -161,7 +161,7 @@ __device__ void TransposeTiledStatic(TiledTransposeDesc<T> desc) {
     __syncthreads();
 
     if (threadIdx.x < tile_h) {
-      for (unsigned int ty = threadIdx.y, dy = 0; ty < tile_w; ty += blockDim.y, dy += blockDim.y) {
+      for (unsigned ty = threadIdx.y, dy = 0; ty < tile_w; ty += blockDim.y, dy += blockDim.y) {
         #pragma unroll 4
         for (int lane = 0; lane < lanes; lane++)
           out[out_ofs + desc.out_strides[ndim-1]*dy + lane] = tmp[lane][threadIdx.x][ty];

--- a/dali/kernels/transpose/transpose_gpu_setup.cuh
+++ b/dali/kernels/transpose/transpose_gpu_setup.cuh
@@ -69,9 +69,9 @@ void InitTiledTranspose(TiledTransposeDesc<T> &desc,
 
   // Make sure that when transposing the last dimension, the last two can be transposed in tiles
   // and loaded and stored in contiguous transactions.
-  if (desc.out_strides[ndim-2] != lanes) {
+  if (desc.out_strides[ndim-2] != static_cast<uint64_t>(lanes)) {
     for (int i = 0; i < ndim-2; i++) {
-      if (desc.out_strides[i] == lanes) {
+      if (desc.out_strides[i] == static_cast<uint64_t>(lanes)) {
         std::rotate(desc.out_strides + i, desc.out_strides + i+1, desc.out_strides + ndim-1);
         std::rotate(desc.in_strides  + i, desc.in_strides  + i+1, desc.in_strides  + ndim-1);
         std::rotate(desc.shape       + i, desc.shape       + i+1, desc.shape       + ndim-1);

--- a/dali/operators/image/convolution/gaussian_blur_params.h
+++ b/dali/operators/image/convolution/gaussian_blur_params.h
@@ -147,7 +147,7 @@ void RepackAsTL(std::array<TensorListShape<1>, axes> &out,
                 const std::vector<GaussianBlurParams<axes>> &params) {
   for (int axis = 0; axis < axes; axis++) {
     out[axis].resize(params.size());
-    for (int i = 0; i < params.size(); i++) {
+    for (size_t i = 0; i < params.size(); i++) {
       out[axis].set_tensor_shape(i, {params[i].window_sizes[axis]});
     }
   }

--- a/dali/operators/random/normal_distribution_op.cu
+++ b/dali/operators/random/normal_distribution_op.cu
@@ -116,7 +116,7 @@ int NormalDistributionGpu::SetupSingleValueDescs(TensorList<GPUBackend> &output,
   assert(output.GetElementsNumber() == output.ntensor());
   auto elems = output.ntensor();
   BlockDesc *blocks = block_descs_cpu_.get();
-  for (int i = 0; i < elems; ++i) {
+  for (size_t i = 0; i < elems; ++i) {
     blocks[i].sample = output.raw_mutable_tensor(i);
     blocks[i].mean = mean_[i];
     blocks[i].std = stddev_[i];

--- a/dali/operators/ssd/box_encoder.cu
+++ b/dali/operators/ssd/box_encoder.cu
@@ -94,7 +94,7 @@ __device__ float4 MatchOffsets(
 }
 
 __device__ void WriteMatchesToOutput(
-  int anchors_count, float criteria, int *labels_out, const int *labels_in,
+  unsigned int anchors_count, float criteria, int *labels_out, const int *labels_in,
   float4 *boxes_out, const float4 *boxes_in,
   volatile int *best_box_idx, volatile float *best_box_iou, bool offset,
   const float* means, const float* stds, float scale, const float4 *anchors_as_cwh) {

--- a/dali/pipeline/operator/builtin/make_contiguous.cu
+++ b/dali/pipeline/operator/builtin/make_contiguous.cu
@@ -23,7 +23,7 @@ void MakeContiguousMixed::Run(MixedWorkspace &ws) {
   size_t batch_size = input.ntensor();
   TypeInfo type = input.type();
 
-  for (int i = 0; i < input.ntensor(); ++i) {
+  for (size_t i = 0; i < input.ntensor(); ++i) {
     auto &sample = ws.Input<CPUBackend>(0, i);
     size_t sample_bytes = sample.nbytes();
     if (coalesced && sample_bytes > COALESCE_THRESHOLD)

--- a/dali/test/device_test_test.cu
+++ b/dali/test/device_test_test.cu
@@ -31,7 +31,7 @@ DEVICE_TEST(DeviceTest, DeviceSideSuccess, dim3(5), dim3(32)) {
 }
 
 DEFINE_TEST_KERNEL(DeviceTest, DeviceSideFailure) {
-  DEV_EXPECT_EQ(threadIdx.x, 0);
+  DEV_EXPECT_EQ(threadIdx.x, 0u);
   DEV_EXPECT_LT(4, 4);
   DEV_EXPECT_LT(5, 4);
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

Fix:
- Wsign-compare
- Wformat
- Winconsistent-missing-override
- Wmismatched-tags
- Wreorder-ctor
- Wdefaulted-function-deleted
- Wcuda-compat 
- Wunused-private-field

~TODO: Some warnings come from code included from cutlass~

#### Why we need this PR?
Fix warnings reported by Clang. 

#### What happened in this PR? 
 - What solution was applied: Build & adjust
 - Affected modules and functionalities: Various
 - Key points relevant for the review: If casts are ok
 - Validation and testing: CI
 - Documentation (including examples): Reasons for turning off warning provided


**JIRA TASK**: *[Use DALI-XXXX or NA]*
