### PR TITLE
Use memory resources in DeviceBuffer and TestTensorList

### DIFF
--- a/dali/core/dev_buffer_test.cc
+++ b/dali/core/dev_buffer_test.cc
@@ -104,8 +104,10 @@ TEST(DeviceBuffer, FromDevice) {
 
 TEST(DeviceBufferFail, Resize) {
   DeviceBuffer<int> db;
-  size_t size = -1_uz;
-  EXPECT_THROW(db.resize(size), CUDABadAlloc);
+  size_t size = -1_uz;  // this should overflow when aligning
+  EXPECT_THROW(db.resize(size), std::bad_alloc);
+  size >>= 1;  // this should just be OOM
+  EXPECT_THROW(db.resize(size), std::bad_alloc);
 }
 
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [X] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [X] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
- Use mm::alloc_raw_unique in DeviceBuffer and TestTensorList
- Add a check in async_pool and cuda_vm_resource for size overflow due to alignment (basically only affects tests).

#### Additional information
##### Affected modules
* Tests
* DeviceBuffer
* cuda_vm_resource
* async_pool

## Checklist

### Tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2281, DALI-2282
<!--- DALI-XXXX or NA --->
