### PR TITLE
Enable support for different layouts in the MelFilterBank GPU Op

### DIFF
--- a/dali/kernels/audio/mel_scale/mel_filter_bank_cpu.cc
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_cpu.cc
@@ -186,15 +186,16 @@ void MelFilterBankCpu<T>::Run(KernelContext &context,
   TensorShape<DynamicDimensions> in_shape = in.shape;
   TensorShape<DynamicDimensions> out_shape = out.shape;
   auto axis = args.axis;
-  while (axis > 1) {
-    in_shape = collapse_dim(in_shape, 0);
-    out_shape = collapse_dim(out_shape, 0);
-    axis--;
+  if (axis > 1) {
+    in_shape = collapse_dims(in_shape, {std::make_pair(0, axis)});
+    out_shape = collapse_dims(out_shape, {std::make_pair(0, axis)});
+    axis = 1;
   }
-  while (axis < in_shape.size() - 2) {
-    in_shape = collapse_dim(in_shape, in_shape.size() - 2);
-    out_shape = collapse_dim(out_shape, out_shape.size() - 2);
+  if (axis < in_shape.size() - 2) {
+    in_shape = collapse_dims(in_shape, {std::make_pair(axis + 1, in_shape.size() - axis - 1)});
+    out_shape = collapse_dims(out_shape, {std::make_pair(axis + 1, out_shape.size() - axis - 1)});
   }
+
   bool is_freq_last = axis == in_shape.size() - 1 || in_shape[in_shape.size() - 1] == 1;
 
   assert(in_shape.size() <= 3);

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_cpu.cc
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_cpu.cc
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <complex>
 #include <algorithm>
+#include <utility>
 #include <vector>
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_cpu.cc
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_cpu.cc
@@ -39,42 +39,51 @@ namespace audio {
 // For every FFT bin we compute the weight for each filter and travel through the row, computing
 // the contributions on every window of the spectrogram (horizontal axis)
 //
-template <typename T, int Dims>
-class MelFilterBankCpu<T, Dims>::Impl: public MelFilterImplBase<T, Dims> {
+template <typename T>
+class MelFilterBankCpu<T>::Impl: public MelFilterImplBase<T> {
  public:
   template <typename MelScale>
   Impl(MelScale mel_scale, const MelFilterBankArgs &args)
-      : MelFilterImplBase<T, Dims>(mel_scale, args) {
-    double mel = mel_low_ + mel_delta_;
+      : MelFilterImplBase<T>(mel_scale, args) {
     auto nfilter = args.nfilter;
-    assert(args.axis == Dims - 1 || args.axis == Dims - 2);
-    if (args.axis == Dims - 2) {
-      intervals_.resize(fftbin_size_, -1);
-      int fftbin = fftbin_start_;
-      double f = fftbin * hz_step_;
-      for (int interval = 0; interval < nfilter + 1; interval++, mel += mel_delta_) {
-        double freq = mel_scale.mel_to_hz(interval == nfilter ? mel_high_ : mel);
-        for (; fftbin <= fftbin_end_ && f < freq; fftbin++, f = fftbin * hz_step_) {
-          intervals_[fftbin] = interval;
-        }
+
+    intervals_.resize(fftbin_size_, -1);
+    int fftbin = fftbin_start_;
+    double f = fftbin * hz_step_;
+    double mel = mel_low_ + mel_delta_;
+    for (int interval = 0; interval < nfilter + 1; interval++, mel += mel_delta_) {
+      double freq = mel_scale.mel_to_hz(interval == nfilter ? mel_high_ : mel);
+      for (; fftbin <= fftbin_end_ && f < freq; fftbin++, f = fftbin * hz_step_) {
+        intervals_[fftbin] = interval;
       }
-    } else {  // args.axis == Dims - 1
-      interval_ends_.resize(nfilter + 2);
-      interval_ends_[0] = fftbin_start_;
-      interval_ends_[nfilter + 1] = fftbin_end_ + 1;
-      for (int interval = 1; interval < nfilter + 1; interval++, mel += mel_delta_) {
-        double freq = mel_scale.mel_to_hz(mel);
-        interval_ends_[interval] = std::ceil(freq / hz_step_);
-      }
+    }
+
+    mel = mel_low_ + mel_delta_;
+    interval_ends_.resize(nfilter + 2);
+    interval_ends_[0] = fftbin_start_;
+    interval_ends_[nfilter + 1] = fftbin_end_ + 1;
+    for (int interval = 1; interval < nfilter + 1; interval++, mel += mel_delta_) {
+      double freq = mel_scale.mel_to_hz(mel);
+      interval_ends_[interval] = std::ceil(freq / hz_step_);
     }
   }
 
-  void ComputeFreqMajor(T* out, const T* in, int64_t nwindows) {
-    int nfilter = args_.nfilter;
 
-    std::memset(out, 0, sizeof(T) * nfilter * nwindows);
-    for (int64_t fftbin = fftbin_start_; fftbin <= fftbin_end_; fftbin++) {
-      auto *in_row_start = in + fftbin * nwindows;
+  /**
+   * @brief Applies mel filter bank to a 2D spectrogram, optimized for 
+   *        frequency-major layout ("ft"). 
+   */
+  void ComputeFreqMajor(T* out, const T* in, int64_t nwindows,
+                        int64_t out_size, int64_t out_stride,
+                        int64_t in_size, int64_t in_stride) {
+    for (int64_t m = 0; m < out_size; m++) {
+      T* out_row = out + m * out_stride;
+      for (int64_t t = 0; t < nwindows; t++)
+        out_row[t] = T(0);
+    }
+
+    const T *in_row = in + fftbin_start_ * in_stride;
+    for (int64_t fftbin = fftbin_start_; fftbin <= fftbin_end_; fftbin++, in_row += in_stride) {
       auto filter_up = intervals_[fftbin];
       auto weight_up = T(1) - weights_down_[fftbin];
       auto filter_down = filter_up - 1;
@@ -83,70 +92,66 @@ class MelFilterBankCpu<T, Dims>::Impl: public MelFilterImplBase<T, Dims> {
       if (filter_down >= 0) {
         if (args_.normalize)
           weight_down *= norm_factors_[filter_down];
-        auto *out_row_start = out + filter_down * nwindows;
+        auto *out_row = out + filter_down * out_stride;
         for (int t = 0; t < nwindows; t++) {
-          out_row_start[t] += weight_down * in_row_start[t];
+          out_row[t] += weight_down * in_row[t];
         }
       }
 
-      if (filter_up >= 0 && filter_up < nfilter) {
+      if (filter_up >= 0 && filter_up < out_size) {
         if (args_.normalize)
           weight_up *= norm_factors_[filter_up];
-        auto *out_row_start = out + filter_up * nwindows;
+        auto *out_row = out + filter_up * out_stride;
         for (int t = 0; t < nwindows; t++) {
-          out_row_start[t] += weight_up * in_row_start[t];
+          out_row[t] += weight_up * in_row[t];
         }
       }
     }
   }
 
-  void ComputeTimeMajor(T* out, const T* in, int64_t nwindows) {
-    int nfilter = args_.nfilter;
-    for (int t = 0; t < nwindows; t++) {
-      const T *in_row = in + t * fftbin_size_;
-      for (int m = 0; m < nfilter; m++) {
-        T val = 0;
-        int fftbin = interval_ends_[m];
-        int f1 = interval_ends_[m + 1];
-        int f2 = interval_ends_[m + 2];
-        for (; fftbin < f1; ++fftbin) {
-          auto weight_up = T(1) - weights_down_[fftbin];
-          if (args_.normalize)
-            weight_up *= norm_factors_[m];
-          val += in_row[fftbin] * weight_up;
-        }
-        for (; fftbin < f2; ++fftbin) {
-          auto weight_down = weights_down_[fftbin];
-          if (args_.normalize)
-            weight_down *= norm_factors_[m];
-          val += in_row[fftbin] * weight_down;
-        }
-        *out++ = val;
+  /**
+   * @brief Applies a mel filter bank to a one-dimensional spectrum input or
+   *        individual frames in a time-major layout spectrogram input ("tf").
+   */
+  void ComputeTimeMajor(T* out, const T* in, int64_t nfilter, int64_t fftbin_size) {
+    for (int m = 0; m < nfilter; m++) {
+      T val = 0;
+      int fftbin = interval_ends_[m];
+      int f1 = interval_ends_[m + 1];
+      int f2 = interval_ends_[m + 2];
+      for (; fftbin < f1; ++fftbin) {
+        auto weight_up = T(1) - weights_down_[fftbin];
+        val += in[fftbin] * weight_up;
       }
+      for (; fftbin < f2; ++fftbin) {
+        val += in[fftbin] * weights_down_[fftbin];
+      }
+      if (args_.normalize)
+        val *= norm_factors_[m];
+      *out++ = val;
     }
   }
 
  private:
   std::vector<int> intervals_;
   std::vector<int> interval_ends_;
-  USE_MEL_FILTER_IMPL_MEMBERS(T, Dims);
+  USE_MEL_FILTER_IMPL_MEMBERS(T);
 };
 
-template <typename T, int Dims>
-MelFilterBankCpu<T, Dims>::MelFilterBankCpu() = default;
+template <typename T>
+MelFilterBankCpu<T>::MelFilterBankCpu() = default;
 
-template <typename T, int Dims>
-MelFilterBankCpu<T, Dims>::~MelFilterBankCpu() = default;
+template <typename T>
+MelFilterBankCpu<T>::~MelFilterBankCpu() = default;
 
-template <typename T, int Dims>
-KernelRequirements MelFilterBankCpu<T, Dims>::Setup(KernelContext &context,
-                                                    const InTensorCPU<T, Dims> &in,
-                                                    const MelFilterBankArgs &orig_args) {
+template <typename T>
+KernelRequirements MelFilterBankCpu<T>::Setup(KernelContext &context,
+                                              const InTensorCPU<T> &in,
+                                              const MelFilterBankArgs &orig_args) {
   auto args = orig_args;
-  args.axis = args.axis >= 0 ? args.axis : Dims - 2;
-  DALI_ENFORCE(args.axis == Dims - 2 || args.axis == Dims - 1,
-               "Input is expected to be a spectrogram with the last two dimensions being "
-               "(fftbin_idx, frame_idx), frequency major, or (frame_idx, fftbin_idx), time major.");
+  int ndim = in.dim();
+  args.axis = args.axis >= 0 ? args.axis : ndim - 2;
+  assert(args.axis >= 0 && args.axis <= ndim - 1);
   auto out_shape = in.shape;
   out_shape[args.axis] = args.nfilter;
 
@@ -171,42 +176,66 @@ KernelRequirements MelFilterBankCpu<T, Dims>::Setup(KernelContext &context,
   return req;
 }
 
-template <typename T, int Dims>
-void MelFilterBankCpu<T, Dims>::Run(KernelContext &context, const OutTensorCPU<T, Dims> &out,
-                                    const InTensorCPU<T, Dims> &in) {
+template <typename T>
+void MelFilterBankCpu<T>::Run(KernelContext &context,
+                              const OutTensorCPU<T> &out,
+                              const InTensorCPU<T> &in) {
   DALI_ENFORCE(impl_ != nullptr);
   const auto &args = impl_->Args();
-  assert(args.axis == Dims - 2 || args.axis == Dims - 1);
-  auto in_shape = in.shape;
-  auto out_shape = out.shape;
-  auto out_strides = GetStrides(out_shape);
-  auto in_strides = GetStrides(in_shape);
 
-  if (args.axis == Dims - 2) {
-    auto nwin = in_shape[Dims - 1];
-    ForAxis(out.data, in.data, out_shape.data(), out_strides.data(), in_shape.data(),
-            in_strides.data(), Dims - 2,
-            Dims - 1,  // Iterating slices of the two last dimensions
-            [this, nwin](T *out_data, const T *in_data, int64_t out_size, int64_t out_stride,
-                         int64_t in_size, int64_t in_stride) {
-              impl_->ComputeFreqMajor(out_data, in_data, nwin);
-            });
+  TensorShape<DynamicDimensions> in_shape = in.shape;
+  TensorShape<DynamicDimensions> out_shape = out.shape;
+  auto axis = args.axis;
+  while (axis > 1) {
+    in_shape = collapse_dim(in_shape, 0);
+    out_shape = collapse_dim(out_shape, 0);
+    axis--;
+  }
+  while (axis < in_shape.size() - 2) {
+    in_shape = collapse_dim(in_shape, in_shape.size() - 2);
+    out_shape = collapse_dim(out_shape, out_shape.size() - 2);
+  }
+  bool is_freq_last = axis == in_shape.size() - 1 || in_shape[in_shape.size() - 1] == 1;
+
+  assert(in_shape.size() <= 3);
+  int64_t fftbin_size = in_shape[axis];
+  int64_t nfilter = out_shape[axis];
+
+  if (is_freq_last) {
+    int64_t nwindows = axis == 0 ? 1 : in_shape[0];
+    for (int t = 0; t < nwindows; t++) {
+      const T *in_row = in.data + t * fftbin_size;
+      T *out_row = out.data + t * nfilter;
+      impl_->ComputeTimeMajor(out_row, in_row, nfilter, fftbin_size);
+    }
   } else {
-    int64_t nwin = 1;
-    for (int d = 0; d < Dims - 1; d++)
-      nwin *= in_shape[d];
-    impl_->ComputeTimeMajor(out.data, in.data, nwin);
+    int64_t nwindows = 1;
+    // Grouping last two dimensions as "ft"
+    auto f_in_size = in_shape[axis];
+    auto f_in_stride = GetStrides(in_shape)[axis];
+    auto f_out_size = out_shape[axis];
+    auto f_out_stride = GetStrides(out_shape)[axis];
+    if (axis < in_shape.size() - 1) {
+      nwindows = in_shape[in_shape.size() - 1];
+      in_shape = collapse_dim(in_shape, axis);
+      out_shape = collapse_dim(out_shape, axis);
+    }
+    auto in_strides = GetStrides(in_shape);
+    auto out_strides = GetStrides(out_shape);
+
+    ForAxis(out.data, in.data, out_shape.data(), out_strides.data(), in_shape.data(),
+            in_strides.data(), axis, in_shape.size(),
+            [this, nwindows, f_out_size, f_out_stride, f_in_size, f_in_stride]
+            (T *out_data, const T *in_data, int64_t out_size, int64_t out_stride,
+             int64_t in_size, int64_t in_stride) {
+              impl_->ComputeFreqMajor(out_data, in_data, nwindows,
+                                      f_out_size, f_out_stride, f_in_size, f_in_stride);
+            });
   }
 }
 
-template class MelFilterBankCpu<float, 2>;
-template class MelFilterBankCpu<double, 2>;
-
-template class MelFilterBankCpu<float, 3>;
-template class MelFilterBankCpu<double, 3>;
-
-template class MelFilterBankCpu<float, 4>;
-template class MelFilterBankCpu<double, 4>;
+template class MelFilterBankCpu<float>;
+template class MelFilterBankCpu<double>;
 
 }  // namespace audio
 }  // namespace kernels

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_cpu.h
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_cpu.h
@@ -42,8 +42,7 @@ class DLL_PUBLIC MelFilterBankCpu {
 
   DLL_PUBLIC void Run(KernelContext &context,
                       const OutTensorCPU<T, Dims> &out,
-                      const InTensorCPU<T, Dims> &in,
-                      const MelFilterBankArgs &args);
+                      const InTensorCPU<T, Dims> &in);
 
  private:
   class Impl;

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_cpu.h
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_cpu.h
@@ -27,22 +27,21 @@ namespace dali {
 namespace kernels {
 namespace audio {
 
-template <typename T = float, int Dims = 2>
+template <typename T = float>
 class DLL_PUBLIC MelFilterBankCpu {
  public:
   static_assert(std::is_floating_point<T>::value, "Only floating point types are supported");
-  static_assert(Dims >= 2, "At least 2 dimensions are expected");
 
   DLL_PUBLIC MelFilterBankCpu();
   DLL_PUBLIC ~MelFilterBankCpu();
 
   DLL_PUBLIC KernelRequirements Setup(KernelContext &context,
-                                      const InTensorCPU<T, Dims> &in,
+                                      const InTensorCPU<T> &in,
                                       const MelFilterBankArgs &args);
 
   DLL_PUBLIC void Run(KernelContext &context,
-                      const OutTensorCPU<T, Dims> &out,
-                      const InTensorCPU<T, Dims> &in);
+                      const OutTensorCPU<T> &out,
+                      const InTensorCPU<T> &in);
 
  private:
   class Impl;

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_cpu_test.cc
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_cpu_test.cc
@@ -136,7 +136,7 @@ TEST_P(MelScaleCpuTest, MelScaleCpuTest) {
   std::vector<T> out(out_size, 0.0f);
   auto out_view = OutTensorCPU<T, Dims>(out.data(), out_shape.to_static<Dims>());
 
-  kernel.Run(ctx, out_view, in_view_, args);
+  kernel.Run(ctx, out_view, in_view_);
 
   LOG_LINE << "in:\n";
   print_data(in_view_);

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.cu
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.cu
@@ -122,7 +122,7 @@ class MelFilterBankGpu<T>::Impl : public MelFilterImplBase<T> {
     }
   }
 
-  void Setup(ScratchpadEstimator &se, TensorListShape<> in_shape) {
+  void Setup(ScratchpadEstimator &se, const TensorListShape<> &in_shape) {
     se.add<int>(AllocType::GPU, interval_ends_.size());
     se.add<T>(AllocType::GPU, weights_down_.size());
     if (args_.normalize)

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.cu
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.cu
@@ -110,9 +110,9 @@ template <typename T, int Dims>
 class MelFilterBankGpu<T, Dims>::Impl : public MelFilterImplBase<T, Dims> {
  public:
   template <typename MelScale>
-  Impl(MelScale mel_scale, const MelFilterBankArgs &args)
-      : MelFilterImplBase<T, Dims>(mel_scale, args)
-      , interval_ends_(args.nfilter+2) {
+  Impl(MelScale mel_scale, const MelFilterBankArgs &args) :
+      MelFilterImplBase<T, Dims>(mel_scale, args),
+      interval_ends_(args.nfilter + 2) {
     double mel = mel_low_ + mel_delta_;
     interval_ends_[0] = fftbin_start_;
     interval_ends_[args.nfilter + 1] = fftbin_end_ + 1;

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.cu
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.cu
@@ -106,12 +106,12 @@ __global__ void MelFilterBankKernelInnerFft(const BlockDesc<T> *block_desc,
                          weights_down, interval_ends, 1, 0, norm_factor);
 }
 
-template <typename T, int Dims>
-class MelFilterBankGpu<T, Dims>::Impl : public MelFilterImplBase<T, Dims> {
+template <typename T>
+class MelFilterBankGpu<T>::Impl : public MelFilterImplBase<T> {
  public:
   template <typename MelScale>
   Impl(MelScale mel_scale, const MelFilterBankArgs &args) :
-      MelFilterImplBase<T, Dims>(mel_scale, args),
+      MelFilterImplBase<T>(mel_scale, args),
       interval_ends_(args.nfilter + 2) {
     double mel = mel_low_ + mel_delta_;
     interval_ends_[0] = fftbin_start_;
@@ -122,22 +122,28 @@ class MelFilterBankGpu<T, Dims>::Impl : public MelFilterImplBase<T, Dims> {
     }
   }
 
-  void Setup(ScratchpadEstimator &se, const TensorListShape<Dims> &in_shape) {
+  void Setup(ScratchpadEstimator &se, TensorListShape<> in_shape) {
     se.add<int>(AllocType::GPU, interval_ends_.size());
     se.add<T>(AllocType::GPU, weights_down_.size());
     if (args_.normalize)
       se.add<T>(AllocType::GPU, norm_factors_.size());
-    fft_dim_ = in_shape[0][args_.axis];
 
-    if (args_.axis == Dims - 1) {
+    inner_fft_ = true;
+    for (int s = 0; s < in_shape.size(); s++) {
+      inner_fft_ &= volume(in_shape.tensor_shape_span(s).begin() + args_.axis + 1,
+                           in_shape.tensor_shape_span(s).end()) == 1;
+    }
+    fft_dim_ = in_shape.tensor_shape_span(0)[args_.axis];
+    if (inner_fft_) {
       SetupBlockDescsInnerFft(se, in_shape);
     } else {
       SetupBlockDescsOuterFft(se, in_shape);
     }
   }
 
-  void Compute(const T* const* in_list, T **out_list, Scratchpad *scratchpad, cudaStream_t stream) {
-    if (args_.axis == Dims - 1) {
+  void Compute(const T* const* in_list, T **out_list, int ndim,
+               Scratchpad *scratchpad, cudaStream_t stream) {
+    if (inner_fft_) {
       FillBlockDescsInnerFft(in_list, out_list);
     } else {
       FillBlockDescsOuterFft(in_list, out_list);
@@ -148,7 +154,7 @@ class MelFilterBankGpu<T, Dims>::Impl : public MelFilterImplBase<T, Dims> {
     T *norm_factors = nullptr;
     if (args_.normalize)
       norm_factors = scratchpad->ToGPU(stream, norm_factors_);
-    if (args_.axis == Dims - 1) {
+    if (inner_fft_) {
       MelFilterBankKernelInnerFft
           <<<block_descs_.size(), kBlockDim1, 0, stream>>>
             (block_descs, weights_down, interval_ends, args_.normalize,
@@ -162,10 +168,10 @@ class MelFilterBankGpu<T, Dims>::Impl : public MelFilterImplBase<T, Dims> {
     }
   }
 
-  using MelFilterImplBase<T, Dims>::Args;
+  using MelFilterImplBase<T>::Args;
 
  private:
-  void SetupBlockDescsOuterFft(ScratchpadEstimator &se, const TensorListShape<Dims> &in_shape) {
+  void SetupBlockDescsOuterFft(ScratchpadEstimator &se, const TensorListShape<> &in_shape) {
     nframes_.clear();
     nwindows_.clear();
     block_descs_.clear();
@@ -185,7 +191,7 @@ class MelFilterBankGpu<T, Dims>::Impl : public MelFilterImplBase<T, Dims> {
     se.add<BlockDesc<T>>(AllocType::GPU, block_descs_.size());
   }
 
-  void SetupBlockDescsInnerFft(ScratchpadEstimator &se, const TensorListShape<Dims> &in_shape) {
+  void SetupBlockDescsInnerFft(ScratchpadEstimator &se, const TensorListShape<> &in_shape) {
     nframes_.clear();
     nwindows_.clear();
     block_descs_.clear();
@@ -238,27 +244,26 @@ class MelFilterBankGpu<T, Dims>::Impl : public MelFilterImplBase<T, Dims> {
   std::vector<int64_t> nwindows_;
   std::vector<BlockDesc<T>> block_descs_;
   int64_t fft_dim_;
-  USE_MEL_FILTER_IMPL_MEMBERS(T, Dims);
+  bool inner_fft_ = false;
+  USE_MEL_FILTER_IMPL_MEMBERS(T);
 };
 
-template <typename T, int Dims>
-KernelRequirements MelFilterBankGpu<T, Dims>::Setup(KernelContext &context,
-                                                    const InListGPU<T, Dims> &in,
-                                                    const MelFilterBankArgs &original_args) {
+template <typename T>
+KernelRequirements MelFilterBankGpu<T>::Setup(KernelContext &context,
+                                              const InListGPU<T> &in,
+                                              const MelFilterBankArgs &original_args) {
   auto args = original_args;
-  args.axis = args.axis >= 0 ? args.axis : Dims - 2;
-  TensorListShape<Dims> out_shape(in.shape.num_samples());
+  args.axis = args.axis >= 0 ? args.axis : in.sample_dim() - 2;
+  TensorListShape<> out_shape = in.shape;
   for (int64_t s = 0; s < out_shape.num_samples(); ++s) {
-    auto s_shape = in.shape[s];
-    s_shape[args.axis] = args.nfilter;
-    out_shape.set_tensor_shape(s, s_shape);
+    out_shape.tensor_shape_span(s)[args.axis] = args.nfilter;
   }
   KernelRequirements req;
   req.output_shapes = {out_shape};
 
-  auto fftdim = in.shape[0][args.axis];
-  for (int s = 1; s < in.shape.nsamples; ++s) {
-    DALI_ENFORCE(in.shape[s][args.axis] == fftdim,
+  auto fftdim = in.shape.tensor_shape_span(0)[args.axis];
+  for (int s = 1; s < in.shape.num_samples(); ++s) {
+    DALI_ENFORCE(in.shape.tensor_shape_span(s)[args.axis] == fftdim,
         "All samples should have the same FFT dimension");
   }
   ScratchpadEstimator se;
@@ -281,30 +286,22 @@ KernelRequirements MelFilterBankGpu<T, Dims>::Setup(KernelContext &context,
   return req;
 }
 
-template <typename T, int Dims>
-void MelFilterBankGpu<T, Dims>::Run(
-    KernelContext &context,
-    OutListGPU<T, Dims> &out,
-    const InListGPU<T, Dims> &in) {
+template <typename T>
+void MelFilterBankGpu<T>::Run(KernelContext &context, OutListGPU<T> &out, const InListGPU<T> &in) {
   assert(impl_ != nullptr);
-  impl_->Compute(in.data.data(), out.data.data(), context.scratchpad, context.gpu.stream);
+  impl_->Compute(in.data.data(), out.data.data(), in.sample_dim(), context.scratchpad,
+                 context.gpu.stream);
 }
 
-template <typename T, int Dims>
-MelFilterBankGpu<T, Dims>::MelFilterBankGpu() {}
+template <typename T>
+MelFilterBankGpu<T>::MelFilterBankGpu() {}
 
-template <typename T, int Dims>
-MelFilterBankGpu<T, Dims>::~MelFilterBankGpu() {}
+template <typename T>
+MelFilterBankGpu<T>::~MelFilterBankGpu() {}
 
 
-template class MelFilterBankGpu<float, 2>;
-template class MelFilterBankGpu<double, 2>;
-
-template class MelFilterBankGpu<float, 3>;
-template class MelFilterBankGpu<double, 3>;
-
-template class MelFilterBankGpu<float, 4>;
-template class MelFilterBankGpu<double, 4>;
+template class MelFilterBankGpu<float>;
+template class MelFilterBankGpu<double>;
 
 }  // namespace audio
 }  // namespace kernels

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.h
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.h
@@ -26,22 +26,21 @@ namespace dali {
 namespace kernels {
 namespace audio {
 
-template <typename T = float, int Dims = 2>
+template <typename T = float>
 class DLL_PUBLIC MelFilterBankGpu {
  public:
   static_assert(std::is_floating_point<T>::value, "Only floating point types are supported");
-  static_assert(Dims >= 2, "At least 2 dimensions are expected");
 
   DLL_PUBLIC MelFilterBankGpu();
   DLL_PUBLIC ~MelFilterBankGpu();
 
   DLL_PUBLIC KernelRequirements Setup(KernelContext &context,
-                                      const InListGPU<T, Dims> &in,
+                                      const InListGPU<T> &in,
                                       const MelFilterBankArgs &args);
 
   DLL_PUBLIC void Run(KernelContext &context,
-                      OutListGPU<T, Dims> &out,
-                      const InListGPU<T, Dims> &in);
+                      OutListGPU<T> &out,
+                      const InListGPU<T> &in);
 
  private:
   class Impl;

--- a/dali/kernels/audio/mel_scale/mel_scale.h
+++ b/dali/kernels/audio/mel_scale/mel_scale.h
@@ -72,7 +72,7 @@ struct SlaneyMelScale {
   }
 };
 
-template <typename T, int Dims>
+template <typename T>
 class MelFilterImplBase {
  public:
   template <typename MelScale>
@@ -143,17 +143,17 @@ class MelFilterImplBase {
   double hz_step_, mel_delta_;
 };
 
-#define USE_MEL_FILTER_IMPL_MEMBERS(T, Dims) \
-  using MelFilterImplBase<T, Dims>::args_; \
-  using MelFilterImplBase<T, Dims>::fftbin_start_; \
-  using MelFilterImplBase<T, Dims>::fftbin_end_; \
-  using MelFilterImplBase<T, Dims>::mel_low_; \
-  using MelFilterImplBase<T, Dims>::mel_high_; \
-  using MelFilterImplBase<T, Dims>::fftbin_size_; \
-  using MelFilterImplBase<T, Dims>::weights_down_; \
-  using MelFilterImplBase<T, Dims>::norm_factors_; \
-  using MelFilterImplBase<T, Dims>::mel_delta_; \
-  using MelFilterImplBase<T, Dims>::hz_step_
+#define USE_MEL_FILTER_IMPL_MEMBERS(T) \
+  using MelFilterImplBase<T>::args_; \
+  using MelFilterImplBase<T>::fftbin_start_; \
+  using MelFilterImplBase<T>::fftbin_end_; \
+  using MelFilterImplBase<T>::mel_low_; \
+  using MelFilterImplBase<T>::mel_high_; \
+  using MelFilterImplBase<T>::fftbin_size_; \
+  using MelFilterImplBase<T>::weights_down_; \
+  using MelFilterImplBase<T>::norm_factors_; \
+  using MelFilterImplBase<T>::mel_delta_; \
+  using MelFilterImplBase<T>::hz_step_
 
 }  // namespace audio
 }  // namespace kernels

--- a/dali/operators/audio/mel_scale/mel_filter_bank.cc
+++ b/dali/operators/audio/mel_scale/mel_filter_bank.cc
@@ -24,9 +24,8 @@ DALI_SCHEMA(MelFilterBank)
 triangular filters.
 
 Expects an input with at least 2 dimensions.
-
-Please note that the CPU implementation supports only the layout with the last two
-dimensions corresponding to the fft bin index and the window index, respectively.
+The frequency ('f') dimension must be present in the layout and should be one of the last two 
+dimensions in the layout.
 )code")
     .NumInput(kNumInputs)
     .NumOutput(kNumOutputs)
@@ -108,7 +107,7 @@ void MelFilterBank<CPUBackend>::RunImpl(workspace_t<CPUBackend> &ws) {
           [this, &input, &output, i](int thread_id) {
             auto in_view = view<const T, Dims>(input[i]);
             auto out_view = view<T, Dims>(output[i]);
-            kmgr_.Run<MelFilterBankKernel>(thread_id, i, ctx_, out_view, in_view, args_);
+            kmgr_.Run<MelFilterBankKernel>(thread_id, i, ctx_, out_view, in_view);
           }, in_shape.tensor_size(i));
       }
     ), DALI_FAIL(make_string("Unsupported number of dimensions ", in_shape.size())));  // NOLINT

--- a/dali/operators/audio/mel_scale/mel_filter_bank.cc
+++ b/dali/operators/audio/mel_scale/mel_filter_bank.cc
@@ -77,7 +77,7 @@ bool MelFilterBank<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
   auto ndim = in_shape.sample_dim();
   args_.axis = layout.empty() ? std::max(0, ndim - 2) : layout.find('f');
   DALI_ENFORCE(args_.axis >= 0 && args_.axis < ndim,
-    make_string("'f' axis not present in the layout. Got: ", layout));
+    make_string("'f' axis not present in the layout. Got: `", layout, "`"));
   TYPE_SWITCH(input.type().id(), type2id, T, MEL_FBANK_SUPPORTED_TYPES, (
     using MelFilterBankKernel = kernels::audio::MelFilterBankCpu<T>;
     kmgr_.Initialize<MelFilterBankKernel>();

--- a/dali/operators/audio/mel_scale/mel_filter_bank.cc
+++ b/dali/operators/audio/mel_scale/mel_filter_bank.cc
@@ -23,8 +23,10 @@ DALI_SCHEMA(MelFilterBank)
     .DocStr(R"code(Converts a spectrogram to a mel spectrogram by applying a bank of
 triangular filters.
 
-Expects an input with at least 2 dimensions where the last two dimensions correspond to
-the fft bin index and the window index, respectively.
+Expects an input with at least 2 dimensions.
+
+Please note that the CPU implementation supports only the layout with the last two
+dimensions corresponding to the fft bin index and the window index, respectively.
 )code")
     .NumInput(kNumInputs)
     .NumOutput(kNumOutputs)
@@ -73,7 +75,7 @@ bool MelFilterBank<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
   auto in_shape = input.shape();
   int nsamples = input.size();
   auto nthreads = ws.GetThreadPool().size();
-
+  args_.axis = input.GetLayout().find('f');
   TYPE_SWITCH(input.type().id(), type2id, T, MEL_FBANK_SUPPORTED_TYPES, (
     VALUE_SWITCH(in_shape.sample_dim(), Dims, MEL_FBANK_SUPPORTED_NDIMS, (
       using MelFilterBankKernel = kernels::audio::MelFilterBankCpu<T, Dims>;

--- a/dali/operators/audio/mel_scale/mel_filter_bank.h
+++ b/dali/operators/audio/mel_scale/mel_filter_bank.h
@@ -25,7 +25,6 @@
 #include "dali/pipeline/operator/operator.h"
 
 #define MEL_FBANK_SUPPORTED_TYPES (float)
-#define MEL_FBANK_SUPPORTED_NDIMS (2, 3, 4)
 
 namespace dali {
 

--- a/dali/operators/audio/mel_scale/mel_filter_bank_gpu.cc
+++ b/dali/operators/audio/mel_scale/mel_filter_bank_gpu.cc
@@ -29,7 +29,7 @@ bool MelFilterBank<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
   auto ndim = in_shape.sample_dim();
   args_.axis = layout.empty() ? std::max(0, ndim - 2) : layout.find('f');
   DALI_ENFORCE(args_.axis >= 0 && args_.axis < ndim,
-    make_string("'f' axis not present in the layout. Got: ", layout));
+    make_string("'f' axis not present in the layout. Got: `", layout, "`"));
   ctx_.gpu.stream = ws.stream();
   TYPE_SWITCH(input.type().id(), type2id, T, MEL_FBANK_SUPPORTED_TYPES, (
     using MelFilterBankKernel = kernels::audio::MelFilterBankGpu<T>;

--- a/dali/operators/audio/mel_scale/mel_filter_bank_gpu.cc
+++ b/dali/operators/audio/mel_scale/mel_filter_bank_gpu.cc
@@ -24,9 +24,13 @@ bool MelFilterBank<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
                                           const workspace_t<GPUBackend> &ws) {
   output_desc.resize(kNumOutputs);
   const auto &input = ws.InputRef<GPUBackend>(0);
-  args_.axis = input.GetLayout().find('f');
-  ctx_.gpu.stream = ws.stream();
   const auto &in_shape = input.shape();
+  auto layout = input.GetLayout();
+  auto ndim = in_shape.sample_dim();
+  args_.axis = layout.empty() ? std::max(0, ndim - 2) : layout.find('f');
+  DALI_ENFORCE(args_.axis >= 0 && args_.axis < ndim,
+    make_string("'f' axis not present in the layout. Got: ", layout));
+  ctx_.gpu.stream = ws.stream();
   TYPE_SWITCH(input.type().id(), type2id, T, MEL_FBANK_SUPPORTED_TYPES, (
     using MelFilterBankKernel = kernels::audio::MelFilterBankGpu<T>;
     kmgr_.Initialize<MelFilterBankKernel>();

--- a/dali/operators/audio/mel_scale/mel_filter_bank_gpu.cc
+++ b/dali/operators/audio/mel_scale/mel_filter_bank_gpu.cc
@@ -24,6 +24,7 @@ bool MelFilterBank<GPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
                                           const workspace_t<GPUBackend> &ws) {
   output_desc.resize(kNumOutputs);
   const auto &input = ws.InputRef<GPUBackend>(0);
+  args_.axis = input.GetLayout().find('f');
   ctx_.gpu.stream = ws.stream();
   const auto &in_shape = input.shape();
   TYPE_SWITCH(input.type().id(), type2id, T, MEL_FBANK_SUPPORTED_TYPES, (

--- a/dali/test/python/test_operator_mel_filter_bank.py
+++ b/dali/test/python/test_operator_mel_filter_bank.py
@@ -127,7 +127,6 @@ def check_operator_mel_filter_bank_vs_python(device, batch_size, max_shape,
 
 def test_operator_mel_filter_bank_vs_python():
     for device in ['cpu', 'gpu']:
-        gpu = device == 'gpu'
         for batch_size in [1, 3]:
             for normalize in [True, False]:
                 for mel_formula in ['htk', 'slaney']:
@@ -135,9 +134,9 @@ def test_operator_mel_filter_bank_vs_python():
                         [(4, 16000.0, 0.0, 8000.0, (17, 1), 'ft'),
                         (128, 16000.0, 0.0, 8000.0, (513, 100), 'ft'),
                         (128, 48000.0, 0.0, 24000.0, (513, 100), 'ft'),
-                        (128, 16000.0, 0.0, 8000.0, (10, 513, 100), 'Ctf' if gpu else 'Cft'),
-                        (128, 48000.0, 4000.0, 24000.0, (513, 100), 'tf' if gpu else 'ft'),
-                        (128, 44100.0, 0.0, 22050.0, (513, 100), 'tf' if gpu else 'ft'),
-                        (128, 44100.0, 1000.0, 22050.0, (513, 100), 'tf' if gpu else 'ft')]:
+                        (128, 16000.0, 0.0, 8000.0, (10, 513, 100), 'Ctf'),
+                        (128, 48000.0, 4000.0, 24000.0, (513, 100), 'tf'),
+                        (128, 44100.0, 0.0, 22050.0, (513, 100), 'tf'),
+                        (128, 44100.0, 1000.0, 22050.0, (513, 100), 'tf')]:
                         yield check_operator_mel_filter_bank_vs_python, device, batch_size, shape, \
                             nfilter, sample_rate, freq_low, freq_high, normalize, mel_formula, layout

--- a/dali/test/python/test_operator_mel_filter_bank.py
+++ b/dali/test/python/test_operator_mel_filter_bank.py
@@ -28,7 +28,7 @@ import librosa as librosa
 
 class MelFilterBankPipeline(Pipeline):
     def __init__(self, device, batch_size, iterator, nfilter, sample_rate, freq_low, freq_high,
-                 normalize, mel_formula, num_threads=1, device_id=0):
+                 normalize, mel_formula, layout='ft', num_threads=1, device_id=0):
         super(MelFilterBankPipeline, self).__init__(batch_size, num_threads, device_id)
         self.device = device
         self.iterator = iterator
@@ -40,6 +40,7 @@ class MelFilterBankPipeline(Pipeline):
                                        freq_high = freq_high,
                                        normalize = normalize,
                                        mel_formula = mel_formula)
+        self.layout=layout
 
     def define_graph(self):
         self.data = self.inputs()
@@ -49,7 +50,7 @@ class MelFilterBankPipeline(Pipeline):
 
     def iter_setup(self):
         data = self.iterator.next()
-        self.feed_input(self.data, data)
+        self.feed_input(self.data, data, layout=self.layout)
 
 def mel_fbank_func(nfilter, sample_rate, freq_low, freq_high, normalize, mel_formula, input_data):
     in_shape = input_data.shape
@@ -75,7 +76,7 @@ def mel_fbank_func(nfilter, sample_rate, freq_low, freq_high, normalize, mel_for
 
 class MelFilterBankPythonPipeline(Pipeline):
     def __init__(self, device, batch_size, iterator, nfilter, sample_rate, freq_low, freq_high,
-                 normalize, mel_formula, num_threads=1, device_id=0, func=mel_fbank_func):
+                 normalize, mel_formula, layout='ft', num_threads=1, device_id=0, func=mel_fbank_func):
         super(MelFilterBankPythonPipeline, self).__init__(
               batch_size, num_threads, device_id,
               seed=12345, exec_async=False, exec_pipelined=False)
@@ -85,43 +86,58 @@ class MelFilterBankPythonPipeline(Pipeline):
 
         function = partial(func, nfilter, sample_rate, freq_low, freq_high, normalize, mel_formula)
         self.mel_fbank = ops.PythonFunction(function=function)
+        self.layout=layout
+        self.freq_major = layout.find('f') != len(layout) - 1
+        if not self.freq_major:
+            perm = [i for i in range(len(layout))]
+            f = layout.find('f')
+            perm[f] = len(layout) - 2
+            perm[-2] = f
+            self.transpose = ops.Transpose(perm=perm)
+
+    def _transposed(self, op):
+        return lambda x: self.transpose(op(self.transpose(x)))
 
     def define_graph(self):
         self.data = self.inputs()
-        out = self.mel_fbank(self.data)
+        mel_fbank = self.mel_fbank if self.freq_major else self._transposed(self.mel_fbank)
+        out = mel_fbank(self.data)
         return out
 
     def iter_setup(self):
         data = self.iterator.next()
-        self.feed_input(self.data, data)
+        self.feed_input(self.data, data, layout=self.layout)
 
 def check_operator_mel_filter_bank_vs_python(device, batch_size, max_shape,
                                              nfilter, sample_rate, freq_low, freq_high,
-                                             normalize, mel_formula):
-    min_shape = [max_shape[0], 1]
+                                             normalize, mel_formula, layout):
+    f_axis = layout.find('f')
+    min_shape = [1 for _ in max_shape]
+    min_shape[f_axis] = max_shape[f_axis]
     eii1 = RandomlyShapedDataIterator(batch_size, min_shape=min_shape, max_shape=max_shape, dtype=np.float32)
     eii2 = RandomlyShapedDataIterator(batch_size, min_shape=min_shape, max_shape=max_shape, dtype=np.float32)
     compare_pipelines(
         MelFilterBankPipeline(device, batch_size, iter(eii1),
                               nfilter=nfilter, sample_rate=sample_rate, freq_low=freq_low, freq_high=freq_high,
-                              normalize=normalize, mel_formula=mel_formula),
+                              normalize=normalize, mel_formula=mel_formula, layout=layout),
         MelFilterBankPythonPipeline(device, batch_size, iter(eii2),
                                     nfilter=nfilter, sample_rate=sample_rate, freq_low=freq_low, freq_high=freq_high,
-                                    normalize=normalize, mel_formula=mel_formula),
+                                    normalize=normalize, mel_formula=mel_formula, layout=layout),
         batch_size=batch_size, N_iterations=5, eps=1e-03)
 
 def test_operator_mel_filter_bank_vs_python():
     for device in ['cpu', 'gpu']:
+        gpu = device == 'gpu'
         for batch_size in [1, 3]:
             for normalize in [True, False]:
                 for mel_formula in ['htk', 'slaney']:
-                    for nfilter, sample_rate, freq_low, freq_high, shape in \
-                        [(4, 16000.0, 0.0, 8000.0, (17, 1)),
-                        (128, 16000.0, 0.0, 8000.0, (513, 100)),
-                        (128, 16000.0, 0.0, 8000.0, (10, 513, 100)),
-                        (128, 48000.0, 0.0, 24000.0, (513, 100)),
-                        (128, 48000.0, 4000.0, 24000.0, (513, 100)),
-                        (128, 44100.0, 0.0, 22050.0, (513, 100)),
-                        (128, 44100.0, 1000.0, 22050.0, (513, 100))]:
+                    for nfilter, sample_rate, freq_low, freq_high, shape, layout in \
+                        [(4, 16000.0, 0.0, 8000.0, (17, 1), 'ft'),
+                        (128, 16000.0, 0.0, 8000.0, (513, 100), 'ft'),
+                        (128, 48000.0, 0.0, 24000.0, (513, 100), 'ft'),
+                        (128, 16000.0, 0.0, 8000.0, (10, 513, 100), 'Ctf' if gpu else 'Cft'),
+                        (128, 48000.0, 4000.0, 24000.0, (513, 100), 'tf' if gpu else 'ft'),
+                        (128, 44100.0, 0.0, 22050.0, (513, 100), 'tf' if gpu else 'ft'),
+                        (128, 44100.0, 1000.0, 22050.0, (513, 100), 'tf' if gpu else 'ft')]:
                         yield check_operator_mel_filter_bank_vs_python, device, batch_size, shape, \
-                            nfilter, sample_rate, freq_low, freq_high, normalize, mel_formula
+                            nfilter, sample_rate, freq_low, freq_high, normalize, mel_formula, layout


### PR DESCRIPTION
Signed-off-by: Rafal <Banas.Rafal97@gmail.com>

#### Why we need this PR?
- It adds a support for the layouts other than #ft in the MelFilterBank GPU Op. Needed for time-major layout support.

#### What happened in this PR?
 - What solution was applied:
     The frequency axis is queried from the layout string
 - Affected modules and functionalities:
     Operators impl.
 - Key points relevant for the review:
    docstring, tests
 - Validation and testing:
     I've extended the existing tests to run on "tf" layout
 - Documentation (including examples):
     Docstring updated 


**JIRA TASK**: *NA*
