### PR TITLE
Add syncrhonization after randomizer construction.

### DIFF
--- a/dali/operators/util/randomizer.cuh
+++ b/dali/operators/util/randomizer.cuh
@@ -39,7 +39,6 @@ struct curand_states {
 
  private:
   size_t len_;
-  int device_;
   std::shared_ptr<curandState> states_mem_;
   curandState* states_;  // std::shared_ptr::get can't be called from __device__ functions
 };


### PR DESCRIPTION
Add syncrhonization after randomizer constructio.
Remove unused device_ field.

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: missing synchronization after initialization of curand states.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Add temporary stream, run everything there and syncrhonize.
 - Affected modules and functionalities:
     * Randomizer: normali distribution, jitter
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * It was a race condition - no reliable repro
     * Regression test: jitter and normal_distribution tests
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
