### PR TITLE
Fix `.gpu` usage detection and error for CPU only pipelines

### DIFF
--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -505,6 +505,9 @@ void Pipeline::Build(vector<std::pair<string, string>> output_names) {
       }
       outputs.push_back("contiguous_" + name + "_" + device);
     } else if (device == "gpu") {
+      DALI_ENFORCE(device_id_ != CPU_ONLY_DEVICE_ID,
+                   make_string("Cannot make a gpu output for ", name, " operator,"
+                   " device_id should not be equal CPU_ONLY_DEVICE_ID."));
       if (!it->second.has_gpu) {
         DALI_ENFORCE(it->second.has_cpu, "Output '" + name +
             "' exists on neither cpu or gpu, internal error");

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -45,6 +45,17 @@ def get_data():
     out = [np.random.randint(0, 255, size = test_data_shape, dtype = np.uint8) for _ in range(batch_size)]
     return out
 
+def test_move_to_device():
+    test_data_shape = [1, 3, 0, 4]
+    def get_data():
+        out = [np.empty(test_data_shape, dtype = np.uint8) for _ in range(batch_size)]
+        return out
+
+    pipe = Pipeline(batch_size=batch_size, num_threads=3, device_id=None)
+    outs = fn.external_source(source = get_data)
+    pipe.set_outputs(outs.gpu())
+    assert_raises(RuntimeError, pipe.build)
+
 def check_bad_device(device_id):
     test_data_shape = [1, 3, 0, 4]
     def get_data():

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -45,7 +45,7 @@ def get_data():
     out = [np.random.randint(0, 255, size = test_data_shape, dtype = np.uint8) for _ in range(batch_size)]
     return out
 
-def test_move_to_device():
+def test_move_to_device_end():
     test_data_shape = [1, 3, 0, 4]
     def get_data():
         out = [np.empty(test_data_shape, dtype = np.uint8) for _ in range(batch_size)]
@@ -54,6 +54,18 @@ def test_move_to_device():
     pipe = Pipeline(batch_size=batch_size, num_threads=3, device_id=None)
     outs = fn.external_source(source = get_data)
     pipe.set_outputs(outs.gpu())
+    assert_raises(RuntimeError, pipe.build)
+
+def test_move_to_device_middle():
+    test_data_shape = [1, 3, 0, 4]
+    def get_data():
+        out = [np.empty(test_data_shape, dtype = np.uint8) for _ in range(batch_size)]
+        return out
+
+    pipe = Pipeline(batch_size=batch_size, num_threads=3, device_id=None)
+    data = fn.external_source(source = get_data)
+    outs = fn.rotate(data.gpu(), angle = 25)
+    pipe.set_outputs(outs)
     assert_raises(RuntimeError, pipe.build)
 
 def check_bad_device(device_id):
@@ -733,6 +745,13 @@ def test_arithm_ops_cpu():
     pipe.build()
     for _ in range(3):
         pipe.run()
+
+def test_arithm_ops_cpu_gpu():
+    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=None)
+    data = fn.external_source(source = get_data, layout = "HWC")
+    processed = [data * data.gpu(), data + data.gpu(), data - data.gpu(), data / data.gpu(), data // data.gpu()]
+    pipe.set_outputs(*processed)
+    assert_raises(RuntimeError, pipe.build)
 
 def test_pytorch_plugin_cpu():
     pipe = Pipeline(batch_size=batch_size, num_threads=3, device_id=None)


### PR DESCRIPTION
- when the user asks to transfer the data node to GPU by calling the `.gpu` method there was no proper error handling in the graph building stage for CPU only pipeline. This change adds proper validation for such a case

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It `.gpu` usage detection and error for CPU only pipelines

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a proper guard for calling the `.gpu` method for CPU only pipeline
 - Affected modules and functionalities:
      pipeline.cc
      test_dali_cpu_only.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     test was added
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
