### PR TITLE
Remove pinning numpy version in TL1_ssd_training test

### DIFF
--- a/qa/TL1_ssd_training/test.sh
+++ b/qa/TL1_ssd_training/test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-# Fixing numpy to 1.17.0 version to avoid the error about not being able to implicitly convert from float64 to integer
-pip_packages="numpy==1.17.0 pillow torch torchvision mlperf_compliance matplotlib Cython"
+pip_packages="numpy pillow torch torchvision mlperf_compliance matplotlib Cython"
 target_dir=./docs/examples/use_cases/pytorch/single_stage_detector/
 
 test_body() {


### PR DESCRIPTION
- cocoapi has been updated and no longer requires numpy version <= 1.17, so remove the pinning in the TL1_ssd_training test

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes pinning numpy version in TL1_ssd_training test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     cocoapi has been updated and no longer requires numpy version <= 1.17, so remove the pinning in the TL1_ssd_training test
 - Affected modules and functionalities:
     TL1_ssd_training test
 - Key points relevant for the review:
     NA
 - Validation and testing:
     preset tests apply
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
