### PR TITLE
Change the way how start and end timestamps are converted to frames

### DIFF
--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -173,9 +173,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
     if (step_ < 0)
       step_ = count_ * stride_;
     if (!file_list_include_preceding_frame_) {
-      DALI_WARN("`file_list_include_preceding_frame_` is set to false (or not set at all). In "
-                "future releases, the default behavior would be changed to True and the argument "
-                "will be removed.");
+      DALI_WARN("``file_list_include_preceding_frame_`` is set to False (or not set at all). In "
+                "future releases, the default behavior would be changed to True..");
     }
 
     bool use_labels = spec.TryGetRepeatedArgument(labels_, "labels");

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -163,8 +163,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
       codec_id_(0),
       skip_vfr_check_(spec.GetArgument<bool>("skip_vfr_check")),
       file_list_frame_num_(spec.GetArgument<bool>("file_list_frame_num")),
-      file_list_include_preceding_frame_(spec.GetArgument<bool>(
-                                                          "file_list_include_preceding_frame")),
+      file_list_include_preceding_frame_(
+        spec.GetArgument<bool>("file_list_include_preceding_frame")),
       pad_sequences_(spec.GetArgument<bool>("pad_sequences")),
       stats_({0, 0, 0, 0, 0}),
       current_frame_idx_(-1),
@@ -173,8 +173,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
     if (step_ < 0)
       step_ = count_ * stride_;
     if (!file_list_include_preceding_frame_) {
-      DALI_WARN("``file_list_include_preceding_frame_`` is set to False (or not set at all). In "
-                "future releases, the default behavior would be changed to True..");
+      DALI_WARN("``file_list_include_preceding_frame`` is set to False (or not set at all). In "
+                "future releases, the default behavior would be changed to True.");
     }
 
     bool use_labels = spec.TryGetRepeatedArgument(labels_, "labels");
@@ -265,15 +265,15 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
                             static_cast<int>(std::ceil(start * av_q2d(frame_rate)));
             }
           }
-          if (file_list_include_preceding_frame_) {
-            if (end > 0) {
+          if (end > 0) {
+            if (file_list_include_preceding_frame_) {
               end_frame = static_cast<int>(std::ceil(end * av_q2d(frame_rate)));
             } else {
-              end_frame = file.frame_count_ + static_cast<int>(std::ceil(end * av_q2d(frame_rate)));
+              end_frame = static_cast<int>(std::floor(end * av_q2d(frame_rate)));
             }
           } else {
-            if (end > 0) {
-              end_frame = static_cast<int>(std::floor(end * av_q2d(frame_rate)));
+            if (file_list_include_preceding_frame_) {
+              end_frame = file.frame_count_ + static_cast<int>(std::ceil(end * av_q2d(frame_rate)));
             } else {
               end_frame = file.frame_count_ +
                           static_cast<int>(std::floor(end * av_q2d(frame_rate)));

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -161,6 +161,26 @@ If floating point values have been provided, the start frame number will be roun
 the end frame number will be rounded down.
 
 Frame numbers start from 0.)code", false)
+  .AddOptionalArg("file_list_include_preceding_frame",
+      R"code(Changes the behavior how `file_list` start and end frame timestamps are translated
+to the frame number.
+
+If the start/end timestamps are provided in file_list as timestamps, the start frame is
+calculated as `ceil(start_time_stamp * FPS)` and the end as `floor(end_time_stamp * FPS)`.
+If this option is turned on the equation changes to `floor(start_time_stamp * FPS)` and
+`ceil(end_time_stamp * FPS)` respectively. In effect, the first returned frame is no later, and
+the end frame no earlier than provided timestamps what is more aligned with how the visible
+timestamps are correlated with displayed video frames.
+
+.. note::
+
+  When `file_list_frame_num` is set this option doesn't take any effect.
+
+.. warning::
+
+  This option is meant to preserve the legacy behavior. It will be removed in the following
+  releases and the default behavior would be changed to ``file_list_include_preceding_frame=True``.
+)code", false)
   .AddOptionalArg("pad_sequences",
       R"code(Allows creation of incomplete sequences if there is an insufficient number
 of frames at the very end of the video.

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -162,24 +162,23 @@ the end frame number will be rounded down.
 
 Frame numbers start from 0.)code", false)
   .AddOptionalArg("file_list_include_preceding_frame",
-      R"code(Changes the behavior how `file_list` start and end frame timestamps are translated
-to the frame number.
+      R"code(Changes the behavior how ``file_list`` start and end frame timestamps are translated
+to a frame number.
 
 If the start/end timestamps are provided in file_list as timestamps, the start frame is
-calculated as `ceil(start_time_stamp * FPS)` and the end as `floor(end_time_stamp * FPS)`.
-If this option is turned on the equation changes to `floor(start_time_stamp * FPS)` and
-`ceil(end_time_stamp * FPS)` respectively. In effect, the first returned frame is no later, and
-the end frame no earlier than provided timestamps what is more aligned with how the visible
+calculated as ``ceil(start_time_stamp * FPS)`` and the end as ``floor(end_time_stamp * FPS)``.
+If this argument is set to True, the equation changes to ``floor(start_time_stamp * FPS)`` and
+``ceil(end_time_stamp * FPS)`` respectively. In effect, the first returned frame is not later, and
+the end frame not earlier, than the provided timestamps. This behavior is more aligned with how the visible
 timestamps are correlated with displayed video frames.
 
 .. note::
 
-  When `file_list_frame_num` is set this option doesn't take any effect.
+  When ``file_list_frame_num`` is set to True, this option does not take any effect.
 
 .. warning::
 
-  This option is meant to preserve the legacy behavior. It will be removed in the following
-  releases and the default behavior would be changed to ``file_list_include_preceding_frame=True``.
+  This option is available for legacy behavior compatibility.
 )code", false)
   .AddOptionalArg("pad_sequences",
       R"code(Allows creation of incomplete sequences if there is an insufficient number


### PR DESCRIPTION
- by default VideoReader file_list timestamps are converted to
 `ceil(start_time_stamp * FPS)` and `floor(end_time_stamp * FPS)`.
  This PR adds an option `file_list_include_preceding_frame` to change
  the behavior to `floor(start_time_stamp * FPS)` and
  `ceil(end_time_stamp * FPS)` respectively. As the sequence includes
  the first frame and excludes the last it is more aligned with the
  the way how visible display time is connected with displayed frames

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [x] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
- by default VideoReader file_list timestamps are converted to
 `ceil(start_time_stamp * FPS)` and `floor(end_time_stamp * FPS)`.
  This PR adds an option `file_list_include_preceding_frame` to change
  the behavior to `floor(start_time_stamp * FPS)` and
  `ceil(end_time_stamp * FPS)` respectively. As the sequence includes
  the first frame and excludes the last it is more aligned with the
  the way how visible display time is connected with displayed frames
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

#### Additional information
- Affected modules and functionalities:
  - video reader
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
  - logic and test
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**:  RVID.22, RVID.23, RVID.24
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
