### PR TITLE
Fix DALI installation for python 3.9 version

### DIFF
--- a/dali/python/setup.py.in
+++ b/dali/python/setup.py.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2018, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ setup(name='nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,
-      python_requires='>=3.6, <=3.9',
+      python_requires='>=3.6, <=3.9.99',
       classifiers=[
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',

--- a/dali/python/setup.py.in
+++ b/dali/python/setup.py.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ setup(name='nvidia-dali@DALI_FLAVOR_MINUS@-cuda@CUDA_VERSION_SHORT_DIGIT_ONLY@',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,
-      python_requires='>=3.6, <=3.9.99',
+      python_requires='>=3.6, <3.10',
       classifiers=[
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
- python_requires has the upper python version set to 3.9
  so any 3.9.x falls beyond that check. Rework the check
  to any 3.9.x based version.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes DALI installation for python 3.9 version

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
    python_requires has the upper python version set to 3.9 so any 3.9.x falls beyond that check. Rework the check to any 3.9.x based version.
 - Affected modules and functionalities:
     python setup.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
