### PR TITLE
Add coverage test for CPU only and variable batch size test

### DIFF
--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -27,6 +27,7 @@ import os
 import glob
 from math import ceil, sqrt
 import tempfile
+import sys
 
 data_root = get_dali_extra_path()
 images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
@@ -817,4 +818,159 @@ def test_separated_exec_setup():
         t_cpu = a_cpu.at(i)
         assert(np.sum(np.abs(t_cpu - t_raw)) == 0)
 
-# ToDo add tests for DLTensorPythonFunction if easily possible
+tested_methods = [
+    "audio_decoder",
+    "image_decoder",
+    "image_decoder_slice",
+    "image_decoder_crop",
+    "image_decoder_random_crop",
+    "decoders.image",
+    "decoders.image_crop",
+    "decoders.image_slice",
+    "decoders.image_random_crop",
+    "decoders.audio",
+    "external_source",
+    "stack",
+    "reductions.variance",
+    "reductions.std_dev",
+    "reductions.rms",
+    "reductions.mean",
+    "reductions.mean_square",
+    "reductions.max",
+    "reductions.min",
+    "reductions.sum",
+    "transforms.translation",
+    "transforms.rotation",
+    "transforms.scale",
+    "transforms.combine",
+    "transforms.shear",
+    "transforms.crop",
+    "transform_translation",
+    "crop",
+    "constant",
+    "dump_image",
+    "numpy_reader",
+    "tfrecord_reader",
+    "file_reader",
+    "sequence_reader",
+    "mxnet_reader",
+    "caffe_reader",
+    "caffe2_reader",
+    "coco_reader",
+    "readers.file",
+    "readers.sequence",
+    "readers.tfrecord",
+    "readers.mxnet",
+    "readers.caffe",
+    "readers.caffe2",
+    "readers.coco",
+    "readers.numpy",
+    "coin_flip",
+    "uniform",
+    "random.uniform",
+    "random.coin_flip",
+    "random.normal",
+    "random_bbox_crop",
+    "python_function",
+    "rotate",
+    "brightness_contrast",
+    "hue",
+    "brightness",
+    "contrast",
+    "hsv",
+    "color_twist",
+    "saturation",
+    "old_color_twist",
+    "shapes",
+    "crop",
+    "color_space_conversion",
+    "cast",
+    "resize",
+    "gaussian_blur",
+    "crop_mirror_normalize",
+    "flip",
+    "jpeg_compression_distortion",
+    "noise.shot",
+    "reshape",
+    "reinterpret",
+    "water",
+    "sphere",
+    "erase",
+    "random_resized_crop",
+    "ssd_random_crop",
+    "bbox_paste",
+    "coord_flip",
+    "cat",
+    "bb_flip",
+    "warp_affine",
+    "normalize",
+    "pad",
+    "preemphasis_filter",
+    "power_spectrum",
+    "spectrogram",
+    "to_decibels",
+    "sequence_rearrange",
+    "normal_distribution",
+    "mel_filter_bank",
+    "nonsilent_region",
+    "one_hot",
+    "copy",
+    "resize_crop_mirror",
+    "fast_resize_crop_mirror",
+    "segmentation.select_masks",
+    "slice",
+    "segmentation.random_mask_pixel",
+    "transpose",
+    "paste",
+    "mfcc",
+    "lookup_table",
+    "element_extract",
+    "arithmetic_generic_op",
+    "box_encoder",
+]
+
+excluded_methods = [
+    "readers.nemo_asr",
+    "roi_random_crop",
+    "squeeze",
+    "jitter",
+    "permute_batch",
+    "peek_image_shape",
+    "batch_permutation",
+    "expand_dims",
+    "noise.gaussian",
+    "grid_mask",
+    "nemo_asr_reader",
+    "coord_transform",
+    "multi_paste",
+    "segmentation.random_object_bbox",
+    "noise.salt_and_pepper",
+    "dl_tensor_python_function",
+    "hidden.arithmetic_generic_op", #internal
+    "hidden.transform_translation", #internal
+    "video_reader",         # not supported for CPU
+    "video_reader_resize",  # not supported for CPU
+    "readers.video",        # not supported for CPU
+    "readers.video_resize", # not supported for CPU
+    "optical_flow",         # not supported for CPU
+]
+def test_coverage():
+    def get_functions(cls, prefix = ""):
+        res = []
+        if len(cls.__dict__.keys()) == 0:
+            prefix = prefix.replace("nvidia.dali.fn", "")
+            prefix = prefix.lstrip('.')
+            if len(prefix):
+                prefix += '.'
+            else:
+                prefix = ""
+            res.append(prefix + cls.__name__)
+        else:
+            for c in cls.__dict__.keys():
+                if not c.startswith("_") and c not in sys.builtin_module_names:
+                    c = cls.__dict__[c]
+                    res += get_functions(c, cls.__name__)
+        return res
+    methods = get_functions(fn)
+    covered = tested_methods + excluded_methods
+    assert set(covered) == set(methods), "Test doesn't cover:\n {}".format(set(methods) - set(covered))

--- a/dali/test/python/test_dali_variable_batch_size.py
+++ b/dali/test/python/test_dali_variable_batch_size.py
@@ -26,6 +26,7 @@ import inspect
 import os
 import math
 import random
+import sys
 
 """
 How to test variable (iter-to-iter) batch size for a given op?
@@ -692,3 +693,169 @@ def test_reinterpret():
                    pipeline_fn=pipe, input_layout="HWC")
     check_pipeline(generate_data(31, 13, (5, 160, 80, 3), lo=0, hi=255, dtype=np.uint8),
                    pipeline_fn=pipe, input_layout="FHWC")
+
+tested_methods = [
+    "audio_decoder",
+    "image_decoder",
+    "image_decoder_slice",
+    "image_decoder_crop",
+    "image_decoder_random_crop",
+    "decoders.image",
+    "decoders.image_crop",
+    "decoders.image_slice",
+    "decoders.image_random_crop",
+    "decoders.audio",
+    "peek_image_shape",
+    "external_source",
+    "brightness",
+    "brightness_contrast",
+    "cat",
+    "color_twist",
+    "contrast",
+    "copy",
+    "crop_mirror_normalize",
+    "dump_image",
+    "hsv",
+    "hue",
+    "jpeg_compression_distortion",
+    "noise.shot",
+    "old_color_twist",
+    "reductions.mean",
+    "reductions.mean_square",
+    "reductions.rms",
+    "reductions.min",
+    "reductions.max",
+    "reductions.sum",
+    "saturation",
+    "shapes",
+    "sphere",
+    "stack",
+    "water",
+    "color_space_conversion",
+    "coord_transform",
+    "crop",
+    "erase",
+    "fast_resize_crop_mirror",
+    "flip",
+    "gaussian_blur",
+    "normalize",
+    "pad",
+    "paste",
+    "resize",
+    "resize_crop_mirror",
+    "rotate",
+    "transpose",
+    "warp_affine",
+    "power_spectrum",
+    "preemphasis_filter",
+    "spectrogram",
+    "to_decibels",
+    "jitter",
+    "random_resized_crop",
+    "cast",
+    "copy",
+    "crop",
+    "crop_mirror_normalize",
+    "erase",
+    "flip",
+    "gaussian_blur",
+    "normalize",
+    "resize",
+    "bb_flip",
+    "one_hot",
+    "reinterpret",
+    "batch_permutation",
+    "reductions.std_dev",
+    "reductions.variance",
+    "mel_filter_bank",
+    "constant",
+    "mfcc",
+    "bbox_paste",
+    "sequence_rearrange",
+    "coord_flip",
+    "lookup_table",
+    "slice",
+    "permute_batch",
+    "nonsilent_region",
+    "element_extract",
+    "reshape",
+    "coin_flip",
+    "uniform",
+    "random.coin_flip",
+    "random.uniform",
+    "python_function",
+    "normal_distribution",
+    "random.normal",
+    "arithmetic_generic_op",
+]
+
+excluded_methods = [
+    "segmentation.select_masks",
+    "segmentation.random_object_bbox",
+    "segmentation.random_mask_pixel",
+    "multi_paste",
+    "random_bbox_crop",
+    "noise.salt_and_pepper",
+    "noise.gaussian",
+    "box_encoder",
+    "optical_flow",
+    "expand_dims",
+    "grid_mask",
+    "roi_random_crop",
+    "squeeze",
+    "ssd_random_crop",
+    "transforms.rotation",
+    "transforms.combine",
+    "transforms.shear",
+    "transforms.crop",
+    "transforms.scale",
+    "transforms.translation",
+    "transform_translation",
+    "dl_tensor_python_function",
+    "hidden.transform_translation", # intentional
+    "hidden.arithmetic_generic_op", # intentional
+    "coco_reader",              # readers are do not support variable batch size yet
+    "sequence_reader",          # readers are do not support variable batch size yet
+    "numpy_reader",             # readers are do not support variable batch size yet
+    "file_reader",              # readers are do not support variable batch size yet
+    "caffe_reader",             # readers are do not support variable batch size yet
+    "caffe2_reader",            # readers are do not support variable batch size yet
+    "mxnet_reader",             # readers are do not support variable batch size yet
+    "tfrecord_reader",          # readers are do not support variable batch size yet
+    "nemo_asr_reader",          # readers are do not support variable batch size yet
+    "video_reader",             # readers are do not support variable batch size yet
+    "video_reader_resize",      # readers are do not support variable batch size yet
+    "readers.coco",             # readers are do not support variable batch size yet
+    "readers.sequence",         # readers are do not support variable batch size yet
+    "readers.numpy",            # readers are do not support variable batch size yet
+    "readers.file",             # readers are do not support variable batch size yet
+    "readers.caffe",            # readers are do not support variable batch size yet
+    "readers.caffe2",           # readers are do not support variable batch size yet
+    "readers.mxnet",            # readers are do not support variable batch size yet
+    "readers.tfrecord",         # readers are do not support variable batch size yet
+    "readers.nemo_asr",         # readers are do not support variable batch size yet
+    "readers.video",            # readers are do not support variable batch size yet
+    "readers.video_resize",     # readers are do not support variable batch size yet
+
+]
+def test_coverage():
+    def get_functions(cls, prefix = ""):
+        res = []
+        if len(cls.__dict__.keys()) == 0:
+            prefix = prefix.replace("nvidia.dali.fn", "")
+            prefix = prefix.lstrip('.')
+            if len(prefix):
+                prefix += '.'
+            else:
+                prefix = ""
+            res.append(prefix + cls.__name__)
+        else:
+            for c in cls.__dict__.keys():
+                if not c.startswith("_") and c not in sys.builtin_module_names:
+                    c = cls.__dict__[c]
+                    res += get_functions(c, cls.__name__)
+        return res
+    methods = get_functions(fn)
+    covered = tested_methods + excluded_methods
+    print(set(methods) - set(covered))
+    assert set(covered) == set(methods), "Test doesn't cover:\n {}".format(set(methods) - set(covered))

--- a/dali/test/python/test_dali_variable_batch_size.py
+++ b/dali/test/python/test_dali_variable_batch_size.py
@@ -849,28 +849,28 @@ excluded_methods = [
     "numba.fn.experimental.numba_function",
     "hidden.transform_translation", # intentional
     "hidden.arithmetic_generic_op", # intentional
-    "coco_reader",              # readers are do not support variable batch size yet
-    "sequence_reader",          # readers are do not support variable batch size yet
-    "numpy_reader",             # readers are do not support variable batch size yet
-    "file_reader",              # readers are do not support variable batch size yet
-    "caffe_reader",             # readers are do not support variable batch size yet
-    "caffe2_reader",            # readers are do not support variable batch size yet
-    "mxnet_reader",             # readers are do not support variable batch size yet
-    "tfrecord_reader",          # readers are do not support variable batch size yet
-    "nemo_asr_reader",          # readers are do not support variable batch size yet
-    "video_reader",             # readers are do not support variable batch size yet
-    "video_reader_resize",      # readers are do not support variable batch size yet
-    "readers.coco",             # readers are do not support variable batch size yet
-    "readers.sequence",         # readers are do not support variable batch size yet
-    "readers.numpy",            # readers are do not support variable batch size yet
-    "readers.file",             # readers are do not support variable batch size yet
-    "readers.caffe",            # readers are do not support variable batch size yet
-    "readers.caffe2",           # readers are do not support variable batch size yet
-    "readers.mxnet",            # readers are do not support variable batch size yet
-    "readers.tfrecord",         # readers are do not support variable batch size yet
-    "readers.nemo_asr",         # readers are do not support variable batch size yet
-    "readers.video",            # readers are do not support variable batch size yet
-    "readers.video_resize",     # readers are do not support variable batch size yet
+    "coco_reader",              # readers do do not support variable batch size yet
+    "sequence_reader",          # readers do do not support variable batch size yet
+    "numpy_reader",             # readers do do not support variable batch size yet
+    "file_reader",              # readers do do not support variable batch size yet
+    "caffe_reader",             # readers do do not support variable batch size yet
+    "caffe2_reader",            # readers do do not support variable batch size yet
+    "mxnet_reader",             # readers do do not support variable batch size yet
+    "tfrecord_reader",          # readers do do not support variable batch size yet
+    "nemo_asr_reader",          # readers do do not support variable batch size yet
+    "video_reader",             # readers do do not support variable batch size yet
+    "video_reader_resize",      # readers do do not support variable batch size yet
+    "readers.coco",             # readers do do not support variable batch size yet
+    "readers.sequence",         # readers do do not support variable batch size yet
+    "readers.numpy",            # readers do do not support variable batch size yet
+    "readers.file",             # readers do do not support variable batch size yet
+    "readers.caffe",            # readers do do not support variable batch size yet
+    "readers.caffe2",           # readers do do not support variable batch size yet
+    "readers.mxnet",            # readers do do not support variable batch size yet
+    "readers.tfrecord",         # readers do do not support variable batch size yet
+    "readers.nemo_asr",         # readers do do not support variable batch size yet
+    "readers.video",            # readers do do not support variable batch size yet
+    "readers.video_resize",     # readers do do not support variable batch size yet
 
 ]
 

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -517,3 +517,20 @@ def to_array(dali_out):
     if isinstance(dali_out, TensorListCPU):
         dali_out = dali_out.as_array()
     return np.array(dali_out)
+
+def module_functions(cls, prefix = "", remove_prefix = ""):
+    res = []
+    if len(cls.__dict__.keys()) == 0:
+        prefix = prefix.replace(remove_prefix, "")
+        prefix = prefix.lstrip('.')
+        if len(prefix):
+            prefix += '.'
+        else:
+            prefix = ""
+        res.append(prefix + cls.__name__)
+    else:
+        for c in cls.__dict__.keys():
+            if not c.startswith("_") and c not in sys.builtin_module_names:
+                c = cls.__dict__[c]
+                res += module_functions(c, cls.__name__, remove_prefix = remove_prefix)
+    return res

--- a/qa/TL0_cpu_only/test.sh
+++ b/qa/TL0_cpu_only/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy>=1.17 pillow torch"
+pip_packages="nose numpy>=1.17 pillow torch numba"
 
 target_dir=./dali/test/python
 

--- a/qa/TL0_python-self-test-core/test_nofw.sh
+++ b/qa/TL0_python-self-test-core/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy>=1.17 opencv-python pillow nvidia-ml-py==11.450.51"
+pip_packages="nose numpy>=1.17 opencv-python pillow nvidia-ml-py==11.450.51 torch numba"
 
 target_dir=./dali/test/python
 


### PR DESCRIPTION
- adds a test that checks if all available DALI operators are covered
  by CPU only and variable batch size test. The test lists all operators
  and checks if the list of tested operators matches it. The list is
  manually maintained and need to be updated when a new test is added

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds coverage test for CPU only and variable batch size test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a test that checks if all available DALI operators are covered by CPU only and variable batch size test. The test lists all operators and checks if the list of tested operators matches it. The list is manually maintained and need to be updated when a new test is added
 - Affected modules and functionalities:
     test_dali_variable_batch_size.py
     test_dali_cpu_only.py
 - Key points relevant for the review:
     check list correctness
 - Validation and testing:
     CI run
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-2032]*
