### PR TITLE
Avoid pre-commit hook for merge commits

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,6 +18,9 @@
 files=`git diff --cached --name-only`
 year=`date +%Y`
 
+git rev-parse -q --verify MERGE_HEAD && \
+    echo "Merge commit, skipping hooks" && exit 0
+
 for f in $files; do
     head -10 $f | grep -i "Copyright (c)" 2>&1 1>/dev/null \
         || continue  # Copyright not present in this file


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to skip running the pre-commit hook on merge commits

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Detect merge commits and skip the pre-commit hook*
 - Affected modules and functionalities:
     *pre-commit hook*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[NA]*
