### PR TITLE
Add break of VideoReader loop when keyframe past requested has been reached

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -575,6 +575,9 @@ void VideoLoader::read_file() {
           if (!is_first_frame) {
             nonkey_frame_count = 0;
             if (frame > req.frame + req.count) {
+              // Found a key frame past the requested range. We can stop searching
+              // (If there were missing frames in the range they won't be found after
+              // the next key frame)
               break;
             }
           }

--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -552,9 +552,9 @@ void VideoLoader::read_file() {
       if ((!key && is_first_frame) ||
           (key && frame > req.frame && is_first_frame)) {
           LOG_LINE << device_id_ << ": We got ahead of ourselves! "
-                    << frame << " > " << req.frame << " + "
-                    << nonkey_frame_count
-                    << " seek_hack = " << seek_hack << std::endl;
+                   << frame << " > " << req.frame << " + "
+                   << nonkey_frame_count
+                   << " seek_hack = " << seek_hack << std::endl;
           if (seek_must_succeed) {
             std::stringstream ss;
             ss << device_id_ << ": failed to seek frame "
@@ -572,10 +572,11 @@ void VideoLoader::read_file() {
       }
       if (frame > req.frame) {
         if (key) {
-          if (frames_left <= 0)
-            break;
           if (!is_first_frame) {
             nonkey_frame_count = 0;
+            if (frame > req.frame + req.count) {
+              break;
+            }
           }
           seek_must_succeed = false;
         } else {


### PR DESCRIPTION
- adds a frame reading loop break when a keyframe following the end of the last requested frame in the sequence

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a frame reading loop break when a keyframe following the end of the last requested frame in the sequence

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a frame reading loop break when a keyframe following the end of the last requested frame in the sequence
 - Affected modules and functionalities:
     video_loader
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
