### PR TITLE
Fix RandomBBoxCrop errors while using crop_shape argument

### DIFF
--- a/dali/operators/image/crop/bbox_crop.cc
+++ b/dali/operators/image/crop/bbox_crop.cc
@@ -526,22 +526,22 @@ class RandomBBoxCropImpl : public OpImplBase<CPUBackend> {
     tp.RunAll();
 
     DALIDataType output_dtype = has_crop_shape_ ? DALI_INT32 : DALI_FLOAT;
-    TYPE_SWITCH(output_dtype, type2id, type, (int, float), (
+    TYPE_SWITCH(output_dtype, type2id, T, (int, float), (
       auto &anchor_out = ws.template OutputRef<CPUBackend>(0);
       anchor_out.Resize(uniform_list_shape(num_samples, {ndim}));
-      auto anchor_out_view = view<type>(anchor_out);
+      auto anchor_out_view = view<T>(anchor_out);
 
       auto &shape_out = ws.template OutputRef<CPUBackend>(1);
       shape_out.Resize(uniform_list_shape(num_samples, {ndim}));
-      auto shape_out_view = view<type>(shape_out);
+      auto shape_out_view = view<T>(shape_out);
 
       for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
         const auto &prospective_crop = sample_data_[sample_idx].prospective_crop;
         auto extent = prospective_crop.crop.extent();
         for (int d = 0; d < ndim; d++) {
           anchor_out_view.tensor_data(sample_idx)[d]
-            = static_cast<type>(prospective_crop.crop.lo[d]);
-          shape_out_view.tensor_data(sample_idx)[d] = static_cast<type>(extent[d]);
+            = static_cast<T>(prospective_crop.crop.lo[d]);
+          shape_out_view.tensor_data(sample_idx)[d] = static_cast<T>(extent[d]);
         }
       }), {});
 

--- a/dali/operators/image/crop/bbox_crop.cc
+++ b/dali/operators/image/crop/bbox_crop.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/operators/image/crop/bbox_crop.cc
+++ b/dali/operators/image/crop/bbox_crop.cc
@@ -158,6 +158,13 @@ for the crop in the ``[x, y, (z)]`` and ``[w, h, (d)]`` formats, respectively. T
 be represented in absolute or relative terms, and the represetnation depends on whether
 the fixed ``crop_shape`` was used.
 
+.. note::
+  Both ``anchor`` and ``shape`` are returned as a ``float``, even if they represent absolute
+  coordinates due to providing ``crop_shape`` argument. In order for them to be interpreted
+  correctly by :meth:`nvidia.dali.ops.Slice`, ``normalized_anchor`` and ``normalized_shape``
+  should be set to False.
+
+
 The third output contains the bounding boxes, after filtering out the ones with a centroid outside
 of the cropping window, and with the coordinates mapped to the new coordinate space.
 

--- a/dali/test/python/test_operator_random_bbox_crop.py
+++ b/dali/test/python/test_operator_random_bbox_crop.py
@@ -186,6 +186,8 @@ def check_crop_dims_variable_size(anchor, shape, scaling, aspect_ratio):
     ndim = len(shape)
     k = 0
     nranges = len(aspect_ratio) / 2
+    assert(anchor.dtype == np.float32)
+    assert(shape.dtype == np.float32)
 
     max_extent = 0.0
     for d in range(ndim):
@@ -208,10 +210,12 @@ def check_crop_dims_variable_size(anchor, shape, scaling, aspect_ratio):
 
 def check_crop_dims_fixed_size(anchor, shape, expected_crop_shape, input_shape):
     ndim = len(shape)
+    assert(anchor.dtype == np.int32)
+    assert(shape.dtype == np.int32)
     for d in range(ndim):
         assert(anchor[d] >= 0.0 and anchor[d] <= input_shape[d])
         assert shape[d] == expected_crop_shape[d], "{} != {}".format(shape, expected_crop_shape)
-        assert(anchor[d] + shape[d] > 0.0 and anchor[d] + shape[d] <= input_shape[d])
+        assert(anchor[d] + shape[d] > 0.0)
 
 def check_random_bbox_crop_variable_shape(batch_size, ndim, scaling, aspect_ratio, use_labels, output_bbox_indices):
     bbox_source = BBoxDataIterator(100, batch_size, ndim, produce_labels=use_labels)
@@ -281,8 +285,8 @@ def test_random_bbox_crop_fixed_shape():
     }
 
     crop_shapes = {
-        2: [[100, 50], [400, 300]],
-        3: [[100, 50, 32], [400, 300, 64]]
+        2: [[100, 50], [400, 300], [600, 400]],
+        3: [[100, 50, 32], [400, 300, 64], [600, 400, 48]]
     }
     for batch_size in [3]:
         for ndim in [2, 3]:

--- a/dali/test/python/test_operator_random_bbox_crop.py
+++ b/dali/test/python/test_operator_random_bbox_crop.py
@@ -186,8 +186,6 @@ def check_crop_dims_variable_size(anchor, shape, scaling, aspect_ratio):
     ndim = len(shape)
     k = 0
     nranges = len(aspect_ratio) / 2
-    assert(anchor.dtype == np.float32)
-    assert(shape.dtype == np.float32)
 
     max_extent = 0.0
     for d in range(ndim):
@@ -210,8 +208,6 @@ def check_crop_dims_variable_size(anchor, shape, scaling, aspect_ratio):
 
 def check_crop_dims_fixed_size(anchor, shape, expected_crop_shape, input_shape):
     ndim = len(shape)
-    assert(anchor.dtype == np.int32)
-    assert(shape.dtype == np.int32)
     for d in range(ndim):
         assert(anchor[d] >= 0.0 and anchor[d] <= input_shape[d])
         assert shape[d] == expected_crop_shape[d], "{} != {}".format(shape, expected_crop_shape)


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It fixes anchor/shape data type returned by calling RandomBBoxCrop with supplied crop_shape/input_shape argument and prevents segfaults in case crop_shape > input_shape.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Anchor and shape outputs of RandomBBoxCrop call with provided crop_shape/input_shape are cast to int before being returned, which prevents pixel dimensions from being interpreted as relative by other operators (eg. Slice). Additionally, anchor selection is handled differently when crop_shape > input_shape, which prevents segfaults previously caused by using std::uniform_int_distribution with incorrect constructor params.
 - Affected modules and functionalities:
     Changes to dali/operators/image/crop/bbox_crop.cc
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA


**JIRA TASK**: *[Use DALI-XXXX or NA]*
