### PR TITLE
Add JpegCompressionDistortionGPU kernel

### DIFF
--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_impl.cuh
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_impl.cuh
@@ -180,8 +180,6 @@ __global__ void ChromaSubsampleDistortion(const SampleDesc *samples,
 }
 
 __device__ __inline__ float quantize(float value, float Q_coeff) {
-  if (Q_coeff < 1)
-    Q_coeff = 1;
   return Q_coeff * roundf(value * __frcp_rn(Q_coeff));
 }
 

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_impl.cuh
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_impl.cuh
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_KERNELS_IMGPROC_JPEG_JPEG_ARTIFACTS_GPU_H_
-#define DALI_KERNELS_IMGPROC_JPEG_JPEG_ARTIFACTS_GPU_H_
+#ifndef DALI_KERNELS_IMGPROC_JPEG_JPEG_DISTORTION_GPU_IMPL_CUH_
+#define DALI_KERNELS_IMGPROC_JPEG_JPEG_DISTORTION_GPU_IMPL_CUH_
 
 #include <cuda_runtime_api.h>
+#include "dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.h"
 #include "dali/kernels/common/block_setup.h"
 #include "dali/kernels/imgproc/surface.h"
 #include "dali/kernels/imgproc/sampler.h"
@@ -27,68 +28,7 @@
 
 namespace dali {
 namespace kernels {
-
-float GetQualityFactorScale(int quality) {
-  quality = clamp<int>(quality, 1, 99);
-  float q_scale = 1.0f;
-  if (quality < 50) {
-    q_scale = 50.0f / quality;
-  } else {
-    q_scale = 2.0f - (2 * quality / 100.0f);
-  }
-  return q_scale;
-}
-
-// Quantization table coefficients that are suggested in the Annex K of the JPEG standard.
-
-mat<8, 8, uint8_t> GetLumaQuantizationTable(int quality) {
-  mat<8, 8, uint8_t> table = {{
-    {16, 11, 10, 16, 24, 40, 51, 61},
-    {12, 12, 14, 19, 26, 58, 60, 55},
-    {14, 13, 16, 24, 40, 57, 69, 56},
-    {14, 17, 22, 29, 51, 87, 80, 62},
-    {18, 22, 37, 56, 68, 109, 103, 77},
-    {24, 35, 55, 64, 81, 104, 113, 92},
-    {49, 64, 78, 87, 103, 121, 120, 101},
-    {72, 92, 95, 98, 112, 100, 103, 99}
-  }};
-  auto scale = GetQualityFactorScale(quality);
-  for (int i = 0; i < 8; i++) {
-    for (int j = 0; j < 8; j++) {
-      table(i, j) = ConvertSat<uint8_t>(scale * table(i, j));
-    }
-  }
-  return table;
-}
-
-mat<8, 8, uint8_t> GetChromaQuantizationTable(int quality) {
-  mat<8, 8, uint8_t> table = {{
-    {17, 18, 24, 47, 99, 99, 99, 99},
-    {18, 21, 26, 66, 99, 99, 99, 99},
-    {24, 26, 56, 99, 99, 99, 99, 99},
-    {47, 66, 99, 99, 99, 99, 99, 99},
-    {99, 99, 99, 99, 99, 99, 99, 99},
-    {99, 99, 99, 99, 99, 99, 99, 99},
-    {99, 99, 99, 99, 99, 99, 99, 99},
-    {99, 99, 99, 99, 99, 99, 99, 99}
-  }};
-  auto scale = GetQualityFactorScale(quality);
-  for (int i = 0; i < 8; i++) {
-    for (int j = 0; j < 8; j++) {
-      table(i, j) = ConvertSat<uint8_t>(scale * table(i, j));
-    }
-  }
-  return table;
-}
-
-struct SampleDesc {
-  const uint8_t *in;  // rgb
-  uint8_t *out;  // rgb
-  ivec<2> size;
-  i64vec<2> strides;
-  mat<8, 8, uint8_t> luma_Q_table = GetLumaQuantizationTable(95);
-  mat<8, 8, uint8_t> chroma_Q_table = GetChromaQuantizationTable(95);
-};
+namespace jpeg {
 
 template <typename T>
 __inline__ __device__ T rgb_to_y(vec<3, T> rgb) {
@@ -409,7 +349,8 @@ __global__ void JpegCompressionDistortion(const SampleDesc *samples,
   }
 }
 
+}  // namespace jpeg
 }  // namespace kernels
 }  // namespace dali
 
-#endif  // DALI_KERNELS_IMGPROC_JPEG_JPEG_ARTIFACTS_GPU_H_
+#endif  // DALI_KERNELS_IMGPROC_JPEG_JPEG_DISTORTION_GPU_IMPL_CUH_

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.cu
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.cu
@@ -91,7 +91,7 @@ void JpegCompressionDistortionGPU::Run(KernelContext &ctx, const OutListGPU<uint
     throw std::invalid_argument(
       make_string("Unexpected number of elements in ``quality`` argument. "
                   "The argument could contain a single value (used for the whole batch), "
-                  "one value per sample, o no values (a default is used). Received ",
+                  "one value per sample, or no values (a default is used). Received ",
                   quality.size(), " values but batch size is ", nsamples, "."));
   }
   SetupSampleDescs(out, in, quality);

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.cu
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.cu
@@ -41,7 +41,7 @@ KernelRequirements JpegDistortionBaseGPU::Setup(KernelContext &ctx,
   }
 
   block_setup_.SetBlockDim(dim3(32, 16, 1));
-  int xblock = 64*(2-horz_subsample_);
+  int xblock = 64 * (2 - horz_subsample_);
   int yblock = 128;
   block_setup_.SetDefaultBlockSize({xblock, yblock});
   block_setup_.SetupBlocks(chroma_shape_, true);
@@ -88,9 +88,11 @@ void JpegCompressionDistortionGPU::Run(KernelContext &ctx, const OutListGPU<uint
   const auto &in_shape = in.shape;
   int nsamples = in_shape.num_samples();
   if (quality.size() > 1 && quality.size() != nsamples) {
-    throw std::invalid_argument(make_string("Received ", quality.size(),
-                                            " quality values but the batch contains ", nsamples,
-                                            " samples."));
+    throw std::invalid_argument(
+      make_string("Unexpected number of elements in ``quality`` argument. "
+                  "The argument could contain a single value (used for the whole batch), "
+                  "one value per sample, o no values (a default is used). Received ",
+                  quality.size(), " values but batch size is ", nsamples, "."));
   }
   SetupSampleDescs(out, in, quality);
   SampleDesc *samples_gpu;

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.h
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.h
@@ -1,0 +1,126 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_IMGPROC_JPEG_JPEG_DISTORTION_GPU_KERNEL_H_
+#define DALI_KERNELS_IMGPROC_JPEG_JPEG_DISTORTION_GPU_KERNEL_H_
+
+#include <vector>
+#include "dali/core/convert.h"
+#include "dali/core/geom/mat.h"
+#include "dali/core/geom/vec.h"
+#include "dali/core/tensor_view.h"
+#include "dali/core/util.h"
+#include "dali/kernels/common/block_setup.h"
+#include "dali/kernels/common/utils.h"
+#include "dali/kernels/kernel.h"
+
+namespace dali {
+namespace kernels {
+namespace jpeg {
+
+inline float GetQualityFactorScale(int quality) {
+  quality = clamp<int>(quality, 1, 99);
+  float q_scale = 1.0f;
+  if (quality < 50) {
+    q_scale = 50.0f / quality;
+  } else {
+    q_scale = 2.0f - (2 * quality / 100.0f);
+  }
+  return q_scale;
+}
+
+// Quantization table coefficients that are suggested in the Annex K of the JPEG standard.
+
+inline mat<8, 8, uint8_t> GetLumaQuantizationTable(int quality) {
+  mat<8, 8, uint8_t> table = {{
+    {16, 11, 10, 16, 24, 40, 51, 61},
+    {12, 12, 14, 19, 26, 58, 60, 55},
+    {14, 13, 16, 24, 40, 57, 69, 56},
+    {14, 17, 22, 29, 51, 87, 80, 62},
+    {18, 22, 37, 56, 68, 109, 103, 77},
+    {24, 35, 55, 64, 81, 104, 113, 92},
+    {49, 64, 78, 87, 103, 121, 120, 101},
+    {72, 92, 95, 98, 112, 100, 103, 99}
+  }};
+  auto scale = GetQualityFactorScale(quality);
+  for (int i = 0; i < 8; i++) {
+    for (int j = 0; j < 8; j++) {
+      table(i, j) = ConvertSat<uint8_t>(scale * table(i, j));
+    }
+  }
+  return table;
+}
+
+inline mat<8, 8, uint8_t> GetChromaQuantizationTable(int quality) {
+  mat<8, 8, uint8_t> table = {{
+    {17, 18, 24, 47, 99, 99, 99, 99},
+    {18, 21, 26, 66, 99, 99, 99, 99},
+    {24, 26, 56, 99, 99, 99, 99, 99},
+    {47, 66, 99, 99, 99, 99, 99, 99},
+    {99, 99, 99, 99, 99, 99, 99, 99},
+    {99, 99, 99, 99, 99, 99, 99, 99},
+    {99, 99, 99, 99, 99, 99, 99, 99},
+    {99, 99, 99, 99, 99, 99, 99, 99}
+  }};
+  auto scale = GetQualityFactorScale(quality);
+  for (int i = 0; i < 8; i++) {
+    for (int j = 0; j < 8; j++) {
+      table(i, j) = ConvertSat<uint8_t>(scale * table(i, j));
+    }
+  }
+  return table;
+}
+
+struct SampleDesc {
+  const uint8_t *in;  // rgb
+  uint8_t *out;  // rgb
+  ivec<2> size;
+  i64vec<2> strides;
+  mat<8, 8, uint8_t> luma_Q_table;
+  mat<8, 8, uint8_t> chroma_Q_table;
+};
+
+template <bool horz_subsample, bool vert_subsample>
+class DLL_PUBLIC JpegCompressionDistortionGPU {
+ public:
+  KernelRequirements Setup(KernelContext &ctx, const TensorListShape<3> &in_shape);
+  void Run(KernelContext &ctx, const OutListGPU<uint8_t, 3> &out, const InListGPU<uint8_t, 3> &in,
+           span<const int> quality);
+
+ protected:
+  void SetupSampleDescs(const OutListGPU<uint8_t, 3> &out, const InListGPU<uint8_t, 3> &in,
+                        span<const int> quality = {});
+
+  using BlkSetup = BlockSetup<2, -1>;
+  BlkSetup block_setup_;
+  using BlockDesc = BlkSetup::BlockDesc;
+
+  TensorListShape<2> chroma_shape_;
+  std::vector<SampleDesc> sample_descs_;
+  std::vector<int> quality_;
+};
+
+template <bool horz_subsample, bool vert_subsample>
+class DLL_PUBLIC ChromaSubsampleDistortionGPU
+    : public JpegCompressionDistortionGPU<horz_subsample, vert_subsample> {
+ public:
+  void Run(KernelContext &ctx, const OutListGPU<uint8_t, 3> &out,
+           const InListGPU<uint8_t, 3> &in);
+};
+
+}  // namespace jpeg
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_IMGPROC_JPEG_JPEG_DISTORTION_GPU_KERNEL_H_

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_test.cu
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_test.cu
@@ -60,7 +60,7 @@ class JpegDistortionTestGPU : public ::testing::TestWithParam<std::tuple<bool, b
 
  public:
   JpegDistortionTestGPU()
-      : horz_subsample(std::get<0>(GetParam())), vert_subsample(std::get<0>(GetParam())) {}
+      : horz_subsample(std::get<0>(GetParam())), vert_subsample(std::get<1>(GetParam())) {}
 
   void SetUp() final {
     if (use_real_images) {

--- a/dali/kernels/normalize/normalize_gpu_test.cu
+++ b/dali/kernels/normalize/normalize_gpu_test.cu
@@ -248,7 +248,7 @@ class NormalizeImplGPUTest<std::pair<Out, In>> : public ::testing::Test {
     KernelContext ctx;
     for (int iter = 0; iter < 3; iter++) {
       auto req = kmgr_.Setup<Kernel>(0, ctx, data_shape_, param_shape_,
-                                    use_scalar_base_, use_scalar_scale_, scale_is_stddev_);
+                                     use_scalar_base_, use_scalar_scale_, scale_is_stddev_);
       ASSERT_EQ(req.output_shapes.size(), 1u);
       ASSERT_EQ(req.output_shapes[0], data_shape_);
       out_.reshape(data_shape_);


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a new feature needed to perform JPEG-like distortion on images

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Created a DALI kernel to wrap the implementation details of the existing JPEG distortion CUDA kernel*
 - Affected modules and functionalities:
     *New kernel*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *Tests updated*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-1932]*
