### PR TITLE
Python fixes: argument inputs, external source, docs

### DIFF
--- a/dali/pipeline/operator/op_spec.cc
+++ b/dali/pipeline/operator/op_spec.cc
@@ -49,11 +49,13 @@ OpSpec& OpSpec::AddOutput(const string &name, const string &device) {
 }
 
 OpSpec& OpSpec::AddArgumentInput(const string &arg_name, const string &inp_name) {
-  DALI_ENFORCE(!this->HasArgument(arg_name),
-      "Argument " + arg_name + " was already added to the op.");
+  DALI_ENFORCE(!this->HasArgument(arg_name), make_string(
+      "Argument ", arg_name, " is already specified."));
   const OpSchema& schema = GetSchema();
-  DALI_ENFORCE(schema.HasArgument(arg_name),
-      "Argument '" + arg_name + "' is not part of the op schema '" + schema.name() + "'");
+  DALI_ENFORCE(schema.HasArgument(arg_name), make_string(
+      "Argument '", arg_name, "' is not part of the op schema '", schema.name(), "'"));
+  DALI_ENFORCE(schema.IsTensorArgument(arg_name), make_string(
+      "Argument `", arg_name, "` in operator `", schema.name(), "` is not a a tensor argument."));
   argument_inputs_[arg_name] = inputs_.size();
   argument_inputs_indexes_.insert(inputs_.size());
   AddInput(inp_name, "cpu", false);

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -252,9 +252,9 @@ Keyword Args
 `cycle`: string or bool, optional
     Specifies if and how to cycle through the source.
     It can be one of the following values:
-        * ``"no"``, ``False`` or ``None`` - don't cycle; StopIteration is raised whe end of data is reached; this is the default behavior
+        * ``"no"``, ``False`` or ``None`` - don't cycle; ``StopIteration`` is raised whe end of data is reached; this is the default behavior
         * ``"quiet"`` or ``True`` - the data is repeated indefinitely,
-        * ``"raise"`` - when the end of data is reached, StopIteration is raised, but the iteration is restarted on subsequent call.
+        * ``"raise"`` - when the end of data is reached, ``StopIteration`` is raised, but the iteration is restarted on subsequent call.
 
     This flag requires that the ``source`` is a collection, for example, an iterable object where
     ``iter(source)`` returns a fresh iterator on each call or a gensource erator function.

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -33,9 +33,10 @@ def _check_data_batch(data, batch_size, layout):
         if layout is not None and layout != "" and dim != len(layout):
             raise RuntimeError("The layout '{}' cannot describe {}-dimensional data".format(layout, dim))
 
-class _CycleIter():
-    def __init__(self, iterable):
+class _CycleIter:
+    def __init__(self, iterable, how):
         self.source = iterable
+        self.signaling = (how == "raise")
 
     def __iter__(self):
         self.it = iter(self.source)
@@ -46,11 +47,15 @@ class _CycleIter():
             return next(self.it)
         except StopIteration:
             self.it = iter(self.source)
-            return next(self.it)
+            if self.signaling:
+                raise
+            else:
+                return next(self.it)
 
 class _CycleGenFunc():
-    def __init__(self, gen_func):
+    def __init__(self, gen_func, how):
         self.source = gen_func
+        self.signaling = (how == "raise")
 
     def __iter__(self):
         self.it = iter(self.source())
@@ -61,7 +66,10 @@ class _CycleGenFunc():
             return next(self.it)
         except StopIteration:
             self.it = iter(self.source())
-            return next(self.it)
+            if self.signaling:
+                raise
+            else:
+                return next(self.it)
 
 class _ExternalSourceGroup(object):
     def __init__(self, callback, is_multioutput, instances = [], cuda_stream = None, use_copy_kernel = None, batch = True):
@@ -129,18 +137,30 @@ def _is_generator_function(x):
     call = getattr(x, "__call__", None)
     return _is_generator_function(call)
 
+def _cycle_enabled(cycle):
+    if cycle is None:
+        return False
+    if cycle == False or cycle == "no":
+        return False
+    if cycle == True or cycle == "quiet" or cycle == "raise":
+        return True
+    raise ValueError("""Invalid value {} for the argument `cycle`. Valid values are
+  - "no", False or None - cycling disabled
+  - "quiet", True - quietly rewind the data
+  - "raise" - raise StopIteration on each rewind.""".format(cycle))
+
 def _get_callback_from_source(source, cycle):
     iterable = False
     if source is not None:
         try:
-            if cycle:
+            if _cycle_enabled(cycle):
                 if inspect.isgenerator(source):
                     raise TypeError("Cannot cycle through a generator - if the generator is a result "
                         "of calling a generator function, pass that function instead as `source`.")
                 if _is_generator_function(source):
-                    iterator = iter(_CycleGenFunc(source))
+                    iterator = iter(_CycleGenFunc(source, cycle))
                 else:
-                    iterator = iter(_CycleIter(source))
+                    iterator = iter(_CycleIter(source, cycle))
             else:
                 if _is_generator_function(source):
                     source = source()
@@ -229,14 +249,18 @@ Args
 Keyword Args
 ------------
 
-`cycle`: bool, optional
-    If set to True, the source will be wrapped.
+`cycle`: string or bool, optional
+    Specifies if and how to cycle through the source. It can be one of the following values:
+        * ``"no"`` or ``False`` - don't cycle; StopIteration is raised whe end of data is reached
+        * ``"quiet"`` or ``True`` - the data is repeated indefinitely
+        * ``"raise"`` - when the end of data is reached, StopIteration is raised, but the iteration is restarted on subsequent call
 
-    If set to False, StopIteration is raised when the end of data is reached.
     This flag requires that the ``source`` is a collection, for example, an iterable object where
     ``iter(source)`` returns a fresh iterator on each call or a gensource erator function.
     In the latter case, the generator function is called again when more data than was
     yielded by the function is requested.
+
+    Specifying ``"raise"`` can be used with DL framework iterators to create a notion of epoch.
 
 `name` : str, optional
     The name of the data node.

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -34,9 +34,9 @@ def _check_data_batch(data, batch_size, layout):
             raise RuntimeError("The layout '{}' cannot describe {}-dimensional data".format(layout, dim))
 
 class _CycleIter:
-    def __init__(self, iterable, how):
+    def __init__(self, iterable, mode):
         self.source = iterable
-        self.signaling = (how == "raise")
+        self.signaling = (mode == "raise")
 
     def __iter__(self):
         self.it = iter(self.source)
@@ -53,9 +53,9 @@ class _CycleIter:
                 return next(self.it)
 
 class _CycleGenFunc():
-    def __init__(self, gen_func, how):
+    def __init__(self, gen_func, mode):
         self.source = gen_func
-        self.signaling = (how == "raise")
+        self.signaling = (mode == "raise")
 
     def __iter__(self):
         self.it = iter(self.source())
@@ -147,7 +147,7 @@ def _cycle_enabled(cycle):
     raise ValueError("""Invalid value {} for the argument `cycle`. Valid values are
   - "no", False or None - cycling disabled
   - "quiet", True - quietly rewind the data
-  - "raise" - raise StopIteration on each rewind.""".format(cycle))
+  - "raise" - raise StopIteration on each rewind.""".format(repr(cycle)))
 
 def _get_callback_from_source(source, cycle):
     iterable = False
@@ -251,16 +251,16 @@ Keyword Args
 
 `cycle`: string or bool, optional
     Specifies if and how to cycle through the source. It can be one of the following values:
-        * ``"no"`` or ``False`` - don't cycle; StopIteration is raised whe end of data is reached
-        * ``"quiet"`` or ``True`` - the data is repeated indefinitely
-        * ``"raise"`` - when the end of data is reached, StopIteration is raised, but the iteration is restarted on subsequent call
+        * ``"no"``, ``False`` or ``None`` - don't cycle; StopIteration is raised whe end of data is reached; this is the default behavior
+        * ``"quiet"`` or ``True`` - the data is repeated indefinitely,
+        * ``"raise"`` - when the end of data is reached, StopIteration is raised, but the iteration is restarted on subsequent call.
 
     This flag requires that the ``source`` is a collection, for example, an iterable object where
     ``iter(source)`` returns a fresh iterator on each call or a gensource erator function.
     In the latter case, the generator function is called again when more data than was
     yielded by the function is requested.
 
-    Specifying ``"raise"`` can be used with DL framework iterators to create a notion of epoch.
+    Specifying ``"raise"`` can be used with DALI iterators to create a notion of epoch.
 
 `name` : str, optional
     The name of the data node.

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -250,7 +250,8 @@ Keyword Args
 ------------
 
 `cycle`: string or bool, optional
-    Specifies if and how to cycle through the source. It can be one of the following values:
+    Specifies if and how to cycle through the source.
+    It can be one of the following values:
         * ``"no"``, ``False`` or ``None`` - don't cycle; StopIteration is raised whe end of data is reached; this is the default behavior
         * ``"quiet"`` or ``True`` - the data is repeated indefinitely,
         * ``"raise"`` - when the end of data is reached, StopIteration is raised, but the iteration is restarted on subsequent call.

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -976,8 +976,14 @@ Parameters
         if self._input_callbacks is None:
             return
 
+        stop_iter = False
         for group in self._input_callbacks:
-            group.call_and_feed(self, self._max_batch_size)
+            try:
+                group.call_and_feed(self, self._max_batch_size)
+            except StopIteration:
+                stop_iter = True
+        if stop_iter:
+            raise StopIteration()
 
     def _iter_setup(self):
         self._run_input_callbacks()

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -74,12 +74,12 @@ if _tfrecord_support:
     _known_types[DALIDataType._FEATURE_DICT] = ("dict of (string, nvidia.dali.tfrecord.Feature)",
             _not_implemented)
 
-def _type_name_convert_to_string(dtype, is_tensor):
+def _type_name_convert_to_string(dtype, allow_tensors):
     if dtype in _known_types:
         ret = _known_types[dtype][0]
-        if is_tensor:
-            ret = "TensorList of " + ret
-        elif dtype in _vector_types:
+        if allow_tensors:
+            ret = "TensorList of " + ret + " or " + ret
+        if dtype in _vector_types:
             ret = ret + " or list of " + _known_types[dtype][0]
         return ret
     else:

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -76,11 +76,12 @@ if _tfrecord_support:
 
 def _type_name_convert_to_string(dtype, allow_tensors):
     if dtype in _known_types:
-        ret = _known_types[dtype][0]
-        if allow_tensors:
-            ret = "TensorList of " + ret + " or " + ret
+        type_name = _known_types[dtype][0]
+        ret = type_name
         if dtype in _vector_types:
-            ret = ret + " or list of " + _known_types[dtype][0]
+            ret += " or list of " + type_name
+        if allow_tensors:
+            ret += " or TensorList of " + type_name
         return ret
     else:
         raise RuntimeError(str(dtype) + " does not correspond to a known type.")

--- a/dali/test/python/test_external_source_impl.py
+++ b/dali/test/python/test_external_source_impl.py
@@ -355,7 +355,7 @@ def test_external_source_collection_cycling_raise():
         for b in batches:
             yield b
 
-    pipe.set_outputs(fn.external_source(batches, cycle = "rise"), fn.external_source(batch_gen, cycle = "raise"))
+    pipe.set_outputs(fn.external_source(batches, cycle = "raise"), fn.external_source(batch_gen, cycle = "raise"))
     pipe.build()
 
     # epochs are cycles over the source iterable

--- a/dali/test/python/test_external_source_impl.py
+++ b/dali/test/python/test_external_source_impl.py
@@ -355,7 +355,7 @@ def test_external_source_collection_cycling_raise():
         for b in batches:
             yield b
 
-    pipe.set_outputs(fn.external_source(batches, cycle = "raise"), fn.external_source(batch_gen, cycle = "raise"))
+    pipe.set_outputs(fn.external_source(batches, cycle = "rise"), fn.external_source(batch_gen, cycle = "raise"))
     pipe.build()
 
     # epochs are cycles over the source iterable


### PR DESCRIPTION
* OpSpec: check schema in AddArgumentInput
* ExternalSource: add alternative cycle behavior (raise)
* Pipeline: call all external sources even if one of them raises StopIteration
* Pipeline: combine multiple StopIteration exceptions in a single `run` into one.
* Docs: remove distinction between `__init__` and `__call__` arguments which now can accept both build-time and run-time (tensor) arguments.

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug #2644
- It adds new feature needed to provide epoch semantics with collection-based external source
- It fixes a documentation issue (artificial separation of argument types)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added a python-side check for argument inputs in schema; print friendly diagnostic
     * Added backend-side check in OpSpec for argument inputs
     * Recognize a new value `"raise"` in ExtenralSoruce's `cycle` argument
 - Affected modules and functionalities:
     * Python ops wrappers
     * ExternalSource
     * OpSpec
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python tests for external source
 - Documentation (including examples):
     * Update docstrings

**JIRA TASK**: DALI-1828
