### PR TITLE
Adjust Python tests to decoders module

### DIFF
--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1067,7 +1067,7 @@ def pipeline_def(fn=None, **pipeline_kwargs):
         def my_pipe(flip_vertical, flip_horizontal):
             ''' Creates a DALI pipeline, which returns flipped and original images '''
             data, _ = fn.readers.file(file_root=images_dir)
-            img = fn.image_decoder(data, device="mixed")
+            img = fn.decoders.image(data, device="mixed")
             flipped = fn.flip(img, horizontal=flip_horizontal, vertical=flip_vertical)
             return flipped, img
 

--- a/dali/test/python/test_RN50_data_fw_iterators.py
+++ b/dali/test/python/test_RN50_data_fw_iterators.py
@@ -25,7 +25,7 @@ class RN50Pipeline(Pipeline):
     def __init__(self, batch_size, num_threads, device_id, num_gpus, data_paths, prefetch, fp16, nhwc):
         super(RN50Pipeline, self).__init__(batch_size, num_threads, device_id, prefetch_queue_depth=prefetch)
         self.input = ops.readers.File(file_root = data_paths[0], shard_id = device_id, num_shards = num_gpus)
-        self.decode_gpu = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
+        self.decode_gpu = ops.decoders.Image(device = "mixed", output_type = types.RGB)
         self.res = ops.RandomResizedCrop(device="gpu", size =(224,224))
 
         layout = types.args.nhwc if nhwc else types.NCHW

--- a/dali/test/python/test_RN50_data_pipeline.py
+++ b/dali/test/python/test_RN50_data_pipeline.py
@@ -28,11 +28,11 @@ class CommonPipeline(Pipeline):
         super(CommonPipeline, self).__init__(batch_size, num_threads, device_id, random_shuffle, prefetch_queue_depth=prefetch)
         if decoder_type == 'roi':
             print('Using nvJPEG with ROI decoding')
-            self.decode_gpu = ops.ImageDecoderRandomCrop(device = "mixed", output_type = types.RGB)
+            self.decode_gpu = ops.decoders.ImageRandomCrop(device = "mixed", output_type = types.RGB)
             self.res = ops.Resize(device="gpu", resize_x=224, resize_y=224)
         elif decoder_type == 'roi_split':
             print('Using nvJPEG with ROI decoding and split CPU/GPU stages')
-            self.decode_gpu = ops.ImageDecoderRandomCrop(device = "mixed", output_type = types.RGB, split_stages=True)
+            self.decode_gpu = ops.decoders.ImageRandomCrop(device = "mixed", output_type = types.RGB, split_stages=True)
             self.res = ops.Resize(device="gpu", resize_x=224, resize_y=224)
         elif decoder_type == 'cached':
             assert decoder_cache_params['cache_enabled'] == True
@@ -40,17 +40,17 @@ class CommonPipeline(Pipeline):
             cache_threshold = decoder_cache_params['cache_threshold']
             cache_type = decoder_cache_params['cache_type']
             print('Using nvJPEG with cache (size : {} threshold: {}, type: {})'.format(cache_size, cache_threshold, cache_type))
-            self.decode_gpu = ops.ImageDecoder(device = "mixed", output_type = types.RGB,
+            self.decode_gpu = ops.decoders.Image(device = "mixed", output_type = types.RGB,
                                                 cache_size=cache_size, cache_threshold=cache_threshold,
                                                 cache_type=cache_type, cache_debug=False)
             self.res = ops.RandomResizedCrop(device="gpu", size =(224,224))
         elif decoder_type == 'split':
             print('Using nvJPEG with split CPU/GPU stages')
-            self.decode_gpu = ops.ImageDecoder(device = "mixed", output_type = types.RGB, split_stages=True)
+            self.decode_gpu = ops.decoders.Image(device = "mixed", output_type = types.RGB, split_stages=True)
             self.res = ops.RandomResizedCrop(device="gpu", size =(224,224))
         else:
             print('Using nvJPEG')
-            self.decode_gpu = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
+            self.decode_gpu = ops.decoders.Image(device = "mixed", output_type = types.RGB)
             self.res = ops.RandomResizedCrop(device="gpu", size =(224,224))
 
         layout = types.NHWC if nhwc else types.NCHW

--- a/dali/test/python/test_coco_tfrecord.py
+++ b/dali/test/python/test_coco_tfrecord.py
@@ -93,7 +93,7 @@ class TFRecordDetectionPipeline(Pipeline):
             num_shards=1,
             random_shuffle=False)
 
-        self.decode_gpu = ops.ImageDecoder(device="mixed", output_type=types.RGB)
+        self.decode_gpu = ops.decoders.Image(device="mixed", output_type=types.RGB)
         self.cast = ops.Cast(dtype = types.INT32)
         self.box_encoder = ops.BoxEncoder(
             device="cpu",
@@ -131,7 +131,7 @@ class COCODetectionPipeline(Pipeline):
             ltrb=True,
             random_shuffle=False)
 
-        self.decode_gpu = ops.ImageDecoder(device="mixed", output_type=types.RGB)
+        self.decode_gpu = ops.decoders.Image(device="mixed", output_type=types.RGB)
         self.box_encoder = ops.BoxEncoder(
             device="cpu",
             criteria=0.5,

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -86,7 +86,7 @@ def test_gpu_op_bad_device():
 def check_mixed_op_bad_device(device_id):
     pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=device_id)
     input, _ = fn.readers.file(file_root=images_dir, shard_id=0, num_shards=1)
-    decoded = fn.image_decoder(input, device="mixed", output_type=types.RGB)
+    decoded = fn.decoders.image(input, device="mixed", output_type=types.RGB)
     pipe.set_outputs(decoded)
     assert_raises(RuntimeError, pipe.build)
 
@@ -97,7 +97,7 @@ def test_mixed_op_bad_device():
 def test_image_decoder_cpu():
     pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=None)
     input, _ = fn.readers.file(file_root=images_dir, shard_id=0, num_shards=1)
-    decoded = fn.image_decoder(input, output_type=types.RGB)
+    decoded = fn.decoders.image(input, output_type=types.RGB)
     pipe.set_outputs(decoded)
     pipe.build()
     for _ in range(3):
@@ -174,7 +174,7 @@ def test_flip_cpu():
 def test_image_decoder_crop_device():
     pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=None)
     input, _ = fn.readers.file(file_root=images_dir, shard_id=0, num_shards=1)
-    decoded = fn.image_decoder_crop(input, output_type=types.RGB, crop = (10, 10))
+    decoded = fn.decoders.image_crop(input, output_type=types.RGB, crop = (10, 10))
     pipe.set_outputs(decoded)
     pipe.build()
     for _ in range(3):
@@ -183,7 +183,7 @@ def test_image_decoder_crop_device():
 def test_image_decoder_random_crop_device():
     pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=None)
     input, _ = fn.readers.file(file_root=images_dir, shard_id=0, num_shards=1)
-    decoded = fn.image_decoder_random_crop(input, output_type=types.RGB)
+    decoded = fn.decoders.image_random_crop(input, output_type=types.RGB)
     pipe.set_outputs(decoded)
     pipe.build()
     for _ in range(3):
@@ -299,7 +299,7 @@ def test_transpose_cpu():
 def test_audio_decoder_cpu():
     pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=None)
     input, _ = fn.readers.file(file_root=audio_dir, shard_id=0, num_shards=1)
-    decoded, _ = fn.audio_decoder(input)
+    decoded, _ = fn.decoders.audio(input)
     pipe.set_outputs(decoded)
     pipe.build()
     for _ in range(3):
@@ -383,7 +383,7 @@ def test_image_decoder_slice_cpu():
     input, _ = fn.readers.file(file_root=images_dir, shard_id=0, num_shards=1)
     anchors = fn.external_source(source = get_anchors)
     shape = fn.external_source(source = get_shape)
-    processed = fn.image_decoder_slice(input, anchors, shape)
+    processed = fn.decoders.image_slice(input, anchors, shape)
     pipe.set_outputs(processed)
     pipe.build()
     for _ in range(3):
@@ -794,7 +794,7 @@ def test_separated_exec_setup():
     batch_size = 128
     pipe = Pipeline(batch_size=batch_size, num_threads=3, device_id=None, prefetch_queue_depth = {"cpu_size": 5, "gpu_size": 3})
     inputs, labels = fn.readers.caffe(path = caffe_dir, shard_id = 0, num_shards = 1)
-    images = fn.image_decoder(inputs, output_type = types.RGB)
+    images = fn.decoders.image(inputs, output_type = types.RGB)
     images = fn.resize(images, resize_x=224, resize_y=224)
     images_cpu = fn.dump_image(images, suffix = "cpu")
     pipe.set_outputs(images, images_cpu)

--- a/dali/test/python/test_dali_tf_dataset_mnist.py
+++ b/dali/test/python/test_dali_tf_dataset_mnist.py
@@ -44,7 +44,7 @@ def mnist_pipeline(
     with pipeline:
         jpegs, labels = fn.readers.caffe2(
             path=path, random_shuffle=True, shard_id=shard_id, num_shards=num_shards)
-        images = fn.image_decoder(jpegs, device='mixed' if device == 'gpu' else 'cpu', output_type=types.GRAY)
+        images = fn.decoders.image(jpegs, device='mixed' if device == 'gpu' else 'cpu', output_type=types.GRAY)
         if device == 'gpu':
             labels = labels.gpu()
         images = fn.crop_mirror_normalize(

--- a/dali/test/python/test_dali_tf_dataset_shape.py
+++ b/dali/test/python/test_dali_tf_dataset_shape.py
@@ -31,7 +31,7 @@ def dali_pipe_batch_1(shapes, types, as_single_tuple = False):
         def __init__(self, **kwargs):
             super(TestPipeline, self).__init__(**kwargs)
             self.reader = ops.readers.File(file_root=data_path, file_list=file_list_path)
-            self.decoder = ops.ImageDecoder(device='mixed')
+            self.decoder = ops.decoders.Image(device='mixed')
 
         def define_graph(self):
             data, _ = self.reader()
@@ -84,7 +84,7 @@ def dali_pipe_batch_N(shapes, types, batch):
         def __init__(self, **kwargs):
             super(TestPipeline, self).__init__(**kwargs)
             self.reader = ops.readers.File(file_root=data_path, file_list=file_list_path)
-            self.decoder = ops.ImageDecoder(device='mixed')
+            self.decoder = ops.decoders.Image(device='mixed')
             self.resize = ops.Resize(device="gpu", resize_x = 200, resize_y = 200)
 
         def define_graph(self):
@@ -125,7 +125,7 @@ def dali_pipe_multiple_out(shapes, types, batch):
         def __init__(self, **kwargs):
             super(TestPipeline, self).__init__(**kwargs)
             self.reader = ops.readers.File(file_root=data_path, file_list=file_list_path)
-            self.decoder = ops.ImageDecoder(device='mixed')
+            self.decoder = ops.decoders.Image(device='mixed')
             self.resize = ops.Resize(device="gpu", resize_x = 200, resize_y = 200)
 
         def define_graph(self):

--- a/dali/test/python/test_dali_tf_plugin_run.py
+++ b/dali/test/python/test_dali_tf_plugin_run.py
@@ -39,7 +39,7 @@ class CommonPipeline(Pipeline):
     def __init__(self, batch_size, num_threads, device_id):
         super(CommonPipeline, self).__init__(batch_size, num_threads, device_id)
 
-        self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB)
         self.resize = ops.Resize(device = "gpu", interp_type = types.INTERP_LINEAR)
         self.cmn = ops.CropMirrorNormalize(device = "gpu",
                                            output_dtype = types.FLOAT,

--- a/dali/test/python/test_dali_variable_batch_size.py
+++ b/dali/test/python/test_dali_variable_batch_size.py
@@ -52,7 +52,7 @@ common cases:
 6. If your operator performs random operation, this approach won't provide
    a comparable result. In this case, the best thing you can do is to check
    whether the operator works, without qualitative comparison. Use `run_pipeline`
-   instead of `check_pipeline`. 
+   instead of `check_pipeline`.
 """
 
 
@@ -602,7 +602,7 @@ def test_audio_decoders():
     def audio_decoder_pipe(max_batch_size, input_data, device):
         pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
         encoded = fn.external_source(source=input_data, cycle=False, device='cpu')
-        decoded, _ = fn.audio_decoder(encoded, downmix=True, sample_rate=12345, device=device)
+        decoded, _ = fn.decoders.audio(encoded, downmix=True, sample_rate=12345, device=device)
         pipe.set_outputs(decoded)
         return pipe
 
@@ -614,14 +614,14 @@ def test_image_decoders():
     def image_decoder_pipe(max_batch_size, input_data, device):
         pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
         encoded = fn.external_source(source=input_data, cycle=False, device='cpu')
-        decoded = fn.image_decoder(encoded, device=device)
+        decoded = fn.decoders.image(encoded, device=device)
         pipe.set_outputs(decoded)
         return pipe
 
     def image_decoder_crop_pipe(max_batch_size, input_data, device):
         pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
         encoded = fn.external_source(source=input_data, cycle=False, device='cpu')
-        decoded = fn.image_decoder_crop(encoded, device=device)
+        decoded = fn.decoders.image_crop(encoded, device=device)
         pipe.set_outputs(decoded)
         return pipe
 
@@ -630,14 +630,14 @@ def test_image_decoders():
         encoded = fn.external_source(source=input_data, cycle=False, device='cpu')
         anch = fn.constant(fdata=.1)
         sh = fn.constant(fdata=.4)
-        decoded = fn.image_decoder_slice(encoded, anch, sh, axes=0, device=device)
+        decoded = fn.decoders.image_slice(encoded, anch, sh, axes=0, device=device)
         pipe.set_outputs(decoded)
         return pipe
 
     def image_decoder_rcrop_pipe(max_batch_size, input_data, device):
         pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
         encoded = fn.external_source(source=input_data, cycle=False, device='cpu')
-        decoded = fn.image_decoder_random_crop(encoded, device=device)
+        decoded = fn.decoders.image_random_crop(encoded, device=device)
         pipe.set_outputs(decoded)
         return pipe
 

--- a/dali/test/python/test_data_containers.py
+++ b/dali/test/python/test_data_containers.py
@@ -25,8 +25,8 @@ class CommonPipeline(Pipeline):
     def __init__(self, batch_size, num_threads, device_id):
         super(CommonPipeline, self).__init__(batch_size, num_threads, device_id)
 
-        self.decode_gpu = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
-        self.decode_host = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode_gpu = ops.decoders.Image(device = "mixed", output_type = types.RGB)
+        self.decode_host = ops.decoders.Image(device = "cpu", output_type = types.RGB)
 
     def base_define_graph(self, inputs, labels):
         images_gpu = self.decode_gpu(inputs)

--- a/dali/test/python/test_detection_pipeline.py
+++ b/dali/test/python/test_detection_pipeline.py
@@ -120,11 +120,11 @@ class DetectionPipeline(Pipeline):
             ltrb=True,
             random_shuffle=True)
 
-        self.decode_cpu = ops.ImageDecoder(device="cpu", output_type=types.RGB)
-        self.decode_crop = ops.ImageDecoderSlice(device="cpu", output_type=types.RGB)
+        self.decode_cpu = ops.decoders.Image(device="cpu", output_type=types.RGB)
+        self.decode_crop = ops.decoders.ImageSlice(device="cpu", output_type=types.RGB)
 
-        self.decode_gpu = ops.ImageDecoder(device="mixed", output_type=types.RGB, hw_decoder_load=0)
-        self.decode_gpu_crop = ops.ImageDecoderSlice(device="mixed", output_type=types.RGB)
+        self.decode_gpu = ops.decoders.Image(device="mixed", output_type=types.RGB, hw_decoder_load=0)
+        self.decode_gpu_crop = ops.decoders.ImageSlice(device="mixed", output_type=types.RGB)
 
         self.ssd_crop = ops.SSDRandomCrop(
             device="cpu", num_attempts=1, seed=args.seed)

--- a/dali/test/python/test_dltensor_operator.py
+++ b/dali/test/python/test_dltensor_operator.py
@@ -87,8 +87,8 @@ class CommonPipeline(Pipeline):
         super(CommonPipeline, self).__init__(BATCH_SIZE, NUM_WORKERS, DEVICE_ID, seed=SEED,
                                              exec_async=False, exec_pipelined=False)
         self.input = ops.readers.File(file_root=images_dir)
-        self.decode = ops.ImageDecoder(device='mixed' if device == 'gpu' else 'cpu',
-                                       output_type=types.RGB)
+        self.decode = ops.decoders.Image(device='mixed' if device == 'gpu' else 'cpu',
+                                         output_type=types.RGB)
         self.resize = ops.Resize(resize_x=400, resize_y=400, device=device)
         self.flip = ops.Flip(device=device)
 

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -663,7 +663,7 @@ def create_custom_pipeline(batch_size, num_threads, device_id, num_gpus, data_pa
     with pipe:
         jpegs, _ = fn.readers.file(
             file_root=data_paths, shard_id=device_id, num_shards=num_gpus, name="Reader")
-        images = fn.image_decoder(jpegs, device="mixed", output_type=types.RGB)
+        images = fn.decoders.image(jpegs, device="mixed", output_type=types.RGB)
         images = fn.random_resized_crop(images, size=(224, 224))
         images = fn.crop_mirror_normalize(images,
                                           dtype=types.FLOAT,

--- a/dali/test/python/test_gpu_python_function_operator.py
+++ b/dali/test/python/test_gpu_python_function_operator.py
@@ -44,8 +44,8 @@ class PythonFunctionPipeline(Pipeline):
                                                      exec_async=False, exec_pipelined=False)
         self.device = device
         self.reader = ops.readers.File(file_root=images_dir)
-        self.decode = ops.ImageDecoder(device='cpu',
-                                       output_type=types.RGB)
+        self.decode = ops.decoders.Image(device='cpu',
+                                         output_type=types.RGB)
         self.norm = ops.CropMirrorNormalize(std=255., mean=0., device=device, output_layout="HWC")
         self.func = ops.PythonFunction(device=device, function=function, num_outputs=num_outputs)
 

--- a/dali/test/python/test_nvjpeg_cache.py
+++ b/dali/test/python/test_nvjpeg_cache.py
@@ -43,7 +43,7 @@ class HybridDecoderPipeline(Pipeline):
         policy = None
         if cache_size > 0:
           policy = "threshold"
-        self.decode = ops.ImageDecoder(device = 'mixed', output_type = types.RGB, cache_debug = False, cache_size = cache_size, cache_type = policy, cache_batch_copy = True)
+        self.decode = ops.decoders.Image(device = 'mixed', output_type = types.RGB, cache_debug = False, cache_size = cache_size, cache_type = policy, cache_batch_copy = True)
 
     def define_graph(self):
         jpegs, labels = self.input(name="Reader")

--- a/dali/test/python/test_operator_audio_decoder.py
+++ b/dali/test/python/test_operator_audio_decoder.py
@@ -38,11 +38,11 @@ class DecoderPipeline(Pipeline):
     super(DecoderPipeline, self).__init__(batch_size=8, num_threads=3, device_id=0,
                                           exec_async=True, exec_pipelined=True)
     self.file_source = ops.ExternalSource()
-    self.plain_decoder = ops.AudioDecoder(dtype = types.INT16)
-    self.resampling_decoder = ops.AudioDecoder(sample_rate=rate1, dtype = types.INT16)
-    self.downmixing_decoder = ops.AudioDecoder(downmix=True, dtype = types.INT16)
-    self.resampling_downmixing_decoder = ops.AudioDecoder(sample_rate=rate2, downmix=True,
-                                                          quality=50, dtype = types.FLOAT)
+    self.plain_decoder = ops.decoders.Audio(dtype = types.INT16)
+    self.resampling_decoder = ops.decoders.Audio(sample_rate=rate1, dtype = types.INT16)
+    self.downmixing_decoder = ops.decoders.Audio(downmix=True, dtype = types.INT16)
+    self.resampling_downmixing_decoder = ops.decoders.Audio(sample_rate=rate2, downmix=True,
+                                                            quality=50, dtype = types.FLOAT)
 
   def define_graph(self):
     self.raw_file = self.file_source()

--- a/dali/test/python/test_operator_compose.py
+++ b/dali/test/python/test_operator_compose.py
@@ -66,11 +66,11 @@ def test_compose_change_device():
 
     size = fn.random.uniform(shape=2, range=(300,500))
     c = ops.Compose([
-        ops.ImageDecoder(device="cpu"),
+        ops.decoders.Image(device="cpu"),
         ops.Resize(size=size, device="gpu")
     ])
     files, labels = fn.readers.caffe(path=caffe_db_folder, seed=1)
-    pipe.set_outputs(c(files), fn.resize(fn.image_decoder(files).gpu(), size=size))
+    pipe.set_outputs(c(files), fn.resize(fn.decoders.image(files).gpu(), size=size))
 
     pipe.build()
     out = pipe.run()

--- a/dali/test/python/test_operator_constant.py
+++ b/dali/test/python/test_operator_constant.py
@@ -194,8 +194,8 @@ def test_constant_promotion_mixed():
     pipe = Pipeline(1, 3, 0)
     with pipe:
         jpegs, _ = fn.readers.file(files=[filename])
-        from_reader = fn.image_decoder(jpegs, device="mixed")
-        from_constant = fn.image_decoder(file_contents, device="mixed")
+        from_reader = fn.decoders.image(jpegs, device="mixed")
+        from_constant = fn.decoders.image(file_contents, device="mixed")
         pipe.set_outputs(from_constant, from_reader)
     pipe.build()
     from_reader, from_constant = pipe.run()

--- a/dali/test/python/test_operator_crop.py
+++ b/dali/test/python/test_operator_crop.py
@@ -41,13 +41,13 @@ class CropPipeline(Pipeline):
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
 
         if self.is_fused_decoder:
-            self.decode = ops.ImageDecoderCrop(device = "cpu",
-                                              crop = crop_shape,
-                                              crop_pos_x = crop_x,
-                                              crop_pos_y = crop_y,
-                                              output_type = types.RGB)
+            self.decode = ops.decoders.ImageCrop(device = "cpu",
+                                                 crop = crop_shape,
+                                                 crop_pos_x = crop_x,
+                                                 crop_pos_y = crop_y,
+                                                 output_type = types.RGB)
         else:
-            self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
             self.crop = ops.Crop(device = self.device,
                                  crop = crop_shape,
                                  crop_pos_x = crop_x,
@@ -193,8 +193,8 @@ class CropCastPipeline(Pipeline):
         self.should_perform_cast = should_perform_cast
         self.device = device
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu",
-                                      output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu",
+                                         output_type = types.RGB)
 
         if self.should_perform_cast:
             self.crop = ops.Crop(device = self.device,

--- a/dali/test/python/test_operator_crop_mirror_normalize.py
+++ b/dali/test/python/test_operator_crop_mirror_normalize.py
@@ -41,7 +41,7 @@ class CropMirrorNormalizePipeline(Pipeline):
         super(CropMirrorNormalizePipeline, self).__init__(batch_size, num_threads, device_id, seed=7865)
         self.device = device
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         self.cmn = ops.CropMirrorNormalize(device = self.device,
                                            dtype = dtype,
                                            output_layout = output_layout,
@@ -105,7 +105,7 @@ class NoCropPipeline(Pipeline):
         self.decoder_only = decoder_only
         self.device = device
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         if not self.decoder_only:
             self.cast = ops.CropMirrorNormalize(device = self.device,
                                                dtype = types.FLOAT,
@@ -138,7 +138,7 @@ class PythonOpPipeline(Pipeline):
 
         super(PythonOpPipeline, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=False, exec_pipelined=False)
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         self.cmn = ops.PythonFunction(function=function, output_layouts=output_layout)
         self.coin = ops.random.CoinFlip(probability=mirror_probability, seed=7865)
 

--- a/dali/test/python/test_operator_decoder.py
+++ b/dali/test/python/test_operator_decoder.py
@@ -29,8 +29,8 @@ class DecoderPipeline(Pipeline):
         self.input = ops.readers.File(file_root = data_path,
                                       shard_id = 0,
                                       num_shards = 1)
-        self.decode = ops.ImageDecoder(device = device, output_type = types.RGB, use_fast_idct=use_fast_idct,
-                                       memory_stats=memory_stats)
+        self.decode = ops.decoders.Image(device = device, output_type = types.RGB, use_fast_idct=use_fast_idct,
+                                         memory_stats=memory_stats)
 
     def define_graph(self):
         inputs, labels = self.input(name="Reader")
@@ -77,7 +77,7 @@ class DecoderPipelineFastIDC(Pipeline):
         self.input = ops.readers.File(file_root = data_path,
                                       shard_id = 0,
                                       num_shards = 1)
-        self.decode = ops.ImageDecoder(device = 'cpu', output_type = types.RGB, use_fast_idct=use_fast_idct)
+        self.decode = ops.decoders.Image(device = 'cpu', output_type = types.RGB, use_fast_idct=use_fast_idct)
 
     def define_graph(self):
         inputs, labels = self.input(name="Reader")

--- a/dali/test/python/test_operator_flip.py
+++ b/dali/test/python/test_operator_flip.py
@@ -33,7 +33,7 @@ class FlipPipeline(Pipeline):
                                            device_id)
         self.device = device
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         self.flip = ops.Flip(device = self.device, vertical=is_vertical, horizontal=is_horizontal)
 
 

--- a/dali/test/python/test_operator_gaussian_blur.py
+++ b/dali/test/python/test_operator_gaussian_blur.py
@@ -96,7 +96,7 @@ def get_gaussian_pipe(batch_size, sigma, window_size, op_type):
     pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0)
     with pipe:
         input, _ = fn.readers.file(file_root=images_dir, shard_id=0, num_shards=1)
-        decoded = fn.image_decoder(input, device="cpu", output_type=types.RGB)
+        decoded = fn.decoders.image(input, device="cpu", output_type=types.RGB)
         if op_type == "gpu":
             decoded = decoded.gpu()
         blurred = fn.gaussian_blur(decoded, device=op_type, sigma=sigma, window_size=window_size)

--- a/dali/test/python/test_operator_gridmask.py
+++ b/dali/test/python/test_operator_gridmask.py
@@ -28,7 +28,7 @@ def get_pipeline(batch_size, tile, ratio, angle):
   pipe = Pipeline(batch_size, 4, None)
   with pipe:
     input, _ = fn.readers.file(file_root=img_dir)
-    decoded = fn.image_decoder(input, device='cpu', output_type=types.RGB)
+    decoded = fn.decoders.image(input, device='cpu', output_type=types.RGB)
     grided = fn.grid_mask(decoded, device='cpu', tile=tile, ratio=ratio, angle=angle)
     pipe.set_outputs(grided, decoded)
   return pipe
@@ -37,7 +37,7 @@ def get_random_pipeline(batch_size):
   pipe = Pipeline(batch_size, 4, None)
   with pipe:
     input, _ = fn.readers.file(file_root=img_dir)
-    decoded = fn.image_decoder(input, device='cpu', output_type=types.RGB)
+    decoded = fn.decoders.image(input, device='cpu', output_type=types.RGB)
     tile = fn.cast(fn.uniform(range=(50, 200), shape=[1]), dtype=types.INT32)
     ratio = fn.uniform(range=(0.3, 0.7), shape=[1])
     angle = fn.uniform(range=(-math.pi, math.pi), shape=[1])

--- a/dali/test/python/test_operator_multipaste.py
+++ b/dali/test/python/test_operator_multipaste.py
@@ -124,7 +124,7 @@ def get_pipeline(
     pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=types.CPU_ONLY_DEVICE_ID)
     with pipe:
         input, _ = fn.readers.file(file_root=img_dir)
-        decoded = fn.image_decoder(input, device='cpu', output_type=types.RGB)
+        decoded = fn.decoders.image(input, device='cpu', output_type=types.RGB)
         resized = fn.resize(decoded, resize_x=in_size[1], resize_y=in_size[0])
         in_idx_l, in_anchors_l, shapes_l, out_anchors_l = prepare_cuts(
             k, batch_size, in_size, out_size, even_paste_count,

--- a/dali/test/python/test_operator_nonsilence.py
+++ b/dali/test/python/test_operator_nonsilence.py
@@ -46,7 +46,7 @@ class NonsilencePipeline(Pipeline):
                                                  exec_async=exec_async,
                                                  exec_pipelined=exec_pipelined)
         self.input = ops.readers.File(device="cpu", file_root=audio_files)
-        self.decode = ops.AudioDecoder(device="cpu", dtype=types.FLOAT, downmix=True)
+        self.decode = ops.decoders.Audio(device="cpu", dtype=types.FLOAT, downmix=True)
 
         self.nonsilence = None
 

--- a/dali/test/python/test_operator_peek_image_shape.py
+++ b/dali/test/python/test_operator_peek_image_shape.py
@@ -28,7 +28,7 @@ def run_decode(data_path, out_type):
     batch_size = 4
     pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0)
     input, _ = fn.readers.file(file_root=data_path, shard_id=0, num_shards=1, name="reader")
-    decoded = fn.image_decoder(input, output_type=types.RGB)
+    decoded = fn.decoders.image(input, output_type=types.RGB)
     decoded_shape = fn.shapes(decoded)
     raw_shape = fn.peek_image_shape(input, type=out_type)
     pipe.set_outputs(decoded, decoded_shape, raw_shape)

--- a/dali/test/python/test_operator_python_function.py
+++ b/dali/test/python/test_operator_python_function.py
@@ -53,7 +53,7 @@ class CommonPipeline(Pipeline):
         super(CommonPipeline, self).__init__(batch_size, num_threads, device_id, seed=_seed, exec_async=False,
                                              exec_pipelined=False)
         self.input = ops.readers.File(file_root=image_dir)
-        self.decode = ops.ImageDecoder(device = 'cpu', output_type=types.RGB)
+        self.decode = ops.decoders.Image(device = 'cpu', output_type=types.RGB)
         self.resize = ops.PythonFunction(function=resize, output_layouts='HWC')
 
     def load(self):

--- a/dali/test/python/test_operator_readers_caffe.py
+++ b/dali/test/python/test_operator_readers_caffe.py
@@ -40,11 +40,11 @@ class CaffeReaderPipeline(Pipeline):
                                            device_id)
         self.input = ops.readers.Caffe(path = path, shard_id = device_id, num_shards = num_gpus)
 
-        self.decode = ops.ImageDecoderCrop(device = "cpu",
-                                           crop = (224, 224),
-                                           crop_pos_x = 0.3,
-                                           crop_pos_y = 0.2,
-                                           output_type = types.RGB)
+        self.decode = ops.decoders.ImageCrop(device = "cpu",
+                                             crop = (224, 224),
+                                             crop_pos_x = 0.3,
+                                             crop_pos_y = 0.2,
+                                             output_type = types.RGB)
     def define_graph(self):
         inputs, labels = self.input(name="Reader")
 

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -35,7 +35,7 @@ class ReshapePipeline(Pipeline):
         super(ReshapePipeline, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=True, exec_pipelined=True)
         self.device = device
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         W = 320
         H = 224
         self.resize = ops.Resize(device = "cpu", resize_x = W, resize_y = H);
@@ -70,7 +70,7 @@ class ReshapeWithInput(Pipeline):
         super(ReshapeWithInput, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=False, exec_pipelined=False)
         self.device = device
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         fn = CollapseChannelsWildcard if use_wildcard else CollapseChannels
         self.gen_shapes = ops.PythonFunction(function=fn)
         self.reshape = ops.Reshape(device = device, layout = "ab");
@@ -99,7 +99,7 @@ class ReshapeWithArgInput(Pipeline):
         self.device = device
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
         self.resize = ops.Resize(device = "cpu");
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         self.gen_shapes = ops.PythonFunction(function=MakeTallFunc(relative, use_wildcard))
         self.reshape = ops.Reshape(device = device);
         self.relative = relative

--- a/dali/test/python/test_operator_resize.py
+++ b/dali/test/python/test_operator_resize.py
@@ -242,7 +242,7 @@ def build_pipes(device, dim, batch_size, channel_first, mode, interp, dtype, w_i
     with dali_pipe:
         if dim == 2:
             files, labels = dali.fn.readers.caffe(path = db_2d_folder, random_shuffle = True)
-            images_cpu = dali.fn.image_decoder(files, device="cpu")
+            images_cpu = dali.fn.decoders.image(files, device="cpu")
         else:
             images_cpu = dali.fn.external_source(source=random_3d_loader(batch_size), layout="DHWC")
 
@@ -451,7 +451,7 @@ def _test_stitching(device, dim, channel_first, dtype, interp):
     with pipe:
         if dim == 2:
             files, labels = dali.fn.readers.caffe(path = db_2d_folder, random_shuffle = True)
-            images_cpu = dali.fn.image_decoder(files, device="cpu")
+            images_cpu = dali.fn.decoders.image(files, device="cpu")
         else:
             images_cpu = dali.fn.external_source(source=random_3d_loader(batch_size), layout="DHWC")
 
@@ -533,7 +533,7 @@ def _test_empty_input(dim, device):
     pipe = Pipeline(batch_size=batch_size, num_threads=8, device_id=0, seed=1234)
     if dim == 2:
         files, labels = dali.fn.readers.caffe(path = db_2d_folder, random_shuffle = True)
-        images_cpu = dali.fn.image_decoder(files, device="cpu")
+        images_cpu = dali.fn.decoders.image(files, device="cpu")
     else:
         images_cpu = dali.fn.external_source(source=random_3d_loader(batch_size), layout="DHWC")
 
@@ -575,7 +575,7 @@ def _test_very_small_output(dim, device):
     pipe = Pipeline(batch_size=batch_size, num_threads=8, device_id=0, seed=1234)
     if dim == 2:
         files, labels = dali.fn.readers.caffe(path = db_2d_folder, random_shuffle = True)
-        images_cpu = dali.fn.image_decoder(files, device="cpu")
+        images_cpu = dali.fn.decoders.image(files, device="cpu")
     else:
         images_cpu = dali.fn.external_source(source=random_3d_loader(batch_size), layout="DHWC")
 

--- a/dali/test/python/test_operator_rotate.py
+++ b/dali/test/python/test_operator_rotate.py
@@ -98,7 +98,7 @@ class RotatePipeline(Pipeline):
         super(RotatePipeline, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=False, exec_pipelined=False)
         self.name = device
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         if input_type != dali.types.UINT8:
           self.cast = ops.Cast(device = device, dtype = input_type)
         else:
@@ -123,7 +123,7 @@ class CVPipeline(Pipeline):
         super(CVPipeline, self).__init__(batch_size, num_threads, device_id, seed=7865, exec_async=False, exec_pipelined=False)
         self.name = "cv"
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         self.rotate = ops.PythonFunction(function=CVRotate(output_type, input_type, fixed_size),
                                          output_layouts="HWC")
         self.uniform = ops.random.Uniform(range = (-180.0, 180.0), seed = 42)

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -115,15 +115,15 @@ class SlicePipeline(Pipeline):
         self.input_crop_size = ops.ExternalSource()
 
         if self.is_fused_decoder:
-            self.decode = ops.ImageDecoderSlice(device = "cpu",
-                                                output_type = types.RGB,
-                                                normalized_anchor=normalized_anchor,
-                                                normalized_shape=normalized_shape,
-                                                axis_names = axis_names,
-                                                axes = axes)
+            self.decode = ops.decoders.ImageSlice(device = "cpu",
+                                                  output_type = types.RGB,
+                                                  normalized_anchor=normalized_anchor,
+                                                  normalized_shape=normalized_shape,
+                                                  axis_names = axis_names,
+                                                  axes = axes)
         else:
-            self.decode = ops.ImageDecoder(device = "cpu",
-                                           output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "cpu",
+                                             output_type = types.RGB)
             self.slice = ops.Slice(device = self.device,
                                    normalized_anchor=normalized_anchor,
                                    normalized_shape=normalized_shape,
@@ -311,7 +311,7 @@ class SlicePythonOp(Pipeline):
         self.pos_size_iter = pos_size_iter
 
         self.input = ops.readers.Caffe(path = caffe_db_folder, random_shuffle=False)
-        self.decode = ops.ImageDecoder(device = 'cpu', output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = 'cpu', output_type = types.RGB)
 
         self.input_crop_pos = ops.ExternalSource()
         self.input_crop_size = ops.ExternalSource()

--- a/dali/test/python/test_operator_spectrogram.py
+++ b/dali/test/python/test_operator_spectrogram.py
@@ -177,7 +177,7 @@ class AudioSpectrogramPipeline(Pipeline):
                  num_threads=1, device_id=0, layout="ft"):
         super(AudioSpectrogramPipeline, self).__init__(batch_size, num_threads, device_id)
         self.input = ops.readers.File(device="cpu", file_root=audio_files)
-        self.decode = ops.AudioDecoder(device="cpu", dtype=types.FLOAT, downmix=True)
+        self.decode = ops.decoders.Audio(device="cpu", dtype=types.FLOAT, downmix=True)
         self.fft = ops.Spectrogram(device=device,
                                    nfft=nfft,
                                    window_length=window_length,
@@ -203,7 +203,7 @@ class AudioSpectrogramPythonPipeline(Pipeline):
             seed=12345, exec_async=False, exec_pipelined=False)
 
         self.input = ops.readers.File(device="cpu", file_root=audio_files)
-        self.decode = ops.AudioDecoder(device="cpu", dtype=types.FLOAT, downmix=True)
+        self.decode = ops.decoders.Audio(device="cpu", dtype=types.FLOAT, downmix=True)
 
         function = partial(spectrogram_func, nfft, window_length, window_step, None)
         self.spectrogram = ops.PythonFunction(function=function, output_layouts=["ft"])

--- a/dali/test/python/test_operator_warp.py
+++ b/dali/test/python/test_operator_warp.py
@@ -86,7 +86,7 @@ class WarpPipeline(Pipeline):
         self.use_dynamic_size = use_input  # avoid Cartesian product
         self.name = device
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         if input_type != dali.types.UINT8:
           self.cast = ops.Cast(device = device, dtype = input_type)
         else:
@@ -127,7 +127,7 @@ class CVPipeline(Pipeline):
         self.use_input = use_input
         self.name = "cv"
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         if self.use_input:
           self.transform_source = ops.ExternalSource(lambda: gen_transforms(self.batch_size, 10))
           self.warp = ops.PythonFunction(function=CVWarp(output_type, input_type, inv_map=inv_map),

--- a/dali/test/python/test_operator_water.py
+++ b/dali/test/python/test_operator_water.py
@@ -32,7 +32,7 @@ class WaterPipeline(Pipeline):
         super(WaterPipeline, self).__init__(batch_size, num_threads, device_id)
         self.device = device
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         self.water = ops.Water(device = self.device, ampl_x=ampl_x, ampl_y=ampl_y,
                                phase_x=phase_x, phase_y=phase_y, freq_x=freq_x, freq_y=freq_y,
                                interp_type = dali.types.INTERP_LINEAR)
@@ -70,7 +70,7 @@ class WaterPythonPipeline(Pipeline):
                                            exec_async=False,
                                            exec_pipelined=False)
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-        self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
         self.water = ops.PythonFunction(function=function, output_layouts="HWC")
 
 

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -57,7 +57,7 @@ def test_tensor_multiple_uses():
                                              num_threads,
                                              device_id)
             self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-            self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
             self.res = ops.Resize(device="cpu", resize_x=224, resize_y=224)
             self.dump_cpu = ops.DumpImage(device = "cpu", suffix = "cpu")
             self.dump_gpu = ops.DumpImage(device = "gpu", suffix = "gpu")
@@ -108,8 +108,8 @@ def test_multiple_input_sets():
                 ltrb=True,
                 random_shuffle=False)
 
-            self.decode_cpu = ops.ImageDecoder(device="cpu", output_type=types.RGB)
-            self.decode_crop = ops.ImageDecoderSlice(device="cpu", output_type=types.RGB)
+            self.decode_cpu = ops.decoders.Image(device="cpu", output_type=types.RGB)
+            self.decode_crop = ops.decoders.ImageSlice(device="cpu", output_type=types.RGB)
 
             self.ssd_crop = ops.SSDRandomCrop(device="cpu", num_attempts=1, seed=0)
             default_boxes = [0.0, 0.0, 1.0, 1.0]
@@ -159,7 +159,7 @@ def test_pipeline_separated_exec_setup():
                                              num_threads,
                                              device_id, prefetch_queue_depth = prefetch_queue_depth)
             self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-            self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
             self.res = ops.Resize(device="cpu", resize_x=224, resize_y=224)
             self.dump_cpu = ops.DumpImage(device = "cpu", suffix = "cpu")
             self.dump_gpu = ops.DumpImage(device = "gpu", suffix = "gpu")
@@ -203,7 +203,7 @@ def test_pipeline_simple_sync_no_prefetch():
                                              device_id=0, prefetch_queue_depth=1,
                                              exec_async=False, exec_pipelined=False)
             self.input = ops.readers.Caffe(path = caffe_db_folder)
-            self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
             self.dump_gpu = ops.DumpImage(device = "gpu", suffix = "gpu")
 
         def define_graph(self):
@@ -223,7 +223,7 @@ def test_use_twice():
         def __init__(self, batch_size, num_threads, device_id, num_gpus):
             super(Pipe, self).__init__(batch_size, num_threads, device_id)
             self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-            self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
             self.res = ops.Resize(device="cpu", resize_x=224, resize_y=224)
 
         def define_graph(self):
@@ -250,7 +250,7 @@ def test_cropmirrornormalize_layout():
                                              num_threads,
                                              device_id)
             self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-            self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
             self.cmnp_nhwc = ops.CropMirrorNormalize(device = "gpu",
                                                      dtype = types.FLOAT,
                                                      output_layout = types.NHWC,
@@ -296,7 +296,7 @@ def test_cropmirrornormalize_pad():
                                              num_threads,
                                              device_id)
             self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-            self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
             self.cmnp_pad  = ops.CropMirrorNormalize(device = "gpu",
                                                      dtype = types.FLOAT,
                                                      output_layout = layout,
@@ -353,8 +353,8 @@ def test_cropmirrornormalize_multiple_inputs():
                                              device_id)
             self.device = device
             self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-            self.decode = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
-            self.decode2 = ops.ImageDecoder(device = "cpu", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "cpu", output_type = types.RGB)
+            self.decode2 = ops.decoders.Image(device = "cpu", output_type = types.RGB)
             self.cmnp = ops.CropMirrorNormalize(device = device,
                                                 dtype = types.FLOAT,
                                                 output_layout = types.NHWC,
@@ -394,7 +394,7 @@ def test_seed():
                                              device_id,
                                              seed = 12)
             self.input = ops.readers.Caffe(path = caffe_db_folder, random_shuffle = True)
-            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB)
             self.cmnp = ops.CropMirrorNormalize(device = "gpu",
                                                 dtype = types.FLOAT,
                                                 crop = (224, 224),
@@ -449,7 +449,7 @@ def test_as_array():
                                              device_id,
                                              seed = 12)
             self.input = ops.readers.Caffe(path = caffe_db_folder, random_shuffle = True)
-            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB)
             self.cmnp = ops.CropMirrorNormalize(device = "gpu",
                                                 dtype = types.FLOAT,
                                                 crop = (224, 224),
@@ -489,7 +489,7 @@ def test_seed_serialize():
                                              device_id,
                                              seed = 12)
             self.input = ops.readers.Caffe(path = caffe_db_folder, random_shuffle = True)
-            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB)
             self.cmnp = ops.CropMirrorNormalize(device = "gpu",
                                                 dtype = types.FLOAT,
                                                 crop = (224, 224),
@@ -527,7 +527,7 @@ def test_make_contiguous_serialize():
         def __init__(self, batch_size, num_threads, device_id):
             super(COCOPipeline, self).__init__(batch_size, num_threads, device_id)
             self.input = ops.readers.COCO(file_root=coco_image_folder, annotations_file=coco_annotation_file, ratio=True, ltrb=True)
-            self.decode = ops.ImageDecoder(device="mixed")
+            self.decode = ops.decoders.Image(device="mixed")
             self.crop = ops.RandomBBoxCrop(device="cpu", seed = 12)
             self.slice = ops.Slice(device="gpu")
 
@@ -550,7 +550,7 @@ def test_make_contiguous_serialize_and_use():
         def __init__(self, batch_size, num_threads, device_id):
             super(COCOPipeline, self).__init__(batch_size, num_threads, device_id)
             self.input = ops.readers.COCO(file_root=coco_image_folder, annotations_file=coco_annotation_file, ratio=True, ltrb=True)
-            self.decode = ops.ImageDecoder(device="mixed")
+            self.decode = ops.decoders.Image(device="mixed")
             self.crop = ops.RandomBBoxCrop(device="cpu", seed = 25)
             self.slice = ops.Slice(device="gpu")
 
@@ -573,7 +573,7 @@ def test_warpaffine():
         def __init__(self, batch_size, num_threads, device_id):
             super(HybridPipe, self).__init__(batch_size, num_threads, device_id, seed = 12)
             self.input = ops.readers.Caffe(path = caffe_db_folder, random_shuffle = True)
-            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB)
             self.cmnp = ops.CropMirrorNormalize(device = "gpu",
                                                 dtype = types.FLOAT,
                                                 output_layout = types.NHWC,
@@ -613,7 +613,7 @@ def test_type_conversion():
         def __init__(self, batch_size, num_threads, device_id):
             super(HybridPipe, self).__init__(batch_size, num_threads, device_id, seed = 12)
             self.input = ops.readers.Caffe(path = caffe_db_folder, random_shuffle = True)
-            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB)
             self.cmnp_all = ops.CropMirrorNormalize(device = "gpu",
                                                     dtype = types.FLOAT,
                                                     output_layout = types.NHWC,
@@ -663,7 +663,7 @@ def test_type_conversion():
 
 def test_equal_ImageDecoderCrop_ImageDecoder():
     """
-        Comparing results of pipeline: (ImageDecoder -> Crop), with the same operation performed by fused operator
+        Comparing results of pipeline: (decoders.Image -> Crop), with the same operation performed by fused operator
     """
     batch_size =128
 
@@ -673,8 +673,8 @@ def test_equal_ImageDecoderCrop_ImageDecoder():
                                              num_threads,
                                              device_id)
             self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
-            # Fixing HW load to 0 to be able to compare with ImageDecoderCrop (which uses CUDA decoder only)
-            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB, hw_decoder_load = 0.0)
+            # Fixing HW load to 0 to be able to compare with decoders.ImageCrop (which uses CUDA decoder only)
+            self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB, hw_decoder_load = 0.0)
             self.pos_rng_x = ops.random.Uniform(range = (0.0, 1.0), seed=1234)
             self.pos_rng_y = ops.random.Uniform(range = (0.0, 1.0), seed=5678)
             self.crop = ops.Crop(device="gpu", crop =(224,224))
@@ -696,7 +696,7 @@ def test_equal_ImageDecoderCrop_ImageDecoder():
             self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus)
             self.pos_rng_x = ops.random.Uniform(range = (0.0, 1.0), seed=1234)
             self.pos_rng_y = ops.random.Uniform(range = (0.0, 1.0), seed=5678)
-            self.decode = ops.ImageDecoderCrop(device = 'mixed', output_type = types.RGB, crop = (224, 224))
+            self.decode = ops.decoders.ImageCrop(device = 'mixed', output_type = types.RGB, crop = (224, 224))
 
         def define_graph(self):
             self.jpegs, self.labels = self.input()
@@ -718,7 +718,7 @@ def test_equal_ImageDecoderCrop_ImageDecoder():
 
 def test_equal_ImageDecoderRandomCrop_ImageDecoder():
     """
-        Comparing results of pipeline: (ImageDecoder -> RandomCrop), with the same operation performed by fused operator
+        Comparing results of pipeline: (decoders.Image -> RandomCrop), with the same operation performed by fused operator
     """
     batch_size =128
 
@@ -726,7 +726,7 @@ def test_equal_ImageDecoderRandomCrop_ImageDecoder():
         def __init__(self, batch_size, num_threads, device_id, num_gpus, seed):
             super(NonFusedPipeline, self).__init__(batch_size, num_threads, device_id)
             self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus, seed = seed)
-            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB)
             self.res = ops.RandomResizedCrop(device="gpu", size =(224,224), seed=seed)
             self.cmnp = ops.CropMirrorNormalize(device = "gpu",
                                                 dtype = types.FLOAT,
@@ -747,7 +747,7 @@ def test_equal_ImageDecoderRandomCrop_ImageDecoder():
         def __init__(self, batch_size, num_threads, device_id, num_gpus, seed):
             super(FusedPipeline, self).__init__(batch_size, num_threads, device_id)
             self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus, seed = seed)
-            self.decode = ops.ImageDecoderRandomCrop(device = "mixed", output_type = types.RGB, seed=seed)
+            self.decode = ops.decoders.ImageRandomCrop(device = "mixed", output_type = types.RGB, seed=seed)
             self.res = ops.Resize(device="gpu", resize_x=224, resize_y=224)
             self.cmnp = ops.CropMirrorNormalize(device = "gpu",
                                                 dtype = types.FLOAT,
@@ -804,7 +804,7 @@ class LazyPipeline(Pipeline):
                                            num_threads,
                                            device_id)
         self.input = ops.readers.Caffe(path = db_folder, shard_id = device_id, num_shards = num_gpus, lazy_init = lazy_type)
-        self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB)
         self.pos_rng_x = ops.random.Uniform(range = (0.0, 1.0), seed=1234)
         self.pos_rng_y = ops.random.Uniform(range = (0.0, 1.0), seed=5678)
         self.crop = ops.Crop(device="gpu", crop =(224,224))
@@ -847,7 +847,7 @@ def test_lazy_init():
 
 def test_equal_ImageDecoderSlice_ImageDecoder():
     """
-        Comparing results of pipeline: (ImageDecoder -> Slice), with the same operation performed by fused operator
+        Comparing results of pipeline: (decoders.Image -> Slice), with the same operation performed by fused operator
     """
     batch_size =128
     eii = ExternalInputIterator(128)
@@ -862,8 +862,8 @@ def test_equal_ImageDecoderSlice_ImageDecoder():
             self.input_crop_pos = ops.ExternalSource()
             self.input_crop_size = ops.ExternalSource()
             self.input_crop = ops.ExternalSource()
-            # Fixing HW load to 0 to be able to compare with ImageDecoderSlice (which uses CUDA decoder only)
-            self.decode = ops.ImageDecoder(device='mixed', output_type=types.RGB, hw_decoder_load = 0.0)
+            # Fixing HW load to 0 to be able to compare with decoders.ImageSlice (which uses CUDA decoder only)
+            self.decode = ops.decoders.Image(device='mixed', output_type=types.RGB, hw_decoder_load = 0.0)
             self.slice = ops.Slice(device = 'gpu')
 
         def define_graph(self):
@@ -889,7 +889,7 @@ def test_equal_ImageDecoderSlice_ImageDecoder():
             self.input_crop_pos = ops.ExternalSource()
             self.input_crop_size = ops.ExternalSource()
             self.input_crop = ops.ExternalSource()
-            self.decode = ops.ImageDecoderSlice(device = 'mixed', output_type = types.RGB)
+            self.decode = ops.decoders.ImageSlice(device = 'mixed', output_type = types.RGB)
 
         def define_graph(self):
             jpegs, labels = self.input()
@@ -994,7 +994,7 @@ def test_pipeline_default_cuda_stream_priority():
                                              exec_async=False, exec_pipelined=False,
                                              default_cuda_stream_priority=default_cuda_stream_priority)
             self.input = ops.readers.Caffe(path = caffe_db_folder)
-            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB)
+            self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB)
 
         def define_graph(self):
             inputs, labels = self.input(name="Reader")
@@ -1062,16 +1062,16 @@ class CachedPipeline(Pipeline):
                                                           "image/class/label": tfrec.FixedLenFeature([1], tfrec.int64,  -1)})
 
         if is_cached:
-            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB,
-                                            cache_size=2000,
-                                            cache_threshold=0,
-                                            cache_type='threshold',
-                                            cache_debug=False,
-                                            hw_decoder_load = 0.0,  # 0.0 for deterministic results
-                                            cache_batch_copy=is_cached_batch_copy)
+            self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB,
+                                             cache_size=2000,
+                                             cache_threshold=0,
+                                             cache_type='threshold',
+                                             cache_debug=False,
+                                             hw_decoder_load = 0.0,  # 0.0 for deterministic results
+                                             cache_batch_copy=is_cached_batch_copy)
         else:
             # hw_decoder_load=0.0 for deterministic results
-            self.decode = ops.ImageDecoder(device = "mixed", output_type = types.RGB, hw_decoder_load = 0.0)
+            self.decode = ops.decoders.Image(device = "mixed", output_type = types.RGB, hw_decoder_load = 0.0)
     def define_graph(self):
         if self.reader_type == "readers.TFRecord":
             inputs = self.input()
@@ -1114,7 +1114,7 @@ def test_caffe_no_label():
                                            stick_to_shard = True,
                                            prefetch_queue_depth = 1,
                                            label_available = labels)
-            self.decode = ops.ImageDecoder(output_type = types.RGB)
+            self.decode = ops.decoders.Image(output_type = types.RGB)
             self.labels = labels
 
         def define_graph(self):
@@ -1142,7 +1142,7 @@ def test_caffe2_no_label():
                                             stick_to_shard = True,
                                             prefetch_queue_depth = 1,
                                             label_type = label_type)
-            self.decode = ops.ImageDecoder(output_type = types.RGB)
+            self.decode = ops.decoders.Image(output_type = types.RGB)
             self.label_type = label_type
 
         def define_graph(self):
@@ -1300,7 +1300,7 @@ class DupPipeline(Pipeline):
         self.first_out_device = first_out_device
         self.second_out_device = second_out_device
         self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = 1)
-        self.decode = ops.ImageDecoder(device = "mixed" if first_out_device == "mixed" else "cpu", output_type = types.RGB)
+        self.decode = ops.decoders.Image(device = "mixed" if first_out_device == "mixed" else "cpu", output_type = types.RGB)
         if self.second_out_device:
             self.cmnp = ops.CropMirrorNormalize(device = second_out_device,
                                                 dtype = types.FLOAT,
@@ -1541,7 +1541,7 @@ def test_executor_meta():
         def __init__(self, batch_size, num_threads, device_id, num_gpus, seed):
             super(TestPipeline, self).__init__(batch_size, num_threads, device_id, enable_memory_stats=True)
             self.input = ops.readers.Caffe(path = caffe_db_folder, shard_id = device_id, num_shards = num_gpus, seed = seed)
-            self.decode = ops.ImageDecoderRandomCrop(device = "mixed", output_type = types.RGB, seed=seed)
+            self.decode = ops.decoders.ImageRandomCrop(device = "mixed", output_type = types.RGB, seed=seed)
             self.res = ops.Resize(device="gpu", resize_x=224, resize_y=224)
             self.cmnp = ops.CropMirrorNormalize(device = "gpu",
                                                 output_dtype = types.FLOAT,
@@ -1565,7 +1565,7 @@ def test_executor_meta():
     test_pipe.build()
     test_pipe.run()
     meta = test_pipe.executor_statistics()
-    # all operators (readers.Caffe, ImageDecoderRandomCrop, Resize, CropMirrorNormalize, CoinFlip) + make_contiguous
+    # all operators (readers.Caffe, decoders.ImageRandomCrop, Resize, CropMirrorNormalize, CoinFlip) + make_contiguous
     assert(len(meta) == 6)
     for k in meta.keys():
         if "CropMirrorNormalize" in k:

--- a/dali/test/python/test_pipeline_decorator.py
+++ b/dali/test/python/test_pipeline_decorator.py
@@ -32,7 +32,7 @@ def reference_pipeline(flip_vertical, flip_horizontal, ref_batch_size=max_batch_
     pipeline = Pipeline(ref_batch_size, num_threads, device_id)
     with pipeline:
         data, _ = fn.readers.file(file_root=images_dir)
-        img = fn.image_decoder(data)
+        img = fn.decoders.image(data)
         flipped = fn.flip(img, horizontal=flip_horizontal, vertical=flip_vertical)
         pipeline.set_outputs(flipped, img)
     return pipeline
@@ -42,7 +42,7 @@ def reference_pipeline(flip_vertical, flip_horizontal, ref_batch_size=max_batch_
 @pipeline_def(batch_size=max_batch_size, num_threads=num_threads, device_id=device_id)
 def pipeline_static(flip_vertical, flip_horizontal):
     data, _ = fn.readers.file(file_root=images_dir)
-    img = fn.image_decoder(data)
+    img = fn.decoders.image(data)
     flipped = fn.flip(img, horizontal=flip_horizontal, vertical=flip_vertical)
     return flipped, img
 
@@ -51,7 +51,7 @@ def pipeline_static(flip_vertical, flip_horizontal):
 @pipeline_def
 def pipeline_runtime(flip_vertical, flip_horizontal):
     data, _ = fn.readers.file(file_root=images_dir)
-    img = fn.image_decoder(data)
+    img = fn.decoders.image(data)
     flipped = fn.flip(img, horizontal=flip_horizontal, vertical=flip_vertical)
     return flipped, img
 

--- a/dali/test/python/test_pipeline_multichannel.py
+++ b/dali/test/python/test_pipeline_multichannel.py
@@ -185,7 +185,7 @@ class MultichannelPipeline(Pipeline):
         self.reader = ops.readers.File(file_root=multichannel_tiff_root)
 
         decoder_device = 'mixed' if self.device == 'gpu' else 'cpu'
-        self.decoder = ops.ImageDecoder(device = decoder_device, output_type = types.ANY_DATA)
+        self.decoder = ops.decoders.Image(device = decoder_device, output_type = types.ANY_DATA)
 
         self.resize = ops.Resize(device = self.device,
                                  resize_y = 900, resize_x = 300,
@@ -222,7 +222,7 @@ class MultichannelPythonOpPipeline(Pipeline):
                                                            exec_async=False,
                                                            exec_pipelined=False)
         self.reader = ops.readers.File(file_root=multichannel_tiff_root)
-        self.decoder = ops.ImageDecoder(device = 'cpu', output_type = types.ANY_DATA)
+        self.decoder = ops.decoders.Image(device = 'cpu', output_type = types.ANY_DATA)
         self.oper = ops.PythonFunction(function=function, output_layouts="HWC")
 
     def define_graph(self):

--- a/dali/test/python/test_pipeline_segmentation.py
+++ b/dali/test/python/test_pipeline_segmentation.py
@@ -46,7 +46,7 @@ def check_bbox_random_crop_adjust_polygons(file_root, annotations_file, batch_si
                 scaling=[0.3, 1.0], bbox_layout='xyXY', output_bbox_indices=True
             )
         # Crop the image
-        images = fn.image_decoder_slice(
+        images = fn.decoders.image_slice(
             inputs, slice_anchor, slice_shape,
             device='mixed', axis_names='WH'
         )

--- a/dali/test/python/test_pytorch_operator.py
+++ b/dali/test/python/test_pytorch_operator.py
@@ -39,7 +39,7 @@ class CommonPipeline(Pipeline):
         super(CommonPipeline, self).__init__(batch_size, num_threads, device_id,
                                              exec_async=False, exec_pipelined=False)
         self.input = ops.readers.File(file_root=image_dir)
-        self.decode = ops.ImageDecoder(device='cpu', output_type=types.RGB)
+        self.decode = ops.decoders.Image(device='cpu', output_type=types.RGB)
 
     def load(self):
         jpegs, labels = self.input()

--- a/dali/test/python/test_torch_pipeline_rnnt.py
+++ b/dali/test/python/test_torch_pipeline_rnnt.py
@@ -186,7 +186,7 @@ class RnntTrainPipeline(nvidia.dali.Pipeline):
         self.read = ops.readers.File(file_root=file_root, file_list=file_list, device="cpu",
                                      shard_id=device_id, num_shards=n_devices)
 
-        self.decode = ops.AudioDecoder(device="cpu", dtype=types.FLOAT, downmix=True)
+        self.decode = ops.decoders.Audio(device="cpu", dtype=types.FLOAT, downmix=True)
 
         self.normal_distribution = ops.random.Normal(device="cpu")
 

--- a/dali/test/python/test_utils_tensorflow.py
+++ b/dali/test/python/test_utils_tensorflow.py
@@ -63,7 +63,7 @@ def get_pipeline(batch_size, num_threads, device, device_id=0, shard_id=0, num_s
             num_shards=num_shards,
             ratio=False,
             image_ids=True)
-        images = fn.image_decoder(
+        images = fn.decoders.image(
             jpegs,
             device=('mixed' if device == 'gpu' else 'cpu'),
             output_type=types.RGB)

--- a/docs/examples/use_cases/paddle/resnet50/main.py
+++ b/docs/examples/use_cases/paddle/resnet50/main.py
@@ -44,13 +44,13 @@ def create_dali_pipeline(batch_size, num_threads, device_id, data_dir, crop, siz
         device_memory_padding = 211025920 if decoder_device == 'mixed' else 0
         host_memory_padding = 140544512 if decoder_device == 'mixed' else 0
         if is_training:
-            images = fn.image_decoder_random_crop(images,
-                                                  device=decoder_device, output_type=types.RGB,
-                                                  device_memory_padding=device_memory_padding,
-                                                  host_memory_padding=host_memory_padding,
-                                                  random_aspect_ratio=[0.8, 1.25],
-                                                  random_area=[0.1, 1.0],
-                                                  num_attempts=100)
+            images = fn.decoders.image_random_crop(images,
+                                                   device=decoder_device, output_type=types.RGB,
+                                                   device_memory_padding=device_memory_padding,
+                                                   host_memory_padding=host_memory_padding,
+                                                   random_aspect_ratio=[0.8, 1.25],
+                                                   random_area=[0.1, 1.0],
+                                                   num_attempts=100)
             images = fn.resize(images,
                                device=dali_device,
                                resize_x=crop,
@@ -58,9 +58,9 @@ def create_dali_pipeline(batch_size, num_threads, device_id, data_dir, crop, siz
                                interp_type=types.INTERP_TRIANGULAR)
             mirror = fn.random.coin_flip(probability=0.5)
         else:
-            images = fn.image_decoder(images,
-                                      device=decoder_device,
-                                      output_type=types.RGB)
+            images = fn.decoders.image(images,
+                                       device=decoder_device,
+                                       output_type=types.RGB)
             images = fn.resize(images,
                                device=dali_device,
                                size=size,

--- a/docs/examples/use_cases/paddle/ssd/train.py
+++ b/docs/examples/use_cases/paddle/ssd/train.py
@@ -62,7 +62,7 @@ def create_coco_pipeline(file_root,
                                                                     bbox_layout="xyXY",
                                                                     allow_no_crop=True,
                                                                     num_attempts=50)
-        images = fn.image_decoder_slice(images, crop_begin, crop_size, device="mixed", output_type=types.RGB)
+        images = fn.decoders.image_slice(images, crop_begin, crop_size, device="mixed", output_type=types.RGB)
         flip_coin = fn.random.coin_flip(probability=0.5)
         images = fn.resize(images,
                            resize_x=300,

--- a/docs/examples/use_cases/pytorch/resnet50/main.py
+++ b/docs/examples/use_cases/pytorch/resnet50/main.py
@@ -104,13 +104,13 @@ def create_dali_pipeline(data_dir, crop, size, shard_id, num_shards, dali_cpu=Fa
     device_memory_padding = 211025920 if decoder_device == 'mixed' else 0
     host_memory_padding = 140544512 if decoder_device == 'mixed' else 0
     if is_training:
-        images = fn.image_decoder_random_crop(images,
-                                              device=decoder_device, output_type=types.RGB,
-                                              device_memory_padding=device_memory_padding,
-                                              host_memory_padding=host_memory_padding,
-                                              random_aspect_ratio=[0.8, 1.25],
-                                              random_area=[0.1, 1.0],
-                                              num_attempts=100)
+        images = fn.decoders.image_random_crop(images,
+                                               device=decoder_device, output_type=types.RGB,
+                                               device_memory_padding=device_memory_padding,
+                                               host_memory_padding=host_memory_padding,
+                                               random_aspect_ratio=[0.8, 1.25],
+                                               random_area=[0.1, 1.0],
+                                               num_attempts=100)
         images = fn.resize(images,
                            device=dali_device,
                            resize_x=crop,
@@ -118,9 +118,9 @@ def create_dali_pipeline(data_dir, crop, size, shard_id, num_shards, dali_cpu=Fa
                            interp_type=types.INTERP_TRIANGULAR)
         mirror = fn.random.coin_flip(probability=0.5)
     else:
-        images = fn.image_decoder(images,
-                                  device=decoder_device,
-                                  output_type=types.RGB)
+        images = fn.decoders.image(images,
+                                   device=decoder_device,
+                                   output_type=types.RGB)
         images = fn.resize(images,
                            device=dali_device,
                            size=size,

--- a/docs/examples/use_cases/pytorch/single_stage_detector/src/coco_pipeline.py
+++ b/docs/examples/use_cases/pytorch/single_stage_detector/src/coco_pipeline.py
@@ -47,7 +47,7 @@ def create_coco_pipeline(default_boxes, args):
                                                                 bbox_layout="xyXY",
                                                                 allow_no_crop=True,
                                                                 num_attempts=50)
-    images = fn.image_decoder_slice(images, crop_begin, crop_size, device="mixed", output_type=types.RGB)
+    images = fn.decoders.image_slice(images, crop_begin, crop_size, device="mixed", output_type=types.RGB)
     flip_coin = fn.random.coin_flip(probability=0.5)
     images = fn.resize(images,
                        resize_x=300,

--- a/docs/examples/use_cases/tensorflow/resnet-n/nvutils/image_processing.py
+++ b/docs/examples/use_cases/tensorflow/resnet-n/nvutils/image_processing.py
@@ -173,7 +173,7 @@ def get_dali_pipeline(
     decode_device = "cpu" if dali_cpu else "mixed"
     resize_device = "cpu" if dali_cpu else "gpu"
     if training:
-        images = fn.image_decoder_random_crop(
+        images = fn.decoders.image_random_crop(
             inputs["image/encoded"],
             device=decode_device,
             output_type=types.RGB,
@@ -182,7 +182,7 @@ def get_dali_pipeline(
             num_attempts=100)
         images = fn.resize(images, device=resize_device, resize_x=width, resize_y=height)
     else:
-        images = fn.image_decoder(
+        images = fn.decoders.image(
             inputs["image/encoded"],
             device=decode_device,
             output_type=types.RGB)


### PR DESCRIPTION
Depends on #2725

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Refactor test to use `decoders` module.

#### What happened in this PR? 
 - What solution was applied:
     Find and replace
 - Affected modules and functionalities:
     Mostly Python tests
 - Key points relevant for the review:
     
 - Validation and testing:
     CI
 - Documentation (including examples):
     Barely


**JIRA TASK**: *[DALI-1882]*
