### PR TITLE
Fix DALI paddle plugin stream synchronization error

### DIFF
--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -318,12 +318,6 @@ class DALIGenericIterator(_DaliBaseIterator):
                                          category_pd_type[cat])
             data_batches[i] = pd_tensors
 
-            # due to https://github.com/PaddlePaddle/Paddle/issues/35555 the tensors are allocated
-            # first by setting shape and calling _mutable_data, then the device is synchronized
-            # and after that, another call to _mutable_data is made to obtain the pointer and
-            # copy data from the pipeline to the tensor
-            # when the issue is solved the copy can be moved to the preceding loop
-            fluid.core._cuda_synchronize(pd_gpu_place)
             for cat, tensor in category_tensors.items():
                 ptr = pd_tensors[cat]._mutable_data(category_place[cat],
                                                category_pd_type[cat])

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -17,6 +17,7 @@ import ctypes
 import math
 
 import numpy as np
+import paddle
 
 from nvidia.dali import types
 from nvidia.dali.backend import TensorListCPU, TensorGPU, TensorListGPU
@@ -72,6 +73,8 @@ def feed_ndarray(dali_tensor, ptr, cuda_stream=None):
                     (if not provided, an internal user stream will be selected)
     """
 
+    if cuda_stream is None:
+        cuda_stream = paddle.device.cuda.current_stream().cuda_stream 
     cuda_stream = types._raw_cuda_stream(cuda_stream)
 
     c_type_pointer = ctypes.c_void_p(ptr)

--- a/qa/setup_packages.py
+++ b/qa/setup_packages.py
@@ -448,8 +448,8 @@ all_packages = [PlainPackage("opencv-python", ["4.5.1.48"]),
                         { "101" : ["0.9.0"],
                           "111" : ["0.9.0"] }, extra_index="https://download.pytorch.org/whl/cu{cuda_v}/"),
                 CudaPackage("paddlepaddle-gpu",
-                        { "100" : ["2.0.2"],
-                          "110" : ["2.0.2"]})
+                        { "100" : ["2.2.0"],
+                          "110" : ["2.2.0"]})
                ]
 
 all_packages_keys = [pckg.key for pckg in all_packages]


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

As far as I know:

- For DALI: if the given stream is `None` when calling the `dali_tensor.copy_to_external()` method, DALI would use an internal stream (non-default stream) to copy the data. Let's call this DALI internal stream to be `dali_stream`.
- For PaddlePaddle: PaddlePaddle uses its own internal stream to launch the CUDA kernel. Let's call this PaddlePaddle internal stream to be `paddle_stream`.

The code of `dali_tensor.copy_to_external(stream=None, non_blocking=False)` is something like this:
```
if stream is None:
    stream = dali_stream

cudaMemcpyAsync(external_tensor_ptr, dali_tensor_ptr, dali_stream)
if not non_blocking:
    cudaStreamSynchronize(dali_stream)
```

When calling `cudaMemcpyAsync`, the `external_tensor_ptr` may be used in the launched CUDA kernel inside the PaddlePaddle framework. Therefore, the `external_tensor_ptr` may be read using `paddle_stream` and be written using `dali_stream` in the same time. This would cause incorrect results. We found this bug when running ResNet50 model of PaddlePaddle.

This PR makes the `cudaMemcpyAsync` use the `paddle_stream` instead of `dali_stream` to make sure the proper synchronization.

#### Additional information
- Affected modules and functionalities: DALI PaddlePaddle plugin
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review: CUDA stream synchronization between the DALI stream and PaddlePaddle stream
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
