### PR TITLE
Remove deprecated usage of fill_last_batch in Pytorch Lightning notebook

### DIFF
--- a/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
@@ -114,32 +114,30 @@
      "output_type": "stream",
      "text": [
       "GPU available: True, used: True\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "TPU available: None, using: 0 TPU cores\n",
+      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0,1]\n",
+      "initializing ddp: GLOBAL_RANK: 0, MEMBER: 1/1\n",
       "\n",
       "  | Name    | Type   | Params\n",
       "-----------------------------------\n",
       "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n",
-      "WARNING: Logging before flag parsing goes to stderr.\n",
-      "I1016 15:34:19.539263 139682004997952 lightning.py:1215] \n",
-      "  | Name    | Type   | Params\n",
+      "1 | layer_2 | Linear | 33.0 K\n",
+      "2 | layer_3 | Linear | 2.6 K \n",
       "-----------------------------------\n",
-      "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n"
+      "136 K     Trainable params\n",
+      "0         Non-trainable params\n",
+      "136 K     Total params\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cd8f7850b2da478dbcbc686fc864bb9b",
+       "model_id": "a53427d6261c4a5fa7a526ba1de92ef6",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value='Training'), FloatProgress(value=1.0, bar_style='info', layout=Layout(flex='2'), max…"
+       "HBox(children=(FloatProgress(value=1.0, bar_style='info', description='Training', layout=Layout(flex='2'), max…"
       ]
      },
      "metadata": {},
@@ -187,6 +185,8 @@
     "import nvidia.dali.ops as ops\n",
     "import nvidia.dali.types as types\n",
     "from nvidia.dali.plugin.pytorch import DALIClassificationIterator\n",
+    "from nvidia.dali.plugin.base_iterator import LastBatchPolicy as LastBatchPolicy\n",
+    "\n",
     "\n",
     "# Path to MNIST dataset\n",
     "data_path = os.path.join(os.environ['DALI_EXTRA_PATH'], 'db/MNIST/training/')\n",
@@ -244,7 +244,7 @@
     "        mnist_pipeline = MnistPipeline(BATCH_SIZE, device='cpu', device_id=device_id, shard_id=shard_id,\n",
     "                                       num_shards=num_shards, num_threads=8)\n",
     "        self.train_loader = DALIClassificationIterator(mnist_pipeline, reader_name=\"Reader\",\n",
-    "                                                       fill_last_batch=False, auto_reset=True)                          \n",
+    "                                                       last_batch_policy=LastBatchPolicy.PARTIAL, auto_reset=True)                          \n",
     "    def train_dataloader(self):\n",
     "        return self.train_loader\n",
     "    \n",
@@ -271,36 +271,30 @@
      "output_type": "stream",
      "text": [
       "GPU available: True, used: True\n",
-      "I1016 15:34:44.947721 139682004997952 distributed.py:49] GPU available: True, used: True\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "I1016 15:34:44.950112 139682004997952 distributed.py:49] TPU available: False, using: 0 TPU cores\n",
+      "TPU available: None, using: 0 TPU cores\n",
       "Using environment variable NODE_RANK for node rank (0).\n",
-      "I1016 15:34:44.952062 139682004997952 distributed.py:49] Using environment variable NODE_RANK for node rank (0).\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "I1016 15:34:44.953487 139682004997952 accelerator_connector.py:333] LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0,1]\n",
       "\n",
       "  | Name    | Type   | Params\n",
       "-----------------------------------\n",
       "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n",
-      "I1016 15:34:45.160256 139682004997952 lightning.py:1215] \n",
-      "  | Name    | Type   | Params\n",
+      "1 | layer_2 | Linear | 33.0 K\n",
+      "2 | layer_3 | Linear | 2.6 K \n",
       "-----------------------------------\n",
-      "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n"
+      "136 K     Trainable params\n",
+      "0         Non-trainable params\n",
+      "136 K     Total params\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ff3f1e0ba4d14d90af284eeab4c1bf06",
+       "model_id": "25f87722a8ed41dc806e8a0455b80a25",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value='Training'), FloatProgress(value=1.0, bar_style='info', layout=Layout(flex='2'), max…"
+       "HBox(children=(FloatProgress(value=1.0, bar_style='info', description='Training', layout=Layout(flex='2'), max…"
       ]
      },
      "metadata": {},
@@ -365,7 +359,7 @@
     "                out = out[0]\n",
     "                return [out[k] if k != \"label\" else torch.squeeze(out[k]) for k in self.output_map]\n",
     "\n",
-    "        self.train_loader = LightningWrapper(mnist_pipeline, reader_name=\"Reader\", fill_last_batch=False, auto_reset=True)\n",
+    "        self.train_loader = LightningWrapper(mnist_pipeline, reader_name=\"Reader\", last_batch_policy=LastBatchPolicy.PARTIAL, auto_reset=True)\n",
     "\n",
     "    def train_dataloader(self):\n",
     "        return self.train_loader"
@@ -390,36 +384,30 @@
      "output_type": "stream",
      "text": [
       "GPU available: True, used: True\n",
-      "I1016 15:35:11.309178 139682004997952 distributed.py:49] GPU available: True, used: True\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "I1016 15:35:11.311038 139682004997952 distributed.py:49] TPU available: False, using: 0 TPU cores\n",
+      "TPU available: None, using: 0 TPU cores\n",
       "Using environment variable NODE_RANK for node rank (0).\n",
-      "I1016 15:35:11.312532 139682004997952 distributed.py:49] Using environment variable NODE_RANK for node rank (0).\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "I1016 15:35:11.314745 139682004997952 accelerator_connector.py:333] LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0,1]\n",
       "\n",
       "  | Name    | Type   | Params\n",
       "-----------------------------------\n",
       "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n",
-      "I1016 15:35:11.358530 139682004997952 lightning.py:1215] \n",
-      "  | Name    | Type   | Params\n",
+      "1 | layer_2 | Linear | 33.0 K\n",
+      "2 | layer_3 | Linear | 2.6 K \n",
       "-----------------------------------\n",
-      "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n"
+      "136 K     Trainable params\n",
+      "0         Non-trainable params\n",
+      "136 K     Total params\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a2c374a9e8874d7597403fd3358584e0",
+       "model_id": "d8eae0850d314e21a3829a8f1ed2740b",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value='Training'), FloatProgress(value=1.0, bar_style='info', layout=Layout(flex='2'), max…"
+       "HBox(children=(FloatProgress(value=1.0, bar_style='info', description='Training', layout=Layout(flex='2'), max…"
       ]
      },
      "metadata": {},


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes usage of a deprecated in a jupyter notebook 

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Replace usage of fill_last_batch=False with last_batch_policy=LastBatchPolicy.PARTIAL*
 - Affected modules and functionalities:
     *Pytorch Lightning example*
 - Key points relevant for the review:
     *N/A*
 - Validation and testing:
     *N/A*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
