### PR TITLE
Explicitly coalesce stores in Slice for smaller output types

### DIFF
--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -84,7 +84,7 @@ union PackedBuffer {
   __device__ inline void store(T* mem, size_t count) {
     if (kCapacity == 1) {
       *mem = *values;
-    } else if (count == kCapacity && (uint64_t)mem % kCapacity == 0) {
+    } else if (count == kCapacity && (uint64_t)mem % sizeof(PackedType) == 0) {
       *reinterpret_cast<PackedType*>(mem) = raw;
     } else {
       #pragma unroll

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -84,7 +84,7 @@ union PackedBuffer {
   __device__ inline void store(T* mem, size_t count) {
     if (kCapacity == 1) {
       *mem = *values;
-    } else if (count == kCapacity && (uint64_t)mem % sizeof(PackedType) == 0) {
+    } else if (count == kCapacity && static_cast<uintptr_t>(mem) % sizeof(PackedType) == 0) {
       *reinterpret_cast<PackedType*>(mem) = raw;
     } else {
       #pragma unroll

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -85,7 +85,7 @@ union PackedBuffer {
   inline void store(T* mem, size_t count) {
     if (kCapacity == 1) {
       *mem = *values;
-    } else if (count == kCapacity) {
+    } else if (count == kCapacity && (uint64_t)mem % kCapacity == 0) {
       *reinterpret_cast<PackedType*>(mem) = raw;
     } else {
       #pragma unroll

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -84,7 +84,7 @@ union PackedBuffer {
   __device__ inline void store(T* mem, size_t count) {
     if (kCapacity == 1) {
       *mem = *values;
-    } else if (count == kCapacity && static_cast<uintptr_t>(mem) % sizeof(PackedType) == 0) {
+    } else if (count == kCapacity && reinterpret_cast<uintptr_t>(mem) % sizeof(PackedType) == 0) {
       *reinterpret_cast<PackedType*>(mem) = raw;
     } else {
       #pragma unroll

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -81,8 +81,7 @@ union PackedBuffer {
   T values[kCapacity];
   PackedType raw;
 
-  __device__
-  inline void store(T* mem, size_t count) {
+  __device__ inline void store(T* mem, size_t count) {
     if (kCapacity == 1) {
       *mem = *values;
     } else if (count == kCapacity && (uint64_t)mem % kCapacity == 0) {


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [x] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

This PR is an extension of the idea I proposed in https://github.com/NVIDIA/DALI/pull/3568 . That PR improved coalescing of L2 to Global Memory transfers for small ( < 32 bits) output types. However, L1 to L2 transfers still were a bottleneck. The L1 to L2 transfers are 128 bytes wide, which makes it impossible for a 32-thread warp to use more than 25% of the bandwidth when issuing single-byte stores, no matter what the access pattern is. 

In this PR I introduce a buffer, in which the data is cached until full 32-bit store (resulting in full 128 bytes wide memory request from the warp) is possible.

This visibly increases Slice's throughput, as you can see in the plots below, which present the throughput improvement in cropping 2000x2000, 1000x1000 and 500x500 uint8 RGB images to 1000x1000, 500x500 and 250x250 respectively on Titan V. The _Original_ is the Slice before my optimizations, _Coalesced (old)_ is the Slice with https://github.com/NVIDIA/DALI/pull/3568 applied, and _Coalesced (new)_ is the Slice with the proposed changes. Also, Slice's performance on 32-bit floats is drawn for reference, indicating the throughput that Slice can achieve for bigger data types when no coalescing problems occur.

![coalesce2](https://user-images.githubusercontent.com/34919255/147410662-a0ae43f6-db32-41a9-ba38-bc0d84acee20.png)


#### Additional information
- Affected modules and functionalities: Slice's performance for smaller output types. Peformance for 32-bit and bigger types is unaffected as almost whole `PackedBuffer` logic gets optimized out.

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
