### PR TITLE
Enable named Slice arguments: start/rel_start, end/rel_end, shape/rel_shape

### DIFF
--- a/dali/operators/decoder/host/fused/host_decoder_slice.h
+++ b/dali/operators/decoder/host/fused/host_decoder_slice.h
@@ -30,8 +30,12 @@ class HostDecoderSlice : public HostDecoder {
   DISABLE_COPY_MOVE_ASSIGN(HostDecoderSlice);
 
  protected:
+  inline void RunImpl(HostWorkspace &ws) override {
+    slice_attr_.ProcessArguments<CPUBackend>(ws);
+    Operator<CPUBackend>::RunImpl(ws);
+  }
+
   inline void RunImpl(SampleWorkspace &ws) override {
-    slice_attr_.ProcessArguments(ws);
     HostDecoder::RunImpl(ws);
   }
 

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -222,20 +222,32 @@ Please note that GPU acceleration for JPEG 2000 decoding is only available for C
 
 
 DALI_SCHEMA(ImageDecoderSlice)
-  .DocStr(R"code(Decodes images and extracts regions of interest based on externally provided
-anchors and shapes.
+  .DocStr(R"code(Decodes images and extracts regions of interest.
 
-Inputs must be supplied as tensors in the following order:
+The slice can be specified by proving the start and end coordinates, or start coordinates 
+and shape of the slice. Both coordinates and shapes can be provided in absolute or relative terms.
 
-* ``data`` that contains the input data.
-* ``anchor`` that contains normalized or absolute coordinates, depending on the
-  ``normalized_anchor`` value, for the starting point of the slice (x0, x1, x2, and so on),
-* ``shape`` that contains normalized or absolute coordinates, depending on the
-  ``normalized_shape`` value, for the dimensions of the slice (s0, s1, s2, and so on).
+The slice arguments can be specified by the following named arguments:
 
-The anchor and shape coordinates must be within the interval [0.0, 1.0] for normalized
-coordinates or within the image shape for the absolute coordinates. The ``anchor`` and ``shape``
-inputs will provide as many dimensions as were specified with arguments ``axis_names`` or ``axes``.
+#. ``start``: Slice start coordinates (absolute)
+#. ``rel_start``: Slice start coordinates (relative)
+#. ``end``: Slice end coordinates (absolute)
+#. ``rel_end``: Slice end coordinates (relative)
+#. ``shape``: Slice shape (absolute)
+#. ``rel_shape``: Slice shape (relative)
+
+The slice can be configured by providing start and end coordinates or start and shape.
+Relative and absolute arguments can be used for different arguments (e.g. ``rel_start``
+and ``shape``) but should not be specified for the same argument (e.g. ``start`` and ``rel_start``
+should not be provided together).
+
+Alternatively, two extra positional inputs can be provided, specifying ``anchor`` and ``shape``.
+When using positional inputs, two extra boolean arguments ``normalized_anchor``/``normalized_shape``
+can be used to specify the nature of the arguments provided. Using positional inputs for anchor
+and shape is incompatible with the named arguments specified above.
+
+The slice arguments should provide as many dimensions as specified by the ``axis_names`` or ``axes``
+arguments.
 
 By default, the :meth:`nvidia.dali.ops.ImageDecoderSlice` operator uses normalized coordinates
 and "WH" order for the slice arguments.

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -237,9 +237,8 @@ The slice arguments can be specified by the following named arguments:
 #. ``rel_shape``: Slice shape (relative)
 
 The slice can be configured by providing start and end coordinates or start and shape.
-Relative and absolute arguments can be used for different arguments (e.g. ``rel_start``
-and ``shape``) but should not be specified for the same argument (e.g. ``start`` and ``rel_start``
-should not be provided together).
+Relative and absolute arguments can be mixed (for example, ``rel_start`` can be used with ``shape``)
+as long as start and shape or end are uniquely defined.
 
 Alternatively, two extra positional inputs can be provided, specifying ``anchor`` and ``shape``.
 When using positional inputs, two extra boolean arguments ``normalized_anchor``/``normalized_shape``
@@ -266,7 +265,7 @@ The output of the decoder is in the *HWC* layout.
 
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
 Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.)code")
-  .NumInput(3)
+  .NumInput(1, 3)
   .NumOutput(1)
   .AddParent("ImageDecoderAttr")
   .AddParent("SliceAttr");

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_cpu_slice.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_cpu_slice.cc
@@ -29,7 +29,7 @@ image data, `begin` containing the starting pixel coordinates for the `crop` in 
 format, and `size` containing the pixel dimensions of the `crop` in `(w,h)` format.
 For both `begin` and `size`, coordinates must be in the interval `[0.0, 1.0]`.
 Output of the decoder is in `HWC` ordering.)code")
-    .NumInput(3)
+    .NumInput(1, 3)
     .NumOutput(3)
     .MakeInternal()
     .AddParent("nvJPEGDecoderCPUStage")

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_cpu_slice.h
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_cpu_slice.h
@@ -32,8 +32,13 @@ class nvJPEGDecoderCPUStageSlice : public nvJPEGDecoderCPUStage {
 
  protected:
   using Operator<CPUBackend>::RunImpl;
+
+  void RunImpl(HostWorkspace &ws) override {
+    slice_attr_.ProcessArguments<CPUBackend>(ws);
+    Operator<CPUBackend>::RunImpl(ws);
+  }
+
   void RunImpl(SampleWorkspace &ws) override {
-    slice_attr_.ProcessArguments(ws);
     nvJPEGDecoderCPUStage::RunImpl(ws);
   }
 

--- a/dali/operators/generic/slice/slice.cc
+++ b/dali/operators/generic/slice/slice.cc
@@ -34,9 +34,8 @@ The slice arguments can be specified by the following named arguments:
 #. ``rel_shape``: Slice shape (relative)
 
 The slice can be configured by providing start and end coordinates or start and shape.
-Relative and absolute arguments can be used for different arguments (e.g. ``rel_start``
-and ``shape``) but should not be specified for the same argument (e.g. ``start`` and ``rel_start``
-should not be provided together).
+Relative and absolute arguments can be mixed (for example, ``rel_start`` can be used with ``shape``)
+as long as start and shape or end are uniquely defined.
 
 Alternatively, two extra positional inputs can be provided, specifying ``anchor`` and ``shape``.
 When using positional inputs, two extra boolean arguments ``normalized_anchor``/``normalized_shape``

--- a/dali/operators/generic/slice/slice.cc
+++ b/dali/operators/generic/slice/slice.cc
@@ -19,17 +19,33 @@ namespace dali {
 
 DALI_SCHEMA(Slice)
     .DocStr(
-        R"code(Extracts a subtensor, or slice, with a specified shape and anchor.
+        R"code(Extracts a subtensor, or slice.
 
-Inputs must be supplied as the following separate tensors in the following order:
+The slice can be specified by proving the start and end coordinates, or start coordinates 
+and shape of the slice. Both coordinates and shapes can be provided in absolute or relative terms.
 
-#. ``data``
-#. ``anchor``
-#. ``shape``
+The slice arguments can be specified by the following named arguments:
 
-The ``anchor`` and ``shape`` coordinates must be in the  [0.0, 1.0] interval for normalized
-coordinates, or in the image shape for absolute coordinates. The ``anchor`` and ``shape`` inputs
-must provide as many dimensions as are specified with the ``axis_names`` or ``axes`` arguments.
+#. ``start``: Slice start coordinates (absolute)
+#. ``rel_start``: Slice start coordinates (relative)
+#. ``end``: Slice end coordinates (absolute)
+#. ``rel_end``: Slice end coordinates (relative)
+#. ``shape``: Slice shape (absolute)
+#. ``rel_shape``: Slice shape (relative)
+
+The slice can be configured by providing start and end coordinates or start and shape.
+Relative and absolute arguments can be used for different arguments (e.g. ``rel_start``
+and ``shape``) but should not be specified for the same argument (e.g. ``start`` and ``rel_start``
+should not be provided together).
+
+Alternatively, two extra positional inputs can be provided, specifying ``anchor`` and ``shape``.
+When using positional inputs, two extra boolean arguments ``normalized_anchor``/``normalized_shape``
+can be used to specify the nature of the arguments provided. Using positional inputs for anchor
+and shape is incompatible with the named arguments specified above.
+
+The slice arguments should provide as many dimensions as specified by the ``axis_names`` or ``axes``
+arguments.
+
 By default, the :meth:`nvidia.dali.ops.Slice` operator uses normalized coordinates and ``WH``
 order for the slice arguments.)code")
     .NumInput(1, 3)
@@ -37,14 +53,14 @@ order for the slice arguments.)code")
     .NumOutput(1)
     .InputDox(0, "data", "TensorList", R"code(Batch that contains the input data.)code")
     .InputDox(1, "anchor", "1D TensorList of float or int",
-                 R"code(Input that contains normalized or absolute coordinates for the starting
+                 R"code((Optional) Input that contains normalized or absolute coordinates for the starting
 point of the slice (x0, x1, x2, …).
 
 Integer coordinates are interpreted as absolute coordinates, while float coordinates can be
 interpreted as absolute or relative coordinates, depending on the value of
 ``normalized_anchor``.)code")
     .InputDox(2, "shape", "1D TensorList of float or int",
-                 R"code(Input that contains normalized or absolute coordinates for the dimensions
+                 R"code((Optional) Input that contains normalized or absolute coordinates for the dimensions
 of the slice (s0, s1, s2, …).
 
 Integer coordinates are interpreted as absolute coordinates, while float coordinates can be

--- a/dali/operators/generic/slice/slice.cc
+++ b/dali/operators/generic/slice/slice.cc
@@ -32,7 +32,7 @@ coordinates, or in the image shape for absolute coordinates. The ``anchor`` and 
 must provide as many dimensions as are specified with the ``axis_names`` or ``axes`` arguments.
 By default, the :meth:`nvidia.dali.ops.Slice` operator uses normalized coordinates and ``WH``
 order for the slice arguments.)code")
-    .NumInput(3)
+    .NumInput(1, 3)
     .InputDevice(1, 3, InputDevice::CPU)
     .NumOutput(1)
     .InputDox(0, "data", "TensorList", R"code(Batch that contains the input data.)code")

--- a/dali/operators/generic/slice/slice_attr.cc
+++ b/dali/operators/generic/slice/slice_attr.cc
@@ -55,18 +55,18 @@ is incompatible with providing positional inputs anchor and shape.)code",
 Note: Providing named arguments ``start``, ``end``, ``shape``, ``rel_start``, ``rel_end``, ``rel_shape``
 is incompatible with providing positional inputs anchor and shape.)code",
         nullptr, true)
-    .AddOptionalArg<int>("shape",
+    .AddOptionalArg<std::vector<int>>("shape",
         R"code(Shape of the slice.
 
 Providing named arguments ``start``, ``end``, ``shape``, ``rel_start``, ``rel_end``, ``rel_shape``
 is incompatible with providing positional inputs anchor and shape.)code",
-        true)
-    .AddOptionalArg<int>("rel_shape",
+        nullptr, true)
+    .AddOptionalArg<std::vector<int>>("rel_shape",
         R"code(Relative shape of the slice (range [0.0 - 1.0]).
 
 Providing named arguments ``start``, ``end``, ``shape``, ``rel_start``, ``rel_end``, ``rel_shape``
 is incompatible with providing positional inputs anchor and shape.)code",
-        true)
+        nullptr, true)
     .AddOptionalArg("normalized_anchor",
         R"code(Determines whether the anchor positional input should be interpreted as normalized
 (range [0.0, 1.0]) or as absolute coordinates.

--- a/dali/operators/generic/slice/slice_attr.cc
+++ b/dali/operators/generic/slice/slice_attr.cc
@@ -31,8 +31,44 @@ as described in layout.
 
 If a value is provided, ``axis_names`` will have a higher priority than ``axes``.)code",
         TensorLayout("WH"))
+    .AddOptionalArg<std::vector<int>>("start",
+        R"code(Start coordinates of the slice.
+
+Note: Providing named arguments ``start``/``end`` or ``start``/``shape`` is incompatible with
+providing positional inputs anchor and shape.)code",
+        nullptr, true)
+    .AddOptionalArg<std::vector<float>>("rel_start",
+        R"code(Start relative coordinates of the slice (range [0.0 - 1.0]).
+
+Note: Providing named arguments ``start``, ``end``, ``shape``, ``rel_start``, ``rel_end``, ``rel_shape``
+is incompatible with providing positional inputs anchor and shape.)code",
+        nullptr, true)
+    .AddOptionalArg<std::vector<int>>("end",
+        R"code(End coordinates of the slice.
+
+Note: Providing named arguments ``start``, ``end``, ``shape``, ``rel_start``, ``rel_end``, ``rel_shape``
+is incompatible with providing positional inputs anchor and shape.)code",
+        nullptr, true)
+    .AddOptionalArg<std::vector<float>>("rel_end",
+        R"code(End relative coordinates of the slice (range [0.0 - 1.0].
+
+Note: Providing named arguments ``start``, ``end``, ``shape``, ``rel_start``, ``rel_end``, ``rel_shape``
+is incompatible with providing positional inputs anchor and shape.)code",
+        nullptr, true)
+    .AddOptionalArg<int>("shape",
+        R"code(Shape of the slice.
+
+Providing named arguments ``start``, ``end``, ``shape``, ``rel_start``, ``rel_end``, ``rel_shape``
+is incompatible with providing positional inputs anchor and shape.)code",
+        true)
+    .AddOptionalArg<int>("rel_shape",
+        R"code(Relative shape of the slice (range [0.0 - 1.0]).
+
+Providing named arguments ``start``, ``end``, ``shape``, ``rel_start``, ``rel_end``, ``rel_shape``
+is incompatible with providing positional inputs anchor and shape.)code",
+        true)
     .AddOptionalArg("normalized_anchor",
-        R"code(Determines whether the anchor input should be interpreted as normalized
+        R"code(Determines whether the anchor positional input should be interpreted as normalized
 (range [0.0, 1.0]) or as absolute coordinates.
 
 .. note::
@@ -40,7 +76,7 @@ If a value is provided, ``axis_names`` will have a higher priority than ``axes``
   the coordinates are always absolute.)code",
         true)
     .AddOptionalArg("normalized_shape",
-        R"code(Determines whether the shape input should be interpreted as normalized
+        R"code(Determines whether the shape positional input should be interpreted as normalized
 (range [0.0, 1.0]) or as absolute coordinates.
 
 .. note::

--- a/dali/operators/generic/slice/slice_attr.h
+++ b/dali/operators/generic/slice/slice_attr.h
@@ -144,8 +144,8 @@ class SliceAttr {
           axes = GetDimIndices(shape_layout, axis_names_).to_vector();
         }
 
-        constexpr double i64min = std::numeric_limits<int64_t>::min();
-        constexpr double i64max = std::numeric_limits<int64_t>::max();
+        constexpr double i64min = static_cast<double>(std::numeric_limits<int64_t>::min());
+        constexpr double i64max = static_cast<double>(std::numeric_limits<int64_t>::max());
 
         for (size_t i = 0; i < axes.size(); i++) {
           auto dim = axes[i];
@@ -222,8 +222,8 @@ class SliceAttr {
           axes = GetDimIndices(shape_layout, axis_names_).to_vector();
         }
 
-        constexpr double i64min = std::numeric_limits<int64_t>::min();
-        constexpr double i64max = std::numeric_limits<int64_t>::max();
+        constexpr double i64min = static_cast<double>(std::numeric_limits<int64_t>::min());
+        constexpr double i64max = static_cast<double>(std::numeric_limits<int64_t>::max());
 
         for (size_t i = 0; i < axes.size(); i++) {
           auto dim = axes[i];

--- a/dali/operators/generic/slice/slice_attr.h
+++ b/dali/operators/generic/slice/slice_attr.h
@@ -113,7 +113,6 @@ class SliceAttr {
         auto shape_view = view<const ArgsType>(crop_shape);
         for (int data_idx = 0; data_idx < curr_batch_size; data_idx++) {
           VerifyArgsShape(anchor_view.tensor_shape(data_idx), shape_view.tensor_shape(data_idx));
-          float *slice_end = nullptr;  // not used
           ProcessPositionalInputArgs(data_idx,
                                      anchor_view.tensor_data(data_idx),
                                      shape_view.tensor_data(data_idx));
@@ -200,16 +199,15 @@ class SliceAttr {
       };
   }
 
-  template <typename AnchorT, typename ShapeT, typename EndT>
+  template <typename AnchorT, typename ShapeT>
   void ProcessPositionalInputArgs(int data_idx,
                                   const AnchorT *slice_anchor_data,
                                   const ShapeT *slice_shape_data) {
     bool normalized_anchor = std::is_floating_point<AnchorT>::value && normalized_anchor_;
     bool normalized_shape  = std::is_floating_point<ShapeT>::value && normalized_shape_;
-    bool normalized_end = std::is_floating_point<EndT>::value;
     crop_window_generators_[data_idx] =
       [this, slice_anchor_data, slice_shape_data,
-       normalized_anchor, normalized_shape, normalized_end]
+       normalized_anchor, normalized_shape]
       (const TensorShape<> &shape, const TensorLayout& shape_layout) {
         CropWindow slice;
         slice.anchor = std::vector<int64_t>(shape.size(), 0);

--- a/dali/operators/generic/slice/slice_attr.h
+++ b/dali/operators/generic/slice/slice_attr.h
@@ -116,8 +116,7 @@ class SliceAttr {
           float *slice_end = nullptr;  // not used
           ProcessPositionalInputArgs(data_idx,
                                      anchor_view.tensor_data(data_idx),
-                                     shape_view.tensor_data(data_idx),
-                                     slice_end);
+                                     shape_view.tensor_data(data_idx));
         }
       ), DALI_FAIL(make_string("Unsupported type of anchor and shape arguments: ", args_dtype)));  // NOLINT
     } else {
@@ -204,13 +203,12 @@ class SliceAttr {
   template <typename AnchorT, typename ShapeT, typename EndT>
   void ProcessPositionalInputArgs(int data_idx,
                                   const AnchorT *slice_anchor_data,
-                                  const ShapeT *slice_shape_data,
-                                  const EndT *slice_end_data) {
+                                  const ShapeT *slice_shape_data) {
     bool normalized_anchor = std::is_floating_point<AnchorT>::value && normalized_anchor_;
     bool normalized_shape  = std::is_floating_point<ShapeT>::value && normalized_shape_;
     bool normalized_end = std::is_floating_point<EndT>::value;
     crop_window_generators_[data_idx] =
-      [this, slice_anchor_data, slice_shape_data, slice_end_data,
+      [this, slice_anchor_data, slice_shape_data,
        normalized_anchor, normalized_shape, normalized_end]
       (const TensorShape<> &shape, const TensorLayout& shape_layout) {
         CropWindow slice;

--- a/dali/operators/generic/slice/slice_attr.h
+++ b/dali/operators/generic/slice/slice_attr.h
@@ -90,6 +90,11 @@ class SliceAttr {
       rel_shape_.Acquire(spec_, ws, curr_batch_size, args_shape);
 
     if (has_end_ || has_shape_) {  // ``start`` can be omitted
+      DALI_ENFORCE(!spec_.HasArgument("normalized_anchor")
+                && !spec_.HasArgument("normalized_shape"),
+        "``normalized_anchor``/``normalized_shape`` is only relevant when using positional "
+        "slice arguments");
+
       DALI_ENFORCE(ws.NumInput() == 1,
         "Named arguments start/end/shape are not compatible with positional"
         " anchor and shape inputs");

--- a/dali/operators/generic/slice/slice_attr.h
+++ b/dali/operators/generic/slice/slice_attr.h
@@ -170,7 +170,7 @@ class SliceAttr {
             DALI_ENFORCE(shape_val >= 0 && shape_val <= i64max,
               make_string("shape value out of range [", 0, ", ", i64max, "]. Got: ", shape_val));
 
-            end_val = std::llround(anchor_val + shape_val);
+            end_val = anchor_val + shape_val;
           } else if (rel_start_.IsDefined() && rel_shape_.IsDefined()) {
             // special case - minimize the floating point error by multiplying only once after sum
             double rel_start_val = rel_start_[data_idx].data[i];
@@ -178,13 +178,13 @@ class SliceAttr {
             DALI_ENFORCE(rel_shape_val >= 0,
               make_string("negative shapes are not allowed. Got: ", rel_shape_val));
 
-            end_val = std::llround((rel_start_val + rel_shape_val) * shape[dim]);
+            end_val = (rel_start_val + rel_shape_val) * shape[dim];
           } else if (rel_shape_.IsDefined()) {
             double shape_val = rel_shape_[data_idx].data[i] * shape[dim];
             DALI_ENFORCE(shape_val >= 0 && shape_val <= i64max,
                          make_string("shape value out of range [", 0, ", ", i64max,
                                      "]. Got: ", shape_val));
-            end_val = std::llround(anchor_val + shape_val);
+            end_val = anchor_val + shape_val;
           }
           DALI_ENFORCE(end_val >= i64min && i64max <= i64max,
                        make_string("end coordinates out of range [", i64min, ", ", i64max,
@@ -195,7 +195,7 @@ class SliceAttr {
                                    anchor_val, " end=", end_val));
 
           slice.anchor[dim] = std::llround(anchor_val);
-          slice.shape[dim] = end_val - slice.anchor[dim];
+          slice.shape[dim] = std::llround(end_val) - slice.anchor[dim];
         }
         return slice;
       };
@@ -232,9 +232,8 @@ class SliceAttr {
           double end_val = 0.0;
           // special case - minimize the floating point error by multiplying only once after sum
           if (normalized_anchor && normalized_shape) {
-            end_val = std::llround((anchor_val + shape_val) * shape[dim]);
+            end_val = (anchor_val + shape_val) * shape[dim];
             anchor_val *= shape[dim];
-            shape_val *= shape[dim];
           } else {
             if (normalized_anchor) {
               anchor_val *= shape[dim];
@@ -242,7 +241,7 @@ class SliceAttr {
             if (normalized_shape) {
               shape_val *= shape[dim];
             }
-            end_val = std::llround(anchor_val + shape_val);
+            end_val = anchor_val + shape_val;
           }
 
           DALI_ENFORCE(anchor_val >= i64min && anchor_val <= i64max,
@@ -256,7 +255,7 @@ class SliceAttr {
                                    anchor_val, " end=", end_val));
 
           slice.anchor[dim] = std::llround(anchor_val);
-          slice.shape[dim] = end_val - slice.anchor[dim];
+          slice.shape[dim] = std::llround(end_val) - slice.anchor[dim];
         }
         return slice;
       };

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -427,6 +427,14 @@ class DLL_PUBLIC TensorList : public Buffer<Backend> {
   }
 
   /**
+   * @brief Returns the number of dimensions of the samples.
+   */
+  DLL_PUBLIC inline int sample_dim() const {
+    return shape_.sample_dim();
+  }
+
+
+  /**
    * @brief Returns the offset of the tensor with the given index.
    */
   DLL_PUBLIC inline Index tensor_offset(int idx) const {

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -99,6 +99,10 @@ class DLL_PUBLIC TensorVector {
     return curr_tensors_size_;
   }
 
+  int sample_dim() const {
+    return IsContiguous() ? tl_->sample_dim() : ntensor() ? tensors_[0]->shape().size() : 0;
+  }
+
   size_t nbytes() const noexcept;
 
   size_t capacity() const noexcept;

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -181,11 +181,9 @@ class WorkspaceBase : public ArgumentWorkspace {
    */
   auto GetInputShape(int input_idx) const {
     if (InputIsType<GPUBackend>(input_idx)) {
-      const auto& input = *InputHandle(input_idx, GPUBackend{});
-      return input.shape();
+      return InputRef<GPUBackend>(input_idx).shape();
     } else {
-      const auto& input = *InputHandle(input_idx, CPUBackend{});
-      return input.shape();
+      return InputRef<CPUBackend>(input_idx).shape();
     }
   }
 
@@ -196,7 +194,11 @@ class WorkspaceBase : public ArgumentWorkspace {
     DALI_ENFORCE(NumInput() > 0, "No inputs found");
     DALI_ENFORCE(input_idx >= 0 && input_idx < NumInput(),
                  make_string("Invalid input index: ", input_idx, "; while NumInput: ", NumInput()));
-    return GetInputShape(input_idx).num_samples();
+    if (InputIsType<GPUBackend>(input_idx)) {
+      return InputRef<GPUBackend>(input_idx).ntensor();
+    } else {
+      return InputRef<CPUBackend>(input_idx).ntensor();
+    }
   }
 
   /**
@@ -206,7 +208,11 @@ class WorkspaceBase : public ArgumentWorkspace {
     DALI_ENFORCE(NumInput() > 0, "No inputs found");
     DALI_ENFORCE(input_idx >= 0 && input_idx < NumInput(),
                  make_string("Invalid input index: ", input_idx, "; while NumInput: ", NumInput()));
-    return GetInputShape(input_idx).sample_dim();
+    if (InputIsType<GPUBackend>(input_idx)) {
+      return InputRef<GPUBackend>(input_idx).sample_dim();
+    } else {
+      return InputRef<CPUBackend>(input_idx).sample_dim();
+    }
   }
 
   /**

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -179,23 +179,34 @@ class WorkspaceBase : public ArgumentWorkspace {
    * Returns shape of input at given index
    * @return TensorShape<> for SampleWorkspace, TensorListShape<> for other Workspaces
    */
-  template <typename Backend>
   auto GetInputShape(int input_idx) const {
-    const auto& input = *InputHandle(input_idx, Backend{});
-    return input.shape();
+    if (InputIsType<GPUBackend>(input_idx)) {
+      const auto& input = *InputHandle(input_idx, GPUBackend{});
+      return input.shape();
+    } else {
+      const auto& input = *InputHandle(input_idx, CPUBackend{});
+      return input.shape();
+    }
   }
 
   /**
-   * Returns batch size for given input
+   * Returns batch size for a given input
    */
   int GetInputBatchSize(int input_idx) const {
     DALI_ENFORCE(NumInput() > 0, "No inputs found");
     DALI_ENFORCE(input_idx >= 0 && input_idx < NumInput(),
                  make_string("Invalid input index: ", input_idx, "; while NumInput: ", NumInput()));
-    if (InputIsType<GPUBackend>(input_idx)) {
-      return GetInputShape<GPUBackend>(input_idx).num_samples();
-    }
-    return GetInputShape<CPUBackend>(input_idx).num_samples();
+    return GetInputShape(input_idx).num_samples();
+  }
+
+  /**
+   * Returns number of dimensions for a given input
+   */
+  int GetInputDim(int input_idx) const {
+    DALI_ENFORCE(NumInput() > 0, "No inputs found");
+    DALI_ENFORCE(input_idx >= 0 && input_idx < NumInput(),
+                 make_string("Invalid input index: ", input_idx, "; while NumInput: ", NumInput()));
+    return GetInputShape(input_idx).sample_dim();
   }
 
   /**

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -596,15 +596,48 @@ def check_slice_named_args(device, batch_size):
         ]
         pipe.set_outputs(*outs)
     pipe.build()
-    for _ in range(1):
+    for _ in range(3):
         outs = pipe.run()
         for out_idx in range(1, len(outs)):
             for sample in range(batch_size):
-                np.testing.assert_equal(outs[0].at(sample), outs[out_idx].at(sample))
+                np.testing.assert_equal(np.array(outs[0][sample]), np.array(outs[out_idx][sample]))
 
 def test_slice_named_args():
-    yield check_slice_named_args, 'cpu', 1 
-    yield check_slice_named_args, 'gpu', 1 
+    yield check_slice_named_args, 'cpu', 3
+    yield check_slice_named_args, 'gpu', 3
+
+def check_slice_named_args_default_start_or_end(device, batch_size):
+    test_data_shape = [5, 4, 3]
+    def get_data():
+        out = [np.random.randint(0, 255, size = test_data_shape, dtype = np.uint8) for _ in range(batch_size)]
+        return out
+    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+    with pipe:
+        data = fn.external_source(source = get_data, layout = "HWC")
+        in_shape = np.array([5, 4])
+        start = np.array([1, 2])
+        shape = np.array([3, 1])
+        end = start + shape
+        rel_start = start / in_shape
+        rel_shape = shape / in_shape
+        rel_end = end / in_shape
+        outs = [
+            fn.slice(data, start=start, end=in_shape, axes = (0, 1)),
+            fn.slice(data, start=[0, 0], end=end, axes = (0, 1)),
+            fn.slice(data, start=start, axes = (0, 1)),
+            fn.slice(data, end=end, axes = (0, 1)),
+        ]
+        pipe.set_outputs(*outs)
+    pipe.build()
+    for _ in range(3):
+        outs = pipe.run()
+        for sample in range(batch_size):
+            np.testing.assert_equal(np.array(outs[0][sample]), np.array(outs[2][sample]))
+            np.testing.assert_equal(np.array(outs[1][sample]), np.array(outs[3][sample]))
+
+def test_slice_named_default_start_or_end_args():
+    yield check_slice_named_args_default_start_or_end, 'cpu', 3
+    yield check_slice_named_args_default_start_or_end, 'gpu', 3
 
 def check_slice_named_args_errors(device, batch_size):
     test_data_shape = [5, 4, 3]
@@ -618,12 +651,12 @@ def check_slice_named_args_errors(device, batch_size):
         start = np.array([1, 2])
         shape = np.array([3, 1])
         outs = [
-            fn.slice(data, start, shape, start=start, shape=shape, axes = (0, 1)),
+            fn.slice(data, start, shape, start=start, end=start+shape, shape=shape, axes = (0, 1)),
         ]
         pipe.set_outputs(*outs)
-    pipe.build()
-    for _ in range(1):
-        with assert_raises(RuntimeError):
+    with assert_raises(RuntimeError):
+        pipe.build()
+        for _ in range(1):
             outs = pipe.run()
 
 def test_slice_named_args_errors():

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -14,6 +14,7 @@
 
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
+import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 import nvidia.dali as dali
 from nvidia.dali.backend_impl import TensorListGPU
@@ -375,11 +376,11 @@ def test_slice_synth_data_vs_numpy():
                 ((80, 30, 20, 3), "DHWC", None, "DHW", types.FLOAT, None),
                 ((80, 30, 20, 3), "DHWC", None, "WH", types.FLOAT, None),
                 ((80, 30, 20, 3), "DHWC", None, "C", types.FLOAT, None)]:
-                for normalized_anchor in [True, False]:
-                    for normalized_shape in [True, False]:
-                        yield check_slice_synth_data_vs_numpy, device, batch_size, \
-                            input_shape, layout, axes, axis_names, normalized_anchor, normalized_shape, \
-                            input_type, output_type
+                    normalized_anchor = np.random.choice([True, False])
+                    normalized_shape = np.random.choice([True, False])
+                    yield check_slice_synth_data_vs_numpy, device, batch_size, \
+                        input_shape, layout, axes, axis_names, normalized_anchor, normalized_shape, \
+                        input_type, output_type
 
 def check_slice_vs_fused_decoder(device, batch_size, axes, axis_names):
     eii_args = [SliceArgsIterator(batch_size, image_layout="HWC", axes=axes, axis_names=axis_names)
@@ -567,3 +568,64 @@ def test_slice_with_out_of_bounds_error():
             for normalized_anchor, normalized_shape in [(False, False), (True, True)]:
                 yield check_slice_with_out_of_bounds_error, \
                     device, batch_size, in_shape, normalized_anchor, normalized_shape
+
+
+def check_slice_named_args(device, batch_size):
+    test_data_shape = [5, 4, 3]
+    def get_data():
+        out = [np.random.randint(0, 255, size = test_data_shape, dtype = np.uint8) for _ in range(batch_size)]
+        return out
+    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+    with pipe:
+        data = fn.external_source(source = get_data, layout = "HWC")
+        in_shape = np.array([5, 4])
+        start = np.array([1, 2])
+        shape = np.array([3, 1])
+        end = start + shape
+        rel_start = start / in_shape
+        rel_shape = shape / in_shape
+        rel_end = end / in_shape 
+        outs = [
+            fn.slice(data, start, shape, axes = (0, 1)),
+            fn.slice(data, rel_start, rel_shape, axes = (0, 1)),
+            fn.slice(data, start=start, shape=shape, axes = (0, 1)),
+            fn.slice(data, start=start, end=end, axes = (0, 1)),
+            fn.slice(data, rel_start=rel_start, rel_shape=rel_shape, axes = (0, 1)),
+            fn.slice(data, rel_start=rel_start, rel_end=rel_end, axes = (0, 1)),
+            fn.slice(data, rel_start=rel_start, shape=shape, axes = (0, 1)),
+        ]
+        pipe.set_outputs(*outs)
+    pipe.build()
+    for _ in range(1):
+        outs = pipe.run()
+        for out_idx in range(1, len(outs)):
+            for sample in range(batch_size):
+                np.testing.assert_equal(outs[0].at(sample), outs[out_idx].at(sample))
+
+def test_slice_named_args():
+    yield check_slice_named_args, 'cpu', 1 
+    yield check_slice_named_args, 'gpu', 1 
+
+def check_slice_named_args_errors(device, batch_size):
+    test_data_shape = [5, 4, 3]
+    def get_data():
+        out = [np.random.randint(0, 255, size = test_data_shape, dtype = np.uint8) for _ in range(batch_size)]
+        return out
+    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+    with pipe:
+        data = fn.external_source(source = get_data, layout = "HWC")
+        in_shape = np.array([5, 4])
+        start = np.array([1, 2])
+        shape = np.array([3, 1])
+        outs = [
+            fn.slice(data, start, shape, start=start, shape=shape, axes = (0, 1)),
+        ]
+        pipe.set_outputs(*outs)
+    pipe.build()
+    for _ in range(1):
+        with assert_raises(RuntimeError):
+            outs = pipe.run()
+
+def test_slice_named_args_errors():
+    yield check_slice_named_args_errors, 'cpu', 1
+    yield check_slice_named_args_errors, 'gpu', 1


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- Refactoring to improve usability of Slice operator

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Introduced named arguments `start`, `rel_start`, `end`, `rel_end`, `shape`, `rel_shape` to define the slice parameters instead of the regular (positional) inputs anchor and shape*
 - Affected modules and functionalities:
     *Slice, ImageDecoderSlice*
 - Key points relevant for the review:
     *SliceAttr implementation, error checking*
 - Validation and testing:
     *Tests added*
 - Documentation (including examples):
     *Operator doc updated*


**JIRA TASK**: *[DALI-1544]*
