### PR TITLE
Use a custom color space conversion kernel for all conversions

### DIFF
--- a/dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h
+++ b/dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h
@@ -55,7 +55,7 @@ DALI_HOST_DEV DALI_FORCEINLINE Output rgb_to_y(vec<3, Input> rgb_in) {
 template <>
 DALI_HOST_DEV DALI_FORCEINLINE uint8_t rgb_to_y(vec<3, uint8_t> rgb) {
   constexpr vec3 coeffs(0.257f, 0.504f, 0.098f);
-  return static_cast<uint8_t>(dot(coeffs, rgb) + 16.0f);
+  return ConvertSat<uint8_t>(dot(coeffs, rgb) + 16.0f);
 }
 
 template <typename Output, typename Input>
@@ -69,7 +69,7 @@ template <>
 DALI_HOST_DEV DALI_FORCEINLINE uint8_t rgb_to_cb(vec<3, uint8_t> rgb) {
   constexpr vec3 coeffs(-0.148f, -0.291f, 0.439f);
   if (rgb.x == rgb.y && rgb.x == rgb.z) return 128;
-  return static_cast<uint8_t>(dot(coeffs, rgb) + 128.0f);
+  return ConvertSat<uint8_t>(dot(coeffs, rgb) + 128.0f);
 }
 
 template <typename Output, typename Input>
@@ -83,7 +83,7 @@ template <>
 DALI_HOST_DEV DALI_FORCEINLINE uint8_t rgb_to_cr(vec<3, uint8_t> rgb) {
   constexpr vec3 coeffs(0.439f, -0.368f, -0.071f);
   if (rgb.x == rgb.y && rgb.x == rgb.z) return 128;
-  return static_cast<uint8_t>(dot(coeffs, rgb) + 128.0f);
+  return ConvertSat<uint8_t>(dot(coeffs, rgb) + 128.0f);
 }
 
 // Gray uses the full dynamic range of the type (e.g. 0..255)
@@ -91,47 +91,49 @@ DALI_HOST_DEV DALI_FORCEINLINE uint8_t rgb_to_cr(vec<3, uint8_t> rgb) {
 template <typename Output, typename Input>
 DALI_HOST_DEV DALI_FORCEINLINE Output y_to_gray(Input gray_in) {
   auto gray = detail::norm(gray_in);  // TODO(janton): optimize number of multiplications
-  return ConvertSatNorm<Output>(1.164f * (gray - 0.0625f));
+  constexpr float scale = 1 / (0.257f +  0.504f + 0.098f);
+  return ConvertSatNorm<Output>(scale * (gray - 0.0625f));
 }
 
 template <>
 DALI_HOST_DEV DALI_FORCEINLINE uint8_t y_to_gray(uint8_t gray) {
-  return static_cast<uint8_t>(1.164f * (gray - 16));
+  constexpr float scale = 1 / (0.257f + 0.504f + 0.098f);
+  return ConvertSat<uint8_t>(scale * (gray - 16));
 }
 
 template <typename Output, typename Input>
 DALI_HOST_DEV DALI_FORCEINLINE Output gray_to_y(Input y_in) {
   auto y = detail::norm(y_in);  // TODO(janton): optimize number of multiplications
-  constexpr float scale = 1 / 1.164f;
+  constexpr float scale = 0.257f + 0.504f + 0.098f;
   return ConvertSatNorm<Output>(y * scale + 0.0625f);
 }
 
 template <>
 DALI_HOST_DEV DALI_FORCEINLINE uint8_t gray_to_y(uint8_t y) {
-  constexpr float scale = 1 / 1.164f;
-  return static_cast<uint8_t>(y * scale + 0.0625f);
+  constexpr float scale = 0.257f + 0.504f + 0.098f;
+  return ConvertSat<uint8_t>(y * scale + 0.0625f);
 }
 
 template <typename Output, typename Input>
 DALI_HOST_DEV DALI_FORCEINLINE vec<3, Output> ycbcr_to_rgb(vec<3, Input> ycbcr_in) {
   auto ycbcr = detail::norm(ycbcr_in);  // TODO(janton): optimize number of multiplications
-  auto gray = y_to_gray<float>(ycbcr.x);
+  auto tmp_y = 1.164f * (ycbcr.x - 0.0625f);
   auto tmp_b = ycbcr.y - 0.5f;
   auto tmp_r = ycbcr.z - 0.5f;
-  auto r = ConvertSatNorm<Output>(gray + 1.596f * tmp_r);
-  auto g = ConvertSatNorm<Output>(gray - 0.813f * tmp_r - 0.392f * tmp_b, 0, 255);
-  auto b = ConvertSatNorm<Output>(gray + 2.017f * tmp_b);
+  auto r = ConvertSatNorm<Output>(tmp_y + 1.596f * tmp_r);
+  auto g = ConvertSatNorm<Output>(tmp_y - 0.813f * tmp_r - 0.392f * tmp_b);
+  auto b = ConvertSatNorm<Output>(tmp_y + 2.017f * tmp_b);
   return {r, g, b};
 }
 
 template <>
 DALI_HOST_DEV DALI_FORCEINLINE vec<3, uint8_t> ycbcr_to_rgb(vec<3, uint8_t> ycbcr) {
-  auto gray = y_to_gray<uint8_t>(ycbcr.x);
+  auto tmp_y = 1.164f * (ycbcr.x - 16);
   auto tmp_b = ycbcr.y - 128;
   auto tmp_r = ycbcr.z - 128;
-  auto r = clamp<uint8_t>(gray + 1.596f * tmp_r, 0, 255);
-  auto g = clamp<uint8_t>(gray - 0.813f * tmp_r - 0.392f * tmp_b, 0, 255);
-  auto b = clamp<uint8_t>(gray + 2.017f * tmp_b, 0, 255);
+  auto r = ConvertSat<uint8_t>(tmp_y + 1.596f * tmp_r);
+  auto g = ConvertSat<uint8_t>(tmp_y - 0.813f * tmp_r - 0.392f * tmp_b);
+  auto b = ConvertSat<uint8_t>(tmp_y + 2.017f * tmp_b);
   return {r, g, b};
 }
 
@@ -194,9 +196,9 @@ template <>
 DALI_HOST_DEV DALI_FORCEINLINE vec<3, uint8_t> ycbcr_to_rgb(vec<3, uint8_t> ycbcr) {
   float tmp_b = ycbcr.y - 128;
   float tmp_r = ycbcr.z - 128;
-  auto r = clamp<uint8_t>(ycbcr.x + 1.402f * tmp_r, 0, 255);
-  auto g = clamp<uint8_t>(ycbcr.x - 0.34413629f * tmp_b - 0.71413629f * tmp_r, 0, 255);
-  auto b = clamp<uint8_t>(ycbcr.x + 1.772f * tmp_b, 0, 255);
+  auto r = ConvertSat<uint8_t>(ycbcr.x + 1.402f * tmp_r);
+  auto g = ConvertSat<uint8_t>(ycbcr.x - 0.34413629f * tmp_b - 0.71413629f * tmp_r);
+  auto b = ConvertSat<uint8_t>(ycbcr.x + 1.772f * tmp_b);
   return {r, g, b};
 }
 

--- a/dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h
+++ b/dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h
@@ -86,6 +86,29 @@ DALI_HOST_DEV DALI_FORCEINLINE uint8_t rgb_to_cr(vec<3, uint8_t> rgb) {
   return static_cast<uint8_t>(dot(coeffs, rgb) + 128.0f);
 }
 
+template <typename Output, typename Input>
+DALI_HOST_DEV DALI_FORCEINLINE vec<3, Output> ycbcr_to_rgb(vec<3, Input> ycbcr_in) {
+  auto ycbcr = detail::norm(ycbcr_in);  // TODO(janton): optimize number of multiplications
+  float tmp_y = 1.164f * (ycbcr.x - 0.0625f);
+  float tmp_b = ycbcr.y - 0.5f;
+  float tmp_r = ycbcr.z - 0.5f;
+  auto r = ConvertSatNorm<Output>(tmp_y + 1.596f * tmp_r);
+  auto g = ConvertSatNorm<Output>(tmp_y - 0.813f * tmp_r - 0.392f * tmp_b, 0, 255);
+  auto b = ConvertSatNorm<Output>(tmp_y + 2.017f * tmp_b);
+  return {r, g, b};
+}
+
+template <>
+DALI_HOST_DEV DALI_FORCEINLINE vec<3, uint8_t> ycbcr_to_rgb(vec<3, uint8_t> ycbcr) {
+  float tmp_y = 1.164f * (ycbcr.x - 16);
+  float tmp_b = ycbcr.y - 128;
+  float tmp_r = ycbcr.z - 128;
+  auto r = clamp<uint8_t>(tmp_y + 1.596f * tmp_r, 0, 255);
+  auto g = clamp<uint8_t>(tmp_y - 0.813f * tmp_r - 0.392f * tmp_b, 0, 255);
+  auto b = clamp<uint8_t>(tmp_y + 2.017f * tmp_b, 0, 255);
+  return {r, g, b};
+}
+
 }  // namespace itu_r_bt_601
 
 // Y, Cb, Cr formulas used in JPEG, using the whole dynamic range of the type.
@@ -129,6 +152,28 @@ DALI_HOST_DEV DALI_FORCEINLINE uint8_t rgb_to_cr(vec<3, uint8_t> rgb) {
   constexpr vec3 coeffs(0.5f, -0.41868759f, -0.08131241f);
   return ConvertSat<uint8_t>(dot(coeffs, rgb) + 128.0f);
 }
+
+template <typename Output, typename Input>
+DALI_HOST_DEV DALI_FORCEINLINE vec<3, Output> ycbcr_to_rgb(vec<3, Input> ycbcr_in) {
+  auto ycbcr = detail::norm(ycbcr_in);  // TODO(janton): optimize number of multiplications
+  float tmp_b = ycbcr.y - 0.5f;
+  float tmp_r = ycbcr.z - 0.5f;
+  auto r = ConvertSatNorm<Output>(ycbcr.x + 1.402f * tmp_r);
+  auto g = ConvertSatNorm<Output>(ycbcr.x - 0.34413629f * tmp_b - 0.71413629f * tmp_r);
+  auto b = ConvertSatNorm<Output>(ycbcr.x + 1.772f * tmp_b);
+  return {r, g, b};
+}
+
+template <>
+DALI_HOST_DEV DALI_FORCEINLINE vec<3, uint8_t> ycbcr_to_rgb(vec<3, uint8_t> ycbcr) {
+  float tmp_b = ycbcr.y - 128;
+  float tmp_r = ycbcr.z - 128;
+  auto r = clamp<uint8_t>(ycbcr.x + 1.402f * tmp_r, 0, 255);
+  auto g = clamp<uint8_t>(ycbcr.x - 0.34413629f * tmp_b - 0.71413629f * tmp_r, 0, 255);
+  auto b = clamp<uint8_t>(ycbcr.x + 1.772f * tmp_b, 0, 255);
+  return {r, g, b};
+}
+
 
 }  // namespace jpeg
 

--- a/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
+++ b/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
@@ -24,10 +24,10 @@ namespace kernels {
 namespace color {
 
 template <typename Out, typename In>
-DALI_HOST_DEV struct RGB_to_BGR_Converter {
+struct RGB_to_BGR_Converter {
   static constexpr int out_pixel_sz = 3;
   static constexpr int in_pixel_sz = 3;
-  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> rgb) {
+  static DALI_HOST_DEV DALI_FORCEINLINE vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> rgb) {
     vec<out_pixel_sz, Out> out;
     out[0] = ConvertSatNorm<Out>(rgb[2]);
     out[1] = ConvertSatNorm<Out>(rgb[1]);
@@ -37,38 +37,38 @@ DALI_HOST_DEV struct RGB_to_BGR_Converter {
 };
 
 template <typename Out, typename In>
-DALI_HOST_DEV struct RGB_to_Gray_Converter {
+struct RGB_to_Gray_Converter {
   static constexpr int out_pixel_sz = 1;
   static constexpr int in_pixel_sz = 3;
-  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> rgb) {
+  static DALI_HOST_DEV DALI_FORCEINLINE vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> rgb) {
     return rgb_to_gray<Out>(rgb);
   }
 };
 
 template <typename Out, typename In>
-DALI_HOST_DEV struct BGR_to_Gray_Converter {
+struct BGR_to_Gray_Converter {
   static constexpr int out_pixel_sz = 1;
   static constexpr int in_pixel_sz = 3;
-  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> bgr) {
+  static DALI_HOST_DEV DALI_FORCEINLINE vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> bgr) {
     return RGB_to_Gray_Converter<Out, In>::convert(
       RGB_to_BGR_Converter<In, In>::convert(bgr));
   }
 };
 
 template <typename Out, typename In>
-DALI_HOST_DEV struct Gray_to_RGB_Converter {
+struct Gray_to_RGB_Converter {
   static constexpr int out_pixel_sz = 3;
   static constexpr int in_pixel_sz = 1;
-  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> gray) {
+  static DALI_HOST_DEV DALI_FORCEINLINE vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> gray) {
     return vec<out_pixel_sz, Out>(gray[0]);
   }
 };
 
 template <typename Out, typename In>
-DALI_HOST_DEV struct Gray_to_YCbCr_Converter {
+struct Gray_to_YCbCr_Converter {
   static constexpr int out_pixel_sz = 3;
   static constexpr int in_pixel_sz = 1;
-  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> gray) {
+  static DALI_HOST_DEV DALI_FORCEINLINE vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> gray) {
     vec<out_pixel_sz, Out> out;
     out[0] = itu_r_bt_601::gray_to_y<Out>(gray[0]);
     out[1] = ConvertNorm<Out>(0.5f);
@@ -78,21 +78,21 @@ DALI_HOST_DEV struct Gray_to_YCbCr_Converter {
 };
 
 template <typename Out, typename In>
-DALI_HOST_DEV struct YCbCr_to_Gray_Converter {
+struct YCbCr_to_Gray_Converter {
   static constexpr int out_pixel_sz = 1;
   static constexpr int in_pixel_sz = 3;
-  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> ycbcr) {
+  static DALI_HOST_DEV DALI_FORCEINLINE vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> ycbcr) {
     vec<out_pixel_sz, Out> out;
-    out[0] = itu_r_bt_601::y_to_gray<Out>(ycbcr[0]);;
+    out[0] = itu_r_bt_601::y_to_gray<Out>(ycbcr[0]);
     return out;
   }
 };
 
 template <typename Out, typename In>
-DALI_HOST_DEV struct RGB_to_YCbCr_Converter {
+struct RGB_to_YCbCr_Converter {
   static constexpr int out_pixel_sz = 3;
   static constexpr int in_pixel_sz = 3;
-  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> rgb) {
+  static DALI_HOST_DEV DALI_FORCEINLINE vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> rgb) {
     vec<out_pixel_sz, Out> out;
     out[0] = itu_r_bt_601::rgb_to_y<Out>(rgb);
     out[1] = itu_r_bt_601::rgb_to_cb<Out>(rgb);
@@ -102,47 +102,47 @@ DALI_HOST_DEV struct RGB_to_YCbCr_Converter {
 };
 
 template <typename Out, typename In>
-DALI_HOST_DEV struct BGR_to_YCbCr_Converter {
+struct BGR_to_YCbCr_Converter {
   static constexpr int out_pixel_sz = 3;
   static constexpr int in_pixel_sz = 3;
-  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> bgr) {
+  static DALI_HOST_DEV DALI_FORCEINLINE vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> bgr) {
     return RGB_to_YCbCr_Converter<Out, In>::convert(
       RGB_to_BGR_Converter<In, In>::convert(bgr));
   }
 };
 
 template <typename Out, typename In>
-DALI_HOST_DEV struct YCbCr_to_RGB_Converter {
+struct YCbCr_to_RGB_Converter {
   static constexpr int out_pixel_sz = 3;
   static constexpr int in_pixel_sz = 3;
-  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> ycbcr) {
+  static DALI_HOST_DEV DALI_FORCEINLINE vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> ycbcr) {
     return itu_r_bt_601::ycbcr_to_rgb<Out>(ycbcr);
   }
 };
 
 template <typename Out, typename In>
-DALI_HOST_DEV struct YCbCr_to_BGR_Converter {
+struct YCbCr_to_BGR_Converter {
   static constexpr int out_pixel_sz = 3;
   static constexpr int in_pixel_sz = 3;
-  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> ycbcr) {
+  static DALI_HOST_DEV DALI_FORCEINLINE vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> ycbcr) {
     return RGB_to_BGR_Converter<Out, In>::convert(
       YCbCr_to_RGB_Converter<Out, Out>::convert(ycbcr));
   }
 };
 
-template<typename Converter, typename Out, typename In>
+template <typename Converter, typename Out, typename In>
 __global__ void ColorSpaceConvKernel(Out *output, const In *input, int64_t sz) {
   int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx >= sz) {
     return;
   }
   vec<Converter::in_pixel_sz, In> pixel;
-  #pragma unroll
+#pragma unroll
   for (int c = 0; c < Converter::in_pixel_sz; c++) {
     pixel[c] = input[idx * Converter::in_pixel_sz + c];
   }
   auto out_pixel = Converter::convert(pixel);
-  #pragma unroll
+#pragma unroll
   for (int c = 0; c < Converter::out_pixel_sz; c++) {
     output[idx * Converter::out_pixel_sz + c] = out_pixel[c];
   }
@@ -150,27 +150,26 @@ __global__ void ColorSpaceConvKernel(Out *output, const In *input, int64_t sz) {
 
 // TODO(janton): Write a generic batched color space conversion kernel template
 template <typename Out, typename In>
-void RunColorSpaceConversionKernel(Out *output, const In *input,
-                                   DALIImageType out_type, DALIImageType in_type,
-                                   int64_t npixels, cudaStream_t stream) {
+void RunColorSpaceConversionKernel(Out *output, const In *input, DALIImageType out_type,
+                                   DALIImageType in_type, int64_t npixels, cudaStream_t stream) {
   // For CUDA kernel
   const unsigned int block = npixels < 1024 ? npixels : 1024;
   const unsigned int grid = (npixels + block - 1) / block;
 
   using ImageTypePair = std::pair<DALIImageType, DALIImageType>;
-  ImageTypePair conversion {in_type, out_type};
-  const ImageTypePair kRGB_TO_BGR { DALI_RGB, DALI_BGR };
-  const ImageTypePair kBGR_TO_RGB { DALI_BGR, DALI_RGB };
-  const ImageTypePair kRGB_TO_YCbCr { DALI_RGB, DALI_YCbCr };
-  const ImageTypePair kBGR_TO_YCbCr { DALI_BGR, DALI_YCbCr };
-  const ImageTypePair kRGB_TO_GRAY { DALI_RGB, DALI_GRAY };
-  const ImageTypePair kBGR_TO_GRAY { DALI_BGR, DALI_GRAY };
-  const ImageTypePair kYCbCr_TO_BGR { DALI_YCbCr, DALI_BGR };
-  const ImageTypePair kYCbCr_TO_RGB { DALI_YCbCr, DALI_RGB };
-  const ImageTypePair kYCbCr_TO_GRAY { DALI_YCbCr, DALI_GRAY };
-  const ImageTypePair kGRAY_TO_RGB { DALI_GRAY, DALI_RGB };
-  const ImageTypePair kGRAY_TO_BGR { DALI_GRAY, DALI_BGR };
-  const ImageTypePair kGRAY_TO_YCbCr { DALI_GRAY, DALI_YCbCr };
+  ImageTypePair conversion{in_type, out_type};
+  const ImageTypePair kRGB_TO_BGR{DALI_RGB, DALI_BGR};
+  const ImageTypePair kBGR_TO_RGB{DALI_BGR, DALI_RGB};
+  const ImageTypePair kRGB_TO_YCbCr{DALI_RGB, DALI_YCbCr};
+  const ImageTypePair kBGR_TO_YCbCr{DALI_BGR, DALI_YCbCr};
+  const ImageTypePair kRGB_TO_GRAY{DALI_RGB, DALI_GRAY};
+  const ImageTypePair kBGR_TO_GRAY{DALI_BGR, DALI_GRAY};
+  const ImageTypePair kYCbCr_TO_BGR{DALI_YCbCr, DALI_BGR};
+  const ImageTypePair kYCbCr_TO_RGB{DALI_YCbCr, DALI_RGB};
+  const ImageTypePair kYCbCr_TO_GRAY{DALI_YCbCr, DALI_GRAY};
+  const ImageTypePair kGRAY_TO_RGB{DALI_GRAY, DALI_RGB};
+  const ImageTypePair kGRAY_TO_BGR{DALI_GRAY, DALI_BGR};
+  const ImageTypePair kGRAY_TO_YCbCr{DALI_GRAY, DALI_YCbCr};
 
   if (conversion == kRGB_TO_BGR || conversion == kBGR_TO_RGB) {
     ColorSpaceConvKernel<RGB_to_BGR_Converter<Out, In>, Out, In>

--- a/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
+++ b/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
@@ -1,0 +1,220 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_IMGPROC_COLOR_MANIPULATION_COLOR_SPACE_CONVERSION_KERNEL_CUH_
+#define DALI_KERNELS_IMGPROC_COLOR_MANIPULATION_COLOR_SPACE_CONVERSION_KERNEL_CUH_
+
+#include <cuda_runtime_api.h>
+#include "dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h"
+
+namespace dali {
+namespace kernels {
+namespace color {
+
+template <typename Out, typename In>
+DALI_HOST_DEV struct RGB_to_BGR_Converter {
+  static constexpr int out_pixel_sz = 3;
+  static constexpr int in_pixel_sz = 3;
+  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> rgb) {
+    vec<out_pixel_sz, Out> out;
+    out[0] = ConvertSatNorm<Out>(rgb[2]);
+    out[1] = ConvertSatNorm<Out>(rgb[1]);
+    out[2] = ConvertSatNorm<Out>(rgb[0]);
+    return out;
+  }
+};
+
+template <typename Out, typename In>
+DALI_HOST_DEV struct RGB_to_Gray_Converter {
+  static constexpr int out_pixel_sz = 1;
+  static constexpr int in_pixel_sz = 3;
+  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> rgb) {
+    return rgb_to_gray<Out>(rgb);
+  }
+};
+
+template <typename Out, typename In>
+DALI_HOST_DEV struct BGR_to_Gray_Converter {
+  static constexpr int out_pixel_sz = 1;
+  static constexpr int in_pixel_sz = 3;
+  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> bgr) {
+    return RGB_to_Gray_Converter<Out, In>::convert(
+      RGB_to_BGR_Converter<In, In>::convert(bgr)
+    );
+  }
+};
+
+template <typename Out, typename In>
+DALI_HOST_DEV struct Gray_to_RGB_Converter {
+  static constexpr int out_pixel_sz = 3;
+  static constexpr int in_pixel_sz = 1;
+  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> gray) {
+    vec<out_pixel_sz, Out> out;
+    out[0] = gray[0];
+    out[1] = gray[0];
+    out[2] = gray[0];
+    return out;
+  }
+};
+
+template <typename Out, typename In>
+DALI_HOST_DEV struct Gray_to_YCbCr_Converter {
+  static constexpr int out_pixel_sz = 3;
+  static constexpr int in_pixel_sz = 1;
+  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> gray) {
+    vec<out_pixel_sz, Out> out;
+    out[0] = ConvertSatNorm<Out>(gray[0]);
+    out[1] = ConvertNorm<Out>(0.5f);
+    out[2] = ConvertNorm<Out>(0.5f);
+    return out;
+  }
+};
+
+template <typename Out, typename In>
+DALI_HOST_DEV struct YCbCr_to_Gray_Converter {
+  static constexpr int out_pixel_sz = 1;
+  static constexpr int in_pixel_sz = 3;
+  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> ycbcr) {
+    vec<out_pixel_sz, Out> out;
+    out[0] = ConvertSatNorm<Out>(ycbcr[0]);
+    return out;
+  }
+};
+
+template <typename Out, typename In>
+DALI_HOST_DEV struct RGB_to_YCbCr_Converter {
+  static constexpr int out_pixel_sz = 3;
+  static constexpr int in_pixel_sz = 3;
+  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> rgb) {
+    vec<out_pixel_sz, Out> out;
+    out[0] = itu_r_bt_601::rgb_to_y<Out>(rgb);
+    out[1] = itu_r_bt_601::rgb_to_cb<Out>(rgb);
+    out[2] = itu_r_bt_601::rgb_to_cr<Out>(rgb);
+    return out;
+  }
+};
+
+template <typename Out, typename In>
+DALI_HOST_DEV struct BGR_to_YCbCr_Converter {
+  static constexpr int out_pixel_sz = 3;
+  static constexpr int in_pixel_sz = 3;
+  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> bgr) {
+    return RGB_to_YCbCr_Converter<Out, In>::convert(
+      RGB_to_BGR_Converter<In, In>::convert(bgr)
+    );
+  }
+};
+
+template <typename Out, typename In>
+DALI_HOST_DEV struct YCbCr_to_RGB_Converter {
+  static constexpr int out_pixel_sz = 3;
+  static constexpr int in_pixel_sz = 3;
+  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> ycbcr) {
+    return itu_r_bt_601::ycbcr_to_rgb<Out>(ycbcr);
+  }
+};
+
+template <typename Out, typename In>
+DALI_HOST_DEV struct YCbCr_to_BGR_Converter {
+  static constexpr int out_pixel_sz = 3;
+  static constexpr int in_pixel_sz = 3;
+  static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> ycbcr) {
+    return RGB_to_BGR_Converter<Out, In>::convert(
+      YCbCr_to_RGB_Converter<Out, Out>::convert(ycbcr)
+    );
+  }
+};
+
+template<typename Converter, typename Out, typename In>
+__global__ void ColorSpaceConvKernel(Out *output, const In *input, int64_t sz) {
+  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= sz) {
+    return;
+  }
+  vec<Converter::in_pixel_sz, In> pixel;
+  #pragma unroll
+  for (int c = 0; c < Converter::in_pixel_sz; c++) {
+    pixel[c] = input[idx * Converter::in_pixel_sz + c];
+  }
+  auto out_pixel = Converter::convert(pixel);
+  #pragma unroll
+  for (int c = 0; c < Converter::out_pixel_sz; c++) {
+    output[idx * Converter::out_pixel_sz + c] = out_pixel[c];
+  }
+}
+
+// TODO(janton): Write a generic batched color space conversion kernel template
+template <typename Out, typename In>
+void RunColorSpaceConversionKernel(Out *output, const In *input,
+                                   DALIImageType out_type, DALIImageType in_type,
+                                   int64_t npixels, cudaStream_t stream) {
+  // For CUDA kernel
+  const unsigned int block = npixels < 1024 ? npixels : 1024;
+  const unsigned int grid = (npixels + block - 1) / block;
+
+  using ImageTypePair = std::pair<DALIImageType, DALIImageType>;
+  ImageTypePair conversion {in_type, out_type};
+  const ImageTypePair kRGB_TO_BGR { DALI_RGB, DALI_BGR };
+  const ImageTypePair kBGR_TO_RGB { DALI_BGR, DALI_RGB };
+  const ImageTypePair kRGB_TO_YCbCr { DALI_RGB, DALI_YCbCr };
+  const ImageTypePair kBGR_TO_YCbCr { DALI_BGR, DALI_YCbCr };
+  const ImageTypePair kRGB_TO_GRAY { DALI_RGB, DALI_GRAY };
+  const ImageTypePair kBGR_TO_GRAY { DALI_BGR, DALI_GRAY };
+  const ImageTypePair kYCbCr_TO_BGR { DALI_YCbCr, DALI_BGR };
+  const ImageTypePair kYCbCr_TO_RGB { DALI_YCbCr, DALI_RGB };
+  const ImageTypePair kYCbCr_TO_GRAY { DALI_YCbCr, DALI_GRAY };
+  const ImageTypePair kGRAY_TO_RGB { DALI_GRAY, DALI_RGB };
+  const ImageTypePair kGRAY_TO_BGR { DALI_GRAY, DALI_BGR };
+  const ImageTypePair kGRAY_TO_YCbCr { DALI_GRAY, DALI_YCbCr };
+
+  if (conversion == kRGB_TO_BGR || conversion == kBGR_TO_RGB) {
+    ColorSpaceConvKernel<RGB_to_BGR_Converter<Out, In>, Out, In>
+        <<<grid, block, 0, stream>>>(output, input, npixels);
+  } else if (conversion == kRGB_TO_YCbCr) {
+    ColorSpaceConvKernel<RGB_to_YCbCr_Converter<Out, In>, Out, In>
+        <<<grid, block, 0, stream>>>(output, input, npixels);
+  } else if (conversion == kBGR_TO_YCbCr) {
+    ColorSpaceConvKernel<BGR_to_YCbCr_Converter<Out, In>, Out, In>
+        <<<grid, block, 0, stream>>>(output, input, npixels);
+  } else if (conversion == kRGB_TO_GRAY) {
+    ColorSpaceConvKernel<RGB_to_Gray_Converter<Out, In>, Out, In>
+        <<<grid, block, 0, stream>>>(output, input, npixels);
+  } else if (conversion == kBGR_TO_GRAY) {
+    ColorSpaceConvKernel<BGR_to_Gray_Converter<Out, In>, Out, In>
+        <<<grid, block, 0, stream>>>(output, input, npixels);
+  } else if (conversion == kYCbCr_TO_BGR) {
+    ColorSpaceConvKernel<YCbCr_to_BGR_Converter<Out, In>, Out, In>
+        <<<grid, block, 0, stream>>>(output, input, npixels);
+  } else if (conversion == kYCbCr_TO_RGB) {
+    ColorSpaceConvKernel<YCbCr_to_RGB_Converter<Out, In>, Out, In>
+        <<<grid, block, 0, stream>>>(output, input, npixels);
+  } else if (conversion == kGRAY_TO_BGR || conversion == kGRAY_TO_RGB) {
+    ColorSpaceConvKernel<Gray_to_RGB_Converter<Out, In>, Out, In>
+        <<<grid, block, 0, stream>>>(output, input, npixels);
+  } else if (conversion == kGRAY_TO_YCbCr) {
+    ColorSpaceConvKernel<Gray_to_YCbCr_Converter<Out, In>, Out, In>
+        <<<grid, block, 0, stream>>>(output, input, npixels);
+  } else if (conversion == kYCbCr_TO_GRAY) {
+    ColorSpaceConvKernel<YCbCr_to_Gray_Converter<Out, In>, Out, In>
+        <<<grid, block, 0, stream>>>(output, input, npixels);
+  } else {
+    DALI_FAIL(make_string("conversion not supported ", in_type, " to ", out_type));
+  }
+}
+
+}  // namespace color
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_IMGPROC_COLOR_MANIPULATION_COLOR_SPACE_CONVERSION_KERNEL_CUH_

--- a/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
+++ b/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
@@ -16,6 +16,7 @@
 #define DALI_KERNELS_IMGPROC_COLOR_MANIPULATION_COLOR_SPACE_CONVERSION_KERNEL_CUH_
 
 #include <cuda_runtime_api.h>
+#include <utility>
 #include "dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h"
 
 namespace dali {
@@ -50,8 +51,7 @@ DALI_HOST_DEV struct BGR_to_Gray_Converter {
   static constexpr int in_pixel_sz = 3;
   static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> bgr) {
     return RGB_to_Gray_Converter<Out, In>::convert(
-      RGB_to_BGR_Converter<In, In>::convert(bgr)
-    );
+      RGB_to_BGR_Converter<In, In>::convert(bgr));
   }
 };
 
@@ -107,8 +107,7 @@ DALI_HOST_DEV struct BGR_to_YCbCr_Converter {
   static constexpr int in_pixel_sz = 3;
   static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> bgr) {
     return RGB_to_YCbCr_Converter<Out, In>::convert(
-      RGB_to_BGR_Converter<In, In>::convert(bgr)
-    );
+      RGB_to_BGR_Converter<In, In>::convert(bgr));
   }
 };
 
@@ -127,8 +126,7 @@ DALI_HOST_DEV struct YCbCr_to_BGR_Converter {
   static constexpr int in_pixel_sz = 3;
   static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> ycbcr) {
     return RGB_to_BGR_Converter<Out, In>::convert(
-      YCbCr_to_RGB_Converter<Out, Out>::convert(ycbcr)
-    );
+      YCbCr_to_RGB_Converter<Out, Out>::convert(ycbcr));
   }
 };
 

--- a/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
+++ b/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
@@ -70,7 +70,7 @@ DALI_HOST_DEV struct Gray_to_YCbCr_Converter {
   static constexpr int in_pixel_sz = 1;
   static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> gray) {
     vec<out_pixel_sz, Out> out;
-    out[0] = ConvertSatNorm<Out>(gray[0]);
+    out[0] = itu_r_bt_601::gray_to_y<Out>(gray[0]);
     out[1] = ConvertNorm<Out>(0.5f);
     out[2] = ConvertNorm<Out>(0.5f);
     return out;
@@ -83,7 +83,7 @@ DALI_HOST_DEV struct YCbCr_to_Gray_Converter {
   static constexpr int in_pixel_sz = 3;
   static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> ycbcr) {
     vec<out_pixel_sz, Out> out;
-    out[0] = ConvertSatNorm<Out>(ycbcr[0]);
+    out[0] = itu_r_bt_601::y_to_gray<Out>(ycbcr[0]);;
     return out;
   }
 };

--- a/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
+++ b/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
@@ -60,11 +60,7 @@ DALI_HOST_DEV struct Gray_to_RGB_Converter {
   static constexpr int out_pixel_sz = 3;
   static constexpr int in_pixel_sz = 1;
   static DALI_HOST_DEV vec<out_pixel_sz, Out> convert(vec<in_pixel_sz, In> gray) {
-    vec<out_pixel_sz, Out> out;
-    out[0] = gray[0];
-    out[1] = gray[0];
-    out[2] = gray[0];
-    return out;
+    return vec<out_pixel_sz, Out>(gray[0]);
   }
 };
 

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -24,7 +24,11 @@ DALI_SCHEMA(ImageDecoderAttr)
   .NumInput(1)
   .NumOutput(1)
   .AddOptionalArg("output_type",
-      R"code(The color space of the output image.)code",
+      R"code(The color space of the output image.
+
+Note: When decoding to YCbCr, the image will be decoded to RGB and then converted to YCbCr,
+following the YCbCr definition from ITU-R BT.601.
+)code",
       DALI_RGB)
   .AddOptionalArg("hybrid_huffman_threshold",
       R"code(Applies **only** to the ``mixed`` backend type.

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -778,12 +778,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
           int i = sample->sample_idx;
           auto data = output.mutable_tensor<uint8_t>(i);
           auto sh = output_shape_.tensor_shape(i);
-          NppiSize size;
-          size.height = sh[0];
-          size.width = sh[1];
-          int step = sh[1] * 3;
-          DALI_CHECK_NPP(nppiRGBToYCbCr_8u_C3R_Ctx(data, step, data, step, size,
-                                                   GetNppContext(hw_decode_stream_)));
+          ConvertRGBToYCbCr(data, sh[0], sh[1], hw_decode_stream_);
         }
       }
 
@@ -918,12 +913,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
         // We don't directly to YCbCr, since we want to control the YCbCr definition,
         // which is different between general color conversion libraries (OpenCV) and
         // what JPEG uses.
-        NppiSize size;
-        size.height = out_shape[0];
-        size.width = out_shape[1];
-        int step = out_shape[1] * 3;
-        DALI_CHECK_NPP(nppiRGBToYCbCr_8u_C3R_Ctx(output_data, step, output_data, step, size,
-                                                 GetNppContext(stream)));
+        ConvertRGBToYCbCr(output_data, out_shape[0], out_shape[1], stream);
       }
 
       CacheStore(file_name, output_data, out_shape, stream);

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -613,9 +613,8 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       auto i = sample->sample_idx;
       auto *output_data = output.mutable_tensor<uint8_t>(i);
       const auto &in = ws.Input<CPUBackend>(0, i);
-      ImageCache::ImageShape shape = output_shape_[i].to_static<3>();
       thread_pool_.AddWork(
-        [this, sample, &in, output_data, shape](int tid) {
+        [this, sample, &in, output_data](int tid) {
           SampleWorker(sample->sample_idx, sample->file_name, in.size(), tid,
             in.data<uint8_t>(), output_data, streams_[tid]);
         }, task_priority_seq_--);  // FIFO order, since the samples were already ordered

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
@@ -42,7 +42,4 @@ const char* nvjpeg_parse_error_code(nvjpegStatus_t code) {
   }
 }
 
-
-
-
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
@@ -43,12 +43,12 @@ const char* nvjpeg_parse_error_code(nvjpegStatus_t code) {
   }
 }
 
-void ConvertRGBToYCbCr(uint8_t* data, int64_t h, int64_t w, cudaStream_t stream) {
+void ConvertRGBToYCbCr(uint8_t* out, const uint8_t* in, int64_t h, int64_t w, cudaStream_t stream) {
   int step = w * 3;
   NppiSize size;
   size.height = h;
   size.width = w;
-  DALI_CHECK_NPP(nppiRGBToYCbCr_8u_C3R_Ctx(data, step, data, step, size, GetNppContext(stream)));
+  DALI_CHECK_NPP(nppiRGBToYCbCr_8u_C3R_Ctx(in, step, out, step, size, GetNppContext(stream)));
 }
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
@@ -14,6 +14,7 @@
 
 #include <string>
 #include "dali/operators/decoder/nvjpeg/nvjpeg_helper.h"
+#include "dali/util/npp.h"
 
 namespace dali {
 
@@ -40,6 +41,14 @@ const char* nvjpeg_parse_error_code(nvjpegStatus_t code) {
     default:
       return "";
   }
+}
+
+void ConvertRGBToYCbCr(uint8_t* data, int64_t h, int64_t w, cudaStream_t stream) {
+  int step = w * 3;
+  NppiSize size;
+  size.height = h;
+  size.width = w;
+  DALI_CHECK_NPP(nppiRGBToYCbCr_8u_C3R_Ctx(data, step, data, step, size, GetNppContext(stream)));
 }
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.cc
@@ -14,7 +14,6 @@
 
 #include <string>
 #include "dali/operators/decoder/nvjpeg/nvjpeg_helper.h"
-#include "dali/util/npp.h"
 
 namespace dali {
 
@@ -43,12 +42,7 @@ const char* nvjpeg_parse_error_code(nvjpegStatus_t code) {
   }
 }
 
-void ConvertRGBToYCbCr(uint8_t* out, const uint8_t* in, int64_t h, int64_t w, cudaStream_t stream) {
-  int step = w * 3;
-  NppiSize size;
-  size.height = h;
-  size.width = w;
-  DALI_CHECK_NPP(nppiRGBToYCbCr_8u_C3R_Ctx(in, step, out, step, size, GetNppContext(stream)));
-}
+
+
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
@@ -88,13 +88,13 @@ inline nvjpegOutputFormat_t GetFormat(DALIImageType type) {
   switch (type) {
     case DALI_RGB:
     case DALI_ANY_DATA:
+    case DALI_YCbCr:  // purposedly not using NVJPEG_OUTPUT_YUV, as we want to control the
+                      // definition of YCbCr to be consistent with the host backend
       return NVJPEG_OUTPUT_RGBI;
     case DALI_BGR:
       return NVJPEG_OUTPUT_BGRI;
     case DALI_GRAY:
       return NVJPEG_OUTPUT_Y;
-    case DALI_YCbCr:
-      return NVJPEG_OUTPUT_YUV;
     default:
       return NVJPEG_OUTPUT_FORMAT_MAX;  // doesn't matter (will fallback to host decoder)
   }

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
@@ -171,7 +171,7 @@ void HostFallback(const uint8_t *data, int size, DALIImageType image_type, uint8
   kernels::copy<StorageType, StorageCPU>(output_buffer, decoded.get(), volume(shape), stream);
 }
 
-void ConvertRGBToYCbCr(uint8_t* data, int64_t h, int64_t w, cudaStream_t stream);
+void ConvertRGBToYCbCr(uint8_t* out, const uint8_t* in, int64_t h, int64_t w, cudaStream_t stream);
 
 }  // namespace dali
 

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
@@ -171,8 +171,6 @@ void HostFallback(const uint8_t *data, int size, DALIImageType image_type, uint8
   kernels::copy<StorageType, StorageCPU>(output_buffer, decoded.get(), volume(shape), stream);
 }
 
-void ConvertRGBToYCbCr(uint8_t* out, const uint8_t* in, int64_t h, int64_t w, cudaStream_t stream);
-
 }  // namespace dali
 
 #endif  // DALI_OPERATORS_DECODER_NVJPEG_NVJPEG_HELPER_H_

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
@@ -171,6 +171,8 @@ void HostFallback(const uint8_t *data, int size, DALIImageType image_type, uint8
   kernels::copy<StorageType, StorageCPU>(output_buffer, decoded.get(), volume(shape), stream);
 }
 
+void ConvertRGBToYCbCr(uint8_t* data, int64_t h, int64_t w, cudaStream_t stream);
+
 }  // namespace dali
 
 #endif  // DALI_OPERATORS_DECODER_NVJPEG_NVJPEG_HELPER_H_

--- a/dali/operators/decoder/nvjpeg/permute_layout.cu
+++ b/dali/operators/decoder/nvjpeg/permute_layout.cu
@@ -17,7 +17,7 @@
 #include "dali/core/format.h"
 #include "dali/core/static_switch.h"
 #include "dali/core/util.h"
-#include "dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h"
+#include "dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh"
 #include "dali/operators/decoder/nvjpeg/permute_layout.h"
 
 namespace dali {
@@ -100,6 +100,14 @@ void PlanarRGBToGray(Output *output, const Input *input, int64_t npixels,
   planar_rgb_to_gray<<<num_blocks, block_size, 0, stream>>>(output, input, npixels);
 }
 
+template <typename Output, typename Input>
+void Convert_RGB_to_YCbCr(Output *out_data, const Input *in_data, int64_t npixels,
+                          cudaStream_t stream) {
+  kernels::color::RunColorSpaceConversionKernel(out_data, in_data, DALI_YCbCr, DALI_RGB, npixels,
+                                                stream);
+}
+
+
 template void PlanarToInterleaved<uint8_t, uint16_t>(uint8_t *, const uint16_t *, int64_t, int64_t,
                                                      DALIImageType, DALIDataType, cudaStream_t);
 template void PlanarToInterleaved<uint8_t, uint8_t>(uint8_t *, const uint8_t *, int64_t, int64_t,
@@ -108,5 +116,7 @@ template void PlanarRGBToGray<uint8_t, uint16_t>(uint8_t *, const uint16_t *, in
                                                  cudaStream_t);
 template void PlanarRGBToGray<uint8_t, uint8_t>(uint8_t *, const uint8_t *, int64_t, DALIDataType,
                                                 cudaStream_t);
+template void Convert_RGB_to_YCbCr<uint8_t, uint8_t>(uint8_t *, const uint8_t *, int64_t,
+                                                     cudaStream_t);
 
 }  // namespace dali

--- a/dali/operators/decoder/nvjpeg/permute_layout.h
+++ b/dali/operators/decoder/nvjpeg/permute_layout.h
@@ -38,6 +38,12 @@ template <typename Output, typename Input>
 void PlanarRGBToGray(Output *output, const Input *input,
                      int64_t npixels, DALIDataType pixel_type, cudaStream_t stream);
 
+/**
+ * @brief Convert interleaved RGB data to interleaved YCbCr .
+ */
+template <typename Output, typename Input>
+void Convert_RGB_to_YCbCr(Output *output, const Input *input, int64_t npixels, cudaStream_t stream);
+
 
 }  // namespace dali
 

--- a/dali/operators/image/color/color_space_conversion.cc
+++ b/dali/operators/image/color/color_space_conversion.cc
@@ -22,42 +22,34 @@ DALI_SCHEMA(ColorSpaceConversion)
     .DocStr(R"code(Converts between various image color models.)code")
     .NumInput(1)
     .NumOutput(1)
-    .InputLayout("HWC")
-    .AddArg("image_type",
-        R"code(The color space of the input image.)code",
-        DALI_IMAGE_TYPE)
-    .AddArg("output_type",
-        R"code(The color space of the output image.)code",
-        DALI_IMAGE_TYPE);
+    .InputLayout({"FDHWC", "FHWC", "DHWC", "HWC"})
+    .AddArg("image_type", R"code(The color space of the input image.)code", DALI_IMAGE_TYPE)
+    .AddArg("output_type", R"code(The color space of the output image.)code", DALI_IMAGE_TYPE)
+    .AllowSequences()
+    .SupportVolumetric();
 
 template <>
-void ColorSpaceConversion<CPUBackend>::RunImpl(SampleWorkspace &ws) {
-  const auto &input = ws.Input<CPUBackend>(0);
-  auto &output = ws.Output<CPUBackend>(0);
-  const auto &input_shape = input.shape();
-  auto output_shape = input_shape;
+void ColorSpaceConversion<CPUBackend>::RunImpl(HostWorkspace &ws) {
+  const auto &input = ws.InputRef<CPUBackend>(0);
+  auto &output = ws.OutputRef<CPUBackend>(0);
   output.SetLayout(input.GetLayout());
-
-  const auto H = input_shape[0];
-  const auto W = input_shape[1];
-  const int input_C = NumberOfChannels(input_type_);
-  const int output_C = NumberOfChannels(output_type_);
-
-  DALI_ENFORCE(input_shape[2] == input_C,
-    "Incorrect number of channels for input");
-  output_shape[2] = output_C;
-  output.Resize(output_shape);
-
-  auto pImgInp = input.template data<uint8>();
-
-  const int input_channel_flag = GetOpenCvChannelType(input_C);
-  const cv::Mat cv_input_img = CreateMatFromPtr(H, W, input_channel_flag, pImgInp);
-
-  auto pImgOut = output.template mutable_data<uint8>();
-  const int output_channel_flag = GetOpenCvChannelType(output_C);
-  cv::Mat cv_output_img = CreateMatFromPtr(H, W, output_channel_flag, pImgOut);
-
-  OpenCvColorConversion(input_type_, cv_input_img, output_type_, cv_output_img);
+  auto in_view = view<const uint8_t>(input);
+  auto out_view = view<uint8_t>(output);
+  const auto &in_sh = in_view.shape;
+  const auto &out_sh = out_view.shape;
+  int nsamples = in_sh.num_samples();
+  int ndim = in_sh.sample_dim();
+  for (int i = 0; i < nsamples; i++) {
+    auto in_sample_sh = in_sh.tensor_shape_span(i);
+    // flatten any leading dimensions together with the height
+    int height = volume(in_sample_sh.begin(), in_sample_sh.end() - 2);
+    int width  = in_sample_sh[ndim - 2];
+    auto cv_in =
+        CreateMatFromPtr(height, width, GetOpenCvChannelType(in_nchannels_), in_view[i].data);
+    auto cv_out =
+        CreateMatFromPtr(height, width, GetOpenCvChannelType(out_nchannels_), out_view[i].data);
+    OpenCvColorConversion(input_type_, cv_in, output_type_, cv_out);
+  }
 }
 
 DALI_REGISTER_OPERATOR(ColorSpaceConversion, ColorSpaceConversion<CPUBackend>, CPU);

--- a/dali/operators/image/color/color_space_conversion.cu
+++ b/dali/operators/image/color/color_space_conversion.cu
@@ -32,7 +32,7 @@ void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   const auto &in_sh = in_view.shape;
   int nsamples = in_sh.num_samples();
   auto stream = ws.stream();
-  for (unsigned int i = 0; i < nsamples; ++i) {
+  for (int i = 0; i < nsamples; ++i) {
     auto sample_sh = in_sh.tensor_shape_span(i);
     int64_t npixels = volume(sample_sh.begin(), sample_sh.end() - 1);
     kernels::color::RunColorSpaceConversionKernel(out_view[i].data, in_view[i].data, output_type_,

--- a/dali/operators/image/color/color_space_conversion.cu
+++ b/dali/operators/image/color/color_space_conversion.cu
@@ -16,80 +16,12 @@
 #include <utility>
 #include <vector>
 #include "dali/operators/image/color/color_space_conversion.h"
-#include "dali/util/npp.h"
+#include "dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh"
 #include "dali/core/dev_buffer.h"
+#include "dali/core/geom/vec.h"
 
 namespace dali {
 
-namespace detail {
-
-template<typename T = uint8_t>
-__global__ void ConvertRGBToBGRKernel(const T *input, T *output, unsigned int total_pixels) {
-  unsigned idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (idx >= total_pixels) {
-    return;
-  }
-
-  const unsigned int C = 3;
-  const T* pixel_in = &input[idx * C];
-  T* pixel_out = &output[idx * C];
-
-  T tmp[3] = { pixel_in[0], pixel_in[1], pixel_in[2] };
-  pixel_out[0] = tmp[2];
-  pixel_out[1] = tmp[1];
-  pixel_out[2] = tmp[0];
-}
-
-auto ConvertBGRToRGB8uKernel = ConvertRGBToBGRKernel<uint8_t>;
-auto ConvertRGBToBGR8uKernel = ConvertRGBToBGRKernel<uint8_t>;
-
-
-template<typename T = uint8_t>
-__global__ void ConvertGrayToRGBKernel(const T *input, T *output, unsigned int total_pixels) {
-  unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (idx >= total_pixels) {
-    return;
-  }
-
-  const T pixel_in = input[idx];
-  const unsigned int C = 3;
-  T* pixel_out = &output[idx * C];
-  pixel_out[0] = pixel_in;
-  pixel_out[1] = pixel_in;
-  pixel_out[2] = pixel_in;
-}
-
-auto ConvertGrayToRGB8uKernel = ConvertGrayToRGBKernel<uint8_t>;
-
-__global__ void ConvertGrayToYCbCr8uKernel(const uint8_t *input, uint8_t *output,
-                                           unsigned int total_pixels) {
-  unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (idx >= total_pixels) {
-    return;
-  }
-
-  const uint8_t pixel_in = input[idx];
-  const unsigned int C = 3;
-  uint8_t* pixel_out = &output[idx * C];
-  pixel_out[0] = pixel_in;
-  pixel_out[1] = 128;
-  pixel_out[2] = 128;
-}
-
-template<typename T = uint8_t>
-__global__ void ConvertYCbCrToGrayKernel(const T *input, T *output, unsigned int total_pixels) {
-  unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
-  if (idx >= total_pixels) {
-    return;
-  }
-
-  const unsigned int C = 3;
-  output[idx] = input[idx * C];
-}
-
-auto ConvertYCbCrToGray8uKernel = ConvertYCbCrToGrayKernel<uint8_t>;
-
-}  // namespace detail
 
 template<>
 void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
@@ -99,31 +31,13 @@ void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   auto &output = ws.Output<GPUBackend>(0);
   auto layout = input.GetLayout();
   output.SetLayout(layout);
-  TensorList<CPUBackend> attr_output_cpu;
   auto stream = ws.stream();
-  auto npp_ctx = GetNppContext(stream);
-
-  using ImageTypePair = std::pair<DALIImageType, DALIImageType>;
-  ImageTypePair conversion { input_type_, output_type_};
-
-  const ImageTypePair kRGB_TO_BGR { DALI_RGB, DALI_BGR };
-  const ImageTypePair kBGR_TO_RGB { DALI_BGR, DALI_RGB };
-  const ImageTypePair kRGB_TO_YCbCr { DALI_RGB, DALI_YCbCr };
-  const ImageTypePair kBGR_TO_YCbCr { DALI_BGR, DALI_YCbCr };
-  const ImageTypePair kRGB_TO_GRAY { DALI_RGB, DALI_GRAY };
-  const ImageTypePair kBGR_TO_GRAY { DALI_BGR, DALI_GRAY };
-  const ImageTypePair kYCbCr_TO_BGR { DALI_YCbCr, DALI_BGR };
-  const ImageTypePair kYCbCr_TO_RGB { DALI_YCbCr, DALI_RGB };
-  const ImageTypePair kYCbCr_TO_GRAY { DALI_YCbCr, DALI_GRAY };
-  const ImageTypePair kGRAY_TO_RGB { DALI_GRAY, DALI_RGB };
-  const ImageTypePair kGRAY_TO_BGR { DALI_GRAY, DALI_BGR };
-  const ImageTypePair kGRAY_TO_YCbCr { DALI_GRAY, DALI_YCbCr };
 
   int input_C = NumberOfChannels(input_type_);
   int output_C = NumberOfChannels(output_type_);
   const auto& input_shape = input.shape();
   auto output_shape = input_shape;
-  if ( input_C != output_C ) {
+  if (input_C != output_C) {
     for (unsigned int i = 0; i < input.ntensor(); ++i) {
       DALI_ENFORCE(input_shape.tensor_shape_span(i)[2] == input_C,
         "Wrong number of channels for input");
@@ -133,100 +47,17 @@ void ColorSpaceConversion<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   output.Resize(output_shape);
   output.set_type(input.type());
 
-  if (conversion == kBGR_TO_YCbCr || conversion == kYCbCr_TO_BGR) {
-    int64_t scratch_sz = volume(scratch_.shape());
-    for (int i = 0; i < output_shape.num_samples(); i++) {
-      auto sz = output_shape.tensor_size(i);
-      if (sz > scratch_sz)
-        scratch_sz = sz;
-    }
-    scratch_.set_type(input.type());
-    scratch_.Resize({scratch_sz});
-  }
-
-  if (layout == "HWC") {
-    // RGB -> BGR || BGR -> RGB
-    for (unsigned int i = 0; i < input.ntensor(); ++i) {
-      auto sample_sh = input_shape.tensor_shape_span(i);
-      // image dimensions
-      NppiSize size;
-      size.height = sample_sh[0];
-      size.width = sample_sh[1];
-
-      // For CUDA kernel
-      const unsigned int total_size = size.height * size.width;
-      const unsigned int block = total_size < 1024 ? total_size : 1024;
-      const unsigned int grid = (total_size + block - 1) / block;
-
-      // For NPPI calls
-      const int nStepInput = input_C * size.width;
-      const int nStepOutput = output_C * size.width;
-
-      // input/output
-      const uint8_t* input_data = input.tensor<uint8_t>(i);
-      uint8_t* output_data = output.mutable_tensor<uint8_t>(i);
-
-      if (conversion == kRGB_TO_BGR || conversion == kBGR_TO_RGB) {
-        // RGB -> BGR
-        // BGR -> RGB
-        detail::ConvertRGBToBGR8uKernel<<<grid, block, 0, stream>>>(
-          input_data, output_data, total_size);
-      } else if (conversion == kRGB_TO_YCbCr) {
-        // RGB -> YCbCr
-        DALI_CHECK_NPP(
-          nppiRGBToYCbCr_8u_C3R_Ctx(
-            input_data, nStepInput, output_data, nStepOutput, size, npp_ctx));
-      } else if (conversion == kBGR_TO_YCbCr) {
-        // BGR -> YCbCr
-        // First from BGR to RGB
-        auto scratch = scratch_.mutable_data<uint8_t>();
-        detail::ConvertBGRToRGB8uKernel<<<grid, block, 0, stream>>>(
-          input_data, scratch, total_size);
-        // Then from RGB to YCbCr
-        DALI_CHECK_NPP(
-          nppiRGBToYCbCr_8u_C3R_Ctx(
-            scratch, nStepInput, output_data, nStepOutput, size, npp_ctx));
-      } else if (conversion == kRGB_TO_GRAY) {
-        // RGB -> GRAY
-        DALI_CHECK_NPP(
-          nppiRGBToGray_8u_C3C1R_Ctx(
-            input_data, nStepInput, output_data, nStepOutput, size, npp_ctx));
-      } else if (conversion == kBGR_TO_GRAY) {
-        // BGR -> GRAY
-        const Npp32f aCoefs[3] = {0.114f, 0.587f, 0.299f};
-        DALI_CHECK_NPP(
-          nppiColorToGray_8u_C3C1R_Ctx(
-            input_data, nStepInput, output_data, nStepOutput, size, aCoefs, npp_ctx));
-      } else if (conversion == kYCbCr_TO_BGR) {
-        // First from YCbCr to RGB
-        auto scratch = scratch_.mutable_data<uint8_t>();
-        DALI_CHECK_NPP(
-          nppiYCbCrToRGB_8u_C3R_Ctx(
-            input_data, nStepInput, scratch, nStepOutput, size, npp_ctx));
-        // Then from RGB to BGR
-        detail::ConvertRGBToBGR8uKernel<<<grid, block, 0, stream>>>(
-          scratch, output_data, total_size);
-      } else if (conversion == kYCbCr_TO_RGB) {
-        // First from YCbCr to RGB
-        DALI_CHECK_NPP(
-          nppiYCbCrToRGB_8u_C3R_Ctx(
-            input_data, nStepInput, output_data, nStepOutput, size, npp_ctx));
-      } else if (conversion == kGRAY_TO_BGR || conversion == kGRAY_TO_RGB) {
-        // GRAY -> RGB / BGR
-        detail::ConvertGrayToRGB8uKernel<<<grid, block, 0, stream>>>(
-          input_data, output_data, total_size);
-      } else if (conversion == kGRAY_TO_YCbCr) {
-        // GRAY -> YCbCr
-        detail::ConvertGrayToYCbCr8uKernel<<<grid, block, 0, stream>>>(
-          input_data, output_data, total_size);
-      } else if (conversion == kYCbCr_TO_GRAY) {
-        // YCbCr -> GRAY
-        detail::ConvertYCbCrToGray8uKernel<<<grid, block, 0, stream>>>(
-          input_data, output_data, total_size);
-      } else {
-        DALI_FAIL("conversion not supported");
-      }
-    }
+  DALI_ENFORCE(layout == "HWC" || (layout.empty() && output_shape.sample_dim() == 3),
+               make_string("Unexpected layout: ", layout, " shape: ", output_shape,
+                           ". Expected data in HWC layout."));
+  for (unsigned int i = 0; i < input.ntensor(); ++i) {
+    auto sample_sh = input_shape.tensor_shape_span(i);
+    // input/output
+    const uint8_t* input_data = input.tensor<uint8_t>(i);
+    uint8_t* output_data = output.mutable_tensor<uint8_t>(i);
+    int64_t npixels = sample_sh[0] * sample_sh[1];
+    kernels::color::RunColorSpaceConversionKernel(output_data, input_data, output_type_,
+                                                  input_type_, npixels, stream);
   }
 }
 

--- a/dali/operators/image/color/color_space_conversion.h
+++ b/dali/operators/image/color/color_space_conversion.h
@@ -43,6 +43,8 @@ class ColorSpaceConversion : public Operator<Backend> {
 
   const DALIImageType input_type_;
   const DALIImageType output_type_;
+
+  Tensor<Backend> scratch_;
 };
 
 }  // namespace dali

--- a/dali/operators/image/color/color_space_conversion.h
+++ b/dali/operators/image/color/color_space_conversion.h
@@ -35,6 +35,7 @@ class ColorSpaceConversion : public Operator<Backend> {
 
  protected:
   bool CanInferOutputs() const override { return true; }
+
   bool SetupImpl(std::vector<OutputDesc> &output_desc,
                  const workspace_t<Backend> &ws) override {
     output_desc.resize(1);
@@ -43,11 +44,9 @@ class ColorSpaceConversion : public Operator<Backend> {
     auto ndim = in_sh.sample_dim();
     int nsamples = in_sh.num_samples();
     auto in_layout = input.GetLayout();
-    int channel_dim = ndim - 1;
+    int channel_dim = in_layout.find('C');
+    assert(channel_dim == ndim - 1);  // shoulb be enforced by input layouts
     DALI_ENFORCE(IsType<uint8_t>(input.type()), "Color space conversion accept only uint8 tensors");
-    DALI_ENFORCE(
-        in_layout.empty() || in_layout.find('C') == channel_dim,
-        make_string("Channel dimension should be the last in the layout. Got ", in_layout));
     auto out_sh = in_sh;
     for (int i = 0; i < in_sh.num_samples(); i++) {
       int c = in_sh.tensor_shape_span(i)[channel_dim];

--- a/dali/operators/image/color/color_space_conversion.h
+++ b/dali/operators/image/color/color_space_conversion.h
@@ -43,8 +43,6 @@ class ColorSpaceConversion : public Operator<Backend> {
 
   const DALIImageType input_type_;
   const DALIImageType output_type_;
-
-  Tensor<Backend> scratch_;
 };
 
 }  // namespace dali

--- a/dali/operators/image/color/color_space_conversion.h
+++ b/dali/operators/image/color/color_space_conversion.h
@@ -26,23 +26,47 @@ template <typename Backend>
 class ColorSpaceConversion : public Operator<Backend> {
  public:
   inline explicit ColorSpaceConversion(const OpSpec &spec)
-    : Operator<Backend>(spec)
-    , input_type_(spec.GetArgument<DALIImageType>("image_type"))
-    , output_type_(spec.GetArgument<DALIImageType>("output_type")) {
+      : Operator<Backend>(spec),
+        input_type_(spec.GetArgument<DALIImageType>("image_type")),
+        output_type_(spec.GetArgument<DALIImageType>("output_type")),
+        in_nchannels_(NumberOfChannels(input_type_)),
+        out_nchannels_(NumberOfChannels(output_type_)) {
   }
 
  protected:
-  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
-    return false;
+  bool CanInferOutputs() const override { return true; }
+  bool SetupImpl(std::vector<OutputDesc> &output_desc,
+                 const workspace_t<Backend> &ws) override {
+    output_desc.resize(1);
+    const auto &input = ws.template InputRef<Backend>(0);
+    auto in_sh = input.shape();
+    auto ndim = in_sh.sample_dim();
+    int nsamples = in_sh.num_samples();
+    auto in_layout = input.GetLayout();
+    int channel_dim = ndim - 1;
+    DALI_ENFORCE(IsType<uint8_t>(input.type()), "Color space conversion accept only uint8 tensors");
+    DALI_ENFORCE(
+        in_layout.empty() || in_layout.find('C') == channel_dim,
+        make_string("Channel dimension should be the last in the layout. Got ", in_layout));
+    auto out_sh = in_sh;
+    for (int i = 0; i < in_sh.num_samples(); i++) {
+      int c = in_sh.tensor_shape_span(i)[channel_dim];
+      DALI_ENFORCE(in_nchannels_ == c, make_string("Expected ", in_nchannels_, ". Got ", c));
+      out_sh.tensor_shape_span(i)[channel_dim] = out_nchannels_;
+    }
+    output_desc[0].type = input.type();
+    output_desc[0].shape = out_sh;
+    return true;
   }
 
-  void RunImpl(Workspace<Backend> &ws) override;
-
+  void RunImpl(workspace_t<Backend> &ws) override;
   USE_OPERATOR_MEMBERS();
   using Operator<Backend>::RunImpl;
 
   const DALIImageType input_type_;
   const DALIImageType output_type_;
+  const int in_nchannels_;
+  const int out_nchannels_;
 };
 
 }  // namespace dali

--- a/dali/util/npp.cc
+++ b/dali/util/npp.cc
@@ -35,40 +35,4 @@ int NPPInterpForDALIInterp(DALIInterpType type, NppiInterpolationMode *npp_type)
   return DALISuccess;
 }
 
-namespace {
-
-NppStreamContext GetNppContextImpl() {
-  NppStreamContext ctx;
-  ctx.hStream = 0;
-  CUDA_CALL(cudaGetDevice(&ctx.nCudaDeviceId));
-  int driver_ver, runtime_ver;
-  cudaDriverGetVersion(&driver_ver);
-  cudaRuntimeGetVersion(&runtime_ver);
-
-  CUDA_CALL(cudaDeviceGetAttribute(&ctx.nCudaDevAttrComputeCapabilityMajor,
-                                   cudaDevAttrComputeCapabilityMajor, ctx.nCudaDeviceId));
-
-  CUDA_CALL(cudaDeviceGetAttribute(&ctx.nCudaDevAttrComputeCapabilityMinor,
-                                   cudaDevAttrComputeCapabilityMinor, ctx.nCudaDeviceId));
-
-  CUDA_CALL(cudaStreamGetFlags(ctx.hStream, &ctx.nStreamFlags));
-  cudaDeviceProp dev_prop;
-  CUDA_CALL(cudaGetDeviceProperties(&dev_prop, ctx.nCudaDeviceId));
-
-  ctx.nMultiProcessorCount = dev_prop.multiProcessorCount;
-  ctx.nMaxThreadsPerMultiProcessor = dev_prop.maxThreadsPerMultiProcessor;
-  ctx.nMaxThreadsPerBlock = dev_prop.maxThreadsPerBlock;
-  ctx.nSharedMemPerBlock = dev_prop.sharedMemPerBlock;
-  return ctx;
-}
-
-}  // namespace
-
-NppStreamContext GetNppContext(cudaStream_t stream) {
-  static NppStreamContext ctx = GetNppContextImpl();
-  auto ret_ctx = ctx;
-  ret_ctx.hStream = stream;
-  return ret_ctx;
-}
-
 }  // namespace dali

--- a/dali/util/npp.cc
+++ b/dali/util/npp.cc
@@ -39,7 +39,7 @@ namespace {
 
 NppStreamContext GetNppContextImpl() {
   NppStreamContext ctx;
-  ctx.hStream = nullptr;
+  ctx.hStream = 0;
   CUDA_CALL(cudaGetDevice(&ctx.nCudaDeviceId));
   int driver_ver, runtime_ver;
   cudaDriverGetVersion(&driver_ver);

--- a/dali/util/npp.h
+++ b/dali/util/npp.h
@@ -334,6 +334,16 @@ static const char *nppErrorString(NppStatus error) {
   return "<unknown>";
 }
 
+template <typename T>
+NppiSize ToNppiSize(const T& size) {
+  NppiSize out;
+  out.width = size.width;
+  out.height = size.height;
+  return out;
+}
+
+DLL_PUBLIC NppStreamContext GetNppContext(cudaStream_t stream);
+
 }  // namespace dali
 
 // For checking npp return errors in dali library functions
@@ -345,17 +355,9 @@ static const char *nppErrorString(NppStatus error) {
       dali::string line = std::to_string(__LINE__);       \
       dali::string error = "[" + file + ":" + line +      \
         "]: NPP error \"" +                               \
-        nppErrorString(status) + "\"";                    \
+        dali::nppErrorString(status) + "\"";              \
       DALI_FAIL(error);                                   \
     }                                                     \
   } while (0)
-
-template <typename T>
-NppiSize ToNppiSize(const T& size) {
-  NppiSize out;
-  out.width = size.width;
-  out.height = size.height;
-  return out;
-}
 
 #endif  // DALI_UTIL_NPP_H_

--- a/dali/util/npp.h
+++ b/dali/util/npp.h
@@ -342,8 +342,6 @@ NppiSize ToNppiSize(const T& size) {
   return out;
 }
 
-DLL_PUBLIC NppStreamContext GetNppContext(cudaStream_t stream);
-
 }  // namespace dali
 
 // For checking npp return errors in dali library functions

--- a/dali/util/ocv.cc
+++ b/dali/util/ocv.cc
@@ -86,60 +86,34 @@ inline void custom_conversion_pixel<DALI_BGR, DALI_YCbCr>(const uint8_t* input, 
   output[2] = kernels::color::itu_r_bt_601::rgb_to_cr<uint8_t>(rgb);
 }
 
-inline static uint8_t clip(float x, float max = 255.0f) {
-  return static_cast<uint8_t>( std::min(std::max(x, 0.0f), max) );
-}
-
-inline static std::tuple<uint8_t, uint8_t, uint8_t> RGB(uint8_t y, uint8_t cb, uint8_t cr) {
-  const float nY = 1.164f * (static_cast<float>(y) - 16.0f);
-  float nR = (static_cast<float>(cr) - 128.0f);
-  float nB = (static_cast<float>(cb) - 128.0f);
-  float nG = nY - 0.813f * nR - 0.392f * nB;
-  nG = std::min(nG, 255.0f);
-  nR = nY + 1.596f * nR;
-  nR = std::min(nR, 255.0f);
-  nB = nY + 2.017f * nB;
-  nB = std::min(nB, 255.0f);
-  const uint8_t r = clip(nR);
-  const uint8_t g = clip(nG);
-  const uint8_t b = clip(nB);
-  return std::tuple<uint8_t, uint8_t, uint8_t>{ r, g, b };
-}
-
 template <>
 inline void custom_conversion_pixel<DALI_YCbCr, DALI_RGB>(const uint8_t* input, uint8_t* output) {
-  const auto y   = input[0];
-  const auto cb  = input[1];
-  const auto cr  = input[2];
-  const auto rgb = RGB(y, cb, cr);
-  output[0] = std::get<0>(rgb);
-  output[1] = std::get<1>(rgb);
-  output[2] = std::get<2>(rgb);
+  vec<3, uint8_t> ycbcr{input[0], input[1], input[2]};
+  auto rgb = kernels::color::itu_r_bt_601::ycbcr_to_rgb<uint8_t>(ycbcr);
+  output[0] = rgb[0];
+  output[1] = rgb[1];
+  output[2] = rgb[2];
 }
 
 template <>
 inline void custom_conversion_pixel<DALI_YCbCr, DALI_BGR>(const uint8_t* input, uint8_t* output) {
-  const auto y   = input[0];
-  const auto cb  = input[1];
-  const auto cr  = input[2];
-  const auto rgb = RGB(y, cb, cr);
-  output[0] = std::get<2>(rgb);
-  output[1] = std::get<1>(rgb);
-  output[2] = std::get<0>(rgb);
+  vec<3, uint8_t> ycbcr{input[0], input[1], input[2]};
+  auto rgb = kernels::color::itu_r_bt_601::ycbcr_to_rgb<uint8_t>(ycbcr);
+  output[0] = rgb[2];
+  output[1] = rgb[1];
+  output[2] = rgb[0];
 }
 
 template <>
 inline void custom_conversion_pixel<DALI_GRAY, DALI_YCbCr>(const uint8_t* input, uint8_t* output) {
-  const auto y = input[0];
-  output[0] = y;
+  output[0] = kernels::color::itu_r_bt_601::gray_to_y<uint8_t>(input[0]);
   output[1] = 128;
   output[2] = 128;
 }
 
 template <>
 inline void custom_conversion_pixel<DALI_YCbCr, DALI_GRAY>(const uint8_t* input, uint8_t* output) {
-  const auto y = input[0];
-  output[0] = y;
+  output[0] = kernels::color::itu_r_bt_601::y_to_gray<uint8_t>(input[0]);
 }
 
 template <DALIImageType input_type, DALIImageType output_type>


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in the usage of NPP color conversion functions that do not support in-place processing.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *[Changed usage of NPP color space conversion functions by a custom kernel. The custom kernel was already in use for some of the conversions, this PRs extends it to all conversions.]*
 - Affected modules and functionalities:
     *[ColorSpaceConversion op, ImageDecoder]*
 - Key points relevant for the review:
     *color space conversion kernel implementation*
 - Validation and testing:
     *[NA]*
 - Documentation (including examples):
     *[NA]*


**JIRA TASK**: *[DALI-2003]*
