### PR TITLE
Enable CUDA 11.3 based builds

### DIFF
--- a/conda/third_party/dali_opencv/recipe/meta.yaml
+++ b/conda/third_party/dali_opencv/recipe/meta.yaml
@@ -21,7 +21,7 @@
   source:
     fn: opencv-4.5.1.tar.gz
     url: https://github.com/opencv/opencv/archive/refs/tags/4.5.1.tar.gz
-    sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    sha256: e27fe5b168918ab60d58d7ace2bd82dd14a4d0bd1d3ae182952c2113f5637513
 
   build:
     number: 0

--- a/docker/Dockerfile.cuda113.aarch64.deps
+++ b/docker/Dockerfile.cuda113.aarch64.deps
@@ -1,0 +1,10 @@
+ARG TOOLKIT_BASE_IMAGE=ubuntu:18.04
+FROM ${TOOLKIT_BASE_IMAGE} as cuda
+
+RUN apt update && apt install -y libxml2 curl perl gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.19.01_linux_sbsa.run && \
+    chmod +x cuda_*.run && \
+    ./cuda_*.run --silent --no-opengl-libs --toolkit && \
+    rm -f cuda_*.run;

--- a/docker/Dockerfile.cuda113.x86_64.deps
+++ b/docker/Dockerfile.cuda113.x86_64.deps
@@ -1,0 +1,22 @@
+ARG TOOLKIT_BASE_IMAGE=ubuntu:18.04
+FROM ${TOOLKIT_BASE_IMAGE} as cuda
+
+RUN apt update && apt install -y libxml2 curl perl gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.19.01_linux.run && \
+    chmod +x cuda_*.run && \
+    ./cuda_*.run --silent --no-opengl-libs --toolkit && \
+    rm -f cuda_*.run;
+
+RUN NVJPEG2K_VERSION=0.2.0 && \
+    apt-get update && \
+    apt-get install wget software-properties-common -y && \
+    wget -qO - https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
+    add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /" && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub && \
+    apt-get update && \
+    apt-get install libnvjpeg2k0 libnvjpeg2k-dev -y && \
+    cp /usr/include/nvjpeg2k* /usr/local/cuda/include/ && \
+    cp /usr/lib/x86_64-linux-gnu/libnvjpeg2k* /usr/local/cuda/lib64/ && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,7 +5,7 @@ a build environment
 
 To change build configuration please export appropriate env variables (for exact meaning please check the README):
 PYVER=[default 3.6, required only by Run image]
-CUDA_VERSION=[default 11.2, accepts also 10.0, 11.0 and 11.1]
+CUDA_VERSION=[default 11.3, accepts also 10.0, 11.0 and 11.1]
 NVIDIA_BUILD_ID=[default 12345]
 CREATE_WHL=[default YES]
 CREATE_RUNNER=[default NO]
@@ -40,14 +40,14 @@ shift $((OPTIND - 1))
 export ARCH=${ARCH:-x86_64}
 export PYVER=${PYVER:-3.6}
 export PYV=${PYVER/./}
-export CUDA_VERSION=${CUDA_VERSION:-11.2}
+export CUDA_VERSION=${CUDA_VERSION:-11.3}
 export CUDA_VER=${CUDA_VERSION//./}
 
 if [ "${CUDA_VERSION%%\.*}" ]
 then
-  if [ $CUDA_VER != "100" ] && [ $CUDA_VER != "110" ] && [ $CUDA_VER != "111" ] && [ $CUDA_VER != "112" ]
+  if [ $CUDA_VER != "100" ] && [ $CUDA_VER != "110" ] && [ $CUDA_VER != "111" ] && [ $CUDA_VER != "112" ] && [ $CUDA_VER != "113" ]
   then
-      echo "Wrong CUDA_VERSION=$CUDA_VERSION provided. Only 10.0, 11.0, 11.1 and 11.2 are supported"
+      echo "Wrong CUDA_VERSION=$CUDA_VERSION provided. Only 10.0, 11.0, 11.1, 11.2 and 11.3 are supported"
       exit 1
   fi
 else

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -38,8 +38,8 @@ Building Python Wheel
 Change directory (``cd``) into ``docker`` directory and run ``./build.sh``. If needed,
 set the following environment variables:
 
-* | CUDA_VERSION - CUDA toolkit version (10.0, 11.0, 11.1 and 11.2).
-  | The default is ``11.2``. Thanks to CUDA extended compatibility mode, CUDA 11.1 and 11.2 wheels are
+* | CUDA_VERSION - CUDA toolkit version (10.0, 11.0, 11.1, 11.2 and 11.23.
+  | The default is ``11.3``. Thanks to CUDA extended compatibility mode, CUDA 11.1, 11.2 and 11.3 wheels are
     named as CUDA 11.0 because it can work with the CUDA 11.0 R450.x driver family. Please update
     to the latest recommended driver version in that family.
   | If the value of the CUDA_VERSION is prefixed with `.` then any value ``.XX.Y`` can be passed,

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -38,7 +38,7 @@ Building Python Wheel
 Change directory (``cd``) into ``docker`` directory and run ``./build.sh``. If needed,
 set the following environment variables:
 
-* | CUDA_VERSION - CUDA toolkit version (10.0, 11.0, 11.1, 11.2 and 11.23.
+* | CUDA_VERSION - CUDA toolkit version (10.0, 11.0, 11.1, 11.2 and 11.3.
   | The default is ``11.3``. Thanks to CUDA extended compatibility mode, CUDA 11.1, 11.2 and 11.3 wheels are
     named as CUDA 11.0 because it can work with the CUDA 11.0 R450.x driver family. Please update
     to the latest recommended driver version in that family.


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It enables CUDA 11.3 based builds

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     enables CUDA 11.3 based builds
 - Affected modules and functionalities:
     docker files
     build.sh
     docs
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI run
 - Documentation (including examples):
     compilation guide has been updated


**JIRA TASK**: *[NA]*
