### PR TITLE
Remove unnecessary cuda runtime dependency from alloc.h

### DIFF
--- a/dali/kernels/alloc.cc
+++ b/dali/kernels/alloc.cc
@@ -18,6 +18,7 @@
 #include "dali/kernels/alloc.h"
 #include "dali/core/static_switch.h"
 #include "dali/core/device_guard.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/alloc.h
+++ b/dali/kernels/alloc.h
@@ -20,7 +20,6 @@
 #include <type_traits>
 #include "dali/kernels/alloc_type.h"
 #include "dali/core/api_helper.h"
-#include "dali/core/cuda_error.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/test/alloc_test.cc
+++ b/dali/kernels/test/alloc_test.cc
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 #include <cstring>
 #include "dali/kernels/alloc.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 namespace kernels {


### PR DESCRIPTION
- move cuda_error.h include from alloc.h to alloc.cc to avoid unnecessary dependency

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a TL1_nodeps_build test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     move cuda_error.h include from alloc.h to alloc.cc to avoid unnecessary dependency
 - Affected modules and functionalities:
     alloc
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current tests apply
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
