### PR TITLE
Improve Optical Flow error verbosity

### DIFF
--- a/dali/operators/sequence/optical_flow/turing_of/optical_flow_buffer.h
+++ b/dali/operators/sequence/optical_flow/turing_of/optical_flow_buffer.h
@@ -35,15 +35,15 @@ class OpticalFlowBuffer {
           turing_of_(function_list),
           descriptor_(GenerateBufferDescriptor(width, height, format, usage)) {
     // Buffer alloc
-    TURING_OF_API_CALL(turing_of_.nvOFCreateGPUBufferCuda(of_handle, &descriptor_,
-                                                          NV_OF_CUDA_BUFFER_TYPE_CUDEVICEPTR,
-                                                          &handle_));
+    CUDA_CALL(turing_of_.nvOFCreateGPUBufferCuda(of_handle, &descriptor_,
+                                                 NV_OF_CUDA_BUFFER_TYPE_CUDEVICEPTR,
+                                                 &handle_));
     ptr_ = turing_of_.nvOFGPUBufferGetCUdeviceptr(handle_);
     DALI_ENFORCE(ptr_ != 0, "Invalid pointer");
 
     // Assigning stride
     NV_OF_CUDA_BUFFER_STRIDE_INFO stride_info;
-    TURING_OF_API_CALL(turing_of_.nvOFGPUBufferGetStrideInfo(handle_, &stride_info));
+    CUDA_CALL(turing_of_.nvOFGPUBufferGetStrideInfo(handle_, &stride_info));
     stride_ = {stride_info.strideInfo[0].strideXInBytes, stride_info.strideInfo[0].strideYInBytes};
   }
 

--- a/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.cc
+++ b/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.cc
@@ -60,7 +60,7 @@ OpticalFlowTuring::OpticalFlowTuring(dali::optical_flow::OpticalFlowParams param
           "Failed to create Optical Flow context: Verify that your device supports Optical Flow.");
     }
   }
-  TURING_OF_API_CALL(turing_of_.nvOFSetIOCudaStreams(of_handle_, stream_, stream_));
+  CUDA_CALL(turing_of_.nvOFSetIOCudaStreams(of_handle_, stream_, stream_));
   VerifySupport(turing_of_.nvOFInit(of_handle_, &init_params_));
 
   inbuf_.reset(
@@ -142,7 +142,7 @@ void OpticalFlowTuring::CalcOpticalFlow(
                                            ? hintsbuf_->GetHandle()
                                            : nullptr);
   auto out_params = GenerateExecuteOutParams(outbuf_->GetHandle());
-  TURING_OF_API_CALL(turing_of_.nvOFExecute(of_handle_, &in_params, &out_params));
+  CUDA_CALL(turing_of_.nvOFExecute(of_handle_, &in_params, &out_params));
 
 
   kernel::DecodeFlowComponents(reinterpret_cast<int16_t *>(outbuf_->GetPtr()), output_image.data,
@@ -221,7 +221,7 @@ OpticalFlowTuring::DLLDRIVER OpticalFlowTuring::LoadTuringOpticalFlow
   init = (decltype(init)) dlsym(lib_handle, kInitSymbol.c_str());
   DALI_ENFORCE(init, "Failed to find symbol " + kInitSymbol + ": " + std::string(dlerror()));
 
-  TURING_OF_API_CALL((*init)(NV_OF_API_VERSION, &turing_of_));
+  CUDA_CALL((*init)(NV_OF_API_VERSION, &turing_of_));
   return lib_handle;
 }
 

--- a/dali/operators/sequence/optical_flow/turing_of/utils.h
+++ b/dali/operators/sequence/optical_flow/turing_of/utils.h
@@ -30,31 +30,31 @@ class NvofError : public std::runtime_error {
   static const char *ErrorString(NV_OF_STATUS result) {
     switch (result) {
       case NV_OF_SUCCESS:
-        return "Nvidia Optical flow operation was successful";
+        return "NVIDIA Optical flow operation was successful";
       case NV_OF_ERR_OF_NOT_AVAILABLE:
-        return "Nvidia HW Optical flow functionality is not supported";
+        return "NVIDIA HW Optical flow functionality is not supported";
       case NV_OF_ERR_UNSUPPORTED_DEVICE:
-        return "The device passed by the client to Nvidia HW Optical flow is not supported";
+        return "The device passed by the client to NVIDIA HW Optical flow is not supported";
       case NV_OF_ERR_DEVICE_DOES_NOT_EXIST:
-        return "The device passed to the Nvidia HW Optical flow API call is no longer available "
+        return "The device passed to the NVIDIA HW Optical flow API call is no longer available "
                 "and needs to be reinitialized";
       case NV_OF_ERR_INVALID_PTR:
-        return "One or more of the pointers passed to the Nvidia HW Optical flow API "
+        return "One or more of the pointers passed to the NVIDIA HW Optical flow "
                "API call is invalid";
       case NV_OF_ERR_INVALID_PARAM:
-        return "One or more of the parameter passed to the Nvidia Optical flow API call is invalid";
+        return "One or more of the parameters passed to the NVIDIA Optical flow API call "
+               "are invalid";
       case NV_OF_ERR_INVALID_CALL:
         return "Nvidia Optical flow API call was made in wrong sequence/order";
       case NV_OF_ERR_INVALID_VERSION:
-        return "An invalid struct version was used by the Nvidia Optical flow client";
+        return "An invalid struct version was used by the NVIDIA Optical flow client";
       case NV_OF_ERR_OUT_OF_MEMORY:
-        return "Nvidia Optical flow API call failed because it was unable to allocate  "
+        return "NVIDIA Optical flow API call failed because it was unable to allocate  "
                "enough memory to perform the requested operation";
       case NV_OF_ERR_NOT_INITIALIZED:
-        return "Nvidia Optical flow session has not been initialized with or initialization "
-               "has failed";
+        return "Nvidia Optical flow session has not been initialized or initialization has failed";
       case NV_OF_ERR_UNSUPPORTED_FEATURE:
-        return "Unsupported parameter was passed by the client to Nvidia Optical flow";
+        return "Unsupported parameter was passed by the client to NVIDIA Optical flow";
       case NV_OF_ERR_GENERIC:
         // fallthrough
       default:
@@ -64,10 +64,10 @@ class NvofError : public std::runtime_error {
 
   static std::string Message(NV_OF_STATUS result, const char *details) {
     if (details && *details) {
-      return make_string("Nvidia Optical flow error: ", result, " ", ErrorString(result),
+      return make_string("NVIDIA Optical flow error: ", result, " ", ErrorString(result),
                          "\nDetails:\n", details);
     } else {
-      return make_string("Nvidia Optical flow error: ", result, " ", ErrorString(result));
+      return make_string("NVIDIA Optical flow error: ", result, " ", ErrorString(result));
     }
   }
 

--- a/dali/operators/sequence/optical_flow/turing_of/utils.h
+++ b/dali/operators/sequence/optical_flow/turing_of/utils.h
@@ -15,15 +15,79 @@
 #ifndef DALI_OPERATORS_SEQUENCE_OPTICAL_FLOW_TURING_OF_UTILS_H_
 #define DALI_OPERATORS_SEQUENCE_OPTICAL_FLOW_TURING_OF_UTILS_H_
 
-#define TURING_OF_API_CALL(nvOFAPI)                                                  \
-    do                                                                               \
-    {                                                                                \
-        NV_OF_STATUS errorCode = nvOFAPI;                                            \
-        if (errorCode != NV_OF_SUCCESS) {                                            \
-            std::ostringstream errorLog;                                             \
-            errorLog << #nvOFAPI << " returned error: " << errorCode << std::endl;   \
-            DALI_FAIL(errorLog.str());                                               \
-        }                                                                            \
-    } while (0)
+#include <string>
+#include "dali/core/cuda_error.h"
+#include "dali/core/format.h"
+
+namespace dali {
+
+class NvofError : public std::runtime_error {
+ public:
+  explicit NvofError(NV_OF_STATUS result, const char *details = nullptr)
+  : std::runtime_error(Message(result, details))
+  , result_(result) {}
+
+  static const char *ErrorString(NV_OF_STATUS result) {
+    switch (result) {
+      case NV_OF_SUCCESS:
+        return "Nvidia Optical flow operation was successful";
+      case NV_OF_ERR_OF_NOT_AVAILABLE:
+        return "Nvidia HW Optical flow functionality is not supported";
+      case NV_OF_ERR_UNSUPPORTED_DEVICE:
+        return "The device passed by the client to Nvidia HW Optical flow is not supported";
+      case NV_OF_ERR_DEVICE_DOES_NOT_EXIST:
+        return "The device passed to the Nvidia HW Optical flow API call is no longer available "
+                "and needs to be reinitialized";
+      case NV_OF_ERR_INVALID_PTR:
+        return "One or more of the pointers passed to the Nvidia HW Optical flow API "
+               "API call is invalid";
+      case NV_OF_ERR_INVALID_PARAM:
+        return "One or more of the parameter passed to the Nvidia Optical flow API call is invalid";
+      case NV_OF_ERR_INVALID_CALL:
+        return "Nvidia Optical flow API call was made in wrong sequence/order";
+      case NV_OF_ERR_INVALID_VERSION:
+        return "An invalid struct version was used by the Nvidia Optical flow client";
+      case NV_OF_ERR_OUT_OF_MEMORY:
+        return "Nvidia Optical flow API call failed because it was unable to allocate  "
+               "enough memory to perform the requested operation";
+      case NV_OF_ERR_NOT_INITIALIZED:
+        return "Nvidia Optical flow session has not been initialized with or initialization "
+               "has failed";
+      case NV_OF_ERR_UNSUPPORTED_FEATURE:
+        return "Unsupported parameter was passed by the client to Nvidia Optical flow";
+      case NV_OF_ERR_GENERIC:
+        // fallthrough
+      default:
+        return "< unknown error >";
+    }
+  }
+
+  static std::string Message(NV_OF_STATUS result, const char *details) {
+    if (details && *details) {
+      return make_string("Nvidia Optical flow error: ", result, " ", ErrorString(result),
+                         "\nDetails:\n", details);
+    } else {
+      return make_string("Nvidia Optical flow error: ", result, " ", ErrorString(result));
+    }
+  }
+
+
+  NV_OF_STATUS result() const { return result_; }
+
+ private:
+  NV_OF_STATUS result_;
+};
+
+template <>
+inline void cudaResultCheck<NV_OF_STATUS>(NV_OF_STATUS status) {
+  switch (status) {
+  case NV_OF_SUCCESS:
+    return;
+  default:
+    throw dali::NvofError(status);
+  }
+}
+
+}  // namespace dali
 
 #endif  // DALI_OPERATORS_SEQUENCE_OPTICAL_FLOW_TURING_OF_UTILS_H_


### PR DESCRIPTION
- use general CUDA_CALL with specialization for NV_OF_STATUS to handle NVIDIA Optical flow errors

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It improves Optical Flow error verbosity

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     use general CUDA_CALL with specialization for NV_OF_STATUS to handle NVIDIA Optical flow errors
 - Affected modules and functionalities:
     optical flow platform specific code
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI, current test applies
 - Documentation (including examples):
     NA

Relates to https://github.com/NVIDIA/DALI/issues/2616
**JIRA TASK**: *[NA]*
