### PR TITLE
Move pycocotools to regular pip packages in SSD test

### DIFF
--- a/qa/TL1_ssd_training/test.sh
+++ b/qa/TL1_ssd_training/test.sh
@@ -1,11 +1,9 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="numpy pillow torch torchvision mlperf_compliance matplotlib Cython"
+pip_packages="numpy pillow torch torchvision mlperf_compliance matplotlib Cython pycocotools"
 target_dir=./docs/examples/use_cases/pytorch/single_stage_detector/
 
 test_body() {
-    # workaround due to errors while pycocotools is int "pip_packages" above
-    pip install -I pycocotools
     apt update && apt install -y gcc-7 g++-7
 
     #install APEX


### PR DESCRIPTION
- pycocotools were installed separately in the SDD test as
  installing it without other packages caused an issue.
  As python wheels are now installed one by one there
  should be no issue anymore

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It moves pycocotools to regular pip packages in SSD test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
      pycocotools were installed separately in the SDD test as installing it without other packages caused an issue. As python wheels are now installed one by one there should be no issue anymore
 - Affected modules and functionalities:
     TL1_ssd_training
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test ap
 - Documentation (including examples):
     NA

**JIRA TASK**: *[DALI-2155]*
