### PR TITLE
Fix alignment constraints in CUDA VM resource.

### DIFF
--- a/include/dali/core/mm/cuda_vm_resource.h
+++ b/include/dali/core/mm/cuda_vm_resource.h
@@ -410,8 +410,8 @@ class cuda_vm_resource_base : public memory_resource<memory_kind::device> {
       assert(!va_ranges_.empty());
       va_size = std::max(va_size, 2 * va_ranges_.back().size());
       hints = {
-        { last_va.address_range.end(), 0_zu },
-        { first_va.address_range.ptr() - va_size, 0_zu }
+        { last_va.address_range.end(), block_size_ },
+        { first_va.address_range.ptr() - va_size, block_size_ }
       };
     }
 
@@ -423,8 +423,8 @@ class cuda_vm_resource_base : public memory_resource<memory_kind::device> {
       } catch (const CUDAError &) {
       } catch (const std::bad_alloc &) {}
     }
-    if (!va)  // ...hint failed - allocate anywhere
-      va = cuvm::CUMemAddressRange::Reserve(va_size, 0, 0);
+    if (!va)  // ...hint failed - allocate anywhere, just align to block_size_
+      va = cuvm::CUMemAddressRange::Reserve(va_size, block_size_, 0);
 
     va_ranges_.push_back(std::move(va));
     va_add_region(va_ranges_.back());

--- a/include/dali/core/mm/cuda_vm_resource.h
+++ b/include/dali/core/mm/cuda_vm_resource.h
@@ -426,6 +426,10 @@ class cuda_vm_resource_base : public memory_resource<memory_kind::device> {
     if (!va)  // ...hint failed - allocate anywhere, just align to block_size_
       va = cuvm::CUMemAddressRange::Reserve(va_size, block_size_, 0);
 
+    if (!mm::detail::is_aligned(detail::u2ptr(va.ptr()), block_size_))
+      throw std::logic_error("The VA region is not aligned to block size!\n"
+        "This should never happen.");
+
     va_ranges_.push_back(std::move(va));
     va_add_region(va_ranges_.back());
     stat_va_add(va_size);

--- a/include/dali/core/mm/detail/align.h
+++ b/include/dali/core/mm/detail/align.h
@@ -29,7 +29,7 @@ constexpr uintptr_t ptr2u(void *p) noexcept {
   return static_cast<char*>(p) - static_cast<char*>(nullptr);
 }
 
-template <typename T>
+template <typename T = void>
 DALI_HOST_DEV
 constexpr T *u2ptr(uintptr_t i) noexcept {
   // reinterpret_cast is not a constant expression - use a series of static casts instead


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [X] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Require that the memory returned by CUDA VM resource is aligned to block_size_

#### Additional information


## Checklist

### Tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2262
<!--- DALI-XXXX or NA --->
