### PR TITLE
Fix paddle ssd

### DIFF
--- a/docs/examples/frameworks/mxnet/gluon.ipynb
+++ b/docs/examples/frameworks/mxnet/gluon.ipynb
@@ -90,7 +90,7 @@
     "@pipeline_def\n",
     "def gluon_pipe():\n",
     "    jpegs, labels = fn.readers.file(\n",
-    "        file_root=data_path + '/lfw-deepfunneled/', random_shuffle = True, pad_last_batch=True)\n",
+    "        name='Reader', file_root=data_path + '/lfw-deepfunneled/', random_shuffle = True, pad_last_batch=True)\n",
     "    images = fn.decoders.image(jpegs, device='mixed')\n",
     "    images = fn.resize(\n",
     "        images, resize_x=target_wd, resize_y=target_ht, interp_type=types.INTERP_LINEAR)\n",

--- a/qa/TL1_paddle_ssd/test.sh
+++ b/qa/TL1_paddle_ssd/test.sh
@@ -5,6 +5,9 @@ pip_packages="paddlepaddle-gpu"
 target_dir=./docs/examples/use_cases/paddle/ssd/
 
 test_body() {
+    # This test is incompatible with multi-gpu environments.
+    export CUDA_VISIBLE_DEVICES=0
+    
     python train.py --check-loss-steps=300 -b 8 /data/coco/coco-2017/coco2017/
 }
 


### PR DESCRIPTION
#### Why we need this PR?

Paddle SSD test failes when there are more GPUs in the test environment. This might casue L1 to fail, when runner with more than one GPUs is selected to run this job.

#### What happened in this PR?
 - What solution was applied:
     *Make Paddle see only one GPU during the test, regardless on the actual runner, by using `CUDA_VISIBLE_DEVICES` in this test*
 - Affected modules and functionalities:
     *Paddle SSD example*
 - Validation and testing:
     *CI L1 tests*


**JIRA TASK**: *[NA]*
