### PR TITLE
Use current device in _as_gpu

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -395,9 +395,11 @@ void ExposeTensor(py::module &m) {
     })
     .def("_as_gpu", [](Tensor<CPUBackend> &t) -> Tensor<GPUBackend>* {
           auto ret = std::make_unique<Tensor<GPUBackend>>();
-          UserStream * us = UserStream::Get();
+          int dev = -1;
+          CUDA_CALL(cudaGetDevice(&dev));
+          ret->set_device_id(dev);
+          UserStream *us = UserStream::Get();
           cudaStream_t s = us->GetStream(*ret);
-          DeviceGuard g((*ret).device_id());
           ret->Copy(t, s);
           us->Wait(*ret);
           return ret.release();
@@ -675,9 +677,11 @@ void ExposeTensorList(py::module &m) {
       )code")
     .def("_as_gpu", [](TensorList<CPUBackend> &t) {
           auto ret = std::make_shared<TensorList<GPUBackend>>();
-          UserStream * us = UserStream::Get();
+          int dev = -1;
+          CUDA_CALL(cudaGetDevice(&dev));
+          ret->set_device_id(dev);
+          UserStream *us = UserStream::Get();
           cudaStream_t s = us->GetStream(*ret);
-          DeviceGuard g((*ret).device_id());
           ret->Copy(t, s);
           us->Wait(*ret);
           return ret;

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -82,6 +82,20 @@ def test_array_interface_tensor_cpu():
     assert np.array_equal(tensorlist[0].__array_interface__['shape'], tensorlist[0].shape())
     assert tensorlist[0].__array_interface__['typestr'] == tensorlist[0].dtype()
 
+def check_transfer(dali_type):
+    arr = np.random.rand(3, 5, 6)
+    data = dali_type(arr)
+    data_gpu = data._as_gpu()
+    data_cpu = data_gpu.as_cpu()
+    if dali_type is TensorListCPU:
+        np.testing.assert_array_equal(arr, data_cpu.as_array())
+    else:
+        np.testing.assert_array_equal(arr, np.array(data_cpu))
+
+def test_transfer_cpu_gpu():
+    for dali_type in [TensorCPU, TensorListCPU]:
+        yield check_transfer, dali_type
+
 def check_array_types(t):
     arr = np.array([[-0.39, 1.5], [-1.5, 0.33]], dtype=t)
     tensor = TensorCPU(arr, "NHWC")


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
In the internal `Tensor[List]CPU._as_gpu` used in debug mode
we used stream tied with the device of the newly created Tensor[List]GPU,
which is not initialized to any of current GPU.
Use the current GPU device for the returned Tensor[List]GPU and 
do the copy & wait on the stream associated with that device.

#### Additional information
- Affected modules and functionalities:
Python/Backend/Debug Mode.

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
