### PR TITLE
Make DALI extra download optional in tests

### DIFF
--- a/qa/setup_dali_extra.sh
+++ b/qa/setup_dali_extra.sh
@@ -3,16 +3,19 @@
 # Fetch test data
 export DALI_EXTRA_PATH=${DALI_EXTRA_PATH:-/opt/dali_extra}
 export DALI_EXTRA_URL=${DALI_EXTRA_URL:-"https://github.com/NVIDIA/DALI_extra.git"}
+export DALI_EXTRA_NO_DOWNLOAD=${DALI_EXTRA_NO_DOWNLOAD}
 
 DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 DALI_EXTRA_VERSION_PATH="${DIR}/../DALI_EXTRA_VERSION"
 DALI_EXTRA_VERSION=${DALI_EXTRA_VERSION_SHA:-$(cat ${DALI_EXTRA_VERSION_PATH})}
 echo "Using DALI_EXTRA_VERSION = ${DALI_EXTRA_VERSION}"
-if [ ! -d "$DALI_EXTRA_PATH" ] ; then
+if [ ! -d "$DALI_EXTRA_PATH" ] && [ "${DALI_EXTRA_NO_DOWNLOAD}" == "" ]; then
     git clone "$DALI_EXTRA_URL" "$DALI_EXTRA_PATH"
 fi
 
 pushd "$DALI_EXTRA_PATH"
-git fetch origin ${DALI_EXTRA_VERSION}
+if [ "${DALI_EXTRA_NO_DOWNLOAD}" == "" ]; then
+    git fetch origin ${DALI_EXTRA_VERSION}
+fi
 git checkout ${DALI_EXTRA_VERSION}
 popd


### PR DESCRIPTION
- introduces DALI_EXTRA_NO_DOWNLOAD env variable that
  can prevent from download/update of DALI extra in the test
  and make it to work only on a local copy

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It makes DALI extra download optional in tests

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     introduces DALI_EXTRA_NO_DOWNLOAD env variable that can prevent from download/update of DALI extra in the test and make it to work only on a local copy
 - Affected modules and functionalities:
     setup_dali_extra.sh
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current tests applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-2169]*
