### PR TITLE
Fix handling of non_existing entries in TFRecord reader

### DIFF
--- a/dali/operators/reader/parser/tfrecord_parser.h
+++ b/dali/operators/reader/parser/tfrecord_parser.h
@@ -73,13 +73,13 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
         // set type
         switch (f.GetType()) {
           case FeatureType::int64:
-            (void) output.mutable_data<int64_t>();
+             output.Resize({0}, TypeTable::GetTypeInfo(DALI_INT64));
             break;
           case FeatureType::string:
-            (void) output.mutable_data<uint8_t>();
+             output.Resize({0}, TypeTable::GetTypeInfo(DALI_UINT8));
             break;
           case FeatureType::float32:
-            (void) output.mutable_data<float>();
+             output.Resize({0}, TypeTable::GetTypeInfo(DALI_FLOAT));
             break;
         }
         output.SetSourceInfo(data.GetSourceInfo());

--- a/dali/operators/reader/tfrecord_reader_op.cc
+++ b/dali/operators/reader/tfrecord_reader_op.cc
@@ -72,7 +72,10 @@ Typically obtained by using the ``dali.tfrecord.FixedLenFeature`` and
 ``tf.FixedLenFeature`` and ``tf.VarLenFeature`` types, respectively. For additional flexibility,
 ``dali.tfrecord.VarLenFeature`` supports the ``partial_shape`` parameter. If provided,
 the data will be reshaped to match its value, and the first dimension will be inferred from
-the data size.)code",
+the data size.
+
+If the named feature doesn't exists in the processed TFRecord entry an empty tensor is returned.
+)code",
       DALI_TF_FEATURE_DICT)
   .AddParent("readers___TFRecordBase")
   .AddParent("LoaderBase");

--- a/dali/test/python/test_operator_readers_index.py
+++ b/dali/test/python/test_operator_readers_index.py
@@ -137,7 +137,7 @@ def test_mxnet_reader_alias():
 def tfrecord_pipe(tfrecord_op, path, index_path):
     inputs = tfrecord_op(path=path, index_path=index_path,
             features={"image/encoded" : tfrec.FixedLenFeature((), tfrec.string, ""),
-                      "image/class/label": tfrec.FixedLenFeature([1], tfrec.int64,  -1)})
+                      "image/class/label": tfrec.FixedLenFeature([1], tfrec.int64, -1)})
     return inputs["image/encoded"]
 
 def test_tfrecord_reader_alias():
@@ -146,3 +146,25 @@ def test_tfrecord_reader_alias():
     new_pipe = tfrecord_pipe(fn.readers.tfrecord, tfrecord, tfrecord_idx)
     legacy_pipe = tfrecord_pipe(fn.tfrecord_reader, tfrecord, tfrecord_idx)
     compare_pipelines(new_pipe, legacy_pipe, batch_size_alias_test, 50)
+
+@pipeline_def(batch_size=batch_size_alias_test, device_id=0, num_threads=4)
+def tfrecord_pipe_empty_fields(path, index_path):
+    inputs = fn.readers.tfrecord(path=path, index_path=index_path,
+            features={"image/encoded" : tfrec.FixedLenFeature((), tfrec.string, ""),
+                      "image/class/label": tfrec.FixedLenFeature([1], tfrec.int64, -1),
+                      "does/not/exists": tfrec.VarLenFeature(tfrec.int64, -1),
+                      "does/not/exists/as/well": tfrec.FixedLenFeature([1], tfrec.float32, .0)})
+    return inputs["image/encoded"], inputs["does/not/exists"], inputs["does/not/exists/as/well"]
+
+def test_tfrecord_reader_alias():
+    tfrecord = os.path.join(get_dali_extra_path(), 'db', 'tfrecord', 'train')
+    tfrecord_idx = os.path.join(get_dali_extra_path(), 'db', 'tfrecord', 'train.idx')
+    pipe = tfrecord_pipe_empty_fields(tfrecord, tfrecord_idx)
+    pipe.build()
+    out = pipe.run()
+    for tensor in out[0]:
+        assert len(np.array(tensor)) != 0
+    for tensor in out[1]:
+        assert len(np.array(tensor)) == 0
+    for tensor in out[2]:
+        assert len(np.array(tensor)) == 0

--- a/dali/test/python/test_operator_readers_index.py
+++ b/dali/test/python/test_operator_readers_index.py
@@ -163,8 +163,14 @@ def test_tfrecord_reader_alias():
     pipe.build()
     out = pipe.run()
     for tensor in out[0]:
-        assert len(np.array(tensor)) != 0
+        data = np.array(tensor)
+        assert len(data) != 0
+        assert data.dtype  == np.uint8
     for tensor in out[1]:
-        assert len(np.array(tensor)) == 0
+        data = np.array(tensor)
+        assert len(data) == 0
+        assert data.dtype  == np.int64
     for tensor in out[2]:
-        assert len(np.array(tensor)) == 0
+        data = np.array(tensor)
+        assert len(data) == 0
+        assert data.dtype  == np.float32


### PR DESCRIPTION
- DALI assumes that all features provided in the TFRecord reader
  exists in every entry, otherwise protobuf will throw.
  This PR lifts that assumption makes the reader return
  empty tensor when the desired entry has not been found.
  It should be in pair what TensorFlow reader does.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes handling of non_existing entries in TFRecord reader

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     DALI assumes that all features provided in the TFRecord reader exists in every entry, otherwise protobuf will throw.
     This PR lifts that assumption makes the reader return empty tensor when the desired entry has not been found.
     It should be in pair what TensorFlow reader does.
 - Affected modules and functionalities:
     tfrecord_parser.h
 - Key points relevant for the review:
     should we return empty tensor and/or warn/enforce that all entries exits
 - Validation and testing:
     test is added
 - Documentation (including examples):
     TFRecord Reader documentation is updated

**JIRA TASK**: *[NA]*
