### PR TITLE
Add missing opencv-python dependency to TL2_FW_iterators_perf test

### DIFF
--- a/qa/TL2_FW_iterators_perf/test_pytorch.sh
+++ b/qa/TL2_FW_iterators_perf/test_pytorch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="pillow torchvision torch"
+pip_packages="pillow torchvision torch opencv-python"
 target_dir=./dali/test/python
 one_config_only=true
 


### PR DESCRIPTION
- there is a missing opencv-python dependency in TL2_FW_iterators_perf/test_pytorch.sh
  test required by test_RN50_external_source_parallel_train_ddp.py

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a missing opencv-python dependency to TL2_FW_iterators_perf test
- 
#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     there is a missing opencv-python dependency in TL2_FW_iterators_perf/test_pytorch.sh test required by test_RN50_external_source_parallel_train_ddp.py
     it seems that after an update in used python packages the opencv-python package is no longer silently installed
 - Affected modules and functionalities:
     TL2_FW_iterators_perf/test_pytorch.sh
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI run
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
