### PR TITLE
Remove workaround for the problem with patchelf changing TLS alignment for CUDA < 10.2 and > 11.1

### DIFF
--- a/dali/benchmark/dali_bench.cc
+++ b/dali/benchmark/dali_bench.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "dali/benchmark/dali_bench.h"
+#include <cuda_runtime_api.h>
 
 #include <benchmark/benchmark.h>
 
@@ -22,6 +23,8 @@
 #include "dali/operators.h"
 #include "dali/pipeline/operator/op_spec.h"
 
+
+#if (CUDART_VERSION >= 10200 && CUDART_VERSION < 11100)
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_bench_force_tls_align;
@@ -29,6 +32,9 @@ alignas(0x1000) thread_local volatile bool __dali_bench_force_tls_align;
 void __dali_bench_force_tls_align_fun(void) {
   __dali_bench_force_tls_align = 0;
 }
+#else
+void __dali_bench_force_tls_align_fun(void) {}
+#endif
 
 int main(int argc, char **argv) {
   __dali_bench_force_tls_align_fun();

--- a/dali/core/dali_core_test.cc
+++ b/dali/core/dali_core_test.cc
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
 
 #include "dali/test/dali_cuda_finalize_test.h"
 
+#if (CUDART_VERSION >= 10200 && CUDART_VERSION < 11100)
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_core_test_force_tls_align;
@@ -23,6 +25,10 @@ alignas(0x1000) thread_local volatile bool __dali_core_test_force_tls_align;
 void __dali_core_test_force_tls_align_fun(void) {
   __dali_core_test_force_tls_align = 0;
 }
+#else
+void __dali_core_test_force_tls_align_fun(void) {}
+#endif
+
 
 int main(int argc, char **argv) {
   __dali_core_test_force_tls_align_fun();

--- a/dali/core/dummy.cc
+++ b/dali/core/dummy.cc
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cuda_runtime_api.h>
 #include "dali/core/api_helper.h"
 
 namespace dali {
 
+#if (CUDART_VERSION >= 10200 && CUDART_VERSION < 11100)
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_core_force_tls_align;
@@ -23,5 +25,8 @@ alignas(0x1000) thread_local volatile bool __dali_core_force_tls_align;
 DLL_PUBLIC void __dali_core_force_tls_align_fun(void) {
   __dali_core_force_tls_align = 0;
 }
+#else
+DLL_PUBLIC void __dali_core_test_force_tls_align_fun(void) {}
+#endif
 
 }  // namespace dali

--- a/dali/kernels/dali_kernel_test.cc
+++ b/dali/kernels/dali_kernel_test.cc
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
 
 #include "dali/test/dali_cuda_finalize_test.h"
 
+#if (CUDART_VERSION >= 10200 && CUDART_VERSION < 11100)
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_kernel_test_force_tls_align;
@@ -23,6 +25,9 @@ alignas(0x1000) thread_local volatile bool __dali_kernel_test_force_tls_align;
 void __dali_kernel_test_force_tls_align_fun(void) {
   __dali_kernel_test_force_tls_align = 0;
 }
+#else
+void __dali_kernel_test_force_tls_align_fun(void) {}
+#endif
 
 int main(int argc, char **argv) {
   __dali_kernel_test_force_tls_align_fun();

--- a/dali/kernels/dummy.cc
+++ b/dali/kernels/dummy.cc
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cuda_runtime_api.h>
 #include "dali/core/api_helper.h"
 
 namespace dali {
 
+#if (CUDART_VERSION >= 10200 && CUDART_VERSION < 11100)
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_kernels_force_tls_align;
@@ -23,5 +25,8 @@ alignas(0x1000) thread_local volatile bool __dali_kernels_force_tls_align;
 DLL_PUBLIC void __dali_kernels_force_tls_align_fun(void) {
   __dali_kernels_force_tls_align = 0;
 }
+#else
+DLL_PUBLIC void __dali_kernels_force_tls_align_fun(void) {}
+#endif
 
 }  // namespace dali

--- a/dali/operators/dali_operator_test.cc
+++ b/dali/operators/dali_operator_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
 
 #include "dali/pipeline/init.h"
@@ -20,6 +21,7 @@
 #include "dali/test/dali_cuda_finalize_test.h"
 #include "dali/test/dali_test_config.h"
 
+#if (CUDART_VERSION >= 10200 && CUDART_VERSION < 11100)
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_operator_test_force_tls_align;
@@ -27,6 +29,9 @@ alignas(0x1000) thread_local volatile bool __dali_operator_test_force_tls_align;
 void __dali_operator_test_force_tls_align_fun(void) {
   __dali_operator_test_force_tls_align = 0;
 }
+#else
+void __dali_operator_test_force_tls_align_fun(void) {}
+#endif
 
 
 int main(int argc, char **argv) {

--- a/dali/operators/python_function/dummy.cc
+++ b/dali/operators/python_function/dummy.cc
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cuda_runtime_api.h>
 #include "dali/core/api_helper.h"
 
 namespace dali {
 
+#if (CUDART_VERSION >= 10200 && CUDART_VERSION < 11100)
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_python_function_force_tls_align;
@@ -23,5 +25,8 @@ alignas(0x1000) thread_local volatile bool __dali_python_function_force_tls_alig
 DLL_PUBLIC void __dali_python_function_force_tls_align_fun(void) {
   __dali_python_function_force_tls_align = 0;
 }
+#else
+DLL_PUBLIC void __dali_python_function_force_tls_align_fun(void) {}
+#endif
 
 }  // namespace dali

--- a/dali/operators/util/dummy.cc
+++ b/dali/operators/util/dummy.cc
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cuda_runtime_api.h>
 #include "dali/core/api_helper.h"
 
 namespace dali {
 
+#if (CUDART_VERSION >= 10200 && CUDART_VERSION < 11100)
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_operators_force_tls_align;
@@ -23,5 +25,8 @@ alignas(0x1000) thread_local volatile bool __dali_operators_force_tls_align;
 DLL_PUBLIC void __dali_operators_force_tls_align_fun(void) {
   __dali_operators_force_tls_align = 0;
 }
+#else
+DLL_PUBLIC void __dali_operators_force_tls_align_fun(void) {}
+#endif
 
 }  // namespace dali

--- a/dali/pipeline/dummy.cc
+++ b/dali/pipeline/dummy.cc
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cuda_runtime_api.h>
 #include "dali/core/api_helper.h"
 
 namespace dali {
 
+#if (CUDART_VERSION >= 10200 && CUDART_VERSION < 11100)
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_pipeline_force_tls_align;
@@ -23,5 +25,8 @@ alignas(0x1000) thread_local volatile bool __dali_pipeline_force_tls_align;
 DLL_PUBLIC void __dali_pipeline_force_tls_align_fun(void) {
   __dali_pipeline_force_tls_align = 0;
 }
+#else
+DLL_PUBLIC void __dali_pipeline_force_tls_align_fun(void) {}
+#endif
 
 }  // namespace dali

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cuda_runtime_api.h>
 #include "dali/core/cuda_utils.h"
 #include "dali/core/device_guard.h"
 #if SHM_WRAPPER_ENABLED
@@ -38,6 +39,8 @@
 namespace dali {
 namespace python {
 
+
+#if (CUDART_VERSION >= 10200 && CUDART_VERSION < 11100)
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __backend_impl_force_tls_align;
@@ -45,6 +48,10 @@ alignas(0x1000) thread_local volatile bool __backend_impl_force_tls_align;
 void __backend_impl_force_tls_align_fun(void) {
   __backend_impl_force_tls_align = 0;
 }
+#else
+void __backend_impl_force_tls_align_fun(void) {}
+#endif
+
 
 using namespace pybind11::literals; // NOLINT
 

--- a/dali/test/dali_test.cc
+++ b/dali/test/dali_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
 
 #include "dali/pipeline/init.h"
@@ -21,6 +22,7 @@
 #include "dali/test/dali_test_config.h"
 #include "dali/operators.h"
 
+#if (CUDART_VERSION >= 10200 && CUDART_VERSION < 11100)
 // add this alignment to work around a patchelf bug/feature which
 // changes TLS alignment and break DALI interoperability with CUDA RT
 alignas(0x1000) thread_local volatile bool __dali_test_force_tls_align;
@@ -28,6 +30,9 @@ alignas(0x1000) thread_local volatile bool __dali_test_force_tls_align;
 void __dali_test_force_tls_align_fun(void) {
   __dali_test_force_tls_align = 0;
 }
+#else
+void __dali_test_force_tls_align_fun(void) {}
+#endif
 
 int main(int argc, char **argv) {
   __dali_test_force_tls_align_fun();


### PR DESCRIPTION
- the workaround for the problem with patchelf changing TLS is not needed
  for > CUDA 11.1 and < 10.2 as CUDA RT handles TLS differently in that
  versions

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes workaround for the problem with patchelf changing TLS alignment for CUDA < 10.2 and > 11.1

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     the workaround for the problem with patchelf changing TLS is not needed for > CUDA 11.1 and < 10.2 as CUDA RT handles TLS differently in that versions
 - Affected modules and functionalities:
     all dali .so libraries and runables
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI build for CUDA 11.3
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
