### PR TITLE
Add launch bounds to TransposeBatch kernel to avoid cudaErrorLaunchOutOfResources

### DIFF
--- a/dali/kernels/signal/fft/fft_postprocess.cuh
+++ b/dali/kernels/signal/fft/fft_postprocess.cuh
@@ -144,7 +144,7 @@ __global__ void ConvertTimeMajorSpectrogram(
 
 template <typename Out, typename In, typename Convert = identity>
 __global__ void
-__launch_bounds__(32*kBlock)
+__launch_bounds__(kBlock*kBlock)
 TransposeBatch(
     const SampleDesc<Out, In> *samples,
     const BlockDesc *blocks,

--- a/dali/kernels/signal/fft/fft_postprocess.cuh
+++ b/dali/kernels/signal/fft/fft_postprocess.cuh
@@ -143,7 +143,9 @@ __global__ void ConvertTimeMajorSpectrogram(
 }
 
 template <typename Out, typename In, typename Convert = identity>
-__global__ void TransposeBatch(
+__global__ void
+__launch_bounds__(32*kBlock)
+TransposeBatch(
     const SampleDesc<Out, In> *samples,
     const BlockDesc *blocks,
     Convert convert = {}) {


### PR DESCRIPTION
- adds launch bounds to TransposeBatch kernel inside fft_postprocess.cuh to make
  sure that cudaErrorLaunchOutOfResources on some GPUs

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds launch bounds to TransposeBatch kernel inside fft_postprocess.cuh to make
  sure that cudaErrorLaunchOutOfResources on some GPUs

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds launch bounds to TransposeBatch kernel inside fft_postprocess.cuh to make sure that cudaErrorLaunchOutOfResources on some GPUs
 - Affected modules and functionalities:
     fft_postprocess.cuh
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
