### PR TITLE
Fix variable batch size handling in pad operator

### DIFF
--- a/dali/operators/generic/pad.h
+++ b/dali/operators/generic/pad.h
@@ -67,6 +67,7 @@ class Pad : public Operator<Backend> {
     auto in_layout = input.GetLayout();
     int ndim = in_shape.sample_dim();
     int nsamples = in_shape.num_samples();
+    bool shape_arg_provided = false;
 
     if (!axis_names_.empty()) {
       axes_ = GetDimIndices(in_layout, axis_names_).to_vector();
@@ -85,12 +86,13 @@ class Pad : public Operator<Backend> {
 
     if (spec.ArgumentDefined("shape")) {
       GetShapeArgument(shape_, spec, "shape", ws, curr_batch_size);
+      shape_arg_provided = true;
     }
     if (spec.ArgumentDefined("align")) {
       GetShapeArgument(align_, spec, "align", ws, curr_batch_size);
     }
 
-    if (shape_.empty())
+    if (!shape_arg_provided)
       shape_ = uniform_list_shape(nsamples, TensorShape<>(std::vector<int64_t>(axes_.size(), -1)));
     // If a single *align* value is provided, use this value for all the axes
     for (int i = 0; i < nsamples; i++) {

--- a/dali/test/python/test_dali_variable_batch_size.py
+++ b/dali/test/python/test_dali_variable_batch_size.py
@@ -318,6 +318,7 @@ ops_image_custom_args = [
     (fn.gaussian_blur, {'window_size': 5}),
     (fn.normalize, {'batch': True}),
     (fn.pad, {'fill_value': -1, 'axes': (0,), 'shape': (10,)}),
+    (fn.pad, {'fill_value': -1, 'axes': (0,), 'align': 16}),
     (fn.paste, {'fill_value': 69, 'ratio': 1, 'devices': ['gpu']}),
     (fn.resize, {'resize_x': 50, 'resize_y': 50}),
     (fn.resize_crop_mirror, {'crop': [5, 5], 'resize_shorter': 10, 'devices': ['cpu']}),


### PR DESCRIPTION
Signed-off-by: Rafal <Banas.Rafal97@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Currently, when shape is not provided, it is set to default value, but only once, due to the check in line 95 (`if shape.empty()`).
This caused problems when the batch size was changed because the shape was not adjusted to that. 
My fix checks if the shape is provided in the current iteration instead of checking if it's empty, so whenever the shape arg is not provided, the shape will be filled with default value of a correct size. 
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a crash in Pad operator happening when there is no shape provided and the batch size is increased during runtime
--->

#### Additional information
- Affected modules and functionalities:
Pad setup and var BS tests

- Key points relevant for the review:
Pad

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2290
<!--- DALI-XXXX or NA --->
