### PR TITLE
Coverity  issue fixes - bulk drop, July 2021

### DIFF
--- a/dali/image/bmp.cc
+++ b/dali/image/bmp.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2018, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ int number_of_channels(int bpp, int compression_type,
                        const uint8_t* palette_start = nullptr, size_t ncolors = 0,
                        size_t palette_entry_size = 0) {
   if (compression_type == BMP_COMPRESSION_RGB || compression_type == BMP_COMPRESSION_RLE8) {
-    if (bpp <= 8 && ncolors <= (static_cast<size_t>(1) << bpp)) {
+    if (bpp <= 8 && ncolors <= (1_uz << bpp)) {
       return is_color_palette(palette_start, ncolors, palette_entry_size) ? 3 : 1;
     } else if (bpp == 24) {
       return 3;
@@ -95,7 +95,7 @@ Image::Shape BmpImage::PeekShapeImpl(const uint8_t *bmp, size_t length) const {
     if (bpp <= 8) {
       palette_start = ptr;
       palette_entry_size = 3;
-      ncolors = (1 << bpp);
+      ncolors = (1_uz << bpp);
     }
   } else if (length >= 26 && header_size >= 40) {
     // BITMAPINFOHEADER and later:
@@ -112,7 +112,7 @@ Image::Shape BmpImage::PeekShapeImpl(const uint8_t *bmp, size_t length) const {
     if (bpp <= 8) {
       palette_start = ptr;
       palette_entry_size = 4;
-      ncolors = ncolors == 0 ? (1 << bpp) : ncolors;
+      ncolors = ncolors == 0 ? 1_uz << bpp : ncolors;
     }
     // sanity check
     if (palette_start != nullptr) {

--- a/dali/kernels/common/split_shape.h
+++ b/dali/kernels/common/split_shape.h
@@ -46,7 +46,7 @@ int split_shape(SplitFactor& split_factor, const Shape& in_shape, int min_nblock
 
   int64_t vol = volume(in_shape);
   for (int d = 0, nblocks = 1; d < ndim && nblocks < min_nblocks && vol > min_sz; d++) {
-    if (skip_dim_mask & (1 << d))
+    if (skip_dim_mask & (1_u64 << d))
       continue;
     int n = in_shape[d];
     int &b = split_factor[d];

--- a/dali/kernels/normalize/normalize_gpu_impl.cuh
+++ b/dali/kernels/normalize/normalize_gpu_impl.cuh
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -273,7 +273,7 @@ class NormalizeImplGPU {
       axes_ = { axes.begin(), axes.end() };
     axis_mask_ = to_bit_mask<uint64_t>(axes_);
     if (scalar_base && scalar_scale) {
-      assert(axis_mask_ == (1 << ndim_) - 1 &&
+      assert(axis_mask_ == (1_u64 << ndim_) - 1 &&
              "Scalar parameters imply that all axes are reduced.");
     }
 
@@ -388,7 +388,7 @@ class NormalizeImplGPU {
       auto dshape = data_shape[i];
       auto pshape = param_shape[p];
       for (int d = 0; d < D; d++) {
-        if (axis_mask_ & (1 << d)) {
+        if (axis_mask_ & (1_u64 << d)) {
           if (pshape[d] != 1) {
             throw std::invalid_argument(make_string("Parameter tensor must have extent 1 "
               "in reduced axes. Got:"

--- a/dali/kernels/normalize/normalize_gpu_test.cu
+++ b/dali/kernels/normalize/normalize_gpu_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ RandomDataShape(int num_samples, int ndim, int64_t max_volume,
       for (int d = 0; d < ndim; d++) {
         // when reducing samples in the batch, the non-reduced extents must be uniform
         // across all samples
-        sample_shape[d] = reduced_axes & (1 << d) || !reduce_batch || i == 0
+        sample_shape[d] = reduced_axes & (1_u64 << d) || !reduce_batch || i == 0
             ? shape_dist(rng)
             : sh.tensor_shape_span(0)[d];
       }
@@ -213,7 +213,7 @@ class NormalizeImplGPUTest<std::pair<Out, In>> : public ::testing::Test {
       param_shape_.resize(param_samples, ndim);
       for (int i = 0; i < param_samples; i++) {
         for (int d = 0; d < ndim; d++) {
-          bool reduced = axis_mask_ & (1 << d);
+          bool reduced = axis_mask_ & (1_u64 << d);
           param_shape_.tensor_shape_span(i)[d] = reduced ? 1 : data_shape_.tensor_shape_span(i)[d];
         }
       }

--- a/dali/kernels/reduce/reduce_cpu_test.cc
+++ b/dali/kernels/reduce/reduce_cpu_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -95,12 +95,12 @@ void TestStatelessReduction3D(bool mean, Preprocess pre, Postprocess post) {
 
   for (auto &axes : axes_sets) {
     TensorShape<> out_shape;
-    int reduction_mask = 0;
+    unsigned reduction_mask = 0;
     for (auto a : axes)
       reduction_mask |= (1 << a);
     int64_t den = 1;
     for (int d = 0; d < 3; d++) {
-      if (!(reduction_mask & (1 << d))) {
+      if (!(reduction_mask & (1u << d))) {
         out_shape.shape.push_back(in.shape[d]);
       } else {
         if (mean)

--- a/dali/kernels/reduce/reduce_drop_dims.h
+++ b/dali/kernels/reduce/reduce_drop_dims.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -198,7 +198,7 @@ struct DropDims {
       volumes[i] = vol_total;
       kept_volumes[i] = vol_kept;
       vol_total *= shape[i];
-      if ((axis_mask & (1 << i)) == 0) {
+      if ((axis_mask & (1u << i)) == 0) {
         vol_kept *= shape[i];
         kept_dims++;
       } else {
@@ -214,7 +214,7 @@ struct DropDims {
 
     for (int i = 0; i < d - 1; i++) {
       assert(volumes[i] > 1);  // simplification should make this impossible
-      if (axis_mask & (1 << i)) {
+      if (axis_mask & (1u << i)) {
         mod(nmod++, volumes[i]);
       } else {
         div(ndiv, volumes[i]);

--- a/dali/kernels/reduce/reduce_gpu_impl_test.cu
+++ b/dali/kernels/reduce/reduce_gpu_impl_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -225,7 +225,7 @@ TEST(ReduceImpl, TestCheckBatchReduce) {
   for (unsigned mask = 0; mask < 16; mask++) {
     axes.clear();
     for (int a = 0; a < 4; a++) {
-      if (mask & (1 << a))
+      if (mask & (1u << a))
         axes.push_back(a);
     }
     if ((mask & must_reduce) == must_reduce) {

--- a/dali/kernels/reduce/reduce_setup_utils.h
+++ b/dali/kernels/reduce/reduce_setup_utils.h
@@ -119,7 +119,7 @@ inline void CheckBatchReduce(const TensorListShape<> &tls, span<const int> axes)
   uint64_t mask = to_bit_mask(axes);
   SmallVector<int, DynamicTensorShapeContainer::static_size> non_reduced;
   for (int a = 0; a < tls.sample_dim(); a++) {
-    if (!(mask & (1 << a)))
+    if (!(mask & (1_u64 << a)))
       non_reduced.push_back(a);
   }
 

--- a/dali/kernels/reduce/reduce_test.h
+++ b/dali/kernels/reduce/reduce_test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ void RefReduce(const TensorView<StorageCPU, Out> &out, const TensorView<StorageC
 
   int ndim = strides.size();
   for (int i = 0, o = 0; i < ndim; i++) {
-    if (mask & (1 << i)) {
+    if (mask & (1_u64 << i)) {
       if (keep_dims) {
         assert(out.shape[o] == 1);
         o++;

--- a/dali/kernels/slice/slice_cpu.h
+++ b/dali/kernels/slice/slice_cpu.h
@@ -321,7 +321,7 @@ void SliceKernel(ExecutionEngine &exec_engine,
   }
 
   std::array<int, Dims> split_factor;
-  uint64_t skip_dim_mask = args.channel_dim >= 0 ? (1 << args.channel_dim) : 0;
+  uint64_t skip_dim_mask = args.channel_dim >= 0 ? (1_u64 << args.channel_dim) : 0;
   int nblocks = split_shape(split_factor, out_shape, req_nblocks, min_blk_sz, skip_dim_mask);
 
   if (nblocks == 1) {

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_cpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_cpu.h
@@ -255,7 +255,7 @@ void SliceFlipNormalizePermutePadKernel(
         int req_nblocks = -1) {
   // Parallelize
   std::array<int, Dims> split_factor;
-  uint64_t skip_dim_mask = args.channel_dim >= 0 ? (1 << args.channel_dim) : 0;
+  uint64_t skip_dim_mask = args.channel_dim >= 0 ? 1_u64 << args.channel_dim : 0;
   int nblocks = split_shape(split_factor, args.out_shape,
                             req_nblocks > 0 ? req_nblocks : exec_engine.NumThreads() * 8,
                             min_blk_sz, skip_dim_mask);

--- a/dali/operators/math/normalize/normalize.h
+++ b/dali/operators/math/normalize/normalize.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ class NormalizeBase : public Operator<Backend> {
     int dim = data_shape_.sample_dim();
     axes_.resize(dim);
     std::iota(axes_.begin(), axes_.end(), 0);
-    axis_mask_ = (1 << dim) - 1;
+    axis_mask_ = (1_u64 << dim) - 1;
     GetParamShapeFromAxes();
   }
 
@@ -233,18 +233,18 @@ class NormalizeBase : public Operator<Backend> {
   void SetAxisMask() {
     axis_mask_ = 0;
     for (auto axis : axes_)
-      axis_mask_ |= 1 << axis;
+      axis_mask_ |= 1_u64 << axis;
   }
 
   bool IsReducedAxis(int axis) const noexcept {
-    return axis_mask_ & (1 << axis);
+    return axis_mask_ & (1_u64 << axis);
   }
 
   bool ShouldCalcMean() const noexcept { return !has_tensor_mean_ && !has_scalar_mean_; }
   bool ShouldCalcStdDev() const noexcept { return !has_tensor_stddev_ && !has_scalar_stddev_; }
   bool IsFullReduction() const noexcept {
     int ndim = data_shape_.sample_dim();
-    return axis_mask_== ((1 << ndim) - 1);
+    return axis_mask_== ((1_u64 << ndim) - 1);
   }
 
  protected:
@@ -268,7 +268,7 @@ class NormalizeBase : public Operator<Backend> {
   int degrees_of_freedom_ = 0;  //!< For Bessel's correction
   DALIDataType input_type_ = DALI_NO_TYPE, output_type_ = DALI_FLOAT;
   std::vector<int> axes_;
-  int axis_mask_ = 0;
+  uint64_t axis_mask_ = 0;
 };
 
 }  // namespace dali

--- a/dali/operators/reader/loader/nemo_asr_loader.h
+++ b/dali/operators/reader/loader/nemo_asr_loader.h
@@ -81,7 +81,7 @@ class AsrSample {
     return *decoder_;
   }
 
-  int64_t index_;
+  int64_t index_ = 0;
   std::string text_;
   AudioMetadata audio_meta_;
   std::string audio_filepath_;  // for tensor metadata purposes

--- a/include/dali/util/half.hpp
+++ b/include/dali/util/half.hpp
@@ -1016,12 +1016,10 @@ namespace half_float
       assign(static_cast<float>(rhs));
     }
 
-    // Copy constructor overriding the one above
-    // It avoids half->float->half path
+    /// Trivial copy constructor.
 	HALF_CONSTEXPR
     CAFFE_UTIL_HD
-    half(const half& rhs) :
-      data_(rhs.data_) {}
+    half(const half &) = default;
 
 //		explicit half(float rhs) : data_(detail::float2half<round_style>(rhs)) {}
     CAFFE_UTIL_HD


### PR DESCRIPTION
#### Why we need this PR?
*Pick one, remove the rest*
- It fixes bugs in the size of bit masks
- It fixes uninitialized but readable member in AsrSample
- It makes `half` type trivially copyable

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Use proper literals `1_u64` or `1_uz` or `1u` when constructing bit masks
     * Make `half` copy constructor defaulted.
     * Initialize the index field in AsrSample with 0.
 - Affected modules and functionalities:
     * Reduction
     * Normalization
     * Nemo ASR reader
     * `half`
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests + coverity
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-2166
