### PR TITLE
Add better exception granurality to memory::alloc_shared and memory::alloc_unique

### DIFF
--- a/dali/core/dev_buffer_test.cc
+++ b/dali/core/dev_buffer_test.cc
@@ -102,4 +102,10 @@ TEST(DeviceBuffer, FromDevice) {
   EXPECT_EQ(v1, v2);
 }
 
+TEST(DeviceBufferFail, Resize) {
+  DeviceBuffer<int> db;
+  size_t size = static_cast<size_t>(-1);
+  EXPECT_THROW(db.resize(size), CUDABadAlloc);
+}
+
 }  // namespace dali

--- a/dali/kernels/alloc.cc
+++ b/dali/kernels/alloc.cc
@@ -24,10 +24,12 @@ namespace kernels {
 namespace memory {
 
 void ThrowMemoryError(AllocType type, size_t requested_size) {
-  if (type == AllocType::Pinned) {
-    throw dali::CUDABadAlloc(requested_size, true);
-  } else if (type == AllocType::GPU) {
-    throw dali::CUDABadAlloc(requested_size, false);
+  if (type != AllocType::Host) {
+    auto err = cudaGetLastError();
+    if (err == cudaErrorMemoryAllocation)
+       throw dali::CUDABadAlloc(requested_size, type == AllocType::Pinned);
+    else
+       throw dali::CUDAError(err);
   } else {
     throw std::bad_alloc();
   }

--- a/dali/kernels/alloc.cc
+++ b/dali/kernels/alloc.cc
@@ -23,6 +23,16 @@ namespace dali {
 namespace kernels {
 namespace memory {
 
+void ThrowMemoryError(AllocType type, size_t requested_size) {
+  if (type == AllocType::Pinned) {
+    throw dali::CUDABadAlloc(requested_size, true);
+  } else if (type == AllocType::GPU) {
+    throw dali::CUDABadAlloc(requested_size, false);
+  } else {
+    throw std::bad_alloc();
+  }
+}
+
 template <AllocType>
 struct Allocator;
 

--- a/dali/kernels/alloc.h
+++ b/dali/kernels/alloc.h
@@ -39,6 +39,9 @@ DLL_PUBLIC Deleter GetDeleter(AllocType type) noexcept;
 
 template <typename T>
 std::shared_ptr<T> alloc_shared(AllocType type, size_t count) {
+  if (count == 0) {
+    return {};
+  }
   static_assert(std::is_pod<T>::value, "Only POD types are supported");
   void *mem = Allocate(type, count*sizeof(T));
   if (!mem)
@@ -54,6 +57,9 @@ using KernelUniquePtr = std::unique_ptr<T, Deleter>;
 
 template <typename T>
 KernelUniquePtr<T> alloc_unique(AllocType type, size_t count) {
+  if (count == 0) {
+    return {};
+  }
   static_assert(std::is_pod<T>::value, "Only POD types are supported");
   void *mem = Allocate(type, count*sizeof(T));
   if (!mem)

--- a/dali/kernels/test/alloc_test.cc
+++ b/dali/kernels/test/alloc_test.cc
@@ -99,6 +99,25 @@ TEST(KernelAlloc, Shared) {
   }
 }
 
+TEST(KernelAllocFail, Host) {
+  size_t size = static_cast<size_t>(-1);
+  EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::Host, size), std::bad_alloc);
+  EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::Host, size), std::bad_alloc);
+}
+
+TEST(KernelAllocFail, Pinned) {
+  (void)cudaGetLastError();
+  size_t size = static_cast<size_t>(-1);
+  EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::Pinned, size), CUDABadAlloc);
+  EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::Pinned, size), CUDABadAlloc);
+}
+
+TEST(KernelAllocFail, GPU) {
+  (void)cudaGetLastError();
+  size_t size = static_cast<size_t>(-1);
+  EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::GPU, size), CUDABadAlloc);
+  EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::GPU, size), CUDABadAlloc);
+}
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/test/alloc_test.cc
+++ b/dali/kernels/test/alloc_test.cc
@@ -103,28 +103,33 @@ TEST(KernelAllocFail, Host) {
   (void)cudaGetLastError();
   size_t size = static_cast<size_t>(-1);
   EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::Host, size), std::bad_alloc);
-  (void)cudaGetLastError();
   EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::Host, size), std::bad_alloc);
-  (void)cudaGetLastError();
+  EXPECT_EQ(memory::alloc_unique<uint8_t>(AllocType::Host, 0),
+            kernels::memory::KernelUniquePtr<uint8_t>{});
+  EXPECT_EQ(memory::alloc_shared<uint8_t>(AllocType::Host, 0),
+            std::shared_ptr<uint8_t>{});
 }
 
 TEST(KernelAllocFail, Pinned) {
   (void)cudaGetLastError();
   size_t size = static_cast<size_t>(-1);
   EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::Pinned, size), CUDABadAlloc);
-  (void)cudaGetLastError();
   EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::Pinned, size), CUDABadAlloc);
-  cudaDeviceSynchronize();
-  (void)cudaGetLastError();
+  EXPECT_EQ(memory::alloc_unique<uint8_t>(AllocType::Pinned, 0),
+            kernels::memory::KernelUniquePtr<uint8_t>{});
+  EXPECT_EQ(memory::alloc_shared<uint8_t>(AllocType::Pinned, 0),
+            std::shared_ptr<uint8_t>{});
 }
 
 TEST(KernelAllocFail, GPU) {
   (void)cudaGetLastError();
   size_t size = static_cast<size_t>(-1);
   EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::GPU, size), CUDABadAlloc);
-  (void)cudaGetLastError();
   EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::GPU, size), CUDABadAlloc);
-  (void)cudaGetLastError();
+  EXPECT_EQ(memory::alloc_unique<uint8_t>(AllocType::GPU, 0),
+            kernels::memory::KernelUniquePtr<uint8_t>{});
+  EXPECT_EQ(memory::alloc_shared<uint8_t>(AllocType::GPU, 0),
+            std::shared_ptr<uint8_t>{});
 }
 
 }  // namespace kernels

--- a/dali/kernels/test/alloc_test.cc
+++ b/dali/kernels/test/alloc_test.cc
@@ -100,23 +100,31 @@ TEST(KernelAlloc, Shared) {
 }
 
 TEST(KernelAllocFail, Host) {
+  (void)cudaGetLastError();
   size_t size = static_cast<size_t>(-1);
   EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::Host, size), std::bad_alloc);
+  (void)cudaGetLastError();
   EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::Host, size), std::bad_alloc);
+  (void)cudaGetLastError();
 }
 
 TEST(KernelAllocFail, Pinned) {
   (void)cudaGetLastError();
   size_t size = static_cast<size_t>(-1);
   EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::Pinned, size), CUDABadAlloc);
+  (void)cudaGetLastError();
   EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::Pinned, size), CUDABadAlloc);
+  cudaDeviceSynchronize();
+  (void)cudaGetLastError();
 }
 
 TEST(KernelAllocFail, GPU) {
   (void)cudaGetLastError();
   size_t size = static_cast<size_t>(-1);
   EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::GPU, size), CUDABadAlloc);
+  (void)cudaGetLastError();
   EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::GPU, size), CUDABadAlloc);
+  (void)cudaGetLastError();
 }
 
 }  // namespace kernels

--- a/include/dali/core/dev_buffer.h
+++ b/include/dali/core/dev_buffer.h
@@ -156,7 +156,7 @@ struct DeviceBuffer {
     T *ptr = nullptr;
     CUDA_CALL(cudaMalloc(reinterpret_cast<void**>(&ptr), count * sizeof(T)));
     if (!ptr)
-      throw std::bad_alloc();
+      throw dali::CUDABadAlloc(count * sizeof(T));
     return { ptr, [](T* ptr) { cudaFree(ptr); } };
   }
 

--- a/include/dali/core/dev_buffer.h
+++ b/include/dali/core/dev_buffer.h
@@ -155,8 +155,10 @@ struct DeviceBuffer {
   static std::unique_ptr<T, std::function<void(T*)>> allocate(size_t count) {
     T *ptr = nullptr;
     CUDA_CALL(cudaMalloc(reinterpret_cast<void**>(&ptr), count * sizeof(T)));
-    if (!ptr)
+    if (!ptr) {
+      (void)cudaGetLastError();
       throw dali::CUDABadAlloc(count * sizeof(T));
+    }
     return { ptr, [](T* ptr) { cudaFree(ptr); } };
   }
 


### PR DESCRIPTION
- makes memory::alloc_shared and memory::alloc_unique to use CUDABadAlloc for GPU and  pinned memory allocation instead of generic std::bad_alloc

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds better exception granurality to memory::alloc_shared and memory::alloc_unique

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     makes memory::alloc_shared and memory::alloc_unique to use CUDABadAlloc for GPU and  pinned memory allocation instead of generic std::bad_alloc
 - Affected modules and functionalities:
     alloc.cc
 - Key points relevant for the review:
     NA
 - Validation and testing:
     tests are added
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
