### PR TITLE
Add information about Open-CE effort that provides DALI

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -164,3 +164,16 @@ For older versions of DALI (0.22 and lower), use the package `nvidia-dali`. The 
 CUDA 9 build is provided up to DALI 0.22.0. CUDA 10 build is provided starting from DALI 0.8.0.
 CUDA 11 build is provided starting from DALI 0.22.0.
 
+An Open Cognitive Environment
+-----------------------------
+
+.. |oce link| replace:: **external organizations**
+.. _oce link: https://github.com/open-ce/open-ce#community-builds
+
+DALI is also available as a part of the Open Cognitive Environment - project that contains everything
+that is needed to build conda packages for a collection of machine learning and deep learning frameworks.
+
+This effort is community-driven and the DALI version available there may not be up to date.
+
+Prebuild packages (including DALI) are hosted by |oce link|_.
+


### PR DESCRIPTION
- Watson Machine Learning Community Edition was replaced by
  Open Cognitive Environment community-driven effort that
  provides DALI. It should be mentioned in the installation
  documentation as well.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds information about Open-CE effort that provides DALI

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Watson Machine Learning Community Edition was replaced by Open Cognitive Environment community-driven effort that provides DALI. It should be mentioned in the installation documentation as well.
 - Affected modules and functionalities:
     installation.rst
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     only documentation was update


**JIRA TASK**: *[NA]*
