### PR TITLE
Add src_dims to reshape operator

### DIFF
--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -425,8 +425,8 @@ void Reshape<Backend>::CheckSrcDims(const Workspace &ws) {
   for (size_t d = 0; d < src_dims_.size(); d++) {
     DALI_ENFORCE(-1 <= src_dims_[d] && src_dims_[d] < ndim,
       make_string(OpName(), ": ``src_dims[", d, "]`` == ", src_dims_[d], " is out of bounds.\n"
-      "The indices in ``src_dims`` should be either valid dimension indices in range [0..", ndim-1, "] "
-      "or -1 to insert a new dimension."));
+      "The indices in ``src_dims`` should be either valid dimension indices in "
+      "range [0..", ndim-1, "] or -1 to insert a new dimension."));
   }
 }
 

--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -63,7 +63,20 @@ If a value is not specified, if number of dimension matches existing layout, the
 layout is preserved. If the number of dimensions does not match, the argument is reset
 to empty. If a value is set, and is not empty, the layout must match the dimensionality
 of the output.)code",
-                  TensorLayout(""));
+                  TensorLayout(""))
+  .AddOptionalArg("src_dims", R"code(Indices of dimensions to keep.
+
+This argument can be used to manipulate the order of existing dimensions or to remove or
+add dimensions with extent one. A special index value -1 can be used to insert new dimensions
+at any particular position.
+
+For example, reshaping a sample with shape ``[300, 200, 1]`` and a ``src_dims``
+argument ``[-1, 1, 0]`` produces an output shape ``[1, 200, 300]``. A leading dimension with
+extent 1 is inserted at the beginning, followed by the first original dimensions but in reverse
+order. The last dimension is removed.
+
+All the indices should be in the range of valid dimensions of the input, or -1.)code",
+                  std::vector<int>(), true);
 
 DALI_SCHEMA(Reinterpret)
   .DocStr(R"(Treats content of the input as if it had a different type, shape, and/or layout.
@@ -89,13 +102,20 @@ Reshape<Backend>::Reshape(const OpSpec &spec) : Base(spec) {
   bool has_shape_arg = spec.HasArgument("shape") || spec.HasTensorArgument("shape");
   bool has_layout_arg = spec.HasArgument("layout");
   bool has_rel_shape_arg = spec.HasArgument("rel_shape") || spec.HasTensorArgument("rel_shape");
+  bool has_src_dims_arg = spec.HasArgument("src_dims");
+  bool has_axes_arg = spec.HasArgument("axes");
+  bool has_axis_names_arg = spec.HasArgument("axis_names");
+
+  if (has_src_dims_arg) {
+    src_dims_ = spec.GetRepeatedArgument<int>("src_dims");
+  }
   if (spec.HasArgument("dtype"))
     output_type_id_ = spec.GetArgument<DALIDataType>("dtype");
   DALI_ENFORCE(has_shape_input + has_shape_arg + has_rel_shape_arg <= 1, make_string(OpName(),
     ": shape input, `shape` argument and `rel_shape` argument are mutually exclusive"));
 
-  bool does_reshape = has_shape_input || has_shape_arg || has_rel_shape_arg || has_layout_arg;
-  if (!has_shape_input && !has_shape_arg && !has_rel_shape_arg && !has_layout_arg) {
+  if (!has_shape_input && !has_shape_arg && !has_rel_shape_arg && !has_layout_arg
+      && !has_src_dims_arg && !has_axes_arg && !has_axis_names_arg) {
     bool can_have_dtype = spec.GetSchema().HasArgument("dtype");
     if (can_have_dtype) {
       DALI_ENFORCE(output_type_id_ != DALI_NO_TYPE, make_string(OpName(),
@@ -164,11 +184,9 @@ Reshape<Backend>::Reshape(const OpSpec &spec) : Base(spec) {
 template <typename Backend>
 bool Reshape<Backend>::SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) {
   output_desc.resize(1);
+  SetOutputType(ws);
 
-  output_type_ = output_type_id_ != DALI_NO_TYPE
-      ? &TypeTable::GetTypeInfo(output_type_id_)
-      : &ws.template InputRef<Backend>(0).type();
-
+  CheckSrcDims(ws);
   CalculateOutputShape(ws);
   output_desc[0].type = *output_type_;
   output_desc[0].shape = output_shape_;
@@ -188,7 +206,7 @@ void Reshape<Backend>::ShapeFromInput(
     auto shape_tensor = shape[0];
     int N = shape_tensor.shape[0];
     DALI_ENFORCE(N == input_shape_.num_samples(), make_string(OpName(),
-      ": the new shape mush have same number of samples. Got ",
+      ": the new shape must have same number of samples. Got ",
       output_shape_.num_samples(), ", expected ", N));
     int dim = shape_tensor.shape[1];
     output_shape_.resize(N, dim);
@@ -202,7 +220,7 @@ void Reshape<Backend>::ShapeFromInput(
   } else {
     int N = shape.num_samples();
     DALI_ENFORCE(N == input_shape_.num_samples(),
-      make_string(OpName(), ": the new shape mush have same number of samples. Got ",
+      make_string(OpName(), ": the new shape must have same number of samples. Got ",
       output_shape_.num_samples(), ", expected ", N));
     int sample_dim;
     for (int i = 0; i < N; i++) {
@@ -247,10 +265,19 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
   switch (shape_source_) {
     case ShapeSource::Arg:
       if (use_rel_shape_) {
+        if (!src_dims_.empty()) {
+          DALI_ENFORCE(rel_uniform_shape_.size() == src_dims_.size(),
+            make_string(OpName(), ": ``src_dims`` and ``rel_shape`` should have the same"
+            " length when both of them are provided. Got ", src_dims_.size(), " and ",
+            rel_uniform_shape_.size(), " elements respectively"));
+        }
+
         output_shape_.resize(N, rel_uniform_shape_.size());
         for (int i = 0; i < N; i++) {
           for (int d = 0; d < output_shape_.sample_dim(); d++) {
-            int out_e = round_int(rel_uniform_shape_[d] * input_shape_.tensor_shape_span(i)[d]);
+            const int src_d = src_dims_.empty() ? d : src_dims_[d];
+            int out_e = round_int(rel_uniform_shape_[d] *
+              (src_d == -1 ? 1 : input_shape_.tensor_shape_span(i)[src_d]));
             output_shape_.tensor_shape_span(i)[d] = out_e;
           }
         }
@@ -270,7 +297,23 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
       ShapeFromInput(ws.template InputRef<CPUBackend>(1), false);
       break;
     case ShapeSource::None:
-      output_shape_ = input_shape_;
+      if (src_dims_.empty()) {
+        output_shape_ = input_shape_;
+        break;
+      }
+      output_shape_.resize(N, src_dims_.size());
+      for (int i = 0; i < N; i++) {
+        for (size_t d = 0; d < src_dims_.size(); d++) {
+          const int src_d = src_dims_[d];
+          output_shape_.tensor_shape_span(i)[d] =
+            src_d == -1 ? 1 : input_shape_.tensor_shape_span(i)[src_d];
+        }
+        DALI_ENFORCE(
+          output_shape_.tensor_size(i) == input_shape_.tensor_size(i),
+          make_string(OpName(), ": The volume of the new shape should match the"
+          " one of the original shape. Requested a shape with ", output_shape_.tensor_size(i),
+          " elements but the original shape has ", input_shape_.tensor_size(i), " elements."));
+      }
       break;
   }
 
@@ -368,6 +411,23 @@ void Reshape<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
     assert(out.raw_tensor(i) == in.raw_tensor(i));
   }
   out.SetLayout(layout);
+}
+
+template <typename Backend>
+void Reshape<Backend>::CheckSrcDims(const Workspace &ws) {
+  if (src_dims_.empty()) {
+    return;
+  }
+
+  const auto &in = ws.template InputRef<Backend>(0);
+  const auto &input_shape = in.shape();
+  const int ndim = input_shape.sample_dim();
+  for (size_t d = 0; d < src_dims_.size(); d++) {
+    DALI_ENFORCE(-1 <= src_dims_[d] && src_dims_[d] < ndim,
+      make_string(OpName(), ": Out of bounds ``src_dims`` index. The indices in ``src_dims``"
+      " should be either a valid dimension index (range 0..ndim-1) or -1 to insert a new dimension."
+      " Got: src_dims[", d, "]=", src_dims_[d], ", ndim=", ndim));
+  }
 }
 
 DALI_REGISTER_OPERATOR(Reshape, Reshape<CPUBackend>, CPU);

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -68,7 +68,10 @@ class Reshape : public Operator<Backend> {
   TensorLayout layout_;
   bool use_layout_ = false;
   bool use_rel_shape_ = false;
+<<<<<<< HEAD
   bool use_src_dims_ = false;
+=======
+>>>>>>> 32f9b2aa... src_dims arg added to reshape
   int wildcard_dim_ = -1;
   DALIDataType output_type_id_ = DALI_NO_TYPE;
 

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -46,7 +46,7 @@ class Reshape : public Operator<Backend> {
   virtual void CalculateOutputShape(const Workspace &ws);
 
   void CheckSrcDims(const Workspace &ws);
-  
+
   inline void SetOutputType(const Workspace &ws) {
     output_type_ = output_type_id_ != DALI_NO_TYPE
       ? &TypeTable::GetTypeInfo(output_type_id_)

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -68,10 +68,7 @@ class Reshape : public Operator<Backend> {
   TensorLayout layout_;
   bool use_layout_ = false;
   bool use_rel_shape_ = false;
-<<<<<<< HEAD
   bool use_src_dims_ = false;
-=======
->>>>>>> 32f9b2aa... src_dims arg added to reshape
   int wildcard_dim_ = -1;
   DALIDataType output_type_id_ = DALI_NO_TYPE;
 

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -44,7 +44,9 @@ class Reshape : public Operator<Backend> {
 
  protected:
   virtual void CalculateOutputShape(const Workspace &ws);
+
   void CheckSrcDims(const Workspace &ws);
+  
   inline void SetOutputType(const Workspace &ws) {
     output_type_ = output_type_id_ != DALI_NO_TYPE
       ? &TypeTable::GetTypeInfo(output_type_id_)

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -68,6 +68,7 @@ class Reshape : public Operator<Backend> {
   TensorLayout layout_;
   bool use_layout_ = false;
   bool use_rel_shape_ = false;
+  bool use_src_dims_ = false;
   int wildcard_dim_ = -1;
   DALIDataType output_type_id_ = DALI_NO_TYPE;
 

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from nvidia.dali.pipeline import Pipeline
+from nvidia.dali import pipeline_def
+import nvidia.dali.fn as fn
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
 import nvidia.dali as dali
@@ -20,11 +22,13 @@ from nvidia.dali.backend_impl import TensorListGPU
 import numpy as np
 import math
 from numpy.testing import assert_array_equal, assert_allclose
+from functools import partial
 import os
 import cv2
 from test_utils import check_batch
 from test_utils import compare_pipelines
 from test_utils import RandomDataIterator
+from nose.tools import assert_raises
 
 test_data_root = os.environ['DALI_EXTRA_PATH']
 caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
@@ -289,3 +293,46 @@ def _test_reinterpret_wildcard_shape(device):
 def test_reinterpret_wildcard_shape():
     for device in ["cpu", "gpu"]:
         yield _test_reinterpret_wildcard_shape, device
+
+def get_data(shapes):
+    return [np.empty(shape, dtype = np.uint8) for shape in shapes]
+
+@pipeline_def
+def reshape_pipe(shapes, src_dims=None, rel_shape=None):
+    data = fn.external_source(lambda: get_data(shapes), batch=True, device = "cpu")
+    return fn.reshape(data, src_dims=src_dims, rel_shape=rel_shape)
+
+def _testimpl_reshape_src_dims_arg(src_dims, rel_shape, shapes, expected_out_shapes):
+    batch_size = len(shapes)
+    pipe = reshape_pipe(batch_size=batch_size, num_threads=1, device_id=0, shapes=shapes, src_dims=src_dims, rel_shape=rel_shape)
+    pipe.build()
+    for _ in range(3):
+        outs = pipe.run()
+        for i in range(batch_size):
+            out_arr = np.array(outs[0][i])
+            assert out_arr.shape == expected_out_shapes[i]
+
+def test_reshape_src_dims_arg():
+    # src_dims, rel_shape, shapes, expected_out_shapes
+    args = [
+        ([0, 1], None, [[200, 300, 1], [300, 400, 1]], [(200, 300), (300, 400)]),
+        ([1, 2, 0], None, [[10, 20, 30], [30, 20, 10], [2, 1, 3]], [(20, 30, 10), (20, 10, 30), (1, 3, 2)]),
+        ([1], None, [[1, 2, 1], [1, 3, 1]], [(2,), (3,)]),
+        ([2, -1, 1, 0], None, [[10, 20, 30]], [(30, 1, 20, 10)]),
+        ([-1, 2], None, [[1, 1, 30], [1, 1, 70]], [(1, 30), (1, 70)]),
+        ([2, 0, 1], [0.5, 0.5, -1], [[200, 300, 100]], [(50, 100, 1200)]),
+    ]
+    for src_dims, rel_shape, shapes, expected_out_shapes in args:
+        yield _testimpl_reshape_src_dims_arg, src_dims, rel_shape, shapes, expected_out_shapes
+
+def test_reshape_src_dims_throw_error():
+    args = [
+        ([2, 0], None, [[20, 10, 20]]),
+        ([2, 0, 1], [1, -1], [[1, 2, 3]]),
+        ([0, 1, 3], None, [1, 2, 3]),
+    ]
+    for src_dims, rel_shape, shapes in args:
+        pipe = reshape_pipe(batch_size=len(shapes), num_threads=1, device_id=0, shapes=shapes, src_dims=src_dims, rel_shape=rel_shape)
+        pipe.build()
+        with assert_raises(RuntimeError):
+          pipe.run()

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -310,7 +310,6 @@ def _testimpl_reshape_src_dims_arg(src_dims, rel_shape, shapes, expected_out_sha
         outs = pipe.run()
         for i in range(batch_size):
             out_arr = np.array(outs[0][i])
-            print(out_arr.shape, expected_out_shapes[i])
             assert out_arr.shape == expected_out_shapes[i]
 
 def test_reshape_src_dims_arg():

--- a/dali/test/python/test_operator_reshape.py
+++ b/dali/test/python/test_operator_reshape.py
@@ -310,6 +310,7 @@ def _testimpl_reshape_src_dims_arg(src_dims, rel_shape, shapes, expected_out_sha
         outs = pipe.run()
         for i in range(batch_size):
             out_arr = np.array(outs[0][i])
+            print(out_arr.shape, expected_out_shapes[i])
             assert out_arr.shape == expected_out_shapes[i]
 
 def test_reshape_src_dims_arg():
@@ -321,6 +322,7 @@ def test_reshape_src_dims_arg():
         ([2, -1, 1, 0], None, [[10, 20, 30]], [(30, 1, 20, 10)]),
         ([-1, 2], None, [[1, 1, 30], [1, 1, 70]], [(1, 30), (1, 70)]),
         ([2, 0, 1], [0.5, 0.5, -1], [[200, 300, 100]], [(50, 100, 1200)]),
+        ([], None, [[1]], [()]),
     ]
     for src_dims, rel_shape, shapes, expected_out_shapes in args:
         yield _testimpl_reshape_src_dims_arg, src_dims, rel_shape, shapes, expected_out_shapes


### PR DESCRIPTION
Signed-off-by: Rafal Maj <rmaj@nvidia.com>

#### Why we need this PR?
- It adds new feature needed because of we want to add squeeze and expandsdim operators and src_dims will allow us to implement them.

#### What happened in this PR?
 - What solution was applied:
     - Added src_dims to reshape operator
 - Affected modules and functionalities:
     - Reshape operator allows to use src_dims to specify which dimensions and in which order should be kept
 - Key points relevant for the review:
     - Remove only dims with shape 1
     - New dims are added when -1 value provided
     - Shapes are reordered
 - Validation and testing:
     - Python tests
 - Documentation (including examples):
     - NA


Dali-1913
