### PR TITLE
Add channel count checking in Dump Image

### DIFF
--- a/dali/operators/debug/dump_image.cc
+++ b/dali/operators/debug/dump_image.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "dali/operators/debug/dump_image.h"
+#include "dali/core/format.h"
 #include "dali/core/tensor_layout.h"
 #include "dali/util/image.h"
 
@@ -24,11 +25,15 @@ void DumpImage<CPUBackend>::RunImpl(SampleWorkspace &ws) {
   auto &output = ws.Output<CPUBackend>(0);
 
   DALI_ENFORCE(input.ndim() == 3,
-      "Input images must have three dimensions.");
+               make_string("Input images must have three dimensions, got input with `",
+                           input.ndim(), "` dimensions."));
 
   int h = input.dim(0);
   int w = input.dim(1);
   int c = input.dim(2);
+  DALI_ENFORCE(c == 1 || c == 3,
+               make_string("Only 3-channel and gray images are supported, got input with `", c,
+                           "` channels."));
 
   WriteHWCImage(input.template data<uint8>(),
       h, w, c, std::to_string(ws.data_idx()) + "-" + suffix_ + "-" + std::to_string(0));

--- a/dali/operators/debug/dump_image.cu
+++ b/dali/operators/debug/dump_image.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "dali/core/format.h"
 #include "dali/operators/debug/dump_image.h"
 #include "dali/util/image.h"
 
@@ -21,6 +22,17 @@ template<>
 void DumpImage<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
   auto &input = ws.Input<GPUBackend>(0);
   auto &output = ws.Output<GPUBackend>(0);
+
+
+  DALI_ENFORCE(input.shape().sample_dim() == 3,
+               make_string("Input images must have three dimensions, got input with `",
+                           input.shape().sample_dim(), "` dimensions."));
+  for (int i = 0; i < input.shape().num_samples(); i++) {
+    int channels = input.shape().tensor_shape_span(i)[2];
+    DALI_ENFORCE(channels == 1 || channels == 3,
+                 make_string("Only 3-channel and gray images are supported, got input with `",
+                             channels, "` channels."));
+  }
 
   // sync before write
   CUDA_CALL(cudaStreamSynchronize(ws.stream()));


### PR DESCRIPTION
The implementation assumes that images have
1 or 3 channels but doesn't check it

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
-Fix a bug in debug operator

#### What happened in this PR?
 - What solution was applied:
     Add checks for assumed number of channels and dimensionality
 - Affected modules and functionalities:
     Dump Image
 - Key points relevant for the review:
     None
 - Validation and testing:
     CI, tbh I didn't try to use non-confomring data, I run the test that uses this operator.
 - Documentation (including examples):
     N/A

**JIRA TASK**: *[Use DALI-2042 or NA]*
