### PR TITLE
Support for nvJPEG preallocate API for batched HW decoder

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -40,6 +40,10 @@ if (BUILD_NVJPEG)
   if (${NVJPEG_DECOUPLED_API})
     add_definitions(-DNVJPEG_DECOUPLED_API)
   endif()
+
+  if (${NVJPEG_PREALLOCATE_API})
+    add_definitions(-DNVJPEG_PREALLOCATE_API)
+  endif()
 endif()
 
 if (BUILD_NVJPEG2K)

--- a/cmake/modules/FindNVJPEG.cmake
+++ b/cmake/modules/FindNVJPEG.cmake
@@ -48,8 +48,9 @@ if(NVJPEG_FOUND)
 
   list(APPEND CMAKE_REQUIRED_LIBRARIES "${NVJPEG_LIBRARY}" cudart_static culibos dl m pthread rt)
   check_cxx_symbol_exists("nvjpegCreateEx" "nvjpeg.h" NVJPEG_LIBRARY_0_2_0)
-
   check_cxx_symbol_exists("nvjpegBufferPinnedCreate" "nvjpeg.h" NVJPEG_DECOUPLED_API)
+  check_cxx_symbol_exists("nvjpegDecodeBatchedPreAllocate" "nvjpeg.h" NVJPEG_PREALLOCATE_API)
+
   set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_OLD})
   set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_OLD})
 

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -147,7 +147,9 @@ The output of the decoder is in *HWC* layout.
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
 Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.)code")
   .AddOptionalArg("hw_decoder_load",
-      R"code(Applies **only** to the ``mixed`` backend type.
+      R"code(The percentage of the image data to be processed by the HW JPEG decoder.
+
+Applies **only** to the ``mixed`` backend type in NVIDIA Ampere GPU architecture.
 
 Determines the percentage of the workload that will be offloaded to the hardware decoder,
 if available. The optimal workload depends on the number of threads that are provided to
@@ -155,16 +157,18 @@ the DALI pipeline and should be found empirically. More details can be found at
 https://developer.nvidia.com/blog/loading-data-fast-with-dali-and-new-jpeg-decoder-in-a100)code",
       0.65f)
   .AddOptionalArg("preallocate_width_hint",
-      R"code(Applies **only** to the ``mixed`` backend type.
+      R"code(Image width hint.
 
-Hint about the expected maximum width of the processed images. It helps to allocate ahead of time
-a memory pool for the HW JPEG decoder in NVIDIA Ampere GPU architecture.)code",
+Applies **only** to the ``mixed`` backend type in NVIDIA Ampere GPU architecture.
+
+The hint is used to preallocate memory for the HW JPEG decoder.)code",
       0)
   .AddOptionalArg("preallocate_height_hint",
-      R"code(Applies **only** to the ``mixed`` backend type.
+      R"code(Image width hint.
 
-Hint about the expected maximum height of the processed images. It helps to allocate ahead of time
-a memory pool for the HW JPEG decoder in NVIDIA Ampere GPU architecture.)code",
+Applies **only** to the ``mixed`` backend type in NVIDIA Ampere GPU architecture.
+
+The hint is used to preallocate memory for the HW JPEG decoder.)code",
       0)
   .NumInput(1)
   .NumOutput(1)

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -154,6 +154,18 @@ if available. The optimal workload depends on the number of threads that are pro
 the DALI pipeline and should be found empirically. More details can be found at
 https://developer.nvidia.com/blog/loading-data-fast-with-dali-and-new-jpeg-decoder-in-a100)code",
       0.65f)
+  .AddOptionalArg("preallocate_width_hint",
+      R"code(Applies **only** to the ``mixed`` backend type.
+
+Hint about the expected maximum width of the processed images. It helps to allocate ahead of time
+a memory pool for the HW JPEG decoder in NVIDIA Ampere GPU architecture.)code",
+      0)
+  .AddOptionalArg("preallocate_height_hint",
+      R"code(Applies **only** to the ``mixed`` backend type.
+
+Hint about the expected maximum height of the processed images. It helps to allocate ahead of time
+a memory pool for the HW JPEG decoder in NVIDIA Ampere GPU architecture.)code",
+      0)
   .NumInput(1)
   .NumOutput(1)
   .AddParent("ImageDecoderAttr")

--- a/tools/hw_decoder_bench.py
+++ b/tools/hw_decoder_bench.py
@@ -12,6 +12,8 @@ parser.add_argument('-t', dest="total_images", help="total images", default=100,
 parser.add_argument('-j', dest="num_threads", help="num_threads", default=1, type=int)
 parser.add_argument('-i', dest="images_dir", help="images dir")
 parser.add_argument('--hw_load', dest="hw_load", help="HW decoder workload (e.g. 0.66 means 66% of the batch)", default=0.65, type=float)
+parser.add_argument('--width_hint', dest="width_hint", default=0, type=int)
+parser.add_argument('--height_hint', dest="height_hint", default=0, type=int)
 parser.add_argument('-dec', dest="decoder")
 
 args = parser.parse_args()
@@ -20,7 +22,12 @@ class SamplePipeline(Pipeline):
     def __init__(self, batch_size=args.batch_size, num_threads=args.num_threads, device_id=args.device_id):
         super(SamplePipeline, self).__init__(batch_size, num_threads, device_id, seed=0)
         self.input = dali.ops.FileReader(file_root = args.images_dir)
-        self.decode = dali.ops.ImageDecoder(device = 'mixed', output_type = dali.types.RGB, hw_decoder_load=args.hw_load)
+        self.decode = dali.ops.ImageDecoder(
+            device = 'mixed',
+            output_type = dali.types.RGB,
+            hw_decoder_load=args.hw_load,
+            preallocate_width_hint=args.width_hint,
+            preallocate_height_hint=args.height_hint)
     def define_graph(self):
         jpegs, _ = self.input()
         images = self.decode(jpegs)


### PR DESCRIPTION
Signed-off-by: Albert Wolant <awolant@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds support for nvJPEG preallocate API for batched HW decoder

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds support for nvJPEG preallocate API for batched HW decoder
 - Affected modules and functionalities:
     ImageDecoder
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     Operator docs are updated


**JIRA TASK**: *[DALI-1443]*
