### PR TITLE
Fix ShareData for TensorVector with no elements

### DIFF
--- a/dali/pipeline/data/tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_vector_test.cc
@@ -144,6 +144,48 @@ TYPED_TEST(TensorVectorSuite, VariableBatchResizeUp) {
   ASSERT_EQ(tv.num_samples(), new_size.num_samples());
 }
 
+TYPED_TEST(TensorVectorSuite, EmptyShareContiguous) {
+  TensorVector<TypeParam> tv;
+  tv.SetContiguous(true);
+  TensorListShape<> shape = {{100, 0, 0}, {42, 0, 0}};
+  tv.Resize(shape, DALI_UINT8);
+  for (int i = 0; i < shape.num_samples(); i++) {
+    ASSERT_EQ(tv[i].raw_data(), nullptr);
+  }
+
+  TensorVector<TypeParam> target;
+  target.ShareData(tv);
+  ASSERT_EQ(target.num_samples(), shape.num_samples());
+  ASSERT_EQ(target.type(), DALI_UINT8);
+  ASSERT_EQ(target.shape(), shape);
+  ASSERT_TRUE(target.IsContiguous());
+  for (int i = 0; i < shape.num_samples(); i++) {
+    ASSERT_EQ(target[i].raw_data(), nullptr);
+    ASSERT_EQ(target[i].raw_data(), tv[i].raw_data());
+  }
+}
+
+TYPED_TEST(TensorVectorSuite, EmptyShareNonContiguous) {
+  TensorVector<TypeParam> tv;
+  tv.SetContiguous(false);
+  TensorListShape<> shape = {{100, 0, 0}, {42, 0, 0}};
+  tv.Resize(shape, DALI_UINT8);
+  for (int i = 0; i < shape.num_samples(); i++) {
+    ASSERT_EQ(tv[i].raw_data(), nullptr);
+  }
+
+  TensorVector<TypeParam> target;
+  target.ShareData(tv);
+  ASSERT_EQ(target.num_samples(), shape.num_samples());
+  ASSERT_EQ(target.type(), DALI_UINT8);
+  ASSERT_EQ(target.shape(), shape);
+  ASSERT_FALSE(target.IsContiguous());
+  for (int i = 0; i < shape.num_samples(); i++) {
+    ASSERT_EQ(target[i].raw_data(), nullptr);
+    ASSERT_EQ(target[i].raw_data(), tv[i].raw_data());
+  }
+}
+
 namespace {
 
 /**


### PR DESCRIPTION
Simplify the logic of the implementation.


## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Do not rely on the `has_data()` but the `state` of the `TensorVector`,
share data accordingly - either with underlying `TensorList`
or directly with the individual `Tensor` samples.
Add a test that triggered the error condition.

#### Additional information
- Affected modules and functionalities:
TensorVector

- Key points relevant for the review:
 

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
