### PR TITLE
Extend the video loader error message for vfr videos

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -379,7 +379,8 @@ VideoFile& VideoLoader::get_or_open_file(const std::string &filename) {
 
     DALI_ENFORCE(skip_vfr_check_ ||
       almost_equal(av_q2d(file.frame_base_), pkt.duration * av_q2d(file.stream_base_), 2),
-      "Variable frame rate videos are unsupported. Check failed for file: " + filename);
+      "Variable frame rate videos are unsupported. This heuristic can yield false positives. "
+      "The check can be disabled via the skip_vfr_check flag. Check failed for file: " + filename);
     av_packet_unref(&pkt);
 
     auto duration = stream->duration;


### PR DESCRIPTION
on how to disable the check in case of false positives

#### Why we need this PR?
- Refactoring to improve the documentation, in case other people stumble upon this in the future. See #3123 for an example.

#### What happened in this PR?
 - What solution was applied:
     *[ A few words mentioning the flag for skipping the vfr check were added ]*
 - Affected modules and functionalities:
     *[ No functionality was changed, only touched the video_loader ]*
 - Key points relevant for the review:
     *[ This is a very small PR, however I have little experience with DALI and e.g. style conventions ]*
 - Validation and testing:
     *[ TBH I did not even compile this :innocent:  ]*
 - Documentation (including examples):
     *[ N/A ]*


**JIRA TASK**: *[NA]*
