### PR TITLE
Refactor functions that extract a range of samples from TLS and TLV.

### DIFF
--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -269,9 +269,9 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocVariableBatchSizePipe) {
                                              {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
   int max_batch_size = reference_input_shape.num_samples();
   std::vector<TensorListShape<>> trimmed_input_shapes = {
-      subshape(reference_input_shape, 0, max_batch_size / 2),
-      subshape(reference_input_shape, 0, max_batch_size / 4),
-      subshape(reference_input_shape, 0, max_batch_size),
+      sample_range(reference_input_shape, 0, max_batch_size / 2),
+      sample_range(reference_input_shape, 0, max_batch_size / 4),
+      sample_range(reference_input_shape, 0, max_batch_size),
   };
 
   auto pipe_ptr = GetTestPipeline<TypeParam>(false, this->output_device_);

--- a/dali/core/tensor_shape_test.cc
+++ b/dali/core/tensor_shape_test.cc
@@ -1303,6 +1303,7 @@ TEST(TensorListShapeTest, SampleRangeTest) {
   TensorListShape<> ref183 = {{1, 2}, {4, 5}, {7, 8}};
   TensorListShape<> ref092 = {{0, 1}, {2, 3}, {4, 5}, {6, 7}, {8, 9}};
   TensorListShape<> ref192 = {{1, 2}, {3, 4}, {5, 6}, {7, 8}};
+  TensorListShape<> ref1917 = {{1, 2}};
 
   EXPECT_EQ(sample_range(tls, 0, 9, 1), ref091);
   EXPECT_EQ(sample_range(tls, 0, 8, 1), ref081);
@@ -1310,6 +1311,9 @@ TEST(TensorListShapeTest, SampleRangeTest) {
   EXPECT_EQ(sample_range(tls, 1, 8, 3), ref183);
   EXPECT_EQ(sample_range(tls, 0, 9, 2), ref092);
   EXPECT_EQ(sample_range(tls, 1, 9, 2), ref192);
+  EXPECT_EQ(sample_range(tls, 1, 9, 17), ref1917);
+  EXPECT_EQ(sample_range(tls, 9, 9, 17), TensorListShape<>(0, 2));
+  EXPECT_EQ(sample_range(TensorListShape<>(), 0, 0), TensorListShape<>());
 }
 
 }  // namespace kernels

--- a/dali/core/tensor_shape_test.cc
+++ b/dali/core/tensor_shape_test.cc
@@ -1294,7 +1294,7 @@ TEST(AppendTest, AppendSingleTLS) {
 }
 
 
-TEST(TensorListShapeTest, SubshapeTest) {
+TEST(TensorListShapeTest, SampleRangeTest) {
   TensorListShape<> tls = {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 6}, {6, 7}, {7, 8}, {8, 9}};
   TensorListShape<> ref091 = {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5},
                               {5, 6}, {6, 7}, {7, 8}, {8, 9}};
@@ -1304,12 +1304,12 @@ TEST(TensorListShapeTest, SubshapeTest) {
   TensorListShape<> ref092 = {{0, 1}, {2, 3}, {4, 5}, {6, 7}, {8, 9}};
   TensorListShape<> ref192 = {{1, 2}, {3, 4}, {5, 6}, {7, 8}};
 
-  EXPECT_EQ(subshape(tls, 0, 9, 1), ref091);
-  EXPECT_EQ(subshape(tls, 0, 8, 1), ref081);
-  EXPECT_EQ(subshape(tls, 0, 5, 2), ref052);
-  EXPECT_EQ(subshape(tls, 1, 8, 3), ref183);
-  EXPECT_EQ(subshape(tls, 0, 9, 2), ref092);
-  EXPECT_EQ(subshape(tls, 1, 9, 2), ref192);
+  EXPECT_EQ(sample_range(tls, 0, 9, 1), ref091);
+  EXPECT_EQ(sample_range(tls, 0, 8, 1), ref081);
+  EXPECT_EQ(sample_range(tls, 0, 5, 2), ref052);
+  EXPECT_EQ(sample_range(tls, 1, 8, 3), ref183);
+  EXPECT_EQ(sample_range(tls, 0, 9, 2), ref092);
+  EXPECT_EQ(sample_range(tls, 1, 9, 2), ref192);
 }
 
 }  // namespace kernels

--- a/dali/core/tensor_view_test.cc
+++ b/dali/core/tensor_view_test.cc
@@ -362,6 +362,15 @@ TEST(TensorListViewTest, SampleRange) {
     EXPECT_EQ(slice.tensor_data(j), whole.tensor_data(start + j));
     EXPECT_EQ(slice.tensor_shape(j), whole.tensor_shape(start + j));
   }
+
+  int stride = 2;
+  auto strided_slice = sample_range(whole, start, start + length, stride);
+  int out_length = 8;  // 15 samples, stride 2
+  ASSERT_EQ(strided_slice.num_samples(), out_length);
+  for (int j = 0; j < out_length; j++) {
+    EXPECT_EQ(strided_slice.tensor_data(j), whole.tensor_data(start + j * stride));
+    EXPECT_EQ(strided_slice.tensor_shape(j), whole.tensor_shape(start + j * stride));
+  }
 }
 
 TEST(TensorListViewTest, IsContiguous) {

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -1445,7 +1445,7 @@ template <int out_ndim, int ndim>
 void sample_range(TensorListShape<out_ndim> &out, const TensorListShape<ndim> &in,
                   int begin, int end, int step = 1) {
   detail::check_compatible_ndim<out_ndim, ndim>();
-  assert(begin >=0 && begin <= in.num_samples());
+  assert(begin >= 0 && begin <= in.num_samples());
   assert(end >= begin && end <= in.num_samples());
 
   int nsamples = div_ceil(end - begin, step);

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -1435,23 +1435,40 @@ auto permute_dims(const TensorListShape<in_ndim> &in, const Permutation &axis_or
 }
 
 /**
- * Returns new shape, where samples are subset of samples in given TensorListShape.
+ * Stores a (strided) range of sample shapes in the output list shape.
  *
- * @param begin Start index, included in the output
- * @param end End index, excluded from the output
+ * @param begin      index of the first sample to include in the subrange
+ * @param end        index one past the last sample to include in the subrange
+ * @param step       stride between consecutive source samples
  */
-template <int ndims>
-TensorListShape<ndims> subshape(const TensorListShape<ndims> &in, int begin, int end,
-                                int step = 1) {
-  assert(step >= 1);
-  assert(end > begin);
-  assert(begin >= 0);
-  auto div_ceil = [](int x, int y) { return 1 + ((x - 1) / y); };
+template <int out_ndim, int ndim>
+void sample_range(TensorListShape<out_ndim> &out, const TensorListShape<ndim> &in,
+                  int begin, int end, int step = 1) {
+  detail::check_compatible_ndim<out_ndim, ndim>();
+  assert(begin >=0 && begin <= in.num_samples());
+  assert(end >= begin && end <= in.num_samples());
+
   int nsamples = div_ceil(end - begin, step);
-  TensorListShape<ndims> ret(nsamples, in.sample_dim());
+  out.resize(nsamples, in.sample_dim());
+
   for (int i = begin, j = 0; j < nsamples; i += step, j++) {
-    ret.set_tensor_shape(j, in.tensor_shape(i));
+    out.set_tensor_shape(j, in.tensor_shape_span(i));
   }
+}
+
+/**
+ * Returns a (strided) range of sample shapes as a new TensorListShape.
+ *
+ * @param begin      index of the first sample to include in the subrange
+ * @param end        index one past the last sample to include in the subrange
+ * @param step       stride between consecutive source samples
+ */
+template <int out_ndim = InferDimensions, int ndim,
+          int output_ndim = (out_ndim == InferDimensions ? ndim : out_ndim)>
+TensorListShape<output_ndim> sample_range(const TensorListShape<ndim> &in,
+                                          int begin, int end, int step = 1) {
+  TensorListShape<output_ndim> ret;
+  sample_range(ret, in, begin, end, step);
   return ret;
 }
 

--- a/include/dali/core/tensor_view.h
+++ b/include/dali/core/tensor_view.h
@@ -766,7 +766,7 @@ template <typename StorageBackend, typename DataType, int out_ndim, int ndim>
 void sample_range(TensorListView<StorageBackend, DataType, out_ndim> &out_slice,
     const TensorListView<StorageBackend, DataType, ndim> &input, int begin, int end, int step = 1) {
   detail::check_compatible_ndim<out_ndim, ndim>();
-  assert(begin >=0 && begin <= input.num_samples());
+  assert(begin >= 0 && begin <= input.num_samples());
   assert(end >= begin && end <= input.num_samples());
   sample_range(out_slice.shape, input.shape, begin, end, step);
   out_slice.data.resize(out_slice.shape.num_samples());


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to improve consistency
- Fix bug in assert condition that disallowed empty results

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
      * Rename subshape to `sample_range`.
      * Reimplement `sample_range` for TensorListView with one for TensorListShape.
      * Add step to `sample_range` for TensorListView.
      * Fix boundary condition assertions
      * Add extended `ndim` handling (already present in TLV variant)
 - Affected modules and functionalities:
     * `sample_range`; renamed `subshape` to `sample_range` when necessary
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Unit tests
 - Documentation (including examples):
     * Doxygen

**JIRA TASK**: N/A
