### PR TITLE
Enable no_copy mode handling in TF DALI Dataset

### DIFF
--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -288,8 +288,10 @@ from Python by several methods.
 
 The simplest and preferred way is to specify a ``source``, which can be a callable or iterable.
 
-.. warning::
-    :meth:`nvidia.dali.fn.external_source` operator is not compatible with TensorFlow integration.
+.. note::
+    :meth:`nvidia.dali.fn.external_source` operator is partially compatible with TensorFlow
+    integration via :meth:`nvidia.dali.plugin.tf.experimental.DALIDatasetWithInputs`.
+    Please refer to its documentation for details.
 
 .. note::
     To return a batch of copies of the same tensor, use :func:`nvidia.dali.types.Constant`,
@@ -650,8 +652,10 @@ provided GPU memory content only using provided stream (DALI schedules a copy on
 and all work is properly queued). If no stream is provided feeding input blocks until the
 provided memory is copied to the internal buffer.
 
-.. warning::
-    :meth:`nvidia.dali.fn.external_source` operator is not compatible with TensorFlow integration.
+.. note::
+    :meth:`nvidia.dali.fn.external_source` operator is partially compatible with TensorFlow
+    integration via :meth:`nvidia.dali.plugin.tf.experimental.DALIDatasetWithInputs`.
+    Please refer to its documentation for details.
 
 .. note::
     To return a batch of copies of the same tensor, use :func:`nvidia.dali.types.Constant`,

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -54,6 +54,11 @@ but not a different number of dimensions.
 .. warning::
     This class is experimental and its API might change without notice.
 
+.. note::
+    Setting ``no_copy`` on the external source nodes when defining the pipeline is considered
+    a no-op when used with DALI Dataset. The ``no_copy`` option is handled internally
+    and enabled automatically if possible.
+
 The operator adds additional parameters to the ones supported by the
 :class:`~nvidia.dali.plugin.tf.DALIDataset`:
 

--- a/dali/test/python/test_dali_tf_dataset_graph.py
+++ b/dali/test/python/test_dali_tf_dataset_graph.py
@@ -73,6 +73,26 @@ def test_tf_dataset_with_random_input_gpu():
             yield run_tf_dataset_with_random_input_gpu, max_shape, dtype
 
 
+def run_tf_dataset_no_copy(max_shape, dtype, dataset_dev, es_dev, no_copy):
+    run_tf_dataset_graph(
+        dataset_dev,
+        get_pipeline_desc=external_source_tester(max_shape, dtype,
+                                                 RandomSampleIterator(max_shape, dtype(0)), es_dev,
+                                                 no_copy),
+        to_dataset=external_source_converter_with_callback(RandomSampleIterator, max_shape, dtype))
+
+
+# Check if setting no_copy flags in all placement scenarios is ok as we override it internally
+def test_tf_dataset_with_no_copy():
+    for max_shape in [(10, 20), (120, 120, 3)]:
+        for dataset_dev in ["cpu", "gpu"]:
+            for es_dev in ["cpu", "gpu"]:
+                if dataset_dev == "cpu" and es_dev == "gpu":
+                    continue  # GPU op in CPU dataset not supported
+                for no_copy in [True, False, None]:
+                    yield run_tf_dataset_no_copy, max_shape, np.uint8, dataset_dev, es_dev, no_copy
+
+
 def run_tf_dataset_with_stop_iter(dev, max_shape, dtype, stop_samples):
     run_tf_dataset_graph(dev,
                          to_stop_iter=True,

--- a/dali_tf_plugin/dali_dataset.h
+++ b/dali_tf_plugin/dali_dataset.h
@@ -76,8 +76,7 @@ class DALIDatasetOp : public tensorflow::data::DatasetOpKernel {
     bool enable_memory_stats;
   };
 
-  // TODO(klecki): I know the name Inputs is not ideal, but we actually get them
-  // in compute from Op inputs.
+  // I know the name Inputs is not ideal, but we actually get them in compute from Op inputs.
   struct Inputs {
     std::vector<tensorflow::data::DatasetBase *> inputs;
   };

--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -118,7 +118,6 @@ class DALIDatasetOp::Dataset : public DatasetBase {
   const device_type_t device_type_;
   const bool fail_on_device_mismatch_;
 
-  daliPipelineHandle pipeline_handle_;
   const InputDescs input_desc_;
 
   Status AsGraphDefInternal(SerializationContext *context, DatasetGraphDefBuilder *b,
@@ -240,6 +239,11 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
         TF_RETURN_IF_ERROR(dataset()->input_desc_.inputs[i]->MakeIterator(
             context, strings::StrCat(prefix(), "[", i, "]"), &input_impls_[i]));
 #endif
+      }
+      input_ext_src_devices_.resize(dataset()->NumInputs());
+      for (size_t i = 0; i < input_ext_src_devices_.size(); i++) {
+        TF_DALI_CALL(input_ext_src_devices_[i] = daliGetOperatorBackend(
+                         &pipeline_handle_, dataset()->input_desc_.input_names[i].c_str()));
       }
     }
     TF_RETURN_IF_ERROR(PrefetchPipeline(context, &pipeline_handle_));
@@ -633,10 +637,22 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
       // device as the DALIDataset placement
       auto input_device = dataset()->device_type_;
       auto &input_layout = dataset()->input_desc_.input_layouts[input_idx];
+      auto ext_src_device = input_ext_src_devices_[input_idx];
+
+
+      unsigned int flag = 0u;
+      // We can share the data without copy when the backends are the same, otherwise
+      // we need to copy.
+      if ((input_device == CPU && ext_src_device == DALI_BACKEND_CPU) ||
+          (input_device == GPU && ext_src_device == DALI_BACKEND_GPU)) {
+        flag = DALI_ext_force_no_copy;
+      } else {
+        flag = DALI_ext_force_copy;
+      }
 
       TF_DALI_CALL(daliSetExternalInputTensors(pipeline_handle, input_name.c_str(), input_device,
                                                ptrs.data(), dtype, shapes.data(), ndim,
-                                               input_layout.c_str(), 0));
+                                               input_layout.c_str(), flag));
     }
     return Status::OK();
   }
@@ -776,6 +792,8 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
 
   tensorflow::mutex mu_;
   std::vector<std::unique_ptr<IteratorBase>> input_impls_;
+  // Obtained from pipeline, the `device` parameter of external source nodes used for inputs
+  std::vector<dali_backend_t> input_ext_src_devices_;
   std::queue<ListOfBatches> alive_batches_;
   InputState iterator_state_ = InputState::in_progress;
   daliPipelineHandle pipeline_handle_;


### PR DESCRIPTION


Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Improves the TF DALI Dataset

#### What happened in this PR? 
 - What solution was applied:
     Detect device of external source node
and force copy or no-copy when feeding
that external source with input.
It can only be done for matching input
and external source placement.

Remove unused pipeline_handle_ member
 - Affected modules and functionalities:
     TF DALI Dataset
 - Key points relevant for the review:
     Not sure about the docstring - is it needed?
 - Validation and testing:
     Tests extended, CI
 - Documentation (including examples):
     I described the behaviour in the docstring, I'm not sure if the user needs that much information.


**JIRA TASK**: *[Use DALI-2151 or NA]*
