### PR TITLE
Fix override no copy flags for External Source C API

### DIFF
--- a/dali/pipeline/operator/builtin/external_source.cu
+++ b/dali/pipeline/operator/builtin/external_source.cu
@@ -32,20 +32,20 @@ void ExternalSource<GPUBackend>::RunImpl(DeviceWorkspace &ws) {
     state_.pop_front();
     // even with no_copy we may have copied from TensorVector to TensorList and we
     // need to sync with that
-    if (!no_copy_ || state_info.copied_shared_data) {
+    if (!state_info.no_copy || state_info.copied_shared_data) {
       internal_copy_to_storage = copy_to_storage_events_.PopFront();
     }
   }
 
   auto &output = ws.Output<GPUBackend>(0);
   cudaStream_t stream_used = ws.has_stream() ? ws.stream() : 0;
-  if (!no_copy_ || state_info.copied_shared_data) {
+  if (!state_info.no_copy || state_info.copied_shared_data) {
     CUDA_CALL(cudaStreamWaitEvent(stream_used, *internal_copy_to_storage.front(), 0));
   }
 
   std::swap(output, *tensor_list_elm.front());
 
-  if (!no_copy_ || state_info.copied_shared_data) {
+  if (!state_info.no_copy || state_info.copied_shared_data) {
     RecycleBuffer(tensor_list_elm, &internal_copy_to_storage);
   } else {
     RecycleBuffer(tensor_list_elm);


### PR DESCRIPTION
#### Why we need this PR?
Fix a bug

#### What happened in this PR? 
 - What solution was applied:

GPU op used only the static flag when accessing the data.

External Source state was extended with flag
indicating no_copy value for given batch.

Test was added to run both override flags.

 - Affected modules and functionalities:

External Source

 - Key points relevant for the review:

N/A

 - Validation and testing:

Test was extended to cover this codepath.

 - Documentation (including examples):

A bit of docstrings.


**JIRA TASK**: *[Use DALI-XXXX or NA]*
