### PR TITLE
Add non-owning SampleView

### DIFF
--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -110,12 +110,7 @@ class SampleView {
   SampleView &operator=(const SampleView &) = default;
 
   SampleView(SampleView &&other) {
-    data_ = other.data_;
-    other.data_ = nullptr;
-    shape_ = std::move(other.shape_);
-    other.shape_ = {};
-    type_id_ = other.type_id_;
-    other.type_id_ = DALI_NO_TYPE;
+    *this = std::move(other);
   }
 
   SampleView &operator=(SampleView &&other) {
@@ -123,7 +118,7 @@ class SampleView {
       data_ = other.data_;
       other.data_ = nullptr;
       shape_ = std::move(other.shape_);
-      other.shape_ = {};
+      other.shape_ = {0};
       type_id_ = other.type_id_;
       other.type_id_ = DALI_NO_TYPE;
     }
@@ -148,7 +143,7 @@ class SampleView {
   // if the usage of shared_ptr is possbile and adjusted if necessary.
   // Using shared_ptr might allow for sample exchange between two batches using operator[]
   void *data_ = nullptr;
-  TensorShape<> shape_ = {};
+  TensorShape<> shape_ = {0};
   DALIDataType type_id_ = DALI_NO_TYPE;
 };
 

--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -1,0 +1,121 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_DATA_SAMPLE_VIEW_H_
+#define DALI_PIPELINE_DATA_SAMPLE_VIEW_H_
+
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+#include "dali/core/tensor_shape.h"
+#include "dali/pipeline/data/types.h"
+
+namespace dali {
+
+/**
+ * @brief SampleView - non-owning view type, keeping the pointer, shape and runtime type information
+ * of specific sample.
+ *
+ * This is a type corresponding to Tensor<Backend> and it's main goal is to become the return type
+ * for the TensorVector/TensorList::operator[]. It allows to access the data via the
+ * convenient `view<T, ndim>(SampleView)` conversion to TensorView, but doesn't break the batch
+ * object encapsulation and doesn't allow to adjust the allocation.
+ */
+template <typename Backend>
+class SampleView {
+ public:
+  /**
+   * @name Get the underlying pointer to data
+   */
+  // @{
+  void *data() {
+    return data_;
+  }
+
+  const void *data() const {
+    return data_;
+  }
+
+  const void *cdata() const {
+    return data_;
+  }
+  //@}
+
+  /**
+   * @brief Get the shape of the sample
+   */
+  const TensorShape<> &shape() const {
+    return shape_;
+  }
+
+  /**
+   * @brief Get the runtime information about the type of the sample
+   */
+  DALIDataType type() const {
+    return type_id_;
+  }
+
+
+  SampleView() = default;
+
+  SampleView(const SampleView &) = default;
+  SampleView &operator=(const SampleView &) = default;
+
+  SampleView(SampleView &&other) {
+    data_ = other.data_;
+    other.data_ = nullptr;
+    shape_ = std::move(other.shape_);
+    other.shape_ = {};
+    type_id_ = other.type_id_;
+    other.type_id_ = DALI_NO_TYPE;
+  }
+
+  SampleView &operator=(SampleView &&other) {
+    if (this != &other) {
+      data_ = other.data_;
+      other.data_ = nullptr;
+      shape_ = std::move(other.shape_);
+      other.shape_ = {};
+      type_id_ = other.type_id_;
+      other.type_id_ = DALI_NO_TYPE;
+    }
+    return *this;
+  }
+
+  /**
+   * @brief Construct the view inferring the type_id from the pointer value.
+   */
+  template <typename T>
+  SampleView(T *data, TensorShape<> shape)
+      : data_(data), shape_(std::move(shape)), type_id_(TypeTable::GetTypeId<T>()) {}
+
+  /**
+   * @brief Construct the view with explicitly provided type_id.
+   */
+  SampleView(void *data, const TensorShape<> shape, DALIDataType type_id)
+      : data_(data), shape_(std::move(shape)), type_id_(type_id)  {}
+
+ private:
+  // TODO(klecki): The view is introduced with no co-owning pointer, it will be evaluated
+  // if the usage of shared_ptr is possbile and adjusted if necessary.
+  // Using shared_ptr might allow for sample exchange between two batches using operator[]
+  void *data_ = nullptr;
+  TensorShape<> shape_ = {};
+  DALIDataType type_id_ = DALI_NO_TYPE;
+};
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_DATA_SAMPLE_VIEW_H_

--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -40,15 +40,11 @@ class SampleView {
    * @name Get the underlying pointer to data
    */
   // @{
-  void *data() {
+  void *raw_mutable_data() {
     return data_;
   }
 
-  const void *data() const {
-    return data_;
-  }
-
-  const void *cdata() const {
+  const void *raw_data() const {
     return data_;
   }
   //@}

--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -40,12 +40,52 @@ class SampleView {
    * @name Get the underlying pointer to data
    */
   // @{
+  /**
+   * @brief Return an un-typed pointer to the underlying storage.
+   * A valid type must be set prior to calling this method by calling
+   * the non-const version of the method, or calling 'set_type'.
+   */
   void *raw_mutable_data() {
     return data_;
   }
 
+  /**
+   * @brief Return a const, un-typed pointer to the underlying storage.
+   * A valid type must be set prior to calling this method by calling
+   * the non-const version of the method, or calling 'set_type'.
+   */
   const void *raw_data() const {
     return data_;
+  }
+
+  /**
+   * @brief Returns a typed pointer to the underlying storage.
+   * The calling type must match the underlying type of the buffer.
+   */
+  template <typename T>
+  inline T *mutable_data() {
+    DALI_ENFORCE(
+        type() == TypeTable::GetTypeId<T>(),
+        make_string(
+            "Calling type does not match buffer data type, requested type: ",
+            TypeTable::GetTypeId<T>(), " current buffer type: ", type(),
+            ". To set type for the Buffer use 'set_type<T>()' or Resize(shape, type) first."));
+    return static_cast<T *>(data_);
+  }
+
+  /**
+   * @brief Returns a const, typed pointer to the underlying storage.
+   * The calling type must match the underlying type of the buffer.
+   */
+  template <typename T>
+  inline const T *data() const {
+    DALI_ENFORCE(
+        type() == TypeTable::GetTypeId<T>(),
+        make_string(
+            "Calling type does not match buffer data type, requested type: ",
+            TypeTable::GetTypeId<T>(), " current buffer type: ", type(),
+            ". To set type for the Buffer use 'set_type<T>()' or Resize(shape, type) first."));
+    return static_cast<T *>(data_);
   }
   //@}
 
@@ -101,7 +141,7 @@ class SampleView {
    * @brief Construct the view with explicitly provided type_id.
    */
   SampleView(void *data, const TensorShape<> shape, DALIDataType type_id)
-      : data_(data), shape_(std::move(shape)), type_id_(type_id)  {}
+      : data_(data), shape_(std::move(shape)), type_id_(type_id) {}
 
  private:
   // TODO(klecki): The view is introduced with no co-owning pointer, it will be evaluated

--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -42,8 +42,6 @@ class SampleView {
   // @{
   /**
    * @brief Return an un-typed pointer to the underlying storage.
-   * A valid type must be set prior to calling this method by calling
-   * the non-const version of the method, or calling 'set_type'.
    */
   void *raw_mutable_data() {
     return data_;
@@ -51,8 +49,6 @@ class SampleView {
 
   /**
    * @brief Return a const, un-typed pointer to the underlying storage.
-   * A valid type must be set prior to calling this method by calling
-   * the non-const version of the method, or calling 'set_type'.
    */
   const void *raw_data() const {
     return data_;

--- a/dali/pipeline/data/sample_view_test.cc
+++ b/dali/pipeline/data/sample_view_test.cc
@@ -1,0 +1,77 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <numeric>
+#include <utility>
+
+#include "dali/c_api.h"
+#include "dali/core/tensor_shape.h"
+#include "dali/core/tensor_view.h"
+#include "dali/pipeline/data/backend.h"
+#include "dali/pipeline/data/sample_view.h"
+#include "dali/pipeline/data/types.h"
+#include "dali/pipeline/data/views.h"
+
+namespace dali {
+
+
+template <typename SampleView>
+void compare(const SampleView &sv, const void *ptr, const TensorShape<> &shape,
+             DALIDataType dtype) {
+  EXPECT_EQ(sv.data(), ptr);
+  EXPECT_EQ(sv.shape(), shape);
+  EXPECT_EQ(sv.type(), dtype);
+}
+
+
+template <typename TensorView>
+void compare(const TensorView &left, const TensorView &right) {
+  EXPECT_EQ(left.data, right.data);
+  EXPECT_EQ(left.shape, right.shape);
+}
+
+
+TEST(SampleView, Constructors) {
+  SampleView<CPUBackend> default_view{};
+  compare(default_view, nullptr, {}, DALI_NO_TYPE);
+
+  int32_t data{};
+  SampleView<CPUBackend> from_ptr{&data, {1, 2, 3}};
+  compare(from_ptr, &data, {1, 2, 3}, DALI_INT32);
+
+  SampleView<CPUBackend> from_void_ptr{reinterpret_cast<void *>(42), {1, 2, 3}, DALI_FLOAT};
+  compare(from_void_ptr, reinterpret_cast<void *>(42), {1, 2, 3}, DALI_FLOAT);
+}
+
+
+TEST(SampleView, ViewConversion) {
+  int32_t data{};
+  SampleView<CPUBackend> sample_view{&data, {1, 2, 3}};
+  const SampleView<CPUBackend> const_sample_view{&data, {1, 2, 3}};
+
+  compare(view<int32_t>(sample_view), TensorView<StorageCPU, int32_t>{&data, {1, 2, 3}});
+  compare(view<int32_t, 3>(sample_view), TensorView<StorageCPU, int32_t, 3>{&data, {1, 2, 3}});
+  compare(view<const int32_t>(sample_view),
+          TensorView<StorageCPU, const int32_t>{&data, {1, 2, 3}});
+  compare(view<const int32_t, 3>(sample_view),
+          TensorView<StorageCPU, const int32_t, 3>{&data, {1, 2, 3}});
+
+  compare(view<const int32_t>(const_sample_view),
+          TensorView<StorageCPU, const int32_t>{&data, {1, 2, 3}});
+  compare(view<const int32_t, 3>(const_sample_view),
+          TensorView<StorageCPU, const int32_t, 3>{&data, {1, 2, 3}});
+}
+
+}  // namespace dali

--- a/dali/pipeline/data/sample_view_test.cc
+++ b/dali/pipeline/data/sample_view_test.cc
@@ -30,7 +30,7 @@ namespace dali {
 template <typename SampleView>
 void compare(const SampleView &sv, const void *ptr, const TensorShape<> &shape,
              DALIDataType dtype) {
-  EXPECT_EQ(sv.data(), ptr);
+  EXPECT_EQ(sv.raw_data(), ptr);
   EXPECT_EQ(sv.shape(), shape);
   EXPECT_EQ(sv.type(), dtype);
 }

--- a/dali/pipeline/data/sample_view_test.cc
+++ b/dali/pipeline/data/sample_view_test.cc
@@ -45,7 +45,7 @@ void compare(const TensorView &left, const TensorView &right) {
 
 TEST(SampleView, Constructors) {
   SampleView<CPUBackend> default_view{};
-  compare(default_view, nullptr, {}, DALI_NO_TYPE);
+  compare(default_view, nullptr, {0}, DALI_NO_TYPE);
 
   int32_t data{};
   SampleView<CPUBackend> from_ptr{&data, {1, 2, 3}};

--- a/dali/pipeline/data/sample_view_test.cc
+++ b/dali/pipeline/data/sample_view_test.cc
@@ -74,4 +74,13 @@ TEST(SampleView, ViewConversion) {
           TensorView<StorageCPU, const int32_t, 3>{&data, {1, 2, 3}});
 }
 
+TEST(SampleView, ViewConversionError) {
+  int32_t data{};
+  SampleView<CPUBackend> sample_view{&data, {1, 2, 3}};
+  const SampleView<CPUBackend> const_sample_view{&data, {1, 2, 3}};
+
+  EXPECT_THROW(view<float>(sample_view), std::runtime_error);
+  EXPECT_THROW(view<const float>(sample_view), std::runtime_error);
+  EXPECT_THROW(view<const float>(const_sample_view), std::runtime_error);
+}
 }  // namespace dali

--- a/dali/pipeline/data/views.h
+++ b/dali/pipeline/data/views.h
@@ -111,11 +111,8 @@ view(const Tensor<Backend> &data) {
 template <typename T, int ndim = DynamicDimensions, typename Backend>
 TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(SampleView<Backend> &data) {
   using U = std::remove_const_t<T>;
-  DALI_ENFORCE(TypeTable::GetTypeId<U>() == data.type(),
-               make_string("Cannot create TensorView of type ", TypeTable::GetTypeId<U>(),
-                           " from SampleView containing ", data.type(), "."));
   detail::enforce_dim_in_view<ndim>(data.shape());
-  return {static_cast<T *>(data.raw_mutable_data()), data.shape()};
+  return {data.template mutable_data<U>(), data.shape()};
 }
 
 
@@ -125,11 +122,8 @@ TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(const SampleView<Ba
                 "Cannot create a non-const view of a `const Tensor<>`. "
                 "Missing `const` in T?");
   using U = std::remove_const_t<T>;
-  DALI_ENFORCE(TypeTable::GetTypeId<U>() == data.type(),
-               make_string("Cannot create TensorView of type ", TypeTable::GetTypeId<U>(),
-                           " from SampleView containing ", data.type(), "."));
   detail::enforce_dim_in_view<ndim>(data.shape());
-  return {static_cast<T *>(data.raw_data()), data.shape()};
+  return {data.template data<U>(), data.shape()};
 }
 // @}
 

--- a/dali/pipeline/data/views.h
+++ b/dali/pipeline/data/views.h
@@ -115,7 +115,7 @@ TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(SampleView<Backend>
                make_string("Cannot create TensorView of type ", TypeTable::GetTypeId<U>(),
                            " from SampleView containing ", data.type(), "."));
   detail::enforce_dim_in_view<ndim>(data.shape());
-  return {static_cast<T *>(data.data()), data.shape()};
+  return {static_cast<T *>(data.raw_mutable_data()), data.shape()};
 }
 
 
@@ -129,7 +129,7 @@ TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(const SampleView<Ba
                make_string("Cannot create TensorView of type ", TypeTable::GetTypeId<U>(),
                            " from SampleView containing ", data.type(), "."));
   detail::enforce_dim_in_view<ndim>(data.shape());
-  return {static_cast<T *>(data.cdata()), data.shape()};
+  return {static_cast<T *>(data.raw_data()), data.shape()};
 }
 // @}
 

--- a/dali/pipeline/data/views.h
+++ b/dali/pipeline/data/views.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,13 @@
 #define  DALI_PIPELINE_DATA_VIEWS_H_
 
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include "dali/core/backend_tags.h"
+#include "dali/core/tensor_shape.h"
 #include "dali/core/tensor_view.h"
+#include "dali/pipeline/data/sample_view.h"
 #include "dali/pipeline/data/tensor.h"
 #include "dali/pipeline/data/tensor_list.h"
 #include "dali/pipeline/data/tensor_vector.h"
@@ -83,7 +86,7 @@ view(Tensor<Backend> &data) {
     return {};
   using U = std::remove_const_t<T>;
   detail::enforce_dim_in_view<ndim>(data.shape());
-  return { data.template mutable_data<U>(),  convert_dim<ndim>(data.shape()) };
+  return { data.template mutable_data<U>(), convert_dim<ndim>(data.shape()) };
 }
 
 
@@ -99,6 +102,36 @@ view(const Tensor<Backend> &data) {
   detail::enforce_dim_in_view<ndim>(data.shape());
   return { data.template data<U>(), convert_dim<ndim>(data.shape()) };
 }
+
+
+/**
+ * @name Convert from SampleView carrying runtime type information to statically typed TensorView.
+ */
+// @{
+template <typename T, int ndim = DynamicDimensions, typename Backend>
+TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(SampleView<Backend> &data) {
+  using U = std::remove_const_t<T>;
+  DALI_ENFORCE(TypeTable::GetTypeId<U>() == data.type(),
+               make_string("Cannot create TensorView of type ", TypeTable::GetTypeId<U>(),
+                           " from SampleView containing ", data.type(), "."));
+  detail::enforce_dim_in_view<ndim>(data.shape());
+  return {static_cast<T *>(data.data()), data.shape()};
+}
+
+
+template <typename T, int ndim = DynamicDimensions, typename Backend>
+TensorView<detail::storage_tag_map_t<Backend>, T, ndim> view(const SampleView<Backend> &data) {
+  static_assert(std::is_const<T>::value,
+                "Cannot create a non-const view of a `const Tensor<>`. "
+                "Missing `const` in T?");
+  using U = std::remove_const_t<T>;
+  DALI_ENFORCE(TypeTable::GetTypeId<U>() == data.type(),
+               make_string("Cannot create TensorView of type ", TypeTable::GetTypeId<U>(),
+                           " from SampleView containing ", data.type(), "."));
+  detail::enforce_dim_in_view<ndim>(data.shape());
+  return {static_cast<T *>(data.cdata()), data.shape()};
+}
+// @}
 
 
 template <typename T, int ndim = DynamicDimensions, typename Backend>
@@ -228,7 +261,6 @@ reinterpret_view(const TensorVector<Backend> &data) {
   }
   return ret;
 }
-
 
 }  // namespace dali
 

--- a/include/dali/core/tensor_view.h
+++ b/include/dali/core/tensor_view.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ struct TensorViewBase {
   }
 
   template <int other_ndim>
-  TensorView<Backend, DataType, other_ndim> to_static();
+  TensorView<Backend, DataType, other_ndim> to_static() const;
 
   DataType *data = nullptr;
   TensorShape<ndim> shape;
@@ -224,7 +224,8 @@ struct TensorView : TensorViewBase<Backend, DataType, ndim> {
 
 template <typename Backend, typename DataType, int ndim>
 template <int other_ndim>
-TensorView<Backend, DataType, other_ndim> TensorViewBase<Backend, DataType, ndim>::to_static() {
+TensorView<Backend, DataType, other_ndim>
+TensorViewBase<Backend, DataType, ndim>::to_static() const {
   static_assert(other_ndim != DynamicDimensions,
                 "Conversion to static only allowed for static shape");
   static_assert(ndim == other_ndim || ndim == DynamicDimensions, "Cannot convert to other ndim");


### PR DESCRIPTION
 ## Category: **New feature**  

Replacing #3700

## Description: 
Add non-owning SampleView

The purpose is to have Tensor wrapper that is similar
to already existing DALI vocabulary types representing
Tensor:
* it is non-owning view to the data
* it allows to access the pointer, the shape and the type id
* can be used as argument to view the same way as Tensor
but as opposed to Tensor doesn't allow to adjust the allocation.

The target of this type is to use it as the return
type of the TensorBatch::operator[] - using static type
is not possible due to the Tensor[List/Vector] not being
statically typed. This should allow for proper encapsulation
of the batch object - SampleView allows access to the data
but does not allow to adjust the allocation or changing
the metadata through the view - as oposed to the currently
used Tensor.

Add conversion from SampleView to statically typed TensorView
using view<T, ndim> template function.

### To consider
Options for follow-up:
* shared_ptr as member to have co-ownership instead of non-owning type.

## Additional information:

### Affected modules and functionalities:
views


### Key points relevant for the review:
Proper encapsulation?

<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [x] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
