### PR TITLE
Fix DALI TF Plugin build in TF 2.6

### DIFF
--- a/dali_tf_plugin/daliop.cc
+++ b/dali_tf_plugin/daliop.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@
 
 #include "tensorflow/core/framework/op.h"
 
-#define EIGEN_USE_GPU  // for Eigen::GpuDevice
-#include "tensorflow/core/framework/op_kernel.h"
+// for Eigen::GpuDevice
+#define EIGEN_USE_GPU
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
+#include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/shape_inference.h"
 #include "tensorflow/core/framework/tensor_shape.h"


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

#### Why we need this PR?
Fix tf plugin compilation in TF 2.6

#### What happened in this PR? 
 - What solution was applied:
     Include eigen through some other header
 - Affected modules and functionalities:
     tf plugin
 - Key points relevant for the review:
     n/a
 - Validation and testing:
     CI only 
 - Documentation (including examples):
     no


**JIRA TASK**: *[Use DALI-XXXX or NA]*
