### PR TITLE
Add `--no-index` option to TL1_tensorflow-dali_test test

### DIFF
--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-pip_packages=""
+pip_packages="horovod==0.21.3"
 target_dir=./docs/examples/use_cases/tensorflow/resnet-n
 
 do_once() {
@@ -56,7 +56,17 @@ do_once() {
     export HOROVOD_NCCL_LIB=/usr/lib/x86_64-linux-gnu
     export HOROVOD_NCCL_LINK=SHARED
     export HOROVOD_WITHOUT_PYTORCH=1
-    pip install horovod==0.21.3
+    # horovod is added to `pip_packages` so it can be preloaded, but install it here when
+    # TF is already available and we can set env variables
+    install_cmd="pip install --force-reinstall horovod==0.21.3 -f /pip-packages"
+    set +e
+    ${install_cmd} --no-index
+    res=$?
+    set -e
+    # if no package was found in our download dir, so install it from index
+    if [ "$res" != "0" ]; then
+        ${install_cmd}
+    fi
 
     for file in $(ls /data/imagenet/train-val-tfrecord-480-subset);
     do

--- a/qa/TL1_tensorflow-dali_test/test.sh
+++ b/qa/TL1_tensorflow-dali_test/test.sh
@@ -15,10 +15,10 @@ do_once() {
     # check if CUDA version is at least 11.x
     if [ "${CUDA_VERSION:0:2}" == "11" ]; then
         # install TF 2.5.x for CUDA 11.x test
-        pip install $($topdir/qa/setup_packages.py -i 1 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
+        install_pip_pkg "pip install $($topdir/qa/setup_packages.py -i 1 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages"
     else
         # install TF 2.3.x for CUDA 10.x test
-        pip install $($topdir/qa/setup_packages.py -i 0 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages
+        install_pip_pkg "pip install $($topdir/qa/setup_packages.py -i 0 -u tensorflow-gpu --cuda ${CUDA_VERSION}) -f /pip-packages"
     fi
 
     # The package name can be nvidia-dali-tf-plugin,  nvidia-dali-tf-plugin-weekly or  nvidia-dali-tf-plugin-nightly
@@ -58,15 +58,7 @@ do_once() {
     export HOROVOD_WITHOUT_PYTORCH=1
     # horovod is added to `pip_packages` so it can be preloaded, but install it here when
     # TF is already available and we can set env variables
-    install_cmd="pip install --force-reinstall horovod==0.21.3 -f /pip-packages"
-    set +e
-    ${install_cmd} --no-index
-    res=$?
-    set -e
-    # if no package was found in our download dir, so install it from index
-    if [ "$res" != "0" ]; then
-        ${install_cmd}
-    fi
+    install_pip_pkg "pip install --force-reinstall horovod==0.21.3 -f /pip-packages"
 
     for file in $(ls /data/imagenet/train-val-tfrecord-480-subset);
     do

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -12,6 +12,12 @@ source $topdir/qa/setup_test_common.sh
 pip_packages=$(echo ${pip_packages} | sed "s/##CUDA_VERSION##/${CUDA_VERSION}/")
 last_config_index=$($topdir/qa/setup_packages.py -n -u $pip_packages --cuda ${CUDA_VERSION})
 
+install_pip_pkg() {
+    install_cmd=$1
+    # if no package was found in our download dir, so install it from index
+    ${install_cmd} --no-index || ${install_cmd}
+}
+
 if [ -n "$gather_pip_packages" ]
 then
     # early exit
@@ -65,15 +71,7 @@ do
         if [ -n "$inst" ]; then
             for pkg in ${inst}
             do
-                # turn off error
-                set +e
-                pip install $pkg -f /pip-packages --no-index
-                res=$?
-                set -e
-                # if no package was found in our download dir, so install it from index
-                if [ "$res" != "0" ]; then
-                    pip install $pkg ${extra_indices_string}
-                fi
+                install_pip_pkg "pip install $pkg -f /pip-packages"
             done
 
             # If we just installed tensorflow, we need to reinstall DALI TF plugin

--- a/qa/test_template.sh
+++ b/qa/test_template.sh
@@ -13,7 +13,7 @@ pip_packages=$(echo ${pip_packages} | sed "s/##CUDA_VERSION##/${CUDA_VERSION}/")
 last_config_index=$($topdir/qa/setup_packages.py -n -u $pip_packages --cuda ${CUDA_VERSION})
 
 install_pip_pkg() {
-    install_cmd=$1
+    install_cmd="$@"
     # if no package was found in our download dir, so install it from index
     ${install_cmd} --no-index || ${install_cmd}
 }


### PR DESCRIPTION
- makes TL1_tensorflow-dali_test test to use predownload package
by adding --no-index option

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- makes TL1_tensorflow-dali_test test to use predownload package
by adding --no-index option

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     makes TL1_tensorflow-dali_test test to use predownload package by adding --no-index option
 - Affected modules and functionalities:
     TL1_tensorflow-dali_test
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test apply
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-2169]*
