### PR TITLE
Fix docs and rename numba_func to numba_function

### DIFF
--- a/dali/operators/numba_function/numba_func.cc
+++ b/dali/operators/numba_function/numba_func.cc
@@ -17,7 +17,7 @@
 
 namespace dali {
 
-DALI_SCHEMA(NumbaFunc)
+DALI_SCHEMA(NumbaFunction)
   .DocStr(R"code(Invokes a njit compiled Numba function.
 
 The run function should be a Python function that can be compiled in Numba ``nopython`` mode.

--- a/dali/python/nvidia/dali/plugin/numba/__init__.py
+++ b/dali/python/nvidia/dali/plugin/numba/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import experimental

--- a/dali/python/nvidia/dali/plugin/numba/experimental.py
+++ b/dali/python/nvidia/dali/plugin/numba/experimental.py
@@ -58,8 +58,8 @@ def _get_shape_view(shapes_ptr, ndims_ptr, num_dims, num_samples):
         l.append(d)
     return l
 
-class NumbaFunc(metaclass=ops._DaliOperatorMeta):
-    ops.register_cpu_op('NumbaFunc')
+class NumbaFunction(metaclass=ops._DaliOperatorMeta):
+    ops.register_cpu_op('NumbaFunction')
 
     @property
     def spec(self):
@@ -84,7 +84,7 @@ class NumbaFunc(metaclass=ops._DaliOperatorMeta):
                         numba_types.uint64,
                         numba_types.uint64,
                         numba_types.int32, numba_types.int32)
-                
+
     def _run_fn_sig(self, batch_processing=False):
         sig_types = []
         sig_types.append(numba_types.uint64)
@@ -126,7 +126,7 @@ class NumbaFunc(metaclass=ops._DaliOperatorMeta):
     def __call__(self, *inputs, **kwargs):
         pipeline = Pipeline.current()
         if pipeline is None:
-            Pipeline._raise_no_current_pipeline("NumbaFunc")
+            Pipeline._raise_no_current_pipeline("NumbaFunction")
         inputs = ops._preprocess_inputs(inputs, self._impl_name, self._device, None)
         if pipeline is None:
             Pipeline._raise_pipeline_required("NumbaFunction operator")
@@ -255,7 +255,7 @@ class NumbaFunc(metaclass=ops._DaliOperatorMeta):
                     out4 = out4_lambda(address_as_void_pointer(out_arr[4]), out_shapes_np[4][0])
                 if num_outs >= 6:
                     out5 = out5_lambda(address_as_void_pointer(out_arr[5]), out_shapes_np[5][0])
-                
+
                 in0 = in1 = in2 = in3 = in4 = in5 = None
                 in_shapes_np = _get_shape_view(in_shapes_ptr, in_ndims_ptr, num_ins, 1)
                 in_arr = carray(address_as_void_pointer(in_ptr), num_ins, dtype=np.int64)
@@ -273,7 +273,7 @@ class NumbaFunc(metaclass=ops._DaliOperatorMeta):
                     in5 = in5_lambda(address_as_void_pointer(in_arr[5]), in_shapes_np[5][0])
 
                 run_fn_lambda(run_fn, out0, out1, out2, out3, out4, out5, in0, in1, in2, in3, in4, in5)
-        
+
         self._impl_name = "NumbaFuncImpl"
         self._schema = _b.GetSchema(self._impl_name)
         self._spec = _b.OpSpec(self._impl_name)
@@ -286,12 +286,12 @@ class NumbaFunc(metaclass=ops._DaliOperatorMeta):
 
         self.run_fn = run_cfunc.address
         self.setup_fn = setup_fn_address
-        self.out_types = out_types 
-        self.in_types = in_types 
-        self.outs_ndim = outs_ndim 
+        self.out_types = out_types
+        self.in_types = in_types
+        self.outs_ndim = outs_ndim
         self.ins_ndim = ins_ndim
         self.num_outputs = len(out_types)
         self.batch_processing = batch_processing
         self._preserve = True
 
-ops._wrap_op(NumbaFunc, "fn.experimental", __name__)
+ops._wrap_op(NumbaFunction, "fn.experimental", "nvidia.dali.plugin.numba")

--- a/dali/test/python/test_operator_numba_func.py
+++ b/dali/test/python/test_operator_numba_func.py
@@ -21,7 +21,7 @@ import nvidia.dali as dali
 import nvidia.dali.fn as fn
 import nvidia.dali.types as dali_types
 from test_utils import get_dali_extra_path
-from nvidia.dali.plugin.numba.fn.experimental import numba_func
+from nvidia.dali.plugin.numba.fn.experimental import numba_function
 
 test_data_root = get_dali_extra_path()
 lmdb_folder = os.path.join(test_data_root, 'db', 'lmdb')
@@ -62,7 +62,7 @@ def get_data_zeros(shapes, dtype):
 @pipeline_def
 def numba_func_pipe(shapes, dtype, run_fn=None, out_types=None, in_types=None, outs_ndim=None, ins_ndim=None, setup_fn=None, batch_processing=None):
     data = fn.external_source(lambda: get_data(shapes, dtype), batch=True, device = "cpu")
-    return numba_func(data, run_fn=run_fn, out_types=out_types, in_types=in_types, outs_ndim=outs_ndim, ins_ndim=ins_ndim, setup_fn=setup_fn, batch_processing=batch_processing)
+    return numba_function(data, run_fn=run_fn, out_types=out_types, in_types=in_types, outs_ndim=outs_ndim, ins_ndim=ins_ndim, setup_fn=setup_fn, batch_processing=batch_processing)
 
 def _testimpl_numba_func(shapes, dtype, run_fn, out_types, in_types, outs_ndim, ins_ndim, setup_fn, batch_processing, expected_out):
     batch_size = len(shapes)
@@ -93,7 +93,7 @@ def test_numba_func():
 def numba_func_image_pipe(run_fn=None, out_types=None, in_types=None, outs_ndim=None, ins_ndim=None, setup_fn=None, batch_processing=None):
     files, _ = dali.fn.readers.caffe(path=lmdb_folder)
     images_in = dali.fn.decoders.image(files, device="cpu")
-    images_out = numba_func(images_in, run_fn=run_fn, out_types=out_types, in_types=in_types, outs_ndim=outs_ndim, ins_ndim=ins_ndim, setup_fn=setup_fn, batch_processing=batch_processing)
+    images_out = numba_function(images_in, run_fn=run_fn, out_types=out_types, in_types=in_types, outs_ndim=outs_ndim, ins_ndim=ins_ndim, setup_fn=setup_fn, batch_processing=batch_processing)
     return images_in, images_out
 
 def _testimpl_numba_func_image(run_fn, out_types, in_types, outs_ndim, ins_ndim, setup_fn, batch_processing, transform):
@@ -165,7 +165,7 @@ def setup_split_images_col(outs, ins):
 def numba_func_split_image_pipe(run_fn=None, out_types=None, in_types=None, outs_ndim=None, ins_ndim=None, setup_fn=None, batch_processing=None):
     files, _ = dali.fn.readers.caffe(path=lmdb_folder)
     images_in = dali.fn.decoders.image(files, device="cpu")
-    out0, out1, out2 = numba_func(images_in, run_fn=run_fn, out_types=out_types, in_types=in_types, outs_ndim=outs_ndim, ins_ndim=ins_ndim, setup_fn=setup_fn, batch_processing=batch_processing)
+    out0, out1, out2 = numba_function(images_in, run_fn=run_fn, out_types=out_types, in_types=in_types, outs_ndim=outs_ndim, ins_ndim=ins_ndim, setup_fn=setup_fn, batch_processing=batch_processing)
     return images_in, out0, out1, out2
 
 def test_split_images_col():
@@ -197,7 +197,7 @@ def numba_multiple_ins_pipe(shapes, dtype, run_fn=None, out_types=None, in_types
     data0 = fn.external_source(lambda: get_data_zeros(shapes, dtype), batch=True, device = "cpu")
     data1 = fn.external_source(lambda: get_data_zeros(shapes, dtype), batch=True, device = "cpu")
     data2 = fn.external_source(lambda: get_data_zeros(shapes, dtype), batch=True, device = "cpu")
-    return numba_func(data0, data1, data2, run_fn=run_fn, out_types=out_types, in_types=in_types, outs_ndim=outs_ndim, ins_ndim=ins_ndim, setup_fn=setup_fn, batch_processing=batch_processing)
+    return numba_function(data0, data1, data2, run_fn=run_fn, out_types=out_types, in_types=in_types, outs_ndim=outs_ndim, ins_ndim=ins_ndim, setup_fn=setup_fn, batch_processing=batch_processing)
 
 def test_multiple_ins():
     pipe = numba_multiple_ins_pipe(shapes=[(10, 10)], dtype=np.uint8, batch_size=8, num_threads=1, device_id=0, run_fn=multiple_ins_run, setup_fn=multiple_ins_setup,

--- a/docs/autodoc_submodules.py
+++ b/docs/autodoc_submodules.py
@@ -8,6 +8,7 @@ import inspect
 # Dictionary with modules that can have registered Ops
 ops_modules = {
     'nvidia.dali.ops': nvidia.dali.ops,
+    'nvidia.dali.plugin.numba.experimental': nvidia.dali.plugin.numba.experimental,
 }
 
 exclude_ops_members = {
@@ -16,7 +17,8 @@ exclude_ops_members = {
 
 fn_modules = {
     'nvidia.dali.fn': nvidia.dali.fn,
-    'nvidia.dali.plugin': nvidia.dali.plugin
+    'nvidia.dali.plugin.pytorch.fn': nvidia.dali.plugin.pytorch.fn,
+    'nvidia.dali.plugin.numba.fn.experimental': nvidia.dali.plugin.numba.fn.experimental,
 }
 
 exclude_fn_members = {

--- a/docs/math.rst
+++ b/docs/math.rst
@@ -103,7 +103,7 @@ Currently, DALI supports the following operations:
 
 
 Mathematical Functions
----------------------
+----------------------
 
 Similarly to arithmetic expressions, one can use selected mathematical functions in the Pipeline
 graph definition. They also accept :class:`nvidia.dali.pipeline.DataNode`,

--- a/docs/operations_table.py
+++ b/docs/operations_table.py
@@ -2,20 +2,20 @@ from nvidia.dali import backend as b
 import nvidia.dali.ops as ops
 import nvidia.dali.fn as fn
 import nvidia.dali.plugin.pytorch
-import nvidia.dali.plugin.numba
+import nvidia.dali.plugin.numba.experimental
 import sys
 
 # Dictionary with modules that can have registered Ops
 ops_modules = {
     'nvidia.dali.ops': nvidia.dali.ops,
     'nvidia.dali.plugin.pytorch': nvidia.dali.plugin.pytorch,
-    'nvidia.dali.plugin.numba': nvidia.dali.plugin.numba
+    'nvidia.dali.plugin.numba.experimental': nvidia.dali.plugin.numba.experimental
 }
 
 # Some operators might have a different module for the fn wrapper
 module_mapping = {
     'nvidia.dali.plugin.pytorch' : 'nvidia.dali.plugin.pytorch.fn',
-    'nvidia.dali.plugin.numba' : 'nvidia.dali.plugin.numba.fn'
+    'nvidia.dali.plugin.numba.experimental' : 'nvidia.dali.plugin.numba.fn.experimental'
 }
 
 cpu_ops = ops.cpu_ops()


### PR DESCRIPTION
* Remove automatic listing of all contents of nvidia.dali.plugin
  from supported ops
* Add layer of experimental for numba plugin for NumbaFunc
* Rename NumbaFunc to NumbaFunction to match PythonFunction
* Small fixups

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fix docs and add self consistency in DALI naming

#### What happened in this PR?
 - What solution was applied:
     * Remove automatic listing of all contents of nvidia.dali.plugin
  from supported ops
* Add layer of experimental for numba plugin for NumbaFunc
* Rename NumbaFunc to NumbaFunction to match PythonFunction
* Small fixups

 - Affected modules and functionalities:
     Numba function & docs
 - Key points relevant for the review:
     Missed renames?
 - Validation and testing:
     Plz check the generated docs.
 - Documentation (including examples):
     Yes, mostly keeping numba_function to fn docs and NumbaFunction to ops doc.


**JIRA TASK**: *[Use DALI-XXXX or NA]*
