### PR TITLE
Enable DALI to build for CUDA 10.2

### DIFF
--- a/dali/python/nvidia/dali/backend.py
+++ b/dali/python/nvidia/dali/backend.py
@@ -40,7 +40,7 @@ if not initialized:
         deprecation_warning("DALI support for Python 3.9 is experimental and some functionalities "
                             "may not work.")
 
-    if __cuda_version__ < 100:
+    if __cuda_version__ < 102:
         deprecation_warning("DALI 1.3 is the last official release that supports CUDA 10.0. "
                             "The next release will support only 10.2 from 10.x familly. "
                             "Please update your environment to CUDA version 10.2 or newer.")

--- a/dali/python/nvidia/dali/backend.py
+++ b/dali/python/nvidia/dali/backend.py
@@ -40,5 +40,10 @@ if not initialized:
         deprecation_warning("DALI support for Python 3.9 is experimental and some functionalities "
                             "may not work.")
 
+    if __cuda_version__ < 100:
+        deprecation_warning("DALI 1.3 is the last official release that supports CUDA 10.0. "
+                            "The next release will support only 10.2 from 10.x familly. "
+                            "Please update your environment to CUDA version 10.2 or newer.")
+
     for lib in default_plugins:
         LoadLibrary(os.path.join(os.path.dirname(__file__), lib))

--- a/docker/Dockerfile.cuda102.x86_64.deps
+++ b/docker/Dockerfile.cuda102.x86_64.deps
@@ -1,0 +1,13 @@
+ARG TOOLKIT_BASE_IMAGE=ubuntu:18.04
+FROM ${TOOLKIT_BASE_IMAGE} as cuda
+
+RUN apt update && apt install -y libxml2 curl perl gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -LO https://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run && \
+    chmod +x cuda_*.run && \
+    ./cuda_*.run --silent --no-opengl-libs --toolkit && \
+    rm -f cuda_*.run;
+
+FROM scratch
+COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -38,7 +38,7 @@ Building Python Wheel
 Change directory (``cd``) into ``docker`` directory and run ``./build.sh``. If needed,
 set the following environment variables:
 
-* | CUDA_VERSION - CUDA toolkit version (10.0, 11.0, 11.1, 11.2 and 11.3.
+* | CUDA_VERSION - CUDA toolkit version (10.0, 10.2, 11.0, 11.1, 11.2 and 11.3).
   | The default is ``11.3``. Thanks to CUDA extended compatibility mode, CUDA 11.1, 11.2 and 11.3 wheels are
     named as CUDA 11.0 because it can work with the CUDA 11.0 R450.x driver family. Please update
     to the latest recommended driver version in that family.


### PR DESCRIPTION
- adds docker file for CUDA 10.2 toolkit
- updates documentation
- adds a deprecation warning that DALI 1.3 is the last release
  for CUDA 10.0, and then DALI moves to 10.2 for CUDA 10.x family

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It enables DALI to build for CUDA 10.2

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds docker file for CUDA 10.2 toolkit
     adds a deprecation warning that DALI 1.3 is the last release for CUDA 10.0, and then DALI moves to 10.2 for CUDA 10.x family
 - Affected modules and functionalities:
     docker files
     docs
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI run for CUDA 10.2
 - Documentation (including examples):
     compilation guide has been updated


**JIRA TASK**: *[NA]*
