### PR TITLE
Remove access to underlying contiguous TL buffers in Flip

### DIFF
--- a/dali/operators/generic/flip.cu
+++ b/dali/operators/generic/flip.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/operators/generic/flip.h"
 #include <cuda_runtime_api.h>
 #include <vector>
 #include "dali/kernels/imgproc/flip_gpu.cuh"
+#include "dali/operators/generic/flip.h"
 #include "dali/operators/generic/flip_util.h"
+#include "dali/pipeline/data/views.h"
 
 namespace dali {
 
@@ -27,17 +28,13 @@ void RunKernel(TensorList<GPUBackend> &output, const TensorList<GPUBackend> &inp
                const std::vector<int32> &depthwise, const std::vector<int32> &horizontal,
                const std::vector<int32> &vertical, cudaStream_t stream) {
   DALI_TYPE_SWITCH(
-      input.type().id(), DType,
-      auto in_shape = TransformShapes(input.shape(), input.GetLayout());
-      kernels::InListGPU<DType, flip_ndim> in_view(input.data<DType>(), in_shape);
-      kernels::KernelContext ctx;
-      ctx.gpu.stream = stream;
-      kernels::FlipGPU<DType> kernel;
+      input.type().id(), DType, auto in_shape = TransformShapes(input.shape(), input.GetLayout());
+      auto in_view = reshape<flip_ndim>(view<const DType>(input), in_shape);
+      kernels::KernelContext ctx; ctx.gpu.stream = stream; kernels::FlipGPU<DType> kernel;
       auto reqs = kernel.Setup(ctx, in_view);
-      kernels::OutListGPU<DType, flip_ndim> out_view(output.mutable_data<DType>(),
-                                             reqs.output_shapes[0].to_static<flip_ndim>());
-      kernel.Run(ctx, out_view, in_view, depthwise, vertical, horizontal);
-  )
+      auto out_view =
+          reshape<flip_ndim>(view<DType>(output), reqs.output_shapes[0].to_static<flip_ndim>());
+      kernel.Run(ctx, out_view, in_view, depthwise, vertical, horizontal);)
 }
 
 template <>


### PR DESCRIPTION
## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [x] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Remove only the mutable_data and data usage 
in CPU variant.

Tested with enforced shapes.
This op still uses per-sample approach in both
CPU and GPU variants, this is left unchanged. 

#### Additional information
- Affected modules and functionalities:
Flip

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
