### PR TITLE
Fix the memory kind stored in AllocInfo in nvjpeg memory.

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_memory.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_memory.cc
@@ -139,7 +139,8 @@ struct NVJpegMem {
     auto ptr = mm::alloc_raw_unique<char>(mr, size);
     std::unique_lock<std::shared_timed_mutex> lock(alloc_info_mutex_);
     AllocInfo &ai = alloc_info_[ptr.get()];  // create entry first (before moving out the deleter)
-    ai = { mm::memory_kind_id::device, std::move(ptr.get_deleter()), size, thread_id};
+    mm::memory_kind_id kind = mm::kind2id_v<MemoryKind>;
+    ai = { kind, std::move(ptr.get_deleter()), size, thread_id};
     return {ptr.release(), {}};
   }
 
@@ -379,7 +380,7 @@ nvjpeg2kDeviceAllocator_t GetDeviceAllocatorNvJpeg2k() {
 
 nvjpeg2kPinnedAllocator_t GetPinnedAllocatorNvJpeg2k() {
   nvjpeg2kPinnedAllocator_t allocator;
-  allocator.pinned_malloc = &PinnedNew;
+  allocator.pinned_malloc = &HostNew;
   allocator.pinned_free = &ReturnBufferToPool;
   return allocator;
 }


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [X] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
* Fix the memory kind stored in AllocInfo in nvjpeg memory.
* Use non-pinned memory in NVJPEG2k when RestrictPinnedMem is set.

#### Additional information
##### Affected modules:
NVJPEG decoder family

#### Key points relevant for the review:
N/A

## Checklist

### Tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
