### PR TITLE
Composite resource + renaming.

### DIFF
--- a/dali/core/mm/async_pool_test.cu
+++ b/dali/core/mm/async_pool_test.cu
@@ -55,7 +55,7 @@ TEST(MMAsyncPool, SingleStreamReuse) {
   CUDAStream stream = CUDAStream::Create(true);
   test::test_device_resource upstream;
 
-  async_pool_base<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+  async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
   stream_view sv(stream);
   int size1 = 1<<20;
   void *ptr = pool.allocate_async(size1, sv);
@@ -80,7 +80,7 @@ TEST(MMAsyncPool, TwoStream) {
   int stream_not_busy = 0;
   int success = 0;
   while (success < min_success) {
-    async_pool_base<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
     void *p1 = pool.allocate_async(1000, sv1);
     hog.run(s1);
     pool.deallocate_async(p1, 1000, sv1);
@@ -205,7 +205,7 @@ TEST(MMAsyncPool, SingleStreamRandom) {
   test::test_device_resource upstream;
 
   {
-    async_pool_base<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
     vector<block> blocks;
     detail::dummy_lock mtx;
     AsyncPoolTest(pool, blocks, mtx, stream);
@@ -224,7 +224,7 @@ TEST(MMAsyncPool, MultiThreadedSingleStreamRandom) {
     vector<block> blocks;
     std::mutex mtx;
 
-    async_pool_base<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
 
     vector<std::thread> threads;
 
@@ -245,7 +245,7 @@ TEST(MMAsyncPool, MultiThreadedSingleStreamRandom) {
 TEST(MMAsyncPool, MultiThreadedMultiStreamRandom) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_base<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
 
     vector<std::thread> threads;
 
@@ -269,7 +269,7 @@ TEST(MMAsyncPool, MultiThreadedMultiStreamRandom) {
 TEST(MMAsyncPool, MultiStreamRandomWithGPUHogs) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_base<memory_kind::device, free_tree, std::mutex> pool(&upstream, false);
+    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream, false);
 
     vector<std::thread> threads;
 
@@ -294,7 +294,7 @@ TEST(MMAsyncPool, MultiStreamRandomWithGPUHogs) {
 TEST(MMAsyncPool, CrossStream) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_base<memory_kind::device, free_tree, std::mutex> pool(&upstream, false);
+    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream, false);
 
     vector<std::thread> threads;
     vector<CUDAStream> streams;
@@ -323,7 +323,7 @@ TEST(MMAsyncPool, CrossStream) {
 TEST(MMAsyncPool, CrossStreamWithHogs) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_base<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
 
     vector<std::thread> threads;
     vector<CUDAStream> streams;

--- a/dali/core/mm/composite_resource_test.cc
+++ b/dali/core/mm/composite_resource_test.cc
@@ -120,9 +120,8 @@ TEST(MMCompositeResource, InterfacePropagation) {
 TEST(MMCompositeResource, Lifetime) {
   auto alive = std::make_shared<IsAlive>();
   auto rsrc = std::make_shared<DummyResource<memory_kind::host>>(alive.get());
-  auto cr = make_shared_composite_resource(rsrc, std::move(alive));
-  rsrc.reset();
-  cr.reset();
+  auto cr = make_shared_composite_resource(std::move(rsrc), std::move(alive));
+  cr.reset();  // the GTEST conditions are in the resource destructor
 }
 
 }  // namespace test

--- a/dali/core/mm/composite_resource_test.cc
+++ b/dali/core/mm/composite_resource_test.cc
@@ -1,0 +1,130 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <type_traits>
+#include "dali/core/mm/composite_resource.h"
+#include "dali/core/mm/async_pool.h"
+#include "dali/core/mm/malloc_resource.h"
+
+namespace dali {
+namespace mm {
+
+static_assert(std::is_convertible<
+    decltype(make_composite_resource(
+        std::make_shared<async_pool_resource<memory_kind::device>>(), 42, "the answer"))*,
+    async_memory_resource<memory_kind::device>*>::value,
+    "A composite resource made from an async resource should have an async interface");
+
+static_assert(std::is_convertible<
+    decltype(make_shared_composite_resource(
+        std::make_shared<malloc_memory_resource>(), "the answer", "is", 42).get()),
+    memory_resource<memory_kind::host>*>::value,
+    "A composite resource made from an sync resource should have a memory_resource interface");
+
+static_assert(!std::is_convertible<
+    decltype(make_composite_resource(
+        std::make_shared<malloc_memory_resource>(), 42, "the answer"))*,
+    async_memory_resource<memory_kind::host>*>::value,
+    "A composite resource made from an sync resource should not have an async interface");
+
+namespace test {
+
+namespace {
+
+struct IsAlive {
+  IsAlive() {
+    alive = true;
+  }
+  ~IsAlive() {
+    alive = false;
+  }
+  bool alive;
+};
+
+
+template <memory_kind kind>
+struct DummyResource : public async_memory_resource<kind> {
+  int allocate_seq = -1;
+  int deallocate_seq = -1;
+  int allocate_async_seq = -1;
+  int deallocate_async_seq = -1;
+  mutable int is_equal_seq = -1;
+
+  mutable int seq = 0;
+  IsAlive *alive = nullptr;
+
+  DummyResource() = default;
+  explicit DummyResource(IsAlive *alive) : alive(alive) {
+  }
+
+  ~DummyResource() {
+    if (alive != nullptr) {
+      EXPECT_TRUE(alive->alive);
+    }
+  }
+
+  void *do_allocate(size_t, size_t) override {
+    allocate_seq = ++seq;
+    return nullptr;
+  }
+
+  void *do_allocate_async(size_t bytes, size_t alignment, stream_view stream) override {
+    allocate_async_seq = ++seq;
+    return nullptr;
+  }
+
+  void do_deallocate(void *, size_t, size_t) override {
+    deallocate_seq = ++seq;
+  }
+
+  void do_deallocate_async(void *, size_t, size_t, stream_view) override {
+    deallocate_async_seq = ++seq;
+  }
+
+  bool do_is_equal(const memory_resource<kind> &other) const noexcept override {
+    is_equal_seq = ++seq;
+    return this == &other;
+  }
+};
+
+}  // namespace
+
+
+TEST(MMCompositeResource, InterfacePropagation) {
+  auto rsrc = std::make_shared<DummyResource<memory_kind::device>>();
+  auto cr = make_composite_resource(rsrc);
+  cr.allocate(0, 0);
+  cr.deallocate(nullptr, 0, 0);
+  cr.allocate_async(0, 0, {});
+  cr.deallocate_async(nullptr, 0, 0, {});
+  EXPECT_TRUE(cr.is_equal(cr));
+  EXPECT_EQ(rsrc->allocate_seq, 1);
+  EXPECT_EQ(rsrc->deallocate_seq, 2);
+  EXPECT_EQ(rsrc->allocate_async_seq, 3);
+  EXPECT_EQ(rsrc->deallocate_async_seq, 4);
+  EXPECT_EQ(rsrc->is_equal_seq, 5);
+}
+
+TEST(MMCompositeResource, Lifetime) {
+  auto alive = std::make_shared<IsAlive>();
+  auto rsrc = std::make_shared<DummyResource<memory_kind::host>>(alive.get());
+  auto cr = make_shared_composite_resource(rsrc, std::move(alive));
+  rsrc.reset();
+  cr.reset();
+}
+
+}  // namespace test
+}  // namespace mm
+}  // namespace dali

--- a/dali/core/mm/mm_test_utils.h
+++ b/dali/core/mm/mm_test_utils.h
@@ -193,8 +193,8 @@ class test_resource_wrapper<owning, security_check, memory_resource<kind, Contex
 
 template <memory_kind kind, bool owning, bool security_check,
           typename Upstream>
-class test_resource_wrapper<owning, security_check, stream_aware_memory_resource<kind>, Upstream>
-: public stream_aware_memory_resource<kind>
+class test_resource_wrapper<owning, security_check, async_memory_resource<kind>, Upstream>
+: public async_memory_resource<kind>
 , public test_resource_wrapper_impl<owning, security_check, Upstream> {
   static_assert(!security_check || kind != memory_kind::device,
                 "Cannot place a security cookie in device memory");
@@ -231,6 +231,8 @@ class test_resource_wrapper<owning, security_check, stream_aware_memory_resource
       return this->upstream_->deallocate_async(p, b, a, sv);
     }, ptr, bytes, alignment, strm_vw);
   }
+
+ public:
 };
 
 struct test_host_resource
@@ -254,9 +256,9 @@ struct test_device_resource
   test_device_resource() : test_resource_wrapper(&cuda_malloc_memory_resource::instance()) {}
 };
 
-template <memory_kind kind, bool owning, typename Upstream = stream_aware_memory_resource<kind>>
+template <memory_kind kind, bool owning, typename Upstream = async_memory_resource<kind>>
 using test_stream_resource = test_resource_wrapper<
-    owning, detail::is_host_memory(kind), stream_aware_memory_resource<kind>, Upstream>;
+    owning, detail::is_host_memory(kind), async_memory_resource<kind>, Upstream>;
 
 
 class test_dev_pool_resource : public test_stream_resource<memory_kind::device, true> {

--- a/dali/core/mm/pinned_pool_test.cc
+++ b/dali/core/mm/pinned_pool_test.cc
@@ -32,7 +32,7 @@ TEST(MMPinnedAlloc, StageCopy) {
   {
     CUDAStream stream = CUDAStream::Create(true);
     stream_view sv(stream);
-    async_pool_base<memory_kind::pinned> pool(&upstream);
+    async_pool_resource<memory_kind::pinned> pool(&upstream);
     std::mt19937_64 rng;
     const int N = 1<<20;
     vector<uint8_t> pattern(N), copy_back(N);
@@ -61,7 +61,7 @@ TEST(MMPinnedAlloc, SyncAndSteal) {
     s2 = CUDAStream::Create(true);
     stream_view sv1(s1), sv2(s2);
     const int N = 1<<24;
-    async_pool_base<memory_kind::pinned> pool(&upstream, true);
+    async_pool_resource<memory_kind::pinned> pool(&upstream, true);
     void *mem1 = pool.allocate_async(N, sv1);
     CUDA_CALL(cudaMemsetAsync(mem1, 0, N, s1));
     pool.deallocate_async(mem1, N, sv1);
@@ -97,7 +97,7 @@ TEST(MMPinnedAlloc, SyncCrossDevice) {
     cudaSetDevice(0);
     stream_view sv1(s1), sv2(s2);
     const int N = 1<<24;
-    async_pool_base<memory_kind::pinned> pool(&upstream, true);
+    async_pool_resource<memory_kind::pinned> pool(&upstream, true);
     void *mem1 = pool.allocate_async(N, sv1);
     CUDA_CALL(cudaMemsetAsync(mem1, 0, N, s1));
     pool.deallocate_async(mem1, N, sv1);
@@ -133,7 +133,7 @@ TEST(MMPinnedAlloc, FreeOnAnotherDevice) {
     cudaSetDevice(0);
     stream_view sv1(s1), sv2(s2);
     const int N = 1<<24;
-    async_pool_base<memory_kind::pinned> pool(&upstream, true);
+    async_pool_resource<memory_kind::pinned> pool(&upstream, true);
     void *mem1 = pool.allocate_async(N, sv1);
     CUDA_CALL(cudaMemsetAsync(mem1, 0, N, s1));
     cudaStreamSynchronize(s1);

--- a/include/dali/core/cuda_event_pool.h
+++ b/include/dali/core/cuda_event_pool.h
@@ -42,7 +42,7 @@ class DLL_PUBLIC CUDAEventPool {
    * @brief Place an event for given device in the pool.
    *
    * @param event     CUDA event wrapper object. The caller relinquishes ownership of the event.
-   * @param device_d  CUDA runtime API device ordinal of the device for which the event was
+   * @param device_id CUDA runtime API device ordinal of the device for which the event was
    *                  created. If negative, calling thread's current device is used.
    *
    * @remarks It is an error to misstate the device_id. Placing an event with improper deviceid

--- a/include/dali/core/mm/async_pool.h
+++ b/include/dali/core/mm/async_pool.h
@@ -36,17 +36,17 @@ namespace mm {
 
 template <memory_kind kind, typename FreeList = free_tree,
           typename LockType = std::mutex, typename Upstream = memory_resource<kind>>
-class async_pool_base : public stream_aware_memory_resource<kind> {
+class async_pool_resource : public async_memory_resource<kind> {
  public:
   /**
    * @param upstream       Upstream resource, used by the global pool
    * @param avoid_upstream If true, synchronize with outstanding deallocations before
    *                       using upstream.
    */
-  explicit async_pool_base(Upstream *upstream, bool avoid_upstream = true)
+  explicit async_pool_resource(Upstream *upstream, bool avoid_upstream = true)
   : global_pool_(upstream), avoid_upstream_(avoid_upstream) {
   }
-  ~async_pool_base() {
+  ~async_pool_resource() {
     try {
       synchronize();
     } catch (const CUDAError &e) {

--- a/include/dali/core/mm/composite_resource.h
+++ b/include/dali/core/mm/composite_resource.h
@@ -1,0 +1,137 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_MM_COMPOSITE_RESOURCE_H_
+#define DALI_CORE_MM_COMPOSITE_RESOURCE_H_
+
+#include <type_traits>
+#include <memory>
+#include <tuple>
+#include <utility>
+#include "dali/core/mm/memory_resource.h"
+
+namespace dali {
+namespace mm {
+
+namespace detail {
+
+template <memory_kind kind, typename Context>
+memory_resource<kind, Context> &GetResourceInterface(const memory_resource<kind, Context> &);
+
+template <memory_kind kind>
+async_memory_resource<kind> &GetResourceInterface(const async_memory_resource<kind> &);
+
+template <typename Resource>
+using resource_interface_t = std::remove_reference_t<
+    decltype(GetResourceInterface(std::declval<Resource>()))>;
+
+
+template <typename Interface, typename Resource, typename...Extra>
+class CompositeResourceBase : public Interface {
+ public:
+  CompositeResourceBase() = default;
+
+  template <typename... ExtraArgs>
+  CompositeResourceBase(std::shared_ptr<Resource> resource,
+                    ExtraArgs... extra)
+  : extra{std::forward<ExtraArgs>(extra)...}
+  , resource(std::move(resource)) {
+    static_assert(sizeof...(ExtraArgs) == sizeof...(Extra), "Incorrect number of extra values");
+  }
+
+ protected:
+  std::tuple<Extra... > extra;
+  std::shared_ptr<Resource> resource;
+
+ private:
+  bool do_is_equal(const memory_resource<Resource::kind> &other) const noexcept override {
+    if (auto *other_composite = dynamic_cast<const CompositeResourceBase *>(&other)) {
+      if ((resource != nullptr) != (other_composite->resource != nullptr))
+        return false;  // one is null, the other is not
+
+      // both null or really equal
+      return !resource || resource->is_equal(*other_composite ->resource);
+    } else {
+      return resource->is_equal(other);
+    }
+  }
+  void *do_allocate(size_t bytes, size_t alignment) override {
+    return resource->allocate(bytes, alignment);
+  }
+  void do_deallocate(void *mem, size_t bytes, size_t alignment) override {
+    resource->deallocate(mem, bytes, alignment);
+  }
+};
+
+template <typename Interface, typename Resource, typename... Extra>
+class CompositeResourceImpl;
+
+template <memory_kind kind, typename Context, typename Resource, typename... Extra>
+class CompositeResourceImpl<memory_resource<kind, Context>, Resource, Extra...>
+: public CompositeResourceBase<memory_resource<kind, Context>, Resource, Extra...> {
+ public:
+  using Base = CompositeResourceBase<memory_resource<kind, Context>, Resource, Extra...>;
+  using Base::Base;
+};
+
+template <memory_kind kind, typename Resource, typename... Extra>
+class CompositeResourceImpl<async_memory_resource<kind>, Resource, Extra...>
+: public CompositeResourceBase<async_memory_resource<kind>, Resource, Extra...> {
+ public:
+  using Base = CompositeResourceBase<async_memory_resource<kind>, Resource, Extra...>;
+  using Base::Base;
+
+ private:
+  void *do_allocate_async(size_t bytes, size_t alignment, stream_view stream) override {
+    return this->resource->allocate_async(bytes, alignment, stream);
+  }
+  void do_deallocate_async(void *mem, size_t bytes, size_t alignment, stream_view stream) override {
+    this->resource->deallocate_async(mem, bytes, alignment, stream);
+  }
+};
+
+}  // namespace detail
+
+/**
+ * @brief Aggregates a memory resource and some additional data.
+ *
+ * Typical examples of extra data would be upstream resources. The object is constructed
+ * in a way that guarantees that the extra data is not destroyed before the resource is,
+ * enabling proper cleanup.
+ */
+template <typename Resource, typename... Extra>
+class CompositeResource
+: public detail::CompositeResourceImpl<detail::resource_interface_t<Resource>, Resource, Extra...> {
+ public:
+  using interface_type = detail::resource_interface_t<Resource>;
+  using Base = detail::CompositeResourceImpl<interface_type, Resource, Extra...>;
+  using Base::Base;
+};
+
+
+template <typename Resource, typename... Extra>
+auto make_composite_resource(std::shared_ptr<Resource> resource, Extra... args) {
+  return CompositeResource<Resource, Extra...>(std::move(resource), std::move(args)...);
+}
+
+template <typename Resource, typename... Extra>
+auto make_shared_composite_resource(std::shared_ptr<Resource> resource, Extra... args) {
+  return std::make_shared<CompositeResource<Resource, Extra...>>(
+    std::move(resource), std::move(args)...);
+}
+
+}  // namespace mm
+}  // namespace dali
+
+#endif  // DALI_CORE_MM_COMPOSITE_RESOURCE_H_

--- a/include/dali/core/mm/memory_resource.h
+++ b/include/dali/core/mm/memory_resource.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ namespace mm {
 
 using rmm::mr::memory_resource;
 using rmm::mr::host_memory_resource;
-using rmm::mr::device_memory_resource;
 using rmm::mr::memory_kind;
 using pinned_memory_resource = memory_resource<memory_kind::pinned>;
 using pinned_malloc_memory_resource = rmm::mr::pinned_memory_resource;
@@ -49,7 +48,10 @@ using stream_view = rmm::cuda_stream_view;
 using rmm::mr::any_context;
 
 template <memory_kind kind>
-using stream_aware_memory_resource = rmm::mr::stream_ordered_memory_resource<kind>;
+using async_memory_resource = rmm::mr::stream_ordered_memory_resource<kind>;
+
+using device_async_resource = async_memory_resource<memory_kind::device>;
+using pinned_async_resource = async_memory_resource<memory_kind::pinned>;
 
 struct stream_context {
   stream_view stream;


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature: composite resource needed to couple lifetime of a resource with its dependencies.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added a class which aggregates a memory resource and some extra data (e.g. upstreams)
     * Renamed stream_aware_memory_resource to a much shorter async_memory_resource.
 - Affected modules and functionalities:
     * Memory manager
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * GTest
 - Documentation (including examples):
     * Comments


**JIRA TASK**: DALI-1813
