### PR TITLE
Multi paste refactor & fix

### DIFF
--- a/dali/kernels/imgproc/paste/paste_gpu.h
+++ b/dali/kernels/imgproc/paste/paste_gpu.h
@@ -48,7 +48,7 @@ struct SampleDescriptorGPU {
   ivec<ndims> patch_counts, out_pitch;
 };
 
-// Could not fill this in Setup, as we are not given reference to out then
+// Could not fill this in Setup - there are no pointers yet
 template <class OutputType, class InputType, int ndims>
 void FillPointers(span<SampleDescriptorGPU<OutputType, InputType, ndims - 1>> descs,
                   span<PatchDesc<InputType, ndims - 1>> patches,
@@ -172,7 +172,7 @@ void CreateSampleDescriptors(
           patch.patch_start[1] = scaled_x_to_x[x];
           patch.patch_end[0] = scaled_y_to_y[y + 1];
           patch.patch_end[1] = scaled_x_to_x[x + 1];
-          patch.in = nullptr;
+          patch.in = nullptr;  // to be filled later
           patch.in_sample_idx = max_paste == -1 ? -1 : sample.inputs[max_paste].in_idx;
           patch.in_pitch[0] = 0;
           patch.in_pitch[1] = max_paste == -1 ? -1 : in_shape[sample.inputs[max_paste].in_idx][1];

--- a/dali/kernels/imgproc/paste/paste_gpu.h
+++ b/dali/kernels/imgproc/paste/paste_gpu.h
@@ -77,7 +77,7 @@ void CreateSampleDescriptors(
     vector<PatchDesc<InputType, ndims - 1>> &out_patches,
     const TensorListShape<ndims> &in_shape,
     span<paste::MultiPasteSampleInput<ndims - 1>> samples) {
-  static_assert(ndims == 3);
+  static_assert(ndims == 3, "Only 2D data with channels supported");
 
   int batch_size = samples.size();
 

--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -57,39 +57,16 @@ R"code(Shape of the output.)code", DALI_INT_VEC, true)
 R"code(Output data type. If not set, the input type is used.)code", DALI_NO_TYPE)
 .NumOutput(1);
 
-DALI_REGISTER_OPERATOR(MultiPaste, MultiPasteCPU, CPU)
-
-bool MultiPasteCPU::SetupImpl(std::vector<OutputDesc> &output_desc,
-                              const workspace_t<CPUBackend> &ws) {
-  AcquireArguments(spec_, ws);
-
-  const auto &images = ws.template InputRef<CPUBackend>(0);
-  const auto &output = ws.template OutputRef<CPUBackend>(0);
-  output_desc.resize(1);
-
-  TYPE_SWITCH(images.type().id(), type2id, InputType, (uint8_t, int16_t, int32_t, float), (
-      TYPE_SWITCH(output_type_, type2id, OutputType, (uint8_t, int16_t, int32_t, float), (
-          {
-            using Kernel = kernels::PasteCPU<OutputType, InputType>;
-            kernel_manager_.Initialize<Kernel>();
-            TensorListShape<> sh = images.shape();
-            TensorListShape<> shapes(sh.num_samples(), sh.sample_dim());
-            for (int i = 0; i < sh.num_samples(); i++) {
-              const TensorShape<> &out_sh = { output_size_[i].data[0],
-                                              output_size_[i].data[1], sh[i][2] };
-              shapes.set_tensor_shape(i, out_sh);
-            }
-
-            output_desc[0] = {shapes, TypeTable::GetTypeInfo(output_type_)};
-          }
-      ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
-  ), DALI_FAIL(make_string("Unsupported input type: ", images.type().id())))  // NOLINT
-  return true;
+template <typename OutputType, typename InputType>
+void MultiPasteCPU::SetupTyped(const workspace_t<CPUBackend> & /*ws*/,
+                               const TensorListShape<> & /*out_shape*/) {
+  using Kernel = kernels::PasteCPU<OutputType, InputType>;
+  kernel_manager_.Initialize<Kernel>();
 }
 
 
-template<typename InputType, typename OutputType>
-void MultiPasteCPU::RunImplExplicitlyTyped(workspace_t<CPUBackend> &ws) {
+template <typename OutputType, typename InputType>
+void MultiPasteCPU::RunTyped(workspace_t<CPUBackend> &ws) {
   const auto &images = ws.template InputRef<CPUBackend>(0);
   auto &output = ws.template OutputRef<CPUBackend>(0);
 
@@ -156,14 +133,6 @@ void MultiPasteCPU::RunImplExplicitlyTyped(workspace_t<CPUBackend> &ws) {
   tp.RunAll();
 }
 
-
-void MultiPasteCPU::RunImpl(workspace_t<CPUBackend> &ws) {
-  const auto input_type_id = ws.template InputRef<CPUBackend>(0).type().id();
-  TYPE_SWITCH(input_type_id, type2id, InputType, (uint8_t, int16_t, int32_t, float), (
-      TYPE_SWITCH(output_type_, type2id, OutputType, (uint8_t, int16_t, int32_t, float), (
-              RunImplExplicitlyTyped<InputType, OutputType>(ws);
-      ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
-  ), DALI_FAIL(make_string("Unsupported input type: ", input_type_id)))  // NOLINT
-}
+DALI_REGISTER_OPERATOR(MultiPaste, MultiPasteCPU, CPU)
 
 }  // namespace dali

--- a/dali/operators/image/paste/multipaste.cu
+++ b/dali/operators/image/paste/multipaste.cu
@@ -19,6 +19,12 @@
 
 namespace dali {
 
+template <int n, typename T, typename Source>
+inline void to_vec(vec<n, T> &out, Source &&src) {
+  for (int i = 0; i < n; i++)
+    out[i] = src[i];
+}
+
 void MultiPasteGPU::InitSamples(const TensorListShape<> &out_shape) {
   assert(spatial_ndim_ == 2);
   int batch_size = out_shape.num_samples();
@@ -30,7 +36,8 @@ void MultiPasteGPU::InitSamples(const TensorListShape<> &out_shape) {
     sample.inputs.resize(n);
 
     sample.channels = 3;
-    memcpy(sample.out_size.begin(), out_shape[i].data(), sizeof(int) * spatial_ndim_);
+
+    to_vec(sample.out_size, out_shape[i]);
     for (int j = 0; j < n; j++) {
       int from_sample = in_idx_[i].data[j];
       auto in_anchor_view = GetInAnchors(i, j);
@@ -38,9 +45,9 @@ void MultiPasteGPU::InitSamples(const TensorListShape<> &out_shape) {
       auto shape_view = GetShape(i, j, Coords(
           raw_input_size_mem_.data() + spatial_ndim_ * from_sample,
           dali::TensorShape<>(spatial_ndim_)));
-      memcpy(&sample.inputs[j].size[0],       shape_view.data,      sizeof(int) * spatial_ndim_);
-      memcpy(&sample.inputs[j].in_anchor[0],  in_anchor_view.data,  sizeof(int) * spatial_ndim_);
-      memcpy(&sample.inputs[j].out_anchor[0], out_anchor_view.data, sizeof(int) * spatial_ndim_);
+      to_vec(sample.inputs[j].size,       shape_view.data);
+      to_vec(sample.inputs[j].in_anchor,  in_anchor_view.data);
+      to_vec(sample.inputs[j].out_anchor, out_anchor_view.data);
       sample.inputs[j].in_idx = from_sample;
     }
   }

--- a/dali/operators/image/paste/multipaste.h
+++ b/dali/operators/image/paste/multipaste.h
@@ -222,7 +222,7 @@ class MultiPasteOp : public Operator<Backend> {
             This().template SetupTyped<OutputType, InputType>(ws, out_shape);
         ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
     ), DALI_FAIL(make_string("Unsupported input type: ", images.type().id())))  // NOLINT
-   return true;
+    return true;
   }
 
   inline Coords GetInAnchors(int sample_num, int paste_num) const {

--- a/dali/operators/image/paste/multipaste.h
+++ b/dali/operators/image/paste/multipaste.h
@@ -33,15 +33,24 @@
 
 namespace dali {
 
-template <typename Backend>
+template <typename Backend, typename Actual>
 class MultiPasteOp : public Operator<Backend> {
  public:
-  ~MultiPasteOp() override = default;
-
   DISABLE_COPY_MOVE_ASSIGN(MultiPasteOp);
 
+  Actual &This() noexcept {
+    return static_cast<Actual &>(*this);
+  }
+
+  const Actual &This() const noexcept {
+    return static_cast<const Actual &>(*this);
+  }
+
+  template <typename T>
+  using InList = TensorListView<detail::storage_tag_map_t<Backend>, const T>;
+
  protected:
-  using Coords = TensorView<typename compute_to_storage<Backend>::type, const int, 1>;
+  using Coords = TensorView<StorageCPU, const int, 1>;
 
   explicit MultiPasteOp(const OpSpec &spec)
       : Operator<Backend>(spec)
@@ -53,8 +62,6 @@ class MultiPasteOp : public Operator<Backend> {
       , in_anchors_("in_anchors", spec)
       , in_shapes_("shapes", spec)
       , out_anchors_("out_anchors", spec) {
-    zero_anchors_ = Coords(zeros_, {2});
-
     if (std::is_same<Backend, GPUBackend>::value) {
       kernel_manager_.Resize(1, 1);
     } else {
@@ -85,8 +92,6 @@ class MultiPasteOp : public Operator<Backend> {
     if (curr_batch_size == 0)
       return;
 
-    const int spatial_ndim = 2;  // in the future we may want to support 3D
-
     output_size_.Acquire(spec, ws, curr_batch_size, true);
     in_idx_.Acquire(spec, ws, curr_batch_size, false);
 
@@ -108,10 +113,10 @@ class MultiPasteOp : public Operator<Backend> {
     raw_input_size_mem_.clear();
     const auto &input_shape = images.shape();
 
-    raw_input_size_mem_.reserve(spatial_ndim * input_shape.num_samples());
+    raw_input_size_mem_.reserve(spatial_ndim_ * input_shape.num_samples());
     for (int i = 0; i < curr_batch_size; i++) {
       auto shape = input_shape.tensor_shape_span(i);
-      for (int j = 0; j < spatial_ndim; j++) {
+      for (int j = 0; j < spatial_ndim_; j++) {
         auto extent = static_cast<int>(shape[j]);
         raw_input_size_mem_.push_back(extent);
       }
@@ -124,22 +129,22 @@ class MultiPasteOp : public Operator<Backend> {
       if (in_anchors_.IsDefined()) {
         DALI_ENFORCE(in_anchors_[i].shape[0] == n_paste,
                      "in_anchors must be same length as in_idx");
-        DALI_ENFORCE(in_anchors_[i].shape[1] == spatial_ndim,
+        DALI_ENFORCE(in_anchors_[i].shape[1] == spatial_ndim_,
                      make_string("Unexpected number of dimensions for ``in_anchors``. Expected ",
-                     spatial_ndim, ", got ", in_anchors_[i].shape[1]));
+                     spatial_ndim_, ", got ", in_anchors_[i].shape[1]));
       }
       if (in_shapes_.IsDefined()) {
         DALI_ENFORCE(in_shapes_[i].shape[0] == n_paste, "in_shapes must be same length as in_idx");
-        DALI_ENFORCE(in_shapes_[i].shape[1] == spatial_ndim,
+        DALI_ENFORCE(in_shapes_[i].shape[1] == spatial_ndim_,
                      make_string("Unexpected number of dimensions for ``in_shapes``. Expected ",
-                     spatial_ndim, ", got ", in_shapes_[i].shape[1]));
+                     spatial_ndim_, ", got ", in_shapes_[i].shape[1]));
       }
       if (out_anchors_.IsDefined()) {
         DALI_ENFORCE(out_anchors_[i].shape[0] == n_paste,
                      "out_anchors must be same length as in_idx");
-        DALI_ENFORCE(out_anchors_[i].shape[1] == spatial_ndim,
+        DALI_ENFORCE(out_anchors_[i].shape[1] == spatial_ndim_,
                      make_string("Unexpected number of dimensions for ``out_anchors``. Expected ",
-                     spatial_ndim, ", got ", out_anchors_[i].shape[1]));
+                     spatial_ndim_, ", got ", out_anchors_[i].shape[1]));
       }
 
       bool found_intersection = false;
@@ -147,9 +152,10 @@ class MultiPasteOp : public Operator<Backend> {
         auto out_anchor = GetOutAnchors(i, j);
         auto in_anchor = GetInAnchors(i, j);
         auto j_idx = in_idx_[i].data[j];
-        auto in_shape = Coords(raw_input_size_mem_.data() + 2 * j_idx, dali::TensorShape<>(2));
+        auto in_shape = Coords(raw_input_size_mem_.data() + spatial_ndim_ * j_idx,
+                               dali::TensorShape<>(spatial_ndim_));
         const auto &shape = GetShape(i, j, in_shape);
-        for (int k = 0; k < spatial_ndim; k++) {
+        for (int k = 0; k < spatial_ndim_; k++) {
           DALI_ENFORCE(out_anchor.data[k] >= 0 && in_anchor.data[k] >= 0 &&
                        out_anchor.data[k] + shape.data[k] <= output_size_[i].data[k] &&
                        in_anchor.data[k] + shape.data[k] <= in_shape.data[k],
@@ -159,7 +165,8 @@ class MultiPasteOp : public Operator<Backend> {
         for (int k = 0; k < j; k++) {
           auto k_idx = in_idx_[i].data[k];
           if (Intersects(out_anchor, shape, GetOutAnchors(i, k), GetShape(
-                  i, k, Coords(raw_input_size_mem_.data() + 2 * k_idx, dali::TensorShape<>(2))))) {
+                  i, k, Coords(raw_input_size_mem_.data() + spatial_ndim_ * k_idx,
+                               dali::TensorShape<>(spatial_ndim_))))) {
             found_intersection = true;
             break;
           }
@@ -170,6 +177,52 @@ class MultiPasteOp : public Operator<Backend> {
       }
       no_intersections_.push_back(!found_intersection);
     }
+  }
+
+  using Operator<Backend>::RunImpl;
+
+  void RunImpl(workspace_t<Backend> &ws) override {
+    const auto input_type_id = ws.template InputRef<Backend>(0).type().id();
+    TYPE_SWITCH(input_type_id, type2id, InputType, (uint8_t, int16_t, int32_t, float), (
+        TYPE_SWITCH(output_type_, type2id, OutputType, (uint8_t, int16_t, int32_t, float), (
+                This().template RunTyped<OutputType, InputType>(ws);
+        ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
+    ), DALI_FAIL(make_string("Unsupported input type: ", input_type_id)))  // NOLINT
+  }
+
+  bool SetupImpl(std::vector<OutputDesc> &output_desc,
+                 const workspace_t<Backend> &ws) override {
+    const auto &images = ws.template InputRef<Backend>(0);
+    int ndim = images.sample_dim();
+    DALI_ENFORCE(ndim == 3, "MultiPaste supports only 2D data with channels (HWC)");
+
+    int channel_dim = ndim - 1;
+    int nsamples = images.ntensor();
+
+    zeros_.resize(spatial_ndim_);
+    zero_anchors_ = make_tensor_cpu<1>(zeros_.data(), { spatial_ndim_ });
+
+    AcquireArguments(spec_, ws);
+
+    output_desc.resize(1);
+    output_desc[0].type = TypeTable::GetTypeInfo(output_type_);
+
+    const auto &in_shape = images.shape();
+    auto &out_shape = output_desc[0].shape;
+    out_shape.resize(nsamples, in_shape.sample_dim());
+
+    for (int i = 0; i < nsamples; i++) {
+      TensorShape<> size(output_size_[i].data, output_size_[i].data + spatial_ndim_);
+      auto out_sh = shape_cat(size, in_shape[i][channel_dim]);
+      out_shape.set_tensor_shape(i, out_sh);
+    }
+
+    TYPE_SWITCH(images.type().id(), type2id, InputType, (uint8_t, int16_t, int32_t, float), (
+        TYPE_SWITCH(output_type_, type2id, OutputType, (uint8_t, int16_t, int32_t, float), (
+            This().template SetupTyped<OutputType, InputType>(ws, out_shape);
+        ), DALI_FAIL(make_string("Unsupported output type: ", output_type_)))  // NOLINT
+    ), DALI_FAIL(make_string("Unsupported input type: ", images.type().id())))  // NOLINT
+   return true;
   }
 
   inline Coords GetInAnchors(int sample_num, int paste_num) const {
@@ -200,58 +253,51 @@ class MultiPasteOp : public Operator<Backend> {
   ArgValue<int, 2> in_shapes_;
   ArgValue<int, 2> out_anchors_;
 
-  kernels::KernelManager kernel_manager_;
-
-  const int zeros_[2] = {0, 0};
+  SmallVector<int, 4> zeros_;
   Coords zero_anchors_;
+
+  const int spatial_ndim_ = 2;
+
+  kernels::KernelManager kernel_manager_;
 
   vector<bool> no_intersections_;
   vector<int> raw_input_size_mem_;
 };
 
 
-class MultiPasteCPU : public MultiPasteOp<CPUBackend> {
+class MultiPasteCPU : public MultiPasteOp<CPUBackend, MultiPasteCPU> {
  public:
   explicit MultiPasteCPU(const OpSpec &spec) : MultiPasteOp(spec) {}
 
-  using Operator<CPUBackend>::RunImpl;
-
-  ~MultiPasteCPU() override = default;
-
-  DISABLE_COPY_MOVE_ASSIGN(MultiPasteCPU);
-
- protected:
-  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<CPUBackend> &ws) override;
-
-  void RunImpl(workspace_t<CPUBackend> &ws) override;
-
  private:
-  template<typename InputType, typename OutputType>
-  void RunImplExplicitlyTyped(workspace_t<CPUBackend> &ws);
+  template<typename OutputType, typename InputType>
+  void RunTyped(workspace_t<CPUBackend> &ws);
+
+  template<typename OutputType, typename InputType>
+  void SetupTyped(const workspace_t<CPUBackend> &ws,
+                  const TensorListShape<> &out_shape);
+
+  friend class MultiPasteOp<CPUBackend, MultiPasteCPU>;
 };
 
-class MultiPasteGPU : public MultiPasteOp<GPUBackend> {
+class MultiPasteGPU : public MultiPasteOp<GPUBackend, MultiPasteGPU> {
  public:
   explicit MultiPasteGPU(const OpSpec &spec) : MultiPasteOp(spec) {}
 
-  using Operator<GPUBackend>::RunImpl;
-
-  ~MultiPasteGPU() override = default;
-
-  DISABLE_COPY_MOVE_ASSIGN(MultiPasteGPU);
-
- protected:
-  bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<GPUBackend> &ws) override;
-
-  void RunImpl(workspace_t<GPUBackend> &ws) override;
-
  private:
-  template<typename InputType, typename OutputType>
-  void RunImplExplicitlyTyped(workspace_t<GPUBackend> &ws);
+  template<typename OutputType, typename InputType>
+  void RunTyped(workspace_t<GPUBackend> &ws);
 
-  void FillGPUInput(const workspace_t<GPUBackend> &ws);
+  template<typename OutputType, typename InputType>
+  void SetupTyped(const workspace_t<GPUBackend> &ws,
+                  const TensorListShape<> &out_shape);
 
-  vector<kernels::paste::MultiPasteSampleInput<2>> samples;
+  void InitSamples(const TensorListShape<> &out_shape);
+
+
+  vector<kernels::paste::MultiPasteSampleInput<2>> samples_;
+
+  friend class MultiPasteOp<GPUBackend, MultiPasteGPU>;
 };
 
 }  // namespace dali

--- a/dali/test/python/test_dali_variable_batch_size.py
+++ b/dali/test/python/test_dali_variable_batch_size.py
@@ -337,7 +337,7 @@ ops_image_custom_args = [
     (numba_function, {'batch_processing': False, 'devices': ['cpu'], 'in_types': [types.UINT8],
                       'ins_ndim': [3], 'out_types': [types.UINT8],  'outs_ndim': [3],
                       'run_fn': numba_set_all_values_to_255_batch,  'setup_fn': numba_setup_out_shape}),
-    # (fn.multi_paste, {'in_ids': np.random.randint(31, size=31), 'output_size': [300, 300, 3]})
+    (fn.multi_paste, {'in_ids': np.zeros([31], dtype=np.int32), 'output_size': [300, 300, 3]})
 ]
 
 def test_ops_image_custom_args():

--- a/dali/test/python/test_operator_multipaste.py
+++ b/dali/test/python/test_operator_multipaste.py
@@ -24,6 +24,7 @@ from test_utils import get_dali_extra_path
 DEBUG_LVL = 0
 SHOW_IMAGES = False
 
+np.random.seed(1234)
 
 data_root = get_dali_extra_path()
 img_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
@@ -144,7 +145,7 @@ def get_pipeline(
         use_gpu=False,
         num_out_of_bounds=0
 ):
-    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+    pipe = Pipeline(batch_size=batch_size, num_threads=4, device_id=0, seed=np.random.randint(12345))
     with pipe:
         input, _ = fn.readers.file(file_root=img_dir)
         decoded = fn.decoders.image(input, device='cpu', output_type=types.RGB)
@@ -205,6 +206,9 @@ def manual_verify(batch_size, inp, output, in_idx_l, in_anchors_l, shapes_l, out
         ref = ref.astype(np_type_map[dtype])
         if DEBUG_LVL > 0 and not np.array_equal(out, ref):
             print(f"Error on image {i}")
+            import PIL.Image
+            PIL.Image.fromarray(out).save("multipaste_out.png")
+            PIL.Image.fromarray(ref).save("multipaste_ref.png")
         assert np.array_equal(out, ref)
 
 


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to reduce code duplication
- It fixes a bug: incorrect memory access when using variable batch size

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Make the operator CRTP, move common code to the sperclass
     * Separate shape and data handling
     * Remove output-dependent code from Setup
     * Split SetupImpl into common base and backend-dependent SetupTyped
     * Move SetupImpl to superclass
 - Affected modules and functionalities:
     * Multipaste
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Unlocked variable batch size test
     * Make main test deterministic
 - Documentation (including examples):
     * N/A


**JIRA TASK**: DALI-2105
