### PR TITLE
Fix pip download folder usage

### DIFF
--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -56,7 +56,18 @@ do
         # install packages
         inst=$($topdir/qa/setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION})
         if [ -n "$inst" ]; then
-            pip install $inst -f /pip-packages
+            for pkg in ${inst}
+            do
+                # turn off error
+                set +e
+                pip install $pkg -f /pip-packages --no-index
+                res=$?
+                set -e
+                # if no package was found in our download dir, so install it from index
+                if [ "$res" != "0" ]; then
+                    pip install $pkg
+                fi
+            done
 
             # If we just installed tensorflow, we need to reinstall DALI TF plugin
             if [[ "$inst" == *tensorflow* ]]; then


### PR DESCRIPTION
- the most recent pip version disregards downloaded files without
  the `--no-index` option. This fix adds this option to pip command
  invocation and adds a fallback when there is no package in the
  download cache present to use the index file

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a pip download folder usage

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     the most recent pip version disregards downloaded files without the `--no-index` option. This fix adds this option to pip command invocation and adds a fallback when there is no package in the download cache present to use the index file
 - Affected modules and functionalities:
     test_template.sh
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
