### PR TITLE
Vectorize CPU resampling

### DIFF
--- a/dali/kernels/common/simd.h
+++ b/dali/kernels/common/simd.h
@@ -1,0 +1,209 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_COMMON_SIMD_H_
+#define DALI_KERNELS_COMMON_SIMD_H_
+
+#ifdef __SSE2__
+#include <emmintrin.h>
+#endif
+
+#include <cstddef>
+#include <type_traits>
+#include "dali/core/force_inline.h"
+
+namespace dali {
+namespace kernels {
+namespace simd {
+
+#ifdef __SSE2__
+
+template <int n>
+struct float4x {
+  __m128 v[n];  // NOLINT
+};
+
+template <int n>
+struct i128x {
+  __m128i v[n];  // NOLINT
+};
+
+using float4x1 = float4x<1>;
+using float4x2 = float4x<2>;
+using float4x4 = float4x<4>;
+using i128x1 = i128x<1>;
+using i128x2 = i128x<2>;
+using i128x4 = i128x<4>;
+
+inline __m128i clamp_round(__m128 f, float lo, float hi) {
+  f = _mm_min_ps(_mm_max_ps(f, _mm_set1_ps(lo)), _mm_set1_ps(hi));
+  return _mm_cvtps_epi32(f);  // round
+}
+
+inline void store(int8_t *i8, i128x4 iv) {
+  __m128i sv0 = _mm_packs_epi32(iv.v[0], iv.v[1]);
+  __m128i sv1 = _mm_packs_epi32(iv.v[2], iv.v[3]);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(i8), _mm_packs_epi16(sv0, sv1));
+}
+
+inline void store(uint8_t *u8, i128x4 iv) {
+  __m128i sv0 = _mm_packs_epi32(iv.v[0], iv.v[1]);
+  __m128i sv1 = _mm_packs_epi32(iv.v[2], iv.v[3]);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(u8), _mm_packus_epi16(sv0, sv1));
+}
+
+inline void store(int16_t *i16, i128x2 iv) {
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(i16), _mm_packs_epi32(iv.v[0], iv.v[1]));
+}
+
+inline void store(uint16_t *u16, i128x2 iv) {
+  __m128i sh = _mm_set_epi32(0, 0, 0, 1);
+  __m128i one = _mm_set1_epi32(1);
+  // avoid signed saturation by shifting right and saving LSB, then reconsitituting it
+  __m128i hi0 = _mm_srl_epi32(iv.v[0], sh);
+  __m128i hi1 = _mm_srl_epi32(iv.v[1], sh);
+  __m128i lo0 = _mm_and_si128(iv.v[0], one);
+  __m128i lo1 = _mm_and_si128(iv.v[0], one);
+  __m128i lo = _mm_packs_epi32(lo0, lo1);
+  __m128i hi = _mm_packs_epi32(hi0, hi1);
+  __m128i out = _mm_or_si128(_mm_sll_epi16(hi, sh), lo);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(u16), out);
+}
+
+inline float4x4 load_f(const uint8_t *u8) {
+  __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i *>(u8));
+  __m128i zero = _mm_setzero_si128();
+  __m128i lo16 = _mm_unpacklo_epi8(in, zero);
+  __m128i hi16 = _mm_unpackhi_epi8(in, zero);
+  __m128i i32_0 = _mm_unpacklo_epi8(lo16, zero);
+  __m128i i32_1 = _mm_unpackhi_epi8(lo16, zero);
+  __m128i i32_2 = _mm_unpacklo_epi8(hi16, zero);
+  __m128i i32_3 = _mm_unpackhi_epi8(hi16, zero);
+  return {{ _mm_cvtepi32_ps(i32_0),
+            _mm_cvtepi32_ps(i32_1),
+            _mm_cvtepi32_ps(i32_2),
+            _mm_cvtepi32_ps(i32_3) }};
+}
+
+inline __m128i sext8_32(__m128i i) {
+  __m128i sh = _mm_set_epi32(0, 0, 0, 24);
+  return _mm_sra_epi32(_mm_sll_epi32(i, sh), sh);
+}
+
+inline float4x4 load_f(const int8_t *i8) {
+  __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i *>(i8));
+  __m128i zero = _mm_setzero_si128();
+  __m128i lo16 = _mm_unpacklo_epi8(in, zero);
+  __m128i hi16 = _mm_unpackhi_epi8(in, zero);
+  __m128i i32_0 = _mm_unpacklo_epi8(lo16, zero);
+  __m128i i32_1 = _mm_unpackhi_epi8(lo16, zero);
+  __m128i i32_2 = _mm_unpacklo_epi8(hi16, zero);
+  __m128i i32_3 = _mm_unpackhi_epi8(hi16, zero);
+  return {{ _mm_cvtepi32_ps(sext8_32(i32_0)),
+            _mm_cvtepi32_ps(sext8_32(i32_1)),
+            _mm_cvtepi32_ps(sext8_32(i32_2)),
+            _mm_cvtepi32_ps(sext8_32(i32_3)) }};
+}
+
+inline __m128i sext16_32(__m128i i) {
+  __m128i sh = _mm_set_epi32(0, 0, 0, 16);
+  return _mm_sra_epi32(_mm_sll_epi32(i, sh), sh);
+}
+
+inline float4x2 load_f(const uint16_t *u16) {
+  __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i *>(u16));
+  __m128i zero = _mm_setzero_si128();
+  __m128i i32_0 = _mm_unpacklo_epi16(in, zero);
+  __m128i i32_1 = _mm_unpackhi_epi16(in, zero);
+  return {{ _mm_cvtepi32_ps(i32_0), _mm_cvtepi32_ps(i32_1) }};
+}
+
+inline float4x2 load_f(const int16_t *i16) {
+  __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i *>(i16));
+  __m128i zero = _mm_setzero_si128();
+  __m128i i32_0 = _mm_unpacklo_epi16(in, zero);
+  __m128i i32_1 = _mm_unpackhi_epi16(in, zero);
+  return {{ _mm_cvtepi32_ps(sext16_32(i32_0)), _mm_cvtepi32_ps(sext16_32(i32_1)) }};
+}
+
+inline float4x1 load_f(const float *f) {
+  return {{ _mm_loadu_ps(f) }};
+}
+
+template <typename Out>
+inline std::enable_if_t<std::is_integral<Out>::value>
+store(Out *out, float4x<sizeof(float)/sizeof(Out)> f) {
+  constexpr int nvec = sizeof(float)/sizeof(Out);
+  constexpr float lo = min_value<Out>();
+  constexpr float hi = max_value<Out>();
+  i128x<nvec> iv;
+  for (int i = 0; i < nvec; i++)
+    iv.v[i] = clamp_round(f.v[i], lo, hi);
+  store(out, iv);
+}
+
+inline void store(float *out, float4x1 f) {
+  _mm_storeu_ps(out, f.v[0]);
+}
+
+template <int num_vecs>
+struct multivec : float4x<num_vecs> {
+  DALI_FORCEINLINE static multivec zero() noexcept  {
+    multivec m;
+    for (int i = 0; i < num_vecs; i++)
+      m.v[i] = _mm_setzero_ps();
+    return m;
+  }
+
+  DALI_FORCEINLINE static multivec load(const float *in) noexcept  {
+    multivec m;
+    for (int i = 0; i < num_vecs; i++)
+      m.v[i] = _mm_loadu_ps(in + 4*i);
+    return m;
+  }
+
+  template <typename In>
+  DALI_FORCEINLINE static multivec load(const In *in) noexcept  {
+    constexpr int load_lanes = 16 / sizeof(In);
+    constexpr int load_vecs = load_lanes / 4;
+    multivec m;
+    for (int i = 0; i < num_vecs; i += load_vecs) {
+      auto tmp = simd::load_f(in + i * load_lanes);
+      for (int j = 0; j < load_vecs; j++)
+        m.v[i + j] = tmp.v[j];
+    }
+    return m;
+  }
+};
+
+
+template <int num_vecs, typename Out>
+DALI_FORCEINLINE static void store(Out *out, multivec<num_vecs> m) noexcept {
+  constexpr int store_lanes = 16 / sizeof(Out);
+  constexpr int store_vecs = store_lanes / 4;
+  for (int i = 0; i < num_vecs; i += store_vecs) {
+    float4x<store_vecs> slice;
+    for (int j = 0; j < store_vecs; j++)
+      slice.v[j] = m.v[i + j];
+    simd::store(out + i * store_lanes, slice);
+  }
+}
+
+#endif  // __SSE2__
+
+}  // namespace simd
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_COMMON_SIMD_H_

--- a/dali/kernels/common/simd.h
+++ b/dali/kernels/common/simd.h
@@ -20,6 +20,7 @@
 #endif
 
 #include <cstddef>
+#include <limits>
 #include <type_traits>
 #include "dali/core/force_inline.h"
 
@@ -46,81 +47,142 @@ using i128x1 = i128x<1>;
 using i128x2 = i128x<2>;
 using i128x4 = i128x<4>;
 
+/**
+ * @brief Clamp floating point value to range [lo, hi], round to nearest and as int32x4
+ */
 inline __m128i clamp_round(__m128 f, float lo, float hi) {
   f = _mm_min_ps(_mm_max_ps(f, _mm_set1_ps(lo)), _mm_set1_ps(hi));
   return _mm_cvtps_epi32(f);  // round
 }
 
-inline void store(int8_t *i8, i128x4 iv) {
+/**
+ * @brief Saturate int32x4x4 to int8x16 and store
+ */
+inline void store_i32(int8_t *i8, i128x4 iv) {
   __m128i sv0 = _mm_packs_epi32(iv.v[0], iv.v[1]);
   __m128i sv1 = _mm_packs_epi32(iv.v[2], iv.v[3]);
   _mm_storeu_si128(reinterpret_cast<__m128i*>(i8), _mm_packs_epi16(sv0, sv1));
 }
 
-inline void store(uint8_t *u8, i128x4 iv) {
+/**
+ * @brief Saturate int32x4x4 to uint8x16 and store
+ */
+inline void store_i32(uint8_t *u8, i128x4 iv) {
   __m128i sv0 = _mm_packs_epi32(iv.v[0], iv.v[1]);
   __m128i sv1 = _mm_packs_epi32(iv.v[2], iv.v[3]);
   _mm_storeu_si128(reinterpret_cast<__m128i*>(u8), _mm_packus_epi16(sv0, sv1));
 }
 
-inline void store(int16_t *i16, i128x2 iv) {
+/**
+ * @brief Saturate and narrow int32x4x2 to int16x8 and store
+ */
+inline void store_i32(int16_t *i16, i128x2 iv) {
   _mm_storeu_si128(reinterpret_cast<__m128i*>(i16), _mm_packs_epi32(iv.v[0], iv.v[1]));
 }
 
-inline void store(uint16_t *u16, i128x2 iv) {
-  __m128i sh = _mm_set_epi32(0, 0, 0, 1);
-  __m128i one = _mm_set1_epi32(1);
-  // avoid signed saturation by shifting right and saving LSB, then reconsitituting it
-  __m128i hi0 = _mm_srl_epi32(iv.v[0], sh);
-  __m128i hi1 = _mm_srl_epi32(iv.v[1], sh);
-  __m128i lo0 = _mm_and_si128(iv.v[0], one);
-  __m128i lo1 = _mm_and_si128(iv.v[0], one);
-  __m128i lo = _mm_packs_epi32(lo0, lo1);
-  __m128i hi = _mm_packs_epi32(hi0, hi1);
-  __m128i out = _mm_or_si128(_mm_sll_epi16(hi, sh), lo);
+inline __m128i clamp_i32_u16(__m128i x) {
+  __m128i below = _mm_cmpgt_epi32(_mm_setzero_si128(), x);  // mask is true for negative
+  __m128i max_u16 = _mm_set1_epi32(0xffff);
+  __m128i above = _mm_cmpgt_epi32(x, max_u16);
+  __m128i fill = _mm_and_si128(above, max_u16);   // if x > 0xffff, store 0xffff
+  __m128i mask = _mm_or_si128(below, above);      // either below zero or above 0xffff
+  __m128i masked = _mm_andnot_si128(mask, x);     // mask out-of-range values
+  return _mm_or_si128(masked, fill);              // replace values above 0xffff with 0xffff
+}
+
+/**
+ * @brief Saturate and narrow int32x4x2 to uint16x8 and store
+ */
+inline void store_i32(uint16_t *u16, i128x2 iv) {
+  __m128i lo = clamp_i32_u16(iv.v[0]);
+  __m128i hi = clamp_i32_u16(iv.v[1]);
+  __m128i even = _mm_castps_si128(
+      _mm_shuffle_ps(_mm_castsi128_ps(lo), _mm_castsi128_ps(hi), _MM_SHUFFLE(2, 0, 2, 0)));
+  __m128i odd = _mm_castps_si128(
+      _mm_shuffle_ps(_mm_castsi128_ps(lo), _mm_castsi128_ps(hi), _MM_SHUFFLE(3, 1, 3, 1)));
+
+  __m128i out = _mm_or_si128(even, _mm_bslli_si128(odd, 2));  // byte shift
+
   _mm_storeu_si128(reinterpret_cast<__m128i*>(u16), out);
 }
 
+inline void store_i32(int32_t *i32, i128x1 iv) {
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(i32), iv.v[0]);
+}
+
+/**
+ * @brief Load int32x4 and convert to 1 float32x4
+ */
+inline float4x1 load_f(const int32_t *i32) {
+  return {{ _mm_cvtepi32_ps(_mm_loadu_si128(reinterpret_cast<const __m128i*>(i32))) }};
+}
+
+/**
+ * @brief Load uint8x16 and convert to 4 float32x4
+ *
+ * Conversion is done by zero-extending to signed int32 and converting to float.
+ */
 inline float4x4 load_f(const uint8_t *u8) {
   __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i *>(u8));
   __m128i zero = _mm_setzero_si128();
   __m128i lo16 = _mm_unpacklo_epi8(in, zero);
   __m128i hi16 = _mm_unpackhi_epi8(in, zero);
-  __m128i i32_0 = _mm_unpacklo_epi8(lo16, zero);
-  __m128i i32_1 = _mm_unpackhi_epi8(lo16, zero);
-  __m128i i32_2 = _mm_unpacklo_epi8(hi16, zero);
-  __m128i i32_3 = _mm_unpackhi_epi8(hi16, zero);
+  __m128i i32_0 = _mm_unpacklo_epi16(lo16, zero);
+  __m128i i32_1 = _mm_unpackhi_epi16(lo16, zero);
+  __m128i i32_2 = _mm_unpacklo_epi16(hi16, zero);
+  __m128i i32_3 = _mm_unpackhi_epi16(hi16, zero);
   return {{ _mm_cvtepi32_ps(i32_0),
             _mm_cvtepi32_ps(i32_1),
             _mm_cvtepi32_ps(i32_2),
             _mm_cvtepi32_ps(i32_3) }};
 }
 
+/**
+ * @brief Sign-extend 8-bit values stored in LSB of 32-bit lanes
+ *
+ * Replicate 7th bit in 32-bit lanes to bits 8-31.
+ */
 inline __m128i sext8_32(__m128i i) {
   __m128i sh = _mm_set_epi32(0, 0, 0, 24);
   return _mm_sra_epi32(_mm_sll_epi32(i, sh), sh);
 }
 
+
+/**
+ * @brief Load int8x16 and convert to 4 float32x4
+ *
+ * Conversion is done by sign-extending to int32 and converting to float.
+ */
 inline float4x4 load_f(const int8_t *i8) {
   __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i *>(i8));
   __m128i zero = _mm_setzero_si128();
   __m128i lo16 = _mm_unpacklo_epi8(in, zero);
   __m128i hi16 = _mm_unpackhi_epi8(in, zero);
-  __m128i i32_0 = _mm_unpacklo_epi8(lo16, zero);
-  __m128i i32_1 = _mm_unpackhi_epi8(lo16, zero);
-  __m128i i32_2 = _mm_unpacklo_epi8(hi16, zero);
-  __m128i i32_3 = _mm_unpackhi_epi8(hi16, zero);
+  __m128i i32_0 = _mm_unpacklo_epi16(lo16, zero);
+  __m128i i32_1 = _mm_unpackhi_epi16(lo16, zero);
+  __m128i i32_2 = _mm_unpacklo_epi16(hi16, zero);
+  __m128i i32_3 = _mm_unpackhi_epi16(hi16, zero);
   return {{ _mm_cvtepi32_ps(sext8_32(i32_0)),
             _mm_cvtepi32_ps(sext8_32(i32_1)),
             _mm_cvtepi32_ps(sext8_32(i32_2)),
             _mm_cvtepi32_ps(sext8_32(i32_3)) }};
 }
 
+/**
+ * @brief Sign-extend 16-bit values stored in LSB of 32-bit lanes
+ *
+ * Replicate 15th bit in 32-bit lanes to bits 16-31.
+ */
 inline __m128i sext16_32(__m128i i) {
   __m128i sh = _mm_set_epi32(0, 0, 0, 16);
   return _mm_sra_epi32(_mm_sll_epi32(i, sh), sh);
 }
 
+/**
+ * @brief Load uint16x8 and convert to 2 float32x4
+ *
+ * Conversion is done by zero-extending to signed int32 and converting to float.
+ */
 inline float4x2 load_f(const uint16_t *u16) {
   __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i *>(u16));
   __m128i zero = _mm_setzero_si128();
@@ -129,6 +191,11 @@ inline float4x2 load_f(const uint16_t *u16) {
   return {{ _mm_cvtepi32_ps(i32_0), _mm_cvtepi32_ps(i32_1) }};
 }
 
+/**
+ * @brief Load int16x8 and convert to 2 float32x4
+ *
+ * Conversion is done by sign-extending to signed int32 and converting to float.
+ */
 inline float4x2 load_f(const int16_t *i16) {
   __m128i in = _mm_loadu_si128(reinterpret_cast<const __m128i *>(i16));
   __m128i zero = _mm_setzero_si128();
@@ -141,19 +208,25 @@ inline float4x1 load_f(const float *f) {
   return {{ _mm_loadu_ps(f) }};
 }
 
+/**
+ * @brief Convert multiple vectors of float and convert them to Out.
+ */
 template <typename Out>
 inline std::enable_if_t<std::is_integral<Out>::value>
-store(Out *out, float4x<sizeof(float)/sizeof(Out)> f) {
+store_f(Out *out, float4x<sizeof(float)/sizeof(Out)> f) {
   constexpr int nvec = sizeof(float)/sizeof(Out);
-  constexpr float lo = min_value<Out>();
-  constexpr float hi = max_value<Out>();
+  constexpr float lo = std::numeric_limits<Out>::min();
+  constexpr float hi = std::numeric_limits<Out>::max();
   i128x<nvec> iv;
   for (int i = 0; i < nvec; i++)
     iv.v[i] = clamp_round(f.v[i], lo, hi);
-  store(out, iv);
+  store_i32(out, iv);
 }
 
-inline void store(float *out, float4x1 f) {
+/**
+ * @brief Store 1 vector of floats
+ */
+inline void store_f(float *out, float4x1 f) {
   _mm_storeu_ps(out, f.v[0]);
 }
 
@@ -177,6 +250,9 @@ struct multivec : float4x<num_vecs> {
   DALI_FORCEINLINE static multivec load(const In *in) noexcept  {
     constexpr int load_lanes = 16 / sizeof(In);
     constexpr int load_vecs = load_lanes / 4;
+    static_assert(load_vecs > 0, "This multivec is too small to be used with this storage type.");
+    static_assert(num_vecs * 4 % load_lanes == 0,
+      "Total number of lanes is not a multiple of storage lanes.");
     multivec m;
     for (int i = 0; i < num_vecs; i += load_vecs) {
       auto tmp = simd::load_f(in + i * load_lanes);
@@ -187,16 +263,23 @@ struct multivec : float4x<num_vecs> {
   }
 };
 
-
+/**
+ * @brief Stores multiple vectors of float, converting them to Out
+ *
+ * The number of lanes must be large enough to fill at least one vector of Out
+ */
 template <int num_vecs, typename Out>
 DALI_FORCEINLINE static void store(Out *out, multivec<num_vecs> m) noexcept {
   constexpr int store_lanes = 16 / sizeof(Out);
   constexpr int store_vecs = store_lanes / 4;
+  static_assert(store_vecs > 0, "This multivec is too small to be used with this storage type.");
+  static_assert(num_vecs * 4 % store_lanes == 0,
+    "Total number of lanes is not a multiple of storage lanes.");
   for (int i = 0; i < num_vecs; i += store_vecs) {
     float4x<store_vecs> slice;
     for (int j = 0; j < store_vecs; j++)
       slice.v[j] = m.v[i + j];
-    simd::store(out + i * store_lanes, slice);
+    store_f(out + i * store_lanes, slice);
   }
 }
 

--- a/dali/kernels/common/simd.h
+++ b/dali/kernels/common/simd.h
@@ -233,8 +233,8 @@ template <typename Out>
 inline std::enable_if_t<std::is_integral<Out>::value>
 store_f(Out *out, float4x<sizeof(float)/sizeof(Out)> f) {
   constexpr int nvec = sizeof(float)/sizeof(Out);
-  constexpr float lo = std::numeric_limits<Out>::min();
-  constexpr float hi = std::numeric_limits<Out>::max();
+  constexpr float lo = static_cast<float>(std::numeric_limits<Out>::min());
+  constexpr float hi = static_cast<float>(std::numeric_limits<Out>::max());
   i128x<nvec> iv;
   for (int i = 0; i < nvec; i++)
     iv.v[i] = clamp_round(f.v[i], lo, hi);

--- a/dali/kernels/test/simd_test.cc
+++ b/dali/kernels/test/simd_test.cc
@@ -1,0 +1,133 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/kernels/common/simd.h"
+#include "dali/core/convert.h"
+
+namespace dali {
+namespace kernels {
+namespace simd {
+namespace test {
+
+#ifdef __SSE2__
+
+template <typename Out, int nvec = sizeof(float)/sizeof(Out)>
+void TestConvertStore(float4x<nvec> vec) {
+  Out out[nvec * 4];  // NOLINT
+  store_f(out, vec);
+  float flt[nvec * 4];  // NOLINT
+  for (int i = 0; i < nvec; i++)
+    _mm_storeu_ps(flt + i * 4, vec.v[i]);
+  for (int i = 0; i < nvec * 4; i++)
+    EXPECT_EQ(out[i], ConvertSat<Out>(flt[i]));
+}
+
+template <typename Out, int nvec = sizeof(int32_t)/sizeof(Out)>
+void TestConvertStore(i128x<nvec> vec) {
+  Out out[nvec * 4];  // NOLINT
+  store_i32(out, vec);
+  int32_t i32[nvec * 4];  // NOLINT
+  for (int i = 0; i < nvec; i++)
+    _mm_storeu_si128(reinterpret_cast<__m128i*>(i32 + i * 4), vec.v[i]);
+  for (int i = 0; i < nvec * 4; i++)
+    EXPECT_EQ(out[i], ConvertSat<Out>(i32[i]));
+}
+
+template <typename In, int nvec = sizeof(float)/sizeof(In)>
+void TestConvertLoad(In lo, In hi) {
+  int lanes = 16 / sizeof(In);
+  In in[lanes];  // NOLINT
+  for (int i = 0; i < lanes; i++) {
+    in[i] = lo + (hi - lo) * i / (lanes - 1);
+  }
+  float4x<nvec> v = load_f(in);
+  for (int i = 0; i < nvec; i++) {
+    float tmp[4];
+    _mm_storeu_ps(tmp, v.v[i]);
+    for (int j = 0; j < 4; j++) {
+      float ref = in[4*i + j];
+      EXPECT_EQ(tmp[j], ref);
+    }
+  }
+}
+
+template <int n>
+float4x<n> make_vec_f(float min, float max) {
+  float range = max - min;
+  min -= range / 4;
+  max += range / 4;
+  range = max - min;
+  float delta = range / (4 * n - 1);
+  float value = min;
+  float4x<n> out;
+  for (int i = 0; i < n; i++) {
+    float tmp[4];
+    for (int j = 0; j < 4; j++) {
+      tmp[j] = value;
+      value += delta;
+    }
+    out.v[i] = _mm_loadu_ps(tmp);
+  }
+  return out;
+}
+
+template <int n>
+i128x<n> make_vec_i32(float min, float max) {
+  float range = max - min;
+  min -= range / 4;
+  max += range / 4;
+  range = max - min;
+  float delta = range / (4 * n - 1);
+  float value = min;
+  i128x<n> out;
+  for (int i = 0; i < n; i++) {
+    int32_t tmp[4];
+    for (int j = 0; j < 4; j++) {
+      tmp[j] = value;
+      value += delta;
+    }
+    out.v[i] = _mm_loadu_si128(reinterpret_cast<const __m128i*>(tmp));
+  }
+  return out;
+}
+
+TEST(SSE2Test, ConvertStore) {
+  TestConvertStore<int8_t>(make_vec_f<4>(-128, 127));
+  TestConvertStore<uint8_t>(make_vec_f<4>(0, 255));
+  TestConvertStore<int16_t>(make_vec_f<2>(-32768, 32767));
+  TestConvertStore<uint16_t>(make_vec_f<2>(0, 65535));
+  TestConvertStore<int32_t>(make_vec_f<1>(-1000000, 1000000));
+
+  TestConvertStore<int8_t>(make_vec_i32<4>(-128, 127));
+  TestConvertStore<uint8_t>(make_vec_i32<4>(0, 255));
+  TestConvertStore<int16_t>(make_vec_i32<2>(-32768, 32767));
+  TestConvertStore<uint16_t>(make_vec_i32<2>(0, 65535));
+  TestConvertStore<int32_t>(make_vec_i32<1>(-1000000, 1000000));
+}
+
+TEST(SSE2Test, ConvertLoad) {
+  TestConvertLoad<int8_t>(-128, 127);
+  TestConvertLoad<int16_t>(-32768, 32767);
+  TestConvertLoad<uint8_t>(0, 255);
+  TestConvertLoad<uint16_t>(0, 65535);
+  TestConvertLoad<int32_t>(-1000000000, 1000000000);
+}
+
+#endif  // __SSE2__
+
+}  // namespace test
+}  // namespace simd
+}  // namespace kernels
+}  // namespace dali

--- a/dali/kernels/test/simd_test.cc
+++ b/dali/kernels/test/simd_test.cc
@@ -109,6 +109,7 @@ TEST(SSE2Test, ConvertStore) {
   TestConvertStore<int16_t>(make_vec_f<2>(-32768, 32767));
   TestConvertStore<uint16_t>(make_vec_f<2>(0, 65535));
   TestConvertStore<int32_t>(make_vec_f<1>(-1000000, 1000000));
+  TestConvertStore<int32_t>(make_vec_f<1>(-2.5e+9, 2.5e+9));
 
   TestConvertStore<int8_t>(make_vec_i32<4>(-128, 127));
   TestConvertStore<uint8_t>(make_vec_i32<4>(0, 255));


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes performance issues when using CPU resize after introducing 3D resampling

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Add SIMD utility header to kernels/common
     * Use multi-vector approach to utilize full width of input and output vectors when resampling vertically
     * Use multi-vector approach to utilize full with of the output when resampling horizontally
     * Tune tile size for vertical resampling
 - Affected modules and functionalities:
     * CPU resampling backend
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests siffuce
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-1776
