### PR TITLE
Use thread_pool in ColorSpaceConversion

### DIFF
--- a/dali/operators/image/color/color_space_conversion.cc
+++ b/dali/operators/image/color/color_space_conversion.cc
@@ -39,17 +39,22 @@ void ColorSpaceConversion<CPUBackend>::RunImpl(HostWorkspace &ws) {
   const auto &out_sh = out_view.shape;
   int nsamples = in_sh.num_samples();
   int ndim = in_sh.sample_dim();
+  auto& thread_pool = ws.GetThreadPool();
   for (int i = 0; i < nsamples; i++) {
-    auto in_sample_sh = in_sh.tensor_shape_span(i);
-    // flatten any leading dimensions together with the height
-    int height = volume(in_sample_sh.begin(), in_sample_sh.end() - 2);
-    int width  = in_sample_sh[ndim - 2];
-    auto cv_in =
-        CreateMatFromPtr(height, width, GetOpenCvChannelType(in_nchannels_), in_view[i].data);
-    auto cv_out =
-        CreateMatFromPtr(height, width, GetOpenCvChannelType(out_nchannels_), out_view[i].data);
-    OpenCvColorConversion(input_type_, cv_in, output_type_, cv_out);
+    thread_pool.AddWork(
+      [&, i](int thread_id) {
+        auto in_sample_sh = in_sh.tensor_shape_span(i);
+        // flatten any leading dimensions together with the height
+        int height = volume(in_sample_sh.begin(), in_sample_sh.end() - 2);
+        int width  = in_sample_sh[ndim - 2];
+        auto cv_in =
+          CreateMatFromPtr(height, width, GetOpenCvChannelType(in_nchannels_), in_view[i].data);
+        auto cv_out =
+          CreateMatFromPtr(height, width, GetOpenCvChannelType(out_nchannels_), out_view[i].data);
+        OpenCvColorConversion(input_type_, cv_in, output_type_, cv_out);
+      }, in_sh.tensor_size(i));
   }
+  thread_pool.RunAll();
 }
 
 DALI_REGISTER_OPERATOR(ColorSpaceConversion, ColorSpaceConversion<CPUBackend>, CPU);


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to improve performance in ColorSpaceConversion

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Use thread pool to process samples in parallel*
 - Affected modules and functionalities:
     *ColorSpaceConversion*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-2106]*
