### PR TITLE
Fix constant input promotion for mixed backend.

### DIFF
--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -1011,12 +1011,14 @@ def _preprocess_inputs(inputs, op_name, device, schema=None):
                 any(isinstance(y, _DataNode) for y in x) and \
                 all(isinstance(y, (_DataNode, nvidia.dali.types.ScalarConstant)) for y in x)
 
+    default_input_device = "gpu" if device == "gpu" else "cpu"
+
     for idx, inp in enumerate(inputs):
         if not is_input(inp):
-            input_device = schema.GetInputDevice(idx) or device if schema else device
+            input_device = schema.GetInputDevice(idx) or default_input_device if schema else default_input_device
             if not isinstance(inp, nvidia.dali.types.ScalarConstant):
                 try:
-                    inp = nvidia.dali.types.Constant(inp, device=input_device)
+                    inp = _Constant(inp, device=input_device)
                 except Exception as ex:
                     raise TypeError("""when calling operator {0}:
 Input {1} is neither a DALI `DataNode` nor a list of data nodes but `{2}`.

--- a/dali/test/python/test_operator_constant.py
+++ b/dali/test/python/test_operator_constant.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nvidia.dali.pipeline import Pipeline
+from nvidia.dali import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 import numpy as np
 import os
+from test_utils import get_dali_extra_path
+from test_utils import check_batch
+
+jpeg_folder = os.path.join(get_dali_extra_path(), 'db', 'single', 'jpeg')
 
 array_interfaces = [(np.array, None)]
 try:
@@ -183,3 +187,16 @@ def test_variable_batch():
         for i in range(len(batch)):
             assert np.array_equal(cpu.at(i), val)
             assert np.array_equal(gpu.at(i), val)
+
+def test_constant_promotion_mixed():
+    filename = os.path.join(jpeg_folder, "241", "cute-4074304_1280.jpg")
+    file_contents = np.fromfile(filename, dtype=np.uint8)
+    pipe = Pipeline(1, 3, 0)
+    with pipe:
+        jpegs, _ = fn.readers.file(files=[filename])
+        from_reader = fn.image_decoder(jpegs, device="mixed")
+        from_constant = fn.image_decoder(file_contents, device="mixed")
+        pipe.set_outputs(from_constant, from_reader)
+    pipe.build()
+    from_reader, from_constant = pipe.run()
+    check_batch(from_reader, from_constant, 1)


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: attempt to create constants op with "mixed" backend when a constant is passed as a regular input to a mixed-backend operator.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Use default_input_device (which is "cpu" for mixed op) instead of op.device
 - Affected modules and functionalities:
     * Constant promotion / Python API
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python unit test in test_operator_constant
 - Documentation (including examples):
     * N/A


**JIRA TASK**: N/A
