### PR TITLE
Make DALI pipeline use default seed (-1) when None is set to seed

### DIFF
--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -129,7 +129,7 @@ Parameters
         if device_id is None:
             device_id = types.CPU_ONLY_DEVICE_ID
         self._device_id = device_id
-        self._seed = seed
+        self._seed = seed if seed is not None else -1
         self._exec_pipelined = exec_pipelined
         self._built = False
         self._first_iter = True

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -424,6 +424,19 @@ def test_seed():
             img_chw = img_chw_test
         assert(np.sum(np.abs(img_chw - img_chw_test)) == 0)
 
+def test_none_seed():
+    batch_size = 10
+    shape = (120, 60, 3)
+    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0, seed=None)
+    data = RandomDataIterator(batch_size, shape=shape, dtype=np.uint8)
+    with pipe:
+        input = fn.external_source(data, layout="HWC")
+        coin = fn.random.coin_flip(seed=None)
+        pipe.set_outputs(input, coin)
+    pipe.build()
+
+    result = pipe.run()
+
 def test_as_array():
     batch_size = 64
     class HybridPipe(Pipeline):

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -425,17 +425,20 @@ def test_seed():
         assert(np.sum(np.abs(img_chw - img_chw_test)) == 0)
 
 def test_none_seed():
-    batch_size = 10
-    shape = (120, 60, 3)
-    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0, seed=None)
-    data = RandomDataIterator(batch_size, shape=shape, dtype=np.uint8)
-    with pipe:
-        input = fn.external_source(data, layout="HWC")
-        coin = fn.random.coin_flip(seed=None)
-        pipe.set_outputs(input, coin)
-    pipe.build()
+    batch_size = 60
 
-    result = pipe.run()
+    for i in range(50):
+        pipe = Pipeline(batch_size=batch_size, num_threads=2, device_id=0, seed=None)
+        with pipe:
+            coin = fn.random.uniform(range = (0.0,1.0))
+        pipe.set_outputs(coin)
+        pipe.build()
+        pipe_out = pipe.run()[0]
+        img_chw_test = pipe_out.as_array()
+        if i == 0:
+            img_chw = img_chw_test
+        else:
+            assert(np.sum(np.abs(img_chw - img_chw_test)) != 0)
 
 def test_as_array():
     batch_size = 64

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -434,11 +434,11 @@ def test_none_seed():
         pipe.set_outputs(coin)
         pipe.build()
         pipe_out = pipe.run()[0]
-        img_chw_test = pipe_out.as_array()
+        test_out = pipe_out.as_array()
         if i == 0:
-            img_chw = img_chw_test
+            test_out_ref = test_out
         else:
-            assert(np.sum(np.abs(img_chw - img_chw_test)) != 0)
+            assert(np.sum(np.abs(test_out_ref - test_out)) != 0)
 
 def test_as_array():
     batch_size = 64


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It makes DALI pipeline use default seed (-1) when None is set to seed

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     allows passing None as a pipeline's seed and translate it internally to -1
 - Affected modules and functionalities:
     pipeline.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     new test is added
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
