### PR TITLE
Add synchronization and deferred deallocation to pool_resource

### DIFF
--- a/dali/core/mm/pool_resource_test.cc
+++ b/dali/core/mm/pool_resource_test.cc
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <random>
 #include <vector>
+#include <chrono>
 #include "dali/core/mm/mm_test_utils.h"
 #include "dali/core/mm/pool_resource.h"
 
@@ -99,6 +100,98 @@ TEST(MMPoolResource, ReturnToUpstream) {
     }
   }
   upstream.check_leaks();
+}
+
+TEST(MMPoolResource, TestBulkDeallocate) {
+  test_host_resource upstream;
+  {
+    pool_options opts;
+    opts.min_block_size = 1000000;
+    pool_resource_base<memory_kind::host, any_context, free_tree, detail::dummy_lock>
+      pool(&upstream, opts);
+    vector<dealloc_params> params;
+    std::mt19937_64 rng(12345);
+    std::uniform_int_distribution<int> align_dist(0, 8);  // alignment anywhere from 1B to 256B
+    std::poisson_distribution<int> size_dist(128);
+    for (int i = 0; i < 100; i++) {
+      dealloc_params par;
+      par.bytes = size_dist(rng);
+      if (par.bytes > 8192) par.bytes = 8192;  // make sure we fit in the preallocated size
+      par.alignment = 1 << align_dist(rng);
+      par.ptr = pool.allocate(par.bytes, par.alignment);
+      params.push_back(par);
+    }
+    pool.bulk_deallocate(make_span(params));  // free everything
+    for (auto &par : params) {
+      void *p = pool.allocate(par.bytes, par.alignment);
+      EXPECT_EQ(p, par.ptr);  // now we should get the same pointers
+    }
+    pool.bulk_deallocate(make_span(params));
+  }
+  upstream.check_leaks();
+}
+
+namespace {
+
+template <memory_kind kind, typename Context = any_context>
+class test_defer_dealloc
+    : public detail::deferred_deallocator<test_defer_dealloc<kind, Context>>
+    , public pool_resource_base<kind, Context, free_tree, detail::dummy_lock> {
+ public:
+  using pool = pool_resource_base<kind, Context, free_tree, detail::dummy_lock>;
+  bool ready() const noexcept {
+    return this->no_pending_deallocs();
+  }
+
+  explicit test_defer_dealloc(memory_resource<kind, Context> *upstream) : pool(upstream) {}
+
+  void check() {
+    // wait up to 1 second for the deferred deallocations to drain
+    for (int t = 0; !ready() && t < 100; t++)
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    EXPECT_TRUE(ready()) << "Timeout - the resource should be ready by this time.";
+    // Now go over all blocks and see if they are all free - that will tell us
+    // if all blocks were properly freed.
+    for (auto &b : this->blocks_) {
+      EXPECT_TRUE(this->free_list_.remove_if_in_list(b.ptr, b.bytes))
+        << "All allocations should have been deallocated";
+      this->free_list_.put(b.ptr, b.bytes);
+    }
+  }
+};
+
+}  // namespace
+
+TEST(MMPoolResource, DeferredCheckAsync) {
+  test_pinned_resource upstream;
+  {
+    test_defer_dealloc<memory_kind::pinned> pool(&upstream);
+    const int max_attempts = 10000;
+    bool success = false;
+    for (int i = 0; i < max_attempts; i++) {
+      int size = 100 * (i + 1);
+      void *p1 = pool.allocate(size);
+      void *p2 = pool.allocate(size);
+      pool.deferred_deallocate(p1, size);
+      pool.deferred_deallocate(p2, size);
+      bool ready = pool.ready();
+      void *p3 = pool.allocate(size);
+      if (p1 != p3 && !ready) {
+        success = true;  // ok, the deallocation was truly asynchrounous
+        pool.deferred_deallocate(p3, size);
+        break;
+      } else {
+        // recheck to avoid race condition
+        ready = pool.ready();
+        pool.deferred_deallocate(p3, size);
+        ASSERT_TRUE(ready) << "The resource returned two identical pointers "
+                              "but the deallocation is reported as incomplete.\n";
+      }
+      pool.check();
+    }
+    EXPECT_TRUE(success) << "All deallocations finished immediately in "
+                         << max_attempts << " attemtps.";
+  }
 }
 
 }  // namespace test


### PR DESCRIPTION
* Add synchronization
* Add bulk deallocation
* Add deferred bulk deallocation utility
* Use deferred deallocation in async_pool

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in #2948 - memory reused before usage is complete
- It adds new feature: deferred deallocation, which improves performance

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * `pool_resource` now synchronizes when calling `deallocate`. The synchronization scope is configurable.
     * `pool_resource` exposes `deallocate_no_sync` in which the caller guarantees that the memory can be reused immediately
     * `pool_resource` exposes `bulk_deallocate` which allows to free multiple blocks with just one synchronization and lock
     * `deferred_deallocator` collects deallocation requests and issues them in bulk in a worker thread
     * `deferred_dealloc_pool` uses deferred deallocator to implement `do_deallocate`
     * `async_pool` now uses `deferred_dealloc_pool`
     * `pool_options` have configurable synchronization scope and limit max. outstanding deallocations
 - Affected modules and functionalities:
     * Memory manager: pool, async pool
 - Key points relevant for the review:
     * Synchronization issues
 - Validation and testing:
     * Unit tests:
         * check bulk deallocation
         * check deferred deallocator with a test CRTP class
         * modify `async_pool` test to use one thread with non-stream allocation/deallocation
      * NOTE: I've confirmed experimentally under stress conditions that bulk asyncrhonous deallocation actually occurs and that this code path is actually used. Unit tests can't check that.
 - Documentation (including examples):
     * Doxygen

**JIRA TASK**: DALI-2095 DALI-2096
