### PR TITLE
Support surfaces with strides over 2G

### DIFF
--- a/dali/kernels/imgproc/surface.h
+++ b/dali/kernels/imgproc/surface.h
@@ -34,7 +34,7 @@ struct Surface {
   DALI_HOST_DEV
   constexpr Surface(T *data,
                     int width, int height, int channels,
-                    int pixel_stride, int row_stride, int channel_stride)
+                    int64_t pixel_stride, int64_t row_stride, int64_t channel_stride)
   : data(data), size(width, height), channels(channels),
     strides(pixel_stride, row_stride), channel_stride(channel_stride) {
   }
@@ -43,7 +43,8 @@ struct Surface {
   DALI_HOST_DEV
   constexpr Surface(T *data,
                     int width, int height, int depth, int channels,
-                    int pixel_stride, int row_stride, int slice_stride, int channel_stride)
+                    int64_t pixel_stride, int64_t row_stride, int64_t slice_stride,
+                    int64_t channel_stride)
   : data(data), size(width, height, depth), channels(channels),
     strides(pixel_stride, row_stride, slice_stride), channel_stride(channel_stride) {
   }
@@ -51,17 +52,17 @@ struct Surface {
   DALI_HOST_DEV
   constexpr Surface(T *data,
                     ivec<spatial_ndim> size, int channels,
-                    ivec<spatial_ndim> strides, int channel_stride)
+                    i64vec<spatial_ndim> strides, int64_t channel_stride)
   : data(data), size(size), channels(channels), strides(strides), channel_stride(channel_stride) {
   }
 
   T *data;
   ivec<spatial_ndim> size;
   int channels;
-  ivec<spatial_ndim> strides;
-  int channel_stride;
+  i64vec<spatial_ndim> strides;
+  int64_t channel_stride;
 
-  DALI_HOST_DEV constexpr ivec<spatial_ndim + 1> strides_ch() const {
+  DALI_HOST_DEV constexpr i64vec<spatial_ndim + 1> strides_ch() const {
     return cat(strides, channel_stride);
   }
 
@@ -142,9 +143,9 @@ DALI_HOST_DEV
 constexpr Surface<(channel_dim < 0 ? n : n-1), T> as_surface(const TensorView<Storage, T, n> &t) {
   const int spatial_ndim = (channel_dim < 0 ? n : n-1);
   ivec<spatial_ndim> size = shape2vec(skip_dim<channel_dim>(t.shape));
-  ivec<spatial_ndim> strides = {};
-  int stride = 1;
-  int channel_stride = 0;
+  i64vec<spatial_ndim> strides = {};
+  int64_t stride = 1;
+  int64_t channel_stride = 0;
   int channels = 1;
   for (int d = n - 1, i = 0; d >=0; d--) {
     if (d == channel_dim) {

--- a/dali/kernels/imgproc/warp/warp_setup.cuh
+++ b/dali/kernels/imgproc/warp/warp_setup.cuh
@@ -31,7 +31,8 @@ template <int spatial_ndim, typename OutputType, typename InputType>
 struct SampleDesc {
   OutputType *__restrict__ output;
   const InputType *__restrict__ input;
-  ivec<spatial_ndim> out_size, out_strides, in_size, in_strides;
+  ivec<spatial_ndim> out_size, in_size;
+  i64vec<spatial_ndim> out_strides, in_strides;
   int channels;
   DALIInterpType interp;
 };

--- a/dali/test/python/test_operator_warp.py
+++ b/dali/test/python/test_operator_warp.py
@@ -232,7 +232,7 @@ def _test_extremely_large_data(device):
       out[in_size-1, in_size-1, c] = c
     return [out]
 
-  pipe = Pipeline(1, 3, 0)
+  pipe = Pipeline(1, 3, 0, prefetch_queue_depth=1)
   input = fn.external_source(source=get_data, device=device)
 
   rotated = fn.warp_affine(input, matrix=[-1, 0, in_size, 0, -1, in_size],
@@ -260,5 +260,5 @@ def _test_extremely_large_data(device):
     assert out[0,0,c] == c
 
 def test_extremely_large_data():
-  for device in ["cpu", "gpu"]:  # cpu is too slow and the failure was not detected anyway
+  for device in ["cpu", "gpu"]:
     yield _test_extremely_large_data, device

--- a/dali/test/python/test_operator_warp.py
+++ b/dali/test/python/test_operator_warp.py
@@ -14,6 +14,7 @@
 
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
+import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 import nvidia.dali as dali
 from nvidia.dali.backend_impl import TensorListGPU
@@ -219,3 +220,45 @@ def test_gpu_vs_cpu():
         gpu_pipeline.build();
 
         compare(cpu_pipeline, gpu_pipeline, 1)
+
+def _test_extremely_large_data(device):
+  in_size = 30000
+  out_size = 10
+  channels = 3
+
+  def get_data():
+    out = np.full([in_size, in_size, channels], 42, dtype=np.uint8)
+    for c in range(channels):
+      out[in_size-1, in_size-1, c] = c
+    return [out]
+
+  pipe = Pipeline(1, 3, 0)
+  input = fn.external_source(source=get_data, device=device)
+
+  rotated = fn.warp_affine(input, matrix=[-1, 0, in_size, 0, -1, in_size],
+                           fill_value=255.0, size=[out_size,out_size], interp_type=types.INTERP_NN)
+  pipe.set_outputs(rotated)
+  pipe.build()
+
+  out = None
+  try:
+    out, = pipe.run()
+  except RuntimeError as e:
+    if "bad_alloc" in str(e):
+      print("Skipping test due to out-of-memory error:", e)
+      return
+    raise
+  except MemoryError as e:
+    print("Skipping test due to out-of-memory error:", e)
+    return
+  if device == "cpu":
+    out = out.at(0)
+  else:
+    out = out.as_cpu().at(0)
+  assert out.shape == (out_size, out_size, channels)
+  for c in range(channels):
+    assert out[0,0,c] == c
+
+def test_extremely_large_data():
+  for device in ["cpu", "gpu"]:  # cpu is too slow and the failure was not detected anyway
+    yield _test_extremely_large_data, device


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: invalid memory access with large inputs (above 2G elements) (#2588)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Changed strides in `Surface` to 64 bits.
     * Change SampleDesc in warp to use 64-bit strides
 - Affected modules and functionalities:
     * CPU resampling, warp operators
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * python test for operator WarpAffine
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-1789
