### PR TITLE
Improve validation in DALIDataset

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -317,6 +317,30 @@ void daliOutputRelease(daliPipelineHandle *pipe_handle) {
 
 
 template<typename T>
+static int64_t daliIsUniformShapeAtHelper(dali::DeviceWorkspace *ws, int n) {
+  int64_t *c_shape = nullptr;
+  std::vector<dali::Index> shape;
+  const auto &out_tensor_list = ws->Output<T>(n);
+  return is_uniform(out_tensor_list.shape());
+}
+
+
+static int64_t daliIsUniformShapeAtTypedHelper(daliPipelineHandle* pipe_handle, int n) {
+  dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
+  if (ws->OutputIsType<dali::CPUBackend>(n)) {
+    return daliIsUniformShapeAtHelper<dali::CPUBackend>(ws, n);
+  } else {
+    return daliIsUniformShapeAtHelper<dali::GPUBackend>(ws, n);
+  }
+}
+
+
+int64_t daliIsUniformShapeAt(daliPipelineHandle* pipe_handle, int n) {
+  return daliIsUniformShapeAtTypedHelper(pipe_handle, n);
+}
+
+
+template<typename T>
 static int64_t *daliShapeAtHelper(dali::DeviceWorkspace *ws, int n, int k) {
   int64_t *c_shape = nullptr;
   std::vector<dali::Index> shape;

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -315,30 +315,14 @@ void daliOutputRelease(daliPipelineHandle *pipe_handle) {
   pipeline->ReleaseOutputs();
 }
 
-
-template<typename T>
-static int64_t daliIsUniformShapeAtHelper(dali::DeviceWorkspace *ws, int n) {
-  int64_t *c_shape = nullptr;
-  std::vector<dali::Index> shape;
-  const auto &out_tensor_list = ws->Output<T>(n);
-  return is_uniform(out_tensor_list.shape());
-}
-
-
-static int64_t daliIsUniformShapeAtTypedHelper(daliPipelineHandle* pipe_handle, int n) {
+int64_t daliOutputHasUniformShape(daliPipelineHandle* pipe_handle, int i) {
   dali::DeviceWorkspace* ws = reinterpret_cast<dali::DeviceWorkspace*>(pipe_handle->ws);
-  if (ws->OutputIsType<dali::CPUBackend>(n)) {
-    return daliIsUniformShapeAtHelper<dali::CPUBackend>(ws, n);
+  if (ws->OutputIsType<dali::CPUBackend>(i)) {
+    return is_uniform(ws->Output<dali::CPUBackend>(i).shape());
   } else {
-    return daliIsUniformShapeAtHelper<dali::GPUBackend>(ws, n);
+    return is_uniform(ws->Output<dali::GPUBackend>(i).shape());
   }
 }
-
-
-int64_t daliIsUniformShapeAt(daliPipelineHandle* pipe_handle, int n) {
-  return daliIsUniformShapeAtTypedHelper(pipe_handle, n);
-}
-
 
 template<typename T>
 static int64_t *daliShapeAtHelper(dali::DeviceWorkspace *ws, int n, int k) {

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -584,12 +584,6 @@ if dataset_compatible_tensorflow():
         def _setup_inputs(self, input_datasets):
             """Verify the input specification and assign it to private members in
             normalized form.
-
-            Raises
-            ------
-            ValueError
-                Raises type error when there is no support for External Source, but
-                ES nodes are detected
             """
 
             has_es = _has_external_source(self._pipeline_instance)
@@ -775,7 +769,7 @@ if dataset_compatible_tensorflow():
             dataset_impl = _DALIDatasetImpl(pipeline, **kwargs)
 
             # TODO(klecki): Remove this when we move support for inputs from experimental.
-                # We detected External Source nodes in the Pipeline
+            # We detected External Source nodes in the Pipeline
             if _has_external_source(dataset_impl._pipeline_instance):
                 raise ValueError(("DALIDataset got a DALI pipeline containing External Source "
                     "operator nodes. External Source nodes can be used to express placeholders "

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -765,17 +765,15 @@ if dataset_compatible_tensorflow():
                         "__init__() got an unexpected keyword argument '{}'. "
                         "Dataset inputs are allowed only in 'experimental.DALIDatasetWithInputs'.").format(
                         disallowed_kwarg))
-            dataset_impl = _DALIDatasetImpl(pipeline, **kwargs)
-
-            # TODO(klecki): Remove this when we move support for inputs from experimental.
             # We detected External Source nodes in the Pipeline
-            if _has_external_source(dataset_impl._pipeline_instance):
+            if _has_external_source(pipeline):
                 raise ValueError(("DALIDataset got a DALI pipeline containing External Source "
                     "operator nodes. External Source nodes can be used to express placeholders "
                     "for tf.data.Dataset inputs to DALI or to run user-provided Python code "
                     "via `source` parameter. Support for Dataset inputs and External Source's "
                     "`source` is allowed only in 'experimental.DALIDatasetWithInputs'."))
 
+            dataset_impl = _DALIDatasetImpl(pipeline, **kwargs)
             super(DALIDataset, self).__init__(dataset_impl, dataset_options())
 
 else:

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -443,7 +443,6 @@ if dataset_compatible_tensorflow():
             self._output_dtypes = output_dtypes
             self._fail_on_device_mismatch = fail_on_device_mismatch
 
-            print(self.__class__.__name__)
             self._setup_inputs(input_datasets)
 
             self._structure = structure.convert_legacy_structure(self._output_dtypes,

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -506,10 +506,11 @@ if dataset_compatible_tensorflow():
 
                 # there is External Source with name equal to `input_name`
                 if input_name not in name_es_map.keys():
-                    raise ValueError(("Did not find an External Source node with name='{}' in "
-                                      "the provided pipeline - required by the name specified "
-                                      "in the `input_datasets`. Names of available External "
-                                      "Source nodes are: {}.").format(input_name,
+                    raise ValueError(("Did not find an External Source placeholder node with "
+                                      "name='{}' in the provided pipeline - required by the name "
+                                      "specified in the `input_datasets`. Names of available  "
+                                      "placeholder External Source nodes are: {}. Placeholder "
+                                      "nodes cannot have `source` argument specified.").format(input_name,
                                                                       list(name_es_map.keys())))
 
                 in_names_list.append(input_name)
@@ -647,17 +648,23 @@ if dataset_compatible_tensorflow():
         def _assert_correct_external_sources(self, external_source):
             """Validate that the external source nodes used are properly configured"""
             if external_source._op._num_outputs is not None:
-                raise ValueError("Found External Source node in the Pipeline that was "
-                                 "created with `num_outputs` parameter. Only single-output "
+                raise ValueError("Found placeholder External Source node (without `source` "
+                                 "argument) in the Pipeline that was created with `num_outputs` "
+                                 "`num_outputs` parameter. Only single-output "
                                  "(with `num_outputs=None`), named (with `name` argument "
                                  "specified) External Source nodes are supported as inputs "
-                                 "for DALIDataset integration.")
+                                 "placeholders for DALIDataset integration. "
+                                 "Alternatively, External Source can be used with `source` "
+                                 "parameter specified.")
             if external_source._op._name is None:
-                raise ValueError("Found External Source node in the Pipeline that was "
-                                 "not named (no `name` argument set). Only single-output "
+                raise ValueError("Found placeholder External Source node (without `source` "
+                                 "argument) in the Pipeline that was not named "
+                                 "(no `name` argument set). Only single-output "
                                  "(with `num_outputs=None`), named (with `name` argument "
                                  "specified) External Source nodes are supported as inputs "
-                                 "for DALIDataset integration.")
+                                 "placeholders for DALIDataset integration. "
+                                 "Alternatively, External Source can be used with `source` "
+                                 "parameter specified.")
 
         def _get_name_es_instance_map(self):
             """Return mappings between name of External Source and the op.

--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -325,6 +325,20 @@ def test_tf_experimental_inputs_disabled():
                         input_datasets={"test" : tf.data.Dataset.from_tensors(np.int32([42, 42]))})
 
 
+# Test if the ValueError is raised for external source with source.
+@raises(ValueError)
+def test_tf_experimental_source_disabled():
+    pipe = Pipeline(10, 4, 0)
+    with pipe:
+        input = fn.external_source(source=lambda : np.full((4, 4), 0), batch=False)
+        # Rely on the Pad internal check to ensure that External Source set layout
+        pipe.set_outputs(fn.pad(input))
+    dali_tf.DALIDataset(
+        pipe,
+        output_dtypes=tf.int32)
+
+
+
 # This test should be private (name starts with _) as it is called separately in L1
 def _test_tf_dataset_other_gpu():
     run_tf_dataset_eager_mode('gpu', 1)

--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -34,6 +34,10 @@ def test_tf_dataset_gpu():
 def test_tf_dataset_cpu():
     run_tf_dataset_eager_mode('cpu')
 
+# Return differently sized images to check if DALIDataset can handle this case gracefully
+@raises(Exception)
+def test_mixed_size_pipeline():
+    run_tf_dataset_eager_mode('gpu', get_pipeline_desc=get_mix_size_image_pipeline)
 
 def run_tf_dataset_with_constant_input(dev, shape, value, dtype, batch):
     tensor = np.full(shape, value, dtype)
@@ -268,8 +272,10 @@ def test_tf_dataset_disallowed_es():
     yield check_disallowed_es, {}, {}
     # num_outputs
     yield check_disallowed_es, {'name': 'a', 'num_outputs': 1}, {'a': in_dataset}
-    # source provided
+    # source provided, so we don't have valid placeholder
     yield check_disallowed_es, {'name': 'a', 'source': []}, {'a': in_dataset}
+    # misnamed placeholder
+    yield check_disallowed_es, {'name': 'b'}, {'a': in_dataset}
 
 
 def check_layout(kwargs, input_datasets, layout):

--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -35,7 +35,7 @@ def test_tf_dataset_cpu():
     run_tf_dataset_eager_mode('cpu')
 
 # Return differently sized images to check if DALIDataset can handle this case gracefully
-@raises(Exception)
+@raises(tf.errors.FailedPreconditionError)
 def test_mixed_size_pipeline():
     run_tf_dataset_eager_mode('gpu', get_pipeline_desc=get_mix_size_image_pipeline)
 
@@ -331,13 +331,12 @@ def test_tf_experimental_inputs_disabled():
                         input_datasets={"test" : tf.data.Dataset.from_tensors(np.int32([42, 42]))})
 
 
-# Test if the ValueError is raised for external source with source.
+# Test if the ValueError is raised for external source with `source`.
 @raises(ValueError)
 def test_tf_experimental_source_disabled():
     pipe = Pipeline(10, 4, 0)
     with pipe:
         input = fn.external_source(source=lambda : np.full((4, 4), 0), batch=False)
-        # Rely on the Pad internal check to ensure that External Source set layout
         pipe.set_outputs(fn.pad(input))
     dali_tf.DALIDataset(
         pipe,

--- a/dali/test/python/test_external_source_impl_utils.py
+++ b/dali/test/python/test_external_source_impl_utils.py
@@ -27,7 +27,7 @@ def passes_assert(callback, sample):
 def raises_type_error(callback, sample):
     callback(sample)
 
-# @raises(ValueError)
+@raises(ValueError)
 def raises_value_error(callback, sample):
     callback(sample)
 

--- a/dali/test/python/test_utils_tensorflow.py
+++ b/dali/test/python/test_utils_tensorflow.py
@@ -21,7 +21,7 @@ import numpy as np
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.fn as fn
 import nvidia.dali.types as types
-from test_utils import to_array
+from test_utils import to_array, get_dali_extra_path
 
 import tensorflow as tf
 from tensorflow.python.client import device_lib
@@ -29,7 +29,6 @@ from nose import SkipTest
 from distutils.version import LooseVersion
 import math
 from contextlib import contextmanager
-
 
 def skip_for_incompatible_tf():
     if not dali_tf.dataset_distributed_compatible_tensorflow():
@@ -90,7 +89,7 @@ def expect_iter_end(should_raise, exception_type):
 
 def get_mix_size_image_pipeline(batch_size, num_threads, device, device_id=0, shard_id=0, num_shards=1,
         def_for_dataset=False):
-    test_data_root = os.environ['DALI_EXTRA_PATH']
+    test_data_root = get_dali_extra_path()
     file_root = os.path.join(test_data_root, 'db', 'coco_dummy', 'images')
     annotations_file = os.path.join(
         test_data_root, 'db', 'coco_dummy', 'instances.json')
@@ -120,7 +119,7 @@ def get_mix_size_image_pipeline(batch_size, num_threads, device, device_id=0, sh
 
 def get_image_pipeline(batch_size, num_threads, device, device_id=0, shard_id=0, num_shards=1,
         def_for_dataset=False):
-    test_data_root = os.environ['DALI_EXTRA_PATH']
+    test_data_root = get_dali_extra_path()
     file_root = os.path.join(test_data_root, 'db', 'coco_dummy', 'images')
     annotations_file = os.path.join(
         test_data_root, 'db', 'coco_dummy', 'instances.json')

--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -515,12 +515,17 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
 
     for (int out_id = 0; out_id < num_outputs; ++out_id) {
       TensorShape output_shape;
+      bool is_uniform = false;
+      TF_DALI_CALL(is_uniform = daliIsUniformShapeAt(&pipeline_handle_, out_id));
 
-      if (!daliIsUniformShapeAt(&pipeline_handle_, out_id)) {
+      if (!is_uniform) {
         std::stringstream shapes;
         for (int sample_id = 0; sample_id < dataset()->pipeline_def_.batch_size; sample_id++) {
-          shapes << DaliToShape(
-              AutoCPtr<int64_t>(daliShapeAtSample(&pipeline_handle_, out_id, sample_id)));
+          AutoCPtr<int64_t> dali_shape;
+          TF_DALI_CALL(dali_shape = AutoCPtr<int64_t>(
+                           daliShapeAtSample(&pipeline_handle_, out_id, sample_id)));
+
+          shapes << DaliToShape(dali_shape);
           if (sample_id < dataset()->pipeline_def_.batch_size - 1) {
             shapes << ", ";
           }
@@ -532,14 +537,17 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
             "TensorFlow. Ensure that all the samples that you produce in given batch have equal "
             "shape. Got shapes: ", shapes.str());
       }
-      auto dali_shape = DaliToShape(AutoCPtr<int64_t>(daliShapeAt(&pipeline_handle_, out_id)));
+      AutoCPtr<int64_t> dali_batch_shape;
+      TF_DALI_CALL(dali_batch_shape = AutoCPtr<int64_t>(daliShapeAt(&pipeline_handle_, out_id)));
+      auto dali_shape = DaliToShape(dali_batch_shape);
       auto status = GetCompatibleShape(output_shape, dataset()->shapes_[out_id], dali_shape,
                                        dataset()->pipeline_def_.batch_size, out_id);
       if (status != Status::OK()) {
         return status;
       }
 
-      auto dali_type = daliTypeAt(&pipeline_handle_, out_id);
+      dali_data_type_t dali_type = DALI_NO_TYPE;
+      TF_DALI_CALL(dali_type = daliTypeAt(&pipeline_handle_, out_id));
       auto tf_type = DaliToTfType(dali_type);
 
       if (tf_type != dataset()->dtypes_[out_id]) {

--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -516,6 +516,22 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
     for (int out_id = 0; out_id < num_outputs; ++out_id) {
       TensorShape output_shape;
 
+      if (!daliIsUniformShapeAt(&pipeline_handle_, out_id)) {
+        std::stringstream shapes;
+        for (int sample_id = 0; sample_id < dataset()->pipeline_def_.batch_size; sample_id++) {
+          shapes << DaliToShape(
+              AutoCPtr<int64_t>(daliShapeAtSample(&pipeline_handle_, out_id, sample_id)));
+          if (sample_id < dataset()->pipeline_def_.batch_size - 1) {
+            shapes << ", ";
+          }
+        }
+        return errors::FailedPrecondition(
+            "Batch output at index '", out_id,
+            "' from DALI pipeline is not uniform - individual samples have different dimensions. "
+            "This output cannot be represented as single, dense Tensor, which is required by "
+            "TensorFlow. Ensure that all the samples that you produce in given batch have equal "
+            "shape. Got shapes: ", shapes.str());
+      }
       auto dali_shape = DaliToShape(AutoCPtr<int64_t>(daliShapeAt(&pipeline_handle_, out_id)));
       auto status = GetCompatibleShape(output_shape, dataset()->shapes_[out_id], dali_shape,
                                        dataset()->pipeline_def_.batch_size, out_id);

--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -516,7 +516,7 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
     for (int out_id = 0; out_id < num_outputs; ++out_id) {
       TensorShape output_shape;
       bool is_uniform = false;
-      TF_DALI_CALL(is_uniform = daliIsUniformShapeAt(&pipeline_handle_, out_id));
+      TF_DALI_CALL(is_uniform = daliOutputHasUniformShape(&pipeline_handle_, out_id));
 
       if (!is_uniform) {
         std::stringstream shapes;

--- a/dali_tf_plugin/daliop.cc
+++ b/dali_tf_plugin/daliop.cc
@@ -130,7 +130,7 @@ class DaliOp : public tf::OpKernel {
       OP_REQUIRES_OK(context, tf::errors::Internal("Cannot output sparse tensors on the GPU"));
     }
     this->device_id_ = device_id;
-    this->batch_size = max_batch_size;
+    this->batch_size_ = max_batch_size;
     LOG_LINE << "Initializing...\n";
 
     if (max_batch_size < 0) {
@@ -229,16 +229,16 @@ class DaliOp : public tf::OpKernel {
       std::vector<tf::int64> max_dims;
       if (!should_be_sparse_tensor) {
         bool is_uniform = false;
-        TF_DALI_CALL(is_uniform = daliIsUniformShapeAt(&pipe_handle_, i));
+        TF_DALI_CALL(is_uniform = daliOutputHasUniformShape(&pipe_handle_, i));
         if (!is_uniform) {
           std::stringstream shapes;
-          for (int sample_id = 0; sample_id < batch_size; sample_id++) {
+          for (int sample_id = 0; sample_id < batch_size_; sample_id++) {
             AutoCPtr<int64_t> dali_shape;
             TF_DALI_CALL(dali_shape = AutoCPtr<int64_t>(
                              daliShapeAtSample(&pipe_handle_, i, sample_id)));
 
             shapes << DaliToShape(dali_shape);
-            if (sample_id < batch_size - 1) {
+            if (sample_id < batch_size_ - 1) {
               shapes << ", ";
             }
           }
@@ -387,7 +387,7 @@ class DaliOp : public tf::OpKernel {
   std::vector<tf::TensorShape> shapes_;
   tf::DataTypeVector types_;
   int device_id_;
-  int batch_size;
+  int batch_size_;
   int prefetch_queue_depth_;
   device_type_t device_type_;
   std::vector<bool> sparse_;

--- a/dali_tf_plugin/daliop.cc
+++ b/dali_tf_plugin/daliop.cc
@@ -14,6 +14,7 @@
 
 #include <cuda_runtime_api.h>
 #include <chrono>
+#include <sstream>
 
 #include "tensorflow/core/framework/op.h"
 
@@ -129,6 +130,7 @@ class DaliOp : public tf::OpKernel {
       OP_REQUIRES_OK(context, tf::errors::Internal("Cannot output sparse tensors on the GPU"));
     }
     this->device_id_ = device_id;
+    this->batch_size = max_batch_size;
     LOG_LINE << "Initializing...\n";
 
     if (max_batch_size < 0) {
@@ -226,6 +228,31 @@ class DaliOp : public tf::OpKernel {
       unsigned dims = 0;
       std::vector<tf::int64> max_dims;
       if (!should_be_sparse_tensor) {
+        bool is_uniform = false;
+        TF_DALI_CALL(is_uniform = daliIsUniformShapeAt(&pipe_handle_, i));
+        if (!is_uniform) {
+          std::stringstream shapes;
+          for (int sample_id = 0; sample_id < batch_size; sample_id++) {
+            AutoCPtr<int64_t> dali_shape;
+            TF_DALI_CALL(dali_shape = AutoCPtr<int64_t>(
+                             daliShapeAtSample(&pipe_handle_, i, sample_id)));
+
+            shapes << DaliToShape(dali_shape);
+            if (sample_id < batch_size - 1) {
+              shapes << ", ";
+            }
+          }
+          OP_REQUIRES(
+              context,
+              is_uniform,
+              tensorflow::errors::FailedPrecondition(
+                  "Batch output at index '", i,
+                  "' from DALI pipeline is not uniform - individual samples have different "
+                  "dimensions. This output cannot be represented as single, dense Tensor, which is "
+                  "required by TensorFlow. Ensure that all the samples that you produce in given "
+                  "batch have equal shape. Or use sparse output representation. Got shapes: ",
+                  shapes.str()));
+        }
         tf::TensorShape data_output_shape;
         TF_DALI_CALL(data_output_shape = DaliToShape(AutoCPtr<int64_t>(
                      daliShapeAt(&pipe_handle_, i))));
@@ -360,6 +387,7 @@ class DaliOp : public tf::OpKernel {
   std::vector<tf::TensorShape> shapes_;
   tf::DataTypeVector types_;
   int device_id_;
+  int batch_size;
   int prefetch_queue_depth_;
   device_type_t device_type_;
   std::vector<bool> sparse_;

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -299,8 +299,18 @@ DLL_PUBLIC void daliShareOutput(daliPipelineHandle *pipe_handle);
 DLL_PUBLIC void daliOutputRelease(daliPipelineHandle *pipe_handle);
 
 /**
- * @brief Return the shape of the output tensor
- * stored at position `n` in the pipeline.
+ * @brief Returns 1 if the the output batch stored at position `n` in the pipeline can
+ * be represented as dense, uniform tensor. Otherwise 0.
+ *
+ * This function may only be called after
+ * calling Output function.
+ */
+DLL_PUBLIC int64_t daliIsUniformShapeAt(daliPipelineHandle *pipe_handle, int n);
+
+/**
+ * @brief Return the shape of the output tensor stored at position `n` in the pipeline.
+ * Valid only if daliIsUniformShapeAt() returns 1.
+ *
  * This function may only be called after
  * calling Output function.
  * @remarks Caller is responsible to 'free' the memory returned

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -305,11 +305,11 @@ DLL_PUBLIC void daliOutputRelease(daliPipelineHandle *pipe_handle);
  * This function may only be called after
  * calling Output function.
  */
-DLL_PUBLIC int64_t daliIsUniformShapeAt(daliPipelineHandle *pipe_handle, int n);
+DLL_PUBLIC int64_t daliOutputHasUniformShape(daliPipelineHandle *pipe_handle, int i);
 
 /**
  * @brief Return the shape of the output tensor stored at position `n` in the pipeline.
- * Valid only if daliIsUniformShapeAt() returns 1.
+ * Valid only if daliOutputHasUniformShape() returns 1.
  *
  * This function may only be called after
  * calling Output function.


### PR DESCRIPTION
## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
- Update error messages to mention support for `source` in External Source.
- Block external source nodes in pipelines passed to non-experimental DALIDataset
    (this check was missing)
- Add check for `source` handling to see if the returned batches
    are uniform - TensorFlow requirement.
- Extend C API to check if output buffer has uniform shape.
- Check if the DALI outputs are uniform before passing them to
    TensorFlow - now we report error instead of segfault.

#### Additional information
- Affected modules and functionalities:
TF DALIDataset
C API

- Key points relevant for the review:


## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2226
<!--- DALI-XXXX or NA --->
