### PR TITLE
Add libopus to the binaries distributed with the wheel

### DIFF
--- a/dali/python/bundle-wheel.sh
+++ b/dali/python/bundle-wheel.sh
@@ -104,6 +104,7 @@ DEPS_LIST=(
     "${DEPS_PATH}/lib/libogg.so.0"
     "${DEPS_PATH}/lib/libvorbis.so.0"
     "${DEPS_PATH}/lib/libvorbisenc.so.2"
+    "${DEPS_PATH}/lib/libopus.so.0"
     "${DEPS_PATH}/lib/libopenjp2.so.7"
     "${DEPS_PATH}/lib/libzstd.so.1"
     "${DEPS_PATH}/lib/libz.so.1"


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds A new library to the bundled binaries distributed with the library.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a libopus to the list of bundled libraries*
 - Affected modules and functionalities:
     *bundle-wheel.sh script*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[NA]*
