### PR TITLE
Fix incorrect use of a global variable in the test of operator Shapes.

### DIFF
--- a/dali/operators/generic/shapes_test.cc
+++ b/dali/operators/generic/shapes_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,25 +52,21 @@ struct ShapesTestArgs {
 template <typename TestArgs>
 class ShapesOpTest;
 
-template <typename Backend>
-static std::vector<std::unique_ptr<TensorList<Backend>>> inputs;
-
-
 template <typename OutputBackend, typename InputBackend, typename OutputType>
 class ShapesOpTest<ShapesTestArgs<OutputBackend, InputBackend, OutputType>>
 : public testing::DaliOperatorTest {
  public:
   using TestArgs = ShapesTestArgs<OutputBackend, InputBackend, OutputType>;
 
+  std::vector<std::unique_ptr<TensorList<InputBackend>>> inputs;
+
   ShapesOpTest() {
-    if (inputs<InputBackend>.empty()) {
-      std::mt19937_64 rng(12345);
-      for (int dim = 1; dim <= 6; dim++) {
-        inputs<InputBackend>.emplace_back(new TensorList<InputBackend>());
-        inputs<InputBackend>.back()->set_pinned(false);
-        int num_samples = 1 << (8-dim);  // Start with 128 and halve with each new dimension
-        GenerateShapeTestInputs(*inputs<InputBackend>.back(), rng, num_samples, dim);
-      }
+    std::mt19937_64 rng(12345);
+    for (int dim = 1; dim <= 6; dim++) {
+      inputs.emplace_back(new TensorList<InputBackend>());
+      inputs.back()->set_pinned(false);
+      int num_samples = 1 << (8-dim);  // Start with 128 and halve with each new dimension
+      GenerateShapeTestInputs(*inputs.back(), rng, num_samples, dim);
     }
   }
 
@@ -82,7 +78,7 @@ class ShapesOpTest<ShapesTestArgs<OutputBackend, InputBackend, OutputType>>
     testing::Arguments args;
     args.emplace("dtype", TestArgs::type_id());
     args.emplace("device", testing::detail::BackendStringName<OutputBackend>());
-    for (auto &in : inputs<InputBackend>) {
+    for (auto &in : inputs) {
       testing::TensorListWrapper out;
       this->RunTest(in.get(), out, args, VerifyShape);
     }


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [X] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
A global variable containing objects allocated with a default resource was used, which could sometimes result in a destruction order where the variable was destroyed after the default resources have been shut down.

#### Additional information
Affected modules: Tests

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
