### PR TITLE
Fix test exclude pattern for Xavier

### DIFF
--- a/dali/operators/reader/loader/loader_test.cc
+++ b/dali/operators/reader/loader/loader_test.cc
@@ -26,7 +26,7 @@
 #include "dali/operators/reader/loader/indexed_file_loader.h"
 #include "dali/operators/reader/loader/coco_loader.h"
 
-#if BUILD_LMDB_ENABLED
+#if LMDB_ENABLED
 #include "dali/operators/reader/loader/lmdb.h"
 #endif
 
@@ -44,7 +44,7 @@ string loader_test_image_folder = testing::dali_extra_path() + "/db/single/jpeg"
 
 TYPED_TEST_SUITE(DataLoadStoreTest, TestTypes);
 
-#if BUILD_LMDB_ENABLED
+#if LMDB_ENABLED
 TYPED_TEST(DataLoadStoreTest, LMDBTest) {
   shared_ptr<dali::LMDBLoader> reader(
       new LMDBLoader(

--- a/qa/TL0_python-self-test_xavier/test_body.sh
+++ b/qa/TL0_python-self-test_xavier/test_body.sh
@@ -9,8 +9,8 @@ test_nose() {
         "scipy"
         "librosa"
         "\"mixed\""
-        "\'mixed\'"
-        "video\n"
+        "'mixed'"
+        "video\("
         "caffe"
     )
 

--- a/qa/TL0_python-self-test_xavier/test_body.sh
+++ b/qa/TL0_python-self-test_xavier/test_body.sh
@@ -8,8 +8,10 @@ test_nose() {
         "cv2"
         "scipy"
         "librosa"
-        "image[_]*decoder\(device\s*="
-        "video[_]*reader"
+        "\"mixed\""
+        "\'mixed\'"
+        "video\n"
+        "caffe"
     )
 
     for test_script in $(ls test_operator_*.py test_pipeline*.py test_external_source_dali.py test_external_source_numpy.py test_functional_api.py test_backend_impl.py); do

--- a/qa/TL0_self-test_xavier/test.sh
+++ b/qa/TL0_self-test_xavier/test.sh
@@ -22,9 +22,10 @@ test_body() {
         exit 1
     fi
 
+    # LMDB seems to be greedy when mmaps memory, disable it as well
     # for some reason mmap based test tends to fail on some runners due to disc issue, so
     # disable it for now
-    "$FULLPATH" --gtest_filter=-*mmap*
+    "$FULLPATH" --gtest_filter=-*mmap*:*LMDBTest*
   done
 }
 


### PR DESCRIPTION
- adjusts test content exclude pattern for Xavier test to work with the functional API as well where the first argument of the ImageDecoder is the data, not the device placement
- after moving VideoReader to the readers' module the appropriate test was not excluded
- disable caffe reader tests as LMDB seems to be very greedy when mmaping the memory and test runner simply runs out of it
- reenable LMDB native test for all backends, but filter it out for Xavier

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes the test exclude pattern for Xavier

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adjusts test content exclude pattern for Xavier test to work with the functional API as well where the first argument of the ImageDecoder is the data, not the device placement
 - Affected modules and functionalities:
     TL0_python-self-test_xavier
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test apply
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
