### PR TITLE
Fix conda test for CUDA 10.x

### DIFF
--- a/qa/TL1_jupyter_conda/test_cupy.sh
+++ b/qa/TL1_jupyter_conda/test_cupy.sh
@@ -13,10 +13,23 @@ test_body() {
         "custom_operations/gpu_python_operator.ipynb"
         "general/data_loading/external_input.ipynb"
     )
+    # workarround for cupy using the wrong version of libnvrtc-builtins.so
+    # while cupy link to libnvrtc.so corresponding to the version it was built for
+    # libnvrtc.so loads the libnvrtc-builtins.so based on the $PATH and for conda
+    # it ends up using libnvrtc-builtins.so installed together with TensorFlow
+    # which is the latest and there is an obvious mismatch between libnvrtc-builtins.so
+    # and libnvrtc.so
+    LIB_PATH=$(dirname $(which python))/../lib
+    for f in $(ls $LIB_PATH/libnvrtc-builtins.so*); do
+        mv $f $f.bak
+    done
     for f in ${test_files[@]}; do
         jupyter nbconvert --to notebook --inplace --execute \
                         --ExecutePreprocessor.kernel_name=python${PYVER:0:1} \
                         --ExecutePreprocessor.timeout=300 $f;
+    done
+    for f in $(ls $LIB_PATH/libnvrtc-builtins.so*); do
+        mv $f ${f/.bak/}
     done
 }
 


### PR DESCRIPTION
- adds a workarround for cupy using wrong version of libnvrtc-builtins.so
  while cupy link to libnvrtc.so corresponding to the version it was build for
  libnvrtc.so loads the libnvrtc-builtins.so based on the $PATH and for conda
  it ends up using libnvrtc-builtins.so installed together with TensorFlow
  which is the latest

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
- adds a workarround for cupy using wrong version of libnvrtc-builtins.so
  while cupy link to libnvrtc.so corresponding to the version it was build for
  libnvrtc.so loads the libnvrtc-builtins.so based on the $PATH and for conda
  it ends up using libnvrtc-builtins.so installed together with TensorFlow
  which is the latest

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

#### Additional information
- Affected modules and functionalities:
  - TL1_jupyter_conda
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
  - is there any other way to change the path where libnvrtc-builtins.so is searched for
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
