### PR TITLE
Fix infinite loop for convolution with extent equal 1

### DIFF
--- a/dali/kernels/imgproc/convolution/convolution_gpu.h
+++ b/dali/kernels/imgproc/convolution/convolution_gpu.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -126,6 +126,11 @@ struct ConvolutionGpu {
         size[0] = volume(sample_shape.begin(), sample_shape.begin() + axis);
         // width
         size[1] = sample_shape[axis];
+        // Special case for extent equal 1, see FillAlignedWindows for details
+        if (size[1] == 1) {
+          window_size = 1;
+          window_anchor = 0;
+        }
         int row_stride = sample_shape[axis] * num_channels;
         auto* window_gpu =
             reinterpret_cast<cutlass_W*>(window_tmp_buffer_gpu + i * kWindowCopyBufferSize);
@@ -160,6 +165,11 @@ struct ConvolutionGpu {
         size[0] = sample_shape[axis];
         // width
         size[1] = volume(sample_shape.begin() + axis + 1, sample_shape.end());
+        // Special case for extent equal 1, see FillAlignedWindows for details
+        if (size[0] == 1) {
+          window_size = 1;
+          window_anchor = 0;
+        }
         auto strides = GetStrides(sample_shape);
         int row_stride = strides[axis];
         int planes = volume(sample_shape.begin(), sample_shape.begin() + axis);
@@ -236,17 +246,45 @@ struct ConvolutionGpu {
                 "Selected axis must be in [0, ndim) when there is no channel axis, or in [0, ndim "
                 "- 1) for channel-last input");
 
-  void FillAlignedWindows(span<W> window_tmp_buffer_host,
-                         const TensorListView<StorageCPU, const W, 1>& window,
+
+  void FillAlignedWindow(span<W> window_tmp_buffer_host, int window_idx, span<const W> window_src,
                          const TensorListShape<ndim>& in_shape) {
+    using dst_win_t = typename CutlassConv::ConvWindowConfiguration::template PaddedWindowBuffer<W>;
+    int num_channels = has_channels ? in_shape[window_idx][ndim - 1] : 1;
+    auto window_padded_dst = dst_win_t(&window_tmp_buffer_host[window_idx * kWindowCopyBufferSize]);
+    CutlassConv::ConvWindowConfiguration::prepare_window(window_padded_dst, window_src,
+                                                         num_channels);
+  }
+
+  /**
+   * @brief Repack kernel windows from packed TLV representation to a padded layout
+   * suitablbe for CUTLASS kernel taking into account the shape.
+   *
+   * For axis of extent 1 the kernel window is compacted to 1 element.
+   */
+  void FillAlignedWindows(span<W> window_tmp_buffer_host,
+                          const TensorListView<StorageCPU, const W, 1>& window,
+                          const TensorListShape<ndim>& in_shape) {
     for (int i = 0; i < window.num_samples(); i++) {
-      using dst_win_t =
-          typename CutlassConv::ConvWindowConfiguration::template PaddedWindowBuffer<W>;
-      int num_channels = has_channels ? in_shape[i][ndim - 1] : 1;
-      auto window_src = make_span(window.tensor_data(i), window.tensor_shape_span(i)[0]);
-      auto window_padded_dst = dst_win_t(&window_tmp_buffer_host[i * kWindowCopyBufferSize]);
-      CutlassConv::ConvWindowConfiguration::prepare_window(window_padded_dst, window_src,
-                                                           num_channels);
+      // Special case, for axis with extent 1 - we need to sum the window to 1 element,
+      // to make it work with border reflect 101. For the CPU version, the reflect 101
+      // works as border repeat - so with 1 elements it works by calculating
+      // (sum(window) * input_element). The kernel matrix generation ends as infinite loop
+      // for input of extent equal 1, so we compact the kernel to 1 element (what would effectively
+      // happen either way) and just lookup that one elemnt in the CUTLASS kernels
+      if (in_shape[i][axis] == 1) {
+        std::array<W, 1> tmp_window = {W{0}};
+        for (int win_elem = 0; win_elem < window.tensor_shape_span(i)[0] / 2; win_elem++) {
+          tmp_window[0] += window.tensor_data(i)[win_elem];
+          tmp_window[0] += window.tensor_data(i)[window.tensor_shape_span(i)[0] - win_elem - 1];
+        }
+        tmp_window[0] += window.tensor_data(i)[window.tensor_shape_span(i)[0] / 2];
+        auto window_src = make_span(tmp_window.data(), 1);
+        FillAlignedWindow(window_tmp_buffer_host, i, window_src, in_shape);
+      } else {
+        auto window_src = make_span(window.tensor_data(i), window.tensor_shape_span(i)[0]);
+        FillAlignedWindow(window_tmp_buffer_host, i, window_src, in_shape);
+      }
     }
   }
 };

--- a/dali/kernels/imgproc/convolution/convolution_gpu_test.cu
+++ b/dali/kernels/imgproc/convolution/convolution_gpu_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -137,15 +137,16 @@ struct ConvolutionGpuKernelTest : public ::testing::Test {
   const TensorListShape<> shape_ch_ = {{29, 145, 128, 3}, {64, 64, 64, 3},  {164, 164, 164, 3},
                                        {12, 12, 12, 3},   {4, 200, 180, 3}, {200, 4, 180, 3},
                                        {75, 75, 75, 5}, {16, 512, 512, 1}, {16, 512, 512, 1},
-                                       {16, 512, 512, 1}};
+                                       {16, 512, 512, 1}, {8, 1, 32, 3}, {8, 32, 1, 3},
+                                       {1, 8, 32, 3}};
   const TensorListShape<> shape_noch_ = {{29, 145, 128}, {64, 64, 64},  {164, 164, 164},
                                          {12, 12, 12},   {4, 200, 180}, {200, 4, 180},
                                          {75, 75, 75}, {16, 512, 512}, {16, 512, 512},
-                                         {16, 512, 512}};
+                                         {16, 512, 512}, {8, 1, 32}, {8, 32, 1}, {1, 8, 32}};
   // Three last window sizes are used to verify against off-by-one error when calculating
   // where the nonzero region ends in the kernel::Conv, as the ThreadblockShape::kK == 8.
   const TensorListShape<1> shape_window = {
-      {1, 3, 5, 15, 25, 51, 101, 2 * 7 + 1, 2 * 8 + 1, 2 * 9 + 1}};
+      {1, 3, 5, 15, 25, 51, 101, 2 * 7 + 1, 2 * 8 + 1, 2 * 9 + 1, 7, 1, 11}};
 };
 
 TYPED_TEST_SUITE_P(ConvolutionGpuKernelTest);

--- a/dali/kernels/imgproc/convolution/cutlass/threadblock/predicated_tile_iterator.h
+++ b/dali/kernels/imgproc/convolution/cutlass/threadblock/predicated_tile_iterator.h
@@ -1,5 +1,5 @@
 /***************************************************************************************************
- * Copyright (c) 2017-2020, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted
  * provided that the following conditions are met:

--- a/dali/kernels/imgproc/convolution/cutlass/threadblock/predicated_tile_iterator.h
+++ b/dali/kernels/imgproc/convolution/cutlass/threadblock/predicated_tile_iterator.h
@@ -184,7 +184,7 @@ namespace threadblock {
 ///  x,  x,  x,  x,  x,  x,  x,  2,
 ///
 /// Row "-2" of "kernel matrix" would multiply column "-2" of the image, which is equal to column
-/// "2" of the image. By the distributive properties of multiplication. We can add the coefficients
+/// "2" of the image. By the distributive properties of multiplication, we can add the coefficients
 /// of row -2 and 2 to get the same result without the need to extend the matrices,
 /// thus the matrix will contain a sum of given kernel elements in given positions:
 ///
@@ -198,7 +198,7 @@ namespace threadblock {
 ///  x,     x,     x,     x,     x,     2,     1,    0,
 ///
 /// To generate specific coordinate (row, col), we check how far it is from diagonal:
-/// dist_diag = row - col <- negative means we're above, that number maps to the base winodw element
+/// dist_diag = row - col <- negative means we're above, that number maps to the base window element
 /// we need to use.
 /// When handling the borders, we need to check the distance to the top and bottom of the matrix.
 /// For the "top" border, we would use elements that are twice the distance to the top from
@@ -214,7 +214,7 @@ namespace threadblock {
 /// Same when going to the bottom, 1 + 2 * 6 = 13 - also out.
 /// Note that, when the distance is 0, we don't add the additional coefficients in this border mode.
 ///
-/// Make channel number > 1 will cause additional gaps in the kernel when looking at the
+/// Makeing the channel number > 1 will cause additional gaps in the kernel when looking at the
 /// columns of "kernel matrix" for example (again without border) for channels = 3,
 /// part of the matrix:
 ///
@@ -830,6 +830,10 @@ class PositionPredicatedTileIterator<Shape_, Element_, layout::PitchLinear, Adva
       // so it is not repeated by every addition - effectively we would change the channel)
       dist_first = (dist_first / Channels()) * Channels();
       dist_last = (dist_last / Channels()) * Channels();
+    }
+    // prevent infinite loop for input of size 1, see FillAlignedWindows for details
+    if (dist_first == 0 && dist_last == 0) {
+      return;
     }
     int neg_abs_element = abs_window_element;
     while (true) {

--- a/dali/kernels/imgproc/convolution/cutlass/threadblock/predicated_tile_iterator.h
+++ b/dali/kernels/imgproc/convolution/cutlass/threadblock/predicated_tile_iterator.h
@@ -214,7 +214,7 @@ namespace threadblock {
 /// Same when going to the bottom, 1 + 2 * 6 = 13 - also out.
 /// Note that, when the distance is 0, we don't add the additional coefficients in this border mode.
 ///
-/// Makeing the channel number > 1 will cause additional gaps in the kernel when looking at the
+/// Making the channel number > 1 will cause additional gaps in the kernel when looking at the
 /// columns of "kernel matrix" for example (again without border) for channels = 3,
 /// part of the matrix:
 ///

--- a/dali/kernels/imgproc/convolution/separable_convolution_gpu_test.cu
+++ b/dali/kernels/imgproc/convolution/separable_convolution_gpu_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ class SepearableConvolutionGpuTestImpl {
     SeparableConvolutionGpu<float, float, float, kAxes, kChannels, kFrames> kernel_gpu;
 
     for (float scale : {0.75f, 1.0f, 1.25f, 0.5f}) {
-      ReshapeData(1.0f);
+      ReshapeData(scale);
       FillData();
 
       auto baseline_out_v = baseline_output_.cpu();

--- a/dali/test/python/test_operator_gaussian_blur.py
+++ b/dali/test/python/test_operator_gaussian_blur.py
@@ -230,8 +230,10 @@ def test_generic_gaussian_blur():
 
 def test_one_sized_extent():
     for dev in ["cpu", "gpu"]:
-        for shape, layout in [((10, 1, 3), "HWC"), ((1, 10, 3), "HWC"), ((1, 10), "HW"), ((10, 1), "HW")]:
-            yield check_generic_gaussian_blur, 10, 2.0, 5, shape, layout, 2, dev, np.float32, types.FLOAT, False
+        for shape, layout in [((1, 10, 6), "DHW"), ((10, 1, 3), "HWC"), ((1, 10, 3), "HWC"),
+                              ((1, 10), "HW"), ((10, 1), "HW")]:
+            axes = len(layout) - ("C" in layout)
+            yield check_generic_gaussian_blur, 10, 2.0, 5, shape, layout, axes, dev, np.float32, types.FLOAT, False
 
 
 @attr('slow')


### PR DESCRIPTION
## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
GPU kernel's border handling went into infinite loop,
as the border reflect 101 is not suited for inputs
with extent zero. As the CPU version treats it as
border replicate, we do the same for GPU.

As it boils down to `sum(window) * input_element`
we compact the window to 1 element and break the
loop early.

Test to cover edge cases added.

Fixes #3277.

#### Additional information
- Affected modules and functionalities:
Convolution/GPU

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
