### PR TITLE
Fix wrong parameter name in Laplacian docs

### DIFF
--- a/dali/operators/image/convolution/laplacian.cc
+++ b/dali/operators/image/convolution/laplacian.cc
@@ -57,10 +57,10 @@ and ``smoothing_size=[sz, sy, sx]`` are specified, the following windows will be
 Window sizes and smoothing sizes must be odd. The size of a derivative window must be at least 3.
 Smoothing window can be of size 1, which implies no smoothing along corresponding axis.
 
-To normalize partial derivatives, ``normalize=True`` can be used. Each partial derivative is scaled
-by ``2^(-s + n + 2)``, where ``s`` is the sum of the window sizes used to calculate a given partial
-derivative (including the smoothing windows) and ``n`` is the number of data dimensions/axes.
-Alternatively, you can specify ``scale`` argument to customize scaling factors.
+To normalize partial derivatives, ``normalized_kernel=True`` can be used. Each partial derivative
+is scaled by ``2^(-s + n + 2)``, where ``s`` is the sum of the window sizes used to calculate
+a given partial derivative (including the smoothing windows) and ``n`` is the number of data
+dimensions/axes. Alternatively, you can specify ``scale`` argument to customize scaling factors.
 Scale can be either a single value or ``n`` values, one for every partial derivative.
 
 Operator uses 32-bit floats as an intermediate type.


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [x] **Other** (*e.g. Documentation, Tests, Configuration*)

The Laplacian docs mentions `normalize=True` parameter, but the parameter was renamed to `normalized_kernel`

#### Additional information
- Affected modules and functionalities:
Only the Laplacian docs.

- Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2527
<!--- DALI-XXXX or NA --->
