### PR TITLE
Fix usage of removed _ExternalSource in test

### DIFF
--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -114,7 +114,7 @@ std::unique_ptr<Pipeline> GetExternalSourcePipeline(bool no_copy, const std::str
                                              prefetch_queue_depth, async);
   auto &pipe = *pipe_ptr;
 
-  pipe.AddOperator(OpSpec("_ExternalSource")
+  pipe.AddOperator(OpSpec("ExternalSource")
                        .AddArg("device", device)
                        .AddArg("name", input_name)
                        .AddArg("no_copy", no_copy)


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fix a bug in test

#### What happened in this PR? 
 - What solution was applied:
     _ExternalSource -> ExternalSource
 - Affected modules and functionalities:
      C API test
 - Key points relevant for the review:
      N/A
 - Validation and testing:
     CI
 - Documentation (including examples):
     N/A


**JIRA TASK**: *[Use DALI-XXXX or NA]*
