### PR TITLE
Add BOOL_SWITCH

### DIFF
--- a/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.cu
+++ b/dali/kernels/imgproc/jpeg/jpeg_distortion_gpu_kernel.cu
@@ -101,12 +101,12 @@ void JpegCompressionDistortionGPU::Run(KernelContext &ctx, const OutListGPU<uint
       ctx.gpu.stream, make_cspan(sample_descs_), block_setup_.Blocks());
   dim3 grid_dim = block_setup_.GridDim();
   dim3 block_dim = block_setup_.BlockDim();
-  VALUE_SWITCH(horz_subsample_ ? 1 : 0, HorzSubsample, (false, true), (
-    VALUE_SWITCH(vert_subsample_ ? 1 : 0, VertSubsample, (false, true), (
+  BOOL_SWITCH(horz_subsample_, HorzSubsample, (
+    BOOL_SWITCH(vert_subsample_, VertSubsample, (
       JpegCompressionDistortion<HorzSubsample, VertSubsample>
           <<<grid_dim, block_dim, 0, ctx.gpu.stream>>>(samples_gpu, blocks_gpu);
-    ), ());  // NOLINT
-  ), ());  // NOLINT
+    ));  // NOLINT
+  ));  // NOLINT
   CUDA_CALL(cudaGetLastError());
 }
 
@@ -119,12 +119,12 @@ void ChromaSubsampleDistortionGPU::Run(KernelContext &ctx, const OutListGPU<uint
       ctx.gpu.stream, make_cspan(sample_descs_), block_setup_.Blocks());
   dim3 grid_dim = block_setup_.GridDim();
   dim3 block_dim = block_setup_.BlockDim();
-  VALUE_SWITCH(horz_subsample_ ? 1 : 0, HorzSubsample, (false, true), (
-    VALUE_SWITCH(vert_subsample_ ? 1 : 0, VertSubsample, (false, true), (
+  BOOL_SWITCH(horz_subsample_, HorzSubsample, (
+    BOOL_SWITCH(vert_subsample_, VertSubsample, (
       ChromaSubsampleDistortion<HorzSubsample, VertSubsample>
           <<<grid_dim, block_dim, 0, ctx.gpu.stream>>>(samples_gpu, blocks_gpu);
-    ), ());  // NOLINT
-  ), ());  // NOLINT
+    ));  // NOLINT
+  ));  // NOLINT
   CUDA_CALL(cudaGetLastError());
 }
 

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_cpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_cpu.h
@@ -223,8 +223,8 @@ void SliceFlipNormalizePermutePadKernel(
   bool has_channels = channel_dim >= 0;
   bool need_normalize = (mean != nullptr && inv_stddev != nullptr);
   // Convert switch argument to `int` to avoid compiler warning about unreachable case label
-  VALUE_SWITCH(need_normalize ? 1 : 0, NeedNormalize, (false, true), (
-    VALUE_SWITCH(has_channels ? 1 : 0, HasChannels, (false, true), (
+  BOOL_SWITCH(need_normalize, NeedNormalize, (
+    BOOL_SWITCH(has_channels, HasChannels, (
       if (need_pad) {
         constexpr bool OutOfBounds = false;
         detail::SliceFlipNormalizePermutePadKernelImpl<NeedNormalize, HasChannels, OutOfBounds>(
@@ -237,8 +237,8 @@ void SliceFlipNormalizePermutePadKernel(
             out_shape.data(), mean, inv_stddev, channel_dim,
             std::integral_constant<int, Dims>());
       }
-    ), ());  // NOLINT
-  ), ());  // NOLINT
+    ));  // NOLINT
+  ));  // NOLINT
 }
 
 template <typename OutputType, typename InputType, int Dims>

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -240,18 +240,18 @@ class SliceFlipNormalizePermutePadGpu {
         make_span(sample_descs_cpu, num_samples),
         make_span(block_descs_cpu, block_count_));
 
-    VALUE_SWITCH(need_pad ? 1 : 0, NeedPad, (false, true), (
-      VALUE_SWITCH(need_flip ? 1 : 0, NeedFlip, (false, true), (
-        VALUE_SWITCH(need_normalize_ ? 1 : 0, NeedNormalize, (false, true), (
+    BOOL_SWITCH(need_pad, NeedPad, (
+      BOOL_SWITCH(need_flip, NeedFlip, (
+        BOOL_SWITCH(need_normalize_, NeedNormalize, (
           auto grid = block_count_;
           // need to handle __half due to compilation differences
           detail::SliceFlipNormalizePermutePadKernel
             <NeedPad, NeedFlip, NeedNormalize,
             OutputType, InputType, Dims>
             <<<grid, kBlockDim, 0, context.gpu.stream>>>(sample_descs_gpu, block_descs_gpu);
-        ), ());  // NOLINT
-      ), ());  // NOLINT
-    ), ());  // NOLINT
+        ));  // NOLINT
+      ));  // NOLINT
+    ));  // NOLINT
 
     CUDA_CALL(cudaGetLastError());
   }

--- a/dali/kernels/test/static_switch_test.cc
+++ b/dali/kernels/test/static_switch_test.cc
@@ -124,11 +124,11 @@ TEST(StaticSwitch, BoolSwitch) {
   BOOL_SWITCH(a > 3, BoolConst, (
     std::integral_constant<bool, BoolConst> constant;
     ASSERT_TRUE(constant);
-  ));
+  ));  // NOLINT
 
   BOOL_SWITCH(a < 3, BoolConst, (
     std::integral_constant<bool, BoolConst> constant;
     ASSERT_FALSE(constant);
-  ));
+  ));  // NOLINT
 }
 

--- a/dali/kernels/test/static_switch_test.cc
+++ b/dali/kernels/test/static_switch_test.cc
@@ -118,3 +118,17 @@ TEST(StaticSwitch, DALIDataType) {
     )); // NOLINT
   }
 }
+
+TEST(StaticSwitch, BoolSwitch) {
+  int a = 7;
+  BOOL_SWITCH(a > 3, BoolConst, (
+    std::integral_constant<bool, BoolConst> constant;
+    ASSERT_TRUE(constant);
+  ));
+
+  BOOL_SWITCH(a < 3, BoolConst, (
+    std::integral_constant<bool, BoolConst> constant;
+    ASSERT_FALSE(constant);
+  ));
+}
+

--- a/dali/operators/image/remap/warp.h
+++ b/dali/operators/image/remap/warp.h
@@ -302,7 +302,7 @@ class Warp : public Operator<Backend> {
     output_type_ = output_type_arg_ == DALI_NO_TYPE ? input_type_ : output_type_arg_;
 
     VALUE_SWITCH(This().SpatialDim(), spatial_ndim, (2, 3), (
-      VALUE_SWITCH(This().BorderClamp() ? 1 : 0, UseBorderClamp, (0, 1), (
+      BOOL_SWITCH(This().BorderClamp(), UseBorderClamp, (
           ToStaticType(
             [&](auto &&args) {
             using OutputType = decltype(args.first);
@@ -319,8 +319,7 @@ class Warp : public Operator<Backend> {
               auto param_provider = This().template CreateParamProvider<spatial_ndim, BorderType>();
               impl_.reset(new ImplType(Spec(), std::move(param_provider)));
             }
-          });),
-          (assert(!"impossible")))),
+          });))),
         (DALI_FAIL("Only 2D and 3D warping is supported")));
 
 

--- a/include/dali/core/static_switch.h
+++ b/include/dali/core/static_switch.h
@@ -135,4 +135,27 @@
   { BOOST_PP_REMOVE_PARENS(default_); } \
   }
 
+/// Pastes the case_ code specialized for true and false values.
+/// The specialization is performed by aliasing a value with a constant named constant_name_
+/// @param expr_       - a boolean expression to switch by
+/// @param const_name_ - a name given for the constexpr bool variable.
+/// @param code_       - code to execute for true and false
+///
+/// Usage:
+/// ```
+/// BOOL_SWITCH(flag, BoolConst, (
+///     std::integral_constant<bool, BoolConst> constant;
+///     some_function<BoolConst>(...);
+///   )
+/// )
+/// ```
+#define BOOL_SWITCH(expr_, const_name_, code_)   \
+  if (expr_) {                                   \
+    constexpr bool const_name_ = true;           \
+    BOOST_PP_REMOVE_PARENS(code_);               \
+  } else {                                       \
+    constexpr bool const_name_ = false;          \
+    BOOST_PP_REMOVE_PARENS(code_);               \
+  }
+
 #endif  // DALI_CORE_STATIC_SWITCH_H_


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds a new macro to replace VALUE_SWITCH macro for boolean expressions. The aim is to simplify the code for bool value switches.*

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a BOOL_SWITCH macro and replaced usages of bool VALUE_SWITCH with the new macro.*
 - Affected modules and functionalities:
     *Operators using VALUE_SWITCH with bool expressions.*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *Test added*
 - Documentation (including examples):
     *Comments in the macro definition*


**JIRA TASK**: *[NA]*
