### PR TITLE
Dynamic & stream-aware scratchpad

### DIFF
--- a/dali/kernels/dynamic_scratchpad.h
+++ b/dali/kernels/dynamic_scratchpad.h
@@ -1,0 +1,170 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_KERNELS_DYNAMIC_SCRATCHPAD_H_
+#define DALI_KERNELS_DYNAMIC_SCRATCHPAD_H_
+
+#include <array>
+#include <cassert>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include "dali/core/static_switch.h"
+#include "dali/core/mm/fixed_order_resource.h"
+#include "dali/core/mm/memory.h"
+#include "dali/core/mm/memory_kind.h"
+#include "dali/core/mm/monotonic_resource.h"
+#include "dali/kernels/context.h"
+#include "dali/kernels/kernel_req.h"
+
+namespace dali {
+namespace kernels {
+
+namespace detail {
+
+template <typename T, typename... Ts>
+struct index_in_pack;
+
+template <typename T, typename... Ts>
+struct index_in_pack<T, T, Ts...> : std::integral_constant<int, 0> {};
+
+template <typename T, typename U, typename... Ts>
+struct index_in_pack<T, U, Ts...> :
+    std::integral_constant<int, index_in_pack<T, Ts...>::value + 1> {};
+
+template <typename T, typename... Ts>
+struct index_in_pack;
+
+/**
+ * @brief Implements upstream handling and ordered wrappers.
+ */
+template <typename... Kinds>
+class DynamicScratchpadImplT {
+ protected:
+  template <typename Kind>
+  void set_upstream_resrouce(mm::memory_resource<Kind> *rsrc) {
+    resource<Kind>() = mm::monotonic_memory_resource<Kind>(rsrc, initial_size<Kind>());
+  }
+
+  template <typename Kind>
+  void set_upstream_resrouce(mm::async_memory_resource<Kind> *rsrc,
+                             AccessOrder alloc_order,
+                             AccessOrder dealloc_order = {}) {
+    static_assert(!std::is_same<Kind, mm::memory_kind::host>::value,
+      "Cannot use a stream-ordered resource for plain host memory");
+    adapter<Kind>() = { rsrc, alloc_order, dealloc_order };
+    set_upstream_resrouce<Kind>(&adapter<Kind>());
+  }
+
+  template <typename Kind>
+  size_t &initial_size() {
+    return initial_sizes_[index_in_pack<Kind, Kinds...>::value];
+  }
+
+  template <typename Kind>
+  size_t initial_size() const {
+    return initial_sizes_[index_in_pack<Kind, Kinds...>::value];
+  }
+
+  template <typename Kind>
+  mm::memory_resource<Kind> *get_upstream() const {
+    std::get<mm::monotonic_memory_resource<Kind>>(resources_)->get_upstream();
+  }
+
+  template <typename Kind>
+  auto &adapter() {
+    return std::get<mm::fixed_order_resource<Kind>>(adapters_);
+  }
+
+  template <typename Kind>
+  auto &adapter() const {
+    return std::get<mm::fixed_order_resource<Kind>>(adapters_);
+  }
+
+  template <typename Kind>
+  auto &resource() {
+    return std::get<mm::monotonic_memory_resource<Kind>>(resources_);
+  }
+
+  template <typename Kind>
+  auto &resource() const {
+    return std::get<mm::monotonic_memory_resource<Kind>>(resources_);
+  }
+
+  std::tuple<mm::fixed_order_resource<Kinds>...>      adapters_;
+  std::tuple<mm::monotonic_memory_resource<Kinds>...> resources_;
+  std::array<size_t, sizeof...(Kinds)>                initial_sizes_ = {};
+};
+
+using DynamicScratchpadImpl = DynamicScratchpadImplT<
+      mm::memory_kind::host,
+      mm::memory_kind::pinned,
+      mm::memory_kind::device,
+      mm::memory_kind::managed>;
+
+}  // namespace detail
+
+class DynamicScratchpad
+  : public Scratchpad
+  , private detail::DynamicScratchpadImpl {
+ public:
+  explicit DynamicScratchpad(scratch_sizes_t initial_sizes = {},
+                             AccessOrder device_order = cudaStream_t(0),
+                             AccessOrder pinned_dealloc_order = {},
+                             AccessOrder managed_dealloc_order = {}) {
+    initial_sizes_ = initial_sizes;
+    for (auto &s : initial_sizes_) {
+      if (s == 0)
+        s = 4096;
+    }
+    if (!pinned_dealloc_order.has_value())
+      pinned_dealloc_order = device_order;
+    if (!managed_dealloc_order.has_value())
+      managed_dealloc_order = device_order;
+
+    set_upstream_resrouce<mm::memory_kind::host>(mm::GetDefaultResource<mm::memory_kind::host>());
+
+    set_upstream_resrouce<mm::memory_kind::pinned>(
+        mm::GetDefaultResource<mm::memory_kind::pinned>(),
+        AccessOrder::host(),
+        pinned_dealloc_order);
+
+    set_upstream_resrouce<mm::memory_kind::device>(
+        mm::GetDefaultResource<mm::memory_kind::device>(),
+        device_order);
+
+    set_upstream_resrouce<mm::memory_kind::managed>(
+        mm::GetDefaultResource<mm::memory_kind::managed>(),
+        AccessOrder::host(),
+        managed_dealloc_order);
+  }
+
+  virtual void *Alloc(mm::memory_kind_id kind_id, size_t bytes, size_t alignment) {
+    void *ret = nullptr;
+    TYPE_SWITCH(kind_id, mm::kind2id, Kind,
+      (mm::memory_kind::host,
+       mm::memory_kind::pinned,
+       mm::memory_kind::device,
+       mm::memory_kind::managed),
+      (ret = resource<Kind>().allocate(bytes, alignment)),
+      (assert(!"Incorrect memory kind id");));
+    return ret;
+  }
+};
+
+}  // namespace kernels
+}  // namespace dali
+
+#endif  // DALI_KERNELS_DYNAMIC_SCRATCHPAD_H_
+

--- a/dali/kernels/dynamic_scratchpad.h
+++ b/dali/kernels/dynamic_scratchpad.h
@@ -116,6 +116,18 @@ class DynamicScratchpad
   : public Scratchpad
   , private detail::DynamicScratchpadImpl {
  public:
+  /**
+   * @brief Constructs a dynamically allocated scratchpad
+   *
+   * @param initial_sizes   Sizes, in bytes, of the initial buffers. Note that these buffers
+   *                        are allocated lazily, so nothing is allocated if there's no request
+   *                        for memory of any given kind.
+   * @param device_order    Allocation and deallocation order for device memory.
+   * @param pinned_dealloc_order  Deallocation order for pinned memory. Allocation is always
+   *                              host-ordered. If not set, device_order is used.
+   * @param managed_dealloc_order Deallocation order for managed memory. Allocation is always
+   *                              host-ordered. If not set, device_order is used.
+   */
   explicit DynamicScratchpad(scratch_sizes_t initial_sizes = {},
                              AccessOrder device_order = cudaStream_t(0),
                              AccessOrder pinned_dealloc_order = {},

--- a/dali/kernels/dynamic_scratchpad_test.cc
+++ b/dali/kernels/dynamic_scratchpad_test.cc
@@ -130,7 +130,7 @@ TEST(DynamicScratchpad, Perf) {
     }
     {
       auto s = std::chrono::high_resolution_clock::now();
-      scratch->~DynamicScratchpad();
+      scratch->DynamicScratchpad::~DynamicScratchpad();
       auto e = std::chrono::high_resolution_clock::now();
       destroy_times.push_back((e-s).count());
     }

--- a/dali/kernels/dynamic_scratchpad_test.cc
+++ b/dali/kernels/dynamic_scratchpad_test.cc
@@ -1,0 +1,162 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/kernels/dynamic_scratchpad.h"  // NOLINT
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <iostream>
+#include <chrono>
+#include <random>
+#include <vector>
+#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_stream_pool.h"
+#include "dali/core/mm/memory.h"
+
+namespace dali {
+namespace kernels {
+namespace test {
+
+/**
+ * @brief Tests basic dynamic scratchpad functioning
+ *
+ * This test checks that:
+ * - the memory is usable and accessible on the right backend
+ * - the pinned memory block is released in stream order, which prevents
+ *   immediate reuse if the stream is still running
+ * - it makes multiple attempts to catch the stream still running
+ */
+TEST(DynamicScratchpad, BasicTest) {
+  const int N = 64 << 10;  // 64 KiB
+
+  std::vector<char> in(N);
+  for (int i = 0; i < N; i++)
+    in[i] = i + 42;  // so it doesn't start or end with 0
+
+  auto stream = CUDAStreamPool::instance().Get();
+  auto dev = mm::alloc_raw_unique<char, mm::memory_kind::device>(N);
+  int max_attempts = 1000;
+  bool was_running = false;
+  for (int attempt = 0; attempt < max_attempts; attempt++) {
+    char *pinned;
+    {
+      DynamicScratchpad scratch({}, AccessOrder(stream));
+      pinned = scratch.Allocate<mm::memory_kind::pinned, char>(N);
+      memcpy(pinned, in.data(), N);
+      CUDA_CALL(cudaMemcpyAsync(dev.get(), pinned, N, cudaMemcpyHostToDevice, stream));
+    }
+    auto out = mm::alloc_raw_unique<char, mm::memory_kind::pinned>(N);
+    bool running = false;
+    if (was_running) {
+      CUDA_CALL(cudaStreamSynchronize(stream));
+    } else {
+      running = cudaStreamQuery(stream) == cudaErrorNotReady;
+      if (running)
+        was_running = true;
+    }
+    ASSERT_TRUE(out.get() + N < pinned || out.get() >= pinned + N || !running);
+    CUDA_CALL(cudaMemcpyAsync(out.get(), dev.get(), N, cudaMemcpyDeviceToHost, stream));
+    CUDA_CALL(cudaStreamSynchronize(stream));
+    ASSERT_EQ(memcmp(in.data(), out.get(), N), 0);
+    if (was_running && !running)
+      break;
+  }
+  if (!was_running)
+    std::cerr << "Warning: Test incomplete - the stream was never caught still running"
+              << std::endl;
+}
+
+TEST(DynamicScratchpad, Perf) {
+  std::poisson_distribution size_dist(1024);  // 1 KiB average
+  int max_size = 64 << 20;  // 64 MiB max
+  std::uniform_int_distribution<> num_dist(1, 100);
+
+  std::mt19937_64 rng(1234);
+
+  auto stream1 = CUDAStreamPool::instance().Get();
+  auto stream2 = CUDAStreamPool::instance().Get();
+  cudaStream_t streams[] = { stream1, stream2 };
+
+  int max_attempts = 100000;
+
+  const int nkinds = static_cast<int>(mm::memory_kind_id::count);
+  std::vector<double> alloc_times[nkinds];
+  std::vector<double> destroy_times;
+  for (auto &v : alloc_times)
+    v.reserve(max_attempts*10);
+
+  for (int attempt = 0; attempt < max_attempts; attempt++) {
+    auto s = streams[attempt % 2];
+    std::aligned_storage_t<sizeof(DynamicScratchpad), alignof(DynamicScratchpad)> scratch_placement;
+    auto *scratch = new(&scratch_placement) DynamicScratchpad({}, AccessOrder(s));
+    for (int k = 0; k < nkinds; k++) {
+      auto kind = static_cast<mm::memory_kind_id>(k);
+      if (kind == mm::memory_kind_id::managed)
+        continue;
+      int n = num_dist(rng);
+      for (int i = 0; i < n; i++) {
+        size_t size = std::min(size_dist(rng), max_size);
+        auto s = std::chrono::high_resolution_clock::now();
+        scratch->Alloc(kind, size, alignof(std::max_align_t));
+        auto e = std::chrono::high_resolution_clock::now();
+        alloc_times[k].push_back((e-s).count());
+      }
+    }
+    {
+      auto s = std::chrono::high_resolution_clock::now();
+      scratch->~DynamicScratchpad();
+      auto e = std::chrono::high_resolution_clock::now();
+      destroy_times.push_back((e-s).count());
+    }
+  }
+
+  const char *names[] = { "host", "pinned", "device", "managed" };
+
+  for (int k = 0; k < nkinds; k++) {
+    if (k == mm::memory_kind_id::managed)
+      continue;
+    auto &v = alloc_times[k];
+
+    std::sort(v.begin(), v.end());
+    double sum = std::accumulate(v.begin(), v.end(), 0);
+    auto b98 = v.begin() + v.size()/100;
+    auto e98 = v.end() - v.size()/100;
+    double sum98 = std::accumulate(b98, e98, 0);
+    std::cout << "Allocation performance for " << names[k] << " memory.\n"
+              << "Median time:            " << v[v.size()/2] << " ns\n"
+              << "90th percentile:        " << v[v.size()*90/100] << " ns\n"
+              << "99th percentile:        " << v[v.size()*99/100] << " ns\n"
+              << "Mean time:              " << sum/v.size() << " ns\n"
+              << "Mean time (middle 98%): " << sum98/(e98-b98) << " ns\n";
+  }
+
+  {
+    auto &v = destroy_times;
+    std::sort(v.begin(), v.end());
+    double sum = std::accumulate(v.begin(), v.end(), 0);
+    auto b98 = v.begin() + v.size()/100;
+    auto e98 = v.end() - v.size()/100;
+    double sum98 = std::accumulate(b98, e98, 0);
+    std::cout << "Scratchpad destruction\n"
+              << "Median time:            " << v[v.size()/2] << " ns\n"
+              << "90th percentile:        " << v[v.size()*90/100] << " ns\n"
+              << "99th percentile:        " << v[v.size()*99/100] << " ns\n"
+              << "Mean time:              " << sum/v.size() << " ns\n"
+              << "Mean time (middle 98%): " << sum98/(e98-b98) << " ns\n";
+  }
+}
+
+
+}  // namespace test
+}  // namespace kernels
+}  // namespace dali

--- a/include/dali/core/mm/fixed_order_resource.h
+++ b/include/dali/core/mm/fixed_order_resource.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_MM_FIXED_ORDER_RESOURCE_H_
+#define DALI_CORE_MM_FIXED_ORDER_RESOURCE_H_
+
+#include <dali/core/mm/memory_resource.h>
+#include <dali/core/access_order.h>
+
+namespace dali {
+namespace mm {
+
+/**
+ * @brief A proxy resource that performs all allocations and deallocation in a fixed order
+ *        (stream or host) and exposes a non-stream allocation API.
+ *
+ * NOTE: This class cannot be used by an arbitrary consumer of memory resources if the
+ *       allocation order is not AccessOrder::host.
+ *
+ * NOTE: If this resource is used as an upstream for another resource, then the pool
+ *       inherits the order of allocation and deallocation if:
+ *       - the allocaton and deallocation order matches
+ *       - it does not attempt to access the memory in order other than specified
+ */
+template <typename MemoryKind, typename Upstream = async_memory_resource<MemoryKind> >
+class fixed_order_resource final : public memory_resource<MemoryKind> {
+ public:
+  fixed_order_resource() = default;
+
+  fixed_order_resource(Upstream *upstream, AccessOrder order)
+  : upstream_(upstream), alloc_order_(order), dealloc_order_(order) {}
+
+  fixed_order_resource(Upstream *upstream, AccessOrder alloc_order, AccessOrder dealloc_order)
+  : upstream_(upstream), alloc_order_(alloc_order), dealloc_order_(dealloc_order) {}
+
+  AccessOrder alloc_order() const { return alloc_order_; }
+  AccessOrder dealloc_order() const { return dealloc_order_; }
+
+ private:
+  void *do_allocate(size_t size, size_t alignment) final {
+    if (alloc_order_.is_device())
+      return upstream_->allocate_async(size, alignment, alloc_order_.stream());
+    else
+      return upstream_->allocate(size, alignment);
+  }
+
+  void do_deallocate(void *ptr, size_t size, size_t alignment) final {
+    if (dealloc_order_.is_device())
+      upstream_->deallocate_async(ptr, size, alignment, dealloc_order_.stream());
+    else
+      upstream_->deallocate(ptr, size, alignment);
+  }
+
+  Upstream *upstream_ = nullptr;
+  AccessOrder alloc_order_, dealloc_order_;
+};
+
+}  // namespace mm
+}  // namespace dali
+
+#endif  // DALI_CORE_MM_FIXED_ORDER_RESOURCE_H_
+

--- a/include/dali/core/mm/monotonic_resource.h
+++ b/include/dali/core/mm/monotonic_resource.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/dali/core/mm/monotonic_resource.h
+++ b/include/dali/core/mm/monotonic_resource.h
@@ -159,6 +159,8 @@ class monotonic_memory_resource<Kind, Upstream, true>
   void *do_allocate(size_t bytes, size_t alignment) override {
     char *ret = detail::align_ptr(curr_, alignment);
     if (ret + bytes > limit_) {
+      if (next_block_size_ == 0)
+        next_block_size_ = alignment;  // must be a power of 2
       while (next_block_size_ < bytes + sizeof(block_info))
         next_block_size_ += next_block_size_;
       alignment = std::max(alignment, alignof(block_info));
@@ -276,6 +278,8 @@ class monotonic_memory_resource<Kind, Upstream, false>
   void *do_allocate(size_t bytes, size_t alignment) override {
     char *ret = detail::align_ptr(curr_, alignment);
     if (ret + bytes > limit_) {
+      if (next_block_size_ == 0)
+        next_block_size_ = alignment;  // must be a power of 2
       while (next_block_size_ < bytes)
         next_block_size_ += next_block_size_;
 

--- a/include/dali/core/mm/monotonic_resource.h
+++ b/include/dali/core/mm/monotonic_resource.h
@@ -75,7 +75,9 @@ class monotonic_buffer_resource : public memory_resource<Kind> {
   char *curr_ = nullptr, *limit_ = nullptr;
 };
 
-template <typename Kind, bool host_impl = detail::is_host_accessible<Kind>>
+template <typename Kind,
+          typename Upstream = mm::memory_resource<Kind>,
+          bool host_impl = detail::is_host_accessible<Kind>>
 class monotonic_memory_resource;
 
 /**
@@ -86,12 +88,13 @@ class monotonic_memory_resource;
  * The lifetime of a monotonic resource is limited and all memory will be deallocated in bulk
  * when the resource is destroyed.
  */
-template <typename Kind>
-class monotonic_memory_resource<Kind, true> : public memory_resource<Kind> {
+template <typename Kind, typename Upstream>
+class monotonic_memory_resource<Kind, Upstream, true>
+  : public memory_resource<Kind> {
  public:
-  explicit monotonic_memory_resource(memory_resource<Kind> *upstream,
-                                     size_t next_block_size = 1024)
-  : upstream_(upstream), next_block_size_(next_block_size) {}
+  explicit monotonic_memory_resource(Upstream *upstream,
+                                     size_t first_block_size = 1024)
+  : upstream_(upstream), first_block_size_(first_block_size), next_block_size_(first_block_size) {}
 
   monotonic_memory_resource() = default;
 
@@ -109,9 +112,12 @@ class monotonic_memory_resource<Kind, true> : public memory_resource<Kind> {
     std::swap(curr_, other.curr_);
     std::swap(limit_, other.limit_);
     std::swap(upstream_, other.upstream_);
+    std::swap(first_block_size_, other.first_block_size_);
     std::swap(next_block_size_, other.next_block_size_);
     std::swap(curr_block_, other.curr_block_);
   }
+
+  Upstream *get_upstream() const noexcept { return upstream_; }
 
   ~monotonic_memory_resource() {
     free_all();
@@ -129,6 +135,24 @@ class monotonic_memory_resource<Kind, true> : public memory_resource<Kind> {
       upstream_->deallocate(base, alloc_size, curr_block_->alignment);
       curr_block_ = prev;
     }
+    next_block_size_ = first_block_size_;
+  }
+
+
+  /**
+   * @brief Releases, in stream order, all memory blocks that were taken from upstream
+   */
+  void free_all_async(stream_view stream) {
+    while (curr_block_) {
+      assert(curr_block_->sentinel == sentinel_value && "Memory corruption detected");
+      auto *prev = curr_block_->prev;
+      auto *base = reinterpret_cast<char*>(curr_block_) - curr_block_->usable_size;
+      size_t alloc_size = curr_block_->usable_size + sizeof(block_info);
+      auto &up = dynamic_cast<async_memory_resource<Kind>&>(*upstream_);
+      up.deallocate_async(base, alloc_size, curr_block_->alignment, stream);
+      curr_block_ = prev;
+    }
+    next_block_size_ = first_block_size_;
   }
 
  private:
@@ -166,8 +190,8 @@ class monotonic_memory_resource<Kind, true> : public memory_resource<Kind> {
 
   char *curr_ = nullptr, *limit_ = nullptr;
 
-  memory_resource<Kind> *upstream_;
-  size_t next_block_size_;
+  Upstream *upstream_;
+  size_t first_block_size_, next_block_size_;
   struct block_info {
     size_t sentinel;
     block_info *prev;
@@ -187,12 +211,13 @@ class monotonic_memory_resource<Kind, true> : public memory_resource<Kind> {
  * The lifetime of a monotonic resource is limited and all memory will be deallocated in bulk
  * when the resource is destroyed.
  */
-template <typename Kind>
-class monotonic_memory_resource<Kind, false> : public memory_resource<Kind> {
+template <typename Kind, typename Upstream>
+class monotonic_memory_resource<Kind, Upstream, false>
+: public memory_resource<Kind> {
  public:
-  explicit monotonic_memory_resource(memory_resource<Kind> *upstream,
-                                     size_t next_block_size = 1024)
-  : upstream_(upstream), next_block_size_(next_block_size) {}
+  explicit monotonic_memory_resource(Upstream *upstream,
+                                     size_t first_block_size = 1024)
+  : upstream_(upstream), first_block_size_(first_block_size), next_block_size_(first_block_size) {}
 
   monotonic_memory_resource() = default;
 
@@ -210,6 +235,7 @@ class monotonic_memory_resource<Kind, false> : public memory_resource<Kind> {
     std::swap(curr_, other.curr_);
     std::swap(limit_, other.limit_);
     std::swap(upstream_, other.upstream_);
+    std::swap(first_block_size_, other.first_block_size_);
     std::swap(next_block_size_, other.next_block_size_);
     std::swap(blocks_, other.blocks_);
   }
@@ -227,7 +253,23 @@ class monotonic_memory_resource<Kind, false> : public memory_resource<Kind> {
       upstream_->deallocate(blk.base, blk.size, blk.alignment);
     }
     blocks_.clear();
+    next_block_size_ = first_block_size_;
   }
+
+  /**
+   * @brief Releases, in stream order, all memory blocks that were taken from upstream
+   */
+  void free_all_async(stream_view stream) {
+    for (int i = blocks_.size() - 1; i >= 0; i--) {
+      auto &blk = blocks_[i];
+      auto &up = dynamic_cast<async_memory_resource<Kind>&>(*upstream_);
+      up.deallocate_async(blk.base, blk.size, blk.alignment, stream);
+    }
+    blocks_.clear();
+    next_block_size_ = first_block_size_;
+  }
+
+  Upstream *get_upstream() const { return upstream_; }
 
 
  private:
@@ -255,8 +297,8 @@ class monotonic_memory_resource<Kind, false> : public memory_resource<Kind> {
 
   char *curr_ = nullptr, *limit_ = nullptr;
 
-  memory_resource<Kind> *upstream_;
-  size_t next_block_size_;
+  Upstream *upstream_;
+  size_t first_block_size_, next_block_size_;
   struct upstream_block {
     void *base;
     size_t size;


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
**New feature** (*non-breaking change which adds functionality*)
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
Dynamic scratchpad is an implementation of the Scratchpad interface which uses built-in monotonic resources instead of preallocated buffers.
Another important feature is that device memory can be allocated and deallocated in steam order. Pinned host memory can be deallocated in stream order, too, which is essential for safe fire-and-forget H2D copying.
To facilitate stream-ordered deallocation of upstream blocks in monotonic resources, an adapter called `fixed_ordered_memory_resource` is added, which executes all allocations and deallocations in a predefined order (stream or host).

## Additional information:

### Affected modules and functionalities:
Monotonic buffer received minor modifications.

### Key points relevant for the review:
N/A


<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2449
<!--- DALI-XXXX or NA --->
