### PR TITLE
Remove compiler name subdirectory in prebuilt DALI TF prebuilt directory

### DIFF
--- a/dali_tf_plugin/build_in_custom_op_docker.sh
+++ b/dali_tf_plugin/build_in_custom_op_docker.sh
@@ -13,8 +13,7 @@ LAST_CONFIG_INDEX=$(python ../qa/setup_packages.py -n -u tensorflow-gpu --cuda $
 PREBUILT_DIR=/prebuilt
 mkdir -p ${PREBUILT_DIR}
 
-COMPILER_SUBDIR_NAME=`python -c 'import dali_tf_plugin_utils as utils; print(utils.get_cpp_compiler_version())'`
-mkdir -p $PREBUILT_DIR/$COMPILER_SUBDIR_NAME
+mkdir -p $PREBUILT_DIR
 
 for i in `seq 0 $LAST_CONFIG_INDEX`; do
     INST=$(python ../qa/setup_packages.py -i $i -u tensorflow-gpu --cuda ${CUDA_VERSION})
@@ -25,7 +24,7 @@ for i in `seq 0 $LAST_CONFIG_INDEX`; do
     pip install ${INST} -f /pip-packages
 
     SUFFIX=$(echo $INST | sed 's/.*=\([0-9]\+\)\.\([0-9]\+\).*/\1_\2/')
-    LIB_PATH="${PREBUILT_DIR}/${COMPILER_SUBDIR_NAME}/libdali_tf_${SUFFIX}.so"
+    LIB_PATH="${PREBUILT_DIR}/libdali_tf_${SUFFIX}.so"
 
     source ./build_dali_tf.sh "${LIB_PATH}"
 

--- a/dali_tf_plugin/dali_tf_plugin_install_tool.py
+++ b/dali_tf_plugin/dali_tf_plugin_install_tool.py
@@ -49,8 +49,7 @@ class InstallerHelper:
         #   major version and the minor version in the prebuilt plugin is lower than the requested one.
         self.can_install_prebuilt = not self.always_build and \
             bool(self.tf_compiler) and \
-            (StrictVersion(self.default_cpp_version) >= StrictVersion('5.0') and \
-             StrictVersion(self.tf_compiler) >= StrictVersion('5.0')) and \
+            StrictVersion(self.tf_compiler) >= StrictVersion('5.0') and \
             self.is_compatible_with_prebuilt_bin
         self.prebuilt_plugins_available = []
         self.prebuilt_plugin_best_match = None


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- Refactoring to improve usage of prebuilt DALI TF plugins.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Remove compiler version subdir in prebuilt directory*
     *Removed exact compiler version match requirements from the DALI TF installation script, since TF is compiled with the newer version than the compiler available in the custom op docker.*
 - Affected modules and functionalities:
     *DALI TF package*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *Existing tests apply*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-2160]*
