### PR TITLE
Fix Slice's adaptive tiling for smaller output types

### DIFF
--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -293,7 +293,8 @@ class SliceGPU {
     }
     unsigned max_active_blocks = blocks_per_sm_ * GetSmCount();
     uint64_t waves = div_ceil(total_volume + 1, kMaxBlockSize * max_active_blocks);
-    block_size_ = div_ceil(total_volume, max_active_blocks * waves);
+    unsigned block_align = 32 * detail::PackedBuffer<OutputType>::kCapacity;
+    block_size_ = block_align * div_ceil(total_volume, max_active_blocks * waves * block_align);
     if (block_size_ < kMinBlockSize) block_size_ = kMinBlockSize;
     if (block_size_ > kMaxBlockSize) block_size_ = kMaxBlockSize;
 

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -25,6 +25,7 @@
 #include "dali/core/error_handling.h"
 #include "dali/core/fast_div.h"
 #include "dali/core/static_switch.h"
+#include "dali/core/util.h"
 #include "dali/kernels/common/copy.h"
 #include "dali/kernels/common/type_erasure.h"
 #include "dali/kernels/kernel.h"
@@ -294,7 +295,7 @@ class SliceGPU {
     unsigned max_active_blocks = blocks_per_sm_ * GetSmCount();
     uint64_t waves = div_ceil(total_volume + 1, kMaxBlockSize * max_active_blocks);
     unsigned block_align = 32 * detail::PackedBuffer<OutputType>::kCapacity;
-    block_size_ = block_align * div_ceil(total_volume, max_active_blocks * waves * block_align);
+    block_size_ = align_up(div_ceil(total_volume, max_active_blocks * waves), block_align);
     if (block_size_ < kMinBlockSize) block_size_ = kMinBlockSize;
     if (block_size_ > kMaxBlockSize) block_size_ = kMaxBlockSize;
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
**Bug fix** (*non-breaking change which fixes an issue*)
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
This PR fixes a bug which caused a small performance loss in Slice for smaller output types.

Some time ago I've made two optimizations to Slice:
- https://github.com/NVIDIA/DALI/pull/3604, which was adaptively choosing values to be processed by one block
- https://github.com/NVIDIA/DALI/pull/3600, which for smaller output types was packing the results in a 32-bit buffer and storing them together (except for rare case when the buffer was partially filled - then values in the buffer were stored one by one).

These two don't work well together: if the adaptive tiling algorithm chooses values per thread count which is not a multiply of buffer size, then a slower store of partially filled buffer will happen.

This PR makes sure that values per block is a multiply of `buffer capacity * warp size`, which eliminates the issue with partially filled buffer and warp divergence on stores.

This PR restores the proper throughput of Slice:
![image](https://user-images.githubusercontent.com/34919255/154528360-7fec51f4-420a-4ee9-b21e-830a3d74241c.png)


<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
Slice GPU tiling algorithm.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
I couldn't find a constant for warp size available in the host code (like device's `warpSize`), so I put `32` directly in the code. A future-proof alternative would be to make an expensive `cudaGetDeviceProperties` call. Do you think it would be better?


<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
