### PR TITLE
Dali TF installation: check import before completing the installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *~
-build*
+build/*
 *.pyc
 doxygen
 html
@@ -25,4 +25,3 @@ docs/fn_to_op_table
 docs/op_autodoc
 docs/fn_autodoc
 docs/nvidia.ico
-

--- a/dali_tf_plugin/build_dali_stub.sh
+++ b/dali_tf_plugin/build_dali_stub.sh
@@ -16,19 +16,20 @@
 
 COMPILER=${CXX:-g++}
 PYTHON=${PYTHON:-python}
-LIB_NAME=${1:-"libdali_tf_current.so"}
-DALI_STUB_DIR=${2:-"${PWD}/stub"}
-SRCS="daliop.cc dali_dataset_op.cc"
-INCL_DIRS="-I/usr/local/cuda/include/"
+DALI_STUB_DIR=${1:-"${PWD}/stub"}
+DALI_STUB_LIB="${DALI_STUB_DIR}/libdali.so"
+SRCS="dali_stub.cc"
+INCL_DIRS="-I/usr/local/cuda/include/ -I"
+
+mkdir -p ${DALI_STUB_DIR}
+
+DALI_STUB_SRC_DIR=`mktemp -d -t "dali_stub_XXXXXX"`
+DALI_STUB_SRC="${DALI_STUB_SRC_DIR}/dali_stub.cc"
+$PYTHON ../tools/stubgen.py ../include/dali/c_api.h --output "${DALI_STUB_SRC}"
 
 DALI_CFLAGS="-I../include -I.."
-DALI_LFLAGS="-L${DALI_STUB_DIR} -ldali"
 
-TF_CFLAGS=( $($PYTHON -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))') )
-TF_LFLAGS=( $($PYTHON -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))') )
+$COMPILER -std=c++14 -DNDEBUG -O2 -shared -fPIC ${DALI_STUB_SRC} -o ${DALI_STUB_LIB} ${INCL_DIRS} ${DALI_CFLAGS}
 
-# Note: DNDEBUG flag is needed due to issue with TensorFlow custom ops:
-# https://github.com/tensorflow/tensorflow/issues/17316
-# Do not remove it.
-$COMPILER -Wl,-rpath,\'$ORIGIN\' -std=c++14 -DNDEBUG -O2 -shared -fPIC ${SRCS} \
-    -o ${LIB_NAME} ${INCL_DIRS} ${DALI_CFLAGS} ${DALI_LFLAGS} ${TF_CFLAGS[@]} ${TF_LFLAGS[@]}
+# Cleaning up stub dir
+rm -rf "${DALI_STUB_DIR}"

--- a/dali_tf_plugin/build_dali_stub.sh
+++ b/dali_tf_plugin/build_dali_stub.sh
@@ -16,20 +16,15 @@
 
 COMPILER=${CXX:-g++}
 PYTHON=${PYTHON:-python}
-DALI_STUB_DIR=${1:-"${PWD}/stub"}
-DALI_STUB_LIB="${DALI_STUB_DIR}/libdali.so"
-SRCS="dali_stub.cc"
-INCL_DIRS="-I/usr/local/cuda/include/ -I"
+OUT_DALI_STUB_LIB=${1:-"${PWD}/stub/libdali.so"}
+INCL_DIRS="-I/usr/local/cuda/include/"
 
-mkdir -p ${DALI_STUB_DIR}
-
-DALI_STUB_SRC_DIR=`mktemp -d -t "dali_stub_XXXXXX"`
-DALI_STUB_SRC="${DALI_STUB_SRC_DIR}/dali_stub.cc"
+DALI_STUB_DIR=`mktemp -d -t "dali_stub_XXXXXX"`
+DALI_STUB_SRC="${DALI_STUB_DIR}/dali_stub.cc"
 $PYTHON ../tools/stubgen.py ../include/dali/c_api.h --output "${DALI_STUB_SRC}"
 
 DALI_CFLAGS="-I../include -I.."
-
-$COMPILER -std=c++14 -DNDEBUG -O2 -shared -fPIC ${DALI_STUB_SRC} -o ${DALI_STUB_LIB} ${INCL_DIRS} ${DALI_CFLAGS}
+$COMPILER -std=c++14 -DNDEBUG -O2 -shared -fPIC ${DALI_STUB_SRC} -o ${OUT_DALI_STUB_LIB} ${INCL_DIRS} ${DALI_CFLAGS}
 
 # Cleaning up stub dir
 rm -rf "${DALI_STUB_DIR}"

--- a/dali_tf_plugin/build_dali_tf.sh
+++ b/dali_tf_plugin/build_dali_tf.sh
@@ -30,5 +30,5 @@ TF_LFLAGS=( $($PYTHON -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.g
 # Note: DNDEBUG flag is needed due to issue with TensorFlow custom ops:
 # https://github.com/tensorflow/tensorflow/issues/17316
 # Do not remove it.
-$COMPILER -Wl,-rpath,\'$ORIGIN\' -std=c++14 -DNDEBUG -O2 -shared -fPIC ${SRCS} \
+$COMPILER -Wl,-rpath,\$ORIGIN -std=c++14 -DNDEBUG -O2 -shared -fPIC ${SRCS} \
     -o ${LIB_NAME} ${INCL_DIRS} ${DALI_CFLAGS} ${DALI_LFLAGS} ${TF_CFLAGS[@]} ${TF_LFLAGS[@]}

--- a/dali_tf_plugin/build_in_custom_op_docker.sh
+++ b/dali_tf_plugin/build_in_custom_op_docker.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -o xtrace
 set -e
 
@@ -13,7 +27,9 @@ LAST_CONFIG_INDEX=$(python ../qa/setup_packages.py -n -u tensorflow-gpu --cuda $
 PREBUILT_DIR=/prebuilt
 mkdir -p ${PREBUILT_DIR}
 
-mkdir -p $PREBUILT_DIR
+STUB_DIR="${PREBUILT_DIR}/stub"
+mkdir -p "${STUB_DIR}"
+source ./build_dali_stub.sh "${STUB_DIR}"
 
 for i in `seq 0 $LAST_CONFIG_INDEX`; do
     INST=$(python ../qa/setup_packages.py -i $i -u tensorflow-gpu --cuda ${CUDA_VERSION})
@@ -26,7 +42,7 @@ for i in `seq 0 $LAST_CONFIG_INDEX`; do
     SUFFIX=$(echo $INST | sed 's/.*=\([0-9]\+\)\.\([0-9]\+\).*/\1_\2/')
     LIB_PATH="${PREBUILT_DIR}/libdali_tf_${SUFFIX}.so"
 
-    source ./build_dali_tf.sh "${LIB_PATH}"
+    source ./build_dali_tf.sh "${LIB_PATH}" "${STUB_DIR}"
 
     pip uninstall -y tensorflow-gpu
 done

--- a/dali_tf_plugin/build_in_custom_op_docker.sh
+++ b/dali_tf_plugin/build_in_custom_op_docker.sh
@@ -28,8 +28,9 @@ PREBUILT_DIR=/prebuilt
 mkdir -p ${PREBUILT_DIR}
 
 STUB_DIR="${PREBUILT_DIR}/stub"
+STUB_LIB="${STUB_DIR}/libdali.so"
 mkdir -p "${STUB_DIR}"
-source ./build_dali_stub.sh "${STUB_DIR}"
+source ./build_dali_stub.sh "${STUB_LIB}"
 
 for i in `seq 0 $LAST_CONFIG_INDEX`; do
     INST=$(python ../qa/setup_packages.py -i $i -u tensorflow-gpu --cuda ${CUDA_VERSION})

--- a/dali_tf_plugin/dali_tf_plugin_utils.py
+++ b/dali_tf_plugin/dali_tf_plugin_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -158,3 +158,10 @@ def find_available_prebuilt_tf(requested_version, available_libs):
             if ver_second <= req_ver_second and (selected_ver is None or selected_ver < (ver_first, ver_second)):
                 selected_ver = (ver_first, ver_second)
     return '.'.join([str(v) for v in selected_ver]) if selected_ver is not None else None
+
+def can_import_dali():
+    try:
+        import nvidia.dali as dali
+        return True
+    except:
+        return False

--- a/dali_tf_plugin/dali_tf_plugin_utils.py
+++ b/dali_tf_plugin/dali_tf_plugin_utils.py
@@ -163,5 +163,5 @@ def can_import_dali():
     try:
         import nvidia.dali as dali
         return True
-    except:
+    except Exception:
         return False

--- a/dali_tf_plugin/dali_tf_plugin_utils.py
+++ b/dali_tf_plugin/dali_tf_plugin_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -158,10 +158,3 @@ def find_available_prebuilt_tf(requested_version, available_libs):
             if ver_second <= req_ver_second and (selected_ver is None or selected_ver < (ver_first, ver_second)):
                 selected_ver = (ver_first, ver_second)
     return '.'.join([str(v) for v in selected_ver]) if selected_ver is not None else None
-
-def can_import_dali():
-    try:
-        import nvidia.dali as dali
-        return True
-    except Exception:
-        return False


### PR DESCRIPTION
#### Why we need this PR?
- It adds new feature needed to make the installation of DALI TF plugin more reliable.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added an import check to the DALI TF installation script to verify that the installed plugin is usable before completing the installation sucessfully*
 - Affected modules and functionalities:
     *DALI TF installer*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *Existing tests apply*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-2170]*
