### PR TITLE
Make all destructors noexcept. Add synchronization when destroying the Executor.

### DIFF
--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -40,6 +40,22 @@ void Executor<WorkspacePolicy, QueuePolicy>::PreRun() {
 }
 
 template <typename WorkspacePolicy, typename QueuePolicy>
+Executor<WorkspacePolicy, QueuePolicy>::~Executor() {
+  if (device_id_ != CPU_ONLY_DEVICE_ID) {
+    try {
+      DeviceGuard dg(device_id_);
+      if (mixed_op_stream_)
+        CUDA_DTOR_CALL(cudaStreamSynchronize(mixed_op_stream_));
+      if (gpu_op_stream_)
+        CUDA_DTOR_CALL(cudaStreamSynchronize(gpu_op_stream_));
+    } catch (const CUDAError &e) {
+      if (!e.is_unloading())
+        std::terminate();
+    }
+  }
+}
+
+template <typename WorkspacePolicy, typename QueuePolicy>
 void Executor<WorkspacePolicy, QueuePolicy>::RunCPUImpl() {
   PreRun();
 

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -28,9 +28,6 @@
 
 namespace dali {
 
-template class DLL_PUBLIC Executor<AOT_WS_Policy<UniformQueuePolicy>, UniformQueuePolicy>;
-template class DLL_PUBLIC Executor<AOT_WS_Policy<SeparateQueuePolicy>, SeparateQueuePolicy>;
-
 template <typename WorkspacePolicy, typename QueuePolicy>
 void Executor<WorkspacePolicy, QueuePolicy>::PreRun() {
   auto batch_size = InferBatchSize(batch_size_providers_);
@@ -386,5 +383,8 @@ int Executor<WorkspacePolicy, QueuePolicy>::InferBatchSize(
   }
   return batch_size;
 }
+
+template class DLL_PUBLIC Executor<AOT_WS_Policy<UniformQueuePolicy>, UniformQueuePolicy>;
+template class DLL_PUBLIC Executor<AOT_WS_Policy<SeparateQueuePolicy>, SeparateQueuePolicy>;
 
 }  // namespace dali

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -68,7 +68,7 @@ static void AppendToMap(ExecutorMetaMap &ret, ExecutorMetaMap &in_stats, std::mu
 class DLL_PUBLIC ExecutorBase {
  public:
   using ExecutorCallback = std::function<void(void)>;
-  DLL_PUBLIC virtual ~ExecutorBase() noexcept(false) {}
+  DLL_PUBLIC virtual ~ExecutorBase() = default;
   DLL_PUBLIC virtual void Build(OpGraph *graph, vector<string> output_names) = 0;
   DLL_PUBLIC virtual void Init() = 0;
   DLL_PUBLIC virtual void RunCPU() = 0;
@@ -118,6 +118,8 @@ class DLL_PUBLIC Executor : public ExecutorBase, public WorkspacePolicy, public 
 
     stage_queue_depths_ = QueuePolicy::GetQueueSizes(prefetch_queue_depth);
   }
+
+  DLL_PUBLIC ~Executor() override;
 
   DLL_PUBLIC void EnableMemoryStats(bool enable_memory_stats = false) override {
     enable_memory_stats_ = enable_memory_stats;

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -68,7 +68,7 @@ static void AppendToMap(ExecutorMetaMap &ret, ExecutorMetaMap &in_stats, std::mu
 class DLL_PUBLIC ExecutorBase {
  public:
   using ExecutorCallback = std::function<void(void)>;
-  DLL_PUBLIC virtual ~ExecutorBase() = default;
+  DLL_PUBLIC virtual ~ExecutorBase() {}
   DLL_PUBLIC virtual void Build(OpGraph *graph, vector<string> output_names) = 0;
   DLL_PUBLIC virtual void Init() = 0;
   DLL_PUBLIC virtual void RunCPU() = 0;

--- a/include/dali/core/cuda_error.h
+++ b/include/dali/core/cuda_error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,10 @@ class CUDAError : public std::runtime_error {
 
   bool is_drv_api() const noexcept { return drv_err != CUDA_SUCCESS; }
   bool is_rt_api() const noexcept { return rt_err != cudaSuccess; }
+
+  bool is_unloading() const noexcept {
+    return rt_err == cudaErrorCudartUnloading || drv_err == CUDA_ERROR_DEINITIALIZED;
+  }
 
  private:
   CUresult drv_err = CUDA_SUCCESS;

--- a/include/dali/core/mm/async_pool.h
+++ b/include/dali/core/mm/async_pool.h
@@ -67,8 +67,7 @@ class async_pool_resource : public async_memory_resource<Kind> {
     try {
       synchronize();
     } catch (const CUDAError &e) {
-      if ((e.is_rt_api() && e.rt_error() != cudaErrorCudartUnloading) ||
-          (e.is_drv_api() && e.drv_error() != CUDA_ERROR_DEINITIALIZED))
+      if (!e.is_unloading())
         std::terminate();
     }
     for (auto &kv : stream_free_) {
@@ -81,8 +80,7 @@ class async_pool_resource : public async_memory_resource<Kind> {
         try {
           global_pool_.deallocate_no_sync(f->addr, f->bytes, f->alignment);
         } catch (const CUDAError &e) {
-          if ((e.is_rt_api() && e.rt_error() != cudaErrorCudartUnloading) ||
-              (e.is_drv_api() && e.drv_error() != CUDA_ERROR_DEINITIALIZED))
+          if (!e.is_unloading())
             std::terminate();
         }
         f = remove_pending_free(free_blocks, f, false);


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [X] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [X] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
- All destructors were made noexcept
- Some destructors that could throw upon CUDA unloading were fixed
- Added a new boolean query: `bool CUDAError::is_unloading()` which returns true if the error was caused by driver/runtime being unloaded
- Added syncrhonization with mixed & gpu op streams in Executor's destructor

#### Additional information
- Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2459
<!--- DALI-XXXX or NA --->
