### PR TITLE
Improve Element Extract Op

### DIFF
--- a/dali/operators/sequence/element_extract.cc
+++ b/dali/operators/sequence/element_extract.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,17 @@
 namespace dali {
 
 DALI_SCHEMA(ElementExtract)
-    .DocStr(R"code(Extracts one or more elements from input.)code")
+    .DocStr(R"code(Extracts one or more elements from input.
+
+The outputs are slices in the first (outermost) dimension of the input.
+There are as many outputs as the elements provided in the ``element_map``.
+
+For example, for ``element_map = [2, 0, 3]`` there will be three outputs, containing
+2nd, 0th and 3rd element of the input sequences respectively.
+
+The input layout, if provided, must begin with ``F`` dimension. The outputs will have one less
+dimension than the input, that is for ``FHWC`` inputs, the outputs will be ``HWC`` elements.
+)code")
     .NumInput(1)
     .NumOutput(1)
     .SequenceOperator()
@@ -34,35 +44,31 @@ DALI_SCHEMA(ElementExtract)
         });
 
 template <>
-void ElementExtract<CPUBackend>::RunImpl(SampleWorkspace &ws) {
-    const auto &input = ws.Input<CPUBackend>(0);
-    auto element_layout = VideoLayoutInfo::GetFrameLayout(input.GetLayout());
+void ElementExtract<CPUBackend>::RunImpl(HostWorkspace &ws) {
+  auto &input = ws.InputRef<CPUBackend>(0);
+  auto element_layout = VideoLayoutInfo::GetFrameLayout(input.GetLayout());
+  int elements_per_sample = element_map_.size();
+  auto data_type = input.type();
+  auto &tp = ws.GetThreadPool();
+  for (int k = 0; k < elements_per_sample; k++) {
+    int element = element_map_[k];
+    auto &output = ws.OutputRef<CPUBackend>(k);
 
-    auto shape = input.shape();
-    detail::CheckInputShape(shape, element_map_);
-    auto output_shape = shape.last(shape.size() - 1);
-    auto element_size = volume(output_shape);
-
-    auto elements_per_sample = element_map_.size();
-    auto output_offset = 0;
-
-    TypeInfo type = input.type();
-    for (std::size_t k = 0; k < elements_per_sample; k++) {
-        auto output_idx = output_offset + k;
-        auto &output = ws.Output<CPUBackend>(output_idx);
-        output.set_type(input.type());
-        output.SetLayout(element_layout);
-        output.Resize(output_shape);
-
-        auto element_idx = element_map_[k];
-        auto element_offset = element_idx * element_size;
-
-        type.Copy<CPUBackend, CPUBackend>(
-            output.raw_mutable_data(),
-            static_cast<const uint8_t*>(input.raw_data()) + element_offset * type.size(),
-            element_size,
-            0);
+    for (unsigned int i = 0; i < input.ntensor(); i++) {
+      auto tensor_shape = input.tensor_shape(i);
+      auto element_size = volume(tensor_shape.begin() + 1, tensor_shape.end());
+      auto input_offset_bytes = element * element_size * data_type.size();
+      tp.AddWork(
+          [out_ptr = output.raw_mutable_tensor(i),
+           in_ptr = static_cast<const uint8_t *>(input.raw_tensor(i)) + input_offset_bytes,
+           element_size, data_type](int thread_id) {
+            data_type.Copy<CPUBackend, CPUBackend>(out_ptr, in_ptr, element_size, 0);
+          },
+          element_size);
     }
+    output.SetLayout(element_layout);
+  }
+  tp.RunAll();
 }
 
 DALI_REGISTER_OPERATOR(ElementExtract, ElementExtract<CPUBackend>, CPU);

--- a/dali/operators/sequence/element_extract.cc
+++ b/dali/operators/sequence/element_extract.cc
@@ -18,7 +18,7 @@
 namespace dali {
 
 DALI_SCHEMA(ElementExtract)
-    .DocStr(R"code(Extracts one or more elements from input.
+    .DocStr(R"code(Extracts one or more elements from input sequence.
 
 The outputs are slices in the first (outermost) dimension of the input.
 There are as many outputs as the elements provided in the ``element_map``.

--- a/dali/operators/sequence/element_extract.cu
+++ b/dali/operators/sequence/element_extract.cu
@@ -19,28 +19,15 @@
 namespace dali {
 
 template <>
-void ElementExtract<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
-  scatter_gather_.Reset();
-  auto &input = ws.Input<GPUBackend>(0);
-  auto element_layout = VideoLayoutInfo::GetFrameLayout(input.GetLayout());
-  int elements_per_sample = element_map_.size();
-  auto data_type = input.type();
-  for (int k = 0; k < elements_per_sample; k++) {
-    int element = element_map_[k];
-    auto &output = ws.Output<GPUBackend>(k);
+void ElementExtract<GPUBackend>::AddCopy(DeviceWorkspace &ws, void *dst, const void *src,
+                                         size_t volume, const TypeInfo &type) {
+  scatter_gather_.AddCopy(dst, src, volume * type.size());
+}
 
-    for (unsigned int i = 0; i < input.ntensor(); i++) {
-      auto tensor_shape = input.tensor_shape(i);
-      auto element_size = volume(tensor_shape.begin() + 1, tensor_shape.end());
-      auto input_offset_bytes = element * element_size * data_type.size();
-      scatter_gather_.AddCopy(
-          output.raw_mutable_tensor(i),
-          static_cast<const uint8_t *>(input.raw_tensor(i)) + input_offset_bytes,
-          element_size * data_type.size());
-    }
-    output.SetLayout(element_layout);
-  }
-  scatter_gather_.Run(ws.stream());
+
+template <>
+void ElementExtract<GPUBackend>::RunCopies(DeviceWorkspace &ws) {
+  scatter_gather_.Run(ws.stream(), true);
 }
 
 DALI_REGISTER_OPERATOR(ElementExtract, ElementExtract<GPUBackend>, GPU);

--- a/dali/operators/sequence/element_extract.cu
+++ b/dali/operators/sequence/element_extract.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,48 +18,29 @@
 
 namespace dali {
 
-namespace detail {
-
-TensorListShape<> GetOutputShape(const TensorList<GPUBackend> &input,
-                                 const std::vector<int>& element_map) {
-    TensorListShape<> output_shape(input.ntensor(), input.shape().sample_dim() - 1);
-    for (unsigned int i = 0; i < input.ntensor(); ++i) {
-        auto shape = input.tensor_shape(i);
-        CheckInputShape(shape, element_map);
-        output_shape.set_tensor_shape(i, shape.last(shape.size() - 1));
-    }
-    return output_shape;
-}
-
-}  // namespace detail
-
 template <>
 void ElementExtract<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
-    auto &input = ws.Input<GPUBackend>(0);
-    auto output_shape = detail::GetOutputShape(input, element_map_);
-    auto element_layout = VideoLayoutInfo::GetFrameLayout(input.GetLayout());
-    int elements_per_sample = element_map_.size();
-    int output_offset = 0;
-    auto data_type = input.type();
-    for (int k = 0; k < elements_per_sample; k++) {
-        int element = element_map_[k];
-        auto &output = ws.Output<GPUBackend>(output_offset + k);
-        output.set_type(input.type());
-        output.SetLayout(element_layout);
-        output.Resize(output_shape);
+  scatter_gather_.Reset();
+  auto &input = ws.Input<GPUBackend>(0);
+  auto element_layout = VideoLayoutInfo::GetFrameLayout(input.GetLayout());
+  int elements_per_sample = element_map_.size();
+  auto data_type = input.type();
+  for (int k = 0; k < elements_per_sample; k++) {
+    int element = element_map_[k];
+    auto &output = ws.Output<GPUBackend>(k);
 
-        for (unsigned int i = 0; i < input.ntensor(); i++) {
-            auto tensor_shape = input.tensor_shape(i);
-            auto element_size = volume(tensor_shape.begin()+1, tensor_shape.end());
-            auto input_offset_bytes = element * element_size * data_type.size();
-
-            data_type.Copy<GPUBackend, GPUBackend>(
-                output.raw_mutable_tensor(i),
-                static_cast<const uint8_t*>(input.raw_tensor(i)) + input_offset_bytes,
-                element_size,
-                ws.stream());
-        }
+    for (unsigned int i = 0; i < input.ntensor(); i++) {
+      auto tensor_shape = input.tensor_shape(i);
+      auto element_size = volume(tensor_shape.begin() + 1, tensor_shape.end());
+      auto input_offset_bytes = element * element_size * data_type.size();
+      scatter_gather_.AddCopy(
+          output.raw_mutable_tensor(i),
+          static_cast<const uint8_t *>(input.raw_tensor(i)) + input_offset_bytes,
+          element_size * data_type.size());
     }
+    output.SetLayout(element_layout);
+  }
+  scatter_gather_.Run(ws.stream());
 }
 
 DALI_REGISTER_OPERATOR(ElementExtract, ElementExtract<GPUBackend>, GPU);

--- a/dali/operators/sequence/element_extract.h
+++ b/dali/operators/sequence/element_extract.h
@@ -68,6 +68,11 @@ class ElementExtract : public Operator<Backend> {
 
     DALI_ENFORCE(!element_map_.empty(),
         "No 'element_map' indexes provided");
+
+    for (auto elem : element_map_) {
+        DALI_ENFORCE(elem >= 0,
+            "index " + std::to_string(elem) + " out of bounds.");
+    }
   }
 
  protected:

--- a/dali/test/python/test_operator_element_extract.py
+++ b/dali/test/python/test_operator_element_extract.py
@@ -142,7 +142,7 @@ def test_element_extract_layout():
     for device in ["cpu", "gpu"]:
         yield check_element_extract, [4, 3, 3], "FXY", [0, 1, 2, 3, 3, 2, 1, 0], device
 
-# @raises(RuntimeError)
+@raises(RuntimeError)
 def check_element_extract_raises(shape, layout, element_map, dev):
     check_element_extract(shape, layout, element_map, dev)
 

--- a/dali/test/python/test_operator_element_extract.py
+++ b/dali/test/python/test_operator_element_extract.py
@@ -150,3 +150,4 @@ def test_raises():
     for shape, layout in [([4], "F"), ([6, 1], "XF"), ([8, 10, 3], "HWC")]:
         yield check_element_extract_raises, shape, layout, [1, 3], "cpu"
     yield check_element_extract_raises, [6, 1], "FX", [10], "cpu"
+    yield check_element_extract_raises, [6, 1], "FX", [-5], "cpu"

--- a/dali/test/python/test_operator_element_extract.py
+++ b/dali/test/python/test_operator_element_extract.py
@@ -142,7 +142,7 @@ def test_element_extract_layout():
     for device in ["cpu", "gpu"]:
         yield check_element_extract, [4, 3, 3], "FXY", [0, 1, 2, 3, 3, 2, 1, 0], device
 
-@raises(RuntimeError)
+# @raises(RuntimeError)
 def check_element_extract_raises(shape, layout, element_map, dev):
     check_element_extract(shape, layout, element_map, dev)
 


### PR DESCRIPTION
#### Why we need this PR?
- Refactoring to improve Element Extract - fix issues found during writing requirements

#### What happened in this PR? 
 - What solution was applied:
* Fix silent assumption that 'F' is always outer
  dimension by adding explicit check for that.
* Remove assertion limiting the size of element_map
  to the length of sequence
* Rework GPU version to use scatter_gather based
  on sequence rearrange
* Use HostWorkspace for CPU with similar implementation
  to the one used in GPU
* Add better docstring
* Add SetupImpl
* Extend Python tests

 - Affected modules and functionalities:
     Element Extract
 - Key points relevant for the review:
     ...
 - Validation and testing:
     Test extended, to cover all cases
 - Documentation (including examples):
     Yes, extended


**JIRA TASK**: *[DALI-2043]*
