### PR TITLE
Make pytorch lightning example work with multiple GPUs

### DIFF
--- a/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "This example shows how to use DALI in PyTorch Lightning.\n",
     "\n",
-    "Let us grab [a toy example](https://pytorch-lightning.readthedocs.io/en/latest/introduction_guide.html) showcasing a classification network and see how DALI can accelerate it.\n",
+    "Let us grab [a toy example](https://pytorch-lightning.readthedocs.io/en/latest/starter/introduction_guide.html) showcasing a classification network and see how DALI can accelerate it.\n",
     "\n",
     "The DALI_EXTRA_PATH environment variable should point to a [DALI extra](https://github.com/NVIDIA/DALI_extra) copy. Please make sure that the proper release tag, the one associated with your DALI version, is checked out."
    ]
@@ -94,10 +94,15 @@
     "  def configure_optimizers(self):\n",
     "      return Adam(self.parameters(), lr=1e-3)\n",
     "\n",
-    "  def prepare_data(self):# transforms for images\n",
+    "  def prepare_data(self):\n",
+    "      # download data only\n",
+    "      self.mnist_train = MNIST(os.getcwd(), train=True, download=True, transform=transforms.ToTensor())\n",
+    "    \n",
+    "  def setup(self, stage=None):\n",
+    "      # transforms for images\n",
     "      transform=transforms.Compose([transforms.ToTensor(), \n",
     "                                    transforms.Normalize((0.1307,), (0.3081,))])\n",
-    "      self.mnist_train = MNIST(os.getcwd(), train=True, download=True, transform=transform)\n",
+    "      self.mnist_train = MNIST(os.getcwd(), train=True, download=False, transform=transform)\n",
     "\n",
     "  def train_dataloader(self):\n",
     "       return DataLoader(self.mnist_train, batch_size=64, num_workers=8, pin_memory=True)\n"
@@ -169,8 +174,12 @@
    ],
    "source": [
     "model = LitMNIST()\n",
-    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=5)\n",
-    "trainer.fit(model)"
+    "trainer = Trainer(max_epochs=5)\n",
+    "# ddp work only in no-interactive mode, to test it unncoment and run as a script\n",
+    "# trainer = Trainer(gpus=8, distributed_backend=\"ddp\", max_epochs=5)\n",
+    "## MNIST data set is not always available to download due to network issues\n",
+    "## to run this part of example either uncomment below line\n",
+    "# trainer.fit(model)"
    ]
   },
   {
@@ -230,7 +239,7 @@
     "    def __init__(self):\n",
     "        super().__init__()\n",
     "    \n",
-    "    def prepare_data(self):\n",
+    "    def setup(self, stage=None):\n",
     "        device_id = self.local_rank\n",
     "        shard_id = self.global_rank\n",
     "        num_shards = self.trainer.world_size\n",
@@ -315,7 +324,9 @@
     "if 'PL_TRAINER_GPUS' in os.environ:\n",
     "    os.environ.pop('PL_TRAINER_GPUS')\n",
     "model = DALILitMNIST()\n",
-    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=5)\n",
+    "trainer = Trainer(max_epochs=5)\n",
+    "# ddp work only in no-interactive mode, to test it unncoment and run as a script\n",
+    "# trainer = Trainer(gpus=8, distributed_backend=\"ddp\", max_epochs=5)\n",
     "trainer.fit(model)"
    ]
   },
@@ -336,7 +347,7 @@
     "    def __init__(self):\n",
     "        super().__init__()\n",
     "    \n",
-    "    def prepare_data(self):\n",
+    "    def setup(self, stage=None):\n",
     "        device_id = self.local_rank\n",
     "        shard_id = self.global_rank\n",
     "        num_shards = self.trainer.world_size\n",
@@ -430,7 +441,9 @@
     "if 'PL_TRAINER_GPUS' in os.environ:\n",
     "    os.environ.pop('PL_TRAINER_GPUS')\n",
     "model = BetterDALILitMNIST()\n",
-    "trainer = Trainer(gpus=1, distributed_backend=\"ddp\", max_epochs=5)\n",
+    "trainer = Trainer(max_epochs=5)\n",
+    "# ddp work only in no-interactive mode, to test it unncoment and run as a script\n",
+    "# trainer = Trainer(gpus=8, distributed_backend=\"ddp\", max_epochs=5)\n",
     "trainer.fit(model)"
    ]
   }
@@ -451,7 +464,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/qa/TL1_jupyter_plugins/test_pytorch.sh
+++ b/qa/TL1_jupyter_plugins/test_pytorch.sh
@@ -10,7 +10,7 @@ do_once() {
 
 test_body() {
   # dummy
-  exclude_files="pytorch-lightning*\|#"
+  exclude_files="#"
 
   # test code
   find frameworks/pytorch/ -name "*.ipynb" | sed "/${exclude_files}/d" | xargs -i jupyter nbconvert \


### PR DESCRIPTION
- replace the wrong usage of `prepare_data` with `setup` method
- disables `ddp` by default and leave it commented out if
  anyone wants to try it out when run as a script
- reenables pytorch lightning example test

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a pytorch lightning example work with multiple GPUs

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     replace wrong usage of `prepare_data` with `setup` method
     disables  `ddp` by default and leave it commented out if anyone wants to try it out when run as a script
 - Affected modules and functionalities:
     pytorch lightning example
 - Key points relevant for the review:
     NA
 - Validation and testing:
     reenables pytorch lightning example test
 - Documentation (including examples):
     only example is affected


**JIRA TASK**: *[NA]*
