### PR TITLE
Disabling buffer registration in GPU variant of the numpy reader operator

### DIFF
--- a/dali/operators/reader/loader/numpy_loader_gpu.h
+++ b/dali/operators/reader/loader/numpy_loader_gpu.h
@@ -45,7 +45,7 @@ class NumpyLoaderGPU : public CUFileLoader {
     vector<std::string> images = std::vector<std::string>(),
     bool shuffle_after_epoch = false) :
       CUFileLoader(spec, images, shuffle_after_epoch),
-      register_buffers_(spec.GetArgument<bool>("register_buffers")),
+      register_buffers_(false),
       header_cache_(spec.GetArgument<bool>("cache_header_information")) {}
 
   ~NumpyLoaderGPU() override {

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -125,7 +125,7 @@ This argument is mutually exclusive with ``file_list``.)", nullptr)
   .AddOptionalArg("register_buffers",
       R"code(Applies **only** to the ``gpu`` backend type.
 .. warning:
-    This argument is temporarily disabled and left for the backward compatibility.
+    This argument is temporarily disabled and left for backward compatibility.
     It will be reenabled in the future releases.
 If true, the device I/O buffers will be registered with cuFile. It is not recommended if the sample
 sizes vary a lot.)code", true)

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -124,9 +124,10 @@ If ``file_root`` is provided, the paths are treated as being relative to it.
 This argument is mutually exclusive with ``file_list``.)", nullptr)
   .AddOptionalArg("register_buffers",
       R"code(Applies **only** to the ``gpu`` backend type.
-.. warning:
+.. warning::
     This argument is temporarily disabled and left for backward compatibility.
     It will be reenabled in the future releases.
+
 If true, the device I/O buffers will be registered with cuFile. It is not recommended if the sample
 sizes vary a lot.)code", true)
   .AddOptionalArg("cache_header_information",

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -125,7 +125,8 @@ This argument is mutually exclusive with ``file_list``.)", nullptr)
   .AddOptionalArg("register_buffers",
       R"code(Applies **only** to the ``gpu`` backend type.
 .. warning:
-this feature is temporarily disabled and will be re-enabled in future releases.
+    This argument is temporarily disabled and left for the backward compatibility.
+    It will be reenabled in the future releases.
 If true, the device I/O buffers will be registered with cuFile. It is not recommended if the sample
 sizes vary a lot.)code", true)
   .AddOptionalArg("cache_header_information",

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -124,6 +124,7 @@ If ``file_root`` is provided, the paths are treated as being relative to it.
 This argument is mutually exclusive with ``file_list``.)", nullptr)
   .AddOptionalArg("register_buffers",
       R"code(Applies **only** to the ``gpu`` backend type.
+
 .. warning::
     This argument is temporarily disabled and left for backward compatibility.
     It will be reenabled in the future releases.

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -124,7 +124,8 @@ If ``file_root`` is provided, the paths are treated as being relative to it.
 This argument is mutually exclusive with ``file_list``.)", nullptr)
   .AddOptionalArg("register_buffers",
       R"code(Applies **only** to the ``gpu`` backend type.
-
+.. warning:
+this feature is temporarily disabled and will be re-enabled in future releases.
 If true, the device I/O buffers will be registered with cuFile. It is not recommended if the sample
 sizes vary a lot.)code", true)
   .AddOptionalArg("cache_header_information",


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug in the gds buffer registration

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     temporarily disabling the gds buffer registration, added a user note that it will be re-enabled
 - Affected modules and functionalities:
    numpy gpu reader
 - Key points relevant for the review:
    the interface to numpy_reader
 - Validation and testing:
    not tested, we should add more rigorous GDS testing in upcoming releases
 - Documentation (including examples):
     


**JIRA TASK**: NA
