### PR TITLE
Fix JPEG distortion kernel quality parameter handling

### DIFF
--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.cu
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.cu
@@ -71,12 +71,12 @@ void JpegDistortionBaseGPU::SetupSampleDescs(const OutListGPU<uint8_t, 3> &out,
     sample_desc.strides.x = 3;
     sample_desc.strides.y = width * 3;
     int q;
-    if (quality_.empty()) {
+    if (quality.empty()) {
       q = 95;
-    } else if (quality_.size() == 1) {
-      q = quality_[0];
+    } else if (quality.size() == 1) {
+      q = quality[0];
     } else {
-      q = quality_[i];
+      q = quality[i];
     }
     sample_desc.luma_Q_table = GetLumaQuantizationTable(q);
     sample_desc.chroma_Q_table = GetChromaQuantizationTable(q);

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.h
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.h
@@ -106,7 +106,6 @@ class DLL_PUBLIC JpegDistortionBaseGPU {
 
   TensorListShape<2> chroma_shape_;
   std::vector<SampleDesc> sample_descs_;
-  std::vector<int> quality_;
   bool horz_subsample_ = true;
   bool vert_subsample_ = true;
 };
@@ -122,7 +121,6 @@ class DLL_PUBLIC JpegCompressionDistortionGPU : public JpegDistortionBaseGPU {
   using Base::SetupSampleDescs;
   using Base::block_setup_;
   using Base::sample_descs_;
-  using Base::quality_;
 };
 
 class DLL_PUBLIC ChromaSubsampleDistortionGPU : public JpegDistortionBaseGPU {

--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_test.cu
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_test.cu
@@ -274,11 +274,9 @@ class JpegDistortionTestGPU : public ::testing::TestWithParam<std::tuple<bool, b
   }
 
   void TestJpegCompressionDistortion(int quality) {
-    quality_.resize(1, quality);
+    quality_ = {quality};
     max_abs_error_ = vert_subsample && horz_subsample ? 80 : 128;
     max_avg_error_ = vert_subsample && horz_subsample ? 3 : 10;
-    luma_table_   = GetLumaQuantizationTable(quality);
-    chroma_table_ = GetChromaQuantizationTable(quality);
     CalcOut_JpegCompressionDistortion();
     TestKernel<JpegCompressionDistortionGPU>(make_cspan(quality_));
   }
@@ -295,9 +293,6 @@ class JpegDistortionTestGPU : public ::testing::TestWithParam<std::tuple<bool, b
   TestTensorList<uint8_t> out_ref_;
 
   std::vector<int> quality_ = {95};
-  mat<8, 8, uint8_t> luma_table_;
-  mat<8, 8, uint8_t> chroma_table_;
-
   kernels::KernelManager kmgr_;
   int max_abs_error_ = 5;
   int max_avg_error_ = 3;


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in the JPEG compression distortion kernel (quality argument was effectively ignored)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Use the quality argument, instead of the member*
     *Fix a bug in the tests causing always to use quality=95, which was the default*
 - Affected modules and functionalities:
     *JPEG distortion kernel*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-1932]*
