### PR TITLE
Fix squeeze operator test on Python3.7 and earlier

### DIFF
--- a/dali/test/python/test_operator_squeeze.py
+++ b/dali/test/python/test_operator_squeeze.py
@@ -81,5 +81,5 @@ def test_squeeze_throw_error():
         "Specified at least twice same dimension to remove."
     ]
     assert len(expected_errors) == len(args_list)
-    for args, error_msg in zip(args_list, expected_errors):
-        yield raises(RuntimeError, error_msg)(_test_squeeze_throw_error), *args
+    for (axes, axis_names, layout, shapes), error_msg in zip(args_list, expected_errors):
+        yield raises(RuntimeError, error_msg)(_test_squeeze_throw_error), axes, axis_names, layout, shapes


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

Fix squeeze operator test on Python3.7 and earlier

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR


#### Additional information
- Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
