### PR TITLE
Fix CUDA 10.0 compilation

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -74,7 +74,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     nvjpeg2k_thread_(1,
                      spec.GetArgument<int>("device_id"),
                      spec.GetArgument<bool>("affine")) {
-#if NVJPEG_VER_MAJOR >= 11
+#if NVJPEG_VER_MAJOR >= 11 && NVJPEG_VER_MINOR >= 1
     // if hw_decoder_load is not present in the schema (crop/sliceDecoder) then it is not supported
     bool try_init_hw_decoder = false;
     if (spec_.GetSchema().HasArgument("hw_decoder_load")) {
@@ -558,7 +558,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
       // only when we have ROI info check if nvjpegDecodeBatchedSupportedEx supports it
       if (nvjpeg_decode) {
-#if NVJPEG_VER_MAJOR >= 11
+#if NVJPEG_VER_MAJOR >= 11 && NVJPEG_VER_MINOR >= 1
         if (state_hw_batched_ != nullptr) {
           NVJPEG_CALL(nvjpegJpegStreamParseHeader(handle_, input_data, in_size,
                                                   hw_decoder_jpeg_stream_));
@@ -734,6 +734,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
   }
 
   void ProcessImagesHw(MixedWorkspace &ws) {
+#if NVJPEG_VER_MAJOR >= 11 && NVJPEG_VER_MINOR >= 1
     auto& output = ws.Output<GPUBackend>(0);
     if (!samples_hw_batched_.empty()) {
       nvjpegJpegState_t &state = state_hw_batched_;
@@ -799,6 +800,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       }
       CUDA_CALL(cudaEventRecord(hw_decode_event_, hw_decode_stream_));
     }
+#endif
   }
 
   void ProcessImages(MixedWorkspace &ws) {

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -74,7 +74,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     nvjpeg2k_thread_(1,
                      spec.GetArgument<int>("device_id"),
                      spec.GetArgument<bool>("affine")) {
-#if NVJPEG_VER_MAJOR >= 11 && NVJPEG_VER_MINOR >= 1
+#if NVJPEG_VER_MAJOR > 11 || (NVJPEG_VER_MAJOR == 11 && NVJPEG_VER_MINOR >= 1)
     // if hw_decoder_load is not present in the schema (crop/sliceDecoder) then it is not supported
     bool try_init_hw_decoder = false;
     if (spec_.GetSchema().HasArgument("hw_decoder_load")) {
@@ -558,7 +558,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
       // only when we have ROI info check if nvjpegDecodeBatchedSupportedEx supports it
       if (nvjpeg_decode) {
-#if NVJPEG_VER_MAJOR >= 11 && NVJPEG_VER_MINOR >= 1
+#if NVJPEG_VER_MAJOR > 11 || (NVJPEG_VER_MAJOR == 11 && NVJPEG_VER_MINOR >= 1)
         if (state_hw_batched_ != nullptr) {
           NVJPEG_CALL(nvjpegJpegStreamParseHeader(handle_, input_data, in_size,
                                                   hw_decoder_jpeg_stream_));
@@ -734,7 +734,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
   }
 
   void ProcessImagesHw(MixedWorkspace &ws) {
-#if NVJPEG_VER_MAJOR >= 11 && NVJPEG_VER_MINOR >= 1
+#if NVJPEG_VER_MAJOR > 11 || (NVJPEG_VER_MAJOR == 11 && NVJPEG_VER_MINOR >= 1)
     auto& output = ws.Output<GPUBackend>(0);
     if (!samples_hw_batched_.empty()) {
       nvjpegJpegState_t &state = state_hw_batched_;

--- a/dali/util/nvml.h
+++ b/dali/util/nvml.h
@@ -242,6 +242,16 @@ inline void Shutdown() {
   CUDA_CALL(nvmlShutdown());
 }
 
+/**
+ * Checks, whether CUDA11-proper NVML functions have been successfully loaded
+ */
+inline bool HasCuda11NvmlFunctions() {
+  if (!nvmlIsInitialized()) {
+    return false;
+  }
+  return nvmlHasCuda11NvmlFunctions();
+}
+
 #if (CUDART_VERSION >= 11000)
 
 /**
@@ -301,17 +311,6 @@ inline bool HasHwDecoder() {
   }
   return false;
 }
-#endif
-
-/**
- * Checks, whether CUDA11-proper NVML functions have been successfully loaded
- */
-inline bool HasCuda11NvmlFunctions() {
-  if (!nvmlIsInitialized()) {
-    return false;
-  }
-  return nvmlHasCuda11NvmlFunctions();
-}
 
 inline bool isHWDecoderSupported() {
   if (nvml::HasCuda11NvmlFunctions()) {
@@ -319,6 +318,13 @@ inline bool isHWDecoderSupported() {
   }
   return false;
 }
+#else
+
+inline bool isHWDecoderSupported()  {
+  return false;
+}
+
+#endif
 
 }  // namespace nvml
 }  // namespace dali


### PR DESCRIPTION
- moves isHWDecoderSupported to CUDA 11 ifdef as it uses HasHwDecoder
  function not available for CUDA 10

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a CUDA 10.0 compilation

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     moves isHWDecoderSupported to CUDA 11 ifdef as it uses HasHwDecoder function not available for CUDA 10
 - Affected modules and functionalities:
     nvml.h
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI build for CUDA 10.0
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
