### PR TITLE
Add support for functools.partial in ExternalSource.

### DIFF
--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -15,8 +15,8 @@
 # custom wrappers around ops
 from nvidia.dali import backend as _b
 import inspect
+import functools
 import nvidia.dali.types
-
 
 def _get_batch_shape(data):
     if isinstance(data, (list, tuple, _b.TensorListCPU, _b.TensorListGPU)):
@@ -222,9 +222,14 @@ def _is_generator_function(x):
     where __call__ is a generator function"""
     if inspect.isgeneratorfunction(x):
         return True
+    if isinstance(x, functools.partial):
+        return _is_generator_function(x.func)
+
     if x is None or inspect.isfunction(x) or inspect.ismethod(x):
         return False
     call = getattr(x, "__call__", None)
+    if call == x:
+        return False
     return _is_generator_function(call)
 
 def _cycle_enabled(cycle):

--- a/dali/test/python/test_external_source_impl.py
+++ b/dali/test/python/test_external_source_impl.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import numpy as np
 from nose.tools import assert_raises
 from test_utils import check_output
 import random
+import functools
 from collections import Iterable
 datapy = np
 
@@ -419,6 +420,21 @@ def test_external_source_gen_function_cycle():
             yield [make_array([i + 1.5], dtype=datapy.float32)]
 
     pipe.set_outputs(fn.external_source(gen, cycle = True))
+    pipe.build()
+
+    for _ in range(3):
+        for i in range(5):
+            check_output(pipe.run(), [np.array([i + 1.5], dtype=np.float32)])
+
+
+def test_external_source_gen_function_partial():
+    pipe = Pipeline(1, 3, 0)
+
+    def gen(base):
+        for i in range(5):
+            yield [make_array([i + base], dtype=datapy.float32)]
+
+    pipe.set_outputs(fn.external_source(functools.partial(gen, 1.5), cycle = True))
     pipe.build()
 
     for _ in range(3):


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

#### Why we need this PR?
*Pick one, remove the rest*
- It fixes a bug: infinite recursion when `functools.partial` is passed to ExternalSource
- It adds new feature: recognize partial invocations of generator functions

#### What happened in this PR?
*Fill relevant points, put NA otherwise. Replace anything inside []*
 - What solution was applied:
     * Check whether a callable is `functools.partial` and if so, use its `func` field instead to check if it's a generator function
     * Prevent recursion when `__call__` field points to self
 - Affected modules and functionalities:
     * External source Python wrapper
 - Key points relevant for the review:
     * N/A
 - Validation and testing:
     * Python test
 - Documentation (including examples):
     * N/A

**JIRA TASK**: N/A
