### PR TITLE
Add ExecutionEngine to Slice CPU kernel, to allow parallel execution

### DIFF
--- a/dali/kernels/common/split_shape.h
+++ b/dali/kernels/common/split_shape.h
@@ -83,11 +83,10 @@ int LastSplitDim(const SplitFactor& split_factor) {
  * @brief Schedule work on a per-block basis
  */
 template <int Dims, typename SplitFactor, typename ScheduleBlockFunc>
-void ScheduleBlocks(TensorShape<Dims> &start, TensorShape<Dims> &end,
+void ScheduleBlocks(TensorShape<Dims> start, TensorShape<Dims> end,
                     const SplitFactor& split_factor, int d, int max_split_dim,
-                    ScheduleBlockFunc &&func) {
+                    ScheduleBlockFunc&& func) {
   if (d > max_split_dim || d == Dims) {
-    std::cout << "Execute \n";
     func(start, end);
     return;
   }
@@ -101,12 +100,10 @@ void ScheduleBlocks(TensorShape<Dims> &start, TensorShape<Dims> &end,
   int64_t start_d  = start[d];
   int64_t extent_d = end[d] - start_d;
   int nblocks_d = split_factor[d];
+  int64_t prev_end = start_d;
   for (int b = 0; b < nblocks_d; b++) {
-    start[d] = extent_d *  b      / nblocks_d + start_d;
-    end[d]   = extent_d * (b + 1) / nblocks_d + start_d;
-    std::cout << "d" << d << " b" << b << " start_d=" << start[d] << " end_d=" << end[d]
-              << " start_d " << start_d << " extent_d " << extent_d << " nblocks_d " << nblocks_d
-              << "\n";
+    start[d] = prev_end;
+    end[d]   = prev_end = extent_d * (b + 1) / nblocks_d + start_d;
     ScheduleBlocks(start, end, split_factor, d + 1, max_split_dim,
                    std::forward<ScheduleBlockFunc>(func));
   }

--- a/dali/kernels/common/split_shape.h
+++ b/dali/kernels/common/split_shape.h
@@ -82,11 +82,12 @@ int LastSplitDim(const SplitFactor& split_factor) {
 /**
  * @brief Schedule work on a per-block basis
  */
-template <int Dims, typename SplitFactor, typename ScheduleBlockFunc>
-void ScheduleBlocks(TensorShape<Dims> start, TensorShape<Dims> end,
+template <int ndim, typename SplitFactor, typename ScheduleBlockFunc>
+void ScheduleBlocks(TensorShape<ndim> start, TensorShape<ndim> end,
                     const SplitFactor& split_factor, int d, int max_split_dim,
                     ScheduleBlockFunc&& func) {
-  if (d > max_split_dim || d == Dims) {
+  assert(start.size() == end.size());
+  if (d > max_split_dim || d == start.size()) {
     func(start, end);
     return;
   }

--- a/dali/kernels/common/split_shape.h
+++ b/dali/kernels/common/split_shape.h
@@ -80,12 +80,17 @@ int LastSplitDim(const SplitFactor& split_factor) {
 }
 
 /**
- * @brief Schedule work on a per-block basis
+ * @brief Iterates over blocks, based on a split factor for each dimension
+ * @param start start coordinates of the region
+ * @param end end coordinates of the region
+ * @param split_factor split factor for each dimension in the region
+ * @param d Current dimension
+ * @param max_split_dim last dimension with a split factor different than 1.
+ * @param func Function to run for each block.
  */
-template <int ndim, typename SplitFactor, typename ScheduleBlockFunc>
-void ScheduleBlocks(TensorShape<ndim> start, TensorShape<ndim> end,
-                    const SplitFactor& split_factor, int d, int max_split_dim,
-                    ScheduleBlockFunc&& func) {
+template <int ndim, typename SplitFactor, typename OnBlockFunc>
+void ForEachBlock(TensorShape<ndim> start, TensorShape<ndim> end, const SplitFactor& split_factor,
+                  int d, int max_split_dim, OnBlockFunc&& func) {
   assert(start.size() == end.size());
   if (d > max_split_dim || d == start.size()) {
     func(start, end);
@@ -93,20 +98,20 @@ void ScheduleBlocks(TensorShape<ndim> start, TensorShape<ndim> end,
   }
 
   if (split_factor[d] == 1) {
-    ScheduleBlocks(start, end, split_factor, d + 1, max_split_dim,
-                   std::forward<ScheduleBlockFunc>(func));
+    ForEachBlock(start, end, split_factor, d + 1, max_split_dim,
+                 std::forward<OnBlockFunc>(func));
     return;
   }
 
-  int64_t start_d  = start[d];
+  int64_t start_d = start[d];
   int64_t extent_d = end[d] - start_d;
   int nblocks_d = split_factor[d];
   int64_t prev_end = start_d;
   for (int b = 0; b < nblocks_d; b++) {
     start[d] = prev_end;
-    end[d]   = prev_end = extent_d * (b + 1) / nblocks_d + start_d;
-    ScheduleBlocks(start, end, split_factor, d + 1, max_split_dim,
-                   std::forward<ScheduleBlockFunc>(func));
+    end[d] = prev_end = extent_d * (b + 1) / nblocks_d + start_d;
+    ForEachBlock(start, end, split_factor, d + 1, max_split_dim,
+                 std::forward<OnBlockFunc>(func));
   }
 }
 

--- a/dali/kernels/common/split_shape.h
+++ b/dali/kernels/common/split_shape.h
@@ -15,6 +15,8 @@
 #ifndef DALI_KERNELS_COMMON_SPLIT_SHAPE_H_
 #define DALI_KERNELS_COMMON_SPLIT_SHAPE_H_
 
+#include "dali/core/util.h"
+
 namespace dali {
 namespace kernels {
 

--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -283,6 +283,7 @@ void SliceKernel(OutputType *output,
  * @brief Implementation of slice kernel with an execution engine.
  */
 template <typename ExecutionEngine, typename OutputType, typename InputType, int Dims>
+DLL_LOCAL  // workaround for GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80947
 void SliceKernel(ExecutionEngine &exec_engine,
                  OutputType *output,
                  const InputType *input,
@@ -320,7 +321,7 @@ void SliceKernel(ExecutionEngine &exec_engine,
   TensorShape<Dims> start;
   const auto& end = out_shape;
 
-  ScheduleBlocks(
+  ForEachBlock(
     start, end, split_factor, 0, last_split_dim,
     [&](const TensorShape<Dims> &blk_start, const TensorShape<Dims> &blk_end) {
       auto output_ptr = output;

--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -383,7 +383,7 @@ class SliceCPU {
    *        The work is only schedule and does not start until the user calls RunAll()
    *        on the execution engine.
    *
-   *        The user is responsible to synchronize with the execution engine (e.g. WaitForWork())
+   *        The user is responsible to synchronize with the execution engine.
    *
    *        For execution engines other than SequentialExecutionEngine, the algorithm will try
    *        to split the slice into similar sized blocks until we either reach a minimum of ``req_nblocks``

--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -316,8 +316,6 @@ void SliceKernel(ExecutionEngine &exec_engine,
 
   int last_split_dim = LastSplitDim(split_factor);
   TensorShape<Dims> start;
-  for (int d = 0; d < Dims; d++)
-    start[d] = 0;
   const auto& end = out_shape;
 
   ScheduleBlocks(
@@ -366,6 +364,8 @@ void SliceKernel(SequentialExecutionEngine &exec_engine,
 template <typename OutputType, typename InputType, int Dims>
 class SliceCPU {
  public:
+  static_assert(Dims >= 0, "Dims must be >= 0");
+
   KernelRequirements Setup(KernelContext &context,
                            const InTensorCPU<InputType, Dims> &in,
                            const SliceArgs<OutputType, Dims> &slice_args) {
@@ -390,7 +390,7 @@ class SliceCPU {
    * @param req_nblocks Requested number of blocks. By default the requested number of blocks
    *                    is calculated as ``num_threads * 8``
    */
-  template <typename ExecutionEngine = SequentialExecutionEngine>
+  template <typename ExecutionEngine>
   void Run(KernelContext &context,
            OutTensorCPU<OutputType, Dims> out,
            InTensorCPU<InputType, Dims> in,

--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -295,7 +295,7 @@ void SliceKernel(ExecutionEngine &exec_engine,
                  int channel_dim = -1,  // negative if no channel dim or already processed
                  int min_blk_sz = 16000,
                  int req_nblocks = -1) {
-    // Parallelize
+  // Parallelize
   if (req_nblocks < 0)
     req_nblocks = exec_engine.NumThreads() * 8;
 
@@ -318,21 +318,10 @@ void SliceKernel(ExecutionEngine &exec_engine,
   TensorShape<Dims> start;
   for (int d = 0; d < Dims; d++)
     start[d] = 0;
-  auto end = out_shape;  // need a copy
-
-  std::cout << "Split factor:";
-  for (int d = 0; d < Dims; d++)
-    std::cout << " " << split_factor[d];
-  std::cout << "\n";
-
-  std::cout << "Shape:";
-  for (int d = 0; d < Dims; d++)
-    std::cout << " " << out_shape[d];
-  std::cout << "\n";
-
+  const auto& end = out_shape;
 
   ScheduleBlocks(
-    start, end, make_cspan(split_factor), 0, last_split_dim,
+    start, end, split_factor, 0, last_split_dim,
     [&](const TensorShape<Dims> &blk_start, const TensorShape<Dims> &blk_end) {
       auto output_ptr = output;
       TensorShape<Dims> blk_anchor;

--- a/dali/operators/generic/slice/slice_base.cc
+++ b/dali/operators/generic/slice/slice_base.cc
@@ -86,10 +86,10 @@ void SliceBaseCpu<OutputType, InputType, Dims>::RunImpl(workspace_t<CPUBackend> 
   int block_threshold = 16000;
   kernels::KernelContext ctx;
   for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
-    kernel_.Run(ctx, out_view[sample_idx], in_view[sample_idx],
-                args_[sample_idx], thread_pool, block_threshold, req_nblocks);
+    kernel_.Schedule(ctx, out_view[sample_idx], in_view[sample_idx],
+                     args_[sample_idx], thread_pool, block_threshold, req_nblocks);
   }
-  thread_pool.WaitForWork();
+  thread_pool.RunAll();  // work starts now
 }
 
 template <>


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to parallelize the slice CPU kernel, especially useful when processing small batches.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Introduce utilities to apply processing to blocks in a region.*
     *Modify SliceCPU to run processing in blocks in parallel if the ratio of samples vs threads is low*
 - Affected modules and functionalities:
     *Slice based operators*
 - Key points relevant for the review:
     *SliceCPU implementation, ScheduleBlocks*
 - Validation and testing:
     *Existing tests apply*
 - Documentation (including examples):
     *Doxygen*


**JIRA TASK**: *[DALI-2128]*
