### PR TITLE
Revert change from python to Python_EXECUTABLE

### DIFF
--- a/dali/core/CMakeLists.txt
+++ b/dali/core/CMakeLists.txt
@@ -31,11 +31,10 @@ endforeach(incl_dir)
 separate_arguments(DEFAULT_COMPILER_INCLUDE UNIX_COMMAND  "${DEFAULT_COMPILER_INCLUDE}")
 
 if (NOT LINK_DRIVER)
-  find_package (Python COMPONENTS Interpreter)
   set(CUDA_GENERATED_STUB "${CMAKE_CURRENT_BINARY_DIR}/dynlink_cuda_gen.cc")
   add_custom_command(
       OUTPUT ${CUDA_GENERATED_STUB}
-      COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/stub_codegen.py --unique_prefix=Cuda --
+      COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/stub_codegen.py --unique_prefix=Cuda --
                   "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/cuda.json" ${CUDA_GENERATED_STUB}
                   "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/cuda.h" "-I${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                   # for some reason QNX fails with 'too many errors emitted' is this is not set
@@ -56,11 +55,10 @@ endif()
 list(FILTER DALI_CORE_SRCS EXCLUDE REGEX ".*dynlink_cuda.cc")
 
 if (BUILD_CUFILE)
-  find_package (Python COMPONENTS Interpreter)
   set(CUFILE_GENERATED_STUB "${CMAKE_CURRENT_BINARY_DIR}/dynlink_cufile_gen.cc")
   add_custom_command(
       OUTPUT ${CUFILE_GENERATED_STUB}
-      COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/stub_codegen.py --unique_prefix=Cufile --
+      COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/stub_codegen.py --unique_prefix=Cufile --
                   "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/cufile.json" ${CUFILE_GENERATED_STUB}
                   "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/cufile.h" "-I${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                   # for some reason QNX fails with 'too many errors emitted' is this is not set

--- a/dali/operators/reader/nvdecoder/CMakeLists.txt
+++ b/dali/operators/reader/nvdecoder/CMakeLists.txt
@@ -27,10 +27,9 @@ endforeach(incl_dir)
 separate_arguments(DEFAULT_COMPILER_INCLUDE UNIX_COMMAND  "${DEFAULT_COMPILER_INCLUDE}")
 
 set(NVCUVID_GENERATED_STUB "${CMAKE_CURRENT_BINARY_DIR}/dynlink_nvcuvid_gen.cc")
-find_package(Python COMPONENTS Interpreter)
 add_custom_command(
     OUTPUT ${NVCUVID_GENERATED_STUB}
-    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/stub_generator/stub_codegen.py --unique_prefix=Nvcuvid --
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/stub_generator/stub_codegen.py --unique_prefix=Nvcuvid --
                 "${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/stub_generator/nvcuvid.json" ${NVCUVID_GENERATED_STUB}
                 "${CMAKE_CURRENT_SOURCE_DIR}/nvcuvid.h" "-I${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                 "-I${CMAKE_SOURCE_DIR}/include" "-I${CMAKE_SOURCE_DIR}"

--- a/dali/util/CMakeLists.txt
+++ b/dali/util/CMakeLists.txt
@@ -55,10 +55,9 @@ if(BUILD_NVML)
 
   if (NOT LINK_DRIVER)
     set(NVML_GENERATED_STUB "${CMAKE_CURRENT_BINARY_DIR}/dynlink_nvml_gen.cc")
-    find_package (Python COMPONENTS Interpreter)
     add_custom_command(
         OUTPUT ${NVML_GENERATED_STUB}
-        COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/stub_codegen.py --unique_prefix=Nvml --
+        COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/stub_codegen.py --unique_prefix=Nvml --
                     "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/nvml.json" ${NVML_GENERATED_STUB}
                     "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/nvml.h" "-I${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
                     # for some reason QNX fails with 'too many errors emitted' is this is not set

--- a/tools/find_dali.cmake
+++ b/tools/find_dali.cmake
@@ -28,9 +28,8 @@
 # target_link_libraries(my_target ${DALI_LIBRARIES})
 ###################################################################
 function(find_dali DALI_INCLUDE_DIR_VAR DALI_LIB_DIR_VAR DALI_LIBRARIES_VAR)
-    find_package(Python COMPONENTS Interpreter)
     execute_process(
-            COMMAND ${Python_EXECUTABLE} -c "import nvidia.dali as dali; print(dali.sysconfig.get_include_dir(), end='')"
+            COMMAND python -c "import nvidia.dali as dali; print(dali.sysconfig.get_include_dir(), end='')"
             OUTPUT_VARIABLE DALI_INCLUDE_DIR
             RESULT_VARIABLE INCLUDE_DIR_RESULT)
 
@@ -39,7 +38,7 @@ function(find_dali DALI_INCLUDE_DIR_VAR DALI_LIB_DIR_VAR DALI_LIBRARIES_VAR)
     endif ()
 
     execute_process(
-            COMMAND ${Python_EXECUTABLE} -c "import nvidia.dali as dali; print(dali.sysconfig.get_lib_dir(), end='')"
+            COMMAND python -c "import nvidia.dali as dali; print(dali.sysconfig.get_lib_dir(), end='')"
             OUTPUT_VARIABLE DALI_LIB_DIR
             RESULT_VARIABLE LIB_DIR_RESULT)
 


### PR DESCRIPTION
- Python_EXECUTABLE points to the most recent python version
  available in the environment, not the default one used
  to install wheels. In the DALI case the build system relies
  on the availability of libclang and clang python bindings
  usually installed for the default python version, not the
  most recent one

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes xavier build failure

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Python_EXECUTABLE points to the most recent python version available in the environment, not the default one used to install wheels. In the DALI case the build system relies on the availability of libclang and clang python bindings usually installed for the default python version, not the most recent one
 - Affected modules and functionalities:
     cmake build system
 - Key points relevant for the review:
     NA
 - Validation and testing:
     CI run
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
