### PR TITLE
Fix cmake installation in TL1 tests for Ubuntu 20.04

### DIFF
--- a/qa/TL1_custom_cpp_lib/test.sh
+++ b/qa/TL1_custom_cpp_lib/test.sh
@@ -5,8 +5,8 @@ export THIS_PATH=`pwd`
 do_once() {
   apt-get update && apt-get -y install wget
   wget https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-Linux-x86_64.sh
-  bash cmake-3.18.4-Linux-x86_64.sh --skip-license --prefix=/
-  rm cmake-3.18.4-Linux-x86_64.sh
+  bash cmake-*.sh --skip-license --prefix=/usr
+  rm cmake-*.sh
 }
 
 test_body() {

--- a/qa/TL1_nodeps_build/test.sh
+++ b/qa/TL1_nodeps_build/test.sh
@@ -3,10 +3,10 @@
 pip_packages=""
 
 do_once() {
-    apt-get update && apt-get -y install wget wget
+    apt-get update && apt-get -y install wget
     wget https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-Linux-x86_64.sh
-    bash cmake-3.18.4-Linux-x86_64.sh --skip-license --prefix=/
-    rm cmake-3.18.4-Linux-x86_64.sh
+    bash cmake-*.sh --skip-license --prefix=/usr
+    rm cmake-*.sh
     # for stub generation
     pip install clang
     pip install libclang


### PR DESCRIPTION
- Ubuntu 20.04 uses a symlink from /usr/bin to /bin and cmake installation from *.sh file overwrites it making all programs mostly unusable. This PR moves installation location from / to /usr

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes cmake installation in TL1 tests for Ubuntu 20.04

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Ubuntu 20.04 uses a symlink from /usr/bin to /bin and cmake installation from *.sh file overwrites it making all programs mostly unusable. This PR moves installation location from / to /usr
 - Affected modules and functionalities:
     TL1_custom_cpp_lib and TL1_nodeps_build tests
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
