### PR TITLE
Remove 0 default value from mean/std arguments of normalize.

### DIFF
--- a/dali/operators/math/normalize/normalize.cc
+++ b/dali/operators/math/normalize/normalize.cc
@@ -83,12 +83,13 @@ The extent in each dimension must match the value of the input or be equal to 1.
 extent is 1, the value will be broadcast in this dimension. If the value is not specified, the
 mean is calculated from the input. A non-scalar mean cannot be used when batch argument
 is set to True.)code",
-    0.0f, true)
+    nullptr, true)
   .AddOptionalArg<float>("stddev", R"code(Standard deviation value to scale the data.
 
 See ``mean`` argument for more information about shape constraints. If a value is not specified,
 the standard deviation is calculated from the input. A non-scalar ``stddev`` cannot be used when
-``batch`` argument is set to True.)code", 0.0f, true)
+``batch`` argument is set to True.)code",
+    nullptr, true)
   .AddOptionalArg("axes", R"code(Indices of dimensions along which the input is normalized.
 
 By default, all axes are used, and the axes can also be specified by name.


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes the default value of `mean`/`stddev` arguments of normalize operator documentation, since the actual default value is to calculate mean and stddev from the input (as described in the argument descriptions).

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Removed 0 default value*
 - Affected modules and functionalities:
     *fn.normalize*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[NA]*
