### PR TITLE
Fix batch size handling in PermuteBatch.

### DIFF
--- a/dali/operators/generic/permute_batch.h
+++ b/dali/operators/generic/permute_batch.h
@@ -29,7 +29,7 @@ class PermuteBatchBase : public Operator<Backend> {
   }
 
   bool SetupImpl(vector<OutputDesc> &outputs, const workspace_t<Backend> &ws) override {
-    auto curr_batch_size = ws.GetInputBatchSize(0);
+    int curr_batch_size = ws.GetRequestedBatchSize(0);
     outputs.resize(1);
     auto &input = ws.template InputRef<Backend>(0);
     const auto &in_shape = input.shape();
@@ -39,6 +39,8 @@ class PermuteBatchBase : public Operator<Backend> {
       GetPerSampleArgument<int>(indices_, "indices", this->spec_, ws, curr_batch_size);
     } else {
       this->spec_.TryGetRepeatedArgument(indices_, "indices");
+      DALI_ENFORCE(static_cast<int>(indices_.size()) == curr_batch_size,
+        "The length of `indices` list does not match the requested batch size");
     }
 
     auto &out_shape = outputs[0].shape;


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: output batch size taken from input instead of RequestedBatchSize

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Use RequestedBatchSize
 - Affected modules and functionalities:
     * PermuteBatch
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests apply
     * Variable batch size tested in a debugger before being temporarily disallowed
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
