### PR TITLE
Add missing include <functional>

### DIFF
--- a/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.h
+++ b/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.h
@@ -18,6 +18,7 @@
 #include <cuda_runtime.h>
 #include <memory>
 #include <string>
+#include <functional>
 #include "dali/core/dynlink_cuda.h"
 #include "nvOpticalFlowCuda.h"
 #include "nvOpticalFlowCommon.h"


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a minor problem: missing `#include <functional>` in a file using `std::function`

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added the missing include
 - Affected modules and functionalities:
     * Optical flow (no functional change)
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Build
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
