### PR TITLE
RNGBase to be used as base for noise augmentations + Add GaussianNoise operator (as an example)

### DIFF
--- a/dali/operators/random/coin_flip.h
+++ b/dali/operators/random/coin_flip.h
@@ -26,7 +26,7 @@
 namespace dali {
 
 template <typename Backend>
-class CoinFlip : public RNGBase<Backend, CoinFlip<Backend>> {
+class CoinFlip : public RNGBase<Backend, CoinFlip<Backend>, false> {
  public:
   template <typename T>
   struct Dist {
@@ -37,7 +37,7 @@ class CoinFlip : public RNGBase<Backend, CoinFlip<Backend>> {
   };
 
   explicit CoinFlip(const OpSpec &spec)
-      : RNGBase<Backend, CoinFlip<Backend>>(spec),
+      : RNGBase<Backend, CoinFlip<Backend>, false>(spec),
         probability_("probability", spec) {
     backend_data_.ReserveDistsData(sizeof(typename Dist<double>::type) * max_batch_size_);
   }
@@ -58,7 +58,7 @@ class CoinFlip : public RNGBase<Backend, CoinFlip<Backend>> {
     return true;
   }
 
-  using RNGBase<Backend, CoinFlip<Backend>>::RunImpl;
+  using RNGBase<Backend, CoinFlip<Backend>, false>::RunImpl;
   void RunImpl(workspace_t<Backend> &ws) override {
     TYPE_SWITCH(dtype_, type2id, T, DALI_COINFLIP_TYPES, (
       using Dist = typename Dist<T>::type;
@@ -68,8 +68,8 @@ class CoinFlip : public RNGBase<Backend, CoinFlip<Backend>> {
 
  protected:
   using Operator<Backend>::max_batch_size_;
-  using RNGBase<Backend, CoinFlip<Backend>>::dtype_;
-  using RNGBase<Backend, CoinFlip<Backend>>::backend_data_;
+  using RNGBase<Backend, CoinFlip<Backend>, false>::dtype_;
+  using RNGBase<Backend, CoinFlip<Backend>, false>::backend_data_;
 
   ArgValue<float> probability_;
 };

--- a/dali/operators/random/noise/CMakeLists.txt
+++ b/dali/operators/random/noise/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,10 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Get all the source files and dump test files
-
-add_subdirectory(noise)
 
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)

--- a/dali/operators/random/noise/gaussian_noise.cc
+++ b/dali/operators/random/noise/gaussian_noise.cc
@@ -23,15 +23,14 @@ DALI_SCHEMA(noise__Gaussian)
 
 The shape and data type of the output will match the input.
 )code")
-    .NumInput(0, 1)
+    .NumInput(1)
     .NumOutput(1)
     .AddOptionalArg<float>("mean",
       R"code(Mean of the distribution.)code",
       0.f, true)
     .AddOptionalArg<float>("stddev",
       R"code(Standard deviation of the distribution.)code",
-      1.f, true)
-    .AddParent("RNGAttr");
+      1.f, true);
 
 DALI_REGISTER_OPERATOR(noise__Gaussian, GaussianNoise<CPUBackend>, CPU);
 

--- a/dali/operators/random/noise/gaussian_noise.cc
+++ b/dali/operators/random/noise/gaussian_noise.cc
@@ -1,0 +1,38 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/random/noise/gaussian_noise.h"
+#include "dali/operators/random/rng_base_cpu.h"
+#include "dali/pipeline/operator/arg_helper.h"
+
+namespace dali {
+
+DALI_SCHEMA(noise__Gaussian)
+    .DocStr(R"code(Applies gaussian noise to the input.
+
+The shape and data type of the output will match the input.
+)code")
+    .NumInput(0, 1)
+    .NumOutput(1)
+    .AddOptionalArg<float>("mean",
+      R"code(Mean of the distribution.)code",
+      0.f, true)
+    .AddOptionalArg<float>("stddev",
+      R"code(Standard deviation of the distribution.)code",
+      1.f, true)
+    .AddParent("RNGAttr");
+
+DALI_REGISTER_OPERATOR(noise__Gaussian, GaussianNoise<CPUBackend>, CPU);
+
+}  // namespace dali

--- a/dali/operators/random/noise/gaussian_noise.cu
+++ b/dali/operators/random/noise/gaussian_noise.cu
@@ -1,0 +1,22 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/random/rng_base_gpu.cuh"
+#include "dali/operators/random/noise/gaussian_noise.h"
+
+namespace dali {
+
+DALI_REGISTER_OPERATOR(noise__Gaussian, GaussianNoise<GPUBackend>, GPU);
+
+}  // namespace dali

--- a/dali/operators/random/noise/gaussian_noise.h
+++ b/dali/operators/random/noise/gaussian_noise.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_RANDOM_NOISE_GAUSSIAN_NOISE_H_
+#define DALI_OPERATORS_RANDOM_NOISE_GAUSSIAN_NOISE_H_
+
+#include "dali/operators/random/rng_base.h"
+#include "dali/pipeline/operator/arg_helper.h"
+#include "dali/operators/random/rng_base_gpu.h"
+#include "dali/operators/random/rng_base_cpu.h"
+
+#define DALI_GAUSSIAN_NOISE_TYPES \
+  (uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t, float)
+
+namespace dali {
+
+template <typename Backend, typename T>
+class gaussian_noise_impl {
+ public:
+  using FloatType =
+      typename std::conditional<((std::is_integral<T>::value && sizeof(T) >= 4) || sizeof(T) > 4),
+                                double, float>::type;
+  using Dist = typename std::conditional_t<std::is_same<Backend, GPUBackend>::value,
+                                           curand_normal_dist<FloatType>,
+                                           std::normal_distribution<FloatType>>;
+
+  DALI_HOST_DEV explicit gaussian_noise_impl(FloatType mean = 0, FloatType stddev = 1)
+      : dist_{mean, stddev} {}
+
+  template <typename Generator>
+  DALI_HOST_DEV inline T operator()(T in_val, Generator& g) {
+    return ConvertSat<T>(in_val + dist_(g));
+  }
+
+ private:
+  Dist dist_;
+};
+
+template <typename Backend>
+class GaussianNoise : public RNGBase<Backend, GaussianNoise<Backend>, true> {
+ public:
+  using BaseImpl = RNGBase<Backend, GaussianNoise<Backend>, true>;
+  template <typename T>
+  struct Dist {
+    using type = gaussian_noise_impl<Backend, T>;
+  };
+
+  explicit GaussianNoise(const OpSpec &spec)
+      : BaseImpl(spec),
+        mean_("mean", spec),
+        stddev_("stddev", spec) {
+    if (mean_.IsDefined() || stddev_.IsDefined()) {
+      backend_data_.ReserveDistsData(sizeof(typename Dist<double>::type) * max_batch_size_);
+    }
+  }
+
+  void AcquireArgs(const OpSpec &spec, const workspace_t<Backend> &ws, int nsamples) {
+    mean_.Acquire(spec, ws, nsamples, true);
+    stddev_.Acquire(spec, ws, nsamples, true);
+  }
+
+  DALIDataType DefaultDataType() const {
+    return DALI_FLOAT;
+  }
+
+  template <typename T>
+  bool SetupDists(typename Dist<T>::type* dists_data, int nsamples) {
+    if (!mean_.IsDefined() && !stddev_.IsDefined()) {
+      return false;
+    }
+    for (int s = 0; s < nsamples; s++) {
+      dists_data[s] = typename Dist<T>::type{mean_[s].data[0], stddev_[s].data[0]};
+    }
+    return true;
+  }
+
+  using BaseImpl::RunImpl;
+  void RunImpl(workspace_t<Backend> &ws) override {
+    TYPE_SWITCH(dtype_, type2id, T, DALI_GAUSSIAN_NOISE_TYPES, (
+      using Dist = typename Dist<T>::type;
+      this->template RunImplTyped<T, Dist>(ws);
+    ), DALI_FAIL(make_string("Unsupported data type: ", dtype_)));  // NOLINT
+  }
+
+ protected:
+  using Operator<Backend>::max_batch_size_;
+  using BaseImpl::dtype_;
+  using BaseImpl::backend_data_;
+
+  ArgValue<float> mean_;
+  ArgValue<float> stddev_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_RANDOM_NOISE_GAUSSIAN_NOISE_H_

--- a/dali/operators/random/normal_distribution.h
+++ b/dali/operators/random/normal_distribution.h
@@ -26,7 +26,7 @@
 namespace dali {
 
 template <typename Backend>
-class NormalDistribution : public RNGBase<Backend, NormalDistribution<Backend>> {
+class NormalDistribution : public RNGBase<Backend, NormalDistribution<Backend>, false> {
  public:
   template <typename T>
   struct Dist {
@@ -41,7 +41,7 @@ class NormalDistribution : public RNGBase<Backend, NormalDistribution<Backend>> 
   };
 
   explicit NormalDistribution(const OpSpec &spec)
-      : RNGBase<Backend, NormalDistribution<Backend>>(spec),
+      : RNGBase<Backend, NormalDistribution<Backend>, false>(spec),
         mean_("mean", spec),
         stddev_("stddev", spec) {
     if (mean_.IsDefined() || stddev_.IsDefined()) {
@@ -69,7 +69,7 @@ class NormalDistribution : public RNGBase<Backend, NormalDistribution<Backend>> 
     return true;
   }
 
-  using RNGBase<Backend, NormalDistribution<Backend>>::RunImpl;
+  using RNGBase<Backend, NormalDistribution<Backend>, false>::RunImpl;
   void RunImpl(workspace_t<Backend> &ws) override {
     TYPE_SWITCH(dtype_, type2id, T, DALI_NORMDIST_TYPES, (
       using Dist = typename Dist<T>::type;
@@ -79,8 +79,8 @@ class NormalDistribution : public RNGBase<Backend, NormalDistribution<Backend>> 
 
  protected:
   using Operator<Backend>::max_batch_size_;
-  using RNGBase<Backend, NormalDistribution<Backend>>::dtype_;
-  using RNGBase<Backend, NormalDistribution<Backend>>::backend_data_;
+  using RNGBase<Backend, NormalDistribution<Backend>, false>::dtype_;
+  using RNGBase<Backend, NormalDistribution<Backend>, false>::backend_data_;
 
   ArgValue<float> mean_;
   ArgValue<float> stddev_;

--- a/dali/operators/random/rng_base.h
+++ b/dali/operators/random/rng_base.h
@@ -55,7 +55,7 @@ class RNGBase : public Operator<Backend> {
                  const workspace_t<Backend> &ws) override {
     if (NeedsInput)
       dtype_ = ws.template InputRef<Backend>(0).type().id();
-    if (!spec_.TryGetArgument(dtype_, "dtype"))
+    else if (!spec_.TryGetArgument(dtype_, "dtype"))
       dtype_ = This().DefaultDataType();
 
     bool has_shape = spec_.ArgumentDefined("shape");

--- a/dali/operators/random/rng_base_cpu.h
+++ b/dali/operators/random/rng_base_cpu.h
@@ -25,8 +25,8 @@
 
 namespace dali {
 
-template <>
-struct RNGBaseFields<CPUBackend> {
+template <bool NeedsInput>
+struct RNGBaseFields<CPUBackend, NeedsInput> {
   RNGBaseFields(int64_t seed, int nsamples) {}
 
   std::vector<uint8_t> dists_cpu_;
@@ -36,9 +36,9 @@ struct RNGBaseFields<CPUBackend> {
   }
 };
 
-template <typename Backend, typename Impl>
+template <typename Backend, typename Impl, bool NeedsInput>
 template <typename T, typename Dist>
-void RNGBase<Backend, Impl>::RunImplTyped(workspace_t<CPUBackend> &ws) {
+void RNGBase<Backend, Impl, NeedsInput>::RunImplTyped(workspace_t<CPUBackend> &ws) {
   // Should never be called for Backend != CPUBackend
   static_assert(std::is_same<Backend, CPUBackend>::value, "Invalid backend");
   auto &output = ws.OutputRef<CPUBackend>(0);

--- a/dali/operators/random/rng_base_cpu.h
+++ b/dali/operators/random/rng_base_cpu.h
@@ -36,6 +36,36 @@ struct RNGBaseFields<CPUBackend, NeedsInput> {
   }
 };
 
+template <bool NeedsInput>
+struct DistGen;
+
+template <>
+struct DistGen<false> {
+  template <typename T, typename Dist, typename RNG>
+  inline void gen(span<T> out, span<const T> in, Dist& dist, RNG &rng) const {
+    (void) in;
+    for (auto &x : out)
+      x = ConvertSat<T>(dist(rng));
+  }
+};
+
+template <>
+struct DistGen<true> {
+  template <typename T, typename Dist, typename RNG>
+  inline void gen(span<T> out, span<const T> in, Dist& dist, RNG &rng) const {
+    assert(out.size() == in.size());
+    for (int64_t k = 0; k < out.size(); k++)
+      out[k] = ConvertSat<T>(dist(in[k], rng));
+  }
+};
+
+template <typename T>
+inline span<T> get_chunk(span<T> data, int c, int chunks) {
+  T* start = data.begin() + data.size() * c / chunks;
+  T* end = data.begin() + data.size() * (c + 1) / chunks;
+  return make_span(start, end - start);
+}
+
 template <typename Backend, typename Impl, bool NeedsInput>
 template <typename T, typename Dist>
 void RNGBase<Backend, Impl, NeedsInput>::RunImplTyped(workspace_t<CPUBackend> &ws) {
@@ -50,28 +80,43 @@ void RNGBase<Backend, Impl, NeedsInput>::RunImplTyped(workspace_t<CPUBackend> &w
   constexpr size_t kNumChunkSeeds = 16;
   int nsamples = output.shape().size();
 
+  TensorListView<detail::storage_tag_map_t<Backend>, const T, DynamicDimensions> in_view;
+  if (NeedsInput) {
+    const auto &input = ws.InputRef<CPUBackend>(0);
+    in_view = view<const T>(input);
+    output.SetLayout(input.GetLayout());
+  }
+
   auto &dists_cpu = backend_data_.dists_cpu_;
   dists_cpu.resize(sizeof(Dist) * nsamples);  // memory was already reserved in the constructor
   Dist* dists = reinterpret_cast<Dist*>(dists_cpu.data());
   bool use_default_dist = !This().template SetupDists<T>(dists, nsamples);
 
+  DistGen<NeedsInput> dist_gen_;
   for (int sample_id = 0; sample_id < nsamples; ++sample_id) {
     auto sample_sz = out_shape.tensor_size(sample_id);
     span<T> out_span{out_view[sample_id].data, sample_sz};
+    span<const T> in_span;
+    if (NeedsInput) {
+      assert(sample_sz == in_view.shape.tensor_size(sample_id));
+      in_span = {in_view[sample_id].data, sample_sz};
+    }
     if (sample_sz < kThreshold) {
       tp.AddWork(
         [=](int thread_id) {
           auto dist = use_default_dist ? Dist() : dists[sample_id];
-          for (auto &x : out_span)
-            x = ConvertSat<T>(dist(rng_[sample_id]));
+          dist_gen_.template gen<T>(out_span, in_span, dist, rng_[sample_id]);
         }, sample_sz);
     } else {
       int chunks = div_ceil(out_span.size(), kChunkSize);
       std::array<uint32_t, kNumChunkSeeds> seed;
       for (int c = 0; c < chunks; c++) {
-        auto start = out_span.begin() + out_span.size() * c / chunks;
-        auto end = out_span.begin() + out_span.size() * (c + 1) / chunks;
-        auto chunk = make_span(start, end - start);
+        auto out_chunk = get_chunk<T>(out_span, c, chunks);
+        span<const T> in_chunk;
+        if (NeedsInput) {
+          in_chunk = get_chunk<const T>(in_span, c, chunks);
+          assert(out_chunk.size() == in_chunk.size());
+        }
         for (auto &s : seed)
           s = rng_[sample_id]();
         tp.AddWork(
@@ -79,9 +124,8 @@ void RNGBase<Backend, Impl, NeedsInput>::RunImplTyped(workspace_t<CPUBackend> &w
             std::seed_seq seq(seed.begin(), seed.end());
             std::mt19937_64 chunk_rng(seq);
             auto dist = use_default_dist ? Dist() : dists[sample_id];
-            for (auto &x : chunk)
-              x = ConvertSat<T>(dist(chunk_rng));
-          }, chunk.size());
+            dist_gen_.template gen<T>(out_chunk, in_chunk, dist, chunk_rng);
+          }, out_chunk.size());
       }
     }
   }

--- a/dali/operators/random/rng_base_gpu.cuh
+++ b/dali/operators/random/rng_base_gpu.cuh
@@ -30,18 +30,19 @@ namespace {
 
 template <typename T, typename Dist>
 __device__ __inline__ void Generate(BlockDesc<true> desc,
-                                    const Dist& dist,
+                                    Dist& dist,
                                     curandState* __restrict__ rng) {
   auto out = static_cast<T*>(desc.output);
   auto in = static_cast<const T*>(desc.input);
-  for (auto idx = desc.offset + threadIdx.x; idx < desc.size; idx += blockDim.x) {
+  auto idx_end = desc.offset + desc.size;
+  for (auto idx = desc.offset + threadIdx.x; idx < idx_end; idx += blockDim.x) {
     out[idx] = ConvertSat<T>(dist(in[idx], rng));
   }
 }
 
 template <typename T, typename Dist>
 __device__ __inline__ void Generate(BlockDesc<false> desc,
-                                    const Dist& dist,
+                                    Dist& dist,
                                     curandState* __restrict__ rng) {
   auto start = static_cast<T*>(desc.start);
   auto block_end = start + desc.size;
@@ -50,7 +51,7 @@ __device__ __inline__ void Generate(BlockDesc<false> desc,
   }
 }
 
-template <typename T, typename Dist, bool DefaultDist = false, bool NeedsInput = false>
+template <typename T, typename Dist, bool NeedsInput, bool DefaultDist>
 __global__ void RNGKernel(BlockDesc<NeedsInput>* __restrict__ block_descs,
                           curandState* __restrict__ states,
                           const Dist* __restrict__ dists, int nblocks) {
@@ -74,7 +75,8 @@ template <typename T, typename Dist>
 void RNGBase<Backend, Impl, NeedsInput>::RunImplTyped(workspace_t<GPUBackend> &ws) {
   using Block = BlockDesc<NeedsInput>;
   static_assert(std::is_same<Backend, GPUBackend>::value, "Unexpected backend");
-  auto out_view = view<T>(ws.template OutputRef<GPUBackend>(0));
+  auto &output = ws.template OutputRef<GPUBackend>(0);
+  auto out_view = view<T>(output);
   int nsamples = out_view.shape.size();
   auto blocks_cpu = backend_data_.block_descs_cpu_.get();
   auto blocks_gpu = backend_data_.block_descs_gpu_.get();
@@ -82,8 +84,14 @@ void RNGBase<Backend, Impl, NeedsInput>::RunImplTyped(workspace_t<GPUBackend> &w
   int block_sz = backend_data_.block_size_;
   int max_nblocks = backend_data_.max_blocks_;
   int blockdesc_count = -1;
+  TensorListView<StorageGPU, const T> in_view;
+  if (NeedsInput) {
+    const auto& input = ws.template InputRef<GPUBackend>(0);
+    in_view = view<const T>(input);
+    output.SetLayout(input.GetLayout());
+  }
   blockdesc_count = SetupBlockDescs(
-    blocks_cpu, block_sz, max_nblocks, out_view);
+    blocks_cpu, block_sz, max_nblocks, out_view, in_view);
   if (blockdesc_count == 0) {
     return;
   }
@@ -117,10 +125,10 @@ void RNGBase<Backend, Impl, NeedsInput>::RunImplTyped(workspace_t<GPUBackend> &w
   gridDim.y = div_ceil(blockdesc_count, blockDim.y);
 
   if (use_default_dist) {
-    RNGKernel<T, Dist, true>
+    RNGKernel<T, Dist, NeedsInput, true>
       <<<gridDim, blockDim, 0, ws.stream()>>>(blocks_gpu, rngs, nullptr, blockdesc_count);
   } else {
-    RNGKernel<T, Dist, false>
+    RNGKernel<T, Dist, NeedsInput, false>
       <<<gridDim, blockDim, 0, ws.stream()>>>(blocks_gpu, rngs, dists, blockdesc_count);
   }
 }

--- a/dali/operators/random/rng_base_gpu.cuh
+++ b/dali/operators/random/rng_base_gpu.cuh
@@ -44,9 +44,9 @@ template <typename T, typename Dist>
 __device__ __inline__ void Generate(BlockDesc<false> desc,
                                     Dist& dist,
                                     curandState* __restrict__ rng) {
-  auto start = static_cast<T*>(desc.start);
-  auto block_end = start + desc.size;
-  for (auto out = start + threadIdx.x; out < block_end; out += blockDim.x) {
+  auto block_start = static_cast<T*>(desc.output);
+  auto block_end = block_start + desc.size;
+  for (auto out = block_start + threadIdx.x; out < block_end; out += blockDim.x) {
     *out = ConvertSat<T>(dist(rng));
   }
 }

--- a/dali/operators/random/rng_base_gpu.h
+++ b/dali/operators/random/rng_base_gpu.h
@@ -49,7 +49,8 @@ struct BlockDesc<true> {
 
 template <bool NeedsInput>
 struct RNGBaseFields<GPUBackend, NeedsInput> {
-  RNGBaseFields<GPUBackend, NeedsInput>(int64_t seed, int max_batch_size, int64_t static_sample_size = -1)
+  RNGBaseFields<GPUBackend, NeedsInput>(int64_t seed, int max_batch_size,
+                                        int64_t static_sample_size = -1)
       : block_size_(static_sample_size < 0 ? 256 : std::min<int64_t>(static_sample_size, 256)),
         max_blocks_(static_sample_size < 0 ?
                         1024 :
@@ -108,7 +109,9 @@ std::pair<std::vector<int>, int> DistributeBlocksPerSample(
 
 template <typename T>
 int64_t SetupBlockDescs(BlockDesc<false> *blocks, int64_t block_sz, int64_t max_nblocks,
-                        TensorListView<StorageGPU, T> &output) {
+                        TensorListView<StorageGPU, T> &output,
+                        TensorListView<StorageGPU, const T> &input) {
+  (void) input;
   std::vector<int> blocks_per_sample;
   int64_t blocks_num;
   auto &shape = output.shape;
@@ -143,7 +146,7 @@ int64_t SetupBlockDescs(BlockDesc<true> *blocks, int64_t block_sz, int64_t max_n
   int64_t block = 0;
   for (int s = 0; s < shape.size(); s++) {
     T *sample_out = static_cast<T*>(output[s].data);
-    T *sample_in = static_cast<const T*>(input[s].data);
+    const T *sample_in = static_cast<const T*>(input[s].data);
     auto sample_size = volume(shape[s]);
     if (sample_size == 0)
       continue;

--- a/dali/operators/random/rng_base_gpu.h
+++ b/dali/operators/random/rng_base_gpu.h
@@ -34,7 +34,7 @@ struct BlockDesc;
 template <>
 struct BlockDesc<false> {
   int sample_idx;
-  void* start;
+  void* output;
   size_t size;
 };
 
@@ -126,7 +126,7 @@ int64_t SetupBlockDescs(BlockDesc<false> *blocks, int64_t block_sz, int64_t max_
     int64_t offset = 0;
     for (int b = 0; b < blocks_per_sample[s]; ++b, ++block) {
       blocks[block].sample_idx = s;
-      blocks[block].start = sample_data + offset;
+      blocks[block].output = sample_data + offset;
       blocks[block].size = std::min(work_per_block, sample_size - offset);
       offset += blocks[block].size;
     }

--- a/dali/operators/random/rng_base_gpu.h
+++ b/dali/operators/random/rng_base_gpu.h
@@ -27,25 +27,38 @@
 
 namespace dali {
 
-struct BlockDesc {
+
+template <bool NeedsInput>
+struct BlockDesc;
+
+template <>
+struct BlockDesc<false> {
   int sample_idx;
   void* start;
   size_t size;
 };
 
 template <>
-struct RNGBaseFields<GPUBackend> {
-  RNGBaseFields<GPUBackend>(int64_t seed, int max_batch_size, int64_t static_sample_size = -1)
+struct BlockDesc<true> {
+  int sample_idx;
+  void* output;
+  const void* input;
+  size_t offset;
+  size_t size;
+};
+
+template <bool NeedsInput>
+struct RNGBaseFields<GPUBackend, NeedsInput> {
+  RNGBaseFields<GPUBackend, NeedsInput>(int64_t seed, int max_batch_size, int64_t static_sample_size = -1)
       : block_size_(static_sample_size < 0 ? 256 : std::min<int64_t>(static_sample_size, 256)),
-        max_blocks_(static_sample_size < 0
-                        ? 1024
-                        : std::min<int64_t>(
-                              max_batch_size * div_ceil(static_sample_size, block_size_), 1024)),
+        max_blocks_(static_sample_size < 0 ?
+                        1024 :
+                        std::min<int64_t>(
+                            max_batch_size * div_ceil(static_sample_size, block_size_), 1024)),
         randomizer_(seed, block_size_ * max_blocks_) {
-    block_descs_gpu_ =
-        kernels::memory::alloc_unique<BlockDesc>(kernels::AllocType::GPU, max_blocks_);
+    block_descs_gpu_ = kernels::memory::alloc_unique<Block>(kernels::AllocType::GPU, max_blocks_);
     block_descs_cpu_ =
-        kernels::memory::alloc_unique<BlockDesc>(kernels::AllocType::Pinned, max_blocks_);
+        kernels::memory::alloc_unique<Block>(kernels::AllocType::Pinned, max_blocks_);
   }
 
   void ReserveDistsData(size_t nbytes) {
@@ -53,11 +66,13 @@ struct RNGBaseFields<GPUBackend> {
     dists_gpu_.reserve(nbytes);
   }
 
+  using Block = BlockDesc<NeedsInput>;
+
   const int block_size_;
   const int max_blocks_;
   curand_states randomizer_;
-  kernels::memory::KernelUniquePtr<BlockDesc> block_descs_gpu_;
-  kernels::memory::KernelUniquePtr<BlockDesc> block_descs_cpu_;
+  kernels::memory::KernelUniquePtr<Block> block_descs_gpu_;
+  kernels::memory::KernelUniquePtr<Block> block_descs_cpu_;
 
   std::vector<uint8_t> dists_cpu_;
   DeviceBuffer<uint8_t> dists_gpu_;
@@ -92,7 +107,7 @@ std::pair<std::vector<int>, int> DistributeBlocksPerSample(
 }
 
 template <typename T>
-int64_t SetupBlockDescs(BlockDesc* blocks, int64_t block_sz, int64_t max_nblocks,
+int64_t SetupBlockDescs(BlockDesc<false> *blocks, int64_t block_sz, int64_t max_nblocks,
                         TensorListView<StorageGPU, T> &output) {
   std::vector<int> blocks_per_sample;
   int64_t blocks_num;
@@ -100,7 +115,7 @@ int64_t SetupBlockDescs(BlockDesc* blocks, int64_t block_sz, int64_t max_nblocks
   std::tie(blocks_per_sample, blocks_num) = DistributeBlocksPerSample(shape, block_sz, max_nblocks);
   int64_t block = 0;
   for (int s = 0; s < shape.size(); s++) {
-    T *sample_data = static_cast<T*>(output[s].data);
+    T *sample_data = static_cast<T *>(output[s].data);
     auto sample_size = volume(shape[s]);
     if (sample_size == 0)
       continue;
@@ -109,6 +124,36 @@ int64_t SetupBlockDescs(BlockDesc* blocks, int64_t block_sz, int64_t max_nblocks
     for (int b = 0; b < blocks_per_sample[s]; ++b, ++block) {
       blocks[block].sample_idx = s;
       blocks[block].start = sample_data + offset;
+      blocks[block].size = std::min(work_per_block, sample_size - offset);
+      offset += blocks[block].size;
+    }
+  }
+  return blocks_num;
+}
+
+template <typename T>
+int64_t SetupBlockDescs(BlockDesc<true> *blocks, int64_t block_sz, int64_t max_nblocks,
+                        TensorListView<StorageGPU, T> &output,
+                        TensorListView<StorageGPU, const T> &input) {
+  std::vector<int> blocks_per_sample;
+  int64_t blocks_num;
+  auto &shape = output.shape;
+  assert(output.shape == input.shape);
+  std::tie(blocks_per_sample, blocks_num) = DistributeBlocksPerSample(shape, block_sz, max_nblocks);
+  int64_t block = 0;
+  for (int s = 0; s < shape.size(); s++) {
+    T *sample_out = static_cast<T*>(output[s].data);
+    T *sample_in = static_cast<const T*>(input[s].data);
+    auto sample_size = volume(shape[s]);
+    if (sample_size == 0)
+      continue;
+    auto work_per_block = div_ceil(sample_size, blocks_per_sample[s]);
+    int64_t offset = 0;
+    for (int b = 0; b < blocks_per_sample[s]; ++b, ++block) {
+      blocks[block].sample_idx = s;
+      blocks[block].output = sample_out;
+      blocks[block].input = sample_in;
+      blocks[block].offset = offset;
       blocks[block].size = std::min(work_per_block, sample_size - offset);
       offset += blocks[block].size;
     }

--- a/dali/operators/random/uniform_distribution.h
+++ b/dali/operators/random/uniform_distribution.h
@@ -79,7 +79,7 @@ class uniform_int_values_dist {
 };
 
 template <typename Backend>
-class UniformDistribution : public RNGBase<Backend, UniformDistribution<Backend>> {
+class UniformDistribution : public RNGBase<Backend, UniformDistribution<Backend>, false> {
  public:
   template <typename T>
   struct DistContinuous {
@@ -103,7 +103,7 @@ class UniformDistribution : public RNGBase<Backend, UniformDistribution<Backend>
   };
 
   explicit UniformDistribution(const OpSpec &spec)
-      : RNGBase<Backend, UniformDistribution<Backend>>(spec),
+      : RNGBase<Backend, UniformDistribution<Backend>, false>(spec),
         values_("values", spec),
         range_("range", spec) {
     int size_dist = values_.IsDefined() ? sizeof(typename DistDiscrete<double>::type)
@@ -175,7 +175,7 @@ class UniformDistribution : public RNGBase<Backend, UniformDistribution<Backend>
 
   template <typename T>
   void RunImplTyped(workspace_t<Backend> &ws) {
-    using Base = RNGBase<Backend, UniformDistribution<Backend>>;
+    using Base = RNGBase<Backend, UniformDistribution<Backend>, false>;
     if (values_.IsDefined()) {
       using Dist = typename DistDiscrete<T>::type;
       Base::template RunImplTyped<T, Dist>(ws);
@@ -193,8 +193,8 @@ class UniformDistribution : public RNGBase<Backend, UniformDistribution<Backend>
 
  protected:
   using Operator<Backend>::max_batch_size_;
-  using RNGBase<Backend, UniformDistribution<Backend>>::dtype_;
-  using RNGBase<Backend, UniformDistribution<Backend>>::backend_data_;
+  using RNGBase<Backend, UniformDistribution<Backend>, false>::dtype_;
+  using RNGBase<Backend, UniformDistribution<Backend>, false>::backend_data_;
 
   ArgValue<float, 1> values_;
   ArgValue<float, 1> range_;
@@ -204,7 +204,6 @@ class UniformDistribution : public RNGBase<Backend, UniformDistribution<Backend>
   std::vector<const float*> per_sample_values_;
   std::vector<int64_t> per_sample_nvalues_;
 };
-
 
 }  // namespace dali
 

--- a/dali/test/python/test_operator_noise_gaussian.py
+++ b/dali/test/python/test_operator_noise_gaussian.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nvidia.dali import pipeline_def
+from nvidia.dali.backend_impl import TensorListGPU
+import nvidia.dali.ops as ops
+import nvidia.dali.fn as fn
+import nvidia.dali.types as types
+import random
+import numpy as np
+import os
+from test_utils import get_dali_extra_path, check_batch
+
+test_data_root = get_dali_extra_path()
+images_dir = os.path.join(test_data_root, 'db', 'single', 'jpeg')
+
+@pipeline_def
+def pipe_gaussian_noise(mean, stddev, variable_dist_params, device=None):
+    encoded, _ = fn.readers.file(file_root=images_dir)
+    in_data = fn.cast(
+        fn.decoders.image(encoded, device="cpu", output_type=types.RGB),
+        dtype = types.FLOAT
+    )
+    if device == 'gpu':
+        in_data = in_data.gpu()
+    mean_arg = mean
+    stddev_arg = stddev
+    if variable_dist_params:
+        mean_arg = fn.random.uniform(range=(-50.0, 50.0))
+        stddev_arg = fn.random.uniform(range=(1.0, 10.0))
+    seed = 12345
+    out_data1 = fn.noise.gaussian(in_data, mean=mean_arg, stddev=stddev_arg, seed=seed)
+    out_data2 = in_data + fn.random.normal(in_data, mean=mean_arg, stddev=stddev_arg, seed=seed)
+    return out_data1, out_data2
+
+def _testimpl_operator_noise_gaussian_vs_add_normal_dist(device, mean, stddev, variable_dist_params,
+                                                         batch_size, niter):
+    pipe = pipe_gaussian_noise(mean, stddev, variable_dist_params,
+                               device=device, batch_size=batch_size, num_threads=3, device_id=0)
+    pipe.build()
+    for _ in range(niter):
+        out0, out1 = pipe.run()
+        check_batch(out0, out1, batch_size=batch_size, eps=0.1)
+
+def test_operator_noise_gaussian_vs_add_normal_dist():
+    niter = 3
+    for device in ("cpu", "gpu"):
+        for batch_size in (1, 3):
+            for mean, stddev, variable_dist_params in [(10.0, 57.0, False), (0.0, 0.0, True)]:
+                yield _testimpl_operator_noise_gaussian_vs_add_normal_dist, \
+                    device, mean, stddev, variable_dist_params, batch_size, niter
+


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It reworks RNGBase class so that it can be used as a template for noise augmentations (applying random noise to an input) as well as the existing random generators (produces a random output, no input).

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Introduced a `NeedsInput` template argument to RNGBase to support a family of noise augmentation operators*.
     *Created a `fn.noise.gaussian` as an example. The output of `noise.gaussian(input, ...)` is tested by comparing to `input + random.normal(...)` *.
 - Affected modules and functionalities:
     *random.* operators*
 - Key points relevant for the review:
     *Design of RNGBase*
 - Validation and testing:
     *Python tests*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-1949]* *[DALI-1950]*
