### PR TITLE
Use HW NVJPEG decoder memory pool even if size hint is not set

### DIFF
--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -108,14 +108,14 @@ https://developer.nvidia.com/blog/loading-data-fast-with-dali-and-new-jpeg-decod
 Applies **only** to the ``mixed`` backend type in NVIDIA Ampere GPU architecture.
 
 The hint is used to preallocate memory for the HW JPEG decoder.)code",
-      1)
+      0)
   .AddOptionalArg("preallocate_height_hint",
       R"code(Image width hint.
 
 Applies **only** to the ``mixed`` backend type in NVIDIA Ampere GPU architecture.
 
 The hint is used to preallocate memory for the HW JPEG decoder.)code",
-      1)
+      0)
   .AddOptionalArg("affine",
       R"code(Applies **only** to the ``mixed`` backend type.
 

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -108,14 +108,14 @@ https://developer.nvidia.com/blog/loading-data-fast-with-dali-and-new-jpeg-decod
 Applies **only** to the ``mixed`` backend type in NVIDIA Ampere GPU architecture.
 
 The hint is used to preallocate memory for the HW JPEG decoder.)code",
-      0)
+      1)
   .AddOptionalArg("preallocate_height_hint",
       R"code(Image width hint.
 
 Applies **only** to the ``mixed`` backend type in NVIDIA Ampere GPU architecture.
 
 The hint is used to preallocate memory for the HW JPEG decoder.)code",
-      0)
+      1)
   .AddOptionalArg("affine",
       R"code(Applies **only** to the ``mixed`` backend type.
 

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -109,8 +109,6 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
                    make_string("Provided preallocate_width_hint=", preallocate_width_hint, ", and ",
                    "preallocate_height_hint=", preallocate_height_hint, " should not be ",
                    "negative."));
-      preallocate_width_hint = preallocate_width_hint < 0 ? 0 : preallocate_width_hint;
-      preallocate_height_hint = preallocate_height_hint < 0 ? 0 : preallocate_height_hint;
       LOG_LINE << "Using NVJPEG_PREALLOCATE_API" << std::endl;
       NVJPEG_CALL(nvjpegDecodeBatchedPreAllocate(
         handle_,

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -105,10 +105,10 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       // call nvjpegDecodeBatchedPreAllocate to use memory pool for HW decoder even if hint is 0
       auto preallocate_width_hint = spec.GetArgument<int>("preallocate_width_hint");
       auto preallocate_height_hint = spec.GetArgument<int>("preallocate_height_hint");
-      DALI_ENFORCE(preallocate_width_hint >= 0 && preallocate_width_hint >= 0,
+      DALI_ENFORCE(preallocate_width_hint > 0 && preallocate_width_hint > 0,
                    make_string("Provided preallocate_width_hint=", preallocate_width_hint, ", and ",
                    "preallocate_height_hint=", preallocate_height_hint, " should not be ",
-                   "negative."));
+                   "bigger than 0."));
       LOG_LINE << "Using NVJPEG_PREALLOCATE_API" << std::endl;
       NVJPEG_CALL(nvjpegDecodeBatchedPreAllocate(
         handle_,

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -107,8 +107,10 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       auto preallocate_width_hint = spec.GetArgument<int>("preallocate_width_hint");
       auto preallocate_height_hint = spec.GetArgument<int>("preallocate_height_hint");
       // make sure it is not negative if provided
-      DALI_ENFORCE((!HasArgument("preallocate_width_hint") || preallocate_width_hint >= 0) &&
-                   (!HasArgument("preallocate_height_hint") || preallocate_height_hint >= 0),
+      DALI_ENFORCE((!spec.HasArgument("preallocate_width_hint") ||
+                      preallocate_width_hint >= 0) &&
+                   (!spec.HasArgument("preallocate_height_hint") ||
+                      preallocate_height_hint >= 0),
                    make_string("Provided preallocate_width_hint=", preallocate_width_hint, ", and ",
                    "preallocate_height_hint=", preallocate_height_hint, " should not be ",
                    "negative."));

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -105,6 +105,10 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       // call nvjpegDecodeBatchedPreAllocate to use memory pool for HW decoder even if hint is 0
       auto preallocate_width_hint = spec.GetArgument<int>("preallocate_width_hint");
       auto preallocate_height_hint = spec.GetArgument<int>("preallocate_height_hint");
+      DALI_ENFORCE(preallocate_width_hint >= 0 && preallocate_width_hint >= 0,
+                   make_string("Provided preallocate_width_hint=", preallocate_width_hint, ", and ",
+                   "preallocate_height_hint=", preallocate_height_hint, " should not be ",
+                   "negative."));
       preallocate_width_hint = preallocate_width_hint < 0 ? 0 : preallocate_width_hint;
       preallocate_height_hint = preallocate_height_hint < 0 ? 0 : preallocate_height_hint;
       LOG_LINE << "Using NVJPEG_PREALLOCATE_API" << std::endl;


### PR DESCRIPTION
- even if the image size hint is not set calling nvjpegDecodeBatchedPreAllocate
  enables memory pooling reducing the number of reallocations during the
  decoding and reducing performance hit

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds HW NVJPEG decoder memory poll even if size hint is not set

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     even if the image size hint is not set calling nvjpegDecodeBatchedPreAllocate enables memory pooling reducing the number of reallocations during the decoding and reducing performance hit
 - Affected modules and functionalities:
     mixed backend image decoder
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
