### PR TITLE
Fix a regression in RandomObjectBBox: weights not set to default.

### DIFF
--- a/dali/operators/segmentation/random_object_bbox.cc
+++ b/dali/operators/segmentation/random_object_bbox.cc
@@ -278,7 +278,7 @@ void RandomObjectBBox::ClassInfo::Init(const int *bg_ptr,
   if (cls_tv.data) {
     int ncls = cls_tv.shape[0];
     classes.resize(ncls);
-    if (!cls_tv.data) {
+    if (!weight_tv.data) {
       weights.clear();
       weights.resize(ncls, 1.0f);
     }


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: weights not set to default when classes are specified, but weights are not.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Fixed :)
     * Added test
 - Affected modules and functionalities:
     * RandomObjectBBox
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python test
 - Documentation (including examples):
     * N/A


**JIRA TASK**: N/A
