### PR TITLE
Remove `context` from memory resources.

### DIFF
--- a/dali/core/mm/default_resources.cc
+++ b/dali/core/mm/default_resources.cc
@@ -191,7 +191,7 @@ inline std::shared_ptr<device_async_resource> CreateDefaultDeviceResource() {
       return make_shared_composite_resource(std::move(rsrc), upstream);
     } else {
       using resource_type = mm::async_pool_resource<mm::memory_kind::device,
-              pool_resource_base<memory_kind::device, any_context, coalescing_free_tree, spinlock>>;
+              pool_resource_base<memory_kind::device, coalescing_free_tree, spinlock>>;
       auto rsrc = std::make_shared<resource_type>(upstream.get());
       return make_shared_composite_resource(std::move(rsrc), upstream);
     }
@@ -210,7 +210,7 @@ inline std::shared_ptr<pinned_async_resource> CreateDefaultPinnedResource() {
     return make_shared_composite_resource(std::move(rsrc), upstream);
   } else {
     using resource_type = mm::async_pool_resource<mm::memory_kind::pinned,
-        pool_resource_base<memory_kind::pinned, any_context, coalescing_free_tree, spinlock>>;
+        pool_resource_base<memory_kind::pinned, coalescing_free_tree, spinlock>>;
     auto rsrc = std::make_shared<resource_type>(upstream.get());
     return make_shared_composite_resource(std::move(rsrc), upstream);
   }

--- a/dali/core/mm/mm_test_utils.h
+++ b/dali/core/mm/mm_test_utils.h
@@ -166,16 +166,16 @@ class test_resource_wrapper_impl {
   }
 };
 
-template <typename Kind, typename Context, bool owning, bool security_check,
+template <typename Kind, bool owning, bool security_check,
           typename Upstream>
-class test_resource_wrapper<owning, security_check, memory_resource<Kind, Context>, Upstream>
-: public memory_resource<Kind, Context>
+class test_resource_wrapper<owning, security_check, memory_resource<Kind>, Upstream>
+: public memory_resource<Kind>
 , public test_resource_wrapper_impl<owning, security_check, Upstream> {
   static_assert(!security_check || !std::is_same<Kind, mm::memory_kind::device>::value,
                 "Cannot place a security cookie in device memory");
 
   using test_resource_wrapper_impl<owning, security_check, Upstream>::test_resource_wrapper_impl;
-  bool do_is_equal(const memory_resource<Kind, Context> &other) const noexcept override {
+  bool do_is_equal(const memory_resource<Kind> &other) const noexcept override {
     if (auto *oth = dynamic_cast<const test_resource_wrapper*>(&other))
       return this->upstream_->is_equal(*oth->upstream_);
     else
@@ -192,10 +192,6 @@ class test_resource_wrapper<owning, security_check, memory_resource<Kind, Contex
     return this->do_deallocate_impl([&](void *p, size_t b, size_t a) {
       return this->upstream_->deallocate(p, b, a);
     }, ptr, bytes, alignment);
-  }
-
-  Context do_get_context() const noexcept override {
-    return this->upstream_->get_context();
   }
 };
 

--- a/dali/core/mm/monotonic_resource_test.cc
+++ b/dali/core/mm/monotonic_resource_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ TEST(MMTest, MonotonicHostResource) {
 TEST(MMTest, MonotonicDeviceResource) {
   test_device_resource upstream;
   {
-    monotonic_device_resource<> mr(&upstream);
+    monotonic_device_resource mr(&upstream);
     void *m1 = mr.allocate(100);
     ASSERT_NE(m1, nullptr);
     CUDA_CALL(cudaMemset(m1, 0xff, 100));

--- a/include/dali/core/mm/async_pool.h
+++ b/include/dali/core/mm/async_pool.h
@@ -35,7 +35,7 @@ namespace dali {
 namespace mm {
 
 template <typename Kind,
-    typename GlobalPool = deferred_dealloc_pool<Kind, any_context, coalescing_free_tree, spinlock>,
+    typename GlobalPool = deferred_dealloc_pool<Kind, coalescing_free_tree, spinlock>,
     typename LockType = std::mutex,
     typename Upstream = memory_resource<Kind>>
 class async_pool_resource : public async_memory_resource<Kind> {

--- a/include/dali/core/mm/composite_resource.h
+++ b/include/dali/core/mm/composite_resource.h
@@ -26,8 +26,8 @@ namespace mm {
 
 namespace detail {
 
-template <typename Kind, typename Context>
-memory_resource<Kind, Context> &GetResourceInterface(const memory_resource<Kind, Context> &);
+template <typename Kind>
+memory_resource<Kind> &GetResourceInterface(const memory_resource<Kind> &);
 
 template <typename Kind>
 async_memory_resource<Kind> &GetResourceInterface(const async_memory_resource<Kind> &);
@@ -78,11 +78,11 @@ class CompositeResourceBase : public Interface {
 template <typename Interface, typename Resource, typename... Extra>
 class CompositeResourceImpl;
 
-template <typename Kind, typename Context, typename Resource, typename... Extra>
-class CompositeResourceImpl<memory_resource<Kind, Context>, Resource, Extra...>
-: public CompositeResourceBase<memory_resource<Kind, Context>, Resource, Extra...> {
+template <typename Kind, typename Resource, typename... Extra>
+class CompositeResourceImpl<memory_resource<Kind>, Resource, Extra...>
+: public CompositeResourceBase<memory_resource<Kind>, Resource, Extra...> {
  public:
-  using Base = CompositeResourceBase<memory_resource<Kind, Context>, Resource, Extra...>;
+  using Base = CompositeResourceBase<memory_resource<Kind>, Resource, Extra...>;
   using Base::Base;
 };
 

--- a/include/dali/core/mm/memory.h
+++ b/include/dali/core/mm/memory.h
@@ -63,14 +63,14 @@ struct AsyncDeleter {
 /**
  * @brief Obtains a type-erased deleter for given memory resource and allocation parameters.
  */
-template <typename Kind, typename Context>
-Deleter GetDeleter(memory_resource<Kind, Context> *resource, size_t size, size_t alignment) {
+template <typename Kind>
+Deleter GetDeleter(memory_resource<Kind> *resource, size_t size, size_t alignment) {
   Deleter del;
   del.resource = static_cast<void *>(resource);
   del.size = size;
   del.alignment = alignment;
   del.free = [](void *res_vptr, void *mem, size_t sz, size_t align) {
-    static_cast<memory_resource<Kind, Context>*>(res_vptr)->deallocate(mem, sz, align);
+    static_cast<memory_resource<Kind>*>(res_vptr)->deallocate(mem, sz, align);
   };
   return del;
 }
@@ -127,10 +127,9 @@ void set_dealloc_stream(async_uptr<T> &ptr, cudaStream_t stream) {
  * @param bytes     Size, in bytes, of the memory being allocated
  * @param alignment Alignment of the requested memory
  * @tparam Kind     The kind of requested memory.
- * @tparam Context  The execution context in which the memory will be available.
  */
-template <typename Kind, typename Context>
-std::pair<void*, Deleter> alloc_raw(memory_resource<Kind, Context> *mr,
+template <typename Kind>
+std::pair<void*, Deleter> alloc_raw(memory_resource<Kind> *mr,
                                     size_t bytes, size_t alignment = alignof(std::max_align_t)) {
   void *mem = mr->allocate(bytes, alignment);
   return { mem, GetDeleter(mr, bytes, alignment) };
@@ -168,10 +167,9 @@ auto alloc_raw(size_t bytes, size_t alignment = alignof(std::max_align_t)) {
  * @param count     Number of objects for which the storage should suffice.
  * @tparam T        Type of the object for which the storage is allocated.
  * @tparam Kind     The kind of requested memory.
- * @tparam Context  The execution context in which the memory will be available.
  */
-template <typename T, typename Kind, typename Context>
-uptr<T> alloc_raw_unique(memory_resource<Kind, Context> *mr, size_t count,
+template <typename T, typename Kind>
+uptr<T> alloc_raw_unique(memory_resource<Kind> *mr, size_t count,
                          size_t alignment = alignof(T)) {
   size_t bytes = sizeof(T) * count;
   auto mem_del = alloc_raw(mr, bytes, alignment);
@@ -213,10 +211,9 @@ auto alloc_raw_unique(size_t count, size_t alignment = alignof(T)) {
  * @param alignment Alignment, in bytes; defaults to the alignment required by `T`
  * @tparam T        Type of the object for which the storage is allocated.
  * @tparam Kind     The kind of requested memory.
- * @tparam Context  The execution context in which the memory will be available.
  */
-template <typename T, typename Kind, typename Context>
-std::shared_ptr<T> alloc_raw_shared(memory_resource<Kind, Context> *mr, size_t count,
+template <typename T, typename Kind>
+std::shared_ptr<T> alloc_raw_shared(memory_resource<Kind> *mr, size_t count,
                                     size_t alignment = alignof(T)) {
   size_t bytes = sizeof(T) * count;
   auto mem_del = alloc_raw(mr, bytes, alignment);

--- a/include/dali/core/mm/memory_resource.h
+++ b/include/dali/core/mm/memory_resource.h
@@ -38,7 +38,6 @@ namespace mm {
 
 namespace memory_kind = cuda::memory_kind;
 
-using cuda::any_context;
 using cuda::memory_resource;
 using cuda::resource_view;
 using cuda::stream_ordered_resource_view;

--- a/include/dali/core/mm/monotonic_resource.h
+++ b/include/dali/core/mm/monotonic_resource.h
@@ -32,8 +32,8 @@ namespace mm {
  * Monotonic buffer resources don't require manual deallocation of the returned pointers.
  * The memory is freed in bulk when the underlying buffer is freed.
  */
-template <typename Kind, typename Context = any_context>
-class monotonic_buffer_resource : public memory_resource<Kind, Context> {
+template <typename Kind>
+class monotonic_buffer_resource : public memory_resource<Kind> {
  public:
   monotonic_buffer_resource() = default;
   monotonic_buffer_resource(void *memory, size_t bytes)
@@ -75,8 +75,7 @@ class monotonic_buffer_resource : public memory_resource<Kind, Context> {
   char *curr_ = nullptr, *limit_ = nullptr;
 };
 
-template <typename Kind, typename Context = any_context,
-          bool host_impl = detail::is_host_accessible<Kind>>
+template <typename Kind, bool host_impl = detail::is_host_accessible<Kind>>
 class monotonic_memory_resource;
 
 /**
@@ -87,10 +86,10 @@ class monotonic_memory_resource;
  * The lifetime of a monotonic resource is limited and all memory will be deallocated in bulk
  * when the resource is destroyed.
  */
-template <typename Kind, typename Context>
-class monotonic_memory_resource<Kind, Context, true> : public memory_resource<Kind, Context> {
+template <typename Kind>
+class monotonic_memory_resource<Kind, true> : public memory_resource<Kind> {
  public:
-  explicit monotonic_memory_resource(memory_resource<Kind, Context> *upstream,
+  explicit monotonic_memory_resource(memory_resource<Kind> *upstream,
                                      size_t next_block_size = 1024)
   : upstream_(upstream), next_block_size_(next_block_size) {}
 
@@ -163,15 +162,11 @@ class monotonic_memory_resource<Kind, Context, true> : public memory_resource<Ki
   void do_deallocate(void *data, size_t bytes, size_t alignment) override {
   }
 
-  Context do_get_context() const noexcept override {
-    return upstream_->get_context();
-  }
-
   static constexpr size_t sentinel_value = detail::sentinel_value<size_t>::value;
 
   char *curr_ = nullptr, *limit_ = nullptr;
 
-  memory_resource<Kind, Context> *upstream_;
+  memory_resource<Kind> *upstream_;
   size_t next_block_size_;
   struct block_info {
     size_t sentinel;
@@ -192,10 +187,10 @@ class monotonic_memory_resource<Kind, Context, true> : public memory_resource<Ki
  * The lifetime of a monotonic resource is limited and all memory will be deallocated in bulk
  * when the resource is destroyed.
  */
-template <typename Kind, typename Context>
-class monotonic_memory_resource<Kind, Context, false> : public memory_resource<Kind, Context> {
+template <typename Kind>
+class monotonic_memory_resource<Kind, false> : public memory_resource<Kind> {
  public:
-  explicit monotonic_memory_resource(memory_resource<Kind, Context> *upstream,
+  explicit monotonic_memory_resource(memory_resource<Kind> *upstream,
                                      size_t next_block_size = 1024)
   : upstream_(upstream), next_block_size_(next_block_size) {}
 
@@ -258,13 +253,9 @@ class monotonic_memory_resource<Kind, Context, false> : public memory_resource<K
   void do_deallocate(void *data, size_t bytes, size_t alignment) override {
   }
 
-  Context do_get_context() const noexcept override {
-    return upstream_->get_context();
-  }
-
   char *curr_ = nullptr, *limit_ = nullptr;
 
-  memory_resource<Kind, Context> *upstream_;
+  memory_resource<Kind> *upstream_;
   size_t next_block_size_;
   struct upstream_block {
     void *base;
@@ -276,8 +267,7 @@ class monotonic_memory_resource<Kind, Context, false> : public memory_resource<K
 
 using monotonic_host_resource = monotonic_memory_resource<memory_kind::host>;
 
-template <typename Context = any_context>
-using monotonic_device_resource = monotonic_memory_resource<memory_kind::device, Context>;
+using monotonic_device_resource = monotonic_memory_resource<memory_kind::device>;
 
 }  // namespace mm
 }  // namespace dali


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>
## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [X] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
As agreed during libcu++ meeting, the initial version of `memory_resource` won't have a notion of a context. This PR removes memory_resource contexts from DALI.

#### Additional information
- Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [X] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
