### PR TITLE
Coverity issue fixes.

### DIFF
--- a/dali/core/float16_test.cu
+++ b/dali/core/float16_test.cu
@@ -362,9 +362,10 @@ TEST(FP16Linkage, KernelTemplate) {
   ts.n = buf.size();
   CUDA_CALL(cudaMemset(buf, 0, buf.size_bytes()));
   FP16TestKernel<<<div_ceil(ts.n, 64), 64>>>(ts);
+  CUDA_CALL(cudaGetLastError());
   vector<float16> host_buf(buf.size());
   CUDA_CALL(cudaMemcpy(host_buf.data(), buf, buf.size_bytes(), cudaMemcpyDeviceToHost));
-  cudaDeviceSynchronize();
+  CUDA_CALL(cudaDeviceSynchronize());
   for (int i = 0; i < ts.n; i++) {
     EXPECT_EQ(static_cast<float>(host_buf[i]), i + 42.0f);
   }

--- a/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.cu
+++ b/dali/kernels/audio/mel_scale/mel_filter_bank_gpu.cu
@@ -175,6 +175,7 @@ class MelFilterBankGpu<T>::Impl : public MelFilterImplBase<T> {
         <<<grid, block, 0, stream>>>(block_descs, weights_down, interval_ends,
                                      args_.normalize, norm_factors, args_.nfilter);
     }
+    CUDA_CALL(cudaGetLastError());
   }
 
   using MelFilterImplBase<T>::Args;

--- a/dali/kernels/context.h
+++ b/dali/kernels/context.h
@@ -151,7 +151,7 @@ struct KernelContext {
   /**
    * @brief Caller-provided allocator for temporary data.
    */
-  Scratchpad *scratchpad;
+  Scratchpad *scratchpad = nullptr;
 };
 
 }  // namespace kernels

--- a/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
+++ b/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
@@ -204,6 +204,7 @@ void RunColorSpaceConversionKernel(Out *output, const In *input, DALIImageType o
   } else {
     DALI_FAIL(make_string("conversion not supported ", in_type, " to ", out_type));
   }
+  CUDA_CALL(cudaGetLastError());
 }
 
 }  // namespace color

--- a/dali/kernels/imgproc/convolution/cutlass/device/gemm.h
+++ b/dali/kernels/imgproc/convolution/cutlass/device/gemm.h
@@ -465,8 +465,12 @@ class Conv {
     }
 
     size_t params_sizeof = host_params_.size() * sizeof(SampleParams);
-    cudaMemcpyAsync(params_.params, host_params_.data(), params_sizeof, cudaMemcpyHostToDevice,
-                    stream);
+    result = cudaMemcpyAsync(params_.params, host_params_.data(), params_sizeof,
+                             cudaMemcpyHostToDevice, stream);
+
+    if (result != cudaSuccess) {
+      return Status::kErrorInternal;
+    }
 
     cutlass::Kernel<ConvKernel><<<grid, block, smem_size, stream>>>(params_);
 

--- a/dali/kernels/mask/grid_mask_gpu.h
+++ b/dali/kernels/mask/grid_mask_gpu.h
@@ -116,6 +116,7 @@ class GridMaskGpu {
     ), (  // NOLINT
       GridMaskKernel<Type, 0><<<grid, block, 0, ctx.gpu.stream>>>(samples_gpu, blocks_gpu);
     ));  // NOLINT
+    CUDA_CALL(cudaGetLastError());
   }
 };
 

--- a/dali/operators/bbox/bb_flip.cu
+++ b/dali/operators/bbox/bb_flip.cu
@@ -155,6 +155,7 @@ void BbFlipGPU::RunImpl(workspace_t<GPUBackend> &ws) {
       global_horz, per_sample_horz, global_vert, per_sample_vert,
       sample_idx);
   }
+  CUDA_CALL(cudaGetLastError());
 }
 
 DALI_REGISTER_OPERATOR(BbFlip, BbFlipGPU, GPU);

--- a/dali/operators/decoder/nvjpeg/permute_layout.cu
+++ b/dali/operators/decoder/nvjpeg/permute_layout.cu
@@ -90,6 +90,7 @@ void PlanarToInterleaved(Output *output, const Input *input, int64_t npixels,
   } else {
     assert(false);
   }
+  CUDA_CALL(cudaGetLastError());
 }
 
 template <typename Output, typename Input>
@@ -98,6 +99,7 @@ void PlanarRGBToGray(Output *output, const Input *input, int64_t npixels,
   int num_blocks = div_ceil(npixels, 1024);
   int block_size = (npixels < 1024) ? npixels : 1024;
   planar_rgb_to_gray<<<num_blocks, block_size, 0, stream>>>(output, input, npixels);
+  CUDA_CALL(cudaGetLastError());
 }
 
 template <typename Output, typename Input>

--- a/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.cu
+++ b/dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.cu
@@ -76,6 +76,7 @@ void ConvertToOFLayout(ColorConversionMethod cvtm, const uint8_t *input, uint8_t
   dim3 grid_dim(num_blocks(out_channels * width_px, block_dim.x),
                 num_blocks(height, block_dim.y));
   cvtm<<<grid_dim, block_dim, 0, stream>>>(input, output, pitch, width_px, height);
+  CUDA_CALL(cudaGetLastError());
 }
 
 }  // namespace

--- a/dali/test/device_test.h
+++ b/dali/test/device_test.h
@@ -36,6 +36,8 @@ struct TestStatus {
   bool Init() {
     ASSERT_EQ(cudaSuccess, cudaMalloc(&device, sizeof(TestStatusBlock)))
       << "Cannot allocate test status block", false;
+    if (device == nullptr)
+      return false;  // this should never happen - it is here to silence static analysis errors
     ASSERT_EQ(cudaSuccess, cudaMemset(device, 0, sizeof(TestStatusBlock)))
       << "Cannot clear test status block", false;
     return true;
@@ -180,7 +182,6 @@ __device__ void suite_name##_##test_name##_body( \
   dali::testing::TestStatus status;                                                     \
   if (!status.Init())                                                                   \
     return;                                                                             \
-  assert(status.device != nullptr);                                                     \
   dali::testing::ClearCudaError();                                                      \
   suite_name##_##test_name##_kernel<<<grid, block>>>(status.device, ##__VA_ARGS__);     \
   auto err = status.to_host();                                                          \

--- a/dali/test/device_test.h
+++ b/dali/test/device_test.h
@@ -33,11 +33,12 @@ struct TestStatusBlock {
 
 struct TestStatus {
   TestStatusBlock host, *device = nullptr;
-  void Init() {
+  bool Init() {
     ASSERT_EQ(cudaSuccess, cudaMalloc(&device, sizeof(TestStatusBlock)))
-      << "Cannot allocate test status block";
-    EXPECT_EQ(cudaSuccess, cudaMemset(device, 0, sizeof(TestStatusBlock)))
-      << "Cannot clear test status block";
+      << "Cannot allocate test status block", false;
+    ASSERT_EQ(cudaSuccess, cudaMemset(device, 0, sizeof(TestStatusBlock)))
+      << "Cannot clear test status block", false;
+    return true;
   }
 
   cudaError_t to_host() {
@@ -169,8 +170,8 @@ __device__ void suite_name##_##test_name##_body( \
  */
 #define DEVICE_TEST_CASE_BODY(suite_name, test_name, grid, block, ...) \
   dali::testing::TestStatus status; \
-  status.Init(); \
-  if (HasFailure()) return; \
+  if (!status.Init()) \
+    return; \
   (void)cudaGetLastError(); \
   suite_name##_##test_name##_kernel<<<grid, block>>>(status.device, ##__VA_ARGS__); \
   auto err = status.to_host(); \

--- a/dali/test/device_test.h
+++ b/dali/test/device_test.h
@@ -54,6 +54,14 @@ struct TestStatus {
   }
 };
 
+
+/**
+ * @brief For silencing static analysis _once_ instead of in every macro expansion
+ */
+inline void ClearCudaError() {
+  (void)cudaGetLastError();
+}
+
 }  // namespace testing
 }  // namespace dali
 
@@ -168,20 +176,21 @@ __device__ void suite_name##_##test_name##_body( \
  * @param block - CUDA block size
  * @param ... - extra parameters passed to the kernel invocation, if any
  */
-#define DEVICE_TEST_CASE_BODY(suite_name, test_name, grid, block, ...) \
-  dali::testing::TestStatus status; \
-  if (!status.Init()) \
-    return; \
-  (void)cudaGetLastError(); \
-  suite_name##_##test_name##_kernel<<<grid, block>>>(status.device, ##__VA_ARGS__); \
-  auto err = status.to_host(); \
-  (void)cudaGetLastError(); \
-  EXPECT_EQ(err, cudaSuccess) << "CUDA error: " \
-    << cudaGetErrorName(err) << " " << cudaGetErrorString(err); \
-  if (err == cudaErrorIllegalAddress || err == cudaErrorIllegalInstruction) { \
+#define DEVICE_TEST_CASE_BODY(suite_name, test_name, grid, block, ...)                  \
+  dali::testing::TestStatus status;                                                     \
+  if (!status.Init())                                                                   \
+    return;                                                                             \
+  assert(status.device != nullptr);                                                     \
+  dali::testing::ClearCudaError();                                                      \
+  suite_name##_##test_name##_kernel<<<grid, block>>>(status.device, ##__VA_ARGS__);     \
+  auto err = status.to_host();                                                          \
+  dali::testing::ClearCudaError();                                                      \
+  EXPECT_EQ(err, cudaSuccess) << "CUDA error: " << cudaGetErrorName(err) << " "         \
+                              << cudaGetErrorString(err);                               \
+  if (err == cudaErrorIllegalAddress || err == cudaErrorIllegalInstruction) {           \
     std::cerr << "A fatal CUDA error was reported. Resetting the device!" << std::endl; \
-    exit(err); \
-  } \
+    exit(err);                                                                          \
+  }                                                                                     \
   EXPECT_FALSE(status.host.failed) << "There were errors in device code";
 
 /**


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes coverity issues:
  * missing CUDA call status checks
  * missing error checks after kernel launches
  * potentially uninitialized pointer in KernelContext

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added checks (mostly CUDA_CALL, but I tried to match surrounding code for the style of checks)
     * Added initialized for `KernelContext::scratchpad` - KernelContext is not trivially constructible anyway.
 - Affected modules and functionalities:
     * Many
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests + CI/coverity
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-2123
