### PR TITLE
Fix typo "funcions" <- "funcions" in math doc

### DIFF
--- a/docs/math.rst
+++ b/docs/math.rst
@@ -102,7 +102,7 @@ Currently, DALI supports the following operations:
     :rtype: TensorList of the type that is calculated based on the type promotion rules.
 
 
-Mathematical Funcions
+Mathematical Functions
 ---------------------
 
 Similarly to arithmetic expressions, one can use selected mathematical functions in the Pipeline


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a typo "funcions" <- "funcions" in math doc
- 
#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     fixes a typo "funcions" <- "funcions" in math doc
 - Affected modules and functionalities:
     math.rst
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     math documentation was updated


**JIRA TASK**: *[NA]*
