### PR TITLE
Fix Video reader documentation

### DIFF
--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ This class only supports constant frame rate videos.
   .AddOptionalArg("filenames",
       R"code(File names of the video files to load.
 
-This option is mutually exclusive with ``filenames`` and ``file_root``.)code",
+This option is mutually exclusive with ``file_list`` and ``file_root``.)code",
       std::vector<std::string>{})
     .AddOptionalArg<vector<int>>("labels", R"(Labels associated with the files listed in
 ``filenames`` argument.

--- a/dali/operators/reader/video_reader_op.h
+++ b/dali/operators/reader/video_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,10 +76,10 @@ class VideoReader : public DataReader<GPUBackend, SequenceWrapper> {
 
     DALI_ENFORCE(can_use_frames_timestamps_ || !enable_frame_num_,
                  "frame numbers can be enabled only when "
-                 "`file_list` or `filenames` argument is passed");
+                 "`file_list`, or `filenames` with `labels` argument are passed");
     DALI_ENFORCE(can_use_frames_timestamps_ || !enable_timestamps_,
                  "timestamps can be enabled only when "
-                 "`file_list` or `filenames` argument is passed");
+                 "`file_list`, or `filenames` with `labels` argument are passed");
 
     DALI_ENFORCE(!(has_labels_arg && filenames_.empty()),
                  "The argument ``labels`` is valid only when file paths "

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ class DLL_PUBLIC Buffer {
                  "on non-const buffer to set valid type for " + type_.name());
     DALI_ENFORCE(type_.id() == TypeTable::GetTypeID<T>(),
                  "Calling type does not match buffer data type: " +
-                 TypeTable::GetTypeName<T>() + " v. " + type_.name());
+                 TypeTable::GetTypeName<T>() + " vs " + type_.name());
     // clang-format on
     return static_cast<T*>(data_.get());
   }


### PR DESCRIPTION
- fixes typo in the `filenames` argument description
- improves error message when timestamps and/or frame numbers
  are requested as an output but no labels are provided
- fix typo in buffer typo mismatch error

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a Video reader documentation

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     fixes typo in the `filenames` argument description
     improves error message when timestamps and/or frame numbers are requested as an output but no labels are provided
     fix typo in buffer typo mismatch error
 - Affected modules and functionalities:
     video reader
     buffer.h
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     only documentation and error messages are updated


**JIRA TASK**: *[NA]*
