### PR TITLE
MultiPaste: Fix in_ids argument type in the schema

### DIFF
--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -28,7 +28,7 @@ This operator can also change the type of data.)code")
 Assumes HWC layout.)code")
 .AddArg("in_ids", R"code(1D TensorList of type int.
 
-Indexes from what inputs to paste data in each iteration.)code", DALI_INT32, true)
+Indexes from what inputs to paste data in each iteration.)code", DALI_INT_VEC, true)
 .AddOptionalArg<int>("in_anchors", R"code(2D TensorList of type int64
 
 Absolute values of LU corner of the selection for each iteration.

--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -31,21 +31,24 @@ Assumes HWC layout.)code")
 .AddOptionalArg<int>("in_anchors", R"code(Absolute coordinates of LU corner
 of the source region.
 
-2D data with where the first dimension corresponds to the elements of ``in_ids``
-and the second one is equal to the number dimensions of the data.
+The anchors are represented as 2D tensors where the first dimension corresponds to the
+elements of ``in_ids`` and the second one is equal to the number of dimensions of the
+data, excluding channels.
 
 If not provided, all anchors are zero.)code", nullptr, true)
 .AddOptionalArg<int>("shapes", R"code(Shape of the paste regions.
 
-2D data with where the first dimension corresponds to the elements of ``in_ids``
-and the second one is equal to the number dimensions of the data.
+The shapes are represented as 2D tensors where the first dimension corresponds to the
+elements of ``in_ids`` and the second one is equal to the number of dimensions of the
+data, excluding channels.
 
 If not provided, the input shape is used.)code", nullptr, true)
 .AddOptionalArg<int>("out_anchors", R"code(Absolute coordinates of LU corner
 of the destination region.
 
-2D data with where the first dimension corresponds to the elements of ``in_ids``
-and the second one is equal to the number dimensions of the data.
+The anchors are represented as 2D tensors where the first dimension corresponds to the
+elements of ``in_ids`` and the second one is equal to the number of dimensions of the
+data, excluding channels.
 
 If not provided, all anchors are zero.)code", nullptr, true)
 .AddArg("output_size",

--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -31,23 +31,23 @@ Assumes HWC layout.)code")
 .AddOptionalArg<int>("in_anchors", R"code(Absolute coordinates of LU corner
 of the source region.
 
-2D data with the first dimension containing as many entries as elements in ``in_ids``
-and the second one containing as many elements as the number of dimensions of the data.
+2D data with where the first dimension corresponds to the elements of ``in_ids``
+and the second one is equal to the number dimensions of the data.
 
-If not provided, zeros are assumed.)code", nullptr, true)
+If not provided, all anchors are zero.)code", nullptr, true)
 .AddOptionalArg<int>("shapes", R"code(Shape of the paste regions.
 
-2D data with the first dimension containing as many entries as elements in ``in_ids``
-and the second one containing as many elements as the number of dimensions of the data.
+2D data with where the first dimension corresponds to the elements of ``in_ids``
+and the second one is equal to the number dimensions of the data.
 
 If not provided, the input shape is used.)code", nullptr, true)
 .AddOptionalArg<int>("out_anchors", R"code(Absolute coordinates of LU corner
 of the destination region.
 
-2D data with the first dimension containing as many entries as elements in ``in_ids``
-and the second one containing as many elements as the number of dimensions of the data.
+2D data with where the first dimension corresponds to the elements of ``in_ids``
+and the second one is equal to the number dimensions of the data.
 
-If not provided, zeros are assumed.)code", nullptr, true)
+If not provided, all anchors are zero.)code", nullptr, true)
 .AddArg("output_size",
 R"code(Shape of the output.)code", DALI_INT_VEC, true)
 .AddOptionalArg("dtype",

--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -26,23 +26,30 @@ This operator can also change the type of data.)code")
 .InputDox(0, "images", "3D TensorList", R"code(Batch of input images.
 
 Assumes HWC layout.)code")
-.AddArg("in_ids", R"code(1D TensorList of type int.
+.AddArg("in_ids", R"code(Indices of the inputs to paste data from.)code",
+        DALI_INT_VEC, true)
+.AddOptionalArg<int>("in_anchors", R"code(Absolute coordinates of LU corner
+of the source region.
 
-Indexes from what inputs to paste data in each iteration.)code", DALI_INT_VEC, true)
-.AddOptionalArg<int>("in_anchors", R"code(2D TensorList of type int64
+2D data with the first dimension containing as many entries as elements in ``in_ids``
+and the second one containing as many elements as the number of dimensions of the data.
 
-Absolute values of LU corner of the selection for each iteration.
-Zeros are used if this is omitted.)code", nullptr, true)
-.AddOptionalArg<int>("shapes", R"code(2D TensorList of type int64
+If not provided, zeros are assumed.)code", nullptr, true)
+.AddOptionalArg<int>("shapes", R"code(Shape of the paste regions.
 
-Absolute values of size of the selection for each iteration.
-Input size is used if this is omitted.)code", nullptr, true)
-.AddOptionalArg<int>("out_anchors", R"code(2D TensorList of type int64
+2D data with the first dimension containing as many entries as elements in ``in_ids``
+and the second one containing as many elements as the number of dimensions of the data.
 
-Absolute values of LU corner of the paste for each iteration.
-Zeros are used if omitted.)code", nullptr, true)
+If not provided, the input shape is used.)code", nullptr, true)
+.AddOptionalArg<int>("out_anchors", R"code(Absolute coordinates of LU corner
+of the destination region.
+
+2D data with the first dimension containing as many entries as elements in ``in_ids``
+and the second one containing as many elements as the number of dimensions of the data.
+
+If not provided, zeros are assumed.)code", nullptr, true)
 .AddArg("output_size",
-R"code(Output size.)code", DALI_INT_VEC, true)
+R"code(Shape of the output.)code", DALI_INT_VEC, true)
 .AddOptionalArg("dtype",
 R"code(Output data type. If not set, the input type is used.)code", DALI_NO_TYPE)
 .NumOutput(1);


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It fixes a bug MultiPaste. An argument type was marked as int, when in fact a vector of int is expected.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Changed from DALI_INT32 to DALI_INT_VEC*
 - Affected modules and functionalities:
     *MultiPaste*
 - Key points relevant for the review:
     *Check docs*
 - Validation and testing:
     *Existing tests apply*
 - Documentation (including examples):
     *Rendered docs should reflect that the argument expects a list of integers*


**JIRA TASK**: *[NA]*
