### PR TITLE
Use NPP to convert from RGB to YCbCr in nvjpeg decoder

### DIFF
--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -24,7 +24,11 @@ DALI_SCHEMA(ImageDecoderAttr)
   .NumInput(1)
   .NumOutput(1)
   .AddOptionalArg("output_type",
-      R"code(The color space of the output image.)code",
+      R"code(The color space of the output image.
+
+Note: When decoding to YCbCr, the image will be decoded to RGB and then converted to YCbCr,
+following the YCbCr definition from ITU-R BT.601.
+)code",
       DALI_RGB)
   .AddOptionalArg("hybrid_huffman_threshold",
       R"code(Applies **only** to the ``mixed`` backend type.

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -778,12 +778,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
           int i = sample->sample_idx;
           auto data = output.mutable_tensor<uint8_t>(i);
           auto sh = output_shape_.tensor_shape(i);
-          NppiSize size;
-          size.height = sh[0];
-          size.width = sh[1];
-          int step = sh[1] * 3;
-          DALI_CHECK_NPP(nppiRGBToYCbCr_8u_C3R_Ctx(data, step, data, step, size,
-                                                   GetNppContext(hw_decode_stream_)));
+          ConvertRGBToYCbCr(data, sh[0], sh[1], hw_decode_stream_);
         }
       }
 
@@ -918,12 +913,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
         // We don't directly to YCbCr, since we want to control the YCbCr definition,
         // which is different between general color conversion libraries (OpenCV) and
         // what JPEG uses.
-        NppiSize size;
-        size.height = out_shape[0];
-        size.width = out_shape[1];
-        int step = out_shape[1] * 3;
-        DALI_CHECK_NPP(nppiRGBToYCbCr_8u_C3R_Ctx(output_data, step, output_data, step, size,
-                                                 GetNppContext(stream)));
+        ConvertRGBToYCbCr(output_data, out_shape[0], out_shape[1], stream);
       }
 
       CacheStore(file_name, output_data, out_shape, stream);

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
@@ -14,6 +14,7 @@
 
 #include <string>
 #include "dali/operators/decoder/nvjpeg/nvjpeg_helper.h"
+#include "dali/util/npp.h"
 
 namespace dali {
 
@@ -40,6 +41,14 @@ const char* nvjpeg_parse_error_code(nvjpegStatus_t code) {
     default:
       return "";
   }
+}
+
+void ConvertRGBToYCbCr(uint8_t* data, int64_t h, int64_t w, cudaStream_t stream) {
+  int step = w * 3;
+  NppiSize size;
+  size.height = h;
+  size.width = w;
+  DALI_CHECK_NPP(nppiRGBToYCbCr_8u_C3R_Ctx(data, step, data, step, size, GetNppContext(stream)));
 }
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
@@ -88,13 +88,13 @@ inline nvjpegOutputFormat_t GetFormat(DALIImageType type) {
   switch (type) {
     case DALI_RGB:
     case DALI_ANY_DATA:
+    case DALI_YCbCr:  // purposedly not using NVJPEG_OUTPUT_YUV, as we want to control the
+                      // definition of YCbCr to be consistent with the host backend
       return NVJPEG_OUTPUT_RGBI;
     case DALI_BGR:
       return NVJPEG_OUTPUT_BGRI;
     case DALI_GRAY:
       return NVJPEG_OUTPUT_Y;
-    case DALI_YCbCr:
-      return NVJPEG_OUTPUT_YUV;
     default:
       return NVJPEG_OUTPUT_FORMAT_MAX;  // doesn't matter (will fallback to host decoder)
   }

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
@@ -171,6 +171,8 @@ void HostFallback(const uint8_t *data, int size, DALIImageType image_type, uint8
   kernels::copy<StorageType, StorageCPU>(output_buffer, decoded.get(), volume(shape), stream);
 }
 
+void ConvertRGBToYCbCr(uint8_t* data, int64_t h, int64_t w, cudaStream_t stream);
+
 }  // namespace dali
 
 #endif  // DALI_OPERATORS_DECODER_NVJPEG_NVJPEG_HELPER_H_

--- a/dali/util/npp.cc
+++ b/dali/util/npp.cc
@@ -39,7 +39,7 @@ namespace {
 
 NppStreamContext GetNppContextImpl() {
   NppStreamContext ctx;
-  ctx.hStream = nullptr;
+  ctx.hStream = 0;
   CUDA_CALL(cudaGetDevice(&ctx.nCudaDeviceId));
   int driver_ver, runtime_ver;
   cudaDriverGetVersion(&driver_ver);

--- a/dali/util/npp.h
+++ b/dali/util/npp.h
@@ -334,6 +334,16 @@ static const char *nppErrorString(NppStatus error) {
   return "<unknown>";
 }
 
+template <typename T>
+NppiSize ToNppiSize(const T& size) {
+  NppiSize out;
+  out.width = size.width;
+  out.height = size.height;
+  return out;
+}
+
+DLL_PUBLIC NppStreamContext GetNppContext(cudaStream_t stream);
+
 }  // namespace dali
 
 // For checking npp return errors in dali library functions
@@ -345,17 +355,9 @@ static const char *nppErrorString(NppStatus error) {
       dali::string line = std::to_string(__LINE__);       \
       dali::string error = "[" + file + ":" + line +      \
         "]: NPP error \"" +                               \
-        nppErrorString(status) + "\"";                    \
+        dali::nppErrorString(status) + "\"";              \
       DALI_FAIL(error);                                   \
     }                                                     \
   } while (0)
-
-template <typename T>
-NppiSize ToNppiSize(const T& size) {
-  NppiSize out;
-  out.width = size.width;
-  out.height = size.height;
-  return out;
-}
 
 #endif  // DALI_UTIL_NPP_H_


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a the internal usage of nvjpeg for YCbCr outputs. Instead, we will decode to RGB and then convert to YCbCr with NPP.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Start using NPP _Ctx APIs*
     *nvjpeg decoder: Decoding to RGB and using NPP in to convert from RGB to YCbCr*
 - Affected modules and functionalities:
     *ImageDecoder*
 - Key points relevant for the review:
     *Logic in nvjpeg decoder*
 - Validation and testing:
     *Exsiting tests*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-1976]*
