### PR TITLE
Enable nvJPEG2K for CUDA 11.2 builds

### DIFF
--- a/docker/Dockerfile.cuda112.x86_64.deps
+++ b/docker/Dockerfile.cuda112.x86_64.deps
@@ -8,5 +8,17 @@ RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.2.0/local_ins
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;
 
+RUN NVJPEG2K_VERSION=0.1.0 && \
+    apt-get update && \
+    apt-get install wget software-properties-common -y && \
+    wget -qO - https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
+    add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /" && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub && \
+    apt-get update && \
+    apt-get install libnvjpeg2k0 libnvjpeg2k-dev -y && \
+    cp /usr/include/nvjpeg2k* /usr/local/cuda/include/ && \
+    cp /usr/lib/x86_64-linux-gnu/libnvjpeg2k* /usr/local/cuda/lib64/ && \
+    rm -rf /var/lib/apt/lists/*
+
 FROM scratch
 COPY --from=cuda /usr/local/cuda /usr/local/cuda


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes lack of nvJPEG2k for CUDA 11.2 based builds
 
#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     enable nvJPEG2K for CUDA 11.2 builds
 - Affected modules and functionalities:
     CUDA 11.2 toolkit base image
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
