### PR TITLE
Add a link to the TensorFlow ResNet50 training script in the Readme

### DIFF
--- a/docs/examples/use_cases/tensorflow/resnet-n/README.rst
+++ b/docs/examples/use_cases/tensorflow/resnet-n/README.rst
@@ -9,7 +9,8 @@ single-node training on multi-GPU systems. They can be used for benchmarking, or
 as a starting point for implementing and training your own network.
 
 Common utilities for defining CNN networks and performing basic training are
-located in the nvutils directory. The utilities are written in Tensorflow 2.0.
+located in the nvutils directory inside :fileref:`docs/examples/use_cases/tensorflow/resnet-n`.
+The utilities are written in Tensorflow 2.0.
 Use of nvutils is demonstrated in the model script (i.e. resnet.py). The scripts
 support both Keras Fit/Compile and Custom Training Loop (CTL) modes with
 Horovod.


### PR DESCRIPTION
- updates TensorFlow ResNet50 readme by adding a link to DALI
  repository

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It update TensorFlow ResNet50 readme by adding a link to DALI repository

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     update TensorFlow ResNet50 readme by adding a link to DALI repository
 - Affected modules and functionalities:
     tensorflow/resnet-n/README.rst
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     only docs are updated


**JIRA TASK**: *[NA]*
