### PR TITLE
Guard changes to default resources with a mutex.

### DIFF
--- a/dali/core/mm/default_resources.cc
+++ b/dali/core/mm/default_resources.cc
@@ -255,6 +255,13 @@ void SetDefaultDeviceResource(int device_id, device_async_resource *resource, bo
   SetDefaultDeviceResource(device_id, wrap(resource, own));
 }
 
+// This function is for testing purposes only - it must be visible
+DLL_PUBLIC void _Test_FreeDeviceResources() {
+  // clear does not deallocate - we need something stronger
+  decltype(g_resources.device) empty;
+  g_resources.device.swap(empty);
+}
+
 template <> DLL_PUBLIC
 void SetDefaultResource<memory_kind::device>(std::shared_ptr<device_async_resource> resource) {
   int dev = 0;


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a race condition when multiple threads try to initialize the default resource - it seems that it fixes the segmentation fault seen in #2948

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Guard changes to default resources with a mutex.
     * Guard initialization of default resources with a mutex.
 - Affected modules and functionalities:
     * Default memory resources
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * N/A
 - Documentation (including examples):
     * N/A


**JIRA TASK**: N/A
