### PR TITLE
Fix Xavier test crash caused by NumPy faulty build

### DIFF
--- a/qa/TL0_python-self-test_xavier/test_nofw.sh
+++ b/qa/TL0_python-self-test_xavier/test_nofw.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy>=1.17 pillow"
+# due to https://github.com/numpy/numpy/issues/18131 we cannot use 1.19.5
+pip_packages="nose numpy>=1.17,<=1.19.4 pillow"
 
 target_dir=./dali/test/python
 


### PR DESCRIPTION
- 1.19.5 NumPy version doesn't work well on all aarch64 systems due to https://github.com/numpy/numpy/issues/18131
- this PR sets the maximum version used by test on Xavier to 1.19.4

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a Xavier test crash caused by NumPy faulty build

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     1.19.5 NumPy version doesn't work well on all aarch64 systems due to https://github.com/numpy/numpy/issues/18131
 - Affected modules and functionalities:
     TL0_python-self-test_xavier
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
