### PR TITLE
Fix HW decoder overwriting growth factor for CPU buffers

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -117,7 +117,6 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
         NVJPEG_CALL(nvjpegJpegStateCreate(handle_, &state_hw_batched_));
         if (!RestrictPinnedMemUsage()) {
           hw_decoder_images_staging_.set_pinned(true);
-          hw_decoder_images_staging_.SetGrowthFactor(2);
           // assume close the worst case size 300kb per image
           auto shapes = uniform_list_shape(CalcHwDecoderBatchSize(hw_decoder_load_,
                                            max_batch_size_), TensorShape<1>{300*1024});


### PR DESCRIPTION
## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
The growth factor was overriden in HW decoder codepath
for newer drivers. As this call sets the factor for
all CPU buffers (static method) instead one particular
buffer, this behaviour is not intended.

With the introduction of pinned pool the allocations
in HW decoder should now be fast enough.


#### Additional information
- Affected modules and functionalities:
HW decoder/CPU buffers

- Key points relevant for the review:
N/A

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
