### PR TITLE
Fix data race when copying outputs in TF plugin

### DIFF
--- a/dali_tf_plugin/dali_dataset_op.cc
+++ b/dali_tf_plugin/dali_dataset_op.cc
@@ -648,8 +648,12 @@ class DALIDatasetOp::Dataset::Iterator : public DatasetIterator<Dataset> {
               std::to_string(out_id));
       }
 
+      // Synchronize with the dataset()->stream_ when doing the last copy, so the outputs
+      // are fully finished before we release the output buffers for reuse.
+      unsigned int wait_flag = (out_id == num_outputs - 1) ? DALI_ext_force_sync : DALI_ext_default;
+
       TF_DALI_CALL(daliOutputCopy(&pipeline_handle_, dst, out_id, dataset()->device_type_,
-                                  dataset()->stream_, false));
+                                  dataset()->stream_, wait_flag));
     }
 
     end_of_sequence = false;

--- a/dali_tf_plugin/daliop.cc
+++ b/dali_tf_plugin/daliop.cc
@@ -350,8 +350,13 @@ class DaliOp : public tf::OpKernel {
           break;
       }
 
+
+      // Synchronize with the dataset()->stream_ when doing the last copy, so the outputs
+      // are fully finished before we release the output buffers for reuse.
+      unsigned int wait_flag = (i == dali_num_out - 1) ? DALI_ext_force_sync : DALI_ext_default;
+
       TF_DALI_CALL(
-          daliOutputCopy(&pipe_handle_, dst, i, this->device_type_, stream, DALI_ext_default));
+          daliOutputCopy(&pipe_handle_, dst, i, this->device_type_, stream, wait_flag));
       if (should_be_sparse_tensor) {
         ++j;
         // copy out shape


### PR DESCRIPTION
## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
DALI TF Plugin was copying the outputs on
TF's stream and was not synchronizing with
the copy.
In some cases we can overtake the copy
with DALI iteration and overwrite the buffers
before they are actually copied.

Add a flag to synchronize with the stream after
last copy is scheduled so we synchronize only
once.

#### Additional information
- Affected modules and functionalities:
TF plugin

- Key points relevant for the review:
Check if sync is enough

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2483
<!--- DALI-XXXX or NA --->
