### PR TITLE
Fix a buffer overrun when the trailing dimension is collapsed.

### DIFF
--- a/dali/operators/audio/mel_scale/mel_filter_bank_gpu.cc
+++ b/dali/operators/audio/mel_scale/mel_filter_bank_gpu.cc
@@ -48,6 +48,7 @@ void MelFilterBank<GPUBackend>::RunImpl(workspace_t<GPUBackend> &ws) {
   const auto &input = ws.InputRef<GPUBackend>(0);
   auto &output = ws.OutputRef<GPUBackend>(0);
   const auto &in_shape = input.shape();
+  ctx_.gpu.stream = ws.stream();
   TYPE_SWITCH(input.type().id(), type2id, T, MEL_FBANK_SUPPORTED_TYPES, (
     using MelFilterBankKernel = kernels::audio::MelFilterBankGpu<T>;
     auto in_view = view<const T>(input);


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: buffer overrun in  GPU MelFilterBank
      The bug manifested itself when I tried to use suballocators that don't have quite as generous padding as plain cudaMalloc

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Use only dimensions up to `axis` when computing the volume for InnerFFT case
 - Affected modules and functionalities:
     * MelFilterBank GPU
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * cudaMemcheck run on the test
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
