### PR TITLE
Fix numpy reader header cache

### DIFF
--- a/dali/operators/reader/loader/numpy_loader.cc
+++ b/dali/operators/reader/loader/numpy_loader.cc
@@ -193,6 +193,7 @@ void ParseHeader(FileStream *file, NumpyParseTarget& target) {
   file->Seek(offset);  // prepare file for later reads
 
   ParseHeaderMetadata(target, header);
+  target.data_offset = offset;
 }
 
 bool NumpyHeaderCache::GetFromCache(const string &file_name, NumpyParseTarget &target) {

--- a/dali/test/python/test_operator_readers_numpy.py
+++ b/dali/test/python/test_operator_readers_numpy.py
@@ -108,7 +108,7 @@ def check_batch(test_data_root, batch_size, num_samples, device, arr_np_all, fil
                                    batch_size = batch_size,
                                    num_threads = num_threads,
                                    device_id = 0,
-                                   cache_header_information = False)
+                                   cache_header_information = cache_header_information)
         pipe.build()
 
         for batch in range(0, num_samples, batch_size):


### PR DESCRIPTION
- fix the header cache in numpy reader. Add missing store
  of the offset to the data in the numpy file
- reenables test for header cache for the numpy reader

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes numpy reader header cache
- 
#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     fix the header cache in numpy reader. Add missing store of the offset to the data in the numpy file
     reenables test for header cache for the numpy reader
 - Affected modules and functionalities:
     numpy reader
 - Key points relevant for the review:
     NA
 - Validation and testing:
     fixed test
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
