### PR TITLE
Expose names of Pipeline outputs in C API

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -418,9 +418,14 @@ size_t daliMaxDimTensors(daliPipelineHandle* pipe_handle, int n) {
   }
 }
 
-unsigned daliGetNumOutput(daliPipelineHandle* pipe_handle) {
+unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle) {
   dali::Pipeline *pipeline = reinterpret_cast<dali::Pipeline *>(pipe_handle->pipe);
   return pipeline->num_outputs();
+}
+
+const char *daliGetOutputName(daliPipelineHandle *pipe_handle, int id) {
+  auto *pipeline = reinterpret_cast<dali::Pipeline *>(pipe_handle->pipe);
+  return pipeline->output_name(id).c_str();
 }
 
 device_type_t daliGetOutputDevice(daliPipelineHandle *pipe_handle, int id) {

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -96,7 +96,7 @@ std::unique_ptr<Pipeline> GetTestPipeline(bool is_file_reader, const std::string
                            .AddArg("resize_x", output_size)
                            .AddArg("resize_y", output_size)
                            .AddInput(input_name, exec_device)
-                           .AddOutput("outputs", exec_device));
+                           .AddOutput(output_name, exec_device));
 
   std::vector<std::pair<std::string, std::string>> outputs = {{output_name, output_device}};
 

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -166,7 +166,7 @@ TYPED_TEST(CApiTest, GetOutputNameTest) {
                      prefetch_queue_depth, false);
 
   ASSERT_EQ(daliGetNumOutput(&handle), 1);
-  EXPECT_EQ(daliGetOutputName(&handle, 0), output_name.c_str());
+  EXPECT_STREQ(daliGetOutputName(&handle, 0), output_name.c_str());
 }
 
 

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -765,16 +765,20 @@ ReaderMeta Pipeline::GetReaderMeta(std::string name) {
   return meta;
 }
 
+const std::string &Pipeline::output_name(int id) const {
+  DALI_ENFORCE(built_, "\"Build()\" must be called prior to calling \"output_name()\".");
+  DALI_ENFORCE_VALID_INDEX(id, output_names_.size());
+  return output_names_[id].first;
+}
+
 const std::string &Pipeline::output_device(int id) const {
-  DALI_ENFORCE(built_,
-      "\"Build()\" must be called prior to calling \"output_device()\".");
+  DALI_ENFORCE(built_, "\"Build()\" must be called prior to calling \"output_device()\".");
   DALI_ENFORCE_VALID_INDEX(id, output_names_.size());
   return output_names_[id].second;
 }
 
 int Pipeline::num_outputs() const {
-  DALI_ENFORCE(built_,
-      "\"Build()\" must be called prior to calling \"num_outputs()\".");
+  DALI_ENFORCE(built_, "\"Build()\" must be called prior to calling \"num_outputs()\".");
   return output_names_.size();
 }
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -421,12 +421,19 @@ class DLL_PUBLIC Pipeline {
   /**
    * @brief Returns the GPU device number used by the pipeline
    */
-  DLL_PUBLIC inline int device_id() const { return device_id_; }
+  DLL_PUBLIC inline int device_id() const {
+    return device_id_;
+  }
 
-    /**
+  /**
    * @brief Returns number of outputs.
    */
   DLL_PUBLIC int num_outputs() const;
+
+  /**
+   * @brief Returns a string describing the name of the output specified by given id.
+   */
+  DLL_PUBLIC const std::string &output_name(int id) const;
 
   /**
    * @brief Returns a string describing the device type backing the output specified by given id.

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -336,6 +336,11 @@ DLL_PUBLIC size_t daliMaxDimTensors(daliPipelineHandle *pipe_handle, int n);
 DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle);
 
 /**
+ * @brief Returns a string indicating name of the output given by id
+ */
+DLL_PUBLIC const char *daliGetOutputName(daliPipelineHandle *pipe_handle, int id);
+
+/**
  * @brief Returns device_type_t indicating device backing pipeline output given by id
  */
 DLL_PUBLIC device_type_t daliGetOutputDevice(daliPipelineHandle *pipe_handle, int id);

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -336,7 +336,8 @@ DLL_PUBLIC size_t daliMaxDimTensors(daliPipelineHandle *pipe_handle, int n);
 DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle);
 
 /**
- * @brief Returns a string indicating name of the output given by id
+ * @brief Returns a string indicating name of the output given by id.
+ * @remark The returned pointer is invalidated after calling `daliDeletePipeline(pipe_handle)`.
  */
 DLL_PUBLIC const char *daliGetOutputName(daliPipelineHandle *pipe_handle, int id);
 


### PR DESCRIPTION
Signed-off-by: szalpal <mszolucha@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed because we need names of the outputs to map them in `dali_backend`

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     augment C API
 - Affected modules and functionalities:
     C API, `Pipeline` class
 - Key points relevant for the review:
     NA
 - Validation and testing:
     Yes
 - Documentation (including examples):
     Yes


**JIRA TASK**: *[Use DALI-XXXX or NA]*
