### PR TITLE
Disable NVJPEG HW decoder for driver < 455 due to performance reason

### DIFF
--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -166,6 +166,9 @@ with *OpenCV* or other specific libraries, such as *libtiff*.
 
 If used with a ``mixed`` backend, and the hardware is available, the operator will use
 a dedicated hardware decoder.
+
+.. warning::
+  Due to performance reasons, hardware decoder is disabled for driver < 455.x
 
 The output of the decoder is in *HWC* layout.
 

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -101,62 +101,65 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     // disable HW decoder for drivers < 455.x as the memory pool for it is not available
     // and multi GPU performance is far from perfect due to frequent memory allocations
 #if NVML_ENABLED
-    char version[80];
-    CUDA_CALL(nvmlInitChecked());
-    CUDA_CALL(nvmlSystemGetDriverVersion(version, sizeof version));
+      char version[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE];
+      CUDA_CALL(nvmlInitChecked());
+      CUDA_CALL(nvmlSystemGetDriverVersion(version, sizeof version));
 
-    float driverVersion = 0;
-    driverVersion = std::stof(version);
-    if (driverVersion < 455) {
-      try_init_hw_decoder = false,
-      hw_decoder_load_ = 0;
-      NVJPEG_CALL(nvjpegDestroy(handle_));
-      LOG_LINE << "NVJPEG_BACKEND_HARDWARE is disabled due to performance reason" << std::endl;
-      NVJPEG_CALL(nvjpegCreateSimple(&handle_));
-      DALI_WARN("Due to performance reason HW NVJPEG decoder is disbaled for the driver "
-                "older than 455.x");
-    }
+      float driverVersion = 0;
+      driverVersion = std::stof(version);
+      if (driverVersion < 455) {
+        try_init_hw_decoder = false,
+        hw_decoder_load_ = 0;
+        NVJPEG_CALL(nvjpegDestroy(handle_));
+        LOG_LINE << "NVJPEG_BACKEND_HARDWARE is disabled due to performance reason" << std::endl;
+        NVJPEG_CALL(nvjpegCreateSimple(&handle_));
+        DALI_WARN("Due to performance reason HW NVJPEG decoder is disbaled for the driver "
+                  "older than 455.x");
+      } else {
 #endif
-      LOG_LINE << "Using NVJPEG_BACKEND_HARDWARE" << std::endl;
-      NVJPEG_CALL(nvjpegJpegStateCreate(handle_, &state_hw_batched_));
-      hw_decoder_images_staging_.set_pinned(true);
-      hw_decoder_images_staging_.SetGrowthFactor(2);
-      // assume close the worst case size 300kb per image
-      auto shapes = uniform_list_shape(CalcHwDecoderBatchSize(hw_decoder_load_, max_batch_size_),
-                                       TensorShape<1>{300*1024});
-      hw_decoder_images_staging_.Resize(shapes, TypeInfo::Create<uint8_t>());
+        LOG_LINE << "Using NVJPEG_BACKEND_HARDWARE" << std::endl;
+        NVJPEG_CALL(nvjpegJpegStateCreate(handle_, &state_hw_batched_));
+        hw_decoder_images_staging_.set_pinned(true);
+        hw_decoder_images_staging_.SetGrowthFactor(2);
+        // assume close the worst case size 300kb per image
+        auto shapes = uniform_list_shape(CalcHwDecoderBatchSize(hw_decoder_load_, max_batch_size_),
+                                        TensorShape<1>{300*1024});
+        hw_decoder_images_staging_.Resize(shapes, TypeInfo::Create<uint8_t>());
 #if defined(NVJPEG_PREALLOCATE_API)
-      // call nvjpegDecodeBatchedPreAllocate to use memory pool for HW decoder even if hint is 0
-      // due to considerable performance benefit - >20% for 8GPU training
-      auto preallocate_width_hint = spec.GetArgument<int>("preallocate_width_hint");
-      auto preallocate_height_hint = spec.GetArgument<int>("preallocate_height_hint");
-      // make sure it is not negative if provided
-      DALI_ENFORCE((!spec.HasArgument("preallocate_width_hint") ||
-                      preallocate_width_hint >= 0) &&
-                   (!spec.HasArgument("preallocate_height_hint") ||
-                      preallocate_height_hint >= 0),
-                   make_string("Provided preallocate_width_hint=", preallocate_width_hint, ", and ",
-                   "preallocate_height_hint=", preallocate_height_hint, " should not be ",
-                   "negative."));
-      LOG_LINE << "Using NVJPEG_PREALLOCATE_API" << std::endl;
-      // for backward compatibility we need to accept 0 as a hint, but nvJPEG return an error
-      // when such value is provided
-      preallocate_width_hint = preallocate_width_hint ? preallocate_width_hint : 1;
-      preallocate_height_hint = preallocate_height_hint ? preallocate_height_hint : 1;
-      NVJPEG_CALL(nvjpegDecodeBatchedPreAllocate(
-        handle_,
-        state_hw_batched_,
-        CalcHwDecoderBatchSize(hw_decoder_load_, max_batch_size_),
-        preallocate_width_hint,
-        preallocate_height_hint,
-        NVJPEG_CSS_444,
-        GetFormat(output_image_type_)));
+        // call nvjpegDecodeBatchedPreAllocate to use memory pool for HW decoder even if hint is 0
+        // due to considerable performance benefit - >20% for 8GPU training
+        auto preallocate_width_hint = spec.GetArgument<int>("preallocate_width_hint");
+        auto preallocate_height_hint = spec.GetArgument<int>("preallocate_height_hint");
+        // make sure it is not negative if provided
+        DALI_ENFORCE((!spec.HasArgument("preallocate_width_hint") ||
+                        preallocate_width_hint >= 0) &&
+                    (!spec.HasArgument("preallocate_height_hint") ||
+                        preallocate_height_hint >= 0),
+                    make_string("Provided preallocate_width_hint=", preallocate_width_hint,
+                     ", and ", "preallocate_height_hint=", preallocate_height_hint,
+                     " should not be ", "negative."));
+        LOG_LINE << "Using NVJPEG_PREALLOCATE_API" << std::endl;
+        // for backward compatibility we need to accept 0 as a hint, but nvJPEG return an error
+        // when such value is provided
+        preallocate_width_hint = preallocate_width_hint ? preallocate_width_hint : 1;
+        preallocate_height_hint = preallocate_height_hint ? preallocate_height_hint : 1;
+        NVJPEG_CALL(nvjpegDecodeBatchedPreAllocate(
+          handle_,
+          state_hw_batched_,
+          CalcHwDecoderBatchSize(hw_decoder_load_, max_batch_size_),
+          preallocate_width_hint,
+          preallocate_height_hint,
+          NVJPEG_CSS_444,
+          GetFormat(output_image_type_)));
 #endif
-      using_hw_decoder_ = true;
-      in_data_.reserve(max_batch_size_);
-      in_lengths_.reserve(max_batch_size_);
-      nvjpeg_destinations_.reserve(max_batch_size_);
-      nvjpeg_params_.reserve(max_batch_size_);
+        using_hw_decoder_ = true;
+        in_data_.reserve(max_batch_size_);
+        in_lengths_.reserve(max_batch_size_);
+        nvjpeg_destinations_.reserve(max_batch_size_);
+        nvjpeg_params_.reserve(max_batch_size_);
+#if NVML_ENABLED
+      }
+#endif
     } else {
       LOG_LINE << "NVJPEG_BACKEND_HARDWARE is either disabled or not supported" << std::endl;
       NVJPEG_CALL(nvjpegCreateSimple(&handle_));

--- a/dali/operators/reader/video_reader_op_test.cc
+++ b/dali/operators/reader/video_reader_op_test.cc
@@ -100,7 +100,7 @@ TEST_F(VideoReaderTest, MultipleVideoResolution) {
   const int initial_fill = 10;
 #if defined(__powerpc64__) || defined(__x86_64__)
   float driverVersion = 0;
-  char version[80];
+  char version[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE];
 
 #if NVML_ENABLED
   if (nvmlInitChecked() != NVML_SUCCESS) {


### PR DESCRIPTION
- Due to frequent memory allocations NVJPEG HW decoder on driver < 455,
  where memory pool is not available in the driver, hits the overall
  performance. Due to this disable it.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [x] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
- Due to frequent memory allocations NVJPEG HW decoder on driver < 455, where memory pool is not available in the driver, hits the overall performance. Due to this disable it.

#### Additional information
- Affected modules and functionalities:
  nvjpeg_decoder_decoupled_api
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
  NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
