### PR TITLE
Fix JPEG2K fused decoding (with ROI), add native tests for JP2k decoding

### DIFF
--- a/dali/operators/decoder/host/fused/host_decoder_crop_test.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_crop_test.cc
@@ -63,4 +63,8 @@ TYPED_TEST(ImageDecoderCropTest_CPU, TiffDecode) {
   this->Run(t_tiffImgType);
 }
 
+TYPED_TEST(ImageDecoderCropTest_CPU, Jpeg2kDecode) {
+  this->Run(t_jpeg2kImgType);
+}
+
 }  // namespace dali

--- a/dali/operators/decoder/host/fused/host_decoder_random_crop_test.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_random_crop_test.cc
@@ -60,4 +60,8 @@ TYPED_TEST(ImageDecoderRandomCropTest_CPU, TiffDecode) {
   this->Run(t_tiffImgType);
 }
 
+TYPED_TEST(ImageDecoderRandomCropTest_CPU, Jpeg2kDecode) {
+  this->Run(t_jpeg2kImgType);
+}
+
 }  // namespace dali

--- a/dali/operators/decoder/host/fused/host_decoder_slice_test.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_slice_test.cc
@@ -88,4 +88,8 @@ TYPED_TEST(ImageDecoderSliceTest_CPU, TiffDecode) {
   this->Run(t_tiffImgType);
 }
 
+TYPED_TEST(ImageDecoderSliceTest_CPU, Jpeg2kDecode) {
+  this->Run(t_jpeg2kImgType);
+}
+
 }  // namespace dali

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -192,7 +192,10 @@ image format, it will decode the entire image and crop the selected ROI.
 The output of the decoder is in *HWC* layout.
 
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
-Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.
+
+.. note::
+  JPEG 2000 decoding and extraction of regions-of-interest (ROI) in not accelerated on the GPU when
+  and uses CPU fallback for mixed backend.
 
 .. note::
   EXIF orientation metadata is disregarded.)code")
@@ -220,7 +223,10 @@ image format, it will decode the entire image and crop the selected ROI.
 The output of the decoder is in *HWC* layout.
 
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
-Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.
+
+.. note::
+  JPEG 2000 decoding and random crop in not accelerated on the GPU when and uses CPU fallback
+  for mixed backend.
 
 .. note::
   EXIF orientation metadata is disregarded.)code")
@@ -273,7 +279,10 @@ image format, it will decode the entire image and crop the selected ROI.
 The output of the decoder is in the *HWC* layout.
 
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
-Please note that GPU acceleration for JPEG 2000 decoding is only available for CUDA 11.
+
+.. note::
+  JPEG 2000 decoding and extraction of regions-of-interest (ROI) in not accelerated on the GPU when
+  and uses CPU fallback for mixed backend.
 
 .. note::
   EXIF orientation metadata is disregarded.)code")

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -194,8 +194,9 @@ The output of the decoder is in *HWC* layout.
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
 
 .. note::
-  JPEG 2000 decoding and extraction of regions-of-interest (ROI) in not accelerated on the GPU when
-  and uses CPU fallback for mixed backend.
+  JPEG 2000 region-of-interest (ROI) decoding is not accelerated on the GPU, and will use
+  a CPU implementation regardless of the selected backend. For a GPU accelerated implementation,
+  consider using separate ``image_decoder`` and ``crop`` operators.
 
 .. note::
   EXIF orientation metadata is disregarded.)code")
@@ -225,8 +226,9 @@ The output of the decoder is in *HWC* layout.
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
 
 .. note::
-  JPEG 2000 decoding and random crop in not accelerated on the GPU when and uses CPU fallback
-  for mixed backend.
+  JPEG 2000 region-of-interest (ROI) decoding is not accelerated on the GPU, and will use
+  a CPU implementation regardless of the selected backend. For a GPU accelerated implementation,
+  consider using separate ``image_decoder`` and ``random_crop`` operators.
 
 .. note::
   EXIF orientation metadata is disregarded.)code")
@@ -281,8 +283,9 @@ The output of the decoder is in the *HWC* layout.
 Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
 
 .. note::
-  JPEG 2000 decoding and extraction of regions-of-interest (ROI) in not accelerated on the GPU when
-  and uses CPU fallback for mixed backend.
+  JPEG 2000 region-of-interest (ROI) decoding is not accelerated on the GPU, and will use
+  a CPU implementation regardless of the selected backend. For a GPU accelerated implementation,
+  consider using separate ``image_decoder`` and ``slice`` operators.
 
 .. note::
   EXIF orientation metadata is disregarded.)code")

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_crop_test.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_crop_test.cc
@@ -63,4 +63,8 @@ TYPED_TEST(ImageDecoderCropTest_GPU, TiffDecode) {
   this->Run(t_tiffImgType);
 }
 
+TYPED_TEST(ImageDecoderCropTest_GPU, Jpeg2kDecode) {
+  this->Run(t_jpeg2kImgType);
+}
+
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop_test.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop_test.cc
@@ -60,4 +60,8 @@ TYPED_TEST(ImageDecoderRandomCropTest_GPU, TiffDecode) {
   this->Run(t_tiffImgType);
 }
 
+TYPED_TEST(ImageDecoderRandomCropTest_GPU, Jpeg2kDecode) {
+  this->Run(t_jpeg2kImgType);
+}
+
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_slice_test.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_slice_test.cc
@@ -92,4 +92,8 @@ TYPED_TEST(ImageDecoderSliceTest_GPU, TiffDecode) {
   this->Run(t_tiffImgType);
 }
 
+TYPED_TEST(ImageDecoderSliceTest_GPU, Jpeg2kDecode) {
+  this->Run(t_jpeg2kImgType);
+}
+
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_split_crop_test.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_split_crop_test.cc
@@ -64,4 +64,8 @@ TYPED_TEST(ImageDecoderSplitCropTest_GPU, TiffDecode) {
   this->Run(t_tiffImgType);
 }
 
+TYPED_TEST(ImageDecoderSplitCropTest_GPU, Jpeg2kDecode) {
+  this->Run(t_jpeg2kImgType);
+}
+
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_split_random_crop_test.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_split_random_crop_test.cc
@@ -61,4 +61,8 @@ TYPED_TEST(ImageDecoderSplitRandomCropTest_GPU, TiffDecode) {
   this->Run(t_tiffImgType);
 }
 
+TYPED_TEST(ImageDecoderSplitRandomCropTest_GPU, Jpeg2kDecode) {
+  this->Run(t_jpeg2kImgType);
+}
+
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_split_slice_test.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_split_slice_test.cc
@@ -93,4 +93,8 @@ TYPED_TEST(ImageDecoderSplitSliceTest_GPU, TiffDecode) {
   this->Run(t_tiffImgType);
 }
 
+TYPED_TEST(ImageDecoderSplitSliceTest_GPU, Jpeg2kDecode) {
+  this->Run(t_jpeg2kImgType);
+}
+
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg2k_helper.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg2k_helper.h
@@ -53,7 +53,10 @@ struct NvJPEG2KHandle : public UniqueHandle<nvjpeg2kHandle_t, NvJPEG2KHandle> {
   NvJPEG2KHandle() = default;
 
   NvJPEG2KHandle(nvjpeg2kDeviceAllocator_t *dev_alloc, nvjpeg2kPinnedAllocator_t *pin_alloc) {
-    NVJPEG2K_CALL(nvjpeg2kCreate(NVJPEG2K_BACKEND_DEFAULT, dev_alloc, pin_alloc, &handle_));
+    if (nvjpeg2kCreate(NVJPEG2K_BACKEND_DEFAULT, dev_alloc, pin_alloc, &handle_) !=
+        NVJPEG2K_STATUS_SUCCESS) {
+      handle_ = null_handle();
+    }
   }
 
   static constexpr nvjpeg2kHandle_t null_handle() { return nullptr; }

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -170,27 +170,32 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     CUDA_CALL(cudaEventRecord(hw_decode_event_, hw_decode_stream_));
 
 #if NVJPEG2K_ENABLED
-    auto nvjpeg2k_thread_id = nvjpeg2k_thread_.GetThreadIds()[0];
-    if (device_memory_padding_jpeg2k > 0) {
-      // Adding smaller buffers that are allocated by nvjpeg2k on startup.
-      // The sizes were obtained empirically.
-      nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 1024);
-      nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 4 * 1024);
-      nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 16 * 1024);
-      nvjpeg2k_intermediate_buffer_.resize(device_memory_padding_jpeg2k / 8);
-      nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU,
-                               device_memory_padding_jpeg2k);
-      nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU,
-                               device_memory_padding_jpeg2k);
-    }
-    if (host_memory_padding_jpeg2k > 0) {
-      nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::Pinned,
-                               host_memory_padding_jpeg2k);
-    }
-    nvjpeg2k_thread_.AddWork([this](int) {
+
+    nvjpeg2k_thread_.AddWork([this, device_memory_padding_jpeg2k, host_memory_padding_jpeg2k](int) {
       nvjpeg2k_handle_ = NvJPEG2KHandle(&nvjpeg2k_dev_alloc_, &nvjpeg2k_pin_alloc_);
 
-      nvjpeg2k_decoder_ = NvJPEG2KDecodeState(nvjpeg2k_handle_);
+      // nvJPEG2k doesn't support deprecated sm while DALI does. In this case, NvJPEG2KHandle may
+      // be empty and we need to fall back to the CPU implementation
+      if (nvjpeg2k_handle_) {
+        auto nvjpeg2k_thread_id = nvjpeg2k_thread_.GetThreadIds()[0];
+        if (device_memory_padding_jpeg2k > 0) {
+          // Adding smaller buffers that are allocated by nvjpeg2k on startup.
+          // The sizes were obtained empirically.
+          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 1024);
+          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 4 * 1024);
+          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 16 * 1024);
+          nvjpeg2k_intermediate_buffer_.resize(device_memory_padding_jpeg2k / 8);
+          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU,
+                                  device_memory_padding_jpeg2k);
+          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU,
+                                  device_memory_padding_jpeg2k);
+        }
+        if (host_memory_padding_jpeg2k > 0) {
+          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::Pinned,
+                                  host_memory_padding_jpeg2k);
+        }
+        nvjpeg2k_decoder_ = NvJPEG2KDecodeState(nvjpeg2k_handle_);
+      }
     });
     nvjpeg2k_thread_.RunAll();
 
@@ -433,29 +438,31 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
   bool ParseNvjpeg2k(SampleData &data, span<const uint8_t> input) {
 #if NVJPEG2K_ENABLED
-    const auto &jpeg2k_stream = nvjpeg2k_streams_[data.sample_idx];
-    auto ret = nvjpeg2kStreamParse(nvjpeg2k_handle_, input.data(), input.size(),
-                                   0, 0, jpeg2k_stream);
-    if (ret == NVJPEG2K_STATUS_SUCCESS) {
-      nvjpeg2kImageInfo_t image_info;
-      NVJPEG2K_CALL(nvjpeg2kStreamGetImageInfo(jpeg2k_stream, &image_info));
-      nvjpeg2kImageComponentInfo_t comp;
-      NVJPEG2K_CALL(nvjpeg2kStreamGetImageComponentInfo(jpeg2k_stream, &comp, 0));
-      uint32_t height = comp.component_height;
-      uint32_t width = comp.component_width;
-      for (uint32_t c = 1; c < image_info.num_components; ++c) {
-        NVJPEG2K_CALL(nvjpeg2kStreamGetImageComponentInfo(jpeg2k_stream, &comp, c));
-        DALI_ENFORCE(height == comp.component_height &&
-                     width == comp.component_width,
-                     make_string("Components dimensions do not match: "
-                                 "component 0 has a shape of {", comp.component_height, ", ",
-                                 comp.component_width, "} and component ", c, " has a shape of {",
-                                 height, ", ", width, "}"));
+    if (nvjpeg2k_handle_) {
+      const auto &jpeg2k_stream = nvjpeg2k_streams_[data.sample_idx];
+      auto ret = nvjpeg2kStreamParse(nvjpeg2k_handle_, input.data(), input.size(),
+                                    0, 0, jpeg2k_stream);
+      if (ret == NVJPEG2K_STATUS_SUCCESS) {
+        nvjpeg2kImageInfo_t image_info;
+        NVJPEG2K_CALL(nvjpeg2kStreamGetImageInfo(jpeg2k_stream, &image_info));
+        nvjpeg2kImageComponentInfo_t comp;
+        NVJPEG2K_CALL(nvjpeg2kStreamGetImageComponentInfo(jpeg2k_stream, &comp, 0));
+        uint32_t height = comp.component_height;
+        uint32_t width = comp.component_width;
+        for (uint32_t c = 1; c < image_info.num_components; ++c) {
+          NVJPEG2K_CALL(nvjpeg2kStreamGetImageComponentInfo(jpeg2k_stream, &comp, c));
+          DALI_ENFORCE(height == comp.component_height &&
+                      width == comp.component_width,
+                      make_string("Components dimensions do not match: "
+                                  "component 0 has a shape of {", comp.component_height, ", ",
+                                  comp.component_width, "} and component ", c, " has a shape of {",
+                                  height, ", ", width, "}"));
+        }
+        data.shape = {height, width, image_info.num_components};
+        data.method = DecodeMethod::Nvjpeg2k;
+        samples_jpeg2k_.push_back(&data);
+        return true;
       }
-      data.shape = {height, width, image_info.num_components};
-      data.method = DecodeMethod::Nvjpeg2k;
-      samples_jpeg2k_.push_back(&data);
-      return true;
     }
 #endif  // NVJPEG2K_ENABLED
     return false;
@@ -526,7 +533,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
           data.method = DecodeMethod::NvjpegCuda;
           samples_single_.push_back(&data);
         }
-      } else if (!ParseNvjpeg2k(data, span<const uint8_t>(input_data, in_size))) {
+      } else if (crop_generator || !ParseNvjpeg2k(data, span<const uint8_t>(input_data, in_size))) {
         try {
           data.method = DecodeMethod::Host;
           auto image = ImageFactory::CreateImage(input_data, in_size, output_image_type_);
@@ -642,19 +649,21 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
   void ProcessImagesJpeg2k(MixedWorkspace &ws) {
 #if NVJPEG2K_ENABLED
-    nvjpeg2k_thread_.AddWork([this, &ws](int) {
-      auto &output = ws.OutputRef<GPUBackend>(0);
-      auto &input = ws.InputRef<CPUBackend>(0);
-      for (auto *sample : samples_jpeg2k_) {
-        assert(sample);
-        auto i = sample->sample_idx;
-        auto output_data = output.mutable_tensor<uint8_t>(i);
-        auto in = span<const uint8_t>(input[i].data<uint8_t>(), input[i].size());
-        ImageCache::ImageShape shape = output_shape_[i].to_static<3>();
-        DecodeJpeg2k(output_data, sample, in);
-        CacheStore(sample->file_name, output_data, shape, nvjpeg2k_cu_stream_);
-      }
-    });
+    if (nvjpeg2k_handle_) {
+      nvjpeg2k_thread_.AddWork([this, &ws](int) {
+        auto &output = ws.OutputRef<GPUBackend>(0);
+        auto &input = ws.InputRef<CPUBackend>(0);
+        for (auto *sample : samples_jpeg2k_) {
+          assert(sample);
+          auto i = sample->sample_idx;
+          auto output_data = output.mutable_tensor<uint8_t>(i);
+          auto in = span<const uint8_t>(input[i].data<uint8_t>(), input[i].size());
+          ImageCache::ImageShape shape = output_shape_[i].to_static<3>();
+          DecodeJpeg2k(output_data, sample, in);
+          CacheStore(sample->file_name, output_data, shape, nvjpeg2k_cu_stream_);
+        }
+      });
+    }
 #endif  // NVJPEG2K_ENABLED
   }
 

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -170,32 +170,33 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     CUDA_CALL(cudaEventRecord(hw_decode_event_, hw_decode_stream_));
 
 #if NVJPEG2K_ENABLED
-
-    nvjpeg2k_thread_.AddWork([this, device_memory_padding_jpeg2k, host_memory_padding_jpeg2k](int) {
+    auto nvjpeg2k_thread_id = nvjpeg2k_thread_.GetThreadIds()[0];
+    nvjpeg2k_thread_.AddWork([this, device_memory_padding_jpeg2k, host_memory_padding_jpeg2k,
+                              nvjpeg2k_thread_id](int) {
       nvjpeg2k_handle_ = NvJPEG2KHandle(&nvjpeg2k_dev_alloc_, &nvjpeg2k_pin_alloc_);
 
       // nvJPEG2k doesn't support deprecated sm while DALI does. In this case, NvJPEG2KHandle may
       // be empty and we need to fall back to the CPU implementation
-      if (nvjpeg2k_handle_) {
-        auto nvjpeg2k_thread_id = nvjpeg2k_thread_.GetThreadIds()[0];
-        if (device_memory_padding_jpeg2k > 0) {
-          // Adding smaller buffers that are allocated by nvjpeg2k on startup.
-          // The sizes were obtained empirically.
-          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 1024);
-          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 4 * 1024);
-          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 16 * 1024);
-          nvjpeg2k_intermediate_buffer_.resize(device_memory_padding_jpeg2k / 8);
-          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU,
-                                  device_memory_padding_jpeg2k);
-          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU,
-                                  device_memory_padding_jpeg2k);
-        }
-        if (host_memory_padding_jpeg2k > 0) {
-          nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::Pinned,
-                                  host_memory_padding_jpeg2k);
-        }
-        nvjpeg2k_decoder_ = NvJPEG2KDecodeState(nvjpeg2k_handle_);
+      if (!nvjpeg2k_handle_) {
+        return;
       }
+      if (device_memory_padding_jpeg2k > 0) {
+        // Adding smaller buffers that are allocated by nvjpeg2k on startup.
+        // The sizes were obtained empirically.
+        nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 1024);
+        nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 4 * 1024);
+        nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU, 16 * 1024);
+        nvjpeg2k_intermediate_buffer_.resize(device_memory_padding_jpeg2k / 8);
+        nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU,
+                                 device_memory_padding_jpeg2k);
+        nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::GPU,
+                                 device_memory_padding_jpeg2k);
+      }
+      if (host_memory_padding_jpeg2k > 0) {
+        nvjpeg_memory::AddBuffer(nvjpeg2k_thread_id, kernels::AllocType::Pinned,
+                                 host_memory_padding_jpeg2k);
+      }
+      nvjpeg2k_decoder_ = NvJPEG2KDecodeState(nvjpeg2k_handle_);
     });
     nvjpeg2k_thread_.RunAll();
 
@@ -438,31 +439,32 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
   bool ParseNvjpeg2k(SampleData &data, span<const uint8_t> input) {
 #if NVJPEG2K_ENABLED
-    if (nvjpeg2k_handle_) {
-      const auto &jpeg2k_stream = nvjpeg2k_streams_[data.sample_idx];
-      auto ret = nvjpeg2kStreamParse(nvjpeg2k_handle_, input.data(), input.size(),
-                                    0, 0, jpeg2k_stream);
-      if (ret == NVJPEG2K_STATUS_SUCCESS) {
-        nvjpeg2kImageInfo_t image_info;
-        NVJPEG2K_CALL(nvjpeg2kStreamGetImageInfo(jpeg2k_stream, &image_info));
-        nvjpeg2kImageComponentInfo_t comp;
-        NVJPEG2K_CALL(nvjpeg2kStreamGetImageComponentInfo(jpeg2k_stream, &comp, 0));
-        uint32_t height = comp.component_height;
-        uint32_t width = comp.component_width;
-        for (uint32_t c = 1; c < image_info.num_components; ++c) {
-          NVJPEG2K_CALL(nvjpeg2kStreamGetImageComponentInfo(jpeg2k_stream, &comp, c));
-          DALI_ENFORCE(height == comp.component_height &&
+    if (!nvjpeg2k_handle_) {
+      return false;
+    }
+    const auto &jpeg2k_stream = nvjpeg2k_streams_[data.sample_idx];
+    auto ret = nvjpeg2kStreamParse(nvjpeg2k_handle_, input.data(), input.size(),
+                                  0, 0, jpeg2k_stream);
+    if (ret == NVJPEG2K_STATUS_SUCCESS) {
+      nvjpeg2kImageInfo_t image_info;
+      NVJPEG2K_CALL(nvjpeg2kStreamGetImageInfo(jpeg2k_stream, &image_info));
+      nvjpeg2kImageComponentInfo_t comp;
+      NVJPEG2K_CALL(nvjpeg2kStreamGetImageComponentInfo(jpeg2k_stream, &comp, 0));
+      uint32_t height = comp.component_height;
+      uint32_t width = comp.component_width;
+      for (uint32_t c = 1; c < image_info.num_components; ++c) {
+        NVJPEG2K_CALL(nvjpeg2kStreamGetImageComponentInfo(jpeg2k_stream, &comp, c));
+        DALI_ENFORCE(height == comp.component_height &&
                       width == comp.component_width,
                       make_string("Components dimensions do not match: "
                                   "component 0 has a shape of {", comp.component_height, ", ",
                                   comp.component_width, "} and component ", c, " has a shape of {",
                                   height, ", ", width, "}"));
-        }
-        data.shape = {height, width, image_info.num_components};
-        data.method = DecodeMethod::Nvjpeg2k;
-        samples_jpeg2k_.push_back(&data);
-        return true;
       }
+      data.shape = {height, width, image_info.num_components};
+      data.method = DecodeMethod::Nvjpeg2k;
+      samples_jpeg2k_.push_back(&data);
+      return true;
     }
 #endif  // NVJPEG2K_ENABLED
     return false;
@@ -649,21 +651,22 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
   void ProcessImagesJpeg2k(MixedWorkspace &ws) {
 #if NVJPEG2K_ENABLED
-    if (nvjpeg2k_handle_) {
-      nvjpeg2k_thread_.AddWork([this, &ws](int) {
-        auto &output = ws.OutputRef<GPUBackend>(0);
-        auto &input = ws.InputRef<CPUBackend>(0);
-        for (auto *sample : samples_jpeg2k_) {
-          assert(sample);
-          auto i = sample->sample_idx;
-          auto output_data = output.mutable_tensor<uint8_t>(i);
-          auto in = span<const uint8_t>(input[i].data<uint8_t>(), input[i].size());
-          ImageCache::ImageShape shape = output_shape_[i].to_static<3>();
-          DecodeJpeg2k(output_data, sample, in);
-          CacheStore(sample->file_name, output_data, shape, nvjpeg2k_cu_stream_);
-        }
-      });
+    if (!nvjpeg2k_handle_) {
+      return;
     }
+    nvjpeg2k_thread_.AddWork([this, &ws](int) {
+      auto &output = ws.OutputRef<GPUBackend>(0);
+      auto &input = ws.InputRef<CPUBackend>(0);
+      for (auto *sample : samples_jpeg2k_) {
+        assert(sample);
+        auto i = sample->sample_idx;
+        auto output_data = output.mutable_tensor<uint8_t>(i);
+        auto in = span<const uint8_t>(input[i].data<uint8_t>(), input[i].size());
+        ImageCache::ImageShape shape = output_shape_[i].to_static<3>();
+        DecodeJpeg2k(output_data, sample, in);
+        CacheStore(sample->file_name, output_data, shape, nvjpeg2k_cu_stream_);
+      }
+    });
 #endif  // NVJPEG2K_ENABLED
   }
 

--- a/dali/test/dali_test.h
+++ b/dali/test/dali_test.h
@@ -369,8 +369,8 @@ class DALITest : public ::testing::Test {
   int GetNumColorComp() const { return c_; }
 
   std::mt19937 rand_gen_;
-  vector<string> jpeg_names_, png_names_, tiff_names_;
-  ImgSetDescr jpegs_, png_, tiff_, bmp_;
+  vector<string> jpeg_names_, png_names_, tiff_names_, jpeg2k_names_;
+  ImgSetDescr jpegs_, png_, tiff_, bmp_, jpeg2ks_;
 
   // Decoded images
   vector<vector<uint8>> images_;

--- a/dali/test/dali_test_decoder.h
+++ b/dali/test/dali_test_decoder.h
@@ -64,6 +64,9 @@ class GenericDecoderTest : public DALISingleOpTest<ImgType> {
       case t_bmpImgType:
         this->EncodedBmpData(&encoded_data);
         break;
+      case t_jpeg2kImgType:
+        this->EncodedJpeg2kData(&encoded_data);
+        break;
       default: {
         char buff[32];
         snprintf(buff, sizeof(buff), "%d", imageType);
@@ -115,7 +118,7 @@ class GenericDecoderTest : public DALISingleOpTest<ImgType> {
   }
 
   uint32_t GetImageLoadingFlags() const override {
-    return t_loadJPEGs | t_loadPNGs | t_loadTiffs | t_loadBmps;
+    return t_loadJPEGs | t_loadPNGs | t_loadTiffs | t_loadBmps | t_loadJPEG2ks;
   }
 };
 

--- a/dali/test/dali_test_single_op.h
+++ b/dali/test/dali_test_single_op.h
@@ -52,6 +52,8 @@ const vector<string> tiff_test_images =
     ImageList(testing::dali_extra_path() + "/db/single/tiff", {".tiff", ".tif"});
 const vector<string> bmp_test_images =
     ImageList(testing::dali_extra_path() + "/db/single/bmp", {".bmp"});
+const vector<string> jpeg2k_test_images =
+    ImageList(testing::dali_extra_path() + "/db/single/jpeg2k", {".jp2"}, 5);
 
 
 }  // namespace images
@@ -71,6 +73,7 @@ typedef enum {
   t_pngImgType,
   t_tiffImgType,
   t_bmpImgType,
+  t_jpeg2kImgType,
 } t_imgType;
 
 typedef enum {
@@ -82,6 +85,8 @@ typedef enum {
   t_decodeTiffs = (1<<5),
   t_loadBmps    = (1<<6),
   t_decodeBmps  = (1<<7),
+  t_loadJPEG2ks  = (1<<6),
+  t_decodeJPEG2ks = (1<<7),
 } t_loadingFlags;
 
 struct OpArg {
@@ -187,9 +192,15 @@ class DALISingleOpTest : public DALITest {
     if (flags & t_loadBmps) {
       LoadImages(images::bmp_test_images, &bmp_);
 
-      if (flags & t_decodeTiffs) {
+      if (flags & t_decodeBmps) {
         DecodeImages(img_type_, bmp_, &bmp_decoded_, &bmp_dims_);
       }
+    }
+
+    if (flags & t_loadJPEG2ks) {
+      LoadImages(images::jpeg2k_test_images, &jpeg2ks_);
+      if (flags & t_decodeJPEGs)
+        DecodeImages(img_type_, jpeg2ks_, &jpeg2k_decoded_, &jpeg2k_dims_);
     }
 
     // Set the pipeline batch size
@@ -320,6 +331,10 @@ class DALISingleOpTest : public DALITest {
 
   void EncodedBmpData(TensorList<CPUBackend>* t) {
     DALITest::MakeEncodedBatch(t, batch_size_, bmp_);
+  }
+
+  void EncodedJpeg2kData(TensorList<CPUBackend>* t) {
+    DALITest::MakeEncodedBatch(t, batch_size_, jpeg2ks_);
   }
 
 
@@ -766,8 +781,8 @@ class DALISingleOpTest : public DALITest {
   vector<std::pair<string, string>> outputs_;
   shared_ptr<Pipeline> pipeline_;
 
-  vector<vector<uint8>> jpeg_decoded_, png_decoded_, tiff_decoded_, bmp_decoded_;
-  vector<DimPair> jpeg_dims_, png_dims_, tiff_dims_, bmp_dims_;
+  vector<vector<uint8>> jpeg_decoded_, png_decoded_, tiff_decoded_, bmp_decoded_, jpeg2k_decoded_;
+  vector<DimPair> jpeg_dims_, png_dims_, tiff_dims_, bmp_dims_, jpeg2k_dims_;
 
 
  protected:


### PR DESCRIPTION
- adds a CPU fallback for fused (slice/crop/randomCrop) JPEG2000 images decoding
- enables JPEG2000 tests for fused CPU/Mixed decoder
- when nvJPEG2000 is not available for given HW fallback to CPU implementation

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes JPEG2K fused decoding (with ROI)
- It adds native tests for JP2k decoding

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     extended tests to use JPEG2K images
     adds a CPU fallback for fused (slice/crop/randomCrop) JPEG2000 images decoding
     adds check if nvJPEG2000 was initialized successfully and can be used
 - Affected modules and functionalities:
     ImageDecoder for mixed backend
     tests for fused ImageDecoder (CPU, Mixed)
 - Key points relevant for the review:
     NA
 - Validation and testing:
     new tests are added
 - Documentation (including examples):
     NA


**JIRA TASK**: *[]*
