### PR TITLE
Fix synchronization bug in operator benchmark

### DIFF
--- a/dali/benchmark/operator_bench.h
+++ b/dali/benchmark/operator_bench.h
@@ -119,19 +119,13 @@ class OperatorBench : public DALIBenchmark {
     op_ptr->Run(ws);
     CUDA_CALL(cudaStreamSynchronize(0));
 
-    int64_t batches = 0;
+    uint64_t batches = 0;
 
-    while (true) {
-      if (!st.KeepRunning()) {
-        // If no iterations left, synchronize and exit the loop
-        CUDA_CALL(cudaStreamSynchronize(0));
-        break;
-      }
-
+    while (st.KeepRunning()) {
       op_ptr->Run(ws);
       batches++;
 
-      if (sync_each_n > 0 && batches % sync_each_n == 0) {
+      if (batches == st.max_iterations || (sync_each_n > 0 && batches % sync_each_n == 0)) {
         CUDA_CALL(cudaStreamSynchronize(0));
       }
     }


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI.

Please fill the relevant information in this PR template.

Fields with `- [ ]` represent check-boxes that can be marked after you create and save the Pull Request.
--->

## Description
- [x] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [ ] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [ ] **Other** (*e.g. Documentation, Tests, Configuration*)

### What happened in this PR
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

In https://github.com/NVIDIA/DALI/pull/3525 I introduced a change in `operator_bench.h`, which by default called `CudaDeviceSynchronize()` only once, at the end of the benchmark. However, my usage of `PauseTimer()` and `ResumeTimer()` turned out to be incorrect and the code was fixed in https://github.com/NVIDIA/DALI/pull/3585 . The logic responsible for synchronizing only at the end now looks as follows:
https://github.com/NVIDIA/DALI/blob/e002fe0a775dcbec9a759177da70c4dba0f902ff/dali/benchmark/operator_bench.h#L125-L129

However, when `KeepRunning()` returns false (meaning that the benchmark is over, i.e. all iterations are complete), it pauses the timer. This means that the `CudaDeviceSynchronize()` call is *not* timed. This makes the benchmark results unreliable, because often most CPU time is spent in `CudaDeviceSynchronize()`. 

In this PR I (try to) fix this bug by checking if an iteration is the last one by simply comparing iteration number with target iteration count.


#### Additional information
- Affected modules and functionalities: operator benchmark behaviour

- I couldn't find any precise specification behaviour of `KeepRunning` in Google Benchmark docs, but the source code seems to confirm that it pauses the timer. `KeepRunning` calls `KeepRunningInternal`, which, if `false` is to be returned, calls `FinishKeepRunning`, and `FinishKeepRunning` calls `PauseTimer`:
https://github.com/google/benchmark/blob/acd75620347618dcf73e9d18474f110db63b97d4/include/benchmark/benchmark.h#L808-L842
https://github.com/google/benchmark/blob/acd75620347618dcf73e9d18474f110db63b97d4/src/benchmark.cc#L236-L245

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
