### PR TITLE
Synchronize CUDA stream once in operator benchmark

### DIFF
--- a/dali/benchmark/operator_bench.h
+++ b/dali/benchmark/operator_bench.h
@@ -88,7 +88,8 @@ class OperatorBench : public DALIBenchmark {
   void RunGPU(benchmark::State &st, const OpSpec &op_spec, int batch_size = 128,
               TensorListShape<> shape = uniform_list_shape(128, {1080, 1920, 3}),
               TensorLayout layout = "HWC",
-              bool fill_in_data = false) {
+              bool fill_in_data = false,
+              int64_t sync_each_n = -1) {
     assert(layout.size() == shape.size());
 
     auto op_ptr = InstantiateOperator(op_spec);
@@ -117,32 +118,36 @@ class OperatorBench : public DALIBenchmark {
     Setup<TensorList<GPUBackend>>(op_ptr, op_spec, ws, batch_size);
     op_ptr->Run(ws);
     CUDA_CALL(cudaStreamSynchronize(0));
+
+    int64_t batches = 0;
     for (auto _ : st) {
       op_ptr->Run(ws);
-
-      int num_batches = st.iterations() + 1;
-      st.counters["FPS"] = benchmark::Counter(batch_size * num_batches,
-        benchmark::Counter::kIsRate);
+      batches++;
+      if (sync_each_n > 0 && batches % sync_each_n == 0) {
+        CUDA_CALL(cudaStreamSynchronize(0));
+      }
     }
 
     st.ResumeTiming();
     CUDA_CALL(cudaStreamSynchronize(0));
     st.PauseTiming();
+    st.counters["FPS"] = benchmark::Counter(batch_size * st.iterations(),
+                                            benchmark::Counter::kIsRate);
   }
 
   template <typename T>
   void RunGPU(benchmark::State &st, const OpSpec &op_spec, int batch_size = 128,
               TensorShape<> shape = {1080, 1920, 3}, TensorLayout layout = "HWC",
-              bool fill_in_data = false) {
+              bool fill_in_data = false, int64_t sync_each_n = -1) {
     RunGPU<T>(st, op_spec, batch_size,
-              uniform_list_shape(batch_size, shape), layout, fill_in_data);
+              uniform_list_shape(batch_size, shape), layout, fill_in_data, sync_each_n);
   }
 
   template <typename T>
   void RunGPU(benchmark::State& st, const OpSpec &op_spec,
               int batch_size = 128, int H = 1080, int W = 1920, int C = 3,
-              bool fill_in_data = false) {
-    RunGPU<T>(st, op_spec, batch_size, {H, W, C}, "HWC", fill_in_data);
+              bool fill_in_data = false, int64_t sync_each_n = -1) {
+    RunGPU<T>(st, op_spec, batch_size, {H, W, C}, "HWC", fill_in_data, sync_each_n);
   }
 };
 

--- a/dali/benchmark/operator_bench.h
+++ b/dali/benchmark/operator_bench.h
@@ -119,12 +119,15 @@ class OperatorBench : public DALIBenchmark {
     CUDA_CALL(cudaStreamSynchronize(0));
     for (auto _ : st) {
       op_ptr->Run(ws);
-      CUDA_CALL(cudaStreamSynchronize(0));
 
       int num_batches = st.iterations() + 1;
       st.counters["FPS"] = benchmark::Counter(batch_size * num_batches,
         benchmark::Counter::kIsRate);
     }
+
+    st.ResumeTiming();
+    CUDA_CALL(cudaStreamSynchronize(0));
+    st.PauseTiming();
   }
 
   template <typename T>


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

CUDA stream was synchronized after each iteration in an operator benchmark, which introduced an overhead to the measurements, especially for small data and small batch sizes. In a real pipeline the synchronization would not happen after each operator but only at the end, so the introduced overhead was benchmark-specific and would not occur in real life.

This overhead was quite significant, when the operator execution was fast: the throughput of Copy measured on Titan V with `copy_bench.cc` for batch_size=1 and 3MiB images was decreased by 25% when synchronizing the stream after each iteration. The main source of the overhead was that the synchronization made it impossible to schedule copy with cudaMemcpyAsync while another copy was still in progress.

This PR moves the stream synchronization out of the loop, synchronizing the stream only once in a benchmark, so that  the measured operator performance is closer to the actual one.

#### Additional information
Key points relevant for the review: 

As synchronizing each loop introduces a benchmark-specific overhead, I consider it a bug that should be fixed. I am assuming that:
 - Google Benchmark measures and reports the *total* execution time of all iterations, so spending most of the time in the last iteration does not impact the results
 - There are no use cases in which synchronizing the stream each iterations is desired
 
If any of the above is false, making synchronization behaviour configurable with some optional parameter to `RunGPU` would be a better solution.

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
