### PR TITLE
Fix nvcc warning about unused arguments in ResampleDepth_Channels

### DIFF
--- a/dali/kernels/imgproc/resample/resampling_impl.cuh
+++ b/dali/kernels/imgproc/resample/resampling_impl.cuh
@@ -489,11 +489,12 @@ __device__ void ResampleVert_Channels(
 
 template <int static_channels = -1, typename Dst, typename Src>
 __device__ void ResampleDepth_Channels(
-    ivec2, ivec2,
-    float, float,
-    Dst *__restrict__, ptrdiff_vec<1>,
-    const Src *__restrict__, ptrdiff_vec<1>, ivec2, int,
-    ResamplingFilter, int) {
+    ivec2 /*lo*/, ivec2 /*hi*/,
+    float /*src_z0*/, float /*scale*/,
+    Dst *__restrict__ /*out*/, ptrdiff_vec<1> /*out_strides*/,
+    const Src *__restrict__ /*in*/, ptrdiff_vec<1> /*in_strides*/, ivec2 /*in_shape*/,
+    int /*dynamic_channels*/,
+    ResamplingFilter /*filter*/, int /*support*/) {
   // Unreachable code - no assert to avoid excessive register pressure.
 }
 

--- a/dali/kernels/imgproc/resample/resampling_impl.cuh
+++ b/dali/kernels/imgproc/resample/resampling_impl.cuh
@@ -489,11 +489,11 @@ __device__ void ResampleVert_Channels(
 
 template <int static_channels = -1, typename Dst, typename Src>
 __device__ void ResampleDepth_Channels(
-    ivec2 lo, ivec2 hi,
-    float src_z0, float scale,
-    Dst *__restrict__ out, ptrdiff_vec<1> out_strides,
-    const Src *__restrict__ in, ptrdiff_vec<1> in_strides, ivec2 in_shape, int dynamic_channels,
-    ResamplingFilter filter, int support) {
+    ivec2, ivec2,
+    float, float,
+    Dst *__restrict__, ptrdiff_vec<1>,
+    const Src *__restrict__, ptrdiff_vec<1>, ivec2, int,
+    ResamplingFilter, int) {
   // Unreachable code - no assert to avoid excessive register pressure.
 }
 


### PR DESCRIPTION
- one on the variants of the ResampleDepth_Channels function has
  an empty body so the compiler warns about unused arguments. This
  change removes their names from the argument list

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a nvcc warning about unused arguments in ResampleDepth_Channels

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     one on the variants of the ResampleDepth_Channels function has an empty body so the compiler warns about unused arguments. This change removes their names from the argument list
 - Affected modules and functionalities:
     resampling_impl.cuh
 - Key points relevant for the review:
     NA
 - Validation and testing:
     inspection of the compilation log for CUDA 11.3
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
