### PR TITLE
Fix stream usage in C API

### DIFF
--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -962,7 +962,7 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
   daliDeletePipeline(&handle);
 }
 
-TYPED_TEST(CApiTest, CpuOnlyTest) {
+TEST(CApiTest, CpuOnlyTest) {
   dali::Pipeline pipe(1, 1, dali::CPU_ONLY_DEVICE_ID);
   pipe.AddExternalInput("dummy");
   std::vector<std::pair<std::string, std::string>> outputs = {{"dummy", "cpu"}};

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -69,9 +69,27 @@ std::string GetDeviceStr(device_type_t dev) {
   return dev == CPU ? "cpu" : "gpu";
 }
 
+// Allocates a buffer on the specified backend and, if necessary, another one for the CPU
+template <typename Backend>
+std::pair<shared_ptr<uint8_t>, shared_ptr<uint8_t>> AllocBufferPair(size_t bytes, bool pinned) {
+  auto buffer = AllocBuffer<Backend>(bytes, pinned);
+  if constexpr (std::is_same_v<Backend, CPUBackend>) {
+    return std::make_pair(buffer, buffer);
+  } else {
+    return std::make_pair(buffer, AllocBuffer<CPUBackend>(bytes, pinned));
+  }
+}
+
+void CopyIfDifferent(void *dest, const void *src, size_t bytes, cudaStream_t stream) {
+  if (dest != src)
+    MemCopy(dest, src, bytes, stream);
+}
+
+
 template<typename Backend, device_type_t execution_device = backend_to_device_type<Backend>::value>
 std::unique_ptr<Pipeline> GetTestPipeline(bool is_file_reader, const std::string &output_device) {
-  auto pipe_ptr = std::make_unique<Pipeline>(batch_size, num_thread, device_id, seed, pipelined,
+  int dev = output_device == "cpu" ? CPU_ONLY_DEVICE_ID : device_id;
+  auto pipe_ptr = std::make_unique<Pipeline>(batch_size, num_thread, dev, seed, pipelined,
                                              prefetch_queue_depth, async);
   auto &pipe = *pipe_ptr;
   std::string exec_device = GetDeviceStr(execution_device);
@@ -110,7 +128,8 @@ std::unique_ptr<Pipeline> GetTestPipeline(bool is_file_reader, const std::string
 
 
 std::unique_ptr<Pipeline> GetExternalSourcePipeline(bool no_copy, const std::string &device) {
-  auto pipe_ptr = std::make_unique<Pipeline>(batch_size, num_thread, device_id, seed, pipelined,
+  int dev = device == "cpu" ? CPU_ONLY_DEVICE_ID : device_id;
+  auto pipe_ptr = std::make_unique<Pipeline>(batch_size, num_thread, dev, seed, pipelined,
                                              prefetch_queue_depth, async);
   auto &pipe = *pipe_ptr;
 
@@ -160,18 +179,22 @@ void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline,
     }
 
     TensorList<CPUBackend> pipeline_output_cpu, c_api_output_cpu;
+    pipeline_output_cpu.set_pinned(false);
+    c_api_output_cpu.set_pinned(false);
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    pipeline_output_cpu.Copy(ws.Output<Backend>(0), cuda_stream);
+    AccessOrder order = std::is_same_v<Backend, GPUBackend> ? AccessOrder(cuda_stream)
+                                                            : AccessOrder::host();
+    pipeline_output_cpu.Copy(ws.Output<Backend>(0), order);
 
     auto num_elems = pipeline_output_cpu.shape().num_elements();
-    auto backend_buf = AllocBuffer<Backend>(num_elems * sizeof(uint8_t), false);
-    auto cpu_buf = AllocBuffer<CPUBackend>(num_elems * sizeof(uint8_t), false);
+    auto [backend_buf, cpu_buf] = AllocBufferPair<Backend>(num_elems, false);
+
     daliOutputCopy(&handle, backend_buf.get(), 0,
                    backend_to_device_type<Backend>::value, 0, copy_output_flags);
 
-    // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    MemCopy(cpu_buf.get(), backend_buf.get(), num_elems * sizeof(uint8_t), cuda_stream);
-    CUDA_CALL(cudaDeviceSynchronize());
+    CopyIfDifferent(cpu_buf.get(), backend_buf.get(), num_elems, cuda_stream);
+    if (std::is_same_v<Backend, GPUBackend>)
+      CUDA_CALL(cudaDeviceSynchronize());
     Check(view<uint8_t>(pipeline_output_cpu),
           TensorListView<StorageCPU, uint8_t>(cpu_buf.get(), pipeline_output_cpu.shape()));
   }
@@ -182,7 +205,16 @@ void ComparePipelinesOutputs(daliPipelineHandle &handle, Pipeline &baseline,
 template<typename Backend>
 class CApiTest : public ::testing::Test {
  protected:
-  std::string output_device_ = backend_to_device_type<Backend>::value == CPU ? "cpu"s : "gpu"s;
+  CApiTest() {
+    constexpr bool is_device = std::is_same_v<Backend, GPUBackend>;
+    output_device_ = is_device ? "gpu" : "cpu";
+    device_id_ = is_device ? device_id : CPU_ONLY_DEVICE_ID;
+    order_ = is_device ? AccessOrder(cuda_stream) : AccessOrder::host();
+  }
+
+  std::string output_device_;
+  int device_id_;
+  AccessOrder order_;
 };
 
 using Backends = ::testing::Types<CPUBackend, GPUBackend>;
@@ -192,8 +224,8 @@ TYPED_TEST_SUITE(CApiTest, Backends);
 TYPED_TEST(CApiTest, GetOutputNameTest) {
   std::string output0_name = "compressed_images";
   std::string output1_name = "labels";
-  auto pipe_ptr = std::make_unique<Pipeline>(batch_size, num_thread, device_id, seed, pipelined,
-                                             prefetch_queue_depth, async);
+  auto pipe_ptr = std::make_unique<Pipeline>(batch_size, num_thread, this->device_id_,
+                                            seed, pipelined, prefetch_queue_depth, async);
   auto &pipe = *pipe_ptr;
   std::string file_root = testing::dali_extra_path() + "/db/single/jpeg/";
   std::string file_list = file_root + "image_list.txt";
@@ -213,7 +245,7 @@ TYPED_TEST(CApiTest, GetOutputNameTest) {
 
   daliPipelineHandle handle;
   daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
-                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     this->device_id_, false, prefetch_queue_depth, prefetch_queue_depth,
                      prefetch_queue_depth, false);
 
   ASSERT_EQ(daliGetNumOutput(&handle), 2);
@@ -236,7 +268,7 @@ TYPED_TEST(CApiTest, FileReaderPipe) {
 
   daliPipelineHandle handle;
   daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
-                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     this->device_id_, false, prefetch_queue_depth, prefetch_queue_depth,
                      prefetch_queue_depth, false);
   daliPrefetchUniform(&handle, prefetch_queue_depth);
 
@@ -286,8 +318,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
   auto num_elems = input_shape.num_elements();
 
-  auto input_cpu = AllocBuffer<CPUBackend>(num_elems * sizeof(uint8_t), false);
-  auto input = AllocBuffer<TypeParam>(num_elems * sizeof(uint8_t), false);
+  auto [input, input_cpu] = AllocBufferPair<TypeParam>(num_elems, false);
   TensorList<TypeParam> input_wrapper;
 
   auto pipe_ptr = GetTestPipeline<TypeParam>(false, this->output_device_);
@@ -297,14 +328,13 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
 
   daliPipelineHandle handle;
   daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
-                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     this->device_id_, false, prefetch_queue_depth, prefetch_queue_depth,
                      prefetch_queue_depth, false);
 
   for (int i = 0; i < prefetch_queue_depth; i++) {
     SequentialFill(TensorListView<StorageCPU, uint8_t>(input_cpu.get(), input_shape), 42 * i);
-    // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    MemCopy(input.get(), input_cpu.get(), num_elems * sizeof(uint8_t), cuda_stream);
-    input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems * sizeof(uint8_t),
+    CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
+    input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
                             false, input_shape, DALI_UINT8);
     pipe_ptr->SetExternalInput(input_name, input_wrapper);
     daliSetExternalInputBatchSize(&handle, input_name.c_str(), input_shape.num_samples());
@@ -327,8 +357,8 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
   SequentialFill(TensorListView<StorageCPU, uint8_t>(input_cpu.get(), input_shape),
                  42 * prefetch_queue_depth);
   // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-  MemCopy(input.get(), input_cpu.get(), num_elems * sizeof(uint8_t), cuda_stream);
-  input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems * sizeof(uint8_t),
+  CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
+  input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
                           false, input_shape, DALI_UINT8);
   pipe_ptr->SetExternalInput(input_name, input_wrapper);
   daliSetExternalInputAsync(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
@@ -359,7 +389,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocVariableBatchSizePipe) {
 
   daliPipelineHandle handle;
   daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
-                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     this->device_id_, false, prefetch_queue_depth, prefetch_queue_depth,
                      prefetch_queue_depth, false);
 
   for (auto &input_shape : trimmed_input_shapes) {
@@ -368,15 +398,14 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocVariableBatchSizePipe) {
 
     auto num_elems = input_shape.num_elements();
 
-    auto input_cpu = AllocBuffer<CPUBackend>(num_elems * sizeof(uint8_t), false);
-    auto input = AllocBuffer<TypeParam>(num_elems * sizeof(uint8_t), false);
+    auto [input, input_cpu] = AllocBufferPair<TypeParam>(num_elems, false);
     TensorList<TypeParam> input_wrapper;
 
     for (int i = 0; i < prefetch_queue_depth; i++) {
       SequentialFill(TensorListView<StorageCPU, uint8_t>(input_cpu.get(), input_shape), 42 * i);
       // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-      MemCopy(input.get(), input_cpu.get(), num_elems, cuda_stream);
-      input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems * sizeof(uint8_t),
+      CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
+      input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
                               false, input_shape, DALI_UINT8);
       pipe_ptr->SetExternalInput(input_name, input_wrapper);
       daliSetExternalInputBatchSize(&handle, input_name.c_str(), input_shape.num_samples());
@@ -408,7 +437,9 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
   TensorList<CPUBackend> input_cpu;
   TensorList<TypeParam> input;
+  input_cpu.set_pinned(false);
   input_cpu.Resize(input_shape, DALI_UINT8);
+  input.set_pinned(false);
   std::vector<const void *> data_ptrs(batch_size);
   for (int i = 0; i < batch_size; i++) {
     data_ptrs[i] = input_cpu.raw_tensor(i);
@@ -420,18 +451,18 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
 
   daliPipelineHandle handle;
   daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
-                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     this->device_id_, false, prefetch_queue_depth, prefetch_queue_depth,
                      prefetch_queue_depth, false);
 
   for (int i = 0; i < prefetch_queue_depth; i++) {
     SequentialFill(view<uint8_t>(input_cpu), 42 * i);
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    input.Copy(input_cpu, cuda_stream);
-    pipe_ptr->SetExternalInput(input_name, input, cuda_stream);
+    input.Copy(input_cpu, this->order_);
+    pipe_ptr->SetExternalInput(input_name, input, this->order_);
     daliSetExternalInputTensorsAsync(&handle, input_name.c_str(),
                                      backend_to_device_type<TypeParam>::value, data_ptrs.data(),
                                      dali_data_type_t::DALI_UINT8, input_shape.data(),
-                                     input_shape.sample_dim(), nullptr, cuda_stream,
+                                     input_shape.sample_dim(), nullptr, this->order_.stream(),
                                      DALI_ext_default);
   }
 
@@ -448,8 +479,8 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
 
   SequentialFill(view<uint8_t>(input_cpu), 42 * prefetch_queue_depth);
   // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-  input.Copy(input_cpu, cuda_stream);
-  pipe_ptr->SetExternalInput(input_name, input, cuda_stream);
+  input.Copy(input_cpu, this->order_);
+  pipe_ptr->SetExternalInput(input_name, input, this->order_);
   daliSetExternalInputTensorsAsync(&handle, input_name.c_str(),
                                    backend_to_device_type<TypeParam>::value, data_ptrs.data(),
                                    dali_data_type_t::DALI_UINT8, input_shape.data(),
@@ -466,7 +497,7 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocPipe) {
 TYPED_TEST(CApiTest, ExternalSourceSingleAllocDifferentBackendsTest) {
   using OpBackend = TypeParam;
   using DataBackend = typename the_other_backend<TypeParam>::type;
-  if (std::is_same<OpBackend, CPUBackend>::value && std::is_same<DataBackend, GPUBackend>::value) {
+  if (std::is_same_v<OpBackend, CPUBackend> && std::is_same_v<DataBackend, GPUBackend>) {
     GTEST_SKIP();  // GPU data -> CPU op   is currently not supported. Might be added later.
   }
   TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8,  8,  3},
@@ -474,8 +505,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocDifferentBackendsTest) {
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
   auto num_elems = input_shape.num_elements();
 
-  auto input_cpu = AllocBuffer<CPUBackend>(num_elems * sizeof(uint8_t), false);
-  auto input = AllocBuffer<DataBackend>(num_elems * sizeof(uint8_t), false);
+  auto [input, input_cpu] = AllocBufferPair<DataBackend>(num_elems, false);
   TensorList<DataBackend> input_wrapper;
 
   auto pipe_ptr = GetTestPipeline<OpBackend>(false, this->output_device_);
@@ -485,15 +515,14 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocDifferentBackendsTest) {
 
   daliPipelineHandle handle;
   daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
-                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     this->device_id_, false, prefetch_queue_depth, prefetch_queue_depth,
                      prefetch_queue_depth, false);
 
   for (int i = 0; i < prefetch_queue_depth; i++) {
     SequentialFill(TensorListView<StorageCPU, uint8_t>(input_cpu.get(), input_shape), 42 * i);
-    // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    MemCopy(input.get(), input_cpu.get(), num_elems, cuda_stream);
+    CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
     CUDA_CALL(cudaStreamSynchronize(cuda_stream));
-    input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems * sizeof(uint8_t),
+    input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
                             false, input_shape, DALI_UINT8);
     pipe_ptr->SetExternalInput(input_name, input_wrapper);
     daliSetExternalInput(&handle, input_name.c_str(), backend_to_device_type<DataBackend>::value,
@@ -515,9 +544,9 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocDifferentBackendsTest) {
   SequentialFill(TensorListView<StorageCPU, uint8_t>(input_cpu.get(), input_shape),
                   42 * prefetch_queue_depth);
   // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-  MemCopy(input.get(), input_cpu.get(), num_elems, cuda_stream);
+  CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
   CUDA_CALL(cudaStreamSynchronize(cuda_stream));
-  input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems * sizeof(uint8_t),
+  input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
                           false, input_shape, DALI_UINT8);
   pipe_ptr->SetExternalInput(input_name, input_wrapper);
   daliSetExternalInput(&handle, input_name.c_str(), backend_to_device_type<DataBackend>::value,
@@ -535,7 +564,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocDifferentBackendsTest) {
 TYPED_TEST(CApiTest, ExternalSourceMultipleAllocDifferentBackendsTest) {
   using OpBackend = TypeParam;
   using DataBackend = typename the_other_backend<TypeParam>::type;
-  if (std::is_same<OpBackend, CPUBackend>::value && std::is_same<DataBackend, GPUBackend>::value) {
+  if (std::is_same_v<OpBackend, CPUBackend> && std::is_same_v<DataBackend, GPUBackend>) {
     GTEST_SKIP();  // GPU data -> CPU op   is currently not supported. Might be added later.
   }
   TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8,  8,  3},
@@ -555,13 +584,13 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocDifferentBackendsTest) {
 
   daliPipelineHandle handle;
   daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
-                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     this->device_id_, false, prefetch_queue_depth, prefetch_queue_depth,
                      prefetch_queue_depth, false);
 
   for (int i = 0; i < prefetch_queue_depth; i++) {
     SequentialFill(view<uint8_t>(input_cpu), 42 * i);
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    input.Copy(input_cpu, cuda_stream);
+    input.Copy(input_cpu, this->order_);
     CUDA_CALL(cudaStreamSynchronize(cuda_stream));
     pipe_ptr->SetExternalInput(input_name, input, cuda_stream);
     daliSetExternalInputTensors(&handle, input_name.c_str(),
@@ -583,7 +612,7 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocDifferentBackendsTest) {
 
   SequentialFill(view<uint8_t>(input_cpu), 42 * prefetch_queue_depth);
   // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-  input.Copy(input_cpu, cuda_stream);
+  input.Copy(input_cpu, this->order_);
   CUDA_CALL(cudaStreamSynchronize(cuda_stream));
   pipe_ptr->SetExternalInput(input_name, input, cuda_stream);
   daliSetExternalInputTensors(&handle, input_name.c_str(),
@@ -605,12 +634,13 @@ TYPED_TEST(CApiTest, TestExecutorMeta) {
   pipe_ptr.reset();
   daliPipelineHandle handle;
   daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
-                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     this->device_id_, false, prefetch_queue_depth, prefetch_queue_depth,
                      prefetch_queue_depth, true);
 
   daliRun(&handle);
   daliOutput(&handle);
-  CUDA_CALL(cudaDeviceSynchronize());
+  if (std::is_same_v<TypeParam, GPUBackend>)
+    CUDA_CALL(cudaDeviceSynchronize());
 
   size_t N;
   daliExecutorMetadata *meta;
@@ -631,11 +661,10 @@ TYPED_TEST(CApiTest, UseCopyKernel) {
                                    {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
   auto num_elems = input_shape.num_elements();
-  auto input_cpu = AllocBuffer<CPUBackend>(num_elems * sizeof(uint8_t), false);
-  auto input = AllocBuffer<TypeParam>(num_elems * sizeof(uint8_t),
-                                      std::is_same<TypeParam, CPUBackend>::value);
+  auto [input, input_cpu] = AllocBufferPair<TypeParam>(num_elems, true);
+
   TensorList<TypeParam> input_wrapper;
-  if (std::is_same<TypeParam, CPUBackend>::value) {
+  if (std::is_same_v<TypeParam, CPUBackend>) {
     input_wrapper.set_pinned(true);
   }
 
@@ -645,18 +674,18 @@ TYPED_TEST(CApiTest, UseCopyKernel) {
 
   daliPipelineHandle handle;
   daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
-                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     this->device_id_, false, prefetch_queue_depth, prefetch_queue_depth,
                      prefetch_queue_depth, false);
 
   unsigned int flags = DALI_ext_default | DALI_ext_force_sync | DALI_use_copy_kernel;
-  if (std::is_same<TypeParam, CPUBackend>::value)
+  if (std::is_same_v<TypeParam, CPUBackend>)
     flags |= DALI_ext_pinned;
   for (int i = 0; i < prefetch_queue_depth; i++) {
     SequentialFill(TensorListView<StorageCPU, uint8_t>(input_cpu.get(), input_shape), 42 * i);
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    MemCopy(input.get(), input_cpu.get(), num_elems, cuda_stream);
-    input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems * sizeof(uint8_t),
-                            std::is_same<TypeParam, CPUBackend>::value, input_shape, DALI_UINT8);
+    CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
+    input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
+                            std::is_same_v<TypeParam, CPUBackend>, input_shape, DALI_UINT8);
     pipe_ptr->SetExternalInput(input_name, input_wrapper);
     daliSetExternalInputAsync(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
                               input.get(), dali_data_type_t::DALI_UINT8, input_shape.data(),
@@ -678,13 +707,13 @@ TYPED_TEST(CApiTest, UseCopyKernel) {
 
 
 TYPED_TEST(CApiTest, ForceNoCopyFail) {
+  this->device_id_ = device_id;  // we need both backends here
   TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
                                    {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
   auto num_elems = input_shape.num_elements();
 
-  auto input_cpu = AllocBuffer<CPUBackend>(num_elems * sizeof(uint8_t), false);
-  auto input = AllocBuffer<TypeParam>(num_elems * sizeof(uint8_t), false);
+  auto [input, input_cpu] = AllocBufferPair<TypeParam>(num_elems, false);
 
   auto device = backend_to_device_type<TypeParam>::value;
   std::string device_str = GetDeviceStr(device);
@@ -697,12 +726,12 @@ TYPED_TEST(CApiTest, ForceNoCopyFail) {
 
   daliPipelineHandle handle;
   daliCreatePipeline(&handle, serialized.c_str(), serialized.size(), batch_size, num_thread,
-                     device_id, false, prefetch_queue_depth, prefetch_queue_depth,
+                     this->device_id_, false, prefetch_queue_depth, prefetch_queue_depth,
                      prefetch_queue_depth, false);
 
     SequentialFill(TensorListView<StorageCPU, uint8_t>(input_cpu.get(), input_shape), 42);
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    MemCopy(input.get(), input_cpu.get(), num_elems, cuda_stream);
+    CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
 
   // Try to fill the pipeline placed on "other_device" with data placed on the current "device"
   // while forcing NO COPY. It's not allowed to do a no copy across backends and it should error
@@ -717,13 +746,13 @@ TYPED_TEST(CApiTest, ForceNoCopyFail) {
 
 
 template <typename TypeParam>
-void TestForceFlagRun(bool ext_src_no_copy, unsigned int flag_to_test) {
+void TestForceFlagRun(bool ext_src_no_copy, unsigned int flag_to_test, int device_id) {
   TensorListShape<> input_shape = {{37, 23, 3}, {12, 22, 3}, {42, 42, 3}, {8, 8, 3},
                                    {64, 32, 3}, {32, 64, 3}, {20, 20, 3}, {64, 64, 3},
                                    {10, 10, 3}, {60, 50, 3}, {10, 15, 3}, {48, 48, 3}};
   auto num_elems = input_shape.num_elements();
 
-  auto input_cpu = AllocBuffer<CPUBackend>(num_elems * sizeof(uint8_t), false);
+  auto input_cpu = AllocBuffer<CPUBackend>(num_elems, false);
 
   auto device = backend_to_device_type<TypeParam>::value;
   std::string device_str = GetDeviceStr(device);
@@ -741,15 +770,18 @@ void TestForceFlagRun(bool ext_src_no_copy, unsigned int flag_to_test) {
   std::vector<std::shared_ptr<uint8_t>> data;
   data.reserve(prefetch_queue_depth);
   for (int i = 0; i < prefetch_queue_depth; i++) {
-    data.push_back(AllocBuffer<TypeParam>(num_elems * sizeof(uint8_t), false));
+    data.push_back(AllocBuffer<TypeParam>(num_elems, false));
   }
   std::vector<TensorList<TypeParam>> input_wrapper(prefetch_queue_depth);
 
   for (int i = 0; i < prefetch_queue_depth; i++) {
     SequentialFill(TensorListView<StorageCPU, uint8_t>(input_cpu.get(), input_shape), 42 * i);
-    // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    MemCopy(data[i].get(), input_cpu.get(), num_elems, cuda_stream);
-    input_wrapper[i].ShareData(std::static_pointer_cast<void>(data[i]), num_elems * sizeof(uint8_t),
+    if constexpr (std::is_same_v<TypeParam, CPUBackend>)
+      memcpy(data[i].get(), input_cpu.get(), num_elems);
+    else
+      MemCopy(data[i].get(), input_cpu.get(), num_elems, cuda_stream);
+
+    input_wrapper[i].ShareData(std::static_pointer_cast<void>(data[i]), num_elems,
                                false, input_shape, DALI_UINT8);
     pipe_ptr->SetExternalInput(input_name, input_wrapper[i]);
     if (flag_to_test == DALI_ext_force_no_copy) {
@@ -759,8 +791,13 @@ void TestForceFlagRun(bool ext_src_no_copy, unsigned int flag_to_test) {
                                 dali_data_type_t::DALI_UINT8, input_shape.data(),
                                 input_shape.sample_dim(), nullptr, cuda_stream, flag_to_test);
     } else {
-      auto tmp_data = AllocBuffer<TypeParam>(num_elems * sizeof(uint8_t), false);
-      MemCopy(tmp_data.get(), data[i].get(), num_elems, cuda_stream);
+      decltype(input_cpu) tmp_data;
+      if constexpr (std::is_same_v<TypeParam, CPUBackend>) {
+        tmp_data = data[i];
+      } else {
+        tmp_data = AllocBuffer<TypeParam>(num_elems, false);
+        MemCopy(tmp_data.get(), data[i].get(), num_elems, cuda_stream);
+      }
       // We pass a temporary TensorList as input and force the copy
       daliSetExternalInputAsync(&handle, input_name.c_str(),
                                 backend_to_device_type<TypeParam>::value, tmp_data.get(),
@@ -784,12 +821,12 @@ void TestForceFlagRun(bool ext_src_no_copy, unsigned int flag_to_test) {
 
 
 TYPED_TEST(CApiTest, ForceCopy) {
-  TestForceFlagRun<TypeParam>(true, DALI_ext_force_copy);
+  TestForceFlagRun<TypeParam>(true, DALI_ext_force_copy, this->device_id_);
 }
 
 
 TYPED_TEST(CApiTest, ForceNoCopy) {
-  TestForceFlagRun<TypeParam>(false, DALI_ext_force_no_copy);
+  TestForceFlagRun<TypeParam>(false, DALI_ext_force_no_copy, this->device_id_);
 }
 
 
@@ -834,17 +871,21 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
     auto type_info = dali::TypeTable::GetTypeInfo(type);
     int64_t out_size = daliNumElements(&handle, out_idx);
     Tensor<TypeParam> output1;
+    output1.set_pinned(false);
     output1.Resize({out_size}, type_info.id());
     daliOutputCopy(&handle, output1.raw_mutable_data(), out_idx,
                    backend_to_device_type<TypeParam>::value, 0, DALI_ext_default);
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
     Tensor<CPUBackend> output1_cpu;
-    output1_cpu.Copy(output1, cuda_stream);
+    output1_cpu.set_pinned(false);
+    output1_cpu.Copy(output1, AccessOrder::host());
 
     for (bool use_copy_kernel : {false, true}) {
+      bool pinned = use_copy_kernel;
       Tensor<TypeParam> output2;
       Tensor<CPUBackend> output2_cpu;
-      output2.set_pinned(std::is_same<TypeParam, CPUBackend>::value);
+      output2_cpu.set_pinned(false);
+      output2.set_pinned(pinned);
       output2.Resize({out_size}, type_info.id());
       // Making sure data is cleared
       // Somehow in debug mode it can get the same raw pointer which happen to have
@@ -861,22 +902,24 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
       unsigned int flags = DALI_ext_default;
       if (use_copy_kernel)
         flags |= DALI_use_copy_kernel;
-      if (std::is_same<TypeParam, CPUBackend>::value)
+      if (pinned)
         flags |= DALI_ext_pinned;
 
       daliOutputCopySamples(&handle, sample_dsts.data(), out_idx,
                             backend_to_device_type<TypeParam>::value, cuda_stream, flags);
 
       // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-      output2_cpu.Copy(output2, cuda_stream);
-      CUDA_CALL(cudaDeviceSynchronize());
+      output2_cpu.Copy(output2, this->order_);
+      if (std::is_same_v<TypeParam, GPUBackend>)
+        CUDA_CALL(cudaDeviceSynchronize());
       Check(view<uint8_t>(output1_cpu), view<uint8_t>(output2_cpu));
     }
 
     for (bool use_copy_kernel : {false, true}) {
       Tensor<TypeParam> output2;
       Tensor<CPUBackend> output2_cpu;
-      output2.set_pinned(std::is_same<TypeParam, CPUBackend>::value);
+      output2_cpu.set_pinned(false);
+      output2.set_pinned(std::is_same_v<TypeParam, CPUBackend>);
       output2.Resize({out_size}, type_info.id());
       // Making sure data is cleared
       // Somehow in debug mode it can get the same raw pointer which happen to have
@@ -901,7 +944,7 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
       unsigned int flags = DALI_ext_default;
       if (use_copy_kernel)
         flags |= DALI_use_copy_kernel;
-      if (std::is_same<TypeParam, CPUBackend>::value)
+      if (std::is_same_v<TypeParam, CPUBackend>)
         flags |= DALI_ext_pinned;
 
       daliOutputCopySamples(&handle, sample_dsts_even.data(), out_idx,
@@ -910,8 +953,9 @@ TYPED_TEST(CApiTest, daliOutputCopySamples) {
                             backend_to_device_type<TypeParam>::value, cuda_stream, flags);
 
       // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-      output2_cpu.Copy(output2, cuda_stream);
-      CUDA_CALL(cudaDeviceSynchronize());
+      output2_cpu.Copy(output2, this->order_);
+      if (std::is_same_v<TypeParam, GPUBackend>)
+        CUDA_CALL(cudaDeviceSynchronize());
       Check(view<uint8_t>(output1_cpu), view<uint8_t>(output2_cpu));
     }
   }

--- a/dali/core/mm/async_pool_test.cu
+++ b/dali/core/mm/async_pool_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ void AsyncPoolTest(Pool &pool, vector<block> &blocks, Mutex &mtx, CUDAStream &st
   std::uniform_int_distribution<> fill_dist(1, 255);
   DeviceBuffer<int> failure_buf;
   int failures = 0;
-  failure_buf.from_host(&failures, 1, stream);
+  failure_buf.from_host(&failures, 1, sv.get());
   GPUHog hog;
   if (use_hog)
     hog.init();
@@ -195,7 +195,7 @@ void AsyncPoolTest(Pool &pool, vector<block> &blocks, Mutex &mtx, CUDAStream &st
       }
     }
   }
-  copyD2H<int>(&failures, failure_buf, 1, stream);
+  copyD2H<int>(&failures, failure_buf, 1, AccessOrder(stream));
   CUDA_CALL(cudaStreamSynchronize(stream));
   ASSERT_EQ(failures, 0);
 }

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -422,7 +422,7 @@ void ExposeTensor(py::module &m) {
       py::return_value_policy::take_ownership)
     .def("copy_to_external",
         [](Tensor<CPUBackend> &t, py::object p) {
-          CopyToExternal<mm::memory_kind::host>(ctypes_void_ptr(p), t, 0, false);
+          CopyToExternal<mm::memory_kind::host>(ctypes_void_ptr(p), t, AccessOrder::host(), false);
         },
       "ptr"_a,
       R"code(
@@ -878,7 +878,7 @@ void ExposeTensorList(py::module &m) {
       )code")
     .def("copy_to_external",
         [](TensorList<CPUBackend> &tl, py::object p) {
-          CopyToExternal<mm::memory_kind::host>(ctypes_void_ptr(p), tl, 0, false);
+          CopyToExternal<mm::memory_kind::host>(ctypes_void_ptr(p), tl, AccessOrder::host(), false);
         },
       R"code(
       Copy the contents of this `TensorList` to an external pointer

--- a/include/dali/core/dev_buffer.h
+++ b/include/dali/core/dev_buffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,25 +26,36 @@
 namespace dali {
 
 template <typename T>
-void copyD2D(T *dst, const T *src, size_t n, cudaStream_t stream = 0) {
-  CUDA_CALL(cudaMemcpyAsync(dst, src, n*sizeof(T), cudaMemcpyDeviceToDevice, stream));
+void copyD2D(T *dst, const T *src, size_t n, AccessOrder order = {}) {
+  if (order.is_device())
+    CUDA_CALL(cudaMemcpyAsync(dst, src, n*sizeof(T), cudaMemcpyDeviceToDevice, order.stream()));
+  else
+    CUDA_CALL(cudaMemcpy(dst, src, n*sizeof(T), cudaMemcpyDeviceToDevice));
 }
 
 template <typename T>
-void copyD2H(T *dst, const T *src, size_t n, cudaStream_t stream = 0) {
-  CUDA_CALL(cudaMemcpyAsync(dst, src, n*sizeof(T), cudaMemcpyDeviceToHost, stream));
+void copyD2H(T *dst, const T *src, size_t n, AccessOrder order = {}) {
+  if (order.is_device())
+    CUDA_CALL(cudaMemcpyAsync(dst, src, n*sizeof(T), cudaMemcpyDeviceToHost, order.stream()));
+  else
+    CUDA_CALL(cudaMemcpy(dst, src, n*sizeof(T), cudaMemcpyDeviceToHost));
 }
 
 template <typename T>
-void copyH2D(T *dst, const T *src, size_t n, cudaStream_t stream = 0) {
-  CUDA_CALL(cudaMemcpyAsync(dst, src, n*sizeof(T), cudaMemcpyHostToDevice, stream));
+void copyH2D(T *dst, const T *src, size_t n, AccessOrder order = {}) {
+  if (order.is_device())
+    CUDA_CALL(cudaMemcpyAsync(dst, src, n*sizeof(T), cudaMemcpyHostToDevice, order.stream()));
+  else
+    CUDA_CALL(cudaMemcpy(dst, src, n*sizeof(T), cudaMemcpyHostToDevice));
 }
 
 template <typename T>
-void copyH2H(T *dst, const T *src, size_t n, cudaStream_t stream = 0) {
-  CUDA_CALL(cudaMemcpyAsync(dst, src, n*sizeof(T), cudaMemcpyHostToHost, stream));
+void copyH2H(T *dst, const T *src, size_t n, AccessOrder order = {}) {
+  if (order.is_device())
+    CUDA_CALL(cudaMemcpyAsync(dst, src, n*sizeof(T), cudaMemcpyHostToHost, order.stream()));
+  else
+    memcpy(dst, src, n*sizeof(T));
 }
-
 
 /**
  * @brief Represents a strongly typed device-side buffer with size and capacity.
@@ -86,56 +97,56 @@ struct DeviceBuffer {
   void clear() { size_ = 0; }
   void free() { size_ = 0; capacity_ = 0; data_.reset(); }
 
-  void shrink_to_fit(cudaStream_t stream = 0) {
-    reallocate(size_, stream);
+  void shrink_to_fit(AccessOrder order = {}) {
+    reallocate(size_, order);
   }
 
-  void from_host(const T *source, size_t count, cudaStream_t stream = 0) {
+  void from_host(const T *source, size_t count, AccessOrder order = {}) {
     clear();
     resize(count);
-    copyH2D(data_.get(), source, size(), stream);
+    copyH2D(data_.get(), source, size(), order);
   }
 
-  void from_device(const T *source, size_t count, cudaStream_t stream = 0) {
+  void from_device(const T *source, size_t count, AccessOrder order = {}) {
     clear();
     resize(count);
-    copyD2D(data_.get(), source, size(), stream);
+    copyD2D(data_.get(), source, size(), order);
   }
 
   template <typename ArrayLike>
-  if_array_like<ArrayLike> from_host(const ArrayLike &source, cudaStream_t stream = 0) {
-    from_host(&source[0], dali::size(source), stream);
+  if_array_like<ArrayLike> from_host(const ArrayLike &source, AccessOrder order = {}) {
+    from_host(&source[0], dali::size(source), order);
   }
 
   template <typename ArrayLike>
-  if_array_like<ArrayLike> from_device(const ArrayLike &source, cudaStream_t stream = 0) {
-    from_device(&source[0], dali::size(source), stream);
+  if_array_like<ArrayLike> from_device(const ArrayLike &source, AccessOrder order = {}) {
+    from_device(&source[0], dali::size(source), order);
   }
 
-  void copy(const DeviceBuffer &src, cudaStream_t stream = 0) {
+  void copy(const DeviceBuffer &src, AccessOrder order = {}) {
     clear();
     resize(src.size());
-    copyD2D(data_.get(), src.data(), size(), stream);
+    copyD2D(data_.get(), src.data(), size(), order);
   }
 
-  void reserve(size_t new_cap, cudaStream_t stream = 0) {
+  void reserve(size_t new_cap, AccessOrder order = {}) {
     if (new_cap > capacity_) {
-      reallocate(new_cap, stream);
+      reallocate(new_cap, order);
     }
   }
 
-  void resize(size_t new_size, cudaStream_t stream = 0) {
+  void resize(size_t new_size, AccessOrder order = {}) {
     if (new_size > capacity_) {
       size_t new_cap = 2 * capacity_;
       if (new_size > new_cap)
         new_cap = new_size;
-      reallocate(new_cap, stream);
+      reallocate(new_cap, order);
     }
     size_ = new_size;
   }
 
  private:
-  void reallocate(size_t new_cap, cudaStream_t stream) {
+  void reallocate(size_t new_cap, AccessOrder order) {
     if (new_cap == 0) {
       free();
       return;
@@ -147,7 +158,7 @@ struct DeviceBuffer {
       capacity_ = new_cap;
     } else {
       auto new_data = allocate(new_cap);
-      copyD2D(new_data.get(), data_.get(), size(), stream);
+      copyD2D(new_data.get(), data_.get(), size(), order);
       capacity_ = new_cap;
       data_ = std::move(new_data);
     }

--- a/qa/TL0_cpu_only/test.sh
+++ b/qa/TL0_cpu_only/test.sh
@@ -31,7 +31,7 @@ test_body() {
         exit 1
     fi
 
-    "$FULLPATH" --gtest_filter="*CpuOnlyTest*"
+    "$FULLPATH" --gtest_filter="*CpuOnly*:*CApi*/0.*-*0.UseCopyKernel:*ForceNoCopyFail:*daliOutputCopySamples"
   done
 }
 

--- a/third_party/cpplint.py
+++ b/third_party/cpplint.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
-# Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -3281,7 +3281,7 @@ def CheckSpacing(filename, clean_lines, linenum, nesting_state, error):
 
   # You shouldn't have spaces before your brackets, except maybe after
   # 'delete []' or 'return []() {};'
-  if Search(r'\w\s+\[', line) and not Search(r'(?:delete|return)\s+\[', line):
+  if Search(r'\w\s+\[', line) and not Search(r'(?:delete|return|auto)\s+\[', line):
     error(filename, linenum, 'whitespace/braces', 5,
           'Extra space before [')
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
**Bug fix** (*non-breaking change which fixes an issue*)
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
- Stream value of 0 should no longer be converted to an AccessOrder in C API.
- Made C API tests that don't use CUDA usable without a CUDA driver (most CPU Backend tests - exclusing those that use copy kernel or both backends).
- Adjust cpplint to support C++17 structured bindings with space in `auto [a, b]`

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [X] Existing tests apply (modified)
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
