### PR TITLE
Fix MultiPaste error message

### DIFF
--- a/dali/operators/image/paste/multipaste.h
+++ b/dali/operators/image/paste/multipaste.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -172,7 +172,7 @@ class MultiPasteOp : public Operator<Backend> {
           DALI_ENFORCE(out_anchor.data[k] >= 0 && in_anchor.data[k] >= 0 &&
                        out_anchor.data[k] + shape.data[k] <= output_size_[i].data[k] &&
                        in_anchor.data[k] + shape.data[k] <= in_shape.data[k],
-                       "Paste in/out coords should be within inout/output bounds.");
+                       "Paste in/out coords should be within input/output bounds.");
         }
 
         for (int k = 0; k < j; k++) {

--- a/dali/test/python/test_operator_multipaste.py
+++ b/dali/test/python/test_operator_multipaste.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -251,7 +251,7 @@ def check_operator_multipaste(bs, pastes, in_size, out_size, even_paste_count, n
         assert not verify_out_of_bounds(bs, in_idx_l, in_anchors_l, shapes_l, out_anchors_l, in_size, out_size)
         manual_verify(bs, input, r, in_idx_l, in_anchors_l, shapes_l, out_anchors_l, [out_size + (3,)] * bs, out_dtype)
     except RuntimeError as e:
-        if "Paste in/out coords should be within inout/output bounds" in str(e):
+        if "Paste in/out coords should be within input/output bounds" in str(e):
             assert verify_out_of_bounds(bs, in_idx_l, in_anchors_l, shapes_l, out_anchors_l, in_size, out_size)
         else:
             assert False


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a typo in error message from multipaste

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Fix typo inout -> input
 - Affected modules and functionalities:
     * Multipaste & its test
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Multipaste test actually looks for this string
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-2156
