### PR TITLE
Add parallel chunking support in GPU variant of the numpy reader operator

### DIFF
--- a/dali/operators/reader/loader/numpy_loader.cc
+++ b/dali/operators/reader/loader/numpy_loader.cc
@@ -193,6 +193,7 @@ void ParseHeader(FileStream *file, NumpyParseTarget& target) {
   file->Seek(offset);  // prepare file for later reads
 
   ParseHeaderMetadata(target, header);
+  target.data_offset = offset;
 }
 
 bool NumpyHeaderCache::GetFromCache(const string &file_name, NumpyParseTarget &target) {

--- a/dali/operators/reader/loader/numpy_loader_gpu.cc
+++ b/dali/operators/reader/loader/numpy_loader_gpu.cc
@@ -50,8 +50,6 @@ void NumpyLoaderGPU::ReadSampleHelper(CUFileStream *file, ImageFileWrapperGPU& i
   // register the buffer (if needed)
   RegisterBuffer(buffer, read_size);
 
-  // Index image_bytes = volume(imfile.shape) * imfile.type_info.size();
-
   // copy the image
   file->ReadGPUThread(static_cast<uint8_t*>(buffer), read_size, 0, file_offset);
 }
@@ -109,8 +107,7 @@ void NumpyLoaderGPU::ReadSample(ImageFileWrapperGPU& imfile) {
                                                       size_t read_size) {
     // read sample
     ReadSampleHelper(imfile.file_stream.get(), imfile, buffer, file_offset, read_size);
-    // close the file handle
-    // imfile.file_stream->Close();
+    // we cannot close the file handle here, we need to remember to do it later on
   };
 
   // set file path

--- a/dali/operators/reader/loader/numpy_loader_gpu.cc
+++ b/dali/operators/reader/loader/numpy_loader_gpu.cc
@@ -45,7 +45,7 @@ void NumpyLoaderGPU::RegisterBuffer(void *buffer, size_t total_size) {
   }
 }
 
-void NumpyLoaderGPU::ReadSampleHelper(CUFileStream *file, ImageFileWrapperGPU& imfile,
+void NumpyLoaderGPU::ReadSampleHelper(CUFileStream *file,
                                       void *buffer, Index file_offset, size_t read_size) {
   // register the buffer (if needed)
   RegisterBuffer(buffer, read_size);
@@ -106,7 +106,7 @@ void NumpyLoaderGPU::ReadSample(ImageFileWrapperGPU& imfile) {
   imfile.read_sample_f = [this, image_file, &imfile] (void *buffer, Index file_offset,
                                                       size_t read_size) {
     // read sample
-    ReadSampleHelper(imfile.file_stream.get(), imfile, buffer, file_offset, read_size);
+    ReadSampleHelper(imfile.file_stream.get(), buffer, file_offset, read_size);
     // we cannot close the file handle here, we need to remember to do it later on
   };
 

--- a/dali/operators/reader/loader/numpy_loader_gpu.cc
+++ b/dali/operators/reader/loader/numpy_loader_gpu.cc
@@ -46,14 +46,14 @@ void NumpyLoaderGPU::RegisterBuffer(void *buffer, size_t total_size) {
 }
 
 void NumpyLoaderGPU::ReadSampleHelper(CUFileStream *file, ImageFileWrapperGPU& imfile,
-                                      void *buffer, Index offset, size_t total_size) {
+                                      void *buffer, Index file_offset, size_t read_size) {
   // register the buffer (if needed)
-  RegisterBuffer(buffer, total_size);
+  RegisterBuffer(buffer, read_size);
 
-  Index image_bytes = volume(imfile.shape) * imfile.type_info.size();
+  // Index image_bytes = volume(imfile.shape) * imfile.type_info.size();
 
   // copy the image
-  file->ReadGPU(static_cast<uint8_t*>(buffer), image_bytes, offset);
+  file->ReadGPUThread(static_cast<uint8_t*>(buffer), read_size, 0, file_offset);
 }
 
 // we need to implement that but we should split parsing and reading in this case
@@ -105,12 +105,12 @@ void NumpyLoaderGPU::ReadSample(ImageFileWrapperGPU& imfile) {
     imfile.transpose_fortan_order = target.fortran_order;
   };
 
-  imfile.read_sample_f = [this, image_file, &imfile] (void *buffer, Index offset,
-                                                      size_t total_size) {
+  imfile.read_sample_f = [this, image_file, &imfile] (void *buffer, Index file_offset,
+                                                      size_t read_size) {
     // read sample
-    ReadSampleHelper(imfile.file_stream.get(), imfile, buffer, offset, total_size);
+    ReadSampleHelper(imfile.file_stream.get(), imfile, buffer, file_offset, read_size);
     // close the file handle
-    imfile.file_stream->Close();
+    // imfile.file_stream->Close();
   };
 
   // set file path

--- a/dali/operators/reader/loader/numpy_loader_gpu.cc
+++ b/dali/operators/reader/loader/numpy_loader_gpu.cc
@@ -51,7 +51,7 @@ void NumpyLoaderGPU::ReadSampleHelper(CUFileStream *file, ImageFileWrapperGPU& i
   RegisterBuffer(buffer, read_size);
 
   // copy the image
-  file->ReadGPUThread(static_cast<uint8_t*>(buffer), read_size, 0, file_offset);
+  file->ReadGPUImpl(static_cast<uint8_t*>(buffer), read_size, 0, file_offset);
 }
 
 // we need to implement that but we should split parsing and reading in this case

--- a/dali/operators/reader/loader/numpy_loader_gpu.h
+++ b/dali/operators/reader/loader/numpy_loader_gpu.h
@@ -67,7 +67,7 @@ class NumpyLoaderGPU : public CUFileLoader {
   void RegisterBuffer(void *buffer, size_t total_size);
 
   // read the full sample
-  void ReadSampleHelper(CUFileStream *file, ImageFileWrapperGPU& imfile,
+  void ReadSampleHelper(CUFileStream *file,
                         void *buffer, Index offset, size_t total_size);
 
   // do we want to register device buffers:

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -69,7 +69,7 @@ void NumpyReaderGPU::Prefetch() {
     size_t file_offset = 0;
     while (image_bytes > 0) {
       size_t read_bytes = std::min(image_bytes, chunk_size);
-      void* buffer = static_cast<void*>(base_ptr);
+      void* buffer = static_cast<void*>(dst_ptr);
       thread_pool_.AddWork([&curr_batch, data_idx, buffer, file_offset, read_bytes](int tid) {
         // curr_batch[data_idx]->read_sample_f(curr_tensor_list.raw_mutable_data(),
         //                                    curr_tensor_list.tensor_offset(data_idx) *
@@ -79,7 +79,7 @@ void NumpyReaderGPU::Prefetch() {
       });
 
       // update addresses
-      base_ptr += read_bytes;
+      dst_ptr += read_bytes;
       file_offset += read_bytes;
       image_bytes -= read_bytes;
     }

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -58,12 +58,12 @@ void NumpyReaderGPU::Prefetch() {
   curr_tensor_list.Resize(TensorListShape<>(tmp_shapes), ref_type);
 
   size_t chunk_size = static_cast<size_t>( \
-                        div_ceil(static_cast<uint64_t>(curr_tensor_list.nbytes()), \
+                        div_ceil(static_cast<uint64_t>(curr_tensor_list.nbytes()),
                                  static_cast<uint64_t>(thread_pool_.NumThreads())));
 
   // read the data
   for (size_t data_idx = 0; data_idx < curr_tensor_list.ntensor(); ++data_idx) {
-    size_t image_bytes = static_cast<size_t>(volume(curr_tensor_list.tensor_shape(data_idx)) \
+    size_t image_bytes = static_cast<size_t>(volume(curr_tensor_list.tensor_shape(data_idx))
                                              * curr_tensor_list.type().size());
     uint8_t* dst_ptr = static_cast<uint8_t*>(curr_tensor_list.raw_mutable_tensor(data_idx));
     size_t file_offset = 0;
@@ -71,10 +71,6 @@ void NumpyReaderGPU::Prefetch() {
       size_t read_bytes = std::min(image_bytes, chunk_size);
       void* buffer = static_cast<void*>(dst_ptr);
       thread_pool_.AddWork([&curr_batch, data_idx, buffer, file_offset, read_bytes](int tid) {
-        // curr_batch[data_idx]->read_sample_f(curr_tensor_list.raw_mutable_data(),
-        //                                    curr_tensor_list.tensor_offset(data_idx) *
-        //                                    curr_tensor_list.type().size(),
-        //                                    image_bytes);
         curr_batch[data_idx]->read_sample_f(buffer, file_offset, read_bytes);
       });
 

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -65,7 +65,7 @@ void NumpyReaderGPU::Prefetch() {
   for (size_t data_idx = 0; data_idx < curr_tensor_list.ntensor(); ++data_idx) {
     size_t image_bytes = static_cast<size_t>(volume(curr_tensor_list.tensor_shape(data_idx)) \
                                              * curr_tensor_list.type().size());
-    uint8_t* base_ptr = static_cast<uint8_t*>(curr_tensor_list.raw_mutable_tensor(data_idx));
+    uint8_t* dst_ptr = static_cast<uint8_t*>(curr_tensor_list.raw_mutable_tensor(data_idx));
     size_t file_offset = 0;
     while (image_bytes > 0) {
       size_t read_bytes = std::min(image_bytes, chunk_size);

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -52,25 +52,43 @@ void NumpyReaderGPU::Prefetch() {
         "The data produced by the reader has inconsistent dimensionality:\n"
         "[", data_idx, "] has ", sample->shape.size(), " dimensions whereas\n"
         "[0] has ", ref_shape.size(), " dimensions."));
-    DALI_ENFORCE(ref_shape.size() == sample->shape.size(),
-                  make_string("The tensors in the input batch do not all have the same number of "
-                  "dimensions for sample [0]: ", ref_shape.size(), " vs [", data_idx, "]: ",
-                  sample->shape.size(), "."));
     tmp_shapes.push_back(sample->shape);
   }
 
   curr_tensor_list.Resize(TensorListShape<>(tmp_shapes), ref_type);
 
+  size_t chunk_size = static_cast<size_t>( \
+                        div_ceil(static_cast<uint64_t>(curr_tensor_list.nbytes()), \
+                                 static_cast<uint64_t>(thread_pool_.NumThreads())));
+
   // read the data
   for (size_t data_idx = 0; data_idx < curr_tensor_list.ntensor(); ++data_idx) {
-    thread_pool_.AddWork([&curr_batch, &curr_tensor_list, data_idx](int tid) {
-        curr_batch[data_idx]->read_sample_f(curr_tensor_list.raw_mutable_data(),
-                                            curr_tensor_list.tensor_offset(data_idx) *
-                                            curr_tensor_list.type().size(),
-                                            curr_tensor_list.nbytes());
+    size_t image_bytes = static_cast<size_t>(volume(curr_tensor_list.tensor_shape(data_idx)) \
+                                             * curr_tensor_list.type().size());
+    uint8_t* base_ptr = static_cast<uint8_t*>(curr_tensor_list.raw_mutable_tensor(data_idx));
+    size_t file_offset = 0;
+    while (image_bytes > 0) {
+      size_t read_bytes = std::min(image_bytes, chunk_size);
+      void* buffer = static_cast<void*>(base_ptr);
+      thread_pool_.AddWork([&curr_batch, data_idx, buffer, file_offset, read_bytes](int tid) {
+        // curr_batch[data_idx]->read_sample_f(curr_tensor_list.raw_mutable_data(),
+        //                                    curr_tensor_list.tensor_offset(data_idx) *
+        //                                    curr_tensor_list.type().size(),
+        //                                    image_bytes);
+        curr_batch[data_idx]->read_sample_f(buffer, file_offset, read_bytes);
       });
+
+      // update addresses
+      base_ptr += read_bytes;
+      file_offset += read_bytes;
+      image_bytes -= read_bytes;
+    }
   }
   thread_pool_.RunAll();
+
+  for (size_t data_idx = 0; data_idx < curr_tensor_list.ntensor(); ++data_idx) {
+    curr_batch[data_idx]->file_stream->Close();
+  }
 }
 
 void PermuteHelper(const TensorShape<> &plain_shapes, std::vector<int64_t> &perm_shape,

--- a/dali/util/cufile.h
+++ b/dali/util/cufile.h
@@ -46,6 +46,8 @@ class DLL_PUBLIC CUFileStream : public FileStream {
    * buffer and the offset where it should put the data.
    */
   virtual size_t ReadGPU(uint8_t* buffer, size_t n_bytes, size_t offset = 0) = 0;
+  virtual size_t ReadGPUThread(uint8_t* buffer, size_t n_bytes, \
+                               size_t buffer_offset, size_t file_offset) = 0;
 
  protected:
   explicit CUFileStream(const std::string& path) : FileStream(path) {}

--- a/dali/util/cufile.h
+++ b/dali/util/cufile.h
@@ -46,7 +46,7 @@ class DLL_PUBLIC CUFileStream : public FileStream {
    * buffer and the offset where it should put the data.
    */
   virtual size_t ReadGPU(uint8_t* buffer, size_t n_bytes, size_t offset = 0) = 0;
-  virtual size_t ReadGPUThread(uint8_t* buffer, size_t n_bytes, \
+  virtual size_t ReadGPUThread(uint8_t* buffer, size_t n_bytes,
                                size_t buffer_offset, size_t file_offset) = 0;
 
  protected:

--- a/dali/util/cufile.h
+++ b/dali/util/cufile.h
@@ -47,7 +47,7 @@ class DLL_PUBLIC CUFileStream : public FileStream {
    */
   virtual size_t ReadGPU(uint8_t* buffer, size_t n_bytes, size_t offset = 0) = 0;
   virtual size_t ReadGPUImpl(uint8_t* buffer, size_t n_bytes,
-			     size_t buffer_offset, size_t file_offset) = 0;
+                             size_t buffer_offset, size_t file_offset) = 0;
 
  protected:
   explicit CUFileStream(const std::string& path) : FileStream(path) {}

--- a/dali/util/cufile.h
+++ b/dali/util/cufile.h
@@ -46,8 +46,8 @@ class DLL_PUBLIC CUFileStream : public FileStream {
    * buffer and the offset where it should put the data.
    */
   virtual size_t ReadGPU(uint8_t* buffer, size_t n_bytes, size_t offset = 0) = 0;
-  virtual size_t ReadGPUThread(uint8_t* buffer, size_t n_bytes,
-                               size_t buffer_offset, size_t file_offset) = 0;
+  virtual size_t ReadGPUImpl(uint8_t* buffer, size_t n_bytes,
+			     size_t buffer_offset, size_t file_offset) = 0;
 
  protected:
   explicit CUFileStream(const std::string& path) : FileStream(path) {}

--- a/dali/util/std_cufile.cc
+++ b/dali/util/std_cufile.cc
@@ -145,7 +145,7 @@ size_t StdCUFileStream::ReadGPUImpl(uint8_t* gpu_buffer, size_t n_bytes,
 }
 
 size_t StdCUFileStream::ReadGPU(uint8_t* gpu_buffer, size_t n_bytes, size_t buffer_offset) {
-  n_bytes = ReadGPUThread(gpu_buffer, n_bytes, buffer_offset, 0);
+  n_bytes = ReadGPUImpl(gpu_buffer, n_bytes, buffer_offset, 0);
 
   // we can safely advance the file pointer here
   pos_ += n_bytes;

--- a/dali/util/std_cufile.cc
+++ b/dali/util/std_cufile.cc
@@ -145,27 +145,9 @@ size_t StdCUFileStream::ReadGPUThread(uint8_t* gpu_buffer, size_t n_bytes,
 }
 
 size_t StdCUFileStream::ReadGPU(uint8_t* gpu_buffer, size_t n_bytes, size_t buffer_offset) {
-  // compute size
-  n_bytes = std::min(n_bytes, length_ - pos_);
+  n_bytes = ReadGPUThread(gpu_buffer, n_bytes, buffer_offset, 0);
 
-  // read data: backup n_bytes here and create a read-offset
-  ssize_t n_read = n_bytes;
-  off_t read_off = 0;
-  while (n_read > 0) {
-    int64_t read = cuFileRead(f_.cufh, static_cast<void*>(gpu_buffer), n_read,
-                              static_cast<off_t>(pos_) + read_off, buffer_offset);
-
-    if (read >= 0) {
-      // worked well, continue
-      n_read -= read;
-      read_off += read;
-      buffer_offset += read;
-    } else {
-      // say goodbye here
-      HandleIOError(read);
-    }
-  }
-
+  // we can safely advance the file pointer here
   pos_ += n_bytes;
   return n_bytes;
 }

--- a/dali/util/std_cufile.cc
+++ b/dali/util/std_cufile.cc
@@ -115,8 +115,8 @@ void StdCUFileStream::HandleIOError(int64 ret) const {
   }
 }
 
-size_t StdCUFileStream::ReadGPUThread(uint8_t* gpu_buffer, size_t n_bytes,
-                                      size_t buffer_offset, size_t file_offset) {
+size_t StdCUFileStream::ReadGPUImpl(uint8_t* gpu_buffer, size_t n_bytes,
+				    size_t buffer_offset, size_t file_offset) {
   // effective pos:
   size_t eff_pos = pos_ + file_offset;
 

--- a/dali/util/std_cufile.cc
+++ b/dali/util/std_cufile.cc
@@ -116,7 +116,7 @@ void StdCUFileStream::HandleIOError(int64 ret) const {
 }
 
 size_t StdCUFileStream::ReadGPUImpl(uint8_t* gpu_buffer, size_t n_bytes,
-				    size_t buffer_offset, size_t file_offset) {
+                                    size_t buffer_offset, size_t file_offset) {
   // effective pos:
   size_t eff_pos = pos_ + file_offset;
 

--- a/dali/util/std_cufile.cc
+++ b/dali/util/std_cufile.cc
@@ -115,7 +115,7 @@ void StdCUFileStream::HandleIOError(int64 ret) const {
   }
 }
 
-size_t StdCUFileStream::ReadGPUThread(uint8_t* gpu_buffer, size_t n_bytes, \
+size_t StdCUFileStream::ReadGPUThread(uint8_t* gpu_buffer, size_t n_bytes,
                                       size_t buffer_offset, size_t file_offset) {
   // effective pos:
   size_t eff_pos = pos_ + file_offset;
@@ -126,16 +126,15 @@ size_t StdCUFileStream::ReadGPUThread(uint8_t* gpu_buffer, size_t n_bytes, \
   // read data: backup n_bytes here and create a read-offset
   ssize_t n_read = n_bytes;
   off_t read_off = 0;
-  off_t buffer_off = buffer_offset;
   while (n_read > 0) {
     int64_t read = cuFileRead(f_.cufh, static_cast<void*>(gpu_buffer), n_read,
-                              static_cast<off_t>(eff_pos) + read_off, buffer_off);
+                              static_cast<off_t>(eff_pos) + read_off, buffer_offset);
 
     if (read >= 0) {
       // worked well, continue
       n_read -= read;
       read_off += read;
-      buffer_off += read;
+      buffer_offset += read;
     } else {
       // say goodbye here
       HandleIOError(read);
@@ -145,23 +144,22 @@ size_t StdCUFileStream::ReadGPUThread(uint8_t* gpu_buffer, size_t n_bytes, \
   return n_bytes;
 }
 
-size_t StdCUFileStream::ReadGPU(uint8_t* gpu_buffer, size_t n_bytes, size_t offset) {
+size_t StdCUFileStream::ReadGPU(uint8_t* gpu_buffer, size_t n_bytes, size_t buffer_offset) {
   // compute size
   n_bytes = std::min(n_bytes, length_ - pos_);
 
   // read data: backup n_bytes here and create a read-offset
   ssize_t n_read = n_bytes;
   off_t read_off = 0;
-  off_t buffer_off = offset;
   while (n_read > 0) {
     int64_t read = cuFileRead(f_.cufh, static_cast<void*>(gpu_buffer), n_read,
-                              static_cast<off_t>(pos_) + read_off, buffer_off);
+                              static_cast<off_t>(pos_) + read_off, buffer_offset);
 
     if (read >= 0) {
       // worked well, continue
       n_read -= read;
       read_off += read;
-      buffer_off += read;
+      buffer_offset += read;
     } else {
       // say goodbye here
       HandleIOError(read);

--- a/dali/util/std_cufile.h
+++ b/dali/util/std_cufile.h
@@ -34,7 +34,7 @@ class StdCUFileStream : public CUFileStream {
   void Close() override;
   shared_ptr<void> Get(size_t n_bytes) override;
   size_t ReadGPUImpl(uint8_t* gpu_buffer, size_t n_bytes,
-		     size_t buffer_offset, size_t file_offset) override;
+                     size_t buffer_offset, size_t file_offset) override;
   size_t ReadGPU(uint8_t * buffer, size_t n_bytes, size_t offset = 0) override;
   size_t Read(uint8_t* cpu_buffer, size_t n_bytes) override;
   size_t Pos() const;

--- a/dali/util/std_cufile.h
+++ b/dali/util/std_cufile.h
@@ -33,7 +33,7 @@ class StdCUFileStream : public CUFileStream {
   explicit StdCUFileStream(const std::string& path);
   void Close() override;
   shared_ptr<void> Get(size_t n_bytes) override;
-  size_t ReadGPUThread(uint8_t* gpu_buffer, size_t n_bytes, \
+  size_t ReadGPUThread(uint8_t* gpu_buffer, size_t n_bytes,
                        size_t buffer_offset, size_t file_offset) override;
   size_t ReadGPU(uint8_t * buffer, size_t n_bytes, size_t offset = 0) override;
   size_t Read(uint8_t* cpu_buffer, size_t n_bytes) override;

--- a/dali/util/std_cufile.h
+++ b/dali/util/std_cufile.h
@@ -33,8 +33,8 @@ class StdCUFileStream : public CUFileStream {
   explicit StdCUFileStream(const std::string& path);
   void Close() override;
   shared_ptr<void> Get(size_t n_bytes) override;
-  size_t ReadGPUThread(uint8_t* gpu_buffer, size_t n_bytes,
-                       size_t buffer_offset, size_t file_offset) override;
+  size_t ReadGPUImpl(uint8_t* gpu_buffer, size_t n_bytes,
+		     size_t buffer_offset, size_t file_offset) override;
   size_t ReadGPU(uint8_t * buffer, size_t n_bytes, size_t offset = 0) override;
   size_t Read(uint8_t* cpu_buffer, size_t n_bytes) override;
   size_t Pos() const;

--- a/dali/util/std_cufile.h
+++ b/dali/util/std_cufile.h
@@ -33,6 +33,8 @@ class StdCUFileStream : public CUFileStream {
   explicit StdCUFileStream(const std::string& path);
   void Close() override;
   shared_ptr<void> Get(size_t n_bytes) override;
+  size_t ReadGPUThread(uint8_t* gpu_buffer, size_t n_bytes, \
+                       size_t buffer_offset, size_t file_offset) override;
   size_t ReadGPU(uint8_t * buffer, size_t n_bytes, size_t offset = 0) override;
   size_t Read(uint8_t* cpu_buffer, size_t n_bytes) override;
   size_t Pos() const;

--- a/include/dali/core/dynlink_cufile.h
+++ b/include/dali/core/dynlink_cufile.h
@@ -62,7 +62,7 @@ class CufileError : public std::runtime_error {
         return "cufile: invalid pointer memory type";
       case CU_FILE_CUDA_POINTER_RANGE_ERROR:
         return "cufile: pointer range exceeds allocated address range";
-      case CU_FILE_CUDA_CONTECUFILE_OPT_MISMATCH:
+      case CU_FILE_CUDA_CONTEXT_MISMATCH:
         return "cufile: cuda context mismatch";
       case CU_FILE_INVALID_MAPPING_SIZE:
         return "cufile: access beyond maximum pinned size";


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed because of Unet3d: threading intra-sample

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     implemented pread style cufile read
 - Affected modules and functionalities:
    base readers, numpy reader gpu backend
 - Key points relevant for the review:
    handling file offsets when doing threaded reads, more low lying IO routines have to be moved to the loader and/or reader
 - Validation and testing:
    should be transparently covered by existing tests
 - Documentation (including examples):
    same as before


**JIRA TASK**: *[Use DALI-XXXX or NA]*
