### PR TITLE
Move to CUDA 11.2 update 1

### DIFF
--- a/docker/Dockerfile.cuda112.aarch64.deps
+++ b/docker/Dockerfile.cuda112.aarch64.deps
@@ -4,7 +4,7 @@ FROM ${TOOLKIT_BASE_IMAGE} as cuda
 RUN apt update && apt install -y libxml2 curl perl gcc && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.2.0/local_installers/cuda_11.2.0_460.27.04_linux_sbsa.run && \
+RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux_sbsa.run && \
     chmod +x cuda_*.run && \
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;

--- a/docker/Dockerfile.cuda112.x86_64.deps
+++ b/docker/Dockerfile.cuda112.x86_64.deps
@@ -3,7 +3,7 @@ FROM ${TOOLKIT_BASE_IMAGE} as cuda
 
 RUN apt update && apt install -y libxml2 curl perl gcc
 
-RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.2.0/local_installers/cuda_11.2.0_460.27.04_linux.run && \
+RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run && \
     chmod +x cuda_*.run && \
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It moves to CUDA 11.2 update 1

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     move to CUDA 11.2 update 1
 - Affected modules and functionalities:
     build system
 - Key points relevant for the review:
     NA
 - Validation and testing:
     present test applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
