### PR TITLE
Remove mixed image decoder from GetBackendTest

### DIFF
--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -757,21 +757,21 @@ TEST(CApiTest, GetBackendTest) {
                           .AddArg("device", "cpu")
                           .AddArg("name", es_cpu_name)
                           .AddOutput(es_cpu_name, "cpu"), es_cpu_name);
-  std::string cnt_name = "decoder";
+  std::string cont_name = "contiguous";
   pipe.AddOperator(OpSpec("MakeContiguous")
                           .AddArg("device", "mixed")
-                          .AddArg("name", cnt_name)
+                          .AddArg("name", cont_name)
                           .AddInput(es_cpu_name, "cpu")
-                          .AddOutput(cnt_name, "gpu"), cnt_name);
+                          .AddOutput(cont_name, "gpu"), cont_name);
   std::vector<std::pair<std::string, std::string>> outputs = {{es_gpu_name, "gpu"},
-                                                              {cnt_name, "gpu"}};
+                                                              {cont_name, "gpu"}};
   pipe.SetOutputNames(outputs);
   std::string ser = pipe.SerializeToProtobuf();
   daliPipelineHandle handle;
   daliDeserializeDefault(&handle, ser.c_str(), ser.size());
   EXPECT_EQ(daliGetOperatorBackend(&handle, es_cpu_name.c_str()), DALI_BACKEND_CPU);
   EXPECT_EQ(daliGetOperatorBackend(&handle, es_gpu_name.c_str()), DALI_BACKEND_GPU);
-  EXPECT_EQ(daliGetOperatorBackend(&handle, cnt_name.c_str()), DALI_BACKEND_MIXED);
+  EXPECT_EQ(daliGetOperatorBackend(&handle, cont_name.c_str()), DALI_BACKEND_MIXED);
 }
 
 }  // namespace dali

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -757,21 +757,21 @@ TEST(CApiTest, GetBackendTest) {
                           .AddArg("device", "cpu")
                           .AddArg("name", es_cpu_name)
                           .AddOutput(es_cpu_name, "cpu"), es_cpu_name);
-  std::string decoder_name = "decoder";
-  pipe.AddOperator(OpSpec("decoders__Image")
+  std::string cnt_name = "decoder";
+  pipe.AddOperator(OpSpec("MakeContiguous")
                           .AddArg("device", "mixed")
-                          .AddArg("name", decoder_name)
+                          .AddArg("name", cnt_name)
                           .AddInput(es_cpu_name, "cpu")
-                          .AddOutput(decoder_name, "gpu"), decoder_name);
+                          .AddOutput(cnt_name, "gpu"), cnt_name);
   std::vector<std::pair<std::string, std::string>> outputs = {{es_gpu_name, "gpu"},
-                                                              {decoder_name, "gpu"}};
+                                                              {cnt_name, "gpu"}};
   pipe.SetOutputNames(outputs);
   std::string ser = pipe.SerializeToProtobuf();
   daliPipelineHandle handle;
   daliDeserializeDefault(&handle, ser.c_str(), ser.size());
   EXPECT_EQ(daliGetOperatorBackend(&handle, es_cpu_name.c_str()), DALI_BACKEND_CPU);
   EXPECT_EQ(daliGetOperatorBackend(&handle, es_gpu_name.c_str()), DALI_BACKEND_GPU);
-  EXPECT_EQ(daliGetOperatorBackend(&handle, decoder_name.c_str()), DALI_BACKEND_MIXED);
+  EXPECT_EQ(daliGetOperatorBackend(&handle, cnt_name.c_str()), DALI_BACKEND_MIXED);
 }
 
 }  // namespace dali


### PR DESCRIPTION
- Jetson platform doesn't support image decoder for the mixed
  backend so replace it with MakeContiguous in GetBackendTest
  test as it needs only any mixed operator

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes mixed image decoder from GetBackendTest

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Jetson platform doesn't support image decoder for the mixed backend so replace it with MakeContiguous in GetBackendTest test as it needs only any mixed operator
 - Affected modules and functionalities:
     c_api_test
 - Key points relevant for the review:
     NA
 - Validation and testing:
     test on Xavier platform
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
