### PR TITLE
Fix apex compilation on Ubuntu 20.04 in TL1_ssd_training

### DIFF
--- a/qa/TL1_ssd_training/test.sh
+++ b/qa/TL1_ssd_training/test.sh
@@ -6,6 +6,7 @@ target_dir=./docs/examples/use_cases/pytorch/single_stage_detector/
 test_body() {
     # workaround due to errors while pycocotools is int "pip_packages" above
     pip install -I pycocotools
+    apt update && apt install -y gcc-7 g++-7
 
     #install APEX
     git clone https://github.com/nvidia/apex
@@ -13,6 +14,11 @@ test_body() {
     # get the lastest stable and tested APEX version
     git checkout 4ef930c1c884fdca5f472ab2ce7cb9b505d26c1a
     export CUDA_HOME=/usr/local/cuda-$(python -c "import torch; print('.'.join(torch.version.cuda.split('.')[0:2]))")
+    export CC=gcc-7
+    export CXX=g++-7
+    # this makes nvcc to use linked gcc-7 as a host compiler, not the default system one
+    ln -s $(which gcc-7) ${CUDA_HOME}/bin/gcc
+    ln -s $(which g++-7) ${CUDA_HOME}/bin/g++
     # build wheel first
     pip wheel -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" .
     # for some reason the `pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" .` doesn't install


### PR DESCRIPTION
- Ubuntu 20.04 has gcc-9 as a default compiler which is not supported by CUDA 10.0 used in the TL1_ssd_training test. Install gcc-7 in the test and set it as a one that should be used to build apex

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes apex compilation on Ubuntu 20.04 in TL1_ssd_training

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Ubuntu 20.04 has gcc-9 as a default compiler which is not supported by CUDA 10.0 used in the TL1_ssd_training test. Install gcc-7 in the test and set it as a one that should be used to build apex
 - Affected modules and functionalities:
     TL1_ssd_training 
 - Key points relevant for the review:
     NA
 - Validation and testing:
     present tests apply
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
