### PR TITLE
Fix aarch64 build errors: compiler issues

### DIFF
--- a/dali/operators/random/normal_distribution_op.h
+++ b/dali/operators/random/normal_distribution_op.h
@@ -78,19 +78,18 @@ class NormalDistribution : public Operator<Backend> {
 
 
   TensorListShape<> GetOutputShape(const workspace_t<Backend> &ws) {
-    DALI_ENFORCE(!(spec_.NumRegularInput() == 1 && IsShapeArgumentProvided(spec_)),
+    DALI_ENFORCE(!(this->spec_.NumRegularInput() == 1 && IsShapeArgumentProvided(spec_)),
                  make_string("Incorrect operator invocation. "
                              "The operator cannot be called with both Input and `shape` argument"));
-    if (spec_.NumRegularInput() == 1) {
+    if (this->spec_.NumRegularInput() == 1) {
       single_value_in_output_ = false;
       return ShapesFromInputTensorList(ws);
     } else if (IsShapeArgumentProvided(spec_)) {
       single_value_in_output_ = false;
       return ShapesFromArgument(ws);
-    } else {
-      single_value_in_output_ = true;
-      return ShapeForDefaultConfig(ws);
     }
+    single_value_in_output_ = true;
+    return ShapeForDefaultConfig(ws);
   }
 
   USE_OPERATOR_MEMBERS();
@@ -126,7 +125,7 @@ class NormalDistribution : public Operator<Backend> {
 
 
   bool IsShapeArgumentProvided(const OpSpec &spec) {
-    return spec_.HasArgument(detail::kShape);
+    return this->spec_.HasArgument(detail::kShape);
   }
 };
 


### PR DESCRIPTION
Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in aarch64 build configuration

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     This was are a compiler issues, added `this->` pointers to class' fields


**JIRA TASK**: *[Use DALI-XXXX or NA]*
