### PR TITLE
Add a separate initialization method to OpticalFlowAdapter

### DIFF
--- a/dali/operators/sequence/optical_flow/optical_flow.h
+++ b/dali/operators/sequence/optical_flow/optical_flow.h
@@ -153,6 +153,7 @@ class OpticalFlow : public Operator<Backend> {
                                                                  image_type,
                                                                  device_id,
                                                                  stream));
+                        optical_flow_->Init(of_params_);
                    });
   }
 

--- a/dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_adapter.h
+++ b/dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_adapter.h
@@ -40,8 +40,12 @@ class DLL_PUBLIC OpticalFlowAdapter {
   using StorageBackend = typename compute_to_storage<ComputeBackend>::type;
 
  public:
-  explicit OpticalFlowAdapter(OpticalFlowParams params) : of_params_(params) {}
+  explicit OpticalFlowAdapter(const OpticalFlowParams &params) : of_params_(params) {}
 
+  /**
+   *  Runs the initialization code that may throw
+   */
+  virtual void Init(OpticalFlowParams &params) = 0;
 
   /**
    * Reconfigures Optical Flow HW for new frame dimensions if necessary

--- a/dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_stub.h
+++ b/dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_stub.h
@@ -31,8 +31,10 @@ template<typename ComputeBackend>
 class DLL_PUBLIC OpticalFlowStub : public OpticalFlowAdapter<ComputeBackend> {
   using StorageBackend = typename OpticalFlowAdapter<ComputeBackend>::StorageBackend;
  public:
-  explicit OpticalFlowStub(OpticalFlowParams params) :
+  explicit OpticalFlowStub(const OpticalFlowParams &params) :
           OpticalFlowAdapter<ComputeBackend>(params) {}
+
+  void Init(OpticalFlowParams &/*params*/) override {}
 
   void Prepare(size_t /*width*/, size_t /*height*/) override {}
 

--- a/dali/operators/sequence/optical_flow/optical_flow_impl/optical_flow_impl.h
+++ b/dali/operators/sequence/optical_flow/optical_flow_impl/optical_flow_impl.h
@@ -110,8 +110,10 @@ inline __host__ __device__ int16_t encode_flow_component(float value) {
 
 class DLL_PUBLIC OpticalFlowImpl : public OpticalFlowAdapter<ComputeGPU> {
  public:
-  OpticalFlowImpl(OpticalFlowParams params, size_t width, size_t height, size_t channels,
+  OpticalFlowImpl(const OpticalFlowParams &params, size_t width, size_t height, size_t channels,
                   DALIImageType image_type, int device_id_, cudaStream_t stream = 0);
+
+  void Init(OpticalFlowParams &params) override;
 
   void Prepare(size_t width, size_t height) override;
 
@@ -168,6 +170,7 @@ class DLL_PUBLIC OpticalFlowImpl : public OpticalFlowAdapter<ComputeGPU> {
   NvOFHandle of_handle_         = nullptr;
   NV_OF_CUDA_API_FUNCTION_LIST of_inst_ = {};
   NV_OF_INIT_PARAMS init_params_ = {};
+  NV_OF_INIT_PARAMS default_init_params_ = {};
   std::unique_ptr<OpticalFlowBuffer> inbuf_, refbuf_, outbuf_, hintsbuf_;
   DALIImageType image_type_     = DALI_RGB;
   ofDriverHandle lib_handle_    = nullptr;
@@ -175,6 +178,7 @@ class DLL_PUBLIC OpticalFlowImpl : public OpticalFlowAdapter<ComputeGPU> {
   std::vector<uint32_t> width_max_;
   std::vector<uint32_t> height_min_;
   std::vector<uint32_t> height_max_;
+  bool is_initialized_ = false;
 };
 
 }  // namespace optical_flow

--- a/dali/test/python/test_optical_flow.py
+++ b/dali/test/python/test_optical_flow.py
@@ -236,7 +236,6 @@ def check_optflow(output_grid=1, hint_grid=1, use_temporal_hints=False):
             out = pipe.run()
             for i in range(batch_size):
                 seq = out[0].at(i)
-                print(seq.shape)
                 out_field = out[1].as_cpu().at(i)[0]
                 _, ref_field = get_mapping(seq.shape[1:3])
                 dsize = (out_field.shape[1], out_field.shape[0])


### PR DESCRIPTION
- adds a separate initialization method to OpticalFlowAdapter,
  so it can throw and still the resources can be properly released.
  Previously the code was run in the constructor which in the case
  of failure prevented from releasing optical flow driver allocated
  structures
- OpticalFlow SDK uses nvCreateOpticalFlowCuda that creates the OF
  instance, nvOFInit that initializes it with the proper parameters,
  and nvOFDestroy to release all resources. If nvOFInit fails because
  wrong parameters are provided by the user it is not possible to gracefully
  release resources as nvOFDestroy fails as well. To fix that DALI
  would call nvOFInit before nvOFDestroy if it was not successful
  with default arguments that should just work

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
**Bug fix** (*non-breaking change which fixes an issue*)
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
- adds a separate initialization method to OpticalFlowAdapter,
  so it can throw and still the resources can be properly released.
  Previously the code was run in the constructor which in the case
  of failure prevented from releasing optical flow driver allocated
  structures
- OpticalFlow SDK uses nvCreateOpticalFlowCuda that creates the OF
  instance, nvOFInit that initializes it with the proper parameters,
  and nvOFDestroy to release all resources. If nvOFInit fails because
  wrong parameters are provided by the user it is not possible to gracefully
  release resources as nvOFDestroy fails as well. To fix that DALI
  would call nvOFInit before nvOFDestroy if it was not successful
  with default arguments that should just work
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- optical flow operator
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
