### PR TITLE
Update documentation of random.uniform to reflect data type conversion behavior

### DIFF
--- a/dali/operators/random/rng_base.cc
+++ b/dali/operators/random/rng_base.cc
@@ -24,6 +24,9 @@ It should be added as parent to all RNG operators.)code")
     .AddOptionalArg<std::vector<int>>("shape",
       R"code(Shape of the output data.)code", nullptr, true)
     .AddOptionalArg<DALIDataType>("dtype",
-      R"code(Output data type.)code", nullptr);
+      R"code(Output data type.
+
+Note: The generated numbers are converted to the output data type, rounding and clamping if necessary.
+)code", nullptr);
 
 }  // namespace dali

--- a/dali/operators/random/rng_base.cc
+++ b/dali/operators/random/rng_base.cc
@@ -26,7 +26,8 @@ It should be added as parent to all RNG operators.)code")
     .AddOptionalArg<DALIDataType>("dtype",
       R"code(Output data type.
 
-Note: The generated numbers are converted to the output data type, rounding and clamping if necessary.
+.. note::
+  The generated numbers are converted to the output data type, rounding and clamping if necessary.
 )code", nullptr);
 
 }  // namespace dali

--- a/dali/operators/random/uniform_distribution_cpu.cc
+++ b/dali/operators/random/uniform_distribution_cpu.cc
@@ -69,8 +69,9 @@ generated.
 
 This argument is mutually exclusive with ``values``.
 
-Warning: When specifying an integer type as ``dtype``, the generated numbers can go outside
-the specified range, due to rounding.
+.. warning::
+  When specifying an integer type as ``dtype``, the generated numbers can go outside
+  the specified range, due to rounding.
 )code",
       std::vector<float>{-1.0f, 1.0f}, true)
     .AddOptionalArg<std::vector<float>>("values",

--- a/dali/operators/random/uniform_distribution_cpu.cc
+++ b/dali/operators/random/uniform_distribution_cpu.cc
@@ -21,6 +21,10 @@ namespace dali {
 DALI_SCHEMA(random__Uniform)
     .DocStr(R"code(Generates random numbers following a uniform distribution.
 
+It can be configured to produce a continuous uniform distribution in the ``range`` [min, max),
+or a discrete uniform distribution where any of the specified ``values`` [v0, v1, ..., vn] occur
+with equal probability.
+
 The shape of the generated data can be either specified explicitly with a ``shape`` argument,
 or chosen to match the shape of the input, if provided. If none are present, a scalar is
 generated.
@@ -30,10 +34,15 @@ generated.
     .AddOptionalArg("range",
       R"code(Range ``[min, max)`` of a continuous uniform distribution.
 
-This argument is mutually exclusive with ``values``.)code",
+This argument is mutually exclusive with ``values``.
+
+.. warning::
+  When specifying an integer type as ``dtype``, the generated numbers can go outside
+  the specified range, due to rounding.
+)code",
       std::vector<float>{-1.0f, 1.0f}, true)
     .AddOptionalArg<std::vector<float>>("values",
-      R"code(The discrete values produced by a discrete uniform distribution.
+      R"code(The discrete values [v0, v1, ..., vn] produced by a discrete uniform distribution.
 
 This argument is mutually exclusive with ``range``.)code",
       nullptr, true)
@@ -45,6 +54,10 @@ DALI_REGISTER_OPERATOR(random__Uniform, UniformDistribution<CPUBackend>, CPU);
 DALI_SCHEMA(Uniform)
     .DocStr(R"code(Generates random numbers following a uniform distribution.
 
+It can be configured to produce a continuous uniform distribution in the ``range`` [min, max),
+or a discrete uniform distribution where any of the specified ``values`` [v0, v1, ..., vn] occur
+with equal probability.
+
 The shape of the generated data can be either specified explicitly with a ``shape`` argument,
 or chosen to match the shape of the input, if provided. If none are present, a scalar is
 generated.
@@ -54,10 +67,14 @@ generated.
     .AddOptionalArg("range",
       R"code(Range ``[min, max)`` of a continuous uniform distribution.
 
-This argument is mutually exclusive with ``values``.)code",
+This argument is mutually exclusive with ``values``.
+
+Warning: When specifying an integer type as ``dtype``, the generated numbers can go outside
+the specified range, due to rounding.
+)code",
       std::vector<float>{-1.0f, 1.0f}, true)
     .AddOptionalArg<std::vector<float>>("values",
-      R"code(The discrete values produced by a discrete uniform distribution.
+      R"code(The discrete values [v0, v1, ..., vn] produced by a discrete uniform distribution.
 
 This argument is mutually exclusive with ``range``.)code",
       nullptr, true)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds an explanatory note to random.Uniform documentation, regarding data type conversion

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Documentation was extended*
 - Affected modules and functionalities:
     *random.Uniform*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[NA]*
