### PR TITLE
Move examples to fn api

### DIFF
--- a/dali/test/python/test_RN50_data_fw_iterators.py
+++ b/dali/test/python/test_RN50_data_fw_iterators.py
@@ -165,7 +165,7 @@ def test_fw_iter(IteratorClass, args):
                         .format(iterator_name, j + 1, iters, data_time.avg, data_time.max_val, args.gpus * args.batch_size / data_time.avg))
                 end = time.time()
         else:
-            dali_train_iter = IteratorClass(pipes, pipes[0].epoch_size("Reader"))
+            dali_train_iter = IteratorClass(pipes, reader_name="Reader")
             j = 0
             for it in iter(dali_train_iter):
                 data_time.update(time.time() - end)

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -29,7 +29,7 @@ class COCOReaderPipeline(Pipeline):
         super(COCOReaderPipeline, self).__init__(batch_size, num_threads, 0, prefetch_queue_depth=1)
         self.input = ops.COCOReader(file_root = data_paths[0], annotations_file=data_paths[1],
                                     shard_id = shard_id, num_shards = num_gpus, random_shuffle=random_shuffle,
-                                    save_img_ids=True, stick_to_shard=stick_to_shard,shuffle_after_epoch=shuffle_after_epoch,
+                                    image_ids=True, stick_to_shard=stick_to_shard,shuffle_after_epoch=shuffle_after_epoch,
                                     pad_last_batch=pad_last_batch, initial_fill=initial_fill)
         self.return_labels=return_labels
 

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -221,10 +221,11 @@ Here are the iterator options:
     divisible by the batch size.
   | Only partially filled with the data or dropped entirely if it. The possible options are:
 
-  - FILL - Fills the last batch with the data wrapping up the data set. The precise
-            behavior depends on the reader which may duplicate the last sample to fill the batch
-  - DROP - If the last batch cannot be fully filled by the data from given epoch it is dropped
-  - PARTIAL - Returns the part of the last batch filled with the data relevant to given epoch
+  - | FILL - Fills the last batch with the data wrapping up the data set.
+    | The precise behavior depends on the reader which may duplicate the last sample to fill
+      the batch.
+  - DROP - If the last batch cannot be fully filled by the data from given epoch it is dropped.
+  - PARTIAL - Returns the part of the last batch filled with the data relevant to given epoch.
 
 Here is the formula to calculate the shard size for a shard ID:
 

--- a/docs/examples/use_cases/mxnet/mxnet-resnet50.ipynb
+++ b/docs/examples/use_cases/mxnet/mxnet-resnet50.ipynb
@@ -24,6 +24,7 @@
     "from nvidia.dali.pipeline import Pipeline\n",
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",
+    "import nvidia.dali.fn as fn\n",
     "\n",
     "N = 8  # number of GPUs\n",
     "batch_size = 128  # batch size per GPU\n",
@@ -43,7 +44,9 @@
     " * RGB images are then randomly cropped and resized to the final size of (224, 224) pixels\n",
     " * Finally, the batch is transposed from NHWC layout to NCHW layout, normalized and randomly mirrored.\n",
     " \n",
-    "`DALIClassificationIterator`, which we will use for interfacing with MXNet in this example, requires outputs of the pipeline to follow (image, label) structure."
+    "`DALIClassificationIterator`, which we will use for interfacing with MXNet in this example, requires outputs of the pipeline to follow (image, label) structure.\n",
+    "\n",
+    "The validation pipeline is similar to the training pipeline, but omits the random resized crop and random mirroring steps, as well as shuffling the data coming from the reader."
    ]
   },
   {
@@ -52,42 +55,53 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class HybridTrainPipe(Pipeline):\n",
-    "    def __init__(self, batch_size, num_threads, device_id, num_gpus):\n",
-    "        super(HybridTrainPipe, self).__init__(batch_size, num_threads, device_id, seed = 12 + device_id)\n",
-    "        self.input = ops.MXNetReader(path = [db_folder+\"train.rec\"], index_path=[db_folder+\"train.idx\"],\n",
-    "                                     random_shuffle = True, shard_id = device_id, num_shards = num_gpus,\n",
-    "                                     pad_last_batch=True)\n",
-    "        self.decode = ops.ImageDecoderRandomCrop(device = \"mixed\",\n",
-    "                                                  output_type = types.RGB,\n",
-    "                                                  random_aspect_ratio = [0.8, 1.25],\n",
-    "                                                  random_area = [0.1, 1.0],\n",
-    "                                                  num_attempts = 100)\n",
-    "        self.resize = ops.Resize(device = \"gpu\", resize_x = 224, resize_y = 224)\n",
-    "        self.cmnp = ops.CropMirrorNormalize(device = \"gpu\",\n",
-    "                                            dtype = types.FLOAT,\n",
-    "                                            output_layout = types.NCHW,\n",
-    "                                            crop = (224, 224),\n",
-    "                                            mean = [0.485 * 255,0.456 * 255,0.406 * 255],\n",
-    "                                            std = [0.229 * 255,0.224 * 255,0.225 * 255])\n",
-    "        self.coin = ops.CoinFlip(probability = 0.5)\n",
+    "def get_dali_pipeline(batch_size, num_threads, device_id, db_folder, crop, size,\n",
+    "                       shard_id, num_shards, dali_cpu=False, is_training=True):\n",
+    "    pipeline = Pipeline(batch_size, num_threads, device_id, seed=12 + device_id)\n",
+    "    with pipeline:\n",
+    "        images, labels = fn.mxnet_reader(path=[db_folder+\"train.rec\"], index_path=[db_folder+\"train.idx\"],\n",
+    "                                          random_shuffle=False, shard_id=device_id, num_shards=num_shards,\n",
+    "                                          pad_last_batch=is_training, name=\"Reader\")\n",
+    "        dali_device = 'cpu' if dali_cpu else 'gpu'\n",
+    "        decoder_device = 'cpu' if dali_cpu else 'mixed'\n",
+    "        device_memory_padding = 211025920 if decoder_device == 'mixed' else 0\n",
+    "        host_memory_padding = 140544512 if decoder_device == 'mixed' else 0\n",
+    "        if is_training:\n",
+    "            images = fn.image_decoder_random_crop(images,\n",
+    "                                                  device=decoder_device, output_type=types.RGB,\n",
+    "                                                  device_memory_padding=device_memory_padding,\n",
+    "                                                  host_memory_padding=host_memory_padding,\n",
+    "                                                  random_aspect_ratio=[0.8, 1.25],\n",
+    "                                                  random_area=[0.1, 1.0],\n",
+    "                                                  num_attempts=100)\n",
+    "            images = fn.resize(images,\n",
+    "                               device=dali_device,\n",
+    "                               resize_x=crop,\n",
+    "                               resize_y=crop,\n",
+    "                               interp_type=types.INTERP_TRIANGULAR)\n",
+    "            mirror = fn.coin_flip(probability=0.5)\n",
+    "        else:\n",
+    "            images = fn.image_decoder(images,\n",
+    "                                      device=decoder_device,\n",
+    "                                      output_type=types.RGB)\n",
+    "            # Make sure that every image > 224 for CropMirrorNormalize\n",
+    "            images = fn.resize(images,\n",
+    "                               device=dali_device,\n",
+    "                               resize_shorter=size,\n",
+    "                               interp_type=types.INTERP_TRIANGULAR)\n",
+    "            mirror = False\n",
     "\n",
-    "    def define_graph(self):\n",
-    "        rng = self.coin()\n",
-    "        self.jpegs, self.labels = self.input(name = \"Reader\")\n",
-    "        images = self.decode(self.jpegs)\n",
-    "        images = self.resize(images)\n",
-    "        output = self.cmnp(images, mirror = rng)\n",
-    "        return [output, self.labels]\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### The validation pipeline\n",
-    "\n",
-    "The validation pipeline is similar to the training pipeline, but omits the random resized crop and random mirroring steps, as well as shuffling the data coming from the reader."
+    "        images = fn.crop_mirror_normalize(images.gpu(),\n",
+    "                                          device=\"gpu\",\n",
+    "                                          dtype=types.FLOAT,\n",
+    "                                          output_layout=\"CHW\",\n",
+    "                                          crop=(crop, crop),\n",
+    "                                          mean=[0.485 * 255,0.456 * 255,0.406 * 255],\n",
+    "                                          std=[0.229 * 255,0.224 * 255,0.225 * 255],\n",
+    "                                          mirror=mirror)\n",
+    "        labels = labels.gpu()\n",
+    "        pipeline.set_outputs(images, labels)\n",
+    "    return pipeline\n"
    ]
   },
   {
@@ -96,35 +110,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class HybridValPipe(Pipeline):\n",
-    "    def __init__(self, batch_size, num_threads, device_id, num_gpus):\n",
-    "        super(HybridValPipe, self).__init__(batch_size, num_threads, device_id, seed = 12 + device_id)\n",
-    "        self.input = ops.MXNetReader(path = [db_folder+\"val.rec\"], index_path=[db_folder+\"val.idx\"],\n",
-    "                                     random_shuffle = False, shard_id = device_id, num_shards = num_gpus,\n",
-    "                                     pad_last_batch=True)\n",
-    "        self.decode = ops.ImageDecoder(device = \"mixed\", output_type = types.RGB)\n",
-    "        self.cmnp = ops.CropMirrorNormalize(device = \"gpu\",\n",
-    "                                            dtype = types.FLOAT,\n",
-    "                                            output_layout = types.NCHW,\n",
-    "                                            crop = (224, 224),\n",
-    "                                            mean = [0.485 * 255,0.456 * 255,0.406 * 255],\n",
-    "                                            std = [0.229 * 255,0.224 * 255,0.225 * 255])\n",
-    "\n",
-    "    def define_graph(self):\n",
-    "        self.jpegs, self.labels = self.input(name = \"Reader\")\n",
-    "        images = self.decode(self.jpegs)\n",
-    "        output = self.cmnp(images)\n",
-    "        return [output, self.labels]\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "trainpipes = [HybridTrainPipe(batch_size=batch_size, num_threads=2, device_id = i, num_gpus = N) for i in range(N)]\n",
-    "valpipes = [HybridValPipe(batch_size=batch_size, num_threads=2, device_id = i, num_gpus = N) for i in range(N)]"
+    "trainpipes = [get_dali_pipeline(db_folder=db_folder, batch_size=batch_size, num_threads=2, device_id=i, crop=224, size=256, shard_id=i, num_shards=N, is_training=True) for i in range(N)]\n",
+    "valpipes = [get_dali_pipeline(db_folder=db_folder, batch_size=batch_size, num_threads=2, device_id=i, crop=224, size=256, shard_id=i, num_shards=N, is_training=False) for i in range(N)]"
    ]
   },
   {
@@ -140,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -176,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -319,3 +306,4 @@
  "nbformat": 4,
  "nbformat_minor": 2
 }
+

--- a/docs/examples/use_cases/mxnet/mxnet-resnet50.ipynb
+++ b/docs/examples/use_cases/mxnet/mxnet-resnet50.ipynb
@@ -55,8 +55,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_dali_pipeline(batch_size, num_threads, device_id, db_folder, crop, size,\n",
-    "                       shard_id, num_shards, dali_cpu=False, is_training=True):\n",
+    "def create_dali_pipeline(batch_size, num_threads, device_id, db_folder, crop, size,\n",
+    "                         shard_id, num_shards, dali_cpu=False, is_training=True):\n",
     "    pipeline = Pipeline(batch_size, num_threads, device_id, seed=12 + device_id)\n",
     "    with pipeline:\n",
     "        images, labels = fn.mxnet_reader(path=[db_folder+\"train.rec\"], index_path=[db_folder+\"train.idx\"],\n",
@@ -84,15 +84,14 @@
     "            images = fn.image_decoder(images,\n",
     "                                      device=decoder_device,\n",
     "                                      output_type=types.RGB)\n",
-    "            # Make sure that every image > 224 for CropMirrorNormalize\n",
     "            images = fn.resize(images,\n",
     "                               device=dali_device,\n",
-    "                               resize_shorter=size,\n",
+    "                               size=size,\n",
+    "                               mode=\"not_smaller\",\n",
     "                               interp_type=types.INTERP_TRIANGULAR)\n",
     "            mirror = False\n",
     "\n",
     "        images = fn.crop_mirror_normalize(images.gpu(),\n",
-    "                                          device=\"gpu\",\n",
     "                                          dtype=types.FLOAT,\n",
     "                                          output_layout=\"CHW\",\n",
     "                                          crop=(crop, crop),\n",
@@ -110,8 +109,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainpipes = [get_dali_pipeline(db_folder=db_folder, batch_size=batch_size, num_threads=2, device_id=i, crop=224, size=256, shard_id=i, num_shards=N, is_training=True) for i in range(N)]\n",
-    "valpipes = [get_dali_pipeline(db_folder=db_folder, batch_size=batch_size, num_threads=2, device_id=i, crop=224, size=256, shard_id=i, num_shards=N, is_training=False) for i in range(N)]"
+    "trainpipes = [create_dali_pipeline(db_folder=db_folder, batch_size=batch_size, \n",
+    "                                   num_threads=2, device_id=i, shard_id=i, num_shards=N, is_training=True,\n",
+    "                                   crop=224, size=256) for i in range(N)]\n",
+    "valpipes = [create_dali_pipeline(db_folder=db_folder, batch_size=batch_size,\n",
+    "                                 num_threads=2, device_id=i, shard_id=i, num_shards=N, is_training=False, \n",
+    "                                 crop=224, size=256) for i in range(N)]"
    ]
   },
   {
@@ -306,4 +309,3 @@
  "nbformat": 4,
  "nbformat_minor": 2
 }
-

--- a/docs/examples/use_cases/paddle/resnet50/main.py
+++ b/docs/examples/use_cases/paddle/resnet50/main.py
@@ -167,30 +167,30 @@ def main():
     FLAGS.whole_batch_size = FLAGS.world_size * FLAGS.batch_size
 
     pipe = create_dali_pipeline(batch_size=FLAGS.batch_size,
-                             num_threads=FLAGS.num_threads,
-                             device_id=FLAGS.device_id,
-                             data_dir=os.path.join(FLAGS.data, 'train'),
-                             crop=224,
-                             size=256,
-                             dali_cpu=False,
-                             shard_id=FLAGS.local_rank,
-                             num_shards=FLAGS.world_size,
-                             is_training=True)
+                                num_threads=FLAGS.num_threads,
+                                device_id=FLAGS.device_id,
+                                data_dir=os.path.join(FLAGS.data, 'train'),
+                                crop=224,
+                                size=256,
+                                dali_cpu=False,
+                                shard_id=FLAGS.local_rank,
+                                num_shards=FLAGS.world_size,
+                                is_training=True)
     pipe.build()
     sample_per_shard = pipe.epoch_size("Reader") // FLAGS.world_size
     train_loader = DALIClassificationIterator(pipe, reader_name="Reader")
 
     if FLAGS.local_rank == 0:
         pipe = create_dali_pipeline(batch_size=FLAGS.batch_size,
-                                num_threads=FLAGS.num_threads,
-                                device_id=FLAGS.device_id,
-                                data_dir=os.path.join(FLAGS.data, 'val'),
-                                crop=224,
-                                size=256,
-                                dali_cpu=False,
-                                shard_id=0,
-                                num_shards=1,
-                                is_training=False)
+                                    num_threads=FLAGS.num_threads,
+                                    device_id=FLAGS.device_id,
+                                    data_dir=os.path.join(FLAGS.data, 'val'),
+                                    crop=224,
+                                    size=256,
+                                    dali_cpu=False,
+                                    shard_id=0,
+                                    num_shards=1,
+                                    is_training=False)
         pipe.build()
         val_loader = DALIClassificationIterator(pipe, reader_name="Reader")
 

--- a/docs/examples/use_cases/paddle/ssd/train.py
+++ b/docs/examples/use_cases/paddle/ssd/train.py
@@ -61,11 +61,9 @@ def create_coco_pipeline(file_root,
                                                                     scaling=[0.3, 1.0],
                                                                     bbox_layout="xyXY",
                                                                     allow_no_crop=True,
-                                                                    num_attempts=1)
-        images = fn.image_decoder_slice(
-            images, crop_begin, crop_size, device="cpu", output_type=types.RGB)
+                                                                    num_attempts=50)
+        images = fn.image_decoder_slice(images, crop_begin, crop_size, device="mixed", output_type=types.RGB)
         flip_coin = fn.coin_flip(probability=0.5)
-        images = images.gpu()
         images = fn.resize(images,
                            resize_x=300,
                            resize_y=300,
@@ -75,20 +73,20 @@ def create_coco_pipeline(file_root,
         images = fn.hsv(images, dtype=types.FLOAT, hue=fn.uniform(range=[-0.5, 0.5]),
                         saturation=fn.uniform(range=[0.5, 1.5]))
 
-        images=fn.brightness_contrast(images,
-                                      contrast_center = 128,  # input is in float, but in 0..255 range
-                                      dtype = types.UINT8,
-                                      brightness = fn.uniform(range=[0.875, 1.125]),
-                                      contrast = fn.uniform(range=[0.5, 1.5]))
+        images = fn.brightness_contrast(images,
+                                        contrast_center = 128,  # input is in float, but in 0..255 range
+                                        dtype = types.UINT8,
+                                        brightness = fn.uniform(range=[0.875, 1.125]),
+                                        contrast = fn.uniform(range=[0.5, 1.5]))
 
-        bboxes=fn.bb_flip(bboxes, ltrb=True, horizontal=flip_coin)
-        images=fn.crop_mirror_normalize(images,
-                                        mean=[104., 117., 123.],
-                                        std=[1., 1., 1.],
-                                        mirror=flip_coin,
-                                        dtype=types.FLOAT,
-                                        output_layout="CHW",
-                                        pad_output=False)
+        bboxes = fn.bb_flip(bboxes, ltrb=True, horizontal=flip_coin)
+        images = fn.crop_mirror_normalize(images,
+                                          mean=[104., 117., 123.],
+                                          std=[1., 1., 1.],
+                                          mirror=flip_coin,
+                                          dtype=types.FLOAT,
+                                          output_layout="CHW",
+                                          pad_output=False)
 
         pipeline.set_outputs(images, bboxes, labels)
     return pipeline

--- a/docs/examples/use_cases/paddle/tsm/infer.py
+++ b/docs/examples/use_cases/paddle/tsm/infer.py
@@ -30,20 +30,19 @@ from utils import load_weights
 PRETRAIN_WEIGHTS = 'https://paddlemodels.bj.bcebos.com/video_classification/TSM_final.pdparams'
 
 
-def get_video_pipe(video_files, sequence_length=8, target_size=224,stride=30):
+def create_video_pipe(video_files, sequence_length=8, target_size=224,stride=30):
     pipeline = Pipeline(1, 4, 0, seed=42)
     with pipeline:
-        images = fn.video_reader(
-            device="gpu", filenames=video_files,
-            sequence_length=sequence_length, stride=stride,
-            shard_id=0, num_shards=1, random_shuffle=False, pad_last_batch=True, name="Reader")
-        images = fn.crop_mirror_normalize(
-            images,
-            dtype=types.FLOAT,
-            output_layout="FCHW",
-            crop=(target_size, target_size),
-            mean=[0.485 * 255, 0.456 * 255, 0.406 * 255],
-            std=[0.229 * 255, 0.224 * 255, 0.225 * 255])
+        images = fn.video_reader(device="gpu", filenames=video_files,
+                                 sequence_length=sequence_length, stride=stride,
+                                 shard_id=0, num_shards=1, random_shuffle=False,
+                                 pad_last_batch=True, name="Reader")
+        images = fn.crop_mirror_normalize(images,
+                                          dtype=types.FLOAT,
+                                          output_layout="FCHW",
+                                          crop=(target_size, target_size),
+                                          mean=[0.485 * 255, 0.456 * 255, 0.406 * 255],
+                                          std=[0.229 * 255, 0.224 * 255, 0.225 * 255])
 
         pipeline.set_outputs(images)
     return pipeline
@@ -64,7 +63,7 @@ def main():
     target_size = 224
 
     video_files = [FLAGS.data + '/' + f for f in os.listdir(FLAGS.data)]
-    pipeline = get_video_pipe(video_files, seg_num, target_size, FLAGS.stride)
+    pipeline = create_video_pipe(video_files, seg_num, target_size, FLAGS.stride)
 
     video_loader = DALIGenericIterator(
         pipeline, ['image'], reader_name="Reader", dynamic_shape=True)

--- a/docs/examples/use_cases/paddle/tsm/infer.py
+++ b/docs/examples/use_cases/paddle/tsm/infer.py
@@ -20,8 +20,8 @@ import os
 from paddle import fluid
 
 from nvidia.dali.pipeline import Pipeline
-import nvidia.dali.ops as ops
 import nvidia.dali.types as types
+import nvidia.dali.fn as fn
 from nvidia.dali.plugin.paddle import DALIGenericIterator
 
 from tsm import TSM
@@ -30,25 +30,23 @@ from utils import load_weights
 PRETRAIN_WEIGHTS = 'https://paddlemodels.bj.bcebos.com/video_classification/TSM_final.pdparams'
 
 
-class VideoPipe(Pipeline):
-    def __init__(self, video_files, sequence_length=8, target_size=224,
-                 stride=30):
-        super(VideoPipe, self).__init__(1, 4, 0, seed=42)
-        self.input = ops.VideoReader(
+def get_video_pipe(video_files, sequence_length=8, target_size=224,stride=30):
+    pipeline = Pipeline(1, 4, 0, seed=42)
+    with pipeline:
+        images = fn.video_reader(
             device="gpu", filenames=video_files,
             sequence_length=sequence_length, stride=stride,
-            shard_id=0, num_shards=1, random_shuffle=False, pad_last_batch=True)
-        self.cmnp = ops.CropMirrorNormalize(
-            device="gpu",
+            shard_id=0, num_shards=1, random_shuffle=False, pad_last_batch=True, name="Reader")
+        images = fn.crop_mirror_normalize(
+            images,
             dtype=types.FLOAT,
-            output_layout=types.NFCHW,
+            output_layout="FCHW",
             crop=(target_size, target_size),
             mean=[0.485 * 255, 0.456 * 255, 0.406 * 255],
             std=[0.229 * 255, 0.224 * 255, 0.225 * 255])
 
-    def define_graph(self):
-        images = self.input(name="Reader")
-        return self.cmnp(images)
+        pipeline.set_outputs(images)
+    return pipeline
 
 
 def build(seg_num=8, target_size=224):
@@ -66,7 +64,7 @@ def main():
     target_size = 224
 
     video_files = [FLAGS.data + '/' + f for f in os.listdir(FLAGS.data)]
-    pipeline = VideoPipe(video_files, seg_num, target_size, FLAGS.stride)
+    pipeline = get_video_pipe(video_files, seg_num, target_size, FLAGS.stride)
 
     video_loader = DALIGenericIterator(
         pipeline, ['image'], reader_name="Reader", dynamic_shape=True)

--- a/docs/examples/use_cases/pytorch/resnet50/main.py
+++ b/docs/examples/use_cases/pytorch/resnet50/main.py
@@ -21,8 +21,8 @@ import numpy as np
 try:
     from nvidia.dali.plugin.pytorch import DALIClassificationIterator, LastBatchPolicy
     from nvidia.dali.pipeline import Pipeline
-    import nvidia.dali.ops as ops
     import nvidia.dali.types as types
+    import nvidia.dali.fn as fn
 except ImportError:
     raise ImportError("Please install DALI from https://www.github.com/NVIDIA/DALI to run this example.")
 
@@ -90,81 +90,56 @@ def to_python_float(t):
     else:
         return t[0]
 
-class HybridTrainPipe(Pipeline):
-    def __init__(self, batch_size, num_threads, device_id, data_dir, crop,
-                 shard_id, num_shards, dali_cpu=False):
-        super(HybridTrainPipe, self).__init__(batch_size,
-                                              num_threads,
-                                              device_id,
-                                              seed=12 + device_id)
-        self.input = ops.FileReader(file_root=data_dir,
-                                    shard_id=args.local_rank,
-                                    num_shards=args.world_size,
-                                    random_shuffle=True,
-                                    pad_last_batch=True)
-        #let user decide which pipeline works him bets for RN version he runs
+def get_dali_pipeline(batch_size, num_threads, device_id, data_dir, crop, size,
+                       shard_id, num_shards, dali_cpu=False, is_training=True):
+    pipeline = Pipeline(batch_size, num_threads, device_id, seed=12 + device_id)
+    with pipeline:
+        images, labels = fn.file_reader(file_root=data_dir,
+                                        shard_id=args.local_rank,
+                                        num_shards=args.world_size,
+                                        random_shuffle=is_training,
+                                        pad_last_batch=True,
+                                        name="Reader")
         dali_device = 'cpu' if dali_cpu else 'gpu'
         decoder_device = 'cpu' if dali_cpu else 'mixed'
-        # This padding sets the size of the internal nvJPEG buffers to be able to handle all images from full-sized ImageNet
-        # without additional reallocations
         device_memory_padding = 211025920 if decoder_device == 'mixed' else 0
         host_memory_padding = 140544512 if decoder_device == 'mixed' else 0
-        self.decode = ops.ImageDecoderRandomCrop(device=decoder_device, output_type=types.RGB,
-                                                 device_memory_padding=device_memory_padding,
-                                                 host_memory_padding=host_memory_padding,
-                                                 random_aspect_ratio=[0.8, 1.25],
-                                                 random_area=[0.1, 1.0],
-                                                 num_attempts=100)
-        self.res = ops.Resize(device=dali_device,
-                              resize_x=crop,
-                              resize_y=crop,
-                              interp_type=types.INTERP_TRIANGULAR)
-        self.cmnp = ops.CropMirrorNormalize(device="gpu",
-                                            dtype=types.FLOAT,
-                                            output_layout=types.NCHW,
-                                            crop=(crop, crop),
-                                            mean=[0.485 * 255,0.456 * 255,0.406 * 255],
-                                            std=[0.229 * 255,0.224 * 255,0.225 * 255])
-        self.coin = ops.CoinFlip(probability=0.5)
-        print('DALI "{0}" variant'.format(dali_device))
+        if is_training:
+            images = fn.image_decoder_random_crop(images,
+                                                  device=decoder_device, output_type=types.RGB,
+                                                  device_memory_padding=device_memory_padding,
+                                                  host_memory_padding=host_memory_padding,
+                                                  random_aspect_ratio=[0.8, 1.25],
+                                                  random_area=[0.1, 1.0],
+                                                  num_attempts=100)
+            images = fn.resize(images,
+                               device=dali_device,
+                               resize_x=crop,
+                               resize_y=crop,
+                               interp_type=types.INTERP_TRIANGULAR)
+            mirror = fn.coin_flip(probability=0.5)
+        else:
+            images = fn.image_decoder(images,
+                                      device=decoder_device,
+                                      output_type=types.RGB)
+            # Make sure that every image > 224 for CropMirrorNormalize
+            images = fn.resize(images,
+                               device=dali_device,
+                               resize_shorter=size,
+                               interp_type=types.INTERP_TRIANGULAR)
+            mirror = False
 
-    def define_graph(self):
-        rng = self.coin()
-        self.jpegs, self.labels = self.input(name="Reader")
-        images = self.decode(self.jpegs)
-        images = self.res(images)
-        output = self.cmnp(images.gpu(), mirror=rng)
-        return [output, self.labels]
-
-class HybridValPipe(Pipeline):
-    def __init__(self, batch_size, num_threads, device_id, data_dir, crop,
-                 size, shard_id, num_shards):
-        super(HybridValPipe, self).__init__(batch_size,
-                                           num_threads,
-                                            device_id,
-                                            seed=12 + device_id)
-        self.input = ops.FileReader(file_root=data_dir,
-                                    shard_id=args.local_rank,
-                                    num_shards=args.world_size,
-                                    random_shuffle=False,
-                                    pad_last_batch=True)
-        self.decode = ops.ImageDecoder(device="mixed", output_type=types.RGB)
-        self.res = ops.Resize(device="gpu",
-                              resize_shorter=size,
-                              interp_type=types.INTERP_TRIANGULAR)
-        self.cmnp = ops.CropMirrorNormalize(device="gpu",
-                                            dtype=types.FLOAT,
-                                            output_layout=types.NCHW,
-                                            crop=(crop, crop),
-                                            mean=[0.485 * 255,0.456 * 255,0.406 * 255],
-                                            std=[0.229 * 255,0.224 * 255,0.225 * 255])
-
-    def define_graph(self):
-        self.jpegs, self.labels = self.input(name="Reader")
-        images = self.decode(self.jpegs)
-        images = self.res(images)
-        output = self.cmnp(images)
-        return [output, self.labels]
+        images = fn.crop_mirror_normalize(images.gpu(),
+                                          device="gpu",
+                                          dtype=types.FLOAT,
+                                          output_layout="CHW",
+                                          crop=(crop, crop),
+                                          mean=[0.485 * 255,0.456 * 255,0.406 * 255],
+                                          std=[0.229 * 255,0.224 * 255,0.225 * 255],
+                                          mirror=mirror)
+        labels = labels.gpu()
+        pipeline.set_outputs(images, labels)
+    return pipeline
 
 def main():
     global best_prec1, args
@@ -311,25 +286,29 @@ def main():
         crop_size = 224
         val_size = 256
 
-    pipe = HybridTrainPipe(batch_size=args.batch_size,
-                           num_threads=args.workers,
-                           device_id=args.local_rank,
-                           data_dir=traindir,
-                           crop=crop_size,
-                           dali_cpu=args.dali_cpu,
-                           shard_id=args.local_rank,
-                           num_shards=args.world_size)
+    pipe = get_dali_pipeline(batch_size=args.batch_size,
+                             num_threads=args.workers,
+                             device_id=args.local_rank,
+                             data_dir=traindir,
+                             crop=crop_size,
+                             size=val_size,
+                             dali_cpu=args.dali_cpu,
+                             shard_id=args.local_rank,
+                             num_shards=args.world_size,
+                             is_training=True)
     pipe.build()
     train_loader = DALIClassificationIterator(pipe, reader_name="Reader", last_batch_policy=LastBatchPolicy.PARTIAL)
 
-    pipe = HybridValPipe(batch_size=args.batch_size,
-                         num_threads=args.workers,
-                         device_id=args.local_rank,
-                         data_dir=valdir,
-                         crop=crop_size,
-                         size=val_size,
-                         shard_id=args.local_rank,
-                         num_shards=args.world_size)
+    pipe = get_dali_pipeline(batch_size=args.batch_size,
+                             num_threads=args.workers,
+                             device_id=args.local_rank,
+                             data_dir=valdir,
+                             crop=crop_size,
+                             size=val_size,
+                             dali_cpu=args.dali_cpu,
+                             shard_id=args.local_rank,
+                             num_shards=args.world_size,
+                             is_training=False)
     pipe.build()
     val_loader = DALIClassificationIterator(pipe, reader_name="Reader", last_batch_policy=LastBatchPolicy.PARTIAL)
 
@@ -382,7 +361,7 @@ def train(train_loader, model, criterion, optimizer, epoch):
 
     for i, data in enumerate(train_loader):
         input = data[0]["data"]
-        target = data[0]["label"].squeeze(-1).cuda().long()
+        target = data[0]["label"].squeeze(-1).long()
         train_loader_len = int(math.ceil(train_loader._size / args.batch_size))
 
         if args.prof >= 0 and i == args.prof:
@@ -478,7 +457,7 @@ def validate(val_loader, model, criterion):
 
     for i, data in enumerate(val_loader):
         input = data[0]["data"]
-        target = data[0]["label"].squeeze(-1).cuda().long()
+        target = data[0]["label"].squeeze(-1).long()
         val_loader_len = int(val_loader._size / args.batch_size)
 
         # compute output

--- a/docs/examples/use_cases/pytorch/single_stage_detector/src/coco_pipeline.py
+++ b/docs/examples/use_cases/pytorch/single_stage_detector/src/coco_pipeline.py
@@ -15,110 +15,84 @@
 
 import torch
 from nvidia.dali.pipeline import Pipeline
-import nvidia.dali.ops as ops
 import nvidia.dali.types as types
+import nvidia.dali.fn as fn
 
 
-class COCOPipeline(Pipeline):
-    def __init__(self, default_boxes, args, seed):
-        super(COCOPipeline, self).__init__(
-            batch_size=args.batch_size,
-            device_id=args.local_rank,
-            num_threads=args.num_workers,
-            seed=seed)
+def get_coco_pipeline(default_boxes, args, seed):
+    pipeline = Pipeline(args.batch_size, args.num_workers,
+                        args.local_rank, seed=seed)
+    try:
+        shard_id = torch.distributed.get_rank()
+        num_shards = torch.distributed.get_world_size()
+    except RuntimeError:
+        shard_id = 0
+        num_shards = 1
+    with pipeline:
+        images, bboxes, labels = fn.coco_reader(file_root=args.train_coco_root,
+                                                annotations_file=args.train_annotate,
+                                                skip_empty=True,
+                                                shard_id=shard_id,
+                                                num_shards=num_shards,
+                                                ratio=True,
+                                                ltrb=True,
+                                                random_shuffle=False,
+                                                shuffle_after_epoch=True,
+                                                name="Reader")
 
-        try:
-            shard_id = torch.distributed.get_rank()
-            num_shards = torch.distributed.get_world_size()
-        except RuntimeError:
-            shard_id = 0
-            num_shards = 1
+        crop_begin, crop_size, bboxes, labels = fn.random_bbox_crop(bboxes, labels,
+                                                                    device="cpu",
+                                                                    aspect_ratio=[
+                                                                        0.5, 2.0],
+                                                                    thresholds=[
+                                                                        0, 0.1, 0.3, 0.5, 0.7, 0.9],
+                                                                    scaling=[
+                                                                        0.3, 1.0],
+                                                                    bbox_layout="xyXY",
+                                                                    allow_no_crop=True,
+                                                                    num_attempts=1)
+        images = fn.image_decoder_slice(
+            images, crop_begin, crop_size, device="cpu", output_type=types.RGB)
+        flip_coin = fn.coin_flip(probability=0.5)
+        images = images.gpu()
+        images = fn.resize(images,
+                            resize_x=300,
+                            resize_y=300,
+                            min_filter=types.DALIInterpType.INTERP_TRIANGULAR)
 
-        self.input = ops.COCOReader(
-            file_root=args.train_coco_root,
-            annotations_file=args.train_annotate,
-            skip_empty=True,
-            shard_id=shard_id,
-            num_shards=num_shards,
-            ratio=True,
-            ltrb=True,
-            random_shuffle=False,
-            shuffle_after_epoch=True)
+        saturation = fn.uniform(range=[0.5, 1.5])
+        contrast = fn.uniform(range=[0.5, 1.5])
+        brightness = fn.uniform(range=[0.875, 1.125])
+        hue = fn.uniform(range=[-0.5, 0.5])
 
-        self.decode = ops.ImageDecoder(device="cpu", output_type=types.RGB)
-
-        # Augumentation techniques
-        self.crop = ops.RandomBBoxCrop(
-            device="cpu",
-            aspect_ratio=[0.5, 2.0],
-            thresholds=[0, 0.1, 0.3, 0.5, 0.7, 0.9],
-            scaling=[0.3, 1.0],
-            bbox_layout="xyXY",
-            allow_no_crop=True,
-            num_attempts=1)
-        self.slice = ops.Slice(device="cpu")
-
-        self.hsv = ops.Hsv(device="gpu", dtype=types.FLOAT)  # use float to avoid clipping and
+        images = fn.hsv(images, dtype=types.FLOAT, hue=hue, saturation=saturation)  # use float to avoid clipping and
                                                              # quantizing the intermediate result
-        self.bc = ops.BrightnessContrast(device="gpu",
-                        contrast_center=128,  # input is in float, but in 0..255 range
-                        dtype=types.UINT8)
+        images=fn.brightness_contrast(images,
+                        contrast_center = 128,  # input is in float, but in 0..255 range
+                        dtype = types.UINT8,
+                        brightness = brightness,
+                        contrast = contrast)
 
-        self.resize = ops.Resize(
-            device="cpu",
-            resize_x=300,
-            resize_y=300,
-            min_filter=types.DALIInterpType.INTERP_TRIANGULAR)
+        dtype=types.FLOAT16 if args.fp16 else types.FLOAT
 
-        dtype = types.FLOAT16 if args.fp16 else types.FLOAT
+        bboxes=fn.bb_flip(bboxes,
+                            ltrb=True, horizontal=flip_coin)
+        images=fn.crop_mirror_normalize(images,
+                                        crop=(300, 300),
+                                        mean=[0.485 * 255, 0.456 * \
+                                            255, 0.406 * 255],
+                                        std=[0.229 * 255, 0.224 * \
+                                            255, 0.225 * 255],
+                                        mirror=flip_coin,
+                                        dtype=dtype,
+                                        output_layout="CHW",
+                                        pad_output=False)
 
-        self.normalize = ops.CropMirrorNormalize(
-            device="gpu",
-            crop=(300, 300),
-            mean=[0.485 * 255, 0.456 * 255, 0.406 * 255],
-            std=[0.229 * 255, 0.224 * 255, 0.225 * 255],
-            mirror=0,
-            dtype=dtype,
-            output_layout=types.NCHW,
-            pad_output=False)
-
-        # Random variables
-        self.rng1 = ops.Uniform(range=[0.5, 1.5])
-        self.rng2 = ops.Uniform(range=[0.875, 1.125])
-        self.rng3 = ops.Uniform(range=[-0.5, 0.5])
-
-        self.flip = ops.Flip(device="cpu")
-        self.bbflip = ops.BbFlip(device="cpu", ltrb=True)
-        self.flip_coin = ops.CoinFlip(probability=0.5)
-
-        self.box_encoder = ops.BoxEncoder(
-            device="cpu",
+        bboxes, labels=fn.box_encoder(bboxes, labels,
             criteria=0.5,
             anchors=default_boxes.as_ltrb_list())
 
-
-    def define_graph(self):
-        saturation = self.rng1()
-        contrast = self.rng1()
-        brightness = self.rng2()
-        hue = self.rng3()
-        coin_rnd = self.flip_coin()
-
-        inputs, bboxes, labels = self.input(name="Reader")
-        images = self.decode(inputs)
-
-        crop_begin, crop_size, bboxes, labels = self.crop(bboxes, labels)
-        images = self.slice(images, crop_begin, crop_size)
-
-        images = self.flip(images, horizontal=coin_rnd)
-        bboxes = self.bbflip(bboxes, horizontal=coin_rnd)
-        images = self.resize(images)
-        images = images.gpu()
-
-        images = self.hsv(images, hue=hue, saturation=saturation)
-        images = self.bc(images, brightness=brightness, contrast=contrast)
-
-        images = self.normalize(images)
-        bboxes, labels = self.box_encoder(bboxes, labels)
-
-        return (images, bboxes.gpu(), labels.gpu())
+        labels=labels.gpu()
+        bboxes=bboxes.gpu()
+        pipeline.set_outputs(images, bboxes, labels)
+    return pipeline

--- a/docs/examples/use_cases/pytorch/single_stage_detector/src/coco_pipeline.py
+++ b/docs/examples/use_cases/pytorch/single_stage_detector/src/coco_pipeline.py
@@ -19,7 +19,7 @@ import nvidia.dali.types as types
 import nvidia.dali.fn as fn
 
 
-def get_coco_pipeline(default_boxes, args, seed):
+def create_coco_pipeline(default_boxes, args, seed):
     pipeline = Pipeline(args.batch_size, args.num_workers,
                         args.local_rank, seed=seed)
     try:

--- a/docs/examples/use_cases/pytorch/single_stage_detector/src/data.py
+++ b/docs/examples/use_cases/pytorch/single_stage_detector/src/data.py
@@ -6,7 +6,7 @@ from torch.utils.data import DataLoader
 
 from src.utils import dboxes300_coco, COCODetection, SSDTransformer
 from src.coco import COCO
-from src.coco_pipeline import get_coco_pipeline
+from src.coco_pipeline import create_coco_pipeline
 from nvidia.dali.plugin.pytorch import DALIGenericIterator, LastBatchPolicy
 
 
@@ -61,7 +61,7 @@ def get_train_pytorch_loader(args, num_workers, default_boxes):
 
 
 def get_train_dali_loader(args, default_boxes, local_seed):
-    train_pipe = get_coco_pipeline(
+    train_pipe = create_coco_pipeline(
         default_boxes,
         args,
         seed=local_seed)

--- a/docs/examples/use_cases/pytorch/single_stage_detector/src/data.py
+++ b/docs/examples/use_cases/pytorch/single_stage_detector/src/data.py
@@ -6,7 +6,7 @@ from torch.utils.data import DataLoader
 
 from src.utils import dboxes300_coco, COCODetection, SSDTransformer
 from src.coco import COCO
-from src.coco_pipeline import COCOPipeline
+from src.coco_pipeline import get_coco_pipeline
 from nvidia.dali.plugin.pytorch import DALIGenericIterator, LastBatchPolicy
 
 
@@ -61,7 +61,7 @@ def get_train_pytorch_loader(args, num_workers, default_boxes):
 
 
 def get_train_dali_loader(args, default_boxes, local_seed):
-    train_pipe = COCOPipeline(
+    train_pipe = get_coco_pipeline(
         default_boxes,
         args,
         seed=local_seed)

--- a/docs/examples/use_cases/video_superres/dataloading/dataloaders.py
+++ b/docs/examples/use_cases/video_superres/dataloading/dataloaders.py
@@ -25,7 +25,7 @@ def create_video_reader_pipeline(batch_size, sequence_length, num_threads, devic
                           crop_pos_x=fn.uniform(range=(0.0, 1.0)),
                           crop_pos_y=fn.uniform(range=(0.0, 1.0)))
 
-        images = fn.tanspose(images, perm=[3, 0, 1, 2])
+        images = fn.transpose(images, perm=[3, 0, 1, 2])
 
         pipeline.set_outputs(images)
     return pipeline

--- a/docs/examples/use_cases/video_superres/dataloading/dataloaders.py
+++ b/docs/examples/use_cases/video_superres/dataloading/dataloaders.py
@@ -11,35 +11,36 @@ from dataloading.datasets import imageDataset
 
 from nvidia.dali.pipeline import Pipeline
 from nvidia.dali.plugin import pytorch
-import nvidia.dali.ops as ops
+import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 
-class VideoReaderPipeline(Pipeline):
-    def __init__(self, batch_size, sequence_length, num_threads, device_id, files, crop_size):
-        super(VideoReaderPipeline, self).__init__(batch_size, num_threads, device_id, seed=12)
-        self.reader = ops.VideoReader(device="gpu", filenames=files, sequence_length=sequence_length,
-                                     normalized=False, random_shuffle=True, image_type=types.RGB,
-                                     dtype=types.UINT8, initial_fill=16, pad_last_batch=True)
-        self.crop = ops.Crop(device="gpu", crop=crop_size, dtype=types.FLOAT)
-        self.uniform = ops.Uniform(range=(0.0, 1.0))
-        self.transpose = ops.Transpose(device="gpu", perm=[3, 0, 1, 2])
 
-    def define_graph(self):
-        input = self.reader(name="Reader")
-        cropped = self.crop(input, crop_pos_x=self.uniform(), crop_pos_y=self.uniform())
-        output = self.transpose(cropped)
-        return output
+def get_video_reader_pipeline(batch_size, sequence_length, num_threads, device_id, files, crop_size):
+    pipeline = Pipeline(batch_size, num_threads, device_id, seed=12)
+    with pipeline:
+        images = fn.video_reader(device="gpu", filenames=files, sequence_length=sequence_length,
+                                 normalized=False, random_shuffle=True, image_type=types.RGB,
+                                 dtype=types.UINT8, initial_fill=16, pad_last_batch=True, name="Reader")
+        images = ops.crop(images, device="gpu", crop=crop_size, dtype=types.FLOAT,
+                          crop_pos_x=fn.uniform(range=(0.0, 1.0)),
+                          crop_pos_y=fn.uniform(range=(0.0, 1.0)))
+
+        images = fn.tanspose(imagesdevice="gpu", perm=[3, 0, 1, 2])
+
+        pipeline.set_outputs(images)
+    return pipeline
+
 
 class DALILoader():
     def __init__(self, batch_size, file_root, sequence_length, crop_size):
         container_files = os.listdir(file_root)
         container_files = [file_root + '/' + f for f in container_files]
-        self.pipeline = VideoReaderPipeline(batch_size=batch_size,
-                                            sequence_length=sequence_length,
-                                            num_threads=2,
-                                            device_id=0,
-                                            files=container_files,
-                                            crop_size=crop_size)
+        self.pipeline = get_video_reader_pipeline(batch_size=batch_size,
+                                                  sequence_length=sequence_length,
+                                                  num_threads=2,
+                                                  device_id=0,
+                                                  files=container_files,
+                                                  crop_size=crop_size)
         self.pipeline.build()
         self.epoch_size = self.pipeline.epoch_size("Reader")
         self.dali_iterator = pytorch.DALIGenericIterator(self.pipeline,
@@ -47,8 +48,10 @@ class DALILoader():
                                                          reader_name="Reader",
                                                          last_batch_policy=pytorch.LastBatchPolicy.PARTIAL,
                                                          auto_reset=True)
+
     def __len__(self):
         return int(self.epoch_size)
+
     def __iter__(self):
         return self.dali_iterator.__iter__()
 
@@ -68,7 +71,8 @@ def get_loader(args, ds_type):
                 args.world_size)
 
             if args.world_size > 1:
-                sampler = torch.utils.data.distributed.DistributedSampler(dataset)
+                sampler = torch.utils.data.distributed.DistributedSampler(
+                    dataset)
             else:
                 sampler = torch.utils.data.RandomSampler(dataset)
 
@@ -94,7 +98,8 @@ def get_loader(args, ds_type):
                 args.world_size)
 
             if args.world_size > 1:
-                sampler = torch.utils.data.distributed.DistributedSampler(dataset)
+                sampler = torch.utils.data.distributed.DistributedSampler(
+                    dataset)
             else:
                 sampler = torch.utils.data.RandomSampler(dataset)
 
@@ -111,9 +116,9 @@ def get_loader(args, ds_type):
 
     elif args.loader == 'DALI':
         loader = DALILoader(args.batchsize,
-            os.path.join(args.root, ds_type),
-            args.frames,
-            args.crop_size)
+                            os.path.join(args.root, ds_type),
+                            args.frames,
+                            args.crop_size)
         batches = len(loader)
         sampler = None
 

--- a/docs/examples/use_cases/video_superres/dataloading/dataloaders.py
+++ b/docs/examples/use_cases/video_superres/dataloading/dataloaders.py
@@ -21,7 +21,7 @@ def create_video_reader_pipeline(batch_size, sequence_length, num_threads, devic
         images = fn.video_reader(device="gpu", filenames=files, sequence_length=sequence_length,
                                  normalized=False, random_shuffle=True, image_type=types.RGB,
                                  dtype=types.UINT8, initial_fill=16, pad_last_batch=True, name="Reader")
-        images = ops.crop(images, crop=crop_size, dtype=types.FLOAT,
+        images = fn.crop(images, crop=crop_size, dtype=types.FLOAT,
                           crop_pos_x=fn.uniform(range=(0.0, 1.0)),
                           crop_pos_y=fn.uniform(range=(0.0, 1.0)))
 
@@ -41,7 +41,7 @@ class DALILoader():
                                                      device_id=0,
                                                      files=container_files,
                                                      crop_size=crop_size)
-        pipeline.build()
+        self.pipeline.build()
         self.epoch_size = self.pipeline.epoch_size("Reader")
         self.dali_iterator = pytorch.DALIGenericIterator(self.pipeline,
                                                          ["data"],

--- a/qa/TL0_FW_iterators/test_mxnet.sh
+++ b/qa/TL0_FW_iterators/test_mxnet.sh
@@ -1,8 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-
-
-pip_packages="nose numpy opencv-python mxnet"
+pip_packages="nose numpy mxnet"
 target_dir=./dali/test/python
 
 one_config_only=true

--- a/qa/TL0_FW_iterators/test_paddle.sh
+++ b/qa/TL0_FW_iterators/test_paddle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy opencv-python paddlepaddle-gpu"
+pip_packages="nose numpy paddlepaddle-gpu"
 target_dir=./dali/test/python
 
 one_config_only=true

--- a/qa/TL0_FW_iterators/test_pytorch.sh
+++ b/qa/TL0_FW_iterators/test_pytorch.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-
-pip_packages="pillow nose numpy opencv-python torch torchvision"
+pip_packages="pillow nose numpy torch torchvision"
 target_dir=./dali/test/python
 
 one_config_only=true

--- a/qa/TL2_FW_iterators_perf/test.sh
+++ b/qa/TL2_FW_iterators_perf/test.sh
@@ -1,21 +1,5 @@
 #!/bin/bash -e
-# used pip packages
-# rarfile>= 3.2 breaks python 3.5 compatibility
-pip_packages="pillow tensorflow-gpu torchvision mxnet torch paddle rarfile<=3.1"
-target_dir=./dali/test/python
-one_config_only=true
-
-do_once() {
-    NUM_GPUS=$(nvidia-smi -L | wc -l)
-}
-
-test_body() {
-    for fw in "mxnet" "pytorch" "tf" "paddle"; do
-        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --prefetch 2 --epochs 3
-    done
-}
-
-pushd ../..
-source ./qa/test_template.sh
-popd
+./test_tf.sh
+./test_paddle.sh
+./test_mxnet.sh
+./test_pytorch.sh

--- a/qa/TL2_FW_iterators_perf/test_mxnet.sh
+++ b/qa/TL2_FW_iterators_perf/test_mxnet.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy tensorflow-gpu"
+pip_packages="mxnet"
 target_dir=./dali/test/python
-
 one_config_only=true
 
 do_once() {
@@ -10,11 +9,9 @@ do_once() {
 }
 
 test_body() {
-    for fw in "tf"; do
+    for fw in "mxnet"; do
         python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --prefetch 2 -i 100 --epochs 2
-        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
+            --workers 3 --prefetch 2 --epochs 3
     done
 }
 

--- a/qa/TL2_FW_iterators_perf/test_paddle.sh
+++ b/qa/TL2_FW_iterators_perf/test_paddle.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy tensorflow-gpu"
+pip_packages="paddlepaddle-gpu"
 target_dir=./dali/test/python
-
 one_config_only=true
 
 do_once() {
@@ -10,11 +9,9 @@ do_once() {
 }
 
 test_body() {
-    for fw in "tf"; do
+    for fw in "paddle"; do
         python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --prefetch 2 -i 100 --epochs 2
-        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
+            --workers 3 --prefetch 2 --epochs 3
     done
 }
 

--- a/qa/TL2_FW_iterators_perf/test_pytorch.sh
+++ b/qa/TL2_FW_iterators_perf/test_pytorch.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy tensorflow-gpu"
+pip_packages="pillow torchvision torch"
 target_dir=./dali/test/python
-
 one_config_only=true
 
 do_once() {
@@ -10,11 +9,9 @@ do_once() {
 }
 
 test_body() {
-    for fw in "tf"; do
+    for fw in "pytorch"; do
         python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --prefetch 2 -i 100 --epochs 2
-        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
+            --workers 3 --prefetch 2 --epochs 3
     done
 }
 

--- a/qa/TL2_FW_iterators_perf/test_tf.sh
+++ b/qa/TL2_FW_iterators_perf/test_tf.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy tensorflow-gpu"
+pip_packages="tensorflow-gpu"
 target_dir=./dali/test/python
-
 one_config_only=true
 
 do_once() {
@@ -12,9 +11,7 @@ do_once() {
 test_body() {
     for fw in "tf"; do
         python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --prefetch 2 -i 100 --epochs 2
-        python test_RN50_data_fw_iterators.py --framework ${fw} --gpus ${NUM_GPUS} -b 13 \
-            --workers 3 --prefetch 2 -i 2 --epochs 2 --fp16
+            --workers 3 --prefetch 2 --epochs 3
     done
 }
 

--- a/qa/TL3_RN50_convergence/test_paddle.sh
+++ b/qa/TL3_RN50_convergence/test_paddle.sh
@@ -13,7 +13,7 @@ pip install $(python /opt/dali/qa/setup_packages.py -i 0 -u paddlepaddle-gpu --c
 
 cd /opt/dali/docs/examples/use_cases/paddle/resnet50
 
-GPUS=$(nvidia-smi -L | sed "s/GPU \([0-9]\):.*/\1/g")
+GPUS=$(nvidia-smi -L | sed "s/GPU \([0-9]*\):.*/\1/g")
 
 if [ ! -d "val" ]; then
    ln -sf /data/imagenet/val-jpeg/ val


### PR DESCRIPTION
- move all use cases to the functional API
- reworks SSD, RN50, super resolution and TSM examples

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It moves network examples to the functional API

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     reworks SSD, RN50, super resolution and TSM examples to use the functional API
 - Affected modules and functionalities:
     use_cases part of the documentation
 - Key points relevant for the review:
     functional API usage
 - Validation and testing:
     CI
 - Documentation (including examples):
     documentation and examples have been updated


**JIRA TASK**: *[NA]*
