### PR TITLE
Implement InputDatasets for DALIDataset

### DIFF
--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -94,6 +94,9 @@ class DALIDatasetOp::Dataset : public DatasetBase {
 
   std::unique_ptr<IteratorBase> MakeIteratorInternal(const string &prefix) const override;
 
+
+#if TF_MAJOR_VERSION > 2 || (TF_MAJOR_VERSION == 2 && TF_MINOR_VERSION >= 4)
+
   /**
    * @brief Current implementation disables splits. For newer TF versions, it is
    * necessary to implement InputDatasets to get rid of the warnings, but adding it would enable
@@ -104,6 +107,9 @@ class DALIDatasetOp::Dataset : public DatasetBase {
       std::vector<std::unique_ptr<SplitProvider>>* split_providers) const override;
 
   Status InputDatasets(std::vector<const DatasetBase*>* inputs) const override;
+
+#endif
+
 
   const DataTypeVector &output_dtypes() const override {
     return dtypes_;
@@ -903,6 +909,8 @@ std::unique_ptr<IteratorBase> DALIDatasetOp::Dataset::MakeIteratorInternal(
 }
 
 
+#if TF_MAJOR_VERSION > 2 || (TF_MAJOR_VERSION == 2 && TF_MINOR_VERSION >= 4)
+
 Status DALIDatasetOp::Dataset::MakeSplitProviders(
     std::vector<std::unique_ptr<SplitProvider>> *split_providers) const {
   return errors::Unimplemented(
@@ -923,6 +931,8 @@ Status DALIDatasetOp::Dataset::InputDatasets(std::vector<const DatasetBase *> *i
   }
   return Status::OK();
 }
+
+#endif
 
 
 // Regestrations

--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -954,25 +954,12 @@ Status DALIDatasetOp::Dataset::InputDatasets(std::vector<const DatasetBase *> *i
 
 #if TF_MAJOR_VERSION == 2 && TF_MINOR_VERSION >= 4 && TF_MINOR_VERSION < 6
 
-  /**
-   * @brief Current implementation disables splits. For newer TF versions, it is
-   * necessary to implement InputDatasets to get rid of the warnings, but adding it would enable
-   * automatic SplitProvider for DALIDataset. As DALI has its own concept of shards, we do not
-   * handle splits as of now, so it is disabled explicitly.
-   */
 Status DALIDatasetOp::Dataset::MakeSplitProvider(std::unique_ptr<SplitProvider> *) const {
   return MakeSplitProvidersImpl();
 }
 
-
 #elif TF_MAJOR_VERSION > 2 || (TF_MAJOR_VERSION == 2 && TF_MINOR_VERSION >= 6)
 
-  /**
-   * @brief Current implementation disables splits. For newer TF versions, it is
-   * necessary to implement InputDatasets to get rid of the warnings, but adding it would enable
-   * automatic SplitProvider for DALIDataset. As DALI has its own concept of shards, we do not
-   * handle splits as of now, so it is disabled explicitly.
-   */
 Status DALIDatasetOp::Dataset::MakeSplitProviders(
     std::vector<std::unique_ptr<SplitProvider>> *) const {
   return MakeSplitProvidersImpl();


### PR DESCRIPTION
## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [x] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Disable Split Provider that is automatically
added when InputDatasets is implemented.

This get rids of the `Unimplemented` warnings.

#### Additional information
- Affected modules and functionalities:
TF DALIDataset

- Key points relevant for the review:


## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
