### PR TITLE
Disable VMAsyncPool CrossStream test on incompatible platforms.

### DIFF
--- a/dali/core/mm/async_pool_test.cu
+++ b/dali/core/mm/async_pool_test.cu
@@ -419,6 +419,9 @@ TEST(MM_VMAsyncPool, MultiStreamRandomWithGPUHogs) {
 }
 
 TEST(MM_VMAsyncPool, CrossStream) {
+  if (!cuvm::IsSupported())
+    GTEST_SKIP() << "Virtual memory management API is not supported on this machine.";
+
   async_pool_resource<memory_kind::device, cuda_vm_resource> pool;
 
   vector<std::thread> threads;


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: attempt to run a VMM dependent test on incompatible systems

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Skip if not supported
 - Affected modules and functionalities:
     * VM AsyncPool test
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Existing tests apply
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
