### PR TITLE
pool_resource: upstream lock & refactoring

### DIFF
--- a/dali/core/mm/pool_resource_test.cc
+++ b/dali/core/mm/pool_resource_test.cc
@@ -135,10 +135,9 @@ namespace {
 
 template <memory_kind kind, typename Context = any_context>
 class test_defer_dealloc
-    : public detail::deferred_deallocator<test_defer_dealloc<kind, Context>>
-    , public pool_resource_base<kind, Context, free_tree, detail::dummy_lock> {
+    : public deferred_dealloc_pool<kind, Context, free_tree, spinlock> {
  public:
-  using pool = pool_resource_base<kind, Context, free_tree, detail::dummy_lock>;
+  using pool = deferred_dealloc_pool<kind, Context, free_tree, spinlock>;
   bool ready() const noexcept {
     return this->no_pending_deallocs();
   }


### PR DESCRIPTION
* Add an upstream lock.
* Simplify the deferred dealloc structure - remove CRTP, use plain inheritance.
* Wait for outstanding deallocations on upstream alloc failure.

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes bugs:
    - potentially allocating multiple upstream blocks if there's an allocation stampede and the pool is empty
    - potential race condition in access to next block size
    - outstanding deallocations are not flished even if upstream allocation fails
- Refactoring to simplify the relationship between pool resource and deferred deallocation

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Add upstream lock
     * Add `flush_deferred` to pool_resource
     * Move deferred deallocation functionality directly to 
 - Affected modules and functionalities:
     * pool resource
 - Key points relevant for the review:
     * Locking and synchronization
     * Inheritance structure
 - Validation and testing:
     * Exsisting tests apply
 - Documentation (including examples):
     * Doxygen

**JIRA TASK**: N/A
