### PR TITLE
Fix layout length check in Transpose.

### DIFF
--- a/dali/operators/generic/transpose/transpose.h
+++ b/dali/operators/generic/transpose/transpose.h
@@ -64,7 +64,7 @@ class Transpose : public Operator<Backend> {
     DALI_ENFORCE(in_layout.ndim() == sample_ndim || in_layout.empty());
     output_layout_ = in_layout;
     if (!output_layout_arg_.empty()) {
-      DALI_ENFORCE(output_layout_.ndim() == sample_ndim);
+      DALI_ENFORCE(output_layout_arg_.ndim() == sample_ndim);
       output_layout_ = output_layout_arg_;
     } else if (transpose_layout_ && !in_layout.empty()) {
       output_layout_ = permute(in_layout, perm_);

--- a/dali/test/python/test_operator_transpose.py
+++ b/dali/test/python/test_operator_transpose.py
@@ -104,7 +104,7 @@ def test_transpose_vs_numpy():
 def check_transpose_layout(device, batch_size, shape, in_layout, permutation,
                            transpose_layout, out_layout_arg):
     eii = RandomDataIterator(batch_size, shape=shape)
-    pipe = TransposePipeline(device, batch_size, "HWC", iter(eii),
+    pipe = TransposePipeline(device, batch_size, in_layout, iter(eii),
                              permutation=permutation,
                              transpose_layout=transpose_layout,
                              out_layout_arg=out_layout_arg)
@@ -117,23 +117,22 @@ def check_transpose_layout(device, batch_size, shape, in_layout, permutation,
     elif transpose_layout:
         expected_out_layout = "".join([list(in_layout)[d] for d in permutation])
     else:
-        expected_out_layout = in_layout
+        expected_out_layout = "" if in_layout is None else in_layout
 
     assert(out[0].layout() == expected_out_layout)
 
 def test_transpose_layout():
     batch_size = 3
-    in_layout = "HWC"
     for device in {'cpu', 'gpu'}:
         for batch_size in (1, 3):
             for shape in [(600, 400, 3), (600, 400, 1)]:
-                for permutation, transpose_layout, out_layout_arg in \
-                    [((2, 0, 1), True, None),
-                     ((2, 0, 1), True, "CHW"),
-                     ((2, 0, 1), False, "CHW"),
-                     ((1, 0, 2), False, None),
-                     ((1, 0, 2), True, None),
-                     ((1, 0, 2), True, "HWC")]:
+                for permutation, in_layout, transpose_layout, out_layout_arg in \
+                    [((2, 0, 1), "HWC", True, None),
+                     ((2, 0, 1), "HWC", True, "CHW"),
+                     ((2, 0, 1), "HWC", False, "CHW"),
+                     ((1, 0, 2), None, False, None),
+                     ((1, 0, 2), "XYZ", True, None),
+                     ((1, 0, 2), None, None, "ABC")]:
                     yield check_transpose_layout, device, batch_size, shape, \
                         in_layout, permutation, transpose_layout, out_layout_arg
 


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: transpose checks _input_ layout length instead of _output_ layout length when explicit layout is provided

Mentioned in #2648

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Changed output_layout_ (not assigned yet) to output_layout_arg_ (what is to be assigned).
 - Affected modules and functionalities:
     * Transpose op with explicit layout provided
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python test added (it failed before the fix)
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A

