### PR TITLE
Remove reseeding of numpy in RandomlyShapedDataIterator

### DIFF
--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -272,9 +272,6 @@ class RandomlyShapedDataIterator(object):
         return self
 
     def __next__(self):
-        import_numpy()
-        np.random.seed(self.seed)
-        random.seed(self.seed)
         self.test_data = []
         for _ in range(self.batch_size):
             # Scale between 0.5 and 1.0
@@ -294,7 +291,6 @@ class RandomlyShapedDataIterator(object):
 
         batch = self.test_data
         self.i = (self.i + 1) % self.n
-        self.seed = self.seed + 12345678
         return (batch)
 
     next = __next__

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -272,6 +272,7 @@ class RandomlyShapedDataIterator(object):
         return self
 
     def __next__(self):
+        import_numpy()
         self.test_data = []
         for _ in range(self.batch_size):
             # Scale between 0.5 and 1.0


### PR DESCRIPTION
## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [x] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Remove importing and setting seeds in the `__next__`
of RandomlyShapedDataIterator used in test. 

#### Additional information
- Affected modules and functionalities:
Python tests.

- Key points relevant for the review:
We didn't remove it last time, do we need this?
The iterator has it's own state already.

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
