### PR TITLE
Add hash-based caching to RandomObjectBBox.

### DIFF
--- a/dali/kernels/common/fast_hash.h
+++ b/dali/kernels/common/fast_hash.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_COMMON_FAST_HASH_H_
+#define DALI_KERNELS_COMMON_FAST_HASH_H_
+
+#include <cstdint>
+#include <cstddef>
+#include <functional>
+#include "dali/core/force_inline.h"
+
+namespace dali {
+namespace kernels {
+
+struct fast_hash_t {
+  uint32_t data[8];
+
+  bool operator==(const fast_hash_t &other) const {
+    for (int i = 0; i < 8; i++) {
+      if (data[i] != other.data[i])
+        return false;
+    }
+    return true;
+  }
+  bool operator!=(const fast_hash_t &other) const {
+    return !(*this == other);
+  }
+  bool operator<(const fast_hash_t &other) const {
+    for (int i = 0; i < 8; i++) {
+      if (data[i] < other.data[i])
+        return true;
+      if (data[i] > other.data[i])
+        return false;
+    }
+    return false;
+  }
+};
+
+DALI_FORCEINLINE
+constexpr uint32_t rotl(uint32_t x, uint8_t r) {
+  return (x << r) | (x >> (32-r));
+}
+
+inline void fast_hash(fast_hash_t &hash, const void *data, size_t n) {
+  const uint8_t *data8 = static_cast<const uint8_t *>(data);
+  constexpr uint32_t prime = 2246822519u;
+  constexpr uint32_t bias =   103456789u;
+  size_t offset = 0;
+  for (; offset + 32 <= n; offset += 32) {
+    const uint32_t *data32 = reinterpret_cast<const uint32_t*>(data8 + offset);
+    fast_hash_t prev = hash;
+    hash.data[0] += (rotl(prev.data[7], 13) + data32[0] + bias) * prime;
+    hash.data[1] += (rotl(prev.data[0], 16) + data32[1] + bias) * prime;
+    hash.data[2] += (rotl(prev.data[1], 15) + data32[2] + bias) * prime;
+    hash.data[3] += (rotl(prev.data[2], 17) + data32[3] + bias) * prime;
+    hash.data[4] += (rotl(prev.data[3], 14) + data32[4] + bias) * prime;
+    hash.data[5] += (rotl(prev.data[4], 18) + data32[5] + bias) * prime;
+    hash.data[6] += (rotl(prev.data[5], 12) + data32[6] + bias) * prime;
+    hash.data[7] += (rotl(prev.data[6], 19) + data32[7] + bias) * prime;
+  }
+  int k = 0;
+  for (; offset + 4 <= n; offset += 4, k++) {
+    const uint32_t *data32 = reinterpret_cast<const uint32_t*>(data8 + offset);
+    hash.data[k] += (rotl(hash.data[(k-1) & 7], 13) + *data32 + bias) * prime;
+  }
+  uint32_t tail = 0xCCCCCCCCu + offset;
+  k &= 7;
+  for (; offset < n; offset++) {
+      tail = rotl(tail, 17) + data8[offset] * prime;
+  }
+  hash.data[k] = (rotl(hash.data[(k-1) & 7], 13) + tail) * prime;
+  // final diffusion, to make hashes visually different even if the data differs near the end
+  for (int k = 0; k < 8; k++) {
+    hash.data[k] += (hash.data[(k+1) & 7] + bias) * prime;
+  }
+  for (int k = 0; k < 8; k++) {
+    hash.data[k] += (hash.data[(k-1) & 7] + bias) * prime;
+  }
+}
+
+}  // namespace kernels
+}  // namespace dali
+
+namespace std {
+
+template<>
+struct hash<dali::kernels::fast_hash_t> {
+  size_t operator()(const dali::kernels::fast_hash_t &h) const {
+    return h.data[0];
+  }
+};
+
+}  // namespace std
+
+#endif  // DALI_KERNELS_COMMON_FAST_HASH_H_

--- a/dali/kernels/common/fast_hash.h
+++ b/dali/kernels/common/fast_hash.h
@@ -53,13 +53,25 @@ constexpr uint32_t rotl(uint32_t x, uint8_t r) {
 }
 
 inline void fast_hash(fast_hash_t &hash, const void *data, size_t n) {
+  // Loosely based on xxHash 3.
+  //
+  // This function computes a 256-bit non-cryptographic hash.
+  // The entropy is diffused across the whole hash (unlike xxHash) by combinng a state entry
+  // with another state entry (shifted by 1 word). The bit rotations are different for each
+  // entry and a bias is added to avoid lack of entropy in constant 0 inputs.
   const uint8_t *data8 = static_cast<const uint8_t *>(data);
-  constexpr uint32_t prime = 2246822519u;
-  constexpr uint32_t bias =   103456789u;
+  constexpr uint32_t prime = 2246822519u;  // prime
+  constexpr uint32_t bias =   103456789u;  // another prime
+
   size_t offset = 0;
   for (; offset + 32 <= n; offset += 32) {
     const uint32_t *data32 = reinterpret_cast<const uint32_t*>(data8 + offset);
     fast_hash_t prev = hash;
+
+    // Hash entries are cycled (see index at prev.data) in order to distribute.
+    // changes that have a period matching the hash size.
+    // Each hash entry is rotated by a different bit count to make hash more sensitive
+    // to position of changes.
     hash.data[0] += (rotl(prev.data[7], 13) + data32[0] + bias) * prime;
     hash.data[1] += (rotl(prev.data[0], 16) + data32[1] + bias) * prime;
     hash.data[2] += (rotl(prev.data[1], 15) + data32[2] + bias) * prime;
@@ -69,18 +81,23 @@ inline void fast_hash(fast_hash_t &hash, const void *data, size_t n) {
     hash.data[6] += (rotl(prev.data[5], 12) + data32[6] + bias) * prime;
     hash.data[7] += (rotl(prev.data[6], 19) + data32[7] + bias) * prime;
   }
+  // proces trailing 32-bit words
   int k = 0;
   for (; offset + 4 <= n; offset += 4, k++) {
     const uint32_t *data32 = reinterpret_cast<const uint32_t*>(data8 + offset);
     hash.data[k] += (rotl(hash.data[(k-1) & 7], 13) + *data32 + bias) * prime;
   }
+  // Process trailing bytes - make sure that the number of trailing constant values (including 0)
+  // changes the output.
   uint32_t tail = 0xCCCCCCCCu + offset;
   k &= 7;
   for (; offset < n; offset++) {
       tail = rotl(tail, 17) + data8[offset] * prime;
   }
   hash.data[k] = (rotl(hash.data[(k-1) & 7], 13) + tail) * prime;
-  // final diffusion, to make hashes visually different even if the data differs near the end
+
+  // Final diffusion, to make hashes visually different even if the data differs near the end
+  // and the changes were not cycled through the whole hash yet.
   for (int k = 0; k < 8; k++) {
     hash.data[k] += (hash.data[(k+1) & 7] + bias) * prime;
   }

--- a/dali/operators/segmentation/random_object_bbox.cc
+++ b/dali/operators/segmentation/random_object_bbox.cc
@@ -103,8 +103,8 @@ Possible choices are::
   * "start_end" - there are two outputs: bounding box start and one-past-end coordinates
   * "box" - there is one output that contains concatenated start and end coordinates
 )", "anchor_shape")
-  .AddOptionalArg("cache_objects", R"(Cache boxes to avoid the computational cost of finding
-object blobs.
+  .AddOptionalArg("cache_objects", R"(Cache object bounding boxes to avoid the computational cost
+of finding object blobs in previously seen inputs.
 
 Searching for blobs of connected pixels and finding boxes can take a long time. When the dataset
 has few items, but item size is big, you can use caching to save the boxes and reuse them when

--- a/dali/operators/segmentation/random_object_bbox.cc
+++ b/dali/operators/segmentation/random_object_bbox.cc
@@ -465,7 +465,7 @@ bool RandomObjectBBox::PickForegroundBox(
   CacheEntry *cache_entry = nullptr;
   kernels::fast_hash_t hash = {};
   if (use_cache_) {
-    kernels::fast_hash(hash, input.data, input.num_elements() * sizeof(T));
+    fast_hash(hash, input.data, input.num_elements() * sizeof(T));
     cache_entry = &cache_[hash];
   }
 
@@ -478,14 +478,14 @@ bool RandomObjectBBox::PickForegroundBox(
     }
     return PickBox(context);
   } else {
-    /*if (cache_entry && !cache_entry->labels.empty()) {
+    if (cache_entry && !cache_entry->labels.empty()) {
       context.labels = cache_entry->labels;
-    } else {*/
+    } else {
       context.FindLabels(input);
       context.labels.erase(class_info_.background);
       if (cache_entry)
         cache_entry->labels = context.labels;
-    //}
+    }
 
     if (!classes_.IsDefined() && !weights_.IsDefined()) {
       class_info_.FromLabels(context.labels);

--- a/dali/operators/segmentation/random_object_bbox.cc
+++ b/dali/operators/segmentation/random_object_bbox.cc
@@ -109,9 +109,7 @@ object blobs.
 Searching for blobs of connected pixels and finding boxes can take a long time. When the dataset
 has few items, but item size is big, you can use caching to save the boxes and reuse them when
 the same input is seen again. The inputs are compared based on 256-bit hash, which is much faster
-to compute than to recalculate the object boxes.
-
-This argument cannot be used when `classes` or `background` change at run-time.)", false);
+to compute than to recalculate the object boxes.)", false);
 
 bool RandomObjectBBox::SetupImpl(vector<OutputDesc> &out_descs, const HostWorkspace &ws) {
   out_descs.resize(spec_.NumOutput());

--- a/dali/operators/segmentation/random_object_bbox.h
+++ b/dali/operators/segmentation/random_object_bbox.h
@@ -69,11 +69,6 @@ class RandomObjectBBox : public Operator<CPUBackend> {
                    "``k_largest`` must be at least 1; got ", k_largest_));
     }
 
-    if (use_cache_) {
-      DALI_ENFORCE(!classes_.IsArgInput() && !background_.IsArgInput(),
-        "`cache_objects` option cannot be used when `classes` or `background` are DataNodes.");
-    }
-
     tmp_blob_storage_.set_pinned(false);
     tmp_filtered_storage_.set_pinned(false);
   }

--- a/dali/test/python/test_operator_random_object_bbox.py
+++ b/dali/test/python/test_operator_random_object_bbox.py
@@ -264,6 +264,9 @@ def _test_random_object_bbox_with_class(max_batch_size, ndim, dtype, format=None
 
     format = format or "anchor_shape"
 
+    foreground_hits = 0
+    total_samples = 0
+
     for _ in range(50):
         inp, classes_out, weights_out, background_out, threshold_out, *outs = pipe.run()
         nout = (len(outs) - 1) // 2
@@ -280,6 +283,7 @@ def _test_random_object_bbox_with_class(max_batch_size, ndim, dtype, format=None
         boxes = convert_boxes(outs, format)
 
         for i in range(len(inp)):
+            total_samples += 1
             in_tensor = inp.at(i)
             class_labels = classes_out.at(i)
             if background is not None or classes is None:
@@ -292,6 +296,8 @@ def _test_random_object_bbox_with_class(max_batch_size, ndim, dtype, format=None
                 assert label == background_label or label in list(class_labels)
 
             is_foreground = label != background_label
+            if is_foreground:
+                foreground_hits += 1
             cls_boxes = class_boxes(in_tensor, label if is_foreground else None)
 
             if is_foreground:

--- a/dali/test/python/test_operator_random_object_bbox.py
+++ b/dali/test/python/test_operator_random_object_bbox.py
@@ -56,7 +56,6 @@ def test_num_output():
 
 @nottest
 def _test_use_foreground(classes, weights, bg):
-    """Test that a proper number of outputs is produced, depending on arguments"""
     inp = fn.external_source(data, batch=False, cycle="quiet")
     pipe = dali.pipeline.Pipeline(10, 4, 0, 12345)
     pipe_outs = fn.segmentation.random_object_bbox(inp, output_class=True, foreground_prob=1, classes=classes, class_weights=weights, background=bg)
@@ -67,6 +66,7 @@ def _test_use_foreground(classes, weights, bg):
         assert outs[2].at(i) != (bg or 0)
 
 def test_use_foreground():
+    """Test that a foreground box is returned when required (prob=1) and possible (fixed data)"""
     for classes, weights, bg in [
         (None, None, None),
         (None, None, 1),
@@ -191,16 +191,29 @@ def generate_data(shape, num_classes, blobs_per_class):
 
     return label
 
+def generate_samples(num_samples, ndim, dtype):
+    samples = []
+    for i in range(num_samples):
+        shape = list(np.random.randint(5, 13, [ndim]))
+        num_classes = np.random.randint(1, 10)
+        blobs_per_class = np.random.randint(1, 10);
+        samples.append(generate_data(shape, num_classes, blobs_per_class).astype(dtype))
+    return samples
+
+
 def batch_generator(batch_size, ndim, dtype):
+    """Returns a generator that generates completely new data each time it's called"""
     def gen():
         # batch_size = np.random.randint(1, max_batch_size+1)
-        batch = []
-        for i in range(batch_size):
-            shape = list(np.random.randint(5, 13, [ndim]))
-            num_classes = np.random.randint(1, 10)
-            blobs_per_class = np.random.randint(1, 10);
-            batch.append(generate_data(shape, num_classes, blobs_per_class).astype(dtype))
-        return batch
+        return generate_samples(batch_size, ndim, dtype)
+    return gen
+
+def sampled_dataset(dataset_size, batch_size, ndim, dtype):
+    """Returns a generator that returns random samples from a pre-generated dataset"""
+    data = generate_samples(dataset_size, ndim, dtype)
+    def gen():
+        # batch_size = np.random.randint(1, max_batch_size+1)
+        return [random.choice(data) for _ in range(batch_size)]
     return gen
 
 def random_classes(background):
@@ -235,15 +248,20 @@ def convert_boxes(outs, format):
 @nottest
 def _test_random_object_bbox_with_class(max_batch_size, ndim, dtype, format=None, fg_prob=None,
                                         classes=None, weights=None, background=None,
-                                        threshold=None, k_largest=None):
+                                        threshold=None, k_largest=None, cache=None):
     pipe = dali.Pipeline(max_batch_size, 4, device_id = None, seed=4321)
     background_out = 0 if background is None else background
     classes_out = np.int32([]) if classes is None else classes
     weights_out = np.int32([]) if weights is None else weights
     threshold_out = np.int32([]) if threshold is None else threshold
 
+    if cache:
+        source = sampled_dataset(2 * max_batch_size, max_batch_size, ndim, dtype)
+    else:
+        source = batch_generator(max_batch_size, ndim, dtype)
+
     with pipe:
-        inp = fn.external_source(batch_generator(max_batch_size, ndim, dtype))
+        inp = fn.external_source(source)
         if isinstance(background, dali.pipeline.DataNode) or (background is not None and background >= 0):
             inp = fn.cast(inp + (background_out + 1), dtype=np_type_to_dali(dtype))
         # preconfigure
@@ -252,7 +270,7 @@ def _test_random_object_bbox_with_class(max_batch_size, ndim, dtype, format=None
                                                classes=classes, class_weights=weights, background=background,
                                                threshold=threshold, k_largest=k_largest,
                                                seed=1234)
-        outs1 = op(inp)
+        outs1 = op(inp, cache_objects=cache)
         outs2 = op(inp, output_class=True)
         if not isinstance(outs1, list):
             outs1 = [outs1]
@@ -280,7 +298,6 @@ def _test_random_object_bbox_with_class(max_batch_size, ndim, dtype, format=None
         boxes = convert_boxes(outs, format)
 
         for i in range(len(inp)):
-            total_samples += 1
             in_tensor = inp.at(i)
             class_labels = classes_out.at(i)
             if background is not None or classes is None:
@@ -346,7 +363,8 @@ def test_random_object_bbox_with_class():
                 format = formats[fmt]
                 fmt = (fmt + 1) % len(formats)
                 dtype = random.choice(types)
-                yield _test_random_object_bbox_with_class, 4, ndim, dtype, format, fg_prob, classes, weights, bg, threshold, k_largest
+                cache = np.random.randint(2) == 1
+                yield _test_random_object_bbox_with_class, 4, ndim, dtype, format, fg_prob, classes, weights, bg, threshold, k_largest, cache
 
 @nottest
 def _test_random_object_bbox_ignore_class(max_batch_size, ndim, dtype, format=None, background=None, threshold=None, k_largest=None):
@@ -437,7 +455,6 @@ def _test_err_args(**kwargs):
     pipe.set_outputs(*outs)
     pipe.build()
     pipe.run()
-
 
 def test_err_classes_bg():
     with assert_raises(RuntimeError):

--- a/dali/test/python/test_operator_random_object_bbox.py
+++ b/dali/test/python/test_operator_random_object_bbox.py
@@ -264,9 +264,6 @@ def _test_random_object_bbox_with_class(max_batch_size, ndim, dtype, format=None
 
     format = format or "anchor_shape"
 
-    foreground_hits = 0
-    total_samples = 0
-
     for _ in range(50):
         inp, classes_out, weights_out, background_out, threshold_out, *outs = pipe.run()
         nout = (len(outs) - 1) // 2
@@ -296,8 +293,6 @@ def _test_random_object_bbox_with_class(max_batch_size, ndim, dtype, format=None
                 assert label == background_label or label in list(class_labels)
 
             is_foreground = label != background_label
-            if is_foreground:
-                foreground_hits += 1
             cls_boxes = class_boxes(in_tensor, label if is_foreground else None)
 
             if is_foreground:


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature: hash-based cache in RandomObjectBBox

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added a new option "cache_objects" which enables caching
     * Added a very fast hashing function
     * Added a cache, where boxes are stored
 - Affected modules and functionalities:
     * RandomObjectBBox
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Fix: Added test that checks that oversampling really happens
     * Cache: Generate a random dataset and sample from it, to trigger caching.
 - Documentation (including examples):
     * Docstring


**JIRA TASK**: DALI-1857
