### PR TITLE
Remove dynlink CUDA libs from the build image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,8 +15,8 @@ ENV PYBIN=${PYTHONPATH}/bin \
 
 # add llvm-toolset-7.0 for python clang bindings on aarch64 where libclang wheel is not available
 ENV PATH=/opt/python/cp36-cp36/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/usr/local/cuda/bin:${PYBIN}:${PATH} \
-    LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:/usr/local/cuda/lib64/stubs:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:/opt/python/cp39-cp39/lib:${PYLIB}:${LD_LIBRARY_PATH} \
-    LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:/usr/local/cuda/lib64/stubs:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:/opt/python/cp39-cp39/lib:${PYLIB}:${LIBRARY_PATH}
+    LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:/opt/python/cp39-cp39/lib:${PYLIB}:${LD_LIBRARY_PATH} \
+    LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:/opt/python/cp39-cp39/lib:${PYLIB}:${LIBRARY_PATH}
 
 RUN ln -s /opt/python/cp${PYV}* /opt/python/v
 
@@ -34,8 +34,7 @@ RUN if [ "$(uname -m)" == "aarch64" ]; then \
         sed -i 's/library_file = None/library_file = "\/opt\/rh\/llvm-toolset-7.0\/root\/usr\/lib64\/libclang.so.7"/' ${PY_CLANG_PATH}; \
     fi
 
-RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    ldconfig
+RUN ldconfig
 
 WORKDIR /opt/dali
 


### PR DESCRIPTION
- as DALI doesn't link any CUDA libraries dynamically but just dlopen then there is no need to have dynlink stubs in the LIBRARY_PATH in the docker build image. Thanks to that builder image can be used to build and run DALI as well (during the development)

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes dynlink CUDA libs from the build image

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     as DALI doesn't link any CUDA libraries dynamically but just dlopen then there is no need to have dynlink stubs in the LIBRARY_PATH in the docker build image. Thanks to that builder image can be used to build and run DALI as well (during the development)
 - Affected modules and functionalities:
     main Dockerfile
 - Key points relevant for the review:
     NA
 - Validation and testing:
     just build in CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[ NA]*
