### PR TITLE
[WIP] Revert "Exclude PyTorch-lighting test with MNIST (#2785)"

### DIFF
--- a/qa/TL1_jupyter_plugins/test_pytorch.sh
+++ b/qa/TL1_jupyter_plugins/test_pytorch.sh
@@ -10,7 +10,7 @@ do_once() {
 
 test_body() {
   # dummy
-  exclude_files="pytorch-lightning*\|#"
+  exclude_files="#"
 
   # test code
   find frameworks/pytorch/ -name "*.ipynb" | sed "/${exclude_files}/d" | xargs -i jupyter nbconvert \


### PR DESCRIPTION
- This reverts commit 5e7a79aafe5174da47c49e708e9b9e443b0a2471.
- MNIST download page is online again so restore the original PyTorch-lighting MNIST example test

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It reverts commit 5e7a79aafe5174da47c49e708e9b9e443b0a2471.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     MNIST download page is online again so restore the original PyTorch-lighting MNIST example test
 - Affected modules and functionalities:
     TL1_jupyter_plugins
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
