### PR TITLE
Shutdown executor when an error occurs in the executor itself, not in one of operators.

### DIFF
--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -40,7 +40,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::PreRun() {
 }
 
 template <typename WorkspacePolicy, typename QueuePolicy>
-void Executor<WorkspacePolicy, QueuePolicy>::RunCPU() {
+void Executor<WorkspacePolicy, QueuePolicy>::RunCPUImpl() {
   PreRun();
 
   if (device_id_ < 0) {
@@ -93,7 +93,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunCPU() {
 
 
 template <typename WorkspacePolicy, typename QueuePolicy>
-void Executor<WorkspacePolicy, QueuePolicy>::RunMixed() {
+void Executor<WorkspacePolicy, QueuePolicy>::RunMixedImpl() {
   DomainTimeRange tr("[DALI][Executor] RunMixed");
   DeviceGuard g(device_id_);
 
@@ -165,7 +165,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunMixed() {
 
 
 template <typename WorkspacePolicy, typename QueuePolicy>
-void Executor<WorkspacePolicy, QueuePolicy>::RunGPU() {
+void Executor<WorkspacePolicy, QueuePolicy>::RunGPUImpl() {
   DomainTimeRange tr("[DALI][Executor] RunGPU");
 
   auto gpu_idxs = QueuePolicy::AcquireIdxs(OpType::GPU);
@@ -243,6 +243,44 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunGPU() {
   QueuePolicy::QueueOutputIdxs(gpu_idxs, gpu_op_stream_);
 }
 
+template <typename WorkspacePolicy, typename QueuePolicy>
+void Executor<WorkspacePolicy, QueuePolicy>::RunCPU() {
+  try {
+    RunCPUImpl();
+  } catch (std::exception &e) {
+    HandleError(make_string("Exception in CPU stage: ", e.what()));
+    throw;
+  } catch (...) {
+    HandleError();
+    throw;
+  }
+}
+
+template <typename WorkspacePolicy, typename QueuePolicy>
+void Executor<WorkspacePolicy, QueuePolicy>::RunMixed() {
+  try {
+    RunMixedImpl();
+  } catch (std::exception &e) {
+    HandleError(make_string("Exception in Mixed stage: ", e.what()));
+    throw;
+  } catch (...) {
+    HandleError();
+    throw;
+  }
+}
+
+template <typename WorkspacePolicy, typename QueuePolicy>
+void Executor<WorkspacePolicy, QueuePolicy>::RunGPU() {
+  try {
+    RunGPUImpl();
+  } catch (std::exception &e) {
+    HandleError(make_string("Exception in GPU stage: ", e.what()));
+    throw;
+  } catch (...) {
+    HandleError();
+    throw;
+  }
+}
 
 template <typename WorkspacePolicy, typename QueuePolicy>
 template <typename Workspace>

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -249,10 +249,8 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunCPU() {
     RunCPUImpl();
   } catch (std::exception &e) {
     HandleError(make_string("Exception in CPU stage: ", e.what()));
-    throw;
   } catch (...) {
-    HandleError();
-    throw;
+    HandleError("Unknown error in CPU stage.");
   }
 }
 
@@ -261,11 +259,9 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunMixed() {
   try {
     RunMixedImpl();
   } catch (std::exception &e) {
-    HandleError(make_string("Exception in Mixed stage: ", e.what()));
-    throw;
+    HandleError(make_string("Exception in mixed stage: ", e.what()));
   } catch (...) {
-    HandleError();
-    throw;
+    HandleError("Unknown error in mixed stage.");
   }
 }
 
@@ -275,10 +271,8 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunGPU() {
     RunGPUImpl();
   } catch (std::exception &e) {
     HandleError(make_string("Exception in GPU stage: ", e.what()));
-    throw;
   } catch (...) {
-    HandleError();
-    throw;
+    HandleError("Unknown error in GPU stage.");
   }
 }
 

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -140,6 +140,10 @@ class DLL_PUBLIC Executor : public ExecutorBase, public WorkspacePolicy, public 
   DISABLE_COPY_MOVE_ASSIGN(Executor);
 
  protected:
+  DLL_PUBLIC void RunCPUImpl();
+  DLL_PUBLIC void RunMixedImpl();
+  DLL_PUBLIC void RunGPUImpl();
+
   template<typename T>
   inline void GetMaxSizesCont(T &in, size_t &max_out_size, size_t &max_reserved_size) {
     auto out_size = in.nbytes();

--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -467,7 +467,9 @@ TEST(ExternalSourceTestNoInput, ThrowCpu) {
   vector<string> outputs = {"data_out_cpu"};
 
   exe->Build(&graph, outputs);
-  ASSERT_THROW(exe->RunCPU(), std::exception);
+  exe->RunCPU();
+  DeviceWorkspace ws;
+  EXPECT_THROW(exe->ShareOutputs(&ws), std::exception);
 }
 
 namespace {


### PR DESCRIPTION

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: exceptions in RunXXX (but not in the loop over operators) cause the executor to hang

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Handle errors and shutdown the queue
 - Affected modules and functionalities:
     * Executor
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python test with a trigger for previously erroneous behavior
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
