### PR TITLE
Make preparation of the first batch during the iterator construction optional

### DIFF
--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -251,6 +251,7 @@ class DataReader : public Operator<Backend> {
 
       // We don't want to cache the image itself
       auto& first_output = cached_outputs[0];
+      first_output.set_pinned(false);
       first_output.SetSourceInfo(source_info);
       first_output.SetSkipSample(should_skip_sample);
       first_output.set_type(TypeInfo::Create<uint8_t>());
@@ -258,6 +259,7 @@ class DataReader : public Operator<Backend> {
 
       for (std::size_t i = 1; i < cached_outputs.size(); i++) {
         auto& output = ws->Output<CPUBackend>(i);
+        cached_outputs[i].set_pinned(false);
         cached_outputs[i].Copy(output, 0);
       }
     }

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -83,7 +83,7 @@ If not provided, it will be populated based on the global seed of the pipeline.)
     AddOptionalArg("bytes_per_sample_hint", R"code(Output size hint, in bytes per sample.
 
 If specified, the operator's outputs residing in GPU or page-locked host memory will be preallocated
-to accommodate a batch of samples of this size.)code", 0);
+to accommodate a batch of samples of this size.)code", std::vector<int>{0, });
 
     AddOptionalArg("preserve",  R"code(Prevents the operator from being removed from the
 graph even if its outputs are not used.)code", false);

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -83,7 +83,7 @@ If not provided, it will be populated based on the global seed of the pipeline.)
     AddOptionalArg("bytes_per_sample_hint", R"code(Output size hint, in bytes per sample.
 
 If specified, the operator's outputs residing in GPU or page-locked host memory will be preallocated
-to accommodate a batch of samples of this size.)code", std::vector<int>{0, });
+to accommodate a batch of samples of this size.)code", std::vector<int>{0});
 
     AddOptionalArg("preserve",  R"code(Prevents the operator from being removed from the
 graph even if its outputs are not used.)code", false);

--- a/dali/python/nvidia/dali/plugin/base_iterator.py
+++ b/dali/python/nvidia/dali/plugin/base_iterator.py
@@ -98,7 +98,7 @@ class _DaliBaseIterator(object):
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
                 Whether DALI should buffer the first batch right after the creation of the iterator,
-                so when it is prompted for the data have one batch already prepared
+                so one batch is already prepared when the iterator is prompted for the data
 
     Example
     -------

--- a/dali/python/nvidia/dali/plugin/base_iterator.py
+++ b/dali/python/nvidia/dali/plugin/base_iterator.py
@@ -96,6 +96,9 @@ class _DaliBaseIterator(object):
                 True next epoch would be the same length as the first one. For this to happen,
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
+    prepare_first_batch : bool, optional, default = True
+                Whether DALI should buffer the first batch right after the creation so when it is
+                prompted for the data have one batch already prepared
 
     Example
     -------
@@ -120,7 +123,8 @@ class _DaliBaseIterator(object):
                  auto_reset=False,
                  fill_last_batch=None,
                  last_batch_padded=False,
-                 last_batch_policy=LastBatchPolicy.FILL):
+                 last_batch_policy=LastBatchPolicy.FILL,
+                 prepare_first_batch = True):
 
         assert pipelines is not None, "Number of provided pipelines has to be at least 1"
         if not isinstance(pipelines, list):
@@ -134,6 +138,7 @@ class _DaliBaseIterator(object):
 
         self._size = int(size)
         self._auto_reset = auto_reset
+        self._prepare_first_batch = prepare_first_batch
 
         if fill_last_batch is not None:
             warnings.warn("Please do not use `fill_last_batch` and use `last_batch_policy` instead.",

--- a/dali/python/nvidia/dali/plugin/base_iterator.py
+++ b/dali/python/nvidia/dali/plugin/base_iterator.py
@@ -97,8 +97,8 @@ class _DaliBaseIterator(object):
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
-                Whether DALI should buffer the first batch right after the creation so when it is
-                prompted for the data have one batch already prepared
+                Whether DALI should buffer the first batch right after the creation of the iterator,
+                so when it is prompted for the data have one batch already prepared
 
     Example
     -------
@@ -124,7 +124,7 @@ class _DaliBaseIterator(object):
                  fill_last_batch=None,
                  last_batch_padded=False,
                  last_batch_policy=LastBatchPolicy.FILL,
-                 prepare_first_batch = True):
+                 prepare_first_batch=True):
 
         assert pipelines is not None, "Number of provided pipelines has to be at least 1"
         if not isinstance(pipelines, list):

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -199,7 +199,7 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
                 Whether DALI should buffer the first batch right after the creation of the iterator,
-                so when it is prompted for the data have one batch already prepared
+                so one batch is already prepared when the iterator is prompted for the data
     Example
     -------
     With the data set ``[1,2,3,4,5,6,7]`` and the batch size 2:
@@ -488,7 +488,7 @@ class DALIClassificationIterator(DALIGenericIterator):
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
                 Whether DALI should buffer the first batch right after the creation of the iterator,
-                so when it is prompted for the data have one batch already prepared
+                so one batch is already prepared when the iterator is prompted for the data
 
     Example
     -------
@@ -628,7 +628,7 @@ class DALIGluonIterator(_DALIMXNetIteratorBase):
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
                 Whether DALI should buffer the first batch right after the creation of the iterator,
-                so when it is prompted for the data have one batch already prepared
+                so one batch is already prepared when the iterator is prompted for the data
 
     Example
     -------

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -198,9 +198,8 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
-                Whether DALI should buffer the first batch right after the creation so when it is
-                prompted for the data have one batch already prepared
-
+                Whether DALI should buffer the first batch right after the creation of the iterator,
+                so when it is prompted for the data have one batch already prepared
     Example
     -------
     With the data set ``[1,2,3,4,5,6,7]`` and the batch size 2:
@@ -241,15 +240,14 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
             "output_names in output_map should be distinct"
         self.output_map = output_map
 
-        _DALIMXNetIteratorBase.__init__(self,
-                                        pipelines,
-                                        size,
-                                        reader_name,
-                                        fill_last_batch,
-                                        last_batch_padded,
-                                        auto_reset,
-                                        last_batch_policy,
-                                        prepare_first_batch=prepare_first_batch)
+        super().__init__(pipelines,
+                         size,
+                         reader_name,
+                         fill_last_batch,
+                         last_batch_padded,
+                         auto_reset,
+                         last_batch_policy,
+                         prepare_first_batch=prepare_first_batch)
         self._squeeze_labels = squeeze_labels
         self._dynamic_shape = dynamic_shape
         # Use double-buffering of data batches
@@ -266,10 +264,13 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
                 assert False, "It seems that there is no data in the pipeline. This may happen if `last_batch_policy` is set to PARTIAL and the requested batch size is greater than the shard size."
 
     def __getattr__(self, key):
+        # these attributes are required by MXNet thus DALI needs to provide them
         if key == 'provide_data' or key == 'provide_label':
             # obtain the first batch to populate the metadata
             try:
                 self._first_batch = DALIGenericIterator.__next__(self)
+                # this entries should be there thanks to the above call
+                return self.__dict__[key]
             except StopIteration:
                 assert False, "It seems that there is no data in the pipeline. This may happen if `last_batch_policy` is set to PARTIAL and the requested batch size is greater than the shard size."
         raise AttributeError
@@ -486,8 +487,8 @@ class DALIClassificationIterator(DALIGenericIterator):
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
-                Whether DALI should buffer the first batch right after the creation so when it is
-                prompted for the data have one batch already prepared
+                Whether DALI should buffer the first batch right after the creation of the iterator,
+                so when it is prompted for the data have one batch already prepared
 
     Example
     -------
@@ -626,8 +627,8 @@ class DALIGluonIterator(_DALIMXNetIteratorBase):
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
-                Whether DALI should buffer the first batch right after the creation so when it is
-                prompted for the data have one batch already prepared
+                Whether DALI should buffer the first batch right after the creation of the iterator,
+                so when it is prompted for the data have one batch already prepared
 
     Example
     -------

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -80,9 +80,17 @@ class _DALIMXNetIteratorBase(mx.io.DataIter, _DaliBaseIterator):
                  fill_last_batch=None,
                  last_batch_padded=False,
                  auto_reset=False,
-                 last_batch_policy=LastBatchPolicy.FILL):
-        _DaliBaseIterator.__init__(self, pipelines, size, reader_name, auto_reset,
-                                   fill_last_batch, last_batch_padded, last_batch_policy)
+                 last_batch_policy=LastBatchPolicy.FILL,
+                 prepare_first_batch=True):
+        _DaliBaseIterator.__init__(self,
+                                   pipelines,
+                                   size,
+                                   reader_name,
+                                   auto_reset,
+                                   fill_last_batch,
+                                   last_batch_padded,
+                                   last_batch_policy,
+                                   prepare_first_batch=prepare_first_batch)
 
     def next(self):
         """
@@ -189,6 +197,9 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
                 True next epoch would be the same length as the first one. For this to happen,
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
+    prepare_first_batch : bool, optional, default = True
+                Whether DALI should buffer the first batch right after the creation so when it is
+                prompted for the data have one batch already prepared
 
     Example
     -------
@@ -217,7 +228,8 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
                  squeeze_labels=True,
                  dynamic_shape=False,
                  last_batch_padded=False,
-                 last_batch_policy=LastBatchPolicy.FILL):
+                 last_batch_policy=LastBatchPolicy.FILL,
+                 prepare_first_batch=True):
 
         # check the assert first as _DaliBaseIterator would run the prefetch
         self._output_names_map = [x[0] for x in output_map]
@@ -229,14 +241,15 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
             "output_names in output_map should be distinct"
         self.output_map = output_map
 
-        super(DALIGenericIterator, self).__init__(
-            pipelines,
-            size,
-            reader_name,
-            fill_last_batch,
-            last_batch_padded,
-            auto_reset,
-            last_batch_policy)
+        _DALIMXNetIteratorBase.__init__(self,
+                                        pipelines,
+                                        size,
+                                        reader_name,
+                                        fill_last_batch,
+                                        last_batch_padded,
+                                        auto_reset,
+                                        last_batch_policy,
+                                        prepare_first_batch=prepare_first_batch)
         self._squeeze_labels = squeeze_labels
         self._dynamic_shape = dynamic_shape
         # Use double-buffering of data batches
@@ -244,25 +257,44 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
         self._current_data_batch = 0
 
         self._first_batch = None
-        try:
-            self._first_batch = DALIGenericIterator.__next__(self)
-        except StopIteration:
-            assert False, "It seems that there is no data in the pipeline. This may happen if `last_batch_policy` is set to PARTIAL and the requested batch size is greater than the shard size."
-        # Set data descriptors for MXNet
-        self.provide_data = []
-        self.provide_label = []
+        self._descriptors_populated = False
+        self._data_layout = data_layout
+        if self._prepare_first_batch:
+            try:
+                self._first_batch = DALIGenericIterator.__next__(self)
+            except StopIteration:
+                assert False, "It seems that there is no data in the pipeline. This may happen if `last_batch_policy` is set to PARTIAL and the requested batch size is greater than the shard size."
 
-        category_names = {key : [] for key in self._output_categories}
-        for name, category in output_map:
-            category_names[category].append(name)
-        for i, data in enumerate(self._first_batch[0].data):
-            data_shape  = (data.shape[0] * self._num_gpus,) + data.shape[1:]
-            self.provide_data.append(mx.io.DataDesc(category_names[DALIGenericIterator.DATA_TAG][i], \
-                data_shape, data.dtype, layout=data_layout))
-        for i, label in enumerate(self._first_batch[0].label):
-            label_shape = (label.shape[0] * self._num_gpus,) + label.shape[1:]
-            self.provide_label.append(mx.io.DataDesc(category_names[DALIGenericIterator.LABEL_TAG][i], \
-                label_shape, label.dtype))
+    def __getattr__(self, key):
+        if key == 'provide_data' or key == 'provide_label':
+            # obtain the first batch to populate the metadata
+            try:
+                self._first_batch = DALIGenericIterator.__next__(self)
+            except StopIteration:
+                assert False, "It seems that there is no data in the pipeline. This may happen if `last_batch_policy` is set to PARTIAL and the requested batch size is greater than the shard size."
+        raise AttributeError
+
+    def _populate_descriptors(self, data_batch):
+        # populate metadata
+        if not self._descriptors_populated:
+            provide_data = []
+            provide_label = []
+
+            category_names = {key : [] for key in self._output_categories}
+            for name, category in self.output_map:
+                category_names[category].append(name)
+            for i, data in enumerate(data_batch[0].data):
+                data_shape  = (data.shape[0] * self._num_gpus,) + data.shape[1:]
+                provide_data.append(mx.io.DataDesc(category_names[DALIGenericIterator.DATA_TAG][i], \
+                    data_shape, data.dtype, layout=self._data_layout))
+            for i, label in enumerate(data_batch[0].label):
+                label_shape = (label.shape[0] * self._num_gpus,) + label.shape[1:]
+                provide_label.append(mx.io.DataDesc(category_names[DALIGenericIterator.LABEL_TAG][i], \
+                    label_shape, label.dtype))
+
+            self.__dict__['provide_data'] = provide_data
+            self.__dict__['provide_label'] = provide_label
+            self._descriptors_populated = True
 
     def __next__(self):
         if self._first_batch is not None:
@@ -364,7 +396,9 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
                 for db in self._data_batches:
                     db[copy_db_index].pad = 0
 
-        return [db[copy_db_index] for db in self._data_batches]
+        batches = [db[copy_db_index] for db in self._data_batches]
+        self._populate_descriptors(batches)
+        return batches
 
     DATA_TAG = "data"
     LABEL_TAG = "label"
@@ -451,6 +485,9 @@ class DALIClassificationIterator(DALIGenericIterator):
                 True next epoch would be the same length as the first one. For this to happen,
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
+    prepare_first_batch : bool, optional, default = True
+                Whether DALI should buffer the first batch right after the creation so when it is
+                prompted for the data have one batch already prepared
 
     Example
     -------
@@ -480,7 +517,8 @@ class DALIClassificationIterator(DALIGenericIterator):
                  squeeze_labels=True,
                  dynamic_shape=False,
                  last_batch_padded=False,
-                 last_batch_policy=LastBatchPolicy.FILL):
+                 last_batch_policy=LastBatchPolicy.FILL,
+                 prepare_first_batch=True):
         super(DALIClassificationIterator, self).__init__(pipelines,
                                                          [(data_name, DALIClassificationIterator.DATA_TAG),
                                                           (label_name, DALIClassificationIterator.LABEL_TAG)],
@@ -492,7 +530,8 @@ class DALIClassificationIterator(DALIGenericIterator):
                                                          squeeze_labels=squeeze_labels,
                                                          dynamic_shape=dynamic_shape,
                                                          last_batch_padded = last_batch_padded,
-                                                         last_batch_policy = last_batch_policy)
+                                                         last_batch_policy = last_batch_policy,
+                                                         prepare_first_batch = prepare_first_batch)
 
 ###############################################
 ###############################################
@@ -586,6 +625,9 @@ class DALIGluonIterator(_DALIMXNetIteratorBase):
                 True next epoch would be the same length as the first one. For this to happen,
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
+    prepare_first_batch : bool, optional, default = True
+                Whether DALI should buffer the first batch right after the creation so when it is
+                prompted for the data have one batch already prepared
 
     Example
     -------
@@ -611,7 +653,8 @@ class DALIGluonIterator(_DALIMXNetIteratorBase):
                  auto_reset=False,
                  fill_last_batch=None,
                  last_batch_padded=False,
-                 last_batch_policy=LastBatchPolicy.FILL):
+                 last_batch_policy=LastBatchPolicy.FILL,
+                 prepare_first_batch=True):
 
         # check the assert first as _DaliBaseIterator would run the prefetch
         self._output_tags = {DALIGluonIterator.DENSE_TAG, DALIGluonIterator.SPARSE_TAG}
@@ -627,15 +670,17 @@ class DALIGluonIterator(_DALIMXNetIteratorBase):
             fill_last_batch,
             last_batch_padded,
             auto_reset,
-            last_batch_policy)
+            last_batch_policy,
+            prepare_first_batch = prepare_first_batch)
 
         self._data_batches = [None for i in range(self._num_gpus)]
 
         self._first_batch = None
-        try:
-            self._first_batch = self._first_batch = DALIGluonIterator.__next__(self)
-        except StopIteration:
-            assert False, "It seems that there is no data in the pipeline. This may happen if `last_batch_policy` is set to PARTIAL and the requested batch size is greater than the shard size."
+        if self._prepare_first_batch:
+            try:
+                self._first_batch = self._first_batch = DALIGluonIterator.__next__(self)
+            except StopIteration:
+                assert False, "It seems that there is no data in the pipeline. This may happen if `last_batch_policy` is set to PARTIAL and the requested batch size is greater than the shard size."
 
     def __next__(self):
         if self._first_batch is not None:

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -189,8 +189,8 @@ class DALIGenericIterator(_DaliBaseIterator):
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
-                Whether DALI should buffer the first batch right after the creation so when it is
-                prompted for the data have one batch already prepared
+                Whether DALI should buffer the first batch right after the creation of the iterator,
+                so when it is prompted for the data have one batch already prepared
 
     Example
     -------
@@ -448,8 +448,8 @@ class DALIClassificationIterator(DALIGenericIterator):
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
-                Whether DALI should buffer the first batch right after the creation so when it is
-                prompted for the data have one batch already prepared
+                Whether DALI should buffer the first batch right after the creation of the iterator,
+                so when it is prompted for the data have one batch already prepared
 
     Example
     -------

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -190,7 +190,7 @@ class DALIGenericIterator(_DaliBaseIterator):
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
                 Whether DALI should buffer the first batch right after the creation of the iterator,
-                so when it is prompted for the data have one batch already prepared
+                so one batch is already prepared when the iterator is prompted for the data
 
     Example
     -------
@@ -449,7 +449,7 @@ class DALIClassificationIterator(DALIGenericIterator):
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
                 Whether DALI should buffer the first batch right after the creation of the iterator,
-                so when it is prompted for the data have one batch already prepared
+                so one batch is already prepared when the iterator is prompted for the data
 
     Example
     -------

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -57,7 +57,7 @@ def to_paddle_type(tensor):
     return dtype_map[dtype]
 
 
-def feed_ndarray(dali_tensor, ptr, cuda_stream = None):
+def feed_ndarray(dali_tensor, ptr, cuda_stream=None):
     """
     Copy contents of DALI tensor to Paddle's Tensor.
 
@@ -76,7 +76,8 @@ def feed_ndarray(dali_tensor, ptr, cuda_stream = None):
 
     c_type_pointer = ctypes.c_void_p(ptr)
     if isinstance(dali_tensor, (TensorGPU, TensorListGPU)):
-        dali_tensor.copy_to_external(c_type_pointer, None if cuda_stream is None else ctypes.c_void_p(cuda_stream))
+        dali_tensor.copy_to_external(
+            c_type_pointer, None if cuda_stream is None else ctypes.c_void_p(cuda_stream))
     else:
         dali_tensor.copy_to_external(c_type_pointer)
     return ptr
@@ -187,6 +188,9 @@ class DALIGenericIterator(_DaliBaseIterator):
                 True next epoch would be the same length as the first one. For this to happen,
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
+    prepare_first_batch : bool, optional, default = True
+                Whether DALI should buffer the first batch right after the creation so when it is
+                prompted for the data have one batch already prepared
 
     Example
     -------
@@ -204,6 +208,7 @@ class DALIGenericIterator(_DaliBaseIterator):
 
     last_batch_policy = DROP, last_batch_padded = False  -> last batch = ``[5, 6]``, next iteration will return ``[2, 3]``
     """
+
     def __init__(self,
                  pipelines,
                  output_map,
@@ -213,7 +218,8 @@ class DALIGenericIterator(_DaliBaseIterator):
                  fill_last_batch=None,
                  dynamic_shape=False,
                  last_batch_padded=False,
-                 last_batch_policy=LastBatchPolicy.FILL):
+                 last_batch_policy=LastBatchPolicy.FILL,
+                 prepare_first_batch=True):
 
         normalized_map = {}
         for v in output_map:
@@ -229,7 +235,15 @@ class DALIGenericIterator(_DaliBaseIterator):
             "output_map names should be distinct"
         self.output_map = output_map
 
-        _DaliBaseIterator.__init__(self, pipelines, size, reader_name, auto_reset, fill_last_batch, last_batch_padded, last_batch_policy)
+        _DaliBaseIterator.__init__(self,
+                                   pipelines,
+                                   size,
+                                   reader_name,
+                                   auto_reset,
+                                   fill_last_batch,
+                                   last_batch_padded,
+                                   last_batch_policy,
+                                   prepare_first_batch=prepare_first_batch)
         self._dynamic_shape = dynamic_shape
 
         # Use double-buffering of data batches
@@ -237,10 +251,11 @@ class DALIGenericIterator(_DaliBaseIterator):
         self._counter = 0
 
         self._first_batch = None
-        try:
-            self._first_batch = DALIGenericIterator.__next__(self)
-        except StopIteration:
-            assert False, "It seems that there is no data in the pipeline. This may happen if `last_batch_policy` is set to PARTIAL and the requested batch size is greater than the shard size."
+        if self._prepare_first_batch:
+            try:
+                self._first_batch = DALIGenericIterator.__next__(self)
+            except StopIteration:
+                assert False, "It seems that there is no data in the pipeline. This may happen if `last_batch_policy` is set to PARTIAL and the requested batch size is greater than the shard size."
 
     def __next__(self):
         if self._first_batch is not None:
@@ -340,7 +355,7 @@ class DALIGenericIterator(_DaliBaseIterator):
                 # First calculate how much data is required to
                 # return exactly self._size entries.
                 diff = self._num_gpus * self.batch_size - (self._counter
-                                                        - self._size)
+                                                           - self._size)
                 # Figure out how many GPUs to grab from.
                 num_gpus_to_grab = int(math.ceil(diff / self.batch_size))
                 # Figure out how many results to grab from the last GPU
@@ -357,10 +372,12 @@ class DALIGenericIterator(_DaliBaseIterator):
                 output[-1] = output[-1].copy()
                 for cat in self.output_map:
                     lod_tensor = output[-1][cat]
-                    output[-1][cat] = lod_tensor_clip(lod_tensor, data_from_last_gpu)
+                    output[-1][cat] = lod_tensor_clip(
+                        lod_tensor, data_from_last_gpu)
                 return output
 
         return self._data_batches
+
 
 class DALIClassificationIterator(DALIGenericIterator):
     """
@@ -430,6 +447,9 @@ class DALIClassificationIterator(DALIGenericIterator):
                 True next epoch would be the same length as the first one. For this to happen,
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
+    prepare_first_batch : bool, optional, default = True
+                Whether DALI should buffer the first batch right after the creation so when it is
+                prompted for the data have one batch already prepared
 
     Example
     -------
@@ -447,6 +467,7 @@ class DALIClassificationIterator(DALIGenericIterator):
 
     last_batch_policy = DROP, last_batch_padded = False  -> last batch = ``[5, 6]``, next iteration will return ``[2, 3]``
     """
+
     def __init__(self,
                  pipelines,
                  size=-1,
@@ -455,11 +476,13 @@ class DALIClassificationIterator(DALIGenericIterator):
                  fill_last_batch=None,
                  dynamic_shape=False,
                  last_batch_padded=False,
-                 last_batch_policy=LastBatchPolicy.FILL):
+                 last_batch_policy=LastBatchPolicy.FILL,
+                 prepare_first_batch=True):
         super(DALIClassificationIterator, self).__init__(
             pipelines, ["data", "label"], size, reader_name=reader_name,
             auto_reset=auto_reset,
             fill_last_batch=fill_last_batch,
             dynamic_shape=dynamic_shape,
             last_batch_padded=last_batch_padded,
-            last_batch_policy=last_batch_policy)
+            last_batch_policy=last_batch_policy,
+            prepare_first_batch=prepare_first_batch)

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -127,8 +127,8 @@ class DALIGenericIterator(_DaliBaseIterator):
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
-                Whether DALI should buffer the first batch right after the creation so when it is
-                prompted for the data have one batch already prepared
+                Whether DALI should buffer the first batch right after the creation of the iterator,
+                so when it is prompted for the data have one batch already prepared
 
     Example
     -------
@@ -354,8 +354,8 @@ class DALIClassificationIterator(DALIGenericIterator):
                 the option `pad_last_batch` in the reader needs to be set to True as well.
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
-                Whether DALI should buffer the first batch right after the creation so when it is
-                prompted for the data have one batch already prepared
+                Whether DALI should buffer the first batch right after the creation of the iterator,
+                so when it is prompted for the data have one batch already prepared
 
     Example
     -------

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -128,7 +128,7 @@ class DALIGenericIterator(_DaliBaseIterator):
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
                 Whether DALI should buffer the first batch right after the creation of the iterator,
-                so when it is prompted for the data have one batch already prepared
+                so one batch is already prepared when the iterator is prompted for the data
 
     Example
     -------
@@ -355,7 +355,7 @@ class DALIClassificationIterator(DALIGenericIterator):
                 It is overwritten when `reader_name` argument is provided
     prepare_first_batch : bool, optional, default = True
                 Whether DALI should buffer the first batch right after the creation of the iterator,
-                so when it is prompted for the data have one batch already prepared
+                so one batch is already prepared when the iterator is prompted for the data
 
     Example
     -------

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -1202,6 +1202,53 @@ def test_mxnet_external_source_do_not_prepare():
     check_external_source_autoreset(MXNetIterator, [(
         "data", MXNetIterator.DATA_TAG)], to_np=lambda x: x.data[0].asnumpy(), prepare_first_batch=False)
 
+def check_mxnet_iterator_properties(prepare_ahead):
+    from nvidia.dali.plugin.mxnet import DALIGenericIterator as MXNetIterator
+    data_to_np = lambda x: x.data[0].asnumpy()
+    label_to_np = lambda x: x.label[0].asnumpy()
+    max_batch_size = 4
+    iter_limit = 4
+    runs = 3
+    test_data_shape = [2, 3, 4]
+    test_label_shape = [2, 7, 5]
+    i = 0
+    dataset = [[[np.random.randint(0, 255, size=test_data_shape, dtype=np.uint8)
+                 for _ in range(max_batch_size)], [np.random.randint(0, 255, size=test_label_shape, dtype=np.uint8)
+                 for _ in range(max_batch_size)]] for _ in range(iter_limit)]
+
+    def get_data():
+        nonlocal i
+        if i == iter_limit:
+            i = 0
+            raise StopIteration
+        out = dataset[i]
+        i += 1
+        return out
+
+    pipe = Pipeline(batch_size=max_batch_size, num_threads=1, device_id=0)
+    with pipe:
+        outs = fn.external_source(source=get_data, num_outputs=2)
+    pipe.set_outputs(*outs)
+
+    it = MXNetIterator([pipe], [("data", MXNetIterator.DATA_TAG), ("label", MXNetIterator.LABEL_TAG)],
+                       auto_reset=True, prepare_first_batch=prepare_ahead)
+    counter = 0
+    assert getattr(it, 'provide_data')[0].shape == tuple([max_batch_size] + test_data_shape)
+    assert getattr(it, 'provide_label')[0].shape == tuple([max_batch_size] + test_label_shape)
+    for _ in range(runs):
+        for j, data in enumerate(it):
+            assert ((data_to_np(data[0]) == np.stack(dataset[j][0])).all())
+            assert ((label_to_np(data[0]) == np.stack(dataset[j][1])).all())
+            assert getattr(it, 'provide_data')[0].shape == tuple([max_batch_size] + test_data_shape)
+            assert getattr(it, 'provide_label')[0].shape == tuple([max_batch_size] + test_label_shape)
+            counter += 1
+    assert counter == iter_limit * runs
+
+
+def test_mxnet_iterator_properties():
+    for prep in [True, False]:
+             yield check_mxnet_iterator_properties, prep
+
 
 def test_mxnet_external_source_variable_size_pass():
     from nvidia.dali.plugin.mxnet import DALIGenericIterator as MXNetIterator

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -1197,6 +1197,12 @@ def test_mxnet_external_source_autoreset():
         "data", MXNetIterator.DATA_TAG)], to_np=lambda x: x.data[0].asnumpy())
 
 
+def test_mxnet_external_source_do_not_prepare():
+    from nvidia.dali.plugin.mxnet import DALIGenericIterator as MXNetIterator
+    check_external_source_autoreset(MXNetIterator, [(
+        "data", MXNetIterator.DATA_TAG)], to_np=lambda x: x.data[0].asnumpy(), prepare_first_batch=False)
+
+
 def test_mxnet_external_source_variable_size_pass():
     from nvidia.dali.plugin.mxnet import DALIGenericIterator as MXNetIterator
     check_external_source_variable_size(MXNetIterator, [(
@@ -1244,6 +1250,12 @@ def test_gluon_external_source_autoreset():
     from nvidia.dali.plugin.mxnet import DALIGluonIterator as GluonIterator
     check_external_source_autoreset(GluonIterator, output_types=[
                                     GluonIterator.DENSE_TAG], to_np=lambda x: x[0].asnumpy())
+
+
+def test_gluon_external_source_do_not_prepare():
+    from nvidia.dali.plugin.mxnet import DALIGluonIterator as GluonIterator
+    check_external_source_autoreset(GluonIterator, output_types=[
+                                    GluonIterator.DENSE_TAG], to_np=lambda x: x[0].asnumpy(), prepare_first_batch=False)
 
 
 def test_gluon_external_source_variable_size_pass():
@@ -1295,6 +1307,12 @@ def test_pytorch_external_source_autoreset():
                                     "data"], to_np=lambda x: x["data"].numpy())
 
 
+def test_pytorch_external_source_do_not_prepare():
+    from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
+    check_external_source_autoreset(PyTorchIterator, output_map=[
+                                    "data"], to_np=lambda x: x["data"].numpy(), prepare_first_batch=False)
+
+
 def test_pytorch_external_source_variable_size_pass():
     from nvidia.dali.plugin.pytorch import DALIGenericIterator as PyTorchIterator
     check_external_source_variable_size(PyTorchIterator, output_map=[
@@ -1342,6 +1360,12 @@ def test_paddle_external_source_autoreset():
     from nvidia.dali.plugin.paddle import DALIGenericIterator as PaddleIterator
     check_external_source_autoreset(PaddleIterator, output_map=[
                                     "data"], to_np=lambda x: np.array(x["data"]))
+
+
+def test_paddle_external_source_do_not_prepare():
+    from nvidia.dali.plugin.paddle import DALIGenericIterator as PaddleIterator
+    check_external_source_autoreset(PaddleIterator, output_map=[
+                                    "data"], to_np=lambda x: np.array(x["data"]), prepare_first_batch=False)
 
 
 def test_paddle_external_source_variable_size_pass():


### PR DESCRIPTION
Make a preparation of the first batch during the iterator construction optional

- when the DALI FW iterator is created it automatically fetches a first batch of data and waits till it is ready. This PR makes it optional so multiple pipelines can be crated and fetch their first batch in parallel, and it blocks only when is prompted for the data
- makes `bytes_per_sample_hint` a vector in schema as it should be
- makes reader cache tensors not pinned

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It makes preparation of the first batch during the iterator construction optional
- Fixes wrong type of operator `bytes_per_sample_hint` argument (int -> vector<int>)
- Makes reader cache tensors not pinned as they should be

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     when the DALI FW iterator is created it automatically fetches the first batch of data and waits till it is ready. This PR makes it optional so multiple pipelines can be crated and fetch their first batch in parallel, and it blocks only when is prompted for the data
 - Affected modules and functionalities:
     FW iterators
     schema
 - Key points relevant for the review:
     NA
 - Validation and testing:
     tests are added
 - Documentation (including examples):
     updated description of the iterato

**JIRA TASK**: *[NA]*
