### PR TITLE
Update TensorFlow ResNet50 example to the latest horovod 21.03

### DIFF
--- a/docs/examples/use_cases/tensorflow/resnet-n/nvutils/hvd_patch.py
+++ b/docs/examples/use_cases/tensorflow/resnet-n/nvutils/hvd_patch.py
@@ -1,4 +1,4 @@
-# This is a patch for Horovod 0.21.0 to work with our custom learning schedule
+# This is a patch for Horovod 0.21.3 to work with our custom learning schedule
 # used in CNN resnet50 scripts.
 
 from tensorflow import keras
@@ -17,7 +17,7 @@ def create_distributed_optimizer(
         keras, optimizer, name, device_dense, device_sparse, compression,
         sparse_as_dense, gradient_predivide_factor, op,
         backward_passes_per_step=1, average_aggregated_gradients=False,
-        num_groups=0):
+        groups=None):
   class _DistributedOptimizer(keras.optimizers.Optimizer):
     _HAS_AGGREGATE_GRAD = True
 
@@ -33,7 +33,7 @@ def create_distributed_optimizer(
           sparse_as_dense,
           op,
           gradient_predivide_factor,
-          num_groups)
+          groups)
 
       self._agg_helper = None
       if backward_passes_per_step > 1:
@@ -51,11 +51,34 @@ def create_distributed_optimizer(
               sparse_as_dense=sparse_as_dense,
               average_aggregated_gradients=average_aggregated_gradients,
               rank=rank(),
-              optimizer_type=\
-                  LocalGradientAggregationHelper._OPTIMIZER_TYPE_KERAS,
+              optimizer_type=(
+                  LocalGradientAggregationHelper._OPTIMIZER_TYPE_KERAS),
           )
 
       super(self.__class__, self).__init__(**kwargs)
+
+    def _compute_gradients(self, loss, var_list, grad_loss=None, tape=None):
+      """
+      Compute gradients of all trainable variables.
+      See Optimizer.get_gradients() for more info.
+      In DistributedOptimizer, get_gradients() is overriden to also
+      allreduce the gradients before returning them.
+      """
+      if _PRE_TF_2_4_0:
+        return super(self.__class__, self)._compute_gradients(
+            loss, var_list, grad_loss, tape)
+
+      tape = backprop.GradientTape() if tape is None else tape
+      grads_and_vars = super(self.__class__, self)._compute_gradients(
+          # pylint: disable=protected-access
+          loss,
+          var_list,
+          grad_loss,
+          tape=tape)
+      grads, weights = list(zip(*grads_and_vars))
+
+      allreduced_grads = self._allreduce(grads, weights)
+      return list(zip(allreduced_grads, weights))
 
     def get_gradients(self, loss, params):
       """
@@ -65,24 +88,24 @@ def create_distributed_optimizer(
       allreduce the gradients before returning them.
       """
       gradients = super(self.__class__, self).get_gradients(loss, params)
-      return self._allreduce(gradients)
+      return self._allreduce(gradients, params)
 
     def _aggregate_gradients(self, grads_and_vars):
-      grads, vars = list(zip(*grads_and_vars))
-      aggregated_grads = self._allreduce(grads)
       if _PRE_TF_2_4_0:
-        # Prior to TF 2.4.0, this function was expected to return only a list of
-        # grads, not a list of (grad, var) tuples.
+        grads, vars = list(zip(*grads_and_vars))
+        aggregated_grads = self._allreduce(grads, vars)
         return aggregated_grads
-      return list(zip(aggregated_grads, vars))
+      else:
+        return super(self.__class__, self)._aggregate_gradients(
+            grads_and_vars)
 
-    def _allreduce(self, grads):
+    def _allreduce(self, grads, vars):
       self._aggregated_gradients = True
 
       if self._agg_helper:
-        return self._agg_helper.compute_gradients(tuple(grads))
+        return self._agg_helper.compute_gradients(tuple(grads), tuple(vars))
       else:
-        return self._allreduce_grads(grads)
+        return self._allreduce_grads(grads, vars)
 
     def apply_gradients(self, *args, **kwargs):
       if self._agg_helper:
@@ -96,15 +119,15 @@ def create_distributed_optimizer(
           args = tuple(args)
 
         results = self._agg_helper.apply_gradients(
-          lambda: super(self.__class__, self).apply_gradients(*args, **kwargs),
-          self,
-          *args,
-          **kwargs,
+            lambda: super(self.__class__, self).apply_gradients(*args, **kwargs),
+            self,
+            *args,
+            **kwargs,
         )
       else:
         results = super(self.__class__, self).apply_gradients(*args, **kwargs)
 
-      if not self._aggregated_gradients:
+      if _PRE_TF_2_4_0 and not self._aggregated_gradients:
         raise Exception('`apply_gradients()` was called without a call to '
                         '`get_gradients()` or `_aggregate_gradients`. If '
                         'you\'re using TensorFlow 2.0, please specify '
@@ -112,10 +135,10 @@ def create_distributed_optimizer(
 
       return results
 
-  # We dynamically create a new class that inherits from the optimizer that was passed in.
-  # The goal is to override get_gradients() method with an allreduce implementation.
-  # This class will have the same name as the optimizer it's wrapping, so that the saved
-  # model could be easily restored without Horovod.
+  # We dynamically create a new class that inherits from the optimizer that was
+  # passed in. The goal is to override get_gradients() method with an allreduce
+  # implementation. This class will have the same name as the optimizer it's
+  # wrapping, so that the saved model could be easily restored without Horovod.
   cls = type(optimizer.__class__.__name__, (optimizer.__class__,),
              dict(_DistributedOptimizer.__dict__))
 
@@ -136,6 +159,43 @@ def DistributedOptimizer(optimizer, name=None,
                          op=Average,
                          backward_passes_per_step=1,
                          average_aggregated_gradients=False):
+  """
+  An optimizer that wraps another keras.optimizers.Optimizer, using an allreduce
+  to average gradient values before applying gradients to model weights.
+  Args:
+      optimizer: Optimizer to use for computing gradients and applying updates.
+      name: Optional name prefix for the operations created when applying
+            gradients. Defaults to "Distributed" followed by the provided
+            optimizer type.
+      device_dense: Device to be used for dense tensors. Uses GPU by default
+                    if Horovod was build with HOROVOD_GPU_OPERATIONS.
+      device_sparse: Device to be used for sparse tensors. Uses GPU by default
+                     if Horovod was build with HOROVOD_GPU_OPERATIONS.
+      compression: Compression algorithm used to reduce the amount of data
+                   sent and received by each worker node.  Defaults to not
+                   using compression.
+      sparse_as_dense: Treat all sparse gradients as dense tensors.  This can
+                       help improve performance and memory utilization if
+                       the original sparse gradient has high density.
+                       Defaults to false.
+      gradient_predivide_factor: gradient_predivide_factor splits the averaging
+                                 before and after the sum. Gradients are scaled
+                                 by 1.0 / gradient_predivide_factor before the
+                                 sum and gradient_predivide_factor / size after
+                                 the sum.
+      op: The reduction operation to use when combining gradients across
+          different ranks. Defaults to Average.
+      backward_passes_per_step: Number of backward passes to perform before
+                                calling hvd.allreduce. This allows accumulating
+                                updates over multiple mini-batches before
+                                reducing and applying them.
+      average_aggregated_gradients: Whether to average the aggregated gradients
+                                    that have been accumulated over multiple
+                                    mini-batches. If true divides gradient
+                                    updates by backward_passes_per_step.
+                                    Only applicable for backward_passes_per_step
+                                    > 1.
+  """
   if gradient_predivide_factor != 1.0 and rocm_built():
     raise ValueError('gradient_predivide_factor not supported yet with ROCm')
 

--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -60,7 +60,7 @@ do_once() {
     export HOROVOD_NCCL_LIB=/usr/lib/x86_64-linux-gnu
     export HOROVOD_NCCL_LINK=SHARED
     export HOROVOD_WITHOUT_PYTORCH=1
-    pip install horovod==0.21.0
+    pip install horovod==0.21.3
 
     for file in $(ls /data/imagenet/train-val-tfrecord-480-subset);
     do


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It updates TensorFlow ResNet50 example to the latest horovod 21.03

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     update TensorFlow ResNet50 example to the latest horovod 21.03
 - Affected modules and functionalities:
     TL1_tensorflow-dali_test
     hvd_patch.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
