### PR TITLE
Make view converters operate on samples only

### DIFF
--- a/dali/operators/audio/nonsilence_op.h
+++ b/dali/operators/audio/nonsilence_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@ void RunKernel(TensorView<StorageCPU, const InputType, 1> in, Tensor<CPUBackend>
   kernels::signal::MovingMeanSquareCpu<InputType> mms;
   auto reqs = mms.Setup(kctx, in, mms_args);
   out.Resize(reqs.output_shapes[0][0]);
-  auto tv = view_as_tensor<float>(out);
+  auto tv = view<float>(out);
   mms.Run(kctx, tv.template to_static<1>(), in, mms_args);
 }
 
@@ -121,7 +121,7 @@ template<typename InputType>
 std::pair<int, int>
 DetectNonsilenceRegion(Tensor<CPUBackend> &intermediate_buffer, const Args<InputType> &args) {
   RunKernel(args.input, intermediate_buffer, {args.window_length, args.reset_interval});
-  auto signal_mms = view_as_tensor<const float>(intermediate_buffer);
+  auto signal_mms = view<const float>(intermediate_buffer);
   kernels::signal::DecibelToMagnitude<float> db2mag(
       10.f, args.reference_max ? max_element(signal_mms) : args.reference_power);
   auto ret = LeadTrailThresh(make_cspan(signal_mms.data, signal_mms.num_elements()),

--- a/dali/operators/image/remap/displacement_filter_impl_cpu.h
+++ b/dali/operators/image/remap/displacement_filter_impl_cpu.h
@@ -93,8 +93,8 @@ class DisplacementFilter<CPUBackend, Displacement, per_channel_transform>
   void RunWarp(Tensor<CPUBackend> &output, const Tensor<CPUBackend> &input, int thread_idx) {
     auto &displace = displace_[thread_idx];
     In fill[1024];
-    auto in = view_as_tensor<const Out, 3>(input);
-    auto out = view_as_tensor<In, 3>(output);
+    auto in = view<const Out, 3>(input);
+    auto out = view<In, 3>(output);
 
     for (int i = 0; i < in.shape[2]; i++) {
       fill[i] = fill_value_;

--- a/dali/pipeline/data/tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_vector_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -195,7 +195,7 @@ class TensorVectorVariableBatchSizeTest : public ::testing::Test {
     test_tv_.Resize(shape_);
     test_tv_.set_type(TypeInfo::Create<float>());
     for (int i = 0; i < shape_.num_samples(); i++) {
-      UniformRandomFill(view_as_tensor<float>(test_tv_[i]), rng_, 0.f, 1.f);
+      UniformRandomFill(view<float>(test_tv_[i]), rng_, 0.f, 1.f);
     }
   }
 

--- a/dali/pipeline/data/view_test.cc
+++ b/dali/pipeline/data/view_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,52 +47,6 @@ TEST(TensorList, View_StaticDim) {
   }
 
   EXPECT_ENFORCE_FAIL((view<float, 2>(tl)));
-}
-
-TEST(TensorList, ViewAsTensor_Fail_NonUniform) {
-  TensorList<CPUBackend> tl;
-  TensorListShape<> shapes = { { {640, 480, 3}, {640, 360, 3} } };
-  tl.Resize(shapes);
-  EXPECT_ENFORCE_FAIL((view_as_tensor<float>(tl)))
-    << "Non-uniform tensor list cannot be viewed as a tensor and view_as_tensor should throw";
-}
-
-TEST(TensorList, ViewAsTensor_StaticDim) {
-  TensorList<CPUBackend> tl;
-  TensorListShape<> shapes = { { {640, 480, 3}, {640, 480, 3} } };
-  tl.Resize(shapes);
-  EXPECT_ENFORCE_FAIL((view_as_tensor<float, 3>(tl)))
-    << "List of 3D tensor should yield a 4D flattened tensor";
-  TensorView<StorageCPU, float, 4> tv;
-  EXPECT_NO_THROW((tv = view_as_tensor<float, 4>(tl)))
-    << "List of 3D tensor should yield a 4D flattened tensor";
-
-  ASSERT_EQ(tv.dim(), static_cast<int>(shapes[0].size()) + 1)
-    << "Resulting tensor must be " << shapes[0].size()+1 << "D";
-
-  EXPECT_EQ(tv.shape[0], shapes.size())
-    << "Outermost size must be equal to the number of samples in the input";
-
-  for (int i = 0; i < static_cast<int>(shapes[0].size()); i++) {
-    EXPECT_EQ(tv.shape[i + 1], shapes[0][i]) << "Wrong size along dimension " << i+1;
-  }
-}
-
-TEST(TensorList, ViewAsTensor) {
-  TensorList<CPUBackend> tl;
-  TensorListShape<> shapes = { { {640, 480, 3}, {640, 480, 3} } };
-  tl.Resize(shapes);
-  auto tv = view_as_tensor<float>(tl);
-
-  ASSERT_EQ(tv.dim(), static_cast<int>(shapes[0].size()) + 1)
-    << "Resulting tensor must be " << shapes[0].size()+1 << "D";
-
-  EXPECT_EQ(tv.shape[0], shapes.size())
-    << "Outermost size must be equal to the number of samples in the input";
-
-  for (int i = 0; i < static_cast<int>(shapes[0].size()); i++) {
-    EXPECT_EQ(tv.shape[i + 1], shapes[0][i]) << "Wrong size along dimension " << i+1;
-  }
 }
 
 TEST(Tensor, ViewAsTensor) {

--- a/dali/pipeline/data/views.h
+++ b/dali/pipeline/data/views.h
@@ -16,11 +16,12 @@
 #define  DALI_PIPELINE_DATA_VIEWS_H_
 
 #include <string>
+#include <utility>
 #include <vector>
-#include "dali/core/tensor_view.h"
 #include "dali/core/backend_tags.h"
-#include "dali/pipeline/data/tensor_list.h"
+#include "dali/core/tensor_view.h"
 #include "dali/pipeline/data/tensor.h"
+#include "dali/pipeline/data/tensor_list.h"
 #include "dali/pipeline/data/tensor_vector.h"
 
 namespace dali {


### PR DESCRIPTION
## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [x] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
`view` for TensorList now accesses samples only
instead of the underlying contiguous buffer.
Remove `view_as_tensor` - never used for TensorList
other than in tests, for Tensor just `view` can
be used.


#### Additional information
- Affected modules and functionalities:
`view`

- Key points relevant for the review:

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2255
<!--- DALI-XXXX or NA --->
