### PR TITLE
Add C API call to check backend of an operator

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -547,10 +547,10 @@ dali_backend_t daliGetOperatorBackend(daliPipelineHandle* pipe_handle, const cha
   dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
   auto *node = pipeline->GetOperatorNode(name);
   switch (node->op_type) {
-    case dali::OpType::GPU:
-      return dali_backend_t::DALI_BACKEND_GPU;
     case dali::OpType::CPU:
       return dali_backend_t::DALI_BACKEND_CPU;
+    case dali::OpType::GPU:
+      return dali_backend_t::DALI_BACKEND_GPU;
     case dali::OpType::MIXED:
       return dali_backend_t::DALI_BACKEND_MIXED;
     default:

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -545,7 +545,7 @@ void daliGetReaderMetadata(daliPipelineHandle* pipe_handle, const char *reader_n
 
 dali_backend_t daliGetOperatorBackend(daliPipelineHandle* pipe_handle, const char *operator_name) {
   dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
-  auto *node = pipeline->GetOperatorNode(name);
+  auto *node = pipeline->GetOperatorNode(operator_name);
   switch (node->op_type) {
     case dali::OpType::CPU:
       return dali_backend_t::DALI_BACKEND_CPU;

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -543,6 +543,21 @@ void daliGetReaderMetadata(daliPipelineHandle* pipe_handle, const char *reader_n
   meta->stick_to_shard = returned_meta.stick_to_shard;
 }
 
+dali_backend_t daliGetOperatorBackend(daliPipelineHandle* pipe_handle, const char *name) {
+  dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
+  auto *node = pipeline->GetOperatorNode(name);
+  switch (node->op_type) {
+    case dali::OpType::GPU:
+      return dali_backend_t::DALI_BACKEND_GPU;
+    case dali::OpType::CPU:
+      return dali_backend_t::DALI_BACKEND_CPU;
+    case dali::OpType::MIXED:
+      return dali_backend_t::DALI_BACKEND_MIXED;
+    default:
+      DALI_FAIL("Invalid operator type.");
+  }
+}
+
 void daliGetExecutorMetadata(daliPipelineHandle* pipe_handle, daliExecutorMetadata **operator_meta,
                              size_t *operator_meta_num) {
   dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -543,7 +543,7 @@ void daliGetReaderMetadata(daliPipelineHandle* pipe_handle, const char *reader_n
   meta->stick_to_shard = returned_meta.stick_to_shard;
 }
 
-dali_backend_t daliGetOperatorBackend(daliPipelineHandle* pipe_handle, const char *name) {
+dali_backend_t daliGetOperatorBackend(daliPipelineHandle* pipe_handle, const char *operator_name) {
   dali::Pipeline* pipeline = reinterpret_cast<dali::Pipeline*>(pipe_handle->pipe);
   auto *node = pipeline->GetOperatorNode(name);
   switch (node->op_type) {

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -43,6 +43,12 @@ typedef enum {
 } device_type_t;
 
 typedef enum {
+  DALI_BACKEND_GPU = 0,
+  DALI_BACKEND_CPU = 1,
+  DALI_BACKEND_MIXED = 2
+} dali_backend_t;
+
+typedef enum {
   DALI_NO_TYPE  = -1,
   DALI_UINT8    =  0,
   DALI_UINT16   =  1,
@@ -407,6 +413,14 @@ DLL_PUBLIC void daliLoadLibrary(const char *lib_path);
  */
 DLL_PUBLIC void daliGetReaderMetadata(daliPipelineHandle* pipe_handle, const char *reader_name,
                                       daliReaderMetadata* meta);
+
+/**
+ * @brief Returns the backend of the operator with a given \p name
+ * @param name Name of the operator to query
+ */
+DLL_PUBLIC dali_backend_t daliGetOperatorBackend(daliPipelineHandle* pipe_handle,
+                                                 const char *name);
+
 /**
  * @brief Obtains the executor statistics
  *  @param operator_meta Pointer to the memory allocated by the function with operator_meta_num

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -43,8 +43,8 @@ typedef enum {
 } device_type_t;
 
 typedef enum {
-  DALI_BACKEND_GPU = 0,
-  DALI_BACKEND_CPU = 1,
+  DALI_BACKEND_CPU = 0,
+  DALI_BACKEND_GPU = 1,
   DALI_BACKEND_MIXED = 2
 } dali_backend_t;
 

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -415,11 +415,11 @@ DLL_PUBLIC void daliGetReaderMetadata(daliPipelineHandle* pipe_handle, const cha
                                       daliReaderMetadata* meta);
 
 /**
- * @brief Returns the backend of the operator with a given \p name
- * @param name Name of the operator to query
+ * @brief Returns the backend of the operator with a given \p operator_name
+ * @param operator_name Name of the operator to query
  */
 DLL_PUBLIC dali_backend_t daliGetOperatorBackend(daliPipelineHandle* pipe_handle,
-                                                 const char *name);
+                                                 const char *operator_name);
 
 /**
  * @brief Obtains the executor statistics


### PR DESCRIPTION
#### Why we need this PR?
- It adds new feature needed in DALI Triton backend.

We need to check the backend of an ExternalSource in DALI Triton backend. 

#### What happened in this PR?
 - What solution was applied:
     *Added an C API call to check backend of an operator.*
 - Affected modules and functionalities:
     *c_api.h/cc*
 - Key points relevant for the review:
     *api design*
 - Validation and testing:
     *added case to C API tests*
 - Documentation (including examples):
     *API call documentation*


**JIRA TASK**: *DALI-2000*
