### PR TITLE
Remove normalization in brightness contrast

### DIFF
--- a/dali/operators/image/color/brightness_contrast.h
+++ b/dali/operators/image/color/brightness_contrast.h
@@ -86,11 +86,9 @@ class BrightnessContrastOp : public Operator<Backend> {
     // out = (brightness_shift * brightness_range +
     //        brightness * (contrast_center - contrast * contrast_center)) +
     //        brightness * contrast * in
-    float norm_brightness = (brightness * brightness_contrast::FullRange<OutputType>()) /
-                 brightness_contrast::FullRange<InputType>();
     addend = brightness_shift * brightness_range +
-             norm_brightness * (contrast_center - contrast * contrast_center);
-    multiplier = norm_brightness * contrast;
+             brightness * (contrast_center - contrast * contrast_center);
+    multiplier = brightness * contrast;
   }
 
   void AcquireArguments(const workspace_t<Backend> &ws) {

--- a/dali/operators/image/color/brightness_contrast_test.cu
+++ b/dali/operators/image/color/brightness_contrast_test.cu
@@ -98,9 +98,8 @@ void BrightnessContrastVerify(TensorListWrapper input, TensorListWrapper output,
     auto in_tensor = input_tl->tensor<InputDataType>(t);
     ASSERT_EQ(in_shape, out_shape);
     for (int i = 0; i < volume(out_shape); i++) {
-      float norm_brightness = brightness * FullRange<OutputType>() / FullRange<InputDataType>();
       float with_contrast = contrast_offset + contrast*(in_tensor[i] - contrast_offset);
-      float with_brighness = norm_brightness * with_contrast;
+      float with_brighness = brightness * with_contrast;
       float with_shift = out_range * brightness_shift + with_brighness;
       EXPECT_EQ(out_tensor[i], ConvertSat<OutputType>(with_shift));
     }

--- a/dali/test/python/test_detection_pipeline.py
+++ b/dali/test/python/test_detection_pipeline.py
@@ -171,11 +171,11 @@ class DetectionPipeline(Pipeline):
         self.twist_cpu = ops.ColorTwist(device="cpu")
         self.twist_gpu = ops.ColorTwist(device="gpu")
 
-        self.hsv_cpu = ops.Hsv(device="cpu")
-        self.hsv_gpu = ops.Hsv(device="gpu")
+        self.hsv_cpu = ops.Hsv(device="cpu", dtype=types.FLOAT)
+        self.hsv_gpu = ops.Hsv(device="gpu", dtype=types.FLOAT)
 
-        self.bc_cpu = ops.BrightnessContrast(device="cpu")
-        self.bc_gpu = ops.BrightnessContrast(device="gpu")
+        self.bc_cpu = ops.BrightnessContrast(device="cpu", dtype=types.UINT8, contrast_center=128)
+        self.bc_gpu = ops.BrightnessContrast(device="gpu", dtype=types.UINT8, contrast_center=128)
 
         self.flip_cpu = ops.Flip(device="cpu")
         self.bbox_flip_cpu = ops.BbFlip(device="cpu", ltrb=True)
@@ -247,20 +247,15 @@ class DetectionPipeline(Pipeline):
         image_legacy_twisted_cpu = self.twist_cpu(
             image_ssd_crop,
             saturation=saturation,
-            hue=hue)
-        image_legacy_twisted_cpu = self.twist_cpu(
-            image_legacy_twisted_cpu,
             contrast=contrast,
-            brightness=brightness)
+            brightness=brightness,
+            hue=hue)
         image_legacy_twisted_gpu = self.twist_gpu(
             image_ssd_crop.gpu(),
             saturation=saturation,
-            hue=hue)
-        image_legacy_twisted_gpu = self.twist_gpu(
-            image_legacy_twisted_gpu,
             contrast=contrast,
-            brightness=brightness
-        )
+            brightness=brightness,
+            hue=hue)
 
         image_flipped_cpu = self.flip_cpu(image_resized_cpu)
         boxes_flipped_cpu = self.bbox_flip_cpu(boxes_ssd_crop)

--- a/dali/test/python/test_operator_brightness_contrast.py
+++ b/dali/test/python/test_operator_brightness_contrast.py
@@ -53,8 +53,7 @@ def dali_type_to_np(dtype):
 def bricon_ref(input, brightness, brightness_shift, contrast, contrast_center, out_dtype):
   output_range = max_range(out_dtype)
   input_range = max_range(input.dtype)
-  norm = output_range / input_range
-  output = brightness_shift * output_range + norm * brightness * (contrast_center + contrast * (input - contrast_center))
+  output = brightness_shift * output_range + brightness * (contrast_center + contrast * (input - contrast_center))
   return convert_sat(output, out_dtype)
 
 def ref_operator(contrast_center, out_dtype):


### PR DESCRIPTION
Signed-off-by: Rafal <Banas.Rafal97@gmail.com>

#### Why we need this PR?
- It reverts brightness contrast to the old behavior because of failing tests.

#### What happened in this PR?
 - What solution was applied:
     *I removed normalization from brightness contrast*
 - Affected modules and functionalities:
     *`BrightnessContrast`*
 - Key points relevant for the review:
     *tests, operator implementation*
 - Validation and testing:
     *I reverted `test_detection_pipeline.py` to the state before the change.*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *NA*
