### PR TITLE
Add more mathematical operations

### DIFF
--- a/dali/core/math_util_test.cc
+++ b/dali/core/math_util_test.cc
@@ -45,4 +45,60 @@ TEST(MathUtil, fast_rsqrtd) {
   EXPECT_NEAR(fast_rsqrt(16.0), 0.25, 0.25 * rel_err);
 }
 
+TEST(MathUtil, IpowAnyZero) {
+  EXPECT_EQ(ipow(100, 0), 1);
+  EXPECT_EQ(ipow(1, 0), 1);
+  EXPECT_EQ(ipow(0, 0), 1);
+  EXPECT_EQ(ipow(-1, 0), 1);
+  EXPECT_EQ(ipow(-100, 0), 1);
+}
+
+TEST(MathUtil, IpowAnyNeg) {
+  EXPECT_EQ(ipow(100, -1), 0);
+  EXPECT_EQ(ipow(1, -1), 0);
+  EXPECT_EQ(ipow(0, -1), 0);
+  EXPECT_EQ(ipow(-1, -1), 0);
+  EXPECT_EQ(ipow(-100, -1), 0);
+}
+
+TEST(MathUtil, IpowNeg) {
+  EXPECT_EQ(ipow(-1, -1), 0);
+  EXPECT_EQ(ipow(-1, 0), 1);
+  EXPECT_EQ(ipow(-1, 1), -1);
+  EXPECT_EQ(ipow(-1, 2), 1);
+  EXPECT_EQ(ipow(-1, 3), -1);
+  EXPECT_EQ(ipow(-1, 4), 1);
+}
+
+TEST(MathUtil, Ipow) {
+  EXPECT_EQ(ipow(2, 1), 2);
+  EXPECT_EQ(ipow(2, 2), 4);
+  EXPECT_EQ(ipow(2, 3), 8);
+  EXPECT_EQ(ipow(2, 4), 16);
+  EXPECT_EQ(ipow(2, 5), 32);
+  EXPECT_EQ(ipow(2, 6), 64);
+  EXPECT_EQ(ipow(2, 7), 128);
+  EXPECT_EQ(ipow(2, 8), 256);
+  EXPECT_EQ(ipow(2, 9), 512);
+  EXPECT_EQ(ipow(2, 10), 1024);
+  EXPECT_EQ(ipow(-2, 1), -2);
+  EXPECT_EQ(ipow(-2, 2), 4);
+  EXPECT_EQ(ipow(-2, 3), -8);
+  EXPECT_EQ(ipow(-2, 4), 16);
+  EXPECT_EQ(ipow(-2, 5), -32);
+  EXPECT_EQ(ipow(-2, 6), 64);
+  EXPECT_EQ(ipow(-2, 7), -128);
+  EXPECT_EQ(ipow(-2, 8), 256);
+  EXPECT_EQ(ipow(-2, 9), -512);
+  EXPECT_EQ(ipow(-2, 10), 1024);
+}
+
+TEST(MathUtil, IpowUnsigned) {
+  EXPECT_EQ(ipow(2, 0u), 1u);
+  EXPECT_EQ(ipow(2u, 0), 1u);
+  EXPECT_EQ(ipow(2u, 2), 4u);
+  EXPECT_EQ(ipow(2, 2u), 4u);
+  EXPECT_EQ(ipow(2u, 2u), 4u);
+}
+
 }  // namespace dali

--- a/dali/operators/math/expressions/arithmetic_meta.h
+++ b/dali/operators/math/expressions/arithmetic_meta.h
@@ -885,7 +885,7 @@ struct arithm_meta<ArithmeticOp::fdiv, Backend> {
   }
 
   static inline std::string to_string() {
-    return "/";
+    return "//";
   }
 
   static constexpr int num_inputs = 2;
@@ -971,8 +971,8 @@ inline std::string to_string(ArithmeticOp op) {
                 ArithmeticOp::acos, ArithmeticOp::atan, ArithmeticOp::sinh, ArithmeticOp::cosh,
                 ArithmeticOp::tanh, ArithmeticOp::asinh, ArithmeticOp::acosh, ArithmeticOp::atanh,
                 ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div,
-                ArithmeticOp::mod, ArithmeticOp::min, ArithmeticOp::max, ArithmeticOp::pow,
-                ArithmeticOp::fpow, ArithmeticOp::atan2,
+                ArithmeticOp::fdiv, ArithmeticOp::mod, ArithmeticOp::min, ArithmeticOp::max,
+                ArithmeticOp::pow, ArithmeticOp::fpow, ArithmeticOp::atan2,
                 ArithmeticOp::eq, ArithmeticOp::neq, ArithmeticOp::lt, ArithmeticOp::leq,
                 ArithmeticOp::gt, ArithmeticOp::geq,
                 ArithmeticOp::bit_and, ArithmeticOp::bit_or, ArithmeticOp::bit_xor,

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_abs.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_abs.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(abs);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_abs.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_abs.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(abs);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_acos.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_acos.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(acos);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_acos.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_acos.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(acos);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_acosh.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_acosh.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(acosh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_acosh.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_acosh.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(acosh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_add.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_add.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_add.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_add.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_asin.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_asin.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(asin);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_asin.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_asin.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(asin);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_asinh.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_asinh.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(asinh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_asinh.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_asinh.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(asinh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_atan.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_atan.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(atan);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_atan.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_atan.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(atan);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_atan2.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_atan2.cc
@@ -1,0 +1,25 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+
+IMPLEMENT_OP_FACTORY_CPU_BINARY(atan2);
+
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_atan2.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_atan2.cu
@@ -1,0 +1,26 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+
+IMPLEMENT_OP_FACTORY_GPU_BINARY(atan2);
+
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_atanh.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_atanh.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(atanh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_atanh.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_atanh.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(atanh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_and.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_and.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_and.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_and.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_or.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_or.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_or.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_or.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_xor.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_xor.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_xor.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_bit_xor.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,5 +20,4 @@
 namespace dali {
 
 IMPLEMENT_OP_FACTORY_GPU_BINARY(bit_xor);
-
 }  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_cbrt.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_cbrt.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(cbrt);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_cbrt.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_cbrt.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(cbrt);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_ceil.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_ceil.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(ceil);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_ceil.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_ceil.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(ceil);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_cos.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_cos.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(cos);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_cos.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_cos.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(cos);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_cosh.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_cosh.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(cosh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_cosh.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_cosh.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(cosh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_div.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_div.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_div.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_div.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_eq.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_eq.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_eq.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_eq.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_fabs.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_fabs.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(fabs);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_fabs.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_fabs.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(fabs);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_fdiv.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_fdiv.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_fdiv.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_fdiv.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_floor.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_floor.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(floor);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_floor.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_floor.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(floor);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_fpow.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_fpow.cc
@@ -1,0 +1,25 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+
+IMPLEMENT_OP_FACTORY_CPU_BINARY(fpow);
+
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_fpow.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_fpow.cu
@@ -1,0 +1,26 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+
+IMPLEMENT_OP_FACTORY_GPU_BINARY(fpow);
+
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_geq.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_geq.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_geq.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_geq.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_gt.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_gt.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_gt.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_gt.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_leq.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_leq.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_leq.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_leq.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_log10.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_log10.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(log10);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_log10.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_log10.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(log10);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_log2.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_log2.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(log2);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_log2.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_log2.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(log2);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_lt.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_lt.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_lt.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_lt.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_max.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_max.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_max.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_max.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_min.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_min.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_min.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_min.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_minus.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_minus.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_minus.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_minus.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_mod.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_mod.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_mod.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_mod.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_mul.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_mul.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_mul.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_mul.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_neq.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_neq.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_neq.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_neq.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_plus.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_plus.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_plus.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_plus.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_pow.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_pow.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_BINARY(pow);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_pow.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_pow.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_BINARY(pow);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_rsqrt.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_rsqrt.cc
@@ -1,0 +1,25 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(rsqrt);
+
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_rsqrt.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_rsqrt.cu
@@ -1,0 +1,26 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(rsqrt);
+
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_sin.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_sin.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(sin);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_sin.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_sin.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(sin);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_sinh.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_sinh.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(sinh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_sinh.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_sinh.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(sinh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_sqrt.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_sqrt.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(sqrt);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_sqrt.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_sqrt.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(sqrt);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_sub.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_sub.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_sub.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_sub.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_tan.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_tan.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(tan);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_tan.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_tan.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(tan);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_tanh.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_tanh.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_cpu.h"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_CPU_UNARY(tanh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_tanh.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_tanh.cu
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/core/static_switch.h"
+#include "dali/operators/math/expressions/arithmetic_meta.h"
+#include "dali/operators/math/expressions/expression_impl_gpu.cuh"
+#include "dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h"
+
+namespace dali {
+
+IMPLEMENT_OP_FACTORY_GPU_UNARY(tanh);
+
+}  // namespace dali

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_ternary.cc
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_ternary.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_factory_ternary.cu
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_factory_ternary.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h
@@ -190,13 +190,13 @@ std::unique_ptr<ExprImplBase> ExprImplFactoryTernaryOp(const ExprFunc &expr) {
 #define IMPLEMENT_OP_FACTORY_CPU_TERNARY(OP)                                                  \
   std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::OP, CPUBackend> op,       \
                                           const ExprFunc &expr) {                             \
-    return ExprImplFactoryTernaryOp<ArithmeticOp::OP, CPUBackend, ExprImplCpuTernary>(expr); \
+    return ExprImplFactoryTernaryOp<ArithmeticOp::OP, CPUBackend, ExprImplCpuTernary>(expr);  \
   }
 
 #define IMPLEMENT_OP_FACTORY_GPU_TERNARY(OP)                                                  \
   std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::OP, GPUBackend> op,       \
                                           const ExprFunc &expr) {                             \
-    return ExprImplFactoryTernaryOp<ArithmeticOp::OP, GPUBackend, ExprImplGpuTernary>(expr); \
+    return ExprImplFactoryTernaryOp<ArithmeticOp::OP, GPUBackend, ExprImplGpuTernary>(expr);  \
   }
 
 /**
@@ -216,6 +216,22 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::minus, CPUBack
                                         const ExprFunc &expr);
 
 /**
+ * @brief Factory function returning proper variant of implementation for `sqrt`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::sqrt, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `cbrt`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::cbrt, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
  * @brief Factory function returning proper variant of implementation for `exp`
  *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
  *        specified in `expr`.
@@ -224,12 +240,158 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::exp, CPUBacken
                                         const ExprFunc &expr);
 
 /**
-  * @brief Factory function returning proper variant of implementation for `log`
-  *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
-  *        specified in `expr`.
-  */
+ * @brief Factory function returning proper variant of implementation for `log`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
 std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::log, CPUBackend>,
                                         const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `log2`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::log2, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `log10`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::log10, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `abs`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::abs, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `fabs`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::fabs, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `floor`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::floor, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `ceil`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::ceil, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `sin`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::sin, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `cos`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::cos, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `tan`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::tan, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `asin`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::asin, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `acos`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::acos, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `atan`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::atan, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `sinh`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::sinh, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `cosh`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::cosh, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `tanh`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::tanh, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `asinh`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::asinh, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `acosh`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::acosh, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `atanh`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::atanh, CPUBackend>,
+                                        const ExprFunc &expr);
+
+
 
 /**
  * @brief Factory function returning proper variant of implementation for `add`
@@ -287,7 +449,6 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::mod, CPUBacken
 std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::min, CPUBackend>,
                                         const ExprFunc &expr);
 
-
 /**
  * @brief Factory function returning proper variant of implementation for `max`
  *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
@@ -296,6 +457,13 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::min, CPUBacken
 std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::max, CPUBackend>,
                                         const ExprFunc &expr);
 
+/**
+ * @brief Factory function returning proper variant of implementation for `pow`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::pow, CPUBackend>,
+                                        const ExprFunc &expr);
 
 /**
  * @brief Factory function returning proper variant of implementation for `eq`
@@ -397,6 +565,22 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::minus, GPUBack
                                         const ExprFunc &expr);
 
 /**
+ * @brief Factory function returning proper variant of implementation for `sqrt`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::sqrt, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `cbrt`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::cbrt, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
  * @brief Factory function returning proper variant of implementation for `exp`
  *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
  *        specified in `expr`.
@@ -405,12 +589,158 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::exp, GPUBacken
                                         const ExprFunc &expr);
 
 /**
-  * @brief Factory function returning proper variant of implementation for `log`
-  *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
-  *        specified in `expr`.
-  */
+ * @brief Factory function returning proper variant of implementation for `log`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
 std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::log, GPUBackend>,
                                         const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `log2`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::log2, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `log10`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::log10, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `abs`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::abs, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `fabs`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::fabs, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `floor`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::floor, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `ceil`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::ceil, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `sin`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::sin, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `cos`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::cos, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `tan`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::tan, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `asin`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::asin, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `acos`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::acos, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `atan`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::atan, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `sinh`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::sinh, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `cosh`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::cosh, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `tanh`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::tanh, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `asinh`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::asinh, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `acosh`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::acosh, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `atanh`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::atanh, GPUBackend>,
+                                        const ExprFunc &expr);
+
+
 
 /**
  * @brief Factory function returning proper variant of implementation for `add`
@@ -468,13 +798,20 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::mod, GPUBacken
 std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::min, GPUBackend>,
                                         const ExprFunc &expr);
 
-
 /**
  * @brief Factory function returning proper variant of implementation for `max`
  *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
  *        specified in `expr`.
  */
 std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::max, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `pow`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::pow, GPUBackend>,
                                         const ExprFunc &expr);
 
 /**
@@ -548,7 +885,6 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::bit_or, GPUBac
  */
 std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::bit_xor, GPUBackend>,
                                         const ExprFunc &expr);
-
 /**
  * @brief Factory function returning proper variant of implementation for `clamp`
  *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),

--- a/dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h
+++ b/dali/operators/math/expressions/expression_factory_instances/expression_impl_factory.h
@@ -224,6 +224,14 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::sqrt, CPUBacke
                                         const ExprFunc &expr);
 
 /**
+ * @brief Factory function returning proper variant of implementation for `rsqrt`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::rsqrt, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
  * @brief Factory function returning proper variant of implementation for `cbrt`
  *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
  *        specified in `expr`.
@@ -466,6 +474,22 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::pow, CPUBacken
                                         const ExprFunc &expr);
 
 /**
+ * @brief Factory function returning proper variant of implementation for `fpow`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::fpow, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `atan2`
+ *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::atan2, CPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
  * @brief Factory function returning proper variant of implementation for `eq`
  *        on CPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
  *        specified in `expr`.
@@ -570,6 +594,14 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::minus, GPUBack
  *        specified in `expr`.
  */
 std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::sqrt, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `rsqrt`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::rsqrt, GPUBackend>,
                                         const ExprFunc &expr);
 
 /**
@@ -812,6 +844,22 @@ std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::max, GPUBacken
  *        specified in `expr`.
  */
 std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::pow, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `fpow`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::fpow, GPUBackend>,
+                                        const ExprFunc &expr);
+
+/**
+ * @brief Factory function returning proper variant of implementation for `atan2`
+ *        on GPUBackend for supplied input types and input kinds (Scalar/Tensor inputs),
+ *        specified in `expr`.
+ */
+std::unique_ptr<ExprImplBase> OpFactory(arithm_meta<ArithmeticOp::atan2, GPUBackend>,
                                         const ExprFunc &expr);
 
 /**

--- a/dali/operators/math/expressions/expression_impl_factory.h
+++ b/dali/operators/math/expressions/expression_impl_factory.h
@@ -33,13 +33,18 @@
 
 namespace dali {
 
-#define ALLOWED_UN_OPS \
-  (ArithmeticOp::plus, ArithmeticOp::minus, ArithmeticOp::exp, ArithmeticOp::log)
+#define ALLOWED_UN_OPS                                                              \
+  (ArithmeticOp::plus, ArithmeticOp::minus, ArithmeticOp::exp, ArithmeticOp::sqrt,  \
+  ArithmeticOp::cbrt, ArithmeticOp::log, ArithmeticOp::log2, ArithmeticOp::log10,   \
+  ArithmeticOp::abs, ArithmeticOp::fabs, ArithmeticOp::floor, ArithmeticOp::ceil,   \
+  ArithmeticOp::sin, ArithmeticOp::cos, ArithmeticOp::tan, ArithmeticOp::asin,      \
+  ArithmeticOp::acos, ArithmeticOp::atan, ArithmeticOp::sinh, ArithmeticOp::cosh,   \
+  ArithmeticOp::tanh, ArithmeticOp::asinh, ArithmeticOp::acosh, ArithmeticOp::atanh)
 
 #define ALLOWED_BIN_OPS                                                                            \
   (ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div, ArithmeticOp::fdiv, \
-  ArithmeticOp::mod, ArithmeticOp::min, ArithmeticOp::max, ArithmeticOp::eq, ArithmeticOp::neq,    \
-  ArithmeticOp::lt, ArithmeticOp::leq, ArithmeticOp::gt, ArithmeticOp::geq,                        \
+  ArithmeticOp::mod, ArithmeticOp::min, ArithmeticOp::max, ArithmeticOp::pow, ArithmeticOp::eq,    \
+  ArithmeticOp::neq, ArithmeticOp::lt, ArithmeticOp::leq, ArithmeticOp::gt, ArithmeticOp::geq,     \
   ArithmeticOp::bit_and, ArithmeticOp::bit_or, ArithmeticOp::bit_xor)
 
 #define ALLOWED_TERNARY_OPS \

--- a/dali/operators/math/expressions/expression_impl_factory.h
+++ b/dali/operators/math/expressions/expression_impl_factory.h
@@ -33,19 +33,21 @@
 
 namespace dali {
 
-#define ALLOWED_UN_OPS                                                              \
-  (ArithmeticOp::plus, ArithmeticOp::minus, ArithmeticOp::exp, ArithmeticOp::sqrt,  \
-  ArithmeticOp::cbrt, ArithmeticOp::log, ArithmeticOp::log2, ArithmeticOp::log10,   \
-  ArithmeticOp::abs, ArithmeticOp::fabs, ArithmeticOp::floor, ArithmeticOp::ceil,   \
-  ArithmeticOp::sin, ArithmeticOp::cos, ArithmeticOp::tan, ArithmeticOp::asin,      \
-  ArithmeticOp::acos, ArithmeticOp::atan, ArithmeticOp::sinh, ArithmeticOp::cosh,   \
-  ArithmeticOp::tanh, ArithmeticOp::asinh, ArithmeticOp::acosh, ArithmeticOp::atanh)
+#define ALLOWED_UN_OPS                                                               \
+  (ArithmeticOp::plus, ArithmeticOp::minus, ArithmeticOp::exp, ArithmeticOp::sqrt,   \
+  ArithmeticOp::rsqrt, ArithmeticOp::cbrt, ArithmeticOp::log, ArithmeticOp::log2,    \
+  ArithmeticOp::log10, ArithmeticOp::abs, ArithmeticOp::fabs, ArithmeticOp::floor,   \
+  ArithmeticOp::ceil, ArithmeticOp::sin, ArithmeticOp::cos, ArithmeticOp::tan,       \
+  ArithmeticOp::asin, ArithmeticOp::acos, ArithmeticOp::atan, ArithmeticOp::sinh,    \
+  ArithmeticOp::cosh, ArithmeticOp::tanh, ArithmeticOp::asinh, ArithmeticOp::acosh,  \
+  ArithmeticOp::atanh)
 
 #define ALLOWED_BIN_OPS                                                                            \
   (ArithmeticOp::add, ArithmeticOp::sub, ArithmeticOp::mul, ArithmeticOp::div, ArithmeticOp::fdiv, \
-  ArithmeticOp::mod, ArithmeticOp::min, ArithmeticOp::max, ArithmeticOp::pow, ArithmeticOp::eq,    \
-  ArithmeticOp::neq, ArithmeticOp::lt, ArithmeticOp::leq, ArithmeticOp::gt, ArithmeticOp::geq,     \
-  ArithmeticOp::bit_and, ArithmeticOp::bit_or, ArithmeticOp::bit_xor)
+  ArithmeticOp::mod, ArithmeticOp::min, ArithmeticOp::max, ArithmeticOp::pow, ArithmeticOp::fpow,  \
+  ArithmeticOp::atan2, ArithmeticOp::eq, ArithmeticOp::neq, ArithmeticOp::lt, ArithmeticOp::leq,   \
+  ArithmeticOp::gt, ArithmeticOp::geq, ArithmeticOp::bit_and, ArithmeticOp::bit_or,                \
+  ArithmeticOp::bit_xor)
 
 #define ALLOWED_TERNARY_OPS \
   (ArithmeticOp::clamp)

--- a/dali/operators/math/expressions/math_overloads.h
+++ b/dali/operators/math/expressions/math_overloads.h
@@ -270,6 +270,15 @@ DALI_HOST_DEV inline auto math_pow(X x, Y y) {
 #endif
 }
 
+
+// DALI_NO_EXEC_CHECK
+// DALI_HOST_DEV inline int32_t math_pow(int32_t x, int32_t y) {
+
+// }
+
+
+
+
 }  // namespace dali
 
 #endif  // DALI_OPERATORS_MATH_EXPRESSIONS_MATH_OVERLOADS_H_

--- a/dali/operators/math/expressions/math_overloads.h
+++ b/dali/operators/math/expressions/math_overloads.h
@@ -1,0 +1,275 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_MATH_EXPRESSIONS_MATH_OVERLOADS_H_
+#define DALI_OPERATORS_MATH_EXPRESSIONS_MATH_OVERLOADS_H_
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "dali/core/cuda_utils.h"
+#include "dali/core/math_util.h"
+#include "dali/core/small_vector.h"
+#include "dali/core/static_switch.h"
+#include "dali/core/tensor_shape.h"
+#include "dali/pipeline/data/backend.h"
+#include "dali/pipeline/data/types.h"
+
+
+#ifdef __CUDA_ARCH__
+#include <cuda_runtime.h>
+#else
+#include <cmath>
+#endif
+
+namespace dali {
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_sqrt(T x) {
+#ifdef __CUDA_ARCH__
+  return sqrt(x);
+#else
+  return std::sqrt(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_cbrt(T x) {
+#ifdef __CUDA_ARCH__
+  return cbrt(x);
+#else
+  return std::cbrt(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_exp(T x) {
+#ifdef __CUDA_ARCH__
+  return exp(x);
+#else
+  return std::exp(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_log(T x) {
+#ifdef __CUDA_ARCH__
+  return log(x);
+#else
+  return std::log(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_log2(T x) {
+#ifdef __CUDA_ARCH__
+  return log2(x);
+#else
+  return std::log2(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_log10(T x) {
+#ifdef __CUDA_ARCH__
+  return log10(x);
+#else
+  return std::log10(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline std::enable_if_t<std::is_signed<T>::value, T> math_abs(T x) {
+  return x < 0 ? -x : x;
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline std::enable_if_t<!std::is_signed<T>::value, T> math_abs(T x) {
+  return x;
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_fabs(T x) {
+#ifdef __CUDA_ARCH__
+  return fabs(x);
+#else
+  return std::fabs(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_floor(T x) {
+#ifdef __CUDA_ARCH__
+  return floor(x);
+#else
+  return std::floor(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_ceil(T x) {
+#ifdef __CUDA_ARCH__
+  return ceil(x);
+#else
+  return std::ceil(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_sin(T x) {
+#ifdef __CUDA_ARCH__
+  return sin(x);
+#else
+  return std::sin(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_cos(T x) {
+#ifdef __CUDA_ARCH__
+  return cos(x);
+#else
+  return std::cos(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_tan(T x) {
+#ifdef __CUDA_ARCH__
+  return tan(x);
+#else
+  return std::tan(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_asin(T x) {
+#ifdef __CUDA_ARCH__
+  return asin(x);
+#else
+  return std::asin(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_acos(T x) {
+#ifdef __CUDA_ARCH__
+  return acos(x);
+#else
+  return std::acos(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_atan(T x) {
+#ifdef __CUDA_ARCH__
+  return atan(x);
+#else
+  return std::atan(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_sinh(T x) {
+#ifdef __CUDA_ARCH__
+  return sinh(x);
+#else
+  return std::sinh(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_cosh(T x) {
+#ifdef __CUDA_ARCH__
+  return cosh(x);
+#else
+  return std::cosh(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_tanh(T x) {
+#ifdef __CUDA_ARCH__
+  return tanh(x);
+#else
+  return std::tanh(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_asinh(T x) {
+#ifdef __CUDA_ARCH__
+  return asinh(x);
+#else
+  return std::asinh(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_acosh(T x) {
+#ifdef __CUDA_ARCH__
+  return acosh(x);
+#else
+  return std::acosh(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
+DALI_HOST_DEV inline T math_atanh(T x) {
+#ifdef __CUDA_ARCH__
+  return atanh(x);
+#else
+  return std::atanh(x);
+#endif
+}
+
+DALI_NO_EXEC_CHECK
+template <typename X, typename Y>
+DALI_HOST_DEV inline auto math_pow(X x, Y y) {
+#ifdef __CUDA_ARCH__
+  return pow(x, y);
+#else
+  return std::pow(x, y);
+#endif
+}
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_MATH_EXPRESSIONS_MATH_OVERLOADS_H_

--- a/dali/operators/math/expressions/math_overloads.h
+++ b/dali/operators/math/expressions/math_overloads.h
@@ -50,6 +50,12 @@ DALI_HOST_DEV inline T math_sqrt(T x) {
 
 DALI_NO_EXEC_CHECK
 template <typename T>
+DALI_HOST_DEV inline T math_rsqrt(T x) {
+  return rsqrt(x);
+}
+
+DALI_NO_EXEC_CHECK
+template <typename T>
 DALI_HOST_DEV inline T math_cbrt(T x) {
 #ifdef __CUDA_ARCH__
   return cbrt(x);
@@ -262,7 +268,9 @@ DALI_HOST_DEV inline T math_atanh(T x) {
 
 DALI_NO_EXEC_CHECK
 template <typename X, typename Y>
-DALI_HOST_DEV inline auto math_pow(X x, Y y) {
+DALI_HOST_DEV inline auto math_pow(
+    X x, Y y,
+    std::enable_if_t<!std::is_integral<X>::value || !std::is_integral<Y>::value>* = nullptr) {
 #ifdef __CUDA_ARCH__
   return pow(x, y);
 #else
@@ -270,13 +278,23 @@ DALI_HOST_DEV inline auto math_pow(X x, Y y) {
 #endif
 }
 
+DALI_NO_EXEC_CHECK
+template <typename X, typename Y>
+DALI_HOST_DEV std::enable_if_t<std::is_integral<X>::value && std::is_integral<Y>::value,
+                               decltype(std::declval<X>() * std::declval<Y>())>
+math_pow(X x, Y y) {
+  return ipow(x, y);
+}
 
-// DALI_NO_EXEC_CHECK
-// DALI_HOST_DEV inline int32_t math_pow(int32_t x, int32_t y) {
-
-// }
-
-
+DALI_NO_EXEC_CHECK
+template <typename X, typename Y>
+DALI_HOST_DEV inline auto math_atan2(X x, Y y) {
+#ifdef __CUDA_ARCH__
+  return atan2(x, y);
+#else
+  return std::atan2(x, y);
+#endif
+}
 
 
 }  // namespace dali

--- a/dali/operators/math/expressions/math_overloads.h
+++ b/dali/operators/math/expressions/math_overloads.h
@@ -281,9 +281,20 @@ DALI_HOST_DEV inline auto math_pow(
 DALI_NO_EXEC_CHECK
 template <typename X, typename Y>
 DALI_HOST_DEV std::enable_if_t<std::is_integral<X>::value && std::is_integral<Y>::value,
-                               decltype(std::declval<X>() * std::declval<Y>())>
+                               decltype(std::declval<X>() * std::declval<X>())>
 math_pow(X x, Y y) {
   return ipow(x, y);
+}
+
+// Template special case
+DALI_NO_EXEC_CHECK
+template <typename X>
+DALI_HOST_DEV std::enable_if_t<std::is_integral<X>::value, X>
+math_pow(X x, bool y) {
+  if (y) {
+    return x;
+  }
+  return 1;
 }
 
 DALI_NO_EXEC_CHECK

--- a/dali/python/nvidia/dali/data_node.py
+++ b/dali/python/nvidia/dali/data_node.py
@@ -59,6 +59,11 @@ class DataNode(object):
     def __rmul__(self, other):
         return _arithm_op("mul", other, self)
 
+    def __pow__(self, other):
+        return _arithm_op("pow", self, other)
+    def __rpow__(self, other):
+        return _arithm_op("pow", other, self)
+
     def __truediv__(self, other):
         return _arithm_op("fdiv", self, other)
     def __rtruediv__(self, other):

--- a/dali/python/nvidia/dali/math.py
+++ b/dali/python/nvidia/dali/math.py
@@ -235,12 +235,12 @@ def fpow(base, exponent):
     return _arithm_op("fpow", base, exponent)
 
 def atan2(x, y):
-    """Computes arcus tangent of x / y.
+    """Computes arcus tangent of corresponding values in  x / y.
 
     :rtype: TensorList of atan2(x, y). If all inputs are integers, the result will be float,
             otherwise the type is preserved.
     """
-    return _arithm_op("atan2", base, exponent)
+    return _arithm_op("atan2", x, y)
 
 def clamp(value, lo, hi):
     """Produces a tensor of values from ``value`` clamped to the range ``[lo, hi]``.

--- a/dali/python/nvidia/dali/math.py
+++ b/dali/python/nvidia/dali/math.py
@@ -23,158 +23,224 @@ def _arithm_op(*args, **kwargs):
 
 
 def sqrt(input):
-    """Fills the output with square root of the input.
-    :rtype: TensorList of sqrt(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes square root of values in ``input``.
+
+    :rtype: TensorList of sqrt(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("sqrt", input)
 
+def rsqrt(input):
+    """Computes reciprocal of the square root of values in ``input``.
+
+    :rtype: TensorList of rsqrt(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
+    """
+    return _arithm_op("rsqrt", input)
+
 def cbrt(input):
-    """Fills the output with cube root of the input.
-    :rtype: TensorList of cbrt(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes cube root of values in ``input``.
+
+    :rtype: TensorList of cbrt(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("cbrt", input)
 
 def exp(input):
-    """Fills the output with exponential of the input.
-    :rtype: TensorList of exp(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes exponential of values in ``input``.
+
+    :rtype: TensorList of exp(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("exp", input)
 
 def log(input):
-    """Fills the output with natural logarithm (base-e) of the input.
-    :rtype: TensorList of log(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes natural logarithm (base-e) of values in ``input``.
+
+    :rtype: TensorList of log(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("log", input)
 
 def log2(input):
-    """Fills the output with logarithm (base-2) of the input.
-    :rtype: TensorList of log2(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes logarithm (base-2) of values in ``input``.
+
+    :rtype: TensorList of log2(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("log2", input)
 
 def log10(input):
-    """Fills the output with logarithm (base-10) of the input.
-    :rtype: TensorList of log10(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes logarithm (base-10) of values in ``input``.
+
+    :rtype: TensorList of log10(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("log10", input)
 
 def abs(input):
-    """Fills the output with absolute value of the input.
+    """Computes absolute value of values in ``input``.
+
     :rtype: TensorList of abs(input). The type is preserved.
     """
     return _arithm_op("abs", input)
 
 def fabs(input):
-    """Fills the output with float absolute value of the input.
-    :rtype: TensorList of fabs(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes float absolute value of values in ``input``.
+
+    :rtype: TensorList of fabs(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("fabs", input)
 
 def floor(input):
-    """Fills the output with floor of the input.
-    :rtype: TensorList of floor(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes floor of values in ``input``.
+
+    :rtype: TensorList of floor(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("floor", input)
 
 def ceil(input):
-    """Fills the output with ceil of the input.
-    :rtype: TensorList of ceil(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes ceil of values in ``input``.
+
+    :rtype: TensorList of ceil(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("ceil", input)
 
 def sin(input):
-    """Fills the output with sine of the input.
-    :rtype: TensorList of sin(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes sine of values in ``input``.
+
+    :rtype: TensorList of sin(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("sin", input)
 
 def cos(input):
-    """Fills the output with cosine of the input.
-    :rtype: TensorList of cos(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes cosine of values in ``input``.
+
+    :rtype: TensorList of cos(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("cos", input)
 
 def tan(input):
-    """Fills the output with tangent of the input.
-    :rtype: TensorList of tan(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes tangent of values in ``input``.
+
+    :rtype: TensorList of tan(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("tan", input)
 
 def asin(input):
-    """Fills the output with arcus sine of the input.
-    :rtype: TensorList of asin(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes arcus sine of values in ``input``.
+
+    :rtype: TensorList of asin(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("asin", input)
 
 def acos(input):
-    """Fills the output with arcus cosine of the input.
-    :rtype: TensorList of acos(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes arcus cosine of values in ``input``.
+
+    :rtype: TensorList of acos(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("acos", input)
 
 def atan(input):
-    """Fills the output with arcus tangent of the input.
-    :rtype: TensorList of atan(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes arcus tangent of values in ``input``.
+
+    :rtype: TensorList of atan(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("atan", input)
 
 def sinh(input):
-    """Fills the output with hyperbolic sine of the input.
-    :rtype: TensorList of sinh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes hyperbolic sine of values in ``input``.
+
+    :rtype: TensorList of sinh(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("sinh", input)
 
 def cosh(input):
-    """Fills the output with hyperbolic cosine of the input.
-    :rtype: TensorList of cosh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes hyperbolic cosine of values in ``input``.
+
+    :rtype: TensorList of cosh(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("cosh", input)
 
 def tanh(input):
-    """Fills the output with hyperbolic tangent of the input.
-    :rtype: TensorList of tanh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes hyperbolic tangent of values in ``input``.
+
+    :rtype: TensorList of tanh(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("tanh", input)
 
 def asinh(input):
-    """Fills the output with inverse hyperbolic sine of the input.
-    :rtype: TensorList of asinh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes inverse hyperbolic sine of values in ``input``.
+
+    :rtype: TensorList of asinh(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("asinh", input)
 
 def acosh(input):
-    """Fills the output with inverse hyperbolic cosine of the input.
-    :rtype: TensorList of acosh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes inverse hyperbolic cosine of values in ``input``.
+
+    :rtype: TensorList of acosh(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("acosh", input)
 
 def atanh(input):
-    """Fills the output with inverse hyperbolic tangent of the input.
-    :rtype: TensorList of atanh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """Computes inverse hyperbolic tangent of values in ``input``.
+
+    :rtype: TensorList of atanh(input). If input is an integer, the result will be float,
+            otherwise the type is preserved.
     """
     return _arithm_op("atanh", input)
 
 def min(left, right):
-    """Fills the output with minima of corresponding inputs in ``left`` and ``right``.
+    """Computes minima of corresponding values in ``left`` and ``right``.
 
     :rtype: TensorList of the type that is calculated based on the type promotion rules.
     """
     return _arithm_op("min", left, right)
 
 def max(left, right):
-    """Fills the output with maxima of corresponding inputs in ``left`` and ``right``.
+    """Computes maxima of corresponding values in ``left`` and ``right``.
 
     :rtype: TensorList of the type that is calculated based on the type promotion rules.
     """
     return _arithm_op("max", left, right)
 
 def pow(base, exponent):
-    """Fills the output with base to the power of exponents, that is base ** exponent.
+    """Computes base to the power of exponents, that is base ** exponent.
 
-    :rtype: TensorList of pow(base, exponent). If input is an integer, the result will be float, otherwise the type is preserved.
+    :rtype: TensorList of pow(base, exponent). Type is calculated based on the type promotion rules.
     """
     return _arithm_op("pow", base, exponent)
 
+def fpow(base, exponent):
+    """Computes base to the power of exponents, that is base ** exponent.
+
+    :rtype: TensorList of pow(base, exponent). If all inputs are integers, the result will be float,
+            otherwise the type is preserved.
+    """
+    return _arithm_op("fpow", base, exponent)
+
+def atan2(x, y):
+    """Computes arcus tangent of x / y.
+
+    :rtype: TensorList of atan2(x, y). If all inputs are integers, the result will be float,
+            otherwise the type is preserved.
+    """
+    return _arithm_op("atan2", base, exponent)
 
 def clamp(value, lo, hi):
     """Produces a tensor of values from ``value`` clamped to the range ``[lo, hi]``.

--- a/dali/python/nvidia/dali/math.py
+++ b/dali/python/nvidia/dali/math.py
@@ -21,31 +21,160 @@ def _arithm_op(*args, **kwargs):
     setattr(sys.modules[__name__], "_arithm_op", nvidia.dali.ops._arithm_op)
     return nvidia.dali.ops._arithm_op(*args, **kwargs)
 
-def exp(value):
-    """Fills the output with exponential of value.
-    :rtype: TensorList of exp(value). If value is an integer, the result will be float, otherwise the type is preserved.
-    """
-    return _arithm_op("exp", value)
 
-def log(value):
-    """Fills the output with logarithm (base-10) of value.
-    :rtype: TensorList of log(value). If value is an integer, the result will be float, otherwise the type is preserved.
+def sqrt(input):
+    """Fills the output with square root of the input.
+    :rtype: TensorList of sqrt(input). If input is an integer, the result will be float, otherwise the type is preserved.
     """
-    return _arithm_op("log", value)
+    return _arithm_op("sqrt", input)
+
+def cbrt(input):
+    """Fills the output with cube root of the input.
+    :rtype: TensorList of cbrt(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("cbrt", input)
+
+def exp(input):
+    """Fills the output with exponential of the input.
+    :rtype: TensorList of exp(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("exp", input)
+
+def log(input):
+    """Fills the output with natural logarithm (base-e) of the input.
+    :rtype: TensorList of log(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("log", input)
+
+def log2(input):
+    """Fills the output with logarithm (base-2) of the input.
+    :rtype: TensorList of log2(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("log2", input)
+
+def log10(input):
+    """Fills the output with logarithm (base-10) of the input.
+    :rtype: TensorList of log10(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("log10", input)
+
+def abs(input):
+    """Fills the output with absolute value of the input.
+    :rtype: TensorList of abs(input). The type is preserved.
+    """
+    return _arithm_op("abs", input)
+
+def fabs(input):
+    """Fills the output with float absolute value of the input.
+    :rtype: TensorList of fabs(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("fabs", input)
+
+def floor(input):
+    """Fills the output with floor of the input.
+    :rtype: TensorList of floor(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("floor", input)
+
+def ceil(input):
+    """Fills the output with ceil of the input.
+    :rtype: TensorList of ceil(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("ceil", input)
+
+def sin(input):
+    """Fills the output with sine of the input.
+    :rtype: TensorList of sin(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("sin", input)
+
+def cos(input):
+    """Fills the output with cosine of the input.
+    :rtype: TensorList of cos(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("cos", input)
+
+def tan(input):
+    """Fills the output with tangent of the input.
+    :rtype: TensorList of tan(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("tan", input)
+
+def asin(input):
+    """Fills the output with arcus sine of the input.
+    :rtype: TensorList of asin(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("asin", input)
+
+def acos(input):
+    """Fills the output with arcus cosine of the input.
+    :rtype: TensorList of acos(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("acos", input)
+
+def atan(input):
+    """Fills the output with arcus tangent of the input.
+    :rtype: TensorList of atan(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("atan", input)
+
+def sinh(input):
+    """Fills the output with hyperbolic sine of the input.
+    :rtype: TensorList of sinh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("sinh", input)
+
+def cosh(input):
+    """Fills the output with hyperbolic cosine of the input.
+    :rtype: TensorList of cosh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("cosh", input)
+
+def tanh(input):
+    """Fills the output with hyperbolic tangent of the input.
+    :rtype: TensorList of tanh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("tanh", input)
+
+def asinh(input):
+    """Fills the output with inverse hyperbolic sine of the input.
+    :rtype: TensorList of asinh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("asinh", input)
+
+def acosh(input):
+    """Fills the output with inverse hyperbolic cosine of the input.
+    :rtype: TensorList of acosh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("acosh", input)
+
+def atanh(input):
+    """Fills the output with inverse hyperbolic tangent of the input.
+    :rtype: TensorList of atanh(input). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("atanh", input)
 
 def min(left, right):
-    """Fills the output with minima of corresponding values in ``left`` and ``right``.
+    """Fills the output with minima of corresponding inputs in ``left`` and ``right``.
 
     :rtype: TensorList of the type that is calculated based on the type promotion rules.
     """
     return _arithm_op("min", left, right)
 
 def max(left, right):
-    """Fills the output with maxima of corresponding values in ``left`` and ``right``.
+    """Fills the output with maxima of corresponding inputs in ``left`` and ``right``.
 
     :rtype: TensorList of the type that is calculated based on the type promotion rules.
     """
     return _arithm_op("max", left, right)
+
+def pow(base, exponent):
+    """Fills the output with base to the power of exponents, that is base ** exponent.
+
+    :rtype: TensorList of pow(base, exponent). If input is an integer, the result will be float, otherwise the type is preserved.
+    """
+    return _arithm_op("pow", base, exponent)
+
 
 def clamp(value, lo, hi):
     """Produces a tensor of values from ``value`` clamped to the range ``[lo, hi]``.

--- a/dali/python/nvidia/dali/math.py
+++ b/dali/python/nvidia/dali/math.py
@@ -227,7 +227,7 @@ def pow(base, exponent):
     return _arithm_op("pow", base, exponent)
 
 def fpow(base, exponent):
-    """Computes base to the power of exponents, that is base ** exponent.
+    """Computes base to the power of exponents as floating point numbers.
 
     :rtype: TensorList of pow(base, exponent). If all inputs are integers, the result will be float,
             otherwise the type is preserved.

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -661,9 +661,13 @@ def check_raises_te(kinds, types, op, shape, _):
 
 # Arithmetic operations between booleans that are not allowed
 bool_disallowed = [((lambda x, y: x + y), "+"), ((lambda x, y: x - y), "-"),
-                   ((lambda x, y: x / y), "/"), ((lambda x, y: x / y), "//")]
+                   ((lambda x, y: x / y), "/"), ((lambda x, y: x / y), "//"),
+                   ((lambda x, y: x ** y), "**")]
 
 def test_bool_disallowed():
+    for kinds in unary_input_kinds:
+        for (op, np_op, op_desc, _) in math_function_operations:
+            yield check_raises_re, kinds, np.bool_, op, shape_small, op_desc
     for kinds in bin_input_kinds:
         for (op, op_desc) in bool_disallowed:
             yield check_raises_re, kinds, (np.bool_, np.bool_), op, shape_small, op_desc

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -81,11 +81,33 @@ bench_ternary_input_kinds = [("cpu", "cpu", "cpu"), ("gpu", "gpu", "gpu"),
 
 unary_operations = [((lambda x: +x), "+"), ((lambda x: -x), "-")]
 
-math_function_operations = [((lambda x: math.exp(x)), (lambda x: np.exp(x)), "exp"),
-                            ((lambda x: math.log(x)), (lambda x: np.log(x)), "log")]
+math_function_operations = [
+    ((lambda x: math.sqrt(x)), (lambda x: np.sqrt(x)), "sqrt"),
+    ((lambda x: math.cbrt(x)), (lambda x: np.cbrt(x)), "cbrt"),
+    ((lambda x: math.exp(x)), (lambda x: np.exp(x)), "exp"),
+    ((lambda x: math.log(x)), (lambda x: np.log(x)), "log"),
+    ((lambda x: math.log2(x)), (lambda x: np.log2(x)), "log2"),
+    ((lambda x: math.log10(x)), (lambda x: np.log10(x)), "log10"),
+    ((lambda x: math.fabs(x)), (lambda x: np.fabs(x)), "fabs"),
+    ((lambda x: math.floor(x)), (lambda x: np.floor(x)), "floor"),
+    ((lambda x: math.ceil(x)), (lambda x: np.ceil(x)), "ceil"),
+    ((lambda x: math.sin(x)), (lambda x: np.sin(x)), "sin"),
+    ((lambda x: math.cos(x)), (lambda x: np.cos(x)), "cos"),
+    ((lambda x: math.tan(x)), (lambda x: np.tan(x)), "tan"),
+    ((lambda x: math.asin(x)), (lambda x: np.arcsin(x)), "asin"),
+    ((lambda x: math.acos(x)), (lambda x: np.arccos(x)), "acos"),
+    ((lambda x: math.atan(x)), (lambda x: np.arctan(x)), "atan"),
+    ((lambda x: math.sinh(x)), (lambda x: np.sinh(x)), "sinh"),
+    ((lambda x: math.cosh(x)), (lambda x: np.cosh(x)), "cosh"),
+    ((lambda x: math.tanh(x)), (lambda x: np.tanh(x)), "tanh"),
+    ((lambda x: math.asinh(x)), (lambda x: np.arcsinh(x)), "asinh"),
+    ((lambda x: math.acosh(x)), (lambda x: np.arccosh(x)), "acosh"),
+    ((lambda x: math.atanh(x)), (lambda x: np.arctanh(x)), "atanh")]
 
 sane_operations = [((lambda x, y: x + y), "+"), ((lambda x, y: x - y), "-"),
                    ((lambda x, y: x * y), "*"),
+                   (((lambda x, y: x ** y), (lambda x, y: np.float(x) ** y)), "**"),
+                   (((lambda x, y: math.pow(x, y)), (lambda x, y: np.pow(np.float(x), y))), "pow"),
                    (((lambda x, y: math.min(x, y)), (lambda x, y: np.minimum(x, y))), "min"),
                    (((lambda x, y: math.max(x, y)), (lambda x, y: np.maximum(x, y))), "max")]
 

--- a/dali/test/python/test_operator_arithmetic_ops.py
+++ b/dali/test/python/test_operator_arithmetic_ops.py
@@ -39,7 +39,7 @@ shape_big = [(1024, 1024)] * batch_size
 shape_small = [(42, 3), (4, 16), (8, 2), (1, 64)]
 
 # A number used to test constant inputs
-magic_number = 42
+magic_number = 7
 
 unary_input_kinds = ["cpu", "gpu", "cpu_scalar", "gpu_scalar", "cpu_scalar_legacy", "gpu_scalar_legacy"]
 
@@ -141,9 +141,8 @@ sane_operations = [((lambda x, y: x + y), "+", default_range),
                    (((lambda x, y: math.max(x, y)), (lambda x, y: np.maximum(x, y))), "max", default_range)]
 
 floaty_operations = [(((lambda x, y: x / y), (lambda x, y: x / y)), "/", default_range),
-                     (((lambda x, y: math.fpow(x, y)), sane_pow), "fpow", pow_range)]
-                    #  (((lambda x, y: x ** y), (lambda x, y: x ** y)), "**"),
-                    #  (((lambda x, y: math.pow(x, y)), (lambda x, y: np.pow(x, y))), "pow")]
+                     (((lambda x, y: math.fpow(x, y)), sane_pow), "fpow", pow_range),
+                     (((lambda x, y: math.atan2(x, y)), (lambda x, y: np.arctan2(x, y))), "atan2", default_range)]
 
 bitwise_operations = [((lambda x, y: x & y), "&"), ((lambda x, y: x | y), "|"),
                       ((lambda x, y: x ^ y), "^")]

--- a/docs/math.rst
+++ b/docs/math.rst
@@ -69,10 +69,10 @@ Currently, DALI supports the following operations:
 
     :rtype: TensorList of the same type
 
-.. function:: Binary arithmetic operations: +, -, *, /, //
+.. function:: Binary arithmetic operations: +, -, *, /, //, **
 
-    Binary operators that implement ``__add__``, ``__sub__``, ``__mul__``, ``__truediv__``
-    and ``__floordiv__`` respectively.
+    Binary operators that implement ``__add__``, ``__sub__``, ``__mul__``, ``__truediv__``,
+    ``__floordiv__`` and ``__pow__`` respectively.
 
     The result of an arithmetic operation between two operands is described
     :ref:`above <type promotions>`, with the exception of ``/``, the ``__truediv__`` operation,
@@ -110,5 +110,44 @@ graph definition. They also accept :class:`nvidia.dali.pipeline.DataNode`,
 :meth:`nvidia.dali.types.Constant` or regular Python value of type ``bool``, ``int``, or ``float``
 as arguments. At least one of the inputs must be the output of other DALI Operator.
 
-.. automodule:: nvidia.dali.math
-   :members:
+.. autofunction:: nvidia.dali.math.abs
+.. autofunction:: nvidia.dali.math.fabs
+.. autofunction:: nvidia.dali.math.floor
+.. autofunction:: nvidia.dali.math.ceil
+.. autofunction:: nvidia.dali.math.pow
+.. autofunction:: nvidia.dali.math.fpow
+.. autofunction:: nvidia.dali.math.min
+.. autofunction:: nvidia.dali.math.max
+.. autofunction:: nvidia.dali.math.clamp
+
+Exponents and logarithms
+========================
+
+.. autofunction:: nvidia.dali.math.sqrt
+.. autofunction:: nvidia.dali.math.rsqrt
+.. autofunction:: nvidia.dali.math.cbrt
+.. autofunction:: nvidia.dali.math.exp
+.. autofunction:: nvidia.dali.math.log
+.. autofunction:: nvidia.dali.math.log2
+.. autofunction:: nvidia.dali.math.log10
+
+Trigonometric Functions
+=======================
+
+.. autofunction:: nvidia.dali.math.sin
+.. autofunction:: nvidia.dali.math.cos
+.. autofunction:: nvidia.dali.math.tan
+.. autofunction:: nvidia.dali.math.asin
+.. autofunction:: nvidia.dali.math.acos
+.. autofunction:: nvidia.dali.math.atan
+.. autofunction:: nvidia.dali.math.atan2
+
+Hyperbolic Functions
+=======================
+
+.. autofunction:: nvidia.dali.math.sinh
+.. autofunction:: nvidia.dali.math.cosh
+.. autofunction:: nvidia.dali.math.tanh
+.. autofunction:: nvidia.dali.math.asinh
+.. autofunction:: nvidia.dali.math.acosh
+.. autofunction:: nvidia.dali.math.atanh

--- a/include/dali/core/math_util.h
+++ b/include/dali/core/math_util.h
@@ -195,7 +195,9 @@ float sinc(float x) {
 /// @brief Calculates power for integer arguments
 template <typename X, typename Y>
 DALI_HOST_DEV DALI_FORCEINLINE
-std::enable_if_t<std::is_integral<X>::value && std::is_integral<Y>::value, decltype(std::declval<X>() * std::declval<Y>())> ipow(X x, Y y) {
+std::enable_if_t<std::is_integral<X>::value && std::is_integral<Y>::value,
+                  decltype(std::declval<X>() * std::declval<Y>())>
+ipow(X x, Y y) {
   decltype(std::declval<X>() * std::declval<Y>()) acc = 1;
   decltype(std::declval<X>() * std::declval<Y>()) pow_acc = x;
   if (y < 0) {
@@ -210,7 +212,6 @@ std::enable_if_t<std::is_integral<X>::value && std::is_integral<Y>::value, declt
   }
   return acc;
 }
-
 
 
 }  // namespace dali

--- a/include/dali/core/math_util.h
+++ b/include/dali/core/math_util.h
@@ -195,8 +195,27 @@ float sinc(float x) {
 /// @brief Calculates power for integer arguments
 template <typename X, typename Y>
 DALI_HOST_DEV DALI_FORCEINLINE
-std::enable_if_t<std::is_integral<X>::value && std::is_integral<Y>::value,
+std::enable_if_t<std::is_integral<X>::value && std::is_unsigned<Y>::value,
                   decltype(std::declval<X>() * std::declval<Y>())>
+ipow(X x, Y y) {
+  decltype(std::declval<X>() * std::declval<Y>()) acc = 1;
+  decltype(std::declval<X>() * std::declval<Y>()) pow_acc = x;
+  while (y > 0) {
+    if (y & 1) {
+      acc *= pow_acc;
+    }
+    pow_acc *= pow_acc;
+    y = y >> 1;
+  }
+  return acc;
+}
+
+/// @brief Calculates power for integer arguments
+template <typename X, typename Y>
+DALI_HOST_DEV DALI_FORCEINLINE
+std::enable_if_t<
+    std::is_integral<X>::value && std::is_integral<Y>::value && std::is_signed<Y>::value,
+    decltype(std::declval<X>() * std::declval<Y>())>
 ipow(X x, Y y) {
   decltype(std::declval<X>() * std::declval<Y>()) acc = 1;
   decltype(std::declval<X>() * std::declval<Y>()) pow_acc = x;

--- a/include/dali/core/math_util.h
+++ b/include/dali/core/math_util.h
@@ -192,6 +192,26 @@ float sinc(float x) {
   return std::sin(x) / x;
 }
 
+/// @brief Calculates power for integer arguments
+template <typename X, typename Y>
+DALI_HOST_DEV DALI_FORCEINLINE
+std::enable_if_t<std::is_integral<X>::value && std::is_integral<Y>::value, decltype(std::declval<X>() * std::declval<Y>())> ipow(X x, Y y) {
+  decltype(std::declval<X>() * std::declval<Y>()) acc = 1;
+  decltype(std::declval<X>() * std::declval<Y>()) pow_acc = x;
+  if (y < 0) {
+    return 0;
+  }
+  while (y > 0) {
+    if (y & 1) {
+      acc *= pow_acc;
+    }
+    pow_acc *= pow_acc;
+    y = y >> 1;
+  }
+  return acc;
+}
+
+
 
 }  // namespace dali
 

--- a/include/dali/core/math_util.h
+++ b/include/dali/core/math_util.h
@@ -195,31 +195,12 @@ float sinc(float x) {
 /// @brief Calculates power for integer arguments
 template <typename X, typename Y>
 DALI_HOST_DEV DALI_FORCEINLINE
-std::enable_if_t<std::is_integral<X>::value && std::is_unsigned<Y>::value,
-                  decltype(std::declval<X>() * std::declval<Y>())>
+std::enable_if_t<std::is_integral<X>::value && std::is_integral<Y>::value,
+                  decltype(std::declval<X>() * std::declval<X>())>
 ipow(X x, Y y) {
-  decltype(std::declval<X>() * std::declval<Y>()) acc = 1;
-  decltype(std::declval<X>() * std::declval<Y>()) pow_acc = x;
-  while (y > 0) {
-    if (y & 1) {
-      acc *= pow_acc;
-    }
-    pow_acc *= pow_acc;
-    y = y >> 1;
-  }
-  return acc;
-}
-
-/// @brief Calculates power for integer arguments
-template <typename X, typename Y>
-DALI_HOST_DEV DALI_FORCEINLINE
-std::enable_if_t<
-    std::is_integral<X>::value && std::is_integral<Y>::value && std::is_signed<Y>::value,
-    decltype(std::declval<X>() * std::declval<Y>())>
-ipow(X x, Y y) {
-  decltype(std::declval<X>() * std::declval<Y>()) acc = 1;
-  decltype(std::declval<X>() * std::declval<Y>()) pow_acc = x;
-  if (y < 0) {
+  decltype(std::declval<X>() * std::declval<X>()) acc = 1;
+  decltype(std::declval<X>() * std::declval<X>()) pow_acc = x;
+  if (std::is_signed<Y>::value && std::make_signed_t<Y>(y) < 0) {
     return 0;
   }
   while (y > 0) {
@@ -231,7 +212,6 @@ ipow(X x, Y y) {
   }
   return acc;
 }
-
 
 }  // namespace dali
 


### PR DESCRIPTION
* sqrt, cbrt, logs of different bases,
* abs and fabs, floor and ceil,
* trig functions
* pow (both function and __pow__ operator)

TODO:

- [x] decide on pow semantics: C++ like or Python like - behaviour for integers, adjust tests. 
- [x] make the ranges for inverse trig functions fit the domain / adjust math function test range.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Adds more mathematical operations.


#### What happened in this PR?
 - What solution was applied:
     Mostly do the same what what was already done for log, exp, etc.
     Generate boilerplate.
 - Affected modules and functionalities:
     Arithm Ops
 - Key points relevant for the review:
     Abs and pow.
 - Validation and testing:
     Test extended. It will be long. How to trim it?
 - Documentation (including examples):
     Docs adjusted.


**JIRA TASK**: *[DALI-1055]*
