### PR TITLE
Use PEP 503 compatible extra url index to install PyTorch

### DIFF
--- a/qa/download_pip_packages.sh
+++ b/qa/download_pip_packages.sh
@@ -17,12 +17,20 @@ do
         if test -n "$pip_packages"
         then
             last_config_index=$(python ../setup_packages.py -n -u $pip_packages --cuda ${CUDA_VERSION})
+
+            # get extra index url for given packages
+            extra_indices=$($topdir/qa/setup_packages.py -u $pip_packages --cuda ${CUDA_VERSION} -e)
+            extra_indices_string=""
+            for e in ${extra_indices}; do
+                extra_indices_string="${extra_indices_string} --extra-index-url=${e}"
+            done
+
             for i in `seq 0 $last_config_index`;
             do
                 inst=$(python ../setup_packages.py -i $i -u $pip_packages --cuda ${CUDA_VERSION})
                 if [ -n "$inst" ]
                 then
-                    pip download $inst -d /pip-packages
+                    pip download $inst -d /pip-packages ${extra_indices_string}
                 fi
             done
         fi

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -293,11 +293,11 @@ class CudaPackageExtraIndex(CudaPackage):
     def __init__(self, key, versions, name=None, extra_index=""):
         super(CudaPackageExtraIndex, self).__init__(key, versions, name)
         if not isinstance(versions, dict):
-            raise TypeError("versions argument should by dict type [cuda_version : list_of_versions")
+            raise TypeError("versions argument should be a dictionary {cuda_version_str : list_of_versions}")
         self.extra_index = extra_index
 
     def get_extra_index(self, cuda_version):
-        """Gets a extra url index for pip for given cuda version.
+        """Gets a extra url index for pip for a given cuda version.
 
             Parameters
             ----------
@@ -459,7 +459,7 @@ def cal_num_of_configs(packages, cuda_version):
     return ret
 
 def for_all_pckg(packages, fun, add_additional_packages=True):
-    """Iterates over all packages, executes a fun. Returns all fun results as a list"""
+    """Iterates over all packages, executes a function. Returns all function results as a list"""
     ret = []
     for pckg in all_packages:
         if pckg.key in packages:

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -46,6 +46,13 @@ test_body_wrapper() {(
     test_body
 )}
 
+# get extra index url for given packages
+extra_indices=$($topdir/qa/setup_packages.py -u $pip_packages --cuda ${CUDA_VERSION} -e)
+extra_indices_string=""
+for e in ${extra_indices}; do
+    extra_indices_string="${extra_indices_string} --extra-index-url=${e}"
+done
+
 for i in `seq 0 $last_config_index`;
 do
     echo "Test run $i"
@@ -65,7 +72,7 @@ do
                 set -e
                 # if no package was found in our download dir, so install it from index
                 if [ "$res" != "0" ]; then
-                    pip install $pkg
+                    pip install $pkg ${extra_indices_string}
                 fi
             done
 


### PR DESCRIPTION
- adds an option to list all extra indices for all installed packages
  in setup_packages.py
- thanks to this change torch whl can be fully downloaded and cached
  for the later installation process (as direct links used before are not)

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds the usage of PEP 503 compatible extra url index to install PyTorch

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds an option to list all extra indices for all installed packages in setup_packages.py
     thanks to this change torch whl can be fully downloaded and cached for the later installation process (as direct links used before are not)
 - Affected modules and functionalities:
     setup_packages.py, test_template.sh, 
 - Key points relevant for the review:download_pip_packages.sh
     NA
 - Validation and testing:
     current tests apply
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-2161]*
