### PR TITLE
Make dynlink_xxx use a fixed function to load symbols.

### DIFF
--- a/dali/core/dynlink_cuda.cc
+++ b/dali/core/dynlink_cuda.cc
@@ -41,23 +41,15 @@ CUDADRIVER loadCudaLibrary() {
   return ret;
 }
 
-void *LoadSymbol(const char *name) {
+}  // namespace
+
+void *CudaLoadSymbol(const char *name) {
   static CUDADRIVER cudaDrvLib = loadCudaLibrary();
   void *ret = cudaDrvLib ? dlsym(cudaDrvLib, name) : nullptr;
   return ret;
 }
 
-}  // namespace
-
-// it is defined in the generated file
-typedef void *tLoadSymbol(const char *name);
-void CudaSetSymbolLoader(tLoadSymbol loader_func);
-
 bool cuInitChecked() {
-#if !LINK_DRIVER_ENABLED
-  static std::once_flag cuda_once;
-  std::call_once(cuda_once, CudaSetSymbolLoader, LoadSymbol);
-#endif
   static CUresult res = cuInit(0);
   return res == CUDA_SUCCESS;
 }
@@ -68,7 +60,7 @@ bool cuIsSymbolAvailable(const char *name) {
   std::lock_guard<std::mutex> lock(symbol_mutex);
   auto it = symbol_map.find(name);
   if (it == symbol_map.end()) {
-    auto *ptr = LoadSymbol(name);
+    auto *ptr = CudaLoadSymbol(name);
     symbol_map.insert({name, ptr});
     return ptr != nullptr;
   }

--- a/dali/core/dynlink_cufile.cc
+++ b/dali/core/dynlink_cufile.cc
@@ -41,21 +41,10 @@ CUFILE loadCufileLibrary() {
   return ret;
 }
 
-void *LoadSymbol(const char *name) {
+}  // namespace
+
+void *CufileLoadSymbol(const char *name) {
   static CUFILE cufileDrvLib = loadCufileLibrary();
   void *ret = cufileDrvLib ? dlsym(cufileDrvLib, name) : nullptr;
   return ret;
-}
-
-}  // namespace
-
-// it is defined in the generated file
-typedef void *tLoadSymbol(const char *name);
-void CufileSetSymbolLoader(tLoadSymbol loader_func);
-
-void cufileInit() {
-#if CUFILE_ENABLED
-  static std::once_flag cufile_once;
-  std::call_once(cufile_once, CufileSetSymbolLoader, LoadSymbol);
-#endif
 }

--- a/dali/operators/reader/nvdecoder/dynlink_nvcuvid.cc
+++ b/dali/operators/reader/nvdecoder/dynlink_nvcuvid.cc
@@ -41,22 +41,15 @@ CUVIDDRIVER loadNvcuvidLibrary() {
   return ret;
 }
 
-void *LoadSymbol(const char *name) {
+}  // namespace
+
+void *NvcuvidLoadSymbol(const char *name) {
   static CUVIDDRIVER nvcuvidDrvLib = loadNvcuvidLibrary();
   void *ret = nvcuvidDrvLib ? dlsym(nvcuvidDrvLib, name) : nullptr;
   return ret;
 }
 
-}  // namespace
-
-// it is defined in the generated file
-typedef void *tLoadSymbol(const char *name);
-void NvcuvidSetSymbolLoader(tLoadSymbol loader_func);
-
 bool cuvidInitChecked() {
-  static std::once_flag cuvid_once;
-  std::call_once(cuvid_once, NvcuvidSetSymbolLoader, LoadSymbol);
-
   static CUVIDDRIVER nvcuvidDrvLib = loadNvcuvidLibrary();
   return nvcuvidDrvLib != nullptr;
 }
@@ -67,7 +60,7 @@ bool cuvidIsSymbolAvailable(const char *name) {
   std::lock_guard<std::mutex> lock(symbol_mutex);
   auto it = symbol_map.find(name);
   if (it == symbol_map.end()) {
-    auto *ptr = LoadSymbol(name);
+    auto *ptr = NvcuvidLoadSymbol(name);
     symbol_map.insert({name, ptr});
     return ptr != nullptr;
   }

--- a/dali/util/cufile_helper.h
+++ b/dali/util/cufile_helper.h
@@ -37,8 +37,6 @@ class CUFileDriverHandle{
  public:
   explicit CUFileDriverHandle(const int& device = 0) {
     dali::DeviceGuard g(device);
-    // make sure library is opened
-    cufileInit();
     CUDA_CALL(cuFileDriverOpen());
   }
 

--- a/dali/util/std_cufile.cc
+++ b/dali/util/std_cufile.cc
@@ -77,9 +77,6 @@ static void cufile_open(cufile::CUFileHandle& fh, size_t& length, const char* pa
 namespace dali {
 
 StdCUFileStream::StdCUFileStream(const std::string& path) : CUFileStream(path) {
-  // make sure lib is loaded
-  cufileInit();
-
   // open file
   cufile_open(f_, length_, path.c_str());
 

--- a/include/dali/core/dynlink_cufile.h
+++ b/include/dali/core/dynlink_cufile.h
@@ -131,6 +131,4 @@ inline void cudaResultCheck<CUfileError_t>(CUfileError_t status) {
 
 }  // namespace dali
 
-void cufileInit();
-
 #endif  // DALI_CORE_DYNLINK_CUFILE_H_

--- a/tools/stub_generator/stub_codegen.py
+++ b/tools/stub_generator/stub_codegen.py
@@ -48,20 +48,18 @@ def main():
 
 {0} {{
   using FuncPtr = {return_type} (%s *)({2});
-  static auto func_ptr = reinterpret_cast<FuncPtr>(load_symbol_func("{1}")) ?
-                           reinterpret_cast<FuncPtr>(load_symbol_func("{1}")) :
+  static auto func_ptr = reinterpret_cast<FuncPtr>(LOAD_SYMBOL_FUNC("{1}")) ?
+                           reinterpret_cast<FuncPtr>(LOAD_SYMBOL_FUNC("{1}")) :
                            {1}NotFound;
   return func_ptr({3});
 }}\n""" % (config['calling_conv'], config['calling_conv'])
 
     prolog = """
-typedef void *tLoadSymbol(const char *name);
+void *{0}LoadSymbol(const char *name);
 
-static tLoadSymbol *load_symbol_func;
+#define LOAD_SYMBOL_FUNC {0}##LoadSymbol
 
-void {0}SetSymbolLoader(tLoadSymbol *loader_func) {{
-  load_symbol_func = loader_func;
-}}\n"""
+"""
 
     index = clang.cindex.Index.create()
     header = args.header


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a problem: requirement to call a specific function first in order to use the library.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Use a named, public function to load symbols
 - Affected modules and functionalities:
     * dynlink_cuda
     * dynlink_nvml
     * dynlink_cufile
     * dynlink_nvcuvid
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests apply
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
