### PR TITLE
Add more synchronization to InitStampede test

### DIFF
--- a/dali/core/mm/default_resource_test.cc
+++ b/dali/core/mm/default_resource_test.cc
@@ -240,7 +240,9 @@ TEST(MMDefaultResource, InitStampede) {
             return;
           std::this_thread::yield();
         }
+        std::atomic_thread_fence(std::memory_order::memory_order_acquire);
         GetDefaultResource<memory_kind::device>();
+        std::atomic_thread_fence(std::memory_order::memory_order_release);
         cnt++;
         while (!f2) {
           if (stop)
@@ -258,6 +260,7 @@ TEST(MMDefaultResource, InitStampede) {
     f1 = false;
     SetDefaultResource<memory_kind::device>(nullptr);
     _Test_FreeDeviceResources();
+    std::atomic_thread_fence(std::memory_order::memory_order_seq_cst);
     f2 = true;
     while (cnt != 0)
       std::this_thread::yield();

--- a/dali/core/mm/default_resources.cc
+++ b/dali/core/mm/default_resources.cc
@@ -351,6 +351,7 @@ void SetDefaultDeviceResource(int device_id, device_async_resource *resource, bo
 // This function is for testing purposes only - it must be visible
 DLL_PUBLIC void _Test_FreeDeviceResources() {
   // clear does not deallocate - we need something stronger
+  std::lock_guard<std::mutex> mtx(g_resources.mtx);
   decltype(g_resources.device) empty;
   g_resources.device.swap(empty);
 }

--- a/dali/core/mm/default_resources.cc
+++ b/dali/core/mm/default_resources.cc
@@ -75,11 +75,14 @@ struct DefaultResources {
   void InitDeviceResArray() {
     if (!device) {
       std::lock_guard<std::mutex> lock(mtx);
-      int ndevs = 0;
-      CUDA_CALL(cudaGetDeviceCount(&ndevs));
-      decltype(device) tmp(new std::shared_ptr<device_async_resource>[ndevs]);
-      num_devices = ndevs;
-      device = std::move(tmp);
+      if (!device) {
+        int ndevs = 0;
+        CUDA_CALL(cudaGetDeviceCount(&ndevs));
+        decltype(device) tmp(new std::shared_ptr<device_async_resource>[ndevs]);
+        std::atomic_thread_fence(std::memory_order::memory_order_seq_cst);
+        num_devices = ndevs;
+        device = std::move(tmp);
+      }
     }
   }
 

--- a/dali/core/mm/default_resources.cc
+++ b/dali/core/mm/default_resources.cc
@@ -52,7 +52,8 @@ struct DefaultResources {
   std::shared_ptr<host_memory_resource> host;
   std::shared_ptr<pinned_async_resource> pinned_async;
   std::shared_ptr<managed_async_resource> managed;
-  std::vector<std::shared_ptr<device_async_resource>> device;
+  std::unique_ptr<std::shared_ptr<device_async_resource>[]> device;
+  int num_devices = 0;
   std::mutex mtx;
 
   void ReleasePinned() {
@@ -71,6 +72,24 @@ struct DefaultResources {
     Release(host);
   }
 
+  void InitDeviceResArray() {
+    if (!device) {
+      std::lock_guard<std::mutex> lock(mtx);
+      int ndevs = 0;
+      CUDA_CALL(cudaGetDeviceCount(&ndevs));
+      decltype(device) tmp(new std::shared_ptr<device_async_resource>[ndevs]);
+      num_devices = ndevs;
+      device = std::move(tmp);
+    }
+  }
+
+  void CheckDeviceIndex(int device_id) const {
+    if (device_id < 0 || device_id >= num_devices) {
+      throw std::out_of_range(make_string(device_id, " is not a valid CUDA device index. "
+        "Shoud be 0 <= device_id < ", num_devices, " or negative for current device."));
+    }
+  }
+
  private:
   template <typename Ptr>
   void Release(Ptr &p) noexcept(false) {
@@ -82,10 +101,8 @@ struct DefaultResources {
   }
 
   template <typename T>
-  void Abandon(std::vector<T> &v) {
-    for (auto &x : v)
-      Abandon(x);
-    v.clear();
+  void Abandon(std::unique_ptr<T> &p) {
+    (void)p.release();
   }
 
   template <typename T>
@@ -269,16 +286,8 @@ const std::shared_ptr<device_async_resource> &ShareDefaultDeviceResourceImpl(int
   if (device_id < 0) {
     CUDA_CALL(cudaGetDevice(&device_id));
   }
-  if (g_resources.device.empty()) {
-    std::lock_guard<std::mutex> lock(g_resources.mtx);
-    int ndevs = 0;
-    CUDA_CALL(cudaGetDeviceCount(&ndevs));
-    g_resources.device.resize(ndevs);
-  }
-  if (static_cast<size_t>(device_id) >= g_resources.device.size()) {
-    throw std::out_of_range(make_string(device_id, " is not a valid CUDA device index. "
-      "Shoud be 0 <= device_id < ", g_resources.device.size(), " or negative for current device."));
-  }
+  g_resources.InitDeviceResArray();
+  g_resources.CheckDeviceIndex(device_id);
   if (!g_resources.device[device_id]) {
     std::lock_guard<std::mutex> lock(g_resources.mtx);
     if (!g_resources.device[device_id]) {
@@ -328,19 +337,12 @@ void SetDefaultResource<memory_kind::pinned>(pinned_async_resource *resource, bo
 
 
 void SetDefaultDeviceResource(int device_id, std::shared_ptr<device_async_resource> resource) {
-  std::lock_guard<std::mutex> lock(g_resources.mtx);
   if (device_id < 0) {
     CUDA_CALL(cudaGetDevice(&device_id));
   }
-  int ndevs = g_resources.device.size();
-  if (ndevs == 0) {
-    CUDA_CALL(cudaGetDeviceCount(&ndevs));
-    g_resources.device.resize(ndevs);
-  }
-  if (device_id < 0 || device_id >= ndevs) {
-    throw std::out_of_range(make_string(device_id, " is not a valid CUDA device index. "
-      "Shoud be 0 <= device_id < ", g_resources.device.size(), " or negative for current device."));
-  }
+  g_resources.InitDeviceResArray();
+  std::lock_guard<std::mutex> lock(g_resources.mtx);
+  g_resources.CheckDeviceIndex(device_id);
   g_resources.device[device_id] = std::move(resource);
 }
 
@@ -350,10 +352,9 @@ void SetDefaultDeviceResource(int device_id, device_async_resource *resource, bo
 
 // This function is for testing purposes only - it must be visible
 DLL_PUBLIC void _Test_FreeDeviceResources() {
-  // clear does not deallocate - we need something stronger
   std::lock_guard<std::mutex> mtx(g_resources.mtx);
-  decltype(g_resources.device) empty;
-  g_resources.device.swap(empty);
+  g_resources.device.reset();
+  g_resources.num_devices = 0;
 }
 
 template <> DLL_PUBLIC

--- a/include/dali/core/mm/async_pool.h
+++ b/include/dali/core/mm/async_pool.h
@@ -87,7 +87,7 @@ class async_pool_resource : public async_memory_resource<Kind> {
           if (!e.is_unloading())
             std::terminate();
         }
-        f = remove_pending_free(free_blocks, f, false, false);
+        f = remove_pending_free(free_blocks, f, false);
       }
       assert(free_blocks.free_list.head == nullptr);
       assert(free_blocks.free_list.tail == nullptr);
@@ -423,7 +423,7 @@ class async_pool_resource : public async_memory_resource<Kind> {
     auto *f = find_first_ready(free);
     while (f) {
       global_pool_.deallocate_no_sync(f->addr, f->bytes, f->alignment);
-      f = remove_pending_free(free, f, true);
+      f = remove_pending_free(free, f);
     }
   }
 
@@ -433,7 +433,7 @@ class async_pool_resource : public async_memory_resource<Kind> {
     try {
       free.by_size.insert({bytes, pending});
     } catch (...) {
-      remove_pending_free(free.free_list, pending, true);
+      remove_pending_free(free.free_list, pending);
       throw;
     }
   }
@@ -482,18 +482,15 @@ class async_pool_resource : public async_memory_resource<Kind> {
   }
 
   pending_free *remove_pending_free(PerStreamFreeBlocks &free, pending_free *f,
-                                    bool remove_by_size = true, bool recycle_event = true) {
+                                    bool remove_by_size = true) {
     if (remove_by_size)
       free.by_size.erase({ f->bytes, f });
-    return remove_pending_free(free.free_list, f, recycle_event);
+    return remove_pending_free(free.free_list, f);
   }
 
-  pending_free *remove_pending_free(PendingFreeList &free, pending_free *f, bool recycle_event) {
+  pending_free *remove_pending_free(PendingFreeList &free, pending_free *f) {
     ContextScope scope(f->ctx);
-    if (recycle_event)
-      CUDAEventPool::instance().Put(std::move(f->event));
-    else
-      f->event.reset();
+    CUDAEventPool::instance().Put(std::move(f->event));
     auto *prev = f->prev;
     auto *next = f->next;
     if (free.head == f)


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [X] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
For some reason, the test fails with a segmentation fault on SBSA. This PR adds more synchronization to the test, in the hope of eradicating some inconsistent state. This is mostly guesswork.

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
