### PR TITLE
Disable MNIST dataset download for DALI pipelines

### DIFF
--- a/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
+++ b/docs/examples/frameworks/pytorch/pytorch-lightning.ipynb
@@ -238,7 +238,11 @@
     "class DALILitMNIST(LitMNIST):\n",
     "    def __init__(self):\n",
     "        super().__init__()\n",
-    "    \n",
+    "\n",
+    "    def prepare_data(self):\n",
+    "      # no preparation is needed in DALI\n",
+    "      pass\n",
+    "\n",
     "    def setup(self, stage=None):\n",
     "        device_id = self.local_rank\n",
     "        shard_id = self.global_rank\n",
@@ -346,7 +350,11 @@
     "class BetterDALILitMNIST(LitMNIST):\n",
     "    def __init__(self):\n",
     "        super().__init__()\n",
-    "    \n",
+    "\n",
+    "    def prepare_data(self):\n",
+    "      # no preparation is needed in DALI\n",
+    "      pass\n",
+    "\n",
     "    def setup(self, stage=None):\n",
     "        device_id = self.local_rank\n",
     "        shard_id = self.global_rank\n",
@@ -449,22 +457,16 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
+  },
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3.6.9 64-bit",
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": ""
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- MNIST dataset is not always available and is not used by
  the DALI pipeline in pytorch lightning example, only the
  native one. Disable downloading it for DALI pipelines as
  it frequently fails in CI

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes MNIST dataset download for DALI pipelines
- 
#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     MNIST dataset is not always available and is not used by the DALI pipeline in pytorch lightning example, only the native one. Disable downloading it for DALI pipelines as it frequently fails in CI
 - Affected modules and functionalities:
     pytorch-lightning example
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     only example is affected


**JIRA TASK**: *[NA]*
