### PR TITLE
Add 60s timeout for URL request in setup_packages.py

### DIFF
--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -315,7 +315,7 @@ class CudaHttpPackage(CudaPackage):
         request = Request(url)
         request.get_method = lambda : 'HEAD'
         try:
-            _ = urlopen(request)
+            _ = urlopen(request, timeout=60)
             return url
         except HTTPError:
             return None


### PR DESCRIPTION
- setup_packages.py needs to perform several URL requests to discover if there is an available package specified. If the
  transaction hangs the whole test hangs. This PR adds a timeout to make the job fail early instead of hang for several hours

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds  60s timeout for URL request in setup_packages.py

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     setup_packages.py needs to perform several URL requests to discover if there is an available package specified. If the
  transaction hangs the whole test hangs. This PR adds a timeout to make the job fail early instead of hang for several hours
 - Affected modules and functionalities:
     setup_packages.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI run, current tests applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
