### PR TITLE
Work around PyTorch internal fragmentation in L3 SSD test.

### DIFF
--- a/qa/TL3_SSD_convergence/test_pytorch.sh
+++ b/qa/TL3_SSD_convergence/test_pytorch.sh
@@ -18,6 +18,8 @@ NUM_GPUS=$(nvidia-smi -L | wc -l)
 LOG=dali.log
 
 SECONDS=0
+# Prevent OOM due to fragmentation on 16G machines
+export PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:4096
 python -m torch.distributed.launch --nproc_per_node=${NUM_GPUS} main.py --backbone resnet50 --warmup 300 --bs 64 --eval-batch-size 8 --data /coco --data /data/coco/coco-2017/coco2017/ --data_pipeline dali --target 0.25 2>&1 | tee $LOG
 
 RET=${PIPESTATUS[0]}


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [X] **Other** (*e.g. Documentation, Tests, Configuration*)

Test configuration change.

### What happened in this PR
After memory consumption in DALI changed, we started hitting some unlucky memory allocation pattern in PyTorch, which results in internal fragmentation and an error being raised by PyTorch. This PR limits the size of blocks that go to fancy allocators in PyTorch, thereby mitigating fragmentation and the error.

#### Additional information
- Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [X] Other
- [ ] N/A
Comment in the test script.

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
