### PR TITLE
Add CUDAStreamPool & CUDAStreamLease.

### DIFF
--- a/dali/core/cuda_stream_pool.cc
+++ b/dali/core/cuda_stream_pool.cc
@@ -26,14 +26,13 @@ CUDAStreamPool::~CUDAStreamPool() {
 }
 
 CUDAStreamPool::CUDAStreamPool() {
-  lease_count_ = 0;
   int num_devices = 0;
   CUDA_CALL(cudaGetDeviceCount(&num_devices));
   dev_streams_.resize(num_devices);
 }
 
 CUDAStreamLease CUDAStreamPool::Get(int device_id) {
-  if (device_id == -1)
+  if (device_id < 0)
     CUDA_CALL(cudaGetDevice(&device_id));
 
   CUDAStream s = GetFromPool(device_id);

--- a/dali/core/cuda_stream_pool.cc
+++ b/dali/core/cuda_stream_pool.cc
@@ -1,0 +1,106 @@
+// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <mutex>
+#include <utility>
+#include "dali/core/cuda_stream_pool.h"
+#include "dali/core/cuda_error.h"
+
+namespace dali {
+
+CUDAStreamPool::~CUDAStreamPool() {
+  Purge();
+  assert(lease_count_ == 0);
+}
+
+CUDAStreamPool::CUDAStreamPool() {
+  lease_count_ = 0;
+  int num_devices = 0;
+  CUDA_CALL(cudaGetDeviceCount(&num_devices));
+  dev_streams_.resize(num_devices);
+}
+
+CUDAStreamLease CUDAStreamPool::Get(int device_id) {
+  if (device_id == -1)
+    CUDA_CALL(cudaGetDevice(&device_id));
+
+  CUDAStream s = GetFromPool(device_id);
+  if (!s)
+    s = CUDAStream::Create(true, device_id);
+  return { std::move(s), device_id, this };
+}
+
+void CUDAStreamPool::Purge() {
+  std::lock_guard<spinlock> guard(lock_);
+  DeleteList(unused_);
+  for (auto &list : dev_streams_)
+    DeleteList(list);
+}
+
+void CUDAStreamPool::DeleteList(StreamEntry *&head) {
+  while (head) {
+    auto *next = head->next;
+    delete head;
+    head = next;
+  }
+}
+
+CUDAStream CUDAStreamPool::GetFromPool(int device_id) {
+  assert(device_id >= 0 && device_id < static_cast<int>(dev_streams_.size()));
+  std::lock_guard<spinlock> guard(lock_);
+  StreamEntry *e = Pop(dev_streams_[device_id]);
+  if (!e)
+    return {};
+  CUDAStream ev = std::move(e->stream);
+  Push(unused_, e);
+  return ev;
+}
+
+void CUDAStreamPool::Put(CUDAStream &&stream, int device_id) {
+  if (!stream)
+    throw std::invalid_argument("Cannot put a null stream in the pool.");
+  if (device_id < 0) {
+    try {
+      device_id = stream.GetDevice();
+    } catch (const CUDAError &e) {
+      if (e.is_unloading()) {
+        stream.reset();
+        return;
+      } else {
+        throw;
+      }
+    }
+  }
+
+  assert(device_id >= 0 && device_id < static_cast<int>(dev_streams_.size()));
+
+  std::unique_lock<spinlock> lock(lock_);
+  StreamEntry *e = Pop(unused_);
+  if (!e) {
+    lock.unlock();
+    e = new StreamEntry(std::move(stream));
+    lock.lock();
+  } else {
+    e->stream = std::move(stream);
+  }
+  Push(dev_streams_[device_id], e);
+}
+
+CUDAStreamPool &CUDAStreamPool::instance() {
+  static CUDAStreamPool instance;
+  return instance;
+}
+
+}  // namespace dali

--- a/dali/core/cuda_stream_pool_test.cc
+++ b/dali/core/cuda_stream_pool_test.cc
@@ -1,0 +1,85 @@
+// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include <random>
+#include <thread>
+#include <vector>
+#include "dali/core/cuda_error.h"
+#include "dali/core/cuda_stream_pool.h"
+#include "dali/core/cuda_stream.h"
+
+namespace dali {
+
+class CUDAStreamPoolTest : public ::testing::Test {
+ public:
+  void TestPutGet() {
+    int devices = 0;
+    (void)cudaGetDeviceCount(&devices);
+    if (devices == 0) {
+      (void)cudaGetLastError();  // No CUDA devices - we don't care about the error
+      GTEST_SKIP();
+    }
+
+    CUDAStreamPool pool;
+
+    vector<std::thread> threads;
+    for (int i = 0; i < 10; i++) {
+      threads.emplace_back([&]() {
+        std::mt19937_64 rng;
+        std::uniform_int_distribution<int> dev_dist(0, devices-1);
+        std::uniform_int_distribution<int> release_method(5);
+        for (int i = 0; i < 10000; i++) {
+          int device_id = dev_dist(rng);
+          CUDAStreamLease s = pool.Get(device_id);  // not current device (in general)
+          CUDAStreamLease stream = std::move(s);  // check move constructor
+          ASSERT_EQ(DeviceFromStream(stream), device_id)
+            << "CUDAStreamPool mixed streams from different devices";
+          ASSERT_EQ(cudaSuccess, cudaSetDevice(device_id));
+          ASSERT_EQ(cudaSuccess, cudaStreamSynchronize(stream));
+          switch (release_method(rng)) {
+            case 1:
+              stream.reset();
+              break;
+            case 2:
+              pool.Put(stream.release());
+              break;
+            case 3:
+              pool.Put(stream.release(), device_id);
+              break;
+            case 4:
+              stream.release().reset();
+              break;
+            default:
+              // just go out of scope
+              break;
+          }
+        }
+      });
+    }
+    for (auto &t : threads)
+      t.join();
+    ASSERT_EQ(0, pool.lease_count_.load());
+  }
+};
+
+namespace test {
+
+TEST_F(CUDAStreamPoolTest, PutGet) {
+  TestPutGet();
+}
+
+}  // namespace test
+}  // namespace dali

--- a/include/dali/core/cuda_stream.h
+++ b/include/dali/core/cuda_stream.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 
 namespace dali {
 
+DLL_PUBLIC int DeviceFromStream(cudaStream_t s);
+
 /**
  * @brief A wrapper class for CUDA stream handle (cudaStream_t),
  *
@@ -42,6 +44,10 @@ class DLL_PUBLIC CUDAStream : public UniqueHandle<cudaStream_t, CUDAStream>{
   /// @brief Creates a stream with given priority on specified device
   ///        (or current device, if device_id < 0)
   static CUDAStream CreateWithPriority(bool non_blocking, int priority, int device_id = -1);
+
+  inline int GetDevice() const {
+    return DeviceFromStream(*this);
+  }
 
   /// @brief Calls cudaStreamDestroy on the handle.
   static void DestroyHandle(cudaStream_t stream);

--- a/include/dali/core/cuda_stream_pool.h
+++ b/include/dali/core/cuda_stream_pool.h
@@ -15,6 +15,7 @@
 #ifndef DALI_CORE_CUDA_STREAM_POOL_H_
 #define DALI_CORE_CUDA_STREAM_POOL_H_
 
+#include <cassert>
 #include <atomic>
 #include <vector>
 #include <utility>
@@ -195,7 +196,7 @@ class CUDAStreamLease {
  private:
   CUDAStreamLease(CUDAStream &&stream, int device_id, CUDAStreamPool *owner)
   : stream_(std::move(stream)), device_id_(device_id), owner_(owner) {
-    assert(owner && stream);
+    assert(owner_ && stream_);
     ++owner->lease_count_;
   }
 

--- a/include/dali/core/cuda_stream_pool.h
+++ b/include/dali/core/cuda_stream_pool.h
@@ -32,7 +32,7 @@ class DLL_PUBLIC CUDAStreamPool {
   ~CUDAStreamPool();
 
   /**
-   * @brief Get a stream for given device.
+   * @brief Gets a stream for given device.
    *
    * @param device_id   CUDA runtime API device ordinal. If negative, calling thread's
    *                    current device is used.
@@ -43,19 +43,19 @@ class DLL_PUBLIC CUDAStreamPool {
   CUDAStreamLease Get(int device_id = -1);
 
   /**
-   * @brief Place a stream for given device in the pool.
+   * @brief Places a stream for given device in the pool.
    *
    * @param device_id CUDA runtime API device ordinal of the device for which the stream was
-   *                  created. If negative, the device is obtained form the device context
+   *                  created. If negative, the device is obtained from the device context
    *                  associated with the stream.
    *
-   * @remarks It is an error to misstate the device_id. Placing a stream with improper deviceid
+   * @remarks It is an error to misstate the device_id. Placing a stream with improper device_id
    *          will render the stream pool unusable.
    */
   void Put(CUDAStream &&stream, int device_id = -1);
 
   /**
-   * @brief Remove all streams currently in the pool and deletes auxiliary data structures.
+   * @brief Removes all streams currently in the pool and deletes auxiliary data structures.
    *
    * NOTE: Avoid using this function on the pool returned by `instance()`
    */
@@ -86,7 +86,7 @@ class DLL_PUBLIC CUDAStreamPool {
   };
 
   StreamEntry *unused_ = nullptr;
-  std::atomic_int lease_count_;
+  std::atomic_int lease_count_ = 0;
 
   vector<StreamEntry *> dev_streams_;
   spinlock lock_;
@@ -151,7 +151,7 @@ class CUDAStreamLease {
   }
 
   /**
-   * @brief Detach the stream from the pool. In most cases this should not be necessary.
+   * @brief Detaches the stream from the pool. In most cases this should not be necessary.
    */
   CUDAStream release() noexcept {
     auto ret = std::move(stream_);

--- a/include/dali/core/cuda_stream_pool.h
+++ b/include/dali/core/cuda_stream_pool.h
@@ -1,0 +1,211 @@
+// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_CUDA_STREAM_POOL_H_
+#define DALI_CORE_CUDA_STREAM_POOL_H_
+
+#include <atomic>
+#include <vector>
+#include <utility>
+#include "dali/core/cuda_stream.h"
+#include "dali/core/spinlock.h"
+
+namespace dali {
+
+class CUDAStreamLease;
+
+class DLL_PUBLIC CUDAStreamPool {
+ public:
+  CUDAStreamPool();
+  ~CUDAStreamPool();
+
+  /**
+   * @brief Get a stream for given device.
+   *
+   * @param device_id   CUDA runtime API device ordinal. If negative, calling thread's
+   *                    current device is used.
+   *
+   * @return A CUDA stream wrapper object. If there were any streams in the pools, the
+   *         stream is taken from it, otherwise a new stream is created.
+   */
+  CUDAStreamLease Get(int device_id = -1);
+
+  /**
+   * @brief Place a stream for given device in the pool.
+   *
+   * @param device_id CUDA runtime API device ordinal of the device for which the stream was
+   *                  created. If negative, the device is obtained form the device context
+   *                  associated with the stream.
+   *
+   * @remarks It is an error to misstate the device_id. Placing a stream with improper deviceid
+   *          will render the stream pool unusable.
+   */
+  void Put(CUDAStream &&stream, int device_id = -1);
+
+  /**
+   * @brief Remove all streams currently in the pool and deletes auxiliary data structures.
+   *
+   * NOTE: Avoid using this function on the pool returned by `instance()`
+   */
+  void Purge();
+
+  /**
+   * @brief Returns a reference to the singleton instance.
+   *
+   * @remarks Using the singleton instance is only possible if:
+   * - the enclosing library is compiled and used as a shared object,
+   * - the enclosing library is static, but matching calls to Get and Put calls are
+   *   contained within one shared object.
+   */
+  static CUDAStreamPool &instance();
+
+ private:
+  friend class CUDAStreamLease;
+  friend class CUDAStreamPoolTest;
+
+  CUDAStream GetFromPool(int device_id);
+
+  struct StreamEntry {
+    StreamEntry() = default;
+    explicit StreamEntry(CUDAStream stream, StreamEntry *next = nullptr)
+    : stream(std::move(stream)), next(next) {}
+    CUDAStream stream;
+    StreamEntry *next = nullptr;
+  };
+
+  StreamEntry *unused_ = nullptr;
+  std::atomic_int lease_count_;
+
+  vector<StreamEntry *> dev_streams_;
+  spinlock lock_;
+
+  static StreamEntry *Pop(StreamEntry *&head) {
+    auto *e = head;
+    if (e)
+      head = head->next;
+    return e;
+  }
+
+  static void Push(StreamEntry *&head, StreamEntry *new_entry) {
+    new_entry->next = head;
+    head = new_entry;
+  }
+
+  void DeleteList(StreamEntry *&head);
+};
+
+/**
+ * @brief Represents a stream which is leased from a CUDAStreamPool
+ *
+ * When obtaining a CUDA stream from a CUDAStreamPool, a stream lease object is returned.
+ * This object holds a handle to the stream, a device id and a pointer to the stream pool
+ * object from which the stream is leased. When the lease is destroyed/reset, the stream is
+ * returned to the owning pool.
+ *
+ * NOTE: The lease must be ended (destroyed or reset) before the owning pool can be destroyed.
+ */
+class CUDAStreamLease {
+ public:
+  constexpr CUDAStreamLease() = default;
+
+  CUDAStreamLease(CUDAStreamLease &&other) {
+    *this = std::move(other);
+  }
+
+  CUDAStreamLease &operator=(CUDAStreamLease &&other) {
+    if ((cudaStream_t)stream_ != (cudaStream_t)other.stream_) {  // NOLINT
+      stream_ = std::move(other.stream_);
+      owner_ = other.owner_;
+      device_id_ = other.device_id_;
+      other.owner_ = nullptr;
+      other.device_id_ = -1;
+    }
+    return *this;
+  }
+
+  ~CUDAStreamLease() {
+    reset();
+  }
+
+  /**
+   * @brief Conversion to a stream handle; enables the use of this object with CUDA runtime APIs.
+   */
+  operator cudaStream_t() const noexcept {
+    return stream_;
+  }
+
+  explicit operator bool() const noexcept {
+    return stream_;
+  }
+
+  /**
+   * @brief Detach the stream from the pool. In most cases this should not be necessary.
+   */
+  CUDAStream release() noexcept {
+    auto ret = std::move(stream_);
+    if (owner_) {
+      if (ret)
+        owner_->lease_count_--;
+      owner_ = nullptr;
+    }
+    device_id_ = -1;
+    return ret;
+  }
+
+  /**
+   * @brief Returns the device ID associated with the stream.
+   */
+  int device_id() const noexcept {
+    return device_id_;
+  }
+
+  /**
+   * @brief Returns the owning pool object.
+   */
+  CUDAStreamPool *pool() const noexcept {
+    return owner_;
+  }
+
+  /**
+   * @brief Returns the stream to the owning pool.
+   */
+  void reset() {
+    if (owner_) {
+      if (stream_) {
+        owner_->Put(std::move(stream_), device_id_);
+        owner_->lease_count_--;
+      }
+      owner_ = nullptr;
+    }
+    stream_.reset();
+    device_id_ = -1;
+  }
+
+ private:
+  CUDAStreamLease(CUDAStream &&stream, int device_id, CUDAStreamPool *owner)
+  : stream_(std::move(stream)), device_id_(device_id), owner_(owner) {
+    assert(owner && stream);
+    ++owner->lease_count_;
+  }
+
+  friend class CUDAStreamPool;
+  CUDAStream stream_;
+  int device_id_ = -1;
+  CUDAStreamPool *owner_ = nullptr;
+};
+
+
+}  // namespace dali
+
+#endif  // DALI_CORE_CUDA_STREAM_POOL_H_


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [X] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Added a CUDA Stream Pool with support for multiple devices.

#### Goals
The high-level goal of this PR is to provide a replacement for cudaStreamCreate/cudaStreamDestroy that never actually destroys the stream object. This is important for stream-aware buffers to prevent them from outliving their associated streams.

#### High-level design
A CUDA stream can be leased from the pool - the pool doesn't return standalone objects to avoid inadvertent deletion of the stream - instead, it returns a CUDAStreamLease which, upon destruction, returns the managed stream to the pool from which the stream was obtained.

#### Additional information
The code for the pool object is mostly a copy-paste from CUDAEventPool - with two notable differences:
1. The Get method returns a CUDAStreamLease instead of CUDAStream.
2. The device can be reliably obtained from a stream object (unlike an Event), so that approach is used in the `Put` method without a device id.

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2498
<!--- DALI-XXXX or NA --->
