### PR TITLE
Make Slice kernel tiling adaptive

### DIFF
--- a/dali/kernels/common/utils.h
+++ b/dali/kernels/common/utils.h
@@ -18,6 +18,7 @@
 #include <utility>
 #include "dali/core/util.h"
 #include "dali/core/traits.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 namespace kernels {
@@ -56,6 +57,16 @@ OutShape GetStrides(const Shape& shape) {
   OutShape strides = shape;
   CalcStrides(strides, shape);
   return strides;
+}
+
+inline int64_t GetSMCount() {
+  static int64_t count = 0;
+  if (!count) {
+    cudaDeviceProp prop;
+    CUDA_CALL(cudaGetDeviceProperties(&prop, 0));
+    count = prop.multiProcessorCount;
+  }
+  return count;
 }
 
 }  // namespace kernels

--- a/dali/kernels/common/utils.h
+++ b/dali/kernels/common/utils.h
@@ -18,7 +18,6 @@
 #include <utility>
 #include "dali/core/util.h"
 #include "dali/core/traits.h"
-#include "dali/core/cuda_error.h"
 
 namespace dali {
 namespace kernels {
@@ -57,16 +56,6 @@ OutShape GetStrides(const Shape& shape) {
   OutShape strides = shape;
   CalcStrides(strides, shape);
   return strides;
-}
-
-inline int64_t GetSMCount() {
-  static int64_t count = 0;
-  if (!count) {
-    cudaDeviceProp prop;
-    CUDA_CALL(cudaGetDeviceProperties(&prop, 0));
-    count = prop.multiProcessorCount;
-  }
-  return count;
 }
 
 }  // namespace kernels

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -255,7 +255,7 @@ class SliceGPU {
     block_count_ = 0;
     for (auto sample_size : sample_sizes) {
       block_count_ += std::ceil(
-      sample_size / static_cast<float>(blockSize));
+        sample_size / static_cast<float>(blockSize));
     }
 
     se.add<mm::memory_kind::host, detail::SliceBlockDesc>(block_count_);

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -246,7 +246,7 @@ class SliceGPU {
       total_volume += volume(args.shape);
     }
 
-    unsigned min_blocks = 4 * GetSMCount();
+    unsigned min_blocks = 4 * GetSmCount();
     block_size_ = kMaxBlockSize;
     while (total_volume / block_size_ < min_blocks && block_size_ > kMinBlockSize) {
       block_size_ /= 2;

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -193,12 +193,12 @@ __global__ void SliceKernel(const SliceSampleDesc<Dims> *samples, const SliceBlo
 template <typename OutputType, typename InputType, int Dims>
 class SliceGPU {
  private:
-  static constexpr int64_t kBlockDim = 256;
-  static constexpr int64_t kMinBlockSize = 4 * kBlockDim;
-  static constexpr int64_t kMaxBlockSize = 64 * kBlockDim;
+  static constexpr uint64_t kBlockDim = 256;
+  static constexpr uint64_t kMinBlockSize = 4 * kBlockDim;
+  static constexpr uint64_t kMaxBlockSize = 64 * kBlockDim;
 
-  int64_t block_size_ = kMaxBlockSize;
-  int64_t block_count_ = 0;
+  uint64_t block_size_ = kMaxBlockSize;
+  uint64_t block_count_ = 0;
 
  public:
   KernelRequirements Setup(KernelContext &context,
@@ -246,7 +246,7 @@ class SliceGPU {
       total_volume += volume(args.shape);
     }
 
-    int min_blocks = 4 * GetSMCount();
+    unsigned min_blocks = 4 * GetSMCount();
     block_size_ = kMaxBlockSize;
     while (total_volume / block_size_ < min_blocks && block_size_ > kMinBlockSize) {
       block_size_ /= 2;

--- a/include/dali/core/cuda_utils.h
+++ b/include/dali/core/cuda_utils.h
@@ -93,7 +93,7 @@ int MaxThreadsPerBlock(KernelFunction *f) {
   return max_block_size[device];
 }
 
-inline int GetSMCount() {
+inline int GetSmCount() {
   static int count = 0;
   if (!count) {
     cudaDeviceProp prop;

--- a/include/dali/core/cuda_utils.h
+++ b/include/dali/core/cuda_utils.h
@@ -93,6 +93,16 @@ int MaxThreadsPerBlock(KernelFunction *f) {
   return max_block_size[device];
 }
 
+inline int GetSMCount() {
+  static int count = 0;
+  if (!count) {
+    cudaDeviceProp prop;
+    CUDA_CALL(cudaGetDeviceProperties(&prop, 0));
+    count = prop.multiProcessorCount;
+  }
+  return count;
+}
+
 }  // namespace dali
 
 #endif  // DALI_CORE_CUDA_UTILS_H_

--- a/include/dali/core/cuda_utils.h
+++ b/include/dali/core/cuda_utils.h
@@ -18,6 +18,7 @@
 #include <cuda_runtime_api.h>  // for __align__ & CUDART_VERSION
 #include <cassert>
 #include <type_traits>
+#include <vector>
 #include "dali/core/host_dev.h"
 #include "dali/core/dynlink_cuda.h"
 #include "dali/core/cuda_error.h"
@@ -93,14 +94,22 @@ int MaxThreadsPerBlock(KernelFunction *f) {
   return max_block_size[device];
 }
 
-inline int GetSmCount() {
-  static int count = 0;
-  if (!count) {
+inline int GetSmCount(int device_id = -1) {
+  if (device_id < 0) {
+    CUDA_CALL(cudaGetDevice(&device_id));
+  }
+  static int dev_count = []() {
+    int ndevs = 0;
+    CUDA_CALL(cudaGetDeviceCount(&ndevs));
+    return ndevs;
+  }();
+  static vector<int> count(dev_count);
+  if (!count[device_id]) {
     cudaDeviceProp prop;
     CUDA_CALL(cudaGetDeviceProperties(&prop, 0));
-    count = prop.multiProcessorCount;
+    count[device_id] = prop.multiProcessorCount;
   }
-  return count;
+  return count[device_id];
 }
 
 }  // namespace dali


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [x] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

When `SliceGPU` runs the kernel, each thread processes a hardcoded count of 64 pixels: https://github.com/NVIDIA/DALI/blob/d7951e557dedba32b36111c206cfcf01afc1824f/dali/kernels/slice/slice_gpu.cuh#L197 This limits the performance for small batches of data, because for small data not enough blocks are run to keep all SMs busy. This PR addresses this issue by computing value of pixels per thread in an adaptive manner.

This increases the throughput by up to 60% for certain configurations.

#### The solution

This solution tries to make at least `4 * number of SMs` tiles to improve total GPU occupancy. 

It starts with original value of 64 pixels per thread and then divides it by 2 until estimated number of tiles reaches `4 * number of SMs` or a lower limit of 4 pixels per thread is reached. This means that for bigger data the behaviour is unchanged as the original value of 64 pixels per thread is used.

#### Benchmarks

**Benchmark.** I have measured Slice's performance in cropping images of size 500x500x3, 1000x1000x3, 2000x2000x3 to 250x250x3, 500x500x3 and 1000x1000x3 respecitvely. The measurements were taken for batches of 1, 2, 4, 8, 16, 32, 64, 128 and 256 images. As the change is not specific to particular shape of input data, I would expect similar performance impact on other, more complex shapes.

**The GPU.** The benchmarks were run on Titan V, which has 80 SMs.

**Performance for various pixels per thread.** I have measured performance of SliceGPU for values of pixels per thread (abbreviated to *ppt* on the plots) other than original 64. An increased throughput can be observed for smaller values of pixels per thread for small batch sizes.

![constant_ppt](https://user-images.githubusercontent.com/34919255/144680813-77678824-3f98-4a19-ad13-727d27e90ee8.png)

**Performance of the adaptive method.** In the second picture the results achieved by the adaptive method described above are presented. As you can see, no other value of pixels per thread performs better than the one chosen by the adaptive method.

![adaptive_ppt](https://user-images.githubusercontent.com/34919255/144680858-bd5c00c4-1eee-4a6c-8b1c-a54b6608070e.png)

### Additional information

#### Affected modules and functionalities:
- SliceGPU kernel tiling is affected, but only for small data

#### Key points relevant for the review:

- The magic constant `4` in computing minimal number of tiles (`4 * number of SMs`). This constant `4` turned out to be the best during benchmarks. The reason for that is probably that the kernel uses 48 registers, which means ~5 blocks can fit on the SM. This probably could be computed somehow from the GPU properties in the runtime, but this would add a lot of complexity to the code while having small effect on performance, so I decided to leave the magic constant here. I'm not really convinced though.

- The placement of `GetSMCount` method. I'm not very familiar with DALI, so I'm not sure if `utils.h` is a good place for the new `GetSMCount` function.

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
