### PR TITLE
Add assert_raises_pattern and raises_pattern utilities

### DIFF
--- a/dali/test/python/nose_utils.py
+++ b/dali/test/python/nose_utils.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nose.tools as tools
+import re
+import fnmatch
+
+
+def assert_raises_pattern(exception, pattern, *args, **kwargs):
+
+    """
+    There already is an assert_raises_regex function available in nose.tools
+    (which is actually a method assertRaisesRegex copied from python's unittest.TestCase dummy instance).
+    This is a simple wrapper around the function that allows to:
+    * specify if the pattern searching should be case-sensitive (by default it is not, use `match_case`=True to change that)
+    * use simple glob pattern instead of regex (specify `use_glob`=False if you want to use regex)
+
+    `exception` can be either a class or list of classes
+    """
+
+    match_case = kwargs.pop("match_case", None)
+    use_glob = kwargs.pop("use_glob", None)
+
+    if not isinstance(pattern, str): # it could be an already compiled regex
+        if use_glob is not None or match_case is not None:
+            raise ValueError("Pattern must be a string if `match_case` or `use_glob` is specified when calling assert_raises_pattern")
+    else:
+        if use_glob is None:
+            use_glob = True
+        if match_case is None:
+            match_case = False
+
+        if use_glob:
+            pattern = fnmatch.translate(pattern)
+        flags = 0
+        if not match_case:
+            flags |= re.IGNORECASE
+        pattern = re.compile(pattern, flags)
+
+    return tools.assert_raises_regex(exception, pattern, *args, **kwargs)
+
+
+def raises_pattern(exception, pattern, match_case=None, use_glob=None):
+
+    def decorator(func):
+
+        def new_func(*args, **kwargs):
+            with assert_raises_pattern(exception, pattern, match_case=match_case, use_glob=use_glob):
+                return func(*args, **kwargs)
+
+        return tools.make_decorator(func)(new_func)
+
+    return decorator

--- a/dali/test/python/test_external_source_parallel_custom_serialization.py
+++ b/dali/test/python/test_external_source_parallel_custom_serialization.py
@@ -15,7 +15,7 @@
 import os
 import copyreg
 import numpy as np
-from nose.tools import raises
+from nose_utils import raises_pattern
 from pickle import PicklingError
 
 from nvidia.dali import pipeline_def
@@ -69,13 +69,9 @@ def callback_idx_by_value(i):
     return np.full((10, 20), i, dtype=np.uint8)
 
 
-class NoDumpsParam(ValueError):
-    pass
-
-
 def dumps(obj, **kwargs):
     if kwargs.get('special_dumps_param') != 42:
-        raise NoDumpsParam("Expected special_dumps_param among kwargs, got {}".format(kwargs))
+        raise ValueError("Expected special_dumps_param among kwargs, got {}".format(kwargs))
     return dali_pickle._DaliPickle.dumps(obj)
 
 
@@ -120,7 +116,7 @@ def create_closure_callback_numpy(shape, data_set_size):
         if sample_info.idx_in_epoch >= data_set_size:
             raise StopIteration
         return data[sample_info.idx_in_epoch]
-    
+
     return callback
 
 
@@ -290,7 +286,7 @@ def test_if_custom_type_reducers_are_respected_by_dali_reducer():
 
 
 @register_case(tests_dali_pickling)
-@raises(PicklingError)
+@raises_pattern(PicklingError, "Can't pickle * attribute lookup simple_callback on * failed")
 def _test_global_function_pickled_by_reference(name, py_callback_pickler):
     # modify callback name so that an attempt to pickle by reference, which is default Python behavior, fails
     _simple_callback.__name__ = _simple_callback.__qualname__ = "simple_callback"
@@ -305,7 +301,7 @@ def _test_pickle_by_value_decorator_on_global_function(name, py_callback_pickler
 
 
 @register_case(tests_dali_pickling)
-@raises(NoDumpsParam)
+@raises_pattern(ValueError, "Expected special_dumps_param among kwargs, got *")
 def _test_pickle_does_not_pass_extra_params_function(name, py_callback_pickler):
     this_module = __import__(__name__)
     _create_and_compare_simple_pipelines(callback_const_42, this_module, batch_size=4, py_num_workers=2)

--- a/dali/test/python/test_external_source_parallel_custom_serialization.py
+++ b/dali/test/python/test_external_source_parallel_custom_serialization.py
@@ -15,7 +15,7 @@
 import os
 import copyreg
 import numpy as np
-from nose_utils import raises_pattern
+from nose_utils import raises
 from pickle import PicklingError
 
 from nvidia.dali import pipeline_def
@@ -286,7 +286,7 @@ def test_if_custom_type_reducers_are_respected_by_dali_reducer():
 
 
 @register_case(tests_dali_pickling)
-@raises_pattern(PicklingError, "Can't pickle * attribute lookup simple_callback on * failed")
+@raises(PicklingError, "Can't pickle * attribute lookup simple_callback on * failed")
 def _test_global_function_pickled_by_reference(name, py_callback_pickler):
     # modify callback name so that an attempt to pickle by reference, which is default Python behavior, fails
     _simple_callback.__name__ = _simple_callback.__qualname__ = "simple_callback"
@@ -301,7 +301,7 @@ def _test_pickle_by_value_decorator_on_global_function(name, py_callback_pickler
 
 
 @register_case(tests_dali_pickling)
-@raises_pattern(ValueError, "Expected special_dumps_param among kwargs, got *")
+@raises(ValueError, "Expected special_dumps_param among kwargs, got *")
 def _test_pickle_does_not_pass_extra_params_function(name, py_callback_pickler):
     this_module = __import__(__name__)
     _create_and_compare_simple_pipelines(callback_const_42, this_module, batch_size=4, py_num_workers=2)


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [x] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Added `assert_raises_pattern` function and `raises_pattern` decorator that work as nose `assert_raises` and `raises` but
with additional pattern check on exception message.

#### Additional information
- Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2233
