### PR TITLE
Improve `set_outputs` to accept list or tuple of data nodes as well

### DIFF
--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -406,17 +406,17 @@ Parameters
         elif not isinstance(outputs, list):
             outputs = [outputs]
 
-        def in_nested(container, pred, container_type):
-            if isinstance(container, container_type):
+        def is_nested(container, pred, container_types):
+            if isinstance(container, container_types):
                 if any(pred(x) for x in container):
                     return True
                 for x in container:
-                    if in_nested(x, pred, container_type):
+                    if is_nested(x, pred, container_types):
                         return True
             return False
 
         def contains_nested_datanode(nested):
-            return in_nested(nested, lambda x: isinstance(x, DataNode), (list, tuple))
+            return is_nested(nested, lambda x: isinstance(x, DataNode), (list, tuple))
 
         for i in range(len(outputs)):
             if isinstance(outputs[i], types.ScalarConstant):

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -425,7 +425,6 @@ Parameters
             elif contains_nested_datanode(outputs[i]):
                 raise TypeError(f"Illegal pipeline output type. The output {i} contains a nested "
                                 "`DataNode`. Missing list/tuple expansion (*) is the likely cause.")
-
             elif not isinstance(outputs[i], DataNode):
                 try:
                     outputs[i] = types.Constant(outputs[i], device="cpu")

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -410,6 +410,9 @@ Parameters
             if isinstance(outputs[i], types.ScalarConstant):
                 import nvidia.dali.ops
                 outputs[i] = nvidia.dali.ops._instantiate_constant_node("cpu", outputs[i])
+            elif isinstance(outputs[i], (list, tuple)) and any(isinstance(x, DataNode) for x in outputs[i]):
+                raise RuntimeError("Pipeline output cannot be a list or tuple of DataNodes, only "
+                                   "data types convertible to ``types.Constant`` are allowed.")
             elif not isinstance(outputs[i], DataNode):
                 outputs[i] = types.Constant(outputs[i], device="cpu")
             _data_node._check(outputs[i])

--- a/dali/test/python/test_functional_api.py
+++ b/dali/test/python/test_functional_api.py
@@ -2,6 +2,8 @@ import nvidia.dali.fn as fn
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.types as types
 import numpy as np
+from test_utils import compare_pipelines
+from nose.tools import assert_raises
 
 def _test_fn_rotate(device):
     pipe = Pipeline(batch_size = 1, num_threads = 1, device_id = 0)
@@ -27,6 +29,12 @@ def _test_fn_rotate(device):
         [2, 6, 10],
         [1, 5, 9]])[:,:,np.newaxis]
     assert(np.array_equal(arr, ref))
+
+def test_set_outputs():
+    data = [[[np.random.rand(1, 3, 2)], [np.random.rand(1, 4, 5)]]]
+    pipe = Pipeline(batch_size = 1, num_threads = 1, device_id = None)
+    pipe.set_outputs(fn.external_source(data, num_outputs = 2, cycle = 'quiet'))
+    assert_raises(RuntimeError, pipe.build)
 
 def test_fn_rotate():
     for device in ["cpu", "gpu"]:


### PR DESCRIPTION
- makes `set_outputs` accepting a list or tuple of data outputs as well, instead of letting DALI try converting a list of DataNodes to input of ExternalSource and failing with misleading error message

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It improves `set_outputs` to accept list or tuple of data nodes as well

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds handling of tuple/list of data nodes in `set_outputs`
 - Affected modules and functionalities:
     pipeline.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     new test is added
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
