### PR TITLE
Fix python test on aarch64 platform

### DIFF
--- a/dali/test/python/test_dali_variable_batch_size.py
+++ b/dali/test/python/test_dali_variable_batch_size.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,28 +15,21 @@
 from nvidia.dali.pipeline import Pipeline
 from segmentation_test_utils import make_batch_select_masks
 from test_utils import module_functions
-from PIL import Image
 from nose.tools import nottest
-import nvidia.dali as dali
 import nvidia.dali.ops as ops
 import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 import nvidia.dali.math as dmath
 from nvidia.dali.plugin.numba.fn.experimental import numba_function
-import torch.utils.dlpack as torch_dlpack
-import nvidia.dali.plugin.pytorch as pytorch
 import numpy as np
 import test_utils
 from test_detection_pipeline import coco_anchors
 from test_optical_flow import load_frames
 import inspect
 import os
-import math
 import random
-import sys
-from collections.abc import Iterable
-from math import ceil, sqrt
 import nose
+from nose.plugins.attrib import attr
 
 """
 How to test variable (iter-to-iter) batch size for a given op?
@@ -490,7 +483,9 @@ def test_combine_transforms():
         pipeline_fn=pipe, devices=['cpu'])
 
 
+@attr('pytorch')
 def test_dl_tensor_python_function():
+    import torch.utils.dlpack as torch_dlpack
     def dl_tensor_operation(tensor):
         tensor = torch_dlpack.from_dlpack(tensor)
         tensor_n = tensor.double() / 255

--- a/qa/TL0_python-self-test-core/test.sh
+++ b/qa/TL0_python-self-test-core/test.sh
@@ -1,2 +1,3 @@
 #!/bin/bash -e
 ./test_nofw.sh
+./test_pytorch.sh

--- a/qa/TL0_python-self-test-core/test_body.sh
+++ b/qa/TL0_python-self-test-core/test_body.sh
@@ -3,9 +3,8 @@
 test_nose() {
     for test_script in $(ls test_pipeline*.py \
                             test_functional_api.py \
-                            test_backend_impl.py \
-                            test_dali_variable_batch_size.py); do
-        nosetests --verbose --attr '!slow' ${test_script}
+                            test_backend_impl.py); do
+        nosetests --verbose --attr '!slow,!pytorch' ${test_script}
     done
 }
 
@@ -17,6 +16,10 @@ test_py() {
     python test_data_containers.py -s -b 20 -n
 }
 
+test_pytorch() {
+    nosetests --verbose --attr '!slow,pytorch' test_dali_variable_batch_size.py
+}
+
 test_no_fw() {
     test_nose
     test_py
@@ -24,4 +27,5 @@ test_no_fw() {
 
 run_all() {
   test_no_fw
+  test_pytorch
 }

--- a/qa/TL0_python-self-test-core/test_nofw.sh
+++ b/qa/TL0_python-self-test-core/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy>=1.17 opencv-python pillow nvidia-ml-py==11.450.51 torch numba"
+pip_packages="nose numpy>=1.17 opencv-python pillow nvidia-ml-py==11.450.51 numba"
 
 target_dir=./dali/test/python
 

--- a/qa/TL0_python-self-test-core/test_pytorch.sh
+++ b/qa/TL0_python-self-test-core/test_pytorch.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+# used pip packages
+pip_packages="nose torch numba"
+
+target_dir=./dali/test/python
+
+# test_body definition is in separate file so it can be used without setup
+source test_body.sh
+
+test_body() {
+  # run this only on x86_64, not arm
+  if [ $(uname -m) == "x86_64" ]
+  then
+    test_pytorch
+  fi
+}
+
+pushd ../..
+source ./qa/test_template.sh
+popd

--- a/qa/TL0_python-self-test-core/test_pytorch.sh
+++ b/qa/TL0_python-self-test-core/test_pytorch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose torch numba"
+pip_packages="nose pillow opencv-python torch numba"
 
 target_dir=./dali/test/python
 
@@ -8,12 +8,14 @@ target_dir=./dali/test/python
 source test_body.sh
 
 test_body() {
-  # run this only on x86_64, not arm
-  if [ $(uname -m) == "x86_64" ]
-  then
-    test_pytorch
-  fi
+  test_pytorch
 }
+
+# run this only on x86_64, not arm
+if [ $(uname -m) != "x86_64" ]
+then
+  exit 0
+fi
 
 pushd ../..
 source ./qa/test_template.sh


### PR DESCRIPTION
- when PyTorch started using extra-index-url setup_packages.py
  no longer early exits when there is no PyTorch available for a given
  platform. This causes all tests using PyTorch to fail on SBSA
  (aarch64) platform

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a python test on aarch64 platform

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     when PyTorch started using extra-index-url setup_packages.py no longer early exits when there is no PyTorch available for a given platform. This causes all tests using PyTorch to fail on SBSA (aarch64) platform
 - Affected modules and functionalities:
    TL0_python-self-test-core
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current tests for SBSA apply
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
