### PR TITLE
Fix hw decoder tests disabled on old drivers

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -101,12 +101,8 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     // disable HW decoder for drivers < 455.x as the memory pool for it is not available
     // and multi GPU performance is far from perfect due to frequent memory allocations
 #if NVML_ENABLED
-      char version[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE];
-      CUDA_CALL(nvmlInitChecked());
-      CUDA_CALL(nvmlSystemGetDriverVersion(version, sizeof version));
-
-      float driverVersion = 0;
-      driverVersion = std::stof(version);
+      nvml::Init();
+      float driverVersion = nvml::GetDriverVersion();
       if (driverVersion < 455) {
         try_init_hw_decoder = false,
         hw_decoder_load_ = 0;
@@ -269,6 +265,10 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
   ~nvJPEGDecoder() override {
     try {
       DeviceGuard g(device_id_);
+
+#if NVML_ENABLED
+      nvml::Shutdown();
+#endif
 
       sample_data_.clear();
 

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api_test.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api_test.cc
@@ -225,7 +225,10 @@ class HwDecoderUtilizationTest : public ::testing::Test {
     auto node = pipeline_.GetOperatorNode(decoder_name_);
     if (!node->op->GetDiagnostic<bool>("using_hw_decoder")) {
       PrintDeviceInfo();
-      if (nvml::isHWDecoderSupported()) {
+      float driver_version = nvml::GetDriverVersion();
+      // HW decoder is disabled for drivers < 455.x, see
+      // dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h for details
+      if (driver_version >= 455 && nvml::isHWDecoderSupported()) {
         FAIL() << "HW Decoder exists in the system and failed to open";
       }
       GTEST_SKIP();
@@ -341,7 +344,10 @@ class HwDecoderSliceUtilizationTest : public ::testing::Test {
     auto node = pipeline_.GetOperatorNode(decoder_name_);
     if (!node->op->GetDiagnostic<bool>("using_hw_decoder")) {
       PrintDeviceInfo();
-      if (nvml::isHWDecoderSupported()) {
+      float driver_version = nvml::GetDriverVersion();
+      // HW decoder is disabled for drivers < 455.x, see
+      // dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h for details
+      if (driver_version >= 455 && nvml::isHWDecoderSupported()) {
         FAIL() << "HW Decoder exists in the system and failed to open";
       }
       GTEST_SKIP();
@@ -394,7 +400,10 @@ class HwDecoderCropUtilizationTest : public ::testing::Test {
     auto node = pipeline_.GetOperatorNode(decoder_name_);
     if (!node->op->GetDiagnostic<bool>("using_hw_decoder")) {
       PrintDeviceInfo();
-      if (nvml::isHWDecoderSupported()) {
+      float driver_version = nvml::GetDriverVersion();
+      // HW decoder is disabled for drivers < 455.x, see
+      // dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h for details
+      if (driver_version >= 455 && nvml::isHWDecoderSupported()) {
         FAIL() << "HW Decoder exists in the system and failed to open";
       }
       GTEST_SKIP();
@@ -447,7 +456,10 @@ class HwDecoderRandomCropUtilizationTest : public ::testing::Test {
     auto node = pipeline_.GetOperatorNode(decoder_name_);
     if (!node->op->GetDiagnostic<bool>("using_hw_decoder")) {
       PrintDeviceInfo();
-      if (nvml::isHWDecoderSupported()) {
+      float driver_version = nvml::GetDriverVersion();
+      // HW decoder is disabled for drivers < 455.x, see
+      // dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h for details
+      if (driver_version >= 455 && nvml::isHWDecoderSupported()) {
         FAIL() << "HW Decoder exists in the system and failed to open";
       }
       GTEST_SKIP();

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api_test.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api_test.cc
@@ -200,6 +200,18 @@ void PrintDeviceInfo() {
   }
 }
 
+/**
+ * @brief Return true if current configuration should be using HW decoder
+ */
+bool ShouldUseHwDecoder() {
+  // HW decoder is disabled for drivers < 455.x, see
+  // dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h for details
+  static float driver_version = nvml::GetDriverVersion();
+  static bool device_supports_hw_decoder = nvml::isHWDecoderSupported();
+  return device_supports_hw_decoder && driver_version >= 455;
+}
+
+
 class HwDecoderUtilizationTest : public ::testing::Test {
  public:
   void SetUp() final {
@@ -225,10 +237,7 @@ class HwDecoderUtilizationTest : public ::testing::Test {
     auto node = pipeline_.GetOperatorNode(decoder_name_);
     if (!node->op->GetDiagnostic<bool>("using_hw_decoder")) {
       PrintDeviceInfo();
-      float driver_version = nvml::GetDriverVersion();
-      // HW decoder is disabled for drivers < 455.x, see
-      // dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h for details
-      if (driver_version >= 455 && nvml::isHWDecoderSupported()) {
+      if (ShouldUseHwDecoder()) {
         FAIL() << "HW Decoder exists in the system and failed to open";
       }
       GTEST_SKIP();
@@ -344,10 +353,7 @@ class HwDecoderSliceUtilizationTest : public ::testing::Test {
     auto node = pipeline_.GetOperatorNode(decoder_name_);
     if (!node->op->GetDiagnostic<bool>("using_hw_decoder")) {
       PrintDeviceInfo();
-      float driver_version = nvml::GetDriverVersion();
-      // HW decoder is disabled for drivers < 455.x, see
-      // dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h for details
-      if (driver_version >= 455 && nvml::isHWDecoderSupported()) {
+      if (ShouldUseHwDecoder()) {
         FAIL() << "HW Decoder exists in the system and failed to open";
       }
       GTEST_SKIP();
@@ -400,10 +406,7 @@ class HwDecoderCropUtilizationTest : public ::testing::Test {
     auto node = pipeline_.GetOperatorNode(decoder_name_);
     if (!node->op->GetDiagnostic<bool>("using_hw_decoder")) {
       PrintDeviceInfo();
-      float driver_version = nvml::GetDriverVersion();
-      // HW decoder is disabled for drivers < 455.x, see
-      // dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h for details
-      if (driver_version >= 455 && nvml::isHWDecoderSupported()) {
+      if (ShouldUseHwDecoder()) {
         FAIL() << "HW Decoder exists in the system and failed to open";
       }
       GTEST_SKIP();
@@ -456,10 +459,7 @@ class HwDecoderRandomCropUtilizationTest : public ::testing::Test {
     auto node = pipeline_.GetOperatorNode(decoder_name_);
     if (!node->op->GetDiagnostic<bool>("using_hw_decoder")) {
       PrintDeviceInfo();
-      float driver_version = nvml::GetDriverVersion();
-      // HW decoder is disabled for drivers < 455.x, see
-      // dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h for details
-      if (driver_version >= 455 && nvml::isHWDecoderSupported()) {
+      if (ShouldUseHwDecoder()) {
         FAIL() << "HW Decoder exists in the system and failed to open";
       }
       GTEST_SKIP();

--- a/dali/operators/reader/video_reader_op_test.cc
+++ b/dali/operators/reader/video_reader_op_test.cc
@@ -100,19 +100,12 @@ TEST_F(VideoReaderTest, MultipleVideoResolution) {
   const int initial_fill = 10;
 #if defined(__powerpc64__) || defined(__x86_64__)
   float driverVersion = 0;
-  char version[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE];
 
 #if NVML_ENABLED
-  if (nvmlInitChecked() != NVML_SUCCESS) {
-    FAIL() << "nvmlInitChecked() failed";
-  }
-
-  if (nvmlSystemGetDriverVersion(version, sizeof version) != NVML_SUCCESS) {
-    FAIL() << "nvmlSystemGetDriverVersion failed!";
-  }
+  nvml::Init();
+  driverVersion = nvml::GetDriverVersion();
 #endif
 
-  driverVersion = std::stof(version);
 
 #if defined(__powerpc64__)
   std::cerr << "Test case running on powerpc64, driver version " << driverVersion << '\n';
@@ -175,6 +168,11 @@ TEST_F(VideoReaderTest, MultipleVideoResolution) {
         FAIL() << "Unexpected label";
     }
   }
+
+#if NVML_ENABLED
+  nvml::Shutdown();
+#endif
+
 }
 
 TEST_F(VideoReaderTest, PackedBFrames) {

--- a/dali/operators/reader/video_reader_op_test.cc
+++ b/dali/operators/reader/video_reader_op_test.cc
@@ -172,7 +172,6 @@ TEST_F(VideoReaderTest, MultipleVideoResolution) {
 #if NVML_ENABLED
   nvml::Shutdown();
 #endif
-
 }
 
 TEST_F(VideoReaderTest, PackedBFrames) {

--- a/dali/operators/sequence/optical_flow/optical_flow.h
+++ b/dali/operators/sequence/optical_flow/optical_flow.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,11 +18,12 @@
 #include <memory>
 #include <vector>
 #include "dali/core/cuda_event.h"
-#include "dali/pipeline/data/views.h"
-#include "dali/pipeline/data/backend.h"
-#include "dali/pipeline/operator/operator.h"
 #include "dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_stub.h"
 #include "dali/operators/sequence/optical_flow/turing_of/optical_flow_turing.h"
+#include "dali/pipeline/data/backend.h"
+#include "dali/pipeline/data/views.h"
+#include "dali/pipeline/operator/operator.h"
+#include "dali/util/nvml.h"
 
 namespace dali {
 
@@ -68,9 +69,12 @@ class OpticalFlow : public Operator<Backend> {
                  "Incorrect number of inputs. Expected: 2, Obtained: " +
                  std::to_string(spec.NumInput()));
     sync_ = CUDAEvent::Create(device_id_);
+#if NVML_ENABLED
+    nvml::Init();
+#endif
   }
 
-  ~OpticalFlow() = default;
+  ~OpticalFlow();
   DISABLE_COPY_MOVE_ASSIGN(OpticalFlow);
 
  protected:

--- a/dali/util/CMakeLists.txt
+++ b/dali/util/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,9 +70,9 @@ if(BUILD_NVML)
         VERBATIM)
 
     set_source_files_properties(${NVML_GENERATED_STUB} PROPERTIES GENERATED TRUE)
-    add_library(dynlink_nvml OBJECT nvml_wrap.cc ${NVML_GENERATED_STUB})
+    add_library(dynlink_nvml OBJECT nvml_wrap.cc nvml.cc ${NVML_GENERATED_STUB})
   else()
-    add_library(dynlink_nvml OBJECT nvml_wrap.cc)
+    add_library(dynlink_nvml OBJECT nvml_wrap.cc nvml.cc)
   endif()
 endif()
 
@@ -80,4 +80,4 @@ set(DALI_INST_HDRS ${DALI_INST_HDRS} PARENT_SCOPE)
 set(DALI_SRCS ${DALI_SRCS} PARENT_SCOPE)
 set(DALI_TEST_SRCS ${DALI_TEST_SRCS} PARENT_SCOPE)
 
-list(FILTER DALI_SRCS EXCLUDE REGEX ".*nvml_wrap.cc")
+list(FILTER DALI_SRCS EXCLUDE REGEX ".*nvml.*\.cc")

--- a/dali/util/nvml.cc
+++ b/dali/util/nvml.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/util/nvml.h"
+
+
+namespace dali {
+namespace nvml {
+namespace impl {
+
+
+float GetDriverVersion() {
+  if (!nvmlIsInitialized()) {
+    return 0;
+  }
+
+  float driver_version = 0;
+  char version[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE];
+
+  CUDA_CALL(nvmlSystemGetDriverVersion(version, sizeof version));
+  driver_version = std::stof(version);
+  return driver_version;
+}
+
+
+}  // namespace impl
+}  // namespace nvml
+}  // namespace dali

--- a/dali/util/nvml.h
+++ b/dali/util/nvml.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -250,6 +250,20 @@ inline bool HasCuda11NvmlFunctions() {
     return false;
   }
   return nvmlHasCuda11NvmlFunctions();
+}
+
+inline float GetDriverVersion() {
+  if (!nvmlIsInitialized()) {
+    return 0;
+  }
+
+  float driver_version = 0;
+  char version[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE];
+
+  CUDA_CALL(nvmlSystemGetDriverVersion(version, sizeof version));
+  driver_version = std::stof(version);
+
+  return driver_version;
 }
 
 #if (CUDART_VERSION >= 11000)

--- a/dali/util/nvml.h
+++ b/dali/util/nvml.h
@@ -252,19 +252,19 @@ inline bool HasCuda11NvmlFunctions() {
   return nvmlHasCuda11NvmlFunctions();
 }
 
+
+namespace impl {
+
+float GetDriverVersion();
+
+}  // namespace impl
+
+
 inline float GetDriverVersion() {
-  if (!nvmlIsInitialized()) {
-    return 0;
-  }
-
-  float driver_version = 0;
-  char version[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE];
-
-  CUDA_CALL(nvmlSystemGetDriverVersion(version, sizeof version));
-  driver_version = std::stof(version);
-
-  return driver_version;
+  static float version = impl::GetDriverVersion();
+  return version;
 }
+
 
 #if (CUDART_VERSION >= 11000)
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [x] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Refactored out function to check driver version.
Skip tests that check for use of HW decoder when they are running on unsupported driver.

#### Additional information
- Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
