### PR TITLE
Enable time-major layout in Spectrogram CPU

### DIFF
--- a/dali/kernels/signal/window/extract_windows_cpu.h
+++ b/dali/kernels/signal/window/extract_windows_cpu.h
@@ -31,6 +31,13 @@ namespace signal {
 /**
  * @brief Extracts windows from 1D signal applying a custom window function
  *
+ * @tparam OutputType Output data type
+ * @tparam InputType Input data type
+ * @tparam Dims Number of dimensions
+ * @tparam vertical If true, the window index dimension comes right after the temporal dimension,
+ *         resulting in "vertical" windows in the output layout.
+ *         Otherwise, the new window index dimension is placed just before the time dimension,
+ *         producing "horizontal windows" in the output layout.
  * @param args.window_length Window size in number of samples
  *
  * @param args.window_step Length of the step between windows. If not provided, win_length
@@ -55,7 +62,7 @@ namespace signal {
  *        This option is only relevant when `window_center` is greater than 0
  *
  */
-template <typename OutputType = float, typename InputType = float, int Dims = 1>
+template <typename OutputType = float, typename InputType = float, int Dims = 1, bool vertical = true>
 class DLL_PUBLIC ExtractWindowsCpu {
  public:
   static constexpr int InputDims = Dims;

--- a/dali/kernels/signal/window/extract_windows_cpu.h
+++ b/dali/kernels/signal/window/extract_windows_cpu.h
@@ -62,7 +62,8 @@ namespace signal {
  *        This option is only relevant when `window_center` is greater than 0
  *
  */
-template <typename OutputType = float, typename InputType = float, int Dims = 1, bool vertical = true>
+template <typename OutputType = float, typename InputType = float, int Dims = 1,
+          bool vertical = true>
 class DLL_PUBLIC ExtractWindowsCpu {
  public:
   static constexpr int InputDims = Dims;

--- a/dali/operators/signal/fft/spectrogram.cc
+++ b/dali/operators/signal/fft/spectrogram.cc
@@ -81,11 +81,7 @@ is padded with zeros.
   When ``center_windows`` is set to False, this option is ignored.
 )",
     true)
-  .AddOptionalArg("layout", R"(Output layout: "ft" (frequency-major) or "tf" (time-major).
-
-.. note::
-  Time-major layout is available only in the implementation for GPU backend.
-)",
+  .AddOptionalArg("layout", R"(Output layout: "ft" (frequency-major) or "tf" (time-major).)",
     TensorLayout("ft"));
 
 template <bool time_major>

--- a/dali/operators/signal/fft/spectrogram.cc
+++ b/dali/operators/signal/fft/spectrogram.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <memory>
+#include <string>
 #include <vector>
 #include "dali/operators/signal/fft/spectrogram.h"
 #include "dali/kernels/kernel_manager.h"
@@ -87,15 +88,18 @@ is padded with zeros.
 )",
     TensorLayout("ft"));
 
+template <bool time_major>
 struct SpectrogramImplCpu : OpImplBase<CPUBackend> {
   using OutputType = float;
   using InputType = float;
 
   static constexpr int InputDims = 1;
+  static constexpr bool vertical_win = !time_major;
   using WindowKernel =
-    kernels::signal::ExtractWindowsCpu<InputType, InputType, InputDims>;
+    kernels::signal::ExtractWindowsCpu<InputType, InputType, InputDims, vertical_win>;
 
   static constexpr int WindowsDims = 2;
+  static constexpr int transform_dim = time_major ? 1 : 0;
   using FftKernel = kernels::signal::fft::Fft1DCpu<OutputType, InputType, WindowsDims>;
 
   explicit SpectrogramImplCpu(const OpSpec & spec);
@@ -126,7 +130,7 @@ struct SpectrogramImplCpu : OpImplBase<CPUBackend> {
 
 namespace {
   void FillFftArgs(kernels::signal::fft::FftArgs& args,
-                   int power, int window_length, int nfft, int ndims) {
+                   int power, int window_length, int nfft, int transform_axis) {
     args.nfft = nfft;
     DALI_ENFORCE(window_length <= nfft, make_string(
       "Window length (", window_length, ") can't be bigger than the FFT size (", nfft, ")"));
@@ -141,13 +145,14 @@ namespace {
         DALI_FAIL(make_string("`power` can be only 1 (energy) or 2 (power), received ", power));
     }
 
-    // layout (.., freq, time)
-    args.transform_axis = ndims - 2;
+    // Time major (.., freq, time) or Freq major (.., time, freq)
+    args.transform_axis = transform_axis;
   }
 
 }  // namespace
 
-SpectrogramImplCpu::SpectrogramImplCpu(const OpSpec &spec)
+template <bool time_major>
+SpectrogramImplCpu<time_major>::SpectrogramImplCpu(const OpSpec &spec)
     : window_length_(spec.GetArgument<int>("window_length"))
     , window_step_(spec.GetArgument<int>("window_step"))
     , power_(spec.GetArgument<int>("power"))
@@ -157,8 +162,7 @@ SpectrogramImplCpu::SpectrogramImplCpu(const OpSpec &spec)
   nfft_ = spec.HasArgument("nfft") ? spec.GetArgument<int>("nfft") : window_length_;
 
   layout_ = spec.GetArgument<TensorLayout>("layout");
-  DALI_ENFORCE(layout_ != "tf", "Time-major spectrogram for CPU backend is not implemented.");
-  DALI_ENFORCE(layout_ == "ft", make_string("Unsupported layout requested: ", layout_));
+  assert((time_major && layout_ == "tf") || (!time_major && layout_ == "ft"));
 
   if (window_fn_.empty()) {
     window_fn_.resize(window_length_);
@@ -176,9 +180,9 @@ SpectrogramImplCpu::SpectrogramImplCpu(const OpSpec &spec)
   }
 }
 
-
-bool SpectrogramImplCpu::SetupImpl(std::vector<OutputDesc> &out_desc,
-                                   const workspace_t<CPUBackend> &ws) {
+template <bool time_major>
+bool SpectrogramImplCpu<time_major>::SetupImpl(std::vector<OutputDesc> &out_desc,
+                                               const workspace_t<CPUBackend> &ws) {
   const auto &input = ws.InputRef<CPUBackend>(0);
   auto &output = ws.OutputRef<CPUBackend>(0);
   kernels::KernelContext ctx;
@@ -217,7 +221,7 @@ bool SpectrogramImplCpu::SetupImpl(std::vector<OutputDesc> &out_desc,
 
   kmgr_fft_.Initialize<FftKernel>();
   kmgr_fft_.Resize<FftKernel>(nthreads, nsamples);
-  FillFftArgs(fft_args_, power_, window_length_, nfft_, WindowsDims);
+  FillFftArgs(fft_args_, power_, window_length_, nfft_, transform_dim);
 
   window_out_desc_.resize(1);
   window_out_desc_[0].type = TypeInfo::Create<InputType>();
@@ -252,7 +256,8 @@ bool SpectrogramImplCpu::SetupImpl(std::vector<OutputDesc> &out_desc,
   return true;
 }
 
-void SpectrogramImplCpu::RunImpl(workspace_t<CPUBackend> &ws) {
+template <bool time_major>
+void SpectrogramImplCpu<time_major>::RunImpl(workspace_t<CPUBackend> &ws) {
   const auto &input = ws.InputRef<CPUBackend>(0);
   auto &output = ws.OutputRef<CPUBackend>(0);
   auto out_shape = output.shape();
@@ -292,8 +297,16 @@ void SpectrogramImplCpu::RunImpl(workspace_t<CPUBackend> &ws) {
 
 template <>
 Spectrogram<CPUBackend>::Spectrogram(const OpSpec &spec)
-    : Operator<CPUBackend>(spec)
-    , impl_(std::make_unique<SpectrogramImplCpu>(spec)) {}
+    : Operator<CPUBackend>(spec) {
+  auto layout = spec.GetArgument<std::string>("layout");
+  DALI_ENFORCE(layout == "tf" || layout == "ft",
+               make_string("Unexpected layout: ", layout));
+  bool time_major = layout == "tf";
+  if (time_major)
+    impl_ = std::make_unique<SpectrogramImplCpu<true>>(spec);
+  else
+    impl_ = std::make_unique<SpectrogramImplCpu<false>>(spec);
+}
 
 DALI_REGISTER_OPERATOR(Spectrogram, Spectrogram<CPUBackend>, CPU);
 

--- a/dali/test/python/test_operator_spectrogram.py
+++ b/dali/test/python/test_operator_spectrogram.py
@@ -230,16 +230,15 @@ def check_operator_decoder_and_spectrogram_vs_python(device, batch_size, nfft, w
 
 def test_operator_decoder_and_spectrogram():
     for device in ["cpu", "gpu"]:
-        layouts = ["tf", "ft"] if device == "gpu" else ["ft"]
-        for batch_size in [3]:
-            for nfft, window_length, window_step, shape in [(256, 256, 128, (1, 4096)),
-                                                            (256, 256, 128, (4096,)),
-                                                            (256, 256, 128, (4096, 1)),
-                                                            (256, 256, 128, (1, 1, 4096, 1)),
-                                                            (16, 16, 8, (1, 1000)),
-                                                            (10, 10, 5, (1, 1000)),
-                                                            ]:
-                for layout in layouts:
+        for layout in ["tf", "ft"]:
+            for batch_size in [3]:
+                for nfft, window_length, window_step, shape in [(256, 256, 128, (1, 4096)),
+                                                                (256, 256, 128, (4096,)),
+                                                                (256, 256, 128, (4096, 1)),
+                                                                (256, 256, 128, (1, 1, 4096, 1)),
+                                                                (16, 16, 8, (1, 1000)),
+                                                                (10, 10, 5, (1, 1000)),
+                                                                ]:
                     yield check_operator_decoder_and_spectrogram_vs_python, device, batch_size, \
                             nfft, window_length, window_step, layout
 


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a new feature needed to calculate time-major spectrograms (CPU)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a template argument to ExtractWindows kernel so that windows can be produced vertically or horizontally*
     *Adjusted use of ExtractWindows and FFT kernel in Spectrogram CPU operator*
 - Affected modules and functionalities:
     *Spectrogram CPU operator. ExtractWindows and FFT 1D kernels*
 - Key points relevant for the review:
     *Correctness, Performance. Anything that could be easility optimized?*
 - Validation and testing:
     *Existing tests*
 - Documentation (including examples):
     *Already done for GPU*


**JIRA TASK**: *[DALI-1811]*
