### PR TITLE
Extend `pip install` command timeout to 100s

### DIFF
--- a/qa/TL1_nodeps_build/test.sh
+++ b/qa/TL1_nodeps_build/test.sh
@@ -8,8 +8,8 @@ do_once() {
     bash cmake-*.sh --skip-license --prefix=/usr
     rm cmake-*.sh
     # for stub generation
-    pip install clang
-    pip install libclang
+    pip install --default-timeout=100 clang
+    pip install --default-timeout=100 libclang
 }
 
 test_body() {

--- a/qa/TL1_ssd_training/test.sh
+++ b/qa/TL1_ssd_training/test.sh
@@ -5,7 +5,7 @@ target_dir=./docs/examples/use_cases/pytorch/single_stage_detector/
 
 test_body() {
     # workaround due to errors while pycocotools is int "pip_packages" above
-    pip install -I pycocotools
+    pip install --default-timeout=100 -I pycocotools
     apt update && apt install -y gcc-7 g++-7
 
     #install APEX

--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -15,10 +15,10 @@ do_once() {
     # check if CUDA version is at least 11.x
     if [ "$(echo "$CUDA_VERSION" | tr " " "\n" | sort -rV | head -n 1)" == "110" ]; then
         # install TF 2.4.x for CUDA 11.x test
-        pip install $($topdir/qa/setup_packages.py -i 1 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
+        pip install --default-timeout=100 $($topdir/qa/setup_packages.py -i 1 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
     else
         # install TF 2.3.x for CUDA 10.x test
-        pip install $($topdir/qa/setup_packages.py -i 0 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
+        pip install --default-timeout=100 $($topdir/qa/setup_packages.py -i 0 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
     fi
 
     # The package name can be nvidia-dali-tf-plugin,  nvidia-dali-tf-plugin-weekly or  nvidia-dali-tf-plugin-nightly
@@ -60,7 +60,7 @@ do_once() {
     export HOROVOD_NCCL_LIB=/usr/lib/x86_64-linux-gnu
     export HOROVOD_NCCL_LINK=SHARED
     export HOROVOD_WITHOUT_PYTORCH=1
-    pip install horovod==0.21.3
+    pip install --default-timeout=100 horovod==0.21.3
 
     for file in $(ls /data/imagenet/train-val-tfrecord-480-subset);
     do

--- a/qa/TL3_RN50_convergence/test_paddle.sh
+++ b/qa/TL3_RN50_convergence/test_paddle.sh
@@ -9,7 +9,7 @@ function CLEAN_AND_EXIT {
 }
 
 export USE_CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2\3/')
-pip install $(python /opt/dali/qa/setup_packages.py -i 0 -u paddlepaddle-gpu --cuda ${USE_CUDA_VERSION})
+pip install --default-timeout=100 $(python /opt/dali/qa/setup_packages.py -i 0 -u paddlepaddle-gpu --cuda ${USE_CUDA_VERSION})
 
 cd /opt/dali/docs/examples/use_cases/paddle/resnet50
 

--- a/qa/TL3_SSD_convergence/test_pytorch.sh
+++ b/qa/TL3_SSD_convergence/test_pytorch.sh
@@ -10,8 +10,8 @@ function CLEAN_AND_EXIT {
 
 cd /opt/dali/docs/examples/use_cases/pytorch/single_stage_detector/
 
-pip install mlperf_compliance Cython==0.28.4
-pip install pycocotools==2.0.0
+pip install --default-timeout=100 mlperf_compliance Cython==0.28.4
+pip install --default-timeout=100 pycocotools==2.0.0
 
 NUM_GPUS=$(nvidia-smi -L | wc -l)
 

--- a/qa/download_pip_packages.sh
+++ b/qa/download_pip_packages.sh
@@ -22,7 +22,7 @@ do
                 inst=$(python ../setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION})
                 if [ -n "$inst" ]
                 then
-                    pip download $inst -d /pip-packages
+                    pip download $inst --default-timeout=100 -d /pip-packages
                 fi
             done
         fi

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -56,7 +56,7 @@ do
         # install packages
         inst=$($topdir/qa/setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION})
         if [ -n "$inst" ]; then
-            pip install $inst -f /pip-packages
+            pip install --default-timeout=100 $inst -f /pip-packages
 
             # If we just installed tensorflow, we need to reinstall DALI TF plugin
             if [[ "$inst" == *tensorflow* ]]; then


### PR DESCRIPTION
- attempts to reduce the number of timeout pip install attempts by extending the command timeout from default 60s to 100s

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It reduces the number of timeout pip install attempts by extending the command timeout from default 60s to 100s

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     attempts to reduce the number of timeout pip install attempts by extending the command timeout from default 60s to 100s
 - Affected modules and functionalities:
     QA scripts
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI run
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
