### PR TITLE
Fix `librosa` bugs after 0.9 release

### DIFF
--- a/dali/test/python/test_audio_decoder_utils.py
+++ b/dali/test/python/test_audio_decoder_utils.py
@@ -14,13 +14,15 @@ def generate_waveforms(length, frequencies):
 
   return np.sin(X[:,np.newaxis] * (np.array(frequencies) * (2 * math.pi))) * window(X)[:,np.newaxis]
 
+
 def rosa_resample(input, in_rate, out_rate):
   if input.shape[1] == 1:
-    return librosa.resample(input[:,0], in_rate, out_rate)[:,np.newaxis]
+    return librosa.resample(input[:, 0], orig_sr=in_rate, target_sr=out_rate)[:, np.newaxis]
 
-  channels = [librosa.resample(np.array(input[:,c]), in_rate, out_rate) for c in range(input.shape[1])]
-  ret = np.zeros(shape = [channels[0].shape[0], len(channels)], dtype=channels[0].dtype)
+  channels = [librosa.resample(np.array(input[:, c]), orig_sr=in_rate, target_sr=out_rate) for c in
+              range(input.shape[1])]
+  ret = np.zeros(shape=[channels[0].shape[0], len(channels)], dtype=channels[0].dtype)
   for c, a in enumerate(channels):
-    ret[:,c] = a
+    ret[:, c] = a
 
   return ret

--- a/dali/test/python/test_torch_pipeline_rnnt.py
+++ b/dali/test/python/test_torch_pipeline_rnnt.py
@@ -87,7 +87,7 @@ class FilterbankFeatures():
         window_fn = torch_windows.get(window, None)
         self.window = window_fn(self.win_length, periodic=False) if window_fn else None
         self.fb = torch.tensor(
-            librosa.filters.mel(sample_rate, self.n_fft, n_mels=nfilt, fmin=lowfreq, fmax=highfreq), dtype=torch.float).unsqueeze(0)
+            librosa.filters.mel(sr=sample_rate, n_fft=self.n_fft, n_mels=nfilt, fmin=lowfreq, fmax=highfreq), dtype=torch.float).unsqueeze(0)
 
     @staticmethod
     def normalize_batch(x, seq_len, normalize_type):

--- a/docs/examples/audio_processing/spectrogram.ipynb
+++ b/docs/examples/audio_processing/spectrogram.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "# Calculate the spectrogram as the square of the complex magnitude of the STFT\n",
     "spectrogram_librosa = np.abs(librosa.stft(\n",
-    "    y, n_fft=n_fft, hop_length=hop_length, win_length=n_fft, window='hann')) ** 2"
+    "    y, n_fft=n_fft, hop_length=hop_length, win_length=n_fft, window='hann', pad_mode='reflect')) ** 2"
    ]
   },
   {
@@ -315,7 +315,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mel_spectrogram_librosa = librosa.feature.melspectrogram(y=y, sr=sr, n_mels=128, fmax=8000)\n",
+    "mel_spectrogram_librosa = librosa.feature.melspectrogram(y=y, sr=sr, n_mels=128, fmax=8000, pad_mode='reflect')\n",
     "mel_spectrogram_librosa_db = librosa.power_to_db(mel_spectrogram_librosa, ref=np.max)\n",
     "assert(np.allclose(mel_spectrogram_dali_db, mel_spectrogram_librosa_db, atol=1))"
    ]

--- a/qa/TL0_cpu_only/test.sh
+++ b/qa/TL0_cpu_only/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy>=1.17 pillow torch numba scipy librosa"
+pip_packages="nose numpy>=1.17 pillow torch numba scipy librosa==0.8.1"
 
 target_dir=./dali/test/python
 

--- a/qa/TL0_jupyter/test_nofw.sh
+++ b/qa/TL0_jupyter/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="jupyter numpy matplotlib pillow opencv-python librosa simpleaudio"
+pip_packages="jupyter numpy matplotlib pillow opencv-python librosa==0.8.1 simpleaudio"
 target_dir=./docs/examples
 
 do_once() {

--- a/qa/TL0_python-self-test-operators/test_nofw.sh
+++ b/qa/TL0_python-self-test-operators/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy>=1.17 opencv-python pillow librosa scipy nvidia-ml-py==11.450.51 numba"
+pip_packages="nose numpy>=1.17 opencv-python pillow librosa==0.8.1 scipy nvidia-ml-py==11.450.51 numba"
 
 target_dir=./dali/test/python
 

--- a/qa/TL0_python-self-test-readers-decoders/test_nofw.sh
+++ b/qa/TL0_python-self-test-readers-decoders/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy>=1.17 librosa scipy nvidia-ml-py==11.450.51 psutil dill cloudpickle"
+pip_packages="nose numpy>=1.17 librosa==0.8.1 scipy nvidia-ml-py==11.450.51 psutil dill cloudpickle"
 
 target_dir=./dali/test/python
 

--- a/qa/TL0_python_self_test_frameworks/test_pytorch.sh
+++ b/qa/TL0_python_self_test_frameworks/test_pytorch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy librosa torch psutil"
+pip_packages="nose numpy librosa==0.8.1 torch psutil"
 target_dir=./dali/test/python
 
 test_body() {

--- a/qa/TL1_jupyter_conda/test_nofw.sh
+++ b/qa/TL1_jupyter_conda/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="jupyter numpy matplotlib pillow opencv-python librosa simpleaudio"
+pip_packages="jupyter numpy matplotlib pillow opencv-python librosa==0.8.1 simpleaudio"
 target_dir=./docs/examples
 
 # populate epilog and prolog with variants to enable/disable conda

--- a/qa/TL1_python-self-test-slow/test.sh
+++ b/qa/TL1_python-self-test-slow/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy opencv-python pillow librosa scipy nvidia-ml-py==11.450.51 numba"
+pip_packages="nose numpy opencv-python pillow librosa==0.8.1 scipy nvidia-ml-py==11.450.51 numba"
 target_dir=./dali/test/python
 
 test_body() {

--- a/qa/TL1_python-self-test_conda/test_nofw.sh
+++ b/qa/TL1_python-self-test_conda/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages="nose numpy>=1.17 opencv-python pillow librosa scipy nvidia-ml-py==11.450.51"
+pip_packages="nose numpy>=1.17 opencv-python pillow librosa==0.8.1 scipy nvidia-ml-py==11.450.51"
 target_dir=./dali/test/python
 
 # test_body definition is in separate file so it can be used without setup


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
 **Bug fix** (*non-breaking change which fixes an issue*) 
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
`librosa` introduced few regressions in the 0.9 release. This PR fixes some of them. What is not fixed is `librosa.effects.trim` misbehaviour, where `librosa` introduced a bug in calculating signal level. The latter problem affects `test_operator_nonsilence.py` in following setups:
```
test_operator_nonsilence.test_nonsilence_operator(3, -10, 512, 0.0003, -1, 512) ... FAIL
test_operator_nonsilence.test_nonsilence_operator(3, -10, 512, 0.0003, 2048, 512) ... FAIL
test_operator_nonsilence.test_nonsilence_operator(3, -10, 512, 0.0003, 8192, 512) ... FAIL
test_operator_nonsilence.test_nonsilence_operator(3, -10, 1024, 0.0003, -1, 1024) ... FAIL
test_operator_nonsilence.test_nonsilence_operator(3, -10, 1024, 0.0003, 2048, 1024) ... FAIL
test_operator_nonsilence.test_nonsilence_operator(3, -10, 1024, 0.0003, 8192, 1024) ... FAIL
```



## Additional information:

### Affected modules and functionalities:
Tests and jupyter notebook



### Key points relevant for the review:
n/a



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
