### PR TITLE
Fix SeparateQueuePolicy handling of the CPU stage

### DIFF
--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -57,7 +57,8 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunCPU() {
   DeviceGuard g(device_id_);
 
   auto cpu_idxs = QueuePolicy::AcquireIdxs(OpType::CPU);
-  if (exec_error_ || QueuePolicy::IsStopSignaled() || !QueuePolicy::AreValid(cpu_idxs)) {
+  if (exec_error_ || QueuePolicy::IsStopSignaled() ||
+      !QueuePolicy::template AreValid<OpType::CPU>(cpu_idxs)) {
     QueuePolicy::ReleaseIdxs(OpType::CPU, cpu_idxs);
     return;
   }
@@ -97,7 +98,8 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunMixed() {
   DeviceGuard g(device_id_);
 
   auto mixed_idxs = QueuePolicy::AcquireIdxs(OpType::MIXED);
-  if (exec_error_ || QueuePolicy::IsStopSignaled() || !QueuePolicy::AreValid(mixed_idxs)) {
+  if (exec_error_ || QueuePolicy::IsStopSignaled() ||
+     !QueuePolicy::template AreValid<OpType::MIXED>(mixed_idxs)) {
     QueuePolicy::ReleaseIdxs(OpType::MIXED, mixed_idxs);
     return;
   }
@@ -167,7 +169,8 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunGPU() {
   DomainTimeRange tr("[DALI][Executor] RunGPU");
 
   auto gpu_idxs = QueuePolicy::AcquireIdxs(OpType::GPU);
-  if (exec_error_ || QueuePolicy::IsStopSignaled() || !QueuePolicy::AreValid(gpu_idxs)) {
+  if (exec_error_ || QueuePolicy::IsStopSignaled() ||
+      !QueuePolicy::template AreValid<OpType::GPU>(gpu_idxs)) {
     QueuePolicy::ReleaseIdxs(OpType::GPU, gpu_idxs);
     return;
   }

--- a/dali/pipeline/executor/queue_metadata.h
+++ b/dali/pipeline/executor/queue_metadata.h
@@ -37,7 +37,7 @@ struct StageQueues {
   }
 
  private:
-  std::array<int, static_cast<size_t>(OpType::COUNT)> idxs = {{0, 0, 0}};
+  std::array<int, static_cast<size_t>(OpType::COUNT)> idxs = {{-1, -1, -1}};
 };
 
 // Used for indexing into stage queues
@@ -54,25 +54,30 @@ struct QueueSizes {
 };
 
 struct OutputIdxs {
-  explicit OutputIdxs(int queue_idx) : mixed(queue_idx), gpu(queue_idx) {}
-  OutputIdxs(int mixed, int gpu) : mixed(mixed), gpu(gpu) {}
+  explicit OutputIdxs(int queue_idx) : cpu(queue_idx),  mixed(queue_idx), gpu(queue_idx) {}
+  OutputIdxs(int cpu, int mixed, int gpu) : cpu(cpu), mixed(mixed), gpu(gpu) {}
 
+  int cpu;
   int mixed;
   int gpu;
 
   int &operator[](OpType op_type) {
     if (op_type == OpType::MIXED) {
       return mixed;
-    } else {
+    } else if (op_type == OpType::GPU) {
       return gpu;
+    } else {
+      return cpu;
     }
   }
 
   const int &operator[](OpType op_type) const {
     if (op_type == OpType::MIXED) {
       return mixed;
-    } else {
+    } else if (op_type == OpType::GPU) {
       return gpu;
+    } else {
+      return cpu;
     }
   }
 };

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -669,7 +669,7 @@ def test_reduce_max_cpu():
 
 def test_reduce_sum_cpu():
     check_single_input(fn.reductions.sum)
-    
+
 def test_segmentation_select_masks():
     def get_data_source(*args, **kwargs):
         return lambda: make_batch_select_masks(*args, **kwargs)
@@ -737,5 +737,48 @@ def test_random_mask_pixel_cpu():
     pipe.build()
     for _ in range(3):
         pipe.run()
+
+def test_cat_cpu():
+    pipe = Pipeline(batch_size=batch_size, num_threads=3, device_id=None)
+    data = fn.external_source(source = get_data, layout = "HWC")
+    data2 = fn.external_source(source = get_data, layout = "HWC")
+    data3 = fn.external_source(source = get_data, layout = "HWC")
+    pixel_pos = fn.cat(data, data2, data3)
+    pipe.set_outputs(pixel_pos)
+    pipe.build()
+    for _ in range(3):
+        pipe.run()
+
+def test_stack_cpu():
+    pipe = Pipeline(batch_size=batch_size, num_threads=3, device_id=None)
+    data = fn.external_source(source = get_data, layout = "HWC")
+    data2 = fn.external_source(source = get_data, layout = "HWC")
+    data3 = fn.external_source(source = get_data, layout = "HWC")
+    pixel_pos = fn.stack(data, data2, data3)
+    pipe.set_outputs(pixel_pos)
+    pipe.build()
+    for _ in range(3):
+        pipe.run()
+
+def test_separated_exec_setup():
+    batch_size = 128
+    pipe = Pipeline(batch_size=batch_size, num_threads=3, device_id=None, prefetch_queue_depth = {"cpu_size": 5, "gpu_size": 3})
+    inputs, labels = fn.caffe_reader(path = caffe_dir, shard_id = 0, num_shards = 1)
+    images = fn.image_decoder(inputs, output_type = types.RGB)
+    images = fn.resize(images, resize_x=224, resize_y=224)
+    images_cpu = fn.dump_image(images, suffix = "cpu")
+    pipe.set_outputs(images, images_cpu)
+
+    pipe.build()
+    out = pipe.run()
+    assert(out[0].is_dense_tensor())
+    assert(out[1].is_dense_tensor())
+    assert(out[0].as_tensor().shape() == out[1].as_tensor().shape())
+    a_raw = out[0]
+    a_cpu = out[1]
+    for i in range(batch_size):
+        t_raw = a_raw.at(i)
+        t_cpu = a_cpu.at(i)
+        assert(np.sum(np.abs(t_cpu - t_raw)) == 0)
 
 # ToDo add tests for DLTensorPythonFunction if easily possible

--- a/dali/test/python/test_operator_join.py
+++ b/dali/test/python/test_operator_join.py
@@ -171,7 +171,7 @@ def _run_test_stack(num_inputs, layout, ndim, axis, axis_name):
         pipe.set_outputs(out_cpu, out_gpu, *inputs);
     pipe.build()
 
-    for iter in range(num_iter):
+    for _ in range(num_iter):
         o_cpu, o_gpu, *inputs = pipe.run()
         ref = ref_stack(inputs, ref_axis)
         check_batch(o_cpu, ref, batch_size, eps=0, expected_layout=ref_layout)
@@ -192,4 +192,3 @@ def test_stack():
                 axis_names = [None] if layout is None and ndim > 0 else [None, 'C']
                 for axis_name in axis_names:
                     yield _run_test_stack, num_inputs, layout, ndim, axis, axis_name
-


### PR DESCRIPTION
- when a CPU-only pipeline was introduced MakeContiguousCPU was created and CPU inputs to the GPU stage can be generated directly by the CPU stage as well, not only the Mixed one. SeparateQueuePolicy assumes otherwise and overwrites the CPU stage buffer as soon as it is consumed by the Mixed stage.  This PR makes the CPU stage a first-class citizen on SeparateQueuePolicy

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in SeparateQueuePolicy handling of the CPU stage

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     when a CPU-only pipeline was introduced MakeContiguousCPU was created and CPU inputs to the GPU stage can be generated directly by the CPU stage as well, not only the Mixed one. SeparateQueuePolicy assumes otherwise and overwrites the CPU stage buffer as soon as it is consumed by the Mixed stage
    makes the CPU stage a first-class citizen on SeparateQueuePolicy
 - Affected modules and functionalities:
     executor
 - Key points relevant for the review:
     executor?
 - Validation and testing:
     added a test for CPU only SeparateQueuePolicy
     run `python test_RN50_data_pipeline.py --gpus 1 -b 10 --workers 3 --separate_queue --cpu_size 2 --gpu_size 2 --fp16 --nhwc -s` in a loop
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1821]*
