### PR TITLE
Replace eval with safer ast.literal_eval

### DIFF
--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -15,6 +15,7 @@
 #pylint: disable=no-member
 import sys
 import copy
+import ast
 from itertools import count
 import threading
 import warnings
@@ -65,7 +66,7 @@ def _get_kwargs(schema):
             type_name += ", optional"
             if schema.HasArgumentDefaultValue(arg):
                 default_value_string = schema.GetArgumentDefaultValueString(arg)
-                default_value = eval(default_value_string)
+                default_value = ast.literal_eval(default_value_string)
                 type_name += ", default = {}".format(_default_converter(dtype, default_value))
         doc = schema.GetArgumentDox(arg)
         ret += _numpydoc_formatter(arg, type_name, doc)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a security issue

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Replaced Python's ``eval`` with safer ``ast.literal_eval``*
 - Affected modules and functionalities:
     *ops.py*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-1861]*
