### PR TITLE
Fix STRING_VEC default arguments presentation in docs

### DIFF
--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -189,11 +189,14 @@ std::string OpSchema::GetArgumentDefaultValueString(const std::string &name) con
 
   auto &val = *value_ptr;
   auto str = val.ToString();
-  if (val.GetTypeId() == DALI_STRING ||
-      val.GetTypeId() == DALI_TENSOR_LAYOUT)
+  if (val.GetTypeId() == DALI_STRING || val.GetTypeId() == DALI_TENSOR_LAYOUT) {
     return python_repr(str);
-  else
+  } else if (val.GetTypeId() == DALI_STRING_VEC) {
+    auto str_vec = dynamic_cast<ValueInst<std::vector<std::string>> &>(val).Get();
+    return python_repr(str_vec);
+  } else {
     return str;
+  }
 }
 
 std::vector<std::string> OpSchema::GetArgumentNames() const {

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -128,7 +128,7 @@ def _get_kwargs(schema):
                 if schema.HasArgumentDefaultValue(arg):
                     default_value_string = schema.GetArgumentDefaultValueString(arg)
                     default_value = ast.literal_eval(default_value_string)
-                    type_name += ", default = {}".format(_default_converter(dtype, default_value))
+                    type_name += ", default = `{}`".format(_default_converter(dtype, default_value))
             doc += schema.GetArgumentDox(arg)
             if deprecation_warning:
                 doc += "\n\n" + deprecation_warning

--- a/include/dali/core/python_util.h
+++ b/include/dali/core/python_util.h
@@ -15,9 +15,10 @@
 #ifndef DALI_CORE_PYTHON_UTIL_H_
 #define DALI_CORE_PYTHON_UTIL_H_
 
-#include <string>
-#include <sstream>
 #include <map>
+#include <sstream>
+#include <string>
+#include <vector>
 #include "dali/core/util.h"
 
 namespace dali {

--- a/include/dali/core/python_util.h
+++ b/include/dali/core/python_util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ inline void python_repr(std::ostream &os, const std::string &s) {
 }
 
 template <typename T>
-if_iterable<T> python_repr(std::ostream &os, const T &collection) {
+void python_repr(std::ostream &os, const std::vector<T> &collection) {
   os << "[";
   bool first = true;
   for (const auto &v : collection) {


### PR DESCRIPTION
Required for #3459 

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [x] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Adjust python_repr to handle vectors of elements,
as it was currently dead code. We need to call repr
on all strings as we do for single string argument.

Add backticks around the default value in the generated
docstring - it prevents string from interpreting
glob expressions as markdown.


#### Additional information
- Affected modules and functionalities:
Docs

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [x] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
