### PR TITLE
SliceCPU kernel to run plain memcpy when applicable

### DIFF
--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -294,15 +294,15 @@ void SliceKernel(ExecutionEngine &exec_engine,
                  const TensorShape<Dims> &out_shape,
                  const TensorShape<Dims> &in_shape,
                  const SliceArgs<OutputType, Dims> &args,
-                 int min_blk_sz = 16000,
+                 int min_blk_sz = 16 << 10,
                  int req_nblocks = -1) {
   if (req_nblocks < 0)
     req_nblocks = exec_engine.NumThreads() * 8;
 
   // If the output and input data type is the same and the slice arguments take the whole extent
   // of the input, then we can simply run memcpy.
-  if (CanRunPlainCopy<OutputType, InputType, Dims>(out_strides, in_strides, out_shape, in_shape,
-                                                   args)) {
+  if (CanRunPlainCopy<OutputType, InputType, Dims>(out_strides, in_strides,
+                                                   out_shape, in_shape, args)) {
     int64_t total_sz = volume(out_shape);
     int64_t nbytes = total_sz * sizeof(OutputType);
     int nblocks = std::min<int64_t>(req_nblocks, div_ceil(total_sz, min_blk_sz));
@@ -371,8 +371,8 @@ void SliceKernel(SequentialExecutionEngine &exec_engine,
 
   // If the output and input data type is the same and the slice arguments take the whole extent
   // of the input, then we can simply run memcpy.
-  if (CanRunPlainCopy<OutputType, InputType, Dims>(out_strides, in_strides, out_shape, in_shape,
-                                                   args)) {
+  if (CanRunPlainCopy<OutputType, InputType, Dims>(out_strides, in_strides,
+                                                   out_shape, in_shape, args)) {
     std::memcpy(out_data, in_data, sizeof(OutputType) * volume(out_shape));
     return;
   }
@@ -420,7 +420,7 @@ class SliceCPU {
                 InTensorCPU<InputType, Dims> in,
                 const SliceArgs<OutputType, Dims> &args,
                 ExecutionEngine &exec_engine,
-                int min_blk_sz = 16000, int req_nblocks = -1) {
+                int min_blk_sz = 16 << 10, int req_nblocks = -1) {
     auto out_strides = GetStrides(out.shape);
     auto in_strides = GetStrides(in.shape);
 

--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -294,7 +294,7 @@ void SliceKernel(ExecutionEngine &exec_engine,
                  const TensorShape<Dims> &out_shape,
                  const TensorShape<Dims> &in_shape,
                  const SliceArgs<OutputType, Dims> &args,
-                 int min_blk_sz = 16 << 10,
+                 int min_blk_sz = kSliceMinBlockSize,
                  int req_nblocks = -1) {
   if (req_nblocks < 0)
     req_nblocks = exec_engine.NumThreads() * 8;
@@ -420,7 +420,7 @@ class SliceCPU {
                 InTensorCPU<InputType, Dims> in,
                 const SliceArgs<OutputType, Dims> &args,
                 ExecutionEngine &exec_engine,
-                int min_blk_sz = 16 << 10, int req_nblocks = -1) {
+                int min_blk_sz = kSliceMinBlockSize, int req_nblocks = -1) {
     auto out_strides = GetStrides(out.shape);
     auto in_strides = GetStrides(in.shape);
 

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_cpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_cpu.h
@@ -251,7 +251,7 @@ DLL_LOCAL  // workaround for GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?
 void SliceFlipNormalizePermutePadKernel(
         ExecutionEngine &exec_engine, OutputType *output, const InputType *input,
         const detail::SliceFlipNormalizePermutePadProcessedArgs<Dims> &args,
-        const SmallVector<OutputType, 8> &fill_values, int min_blk_sz = 16000,
+        const SmallVector<OutputType, 8> &fill_values, int min_blk_sz = 16 << 10,
         int req_nblocks = -1) {
   // Parallelize
   std::array<int, Dims> split_factor;

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_cpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_cpu.h
@@ -251,7 +251,7 @@ DLL_LOCAL  // workaround for GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?
 void SliceFlipNormalizePermutePadKernel(
         ExecutionEngine &exec_engine, OutputType *output, const InputType *input,
         const detail::SliceFlipNormalizePermutePadProcessedArgs<Dims> &args,
-        const SmallVector<OutputType, 8> &fill_values, int min_blk_sz = 16 << 10,
+        const SmallVector<OutputType, 8> &fill_values, int min_blk_sz = kSliceMinBlockSize,
         int req_nblocks = -1) {
   // Parallelize
   std::array<int, Dims> split_factor;

--- a/dali/kernels/slice/slice_kernel_utils.h
+++ b/dali/kernels/slice/slice_kernel_utils.h
@@ -104,6 +104,31 @@ inline std::tuple<int64_t, int64_t, int64_t> CalcPadCopyExtents(int64_t anchor,
   return std::tuple<int64_t, int64_t, int64_t>{pad_before, to_copy, pad_after};
 }
 
+
+template <typename OutputType, typename InputType, int Dims>
+bool CanRunPlainCopy(const TensorShape<Dims> &out_strides,
+                     const TensorShape<Dims> &in_strides,
+                     const TensorShape<Dims> &out_shape,
+                     const TensorShape<Dims> &in_shape,
+                     const SliceArgs<OutputType, Dims> &args) {
+  // if there's type conversion we can't run memcpy
+  if (!std::is_same<OutputType, InputType>::value)
+    return false;
+
+  auto default_out_strides = GetStrides(out_shape);
+  auto default_in_strides = GetStrides(in_shape);
+
+  // If the strides are not the default ones, or the window anchor and shape
+  // are different than the bounds of the input, we can't run plain memcpy
+  for (int d = 0; d < Dims; d++) {
+    if (args.anchor[d] != 0 || out_shape[d] != in_shape[d] ||
+        default_out_strides[d] != out_strides[d] ||
+        default_in_strides[d] != in_strides[d])
+      return false;
+  }
+  return true;
+}
+
 }  // namespace kernels
 }  // namespace dali
 

--- a/dali/kernels/slice/slice_kernel_utils.h
+++ b/dali/kernels/slice/slice_kernel_utils.h
@@ -26,6 +26,8 @@
 namespace dali {
 namespace kernels {
 
+static constexpr int kSliceMinBlockSize = 16 << 10;
+
 template <typename T, int Dims>
 struct SliceArgs {
   TensorShape<Dims> anchor;

--- a/dali/operators/image/crop/crop_mirror_normalize.cc
+++ b/dali/operators/image/crop/crop_mirror_normalize.cc
@@ -120,12 +120,11 @@ void CropMirrorNormalize<CPUBackend>::RunImpl(HostWorkspace &ws) {
         auto in_view = view<const InputType, Dims>(input);
         auto out_view = view<OutputType, Dims>(output);
         int req_nblocks = std::max(1, 10 * thread_pool.NumThreads() / nsamples);
-        int block_min_sz = 16 << 10;
         kernels::KernelContext ctx;
         for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
           Kernel().Schedule(ctx, out_view[sample_idx], in_view[sample_idx],
                             kernel_sample_args[sample_idx],
-                            thread_pool, block_min_sz, req_nblocks);
+                            thread_pool, kernels::kSliceMinBlockSize, req_nblocks);
         }
         thread_pool.RunAll();
       ), DALI_FAIL(make_string("Not supported number of dimensions:", ndim));); // NOLINT

--- a/dali/operators/image/crop/crop_mirror_normalize.cc
+++ b/dali/operators/image/crop/crop_mirror_normalize.cc
@@ -120,7 +120,7 @@ void CropMirrorNormalize<CPUBackend>::RunImpl(HostWorkspace &ws) {
         auto in_view = view<const InputType, Dims>(input);
         auto out_view = view<OutputType, Dims>(output);
         int req_nblocks = std::max(1, 10 * thread_pool.NumThreads() / nsamples);
-        int block_min_sz = 16000;
+        int block_min_sz = 16 << 10;
         kernels::KernelContext ctx;
         for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
           Kernel().Schedule(ctx, out_view[sample_idx], in_view[sample_idx],

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -240,7 +240,7 @@ void NumpyReaderCPU::RunImpl(HostWorkspace &ws) {
 
   // From 1 to 10 blocks per sample depending on the nthreads/nsamples ratio
   int blocks_per_sample = std::max(1, 10 * nthreads / nsamples);
-  constexpr int kThreshold = 16 << 10;  // smaller samples will not be subdivided
+  constexpr int kThreshold = kernels::kSliceMinBlockSize;  // smaller samples will not be subdivided
 
   for (int i = 0; i < nsamples; i++) {
     const auto& file_i = GetSample(i);

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -240,7 +240,7 @@ void NumpyReaderCPU::RunImpl(HostWorkspace &ws) {
 
   // From 1 to 10 blocks per sample depending on the nthreads/nsamples ratio
   int blocks_per_sample = std::max(1, 10 * nthreads / nsamples);
-  constexpr int kThreshold = 16000;  // smaller samples will not be subdivided
+  constexpr int kThreshold = 16 << 10;  // smaller samples will not be subdivided
 
   for (int i = 0; i < nsamples; i++) {
     const auto& file_i = GetSample(i);

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -676,7 +676,7 @@ def test_slice_named_args_errors():
     yield check_slice_named_args_errors, 'cpu', 1
     yield check_slice_named_args_errors, 'gpu', 1
 
-def check_plain_memcpy(device, dtype, batch_size, num_threads):
+def check_no_slice(device, dtype, batch_size, num_threads):
     @pipeline_def(batch_size=batch_size, num_threads=num_threads, device_id=0)
     def make_pipe():
         encoded, _ = fn.readers.caffe(path=caffe_db_folder, random_shuffle=False)
@@ -695,9 +695,9 @@ def check_plain_memcpy(device, dtype, batch_size, num_threads):
             out_img = np.array(outs[out_idx][0])
             np.testing.assert_array_equal(in_img, out_img)
 
-def test_plain_memcpy():
+def test_no_slice():
     batch_size=4
     num_threads=3
     for device in ['cpu', 'gpu']:
         for dtype in [types.UINT8, types.UINT16, types.FLOAT]:
-            yield check_plain_memcpy, device, dtype, batch_size, num_threads
+            yield check_no_slice, device, dtype, batch_size, num_threads

--- a/dali/test/python/test_operator_slice.py
+++ b/dali/test/python/test_operator_slice.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nvidia.dali.pipeline import Pipeline
-import nvidia.dali.ops as ops
-import nvidia.dali.fn as fn
-import nvidia.dali.types as types
+from nvidia.dali import Pipeline, pipeline_def, ops, fn, types
 import nvidia.dali as dali
 from nvidia.dali.backend_impl import TensorListGPU
 import numpy as np
@@ -678,3 +675,29 @@ def check_slice_named_args_errors(device, batch_size):
 def test_slice_named_args_errors():
     yield check_slice_named_args_errors, 'cpu', 1
     yield check_slice_named_args_errors, 'gpu', 1
+
+def check_plain_memcpy(device, dtype, batch_size, num_threads):
+    @pipeline_def(batch_size=batch_size, num_threads=num_threads, device_id=0)
+    def make_pipe():
+        encoded, _ = fn.readers.caffe(path=caffe_db_folder, random_shuffle=False)
+        image = fn.decoders.image(encoded, device="cpu", output_type=types.RGB)
+        image = fn.cast(image, dtype=dtype)
+        sliced1 = fn.slice(image, 0, 3, axes=(2,))
+        sliced2 = fn.slice(image, rel_start=(0, 0, 0), rel_end=(1, 1, 1), axis_names="HWC")
+        return image, sliced1, sliced2
+    pipe = make_pipe()
+    pipe.build()
+    for _ in range(3):
+        outs = pipe.run()
+        nouts = len(outs)
+        in_img = np.array(outs[0][0])
+        for out_idx in range(1, nouts):
+            out_img = np.array(outs[out_idx][0])
+            np.testing.assert_array_equal(in_img, out_img)
+
+def test_plain_memcpy():
+    batch_size=4
+    num_threads=3
+    for device in ['cpu', 'gpu']:
+        for dtype in [types.UINT8, types.UINT16, types.FLOAT]:
+            yield check_plain_memcpy, device, dtype, batch_size, num_threads


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds new feature needed to improve the performance of SliceCPU kernel when the arguments are such that the slicing operation is equivalent to a copy operation.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added special handling in SliceCPU to detect the plain copy case and run memcpy instead of the slice kernel function*
 - Affected modules and functionalities:
     *SliceCPU kernel and all the operators using it*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *New tests added*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[DALI-2138]*
