### PR TITLE
Ensure that num_devices and device are stored in correct order.

### DIFF
--- a/dali/core/mm/default_resources.cc
+++ b/dali/core/mm/default_resources.cc
@@ -81,6 +81,7 @@ struct DefaultResources {
         decltype(device) tmp(new std::shared_ptr<device_async_resource>[ndevs]);
         std::atomic_thread_fence(std::memory_order::memory_order_seq_cst);
         num_devices = ndevs;
+        std::atomic_thread_fence(std::memory_order::memory_order_seq_cst);
         device = std::move(tmp);
       }
     }


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

## Description
- [X] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Prevent the writes to `num_devices` and `device` from being observed in reverse order.

#### Additional information
N/A

## Checklist

### Tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
