### PR TITLE
Add check of strerror_r return value in CUFile HandleIOError

### DIFF
--- a/dali/util/std_cufile.cc
+++ b/dali/util/std_cufile.cc
@@ -107,7 +107,9 @@ void StdCUFileStream::HandleIOError(int64 ret) const {
     std::string errmsg(256, '\0');
     int e = errno;
     auto ret = strerror_r(e, &errmsg[0], errmsg.size());
-    DALI_ENFORCE(ret == 0, make_string("Unknown CUFile error: ", e));
+    if (ret != 0) {
+      DALI_FAIL(make_string("Unknown CUFile error: ", e));
+    }
     DALI_FAIL(
         make_string("CUFile read failed for file ", path_, " with error (", e, "): ", errmsg));
   } else {

--- a/dali/util/std_cufile.cc
+++ b/dali/util/std_cufile.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -106,7 +106,8 @@ void StdCUFileStream::HandleIOError(int64 ret) const {
   if (ret == -1) {
     std::string errmsg(256, '\0');
     int e = errno;
-    strerror_r(e, &errmsg[0], errmsg.size());
+    auto ret = strerror_r(e, &errmsg[0], errmsg.size());
+    DALI_ENFORCE(ret == 0, make_string("Unknown CUFile error: ", e));
     DALI_FAIL(
         make_string("CUFile read failed for file ", path_, " with error (", e, "): ", errmsg));
   } else {


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds check of strerror_r return value in CUFile HandleIOError

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds a check of strerror_r return value in CUFile HandleIOError
 - Affected modules and functionalities:
     std_cufile.cc
 - Key points relevant for the review:
     error message wording
 - Validation and testing:
     CI test run
 - Documentation (including examples):
     NA


**JIRA TASK**: *[DALI-2174]*
