### PR TITLE
Better error message when insufficient data in cache

### DIFF
--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -362,7 +362,7 @@ int Executor<WorkspacePolicy, QueuePolicy>::InferBatchSize(
     for (auto &bsp : bsps) {
       bsp->Advance();
     }
-  } catch (const std::exception &e) {
+  } catch (const std::out_of_range &e) {
     DALI_FAIL(
         make_string("Failed to acquire the next batch. Make sure, that DALI Pipeline is fed "
                     "with sufficient amount of data. ", e.what()));

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -356,8 +356,9 @@ int Executor<WorkspacePolicy, QueuePolicy>::InferBatchSize(
     DALI_ENFORCE(bsps[0]->NextBatchSize() == bsps[i]->NextBatchSize(),
                  "Batch size must be uniform across an iteration");
   }
+  int batch_size;
   try {
-    auto batch_size = bsps[0]->NextBatchSize();
+    batch_size = bsps[0]->NextBatchSize();
     assert(batch_size > 0);
     for (auto &bsp : bsps) {
       bsp->Advance();

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -356,10 +356,20 @@ int Executor<WorkspacePolicy, QueuePolicy>::InferBatchSize(
     DALI_ENFORCE(bsps[0]->NextBatchSize() == bsps[i]->NextBatchSize(),
                  "Batch size must be uniform across an iteration");
   }
-  auto batch_size = bsps[0]->NextBatchSize();
-  assert(batch_size > 0);
-  for (auto &bsp : bsps) {
-    bsp->Advance();
+  try {
+    auto batch_size = bsps[0]->NextBatchSize();
+    assert(batch_size > 0);
+    for (auto &bsp : bsps) {
+      bsp->Advance();
+    }
+  } catch (const std::runtime_error &e) {
+    DALI_FAIL(
+        make_string("Failed to acquire the next batch size. Make sure, that DALI Pipeline is fed "
+                    "with sufficient amount of data. ", e.what()));
+  } catch (const std::out_of_range &e) {
+    DALI_FAIL(
+        make_string("No more batches in cache left. Make sure, that DALI Pipeline is fed with "
+                    "sufficient amount of data. ", e.what()));
   }
   return batch_size;
 }

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -362,14 +362,10 @@ int Executor<WorkspacePolicy, QueuePolicy>::InferBatchSize(
     for (auto &bsp : bsps) {
       bsp->Advance();
     }
-  } catch (const std::runtime_error &e) {
+  } catch (const std::exception &e) {
     DALI_FAIL(
-        make_string("Failed to acquire the next batch size. Make sure, that DALI Pipeline is fed "
+        make_string("Failed to acquire the next batch. Make sure, that DALI Pipeline is fed "
                     "with sufficient amount of data. ", e.what()));
-  } catch (const std::out_of_range &e) {
-    DALI_FAIL(
-        make_string("No more batches in cache left. Make sure, that DALI Pipeline is fed with "
-                    "sufficient amount of data. ", e.what()));
   }
   return batch_size;
 }

--- a/dali/pipeline/operator/batch_size_provider.h
+++ b/dali/pipeline/operator/batch_size_provider.h
@@ -38,8 +38,7 @@ class BatchSizeProvider {
    * Implementation shall assure that it's possible to call NextBatchSize()
    * multiple times for the same batch, before Advance() invocation.
    *
-   * If invoking this function is illegal for any reason,
-   * implementation shall throw std::runtime_error.
+   * When there's no next batch size available, the implementation shall throw std::out_of_range.
    */
   virtual int NextBatchSize() = 0;
 


### PR DESCRIPTION


Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
This PR adds better error message, when DALI fails on the situation, that there's not enough data in external_source's cache

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     try-catch block
 - Affected modules and functionalities:
     executor
 - Key points relevant for the review:
     NA
 - Validation and testing:
    NA
 - Documentation (including examples):
     NA


**JIRA TASK**: *[Use DALI-XXXX or NA]*
