### PR TITLE
Mention WarpAffine in transforms.* documentation

### DIFF
--- a/dali/operators/geometry/affine_transforms/transform_crop.cc
+++ b/dali/operators/geometry/affine_transforms/transform_crop.cc
@@ -26,7 +26,7 @@ be mapped to ``to_start`` and ``from_end`` will be mapped to ``to_end``.
 If another transform matrix is passed as an input, the operator applies the transformation to the matrix provided.
 
 .. note::
-    The output of this operator can be fed directly to the ``MT`` argument of ``CoordTransform`` operator.
+    The output of this operator can be fed directly to ``CoordTransform`` and ``WarpAffine`` operators.
 )code")
   .AddOptionalArg(
     "from_start",

--- a/dali/operators/geometry/affine_transforms/transform_rotation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_rotation.cc
@@ -27,7 +27,7 @@ If another transform matrix is passed as an input, the operator applies rotation
 The number of dimensions is assumed to be 3 if a rotation axis is provided or 2 otherwise.
 
 .. note::
-    The output of this operator can be fed directly to the ``MT`` argument of ``CoordTransform`` operator.
+    The output of this operator can be fed directly to ``CoordTransform`` and ``WarpAffine`` operators.
 )code")
   .AddArg(
     "angle",

--- a/dali/operators/geometry/affine_transforms/transform_scale.cc
+++ b/dali/operators/geometry/affine_transforms/transform_scale.cc
@@ -23,7 +23,7 @@ DALI_SCHEMA(transforms__Scale)
 If another transform matrix is passed as an input, the operator applies scaling to the matrix provided.
 
 .. note::
-    The output of this operator can be fed directly to the ``MT`` argument of ``CoordTransform`` operator.
+    The output of this operator can be fed directly to ``CoordTransform`` and ``WarpAffine`` operators.
 )code")
   .AddArg(
     "scale",

--- a/dali/operators/geometry/affine_transforms/transform_shear.cc
+++ b/dali/operators/geometry/affine_transforms/transform_shear.cc
@@ -25,7 +25,7 @@ DALI_SCHEMA(transforms__Shear)
 If another transform matrix is passed as an input, the operator applies the shear mapping to the matrix provided.
 
 .. note::
-    The output of this operator can be fed directly to the ``MT`` argument of ``CoordTransform`` operator.
+    The output of this operator can be fed directly to ``CoordTransform`` and ``WarpAffine`` operators.
 )code")
   .AddOptionalArg<std::vector<float>>(
     "shear",

--- a/dali/operators/geometry/affine_transforms/transform_translation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_translation.cc
@@ -23,7 +23,7 @@ DALI_SCHEMA(transforms__Translation)
 If another transform matrix is passed as an input, the operator applies translation to the matrix provided.
 
 .. note::
-    The output of this operator can be fed directly to the ``MT`` argument of ``CoordTransform`` operator.
+    The output of this operator can be fed directly to ``CoordTransform`` and ``WarpAffine`` operators.
 )code")
   .AddArg(
     "offset",


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It improves documentation

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Extended note saying that the output of transforms.* can be fed directly to CoordTransform to mention that it can be used with WarpAffine as well*
 - Affected modules and functionalities:
     *transforms.* docs*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[Use DALI-1766]*
