### PR TITLE
Fix error message when creating a TensorShape from iterators with more elements than expected

### DIFF
--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -265,8 +265,10 @@ struct TensorShape : public TensorShapeBase<DeviceArray<int64_t, ndim>, ndim> {
       this->shape[i] = *it;
     }
 #ifndef __CUDA_ARCH__
-    if (i != ndim || it != last)
-      throw std::invalid_argument(make_string("Expected ", ndim, " elements. Got ", i));
+    if (i != ndim)
+      throw std::invalid_argument(make_string("Expected ", ndim, " elements, got ", i));
+    if (it != last)
+      throw std::invalid_argument(make_string("Expected ", ndim, " elements, got more."));
 #endif
   }
 


### PR DESCRIPTION

Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes an incorrect error message

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Fix the error message when creating a TensorShape from iterators with more elements than expected. If the iterator range is different than ndim, the error message printed that the received number of elements was ndim. In the fixed version we simply state that we got more elements than expected.*
 - Affected modules and functionalities:
     *TensorShape*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[NA]*
