### PR TITLE
Fix Laplacian GPU tests compilation on Xavier

### DIFF
--- a/dali/kernels/imgproc/convolution/laplacian_gpu_test.cu
+++ b/dali/kernels/imgproc/convolution/laplacian_gpu_test.cu
@@ -14,7 +14,7 @@
 
 #include <gtest/gtest.h>
 #include <array>
-#include <numeric>
+#include <cmath>
 #include <vector>
 
 #include "dali/kernels/common/utils.h"
@@ -154,7 +154,7 @@ struct LaplacianGpuTest : public ::testing::Test {
           windows_[i][j].data[sample_idx] = window.data;
           windows_[i][j].shape.set_tensor_shape(sample_idx, window.shape);
         }
-        scales_[i][sample_idx] = exp2(-win_size_sum);
+        scales_[i][sample_idx] = std::exp2f(-win_size_sum);
       }
     }
   }

--- a/dali/operators/image/convolution/laplacian_params.h
+++ b/dali/operators/image/convolution/laplacian_params.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #ifndef DALI_OPERATORS_IMAGE_CONVOLUTION_LAPLACIAN_PARAMS_H_
 #define DALI_OPERATORS_IMAGE_CONVOLUTION_LAPLACIAN_PARAMS_H_
 
-#include <numeric>
+#include <cmath>
 #include <vector>
 
 #include "dali/core/small_vector.h"
@@ -135,7 +135,7 @@ std::array<float, axes> GetNormalizationFactors(
   for (int i = 0; i < axes; i++) {
     auto initial = -axes - 2;
     auto exponent = std::accumulate(window_sizes[i].begin(), window_sizes[i].end(), initial);
-    factors[i] = exp2(-exponent);
+    factors[i] = std::exp2f(-exponent);
   }
   return factors;
 }


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*) 



## Description:
Compilation on Xavier, CUDA 10.2 fails due to ambiguity of exp2(int) call (between exp2(float) and exp2(double).



## Additional information:

### Affected modules and functionalities:
* Laplacian GPU tests
* LaplacianWindows class



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2570
<!--- DALI-XXXX or NA --->
