### PR TITLE
Fix test_detection_pipeline.py

### DIFF
--- a/dali/test/python/test_detection_pipeline.py
+++ b/dali/test/python/test_detection_pipeline.py
@@ -124,7 +124,7 @@ class DetectionPipeline(Pipeline):
         self.decode_crop = ops.decoders.ImageSlice(device="cpu", output_type=types.RGB)
 
         self.decode_gpu = ops.decoders.Image(device="mixed", output_type=types.RGB, hw_decoder_load=0)
-        self.decode_gpu_crop = ops.decoders.ImageSlice(device="mixed", output_type=types.RGB)
+        self.decode_gpu_crop = ops.decoders.ImageSlice(device="mixed", output_type=types.RGB, hw_decoder_load=0)
 
         self.ssd_crop = ops.SSDRandomCrop(
             device="cpu", num_attempts=1, seed=args.seed)


### PR DESCRIPTION
- sets HW load to 0 for image.decoder_slice to make sure that there is no
  discrepancy due to different decoding backend selected during the test

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a discrepancy in test_detection_pipeline.py

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     sets HW load to 0 for image.decoder_slice to make sure that there is no discrepancy due to different decoding backend selected during the test
 - Affected modules and functionalities:
     test_detection_pipeline.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
