### PR TITLE
Clear to_dealloc and notify under a lock.

### DIFF
--- a/dali/core/mm/pool_resource_test.cc
+++ b/dali/core/mm/pool_resource_test.cc
@@ -219,8 +219,11 @@ void PoolTest(Pool &pool, vector<block> &blocks, Mutex &mtx, int max_iters = 200
   std::poisson_distribution<> size_dist(1<<20);
   const int max_size = 1 << 26;
   std::bernoulli_distribution action_dist;
+  std::bernoulli_distribution flush_dist(0.01);
   std::uniform_int_distribution<> fill_dist(1, 255);
   for (int i = 0; i < max_iters; i++) {
+    if (flush_dist(rng))
+      pool.flush_deferred();
     if (action_dist(rng) || blocks.empty()) {
       size_t size;
       do {
@@ -288,7 +291,7 @@ TEST(MMPoolResource, ParallelDeferred) {
     std::vector<block> blocks;
     spinlock mtx;
 
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 4; i++) {
       threads.emplace_back([&]() {
         PoolTest(pool, blocks, mtx, 50000);
       });

--- a/include/dali/core/mm/detail/deferred_dealloc.h
+++ b/include/dali/core/mm/detail/deferred_dealloc.h
@@ -152,9 +152,9 @@ class deferred_dealloc_resource : public BaseResource {
       queue_idx_ = 1 - queue_idx_;
       ulock.unlock();
       this->bulk_deallocate(make_span(to_free));
+      ulock.lock();
       to_free.clear();
       ready_.notify_all();
-      ulock.lock();
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [X] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Clear and notify under a lock - otherwise it's was possible that the list was cleared between the `if (!NoPendingDeallocs()` and `ready_.wait()`.

#### Additional information
Deferred deallocation in memory resources.

## Checklist

### Tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2264
<!--- DALI-XXXX or NA --->
