### PR TITLE
Remove redundant JPEG decoder initialization from peeking shape function

### DIFF
--- a/dali/image/jpeg_mem.cc
+++ b/dali/image/jpeg_mem.cc
@@ -593,10 +593,9 @@ bool GetImageInfo(const void* srcdata, int datasize, int* width, int* height,
   SetSrc(&cinfo, srcdata, datasize, false);
 
   DALI_ENFORCE(jpeg_read_header(&cinfo, TRUE) == JPEG_HEADER_OK);
-  DALI_ENFORCE(jpeg_start_decompress(&cinfo));  // required to transfer image size to cinfo
-  if (width) *width = cinfo.output_width;
-  if (height) *height = cinfo.output_height;
-  if (components) *components = cinfo.output_components;
+  if (width) *width = cinfo.image_width;
+  if (height) *height = cinfo.image_height;
+  if (components) *components = cinfo.num_components;
 
   jpeg_destroy_decompress(&cinfo);
 


### PR DESCRIPTION
- in the case of progressive JPEG decoder initialization is very expensive and not needed for image shape inference

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It improves PeekImageShape operator performance for progressive JPEGs

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
    Removes redundant JPEG decoder initialization from peeking shape function as in the case of progressive JPEG decoder initialization is very expensive and not needed for image shape inference
 - Affected modules and functionalities:
     PeekImageShape operator
 - Key points relevant for the review:
     NA
 - Validation and testing:
     present test applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
