### PR TITLE
Add an ability to provide a custom DALI_extra sha via env variable

### DIFF
--- a/qa/setup_dali_extra.sh
+++ b/qa/setup_dali_extra.sh
@@ -6,7 +6,7 @@ export DALI_EXTRA_URL=${DALI_EXTRA_URL:-"https://github.com/NVIDIA/DALI_extra.gi
 
 DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 DALI_EXTRA_VERSION_PATH="${DIR}/../DALI_EXTRA_VERSION"
-read -r DALI_EXTRA_VERSION < ${DALI_EXTRA_VERSION_PATH}
+DALI_EXTRA_VERSION=${DALI_EXTRA_VERSION_SHA:-$(cat ${DALI_EXTRA_VERSION_PATH})}
 echo "Using DALI_EXTRA_VERSION = ${DALI_EXTRA_VERSION}"
 if [ ! -d "$DALI_EXTRA_PATH" ] ; then
     git clone "$DALI_EXTRA_URL" "$DALI_EXTRA_PATH"


### PR DESCRIPTION
- allows overwriting DALI_EXTRA_VERSION value using DALI_EXTRA_VERSION_SHA
  environment variable

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds an ability to provide a custom DALI_extra sha via env variable

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     allows overwriting DALI_EXTRA_VERSION value using DALI_EXTRA_VERSION_SHA environment variable
 - Affected modules and functionalities:
     setup_dali_extra.sh
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI run
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
