### PR TITLE
Fix length reported by DALI FW iterators when DROP policy is used

### DIFF
--- a/dali/python/nvidia/dali/plugin/base_iterator.py
+++ b/dali/python/nvidia/dali/plugin/base_iterator.py
@@ -199,7 +199,10 @@ class _DaliBaseIterator(object):
 
             self._shards_id = np.array([meta["shard_id"] for meta in readers_meta], dtype=np.int)
 
-            if self._last_batch_padded:
+            if self._last_batch_policy == LastBatchPolicy.DROP:
+                # when DROP policy is used round down the shard size
+                self._size = self._size_no_pad // self._shards_num
+            elif self._last_batch_padded:
                 # if padding is enabled all shards are equal
                 self._size = readers_meta[0]["epoch_size_padded"] // self._shards_num
             else:
@@ -361,6 +364,12 @@ class _DaliBaseIterator(object):
 
     def __len__(self):
         if self._reader_name:
-            return math.ceil(self.size / self.batch_size)
+            if self._last_batch_policy != LastBatchPolicy.DROP:
+                return math.ceil(self.size / self.batch_size)
+            else:
+                return self.size // self.batch_size
         else:
-            return math.ceil(self.size / (self._num_gpus * self.batch_size))
+            if self._last_batch_policy != LastBatchPolicy.DROP:
+                return math.ceil(self.size / (self._num_gpus * self.batch_size))
+            else:
+                return self.size // (self._num_gpus * self.batch_size)

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -339,6 +339,7 @@ def check_mxnet_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
     for _ in range(iters):
         out_set = []
         img_ids_list = [[] for _ in range(pipes_number)]
+        orig_length = length = len(dali_train_iter)
         for it in iter(dali_train_iter):
             for id in range(pipes_number):
                 tmp = it[id].data[0].squeeze(-1).asnumpy().copy()
@@ -346,6 +347,9 @@ def check_mxnet_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
                     tmp = tmp[0:-it[id].pad]
                 img_ids_list[id].append(tmp)
             sample_counter += batch_size
+            length -= 1
+
+        assert length == 0, "Iterator has reported wrong size {}, while {} iteration of data has been provide".format(orig_length, orig_length - length)
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):
@@ -494,6 +498,7 @@ def check_gluon_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
     for _ in range(iters):
         out_set = []
         img_ids_list = [[] for _ in range(pipes_number)]
+        orig_length = length = len(dali_train_iter)
         for it in iter(dali_train_iter):
             for id in range(pipes_number):
                 if len(it[id][0]):
@@ -502,6 +507,9 @@ def check_gluon_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
                     tmp = np.empty([0])
                 img_ids_list[id].append(tmp)
             sample_counter += batch_size
+            length -= 1
+
+        assert length == 0, "Iterator has reported wrong size {}, while {} iteration of data has been provide".format(orig_length, orig_length - length)
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):
@@ -728,11 +736,15 @@ def check_pytorch_iterator_pass_reader_name(shards_num, pipes_number, batch_size
     for _ in range(iters):
         out_set = []
         img_ids_list = [[] for _ in range(pipes_number)]
+        orig_length = length = len(dali_train_iter)
         for it in iter(dali_train_iter):
             for id in range(pipes_number):
                 tmp = it[id]["data"].squeeze(dim=1).numpy().copy()
                 img_ids_list[id].append(tmp)
             sample_counter += batch_size
+            length -= 1
+
+        assert length == 0, "Iterator has reported wrong size {}, while {} iteration of data has been provide".format(orig_length, orig_length - length)
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):
@@ -858,11 +870,15 @@ def check_paddle_iterator_pass_reader_name(shards_num, pipes_number, batch_size,
     for _ in range(iters):
         out_set = []
         img_ids_list = [[] for _ in range(pipes_number)]
+        orig_length = length = len(dali_train_iter)
         for it in iter(dali_train_iter):
             for id in range(pipes_number):
                 tmp = np.array(it[id]["data"]).squeeze(axis=1).copy()
                 img_ids_list[id].append(tmp)
             sample_counter += batch_size
+            length -= 1
+
+        assert length == 0, "Iterator has reported wrong size {}, while {} iteration of data has been provide".format(orig_length, orig_length - length)
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -349,7 +349,7 @@ def check_mxnet_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
             sample_counter += batch_size
             length -= 1
 
-        assert length == 0, "Iterator has reported wrong size {}, while {} iteration of data has been provide".format(orig_length, orig_length - length)
+        assert length == 0, "The iterator has reported the length of {} but provided {} iterations.".format(orig_length, orig_length - length)
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):
@@ -509,7 +509,7 @@ def check_gluon_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
             sample_counter += batch_size
             length -= 1
 
-        assert length == 0, "Iterator has reported wrong size {}, while {} iteration of data has been provide".format(orig_length, orig_length - length)
+        assert length == 0, "The iterator has reported the length of {} but provided {} iterations.".format(orig_length, orig_length - length)
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):
@@ -744,7 +744,7 @@ def check_pytorch_iterator_pass_reader_name(shards_num, pipes_number, batch_size
             sample_counter += batch_size
             length -= 1
 
-        assert length == 0, "Iterator has reported wrong size {}, while {} iteration of data has been provide".format(orig_length, orig_length - length)
+        assert length == 0, "The iterator has reported the length of {} but provided {} iterations.".format(orig_length, orig_length - length)
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):
@@ -878,7 +878,7 @@ def check_paddle_iterator_pass_reader_name(shards_num, pipes_number, batch_size,
             sample_counter += batch_size
             length -= 1
 
-        assert length == 0, "Iterator has reported wrong size {}, while {} iteration of data has been provide".format(orig_length, orig_length - length)
+        assert length == 0, "The iterator has reported the length of {} but provided {} iterations.".format(orig_length, orig_length - length)
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -349,7 +349,7 @@ def check_mxnet_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
             sample_counter += batch_size
             length -= 1
 
-        assert length == 0, "The iterator has reported the length of {} but provided {} iterations.".format(orig_length, orig_length - length)
+        assert length == 0, f"The iterator has reported the length of {orig_length} but provided {orig_length - length} iterations."
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):
@@ -509,7 +509,7 @@ def check_gluon_iterator_pass_reader_name(shards_num, pipes_number, batch_size, 
             sample_counter += batch_size
             length -= 1
 
-        assert length == 0, "The iterator has reported the length of {} but provided {} iterations.".format(orig_length, orig_length - length)
+        assert length == 0, f"The iterator has reported the length of {orig_length} but provided {orig_length - length} iterations."
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):
@@ -744,7 +744,7 @@ def check_pytorch_iterator_pass_reader_name(shards_num, pipes_number, batch_size
             sample_counter += batch_size
             length -= 1
 
-        assert length == 0, "The iterator has reported the length of {} but provided {} iterations.".format(orig_length, orig_length - length)
+        assert length == 0, f"The iterator has reported the length of {orig_length} but provided {orig_length - length} iterations."
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):
@@ -878,7 +878,7 @@ def check_paddle_iterator_pass_reader_name(shards_num, pipes_number, batch_size,
             sample_counter += batch_size
             length -= 1
 
-        assert length == 0, "The iterator has reported the length of {} but provided {} iterations.".format(orig_length, orig_length - length)
+        assert length == 0, f"The iterator has reported the length of {orig_length} but provided {orig_length - length} iterations."
         if not auto_reset:
             dali_train_iter.reset()
         for id in range(pipes_number):


### PR DESCRIPTION
- DALI reported the wrong length of the FW iterator when the drop policy was used. This PR corrects this.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes the length reported by DALI FW iterators when DROP policy is used

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     DALI reported the wrong length of the FW iterator when the drop policy was used. Fix the calculation logic
 - Affected modules and functionalities:
     base_iterator
 - Key points relevant for the review:
     NA
 - Validation and testing:
     Test is added
 - Documentation (including examples):
     NA

Relates to https://github.com/NVIDIA/DALI/issues/2607
**JIRA TASK**: *[NA]*
