### PR TITLE
Build the latest clang from source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,7 +317,7 @@ if (DALI_CLANG_ONLY)
   message(STATUS "Generated gencode flags for clang: ${CUDA_gencode_flags_clang}")
   CUDA_get_toolkit_from_compiler(CUDA_TOOLKIT_PATH_VAR)
   message(STATUS "Used CUDA toolkit: ${CUDA_TOOLKIT_PATH_VAR}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --cuda-path=${CUDA_TOOLKIT_PATH_VAR} ${CUDA_gencode_flags_clang}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-cuda-version --cuda-path=${CUDA_TOOLKIT_PATH_VAR} ${CUDA_gencode_flags_clang}")
 endif()
 
 # Add ptx & bin flags for cuda compiler (nvcc)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ ENV PATH=/opt/python/cp36-cp36/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-c
 
 RUN ln -s /opt/python/cp${PYV}* /opt/python/v
 
-# install pyhton bindings and patch it to use the clang we have here
+# install Python bindings and patch it to use the clang we have here
 RUN pip install future setuptools wheel clang && \
     PY_CLANG_PATH=$(echo $(pip show clang) | sed 's/.*Location: \(.*\) Requires.*/\1/')/clang/cindex.py && \
     LIBCLANG_PATH=/usr/local/lib/libclang.so && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,26 +13,18 @@ ENV PYVER=${PYVER} PYV=${PYV} PYTHONPATH=/opt/python/v
 ENV PYBIN=${PYTHONPATH}/bin \
     PYLIB=${PYTHONPATH}/lib
 
-# add llvm-toolset-7.0 for python clang bindings on aarch64 where libclang wheel is not available
 ENV PATH=/opt/python/cp36-cp36/bin:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin:${PYBIN}:${PATH} \
-    LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:/opt/python/cp39-cp39/lib:${PYLIB}:${LD_LIBRARY_PATH} \
-    LIBRARY_PATH=/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:/opt/python/cp39-cp39/lib:${PYLIB}:${LIBRARY_PATH}
+    LD_LIBRARY_PATH=/usr/local/lib:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:/opt/python/cp39-cp39/lib:${PYLIB}:${LD_LIBRARY_PATH} \
+    LIBRARY_PATH=/usr/local/lib:/opt/dali/${DALI_BUILD_DIR}:/opt/python/cp36-cp36/lib:/opt/python/cp37-cp37m/lib:/opt/python/cp38-cp38/lib:/opt/python/cp39-cp39/lib:${PYLIB}:${LIBRARY_PATH}
 
 RUN ln -s /opt/python/cp${PYV}* /opt/python/v
 
-# in aarch64 pip install libclang will fail
+# install pyhton bindings and patch it to use the clang we have here
 RUN pip install future setuptools wheel clang && \
-    pip install libclang || test "$(uname -m)" == "aarch64" && \
+    PY_CLANG_PATH=$(echo $(pip show clang) | sed 's/.*Location: \(.*\) Requires.*/\1/')/clang/cindex.py && \
+    LIBCLANG_PATH=/usr/local/lib/libclang.so && \
+    sed -i "s|library_file = None|library_file = \"${LIBCLANG_PATH}\"|" ${PY_CLANG_PATH} && \
     rm -rf /root/.cache/pip/
-
-# install clang for aarch64 from llvm-toolset-7.0, and patch clang pip package to use it
-RUN if [ "$(uname -m)" == "aarch64" ]; then \
-        yum install -y centos-release-scl && \
-        yum-config-manager -y --enable rhel-server-rhscl-7-rpms && \
-        yum install -y llvm-toolset-7.0 && \
-        PY_CLANG_PATH=$(echo $(pip show clang) | sed 's/.*Location: \(.*\) Requires.*/\1/')/clang/cindex.py && \
-        sed -i 's/library_file = None/library_file = "\/opt\/rh\/llvm-toolset-7.0\/root\/usr\/lib64\/libclang.so.7"/' ${PY_CLANG_PATH}; \
-    fi
 
 RUN ldconfig
 

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -30,6 +30,20 @@ ENV DALI_DEPS_REPO=${DALI_DEPS_REPO:-https://github.com/NVIDIA/DALI_deps}
 ARG DALI_DEPS_VERSION_SHA
 ENV DALI_DEPS_VERSION_SHA=${DALI_DEPS_VERSION_SHA}
 
+# Clang, build it before deps as deps changes more frequently
+RUN CLANG_VERSION=11.1.0                                                                           && \
+    cd tmp                                                                                         && \
+    wget https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-${CLANG_VERSION}.tar.gz    && \
+    tar -xf llvmorg-*.tar.gz                                                                       && \
+    rm -rf llvmorg-*.tar.gz                                                                        && \
+    cd llvm-*                                                                                      && \
+    mkdir build                                                                                    && \
+    cd build                                                                                       && \
+    cmake -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" ../llvm && \
+    make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install                                      && \
+    cd /tmp                                                                                        && \
+    rm -rf llvm-*
+
 # run in /bin/bash to have more advanced features supported like list
 RUN /bin/bash -c 'DALI_DEPS_VERSION_SHA=${DALI_DEPS_VERSION_SHA:-$(cat /tmp/DALI_DEPS_VERSION)}    && \
     git clone ${DALI_DEPS_REPO} /tmp/dali_deps                                                     && \
@@ -40,15 +54,6 @@ RUN /bin/bash -c 'DALI_DEPS_VERSION_SHA=${DALI_DEPS_VERSION_SHA:-$(cat /tmp/DALI
     export CC_COMP=${CC}                                                                           && \
     export CXX_COMP=${CXX}                                                                         && \
     /tmp/dali_deps/build_scripts/build_deps.sh && rm -rf /tmp/dali_deps && rm -rf /tmp/DALI_DEPS_VERSION'
-
-# Clang, but only for x86_64
-RUN if [ "$(uname -m)" == "x86_64" ]; then \
-        CLANG_VERSION=10.0.0 && \
-        cd /usr/local && \
-        wget https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_VERSION}/clang+llvm-${CLANG_VERSION}-x86_64-linux-sles11.3.tar.xz && \
-        tar -xJf clang+llvm-*.tar.xz --strip 1 && \
-        rm clang+llvm-*.tar.xz; \
-    fi
 
 # extra deps
 COPY --from=extra_deps / /

--- a/docker/Dockerfile.deps
+++ b/docker/Dockerfile.deps
@@ -22,14 +22,6 @@ RUN yum remove -y devtoolset* && \
 # Don't want the short-unicode version for Python 2.7
 RUN rm -f /opt/python/cp27-cp27m
 
-COPY DALI_DEPS_VERSION /tmp
-
-ARG DALI_DEPS_REPO
-ENV DALI_DEPS_REPO=${DALI_DEPS_REPO:-https://github.com/NVIDIA/DALI_deps}
-
-ARG DALI_DEPS_VERSION_SHA
-ENV DALI_DEPS_VERSION_SHA=${DALI_DEPS_VERSION_SHA}
-
 # Clang, build it before deps as deps changes more frequently
 RUN CLANG_VERSION=11.1.0                                                                           && \
     cd tmp                                                                                         && \
@@ -43,6 +35,14 @@ RUN CLANG_VERSION=11.1.0                                                        
     make -j"$(grep ^processor /proc/cpuinfo | wc -l)" install                                      && \
     cd /tmp                                                                                        && \
     rm -rf llvm-*
+
+COPY DALI_DEPS_VERSION /tmp
+
+ARG DALI_DEPS_REPO
+ENV DALI_DEPS_REPO=${DALI_DEPS_REPO:-https://github.com/NVIDIA/DALI_deps}
+
+ARG DALI_DEPS_VERSION_SHA
+ENV DALI_DEPS_VERSION_SHA=${DALI_DEPS_VERSION_SHA}
 
 # run in /bin/bash to have more advanced features supported like list
 RUN /bin/bash -c 'DALI_DEPS_VERSION_SHA=${DALI_DEPS_VERSION_SHA:-$(cat /tmp/DALI_DEPS_VERSION)}    && \


### PR DESCRIPTION
- as the most recent prebuild clang is not compatible with manylinux2014
  build it from source

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It builds the latest clang from source

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     as the most recent prebuild clang is not compatible with manylinux2014 build it from source
 - Affected modules and functionalities:
     Dockerfile and Dockerfile.deps
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI run
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
