### PR TITLE
Fix Uniform discrete distribution

### DIFF
--- a/dali/operators/random/uniform_distribution.h
+++ b/dali/operators/random/uniform_distribution.h
@@ -118,11 +118,11 @@ class UniformDistribution : public RNGBase<Backend, UniformDistribution<Backend>
       // read only once for build time arguments
       if (!values_.IsConstant() || per_sample_values_.empty()) {
         values_.Acquire(spec, ws, values_.IsConstant() ? max_batch_size_ : nsamples, false);
-        per_sample_values_.resize(nsamples);
-        per_sample_nvalues_.resize(nsamples);
+        per_sample_values_.resize(values_.size());
+        per_sample_nvalues_.resize(values_.size());
         if (std::is_same<Backend, GPUBackend>::value) {
           values_cpu_.clear();
-          for (int s = 0; s < nsamples; s++) {
+          for (int s = 0; s < values_.size(); s++) {
             values_cpu_.insert(values_cpu_.end(),
                                values_[s].data,
                                values_[s].data + values_[s].shape[0]);
@@ -130,12 +130,12 @@ class UniformDistribution : public RNGBase<Backend, UniformDistribution<Backend>
           }
           values_gpu_.from_host(values_cpu_, ws.stream());
           int64_t offset = 0;
-          for (int s = 0; s < nsamples; s++) {
+          for (int s = 0; s < values_.size(); s++) {
             per_sample_values_[s] = values_gpu_.data() + offset;
             offset += per_sample_nvalues_[s];
           }
         } else {
-          for (int s = 0; s < nsamples; s++) {
+          for (int s = 0; s < values_.size(); s++) {
             per_sample_values_[s] = values_[s].data;
             per_sample_nvalues_[s] = values_[s].shape[0];
           }

--- a/dali/operators/random/uniform_distribution.h
+++ b/dali/operators/random/uniform_distribution.h
@@ -115,9 +115,9 @@ class UniformDistribution : public RNGBase<Backend, UniformDistribution<Backend>
 
   void AcquireArgs(const OpSpec &spec, const workspace_t<Backend> &ws, int nsamples) {
     if (values_.IsDefined()) {
-      values_.Acquire(spec, ws, nsamples, false);
       // read only once for build time arguments
       if (!values_.IsConstant() || per_sample_values_.empty()) {
+        values_.Acquire(spec, ws, values_.IsConstant() ? max_batch_size_ : nsamples, false);
         per_sample_values_.resize(nsamples);
         per_sample_nvalues_.resize(nsamples);
         if (std::is_same<Backend, GPUBackend>::value) {

--- a/dali/pipeline/operator/arg_helper.h
+++ b/dali/pipeline/operator/arg_helper.h
@@ -116,7 +116,7 @@ class ArgValue {
       DALI_ENFORCE(is_uniform(view_.shape) && expected_shape == view_.shape[0],
         make_string("Expected uniform shape for argument \"", arg_name_,
                     "\" but got shape ", view_.shape));
-    } else {
+    } else if (view_.empty()) {
       if (ndim == 0) {
         data_ = {spec.GetArgument<T>(arg_name_)};
       } else {
@@ -151,7 +151,7 @@ class ArgValue {
           make_string("Expected uniform shape for argument \"", arg_name_,
                       "\" but got shape ", view_.shape));
       }
-    } else {
+    } else if (view_.empty()) {
       if (ndim == 0) {
         data_ = {spec.GetArgument<T>(arg_name_)};
       } else {

--- a/dali/pipeline/operator/arg_helper.h
+++ b/dali/pipeline/operator/arg_helper.h
@@ -119,9 +119,15 @@ class ArgValue {
     } else {
       if (ndim == 0) {
         data_.resize(1);
-        spec.TryGetArgument<T>(data_[0], arg_name_);
+        if (!spec.TryGetArgument<T>(data_[0], arg_name_)) {
+          // something went bad - call GetArgument and let it throw
+          (void) spec.GetArgument<T>(arg_name_);
+        }
       } else {
-        spec.TryGetRepeatedArgument<T>(data_, arg_name_);
+        if (!spec.TryGetRepeatedArgument<T>(data_, arg_name_)) {
+          // something went bad - call GetRepeatedArgument and let it throw
+          (void) spec.GetRepeatedArgument<T>(arg_name_);
+        }
         int64_t len = data_.size();
         int64_t expected_len = volume(expected_shape);
         if (len == 1 && expected_len > 1) {
@@ -155,9 +161,15 @@ class ArgValue {
     } else {
       if (ndim == 0) {
         data_.resize(1);
-        spec.TryGetArgument<T>(data_[0], arg_name_);
+        if (!spec.TryGetArgument<T>(data_[0], arg_name_)) {
+          // something went bad - call GetArgument and let it throw
+          (void) spec.GetArgument<T>(arg_name_);
+        }
       } else {
-        spec.TryGetRepeatedArgument<T>(data_, arg_name_);
+        if (!spec.TryGetRepeatedArgument<T>(data_, arg_name_)) {
+          // something went bad - call GetRepeatedArgument and let it throw
+          (void) spec.GetRepeatedArgument<T>(arg_name_);
+        }
       }
       auto sh = shape_from_size(static_cast<int64_t>(data_.size()));
       view_ = constant_view(nsamples, data_.data(), std::move(sh));

--- a/dali/pipeline/operator/arg_helper.h
+++ b/dali/pipeline/operator/arg_helper.h
@@ -116,11 +116,12 @@ class ArgValue {
       DALI_ENFORCE(is_uniform(view_.shape) && expected_shape == view_.shape[0],
         make_string("Expected uniform shape for argument \"", arg_name_,
                     "\" but got shape ", view_.shape));
-    } else if (view_.empty()) {
+    } else {
       if (ndim == 0) {
-        data_ = {spec.GetArgument<T>(arg_name_)};
+        data_.resize(1);
+        spec.TryGetArgument<T>(data_[0], arg_name_);
       } else {
-        data_ = spec.GetRepeatedArgument<T>(arg_name_);
+        spec.TryGetRepeatedArgument<T>(data_, arg_name_);
         int64_t len = data_.size();
         int64_t expected_len = volume(expected_shape);
         if (len == 1 && expected_len > 1) {
@@ -151,11 +152,12 @@ class ArgValue {
           make_string("Expected uniform shape for argument \"", arg_name_,
                       "\" but got shape ", view_.shape));
       }
-    } else if (view_.empty()) {
+    } else {
       if (ndim == 0) {
-        data_ = {spec.GetArgument<T>(arg_name_)};
+        data_.resize(1);
+        spec.TryGetArgument<T>(data_[0], arg_name_);
       } else {
-        data_ = spec.GetRepeatedArgument<T>(arg_name_);
+        spec.TryGetRepeatedArgument<T>(data_, arg_name_);
       }
       auto sh = shape_from_size(static_cast<int64_t>(data_.size()));
       view_ = constant_view(nsamples, data_.data(), std::move(sh));

--- a/dali/pipeline/operator/arg_helper_test.cc
+++ b/dali/pipeline/operator/arg_helper_test.cc
@@ -83,8 +83,8 @@ TEST(ArgValue, TensorInput_3D) {
 
 TEST(ArgValueTests, Constant_0D) {
   int nsamples = 5;
-  auto spec = OpSpec("opname").AddArg("argname", 0.123f);
-  ArgValue<float, 0> arg("argname", spec);
+  auto spec = OpSpec("Erase").AddArg("shape", 0.123f);
+  ArgValue<float, 0> arg("shape", spec);
   workspace_t<CPUBackend> ws;
   arg.Acquire(spec, ws, nsamples, true);
   ASSERT_TRUE(arg.IsConstant());
@@ -92,8 +92,8 @@ TEST(ArgValueTests, Constant_0D) {
   ASSERT_EQ(0.123f, *arg[0].data);
 
   // Passing a vector to a scalar ArgValue
-  auto spec2 = OpSpec("opname").AddArg("argname", vector<float>{0.1f, 0.2f});
-  ArgValue<float, 0> arg2("argname", spec2);
+  auto spec2 = OpSpec("Erase").AddArg("shape", vector<float>{0.1f, 0.2f});
+  ArgValue<float, 0> arg2("shape", spec2);
   EXPECT_THROW(arg2.Acquire(spec2, ws, nsamples, true), std::runtime_error);
 }
 
@@ -102,8 +102,8 @@ TEST(ArgValueTests, Constant_1D) {
   int nsamples = 5;
   std::vector<float> data{0.1f, 0.2f, 0.3f};
   TensorShape<1> expected_shape{3};
-  auto spec = OpSpec("opname").AddArg("argname", data);
-  ArgValue<float, 1> arg("argname", spec);
+  auto spec = OpSpec("Erase").AddArg("shape", data);
+  ArgValue<float, 1> arg("shape", spec);
   workspace_t<CPUBackend> ws;
   arg.Acquire(spec, ws, nsamples, true);
   ASSERT_TRUE(arg.IsConstant());

--- a/dali/test/python/test_operator_uniform.py
+++ b/dali/test/python/test_operator_uniform.py
@@ -22,42 +22,44 @@ import scipy.stats as st
 import math
 
 
-def check_uniform_default(device='cpu', batch_size=32, shape=[1e5], val_range=None):
+def check_uniform_default(device='cpu', batch_size=32, shape=[1e5], val_range=None, niter=3):
     pipe = Pipeline(batch_size=batch_size, device_id=0, num_threads=3, seed=123456)
     with pipe:
         pipe.set_outputs(dali.fn.random.uniform(device=device, range=val_range, shape=shape))
     pipe.build()
-    outputs = pipe.run()
-    val_range = (-1.0, 1.0) if val_range is None else val_range
-    data_out = outputs[0].as_cpu() \
-        if isinstance(outputs[0], TensorListGPU) else outputs[0]
-    pvs = []
-    for i in range(batch_size):
-        data = np.array(data_out[i])
-        # Check that the data is within the default range
-        assert (data >= val_range[0]).all() and \
-               (data <= val_range[1]).all(), \
-            "Value returned from the op is outside of requested range"
+    for it in range(niter):
+        outputs = pipe.run()
+        val_range = (-1.0, 1.0) if val_range is None else val_range
+        data_out = outputs[0].as_cpu() \
+            if isinstance(outputs[0], TensorListGPU) else outputs[0]
+        pvs = []
+        for i in range(batch_size):
+            data = np.array(data_out[i])
+            # Check that the data is within the default range
+            assert (data >= val_range[0]).all() and \
+                (data <= val_range[1]).all(), \
+                "Value returned from the op is outside of requested range"
 
-        h, b = np.histogram(data, bins=10)
-        mean_h = np.mean(h)
-        for hval in h:
-            np.testing.assert_allclose(mean_h, hval, rtol=0.05)  # +/- 5%
+            h, b = np.histogram(data, bins=10)
+            mean_h = np.mean(h)
+            for hval in h:
+                np.testing.assert_allclose(mean_h, hval, rtol=0.05)  # +/- 5%
 
-        # normalize to 0-1 range
-        data_kstest = (data - val_range[0]) / (val_range[1] - val_range[0])
-        _, pv = st.kstest(rvs=data_kstest, cdf='uniform')
-        pvs = pvs + [pv]
-    assert np.mean(pvs) > 0.05, f"data is not a uniform distribution. pv = {np.mean(pvs)}"
+            # normalize to 0-1 range
+            data_kstest = (data - val_range[0]) / (val_range[1] - val_range[0])
+            _, pv = st.kstest(rvs=data_kstest, cdf='uniform')
+            pvs = pvs + [pv]
+        assert np.mean(pvs) > 0.05, f"data is not a uniform distribution. pv = {np.mean(pvs)}"
 
 def test_uniform_continuous():
     batch_size = 4
     shape = [100000]
+    niter = 3
     for device in ['cpu', 'gpu']:
         for val_range in [None, (200.0, 400.0)]:
-            yield check_uniform_default, device, batch_size, shape, val_range
+            yield check_uniform_default, device, batch_size, shape, val_range, niter
 
-def check_uniform_continuous_next_after(device='cpu', batch_size=32, shape=[1e5]):
+def check_uniform_continuous_next_after(device='cpu', batch_size=32, shape=[1e5], niter=3):
     batch_size = 4
     shape = [100000]
     val_range = [np.float32(10.0), np.nextafter(np.float32(10.0), np.float32(11.0))]
@@ -66,45 +68,49 @@ def check_uniform_continuous_next_after(device='cpu', batch_size=32, shape=[1e5]
     with pipe:
         pipe.set_outputs(dali.fn.random.uniform(device=device, range=val_range, shape=shape))
     pipe.build()
-    outputs = pipe.run()
-    data_out = outputs[0].as_cpu() \
-        if isinstance(outputs[0], TensorListGPU) else outputs[0]
-    for i in range(batch_size):
-        data = np.array(data_out[i])
-        assert (val_range[0] == data).all(), \
-            f"{data} is outside of requested range"
+    for it in range(niter):
+        outputs = pipe.run()
+        data_out = outputs[0].as_cpu() \
+            if isinstance(outputs[0], TensorListGPU) else outputs[0]
+        for i in range(batch_size):
+            data = np.array(data_out[i])
+            assert (val_range[0] == data).all(), \
+                f"{data} is outside of requested range"
 
 def test_uniform_continuous_next_after():
     batch_size = 4
     shape = [100000]
+    niter = 3
     for device in ['cpu', 'gpu']:
-        yield check_uniform_continuous_next_after, device, batch_size, shape
+        yield check_uniform_continuous_next_after, device, batch_size, shape, niter
 
-def check_uniform_discrete(device='cpu', batch_size=32, shape=[1e5], values=None):
+def check_uniform_discrete(device='cpu', batch_size=32, shape=[1e5], values=None, niter=10):
     pipe = Pipeline(batch_size=batch_size, device_id=0, num_threads=3, seed=123456)
     with pipe:
         pipe.set_outputs(dali.fn.random.uniform(device=device, values=values, shape=shape))
     pipe.build()
-    outputs = pipe.run()
-    data_out = outputs[0].as_cpu() \
-        if isinstance(outputs[0], TensorListGPU) else outputs[0]
-    values_set = set(values)
-    maxval = np.max(values)
-    bins = np.concatenate([values, np.array([np.nextafter(maxval, maxval+1)])])
-    bins.sort()
-    pvs = []
-    for i in range(batch_size):
-        data = np.array(data_out[i])
-        for x in data:
-            assert x in values_set
-        h, _ = np.histogram(data, bins=bins)
-        _, pv = st.chisquare(h)
-        pvs = pvs + [pv]
-    assert np.mean(pvs) > 0.05, f"data is not a uniform distribution. pv = {np.mean(pvs)}"
+    for it in range(niter):
+        outputs = pipe.run()
+        data_out = outputs[0].as_cpu() \
+            if isinstance(outputs[0], TensorListGPU) else outputs[0]
+        values_set = set(values)
+        maxval = np.max(values)
+        bins = np.concatenate([values, np.array([np.nextafter(maxval, maxval+1)])])
+        bins.sort()
+        pvs = []
+        for i in range(batch_size):
+            data = np.array(data_out[i])
+            for x in data:
+                assert x in values_set
+            h, _ = np.histogram(data, bins=bins)
+            _, pv = st.chisquare(h)
+            pvs = pvs + [pv]
+        assert np.mean(pvs) > 0.05, f"data is not a uniform distribution. pv = {np.mean(pvs)}"
 
 def test_uniform_discrete():
     batch_size = 4
-    shape = [100000]
+    shape = [10000]
+    niter = 3
     for device in ['cpu', 'gpu']:
         for values in [(0, 1, 2, 3, 4, 5), (200, 400, 5000, 1)]:
-            yield check_uniform_discrete, device, batch_size, shape, values
+            yield check_uniform_discrete, device, batch_size, shape, values, niter


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in Uniform distribution producing unexpected values

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *An extra ArgValue Acquire call every iteration was overriding the values pointer inside ArgValue implementation while the per_sample_values data was kept unmodified due to the assumption that the pointer won't change.*
     *As a solution, we Acquire the values only once when a non-tensor argument is given*
     *Using TryGetArgument/TryGetRepeatedArgument to avoid reallocation*
 - Affected modules and functionalities:
     *Uniform distribution and other operators using ArgValue*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     *Added niter to uniform tests*
 - Documentation (including examples):
     *N/A*


**JIRA TASK**: *[DALI-1824*
