### PR TITLE
Ensure keeping py_pool alive until pipline is garbage collected

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1417,6 +1417,8 @@ PYBIND11_MODULE(backend_impl, m) {
         "list"_a,
         "cuda_stream"_a = py::none(),
         "use_copy_kernel"_a = false)
+    .def("SetPyObjDependency",
+      [](Pipeline *p, py::object obj) {}, "obj"_a, py::keep_alive<1, 2>())
     .def("SerializeToProtobuf",
         [](Pipeline *p) -> py::bytes {
           string s = p->SerializeToProtobuf();

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -552,10 +552,10 @@ Parameters
 
     def _setup_pipe_pool_dependency(self):
         if self._py_pool_started:
-            # Pipeline backend doesn't really do anything with the pool, sole point of this call
-            # is to ensure lifetime of the pool exceeds the lifetime of the pipeline's backend
-            # so that shared memory managed by the pool is not freed before pipline is garbage collected.
-            # Otherwise pipline may try to access freed memory which leads to crashes at the Python teardown
+            # The sole point of this call is to ensure the lifetime of the pool exceeds the lifetime
+            # of the pipeline's backend, so that shared memory managed by the pool is not freed
+            # before pipline's backend is garbage collected.
+            # Otherwise the backend may try to access unmmaped memory which leads to crashes at the Python teardown.
             self._pipe.SetPyObjDependency(self._py_pool)
 
     def _start_py_workers(self):

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -550,13 +550,20 @@ Parameters
         self._setup_input_callbacks()
         self._py_graph_built = True
 
+    def _setup_pipe_pool_dependency(self):
+        if self._py_pool_started:
+            # Pipeline backend doesn't really do anything with the pool, sole point of this call
+            # is to ensure lifetime of the pool exceeds the lifetime of the pipeline's backend
+            # so that shared memory managed by the pool is not freed before pipline is garbage collected.
+            # Otherwise pipline may try to access freed memory which leads to crashes at the Python teardown
+            self._pipe.SetPyObjDependency(self._py_pool)
+
     def _start_py_workers(self):
         if not self._parallel_input_callbacks:
             return
         self._py_pool = WorkerPool.from_groups(
             self._parallel_input_callbacks, self._prefetch_queue_depth, self._py_start_method, self._py_num_workers)
-        # pool instance releases shared memory when garbage collected, thus it must outlive the pipeline instance
-        # when external source is used with no_copy=True
+        # ensure processes started by the pool are termineted when pipeline is no longer used
         weakref.finalize(self, lambda pool : pool.close(), self._py_pool)
         self._py_pool_started = True
 
@@ -657,6 +664,7 @@ Parameters
         self.start_py_workers()
         if not self._backend_prepared:
             self._init_pipeline_backend()
+        self._setup_pipe_pool_dependency()
 
         self._pipe.Build(self._names_and_devices)
         self._built = True

--- a/dali/test/python/test_external_source_parallel_garbage_collection_order.py
+++ b/dali/test/python/test_external_source_parallel_garbage_collection_order.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import nvidia.dali.fn as fn
+from nvidia.dali import pipeline_def
+from test_utils import get_dali_extra_path
+
+import numpy as np
+
+
+data_root = get_dali_extra_path()
+images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
+batch_size = 16
+
+
+def create_py_file_reader(images_dir):
+    with open(os.path.join(images_dir, "image_list.txt"), 'r') as f:
+        file_label = [line.rstrip().split(' ') for line in f if line != '']
+        files, labels = zip(*file_label)
+
+    def py_file_reader(sample_info):
+        sample_idx = sample_info.idx_in_epoch
+        jpeg_filename = files[sample_idx]
+        label = np.int32([labels[sample_idx]])
+        with open(os.path.join(images_dir, jpeg_filename), 'rb') as f:
+            encoded_img = np.frombuffer(f.read(), dtype=np.uint8)
+        return encoded_img, label
+
+    return py_file_reader
+
+
+@pipeline_def(py_start_method='fork', batch_size=batch_size)
+def simple_pipeline():
+    jpegs, labels = fn.external_source(source=create_py_file_reader(images_dir), num_outputs=2, parallel=True, batch=False)
+    images = fn.decoders.image(jpegs, device="cpu")
+    return images, labels
+
+
+def test_no_segfault():
+    """
+    This may cause segmentation fault on Python teardown if shared memory wrappers managed by the py_pool
+    are garbage collected before pipeline's backend
+    """
+    pipe = simple_pipeline(batch_size=batch_size, py_start_method='fork', num_threads=4, prefetch_queue_depth=2, device_id=0)
+    pipe.build()
+    pipe.run()

--- a/dali/test/python/test_external_source_parallel_garbage_collection_order.py
+++ b/dali/test/python/test_external_source_parallel_garbage_collection_order.py
@@ -42,7 +42,7 @@ def create_py_file_reader(images_dir):
     return py_file_reader
 
 
-@pipeline_def(py_start_method='fork', batch_size=batch_size)
+@pipeline_def
 def simple_pipeline():
     jpegs, labels = fn.external_source(source=create_py_file_reader(images_dir), num_outputs=2, parallel=True, batch=False)
     images = fn.decoders.image(jpegs, device="cpu")

--- a/qa/TL0_python-self-test-readers-decoders/test_body.sh
+++ b/qa/TL0_python-self-test-readers-decoders/test_body.sh
@@ -3,6 +3,7 @@
 test_nose() {
     for test_script in $(ls test_operator_readers_*.py test_operator_decoders_*.py \
       test_external_source_dali.py test_external_source_numpy.py \
+      test_external_source_parallel_garbage_collection_order.py \
       test_pool.py test_external_source_parallel.py test_external_source_parallel_shared_batch.py); do
         nosetests --verbose --attr '!slow' ${test_script}
     done

--- a/qa/TL1_python-self-test_conda/test_body.sh
+++ b/qa/TL1_python-self-test_conda/test_body.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 test_nose() {
-    for test_script in $(ls test_operator_*.py test_pipeline*.py test_external_source_dali.py test_external_source_numpy.py test_functional_api.py test_backend_impl.py); do
+    for test_script in $(ls test_operator_*.py test_pipeline*.py test_external_source_dali.py test_external_source_numpy.py test_external_source_parallel_garbage_collection_order.py test_functional_api.py test_backend_impl.py); do
         nosetests --verbose --attr '!slow' ${test_script}
     done
 }


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Fixes an issue of random Python crashes at teardown if parallel external source is used.
That behavior was caused by garbage collection order issue: python pool objects, and in effect, shared memory wrappers
could be collected before pipeline backed, which led to pipeline accessing unmmaped memory regions.

#### Additional information
- Affected modules and functionalities:
Pipeline/Pipeline backend

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2239
<!--- DALI-XXXX or NA --->
