### PR TITLE
Use the same device for debug mode test and baseline

### DIFF
--- a/dali/test/python/test_pipeline_debug.py
+++ b/dali/test/python/test_pipeline_debug.py
@@ -110,6 +110,8 @@ def injection_pipeline_standard(device='cpu'):
         file_root=file_root, shard_id=0, num_shards=2)
     images = fn.decoders.image(jpegs, output_type=types.RGB)
     rng = fn.random.coin_flip(probability=0.5, seed=47)
+    if device == "gpu":
+        images = images.gpu()
     images = fn.random_resized_crop(images, device=device, size=(224, 224), seed=27)
     out_type = types.FLOAT16
 
@@ -141,19 +143,19 @@ def test_injection_mxnet():
 def test_injection_torch():
     import torch
     yield _test_injection, 'cpu', 'torch cpu tensor', lambda xs: [torch.tensor(np.array(x), device='cpu') for x in xs]
-    yield _test_injection, 'gpu', 'torch gpu tensor', lambda xs: [torch.tensor(np.array(x), device='cuda') for x in xs], 1e-03
+    yield _test_injection, 'gpu', 'torch gpu tensor', lambda xs: [torch.tensor(np.array(x), device='cuda') for x in xs]
 
 
 @attr('cupy')
 def test_injection_cupy():
     import cupy
-    _test_injection('gpu', 'cupy array', lambda xs: [cupy.array(x) for x in xs], 1e-03)
+    _test_injection('gpu', 'cupy array', lambda xs: [cupy.array(x) for x in xs])
 
 
 def test_injection_dali_types():
-    yield _test_injection, 'gpu', 'list of TensorGPU', lambda xs: [x._as_gpu() for x in xs], 1e-03
+    yield _test_injection, 'gpu', 'list of TensorGPU', lambda xs: [x._as_gpu() for x in xs]
     yield _test_injection, 'cpu', 'TensorListCPU', lambda xs: xs
-    yield _test_injection, 'gpu', 'TensorListGPU', lambda xs: xs._as_gpu(), 1e-03
+    yield _test_injection, 'gpu', 'TensorListGPU', lambda xs: xs._as_gpu()
 
 
 @pipeline_def(batch_size=8, num_threads=3, device_id=0, debug=True)


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [x] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
Random resized crop was invoked always on CPU in baseline code,
but on GPU for some debug mode tests leading to inaccuracies.

The reduced epsilon was removed.

#### Additional information
- Affected modules and functionalities:
Debug mode tests

- Key points relevant for the review:
N/a

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
