### PR TITLE
Adds interleaving to videos to read them as specified in #2621

### DIFF
--- a/dali/operators/reader/loader/loader.cc
+++ b/dali/operators/reader/loader/loader.cc
@@ -23,6 +23,20 @@ DALI_SCHEMA(LoaderBase)
 
 A prefetch buffer with a size equal to ``initial_fill`` is used to read data sequentially,
 and then samples are selected randomly to form a batch.)code", false)
+  .AddOptionalArg("interleavement",
+      R"code(Determines how to shuffle the data.
+
+Sets the how many sequences should be interleaved. 
+A prefetch buffer with a size equal to ``initial_fill`` is used to read data sequentially,
+and then samples are selected randomly to form a batch.)code", 0)
+  .AddOptionalArg("interleave_type",
+      R"code(Determines how to interleave the data.
+
+Sets the interleavement mode. It requires that the interleavement is not zero in order
+to interleave the data. The supported modes are continuous interleavement, reduction to
+the shortest sequence, repeating the sequence until all others have been read, repeating
+the last element until all others have been read or appending zeros until all others have
+been read.)code", DALI_SHORTEN)
   .AddOptionalArg("initial_fill",
       R"code(Size of the buffer that is used for shuffling.
 

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -55,9 +55,11 @@ class Loader {
   using LoadTargetSharedPtr = std::shared_ptr<LoadTarget>;
   explicit Loader(const OpSpec& options)
     : shuffle_(options.GetArgument<bool>("random_shuffle")),
+      interleavement_(options.GetArgument<int>("interleavement")),
+      interleave_type_(options.GetArgument<DALIInterleaveType>("interleave_type")),
       initial_buffer_fill_(shuffle_ ? options.GetArgument<int>("initial_fill") : 1),
       initial_empty_size_(2 * options.GetArgument<int>("prefetch_queue_depth")
-                          * options.GetArgument<int>("max_batch_size")),
+                            * options.GetArgument<int>("max_batch_size")),
       tensor_init_bytes_(options.GetArgument<int>("tensor_init_bytes")),
       seed_(options.GetArgument<Index>("seed")),
       shard_id_(options.GetArgument<int>("shard_id")),
@@ -316,6 +318,8 @@ class Loader {
   // number of samples to initialize buffer with
   // ~1 minibatch seems reasonable
   bool shuffle_;
+  const int interleavement_;
+  DALIInterleaveType interleave_type_;
   const int initial_buffer_fill_;
   const int initial_empty_size_;
   const int tensor_init_bytes_;

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -118,6 +118,7 @@ enum DALIDataType : int {
   DALI_TENSOR_LAYOUT     = 23,
   DALI_PYTHON_OBJECT     = 24,
   DALI_TENSOR_LAYOUT_VEC = 25,
+  DALI_INTERLEAVE_TYPE   = 26,
   DALI_DATATYPE_END      = 1000
 };
 
@@ -205,6 +206,9 @@ inline std::ostream &operator<<(std::ostream &os, DALIDataType t) {
       break;
     case DALI_TENSOR_LAYOUT_VEC:
       os << "list of TensorLayout";
+      break;
+    case DALI_INTERLEAVE_TYPE:
+      os << "DALIInterleaveType";
       break;
     case DALI_DATATYPE_END:  // fall through
     default:
@@ -527,24 +531,25 @@ DLL_PUBLIC inline bool IsValidType(const TypeInfo &type) {
   DALI_REGISTER_TYPE_IMPL(Type, dtype);
 
 // Instantiate some basic types
-DALI_REGISTER_TYPE(NoType,         DALI_NO_TYPE);
-DALI_REGISTER_TYPE(uint8_t,        DALI_UINT8);
-DALI_REGISTER_TYPE(uint16_t,       DALI_UINT16);
-DALI_REGISTER_TYPE(uint32_t,       DALI_UINT32);
-DALI_REGISTER_TYPE(uint64_t,       DALI_UINT64);
-DALI_REGISTER_TYPE(int8_t,         DALI_INT8);
-DALI_REGISTER_TYPE(int16_t,        DALI_INT16);
-DALI_REGISTER_TYPE(int32_t,        DALI_INT32);
-DALI_REGISTER_TYPE(int64_t,        DALI_INT64);
-DALI_REGISTER_TYPE(float16,        DALI_FLOAT16);
-DALI_REGISTER_TYPE(float,          DALI_FLOAT);
-DALI_REGISTER_TYPE(double,         DALI_FLOAT64);
-DALI_REGISTER_TYPE(bool,           DALI_BOOL);
-DALI_REGISTER_TYPE(string,         DALI_STRING);
-DALI_REGISTER_TYPE(DALIImageType,  DALI_IMAGE_TYPE);
-DALI_REGISTER_TYPE(DALIDataType,   DALI_DATA_TYPE);
-DALI_REGISTER_TYPE(DALIInterpType, DALI_INTERP_TYPE);
-DALI_REGISTER_TYPE(TensorLayout,   DALI_TENSOR_LAYOUT);
+DALI_REGISTER_TYPE(NoType,             DALI_NO_TYPE);
+DALI_REGISTER_TYPE(uint8_t,            DALI_UINT8);
+DALI_REGISTER_TYPE(uint16_t,           DALI_UINT16);
+DALI_REGISTER_TYPE(uint32_t,           DALI_UINT32);
+DALI_REGISTER_TYPE(uint64_t,           DALI_UINT64);
+DALI_REGISTER_TYPE(int8_t,             DALI_INT8);
+DALI_REGISTER_TYPE(int16_t,            DALI_INT16);
+DALI_REGISTER_TYPE(int32_t,            DALI_INT32);
+DALI_REGISTER_TYPE(int64_t,            DALI_INT64);
+DALI_REGISTER_TYPE(float16,            DALI_FLOAT16);
+DALI_REGISTER_TYPE(float,              DALI_FLOAT);
+DALI_REGISTER_TYPE(double,             DALI_FLOAT64);
+DALI_REGISTER_TYPE(bool,               DALI_BOOL);
+DALI_REGISTER_TYPE(string,             DALI_STRING);
+DALI_REGISTER_TYPE(DALIImageType,      DALI_IMAGE_TYPE);
+DALI_REGISTER_TYPE(DALIDataType,       DALI_DATA_TYPE);
+DALI_REGISTER_TYPE(DALIInterpType,     DALI_INTERP_TYPE);
+DALI_REGISTER_TYPE(DALIInterleaveType, DALI_INTERLEAVE_TYPE);
+DALI_REGISTER_TYPE(TensorLayout,       DALI_TENSOR_LAYOUT);
 
 
 #ifdef DALI_BUILD_PROTO3

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1155,6 +1155,7 @@ PYBIND11_MODULE(backend_impl, m) {
     .value("INTERP_TYPE",   DALI_INTERP_TYPE)
     .value("TENSOR_LAYOUT", DALI_TENSOR_LAYOUT)
     .value("PYTHON_OBJECT", DALI_PYTHON_OBJECT)
+    .value("INTERLEAVE_TYPE", DALI_INTERLEAVE_TYPE)
     .value("_TENSOR_LAYOUT_VEC", DALI_TENSOR_LAYOUT_VEC)
     .export_values();
 
@@ -1175,6 +1176,17 @@ PYBIND11_MODULE(backend_impl, m) {
     .value("INTERP_LANCZOS3", DALI_INTERP_LANCZOS3)
     .value("INTERP_TRIANGULAR", DALI_INTERP_TRIANGULAR)
     .value("INTERP_GAUSSIAN", DALI_INTERP_GAUSSIAN)
+    .export_values();
+
+  // DALIInterleaveType
+  py::enum_<DALIInterleaveType>(types_m, "DALIInterleaveType",
+                                "Interleave mode when shuffling\n<SPHINX_IGNORE>")
+    .value("SHORTEN_CONTINUOUS", DALI_SHORTEN_CONTINUOUS)
+    .value("REPEAT_CONTINUOUS", DALI_REPEAT_CONTINUOUS)
+    .value("CLAMP_CONTINUOUS", DALI_CLAMP_CONTINUOUS)
+    .value("SHORTEN", DALI_SHORTEN)
+    .value("REPEAT", DALI_REPEAT)
+    .value("CLAMP", DALI_CLAMP)
     .export_values();
 
   // Operator node

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -55,6 +55,7 @@ _known_types = {
         DALIDataType.INTERP_TYPE : ("nvidia.dali.types.DALIInterpType", lambda x: DALIInterpType(int(x))),
         DALIDataType.TENSOR_LAYOUT : (":ref:`layout str<layout_str_doc>`", lambda x: str(x)),
         DALIDataType.PYTHON_OBJECT : ("object", lambda x: x),
+        DALIDataType.INTERLEAVE_TYPE : ("nvidia.dali.types.DALIInterleaveType", lambda x: DALIInterleaveType(int(x))),
         DALIDataType._TENSOR_LAYOUT_VEC : (":ref:`layout str<layout_str_doc>`", _to_list(lambda x: str(x)))
         }
 
@@ -129,7 +130,8 @@ _float_types = [DALIDataType.FLOAT16, DALIDataType.FLOAT, DALIDataType.FLOAT64]
 _int_like_types = _bool_types + _int_types
 _all_types = _bool_types + _int_types + _float_types
 
-_enum_types = [DALIDataType.IMAGE_TYPE, DALIDataType.DATA_TYPE, DALIDataType.INTERP_TYPE]
+_enum_types = [DALIDataType.IMAGE_TYPE, DALIDataType.DATA_TYPE, DALIDataType.INTERP_TYPE,
+               DALIDataType.INTERLEAVE_TYPE]
 
 
 class ScalarConstant(object):

--- a/include/dali/core/common.h
+++ b/include/dali/core/common.h
@@ -110,6 +110,18 @@ enum DALIImageType {
   DALI_ANY_DATA     = 4
 };
 
+/**
+ * @brief Supported interleaving formats
+ */
+enum DALIInterleaveType {
+  DALI_SHORTEN_CONTINUOUS = 0,
+  DALI_REPEAT_CONTINUOUS  = 1,
+  DALI_CLAMP_CONTINUOUS   = 2,
+  DALI_SHORTEN            = 3,
+  DALI_REPEAT             = 4,
+  DALI_CLAMP              = 5,
+};
+
 
 inline bool IsColor(DALIImageType type) {
   return type == DALI_RGB || type == DALI_BGR || type == DALI_YCbCr;
@@ -171,6 +183,23 @@ inline std::string to_string(const DALIImageType& im_type) {
       return "GRAY";
     case DALI_YCbCr:
       return "YCbCr";
+    default:
+      return "<unknown>";
+  }
+}
+
+inline std::string to_string(const DALIInterleaveType& in_type) {
+  switch (in_type) {
+    case DALI_REPEAT_CONTINUOUS:
+      return "REPEAT_CONTINUOUS";
+    case DALI_CLAMP_CONTINUOUS:
+      return "CLAMP_CONTINUOUS";
+    case DALI_SHORTEN:
+      return "SHORTEN";
+    case DALI_REPEAT:
+      return "REPEAT";
+    case DALI_CLAMP:
+      return "CLAMP";
     default:
       return "<unknown>";
   }


### PR DESCRIPTION
#### Why we need this PR?
- This PR adds the feature mentioned in #2621. It allows to merge multiple videos into one batch by using a specified interleave size and type. To generate the *_CONTINUOUS behavoir of the PR it was previously necessary to construct multiple VideoReaders.
Further, it was previously impossible to rearange video sequences such that they are read simultaneously while still respecting the boundary between different video batches.

#### What happened in this PR?
 - What solution was applied:
    The PR changes the order of the frames by interleaving them. This process is done by picking the videos in a round robin order with a interleave size specified when creating a new VideoReader object. For this change a new type was introduced that is used to specify how samples are selected. The options are:
      -  SHORTEN_CONTINUOUS
           Merges all sequences while disregarding boundary inbetween different videos except for the last ones. In this case the last sequences are all shortened to the same size.

             Example in between videos: see SHORTEN_CONTINUOUS
             
              labels            frames
             [0 1 2 3] [11340 11340 11340  11340]             
             [0 1 6 3] [11370 11370     0  11370]
             [0 1 6 3] [11400 11400    30  11400]
             [0 5 6 3] [11430     0    60  11430]
             [0 5 6 3] [11460    30    90  11460]
             [0 5 6 3] [11490    60    120 11490]
             [0 5 6 7] [11520    90    150     0]
             [4 5 6 7] [    0   120    180    30]

             Example at the end of all videos:

              labels            frames
             [ 8  9 10 11] [10290 10890 10980 10830]
             [ 8  9 10 11] [10320 10920 11010 10860]
             [ 0  1  2  3] [    0     0     0     0]
             [ 0  1  2  3] [   30    30    30    30]
            
             with video 8 (11100 frames); video 9 (11130 frames); video 10 (11010 frames) and video 11 (11310 frames).



      - REPEAT_CONTINUOUS
           Merges all sequences while disregarding boundary inbetween different videos except for the last ones. In this case the last sequences of the last video are repeated until all video sequences have been read.

            Example in between videos: see SHORTEN_CONTINUOUS
            Example at the end of all videos:
             
             labels            frames
            [ 8  9 10 11] [10770   210   420 11310]
            [ 8  9 10 11] [10800   240   450     0]
                            ...
            [ 8  9 10 11] [11100   540   750   300]
            [ 0  1  2  3] [    0     0     0     0]

            with video 8 (11100 frames); video 9 (11130 frames); video 10 (11010 frames) and video 11 (11310 frames).

     - CLAMP_CONTINUOUS
           Merges all sequences while disregarding boundary inbetween different videos except for the last ones. In this case the last sequence of a video is repeated until all sequences have been read.

           Example in between videos: see SHORTEN_CONTINUOUS
           Example at the end of all videos:
             
            labels                frames
           [ 8  9 10 11] [11070 11130 11010 11310]
           [ 8  9 10 11] [11100 11130 11010 11310]
           [ 0  1  2  3] [    0     0     0     0]
           [ 0  1  2  3] [   30    30    30     0]

           with video 8 (11100 frames); video 9 (11130 frames); video 10 (11010 frames) and video 11 (11310 frames).

      -  SHORTEN
           Merges all sequences while keeping the boundary inbetween different videos. In this case all videos are shortened to the shortest video in the current video batch.

           
             Example inbetween videos:
              
             labels                frames
             [0 1 2 3] [11310 11310 11310 11310]
             [0 1 2 3] [11340 11340 11340 11340]
             [4 5 6 7] [    0     0     0     0]
             [4 5 6 7] [   30    30    30    30]

             with video 0 (11520 frames), video 1 (11400 frames), video 2 (11340 frames) and video 3 (11490 frames).

      - REPEAT
         Merges all sequences while keeping the boundary inbetween different videos. In this case videos are repeated until the whole video batch has been read.

           
            Example inbetween videos:
              
             labels                frames
            [0 1 2 3] [11340 11340 11340 11340]
            [0 1 2 3] [11370 11370     0 11370]
                          ...
            [0 1 2 3] [11520    90   150     0]
            [4 5 6 7] [    0     0     0     0]

            with video 0 (11520 frames), video 1 (11400 frames), video 2 (11340 frames) and video 3 (11490 frames).

      - CLAMP
         Merges all sequences while keeping the boundary inbetween different videos. In this case last sequences of the videos are repeated until the whole video batch has been read.


           
            Example inbetween videos:
              
             labels                frames
            [0 1 2 3] [11310 11310 11310 11310]
            [0 1 2 3] [11340 11340 11340 11340]
                        ...
            [0 1 2 3] [11490 11400 11340 11490]
            [0 1 2 3] [11520 11400 11340 11490]
            [4 5 6 7] [    0     0     0     0]
            [4 5 6 7] [   30    30    30    30]

            with video 0 (11520 frames), video 1 (11400 frames), video 2 (11340 frames) and video 3 (11490 frames).

 - Affected modules and functionalities:
     Changes to:
       - dali/operators/reader/loader/loader.h
       - dali/operators/reader/loader/loader.cc
       - dali/operators/reader/loader/video_loader.h
       - dali/pipeline/data/types.h
       - dali/python/backend_impl.cc 
       - dali/python/nvidia/dali/types.py
       - include/dali/core/common.h

 - Key points relevant for the review:
     Implementation.
 - Validation and testing:
     Run tests not sure if more tests are required.
 - Documentation (including examples):
     Added docstrings for the newly introduced parameters.

**JIRA TASK**: NA
