### PR TITLE
Bump up OpenCV-python version in tests

### DIFF
--- a/qa/TL0_python-self-test_xavier/test_body.sh
+++ b/qa/TL0_python-self-test_xavier/test_body.sh
@@ -5,7 +5,6 @@ test_nose() {
     # also there is no nvJPEG on xavier so don't run any test with the ImageDecoder having
     # the device explicitly set
     EXCLUDE_PACKAGES=(
-        "cv2"
         "scipy"
         "librosa"
         "\"mixed\""

--- a/qa/TL0_python-self-test_xavier/test_nofw.sh
+++ b/qa/TL0_python-self-test_xavier/test_nofw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # used pip packages
 # due to https://github.com/numpy/numpy/issues/18131 we cannot use 1.19.5
-pip_packages="nose numpy>=1.17,<=1.19.4 pillow psutil"
+pip_packages="nose numpy>=1.17,<=1.19.4 opencv-python pillow psutil"
 
 target_dir=./dali/test/python
 

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -350,7 +350,7 @@ class CudaHttpPackage(CudaPackage):
                     return ret
         return ""
 
-all_packages = [PlainPackage("opencv-python", ["4.4.0.42"]),
+all_packages = [PlainPackage("opencv-python", ["4.5.1.48"]),
                 CudaPackage("cupy",
                         { "100" : ["8.0.0"],
                           "110" : ["8.0.0"] },


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It bumps up OpenCV-python version in tests

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     bumps up OpenCV-python version in tests
     enables test with OpenCV-python package for Xavier platform
 - Affected modules and functionalities:
     setup_packages.py
     TL0_python-self-test_xavier
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current CI test apply
 - Documentation (including examples):
     NA


**JIRA TASK**: *[ NA]*
