### PR TITLE
Disallow some types of sources for parallel ES explicitly

### DIFF
--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -346,7 +346,7 @@ Keyword Args
     Only callables that accept one argument (:meth:`~nvidia.dali.types.SampleInfo` objects that
     represent the index of the requested sample) can be used as ``source`` when ``parallel`` is
     set to True. It can be a function or an object implementing ``__call__`` operator, which
-    allows to add some initial state to the object instance.
+    allows to add an initial state to the object instance.
 
     Keep in mind, that **copies** of the ``source`` will be distributed between Python workers,
     and no global state can be shared between them.

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -342,6 +342,15 @@ Keyword Args
 
     When ``parallel`` is set to True, ``source`` must return NumPy/MXNet/PyTorch CPU array,
     TensorCPU, or tuple/list of these types with length matching num_outputs.
+
+    Only callables that accept one argument (:meth:`~nvidia.dali.types.SampleInfo` objects that
+    represent the index of the requested sample) can be used as ``source`` when ``parallel`` is
+    set to True. It can be a function or an object implementing ``__call__`` operator, which
+    allows to add some initial state to the object instance.
+
+    Keep in mind, that **copies** of the ``source`` will be distributed between Python workers,
+    and no global state can be shared between them.
+
     The ``source`` callback must raise StopIteration when the end of data is reached.
 
     Setting ``parallel`` to True makes the external source work in per-sample mode.


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Only one-argument callables in per-sample mode
are supported. Other options do not allow us
to distribute the work between worker processes.

Update docs.

Detect the disallowed cases and provide 
a meaningful error message.
Add test coverage.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>
 
#### Additional information
- Affected modules and functionalities:
Parallel External Source

- Key points relevant for the review:
Nah

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2213
<!--- DALI-XXXX or NA --->
