### PR TITLE
Fix pool process tracking in parallel ES tests, cleanup batches properly

### DIFF
--- a/dali/python/nvidia/dali/_multiproc/pool.py
+++ b/dali/python/nvidia/dali/_multiproc/pool.py
@@ -126,8 +126,7 @@ received so far.
         """Check if given batch notified error and raise it"""
         if batch_i in self.iter_failed:
             exception, traceback_str = self.iter_failed[batch_i]
-            del self.iter_failed[batch_i]
-            del self.partially_received[batch_i]
+            self.clear_scheduled(batch_i)
             if isinstance(exception, StopIteration):
                 raise exception
             else:
@@ -149,11 +148,16 @@ received so far.
         """Check if we didn't receive all results for given tasks and batch_i"""
         return len(self.partially_received[batch_i]) < len(tasks)
 
+    def clear_scheduled(self, batch_i):
+        del self.partially_received[batch_i]
+        if batch_i in self.iter_failed:
+            del self.iter_failed[batch_i]
+
     def get_batch(self, batch_i, tasks):
         """Return the full batch, mark it as cleared and consumed"""
         full_batch = self.partially_received[batch_i]
         res = [full_batch[i] for i, _ in tasks]
-        del full_batch
+        self.clear_scheduled(batch_i)
         return res
 
     def receive_chunk(self, batch_i, sock, serialized_batch):

--- a/dali/test/python/test_external_source_parallel_mxnet.py
+++ b/dali/test/python/test_external_source_parallel_mxnet.py
@@ -19,7 +19,6 @@
 
 import mxnet as mx
 from nose_utils import raises
-from nose.tools import with_setup
 
 from test_pool_utils import *
 from test_external_source_parallel_utils import *
@@ -30,7 +29,6 @@ class ExtCallbackMX(ExtCallback):
         return mx.nd.array(a, dtype=a.dtype)
 
 
-@with_setup(setup_function, teardown_function)
 def test_mxnet():
     yield from check_spawn_with_callback(ExtCallbackMX)
 
@@ -44,7 +42,6 @@ class ExtCallbackMXCuda(ExtCallback):
 @raises(Exception, "Exception traceback received from worker thread*"
                    "TypeError: Unsupported callback return type. GPU tensors*not supported*"
                    "Got*MXNet GPU tensor.")
-@with_setup(setup_function, teardown_function)
 def test_mxnet_cuda():
     callback = ExtCallbackMXCuda((4, 5), 10, np.int32)
     pipe = create_pipe(callback, 'cpu', 5, py_num_workers=6,

--- a/dali/test/python/test_external_source_parallel_pytorch.py
+++ b/dali/test/python/test_external_source_parallel_pytorch.py
@@ -19,7 +19,6 @@
 
 import torch
 from nose_utils import raises
-from nose.tools import with_setup
 
 from test_pool_utils import *
 from test_external_source_parallel_utils import *
@@ -33,7 +32,6 @@ class ExtCallbackTorch(ExtCallback):
 @raises(RuntimeError, "Error*starting Python worker threads for*parallel External Source*"
                       "Cannot fork*CUDA context already bound*"
                       "*start_py_workers*fork*spawn*")
-@with_setup(setup_function, teardown_function)
 def test_pytorch_cuda_context():
     # Create a dummy torch CUDA tensor so we acquire CUDA context
     cuda0 = torch.device('cuda:0')
@@ -42,10 +40,8 @@ def test_pytorch_cuda_context():
     pipe = create_pipe(callback, 'cpu', 5, py_num_workers=6,
                        py_start_method='fork', parallel=True)
     pipe.start_py_workers()
-    capture_processes(pipe._py_pool)
 
 
-@with_setup(setup_function, teardown_function)
 def test_pytorch():
     yield from check_spawn_with_callback(ExtCallbackTorch)
 
@@ -58,7 +54,6 @@ class ExtCallbackTorchCuda(ExtCallback):
 @raises(Exception, "Exception traceback received from worker thread*"
                    "TypeError: Unsupported callback return type. GPU tensors*not supported*"
                    "Got*PyTorch GPU tensor")
-@with_setup(setup_function, teardown_function)
 def test_pytorch_cuda():
     callback = ExtCallbackTorchCuda((4, 5), 10, np.int32)
     pipe = create_pipe(callback, 'cpu', 5, py_num_workers=6,

--- a/dali/test/python/test_external_source_parallel_utils.py
+++ b/dali/test/python/test_external_source_parallel_utils.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 import numpy as np
+from nose.tools import with_setup
 import nvidia.dali as dali
+
+from test_pool_utils import capture_processes, teardown_function, setup_function
 
 from test_pool_utils import capture_processes
 from test_utils import compare_pipelines, check_batch, RandomDataIterator, RandomlyShapedDataIterator
@@ -97,6 +100,17 @@ def check_callback(parallel_pipe, pipe, epoch_size, batch_size, dtype=None):
     parallel_pipe._py_pool.close()
 
 
+@with_setup(setup_function, teardown_function)
+def _check_spawn_with_callback(callback, callback_ref, batch_size, num_outputs, layout, workers_num, epoch_size, dtype):
+    pipe_parallel = create_pipe(
+        callback, 'cpu', batch_size, py_num_workers=workers_num,
+        py_start_method='spawn', parallel=True, num_outputs=num_outputs,
+        layout=layout)
+    pipe = create_pipe(
+        callback_ref, 'cpu', batch_size, parallel=False,
+        num_outputs=num_outputs, layout=layout)
+    check_callback(pipe_parallel, pipe, epoch_size, batch_size, dtype)
+
 def check_spawn_with_callback(
         callback_class, callback_ref_class=ExtCallback, num_outputs=None, layout=None,
         dtypes=[np.float32, np.int32, np.uint8],
@@ -111,13 +125,8 @@ def check_spawn_with_callback(
                 shape, epoch_size, dtype, random_data=random_data, random_shape=random_shape)
             for workers_num in [1, 4]:
                 for batch_size in [1, 16, 150]:
-                    pipe_parallel = create_pipe(
-                        callback, 'cpu', batch_size, py_num_workers=workers_num,
-                        py_start_method='spawn', parallel=True, num_outputs=num_outputs,
-                        layout=layout)
-                    pipe = create_pipe(callback_ref, 'cpu', batch_size, parallel=False,
-                                       num_outputs=num_outputs, layout=layout)
-                    yield check_callback, pipe_parallel, pipe, epoch_size, batch_size, dtype
+                    yield _check_spawn_with_callback, callback, callback_ref, batch_size, \
+                        num_outputs, layout, workers_num, epoch_size, dtype
 
 
 class ExtCallbackMultipleOutputs(ExtCallback):


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

Fixing two bugs for parallel external source: 
   * When batch received from workers in coalesced, its parts were not properly deleted in the pool context which results in keeping corrupted arrays (as the underlying buffer is overwritten) throughout the epoch - they were not exposed anywhere but still took some space and accidental access to them could kill process.
   * Tests for ES should check if pool processes are closed at the end of the test, but by mistake pids were compared against process instance, so this oranges to apples check was falsely passing all the time.

#### Additional information
- Affected modules and functionalities:
Python part of External Source.

- Key points relevant for the review:
It is separated from bigger PR for batch mode in external source.

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
