### PR TITLE
Remove intermediate stage from CUDA toolkit dockerfile

### DIFF
--- a/docker/Dockerfile.cuda100.x86_64.deps
+++ b/docker/Dockerfile.cuda100.x86_64.deps
@@ -24,6 +24,3 @@ RUN CUDA_VERSION=10.0 && \
     mv /usr/local/cuda/include /usr/local/cuda/targets/x86_64-linux && \
     ln -s targets/x86_64-linux/lib /usr/local/cuda/lib64 && \
     ln -s targets/x86_64-linux/include /usr/local/cuda/include
-
-FROM scratch
-COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.cuda110.aarch64.deps
+++ b/docker/Dockerfile.cuda110.aarch64.deps
@@ -8,6 +8,3 @@ RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.0.3/local_ins
     chmod +x cuda_*.run && \
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;
-
-FROM scratch
-COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.cuda110.x86_64.deps
+++ b/docker/Dockerfile.cuda110.x86_64.deps
@@ -20,6 +20,3 @@ RUN NVJPEG2K_VERSION=0.1.0 && \
     cp /usr/include/nvjpeg2k* /usr/local/cuda/include/ && \
     cp /usr/lib/x86_64-linux-gnu/libnvjpeg2k* /usr/local/cuda/lib64/ && \
     rm -rf /var/lib/apt/lists/*
-
-FROM scratch
-COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.cuda111.aarch64.deps
+++ b/docker/Dockerfile.cuda111.aarch64.deps
@@ -8,6 +8,3 @@ RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.1.1/local_ins
     chmod +x cuda_*.run && \
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;
-
-FROM scratch
-COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.cuda111.x86_64.deps
+++ b/docker/Dockerfile.cuda111.x86_64.deps
@@ -20,6 +20,3 @@ RUN NVJPEG2K_VERSION=0.1.0 && \
     cp /usr/include/nvjpeg2k* /usr/local/cuda/include/ && \
     cp /usr/lib/x86_64-linux-gnu/libnvjpeg2k* /usr/local/cuda/lib64/ && \
     rm -rf /var/lib/apt/lists/*
-
-FROM scratch
-COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.cuda112.aarch64.deps
+++ b/docker/Dockerfile.cuda112.aarch64.deps
@@ -8,6 +8,3 @@ RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.2.2/local_ins
     chmod +x cuda_*.run && \
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
     rm -f cuda_*.run;
-
-FROM scratch
-COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.cuda112.x86_64.deps
+++ b/docker/Dockerfile.cuda112.x86_64.deps
@@ -19,6 +19,3 @@ RUN NVJPEG2K_VERSION=0.2.0 && \
     cp /usr/include/nvjpeg2k* /usr/local/cuda/include/ && \
     cp /usr/lib/x86_64-linux-gnu/libnvjpeg2k* /usr/local/cuda/lib64/ && \
     rm -rf /var/lib/apt/lists/*
-
-FROM scratch
-COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.cuda90.x86_64.deps
+++ b/docker/Dockerfile.cuda90.x86_64.deps
@@ -18,6 +18,3 @@ RUN CUDA_VERSION=9.0 && \
     mv lib64/libnvjpeg*.a* /usr/local/cuda/lib64/ && \
     mv include/nvjpeg.h /usr/local/cuda/include/ && \
     rm -rf /cuda-linux64-nvjpeg;
-
-FROM scratch
-COPY --from=cuda /usr/local/cuda /usr/local/cuda


### PR DESCRIPTION
- despite the fact, the multistage CUDA toolkit image is lighter it is always rebuilt as the intermediate stage is not preserved as the artifact. This PR removes the intermediate stage to make the build fully cachable

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes the intermediate stage to make the build fully cachable

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     despite the fact, the multistage CUDA toolkit image is lighter it is always rebuilt as the intermediate stage is not preserved as the artifact. This PR removes the intermediate stage to make the build fully cachable
 - Affected modules and functionalities:
     Dockerfile.cudaXX.arch.deps
 - Key points relevant for the review:
     NA
 - Validation and testing:
     full deps rebuild
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
