### PR TITLE
Pad missing frames

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -733,7 +733,7 @@ void VideoLoader::PrepareEmpty(SequenceWrapper &tensor) {}
 void VideoLoader::ReadSample(SequenceWrapper& tensor) {
     // TODO(spanev) remove the async between the 2 following methods?
     auto& seq_meta = frame_starts_[current_frame_idx_];
-    tensor.initialize(count_, seq_meta.height, seq_meta.width, channels_, dtype_);
+    tensor.initialize(seq_meta.N_frames, seq_meta.height, seq_meta.width, channels_, dtype_);
 
     tensor.read_sample_f = [this,
                             file_name = file_info_[seq_meta.filename_idx].video_file,

--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -737,7 +737,7 @@ void VideoLoader::ReadSample(SequenceWrapper& tensor) {
 
     tensor.read_sample_f = [this,
                             file_name = file_info_[seq_meta.filename_idx].video_file,
-                            index = seq_meta.frame_idx, count = count_, &tensor] () {
+                            index = seq_meta.frame_idx, count = seq_meta.N_frames, &tensor] () {
       push_sequence_to_read(file_name, index, count);
       receive_frames(tensor);
     };

--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -733,11 +733,11 @@ void VideoLoader::PrepareEmpty(SequenceWrapper &tensor) {}
 void VideoLoader::ReadSample(SequenceWrapper& tensor) {
     // TODO(spanev) remove the async between the 2 following methods?
     auto& seq_meta = frame_starts_[current_frame_idx_];
-    tensor.initialize(seq_meta.N_frames, seq_meta.height, seq_meta.width, channels_, dtype_);
+    tensor.initialize(seq_meta.length, count_, seq_meta.height, seq_meta.width, channels_, dtype_);
 
     tensor.read_sample_f = [this,
                             file_name = file_info_[seq_meta.filename_idx].video_file,
-                            index = seq_meta.frame_idx, count = seq_meta.N_frames, &tensor] () {
+                            index = seq_meta.frame_idx, count = seq_meta.length, &tensor] () {
       push_sequence_to_read(file_name, index, count);
       receive_frames(tensor);
     };

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -139,7 +139,7 @@ struct sequence_meta {
   int label;
   int height;
   int width;
-  int N_frames;
+  int length;
 };
 
 
@@ -164,6 +164,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       codec_id_(0),
       skip_vfr_check_(spec.GetArgument<bool>("skip_vfr_check")),
       file_list_frame_num_(spec.GetArgument<bool>("file_list_frame_num")),
+      pad_sequences_(spec.GetArgument<bool>("pad_sequences")),
       stats_({0, 0, 0, 0, 0}),
       current_frame_idx_(-1),
       stop_(false) {
@@ -266,18 +267,18 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       }
 
       int s;
-      for (int s = start_frame; s < end_frame && s + total_count <= end_frame; s += step_) {
+      for (s = start_frame; s < end_frame && s + total_count <= end_frame; s += step_) {
         frame_starts_.emplace_back(sequence_meta{i, s, file_info_[i].label,
                                    codecpar(stream)->height, codecpar(stream)->width,
                                    count_});
       }
-      if (s < end_frame) {
-        int fcount = 1 + (end_frame - 1 - s) / stride_;
-        if (fcount > 0) {
+      if (pad_sequences_ && s < end_frame) {
+        for (; s < end_frame; s += step_) {
+          int fcount = 1 + (end_frame - 1 - s) / stride_;
           frame_starts_.emplace_back(sequence_meta{i, s, file_info_[i].label,
                                      codecpar(stream)->height, codecpar(stream)->width,
                                      fcount});
-         }
+        }
       }
     }
     DALI_ENFORCE(!frame_starts_.empty(), "There are no valid sequences in the provided "
@@ -339,6 +340,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   int codec_id_;
   bool skip_vfr_check_;
   bool file_list_frame_num_;
+  bool pad_sequences_;
   VideoLoaderStats stats_;
 
   std::unordered_map<std::string, VideoFile> open_files_;

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -139,6 +139,7 @@ struct sequence_meta {
   int label;
   int height;
   int width;
+  int N_frames;
 };
 
 
@@ -264,9 +265,19 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
         }
       }
 
+      int s;
       for (int s = start_frame; s < end_frame && s + total_count <= end_frame; s += step_) {
         frame_starts_.emplace_back(sequence_meta{i, s, file_info_[i].label,
-                                   codecpar(stream)->height, codecpar(stream)->width});
+                                   codecpar(stream)->height, codecpar(stream)->width,
+                                   count_});
+      }
+      if (s < end_frame) {
+        int fcount = 1 + (end_frame - 1 - s) / stride_;
+        if (fcount > 0) {
+          frame_starts_.emplace_back(sequence_meta{i, s, file_info_[i].label,
+                                     codecpar(stream)->height, codecpar(stream)->width,
+                                     fcount});
+         }
       }
     }
     DALI_ENFORCE(!frame_starts_.empty(), "There are no valid sequences in the provided "

--- a/dali/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/operators/reader/nvdecoder/nvdecoder.cc
@@ -416,6 +416,13 @@ void NvDecoder::receive_frames(SequenceWrapper& sequence) {
   }
   if (captured_exception_)
     std::rethrow_exception(captured_exception_);
+  if (sequence.count < sequence.max_count) {
+    auto data_size = sequence.count * volume(sequence.frame_shape()) *
+                     dali::TypeTable::GetTypeInfo(sequence.dtype).size();
+    auto pad_size = (sequence.max_count - sequence.count) * volume(sequence.frame_shape()) *
+                     dali::TypeTable::GetTypeInfo(sequence.dtype).size();
+    cudaMemsetAsync(sequence.sequence.raw_mutable_data() + data_size, 0, pad_size, stream_);
+  }
   record_sequence_event_(sequence);
 }
 

--- a/dali/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/operators/reader/nvdecoder/nvdecoder.cc
@@ -417,11 +417,14 @@ void NvDecoder::receive_frames(SequenceWrapper& sequence) {
   if (captured_exception_)
     std::rethrow_exception(captured_exception_);
   if (sequence.count < sequence.max_count) {
-    auto data_size = sequence.count * volume(sequence.frame_shape()) *
-                     dali::TypeTable::GetTypeInfo(sequence.dtype).size();
+    auto data_size = sequence.count * volume(sequence.frame_shape());
     auto pad_size = (sequence.max_count - sequence.count) * volume(sequence.frame_shape()) *
                      dali::TypeTable::GetTypeInfo(sequence.dtype).size();
-    cudaMemsetAsync(sequence.sequence.raw_mutable_data() + data_size, 0, pad_size, stream_);
+    TYPE_SWITCH(dtype_, type2id, OutputType, NVDECODER_SUPPORTED_TYPES, (
+      cudaMemsetAsync(sequence.sequence.mutable_data<OutputType>() + data_size, 0, pad_size,
+                      stream_);
+    ), DALI_FAIL(make_string("Not supported output type:", dtype_, // NOLINT
+        "Only DALI_UINT8 and DALI_FLOAT are supported as the decoder outputs.")););
   }
   record_sequence_event_(sequence);
 }

--- a/dali/operators/reader/nvdecoder/sequencewrapper.h
+++ b/dali/operators/reader/nvdecoder/sequencewrapper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,8 +37,10 @@ struct SequenceWrapper {
  public:
   SequenceWrapper() = default;
 
-  void initialize(int count, int height, int width, int channels, DALIDataType dtype) {
+  void initialize(int count, int max_count, int height, int width, int channels,
+                  DALIDataType dtype) {
     this->count = count;
+    this->max_count = max_count;
     this->height = height;
     this->width = width;
     this->channels = channels;
@@ -69,12 +71,13 @@ struct SequenceWrapper {
   }
 
   TensorShape<4> shape() const {
-    return TensorShape<4>{count, height, width, channels};
+    return TensorShape<4>{max_count, height, width, channels};
   }
 
   Tensor<GPUBackend> sequence;
 
   int count = -1;
+  int max_count = -1;
   int height = -1;
   int width = -1;
   int channels = -1;

--- a/dali/operators/reader/nvdecoder/sequencewrapper.h
+++ b/dali/operators/reader/nvdecoder/sequencewrapper.h
@@ -47,7 +47,7 @@ struct SequenceWrapper {
     this->dtype = dtype;
 
     timestamps.clear();
-    timestamps.reserve(count);
+    timestamps.reserve(max_count);
 
     if (!event_) {
       event_ = CUDAEvent::CreateWithFlags(cudaEventBlockingSync | cudaEventDisableTiming);

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -161,6 +161,11 @@ If floating point values have been provided, the start frame number will be roun
 the end frame number will be rounded down.
 
 Frame numbers start from 0.)code", false)
+  .AddOptionalArg("pad_sequences",
+      R"code(Allows creation of incomplete sequences if there is an insufficient number
+of frames at the very end of the video.
+
+Redundant frames are zeroed. Corresponding time stamps and frame numbers are set to -1.)code", false)
   .AddParent("LoaderBase");
 
 

--- a/dali/operators/reader/video_reader_op.h
+++ b/dali/operators/reader/video_reader_op.h
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include "dali/operators/reader/loader/video_loader.h"
 #include "dali/operators/reader/reader_op.h"
@@ -167,6 +168,13 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
         }
         if (enable_timestamps_) {
           auto *timestamp = timestamp_output_->mutable_tensor<double>(data_idx);
+          if (prefetched_video.timestamps.size() < static_cast<size_t>(count_)) {
+            // pad timestamps for shorter sequences
+            auto old_size = prefetched_video.timestamps.size();
+            prefetched_video.timestamps.resize(count_);
+            std::fill(prefetched_video.timestamps.begin() + old_size,
+                      prefetched_video.timestamps.end(), -1);
+          }
           timestamp_output_->type().Copy<GPUBackend, CPUBackend>(
               timestamp, prefetched_video.timestamps.data(), prefetched_video.timestamps.size(),
               stream);

--- a/dali/test/python/test_video_pipeline.py
+++ b/dali/test/python/test_video_pipeline.py
@@ -327,9 +327,9 @@ def test_pad_sequence():
     assert get_epoch_size(dali_pipe) == 1
 
     def divisor_generator(n, max_val):
-        for i in range(1, max_val + 1):
+        for i in range(max_val + 1, 1, -1):
             if n % i == 0:
-                yield i
+                return i
 
     dali_pipe = create_video_pipe(batch_size=1, filenames=video_filename, sequence_length=1,
                                   stride=1, pad_sequences=False)
@@ -337,7 +337,7 @@ def test_pad_sequence():
 
     # to speed things up read as close as 30 frames at the time, but in the way that the sequences
     # cover the whole video (without padding)
-    ref_sequence_length = list(divisor_generator(get_epoch_size(dali_pipe), 30))[-1]
+    ref_sequence_length = divisor_generator(get_epoch_size(dali_pipe), 30)
 
     # extract frames from the test video without padding and compare with one from padded pipeline
     dali_pipe = create_video_pipe(batch_size=1, filenames=video_filename, sequence_length=ref_sequence_length,


### PR DESCRIPTION
#### Why we need this PR?
Use case : Frame-by-frame inference of a video dataset. Previously, the last frames of a video would not be output, because the remainder would be less than the `sequence_length`. Users could solve this by setting `sequence_length` to 1, but this would have severe performance issues. Now, we set `batch_size` equal to one and `sequence_length` to a VRAM limited number. I'm leaving these small changes here for the community as a WIP per @JanuszL suggestions, but I don't have time to continue development as my initial use-case was satisfied.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Find how many frames are left that don't fit into a full sequence. Add those frame numbers to the list of frames to decode. Added a counter to hold the number of frames in this last sequence, and resize the tensor holding the frame data based on that. 
 - Affected modules and functionalities:
     I think this only affects `fn.readers.video_resize` and `fn.readers.video`?
 - Key points relevant for the review:
     Since my use-case is with `batch_size=1`, this is a brute force solution that does not currently generalize. There's no flag to trigger this behavior compared to the default. I tried to see if I could just keep the tensor size unchanged and zero out the garbage frames and timestamps in attempts to keep full (non-sparse) tensors in the case of `batch_size>1`. However, I was not successful; see : https://github.com/NVIDIA/DALI/issues/2760#issuecomment-844409642
 - Validation and testing:
Test script using videos from https://github.com/NVIDIA/DALI_extra
```
from nvidia.dali.pipeline import Pipeline
import nvidia.dali.fn as fn
import nvidia.dali.types as types

def create_video_reader_pipeline(batch_size, sequence_length, num_threads, 
                                 device_id, video_filenames, labels, frame_stride):
    pipeline = Pipeline(batch_size, num_threads, device_id, seed=12)
    with pipeline:
        images, label, start_frame_num, timestamps = fn.readers.video_resize(device="gpu", 
                                 filenames=video_filenames, 
                                 sequence_length=sequence_length,
                                 normalized=False, random_shuffle=False, 
                                 image_type=types.RGB, 
                                 dtype=types.UINT8, 
                                 enable_frame_num=True,
                                 enable_timestamps=True,
                                 labels=labels, 
                                 stride=frame_stride,
                                 pad_last_batch=False, name="Reader",
                                 size=[640, 640])

        pipeline.set_outputs(images, label, start_frame_num, timestamps)
    return pipeline


batch_size = 1
sequence_length = 8
frame_stride = 5
video_filenames = ["./cfr_ntsc_29_97_test.mp4",
                   "./test_label.mp4"]
labels = list(range(len(video_filenames))) # how we keep track of sample-video pairs

pipe = create_video_reader_pipeline(batch_size,
                                    sequence_length, 2, 0, video_filenames, 
                                    labels, frame_stride)
pipe.build()
n_iter = 11
for i in range(n_iter):
    sequences_out, labels, start_frame_num, timestamps = pipe.run()
    data = sequences_out.as_cpu().as_array()
    n_frames = data.shape[1]
    labels = labels.as_cpu().as_array()
    start_frame_num = start_frame_num.as_cpu().as_array()
    filt_timestamps = timestamps.as_cpu().as_array()[:,:n_frames]
    
    print(data.shape)
    print(filt_timestamps)
```

Default output:
```
(1, 8, 640, 640, 3)
[[0.        0.1668333 0.3336667 0.5005    0.6673333 0.8341667 1.001
  1.1678333]]
(1, 8, 640, 640, 3)
[[1.3346667 1.5015    1.6683333 1.8351667 2.002     2.1688333 2.3356667
  2.5025   ]]
(1, 8, 640, 640, 3)
[[0.  0.2 0.4 0.6 0.8 1.  1.2 1.4]]
(1, 8, 640, 640, 3)
[[1.6 1.8 2.  2.2 2.4 2.6 2.8 3. ]]
(1, 8, 640, 640, 3)
[[3.2 3.4 3.6 3.8 4.  4.2 4.4 4.6]]
(1, 8, 640, 640, 3)
[[4.8 5.  5.2 5.4 5.6 5.8 6.  6.2]]
(1, 8, 640, 640, 3)
[[6.4 6.6 6.8 7.  7.2 7.4 7.6 7.8]]
(1, 8, 640, 640, 3)
[[8.  8.2 8.4 8.6 8.8 9.  9.2 9.4]]
(1, 8, 640, 640, 3)
[[0.        0.1668333 0.3336667 0.5005    0.6673333 0.8341667 1.001
  1.1678333]]
  ```
After changes:
```
(1, 8, 640, 640, 3)
[[0.        0.1668333 0.3336667 0.5005    0.6673333 0.8341667 1.001
  1.1678333]]
(1, 8, 640, 640, 3)
[[1.3346667 1.5015    1.6683333 1.8351667 2.002     2.1688333 2.3356667
  2.5025   ]]
(1, 2, 640, 640, 3)
[[2.6693333 2.8361667]]
(1, 8, 640, 640, 3)
[[0.  0.2 0.4 0.6 0.8 1.  1.2 1.4]]
(1, 8, 640, 640, 3)
[[1.6 1.8 2.  2.2 2.4 2.6 2.8 3. ]]
(1, 8, 640, 640, 3)
[[3.2 3.4 3.6 3.8 4.  4.2 4.4 4.6]]
(1, 8, 640, 640, 3)
[[4.8 5.  5.2 5.4 5.6 5.8 6.  6.2]]
(1, 8, 640, 640, 3)
[[6.4 6.6 6.8 7.  7.2 7.4 7.6 7.8]]
(1, 8, 640, 640, 3)
[[8.  8.2 8.4 8.6 8.8 9.  9.2 9.4]]
(1, 2, 640, 640, 3)
[[9.6 9.8]]
(1, 8, 640, 640, 3)
[[0.        0.1668333 0.3336667 0.5005    0.6673333 0.8341667 1.001
  1.1678333]]
```
**JIRA TASK**: *[NA]*
