### PR TITLE
Fix autoreset option in iterator for DROP policy

### DIFF
--- a/dali/python/nvidia/dali/plugin/base_iterator.py
+++ b/dali/python/nvidia/dali/plugin/base_iterator.py
@@ -237,9 +237,7 @@ class _DaliBaseIterator(object):
         Checks iterator stop condition, gets DALI outputs and perform reset in case of StopIteration
         """
         if self._size > 0 and self._counter >= self._size:
-            if self._auto_reset:
-                self.reset()
-            raise StopIteration
+            self._end_iteration()
 
         outputs = []
         try:
@@ -252,6 +250,11 @@ class _DaliBaseIterator(object):
                 self.reset()
             raise e
         return outputs
+
+    def _end_iteration(self):
+        if self._auto_reset:
+            self.reset()
+        raise StopIteration
 
     def _schedule_runs(self, release_outputs=True):
         """
@@ -272,12 +275,12 @@ class _DaliBaseIterator(object):
             self._counter += self.batch_size
             if self._last_batch_policy == LastBatchPolicy.DROP:
                 if np.any(self._counter_per_gpu + self._counter > self._shard_sizes_per_gpu):
-                    raise StopIteration
+                    self._end_iteration()
         else:
             self._counter += self._num_gpus * self.batch_size
             if self._last_batch_policy == LastBatchPolicy.DROP:
                 if self._counter > self._size:
-                    raise StopIteration
+                    self._end_iteration()
 
     def reset(self):
         """

--- a/dali/test/python/test_dali_tf_dataset.py
+++ b/dali/test/python/test_dali_tf_dataset.py
@@ -47,7 +47,7 @@ class TestPipeline(Pipeline):
             shard_id = shard_id,
             num_shards = num_shards,
             ratio=False,
-            save_img_ids=True)
+            image_ids=True)
         self.decode = ops.ImageDecoder(
             device = 'mixed' if device == 'gpu' else 'cpu',
             output_type = types.RGB)

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -29,7 +29,7 @@ class COCOReaderPipeline(Pipeline):
         super(COCOReaderPipeline, self).__init__(batch_size, num_threads, 0, prefetch_queue_depth=1)
         self.input = ops.COCOReader(file_root = data_paths[0], annotations_file=data_paths[1],
                                     shard_id = shard_id, num_shards = num_gpus, random_shuffle=random_shuffle,
-                                    save_img_ids=True, stick_to_shard=stick_to_shard,shuffle_after_epoch=shuffle_after_epoch,
+                                    image_ids=True, stick_to_shard=stick_to_shard,shuffle_after_epoch=shuffle_after_epoch,
                                     pad_last_batch=pad_last_batch, initial_fill=initial_fill)
         self.return_labels=return_labels
 
@@ -314,7 +314,7 @@ def check_iterator_results(pad, pipes_number, shards_num, out_set, last_batch_po
     return (ids, sample_counter, per_gpu_counter, epoch_counter, rounded_shard_size)
 
 
-def check_mxnet_iterator_pass_reader_name(shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy):
+def check_mxnet_iterator_pass_reader_name(shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy, auto_reset=False):
     from nvidia.dali.plugin.mxnet import DALIGenericIterator as MXNetIterator
 
     pipes = [COCOReaderPipeline(batch_size=batch_size, num_threads=4, shard_id=id, num_gpus=shards_num,
@@ -334,7 +334,7 @@ def check_mxnet_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
         assert_raises(AssertionError, MXNetIterator, pipes, [("ids", MXNetIterator.DATA_TAG)], reader_name="Reader", last_batch_policy=last_batch_policy)
         return
     else:
-        dali_train_iter = MXNetIterator(pipes, [("ids", MXNetIterator.DATA_TAG)], reader_name="Reader", last_batch_policy=last_batch_policy)
+        dali_train_iter = MXNetIterator(pipes, [("ids", MXNetIterator.DATA_TAG)], reader_name="Reader", last_batch_policy=last_batch_policy, auto_reset=auto_reset)
 
     for _ in range(iters):
         out_set = []
@@ -346,7 +346,8 @@ def check_mxnet_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
                     tmp = tmp[0:-it[id].pad]
                 img_ids_list[id].append(tmp)
             sample_counter += batch_size
-        dali_train_iter.reset()
+        if not auto_reset:
+            dali_train_iter.reset()
         for id in range(pipes_number):
             img_ids_list[id] = np.concatenate(img_ids_list[id])
             out_set.append(set(img_ids_list[id]))
@@ -364,7 +365,11 @@ def test_mxnet_iterator_pass_reader_name():
                     for last_batch_policy in [LastBatchPolicy.PARTIAL, LastBatchPolicy.FILL, LastBatchPolicy.DROP]:
                         for iters in [1, 2, 3, 2*shards_num]:
                             for pipes_number in [1, shards_num]:
-                                yield check_mxnet_iterator_pass_reader_name, shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy
+                                yield check_mxnet_iterator_pass_reader_name, shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy, False
+
+def test_mxnet_iterator_pass_reader_name_autoreset():
+    for auto_reset in [True, False]:
+        yield check_mxnet_iterator_pass_reader_name, 3, 1, 3, False, True, 3, LastBatchPolicy.DROP, auto_reset
 
 def test_gluon_iterator_last_batch_no_pad_last_batch():
     from nvidia.dali.plugin.mxnet import DALIGluonIterator as GluonIterator
@@ -464,7 +469,7 @@ def test_gluon_iterator_sparse_batch():
         assert isinstance(ids, NDArray)
 
 
-def check_gluon_iterator_pass_reader_name(shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy):
+def check_gluon_iterator_pass_reader_name(shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy, auto_reset=False):
     from nvidia.dali.plugin.mxnet import DALIGluonIterator as GluonIterator
 
     pipes = [COCOReaderPipeline(batch_size=batch_size, num_threads=4, shard_id=id, num_gpus=shards_num,
@@ -484,7 +489,7 @@ def check_gluon_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
         assert_raises(AssertionError, GluonIterator, pipes, reader_name="Reader", last_batch_policy=last_batch_policy)
         return
     else:
-        dali_train_iter = GluonIterator(pipes, reader_name="Reader", last_batch_policy=last_batch_policy)
+        dali_train_iter = GluonIterator(pipes, reader_name="Reader", last_batch_policy=last_batch_policy, auto_reset=auto_reset)
 
     for _ in range(iters):
         out_set = []
@@ -497,7 +502,8 @@ def check_gluon_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
                     tmp = np.empty([0])
                 img_ids_list[id].append(tmp)
             sample_counter += batch_size
-        dali_train_iter.reset()
+        if not auto_reset:
+            dali_train_iter.reset()
         for id in range(pipes_number):
             assert (batch_size > data_set_size // shards_num and \
                     last_batch_policy == LastBatchPolicy.DROP) or len(img_ids_list[id])
@@ -521,7 +527,11 @@ def test_gluon_iterator_pass_reader_name():
                     for last_batch_policy in [LastBatchPolicy.PARTIAL, LastBatchPolicy.FILL, LastBatchPolicy.DROP]:
                         for iters in [1, 2, 3, 2*shards_num]:
                             for pipes_number in [1, shards_num]:
-                                yield check_gluon_iterator_pass_reader_name, shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy
+                                yield check_gluon_iterator_pass_reader_name, shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy, False
+
+def test_gluon_iterator_pass_reader_name_autoreset():
+    for auto_reset in [True, False]:
+        yield check_gluon_iterator_pass_reader_name, 3, 1, 3, False, True, 3, LastBatchPolicy.DROP, auto_reset
 
 def test_pytorch_iterator_last_batch_no_pad_last_batch():
     from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
@@ -692,7 +702,7 @@ def test_paddle_iterator_feed_ndarray():
         feed_ndarray(out_data, ptr2, cuda_stream = 0)  # Using default stream
         np.testing.assert_equal(np.array(lod_tensor2), outs[0].as_cpu().as_array())
 
-def check_pytorch_iterator_pass_reader_name(shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy):
+def check_pytorch_iterator_pass_reader_name(shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy, auto_reset=False):
     from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
 
     pipes = [COCOReaderPipeline(batch_size=batch_size, num_threads=4, shard_id=id, num_gpus=shards_num,
@@ -713,7 +723,7 @@ def check_pytorch_iterator_pass_reader_name(shards_num, pipes_number, batch_size
         assert_raises(AssertionError, PyTorchIterator, pipes, output_map=["data"], reader_name="Reader", last_batch_policy=last_batch_policy)
         return
     else:
-        dali_train_iter = PyTorchIterator(pipes, output_map=["data"], reader_name="Reader", last_batch_policy=last_batch_policy)
+        dali_train_iter = PyTorchIterator(pipes, output_map=["data"], reader_name="Reader", last_batch_policy=last_batch_policy, auto_reset=auto_reset)
 
     for _ in range(iters):
         out_set = []
@@ -723,7 +733,8 @@ def check_pytorch_iterator_pass_reader_name(shards_num, pipes_number, batch_size
                 tmp = it[id]["data"].squeeze(dim=1).numpy().copy()
                 img_ids_list[id].append(tmp)
             sample_counter += batch_size
-        dali_train_iter.reset()
+        if not auto_reset:
+            dali_train_iter.reset()
         for id in range(pipes_number):
             img_ids_list[id] = np.concatenate(img_ids_list[id])
             out_set.append(set(img_ids_list[id]))
@@ -741,7 +752,11 @@ def test_pytorch_iterator_pass_reader_name():
                     for last_batch_policy in [LastBatchPolicy.PARTIAL, LastBatchPolicy.FILL, LastBatchPolicy.DROP]:
                         for iters in [1, 2, 3, 2*shards_num]:
                             for pipes_number in [1, shards_num]:
-                                yield check_pytorch_iterator_pass_reader_name, shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy
+                                yield check_pytorch_iterator_pass_reader_name, shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy, False
+
+def test_pytorch_iterator_pass_reader_name_autoreset():
+    for auto_reset in [True, False]:
+        yield check_pytorch_iterator_pass_reader_name, 3, 1, 3, False, True, 3, LastBatchPolicy.DROP, auto_reset
 
 def test_paddle_iterator_last_batch_no_pad_last_batch():
     from nvidia.dali.plugin.paddle import DALIGenericIterator as PaddleIterator
@@ -817,7 +832,7 @@ def test_paddle_iterator_not_fill_last_batch_pad_last_batch():
     assert len(set(next_mirrored_data)) != 1
 
 
-def check_paddle_iterator_pass_reader_name(shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy):
+def check_paddle_iterator_pass_reader_name(shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy, auto_reset=False):
     from nvidia.dali.plugin.paddle import DALIGenericIterator as PaddleIterator
 
     pipes = [COCOReaderPipeline(batch_size=batch_size, num_threads=4, shard_id=id, num_gpus=shards_num,
@@ -838,7 +853,7 @@ def check_paddle_iterator_pass_reader_name(shards_num, pipes_number, batch_size,
         assert_raises(AssertionError, PaddleIterator, pipes, output_map=["data"], reader_name="Reader", last_batch_policy=last_batch_policy)
         return
     else:
-        dali_train_iter = PaddleIterator(pipes, output_map=["data"], reader_name="Reader", last_batch_policy=last_batch_policy)
+        dali_train_iter = PaddleIterator(pipes, output_map=["data"], reader_name="Reader", last_batch_policy=last_batch_policy, auto_reset=auto_reset)
 
     for _ in range(iters):
         out_set = []
@@ -848,7 +863,8 @@ def check_paddle_iterator_pass_reader_name(shards_num, pipes_number, batch_size,
                 tmp = np.array(it[id]["data"]).squeeze(axis=1).copy()
                 img_ids_list[id].append(tmp)
             sample_counter += batch_size
-        dali_train_iter.reset()
+        if not auto_reset:
+            dali_train_iter.reset()
         for id in range(pipes_number):
             img_ids_list[id] = np.concatenate(img_ids_list[id])
             out_set.append(set(img_ids_list[id]))
@@ -866,7 +882,11 @@ def test_paddle_iterator_pass_reader_name():
                     for last_batch_policy in [LastBatchPolicy.PARTIAL, LastBatchPolicy.FILL, LastBatchPolicy.DROP]:
                         for iters in [1, 2, 3, 2*shards_num]:
                             for pipes_number in [1, shards_num]:
-                                yield check_paddle_iterator_pass_reader_name, shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy
+                                yield check_paddle_iterator_pass_reader_name, shards_num, pipes_number, batch_size, stick_to_shard, pad, iters, last_batch_policy, False
+
+def test_paddle_iterator_pass_reader_name_autoreset():
+    for auto_reset in [True, False]:
+        yield check_paddle_iterator_pass_reader_name, 3, 1, 3, False, True, 3, LastBatchPolicy.DROP, auto_reset
 
 class TestIterator():
     def __init__(self, iters_per_epoch, batch_size, total_iter_num=-1):

--- a/dali/test/python/test_operator_reader_shuffling.py
+++ b/dali/test/python/test_operator_reader_shuffling.py
@@ -25,7 +25,7 @@ class COCOReaderPipeline(Pipeline):
         super(COCOReaderPipeline, self).__init__(batch_size, num_threads, 0, prefetch_queue_depth=1)
         self.input = ops.COCOReader(file_root = data_paths[0], annotations_file=data_paths[1],
                                     shard_id = shard_id, num_shards = num_gpus, random_shuffle=random_shuffle,
-                                    save_img_ids=True, stick_to_shard=stick_to_shard,shuffle_after_epoch=shuffle_after_epoch,
+                                    image_ids=True, stick_to_shard=stick_to_shard,shuffle_after_epoch=shuffle_after_epoch,
                                     pad_last_batch=pad_last_batch, initial_fill=initial_fill)
 
     def define_graph(self):


### PR DESCRIPTION
- when the drop policy is set autoreset option is disregarded

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes an autoreset option in iterator for DROP policy

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     when the drop policy is set autoreset option is disregarded
 - Affected modules and functionalities:
     base_iterator.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     new test added
 - Documentation (including examples):
     NA

Relates to https://github.com/NVIDIA/DALI/issues/2559

**JIRA TASK**: *[NA]*
