### PR TITLE
Reuse GaussianBlur windows between iterations

### DIFF
--- a/dali/operators/image/convolution/gaussian_blur.cu
+++ b/dali/operators/image/convolution/gaussian_blur.cu
@@ -80,15 +80,20 @@ bool GaussianBlur<GPUBackend>::SetupImpl(std::vector<OutputDesc>& output_desc,
   DALI_ENFORCE(dtype_ == input.type() || dtype_ == DALI_FLOAT,
                "Output data type must be same as input, FLOAT or skipped (defaults to input type)");
 
-  // clang-format off
-  TYPE_SWITCH(input.type(), type2id, In, GAUSSIAN_BLUR_GPU_SUPPORTED_TYPES, (
+  if (!impl_ || impl_in_dtype_ != input.type() || impl_dim_desc_ != dim_desc) {
+    impl_in_dtype_ = input.type();
+    impl_dim_desc_ = dim_desc;
+
+    // clang-format off
+    TYPE_SWITCH(input.type(), type2id, In, GAUSSIAN_BLUR_GPU_SUPPORTED_TYPES, (
       if (dtype_ == input.type()) {
         impl_ = GetGaussianBlurGpuImpl<In, In>(&spec_, dim_desc);
       } else {
         impl_ = GetGaussianBlurGpuImpl<float, In>(&spec_, dim_desc);
       }
-  ), DALI_FAIL(make_string("Unsupported data type: ", input.type())));  // NOLINT
-  // clang-format on
+    ), DALI_FAIL(make_string("Unsupported data type: ", input.type())));  // NOLINT
+    // clang-format on
+  }
 
   return impl_->SetupImpl(output_desc, ws);
 }

--- a/dali/operators/image/convolution/gaussian_blur.h
+++ b/dali/operators/image/convolution/gaussian_blur.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,6 +56,8 @@ class GaussianBlur : public Operator<Backend> {
   DALIDataType dtype_ = DALI_NO_TYPE;
   USE_OPERATOR_MEMBERS();
   std::unique_ptr<OpImplBase<Backend>> impl_;
+  DALIDataType impl_in_dtype_ = DALI_NO_TYPE;
+  gaussian_blur::DimDesc impl_dim_desc_;
 };
 
 namespace gaussian_blur {

--- a/dali/operators/image/convolution/gaussian_blur_params.h
+++ b/dali/operators/image/convolution/gaussian_blur_params.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,9 +98,10 @@ class GaussianWindows {
   }
 
   void PrepareWindows(const GaussianBlurParams<axes> &params) {
-    bool changed = previous != params;
-    if (!changed)
+    if (previous == params) {
       return;
+    }
+    previous = params;
 
     // Reallocate if necessary and fill the windows
     bool is_uniform = params.IsUniform();

--- a/dali/operators/image/convolution/gaussian_blur_params.h
+++ b/dali/operators/image/convolution/gaussian_blur_params.h
@@ -40,6 +40,17 @@ struct DimDesc {
   int total_axes_count;
   bool has_channels;
   bool is_sequence;
+
+  bool operator==(const DimDesc &other) const {
+    return usable_axes_start == other.usable_axes_start &&
+      usable_axes_count == other.usable_axes_count &&
+      total_axes_count == other.total_axes_count && has_channels == other.has_channels &&
+      is_sequence == other.is_sequence;
+  }
+
+  bool operator!=(const DimDesc &other) const {
+    return !(*this == other);
+  }
 };
 
 template <int axes>

--- a/dali/operators/image/convolution/gaussian_blur_params.h
+++ b/dali/operators/image/convolution/gaussian_blur_params.h
@@ -107,6 +107,10 @@ class GaussianWindows {
     previous.sigmas = uniform_array<axes>(-1.f);
     previous.window_sizes = uniform_array<axes>(0);
   }
+  // If ``memory`` was copied, ``precomputed_window`` would have old pointers,
+  // prevent that form happening on GaussianWindows vector resize.
+  GaussianWindows(GaussianWindows &) = delete;
+  GaussianWindows(GaussianWindows &&) = default;
 
   void PrepareWindows(const GaussianBlurParams<axes> &params) {
     if (previous == params) {

--- a/dali/operators/image/convolution/gaussian_blur_params_test.cc
+++ b/dali/operators/image/convolution/gaussian_blur_params_test.cc
@@ -92,11 +92,11 @@ auto CollectWindowsForParams(
   for (size_t i = 0; i < num_iters; i++) {
     windows.PrepareWindows(params[i]);
     auto window_views = windows.GetWindows();
-    for (int axe = 0; axe < axes; axe++) {
-      auto *data = window_views[axe].data;
-      windows_hist[i][axe].assign(data, data + window_views[axe].num_elements());
-      TensorShape<1> expected_shape = {params[i].window_sizes[axe]};
-      EXPECT_EQ(window_views[axe].shape, expected_shape);
+    for (int axis = 0; axis < axes; axis++) {
+      auto *data = window_views[axis].data;
+      windows_hist[i][axis].assign(data, data + window_views[axis].num_elements());
+      TensorShape<1> expected_shape = {params[i].window_sizes[axis]};
+      EXPECT_EQ(window_views[axis].shape, expected_shape);
     }
   }
   return windows_hist;
@@ -204,9 +204,9 @@ TEST(GaussianWindowsTest, UpdateWindowsOnSigmaChange) {
     {{7, 7}, {1.0f, 2.0f}}
   }};
   auto windows_hist = CollectWindowsForParams(params);
-  for (int axe = 0; axe < axes; axe++) {
-    EXPECT_NE(windows_hist[0][axe], windows_hist[1][axe]);
-    EXPECT_EQ(windows_hist[0][axe], windows_hist[2][axe]);
+  for (int axis = 0; axis < axes; axis++) {
+    EXPECT_NE(windows_hist[0][axis], windows_hist[1][axis]);
+    EXPECT_EQ(windows_hist[0][axis], windows_hist[2][axis]);
   }
   EXPECT_EQ(windows_hist[0][0], windows_hist[3][0]);
   EXPECT_EQ(windows_hist[1][0], windows_hist[3][1]);
@@ -221,9 +221,9 @@ TEST(GaussianWindowsTest, UpdateWindowsOnWindowSizeChange) {
     {{7, 7}, {1.0f, 1.0f}}
   }};
   auto windows_hist = CollectWindowsForParams(params);
-  for (int axe = 0; axe < axes; axe++) {
-    EXPECT_NE(windows_hist[0][axe], windows_hist[1][axe]);
-    EXPECT_EQ(windows_hist[0][axe], windows_hist[2][axe]);
+  for (int axis = 0; axis < axes; axis++) {
+    EXPECT_NE(windows_hist[0][axis], windows_hist[1][axis]);
+    EXPECT_EQ(windows_hist[0][axis], windows_hist[2][axis]);
   }
 }
 

--- a/dali/operators/image/convolution/gaussian_blur_params_test.cc
+++ b/dali/operators/image/convolution/gaussian_blur_params_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -84,6 +84,24 @@ void CheckMatchingShapes(const std::array<TensorView<StorageCPU, const float, 1>
   }
 }
 
+template <int axes, size_t num_iters>
+auto CollectWindowsForParams(
+    std::array<GaussianBlurParams<axes>, num_iters> &params) {
+  std::array<std::array<std::vector<float>, axes>, num_iters> windows_hist;
+  GaussianWindows<axes> windows;
+  for (size_t i = 0; i < num_iters; i++) {
+    windows.PrepareWindows(params[i]);
+    auto window_views = windows.GetWindows();
+    for (int axe = 0; axe < axes; axe++) {
+      auto *data = window_views[axe].data;
+      windows_hist[i][axe].assign(data, data + window_views[axe].num_elements());
+      TensorShape<1> expected_shape = {params[i].window_sizes[axe]};
+      EXPECT_EQ(window_views[axe].shape, expected_shape);
+    }
+  }
+  return windows_hist;
+}
+
 TEST(GaussianWindowsTest, InitUniform) {
   constexpr int axes = 2;
   GaussianWindows<axes> windows;
@@ -150,31 +168,62 @@ TEST(GaussianWindowsTest, NonUniform2Uniform) {
 
 TEST(GaussianWindowsTest, NoChangeUniform) {
   constexpr int axes = 2;
-  GaussianWindows<axes> windows;
-  GaussianBlurParams<axes> params_uniform = {{7, 7}, {1.0f, 1.0f}};
-
-  windows.PrepareWindows(params_uniform);
-  auto views_uniform_0 = windows.GetWindows();
-  windows.PrepareWindows(params_uniform);
-  auto views_uniform_1 = windows.GetWindows();
-  for (int i = 0; i < axes; i++) {
-    EXPECT_EQ(views_uniform_0[i].data, views_uniform_1[i].data);
-    EXPECT_EQ(views_uniform_0[i].shape, views_uniform_1[i].shape);
+  constexpr size_t num_iters = 3;
+  std::array<GaussianBlurParams<axes>, num_iters> params_uniform = {{
+    {{7, 7}, {1.0f, 1.0f}},
+    {{7, 7}, {1.0f, 1.0f}},
+    {{7, 7}, {1.0f, 1.0f}}
+  }};
+  auto windows_hist = CollectWindowsForParams(params_uniform);
+  for (size_t i = 1; i < num_iters; i++) {
+    EXPECT_EQ(windows_hist[i - 1], windows_hist[i]);
   }
 }
 
 TEST(GaussianWindowsTest, NoChangeNonUniform) {
   constexpr int axes = 2;
-  GaussianWindows<axes> windows;
-  GaussianBlurParams<axes> params_non_uniform = {{7, 14}, {2.0f, 1.0f}};
+  constexpr size_t num_iters = 3;
+  std::array<GaussianBlurParams<axes>, num_iters> params_non_uniform = {{
+    {{7, 14}, {2.0f, 1.0f}},
+    {{7, 14}, {2.0f, 1.0f}},
+    {{7, 14}, {2.0f, 1.0f}}
+  }};
+  auto windows_hist = CollectWindowsForParams(params_non_uniform);
+  for (size_t i = 1; i < num_iters; i++) {
+    EXPECT_EQ(windows_hist[i - 1], windows_hist[i]);
+  }
+}
 
-  windows.PrepareWindows(params_non_uniform);
-  auto views_non_uniform_0 = windows.GetWindows();
-  windows.PrepareWindows(params_non_uniform);
-  auto views_non_uniform_1 = windows.GetWindows();
-  for (int i = 0; i < axes; i++) {
-    EXPECT_EQ(views_non_uniform_0[i].data, views_non_uniform_1[i].data);
-    EXPECT_EQ(views_non_uniform_0[i].shape, views_non_uniform_1[i].shape);
+TEST(GaussianWindowsTest, UpdateWindowsOnSigmaChange) {
+  constexpr int axes = 2;
+  constexpr size_t num_iters = 4;
+  std::array<GaussianBlurParams<axes>, num_iters> params = {{
+    {{7, 7}, {1.0f, 1.0f}},
+    {{7, 7}, {2.0f, 3.0f}},
+    {{7, 7}, {1.0f, 1.0f}},
+    {{7, 7}, {1.0f, 2.0f}}
+  }};
+  auto windows_hist = CollectWindowsForParams(params);
+  for (int axe = 0; axe < axes; axe++) {
+    EXPECT_NE(windows_hist[0][axe], windows_hist[1][axe]);
+    EXPECT_EQ(windows_hist[0][axe], windows_hist[2][axe]);
+  }
+  EXPECT_EQ(windows_hist[0][0], windows_hist[3][0]);
+  EXPECT_EQ(windows_hist[1][0], windows_hist[3][1]);
+}
+
+TEST(GaussianWindowsTest, UpdateWindowsOnWindowSizeChange) {
+  constexpr int axes = 2;
+  constexpr size_t num_iters = 3;
+  std::array<GaussianBlurParams<axes>, num_iters> params = {{
+    {{7, 7}, {1.0f, 1.0f}},
+    {{5, 5}, {1.0f, 1.0f}},
+    {{7, 7}, {1.0f, 1.0f}}
+  }};
+  auto windows_hist = CollectWindowsForParams(params);
+  for (int axe = 0; axe < axes; axe++) {
+    EXPECT_NE(windows_hist[0][axe], windows_hist[1][axe]);
+    EXPECT_EQ(windows_hist[0][axe], windows_hist[2][axe]);
   }
 }
 


### PR DESCRIPTION
Makes GaussianBlur operator reuse windows from previous iteration if parameters did not change.

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Makes GaussianBlur operator reuse windows from previous iteration if parameters did not change.


#### Additional information
- Affected modules and functionalities:
GuassianBlur operator.

- Key points relevant for the review:
Existing implementation already had `previous` parameters stored but never actually updated them, additionally it reset its impl pointer at each iteration defeating the idea. Now impl is updated only on relevant input changes and `previous` parameters are updated. *Note that existing implementation produced correct results* - the comparison against `previous` parameters was simply always false.
Additionally fixes two tests that aimed to compare views between iterations but actually compared views on windows from the last iteration.

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2458
