### PR TITLE
Bit mask utility

### DIFF
--- a/dali/core/bitmask_test.cc
+++ b/dali/core/bitmask_test.cc
@@ -53,7 +53,29 @@ TEST(Bitmask, Indexing) {
   EXPECT_TRUE(mask[1]);
   EXPECT_FALSE(mask[2]);
   EXPECT_TRUE(mask[3]);
+
   EXPECT_TRUE(mask[99]);
+  mask[99] ^= false;
+  EXPECT_TRUE(mask[99]);
+  mask[99] ^= true;
+  EXPECT_FALSE(mask[99]);
+  mask[99] ^= false;
+  EXPECT_FALSE(mask[99]);
+
+  mask[99] |= false;
+  EXPECT_FALSE(mask[99]);
+  mask[99] |= true;
+  EXPECT_TRUE(mask[99]);
+  mask[99] |= false;
+  EXPECT_TRUE(mask[99]);
+
+  mask[99] &= true;
+  EXPECT_TRUE(mask[99]);
+  mask[99] &= false;
+  EXPECT_FALSE(mask[99]);
+  mask[99] &= true;
+  EXPECT_FALSE(mask[99]);
+
   EXPECT_EQ(mask.data()[0], bitmask::bit_storage_t(0b1010));
 }
 

--- a/dali/core/bitmask_test.cc
+++ b/dali/core/bitmask_test.cc
@@ -112,7 +112,7 @@ TEST(Bitmask, Find) {
   std::mt19937_64 rng(12345);
   std::bernoulli_distribution what;
   std::uniform_int_distribution<> len_dist(1, 200);
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < 200; i++) {
     int rep = len_dist(rng);
     bool value = what(rng);
     for (int j = 0; j < rep; j++) {

--- a/dali/core/bitmask_test.cc
+++ b/dali/core/bitmask_test.cc
@@ -1,0 +1,134 @@
+// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <random>
+#include "dali/core/bitmask.h"
+
+namespace dali {
+namespace test {
+
+TEST(Bitmask, ResizeFullWord) {
+  for (bool value : { false, true }) {
+    bitmask mask;
+    const size_t size = 3 * bitmask::storage_bits;
+    mask.resize(size, value);
+    EXPECT_EQ(mask.size(), size);
+    for (size_t i = 0; i < size; i++)
+      EXPECT_EQ(mask[i], value);
+  }
+}
+
+TEST(Bitmask, ResizePartialWord) {
+  bitmask mask;
+  mask.resize(3, false);
+  mask.resize(7, true);
+  EXPECT_EQ(mask.data()[0], bitmask::bit_storage_t(0b1111000));
+  mask.resize(6, true);
+  EXPECT_EQ(mask.data()[0], bitmask::bit_storage_t(0b111000));
+  mask.resize(5, true);
+  EXPECT_EQ(mask.data()[0], bitmask::bit_storage_t(0b11000));
+}
+
+TEST(Bitmask, Indexing) {
+  bitmask mask;
+  mask.resize(100, false);
+  mask[1] = true;
+  mask[2] = true;
+  mask[3] = true;
+  mask[2] = false;
+  mask[99] = true;
+  EXPECT_FALSE(mask[0]);
+  EXPECT_TRUE(mask[1]);
+  EXPECT_FALSE(mask[2]);
+  EXPECT_TRUE(mask[3]);
+  EXPECT_TRUE(mask[99]);
+  EXPECT_EQ(mask.data()[0], bitmask::bit_storage_t(0b1010));
+}
+
+TEST(Bitmask, Fill) {
+  bitmask mask;
+  mask.resize(500, false);
+  mask.fill(3, 5, true);
+  EXPECT_EQ(mask.data()[0], bitmask::bit_storage_t(0b11000));
+  mask.fill(0, 10, true);
+  EXPECT_EQ(mask.data()[0], bitmask::bit_storage_t(0b1111111111));
+  mask.fill(4, 8, false);
+  EXPECT_EQ(mask.data()[0], bitmask::bit_storage_t(0b1100001111));
+
+  for (int start  : { 0, 64, 9 }) {
+    for (int end    : { 7, 64, 67, 128, 199 }) {
+      for (bool value : { false, true }) {
+        std::cerr << "Filling range " << start << " to " << end << " with " << (value ? 1 : 0)
+                  << std::endl;
+        mask.fill(!value);
+        mask.fill(start, end, value);
+        for (int i = 0; i < 500; i++) {
+          bool expected = (i >= start && i < end) ? value : !value;
+          ASSERT_EQ(mask[i], expected) << " @ index " << i;
+        }
+      }
+    }
+  }
+}
+
+TEST(Bitmask, PushPop) {
+  bitmask mask;
+  std::vector<bool> ref;
+  std::mt19937_64 rng(12345);
+  std::bernoulli_distribution what;
+  std::bernoulli_distribution action(0.8);
+  for (int i = 0; i < 1000; i++) {
+    if (action(rng) || ref.empty()) {
+      bool value = what(rng);
+      mask.push_back(value);
+      ref.push_back(value);
+    } else {
+      mask.pop_back();
+      ref.pop_back();
+    }
+    EXPECT_EQ(mask.size(), ref.size());
+  }
+
+  for (int i = 0; i < static_cast<int>(ref.size()); i++) {
+    EXPECT_EQ(mask[i], ref[i]);
+  }
+}
+
+TEST(Bitmask, Find) {
+  bitmask mask;
+  std::vector<bool> ref;
+  std::mt19937_64 rng(12345);
+  std::bernoulli_distribution what;
+  std::uniform_int_distribution<> len_dist(1, 200);
+  for (int i = 0; i < 2; i++) {
+    int rep = len_dist(rng);
+    bool value = what(rng);
+    for (int j = 0; j < rep; j++) {
+      mask.push_back(value);
+      ref.push_back(value);
+    }
+  }
+
+  for (bool value : { false, true }) {
+    for (size_t start = 0; start < ref.size(); start++) {
+      ptrdiff_t idx = mask.find(value, start);
+      ptrdiff_t ref_idx = std::find(ref.begin() + start, ref.end(), value) - ref.begin();
+      EXPECT_EQ(idx, ref_idx);
+    }
+  }
+}
+
+}  // namespace test
+}  // namespace dali

--- a/dali/core/utils_test.cu
+++ b/dali/core/utils_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,6 +90,49 @@ TEST(CoreUtils, SpanFlatten) {
   span<const int> cflat = flatten(make_cspan(&arr[0], 2));
   for (int i = 0; i < 24; i++)
     EXPECT_EQ(cflat[i], i+1);
+}
+
+TEST(CoreUtils, CTZ) {
+  int32_t i32 = 0;
+  int64_t i64 = 0;
+  EXPECT_EQ(ctz(i32), 32);
+  EXPECT_EQ(ctz(i64), 64);
+  i32 = 1;
+  i64 = 1;
+  EXPECT_EQ(ctz(i32), 0);
+  EXPECT_EQ(ctz(i64), 0);
+  i32 = 0b11010010101;
+  i64 = 0b10010110111;
+  EXPECT_EQ(ctz(i32), 0);
+  EXPECT_EQ(ctz(i64), 0);
+
+  i32 = 0b110100101010;
+  i64 = 0b100101101110;
+  EXPECT_EQ(ctz(i32), 1);
+  EXPECT_EQ(ctz(i64), 1);
+
+  i32 = 0b11010010101000;
+  i64 = 0b10010110111000;
+  EXPECT_EQ(ctz(i32), 3);
+  EXPECT_EQ(ctz(i64), 3);
+
+  i32 = -1;
+  i64 = -1;
+  uint32_t u32 = i32;
+  uint64_t u64 = i64;
+  for (int s = 0; s <= 32; s++) {
+    EXPECT_EQ(ctz(i32), s);
+    EXPECT_EQ(ctz(u32), s);
+    u32 <<= 1;
+    i32 = u32;
+  }
+
+  for (int s = 0; s <= 64; s++) {
+    EXPECT_EQ(ctz(i64), s);
+    EXPECT_EQ(ctz(u64), s);
+    u64 <<= 1;
+    i64 = u64;
+  }
 }
 
 }  // namespace dali

--- a/include/dali/core/bitmask.h
+++ b/include/dali/core/bitmask.h
@@ -31,6 +31,11 @@ struct bitmask {
   static constexpr const int storage_bits = sizeof(bit_storage_t) * 8;
   static constexpr const int storage_bits_log = ilog2(storage_bits);
 
+  /**
+   * @brief Find the first bit with given value, starting at start
+   *
+   * @return The index of the first bit found of the size of the bit mask if not found.
+   */
   ptrdiff_t find(bool value, ptrdiff_t start = 0) const {
     assert(start >= 0);
     if (start >= size_)
@@ -61,6 +66,9 @@ struct bitmask {
     return size_;
   }
 
+  /**
+   * @brief Fill a range of bits with given value
+   */
   void fill(ptrdiff_t start, ptrdiff_t end, bool value) {
     if (start >= end)
       return;
@@ -98,12 +106,18 @@ struct bitmask {
     }
   }
 
+  /**
+   * @brief Fill the entire mask with given value.
+   */
   void fill(bool value) {
     size_t s = size();
     clear();
     resize(s, value);
   }
 
+  /**
+   * @brief A pseudoreference to a single bit in the mask
+   */
   struct bitref {
     bitref &operator=(bool value) {
       if (value)
@@ -208,6 +222,7 @@ struct bitmask {
  private:
   // vector of bit storage words - the bits that are outside of the mask are 0
   std::vector<bit_storage_t> storage_;
+  // number of bits in the mask
   ptrdiff_t size_ = 0;
 };
 

--- a/include/dali/core/bitmask.h
+++ b/include/dali/core/bitmask.h
@@ -24,7 +24,7 @@ namespace dali {
 /**
  * @brief A vector of bits with a utility for quickly searching for set/cleared bits.
  */
-struct bitmask {
+class bitmask {
  public:
   using bit_storage_t = uint64_t;
 

--- a/include/dali/core/bitmask.h
+++ b/include/dali/core/bitmask.h
@@ -1,0 +1,216 @@
+// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_BITMASK_H_
+#define DALI_CORE_BITMASK_H_
+
+#include <vector>
+#include <cassert>
+#include "dali/core/util.h"
+
+namespace dali {
+
+/**
+ * @brief A vector of bits with a utility for quickly searching for set/cleared bits.
+ */
+struct bitmask {
+ public:
+  using bit_storage_t = uint64_t;
+
+  static constexpr const int storage_bits = sizeof(bit_storage_t) * 8;
+  static constexpr const int storage_bits_log = ilog2(storage_bits);
+
+  ptrdiff_t find(bool value, ptrdiff_t start = 0) const {
+    assert(start >= 0);
+    if (start >= size_)
+      return size_;
+    auto index = start >> storage_bits_log;
+    int bit = start & (storage_bits - 1);
+    bit_storage_t flip = 0;
+    if (!value)
+      flip = ~flip;
+
+    // we're not starting at a storage word boundary - look at the first word first
+    if (bit > 0) {
+      auto word = storage_[index] ^ flip;
+      word >>= bit;  // skip bits before start
+      if (word)
+        return start + ctz(word);
+      index++;
+    }
+
+    ptrdiff_t num_words = storage_.size();
+    for (; index < num_words; index++) {
+      auto word = storage_[index] ^ flip;
+      if (word) {  // we've found something...
+        return (index << storage_bits_log) | ctz(word);
+      }
+    }
+
+    return size_;
+  }
+
+  void fill(ptrdiff_t start, ptrdiff_t end, bool value) {
+    if (start >= end)
+      return;
+    ptrdiff_t start_idx = start >> storage_bits_log;
+    ptrdiff_t end_idx = end >> storage_bits_log;
+    bit_storage_t ones = ~bit_storage_t(0);
+    bit_storage_t start_mask = ones;
+    bit_storage_t end_mask = 0;
+    if (start & (storage_bits - 1)) {
+        start_mask <<= (start & (storage_bits - 1));
+    }
+    if (end & (storage_bits - 1)) {
+        end_mask = ones >> (storage_bits - (end & (storage_bits - 1)));
+    }
+    if (start_idx == end_idx) {
+        start_mask &= end_mask;
+    }
+    ptrdiff_t idx = start_idx;
+    if (value)
+        storage_[idx++] |= start_mask;
+    else
+        storage_[idx++] &= ~start_mask;
+    if (value) {
+        for (; idx < end_idx; idx++)
+            storage_[idx] = ones;
+    } else {
+        for (; idx < end_idx; idx++)
+            storage_[idx] = 0;
+    }
+    if (end_mask && start_idx != end_idx) {
+      if (value)
+        storage_[end_idx] |= end_mask;
+      else
+        storage_[end_idx] &= ~end_mask;
+    }
+  }
+
+  void fill(bool value) {
+    size_t s = size();
+    clear();
+    resize(s, value);
+  }
+
+  struct bitref {
+    bitref &operator=(bool value) {
+      if (value)
+        *storage |= mask;
+      else
+        *storage &= ~mask;
+      return *this;
+    }
+    constexpr operator bool() const {
+      return *storage & mask;
+    }
+   private:
+    friend class bitmask;
+    constexpr bitref(bit_storage_t *array, ptrdiff_t index)
+    : storage(&array[index >> storage_bits_log])
+    , mask(bit_storage_t(1) << (index & (storage_bits - 1))) {}
+
+    bit_storage_t *storage;
+    bit_storage_t mask;
+  };
+
+  using reference_type = bitref;
+  using value_type = bool;
+
+  void push_back(bool value) {
+    size_t req_words = (size_ + storage_bits) >> storage_bits_log;
+    if (req_words > storage_.size())
+      storage_.push_back(value ? 1 : 0);  // put LSB in the storage vector
+    else
+      (*this)[size_] = value;  // set the last bit
+    size_++;
+  }
+
+  void pop_back() {
+    assert(!empty());
+    (*this)[--size_] = 0;
+    if ((size_ & (storage_bits - 1)) == 0)
+      storage_.pop_back();
+  }
+
+  constexpr bool empty() const noexcept { return size_ == 0; }
+
+  void reserve(size_t capacity) {
+    storage_.reserve((capacity + storage_bits - 1) >> storage_bits_log);
+  }
+
+  size_t capacity() const noexcept {
+    return storage_.capacity() * storage_bits;
+  }
+
+  void resize(size_t new_size, bool value = false) {
+    if (new_size == size())
+      return;
+    bit_storage_t ones = ~bit_storage_t(0);
+    bit_storage_t fill = value ? ones : 0;
+    size_t prev_words = storage_.size();
+    storage_.resize((new_size + storage_bits - 1) >> storage_bits_log, fill);
+    if (storage_.size() == prev_words && new_size > size()) {
+      if (value) {
+        storage_.back() |= ones << (size_ & (storage_bits - 1));
+      }
+    }
+    if (new_size & (storage_bits - 1)) {
+      bit_storage_t mask = ones;
+      mask = (mask << (new_size & (storage_bits - 1)));  // remove leading ones
+      mask = ~mask;  // flip values to keep only the leading ones
+      storage_.back() &= mask;
+    }
+    size_ = new_size;
+  }
+
+  void clear() {
+    storage_.clear();
+    size_ = 0;
+  }
+
+  bit_storage_t *data() noexcept {
+    return storage_.data();
+  }
+
+  const bit_storage_t *data() const noexcept {
+    return storage_.data();
+  }
+
+  constexpr size_t size() const noexcept {
+    return size_;
+  }
+  constexpr ssize_t ssize() const noexcept {
+    return size_;
+  }
+
+  bitref operator[](ptrdiff_t index) {
+    return { storage_.data(), index };
+  }
+
+  bool operator[](const ptrdiff_t index) const {
+    bit_storage_t storage = storage_[index >> storage_bits_log];
+    bit_storage_t mask = bit_storage_t(1) << (index & (storage_bits - 1));
+    return storage & mask;
+  }
+
+ private:
+  // vector of bit storage words - the bits that are outside of the mask are 0
+  std::vector<bit_storage_t> storage_;
+  ptrdiff_t size_ = 0;
+};
+
+}  // namespace dali
+
+#endif  // DALI_CORE_BITMASK_H_

--- a/include/dali/core/bitmask.h
+++ b/include/dali/core/bitmask.h
@@ -80,6 +80,8 @@ class bitmask {
   void fill(ptrdiff_t start, ptrdiff_t end, bool value) {
     if (start >= end)
       return;
+    assert(start >= 0 && start <= ssize());
+    assert(end   >= 0 && end   <= ssize());
     ptrdiff_t start_idx = word_idx(start);
     ptrdiff_t end_idx = word_idx(end);
     bit_storage_t ones = ~bit_storage_t(0);

--- a/include/dali/core/bitmask.h
+++ b/include/dali/core/bitmask.h
@@ -15,9 +15,9 @@
 #ifndef DALI_CORE_BITMASK_H_
 #define DALI_CORE_BITMASK_H_
 
-#include <vector>
 #include <cassert>
 #include "dali/core/util.h"
+#include "dali/core/small_vector.h"
 
 namespace dali {
 
@@ -221,7 +221,7 @@ class bitmask {
 
  private:
   // vector of bit storage words - the bits that are outside of the mask are 0
-  std::vector<bit_storage_t> storage_;
+  SmallVector<bit_storage_t, 1> storage_;
   // number of bits in the mask
   ptrdiff_t size_ = 0;
 };

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -160,15 +160,18 @@ std::enable_if_t<std::is_integral<Integer>::value, int> ctz(Integer word) {
   int bit = 0;
   if (sizeof(uword) > 4 && (uword & 0xffffffffu) == 0) {
     bit += 32;
-    uword >>= 32;
+    const int shift32 = sizeof(uword) > 4 ? 32 : 0;  // workaround undefined shift warning
+    uword >>= shift32;
   }
   if (sizeof(uword) > 2 && (uword & 0xffffu) == 0) {
     bit += 16;
-    uword >>= 16;
+    const int shift16 = sizeof(uword) > 2 ? 16 : 0;  // workaround undefined shift warning
+    uword >>= shift16;
   }
   if (sizeof(uword) > 1 && (uword & 0xffu) == 0) {
     bit += 8;
-    uword >>= 8;
+    const int shift8 = sizeof(uword) > 1 ? 8 : 0;  // workaround undefined shift warning
+    uword >>= shift8;
   }
   if ((uword & 0xfu) == 0) {
     bit += 4;

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -142,6 +142,49 @@ constexpr std::enable_if_t<std::is_integral<T>::value, int> ilog2(T x) {
     n++;
   return n;
 }
+
+
+/**
+ * @brief Count Trailing Zeros (CTZ)
+ *
+ * @return The number of trailing (LSB) zeros or the number of bits in the argument,
+ *         if it's equal to 0.
+ */
+template <typename Integer>
+DALI_HOST_DEV DALI_FORCEINLINE
+std::enable_if_t<std::is_integral<Integer>::value, int> ctz(Integer word) {
+  std::make_unsigned_t<Integer> uword = word;
+  if (uword == 0)
+    return sizeof(uword) * 8;
+  // The hardware can check for multiple bits at a time, so we don't have to scan sequentially
+  int bit = 0;
+  if (sizeof(uword) > 4 && (uword & 0xffffffffu) == 0) {
+    bit += 32;
+    uword >>= 32;
+  }
+  if (sizeof(uword) > 2 && (uword & 0xffffu) == 0) {
+    bit += 16;
+    uword >>= 16;
+  }
+  if (sizeof(uword) > 1 && (uword & 0xffu) == 0) {
+    bit += 8;
+    uword >>= 8;
+  }
+  if ((uword & 0xfu) == 0) {
+    bit += 4;
+    uword >>= 4;
+  }
+  if ((uword & 0x3u) == 0) {
+    bit += 2;
+    uword >>= 2;
+  }
+  if ((uword & 0x1u) == 0) {
+    bit += 1;
+    uword >>= 1;
+  }
+  return bit;
+}
+
 
 /**
  * @brief Returns an integer where bits at indicies in `bit_indices` are set to 1.


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature: a bit mask for extremely fast searching for set/cleared bits.
     * the search is 2 orders of magnitude faster than std::find on a `vector<bool>` or `vector<char>`

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added a `bitmask` collection, somewhat similar to vector<bool>
     * Use a bulk comparison for consecutive bits that fit into a single machine word
 - Affected modules and functionalities:
     * core/util
 - Key points relevant for the review:
     * ?
 - Validation and testing:
     * Unit tests
 - Documentation (including examples):
     * Doxygen

**JIRA TASK**: N/A
