### PR TITLE
Add COCOReader `files` arg support and fix bug in the segmentation data parsing

### DIFF
--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -125,10 +125,14 @@ instance of an object is lower than this value, the object will be ignored.)code
   .AddOptionalArg("image_ids",
       R"code(If set to True, the image IDs will be produced in an extra output.)code",
       false)
-    .AddOptionalArg<vector<string>>("files", R"(A list of file paths to read the data from.
+  .AddOptionalArg<vector<string>>("files", R"code(A list of image paths.
 
-If ``file_root`` is provided, the paths are treated as being relative to it.
-This argument is mutually exclusive with ``preprocessed_annotations``.)", nullptr)
+If specified, it acts as a filter for the file paths present in the annotation file.
+If left unspecified or set to None, all images listed in the annotation file are read.
+
+The paths to be kept should match those in the annotations file.
+
+Note: This argument is mutually exclusive with ``preprocessed_annotations``.)code", nullptr)
   .DeprecateArgInFavorOf("save_img_ids", "image_ids")  // deprecated since 0.28dev
   .AddOptionalArg("save_preprocessed_annotations",
       R"code(If set to True, the operator saves a set of files containing binary representations of the

--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -126,8 +126,9 @@ instance of an object is lower than this value, the object will be ignored.)code
       R"code(If set to True, the image IDs will be produced in an extra output.)code",
       false)
     .AddOptionalArg<vector<string>>("files", R"(A list of file paths to read the data from.
-  If ``file_root`` is provided, the paths are treated as being relative to it.
-  This argument is mutually exclusive with ``preprocessed_annotations``.)", nullptr)
+
+If ``file_root`` is provided, the paths are treated as being relative to it.
+This argument is mutually exclusive with ``preprocessed_annotations``.)", nullptr)
   .DeprecateArgInFavorOf("save_img_ids", "image_ids")  // deprecated since 0.28dev
   .AddOptionalArg("save_preprocessed_annotations",
       R"code(If set to True, the operator saves a set of files containing binary representations of the

--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -125,7 +125,7 @@ instance of an object is lower than this value, the object will be ignored.)code
   .AddOptionalArg("image_ids",
       R"code(If set to True, the image IDs will be produced in an extra output.)code",
       false)
-  .AddOptionalArg<vector<string>>("files", R"code(A list of image paths.
+  .AddOptionalArg<vector<string>>("images", R"code(A list of image paths.
 
 If specified, it acts as a filter for the file paths present in the annotation file.
 If left unspecified or set to None, all images listed in the annotation file are read.

--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -125,6 +125,9 @@ instance of an object is lower than this value, the object will be ignored.)code
   .AddOptionalArg("image_ids",
       R"code(If set to True, the image IDs will be produced in an extra output.)code",
       false)
+    .AddOptionalArg<vector<string>>("files", R"(A list of file paths to read the data from.
+  If ``file_root`` is provided, the paths are treated as being relative to it.
+  This argument is mutually exclusive with ``preprocessed_annotations``.)", nullptr)
   .DeprecateArgInFavorOf("save_img_ids", "image_ids")  // deprecated since 0.28dev
   .AddOptionalArg("save_preprocessed_annotations",
       R"code(If set to True, the operator saves a set of files containing binary representations of the

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -352,6 +352,8 @@ void ParseAnnotations(LookaheadParser &parser, std::vector<Annotation> &annotati
             }
             segm_meta.push_back(coord_offset);
           }
+        } else {
+          parser.SkipValue();
         }
       } else {
         parser.SkipValue();

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -485,34 +485,25 @@ void CocoLoader::ParseJsonAnnotations() {
   bool parse_segmentation = output_polygon_masks_ || output_pixelwise_masks_;
   detail::ParseJsonFile(spec_, image_infos, annotations, category_ids,
                         parse_segmentation, output_pixelwise_masks_);
-  // Files args was provided. Filter out image_infos and annotations.
-  // Clear image_label_pairs_ to make ID match later.
-  if (has_files_arg_) {
-    std::unordered_set<std::string> file_names;
 
-    for (auto &image_label_pair : image_label_pairs_) {
-      file_names.insert(image_label_pair.first);
-    }
-
-    std::vector<detail::ImageInfo> new_image_infos;
+  if (!images_.empty()) {  // Filter for image files was provided.
     std::unordered_set<int> ids_to_keep;
-    std::vector<detail::Annotation> new_annotations;
+    image_infos.erase(
+      std::remove_if(image_infos.begin(), image_infos.end(),
+        [&](const detail::ImageInfo &info) {
+          if (images_.find(info.filename_) == images_.end()) {
+            return true;
+          } else {
+            ids_to_keep.insert(info.original_id_);
+            return false;
+          }
+        }), image_infos.end());
 
-    for (auto &image_info : image_infos) {
-      if (file_names.count(image_info.filename_) == 1) {
-        new_image_infos.push_back(image_info);
-        ids_to_keep.insert(image_info.original_id_);
-      }
-    }
-
-    for (auto &annotation : annotations) {
-      if (ids_to_keep.count(annotation.image_id_) == 1) {
-        new_annotations.emplace_back(std::move(annotation));
-      }
-    }
-    annotations = std::move(new_annotations);
-    image_infos = std::move(new_image_infos);
-    image_label_pairs_.clear();
+    annotations.erase(
+      std::remove_if(annotations.begin(), annotations.end(),
+        [&](const detail::Annotation &annotation) {
+          return ids_to_keep.find(annotation.image_id_) == ids_to_keep.end();
+        }), annotations.end());
   }
 
   bool skip_empty = spec_.GetArgument<bool>("skip_empty");

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -509,7 +509,7 @@ void CocoLoader::ParseJsonAnnotations() {
       }
     }
     annotations = std::move(new_annotations);
-    image_infos = new_image_infos;
+    image_infos = std::move(new_image_infos);
     image_label_pairs_.clear();
   }
 

--- a/dali/operators/reader/loader/coco_loader.h
+++ b/dali/operators/reader/loader/coco_loader.h
@@ -121,6 +121,10 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
       DALI_FAIL("``save_preprocessed_annotations`` and ``save_preprocessed_annotations_dir`` "
                 "should be provided together");
     }
+
+    if (has_files_arg_ && HasPreprocessedAnnotations(spec)) {
+      DALI_FAIL("``files`` and ``preprocessed_annotations`` are mutually exclusive")
+    }
   }
 
   struct PixelwiseMasksInfo {

--- a/dali/operators/reader/loader/coco_loader.h
+++ b/dali/operators/reader/loader/coco_loader.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_set>
 #include <utility>
 
 #include "dali/operators/reader/loader/file_label_loader.h"
@@ -102,12 +103,20 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
     DALI_ENFORCE(has_preprocessed_annotations_ || spec.HasArgument("annotations_file"),
         "Either ``annotations_file`` or ``preprocessed_annotations`` must be provided");
     if (has_preprocessed_annotations_) {
-      for (const char* arg_name : {"annotations_file", "skip_empty", "ratio", "ltrb",
+      for (const char* arg_name : {"annotations_file", "skip_empty", "ratio", "ltrb", "images",
                                    "size_threshold", "dump_meta_files", "dump_meta_files_path"}) {
         if (spec.HasArgument(arg_name))
           DALI_FAIL(make_string("When reading data from preprocessed annotation files, \"",
                                 arg_name, "\" is not supported."));
       }
+    }
+
+    std::vector<std::string> images_vec;
+    if (spec.TryGetRepeatedArgument(images_vec, "images")) {
+      for (auto &image_path : images_vec) {
+        images_.insert(std::move(image_path));
+      }
+      images_vec.clear();
     }
 
     output_polygon_masks_ = OutPolygonMasksEnabled(spec);
@@ -120,10 +129,6 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
     if (HasSavePreprocessedAnnotations(spec) != HasSavePreprocessedAnnotationsDir(spec)) {
       DALI_FAIL("``save_preprocessed_annotations`` and ``save_preprocessed_annotations_dir`` "
                 "should be provided together");
-    }
-
-    if (has_files_arg_ && HasPreprocessedAnnotations(spec)) {
-      DALI_FAIL("``files`` and ``preprocessed_annotations`` are mutually exclusive")
     }
   }
 
@@ -229,6 +234,8 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
   bool output_pixelwise_masks_ = false;
   bool output_image_ids_ = false;
   bool has_preprocessed_annotations_ = false;
+
+  std::unordered_set<std::string> images_;
 };
 
 }  // namespace dali

--- a/dali/test/python/test_operator_coco_reader.py
+++ b/dali/test/python/test_operator_coco_reader.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.fn as fn
+from test_utils import get_dali_extra_path
+import os
+from nose.tools import raises
+
+test_data_root = get_dali_extra_path()
+file_root = os.path.join(test_data_root, 'db', 'coco', 'images')
+train_annotations = os.path.join(test_data_root, 'db', 'coco', 'instances.json')
+
+files = [
+    'car-race-438467_1280.jpg', 
+    'clock-1274699_1280.jpg', 
+    'kite-1159538_1280.jpg', 
+    'cow-234835_1280.jpg', 
+    'home-office-336378_1280.jpg', 
+    'suit-2619784_1280.jpg', 
+    'business-suit-690048_1280.jpg', 
+    'car-604019_1280.jpg']
+
+
+def get_pipeline():
+    pipeline = Pipeline(batch_size=2, num_threads=4, device_id=0)
+    
+    with pipeline:
+        inputs, _, _, ids = fn.coco_reader(
+            file_root=file_root,
+            annotations_file=train_annotations,
+            image_ids=True,
+            files=files,
+            save_preprocessed_annotations=True,
+            save_preprocessed_annotations_dir='/tmp')
+        pipeline.set_outputs(ids)
+
+    return pipeline
+
+
+def test_operator_coco_reader():
+    pipeline = get_pipeline()
+    pipeline.build()
+
+    out = pipeline.run()
+    assert (out[0].as_array().ravel() == [0, 5]).all()
+
+    out = pipeline.run()
+    assert (out[0].as_array().ravel() == [6, 17]).all()
+
+    out = pipeline.run()
+    assert (out[0].as_array().ravel() == [21, 39]).all()
+
+    out = pipeline.run()
+    assert (out[0].as_array().ravel() == [41, 59]).all()
+
+    out = pipeline.run()
+    assert (out[0].as_array().ravel() == [0, 5]).all()
+
+    out = pipeline.run()
+    assert (out[0].as_array().ravel() == [6, 17]).all()
+
+    out = pipeline.run()
+    assert (out[0].as_array().ravel() == [21, 39]).all()
+
+    out = pipeline.run()
+    assert (out[0].as_array().ravel() == [41, 59]).all()
+
+
+    with open('/tmp/filenames.dat') as f:
+        lines = f.read().splitlines()
+
+    assert lines.sort() == files.sort()
+
+
+@raises(RuntimeError)
+def test_invalid_args():
+    pipeline = Pipeline(batch_size=2, num_threads=4, device_id=0)
+    
+    with pipeline:
+        inputs, _, _, ids = fn.coco_reader(
+            file_root=file_root,
+            annotations_file=train_annotations,
+            image_ids=True,
+            files=files,
+            preprocessed_annotations_dir='/tmp')
+        pipeline.set_outputs(ids)
+
+    pipeline.build()
+

--- a/dali/test/python/test_operator_coco_reader.py
+++ b/dali/test/python/test_operator_coco_reader.py
@@ -23,16 +23,19 @@ test_data_root = get_dali_extra_path()
 file_root = os.path.join(test_data_root, 'db', 'coco', 'images')
 train_annotations = os.path.join(test_data_root, 'db', 'coco', 'instances.json')
 
-files = [
-    'car-race-438467_1280.jpg', 
-    'clock-1274699_1280.jpg', 
-    'kite-1159538_1280.jpg', 
-    'cow-234835_1280.jpg', 
-    'home-office-336378_1280.jpg', 
-    'suit-2619784_1280.jpg', 
-    'business-suit-690048_1280.jpg', 
-    'car-604019_1280.jpg']
+test_data = {
+    'car-race-438467_1280.jpg' : 0,
+    'clock-1274699_1280.jpg' : 5,
+    'kite-1159538_1280.jpg' : 6,
+    'cow-234835_1280.jpg' : 17,
+    'home-office-336378_1280.jpg' : 21,
+    'suit-2619784_1280.jpg' : 39,
+    'business-suit-690048_1280.jpg' : 41,
+    'car-604019_1280.jpg' : 59
+}
 
+files = list(test_data.keys())
+expected_ids = list(test_data.values())
 
 def test_operator_coco_reader():
     with tempfile.TemporaryDirectory() as annotations_dir:
@@ -48,10 +51,12 @@ def test_operator_coco_reader():
             pipeline.set_outputs(ids)
         pipeline.build()
 
-        expected_ids = [[0, 5], [6, 17], [21, 39], [41, 59], [0, 5], [6, 17], [21, 39], [41, 59]]
-        for i in range(len(expected_ids)):
+        i = 0
+        while i < len(files):
             out = pipeline.run()
-            assert (out[0].as_array().ravel() == expected_ids[i]).all()
+            assert out[0].at(0) == expected_ids[i]
+            assert out[0].at(1) == expected_ids[i + 1]
+            i = i + 2
 
         filenames_file = os.path.join(annotations_dir, 'filenames.dat')
         with open(filenames_file) as f:

--- a/dali/test/python/test_operator_coco_reader.py
+++ b/dali/test/python/test_operator_coco_reader.py
@@ -35,7 +35,7 @@ test_data = {
     'car-604019_1280.jpg' : 59
 }
 
-files = list(test_data.keys())
+images = list(test_data.keys())
 expected_ids = list(test_data.values())
 
 def test_operator_coco_reader():
@@ -46,23 +46,23 @@ def test_operator_coco_reader():
                 file_root=file_root,
                 annotations_file=train_annotations,
                 image_ids=True,
-                files=files,
+                images=images,
                 save_preprocessed_annotations=True,
                 save_preprocessed_annotations_dir=annotations_dir)
             pipeline.set_outputs(ids)
         pipeline.build()
 
         i = 0
-        while i < len(files):
+        while i < len(images):
             out = pipeline.run()
-            assert out[0].at(0) == expected_ids[i]
-            assert out[0].at(1) == expected_ids[i + 1]
+            assert out[0].at(0) == expected_ids[i], f"{out[0].at(0)} != {expected_ids[i]}"
+            assert out[0].at(1) == expected_ids[i + 1], f"{out[0].at(1)} != {expected_ids[i + 1]}"
             i = i + 2
 
         filenames_file = os.path.join(annotations_dir, 'filenames.dat')
         with open(filenames_file) as f:
             lines = f.read().splitlines()
-        assert lines.sort() == files.sort()
+        assert lines.sort() == images.sort()
 
 def test_operator_coco_reader_same_images():
     file_root = os.path.join(test_data_root, 'db', 'coco_pixelwise', 'images')
@@ -126,7 +126,7 @@ def test_invalid_args():
             file_root=file_root,
             annotations_file=train_annotations,
             image_ids=True,
-            files=files,
+            images=images,
             preprocessed_annotations_dir='/tmp')
         pipeline.set_outputs(ids)
     pipeline.build()

--- a/dali/test/python/test_operator_coco_reader.py
+++ b/dali/test/python/test_operator_coco_reader.py
@@ -55,8 +55,8 @@ def test_operator_coco_reader():
         i = 0
         while i < len(images):
             out = pipeline.run()
-            assert out[0].at(0) == expected_ids[i], f"{out[0].at(0)} != {expected_ids[i]}"
-            assert out[0].at(1) == expected_ids[i + 1], f"{out[0].at(1)} != {expected_ids[i + 1]}"
+            assert out[0].at(0) == expected_ids[i]
+            assert out[0].at(1) == expected_ids[i + 1]
             i = i + 2
 
         filenames_file = os.path.join(annotations_dir, 'filenames.dat')


### PR DESCRIPTION
Signed-off-by: Albert Wolant <awolant@nvidia.com>

#### Why we need this PR?
- It adds new feature

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Filter parsed image infos and annotations based on provided arg*
 - Affected modules and functionalities:
     *CocoLoader*
 - Validation and testing:
     *Added Python test*
 - Documentation (including examples):
     *Added doc string for new arg*

**JIRA TASK**: *[Use DALI-1773]*
