### PR TITLE
Fix wrong early exit in function inside bundle-wheel.sh

### DIFF
--- a/dali/python/bundle-wheel.sh
+++ b/dali/python/bundle-wheel.sh
@@ -125,7 +125,7 @@ copy_and_patch() {
 
     if [[ ! -f "$filepath" ]]; then
         echo "Didn't find $filename, skipping..."
-        continue
+        return
     fi
     patchedname=$(fname_with_sha256 $filepath)
     patchedpath=$PKGNAME_PATH/.libs/$patchedname

--- a/dali/test/python/test_pipeline_decorator.py
+++ b/dali/test/python/test_pipeline_decorator.py
@@ -21,9 +21,9 @@ import os
 data_root = get_dali_extra_path()
 images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
 
-N_ITER = 7
+N_ITER = 2
 
-max_batch_size = 16
+max_batch_size = 4
 num_threads = 4
 device_id = 0
 
@@ -32,7 +32,7 @@ def reference_pipeline(flip_vertical, flip_horizontal, ref_batch_size=max_batch_
     pipeline = Pipeline(ref_batch_size, num_threads, device_id)
     with pipeline:
         data, _ = fn.file_reader(file_root=images_dir)
-        img = fn.image_decoder(data, device="mixed")
+        img = fn.image_decoder(data)
         flipped = fn.flip(img, horizontal=flip_horizontal, vertical=flip_vertical)
         pipeline.set_outputs(flipped, img)
     return pipeline
@@ -42,7 +42,7 @@ def reference_pipeline(flip_vertical, flip_horizontal, ref_batch_size=max_batch_
 @pipeline_def(batch_size=max_batch_size, num_threads=num_threads, device_id=device_id)
 def pipeline_static(flip_vertical, flip_horizontal):
     data, _ = fn.file_reader(file_root=images_dir)
-    img = fn.image_decoder(data, device="mixed")
+    img = fn.image_decoder(data)
     flipped = fn.flip(img, horizontal=flip_horizontal, vertical=flip_vertical)
     return flipped, img
 
@@ -51,7 +51,7 @@ def pipeline_static(flip_vertical, flip_horizontal):
 @pipeline_def
 def pipeline_runtime(flip_vertical, flip_horizontal):
     data, _ = fn.file_reader(file_root=images_dir)
-    img = fn.image_decoder(data, device="mixed")
+    img = fn.image_decoder(data)
     flipped = fn.flip(img, horizontal=flip_horizontal, vertical=flip_vertical)
     return flipped, img
 
@@ -84,7 +84,7 @@ def test_pipeline_decorator():
         for hori in [0, 1]:
             yield test_pipeline_static, vert, hori
             yield test_pipeline_runtime, vert, hori
-            yield test_pipeline_override, vert, hori, 16
+            yield test_pipeline_override, vert, hori, 5
     yield test_pipeline_runtime, fn.random.coin_flip(seed=123), fn.random.coin_flip(seed=234)
     yield test_pipeline_static, fn.random.coin_flip(seed=123), fn.random.coin_flip(seed=234)
 


### PR DESCRIPTION
- continue statement was used as an early exit from a condition in the for a loop. When the body of the loop was moved to function is should be replaced by a return. Old bash complains about it while the newer is okay
- Mixed backend decoder is not supported in the Xavier platform so make it a cpu one in test_pipeline_decorator.py test. Also, shorten the test a bit

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes wrong early exit in function inside bundle-wheel.sh
- It makes test_pipeline_decorator.py not use Mixed decoder

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     continue statement was used as an early exit from a condition in the for a loop.
     test_pipeline_decorator.py not use mixed ImageDecoder not supported on Xavier platform
 - Affected modules and functionalities:
     bundle-wheel.sh
     test_pipeline_decorator.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
