### PR TITLE
Fix TL1_tensorflow-dali_test

### DIFF
--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -12,7 +12,7 @@ do_once() {
 
     CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2\3/')
 
-    # install TF 2.2.x
+    # install TF 2.3.x
     pip install $($topdir/qa/setup_packages.py -i 0 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
 
     # The package name can be nvidia-dali-tf-plugin,  nvidia-dali-tf-plugin-weekly or  nvidia-dali-tf-plugin-nightly

--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -13,7 +13,7 @@ do_once() {
     CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2\3/')
 
     # install TF 2.x
-    pip install $($topdir/qa/setup_packages.py -i 1 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
+    pip install $($topdir/qa/setup_packages.py -i 0 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
 
     # The package name can be nvidia-dali-tf-plugin,  nvidia-dali-tf-plugin-weekly or  nvidia-dali-tf-plugin-nightly
     pip uninstall -y `pip list | grep nvidia-dali-tf-plugin | cut -d " " -f1` || true

--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -12,7 +12,7 @@ do_once() {
 
     CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2\3/')
 
-    # install TF 2.x
+    # install TF 2.2.x
     pip install $($topdir/qa/setup_packages.py -i 0 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
 
     # The package name can be nvidia-dali-tf-plugin,  nvidia-dali-tf-plugin-weekly or  nvidia-dali-tf-plugin-nightly

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -361,7 +361,6 @@ all_packages = [PlainPackage("opencv-python", ["4.4.0.42"]),
                 CudaPackage("tensorflow-gpu",
                         { "100" : [
                               PckgVer("1.15.4",  python_max_ver="3.7"),
-                              "2.2.1",
                               "2.3.1"],
                           "110" : [
                               PckgVer("1.15.4",  python_max_ver="3.7"),


### PR DESCRIPTION
- sets a version of TF that works with the current version of ResNet50 TensorFlow example
- adjusts TF version tested for CUDA 10

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes TL1_tensorflow-dali_test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     sets a version of TF that works with the current version of ResNet50 TensorFlow example
     adjusts TF version tested for CUDA 10
 - Affected modules and functionalities:
     TL1_tensorflow-dali_test
     setup_packages.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
