### PR TITLE
Update to CUDA 11.2 update 2

### DIFF
--- a/docker/Dockerfile.cuda112.aarch64.deps
+++ b/docker/Dockerfile.cuda112.aarch64.deps
@@ -4,7 +4,7 @@ FROM ${TOOLKIT_BASE_IMAGE} as cuda
 RUN apt update && apt install -y libxml2 curl perl gcc && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux_sbsa.run && \
+RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux_sbsa.run && \
     chmod +x cuda_*.run && \
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;

--- a/docker/Dockerfile.cuda112.x86_64.deps
+++ b/docker/Dockerfile.cuda112.x86_64.deps
@@ -3,7 +3,7 @@ FROM ${TOOLKIT_BASE_IMAGE} as cuda
 
 RUN apt update && apt install -y libxml2 curl perl gcc
 
-RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run && \
+RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run && \
     chmod +x cuda_*.run && \
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It updates to CUDA 11.2 update 2
- 
#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     update to CUDA 11.2 update 2
 - Affected modules and functionalities:
     Dockerfile.cuda112.aarch64.deps
     Dockerfile.cuda112.x86_64deps
 - Key points relevant for the review:
     NA
 - Validation and testing:
     present tests applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
