### PR TITLE
Remove no longer applicable sed command from RN50 MXNet test

### DIFF
--- a/qa/TL3_RN50_convergence/test_mxnet.sh
+++ b/qa/TL3_RN50_convergence/test_mxnet.sh
@@ -5,9 +5,6 @@ min_perf=10000
 
 NUM_GPUS=`nvidia-smi -L | wc -l`
 
-# Fix deprecations, we need to fix that for the older FW containers version
-sed -i "s/nvJPEGDecoder/ImageDecoder/" /opt/mxnet/example/image-classification/common/dali.py
-
 python /opt/mxnet/example/image-classification/train_imagenet_runner \
        --data-root=/data/imagenet/train-val-recordio-passthrough/ -b 208 \
        -n $NUM_GPUS --seed 42 2>&1 | tee dali.log


### PR DESCRIPTION
- removes sed command that was a runtime patch for a container
  RN50 training script in the MXNet Rn50 test

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It removes no longer applicable sed command from RN50 MXNet test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     removes sed command that was a runtime patch for a container RN50 training script in the MXNet Rn50 test
 - Affected modules and functionalities:
     TL3_RN50_convergence
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test applies
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-2169]*
