### PR TITLE
Fix memory leak in backend_impl.cc caused by PyObject_GetAttr

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -56,8 +56,8 @@ void __backend_impl_force_tls_align_fun(void) {}
 using namespace pybind11::literals; // NOLINT
 
 static void* ctypes_void_ptr(const py::object& object) {
-  auto ptr_as_int = getattr(object, "value", py::cast<py::none>(Py_None));
-  if (ptr_as_int.is(py::cast<py::none>(Py_None))) {
+  auto ptr_as_int = getattr(object, "value", py::none());
+  if (ptr_as_int.is_none()) {
     return nullptr;
   }
   void *ptr = PyLong_AsVoidPtr(ptr_as_int.ptr());
@@ -195,9 +195,8 @@ void FillTensorFromDlPack(py::capsule capsule, SourceDataType<SrcBackend> *batch
 template <typename TensorType>
 void FillTensorFromCudaArray(const py::object object, TensorType *batch, int device_id,
                              string layout) {
-  py::dict cu_a_interface = getattr(object, "__cuda_array_interface__",
-                                    py::cast<py::none>(Py_None));
-  if (cu_a_interface.is(py::cast<py::none>(Py_None))) {
+  py::dict cu_a_interface = getattr(object, "__cuda_array_interface__", py::none());
+  if (cu_a_interface.is_none()) {
     DALI_FAIL("Provided object doesn't support cuda array interface protocol.")
   }
 


### PR DESCRIPTION
- not increasing reference count to the result of PyObject_GetAttr
  causes leaking of the python object. This PR moves to the usage of
  `getattr` to handle this automatically

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

#### Additional information
- Affected modules and functionalities:
  - backend_impl.cc
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
  - NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
