### PR TITLE
Install libcufile (for GDS) as a part of the cuda base build step

### DIFF
--- a/docker/Dockerfile.cuda114.x86_64.deps
+++ b/docker/Dockerfile.cuda114.x86_64.deps
@@ -10,13 +10,14 @@ RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.4.0/local_ins
     rm -f cuda_*.run;
 
 RUN NVJPEG2K_VERSION=0.2.0 && \
+    CUFILE_VERSION=1.0.0 && \
     apt-get update && \
     apt-get install wget software-properties-common -y && \
     wget -qO - https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub | apt-key add - && \
     add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /" && \
     apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub && \
     apt-get update && \
-    apt-get install libnvjpeg2k0 libnvjpeg2k-dev -y && \
+    apt-get install libnvjpeg2k0 libnvjpeg2k-dev libcufile-dev-11-4 -y && \
     cp /usr/include/nvjpeg2k* /usr/local/cuda/include/ && \
     cp /usr/lib/x86_64-linux-gnu/libnvjpeg2k* /usr/local/cuda/lib64/ && \
     rm -rf /var/lib/apt/lists/*

--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -173,7 +173,8 @@ disable them.
    | (Optional) |lmdb link|_                | The currently supported version can be check |dali_deps link|_ repository.                  |
    +----------------------------------------+---------------------------------------------------------------------------------------------+
    | (Optional) |gds link|_                 | Only libcufile is required for the build process, and the installed header needs to land    |
-   |                                        | in `/usr/local/cuda/include` directory.                                                     |
+   |                                        | in `/usr/local/cuda/include` directory. For CUDA 11.4 it can be installed as a part of CUDA |
+   |                                        | toolkit.                                                                                    |
    +----------------------------------------+---------------------------------------------------------------------------------------------+
    | One or more of the following Deep Learning frameworks:                                                                               |
    |      * |mxnet link|_ ``mxnet-cu90`` or later                                                                                         |


### PR DESCRIPTION
Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It adds installation of libcufile (for GDS) as a part of the cuda base build step

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     adds installation of libcufile (for GDS) as a part of the cuda base build step
 - Affected modules and functionalities:
     Dockerfile.cuda114.x86_64.deps
 - Key points relevant for the review:
     NA
 - Validation and testing:
     current test applies
 - Documentation (including examples):
     compilation guide has been updated


**JIRA TASK**: *[NA]*
