### PR TITLE
Add override flags for no_copy option of External Source

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -57,15 +57,20 @@ int PopCurrBatchSize(batch_size_map_t *batch_size_map, int max_batch_size,
   return ret;
 }
 
-
-dali::DALIExtNoCopyMode GetExternalSourceCopyMode(unsigned int flags) {
-  dali::DALIExtNoCopyMode no_copy_mode = dali::DALIExtNoCopyMode::DEFAULT;
+/**
+ * @brief Extract ExtSrcNoCopyMode based on the DALI_ext_force_copy and DALI_ext_force_no_copy
+ *
+ * @param flags Flags typically specified in daliSetExternalInput* functions.
+ */
+dali::ExtSrcNoCopyMode GetExternalSourceCopyMode(unsigned int flags) {
+  dali::ExtSrcNoCopyMode no_copy_mode = dali::ExtSrcNoCopyMode::DEFAULT;
   DALI_ENFORCE(!((flags & DALI_ext_force_copy) && (flags & DALI_ext_force_no_copy)),
-               "External Source cannot be forced to use copy and no copy at the same time.");
+               "External Source cannot be forced to use DALI_ext_force_copy and "
+               "DALI_ext_force_no_copy at the same time.");
   if (flags & DALI_ext_force_copy) {
-    no_copy_mode = dali::DALIExtNoCopyMode::FORCE_COPY;
+    no_copy_mode = dali::ExtSrcNoCopyMode::FORCE_COPY;
   } else if (flags & DALI_ext_force_no_copy) {
-    no_copy_mode = dali::DALIExtNoCopyMode::FORCE_NO_COPY;
+    no_copy_mode = dali::ExtSrcNoCopyMode::FORCE_NO_COPY;
   }
   return no_copy_mode;
 }

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -64,12 +64,16 @@ struct the_other_backend<GPUBackend> {
 };
 
 
+std::string GetDeviceStr(device_type_t dev) {
+  return dev == CPU ? "cpu" : "gpu";
+}
+
 template<typename Backend, device_type_t execution_device = backend_to_device_type<Backend>::value>
 std::unique_ptr<Pipeline> GetTestPipeline(bool is_file_reader, const std::string &output_device) {
   auto pipe_ptr = std::make_unique<Pipeline>(batch_size, num_thread, device_id, seed, pipelined,
                                              prefetch_queue_depth, async);
   auto &pipe = *pipe_ptr;
-  std::string exec_device = execution_device == CPU ? "cpu" : "gpu";
+  std::string exec_device = GetDeviceStr(execution_device);
   TensorList<Backend> data;
   if (is_file_reader) {
     std::string file_root = testing::dali_extra_path() + "/db/single/jpeg/";
@@ -637,7 +641,7 @@ TYPED_TEST(CApiTest, UseCopyKernel) {
 }
 
 
-TYPED_TEST(CApiTest, NoCopyForce) {
+TYPED_TEST(CApiTest, ForceNoCopyFail) {
   TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
                                    {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
@@ -647,10 +651,10 @@ TYPED_TEST(CApiTest, NoCopyForce) {
   TensorList<TypeParam> input;
 
   auto device = backend_to_device_type<TypeParam>::value;
-  std::string device_str = device == CPU ? "cpu" : "gpu";
+  std::string device_str = GetDeviceStr(device);
 
   auto other_device = device == CPU ? GPU : CPU;
-  std::string other_device_str = other_device == CPU ? "cpu" : "gpu";
+  std::string other_device_str = GetDeviceStr(other_device);
 
   auto pipe_ptr = GetExternalSourcePipeline(false, other_device_str);
   auto serialized = pipe_ptr->SerializeToProtobuf();
@@ -678,7 +682,7 @@ TYPED_TEST(CApiTest, NoCopyForce) {
 
 
 
-TYPED_TEST(CApiTest, CopyForce) {
+TYPED_TEST(CApiTest, ForceCopy) {
   TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
                                    {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
@@ -688,7 +692,7 @@ TYPED_TEST(CApiTest, CopyForce) {
   TensorList<TypeParam> input;
 
   auto device = backend_to_device_type<TypeParam>::value;
-  std::string device_str = device == CPU ? "cpu" : "gpu";
+  std::string device_str = GetDeviceStr(device);
 
   auto pipe_ptr = GetExternalSourcePipeline(true, device_str);
   auto serialized = pipe_ptr->SerializeToProtobuf();

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -497,7 +497,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
       default:
         actual_no_copy = no_copy_;
         break;
-    };
+    }
 
     if (actual_no_copy) {
       ShareUserData(batch, stream, set_data_config.use_copy_kernel);

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -137,13 +137,13 @@ class DLL_PUBLIC Pipeline {
 
   template <typename T, typename OperatorBackend>
   void SetDataSourceHelper(const string &name, const T &tl, OperatorBase *op_ptr,
-                           cudaStream_t stream = 0, SetDataConfig set_data_config = {}) {
+                           cudaStream_t stream = 0, ExtSrcSettingMode ext_src_setting_mode = {}) {
     // Note: we have 2 different Backends here - OperatorBackend and T's Backend (StorageBackend).
     // The StorageBackend is hidden under `T` type.
     auto *source = dynamic_cast<ExternalSource<OperatorBackend> *>(op_ptr);
     DALI_ENFORCE(source != nullptr,
                  "Input name '" + name + "' is not marked as an external input.");
-    source->SetDataSource(tl, stream, set_data_config);
+    source->SetDataSource(tl, stream, ext_src_setting_mode);
   }
 
   /**
@@ -153,12 +153,12 @@ class DLL_PUBLIC Pipeline {
    * @param name name of the input
    * @param tl data
    * @param stream CUDA stream to use in case of GPUBackend
-   * @param set_data_config Options passed to the External Source describing the behaviour
+   * @param ext_src_setting_mode Options passed to the External Source describing the behaviour
    *                        of setting the data.
    */
   template <typename TL>
   inline void SetExternalInputHelper(const string &name, const TL &tl, cudaStream_t stream = 0,
-                                     SetDataConfig set_data_config = {}) {
+                                     ExtSrcSettingMode ext_src_setting_mode = {}) {
     bool is_cpu_node = true;
     OpNodeId node_id;
 
@@ -179,9 +179,9 @@ class DLL_PUBLIC Pipeline {
     OperatorBase *op_ptr = &node.InstantiateOperator();
 
     if (is_cpu_node) {
-      SetDataSourceHelper<TL, CPUBackend>(name, tl, op_ptr, stream, set_data_config);
+      SetDataSourceHelper<TL, CPUBackend>(name, tl, op_ptr, stream, ext_src_setting_mode);
     } else {
-      SetDataSourceHelper<TL, GPUBackend>(name, tl, op_ptr, stream, set_data_config);
+      SetDataSourceHelper<TL, GPUBackend>(name, tl, op_ptr, stream, ext_src_setting_mode);
     }
   }
 
@@ -200,7 +200,7 @@ class DLL_PUBLIC Pipeline {
   template <typename Backend>
   DLL_PUBLIC inline void SetExternalInput(
       const string &name, const TensorList<Backend> &tl, cudaStream_t stream = 0, bool sync = false,
-      bool use_copy_kernel = false, DALIExtNoCopyMode no_copy_mode = DALIExtNoCopyMode::DEFAULT) {
+      bool use_copy_kernel = false, ExtSrcNoCopyMode no_copy_mode = ExtSrcNoCopyMode::DEFAULT) {
     SetExternalInputHelper(name, tl, stream, {sync, use_copy_kernel, no_copy_mode});
   }
 
@@ -220,7 +220,7 @@ class DLL_PUBLIC Pipeline {
   DLL_PUBLIC inline void SetExternalInput(
       const string &name, const TensorVector<Backend> &tv, cudaStream_t stream = 0,
       bool sync = false, bool use_copy_kernel = false,
-      DALIExtNoCopyMode no_copy_mode = DALIExtNoCopyMode::DEFAULT) {
+      ExtSrcNoCopyMode no_copy_mode = ExtSrcNoCopyMode::DEFAULT) {
     SetExternalInputHelper(name, tv, stream, {sync, use_copy_kernel, no_copy_mode});
   }
 

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -194,7 +194,7 @@ DLL_PUBLIC void daliSetExternalInputBatchSize(daliPipelineHandle *pipe_handle, c
  *                   Can be set to NULL.
  * @param stream CUDA stream to use when copying the data onto GPU. Remember to synchronize on the
  *               provided stream.
- * @param flags Extra flags, check DALI_ext_force_sync, DALI_ext_pinned, DALI_use_copy_kernel
+ * @param flags Extra flags, check DALI_ext_* and DALI_use_copy_kernel flags
  */
 DLL_PUBLIC void
 daliSetExternalInputAsync(daliPipelineHandle *pipe_handle, const char *name,

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -126,7 +126,8 @@ enum {
   /**
    * If memory transfer should be synchronous - applies to GPU memory
    */
-  DALI_ext_force_sync = (1<<0),
+  DALI_ext_force_sync = (1 << 0),
+
   /**
    * If provided CPU memory is page-locked
    */
@@ -137,6 +138,17 @@ enum {
    * Only relevant when the input is either pinned host memory or device memory
    */
   DALI_use_copy_kernel = (1 << 2),
+
+  /**
+   * Override the `no_copy` specified for given External Source and force the data to be copied.
+   */
+  DALI_ext_force_copy = (1 << 3),
+
+  /**
+   * Override the `no_copy` specified for given External Source and pass the data directly to the
+   * Pipeline.
+   */
+  DALI_ext_force_no_copy = (1 << 4),
 };
 
 /**

--- a/include/dali/core/common.h
+++ b/include/dali/core/common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,6 +109,12 @@ enum DALIImageType {
   DALI_GRAY         = 2,
   DALI_YCbCr        = 3,
   DALI_ANY_DATA     = 4
+};
+
+enum class DALIExtNoCopyMode {
+  DEFAULT,
+  FORCE_COPY,
+  FORCE_NO_COPY
 };
 
 

--- a/include/dali/core/common.h
+++ b/include/dali/core/common.h
@@ -111,13 +111,6 @@ enum DALIImageType {
   DALI_ANY_DATA     = 4
 };
 
-enum class DALIExtNoCopyMode {
-  DEFAULT,
-  FORCE_COPY,
-  FORCE_NO_COPY
-};
-
-
 inline bool IsColor(DALIImageType type) {
   return type == DALI_RGB || type == DALI_BGR || type == DALI_YCbCr;
 }


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
- It's needed for better TF integration 

#### What happened in this PR?
 - What solution was applied:
     The External Source no_copy option is a "static" parameter, that is fixed after the pipeline build (and serialization). We need a way to control it from TF integration, so we added override flags for C API to control the External Source behaviour.
   This solution fits in with the other flags that we already have.   
 - Affected modules and functionalities:
     External Source & C API.
 - Key points relevant for the review:
     Check if the flags are not swapped, or smth.
 - Validation and testing:
     C API test added.
 - Documentation (including examples):
     Yes.


**JIRA TASK**: *[Use DALI-2141 or NA]*
