### PR TITLE
Add ability to pass arguments to generator function in external_source op

### DIFF
--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -69,20 +69,20 @@ class _CycleIter:
 
 
 class _CycleGenFunc:
-    def __init__(self, gen_func, mode, source_args={}):
+    def __init__(self, gen_func, mode, gen_func_args={}):
         self.source = gen_func
-        self.source_args = source_args
+        self.gen_func_args = gen_func_args
         self.signaling = (mode == "raise")
 
     def __iter__(self):
-        self.it = iter(self.source(**self.source_args))
+        self.it = iter(self.source(**self.gen_func_args))
         return self
 
     def __next__(self):
         try:
             return next(self.it)
         except StopIteration:
-            self.it = iter(self.source(**self.source_args))
+            self.it = iter(self.source(**self.gen_func_args))
             if self.signaling:
                 raise
             else:


### PR DESCRIPTION
Signed-off-by: Michał Szołucha <mszolucha@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*

- It adds new feature: Ability to provide argument list to a generator function in external_source op.

The need for this feature emerged, when I was migrating from old object-API to the new fn-API. Previously,
since the Pipeline class had a state, it was possible to use member variables as "arguments" in the generator function.
With the fn API we'd need to use global variables. However, using an additional argument to `external_source` operator, we can pass the arguments to the generator function within the `external_source`.


#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     Added an argument
 - Affected modules and functionalities:
     Python layer in the external_source operator
 - Key points relevant for the review:
     NA
 - Validation and testing:
     Yes
 - Documentation (including examples):
     Yes


**JIRA TASK**: *[Use DALI-XXXX or NA]*
