### PR TITLE
Better error handling in pipeline.py

### DIFF
--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1021,8 +1021,8 @@ Parameters
         if define_graph is not None and not callable(define_graph):
             raise TypeError(
                 "Provided `define_graph` argument is not callable." +
-                " Didn't you want to write `.serialize(filename=...)`?"
-                if isinstance(define_graph, str) else "")
+                (" Didn't you want to write `.serialize(filename=...)`?"
+                if isinstance(define_graph, str) else ""))
         if not self._py_graph_built:
             self._build_graph(define_graph)
         if not self._backend_prepared:

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1018,6 +1018,11 @@ Parameters
         kwargs : dict
                 Refer to Pipeline constructor for full list of arguments.
         """
+        if define_graph is not None and not callable(define_graph):
+            raise TypeError(
+                "Provided `define_graph` argument is not callable." +
+                " Didn't you want to write `.serialize(filename=...)`?"
+                if isinstance(define_graph, str) else "")
         if not self._py_graph_built:
             self._build_graph(define_graph)
         if not self._backend_prepared:

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -19,6 +19,7 @@ import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 import nvidia.dali.tfrecord as tfrec
 import nvidia.dali as dali
+from nvidia.dali import pipeline_def
 from nvidia.dali.backend_impl import TensorListGPU
 from timeit import default_timer as timer
 import numpy as np
@@ -1785,11 +1786,28 @@ def test_properties():
         assert pipe.exec_async == True
         assert pipe.set_affinity == True
         assert pipe.max_streams == -1
-        assert pipe.prefetch_queue_depth == {"cpu_size":3, "gpu_size":2}
+        assert pipe.prefetch_queue_depth == {"cpu_size": 3, "gpu_size": 2}
         assert pipe.cpu_queue_size == 3
         assert pipe.gpu_queue_size == 2
         assert pipe.py_num_workers == 3
         assert pipe.py_start_method == "fork"
         assert pipe.enable_memory_stats == False
-        return np.float32([1,2,3])
+        return np.float32([1, 2, 3])
+
     p = my_pipe(device_id=0, seed=1234, num_threads=3, set_affinity=True, py_num_workers=3)
+
+
+@pipeline_def(batch_size=1, num_threads=1, device_id=0)
+def _identity_pipe():
+    x = fn.external_source(device="gpu", name="identity_input")
+    return x
+
+
+@raises(TypeError)
+def test_invoke_serialize_error_handling_string():
+    _identity_pipe().serialize("any_string")
+
+
+@raises(TypeError)
+def test_invoke_serialize_error_handling_not_string():
+    _identity_pipe().serialize(42)


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve error handling. This is especially useful in dali_backend pipelines, where the common pattern used is:

```python
@piepline_def(...)
def pipe():
    ...
    return x

def main(filename):
    pipe().serialize(filename)
```
Without the change, the code above would explode with meaningless error, saying that you can't use `define_graph` and `set_outputs` at the same time...

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Added `if` statement
 - Affected modules and functionalities:
     `pipeline.py`
 - Key points relevant for the review:
     NA
 - Validation and testing:
     NA
 - Documentation (including examples):
     NA


**JIRA TASK**: *[Use DALI-XXXX or NA]*


Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

