### PR TITLE
Add deferred deallocation to `cuda_vm_resource`.

### DIFF
--- a/dali/core/mm/cuda_vm_resource_test.cc
+++ b/dali/core/mm/cuda_vm_resource_test.cc
@@ -188,6 +188,7 @@ class VMResourceTest : public ::testing::Test {
     void *p2 = res.allocate(block_size);  // allocate another block
     res.deallocate(p2, block_size);       // now free the second block
     res.flush_deferred();
+    res.flush_deferred();
     auto &region = res.va_regions_[0];
     EXPECT_EQ(region.available_blocks, 1);
     EXPECT_EQ(region.mapped.find(false), 2);    // 2 mapped blocks
@@ -206,6 +207,7 @@ class VMResourceTest : public ::testing::Test {
     }
     res.deallocate(p1, block_size);
     res.deallocate(p3, 2 * block_size);
+    res.flush_deferred();
     res.flush_deferred();
     EXPECT_EQ(region.available_blocks, 3);
   }
@@ -318,6 +320,7 @@ TEST_F(VMResourceTest, RandomAllocations) {
   }
   allocs.clear();
 
+  pool.flush_deferred();
   pool.flush_deferred();
 
   auto stat = pool.get_stat();

--- a/dali/core/mm/cuda_vm_resource_test.cc
+++ b/dali/core/mm/cuda_vm_resource_test.cc
@@ -28,7 +28,7 @@ namespace test {
 class VMResourceTest : public ::testing::Test {
  public:
   void TestAlloc() {
-    cuda_vm_resource res;
+    cuda_vm_resource_base res;
     res.block_size_ = 32 << 20;  // fix the block size at 32 MiB for this test
     const size_t size1 = 100 << 20;  // used for first three allocations
     const size_t size4 = 150 << 20;  // used for the fourth allocation
@@ -187,6 +187,7 @@ class VMResourceTest : public ::testing::Test {
     void *p1 = res.allocate(block_size);  // allocate one block
     void *p2 = res.allocate(block_size);  // allocate another block
     res.deallocate(p2, block_size);       // now free the second block
+    res.flush_deferred();
     auto &region = res.va_regions_[0];
     EXPECT_EQ(region.available_blocks, 1);
     EXPECT_EQ(region.mapped.find(false), 2);    // 2 mapped blocks
@@ -204,7 +205,8 @@ class VMResourceTest : public ::testing::Test {
       }
     }
     res.deallocate(p1, block_size);
-    res.deallocate(p2, 2 * block_size);
+    res.deallocate(p3, 2 * block_size);
+    res.flush_deferred();
     EXPECT_EQ(region.available_blocks, 3);
   }
 
@@ -315,6 +317,8 @@ TEST_F(VMResourceTest, RandomAllocations) {
     dealloc_time += t1 - t0;
   }
   allocs.clear();
+
+  pool.flush_deferred();
 
   auto stat = pool.get_stat();
   print(std::cerr,

--- a/include/dali/core/mm/cuda_vm_resource.h
+++ b/include/dali/core/mm/cuda_vm_resource.h
@@ -90,7 +90,7 @@ class cuda_vm_resource_base : public memory_resource<memory_kind::device> {
   void synchronize(span<const dealloc_params> params) {
     assert(device_ordinal_ >= 0 && "synchronize called before the resource initialization");
     for (auto &p : params) {
-      if (p.sync_device >= 0 && p.sync_device < device_ordinal_)
+      if (p.sync_device >= 0 && p.sync_device != device_ordinal_)
         throw std::invalid_argument(
           "Cannot synchronize with a different device than used by this resource");
     }
@@ -715,6 +715,10 @@ class cuda_vm_resource : public deferred_dealloc_resource<cuda_vm_resource_base>
 };
 
 namespace detail {
+
+template <>
+struct can_merge<cuda_vm_resource_base> : std::true_type {};
+
 template <>
 struct can_merge<cuda_vm_resource> : std::true_type {};
 

--- a/include/dali/core/mm/cuda_vm_resource.h
+++ b/include/dali/core/mm/cuda_vm_resource.h
@@ -28,6 +28,7 @@
 #include "dali/core/bitmask.h"
 #include "dali/core/spinlock.h"
 #include "dali/core/device_guard.h"
+#include "dali/core/mm/detail/deferred_dealloc.h"
 
 namespace dali {
 namespace mm {
@@ -36,11 +37,11 @@ namespace test {
 class VMResourceTest;
 }  // namespace test
 
-class cuda_vm_resource : public memory_resource<memory_kind::device> {
+class cuda_vm_resource_base : public memory_resource<memory_kind::device> {
  public:
-  explicit cuda_vm_resource(int device_ordinal = -1,
-                            size_t block_size = 0,
-                            size_t initial_va_size = size_t(4) << 30) {
+  explicit cuda_vm_resource_base(int device_ordinal = -1,
+                                 size_t block_size = 0,
+                                 size_t initial_va_size = size_t(4) << 30) {
     device_ordinal_ = device_ordinal;
     if (block_size != 0 && !is_pow2(block_size))
       throw std::invalid_argument("block_size must be a power of 2");
@@ -51,7 +52,7 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
   }
   using mem_handle_t = CUmemGenericAllocationHandle;
 
-  ~cuda_vm_resource() {
+  ~cuda_vm_resource_base() {
     purge();
   }
 
@@ -69,7 +70,32 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
   }
 
   void deallocate_no_sync(void *ptr, size_t size, size_t alignment) {
-    deallocate_impl(ptr, size, alignment, false);
+    deallocate_impl(ptr, size, alignment, false, true);
+  }
+
+  /**
+   * @brief Deallocates multiple blocks of memory, but synchronizes only once
+   *
+   * @remarks This function must not use do_deallocate virtual function.
+   */
+  void bulk_deallocate(span<const dealloc_params> params) {
+    if (!params.empty()) {
+      synchronize(params);
+      lock_guard guard(pool_lock_);
+      for (const auto &p : params)
+        deallocate_impl(p.ptr, p.bytes, p.alignment, false, false);
+    }
+  }
+
+  void synchronize(span<const dealloc_params> params) {
+    assert(device_ordinal_ >= 0 && "synchronize called before the resource initialization");
+    for (auto &p : params) {
+      if (p.sync_device >= 0 && p.sync_device < device_ordinal_)
+        throw std::invalid_argument(
+          "Cannot synchronize with a different device than used by this resource");
+    }
+    DeviceGuard dg(device_ordinal_);
+    CUDA_CALL(cudaDeviceSynchronize());
   }
 
   struct Stat {
@@ -102,6 +128,50 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
   void clear_stat() {
     lock_guard pool_guard(pool_lock_);
     stat_ = {};
+  }
+
+ protected:
+  bool defer_dealloc_ = false;
+  constexpr bool deferred_dealloc_enabled() const noexcept { return defer_dealloc_; }
+  static constexpr int deferred_dealloc_max_outstanding() { return 16; }
+
+  virtual void flush_deferred() {}
+
+  void do_deallocate(void *ptr, size_t size, size_t alignment) override {
+    deallocate_impl(ptr, size, alignment, true, true);
+  }
+
+  void *do_allocate(size_t size, size_t alignment) override {
+    if (size == 0)
+      return nullptr;
+    adjust_params(size, alignment);
+    std::unique_lock<pool_lock_t> pool_guard(pool_lock_);
+    // try to get a free region that's already mapped
+    void *ptr = try_get_mapped(size, alignment);
+    if (ptr) {
+      stat_add_allocation(size);
+      return ptr;
+    }
+    if (deferred_dealloc_enabled()) {
+      pool_guard.unlock();
+      flush_deferred();
+      pool_guard.lock();
+      ptr = try_get_mapped(size, alignment);
+      if (ptr) {
+        stat_add_allocation(size);
+        return ptr;
+      }
+    }
+    DeviceGuard dg(device_ordinal_);
+    mem_lock_guard mem_guard(mem_lock_);
+    void *va = get_va(size, alignment);
+    map_storage(va, size);
+    ptr = free_mapped_.get_specific_block(va, size);
+    assert(ptr == va);
+    stat_take_free(size);
+    mark_as_unavailable(ptr, size);
+    stat_add_allocation(size);
+    return ptr;
   }
 
  private:
@@ -185,7 +255,7 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
       available_blocks++;
     }
 
-    cuvm::CUMem unmap_block(ptrdiff_t block_idx) {
+    cuvm::CUMem unmap_block(int block_idx) {
       assert(available[block_idx]);
       cuvm::Unmap(block_dptr(block_idx), block_size);
       cuvm::CUMem mem({mapping[block_idx], block_size });
@@ -255,6 +325,7 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
         available_blocks += flipped;
       else
         available_blocks -= flipped;
+      assert(available_blocks >= 0 && available_blocks <= num_blocks());
       available.fill(start_blk, end_blk, availability);
     }
 
@@ -278,32 +349,13 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
     size = align_up(size, alignment);
   }
 
-  void *do_allocate(size_t size, size_t alignment) override {
-    if (size == 0)
-      return nullptr;
-    adjust_params(size, alignment);
-    lock_guard pool_guard(pool_lock_);
-    // try to get a free region that's already mapped
-    void *ptr = try_get_mapped(size, alignment);
-    if (ptr) {
-      stat_add_allocation(size);
-      return ptr;
-    }
-    DeviceGuard dg(device_ordinal_);
-    mem_lock_guard mem_guard(mem_lock_);
-    ptr = get_va(size, alignment);
-    map_storage(ptr, size);
-    ptr = try_get_mapped(size, alignment);
-    assert(ptr != nullptr);
-    stat_add_allocation(size);
-    return ptr;
-  }
-
   void *try_get_mapped(size_t size, size_t alignment) {
     char *ptr = static_cast<char*>(free_mapped_.get(size, alignment));
     if (ptr) {
       stat_take_free(size);
-      free_va_.get_specific_block(ptr, ptr + size);
+      auto *va = free_va_.get_specific_block(ptr, size);
+      (void)va;
+      assert(va == ptr);
       mark_as_unavailable(ptr, size);
       return ptr;
     } else {
@@ -417,19 +469,17 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
     free_va_.put(reinterpret_cast<void*>(va.ptr()), va.size());
   }
 
-  void do_deallocate(void *ptr, size_t size, size_t alignment) override {
-    deallocate_impl(ptr, size, alignment, true);
-  }
-
-  void deallocate_impl(void *ptr, size_t size, size_t alignment, bool sync) {
+  void deallocate_impl(void *ptr, size_t size, size_t alignment, bool sync, bool lock) {
     if (size == 0)
       return;
     adjust_params(size, alignment);
-    DeviceGuard dg(device_ordinal_);
     if (sync) {
+      DeviceGuard dg(device_ordinal_);
       CUDA_CALL(cudaDeviceSynchronize());
     }
-    lock_guard pool_guard(pool_lock_);
+    std::unique_lock<pool_lock_t> pool_guard(pool_lock_, std::defer_lock);
+    if (lock)
+      pool_guard.lock();
     stat_add_deallocation(size);
     free_mapped_.put(ptr, size);
     free_va_.put(ptr, size);
@@ -460,6 +510,7 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
    */
   void mark_as_available(void *ptr, size_t size) {
     char *cptr = static_cast<char *>(ptr);
+    assert(free_mapped_.contains(cptr, cptr + size));
 
     char *start = nullptr, *end = nullptr;
     if (!is_block_aligned(cptr)) {
@@ -522,6 +573,7 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
     };
     SmallVector<block_range, 8> to_map;
     int blocks_to_map = 0;
+
     for (int block_idx = start_block_idx; block_idx < end_block_idx; ) {
       int next_unmapped = region->mapped.find(false, block_idx);
       if (next_unmapped >= end_block_idx)
@@ -552,6 +604,7 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
       stat_add_free(range_size);
     }
     mark_as_available(ptr, size);
+    assert(free_mapped_.contains(ptr, static_cast<char*>(ptr) + size));
     assert(i == blocks_to_map);
   }
 
@@ -575,7 +628,7 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
           out.push_back(r.unmap_block(block_idx));
           stat_.total_unmaps++;
           char *ptr = r.block_ptr<char>(block_idx);
-          free_mapped_.get_specific_block(ptr, ptr + block_size_);
+          free_mapped_.get_specific_block(ptr, block_size_);
           stat_take_free(block_size_);
           count--;
         }
@@ -605,7 +658,7 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
   friend class test::VMResourceTest;
 
   coalescing_free_tree free_mapped_, free_va_;
-  using pool_lock_t = spinlock;
+  using pool_lock_t = std::mutex;
   using mem_lock_t = std::mutex;
   mutable pool_lock_t pool_lock_;
   mutable mem_lock_t mem_lock_;
@@ -646,6 +699,18 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
 
   void stat_va_add(size_t size) {
     stat_.allocated_va += size;
+  }
+};
+
+class cuda_vm_resource : public deferred_dealloc_resource<cuda_vm_resource_base> {
+ public:
+  using base = deferred_dealloc_resource<cuda_vm_resource_base>;
+
+  explicit cuda_vm_resource(int device_ordinal = -1,
+                            size_t block_size = 0,
+                            size_t initial_va_size = size_t(4) << 30)
+  : base(device_ordinal, block_size, initial_va_size) {
+    defer_dealloc_ = true;
   }
 };
 

--- a/include/dali/core/mm/detail/deferred_dealloc.h
+++ b/include/dali/core/mm/detail/deferred_dealloc.h
@@ -1,0 +1,189 @@
+// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef DALI_CORE_MM_DETAIL_DEFERRED_DEALLOC_H_
+#define DALI_CORE_MM_DETAIL_DEFERRED_DEALLOC_H_
+
+#include <cstddef>
+#include <thread>
+#include <mutex>
+#include "dali/core/mm/detail/util.h"
+#include "dali/core/mm/memory_resource.h"
+#include "dali/core/small_vector.h"
+
+namespace dali {
+namespace mm {
+
+struct dealloc_params {
+  int sync_device = -1;  // -1 == current device
+  void *ptr = nullptr;
+  size_t bytes = 0, alignment = 0;
+};
+
+inline bool use_deferred_deallocation(...) {
+  return true;
+}
+
+/**
+ * @brief A resource with deferred deallocation
+ *
+ * The BaseResource must satisfy the following concept:
+ *
+ * ```
+ * public:
+ *   virtual void flush_deferred();
+ *   void bulk_deallocate(span<const dealloc_params> deallocs);
+ *   bool deferred_dealloc_enabled() const;
+ *   int deferred_dealloc_max_outstanding() const;
+ * ```
+ */
+template <typename BaseResource>
+class deferred_dealloc_resource : public BaseResource {
+ public:
+  using base = BaseResource;
+  using base::base;
+
+  ~deferred_dealloc_resource() {
+    if (worker_.joinable()) {
+      stop();
+      worker_.join();
+    }
+    this->bulk_deallocate(make_span(deallocs_[0]));
+    this->bulk_deallocate(make_span(deallocs_[1]));
+  }
+
+  void deferred_deallocate(void *ptr,
+                           size_t bytes,
+                           size_t alignment = alignof(std::max_align_t),
+                           int device_id = -1) {
+    if (!ptr || !bytes)
+      return;  // nothing to do
+    if (device_id < 0) {
+      CUDA_CALL(cudaGetDevice(&device_id));
+    }
+
+    {
+      std::lock_guard<std::mutex> g(mtx_);
+      deallocs_[queue_idx_].push_back({device_id, ptr, bytes, alignment});
+
+      if (!started_)
+        start_worker();
+    }
+    cv_.notify_one();
+  }
+
+
+  /**
+   * @brief The number of outstanding deferred deallocations
+   */
+  int deferred_dealloc_count() const {
+    return deallocs_[0].size() + deallocs_[1].size();
+  }
+
+  /**
+   * @brief Waits until currently scheduled deallocations are flushed.
+   *
+   * This function waits until the worker notifies that it's completed flushing
+   * current queue (there are two queues). It doesn't wait for the other queue
+   * nor prevent new deallocations from being scheduled.
+   *
+   * This method overrides the default no-op function from BaseResource.
+   */
+  void flush_deferred() override {
+    if (!no_pending_deallocs()) {
+      std::unique_lock<std::mutex> ulock(mtx_);
+      if (!no_pending_deallocs())
+        ready_.wait(ulock);
+    }
+  }
+
+ protected:
+  // exposed for testing
+  bool no_pending_deallocs() const noexcept {
+    return deallocs_[0].empty() && deallocs_[1].empty();
+  }
+
+ private:
+  using dealloc_queue = SmallVector<dealloc_params, 16>;
+
+  void *do_allocate(size_t bytes, size_t alignment) override {
+    if (this->deferred_dealloc_enabled()) {
+      if (this->deferred_dealloc_count() > this->deferred_dealloc_max_outstanding())
+        this->flush_deferred();
+    }
+    return base::do_allocate(bytes, alignment);
+  }
+
+  void do_deallocate(void *ptr, size_t bytes, size_t alignment) override {
+    if (this->deferred_dealloc_enabled())
+      this->deferred_deallocate(ptr, bytes, alignment);
+    else
+      base::do_deallocate(ptr, bytes, alignment);
+  }
+
+
+  void start_worker() {
+    worker_ = std::thread([this]() {
+      run();
+    });
+    started_ = true;
+  }
+
+  void run() {
+    std::unique_lock<std::mutex> ulock(mtx_);
+    while (!is_stopped()) {
+      cv_.wait(ulock, [&](){ return stopped_ || !deallocs_[queue_idx_].empty(); });
+      if (is_stopped())
+        break;
+      auto &to_free = deallocs_[queue_idx_];
+      queue_idx_ = 1 - queue_idx_;
+      ulock.unlock();
+      this->bulk_deallocate(make_span(to_free));
+      to_free.clear();
+      ready_.notify_one();
+      ulock.lock();
+    }
+  }
+
+  void stop() {
+    stopped_ = true;
+    cv_.notify_all();
+  }
+
+  bool is_stopped() const noexcept { return stopped_; }
+
+  std::thread worker_;
+  std::mutex mtx_;
+  std::condition_variable cv_, ready_;
+  dealloc_queue deallocs_[2];
+  int queue_idx_ = 0;
+  bool started_ = false;
+  bool stopped_ = false;
+};
+
+namespace detail {
+
+template <typename T>
+struct can_merge;
+
+template <typename BaseResource>
+struct can_merge<deferred_dealloc_resource<BaseResource>> : can_merge<BaseResource> {};
+
+}  // namespace detail
+
+}  // namespace mm
+}  // namespace dali
+
+#endif  // DALI_CORE_MM_DETAIL_DEFERRED_DEALLOC_H_

--- a/include/dali/core/mm/detail/free_list.h
+++ b/include/dali/core/mm/detail/free_list.h
@@ -603,6 +603,15 @@ class coalescing_free_tree {
   }
 
   /**
+   * @brief Retrieves a specific memory region from the free tree.
+   *
+   * If the block is not covered by the free tree, nullptr is returned.
+   */
+  void *get_specific_block(void *start, size_t size) {
+    return get_specific_block(start, static_cast<char*>(start) + size);
+  }
+
+  /**
    * @brief Removes given memory range from the tree, if present
    *
    * This function checks if the tree contains given address range and if it does,
@@ -614,7 +623,7 @@ class coalescing_free_tree {
    * @return True, if the block was successfully removed from the tree.
    */
   bool remove_if_in_list(void *base, size_t size) {
-    return get_specific_block(base, static_cast<char*>(base)+size) != nullptr;
+    return get_specific_block(base, size) != nullptr;
   }
 
   /**
@@ -631,6 +640,9 @@ class coalescing_free_tree {
     auto prev = next != by_addr_.begin() ? std::prev(next) : next;
     bool join_prev = prev != next && prev->first + prev->second == addr;
     bool join_next = next != by_addr_.end() && next->first == addr + size;
+
+    assert(next == by_addr_.end() || next->first >= addr + size);
+    assert(prev == next || prev->first + prev->second <= addr);
 
     if (join_prev) {
       by_size_.erase({ prev->second, prev->first });
@@ -754,10 +766,20 @@ class best_fit_free_tree {
   }
 
   /**
+   * @brief Retrieves a specific memory region from the free tree.
+   *
+   * If the exact block is not found, the function fails - no splitting occurs
+   */
+  void *get_specific_block(void *start, size_t size) {
+    return get_specific_block(start, static_cast<char*>(start) + size);
+  }
+
+
+  /**
    * @brief Removes a block from the tree if _exactly_ this block is free - no splitting occurs
    */
   bool remove_if_in_list(void *base, size_t size) {
-    return get_specific_block(base, static_cast<char*>(base)+size) != nullptr;
+    return get_specific_block(base, size) != nullptr;
   }
 
   detail::pooled_set<std::pair<size_t, char *>, true> by_size_;

--- a/include/dali/core/mm/pool_resource.h
+++ b/include/dali/core/mm/pool_resource.h
@@ -405,6 +405,9 @@ namespace detail {
 template <memory_kind kind, typename Context, class FreeList, class LockType>
 struct can_merge<pool_resource_base<kind, Context, FreeList, LockType>> : can_merge<FreeList> {};
 
+template <memory_kind kind, typename Context, class FreeList, class LockType>
+struct can_merge<deferred_dealloc_pool<kind, Context, FreeList, LockType>> : can_merge<FreeList> {};
+
 }  // namespace detail
 
 }  // namespace mm


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [x] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [x] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
* Factor out deferred dealloction from pool resource to a standalone file.
* Add deferred deallocation to `cuda_vm_resource`.
* Add more asserts to `free_tree`.
* Improve free_tree API
* Flush deallocations in tests, where necessary.

#### Additional information
- Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [x] Existing tests apply (with adjustments)
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [x] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2190
<!--- DALI-XXXX or NA --->
