### PR TITLE
Add information about installing CUDA 10.2 DALI version

### DIFF
--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -38,7 +38,7 @@ Building Python Wheel
 Change directory (``cd``) into ``docker`` directory and run ``./build.sh``. If needed,
 set the following environment variables:
 
-* | CUDA_VERSION - CUDA toolkit version (10.0, 10.2, 11.0, 11.1, 11.2 and 11.3).
+* | CUDA_VERSION - CUDA toolkit version (10.2 and 11.3 are offiically supported, 10.0, 11.0, 11.1 and 11.2 are deprecated and may not work).
   | The default is ``11.3``. Thanks to CUDA extended compatibility mode, CUDA 11.1, 11.2 and 11.3 wheels are
     named as CUDA 11.0 because it can work with the CUDA 11.0 R450.x driver family. Please update
     to the latest recommended driver version in that family.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -44,11 +44,11 @@ nvidia-dali
 Execute the following command to install the latest DALI for specified CUDA version (please check
 :doc:`support matrix <support_matrix>` to see if your platform is supported):
 
-* for CUDA 10:
+* for CUDA 10.2:
 
 .. code-block:: bash
 
-   pip install --extra-index-url https://developer.download.nvidia.com/compute/redist --upgrade nvidia-dali-cuda100
+   pip install --extra-index-url https://developer.download.nvidia.com/compute/redist --upgrade nvidia-dali-cuda102
 
 * for CUDA 11.0:
 
@@ -73,11 +73,11 @@ nvidia-dali-tf-plugin
 DALI doesn't contain prebuilt versions of the DALI TensorFlow plugin. It needs to be installed as a separate package
 which will be built against the currently installed version of TensorFlow:
 
-* for CUDA 10:
+* for CUDA 10.2:
 
 .. code-block:: bash
 
-   pip install --extra-index-url https://developer.download.nvidia.com/compute/redist --upgrade nvidia-dali-tf-plugin-cuda100
+   pip install --extra-index-url https://developer.download.nvidia.com/compute/redist --upgrade nvidia-dali-tf-plugin-cuda102
 
 * for CUDA 11.0:
 
@@ -114,12 +114,12 @@ Nightly Builds
 
 To access most recent nightly builds please use flowing release channel:
 
-* for CUDA 10:
+* for CUDA 10.2:
 
 .. code-block:: bash
 
-  pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly --upgrade nvidia-dali-nightly-cuda100
-  pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly --upgrade nvidia-dali-tf-plugin-nightly-cuda100
+  pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly --upgrade nvidia-dali-nightly-cuda102
+  pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/nightly --upgrade nvidia-dali-tf-plugin-nightly-cuda102
 
 * for CUDA 11.0:
 
@@ -161,7 +161,12 @@ For older versions of DALI (0.22 and lower), use the package `nvidia-dali`. The 
    pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/cuda/11.0 --upgrade nvidia-dali
    pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/cuda/11.0 --upgrade nvidia-dali-tf-plugin
 
-CUDA 9 build is provided up to DALI 0.22.0. CUDA 10 build is provided starting from DALI 0.8.0.
+CUDA 9 build is provided up to DALI 0.22.0.
+
+CUDA 10 build is provided up to DALI 1.3.0.
+
+CUDA 10.2 build is provided starting from DALI 1.4.0.
+
 CUDA 11 build is provided starting from DALI 0.22.0.
 
 Open Cognitive Environment (Open-CE)


### PR DESCRIPTION
- as DALI starting from 1.4 will stop supporting CUDA 10.0 builds
  and provide 10.2 one instead the installation guide needs to be
  updated
- updates compilation guide deprecated all but  CUDA 10.2 and 11.3 builds

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds information about installing CUDA 10.2 DALI version

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     as DALI starting from 1.4 will stop supporting CUDA 10.0 builds and provide 10.2 one instead the installation guide needs to be updated
    updates compilation guide deprecated all but  CUDA 10.2 and 11.3 builds
 - Affected modules and functionalities:
     installation guide
    compilation guide
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     only documentation is updated


**JIRA TASK**: *[Use DALI-XXXX or NA]*
