### PR TITLE
Make nvJPEG detect corrupted stream before offloading to HW decoder

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -587,10 +587,10 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
             // in some cases hybrid decoder can handle the image but HW decoder can't, we should not
             // error in that case
             ret = nvjpegJpegStreamParse(handle_, input_data, in_size, 0, 0,
-                                        hw_decoder_jpeg_streams_[i]);
+                                        hw_decoder_jpeg_streams_[tid]);
             if (ret == NVJPEG_STATUS_SUCCESS) {
               int is_supported = -1;
-              NVJPEG_CALL(nvjpegDecodeBatchedSupportedEx(handle_, hw_decoder_jpeg_streams_[i],
+              NVJPEG_CALL(nvjpegDecodeBatchedSupportedEx(handle_, hw_decoder_jpeg_streams_[tid],
                                                           data.params, &is_supported));
               hw_decode = is_supported == 0;
             }

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -623,7 +623,6 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       }, in_size);
     }
     thread_pool_.RunAll();
-    thread_pool_.WaitForWork();
 
     for (auto &data : sample_data_) {
       switch (data.method) {

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -581,7 +581,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
         if (state_hw_batched_ != nullptr) {
           // in some cases hybrid decoder can handle the image but HW decoder can't, we should not
           // error in that case
-          ret = nvjpegJpegStreamParseHeader(handle_, input_data, in_size, hw_decoder_jpeg_stream_);
+          ret = nvjpegJpegStreamParse(handle_, input_data, in_size, 0, 0, hw_decoder_jpeg_stream_);
           if (ret == NVJPEG_STATUS_SUCCESS) {
             int is_supported = -1;
             NVJPEG_CALL(nvjpegDecodeBatchedSupportedEx(handle_, hw_decoder_jpeg_stream_,

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -586,7 +586,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
           if (state_hw_batched_ != nullptr) {
             // in some cases hybrid decoder can handle the image but HW decoder can't, we should not
             // error in that case
-            ret = nvjpegJpegStreamParse(handle_, input_data, in_size, 0, 0,
+            ret = nvjpegJpegStreamParse(handle_, input_data, in_size, false, false,
                                         hw_decoder_jpeg_streams_[tid]);
             if (ret == NVJPEG_STATUS_SUCCESS) {
               int is_supported = -1;


### PR DESCRIPTION
- there are cases when the JPEG stream can be corrupted and HW decoder
  will fail. Replace check nvjpegJpegStreamParseHeader with nvjpegJpegStreamParse
  to catch this corruption earlier

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a HW decoder error when JPEG stream is corrupted

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     there are cases when the JPEG stream can be corrupted and HW decoder will fail. Replace check nvjpegJpegStreamParseHeader with nvjpegJpegStreamParse to catch this corruption earlier
 - Affected modules and functionalities:
     mixed backed of image decoder
 - Key points relevant for the review:
      NA
 - Validation and testing:
     current test applies
 - Documentation (including examples):
     NA

Relates to https://github.com/NVIDIA/DALI/issues/3084#issuecomment-872108185
**JIRA TASK**: *[NA]*
