### PR TITLE
Require uniform StopIteration for parallel External Source

### DIFF
--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -394,7 +394,11 @@ Keyword Args
 
     When ``parallel`` is set to True, ``source`` must return NumPy/MXNet/PyTorch CPU array,
     TensorCPU, or tuple/list of these types with length matching num_outputs.
-    The ``source`` callback must raise StopIteration when the end of data is reached.
+    The ``source`` callback must raise ``StopIteration`` when the end of data is reached.
+
+    .. warning:: ``StopIteration`` must be raised for all samples calculated in a given iteration,
+        so all worker processes can propagate the ``StopIteration`` signal. Producing a partial
+        batch is prohibited.
 
     Setting ``parallel`` to True makes the external source work in per-sample mode.
     If ``batch`` was not set it is set to False.

--- a/dali/python/nvidia/dali/types.py
+++ b/dali/python/nvidia/dali/types.py
@@ -495,7 +495,7 @@ class SampleInfo:
     """
     Describes the indices of a sample requested from :meth:`nvidia.dali.fn.external_source`
 
-    :ivar idx_in_epoch: 0-based index of the sample witin epoch
+    :ivar idx_in_epoch: 0-based index of the sample within epoch
     :ivar idx_in_batch: 0-based index of the sample within batch
     :ivar iteration:    number of current batch within epoch
     """

--- a/dali/test/python/test_external_source_parallel.py
+++ b/dali/test/python/test_external_source_parallel.py
@@ -115,6 +115,14 @@ def test_stop_iteration_resume():
                                 py_num_workers=num_workers, py_start_method='spawn', parallel=True)
                 yield check_stop_iteration_resume, pipe, batch_size, layout
 
+@raises(RuntimeError)
+@with_setup(setup_function, teardown_function)
+def test_stop_iteration_mismatch():
+    callback = ExtCallback((4, 4), 299, 'int32')
+    pipe = create_pipe(callback, 'cpu', batch_size=100, layout="XY",
+                    py_num_workers=4, py_start_method='spawn', parallel=True)
+    build_and_run_pipeline(pipe)
+
 @with_setup(setup_function, teardown_function)
 def test_layout():
     for layout, dims in zip(["X", "XY", "XYZ"], ((4,), (4, 4), (4, 4, 4))):

--- a/dali/test/python/test_external_source_parallel_utils.py
+++ b/dali/test/python/test_external_source_parallel_utils.py
@@ -105,15 +105,15 @@ def check_spawn_with_callback(
         dtypes=[np.float32, np.int32, np.uint8],
         shapes=[(4, 5)],
         random_data=False, random_shape=False):
-    epoch_size = 250
     for shape in shapes:
         for dtype in dtypes:
-            callback = callback_class(shape, epoch_size, dtype,
-                                      random_data=random_data, random_shape=random_shape)
-            callback_ref = callback_ref_class(
-                shape, epoch_size, dtype, random_data=random_data, random_shape=random_shape)
             for workers_num in [1, 4]:
                 for batch_size in [1, 16, 150]:
+                    epoch_size = (250 // batch_size) * batch_size
+                    callback = callback_class(shape, epoch_size, dtype,
+                                            random_data=random_data, random_shape=random_shape)
+                    callback_ref = callback_ref_class(
+                        shape, epoch_size, dtype, random_data=random_data, random_shape=random_shape)
                     pipe_parallel = create_pipe(
                         callback, 'cpu', batch_size, py_num_workers=workers_num,
                         py_start_method='spawn', parallel=True, num_outputs=num_outputs,
@@ -142,7 +142,7 @@ def check_stop_iteration_resume(pipe, batch_size, layout):
         try:
             while True:
                 (r, ) = pipe.run()
-                output.append(r)
+                output.append(r.as_array())
         except StopIteration:
             pipe.reset()
     assert len(outputs_epoch_1) == len(outputs_epoch_2), ("Epochs must have same number of iterations, "

--- a/dali/test/python/test_external_source_parallel_utils.py
+++ b/dali/test/python/test_external_source_parallel_utils.py
@@ -142,7 +142,7 @@ def check_stop_iteration_resume(pipe, batch_size, layout):
         try:
             while True:
                 (r, ) = pipe.run()
-                output.append(r.as_array())
+                output.append(np.copy(r.as_array()))
         except StopIteration:
             pipe.reset()
     assert len(outputs_epoch_1) == len(outputs_epoch_2), ("Epochs must have same number of iterations, "


### PR DESCRIPTION
Fix potential mismatch between worker processes, when
StopIteration is raised for only part of the calculated
batch.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- Fix a mismatch in parallel External Source test and add an error when it happens. 

#### What happened in this PR?
 - What solution was applied:
     StopIteration is treated under the hood as different entity and included in calculation of processed tasks.
     Batch is completed when all tasks from workers are returned back (either processed of signalling Stop).
     If there are StopIterations, they must come from all workers at the same time (cover all samples).
     Raise an error if there is a mismatch, adjust tests' epoch sizes.
     Adjust docs
 - Affected modules and functionalities:
     Parallel External Source and docs.
 - Key points relevant for the review:
     
 - Validation and testing:
     CI.
 - Documentation (including examples):
     Warning in docs added.


**JIRA TASK**: *[DALI-1910]*
