### PR TITLE
Workaround a compiler problem that caused Invalid device function error.

### DIFF
--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -245,15 +245,10 @@ class SliceFlipNormalizePermutePadGpu {
         VALUE_SWITCH(need_normalize_ ? 1 : 0, NeedNormalize, (false, true), (
           auto grid = block_count_;
           // need to handle __half due to compilation differences
-          #if defined(__clang__)
           detail::SliceFlipNormalizePermutePadKernel
-            <NeedPad, NeedFlip, NeedNormalize, to_gpu_t<OutputType>, to_gpu_t<InputType>, Dims>
+            <NeedPad, NeedFlip, NeedNormalize,
+            DALI_TO_GPU_T(OutputType), DALI_TO_GPU_T(InputType), Dims>
             <<<grid, kBlockDim, 0, context.gpu.stream>>>(sample_descs_gpu, block_descs_gpu);
-          #else
-          detail::SliceFlipNormalizePermutePadKernel
-            <NeedPad, NeedFlip, NeedNormalize, OutputType, InputType, Dims>
-            <<<grid, kBlockDim, 0, context.gpu.stream>>>(sample_descs_gpu, block_descs_gpu);
-          #endif
         ), ());  // NOLINT
       ), ());  // NOLINT
     ), ());  // NOLINT

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -256,7 +256,7 @@ class SliceGPU {
     for (int i = 0; i < in.size(); i++) {
       if (default_fill_values_) {
         assert(nfill_values_ == 1);
-        fill_values_cpu[i] = static_cast<OutputType>(0.f);
+        fill_values_cpu[i] = OutputType{};
       } else {
         auto *fill_values = fill_values_cpu + i * nfill_values_;
         for (int d = 0; d < nfill_values_; d++)
@@ -324,10 +324,10 @@ class SliceGPU {
 
     const auto grid = block_count_;
     if (any_padded_sample)
-      detail::SliceKernel<to_gpu_t<OutputType>, to_gpu_t<InputType>, Dims, true>
+      detail::SliceKernel<DALI_TO_GPU_T(OutputType), DALI_TO_GPU_T(InputType), Dims, true>
         <<<grid, kBlockDim, 0, context.gpu.stream>>>(sample_descs, block_descs);
     else
-      detail::SliceKernel<to_gpu_t<OutputType>, to_gpu_t<InputType>, Dims, false>
+      detail::SliceKernel<DALI_TO_GPU_T(OutputType), DALI_TO_GPU_T(InputType), Dims, false>
         <<<grid, kBlockDim, 0, context.gpu.stream>>>(sample_descs, block_descs);
     CUDA_CALL(cudaGetLastError());
   }

--- a/dali/pipeline/data/dltensor.cc
+++ b/dali/pipeline/data/dltensor.cc
@@ -19,10 +19,10 @@ namespace dali {
 
 DLDataType GetDLType(const TypeInfo &type) {
   DLDataType dl_type{};
-  DALI_TYPE_SWITCH(type.id(), T,
+  DALI_TYPE_SWITCH_WITH_FP16(type.id(), T,
       dl_type.bits = sizeof(T) * 8;
       dl_type.lanes = 1;
-      if (std::is_floating_point<T>::value) {
+      if (dali::is_fp_or_half<T>::value) {
         dl_type.code = kDLFloat;
       } else if (std::is_unsigned<T>::value) {
         dl_type.code = kDLUInt;

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -362,7 +362,7 @@ def test_slice_synth_data_vs_numpy():
                 ((200,400,3), "HWC", None, "HW", types.INT64, types.UINT8),
                 ((200,400,3), "HWC", None, "C", types.FLOAT, None),
                 ((200,400,3), "HWC", (1,0), None, types.FLOAT, types.FLOAT16),
-                ((200,400,3), "HWC", (0,1), None, types.INT32, types.FLOAT16),
+                ((200,400,3), "HWC", (0,1), None, types.FLOAT16, types.FLOAT16),
                 ((200,400,3), "HWC", (2,), None, types.FLOAT, None),
                 ((200,), "H", (0,), None, types.FLOAT, None),
                 ((200,), "H", None, "H", types.FLOAT, None),

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -361,8 +361,8 @@ def test_slice_synth_data_vs_numpy():
                 ((200,400,3), "HWC", None, "HW", types.INT32, types.FLOAT),
                 ((200,400,3), "HWC", None, "HW", types.INT64, types.UINT8),
                 ((200,400,3), "HWC", None, "C", types.FLOAT, None),
-                ((200,400,3), "HWC", (1,0), None, types.FLOAT, None),
-                ((200,400,3), "HWC", (0,1), None, types.FLOAT, None),
+                ((200,400,3), "HWC", (1,0), None, types.FLOAT, types.FLOAT16),
+                ((200,400,3), "HWC", (0,1), None, types.INT32, types.FLOAT16),
                 ((200,400,3), "HWC", (2,), None, types.FLOAT, None),
                 ((200,), "H", (0,), None, types.FLOAT, None),
                 ((200,), "H", None, "H", types.FLOAT, None),
@@ -467,7 +467,7 @@ def check_slice_output(sample_in, sample_out, anchor, abs_slice_shape, abs_start
         for d in range(len(flip)):
             if flip[d]:
                 expected = np.flip(expected, d)
-   
+
     if permute is not None:
         expected = np.transpose(expected, permute)
 

--- a/include/dali/core/float16.h
+++ b/include/dali/core/float16.h
@@ -66,14 +66,16 @@ struct is_fp_or_half {
 template <typename T>
 using to_gpu_t = std::conditional_t<is_half<T>::value, __half, T>;
 
+#define DALI_TO_GPU_T(T) to_gpu_t<T>
+
 #else
 
 template <typename T>
 using to_gpu_t = T;
 
+#define DALI_TO_GPU_T(T) T
+
 #endif
-
-
 
 }  // namespace dali
 


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes bugs:
    * Invalid device function when calling operator Slice on half precision data.
    * Unknown type: float16 in DLTensor

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * WAR Use a compiler-dependent macro instead of an identity typedef
     * use `DALI_TYPE_SWITCH_WITH_FP16` and `is_fp_or_half` in DLTensor
 - Affected modules and functionalities:
     * float16 header
     * Slice and SliceFlipNormalize kernels
     * Slice tests
     * DLTensor
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python tests
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-1831
