### PR TITLE
Use flattened view of the array for copying.

### DIFF
--- a/dali/python/nvidia/dali/_multiproc/shared_batch.py
+++ b/dali/python/nvidia/dali/_multiproc/shared_batch.py
@@ -244,7 +244,7 @@ class SharedBatchWriter:
         buffer = memview[offset:(offset + sample_size)]
         shared_array = np.ndarray(
             np_array.shape, dtype=np_array.dtype, buffer=buffer)
-        shared_array[:] = np_array[:]
+        shared_array.ravel()[:] = np_array.ravel()[:]
 
     def _write_batch(self, batch):
         if not batch:


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: parallel ExternalSource crashes on 0D data.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Use flattened view of the array for copying
 - Affected modules and functionalities:
     * shared_batch
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Yes
 - Documentation (including examples):
     * N/A


**JIRA TASK**: N/A
