### PR TITLE
Fix allocation hint handling in CUDA VM resource

### DIFF
--- a/include/dali/core/mm/cuda_vm_resource.h
+++ b/include/dali/core/mm/cuda_vm_resource.h
@@ -331,22 +331,43 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
   void va_allocate(size_t min_size) {
     size_t va_size = std::max(next_pow2(min_size), initial_va_size_);
 
-    CUdeviceptr hint = {};
-    va_region *last_va = nullptr;
+    cuvm::CUMemAddressRange va;
+
+    SmallVector<CUdeviceptr, 3> hints;
+
     if (va_regions_.empty()) {
       // Calculate the hint address for the allocations for this device.
       // There's some not very significant base and different devices get
-      // address spaces separated by 2^40 - this should be quite enough.
-      hint = (device_ordinal_ + 1) * 0x10000000000u;
+      // address spaces separated by at least 2^40 - this should be quite enough.
+      hints = {
+        (device_ordinal_ +  1) * (1_u64 << 40),
+        (device_ordinal_ + 17) * (1_u64 << 40),
+        (device_ordinal_ + 33) * (1_u64 << 40),
+      };
     } else {
-      // Try to allocate after the last VA for this device
-      last_va = &va_regions_.back();
-      hint = last_va->address_range.end();
+      // Try to allocate after the last VA for this device or before the first
+      auto &first_va = va_regions_.front();
+      auto &last_va = va_regions_.back();
+      assert(!va_ranges_.empty());
+      va_size = 2 * va_ranges_.back().size();
+      hints = {
+        last_va.address_range.end(),
+        first_va.address_range.ptr() - va_size
+      };
     }
-    va_ranges_.push_back(cuvm::CUMemAddressRange::Reserve(va_size, 0, hint));
-    auto &va = va_ranges_.back();
 
-    va_add_region(va);
+    // Try to allocate at hinted locations...
+    for (auto hint : hints) {
+      try {
+        va = cuvm::CUMemAddressRange::Reserve(va_size, 0, hint);
+        break;
+      } catch (const std::bad_alloc &) {}
+    }
+    if (!va)  // ...hint failed - allocate anywhere
+      va = cuvm::CUMemAddressRange::Reserve(va_size, 0, 0);
+
+    va_ranges_.push_back(std::move(va));
+    va_add_region(va_ranges_.back());
     stat_va_add(va_size);
   }
 


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: allocation with a hint fails on some drivers

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Try more hints
     * Fall back to allocation without a hint when allocation with a hint fails
 - Affected modules and functionalities:
     * CUDA VM resource
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests apply
 - Documentation (including examples):
     * N/A

**JIRA TASK**: DALI-2033 (follow-up)
