### PR TITLE
Enable SaltAndPepper GPU variable batch size tests

### DIFF
--- a/dali/test/python/test_dali_variable_batch_size.py
+++ b/dali/test/python/test_dali_variable_batch_size.py
@@ -289,7 +289,7 @@ random_ops = [
     (fn.random_resized_crop, {'size': 69}),
     (fn.noise.gaussian, {}),
     (fn.noise.shot, {}),
-    (fn.noise.salt_and_pepper, {'devices': ['cpu']}),  # TODO(janton): Enalble GPU once salt_and_pepper supports it.
+    (fn.noise.salt_and_pepper, {}),
 ]
 
 def test_random_ops():


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It enables variable batch size tests for SaltAndPepper GPU operator

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Enabled variable batch size Salt and pepper tests for both cpu and gpu backends*
 - Affected modules and functionalities:
     *Salt and pepper, variable batch size tests*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[NA]*
