### PR TITLE
Move decoders to decoders module

### DIFF
--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -53,8 +53,8 @@ DALI_REGISTER_OPERATOR(AudioDecoder, AudioDecoderCpu, CPU);
 
 DALI_SCHEMA(AudioDecoder)
     .DocStr("Legacy alias for :meth:`decoders.audio`.")
-  .NumInput(1)
-  .NumOutput(2)
+    .NumInput(1)
+    .NumOutput(2)
     .AddParent("decoders__Audio")
     .MakeDocPartiallyHidden()
     .Deprecate(

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -19,7 +19,9 @@
 
 namespace dali {
 
-DALI_SCHEMA(AudioDecoder)
+DALI_REGISTER_OPERATOR(decoders__Audio, AudioDecoderCpu, CPU);
+
+DALI_SCHEMA(decoders__Audio)
   .DocStr(R"code(Decodes waveforms from encoded audio data.
 
 It supports the following audio formats: wav, flac and ogg.
@@ -46,7 +48,20 @@ the highest.
 0 gives 3 lobes of the sinc filter, 50 gives 16 lobes, and 100 gives 64 lobes.)code",
           50.0f, false);
 
+
 DALI_REGISTER_OPERATOR(AudioDecoder, AudioDecoderCpu, CPU);
+
+DALI_SCHEMA(AudioDecoder)
+    .DocStr("Legacy alias for :meth:`decoders.audio`.")
+  .NumInput(1)
+  .NumOutput(2)
+    .AddParent("decoders__Audio")
+    .MakeDocPartiallyHidden()
+    .Deprecate(
+        "decoders__Audio",
+        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
+submodule and renamed to follow a common pattern. This is a placeholder operator with identical
+functionality to allow for backward compatibility.)code");  // Deprecated in 1.0;
 
 bool
 AudioDecoderCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) {

--- a/dali/operators/decoder/host/fused/host_decoder_crop.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_crop.cc
@@ -29,6 +29,7 @@ HostDecoderCrop::HostDecoderCrop(const OpSpec &spec)
   , CropAttr(spec) {
 }
 
+DALI_REGISTER_OPERATOR(decoders__ImageCrop, HostDecoderCrop, CPU);
 DALI_REGISTER_OPERATOR(ImageDecoderCrop, HostDecoderCrop, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/host/fused/host_decoder_random_crop.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_random_crop.cc
@@ -23,6 +23,7 @@
 
 namespace dali {
 
+DALI_REGISTER_OPERATOR(decoders__ImageRandomCrop, HostDecoderRandomCrop, CPU);
 DALI_REGISTER_OPERATOR(ImageDecoderRandomCrop, HostDecoderRandomCrop, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/host/fused/host_decoder_slice.cc
+++ b/dali/operators/decoder/host/fused/host_decoder_slice.cc
@@ -28,6 +28,7 @@ HostDecoderSlice::HostDecoderSlice(const OpSpec &spec)
   , slice_attr_(spec) {
 }
 
+DALI_REGISTER_OPERATOR(decoders__ImageSlice, HostDecoderSlice, CPU);
 DALI_REGISTER_OPERATOR(ImageDecoderSlice, HostDecoderSlice, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/host/host_decoder.cc
+++ b/dali/operators/decoder/host/host_decoder.cc
@@ -48,6 +48,7 @@ void HostDecoder::RunImpl(SampleWorkspace &ws) {
   std::memcpy(out_data, decoded.get(), volume(shape));
 }
 
+DALI_REGISTER_OPERATOR(decoders__Image, HostDecoder, CPU);
 DALI_REGISTER_OPERATOR(ImageDecoder, HostDecoder, CPU);
 
 }  // namespace dali

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -339,7 +339,7 @@ submodule and renamed to follow a common pattern. This is a placeholder operator
 functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
 
 DALI_SCHEMA(ImageDecoderRandomCrop)
-    .DocStr("Legacy alias for :meth:`decoders.image_random`.")
+    .DocStr("Legacy alias for :meth:`decoders.image_random_crop`.")
     .NumInput(1)
     .NumOutput(1)
     .AddParent("decoders__ImageRandomCrop")

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -127,7 +127,7 @@ allocation might be useful to determine suitable values for ``device_memory_padd
 )code",
       false);
 
-DALI_SCHEMA(ImageDecoder)
+DALI_SCHEMA(decoders__Image)
   .DocStr(R"code(Decodes images.
 
 For jpeg images, depending on the backend selected ("mixed" and "cpu"), the implementation uses
@@ -175,7 +175,7 @@ The hint is used to preallocate memory for the HW JPEG decoder.)code",
 
 // Fused
 
-DALI_SCHEMA(ImageDecoderCrop)
+DALI_SCHEMA(decoders__ImageCrop)
   .DocStr(R"code(Decodes images and extracts regions-of-interest (ROI) that are specified
 by fixed window dimensions and variable anchors.
 
@@ -185,8 +185,8 @@ image format, it will decode the entire image and crop the selected ROI.
 
 .. note::
   ROI decoding is currently not compatible with hardware-based decoding. Using
-  :meth:`nvidia.dali.fn.image_decoder` automatically disables hardware accelerated
-  decoding. To use the hardware decoder, use the :meth:`nvidia.dali.fn.image_decoder` and
+  :meth:`nvidia.dali.fn.decoders.image` automatically disables hardware accelerated
+  decoding. To use the hardware decoder, use the :meth:`nvidia.dali.fn.decoders.image` and
   :meth:`nvidia.dali.fn.crop` operators instead.
 
 The output of the decoder is in *HWC* layout.
@@ -196,7 +196,7 @@ Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
 .. note::
   JPEG 2000 region-of-interest (ROI) decoding is not accelerated on the GPU, and will use
   a CPU implementation regardless of the selected backend. For a GPU accelerated implementation,
-  consider using separate ``image_decoder`` and ``crop`` operators.
+  consider using separate ``decoders.image`` and ``crop`` operators.
 
 .. note::
   EXIF orientation metadata is disregarded.)code")
@@ -205,7 +205,7 @@ Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
   .AddParent("ImageDecoderAttr")
   .AddParent("CropAttr");
 
-DALI_SCHEMA(ImageDecoderRandomCrop)
+DALI_SCHEMA(decoders__ImageRandomCrop)
   .DocStr(R"code(Decodes images and randomly crops them.
 
 The cropping window's area (relative to the entire image) and aspect ratio can be restricted to
@@ -217,8 +217,8 @@ image format, it will decode the entire image and crop the selected ROI.
 
 .. note::
   ROI decoding is currently not compatible with hardware-based decoding. Using
-  :meth:`nvidia.dali.fn.image_decoder_random_crop` automatically disables hardware accelerated
-  decoding. To use the hardware decoder, use the :meth:`nvidia.dali.fn.image_decoder` and
+  :meth:`nvidia.dali.fn.decoders.image_random_crop` automatically disables hardware accelerated
+  decoding. To use the hardware decoder, use the :meth:`nvidia.dali.fn.decoders.image` and
   :meth:`nvidia.dali.fn.random_crop` operators instead.
 
 The output of the decoder is in *HWC* layout.
@@ -228,7 +228,7 @@ Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
 .. note::
   JPEG 2000 region-of-interest (ROI) decoding is not accelerated on the GPU, and will use
   a CPU implementation regardless of the selected backend. For a GPU accelerated implementation,
-  consider using separate ``image_decoder`` and ``random_crop`` operators.
+  consider using separate ``decoders.image`` and ``random_crop`` operators.
 
 .. note::
   EXIF orientation metadata is disregarded.)code")
@@ -238,7 +238,7 @@ Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
   .AddParent("RandomCropAttr");
 
 
-DALI_SCHEMA(ImageDecoderSlice)
+DALI_SCHEMA(decoders__ImageSlice)
   .DocStr(R"code(Decodes images and extracts regions of interest.
 
 The slice can be specified by proving the start and end coordinates, or start coordinates
@@ -265,7 +265,7 @@ and shape is incompatible with the named arguments specified above.
 The slice arguments should provide as many dimensions as specified by the ``axis_names`` or ``axes``
 arguments.
 
-By default, the :meth:`nvidia.dali.fn.image_decoder_slice` operator uses normalized coordinates
+By default, the :meth:`nvidia.dali.fn.decoders.image_slice` operator uses normalized coordinates
 and "WH" order for the slice arguments.
 
 When possible, the argument uses the ROI decoding APIs (for example, *libjpeg-turbo* and *nvJPEG*)
@@ -274,8 +274,8 @@ image format, it will decode the entire image and crop the selected ROI.
 
 .. note::
   ROI decoding is currently not compatible with hardware-based decoding. Using
-  :meth:`nvidia.dali.fn.image_decoder_slice` automatically disables hardware accelerated decoding.
-  To use the hardware decoder, use the :meth:`nvidia.dali.fn.image_decoder` and
+  :meth:`nvidia.dali.fn.decoders.image_slice` automatically disables hardware accelerated decoding.
+  To use the hardware decoder, use the :meth:`nvidia.dali.fn.decoders.image` and
   :meth:`nvidia.dali.fn.slice` operators instead.
 
 The output of the decoder is in the *HWC* layout.
@@ -285,7 +285,7 @@ Supported formats: JPG, BMP, PNG, TIFF, PNM, PPM, PGM, PBM, JPEG 2000.
 .. note::
   JPEG 2000 region-of-interest (ROI) decoding is not accelerated on the GPU, and will use
   a CPU implementation regardless of the selected backend. For a GPU accelerated implementation,
-  consider using separate ``image_decoder`` and ``slice`` operators.
+  consider using separate ``decoders.image`` and ``slice`` operators.
 
 .. note::
   EXIF orientation metadata is disregarded.)code")
@@ -308,5 +308,59 @@ of the slice (s0, s1, s2, …).
 Integer coordinates are interpreted as absolute coordinates, while float coordinates can be
 interpreted as absolute or relative coordinates, depending on the value of
 ``normalized_shape``.)code");
+
+
+// Deprecated aliases
+
+DALI_SCHEMA(ImageDecoder)
+    .DocStr("Legacy alias for :meth:`decoders.image_decoder`.")
+    .NumInput(1)
+    .NumOutput(1)
+    .AddParent("decoders__Image")
+    .MakeDocPartiallyHidden()
+    .Deprecate(
+        "decoders__Image",
+        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
+submodule and renamed to follow a common pattern. This is a placeholder operator with identical
+functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
+
+// Fused
+
+DALI_SCHEMA(ImageDecoderCrop)
+    .DocStr("Legacy alias for :meth:`decoders.image_decoder_crop`.")
+    .NumInput(1)
+    .NumOutput(1)
+    .AddParent("decoders__ImageCrop")
+    .MakeDocPartiallyHidden()
+    .Deprecate(
+        "decoders__ImageCrop",
+        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
+submodule and renamed to follow a common pattern. This is a placeholder operator with identical
+functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
+
+DALI_SCHEMA(ImageDecoderRandomCrop)
+    .DocStr("Legacy alias for :meth:`decoders.image_decoder_random`.")
+    .NumInput(1)
+    .NumOutput(1)
+    .AddParent("decoders__ImageRandomCrop")
+    .MakeDocPartiallyHidden()
+    .Deprecate(
+        "decoders__ImageRandomCrop",
+        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
+submodule and renamed to follow a common pattern. This is a placeholder operator with identical
+functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
+
+
+DALI_SCHEMA(ImageDecoderSlice)
+    .DocStr("Legacy alias for :meth:`decoders.image_decoder_slice`.")
+    .NumInput(1, 3)
+    .NumOutput(1)
+    .AddParent("decoders__ImageSlice")
+    .MakeDocPartiallyHidden()
+    .Deprecate(
+        "decoders__ImageSlice",
+        R"code(In DALI 1.0 all decoders were moved into a dedicated :mod:`~nvidia.dali.fn.decoders`
+submodule and renamed to follow a common pattern. This is a placeholder operator with identical
+functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
 
 }  // namespace dali

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -185,7 +185,7 @@ image format, it will decode the entire image and crop the selected ROI.
 
 .. note::
   ROI decoding is currently not compatible with hardware-based decoding. Using
-  :meth:`nvidia.dali.fn.decoders.image` automatically disables hardware accelerated
+  :meth:`nvidia.dali.fn.decoders.image_crop` automatically disables hardware accelerated
   decoding. To use the hardware decoder, use the :meth:`nvidia.dali.fn.decoders.image` and
   :meth:`nvidia.dali.fn.crop` operators instead.
 
@@ -313,7 +313,7 @@ interpreted as absolute or relative coordinates, depending on the value of
 // Deprecated aliases
 
 DALI_SCHEMA(ImageDecoder)
-    .DocStr("Legacy alias for :meth:`decoders.image_decoder`.")
+    .DocStr("Legacy alias for :meth:`decoders.image`.")
     .NumInput(1)
     .NumOutput(1)
     .AddParent("decoders__Image")
@@ -327,7 +327,7 @@ functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
 // Fused
 
 DALI_SCHEMA(ImageDecoderCrop)
-    .DocStr("Legacy alias for :meth:`decoders.image_decoder_crop`.")
+    .DocStr("Legacy alias for :meth:`decoders.image_crop`.")
     .NumInput(1)
     .NumOutput(1)
     .AddParent("decoders__ImageCrop")
@@ -339,7 +339,7 @@ submodule and renamed to follow a common pattern. This is a placeholder operator
 functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
 
 DALI_SCHEMA(ImageDecoderRandomCrop)
-    .DocStr("Legacy alias for :meth:`decoders.image_decoder_random`.")
+    .DocStr("Legacy alias for :meth:`decoders.image_random`.")
     .NumInput(1)
     .NumOutput(1)
     .AddParent("decoders__ImageRandomCrop")
@@ -352,7 +352,7 @@ functionality to allow for backward compatibility.)code");  // Deprecated in 1.0
 
 
 DALI_SCHEMA(ImageDecoderSlice)
-    .DocStr("Legacy alias for :meth:`decoders.image_decoder_slice`.")
+    .DocStr("Legacy alias for :meth:`decoders.image_slice`.")
     .NumInput(1, 3)
     .NumOutput(1)
     .AddParent("decoders__ImageSlice")

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_crop.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_crop.cc
@@ -17,6 +17,7 @@
 
 namespace dali {
 
+DALI_REGISTER_OPERATOR(decoders__ImageCrop, nvJPEGDecoderCrop, Mixed);
 DALI_REGISTER_OPERATOR(ImageDecoderCrop, nvJPEGDecoderCrop, Mixed);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_random_crop.cc
@@ -19,6 +19,7 @@
 
 namespace dali {
 
+DALI_REGISTER_OPERATOR(decoders__ImageRandomCrop, nvJPEGDecoderRandomCrop, Mixed);
 DALI_REGISTER_OPERATOR(ImageDecoderRandomCrop, nvJPEGDecoderRandomCrop, Mixed);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_slice.cc
+++ b/dali/operators/decoder/nvjpeg/fused/nvjpeg_decoder_slice.cc
@@ -17,6 +17,7 @@
 
 namespace dali {
 
+DALI_REGISTER_OPERATOR(decoders__ImageSlice, nvJPEGDecoderSlice, Mixed);
 DALI_REGISTER_OPERATOR(ImageDecoderSlice, nvJPEGDecoderSlice, Mixed);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg_allocator.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_allocator.h
@@ -48,7 +48,7 @@ class ChunkPinnedAllocator {
       element_size_hint_ = element_size_hint;
     } else {
       DALI_ENFORCE(element_size_hint_ == element_size_hint,
-        "All instances of ImageDecoder should have the same host_memory_padding.");
+        "All instances of `decoders.image` should have the same host_memory_padding.");
     }
 
     Chunk chunk;

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_cpu.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_cpu.cc
@@ -26,6 +26,6 @@ It is automatically inserted during the pipeline creation.)code")
   .NumInput(1)
   .NumOutput(3)
   .MakeInternal()
-  .AddParent("ImageDecoder");
+  .AddParent("decoders__Image");
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.cc
@@ -18,6 +18,7 @@
 
 namespace dali {
 
+DALI_REGISTER_OPERATOR(decoders__Image, nvJPEGDecoder, Mixed);
 DALI_REGISTER_OPERATOR(ImageDecoder, nvJPEGDecoder, Mixed);
 
 }  // namespace dali

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -212,8 +212,8 @@ int Pipeline::AddOperator(const OpSpec &const_spec, const std::string& inst_name
 
   // If necessary, split ImageDecoder operator in two separated stages (CPU and Mixed-GPU)
   bool split_stages = false;
-  bool is_hybrid_decoder = device == "mixed" &&
-    (has_prefix(operator_name, "ImageDecoder"));
+  bool is_hybrid_decoder = device == "mixed" && (has_prefix(operator_name, "ImageDecoder") ||
+                                                 has_prefix(operator_name, "decoders__Image"));
 
   if (is_hybrid_decoder &&
       operator_name.find("CPUStage") == std::string::npos &&
@@ -340,7 +340,7 @@ inline void Pipeline::AddSplitHybridDecoder(OpSpec &spec, const std::string &ins
 
   std::string suffix = "";
   bool any_match = false;
-  for (const std::string& prefix : {"ImageDecoder"}) {
+  for (const std::string& prefix : {"ImageDecoder", "decoders__Image"}) {
     if (has_prefix(operator_name, prefix)) {
       suffix = operator_name.substr(prefix.size());
       any_match = true;

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -1229,7 +1229,7 @@ The example below chains an image decoder and a Resize operation with random squ
 The  ``decode_and_resize`` object can be called as if it was an operator::
 
     decode_and_resize = ops.Compose([
-        ops.ImageDecoder(device="cpu"),
+        ops.decoders.Image(device="cpu"),
         ops.Resize(size=fn.random.uniform(range=400,500)), device="gpu")
     ])
 

--- a/dali/test/python/test_operator_audio_decoder.py
+++ b/dali/test/python/test_operator_audio_decoder.py
@@ -127,9 +127,9 @@ def decoder_pipe(decoder_op, sample_rate, downmix, quality, dtype):
 
 
 def check_audio_decoder_alias(sample_rate, downmix, quality, dtype):
-        new_pipe = decoder_pipe(fn.decoders.audio, sample_rate, downmix, quality, dtype)
-        legacy_pipe = decoder_pipe(fn.audio_decoder, sample_rate, downmix, quality, dtype)
-        compare_pipelines(new_pipe, legacy_pipe, batch_size_alias_test, 10)
+    new_pipe = decoder_pipe(fn.decoders.audio, sample_rate, downmix, quality, dtype)
+    legacy_pipe = decoder_pipe(fn.audio_decoder, sample_rate, downmix, quality, dtype)
+    compare_pipelines(new_pipe, legacy_pipe, batch_size_alias_test, 10)
 
 
 def test_audio_decoder_alias():

--- a/dali/test/python/test_operator_decoder.py
+++ b/dali/test/python/test_operator_decoder.py
@@ -132,9 +132,9 @@ def decoder_pipe(decoder_op, file_root, device, use_fast_idct, split_stages):
 
 
 def check_image_decoder_alias(new_op, old_op, file_root, device, use_fast_idct, split_stages):
-        new_pipe = decoder_pipe(new_op, file_root, device, use_fast_idct, split_stages)
-        legacy_pipe = decoder_pipe(old_op, file_root, device, use_fast_idct, split_stages)
-        compare_pipelines(new_pipe, legacy_pipe, batch_size_alias_test, 10)
+    new_pipe = decoder_pipe(new_op, file_root, device, use_fast_idct, split_stages)
+    legacy_pipe = decoder_pipe(old_op, file_root, device, use_fast_idct, split_stages)
+    compare_pipelines(new_pipe, legacy_pipe, batch_size_alias_test, 10)
 
 
 def test_image_decoder_alias():
@@ -145,7 +145,7 @@ def test_image_decoder_alias():
         for device in ["cpu", "mixed"]:
             for use_fast_idct in [True, False]:
                 for split_stages in [False]:
-                        yield check_image_decoder_alias, new_op, old_op, data_path, device, use_fast_idct, split_stages
+                    yield check_image_decoder_alias, new_op, old_op, data_path, device, use_fast_idct, split_stages
 
 def test_image_decoder_split_alias():
     raise SkipTest("Sanity tests for aliases of split decoder are temporarily disabled due to accuracy issues.")
@@ -167,13 +167,13 @@ def decoder_slice_pipe(decoder_op, file_root, device, use_fast_idct):
 
 
 def check_image_decoder_slice_alias(new_op, old_op, file_root, device, use_fast_idct):
-        new_pipe = decoder_slice_pipe(new_op, file_root, device, use_fast_idct)
-        legacy_pipe = decoder_slice_pipe(old_op, file_root, device, use_fast_idct)
-        compare_pipelines(new_pipe, legacy_pipe, batch_size_alias_test, 10)
+    new_pipe = decoder_slice_pipe(new_op, file_root, device, use_fast_idct)
+    legacy_pipe = decoder_slice_pipe(old_op, file_root, device, use_fast_idct)
+    compare_pipelines(new_pipe, legacy_pipe, batch_size_alias_test, 10)
 
 def test_image_decoder_slice_alias():
     data_path = os.path.join(test_data_root, good_path, "jpeg")
     new_op, old_op = fn.decoders.image_slice, fn.image_decoder_slice
     for device in ["cpu", "mixed"]:
         for use_fast_idct in [True, False]:
-                    yield check_image_decoder_slice_alias, new_op, old_op, data_path, device, use_fast_idct
+            yield check_image_decoder_slice_alias, new_op, old_op, data_path, device, use_fast_idct

--- a/dali/test/python/test_operator_decoder.py
+++ b/dali/test/python/test_operator_decoder.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nvidia.dali.pipeline import Pipeline
+from nvidia.dali import Pipeline, pipeline_def
+import nvidia.dali.fn as fn
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
 import os
+import numpy as np
 
 from test_utils import check_batch
 from test_utils import compare_pipelines
@@ -114,3 +116,55 @@ def test_image_decoder_memory_stats():
     for threads in {1, 2, 3, 4}:
         for size in {1, 10}:
             yield check, img_type, size, device, threads
+
+
+
+batch_size_alias_test=16
+
+@pipeline_def(batch_size=batch_size_alias_test, device_id=0, num_threads=4)
+def decoder_pipe(decoder_op, file_root, device, use_fast_idct, split_stages):
+    encoded, labels = fn.readers.file(file_root=file_root)
+    decoded = decoder_op(encoded, device=device, output_type=types.RGB, use_fast_idct=use_fast_idct,
+                         split_stages=split_stages, seed=42)
+    return decoded
+
+
+def check_image_decoder_alias(new_op, old_op, file_root, device, use_fast_idct, split_stages):
+        new_pipe = decoder_pipe(new_op, file_root, device, use_fast_idct, split_stages)
+        legacy_pipe = decoder_pipe(old_op, file_root, device, use_fast_idct, split_stages)
+        compare_pipelines(new_pipe, legacy_pipe, batch_size_alias_test, 10)
+
+
+def test_image_decoder_alias():
+    data_path = os.path.join(test_data_root, good_path, "jpeg")
+    for new_op, old_op in [(fn.decoders.image, fn.image_decoder),
+                           (fn.decoders.image_crop, fn.image_decoder_crop),
+                           (fn.decoders.image_random_crop, fn.image_decoder_random_crop)]:
+        for device in ["cpu", "mixed"]:
+            for use_fast_idct in [True, False]:
+                for split_stages in [True, False]:
+                        yield check_image_decoder_alias, new_op, old_op, data_path, device, use_fast_idct, split_stages
+
+@pipeline_def(batch_size=batch_size_alias_test, device_id=0, num_threads=4)
+def decoder_slice_pipe(decoder_op, file_root, device, use_fast_idct, split_stages):
+    encoded, labels = fn.readers.file(file_root=file_root)
+    start = types.Constant(np.array([0., 0.]))
+    end = types.Constant(np.array([0.5, 0.5]))
+    decoded = decoder_op(encoded, start, end, device=device,
+                         output_type=types.RGB, use_fast_idct=use_fast_idct,
+                         split_stages=split_stages, seed=42)
+    return decoded
+
+
+def check_image_decoder_slice_alias(new_op, old_op, file_root, device, use_fast_idct, split_stages):
+        new_pipe = decoder_slice_pipe(new_op, file_root, device, use_fast_idct, split_stages)
+        legacy_pipe = decoder_slice_pipe(old_op, file_root, device, use_fast_idct, split_stages)
+        compare_pipelines(new_pipe, legacy_pipe, batch_size_alias_test, 10)
+
+def test_image_decoder_slice_alias():
+    data_path = os.path.join(test_data_root, good_path, "jpeg")
+    new_op, old_op = fn.decoders.image_slice, fn.image_decoder_slice
+    for device in ["cpu", "mixed"]:
+        for use_fast_idct in [True, False]:
+            for split_stages in [True, False]:
+                    yield check_image_decoder_slice_alias, new_op, old_op, data_path, device, use_fast_idct, split_stages


### PR DESCRIPTION
Add alias test for image decoder - split decoder is broken.
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Refactoring to introduce decoders module.

#### What happened in this PR?
 - What solution was applied:
     Introduce alias operators for audio and image* decoders. Move the main ones to `decoders` module
 - Affected modules and functionalities:
     Decoders operators
 - Key points relevant for the review:
     Look out for typos?
 - Validation and testing:
     Sanity alias tests 
 - Documentation (including examples):
     Yes.

**JIRA TASK**: *[DALI-1882]*
