### PR TITLE
Make sure that OpenCV decoding fallback follows EXIF information handling

### DIFF
--- a/dali/image/generic_image.cc
+++ b/dali/image/generic_image.cc
@@ -30,7 +30,7 @@ GenericImage::DecodeImpl(DALIImageType image_type,
   // Decode image to tmp cv::Mat
   cv::Mat decoded_image = cv::imdecode(
     cv::Mat(1, length, CV_8UC1, (void *) (encoded_buffer)),         //NOLINT
-    IsColor(image_type) ? cv::IMREAD_COLOR : cv::IMREAD_GRAYSCALE);
+    IsColor(image_type) ? cv::IMREAD_COLOR : cv::IMREAD_GRAYSCALE | cv::IMREAD_IGNORE_ORIENTATION);
 
   int W = decoded_image.cols;
   int H = decoded_image.rows;

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -140,7 +140,10 @@ a dedicated hardware decoder.
 The output of the decoder is in *HWC* layout.
 
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
-Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.)code")
+Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.
+
+.. note::
+  EXIF orientation metadata is disregarded.)code")
   .AddOptionalArg("hw_decoder_load",
       R"code(The percentage of the image data to be processed by the HW JPEG decoder.
 
@@ -189,7 +192,10 @@ image format, it will decode the entire image and crop the selected ROI.
 The output of the decoder is in *HWC* layout.
 
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
-Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.)code")
+Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.
+
+.. note::
+  EXIF orientation metadata is disregarded.)code")
   .NumInput(1)
   .NumOutput(1)
   .AddParent("ImageDecoderAttr")
@@ -214,7 +220,10 @@ image format, it will decode the entire image and crop the selected ROI.
 The output of the decoder is in *HWC* layout.
 
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
-Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.)code")
+Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.
+
+.. note::
+  EXIF orientation metadata is disregarded.)code")
   .NumInput(1)
   .NumOutput(1)
   .AddParent("ImageDecoderAttr")
@@ -224,7 +233,7 @@ Please note that GPU acceleration for JPEG 2000 decoding is only available for C
 DALI_SCHEMA(ImageDecoderSlice)
   .DocStr(R"code(Decodes images and extracts regions of interest.
 
-The slice can be specified by proving the start and end coordinates, or start coordinates 
+The slice can be specified by proving the start and end coordinates, or start coordinates
 and shape of the slice. Both coordinates and shapes can be provided in absolute or relative terms.
 
 The slice arguments can be specified by the following named arguments:
@@ -264,7 +273,10 @@ image format, it will decode the entire image and crop the selected ROI.
 The output of the decoder is in the *HWC* layout.
 
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
-Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.)code")
+Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.
+
+.. note::
+  EXIF orientation metadata is disregarded.)code")
   .NumInput(1, 3)
   .NumOutput(1)
   .AddParent("ImageDecoderAttr")


### PR DESCRIPTION
- nvJPEG and libjpeg-turbo image decoding don't apply image rotation based on EXIF metadata. This PR makes sure that OpenCV fallback does the same to have a consistent behavior

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Makes sure that OpenCV decoding fallback follows EXIF information handling

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     nvJPEG and libjpeg-turbo image decoding don't apply image rotation based on EXIF metadata. This PR makes sure that OpenCV fallback does the same to have a consistent behavior
 - Affected modules and functionalities:
     generic_image
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current tests apply
 - Documentation (including examples):
     Docs updated


**JIRA TASK**: *[NA]*
