### PR TITLE
Bump up nvidia-tensorflow version to 1.15.5 21.02

### DIFF
--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -366,7 +366,7 @@ all_packages = [PlainPackage("opencv-python", ["4.4.0.42"]),
                               PckgVer("1.15.4",  python_max_ver="3.7"),
                               "2.3.1",
                               "2.4.1",
-                              PckgVer("1.15.4+nv20.12", python_min_ver="3.8", python_max_ver="3.8", alias="nvidia-tensorflow")]
+                              PckgVer("1.15.5+nv21.02", python_min_ver="3.8", python_max_ver="3.8", alias="nvidia-tensorflow")]
                         }),
                 CudaHttpPackage("torch",
                         { "100" : ["http://download.pytorch.org/whl/cu{cuda_v}/torch-1.4.0+cu{cuda_v}-{platform}.whl"] }),


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It bumps up nvidia-tensorflow version to 1.15.5 21.02

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     bumps up nvidia-tensorflow version to 1.15.5 21.02
 - Affected modules and functionalities:
     setup_packages.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
