### PR TITLE
Unify apt-get invocations

### DIFF
--- a/qa/TL1_ssd_training/test.sh
+++ b/qa/TL1_ssd_training/test.sh
@@ -4,7 +4,7 @@ pip_packages="numpy pillow torch torchvision mlperf_compliance matplotlib Cython
 target_dir=./docs/examples/use_cases/pytorch/single_stage_detector/
 
 test_body() {
-    apt update && apt install -y gcc-7 g++-7
+    apt-get update && apt-get install -y gcc-7 g++-7
 
     #install APEX
     git clone https://github.com/nvidia/apex


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It unifies `apt-get` invocations

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     unify apt-get invocations to use `apt-get` instead of just `apt`
 - Affected modules and functionalities:
     TL1_ssd_training
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-2169]*
