### PR TITLE
Fix variable batch size for list of tensors. Make Constant op constant again

### DIFF
--- a/dali/operators/generic/constant.cc
+++ b/dali/operators/generic/constant.cc
@@ -104,14 +104,15 @@ void Constant<CPUBackend>::RunImpl(HostWorkspace &ws) {
     TYPE_SWITCH(output_type_, type2id, type, CONSTANT_OP_SUPPORTED_TYPES,
       (
         if (!fdata_.empty()) {
-          FillTensorVector<type>(output_, output_shape_, fdata_);
+          FillTensorVector<type>(output_, max_output_shape_, fdata_);
         } else {
-          FillTensorVector<type>(output_, output_shape_, idata_);
+          FillTensorVector<type>(output_, max_output_shape_, idata_);
         }
       ), (DALI_FAIL(make_string("Unsupported type: ", output_type_))));  // NOLINT
   }
 
   out.ShareData(&output_);
+  out.Resize(output_shape_);
   int N = output_shape_.num_samples();
   for (int i = 0; i < N; i++) {
     assert(out[i].raw_data() == output_[i].raw_data());

--- a/dali/operators/generic/constant.cu
+++ b/dali/operators/generic/constant.cu
@@ -88,9 +88,9 @@ void Constant<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
     TYPE_SWITCH(output_type_, type2id, type, CONSTANT_OP_SUPPORTED_TYPES,
       (
         if (!fdata_.empty()) {
-          FillTensorList<type>(output_, output_shape_, fdata_, ws.stream());
+          FillTensorList<type>(output_, max_output_shape_, fdata_, ws.stream());
         } else {
-          FillTensorList<type>(output_, output_shape_, idata_, ws.stream());
+          FillTensorList<type>(output_, max_output_shape_, idata_, ws.stream());
         }
       ), (DALI_FAIL(make_string("Unsupported type: ", output_type_))));  // NOLINT
   }
@@ -98,6 +98,7 @@ void Constant<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
 
   out.Reset();
   out.ShareData(&output_);
+  out.Resize(output_shape_);
   int N = output_shape_.num_samples();
   for (int i = 0; i < N; i++) {
     assert(out.raw_tensor(i) == output_.raw_tensor(i));

--- a/dali/operators/generic/constant.h
+++ b/dali/operators/generic/constant.h
@@ -80,11 +80,12 @@ class Constant : public Operator<Backend> {
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
     output_desc.resize(1);
-    auto curr_batch_size = ws.GetRequestedBatchSize(0);
-    if (output_shape_.empty() || output_shape_.num_samples() != curr_batch_size) {
-      output_shape_ = uniform_list_shape(curr_batch_size, shape_arg_);
+    if (max_output_shape_.empty()) {
+      max_output_shape_ = uniform_list_shape(max_batch_size_, shape_arg_);
       output_.Reset();
     }
+    output_shape_ = max_output_shape_;
+    output_shape_.resize(ws.GetRequestedBatchSize(0));
     output_desc[0] = {output_shape_, TypeTable::GetTypeInfo(output_type_)};
     return false;
   }
@@ -97,6 +98,7 @@ class Constant : public Operator<Backend> {
   std::vector<int> idata_;
   std::vector<float> fdata_;
   TensorListShape<> output_shape_;
+  TensorListShape<> max_output_shape_;
   TensorLayout layout_;
   DALIDataType output_type_;
   using storage_t = std::conditional_t<std::is_same<Backend, CPUBackend>::value,

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1350,8 +1350,8 @@ PYBIND11_MODULE(backend_impl, m) {
           // tries to call the deleted copy constructor for Tensor.
           // instead, we cast to a reference type and manually
           // move into the vector.
-          DALI_ENFORCE(p->batch_size() == static_cast<int>(list.size()),
-             "Data list provided to feed_input needs to have batch_size length.");
+          DALI_ENFORCE(static_cast<int>(list.size()) <= p->max_batch_size(),
+             "Data list provided to feed_input exceeds maximum batch_size for this pipeline.");
 
           // not the most beautiful but at least it doesn't throw as plain cast<T>()
           py::detail::make_caster<Tensor<CPUBackend>&> conv;


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: assertion when providing variable batch as a list of tensors.
- It doesn not recreate constants when batch size changes.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * changed the condition in BackendImpl from `== p->batch_size()` to ` <= p->max_batch_size()`
     * max_batch_size TensorList/TensorVector is populated and then only trimmed to required length.
 - Affected modules and functionalities:
     * Python interface for Pipeline
     * Constant op
     * Constant op tests
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python test
 - Documentation (including examples):
     * documentation stated that Constants are never reallocated which is true... again

**JIRA TASK**: N/A
