### PR TITLE
Fix `version_ge: command not found` error in TL0_python-self-test-base-cuda

### DIFF
--- a/qa/setup_test_common.sh
+++ b/qa/setup_test_common.sh
@@ -3,11 +3,6 @@
 CUDA_VERSION=$(echo $(nvcc --version) | sed 's/.*\(release \)\([0-9]\+\)\.\([0-9]\+\).*/\2\3/')
 CUDA_VERSION=${CUDA_VERSION:-100}
 
-if [ -n "$gather_pip_packages" ]
-then
-    # early exit
-    return 0
-fi
 PYTHON_VERSION=$(python -c "import sys; print(\"{}.{}\".format(sys.version_info[0],sys.version_info[1]))")
 PYTHON_VERSION_SHORT=${PYTHON_VERSION/\./}
 
@@ -17,6 +12,12 @@ function version_gt() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" 
 function version_le() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" == "$1"; }
 function version_lt() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1"; }
 function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
+
+if [ -n "$gather_pip_packages" ]
+then
+    # early exit
+    return 0
+fi
 
 # If driver version is less than 450 and CUDA version is 11,
 # add /usr/local/cuda/compat to LD_LIBRARY_PATH


### PR DESCRIPTION
- when pip packages are predownloaded setup_test_common.sh early
  exits and version_ge function is not defined. This PR moves
  early exit to make this function defined

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
- when pip packages are predownloaded setup_test_common.sh early
  exits and version_ge function is not defined. This PR moves
  early exit to make this function defined
- fix to https://github.com/NVIDIA/DALI/pull/3540
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

#### Additional information
- Affected modules and functionalities:
  - qa/setup_test_common.sh
<!--- Describe here what was changed, added, removed. --->

- Key points relevant for the review:
  - NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
