### PR TITLE
Update nvJPEG2000 version to 0.2

### DIFF
--- a/docker/Dockerfile.cuda112.x86_64.deps
+++ b/docker/Dockerfile.cuda112.x86_64.deps
@@ -8,7 +8,7 @@ RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.2.2/local_ins
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;
 
-RUN NVJPEG2K_VERSION=0.1.0 && \
+RUN NVJPEG2K_VERSION=0.2.0 && \
     apt-get update && \
     apt-get install wget software-properties-common -y && \
     wget -qO - https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It updates nvJPEG2000 version to 0.2

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     update nvJPEG2000 version to 0.2
 - Affected modules and functionalities:
     Dockerfile.cuda112.x86_64.deps
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current tests applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
