### PR TITLE
Add portable FP16 type & tests.

### DIFF
--- a/dali/core/float16_test.cu
+++ b/dali/core/float16_test.cu
@@ -14,11 +14,50 @@
 
 #include <gtest/gtest.h>
 #include <vector>
+#include <cstring>
 #include "dali/core/float16.h"
 #include "dali/test/device_test.h"
 #include "dali/core/dev_buffer.h"
 
 namespace dali {
+
+TEST(FP16Host, Construction) {
+#ifndef __CUDA_ARCH__
+  float16 a = {};
+  EXPECT_EQ(a.impl, float16::impl_t());
+#endif
+  float16 b = 42;
+  EXPECT_EQ(static_cast<float>(b), 42.0f);
+  float16 c{-42L};
+  EXPECT_EQ(static_cast<float>(c), -42);
+  long long ll = 1234;  // NOLINT
+  float16 d(ll);
+  EXPECT_EQ(static_cast<float>(d), 1234);
+  float16 e = { -5.5f };
+  EXPECT_EQ(static_cast<float>(e), -5.5f);
+  float16 f = 2u;
+  EXPECT_EQ(static_cast<float>(f), 2.0f);
+  float16 g = f.impl;
+  EXPECT_EQ(0, std::memcmp(&g, &f, 2));
+}
+
+DEVICE_TEST(FP16Dev, Construction, 1, 1) {
+  float16 a = {};
+  DEV_EXPECT_EQ(static_cast<float>(a), 0.0f);
+  float16 b = 42;
+  DEV_EXPECT_EQ(static_cast<float>(b), 42.0f);
+  float16 c{-42L};
+  DEV_EXPECT_EQ(static_cast<float>(c), -42);
+  long long ll = 1234;  // NOLINT
+  float16 d(ll);
+  DEV_EXPECT_EQ(static_cast<float>(d), 1234);
+  float16 e = { -5.5f };
+  DEV_EXPECT_EQ(static_cast<float>(e), -5.5f);
+  float16 f = 2u;
+  DEV_EXPECT_EQ(static_cast<float>(f), 2.0f);
+  float16 g{f.impl};
+  DEV_EXPECT_EQ(static_cast<float>(g), 2.0f);
+}
 
 TEST(FP16Host, Conversions) {
   float16 a = {};
@@ -39,7 +78,6 @@ TEST(FP16Host, Conversions) {
 }
 
 DEVICE_TEST(FP16Dev, Conversions, 1, 1) {
-#ifdef __CUDA_ARCH__
   float16 a = {};
   DEV_EXPECT_EQ(static_cast<float>(a.impl), 0.0f);
   a = 42;
@@ -51,7 +89,6 @@ DEVICE_TEST(FP16Dev, Conversions, 1, 1) {
   DEV_EXPECT_EQ(static_cast<float>(a), -5.5f);
   a = 2u;
   DEV_EXPECT_EQ(static_cast<float>(a), 2.0f);
-#endif
 }
 
 TEST(FP16Host, Arithm) {

--- a/dali/core/float16_test.cu
+++ b/dali/core/float16_test.cu
@@ -1,0 +1,269 @@
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <vector>
+#include "dali/core/float16.h"
+#include "dali/test/device_test.h"
+#include "dali/core/dev_buffer.h"
+
+namespace dali {
+
+TEST(FP16Host, Conversions) {
+  float16 a = {};
+#ifndef __CUDA_ARCH__
+  EXPECT_EQ(a.impl, float16::impl_t());
+#endif
+  a = 42;
+  EXPECT_EQ(static_cast<float>(a), 42.0f);
+  a = -42L;
+  EXPECT_EQ(static_cast<float>(a), -42);
+  long long ll = 1234;  // NOLINT
+  a = ll;
+  EXPECT_EQ(static_cast<float>(a), 1234);
+  a = -5.5f;
+  EXPECT_EQ(static_cast<float>(a), -5.5f);
+  a = 2u;
+  EXPECT_EQ(static_cast<float>(a), 2.0f);
+}
+
+DEVICE_TEST(FP16Dev, Conversions, 1, 1) {
+#ifdef __CUDA_ARCH__
+  float16 a = {};
+  DEV_EXPECT_EQ(static_cast<float>(a.impl), 0.0f);
+  a = 42;
+  DEV_EXPECT_EQ(static_cast<float>(a), 42.0f);
+  long long ll = 1234;  // NOLINT
+  a = ll;
+  DEV_EXPECT_EQ(static_cast<float>(a), 1234);
+  a = -5.5f;
+  DEV_EXPECT_EQ(static_cast<float>(a), -5.5f);
+  a = 2u;
+  DEV_EXPECT_EQ(static_cast<float>(a), 2.0f);
+#endif
+}
+
+TEST(FP16Host, Arithm) {
+  float16 a = 5;
+  float16 b = 42;
+  float16 c = a + b;
+  EXPECT_EQ(static_cast<float>(c), 47);
+  c = a - b;
+  EXPECT_EQ(static_cast<float>(c), -37);
+  b = -b;
+  EXPECT_EQ(static_cast<float>(b), -42);
+  b = +b;
+  EXPECT_EQ(static_cast<float>(b), -42);
+  c = a * b;
+  EXPECT_EQ(static_cast<float>(c), -210);
+  a = 12;
+  b = 4;
+  c = a / b;
+  EXPECT_EQ(static_cast<float>(c), 3);
+}
+
+DEVICE_TEST(FP16Dev, Arithm, 1, 1) {
+  float16 a = 5;
+  float16 b = 42;
+  float16 c = a + b;
+  DEV_EXPECT_EQ(static_cast<float>(c), 47);
+  c = a - b;
+  DEV_EXPECT_EQ(static_cast<float>(c), -37);
+  b = -b;
+  DEV_EXPECT_EQ(static_cast<float>(b), -42);
+  b = +b;
+  DEV_EXPECT_EQ(static_cast<float>(b), -42);
+  c = a * b;
+  DEV_EXPECT_EQ(static_cast<float>(c), -210);
+  a = 12;
+  b = 4;
+  c = a / b;
+  DEV_EXPECT_EQ(static_cast<float>(c), 3);
+}
+
+
+TEST(FP16Host, Compound) {
+  float16 a = 5;
+  float16 b = 42;
+  a += b;
+  EXPECT_EQ(static_cast<float>(a), 47);
+  a = 5;
+  a -= b;
+  EXPECT_EQ(static_cast<float>(a), -37);
+  a = 5;
+  a *= b;
+  EXPECT_EQ(static_cast<float>(a), 210);
+  a = 12;
+  b = 4;
+  a /= b;
+  EXPECT_EQ(static_cast<float>(a), 3);
+
+  a = 5;
+  a += 42.0;
+  EXPECT_EQ(static_cast<float>(a), 47);
+  a = 5;
+  a -= 42.0f;
+  EXPECT_EQ(static_cast<float>(a), -37);
+  a = 5;
+  a *= 42u;
+  EXPECT_EQ(static_cast<float>(a), 210);
+  a = 12;
+  a /= '\4';
+  EXPECT_EQ(static_cast<float>(a), 3);
+}
+
+DEVICE_TEST(FP16Dev, Compound, 1, 1) {
+  float16 a = 5;
+  float16 b = 42;
+  a += b;
+  DEV_EXPECT_EQ(static_cast<float>(a), 47);
+  a = 5;
+  a -= b;
+  DEV_EXPECT_EQ(static_cast<float>(a), -37);
+  a = 5;
+  a *= b;
+  DEV_EXPECT_EQ(static_cast<float>(a), 210);
+  a = 12;
+  b = 4;
+  a /= b;
+  DEV_EXPECT_EQ(static_cast<float>(a), 3);
+
+  a = 5;
+  a += 42.0;
+  DEV_EXPECT_EQ(static_cast<float>(a), 47);
+  a = 5;
+  a -= 42.0f;
+  DEV_EXPECT_EQ(static_cast<float>(a), -37);
+  a = 5;
+  a *= 42u;
+  DEV_EXPECT_EQ(static_cast<float>(a), 210);
+  a = 12;
+  a /= '\4';
+  DEV_EXPECT_EQ(static_cast<float>(a), 3);
+}
+
+
+TEST(FP16Host, Comparison) {
+  auto test_cmp = [&](float16 x, auto y) {
+    EXPECT_EQ((x == y), (static_cast<float>(x) == static_cast<double>(y)));
+    EXPECT_EQ((y == x), (static_cast<float>(x) == static_cast<double>(y)));
+    EXPECT_EQ((x != y), (static_cast<float>(x) != static_cast<double>(y)));
+    EXPECT_EQ((y != x), (static_cast<float>(x) != static_cast<double>(y)));
+
+    EXPECT_EQ((x < y), (static_cast<float>(x) < static_cast<double>(y)));
+    EXPECT_EQ((y > x), (static_cast<float>(x) < static_cast<double>(y)));
+
+    EXPECT_EQ((x > y), (static_cast<float>(x) > static_cast<double>(y)));
+    EXPECT_EQ((y < x), (static_cast<float>(x) > static_cast<double>(y)));
+
+    EXPECT_EQ((x <= y), (static_cast<float>(x) <= static_cast<double>(y)));
+    EXPECT_EQ((y >= x), (static_cast<float>(x) <= static_cast<double>(y)));
+
+    EXPECT_EQ((x >= y), (static_cast<float>(x) >= static_cast<double>(y)));
+    EXPECT_EQ((y <= x), (static_cast<float>(x) >= static_cast<double>(y)));
+  };
+
+  float16 x = 42;
+  test_cmp(x, float16(-100));
+  test_cmp(x, float16(41));
+  test_cmp(x, float16(42));
+  test_cmp(x, float16(100));
+
+  test_cmp(x, -100);
+  test_cmp(x, 41u);
+  test_cmp(x, 41.0f);
+
+  test_cmp(x, 42.0f);
+  test_cmp(x, 42);
+  test_cmp(x, 42u);
+  test_cmp(x, 42.0);
+
+  test_cmp(x, 43.0f);
+  test_cmp(x, 430.0);
+  test_cmp(x, 100);
+  test_cmp(x, 100u);
+}
+
+
+DEVICE_TEST(FP16Dev, Comparison, 1, 1) {
+  auto test_cmp = [&](float16 x, auto y) {
+    DEV_EXPECT_EQ((x == y), (static_cast<float>(x) == static_cast<double>(y)));
+    DEV_EXPECT_EQ((y == x), (static_cast<float>(x) == static_cast<double>(y)));
+    DEV_EXPECT_EQ((x != y), (static_cast<float>(x) != static_cast<double>(y)));
+    DEV_EXPECT_EQ((y != x), (static_cast<float>(x) != static_cast<double>(y)));
+
+    DEV_EXPECT_EQ((x < y), (static_cast<float>(x) < static_cast<double>(y)));
+    DEV_EXPECT_EQ((y > x), (static_cast<float>(x) < static_cast<double>(y)));
+
+    DEV_EXPECT_EQ((x > y), (static_cast<float>(x) > static_cast<double>(y)));
+    DEV_EXPECT_EQ((y < x), (static_cast<float>(x) > static_cast<double>(y)));
+
+    DEV_EXPECT_EQ((x <= y), (static_cast<float>(x) <= static_cast<double>(y)));
+    DEV_EXPECT_EQ((y >= x), (static_cast<float>(x) <= static_cast<double>(y)));
+
+    DEV_EXPECT_EQ((x >= y), (static_cast<float>(x) >= static_cast<double>(y)));
+    DEV_EXPECT_EQ((y <= x), (static_cast<float>(x) >= static_cast<double>(y)));
+  };
+
+  float16 x = 42;
+  test_cmp(x, float16(-100));
+  test_cmp(x, float16(41));
+  test_cmp(x, float16(42));
+  test_cmp(x, float16(100));
+
+  test_cmp(x, -100);
+  test_cmp(x, 41u);
+  test_cmp(x, 41.0f);
+
+  test_cmp(x, 42.0f);
+  test_cmp(x, 42);
+  test_cmp(x, 42u);
+  test_cmp(x, 42.0);
+
+  test_cmp(x, 43.0f);
+  test_cmp(x, 430.0);
+  test_cmp(x, 100);
+  test_cmp(x, 100u);
+}
+
+template <typename T>
+struct TestStruct {
+  T *ptr;
+  int n;
+};
+
+template <typename T>
+__global__ void FP16TestKernel(TestStruct<T> ts) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (idx < ts.n)
+    ts.ptr[idx] = idx + float16(42);
+}
+
+TEST(FP16Linkage, KernelTemplate) {
+  DeviceBuffer<float16> buf;
+  buf.resize(10*64);
+  TestStruct<float16> ts;
+  ts.ptr = buf;
+  ts.n = buf.size();
+  CUDA_CALL(cudaMemset(buf, 0, buf.size_bytes()));
+  FP16TestKernel<<<div_ceil(ts.n, 64), 64>>>(ts);
+  vector<float16> host_buf(buf.size());
+  CUDA_CALL(cudaMemcpy(host_buf.data(), buf, buf.size_bytes(), cudaMemcpyDeviceToHost));
+  cudaDeviceSynchronize();
+  for (int i = 0; i < ts.n; i++) {
+    EXPECT_EQ(static_cast<float>(host_buf[i]), i + 42.0f);
+  }
+}
+
+}  // namespace dali

--- a/dali/core/float16_test.cu
+++ b/dali/core/float16_test.cu
@@ -37,8 +37,10 @@ TEST(FP16Host, Construction) {
   EXPECT_EQ(static_cast<float>(e), -5.5f);
   float16 f = 2u;
   EXPECT_EQ(static_cast<float>(f), 2.0f);
+#ifndef __CUDA_ARCH__
   float16 g = f.impl;
   EXPECT_EQ(0, std::memcmp(&g, &f, 2));
+#endif
 }
 
 DEVICE_TEST(FP16Dev, Construction, 1, 1) {
@@ -55,8 +57,10 @@ DEVICE_TEST(FP16Dev, Construction, 1, 1) {
   DEV_EXPECT_EQ(static_cast<float>(e), -5.5f);
   float16 f = 2u;
   DEV_EXPECT_EQ(static_cast<float>(f), 2.0f);
+#ifdef __CUDA_ARCH__
   float16 g{f.impl};
   DEV_EXPECT_EQ(static_cast<float>(g), 2.0f);
+#endif
 }
 
 TEST(FP16Host, Conversions) {

--- a/dali/core/float16_test.cu
+++ b/dali/core/float16_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/core/float16_test.cu
+++ b/dali/core/float16_test.cu
@@ -83,7 +83,9 @@ TEST(FP16Host, Conversions) {
 
 DEVICE_TEST(FP16Dev, Conversions, 1, 1) {
   float16 a = {};
+#ifdef __CUDA_ARCH__
   DEV_EXPECT_EQ(static_cast<float>(a.impl), 0.0f);
+#endif
   a = 42;
   DEV_EXPECT_EQ(static_cast<float>(a), 42.0f);
   long long ll = 1234;  // NOLINT

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -247,7 +247,7 @@ class SliceFlipNormalizePermutePadGpu {
           // need to handle __half due to compilation differences
           detail::SliceFlipNormalizePermutePadKernel
             <NeedPad, NeedFlip, NeedNormalize,
-            DALI_TO_GPU_T(OutputType), DALI_TO_GPU_T(InputType), Dims>
+            OutputType, InputType, Dims>
             <<<grid, kBlockDim, 0, context.gpu.stream>>>(sample_descs_gpu, block_descs_gpu);
         ), ());  // NOLINT
       ), ());  // NOLINT

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -324,10 +324,10 @@ class SliceGPU {
 
     const auto grid = block_count_;
     if (any_padded_sample)
-      detail::SliceKernel<DALI_TO_GPU_T(OutputType), DALI_TO_GPU_T(InputType), Dims, true>
+      detail::SliceKernel<OutputType, InputType, Dims, true>
         <<<grid, kBlockDim, 0, context.gpu.stream>>>(sample_descs, block_descs);
     else
-      detail::SliceKernel<DALI_TO_GPU_T(OutputType), DALI_TO_GPU_T(InputType), Dims, false>
+      detail::SliceKernel<OutputType, InputType, Dims, false>
         <<<grid, kBlockDim, 0, context.gpu.stream>>>(sample_descs, block_descs);
     CUDA_CALL(cudaGetLastError());
   }

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -28,6 +28,7 @@
 #include "dali/kernels/common/scatter_gather.h"
 #include "dali/core/common.h"
 #include "dali/core/spinlock.h"
+#include "dali/core/float16.h"
 #include "dali/core/cuda_utils.h"
 #include "dali/core/error_handling.h"
 #include "dali/core/tensor_layout.h"

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -70,30 +70,6 @@ struct needs_clamp {
     (from_unsigned && !to_unsigned && sizeof(To) <= sizeof(From));
 };
 
-// For whatever reason clang tries the templates instead the overloads, so we sfinae the
-// generic clamp out and let it use the explicit overloads for __half
-#if defined(__clang__) && defined(__CUDA__)
-template <typename To>
-struct needs_clamp<__half, To> {
-  static constexpr bool value = false;
-};
-
-template <typename From>
-struct needs_clamp<From, __half> {
-  static constexpr bool value = false;
-};
-
-template <typename T, typename U>
-using skip_clamp_template =
-    std::conditional_t<is_half<T>::value || is_half<U>::value, std::true_type, std::false_type>;
-
-#else
-
-template <typename T, typename U>
-using skip_clamp_template = std::false_type;
-
-#endif
-
 template <typename To>
 struct needs_clamp<bool, To> {
   static constexpr bool value = false;
@@ -146,9 +122,7 @@ clamp(U value, ret_type<T>) {
 }
 
 template <typename T, typename U>
-DALI_HOST_DEV constexpr std::enable_if_t<
-    !needs_clamp<U, T>::value && !skip_clamp_template<T, U>::value,
-    T>
+DALI_HOST_DEV constexpr std::enable_if_t<!needs_clamp<U, T>::value, T>
 clamp(U value, ret_type<T>) { return value; }
 
 DALI_HOST_DEV constexpr int32_t clamp(uint32_t value, ret_type<int32_t>) {
@@ -190,44 +164,6 @@ DALI_HOST_DEV constexpr bool clamp(T value, ret_type<bool>) {
 }
 
 
-#if defined(__clang__) && defined(__CUDA__)
-
-template <typename T>
-DALI_HOST constexpr T clamp(float16 value, ret_type<T>) {
-  return clamp(static_cast<float>(value), ret_type<T>());
-}
-
-DALI_HOST constexpr float16 clamp(float16 value, ret_type<float16>) {
-  return value;
-}
-
-template <typename T>
-DALI_DEVICE constexpr T clamp(__half value, ret_type<T>) {
-  return clamp(static_cast<float>(value), ret_type<T>());
-}
-
-DALI_DEVICE constexpr __half clamp(__half value, ret_type<__half>) {
-  return value;
-}
-
-template <typename T>
-DALI_HOST constexpr float16 clamp(T value, ret_type<float16>) {
-  constexpr float f16_min = -65504.0f, f16_max = 65504.0f;
-  float f = clamp(value, ret_type<float>());
-  f = f < f16_min ? f16_min : f > f16_max ? f16_max : f;
-  return static_cast<float16>(f);
-}
-
-template <typename T>
-DALI_DEVICE constexpr __half clamp(T value, ret_type<__half>) {
-  constexpr float f16_min = -65504.0f, f16_max = 65504.0f;
-  float f = clamp(value, ret_type<float>());
-  f = f < f16_min ? f16_min : f > f16_max ? f16_max : f;
-  return static_cast<__half>(f);
-}
-
-#else
-
 template <typename T>
 DALI_HOST_DEV constexpr T clamp(float16 value, ret_type<T>) {
   return clamp(static_cast<float>(value), ret_type<T>());
@@ -237,7 +173,6 @@ DALI_HOST_DEV constexpr float16 clamp(float16 value, ret_type<float16>) {
   return value;
 }
 
-
 template <typename T>
 DALI_HOST_DEV constexpr float16 clamp(T value, ret_type<float16>) {
   constexpr float f16_min = -65504.0f, f16_max = 65504.0f;
@@ -245,8 +180,6 @@ DALI_HOST_DEV constexpr float16 clamp(T value, ret_type<float16>) {
   f = f < f16_min ? f16_min : f > f16_max ? f16_max : f;
   return static_cast<float16>(f);
 }
-
-#endif
 
 template <typename T, typename U>
 DALI_HOST_DEV constexpr T clamp(U value) {

--- a/include/dali/core/cuda_utils.h
+++ b/include/dali/core/cuda_utils.h
@@ -18,7 +18,6 @@
 #include <cuda_runtime_api.h>  // for __align__ & CUDART_VERSION
 #include <cassert>
 #include <type_traits>
-#include "dali/core/float16.h"
 #include "dali/core/host_dev.h"
 #include "dali/core/dynlink_cuda.h"
 #include "dali/core/cuda_error.h"

--- a/include/dali/core/float16.h
+++ b/include/dali/core/float16.h
@@ -17,31 +17,315 @@
 
 #include <cuda_fp16.h>  // for __half & related methods
 #include <type_traits>
+#include "dali/core/host_dev.h"
+#include "dali/core/force_inline.h"
 #ifndef __CUDA_ARCH__
 #include "dali/util/half.hpp"
 #endif
 
 namespace dali {
 
-// For the GPU
+struct float16 {
+  DALI_HOST_DEV
+  float16() = default;
+  float16(const float16 &) = default;
+
 #ifdef __CUDA_ARCH__
-using float16 = __half;
-#else
-using float16 = half_float::half;
+  __device__ float16(__half x)          : impl(x) {}  // NOLINT
+  __device__ float16(float x)           : impl(x) {}  // NOLINT
+  __device__ float16(double x)          : impl(x) {}  // NOLINT
+  __device__ float16(signed char x)     : impl(x) {}  // NOLINT
+  __device__ float16(unsigned char x)   : impl(x) {}  // NOLINT
+  __device__ float16(short x)           : impl(x) {}  // NOLINT
+  __device__ float16(unsigned short x)  : impl(x) {}  // NOLINT
+  __device__ float16(int x)             : impl(x) {}  // NOLINT
+  __device__ float16(unsigned int x)    : impl(x) {}  // NOLINT
+  __device__ float16(long x)            : impl(static_cast<long long>(x)) {}  // NOLINT
+  __device__ float16(unsigned long x)   : impl(static_cast<unsigned long long>(x)) {}  // NOLINT
+  __device__ float16(long long x)           : impl(x) {}  // NOLINT
+  __device__ float16(unsigned long long x)  : impl(x) {}  // NOLINT
 #endif
+#ifndef __CUDA_ARCH__
+  __host__ float16(half_float::half x) : impl(x) {}  // NOLINT
+  __host__ float16(float x)           : impl(x) {}  // NOLINT
+  __host__ float16(double x)          : impl(x) {}  // NOLINT
+  __host__ float16(signed char x)     : impl(x) {}  // NOLINT
+  __host__ float16(unsigned char x)   : impl(x) {}  // NOLINT
+  __host__ float16(short x)           : impl(x) {}  // NOLINT
+  __host__ float16(unsigned short x)  : impl(x) {}  // NOLINT
+  __host__ float16(int x)             : impl(x) {}  // NOLINT
+  __host__ float16(unsigned int x)    : impl(x) {}  // NOLINT
+  __host__ float16(long x)            : impl(static_cast<int64_t>(x)) {}  // NOLINT
+  __host__ float16(unsigned long x)   : impl(static_cast<uint64_t>(x)) {}  // NOLINT
+  __host__ float16(long long x)          : impl(static_cast<int64_t>(x)) {}  // NOLINT
+  __host__ float16(unsigned long long x) : impl(static_cast<uint64_t>(x)) {}  // NOLINT
+#endif
+
+
+#ifdef __CUDA_ARCH__
+  using impl_t = __half;
+#else
+  using impl_t = half_float::half;
+#endif
+
+  impl_t impl;
+
+  DALI_HOST_DEV DALI_FORCEINLINE
+  constexpr operator impl_t() const noexcept { return impl; }
+
+#ifdef __CUDA_ARCH__
+  DALI_FORCEINLINE
+  __device__ operator float() const noexcept { return impl; }
+#else
+  DALI_FORCEINLINE
+  __host__ operator float() const noexcept { return impl; }
+#endif
+
+  DALI_FORCEINLINE DALI_HOST_DEV float16 operator-() const noexcept {
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ >= 530
+    return __hneg(impl);
+#else
+  return float16(-static_cast<float>(impl));
+#endif
+#else
+    return float16(-impl);
+#endif
+  }
+
+  DALI_FORCEINLINE DALI_HOST_DEV float16 operator+() const noexcept {
+    return *this;
+  }
+
+  DALI_FORCEINLINE DALI_HOST_DEV float16 &operator++() noexcept;
+  DALI_FORCEINLINE DALI_HOST_DEV float16 operator++(int) noexcept;
+
+#define DALI_HALF_DECLARE_COMPOUND_ASSIGNMENT(op) \
+  DALI_FORCEINLINE DALI_HOST_DEV float16 &operator op(float16 other) noexcept; \
+  DALI_FORCEINLINE DALI_HOST_DEV float16 &operator op(float other) noexcept; \
+  DALI_FORCEINLINE DALI_HOST_DEV float16 &operator op(double other) noexcept; \
+  template <typename T> \
+  DALI_FORCEINLINE DALI_HOST_DEV \
+  std::enable_if_t<std::is_integral<T>::value, float16 &> \
+  operator op(T other) noexcept { \
+    return *this op float16(other); \
+  }
+
+  DALI_HALF_DECLARE_COMPOUND_ASSIGNMENT(+=)
+  DALI_HALF_DECLARE_COMPOUND_ASSIGNMENT(-=)
+  DALI_HALF_DECLARE_COMPOUND_ASSIGNMENT(*=)
+  DALI_HALF_DECLARE_COMPOUND_ASSIGNMENT(/=)
+};
+
+DALI_HOST_DEV DALI_FORCEINLINE
+float16 operator +(float16 a, float16 b) noexcept {
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ >= 530
+  return float16(__hadd(a.impl, b.impl));
+#else
+  return float16(static_cast<float>(a.impl) + static_cast<float>(b.impl));
+#endif
+#else
+  return float16(float16::impl_t(a.impl + b.impl));
+#endif
+}
+
+DALI_HOST_DEV DALI_FORCEINLINE
+float16 operator -(float16 a, float16 b) noexcept {
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ >= 530
+  return float16(__hsub(a.impl, b.impl));
+#else
+  return float16(static_cast<float>(a.impl) - static_cast<float>(b.impl));
+  return {};
+#endif
+#else
+  return float16(float16::impl_t(a.impl - b.impl));
+#endif
+}
+
+DALI_HOST_DEV DALI_FORCEINLINE
+float16 operator *(float16 a, float16 b) noexcept {
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ >= 530
+  return float16(__hmul(a.impl, b.impl));
+#else
+  return float16(static_cast<float>(a.impl) * static_cast<float>(b.impl));
+#endif
+#else
+  return float16(float16::impl_t(a.impl * b.impl));
+#endif
+}
+
+DALI_HOST_DEV DALI_FORCEINLINE
+float16 operator /(float16 a, float16 b) noexcept {
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ >= 530
+  return float16(__hdiv(a.impl, b.impl));
+#else
+  return float16(static_cast<float>(a.impl) / static_cast<float>(b.impl));
+#endif
+#else
+  return float16(float16::impl_t(a.impl / b.impl));
+#endif
+}
+
+DALI_HOST_DEV DALI_FORCEINLINE
+bool operator ==(float16 a, float16 b) noexcept {
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ >= 530
+  return __heq(a.impl, b.impl);
+#else
+  return static_cast<float>(a.impl) == static_cast<float>(b.impl);
+#endif
+#else
+  return a.impl == b.impl;
+#endif
+}
+
+DALI_HOST_DEV DALI_FORCEINLINE
+bool operator !=(float16 a, float16 b) noexcept {
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ >= 530
+  return __hne(a.impl, b.impl);
+#else
+  return static_cast<float>(a.impl) != static_cast<float>(b.impl);
+#endif
+#else
+  return a.impl != b.impl;
+#endif
+}
+
+DALI_HOST_DEV DALI_FORCEINLINE
+bool operator <(float16 a, float16 b) noexcept {
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ >= 530
+  return __hlt(a.impl, b.impl);
+#else
+  return static_cast<float>(a.impl) < static_cast<float>(b.impl);
+#endif
+#else
+  return a.impl < b.impl;
+#endif
+}
+
+DALI_HOST_DEV DALI_FORCEINLINE
+bool operator <=(float16 a, float16 b) noexcept {
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ >= 530
+  return __hle(a.impl, b.impl);
+#else
+  return static_cast<float>(a.impl) <= static_cast<float>(b.impl);
+#endif
+#else
+  return a.impl <= b.impl;
+#endif
+}
+
+DALI_HOST_DEV DALI_FORCEINLINE
+bool operator >(float16 a, float16 b) noexcept {
+  return b < a;
+}
+
+DALI_HOST_DEV DALI_FORCEINLINE
+bool operator >=(float16 a, float16 b) noexcept {
+  return b <= a;
+}
+
+#define DALI_IMPL_HALF_FLOAT_OP(op) \
+DALI_HOST_DEV DALI_FORCEINLINE \
+auto operator op(float a, float16 b) noexcept { \
+  return a op static_cast<float>(b); \
+} \
+DALI_HOST_DEV DALI_FORCEINLINE \
+auto operator op(float16 a, float b) noexcept { \
+  return static_cast<float>(a) op b; \
+}
+
+DALI_IMPL_HALF_FLOAT_OP(+)
+DALI_IMPL_HALF_FLOAT_OP(-)
+DALI_IMPL_HALF_FLOAT_OP(*)
+DALI_IMPL_HALF_FLOAT_OP(/)
+
+#define DALI_IMPL_HALF_CMP_OP(op) \
+template <typename FP16, typename T> \
+DALI_HOST_DEV DALI_FORCEINLINE \
+std::enable_if_t<std::is_same<FP16, float16>::value, bool> \
+operator op(T a, const FP16 &b) noexcept { \
+  return a op static_cast<float>(b); \
+} \
+template <typename FP16, typename T> \
+DALI_HOST_DEV DALI_FORCEINLINE \
+std::enable_if_t<std::is_same<FP16, float16>::value, bool> \
+operator op(const FP16 &a, T b) noexcept { \
+  return static_cast<float>(a) op b; \
+}
+
+DALI_IMPL_HALF_CMP_OP(==)
+DALI_IMPL_HALF_CMP_OP(!=)
+DALI_IMPL_HALF_CMP_OP(<)  // NOLINT
+DALI_IMPL_HALF_CMP_OP(>)  // NOLINT
+DALI_IMPL_HALF_CMP_OP(<=) // NOLINT
+DALI_IMPL_HALF_CMP_OP(>=) // NOLINT
+
+
+
+DALI_HOST_DEV DALI_FORCEINLINE
+float16 fma(float16 a, float16 b, float16 c) noexcept {
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ >= 530
+  return __hfma(a.impl, b.impl, c.impl);
+#else
+  return float16(fmaf(static_cast<float>(a.impl),
+                      static_cast<float>(b.impl),
+                      static_cast<float>(c.impl)));
+#endif
+#else
+  return static_cast<float>(a) * static_cast<float>(b) + static_cast<float>(c);
+#endif
+}
+
+DALI_FORCEINLINE DALI_HOST_DEV float16 &float16::operator++() noexcept {
+  *this += float16(1);
+  return *this;
+}
+
+DALI_FORCEINLINE DALI_HOST_DEV float16 float16::operator++(int) noexcept {  // NOLINT misfired cast warning
+  auto old = *this;
+  *this += float16(1);
+  return old;
+}
+
+#define DALI_HALF_FLOAT_COMPOUND_OP(op) \
+DALI_FORCEINLINE DALI_HOST_DEV float16 &float16::operator op##=(float16 other) noexcept { \
+  return *this = *this op other; \
+} \
+DALI_FORCEINLINE DALI_HOST_DEV float16 &float16::operator op##=(float other) noexcept { \
+  return *this = static_cast<float>(impl) op other; \
+} \
+DALI_FORCEINLINE DALI_HOST_DEV float16 &float16::operator op##=(double other) noexcept { \
+  return *this = static_cast<float>(impl) op other; \
+}
+
+DALI_HALF_FLOAT_COMPOUND_OP(+)
+DALI_HALF_FLOAT_COMPOUND_OP(-)
+DALI_HALF_FLOAT_COMPOUND_OP(*)
+DALI_HALF_FLOAT_COMPOUND_OP(/)
 
 namespace detail {
 
 template <typename T>
 struct is_half : std::false_type {};
 
-// TODO(klecki): this should be defined per internal type, not for the magic typedef
 template <>
 struct is_half<float16> : std::true_type {};
 
-#ifndef __CUDA_ARCH__
+#ifdef __CUDA_ARCH__
 template <>
 struct is_half<__half> : std::true_type {};
+#else
+template <>
+struct is_half<half_float::half> : std::true_type {};
 #endif
 
 }  // namespace detail
@@ -60,22 +344,6 @@ struct is_fp_or_half {
   static constexpr bool value =
     std::is_floating_point<T>::value || is_half<T>::value;
 };
-
-// If not clang, just let everyone deal with the alias
-#if defined(__clang__) && defined(__CUDA__)
-template <typename T>
-using to_gpu_t = std::conditional_t<is_half<T>::value, __half, T>;
-
-#define DALI_TO_GPU_T(T) to_gpu_t<T>
-
-#else
-
-template <typename T>
-using to_gpu_t = T;
-
-#define DALI_TO_GPU_T(T) T
-
-#endif
 
 }  // namespace dali
 

--- a/include/dali/core/float16.h
+++ b/include/dali/core/float16.h
@@ -330,13 +330,15 @@ dali::float16 fma(dali::float16 a, dali::float16 b, dali::float16 c) noexcept {
 #endif
 }
 
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 350  // this is for clang-only build
 inline __device__ dali::float16 __ldg(const dali::float16 *mem) {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 350
   return dali::float16(__ldg(reinterpret_cast<const __half *>(mem)));
 #else
   assert(!"Unreachable code!");
   return {};
 #endif
 }
+#endif
 
 #endif  // DALI_CORE_FLOAT16_H_

--- a/include/dali/core/float16.h
+++ b/include/dali/core/float16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/dali/core/float16.h
+++ b/include/dali/core/float16.h
@@ -26,41 +26,33 @@
 namespace dali {
 
 struct float16 {
-  DALI_HOST_DEV
   float16() = default;
   float16(const float16 &) = default;
 
 #ifdef __CUDA_ARCH__
   __device__ float16(__half x)          : impl(x) {}  // NOLINT
-  __device__ float16(float x)           : impl(x) {}  // NOLINT
-  __device__ float16(double x)          : impl(x) {}  // NOLINT
-  __device__ float16(signed char x)     : impl(x) {}  // NOLINT
-  __device__ float16(unsigned char x)   : impl(x) {}  // NOLINT
-  __device__ float16(short x)           : impl(x) {}  // NOLINT
-  __device__ float16(unsigned short x)  : impl(x) {}  // NOLINT
-  __device__ float16(int x)             : impl(x) {}  // NOLINT
-  __device__ float16(unsigned int x)    : impl(x) {}  // NOLINT
-  __device__ float16(long x)            : impl(static_cast<long long>(x)) {}  // NOLINT
-  __device__ float16(unsigned long x)   : impl(static_cast<unsigned long long>(x)) {}  // NOLINT
-  __device__ float16(long long x)           : impl(x) {}  // NOLINT
-  __device__ float16(unsigned long long x)  : impl(x) {}  // NOLINT
+#else
+  __host__ float16(half_float::half x)  : impl(x) {}  // NOLINT
 #endif
-#ifndef __CUDA_ARCH__
-  __host__ float16(half_float::half x) : impl(x) {}  // NOLINT
-  __host__ float16(float x)           : impl(x) {}  // NOLINT
-  __host__ float16(double x)          : impl(x) {}  // NOLINT
-  __host__ float16(signed char x)     : impl(x) {}  // NOLINT
-  __host__ float16(unsigned char x)   : impl(x) {}  // NOLINT
-  __host__ float16(short x)           : impl(x) {}  // NOLINT
-  __host__ float16(unsigned short x)  : impl(x) {}  // NOLINT
-  __host__ float16(int x)             : impl(x) {}  // NOLINT
-  __host__ float16(unsigned int x)    : impl(x) {}  // NOLINT
-  __host__ float16(long x)            : impl(static_cast<int64_t>(x)) {}  // NOLINT
-  __host__ float16(unsigned long x)   : impl(static_cast<uint64_t>(x)) {}  // NOLINT
-  __host__ float16(long long x)          : impl(static_cast<int64_t>(x)) {}  // NOLINT
-  __host__ float16(unsigned long long x) : impl(static_cast<uint64_t>(x)) {}  // NOLINT
+  DALI_HOST_DEV float16(float x)           : impl(x) {}  // NOLINT
+  DALI_HOST_DEV float16(double x)          : impl(x) {}  // NOLINT
+  DALI_HOST_DEV float16(signed char x)     : impl(x) {}  // NOLINT
+  DALI_HOST_DEV float16(unsigned char x)   : impl(x) {}  // NOLINT
+  DALI_HOST_DEV float16(short x)           : impl(x) {}  // NOLINT
+  DALI_HOST_DEV float16(unsigned short x)  : impl(x) {}  // NOLINT
+  DALI_HOST_DEV float16(int x)             : impl(x) {}  // NOLINT
+  DALI_HOST_DEV float16(unsigned int x)    : impl(x) {}  // NOLINT
+#ifdef __CUDA_ARCH__
+  DALI_HOST_DEV float16(long x)            : impl(static_cast<long long>(x)) {}  // NOLINT
+  DALI_HOST_DEV float16(unsigned long x)   : impl(static_cast<unsigned long long>(x)) {}  // NOLINT
+  DALI_HOST_DEV float16(long long x)           : impl(x) {}  // NOLINT
+  DALI_HOST_DEV float16(unsigned long long x)  : impl(x) {}  // NOLINT
+#else
+  DALI_HOST_DEV float16(long x)            : impl(static_cast<int64_t>(x)) {}  // NOLINT
+  DALI_HOST_DEV float16(unsigned long x)   : impl(static_cast<uint64_t>(x)) {}  // NOLINT
+  DALI_HOST_DEV float16(long long x)          : impl(static_cast<int64_t>(x)) {}  // NOLINT
+  DALI_HOST_DEV float16(unsigned long long x) : impl(static_cast<uint64_t>(x)) {}  // NOLINT
 #endif
-
 
 #ifdef __CUDA_ARCH__
   using impl_t = __half;
@@ -73,13 +65,7 @@ struct float16 {
   DALI_HOST_DEV DALI_FORCEINLINE
   constexpr operator impl_t() const noexcept { return impl; }
 
-#ifdef __CUDA_ARCH__
-  DALI_FORCEINLINE
-  __device__ operator float() const noexcept { return impl; }
-#else
-  DALI_FORCEINLINE
-  __host__ operator float() const noexcept { return impl; }
-#endif
+  DALI_FORCEINLINE DALI_HOST_DEV operator float() const noexcept { return impl; }
 
   DALI_FORCEINLINE DALI_HOST_DEV float16 operator-() const noexcept {
 #ifdef __CUDA_ARCH__
@@ -100,15 +86,14 @@ struct float16 {
   DALI_FORCEINLINE DALI_HOST_DEV float16 &operator++() noexcept;
   DALI_FORCEINLINE DALI_HOST_DEV float16 operator++(int) noexcept;
 
-#define DALI_HALF_DECLARE_COMPOUND_ASSIGNMENT(op) \
-  DALI_FORCEINLINE DALI_HOST_DEV float16 &operator op(float16 other) noexcept; \
-  DALI_FORCEINLINE DALI_HOST_DEV float16 &operator op(float other) noexcept; \
-  DALI_FORCEINLINE DALI_HOST_DEV float16 &operator op(double other) noexcept; \
-  template <typename T> \
-  DALI_FORCEINLINE DALI_HOST_DEV \
-  std::enable_if_t<std::is_integral<T>::value, float16 &> \
-  operator op(T other) noexcept { \
-    return *this op float16(other); \
+#define DALI_HALF_DECLARE_COMPOUND_ASSIGNMENT(op)                                        \
+  DALI_FORCEINLINE DALI_HOST_DEV float16 &operator op(float16 other) noexcept;           \
+  DALI_FORCEINLINE DALI_HOST_DEV float16 &operator op(float other) noexcept;             \
+  DALI_FORCEINLINE DALI_HOST_DEV float16 &operator op(double other) noexcept;            \
+  template <typename T>                                                                  \
+  DALI_FORCEINLINE DALI_HOST_DEV std::enable_if_t<std::is_integral<T>::value, float16 &> \
+  operator op(T other) noexcept {                                                        \
+    return *this op float16(other);                                                      \
   }
 
   DALI_HALF_DECLARE_COMPOUND_ASSIGNMENT(+=)
@@ -137,7 +122,6 @@ float16 operator -(float16 a, float16 b) noexcept {
   return float16(__hsub(a.impl, b.impl));
 #else
   return float16(static_cast<float>(a.impl) - static_cast<float>(b.impl));
-  return {};
 #endif
 #else
   return float16(float16::impl_t(a.impl - b.impl));
@@ -232,34 +216,34 @@ bool operator >=(float16 a, float16 b) noexcept {
   return b <= a;
 }
 
-#define DALI_IMPL_HALF_FLOAT_OP(op) \
-DALI_HOST_DEV DALI_FORCEINLINE \
-auto operator op(float a, float16 b) noexcept { \
-  return a op static_cast<float>(b); \
-} \
-DALI_HOST_DEV DALI_FORCEINLINE \
-auto operator op(float16 a, float b) noexcept { \
-  return static_cast<float>(a) op b; \
-}
+#define DALI_IMPL_HALF_FLOAT_OP(op)                                              \
+  template <typename FP16, typename T,                                           \
+            typename = std::enable_if_t<std::is_same<FP16, float16>::value>>     \
+  DALI_HOST_DEV DALI_FORCEINLINE auto operator op(T a, const FP16 &b) noexcept { \
+    return a op static_cast<float>(b);                                           \
+  }                                                                              \
+  template <typename FP16, typename T,                                           \
+            typename = std::enable_if_t<std::is_same<FP16, float16>::value>>     \
+  DALI_HOST_DEV DALI_FORCEINLINE auto operator op(const FP16 &a, T b) noexcept { \
+    return static_cast<float>(a) op b;                                           \
+  }
 
 DALI_IMPL_HALF_FLOAT_OP(+)
 DALI_IMPL_HALF_FLOAT_OP(-)
 DALI_IMPL_HALF_FLOAT_OP(*)
 DALI_IMPL_HALF_FLOAT_OP(/)
 
-#define DALI_IMPL_HALF_CMP_OP(op) \
-template <typename FP16, typename T> \
-DALI_HOST_DEV DALI_FORCEINLINE \
-std::enable_if_t<std::is_same<FP16, float16>::value, bool> \
-operator op(T a, const FP16 &b) noexcept { \
-  return a op static_cast<float>(b); \
-} \
-template <typename FP16, typename T> \
-DALI_HOST_DEV DALI_FORCEINLINE \
-std::enable_if_t<std::is_same<FP16, float16>::value, bool> \
-operator op(const FP16 &a, T b) noexcept { \
-  return static_cast<float>(a) op b; \
-}
+#define DALI_IMPL_HALF_CMP_OP(op)                                                           \
+  template <typename FP16, typename T>                                                      \
+  DALI_HOST_DEV DALI_FORCEINLINE std::enable_if_t<std::is_same<FP16, float16>::value, bool> \
+  operator op(T a, const FP16 &b) noexcept {                                                \
+    return a op static_cast<float>(b);                                                      \
+  }                                                                                         \
+  template <typename FP16, typename T>                                                      \
+  DALI_HOST_DEV DALI_FORCEINLINE std::enable_if_t<std::is_same<FP16, float16>::value, bool> \
+  operator op(const FP16 &a, T b) noexcept {                                                \
+    return static_cast<float>(a) op b;                                                      \
+  }
 
 DALI_IMPL_HALF_CMP_OP(==)
 DALI_IMPL_HALF_CMP_OP(!=)
@@ -294,16 +278,16 @@ DALI_FORCEINLINE DALI_HOST_DEV float16 float16::operator++(int) noexcept {  // N
   return old;
 }
 
-#define DALI_HALF_FLOAT_COMPOUND_OP(op) \
-DALI_FORCEINLINE DALI_HOST_DEV float16 &float16::operator op##=(float16 other) noexcept { \
-  return *this = *this op other; \
-} \
-DALI_FORCEINLINE DALI_HOST_DEV float16 &float16::operator op##=(float other) noexcept { \
-  return *this = static_cast<float>(impl) op other; \
-} \
-DALI_FORCEINLINE DALI_HOST_DEV float16 &float16::operator op##=(double other) noexcept { \
-  return *this = static_cast<float>(impl) op other; \
-}
+#define DALI_HALF_FLOAT_COMPOUND_OP(op)                                                     \
+  DALI_FORCEINLINE DALI_HOST_DEV float16 &float16::operator op##=(float16 other) noexcept { \
+    return *this = *this op other;                                                          \
+  }                                                                                         \
+  DALI_FORCEINLINE DALI_HOST_DEV float16 &float16::operator op##=(float other) noexcept {   \
+    return *this = static_cast<float>(impl) op other;                                       \
+  }                                                                                         \
+  DALI_FORCEINLINE DALI_HOST_DEV float16 &float16::operator op##=(double other) noexcept {  \
+    return *this = static_cast<float>(impl) op other;                                       \
+  }
 
 DALI_HALF_FLOAT_COMPOUND_OP(+)
 DALI_HALF_FLOAT_COMPOUND_OP(-)

--- a/include/dali/core/float16.h
+++ b/include/dali/core/float16.h
@@ -16,6 +16,7 @@
 #define DALI_CORE_FLOAT16_H_
 
 #include <cuda_fp16.h>  // for __half & related methods
+#include <cassert>
 #include <type_traits>
 #include "dali/core/host_dev.h"
 #include "dali/core/force_inline.h"
@@ -329,10 +330,13 @@ struct is_fp_or_half {
 
 }  // namespace dali
 
-#ifdef __CUDA_ARCH__
 inline __device__ dali::float16 __ldg(const dali::float16 *mem) {
+#ifdef __CUDA_ARCH__
   return dali::float16(__ldg(reinterpret_cast<const __half *>(mem)));
-}
+#else
+  assert(!"Unreachable code!");
+  return {};
 #endif
+}
 
 #endif  // DALI_CORE_FLOAT16_H_

--- a/include/dali/core/float16.h
+++ b/include/dali/core/float16.h
@@ -253,21 +253,6 @@ DALI_IMPL_HALF_CMP_OP(>)  // NOLINT
 DALI_IMPL_HALF_CMP_OP(<=) // NOLINT
 DALI_IMPL_HALF_CMP_OP(>=) // NOLINT
 
-DALI_HOST_DEV DALI_FORCEINLINE
-float16 fma(float16 a, float16 b, float16 c) noexcept {
-#ifdef __CUDA_ARCH__
-#if __CUDA_ARCH__ >= 530
-  return __hfma(a.impl, b.impl, c.impl);
-#else
-  return float16(fmaf(static_cast<float>(a.impl),
-                      static_cast<float>(b.impl),
-                      static_cast<float>(c.impl)));
-#endif
-#else
-  return static_cast<float>(a) * static_cast<float>(b) + static_cast<float>(c);
-#endif
-}
-
 DALI_FORCEINLINE DALI_HOST_DEV float16 &float16::operator++() noexcept {
   *this += float16(1);
   return *this;
@@ -329,6 +314,21 @@ struct is_fp_or_half {
 };
 
 }  // namespace dali
+
+DALI_HOST_DEV DALI_FORCEINLINE
+dali::float16 fma(dali::float16 a, dali::float16 b, dali::float16 c) noexcept {
+#ifdef __CUDA_ARCH__
+#if __CUDA_ARCH__ >= 530
+  return __hfma(a.impl, b.impl, c.impl);
+#else
+  return dali::float16(fmaf(static_cast<float>(a.impl),
+                            static_cast<float>(b.impl),
+                            static_cast<float>(c.impl)));
+#endif
+#else
+  return static_cast<float>(a) * static_cast<float>(b) + static_cast<float>(c);
+#endif
+}
 
 inline __device__ dali::float16 __ldg(const dali::float16 *mem) {
 #ifdef __CUDA_ARCH__

--- a/include/dali/core/float16.h
+++ b/include/dali/core/float16.h
@@ -26,6 +26,34 @@
 
 namespace dali {
 
+/**
+ * @brief Half-precision type usable in host and device code
+ *
+ * This type implements half-precision arithmetic and is usable both
+ * in host and device code. It features implicit conversion from fundamental
+ * arithmetic types and implicit conversion to the underlying implementation
+ * (`__half` or `half_float::half`) and `float`.
+ *
+ * `float16` provides overloads of arithmetic operators with host and device
+ * implementation - the latter is implemented with half-precision intrinsics
+ * for devices with compute capability 5.3 and is effectively done in float
+ * for older devices.
+ *
+ * The type promotion rules for binary operators are:
+ * - float16 op float -> float
+ * - float16 op double -> double
+ * - float16 op (u)intX -> float16
+ *
+ * The calculations with integer arguments are implemented as:
+ * ```
+ *    float16 operator op(float16 a, intX b) { return a op float16(b); }
+ * ```
+ * This may lead to loss of precision or overflow to infinity. Please be careful
+ * when using mixed float16/integer arithmetic.
+ *
+ * `float16` constants can be defined with _hf suffix, for example:
+ * 1.234_hf, 42_hf
+ */
 struct float16 {
   float16() = default;
   float16(const float16 &) = default;

--- a/include/dali/core/float16.h
+++ b/include/dali/core/float16.h
@@ -268,8 +268,6 @@ DALI_IMPL_HALF_CMP_OP(>)  // NOLINT
 DALI_IMPL_HALF_CMP_OP(<=) // NOLINT
 DALI_IMPL_HALF_CMP_OP(>=) // NOLINT
 
-
-
 DALI_HOST_DEV DALI_FORCEINLINE
 float16 fma(float16 a, float16 b, float16 c) noexcept {
 #ifdef __CUDA_ARCH__
@@ -346,5 +344,11 @@ struct is_fp_or_half {
 };
 
 }  // namespace dali
+
+#ifdef __CUDA_ARCH__
+inline __device__ dali::float16 __ldg(const dali::float16 *mem) {
+  return dali::float16(__ldg(reinterpret_cast<const __half *>(mem)));
+}
+#endif
 
 #endif  // DALI_CORE_FLOAT16_H_


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to improve FP16 support

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added a new type, float16 which is not a typedef, but a structure.
     * The actual implementation is used underneath
     * Added arithmetic, compound assignment and comparison operators
     * Added implicit cast to underlying implementation and to `float`.
     * Removed clang-only magic from convert.h
     * Remove `#include "float16.h"` from `cuda_utils.h`
 - Affected modules and functionalities:
     * Everything that uses float16
 - Key points relevant for the review:
     * What can possibly go wrong?
 - Validation and testing:
     * GTest
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-2024
