### PR TITLE
Fix documentation instances of deprecated fn.image_decoder

### DIFF
--- a/docs/advanced_topics_performance_tuning.rst
+++ b/docs/advanced_topics_performance_tuning.rst
@@ -16,7 +16,7 @@ threads. The number of DALI threads is set during the pipeline construction by t
 argument and ``set_affinity`` enables thread affinity for the CPU worker threads.
 
 .. note::
-  For performance reasons, the hybrid :meth:`nvidia.dali.fn.image_decoder` operator, which is
+  For performance reasons, the hybrid :meth:`nvidia.dali.fn.decoders.image` operator, which is
   nvJPEG based, creates threads on its own, and these threads are always affined.
 
 In ``DALI_AFFINITY_MASK``, if the number of threads is higher than the number of CPU IDs,

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -36,8 +36,8 @@ Example::
         """ Create a pipeline which reads images and masks, decodes the images and returns them. """
         img_files, labels = fn.readers.file(file_root="image_dir", seed=1)
         mask_files, _ = fn.readers.file(file_root="mask_dir", seed=1)
-        images = fn.image_decoder(img_files, device="mixed")
-        masks  = fn.image_decoder(mask_files, device="mixed")
+        images = fn.decoders.image(img_files, device="mixed")
+        masks  = fn.decoders.image(mask_files, device="mixed")
         return images, masks, labels
 
     pipe = my_pipeline(batch_size=4, num_threads=2, device_id=0)

--- a/docs/supported_ops_legacy.rst
+++ b/docs/supported_ops_legacy.rst
@@ -6,7 +6,7 @@ a functional API. The use of the object API is discouraged now and its documenta
 here for reference purposes.
 
 The legacy object "operators" are contained in the ``dali.ops`` module and their names are camel cased, instead of snake cased.
-For example, ``dali.ops.ImageDecoder`` is the legacy counterpart of ``dali.fn.image_decoder``.
+For example, ``dali.ops.CropMirrorNormalize`` is the legacy counterpart of ``dali.fn.crop_mirror_normalize``.
 
 When using the operator object API, the definition of the operator is separated from its use in a
 DALI pipeline, which allows to set static arguments during instantiation.
@@ -18,7 +18,7 @@ Here is an example pipeline using the (recommended) functional API::
     pipe = dali.pipeline.Pipeline(batch_size = 3, num_threads = 2, device_id = 0)
     with pipe:
         files, labels = dali.fn.readers.file(file_root = "./my_file_root")
-        images = dali.fn.image_decoder(files, device = "mixed")
+        images = dali.fn.decoders.image(files, device = "mixed")
         images = dali.fn.rotate(images, angle = dali.fn.random.uniform(range=(-45,45)))
         images = dali.fn.resize(images, resize_x = 300, resize_y = 300)
         pipe.set_outputs(images, labels)
@@ -58,7 +58,7 @@ It is worth noting that the two APIs can be used together in a single pipeline. 
 
     with pipe:
         files, labels = reader()
-        images = dali.fn.image_decoder(files, device = "mixed")
+        images = dali.fn.decoders.image(files, device = "mixed")
         images = dali.fn.rotate(images, angle = dali.fn.random.uniform(range=(-45,45)))
         images = resize(images)
         pipe.set_outputs(images, labels)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Few instances of deprecated alias `fn.image_decoder` are still present in the documentation. Changed it to `fn.decoders.image`.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Replace remaining instances of fn.image_decoder with fn.decoders.image*
 - Affected modules and functionalities:
     *Docs*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-1866]*
