### PR TITLE
Add handling of empty inputs and tiny outputs in Resize op and Resampling kernels.

### DIFF
--- a/dali/kernels/imgproc/resample/resampling_setup.cc
+++ b/dali/kernels/imgproc/resample/resampling_setup.cc
@@ -22,6 +22,8 @@ namespace dali {
 namespace kernels {
 namespace resampling {
 
+constexpr int kMaxGPUFilterSupport = 8192;
+
 ResamplingFilter GetResamplingFilter(const ResamplingFilters *filters, const FilterDesc &params) {
   switch (params.type) {
     case ResamplingFilterType::Linear:
@@ -90,6 +92,8 @@ SeparableResamplingSetup<spatial_ndim>::ComputeScaleAndROI(
     auto &filter = desc.filter[axis];
 
     int support = filter.num_coeffs ? filter.support() : 1;
+    if (support > kMaxGPUFilterSupport)
+      filter.rescale(kMaxGPUFilterSupport);
 
     float lo, hi;
     if (roi_start <= roi_end) {

--- a/dali/kernels/imgproc/resample/separable_cpu.h
+++ b/dali/kernels/imgproc/resample/separable_cpu.h
@@ -143,9 +143,11 @@ struct SeparableResampleCPU  {
       shape_cat(vec2shape(setup.desc.out_shape()), setup.desc.channels);
 
     ScratchpadEstimator se;
-    se.add<float>(AllocType::Host, setup.memory.tmp_size);
-    se.add<float>(AllocType::Host, setup.memory.coeffs_size);
-    se.add<int32_t>(AllocType::Host, setup.memory.indices_size);
+    if (out_shape.num_elements() > 0) {
+      se.add<float>(AllocType::Host, setup.memory.tmp_size);
+      se.add<float>(AllocType::Host, setup.memory.coeffs_size);
+      se.add<int32_t>(AllocType::Host, setup.memory.indices_size);
+    }
 
     TensorListShape<> out_tls({ out_shape });
 
@@ -160,6 +162,9 @@ struct SeparableResampleCPU  {
            const Output &output,
            const Input &input,
            const ResamplingParamsND<spatial_ndim> &params) {
+    if (output.shape.num_elements() == 0)
+      return;
+
     auto &desc = setup.desc;
 
     desc.set_base_pointers(input.data, nullptr, output.data);

--- a/dali/operators/image/resize/resize_attr.cc
+++ b/dali/operators/image/resize/resize_attr.cc
@@ -449,10 +449,17 @@ void ResizeAttr::CalculateSampleParams(ResizeParams &params,
       double real_size = params.dst_size[d];
       double adjustment = real_size / std::fabs(out_sz);
 
+      // This means that our output is 0.1 pixels - we might get inaccurate results
+      // with 1x1 real output and small ROI, but it means that the user should use a proper ROI
+      // and real output size instead.
+      adjustment = clamp(adjustment, -10.0, 10.0);
+
       // keep center of the ROI - adjust the edges
       double center = (params.src_lo[d] + params.src_hi[d]) * 0.5;
-      params.src_lo[d] = center + (params.src_lo[d] - center) * adjustment;
-      params.src_hi[d] = center + (params.src_hi[d] - center) * adjustment;
+
+      // clamp to more-or-less sane interval to avoid arithmetic problems downstream
+      params.src_lo[d] = clamp(center + (params.src_lo[d] - center) * adjustment, -1e+9, 1e+9);
+      params.src_hi[d] = clamp(center + (params.src_hi[d] - center) * adjustment, -1e+9, 1e+9);
     }
   }
 }

--- a/dali/operators/image/resize/resize_attr.cc
+++ b/dali/operators/image/resize/resize_attr.cc
@@ -265,8 +265,9 @@ void ResizeAttr::PrepareResizeParams(const OpSpec &spec, const ArgumentWorkspace
         requested_size[d] = size_vecs[d][i];
       }
 
+      bool empty_input = volume(input_shape.tensor_shape_span(i)) == 0;
       CalculateInputRoI(in_lo, in_hi, input_shape, i);
-      CalculateSampleParams(params_[i], requested_size, in_lo, in_hi, subpixel_scale_);
+      CalculateSampleParams(params_[i], requested_size, in_lo, in_hi, subpixel_scale_, empty_input);
     }
   } else if (has_resize_shorter_ || has_resize_longer_) {
     const char *arg_name = has_resize_shorter_ ? "resize_shorter" : "resize_longer";
@@ -277,8 +278,9 @@ void ResizeAttr::PrepareResizeParams(const OpSpec &spec, const ArgumentWorkspace
         requested_size[d] = res_x_[i];
       }
 
+      bool empty_input = volume(input_shape.tensor_shape_span(i)) == 0;
       CalculateInputRoI(in_lo, in_hi, input_shape, i);
-      CalculateSampleParams(params_[i], requested_size, in_lo, in_hi, subpixel_scale_);
+      CalculateSampleParams(params_[i], requested_size, in_lo, in_hi, subpixel_scale_, empty_input);
     }
   } else if (has_size_) {
     for (int i = 0; i < N; i++) {
@@ -287,8 +289,9 @@ void ResizeAttr::PrepareResizeParams(const OpSpec &spec, const ArgumentWorkspace
         requested_size[d] = size_arg_[i * spatial_ndim_ + d];
       }
 
+      bool empty_input = volume(input_shape.tensor_shape_span(i)) == 0;
       CalculateInputRoI(in_lo, in_hi, input_shape, i);
-      CalculateSampleParams(params_[i], requested_size, in_lo, in_hi, subpixel_scale_);
+      CalculateSampleParams(params_[i], requested_size, in_lo, in_hi, subpixel_scale_, empty_input);
     }
   }
 }
@@ -301,7 +304,7 @@ void ResizeAttr::AdjustOutputSize(float *out_size, const float *in_size) {
 
   int sizes_provided = 0;
   for (int d = 0; d < spatial_ndim_; d++) {
-    mask[d] = (out_size[d] != 0);
+    mask[d] = (out_size[d] != 0 && in_size[d] != 0);
     scale[d] = in_size[d] ? out_size[d] / in_size[d] : 1;
     sizes_provided += mask[d];
   }
@@ -316,7 +319,6 @@ void ResizeAttr::AdjustOutputSize(float *out_size, const float *in_size) {
         // and use it for the missing dimensions;
         double avg_scale = 1;
         for (int d = 0; d < spatial_ndim_; d++) {
-          scale[d] = out_size[d] / in_size[d];
           if (mask[d])
             avg_scale *= std::abs(scale[d]);  // abs because of possible flipping
         }
@@ -400,15 +402,11 @@ void ResizeAttr::CalculateSampleParams(ResizeParams &params,
                                        SmallVector<float, 3> requested_size,
                                        SmallVector<float, 3> in_lo,
                                        SmallVector<float, 3> in_hi,
-                                       bool adjust_roi) {
+                                       bool adjust_roi,
+                                       bool empty_input) {
   assert(static_cast<int>(requested_size.size()) == spatial_ndim_);
   assert(static_cast<int>(in_lo.size()) == spatial_ndim_);
   assert(static_cast<int>(in_hi.size()) == spatial_ndim_);
-
-  for (int d = 0; d < spatial_ndim_; d++) {
-    DALI_ENFORCE(in_lo[d] != in_hi[d] || requested_size[d] == 0,
-                "Cannot produce non-empty output from empty input");
-  }
 
   SmallVector<float, 3> in_size;
   in_size.resize(spatial_ndim_);
@@ -424,14 +422,25 @@ void ResizeAttr::CalculateSampleParams(ResizeParams &params,
 
   AdjustOutputSize(requested_size.data(), in_size.data());
 
+  for (int d = 0; d < spatial_ndim_; d++) {
+    DALI_ENFORCE(in_lo[d] != in_hi[d] || requested_size[d] == 0,
+                "Cannot produce non-empty output from empty input");
+  }
+
   params.resize(spatial_ndim_);
   params.src_lo = in_lo;
   params.src_hi = in_hi;
 
+  // If the input sample is empty, we simply can't produce _any_ non-empty output.
+  // If ROI is degenerate but there's some input, we can sample it at the degenerate location.
+  // To prevent empty outputs when we have some means of producing non-empty output, we bump
+  // up the size of the output to at least 1 in each axis.
+  int min_size = empty_input ? 0 : 1;
+
   for (int d = 0; d < spatial_ndim_; d++) {
     float out_sz = requested_size[d];
     bool flip = out_sz < 0;
-    params.dst_size[d] = std::max(1, round_int(std::fabs(out_sz)));
+    params.dst_size[d] = std::max(min_size, round_int(std::fabs(out_sz)));
     if (flip)
       std::swap(params.src_lo[d], params.src_hi[d]);
 

--- a/dali/operators/image/resize/resize_attr.h
+++ b/dali/operators/image/resize/resize_attr.h
@@ -118,7 +118,8 @@ class DLL_PUBLIC ResizeAttr {
                              SmallVector<float, 3> requested_size,
                              SmallVector<float, 3> in_lo,
                              SmallVector<float, 3> in_hi,
-                             bool adjust_roi);
+                             bool adjust_roi,
+                             bool empty_input);
 };
 
 }  // namespace dali

--- a/dali/test/python/test_operator_resize.py
+++ b/dali/test/python/test_operator_resize.py
@@ -527,3 +527,45 @@ def test_stitching():
                 for channel_first in [False, True]:
                     for interp in [types.INTERP_LINEAR, types.INTERP_CUBIC, types.INTERP_TRIANGULAR, types.INTERP_LANCZOS3]:
                         yield _test_stitching, device, dim, channel_first, dtype, interp
+
+def _test_empty_input(dim, device):
+    batch_size = 8
+    pipe = Pipeline(batch_size=batch_size, num_threads=8, device_id=0, seed=1234)
+    if dim == 2:
+        files, labels = dali.fn.caffe_reader(path = db_2d_folder, random_shuffle = True)
+        images_cpu = dali.fn.image_decoder(files, device="cpu")
+    else:
+        images_cpu = dali.fn.external_source(source=random_3d_loader(batch_size), layout="DHWC")
+
+    images = images_cpu if device == "cpu" else images_cpu.gpu()
+
+    in_rel_shapes = np.ones([batch_size, dim], dtype=np.float32)
+
+    in_rel_shapes[::2,:] *= 0 # all zeros in every second sample
+
+    degenerate_images = fn.slice(images, np.zeros([dim]), fn.external_source(lambda: in_rel_shapes), axes=list(range(dim)))
+
+    sizes = np.random.randint(20, 50, [batch_size, dim], dtype=np.int32)
+    size_inp = fn.external_source(lambda: [x.astype(np.float32) for x in sizes])
+
+    resize_no_empty = fn.resize(images, size = size_inp, mode="not_larger")
+    resize_with_empty = fn.resize(degenerate_images, size = size_inp, mode="not_larger")
+
+    pipe.set_outputs(resize_no_empty, resize_with_empty)
+    pipe.build()
+
+    for it in range(3):
+        out_no_empty, out_with_empty = pipe.run()
+        if device == "gpu":
+            out_no_empty = out_no_empty.as_cpu()
+            out_with_empty = out_with_empty.as_cpu()
+        for i in range(batch_size):
+            if i%2 != 0:
+                assert np.array_equal(out_no_empty.at(i), out_with_empty.at(i))
+            else:
+                assert np.prod(out_with_empty.at(i).shape) == 0
+
+def test_empty_input():
+    for device in ["cpu", "gpu"]:
+        for dim in [2, 3]:
+            yield _test_empty_input, dim, device


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug:
    * division by zero when empty output sample is encountered in GPU resampling setup
    * incorrect indexing resulting in spurious assertion in CPU resampling when empty output is encountered
    * incorrect DALI_ENFORCE when requested output size is nonzero before adjusting to empty input (with not_larger/resize_longer)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
    * skip generating blocks for empty samples (in all passes)
    * early return in CPU resampling when empty output is requested
    * don't force output to at least 1 pixel when input sample is empty
    * check for non-empty output for empty input after adjusting the input size, not before (mitigating incorrect ENFORCE)
    * limit the ROI adjustment factor to 10
    * limit ROI to reasonable range
    * limit filter support to 8k samples (32kB) to avoid shared memory overrun
 - Affected modules and functionalities:
     * Resampling, resize
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python test with empty inputs
     * Python test with tiny output
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
