### PR TITLE
Remove access to underlying contiguous TL buffer in Constant op

### DIFF
--- a/dali/operators/generic/constant.cu
+++ b/dali/operators/generic/constant.cu
@@ -78,7 +78,7 @@ void FillTensorList(
   kernels::ScatterGatherGPU scatter_gather;
 
   for (int i = 1; i < shape.num_samples(); i++) {
-    scatter_gather_.AddCopy(dst.mutable_tensor<Dst>(i), dst.mutable_tensor<Dst>(0),
+    scatter_gather.AddCopy(dst.mutable_tensor<Dst>(i), dst.mutable_tensor<Dst>(0),
                             sample_size * sizeof(Dst));
   }
   scatter_gather.Run(stream);

--- a/dali/operators/generic/constant.cu
+++ b/dali/operators/generic/constant.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include "dali/core/convert.h"
 #include "dali/core/static_switch.h"
 #include "dali/pipeline/data/views.h"
+#include "dali/kernels/common/scatter_gather.h"
 
 namespace dali {
 
@@ -43,6 +44,7 @@ __global__ void Fill(void *data, size_t count, Placeholder<size, alignment> valu
     static_cast<Placeholder<size, alignment>*>(data)[i] = value;
 }
 
+// TODO(klecki): [Conditional] - replace by sharing repeated sample
 template <typename Dst, typename Src>
 void FillTensorList(
       TensorList<GPUBackend> &dst, const TensorListShape<> &shape, const std::vector<Src> &src,
@@ -51,35 +53,35 @@ void FillTensorList(
   if (shape.num_samples() == 0)
     return;
 
-  if (src.size() == 1) {
-    int64_t size = shape.num_elements();
-    int64_t threads = 1024;
-    int64_t blocks = div_ceil(size, threads);
-    Dst *data = dst.mutable_data<Dst>();
 
-    Fill<<<dim3(blocks), dim3(threads), 0, stream>>>(data, size, opaque(ConvertSat<Dst>(src[0])));
+  int64_t sample_size = shape[0].num_elements();
+
+  if (src.size() == 1) {
+    int64_t threads = 1024;
+    int64_t blocks = div_ceil(sample_size, threads);
+    Dst *data = dst.mutable_tensor<Dst>(0);
+
+    Fill<<<dim3(blocks), dim3(threads), 0, stream>>>(data, sample_size,
+                                                     opaque(ConvertSat<Dst>(src[0])));
   } else {
     SmallVector<Dst, 64> tmp;
+    assert(src.size() == sample_size);
     tmp.resize(src.size());
     for (size_t i = 0; i < tmp.size(); i++)
       tmp[i] = ConvertSat<Dst>(src[i]);
 
     int n = tmp.size() * sizeof(Dst);
-    int N = shape.num_samples();
     CUDA_CALL(
       cudaMemcpyAsync(dst.mutable_tensor<Dst>(0), tmp.data(), n, cudaMemcpyHostToDevice, stream));
-    int copied = 1;
-    // this loop doubles the data in GPU memory, so that there are log2(N) memcpys at most
-    while (copied < N) {
-      int to_copy = copied;
-      if (copied + to_copy > N)
-        to_copy = N - copied;
-      CUDA_CALL(
-        cudaMemcpyAsync(dst.mutable_tensor<Dst>(copied), dst.mutable_tensor<Dst>(0), n * to_copy,
-                        cudaMemcpyDeviceToDevice, stream));
-      copied += to_copy;
-    }
   }
+
+  kernels::ScatterGatherGPU scatter_gather;
+
+  for (int i = 1; i < shape.num_samples(); i++) {
+    scatter_gather_.AddCopy(dst.mutable_tensor<Dst>(i), dst.mutable_tensor<Dst>(0),
+                            sample_size * sizeof(Dst));
+  }
+  scatter_gather.Run(stream);
 }
 
 }  // namespace

--- a/dali/operators/generic/constant.h
+++ b/dali/operators/generic/constant.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ class Constant : public Operator<Backend> {
     layout_ = spec.GetArgument<TensorLayout>("layout");
     if (!layout_.empty()) {
       DALI_ENFORCE(layout_.size() == static_cast<int>(shape_arg_.size()), make_string(
-        "Constant node: The requested layout \"", layout_, "\" has dimensionalilty which is "
+        "Constant node: The requested layout \"", layout_, "\" has dimensionality which is "
         "incompatible with the requested output shape."));
     }
   }
@@ -103,7 +103,6 @@ class Constant : public Operator<Backend> {
   DALIDataType output_type_;
   using storage_t = std::conditional_t<std::is_same<Backend, CPUBackend>::value,
     TensorVector<CPUBackend>, TensorList<GPUBackend>>;
-
   storage_t output_;
 };
 


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [x] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Remove access to underlying contiguous buffer
of TensorList in Constant op.

Instead of log copies over the contiguous buffer,
we do H2D copy or fill of the first sample and than
repeat it in the rest.

#### Additional information
- Affected modules and functionalities:
Constant op

- Key points relevant for the review:
N/A

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
