### PR TITLE
Enable pool to return memory to the upstream upon OOM.

### DIFF
--- a/dali/core/mm/free_list_test.cc
+++ b/dali/core/mm/free_list_test.cc
@@ -83,7 +83,8 @@ TEST(MMBestFitFreeList, PutGetMoveGet) {
 template <typename FreeList>
 void TestCoalescingRemoveIf() {
   FreeList fl;
-  char a alignas(16)[1000];
+  char storage alignas(16)[4000];
+  char *a = storage + 128;   // thank you, overzealous compiler!
   ASSERT_FALSE(fl.remove_if_in_list(a, 1));  // total removed: 250..750
   fl.put(a, 500);
   fl.put(a + 500, 500);
@@ -188,7 +189,8 @@ TEST(MMFreeTree, PutGet) {
 
 TEST(MMBestFitFreeList, RemoveIf) {
   best_fit_free_list fl;
-  char a alignas(16)[1000];
+  char storage alignas(16)[4000];
+  char *a = storage + 128;   // thank you, overzealous compiler!
   fl.put(a, 100);
   fl.put(a + 100, 200);
   fl.put(a + 300, 700);

--- a/dali/core/mm/mm_test_utils.h
+++ b/dali/core/mm/mm_test_utils.h
@@ -40,9 +40,10 @@ class test_resource_wrapper_impl {
  protected:
   using sentinel_t = uint32_t;
 
-  size_t alloc_curr_ = 0;
-  size_t alloc_peak_ = 0;
-  size_t num_allocs_ = 0;
+  size_t alloc_curr_   = 0;
+  size_t alloc_peak_   = 0;
+  size_t num_allocs_   = 0;
+  size_t num_deallocs_ = 0;
 
   template <typename UpstreamAlloc, typename... Extra>
   void *do_allocate_impl(UpstreamAlloc &&ua, size_t bytes, size_t alignment, Extra&&... extra) {
@@ -84,6 +85,7 @@ class test_resource_wrapper_impl {
     if (security_check) {
       ASSERT_TRUE(detail::check_sentinel<sentinel_t>(ptr, bytes)) << "Memory corruption detected";
     }
+    num_deallocs_++;
     alloc_curr_ -= bytes;
     freed_.insert(ptr);
     allocated_.erase(ptr);
@@ -114,8 +116,16 @@ class test_resource_wrapper_impl {
     return alloc_peak_;
   }
 
+  size_t get_current_size() const {
+    return alloc_curr_;
+  }
+
   size_t get_num_allocs() const {
     return num_allocs_;
+  }
+
+  size_t get_num_deallocs() const {
+    return num_deallocs_;
   }
 
   void simulate_out_of_memory(bool enable) {

--- a/include/dali/core/mm/detail/free_list.h
+++ b/include/dali/core/mm/detail/free_list.h
@@ -551,7 +551,7 @@ class free_tree {
     size_t size = end - start;
 
     auto it = by_addr_.lower_bound(start);
-    if (it == by_addr_.end() || it->first > start)
+    if ((it == by_addr_.end() || it->first > start) && it != by_addr_.begin())
       it--;
     char *base = it->first;
     if (start < base || end > it->first + it->second)

--- a/include/dali/core/mm/pool_resource.h
+++ b/include/dali/core/mm/pool_resource.h
@@ -19,6 +19,7 @@
 #include "dali/core/mm/memory_resource.h"
 #include "dali/core/mm/detail/free_list.h"
 #include "dali/core/small_vector.h"
+#include "dali/core/util.h"
 
 namespace dali {
 namespace mm {
@@ -40,15 +41,22 @@ struct pool_options {
    *        block is unavailable.
    */
   bool try_smaller_on_failure = true;
+  /**
+   * @brief Whether to try to return completely free blocks to the upstream when an allocation
+   *        from upstream failed. This may effectively flush the pool.
+   *
+   * @remarks This option is ignored when `try_smaller_on_failure` is set to `false`.
+   */
+  bool return_to_upstream_on_failure = true;
   size_t upstream_alignment = 256;
 };
 
 constexpr pool_options default_host_pool_opts() noexcept {
-  return { (1 << 28), (1 << 12), 2.0f, true };
+  return { (1 << 28), (1 << 12), 2.0f, true, true };
 }
 
 constexpr pool_options default_device_pool_opts() noexcept {
-  return { (static_cast<size_t>(1) << 32), (1 << 20), 2.0f, false };
+  return { (static_cast<size_t>(1) << 32), (1 << 20), 2.0f, true, true };
 }
 
 template <memory_kind kind, typename Context, class FreeList, class LockType>
@@ -133,13 +141,36 @@ class pool_resource_base : public memory_resource<kind, Context> {
 
   void *get_upstream_block(size_t &blk_size, size_t min_bytes, size_t alignment) {
     blk_size = next_block_size(min_bytes);
+    bool tried_return_to_upstream = false;
     for (;;) {
       try {
         return upstream_->allocate(blk_size, alignment);
       } catch (const std::bad_alloc &) {
-        if (blk_size == min_bytes || !options_.try_smaller_on_failure)
+        if (!options_.try_smaller_on_failure)
           throw;
+        if (blk_size == min_bytes) {
+          if (tried_return_to_upstream || !options_.return_to_upstream_on_failure)
+            throw;
+          if (blocks_.empty())
+            throw;
+          int blocks_freed = 0;
+          for (int i = blocks_.size() - 1; i >= 0; i--) {
+            UpstreamBlock blk = blocks_[i];
+            if (free_list_.remove_if_in_list(blk.ptr, blk.bytes)) {
+              upstream_->deallocate(blk.ptr, blk.bytes, blk.alignment);
+              blocks_.erase_at(i--);
+              blocks_freed++;
+            }
+          }
+          if (!blocks_freed)
+            throw;
+          tried_return_to_upstream = true;
+        }
         blk_size = std::max(min_bytes, blk_size >> 1);
+
+        // Shrink the next_block_size_, so that we don't try to allocate a big block
+        // next time, because it would likely fail anyway.
+        next_block_size_ = blk_size;
       }
     }
   }
@@ -149,9 +180,11 @@ class pool_resource_base : public memory_resource<kind, Context> {
   }
 
   size_t next_block_size(size_t upcoming_allocation_size) {
-    size_t actual_block_size = std::max(upcoming_allocation_size, next_block_size_);
-    next_block_size_ = std::min<size_t>(actual_block_size * options_.growth_factor,
-                                        options_.max_block_size);
+    size_t actual_block_size = std::max<size_t>(upcoming_allocation_size,
+                                                next_block_size_ * options_.growth_factor);
+    size_t alignment = 1uL << std::max((ilog2(actual_block_size) - 10), 12);
+    actual_block_size = align_up(actual_block_size, alignment);
+    next_block_size_ = std::min<size_t>(actual_block_size, options_.max_block_size);
     return actual_block_size;
   }
 

--- a/include/dali/core/mm/pool_resource.h
+++ b/include/dali/core/mm/pool_resource.h
@@ -149,13 +149,22 @@ class pool_resource_base : public memory_resource<kind, Context> {
         if (!options_.try_smaller_on_failure)
           throw;
         if (blk_size == min_bytes) {
+          // We've reached the minimum size and still got no memory from upstream
+          // - try to free something.
           if (tried_return_to_upstream || !options_.return_to_upstream_on_failure)
             throw;
-          if (blocks_.empty())
+          if (blocks_.empty())  // nothing to free -> fail
             throw;
+          // If there are some upstream blocks which are completely free
+          // (the free list covers them completely), we can try to return them
+          // to the upstream, with the hope that it will reorganize and succeed in
+          // the subsequent allocation attempt.
           int blocks_freed = 0;
           for (int i = blocks_.size() - 1; i >= 0; i--) {
             UpstreamBlock blk = blocks_[i];
+            // If we can remove the block from the free list, it
+            // means that there are no suballocations from this block
+            // - we can safely free it to the upstream.
             if (free_list_.remove_if_in_list(blk.ptr, blk.bytes)) {
               upstream_->deallocate(blk.ptr, blk.bytes, blk.alignment);
               blocks_.erase_at(i--);
@@ -163,7 +172,8 @@ class pool_resource_base : public memory_resource<kind, Context> {
             }
           }
           if (!blocks_freed)
-            throw;
+            throw;  // we freed nothing, so there's no point in retrying to allocate
+          // mark that we've tried, so we can fail fast the next time
           tried_return_to_upstream = true;
         }
         blk_size = std::max(min_bytes, blk_size >> 1);
@@ -182,6 +192,15 @@ class pool_resource_base : public memory_resource<kind, Context> {
   size_t next_block_size(size_t upcoming_allocation_size) {
     size_t actual_block_size = std::max<size_t>(upcoming_allocation_size,
                                                 next_block_size_ * options_.growth_factor);
+    // Align the upstream block to reduce fragmentation.
+    // The upstream resource (e.g. OS routine) may return blocks that have
+    // coarse size granularity. This may result in fragmentation - the next
+    // large block will be overaligned and we'll never see the padding.
+    // Even though we might have received contiguous memory, we're not aware of that.
+    // To reduce the probability of this happening, we align the size to 1/1024th
+    // of the allocation size or 4kB (typical page size), whichever is larger.
+    // This makes (at least sometimes) the large blocks to be seen as adjacent
+    // and therefore enables coalescing in the free list.
     size_t alignment = 1uL << std::max((ilog2(actual_block_size) - 10), 12);
     actual_block_size = align_up(actual_block_size, alignment);
     next_block_size_ = std::min<size_t>(actual_block_size, options_.max_block_size);


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature: **returning memory to upstream** needed because we allocate huge memory chunks for tensor lists.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added an option to get a specific address range from a free list and free tree
     * Upon OOM, run over upstream blocks and return the completely free blocks to the upstream, removing them from free list
     * If the upstream uses paging, it can rearrange physical storage and assign a new continuous virtual address space to the released fragments
 - Affected modules and functionalities:
     * Pooling resource
     * Free lists
     * Test tracking resource
 - Key points relevant for the review:
     *[ Describe here what is the most important part that reviewers should focus on. ]*
 - Validation and testing:
     * Unit tests for free_list
     * Unit test for pooling resource that checks that the deallocation actually happens
 - Documentation (including examples):
     * Doxygen docstrings, when necessary


**JIRA TASK**: DALI-2027 (needed as a fix)
