### PR TITLE
Use stream 0 in VideoDecoder when running driver >460 / CUDA >= 11.3.

### DIFF
--- a/dali/operators/CMakeLists.txt
+++ b/dali/operators/CMakeLists.txt
@@ -57,7 +57,11 @@ add_library(dali_operators ${LIBTYPE} ${DALI_OPERATOR_SRCS} ${DALI_OPERATOR_OBJ}
 set_target_properties(dali_operators PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${DALI_LIBRARY_OUTPUT_DIR}")
 target_link_libraries(dali_operators PUBLIC dali dali_kernels dali_core)
-target_link_libraries(dali_operators PRIVATE dynlink_cuda dynlink_nvml ${DALI_LIBS})
+target_link_libraries(dali_operators PRIVATE dynlink_cuda ${DALI_LIBS})
+if (BUILD_NVML)
+  target_link_libraries(dali_operators PRIVATE $<TARGET_OBJECTS:dynlink_nvml>)
+endif(BUILD_NVML)
+
 if (BUILD_CUFILE)
   target_link_libraries(dali_operators PRIVATE dynlink_cufile)
 endif()

--- a/dali/operators/CMakeLists.txt
+++ b/dali/operators/CMakeLists.txt
@@ -57,7 +57,7 @@ add_library(dali_operators ${LIBTYPE} ${DALI_OPERATOR_SRCS} ${DALI_OPERATOR_OBJ}
 set_target_properties(dali_operators PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${DALI_LIBRARY_OUTPUT_DIR}")
 target_link_libraries(dali_operators PUBLIC dali dali_kernels dali_core)
-target_link_libraries(dali_operators PRIVATE dynlink_cuda ${DALI_LIBS})
+target_link_libraries(dali_operators PRIVATE dynlink_cuda dynlink_nvml ${DALI_LIBS})
 if (BUILD_CUFILE)
   target_link_libraries(dali_operators PRIVATE dynlink_cufile)
 endif()

--- a/dali/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/operators/reader/nvdecoder/nvdecoder.cc
@@ -84,6 +84,7 @@ NvDecoder::NvDecoder(int device_id,
   }
 #endif
   if (use_default_stream) {
+    DALI_WARN_ONCE("Warning: Decoding on a default stream. Performance may be affected.");
     stream_.reset(0);
   } else {
     stream_ = CUDAStream::Create(true, device_id);


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: crash when running 2 video decoders in parallel.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Detect driver version >460 or driver CUDA version >= 11.3 and use default stream
 - Affected modules and functionalities:
     * NVDEC
     * dali_operators linkage (added dependency on dynlink_nvml)
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests cover it
 - Documentation (including examples):
     * N/A


**JIRA TASK**: [DALI-1973]
