### PR TITLE
Skip Keras TF tests in versions with broken execption handling

### DIFF
--- a/dali/test/python/test_dali_tf_dataset_mnist_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_mnist_eager.py
@@ -28,7 +28,7 @@ def test_keras_single_other_gpu():
 def test_keras_single_cpu():
     run_keras_single_device('cpu', 0)
 
-
+@with_setup(skip_for_incompatible_tf)
 @raises(Exception, "TF device and DALI device mismatch")
 def test_keras_wrong_placement_gpu():
     with tf.device('cpu:0'):
@@ -41,6 +41,7 @@ def test_keras_wrong_placement_gpu():
         steps_per_epoch=ITERATIONS)
 
 
+@with_setup(skip_for_incompatible_tf)
 @raises(Exception, "TF device and DALI device mismatch")
 def test_keras_wrong_placement_cpu():
     with tf.device('gpu:0'):


### PR DESCRIPTION
## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
The functionality works ok, and the expected DALI
exception is thrown but it is hidden in internal
exception by Keras.
Skip the tests temporarily.

#### Additional information
- Affected modules and functionalities:
TF tests

- Key points relevant for the review:
N/A

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] ~New tests added~ Tests removed
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
