### PR TITLE
Add batch support to DALI Dataset

### DIFF
--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -615,6 +615,7 @@ Keyword Args
                         op_instance._layout = layout
                 else:
                     op_instance._layout = None
+                op_instance._batch = batch
 
                 group.append(op_instance)
                 op_instance.generate_outputs()
@@ -632,6 +633,7 @@ Keyword Args
             op_instance._group = _ExternalSourceGroup(
                 callback, False, [op_instance], **group_common_kwargs)
             op_instance._layout = layout
+            op_instance._batch = batch
             op_instance.generate_outputs()
 
             return op_instance.unwrapped_outputs

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -578,7 +578,8 @@ if dataset_compatible_tensorflow():
         class Input:
             """Wrapper for input passed to DALIDataset. Allows to pass additional options that
             can override some of the ones provided to the External Source node in the
-            Python Pipeline object.
+            Python Pipeline object. Passing None indicates, that the value should be looked up
+            in the Pipeline defintion.
 
             Parameters
             ----------
@@ -588,11 +589,12 @@ if dataset_compatible_tensorflow():
                 Layout of given input. If None, the layout will be taken from the corresponding
                 External Source node in the Python Pipeline object. If it is not provided there,
                 empty layout will be used.
-            batch: bool, optional, default = None
+            batch: bool, optional, default = False
                 Batch mode of given input. If None, the batch mode will be taken from the
                 corresponding External Source node in the Python Pipeline object.
 
                 If the ``batch = False``, the input dataset is considered sample input.
+
                 If the ``batch = True``, the input dataset is expected to return batches.
             """
             def __init__(self, dataset, *, layout=None, batch=False):

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -52,11 +52,11 @@ The input datasets can operate in per-sample mode or in batch mode.
 
 In per-sample mode, the values produced by the source dataset are interpreted
 as individual samples. The batch dimension is absent. For example, a 640x480 RGB image would
-have a shape `[480, 640, 3]`.
+have a shape ``[480, 640, 3]``.
 
 In batch mode, the tensors produced by the source dataset are interpreted as batches,
 with an additional outer dimension denoting the samples in the batch. For example, a batch of
-ten 640x480 RGB images would have a shape `[10, 480, 640, 3]`.
+ten 640x480 RGB images would have a shape ``[10, 480, 640, 3]``.
 
 In both cases (per-sample and batch mode), the layout of those inputs should be denoted as "HWC".
 

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -239,6 +239,13 @@ def dataset_compatible_tensorflow():
     return LooseVersion(tf.__version__) >= MIN_TENSORFLOW_VERSION
 
 
+def dataset_inputs_compatible_tensorflow():
+    """Returns ``True`` if the current TensorFlow version is compatible with
+    experimental.DALIDatasetWithInputs and input Datasets can be used with DALI.
+    """
+    return LooseVersion(tf.__version__) >= LooseVersion('2.4.1')
+
+
 def dataset_distributed_compatible_tensorflow():
     """Returns ``True`` if the tf.distribute APIs for current TensorFlow version are compatible
     with DALIDataset.

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -41,6 +41,7 @@ _dali_tf.__doc__ = _dali_tf.__doc__ + """
 
 _experimental_dataset_docstring = """Experimental variant of
 :class:`~nvidia.dali.plugin.tf.DALIDataset`. This dataset adds support for input tf.data.Datasets.
+Support for input tf.data.Datasets is available only for TensorFlow 2.4.1 and newer.
 
 Each of the input datasets must be mapped to a :meth:`~nvidia.dali.fn.external_source` operator
 that will represent the input to the DALI pipeline. In the pipeline the input is represented as
@@ -568,6 +569,30 @@ if dataset_compatible_tensorflow():
             dataset_impl = _DALIDatasetImpl(pipeline, **kwargs)
             super(DALIDataset, self).__init__(dataset_impl, dataset_options())
 
+else:
+
+    class DALIDataset:
+        def __init__(self,
+                     pipeline,
+                     output_dtypes=None,
+                     output_shapes=None,
+                     fail_on_device_mismatch=True,
+                     *,
+                     batch_size=1,
+                     num_threads=4,
+                     device_id=0,
+                     exec_separated=False,
+                     prefetch_queue_depth=2,
+                     cpu_prefetch_queue_depth=2,
+                     gpu_prefetch_queue_depth=2,
+                     dtypes=None,
+                     shapes=None):
+            raise RuntimeError(
+                'DALIDataset is not supported for detected version of TensorFlow.  DALIDataset supports versions: 1.15, 2.x family'
+            )
+
+
+if dataset_inputs_compatible_tensorflow():
     def _load_experimental_dataset():
         class DALIDatasetWithInputs(dataset_ops._OptionsDataset):
             @functools.wraps(_DALIDatasetV2.__init__)
@@ -615,33 +640,12 @@ if dataset_compatible_tensorflow():
     _load_experimental_dataset()
 
 else:
-
-    class DALIDataset:
-        def __init__(self,
-                     pipeline,
-                     output_dtypes=None,
-                     output_shapes=None,
-                     fail_on_device_mismatch=True,
-                     *,
-                     batch_size=1,
-                     num_threads=4,
-                     device_id=0,
-                     exec_separated=False,
-                     prefetch_queue_depth=2,
-                     cpu_prefetch_queue_depth=2,
-                     gpu_prefetch_queue_depth=2,
-                     dtypes=None,
-                     shapes=None):
-            raise RuntimeError(
-                'DALIDataset is not supported for detected version of TensorFlow.  DALIDataset supports versions: 1.15, 2.x family'
-            )
-
     def _load_experimental_dataset():
         class DALIDatasetWithInputs:
             def __init__(self, *args, **kwargs):
                 raise RuntimeError(
                     'experimental.DALIDatasetWithInputs is not supported for detected version of TensorFlow. '
-                    + 'DALIDataset supports versions: 1.15, 2.x family')
+                    + 'DALIDataset supports versions: 2.4.1 and above.')
 
         DALIDatasetWithInputs.__doc__ = _experimental_dataset_docstring
         _insert_experimental_member(DALIDatasetWithInputs, "DALIDatasetWithInputs")

--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -32,48 +32,70 @@ def test_tf_dataset_cpu():
     run_tf_dataset_eager_mode('cpu')
 
 
-def run_tf_dataset_with_constant_input(dev, shape, value, dtype):
+def run_tf_dataset_with_constant_input(dev, shape, value, dtype, batch):
     tensor = np.full(shape, value, dtype)
     run_tf_dataset_eager_mode(dev,
-        get_pipeline_desc=external_source_tester(shape, dtype, FixedSampleIterator(tensor)),
-        to_dataset=external_source_converter_with_fixed_value(shape, dtype, tensor))
+        get_pipeline_desc=external_source_tester(shape, dtype, FixedSampleIterator(tensor), batch=batch),
+        to_dataset=external_source_converter_with_fixed_value(shape, dtype, tensor, batch))
 
 def test_tf_dataset_with_constant_input():
     for dev in ['cpu', 'gpu']:
         for shape in [(7, 42), (64, 64, 3), (3, 40, 40, 4)]:
             for dtype in [np.uint8, np.int32, np.float32]:
-                value = random.choice([42, 255])
-                yield run_tf_dataset_with_constant_input, dev, shape, value, dtype
+                for batch in ["dataset", True, False, None]:
+                    value = random.choice([42, 255])
+                    yield run_tf_dataset_with_constant_input, dev, shape, value, dtype, batch
 
 
-def run_tf_dataset_with_random_input(dev, max_shape, dtype, no_copy=None):
+def run_tf_dataset_with_random_input(dev, max_shape, dtype, batch="dataset"):
+    min_shape = get_min_shape_helper(batch, max_shape)
     run_tf_dataset_eager_mode(
         dev,
-        get_pipeline_desc=external_source_tester(max_shape, dtype,
-                                                 RandomSampleIterator(max_shape, dtype(0))),
-        to_dataset=external_source_converter_with_callback(RandomSampleIterator, max_shape, dtype))
+        get_pipeline_desc=external_source_tester(max_shape,
+                                                 dtype,
+                                                 RandomSampleIterator(max_shape, dtype(0), min_shape=min_shape),
+                                                 batch=batch),
+        to_dataset=external_source_converter_with_callback(RandomSampleIterator,
+                                                           max_shape,
+                                                           dtype,
+                                                           0,
+                                                           1e10,
+                                                           min_shape,
+                                                           batch=batch))
 
 
 def test_tf_dataset_with_random_input():
     for dev in ['cpu', 'gpu']:
         for max_shape in [(10, 20), (120, 120, 3), (3, 40, 40, 4)]:
             for dtype in [np.uint8, np.int32, np.float32]:
-                yield run_tf_dataset_with_random_input, dev, max_shape, dtype
+                for batch in ["dataset", False, True, None]:
+                    yield run_tf_dataset_with_random_input, dev, max_shape, dtype, batch
 
 
 # Run with everything on GPU (External Source op as well)
-def run_tf_dataset_with_random_input_gpu(max_shape, dtype):
+def run_tf_dataset_with_random_input_gpu(max_shape, dtype, batch):
+    min_shape = get_min_shape_helper(batch, max_shape)
     run_tf_dataset_eager_mode(
         "gpu",
-        get_pipeline_desc=external_source_tester(max_shape, dtype,
-                                                 RandomSampleIterator(max_shape, dtype(0)), "gpu"),
-        to_dataset=external_source_converter_with_callback(RandomSampleIterator, max_shape, dtype))
+        get_pipeline_desc=external_source_tester(max_shape,
+                                                 dtype,
+                                                 RandomSampleIterator(max_shape, dtype(0), min_shape=min_shape),
+                                                 "gpu",
+                                                 batch=batch),
+        to_dataset=external_source_converter_with_callback(RandomSampleIterator,
+                                                           max_shape,
+                                                           dtype,
+                                                           0,
+                                                           1e10,
+                                                           min_shape,
+                                                           batch=batch))
 
 
 def test_tf_dataset_with_random_input_gpu():
     for max_shape in [(10, 20), (120, 120, 3), (3, 40, 40, 4)]:
         for dtype in [np.uint8, np.int32, np.float32]:
-            yield run_tf_dataset_with_random_input_gpu, max_shape, dtype
+                for batch in ["dataset", False, True, None]:
+                    yield run_tf_dataset_with_random_input_gpu, max_shape, dtype, batch
 
 
 def run_tf_dataset_no_copy(max_shape, dtype, dataset_dev, es_dev, no_copy):

--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -218,6 +218,7 @@ def check_tf_dataset_wrong_input_type(wrong_input_datasets):
                 device_id=pipe.device_id)
         return dali_dataset
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_wrong_input_type():
     input_dataset = tf.data.Dataset.from_tensors(np.full((2, 2), 42)).repeat()
     # wrong `input_datasets` type (no dictionary)
@@ -258,6 +259,7 @@ def check_disallowed_es(kwargs, input_datasets):
                 device_id=pipe.device_id)
         return dali_dataset
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_disallowed_es():
     in_dataset = tf.data.Dataset.from_tensors(np.full((2, 2), 42)).repeat()
     # no names
@@ -288,6 +290,7 @@ def check_layout(kwargs, input_datasets, layout):
     run_dataset_eager_mode(dali_dataset, 10)
 
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_layouts():
     for shape, layout in [((2, 3), "XY"), ((10, 20, 3), "HWC"), ((4, 128, 64, 3), "FHWC")]:
         in_dataset = tf.data.Dataset.from_tensors(np.full(shape, 42)).repeat()

--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -39,6 +39,7 @@ def run_tf_dataset_with_constant_input(dev, shape, value, dtype, batch):
         get_pipeline_desc=external_source_tester(shape, dtype, FixedSampleIterator(tensor), batch=batch),
         to_dataset=external_source_converter_with_fixed_value(shape, dtype, tensor, batch))
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_with_constant_input():
     for dev in ['cpu', 'gpu']:
         for shape in [(7, 42), (64, 64, 3), (3, 40, 40, 4)]:
@@ -65,6 +66,7 @@ def run_tf_dataset_with_random_input(dev, max_shape, dtype, batch="dataset"):
                                                            batch=batch))
 
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_with_random_input():
     for dev in ['cpu', 'gpu']:
         for max_shape in [(10, 20), (120, 120, 3), (3, 40, 40, 4)]:
@@ -92,6 +94,7 @@ def run_tf_dataset_with_random_input_gpu(max_shape, dtype, batch):
                                                            batch=batch))
 
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_with_random_input_gpu():
     for max_shape in [(10, 20), (120, 120, 3), (3, 40, 40, 4)]:
         for dtype in [np.uint8, np.int32, np.float32]:
@@ -109,6 +112,7 @@ def run_tf_dataset_no_copy(max_shape, dtype, dataset_dev, es_dev, no_copy):
 
 
 # Check if setting no_copy flags in all placement scenarios is ok as we override it internally
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_with_no_copy():
     for max_shape in [(10, 20), (120, 120, 3)]:
         for dataset_dev in ["cpu", "gpu"]:
@@ -132,6 +136,7 @@ def run_tf_dataset_with_stop_iter(dev, max_shape, dtype, stop_samples):
                                   RandomSampleIterator, max_shape, dtype, 0, stop_samples))
 
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_with_stop_iter():
     batch_size = 12
     for dev in ['cpu', 'gpu']:
@@ -158,6 +163,7 @@ start_values = [[np.full((2, 4), 42, dtype=np.int64),
 input_names = [["input_{}".format(i) for i, _ in enumerate(vals)] for vals in start_values]
 
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_multi_input():
     for dev in ['cpu', 'gpu']:
         for starts, names in zip(start_values, input_names):

--- a/dali/test/python/test_dali_tf_dataset_graph.py
+++ b/dali/test/python/test_dali_tf_dataset_graph.py
@@ -134,10 +134,10 @@ def test_tf_dataset_with_stop_iter():
                     yield run_tf_dataset_with_stop_iter, dev, max_shape, dtype, iters * batch_size - 3
 
 
-def run_tf_dataset_multi_input(dev, start_values, input_names):
+def run_tf_dataset_multi_input(dev, start_values, input_names, batches):
     run_tf_dataset_graph(dev,
-        get_pipeline_desc=external_source_tester_multiple(start_values, input_names),
-        to_dataset=external_source_converter_multiple(start_values, input_names))
+        get_pipeline_desc=external_source_tester_multiple(start_values, input_names, batches),
+        to_dataset=external_source_converter_multiple(start_values, input_names, batches))
 
 
 start_values = [[np.full((2, 4), -42, dtype=np.int64),
@@ -155,7 +155,10 @@ input_names = [["input_{}".format(i) for i, _ in enumerate(vals)] for vals in st
 def test_tf_dataset_multi_input():
     for dev in ['cpu', 'gpu']:
         for starts, names in zip(start_values, input_names):
-            yield run_tf_dataset_multi_input, dev, starts, names
+            yield run_tf_dataset_multi_input, dev, starts, names, ["dataset" for _ in input_names]
+            for batches in list(itertools.product([True, False], repeat=len(input_names))):
+                yield run_tf_dataset_multi_input, dev, starts, names, batches
+
 
 
 @raises(Exception)

--- a/dali/test/python/test_dali_tf_dataset_graph.py
+++ b/dali/test/python/test_dali_tf_dataset_graph.py
@@ -36,6 +36,7 @@ def run_tf_dataset_with_constant_input(dev, shape, value, dtype, batch):
         get_pipeline_desc=external_source_tester(shape, dtype, FixedSampleIterator(tensor), batch=batch),
         to_dataset=external_source_converter_with_fixed_value(shape, dtype, tensor, batch))
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_with_constant_input():
     for dev in ['cpu', 'gpu']:
         for shape in [(7, 42), (64, 64, 3), (3, 40, 40, 4)]:
@@ -62,6 +63,7 @@ def run_tf_dataset_with_random_input(dev, max_shape, dtype, batch):
                                                            batch=batch))
 
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_with_random_input():
     for dev in ['cpu', 'gpu']:
         for max_shape in [(10, 20), (120, 120, 3), (3, 40, 40, 4)]:
@@ -89,6 +91,7 @@ def run_tf_dataset_with_random_input_gpu(max_shape, dtype, batch):
                                                            batch=batch))
 
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_with_random_input_gpu():
     for max_shape in [(10, 20), (120, 120, 3), (3, 40, 40, 4)]:
         for dtype in [np.uint8, np.int32, np.float32]:
@@ -106,6 +109,7 @@ def run_tf_dataset_no_copy(max_shape, dtype, dataset_dev, es_dev, no_copy):
 
 
 # Check if setting no_copy flags in all placement scenarios is ok as we override it internally
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_with_no_copy():
     for max_shape in [(10, 20), (120, 120, 3)]:
         for dataset_dev in ["cpu", "gpu"]:
@@ -126,6 +130,7 @@ def run_tf_dataset_with_stop_iter(dev, max_shape, dtype, stop_samples):
                              RandomSampleIterator, max_shape, dtype, 0, stop_samples))
 
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_with_stop_iter():
     batch_size = 12
     for dev in ['cpu', 'gpu']:
@@ -153,6 +158,7 @@ start_values = [[np.full((2, 4), -42, dtype=np.int64),
 input_names = [["input_{}".format(i) for i, _ in enumerate(vals)] for vals in start_values]
 
 
+@with_setup(skip_inputs_for_incompatible_tf)
 def test_tf_dataset_multi_input():
     for dev in ['cpu', 'gpu']:
         for starts, names in zip(start_values, input_names):

--- a/dali/test/python/test_dali_tf_dataset_graph.py
+++ b/dali/test/python/test_dali_tf_dataset_graph.py
@@ -17,6 +17,7 @@ from test_utils_tensorflow import *
 from test_dali_tf_dataset_pipelines import *
 from nose.tools import raises, with_setup
 import random as random
+import itertools
 
 tensorflow.compat.v1.disable_eager_execution()
 

--- a/dali/test/python/test_dali_tf_dataset_pipelines.py
+++ b/dali/test/python/test_dali_tf_dataset_pipelines.py
@@ -27,8 +27,12 @@ import numpy as np
 from nose.tools import nottest
 
 def get_min_shape_helper(batch, max_shape):
+    """For batch=None or batch=True, we use batch mode which requires fixed shape.
+    In that case min and max shape for RandomSampleIterator need to be equal.
+    `batch` can also be a string "dataset" that indicates we passed a Dataset object as input
+    without specifying the batch mode through: Input(dataset, batch=...)
+    """
     if batch is None or batch == True:
-        # Make the shape fixed for batched mode
         return max_shape
     else:
         return None

--- a/dali/test/python/test_utils_tensorflow.py
+++ b/dali/test/python/test_utils_tensorflow.py
@@ -35,6 +35,10 @@ def skip_for_incompatible_tf():
     if not dali_tf.dataset_distributed_compatible_tensorflow():
         raise SkipTest('This feature is enabled for TF 2.5.0 and higher')
 
+def skip_inputs_for_incompatible_tf():
+    if not dali_tf.dataset_inputs_compatible_tensorflow():
+        raise SkipTest('This feature is enabled for TF 2.4.1 and higher')
+
 
 def num_available_gpus():
     local_devices = device_lib.list_local_devices()

--- a/dali_tf_plugin/CMakeLists.txt
+++ b/dali_tf_plugin/CMakeLists.txt
@@ -39,7 +39,7 @@ install(FILES "${PROJECT_SOURCE_DIR}/nvidia/dali_tf_plugin/dali_tf_plugin.py" DE
 install(DIRECTORY "${DALI_ROOT}/include" DESTINATION "${PROJECT_BINARY_DIR}")
 install(FILES "${DALI_ROOT}/tools/stubgen.py" DESTINATION "${PROJECT_BINARY_DIR}")
 install(FILES "dali_dataset.h" DESTINATION "${PROJECT_BINARY_DIR}/dali_tf_plugin")
-install(FILES "dali_shape_helper.h" DESTINATION "${PROJECT_BINARY_DIR}/dali_tf_plugin")
+install(FILES "dali_helper.h" DESTINATION "${PROJECT_BINARY_DIR}/dali_tf_plugin")
 install(FILES "daliop.cc" DESTINATION "${PROJECT_BINARY_DIR}")
 install(FILES "dali_dataset_op.cc" DESTINATION "${PROJECT_BINARY_DIR}")
 install(FILES "dali_tf_plugin_install_tool.py" DESTINATION "${PROJECT_BINARY_DIR}")

--- a/dali_tf_plugin/CMakeLists.txt
+++ b/dali_tf_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dali_tf_plugin/dali_dataset.h
+++ b/dali_tf_plugin/dali_dataset.h
@@ -85,6 +85,7 @@ class DALIDatasetOp : public tensorflow::data::DatasetOpKernel {
   struct InputAttrs {
     std::vector<std::string> input_names;
     std::vector<std::string> input_layouts;
+    std::vector<int> input_batched;
   };
 
   struct InputDescs : Inputs, InputAttrs {
@@ -106,6 +107,7 @@ class DALIDatasetOp : public tensorflow::data::DatasetOpKernel {
   // Arguments describing inputs
   static constexpr const char* const kInputNames = "input_names";
   static constexpr const char* const kInputLayouts = "input_layouts";
+  static constexpr const char* const kInputBatched = "input_batched";
 
   // Arguments describing outputs
   static constexpr const char* const kOutputShapes = "output_shapes";

--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -177,6 +177,7 @@ class DALIDatasetOp::Dataset : public DatasetBase {
                                 AttrSerializationContainer &attrs) const {
     SerializeField(attrs, b, kInputNames, input_desc.input_names);
     SerializeField(attrs, b, kInputLayouts, input_desc.input_layouts);
+    SerializeField(attrs, b, kInputBatched, input_desc.input_batched);
   }
 
   Status InputsToNodeList(SerializationContext *context, DatasetGraphDefBuilder *b,
@@ -411,12 +412,89 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
     return Status::OK();
   }
 
+  /**
+   * @brief Call GetNext on given input and extract the only Tensor Example that is expected as
+   * output or signall stop.
+   */
+  Status GetExampleFromInput(IteratorContext *context, int input_idx, Tensor &example,
+                             bool *end_of_sequence) {
+    TfExample input_example;
+    *end_of_sequence = false;
+    auto &input = input_impls_[input_idx];
+    // TODO(klecki): ZipDataset just goes to next iteration on Error.
+    // Desync of input datasets is not desired, we just report the problem fast
+    TF_RETURN_IF_ERROR(input->GetNext(context, &input_example, end_of_sequence));
+    if (*end_of_sequence) {
+      return Status::OK();
+    }
+
+    // Repack the single Tensor from TfExample to Batch
+    if (input_example.size() != 1) {
+      return errors::InvalidArgument("Got a sample consisting of ", input_example.size(),
+                                     " elements for input: ", input_idx,
+                                     ". Only samples of 1 element are supported.");
+    }
+    // Extract the obtained example
+    example = input_example[0];
+    return Status::OK();
+  }
+
+  /**
+   * @brief Obtain samples from input of given index, operating in batch mode
+   *
+   * out_batch will contain one output sample representing whole batch
+   */
+  Status PrepareBatchesBatchMode(IteratorContext *context, int input_idx, Batch &out_batch,
+                                 bool *end_of_sequence) {
+    int next_batch_size = dataset()->pipeline_def_.batch_size;
+    // In batch mode, we have tensors representing batches, so we keep only 1 of them
+    out_batch.clear();
+    *end_of_sequence = false;
+
+    Tensor example;
+    TF_RETURN_IF_ERROR(GetExampleFromInput(context, input_idx, example, end_of_sequence));
+    if (*end_of_sequence) {
+      return Status::OK();
+    }
+    // Batch mode, only one tensor for whole batch
+    out_batch.push_back(example);
+    return Status::OK();
+  }
+
+  /**
+   * @brief Obtain samples from input of given index, operation in sample mode.
+   *
+   * out_batch will contain sample tensors.
+   */
+  Status PrepareBatchesSampleMode(IteratorContext *context, int input_idx, Batch &out_batch,
+                                  bool *end_of_sequence) {
+    int next_batch_size = dataset()->pipeline_def_.batch_size;
+    // Sample mode, so we have batch of actual sample tensors
+    out_batch.clear();
+    Batch in_batch;
+    in_batch.resize(next_batch_size);
+    *end_of_sequence = false;
+
+    // We fail fast, we will either bubble up the error or set the state of dataset to stop_pending
+    // and just use up what is queued.
+    for (int sample_idx = 0; sample_idx < next_batch_size; sample_idx++) {
+      TF_RETURN_IF_ERROR(
+          GetExampleFromInput(context, input_idx, in_batch[sample_idx], end_of_sequence));
+      if (*end_of_sequence) {
+        return Status::OK();
+      }
+    }
+    out_batch = std::move(in_batch);
+    return Status::OK();
+  }
+
 
   /**
    * @brief Obtain samples from input interators and build collection of batches representing
    * one input iteration.
    *
-   * We query one sample at a time to signal stop as soon as possible.
+   * Get the input in either batch or sample mode, report errors fast and return empty batches.
+   * In case of end_of_sequence or error we expect to start over.
    */
   Status PrepareBatches(IteratorContext *context, ListOfBatches &out_batches,
                         bool *end_of_sequence) {
@@ -424,29 +502,18 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
     *end_of_sequence = false;
     ListOfBatches input_batches(dataset()->NumInputs());
     int next_batch_size = dataset()->pipeline_def_.batch_size;
-    for (auto &batch : input_batches) {
-      batch.resize(next_batch_size);
-    }
-    for (int sample_idx = 0; sample_idx < next_batch_size; sample_idx++) {
-      for (int input_idx = 0; input_idx < dataset()->NumInputs(); input_idx++) {
-        TfExample example;
-        bool input_end_of_sequence = false;
-        auto &input = input_impls_[input_idx];
-        // TODO(klecki): ZipDataset just goes to next iteration on Error.
-        // Desync of input datasets is not desired, we just report the problem fast
-        TF_RETURN_IF_ERROR(input->GetNext(context, &example, &input_end_of_sequence));
-        *end_of_sequence |= input_end_of_sequence;
-        if (*end_of_sequence) {
-          return Status::OK();
-        }
 
-        // Repack the single Tensor from TfExample to Batch
-        if (example.size() != 1) {
-          return errors::InvalidArgument("Got a sample consisting of ", example.size(),
-                                         " elements for input: ", input_idx,
-                                         ". Only samples of 1 element are supported.");
-        }
-        input_batches[input_idx][sample_idx] = example[0];
+    for (int input_idx = 0; input_idx < dataset()->NumInputs(); input_idx++) {
+      bool batched = dataset()->input_desc_.input_batched[input_idx];
+      if (batched) {
+        TF_RETURN_IF_ERROR(
+            PrepareBatchesBatchMode(context, input_idx, input_batches[input_idx], end_of_sequence));
+      } else {
+        TF_RETURN_IF_ERROR(PrepareBatchesSampleMode(context, input_idx, input_batches[input_idx],
+                                                    end_of_sequence));
+      }
+      if (*end_of_sequence) {
+        return Status::OK();
       }
     }
     out_batches = std::move(input_batches);
@@ -574,35 +641,56 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
     return Status::OK();
   }
 
+  void *GetTensorData(const Tensor &t) {
+#if TF_MAJOR_VERSION == 2 && TF_MINOR_VERSION >= 2
+    return t.data();
+#else
+    return t.tensor_data().data();
+#endif
+  }
 
   /**
-   * @brief Helper function that repacks the `Batch` (which is an list of samples returned by
-   * GetNext()), to the format used by DALI C API for feeding External Source.
+   * @brief Helper function that repacks the pointer to data of `Batch` (which is an list of
+   * samples returned by GetNext()), to the format used by DALI C API for feeding External Source.
    *
    * Outputs: ptrs, dtype, shapes, ndim
-   * Inputs: input_batch
+   * @param ptrs output pointers, in sample mode, batch size of pointers, in batch mode
+   *             a vector with one pointer to data.
+   *
+   * Inputs: input_batch, batched
+   * @param input_batch Batch tensor in batch mode, othewise batch of sample tensors
+   * @param batched true if batch mode, otherwise sample mode
    */
-  Status RepackNonContiguousBatch(std::vector<const void *> &ptrs, dali_data_type_t &dtype,
-                                  std::vector<int64_t> &shapes, int64_t &ndim,
-                                  const Batch &input_batch) {
-    int batch_size = dataset()->pipeline_def_.batch_size;
-    assert(input_batch.size() == batch_size);
+  Status RepackBatch(std::vector<const void *> &ptrs, dali_data_type_t &dtype,
+                     std::vector<int64_t> &shapes, int64_t &ndim, const Batch &input_batch,
 
-    ptrs.resize(batch_size, nullptr);
+                     bool batched) {
+    int batch_size = dataset()->pipeline_def_.batch_size;
+
     dtype = TfToDaliType(input_batch[0].dtype());
-    ndim = input_batch[0].dims();
+    // remove the batch dimension if present
+    ndim = batched ? input_batch[0].dims() - 1 : input_batch[0].dims();
     shapes.clear();
     shapes.reserve(batch_size * ndim);
 
-    for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
-      auto &tensor = input_batch[sample_idx];
-#if TF_MAJOR_VERSION == 2 && TF_MINOR_VERSION >= 2
-      ptrs[sample_idx] = tensor.data();
-#else
-      ptrs[sample_idx] = tensor.tensor_data().data();
-#endif
-      for (int d = 0; d < ndim; d++) {
-        shapes.push_back(tensor.dim_size(d));
+    if (batched) {
+      auto &tensor = input_batch[0];
+      assert(tensor.dim(0) == batch_size);
+      ptrs.resize(1, nullptr);
+      ptrs[0] = GetTensorData(tensor);
+      for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
+        for (int d = 0; d < ndim; d++) {
+          shapes.push_back(tensor.dim_size(d + 1));
+        }
+      }
+    } else {
+      assert(input_batch.size() == batch_size);
+      ptrs.resize(batch_size, nullptr);
+      for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
+        ptrs[sample_idx] = GetTensorData(input_batch[sample_idx]);
+        for (int d = 0; d < ndim; d++) {
+          shapes.push_back(input_batch[sample_idx].dim_size(d));
+        }
       }
     }
     return Status::OK();
@@ -628,7 +716,8 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
     for (int input_idx = 0; input_idx < dataset()->NumInputs(); input_idx++) {
       auto &input_batch = current_batches[input_idx];
       TF_RETURN_IF_ERROR(VerifyUniform(input_batch, input_idx));
-      TF_RETURN_IF_ERROR(RepackNonContiguousBatch(ptrs, dtype, shapes, ndim, input_batch));
+      bool batched = dataset()->input_desc_.input_batched[input_idx];
+      TF_RETURN_IF_ERROR(RepackBatch(ptrs, dtype, shapes, ndim, input_batch, batched));
 
       auto &input_name = dataset()->input_desc_.input_names[input_idx];
       // TODO(klecki): Currently we are restricted to supporting input memory on the same
@@ -648,9 +737,15 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
         flag = DALI_ext_force_copy;
       }
 
-      TF_DALI_CALL(daliSetExternalInputTensors(pipeline_handle, input_name.c_str(), input_device,
-                                               ptrs.data(), dtype, shapes.data(), ndim,
-                                               input_layout.c_str(), flag));
+      if (batched) {
+        TF_DALI_CALL(daliSetExternalInput(pipeline_handle, input_name.c_str(), input_device,
+                                          ptrs[0], dtype, shapes.data(), ndim, input_layout.c_str(),
+                                          flag));
+      } else {
+        TF_DALI_CALL(daliSetExternalInputTensors(pipeline_handle, input_name.c_str(), input_device,
+                                                 ptrs.data(), dtype, shapes.data(), ndim,
+                                                 input_layout.c_str(), flag));
+      }
 
       // No need keep the data if we did the copy
       if ((input_device == CPU && ext_src_device != DALI_BACKEND_CPU) ||
@@ -827,6 +922,7 @@ void DALIDatasetOp::FillPipelineDef(OpKernelConstruction *context, PipelineDef &
 void DALIDatasetOp::FillInputAttrs(OpKernelConstruction *context, InputAttrs &def) {
   OP_REQUIRES_OK(context, context->GetAttr(kInputNames, &def.input_names));
   OP_REQUIRES_OK(context, context->GetAttr(kInputLayouts, &def.input_layouts));
+  OP_REQUIRES_OK(context, context->GetAttr(kInputBatched, &def.input_batched));
 }
 
 void DALIDatasetOp::FillInputs(OpKernelContext *context, Inputs &def) {
@@ -853,6 +949,11 @@ void DALIDatasetOp::ValidateInputs(OpKernelContext *context, Inputs &inputs,
       errors::InvalidArgument("Number of inputs and input layouts provided must match, got ",
                               inputs.inputs.size(), " inputs and ",
                               input_attrs.input_layouts.size(), " input layouts."));
+  OP_REQUIRES(
+      context, inputs.inputs.size() == input_attrs.input_batched.size(),
+      errors::InvalidArgument("Number of inputs and input batched specification must match, got ",
+                              inputs.inputs.size(), " inputs and ",
+                              input_attrs.input_batched.size(), " input batched."));
   // TODO(klecki): Validate the input devices against the current device
 }
 
@@ -881,6 +982,7 @@ REGISTER_OP("DALIDataset")
     .Output("handle: variant")
     .Attr("input_names: list(string)")    // must match the input_datasets
     .Attr("input_layouts: list(string)")  // must match the input_datasets
+    .Attr("input_batched: list(int)")  // must match the input_datasets, use int instead of bool
     .Attr("pipeline: string")
     .Attr("batch_size: int")
     .Attr("num_threads: int")

--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -641,7 +641,7 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
     return Status::OK();
   }
 
-  void *GetTensorData(const Tensor &t) {
+  const void *GetTensorData(const Tensor &t) const {
 #if TF_MAJOR_VERSION == 2 && TF_MINOR_VERSION >= 2
     return t.data();
 #else

--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -737,6 +737,7 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
         flag = DALI_ext_force_copy;
       }
 
+      // TODO(klecki): Consider using other stream here: Dataset's stream_ or stream 0.
       if (batched) {
         TF_DALI_CALL(daliSetExternalInput(pipeline_handle, input_name.c_str(), input_device,
                                           ptrs[0], dtype, shapes.data(), ndim, input_layout.c_str(),

--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -430,9 +430,9 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
 
     // Repack the single Tensor from TfExample to Batch
     if (input_example.size() != 1) {
-      return errors::InvalidArgument("Got a sample consisting of ", input_example.size(),
+      return errors::InvalidArgument("Got an example consisting of ", input_example.size(),
                                      " elements for input: ", input_idx,
-                                     ". Only samples of 1 element are supported.");
+                                     ". Only examples of 1 element are supported.");
     }
     // Extract the obtained example
     example = input_example[0];
@@ -650,7 +650,7 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
   }
 
   /**
-   * @brief Helper function that repacks the pointer to data of `Batch` (which is an list of
+   * @brief Helper function that repacks the pointer to data of `Batch` (which is a list of
    * samples returned by GetNext()), to the format used by DALI C API for feeding External Source.
    *
    * Outputs: ptrs, dtype, shapes, ndim
@@ -981,9 +981,10 @@ REGISTER_INPUT_COLOCATION_EXEMPTION("DALIDataset");
 REGISTER_OP("DALIDataset")
     .Input("input_datasets: N * variant")
     .Output("handle: variant")
-    .Attr("input_names: list(string)")    // must match the input_datasets
-    .Attr("input_layouts: list(string)")  // must match the input_datasets
-    .Attr("input_batched: list(int)")  // must match the input_datasets, use int instead of bool
+    // the input_* attrs must match the input_datasets length
+    .Attr("input_names: list(string)")
+    .Attr("input_layouts: list(string)")
+    .Attr("input_batched: list(int)")  // use vector<int> instead of vector<bool>
     .Attr("pipeline: string")
     .Attr("batch_size: int")
     .Attr("num_threads: int")

--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -45,7 +45,7 @@
 #include "dali/c_api.h"
 #include "dali/core/common.h"
 #include "dali/core/format.h"
-#include "dali_tf_plugin/dali_shape_helper.h"
+#include "dali_tf_plugin/dali_helper.h"
 
 #include "dali_tf_plugin/dali_dataset.h"
 

--- a/dali_tf_plugin/dali_helper.h
+++ b/dali_tf_plugin/dali_helper.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_TF_PLUGIN_DALI_SHAPE_HELPER_H_
-#define DALI_TF_PLUGIN_DALI_SHAPE_HELPER_H_
+#ifndef DALI_TF_PLUGIN_DALI_HELPER_H_
+#define DALI_TF_PLUGIN_DALI_HELPER_H_
 
 #include <memory>
 #include <utility>
@@ -244,4 +244,4 @@ using ListOfBatches = std::vector<Batch>;
 }  // namespace dali_tf_impl
 
 
-#endif  // DALI_TF_PLUGIN_DALI_SHAPE_HELPER_H_
+#endif  // DALI_TF_PLUGIN_DALI_HELPER_H_

--- a/dali_tf_plugin/daliop.cc
+++ b/dali_tf_plugin/daliop.cc
@@ -34,7 +34,7 @@
 
 #include "dali/c_api.h"
 #include "dali/core/common.h"
-#include "dali_tf_plugin/dali_shape_helper.h"
+#include "dali_tf_plugin/dali_helper.h"
 
 typedef std::chrono::high_resolution_clock Clock;
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>#### Why we need this PR?
- It adds new feature needed because of we need to support batched callbacks mostly


#### What happened in this PR? 
 - What solution was applied:
     
 - Affected modules and functionalities:
     TF Dataset
 - Key points relevant for the review:
     N/A
 - Validation and testing:
     Yes
 - Documentation (including examples):
     Yes


**JIRA TASK**: *[Use DALI-1955 or NA]*
