### PR TITLE
Adjust tf code for experimental Dataset with inputs

### DIFF
--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -57,20 +57,20 @@ The operator adds additional parameters to the ones supported by the
 
 Parameters
 ----------
-    `input_datasets` : `tf.data.Dataset` or `tuple` of `tf.data.Dataset`, optional, default = None
+    input_datasets : tf.data.Dataset or tuple of tf.data.Dataset, optional, default = None
         input datasets to the DALI Pipeline. When provided, user must specify the ``input_names``
-        as well to provide the mapping of input datasets to `External Source` nodes.
-    `input_names` : `str` or `tuple` of `str`, optional, default = None
+        as well to provide the mapping of input datasets to ``External Source`` nodes.
+    input_names : str or tuple of str, optional, default = None
         names of inputs to the DALI Pipeline. Must match arity of the ``input_datasets``.
         ``input_datasets[i]`` will be provided to the external source instance with the name
         ``input_names[i]``.
-    `input_layouts` : `str` or `tuple` of `str`, optional, default = None
+    input_layouts : str or tuple of str, optional, default = None
         layouts of inputs to the DALI Pipeline. Must match arity of the ``input_datasets``.
         ``input_layouts[i]`` will be set for ``input_datasets[i]`` provided to the external source
         instance with the name ``input_names[i]``.
         If not provided while specifying the ``input_datasets``, an empty layout string will be
         used.
-    `input_batch` : bool, optional, default = False
+    input_batch : bool, optional, default = False
         batch mode for the input datasets. Only the default - sample mode - is supported,
         that is ``input_batch = False``.
         Sample mode means that every input dataset is treated as if providing individual samples.
@@ -401,64 +401,65 @@ else:
     _load_experimental_dataset()
 
 
-DALIDataset.__doc__ = """Creates a `DALIDataset` compatible with tf.data.Dataset from a DALI pipeline. It supports TensorFlow 1.15 and 2.x family
+DALIDataset.__doc__ = """Creates a `DALIDataset` compatible with tf.data.Dataset from a DALI
+    pipeline. It supports TensorFlow 1.15 and 2.x family
 
 
-    Please keep in mind that TensorFlow allocates almost all available device memory by default. This might cause errors in
-    DALI due to insufficient memory. On how to change this behaviour please look into the TensorFlow documentation, as it may
-    differ based on your use case.
+    Please keep in mind that TensorFlow allocates almost all available device memory by default.
+    This might cause errors in DALI due to insufficient memory. On how to change this behaviour
+    please look into the TensorFlow documentation, as it may differ based on your use case.
 
     Parameters
     ----------
-    `pipeline` : `nvidia.dali.Pipeline`
+    pipeline : :class:`nvidia.dali.Pipeline`
         defining the data processing to be performed.
-    `output_dtypes`: `tf.DType` or `tuple` of `tf.DType`, default = None
+    output_dtypes: tf.DType or tuple of tf.DType, default = None
         expected output types
-    `output_shapes`: tuple of shapes, optional, default = None
-        expected output shapes. If provided, must match arity of the `output_dtypes`.
+    output_shapes: tuple of shapes, optional, default = None
+        expected output shapes. If provided, must match arity of the ``output_dtypes``.
         When set to None, DALI will infer the shapes on its own.
         Individual shapes can be also set to None or contain None to indicate unknown dimensions.
         If specified must be compatible with shape returned from DALI Pipeline
-        and with `batch_size` argument which will be the outermost dimension of returned tensors.
-        In case of `batch_size = 1` it can be omitted in the shape.
+        and with ``batch_size`` argument which will be the outermost dimension of returned tensors.
+        In case of ``batch_size = 1`` it can be omitted in the shape.
         DALI Dataset will try to match requested shape by squeezing 1-sized dimensions
         from shape obtained from Pipeline.
-    `fail_on_device_mismatch` : bool, optional, default = True
-        When set to `True` runtime check will be performed to ensure DALI device and TF device are
-        both CPU or both GPU. In some contexts this check might be inaccurate. When set to `False`
+    fail_on_device_mismatch : bool, optional, default = True
+        When set to ``True`` runtime check will be performed to ensure DALI device and TF device are
+        both CPU or both GPU. In some contexts this check might be inaccurate. When set to ``False``
         will skip the check but print additional logs to check the devices. Keep in mind that this
         may allow hidden GPU to CPU copies in the workflow and impact performance.
-    `batch_size` : int, optional, default = 1
+    batch_size : int, optional, default = 1
         batch size of the pipeline.
-    `num_threads` : int, optional, default = 4
+    num_threads : int, optional, default = 4
         number of CPU threads used by the pipeline.
-    `device_id` : int, optional, default = 0
+    device_id : int, optional, default = 0
         id of GPU used by the pipeline.
         A None value for this parameter means that DALI should not use GPU nor CUDA runtime.
         This limits the pipeline to only CPU operators but allows it to run on any CPU capable machine.
-    `exec_separated` : bool, optional, default = False
+    exec_separated : bool, optional, default = False
         Whether to execute the pipeline in a way that enables
         overlapping CPU and GPU computation, typically resulting
         in faster execution speed, but larger memory consumption.
-    `prefetch_queue_depth` : int, optional, default = 2
+    prefetch_queue_depth : int, optional, default = 2
         depth of the executor queue. Deeper queue makes DALI more
         resistant to uneven execution time of each batch, but it also
         consumes more memory for internal buffers.
-        Value will be used with `exec_separated` set to False.
-    `cpu_prefetch_queue_depth` : int, optional, default = 2
+        Value will be used with ``exec_separated`` set to ``False``.
+    cpu_prefetch_queue_depth : int, optional, default = 2
         depth of the executor cpu queue. Deeper queue makes DALI more
         resistant to uneven execution time of each batch, but it also
         consumes more memory for internal buffers.
-        Value will be used with `exec_separated` set to True.
-    `gpu_prefetch_queue_depth` : int, optional, default = 2
+        Value will be used with ``exec_separated`` set to ``True``.
+    gpu_prefetch_queue_depth : int, optional, default = 2
         depth of the executor gpu queue. Deeper queue makes DALI more
         resistant to uneven execution time of each batch, but it also
         consumes more memory for internal buffers.
-        Value will be used with `exec_separated` set to True.
+        Value will be used with ``exec_separated`` set to ``True``.
 
     Returns
     -------
-    `DALIDataset` object based on DALI pipeline and compatible with `tf.data.Dataset` API.
+    ``DALIDataset`` object based on DALI pipeline and compatible with ``tf.data.Dataset`` API.
 
     """
 

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import tensorflow as tf
 from tensorflow.python.data.util import nest
 from tensorflow.python.framework import tensor_shape
 from nvidia.dali import types
+from nvidia.dali import internal as _internal
 
 from collections import Iterable
 from distutils.version import LooseVersion
@@ -30,6 +33,48 @@ _dali_tf.__doc__ = _dali_tf.__doc__ + """
     Please keep in mind that TensorFlow allocates almost all available device memory by default. This might cause errors in
     DALI due to insufficient memory. On how to change this behaviour please look into the TensorFlow documentation, as it may
     differ based on your use case.
+"""
+
+
+_experimental_dataset_docstring = """Experimental variant of
+:class:`~nvidia.dali.plugin.tf.DALIDataset`. This dataset adds support for input tf.data.Datasets.
+
+Each of the input datasets must be mapped to a :meth:`~nvidia.dali.fn.external_source` operator
+that will represent the input to the DALI pipeline. The input is represented by the ``name``
+parameter of :meth:`~nvidia.dali.fn.external_source` and needs to be provided for corresponding
+input dataset via the ``input_names`` argument of DALIDatasetWithInputs.
+
+.. warning::
+    This class is experimental and its API might change without notice.
+
+
+.. warning::
+    This version of the class is just API placeholder and the functionality is not yet implemented.
+
+The operator adds additional parameters to the ones supported by the
+:class:`~nvidia.dali.plugin.tf.DALIDataset`:
+
+    Parameters
+    ----------
+    `input_datasets` : `tf.data.Dataset` or `tuple` of `tf.data.Dataset`, optional, default = None
+        input datasets to the DALI Pipeline. When provided, user must specify the `input_names`
+        as well to provide the mapping of input datasets to `External Source` nodes.
+    `input_names` : `str` or `tuple` of `str`, optional, default = None
+        names of inputs to the DALI Pipeline. Must match arity of the `input_datasets`.
+        `input_datasets[i]` will be provided to `External Source` of the name `input_names[i]`.
+    `input_layouts` : `str` or `tuple` of `str`, optional, default = None
+        layouts of inputs to the DALI Pipeline. Must match arity of the `input_datasets`.
+        `input_layouts[i]` will be set for `input_datasets[i]` provided to `External Source`
+        of the name `input_names[i]`.
+        If not provided while specifying the input_datasets, empty layout string will be used.
+    `input_batch` : bool, optional, default = False
+        batch mode for the input datasets. Only the default - sample mode - is supported,
+        that is `input_batch = False`.
+        Sample mode means that every input dataset is treated as if providing individual samples.
+        DALIDataset will query the inputs dataset `batch_size`-times to build a batch that would
+        be fed into the DALI Pipeline.
+        In sample mode, each sample produced by the input dataset can have different shape,
+        but not number of dimensions.
 """
 
 
@@ -144,10 +189,14 @@ MIN_TENSORFLOW_VERSION = LooseVersion('1.15')
 
 
 def dataset_compatible_tensorflow():
+    """Returns ``True`` if current TensorFlow version is compatible with DALIDataset."""
     return LooseVersion(tf.__version__) >= MIN_TENSORFLOW_VERSION
 
 
 def dataset_distributed_compatible_tensorflow():
+    """Returns ``True`` if the tf.distribute APIs for current TensorFlow version are compatible
+    with DALIDataset.
+    """
     return LooseVersion(tf.__version__) >= LooseVersion('2.5.0')
 
 
@@ -281,11 +330,35 @@ if dataset_compatible_tensorflow():
     else:
         _DALIDatasetImpl = _DALIDatasetV2
 
+    _experimental_kwargs = ['input_datasets', 'input_names', 'input_layouts', 'input_batch']
+
     class DALIDataset(dataset_ops._OptionsDataset):
         @functools.wraps(_DALIDatasetV2.__init__)
         def __init__(self, pipeline, **kwargs):
+            for disallowed_kwarg in _experimental_kwargs:
+                if disallowed_kwarg in kwargs.keys():
+                    raise TypeError("__init__() got an unexpected keyword argument '{}'".format(disallowed_kwarg))
             dataset_impl = _DALIDatasetImpl(pipeline, **kwargs)
             super(DALIDataset, self).__init__(dataset_impl, dataset_options())
+
+    def _load_experimental_dataset():
+        class DALIDatasetWithInputs(dataset_ops._OptionsDataset):
+            # @functools.wraps(_DALIDatasetV2.__init__)
+            def __init__(self, pipeline, **kwargs):
+                raise NotImplementedError("DALIDatasetWithInputs is only a placeholder operator.")
+
+                dataset_impl = _DALIDatasetImpl(pipeline, **kwargs)
+                super(DALIDataset, self).__init__(dataset_impl, dataset_options())
+
+
+        current_module = sys.modules[__name__]
+        experimental_module = _internal.get_submodule(current_module, "experimental")
+        DALIDatasetWithInputs.__module__ = experimental_module
+        DALIDatasetWithInputs.__doc__ = _experimental_dataset_docstring
+        setattr(experimental_module, "DALIDatasetWithInputs", DALIDatasetWithInputs)
+
+    _load_experimental_dataset()
+
 
 else:
 
@@ -308,6 +381,21 @@ else:
             raise RuntimeError(
                 'DALIDataset is not supported for detected version of TensorFlow.  DALIDataset supports versions: 1.15, 2.x family'
             )
+
+    def _load_experimental_dataset():
+        class DALIDatasetWithInputs:
+            def __init__(self, *args, **kwargs):
+                raise RuntimeError(
+                    'experimental.DALIDatasetWithInputs is not supported for detected version of TensorFlow. '
+                    + 'DALIDataset supports versions: 1.15, 2.x family')
+
+        current_module = sys.modules[__name__]
+        experimental_module = _internal.get_submodule(current_module, "experimental")
+        DALIDatasetWithInputs.__module__ = experimental_module
+        DALIDatasetWithInputs.__doc__ = _experimental_dataset_docstring
+        setattr(experimental_module, "DALIDatasetWithInputs", DALIDatasetWithInputs)
+
+    _load_experimental_dataset()
 
 
 DALIDataset.__doc__ = """Creates a `DALIDataset` compatible with tf.data.Dataset from a DALI pipeline. It supports TensorFlow 1.15 and 2.x family

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -41,7 +41,7 @@ _experimental_dataset_docstring = """Experimental variant of
 
 Each of the input datasets must be mapped to a :meth:`~nvidia.dali.fn.external_source` operator
 that will represent the input to the DALI pipeline. The input is represented by the ``name``
-parameter of :meth:`~nvidia.dali.fn.external_source` and needs to be provided for corresponding
+parameter of :meth:`~nvidia.dali.fn.external_source` and needs to be provided to the corresponding
 input dataset via the ``input_names`` argument of DALIDatasetWithInputs.
 
 .. warning::
@@ -49,32 +49,35 @@ input dataset via the ``input_names`` argument of DALIDatasetWithInputs.
 
 
 .. warning::
-    This version of the class is just API placeholder and the functionality is not yet implemented.
+    This version of the class is just an API placeholder and the functionality is not yet
+    implemented.
 
 The operator adds additional parameters to the ones supported by the
 :class:`~nvidia.dali.plugin.tf.DALIDataset`:
 
-    Parameters
-    ----------
+Parameters
+----------
     `input_datasets` : `tf.data.Dataset` or `tuple` of `tf.data.Dataset`, optional, default = None
-        input datasets to the DALI Pipeline. When provided, user must specify the `input_names`
+        input datasets to the DALI Pipeline. When provided, user must specify the ``input_names``
         as well to provide the mapping of input datasets to `External Source` nodes.
     `input_names` : `str` or `tuple` of `str`, optional, default = None
-        names of inputs to the DALI Pipeline. Must match arity of the `input_datasets`.
-        `input_datasets[i]` will be provided to `External Source` of the name `input_names[i]`.
+        names of inputs to the DALI Pipeline. Must match arity of the ``input_datasets``.
+        ``input_datasets[i]`` will be provided to the external source instance with the name
+        ``input_names[i]``.
     `input_layouts` : `str` or `tuple` of `str`, optional, default = None
-        layouts of inputs to the DALI Pipeline. Must match arity of the `input_datasets`.
-        `input_layouts[i]` will be set for `input_datasets[i]` provided to `External Source`
-        of the name `input_names[i]`.
-        If not provided while specifying the input_datasets, empty layout string will be used.
+        layouts of inputs to the DALI Pipeline. Must match arity of the ``input_datasets``.
+        ``input_layouts[i]`` will be set for ``input_datasets[i]`` provided to the external source
+        instance with the name ``input_names[i]``.
+        If not provided while specifying the ``input_datasets``, an empty layout string will be
+        used.
     `input_batch` : bool, optional, default = False
         batch mode for the input datasets. Only the default - sample mode - is supported,
-        that is `input_batch = False`.
+        that is ``input_batch = False``.
         Sample mode means that every input dataset is treated as if providing individual samples.
-        DALIDataset will query the inputs dataset `batch_size`-times to build a batch that would
+        DALIDataset will query the inputs dataset ``batch_size``-times to build a batch that would
         be fed into the DALI Pipeline.
-        In sample mode, each sample produced by the input dataset can have different shape,
-        but not number of dimensions.
+        In sample mode, each sample produced by the input dataset can have a different shape,
+        but not a different number of dimensions.
 """
 
 

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -351,7 +351,7 @@ if dataset_compatible_tensorflow():
                 raise NotImplementedError("DALIDatasetWithInputs is only a placeholder operator.")
 
                 dataset_impl = _DALIDatasetImpl(pipeline, **kwargs)
-                super(DALIDataset, self).__init__(dataset_impl, dataset_options())
+                super(DALIDatasetWithInputs, self).__init__(dataset_impl, dataset_options())
 
 
         current_module = sys.modules[__name__]

--- a/dali/test/python/test_dali_tf_dataset.py
+++ b/dali/test/python/test_dali_tf_dataset.py
@@ -19,7 +19,7 @@ import nvidia.dali.fn as fn
 import nvidia.dali.plugin.tf as dali_tf
 from nose.tools import raises
 
-from test_utils_tensorflow import get_pipeline
+from test_utils_tensorflow import get_image_pipeline
 
 
 @raises(Exception)
@@ -27,7 +27,7 @@ def test_different_num_shapes_dtypes():
     batch_size = 12
     num_threads = 4
 
-    dataset_pipeline = get_pipeline(batch_size, num_threads, 'cpu')
+    dataset_pipeline = get_image_pipeline(batch_size, num_threads, 'cpu')
     shapes = (
         (batch_size, 3, 224, 224),
         (batch_size, 1, 1),

--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import tensorflow as tf
+from nvidia.dali.plugin.tf.experimental import DALIDatasetWithInputs
 import nvidia.dali.plugin.tf as dali_tf
 from test_utils_tensorflow import *
 from nose.tools import raises, with_setup
@@ -34,7 +35,7 @@ def test_tf_dataset_wrong_placement_cpu():
     num_threads = 4
     iterations = 10
 
-    pipeline = get_pipeline(batch_size, num_threads, 'cpu', 0)
+    pipeline = get_image_pipeline(batch_size, num_threads, 'cpu', 0)
 
     with tf.device('/gpu:0'):
         dataset = get_dali_dataset_from_pipeline(
@@ -50,7 +51,7 @@ def test_tf_dataset_wrong_placement_gpu():
     num_threads = 4
     iterations = 10
 
-    pipeline = get_pipeline(batch_size, num_threads, 'gpu', 0)
+    pipeline = get_image_pipeline(batch_size, num_threads, 'gpu', 0)
 
     with tf.device('/cpu:0'):
         dataset = get_dali_dataset_from_pipeline(
@@ -58,6 +59,22 @@ def test_tf_dataset_wrong_placement_gpu():
 
     for sample in dataset:
         pass
+
+
+# Test if the experimental Dataset can be imported and that it is not yet implemented
+@raises(NotImplementedError)
+def test_tf_experimental_inputs_disabled():
+    pipeline = get_image_pipeline(4, 4, 'cpu', 0)
+    DALIDatasetWithInputs(pipeline)
+
+
+# Test if the TypeError is raised for unsupported arguments for regular DALIDataset
+@raises(TypeError)
+def test_tf_experimental_inputs_disabled():
+    pipeline = get_image_pipeline(4, 4, 'cpu', 0)
+    dali_tf.DALIDataset(pipeline,
+                        input_datasets=tf.data.Dataset.from_tensors(np.int32([42, 42])),
+                        input_names="test")
 
 
 # This test should be private (name starts with _) as it is called separately in L1

--- a/dali/test/python/test_dali_tf_dataset_graph.py
+++ b/dali/test/python/test_dali_tf_dataset_graph.py
@@ -33,7 +33,7 @@ def test_tf_dataset_wrong_placement_cpu():
     num_threads = 4
     iterations = 10
 
-    pipeline = get_pipeline(batch_size, num_threads, 'cpu', 0)
+    pipeline = get_image_pipeline(batch_size, num_threads, 'cpu', 0)
 
     with tf.device('/gpu:0'):
         dataset = get_dali_dataset_from_pipeline(
@@ -48,7 +48,7 @@ def test_tf_dataset_wrong_placement_gpu():
     num_threads = 4
     iterations = 10
 
-    pipeline = get_pipeline(batch_size, num_threads, 'gpu', 0)
+    pipeline = get_image_pipeline(batch_size, num_threads, 'gpu', 0)
 
     with tf.device('/cpu:0'):
         dataset = get_dali_dataset_from_pipeline(

--- a/dali/test/python/test_utils_tensorflow.py
+++ b/dali/test/python/test_utils_tensorflow.py
@@ -48,6 +48,7 @@ def available_gpus():
     return devices
 
 
+# ################################################################################################ #
 #
 # To test custom DALI pipeline and DALIDataset wrapper for it all the `run_tf_dataset_*`
 # routines accept two arguments:
@@ -68,7 +69,8 @@ def available_gpus():
 # to_image_dataset(image_pipeline_desc, device_str) -> tf.data.Dataset
 # image_pipeline_desc will be the tuple returned by the `get_pipeline_desc`, device_str
 # is the expected placement of the tested DALIDataset
-
+#
+# ################################################################################################ #
 
 def get_image_pipeline(batch_size, num_threads, device, device_id=0, shard_id=0, num_shards=1,
         def_for_dataset=False):

--- a/dali/test/python/test_utils_tensorflow.py
+++ b/dali/test/python/test_utils_tensorflow.py
@@ -20,6 +20,7 @@ import numpy as np
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.fn as fn
 import nvidia.dali.types as types
+from test_utils import to_array
 
 import tensorflow as tf
 from tensorflow.python.client import device_lib
@@ -61,7 +62,7 @@ def available_gpus():
 # Respective signatures:
 # get_pipeline_desc(batch_size, num_threads, device, device_id, shard_id, num_shards,
 #                  def_for_dataset) -> nvidia.dali.pipeline, shapes, dtypes
-# `def_for_dataset` - indicates if this function is invoked to create a basaline standalone
+# `def_for_dataset` - indicates if this function is invoked to create a baseline standalone
 #                     pipeline (False), or it will be wrapped into TF dataset (True)
 # It is supposed to return a tuple that also describes the shapes and dtypes returned by the pipe.
 #
@@ -208,13 +209,7 @@ def run_pipeline(pipelines, iterations, device):
         shard_outputs = []
         for pipeline in pipelines:
             pipe_outputs = pipeline.run()
-            if device == 'gpu':
-                shard_outputs.append(
-                    tuple(result.as_cpu().as_array() for result in pipe_outputs))
-            else:
-                shard_outputs.append(
-                    tuple(result.as_array() for result in pipe_outputs))
-
+            shard_outputs.append(tuple(to_array(result) for result in pipe_outputs))
         results.append(tuple(shard_outputs))
     return results
 

--- a/docs/plugins/tensorflow_plugin_api.rst
+++ b/docs/plugins/tensorflow_plugin_api.rst
@@ -5,3 +5,7 @@ TensorFlow Plugin API reference
    :members:
    :undoc-members:
 
+Experimental
+------------
+
+.. autofunction:: nvidia.dali.plugin.tf.experimental.DALIDatasetWithInputs


### PR DESCRIPTION
* Add placeholder Dataset
* Expose it in documentation
* Adjust the TF Dataset tests for custom pipeline/dataset
  definition.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- Refactoring as a first step to add inputs to TF dataset

#### What happened in this PR?
 - What solution was applied:
     Dynamic nvidia.dali.plugin.tf.experimental module added for the placeholder Dataset.
     Tests extended to allow for custom pipeline/dataset pair to be specified.
 - Affected modules and functionalities:
     tf api & docs, tf-dataset tests
 - Key points relevant for the review:
     Mostly the tf api "changes"?
 - Validation and testing:
     CI, local testing, :eyes: for docs
 - Documentation (including examples):
     Yes


**JIRA TASK**: *[Use DALI-XXXX or NA]*
