### PR TITLE
Disable mmap based test for Xavier

### DIFF
--- a/qa/TL0_self-test_xavier/test.sh
+++ b/qa/TL0_self-test_xavier/test.sh
@@ -22,7 +22,7 @@ test_body() {
         exit 1
     fi
 
-    # for some reason mmap baed test tends to fail on some runners due to disc issue, so
+    # for some reason mmap based test tends to fail on some runners due to disc issue, so
     # disable it for now
     "$FULLPATH" --gtest_filter=-*mmap*
   done

--- a/qa/TL0_self-test_xavier/test.sh
+++ b/qa/TL0_self-test_xavier/test.sh
@@ -22,7 +22,9 @@ test_body() {
         exit 1
     fi
 
-    "$FULLPATH"
+    # for some reason mmap baed test tends to fail on some runners due to disc issue, so
+    # disable it for now
+    "$FULLPATH" --gtest_filter=-*mmap*
   done
 }
 


### PR DESCRIPTION
- some CI Xavier runners due to disc issue fails mmap based tests

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It disables mmap based test for Xavier

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     some CI Xavier runners due to disc issue fails mmap based tests so disable mmap based test for Xavier
 - Affected modules and functionalities:
     test is blacklisted
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
