### PR TITLE
Integer literal suffixes

### DIFF
--- a/dali/core/dev_buffer_test.cc
+++ b/dali/core/dev_buffer_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ TEST(DeviceBuffer, FromDevice) {
 
 TEST(DeviceBufferFail, Resize) {
   DeviceBuffer<int> db;
-  size_t size = static_cast<size_t>(-1);
+  size_t size = -1_uz;
   EXPECT_THROW(db.resize(size), CUDABadAlloc);
 }
 

--- a/dali/core/error_test.cc
+++ b/dali/core/error_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ TEST(Error, CudaAlloc_Drv) {
 
 TEST(Error, CudaAlloc) {
   void *mem = nullptr;
-  size_t sz = 1LL << 62;
+  size_t sz = 1_uz << 62;
   EXPECT_THROW(CUDA_CALL(cudaMalloc(&mem, sz)), CUDABadAlloc);
 }
 

--- a/dali/core/fast_div_test.cu
+++ b/dali/core/fast_div_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ void TestDiv64(bool quick_test) {
       : ((xx >> 12) << 44) + (xx & 0xfff);
     ASSERT_EQ(x / divisor, x / fast) << " when dividing " << x << " / " << divisor;
   }
-  uint64_t x = 0xFFFFFFFFFFFFFFFEuL;
+  uint64_t x = 0xFFFFFFFFFFFFFFFE_u64;
   ASSERT_EQ(x / divisor, x / fast) << " when dividing " << x << " / " << divisor;
 }
 
@@ -71,17 +71,17 @@ void TestDiv32(bool quick) {
 
 void TestDiv64(bool quick) {
   // use compile-time constants so the compiler can optimize the reference division
-  TestDiv64<0xFFFFFFFFFFFFFFFEuL>(quick);
+  TestDiv64<0xFFFFFFFFFFFFFFFE_u64>(quick);
   TestDiv64<3>(quick);
   TestDiv64<5>(quick);
   TestDiv64<7>(quick);
   TestDiv64<1>(quick);
   TestDiv64<0x800000>(quick);
-  TestDiv64<0x80000000000000uL>(quick);
+  TestDiv64<0x80000000000000_u64>(quick);
   TestDiv64<19>(quick);
   TestDiv64<42>(quick);
-  TestDiv64<12345678901234567uL>(quick);
-  TestDiv64<0x82345678DEADBEEFuL>(quick);
+  TestDiv64<12345678901234567_u64>(quick);
+  TestDiv64<0x82345678DEADBEEF_u64>(quick);
 }
 
 // This test is disabled because it's ridiculously slow - only run when touching fast_div
@@ -123,8 +123,8 @@ DEVICE_TEST(FastDiv, DISABLED_U64_GPU_Slow, dim3(1<<10, 1<<10), (1<<10)) {
   fast.init(divisor);
   uint64_t end = start + (1<<12);
   if (blockIdx.x == gridDim.x - 1 && threadIdx.x == blockDim.x-1) {
-    start = 0xfffffffffffffffeuL - (1<<12);
-    end = 0xffffffffffffffffuL;
+    start = 0xfffffffffffffffe_u64 - (1<<12);
+    end = 0xffffffffffffffff_u64;
   }
   for (uint64_t value = start; value < end; value++) {
     auto ref = value / divisor;
@@ -163,7 +163,7 @@ DEVICE_TEST(FastDiv, U32_GPU, dim3(1<<10, 11), (1<<10)) {
 DEVICE_TEST(FastDiv, U64_GPU, dim3(1<<10, 11), (1<<10)) {
   static constexpr uint64_t divisors[11] = {
     1, 2, 3, 5, 7, 14, 19, 42,
-    0x7fffffffffffffffuL, 0x8000000000000000uL, 0xfffffffffffffffeuL
+    0x7fffffffffffffff_u64, 0x8000000000000000_u64, 0xfffffffffffffffe_u64
   };
   uint64_t start = static_cast<uint64_t>(blockIdx.x * blockDim.x + threadIdx.x) << 44;
   uint64_t divisor = divisors[blockIdx.y];
@@ -171,8 +171,8 @@ DEVICE_TEST(FastDiv, U64_GPU, dim3(1<<10, 11), (1<<10)) {
   fast.init(divisor);
   uint64_t end = start + (1<<12);
   if (blockIdx.x == gridDim.x - 1 && threadIdx.x == blockDim.x-1) {
-    start = 0xfffffffffffffffeuL - (1<<12);
-    end = 0xffffffffffffffffuL;
+    start = 0xfffffffffffffffe_u64 - (1<<12);
+    end = 0xffffffffffffffff_u64;
   }
   for (uint64_t value = start; value < end; value++) {
     auto ref = value / divisor;
@@ -237,14 +237,14 @@ TEST(FastDiv_Host, div_lohi) {
   num = { 0, 1 };
   den = 2;
   q = detail::div_lohi(num.lo, num.hi, den);
-  ref = 1uL << 63;
+  ref = 1_u64 << 63;
   EXPECT_EQ(q, ref);
 
-  num = { 0xCAFEBABEFACEFEEDuL, 0x600DF00DuL };
-  den = 0x600DF00EuL;  // this divisor is only slightly larger than the high word which
+  num = { 0xCAFEBABEFACEFEED_u64, 0x600DF00D_u64 };
+  den = 0x600DF00E_u64;  // this divisor is only slightly larger than the high word which
                        // makes the division more prone to errors, should there be any
   // reference is calculated off-line as ((unsigned __int128)num.hi << 64 | num.lo) / den;
-  ref = 0xFFFFFFFF72BBC9CEuL;
+  ref = 0xFFFFFFFF72BBC9CE_u64;
   q = detail::div_lohi(num.lo, num.hi, den);
   EXPECT_EQ(q, ref);
 }
@@ -255,14 +255,14 @@ DEVICE_TEST(FastDiv_Dev, div_lohi, 1, 1) {
   num = { 0, 1 };
   den = 2;
   q = detail::div_lohi(num.lo, num.hi, den);
-  ref = 1uL << 63;
+  ref = 1_u64 << 63;
   DEV_EXPECT_EQ(q, ref);
 
-  num = { 0xCAFEBABEFACEFEEDuL, 0x600DF00DuL };
-  den = 0x600DF00EuL;  // this divisor is only slightly larger than the high word which
+  num = { 0xCAFEBABEFACEFEED_u64, 0x600DF00D_u64 };
+  den = 0x600DF00E_u64;  // this divisor is only slightly larger than the high word which
                        // makes the division more prone to errors, should there be any
   // reference is calculated off-line as ((unsigned __int128)num.hi << 64 | num.lo) / den;
-  ref = 0xFFFFFFFF72BBC9CEuL;
+  ref = 0xFFFFFFFF72BBC9CE_u64;
   q = detail::div_lohi(num.lo, num.hi, den);
   DEV_EXPECT_EQ(q, ref);
 }

--- a/dali/core/utils_test.cu
+++ b/dali/core/utils_test.cu
@@ -19,6 +19,7 @@
 #include "dali/core/span.h"
 
 namespace dali {
+namespace test {
 
 DEVICE_TEST(CoreUtilsDev, Volume, 1, 1) {
   int a0[] = { 42 };
@@ -135,4 +136,5 @@ TEST(CoreUtils, CTZ) {
   }
 }
 
+}  // namespace test
 }  // namespace dali

--- a/dali/image/jpeg_mem.cc
+++ b/dali/image/jpeg_mem.cc
@@ -1,6 +1,6 @@
 /* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
 
-Copyright 2019, NVIDIA CORPORATION. All rights reserved.
+Copyright 2019, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -618,7 +618,7 @@ bool CompressInternal(const uint8* srcdata, int width, int height,
     ERROR_LOG << "Invalid image size: " << width << " x " << height << std::endl;
     return false;
   }
-  if (total_size >= (1LL << 29)) {
+  if (total_size >= (1_i64 << 29)) {
     ERROR_LOG << "Image too large: " << total_size << std::endl;
     return false;
   }

--- a/dali/kernels/reduce/reduce_cpu.h
+++ b/dali/kernels/reduce/reduce_cpu.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -245,12 +245,12 @@ struct ReduceBaseCPU {
     axes = _axes;
     axis_mask = 0;
     for (int axis : axes) {
-      axis_mask |= static_cast<uint64_t>(1) << axis;
+      axis_mask |= 1_u64 << axis;
     }
   }
 
   void CheckOutput() {
-    if (axis_mask == (static_cast<uint64_t>(1) << ndim()) - 1) {
+    if (axis_mask == (1_u64 << ndim()) - 1) {
       DALI_ENFORCE(
         (output.dim() == 1 || output.dim() == 0 || output.dim() == input.dim()) &&
           output.num_elements() == 1,
@@ -290,7 +290,7 @@ struct ReduceBaseCPU {
     }
     axis_mask = 0;
     for (int axis : axes) {
-      axis_mask |= static_cast<uint64_t>(1) << axis;
+      axis_mask |= 1_u64 << axis;
     }
   }
 
@@ -323,7 +323,7 @@ struct ReduceBaseCPU {
 
   DALI_FORCEINLINE int ndim() const noexcept { return input.shape.size(); }
   DALI_FORCEINLINE bool is_reduced_axis(int axis) const noexcept {
-    return axis_mask & (static_cast<uint64_t>(1) << axis);
+    return axis_mask & (1_u64 << axis);
   }
 
   OutTensorCPU<Dst, -1> output;

--- a/dali/kernels/reduce/reduce_setup_utils.h
+++ b/dali/kernels/reduce/reduce_setup_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -150,7 +150,7 @@ inline void CheckAxes(span<const int> axes, int ndim) {
   for (auto a : axes) {
     if (a < 0 || a >= ndim)
       throw std::out_of_range(make_string("Axis index out of range: ", a, " not in 0..", ndim-1));
-    uint64_t amask = 1ul << a;
+    uint64_t amask = 1_u64 << a;
     if (mask & amask)
       throw std::invalid_argument(make_string("Duplicate axis index ", a));
     mask |= amask;

--- a/dali/kernels/test/alloc_test.cc
+++ b/dali/kernels/test/alloc_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -102,7 +102,7 @@ TEST(KernelAlloc, Shared) {
 
 TEST(KernelAllocFail, Host) {
   (void)cudaGetLastError();
-  size_t size = static_cast<size_t>(-1);
+  size_t size = -1_uz;
   EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::Host, size), std::bad_alloc);
   EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::Host, size), std::bad_alloc);
   EXPECT_EQ(memory::alloc_unique<uint8_t>(AllocType::Host, 0),
@@ -113,7 +113,7 @@ TEST(KernelAllocFail, Host) {
 
 TEST(KernelAllocFail, Pinned) {
   (void)cudaGetLastError();
-  size_t size = static_cast<size_t>(-1);
+  size_t size = -1_uz;
   EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::Pinned, size), CUDABadAlloc);
   EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::Pinned, size), CUDABadAlloc);
   EXPECT_EQ(memory::alloc_unique<uint8_t>(AllocType::Pinned, 0),
@@ -124,7 +124,7 @@ TEST(KernelAllocFail, Pinned) {
 
 TEST(KernelAllocFail, GPU) {
   (void)cudaGetLastError();
-  size_t size = static_cast<size_t>(-1);
+  size_t size = -1_uz;
   EXPECT_THROW(memory::alloc_unique<uint8_t>(AllocType::GPU, size), CUDABadAlloc);
   EXPECT_THROW(memory::alloc_shared<uint8_t>(AllocType::GPU, size), CUDABadAlloc);
   EXPECT_EQ(memory::alloc_unique<uint8_t>(AllocType::GPU, 0),

--- a/dali/test/dali_operator_test.h
+++ b/dali/test/dali_operator_test.h
@@ -244,8 +244,8 @@ class DaliOperatorTest : public ::testing::Test, public ::testing::WithParamInte
   void RunTest(const TensorListWrapper &input, TensorListWrapper &output,
                const Arguments &operator_arguments, const VerifySingleIo &verify) {
     std::string op_backend = detail::GetOpDevice(operator_arguments);
-    const auto batch_size = input.has_cpu() ? input.cpu().ntensor() : input.gpu().ntensor();
-    ASSERT_GT(batch_size, 0UL) << "Looks like there ain't no tensors in input";
+    const size_t batch_size = input.has_cpu() ? input.cpu().ntensor() : input.gpu().ntensor();
+    ASSERT_GT(batch_size, 0_uz) << "Looks like there are no tensors in the input";
     auto pipeline = CreatePipeline(batch_size, num_threads_);
     if (input) {
       AddInputToPipeline(*pipeline, input.has_cpu() ? "cpu" : "gpu");

--- a/include/dali/core/common.h
+++ b/include/dali/core/common.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "dali/core/api_helper.h"
+#include "dali/core/int_literals.h"
 
 namespace dali {
 

--- a/include/dali/core/float16.h
+++ b/include/dali/core/float16.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -368,6 +368,7 @@ struct is_fp_or_half {
     std::is_floating_point<T>::value || is_half<T>::value;
 };
 
+namespace literal {
 DALI_HOST_DEV DALI_FORCEINLINE
 float16 operator "" _hf(long double x) {
   return float16(static_cast<double>(x));
@@ -378,6 +379,8 @@ float16 operator "" _hf(unsigned long long int x) {  // NOLINT(runtime/int)
   return float16(x);
 }
 
+}  // namespace literal
+using namespace literal;  // NOLINT
 }  // namespace dali
 
 DALI_HOST_DEV DALI_FORCEINLINE

--- a/include/dali/core/int_literals.h
+++ b/include/dali/core/int_literals.h
@@ -1,0 +1,89 @@
+// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_INT_LITERALS_H_
+#define DALI_CORE_INT_LITERALS_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+#include "dali/core/host_dev.h"
+
+namespace dali {
+
+using size_t = std::size_t;
+using ssize_t = std::make_signed_t<size_t>;
+
+namespace literal {
+
+DALI_HOST_DEV
+constexpr ssize_t operator ""_z(unsigned long long x) {  // NOLINT(runtime/int)
+    return x;
+}
+
+DALI_HOST_DEV
+constexpr size_t operator ""_uz(unsigned long long x) {  // NOLINT(runtime/int)
+    return x;
+}
+
+DALI_HOST_DEV
+constexpr size_t operator ""_zu(unsigned long long x) {  // NOLINT(runtime/int)
+    return x;
+}
+
+DALI_HOST_DEV
+constexpr int8_t operator ""_i8(unsigned long long x) {  // NOLINT(runtime/int)
+    return x;
+}
+
+DALI_HOST_DEV
+constexpr uint8_t operator ""_u8(unsigned long long x) {  // NOLINT(runtime/int)
+    return x;
+}
+
+DALI_HOST_DEV
+constexpr int16_t operator ""_i16(unsigned long long x) {  // NOLINT(runtime/int)
+    return x;
+}
+
+DALI_HOST_DEV
+constexpr uint16_t operator ""_u16(unsigned long long x) {  // NOLINT(runtime/int)
+    return x;
+}
+
+DALI_HOST_DEV
+constexpr int32_t operator ""_i32(unsigned long long x) {  // NOLINT(runtime/int)
+    return x;
+}
+
+DALI_HOST_DEV
+constexpr uint32_t operator ""_u32(unsigned long long x) {  // NOLINT(runtime/int)
+    return x;
+}
+
+DALI_HOST_DEV
+constexpr int64_t operator ""_i64(unsigned long long x) {  // NOLINT(runtime/int)
+    return x;
+}
+
+DALI_HOST_DEV
+constexpr uint64_t operator ""_u64(unsigned long long x) {  // NOLINT(runtime/int)
+    return x;
+}
+
+}  // namespace literal
+using namespace literal;  // NOLINT
+}  // namespace dali
+
+#endif  // DALI_CORE_INT_LITERALS_H_

--- a/include/dali/core/mm/detail/free_list.h
+++ b/include/dali/core/mm/detail/free_list.h
@@ -194,7 +194,7 @@ class best_fit_free_list {
    */
   void *get(size_t bytes, size_t alignment) {
     block **pbest = nullptr;
-    size_t best_fit = (static_cast<size_t>(-1)) >> 1;  // clear MSB
+    size_t best_fit = (-1_uz) >> 1;  // clear MSB
     for (block **pptr = &head_; *pptr; pptr = &(*pptr)->next) {
       size_t fit = (*pptr)->fit(bytes, alignment);
       if (fit < best_fit) {

--- a/include/dali/core/mm/pool_resource.h
+++ b/include/dali/core/mm/pool_resource.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ struct pool_options {
    * Growth stops at this point; larger blocks are allocated only when allocate is called with
    * a larger memory requirements.
    */
-  size_t max_block_size = static_cast<size_t>(-1);  // no limit
+  size_t max_block_size = -1_uz;  // no limit
   /// Minimum size of blocks requested from upstream
   size_t min_block_size = (1 << 12);
   /// The factor by which the allocation size grows until it reaches max_block_size
@@ -83,7 +83,7 @@ constexpr pool_options default_host_pool_opts() noexcept {
 }
 
 constexpr pool_options default_device_pool_opts() noexcept {
-  return { (static_cast<size_t>(1) << 32), (1 << 20), 2.0f, true, true };
+  return { (1_uz << 32), (1 << 20), 2.0f, true, true };
 }
 
 template <memory_kind kind>

--- a/include/dali/core/small_vector.h
+++ b/include/dali/core/small_vector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -660,7 +660,7 @@ class SmallVector : SmallVectorAlloc<T, allocator>, SmallVectorBase<T> {
     } dynamic;
   };
   size_t size_ = 0;
-  static constexpr size_t size_mask = static_cast<size_t>(-1) >> 1;
+  static constexpr size_t size_mask = -1_uz >> 1;
   static constexpr size_t dynamic_flag = ~size_mask;
 
   template <typename U>

--- a/include/dali/core/util.h
+++ b/include/dali/core/util.h
@@ -21,6 +21,7 @@
 #include <utility>
 #include <initializer_list>
 
+#include "dali/core/int_literals.h"
 #include "dali/core/host_dev.h"
 #include "dali/core/force_inline.h"
 #include "dali/core/span.h"


### PR DESCRIPTION
* Add literal suffixes for size_t, ssize_t and fixed-size integer types.
* Rework usage of (unsigned) long or long long literals to proper 64-bit
integers or size_t.

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- Refactoring to improve usage of properly-sized integers.

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Added literal operators with suffixes:
     * `_z` for `ssize_t`
     * `_uz` and `_zu` for `size_t`
     * `_iXX and `_uXX` for fixed-size integers of 8, 16, 32, and 64 bits
 - Affected modules and functionalities:
     * Application code: reduce kernel
     * Tests
     * Build: almost everything
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests apply
 - Documentation (including examples):
     * N/A

**JIRA TASK**: related to DALI-2166
