### PR TITLE
Fix race condition in NemoAsrReader when pad_last_batch is set to True

### DIFF
--- a/dali/operators/decoder/audio/audio_decoder_impl.cc
+++ b/dali/operators/decoder/audio/audio_decoder_impl.cc
@@ -65,7 +65,9 @@ void DecodeAudio(TensorView<StorageCPU, T, DynamicDimensions> audio, AudioDecode
     assert(meta.channels == (audio.shape.size() == 1 ? 1 : audio.shape[1]) &&
            "Number of channels should match the metadata.");
     int64_t ret = decoder.DecodeFrames(audio.data, audio.shape[0]);
-    DALI_ENFORCE(ret == audio.shape[0], make_string("Error decoding audio file ", audio_filepath));
+    DALI_ENFORCE(ret == audio.shape[0],
+      make_string("Error decoding audio file ", audio_filepath, ". Requested ",
+                  audio.shape[0], " samples but got ", ret, " samples."));
     return;
   }
 

--- a/dali/operators/reader/nemo_asr_reader_op.h
+++ b/dali/operators/reader/nemo_asr_reader_op.h
@@ -50,6 +50,8 @@ class NemoAsrReader : public DataReader<CPUBackend, AsrSample> {
   // prefetch_depth * batch_size set of buffers that we reuse to decode audio
   using TensorVectorPtr = std::unique_ptr<TensorVector<CPUBackend>>;
   std::vector<TensorVectorPtr> prefetched_decoded_audio_;
+
+  std::unordered_map<void*, int> decoded_map_;
 };
 
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in NemoAsrReader, when pad_last_batch option is set to True

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Detect repeated samples and only decode once*
 - Affected modules and functionalities:
     *readers.nemo_asr*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *Test added*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-1942]*
