### PR TITLE
Make TF graph-mode test ultra fast

### DIFF
--- a/dali/test/python/test_utils_tensorflow.py
+++ b/dali/test/python/test_utils_tensorflow.py
@@ -246,6 +246,7 @@ def compare(dataset_results, standalone_results, iterations=-1,  num_devices=1):
 
 def run_tf_dataset_graph(device, device_id=0, get_pipeline_desc=get_image_pipeline,
         to_dataset=to_image_dataset, to_stop_iter=False):
+    tf.compat.v1.reset_default_graph()
     batch_size = 12
     num_threads = 4
     iterations = 10


### PR DESCRIPTION

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
It seems that with every test in graph mode
the default graph is growing and takes longer
and longer to execute. We just clear the default
graph before running the tests and now the
whole test_dali_tf_dataset_graph executes orders
of magnitude faster, almost matching the eager
mode tests.


#### Additional information
- Affected modules and functionalities:
TF tests

- Key points relevant for the review:
N/A

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
