### PR TITLE
Rework ThreadPool and spinlock

### DIFF
--- a/dali/benchmark/thread_pool_bench.cc
+++ b/dali/benchmark/thread_pool_bench.cc
@@ -27,7 +27,7 @@ static void ThreadPoolArgs(benchmark::internal::Benchmark *b) {
   b->Args({batch_size, work_size_min, work_size_max, nthreads});
 }
 
-BENCHMARK_DEFINE_F(ThreadPoolBench, DoWorkWithID)(benchmark::State& st) {
+BENCHMARK_DEFINE_F(ThreadPoolBench, AddWork)(benchmark::State& st) {
   int batch_size = st.range(0);
   int work_size_min = st.range(1);
   int work_size_max = st.range(2);
@@ -40,7 +40,7 @@ BENCHMARK_DEFINE_F(ThreadPoolBench, DoWorkWithID)(benchmark::State& st) {
   while (st.KeepRunning()) {
     for (int i = 0; i < batch_size; i++) {
         auto size = this->RandInt(work_size_min, work_size_max);
-        thread_pool.DoWorkWithID(
+        thread_pool.AddWork(
           [&data, size, &total_count](int thread_id){
             std::vector<uint8_t> other_data;
             for (int i = 0; i < size; i++) {
@@ -48,7 +48,7 @@ BENCHMARK_DEFINE_F(ThreadPoolBench, DoWorkWithID)(benchmark::State& st) {
             }
             std::this_thread::sleep_for(std::chrono::nanoseconds(size * 10));
             total_count += size;
-          });
+          }, 0, true);
     }
     thread_pool.WaitForWork();
 
@@ -59,13 +59,13 @@ BENCHMARK_DEFINE_F(ThreadPoolBench, DoWorkWithID)(benchmark::State& st) {
   std::cout << total_count << std::endl;
 }
 
-BENCHMARK_REGISTER_F(ThreadPoolBench, DoWorkWithID)->Iterations(1000)
+BENCHMARK_REGISTER_F(ThreadPoolBench, AddWork)->Iterations(1000)
 ->Unit(benchmark::kMicrosecond)
 ->UseRealTime()
 ->Apply(ThreadPoolArgs);
 
 
-BENCHMARK_DEFINE_F(ThreadPoolBench, AddWork)(benchmark::State& st) {
+BENCHMARK_DEFINE_F(ThreadPoolBench, AddWorkDeferred)(benchmark::State& st) {
   int batch_size = st.range(0);
   int work_size_min = st.range(1);
   int work_size_max = st.range(2);
@@ -98,7 +98,7 @@ BENCHMARK_DEFINE_F(ThreadPoolBench, AddWork)(benchmark::State& st) {
 }
 
 
-BENCHMARK_REGISTER_F(ThreadPoolBench, AddWork)->Iterations(1000)
+BENCHMARK_REGISTER_F(ThreadPoolBench, AddWorkDeferred)->Iterations(1000)
 ->Unit(benchmark::kMicrosecond)
 ->UseRealTime()
 ->Apply(ThreadPoolArgs);

--- a/dali/operators/audio/mel_scale/mel_filter_bank.cc
+++ b/dali/operators/audio/mel_scale/mel_filter_bank.cc
@@ -72,7 +72,7 @@ bool MelFilterBank<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
   const auto &input = ws.InputRef<CPUBackend>(0);
   auto in_shape = input.shape();
   int nsamples = input.size();
-  auto nthreads = ws.GetThreadPool().size();
+  auto nthreads = ws.GetThreadPool().NumThreads();
   auto layout = input.GetLayout();
   auto ndim = in_shape.sample_dim();
   args_.axis = layout.empty() ? std::max(0, ndim - 2) : layout.find('f');

--- a/dali/operators/audio/mfcc/mfcc.cc
+++ b/dali/operators/audio/mfcc/mfcc.cc
@@ -120,7 +120,7 @@ bool MFCC<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
   kernels::KernelContext ctx;
   auto in_shape = input.shape();
   int nsamples = input.size();
-  auto nthreads = ws.GetThreadPool().size();
+  auto nthreads = ws.GetThreadPool().NumThreads();
 
   int64_t max_length = -1;
 

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -129,8 +129,8 @@ void AudioDecoderCpu::DecodeBatch(workspace_t<Backend> &ws) {
   int batch_size = decoded_output.shape.num_samples();
   auto &tp = ws.GetThreadPool();
 
-  scratch_decoder_.resize(tp.size());
-  scratch_resampler_.resize(tp.size());
+  scratch_decoder_.resize(tp.NumThreads());
+  scratch_resampler_.resize(tp.NumThreads());
 
   for (int i = 0; i < batch_size; i++) {
     tp.AddWork([&, i](int thread_id) {

--- a/dali/operators/generic/erase/erase.cc
+++ b/dali/operators/generic/erase/erase.cc
@@ -183,7 +183,7 @@ bool EraseImplCpu<T, Dims>::SetupImpl(std::vector<OutputDesc> &output_desc,
   auto type = input.type();
   auto shape = input.shape();
   int nsamples = input.size();
-  auto nthreads = ws.GetThreadPool().size();
+  auto nthreads = ws.GetThreadPool().NumThreads();
 
   args_ = detail::GetEraseArgs<T, Dims>(spec_, ws, shape, layout);
 

--- a/dali/operators/generic/join.cc
+++ b/dali/operators/generic/join.cc
@@ -199,7 +199,7 @@ void TensorJoin<Backend, new_axis>::RunTyped(
     const TensorListView<Storage, T> &out, HostWorkspace &ws) {
   using Kernel = kernels::TensorJoinCPU<T, new_axis>;
   ThreadPool &tp = ws.GetThreadPool();
-  int num_threads = tp.size();
+  int num_threads = tp.NumThreads();
   kmgr_.Resize<Kernel>(num_threads, num_threads);
   auto &inputs = this->template inputs<T>();
   SmallVector<kernels::InTensorCPU<T>, 128> in_tensors;

--- a/dali/operators/generic/pad.cc
+++ b/dali/operators/generic/pad.cc
@@ -191,7 +191,7 @@ bool Pad<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
   auto in_layout = input.GetLayout();
   int ndim = in_shape.sample_dim();
   int nsamples = in_shape.num_samples();
-  auto nthreads = ws.GetThreadPool().size();
+  auto nthreads = ws.GetThreadPool().NumThreads();
 
   ReadArguments(spec_, ws);
 

--- a/dali/operators/generic/reduce/reduce.h
+++ b/dali/operators/generic/reduce/reduce.h
@@ -116,7 +116,7 @@ class Reduce : public Operator<Backend>, detail::AxesHelper {
     auto out_view = view<OutputType>(out);
 
     auto &thread_pool = ws.GetThreadPool();
-    int num_threads = thread_pool.size();
+    int num_threads = thread_pool.NumThreads();
 
     using Kernel = ReductionType<OutputType, InputType>;
     kmgr_.template Resize<Kernel>(num_threads, num_threads);

--- a/dali/operators/generic/reduce/reduce_with_mean_input.h
+++ b/dali/operators/generic/reduce/reduce_with_mean_input.h
@@ -94,7 +94,7 @@ class ReduceWithMeanInput : public Operator<Backend>, detail::AxesHelper {
     auto out_view = view<OutputType>(out);
 
     auto &thread_pool = ws.GetThreadPool();
-    int num_threads = thread_pool.size();
+    int num_threads = thread_pool.NumThreads();
 
     using Kernel = ReductionType<OutputType, InputType, OutputType>;
     kmgr_.template Resize<Kernel>(num_threads, num_threads);

--- a/dali/operators/generic/slice/slice_base.cc
+++ b/dali/operators/generic/slice/slice_base.cc
@@ -52,7 +52,7 @@ bool SliceBaseCpu<OutputType, InputType, Dims>::SetupImpl(std::vector<OutputDesc
   const auto &input = ws.template InputRef<CPUBackend>(0);
   auto in_shape = input.shape();
   int nsamples = in_shape.num_samples();
-  auto nthreads = ws.GetThreadPool().size();
+  auto nthreads = ws.GetThreadPool().NumThreads();
   assert(nsamples == static_cast<int>(args_.size()));
   output_desc.resize(1);
   output_desc[0].type = TypeInfo::Create<OutputType>();

--- a/dali/operators/geometry/coord_transform.cc
+++ b/dali/operators/geometry/coord_transform.cc
@@ -54,7 +54,7 @@ void CoordTransform<CPUBackend>::RunTyped(HostWorkspace &ws) {
   auto out_view = view<OutputType>(out);
   auto &tp = ws.GetThreadPool();
 
-  int nthreads = tp.size();
+  int nthreads = tp.NumThreads();
 
   using Kernel = kernels::TransformPointsCPU<OutputType, InputType, out_dim, in_dim>;
   kmgr_.template Resize<Kernel>(nthreads, nthreads);

--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -127,7 +127,7 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
   bool SetupImpl(std::vector<OutputDesc>& output_desc, const workspace_t<CPUBackend>& ws) override {
     const auto& input = ws.template InputRef<CPUBackend>(0);
     int nsamples = input.size();
-    auto nthreads = ws.GetThreadPool().size();
+    auto nthreads = ws.GetThreadPool().NumThreads();
 
     output_desc.resize(1);
     output_desc[0].type = TypeInfo::Create<Out>();

--- a/dali/operators/image/crop/crop_mirror_normalize.cc
+++ b/dali/operators/image/crop/crop_mirror_normalize.cc
@@ -80,7 +80,7 @@ bool CropMirrorNormalize<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_
   auto in_shape = input.shape();
   int ndim = in_shape.sample_dim();
   int nsamples = in_shape.size();
-  auto nthreads = ws.GetThreadPool().size();
+  auto nthreads = ws.GetThreadPool().NumThreads();
   TYPE_SWITCH(input_type_, type2id, InputType, CMN_IN_TYPES, (
     TYPE_SWITCH(output_type_, type2id, OutputType, CMN_OUT_TYPES, (
       VALUE_SWITCH(ndim, Dims, CMN_NDIMS, (

--- a/dali/operators/image/remap/warp.h
+++ b/dali/operators/image/remap/warp.h
@@ -125,7 +125,7 @@ class WarpOpImpl : public OpImplInterface<Backend> {
   }
 
   void SetupBackend(TensorListShape<> &shape, const HostWorkspace &ws) {
-    int threads = ws.HasThreadPool() ? ws.GetThreadPool().size() : 1;
+    int threads = ws.HasThreadPool() ? ws.GetThreadPool().NumThreads() : 1;
     int N = input_.num_samples();
     kmgr_.Resize<Kernel>(threads, N);
 

--- a/dali/operators/math/normalize/normalize.cc
+++ b/dali/operators/math/normalize/normalize.cc
@@ -147,7 +147,7 @@ template <typename OutputType, typename InputType>
 void Normalize<CPUBackend>::SetupTyped(const HostWorkspace &ws) {
   auto &input = ws.InputRef<CPUBackend>(0);
   int nsamples = input.ntensor();
-  int nthreads = ws.GetThreadPool().size();
+  int nthreads = ws.GetThreadPool().NumThreads();
 
   using Kernel = kernels::NormalizeCPU<OutputType, InputType, float>;
   kmgr_.Resize<Kernel>(nthreads, nsamples);
@@ -256,7 +256,7 @@ void Normalize<CPUBackend>::RunTyped(HostWorkspace &ws) {
   output.SetLayout(input.GetLayout());
 
   int nsamples = input.ntensor();
-  int nthreads = ws.GetThreadPool().size();
+  int nthreads = ws.GetThreadPool().NumThreads();
 
   float scalar_mean = 0;
   float scalar_inv_stddev = 1;

--- a/dali/operators/segmentation/random_mask_pixel.cc
+++ b/dali/operators/segmentation/random_mask_pixel.cc
@@ -120,7 +120,7 @@ void RandomMaskPixelCPU::RunImplTyped(workspace_t<CPUBackend> &ws) {
   auto pixel_pos_view = view<int64_t>(out_pixel_pos);
   auto& thread_pool = ws.GetThreadPool();
 
-  rle_.resize(thread_pool.size());
+  rle_.resize(thread_pool.NumThreads());
 
   for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
     thread_pool.AddWork(

--- a/dali/operators/segmentation/random_object_bbox.cc
+++ b/dali/operators/segmentation/random_object_bbox.cc
@@ -424,7 +424,7 @@ void RandomObjectBBox::RunImpl(HostWorkspace &ws) {
   TensorShape<> default_anchor;
   default_anchor.resize(ndim);
 
-  contexts_.resize(tp.size()+1);
+  contexts_.resize(tp.NumThreads()+1);
 
   std::uniform_real_distribution<> foreground(0, 1);
   for (int i = 0; i < N; i++) {

--- a/dali/operators/signal/decibel/to_decibels_op_cpu.cc
+++ b/dali/operators/signal/decibel/to_decibels_op_cpu.cc
@@ -56,7 +56,7 @@ bool ToDecibels<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
   kernels::KernelContext ctx;
   auto in_shape = input.shape();
   int nsamples = input.size();
-  auto nthreads = ws.GetThreadPool().size();
+  auto nthreads = ws.GetThreadPool().NumThreads();
 
   TYPE_SWITCH(input.type().id(), type2id, T, (float), (
     using ToDbKernel = kernels::signal::ToDecibelsCpu<T>;

--- a/dali/operators/signal/fft/power_spectrum.cc
+++ b/dali/operators/signal/fft/power_spectrum.cc
@@ -63,7 +63,7 @@ bool PowerSpectrum<CPUBackend>::SetupImpl(std::vector<OutputDesc> &output_desc,
   kernels::KernelContext ctx;
   auto in_shape = input.shape();
   int nsamples = input.size();
-  auto nthreads = ws.GetThreadPool().size();
+  auto nthreads = ws.GetThreadPool().NumThreads();
 
   // Other types not supported for now
   using InputType = float;

--- a/dali/operators/signal/fft/spectrogram.cc
+++ b/dali/operators/signal/fft/spectrogram.cc
@@ -184,7 +184,7 @@ bool SpectrogramImplCpu<time_major>::SetupImpl(std::vector<OutputDesc> &out_desc
   kernels::KernelContext ctx;
   auto in_shape = input.shape();
   int nsamples = input.size();
-  auto nthreads = ws.GetThreadPool().size();
+  auto nthreads = ws.GetThreadPool().NumThreads();
 
   // Check that input is 1-D (allowing having extra dims with extent 1)
   if (in_shape.sample_dim() > 1) {

--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -64,7 +64,8 @@ void ThreadPool::AddWork(Work work, int64_t priority, bool start_immediately) {
     work_complete_ = false;
     started_ |= start_immediately;
   }
-  condition_.notify_all();
+  if (started_)
+    condition_.notify_all();
 }
 
 // Blocks until all work issued to the thread pool is complete

--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -25,7 +25,7 @@
 namespace dali {
 
 ThreadPool::ThreadPool(int num_thread, int device_id, bool set_affinity)
-    : threads_(num_thread), running_(true), work_complete_(true), adding_work_(false)
+    : threads_(num_thread), running_(true), work_complete_(true), started_(false)
     , active_threads_(0) {
   DALI_ENFORCE(num_thread > 0, "Thread pool must have non-zero size");
 #if NVML_ENABLED
@@ -57,24 +57,21 @@ ThreadPool::~ThreadPool() {
 #endif
 }
 
-void ThreadPool::AddWork(Work work, int64_t priority, bool finished_adding_work) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  work_queue_.push({priority, std::move(work)});
-  work_complete_ = false;
-  adding_work_ = !finished_adding_work;
-}
-
-void ThreadPool::DoWorkWithID(Work work, int64_t priority) {
-  AddWork(std::move(work), priority, true);
-  // Signal a thread to complete the work
-  condition_.notify_one();
+void ThreadPool::AddWork(Work work, int64_t priority, bool start_immediately) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    work_queue_.push({priority, std::move(work)});
+    work_complete_ = false;
+    started_ |= start_immediately;
+  }
+  condition_.notify_all();
 }
 
 // Blocks until all work issued to the thread pool is complete
 void ThreadPool::WaitForWork(bool checkForErrors) {
   std::unique_lock<std::mutex> lock(mutex_);
   completed_.wait(lock, [this] { return this->work_complete_; });
-
+  started_ = false;
   if (checkForErrors) {
     // Check for errors
     for (size_t i = 0; i < threads_.size(); ++i) {
@@ -91,15 +88,15 @@ void ThreadPool::WaitForWork(bool checkForErrors) {
 void ThreadPool::RunAll(bool wait) {
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    adding_work_ = false;
+    started_ = true;
   }
-  condition_.notify_one();  // other threads will be waken up if needed
+  condition_.notify_all();  // other threads will be waken up if needed
   if (wait) {
     WaitForWork();
   }
 }
 
-int ThreadPool::size() const {
+int ThreadPool::NumThreads() const {
   return threads_.size();
 }
 
@@ -141,7 +138,7 @@ void ThreadPool::ThreadMain(int thread_id, int device_id, bool set_affinity) {
   while (running_) {
     // Block on the condition to wait for work
     std::unique_lock<std::mutex> lock(mutex_);
-    condition_.wait(lock, [this] { return !running_ || (!work_queue_.empty() && !adding_work_); });
+    condition_.wait(lock, [this] { return !running_ || (!work_queue_.empty() && started_); });
     // If we're no longer running, exit the run loop
     if (!running_) break;
 
@@ -149,15 +146,10 @@ void ThreadPool::ThreadMain(int thread_id, int device_id, bool set_affinity) {
     // this thread as active
     Work work = std::move(work_queue_.top().second);
     work_queue_.pop();
-    bool should_wake_next = !work_queue_.empty();
     ++active_threads_;
 
     // Unlock the lock
     lock.unlock();
-
-    if (should_wake_next) {
-      condition_.notify_one();
-    }
 
     // If an error occurs, we save it in tl_errors_. When
     // WaitForWork is called, we will check for any errors

--- a/dali/pipeline/util/thread_pool.h
+++ b/dali/pipeline/util/thread_pool.h
@@ -39,21 +39,14 @@ class DLL_PUBLIC ThreadPool {
   DLL_PUBLIC ~ThreadPool();
 
   /**
-   * @brief Adds work to the queue with optional priority.
-   *        The work only gets queued and it will only start after invoking
-   *        `RunAll` (wakes up all threads to complete all remaining works) or
-   *        `DoWorkWithID` (wakes up a single thread to complete one work unit).
-   * @remarks if finished_adding_work == true, the thread pool will proceed picking
-   *          tasks from its queue, otherwise it will hold execution until `RunAll`
-   *          is invoked.
+   * @brief Adds work to the queue with optional priority, and optionally starts processing
+   *
+   * The jobs are queued but the workers don't pick up the work unless they have
+   * already been started by a previous call to AddWork with start_immediately = true or RunAll.
+   * Once work is started, the threads will continue to pick up whatever work is scheduled
+   * until WaitForWork is called.
    */
-  DLL_PUBLIC void AddWork(Work work, int64_t priority = 0, bool finished_adding_work = false);
-
-  /**
-   * @brief Adds work to the queue with optional priority and wakes up a single
-   *        thread that will pick the task in the queue with highest priority.
-   */
-  DLL_PUBLIC void DoWorkWithID(Work work, int64_t priority = 0);
+  DLL_PUBLIC void AddWork(Work work, int64_t priority = 0, bool start_immediately = false);
 
   /**
    * @brief Wakes up all the threads to complete all the queued work,
@@ -67,7 +60,7 @@ class DLL_PUBLIC ThreadPool {
    */
   DLL_PUBLIC void WaitForWork(bool checkForErrors = true);
 
-  DLL_PUBLIC int size() const;
+  DLL_PUBLIC int NumThreads() const;
 
   DLL_PUBLIC std::vector<std::thread::id> GetThreadIds() const;
 
@@ -88,7 +81,7 @@ class DLL_PUBLIC ThreadPool {
 
   bool running_;
   bool work_complete_;
-  bool adding_work_;
+  bool started_;
   int active_threads_;
   std::mutex mutex_;
   std::condition_variable condition_;

--- a/dali/pipeline/util/thread_pool_test.cc
+++ b/dali/pipeline/util/thread_pool_test.cc
@@ -32,12 +32,12 @@ TEST(ThreadPool, AddWork) {
   ASSERT_EQ(count, 64);
 }
 
-TEST(ThreadPool, DoWorkWithID) {
+TEST(ThreadPool, AddWorkImmediateStart) {
   ThreadPool tp(16, 0, false);
   std::atomic<int> count{0};
   auto increase = [&count](int thread_id) { count++; };
   for (int i = 0; i < 64; i++) {
-    tp.DoWorkWithID(increase);
+    tp.AddWork(increase, 0, true);
   }
   tp.WaitForWork();
   ASSERT_EQ(count, 64);


### PR DESCRIPTION
* Rework ThreadPool
  - rename size to NumThreads
  - remove DoWorkWithID
  - change semantics of AddWork - start_immediately instead of finished_adding_tasks
  - AddWork should never stop the jobs (now done in WaitForWork)
* Change spinlock to yield after a predefined number of cycles.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring ThreadPool to fit ExecutionEngine concept (introduced in another PR)
- Rework ThreadPool semantics to less suprising; remove unused functions.
- Improve spinlock by yielding after N cycles


#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
      * Refactor ThreadPool
        - rename size to NumThreads
        - remove DoWorkWithID
        - change semantics of AddWork - start_immediately instead of finished_adding_tasks
        - AddWork should never stop the jobs (now done in WaitForWork)
      * Change spinlock to yield after a predefined number of cycles.
 - Affected modules and functionalities:
     * ThreadPool and Spinlock - affects most of the operators
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests apply
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
