### PR TITLE
Fix bugs in C API and refactor tests

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -41,7 +41,7 @@ bool dali_initialized = false;
  * Typically, this operator will be BatchSizeProvider.
  * Negative values denote max batch size (default state).
  * Typical usage:
- * auto batch_sizes_map = reinterpret_cast<batch_size_map_t*>(handle->batch_sizes_map);
+ * auto *batch_size_map = reinterpret_cast<batch_size_map_t *>(handle->batch_size_map);
  */
 using batch_size_map_t = std::unordered_map<std::string /* op_name */, int /* batch_size */>;
 
@@ -80,7 +80,7 @@ void SetExternalInput(daliPipelineHandle *pipe_handle, const char *name, const v
                       dali_data_type_t data_type, const int64_t *shapes, int sample_dim,
                       const char *layout_str, cudaStream_t stream = 0, unsigned int flags = 0) {
   dali::Pipeline *pipeline = reinterpret_cast<dali::Pipeline *>(pipe_handle->pipe);
-  auto bs_map = reinterpret_cast<batch_size_map_t *>(pipe_handle->batch_sizes_map);
+  auto *bs_map = reinterpret_cast<batch_size_map_t *>(pipe_handle->batch_size_map);
   auto curr_batch_size = PopCurrBatchSize(bs_map, pipeline->max_batch_size(), name);
   std::vector<int64_t> shapes_tmp(shapes, shapes + sample_dim * curr_batch_size);
   dali::TensorListShape<> tl_shape(std::move(shapes_tmp), curr_batch_size, sample_dim);
@@ -111,7 +111,7 @@ void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
                              const int64_t *shapes, int64_t sample_dim, const char *layout_str,
                              cudaStream_t stream = 0, unsigned int flags = 0) {
   dali::Pipeline *pipeline = reinterpret_cast<dali::Pipeline *>(pipe_handle->pipe);
-  auto bs_map = reinterpret_cast<batch_size_map_t *>(pipe_handle->batch_sizes_map);
+  auto *bs_map = reinterpret_cast<batch_size_map_t *>(pipe_handle->batch_size_map);
   auto curr_batch_size = PopCurrBatchSize(bs_map, pipeline->max_batch_size(), name);
   std::vector<int64_t> shapes_tmp(shapes, shapes + sample_dim * curr_batch_size);
   dali::TensorListShape<> tl_shape(std::move(shapes_tmp), curr_batch_size, sample_dim);
@@ -182,7 +182,7 @@ void daliCreatePipeline(daliPipelineHandle *pipe_handle, const char *serialized_
   pipe_handle->ws = ws.release();
   pipe_handle->copy_stream = stream.release();
   pipe_handle->pipe = pipeline.release();
-  pipe_handle->batch_sizes_map = bs_map.release();
+  pipe_handle->batch_size_map = bs_map.release();
 }
 
 
@@ -199,7 +199,7 @@ void daliDeserializeDefault(daliPipelineHandle *pipe_handle, const char *seriali
   pipe_handle->ws = ws.release();
   pipe_handle->copy_stream = stream.release();
   pipe_handle->pipe = pipeline.release();
-  pipe_handle->batch_sizes_map = bs_map.release();
+  pipe_handle->batch_size_map = bs_map.release();
 }
 
 
@@ -227,7 +227,7 @@ void daliPrefetchSeparate(daliPipelineHandle *pipe_handle,
 
 void daliSetExternalInputBatchSize(daliPipelineHandle *pipe_handle, const char *name,
                                    int batch_size) {
-  auto *bs_map = reinterpret_cast<batch_size_map_t *>(pipe_handle->batch_sizes_map);
+  auto *bs_map = reinterpret_cast<batch_size_map_t *>(pipe_handle->batch_size_map);
   (*bs_map)[name] = batch_size;
 }
 
@@ -543,7 +543,7 @@ void daliCopyTensorListNTo(daliPipelineHandle *pipe_handle, void *dst, int outpu
 void daliDeletePipeline(daliPipelineHandle* pipe_handle) {
   dali::Pipeline *pipeline = reinterpret_cast<dali::Pipeline *>(pipe_handle->pipe);
   dali::DeviceWorkspace *ws = reinterpret_cast<dali::DeviceWorkspace *>(pipe_handle->ws);
-  auto *bs_map = reinterpret_cast<batch_size_map_t *>(pipe_handle->batch_sizes_map);
+  auto *bs_map = reinterpret_cast<batch_size_map_t *>(pipe_handle->batch_size_map);
   DALI_ENFORCE(pipeline != nullptr && ws != nullptr, "Pipeline already deleted");
   if (pipe_handle->copy_stream) {
     CUDA_CALL(cudaStreamDestroy(pipe_handle->copy_stream));
@@ -554,7 +554,7 @@ void daliDeletePipeline(daliPipelineHandle* pipe_handle) {
   delete bs_map;
   pipe_handle->ws = nullptr;
   pipe_handle->pipe = nullptr;
-  pipe_handle->batch_sizes_map = nullptr;
+  pipe_handle->batch_size_map = nullptr;
 }
 
 void daliLoadLibrary(const char* lib_path) {

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -177,11 +177,11 @@ void daliCreatePipeline(daliPipelineHandle *pipe_handle, const char *serialized_
   if (pipeline->device_id() >= 0) {
     stream = dali::CUDAStream::Create(true);
   }
+  auto bs_map = std::make_unique<batch_size_map_t>();
+
   pipe_handle->ws = ws.release();
   pipe_handle->copy_stream = stream.release();
   pipe_handle->pipe = pipeline.release();
-
-  auto bs_map = std::make_unique<batch_size_map_t>();
   pipe_handle->batch_sizes_map = bs_map.release();
 }
 
@@ -195,9 +195,11 @@ void daliDeserializeDefault(daliPipelineHandle *pipe_handle, const char *seriali
     stream = dali::CUDAStream::Create(true);
   }
   auto ws = std::make_unique<dali::DeviceWorkspace>();
+  auto bs_map = std::make_unique<batch_size_map_t>();
   pipe_handle->ws = ws.release();
   pipe_handle->copy_stream = stream.release();
   pipe_handle->pipe = pipeline.release();
+  pipe_handle->batch_sizes_map = bs_map.release();
 }
 
 

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -176,10 +176,6 @@ void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline,
     Check(view<uint8_t>(pipeline_output_cpu),
           TensorListView<StorageCPU, uint8_t>(cpu_buf.get(), pipeline_output_cpu.shape()));
   }
-  baseline.ReleaseOutputs();
-  daliOutputRelease(&handle);
-
-  CUDA_CALL(cudaDeviceSynchronize());
 }
 
 }  // namespace
@@ -921,7 +917,6 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
       Check(view<uint8_t>(output1_cpu), view<uint8_t>(output2_cpu));
     }
   }
-  daliOutputRelease(&handle);
   daliDeletePipeline(&handle);
 }
 

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -935,6 +935,7 @@ TYPED_TEST(CApiTest, CpuOnlyTest) {
   std::string ser = pipe.SerializeToProtobuf();
   daliPipelineHandle handle;
   daliDeserializeDefault(&handle, ser.c_str(), ser.size());
+  daliDeletePipeline(&handle);
 }
 
 TEST(CApiTest, GetBackendTest) {
@@ -958,6 +959,7 @@ TEST(CApiTest, GetBackendTest) {
   EXPECT_EQ(daliGetOperatorBackend(&handle, es_cpu_name.c_str()), DALI_BACKEND_CPU);
   EXPECT_EQ(daliGetOperatorBackend(&handle, es_gpu_name.c_str()), DALI_BACKEND_GPU);
   EXPECT_EQ(daliGetOperatorBackend(&handle, cont_name.c_str()), DALI_BACKEND_MIXED);
+  daliDeletePipeline(&handle);
 }
 
 }  // namespace dali

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -226,6 +226,8 @@ TYPED_TEST(CApiTest, GetOutputNameTest) {
   ASSERT_EQ(daliGetNumOutput(&handle), 2);
   EXPECT_STREQ(daliGetOutputName(&handle, 0), output0_name.c_str());
   EXPECT_STREQ(daliGetOutputName(&handle, 1), output1_name.c_str());
+
+  daliDeletePipeline(&handle);
 }
 
 
@@ -255,6 +257,7 @@ TYPED_TEST(CApiTest, FileReaderPipe) {
   pipe_ptr->RunGPU();
 
   ComparePipelinesOutputs<TypeParam>(handle, *pipe_ptr);
+  daliDeletePipeline(&handle);
 }
 
 TYPED_TEST(CApiTest, FileReaderDefaultPipe) {
@@ -281,6 +284,7 @@ TYPED_TEST(CApiTest, FileReaderDefaultPipe) {
   pipe_ptr->RunGPU();
 
   ComparePipelinesOutputs<TypeParam>(handle, *pipe_ptr);
+  daliDeletePipeline(&handle);
 }
 
 
@@ -342,6 +346,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
   pipe_ptr->RunGPU();
 
   ComparePipelinesOutputs<TypeParam>(handle, *pipe_ptr);
+  daliDeletePipeline(&handle);
 }
 
 
@@ -400,6 +405,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocVariableBatchSizePipe) {
                                          input_shape.num_samples());
     }
   }
+  daliDeletePipeline(&handle);
 }
 
 
@@ -460,6 +466,7 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
   pipe_ptr->RunGPU();
 
   ComparePipelinesOutputs<TypeParam>(handle, *pipe_ptr);
+  daliDeletePipeline(&handle);
 }
 
 
@@ -527,6 +534,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocDifferentBackendsTest) {
   pipe_ptr->RunGPU();
 
   ComparePipelinesOutputs<OpBackend>(handle, *pipe_ptr);
+  daliDeletePipeline(&handle);
 }
 
 
@@ -593,6 +601,7 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocDifferentBackendsTest) {
   pipe_ptr->RunGPU();
 
   ComparePipelinesOutputs<OpBackend>(handle, *pipe_ptr);
+  daliDeletePipeline(&handle);
 }
 
 TYPED_TEST(CApiTest, TestExecutorMeta) {
@@ -620,6 +629,7 @@ TYPED_TEST(CApiTest, TestExecutorMeta) {
     }
   }
   daliFreeExecutorMetadata(meta, N);
+  daliDeletePipeline(&handle);
 }
 
 TYPED_TEST(CApiTest, UseCopyKernel) {
@@ -669,6 +679,7 @@ TYPED_TEST(CApiTest, UseCopyKernel) {
   for (int i = 0; i < prefetch_queue_depth; i++) {
     ComparePipelinesOutputs<TypeParam>(handle, *pipe_ptr, flags);
   }
+  daliDeletePipeline(&handle);
 }
 
 
@@ -708,6 +719,7 @@ TYPED_TEST(CApiTest, ForceNoCopyFail) {
                     input.get(), dali_data_type_t::DALI_UINT8, input_shape.data(),
                     input_shape.sample_dim(), nullptr, cuda_stream, DALI_ext_force_no_copy),
                 std::runtime_error);
+  daliDeletePipeline(&handle);
 }
 
 

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -745,7 +745,7 @@ void TestForceFlagRun(bool ext_src_no_copy, unsigned int flag_to_test) {
   for (int i = 0; i < prefetch_queue_depth; i++) {
     data.push_back(AllocBuffer<TypeParam>(num_elems * sizeof(uint8_t), false));
   }
-  std::vector<TensorList<TypeParam>> input_wrapper(3);
+  std::vector<TensorList<TypeParam>> input_wrapper(prefetch_queue_depth);
 
   for (int i = 0; i < prefetch_queue_depth; i++) {
     SequentialFill(TensorListView<StorageCPU, uint8_t>(input_cpu.get(), input_shape), 42 * i);

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -33,7 +33,7 @@ extern "C" {
 typedef struct {
   void *pipe;
   void *ws;
-  void *batch_sizes_map;     /// @see batch_size_map_t
+  void *batch_size_map;     /// @see batch_size_map_t
   cudaStream_t copy_stream;  /// Stream to perform copy operations on
 } daliPipelineHandle;
 


### PR DESCRIPTION
## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [x] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Fix `daliDeserializeDefault` - the batch size
map was not allocated and when the pipeline
handle was correctly cleaned, it tried to
deallocate memory under invalid pointer.

Add missing `daliDeletePipeline` in all C API tests
so the tests no longer leak the created pipeline.

Some tests (daliOutputCopySamples) used to fill the
prefetch queue and schedule additional runs, 
whilst accessing only one output iteration. 
The not-freed pipeline could be actively using the memory
when the memory resources were cleared on shutdown
and the whole test process could crash during shutdown.
Remove the additional unused iteration in such case.

Rework tests to not use access to underlying
contiguous buffer of TensorList.

#### Additional information
- Affected modules and functionalities:
C API

- Key points relevant for the review:


## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
