### PR TITLE
Fix cuda 11.3 warnings

### DIFF
--- a/dali/kernels/imgproc/resample/resampling_impl.cuh
+++ b/dali/kernels/imgproc/resample/resampling_impl.cuh
@@ -495,6 +495,18 @@ __device__ void ResampleDepth_Channels(
     const Src *__restrict__ in, ptrdiff_vec<1> in_strides, ivec2 in_shape, int dynamic_channels,
     ResamplingFilter filter, int support) {
   // Unreachable code - no assert to avoid excessive register pressure.
+  (void) lo;
+  (void) hi;
+  (void) src_z0;
+  (void) scale;
+  (void) out;
+  (void) out_strides;
+  (void) in;
+  (void) in_strides;
+  (void) in_shape;
+  (void) dynamic_channels;
+  (void) filter;
+  (void) support;
 }
 
 /**

--- a/dali/pipeline/operator/operator_factory.h
+++ b/dali/pipeline/operator/operator_factory.h
@@ -88,27 +88,35 @@ class Registerer {
 
 
 // Creators a registry object for a specific op type
-#define DALI_DECLARE_OPTYPE_REGISTRY(RegistryName, OpType)            \
-  class DLL_PUBLIC RegistryName##Registry {                           \
-   public:                                                            \
+#define DALI_DECLARE_OPTYPE_REGISTRY(RegistryName, OpType)              \
+  class DLL_PUBLIC RegistryName##Registry {                             \
+   public:                                                              \
     DLL_PUBLIC static ::dali::OperatorRegistry<OpType>& Registry();     \
   };
 
 #define DALI_DEFINE_OPTYPE_REGISTRY(RegistryName, OpType)               \
   dali::OperatorRegistry<OpType>& RegistryName##Registry::Registry() {  \
-    static ::dali::OperatorRegistry<OpType> registry;                     \
+    static ::dali::OperatorRegistry<OpType> registry;                   \
     return registry;                                                    \
   }
 
 // Helper to define a registerer for a specific op type. Each op type
 // defines its own, more aptly named, registration macros on top of this
+#if defined(__CUDACC__)
+  #pragma push
+  // suppress "function was declared but never referenced warning" for nvcc
+  #pragma diag_suppress 177
+#endif
 #define DALI_DEFINE_OPTYPE_REGISTERER(OpName, DerivedType,              \
     RegistryName, OpType, dev)                                          \
   namespace {                                                           \
-    static ::dali::Registerer<OpType> ANONYMIZE_VARIABLE(anon##OpName)(   \
+    static ::dali::Registerer<OpType> ANONYMIZE_VARIABLE(anon##OpName)( \
         #OpName, &RegistryName##Registry::Registry(),                   \
-        ::dali::Registerer<OpType>::OperatorCreator<DerivedType>, dev);   \
+        ::dali::Registerer<OpType>::OperatorCreator<DerivedType>, dev); \
   }
+#if defined(__CUDACC__)
+  #pragma pop
+#endif
 
 }  // namespace dali
 


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It fixes CUDA 11.3 compiler warnings

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     fixes unused argument warning in resampling_impl.cuh
     fixes unreferenced variable waring in operator_factory.h
 - Affected modules and functionalities:
     resampling_impl.cuh
     operator_factory.h
 - Key points relevant for the review:
     NA
 - Validation and testing:
     visual examination of the build log
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
