### PR TITLE
VM Async Pool - refactoring & tests

### DIFF
--- a/dali/core/mm/async_pool_test.cu
+++ b/dali/core/mm/async_pool_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ TEST(MMAsyncPool, SingleStreamReuse) {
   CUDAStream stream = CUDAStream::Create(true);
   test::test_device_resource upstream;
 
-  async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
+  async_pool_resource<memory_kind::device> pool(&upstream);
   stream_view sv(stream);
   int size1 = 1<<20;
   void *ptr = pool.allocate_async(size1, sv);
@@ -80,7 +80,7 @@ TEST(MMAsyncPool, TwoStream) {
   int stream_not_busy = 0;
   int success = 0;
   while (success < min_success) {
-    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device> pool(&upstream);
     void *p1 = pool.allocate_async(1000, sv1);
     hog.run(s1);
     pool.deallocate_async(p1, 1000, sv1);
@@ -204,7 +204,7 @@ TEST(MMAsyncPool, SingleStreamRandom) {
   test::test_device_resource upstream;
 
   {
-    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device> pool(&upstream);
     vector<block> blocks;
     detail::dummy_lock mtx;
     AsyncPoolTest(pool, blocks, mtx, stream);
@@ -223,7 +223,7 @@ TEST(MMAsyncPool, MultiThreadedSingleStreamRandom) {
     vector<block> blocks;
     std::mutex mtx;
 
-    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device> pool(&upstream);
 
     vector<std::thread> threads;
 
@@ -244,7 +244,7 @@ TEST(MMAsyncPool, MultiThreadedSingleStreamRandom) {
 TEST(MMAsyncPool, MultiThreadedMultiStreamRandom) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device> pool(&upstream);
 
     vector<std::thread> threads;
 
@@ -268,8 +268,7 @@ TEST(MMAsyncPool, MultiThreadedMultiStreamRandom) {
 TEST(MMAsyncPool, MultiStreamRandomWithGPUHogs) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex>
-        pool(&upstream, false);
+    async_pool_resource<memory_kind::device> pool(&upstream, false);
 
     vector<std::thread> threads;
 
@@ -295,8 +294,7 @@ TEST(MMAsyncPool, MultiStreamRandomWithGPUHogs) {
 TEST(MMAsyncPool, CrossStream) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex>
-        pool(&upstream, false);
+    async_pool_resource<memory_kind::device> pool(&upstream, false);
 
     vector<std::thread> threads;
     vector<CUDAStream> streams;
@@ -325,7 +323,7 @@ TEST(MMAsyncPool, CrossStream) {
 TEST(MMAsyncPool, CrossStreamWithHogs) {
   mm::test::test_device_resource upstream;
   {
-    async_pool_resource<memory_kind::device, coalescing_free_tree, std::mutex> pool(&upstream);
+    async_pool_resource<memory_kind::device> pool(&upstream);
 
     vector<std::thread> threads;
     vector<CUDAStream> streams;

--- a/include/dali/core/mm/cuda_vm_resource.h
+++ b/include/dali/core/mm/cuda_vm_resource.h
@@ -265,8 +265,8 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
     size_t                  block_size = 0;
   };
 
-  SmallVector<va_region, 8> va_regions_;
-  SmallVector<cuvm::CUMemAddressRange, 8> va_ranges_;
+  std::vector<va_region> va_regions_;
+  std::vector<cuvm::CUMemAddressRange> va_ranges_;
   size_t initial_va_size_ = 0;
   size_t block_size_ = 0;
   size_t total_mem_ = 0;
@@ -402,7 +402,7 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
         // Found - now we append the old range (which follows the new one) to the new one...
         region->append(std::move(r));
         // ...and remove the old one
-        va_regions_.erase_at(i);
+        va_regions_.erase(va_regions_.begin() + i);
         break;
       }
     }
@@ -563,7 +563,6 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
       return;
     for (va_region &r : va_regions_) {
       if (r.available_blocks) {
-        int block_idx = 0;
         for (int block_idx = r.available.find(true);
              block_idx < r.num_blocks() && count > 0;
              block_idx = r.available.find(true, block_idx+1)) {

--- a/include/dali/core/mm/cuda_vm_resource.h
+++ b/include/dali/core/mm/cuda_vm_resource.h
@@ -644,6 +644,11 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
   }
 };
 
+namespace detail {
+template <>
+struct can_merge<cuda_vm_resource> : std::true_type {};
+
+}  // namespace detail
 }  // namespace mm
 }  // namespace dali
 

--- a/include/dali/core/mm/pool_resource.h
+++ b/include/dali/core/mm/pool_resource.h
@@ -511,6 +511,12 @@ class deferred_dealloc_pool : public pool_resource_base<kind, Context, FreeList,
   bool stopped_ = false;
 };
 
+namespace detail {
+
+template <memory_kind kind, typename Context, class FreeList, class LockType>
+struct can_merge<pool_resource_base<kind, Context, FreeList, LockType>> : can_merge<FreeList> {};
+}  // namespace detail
+
 }  // namespace mm
 }  // namespace dali
 


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to allow aync_pool to be used with `cuda_vm_resource`

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Make global_pool type a template argument of the async resource
     * Conditionally enable the constructor with upstream only if the pool can be constructed with Upstream*
     * Add a constructor with arbitrary global pool arguments forwarded.
     * Specialize `can_merge` to pools, not just free lists
 - Affected modules and functionalities:
     * Memory pool
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * TODO
 - Documentation (including examples):
     * N/A


**JIRA TASK**: DALI-2178
