### PR TITLE
Separate creation of dependency creation and CUDA installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ENV PYBIN=${PYTHONPATH}/bin \
     PYLIB=${PYTHONPATH}/lib
 
 # add llvm-toolset-7.0 for python clang bindings on aarch64 where libclang wheel is not available
-ENV PATH=/opt/python/cp36-cp36/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:/usr/local/cuda/bin:${PYBIN}:${PATH} \
+ENV PATH=/opt/python/cp36-cp36/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:${PYBIN}:${PATH} \
     LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:/opt/python/cp39-cp39/lib:${PYLIB}:${LD_LIBRARY_PATH} \
     LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:/opt/python/cp39-cp39/lib:${PYLIB}:${LIBRARY_PATH}
 

--- a/docker/Dockerfile.cuda.deps
+++ b/docker/Dockerfile.cuda.deps
@@ -1,0 +1,14 @@
+#########################################################################################
+## Get manylinux image with any neccessary DALI dependencies.
+## It is possible to just use defaults and have a pure manylinux2014 with CUDA on top
+## DALI is based on "manylinux2014", official page https://github.com/pypa/manylinux
+#########################################################################################
+ARG FROM_IMAGE_NAME=quay.io/pypa/manylinux2014_x86_64
+ARG CUDA_IMAGE
+FROM ${CUDA_IMAGE} as cuda
+FROM ${FROM_IMAGE_NAME}
+
+ENV PATH=/usr/local/cuda/bin:${PATH}
+
+# CUDA
+COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.cuda.deps
+++ b/docker/Dockerfile.cuda.deps
@@ -10,5 +10,7 @@ FROM ${FROM_IMAGE_NAME}
 
 ENV PATH=/usr/local/cuda/bin:${PATH}
 
+ENV NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
+
 # CUDA
 COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -1,12 +1,10 @@
 #########################################################################################
-##  Stage 1: build DALI dependencies
-##     DALI is based on "manylinux2014", official page https://github.com/pypa/manylinux
+##  Build DALI dependencies on top of manylinux2014
+##  DALI is based on "manylinux2014", official page https://github.com/pypa/manylinux
 #########################################################################################
 ARG FROM_IMAGE_NAME=quay.io/pypa/manylinux2014_x86_64
-ARG CUDA_IMAGE
 ARG BUILDER_EXTRA_DEPS=scratch
 FROM ${BUILDER_EXTRA_DEPS} as extra_deps
-FROM ${CUDA_IMAGE} as cuda
 FROM ${FROM_IMAGE_NAME}
 
 # Install yum Dependencies
@@ -242,9 +240,6 @@ RUN LIBSND_VERSION=1.0.28 && cd /tmp                                            
     ./configure && make -j"$(grep ^processor /proc/cpuinfo | wc -l)" && make install                           && \
     cd / && \
     rm -rf /tmp/libsndfile-$LIBSND_VERSION
-
-# CUDA
-COPY --from=cuda /usr/local/cuda /usr/local/cuda
 
 # extra deps
 COPY --from=extra_deps / /

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -144,8 +144,6 @@ RUN if [ "$(uname -m)" == "x86_64" ]; then \
         rm clang+llvm-*.tar.xz; \
     fi
 
-ENV NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
-
 # FFmpeg
 RUN FFMPEG_VERSION=4.3.1 && \
     cd /tmp && \


### PR DESCRIPTION
- separates build process of DALI dependencies in the manylinux image from the CUDA installation, so one can just easily create manylinux image with just CUDA without any DALI dependencies in between

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It separates creation of dependency creation and CUDA installation

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     separates build process of DALI dependencies in the manylinux image from the CUDA installation, so one can just easily create manylinux image with just CUDA without any DALI dependencies in between
 - Affected modules and functionalities:
     Dockerfile.cuda.deps
     Dockerfile.deps
     build.sh
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-1917]*
