### PR TITLE
Fix a race when loader starts reading even the metadata is not ready yet

### DIFF
--- a/dali/operators/reader/loader/coco_loader.h
+++ b/dali/operators/reader/loader/coco_loader.h
@@ -183,7 +183,7 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
       ParseJsonAnnotations();
     }
 
-    DALI_ENFORCE(Size() > 0, "No files found.");
+    DALI_ENFORCE(SizeNoLock() > 0, "No files found.");
     if (shuffle_) {
       // seeded with hardcoded value to get
       // the same sequence on every shard

--- a/dali/operators/reader/loader/coco_loader.h
+++ b/dali/operators/reader/loader/coco_loader.h
@@ -183,7 +183,7 @@ class DLL_PUBLIC CocoLoader : public FileLabelLoader {
       ParseJsonAnnotations();
     }
 
-    DALI_ENFORCE(SizeNoLock() > 0, "No files found.");
+    DALI_ENFORCE(SizeImpl() > 0, "No files found.");
     if (shuffle_) {
       // seeded with hardcoded value to get
       // the same sequence on every shard

--- a/dali/operators/reader/loader/file_label_loader.h
+++ b/dali/operators/reader/loader/file_label_loader.h
@@ -165,7 +165,7 @@ class DLL_PUBLIC FileLabelLoader : public Loader<CPUBackend, ImageLabelWrapper> 
         DALI_ENFORCE(s.eof(), "Wrong format of file_list: " + file_list_);
       }
     }
-    DALI_ENFORCE(SizeNoLock() > 0, "No files found.");
+    DALI_ENFORCE(SizeImpl() > 0, "No files found.");
 
     if (shuffle_) {
       // seeded with hardcoded value to get
@@ -178,7 +178,7 @@ class DLL_PUBLIC FileLabelLoader : public Loader<CPUBackend, ImageLabelWrapper> 
 
   void Reset(bool wrap_to_shard) override {
     if (wrap_to_shard) {
-      current_index_ = start_index(shard_id_, num_shards_, SizeNoLock());
+      current_index_ = start_index(shard_id_, num_shards_, SizeImpl());
     } else {
       current_index_ = 0;
     }

--- a/dali/operators/reader/loader/file_label_loader.h
+++ b/dali/operators/reader/loader/file_label_loader.h
@@ -165,7 +165,7 @@ class DLL_PUBLIC FileLabelLoader : public Loader<CPUBackend, ImageLabelWrapper> 
         DALI_ENFORCE(s.eof(), "Wrong format of file_list: " + file_list_);
       }
     }
-    DALI_ENFORCE(Size() > 0, "No files found.");
+    DALI_ENFORCE(SizeNoLock() > 0, "No files found.");
 
     if (shuffle_) {
       // seeded with hardcoded value to get
@@ -178,7 +178,7 @@ class DLL_PUBLIC FileLabelLoader : public Loader<CPUBackend, ImageLabelWrapper> 
 
   void Reset(bool wrap_to_shard) override {
     if (wrap_to_shard) {
-      current_index_ = start_index(shard_id_, num_shards_, Size());
+      current_index_ = start_index(shard_id_, num_shards_, SizeNoLock());
     } else {
       current_index_ = 0;
     }

--- a/dali/operators/reader/loader/file_loader.h
+++ b/dali/operators/reader/loader/file_loader.h
@@ -182,7 +182,7 @@ class FileLoader : public Loader<Backend, Target> {
         DALI_ENFORCE(s.eof(), "Wrong format of file_list: " + file_list_);
       }
     }
-    DALI_ENFORCE(SizeNoLock() > 0, "No files found.");
+    DALI_ENFORCE(SizeImpl() > 0, "No files found.");
 
     if (shuffle_) {
       // seeded with hardcoded value to get
@@ -195,7 +195,7 @@ class FileLoader : public Loader<Backend, Target> {
 
   void Reset(bool wrap_to_shard) override {
     if (wrap_to_shard) {
-      current_index_ = start_index(shard_id_, num_shards_, SizeNoLock());
+      current_index_ = start_index(shard_id_, num_shards_, SizeImpl());
     } else {
       current_index_ = 0;
     }
@@ -219,7 +219,6 @@ class FileLoader : public Loader<Backend, Target> {
   using Loader<Backend, Target>::MoveToNextShard;
   using Loader<Backend, Target>::ShouldSkipImage;
   using Loader<Backend, Target>::Size;
-  using Loader<Backend, Target>::SizeNoLock;
   using Loader<Backend, Target>::PrepareEmptyTensor;
 
   string file_list_, file_root_, file_filter_;

--- a/dali/operators/reader/loader/file_loader.h
+++ b/dali/operators/reader/loader/file_loader.h
@@ -182,7 +182,7 @@ class FileLoader : public Loader<Backend, Target> {
         DALI_ENFORCE(s.eof(), "Wrong format of file_list: " + file_list_);
       }
     }
-    DALI_ENFORCE(Size() > 0, "No files found.");
+    DALI_ENFORCE(SizeNoLock() > 0, "No files found.");
 
     if (shuffle_) {
       // seeded with hardcoded value to get
@@ -195,7 +195,7 @@ class FileLoader : public Loader<Backend, Target> {
 
   void Reset(bool wrap_to_shard) override {
     if (wrap_to_shard) {
-      current_index_ = start_index(shard_id_, num_shards_, Size());
+      current_index_ = start_index(shard_id_, num_shards_, SizeNoLock());
     } else {
       current_index_ = 0;
     }
@@ -219,6 +219,7 @@ class FileLoader : public Loader<Backend, Target> {
   using Loader<Backend, Target>::MoveToNextShard;
   using Loader<Backend, Target>::ShouldSkipImage;
   using Loader<Backend, Target>::Size;
+  using Loader<Backend, Target>::SizeNoLock;
   using Loader<Backend, Target>::PrepareEmptyTensor;
 
   string file_list_, file_root_, file_filter_;

--- a/dali/operators/reader/loader/indexed_file_loader.h
+++ b/dali/operators/reader/loader/indexed_file_loader.h
@@ -137,7 +137,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     int64 seek_pos, size;
     size_t file_index;
     if (wrap_to_shard) {
-      current_index_ = start_index(shard_id_, num_shards_, Size());
+      current_index_ = start_index(shard_id_, num_shards_, SizeNoLock());
     } else {
       current_index_ = 0;
     }

--- a/dali/operators/reader/loader/indexed_file_loader.h
+++ b/dali/operators/reader/loader/indexed_file_loader.h
@@ -137,7 +137,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     int64 seek_pos, size;
     size_t file_index;
     if (wrap_to_shard) {
-      current_index_ = start_index(shard_id_, num_shards_, SizeNoLock());
+      current_index_ = start_index(shard_id_, num_shards_, SizeImpl());
     } else {
       current_index_ = 0;
     }

--- a/dali/operators/reader/loader/lmdb.h
+++ b/dali/operators/reader/loader/lmdb.h
@@ -222,7 +222,7 @@ class LMDBLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
   void Reset(bool wrap_to_shard) override {
     // work out how many entries to move forward to handle sharding
     if (wrap_to_shard) {
-      current_index_ = start_index(shard_id_, num_shards_, SizeNoLock());
+      current_index_ = start_index(shard_id_, num_shards_, SizeImpl());
     } else {
       current_index_ = 0;
     }

--- a/dali/operators/reader/loader/lmdb.h
+++ b/dali/operators/reader/loader/lmdb.h
@@ -222,7 +222,7 @@ class LMDBLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
   void Reset(bool wrap_to_shard) override {
     // work out how many entries to move forward to handle sharding
     if (wrap_to_shard) {
-      current_index_ = start_index(shard_id_, num_shards_, Size());
+      current_index_ = start_index(shard_id_, num_shards_, SizeNoLock());
     } else {
       current_index_ = 0;
     }

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -217,8 +217,8 @@ class Loader {
   void PrepareMetadata() {
     std::lock_guard<std::mutex> l(prepare_metadata_mutex_);
     if (!loading_flag_) {
-      loading_flag_ = true;
       PrepareMetadataImpl();
+      loading_flag_ = true;
     }
   }
 

--- a/dali/operators/reader/loader/loader.h
+++ b/dali/operators/reader/loader/loader.h
@@ -158,7 +158,7 @@ class Loader {
       // First part of this condition makes sure that the same number of batches is returned in each
       // shard. Second makes sure that padding is done up to the full batch. For the first sample in
       // the batch is_new_batch is set so it means that padding may be no longer needed
-      if ((returned_sample_counter_  < num_samples(num_shards_, SizeNoLock()) || !is_new_batch) &&
+      if ((returned_sample_counter_  < num_samples(num_shards_, Size()) || !is_new_batch) &&
         pad_last_batch_) {
         ++returned_sample_counter_;
         return last_sample_ptr_tmp;
@@ -227,12 +227,6 @@ class Loader {
   // Give the size of the data accessed through the Loader
   Index Size(bool consider_padding = false) {
     PrepareMetadata();
-    return SizeNoLock(consider_padding);
-  }
-
-  // Give the size of the data accessed through the Loader, it assumes that
-  // PrepareMetadataImpl() was called before
-  Index SizeNoLock(bool consider_padding = false) {
     if (pad_last_batch_ && consider_padding) {
       return num_samples(num_shards_, SizeImpl()) * num_shards_;
     } else {
@@ -271,18 +265,18 @@ class Loader {
 
   // Check if given reader moved to the next shard
   virtual inline bool IsNextShard(Index current_index) {
-     return current_index >= SizeNoLock() ||
+     return current_index >= Size() ||
             (stick_to_shard_ && shard_id_ + 1 < num_shards_ &&
-            current_index >= static_cast<Index>(start_index(shard_id_ + 1, num_shards_, SizeNoLock())));
+            current_index >= static_cast<Index>(start_index(shard_id_ + 1, num_shards_, Size())));
   }
 
   inline bool IsNextShardRelative(Index already_read, int virtual_shard_id) {
      Index current_index = already_read
-                         + static_cast<Index>(start_index(virtual_shard_id, num_shards_, SizeNoLock()));
-     return current_index >= SizeNoLock() ||
+                         + static_cast<Index>(start_index(virtual_shard_id, num_shards_, Size()));
+     return current_index >= Size() ||
             (virtual_shard_id + 1 < num_shards_ &&
               current_index >=
-              static_cast<Index>(start_index(virtual_shard_id + 1, num_shards_, SizeNoLock())));
+              static_cast<Index>(start_index(virtual_shard_id + 1, num_shards_, Size())));
   }
 
   inline void IncreaseReadSampleCounter() {

--- a/dali/operators/reader/loader/nemo_asr_loader.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader.cc
@@ -80,7 +80,7 @@ void NemoAsrLoader::PrepareMetadataImpl() {
   shuffled_indices_.resize(entries_.size());
   std::iota(shuffled_indices_.begin(), shuffled_indices_.end(), 0);
 
-  DALI_ENFORCE(SizeNoLock() > 0, "No files found.");
+  DALI_ENFORCE(SizeImpl() > 0, "No files found.");
   if (shuffle_) {
     // seeded with hardcoded value to get
     // the same sequence on every shard
@@ -91,7 +91,7 @@ void NemoAsrLoader::PrepareMetadataImpl() {
 }
 
 void NemoAsrLoader::Reset(bool wrap_to_shard) {
-  current_index_ = wrap_to_shard ? start_index(shard_id_, num_shards_, SizeNoLock()) : 0;
+  current_index_ = wrap_to_shard ? start_index(shard_id_, num_shards_, SizeImpl()) : 0;
   current_epoch_++;
 
   if (shuffle_after_epoch_) {

--- a/dali/operators/reader/loader/nemo_asr_loader.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader.cc
@@ -80,7 +80,7 @@ void NemoAsrLoader::PrepareMetadataImpl() {
   shuffled_indices_.resize(entries_.size());
   std::iota(shuffled_indices_.begin(), shuffled_indices_.end(), 0);
 
-  DALI_ENFORCE(Size() > 0, "No files found.");
+  DALI_ENFORCE(SizeNoLock() > 0, "No files found.");
   if (shuffle_) {
     // seeded with hardcoded value to get
     // the same sequence on every shard
@@ -91,7 +91,7 @@ void NemoAsrLoader::PrepareMetadataImpl() {
 }
 
 void NemoAsrLoader::Reset(bool wrap_to_shard) {
-  current_index_ = wrap_to_shard ? start_index(shard_id_, num_shards_, Size()) : 0;
+  current_index_ = wrap_to_shard ? start_index(shard_id_, num_shards_, SizeNoLock()) : 0;
   current_epoch_++;
 
   if (shuffle_after_epoch_) {

--- a/dali/operators/reader/loader/nemo_asr_loader_test.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader_test.cc
@@ -141,7 +141,6 @@ TEST(NemoAsrLoaderTest, ParseManifestContent) {
   {
     NemoAsrLoader loader(spec);
     ASSERT_THROW(loader.PrepareMetadata(), std::runtime_error);
-    EXPECT_EQ(0, loader.Size());
   }
 
   {
@@ -151,7 +150,6 @@ TEST(NemoAsrLoaderTest, ParseManifestContent) {
 
     NemoAsrLoader loader(spec);
     ASSERT_THROW(loader.PrepareMetadata(), std::runtime_error);
-    EXPECT_EQ(0, loader.Size());
   }
 
   {
@@ -161,7 +159,6 @@ TEST(NemoAsrLoaderTest, ParseManifestContent) {
 
     NemoAsrLoader loader(spec);
     ASSERT_THROW(loader.PrepareMetadata(), std::runtime_error);
-    EXPECT_EQ(0, loader.Size());
   }
 
   {

--- a/dali/operators/reader/loader/sequence_loader.h
+++ b/dali/operators/reader/loader/sequence_loader.h
@@ -126,7 +126,7 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
  private:
   void Reset(bool wrap_to_shard) override {
     if (wrap_to_shard) {
-      current_sequence_ = start_index(shard_id_, num_shards_, SizeNoLock());
+      current_sequence_ = start_index(shard_id_, num_shards_, SizeImpl());
     } else {
       current_sequence_ = 0;
     }

--- a/dali/operators/reader/loader/sequence_loader.h
+++ b/dali/operators/reader/loader/sequence_loader.h
@@ -126,7 +126,7 @@ class SequenceLoader : public Loader<CPUBackend, TensorSequence> {
  private:
   void Reset(bool wrap_to_shard) override {
     if (wrap_to_shard) {
-      current_sequence_ = start_index(shard_id_, num_shards_, Size());
+      current_sequence_ = start_index(shard_id_, num_shards_, SizeNoLock());
     } else {
       current_sequence_ = 0;
     }

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -302,7 +302,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
  private:
   void Reset(bool wrap_to_shard) override {
     if (wrap_to_shard) {
-      current_frame_idx_ = start_index(shard_id_, num_shards_, Size());
+      current_frame_idx_ = start_index(shard_id_, num_shards_, SizeNoLock());
     } else {
       current_frame_idx_ = 0;
     }

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -302,7 +302,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
  private:
   void Reset(bool wrap_to_shard) override {
     if (wrap_to_shard) {
-      current_frame_idx_ = start_index(shard_id_, num_shards_, SizeNoLock());
+      current_frame_idx_ = start_index(shard_id_, num_shards_, SizeImpl());
     } else {
       current_frame_idx_ = 0;
     }


### PR DESCRIPTION
- PrepareMetadata sets that the reader is ready to read first before the metadata is prepared. In effect when the user queries loader for any meta, like size, it will start prefetching even the metadata itself is not ready yet. Fix the race by preparing the meta first and then setting the ready variable
- fixes a deadlock caused by a sequence of calls PrepareMetadata->PrepareMetadataImpl->Reset->Size->PrepareMetadata, by replacing the call to Size by SizeImpl which provides the same functionality with the used set of arguments, but it can be done only when the loader has the necessary data fields initialized

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a race when loader starts reading even the metadata is not ready yet
- It fixes a deadlock caused by a sequence of calls PrepareMetadata->PrepareMetadataImpl->Reset->Size->PrepareMetadata

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Fix the race by preparing the meta first and then setting the ready variable
     Fixes a deadlock caused by a sequence of calls PrepareMetadata->PrepareMetadataImpl->Reset->Size->PrepareMetadata
 - Affected modules and functionalities:
     loader
     loader subclasses
 - Key points relevant for the review:
     check if there is no more inversed order leading to a race
 - Validation and testing:
     current tests applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1909]*