### PR TITLE
Adding src_dims to reshape operator

### DIFF
--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -289,7 +289,7 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
 
       output_shape_.resize(N, src_dims_.size());
       for (int i = 0; i < N; i++) {
-        for (int d = 0; d < input_shape_.sample_dim(); d++) {
+        for (size_t d = 0; d < src_dims_.size(); d++) {
           const int src_d = src_dims_[d];
           output_shape_.tensor_shape_span(i)[d] = src_d == -1 ? 1 : input_shape_.tensor_shape_span(i)[src_d];
         }

--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -253,10 +253,12 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
       if (use_rel_shape_) {
         if (!src_dims_.empty()) {
           DALI_ENFORCE(rel_uniform_shape_.size() == src_dims_.size(),
-            make_string(OpName(), ": ``src_dims`` and ``rel_shape`` should have the same length when both of them are provided."));
+            make_string(OpName(), ": ``src_dims`` and ``rel_shape`` should have the same"
+            " length when both of them are provided. Got ", src_dims_.size(), " and ",
+            rel_uniform_shape_.size(), " elements respectively"));
         }
     
-        output_shape_.resize(N, std::max(src_dims_.size(), rel_uniform_shape_.size()));
+        output_shape_.resize(N, rel_uniform_shape_.size());
         for (int i = 0; i < N; i++) {
           for (int d = 0; d < output_shape_.sample_dim(); d++) {
             const int src_d = src_dims_.empty() ? d : src_dims_[d];
@@ -400,9 +402,11 @@ void Reshape<Backend>::CheckSrcDims(const Workspace &ws) {
   const auto &in = ws.template InputRef<Backend>(0);
   const auto &input_shape = in.shape();
   const int ndim = input_shape.sample_dim();
-  for (const auto src_dim : src_dims_) {
-    DALI_ENFORCE(-1 <= src_dim && src_dim < ndim,
-      make_string(OpName(), ": dimension in src_dims is out of range"));
+  for (size_t d = 0; d < src_dims_.size(); d++) {
+    DALI_ENFORCE(-1 <= src_dims_[d] && src_dims_[d] < ndim,
+      make_string(OpName(), ": Out of bounds ``src_dims`` index. The indices in ``src_dims``"
+      " should be either a valid dimension index (range 0..ndim-1) or -1 to insert a new dimension. Got:"
+      " src_dims[", d, "]=", src_dims_[d], ", ndim=", ndim));
   }
 }
 

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "dali/pipeline/operator/arg_helper.h"
 #include "dali/pipeline/operator/operator.h"
 #include "dali/core/tensor_view.h"
 
@@ -40,6 +41,11 @@ class Reshape : public Operator<Backend> {
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override;
 
   void RunImpl(Workspace &ws) override;
+ 
+ protected:
+  virtual void CalculateOutputShape(const Workspace &ws);
+  std::vector<int> src_dims_;
+  void CheckSrcDims(const Workspace &ws);
 
  private:
   TensorListShape<> input_shape_, output_shape_;
@@ -63,8 +69,6 @@ class Reshape : public Operator<Backend> {
   int wildcard_dim_ = -1;
   DALIDataType output_type_id_ = DALI_NO_TYPE;
   const TypeInfo *output_type_ = nullptr;
-
-  void CalculateOutputShape(const Workspace &ws);
 
   template <typename TensorListLike>
   void ShapeFromInput(const TensorListLike &tl, bool relative);

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -44,18 +44,24 @@ class Reshape : public Operator<Backend> {
  
  protected:
   virtual void CalculateOutputShape(const Workspace &ws);
-  std::vector<int> src_dims_;
   void CheckSrcDims(const Workspace &ws);
+  
+  std::vector<int> src_dims_;
 
  private:
+  inline const std::string &OpName() const {
+    return this->spec_.name();
+  }
+
   TensorListShape<> input_shape_, output_shape_;
   TensorShape<> uniform_shape_;
   std::vector<float> rel_uniform_shape_;
   TensorLayout layout_;
   bool use_layout_ = false;
-  inline const std::string &OpName() const {
-    return this->spec_.name();
-  }
+  bool use_rel_shape_ = false;
+  int wildcard_dim_ = -1;
+  DALIDataType output_type_id_ = DALI_NO_TYPE;
+  const TypeInfo *output_type_ = nullptr;
 
   enum class ShapeSource {
     None,
@@ -63,12 +69,7 @@ class Reshape : public Operator<Backend> {
     Arg,
     ArgInput
   };
-
   ShapeSource shape_source_ = ShapeSource::None;
-  bool use_rel_shape_ = false;
-  int wildcard_dim_ = -1;
-  DALIDataType output_type_id_ = DALI_NO_TYPE;
-  const TypeInfo *output_type_ = nullptr;
 
   template <typename TensorListLike>
   void ShapeFromInput(const TensorListLike &tl, bool relative);


### PR DESCRIPTION
#### Why we need this PR?
- It adds new feature needed because of adding Squeeze and ExpandDims operators

#### What happened in this PR?
 - What solution was applied:
     - added src_dims argument to reshape
     - added protected member value to be able to fill it in derived class.
 - Affected modules and functionalities:
     - Reshape operator can take src_dims argument which tells which dimensions should be kept and in which order
 - Key points relevant for the review:
     NA
 - Validation and testing:
     - python notebook tests to check if src_dims works
     - update python tests TODO
 - Documentation (including examples):
     TODO


DALI-1913
