### PR TITLE
Use smaller block in Warp

### DIFF
--- a/dali/kernels/imgproc/warp_gpu.cuh
+++ b/dali/kernels/imgproc/warp_gpu.cuh
@@ -64,7 +64,7 @@ class WarpGPU {
                            span<const DALIInterpType> interp,
                            BorderType border = {}) {
     assert(in.size() == output_sizes.size());
-    setup.SetBlockDim(dim3(32, 16, 1));
+    setup.SetBlockDim(dim3(32, 8, 1));
     auto out_shapes = setup.GetOutputShape(in.shape, output_sizes);
     return setup.Setup(out_shapes);
   }

--- a/dali/kernels/test/warp_test/warp_gpu_test.cu
+++ b/dali/kernels/test/warp_test/warp_gpu_test.cu
@@ -78,6 +78,7 @@ void WarpGPU_Affine_Transpose(bool force_variable) {
 
   if (force_variable) {
     auto &setup = WarpPrivateTest::GetSetup(warp);
+    setup.SetBlockDim(dim3(32, 8, 1));
     auto out_shapes = setup.GetOutputShape(in_list.shape, out_shapes_hw);
     req = setup.Setup(out_shapes, true);
     req.scratch_sizes[static_cast<int>(AllocType::GPU)] += sizeof(warp::SampleDesc<2, int, int>);


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: "out of launch resources" on some machines after changing strides to 64-bit

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Decreased block size to 32x8 threads
 - Affected modules and functionalities:
     * GPU warp kernels
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests apply
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
