### PR TITLE
COCOReader `images` argument can be used to provide a custom order of images

### DIFF
--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -127,8 +127,11 @@ instance of an object is lower than this value, the object will be ignored.)code
       false)
   .AddOptionalArg<vector<string>>("images", R"code(A list of image paths.
 
-If specified, it acts as a filter for the file paths present in the annotation file.
-If left unspecified or set to None, all images listed in the annotation file are read.
+If specified, it acts as a filter for the file paths present in the annotation file, which will be
+read in the same order as they appear in the list.
+
+If left unspecified or set to None, all images listed in the annotation file are read, the order
+being determined by the image ids.
 
 The paths to be kept should match those in the annotations file.
 

--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -127,13 +127,14 @@ instance of an object is lower than this value, the object will be ignored.)code
       false)
   .AddOptionalArg<vector<string>>("images", R"code(A list of image paths.
 
-If specified, it acts as a filter for the file paths present in the annotation file, which will be
-read in the same order as they appear in the list.
+If provided, it specifies the images that will be read.
+The images will be read in the same order as they appear in the list, and in case of
+duplicates, multiple copies of the relevant samples will be produced.
 
-If left unspecified or set to None, all images listed in the annotation file are read, the order
-being determined by the image ids.
+If left unspecified or set to None, all images listed in the annotation file are read exactly once,
+ordered by their image id.
 
-The paths to be kept should match those in the annotations file.
+The paths to be kept should match exactly those in the annotations file.
 
 Note: This argument is mutually exclusive with ``preprocessed_annotations``.)code", nullptr)
   .DeprecateArgInFavorOf("save_img_ids", "image_ids")  // deprecated since 0.28dev
@@ -279,7 +280,7 @@ void COCOReader::PixelwiseMasks(int image_idx, int* mask) {
     const auto &rle = masks_info.rles[ann_id];
     auto mask_idx = masks_info.mask_indices[ann_id];
     int label = labels_span[mask_idx];
-    rleInit(&R[label], rle->h, rle->w, rle->m, rle->cnts);
+    rleInit(&R[label], (*rle)->h, (*rle)->w, (*rle)->m, (*rle)->cnts);
   }
 
   // Merge each label (from multi-polygons annotations)

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <list>
 #include <map>
-#include <unordered_set>
 #include <unordered_map>
 #include <iomanip>
 #include <iostream>
@@ -44,7 +44,7 @@ struct Annotation {
   std::array<float, 4> box_;
   // union
   Polygons poly_;
-  RLEMask rle_;
+  RLEMaskPtr rle_;
 
   void ToLtrb() {
     box_[2] += box_[0];
@@ -106,7 +106,7 @@ void SaveToFile(const std::vector<T> &input, const std::string path) {
 }
 
 template <>
-void SaveToFile(const std::vector<RLEMask> &input, const std::string path) {
+void SaveToFile(const std::vector<RLEMaskPtr> &input, const std::string path) {
   if (input.empty())
     return;
   std::ofstream file(path, std::ios_base::binary | std::ios_base::out);
@@ -115,10 +115,10 @@ void SaveToFile(const std::vector<RLEMask> &input, const std::string path) {
   unsigned size = input.size();
   Write(file, size, path.c_str());
   for (auto &rle : input) {
-    assert(rle->h > 0 && rle->w > 0 && rle->m > 0);
-    siz dims[3] = {rle->h, rle->w, rle->m};
+    assert((*rle)->h > 0 && (*rle)->w > 0 && (*rle)->m > 0);
+    siz dims[3] = {(*rle)->h, (*rle)->w, (*rle)->m};
     Write(file, span<const siz>{&dims[0], 3}, path.c_str());
-    Write(file, span<const uint>{rle->cnts, static_cast<ptrdiff_t>(rle->m)}, path.c_str());
+    Write(file, span<const uint>{(*rle)->cnts, static_cast<ptrdiff_t>((*rle)->m)}, path.c_str());
   }
 }
 
@@ -166,7 +166,7 @@ void LoadFromFile(std::vector<T> &output, const std::string path) {
 }
 
 template <>
-void LoadFromFile(std::vector<RLEMask> &output, const std::string path) {
+void LoadFromFile(std::vector<RLEMaskPtr> &output, const std::string path) {
   std::ifstream file(path);
   output.clear();
   if (!file.good())
@@ -180,8 +180,8 @@ void LoadFromFile(std::vector<RLEMask> &output, const std::string path) {
     siz dims[3];
     Read(file, span<siz>{&dims[0], 3}, path.c_str());
     siz h = dims[0], w = dims[1], m = dims[2];
-    rle = RLEMask(h, w, m);
-    Read(file, span<uint>{rle->cnts, static_cast<ptrdiff_t>(rle->m)}, path.c_str());
+    rle = std::make_shared<RLEMask>(h, w, m);
+    Read(file, span<uint>{(*rle)->cnts, static_cast<ptrdiff_t>((*rle)->m)}, path.c_str());
   }
 }
 
@@ -332,9 +332,9 @@ void ParseAnnotations(LookaheadParser &parser, std::vector<Annotation> &annotati
           }
           DALI_ENFORCE(h > 0 && w > 0, "Invalid or missing mask sizes");
           if (!rle_str.empty()) {
-            annotation.rle_ = RLEMask(h, w, rle_str.c_str());
+            annotation.rle_ = std::make_shared<RLEMask>(h, w, rle_str.c_str());
           } else if (!rle_uints.empty()) {
-            annotation.rle_ = RLEMask(h, w, make_cspan(rle_uints));
+            annotation.rle_ = std::make_shared<RLEMask>(h, w, make_cspan(rle_uints));
           } else {
             DALI_FAIL("Missing or invalid ``counts`` attribute.");
           }
@@ -487,70 +487,47 @@ void CocoLoader::ParseJsonAnnotations() {
   detail::ParseJsonFile(spec_, image_infos, annotations, category_ids,
                         parse_segmentation, output_pixelwise_masks_);
 
-  if (!images_.empty()) {
-    std::unordered_map<std::string, detail::ImageInfo*> image_info_map;
-    std::unordered_map<int, size_t> custom_order;
-
-    for (const auto &filename : images_) {
-      image_info_map[filename] = nullptr;
-    }
-    for (auto &info : image_infos) {
-      auto it = image_info_map.find(info.filename_);
-      if (it != image_info_map.end()) {
-        it->second = &info;
-      }
-    }
-
-    size_t idx = 0;
-    for (const auto &filename : images_) {
-      auto *info = image_info_map[filename];
-      custom_order[info->original_id_] = idx++;
-    }
-
-    image_infos.erase(
-      std::remove_if(
-        image_infos.begin(), image_infos.end(),
-        [&](const detail::ImageInfo &info) {
-          return custom_order.find(info.original_id_) ==
-                custom_order.end();
-        }),
-      image_infos.end());
-
-    annotations.erase(
-      std::remove_if(
-        annotations.begin(), annotations.end(),
-        [&](const detail::Annotation &annotation) {
-          return custom_order.find(annotation.image_id_) == custom_order.end();
-        }),
-      annotations.end());
-
-    std::sort(image_infos.begin(), image_infos.end(), [&](auto &left, auto &right) {
-      return custom_order[left.original_id_] < custom_order[right.original_id_];
-    });
-    std::stable_sort(annotations.begin(), annotations.end(), [&](auto &left, auto &right) {
-      return custom_order[left.image_id_] < custom_order[right.image_id_];
-    });
-  } else {
+  if (images_.empty()) {
     std::sort(image_infos.begin(), image_infos.end(), [&](auto &left, auto &right) {
       return left.original_id_ < right.original_id_;
     });
-    std::stable_sort(annotations.begin(), annotations.end(), [&](auto &left, auto &right) {
-      return left.image_id_ < right.image_id_;
-    });
+    for (auto &info : image_infos) {
+      images_.push_back(info.filename_);
+    }
+  }
+
+  std::unordered_map<std::string, const detail::ImageInfo*> img_infos_map;
+  std::unordered_map<int, std::list<const detail::Annotation*>> img_annotations_map;
+  img_infos_map.reserve(images_.size());
+  img_annotations_map.reserve(images_.size());
+  for (const auto &filename : images_) {
+    img_infos_map[filename] = nullptr;
+  }
+  for (auto &info : image_infos) {
+    auto it = img_infos_map.find(info.filename_);
+    if (it != img_infos_map.end()) {
+      it->second = &info;
+      img_annotations_map[info.original_id_] = {};
+    }
+  }
+
+  for (const auto &annotation : annotations) {
+    auto it = img_annotations_map.find(annotation.image_id_);
+    if (it != img_annotations_map.end()) {
+      it->second.push_back(&annotation);
+    }
   }
 
   bool skip_empty = spec_.GetArgument<bool>("skip_empty");
   bool ratio = spec_.GetArgument<bool>("ratio");
 
-  detail::Annotation sentinel;
-  sentinel.image_id_ = -1;
-  annotations.emplace_back(std::move(sentinel));
-
   int new_image_id = 0;
   int annotation_id = 0;
   int total_count = 0;
 
-  for (auto &image_info : image_infos) {
+  for (auto &img_filename : images_) {
+    const auto &image_info = *img_infos_map[img_filename];
+    auto image_id = image_info.original_id_;
     int objects_in_sample = 0;
     int64_t sample_polygons_offset = polygon_data_.size();
     int64_t sample_polygons_count = 0;
@@ -558,8 +535,8 @@ void CocoLoader::ParseJsonAnnotations() {
     int64_t sample_vertices_count = 0;
     int64_t mask_offset = masks_rles_.size();
     int64_t mask_count = 0;
-    while (annotations[annotation_id].image_id_ == image_info.original_id_) {
-      auto &annotation = annotations[annotation_id];
+    for (const auto* annotation_ptr : img_annotations_map[image_id]) {
+      const auto &annotation = *annotation_ptr;
       labels_.push_back(category_ids[annotation.category_id_]);
       if (ratio) {
         boxes_.push_back(annotation.box_[0] / image_info.width_);
@@ -606,7 +583,7 @@ void CocoLoader::ParseJsonAnnotations() {
           }
           case detail::Annotation::RLE: {
             masks_rles_idx_.push_back(objects_in_sample);
-            masks_rles_.push_back(std::move(annotation.rle_));
+            masks_rles_.push_back(annotation.rle_);
             mask_count++;
             break;
           }

--- a/dali/operators/reader/loader/coco_loader.cc
+++ b/dali/operators/reader/loader/coco_loader.cc
@@ -526,7 +526,10 @@ void CocoLoader::ParseJsonAnnotations() {
   int total_count = 0;
 
   for (auto &img_filename : images_) {
-    const auto &image_info = *img_infos_map[img_filename];
+    auto img_info_ptr = img_infos_map[img_filename];
+    if (!img_info_ptr)
+      continue;
+    const auto &image_info = *img_info_ptr;
     auto image_id = image_info.original_id_;
     int objects_in_sample = 0;
     int64_t sample_polygons_offset = polygon_data_.size();
@@ -620,6 +623,9 @@ void CocoLoader::ParseJsonAnnotations() {
       new_image_id++;
     }
   }
+
+  // we don't need the list anymore and it can contain a lot of strings
+  images_.clear();
 
   if (spec_.GetArgument<bool>("save_preprocessed_annotations")) {
     SavePreprocessedAnnotations(

--- a/dali/operators/reader/loader/coco_loader.h
+++ b/dali/operators/reader/loader/coco_loader.h
@@ -111,14 +111,7 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
       }
     }
 
-    std::vector<std::string> images_vec;
-    if (spec.TryGetRepeatedArgument(images_vec, "images")) {
-      for (auto &image_path : images_vec) {
-        images_.insert(std::move(image_path));
-      }
-      images_vec.clear();
-    }
-
+    spec.TryGetRepeatedArgument(images_, "images");
     output_polygon_masks_ = OutPolygonMasksEnabled(spec);
     output_pixelwise_masks_ = OutPixelwiseMasksEnabled(spec);
     output_image_ids_ = OutImageIdsEnabled(spec);
@@ -235,7 +228,7 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
   bool output_image_ids_ = false;
   bool has_preprocessed_annotations_ = false;
 
-  std::unordered_set<std::string> images_;
+  std::vector<std::string> images_;
 };
 
 }  // namespace dali

--- a/dali/test/python/test_operator_coco_reader.py
+++ b/dali/test/python/test_operator_coco_reader.py
@@ -25,14 +25,14 @@ file_root = os.path.join(test_data_root, 'db', 'coco', 'images')
 train_annotations = os.path.join(test_data_root, 'db', 'coco', 'instances.json')
 
 test_data = {
-    'car-race-438467_1280.jpg' : 0,
-    'clock-1274699_1280.jpg' : 5,
-    'kite-1159538_1280.jpg' : 6,
-    'cow-234835_1280.jpg' : 17,
-    'home-office-336378_1280.jpg' : 21,
-    'suit-2619784_1280.jpg' : 39,
-    'business-suit-690048_1280.jpg' : 41,
-    'car-604019_1280.jpg' : 59
+    'car-race-438467_1280.jpg' : 17,
+    'clock-1274699_1280.jpg' : 6,
+    'kite-1159538_1280.jpg' : 21,
+    'cow-234835_1280.jpg' : 59,
+    'home-office-336378_1280.jpg' : 39,
+    'suit-2619784_1280.jpg' : 0,
+    'business-suit-690048_1280.jpg' : 5,
+    'car-604019_1280.jpg' : 41
 }
 
 images = list(test_data.keys())
@@ -63,6 +63,7 @@ def test_operator_coco_reader():
         with open(filenames_file) as f:
             lines = f.read().splitlines()
         assert lines.sort() == images.sort()
+
 
 def test_operator_coco_reader_same_images():
     file_root = os.path.join(test_data_root, 'db', 'coco_pixelwise', 'images')


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to allow custom order of images in COCOReader

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Rework the way that `images` argument is consumed, so that the images are sorted according to the order they appear in the provided file list*
     *Fix wrong data in tests*
 - Affected modules and functionalities:
     *COCOReader*
 - Key points relevant for the review:
     *COCOLoader changes*
 - Validation and testing:
     *Test updated*
 - Documentation (including examples):
     *Operator documentation updated*


**JIRA TASK**: *[DALI-1791]*
