### PR TITLE
Fix ES debug mode test failing with missing batch

### DIFF
--- a/dali/test/python/test_pipeline_debug.py
+++ b/dali/test/python/test_pipeline_debug.py
@@ -193,6 +193,8 @@ def test_external_source_debug_sample_pipeline():
     pipe_debug = es_pipeline_debug(prefetch_queue_depth=prefetch_queue_depth)
     pipe_load.build()
     pipe_debug.build()
+    # Call feed_input `prefetch_queue_depth` extra times to avoid issues with
+    # missing batches near the end of the epoch caused by prefetching
     for _ in range(n_iters + prefetch_queue_depth):
         images, labels = pipe_load.run()
         pipe_debug.feed_input('input', [np.array(t) for t in images])
@@ -216,6 +218,8 @@ def _test_external_source_debug(source, batch):
     pipe_debug.build()
     pipe_standard.build()
     if source is None:
+        # Call feed_input `prefetch_queue_depth` extra times to avoid issues with
+        # missing batches near the end of the epoch caused by prefetching
         for _ in range(n_iters + prefetch_queue_depth):
             x = np.random.rand(8, 5, 1)
             pipe_debug.feed_input('input', x)

--- a/dali/test/python/test_pipeline_debug.py
+++ b/dali/test/python/test_pipeline_debug.py
@@ -187,12 +187,13 @@ def es_pipeline_standard():
 
 def test_external_source_debug_sample_pipeline():
     n_iters = 10
+    prefetch_queue_depth = 2
     pipe_load = load_images_pipeline()
-    pipe_standard = es_pipeline_standard()
-    pipe_debug = es_pipeline_debug()
+    pipe_standard = es_pipeline_standard(prefetch_queue_depth=prefetch_queue_depth)
+    pipe_debug = es_pipeline_debug(prefetch_queue_depth=prefetch_queue_depth)
     pipe_load.build()
     pipe_debug.build()
-    for _ in range(n_iters):
+    for _ in range(n_iters + prefetch_queue_depth):
         images, labels = pipe_load.run()
         pipe_debug.feed_input('input', [np.array(t) for t in images])
         pipe_debug.feed_input('labels', np.array(labels.as_tensor()))
@@ -209,12 +210,13 @@ def es_pipeline(source, batch):
 
 def _test_external_source_debug(source, batch):
     n_iters = 8
-    pipe_debug = es_pipeline(source, batch, debug=True)
-    pipe_standard = es_pipeline(source, batch)
+    prefetch_queue_depth = 2
+    pipe_debug = es_pipeline(source, batch, prefetch_queue_depth=prefetch_queue_depth, debug=True)
+    pipe_standard = es_pipeline(source, batch, prefetch_queue_depth=prefetch_queue_depth)
     pipe_debug.build()
     pipe_standard.build()
     if source is None:
-        for _ in range(n_iters):
+        for _ in range(n_iters + prefetch_queue_depth):
             x = np.random.rand(8, 5, 1)
             pipe_debug.feed_input('input', x)
             pipe_standard.feed_input('input', x)


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
**Bug fix** (*non-breaking change which fixes an issue*) 
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
Increases the number of input batches fed into the external source to make allowance for `prefetch_queue_depth`, so that the test does not randomly fail with missing batch error.



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2621
<!--- DALI-XXXX or NA --->
