### PR TITLE
Bump TensorFlow version in tests

### DIFF
--- a/dali/test/python/test_dali_tf_dataset_mnist.py
+++ b/dali/test/python/test_dali_tf_dataset_mnist.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ def get_dataset_multi_gpu(strategy):
 
     input_options = tf.distribute.InputOptions(
         experimental_place_dataset_on_device = True,
-        experimental_prefetch_to_device = False,
+        experimental_fetch_to_device = False,
         experimental_replication_mode = tf.distribute.InputReplicationMode.PER_REPLICA)
 
     train_dataset = strategy.distribute_datasets_from_function(dataset_fn, input_options)

--- a/dali/test/python/test_utils_tensorflow.py
+++ b/dali/test/python/test_utils_tensorflow.py
@@ -336,7 +336,7 @@ def run_tf_dataset_multigpu_eager_mirrored_strategy(get_pipeline_desc=get_image_
     strategy = tf.distribute.MirroredStrategy(devices=available_gpus())
     input_options = tf.distribute.InputOptions(
         experimental_place_dataset_on_device = True,
-        experimental_prefetch_to_device = False,
+        experimental_fetch_to_device = False,
         experimental_replication_mode = tf.distribute.InputReplicationMode.PER_REPLICA)
 
     def dataset_fn(input_context):

--- a/docs/examples/frameworks/tensorflow/tensorflow-dataset-multigpu.ipynb
+++ b/docs/examples/frameworks/tensorflow/tensorflow-dataset-multigpu.ipynb
@@ -147,7 +147,7 @@
     "\n",
     "input_options = tf.distribute.InputOptions(\n",
     "    experimental_place_dataset_on_device = True,\n",
-    "    experimental_prefetch_to_device = False,\n",
+    "    experimental_fetch_to_device = False,\n",
     "    experimental_replication_mode = tf.distribute.InputReplicationMode.PER_REPLICA)\n",
     "\n",
     "train_dataset = strategy.distribute_datasets_from_function(dataset_fn, input_options)"

--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -13,8 +13,8 @@ do_once() {
     CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2\3/')
 
     # check if CUDA version is at least 11.x
-    if [ "$(echo "$CUDA_VERSION" | tr " " "\n" | sort -rV | head -n 1)" == "110" ]; then
-        # install TF 2.4.x for CUDA 11.x test
+    if [ "${CUDA_VERSION:0:2}" == "11" ]; then
+        # install TF 2.5.x for CUDA 11.x test
         pip install $($topdir/qa/setup_packages.py -i 1 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
     else
         # install TF 2.3.x for CUDA 10.x test

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -400,20 +400,21 @@ class CudaHttpPackage(CudaPackage):
 all_packages = [PlainPackage("opencv-python", ["4.5.1.48"]),
                 CudaPackage("cupy",
                         { "100" : ["8.6.0"],
-                          "110" : ["8.6.0"] },
+                          "110" : ["8.6.0"],
+                          "111" : ["8.6.0"] },
                         "cupy-cuda{cuda_v}"),
                 CudaPackage("mxnet",
                         { "100" : ["1.8.0.post0"] },
                         "mxnet-cu{cuda_v}"),
                 CudaPackage("tensorflow-gpu",
                         { "100" : [
-                              PckgVer("1.15.4",  python_max_ver="3.7"),
-                              "2.3.1"],
+                              PckgVer("1.15.5",  python_max_ver="3.7"),
+                              "2.3.3"],
                           "110" : [
-                              PckgVer("1.15.4",  python_max_ver="3.7"),
-                              "2.3.1",
-                              "2.4.1",
-                              PckgVer("1.15.5+nv21.04", python_min_ver="3.8", python_max_ver="3.8", alias="nvidia-tensorflow")]
+                              PckgVer("1.15.5",  python_max_ver="3.7"),
+                              "2.4.2",
+                              "2.5.0",
+                              PckgVer("1.15.5+nv21.06", python_min_ver="3.8", python_max_ver="3.8", alias="nvidia-tensorflow")]
                         }),
                 CudaPackageExtraIndex("torch",
                         { "100" : ["1.4.0"],


### PR DESCRIPTION
- adds support for 2.5.0
- replaces support for 1.15.4 with 1.15.5
- replaces tests from 1.15.5+nv21.04 to 1.15.5+nv21.06
- bumps 2.3.x version to 2.3.3
- bumps 2.4.x version to 2.4.2

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It bumps TensorFlow version in tests

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds support for 2.5.0
     replaces support for 1.15.4 with 1.15.5
     replaces tests from 1.15.5+nv21.04 to 1.15.5+nv21.06
     bumps 2.3.x version to 2.3.3
     bumps 2.4.x version to 2.4.2
 - Affected modules and functionalities:
     setup_packages.py
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current TF tests apply
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-2167]*
