### PR TITLE
Add Preemphasis border policy

### DIFF
--- a/dali/operators/audio/preemphasis_filter_op.h
+++ b/dali/operators/audio/preemphasis_filter_op.h
@@ -15,6 +15,7 @@
 #ifndef DALI_OPERATORS_AUDIO_PREEMPHASIS_FILTER_OP_H_
 #define DALI_OPERATORS_AUDIO_PREEMPHASIS_FILTER_OP_H_
 
+#include <string>
 #include <vector>
 #include "dali/core/convert.h"
 #include "dali/core/static_switch.h"
@@ -28,7 +29,7 @@ namespace dali {
 namespace detail {
 
 const std::string kCoeff = "preemph_coeff";  // NOLINT
-const std::string kReflectPadding = "reflect_padding";  // NOLINT
+const std::string kBorder = "border";  // NOLINT
 const int kNumOutputs = 1;
 
 }  // namespace detail
@@ -36,10 +37,26 @@ const int kNumOutputs = 1;
 template<typename Backend>
 class PreemphasisFilter : public Operator<Backend> {
  public:
+  enum class BorderType : uint8_t {
+    Zero = 0,
+    Clamp,
+    Reflect,
+  };
+
   explicit PreemphasisFilter(const OpSpec &spec)
       : Operator<Backend>(spec),
-        output_type_(spec.GetArgument<DALIDataType>(arg_names::kDtype)),
-        reflect_padding_(spec.GetArgument<bool>(detail::kReflectPadding)) {}
+        output_type_(spec.GetArgument<DALIDataType>(arg_names::kDtype)) {
+    auto border_str = spec.GetArgument<std::string>(detail::kBorder);
+    if (border_str == "zero") {
+      border_type_ = BorderType::Zero;
+    } else if (border_str == "reflect") {
+      border_type_ = BorderType::Reflect;
+    } else if (border_str == "clamp") {
+      border_type_ = BorderType::Clamp;
+    } else {
+      DALI_FAIL(make_string("``border`` mode \"", border_str, "\" is not supported."));
+    }
+  }
 
   ~PreemphasisFilter() override = default;
   DISABLE_COPY_MOVE_ASSIGN(PreemphasisFilter);
@@ -68,7 +85,7 @@ class PreemphasisFilter : public Operator<Backend> {
   USE_OPERATOR_MEMBERS();
   std::vector<float> preemph_coeff_;
   const DALIDataType output_type_;
-  bool reflect_padding_;
+  BorderType border_type_;
 };
 
 }  // namespace dali

--- a/dali/operators/audio/preemphasis_filter_op.h
+++ b/dali/operators/audio/preemphasis_filter_op.h
@@ -28,6 +28,7 @@ namespace dali {
 namespace detail {
 
 const std::string kCoeff = "preemph_coeff";  // NOLINT
+const std::string kReflectPadding = "reflect_padding";  // NOLINT
 const int kNumOutputs = 1;
 
 }  // namespace detail
@@ -36,7 +37,9 @@ template<typename Backend>
 class PreemphasisFilter : public Operator<Backend> {
  public:
   explicit PreemphasisFilter(const OpSpec &spec)
-      : Operator<Backend>(spec), output_type_(spec.GetArgument<DALIDataType>(arg_names::kDtype)) {}
+      : Operator<Backend>(spec),
+        output_type_(spec.GetArgument<DALIDataType>(arg_names::kDtype)),
+        reflect_padding_(spec.GetArgument<bool>(detail::kReflectPadding)) {}
 
   ~PreemphasisFilter() override = default;
   DISABLE_COPY_MOVE_ASSIGN(PreemphasisFilter);
@@ -65,6 +68,7 @@ class PreemphasisFilter : public Operator<Backend> {
   USE_OPERATOR_MEMBERS();
   std::vector<float> preemph_coeff_;
   const DALIDataType output_type_;
+  bool reflect_padding_;
 };
 
 }  // namespace dali

--- a/dali/test/python/test_operator_preemph.py
+++ b/dali/test/python/test_operator_preemph.py
@@ -57,7 +57,7 @@ class PreemphasisPipeline(Pipeline):
             return self.preemph(out)
 
 class PreemphasisPythonPipeline(Pipeline):
-    def __init__(self, device, batch_size, iterator, border='clamp', preemph_coeff=0.97, reflect=True, per_sample_coeff=False,
+    def __init__(self, device, batch_size, iterator, border='clamp', preemph_coeff=0.97, per_sample_coeff=False,
                  num_threads=4, device_id=0):
         super(PreemphasisPythonPipeline, self).__init__(batch_size, num_threads, device_id, seed=SEED,
                                                         exec_async=False, exec_pipelined=False)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to be consistent with other preemphasis filter implementations.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a "border" option to Preemphasis filter operator, used to determine the padding behavior at the first sample. The possible values are zero-padding, clamping to repeat the border sample, or reflect padding. By default, clamping is used.*
 - Affected modules and functionalities:
     *Preemphasis operator*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *Tests added*
 - Documentation (including examples):
     *Docstr*


**JIRA TASK**: *[DALI-2084]*
