### PR TITLE
Fix optical flow parameter initialization.

### DIFF
--- a/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.cc
+++ b/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.cc
@@ -152,6 +152,7 @@ void OpticalFlowTuring::CalcOpticalFlow(
 
 
 void OpticalFlowTuring::SetInitParams(dali::optical_flow::OpticalFlowParams api_params) {
+  init_params_ = {};
   init_params_.width = static_cast<uint32_t>(width_);
   init_params_.height = static_cast<uint32_t>(height_);
 
@@ -178,6 +179,7 @@ void OpticalFlowTuring::SetInitParams(dali::optical_flow::OpticalFlowParams api_
   init_params_.enableExternalHints = of_params_.enable_external_hints ? NV_OF_TRUE : NV_OF_FALSE;
   init_params_.enableOutputCost = NV_OF_FALSE;
   init_params_.hPrivData = NULL;
+  init_params_.disparityRange = NV_OF_STEREO_DISPARITY_RANGE_UNDEFINED;
 }
 
 

--- a/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.h
+++ b/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.h
@@ -148,16 +148,18 @@ class DLL_PUBLIC OpticalFlowTuring : public OpticalFlowAdapter<ComputeGPU> {
 
   const std::string kInitSymbol = "NvOFAPICreateInstanceCuda";
 
-  const size_t width_, height_, channels_;
-  int device_id_;
-  CUcontext context_;
-  cudaStream_t stream_;
-  NvOFHandle of_handle_;
-  NV_OF_CUDA_API_FUNCTION_LIST turing_of_;
-  NV_OF_INIT_PARAMS init_params_;
+  size_t width_                 = 0;
+  size_t height_                = 0;
+  size_t channels_              = 3;
+  int device_id_                = -1;
+  CUcontext context_            = nullptr;
+  cudaStream_t stream_          = 0;
+  NvOFHandle of_handle_         = nullptr;
+  NV_OF_CUDA_API_FUNCTION_LIST turing_of_ = {};
+  NV_OF_INIT_PARAMS init_params_ = {};
   std::unique_ptr<OpticalFlowBuffer> inbuf_, refbuf_, outbuf_, hintsbuf_;
-  DALIImageType image_type_;
-  ofDriverHandle lib_handle_;
+  DALIImageType image_type_     = DALI_RGB;
+  ofDriverHandle lib_handle_    = nullptr;
 };
 
 }  // namespace optical_flow


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: NVOF init returns INVALID_PARAM #2815

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * default-initialize the param structure
     * provide disparityRange parameter
 - Affected modules and functionalities:
     * Optical flow
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests apply
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-1936
