### PR TITLE
Add a link to the DALI roadmap in the main readme and the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,20 @@ Highlights
 
 ----
 
+DALI Roadmap
+------------
+
+|dali-roadmap-link|_ a high-level overview of our 2021 plan. You should be aware that this
+roadmap may change at any time and the order below does not reflect any type of priority.
+
+We strongly encourage you to comment on our roadmap and provide us feedback on the mentioned
+GitHub issue.
+
+.. |dali-roadmap-link| replace:: The following represents
+.. _dali-roadmap-link: https://github.com/NVIDIA/DALI/issues/2978
+
+----
+
 Installing DALI
 ---------------
 

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ roadmap may change at any time and the order below does not reflect any type of 
 We strongly encourage you to comment on our roadmap and provide us feedback on the mentioned
 GitHub issue.
 
-.. |dali-roadmap-link| replace:: The following represents
+.. |dali-roadmap-link| replace:: The following issue represents
 .. _dali-roadmap-link: https://github.com/NVIDIA/DALI/issues/2978
 
 ----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,3 +65,4 @@ NVIDIA DALI Documentation
 
    Release Notes <https://docs.nvidia.com/deeplearning/dali/release-notes/index.html>
    GitHub <https://github.com/NVIDIA/DALI>
+   Roadmap <https://github.com/NVIDIA/DALI/issues/2978>


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds a link to the DALI roadmap in the main readme and the documentation

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a link to the DALI roadmap in the main readme and the documentation
 - Affected modules and functionalities:
     documentation index page, main README
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     only documentation is affected


**JIRA TASK**: *[DALI-2091]*
