### PR TITLE
Rename free_tree to coalescing_free_tree.

### DIFF
--- a/dali/core/mm/async_pool_test.cu
+++ b/dali/core/mm/async_pool_test.cu
@@ -55,7 +55,7 @@ TEST(MMAsyncPool, SingleStreamReuse) {
   CUDAStream stream = CUDAStream::Create(true);
   test::test_device_resource upstream;
 
-  async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+  async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
   stream_view sv(stream);
   int size1 = 1<<20;
   void *ptr = pool.allocate_async(size1, sv);
@@ -80,7 +80,7 @@ TEST(MMAsyncPool, TwoStream) {
   int stream_not_busy = 0;
   int success = 0;
   while (success < min_success) {
-    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
     void *p1 = pool.allocate_async(1000, sv1);
     hog.run(s1);
     pool.deallocate_async(p1, 1000, sv1);
@@ -204,7 +204,7 @@ TEST(MMAsyncPool, SingleStreamRandom) {
   test::test_device_resource upstream;
 
   {
-    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
     vector<block> blocks;
     detail::dummy_lock mtx;
     AsyncPoolTest(pool, blocks, mtx, stream);
@@ -223,7 +223,7 @@ TEST(MMAsyncPool, MultiThreadedSingleStreamRandom) {
     vector<block> blocks;
     std::mutex mtx;
 
-    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
 
     vector<std::thread> threads;
 
@@ -244,7 +244,7 @@ TEST(MMAsyncPool, MultiThreadedSingleStreamRandom) {
 TEST(MMAsyncPool, MultiThreadedMultiStreamRandom) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
 
     vector<std::thread> threads;
 
@@ -268,7 +268,8 @@ TEST(MMAsyncPool, MultiThreadedMultiStreamRandom) {
 TEST(MMAsyncPool, MultiStreamRandomWithGPUHogs) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream, false);
+    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex>
+        pool(&upstream, false);
 
     vector<std::thread> threads;
 
@@ -294,7 +295,8 @@ TEST(MMAsyncPool, MultiStreamRandomWithGPUHogs) {
 TEST(MMAsyncPool, CrossStream) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream, false);
+    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex>
+        pool(&upstream, false);
 
     vector<std::thread> threads;
     vector<CUDAStream> streams;
@@ -323,7 +325,7 @@ TEST(MMAsyncPool, CrossStream) {
 TEST(MMAsyncPool, CrossStreamWithHogs) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_resource<memory_kind::device, free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
 
     vector<std::thread> threads;
     vector<CUDAStream> streams;

--- a/dali/core/mm/free_list_test.cc
+++ b/dali/core/mm/free_list_test.cc
@@ -183,8 +183,8 @@ TEST(MMCoalescingFreeList, PutGet) {
   TestCoalescingPutGet<coalescing_free_list>();
 }
 
-TEST(MMFreeTree, PutGet) {
-  TestCoalescingPutGet<free_tree>();
+TEST(MMCoalescingFreeTree, PutGet) {
+  TestCoalescingPutGet<coalescing_free_tree>();
 }
 
 TEST(MMBestFitFreeList, RemoveIf) {
@@ -210,8 +210,8 @@ TEST(MMCoalescingFreeList, RemoveIf) {
   TestCoalescingRemoveIf<coalescing_free_list>();
 }
 
-TEST(MMFreeTree, RemoveIf) {
-  TestCoalescingRemoveIf<free_tree>();
+TEST(MMCoalescingFreeTree, RemoveIf) {
+  TestCoalescingRemoveIf<coalescing_free_tree>();
 }
 
 
@@ -229,7 +229,7 @@ class test_coalescing_free_list : public coalescing_free_list {
   }
 };
 
-class test_free_tree : public free_tree {
+class test_free_tree : public coalescing_free_tree {
  public:
   void CheckEqual(const test_free_tree &ref) {
     for (auto it1 = by_addr_.cbegin(), it2 = ref.by_addr_.cbegin();
@@ -248,7 +248,7 @@ TEST(MMCoalescingFreeList, Merge) {
   TestMerge<test_coalescing_free_list>();
 }
 
-TEST(MMFreeTree, Merge) {
+TEST(MMCoalescingFreeTree, Merge) {
   TestMerge<test_free_tree>();
 }
 

--- a/dali/core/mm/pool_resource_test.cc
+++ b/dali/core/mm/pool_resource_test.cc
@@ -73,13 +73,13 @@ TEST(MMPoolResource, Coalescing) {
 }
 
 TEST(MMPoolResource, Tree) {
-  TestPoolResource<free_tree>(100000);
+  TestPoolResource<coalescing_free_tree>(100000);
 }
 
 TEST(MMPoolResource, ReturnToUpstream) {
   test_device_resource upstream;
   {
-    pool_resource_base<memory_kind::device, any_context, free_tree, detail::dummy_lock>
+    pool_resource_base<memory_kind::device, any_context, coalescing_free_tree, detail::dummy_lock>
       pool(&upstream);
     size_t size = 1<<28;  // 256M
     for (;;) {
@@ -107,7 +107,7 @@ TEST(MMPoolResource, TestBulkDeallocate) {
   {
     pool_options opts;
     opts.min_block_size = 1000000;
-    pool_resource_base<memory_kind::host, any_context, free_tree, detail::dummy_lock>
+    pool_resource_base<memory_kind::host, any_context, coalescing_free_tree, detail::dummy_lock>
       pool(&upstream, opts);
     vector<dealloc_params> params;
     std::mt19937_64 rng(12345);
@@ -135,9 +135,9 @@ namespace {
 
 template <memory_kind kind, typename Context = any_context>
 class test_defer_dealloc
-    : public deferred_dealloc_pool<kind, Context, free_tree, spinlock> {
+    : public deferred_dealloc_pool<kind, Context, coalescing_free_tree, spinlock> {
  public:
-  using pool = deferred_dealloc_pool<kind, Context, free_tree, spinlock>;
+  using pool = deferred_dealloc_pool<kind, Context, coalescing_free_tree, spinlock>;
   bool ready() const noexcept {
     return this->no_pending_deallocs();
   }

--- a/include/dali/core/mm/async_pool.h
+++ b/include/dali/core/mm/async_pool.h
@@ -34,7 +34,7 @@
 namespace dali {
 namespace mm {
 
-template <memory_kind kind, typename FreeList = free_tree,
+template <memory_kind kind, typename FreeList = coalescing_free_tree,
           typename LockType = std::mutex, typename Upstream = memory_resource<kind>>
 class async_pool_resource : public async_memory_resource<kind> {
  public:

--- a/include/dali/core/mm/detail/free_list.h
+++ b/include/dali/core/mm/detail/free_list.h
@@ -213,7 +213,8 @@ class best_fit_free_list {
    * @brief Places the free block in the list.
    *
    * The block is not merged with adjacent blocks. The fragmentation of the list is permanent.
-   * For long term usage, when fragmentation is an issue, use coalescing_free_list or free_tree.
+   * For long term usage, when internal fragmentation is an issue, use coalescing_free_list or
+   * coalescing_free_tree.
    */
   void put(void *ptr, size_t bytes) {
     block *blk = get_block();
@@ -479,19 +480,19 @@ class coalescing_free_list : public best_fit_free_list {
  * @brief Maintains a list of free memory blocks of variable size, returning free blocks
  *        with least margin.
  *
- * The free_tree yields exactly the same results as coalescing_free_list, but the operations
- * are completed in log(n) time.
+ * The coalescing_free_tree yields exactly the same results as coalescing_free_list, but the
+ * operations are completed in log(n) time.
  *
  * When there are few elements, the additional constant overhead may favor the use of
- * coalescing_free_list, but for long lifetimes and large number of free blocks free_tree
+ * coalescing_free_list, but for long lifetimes and large number of free blocks coalescing_free_tree
  * yields superior performance.
  *
- * Merging of the free_trees is accomplished in k*(log(n)+log(k)) time where n is the number
- * of elements already in the list and k is the number of inserted elements.
+ * Merging of the coalescing_free_trees is accomplished in k*(log(n)+log(k)) time where n is the
+ * number of elements already in the list and k is the number of inserted elements.
  *
  * The tree nodes are allocated from a pooling allocator.
  */
-class free_tree {
+class coalescing_free_tree {
  public:
   void clear() {
     by_addr_.clear();
@@ -630,7 +631,7 @@ class free_tree {
     }
   }
 
-  void merge(free_tree &&with) {
+  void merge(coalescing_free_tree &&with) {
     with.by_size_.clear();
     // Erase the source list one by one - this reduces requirements on total auxiliary memory
     // for the maps.
@@ -652,7 +653,7 @@ template <>
 struct can_merge<coalescing_free_list> : std::true_type {};
 
 template <>
-struct can_merge<free_tree> : std::true_type {};
+struct can_merge<coalescing_free_tree> : std::true_type {};
 }  // namespace detail
 
 }  // namespace mm


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to accommodate non-coalescing free tree (groundwork for DALI-2110)

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Rename class & tests
     * Edit comments
 - Affected modules and functionalities:
     * mm::detail::free_tree and its usages
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * N/A
 - Documentation (including examples):
     * Comments

**JIRA TASK**: DALI-2110
