### PR TITLE
Rework the TF DALIDataset input API

### DIFF
--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -583,6 +583,8 @@ Keyword Args
 
         if name is None:
             name = self._name
+        else:
+            self._name = name
 
         if name is not None and self._num_outputs is not None:
             raise RuntimeError("``num_outputs`` is not compatible with named ``ExternalSource``.")
@@ -638,6 +640,11 @@ Keyword Args
 
 def _is_external_source_with_callback(op_instance):
     return isinstance(op_instance._op, ExternalSource) and op_instance._callback is not None
+
+
+def _is_external_source(op_instance):
+    return isinstance(op_instance._op, ExternalSource)
+
 
 def external_source(source = None, num_outputs = None, *, cycle = None, name = None, device = "cpu", layout = None,
                     cuda_stream = None, use_copy_kernel = None, batch = True, **kwargs):

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -153,6 +153,7 @@ Parameters
         # * Start the Python workers pool (_start_py_workers())
         # * Construct the C++ Pipeline backend and pass the graph to it (_init_pipeline_backend())
         # * Build the pieline. (_pipe.Build())
+        # In case of deserialized pipeline, only _backend_prepared and _built will be True
         self._py_graph_built = False
         self._py_pool_started = False
         self._backend_prepared = False

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -246,10 +246,7 @@ if dataset_compatible_tensorflow():
                 output_shapes=None,
                 fail_on_device_mismatch=True,
                 *,
-                # using kwargs for inputs allow us to add more kinds of parameters
-                # Experimental inputs begin
                 input_datasets=None,
-                # Experimental inputs end
                 batch_size=1,
                 num_threads=4,
                 device_id=0,
@@ -297,8 +294,6 @@ if dataset_compatible_tensorflow():
             self._fail_on_device_mismatch = fail_on_device_mismatch
 
             self._setup_inputs(input_datasets)
-
-            # TODO(klecki): Inspect the graph in the pipeline and set proper defaults in the External Source
 
             self._structure = structure.convert_legacy_structure(self._output_dtypes,
                                                                  self._output_shapes,
@@ -514,7 +509,6 @@ if dataset_compatible_tensorflow():
         DALIDatasetWithInputs.__doc__ = _experimental_dataset_docstring
         _insert_experimental_member(DALIDatasetWithInputs, "DALIDatasetWithInputs")
 
-        # TODO(klecki): Do I even want this?
         class input:
             """Wrapper for input passed to DALIDataset. Allows to pass additional options.
 

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -62,10 +62,10 @@ The operator adds additional parameters to the ones supported by the
 
 Parameters
 ----------
-    input_datasets : dict[str, tf.data.Dataset] or dict[str, nvidia.dali.plugin.tf.experimental.input]
+    input_datasets : dict[str, tf.data.Dataset] or dict[str, nvidia.dali.plugin.tf.experimental.Input]
         input datasets to the DALI Pipeline. It must be provided as a dictionary mapping from
-        the names of the ``External Source`` nodes to the datasets objects intended as inputs
-        for those nodes (or to the :meth:`~nvidia.dali.plugin.tf.experimental.input` wrapper).
+        the names of the ``External Source`` nodes to the datasets objects or to the
+        :meth:`~nvidia.dali.plugin.tf.experimental.Input` wrapper.
 
         For example::
 
@@ -261,7 +261,7 @@ if dataset_compatible_tensorflow():
             output_dtypes = self._handle_deprecation(output_dtypes, dtypes, "dtypes")
 
             if not self._check_dtypes(output_dtypes, tf.DType):
-                raise TypeError(("`output_dtypes` should be provided as single tf.DType value " +
+                raise TypeError(("`output_dtypes` should be provided as single tf.DType value "
                     "or a tuple of tf.DType values. Got value `{}` of type `{}`.") \
                         .format(output_dtypes, type(output_dtypes)))
 
@@ -311,7 +311,7 @@ if dataset_compatible_tensorflow():
                 self._input_layouts = ()
                 return
 
-            self._assert_pipeline_instace()
+            self._assert_pipeline_instance()
 
             name_es_map = self._get_name_es_instance_map()
 
@@ -326,8 +326,8 @@ if dataset_compatible_tensorflow():
                     return value.dataset
 
             error_str = (
-                "`input_datasets` must be a dictionary that maps input names (the `name` " +
-                "specified for External Source node in DALI pipeline) to input datasets " +
+                "`input_datasets` must be a dictionary that maps input names (the `name` "
+                "specified for External Source node in DALI pipeline) to input datasets "
                 "objects (`tf.data.Dataset`) or `nvidia.dali.plugin.tf.input` wrapper objects")
 
             if not isinstance(input_datasets, Mapping):
@@ -337,25 +337,25 @@ if dataset_compatible_tensorflow():
             for input_name, input_value in input_datasets.items():
                 # keys are str
                 if not isinstance(input_name, str):
-                    raise TypeError(error_str + (". Expected the keys (representing the input " +
-                                                 "names) to be of type `str`, got: `{}` of type: " +
+                    raise TypeError(error_str + (". Expected the keys (representing the input "
+                                                 "names) to be of type `str`, got: `{}` of type: "
                                                  "{} instead.").format(input_name, type(input_name)))
 
                 # values are tf.data.Dataset or input
                 is_dataset_only = isinstance(input_value, dataset_ops.DatasetV2)
                 experimental = _get_experimental()
-                if not is_dataset_only and not isinstance(input_value, experimental.input):
-                    raise TypeError(error_str + (". Expected the values of the dictionary " +
-                                                 "(representing the inputs) " +
-                                                 " to be of type `tf.data.Dataset` or " +
-                                                 "`nvidia.dali.plugin.tf.input` got: `{}` of " +
+                if not is_dataset_only and not isinstance(input_value, experimental.Input):
+                    raise TypeError(error_str + (". Expected the values of the dictionary "
+                                                 "(representing the inputs) "
+                                                 " to be of type `tf.data.Dataset` or "
+                                                 "`nvidia.dali.plugin.tf.Input` got: `{}` of "
                                                  "type: {} instead.").format(input_value, type(input_value)))
 
                 # there is External Source with name equal to `input_name`
                 if input_name not in name_es_map.keys():
-                    raise ValueError(("Did not find an External Source node with nam=' {}' in " +
-                                      "the provided pipeline - required by the name specified " +
-                                      "in the `input_datasets`. Names of available External " +
+                    raise ValueError(("Did not find an External Source node with name=' {}' in "
+                                      "the provided pipeline - required by the name specified "
+                                      "in the `input_datasets`. Names of available External "
                                       "Source nodes are: {}.").format(input_name,
                                                                       list(name_es_map.keys())))
 
@@ -366,46 +366,45 @@ if dataset_compatible_tensorflow():
                 if is_dataset_only or input_value.layout is None:
                     input_layouts_list.append(self._get_layout_from_pipeline(input_name, name_es_map))
                 else:
-                    print("HERE: ", input_value, input_value.layout)
                     input_layouts_list.append(input_value.layout)
 
             # We covered all inputs
             non_matched = set(name_es_map.keys()) - set(input_datasets.keys())
             if len(non_matched) != 0:
-                raise ValueError(("Found External Source nodes in the Pipeline, that were not " +
-                                  "assigned any inputs. Nodes without inputs: \n{}.\nNodes that " +
+                raise ValueError(("Found External Source nodes in the Pipeline, that were not "
+                                  "assigned any inputs. Nodes without inputs: \n{}.\nNodes that "
                                   "were assigned inputs:\n{}.").format(list(non_matched), list(input_datasets.keys())))
 
             self._input_datasets = tuple(input_datasets_list)
             self._input_names = tuple(input_names_list)
             self._input_layouts = tuple(input_layouts_list)
 
-        def _assert_pipeline_instace(self):
+        def _assert_pipeline_instance(self):
             """Ensure that the pipeline is built, and check if the Python part is available.
             """
             #
             self._pipeline_instance.build()
             if not self._pipeline_instance._py_graph_built and self._pipeline_instance._built:
-                raise ValueError("Deserialized pipelines cannot be used with `input_datasets`. " +
-                                 "Please provide a pipeline that was created directly in Python " +
+                raise ValueError("Deserialized pipelines cannot be used with `input_datasets`. "
+                                 "Please provide a pipeline that was created directly in Python "
                                  "and not recreated from serialized one.")
 
         def _assert_correct_external_sources(self, external_source):
             """Validate that the external source nodes used are properly configured"""
             if external_source._op._num_outputs is not None:
-                raise ValueError("Found External Source node in the Pipeline that was " +
-                                 "created with `num_outputs` parameter. Only single-output " +
-                                 "(with `num_outputs=None`), named (with `name` argument " +
-                                 "specified) External Source nodes are supported as inputs " +
+                raise ValueError("Found External Source node in the Pipeline that was "
+                                 "created with `num_outputs` parameter. Only single-output "
+                                 "(with `num_outputs=None`), named (with `name` argument "
+                                 "specified) External Source nodes are supported as inputs "
                                  "for DALIDataset integration.")
             if external_source._op._callback is not None:
-                raise NotImplementedError("External Source with `callback` specified as input " +
+                raise NotImplementedError("External Source with `callback` specified as input "
                                           "for DALIDataset are not supported yet.")
             if external_source._op._name is None:
-                raise ValueError("Found External Source node in the Pipeline that was " +
-                                 "not named (no `name` argument set). Only single-output " +
-                                 "(with `num_outputs=None`), named (with `name` argument " +
-                                 "specified) External Source nodes are supported as inputs " +
+                raise ValueError("Found External Source node in the Pipeline that was "
+                                 "not named (no `name` argument set). Only single-output "
+                                 "(with `num_outputs=None`), named (with `name` argument "
+                                 "specified) External Source nodes are supported as inputs "
                                  "for DALIDataset integration.")
 
         def _get_name_es_instance_map(self):
@@ -436,7 +435,7 @@ if dataset_compatible_tensorflow():
             if deprecated_arg is not None:
                 if supported_arg is not None:
                     raise ValueError((
-                        "Usage of `{name}` is deprecated in favor of `output_{name}`. " +
+                        "Usage of `{name}` is deprecated in favor of `output_{name}`. "
                         "Both arguments were provided, but only `output_{name}` should be provided."
                     ).format(name=name))
                 # show only this warning
@@ -513,7 +512,7 @@ if dataset_compatible_tensorflow():
         DALIDatasetWithInputs.__doc__ = _experimental_dataset_docstring
         _insert_experimental_member(DALIDatasetWithInputs, "DALIDatasetWithInputs")
 
-        class input:
+        class Input:
             """Wrapper for input passed to DALIDataset. Allows to pass additional options.
 
             Parameters
@@ -532,13 +531,13 @@ if dataset_compatible_tensorflow():
             def __init__(self, dataset, *, layout=None):
                 if not isinstance(dataset, dataset_ops.DatasetV2):
                     raise TypeError(
-                        ("The inputs specified to DALIDataset must be instances of " +
+                        ("The inputs specified to DALIDataset must be instances of "
                          "type `tf.data.Dataset` got: `{}` of type: {} instead.").format(
                              dataset, type(dataset)))
                 self.dataset = dataset
                 self.layout = layout
 
-        _insert_experimental_member(input, "input")
+        _insert_experimental_member(Input, "Input")
 
     _load_experimental_dataset()
 
@@ -574,11 +573,11 @@ else:
         DALIDatasetWithInputs.__doc__ = _experimental_dataset_docstring
         _insert_experimental_member(DALIDatasetWithInputs, "DALIDatasetWithInputs")
 
-        class input:
+        class Input:
             def __init__(self, *args, **kwargs):
                 pass
 
-        _insert_experimental_member(input, "input")
+        _insert_experimental_member(Input, "Input")
 
     _load_experimental_dataset()
 

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -381,6 +381,10 @@ if dataset_compatible_tensorflow():
             self._input_layouts = tuple(input_layouts_list)
 
         def _assert_pipeline_instace(self):
+            """Ensure that the pipeline is built, and check if the Python part is available.
+            """
+            #
+            self._pipeline_instance.build()
             if not self._pipeline_instance._py_graph_built and self._pipeline_instance._built:
                 raise ValueError("Deserialized pipelines cannot be used with `input_datasets`. " +
                                  "Please provide a pipeline that was created directly in Python " +

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -328,7 +328,8 @@ if dataset_compatible_tensorflow():
             error_str = (
                 "`input_datasets` must be a dictionary that maps input names (the `name` "
                 "specified for External Source node in DALI pipeline) to input datasets "
-                "objects (`tf.data.Dataset`) or `nvidia.dali.plugin.tf.input` wrapper objects")
+                "objects (`tf.data.Dataset`) or `nvidia.dali.plugin.tf.experimental.Input` wrapper "
+                "objects")
 
             if not isinstance(input_datasets, Mapping):
                 raise TypeError(error_str +
@@ -341,7 +342,7 @@ if dataset_compatible_tensorflow():
                                                  "names) to be of type `str`, got: `{}` of type: "
                                                  "{} instead.").format(input_name, type(input_name)))
 
-                # values are tf.data.Dataset or input
+                # values are tf.data.Dataset or Input
                 is_dataset_only = isinstance(input_value, dataset_ops.DatasetV2)
                 experimental = _get_experimental()
                 if not is_dataset_only and not isinstance(input_value, experimental.Input):
@@ -353,7 +354,7 @@ if dataset_compatible_tensorflow():
 
                 # there is External Source with name equal to `input_name`
                 if input_name not in name_es_map.keys():
-                    raise ValueError(("Did not find an External Source node with name=' {}' in "
+                    raise ValueError(("Did not find an External Source node with name='{}' in "
                                       "the provided pipeline - required by the name specified "
                                       "in the `input_datasets`. Names of available External "
                                       "Source nodes are: {}.").format(input_name,

--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-from nvidia.dali import Pipeline, pipeline_def
-logging.getLogger('tensorflow').disabled = True
-# logging.getLogger('tensorflow').setLevel(logging.WARNING)
-
 import tensorflow as tf
-from nvidia.dali.plugin.tf.experimental import DALIDatasetWithInputs, input as experimental_input
+from nvidia.dali import Pipeline, pipeline_def
 import nvidia.dali.plugin.tf as dali_tf
+from nvidia.dali.plugin.tf.experimental import DALIDatasetWithInputs, input as experimental_input
 from test_utils_tensorflow import *
 from test_dali_tf_dataset_pipelines import *
 from nose.tools import raises, with_setup

--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -15,7 +15,7 @@
 import tensorflow as tf
 from nvidia.dali import Pipeline, pipeline_def
 import nvidia.dali.plugin.tf as dali_tf
-from nvidia.dali.plugin.tf.experimental import DALIDatasetWithInputs, input as experimental_input
+from nvidia.dali.plugin.tf.experimental import DALIDatasetWithInputs, Input
 from test_utils_tensorflow import *
 from test_dali_tf_dataset_pipelines import *
 from nose.tools import raises, with_setup
@@ -243,9 +243,9 @@ def test_tf_dataset_layouts():
         # Captured from pipeline
         yield check_layout, {'layout': layout, 'name': 'in'}, {'in': in_dataset}, layout
         # Captured from pipeline
-        yield check_layout, {'layout': layout, 'name': 'in'}, {'in': experimental_input(in_dataset)}, layout
+        yield check_layout, {'layout': layout, 'name': 'in'}, {'in': Input(in_dataset)}, layout
         # Overridden via experimental.input
-        yield check_layout, {'layout': 'TO_OVERRIDE', 'name': 'in'}, {'in': experimental_input(in_dataset, layout=layout)}, layout
+        yield check_layout, {'layout': 'TO_OVERRIDE', 'name': 'in'}, {'in': Input(in_dataset, layout=layout)}, layout
 
 
 

--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -244,7 +244,7 @@ def test_tf_dataset_layouts():
         yield check_layout, {'layout': layout, 'name': 'in'}, {'in': in_dataset}, layout
         # Captured from pipeline
         yield check_layout, {'layout': layout, 'name': 'in'}, {'in': Input(in_dataset)}, layout
-        # Overridden via experimental.input
+        # Overridden via experimental.Input
         yield check_layout, {'layout': 'TO_OVERRIDE', 'name': 'in'}, {'in': Input(in_dataset, layout=layout)}, layout
 
 

--- a/dali/test/python/test_dali_tf_dataset_pipelines.py
+++ b/dali/test/python/test_dali_tf_dataset_pipelines.py
@@ -128,7 +128,7 @@ def external_source_converter_with_fixed_value(shape, dtype, tensor):
             dali_dataset = dali_tf.experimental.DALIDatasetWithInputs(
                     input_datasets={"input_placeholder": input_dataset},
                     pipeline=dataset_pipeline,
-                    batch_size=dataset_pipeline.batch_size,
+                    batch_size=dataset_pipeline.max_batch_size,
                     output_shapes=shapes,
                     output_dtypes=dtypes,
                     num_threads=dataset_pipeline.num_threads,
@@ -155,7 +155,7 @@ def external_source_converter_with_callback(input_iterator, shape, dtype, *args)
             dali_dataset = dali_tf.experimental.DALIDatasetWithInputs(
                     input_datasets={"input_placeholder": input_dataset},
                     pipeline=dataset_pipeline,
-                    batch_size=dataset_pipeline.batch_size,
+                    batch_size=dataset_pipeline.max_batch_size,
                     output_shapes=shapes,
                     output_dtypes=dtypes,
                     num_threads=dataset_pipeline.num_threads,
@@ -236,7 +236,7 @@ def external_source_converter_multiple(start_values, input_names):
             dali_dataset = dali_tf.experimental.DALIDatasetWithInputs(
                     input_datasets=input_datasets,
                     pipeline=dataset_pipeline,
-                    batch_size=dataset_pipeline.batch_size,
+                    batch_size=dataset_pipeline.max_batch_size,
                     output_shapes=shapes,
                     output_dtypes=dtypes,
                     num_threads=dataset_pipeline.num_threads,

--- a/docs/plugins/tensorflow_plugin_api.rst
+++ b/docs/plugins/tensorflow_plugin_api.rst
@@ -10,4 +10,4 @@ Experimental
 
 .. autofunction:: nvidia.dali.plugin.tf.experimental.DALIDatasetWithInputs
 
-.. autofunction:: nvidia.dali.plugin.tf.experimental.input
+.. autofunction:: nvidia.dali.plugin.tf.experimental.Input

--- a/docs/plugins/tensorflow_plugin_api.rst
+++ b/docs/plugins/tensorflow_plugin_api.rst
@@ -9,3 +9,5 @@ Experimental
 ------------
 
 .. autofunction:: nvidia.dali.plugin.tf.experimental.DALIDatasetWithInputs
+
+.. autofunction:: nvidia.dali.plugin.tf.experimental.input


### PR DESCRIPTION
Change from separate tuples for every
parameter to a dictionary that maps
the input names to the actual inputs.

Adjust docs and tests.

TODO:
- [x] Automatic layout handling from Pipeline.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Improve API of TF DALI Dataset.


#### What happened in this PR? 
 - What solution was applied:
     
Change from separate tuples for every
parameter to a dictionary that maps
the input names to the actual inputs.

Adjust docs and tests.

 - Affected modules and functionalities:
     tf plugin
 - Key points relevant for the review:
     
 - Validation and testing:
     CI
 - Documentation (including examples):
     Yes


**JIRA TASK**: *[Use DALI-2144 or NA]*
