### PR TITLE
Remove pre CUDA 10.0 support in TL1_tensorflow-dali_test

### DIFF
--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -50,10 +50,6 @@ do_once() {
         echo "plm_rsh_agent = /usr/local/mpi/bin/rsh_warn.sh" >> /usr/local/mpi/etc/openmpi-mca-params.conf
     fi
 
-    if [ ${CUDA_VERSION} -lt 100 ]; then
-        apt-get update && apt-get install -y gcc-4.8 g++-4.8
-    fi
-
     apt-get update && apt-get install -y cmake
     export HOROVOD_GPU_ALLREDUCE=NCCL
     export HOROVOD_NCCL_INCLUDE=/usr/include


### PR DESCRIPTION
- removes CUDA 10.0 condition for an old gcc installation
  in TL1_tensorflow-dali_test test

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes CUDA 10.0 condition for an old gcc installation in TL1_tensorflow-dali_test test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     removes CUDA 10.0 condition for an old gcc installation in TL1_tensorflow-dali_test test
 - Affected modules and functionalities:
     TL1_tensorflow-dali_test test
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-2169]*
