### PR TITLE
Parallel random object BBox

### DIFF
--- a/dali/kernels/imgproc/structure/connected_components.h
+++ b/dali/kernels/imgproc/structure/connected_components.h
@@ -18,6 +18,8 @@
 #include <set>
 #include <stdexcept>
 #include <unordered_map>
+#include <unordered_set>
+#include <mutex>
 #include "dali/core/tensor_view.h"
 #include "dali/core/geom/vec.h"
 #include "dali/core/geom/box.h"
@@ -25,6 +27,8 @@
 #include "dali/kernels/common/disjoint_set.h"
 #include "dali/kernels/common/utils.h"
 #include "dali/kernels/kernel.h"
+#include "dali/core/exec/engine.h"
+#include "dali/core/spinlock.h"
 
 namespace dali {
 namespace kernels {
@@ -80,16 +84,17 @@ void LabelRow(OutLabel *label_base,
   }
 }
 
-template <typename OutLabel, typename InLabel>
+template <typename OutLabel, typename InLabel, typename ExecutionEngine>
 void LabelSlice(OutLabel *label_base,
                 TensorSlice<OutLabel, 1> out,
                 TensorSlice<const InLabel, 1> slice,
-                InLabel background) {
+                InLabel background,
+                ExecutionEngine &engine) {
   LabelRow(label_base, out.data, slice.data, slice.size[0], background);
 }
 
 /**
- * @brief Merges corresponding labels in out1 and out2 slices when the correspinding
+ * @brief Merges corresponding labels in out1 and out2 slices when the corresponding
  *        input labels match.
  *
  * @param label_base Start of the output tensor.
@@ -128,7 +133,7 @@ void MergeSlices(OutLabel *label_base,
 }
 
 /**
- * @brief Merges corresponding labels in out1 and out2 slices when the correspinding
+ * @brief Merges corresponding labels in out1 and out2 slices when the corresponding
  *        input labels match.
  *
  * @param label_base Start of the output tensor.
@@ -150,23 +155,75 @@ void MergeSlices(OutLabel *label_base,
 }
 
 template <typename OutLabel, typename InLabel, int ndim>
-void LabelSlice(OutLabel *label_base,
-                TensorSlice<OutLabel, ndim> out,
-                TensorSlice<const InLabel, ndim> in,
-                InLabel background) {
+enable_if_t<(ndim > 1)> LabelSlice(OutLabel *label_base,
+                                   TensorSlice<OutLabel, ndim> out,
+                                   TensorSlice<const InLabel, ndim> in,
+                                   InLabel background,
+                                   SequentialExecutionEngine &engine) {
   int64_t n = in.size[0];
   TensorSlice<OutLabel, ndim-1> prev_out;
   TensorSlice<const InLabel, ndim-1> prev_in;
   for (int64_t i = 0; i < n; i++) {
     auto out_slice = out.slice(i);
     auto in_slice = in.slice(i);
-    LabelSlice(label_base, out_slice, in_slice, background);
+    LabelSlice(label_base, out_slice, in_slice, background, engine);
 
     if (i > 0)
       MergeSlices(label_base, prev_out, out_slice, prev_in, in_slice);
 
     prev_out = out_slice;
     prev_in  = in_slice;
+  }
+}
+
+template <typename OutLabel, typename InLabel, int ndim, typename ExecutionEngine>
+void LabelSlice(OutLabel *label_base,
+                TensorSlice<OutLabel, ndim> out,
+                TensorSlice<const InLabel, ndim> in,
+                InLabel background,
+                ExecutionEngine &engine) {
+  int64_t n = in.size[0];
+
+  constexpr int kMinParallelInner = 1000;
+  if (n < 3 || volume(sub<ndim-1>(in.size, 1)) < kMinParallelInner) {
+    TensorSlice<OutLabel, ndim-1> prev_out;
+    TensorSlice<const InLabel, ndim-1> prev_in;
+    for (int64_t i = 0; i < n; i++) {
+      auto out_slice = out.slice(i);
+      auto in_slice = in.slice(i);
+      LabelSlice(label_base, out_slice, in_slice, background, engine);
+
+      if (i > 0)
+        MergeSlices(label_base, prev_out, out_slice, prev_in, in_slice);
+
+      prev_out = out_slice;
+      prev_in  = in_slice;
+    }
+    return;
+  }
+
+  SequentialExecutionEngine seq_engn;
+
+  for (int64_t i = 0; i < n; i++) {
+    auto out_slice = out.slice(i);
+    auto in_slice = in.slice(i);
+    engine.AddWork([=, &seq_engn](int){
+      LabelSlice(label_base, out_slice, in_slice, background, seq_engn);
+    });
+  }
+  engine.RunAll();
+
+  for (int64_t stride = 1; stride <= n; stride *= 2) {
+    for (int64_t i = stride; i < n; i += 2*stride) {
+      auto out_slice = out.slice(i);
+      auto in_slice = in.slice(i);
+      auto prev_out = out.slice(i-1);
+      auto prev_in = in.slice(i-1);
+      engine.AddWork([=](int){
+        MergeSlices(label_base, prev_out, out_slice, prev_in, in_slice);
+      });
+    }
+    engine.RunAll();
   }
 }
 
@@ -178,6 +235,20 @@ auto FullTensorSlice(const TensorView<StorageCPU, T, ndim> &tensor) {
     slice.size[i] = tensor.shape[i];
   CalcStrides(slice.stride, slice.size);
   return slice;
+}
+
+template <typename OutLabel, typename LabelMapping>
+void RemapChunk(span<OutLabel> chunk, const LabelMapping &mapping) {
+  assert(!chunk.empty());
+  OutLabel prev = chunk[0];
+  OutLabel remapped = mapping.find(prev)->second;
+  for (auto &label : chunk) {
+    if (label != prev) {
+      prev = label;
+      remapped = mapping.find(prev)->second;
+    }
+    label = remapped;
+  }
 }
 
 /**
@@ -192,13 +263,18 @@ auto FullTensorSlice(const TensorView<StorageCPU, T, ndim> &tensor) {
  * @param bg_label  The output label assigned to background.
  * @return Number of distinct non-background labels.
  */
-template <typename OutLabel>
-int64_t CompactLabels(OutLabel *labels, int64_t volume, OutLabel bg_label = 0) {
+template <typename OutLabel, typename ExecutionEngine>
+int64_t CompactLabels(OutLabel *labels,
+                      int64_t volume,
+                      ExecutionEngine &engine,
+                      OutLabel bg_label = 0) {
   constexpr OutLabel old_bg_label = static_cast<OutLabel>(-1);
   OutLabel curr_label = 1;
-  std::set<OutLabel> label_set;
   std::unordered_map<OutLabel, OutLabel> label_map;
   disjoint_set<OutLabel, OutLabel> ds;
+
+  const int64_t chunk_size = 16<<10;
+  int num_chunks = std::min<int>(div_ceil(volume, chunk_size), engine.size());
 
   // Optimized label compaction algorithm:
   //
@@ -207,13 +283,60 @@ int64_t CompactLabels(OutLabel *labels, int64_t volume, OutLabel bg_label = 0) {
   // can't call ds.find, because we're overwriting the labels array and the disjoint set
   // structure is effectively corrupted.
 
-  OutLabel prev = old_bg_label;
-  for (int64_t i = 0; i < volume; i++) {
-    if (labels[i] != old_bg_label && labels[i] != prev) {
-      // look up `ds` only when the value changes - this saves a lot of lookups
-      label_set.insert(ds.find(labels, i));
-      prev = labels[i];
+  std::set<OutLabel> label_set;
+
+  if (num_chunks == 1) {
+    std::unordered_set<OutLabel> tmp_set;
+    OutLabel prev = old_bg_label;
+    OutLabel remapped = old_bg_label;
+    for (int64_t i = 0; i < volume; i++) {
+      if (labels[i] != old_bg_label) {
+        if (labels[i] != prev) {
+          prev = labels[i];
+          // look up `ds` only when the value changes - this saves a lot of lookups
+          remapped = ds.find(labels, i);
+          tmp_set.insert(remapped);
+        } else {
+          labels[i] = remapped;
+        }
+      }
     }
+    for (auto l : tmp_set)
+      label_set.insert(l);
+  } else {
+    SmallVector<std::unordered_set<OutLabel>, 16> tmp_sets;
+    tmp_sets.resize(engine.size());
+    spinlock lock;
+    for (int chunk = 0; chunk < num_chunks; chunk++) {
+      int64_t chunk_start = volume * chunk / num_chunks;
+      int64_t chunk_end = volume * (chunk + 1) / num_chunks;
+
+      engine.AddWork([=, &tmp_sets, &lock](int thread) {
+        OutLabel prev = old_bg_label;
+        OutLabel remapped = old_bg_label;
+        for (int64_t i = chunk_start; i < chunk_end; i++) {
+          OutLabel curr = labels[i];
+          if (curr != old_bg_label) {
+            if (curr != prev) {
+              {
+                std::lock_guard<spinlock> g(lock);
+                prev = curr;
+                // look up `ds` only when the value changes - this saves a lot of lookups
+                remapped = ds.find(labels, i);
+              }
+              tmp_sets[thread].insert(remapped);
+            } else {
+              labels[i] = remapped;
+            }
+          }
+        }
+      });
+    }
+    engine.RunAll();
+
+    for (auto &tmp_set : tmp_sets)
+      for (OutLabel l : tmp_set)
+        label_set.insert(l);
   }
 
   OutLabel next_label = 0;
@@ -222,25 +345,27 @@ int64_t CompactLabels(OutLabel *labels, int64_t volume, OutLabel bg_label = 0) {
       next_label++;
     label_map[old] = next_label++;
   }
+  label_map[old_bg_label] = bg_label;
 
-  prev = old_bg_label;
-  OutLabel remapped = 0;
-  for (int64_t i = 0; i < volume; i++) {
-    if (labels[i] != old_bg_label) {
-      if (labels[i] != prev) {
-        // We can't call ds.find, because the beginning of the labels array is overwritten
-        // - but we don't have to, because we've already done that in the previous pass.
-        auto it = label_map.find(labels[i]);
-        assert(it != label_map.end());
-        remapped = it->second;
-        prev = labels[i];
-      }
-      labels[i] = remapped;
-    } else {
-      labels[i] = bg_label;
-    }
+  OutLabel prev = old_bg_label;
+
+  for (int chunk = 0; chunk < num_chunks; chunk++) {
+    int64_t chunk_start = volume * chunk / num_chunks;
+    int64_t chunk_end = volume * (chunk + 1) / num_chunks;
+    engine.AddWork([=, &label_map](int) {
+      RemapChunk(make_span(labels + chunk_start, chunk_end - chunk_start), label_map);
+    });
   }
+  engine.RunAll();
   return label_set.size();
+}
+
+template <typename OutLabel>
+int64_t CompactLabels(OutLabel *labels,
+                      int64_t volume,
+                      OutLabel bg_label = 0) {
+  SequentialExecutionEngine engine;
+  return CompactLabels(labels, volume, engine, bg_label);
 }
 
 /**
@@ -259,15 +384,16 @@ int64_t CompactLabels(OutLabel *labels, int64_t volume, OutLabel bg_label = 0) {
  *
  * @return Number of non-background connected detected.
  */
-template <typename OutLabel, typename InLabel, int ndim>
+template <typename OutLabel, typename InLabel, int ndim, typename ExecutionEngine>
 int64_t LabelConnectedRegionsImpl(const OutTensorCPU<OutLabel, ndim> &out,
                                   const InTensorCPU<InLabel, ndim> &in,
+                                  ExecutionEngine &engine,
                                   same_as_t<OutLabel> background_out = 0,
                                   same_as_t<InLabel> background_in = 0) {
   auto out_slice = detail::FullTensorSlice(out);
   auto in_slice = detail::FullTensorSlice(in);
-  detail::LabelSlice(out.data, out_slice, in_slice, background_in);
-  return detail::CompactLabels(out.data, out.num_elements(), background_out);
+  detail::LabelSlice(out.data, out_slice, in_slice, background_in, engine);
+  return detail::CompactLabels(out.data, out.num_elements(), engine, background_out);
 }
 
 }  // namespace detail
@@ -283,14 +409,16 @@ int64_t LabelConnectedRegionsImpl(const OutTensorCPU<OutLabel, ndim> &out,
  *
  * @param out Tensor where each connected object is assigned a unique label
  * @param in  Tensor with objects, where one label value may be used to mark multiple objects
+ * @param engine  Execution engine for deferred execution (e.g. ThreadPool)
  * @param background_out Value in the output which will be set for background pixels
  * @param background_in  Value in the input which denotes background pixels
  *
  * @return Number of non-background connected detected.
  */
-template <typename OutLabel, typename InLabel, int ndim>
+template <typename OutLabel, typename InLabel, int ndim, typename ExecutionEngine>
 int64_t LabelConnectedRegions(const OutTensorCPU<OutLabel, ndim> &out,
                               const InTensorCPU<InLabel, ndim> &in,
+                              ExecutionEngine &engine,
                               same_as_t<OutLabel> background_out = 0,
                               same_as_t<InLabel> background_in = 0) {
   assert(out.shape == in.shape);
@@ -314,7 +442,7 @@ int64_t LabelConnectedRegions(const OutTensorCPU<OutLabel, ndim> &out,
       TensorShape<simplified_ndim> sh = simplified.to_static<simplified_ndim>();
       auto s_out = make_tensor_cpu(out.data, sh);
       auto s_in  = make_tensor_cpu(in.data, sh);
-      ret = detail::LabelConnectedRegionsImpl(s_out, s_in, background_out, background_in);
+      ret = detail::LabelConnectedRegionsImpl(s_out, s_in, engine, background_out, background_in);
     ), (  // NOLINT
       throw std::invalid_argument(make_string(
           "Unsupported number of non-degenerate dimensions: ", simplified.size(),
@@ -322,6 +450,15 @@ int64_t LabelConnectedRegions(const OutTensorCPU<OutLabel, ndim> &out,
     )     // NOLINT
   );      // NOLINT
   return ret;
+}
+
+template <typename OutLabel, typename InLabel, int ndim>
+int64_t LabelConnectedRegions(const OutTensorCPU<OutLabel, ndim> &out,
+                              const InTensorCPU<InLabel, ndim> &in,
+                              same_as_t<OutLabel> background_out = 0,
+                              same_as_t<InLabel> background_in = 0) {
+  SequentialExecutionEngine engine;
+  return LabelConnectedRegions(out, in, engine, background_out, background_in);
 }
 
 }  // namespace connected_components

--- a/dali/kernels/imgproc/structure/connected_components.h
+++ b/dali/kernels/imgproc/structure/connected_components.h
@@ -296,6 +296,7 @@ int64_t CompactLabels(OutLabel *labels,
           prev = labels[i];
           // look up `ds` only when the value changes - this saves a lot of lookups
           remapped = ds.find(labels, i);
+          // no need to assign labels[i] = remapped; find did it
           tmp_set.insert(remapped);
         } else {
           labels[i] = remapped;

--- a/dali/kernels/imgproc/structure/label_bbox.h
+++ b/dali/kernels/imgproc/structure/label_bbox.h
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <limits>
 #include <type_traits>
+#include "dali/core/exec/engine.h"
 #include "dali/core/geom/box.h"
 #include "dali/core/span.h"
 #include "dali/kernels/imgproc/structure/connected_components.h"
@@ -112,8 +113,8 @@ void GetLabelBoundingBoxes(span<Box<ndim, Coord>> boxes,
         continue;
       }
       if (mask & 1) {  // label found? mark it
-        lo[d] = ranges[i].lo;
-        hi[d] = next<Coord>(ranges[i].hi);  // one past the index found in this function
+        lo[d] = ranges[i].lo + pos[d];
+        hi[d] = next<Coord>(ranges[i].hi + pos[d]);  // one past the index found in this function
         if (boxes[i].empty()) {
           // empty box - create a new one
           boxes[i] = { lo, hi };
@@ -147,12 +148,110 @@ void GetLabelBoundingBoxes(span<Box<ndim, Coord>> boxes,
                            TensorSlice<const Label, remaining_dims> in,
                            ivec<simplified_ndim> dim_mapping,
                            Label background,
-                           i64vec<ndim> pos = {}) {
+                           i64vec<ndim> pos) {
   int64_t n = in.size[0];
   int d = dim_mapping[simplified_ndim - remaining_dims];
-  for (int64_t i = 0; i < n; i++) {
-    pos[d] = i;
+  for (int64_t i = 0, p = pos[d]; i < n; i++, p++) {
+    pos[d] = p;
     GetLabelBoundingBoxes(boxes, ranges, hits, in.slice(i), dim_mapping, background, pos);
+  }
+}
+
+
+/**
+ * @brief Calculates a bounding box for each lablel in `in`
+ *
+ * @param boxes     output bounding boxes; labels whose box index is outside of valid range of
+ *                  indices in `boxes` are ignored; box index for a label is calculaed as:
+ *                  label > background ? label-1 : label
+ * @param in        input tensor containing zero-based labels
+ * @param backgroun the label value interpreted as a background; it doesn't have its corresponding
+ *                  bounding box
+ * @param engine    thread-pool-like object
+ */
+template <typename Coord, typename Label, int simplified_ndim, int ndim,
+          int remaining_dims>
+void GetLabelBoundingBoxes(span<Box<ndim, Coord>> boxes,
+                           TensorSlice<const Label, remaining_dims> in,
+                           ivec<simplified_ndim> dim_mapping,
+                           Label background,
+                           i64vec<ndim> pos) {
+  SmallVector<detail::Range, 16> ranges;
+  SmallVector<uint32_t, 4> hits;
+  ranges.resize(boxes.size());
+  hits.resize(div_ceil(boxes.size(), 32));
+  GetLabelBoundingBoxes(boxes, make_span(ranges), make_span(hits),
+                        in, dim_mapping, background, pos);
+}
+
+/**
+ * @brief Calculates a bounding box for each lablel in `in`
+ *
+ * @param boxes     output bounding boxes; labels whose box index is outside of valid range of
+ *                  indices in `boxes` are ignored; box index for a label is calculaed as:
+ *                  label > background ? label-1 : label
+ * @param in        input tensor containing zero-based labels
+ * @param backgroun the label value interpreted as a background; it doesn't have its corresponding
+ *                  bounding box
+ * @param engine    thread-pool-like object
+ */
+template <typename Coord, typename Label, int simplified_ndim, int ndim,
+          int remaining_dims, typename ExecutionEngine>
+void GetLabelBoundingBoxes(span<Box<ndim, Coord>> boxes,
+                           TensorSlice<const Label, remaining_dims> in,
+                           ivec<simplified_ndim> dim_mapping,
+                           Label background,
+                           ExecutionEngine &engine) {
+  const int64_t min_parallel_elements = 1<<16;
+  if (engine.size() == 1 || in.size[0] * in.stride[0] < min_parallel_elements) {
+    GetLabelBoundingBoxes(boxes, in, dim_mapping, background, {});
+    return;
+  }
+  SmallVector<Box<ndim, Coord>, 64> tmp_boxes;
+  int max_d = -1;
+  int64_t max_result = 0;
+  for (int d = 0; d < simplified_ndim; d++) {
+    int mul = d == simplified_ndim - 1 ? 1 : 2;  // it's less efficient to slice last dim
+    int64_t result = in.size[d] * mul;
+    if (result > max_result) {
+      max_d = d;
+      max_result = result;
+    }
+  }
+  int num_chunks = std::min<int64_t>(in.size[max_d], engine.size());
+  tmp_boxes.resize(boxes.size() * (num_chunks - 1));
+  int64_t stride = in.stride[max_d];
+  TensorSlice<const Label, remaining_dims> part = in;
+  for (int i = 0; i < num_chunks; i++) {
+    int64_t start = in.size[max_d] * i / num_chunks;
+    int64_t end = in.size[max_d] * (i + 1) / num_chunks;
+    span<Box<ndim, Coord>> part_boxes;
+    if (i == 0)
+      part_boxes = boxes;  // store 1st chunk directly
+    else
+      part_boxes = make_span(&tmp_boxes[(i - 1)*boxes.size()], boxes.size());
+    part.size[max_d] = end - start;
+    part.data = in.data + start * stride;
+    engine.AddWork([=](int) {
+      i64vec<ndim> pos = {};
+      pos[dim_mapping[max_d]] = start;
+      GetLabelBoundingBoxes(part_boxes, part, dim_mapping, background, pos);
+    });
+  }
+  engine.RunAll();
+  // BBox reduction
+  for (int i = 1; i < num_chunks; i++) {
+    auto part_boxes = make_span(&tmp_boxes[(i - 1)*boxes.size()], boxes.size());
+    for (int j = 0; j < boxes.size(); j++) {
+      if (part_boxes[j].empty())
+        continue;
+      if (boxes[j].empty()) {
+        boxes[j] = part_boxes[j];
+      } else {
+        boxes[j].lo = min(boxes[j].lo, part_boxes[j].lo);
+        boxes[j].hi = max(boxes[j].hi, part_boxes[j].hi);
+      }
+    }
   }
 }
 
@@ -167,18 +266,16 @@ void GetLabelBoundingBoxes(span<Box<ndim, Coord>> boxes,
  * @param in        input tensor containing zero-based labels
  * @param backgroun the label value interpreted as a background; it doesn't have its corresponding
  *                  bounding box
+ * @param engine    thread-pool-like object
  */
-template <typename Coord, typename Label, int ndim>
+template <typename Coord, typename Label, int ndim, typename ExecutionEngine>
 void GetLabelBoundingBoxes(span<Box<ndim, Coord>> boxes,
                            const TensorView<StorageCPU, Label, ndim> &in,
-                           std::remove_const_t<Label> background) {
+                           std::remove_const_t<Label> background,
+                           ExecutionEngine &engine) {
   std::fill(boxes.begin(), boxes.end(), Box<ndim, Coord>{});
   if (in.num_elements() == 0)
     return;
-  SmallVector<detail::Range, 16> ranges;
-  SmallVector<uint32_t, 4> hits;
-  ranges.resize(boxes.size());
-  hits.resize(div_ceil(boxes.size(), 32));
   TensorShape<> simplified_shape;
   SmallVector<int, 6> dim_mapping;
   for (int d = 0; d < ndim; d++) {
@@ -200,13 +297,20 @@ void GetLabelBoundingBoxes(span<Box<ndim, Coord>> boxes,
       coord_vec[d] = dim_mapping[d];
     auto simplified_in = make_tensor_cpu<simplified_ndim, const Label>(
       in.data, simplified_shape.to_static<simplified_ndim>());
-    GetLabelBoundingBoxes<Coord, std::remove_const_t<Label>>(
-        boxes, make_span(ranges), make_span(hits),
-        detail::FullTensorSlice(simplified_in), coord_vec,
-        background);
+    detail::GetLabelBoundingBoxes<Coord, std::remove_const_t<Label>>(
+        boxes, detail::FullTensorSlice(simplified_in), coord_vec,
+        background, engine);
   ), (   // NOLINT
     throw std::invalid_argument("Only up to 6 non-degenerate dimensions are supported")
   ));  // NOLINT
+}
+
+template <typename Coord, typename Label, int ndim>
+void GetLabelBoundingBoxes(span<Box<ndim, Coord>> boxes,
+                           const TensorView<StorageCPU, Label, ndim> &in,
+                           std::remove_const_t<Label> background) {
+  SequentialExecutionEngine seq_engn;
+  GetLabelBoundingBoxes(boxes, in, background, seq_engn);
 }
 
 }  // namespace label_bbox

--- a/dali/kernels/imgproc/structure/label_bbox.h
+++ b/dali/kernels/imgproc/structure/label_bbox.h
@@ -158,8 +158,7 @@ void GetLabelBoundingBoxes(span<Box<ndim, Coord>> boxes,
                            i64vec<ndim> origin) {
   int64_t n = in.size[0];
   int d = dim_mapping[simplified_ndim - remaining_dims];
-  for (int64_t i = 0, p = origin[d]; i < n; i++, p++) {
-    origin[d] = p;
+  for (int64_t i = 0; i < n; i++, origin[d]++) {
     GetLabelBoundingBoxes(boxes, ranges, hits, in.slice(i), dim_mapping, background, origin);
   }
 }

--- a/dali/kernels/imgproc/structure/label_bbox.h
+++ b/dali/kernels/imgproc/structure/label_bbox.h
@@ -203,7 +203,7 @@ void GetLabelBoundingBoxes(span<Box<ndim, Coord>> boxes,
                            Label background,
                            ExecutionEngine &engine) {
   const int64_t min_parallel_elements = 1<<16;
-  if (engine.size() == 1 || in.size[0] * in.stride[0] < min_parallel_elements) {
+  if (engine.NumThreads() == 1 || in.size[0] * in.stride[0] < min_parallel_elements) {
     GetLabelBoundingBoxes(boxes, in, dim_mapping, background, {});
     return;
   }
@@ -218,7 +218,7 @@ void GetLabelBoundingBoxes(span<Box<ndim, Coord>> boxes,
       max_result = result;
     }
   }
-  int num_chunks = std::min<int64_t>(in.size[max_d], engine.size());
+  int num_chunks = std::min<int64_t>(in.size[max_d], engine.NumThreads());
   tmp_boxes.resize(boxes.size() * (num_chunks - 1));
   int64_t stride = in.stride[max_d];
   TensorSlice<const Label, remaining_dims> part = in;

--- a/dali/operators/segmentation/random_object_bbox.cc
+++ b/dali/operators/segmentation/random_object_bbox.cc
@@ -148,8 +148,10 @@ void RandomObjectBBox::AcquireArgs(const HostWorkspace &ws, int N, int ndim) {
 
 #define INPUT_TYPES (bool, uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t)
 
+namespace detail {
+
 template <typename T>
-void RandomObjectBBox::FindLabels(std::unordered_set<int> &labels, const T *data, int64_t N) {
+void FindLabels(std::unordered_set<int> &labels, const T *data, int64_t N) {
   if (!N)
     return;
   T prev = data[0];
@@ -162,34 +164,36 @@ void RandomObjectBBox::FindLabels(std::unordered_set<int> &labels, const T *data
   }
 }
 
+}  // namespace detail
 
-template <typename BlobLabel, typename T>
-void RandomObjectBBox::FindLabels(SampleContext<BlobLabel> &ctx,
-                                  const TensorView<StorageCPU, const T> &in) {
-  ctx.labels.clear();
+template <typename BlobLabel>
+template <typename T>
+void RandomObjectBBox::SampleContext<BlobLabel>::FindLabels(const InTensorCPU<T> &in) {
+  labels.clear();
   int64_t N = in.num_elements();
   if (!N)
     return;
 
-  constexpr int64_t chunk_size = 1<<16;
-  int num_chunks = std::min<int>(2*ctx.thread_pool->NumThreads(), div_ceil(N, chunk_size));
+  constexpr int64_t min_chunk_size = 1<<16;
+  int num_chunks = std::min<int>(2*thread_pool->NumThreads(), div_ceil(N, min_chunk_size));
   const T *data = in.data;
 
-  ctx.tmp_labels.resize(num_chunks);
+  tmp_labels.resize(num_chunks);
 
   for (int i = 0; i < num_chunks; i++) {
     int64_t start = N * i / num_chunks;
     int64_t end = N * (i + 1)  / num_chunks;
-    ctx.thread_pool->AddWork([=, &ctx](int) {
-      auto &lbl = ctx.tmp_labels[i];
+    thread_pool->AddWork([=](int) {
+      auto &lbl = tmp_labels[i];
       lbl.clear();
-      FindLabels(lbl, data + start, end - start);
+      detail::FindLabels(lbl, data + start, end - start);
     });
   }
-  ctx.thread_pool->RunAll();
-  for (auto &tmp : ctx.tmp_labels) {
+  thread_pool->RunAll();
+
+  for (auto &tmp : tmp_labels) {
     for (auto l : tmp)
-      ctx.labels.insert(l);
+      labels.insert(l);
   }
 }
 
@@ -206,8 +210,8 @@ void FilterByLabel(ThreadPool *tp,
                    const OutTensorCPU<Out> &out, const InTensorCPU<In> &in, same_as_t<In> label) {
   assert(out.shape == in.shape);
   int64_t N = in.num_elements();
-  const int64_t chunk_size = 1<<16;
-  int num_chunks = std::min<int>(tp->NumThreads(), div_ceil(N, chunk_size));
+  const int64_t min_chunk_size = 1<<16;
+  int num_chunks = std::min<int>(tp->NumThreads(), div_ceil(N, min_chunk_size));
   if (num_chunks == 1) {
     FilterByLabel(out.data, in.data, N, label);
   } else {
@@ -265,17 +269,16 @@ void StoreBox(const OutListCPU<int, 1> &out1,
   StoreBox(out1, out2, format, sample_idx, box.lo, box.hi);
 }
 
-void RandomObjectBBox::GetBgFgAndWeights(
-      ClassVec &classes, WeightVec &weights, int &background, int sample_idx) {
-  background = background_[sample_idx].data[0];
-  if (ignore_class_)
-    return;  // we don't care about classes at all
+void RandomObjectBBox::ClassInfo::Init(const int *bg_ptr,
+                                       const InTensorCPU<int, 1> &cls_tv,
+                                       const InTensorCPU<float, 1> &weight_tv) {
+  Reset();
+  background = bg_ptr ? *bg_ptr : 0;
 
-  if (classes_.IsDefined()) {
-    const auto &cls_tv = classes_[sample_idx];
+  if (cls_tv.data) {
     int ncls = cls_tv.shape[0];
     classes.resize(ncls);
-    if (!weights_.IsDefined()) {
+    if (!cls_tv.data) {
       weights.clear();
       weights.resize(ncls, 1.0f);
     }
@@ -288,7 +291,7 @@ void RandomObjectBBox::GetBgFgAndWeights(
         min_class_label = classes[i];
 
       if (classes[i] == background) {
-        if (background_.IsDefined()) {
+        if (bg_ptr) {
           // Background was explicitly specified this way - that's an error
           DALI_FAIL(make_string("Class label ", classes[i],
             " coincides with background label - please specify a different background label or "
@@ -314,13 +317,12 @@ void RandomObjectBBox::GetBgFgAndWeights(
       }
     }
   }
-  if (weights_.IsDefined()) {
-    const auto &cls_tv = weights_[sample_idx];
-    int ncls = cls_tv.shape[0];
+  if (weight_tv.data) {
+    int ncls = weight_tv.shape[0];
     weights.resize(ncls);
     for (int i = 0; i < ncls; i++)
-      weights[i] = cls_tv.data[i];
-    if (!classes_.IsDefined()) {
+      weights[i] = weight_tv.data[i];
+    if (!cls_tv.data) {
       classes.resize(ncls);
       int cls = 0;
       for (int i = 0; i < ncls; i++, cls++) {
@@ -330,6 +332,15 @@ void RandomObjectBBox::GetBgFgAndWeights(
       }
     }
   }
+}
+
+void RandomObjectBBox::InitClassInfo(int sample_idx) {
+  const int *bg = background_.IsDefined() ? background_[sample_idx].data : nullptr;
+  InTensorCPU<int, 1> class_tv;
+  InTensorCPU<float, 1> weight_tv;
+  if (classes_.IsDefined() && !ignore_class_) class_tv  = classes_[sample_idx];
+  if (weights_.IsDefined() && !ignore_class_) weight_tv = weights_[sample_idx];
+  class_info_.Init(bg, class_tv, weight_tv);
 }
 
 template <int ndim>
@@ -392,44 +403,57 @@ bool RandomObjectBBox::PickBlob(SampleContext<BlobLabel> &ctx, int nblobs) {
   return false;
 }
 
+void RandomObjectBBox::ClassInfo::Reset() {
+  classes.clear();
+  weights.clear();
+  cdf.clear();
+}
+
+void RandomObjectBBox::ClassInfo::FromLabels(const LabelSet &labels) {
+  classes.clear();
+  weights.clear();
+  for (auto cls : labels) {
+    classes.push_back(cls);
+    weights.push_back(1);
+  }
+  // We need to sort, because the order in `context.labels` depends on its previous contents
+  // (it changes with the number of bins in the hastable).
+  // We want don't need any particular order here, but it must be deterministic
+  // - thus, sort.
+  std::sort(classes.begin(), classes.end());
+}
+
+void RandomObjectBBox::ClassInfo::DisableAbsentClasses(const LabelSet &labels) {
+  for (int i = 0; i < static_cast<int>(classes.size()); i++) {
+    if (!labels.count(classes[i]))
+      weights[i] = 0;  // label not present - reduce its weight to 0
+  }
+}
+
 template <typename BlobLabel, typename T>
 bool RandomObjectBBox::PickForegroundBox(
       SampleContext<BlobLabel> &context, const InTensorCPU<T> &input) {
-  GetBgFgAndWeights(context.classes, context.weights, context.background, context.sample_idx);
-  context.class_label = context.background;
+  InitClassInfo(context.sample_idx);
+  context.class_label = class_info_.background;
   auto &tp = *context.thread_pool;
   if (ignore_class_) {
-    int nblobs = LabelConnectedRegions(context.blobs, input, tp, -1, context.background);
+    int nblobs = LabelConnectedRegions(context.blobs, input, tp, -1, class_info_.background);
     return PickBlob(context, nblobs);
   } else {
-    FindLabels(context, input);
-
-    context.labels.erase(context.background);
+    context.FindLabels(input);
+    context.labels.erase(class_info_.background);
 
     if (!classes_.IsDefined() && !weights_.IsDefined()) {
-      context.classes.clear();
-      context.weights.clear();
-      for (auto cls : context.labels) {
-        context.classes.push_back(cls);
-        context.weights.push_back(1);
-      }
-      // We need to sort, because the order in `context.labels` depends on its previous contents
-      // (it changes with the number of bins in the hastable).
-      // We want don't need any particular order here, but it must be deterministic
-      // - thus, sort.
-      std::sort(context.classes.begin(), context.classes.end());
+      class_info_.FromLabels(context.labels);
     } else {
-      for (int i = 0; i < static_cast<int>(context.classes.size()); i++) {
-        if (!context.labels.count(context.classes[i]))
-          context.weights[i] = 0;  // label not present - reduce its weight to 0
-      }
+      class_info_.DisableAbsentClasses(context.labels);
     }
 
-    while (context.CalculateCDF()) {
-      if (!context.PickClassLabel(rngs_[context.sample_idx]))
+    while (class_info_.CalculateCDF()) {
+      if (!context.PickClassLabel(class_info_, rngs_[context.sample_idx]))
         return false;
 
-      assert(context.class_label != context.background);
+      assert(context.class_label != class_info_.background);
       FilterByLabel(context.thread_pool, context.filtered, input, context.class_label);
 
       int nblobs = LabelConnectedRegions<BlobLabel, uint8_t, -1>(
@@ -439,8 +463,8 @@ bool RandomObjectBBox::PickForegroundBox(
         return true;
 
       // we couldn't find a satisfactory blob in this class, so let's exclude it and try again
-      context.weights[context.class_idx] = 0;
-      context.class_label = context.background;
+      class_info_.weights[context.class_idx] = 0;
+      context.class_label = class_info_.background;
     }
     // we've run out of classes and still there's no good blob
     return false;
@@ -490,8 +514,6 @@ void RandomObjectBBox::RunImpl(HostWorkspace &ws) {
   int ndim = input.sample_dim();
   auto &tp = ws.GetThreadPool();
 
-  auto input_shape = input.shape();
-
   OutListCPU<int, 1> out1 = view<int, 1>(ws.OutputRef<CPUBackend>(0));
   OutListCPU<int, 1> out2;
   if (format_ != Out_Box)
@@ -514,12 +536,17 @@ void RandomObjectBBox::RunImpl(HostWorkspace &ws) {
     if (!fg) {
       StoreBox(out1, out2, format_, i, default_anchor, input.tensor_shape(i));
       if (HasClassLabelOutput()) {
-        auto &ctx = default_context_;
-        GetBgFgAndWeights(ctx.classes, ctx.weights, ctx.background, i);
-        class_label_out.data[i][0] = ctx.background;
+        InitClassInfo(i);
+        class_label_out.data[i][0] = class_info_.background;
       }
     } else {
-      auto blob_label = (input[i].size() > 0x80000000L) ? DALI_INT64 : DALI_INT32;
+      // Blobl labeling uses disjoint sets as an implementation - as such,
+      // the label type must be large enough to store flattened element indices within
+      // the input tensor.
+      // We want to limit the size of this auxiliary storage to limit memory traffic.
+      // To that end, when the indices fit in int32_t, we use that type for the labels,
+      // otherwise we fall back to int64_t.
+      auto blob_label = (input[i].size() > 0x80000000) ? DALI_INT64 : DALI_INT32;
       TYPE_SWITCH(blob_label, type2id, BlobLabel, (int32_t, int64_t), (
         auto &ctx = GetContext(BlobLabel());
         ctx.Init(i, &input[i], &tp, tmp_filtered_storage_, tmp_blob_storage_);
@@ -528,10 +555,10 @@ void RandomObjectBBox::RunImpl(HostWorkspace &ws) {
           ctx.out2 = out2[i];
 
         if (PickForegroundBox(ctx)) {
-          assert(ctx.class_label != ctx.background || ignore_class_);
+          assert(ctx.class_label != class_info_.background || ignore_class_);
           StoreBox(out1, out2, format_, i, ctx.selected_box);
         } else {
-          assert(ctx.class_label == ctx.background);
+          assert(ctx.class_label == class_info_.background);
           StoreBox(out1, out2, format_, i, default_anchor, input.tensor_shape(i));
         }
 

--- a/dali/operators/segmentation/random_object_bbox.cc
+++ b/dali/operators/segmentation/random_object_bbox.cc
@@ -506,6 +506,8 @@ void RandomObjectBBox::RunImpl(HostWorkspace &ws) {
   default_context_.thread_pool = &tp;
   huge_context_.thread_pool = &tp;
 
+  AllocateTempStorage(input);
+
   std::uniform_real_distribution<> foreground(0, 1);
   for (int i = 0; i < N; i++) {
     bool fg = foreground(rngs_[i]) < foreground_prob_[i].data[0];

--- a/dali/operators/segmentation/random_object_bbox.h
+++ b/dali/operators/segmentation/random_object_bbox.h
@@ -61,9 +61,7 @@ class RandomObjectBBox : public Operator<CPUBackend> {
     }
 
     tmp_blob_storage_.set_pinned(false);
-    tmp_blob_storage_.SetGrowthFactor(2);
     tmp_filtered_storage_.set_pinned(false);
-    tmp_filtered_storage_.SetGrowthFactor(2);
   }
 
   static OutputFormat ParseOutputFormat(const std::string &format)  {

--- a/dali/test/python/test_operator_random_object_bbox.py
+++ b/dali/test/python/test_operator_random_object_bbox.py
@@ -31,7 +31,6 @@ def count_outputs(outs):
         return 1
     return len(outs)
 
-
 data = [
     np.int32([[1, 0, 0, 0],
               [1, 2, 2, 1],

--- a/dali/test/python/test_operator_random_object_bbox.py
+++ b/dali/test/python/test_operator_random_object_bbox.py
@@ -173,7 +173,7 @@ def batch_generator(batch_size, ndim, dtype):
         # batch_size = np.random.randint(1, max_batch_size+1)
         batch = []
         for i in range(batch_size):
-            shape = list(np.random.randint(5, 11, [ndim]))
+            shape = list(np.random.randint(5, 13, [ndim]))
             num_classes = np.random.randint(1, 10)
             blobs_per_class = np.random.randint(1, 10);
             batch.append(generate_data(shape, num_classes, blobs_per_class).astype(dtype))

--- a/dali/test/python/test_operator_random_object_bbox.py
+++ b/dali/test/python/test_operator_random_object_bbox.py
@@ -438,3 +438,6 @@ def test_err_k_largest_nonpositive():
 def test_err_threshold_dim_clash():
     with assert_raises(RuntimeError):
         _test_err_args(threshold=[1,2,3,4,5])
+
+def test_large_data():
+    yield _test_random_object_bbox_with_class, 4, 5, np.int32, None, 1., [1,2,3], None, None, None, 10

--- a/include/dali/core/exec/engine.h
+++ b/include/dali/core/exec/engine.h
@@ -1,0 +1,87 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_EXEC_ENGINE_H_
+#define DALI_CORE_EXEC_ENGINE_H_
+
+#include <stdexcept>
+#include <functional>
+#include <utility>
+
+namespace dali {
+
+/*
+concept ExecutionEngine {
+  /// @brief Adds work to the engine
+  /// @param f           work item, callable with `int thread_idx`
+  /// @param priority    priority hint fort the job, the higher, the earlier it should start
+  /// @param finished_adding_work        if true, all jobs can start - it's just a hint
+  ///                                     and implementations may start running the jobs earlier
+  void AddWork(CallableWithInt f, int64_t priority, bool finished_adding_work = false);
+
+  /// @brief Starts the work and waits for it to complete.
+  /// If there was an exception in one of the jobs, rethrows one of them.
+  void RunAll();
+
+  /// @brief Returns number of workers in this execution engine.
+  int size() const noexcept;
+};
+*/
+
+/**
+ * @brief Implements a fake thread-pool-like object which immediately executes any work submitted
+ */
+class SequentialExecutionEngine {
+ public:
+  /**
+   * @brief Immediately execute a callable object `f` with argument 0.
+   *
+   * If an exception occurs, it's stored for later
+   */
+  template <typename FunctionLike>
+  void AddWork(FunctionLike &&f, int64_t priority = 0, bool finished_adding_work = true) noexcept {
+    try {
+      const int idx = 0;  // make it an integer to avoid ambiguity with NULL pointer
+      f(idx);
+    } catch (...) {
+      if (!exception_)
+        exception_ = std::current_exception();
+    }
+  }
+
+  /**
+   * @brief Doesn't execute anything (AddWork did it)
+   *
+   * This function rethrows the exception that was thrown by the function passed to AddWork, if any.
+   */
+  void RunAll() {
+    if (exception_) {
+      std::exception_ptr eptr = std::move(exception_);
+      exception_ = {};  // in case move doesn't do it
+      std::rethrow_exception(std::move(eptr));
+    }
+  }
+
+  /**
+   * @brief Returns 1
+   */
+  constexpr int size() const noexcept { return 1; }
+
+ private:
+  std::exception_ptr exception_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_CORE_EXEC_ENGINE_H_

--- a/include/dali/core/exec/engine.h
+++ b/include/dali/core/exec/engine.h
@@ -15,8 +15,6 @@
 #ifndef DALI_CORE_EXEC_ENGINE_H_
 #define DALI_CORE_EXEC_ENGINE_H_
 
-#include <stdexcept>
-#include <functional>
 #include <utility>
 
 namespace dali {
@@ -25,7 +23,7 @@ namespace dali {
 concept ExecutionEngine {
   /// @brief Adds work to the engine
   /// @param f           work item, callable with `int thread_idx`
-  /// @param priority    priority hint fort the job, the higher, the earlier it should start
+  /// @param priority    priority hint for the job, the higher, the earlier it should start
   /// @param start_immediately        if true, all jobs can start - it's just a hint
   ///                                 and implementations may start running the jobs earlier
   void AddWork(CallableWithInt f, int64_t priority, bool finished_adding_work = false);
@@ -59,9 +57,6 @@ class SequentialExecutionEngine {
    * @brief Returns 1
    */
   constexpr int NumThreads() const noexcept { return 1; }
-
- private:
-  std::exception_ptr exception_;
 };
 
 }  // namespace dali

--- a/include/dali/core/exec/engine.h
+++ b/include/dali/core/exec/engine.h
@@ -26,7 +26,7 @@ concept ExecutionEngine {
   /// @param priority    priority hint for the job, the higher, the earlier it should start
   /// @param start_immediately        if true, all jobs can start - it's just a hint
   ///                                 and implementations may start running the jobs earlier
-  void AddWork(CallableWithInt f, int64_t priority, bool finished_adding_work = false);
+  void AddWork(CallableWithInt f, int64_t priority, bool start_immediately = false);
 
   /// @brief Starts the work and waits for it to complete.
   /// If there was an exception in one of the jobs, rethrows one of them.


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It significantly improves performance of RandomObjectBBox

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Moved parallelism to within sample
     * Added an ExecutionEngine concept (essentially same interface as ThreadPool - we should do some refactoring there)
 - Affected modules and functionalities:
     * RandomObjectBBox
     * ConnectedBomponents
     * LabelBBox
 - Key points relevant for the review:
     * Thread-safety issues in connected components?
 - Validation and testing:
     * Python tests
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-1852
