### PR TITLE
Fix the lack of execution of variable batch size test

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -624,7 +624,8 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     }
     thread_pool_.RunAll();
 
-    for (auto &data : sample_data_) {
+    for (int i = 0; i < curr_batch_size; i++) {
+      SampleData &data = sample_data_[i];
       switch (data.method) {
         case DecodeMethod::Host:
           samples_host_.push_back(&data);

--- a/qa/TL0_python-self-test-core/test_body.sh
+++ b/qa/TL0_python-self-test-core/test_body.sh
@@ -3,7 +3,8 @@
 test_nose() {
     for test_script in $(ls test_pipeline*.py \
                             test_functional_api.py \
-                            test_backend_impl.py); do
+                            test_backend_impl.py \
+                            test_dali_variable_batch_size.py); do
         nosetests --verbose --attr '!slow,!pytorch' ${test_script}
     done
 }


### PR DESCRIPTION
- by mistake, only pytorch and optical flow tests are executed
  inside test_dali_variable_batch_size.py
- fixes access to non-existing samples in the image decoder
   when the batch size shrinks iteration to iteration

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a lack of execution of variable batch size test

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     by mistake, only pytorch and optical flow tests are executed inside test_dali_variable_batch_size.py
     fixes access to non-existing samples in the image decoder  when the batch size shrinks iteration to iteration
 - Affected modules and functionalities:
     test_dali_variable_batch_size.py
     nvjpeg_decoder_decoupled_api.h
 - Key points relevant for the review:
     NA
 - Validation and testing:
     tests are fixed
 - Documentation (including examples):
     NA


**JIRA TASK**: *[NA]*
