### PR TITLE
Fix libcufile.so name to have *.0 sufix

### DIFF
--- a/dali/core/dynlink_cufile.cc
+++ b/dali/core/dynlink_cufile.cc
@@ -24,7 +24,7 @@ namespace {
 typedef void* CUFILE;
 
 static const char __CufileLibName[] = "libcufile.so";
-static const char __CufileLibName1[] = "libcufile.so.1";
+static const char __CufileLibName1[] = "libcufile.so.0";
 
 CUFILE loadCufileLibrary() {
   CUFILE ret = nullptr;


### PR DESCRIPTION
- as libcufile.so is still 0.x version it is named as .so.0, not .so.1, so fix the name of cuFile that DALI looks for

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes libcufile.so name to have *.0 sufix

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     as libcufile.so is still 0.x version it is named as .so.0, not .so.1, so fix the name of cuFile that DALI looks for
 - Affected modules and functionalities:
     dynlink_cufile.cc
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test apply
 - Documentation (including examples):
     NA

**JIRA TASK**: *[NA]*
