### PR TITLE
Fix missing sizeof in Tensor Test

### DIFF
--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -431,10 +431,10 @@ std::vector<T> to_vec(Tensor<Backend> &tensor) {
   if (std::is_same<Backend, GPUBackend>::value) {
     CUDA_CALL(
       cudaMemcpyAsync(tmp.data(), tensor.template data<T>(),
-                      tensor.size(), cudaMemcpyDeviceToHost, 0));
+                      tensor.nbytes(), cudaMemcpyDeviceToHost, 0));
     CUDA_CALL(cudaStreamSynchronize(0));
   } else if (std::is_same<Backend, CPUBackend>::value) {
-    memcpy(tmp.data(), tensor.template data<float>(), tensor.size());
+    memcpy(tmp.data(), tensor.template data<float>(), tensor.nbytes());
   }
   return tmp;
 }
@@ -451,10 +451,11 @@ TYPED_TEST(TensorTest, TestCopyFromBuf) {
   tensor1.Copy(vec, 0);
   ASSERT_NE(tensor1.template mutable_data<float>(), nullptr);
   ASSERT_EQ(vec.size(), tensor1.size());
+  ASSERT_EQ(vec.size() * sizeof(float), tensor1.nbytes());
   ASSERT_EQ(1, tensor1.ndim());
 
   auto tensor1_data = to_vec(tensor1);
-  EXPECT_EQ(0, std::memcmp(vec.data(), tensor1_data.data(), vec.size()));
+  EXPECT_EQ(0, std::memcmp(vec.data(), tensor1_data.data(), vec.size() * sizeof(float)));
 
   Tensor<TypeParam> tensor2;
   tensor2.Copy(make_span(vec), 0);
@@ -463,7 +464,7 @@ TYPED_TEST(TensorTest, TestCopyFromBuf) {
   ASSERT_EQ(1, tensor2.ndim());
 
   auto tensor2_data = to_vec(tensor2);
-  EXPECT_EQ(0, std::memcmp(vec.data(), tensor2_data.data(), vec.size()));
+  EXPECT_EQ(0, std::memcmp(vec.data(), tensor2_data.data(), vec.size() * sizeof(float)));
 }
 
 TYPED_TEST(TensorTest, TestMultipleResize) {


### PR DESCRIPTION
## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Take size of element into account when
doing copies and comparisons.

Fixes #3265


#### Additional information
- Affected modules and functionalities:
Tensor Test

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
