### PR TITLE
Extend BlockSetup with 1-dim specialization

### DIFF
--- a/dali/kernels/common/block_setup.h
+++ b/dali/kernels/common/block_setup.h
@@ -25,12 +25,20 @@
 namespace dali {
 namespace kernels {
 
+/**
+ * @brief Block descriptor specifying multidimensional range for given sample.
+ */
 template <int ndim>
 struct BlockDesc {
   int sample_idx;
   ivec<ndim> start, end;
 };
 
+/**
+ * @brief Block descriptor specifying range in given sample.
+ *
+ * Specialization for 1 dim to support 64bit addressing range.
+ */
 template <>
 struct BlockDesc<1> {
   int sample_idx;

--- a/dali/kernels/imgproc/roi.h
+++ b/dali/kernels/imgproc/roi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,18 +43,18 @@ namespace kernels {
 template <int ndims>
 using Roi = Box<ndims, int>;
 
-template <int n>
+template <int n, typename T = int32_t>
 DALI_HOST_DEV
-ivec<n> shape2vec(const TensorShape<n> &shape) {
-  ivec<n> ret;
+vec<n, T> shape2vec(const TensorShape<n> &shape) {
+  vec<n, T> ret;
   for (int i = 0; i < n; i++)
     ret[n-1-i] = shape[i];
   return ret;
 }
 
-template <int n>
+template <int n, typename T>
 DALI_HOST_DEV
-TensorShape<n> vec2shape(const ivec<n> &shape_vec) {
+TensorShape<n> vec2shape(const vec<n, T> &shape_vec) {
   TensorShape<n> ret;
   for (int i = 0; i < n; i++)
     ret[n-1-i] = shape_vec[i];

--- a/dali/kernels/test/block_setup_test.cc
+++ b/dali/kernels/test/block_setup_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 #include "dali/kernels/common/block_setup.h"
 #include "dali/core/tensor_shape_print.h"
+#include "dali/core/int_literals.h"
 
 namespace dali {
 namespace kernels {
@@ -119,13 +120,13 @@ namespace {
 
 template <int dim>
 struct BlockMap {
-  unsigned end;
-  std::map<unsigned, BlockMap<dim-1>> inner;
+  int64_t end;
+  std::map<int64_t, BlockMap<dim-1>> inner;
 };
 
 template <>
 struct BlockMap<0> {
-  unsigned end;
+  int64_t end;
   // dummy - to avoid specialization
   const bool inner = false;
 };
@@ -146,7 +147,7 @@ inline void ValidateBlockMap(const BlockMap<0> &map, const TensorShape<0> &shape
 template <int dim>
 void ValidateBlockMap(const BlockMap<dim> &map, const TensorShape<dim> &shape) {
   ASSERT_FALSE(map.inner.empty());
-  unsigned i = 0;
+  int64_t i = 0;
   for (auto &p : map.inner) {
     ASSERT_EQ(p.first, i) << "Blocks don't cover the image";
     ASSERT_GT(p.second.end, i) << "Block end coordinate must be greater than start";
@@ -161,7 +162,7 @@ void ValidateBlockMap(const BlockMap<dim> &map, const TensorShape<dim> &shape) {
       EXPECT_EQ(p.second.inner, first_slice->inner) << "Inner block layout must be uniform";
     } else {
       first_slice = &p.second;
-      // Validate the first slice recurisvely - the remaining slices should be equal and
+      // Validate the first slice recursively - the remaining slices should be equal and
       // therefore don't require validation.
       ValidateBlockMap(p.second, shape.template last<dim-1>());
     }
@@ -169,6 +170,71 @@ void ValidateBlockMap(const BlockMap<dim> &map, const TensorShape<dim> &shape) {
 }
 
 }  // namespace
+
+TEST(BlockSetup, SetupBlocks_Variable_1D) {
+  TensorListShape<1> TLS({
+    { 1_i64 << 32 },
+    { (1_i64 << 32) + 1023 },
+    { 1024 },
+    { 512 },
+    { 733 },
+  });
+
+  BlockSetup<1, -1> setup(16);
+  setup.SetDefaultBlockSize({1024});
+  static_assert(setup.tensor_ndim == 1, "Incorrectly inferred tensor_ndim");
+  setup.SetupBlocks(TLS);
+  ASSERT_FALSE(setup.IsUniformSize());
+  int prev = -1;
+  BlockMap<1> map;
+  for (auto &blk : setup.Blocks()) {
+    if (blk.sample_idx != prev) {
+      if (prev != -1) {
+        ValidateBlockMap(map, TLS[prev]);
+      }
+      prev = blk.sample_idx;
+      map = {};
+    }
+    map.inner[blk.start.x].end = blk.end.x;
+  }
+  if (prev != -1)
+    ValidateBlockMap(map, TLS[prev]);
+
+  EXPECT_EQ(setup.GridDimVec(), ivec3(setup.Blocks().size(), 1, 1));
+}
+
+TEST(BlockSetup, SetupBlocks_Variable_1D_Ch) {
+  TensorListShape<2> TLS({
+    { 1_i64 << 32, 3 },
+    { (1_i64 << 32) + 1023, 5 },
+    { 1024, 3 },
+    { 512, 3 },
+    { 733, 3 },
+  });
+
+  BlockSetup<1, 1> setup(16);
+  setup.SetDefaultBlockSize({1024});
+  static_assert(setup.tensor_ndim == 2, "Incorrectly inferred tensor_ndim");
+  setup.SetupBlocks(TLS);
+  ASSERT_FALSE(setup.IsUniformSize());
+  int prev = -1;
+  BlockMap<1> map;
+  for (auto &blk : setup.Blocks()) {
+    if (blk.sample_idx != prev) {
+      if (prev != -1) {
+        ValidateBlockMap(map, TLS[prev].first<1>());
+      }
+      prev = blk.sample_idx;
+      map = {};
+    }
+    map.inner[blk.start.x].end = blk.end.x;
+  }
+  if (prev != -1)
+    ValidateBlockMap(map, TLS[prev].first<1>());
+
+  EXPECT_EQ(setup.GridDimVec(), ivec3(setup.Blocks().size(), 1, 1));
+}
+
 
 
 TEST(BlockSetup, SetupBlocks_Variable) {

--- a/dali/kernels/test/block_setup_test.cc
+++ b/dali/kernels/test/block_setup_test.cc
@@ -180,7 +180,7 @@ TEST(BlockSetup, SetupBlocks_Variable_1D) {
     { 733 },
   });
 
-  BlockSetup<1, -1> setup(16);
+  BlockSetup<1, -1> setup(1 << 16);
   setup.SetDefaultBlockSize({1024});
   static_assert(setup.tensor_ndim == 1, "Incorrectly inferred tensor_ndim");
   setup.SetupBlocks(TLS);
@@ -212,7 +212,7 @@ TEST(BlockSetup, SetupBlocks_Variable_1D_Ch) {
     { 733, 3 },
   });
 
-  BlockSetup<1, 1> setup(16);
+  BlockSetup<1, 1> setup(1 << 16);
   setup.SetDefaultBlockSize({1024});
   static_assert(setup.tensor_ndim == 2, "Incorrectly inferred tensor_ndim");
   setup.SetupBlocks(TLS);


### PR DESCRIPTION
## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [x] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
BlockSetup is now specialized for 1 dimension
to handle cases where the extent size doesn't
fit in 32 bit signed integer by using 64 bit
indexing. For other cases we keep the 32 bit
indexing to save space.

#### Additional information
- Affected modules and functionalities:
BlockSetup

- Key points relevant for the review:
If I didn't miss any `int` somewhere

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
