### PR TITLE
Introduce runtime typed TensorView

### DIFF
--- a/dali/pipeline/data/dynamic_tensor_view.h
+++ b/dali/pipeline/data/dynamic_tensor_view.h
@@ -1,0 +1,589 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_DATA_DYNAMIC_TENSOR_VIEW_H_
+#define DALI_PIPELINE_DATA_DYNAMIC_TENSOR_VIEW_H_
+
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+#include "dali/core/tensor_shape.h"
+#include "dali/core/tensor_view.h"
+#include "dali/pipeline/data/types.h"
+
+namespace dali {
+
+/**
+ * @brief Tag type indicating that the TensorView is keeping the type information in runtime.
+ *
+ * It can be converted to the statically-typed TensorView using `view<T, ndim>()` function
+ * or by `TensorView::to_static_type<T, ndim>()` member function.
+ */
+struct DynamicType {
+  DynamicType() = delete;
+};
+
+template <typename Backend, typename DataType, int ndim = DynamicDimensions>
+struct DynamicTensorViewBase {
+  static_assert(std::is_same<std::remove_const_t<DataType>, void>::value,
+                "The underlying type must either be void or const void");
+  using element_type = DataType;
+  int dim() const {
+    return shape.sample_dim();
+  }
+  DALIDataType type() const {
+    return type_id;
+  }
+
+  ptrdiff_t num_elements() const {
+    return shape.num_elements();
+  }
+
+  /**
+   * @brief Utility to calculate pointer to element at given coordinates
+   */
+  template <typename... Indices>
+  DataType *operator()(int64_t idx0, Indices &&...idx) const {
+    return data + CalcOffset(shape, std::array<ptrdiff_t, sizeof...(Indices) + 1>{
+                                        idx0, (ptrdiff_t{idx})...});
+  }
+
+  /**
+   * @brief Utility to calculate pointer to element at given coordinates
+   */
+  template <typename Offset>
+  DataType *operator()(const Offset &pos) const {
+    return data + CalcOffset(shape, pos);
+  }
+
+  DataType *data = nullptr;
+  TensorShape<ndim> shape = {};
+  DALIDataType type_id = DALI_NO_TYPE;
+
+ protected:
+  DynamicTensorViewBase() = default;
+  DynamicTensorViewBase(const DynamicTensorViewBase &) = default;
+  DynamicTensorViewBase(DataType *data, const TensorShape<ndim> &shape, DALIDataType type_id)
+      : data(data), shape(shape), type_id(type_id) {}
+  DynamicTensorViewBase(DataType *data, TensorShape<ndim> &&shape, DALIDataType type_id)
+      : data(data), shape(std::move(shape)), type_id(type_id) {}
+};
+
+template <typename Backend, int ndim = DynamicDimensions>
+struct DynamicTensorView : DynamicTensorViewBase<Backend, void, ndim> {
+  using Base = DynamicTensorViewBase<Backend, void, ndim>;
+
+  DynamicTensorView() = default;
+
+  /**
+   * @name Construct the view inferring the type_id from the pointer value.
+   */
+  // @{
+  template <typename T, typename = std::enable_if_t<!std::is_const<T>::value>>
+  DynamicTensorView(T *data, const TensorShape<ndim> &shape)
+      : Base(data, shape, TypeTable::GetTypeId<T>()) {}
+
+  template <typename T, typename = std::enable_if_t<!std::is_const<T>::value>>
+  DynamicTensorView(T *data, TensorShape<ndim> &&shape)
+      : Base(data, std::move(shape), TypeTable::GetTypeId<T>()) {}
+
+  template <typename T, int other_ndim, typename = std::enable_if_t<!std::is_const<T>::value>>
+  DynamicTensorView(T *data, const TensorShape<other_ndim> &shape)
+      : Base(data, shape, TypeTable::GetTypeId<T>()) {
+    // TODO(klecki): The tensor shape goes through a runtime check for some reason, so we
+    // temporarily plug it here before we evaluate TensorShape fix
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+
+  template <typename T, int other_ndim, typename = std::enable_if_t<!std::is_const<T>::value>>
+  DynamicTensorView(T *data, TensorShape<other_ndim> &&shape)
+      : Base(data, std::move(shape), TypeTable::GetTypeId<T>()) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+  // @}
+
+  /**
+   * @name Construct the view with explicitly provided type_id.
+   */
+  // @{
+  DynamicTensorView(void *data, const TensorShape<ndim> &shape, DALIDataType type_id)
+      : Base(data, shape, type_id) {}
+
+  DynamicTensorView(void *data, TensorShape<ndim> &&shape, DALIDataType type_id)
+      : Base(data, std::move(shape), type_id) {}
+
+  template <int other_ndim>
+  DynamicTensorView(void *data, const TensorShape<other_ndim> &shape, DALIDataType type_id)
+      : Base(data, shape, type_id) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+
+  template <int other_ndim>
+  DynamicTensorView(void *data, TensorShape<other_ndim> &&shape, DALIDataType type_id)
+      : Base(data, std::move(shape), type_id) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+  // @}
+
+  /**
+   * @name nullptr overloads with DALI_NO_TYPE
+   */
+  // @{
+  DynamicTensorView(std::nullptr_t *, const TensorShape<ndim> &shape)
+      : Base(nullptr, shape, DALI_NO_TYPE) {}
+
+  DynamicTensorView(std::nullptr_t *, TensorShape<ndim> &&shape)
+      : Base(nullptr, std::move(shape), DALI_NO_TYPE) {}
+
+  template <int other_ndim>
+  DynamicTensorView(std::nullptr_t *, const TensorShape<other_ndim> &shape)
+      : Base(nullptr, shape, DALI_NO_TYPE) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+
+  template <int other_ndim>
+  DynamicTensorView(std::nullptr_t *, TensorShape<other_ndim> &&shape)
+      : Base(nullptr, std::move(shape), DALI_NO_TYPE) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+  // @}
+
+  /**
+   * @name Copy and move constructor and assignment ops.
+   */
+  // @{
+  template <int other_ndim>
+  explicit DynamicTensorView(const DynamicTensorView<Backend, other_ndim> &other)
+      : Base(other.data, other.shape, other.type_id) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+
+  template <int other_ndim>
+  DynamicTensorView &operator=(const DynamicTensorView<Backend, other_ndim> &other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    this->shape = other.shape;
+    this->type_id = other.type_id;
+    return *this;
+  }
+
+  template <int other_ndim>
+  explicit DynamicTensorView(DynamicTensorView<Backend, other_ndim> &&other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    other.data = nullptr;
+    this->shape = std::move(other.shape);
+    this->type_id = other.type_id;
+    other.type_id = DALI_NO_TYPE;
+  }
+
+  template <int other_ndim>
+  DynamicTensorView &operator=(DynamicTensorView<Backend, other_ndim> &&other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    other.data = nullptr;
+    this->shape = std::move(other.shape);
+    this->type_id = other.type_id;
+    other.type_id = DALI_NO_TYPE;
+    return *this;
+  }
+  // @}
+
+  /**
+   * @name Converters from static TensorView
+   */
+  // @{
+  template <
+      typename T, int other_ndim,
+      typename = std::enable_if_t<!std::is_const<T>::value && !std::is_same<T, DynamicType>::value>>
+  explicit DynamicTensorView(const TensorView<Backend, T, other_ndim> &other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    this->shape = other.shape;
+    this->type_id = TypeTable::GetTypeId<T>();
+  }
+
+  template <
+      typename T, int other_ndim,
+      typename = std::enable_if_t<!std::is_const<T>::value && !std::is_same<T, DynamicType>::value>>
+  explicit DynamicTensorView(TensorView<Backend, T, other_ndim> &&other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    other.data = nullptr;
+    this->shape = std::move(other.shape);
+    this->type_id = TypeTable::GetTypeId<T>();
+  }
+
+  template <
+      typename T, int other_ndim,
+      typename = std::enable_if_t<!std::is_const<T>::value && !std::is_same<T, DynamicType>::value>>
+  DynamicTensorView &operator=(const TensorView<Backend, T, other_ndim> &other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    this->shape = other.shape;
+    this->type_id = TypeTable::GetTypeId<T>();
+    return *this;
+  }
+
+  template <
+      typename T, int other_ndim,
+      typename = std::enable_if_t<!std::is_const<T>::value && !std::is_same<T, DynamicType>::value>>
+  DynamicTensorView &operator=(TensorView<Backend, T, other_ndim> &&other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    other.data = nullptr;
+    this->shape = std::move(other.shape);
+    this->type_id = TypeTable::GetTypeId<T>();
+    return *this;
+  }
+  // @}
+
+
+  /**
+   * @name Explicitly deleted constructors disallowing passing a pointer to const.
+   *
+   * Listing all the variants here, and blocking others with SFINAE allows the compiler
+   * to state that such constructor is deleted rather than trying to instantiate the type2id
+   * trait with const type and failing miserably with supper long message.
+   *
+   * If you see any of the constructors below being used, it means that you tired to pass pointer to
+   * const to a non-const view container, which is not allowed.
+   */
+  // @{
+  template <typename T>
+  DynamicTensorView(const T *data, const TensorShape<ndim> &shape) = delete;
+  template <typename T>
+  DynamicTensorView(const T *data, const TensorShape<ndim> &shape, DALIDataType type_id) = delete;
+  template <typename T, int other_ndim>
+  DynamicTensorView(const T *data, const TensorShape<other_ndim> &shape) = delete;
+  template <typename T, int other_ndim>
+  DynamicTensorView(const T *data, const TensorShape<other_ndim> &shape,
+                    DALIDataType type_id) = delete;
+  template <typename T>
+  explicit DynamicTensorView(const TensorView<Backend, const T, ndim> &other) = delete;
+  template <typename T, int other_ndim>
+  explicit DynamicTensorView(const TensorView<Backend, const T, other_ndim> &other) = delete;
+  // @}
+
+  /**
+   * @brief Convert to strongly-typed TensorView
+   *
+   * Requires match between runtime and static types.
+   */
+  template <typename DataType, int other_ndim = ndim>
+  std::enable_if_t<!std::is_same<std::remove_const_t<DataType>, DynamicType>::value,
+                   TensorView<Backend, DataType, other_ndim>>
+  to_static_type() const {
+    DALI_ENFORCE(type_id == TypeTable::GetTypeId<DataType>(),
+                 make_string("Calling type does not match view data type, requested type: ",
+                             TypeTable::GetTypeId<DataType>(), " current view type: ", type_id));
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    return {static_cast<DataType *>(data), shape};
+  }
+
+  /**
+   * @brief Convert to strongly-typed TensorView
+   *
+   * No-op conversion to DynamicType
+   */
+  template <typename DataType, int other_ndim = ndim>
+  std::enable_if_t<std::is_same<std::remove_const_t<DataType>, DynamicType>::value,
+                   TensorView<Backend, DataType, other_ndim>>
+  to_static_type() const {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    return {data, shape, type_id};
+  }
+
+  /**
+   * @brief Change the ndim, compatible with TensorView API
+   */
+  template <int other_ndim>
+  DynamicTensorView<Backend, other_ndim> to_static() const {
+    static_assert(other_ndim != DynamicDimensions,
+                  "Conversion to static only allowed for static shape");
+    static_assert(ndim == other_ndim || ndim == DynamicDimensions, "Cannot convert to other ndim");
+    return {data, shape.template to_static<other_ndim>(), type_id};
+  }
+
+  using Base::data;
+  using Base::shape;
+  using Base::type_id;
+};
+
+template <typename Backend, int ndim = DynamicDimensions>
+struct ConstDynamicTensorView : DynamicTensorViewBase<Backend, const void, ndim> {
+  using Base = DynamicTensorViewBase<Backend, const void, ndim>;
+
+  ConstDynamicTensorView() = default;
+
+  /**
+   * @name Construct the view inferring the type_id from the pointer value.
+   */
+  // @{
+  template <typename T>
+  ConstDynamicTensorView(T *data, const TensorShape<ndim> &shape)
+      : Base(data, shape, TypeTable::GetTypeId<std::remove_const_t<T>>()) {}
+
+  template <typename T>
+  ConstDynamicTensorView(T *data, TensorShape<ndim> &&shape)
+      : Base(data, std::move(shape), TypeTable::GetTypeId<std::remove_const_t<T>>()) {}
+
+  template <typename T, int other_ndim>
+  ConstDynamicTensorView(T *data, const TensorShape<other_ndim> &shape)
+      : Base(data, shape, TypeTable::GetTypeId<std::remove_const_t<T>>()) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+
+  template <typename T, int other_ndim>
+  ConstDynamicTensorView(T *data, TensorShape<other_ndim> &&shape)
+      : Base(data, std::move(shape), TypeTable::GetTypeId<std::remove_const_t<T>>()) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+  // @}
+
+
+  /**
+   * @name Construct the view with explicitly provided type_id.
+   */
+  // @{
+  ConstDynamicTensorView(const void *data, const TensorShape<ndim> &shape, DALIDataType type_id)
+      : Base(data, shape, type_id) {}
+
+  ConstDynamicTensorView(const void *data, TensorShape<ndim> &&shape, DALIDataType type_id)
+      : Base(data, std::move(shape), type_id) {}
+
+  template <int other_ndim>
+  ConstDynamicTensorView(const void *data, const TensorShape<other_ndim> &shape,
+                         DALIDataType type_id)
+      : Base(data, shape, type_id) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+
+  template <int other_ndim>
+  ConstDynamicTensorView(const void *data, TensorShape<other_ndim> &&shape, DALIDataType type_id)
+      : Base(data, std::move(shape), type_id) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+  // @}
+
+  /**
+   * @name nullptr overloads with DALI_NO_TYPE
+   */
+  // @{
+  ConstDynamicTensorView(std::nullptr_t *, const TensorShape<ndim> &shape)
+      : Base(nullptr, shape, DALI_NO_TYPE) {}
+
+  ConstDynamicTensorView(std::nullptr_t *, TensorShape<ndim> &&shape)
+      : Base(nullptr, std::move(shape), DALI_NO_TYPE) {}
+
+  template <int other_ndim>
+  ConstDynamicTensorView(std::nullptr_t *, const TensorShape<other_ndim> &shape)
+      : Base(nullptr, shape, DALI_NO_TYPE) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+
+  template <int other_ndim>
+  ConstDynamicTensorView(std::nullptr_t *, TensorShape<other_ndim> &&shape)
+      : Base(nullptr, std::move(shape), DALI_NO_TYPE) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+  }
+  // @}
+
+  /**
+   * @name Copy and move constructor and assignment ops.
+   */
+  // @{
+  template <typename T, int other_ndim>
+  explicit ConstDynamicTensorView(const DynamicTensorViewBase<Backend, T, other_ndim> &other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    this->shape = other.shape;
+    this->type_id = other.type_id;
+  }
+
+  template <typename T, int other_ndim>
+  ConstDynamicTensorView &operator=(const DynamicTensorViewBase<Backend, T, other_ndim> &other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    this->shape = other.shape;
+    this->type_id = other.type_id;
+    return *this;
+  }
+
+  template <typename T, int other_ndim>
+  explicit ConstDynamicTensorView(DynamicTensorViewBase<Backend, T, other_ndim> &&other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    other.data = nullptr;
+    this->shape = std::move(other.shape);
+    this->type_id = other.type_id;
+    other.type_id = DALI_NO_TYPE;
+  }
+
+  template <typename T, int other_ndim>
+  ConstDynamicTensorView &operator=(DynamicTensorViewBase<Backend, T, other_ndim> &&other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    other.data = nullptr;
+    this->shape = std::move(other.shape);
+    this->type_id = other.type_id;
+    other.type_id = DALI_NO_TYPE;
+    return *this;
+  }
+  // @}
+
+
+  /**
+   * @name Converters from static TensorView
+   */
+  // @{
+  template <typename T, int other_ndim,
+            typename = std::enable_if_t<!std::is_same<std::remove_const_t<T>, DynamicType>::value>>
+  explicit ConstDynamicTensorView(const TensorView<Backend, T, other_ndim> &other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    this->shape = other.shape;
+    this->type_id = TypeTable::GetTypeId<remove_const_t<T>>();
+  }
+
+  template <typename T, int other_ndim,
+            typename = std::enable_if_t<!std::is_same<std::remove_const_t<T>, DynamicType>::value>>
+  explicit ConstDynamicTensorView(TensorView<Backend, T, other_ndim> &&other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    other.data = nullptr;
+    this->shape = std::move(other.shape);
+    this->type_id = TypeTable::GetTypeId<remove_const_t<T>>();
+  }
+
+  template <typename T, int other_ndim,
+            typename = std::enable_if_t<!std::is_same<std::remove_const_t<T>, DynamicType>::value>>
+  ConstDynamicTensorView &operator=(const TensorView<Backend, T, other_ndim> &other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    this->shape = other.shape;
+    this->type_id = TypeTable::GetTypeId<remove_const_t<T>>();
+    return *this;
+  }
+
+  template <typename T, int other_ndim,
+            typename = std::enable_if_t<!std::is_same<std::remove_const_t<T>, DynamicType>::value>>
+  ConstDynamicTensorView &operator=(TensorView<Backend, T, other_ndim> &&other) {
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    this->data = other.data;
+    other.data = nullptr;
+    this->shape = std::move(other.shape);
+    this->type_id = TypeTable::GetTypeId<remove_const_t<T>>();
+    return *this;
+  }
+  // @}
+
+  /**
+   * @brief Convert to strongly-typed TensorView
+   *
+   * Requires match between runtime and static types.
+   */
+  template <typename DataType, int other_ndim = ndim>
+  std::enable_if_t<!std::is_same<std::remove_const_t<DataType>, DynamicType>::value,
+                   TensorView<Backend, DataType, other_ndim>>
+  to_static_type() const {
+    DALI_ENFORCE(type_id == TypeTable::GetTypeId<std::remove_const_t<DataType>>(),
+                 make_string("Calling type does not match view data type, requested type: ",
+                             TypeTable::GetTypeId<DataType>(), " current view type: ", type_id));
+    static_assert(std::is_const<DataType>::value,
+                  "This view contains a pointer to const, so the target type must also be const.");
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    return {static_cast<DataType *>(data), shape};
+  }
+
+
+  /**
+   * @brief Convert to strongly-typed TensorView
+   *
+   * No-op conversion to DynamicType
+   */
+  template <typename DataType, int other_ndim = ndim>
+  std::enable_if_t<std::is_same<std::remove_const_t<DataType>, DynamicType>::value,
+                   TensorView<Backend, DataType, other_ndim>>
+  to_static_type() const {
+    static_assert(std::is_const<DataType>::value,
+                  "This view contains a pointer to const, so the target type must also be const.");
+    detail::check_compatible_ndim<ndim, other_ndim>();
+    return {data, shape, type_id};
+  }
+
+
+  /**
+   * @brief Change the ndim, compatible with TensorView API
+   */
+  template <int other_ndim>
+  ConstDynamicTensorView<Backend, other_ndim> to_static() const {
+    static_assert(other_ndim != DynamicDimensions,
+                  "Conversion to static only allowed for static shape");
+    static_assert(ndim == other_ndim || ndim == DynamicDimensions, "Cannot convert to other ndim");
+    return {data, shape.template to_static<other_ndim>(), type_id};
+  }
+
+  using Base::data;
+  using Base::shape;
+  using Base::type_id;
+};
+
+
+/**
+ * @brief TensorView keeping the type information as dynamic `type_id` field.
+ */
+template <typename Backend, int ndim>
+struct TensorView<Backend, DynamicType, ndim> : public DynamicTensorView<Backend, ndim> {
+  using DynamicTensorView<Backend, ndim>::DynamicTensorView;
+};
+
+
+/**
+ * @brief TensorView keeping the type information as dynamic `type_id` field, with pointer to const.
+ */
+template <typename Backend, int ndim>
+struct TensorView<Backend, const DynamicType, ndim> : public ConstDynamicTensorView<Backend, ndim> {
+  using ConstDynamicTensorView<Backend, ndim>::ConstDynamicTensorView;
+};
+
+
+/**
+ * @brief TensorView keeping the type information as dynamic `type_id` field.
+ *
+ * Default variant with dynamic shape (DynamicDimensions specialization).
+ */
+template <typename Backend>
+struct TensorView<Backend, DynamicType, DynamicDimensions>
+    : public DynamicTensorView<Backend, DynamicDimensions> {
+  using DynamicTensorView<Backend, DynamicDimensions>::DynamicTensorView;
+};
+
+
+/**
+ * @brief TensorView keeping the type information as dynamic `type_id` field, with pointer to const.
+ *
+ * Default variant with dynamic shape (DynamicDimensions specialization).
+ */
+template <typename Backend>
+struct TensorView<Backend, const DynamicType, DynamicDimensions>
+    : public ConstDynamicTensorView<Backend, DynamicDimensions> {
+  using ConstDynamicTensorView<Backend, DynamicDimensions>::ConstDynamicTensorView;
+};
+
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_DATA_DYNAMIC_TENSOR_VIEW_H_

--- a/dali/pipeline/data/dynamic_tensor_view_test.cc
+++ b/dali/pipeline/data/dynamic_tensor_view_test.cc
@@ -1,0 +1,289 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <numeric>
+#include <utility>
+
+#include "dali/c_api.h"
+#include "dali/core/tensor_shape.h"
+#include "dali/core/tensor_view.h"
+#include "dali/pipeline/data/backend.h"
+#include "dali/pipeline/data/dynamic_tensor_view.h"
+#include "dali/pipeline/data/types.h"
+#include "dali/pipeline/data/views.h"
+
+namespace dali {
+
+using EBT = EmptyBackendTag;  // allow most of the checks to fit in one line
+
+template <typename DynamicTV, int ndim>
+void compare(const DynamicTV &dtv, const void *ptr, const TensorShape<ndim> &shape,
+             DALIDataType dtype) {
+  EXPECT_EQ(dtv.data, ptr);
+  EXPECT_EQ(dtv.shape, shape);
+  EXPECT_EQ(dtv.type_id, dtype);
+}
+
+template <typename TV>
+std::enable_if_t<std::is_same<std::remove_const_t<typename TV::element_type>, void>::value,
+                 DALIDataType>
+GetDataType(const TV &tv) {
+  return tv.type_id;
+}
+
+template <typename TV>
+std::enable_if_t<!std::is_same<std::remove_const_t<typename TV::element_type>, void>::value,
+                 DALIDataType>
+GetDataType(const TV &tv) {
+  return TypeTable::GetTypeId<typename TV::element_type>();
+}
+
+template <typename Left, typename Right>
+void compare(const Left &left, const Right &right) {
+  EXPECT_EQ(left.data, right.data);
+  EXPECT_EQ(left.shape, right.shape);
+  EXPECT_EQ(GetDataType(left), GetDataType(right));
+}
+
+template <typename Expected, typename Actual, typename Source>
+void compare_typed(const Actual &converted, const Source &source) {
+  static_assert(std::is_same<Expected, Actual>::value, "Static type test");
+  compare(converted, source);
+}
+
+TEST(DynamicTypesTensorViewTest, DefaultConstructors) {
+  TensorView<EBT, DynamicType, 4> empty_static_dim{};
+  compare(empty_static_dim, nullptr, TensorShape<4>{}, DALI_NO_TYPE);
+
+  TensorView<EBT, DynamicType> empty_dynamic_dim{};
+  compare(empty_dynamic_dim, nullptr, TensorShape<>{}, DALI_NO_TYPE);
+
+  TensorView<EBT, const DynamicType, 4> const_empty_static_dim{};
+  compare(const_empty_static_dim, nullptr, TensorShape<4>{}, DALI_NO_TYPE);
+
+  TensorView<EBT, const DynamicType> const_empty_dynamic_dim{};
+  compare(const_empty_dynamic_dim, nullptr, TensorShape<>{}, DALI_NO_TYPE);
+}
+
+TEST(DynamicTypesTensorViewTest, PtrConstructors) {
+  int data = {};
+  TensorView<EBT, DynamicType, 4> empty_static_dim{&data, {1, 2, 3, 4}};
+  compare(empty_static_dim, &data, TensorShape<4>{1, 2, 3, 4}, DALI_INT32);
+
+  TensorView<EBT, DynamicType, 4> empty_static_dim_conv{&data, TensorShape<>{1, 2, 3, 4}};
+  compare(empty_static_dim_conv, &data, TensorShape<4>{1, 2, 3, 4}, DALI_INT32);
+
+  TensorView<EBT, DynamicType> empty_dynamic_dim{&data, {1, 2, 3, 4}};
+  compare(empty_dynamic_dim, &data, TensorShape<>{1, 2, 3, 4}, DALI_INT32);
+
+  TensorView<EBT, DynamicType> empty_dynamic_dim_conv{&data, TensorShape<4>{1, 2, 3, 4}};
+  compare(empty_dynamic_dim_conv, &data, TensorShape<>{1, 2, 3, 4}, DALI_INT32);
+}
+
+TEST(ConstDynamicTypesTensorViewTest, PtrConstructors) {
+  int data = {};
+  TensorView<EBT, const DynamicType, 4> const_empty_static_dim{&data, {1, 2, 3, 4}};
+  compare(const_empty_static_dim, &data, TensorShape<4>{1, 2, 3, 4}, DALI_INT32);
+
+  TensorView<EBT, const DynamicType, 4> const_empty_static_dim_conv{&data,
+                                                                    TensorShape<>{1, 2, 3, 4}};
+  compare(const_empty_static_dim_conv, &data, TensorShape<4>{1, 2, 3, 4}, DALI_INT32);
+
+  TensorView<EBT, const DynamicType> const_empty_dynamic_dim{&data, {1, 2, 3, 4}};
+  compare(const_empty_dynamic_dim, &data, TensorShape<>{1, 2, 3, 4}, DALI_INT32);
+
+  TensorView<EBT, const DynamicType> const_empty_dynamic_dim_conv{&data,
+                                                                  TensorShape<4>{1, 2, 3, 4}};
+  compare(const_empty_dynamic_dim_conv, &data, TensorShape<>{1, 2, 3, 4}, DALI_INT32);
+}
+
+TEST(ConstDynamicTypesTensorViewTest, ConstPtrConstructors) {
+  const int data = {};
+  TensorView<EBT, const DynamicType, 4> const_empty_static_dim{&data, {1, 2, 3, 4}};
+  compare(const_empty_static_dim, &data, TensorShape<4>{1, 2, 3, 4}, DALI_INT32);
+
+  TensorView<EBT, const DynamicType, 4> const_empty_static_dim_conv{&data,
+                                                                    TensorShape<>{1, 2, 3, 4}};
+  compare(const_empty_static_dim_conv, &data, TensorShape<4>{1, 2, 3, 4}, DALI_INT32);
+
+  TensorView<EBT, const DynamicType> const_empty_dynamic_dim{&data, {1, 2, 3, 4}};
+  compare(const_empty_dynamic_dim, &data, TensorShape<>{1, 2, 3, 4}, DALI_INT32);
+
+  TensorView<EBT, const DynamicType> const_empty_dynamic_dim_conv{&data,
+                                                                  TensorShape<4>{1, 2, 3, 4}};
+  compare(const_empty_dynamic_dim_conv, &data, TensorShape<>{1, 2, 3, 4}, DALI_INT32);
+}
+
+TEST(DynamicTypesTensorViewTest, NullPtrConstructors) {
+  TensorView<EBT, DynamicType, 4> empty_static_dim{nullptr, {1, 2, 3, 4}};
+  compare(empty_static_dim, nullptr, TensorShape<4>{1, 2, 3, 4}, DALI_NO_TYPE);
+
+  TensorView<EBT, DynamicType> empty_dynamic_dim{nullptr, {1, 2, 3, 4}};
+  compare(empty_dynamic_dim, nullptr, TensorShape<>{1, 2, 3, 4}, DALI_NO_TYPE);
+
+  TensorView<EBT, const DynamicType, 4> const_empty_static_dim{nullptr, {1, 2, 3, 4}};
+  compare(const_empty_static_dim, nullptr, TensorShape<4>{1, 2, 3, 4}, DALI_NO_TYPE);
+
+  TensorView<EBT, const DynamicType> const_empty_dynamic_dim{nullptr, {1, 2, 3, 4}};
+  compare(const_empty_dynamic_dim, nullptr, TensorShape<>{1, 2, 3, 4}, DALI_NO_TYPE);
+}
+
+TEST(DynamicTypesTensorViewTest, TypeIdConstructors) {
+  TensorView<EBT, DynamicType, 4> empty_static_dim{nullptr, {1, 2, 3, 4}, DALI_INT32};
+  compare(empty_static_dim, nullptr, TensorShape<4>{1, 2, 3, 4}, DALI_INT32);
+
+  TensorView<EBT, DynamicType> empty_dynamic_dim{nullptr, {1, 2, 3, 4}, DALI_INT32};
+  compare(empty_dynamic_dim, nullptr, TensorShape<>{1, 2, 3, 4}, DALI_INT32);
+
+  TensorView<EBT, DynamicType> empty_dynamic_dim_conv{nullptr, TensorShape<4>{1, 2, 3, 4},
+                                                      DALI_INT32};
+  compare(empty_dynamic_dim_conv, nullptr, TensorShape<>{1, 2, 3, 4}, DALI_INT32);
+}
+
+TEST(DynamicTypesTensorViewTest, ConverterConstructors) {
+  int data = {};
+  TensorView<EBT, int, 3> tv{&data, {1, 2, 3}};
+  TensorView<EBT, int> dyn_tv{&data, {1, 2, 3}};
+
+  TensorView<EBT, DynamicType, 3> static_dim{tv}, static_dim_2{dyn_tv};
+  compare(static_dim, tv);
+  compare(static_dim_2, dyn_tv);
+
+  TensorView<EBT, DynamicType> dynamic_dim{tv}, dynamic_dim_2{dyn_tv};
+  compare(dynamic_dim, tv);
+  compare(dynamic_dim_2, dyn_tv);
+
+  TensorView<EBT, DynamicType, 3> copy_static_to_static{static_dim};
+  compare(copy_static_to_static, tv);
+
+  TensorView<EBT, DynamicType> copy_static_to_dynamic{static_dim};
+  compare(copy_static_to_dynamic, tv);
+
+
+  TensorView<EBT, DynamicType, 3> copy_dynamic_to_static{dynamic_dim};
+  compare(copy_dynamic_to_static, tv);
+
+  TensorView<EBT, DynamicType, 3> copy_dynamic_to_dynamic{dynamic_dim};
+  compare(copy_dynamic_to_dynamic, tv);
+}
+
+TEST(ConstDynamicTypesTensorViewTest, ConverterConstructors) {
+  const int cdata = {};
+  TensorView<EBT, const int, 3> ctv{&cdata, {1, 2, 3}};
+  TensorView<EBT, const int> dyn_ctv{&cdata, {1, 2, 3}};
+
+  TensorView<EBT, const DynamicType, 3> static_dim{ctv}, static_dim_2{dyn_ctv};
+  compare(static_dim, ctv);
+  compare(static_dim_2, dyn_ctv);
+
+  TensorView<EBT, const DynamicType> dynamic_dim{ctv}, dynamic_dim_2{dyn_ctv};
+  compare(dynamic_dim, ctv);
+  compare(dynamic_dim_2, dyn_ctv);
+
+  int data = {};
+  TensorView<EBT, int, 3> tv{&data, {1, 2, 3}};
+  TensorView<EBT, int> dyn_tv{&data, {1, 2, 3}};
+
+  TensorView<EBT, const DynamicType, 3> static_dim_nonconst{tv}, static_dim_nonconst_2{dyn_tv};
+  compare(static_dim_nonconst, tv);
+  compare(static_dim_nonconst_2, dyn_tv);
+
+  TensorView<EBT, const DynamicType> dynamic_dim_nonconst{tv}, dynamic_dim_nonconst_2{dyn_tv};
+  compare(dynamic_dim_nonconst, tv);
+  compare(dynamic_dim_nonconst_2, dyn_tv);
+
+  TensorView<EBT, const DynamicType, 3> copy_static_to_static{static_dim};
+  compare(copy_static_to_static, ctv);
+
+  TensorView<EBT, const DynamicType> copy_static_to_dynamic{static_dim};
+  compare(copy_static_to_dynamic, ctv);
+
+  TensorView<EBT, const DynamicType, 3> copy_dynamic_to_static{dynamic_dim};
+  compare(copy_dynamic_to_static, ctv);
+
+  TensorView<EBT, const DynamicType, 3> copy_dynamic_to_dynamic{dynamic_dim};
+  compare(copy_dynamic_to_dynamic, ctv);
+}
+
+template <typename Actual>
+void test_views_non_const(const Actual &tv) {
+  compare_typed<TensorView<EBT, int, 3>>(view<int, 3>(tv), tv);
+  compare_typed<TensorView<EBT, int, DynamicDimensions>>(view<int>(tv), tv);
+  compare_typed<TensorView<EBT, DynamicType, 3>>(view<DynamicType, 3>(tv), tv);
+  compare_typed<TensorView<EBT, DynamicType, DynamicDimensions>>(view<DynamicType>(tv), tv);
+}
+
+template <typename Actual>
+void test_views_const(const Actual &tv) {
+  compare_typed<TensorView<EBT, const int, 3>>(view<const int, 3>(tv), tv);
+  compare_typed<TensorView<EBT, const int, DynamicDimensions>>(view<const int>(tv), tv);
+  compare_typed<TensorView<EBT, const DynamicType, 3>>(view<const DynamicType, 3>(tv), tv);
+  compare_typed<TensorView<EBT, const DynamicType, DynamicDimensions>>(view<const DynamicType>(tv),
+                                                                       tv);
+}
+
+template <typename Actual>
+void test_views(const Actual &tv) {
+  test_views_non_const(tv);
+  test_views_const(tv);
+}
+
+TEST(DynamicTypesTensorViewTest, ViewFunction) {
+  auto tv1 = TensorView<EBT, int, 3>{reinterpret_cast<int *>(42), {1, 2, 3}};
+  test_views(tv1);
+
+  auto ctv1 = TensorView<EBT, const int, 3>{reinterpret_cast<const int *>(42), {1, 2, 3}};
+  test_views_const(ctv1);
+
+  auto tv2 = TensorView<EBT, int>{reinterpret_cast<int *>(42), TensorShape<3>{1, 2, 3}};
+  test_views(tv2);
+
+  auto ctv2 =
+      TensorView<EBT, const int>{reinterpret_cast<const int *>(42), TensorShape<3>{1, 2, 3}};
+  test_views_const(ctv2);
+
+  auto tv3 = TensorView<EBT, DynamicType, 3>{reinterpret_cast<int *>(42), {1, 2, 3}};
+  test_views(tv3);
+
+  auto ctv3 = TensorView<EBT, const DynamicType, 3>{reinterpret_cast<const int *>(42), {1, 2, 3}};
+  test_views_const(ctv3);
+
+  auto tv4 = TensorView<EBT, DynamicType>{reinterpret_cast<int *>(42), TensorShape<3>{1, 2, 3}};
+  test_views(tv4);
+
+  auto ctv4 = TensorView<EBT, const DynamicType>{reinterpret_cast<const int *>(42),
+                                                 TensorShape<3>{1, 2, 3}};
+  test_views_const(ctv4);
+}
+
+TEST(DynamicTypesTensorViewTest, FromTensor) {
+  Tensor<CPUBackend> tensor;
+  tensor.Resize({1, 2, 3}, DALI_INT32);
+  auto dtv = view<DynamicType>(tensor);
+  auto cdtv = view<const DynamicType>(tensor);
+
+  auto dtv_3 = view<DynamicType, 3>(tensor);
+  auto cdtv_3 = view<const DynamicType, 3>(tensor);
+
+  auto baseline_tv = view<int, 3>(tensor);
+
+  compare(dtv, baseline_tv);
+  compare(cdtv, baseline_tv);
+
+  compare(dtv_3, baseline_tv);
+  compare(cdtv_3, baseline_tv);
+}
+
+}  // namespace dali

--- a/include/dali/core/tensor_view.h
+++ b/include/dali/core/tensor_view.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ struct TensorViewBase {
   }
 
   template <int other_ndim>
-  TensorView<Backend, DataType, other_ndim> to_static();
+  TensorView<Backend, DataType, other_ndim> to_static() const;
 
   DataType *data = nullptr;
   TensorShape<ndim> shape;
@@ -224,7 +224,8 @@ struct TensorView : TensorViewBase<Backend, DataType, ndim> {
 
 template <typename Backend, typename DataType, int ndim>
 template <int other_ndim>
-TensorView<Backend, DataType, other_ndim> TensorViewBase<Backend, DataType, ndim>::to_static() {
+TensorView<Backend, DataType, other_ndim>
+TensorViewBase<Backend, DataType, ndim>::to_static() const {
   static_assert(other_ndim != DynamicDimensions,
                 "Conversion to static only allowed for static shape");
   static_assert(ndim == other_ndim || ndim == DynamicDimensions, "Cannot convert to other ndim");


### PR DESCRIPTION

 

## Category: New feature
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
### `TensorView<DynamicType>`
Introduce runtime typed TensorView.
The new specialization uses `DynamicType` tag
as the type parameter to TensorView.

The purpose is to have Tensor wrapper that is similar
to already existing DALI vocabulary types, and additionally
allows to keep the type as a runtime information.

### view<T, ndim> conversions

Extend the utility of the `view` function
template to allow for any conversions between
statically and dynamically typed TensorViews.

### Next steps
The target use of this type is to use it as the return
type of the TensorBatch::operator[] - using static type
is not possible due to the Tensor[List/Vector] not being
statically typed. This should allow for proper encapsulation
of the batch object - TensorView allow access to the data
but do not allow to adjust the allocation or changing
the metadata through the view - as opposed to the currently
used Tensor.

The current use pattern of obtaining statically TensorViews
in CPU operators using: `view<T>(tensor_vector[i])` 
will work without additional changes.

### To consider
I specifically added the specialization as small definition 
at the end of dynamic_tensor_view.h, and implemented
most of the operations as DynamicTensorView and ConstDynamicTensorView
if we find a good reason not to expose those dynamic views
as TensorView specialization.

Options for follow-up:
* extending the capabilities of `view` overload for TensorListView.
* adding `type()` method to TensorView that would not be callable
  for statically typed ones, but would ease the work in template contexts. 

### What this PR is not

This PR does not add similar capabilities to TensorListView
as they are not needed for the further work and TensorVector/List
and statically typed TensorListView are enough for current DALI
usage.

## Additional information:

### Affected modules and functionalities:
TensorViews, view<T, ndim>()


### Key points relevant for the review:
There is a lot of boilerplate related to move variants
for the conversions etc.



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [x] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
