### PR TITLE
Temporarily disable bes-fit PoolTest test due to incompatible free list.

### DIFF
--- a/dali/core/mm/pool_resource_test.cc
+++ b/dali/core/mm/pool_resource_test.cc
@@ -75,9 +75,11 @@ TEST(MMPoolResource, Coalescing) {
   TestPoolResource<coalescing_free_list>(10000);
 }
 
+/* TODO(michalz): Unlock when pool resource can work with best_fit_free_tree
 TEST(MMPoolResource, BestFitFreeTree) {
   TestPoolResource<best_fit_free_tree>(100000);
 }
+*/
 
 TEST(MMPoolResource, CoalescingFreeTree) {
   TestPoolResource<coalescing_free_tree>(100000);


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: test running out of host memory or virtual space

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Disabled the test - the pool should not be used with this free list without adjustments
 - Affected modules and functionalities:
     * Pool tests
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * N/A
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A

