### PR TITLE
Fix sharding and shuffling in VideoLoaderDecoder

### DIFF
--- a/dali/operators/reader/loader/video/video_loader_decoder.cc
+++ b/dali/operators/reader/loader/video/video_loader_decoder.cc
@@ -62,6 +62,15 @@ void VideoLoaderDecoder::PrepareMetadataImpl() {
         VideoSampleDesc(start, start + stride_ * sequence_len_, stride_, video_idx));
     }
   }
+  if (shuffle_) {
+      // seeded with hardcoded value to get
+      // the same sequence on every shard
+      std::mt19937 g(kDaliDataloaderSeed);
+      std::shuffle(std::begin(sample_spans_), std::end(sample_spans_), g);
+    }
+
+    // set the initial index for each shard
+    Reset(true);
 }
 
 void VideoLoaderDecoder::Reset(bool wrap_to_shard) {

--- a/dali/operators/reader/video_reader_decoder_op_test.cc
+++ b/dali/operators/reader/video_reader_decoder_op_test.cc
@@ -184,7 +184,7 @@ TEST_F(VideoReaderDecoderTest, RandomShuffle) {
 
   pipe.Build({{"frames", "cpu"}});
 
-  std::vector<int> expected_order = {44, 12, 49, 38, 8};
+  std::vector<int> expected_order = {29, 46, 33, 6, 37};
 
   int num_sequences = 5;
 
@@ -206,6 +206,10 @@ TEST_F(VideoReaderDecoderTest, CompareReaders) {
   const int sequence_length = 6;
   const int stride = 3;
   const int step = 10;
+  const int shard_id = 3;
+  const int num_shards = 10;
+  const int seed = 1234;
+  const int initial_fill = 50;
 
   Pipeline pipe(batch_size, 4, 0);
 
@@ -214,6 +218,11 @@ TEST_F(VideoReaderDecoderTest, CompareReaders) {
     .AddArg("sequence_length", sequence_length)
     .AddArg("stride", stride)
     .AddArg("step", step)
+    .AddArg("shard_id ", shard_id)
+    .AddArg("num_shards ", num_shards)
+    .AddArg("seed", seed)
+    .AddArg("initial_fill", initial_fill)
+    .AddArg("random_shuffle", true)
     .AddArg(
       "filenames",
       std::vector<std::string>{
@@ -227,6 +236,11 @@ TEST_F(VideoReaderDecoderTest, CompareReaders) {
     .AddArg("sequence_length", sequence_length)
     .AddArg("stride", stride)
     .AddArg("step", step)
+    .AddArg("shard_id ", shard_id)
+    .AddArg("num_shards ", num_shards)
+    .AddArg("seed", seed)
+    .AddArg("initial_fill", initial_fill)
+    .AddArg("random_shuffle", true)
     .AddArg(
       "filenames",
       std::vector<std::string>{


### PR DESCRIPTION
- fixes calculation of sample start index for each shard when
  VideoLoaderDecoder is created
- adds preshuffling when VideoLoaderDecoder is created to make
  sure that samples are globally mixed, not only inside the prefetch
  buffer
- updates VideoReaderDecoderTest.CompareReaders to use sharding

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [X] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
- fixes calculation of sample start index for each shard when
  VideoLoaderDecoder is created
- adds preshuffling when VideoLoaderDecoder is created to make
  sure that samples are globally mixed, not only inside the prefetch
  buffer
- updates VideoReaderDecoderTest.CompareReaders to use sharding
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

#### Additional information
- Affected modules and functionalities:
  - video_loader_decoder.cc
  - video_reader_decoder_op_test
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
  - NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [X] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
