### PR TITLE
Add non-coalescing free tree.

### DIFF
--- a/dali/core/mm/free_list_test.cc
+++ b/dali/core/mm/free_list_test.cc
@@ -214,6 +214,27 @@ TEST(MMCoalescingFreeTree, RemoveIf) {
   TestCoalescingRemoveIf<coalescing_free_tree>();
 }
 
+TEST(MMBestFitFreeTree, Alignment) {
+  best_fit_free_tree fl;
+  fl.max_padding_ratio = 10;
+  char storage alignas(1024)[4096];
+  assert(detail::is_aligned(storage, 1024));
+  fl.put(storage+1, 1024);
+  EXPECT_EQ(fl.get(1024, 512), nullptr) << "Block out of range or misaligned";
+  fl.put(storage+1025, 2047);
+  EXPECT_EQ(fl.get(1024, 512), storage + 1536);
+}
+
+
+TEST(MMCoalescingFreeTree, Alignment) {
+  coalescing_free_tree fl;
+  char storage alignas(1024)[4096];
+  assert(detail::is_aligned(storage, 1024));
+  fl.put(storage+1, 1024);
+  EXPECT_EQ(fl.get(1024, 512), nullptr) << "Block out of range or misaligned";
+  fl.put(storage+1025, 2047);
+  EXPECT_EQ(fl.get(1024, 512), storage + 512);
+}
 
 TEST(MMBestFitFreeTree, PaddingLimit) {
   best_fit_free_tree fl;

--- a/dali/core/mm/pool_resource_test.cc
+++ b/dali/core/mm/pool_resource_test.cc
@@ -27,52 +27,59 @@ namespace test {
 template <typename FreeList>
 void TestPoolResource(int num_iter) {
   test_host_resource upstream;
-  auto opt = default_host_pool_opts();
-  pool_resource_base<memory_kind::host, any_context, FreeList, detail::dummy_lock>
-    pool(&upstream, opt);
-  std::mt19937_64 rng(12345);
-  std::bernoulli_distribution is_free(0.4);
-  std::uniform_int_distribution<int> align_dist(0, 8);  // alignment anywhere from 1B to 256B
-  std::poisson_distribution<int> size_dist(128);
-  struct allocation {
-    void *ptr;
-    size_t size, alignment;
-    size_t fill;
-  };
-  std::vector<allocation> allocs;
+  {
+    auto opt = default_host_pool_opts();
+    pool_resource_base<memory_kind::host, any_context, FreeList, detail::dummy_lock>
+      pool(&upstream, opt);
+    std::mt19937_64 rng(12345);
+    std::bernoulli_distribution is_free(0.4);
+    std::uniform_int_distribution<int> align_dist(0, 8);  // alignment anywhere from 1B to 256B
+    std::poisson_distribution<int> size_dist(128);
+    struct allocation {
+      void *ptr;
+      size_t size, alignment;
+      size_t fill;
+    };
+    std::vector<allocation> allocs;
 
-  for (int i = 0; i < num_iter; i++) {
-    if (is_free(rng) && !allocs.empty()) {
-      auto idx = rng() % allocs.size();
-      allocation a = allocs[idx];
+    for (int i = 0; i < num_iter; i++) {
+      if (is_free(rng) && !allocs.empty()) {
+        auto idx = rng() % allocs.size();
+        allocation a = allocs[idx];
+        CheckFill(a.ptr, a.size, a.fill);
+        pool.deallocate(a.ptr, a.size, a.alignment);
+        std::swap(allocs[idx], allocs.back());
+        allocs.pop_back();
+      } else {
+        allocation a;
+        a.size = std::max(1, std::min(size_dist(rng), 1<<24));
+        a.alignment = 1 << align_dist(rng);
+        a.fill = rng();
+        a.ptr = pool.allocate(a.size, a.alignment);
+        ASSERT_TRUE(detail::is_aligned(a.ptr, a.alignment));
+        Fill(a.ptr, a.size, a.fill);
+        allocs.push_back(a);
+      }
+    }
+
+    for (auto &a : allocs) {
       CheckFill(a.ptr, a.size, a.fill);
       pool.deallocate(a.ptr, a.size, a.alignment);
-      std::swap(allocs[idx], allocs.back());
-      allocs.pop_back();
-    } else {
-      allocation a;
-      a.size = std::max(1, std::min(size_dist(rng), 1<<24));
-      a.alignment = 1 << align_dist(rng);
-      a.fill = rng();
-      a.ptr = pool.allocate(a.size, a.alignment);
-      ASSERT_TRUE(detail::is_aligned(a.ptr, a.alignment));
-      Fill(a.ptr, a.size, a.fill);
-      allocs.push_back(a);
     }
+    allocs.clear();
   }
-
-  for (auto &a : allocs) {
-    CheckFill(a.ptr, a.size, a.fill);
-    pool.deallocate(a.ptr, a.size, a.alignment);
-  }
-  allocs.clear();
+  upstream.check_leaks();
 }
 
 TEST(MMPoolResource, Coalescing) {
   TestPoolResource<coalescing_free_list>(10000);
 }
 
-TEST(MMPoolResource, Tree) {
+TEST(MMPoolResource, BestFitFreeTree) {
+  TestPoolResource<best_fit_free_tree>(100000);
+}
+
+TEST(MMPoolResource, CoalescingFreeTree) {
   TestPoolResource<coalescing_free_tree>(100000);
 }
 

--- a/include/dali/core/mm/detail/free_list.h
+++ b/include/dali/core/mm/detail/free_list.h
@@ -682,6 +682,8 @@ class best_fit_free_tree {
         break;  // nothing good will happen
       char *base = it->second;
       char *aligned = detail::align_ptr(base, alignment);
+      if (aligned + size > base + block_size)
+        continue;  // alignment made it out of range
       by_size_.erase(it);
       by_addr_.erase(base);
       if (block_size != size)  // only store if there's padding


### PR DESCRIPTION
- add tests
- add integration tests with pool resource

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to avoid immobilizing large upstream blocks

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Use best-fit strategy
     * Store padding and restore original blocks upon deallocation
     * Refuse to allocate blocks with too much padding
 - Affected modules and functionalities:
     * Free lists
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Unit tests
     * Integration tests with pool resource
 - Documentation (including examples):
     * Doxygen


**JIRA TASK**: DALI-2110
