### PR TITLE
Fix Video reader race condition

### DIFF
--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -179,9 +179,8 @@ class DataReader : public Operator<Backend> {
     // Consume batch
     Operator<Backend>::Run(ws);
     CUDA_CALL(cudaStreamSynchronize(ws.stream()));
-    for (int sample_idx = 0; sample_idx < max_batch_size_; sample_idx++) {
-      auto sample = MoveSample(sample_idx);
-    }
+    // clear samples from the current batch so they can be recycled
+    ClearCurentBatch();
 
     // Notify we have consumed a batch
     ConsumerAdvanceQueue();
@@ -214,11 +213,8 @@ class DataReader : public Operator<Backend> {
     return *GetCurrBatch()[sample_idx];
   }
 
-  LoadTargetPtr MoveSample(int sample_idx) {
-    auto &sample = prefetched_batch_queue_[curr_batch_consumer_][sample_idx];
-    auto sample_ptr = std::move(sample);
-    sample = {};
-    return sample_ptr;
+  void ClearCurentBatch() {
+    prefetched_batch_queue_[curr_batch_consumer_].clear();
   }
 
  protected:

--- a/dali/operators/reader/reader_op.h
+++ b/dali/operators/reader/reader_op.h
@@ -84,8 +84,8 @@ class DataReader : public Operator<Backend> {
     DomainTimeRange tr("[DALI][DataReader] Prefetch #" + to_string(curr_batch_producer_),
                        DomainTimeRange::kRed);
     auto &curr_batch = prefetched_batch_queue_[curr_batch_producer_];
-    curr_batch.reserve(max_batch_size_);
     curr_batch.clear();
+    curr_batch.reserve(max_batch_size_);
     for (int i = 0; i < max_batch_size_; ++i) {
       curr_batch.push_back(loader_->ReadOne(i == 0));
     }


### PR DESCRIPTION
- there is a race condition between the video reader
  destructor and the reader Run method. After the reader
  run method, all current batch samples are zeroed
  to recycle the underlying storage. However, the video
  reader destructor calls the` wait` method on all samples
  in the prefetch buffer to make sure that all underlying
  kernels that operate on them ended. There is a short period
  between zeroing samples and creating a fresh batch where
  the destructor may attempt to access nullptr. This PR fixes
  the issue but not only clearing all samples but reducing
  vector length that holds them to 0 so the destructor won't
  access them as it iterates only over available samples in the vector

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
- there is a race condition between the video reader
  destructor and the reader Run method. After the reader
  run method, all current batch samples are zeroed
  to recycle the underlying storage. However, the video
  reader destructor calls the` wait` method on all samples
  in the prefetch buffer to make sure that all underlying
  kernels that operate on them ended. There is a short period
  between zeroing samples and creating a fresh batch where
  the destructor may attempt to access nullptr. This PR fixes
  the issue but not only clearing all samples but reducing
  vector length that holds them to 0 so the destructor won't
  access them as it iterates only over available samples in the vector
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

#### Additional information
- Affected modules and functionalities:
  - reader_op.
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
  - NA 
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2292
<!--- DALI-XXXX or NA --->
