### PR TITLE
Add NumpyReader tutorial to the rendered documentation page

### DIFF
--- a/docs/examples/general/data_loading/index.rst
+++ b/docs/examples/general/data_loading/index.rst
@@ -9,3 +9,4 @@ Data Loading
    dataloading_recordio.ipynb
    dataloading_tfrecord.ipynb
    coco_reader.ipynb
+   numpy_reader.ipynb


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

#### Why we need this PR?
- It adds a missing notebook in the RST index

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     *Added a missing link to the new Numpy reader notebook*
 - Affected modules and functionalities:
     *Doc*
 - Key points relevant for the review:
     *NA*
 - Validation and testing:
     *NA*
 - Documentation (including examples):
     *NA*


**JIRA TASK**: *[NA]*
