### PR TITLE
NumpyReader to use HostWorkspace

### DIFF
--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -118,12 +118,12 @@ bool NumpyReader::SetupImpl(std::vector<OutputDesc> &output_desc,
   // If necessary start prefetching thread and wait for a consumable batch
   DataReader<CPUBackend, ImageFileWrapper>::SetupImpl(output_desc, ws);
 
+  int batch_size = prefetched_batch_queue_[curr_batch_consumer_].size();
   const auto &file_0 = GetSample(0);
   TypeInfo output_type = file_0.image.type();
   int ndim = file_0.image.shape().sample_dim();
-
-  TensorListShape<> sh(max_batch_size_, ndim);
-  for (int i = 0; i < max_batch_size_; i++) {
+  TensorListShape<> sh(batch_size, ndim);
+  for (int i = 0; i < batch_size; i++) {
     auto sample_sh = sh.tensor_shape_span(i);
     const auto& file_i = GetSample(i);
     const auto &file_sh = file_i.image.shape();

--- a/dali/operators/reader/numpy_reader_op.h
+++ b/dali/operators/reader/numpy_reader_op.h
@@ -15,19 +15,19 @@
 #ifndef DALI_OPERATORS_READER_NUMPY_READER_OP_H_
 #define DALI_OPERATORS_READER_NUMPY_READER_OP_H_
 
-#include <utility>
 #include <string>
+#include <utility>
 #include <vector>
-
-#include "dali/operators/reader/reader_op.h"
 #include "dali/operators/reader/loader/numpy_loader.h"
+#include "dali/operators/reader/reader_op.h"
+#include "dali/pipeline/operator/arg_helper.h"
 
 namespace dali {
 
 class NumpyReader : public DataReader<CPUBackend, ImageFileWrapper > {
  public:
   explicit NumpyReader(const OpSpec& spec)
-    : DataReader< CPUBackend, ImageFileWrapper >(spec) {
+      : DataReader<CPUBackend, ImageFileWrapper>(spec) {
     bool shuffle_after_epoch = spec.GetArgument<bool>("shuffle_after_epoch");
     loader_ = InitLoader<NumpyLoader>(spec, shuffle_after_epoch);
   }

--- a/dali/operators/reader/numpy_reader_op.h
+++ b/dali/operators/reader/numpy_reader_op.h
@@ -42,8 +42,6 @@ class NumpyReader : public DataReader<CPUBackend, ImageFileWrapper > {
  protected:
   void TransposeHelper(Tensor<CPUBackend>& output, const Tensor<CPUBackend>& input);
   USE_READER_OPERATOR_MEMBERS(CPUBackend, ImageFileWrapper);
-
-  using Operator<CPUBackend>::max_batch_size_;
 };
 
 }  // namespace dali

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -196,8 +196,20 @@ class DataReader : public Operator<Backend> {
     return ret;
   }
 
-  LoadTarget& GetSample(int sample_idx) {
-    return *prefetched_batch_queue_[curr_batch_consumer_][sample_idx];
+  inline std::vector<std::shared_ptr<LoadTarget>>& GetCurrBatch() {
+    return prefetched_batch_queue_[curr_batch_consumer_];
+  }
+
+  inline const std::vector<std::shared_ptr<LoadTarget>>& GetCurrBatch() const {
+    return prefetched_batch_queue_[curr_batch_consumer_];
+  }
+
+  inline int GetCurrBatchSize() const {
+    return GetCurrBatch().size();
+  }
+
+  inline LoadTarget& GetSample(int sample_idx) {
+    return *GetCurrBatch()[sample_idx];
   }
 
   LoadTargetPtr MoveSample(int sample_idx) {

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -127,15 +127,14 @@ class DataReader : public Operator<Backend> {
   }
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    // If necessary start prefetching thread and wait for a consumable batch
+    StartPrefetchThread();
+    ConsumerWait();
     return false;
   }
 
   // CPUBackend operators
   void Run(HostWorkspace &ws) override {
-    // If necessary start prefetching thread and wait for a consumable batch
-    StartPrefetchThread();
-    ConsumerWait();
-
     // consume batch
     DomainTimeRange tr("[DALI][DataReader] Run #" + to_string(curr_batch_consumer_),
                        DomainTimeRange::kViolet);
@@ -175,10 +174,6 @@ class DataReader : public Operator<Backend> {
 
   // GPUBackend operators
   void Run(DeviceWorkspace &ws) override {
-    // If necessary start prefetching thread and wait for a consumable batch
-    StartPrefetchThread();
-    ConsumerWait();
-
     // Consume batch
     Operator<Backend>::Run(ws);
     CUDA_CALL(cudaStreamSynchronize(ws.stream()));


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to improve flexibility of implementation and to adhere to the current HostWorkspace.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Reworked NumpyReader to use HostWorkspace instead of SampleWorkspace, so that we can control the level of parallelism (e.g. intra-sample parallelism)*
 - Affected modules and functionalities:
     *NumpyReader*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *Existing tests apply*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-2127]*
