### PR TITLE
Fix DALI compilation for CUDA 11 pre 11.3 version

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -74,7 +74,9 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     nvjpeg2k_thread_(1,
                      spec.GetArgument<int>("device_id"),
                      spec.GetArgument<bool>("affine")) {
-#if NVJPEG_VER_MAJOR > 11 || (NVJPEG_VER_MAJOR == 11 && NVJPEG_VER_MINOR >= 1)
+#if NVJPEG_VER_MAJOR > 11 || \
+    (NVJPEG_VER_MAJOR == 11 && (NVJPEG_VER_MINOR > 4 || \
+                               (NVJPEG_VER_MINOR == 4 && NVJPEG_VER_PATCH >= 1)))
     // if hw_decoder_load is not present in the schema (crop/sliceDecoder) then it is not supported
     bool try_init_hw_decoder = false;
     if (spec_.GetSchema().HasArgument("hw_decoder_load")) {
@@ -558,7 +560,9 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
       // only when we have ROI info check if nvjpegDecodeBatchedSupportedEx supports it
       if (nvjpeg_decode) {
-#if NVJPEG_VER_MAJOR > 11 || (NVJPEG_VER_MAJOR == 11 && NVJPEG_VER_MINOR >= 1)
+#if NVJPEG_VER_MAJOR > 11 || \
+    (NVJPEG_VER_MAJOR == 11 && (NVJPEG_VER_MINOR > 4 || \
+                               (NVJPEG_VER_MINOR == 4 && NVJPEG_VER_PATCH >= 1)))
         if (state_hw_batched_ != nullptr) {
           NVJPEG_CALL(nvjpegJpegStreamParseHeader(handle_, input_data, in_size,
                                                   hw_decoder_jpeg_stream_));
@@ -734,7 +738,9 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
   }
 
   void ProcessImagesHw(MixedWorkspace &ws) {
-#if NVJPEG_VER_MAJOR > 11 || (NVJPEG_VER_MAJOR == 11 && NVJPEG_VER_MINOR >= 1)
+#if NVJPEG_VER_MAJOR > 11 || \
+    (NVJPEG_VER_MAJOR == 11 && (NVJPEG_VER_MINOR > 4 || \
+                               (NVJPEG_VER_MINOR == 4 && NVJPEG_VER_PATCH >= 1)))
     auto& output = ws.Output<GPUBackend>(0);
     if (!samples_hw_batched_.empty()) {
       nvjpegJpegState_t &state = state_hw_batched_;

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -39,6 +39,10 @@
 #include "dali/core/static_switch.h"
 #include "dali/operators/decoder/nvjpeg/permute_layout.h"
 
+#define IF_HW_DECODER_COMPATIBLE \
+        NVJPEG_VER_MAJOR > 11 || \
+        (NVJPEG_VER_MAJOR == 11 && (NVJPEG_VER_MINOR > 4 || \
+                                   (NVJPEG_VER_MINOR == 4 && NVJPEG_VER_PATCH >= 1)))
 
 namespace dali {
 
@@ -74,9 +78,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     nvjpeg2k_thread_(1,
                      spec.GetArgument<int>("device_id"),
                      spec.GetArgument<bool>("affine")) {
-#if NVJPEG_VER_MAJOR > 11 || \
-    (NVJPEG_VER_MAJOR == 11 && (NVJPEG_VER_MINOR > 4 || \
-                               (NVJPEG_VER_MINOR == 4 && NVJPEG_VER_PATCH >= 1)))
+#if IF_HW_DECODER_COMPATIBLE
     // if hw_decoder_load is not present in the schema (crop/sliceDecoder) then it is not supported
     bool try_init_hw_decoder = false;
     if (spec_.GetSchema().HasArgument("hw_decoder_load")) {
@@ -560,9 +562,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
       // only when we have ROI info check if nvjpegDecodeBatchedSupportedEx supports it
       if (nvjpeg_decode) {
-#if NVJPEG_VER_MAJOR > 11 || \
-    (NVJPEG_VER_MAJOR == 11 && (NVJPEG_VER_MINOR > 4 || \
-                               (NVJPEG_VER_MINOR == 4 && NVJPEG_VER_PATCH >= 1)))
+#if IF_HW_DECODER_COMPATIBLE
         if (state_hw_batched_ != nullptr) {
           NVJPEG_CALL(nvjpegJpegStreamParseHeader(handle_, input_data, in_size,
                                                   hw_decoder_jpeg_stream_));
@@ -738,9 +738,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
   }
 
   void ProcessImagesHw(MixedWorkspace &ws) {
-#if NVJPEG_VER_MAJOR > 11 || \
-    (NVJPEG_VER_MAJOR == 11 && (NVJPEG_VER_MINOR > 4 || \
-                               (NVJPEG_VER_MINOR == 4 && NVJPEG_VER_PATCH >= 1)))
+#if IF_HW_DECODER_COMPATIBLE
     auto& output = ws.Output<GPUBackend>(0);
     if (!samples_hw_batched_.empty()) {
       nvjpegJpegState_t &state = state_hw_batched_;

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -39,10 +39,13 @@
 #include "dali/core/static_switch.h"
 #include "dali/operators/decoder/nvjpeg/permute_layout.h"
 
-#define IF_HW_DECODER_COMPATIBLE \
-        NVJPEG_VER_MAJOR > 11 || \
-        (NVJPEG_VER_MAJOR == 11 && (NVJPEG_VER_MINOR > 4 || \
-                                   (NVJPEG_VER_MINOR == 4 && NVJPEG_VER_PATCH >= 1)))
+#if NVJPEG_VER_MAJOR > 11 || \
+    (NVJPEG_VER_MAJOR == 11 && (NVJPEG_VER_MINOR > 4 || \
+                               (NVJPEG_VER_MINOR == 4 && NVJPEG_VER_PATCH >= 1)))
+  #define IS_HW_DECODER_COMPATIBLE 1
+#else
+  #define IS_HW_DECODER_COMPATIBLE 0
+#endif
 
 namespace dali {
 
@@ -78,7 +81,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     nvjpeg2k_thread_(1,
                      spec.GetArgument<int>("device_id"),
                      spec.GetArgument<bool>("affine")) {
-#if IF_HW_DECODER_COMPATIBLE
+#if IS_HW_DECODER_COMPATIBLE
     // if hw_decoder_load is not present in the schema (crop/sliceDecoder) then it is not supported
     bool try_init_hw_decoder = false;
     if (spec_.GetSchema().HasArgument("hw_decoder_load")) {
@@ -562,7 +565,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
       // only when we have ROI info check if nvjpegDecodeBatchedSupportedEx supports it
       if (nvjpeg_decode) {
-#if IF_HW_DECODER_COMPATIBLE
+#if IS_HW_DECODER_COMPATIBLE
         if (state_hw_batched_ != nullptr) {
           NVJPEG_CALL(nvjpegJpegStreamParseHeader(handle_, input_data, in_size,
                                                   hw_decoder_jpeg_stream_));
@@ -738,7 +741,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
   }
 
   void ProcessImagesHw(MixedWorkspace &ws) {
-#if IF_HW_DECODER_COMPATIBLE
+#if IS_HW_DECODER_COMPATIBLE
     auto& output = ws.Output<GPUBackend>(0);
     if (!samples_hw_batched_.empty()) {
       nvjpegJpegState_t &state = state_hw_batched_;


### PR DESCRIPTION
- fixes the if condition for enabling nvJPEG HW backend with ROI
  support

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes DALI compilation for CUDA 11 pre 11.3 version

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     fixes the if condition for enabling nvJPEG HW backend with ROI support
 - Affected modules and functionalities:
     nvjpeg_decoder_decoupled_api.h
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
