### PR TITLE
Fix type of slice's rel_shape argument

### DIFF
--- a/dali/operators/generic/slice/slice_attr.cc
+++ b/dali/operators/generic/slice/slice_attr.cc
@@ -61,7 +61,7 @@ is incompatible with providing positional inputs anchor and shape.)code",
 Providing named arguments ``start``, ``end``, ``shape``, ``rel_start``, ``rel_end``, ``rel_shape``
 is incompatible with providing positional inputs anchor and shape.)code",
         nullptr, true)
-    .AddOptionalArg<std::vector<int>>("rel_shape",
+    .AddOptionalArg<std::vector<float>>("rel_shape",
         R"code(Relative shape of the slice (range [0.0 - 1.0]).
 
 Providing named arguments ``start``, ``end``, ``shape``, ``rel_start``, ``rel_end``, ``rel_shape``

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -609,7 +609,7 @@ def check_slice_named_args(device, batch_size):
             for rel_end_arg in [rel_end, rel_end_list]:
                 outs += [fn.slice(data, rel_start=rel_start_arg, rel_end=rel_end_arg, axes = (0, 1))]
             for shape_arg in [shape, shape_list]:
-                outs += [fn.slice(data, rel_start=start_arg, shape=shape_arg, axes = (0, 1))]
+                outs += [fn.slice(data, rel_start=rel_start_arg, shape=shape_arg, axes = (0, 1))]
         pipe.set_outputs(*outs)
     pipe.build()
     for _ in range(3):


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in SliceAttr: ``rel_shape`` should be of type ``vector<float>``

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Fixed the type of ``rel_shape`` in SliceAttr*
 - Affected modules and functionalities:
     *Slice operator, when using the operator object API*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[Use DALI-XXXX or NA]*
