### PR TITLE
Add error checking if provided shape to tfrecord can house underlying data

### DIFF
--- a/dali/operators/reader/parser/tfrecord_parser.h
+++ b/dali/operators/reader/parser/tfrecord_parser.h
@@ -81,9 +81,9 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
           if (!f.HasShape()) {
             output.Resize(InferShape(f, number_of_elms));
           }
-          DALI_ENFORCE(number_of_elms <= output.size(), make_string("Output tensor is too "
-                        "small, make sure that provided shape: [", output.shape(),
-                        "], is insufficient."));
+          DALI_ENFORCE(number_of_elms <= output.size(), make_string("Output tensor shape is too "
+                       "small, make sure that provided shape: [", output.shape(),
+                       "], is insufficient."));
           std::memcpy(output.mutable_data<int64_t>(),
               encoded_feature.int64_list().value().data(),
               encoded_feature.int64_list().value().size()*sizeof(int64_t));
@@ -102,9 +102,9 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
           if (!f.HasShape()) {
             output.Resize(InferShape(f, number_of_elms));
           }
-          DALI_ENFORCE(number_of_elms <= output.size(), make_string("Output tensor is too "
-                        "small, make sure that provided shape: [", output.shape(),
-                        "], is insufficient."));
+          DALI_ENFORCE(number_of_elms <= output.size(), make_string("Output tensor shape is too "
+                       "small, make sure that provided shape: [", output.shape(),
+                       "], is insufficient."));
           std::memcpy(output.mutable_data<float>(),
               encoded_feature.float_list().value().data(),
               number_of_elms * sizeof(float));

--- a/dali/operators/reader/parser/tfrecord_parser.h
+++ b/dali/operators/reader/parser/tfrecord_parser.h
@@ -82,8 +82,8 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
             output.Resize(InferShape(f, number_of_elms));
           }
           DALI_ENFORCE(number_of_elms <= output.size(), make_string("Output tensor shape is too "
-                       "small, make sure that provided shape: [", output.shape(),
-                       "], is insufficient."));
+                       "small: [", output.shape(),"]. Expected at least ", number_of_elms,
+                       " elements."));
           std::memcpy(output.mutable_data<int64_t>(),
               encoded_feature.int64_list().value().data(),
               encoded_feature.int64_list().value().size()*sizeof(int64_t));
@@ -103,8 +103,8 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
             output.Resize(InferShape(f, number_of_elms));
           }
           DALI_ENFORCE(number_of_elms <= output.size(), make_string("Output tensor shape is too "
-                       "small, make sure that provided shape: [", output.shape(),
-                       "], is insufficient."));
+                       "small: [", output.shape(),"]. Expected at least ", number_of_elms,
+                       " elements."));
           std::memcpy(output.mutable_data<float>(),
               encoded_feature.float_list().value().data(),
               number_of_elms * sizeof(float));

--- a/dali/operators/reader/parser/tfrecord_parser.h
+++ b/dali/operators/reader/parser/tfrecord_parser.h
@@ -82,7 +82,7 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
             output.Resize(InferShape(f, number_of_elms));
           }
           DALI_ENFORCE(number_of_elms <= output.size(), make_string("Output tensor shape is too "
-                       "small: [", output.shape(),"]. Expected at least ", number_of_elms,
+                       "small: [", output.shape(), "]. Expected at least ", number_of_elms,
                        " elements."));
           std::memcpy(output.mutable_data<int64_t>(),
               encoded_feature.int64_list().value().data(),
@@ -103,7 +103,7 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
             output.Resize(InferShape(f, number_of_elms));
           }
           DALI_ENFORCE(number_of_elms <= output.size(), make_string("Output tensor shape is too "
-                       "small: [", output.shape(),"]. Expected at least ", number_of_elms,
+                       "small: [", output.shape(), "]. Expected at least ", number_of_elms,
                        " elements."));
           std::memcpy(output.mutable_data<float>(),
               encoded_feature.float_list().value().data(),

--- a/dali/test/python/test_operator_index_reader.py
+++ b/dali/test/python/test_operator_index_reader.py
@@ -1,12 +1,13 @@
 import math
-from nvidia.dali.pipeline import Pipeline
+from nvidia.dali import Pipeline
 import nvidia.dali.ops as ops
+import nvidia.dali.fn as fn
 import nvidia.dali.tfrecord as tfrec
 import os.path
 import tempfile
 import numpy as np
-
-test_data_root = os.environ['DALI_EXTRA_PATH']
+from test_utils import get_dali_extra_path
+from nose.tools import assert_raises
 
 def skip_second(src, dst):
     with open(src, 'r') as tmp_f:
@@ -32,8 +33,8 @@ def test_tfrecord():
             images = inputs["image/encoded"]
             return images
 
-    tfrecord = os.path.join(test_data_root, 'db', 'tfrecord', 'train')
-    tfrecord_idx_org = os.path.join(test_data_root, 'db', 'tfrecord', 'train.idx')
+    tfrecord = os.path.join(get_dali_extra_path(), 'db', 'tfrecord', 'train')
+    tfrecord_idx_org = os.path.join(get_dali_extra_path(), 'db', 'tfrecord', 'train.idx')
     tfrecord_idx = "tfr_train.idx"
 
     idx_files_dir = tempfile.TemporaryDirectory()
@@ -64,8 +65,8 @@ def test_recordio():
             images, _ = self.input(name="Reader")
             return images
 
-    recordio = os.path.join(test_data_root, 'db', 'recordio', 'train.rec')
-    recordio_idx_org = os.path.join(test_data_root, 'db', 'recordio', 'train.idx')
+    recordio = os.path.join(get_dali_extra_path(), 'db', 'recordio', 'train.rec')
+    recordio_idx_org = os.path.join(get_dali_extra_path(), 'db', 'recordio', 'train.idx')
     recordio_idx = "rio_train.idx"
 
     idx_files_dir = tempfile.TemporaryDirectory()
@@ -84,3 +85,19 @@ def test_recordio():
         for a, b in zip(out, out_ref):
             assert np.array_equal(a.as_array(), b.as_array())
         _ = pipe_org.run()
+
+def test_wrong_feature_shape():
+    features = {
+        'image/encoded': tfrec.FixedLenFeature((), tfrec.string, ""),
+        'image/object/bbox': tfrec.FixedLenFeature([], tfrec.float32, -1.0),
+        'image/object/class/label': tfrec.FixedLenFeature([], tfrec.int64, -1),
+    }
+    test_dummy_data_path = os.path.join(get_dali_extra_path(), 'db', 'coco_dummy')
+    pipe = Pipeline(1, 1, 0)
+    with pipe:
+        input = fn.tfrecord_reader(path = os.path.join(test_dummy_data_path, 'small_coco.tfrecord'),
+                                   index_path = os.path.join(test_dummy_data_path, 'small_coco_index.idx'),
+                                   features = features)
+    pipe.set_outputs(input['image/encoded'], input['image/object/class/label'], input['image/object/bbox'])
+    pipe.build()
+    assert_raises(RuntimeError, pipe.run)

--- a/dali/test/python/test_operator_index_reader.py
+++ b/dali/test/python/test_operator_index_reader.py
@@ -100,4 +100,5 @@ def test_wrong_feature_shape():
                                    features = features)
     pipe.set_outputs(input['image/encoded'], input['image/object/class/label'], input['image/object/bbox'])
     pipe.build()
+    # the error is raised because FixedLenFeature is used with insufficient shape to house the input
     assert_raises(RuntimeError, pipe.run)


### PR DESCRIPTION
- when the user provides a shape to tfrecord feature descrption there was not check if the reader output tensor is big enough and there won't be out of bound access. This change adds proper DALI_ENFORCE

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds error checking if provided shape to tfrecord can house underlying data

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     when the user provides a shape to tfrecord feature descrption there was not check if the reader output tensor is big enough and there won't be out of bound access. This change adds proper DALI_ENFORCE
 - Affected modules and functionalities:
     tfrecord_parser
 - Key points relevant for the review:
     NA
 - Validation and testing:
     new test is added
 - Documentation (including examples):
     NA

Relates to https://github.com/NVIDIA/DALI/issues/2701
**JIRA TASK**: *[NA]*
