### PR TITLE
NemoAsrReader to optionally return indices of the entries in the manifest.

### DIFF
--- a/dali/operators/reader/loader/nemo_asr_loader.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,8 +31,9 @@ namespace dali {
 namespace detail {
 
 void ParseManifest(std::vector<NemoAsrEntry> &entries, std::istream& manifest_file,
-                   double min_duration, double max_duration) {
+                   double min_duration, double max_duration, bool read_text) {
   std::string line;
+  int64_t index = 0;
   while (std::getline(manifest_file, line)) {
     detail::LookaheadParser parser(const_cast<char*>(line.c_str()));
     if (parser.PeekType() != kObjectType) {
@@ -41,6 +42,7 @@ void ParseManifest(std::vector<NemoAsrEntry> &entries, std::istream& manifest_fi
     }
     parser.EnterObject();
     NemoAsrEntry entry;
+    entry.index = index;
     while (const char* key = parser.NextObjectKey()) {
       if (0 == std::strcmp(key, "audio_filepath")) {
         entry.audio_filepath = parser.GetString();
@@ -48,7 +50,7 @@ void ParseManifest(std::vector<NemoAsrEntry> &entries, std::istream& manifest_fi
         entry.duration = parser.GetDouble();
       } else if (0 == std::strcmp(key, "offset")) {
         entry.offset = parser.GetDouble();
-      } else if (0 == std::strcmp(key, "text")) {
+      } else if (read_text && 0 == std::strcmp(key, "text")) {
         entry.text = parser.GetString();
       } else {
         parser.SkipValue();
@@ -65,6 +67,7 @@ void ParseManifest(std::vector<NemoAsrEntry> &entries, std::istream& manifest_fi
     }
 
     entries.emplace_back(std::move(entry));
+    index++;
   }
 }
 
@@ -75,7 +78,7 @@ void NemoAsrLoader::PrepareMetadataImpl() {
     std::ifstream fstream(manifest_filepath);
     DALI_ENFORCE(fstream,
                  make_string("Could not open NEMO ASR manifest file: \"", manifest_filepath, "\""));
-    detail::ParseManifest(entries_, fstream, min_duration_, max_duration_);
+    detail::ParseManifest(entries_, fstream, min_duration_, max_duration_, read_text_);
   }
   shuffled_indices_.resize(entries_.size());
   std::iota(shuffled_indices_.begin(), shuffled_indices_.end(), 0);
@@ -144,6 +147,7 @@ void NemoAsrLoader::ReadSample(AsrSample& sample) {
   MoveToNextShard(current_index_);
 
   // metadata info
+  sample.index_ = entry.index;
   sample.text_ = entry.text;
 
   // Ignoring copy_read_data_, Sharing data is not supported with this loader

--- a/dali/operators/reader/loader/nemo_asr_loader.h
+++ b/dali/operators/reader/loader/nemo_asr_loader.h
@@ -39,8 +39,8 @@ struct NemoAsrEntry {
   std::string audio_filepath;
   double duration = kDefaultDuration;  // in seconds, optional
   double offset = 0.0;  // in seconds, optional
+  int64_t index = -1;
   std::string text;  // transcription
-  int64_t index;
 };
 
 class AsrSample {
@@ -93,6 +93,13 @@ class AsrSample {
 
 namespace detail {
 
+/**
+ * @brief Parses the contents of a manifest file and populates a vector of NemoAsrEntry
+ * @param min_duration Minimum audio duration, in seconds. Shorter samples will be filtered out.
+ * @param max_duration Maximum audio duration, in seconds. Longer samples will be filtered out.
+ * @param read_text If True, the parser will read the text transcript from the manifest.
+ *                  If False, the text field is ignored.
+ */
 DLL_PUBLIC void ParseManifest(std::vector<NemoAsrEntry> &entries, std::istream &manifest_file,
                               double min_duration = kDefaultDuration,
                               double max_duration = kDefaultDuration,

--- a/dali/operators/reader/loader/nemo_asr_loader.h
+++ b/dali/operators/reader/loader/nemo_asr_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,10 +40,15 @@ struct NemoAsrEntry {
   double duration = kDefaultDuration;  // in seconds, optional
   double offset = 0.0;  // in seconds, optional
   std::string text;  // transcription
+  int64_t index;
 };
 
 class AsrSample {
  public:
+  int64_t index() const {
+    return index_;
+  }
+
   const std::string& text() const {
     return text_;
   }
@@ -76,6 +81,7 @@ class AsrSample {
     return *decoder_;
   }
 
+  int64_t index_;
   std::string text_;
   AudioMetadata audio_meta_;
   std::string audio_filepath_;  // for tensor metadata purposes
@@ -89,7 +95,8 @@ namespace detail {
 
 DLL_PUBLIC void ParseManifest(std::vector<NemoAsrEntry> &entries, std::istream &manifest_file,
                               double min_duration = kDefaultDuration,
-                              double max_duration = kDefaultDuration);
+                              double max_duration = kDefaultDuration,
+                              bool read_text = true);
 
 }  // namespace detail
 
@@ -105,6 +112,7 @@ class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
         dtype_(spec.GetArgument<DALIDataType>("dtype")),
         min_duration_(spec.GetArgument<float>("min_duration")),
         max_duration_(spec.GetArgument<float>("max_duration")),
+        read_text_(spec.GetArgument<bool>("read_text")),
         num_threads_(std::max(1, spec.GetArgument<int>("num_threads"))),
         decode_scratch_(num_threads_),
         resample_scratch_(num_threads_) {
@@ -164,6 +172,7 @@ class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
   DALIDataType dtype_;
   double min_duration_;
   double max_duration_;
+  bool read_text_;
   int num_threads_;
   kernels::signal::resampling::Resampler resampler_;
   std::vector<std::vector<float>> decode_scratch_;

--- a/dali/operators/reader/loader/nemo_asr_loader_test.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,16 +41,19 @@ TEST(NemoAsrLoaderTest, ParseManifest) {
   EXPECT_NEAR(1.45, entries[0].duration, 1e-7);
   EXPECT_NEAR(0.0, entries[0].offset, 1e-7);
   EXPECT_EQ("     A ab B C D   ", entries[0].text);
+  EXPECT_EQ(0, entries[0].index);
 
   EXPECT_EQ("path/to/audio2.wav", entries[1].audio_filepath);
   EXPECT_NEAR(2.45, entries[1].duration, 1e-7);
   EXPECT_NEAR(1.03, entries[1].offset, 1e-7);
   EXPECT_EQ("C DA B", entries[1].text);
+  EXPECT_EQ(1, entries[1].index);
 
   EXPECT_EQ("path/to/audio3.wav", entries[2].audio_filepath);
   EXPECT_NEAR(3.45, entries[2].duration, 1e-7);
   EXPECT_NEAR(0.0, entries[2].offset, 1e-7);
   EXPECT_EQ("", entries[2].text);
+  EXPECT_EQ(2, entries[2].index);
 
   entries.clear();
   ss.clear();
@@ -67,6 +70,8 @@ TEST(NemoAsrLoaderTest, ParseManifest) {
   ASSERT_EQ(2, entries.size());
   EXPECT_EQ("path/to/audio1.wav", entries[0].audio_filepath);
   EXPECT_EQ("path/to/audio2.wav", entries[1].audio_filepath);
+  EXPECT_EQ(0, entries[0].index);
+  EXPECT_EQ(1, entries[1].index);
 
   entries.clear();
   ss.clear();
@@ -74,6 +79,7 @@ TEST(NemoAsrLoaderTest, ParseManifest) {
   detail::ParseManifest(entries, ss, 0.0, 2.44999f);
   ASSERT_EQ(1, entries.size());
   EXPECT_EQ("path/to/audio1.wav", entries[0].audio_filepath);
+  EXPECT_EQ(0, entries[0].index);
 }
 
 TEST(NemoAsrLoaderTest, ParseNonAsciiTransript) {
@@ -215,6 +221,7 @@ TEST(NemoAsrLoaderTest, ReadSample) {
     loader.ReadSample(sample);
     sample_audio.Resize(sample.shape());
     sample.decode_audio(sample_audio, 0);
+    ASSERT_EQ(sample.index(), 0);
     TensorView<StorageCPU, int16_t> ref(ref_data.data(), {ref_samples, 2});
     Check(ref, view<const int16_t>(sample_audio));
   }
@@ -242,6 +249,7 @@ TEST(NemoAsrLoaderTest, ReadSample) {
     loader.ReadSample(sample);
     sample_audio.Resize(sample.shape());
     sample.decode_audio(sample_audio, 0);
+    ASSERT_EQ(sample.index(), 0);
     TensorView<StorageCPU, float> ref(downmixed.data(), {ref_samples});
     Check(ref, view<const float>(sample_audio), EqualEpsRel(1e-5, 1e-5));
   }
@@ -388,4 +396,3 @@ TEST(NemoAsrLoaderTest, ReadSample_OffsetAndDuration) {
 
 
 }  // namespace dali
-

--- a/dali/operators/reader/nemo_asr_reader_op.cc
+++ b/dali/operators/reader/nemo_asr_reader_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,8 @@ namespace {
 
 int NemoAsrReaderOutputFn(const OpSpec &spec) {
   return static_cast<int>(spec.GetArgument<bool>("read_sample_rate")) +
-         static_cast<int>(spec.GetArgument<bool>("read_text"));
+         static_cast<int>(spec.GetArgument<bool>("read_text")) +
+         static_cast<int>(spec.GetArgument<bool>("read_idxs"));
 }
 
 }  // namespace
@@ -51,6 +52,7 @@ This reader produces between 1 and 3 outputs:
 - Decoded audio data: float, shape=``(audio_length,)``
 - (optional, if ``read_sample_rate=True``) Audio sample rate: float, shape=``(1,)``
 - (optional, if ``read_text=True``) Transcript text as a null terminated string: uint8, shape=``(text_len + 1,)``
+- (optional, if ``read_idxs=True``) Index of the manifest entry: int64, shape=``(1,)``
 
 )code")
   .AddArg("manifest_filepaths",
@@ -62,6 +64,9 @@ This reader produces between 1 and 3 outputs:
   .AddOptionalArg("read_text",
     "Whether to output the transcript text for each sample as a separate output",
     true)
+  .AddOptionalArg("read_idxs",
+    "Whether to output the indices of samples as they occur in the manifest file as a separate output",
+    false)
   .AddOptionalArg("shuffle_after_epoch",
     "If true, reader shuffles whole dataset after each epoch",
     false)
@@ -120,6 +125,7 @@ NemoAsrReader::NemoAsrReader(const OpSpec& spec)
     : DataReader<CPUBackend, AsrSample>(spec),
       read_sr_(spec.GetArgument<bool>("read_sample_rate")),
       read_text_(spec.GetArgument<bool>("read_text")),
+      read_idxs_(spec.GetArgument<bool>("read_idxs")),
       dtype_(spec.GetArgument<DALIDataType>("dtype")),
       num_threads_(std::max(1, spec.GetArgument<int>("num_threads"))),
       thread_pool_(num_threads_, spec.GetArgument<int>("device_id"), false) {
@@ -211,6 +217,14 @@ void NemoAsrReader::RunImpl(SampleWorkspace &ws) {
     text_out.Resize({text_sz});
     std::memcpy(text_out.mutable_data<uint8_t>(), text.c_str(), text_sz);
     text_out.SetMeta(meta);
+  }
+
+  if (read_idxs_) {
+    auto &idxs_out = ws.Output<CPUBackend>(next_out_idx++);
+    idxs_out.set_type(TypeTable::GetTypeInfo(DALI_INT64));
+    idxs_out.Resize({1});
+    *idxs_out.mutable_data<int64_t>() = sample.index();
+    idxs_out.SetMeta(meta);
   }
 }
 

--- a/dali/operators/reader/nemo_asr_reader_op.cc
+++ b/dali/operators/reader/nemo_asr_reader_op.cc
@@ -49,10 +49,10 @@ Example manifest file::
 
 This reader produces between 1 and 3 outputs:
 
-- Decoded audio data: float, shape=``(audio_length,)``
-- (optional, if ``read_sample_rate=True``) Audio sample rate: float, shape=``(1,)``
-- (optional, if ``read_text=True``) Transcript text as a null terminated string: uint8, shape=``(text_len + 1,)``
-- (optional, if ``read_idxs=True``) Index of the manifest entry: int64, shape=``(1,)``
+- Decoded audio data: float, ``shape=(audio_length,)``
+- (optional, if ``read_sample_rate=True``) Audio sample rate: float, ``shape=(1,)``
+- (optional, if ``read_text=True``) Transcript text as a null terminated string: uint8, ``shape=(text_len + 1,)``
+- (optional, if ``read_idxs=True``) Index of the manifest entry: int64, ``shape=(1,)``
 
 )code")
   .AddArg("manifest_filepaths",
@@ -65,7 +65,8 @@ This reader produces between 1 and 3 outputs:
     "Whether to output the transcript text for each sample as a separate output",
     true)
   .AddOptionalArg("read_idxs",
-    "Whether to output the indices of samples as they occur in the manifest file as a separate output",
+    R"code(Whether to output the indices of samples as they occur in the manifest file
+ as a separate output)code",
     false)
   .AddOptionalArg("shuffle_after_epoch",
     "If true, reader shuffles whole dataset after each epoch",

--- a/dali/operators/reader/nemo_asr_reader_op.h
+++ b/dali/operators/reader/nemo_asr_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ class NemoAsrReader : public DataReader<CPUBackend, AsrSample> {
 
   bool read_sr_;
   bool read_text_;
+  bool read_idxs_;
   DALIDataType dtype_;
 
   int num_threads_;

--- a/dali/test/python/test_operator_readers_nemo_asr.py
+++ b/dali/test/python/test_operator_readers_nemo_asr.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -257,3 +257,25 @@ def test_nemo_asr_reader_pad_last_batch():
 
   # Trying to catch race conditions (A lot of samples in the batch to be replicated)
   yield _testimpl_nemo_asr_reader_pad_last_batch, 128
+
+def test_read_idxs(batch_size=10):
+  @pipeline_def(device_id=0, num_threads=4)
+  def nemo_asr_reader_read_idxs(reader_seed=12345):
+    audio, idx = fn.readers.nemo_asr(manifest_filepaths=[nemo_asr_manifest], random_shuffle=True, seed=reader_seed,
+                                     read_sample_rate=False, read_text=False, read_idxs=True)
+    return audio, idx
+  pipe1 = nemo_asr_reader_read_idxs(batch_size=batch_size)
+  pipe1.build()
+  pipe2 = nemo_asr_reader_read_idxs(batch_size=batch_size)
+  pipe2.build()
+
+  total_samples = len(names)
+
+  for iter in range(3):
+    audio1, idx1 = pipe1.run()
+    audio2, idx2 = pipe2.run()
+    for s in range(batch_size):
+      np.testing.assert_array_equal(np.array(audio1[s]), np.array(audio2[s]))
+      np.testing.assert_array_equal(np.array(idx1[s]), np.array(idx2[s]))
+      idx = np.array(idx1[s])[0]
+      assert idx >= 0 and idx < total_samples

--- a/dali/test/python/test_operator_readers_nemo_asr.py
+++ b/dali/test/python/test_operator_readers_nemo_asr.py
@@ -258,15 +258,16 @@ def test_nemo_asr_reader_pad_last_batch():
   # Trying to catch race conditions (A lot of samples in the batch to be replicated)
   yield _testimpl_nemo_asr_reader_pad_last_batch, 128
 
-def test_read_idxs(batch_size=10):
+def test_read_idxs(batch_size=10, reader_seed=12345):
   @pipeline_def(device_id=0, num_threads=4)
-  def nemo_asr_reader_read_idxs(reader_seed=12345):
+  def nemo_asr_reader_read_idxs(reader_seed=reader_seed):
     audio, idx = fn.readers.nemo_asr(manifest_filepaths=[nemo_asr_manifest], random_shuffle=True, seed=reader_seed,
                                      read_sample_rate=False, read_text=False, read_idxs=True)
     return audio, idx
-  pipe1 = nemo_asr_reader_read_idxs(batch_size=batch_size)
+  seed = 12345
+  pipe1 = nemo_asr_reader_read_idxs(batch_size=batch_size, reader_seed=seed)
   pipe1.build()
-  pipe2 = nemo_asr_reader_read_idxs(batch_size=batch_size)
+  pipe2 = nemo_asr_reader_read_idxs(batch_size=batch_size, reader_seed=seed)
   pipe2.build()
 
   total_samples = len(names)


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to map the outputs of NemoAsrReader with the entry from the manifest it belongs to.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a ``read_idxs`` option. When true, the operator outputs the indices of the samples as they appear in the manifest file*
     *Bonus: Skip reading the text (and keep it in memory) when not requested by the user*
 - Affected modules and functionalities:
     *NemoAsrReader*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *Tests added*
 - Documentation (including examples):
     *Op documentation updated*

**REQ IDs**: *[RDNEMO.10]*
**JIRA TASK**: *[DALI-2163]*
