### PR TITLE
Exclude PyTorch-lighting test with MNIST

### DIFF
--- a/qa/TL1_jupyter_plugins/test_pytorch.sh
+++ b/qa/TL1_jupyter_plugins/test_pytorch.sh
@@ -10,7 +10,7 @@ do_once() {
 
 test_body() {
   # dummy
-  exclude_files="#"
+  exclude_files="pytorch-lightning*\|#"
 
   # test code
   find frameworks/pytorch/ -name "*.ipynb" | sed "/${exclude_files}/d" | xargs -i jupyter nbconvert \


### PR DESCRIPTION
- excludes PyTorch-lighting test with MNIST that fails due to MNIST hosting page outage

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It excludes PyTorch-lighting test with MNIST and fixes TL1_jupyter_plugins

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     excludes PyTorch-lighting test with MNIST that fails due to MNIST hosting page outage
 - Affected modules and functionalities:
     TL1_jupyter_plugins
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
