### PR TITLE
Fix bug in default constructed curand_uniform_dist

### DIFF
--- a/dali/operators/util/randomizer.cuh
+++ b/dali/operators/util/randomizer.cuh
@@ -69,8 +69,7 @@ struct curand_uniform_dist {
   static_assert(std::is_same<T, float>::value || std::is_same<T, double>::value,
     "Unexpected data type");
 
-  DALI_HOST_DEV curand_uniform_dist()
-      : range_start_(0), range_end_(1), range_size_(1) {}
+  DALI_HOST_DEV curand_uniform_dist() = default;
 
   DALI_HOST_DEV curand_uniform_dist(T start, T end)
       : range_start_(start), range_end_(end), range_size_(end-start) {
@@ -92,7 +91,7 @@ struct curand_uniform_dist {
   }
 
  private:
-  T range_start_, range_end_, range_size_;
+  T range_start_ = 0, range_end_ = 1, range_size_ = 1;
 };
 
 struct curand_uniform_int_range_dist {

--- a/dali/operators/util/randomizer.cuh
+++ b/dali/operators/util/randomizer.cuh
@@ -70,7 +70,7 @@ struct curand_uniform_dist {
     "Unexpected data type");
 
   DALI_HOST_DEV curand_uniform_dist()
-      : range_start_(0.0), range_size_(1.0) {}
+      : range_start_(0), range_end_(1), range_size_(1) {}
 
   DALI_HOST_DEV curand_uniform_dist(T start, T end)
       : range_start_(start), range_end_(end), range_size_(end-start) {

--- a/dali/operators/util/randomizer_test.cu
+++ b/dali/operators/util/randomizer_test.cu
@@ -16,12 +16,6 @@
 #include "dali/test/device_test.h"
 
 namespace dali {
-
-// TODO(janton): Remove when a proper overload is available
-inline __device__ DeviceString dev_to_string(double x) {
-  return dev_to_string(static_cast<float>(x));
-}
-
 namespace test {
 
 DEVICE_TEST(uniform_dist, default_ctor, 110, 1024) {

--- a/dali/operators/util/randomizer_test.cu
+++ b/dali/operators/util/randomizer_test.cu
@@ -16,6 +16,12 @@
 #include "dali/test/device_test.h"
 
 namespace dali {
+
+// TODO(janton): Remove when a proper overload is available
+inline __device__ DeviceString dev_to_string(double x) {
+  return dev_to_string(static_cast<float>(x));
+}
+
 namespace test {
 
 DEVICE_TEST(uniform_dist, default_ctor, 110, 1024) {

--- a/dali/operators/util/randomizer_test.cu
+++ b/dali/operators/util/randomizer_test.cu
@@ -16,7 +16,6 @@
 #include "dali/test/device_test.h"
 
 namespace dali {
-
 namespace test {
 
 DEVICE_TEST(uniform_dist, default_ctor, 110, 1024) {
@@ -27,11 +26,11 @@ DEVICE_TEST(uniform_dist, default_ctor, 110, 1024) {
   curand_uniform_dist<double> dist_f64;
   for (int i = 0; i < 3; i++) {
     auto n1 = dist_f(&state);
-    DEV_EXPECT_GT(n1, 0.0f);
+    DEV_EXPECT_GE(n1, 0.0f);
     DEV_EXPECT_LT(n1, 1.0f);
 
     auto n2 = dist_f64(&state);
-    DEV_EXPECT_GT(n2, 0.0);
+    DEV_EXPECT_GE(n2, 0.0);
     DEV_EXPECT_LT(n2, 1.0);
   }
 }
@@ -44,16 +43,15 @@ DEVICE_TEST(uniform_dist, custom_range, 110, 1024) {
   curand_uniform_dist<double> dist_f64(-0.5, 0.5);
   for (int i = 0; i < 3; i++) {
     auto n1 = dist_f(&state);
-    DEV_EXPECT_GT(n1, -0.5f);
+    DEV_EXPECT_GE(n1, -0.5f);
     DEV_EXPECT_LT(n1, 0.5f);
 
     auto n2 = dist_f64(&state);
-    DEV_EXPECT_GT(n2, -0.5);
+    DEV_EXPECT_GE(n2, -0.5);
     DEV_EXPECT_LT(n2, 0.5);
   }
 }
 
 
 }  // namespace test
-
 }  // namespace dali

--- a/dali/operators/util/randomizer_test.cu
+++ b/dali/operators/util/randomizer_test.cu
@@ -1,0 +1,59 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/util/randomizer.cuh"
+#include "dali/test/device_test.h"
+
+namespace dali {
+
+namespace test {
+
+DEVICE_TEST(uniform_dist, default_ctor, 110, 1024) {
+  uint64_t seed = 12345;
+  curandState state;
+  curand_init(seed, 0, 0, &state);
+  curand_uniform_dist<float> dist_f;
+  curand_uniform_dist<double> dist_f64;
+  for (int i = 0; i < 3; i++) {
+    auto n1 = dist_f(&state);
+    DEV_EXPECT_GT(n1, 0.0f);
+    DEV_EXPECT_LT(n1, 1.0f);
+
+    auto n2 = dist_f64(&state);
+    DEV_EXPECT_GT(n2, 0.0);
+    DEV_EXPECT_LT(n2, 1.0);
+  }
+}
+
+DEVICE_TEST(uniform_dist, custom_range, 110, 1024) {
+  uint64_t seed = 12345;
+  curandState state;
+  curand_init(seed, 0, 0, &state);
+  curand_uniform_dist<float> dist_f(-0.5, 0.5);
+  curand_uniform_dist<double> dist_f64(-0.5, 0.5);
+  for (int i = 0; i < 3; i++) {
+    auto n1 = dist_f(&state);
+    DEV_EXPECT_GT(n1, -0.5f);
+    DEV_EXPECT_LT(n1, 0.5f);
+
+    auto n2 = dist_f64(&state);
+    DEV_EXPECT_GT(n2, -0.5);
+    DEV_EXPECT_LT(n2, 0.5);
+  }
+}
+
+
+}  // namespace test
+
+}  // namespace dali

--- a/include/dali/core/dev_string.h
+++ b/include/dali/core/dev_string.h
@@ -266,10 +266,6 @@ dev_to_string(F x) {
   return buf+lcursor;
 }
 
-inline __device__ DeviceString dev_to_string(double x) {
-  return dev_to_string(static_cast<float>(x));
-}
-
 }  // namespace dali
 
 #endif  // DALI_CORE_DEV_STRING_H_

--- a/include/dali/core/dev_string.h
+++ b/include/dali/core/dev_string.h
@@ -266,6 +266,10 @@ dev_to_string(F x) {
   return buf+lcursor;
 }
 
+inline __device__ DeviceString dev_to_string(double x) {
+  return dev_to_string(static_cast<float>(x));
+}
+
 }  // namespace dali
 
 #endif  // DALI_CORE_DEV_STRING_H_


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in curand_uniform_dist, causing a hang when using a default constructed instance

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *range_end_ was left uninitialized in the default constructor. It should be initialized to 1.0*
 - Affected modules and functionalities:
     *Uniform distribution*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *Unit tests added*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-1970]*
