### PR TITLE
Fix coverity issues by adding lacking CUDA_CALL

### DIFF
--- a/dali/benchmark/slice_kernel_bench.cu
+++ b/dali/benchmark/slice_kernel_bench.cu
@@ -82,7 +82,7 @@ class SliceBenchGPU : public DALIBenchmark {
       ctx.scratchpad = &scratchpad;
 
       kernel.Run(ctx, out_tv, in_tv, args_vec);
-      cudaStreamSynchronize(ctx.gpu.stream);
+      CUDA_CALL(cudaStreamSynchronize(ctx.gpu.stream));
       st.counters["FPS"] = benchmark::Counter(st.iterations() + 1,
         benchmark::Counter::kIsRate);
     }

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -457,7 +457,7 @@ void daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx,
                    stream, use_copy_kernel);
   }
   if (sync) {
-    cudaStreamSynchronize(stream);
+    CUDA_CALL(cudaStreamSynchronize(stream));
   }
 }
 
@@ -482,7 +482,7 @@ void daliOutputCopySamples(daliPipelineHandle *pipe_handle, void **dsts, int out
                    stream, use_copy_kernel);
   }
   if (sync) {
-    cudaStreamSynchronize(stream);
+    CUDA_CALL(cudaStreamSynchronize(stream));
   }
 }
 

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -620,7 +620,7 @@ void Clear(Tensor<CPUBackend>& tensor) {
 
 template <>
 void Clear(Tensor<GPUBackend>& tensor) {
-  cudaMemset(tensor.raw_mutable_data(), 0, tensor.nbytes());
+  CUDA_CALL(cudaMemset(tensor.raw_mutable_data(), 0, tensor.nbytes()));
 }
 
 

--- a/dali/core/fast_div_test.cu
+++ b/dali/core/fast_div_test.cu
@@ -287,20 +287,20 @@ TYPED_TEST(FastDivPerf, Perf) {
   T d3 = std::max(dist(rng), T(1));
 
   FastDivMod<T><<<1000, 1024>>>(m, d1, d2, d3);
-  cudaEventRecord(start, 0);
+  CUDA_CALL(cudaEventRecord(start, 0));
   FastDivMod<T><<<N, 1024>>>(m, d1, d2, d3);
-  cudaEventRecord(end, 0);
+  CUDA_CALL(cudaEventRecord(end, 0));
   CUDA_CALL(cudaDeviceSynchronize());
   float t_fast = 0;
-  cudaEventElapsedTime(&t_fast, start, end);
+  CUDA_CALL(cudaEventElapsedTime(&t_fast, start, end));
 
   NormalDivMod<<<1000, 1024>>>(m + 1024, d1, d2, d3);
-  cudaEventRecord(start, 0);
+  CUDA_CALL(cudaEventRecord(start, 0));
   NormalDivMod<<<N, 1024>>>(m + 1024, d1, d2, d3);
-  cudaEventRecord(end, 0);
+  CUDA_CALL(cudaEventRecord(end, 0));
   CUDA_CALL(cudaDeviceSynchronize());
   float t_norm = 0;
-  cudaEventElapsedTime(&t_norm, start, end);
+  CUDA_CALL(cudaEventElapsedTime(&t_norm, start, end));
 
   t_norm *= 1e+6;
   t_fast *= 1e+6;

--- a/dali/core/mm/monotonic_resource_test.cc
+++ b/dali/core/mm/monotonic_resource_test.cc
@@ -74,21 +74,21 @@ TEST(MMTest, MonotonicDeviceResource) {
     monotonic_device_resource<> mr(&upstream);
     void *m1 = mr.allocate(100);
     ASSERT_NE(m1, nullptr);
-    cudaMemset(m1, 0xff, 100);
+    CUDA_CALL(cudaMemset(m1, 0xff, 100));
     void *m2 = mr.allocate(256, 32);
     ASSERT_NE(m2, nullptr);
-    cudaMemset(m2, 0xfe, 256);
+    CUDA_CALL(cudaMemset(m2, 0xfe, 256));
     EXPECT_GE(static_cast<char *>(m2), static_cast<char *>(m1) + 100);
     EXPECT_TRUE(detail::is_aligned(m2, 32));
     EXPECT_LE(static_cast<char *>(m2), static_cast<char *>(m1) + align_up(100, 32));
     void *m3 = mr.allocate(1024);
     ASSERT_NE(m3, nullptr);
-    cudaMemset(m3, 0xfd, 1024);
+    CUDA_CALL(cudaMemset(m3, 0xfd, 1024));
     void *m4 = mr.allocate(64000);
     ASSERT_NE(m4, nullptr);
-    cudaMemset(m4, 0xfc, 64000);
+    CUDA_CALL(cudaMemset(m4, 0xfc, 64000));
   }
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
   upstream.check_leaks();
 }
 

--- a/dali/core/mm/pinned_pool_test.cc
+++ b/dali/core/mm/pinned_pool_test.cc
@@ -92,9 +92,9 @@ TEST(MMPinnedAlloc, SyncCrossDevice) {
     CUDAStream s1, s2;
     DeviceGuard dg(0);
     s1 = CUDAStream::Create(true);
-    cudaSetDevice(1);
+    CUDA_CALL(cudaSetDevice(1));
     s2 = CUDAStream::Create(true);
-    cudaSetDevice(0);
+    CUDA_CALL(cudaSetDevice(0));
     stream_view sv1(s1), sv2(s2);
     const int N = 1<<24;
     async_pool_base<memory_kind::pinned> pool(&upstream, true);
@@ -128,9 +128,9 @@ TEST(MMPinnedAlloc, FreeOnAnotherDevice) {
     CUDAStream s1, s2;
     DeviceGuard dg(0);
     s1 = CUDAStream::Create(true);
-    cudaSetDevice(1);
+    CUDA_CALL(cudaSetDevice(1));
     s2 = CUDAStream::Create(true);
-    cudaSetDevice(0);
+    CUDA_CALL(cudaSetDevice(0));
     stream_view sv1(s1), sv2(s2);
     const int N = 1<<24;
     async_pool_base<memory_kind::pinned> pool(&upstream, true);
@@ -140,7 +140,7 @@ TEST(MMPinnedAlloc, FreeOnAnotherDevice) {
     // don't set device - it should be inferred from the stream
     pool.deallocate_async(mem1, N, sv2);
     // now set the device and allocate
-    cudaSetDevice(1);
+    CUDA_CALL(cudaSetDevice(1));
     void *mem2 = pool.allocate_async(N, sv2);
     EXPECT_EQ(mem1, mem2) << "Memory should have been moved to stream2 on another device.";
     pool.deallocate_async(mem2, N, sv2);

--- a/dali/core/mm/pinned_pool_test.cc
+++ b/dali/core/mm/pinned_pool_test.cc
@@ -136,7 +136,7 @@ TEST(MMPinnedAlloc, FreeOnAnotherDevice) {
     async_pool_base<memory_kind::pinned> pool(&upstream, true);
     void *mem1 = pool.allocate_async(N, sv1);
     CUDA_CALL(cudaMemsetAsync(mem1, 0, N, s1));
-    cudaStreamSynchronize(s1);
+    CUDA_CALL(cudaStreamSynchronize(s1));
     // don't set device - it should be inferred from the stream
     pool.deallocate_async(mem1, N, sv2);
     // now set the device and allocate

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_gpu_test.cc
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_gpu_test.cc
@@ -156,7 +156,7 @@ TEST_P(MelScaleGpuTest, MelScaleGpuTest) {
   auto out_view = out.gpu();
   kmgr.Run<Kernel>(0, 0, ctx, out_view, in_view);
   auto out_view_cpu = out.cpu();
-  cudaStreamSynchronize(0);
+  CUDA_CALL(cudaStreamSynchronize(0));
   for (int b = 0; b < batch_size; ++b) {
     for (int idx = 0; idx < out_sizes[b]; idx++) {
       ASSERT_NEAR(expected_out[b][idx], out_view_cpu.tensor_data(b)[idx], 1e-5) <<

--- a/dali/kernels/common/copy.h
+++ b/dali/kernels/common/copy.h
@@ -31,16 +31,16 @@ void copy(void* out, const void* in, std::size_t N, cudaStream_t stream = 0) {
   if (!is_gpu_accessible<StorageOut>::value) {
     if (is_cpu_accessible<StorageIn>::value) {
       if (is_gpu_accessible<StorageIn>::value)
-        cudaStreamSynchronize(stream);  // or cudaDeviceSynchronize?
+        CUDA_CALL(cudaStreamSynchronize(stream));  // or cudaDeviceSynchronize?
       std::memcpy(out, in, N);
     } else {
-      cudaMemcpyAsync(out, in, N, cudaMemcpyDeviceToHost, stream);
+      CUDA_CALL(cudaMemcpyAsync(out, in, N, cudaMemcpyDeviceToHost, stream));
     }
   } else {
     if (is_gpu_accessible<StorageIn>::value) {
-      cudaMemcpyAsync(out, in, N, cudaMemcpyDeviceToDevice, stream);
+      CUDA_CALL(cudaMemcpyAsync(out, in, N, cudaMemcpyDeviceToDevice, stream));
     } else {
-      cudaMemcpyAsync(out, in, N, cudaMemcpyHostToDevice, stream);
+      CUDA_CALL(cudaMemcpyAsync(out, in, N, cudaMemcpyHostToDevice, stream));
     }
   }
 }

--- a/dali/kernels/common/copy_test.cu
+++ b/dali/kernels/common/copy_test.cu
@@ -167,7 +167,7 @@ TEST_F(CopyTest, CopyReturnTensorViewTestUnified) {
   auto tv = make_tensor_cpu(data_src, shape);
   UniformRandomFill(tv, rng, -1, 1);
   auto tvcpy = copy<AllocType::Unified>(tv);
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
   Check(tv, tvcpy.first);
 }
 
@@ -177,7 +177,7 @@ TEST_F(CopyTest, CopyReturnTensorViewTestHost) {
   auto tv = make_tensor_cpu(data_src, shape);
   UniformRandomFill(tv, rng, -1, 1);
   auto tvcpy = copy<AllocType::Host>(tv);
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
   Check(tv, tvcpy.first);
 }
 

--- a/dali/kernels/common/join/tensor_join_gpu_impl_test.cu
+++ b/dali/kernels/common/join/tensor_join_gpu_impl_test.cu
@@ -139,7 +139,9 @@ struct TensorJoinGPUTest : public ::testing::Test {
 
   void ClearOutput(cudaStream_t stream) {
     auto out_tl = out.gpu(stream);
-    cudaMemsetAsync(out_tl.data[0], 0, sizeof(out_tl.data[0][0]) * out_tl.num_elements(), stream);
+    CUDA_CALL(
+      cudaMemsetAsync(out_tl.data[0], 0, sizeof(out_tl.data[0][0]) * out_tl.num_elements(),
+                      stream));
   }
 
   void FillInputs(cudaStream_t stream) {

--- a/dali/kernels/common/scatter_gather.cu
+++ b/dali/kernels/common/scatter_gather.cu
@@ -112,13 +112,14 @@ void ScatterGatherGPU::Run(cudaStream_t stream, bool reset, ScatterGatherGPU::Me
 
   if (use_memcpy) {
     for (auto &r : ranges_) {
-      cudaMemcpyAsync(r.dst, r.src, r.size, memcpyKind, stream);
+      CUDA_CALL(cudaMemcpyAsync(r.dst, r.src, r.size, memcpyKind, stream));
     }
   } else {
     MakeBlocks();
     ReserveGPUBlocks();
-    cudaMemcpyAsync(blocks_dev_.get(), blocks_.data(), blocks_.size() * sizeof(blocks_[0]),
-      cudaMemcpyHostToDevice, stream);
+    CUDA_CALL(
+      cudaMemcpyAsync(blocks_dev_.get(), blocks_.data(), blocks_.size() * sizeof(blocks_[0]),
+                      cudaMemcpyHostToDevice, stream));
 
     dim3 grid(blocks_.size());
     dim3 block(std::min<size_t>(size_per_block_, 1024));

--- a/dali/kernels/imgproc/convolution/cutlass/device/gemm.h
+++ b/dali/kernels/imgproc/convolution/cutlass/device/gemm.h
@@ -469,8 +469,9 @@ class Conv {
     }
 
     size_t params_sizeof = host_params_.size() * sizeof(SampleParams);
-    cudaMemcpyAsync(params_.params, host_params_.data(), params_sizeof, cudaMemcpyHostToDevice,
-                    stream);
+    CUDA_CALL(
+      cudaMemcpyAsync(params_.params, host_params_.data(), params_sizeof, cudaMemcpyHostToDevice,
+                      stream));
 
     cutlass::Kernel<ConvKernel><<<grid, block, smem_size, stream>>>(params_);
 

--- a/dali/kernels/imgproc/convolution/cutlass/device/gemm.h
+++ b/dali/kernels/imgproc/convolution/cutlass/device/gemm.h
@@ -469,9 +469,8 @@ class Conv {
     }
 
     size_t params_sizeof = host_params_.size() * sizeof(SampleParams);
-    CUDA_CALL(
-      cudaMemcpyAsync(params_.params, host_params_.data(), params_sizeof, cudaMemcpyHostToDevice,
-                      stream));
+    cudaMemcpyAsync(params_.params, host_params_.data(), params_sizeof, cudaMemcpyHostToDevice,
+                    stream);
 
     cutlass::Kernel<ConvKernel><<<grid, block, smem_size, stream>>>(params_);
 

--- a/dali/kernels/imgproc/convolution/separable_convolution_gpu_test.cu
+++ b/dali/kernels/imgproc/convolution/separable_convolution_gpu_test.cu
@@ -164,7 +164,7 @@ class SepearableConvolutionGpuTestImpl {
 
 
       auto out_cpu_v = output_.cpu(0);
-      cudaDeviceSynchronize();
+      CUDA_CALL(cudaDeviceSynchronize());
       CUDA_CALL(cudaGetLastError());
       double eps = 0.001;
       Check(out_cpu_v, baseline_out_v, EqualEps(eps));

--- a/dali/kernels/imgproc/pointwise/linear_transformation_gpu_test.cu
+++ b/dali/kernels/imgproc/pointwise/linear_transformation_gpu_test.cu
@@ -58,7 +58,7 @@ class LinearTransformationGpuTest : public ::testing::Test {
     CUDA_CALL(cudaMemcpy(input_device_, input_host_.data(), input_host_.size() * sizeof(In),
                          cudaMemcpyDefault));
     CUDA_CALL(cudaMalloc(&output_, dataset_size(out_shapes_) * sizeof(Out)));
-    cudaDeviceSynchronize();
+    CUDA_CALL(cudaDeviceSynchronize());
   }
 
   void TearDown() final {
@@ -164,7 +164,7 @@ TYPED_TEST(LinearTransformationGpuTest, run_test) {
           this->output_, reqs.output_shapes[0].template to_static<kNDims>());
 
   kernel.Run(c, out, in, make_cspan(this->vmat_), make_cspan(this->vvec_));
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
 
   auto res = copy<AllocType::Host>(out[0]);
   auto ref_tv = TensorView<StorageCPU, typename TypeParam::Out>(this->ref_output_.data(),
@@ -191,7 +191,7 @@ TYPED_TEST(LinearTransformationGpuTest, run_test_with_roi) {
           this->output_, reqs.output_shapes[0].template to_static<kNDims>());
 
   kernel.Run(c, out, in, make_cspan(this->vmat_), make_cspan(this->vvec_), make_cspan(this->rois_));
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
 
   auto res = copy<AllocType::Host>(out[0]);
   auto mat = testing::copy_to_mat<kNChannelsOut>(

--- a/dali/kernels/imgproc/pointwise/multiply_add_gpu_test.cu
+++ b/dali/kernels/imgproc/pointwise/multiply_add_gpu_test.cu
@@ -68,7 +68,7 @@ class MultiplyAddGpuTest : public ::testing::Test {
     CUDA_CALL(cudaMemcpy(input_device_, input_host_.data(), input_host_.size() * sizeof(In),
                          cudaMemcpyDefault));
     CUDA_CALL(cudaMalloc(&output_, dataset_size() * sizeof(Out)));
-    cudaDeviceSynchronize();
+    CUDA_CALL(cudaDeviceSynchronize());
 
     verify_test();
   }
@@ -155,7 +155,7 @@ TYPED_TEST(MultiplyAddGpuTest, run_test) {
   auto scratchpad = sa.GetScratchpad();
   c.scratchpad = &scratchpad;
   kernel.Run(c, out, in, this->addends_, this->multipliers_);
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
 
   auto res = copy<AllocType::Host>(out[0]);
   ASSERT_EQ(static_cast<int>(this->ref_output_.size()), res.first.num_elements());

--- a/dali/kernels/imgproc/resample/resampling_filters.cu
+++ b/dali/kernels/imgproc/resample/resampling_filters.cu
@@ -101,8 +101,8 @@ void InitFilters(ResamplingFilters &filters, AllocType alloc) {
 
   if (alloc == AllocType::GPU) {
     auto filter_data_gpu = memory::alloc_unique<float>(AllocType::GPU, total_size);
-    cudaMemcpy(filter_data_gpu.get(), filters.filter_data.get(),
-               total_size * sizeof(float), cudaMemcpyHostToDevice);
+    CUDA_CALL(cudaMemcpy(filter_data_gpu.get(), filters.filter_data.get(),
+                         total_size * sizeof(float), cudaMemcpyHostToDevice));
     ptrdiff_t  diff = filter_data_gpu.get() - filters.filter_data.get();
     filters.filter_data = std::move(filter_data_gpu);
     for (auto &f : filters.filters)

--- a/dali/kernels/imgproc/resample/separable_impl.h
+++ b/dali/kernels/imgproc/resample/separable_impl.h
@@ -186,7 +186,7 @@ struct SeparableResamplingGPUImpl : Interface {
         tmp_buffers,
         out.tensor_data(i));
     }
-    
+
     CUDA_CALL(cudaMemcpyAsync(
         descs_gpu,
         setup.sample_descs.data(),

--- a/dali/kernels/imgproc/resample/separable_impl.h
+++ b/dali/kernels/imgproc/resample/separable_impl.h
@@ -186,13 +186,13 @@ struct SeparableResamplingGPUImpl : Interface {
         tmp_buffers,
         out.tensor_data(i));
     }
-
-    cudaMemcpyAsync(
+    
+    CUDA_CALL(cudaMemcpyAsync(
         descs_gpu,
         setup.sample_descs.data(),
         setup.sample_descs.size()*sizeof(SampleDesc),
         cudaMemcpyHostToDevice,
-        stream);
+        stream));
 
     RunPasses(descs_gpu, pass_lookup, stream, std::integral_constant<int, spatial_ndim>());
   }

--- a/dali/kernels/imgproc/sampler_gpu_test.cu
+++ b/dali/kernels/imgproc/sampler_gpu_test.cu
@@ -90,7 +90,7 @@ TEST(Sampler2D_GPU, NN) {
   RunSampler2D<<<grid, block>>>(out_surf, sampler, border_value, dx, dy, x0, y0);
   Surface2D<uint8_t> out_cpu = { out_mem_cpu.data(), { w, h }, c, { c, w*c }, 1 };
 
-  cudaMemcpy(out_cpu.data, out_surf.data, w*h*c, cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(out_cpu.data, out_surf.data, w*h*c, cudaMemcpyDeviceToHost));
 
   for (int oy = 0; oy < h; oy++) {
     float y = oy * dy + y0;
@@ -149,7 +149,7 @@ TEST(Sampler3D_GPU, NN) {
   RunSampler3D<<<grid, block>>>(out_surf, sampler, border_value, dx, dy, dz, x0, y0, z0);
   Surface3D<uint8_t> out_cpu = { out_mem_cpu.data(), { w, h, d }, c, { c, w*c, h*w*c }, 1 };
 
-  cudaMemcpy(out_cpu.data, out_surf.data, w*h*d*c, cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(out_cpu.data, out_surf.data, w*h*d*c, cudaMemcpyDeviceToHost));
 
   for (int oz = 0; oz < d; oz++) {
     float z = oz * dz + z0;
@@ -212,7 +212,7 @@ TEST(Sampler2D_GPU, Linear) {
   RunSampler2D<<<grid, block>>>(out_surf, sampler, border_value, dx, dy, x0, y0);
   Surface2D<uint8_t> out_cpu = { out_mem_cpu.data(), { w, h }, c, { c, w*c }, 1 };
 
-  cudaMemcpy(out_cpu.data, out_surf.data, w*h*c, cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(out_cpu.data, out_surf.data, w*h*c, cudaMemcpyDeviceToHost));
 
   const float eps = 0.50000025f;  // 0.5 + 4 ULP
 
@@ -270,7 +270,7 @@ TEST(Sampler3D_GPU, Linear) {
   RunSampler3D<<<grid, block>>>(out_surf, sampler, border_value, dx, dy, dz, x0, y0, z0);
   Surface3D<uint8_t> out_cpu = { out_mem_cpu.data(), { w, h, d }, c, { c, w*c, h*w*c }, 1 };
 
-  cudaMemcpy(out_cpu.data, out_surf.data, w*h*d*c, cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(out_cpu.data, out_surf.data, w*h*d*c, cudaMemcpyDeviceToHost));
 
   const float eps = 0.50000025f;  // 0.5 + 4 ULP
 

--- a/dali/kernels/imgproc/sampler_test.h
+++ b/dali/kernels/imgproc/sampler_test.h
@@ -75,7 +75,8 @@ struct SamplerTestData {
   const T *GetGPUData() {
     if (!gpu_storage) {
       gpu_storage = memory::alloc_unique<T>(AllocType::GPU, D*W*H*C);
-      cudaMemcpy(gpu_storage.get(), GetCPUData(), sizeof(T)*D*W*H*C, cudaMemcpyHostToDevice);
+      CUDA_CALL(
+        cudaMemcpy(gpu_storage.get(), GetCPUData(), sizeof(T)*D*W*H*C, cudaMemcpyHostToDevice));
     }
     return gpu_storage.get();
   }

--- a/dali/kernels/normalize/normalize_gpu_test.cu
+++ b/dali/kernels/normalize/normalize_gpu_test.cu
@@ -287,13 +287,14 @@ class NormalizeImplGPUTest<std::pair<Out, In>> : public ::testing::Test {
 
 
     auto out_gpu = out_.gpu();
-    cudaMemsetAsync(out_gpu.data[0], 0, sizeof(Out) * out_gpu.num_elements(), ctx.gpu.stream);
+    CUDA_CALL(
+      cudaMemsetAsync(out_gpu.data[0], 0, sizeof(Out) * out_gpu.num_elements(), ctx.gpu.stream));
     Launch(ctx);
-    cudaEventRecord(start, ctx.gpu.stream);
+    CUDA_CALL(cudaEventRecord(start, ctx.gpu.stream));
     Launch(ctx);
-    cudaEventRecord(end, ctx.gpu.stream);
+    CUDA_CALL(cudaEventRecord(end, ctx.gpu.stream));
     float time;
-    cudaDeviceSynchronize();
+    CUDA_CALL(cudaDeviceSynchronize());
     CUDA_CALL(cudaEventElapsedTime(&time, start, end));
     time *= 1e+6f;  // convert to nanoseconds
     int64_t out_size = data_shape_.num_elements() * sizeof(Out);

--- a/dali/kernels/reduce/reduce_all_gpu_test.cu
+++ b/dali/kernels/reduce/reduce_all_gpu_test.cu
@@ -154,7 +154,7 @@ void ReduceAllGPUTest<Reduction>::TestReduceBatched() {
   // warm-up
   ReduceAllBatchedKernel<float><<<1, block>>>(
       out_data.get(), gpu_dev_ptrs.get(), gpu_sizes.get(), R);
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
   auto start = CUDAEvent::CreateWithFlags(0);
   auto end =   CUDAEvent::CreateWithFlags(0);
   CUDA_CALL(cudaEventRecord(start));
@@ -242,7 +242,7 @@ void ReduceAllGPUTest<Reduction>::TestReduceAllKernel(int min_size, int max_size
 
   kernel.Run(ctx, out_view_gpu, in_view_gpu);
 
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
 
   auto in_view_cpu = in.cpu();
   auto out_view_cpu = out.cpu();

--- a/dali/kernels/reduce/reduce_axes_gpu_test.cu
+++ b/dali/kernels/reduce/reduce_axes_gpu_test.cu
@@ -111,9 +111,9 @@ class ReduceInnerGPUTest : public ::testing::Test {
     auto start = CUDAEvent::CreateWithFlags(0);
     auto end =   CUDAEvent::CreateWithFlags(0);
     gpu_descs.from_host(cpu_descs);
-    cudaEventRecord(start);
+    CUDA_CALL(cudaEventRecord(start));
     ReduceInnerKernel<float><<<grid, block>>>(gpu_descs.data(), reduction);
-    cudaEventRecord(end);
+    CUDA_CALL(cudaEventRecord(end));
     CUDA_CALL(cudaDeviceSynchronize());
     float t = 0;
     cudaEventElapsedTime(&t, start, end);
@@ -252,13 +252,13 @@ class ReduceMiddleGPUTest : public ::testing::Test {
     dim3 block(32, 24);
     auto start = CUDAEvent::CreateWithFlags(0);
     auto end =   CUDAEvent::CreateWithFlags(0);
-    cudaEventRecord(start);
+    CUDA_CALL(cudaEventRecord(start));
     ReduceMiddleKernel<float><<<grid, block, sizeof(float)*32*33>>>(gpu_descs.data(), reduction);
     CUDA_CALL(cudaGetLastError());
-    cudaEventRecord(end);
+    CUDA_CALL(cudaEventRecord(end));
     CUDA_CALL(cudaDeviceSynchronize());
     float t = 0;
-    cudaEventElapsedTime(&t, start, end);
+    CUDA_CALL(cudaEventElapsedTime(&t, start, end));
     t /= 1000;  // convert to seconds
     int64_t read = gpu_in.num_elements() * sizeof(float);
     int64_t written = gpu_out.num_elements() * sizeof(float);
@@ -377,12 +377,12 @@ TEST(ReduceSamples, Sum) {
   auto start = CUDAEvent::CreateWithFlags(0);
   auto end =   CUDAEvent::CreateWithFlags(0);
   sample_ptrs.from_host(gpu_in.data);
-  cudaEventRecord(start);
+  CUDA_CALL(cudaEventRecord(start));
   ReduceSamplesKernel<float><<<256, 1024>>>(gpu_out.data[0], sample_ptrs.data(), n, N, R);
-  cudaEventRecord(end);
+  CUDA_CALL(cudaEventRecord(end));
   auto cpu_out = out.cpu();
   float t = 0;
-  cudaEventElapsedTime(&t, start, end);
+  CUDA_CALL(cudaEventElapsedTime(&t, start, end));
   t /= 1000;  // convert to seconds
   int64_t read = sizeof(float) * in_shape.num_elements();
   int64_t written = sizeof(float) * out_shape.num_elements();

--- a/dali/kernels/reduce/reduce_gpu_test.h
+++ b/dali/kernels/reduce/reduce_gpu_test.h
@@ -59,7 +59,8 @@ struct ReductionKernelTest {
 
   void FillData(In min_value, In max_value) {
     UniformRandomFill(in.cpu(), rng, 0, 255);
-    cudaMemsetAsync(out.gpu().data[0], -1, sizeof(Out) * out.gpu().num_elements(), stream());
+    CUDA_CALL(
+      cudaMemsetAsync(out.gpu().data[0], -1, sizeof(Out) * out.gpu().num_elements(), stream()));
   }
 
   template <typename... Args>

--- a/dali/kernels/signal/dct/dct_gpu.cu
+++ b/dali/kernels/signal/dct/dct_gpu.cu
@@ -199,11 +199,11 @@ DLL_PUBLIC void Dct1DGpu<OutputType, InputType>::Run(KernelContext &ctx,
     int n;
     DctArgs arg;
     std::tie(n, arg) = table_entry.first;
-    cudaEventSynchronize(buffer_event);
+    CUDA_CALL(cudaEventSynchronize(buffer_event));
     FillCosineTable(cpu_table, n, arg);
     table_entry.second = ctx.scratchpad->ToGPU(ctx.gpu.stream,
                                                span<OutputType>(cpu_table, n * arg.ndct));
-    cudaEventRecord(buffer_event, ctx.gpu.stream);
+    CUDA_CALL(cudaEventRecord(buffer_event, ctx.gpu.stream));
     ++i;
   }
   sample_descs_.clear();

--- a/dali/kernels/signal/decibel/to_decibels_gpu_test.cc
+++ b/dali/kernels/signal/decibel/to_decibels_gpu_test.cc
@@ -103,14 +103,14 @@ TEST_P(ToDecibelsGpuTest, ToDecibelsGpuTest) {
       }
     }
     max_values_gpu = memory::alloc_unique<T>(AllocType::GPU, batch_size);
-    cudaMemcpy(max_values_gpu.get(), max_values.data(), batch_size * sizeof(T),
-               cudaMemcpyHostToDevice);
+    CUDA_CALL(cudaMemcpy(max_values_gpu.get(), max_values.data(), batch_size * sizeof(T),
+                         cudaMemcpyHostToDevice));
     max_values_arg = {max_values_gpu.get(),
                       TensorListShape<0>(batch_size)};
   }
 
   kernel.Run(ctx, out.gpu(), in_.gpu(), args, max_values_arg);
-  cudaStreamSynchronize(0);
+  CUDA_CALL(cudaStreamSynchronize(0));
   auto out_view_cpu = out.cpu();
   for (int b = 0; b < batch_size; ++b) {
     int64_t sz = volume(data_shape_[b]);

--- a/dali/kernels/signal/fft/stft_gpu_impl.cu
+++ b/dali/kernels/signal/fft/stft_gpu_impl.cu
@@ -311,7 +311,7 @@ void StftImplGPU::ExtractWindows(ExecutionContext &ctx) {
   int64_t pad = num_temp_windows() * transform_in_size() - ofs;
 
   // 0-pad to avoid running FFT on garbage
-  cudaMemsetAsync(fft_in + ofs, 0, pad*sizeof(float), ctx.stream());
+  CUDA_CALL(cudaMemsetAsync(fft_in + ofs, 0, pad*sizeof(float), ctx.stream()));
 }
 
 }  // namespace fft

--- a/dali/kernels/slice/slice_gpu_test.cu
+++ b/dali/kernels/slice/slice_gpu_test.cu
@@ -57,7 +57,7 @@ class SliceGPUTest : public SliceTest<TestArgs> {
     OutListGPU<OutputType, Dims> out_tlv = output_data.gpu();
 
     kernel.Run(ctx, out_tlv, test_data.gpu(), slice_args);
-    cudaStreamSynchronize(ctx.gpu.stream);
+    CUDA_CALL(cudaStreamSynchronize(ctx.gpu.stream));
 
     TestTensorList<OutputType, Dims> expected_output;
     this->PrepareExpectedOutput(test_data, slice_args, expected_output);

--- a/dali/kernels/test/alloc_test.cc
+++ b/dali/kernels/test/alloc_test.cc
@@ -62,13 +62,13 @@ TEST(KernelAlloc, HostDevice) {
   int count = 1;
   cudaGetDeviceCount(&count);
   if (count > 1)
-    cudaSetDevice(1);
+    CUDA_CALL(cudaSetDevice(1));
   EXPECT_EQ(cudaGetLastError(), 0);
   pinned_deallocator(pinned);
   host_deallocator(plain);
   gpu_deallocator(gpu);
   EXPECT_EQ(cudaGetLastError(), 0);
-  cudaSetDevice(0);
+  CUDA_CALL(cudaSetDevice(0));
 }
 
 TEST(KernelAlloc, Unique) {

--- a/dali/kernels/test/resampling_test/resampling_compare_test.cc
+++ b/dali/kernels/test/resampling_test/resampling_compare_test.cc
@@ -151,7 +151,7 @@ TEST_P(ResamplingCompareTest, ResamplingKernelAPI) {
   OutListGPU<uint8_t, 3> out_gpu = output_gpu.gpu();
   for (int i = 0; i < out_gpu.num_samples(); i++) {
     auto tv = out_gpu[i];
-    cudaMemset(tv.data, 0, tv.num_elements()*sizeof(*tv.data));
+    CUDA_CALL(cudaMemset(tv.data, 0, tv.num_elements()*sizeof(*tv.data)));
   }
 
   OutListCPU<uint8_t, 3> out_cpu = output_cpu.cpu();

--- a/dali/kernels/test/resampling_test/resampling_filters_test.cu
+++ b/dali/kernels/test/resampling_test/resampling_filters_test.cu
@@ -58,7 +58,7 @@ TEST(ResamplingFilters, TestTriangular) {
   auto mem = memory::alloc_unique<float>(AllocType::GPU, size);
   GetFilterValues<<<1, size>>>(mem.get(), f, size, -f.anchor, 1.0f);
   std::vector<float> host(size);
-  cudaMemcpy(host.data(), mem.get(), size*sizeof(float), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(host.data(), mem.get(), size*sizeof(float), cudaMemcpyDeviceToHost));
   for (int i = 0; i < size; i++) {
     float x = (i - f.anchor) * f.scale;
     float ref = std::max(0.0f, 1.0f - fabsf(x));
@@ -81,7 +81,7 @@ TEST(ResamplingFilters, Gaussian) {
   auto mem = memory::alloc_unique<float>(AllocType::GPU, size);
   GetFilterValues<<<1, size>>>(mem.get(), flt, size, -radius, 1);
   std::vector<float> host(size);
-  cudaMemcpy(host.data(), mem.get(), size*sizeof(float), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(host.data(), mem.get(), size*sizeof(float), cudaMemcpyDeviceToHost));
   for (int i = 0; i < size-1; i++) {
     float x = (i - radius);
     float ref = expf(-x*x / (2 * sigma*sigma));
@@ -105,7 +105,7 @@ TEST(ResamplingFilters, Lanczos3) {
   auto mem = memory::alloc_unique<float>(AllocType::GPU, size);
   GetFilterValues<<<1, size>>>(mem.get(), flt, size, -3.0f, 3.0f / radius);
   std::vector<float> host(size);
-  cudaMemcpy(host.data(), mem.get(), size*sizeof(float), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(host.data(), mem.get(), size*sizeof(float), cudaMemcpyDeviceToHost));
   for (int i = 0; i < size; i++) {
     float x = 3.0f * (i - radius) / radius;
     float ref = sinc(x) * sinc(x / 3);
@@ -129,7 +129,7 @@ TEST(ResamplingFilters, Cubic) {
   auto mem = memory::alloc_unique<float>(AllocType::GPU, size);
   GetFilterValues<<<1, size>>>(mem.get(), flt, size, -2.0f, 2.0f / radius);
   std::vector<float> host(size);
-  cudaMemcpy(host.data(), mem.get(), size*sizeof(float), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(host.data(), mem.get(), size*sizeof(float), cudaMemcpyDeviceToHost));
   for (int i = 0; i < size; i++) {
     float x = 2.0f * (i - radius) / radius;
     float ref = CubicWindow(x);

--- a/dali/kernels/test/resampling_test/resampling_internal_test.cu
+++ b/dali/kernels/test/resampling_test/resampling_internal_test.cu
@@ -100,7 +100,7 @@ TEST(Resample, HorizontalGaussian) {
     ResampleHorzTestKernel<<<1, dim3(32, 24), ResampleSharedMemSize>>>(
       img_out.data, outW*channels, outW, img_in.data, W*channels, W, H, channels,
       filter, filter.support());
-    cudaDeviceSynchronize();
+    CUDA_CALL(cudaDeviceSynchronize());
   }
 
   cv::Mat out;
@@ -108,7 +108,7 @@ TEST(Resample, HorizontalGaussian) {
   auto img_out_cpu = view_as_tensor<uint8_t, 3>(out);
   auto img_ref_cpu = view_as_tensor<uint8_t, 3>(cv_ref);
   copy(img_out_cpu, img_out);  // NOLINT
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
   EXPECT_NO_FATAL_FAILURE(Check(img_out_cpu, img_ref_cpu, EqualEps(1))) <<
   [&]() {
     cv::Mat diff;
@@ -149,7 +149,7 @@ TEST(Resample, VerticalGaussian) {
     ResampleVertTestKernel<<<1, dim3(32, 24), ResampleSharedMemSize>>>(
       img_out.data, W*channels, outH, img_in.data, W*channels, W, H, channels,
       filter, filter.support());
-    cudaDeviceSynchronize();
+    CUDA_CALL(cudaDeviceSynchronize());
   }
 
   cv::Mat out;
@@ -157,7 +157,7 @@ TEST(Resample, VerticalGaussian) {
   auto img_out_cpu = view_as_tensor<uint8_t, 3>(out);
   auto img_ref_cpu = view_as_tensor<uint8_t, 3>(cv_ref);
   copy(img_out_cpu, img_out);  // NOLINT
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
   EXPECT_NO_FATAL_FAILURE(Check(img_out_cpu, img_ref_cpu, EqualEps(1))) <<
   [&]() {
     cv::Mat diff;
@@ -214,7 +214,7 @@ class ResamplingTest : public ::testing::Test {
       output_.create(img_out_.shape[0], img_out_.shape[1], type);
       auto img_out_cpu = view_as_tensor<uint8_t, 3>(output_);
       copy(img_out_cpu, img_out_);
-      cudaDeviceSynchronize();
+      CUDA_CALL(cudaDeviceSynchronize());
     }
   }
 

--- a/dali/kernels/test/resampling_test/separable_3D_test.cu
+++ b/dali/kernels/test/resampling_test/separable_3D_test.cu
@@ -431,7 +431,8 @@ class Resample3DTest<ResamplingTestParams<Out, In, interp>>
       ASSERT_EQ(req.output_shapes.size(), 1u) << "Expected only 1 output";
       ASSERT_EQ(req.output_shapes[0], out_shape) << "Unexpected output shape";
       out.reshape(out_shape);
-      cudaMemsetAsync(out.gpu(stream).data[0], 0, sizeof(Out)*out_shape.num_elements(), stream);
+      CUDA_CALL(
+        cudaMemsetAsync(out.gpu(stream).data[0], 0, sizeof(Out)*out_shape.num_elements(), stream));
 
       sa.Reserve(req.scratch_sizes);
       auto scratchpad = sa.GetScratchpad();

--- a/dali/kernels/test/resampling_test/separable_impl_test.cc
+++ b/dali/kernels/test/resampling_test/separable_impl_test.cc
@@ -224,7 +224,7 @@ TEST_P(BatchResamplingTest, ResamplingImpl) {
   OutListGPU<uint8_t, 3> out_tlv = output.gpu();
   for (int i = 0; i < out_tlv.num_samples(); i++) {
     auto tv = out_tlv[i];
-    cudaMemset(tv.data, 0, tv.num_elements()*sizeof(*tv.data));
+    CUDA_CALL(cudaMemset(tv.data, 0, tv.num_elements()*sizeof(*tv.data)));
   }
 
 
@@ -307,7 +307,7 @@ TEST_P(BatchResamplingTest, ResamplingKernelAPI) {
   OutListGPU<uint8_t, 3> out_tlv = output.gpu();
   for (int i = 0; i < out_tlv.num_samples(); i++) {
     auto tv = out_tlv[i];
-    cudaMemset(tv.data, 0, tv.num_elements()*sizeof(*tv.data));
+    CUDA_CALL(cudaMemset(tv.data, 0, tv.num_elements()*sizeof(*tv.data)));
   }
 
   for (int i = 0; i < N; i++) {

--- a/dali/kernels/test/scratch_copy_test.cc
+++ b/dali/kernels/test/scratch_copy_test.cc
@@ -47,10 +47,13 @@ TEST(Scratchpad, ToContiguous) {
   std::vector<char> chars2(chars.size());
   std::vector<float> floats2(floats.size());
   std::vector<int16_t> shorts2(shorts.size());
-  cudaDeviceSynchronize();
-  cudaMemcpy(chars2.data(), std::get<0>(ptrs), size_bytes(chars2), cudaMemcpyDeviceToHost);
-  cudaMemcpy(floats2.data(), std::get<1>(ptrs), size_bytes(floats2), cudaMemcpyDeviceToHost);
-  cudaMemcpy(shorts2.data(), std::get<2>(ptrs), size_bytes(shorts2), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaDeviceSynchronize());
+  CUDA_CALL(
+    cudaMemcpy(chars2.data(), std::get<0>(ptrs), size_bytes(chars2), cudaMemcpyDeviceToHost));
+  CUDA_CALL(
+    cudaMemcpy(floats2.data(), std::get<1>(ptrs), size_bytes(floats2), cudaMemcpyDeviceToHost));
+  CUDA_CALL(
+    cudaMemcpy(shorts2.data(), std::get<2>(ptrs), size_bytes(shorts2), cudaMemcpyDeviceToHost));
 
   EXPECT_EQ(chars, chars);
   EXPECT_EQ(floats, floats2);

--- a/dali/kernels/test/warp_test/warp_gpu_test.cu
+++ b/dali/kernels/test/warp_test/warp_gpu_test.cu
@@ -94,7 +94,7 @@ void WarpGPU_Affine_Transpose(bool force_variable) {
   warp.Run(ctx, out.gpu(0), in_list, mappings, out_shapes_hw, {&interp, 1});
 
   auto cpu_out = out.cpu(0)[0];
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
   ASSERT_EQ(cpu_out.shape[0], img_tensor.shape[1]);
   ASSERT_EQ(cpu_out.shape[1], img_tensor.shape[0]);
   ASSERT_EQ(cpu_out.shape[2], 3);
@@ -185,7 +185,7 @@ TEST(WarpGPU, Affine_RotateScale_Single) {
   warp.Run(ctx, out.gpu(0), in_list, mappings, out_shapes_hw, {&interp, 1}, 255);
 
   auto cpu_out = out.cpu(0)[0];
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
   ASSERT_EQ(cpu_out.shape[0], out_shapes_hw[0][0]);
   ASSERT_EQ(cpu_out.shape[1], out_shapes_hw[0][1]);
   ASSERT_EQ(cpu_out.shape[2], 3);
@@ -252,7 +252,7 @@ TEST(WarpGPU, Affine_RotateScale_Uniform) {
   auto scratchpad = scratch_alloc.GetScratchpad();
   ctx.scratchpad = &scratchpad;
   warp.Run(ctx, out.gpu(0), in_list, mappings, make_span(out_shapes_hw), {&interp, 1}, 255);
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
 
   for (int i = 0; i < samples; i++) {
     auto cpu_out = out.cpu(0)[i];

--- a/dali/kernels/transpose/transpose_gpu_impl_test.cu
+++ b/dali/kernels/transpose/transpose_gpu_impl_test.cu
@@ -139,19 +139,19 @@ TEST(TransposeTiled, AllPerm4DInnermost) {
 
     std::cerr << "Testing permutation "
       << perm[0] << " " << perm[1] << " " << perm[2] << " " << perm[3] << "\n";
-    cudaMemset(out_gpu, 0xff, size*sizeof(int));
+    CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
 
     TiledTransposeDesc<int> desc;
     memset(&desc, 0xCC, sizeof(desc));
     InitTiledTranspose(desc, shape, make_span(perm), out_gpu, in_gpu, grid_size);
-    cudaEventRecord(start);
+    CUDA_CALL(cudaEventRecord(start));
     TransposeTiledSingle<<<grid_size, dim3(32, 16), kTiledTransposeMaxSharedMem>>>(desc);
-    cudaEventRecord(end);
+    CUDA_CALL(cudaEventRecord(end));
     copyD2H(out_cpu.data(), out_gpu.data(), size);
     testing::RefTranspose(ref.data(), in_cpu.data(), shape.data(), perm, 4);
 
     float time;
-    cudaEventElapsedTime(&time, start, end);
+    CUDA_CALL(cudaEventElapsedTime(&time, start, end));
     time *= 1e+6;
     std::cerr << 2*size*sizeof(int) / time << " GB/s" << "\n";
 
@@ -170,7 +170,7 @@ TEST(TransposeTiled, BuildDescVectorized) {
   DeviceBuffer<int> in_gpu, out_gpu;
   in_gpu.resize(size);
   out_gpu.resize(size);
-  cudaMemset(out_gpu, 0xff, size*sizeof(int));
+  CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
   copyH2D(in_gpu.data(), in_cpu.data(), size);
 
   SmallVector<int, 6> perm = { 1, 2, 0, 3 };
@@ -216,19 +216,19 @@ TEST(TransposeDeinterleave, AllPerm4DInnermost) {
 
     std::cerr << "Testing permutation "
       << perm[0] << " " << perm[1] << " " << perm[2] << " " << perm[3] << "\n";
-    cudaMemset(out_gpu, 0xff, size*sizeof(int));
+      CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
 
     DeinterleaveDesc<int> desc;
     memset(&desc, 0xCC, sizeof(desc));
     InitDeinterleave(desc, shape, make_span(perm), out_gpu, in_gpu);
-    cudaEventRecord(start);
+    CUDA_CALL(cudaEventRecord(start));
     TransposeDeinterleaveSingle<<<grid_size, block_size>>>(desc);
-    cudaEventRecord(end);
+    CUDA_CALL(cudaEventRecord(end));
     copyD2H(out_cpu.data(), out_gpu.data(), size);
     testing::RefTranspose(ref.data(), in_cpu.data(), shape.data(), perm, 4);
 
     float time;
-    cudaEventElapsedTime(&time, start, end);
+    CUDA_CALL(cudaEventElapsedTime(&time, start, end));
     time *= 1e+6;
     std::cerr << 2*size*sizeof(int) / time << " GB/s" << "\n";
 
@@ -257,7 +257,7 @@ TEST(TransposeGeneric, AllPerm4D) {
     std::cerr << "Testing permutation "
       << perm[0] << " " << perm[1] << " " << perm[2] << " " << perm[3] << "  input shape "
       << shape << "\n";
-    cudaMemset(out_gpu, 0xff, size*sizeof(int));
+      CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
 
     GenericTransposeDesc<int> desc;
     memset(&desc, 0xCC, sizeof(desc));
@@ -289,7 +289,7 @@ TEST(TransposeGeneric, AllPerm4D) {
     std::cerr << " input shape " << simplified_shape << "\n";
 
     memset(&desc, 0xCC, sizeof(desc));
-    cudaMemset(out_gpu, 0xff, size*sizeof(int));
+    CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
     InitGenericTranspose(desc, simplified_shape, make_span(simplified_perm), out_gpu, in_gpu);
     TransposeGenericSingle<<<grid_size, block_size>>>(desc);
     copyD2H(out_cpu.data(), out_gpu.data(), size);

--- a/dali/kernels/transpose/transpose_gpu_test.cc
+++ b/dali/kernels/transpose/transpose_gpu_test.cc
@@ -81,16 +81,16 @@ TEST(TransposeGPU, Test4DAll) {
     auto in_gpu  = in.gpu();
     auto out_gpu = out.gpu();
 
-    cudaMemset(out_gpu.data[0], 0xff, shape.num_elements() * sizeof(int));
-    cudaEventRecord(start, ctx.gpu.stream);
+    CUDA_CALL(cudaMemset(out_gpu.data[0], 0xff, shape.num_elements() * sizeof(int)));
+    CUDA_CALL(cudaEventRecord(start, ctx.gpu.stream));
     transpose.Run<int>(ctx, out_gpu, in_gpu);
-    cudaEventRecord(end, ctx.gpu.stream);
+    CUDA_CALL(cudaEventRecord(end, ctx.gpu.stream));
     CUDA_CALL(cudaGetLastError());
 
     auto ref_cpu = ref.cpu();
     auto out_cpu = out.cpu();
     float time;
-    cudaEventElapsedTime(&time, start, end);
+    CUDA_CALL(cudaEventElapsedTime(&time, start, end));
     time *= 1e+6;
     std::cerr << 2*shape.num_elements()*sizeof(int) / time << " GB/s" << "\n";
 
@@ -137,16 +137,16 @@ void RunPerfTest(RNG &rng, const TensorListShape<> &shape, span<const int> perm)
 
   transpose.Run<T>(ctx, out_gpu, in_gpu);  // warm-up
   scratch = sa.GetScratchpad();
-  cudaMemset(out_gpu.data[0], 0xff, shape.num_elements() * sizeof(T));
-  cudaEventRecord(start, ctx.gpu.stream);
+  CUDA_CALL(cudaMemset(out_gpu.data[0], 0xff, shape.num_elements() * sizeof(T)));
+  CUDA_CALL(cudaEventRecord(start, ctx.gpu.stream));
   transpose.Run<T>(ctx, out_gpu, in_gpu);
-  cudaEventRecord(end, ctx.gpu.stream);
+  CUDA_CALL(cudaEventRecord(end, ctx.gpu.stream));
   CUDA_CALL(cudaGetLastError());
 
   auto ref_cpu = ref.cpu();
   auto out_cpu = out.cpu();
   float time;
-  cudaEventElapsedTime(&time, start, end);
+  CUDA_CALL(cudaEventElapsedTime(&time, start, end));
   time *= 1e+6;
   std::cerr << 2*shape.num_elements()*sizeof(T) / time << " GB/s" << "\n";
 

--- a/dali/operators/audio/mfcc/mfcc.cu
+++ b/dali/operators/audio/mfcc/mfcc.cu
@@ -40,8 +40,9 @@ DLL_PUBLIC  void LifterCoeffs<GPUBackend>::Calculate(int64_t target_length, floa
     coeffs_.resize(target_length, stream);
     std::vector<float> new_coeffs(added_length);
     CalculateCoeffs(new_coeffs.data(), start_idx, added_length);
-    cudaMemcpyAsync(&coeffs_.data()[start_idx], new_coeffs.data(), added_length * sizeof(float),
-                    cudaMemcpyHostToDevice, stream);
+    CUDA_CALL(
+      cudaMemcpyAsync(&coeffs_.data()[start_idx], new_coeffs.data(), added_length * sizeof(float),
+                      cudaMemcpyHostToDevice, stream));
   }
 }
 

--- a/dali/operators/audio/mfcc/mfcc_test.cc
+++ b/dali/operators/audio/mfcc/mfcc_test.cc
@@ -62,26 +62,26 @@ TEST(LifterCoeffsGPU, correctness) {
   lifter = 1.234f;
   coeffs.Calculate(10, lifter);
   coeffs_cpu.resize(coeffs.size());
-  cudaMemcpy(coeffs_cpu.data(), coeffs.data(),
-             coeffs.size() * sizeof(float), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(coeffs_cpu.data(), coeffs.data(),
+                       coeffs.size() * sizeof(float), cudaMemcpyDeviceToHost));
   check_lifter_coeffs(make_cspan(coeffs_cpu), lifter, coeffs.size());
 
   coeffs.Calculate(20, lifter);
   coeffs_cpu.resize(coeffs.size());
-  cudaMemcpy(coeffs_cpu.data(), coeffs.data(),
-             coeffs.size() * sizeof(float), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(coeffs_cpu.data(), coeffs.data(),
+                       coeffs.size() * sizeof(float), cudaMemcpyDeviceToHost));
   check_lifter_coeffs(make_cspan(coeffs_cpu), lifter, coeffs.size());
 
   coeffs.Calculate(10, lifter);
   coeffs_cpu.resize(coeffs.size());
-  cudaMemcpy(coeffs_cpu.data(), coeffs.data(),
-             coeffs.size() * sizeof(float), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(coeffs_cpu.data(), coeffs.data(),
+                       coeffs.size() * sizeof(float), cudaMemcpyDeviceToHost));
   check_lifter_coeffs(make_cspan(coeffs_cpu), lifter, coeffs.size());
 
   coeffs.Calculate(5, lifter);
   coeffs_cpu.resize(coeffs.size());
-  cudaMemcpy(coeffs_cpu.data(), coeffs.data(),
-             coeffs.size() * sizeof(float), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(coeffs_cpu.data(), coeffs.data(),
+                       coeffs.size() * sizeof(float), cudaMemcpyDeviceToHost));
   check_lifter_coeffs(make_cspan(coeffs_cpu), lifter, coeffs.size());
 }
 

--- a/dali/operators/decoder/cache/image_cache_largest_test.cc
+++ b/dali/operators/decoder/cache/image_cache_largest_test.cc
@@ -128,7 +128,7 @@ TEST_F(ImageCacheLargestTest, ReadWorks) {
 
   std::vector<uint8_t> dst(4, 0x00);
   cache_->Read("4", &dst[0], 0);
-  cudaStreamSynchronize(0);
+  CUDA_CALL(cudaStreamSynchronize(0));
   EXPECT_EQ(data_[4].second, dst);
 }
 
@@ -144,7 +144,7 @@ TEST_F(ImageCacheLargestTest, GetWorks) {
   auto dev = cache_->Get("4");
   TensorView<StorageCPU, uint8_t, 3> host(dst.data(), dev.shape);
   kernels::copy(host, dev);
-  cudaStreamSynchronize(0);
+  CUDA_CALL(cudaStreamSynchronize(0));
   EXPECT_EQ(data_[4].second, dst);
 }
 

--- a/dali/operators/decoder/nvjpeg/permute_layout.cu
+++ b/dali/operators/decoder/nvjpeg/permute_layout.cu
@@ -71,7 +71,8 @@ void PlanarToInterleaved(Output *output, const Input *input, int64_t npixels,
                          int64_t comp_count, DALIImageType out_img_type, DALIDataType pixel_type,
                          cudaStream_t stream) {
   if (comp_count < 2) {
-    cudaMemcpyAsync(output, input, npixels * comp_count, cudaMemcpyDeviceToDevice, stream);
+    CUDA_CALL(
+      cudaMemcpyAsync(output, input, npixels * comp_count, cudaMemcpyDeviceToDevice, stream));
     return;
   }
   int num_blocks = div_ceil(npixels, 1024);

--- a/dali/operators/generic/constant.cu
+++ b/dali/operators/generic/constant.cu
@@ -66,7 +66,8 @@ void FillTensorList(
 
     int n = tmp.size() * sizeof(Dst);
     int N = shape.num_samples();
-    cudaMemcpyAsync(dst.mutable_tensor<Dst>(0), tmp.data(), n, cudaMemcpyHostToDevice, stream);
+    CUDA_CALL(
+      cudaMemcpyAsync(dst.mutable_tensor<Dst>(0), tmp.data(), n, cudaMemcpyHostToDevice, stream));
     int copied = 1;
     // this loop doubles the data in GPU memory, so that there are log2(N) memcpys at most
     while (copied < N) {

--- a/dali/operators/generic/constant.cu
+++ b/dali/operators/generic/constant.cu
@@ -74,8 +74,9 @@ void FillTensorList(
       int to_copy = copied;
       if (copied + to_copy > N)
         to_copy = N - copied;
-      cudaMemcpyAsync(dst.mutable_tensor<Dst>(copied), dst.mutable_tensor<Dst>(0), n * to_copy,
-                      cudaMemcpyDeviceToDevice, stream);
+      CUDA_CALL(
+        cudaMemcpyAsync(dst.mutable_tensor<Dst>(copied), dst.mutable_tensor<Dst>(0), n * to_copy,
+                        cudaMemcpyDeviceToDevice, stream));
       copied += to_copy;
     }
   }

--- a/dali/operators/generic/one_hot_test.cu
+++ b/dali/operators/generic/one_hot_test.cu
@@ -88,14 +88,14 @@ struct OneHotOpGpuPerfTest : public ::testing::Test {
     CUDAEvent start = CUDAEvent::CreateWithFlags(0);
     CUDAEvent end = CUDAEvent::CreateWithFlags(0);
 
-    cudaEventRecord(start, stream_);
+    CUDA_CALL(cudaEventRecord(start, stream_));
     constexpr int kIters = 100;
     for (int i = 0; i < kIters; i++) {
       detail::PopulateOneHot<Out, In><<<grid, block, 0, stream_>>>(
         on_value, off_value, samples_gpu_);
     }
-    cudaEventRecord(end, stream_);
-    cudaDeviceSynchronize();
+    CUDA_CALL(cudaEventRecord(end, stream_));
+    CUDA_CALL(cudaDeviceSynchronize());
     float time;
     CUDA_CALL(cudaEventElapsedTime(&time, start, end));
 

--- a/dali/operators/generic/shapes_test.cc
+++ b/dali/operators/generic/shapes_test.cc
@@ -104,7 +104,7 @@ class ShapesOpTest<ShapesTestArgs<OutputBackend, InputBackend, OutputType>>
       const TensorList<GPUBackend> &out) {
     TensorList<CPUBackend> tmp;
     tmp.Copy(out, 0);
-    cudaDeviceSynchronize();
+    CUDA_CALL(cudaDeviceSynchronize());
     VerifyShapeImpl(in, tmp);
   }
 

--- a/dali/operators/math/expressions/arithmetic_test.cc
+++ b/dali/operators/math/expressions/arithmetic_test.cc
@@ -228,7 +228,7 @@ class BinaryArithmeticOpsTest
     auto *result = ws.OutputRef<Backend>(0).template data<T>();
     vector<T> result_cpu(shape.num_elements());
     MemCopy(result_cpu.data(), result, shape.num_elements() * sizeof(T));
-    cudaStreamSynchronize(0);
+    CUDA_CALL(cudaStreamSynchronize(0));
 
     int64_t offset = 0;
     for (int i = 0; i < shape.num_samples(); i++) {
@@ -345,7 +345,7 @@ TEST(ArithmeticOpsTest, GenericPipeline) {
   vector<int32_t> result2_cpu(batch_size * tensor_elements);
 
   MemCopy(result2_cpu.data(), result2, batch_size * tensor_elements * sizeof(int));
-  cudaStreamSynchronize(0);
+  CUDA_CALL(cudaStreamSynchronize(0));
   for (int i = 0; i < batch_size * tensor_elements; i++) {
     EXPECT_EQ(result[i], data[i] + data[i]);
     EXPECT_EQ(result2_cpu[i], data[i] * (data[i] + data[i]));
@@ -403,7 +403,7 @@ TEST(ArithmeticOpsTest, FdivPipeline) {
   vector<float> result1_cpu(batch_size * tensor_elements);
 
   MemCopy(result1_cpu.data(), result1, batch_size * tensor_elements * sizeof(float));
-  cudaStreamSynchronize(0);
+  CUDA_CALL(cudaStreamSynchronize(0));
   for (int i = 0; i < batch_size * tensor_elements; i++) {
     EXPECT_EQ(result0[i], static_cast<float>(data0[i]) / data1[i]);
     EXPECT_EQ(result1_cpu[i], static_cast<float>(data0[i]) / data1[i]);
@@ -524,7 +524,7 @@ class ArithmeticOpsScalarTest :  public ::testing::TestWithParam<shape_sequence>
       vector<int> result1_cpu(result_shape.num_elements());
 
       MemCopy(result1_cpu.data(), result1, result_shape.num_elements() * sizeof(int));
-      cudaStreamSynchronize(0);
+      CUDA_CALL(cudaStreamSynchronize(0));
 
       int64_t offset_out = 0;
       int64_t offset_in[2] = {0, 0};
@@ -666,7 +666,7 @@ TEST(ArithmeticOpsTest, UnaryPipeline) {
   vector<int32_t> result1_cpu(batch_size * tensor_elements);
 
   MemCopy(result1_cpu.data(), result1, batch_size * tensor_elements * sizeof(int));
-  cudaStreamSynchronize(0);
+  CUDA_CALL(cudaStreamSynchronize(0));
   for (int i = 0; i < batch_size * tensor_elements; i++) {
     EXPECT_EQ(result0[i], -i);
     EXPECT_EQ(result1_cpu[i], -i);

--- a/dali/operators/math/expressions/arithmetic_test.cu
+++ b/dali/operators/math/expressions/arithmetic_test.cu
@@ -120,14 +120,14 @@ struct BinaryArithmeticOpGpuPerfTest : public ::testing::Test {
     CUDAEvent start = CUDAEvent::CreateWithFlags(0);
     CUDAEvent end = CUDAEvent::CreateWithFlags(0);
 
-    cudaEventRecord(start, stream);
+    CUDA_CALL(cudaEventRecord(start, stream));
     constexpr int kIters = 100;
     for (int i = 0; i < kIters; i++) {
       ExecuteTiledBinOp<TestConfig::op, Result, Left, Right, TestConfig::IsLeftTensor,
                         TestConfig::IsRightTensor><<<grid, block, 0, stream>>>(tiles_gpu);
     }
-    cudaEventRecord(end, stream);
-    cudaDeviceSynchronize();
+    CUDA_CALL(cudaEventRecord(end, stream));
+    CUDA_CALL(cudaDeviceSynchronize());
     float time;
     CUDA_CALL(cudaEventElapsedTime(&time, start, end));
 

--- a/dali/operators/python_function/dltensor_function.h
+++ b/dali/operators/python_function/dltensor_function.h
@@ -144,7 +144,7 @@ class StreamSynchronizer<GPUBackend> {
  public:
   StreamSynchronizer(DeviceWorkspace &ws, bool synchronize): previous_(GetCurrentStream()) {
     SetCurrentStream(ws.stream());
-    if (synchronize) cudaStreamSynchronize(ws.stream());
+    if (synchronize) CUDA_CALL(cudaStreamSynchronize(ws.stream()));
   }
 
   ~StreamSynchronizer() {

--- a/dali/operators/reader/video_reader_op_test.cc
+++ b/dali/operators/reader/video_reader_op_test.cc
@@ -151,7 +151,7 @@ TEST_F(VideoReaderTest, MultipleVideoResolution) {
 
   TensorList<CPUBackend> labels_cpu;
   labels_cpu.Copy(labels_output, 0);
-  cudaStreamSynchronize(0);
+  CUDA_CALL(cudaStreamSynchronize(0));
   labels_cpu.set_type(TypeInfo::Create<int>());
   const int *labels = static_cast<const int *>(labels_cpu.raw_data());
 
@@ -326,7 +326,7 @@ TEST_F(VideoReaderTest, FrameLabels) {
     labels_cpu.Copy(label_gpu, 0);
     TensorList<CPUBackend> frame_num_cpu;
     frame_num_cpu.Copy(frame_num_gpu, 0);
-    cudaStreamSynchronize(0);
+    CUDA_CALL(cudaStreamSynchronize(0));
 
     const uint8 *frames = static_cast<const uint8 *>(frames_cpu.raw_data());
     const int *label = static_cast<const int *>(labels_cpu.raw_data());
@@ -373,7 +373,7 @@ TEST_F(VideoReaderTest, FrameLabelsFilenames) {
     labels_cpu.Copy(label_gpu, 0);
     TensorList<CPUBackend> frame_num_cpu;
     frame_num_cpu.Copy(frame_num_gpu, 0);
-    cudaStreamSynchronize(0);
+    CUDA_CALL(cudaStreamSynchronize(0));
 
     const uint8 *frames = static_cast<const uint8 *>(frames_cpu.raw_data());
     const int *label = static_cast<const int *>(labels_cpu.raw_data());
@@ -421,7 +421,7 @@ TEST_F(VideoReaderTest, LabelsFilenames) {
     labels_cpu.Copy(label_gpu, 0);
     TensorList<CPUBackend> frame_num_cpu;
     frame_num_cpu.Copy(frame_num_gpu, 0);
-    cudaStreamSynchronize(0);
+    CUDA_CALL(cudaStreamSynchronize(0));
 
     const uint8 *frames = static_cast<const uint8 *>(frames_cpu.raw_data());
     const int *label = static_cast<const int *>(labels_cpu.raw_data());
@@ -472,7 +472,7 @@ TEST_F(VideoReaderTest, FrameLabelsWithFileListFrameNum) {
     frame_num_cpu.Copy(frame_num_gpu, 0);
     TensorList<CPUBackend> timestamps_cpu;
     timestamps_cpu.Copy(timestamp_gpu, 0);
-    cudaStreamSynchronize(0);
+    CUDA_CALL(cudaStreamSynchronize(0));
 
     const uint8 *frames = static_cast<const uint8 *>(frames_cpu.raw_data());
     const int *label = static_cast<const int *>(labels_cpu.raw_data());
@@ -535,7 +535,7 @@ TEST_F(VideoReaderTest, TimestampLabels) {
     timestamps_cpu.Copy(timestamp_gpu, 0);
     TensorList<CPUBackend> frame_num_cpu;
     frame_num_cpu.Copy(frame_num_gpu, 0);
-    cudaStreamSynchronize(0);
+    CUDA_CALL(cudaStreamSynchronize(0));
 
     const uint8 *frames = static_cast<const uint8 *>(frames_cpu.raw_data());
     const int *label = static_cast<const int *>(labels_cpu.raw_data());
@@ -580,7 +580,7 @@ TEST_F(VideoReaderTest, StartEndLabels) {
     labels_cpu.Copy(label_gpu, 0);
     TensorList<CPUBackend> timestamps_cpu;
     timestamps_cpu.Copy(frame_num_gpu, 0);
-    cudaStreamSynchronize(0);
+    CUDA_CALL(cudaStreamSynchronize(0));
 
     const uint8 *frames = static_cast<const uint8 *>(frames_cpu.raw_data());
     const int *label = static_cast<const int *>(labels_cpu.raw_data());

--- a/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing_test.cc
+++ b/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing_test.cc
@@ -55,7 +55,7 @@ class OpticalFlowTuringKernelTest : public ::testing::Test {
     auto p = Grayscale ? pitch_gray_ : pitch_;
 
     cc(input, tested, p, w, h, 0);
-    cudaDeviceSynchronize();
+    CUDA_CALL(cudaDeviceSynchronize());
 
     for (size_t i = 0; i < reference_data.size(); i++) {
       EXPECT_EQ(reference_data[i], tested[i]) << "Failed on index: " << i;
@@ -147,7 +147,7 @@ TEST_F(OpticalFlowTuringKernelTest, FlowVectorTest) {
           cudaMemcpy(input, test_data.data(), test_data.size() * sizeof(float), cudaMemcpyDefault));
 
   optical_flow::kernel::EncodeFlowComponents(input, tested, pitch, width, height, 0);
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
 
   for (size_t i = 0; i < reference_data.size(); i++) {
     EXPECT_EQ(reference_data[i], tested[i]) << "Failed on index: " << i;

--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -145,7 +145,7 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
       }
       vt_gpu_[j].Copy(tensor, 0);
     }
-    cudaStreamSynchronize(0);
+    CUDA_CALL(cudaStreamSynchronize(0));
     src_op->SetDataSource(vt_gpu_);
   }
 
@@ -180,7 +180,7 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
       }
       tl_gpu_.Copy(tensor_list, 0);
     }
-    cudaStreamSynchronize(0);
+    CUDA_CALL(cudaStreamSynchronize(0));
     src_op->SetDataSource(tl_gpu_);
   }
 
@@ -196,7 +196,7 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
     auto &tensor_gpu_list = ws.Output<GPUBackend>(0);
     TensorList<CPUBackend> tensor_cpu_list;
     tensor_cpu_list.Copy(tensor_gpu_list, (ws.has_stream() ? ws.stream() : 0));
-    cudaStreamSynchronize(ws.has_stream() ? ws.stream() : 0);
+    CUDA_CALL(cudaStreamSynchronize(ws.has_stream() ? ws.stream() : 0));
 
     for (int j = 0; j < this->batch_size_; ++j) {
       auto data = tensor_cpu_list.template mutable_tensor<int>(j);

--- a/dali/pipeline/util/copy_with_stride.cu
+++ b/dali/pipeline/util/copy_with_stride.cu
@@ -46,8 +46,9 @@ void CopyWithStride<GPUBackend>(void *output, const void *input,
                                 size_t item_size,
                                 cudaStream_t stream) {
   if (!in_strides) {
-    cudaMemcpyAsync(output, input, volume(shape, shape + ndim) * item_size,
-                    cudaMemcpyDeviceToDevice, stream);
+    CUDA_CALL(
+      cudaMemcpyAsync(output, input, volume(shape, shape + ndim) * item_size,
+                      cudaMemcpyDeviceToDevice, stream));
     return;
   }
   DeviceArray<Index, MAX_DIMS> out_strides{};

--- a/dali/pipeline/util/copy_with_stride_test.cc
+++ b/dali/pipeline/util/copy_with_stride_test.cc
@@ -61,13 +61,13 @@ TEST(CopyWithStrideTest, OneDimGPU) {
   Index stride = 2 * sizeof(float);
   Index shape = 3;
   float *data;
-  cudaMalloc(reinterpret_cast<void**>(&data), sizeof(float) * 6);
-  cudaMemcpy(data, h_data, sizeof(float) * 6, cudaMemcpyHostToDevice);
+  CUDA_CALL(cudaMalloc(reinterpret_cast<void**>(&data), sizeof(float) * 6));
+  CUDA_CALL(cudaMemcpy(data, h_data, sizeof(float) * 6, cudaMemcpyHostToDevice));
   float *out;
-  cudaMalloc(reinterpret_cast<void**>(&out), sizeof(float) * 3);
+  CUDA_CALL(cudaMalloc(reinterpret_cast<void**>(&out), sizeof(float) * 3));
   CopyWithStride<GPUBackend>(out, data, &stride, &shape, 1, sizeof(float));
   std::array<float, 3> h_out;
-  cudaMemcpy(h_out.data(), out, 3 * sizeof(float), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(h_out.data(), out, 3 * sizeof(float), cudaMemcpyDeviceToHost));
   ASSERT_TRUE((h_out == std::array<float, 3>{1, 3, 5}));
 }
 
@@ -79,13 +79,13 @@ TEST(CopyWithStrideTest, TwoDimsGPU) {
   Index stride[] = {8 * sizeof(size_t), sizeof(size_t)};
   Index shape[] = {2, 4};
   size_t *data;
-  cudaMalloc(reinterpret_cast<void**>(&data), sizeof(size_t) * 16);
-  cudaMemcpy(data, h_data, sizeof(size_t) * 16, cudaMemcpyHostToDevice);
+  CUDA_CALL(cudaMalloc(reinterpret_cast<void**>(&data), sizeof(size_t) * 16));
+  CUDA_CALL(cudaMemcpy(data, h_data, sizeof(size_t) * 16, cudaMemcpyHostToDevice));
   size_t *out;
-  cudaMalloc(reinterpret_cast<void**>(&out), sizeof(size_t) * 8);
+  CUDA_CALL(cudaMalloc(reinterpret_cast<void**>(&out), sizeof(size_t) * 8));
   CopyWithStride<GPUBackend>(out, data, stride, shape, 2, sizeof(size_t));
   std::array<size_t , 8> h_out;
-  cudaMemcpy(h_out.data(), out, 8 * sizeof(size_t), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(h_out.data(), out, 8 * sizeof(size_t), cudaMemcpyDeviceToHost));
   ASSERT_TRUE((h_out == std::array<size_t, 8>{11, 12, 13, 14,
                                               31, 32, 33, 34}));
 }
@@ -99,13 +99,13 @@ TEST(CopyWithStrideTest, SimpleCopyGPU) {
   Index stride[] = {4, 2, 1};
   Index shape[] = {2, 2, 2};
   uint8 *data;
-  cudaMalloc(reinterpret_cast<void**>(&data), sizeof(uint8) * 8);
-  cudaMemcpy(data, h_data, sizeof(uint8) * 8, cudaMemcpyHostToDevice);
+  CUDA_CALL(cudaMalloc(reinterpret_cast<void**>(&data), sizeof(uint8) * 8));
+  CUDA_CALL(cudaMemcpy(data, h_data, sizeof(uint8) * 8, cudaMemcpyHostToDevice));
   uint8 *out;
-  cudaMalloc(reinterpret_cast<void**>(&out), sizeof(uint8) * 8);
+  CUDA_CALL(cudaMalloc(reinterpret_cast<void**>(&out), sizeof(uint8) * 8));
   CopyWithStride<GPUBackend>(out, data, stride, shape, 3, sizeof(uint8));
   std::array<uint8 , 8> h_out;
-  cudaMemcpy(h_out.data(), out, 8 * sizeof(uint8), cudaMemcpyDeviceToHost);
+  CUDA_CALL(cudaMemcpy(h_out.data(), out, 8 * sizeof(uint8), cudaMemcpyDeviceToHost));
   ASSERT_TRUE((h_out == std::array<uint8, 8>{1, 2,
                                              3, 4,
 

--- a/dali/test/mat2tensor_test.cc
+++ b/dali/test/mat2tensor_test.cc
@@ -58,7 +58,7 @@ namespace {
 
 void CopyAsTensorGpuTest(const cv::Mat &mat) {
   auto tvpair = kernels::copy_as_tensor<kernels::AllocType::Unified>(mat);
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
   auto imgptr = mat.data;
   auto tvptr = tvpair.first.data;
   ASSERT_EQ(mat.rows * mat.cols * mat.channels(), volume(tvpair.first.shape))

--- a/include/dali/core/per_stream_pool.h
+++ b/include/dali/core/per_stream_pool.h
@@ -165,7 +165,7 @@ class PerStreamPool {
   friend class ObjectLease;
 
   void Release(std::unique_ptr<ListNode> node) {
-    cudaEventRecord(node->event, node->stream);
+    CUDA_CALL(cudaEventRecord(node->event, node->stream));
     std::lock_guard<mutex_type> guard(lock_);
     node->next = std::move(pending_);
     pending_ = std::move(node);

--- a/include/dali/core/per_stream_pool.h
+++ b/include/dali/core/per_stream_pool.h
@@ -21,6 +21,7 @@
 #include <utility>
 #include <mutex>
 #include "dali/core/cuda_event.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 
@@ -157,7 +158,7 @@ class PerStreamPool {
   template <typename... ObjectConstructorArgs>
   ObjectLease Get(cudaStream_t stream, ObjectConstructorArgs&&... args) {
     int device = -1;
-    cudaGetDevice(&device);
+    CUDA_CALL(cudaGetDevice(&device));
     return Get(device, stream, std::forward<ObjectConstructorArgs>(args)...);
   }
 
@@ -165,7 +166,7 @@ class PerStreamPool {
   friend class ObjectLease;
 
   void Release(std::unique_ptr<ListNode> node) {
-    CUDA_CALL(cudaEventRecord(node->event, node->stream));
+    CUDA_DTOR_CALL(cudaEventRecord(node->event, node->stream));
     std::lock_guard<mutex_type> guard(lock_);
     node->next = std::move(pending_);
     pending_ = std::move(node);


### PR DESCRIPTION
Signed-off-by: Rafal <Banas.Rafal97@gmail.com>

#### Why we need this PR?
- It fixes coverity issues for unchecked results of CUDA calls.

#### What happened in this PR?
 - What solution was applied:
     searched for the following calls: 
     cudaMemcpy, cudaMemcpyAsync, cudaMemset, cudaMalloc, cudaEventRecord, cudaEventElapsedTime, cudaEventSynchronize, cudaStreamSynchronize, cudaStreamWaitEvent, cudaDeviceSynchronize and added lacking CUDA_CALLs
 - Affected modules and functionalities:
     *multiple files*
 - Key points relevant for the review:
     * not much important stuff here*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *DALI-1965*
