### PR TITLE
Add JpegCompressionDistortion CPU and GPU operators

### DIFF
--- a/dali/operators/image/distortion/CMakeLists.txt
+++ b/dali/operators/image/distortion/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,19 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Get all the source files and dump test files
-
-add_subdirectory(color)
-add_subdirectory(crop)
-
-add_subdirectory(convolution)
-add_subdirectory(distortion)
-add_subdirectory(resize)
-add_subdirectory(paste)
-add_subdirectory(remap)
-add_subdirectory(peek_shape)
-add_subdirectory(mask)
 
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)

--- a/dali/operators/image/distortion/jpeg_compression_distortion_op.h
+++ b/dali/operators/image/distortion/jpeg_compression_distortion_op.h
@@ -27,11 +27,6 @@ namespace dali {
 
 template <typename Backend>
 class JpegCompressionDistortion : public Operator<Backend> {
- public:
-  ~JpegCompressionDistortion() override = default;
-
-  DISABLE_COPY_MOVE_ASSIGN(JpegCompressionDistortion);
-
  protected:
   explicit JpegCompressionDistortion(const OpSpec &spec)
       : Operator<Backend>(spec),
@@ -46,7 +41,7 @@ class JpegCompressionDistortion : public Operator<Backend> {
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
     const auto &input = ws.template InputRef<Backend>(0);
     output_desc.resize(1);
-    auto in_sh = input.shape();
+    const auto &in_sh = input.shape();
     assert(in_sh.sample_dim() == 3);  // should be check by the layout
     for (int s = 0; s < in_sh.num_samples(); s++) {
       DALI_ENFORCE(in_sh.tensor_shape_span(s)[2] == 3,

--- a/dali/operators/image/distortion/jpeg_compression_distortion_op.h
+++ b/dali/operators/image/distortion/jpeg_compression_distortion_op.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_IMAGE_DISTORTION_JPEG_COMPRESSION_DISTORTION_OP_H_
+#define DALI_OPERATORS_IMAGE_DISTORTION_JPEG_COMPRESSION_DISTORTION_OP_H_
+
+#include <string>
+#include <vector>
+#include "dali/pipeline/operator/arg_helper.h"
+#include "dali/pipeline/data/views.h"
+#include "dali/pipeline/operator/common.h"
+#include "dali/pipeline/operator/operator.h"
+#include "dali/core/format.h"
+
+namespace dali {
+
+template <typename Backend>
+class JpegCompressionDistortion : public Operator<Backend> {
+ public:
+  ~JpegCompressionDistortion() override = default;
+
+  DISABLE_COPY_MOVE_ASSIGN(JpegCompressionDistortion);
+
+ protected:
+  explicit JpegCompressionDistortion(const OpSpec &spec)
+      : Operator<Backend>(spec),
+        spec_(spec),
+        quality_arg_("quality", spec) {
+  }
+
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    const auto &input = ws.template InputRef<Backend>(0);
+    output_desc.resize(1);
+    auto in_sh = input.shape();
+    assert(in_sh.sample_dim() == 3);  // should be check by the layout
+    for (int s = 0; s < in_sh.num_samples(); s++) {
+      DALI_ENFORCE(in_sh.tensor_shape_span(s)[2] == 3,
+        make_string("Expected RGB samples with HWC layout, got shape: ", in_sh[s]));
+    }
+
+    output_desc[0] = {in_sh, input.type()};
+    quality_arg_.Acquire(spec_, ws, in_sh.num_samples(), TensorShape<0>{});
+    return true;
+  }
+
+  OpSpec spec_;
+  ArgValue<int> quality_arg_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_IMAGE_DISTORTION_JPEG_COMPRESSION_DISTORTION_OP_H_

--- a/dali/operators/image/distortion/jpeg_compression_distortion_op_cpu.cc
+++ b/dali/operators/image/distortion/jpeg_compression_distortion_op_cpu.cc
@@ -1,0 +1,83 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include <opencv2/opencv.hpp>
+#include "dali/operators/image/distortion/jpeg_compression_distortion_op.h"
+
+namespace dali {
+
+DALI_SCHEMA(JpegCompressionDistortion)
+    .DocStr(R"code(Produces JPEG-like distortion in RGB images.
+
+The level of degradation of the image can be controlled with the ``quality`` argument,
+)code")
+    .NumInput(1)
+    .InputLayout(0, "HWC")
+    .NumOutput(1)
+    .AddOptionalArg("quality",
+        R"code(JPEG compression quality from 1 (lowest quality) to 99 (highest quality).
+
+Any values outside the range 1-99 will be clamped.)code",
+                    95, true);
+
+class JpegCompressionDistortionCPU : public JpegCompressionDistortion<CPUBackend> {
+ public:
+  explicit JpegCompressionDistortionCPU(const OpSpec &spec) : JpegCompressionDistortion(spec) {}
+
+  using Operator<CPUBackend>::RunImpl;
+  ~JpegCompressionDistortionCPU() override = default;
+  DISABLE_COPY_MOVE_ASSIGN(JpegCompressionDistortionCPU);
+
+ protected:
+  void RunImpl(workspace_t<CPUBackend> &ws) override;
+
+ private:
+  struct ThreadCtx {
+    std::vector<uint8_t> encoded;
+    cv::Mat tmp;
+  };
+  std::vector<ThreadCtx> thread_ctx_;
+};
+
+void JpegCompressionDistortionCPU::RunImpl(workspace_t<CPUBackend> &ws) {
+  const auto &input = ws.InputRef<CPUBackend>(0);
+  auto &output = ws.OutputRef<CPUBackend>(0);
+  auto in_shape = input.shape();
+  int nsamples = input.size();
+  auto& thread_pool = ws.GetThreadPool();
+  auto in_view = view<const uint8_t>(input);
+  auto out_view = view<uint8_t>(output);
+
+  thread_ctx_.resize(thread_pool.NumThreads());
+
+  for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
+    thread_pool.AddWork(
+      [&, sample_idx, quality = quality_arg_[sample_idx].data[0]](int thread_id) {
+        auto &ctx = thread_ctx_[thread_id];
+        auto sh = in_shape.tensor_shape_span(sample_idx);
+        cv::Mat in_mat(sh[0], sh[1], CV_8UC3, (void*) in_view[sample_idx].data);  // NOLINT
+        cv::Mat out_mat(sh[0], sh[1], CV_8UC3, (void*) out_view[sample_idx].data);  // NOLINT
+        cv::cvtColor(in_mat, ctx.tmp, cv::COLOR_RGB2BGR);
+        cv::imencode(".jpg", ctx.tmp, ctx.encoded, {cv::IMWRITE_JPEG_QUALITY, quality});
+        cv::imdecode(ctx.encoded, cv::IMREAD_COLOR, &ctx.tmp);
+        cv::cvtColor(ctx.tmp, out_mat, cv::COLOR_BGR2RGB);
+      }, in_shape.tensor_size(sample_idx));
+  }
+  thread_pool.RunAll();
+}
+
+DALI_REGISTER_OPERATOR(JpegCompressionDistortion, JpegCompressionDistortionCPU, CPU);
+
+}  // namespace dali

--- a/dali/operators/image/distortion/jpeg_compression_distortion_op_cpu.cc
+++ b/dali/operators/image/distortion/jpeg_compression_distortion_op_cpu.cc
@@ -27,9 +27,9 @@ The level of degradation of the image can be controlled with the ``quality`` arg
     .InputLayout(0, "HWC")
     .NumOutput(1)
     .AddOptionalArg("quality",
-        R"code(JPEG compression quality from 1 (lowest quality) to 99 (highest quality).
+        R"code(JPEG compression quality from 1 (lowest quality) to 100 (highest quality).
 
-Any values outside the range 1-99 will be clamped.)code",
+Any values outside the range 1-100 will be clamped.)code",
                     95, true);
 
 class JpegCompressionDistortionCPU : public JpegCompressionDistortion<CPUBackend> {

--- a/dali/operators/image/distortion/jpeg_compression_distortion_op_cpu.cc
+++ b/dali/operators/image/distortion/jpeg_compression_distortion_op_cpu.cc
@@ -39,7 +39,7 @@ mimics JPEG compression with given ``quality`` factor followed by decompression.
         R"code(JPEG compression quality from 1 (lowest quality) to 100 (highest quality).
 
 Any values outside the range 1-100 will be clamped.)code",
-                    95, true);
+                    50, true);
 
 class JpegCompressionDistortionCPU : public JpegCompressionDistortion<CPUBackend> {
  public:

--- a/dali/operators/image/distortion/jpeg_compression_distortion_op_gpu.cu
+++ b/dali/operators/image/distortion/jpeg_compression_distortion_op_gpu.cu
@@ -28,8 +28,6 @@ class JpegCompressionDistortionGPU : public JpegCompressionDistortion<GPUBackend
   }
 
   using Operator<GPUBackend>::RunImpl;
-  ~JpegCompressionDistortionGPU() override = default;
-  DISABLE_COPY_MOVE_ASSIGN(JpegCompressionDistortionGPU);
 
  protected:
   void RunImpl(workspace_t<GPUBackend> &ws) override;

--- a/dali/operators/image/distortion/jpeg_compression_distortion_op_gpu.cu
+++ b/dali/operators/image/distortion/jpeg_compression_distortion_op_gpu.cu
@@ -1,0 +1,73 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include "dali/operators/image/distortion/jpeg_compression_distortion_op.h"
+#include "dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.h"
+#include "dali/kernels/kernel_manager.h"
+
+namespace dali {
+
+class JpegCompressionDistortionGPU : public JpegCompressionDistortion<GPUBackend> {
+ public:
+  explicit JpegCompressionDistortionGPU(const OpSpec &spec)
+    : JpegCompressionDistortion(spec) {
+      kmgr_.Initialize<JpegDistortionKernel>();
+      kmgr_.Resize<JpegDistortionKernel>(1, 1);
+  }
+
+  using Operator<GPUBackend>::RunImpl;
+  ~JpegCompressionDistortionGPU() override = default;
+  DISABLE_COPY_MOVE_ASSIGN(JpegCompressionDistortionGPU);
+
+ protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc,
+                 const workspace_t<GPUBackend> &ws) override;
+  void RunImpl(workspace_t<GPUBackend> &ws) override;
+
+ private:
+  using JpegDistortionKernel = kernels::jpeg::JpegCompressionDistortionGPU<true, true>;
+  kernels::KernelManager kmgr_;
+  std::vector<int> quality_;
+};
+
+bool JpegCompressionDistortionGPU::SetupImpl(std::vector<OutputDesc> &output_desc,
+                                             const workspace_t<GPUBackend> &ws) {
+  const auto &input = ws.InputRef<GPUBackend>(0);
+  auto in_view = view<const uint8_t, 3>(input);
+  kernels::KernelContext ctx;
+  auto req = kmgr_.Setup<JpegDistortionKernel>(0, ctx, in_view.shape);
+  output_desc = {{req.output_shapes[0], input.type()}};
+  return true;
+}
+
+void JpegCompressionDistortionGPU::RunImpl(workspace_t<GPUBackend> &ws) {
+  const auto &input = ws.InputRef<GPUBackend>(0);
+  auto &output = ws.OutputRef<GPUBackend>(0);
+  auto in_view = view<const uint8_t, 3>(input);
+  auto out_view = view<uint8_t, 3>(output);
+  int nsamples = in_view.shape.size();
+
+  quality_.resize(nsamples);
+  for (int i = 0; i < nsamples; i++) {
+    quality_[i] = quality_arg_[i].data[0];
+  }
+  kernels::KernelContext ctx;
+  ctx.gpu.stream = ws.stream();
+  kmgr_.Run<JpegDistortionKernel>(0, 0, ctx, out_view, in_view, make_cspan(quality_));
+}
+
+DALI_REGISTER_OPERATOR(JpegCompressionDistortion, JpegCompressionDistortionGPU, GPU);
+
+}  // namespace dali

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -171,6 +171,9 @@ def test_crop_mirror_normalize_cpu():
 def test_flip_cpu():
     check_single_input(fn.flip, horizontal = True)
 
+def test_jpeg_compression_distortion_cpu():
+    check_single_input(fn.jpeg_compression_distortion, quality = 10)
+
 def test_image_decoder_crop_device():
     pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=None)
     input, _ = fn.readers.file(file_root=images_dir, shard_id=0, num_shards=1)

--- a/dali/test/python/test_dali_variable_batch_size.py
+++ b/dali/test/python/test_dali_variable_batch_size.py
@@ -683,6 +683,15 @@ def test_python_function():
 
     check_pipeline(generate_data(31, 13, image_like_shape_generator), pipe, devices=['cpu'])
 
+def test_jpeg_compression_distortion():
+    def pipe(max_batch_size, input_data, device):
+        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        with pipe:
+            data = fn.external_source(source=input_data, cycle=False, device=device)
+            out = fn.jpeg_compression_distortion(data)
+            pipe.set_outputs(out)
+        return pipe
+    check_pipeline(generate_data(31, 13, image_like_shape_generator), pipe, devices=['cpu'])
 
 def test_reinterpret():
     def pipe(max_batch_size, input_data, device, input_layout):

--- a/dali/test/python/test_dali_variable_batch_size.py
+++ b/dali/test/python/test_dali_variable_batch_size.py
@@ -222,6 +222,7 @@ ops_image_default_args = [
     fn.dump_image,
     fn.hsv,
     fn.hue,
+    fn.jpeg_compression_distortion,
     fn.old_color_twist,
     fn.reductions.mean,
     fn.reductions.mean_square,
@@ -681,16 +682,6 @@ def test_python_function():
             pipe.set_outputs(processed)
         return pipe
 
-    check_pipeline(generate_data(31, 13, image_like_shape_generator), pipe, devices=['cpu'])
-
-def test_jpeg_compression_distortion():
-    def pipe(max_batch_size, input_data, device):
-        pipe = Pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
-        with pipe:
-            data = fn.external_source(source=input_data, cycle=False, device=device)
-            out = fn.jpeg_compression_distortion(data)
-            pipe.set_outputs(out)
-        return pipe
     check_pipeline(generate_data(31, 13, image_like_shape_generator), pipe, devices=['cpu'])
 
 def test_reinterpret():

--- a/dali/test/python/test_operator_jpeg_compression_distortion.py
+++ b/dali/test/python/test_operator_jpeg_compression_distortion.py
@@ -66,5 +66,5 @@ def _testimpl_jpeg_compression_distortion(batch_size, device, quality):
 def test_jpeg_compression_distortion():
   for batch_size in [1, 15]:
     for device in ['cpu', 'gpu']:
-      for quality in [2, None, 95]:
+      for quality in [2, None, 50]:
         yield _testimpl_jpeg_compression_distortion, batch_size, device, quality

--- a/dali/test/python/test_operator_jpeg_compression_distortion.py
+++ b/dali/test/python/test_operator_jpeg_compression_distortion.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali import pipeline, pipeline_def
+import nvidia.dali.fn as fn
+import nvidia.dali.types as types
+import nvidia.dali as dali
+import numpy as np
+from numpy.testing import assert_array_equal, assert_allclose
+import os
+import cv2
+
+test_data_root = os.environ['DALI_EXTRA_PATH']
+images_dir = os.path.join(test_data_root, 'db', 'single', 'tiff')
+dump_images = False
+
+def _testimpl_jpeg_compression_distortion(batch_size, device, quality):
+  @pipeline_def()
+  def jpeg_distortion_pipe(device='cpu', quality=None):
+    encoded, _ = fn.readers.file(file_root=images_dir)
+    in_images = fn.decoders.image(encoded, device='cpu')
+    if quality is None:
+      quality = fn.random.uniform(range=[1, 99], dtype=types.INT32)
+    images = in_images.gpu() if device == 'gpu' else in_images
+    out_images = fn.jpeg_compression_distortion(images, quality=quality)
+    return out_images, in_images, quality
+
+  pipe = jpeg_distortion_pipe(device=device, quality=quality,
+                              batch_size=batch_size, num_threads=2, device_id=0)
+  pipe.build()
+  for _ in range(3):
+    out = pipe.run()
+    out_images = out[0].as_cpu() if device == 'gpu' else out[0]
+    in_images = out[1]
+    quality = out[2]
+    for i in range(batch_size):
+      out_img = np.array(out_images[i])
+      in_img = np.array(in_images[i])
+      q = int(np.array(quality[i]))
+
+      bgr = cv2.cvtColor(in_img, cv2.COLOR_RGB2BGR)
+      encode_params = [int(cv2.IMWRITE_JPEG_QUALITY), q]
+      _, encoded_img = cv2.imencode('.jpg', bgr, params=encode_params)
+
+      decoded_img_bgr = cv2.imdecode(encoded_img, cv2.IMREAD_COLOR)
+      decoded_img = cv2.cvtColor(decoded_img_bgr, cv2.COLOR_BGR2RGB)
+
+      if dump_images:
+        cv2.imwrite(f"./reference_q{q}_sample{i}.bmp", cv2.cvtColor(decoded_img, cv2.COLOR_BGR2RGB))
+        cv2.imwrite(f"./output_q{q}_sample{i}.bmp", cv2.cvtColor(out_img, cv2.COLOR_BGR2RGB))
+
+      diff = cv2.absdiff(out_img, decoded_img)
+      assert np.average(diff) < 5, f"Absolute difference with the reference is too big: {np.average(diff)}"
+
+def test_jpeg_compression_distortion():
+  for batch_size in [1, 15]:
+    for device in ['cpu', 'gpu']:
+      for quality in [2, None, 95]:
+        yield _testimpl_jpeg_compression_distortion, batch_size, device, quality


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a new operator needed to generate JPEG-like distortion

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a JpegCompressionDistortion operator, both GPU and CPU implementations.*
     *The CPU version uses OpenCV imencode/imdecode*
     *The GPU version uses a custom CUDA kernel*
 - Affected modules and functionalities:
     *New operator*
 - Key points relevant for the review:
     *All*
 - Validation and testing:
     *Python tests added*
 - Documentation (including examples):
     *Docstr*


**JIRA TASK**: *[DALI-1932]* *[DALI-1941]*
