### PR TITLE
Ensure sample encapsulation in Tensor Vector

### DIFF
--- a/dali/benchmark/displacement_cpu_bench.cc
+++ b/dali/benchmark/displacement_cpu_bench.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ void DisplacementBench(benchmark::State& st) {//NOLINT
   // tensor out is resized by operator itself in DisplacementFilter::DataDependentSetup()
 
   // TODO(klecki) Accomodate to use different inputs from test data
-  auto *ptr = (*tensor_in)[0].template mutable_data<T>();
+  auto *ptr = (*tensor_in).template mutable_tensor<T>(0);
   for (int i = 0; i < N; i++) {
     ptr[i] = i;
   }

--- a/dali/benchmark/operator_bench.h
+++ b/dali/benchmark/operator_bench.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,16 +54,13 @@ class OperatorBench : public DALIBenchmark {
     auto op_ptr = InstantiateOperator(op_spec);
 
     auto data_in = std::make_shared<TensorVector<CPUBackend>>(batch_size);
-    for (auto &in_ptr : *data_in) {
-      in_ptr = std::make_shared<Tensor<CPUBackend>>();
-      in_ptr->set_type<T>();
-      in_ptr->Resize({H, W, C});
-      in_ptr->SetLayout("HWC");
-    }
+    data_in->set_type<T>();
+    data_in->Resize(uniform_list_shape(batch_size, TensorShape<>{H, W, C}));
+    data_in->SetLayout("HWC");
 
     if (fill_in_data) {
-      for (auto &in_ptr : *data_in) {
-        auto *ptr = in_ptr->template mutable_data<T>();
+      for (int sample_id = 0; sample_id < batch_size; sample_id++) {
+        auto *ptr = data_in->template mutable_tensor<T>(sample_id);
         for (int i = 0; i < N; i++) {
           ptr[i] = static_cast<T>(i);
         }

--- a/dali/benchmark/operator_bench.h
+++ b/dali/benchmark/operator_bench.h
@@ -59,8 +59,8 @@ class OperatorBench : public DALIBenchmark {
     data_in->SetLayout("HWC");
 
     if (fill_in_data) {
-      for (int sample_id = 0; sample_id < batch_size; sample_id++) {
-        auto *ptr = data_in->template mutable_tensor<T>(sample_id);
+      for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
+        auto *ptr = data_in->template mutable_tensor<T>(sample_idx);
         for (int i = 0; i < N; i++) {
           ptr[i] = static_cast<T>(i);
         }

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -130,6 +130,7 @@ void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
     layout = dali::TensorLayout(layout_str);
   }
   dali::TensorVector<Backend> data(curr_batch_size);
+  data.set_pinned(flags & DALI_ext_pinned);
   auto type_id = static_cast<dali::DALIDataType>(data_type);
   auto elem_sizeof = dali::TypeTable::GetTypeInfo(type_id).size();
 
@@ -138,6 +139,7 @@ void SetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
     order = AccessOrder(stream);
   else
     order = AccessOrder::host();
+
 
   for (int i = 0; i < curr_batch_size; i++) {
     // We cast away the const from data_ptr, as there is no other way of passing it to the

--- a/dali/operators/audio/nonsilence_op.h
+++ b/dali/operators/audio/nonsilence_op.h
@@ -228,8 +228,8 @@ class NonsilenceOperatorCpu : public NonsilenceOperator<CPUBackend> {
                   args.reset_interval = reset_interval_;
 
                   auto res = DetectNonsilenceRegion(intermediate_buffers_[thread_id], args);
-                  auto beg_ptr = output_begin.mutable_tensor<int>(sample_id);
-                  auto len_ptr = output_length.mutable_tensor<int>(sample_id);
+                  auto *beg_ptr = output_begin.mutable_tensor<int>(sample_id);
+                  auto *len_ptr = output_length.mutable_tensor<int>(sample_id);
                   *beg_ptr = res.first;
                   *len_ptr = res.second;
               }, in_shape.tensor_size(sample_id));

--- a/dali/operators/audio/nonsilence_op.h
+++ b/dali/operators/audio/nonsilence_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -228,8 +228,8 @@ class NonsilenceOperatorCpu : public NonsilenceOperator<CPUBackend> {
                   args.reset_interval = reset_interval_;
 
                   auto res = DetectNonsilenceRegion(intermediate_buffers_[thread_id], args);
-                  auto beg_ptr = output_begin[sample_id].mutable_data<int>();
-                  auto len_ptr = output_length[sample_id].mutable_data<int>();
+                  auto beg_ptr = output_begin.mutable_tensor<int>(sample_id);
+                  auto len_ptr = output_length.mutable_tensor<int>(sample_id);
                   *beg_ptr = res.first;
                   *len_ptr = res.second;
               }, in_shape.tensor_size(sample_id));

--- a/dali/operators/audio/preemphasis_filter_op.cc
+++ b/dali/operators/audio/preemphasis_filter_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,11 +65,11 @@ void PreemphasisFilterCPU::RunImplTyped(workspace_t<CPUBackend> &ws) {
   for (int sample_id = 0; sample_id < nsamples; sample_id++) {
     tp.AddWork(
       [this, &output, &input, sample_id](int thread_id) {
-        const auto in_ptr = input[sample_id].data<InputType>();
-        auto out_ptr = output[sample_id].mutable_data<OutputType>();
-        DALI_ENFORCE(input[sample_id].shape() == output[sample_id].shape(),
+        const auto in_ptr = input.tensor<InputType>(sample_id);
+        auto out_ptr = output.mutable_tensor<OutputType>(sample_id);
+        DALI_ENFORCE(input.tensor_shape(sample_id) == output.tensor_shape(sample_id),
                      "Input and output shapes don't match");
-        auto n = volume(output[sample_id].shape());
+        auto n = volume(output.tensor_shape(sample_id));
         auto coeff = preemph_coeff_[sample_id];
         if (coeff == 0.0f) {
           for (int64_t j = 0; j < n; j++) {

--- a/dali/operators/audio/preemphasis_filter_op.cc
+++ b/dali/operators/audio/preemphasis_filter_op.cc
@@ -65,8 +65,8 @@ void PreemphasisFilterCPU::RunImplTyped(workspace_t<CPUBackend> &ws) {
   for (int sample_id = 0; sample_id < nsamples; sample_id++) {
     tp.AddWork(
       [this, &output, &input, sample_id](int thread_id) {
-        const auto in_ptr = input.tensor<InputType>(sample_id);
-        auto out_ptr = output.mutable_tensor<OutputType>(sample_id);
+        const auto *in_ptr = input.tensor<InputType>(sample_id);
+        auto *out_ptr = output.mutable_tensor<OutputType>(sample_id);
         DALI_ENFORCE(input.tensor_shape(sample_id) == output.tensor_shape(sample_id),
                      "Input and output shapes don't match");
         auto n = volume(output.tensor_shape(sample_id));

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,13 +88,13 @@ AudioDecoderCpu::SetupImpl(std::vector<OutputDesc> &output_desc, const workspace
 
   for (int i = 0; i < batch_size; i++) {
     auto &meta = sample_meta_[i] =
-        decoders_[i]->Open({static_cast<const char *>(input[i].raw_data()),
-                            input[i].shape().num_elements()});
+        decoders_[i]->Open({static_cast<const char *>(input.raw_tensor(i)),
+                            input.tensor_shape(i).num_elements()});
     TensorShape<> data_sample_shape = DecodedAudioShape(
         meta, use_resampling_ ? target_sample_rates_[i] : -1.0f, downmix_);
     shape_data.set_tensor_shape(i, data_sample_shape);
     shape_rate.set_tensor_shape(i, {});
-    files_names_[i] = input[i].GetSourceInfo();
+    files_names_[i] = input.GetMeta(i).GetSourceInfo();
   }
 
   output_desc[0] = { shape_data, output_type_ };

--- a/dali/operators/decoder/decoder_test.h
+++ b/dali/operators/decoder/decoder_test.h
@@ -81,6 +81,7 @@ class DecodeTestBase : public GenericDecoderTest<ImgType> {
     for (size_t i = 0; i < encoded_data.num_samples(); ++i) {
       out_shape.set_tensor_shape(i, tmp_out[i].shape());
     }
+    out.SetupLike(tmp_out[0]);
     out.Resize(out_shape, DALI_UINT8);
     for (size_t i = 0; i < encoded_data.num_samples(); ++i) {
       out.UnsafeSetSample(i, tmp_out[i]);

--- a/dali/operators/decoder/decoder_test.h
+++ b/dali/operators/decoder/decoder_test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include "dali/pipeline/data/types.h"
 #include "dali/test/dali_test_decoder.h"
 
 namespace dali {
@@ -64,6 +65,7 @@ class DecodeTestBase : public GenericDecoderTest<ImgType> {
     // single input - encoded images
     // single output - decoded images
     TensorVector<CPUBackend> out(inputs[0]->num_samples());
+    std::vector<Tensor<CPUBackend>> tmp_out(inputs[0]->num_samples());
     const TensorList<CPUBackend> &encoded_data = *inputs[0];
     const int c = this->GetNumColorComp();
 
@@ -72,7 +74,16 @@ class DecodeTestBase : public GenericDecoderTest<ImgType> {
       auto data_size = volume(encoded_data.tensor_shape(i));
       this->DecodeImage(
         data, data_size, c, this->ImageType(),
-        &out[i], GetCropWindowGenerator(i));
+        &tmp_out[i], GetCropWindowGenerator(i));
+    }
+
+    TensorListShape<> out_shape(inputs[0]->num_samples(), 3);
+    for (size_t i = 0; i < encoded_data.num_samples(); ++i) {
+      out_shape.set_tensor_shape(i, tmp_out[i].shape());
+    }
+    out.Resize(out_shape, DALI_UINT8);
+    for (size_t i = 0; i < encoded_data.num_samples(); ++i) {
+      out.UnsafeSetSample(i, tmp_out[i]);
     }
 
     vector<std::shared_ptr<TensorList<CPUBackend>>> outputs;

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -852,6 +852,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       TensorVector<CPUBackend> tv(samples_hw_batched_.size());
 
       const auto &input = ws.Input<CPUBackend>(0);
+      tv.SetupLike(input);
       for (auto *sample : samples_hw_batched_) {
         int i = sample->sample_idx;
         const auto &out_shape = output_shape_.tensor_shape(i);

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -554,15 +554,16 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     samples_jpeg2k_.clear();
 #endif  // NVJPEG2K_ENABLED
 
+    const auto &input = ws.Input<CPUBackend>(0);
     for (int i = 0; i < curr_batch_size; i++) {
-      const auto &in = ws.Input<CPUBackend>(0)[i];
-      const auto in_size = in.size();
-      thread_pool_.AddWork([this, i, &in, in_size](int tid) {
-        auto *input_data = in.data<uint8_t>();
+      auto *input_data = input.tensor<uint8_t>(i);
+      const auto in_size = input.tensor_shape(i).num_elements();
+      const auto &source_info = input.GetMeta(i).GetSourceInfo();
+      thread_pool_.AddWork([this, i, input_data, in_size, source_info](int tid) {
         SampleData &data = sample_data_[i];
         data.clear();
         data.sample_idx = i;
-        data.file_name = in.GetSourceInfo();
+        data.file_name = source_info;
         data.encoded_length = in_size;
 
         auto cached_shape = CacheImageShape(data.file_name);
@@ -704,15 +705,17 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
   void ProcessImagesCuda(MixedWorkspace &ws) {
     auto& output = ws.Output<GPUBackend>(0);
+    const auto &input = ws.Input<CPUBackend>(0);
     for (auto *sample : samples_single_) {
       assert(sample);
       auto i = sample->sample_idx;
       auto *output_data = output.mutable_tensor<uint8_t>(i);
-      const auto &in = ws.Input<CPUBackend>(0)[i];
+      const auto *in_data = input.tensor<uint8_t>(i);
+      const auto in_size = input.tensor_shape(i).num_elements();
       thread_pool_.AddWork(
-        [this, sample, &in, output_data](int tid) {
-          SampleWorker(sample->sample_idx, sample->file_name, in.size(), tid,
-            in.data<uint8_t>(), output_data, streams_[tid]);
+        [this, sample, in_data, in_size, output_data](int tid) {
+          SampleWorker(sample->sample_idx, sample->file_name, in_size, tid,
+            in_data, output_data, streams_[tid]);
         }, task_priority_seq_--);  // FIFO order, since the samples were already ordered
     }
   }
@@ -808,15 +811,17 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
   }
 
   void ProcessImagesHost(MixedWorkspace &ws) {
+    const auto &input = ws.Input<CPUBackend>(0);
     auto& output = ws.Output<GPUBackend>(0);
     for (auto *sample : samples_host_) {
       auto i = sample->sample_idx;
+      const auto *input_data = input.tensor<uint8_t>(i);
+      auto in_size = input.tensor_shape(i).num_elements();
       auto *output_data = output.mutable_tensor<uint8_t>(i);
-      const auto &in = ws.Input<CPUBackend>(0)[i];
       ImageCache::ImageShape shape = output_shape_[i].to_static<3>();
       thread_pool_.AddWork(
-        [this, sample, &in, output_data, shape](int tid) {
-          HostFallback<StorageGPU>(in.data<uint8_t>(), in.size(), output_image_type_, output_data,
+        [this, sample, input_data, in_size, output_data, shape](int tid) {
+          HostFallback<StorageGPU>(input_data, in_size, output_image_type_, output_data,
                                    streams_[tid], sample->file_name, sample->roi, use_fast_idct_);
           CacheStore(sample->file_name, output_data, shape, streams_[tid]);
         }, task_priority_seq_--);  // FIFO order, since the samples were already ordered
@@ -846,13 +851,13 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       int j = 0;
       TensorVector<CPUBackend> tv(samples_hw_batched_.size());
 
+      const auto &input = ws.Input<CPUBackend>(0);
       for (auto *sample : samples_hw_batched_) {
         int i = sample->sample_idx;
-        const auto &in = ws.Input<CPUBackend>(0)[i];
         const auto &out_shape = output_shape_.tensor_shape(i);
 
-        tv[j].ShareData(const_cast<Tensor<CPUBackend> &>(in));
-        in_lengths_[j] = in.size();
+        tv.UnsafeSetSample(j, input, i);
+        in_lengths_[j] = input.tensor_shape(i).num_elements();
         nvjpeg_destinations_[j].channel[0] = output.mutable_tensor<uint8_t>(i);
         nvjpeg_destinations_[j].pitch[0] = out_shape[1] * out_shape[2];
         nvjpeg_params_[j] = sample->params;

--- a/dali/operators/generic/cast.cc
+++ b/dali/operators/generic/cast.cc
@@ -51,8 +51,8 @@ void CastCPU::RunImpl(HostWorkspace &ws) {
     TYPE_SWITCH(itype, type2id, IType, CAST_ALLOWED_TYPES, (
 
       for (int sample_id = 0; sample_id < num_samples; sample_id++) {
-        auto *out = output[sample_id].mutable_data<OType>();
-        const auto *in = input[sample_id].data<IType>();
+        auto *out = output.mutable_tensor<OType>(sample_id);
+        const auto *in = input.tensor<IType>(sample_id);
         auto size = input_shape.tensor_size(sample_id);
         tp.AddWork([out, in, size](int thread_id) { CpuHelper<OType, IType>(out, in, size); },
                    size);

--- a/dali/operators/generic/constant.cc
+++ b/dali/operators/generic/constant.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ void FillTensorVector(
   assert(is_uniform(shape));
   int64_t n = shape[0].num_elements();
   assert(src.size() == static_cast<size_t>(n) || src.size() == 1);
-  Dst *out = dst[0].mutable_data<Dst>();
+  Dst *out = dst.mutable_tensor<Dst>(0);
   if (src.size() == 1) {
     Dst val = ConvertSat<Dst>(src[0]);
     for (int64_t i = 0; i < n; i++) {
@@ -92,7 +92,7 @@ void FillTensorVector(
     }
   }
   for (int i = 1; i < shape.num_samples(); i++) {
-    dst[i].ShareData(dst[0]);
+    dst.UnsafeSetSample(i, dst, 0);
   }
 }
 }  // namespace
@@ -116,7 +116,7 @@ void Constant<CPUBackend>::RunImpl(HostWorkspace &ws) {
   out.Resize(output_shape_);
   int N = output_shape_.num_samples();
   for (int i = 0; i < N; i++) {
-    assert(out[i].raw_data() == output_[i].raw_data());
+    assert(out.raw_tensor(i) == output_.raw_tensor(i));
   }
   out.SetLayout(layout_);
 }

--- a/dali/operators/generic/erase/erase_utils.h
+++ b/dali/operators/generic/erase/erase_utils.h
@@ -95,14 +95,14 @@ std::vector<kernels::EraseArgs<T, Dims>> GetEraseArgs(const OpSpec &spec,
 
   for (int i = 0; i < nsamples; i++) {
     if (has_tensor_roi_anchor) {
-      const auto& anchor = view<const float>(ws.ArgumentInput("anchor")[i]);
+      auto anchor = view<const float>(ws.ArgumentInput("anchor")[i]);
       assert(anchor.shape.num_elements() > 0);
       roi_anchor.resize(anchor.shape.num_elements());
       std::memcpy(roi_anchor.data(), anchor.data, sizeof(float) * roi_anchor.size());
     }
 
     if (has_tensor_roi_shape) {
-      const auto& shape = view<const float>(ws.ArgumentInput("shape")[i]);
+      auto shape = view<const float>(ws.ArgumentInput("shape")[i]);
       assert(shape.shape.num_elements() > 0);
       roi_shape.resize(shape.num_elements());
       std::memcpy(roi_shape.data(), shape.data, sizeof(float) * roi_shape.size());

--- a/dali/operators/generic/erase/erase_utils.h
+++ b/dali/operators/generic/erase/erase_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -95,17 +95,17 @@ std::vector<kernels::EraseArgs<T, Dims>> GetEraseArgs(const OpSpec &spec,
 
   for (int i = 0; i < nsamples; i++) {
     if (has_tensor_roi_anchor) {
-      const auto& anchor = ws.ArgumentInput("anchor")[i];
-      assert(anchor.size() > 0);
-      roi_anchor.resize(anchor.size());
-      std::memcpy(roi_anchor.data(), anchor.data<float>(), sizeof(float) * roi_anchor.size());
+      const auto& anchor = view<const float>(ws.ArgumentInput("anchor")[i]);
+      assert(anchor.shape.num_elements() > 0);
+      roi_anchor.resize(anchor.shape.num_elements());
+      std::memcpy(roi_anchor.data(), anchor.data, sizeof(float) * roi_anchor.size());
     }
 
     if (has_tensor_roi_shape) {
-      const auto& shape = ws.ArgumentInput("shape")[i];
-      assert(shape.size() > 0);
-      roi_shape.resize(shape.size());
-      std::memcpy(roi_shape.data(), shape.data<float>(), sizeof(float) * roi_shape.size());
+      const auto& shape = view<const float>(ws.ArgumentInput("shape")[i]);
+      assert(shape.shape.num_elements() > 0);
+      roi_shape.resize(shape.num_elements());
+      std::memcpy(roi_shape.data(), shape.data, sizeof(float) * roi_shape.size());
     }
 
     DALI_ENFORCE(roi_anchor.size() == roi_shape.size());

--- a/dali/operators/generic/lookup_table.cc
+++ b/dali/operators/generic/lookup_table.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ void LookupValuesImpl(ThreadPool &tp, TensorVector<CPUBackend> &output,
                       const Output *lookup_table, const Output default_value) {
   for (int sample_idx = 0; sample_idx < shape.num_samples(); sample_idx++) {
     auto data_size = shape.tensor_size(sample_idx);
-    auto *out_data = output[sample_idx].mutable_data<Output>();
-    const auto *in_data = input[sample_idx].data<Input>();
+    auto *out_data = output.mutable_tensor<Output>(sample_idx);
+    const auto *in_data = input.tensor<Input>(sample_idx);
     tp.AddWork(
         [=](int thread_id) {
           for (int64_t i = 0; i < data_size; i++) {

--- a/dali/operators/generic/permute_batch.cc
+++ b/dali/operators/generic/permute_batch.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,8 @@ void PermuteBatch<CPUBackend>::RunImpl(HostWorkspace &ws) {
     int src = indices_[i];
     tp.AddWork([&, i, src](int tid) {
       output.SetMeta(i, input.GetMeta(i));
-      output[i].Copy(input[src]);
+      // TODO(klecki): SetSample
+      output.UnsafeCopySample(i, input, src);
     }, size);
   }
   tp.RunAll();

--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -393,8 +393,8 @@ void Reshape<CPUBackend>::RunImpl(HostWorkspace &ws) {
   out.Resize(output_shape_, output_type_->id());
   int N = output_shape_.num_samples();
   for (int i = 0; i < N; i++) {
-    assert(out[i].raw_data() == in[i].raw_data());
-    assert(out[i].shape() == output_shape_[i]);
+    assert(out.raw_tensor(i) == in.raw_tensor(i));
+    assert(out.tensor_shape(i) == output_shape_[i]);
   }
   out.SetLayout(layout);
 }

--- a/dali/operators/generic/shapes.h
+++ b/dali/operators/generic/shapes.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ class Shapes : public Operator<Backend> {
     int n = out.num_samples();
     assert(n == shape.num_samples());
     for (int i = 0; i < n; i++) {
-      type *data = out[i].mutable_data<type>();
+      type *data = out.mutable_tensor<type>(i);
       auto sample_shape = shape.tensor_shape_span(i);
       for (int j = 0; j < shape.sample_dim(); j++)
         data[j] = sample_shape[j];

--- a/dali/operators/generic/slice/slice_base.cc
+++ b/dali/operators/generic/slice/slice_base.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,7 +58,6 @@ bool SliceBaseCpu<OutputType, InputType, Dims>::SetupImpl(std::vector<OutputDesc
   output_desc[0].shape.resize(nsamples, Dims);
 
   kernels::KernelContext ctx;
-  auto in_view = view<const InputType, Dims>(input);
   for (int i = 0; i < nsamples; i++) {
     auto in_view = view<const InputType, Dims>(input[i]);
     auto req = Kernel().Setup(ctx, in_view, args_[i]);

--- a/dali/operators/generic/transpose/transpose.cc
+++ b/dali/operators/generic/transpose/transpose.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,8 +46,8 @@ class TransposeCPU : public Transpose<CPUBackend> {
             TensorShape<> src_ts = input.shape()[i];
             auto dst_ts = permute(src_ts, perm_);
             kernels::TransposeGrouped(
-                TensorView<StorageCPU, T>{output[i].mutable_data<T>(), dst_ts},
-                TensorView<StorageCPU, const T>{input[i].data<T>(), src_ts}, make_cspan(perm_));
+                TensorView<StorageCPU, T>{output.mutable_tensor<T>(i), dst_ts},
+                TensorView<StorageCPU, const T>{input.tensor<T>(i), src_ts}, make_cspan(perm_));
           }, out_shape.tensor_size(i));
       }
     ), DALI_FAIL(make_string("Unsupported input type: ", input_type)));  // NOLINT

--- a/dali/operators/geometry/coord_flip.cc
+++ b/dali/operators/geometry/coord_flip.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,11 +77,11 @@ void CoordFlipCPU::RunImpl(workspace_t<CPUBackend> &ws) {
     mirrored_origin[y_dim_] = 2.0f * spec_.GetArgument<float>("center_y", &ws, sample_id);
     mirrored_origin[z_dim_] = 2.0f * spec_.GetArgument<float>("center_z", &ws, sample_id);
 
-    auto in_size = volume(input[sample_id].shape());
+    auto in_size = volume(input.tensor_shape(sample_id));
     thread_pool.AddWork(
         [this, &input, in_size, &output, sample_id, flip_dim, mirrored_origin](int thread_id) {
-          const auto *in = input[sample_id].data<float>();
-          auto *out = output[sample_id].mutable_data<float>();
+          const auto *in = input.tensor<float>(sample_id);
+          auto *out = output.mutable_tensor<float>(sample_id);
           int d = 0;
           int64_t i = 0;
           for (; i < in_size; i++, d++) {

--- a/dali/operators/geometry/mt_transform_attr_test.cc
+++ b/dali/operators/geometry/mt_transform_attr_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -155,11 +155,11 @@ TEST(MTTransformAttr, MInputTInput) {
   Minp->Resize(Mtls, DALI_FLOAT);
   Tinp->Resize(Ttls, DALI_FLOAT);
   for (int i = 0; i < N; i++) {
-    float *data = (*Minp)[i].mutable_data<float>();
+    float *data = Minp->mutable_tensor<float>(i);
     for (int j = 0; j < volume(Mtls[i]); j++)
       data[j] = 1 + j + i * 10;
 
-    data = (*Tinp)[i].mutable_data<float>();
+    data = Tinp->mutable_tensor<float>(i);
     for (int j = 0; j < volume(Ttls[i]); j++)
       data[j] = 10 + j * 10  + i * 100;
   }
@@ -198,9 +198,9 @@ TEST(MTTransformAttr, MScalarInputTScalarInput) {
   Minp->Resize(tls, DALI_FLOAT);
   Tinp->Resize(tls, DALI_FLOAT);
   for (int i = 0; i < N; i++) {
-    float *data = (*Minp)[i].mutable_data<float>();
+    float *data = Minp->mutable_tensor<float>(i);
     data[0] = i + 10;
-    data = (*Tinp)[i].mutable_data<float>();
+    data = Tinp->mutable_tensor<float>(i);
     data[0] = i + 100;
   }
 
@@ -233,7 +233,7 @@ TEST(MTTransformAttr, MTInput) {
   int N = tls.num_samples();;
   MTinp->Resize(tls, DALI_FLOAT);
   for (int i = 0; i < N; i++) {
-    auto *data = (*MTinp)[i].mutable_data<float>();
+    auto *data = MTinp->mutable_tensor<float>(i);
     for (int j = 0; j < volume(tls[i]); j++)
       data[j] = 1 + j + i * 10;
   }
@@ -342,7 +342,7 @@ TEST(MTTransformAttr, MTInput_ErrorSize) {
   int N = tls.num_samples();;
   MTinp->Resize(tls, DALI_FLOAT);
   for (int i = 0; i < N; i++) {
-    auto *data = (*MTinp)[i].mutable_data<float>();
+    auto *data = MTinp->mutable_tensor<float>(i);
     for (int j = 0; j < volume(tls[i]); j++)
       data[j] = 1 + j + i * 10;
   }

--- a/dali/operators/image/convolution/laplacian.cc
+++ b/dali/operators/image/convolution/laplacian.cc
@@ -141,10 +141,10 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
     kmgr_.template Resize<Kernel>(nsamples);
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
       // We take only last `ndim` siginificant dimensions to handle sequences as well
-      auto elem_shape = input[sample_idx].shape().template last<ndim>();
+      auto elem_shape = input.shape()[sample_idx].template last<ndim>();
       kmgr_.Setup<Kernel>(sample_idx, ctx_, elem_shape, args.GetWindowSizes(sample_idx));
       // The shape of data stays untouched
-      output_desc[0].shape.set_tensor_shape(sample_idx, input[sample_idx].shape());
+      output_desc[0].shape.set_tensor_shape(sample_idx, input.tensor_shape(sample_idx));
     }
     return true;
   }
@@ -158,7 +158,7 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
     int nsamples = input.shape().num_samples();
 
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
-      const auto& shape = input[sample_idx].shape();
+      const auto& shape = input.tensor_shape(sample_idx);
       auto elem_volume = volume(shape.begin() + dim_desc_.usable_axes_start, shape.end());
       auto priority = elem_volume * args.GetTotalWindowSizes(sample_idx);
       int seq_elements = volume(shape.begin(), shape.begin() + dim_desc_.usable_axes_start);
@@ -170,9 +170,9 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
               const auto& scales = args.GetScales(sample_idx);
               auto elem_shape = input[sample_idx].shape().template last<ndim>();
               auto in_view = TensorView<StorageCPU, const In, ndim>{
-                  input[sample_idx].template data<In>() + stride * elem_idx, elem_shape};
+                  input.template tensor<In>(sample_idx) + stride * elem_idx, elem_shape};
               auto out_view = TensorView<StorageCPU, Out, ndim>{
-                  output[sample_idx].template mutable_data<Out>() + stride * elem_idx, elem_shape};
+                  output.template mutable_tensor<Out>(sample_idx) + stride * elem_idx, elem_shape};
               // Copy context so that the kernel instance can modify scratchpad
               auto ctx = ctx_;
               kmgr_.Run<Kernel>(sample_idx, ctx, out_view, in_view, windows_[sample_idx],

--- a/dali/operators/image/distortion/jpeg_compression_distortion_op_gpu.cu
+++ b/dali/operators/image/distortion/jpeg_compression_distortion_op_gpu.cu
@@ -71,7 +71,7 @@ void JpegCompressionDistortionGPU::RunImpl(workspace_t<GPUBackend> &ws) {
   // Set quality argument for an image from samples
   if (is_sequence) {
     for (int i = 0; i < nsamples; i++) {
-      auto nframes = input.tensor_shape_span(i)[0];
+      auto nframes = input.shape().tensor_shape_span(i)[0];
       for (int j = 0; j < nframes; ++j) {
         quality_.push_back(quality_arg_[i].data[0]);
       }

--- a/dali/operators/image/distortion/jpeg_compression_distortion_op_gpu.cu
+++ b/dali/operators/image/distortion/jpeg_compression_distortion_op_gpu.cu
@@ -70,8 +70,9 @@ void JpegCompressionDistortionGPU::RunImpl(workspace_t<GPUBackend> &ws) {
 
   // Set quality argument for an image from samples
   if (is_sequence) {
+    const auto &in_shape = input.shape();
     for (int i = 0; i < nsamples; i++) {
-      auto nframes = input.shape().tensor_shape_span(i)[0];
+      int nframes = in_shape.tensor_shape_span(i)[0];
       for (int j = 0; j < nframes; ++j) {
         quality_.push_back(quality_arg_[i].data[0]);
       }

--- a/dali/operators/image/peek_shape/peek_image_shape.h
+++ b/dali/operators/image/peek_shape/peek_image_shape.h
@@ -75,16 +75,13 @@ class PeekImageShape : public Operator<CPUBackend> {
     const auto &input = ws.template Input<CPUBackend>(0);
     auto &output = ws.template Output<CPUBackend>(0);
     size_t batch_size = input.num_samples();
-    DALI_ENFORCE(input.type() == DALI_UINT8, "Input must be stored as uint8 data.");
+    DALI_ENFORCE(input.type() == DALI_UINT8,
+                 "The input must be raw, undecoded files stored as a flat uint8 arrays.");
+    DALI_ENFORCE(input.sample_dim() == 1, "Input must be 1D encoded jpeg string.");
 
     for (size_t sample_id = 0; sample_id < batch_size; ++sample_id) {
       thread_pool.AddWork([sample_id, &input, &output, this] (int tid) {
         const auto& image = input[sample_id];
-        // Verify input
-        // TODO(klecki): Move the checks to scope above
-        DALI_ENFORCE(image.shape().sample_dim() == 1,
-                      "Input must be 1D encoded jpeg string.");
-        DALI_ENFORCE(image.type() == DALI_UINT8, "Input must be stored as uint8 data.");
         auto img =
             ImageFactory::CreateImage(image._data<uint8>(), image.shape().num_elements(), {});
         auto shape = img->PeekShape();

--- a/dali/operators/image/peek_shape/peek_image_shape.h
+++ b/dali/operators/image/peek_shape/peek_image_shape.h
@@ -76,8 +76,8 @@ class PeekImageShape : public Operator<CPUBackend> {
     auto &output = ws.template Output<CPUBackend>(0);
     size_t batch_size = input.num_samples();
     DALI_ENFORCE(input.type() == DALI_UINT8,
-                 "The input must be raw, undecoded files stored as a flat uint8 arrays.");
-    DALI_ENFORCE(input.sample_dim() == 1, "Input must be 1D encoded jpeg string.");
+                 "The input must be a raw, undecoded file stored as a flat uint8 array.");
+    DALI_ENFORCE(input.sample_dim() == 1, "Input must be 1D encoded JPEG bit stream.");
 
     for (size_t sample_id = 0; sample_id < batch_size; ++sample_id) {
       thread_pool.AddWork([sample_id, &input, &output, this] (int tid) {

--- a/dali/operators/image/peek_shape/peek_image_shape.h
+++ b/dali/operators/image/peek_shape/peek_image_shape.h
@@ -83,7 +83,7 @@ class PeekImageShape : public Operator<CPUBackend> {
       thread_pool.AddWork([sample_id, &input, &output, this] (int tid) {
         const auto& image = input[sample_id];
         auto img =
-            ImageFactory::CreateImage(image._data<uint8>(), image.shape().num_elements(), {});
+            ImageFactory::CreateImage(image.data<uint8>(), image.shape().num_elements(), {});
         auto shape = img->PeekShape();
         TYPE_SWITCH(output_type_, type2id, type,
                 (int32_t, uint32_t, int64_t, uint64_t, float, double),

--- a/dali/operators/image/peek_shape/peek_image_shape.h
+++ b/dali/operators/image/peek_shape/peek_image_shape.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 #define DALI_OPERATORS_IMAGE_PEEK_SHAPE_PEEK_IMAGE_SHAPE_H_
 
 #include <vector>
+#include "dali/core/backend_tags.h"
 #include "dali/image/image_factory.h"
 #include "dali/core/tensor_shape.h"
+#include "dali/pipeline/data/types.h"
 #include "dali/pipeline/operator/operator.h"
 #include "dali/core/static_switch.h"
 
@@ -62,10 +64,9 @@ class PeekImageShape : public Operator<CPUBackend> {
   }
 
   template <typename type>
-  void WriteShape(Tensor<CPUBackend> &out, const TensorShape<3> &shape) {
-    type *data = out.mutable_data<type>();
+  void WriteShape(TensorView<StorageCPU, type, 1> out, const TensorShape<3> &shape) {
     for (int i = 0; i < 3; ++i) {
-      data[i] = shape[i];
+      out.data[i] = shape[i];
     }
   }
 
@@ -74,20 +75,22 @@ class PeekImageShape : public Operator<CPUBackend> {
     const auto &input = ws.template Input<CPUBackend>(0);
     auto &output = ws.template Output<CPUBackend>(0);
     size_t batch_size = input.num_samples();
+    DALI_ENFORCE(input.type() == DALI_UINT8, "Input must be stored as uint8 data.");
 
     for (size_t sample_id = 0; sample_id < batch_size; ++sample_id) {
       thread_pool.AddWork([sample_id, &input, &output, this] (int tid) {
         const auto& image = input[sample_id];
         // Verify input
-        DALI_ENFORCE(image.ndim() == 1,
+        // TODO(klecki): Move the checks to scope above
+        DALI_ENFORCE(image.shape().sample_dim() == 1,
                       "Input must be 1D encoded jpeg string.");
-        DALI_ENFORCE(IsType<uint8>(image.type()),
-                      "Input must be stored as uint8 data.");
-        auto img = ImageFactory::CreateImage(image.data<uint8>(), image.size(), {});
+        DALI_ENFORCE(image.type() == DALI_UINT8, "Input must be stored as uint8 data.");
+        auto img =
+            ImageFactory::CreateImage(image._data<uint8>(), image.shape().num_elements(), {});
         auto shape = img->PeekShape();
         TYPE_SWITCH(output_type_, type2id, type,
                 (int32_t, uint32_t, int64_t, uint64_t, float, double),
-          (WriteShape<type>(output[sample_id], shape);),
+          (WriteShape(view<type, 1>(output[sample_id]), shape);),
           (DALI_FAIL(make_string("Unsupported type for Shapes: ", output_type_))));
       }, 0);
       // the amount of work depends on the image format and exact sample which is unknown here

--- a/dali/operators/image/remap/displacement_filter_impl_gpu.cuh
+++ b/dali/operators/image/remap/displacement_filter_impl_gpu.cuh
@@ -325,7 +325,7 @@ class DisplacementFilter<GPUBackend, Displacement,
       sample.input = input.template tensor<T>(sample_idx);
       sample.raw_params = GetDisplacementParams(sample_idx);
       sample.shape = shape.tensor_shape<nDims>(sample_idx);
-      sample.mask = has_mask_ ? (ws.ArgumentInput("mask").tensor<int>(sample_idx))[0] : true;
+      sample.mask = has_mask_ ? ws.ArgumentInput("mask").tensor<int>(sample_idx)[0] : true;
     }
 
     samples_dev_.from_host(samples_, stream);

--- a/dali/operators/image/remap/displacement_filter_impl_gpu.cuh
+++ b/dali/operators/image/remap/displacement_filter_impl_gpu.cuh
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -325,7 +325,7 @@ class DisplacementFilter<GPUBackend, Displacement,
       sample.input = input.template tensor<T>(sample_idx);
       sample.raw_params = GetDisplacementParams(sample_idx);
       sample.shape = shape.tensor_shape<nDims>(sample_idx);
-      sample.mask = has_mask_ ? ws.ArgumentInput("mask")[sample_idx].data<int>()[0] : true;
+      sample.mask = has_mask_ ? (ws.ArgumentInput("mask").tensor<int>(sample_idx))[0] : true;
     }
 
     samples_dev_.from_host(samples_, stream);

--- a/dali/operators/image/remap/warp_affine_params.h
+++ b/dali/operators/image/remap/warp_affine_params.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -139,9 +139,9 @@ class WarpAffineParamProvider
     auto *params = this->template AllocParams<mm::memory_kind::host>();
     for (int i = 0; i < num_samples_; i++) {
       if (invert) {
-        params[i] = static_cast<const MappingParams *>(input[i].raw_data())->inv();
+        params[i] = static_cast<const MappingParams *>(input.raw_tensor(i))->inv();
       } else {
-        params[i] = *static_cast<const MappingParams *>(input[i].raw_data());
+        params[i] = *static_cast<const MappingParams *>(input.raw_tensor(i));
       }
     }
 }

--- a/dali/operators/image/remap/warp_param_provider.h
+++ b/dali/operators/image/remap/warp_param_provider.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ class InterpTypeProvider {
         "interp_type must be a single value or contain one value per sample");
       interp_types_.resize(n);
       for (int i = 0; i < n; i++)
-        interp_types_[i] = tensor_vector[i].data<DALIInterpType>()[0];
+        interp_types_[i] = tensor_vector.tensor<DALIInterpType>(i)[0];
     } else {
       interp_types_.resize(1, spec.template GetArgument<DALIInterpType>("interp_type"));
     }

--- a/dali/operators/math/expressions/expression_impl_factory.h
+++ b/dali/operators/math/expressions/expression_impl_factory.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -130,7 +130,7 @@ struct ExprImplTask {
 };
 
 inline OutputSamplePtr GetOutputSamplePointer(HostWorkspace &ws, int output_idx, int sample_idx) {
-  return ws.template Output<CPUBackend>(output_idx)[sample_idx].raw_mutable_data();
+  return ws.template Output<CPUBackend>(output_idx).raw_mutable_tensor(sample_idx);
 }
 
 inline OutputSamplePtr GetOutputSamplePointer(DeviceWorkspace &ws, int output_idx, int sample_idx) {
@@ -138,7 +138,7 @@ inline OutputSamplePtr GetOutputSamplePointer(DeviceWorkspace &ws, int output_id
 }
 
 inline InputSamplePtr GetInputSamplePointer(HostWorkspace &ws, int input_idx, int sample_idx) {
-  return ws.template Input<CPUBackend>(input_idx)[sample_idx].raw_data();
+  return ws.template Input<CPUBackend>(input_idx).raw_tensor(sample_idx);
 }
 
 inline InputSamplePtr GetInputSamplePointer(DeviceWorkspace &ws, int input_idx, int sample_idx) {

--- a/dali/operators/numba_function/numba_func.cc
+++ b/dali/operators/numba_function/numba_func.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -260,13 +260,13 @@ void NumbaFuncImpl<CPUBackend>::RunImpl(workspace_t<CPUBackend> &ws) {
   for (size_t out_id = 0; out_id < out_types_.size(); out_id++) {
     auto& out = ws.Output<CPUBackend>(out_id);
     for (int i = 0; i < N; i++) {
-      out_ptrs[N * out_id + i] = reinterpret_cast<uint64_t>(out[i].raw_mutable_data());
+      out_ptrs[N * out_id + i] = reinterpret_cast<uint64_t>(out.raw_mutable_tensor(i));
     }
   }
   for (size_t in_id = 0; in_id < in_types_.size(); in_id++) {
     auto& in = ws.Input<CPUBackend>(in_id);
     for (int i = 0; i < N; i++) {
-      in_ptrs[N * in_id + i] = reinterpret_cast<uint64_t>(in[i].raw_data());
+      in_ptrs[N * in_id + i] = reinterpret_cast<uint64_t>(in.raw_tensor(i));
     }
   }
 

--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -77,9 +77,9 @@ py::list PrepareDLTensorInputs<CPUBackend>(HostWorkspace &ws) {
   py::list input_tuple;
   for (Index idx = 0; idx < ws.NumInput(); ++idx) {
     py::list dl_tensor_list;
+    auto &tvec = ws.UnsafeMutableInput<CPUBackend>(idx);
     for (Index i = 0; i < ws.GetInputBatchSize(idx); ++i) {
-      auto &t = ws.UnsafeMutableInput<CPUBackend>(idx)[i];
-      auto dl_capsule = TensorToDLPackView(t);
+      auto dl_capsule = TensorToDLPackView(tvec[i], tvec.device_id());
       dl_tensor_list.append(dl_capsule);
     }
     input_tuple.append(dl_tensor_list);
@@ -106,8 +106,8 @@ py::list PrepareDLTensorInputsPerSample<CPUBackend>(HostWorkspace &ws) {
   for (Index s = 0; s < batch_size; ++s) {
     py::list tuple;
     for (Index idx = 0; idx < ws.NumInput(); ++idx) {
-      auto &t = ws.UnsafeMutableInput<CPUBackend>(idx)[s];
-      auto dl_capsule = TensorToDLPackView(t);
+      auto &tvec = ws.UnsafeMutableInput<CPUBackend>(idx);
+      auto dl_capsule = TensorToDLPackView(tvec[s], tvec.device_id());
       tuple.append(dl_capsule);
     }
     input_tuples.append(tuple);
@@ -148,7 +148,7 @@ void CopyOutputData(TensorVector<CPUBackend> &output, std::vector<DLMTensorPtr> 
   auto out_shape = output.shape();
   for (int i = 0; i < batch_size; ++i) {
     thread_pool.AddWork([&, i](int) {
-      CopyDlTensor<CPUBackend>(output[i].raw_mutable_data(), dl_tensors[i]);
+      CopyDlTensor<CPUBackend>(output.raw_mutable_tensor(i), dl_tensors[i]);
     }, out_shape.tensor_size(i));
   }
   thread_pool.RunAll();

--- a/dali/operators/python_function/dltensor_function.cc
+++ b/dali/operators/python_function/dltensor_function.cc
@@ -77,9 +77,9 @@ py::list PrepareDLTensorInputs<CPUBackend>(HostWorkspace &ws) {
   py::list input_tuple;
   for (Index idx = 0; idx < ws.NumInput(); ++idx) {
     py::list dl_tensor_list;
-    auto &tvec = ws.UnsafeMutableInput<CPUBackend>(idx);
+    auto &input = ws.UnsafeMutableInput<CPUBackend>(idx);
     for (Index i = 0; i < ws.GetInputBatchSize(idx); ++i) {
-      auto dl_capsule = TensorToDLPackView(tvec[i], tvec.device_id());
+      auto dl_capsule = TensorToDLPackView(input[i], input.device_id());
       dl_tensor_list.append(dl_capsule);
     }
     input_tuple.append(dl_tensor_list);
@@ -91,8 +91,8 @@ template <>
 py::list PrepareDLTensorInputs<GPUBackend>(DeviceWorkspace &ws) {
   py::list input_tuple;
   for (Index idx = 0; idx < ws.NumInput(); ++idx) {
-    auto &tlist = ws.UnsafeMutableInput<GPUBackend>(idx);
-    py::list dl_tensor_list = TensorListToDLPackView(tlist);
+    auto &input = ws.UnsafeMutableInput<GPUBackend>(idx);
+    py::list dl_tensor_list = TensorListToDLPackView(input);
     input_tuple.append(dl_tensor_list);
   }
   return input_tuple;
@@ -106,8 +106,8 @@ py::list PrepareDLTensorInputsPerSample<CPUBackend>(HostWorkspace &ws) {
   for (Index s = 0; s < batch_size; ++s) {
     py::list tuple;
     for (Index idx = 0; idx < ws.NumInput(); ++idx) {
-      auto &tvec = ws.UnsafeMutableInput<CPUBackend>(idx);
-      auto dl_capsule = TensorToDLPackView(tvec[s], tvec.device_id());
+      auto &input = ws.UnsafeMutableInput<CPUBackend>(idx);
+      auto dl_capsule = TensorToDLPackView(input[s], input.device_id());
       tuple.append(dl_capsule);
     }
     input_tuples.append(tuple);

--- a/dali/operators/reader/loader/nemo_asr_loader.cc
+++ b/dali/operators/reader/loader/nemo_asr_loader.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@ void NemoAsrLoader::PrepareEmpty(AsrSample &sample) {
 }
 
 template <typename OutputType>
-void NemoAsrLoader::ReadAudio(Tensor<CPUBackend> &audio,
+void NemoAsrLoader::ReadAudio(SampleView<CPUBackend> audio,
                               const AudioMetadata &audio_meta,
                               const NemoAsrEntry &entry,
                               AudioDecoderBase &decoder,
@@ -170,7 +170,7 @@ void NemoAsrLoader::ReadSample(AsrSample& sample) {
 
   TYPE_SWITCH(dtype_, type2id, OutputType, (int16_t, int32_t, float), (
     // Audio decoding will be run in the prefetch function, once the batch is formed
-    sample.decode_f_ = [this, &sample, &entry, offset](Tensor<CPUBackend> &audio, int tid) {
+    sample.decode_f_ = [this, &sample, &entry, offset](SampleView<CPUBackend> audio, int tid) {
       sample.decoder().OpenFromFile(entry.audio_filepath);
       if (offset > 0)
         sample.decoder().SeekFrames(offset);

--- a/dali/operators/reader/loader/nemo_asr_loader.h
+++ b/dali/operators/reader/loader/nemo_asr_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ class AsrSample {
     return shape_;
   }
 
-  void decode_audio(Tensor<CPUBackend>& audio, int tid) {
+  void decode_audio(SampleView<CPUBackend> audio, int tid) {
     decode_f_(audio, tid);
   }
 
@@ -87,7 +87,7 @@ class AsrSample {
   std::string audio_filepath_;  // for tensor metadata purposes
   TensorShape<> shape_;
 
-  std::function<void(Tensor<CPUBackend>&, int)> decode_f_;
+  std::function<void(SampleView<CPUBackend>, int)> decode_f_;
   std::unique_ptr<AudioDecoderBase> decoder_;
 };
 
@@ -158,7 +158,7 @@ class DLL_PUBLIC NemoAsrLoader : public Loader<CPUBackend, AsrSample> {
 
  private:
   template <typename OutputType>
-  void ReadAudio(Tensor<CPUBackend> &audio,
+  void ReadAudio(SampleView<CPUBackend> audio,
                  const AudioMetadata &audio_meta,
                  const NemoAsrEntry &entry,
                  AudioDecoderBase &decoder,

--- a/dali/operators/reader/nemo_asr_reader_op.cc
+++ b/dali/operators/reader/nemo_asr_reader_op.cc
@@ -199,7 +199,7 @@ void NemoAsrReader::RunImpl(SampleWorkspace &ws) {
   audio.Resize(sample_audio.shape(), sample_audio.type());
   std::memcpy(
       audio.raw_mutable_data(), sample_audio.raw_data(),
-      sample_audio.shape().num_elements() * TypeTable::GetTypeInfo(sample_audio.type()).size());
+      sample_audio.shape().num_elements() * audio.type_info().size());
 
   DALIMeta meta;
   meta.SetSourceInfo(sample.audio_filepath());

--- a/dali/operators/reader/nemo_asr_reader_op.cc
+++ b/dali/operators/reader/nemo_asr_reader_op.cc
@@ -198,7 +198,7 @@ void NemoAsrReader::RunImpl(SampleWorkspace &ws) {
   auto &audio = ws.Output<CPUBackend>(0);
   audio.Resize(sample_audio.shape(), sample_audio.type());
   std::memcpy(
-      audio.raw_mutable_data(), sample_audio._raw_data(),
+      audio.raw_mutable_data(), sample_audio.raw_data(),
       sample_audio.shape().num_elements() * TypeTable::GetTypeInfo(sample_audio.type()).size());
 
   DALIMeta meta;

--- a/dali/operators/reader/nemo_asr_reader_op.h
+++ b/dali/operators/reader/nemo_asr_reader_op.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ class NemoAsrReader : public DataReader<CPUBackend, AsrSample> {
   void RunImpl(SampleWorkspace &ws) override;
 
  private:
-  Tensor<CPUBackend>& GetDecodedAudioSample(int sample_idx);
+  ConstSampleView<CPUBackend> GetDecodedAudioSample(int sample_idx);
 
   bool read_sr_;
   bool read_text_;

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -97,10 +97,10 @@ void NumpyReaderGPU::Prefetch() {
 
   const size_t kGDSChunkGranularity = 1<<20;
 
-  size_t chunk_size = align_up(div_ceil(static_cast<uint64_t>(curr_tensor_list.chunks_nbytes()),
+  size_t chunk_size = align_up(div_ceil(static_cast<uint64_t>(curr_tensor_list.nbytes()),
                                         static_cast<uint64_t>(thread_pool_.NumThreads())),
                                kGDSChunkGranularity);
-  chunk_size = std::min(chunk_size, curr_tensor_list.chunks_nbytes());
+  chunk_size = std::min(chunk_size, curr_tensor_list.nbytes());
 
   // read the data
   for (size_t data_idx = 0; data_idx < curr_tensor_list.num_samples(); ++data_idx) {

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -97,11 +97,10 @@ void NumpyReaderGPU::Prefetch() {
 
   const size_t kGDSChunkGranularity = 1<<20;
 
-  size_t chunk_size = align_up(div_ceil(static_cast<uint64_t>(curr_tensor_list.nbytes()),
+  size_t chunk_size = align_up(div_ceil(static_cast<uint64_t>(curr_tensor_list.total_nbytes()),
                                         static_cast<uint64_t>(thread_pool_.NumThreads())),
                                kGDSChunkGranularity);
-  chunk_size = std::min(chunk_size, curr_tensor_list.nbytes());
-
+  chunk_size = std::min(chunk_size, curr_tensor_list.total_nbytes());
 
   // read the data
   for (size_t data_idx = 0; data_idx < curr_tensor_list.num_samples(); ++data_idx) {

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -102,6 +102,7 @@ void NumpyReaderGPU::Prefetch() {
                                kGDSChunkGranularity);
   chunk_size = std::min(chunk_size, curr_tensor_list.nbytes());
 
+
   // read the data
   for (size_t data_idx = 0; data_idx < curr_tensor_list.num_samples(); ++data_idx) {
     curr_tensor_list.SetMeta(data_idx, curr_batch[data_idx]->get_meta());

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -97,10 +97,10 @@ void NumpyReaderGPU::Prefetch() {
 
   const size_t kGDSChunkGranularity = 1<<20;
 
-  size_t chunk_size = align_up(div_ceil(static_cast<uint64_t>(curr_tensor_list.total_nbytes()),
+  size_t chunk_size = align_up(div_ceil(static_cast<uint64_t>(curr_tensor_list.chunks_nbytes()),
                                         static_cast<uint64_t>(thread_pool_.NumThreads())),
                                kGDSChunkGranularity);
-  chunk_size = std::min(chunk_size, curr_tensor_list.total_nbytes());
+  chunk_size = std::min(chunk_size, curr_tensor_list.chunks_nbytes());
 
   // read the data
   for (size_t data_idx = 0; data_idx < curr_tensor_list.num_samples(); ++data_idx) {

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -26,8 +26,8 @@ namespace dali {
 
 static void CopyHelper(SampleView<CPUBackend> output, ConstSampleView<CPUBackend> input,
                        ThreadPool &thread_pool, int min_blk_sz, int req_nblocks) {
-  auto *out_ptr = static_cast<uint8_t *>(output._raw_mutable_data());
-  const auto *in_ptr = static_cast<const uint8_t *>(input._raw_data());
+  auto *out_ptr = static_cast<uint8_t *>(output.raw_mutable_data());
+  const auto *in_ptr = static_cast<const uint8_t *>(input.raw_data());
   auto nelements = input.shape().num_elements();
   auto nbytes = nelements * TypeTable::GetTypeInfo(input.type()).size();
   if (nelements <= min_blk_sz) {

--- a/dali/operators/reader/numpy_reader_op.cc
+++ b/dali/operators/reader/numpy_reader_op.cc
@@ -14,20 +14,22 @@
 
 #include <string>
 
+#include "dali/core/backend_tags.h"
 #include "dali/kernels/slice/slice_cpu.h"
 #include "dali/kernels/slice/slice_flip_normalize_permute_pad_cpu.h"
 #include "dali/kernels/transpose/transpose.h"
 #include "dali/core/static_switch.h"
 #include "dali/operators/reader/numpy_reader_op.h"
+#include "dali/pipeline/data/backend.h"
 
 namespace dali {
 
-static void CopyHelper(Tensor<CPUBackend> &output, const Tensor<CPUBackend> &input,
+static void CopyHelper(SampleView<CPUBackend> output, ConstSampleView<CPUBackend> input,
                        ThreadPool &thread_pool, int min_blk_sz, int req_nblocks) {
-  auto out_ptr = static_cast<uint8_t*>(output.raw_mutable_data());
-  auto in_ptr = static_cast<const uint8_t*>(input.raw_data());
-  auto nelements = volume(input.shape());
-  auto nbytes = input.nbytes();
+  auto *out_ptr = static_cast<uint8_t *>(output._raw_mutable_data());
+  const auto *in_ptr = static_cast<const uint8_t *>(input._raw_data());
+  auto nelements = input.shape().num_elements();
+  auto nbytes = nelements * TypeTable::GetTypeInfo(input.type()).size();
   if (nelements <= min_blk_sz) {
     thread_pool.AddWork([=](int tid) {
       std::memcpy(out_ptr, in_ptr, nbytes);
@@ -45,7 +47,7 @@ static void CopyHelper(Tensor<CPUBackend> &output, const Tensor<CPUBackend> &inp
   }
 }
 
-static void TransposeHelper(Tensor<CPUBackend> &output, const Tensor<CPUBackend> &input) {
+static void TransposeHelper(SampleView<CPUBackend> output, ConstSampleView<CPUBackend> input) {
   int n_dims = input.shape().sample_dim();
   SmallVector<int, 6> perm;
   perm.resize(n_dims);
@@ -56,7 +58,7 @@ static void TransposeHelper(Tensor<CPUBackend> &output, const Tensor<CPUBackend>
   ), DALI_FAIL(make_string("Unsupported input type: ", input.type())));  // NOLINT
 }
 
-static void SliceHelper(Tensor<CPUBackend> &output, const Tensor<CPUBackend> &input,
+static void SliceHelper(SampleView<CPUBackend> output, ConstSampleView<CPUBackend> input,
                         const CropWindow &roi, float fill_value, ThreadPool &thread_pool,
                         int min_blk_sz, int req_nblocks) {
   int ndim = input.shape().sample_dim();
@@ -77,7 +79,7 @@ static void SliceHelper(Tensor<CPUBackend> &output, const Tensor<CPUBackend> &in
   ), DALI_FAIL(make_string("Unsupported number of dimensions: ", ndim)););  // NOLINT
 }
 
-static void SlicePermuteHelper(Tensor<CPUBackend> &output, const Tensor<CPUBackend> &input,
+static void SlicePermuteHelper(SampleView<CPUBackend> output, ConstSampleView<CPUBackend> input,
                                const CropWindow &roi, float fill_value, ThreadPool &thread_pool,
                                int min_blk_sz, int req_nblocks) {
   const auto &in_shape = input.shape();
@@ -245,19 +247,20 @@ void NumpyReaderCPU::RunImpl(HostWorkspace &ws) {
     const auto& file_i = GetSample(i);
     const auto& file_sh = file_i.get_shape();
     int64_t sample_sz = volume(file_i.get_shape());
+    auto input_sample = const_sample_view(file_i.data);
     if (need_slice_[i] && need_transpose_[i]) {
-      SlicePermuteHelper(output[i], file_i.data, rois_[i], fill_value_, thread_pool, kThreshold,
+      SlicePermuteHelper(output[i], input_sample, rois_[i], fill_value_, thread_pool, kThreshold,
                          blocks_per_sample);
     } else if (need_slice_[i]) {
-      SliceHelper(output[i], file_i.data, rois_[i], fill_value_, thread_pool, kThreshold,
+      SliceHelper(output[i], input_sample, rois_[i], fill_value_, thread_pool, kThreshold,
                   blocks_per_sample);
     } else if (need_transpose_[i]) {
       // TODO(janton): Parallelize when Transpose supports tiling
-      thread_pool.AddWork([&, i](int tid) {
-        TransposeHelper(output[i], file_i.data);
+      thread_pool.AddWork([&, i, input_sample](int tid) {
+        TransposeHelper(output[i], input_sample);
       }, sample_sz * 8);  // 8 x (heuristic)
     } else {
-      CopyHelper(output[i], file_i.data, thread_pool, kThreshold, blocks_per_sample);
+      CopyHelper(output[i], input_sample, thread_pool, kThreshold, blocks_per_sample);
     }
   }
   thread_pool.RunAll();

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -47,7 +47,7 @@ void VideoReader::Prefetch() {
     auto &sample = curr_batch[data_idx];
     // TODO(klecki): Rework this with proper sample-based tensor batch data structure
     auto sample_shared_ptr = unsafe_sample_owner(curr_tensor_list, data_idx);
-    sample->sequence.ShareData(sample_shared_ptr, curr_tensor_list.total_capacity(),
+    sample->sequence.ShareData(sample_shared_ptr, curr_tensor_list.capacity(),
                                curr_tensor_list.is_pinned(), curr_tensor_list.shape()[data_idx],
                                curr_tensor_list.type(), curr_tensor_list.order());
     sample->sequence.set_device_id(curr_tensor_list.device_id());

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -47,7 +47,7 @@ void VideoReader::Prefetch() {
     auto &sample = curr_batch[data_idx];
     // TODO(klecki): Rework this with proper sample-based tensor batch data structure
     auto sample_shared_ptr = unsafe_sample_owner(curr_tensor_list, data_idx);
-    sample->sequence.ShareData(sample_shared_ptr, curr_tensor_list.capacity(),
+    sample->sequence.ShareData(sample_shared_ptr, curr_tensor_list.total_capacity(),
                                curr_tensor_list.is_pinned(), curr_tensor_list.shape()[data_idx],
                                curr_tensor_list.type(), curr_tensor_list.order());
     sample->sequence.set_device_id(curr_tensor_list.device_id());

--- a/dali/operators/reader/webdataset_reader_op.cc
+++ b/dali/operators/reader/webdataset_reader_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,8 +52,8 @@ void WebdatasetReader::RunImpl(HostWorkspace& ws) {
       auto& sample = GetSample(data_idx);
       ThreadPool::Work copy_task = [output_idx = output_idx, data_idx = data_idx, &output,
                                     &sample](int) {
-        output[data_idx].SetMeta(sample[output_idx].GetMeta());
-        std::memcpy(output[data_idx].raw_mutable_data(), sample[output_idx].raw_data(),
+        output.SetMeta(data_idx, sample[output_idx].GetMeta());
+        std::memcpy(output.raw_mutable_tensor(data_idx), sample[output_idx].raw_data(),
                     sample[output_idx].nbytes());
       };
       if (threaded) {

--- a/dali/operators/segmentation/random_object_bbox.cc
+++ b/dali/operators/segmentation/random_object_bbox.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -521,9 +521,9 @@ bool RandomObjectBBox::PickForegroundBox(
 template <typename BlobLabel>
 bool RandomObjectBBox::PickForegroundBox(SampleContext<BlobLabel> &context) {
   bool ret = false;
-  TYPE_SWITCH(context.input->type(), type2id, T, INPUT_TYPES,
-    (ret = PickForegroundBox(context, view<const T>(*context.input));),
-    (DALI_FAIL(make_string("Unsupported input type: ", context.input->type())))
+  TYPE_SWITCH(context.input.type(), type2id, T, INPUT_TYPES,
+    (ret = PickForegroundBox(context, view<const T>(context.input));),
+    (DALI_FAIL(make_string("Unsupported input type: ", context.input.type())))
   );  // NOLINT
   return ret;
 }
@@ -533,7 +533,7 @@ void RandomObjectBBox::AllocateTempStorage(const TensorVector<CPUBackend> &input
   int64_t max_filtered_bytes = 0;
   int N = input.num_samples();
   for (int i = 0; i < N; i++) {
-    int64_t vol = input[i].size();
+    int64_t vol = input[i].shape().num_elements();
     int label_size = vol > 0x80000000 ? 8 : 4;
     int64_t blob_bytes = vol * label_size;
     if (blob_bytes > max_blob_bytes)
@@ -592,10 +592,10 @@ void RandomObjectBBox::RunImpl(HostWorkspace &ws) {
       // We want to limit the size of this auxiliary storage to limit memory traffic.
       // To that end, when the indices fit in int32_t, we use that type for the labels,
       // otherwise we fall back to int64_t.
-      auto blob_label = (input[i].size() > 0x80000000) ? DALI_INT64 : DALI_INT32;
+      auto blob_label = (input[i].shape().num_elements() > 0x80000000) ? DALI_INT64 : DALI_INT32;
       TYPE_SWITCH(blob_label, type2id, BlobLabel, (int32_t, int64_t), (
         auto &ctx = GetContext(BlobLabel());
-        ctx.Init(i, &input[i], &tp, tmp_filtered_storage_, tmp_blob_storage_);
+        ctx.Init(i, input[i], &tp, tmp_filtered_storage_, tmp_blob_storage_);
         ctx.out1 = out1[i];
         if (out2.num_samples() > 0)
           ctx.out2 = out2[i];

--- a/dali/operators/segmentation/random_object_bbox.h
+++ b/dali/operators/segmentation/random_object_bbox.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -175,12 +175,12 @@ class RandomObjectBBox : public Operator<CPUBackend> {
 
   template <typename BlobLabel>
   struct SampleContext {
-    void Init(int sample_idx, const Tensor<CPUBackend> *in, ThreadPool *tp,
+    void Init(int sample_idx, ConstSampleView<CPUBackend> in, ThreadPool *tp,
               Tensor<CPUBackend> &tmp_filtered, Tensor<CPUBackend> &tmp_blob) {
       this->sample_idx = sample_idx;
       thread_pool = tp;
       input = in;
-      auto &shape = input->shape();
+      auto &shape = input.shape();
       tmp_filtered.Resize(shape, DALI_UINT8);
       tmp_blob.Resize(shape, TypeTable::GetTypeId<BlobLabel>());
       filtered = view<uint8_t>(tmp_filtered);
@@ -192,7 +192,7 @@ class RandomObjectBBox : public Operator<CPUBackend> {
 
     ThreadPool *thread_pool = nullptr;
     TensorView<StorageCPU, int> out1, out2;
-    const Tensor<CPUBackend> *input = nullptr;
+    ConstSampleView<CPUBackend> input = {};
 
     int sample_idx;
     int class_idx;

--- a/dali/operators/segmentation/random_object_bbox.h
+++ b/dali/operators/segmentation/random_object_bbox.h
@@ -192,7 +192,7 @@ class RandomObjectBBox : public Operator<CPUBackend> {
 
     ThreadPool *thread_pool = nullptr;
     TensorView<StorageCPU, int> out1, out2;
-    ConstSampleView<CPUBackend> input = {};
+    ConstSampleView<CPUBackend> input;
 
     int sample_idx;
     int class_idx;

--- a/dali/operators/sequence/sequence_rearrange.cc
+++ b/dali/operators/sequence/sequence_rearrange.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -79,9 +79,9 @@ void SequenceRearrange<CPUBackend>::RunImpl(workspace_t<CPUBackend> &ws) {
   for (int sample_idx = 0; sample_idx < curr_batch_size; ++sample_idx) {
     thread_pool.AddWork([this, &ws, &input, &output, sample_idx](int tid) {
       const TypeInfo &type = input.type_info();
-      const auto *in_sample = reinterpret_cast<const char *>(input[sample_idx].raw_data());
-      auto *out_sample = reinterpret_cast<char *>(output[sample_idx].raw_mutable_data());
-      const auto &in_shape = input[sample_idx].shape();
+      const auto *in_sample = reinterpret_cast<const char *>(input.raw_tensor(sample_idx));
+      auto *out_sample = reinterpret_cast<char *>(output.raw_mutable_tensor(sample_idx));
+      const auto &in_shape = input.tensor_shape(sample_idx);
       auto element_sizeof = volume(in_shape.last(in_shape.sample_dim() - 1)) * type.size();
 
       TensorView<StorageCPU, const int, 1> new_order = {};

--- a/dali/operators/signal/fft/spectrogram.cc
+++ b/dali/operators/signal/fft/spectrogram.cc
@@ -227,8 +227,8 @@ bool SpectrogramImplCpu<time_major>::SetupImpl(std::vector<OutputDesc> &out_desc
 
   auto view_window_fn = make_tensor_cpu<1>(window_fn_.data(), window_length_);
   for (int i = 0; i < nsamples; i++) {
-    auto view_signal_1d =
-        make_tensor_cpu<1>(input[i].template data<const InputType>(), {input[i].size()});
+    auto view_signal_1d = make_tensor_cpu<1>(input.template tensor<const InputType>(i),
+                                             {input.tensor_shape(i).num_elements()});
 
     auto &windows_req =
       kmgr_window_.Setup<WindowKernel>(
@@ -269,8 +269,8 @@ void SpectrogramImplCpu<time_major>::RunImpl(workspace_t<CPUBackend> &ws) {
         win_out.set_type<InputType>();
         win_out.Resize(window_out_desc_[0].shape.tensor_shape(i));
 
-        auto view_signal_1d =
-            make_tensor_cpu<1>(input[i].data<const InputType>(), {input[i].size()});
+        auto view_signal_1d = make_tensor_cpu<1>(input.tensor<const InputType>(i),
+                                                 {input.tensor_shape(i).num_elements()});
         kmgr_window_.Run<WindowKernel>(
           i, ctx,
           view<InputType, WindowsDims>(win_out),

--- a/dali/operators/util/property.cc
+++ b/dali/operators/util/property.cc
@@ -24,7 +24,7 @@ void SourceInfo<CPUBackend>::FillOutput(workspace_t<CPUBackend>& ws) {
   auto& output = ws.template Output<CPUBackend>(0);
   for (size_t sample_id = 0; sample_id < input.num_samples(); sample_id++) {
     auto si = GetSourceInfo(input, sample_id);
-    output[sample_id].Copy(make_cspan((const uint8_t*)si.c_str(), si.length()));
+    std::memcpy(output.mutable_tensor<uint8_t>(sample_id), si.c_str(), si.length());
   }
 }
 
@@ -34,8 +34,7 @@ void Layout<CPUBackend>::FillOutput(workspace_t<CPUBackend>& ws) {
   auto& output = ws.template Output<CPUBackend>(0);
   for (size_t sample_id = 0; sample_id < input.num_samples(); sample_id++) {
     auto layout = GetLayout(input, sample_id);
-    output[sample_id].Copy(
-        make_cspan(reinterpret_cast<const uint8_t*>(layout.c_str()), layout.size()));
+    std::memcpy(output.mutable_tensor<uint8_t>(sample_id), layout.c_str(), layout.size());
   }
 }
 

--- a/dali/operators/util/property.h
+++ b/dali/operators/util/property.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ namespace tensor_property {
 namespace detail {
 
 inline const DALIMeta& GetMeta(const TensorVector<CPUBackend>& batch, int tensor_idx) {
-  return batch[tensor_idx].GetMeta();
+  return batch.GetMeta(tensor_idx);
 }
 
 inline const DALIMeta& GetMeta(const TensorList<GPUBackend>& batch, int tensor_idx) {

--- a/dali/pipeline/data/dltensor.h
+++ b/dali/pipeline/data/dltensor.h
@@ -51,7 +51,7 @@ DLL_PUBLIC DLMTensorPtr MakeDLTensor(void *data, DALIDataType type,
 
 template <typename Backend>
 DLMTensorPtr GetDLTensorView(SampleView<Backend> tensor, int device_id) {
-  return MakeDLTensor(tensor._raw_mutable_data(),
+  return MakeDLTensor(tensor.raw_mutable_data(),
                       tensor.type(),
                       std::is_same<Backend, GPUBackend>::value,
                       device_id,

--- a/dali/pipeline/data/dltensor.h
+++ b/dali/pipeline/data/dltensor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
 #define DALI_PIPELINE_DATA_DLTENSOR_H_
 
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 #include "third_party/dlpack/include/dlpack/dlpack.h"
-#include "dali/pipeline/data/tensor.h"
+
+#include "dali/pipeline/data/sample_view.h"
+#include "dali/pipeline/data/tensor_list.h"
 
 namespace dali {
 
@@ -48,11 +50,11 @@ DLL_PUBLIC DLMTensorPtr MakeDLTensor(void *data, DALIDataType type,
                                      std::unique_ptr<DLTensorResource> resource);
 
 template <typename Backend>
-DLMTensorPtr GetDLTensorView(Tensor<Backend> &tensor) {
-  return MakeDLTensor(tensor.raw_mutable_data(),
+DLMTensorPtr GetDLTensorView(SampleView<Backend> tensor, int device_id) {
+  return MakeDLTensor(tensor._raw_mutable_data(),
                       tensor.type(),
                       std::is_same<Backend, GPUBackend>::value,
-                      tensor.device_id(),
+                      device_id,
                       std::make_unique<DLTensorResource>(tensor.shape()));
 }
 

--- a/dali/pipeline/data/dltensor_test.cc
+++ b/dali/pipeline/data/dltensor_test.cc
@@ -31,7 +31,7 @@ TEST(DLMTensorPtr, CPU) {
   ASSERT_EQ(dlm_tensor->dl_tensor.shape[0], 100);
   ASSERT_EQ(dlm_tensor->dl_tensor.shape[1], 50);
   ASSERT_EQ(dlm_tensor->dl_tensor.shape[2], 3);
-  ASSERT_EQ(dlm_tensor->dl_tensor.data, sv._raw_data());
+  ASSERT_EQ(dlm_tensor->dl_tensor.data, sv.raw_data());
   ASSERT_EQ(dlm_tensor->dl_tensor.dtype.code, kDLFloat);
   ASSERT_EQ(dlm_tensor->dl_tensor.dtype.bits, sizeof(float) * 8);
   ASSERT_EQ(dlm_tensor->dl_tensor.device.device_type, kDLCPU);
@@ -47,7 +47,7 @@ TEST(DLMTensorPtr, GPU) {
   ASSERT_EQ(dlm_tensor->dl_tensor.shape[0], 100);
   ASSERT_EQ(dlm_tensor->dl_tensor.shape[1], 50);
   ASSERT_EQ(dlm_tensor->dl_tensor.shape[2], 1);
-  ASSERT_EQ(dlm_tensor->dl_tensor.data, sv._raw_data());
+  ASSERT_EQ(dlm_tensor->dl_tensor.data, sv.raw_data());
   ASSERT_EQ(dlm_tensor->dl_tensor.dtype.code, kDLInt);
   ASSERT_EQ(dlm_tensor->dl_tensor.dtype.bits, sizeof(int) * 8);
   ASSERT_EQ(dlm_tensor->dl_tensor.device.device_type, kDLCUDA);

--- a/dali/pipeline/data/dltensor_test.cc
+++ b/dali/pipeline/data/dltensor_test.cc
@@ -14,7 +14,6 @@
 
 #include <gtest/gtest.h>
 #include <utility>
-
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/dltensor.h"
 #include "dali/pipeline/data/sample_view.h"

--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -144,6 +144,7 @@ class SampleViewBase {
   ptr_t data_ = nullptr;
   TensorShape<> shape_ = {0};
   DALIDataType type_id_ = DALI_NO_TYPE;
+  ~SampleViewBase() = default;
 };
 
 
@@ -166,7 +167,7 @@ class ConstSampleView : public SampleViewBase<Backend, const void *> {
   using Base = SampleViewBase<Backend, const void *>;
   using Base::Base;
 
-  explicit ConstSampleView(const SampleView<Backend> &other)
+  ConstSampleView(const SampleView<Backend> &other)  // NOLINT
       : Base(other._raw_data(), other.shape(), other.type()) {}
 
   ConstSampleView &operator=(const SampleView<Backend> &other) {

--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -44,14 +44,14 @@ class SampleViewBase {
    * @brief Return an un-typed pointer to the underlying storage.
    */
   template <typename ptr_t_ = ptr_t>
-  std::enable_if_t<std::is_same<ptr_t_, void *>::value, void *> _raw_mutable_data() {
+  std::enable_if_t<std::is_same<ptr_t_, void *>::value, void *> raw_mutable_data() {
     return data_;
   }
 
   /**
    * @brief Return a const, un-typed pointer to the underlying storage.
    */
-  const void *_raw_data() const {
+  const void *raw_data() const {
     return data_;
   }
 
@@ -60,7 +60,7 @@ class SampleViewBase {
    * The calling type must match the underlying type of the buffer.
    */
   template <typename T, typename ptr_t_ = ptr_t>
-  inline std::enable_if_t<std::is_same<ptr_t_, void *>::value, T *> _mutable_data() {
+  inline std::enable_if_t<std::is_same<ptr_t_, void *>::value, T *> mutable_data() {
     DALI_ENFORCE(
         type() == TypeTable::GetTypeId<T>(),
         make_string(
@@ -75,7 +75,7 @@ class SampleViewBase {
    * The calling type must match the underlying type of the buffer.
    */
   template <typename T>
-  inline const T *_data() const {
+  inline const T *data() const {
     DALI_ENFORCE(
         type() == TypeTable::GetTypeId<T>(),
         make_string(
@@ -168,10 +168,10 @@ class ConstSampleView : public SampleViewBase<Backend, const void *> {
   using Base::Base;
 
   ConstSampleView(const SampleView<Backend> &other)  // NOLINT
-      : Base(other._raw_data(), other.shape(), other.type()) {}
+      : Base(other.raw_data(), other.shape(), other.type()) {}
 
   ConstSampleView &operator=(const SampleView<Backend> &other) {
-    data_ = other._raw_data();
+    data_ = other.raw_data();
     shape_ = other.shape();
     type_id_ = other.type();
     return *this;

--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -33,8 +33,8 @@ namespace dali {
  * convenient `view<T, ndim>(SampleView)` conversion to TensorView, but doesn't break the batch
  * object encapsulation and doesn't allow to adjust the allocation.
  */
-template <typename Backend>
-class SampleView {
+template <typename Backend, typename ptr_t>
+class SampleViewBase {
  public:
   /**
    * @name Get the underlying pointer to data
@@ -43,14 +43,15 @@ class SampleView {
   /**
    * @brief Return an un-typed pointer to the underlying storage.
    */
-  void *raw_mutable_data() {
+  template <typename ptr_t_ = ptr_t>
+  std::enable_if_t<std::is_same<ptr_t_, void *>::value, void *> _raw_mutable_data() {
     return data_;
   }
 
   /**
    * @brief Return a const, un-typed pointer to the underlying storage.
    */
-  const void *raw_data() const {
+  const void *_raw_data() const {
     return data_;
   }
 
@@ -58,8 +59,8 @@ class SampleView {
    * @brief Returns a typed pointer to the underlying storage.
    * The calling type must match the underlying type of the buffer.
    */
-  template <typename T>
-  inline T *mutable_data() {
+  template <typename T, typename ptr_t_ = ptr_t>
+  inline std::enable_if_t<std::is_same<ptr_t_, void *>::value, T *> _mutable_data() {
     DALI_ENFORCE(
         type() == TypeTable::GetTypeId<T>(),
         make_string(
@@ -74,14 +75,14 @@ class SampleView {
    * The calling type must match the underlying type of the buffer.
    */
   template <typename T>
-  inline const T *data() const {
+  inline const T *_data() const {
     DALI_ENFORCE(
         type() == TypeTable::GetTypeId<T>(),
         make_string(
             "Calling type does not match buffer data type, requested type: ",
             TypeTable::GetTypeId<T>(), " current buffer type: ", type(),
             ". To set type for the Buffer use 'set_type<T>()' or Resize(shape, type) first."));
-    return static_cast<T *>(data_);
+    return static_cast<const T *>(data_);
   }
   //@}
 
@@ -100,16 +101,16 @@ class SampleView {
   }
 
 
-  SampleView() = default;
+  SampleViewBase() = default;
 
-  SampleView(const SampleView &) = default;
-  SampleView &operator=(const SampleView &) = default;
+  SampleViewBase(const SampleViewBase &) = default;
+  SampleViewBase &operator=(const SampleViewBase &) = default;
 
-  SampleView(SampleView &&other) {
+  SampleViewBase(SampleViewBase &&other) {
     *this = std::move(other);
   }
 
-  SampleView &operator=(SampleView &&other) {
+  SampleViewBase &operator=(SampleViewBase &&other) {
     if (this != &other) {
       data_ = other.data_;
       other.data_ = nullptr;
@@ -125,23 +126,78 @@ class SampleView {
    * @brief Construct the view inferring the type_id from the pointer value.
    */
   template <typename T>
-  SampleView(T *data, TensorShape<> shape)
-      : data_(data), shape_(std::move(shape)), type_id_(TypeTable::GetTypeId<T>()) {}
+  SampleViewBase(T *data, TensorShape<> shape)
+      : data_(data),
+        shape_(std::move(shape)),
+        type_id_(TypeTable::GetTypeId<std::remove_const_t<T>>()) {}
 
   /**
    * @brief Construct the view with explicitly provided type_id.
    */
-  SampleView(void *data, const TensorShape<> shape, DALIDataType type_id)
+  SampleViewBase(ptr_t data, const TensorShape<> shape, DALIDataType type_id)
       : data_(data), shape_(std::move(shape)), type_id_(type_id) {}
 
- private:
+ protected:
   // TODO(klecki): The view is introduced with no co-owning pointer, it will be evaluated
   // if the usage of shared_ptr is possbile and adjusted if necessary.
   // Using shared_ptr might allow for sample exchange between two batches using operator[]
-  void *data_ = nullptr;
+  ptr_t data_ = nullptr;
   TensorShape<> shape_ = {0};
   DALIDataType type_id_ = DALI_NO_TYPE;
 };
+
+
+template <typename Backend>
+class SampleView : public SampleViewBase<Backend, void *> {
+ public:
+  using Base = SampleViewBase<Backend, void *>;
+  using Base::Base;
+
+ private:
+  using Base::data_;
+  using Base::shape_;
+  using Base::type_id_;
+};
+
+
+template <typename Backend>
+class ConstSampleView : public SampleViewBase<Backend, const void *> {
+ public:
+  using Base = SampleViewBase<Backend, const void *>;
+  using Base::Base;
+
+  explicit ConstSampleView(const SampleView<Backend> &other)
+      : Base(other._raw_data(), other.shape(), other.type()) {}
+
+  ConstSampleView &operator=(const SampleView<Backend> &other) {
+    data_ = other.data();
+    shape_ = other.shape();
+    type_id_ = other.type();
+    return *this;
+  }
+
+  explicit ConstSampleView(SampleView<Backend> &&other) {
+    *this = std::move(other);
+  }
+
+  ConstSampleView &operator=(SampleView<Backend> &&other) {
+    if (this != &other) {
+      data_ = other.data_;
+      other.data_ = nullptr;
+      shape_ = std::move(other.shape_);
+      other.shape_ = {0};
+      type_id_ = other.type_id_;
+      other.type_id_ = DALI_NO_TYPE;
+    }
+    return *this;
+  }
+
+ private:
+  using Base::data_;
+  using Base::shape_;
+  using Base::type_id_;
+};
+
 
 }  // namespace dali
 

--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -171,13 +171,13 @@ class ConstSampleView : public SampleViewBase<Backend, const void *> {
       : Base(other._raw_data(), other.shape(), other.type()) {}
 
   ConstSampleView &operator=(const SampleView<Backend> &other) {
-    data_ = other.data();
+    data_ = other._raw_data();
     shape_ = other.shape();
     type_id_ = other.type();
     return *this;
   }
 
-  explicit ConstSampleView(SampleView<Backend> &&other) {
+  ConstSampleView(SampleView<Backend> &&other) {  // NOLINT
     *this = std::move(other);
   }
 

--- a/dali/pipeline/data/sample_view_test.cc
+++ b/dali/pipeline/data/sample_view_test.cc
@@ -67,13 +67,16 @@ TEST(SampleView, Constructors) {
   ConstSampleView<CPUBackend> const_from_const{const_from_ptr};
   compare(const_from_const, &cdata, {1, 2, 3}, DALI_INT32);
 
-  SampleView<CPUBackend> nonconst_from_nonconst{from_ptr};
+  SampleView<CPUBackend> nonconst_from_nonconst;
+  nonconst_from_nonconst = from_ptr;
   compare(nonconst_from_nonconst, &data, {1, 2, 3}, DALI_INT32);
 
-  SampleView<CPUBackend> nonconst_from_moved_nonconst{std::move(from_ptr)};
+  SampleView<CPUBackend> nonconst_from_moved_nonconst;
+  nonconst_from_moved_nonconst = std::move(from_ptr);
   compare(nonconst_from_moved_nonconst, &data, {1, 2, 3}, DALI_INT32);
 
-  ConstSampleView<CPUBackend> const_from_moved_const{std::move(const_from_ptr)};
+  ConstSampleView<CPUBackend> const_from_moved_const;
+  const_from_moved_const = std::move(const_from_ptr);
   compare(const_from_moved_const, &cdata, {1, 2, 3}, DALI_INT32);
 }
 

--- a/dali/pipeline/data/sample_view_test.cc
+++ b/dali/pipeline/data/sample_view_test.cc
@@ -71,6 +71,10 @@ TEST(SampleView, Constructors) {
   nonconst_from_nonconst = from_ptr;
   compare(nonconst_from_nonconst, &data, {1, 2, 3}, DALI_INT32);
 
+  ConstSampleView<CPUBackend> const_from_nonconst_assgin;
+  const_from_nonconst_assgin = from_ptr;
+  compare(const_from_nonconst_assgin, &data, {1, 2, 3}, DALI_INT32);
+
   SampleView<CPUBackend> nonconst_from_moved_nonconst;
   nonconst_from_moved_nonconst = std::move(from_ptr);
   compare(nonconst_from_moved_nonconst, &data, {1, 2, 3}, DALI_INT32);

--- a/dali/pipeline/data/sample_view_test.cc
+++ b/dali/pipeline/data/sample_view_test.cc
@@ -63,6 +63,18 @@ TEST(SampleView, Constructors) {
 
   ConstSampleView<CPUBackend> const_from_nonconst{from_ptr};
   compare(const_from_nonconst, &data, {1, 2, 3}, DALI_INT32);
+
+  ConstSampleView<CPUBackend> const_from_const{const_from_ptr};
+  compare(const_from_const, &cdata, {1, 2, 3}, DALI_INT32);
+
+  SampleView<CPUBackend> nonconst_from_nonconst{from_ptr};
+  compare(nonconst_from_nonconst, &data, {1, 2, 3}, DALI_INT32);
+
+  SampleView<CPUBackend> nonconst_from_moved_nonconst{std::move(from_ptr)};
+  compare(nonconst_from_moved_nonconst, &data, {1, 2, 3}, DALI_INT32);
+
+  ConstSampleView<CPUBackend> const_from_moved_const{std::move(const_from_nonconst)};
+  compare(const_from_moved_const, &cdata, {1, 2, 3}, DALI_INT32);
 }
 
 

--- a/dali/pipeline/data/sample_view_test.cc
+++ b/dali/pipeline/data/sample_view_test.cc
@@ -29,7 +29,7 @@ namespace dali {
 template <typename SampleView>
 void compare(const SampleView &sv, const void *ptr, const TensorShape<> &shape,
              DALIDataType dtype) {
-  EXPECT_EQ(sv._raw_data(), ptr);
+  EXPECT_EQ(sv.raw_data(), ptr);
   EXPECT_EQ(sv.shape(), shape);
   EXPECT_EQ(sv.type(), dtype);
 }

--- a/dali/pipeline/data/sample_view_test.cc
+++ b/dali/pipeline/data/sample_view_test.cc
@@ -26,11 +26,10 @@
 
 namespace dali {
 
-
 template <typename SampleView>
 void compare(const SampleView &sv, const void *ptr, const TensorShape<> &shape,
              DALIDataType dtype) {
-  EXPECT_EQ(sv.raw_data(), ptr);
+  EXPECT_EQ(sv._raw_data(), ptr);
   EXPECT_EQ(sv.shape(), shape);
   EXPECT_EQ(sv.type(), dtype);
 }
@@ -53,13 +52,45 @@ TEST(SampleView, Constructors) {
 
   SampleView<CPUBackend> from_void_ptr{reinterpret_cast<void *>(42), {1, 2, 3}, DALI_FLOAT};
   compare(from_void_ptr, reinterpret_cast<void *>(42), {1, 2, 3}, DALI_FLOAT);
+
+  const int32_t cdata{};
+  ConstSampleView<CPUBackend> const_from_ptr{&cdata, {1, 2, 3}};
+  compare(const_from_ptr, &cdata, {1, 2, 3}, DALI_INT32);
+
+  ConstSampleView<CPUBackend> const_from_void_ptr{
+      reinterpret_cast<const void *>(42), {1, 2, 3}, DALI_FLOAT};
+  compare(const_from_void_ptr, reinterpret_cast<void *>(42), {1, 2, 3}, DALI_FLOAT);
+
+  ConstSampleView<CPUBackend> const_from_nonconst{from_ptr};
+  compare(const_from_nonconst, &data, {1, 2, 3}, DALI_INT32);
+}
+
+
+TEST(SampleView, FromTensor) {
+  Tensor<CPUBackend> tensor;
+  tensor.Resize({1, 2, 3}, DALI_INT32);
+
+  auto sv = sample_view(tensor);
+  auto csv = const_sample_view(tensor);
+
+  compare(sv, tensor.raw_data(), {1, 2, 3}, DALI_INT32);
+  compare(csv, tensor.raw_data(), {1, 2, 3}, DALI_INT32);
+
+  Tensor<CPUBackend> scalar_tensor;
+  scalar_tensor.Resize({}, DALI_FLOAT);
+
+  auto scalar_sv = sample_view(scalar_tensor);
+  auto scalar_csv = const_sample_view(scalar_tensor);
+
+  compare(scalar_sv, scalar_tensor.raw_data(), {}, DALI_FLOAT);
+  compare(scalar_csv, scalar_tensor.raw_data(), {}, DALI_FLOAT);
 }
 
 
 TEST(SampleView, ViewConversion) {
   int32_t data{};
   SampleView<CPUBackend> sample_view{&data, {1, 2, 3}};
-  const SampleView<CPUBackend> const_sample_view{&data, {1, 2, 3}};
+  ConstSampleView<CPUBackend> const_sample_view{&data, {1, 2, 3}};
 
   compare(view<int32_t>(sample_view), TensorView<StorageCPU, int32_t>{&data, {1, 2, 3}});
   compare(view<int32_t, 3>(sample_view), TensorView<StorageCPU, int32_t, 3>{&data, {1, 2, 3}});
@@ -77,10 +108,11 @@ TEST(SampleView, ViewConversion) {
 TEST(SampleView, ViewConversionError) {
   int32_t data{};
   SampleView<CPUBackend> sample_view{&data, {1, 2, 3}};
-  const SampleView<CPUBackend> const_sample_view{&data, {1, 2, 3}};
+  ConstSampleView<CPUBackend> const_sample_view{&data, {1, 2, 3}};
 
   EXPECT_THROW(view<float>(sample_view), std::runtime_error);
   EXPECT_THROW(view<const float>(sample_view), std::runtime_error);
   EXPECT_THROW(view<const float>(const_sample_view), std::runtime_error);
 }
+
 }  // namespace dali

--- a/dali/pipeline/data/sample_view_test.cc
+++ b/dali/pipeline/data/sample_view_test.cc
@@ -73,7 +73,7 @@ TEST(SampleView, Constructors) {
   SampleView<CPUBackend> nonconst_from_moved_nonconst{std::move(from_ptr)};
   compare(nonconst_from_moved_nonconst, &data, {1, 2, 3}, DALI_INT32);
 
-  ConstSampleView<CPUBackend> const_from_moved_const{std::move(const_from_nonconst)};
+  ConstSampleView<CPUBackend> const_from_moved_const{std::move(const_from_ptr)};
   compare(const_from_moved_const, &cdata, {1, 2, 3}, DALI_INT32);
 }
 

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -422,6 +422,10 @@ class Tensor : public Buffer<Backend> {
     return *this;
   }
 
+  DALIMeta &GetMeta() {
+    return meta_;
+  }
+
   const DALIMeta &GetMeta() const {
     return meta_;
   }

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -422,10 +422,6 @@ class Tensor : public Buffer<Backend> {
     return *this;
   }
 
-  DALIMeta &GetMeta() {
-    return meta_;
-  }
-
   const DALIMeta &GetMeta() const {
     return meta_;
   }

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -145,7 +145,7 @@ class DLL_PUBLIC TensorList {
     sizes.reserve(nsamples);
     for (size_t i = 0; i < nsamples; i++) {
       dsts.emplace_back(this->raw_mutable_tensor(i));
-      srcs.emplace_back(other[i]._raw_data());
+      srcs.emplace_back(other[i].raw_data());
       sizes.emplace_back(other[i].shape().num_elements());
       this->meta_[i] = other.GetMeta(i);
     }

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -648,15 +648,17 @@ class DLL_PUBLIC TensorList {
 
   /**
    * @brief Returns the size in bytes of the underlying data chunks
+   * TODO(klecki): Temporary API to be reworked, do not use.
    */
-  std::vector<size_t> chunks_nbytes() const {
+  std::vector<size_t> _chunks_nbytes() const {
     return {data_.nbytes()};
   }
 
   /**
    * @brief Returns the real size of the underlying allocations
+   * TODO(klecki): Temporary API to be reworked, do not use.
    */
-  std::vector<size_t> chunks_capacity() const {
+  std::vector<size_t> _chunks_capacity() const {
     return {data_.capacity()};
   }
 

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -604,10 +604,6 @@ class DLL_PUBLIC TensorList {
     return meta_[idx].ShouldSkipSample();
   }
 
-  inline DALIMeta &GetMeta(int idx) {
-    return meta_[idx];
-  }
-
   inline const DALIMeta &GetMeta(int idx) const {
     return meta_[idx];
   }
@@ -639,28 +635,28 @@ class DLL_PUBLIC TensorList {
   /**
    * @brief Returns the size in bytes of the underlying data
    */
-  size_t total_nbytes() const {
+  size_t nbytes() const {
     return data_.nbytes();
   }
 
   /**
    * @brief Returns the real size of the allocation
    */
-  size_t total_capacity() const {
+  size_t capacity() const {
     return data_.capacity();
   }
 
   /**
-   * @brief Returns the size in bytes of the underlying data
+   * @brief Returns the size in bytes of the underlying data chunks
    */
-  std::vector<size_t> nbytes() const {
+  std::vector<size_t> chunks_nbytes() const {
     return {data_.nbytes()};
   }
 
   /**
-   * @brief Returns the real size of the allocation
+   * @brief Returns the real size of the underlying allocations
    */
-  std::vector<size_t> capacity() const {
+  std::vector<size_t> chunks_capacity() const {
     return {data_.capacity()};
   }
 

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ TYPED_TEST(TensorListTest, TestGetTypeSizeBytes) {
   tl.template set_type<float>();
 
   ASSERT_EQ(tl._num_elements(), 0);
-  ASSERT_EQ(tl.nbytes(), 0);
+  ASSERT_EQ(tl.total_nbytes(), 0);
   ASSERT_FALSE(tl.has_data());
 
   // Give the tensor list a size. This
@@ -127,7 +127,7 @@ TYPED_TEST(TensorListTest, TestGetTypeSizeBytes) {
   ASSERT_TRUE(tl.has_data());
   ASSERT_EQ(tl.num_samples(), num_tensor);
   ASSERT_EQ(tl._num_elements(), size);
-  ASSERT_EQ(tl.nbytes(), size*sizeof(float));
+  ASSERT_EQ(tl.total_nbytes(), size*sizeof(float));
   ASSERT_TRUE(IsType<float>(tl.type()));
 
   tl.reserve(shape.num_elements() * sizeof(float));
@@ -146,8 +146,8 @@ TYPED_TEST(TensorListTest, TestReserveResize) {
   ASSERT_THROW(tl.set_pinned(true), std::runtime_error);
 
   ASSERT_TRUE(tl.has_data());
-  ASSERT_EQ(tl.capacity(), shape.num_elements() * sizeof(float));
-  ASSERT_EQ(tl.nbytes(), 0);
+  ASSERT_EQ(tl.total_capacity(), shape.num_elements() * sizeof(float));
+  ASSERT_EQ(tl.total_nbytes(), 0);
   ASSERT_EQ(tl._num_elements(), 0);
   ASSERT_NE(unsafe_raw_data(tl), nullptr);
 
@@ -155,7 +155,7 @@ TYPED_TEST(TensorListTest, TestReserveResize) {
   tl.template set_type<float>();
 
   ASSERT_EQ(tl._num_elements(), 0);
-  ASSERT_EQ(tl.nbytes(), 0);
+  ASSERT_EQ(tl.total_nbytes(), 0);
   ASSERT_TRUE(tl.has_data());
 
   // We already had the allocation, just give it a shape and a type
@@ -173,7 +173,7 @@ TYPED_TEST(TensorListTest, TestReserveResize) {
   ASSERT_TRUE(tl.has_data());
   ASSERT_EQ(tl.num_samples(), num_tensor);
   ASSERT_EQ(tl._num_elements(), size);
-  ASSERT_EQ(tl.nbytes(), size*sizeof(float));
+  ASSERT_EQ(tl.total_nbytes(), size*sizeof(float));
   ASSERT_TRUE(IsType<float>(tl.type()));
 
 
@@ -214,7 +214,7 @@ TYPED_TEST(TensorListTest, TestGetContiguousPointer) {
   // Verify the internals
   ASSERT_EQ(tl._num_elements(), volume);
   ASSERT_EQ(tl.num_samples(), num_tensor);
-  ASSERT_EQ(tl.nbytes(), volume * sizeof(uint32_t));
+  ASSERT_EQ(tl.total_nbytes(), volume * sizeof(uint32_t));
   ASSERT_EQ(tl.type(), DALI_UINT32);
   ASSERT_TRUE(tl.IsContiguous());
   ASSERT_NE(unsafe_raw_data(tl), nullptr);
@@ -244,7 +244,7 @@ TYPED_TEST(TensorListTest, TestGetBytesThenNoAlloc) {
     ASSERT_EQ(tl.raw_tensor(i), sharer.raw_tensor(i));
   }
   ASSERT_EQ(tl._num_elements(), size);
-  ASSERT_EQ(tl.nbytes(), size*sizeof(float));
+  ASSERT_EQ(tl.total_nbytes(), size*sizeof(float));
   ASSERT_EQ(tl.type(), sharer.type());
   ASSERT_EQ(tl.num_samples(), num_tensor);
   ASSERT_TRUE(tl.shares_data());
@@ -279,7 +279,7 @@ TYPED_TEST(TensorListTest, TestGetBytesThenAlloc) {
     ASSERT_EQ(tl.raw_tensor(i), sharer.raw_tensor(i));
   }
   ASSERT_EQ(tl._num_elements(), size);
-  ASSERT_EQ(tl.nbytes(), size*sizeof(float));
+  ASSERT_EQ(tl.total_nbytes(), size*sizeof(float));
   ASSERT_EQ(tl.type(), sharer.type());
   ASSERT_EQ(tl.num_samples(), num_tensor);
   ASSERT_TRUE(tl.shares_data());
@@ -298,7 +298,7 @@ TYPED_TEST(TensorListTest, TestZeroSizeResize) {
   tensor_list.Resize(shape);
 
   ASSERT_FALSE(tensor_list.has_data());
-  ASSERT_EQ(tensor_list.nbytes(), 0);
+  ASSERT_EQ(tensor_list.total_nbytes(), 0);
   ASSERT_EQ(tensor_list._num_elements(), 0);
   ASSERT_FALSE(tensor_list.shares_data());
 }
@@ -311,7 +311,7 @@ TYPED_TEST(TensorListTest, TestMultipleZeroSizeResize) {
   tensor_list.Resize(shape, DALI_FLOAT);
 
   ASSERT_FALSE(tensor_list.has_data());
-  ASSERT_EQ(tensor_list.nbytes(), 0);
+  ASSERT_EQ(tensor_list.total_nbytes(), 0);
   ASSERT_EQ(tensor_list.num_samples(), num_tensor);
   ASSERT_EQ(tensor_list._num_elements(), 0);
   ASSERT_FALSE(tensor_list.shares_data());
@@ -333,7 +333,7 @@ TYPED_TEST(TensorListTest, TestFakeScalarResize) {
   tensor_list.Resize(shape);
 
   ASSERT_TRUE(tensor_list.has_data());
-  ASSERT_EQ(tensor_list.nbytes(), num_scalar*sizeof(float));
+  ASSERT_EQ(tensor_list.total_nbytes(), num_scalar*sizeof(float));
   ASSERT_EQ(tensor_list._num_elements(), num_scalar);
   ASSERT_FALSE(tensor_list.shares_data());
 
@@ -353,7 +353,7 @@ TYPED_TEST(TensorListTest, TestTrueScalarResize) {
   tensor_list.Resize(shape);
 
   ASSERT_TRUE(tensor_list.has_data());
-  ASSERT_EQ(tensor_list.nbytes(), num_scalar*sizeof(float));
+  ASSERT_EQ(tensor_list.total_nbytes(), num_scalar*sizeof(float));
   ASSERT_EQ(tensor_list._num_elements(), num_scalar);
   ASSERT_FALSE(tensor_list.shares_data());
 
@@ -456,7 +456,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeSameSize) {
   for (size_t i = 0; i < tensor_list.num_samples(); i++) {
     ptrs.push_back(tensor_list.raw_tensor(i));
   }
-  size_t nbytes = tensor_list.nbytes();
+  size_t nbytes = tensor_list.total_nbytes();
 
   // Change the data type
   tensor_list.template set_type<int>();
@@ -470,7 +470,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeSameSize) {
   }
 
   // No memory allocation should have occurred
-  ASSERT_EQ(nbytes, tensor_list.nbytes());
+  ASSERT_EQ(nbytes, tensor_list.total_nbytes());
 }
 
 TYPED_TEST(TensorListTest, TestTypeChangeSmaller) {
@@ -482,7 +482,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeSmaller) {
 
   this->SetupTensorList(&tensor_list, shape, &offsets);
 
-  size_t nbytes = tensor_list.nbytes();
+  size_t nbytes = tensor_list.total_nbytes();
   const auto *base_ptr = unsafe_raw_data(tensor_list);
 
   // Change the data type to something smaller
@@ -497,7 +497,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeSmaller) {
   }
 
   // nbytes should have reduced by a factor of 4
-  ASSERT_EQ(nbytes / sizeof(float) * sizeof(uint8), tensor_list.nbytes());
+  ASSERT_EQ(nbytes / sizeof(float) * sizeof(uint8), tensor_list.total_nbytes());
 }
 
 TYPED_TEST(TensorListTest, TestTypeChangeLarger) {
@@ -509,7 +509,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeLarger) {
 
   this->SetupTensorList(&tensor_list, shape, &offsets);
 
-  size_t nbytes = tensor_list.nbytes();
+  size_t nbytes = tensor_list.total_nbytes();
 
   // Change the data type to something larger
   tensor_list.template set_type<double>();
@@ -522,7 +522,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeLarger) {
   }
 
   // nbytes should have increased by a factor of 2
-  ASSERT_EQ(nbytes / sizeof(float) * sizeof(double), tensor_list.nbytes());
+  ASSERT_EQ(nbytes / sizeof(float) * sizeof(double), tensor_list.total_nbytes());
 }
 
 TYPED_TEST(TensorListTest, TestShareData) {
@@ -559,7 +559,7 @@ TYPED_TEST(TensorListTest, TestShareData) {
 
   // Check the internals
   ASSERT_TRUE(tensor_list2.shares_data());
-  ASSERT_EQ(tensor_list2.nbytes(), tensor_list.nbytes());
+  ASSERT_EQ(tensor_list2.total_nbytes(), tensor_list.total_nbytes());
   ASSERT_EQ(tensor_list2.num_samples(), tensor_list.num_samples());
   ASSERT_EQ(tensor_list2._num_elements(), tensor_list._num_elements());
   for (size_t i = 0; i < tensor_list.num_samples(); ++i) {
@@ -575,7 +575,7 @@ TYPED_TEST(TensorListTest, TestShareData) {
 
   // Check the internals
   ASSERT_EQ(tensor_list2._num_elements(), 0);
-  ASSERT_EQ(tensor_list2.nbytes(), 0);
+  ASSERT_EQ(tensor_list2.total_nbytes(), 0);
   ASSERT_EQ(tensor_list2.num_samples(), 0);
   ASSERT_EQ(tensor_list2.shape(), TensorListShape<>());
 }

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -107,7 +107,7 @@ TYPED_TEST(TensorListTest, TestGetTypeSizeBytes) {
   tl.template set_type<float>();
 
   ASSERT_EQ(tl._num_elements(), 0);
-  ASSERT_EQ(tl.total_nbytes(), 0);
+  ASSERT_EQ(tl.nbytes(), 0);
   ASSERT_FALSE(tl.has_data());
 
   // Give the tensor list a size. This
@@ -127,7 +127,7 @@ TYPED_TEST(TensorListTest, TestGetTypeSizeBytes) {
   ASSERT_TRUE(tl.has_data());
   ASSERT_EQ(tl.num_samples(), num_tensor);
   ASSERT_EQ(tl._num_elements(), size);
-  ASSERT_EQ(tl.total_nbytes(), size*sizeof(float));
+  ASSERT_EQ(tl.nbytes(), size*sizeof(float));
   ASSERT_TRUE(IsType<float>(tl.type()));
 
   tl.reserve(shape.num_elements() * sizeof(float));
@@ -146,8 +146,8 @@ TYPED_TEST(TensorListTest, TestReserveResize) {
   ASSERT_THROW(tl.set_pinned(true), std::runtime_error);
 
   ASSERT_TRUE(tl.has_data());
-  ASSERT_EQ(tl.total_capacity(), shape.num_elements() * sizeof(float));
-  ASSERT_EQ(tl.total_nbytes(), 0);
+  ASSERT_EQ(tl.capacity(), shape.num_elements() * sizeof(float));
+  ASSERT_EQ(tl.nbytes(), 0);
   ASSERT_EQ(tl._num_elements(), 0);
   ASSERT_NE(unsafe_raw_data(tl), nullptr);
 
@@ -155,7 +155,7 @@ TYPED_TEST(TensorListTest, TestReserveResize) {
   tl.template set_type<float>();
 
   ASSERT_EQ(tl._num_elements(), 0);
-  ASSERT_EQ(tl.total_nbytes(), 0);
+  ASSERT_EQ(tl.nbytes(), 0);
   ASSERT_TRUE(tl.has_data());
 
   // We already had the allocation, just give it a shape and a type
@@ -173,7 +173,7 @@ TYPED_TEST(TensorListTest, TestReserveResize) {
   ASSERT_TRUE(tl.has_data());
   ASSERT_EQ(tl.num_samples(), num_tensor);
   ASSERT_EQ(tl._num_elements(), size);
-  ASSERT_EQ(tl.total_nbytes(), size*sizeof(float));
+  ASSERT_EQ(tl.nbytes(), size*sizeof(float));
   ASSERT_TRUE(IsType<float>(tl.type()));
 
 
@@ -214,7 +214,7 @@ TYPED_TEST(TensorListTest, TestGetContiguousPointer) {
   // Verify the internals
   ASSERT_EQ(tl._num_elements(), volume);
   ASSERT_EQ(tl.num_samples(), num_tensor);
-  ASSERT_EQ(tl.total_nbytes(), volume * sizeof(uint32_t));
+  ASSERT_EQ(tl.nbytes(), volume * sizeof(uint32_t));
   ASSERT_EQ(tl.type(), DALI_UINT32);
   ASSERT_TRUE(tl.IsContiguous());
   ASSERT_NE(unsafe_raw_data(tl), nullptr);
@@ -244,7 +244,7 @@ TYPED_TEST(TensorListTest, TestGetBytesThenNoAlloc) {
     ASSERT_EQ(tl.raw_tensor(i), sharer.raw_tensor(i));
   }
   ASSERT_EQ(tl._num_elements(), size);
-  ASSERT_EQ(tl.total_nbytes(), size*sizeof(float));
+  ASSERT_EQ(tl.nbytes(), size*sizeof(float));
   ASSERT_EQ(tl.type(), sharer.type());
   ASSERT_EQ(tl.num_samples(), num_tensor);
   ASSERT_TRUE(tl.shares_data());
@@ -279,7 +279,7 @@ TYPED_TEST(TensorListTest, TestGetBytesThenAlloc) {
     ASSERT_EQ(tl.raw_tensor(i), sharer.raw_tensor(i));
   }
   ASSERT_EQ(tl._num_elements(), size);
-  ASSERT_EQ(tl.total_nbytes(), size*sizeof(float));
+  ASSERT_EQ(tl.nbytes(), size*sizeof(float));
   ASSERT_EQ(tl.type(), sharer.type());
   ASSERT_EQ(tl.num_samples(), num_tensor);
   ASSERT_TRUE(tl.shares_data());
@@ -298,7 +298,7 @@ TYPED_TEST(TensorListTest, TestZeroSizeResize) {
   tensor_list.Resize(shape);
 
   ASSERT_FALSE(tensor_list.has_data());
-  ASSERT_EQ(tensor_list.total_nbytes(), 0);
+  ASSERT_EQ(tensor_list.nbytes(), 0);
   ASSERT_EQ(tensor_list._num_elements(), 0);
   ASSERT_FALSE(tensor_list.shares_data());
 }
@@ -311,7 +311,7 @@ TYPED_TEST(TensorListTest, TestMultipleZeroSizeResize) {
   tensor_list.Resize(shape, DALI_FLOAT);
 
   ASSERT_FALSE(tensor_list.has_data());
-  ASSERT_EQ(tensor_list.total_nbytes(), 0);
+  ASSERT_EQ(tensor_list.nbytes(), 0);
   ASSERT_EQ(tensor_list.num_samples(), num_tensor);
   ASSERT_EQ(tensor_list._num_elements(), 0);
   ASSERT_FALSE(tensor_list.shares_data());
@@ -333,7 +333,7 @@ TYPED_TEST(TensorListTest, TestFakeScalarResize) {
   tensor_list.Resize(shape);
 
   ASSERT_TRUE(tensor_list.has_data());
-  ASSERT_EQ(tensor_list.total_nbytes(), num_scalar*sizeof(float));
+  ASSERT_EQ(tensor_list.nbytes(), num_scalar*sizeof(float));
   ASSERT_EQ(tensor_list._num_elements(), num_scalar);
   ASSERT_FALSE(tensor_list.shares_data());
 
@@ -353,7 +353,7 @@ TYPED_TEST(TensorListTest, TestTrueScalarResize) {
   tensor_list.Resize(shape);
 
   ASSERT_TRUE(tensor_list.has_data());
-  ASSERT_EQ(tensor_list.total_nbytes(), num_scalar*sizeof(float));
+  ASSERT_EQ(tensor_list.nbytes(), num_scalar*sizeof(float));
   ASSERT_EQ(tensor_list._num_elements(), num_scalar);
   ASSERT_FALSE(tensor_list.shares_data());
 
@@ -456,7 +456,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeSameSize) {
   for (size_t i = 0; i < tensor_list.num_samples(); i++) {
     ptrs.push_back(tensor_list.raw_tensor(i));
   }
-  size_t nbytes = tensor_list.total_nbytes();
+  size_t nbytes = tensor_list.nbytes();
 
   // Change the data type
   tensor_list.template set_type<int>();
@@ -470,7 +470,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeSameSize) {
   }
 
   // No memory allocation should have occurred
-  ASSERT_EQ(nbytes, tensor_list.total_nbytes());
+  ASSERT_EQ(nbytes, tensor_list.nbytes());
 }
 
 TYPED_TEST(TensorListTest, TestTypeChangeSmaller) {
@@ -482,7 +482,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeSmaller) {
 
   this->SetupTensorList(&tensor_list, shape, &offsets);
 
-  size_t nbytes = tensor_list.total_nbytes();
+  size_t nbytes = tensor_list.nbytes();
   const auto *base_ptr = unsafe_raw_data(tensor_list);
 
   // Change the data type to something smaller
@@ -497,7 +497,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeSmaller) {
   }
 
   // nbytes should have reduced by a factor of 4
-  ASSERT_EQ(nbytes / sizeof(float) * sizeof(uint8), tensor_list.total_nbytes());
+  ASSERT_EQ(nbytes / sizeof(float) * sizeof(uint8), tensor_list.nbytes());
 }
 
 TYPED_TEST(TensorListTest, TestTypeChangeLarger) {
@@ -509,7 +509,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeLarger) {
 
   this->SetupTensorList(&tensor_list, shape, &offsets);
 
-  size_t nbytes = tensor_list.total_nbytes();
+  size_t nbytes = tensor_list.nbytes();
 
   // Change the data type to something larger
   tensor_list.template set_type<double>();
@@ -522,7 +522,7 @@ TYPED_TEST(TensorListTest, TestTypeChangeLarger) {
   }
 
   // nbytes should have increased by a factor of 2
-  ASSERT_EQ(nbytes / sizeof(float) * sizeof(double), tensor_list.total_nbytes());
+  ASSERT_EQ(nbytes / sizeof(float) * sizeof(double), tensor_list.nbytes());
 }
 
 TYPED_TEST(TensorListTest, TestShareData) {
@@ -559,7 +559,7 @@ TYPED_TEST(TensorListTest, TestShareData) {
 
   // Check the internals
   ASSERT_TRUE(tensor_list2.shares_data());
-  ASSERT_EQ(tensor_list2.total_nbytes(), tensor_list.total_nbytes());
+  ASSERT_EQ(tensor_list2.nbytes(), tensor_list.nbytes());
   ASSERT_EQ(tensor_list2.num_samples(), tensor_list.num_samples());
   ASSERT_EQ(tensor_list2._num_elements(), tensor_list._num_elements());
   for (size_t i = 0; i < tensor_list.num_samples(); ++i) {
@@ -575,7 +575,7 @@ TYPED_TEST(TensorListTest, TestShareData) {
 
   // Check the internals
   ASSERT_EQ(tensor_list2._num_elements(), 0);
-  ASSERT_EQ(tensor_list2.total_nbytes(), 0);
+  ASSERT_EQ(tensor_list2.nbytes(), 0);
   ASSERT_EQ(tensor_list2.num_samples(), 0);
   ASSERT_EQ(tensor_list2.shape(), TensorListShape<>());
 }

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -361,7 +361,7 @@ TYPED_TEST(TensorTest, TestShareData) {
   for (int i = 0; i < num_tensor; ++i) {
     // TODO(klecki): Rework this with proper sample-based tensor batch data structure
     auto sample_shared_ptr = unsafe_sample_owner(tl, i);
-    tensor.ShareData(sample_shared_ptr, tl.total_capacity(), tl.is_pinned(), tl.shape()[i],
+    tensor.ShareData(sample_shared_ptr, tl.capacity(), tl.is_pinned(), tl.shape()[i],
                      tl.type());
     tensor.set_device_id(tl.device_id());
     tensor.SetMeta(tl.GetMeta(i));

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -188,21 +188,6 @@ void TensorVector<Backend>::UnsafeCopySample(int sample_idx, const TensorVector<
 }
 
 template <typename Backend>
-void TensorVector<Backend>::SetupLike(const Tensor<Backend> &sample) {
-  SetupLikeImpl(sample);
-}
-
-template <typename Backend>
-void TensorVector<Backend>::SetupLike(const TensorVector<Backend> &other) {
-  SetupLikeImpl(other);
-}
-
-template <typename Backend>
-void TensorVector<Backend>::SetupLike(const TensorList<Backend> &other) {
-  SetupLikeImpl(other);
-}
-
-template <typename Backend>
 void TensorVector<Backend>::set_sample_dim(int sample_dim) {
   DALI_ENFORCE(
       !has_data(),

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -88,6 +88,10 @@ void TensorVector<Backend>::UnsafeSetSample(int dst, const TensorVector<Backend>
       GetLayout() == "" || GetLayout() == owner.GetLayout(),
       make_string("Sample must have the same layout as a target batch current: ", GetLayout(),
                   " new: ", owner.GetLayout(), " for ", dst, " <- ", src, "."));
+  DALI_ENFORCE(
+      is_pinned() == owner.is_pinned(),
+      make_string("Sample must have the same pinned status as target batch, current: ", is_pinned(),
+                  " new: ", owner.is_pinned(), " for ", dst, " <- ", src, "."));
 
   SetContiguous(false);
   // Setting a new share overwrites the previous one - so we can safely assume that even if
@@ -120,6 +124,10 @@ void TensorVector<Backend>::UnsafeSetSample(int dst, const Tensor<Backend> &owne
       GetLayout() == "" || GetLayout() == owner.GetLayout(),
       make_string("Sample must have the same layout as a target batch current: ", GetLayout(),
                   " new: ", owner.GetLayout(), " for ", dst, " <-."));
+  DALI_ENFORCE(
+      is_pinned() == owner.is_pinned(),
+      make_string("Sample must have the same pinned status as target batch, current: ", is_pinned(),
+                  " new: ", owner.is_pinned(), " for ", dst, " <-."));
   SetContiguous(false);
   // Setting a new share overwrites the previous one - so we can safely assume that even if
   // we had a sample sharing into TL, it will be overwritten
@@ -386,16 +394,7 @@ void TensorVector<Backend>::set_pinned(bool pinned) {
 
 template <typename Backend>
 bool TensorVector<Backend>::is_pinned() const {
-  if (state_ == State::contiguous) {
-    return tl_->is_pinned();
-  }
-  if (curr_tensors_size_ == 0) {
-    return pinned_;
-  }
-  for (size_t i = 1; i < curr_tensors_size_; i++) {
-    assert(tensors_[i]->is_pinned() == tensors_[0]->is_pinned());
-  }
-  return tensors_[0]->is_pinned();
+  return pinned_;
 }
 
 

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -191,7 +191,7 @@ void TensorVector<Backend>::UnsafeCopySample(int sample_idx, const TensorVector<
 template <typename Backend>
 void TensorVector<Backend>::SetupLike(const Tensor<Backend> &sample) {
   DALI_ENFORCE(!has_data(),
-               "Batch object can be initialized this way only when it doesn't have allocation.");
+               "Batch object can be initialized this way only when it isn't allocated.");
   set_type(sample.type());
   set_sample_dim(sample.shape().sample_dim());
   SetLayout(sample.GetLayout());
@@ -202,7 +202,7 @@ void TensorVector<Backend>::SetupLike(const Tensor<Backend> &sample) {
 template <typename Backend>
 void TensorVector<Backend>::SetupLike(const TensorVector<Backend> &other) {
   DALI_ENFORCE(!has_data(),
-               "Batch object can be initialized this way only when it doesn't have allocation.");
+               "Batch object can be initialized this way only when it isn't allocated.");
   set_type(other.type());
   set_sample_dim(other.shape().sample_dim());
   SetLayout(other.GetLayout());

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -223,7 +223,7 @@ size_t TensorVector<Backend>::capacity() const noexcept {
 }
 
 template <typename Backend>
-std::vector<size_t> TensorVector<Backend>::_chunks_nbytes() const noexcept {
+std::vector<size_t> TensorVector<Backend>::_chunks_nbytes() const {
   if (state_ == State::contiguous) {
     return {tl_->nbytes()};
   }
@@ -237,7 +237,7 @@ std::vector<size_t> TensorVector<Backend>::_chunks_nbytes() const noexcept {
 
 
 template <typename Backend>
-std::vector<size_t> TensorVector<Backend>::_chunks_capacity() const noexcept {
+std::vector<size_t> TensorVector<Backend>::_chunks_capacity() const {
   if (state_ == State::contiguous) {
     return {tl_->capacity()};
   }

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -187,27 +187,19 @@ void TensorVector<Backend>::UnsafeCopySample(int sample_idx, const TensorVector<
   tensors_[sample_idx]->Copy(*src.tensors_[src_sample_idx], order);
 }
 
-
 template <typename Backend>
 void TensorVector<Backend>::SetupLike(const Tensor<Backend> &sample) {
-  DALI_ENFORCE(!has_data(),
-               "Batch object can be initialized this way only when it isn't allocated.");
-  set_type(sample.type());
-  set_sample_dim(sample.shape().sample_dim());
-  SetLayout(sample.GetLayout());
-  set_order(sample.order());
-  set_pinned(sample.is_pinned());
+  SetupLikeImpl(sample);
 }
 
 template <typename Backend>
 void TensorVector<Backend>::SetupLike(const TensorVector<Backend> &other) {
-  DALI_ENFORCE(!has_data(),
-               "Batch object can be initialized this way only when it isn't allocated.");
-  set_type(other.type());
-  set_sample_dim(other.shape().sample_dim());
-  SetLayout(other.GetLayout());
-  set_order(other.order());
-  set_pinned(other.is_pinned());
+  SetupLikeImpl(other);
+}
+
+template <typename Backend>
+void TensorVector<Backend>::SetupLike(const TensorList<Backend> &other) {
+  SetupLikeImpl(other);
 }
 
 template <typename Backend>
@@ -246,7 +238,7 @@ size_t TensorVector<Backend>::capacity() const noexcept {
 }
 
 template <typename Backend>
-std::vector<size_t> TensorVector<Backend>::chunks_nbytes() const noexcept {
+std::vector<size_t> TensorVector<Backend>::_chunks_nbytes() const noexcept {
   if (state_ == State::contiguous) {
     return {tl_->nbytes()};
   }
@@ -260,7 +252,7 @@ std::vector<size_t> TensorVector<Backend>::chunks_nbytes() const noexcept {
 
 
 template <typename Backend>
-std::vector<size_t> TensorVector<Backend>::chunks_capacity() const noexcept {
+std::vector<size_t> TensorVector<Backend>::_chunks_capacity() const noexcept {
   if (state_ == State::contiguous) {
     return {tl_->capacity()};
   }

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -235,9 +235,17 @@ class DLL_PUBLIC TensorVector {
    * Configures: type, layout, pinned, order and dimensionality.
    */
   // @{
-  void SetupLike(const Tensor<Backend> &sample);
-  void SetupLike(const TensorVector<Backend> &other);
-  void SetupLike(const TensorList<Backend> &other);
+  void SetupLike(const Tensor<Backend> &sample) {
+    SetupLikeImpl(sample);
+  }
+
+  void SetupLike(const TensorVector<Backend> &other) {
+    SetupLikeImpl(other);
+  }
+
+  void SetupLike(const TensorList<Backend> &other) {
+    SetupLikeImpl(other);
+  }
   // @}
 
   void set_type(DALIDataType new_type);

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -114,13 +114,13 @@ class DLL_PUBLIC TensorVector {
    * @brief Returns the size in bytes of the underlying data chunks
    * TODO(klecki): Temporary API to be reworked, do not use.
    */
-  std::vector<size_t> _chunks_nbytes() const noexcept;
+  std::vector<size_t> _chunks_nbytes() const;
 
   /**
    * @brief Returns the real size of the underlying allocations
    * TODO(klecki): Temporary API to be reworked, do not use.
    */
-  std::vector<size_t> _chunks_capacity() const noexcept;
+  std::vector<size_t> _chunks_capacity() const;
 
   TensorListShape<> shape() const;
 

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -110,9 +110,17 @@ class DLL_PUBLIC TensorVector {
 
   size_t capacity() const noexcept;
 
-  std::vector<size_t> chunks_nbytes() const noexcept;
+  /**
+   * @brief Returns the size in bytes of the underlying data chunks
+   * TODO(klecki): Temporary API to be reworked, do not use.
+   */
+  std::vector<size_t> _chunks_nbytes() const noexcept;
 
-  std::vector<size_t> chunks_capacity() const noexcept;
+  /**
+   * @brief Returns the real size of the underlying allocations
+   * TODO(klecki): Temporary API to be reworked, do not use.
+   */
+  std::vector<size_t> _chunks_capacity() const noexcept;
 
   TensorListShape<> shape() const;
 
@@ -221,14 +229,16 @@ class DLL_PUBLIC TensorVector {
   void SetSize(int new_size);
 
   /**
-   * @brief Setup all the batch properties of this TensorVector the same way as the provided tensor:
+   * @name Setup all the batch properties of this TensorVector the same way as the provided tensor:
    *
    * Precondition: the TensorVector should not have data.
    * Configures: type, layout, pinned, order and dimensionality.
    */
+  // @{
   void SetupLike(const Tensor<Backend> &sample);
-
   void SetupLike(const TensorVector<Backend> &other);
+  void SetupLike(const TensorList<Backend> &other);
+  // @}
 
   void set_type(DALIDataType new_type);
 
@@ -313,6 +323,17 @@ class DLL_PUBLIC TensorVector {
 
   auto tensor_handle(size_t pos) const {
     return tensors_[pos];
+  }
+
+  template <typename T>
+  void SetupLikeImpl(const T &other) {
+    DALI_ENFORCE(!has_data(),
+                "Batch object can be initialized this way only when it isn't allocated.");
+    set_type(other.type());
+    set_sample_dim(other.shape().sample_dim());
+    SetLayout(other.GetLayout());
+    set_order(other.order());
+    set_pinned(other.is_pinned());
   }
 
   /**

--- a/dali/pipeline/data/tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_vector_test.cc
@@ -93,8 +93,8 @@ TYPED_TEST(TensorVectorSuite, PinnedBeforeResizeContiguous) {
   EXPECT_EQ(tv[0].shape(), TensorShape<>(2, 4));
   EXPECT_EQ(tv[1].shape(), TensorShape<>(4, 2));
   EXPECT_EQ(tv.is_pinned(), false);
-  for (auto &t : tv) {
-    EXPECT_EQ(t->type(), DALI_INT32);
+  for (size_t i = 0; i < tv.num_samples(); i++) {
+    EXPECT_EQ(tv[i].type(), DALI_INT32);
   }
 }
 
@@ -109,8 +109,8 @@ TYPED_TEST(TensorVectorSuite, PinnedBeforeResizeNoncontiguous) {
   EXPECT_EQ(tv[0].shape(), TensorShape<>(2, 4));
   EXPECT_EQ(tv[1].shape(), TensorShape<>(4, 2));
   EXPECT_EQ(tv.is_pinned(), false);
-  for (auto &t : tv) {
-    EXPECT_EQ(t->type(), DALI_INT32);
+  for (size_t i = 0; i < tv.num_samples(); i++) {
+    EXPECT_EQ(tv[i].type(), DALI_INT32);
   }
 }
 
@@ -121,9 +121,6 @@ TYPED_TEST(TensorVectorSuite, BatchResize) {
   tv.reserve(200);
   tv.template set_type<int32_t>();
   tv.Resize(uniform_list_shape(5, {10, 20}));
-  // for (auto &t : tv) {
-  //   EXPECT_TRUE(t->shares_data());
-  // }
 }
 
 TYPED_TEST(TensorVectorSuite, VariableBatchResizeDown) {

--- a/dali/pipeline/data/view_test.cc
+++ b/dali/pipeline/data/view_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -66,8 +66,12 @@ TEST(TensorVector, View) {
   TensorVector<CPUBackend> tvec(10);
   tvec.set_type<int>();
   std::mt19937_64 rng;
+  TensorListShape<3> shape(10);
   for (int i = 0; i < 10; i++) {
-    tvec[i].Resize(TensorShape<3>(100+i, 40+i, 3+i));
+    shape.set_tensor_shape(i, TensorShape<3>(100+i, 40+i, 3+i));
+  }
+  tvec.Resize(shape);
+  for (int i = 0; i < 10; i++) {
     UniformRandomFill(view<int>(tvec[i]), rng, 0, 10000);
   }
 
@@ -79,8 +83,8 @@ TEST(TensorVector, View) {
   EXPECT_EQ(tv_shape, tlv.shape);
   EXPECT_EQ(tlv2.shape, tlv.shape);
   for (int i = 0; i < 10; i++) {
-    EXPECT_EQ(tlv[i].data, tvec[i].data<int>());
-    EXPECT_EQ(tlv2[i].data, tvec[i].data<int>());
+    EXPECT_EQ(tlv[i].data, tvec.tensor<int>(i));
+    EXPECT_EQ(tlv2[i].data, tvec.tensor<int>(i));
     Check(tlv[i], view<int>(tvec[i]));
   }
 }
@@ -89,11 +93,14 @@ TEST(TensorVector, ReinterpretView) {
   TensorVector<CPUBackend> tvec(10);
   tvec.set_type<int>();
   std::mt19937_64 rng;
+  TensorListShape<3> shape(10);
   for (int i = 0; i < 10; i++) {
-    tvec[i].Resize(TensorShape<3>(100+i, 40+i, 3+i));
+    shape.set_tensor_shape(i, TensorShape<3>(100+i, 40+i, 3+i));
+  }
+  tvec.Resize(shape);
+  for (int i = 0; i < 10; i++) {
     UniformRandomFill(view<int>(tvec[i]), rng, 0, 10000);
   }
-
   auto tlv = view<int, 3>(tvec);
   auto tlv_i16 = reinterpret_view<int16_t, 3>(tvec);
   const auto& ctvec = tvec;

--- a/dali/pipeline/data/views.h
+++ b/dali/pipeline/data/views.h
@@ -107,7 +107,7 @@ template <typename T, int ndim = DynamicDimensions, typename Backend>
 TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(SampleView<Backend> data) {
   using U = std::remove_const_t<T>;
   detail::enforce_dim_in_view<ndim>(data.shape());
-  return {data.template _mutable_data<U>(), data.shape()};
+  return {data.template mutable_data<U>(), data.shape()};
 }
 
 template <typename T, int ndim = DynamicDimensions, typename Backend>
@@ -117,7 +117,7 @@ TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(ConstSampleView<Bac
                 "Missing `const` in T?");
   using U = std::remove_const_t<T>;
   detail::enforce_dim_in_view<ndim>(data.shape());
-  return {data.template _data<U>(), data.shape()};
+  return {data.template data<U>(), data.shape()};
 }
 // @}
 

--- a/dali/pipeline/data/views.h
+++ b/dali/pipeline/data/views.h
@@ -82,8 +82,6 @@ TensorShape<ndim> get_tensor_shape(const TensorList<Backend> &tl) {
 template <typename T, int ndim = DynamicDimensions, typename Backend>
 TensorView<detail::storage_tag_map_t<Backend>, T, ndim>
 view(Tensor<Backend> &data) {
-  if (data.shape().empty())
-    return {};
   using U = std::remove_const_t<T>;
   detail::enforce_dim_in_view<ndim>(data.shape());
   return { data.template mutable_data<U>(), convert_dim<ndim>(data.shape()) };
@@ -96,8 +94,6 @@ view(const Tensor<Backend> &data) {
   static_assert(std::is_const<T>::value,
                 "Cannot create a non-const view of a `const Tensor<>`. "
                 "Missing `const` in T?");
-  if (data.shape().empty())
-    return {};
   using U = std::remove_const_t<T>;
   detail::enforce_dim_in_view<ndim>(data.shape());
   return { data.template data<U>(), convert_dim<ndim>(data.shape()) };
@@ -107,23 +103,21 @@ view(const Tensor<Backend> &data) {
 /**
  * @name Convert from SampleView carrying runtime type information to statically typed TensorView.
  */
-// @{
 template <typename T, int ndim = DynamicDimensions, typename Backend>
-TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(SampleView<Backend> &data) {
+TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(SampleView<Backend> data) {
   using U = std::remove_const_t<T>;
   detail::enforce_dim_in_view<ndim>(data.shape());
-  return {data.template mutable_data<U>(), data.shape()};
+  return {data.template _mutable_data<U>(), data.shape()};
 }
 
-
 template <typename T, int ndim = DynamicDimensions, typename Backend>
-TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(const SampleView<Backend> &data) {
+TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(ConstSampleView<Backend> data) {
   static_assert(std::is_const<T>::value,
                 "Cannot create a non-const view of a `const Tensor<>`. "
                 "Missing `const` in T?");
   using U = std::remove_const_t<T>;
   detail::enforce_dim_in_view<ndim>(data.shape());
-  return {data.template data<U>(), data.shape()};
+  return {data.template _data<U>(), data.shape()};
 }
 // @}
 
@@ -176,7 +170,7 @@ view(TensorVector<Backend> &data) {
 
   std::vector<T *> ptrs(shape.num_samples());
   for (int i = 0; i < shape.num_samples(); i++) {
-    ptrs[i] = data[i].template mutable_data<U>();
+    ptrs[i] = data.template mutable_tensor<U>(i);
   }
   return { std::move(ptrs), convert_dim<ndim>(shape) };
 }
@@ -196,7 +190,7 @@ view(const TensorVector<Backend> &data) {
 
   std::vector<T *> ptrs(shape.num_samples());
   for (int i = 0; i < shape.num_samples(); i++) {
-    ptrs[i] = data[i].template data<U>();
+    ptrs[i] = data.template tensor<U>(i);
   }
   return { std::move(ptrs), convert_dim<ndim>(shape) };
 }
@@ -214,7 +208,7 @@ reinterpret_view(TensorVector<Backend> &data) {
   assert(data.type_info().size() >= sizeof(T));
   assert(data.type_info().size() % sizeof(T) == 0);
   for (int i = 0; i < ret.shape.num_samples(); i++) {
-    ret.data[i] = static_cast<T*>(data[i].raw_mutable_data());
+    ret.data[i] = static_cast<T*>(data.raw_mutable_tensor(i));
   }
   // If reinterpreting to a smaller type, adjust the inner extent
   if (data.type_info().size() > sizeof(T)) {
@@ -243,7 +237,7 @@ reinterpret_view(const TensorVector<Backend> &data) {
   assert(data.type_info().size() >= sizeof(T));
   assert(data.type_info().size() % sizeof(T) == 0);
   for (int i = 0; i < ret.shape.num_samples(); i++) {
-    ret.data[i] = static_cast<T*>(data[i].raw_data());
+    ret.data[i] = static_cast<T*>(data.raw_tensor(i));
   }
   // If reinterpreting to a smaller type, adjust the inner extent
   if (data.type_info().size() > sizeof(T)) {
@@ -254,6 +248,20 @@ reinterpret_view(const TensorVector<Backend> &data) {
     }
   }
   return ret;
+}
+
+
+template <typename Backend>
+SampleView<Backend>
+sample_view(Tensor<Backend> &data) {
+  return { data.raw_mutable_data(), data.shape(), data.type() };
+}
+
+
+template <typename Backend>
+ConstSampleView<Backend>
+const_sample_view(const Tensor<Backend> &data) {
+  return { data.raw_data(), data.shape(), data.type() };
 }
 
 }  // namespace dali

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -149,8 +149,8 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
 
   template <typename T>
   inline void GetMaxSizesCont(T &in, size_t &max_out_size, size_t &max_reserved_size) {
-    auto out_size = in.total_nbytes();
-    auto reserved_size = in.total_capacity();
+    auto out_size = in.nbytes();
+    auto reserved_size = in.capacity();
     max_out_size = std::max<size_t>(std::ceil((out_size * 1.0) / in.num_samples()), max_out_size);
     max_reserved_size = std::max<size_t>(std::ceil((reserved_size * 1.0) / in.num_samples()),
                                          max_reserved_size);
@@ -158,8 +158,8 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
 
   template <typename T>
   inline void GetMaxSizesNonCont(T &in, size_t &max_out_size, size_t &max_reserved_size) {
-    const auto &nbytes = in.nbytes();
-    const auto &capacity = in.capacity();
+    const auto &nbytes = in.chunks_nbytes();
+    const auto &capacity = in.chunks_capacity();
     max_out_size = 0;
     max_reserved_size = 0;
     for (auto &elem : nbytes) {
@@ -205,13 +205,13 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
           max_reserved_size = 0;
           if (ws.template OutputIsType<CPUBackend>(i)) {
             auto &out = ws.template Output<CPUBackend>(i);
-            out_size = out.total_nbytes();
-            reserved_size = out.total_capacity();
+            out_size = out.nbytes();
+            reserved_size = out.capacity();
             GetMaxSizes(out, max_out_size, max_reserved_size);
           } else {
             auto &out = ws.template Output<GPUBackend>(i);
-            out_size = out.total_nbytes();
-            reserved_size = out.total_capacity();
+            out_size = out.nbytes();
+            reserved_size = out.capacity();
             GetMaxSizes(out, max_out_size, max_reserved_size);
           }
           stats[i].real_size = std::max(out_size, stats[i].real_size);

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -170,14 +170,14 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
     }
   }
 
-  template <typename Backend>
-  inline void GetMaxSizes(TensorList<Backend> &in, size_t &max_out_size,
+  template<typename backend>
+  inline void GetMaxSizes(TensorList<backend> &in, size_t &max_out_size,
                           size_t &max_reserved_size) {
     GetMaxSizesCont(in, max_out_size, max_reserved_size);
   }
 
-  template <typename Backend>
-  inline void GetMaxSizes(TensorVector<Backend> &in, size_t &max_out_size,
+  template<typename backend>
+  inline void GetMaxSizes(TensorVector<backend> &in, size_t &max_out_size,
                           size_t &max_reserved_size) {
     if (in.IsContiguous()) {
       GetMaxSizesCont(in, max_out_size, max_reserved_size);

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -158,8 +158,8 @@ class DLL_PUBLIC Executor : public ExecutorBase, public QueuePolicy {
 
   template <typename T>
   inline void GetMaxSizesNonCont(T &in, size_t &max_out_size, size_t &max_reserved_size) {
-    const auto &nbytes = in.chunks_nbytes();
-    const auto &capacity = in.chunks_capacity();
+    const auto &nbytes = in._chunks_nbytes();
+    const auto &capacity = in._chunks_capacity();
     max_out_size = 0;
     max_reserved_size = 0;
     for (auto &elem : nbytes) {

--- a/dali/pipeline/operator/arg_helper_test.cc
+++ b/dali/pipeline/operator/arg_helper_test.cc
@@ -38,7 +38,7 @@ void SetupData(TensorVector<CPUBackend> &tv,
   tv.set_pinned(false);
   tv.Resize(sh, DALI_FLOAT);
   for (size_t i = 0; i < tv.num_samples(); i++) {
-    float *data = tv[i].mutable_data<float>();
+    float *data = tv.mutable_tensor<float>(i);
     for (int j = 0; j < volume(sh[i]); j++) {
       data[j] = 100 * i + j;
     }
@@ -63,7 +63,7 @@ void ArgValueTestTensorInput(TensorListShape<ndim> ts, AcquireArgs... args) {
     auto sh = ts[i];
     ASSERT_EQ(sh, arg[i].shape);
     for (int j = 0; j < volume(sh); j++) {
-      float *ptr = (*arg_data)[i].mutable_data<float>();
+      float *ptr = arg_data->mutable_tensor<float>(i);
       ASSERT_EQ(ptr[j], arg[i].data[j]);
     }
   }

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -33,11 +33,12 @@ void ExternalSource<CPUBackend>::RunImpl(HostWorkspace &ws) {
     auto curr_batch_size = shapes.num_samples();
     output.Resize(shapes, tensor_vector_elm.front()->type());
 
+
     for (int sample_id = 0; sample_id < curr_batch_size; ++sample_id) {
       thread_pool.AddWork(
-          [&ws, sample_id, &tensor_vector_elm](int tid) {
-            Tensor<CPUBackend> &output_tensor = ws.Output<CPUBackend>(0)[sample_id];
-            output_tensor.Copy((*tensor_vector_elm.front())[sample_id], AccessOrder::host());
+          [&output, sample_id, &tensor_vector_elm](int tid) {
+            output.UnsafeCopySample(sample_id, *tensor_vector_elm.front(), sample_id,
+                                    AccessOrder::host());
           },
           shapes.tensor_size(sample_id));
     }

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -255,7 +255,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
     DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", DomainTimeRange::kViolet);
     TensorVector<SrcBackend> tv(vect_of_tensors.size());
     for (size_t i = 0; i < tv.num_samples(); ++i) {
-      tv[i].ShareData(const_cast<Tensor<SrcBackend> &>(vect_of_tensors[i]));
+      tv.UnsafeSetSample(i, const_cast<Tensor<SrcBackend> &>(vect_of_tensors[i]));
     }
     SetDataSourceHelper(tv, order, ext_src_setting_mode);
   }

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -255,7 +255,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
     DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", DomainTimeRange::kViolet);
     TensorVector<SrcBackend> tv(vect_of_tensors.size());
     assert(vect_of_tensors.size() > 0);
-    tv.set_pinned(vect_of_tensors[0].is_pinned());
+    tv.SetupLike(vect_of_tensors[0]);
     for (size_t i = 0; i < tv.num_samples(); ++i) {
       tv.UnsafeSetSample(i, const_cast<Tensor<SrcBackend> &>(vect_of_tensors[i]));
     }

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -20,6 +20,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -253,8 +254,8 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
                             AccessOrder order = {}, ExtSrcSettingMode ext_src_setting_mode = {}) {
     DeviceGuard g(device_id_);
     DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", DomainTimeRange::kViolet);
+    DALI_ENFORCE(vect_of_tensors.size() > 0, "Provided batch cannot be empty.");
     TensorVector<SrcBackend> tv(vect_of_tensors.size());
-    assert(vect_of_tensors.size() > 0);
     tv.SetupLike(vect_of_tensors[0]);
     for (size_t i = 0; i < tv.num_samples(); ++i) {
       tv.UnsafeSetSample(i, const_cast<Tensor<SrcBackend> &>(vect_of_tensors[i]));

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -254,6 +254,8 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
     DeviceGuard g(device_id_);
     DomainTimeRange tr("[DALI][ExternalSource] SetDataSource", DomainTimeRange::kViolet);
     TensorVector<SrcBackend> tv(vect_of_tensors.size());
+    assert(vect_of_tensors.size() > 0);
+    tv.set_pinned(vect_of_tensors[0].is_pinned());
     for (size_t i = 0; i < tv.num_samples(); ++i) {
       tv.UnsafeSetSample(i, const_cast<Tensor<SrcBackend> &>(vect_of_tensors[i]));
     }

--- a/dali/pipeline/operator/builtin/external_source_test.cc
+++ b/dali/pipeline/operator/builtin/external_source_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -202,7 +202,7 @@ class ExternalSourceTest : public::testing::WithParamInterface<int>,
     CUDA_CALL(cudaStreamSynchronize(ws.has_stream() ? ws.stream() : 0));
 
     for (int j = 0; j < this->batch_size_; ++j) {
-      auto data = tensor_cpu_list.template mutable_tensor<int>(j);
+      const auto *data = tensor_cpu_list.template tensor<int>(j);
       for (int i = 0; i < volume(tensor_cpu_list.tensor_shape(j)); ++i) {
         if (data[i] != check_counter_) {
           return false;

--- a/dali/pipeline/operator/builtin/make_contiguous.cc
+++ b/dali/pipeline/operator/builtin/make_contiguous.cc
@@ -26,7 +26,7 @@ void MakeContiguousCPU::RunImpl(HostWorkspace &ws) {
   auto &thread_pool = ws.GetThreadPool();
   for (int sample_id = 0; sample_id < batch_size; ++sample_id) {
     thread_pool.AddWork([sample_id, &input, &output] (int tid) {
-      output[sample_id].Copy(input[sample_id], AccessOrder::host());
+      output.UnsafeCopySample(sample_id, input, sample_id, AccessOrder::host());
     }, shapes.tensor_size(sample_id));
   }
   thread_pool.RunAll();

--- a/dali/pipeline/operator/builtin/make_contiguous.cu
+++ b/dali/pipeline/operator/builtin/make_contiguous.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,11 @@ void MakeContiguousMixed::Run(MixedWorkspace &ws) {
   int sample_dim = input[0].shape().sample_dim();
   size_t batch_size = input.num_samples();
   DALIDataType type = input.type();
+  size_t type_size = input.type_info().size();
 
   for (size_t i = 0; i < input.num_samples(); ++i) {
-    auto &sample = ws.Input<CPUBackend>(0)[i];
-    size_t sample_bytes = sample.nbytes();
+    auto sample = ws.Input<CPUBackend>(0)[i];
+    size_t sample_bytes = sample.shape().num_elements() * type_size;
     if (coalesced && sample_bytes > COALESCE_THRESHOLD)
       coalesced = false;
     DALI_ENFORCE(type == sample.type(), "Inconsistent types in "

--- a/dali/pipeline/operator/common.h
+++ b/dali/pipeline/operator/common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ void GetPerSampleArgument(std::vector<T> &output, const std::string &argument_na
                                                batch_size, ") tensor list. Got: ", shape));
 
       output.resize(batch_size);
-      auto *data = arg[0].template data<T>();
+      auto *data = arg.template tensor<T>(0);
 
       for (int i = 0; i < batch_size; i++) {
         output[i] = data[i];
@@ -75,7 +75,7 @@ void GetPerSampleArgument(std::vector<T> &output, const std::string &argument_na
 
       output.resize(batch_size);
       for (int i = 0; i < batch_size; i++) {
-        output[i] = arg[i].template data<T>()[0];
+        output[i] = arg.template tensor<T>(i)[0];
       }
     }
   } else {
@@ -103,8 +103,7 @@ void GetGeneralizedArg(span<T> result, const std::string &name, int sample_idx, 
   int argument_length = result.size();
   if (spec.HasTensorArgument(name)) {
     const auto& tv = ws.ArgumentInput(name);
-    const auto& tensor = tv[sample_idx];
-    const auto& shape = tensor.shape();
+    const auto& shape = tv.tensor_shape(sample_idx);
     auto vol = volume(shape);
     if (shape.size() != 0) {
       DALI_ENFORCE(shape.size() == 1,
@@ -118,10 +117,10 @@ void GetGeneralizedArg(span<T> result, const std::string &name, int sample_idx, 
     }
     if (vol == 1) {
       for (int i = 0; i < argument_length; i++) {
-        result[i] = tensor.data<T>()[0];
+        result[i] = tv.tensor<T>(sample_idx)[0];
       }
     } else {
-      memcpy(result.data(), tensor.data<T>(), sizeof(T) * argument_length);
+      memcpy(result.data(), tv.tensor<T>(sample_idx), sizeof(T) * argument_length);
     }
     return;
   }

--- a/dali/pipeline/operator/op_spec.h
+++ b/dali/pipeline/operator/op_spec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -494,7 +494,7 @@ inline T OpSpec::GetArgumentImpl(
     DALI_ENFORCE(IsType<T>(value.type()), make_string(
         "Unexpected type of argument \"", name, "\". Expected ",
         TypeTable::GetTypeName<T>(), " and got ", value.type()));
-    return static_cast<T>(value[idx].data<T>()[0]);
+    return static_cast<T>(value.tensor<T>(idx)[0]);
   }
   // Search for the argument locally
   auto arg_it = arguments_.find(name);
@@ -524,7 +524,7 @@ inline bool OpSpec::TryGetArgumentImpl(
     }
     if (!IsType<T>(value.type()))
       return false;
-    result = value[idx].data<T>()[0];
+    result = value.tensor<T>(idx)[0];
     return true;
   }
   // Search for the argument locally

--- a/dali/pipeline/operator/op_spec_test.cc
+++ b/dali/pipeline/operator/op_spec_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ TEST(OpSpecTest, GetArgumentTensorSet) {
     auto tv = std::make_shared<TensorVector<CPUBackend>>(2);
     tv->Resize(TensorListShape<0>(2), DALI_INT32);
     for (int i = 0; i < 2; i++) {
-      tv->tensor_handle(i)->mutable_data<int32_t>()[0] = 42 + i;
+      view<int32_t>((*tv)[i]).data[0] = 42 + i;
     }
     ws0.AddArgumentInput(arg_name, tv);
     auto spec0 = OpSpec("DummyOpForSpecTest")
@@ -325,18 +325,18 @@ class TestArgumentInput_Producer : public Operator<CPUBackend> {
     // Initialize all the data with a 0, 1, 2 .... sequence
     auto &out0 = ws.Output<CPUBackend>(0);
     for (int i = 0; i < out0.shape().num_samples(); i++) {
-      *out0[i].mutable_data<int>() = i;
+      *out0.mutable_tensor<int>(i) = i;
     }
 
     auto &out1 = ws.Output<CPUBackend>(1);
     for (int i = 0; i < out1.shape().num_samples(); i++) {
-      *out1[i].mutable_data<float>() = i;
+      *out1.mutable_tensor<float>(i) = i;
     }
 
     auto &out2 = ws.Output<CPUBackend>(2);
     for (int i = 0; i < out2.shape().num_samples(); i++) {
       for (int j = 0; j < 2; j++) {
-        out2[i].mutable_data<int>()[j] = i;
+        out2.mutable_tensor<int>(i)[j] = i;
       }
     }
   }
@@ -379,7 +379,7 @@ class TestArgumentInput_Consumer : public Operator<CPUBackend> {
     ASSERT_TRUE(is_uniform(ref_1.shape()));
     ASSERT_EQ(ref_1.shape()[0], TensorShape<>(1));
     for (int i = 0; i < ref_1.shape().num_samples(); i++) {
-      EXPECT_EQ(ref_1[i].data<float>()[0], i);
+      EXPECT_EQ(ref_1.tensor<float>(i)[0], i);
     }
 
     auto &ref_2 = ws.ArgumentInput("arg2");
@@ -388,7 +388,7 @@ class TestArgumentInput_Consumer : public Operator<CPUBackend> {
     ASSERT_EQ(ref_2.shape()[0], TensorShape<>(1, 2));
     for (int i = 0; i < ref_2.shape().num_samples(); i++) {
       for (int j = 0; j < 2; j++) {
-        EXPECT_EQ(ref_2[i].data<int>()[j], i);
+        EXPECT_EQ(ref_2.tensor<int>(i)[j], i);
       }
     }
   }

--- a/dali/pipeline/operator/op_spec_test.cc
+++ b/dali/pipeline/operator/op_spec_test.cc
@@ -74,7 +74,7 @@ TEST(OpSpecTest, GetArgumentTensorSet) {
     auto tv = std::make_shared<TensorVector<CPUBackend>>(2);
     tv->Resize(TensorListShape<0>(2), DALI_INT32);
     for (int i = 0; i < 2; i++) {
-      view<int32_t>((*tv)[i]).data[0] = 42 + i;
+      tv->mutable_tensor<int32_t>(i)[0] = 42 + i;
     }
     ws0.AddArgumentInput(arg_name, tv);
     auto spec0 = OpSpec("DummyOpForSpecTest")

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -337,7 +337,11 @@ class Operator<CPUBackend> : public OperatorBase {
         this->RunImpl(sample);
       }, -data_idx);  // -data_idx for FIFO order
     }
+    // Run all tasks and wait for them to finish
     thread_pool.RunAll();
+    // Propagate metadata from individual samples to the whole batch as working with SampleWorkspace
+    // breaks metadata consistency - it sets it only to samples
+    EnforceCorrectness(ws, CanInferOutputs());
   }
 
   /**

--- a/dali/pipeline/operator/operator.h
+++ b/dali/pipeline/operator/operator.h
@@ -341,7 +341,7 @@ class Operator<CPUBackend> : public OperatorBase {
     thread_pool.RunAll();
     // Propagate metadata from individual samples to the whole batch as working with SampleWorkspace
     // breaks metadata consistency - it sets it only to samples
-    EnforceCorrectness(ws, CanInferOutputs());
+    FixBatchPropertiesConsistency(ws, CanInferOutputs());
   }
 
   /**

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -301,13 +301,13 @@ class DummyPresizeOpCPU : public Operator<CPUBackend> {
     const auto &input = ws.Input<CPUBackend>(0);
     int num_samples = input.shape().num_samples();
     auto &output = ws.Output<CPUBackend>(0);
-    auto tmp_size = output.capacity();
+    auto tmp_size = output.total_capacity();
     output.set_type<size_t>();
     output.Resize(uniform_list_shape(num_samples, std::vector<int64_t>{2}));
     for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
-      auto *out = output[sample_idx].mutable_data<size_t>();
+      auto *out = output.mutable_tensor<size_t>(sample_idx);
       out[0] = tmp_size;
-      out[1] = input.capacity();
+      out[1] = input.total_capacity();
     }
   }
 };
@@ -327,7 +327,7 @@ class DummyPresizeOpGPU : public Operator<GPUBackend> {
     int num_samples = input.shape().num_samples();
     auto &output = ws.Output<GPUBackend>(0);
     output.set_type<size_t>();
-    size_t tmp_size[2] = {output.capacity(), input.capacity()};
+    size_t tmp_size[2] = {output.total_capacity(), input.total_capacity()};
     output.Resize(uniform_list_shape(num_samples, std::vector<int64_t>{2}));
     for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
       auto *out = output.mutable_tensor<size_t>(sample_idx);
@@ -353,7 +353,7 @@ class DummyPresizeOpMixed : public Operator<MixedBackend> {
     int num_samples = input.shape().num_samples();
     auto &output = ws.Output<GPUBackend>(0);
     output.set_type<size_t>();
-    size_t tmp_size[2] = {output.capacity(), input.capacity()};
+    size_t tmp_size[2] = {output.total_capacity(), input.total_capacity()};
     output.Resize(uniform_list_shape(num_samples, std::vector<int64_t>{2}));
     for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
       auto *out = output.mutable_tensor<size_t>(sample_idx);

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -301,13 +301,13 @@ class DummyPresizeOpCPU : public Operator<CPUBackend> {
     const auto &input = ws.Input<CPUBackend>(0);
     int num_samples = input.shape().num_samples();
     auto &output = ws.Output<CPUBackend>(0);
-    auto tmp_size = output.total_capacity();
+    auto tmp_size = output.capacity();
     output.set_type<size_t>();
     output.Resize(uniform_list_shape(num_samples, std::vector<int64_t>{2}));
     for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
       auto *out = output.mutable_tensor<size_t>(sample_idx);
       out[0] = tmp_size;
-      out[1] = input.total_capacity();
+      out[1] = input.capacity();
     }
   }
 };
@@ -327,7 +327,7 @@ class DummyPresizeOpGPU : public Operator<GPUBackend> {
     int num_samples = input.shape().num_samples();
     auto &output = ws.Output<GPUBackend>(0);
     output.set_type<size_t>();
-    size_t tmp_size[2] = {output.total_capacity(), input.total_capacity()};
+    size_t tmp_size[2] = {output.capacity(), input.capacity()};
     output.Resize(uniform_list_shape(num_samples, std::vector<int64_t>{2}));
     for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
       auto *out = output.mutable_tensor<size_t>(sample_idx);
@@ -353,7 +353,7 @@ class DummyPresizeOpMixed : public Operator<MixedBackend> {
     int num_samples = input.shape().num_samples();
     auto &output = ws.Output<GPUBackend>(0);
     output.set_type<size_t>();
-    size_t tmp_size[2] = {output.total_capacity(), input.total_capacity()};
+    size_t tmp_size[2] = {output.capacity(), input.capacity()};
     output.Resize(uniform_list_shape(num_samples, std::vector<int64_t>{2}));
     for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
       auto *out = output.mutable_tensor<size_t>(sample_idx);

--- a/dali/pipeline/workspace/sample_workspace.cc
+++ b/dali/pipeline/workspace/sample_workspace.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ void MakeSampleView(SampleWorkspace& sample, HostWorkspace& batch, int data_idx,
   for (int i = 0; i < num_inputs; i++) {
     if (batch.InputIsType<CPUBackend>(i)) {
       auto &input_ref = batch.UnsafeMutableInput<CPUBackend>(i);
-      sample.AddInput(&input_ref[data_idx]);
+      sample.AddInput(input_ref.tensor_handle(data_idx).get());
     } else {
       auto &input_ref = batch.UnsafeMutableInput<GPUBackend>(i);
-      sample.AddInput(&input_ref[data_idx]);
+      sample.AddInput(input_ref.tensor_handle(data_idx).get());
     }
   }
 
@@ -36,15 +36,21 @@ void MakeSampleView(SampleWorkspace& sample, HostWorkspace& batch, int data_idx,
   for (int i = 0; i < num_outputs; i++) {
     if (batch.OutputIsType<CPUBackend>(i)) {
       auto &output_ref = batch.Output<CPUBackend>(i);
-      sample.AddOutput(&output_ref[data_idx]);
+      sample.AddOutput(output_ref.tensor_handle(data_idx).get());
     } else {
       auto &output_ref = batch.Output<GPUBackend>(i);
-      sample.AddOutput(&output_ref[data_idx]);
+      sample.AddOutput(output_ref.tensor_handle(data_idx).get());
     }
   }
   for (auto& arg_pair : batch) {
     assert(!arg_pair.second.should_update);
     sample.AddArgumentInput(arg_pair.first, arg_pair.second.tvec);
+  }
+}
+
+void EnforceCorrectness(HostWorkspace& ws, bool contiguous) {
+  for (int i = 0; i < ws.NumOutput(); i++) {
+    ws.Output<CPUBackend>(i).PropagateUp(contiguous);
   }
 }
 

--- a/dali/pipeline/workspace/sample_workspace.cc
+++ b/dali/pipeline/workspace/sample_workspace.cc
@@ -48,9 +48,9 @@ void MakeSampleView(SampleWorkspace& sample, HostWorkspace& batch, int data_idx,
   }
 }
 
-void EnforceCorrectness(HostWorkspace& ws, bool contiguous) {
+void FixBatchPropertiesConsistency(HostWorkspace& ws, bool contiguous) {
   for (int i = 0; i < ws.NumOutput(); i++) {
-    ws.Output<CPUBackend>(i).PropagateUp(contiguous);
+    ws.Output<CPUBackend>(i).UpdatePropertiesFromSamples(contiguous);
   }
 }
 

--- a/dali/pipeline/workspace/sample_workspace.h
+++ b/dali/pipeline/workspace/sample_workspace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -133,6 +133,17 @@ class DLL_PUBLIC SampleWorkspace : public WorkspaceBase<SampleInputType, SampleO
  */
 DLL_PUBLIC void MakeSampleView(SampleWorkspace& sample, HostWorkspace& batch, int data_idx,
                                  int thread_idx);
+
+/**
+ * @brief After running sample-wise operator we need to fix the Tensor Vector guarantees that were
+ * broken by the legacy operators operating just on samples. We propagate the properties from
+ * samples and enforce they are consistent.
+ *
+ * TODO(klecki): Introduce RAII wrapper for MakeSampleView and EnforceCorrectness
+ * @param batch The workspace to update after executing samplewise operator
+ * @param contiguous If the operator infers outputs and thus uses contiguous allocations
+ */
+DLL_PUBLIC void EnforceCorrectness(HostWorkspace& ws, bool contiguous);
 
 }  // namespace dali
 

--- a/dali/pipeline/workspace/sample_workspace.h
+++ b/dali/pipeline/workspace/sample_workspace.h
@@ -135,15 +135,17 @@ DLL_PUBLIC void MakeSampleView(SampleWorkspace& sample, HostWorkspace& batch, in
                                  int thread_idx);
 
 /**
- * @brief After running sample-wise operator we need to fix the Tensor Vector guarantees that were
- * broken by the legacy operators operating just on samples. We propagate the properties from
- * samples and enforce they are consistent.
+ * @brief Update the TensorVector properties based on the ones that were set in the individual
+ * samples during execution of the sample-wise operator.
  *
- * TODO(klecki): Introduce RAII wrapper for MakeSampleView and EnforceCorrectness
- * @param batch The workspace to update after executing samplewise operator
+ * After running sample-wise operator we need to fix the Tensor Vector guarantees that were
+ * broken by the legacy operators operating just on samples.
+ *
+ * TODO(klecki): Introduce RAII wrapper for MakeSampleView and FixBatchPropertiesConsistency
+ * @param ws The workspace to update after executing samplewise operator
  * @param contiguous If the operator infers outputs and thus uses contiguous allocations
  */
-DLL_PUBLIC void EnforceCorrectness(HostWorkspace& ws, bool contiguous);
+DLL_PUBLIC void FixBatchPropertiesConsistency(HostWorkspace& ws, bool contiguous);
 
 }  // namespace dali
 

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -593,7 +593,7 @@ std::unique_ptr<Tensor<Backend> > TensorListGetItemImpl(TensorList<Backend> &t, 
   auto ptr = std::make_unique<Tensor<Backend>>();
   // TODO(klecki): Rework this with proper sample-based tensor batch data structure
   auto sample_shared_ptr = unsafe_sample_owner(t, id);
-  ptr->ShareData(sample_shared_ptr, t.total_capacity(), t.is_pinned(), t.shape()[id], t.type());
+  ptr->ShareData(sample_shared_ptr, t.capacity(), t.is_pinned(), t.shape()[id], t.type());
   ptr->set_device_id(t.device_id());
   ptr->SetMeta(t.GetMeta(id));
   return ptr;
@@ -613,6 +613,9 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(py::list &list_
   for (size_t i = 0; i < list_of_tensors.size(); ++i) {
     try {
       auto &t = list_of_tensors[i].cast<Tensor<Backend> &>();
+      if (i == 0) {
+        tv.SetupLike(t);
+      }
       DALIDataType cur_type = t.type();
 
       if (expected_type == -2) {
@@ -622,7 +625,6 @@ std::shared_ptr<TensorList<Backend>> TensorListFromListOfTensors(py::list &list_
             "Tensors cannot have different data types. Tensor at position ", i, " has type '",
             cur_type, "' expected to have type '", DALIDataType(expected_type), "'."));
       }
-
       tv.UnsafeSetSample(i, t);
     } catch (const py::type_error &) {
       throw;
@@ -1269,9 +1271,11 @@ void FeedPipeline(Pipeline *p, const string &name, py::list list, AccessOrder or
   TensorVector<Backend> tv(list.size());
   for (size_t i = 0; i < list.size(); ++i) {
     auto &t = list[i].cast<Tensor<Backend>&>();
-    // TODO(klecki): evaluate if we want to keep such code
+    // TODO(klecki): evaluate if we want to keep such code - we need to be able to set
+    // order, pinned, type, dimensionality and layout every time if we don't want
+    // SetSample to do that.
     if (i == 0) {
-      tv.set_pinned(t.is_pinned());
+      tv.SetupLike(t);
     }
     tv.UnsafeSetSample(i, t);
     // TODO(klecki): tv[i] = std::move(t);

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1269,6 +1269,10 @@ void FeedPipeline(Pipeline *p, const string &name, py::list list, AccessOrder or
   TensorVector<Backend> tv(list.size());
   for (size_t i = 0; i < list.size(); ++i) {
     auto &t = list[i].cast<Tensor<Backend>&>();
+    // TODO(klecki): evaluate if we want to keep such code
+    if (i == 0) {
+      tv.set_pinned(t.is_pinned());
+    }
     tv.UnsafeSetSample(i, t);
     // TODO(klecki): tv[i] = std::move(t);
   }

--- a/dali/test/dali_test.h
+++ b/dali/test/dali_test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -186,7 +186,7 @@ class DALITest : public ::testing::Test {
     for (int i = 0; i < n; ++i) {
       std::memcpy(tl->template mutable_tensor<uint8>(i), data[i % nImgs],
                   data_sizes[i % nImgs]);
-      tl->SetSourceInfo(i, imgs.filenames_[i % nImgs]);
+      tl->GetMeta(i).SetSourceInfo(imgs.filenames_[i % nImgs]);
     }
   }
 

--- a/dali/test/dali_test.h
+++ b/dali/test/dali_test.h
@@ -186,7 +186,7 @@ class DALITest : public ::testing::Test {
     for (int i = 0; i < n; ++i) {
       std::memcpy(tl->template mutable_tensor<uint8>(i), data[i % nImgs],
                   data_sizes[i % nImgs]);
-      tl->GetMeta(i).SetSourceInfo(imgs.filenames_[i % nImgs]);
+      tl->SetSourceInfo(i, imgs.filenames_[i % nImgs]);
     }
   }
 

--- a/dali/test/dali_test.h
+++ b/dali/test/dali_test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/test/dali_test_decoder.h
+++ b/dali/test/dali_test_decoder.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,8 @@ class GenericDecoderTest : public DALISingleOpTest<ImgType> {
     // single input - encoded images
     // single output - decoded images
 
-     TensorVector<CPUBackend> out(inputs[0]->num_samples());
+    TensorVector<CPUBackend> out(inputs[0]->num_samples());
+    std::vector<Tensor<CPUBackend>> tmp_out(inputs[0]->num_samples());
 
     const TensorList<CPUBackend> &encoded_data = *inputs[0];
 
@@ -41,7 +42,16 @@ class GenericDecoderTest : public DALISingleOpTest<ImgType> {
       auto *data = encoded_data.tensor<unsigned char>(i);
       auto data_size = volume(encoded_data.tensor_shape(i));
 
-      this->DecodeImage(data, data_size, c, this->ImageType(), &out[i]);
+      this->DecodeImage(data, data_size, c, this->ImageType(), &tmp_out[i]);
+    }
+
+    TensorListShape<> out_shape(inputs[0]->num_samples(), 3);
+    for (size_t i = 0; i < encoded_data.num_samples(); ++i) {
+      out_shape.set_tensor_shape(i, tmp_out[i].shape());
+    }
+    out.Resize(out_shape, DALI_UINT8);
+    for (size_t i = 0; i < encoded_data.num_samples(); ++i) {
+      out.UnsafeSetSample(i, tmp_out[i]);
     }
 
     vector<std::shared_ptr<TensorList<CPUBackend>>> outputs;

--- a/dali/test/dali_test_decoder.h
+++ b/dali/test/dali_test_decoder.h
@@ -45,11 +45,7 @@ class GenericDecoderTest : public DALISingleOpTest<ImgType> {
       this->DecodeImage(data, data_size, c, this->ImageType(), &tmp_out[i]);
     }
 
-    TensorListShape<> out_shape(inputs[0]->num_samples(), 3);
-    for (size_t i = 0; i < encoded_data.num_samples(); ++i) {
-      out_shape.set_tensor_shape(i, tmp_out[i].shape());
-    }
-    out.Resize(out_shape, DALI_UINT8);
+    out.SetupLike(tmp_out[0]);
     for (size_t i = 0; i < encoded_data.num_samples(); ++i) {
       out.UnsafeSetSample(i, tmp_out[i]);
     }

--- a/dali/test/dali_test_resize.h
+++ b/dali/test/dali_test_resize.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #ifndef DALI_TEST_DALI_TEST_RESIZE_H_
 #define DALI_TEST_DALI_TEST_RESIZE_H_
 
@@ -28,6 +28,7 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
     // single input - encoded images
     // single output - decoded images
     TensorVector<CPUBackend> out(inputs[0]->num_samples());
+    std::vector<Tensor<CPUBackend>> tmp_out(inputs[0]->num_samples());
     const TensorList<CPUBackend>& image_data = *inputs[0];
 
     const uint32_t resizeOptions = getResizeOptions();
@@ -175,10 +176,21 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
         finalImg = &mirror_img;
       }
 
-      out[i].Resize({finalImg->rows, finalImg->cols, c}, DALI_UINT8);
-      auto *out_data = out[i].mutable_data<unsigned char>();
+      tmp_out[i].Resize({finalImg->rows, finalImg->cols, c}, DALI_UINT8);
+      auto *out_data = tmp_out[i].mutable_data<unsigned char>();
 
       std::memcpy(out_data, finalImg->ptr(), finalImg->rows * finalImg->cols * c);
+    }
+
+    TensorListShape<> shape(tmp_out.size(), tmp_out[0].shape().sample_dim());
+    for (size_t i = 0; i < image_data.num_samples(); ++i) {
+      shape.set_tensor_shape(i, tmp_out[i].shape());
+    }
+    // TODO(klecki): If sharing we do not need to resize, we just need to enforce that we have
+    // enough samples
+    out.Resize(shape, tmp_out[0].type());
+    for (size_t i = 0; i < image_data.num_samples(); ++i) {
+      out.UnsafeSetSample(i, tmp_out[i]);
     }
 
     vector<std::shared_ptr<TensorList<CPUBackend>>> outputs;

--- a/dali/test/dali_test_resize.h
+++ b/dali/test/dali_test_resize.h
@@ -182,13 +182,7 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
       std::memcpy(out_data, finalImg->ptr(), finalImg->rows * finalImg->cols * c);
     }
 
-    TensorListShape<> shape(tmp_out.size(), tmp_out[0].shape().sample_dim());
-    for (size_t i = 0; i < image_data.num_samples(); ++i) {
-      shape.set_tensor_shape(i, tmp_out[i].shape());
-    }
-    // TODO(klecki): If sharing we do not need to resize, we just need to enforce that we have
-    // enough samples
-    out.Resize(shape, tmp_out[0].type());
+    out.SetupLike(tmp_out[0]);
     for (size_t i = 0; i < image_data.num_samples(); ++i) {
       out.UnsafeSetSample(i, tmp_out[i]);
     }

--- a/dali/util/pybind.h
+++ b/dali/util/pybind.h
@@ -203,8 +203,8 @@ static py::capsule DLTensorToCapsule(DLMTensorPtr dl_tensor) {
 }
 
 template <typename Backend>
-py::capsule TensorToDLPackView(Tensor<Backend> &tensor) {
-  DLMTensorPtr dl_tensor = GetDLTensorView(tensor);
+py::capsule TensorToDLPackView(SampleView<Backend> tensor, int device_id) {
+  DLMTensorPtr dl_tensor = GetDLTensorView(tensor, device_id);
   return DLTensorToCapsule(std::move(dl_tensor));
 }
 


### PR DESCRIPTION
## Category: New feature, Breaking change
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->


## Description:
Add APIs matching TensorList to TensorVector:
* sample pointer accessors
* Set/GetMeta

Change operator[] to return [Const]SampleView.
Introduce UnsafeSetSample and UnsafeCopySample 
to replace TensorVector[i].ShareData(tensor) 
and TensorVector[i].Copy(tensor) - they work with current
code base, but for proper sample-based data structure
more checks should be introduced - intended for follow up.

Adjust code where necessary:
* where possible use data accessors directly on the TensorVector
    instead of the sample, as it should be faster than create temporary, so:
    tv[i].mutable_data<T>() -> tv.mutable_tensor<T>(i) etc.
* Using SampleViews is compatible with code that uses `view<T>`,
    as `view<T>(Tensor)` is equivalent to `view<T>(sample_view(Tensor))` 

Adjustments:
* allow views to work with scalar Tensors (they treated them as empty)
* introduce distinct SampleView and ConstSampleView as they need to
    be returned by value and we need sensible overloads for `view<>`.
* allow to access `capacity` and `nbytes` of individual samples,
    introduce total_capacity and total_nbytes for sum of them.

Next steps written as TODO in TensorVector dosctring.

Keep the SampleView accessors temporarily with leading underscore
so they can be easily adjusted during review.

Current naming:
The sample view has temporary leading underscores in the API (`_raw_data`), 
that would be removed before merging the PR - it's to facilitate renaming in case
it's requested and to help with verifying all calls are reworked to the
intended `tv.raw_tensor(i)` etc.

The `Unsafe` prefix in SetSample and CopySample is intended to temporary stay
there to discourage introduction of new use cases till the followup introduces
remaining checks.  

- [x] Remove prefix `_` from sample view naming before merge.
  
## Additional information:

### Affected modules and functionalities:
TensorVector, SampleView, SampleWorkspace-based operators, CPU operators,
C API, small bits of executor.

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->


<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [x] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
