### PR TITLE
Update DALI PyTorch ligthing example to work with the newest lighting

### DIFF
--- a/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
@@ -71,13 +71,10 @@
     "    x = self.layer_3(x)\n",
     "\n",
     "    x = F.log_softmax(x, dim=1)\n",
-    "    return x\n",
-    "\n",
-    "  def process_batch(self, batch):\n",
-    "      return batch\n",
+    "    return x.cuda()\n",
     "\n",
     "  def training_step(self, batch, batch_idx):\n",
-    "      x, y = self.process_batch(batch)\n",
+    "      x, y = batch\n",
     "      logits = self(x)\n",
     "      loss = F.nll_loss(logits, y)\n",
     "      return loss\n",
@@ -114,27 +111,25 @@
      "output_type": "stream",
      "text": [
       "GPU available: True, used: True\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "TPU available: None, using: 0 TPU cores\n",
+      "initializing ddp: GLOBAL_RANK: 0, MEMBER: 1/1\n",
       "\n",
       "  | Name    | Type   | Params\n",
       "-----------------------------------\n",
       "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n",
-      "WARNING: Logging before flag parsing goes to stderr.\n",
-      "I1016 15:34:19.539263 139682004997952 lightning.py:1215] \n",
-      "  | Name    | Type   | Params\n",
+      "1 | layer_2 | Linear | 33.0 K\n",
+      "2 | layer_3 | Linear | 2.6 K \n",
       "-----------------------------------\n",
-      "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n"
+      "136 K     Trainable params\n",
+      "0         Non-trainable params\n",
+      "136 K     Total params\n",
+      "0.544     Total estimated model params size (MB)\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cd8f7850b2da478dbcbc686fc864bb9b",
+       "model_id": "7a387365edfe47c2a00e36dabfc52bad",
        "version_major": 2,
        "version_minor": 0
       },
@@ -184,47 +179,40 @@
    "source": [
     "import nvidia.dali as dali\n",
     "from nvidia.dali.pipeline import Pipeline\n",
-    "import nvidia.dali.ops as ops\n",
+    "import nvidia.dali.fn as fn\n",
     "import nvidia.dali.types as types\n",
-    "from nvidia.dali.plugin.pytorch import DALIClassificationIterator\n",
+    "from nvidia.dali.plugin.pytorch import DALIClassificationIterator, LastBatchPolicy\n",
     "\n",
     "# Path to MNIST dataset\n",
     "data_path = os.path.join(os.environ['DALI_EXTRA_PATH'], 'db/MNIST/training/')\n",
     "\n",
-    "class MnistPipeline(Pipeline):\n",
-    "    def __init__(self, batch_size, device, device_id=0, shard_id=0, num_shards=1, num_threads=4, seed=0):\n",
-    "        super(MnistPipeline, self).__init__(\n",
-    "            batch_size, num_threads, device_id, seed)\n",
-    "        self.device = device\n",
-    "        self.reader = ops.Caffe2Reader(path=data_path, shard_id=shard_id, num_shards=num_shards, random_shuffle=True)\n",
-    "        self.decode = ops.ImageDecoder(\n",
-    "            device='mixed' if device == 'gpu' else 'cpu',\n",
-    "            output_type=types.GRAY)\n",
-    "        self.cmn = ops.CropMirrorNormalize(\n",
-    "            device=device,\n",
-    "            dtype=types.FLOAT,\n",
-    "            std=[0.3081 * 255],\n",
-    "            mean=[0.1307 * 255],\n",
-    "            output_layout=\"CHW\")\n",
-    "        self.to_int64 = ops.Cast(dtype=types.INT64, device=device)\n",
-    "\n",
-    "    def define_graph(self):\n",
-    "        inputs, labels = self.reader(name=\"Reader\")\n",
-    "        images = self.decode(inputs)\n",
-    "        images = self.cmn(images)\n",
-    "        if self.device == \"gpu\":\n",
+    "def CreateMnistPipeline(batch_size, device, device_id=0, shard_id=0, num_shards=1, num_threads=4, seed=0):\n",
+    "    pipe = Pipeline(batch_size, num_threads, device_id, seed)\n",
+    "    with pipe:\n",
+    "        jpegs, labels = fn.caffe2_reader(path=data_path, shard_id=shard_id, num_shards=num_shards, random_shuffle=True, name=\"Reader\")\n",
+    "        images = fn.image_decoder(jpegs,\n",
+    "                                  device='mixed' if device == 'gpu' else 'cpu',\n",
+    "                                  output_type=types.GRAY)\n",
+    "        images = fn.crop_mirror_normalize(images,\n",
+    "                                          dtype=types.FLOAT,\n",
+    "                                          std=[0.3081 * 255],\n",
+    "                                          mean=[0.1307 * 255],\n",
+    "                                          output_layout=\"CHW\")\n",
+    "        if device == \"gpu\":\n",
     "            labels = labels.gpu()\n",
     "        # PyTorch expects labels as INT64\n",
-    "        labels = self.to_int64(labels)\n",
-    "\n",
-    "        return (images, labels)"
+    "        labels = fn.cast(labels, dtype=types.INT64)\n",
+    "        pipe.set_outputs(images, labels)\n",
+    "    return pipe"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we are ready to modify the training class to use the DALI pipeline we have just defined. Because we want to integrate with PyTorch, we wrap our pipeline with a PyTorch DALI iterator, that can replace the native data loader with some minor changes in the code. The DALI iterator returns a list dictionaries, where each element in the list corresponds to a pipeline instance, and the entries in the dictionary map to the outputs of the pipeline. For more information, check the documentation of DALIGenericIterator."
+    "Now we are ready to modify the training class to use the DALI pipeline we have just defined. Because we want to integrate with PyTorch, we wrap our pipeline with a PyTorch DALI iterator, that can replace the native data loader with some minor changes in the code. The DALI iterator returns a list of dictionaries, where each element in the list corresponds to a pipeline instance, and the entries in the dictionary map to the outputs of the pipeline. For more information, check the documentation of the DALIGenericIterator.\n",
+    "\n",
+    "As PyTorch-Lighting expects data iterator to return an iterable of raw tensors, not a dictionary, we need to provide a custom DALI iterator wrapper. Also, PyTorch can learn the size of the dataset this way."
    ]
   },
   {
@@ -233,7 +221,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class DALILitMNIST(LitMNIST):\n",
+    "class BetterDALILitMNIST(LitMNIST):\n",
     "    def __init__(self):\n",
     "        super().__init__()\n",
     "    \n",
@@ -241,61 +229,63 @@
     "        device_id = self.local_rank\n",
     "        shard_id = self.global_rank\n",
     "        num_shards = self.trainer.world_size\n",
-    "        mnist_pipeline = MnistPipeline(BATCH_SIZE, device='cpu', device_id=device_id, shard_id=shard_id,\n",
-    "                                       num_shards=num_shards, num_threads=8)\n",
-    "        self.train_loader = DALIClassificationIterator(mnist_pipeline, reader_name=\"Reader\",\n",
-    "                                                       fill_last_batch=False, auto_reset=True)                          \n",
-    "    def train_dataloader(self):\n",
-    "        return self.train_loader\n",
+    "        mnist_pipeline = CreateMnistPipeline(BATCH_SIZE, device='gpu', device_id=device_id, shard_id=shard_id, num_shards=num_shards, num_threads=8)\n",
+    "\n",
+    "        class LightningWrapper(DALIClassificationIterator):\n",
+    "            def __init__(self, *kargs, **kvargs):\n",
+    "                super().__init__(*kargs, **kvargs)\n",
     "    \n",
-    "    def process_batch(self, batch):\n",
-    "        x = batch[0][\"data\"]\n",
-    "        y = batch[0][\"label\"].squeeze(-1).cuda().long()\n",
-    "        return (x, y)"
+    "            def __next__(self):\n",
+    "                out = super().__next__()\n",
+    "                # DDP is used so only one pipeline per process\n",
+    "                # also we need to transform dict returned by DALIClassificationIterator to iterable\n",
+    "                # and squeeze the lables\n",
+    "                out = out[0]\n",
+    "                return [out[k] if k != \"label\" else torch.squeeze(out[k]) for k in self.output_map]\n",
+    "\n",
+    "        self.train_loader = LightningWrapper(mnist_pipeline, reader_name=\"Reader\", last_batch_policy=LastBatchPolicy.PARTIAL, auto_reset=True)\n",
+    "\n",
+    "    def train_dataloader(self):\n",
+    "        return self.train_loader"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now run the training"
+    "Let us run the training one more time"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
       "GPU available: True, used: True\n",
-      "I1016 15:34:44.947721 139682004997952 distributed.py:49] GPU available: True, used: True\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "I1016 15:34:44.950112 139682004997952 distributed.py:49] TPU available: False, using: 0 TPU cores\n",
-      "Using environment variable NODE_RANK for node rank (0).\n",
-      "I1016 15:34:44.952062 139682004997952 distributed.py:49] Using environment variable NODE_RANK for node rank (0).\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "I1016 15:34:44.953487 139682004997952 accelerator_connector.py:333] LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "TPU available: None, using: 0 TPU cores\n",
       "\n",
       "  | Name    | Type   | Params\n",
       "-----------------------------------\n",
       "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n",
-      "I1016 15:34:45.160256 139682004997952 lightning.py:1215] \n",
-      "  | Name    | Type   | Params\n",
+      "1 | layer_2 | Linear | 33.0 K\n",
+      "2 | layer_3 | Linear | 2.6 K \n",
       "-----------------------------------\n",
-      "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n"
+      "136 K     Trainable params\n",
+      "0         Non-trainable params\n",
+      "136 K     Total params\n",
+      "0.544     Total estimated model params size (MB)\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ff3f1e0ba4d14d90af284eeab4c1bf06",
+       "model_id": "fa44412d218b47e690baff58b4945f62",
        "version_major": 2,
        "version_minor": 0
       },
@@ -325,125 +315,9 @@
     }
    ],
    "source": [
-    "model = DALILitMNIST()\n",
-    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=5)\n",
-    "trainer.fit(model)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For even better integration, we can provide a custom DALI iterator wrapper so that no extra processing is required inside `LitMNIST.process_batch`. Also, PyTorch can learn the size of the dataset this way."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class BetterDALILitMNIST(LitMNIST):\n",
-    "    def __init__(self):\n",
-    "        super().__init__()\n",
-    "    \n",
-    "    def prepare_data(self):\n",
-    "        device_id = self.local_rank\n",
-    "        shard_id = self.global_rank\n",
-    "        num_shards = self.trainer.world_size\n",
-    "        mnist_pipeline = MnistPipeline(BATCH_SIZE, device='cpu', device_id=device_id, shard_id=shard_id, num_shards=num_shards, num_threads=8)\n",
-    "\n",
-    "        class LightningWrapper(DALIClassificationIterator):\n",
-    "            def __init__(self, *kargs, **kvargs):\n",
-    "                super().__init__(*kargs, **kvargs)\n",
-    "    \n",
-    "            def __next__(self):\n",
-    "                out = super().__next__()\n",
-    "                # DDP is used so only one pipeline per process\n",
-    "                # also we need to transform dict returned by DALIClassificationIterator to iterable\n",
-    "                # and squeeze the lables\n",
-    "                out = out[0]\n",
-    "                return [out[k] if k != \"label\" else torch.squeeze(out[k]) for k in self.output_map]\n",
-    "\n",
-    "        self.train_loader = LightningWrapper(mnist_pipeline, reader_name=\"Reader\", fill_last_batch=False, auto_reset=True)\n",
-    "\n",
-    "    def train_dataloader(self):\n",
-    "        return self.train_loader"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let us run the training one more time"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "GPU available: True, used: True\n",
-      "I1016 15:35:11.309178 139682004997952 distributed.py:49] GPU available: True, used: True\n",
-      "TPU available: False, using: 0 TPU cores\n",
-      "I1016 15:35:11.311038 139682004997952 distributed.py:49] TPU available: False, using: 0 TPU cores\n",
-      "Using environment variable NODE_RANK for node rank (0).\n",
-      "I1016 15:35:11.312532 139682004997952 distributed.py:49] Using environment variable NODE_RANK for node rank (0).\n",
-      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "I1016 15:35:11.314745 139682004997952 accelerator_connector.py:333] LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "\n",
-      "  | Name    | Type   | Params\n",
-      "-----------------------------------\n",
-      "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n",
-      "I1016 15:35:11.358530 139682004997952 lightning.py:1215] \n",
-      "  | Name    | Type   | Params\n",
-      "-----------------------------------\n",
-      "0 | layer_1 | Linear | 100 K \n",
-      "1 | layer_2 | Linear | 33 K  \n",
-      "2 | layer_3 | Linear | 2 K   \n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a2c374a9e8874d7597403fd3358584e0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(HTML(value='Training'), FloatProgress(value=1.0, bar_style='info', layout=Layout(flex='2'), max…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
+    "# even if previous Trainer finihsed his work it still keeps the GPU booked, hack to free it\n",
+    "if 'PL_TRAINER_GPUS' in os.environ:\n",
+    "    os.environ.pop('PL_TRAINER_GPUS')\n",
     "model = BetterDALILitMNIST()\n",
     "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=5)\n",
     "trainer.fit(model)"

--- a/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
@@ -132,7 +132,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bc1521c59a7c4ba28bc82f268df51ba0",
+       "model_id": "c5d5b13b638242c8a4cce5b0ea0b0885",
        "version_major": 2,
        "version_minor": 0
       },
@@ -181,7 +181,7 @@
    "outputs": [],
    "source": [
     "import nvidia.dali as dali\n",
-    "from nvidia.dali.pipeline import Pipeline\n",
+    "from nvidia.dali.pipeline import pipeline_def\n",
     "import nvidia.dali.fn as fn\n",
     "import nvidia.dali.types as types\n",
     "from nvidia.dali.plugin.pytorch import DALIClassificationIterator, LastBatchPolicy\n",
@@ -189,24 +189,22 @@
     "# Path to MNIST dataset\n",
     "data_path = os.path.join(os.environ['DALI_EXTRA_PATH'], 'db/MNIST/training/')\n",
     "\n",
-    "def CreateMnistPipeline(batch_size, device, device_id=0, shard_id=0, num_shards=1, num_threads=4, seed=0):\n",
-    "    pipe = Pipeline(batch_size, num_threads, device_id, seed)\n",
-    "    with pipe:\n",
-    "        jpegs, labels = fn.caffe2_reader(path=data_path, shard_id=shard_id, num_shards=num_shards, random_shuffle=True, name=\"Reader\")\n",
-    "        images = fn.image_decoder(jpegs,\n",
-    "                                  device='mixed' if device == 'gpu' else 'cpu',\n",
-    "                                  output_type=types.GRAY)\n",
-    "        images = fn.crop_mirror_normalize(images,\n",
-    "                                          dtype=types.FLOAT,\n",
-    "                                          std=[0.3081 * 255],\n",
-    "                                          mean=[0.1307 * 255],\n",
-    "                                          output_layout=\"CHW\")\n",
-    "        if device == \"gpu\":\n",
-    "            labels = labels.gpu()\n",
-    "        # PyTorch expects labels as INT64\n",
-    "        labels = fn.cast(labels, dtype=types.INT64)\n",
-    "        pipe.set_outputs(images, labels)\n",
-    "    return pipe"
+    "@pipeline_def\n",
+    "def GetMnistPipeline(device, shard_id=0, num_shards=1):\n",
+    "    jpegs, labels = fn.caffe2_reader(path=data_path, shard_id=shard_id, num_shards=num_shards, random_shuffle=True, name=\"Reader\")\n",
+    "    images = fn.image_decoder(jpegs,\n",
+    "                              device='mixed' if device == 'gpu' else 'cpu',\n",
+    "                              output_type=types.GRAY)\n",
+    "    images = fn.crop_mirror_normalize(images,\n",
+    "                                      dtype=types.FLOAT,\n",
+    "                                      std=[0.3081 * 255],\n",
+    "                                      mean=[0.1307 * 255],\n",
+    "                                      output_layout=\"CHW\")\n",
+    "    if device == \"gpu\":\n",
+    "        labels = labels.gpu()\n",
+    "    # PyTorch expects labels as INT64\n",
+    "    labels = fn.cast(labels, dtype=types.INT64)\n",
+    "    return images, labels"
    ]
   },
   {
@@ -230,7 +228,7 @@
     "        device_id = self.local_rank\n",
     "        shard_id = self.global_rank\n",
     "        num_shards = self.trainer.world_size\n",
-    "        mnist_pipeline = CreateMnistPipeline(BATCH_SIZE, device='gpu', device_id=device_id, shard_id=shard_id,\n",
+    "        mnist_pipeline = GetMnistPipeline(batch_size=BATCH_SIZE, device='gpu', device_id=device_id, shard_id=shard_id,\n",
     "                                       num_shards=num_shards, num_threads=8)\n",
     "        self.train_loader = DALIClassificationIterator(mnist_pipeline, reader_name=\"Reader\",\n",
     "                                                       last_batch_policy=LastBatchPolicy.PARTIAL, auto_reset=True)                          \n",
@@ -277,7 +275,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "755e06a35b1b4986a004d1a8e9230ff4",
+       "model_id": "c77ecbcc627a4e6095325f0aec9c0a56",
        "version_major": 2,
        "version_minor": 0
       },
@@ -307,7 +305,7 @@
     }
    ],
    "source": [
-    "# even if previous Trainer finihsed his work it still keeps the GPU booked, hack to free it\n",
+    "# Even if previous Trainer finished his work it still keeps the GPU booked, force it to release the device.\n",
     "if 'PL_TRAINER_GPUS' in os.environ:\n",
     "    os.environ.pop('PL_TRAINER_GPUS')\n",
     "model = DALILitMNIST()\n",
@@ -336,7 +334,7 @@
     "        device_id = self.local_rank\n",
     "        shard_id = self.global_rank\n",
     "        num_shards = self.trainer.world_size\n",
-    "        mnist_pipeline = CreateMnistPipeline(BATCH_SIZE, device='gpu', device_id=device_id, shard_id=shard_id, num_shards=num_shards, num_threads=8)\n",
+    "        mnist_pipeline = GetMnistPipeline(batch_size=BATCH_SIZE, device='gpu', device_id=device_id, shard_id=shard_id, num_shards=num_shards, num_threads=8)\n",
     "\n",
     "        class LightningWrapper(DALIClassificationIterator):\n",
     "            def __init__(self, *kargs, **kvargs):\n",
@@ -365,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "scrolled": false
    },
@@ -392,7 +390,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b7eab6f0b39f48f28941c79a24a58ba3",
+       "model_id": "59aa3ce3b1a842bbb985688d2a71d539",
        "version_major": 2,
        "version_minor": 0
       },
@@ -402,10 +400,27 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# even if previous Trainer finihsed his work it still keeps the GPU booked, hack to free it\n",
+    "# Even if previous Trainer finished his work it still keeps the GPU booked, force it to release the device.\n",
     "if 'PL_TRAINER_GPUS' in os.environ:\n",
     "    os.environ.pop('PL_TRAINER_GPUS')\n",
     "model = BetterDALILitMNIST()\n",

--- a/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
@@ -132,7 +132,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c5d5b13b638242c8a4cce5b0ea0b0885",
+       "model_id": "799fd4892c964d01b0e3d9509555ae72",
        "version_major": 2,
        "version_minor": 0
       },
@@ -163,7 +163,7 @@
    ],
    "source": [
     "model = LitMNIST()\n",
-    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=1)\n",
+    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=5)\n",
     "trainer.fit(model)"
    ]
   },
@@ -181,7 +181,7 @@
    "outputs": [],
    "source": [
     "import nvidia.dali as dali\n",
-    "from nvidia.dali.pipeline import pipeline_def\n",
+    "from nvidia.dali import pipeline_def\n",
     "import nvidia.dali.fn as fn\n",
     "import nvidia.dali.types as types\n",
     "from nvidia.dali.plugin.pytorch import DALIClassificationIterator, LastBatchPolicy\n",
@@ -275,7 +275,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c77ecbcc627a4e6095325f0aec9c0a56",
+       "model_id": "3a19cdc52d0e4596abed2902c1a4d7fa",
        "version_major": 2,
        "version_minor": 0
       },
@@ -309,7 +309,7 @@
     "if 'PL_TRAINER_GPUS' in os.environ:\n",
     "    os.environ.pop('PL_TRAINER_GPUS')\n",
     "model = DALILitMNIST()\n",
-    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=1)\n",
+    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=5)\n",
     "trainer.fit(model)"
    ]
   },
@@ -390,7 +390,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "59aa3ce3b1a842bbb985688d2a71d539",
+       "model_id": "b251208981c64d20b0469853f6a63b56",
        "version_major": 2,
        "version_minor": 0
       },
@@ -424,7 +424,7 @@
     "if 'PL_TRAINER_GPUS' in os.environ:\n",
     "    os.environ.pop('PL_TRAINER_GPUS')\n",
     "model = BetterDALILitMNIST()\n",
-    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=1)\n",
+    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=5)\n",
     "trainer.fit(model)"
    ]
   }

--- a/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
@@ -71,10 +71,13 @@
     "    x = self.layer_3(x)\n",
     "\n",
     "    x = F.log_softmax(x, dim=1)\n",
-    "    return x.cuda()\n",
+    "    return x\n",
+    "\n",
+    "  def process_batch(self, batch):\n",
+    "      return batch\n",
     "\n",
     "  def training_step(self, batch, batch_idx):\n",
-    "      x, y = batch\n",
+    "      x, y = self.process_batch(batch)\n",
     "      logits = self(x)\n",
     "      loss = F.nll_loss(logits, y)\n",
     "      return loss\n",
@@ -129,7 +132,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7a387365edfe47c2a00e36dabfc52bad",
+       "model_id": "bc1521c59a7c4ba28bc82f268df51ba0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -160,7 +163,7 @@
    ],
    "source": [
     "model = LitMNIST()\n",
-    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=5)\n",
+    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=1)\n",
     "trainer.fit(model)"
    ]
   },
@@ -210,14 +213,118 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we are ready to modify the training class to use the DALI pipeline we have just defined. Because we want to integrate with PyTorch, we wrap our pipeline with a PyTorch DALI iterator, that can replace the native data loader with some minor changes in the code. The DALI iterator returns a list of dictionaries, where each element in the list corresponds to a pipeline instance, and the entries in the dictionary map to the outputs of the pipeline. For more information, check the documentation of the DALIGenericIterator.\n",
-    "\n",
-    "As PyTorch-Lighting expects data iterator to return an iterable of raw tensors, not a dictionary, we need to provide a custom DALI iterator wrapper. Also, PyTorch can learn the size of the dataset this way."
+    "Now we are ready to modify the training class to use the DALI pipeline we have just defined. Because we want to integrate with PyTorch, we wrap our pipeline with a PyTorch DALI iterator, that can replace the native data loader with some minor changes in the code. The DALI iterator returns a list of dictionaries, where each element in the list corresponds to a pipeline instance, and the entries in the dictionary map to the outputs of the pipeline. For more information, check the documentation of DALIGenericIterator."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DALILitMNIST(LitMNIST):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "    \n",
+    "    def prepare_data(self):\n",
+    "        device_id = self.local_rank\n",
+    "        shard_id = self.global_rank\n",
+    "        num_shards = self.trainer.world_size\n",
+    "        mnist_pipeline = CreateMnistPipeline(BATCH_SIZE, device='gpu', device_id=device_id, shard_id=shard_id,\n",
+    "                                       num_shards=num_shards, num_threads=8)\n",
+    "        self.train_loader = DALIClassificationIterator(mnist_pipeline, reader_name=\"Reader\",\n",
+    "                                                       last_batch_policy=LastBatchPolicy.PARTIAL, auto_reset=True)                          \n",
+    "    def train_dataloader(self):\n",
+    "        return self.train_loader\n",
+    "    \n",
+    "    def process_batch(self, batch):\n",
+    "        x = batch[0][\"data\"]\n",
+    "        y = batch[0][\"label\"].squeeze(-1)\n",
+    "        return (x, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now run the training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "GPU available: True, used: True\n",
+      "TPU available: None, using: 0 TPU cores\n",
+      "\n",
+      "  | Name    | Type   | Params\n",
+      "-----------------------------------\n",
+      "0 | layer_1 | Linear | 100 K \n",
+      "1 | layer_2 | Linear | 33.0 K\n",
+      "2 | layer_3 | Linear | 2.6 K \n",
+      "-----------------------------------\n",
+      "136 K     Trainable params\n",
+      "0         Non-trainable params\n",
+      "136 K     Total params\n",
+      "0.544     Total estimated model params size (MB)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "755e06a35b1b4986a004d1a8e9230ff4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Training'), FloatProgress(value=1.0, bar_style='info', layout=Layout(flex='2'), max…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# even if previous Trainer finihsed his work it still keeps the GPU booked, hack to free it\n",
+    "if 'PL_TRAINER_GPUS' in os.environ:\n",
+    "    os.environ.pop('PL_TRAINER_GPUS')\n",
+    "model = DALILitMNIST()\n",
+    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=1)\n",
+    "trainer.fit(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For even better integration, we can provide a custom DALI iterator wrapper so that no extra processing is required inside `LitMNIST.process_batch`. Also, PyTorch can learn the size of the dataset this way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
@@ -285,7 +392,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fa44412d218b47e690baff58b4945f62",
+       "model_id": "b7eab6f0b39f48f28941c79a24a58ba3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -295,23 +402,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -319,7 +409,7 @@
     "if 'PL_TRAINER_GPUS' in os.environ:\n",
     "    os.environ.pop('PL_TRAINER_GPUS')\n",
     "model = BetterDALILitMNIST()\n",
-    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=5)\n",
+    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=1)\n",
     "trainer.fit(model)"
    ]
   }


### PR DESCRIPTION
- updates DALI PyTorch lighting example to work with the newest lighting
- moves to the functional API

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a n DALI PyTorch lighting example incompatibility with the latest PyTorch lighting version 

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     add a work around to free GPU booked by the previous instance of PyTorch lighting Trainer class
 - Affected modules and functionalities:
     DALI PyTorch lighting example
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test apply
 - Documentation (including examples):
     example is updated


**JIRA TASK**: *[DALI-1865]*