### PR TITLE
Enhance deprecated argument documentation

### DIFF
--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -97,10 +97,7 @@ Otherwise, the threads can be reassigned to any CPU core by the operating system
   .AddOptionalArg("split_stages",
       R"code(Applies **only** to the ``mixed`` backend type.
 
-If True, the operator will be split into two sub-stages: a CPU and GPU one.
-
-Warning: This argument is now deprecated, and its value will be ignored.
-)code",
+If True, the operator will be split into two sub-stages: a CPU and GPU one.)code",
       false)
   .DeprecateArg("split_stages")  // deprecated in DALI 1.0
   .AddOptionalArg("use_chunk_allocator",
@@ -108,10 +105,7 @@ Warning: This argument is now deprecated, and its value will be ignored.
 
 Uses the chunk pinned memory allocator and allocates a chunk of the
 ``batch_size * prefetch_queue_depth`` size during the construction and suballocates
-them at runtime.
-
-Warning: This argument is now deprecated, and its value will be ignored.
-)code",
+them at runtime.)code",
       false)
   .DeprecateArg("use_chunk_allocator")  // deprecated in DALI 1.0
   .AddOptionalArg("use_fast_idct",

--- a/dali/operators/reader/coco_reader_op.cc
+++ b/dali/operators/reader/coco_reader_op.cc
@@ -109,15 +109,12 @@ If set to False, the bboxes are returned as [x, y, width, height].)code",
 .. warning::
     Currently objects with ``iscrowd=1`` annotations are skipped.)code",
       false)
-  .AddOptionalArg("masks",
-  R"code(Enable polygon masks.
-
-.. warning::
-  Use ``polygon_masks`` instead. Note that the polygon format has changed ``mask_id, start_coord, end_coord`` to ``mask_id, start_vertex, end_vertex`` where
-  start_coord and end_coord are total number of coordinates, effectly ``start_coord = 2 * start_vertex`` and ``end_coord = 2 * end_vertex``.
-  Example: A polygon with vertices ``[[x0, y0], [x1, y1], [x2, y2]]`` would be represented as ``[mask_id, 0, 6]`` when using the deprecated
-  argument ``masks``, but ``[mask_id, 0, 3]`` when using the new argument ``polygon_masks``.)code", false)
-  .DeprecateArg("masks", false)  // deprecated since 0.28dev
+  .AddOptionalArg("masks", R"code(Enable polygon masks.)code", false)
+  .DeprecateArg("masks", false,
+R"code(Use ``polygon_masks`` instead. Note that the polygon format has changed ``mask_id, start_coord, end_coord`` to ``mask_id, start_vertex, end_vertex`` where
+start_coord and end_coord are total number of coordinates, effectly ``start_coord = 2 * start_vertex`` and ``end_coord = 2 * end_vertex``.
+Example: A polygon with vertices ``[[x0, y0], [x1, y1], [x2, y2]]`` would be represented as ``[mask_id, 0, 6]`` when using the deprecated
+argument ``masks``, but ``[mask_id, 0, 3]`` when using the new argument ``polygon_masks``.)code")  // deprecated since 0.28dev
   .AddOptionalArg("pixelwise_masks",
       R"code(If true, segmentation masks are read and returned as pixel-wise masks. This argument is
 mutually exclusive with ``polygon_masks``.)code",

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -848,7 +848,7 @@ graph even if its outputs are not used.)code", false);
   DLL_PUBLIC std::string GetArgumentDefaultValueString(const std::string &name) const;
 
   /**
-   * @brief Get names of all required and optional arguments
+   * @brief Get names of all required, optional, and deprecated arguments
    */
   DLL_PUBLIC std::vector<std::string> GetArgumentNames() const;
   DLL_PUBLIC bool IsTensorArgument(const std::string &name) const;
@@ -871,11 +871,14 @@ graph even if its outputs are not used.)code", false);
                                              const std::string &renamed_to,
                                              bool removed) const {
     std::stringstream ss;
-    ss << "Argument '" << arg_name << "' for operator '" << name_ << "' is now deprecated.";
-    if (!renamed_to.empty()) {
-      ss << " Use '" << renamed_to << "' instead.";
-    } else if (removed) {
-      ss << " The argument is no longer used and should be removed.";
+    if (removed) {
+      ss << "The argument `" << arg_name
+         << "` is no longer used and will be removed in a future release.";
+    } else if (!renamed_to.empty()) {
+      ss << "The argument `" << arg_name << "` is a deprecated alias for `" << renamed_to
+         << "`. Use `" << renamed_to << "` instead.";
+    } else {
+      ss << "The argument `" << arg_name << "` is now deprecated and its usage is discouraged.";
     }
     return ss.str();
   }
@@ -891,8 +894,8 @@ graph even if its outputs are not used.)code", false);
   }
 
   std::map<std::string, RequiredArgumentDef> GetRequiredArguments() const;
-
   std::map<std::string, DefaultedArgumentDef> GetOptionalArguments() const;
+  std::map<std::string, DeprecatedArgDef> GetDeprecatedArguments() const;
 
   string dox_;
   string name_;

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -872,13 +872,13 @@ graph even if its outputs are not used.)code", false);
                                              bool removed) const {
     std::stringstream ss;
     if (removed) {
-      ss << "The argument `" << arg_name
-         << "` is no longer used and will be removed in a future release.";
+      ss << "The argument ``" << arg_name
+         << "`` is no longer used and will be removed in a future release.";
     } else if (!renamed_to.empty()) {
-      ss << "The argument `" << arg_name << "` is a deprecated alias for `" << renamed_to
-         << "`. Use `" << renamed_to << "` instead.";
+      ss << "The argument ``" << arg_name << "`` is a deprecated alias for ``" << renamed_to
+         << "``. Use ``" << renamed_to << "`` instead.";
     } else {
-      ss << "The argument `" << arg_name << "` is now deprecated and its usage is discouraged.";
+      ss << "The argument ``" << arg_name << "`` is now deprecated and its usage is discouraged.";
     }
     return ss.str();
   }

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -110,7 +110,7 @@ def _get_kwargs(schema):
             renamed_arg = meta['renamed_to']
             # Renamed and removed arguments won't show full documentation (only warning box)
             skip_full_doc = renamed_arg or meta['removed']
-            # Renamed aliases don't are not fully registered to the schema, that's why we query for the
+            # Renamed aliases are not fully registered to the schema, that's why we query for the
             # info on the renamed_arg name.
             if renamed_arg:
                 dtype = schema.GetArgumentType(renamed_arg)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -101,11 +101,12 @@ def _get_kwargs(schema):
         type_name = ""
         dtype = None
         doc = ""
+        deprecation_warning = None
         if schema.IsDeprecatedArg(arg):
             meta = schema.DeprecatedArgMeta(arg)
             msg = meta['msg']
             assert msg is not None
-            doc += ".. warning::\n\n    " + msg
+            deprecation_warning = ".. warning::\n\n    " + msg.replace("\n", "\n    ")
             renamed_arg = meta['renamed_to']
             # Renamed and removed arguments won't show full documentation (only warning box)
             skip_full_doc = renamed_arg or meta['removed']
@@ -129,6 +130,10 @@ def _get_kwargs(schema):
                     default_value = ast.literal_eval(default_value_string)
                     type_name += ", default = {}".format(_default_converter(dtype, default_value))
             doc += schema.GetArgumentDox(arg)
+            if deprecation_warning:
+                doc += "\n\n" + deprecation_warning
+        elif deprecation_warning:
+            doc += deprecation_warning
         ret += _numpydoc_formatter(arg, type_name, doc)
         ret += '\n'
     return ret

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -97,17 +97,38 @@ def _get_kwargs(schema):
     """
     ret = ""
     for arg in schema.GetArgumentNames():
-        allow_tensors = schema.IsTensorArgument(arg)
-        arg_name_doc = arg
-        dtype = schema.GetArgumentType(arg)
-        type_name = _type_name_convert_to_string(dtype, allow_tensors = allow_tensors)
-        if schema.IsArgumentOptional(arg):
-            type_name += ", optional"
-            if schema.HasArgumentDefaultValue(arg):
-                default_value_string = schema.GetArgumentDefaultValueString(arg)
-                default_value = ast.literal_eval(default_value_string)
-                type_name += ", default = {}".format(_default_converter(dtype, default_value))
-        doc = schema.GetArgumentDox(arg)
+        skip_full_doc = False
+        type_name = ""
+        dtype = None
+        doc = ""
+        if schema.IsDeprecatedArg(arg):
+            meta = schema.DeprecatedArgMeta(arg)
+            msg = meta['msg']
+            assert msg is not None
+            doc += ".. warning::\n\n    " + msg
+            renamed_arg = meta['renamed_to']
+            # Renamed and removed arguments won't show full documentation (only warning box)
+            skip_full_doc = renamed_arg or meta['removed']
+            # Renamed aliases don't are not fully registered to the schema, that's why we query for the
+            # info on the renamed_arg name.
+            if renamed_arg:
+                dtype = schema.GetArgumentType(renamed_arg)
+                type_name = _type_name_convert_to_string(dtype,
+                                                         allow_tensors=schema.IsTensorArgument(renamed_arg))
+        # Try to get dtype only if not set already (renamed args go through a different path, see above)
+        if not dtype:
+            dtype = schema.GetArgumentType(arg)
+            type_name = _type_name_convert_to_string(dtype,
+                                                     allow_tensors=schema.IsTensorArgument(arg))
+        # Add argument documentation if necessary
+        if not skip_full_doc:
+            if schema.IsArgumentOptional(arg):
+                type_name += ", optional"
+                if schema.HasArgumentDefaultValue(arg):
+                    default_value_string = schema.GetArgumentDefaultValueString(arg)
+                    default_value = ast.literal_eval(default_value_string)
+                    type_name += ", default = {}".format(_default_converter(dtype, default_value))
+            doc += schema.GetArgumentDox(arg)
         ret += _numpydoc_formatter(arg, type_name, doc)
         ret += '\n'
     return ret

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1664,9 +1664,7 @@ def test_output_dtype_deprecation():
         # Verify DeprecationWarning
         assert len(w) == 1
         assert issubclass(w[-1].category, DeprecationWarning)
-        print(str(w[-1].message))
-        assert ("Argument 'output_dtype' for operator 'CropMirrorNormalize' is now deprecated. " +
-                "Use 'dtype' instead.") == str(w[-1].message)
+        assert ("The argument ``output_dtype`` is a deprecated alias for ``dtype``. Use ``dtype`` instead." == str(w[-1].message))
 
 def test_image_type_deprecation():
     with warnings.catch_warnings(record=True) as w:
@@ -1677,8 +1675,7 @@ def test_image_type_deprecation():
         # Verify DeprecationWarning
         assert len(w) == 1
         assert issubclass(w[-1].category, DeprecationWarning)
-        assert ("Argument 'image_type' for operator 'CropMirrorNormalize' is now deprecated. " +
-                "The argument is no longer used and should be removed.") == str(w[-1].message)
+        assert ("The argument ``image_type`` is no longer used and will be removed in a future release." == str(w[-1].message))
 
 @raises(TypeError)
 def test_output_dtype_both_error():


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It improves documentation of deprecated arguments by adding a warning box

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added limited documentation for renamed and removed variables*
     *Added warning message about deprecation*
 - Affected modules and functionalities:
     *Docs*
 - Key points relevant for the review:
     *Check the look and feel of docs?*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *[Documentation updated]*


**JIRA TASK**: *[DALI-1894, DALI-1895]*
