### PR TITLE
Check CUDA API return values in device-side test helper.

### DIFF
--- a/dali/test/device_test_test.cu
+++ b/dali/test/device_test_test.cu
@@ -50,7 +50,7 @@ TEST(DeviceTest, DeviceSideFailure) {
   int num = 0;
   EXPECT_NONFATAL_FAILURE({
     DEVICE_TEST_CASE_BODY(DeviceTest, DeviceSideFailure, dim3(1), dim3(2))
-    num = host_status.num_messages;
+    num = status.host.num_messages;
   }, "There were errors in device code");
   EXPECT_EQ(num, 21);  // threadIdx.x == 0 succeeds once
   EXPECT_EQ(cudaGetLastError(), cudaSuccess);


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes an annoyance - coverity reporting bugs in each new instance of device-side tests (instantiated by a macor

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added checks
     * Moved most of the CUDA calls to functions outside of macro, so they can be classified once
 - Affected modules and functionalities:
     * Device-side test helper
     * Device-side test helper test
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * It is all about tests
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-2123
