### PR TITLE
Add support for VP8 and MJPEG videos

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -392,7 +392,8 @@ VideoFile& VideoLoader::get_or_open_file(const std::string &filename) {
                                      file.frame_base_);
 
     if (codec_id == AV_CODEC_ID_H264 || codec_id == AV_CODEC_ID_HEVC ||
-        codec_id == AV_CODEC_ID_MPEG4 || codec_id == AV_CODEC_ID_VP9) {
+        codec_id == AV_CODEC_ID_MPEG4 || codec_id == AV_CODEC_ID_VP8 ||
+        codec_id == AV_CODEC_ID_VP9 || codec_id == AV_CODEC_ID_MJPEG) {
       const char* filtername = nullptr;
       if (codec_id == AV_CODEC_ID_H264) {
         filtername = "h264_mp4toannexb";

--- a/dali/operators/reader/nvdecoder/cuvideodecoder.cc
+++ b/dali/operators/reader/nvdecoder/cuvideodecoder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ const char* GetVideoCodecString(cudaVideoCodec eCodec) {
         { cudaVideoCodec_H264_SVC,  "H.264/SVC"    },
         { cudaVideoCodec_H264_MVC,  "H.264/MVC"    },
         { cudaVideoCodec_HEVC,      "H.265/HEVC"   },
+        { cudaVideoCodec_VP8,       "VP8"          },
         { cudaVideoCodec_VP9,       "VP9"          },
         { cudaVideoCodec_NumCodecs, "Invalid"      },
         { cudaVideoCodec_YUV420,    "YUV  4:2:0"   },

--- a/dali/operators/reader/nvdecoder/cuvideoparser.h
+++ b/dali/operators/reader/nvdecoder/cuvideoparser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ enum class Codec {
   H264,
   HEVC,
   MPEG4,
+  MJPEG,
+  VP8,
   VP9
 };
 
@@ -51,12 +53,20 @@ class CUVideoParser {
         parser_info_.CodecType = cudaVideoCodec_HEVC;
         parser_info_.ulMaxNumDecodeSurfaces = 20;
         break;
+      case Codec::MJPEG:
+        parser_info_.CodecType = cudaVideoCodec_JPEG;
+        parser_info_.ulMaxNumDecodeSurfaces = 20;
+        break;
       case Codec::MPEG4:
         parser_info_.CodecType = cudaVideoCodec_MPEG4;
         parser_info_.ulMaxNumDecodeSurfaces = 20;
         break;
       case Codec::VP9:
         parser_info_.CodecType = cudaVideoCodec_VP9;
+        parser_info_.ulMaxNumDecodeSurfaces = 20;
+        break;
+      case Codec::VP8:
+        parser_info_.CodecType = cudaVideoCodec_VP8;
         parser_info_.ulMaxNumDecodeSurfaces = 20;
         break;
       default:

--- a/dali/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/operators/reader/nvdecoder/nvdecoder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -115,6 +115,15 @@ NvDecoder::NvDecoder(int device_id,
       codec = Codec::VP9;
       break;
 
+    case AV_CODEC_ID_VP8:
+      codec = Codec::VP8;
+      break;
+
+
+    case AV_CODEC_ID_MJPEG:
+      codec = Codec::MJPEG;
+      break;
+
     default:
       DALI_FAIL("Invalid codec for NvDecoder");
       return;
@@ -160,7 +169,12 @@ int NvDecoder::decode_av_packet(AVPacket* avpkt, int64_t start_time, AVRational 
   }
 
   // parser_ will call handle_* callbacks after parsing
-  NVCUVID_CALL(cuvidParseVideoData(parser_, &cupkt));
+  auto ret = cuvidParseVideoData(parser_, &cupkt);
+  if (!captured_exception_) {
+    // throw only if we haven't captured any other exception before which is probably processed
+    // right now and we don't want to throw exception in exception
+    NVCUVID_CALL(ret);
+  }
   return 0;
 }
 


### PR DESCRIPTION
- adds an appropriate enums to support VP8 and MJPEG video streams
- makes sure that not supported codec error is properly propagated

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds support for VP8 and MJPEG videos

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds an appropriate enums to support VP8 and MJPEG video streams
     makes sure that not supported codec error is properly propagated
 - Affected modules and functionalities:
     video reader
 - Key points relevant for the review:
     NA
 - Validation and testing:
     new test cases are added
 - Documentation (including examples):
     NA

relates to https://github.com/NVIDIA/DALI/issues/3044

**JIRA TASK**: *[NA]*
