### PR TITLE
Fix a double set of `preserve` schema arg and uninitialized var

### DIFF
--- a/dali/operators/reader/loader/indexed_file_loader.h
+++ b/dali/operators/reader/loader/indexed_file_loader.h
@@ -161,7 +161,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
   FileStream::MappingReserver mmap_reserver_;
   static constexpr int INVALID_INDEX = -1;
   bool should_seek_ = false;
-  int64 next_seek_pos_;
+  int64 next_seek_pos_ = 0;
 };
 
 }  // namespace dali

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -448,6 +448,8 @@ def python_op_factory(name, schema_name = None, op_device = "cpu"):
 
             if "preserve" in kwargs.keys():
                 self._preserve = kwargs["preserve"]
+                # we don't want to set "preserve" arg twice
+                del kwargs["preserve"]
             else:
                 self._preserve = False
             self._spec.AddArg("preserve", self._preserve)

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1719,7 +1719,7 @@ def test_return_constants():
         assert o.at(0) == types[i](42)
         assert o.at(0).dtype == types[i]
 
-def test_preserver():
+def test_preserve_arg():
     pipe = dali.pipeline.Pipeline(1, 1, 0)
     with pipe:
         out = dali.fn.external_source(source=[[np.array([-0.5, 1.25])]], preserve = True)

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1718,3 +1718,11 @@ def test_return_constants():
     for i, o in enumerate(other):
         assert o.at(0) == types[i](42)
         assert o.at(0).dtype == types[i]
+
+def test_preserver():
+    pipe = dali.pipeline.Pipeline(1, 1, 0)
+    with pipe:
+        out = dali.fn.external_source(source=[[np.array([-0.5, 1.25])]], preserve = True)
+        res = dali.fn.resize(out, preserve = True)
+        pipe.set_outputs(out)
+    pipe.build()


### PR DESCRIPTION
- when the user specifies the `preserve` operator argument it is set twice due to logic in ops.py. This PR makes sure it is set only once
- 0 initializes next_seek_pos_ variable in the index_file_loader

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug with double set of `preserve` schema arg and uninitialized var

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     makes sure `preserve` schema arg  is set only once
     0 initializes next_seek_pos_ variable in the index_file_loader
 - Affected modules and functionalities:
     ops.py
     index_file_loader
 - Key points relevant for the review:
     NA
 - Validation and testing:
     test added
     valgrind run
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
