### PR TITLE
Add a missing state destroy for the NVJPEG HW decoder

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -300,6 +300,10 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       }
       CUDA_CALL(cudaStreamDestroy(hw_decode_stream_));
 
+      if (state_hw_batched_) {
+        NVJPEG_CALL(nvjpegJpegStateDestroy(state_hw_batched_));
+      }
+
       NVJPEG_CALL(nvjpegDestroy(handle_));
 
       // Free any remaining buffers and remove the thread entry from the global map


### PR DESCRIPTION
- when mixed backend image decoder instance is destroyed
  HW NVJPEG memory pool is not released properly. To fix
  that the state_hw_batched_ should be released upon the
  operator destruction

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [X] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
- when mixed backend image decoder instance is destroyed
  HW NVJPEG memory pool is not released properly. To fix
  that the state_hw_batched_ should be released upon the
  operator destruction
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

#### Additional information
- Affected modules and functionalities:
  - nvjpeg_decoder_decoupled_api.h 
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
  - NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [X] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->

Relates to https://github.com/NVIDIA/DALI/issues/3396