### PR TITLE
Add sequence handling to Gaussian Blur and Laplacian operators

### DIFF
--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -119,7 +119,7 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
 
     int nsamples = input.num_samples();
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
-      const auto& shape = input[sample_idx].shape();
+      const auto& shape = input.tensor_shape(sample_idx);
       auto elem_volume = volume(shape);
       thread_pool.AddWork(
           [this, &input, &output, sample_idx, shape](int thread_id) {

--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -92,7 +92,6 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
   bool SetupImpl(std::vector<OutputDesc>& output_desc, const workspace_t<CPUBackend>& ws) override {
     const auto& input = ws.template Input<CPUBackend>(0);
     int nsamples = input.num_samples();
-    auto nthreads = ws.GetThreadPool().NumThreads();
 
     output_desc.resize(1);
     output_desc[0].type = type2id<Out>::value;

--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -115,18 +115,19 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
     const auto& input = ws.template Input<CPUBackend>(0);
     auto& output = ws.template Output<CPUBackend>(0);
     output.SetLayout(input.GetLayout());
-    auto in_shape = input.shape();
     auto& thread_pool = ws.GetThreadPool();
 
-    int nsamples = input.shape().num_samples();
+    int nsamples = input.num_samples();
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
       const auto& shape = input[sample_idx].shape();
       auto elem_volume = volume(shape);
       thread_pool.AddWork(
-          [this, &input, &output, shape, sample_idx](int thread_id) {
+          [this, &input, &output, sample_idx, shape](int thread_id) {
             auto gaussian_windows = windows_[sample_idx].GetWindows();
-            auto in_view = view<const In, ndim>(input[sample_idx]);
-            auto out_view = view<Out, ndim>(output[sample_idx]);
+            auto in_view = TensorView<StorageCPU, const In, ndim>{
+                input.template tensor<In>(sample_idx), shape};
+            auto out_view = TensorView<StorageCPU, Out, ndim>{
+                output.template mutable_tensor<Out>(sample_idx), shape};
             // I need a context for that particular run (or rather matching the thread &
             // scratchpad)
             auto ctx = ctx_;

--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -87,8 +87,7 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
    * @param spec  Pointer to a persistent OpSpec object,
    *              which is guaranteed to be alive for the entire lifetime of this object
    */
-  explicit GaussianBlurOpCpu(const OpSpec* spec, const DimDesc& dim_desc)
-      : spec_(*spec), dim_desc_(dim_desc) {}
+  explicit GaussianBlurOpCpu(const OpSpec* spec) : spec_(*spec) {}
 
   bool SetupImpl(std::vector<OutputDesc>& output_desc, const workspace_t<CPUBackend>& ws) override {
     const auto& input = ws.template Input<CPUBackend>(0);
@@ -97,7 +96,7 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
 
     output_desc.resize(1);
     output_desc[0].type = type2id<Out>::value;
-    output_desc[0].shape.resize(nsamples, input.shape().sample_dim());
+    // Shape is set by ProcessOutputDesc
 
     params_.resize(nsamples);
     windows_.resize(nsamples);
@@ -107,11 +106,7 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
     for (int i = 0; i < nsamples; i++) {
       params_[i] = ObtainSampleParams<axes>(i, spec_, ws);
       windows_[i].PrepareWindows(params_[i]);
-      // We take only last `ndim` siginificant dimensions to handle sequences as well
-      auto elem_shape = input.tensor_shape(i).template last<ndim>();
-      auto& req = kmgr_.Setup<Kernel>(i, ctx_, elem_shape, params_[i].window_sizes);
-      // The shape of data stays untouched
-      output_desc[0].shape.set_tensor_shape(i, input.tensor_shape(i));
+      auto& req = kmgr_.Setup<Kernel>(i, ctx_, input[i].shape(), params_[i].window_sizes);
     }
     return true;
   }
@@ -125,37 +120,25 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
 
     int nsamples = input.shape().num_samples();
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
-      const auto& shape = input.tensor_shape(sample_idx);
-      auto elem_volume = volume(shape.begin() + dim_desc_.usable_axes_start, shape.end());
-
-      int seq_elements = 1;
-      int64_t stride = 0;
-      if (dim_desc_.is_sequence()) {
-        seq_elements = volume(shape.begin(), shape.begin() + dim_desc_.usable_axes_start);
-        stride = elem_volume;
-      }
-      for (int elem_idx = 0; elem_idx < seq_elements; elem_idx++) {
-        thread_pool.AddWork(
-            [this, &input, &output, sample_idx, elem_idx, stride](int thread_id) {
-              auto gaussian_windows = windows_[sample_idx].GetWindows();
-              auto elem_shape = input.tensor_shape(sample_idx).template last<ndim>();
-              auto in_view = TensorView<StorageCPU, const In, ndim>{
-                  input.template tensor<In>(sample_idx) + stride * elem_idx, elem_shape};
-              auto out_view = TensorView<StorageCPU, Out, ndim>{
-                  output.template mutable_tensor<Out>(sample_idx) + stride * elem_idx, elem_shape};
-              // I need a context for that particular run (or rather matching the thread &
-              // scratchpad)
-              auto ctx = ctx_;
-              kmgr_.Run<Kernel>(sample_idx, ctx, out_view, in_view, gaussian_windows);
-            }, elem_volume);
-      }
+      const auto& shape = input[sample_idx].shape();
+      auto elem_volume = volume(shape);
+      thread_pool.AddWork(
+          [this, &input, &output, shape, sample_idx](int thread_id) {
+            auto gaussian_windows = windows_[sample_idx].GetWindows();
+            auto in_view = view<const In, ndim>(input[sample_idx]);
+            auto out_view = view<Out, ndim>(output[sample_idx]);
+            // I need a context for that particular run (or rather matching the thread &
+            // scratchpad)
+            auto ctx = ctx_;
+            kmgr_.Run<Kernel>(sample_idx, ctx, out_view, in_view, gaussian_windows);
+          },
+          elem_volume);
     }
     thread_pool.RunAll();
   }
 
  private:
   const OpSpec &spec_;
-  DimDesc dim_desc_;
 
   kernels::KernelManager kmgr_;
   kernels::KernelContext ctx_;
@@ -168,29 +151,40 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
 }  // namespace gaussian_blur
 
 template <>
+bool GaussianBlur<CPUBackend>::ShouldExpand(const workspace_t<CPUBackend>& ws) {
+  const auto& input = ws.template Input<CPUBackend>(0);
+  auto layout = input.GetLayout();
+  dim_desc_ = convolution_utils::ParseAndValidateDim(input.shape().sample_dim(), layout);
+  bool should_expand = SequenceOperator<CPUBackend>::ShouldExpand(ws);
+  if (should_expand) {
+    assert(dim_desc_.usable_axes_start > 0);
+    dim_desc_.total_axes_count -= dim_desc_.usable_axes_start;
+    dim_desc_.usable_axes_start = 0;
+  }
+  return should_expand;
+}
+
+template <>
 bool GaussianBlur<CPUBackend>::SetupImpl(std::vector<OutputDesc>& output_desc,
                                          const workspace_t<CPUBackend>& ws) {
   const auto& input = ws.template Input<CPUBackend>(0);
-  auto layout = input.GetLayout();
-  auto dim_desc = ParseAndValidateDim(input.shape().sample_dim(), layout);
-  dtype_ = dtype_ != DALI_NO_TYPE ? dtype_ : input.type();
-  DALI_ENFORCE(dtype_ == input.type() || dtype_ == DALI_FLOAT,
+  assert(input.GetLayout().size() == dim_desc_.total_axes_count);
+  auto dtype = dtype_ == DALI_NO_TYPE ? input.type() : dtype_;
+  DALI_ENFORCE(dtype == input.type() || dtype == DALI_FLOAT,
                "Output data type must be same as input, FLOAT or skipped (defaults to input type)");
 
-  if (!impl_ || impl_in_dtype_ != input.type() || impl_dim_desc_ != dim_desc) {
+  if (!impl_ || impl_in_dtype_ != input.type() || impl_dim_desc_ != dim_desc_) {
     impl_in_dtype_ = input.type();
-    impl_dim_desc_ = dim_desc;
+    impl_dim_desc_ = dim_desc_;
 
     // clang-format off
     TYPE_SWITCH(input.type(), type2id, In, GAUSSIAN_BLUR_CPU_SUPPORTED_TYPES, (
-      VALUE_SWITCH(dim_desc.usable_axes_count, Axes, GAUSSIAN_BLUR_SUPPORTED_AXES, (
-        BOOL_SWITCH(dim_desc.is_channel_last(), HasChannels, (
-          if (dtype_ == input.type()) {
-            impl_ =
-              std::make_unique<GaussianBlurOpCpu<In, In, Axes, HasChannels>>(&spec_, dim_desc);
+      VALUE_SWITCH(dim_desc_.usable_axes_count, Axes, GAUSSIAN_BLUR_SUPPORTED_AXES, (
+        BOOL_SWITCH(dim_desc_.is_channel_last(), HasChannels, (
+          if (dtype == input.type()) {
+            impl_ = std::make_unique<GaussianBlurOpCpu<In, In, Axes, HasChannels>>(&spec_);
           } else {
-            impl_ =
-              std::make_unique<GaussianBlurOpCpu<float, In, Axes, HasChannels>>(&spec_, dim_desc);
+            impl_ = std::make_unique<GaussianBlurOpCpu<float, In, Axes, HasChannels>>(&spec_);
           }
         ));  // NOLINT
       ), DALI_FAIL("Axis count out of supported range."));  // NOLINT

--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -168,7 +168,7 @@ template <>
 bool GaussianBlur<CPUBackend>::SetupImpl(std::vector<OutputDesc>& output_desc,
                                          const workspace_t<CPUBackend>& ws) {
   const auto& input = ws.template Input<CPUBackend>(0);
-  assert(input.GetLayout().size() == dim_desc_.total_axes_count);
+  assert(input.GetLayout().empty() || input.GetLayout().size() == dim_desc_.total_axes_count);
   auto dtype = dtype_ == DALI_NO_TYPE ? input.type() : dtype_;
   DALI_ENFORCE(dtype == input.type() || dtype == DALI_FLOAT,
                "Output data type must be same as input, FLOAT or skipped (defaults to input type)");

--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -63,9 +63,9 @@ The same input can be provided as per-sample tensors.
     .AllowSequences()
     .SupportVolumetric()
     .AddOptionalArg<int>(kWindowSizeArgName, "The diameter of the kernel.",
-                         std::vector<int>{0}, true)
+                         std::vector<int>{0}, true, true)
     .AddOptionalArg<float>(kSigmaArgName, "Sigma value for the Gaussian Kernel.",
-                           std::vector<float>{0.f}, true)
+                           std::vector<float>{0.f}, true, true)
     .AddOptionalArg(
         "dtype", R"code(Output data type.
 

--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -118,11 +118,11 @@ class GaussianBlurOpCpu : public OpImplBase<CPUBackend> {
 
     int nsamples = input.num_samples();
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
-      const auto& shape = input.tensor_shape(sample_idx);
-      auto elem_volume = volume(shape);
+      auto elem_volume = volume(input.tensor_shape(sample_idx));
       thread_pool.AddWork(
-          [this, &input, &output, sample_idx, shape](int thread_id) {
+          [this, &input, &output, sample_idx](int thread_id) {
             auto gaussian_windows = windows_[sample_idx].GetWindows();
+            const auto &shape = input.tensor_shape(sample_idx);
             auto in_view = TensorView<StorageCPU, const In, ndim>{
                 input.template tensor<In>(sample_idx), shape};
             auto out_view = TensorView<StorageCPU, Out, ndim>{

--- a/dali/operators/image/convolution/gaussian_blur.cu
+++ b/dali/operators/image/convolution/gaussian_blur.cu
@@ -77,7 +77,7 @@ bool GaussianBlur<GPUBackend>::ShouldExpand(const workspace_t<GPUBackend>& ws) {
   const auto& input = ws.template Input<GPUBackend>(0);
   auto layout = input.GetLayout();
   dim_desc_ = convolution_utils::ParseAndValidateDim(input.shape().sample_dim(), layout);
-  bool should_expand = SequenceOperator<GPUBackend>::ShouldExpand(ws) && HasPerFrameArgInput(ws);
+  bool should_expand = SequenceOperator<GPUBackend>::ShouldExpand(ws) && HasPerFrameArgInputs(ws);
   if (should_expand) {
     assert(dim_desc_.usable_axes_start > 0);
     dim_desc_.total_axes_count -= dim_desc_.usable_axes_start;

--- a/dali/operators/image/convolution/gaussian_blur.cu
+++ b/dali/operators/image/convolution/gaussian_blur.cu
@@ -90,7 +90,7 @@ template <>
 bool GaussianBlur<GPUBackend>::SetupImpl(std::vector<OutputDesc>& output_desc,
                                          const workspace_t<GPUBackend>& ws) {
   const auto& input = ws.template Input<GPUBackend>(0);
-  assert(input.GetLayout().size() == dim_desc_.total_axes_count);
+  assert(input.GetLayout().empty() || input.GetLayout().size() == dim_desc_.total_axes_count);
   auto dtype = dtype_ == DALI_NO_TYPE ? input.type() : dtype_;
   DALI_ENFORCE(dtype == input.type() || dtype == DALI_FLOAT,
                "Output data type must be same as input, FLOAT or skipped (defaults to input type)");

--- a/dali/operators/image/convolution/gaussian_blur.cu
+++ b/dali/operators/image/convolution/gaussian_blur.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,26 +70,41 @@ extern template op_impl_uptr GetGaussianBlurGpuImpl<float, double>(const OpSpec*
 
 }  // namespace gaussian_blur
 
+// Passing to the kernel less samples (not split into frames) speeds-up
+// the processing, so expand frames dim only if some argument was specified per-frame
+template <>
+bool GaussianBlur<GPUBackend>::ShouldExpand(const workspace_t<GPUBackend>& ws) {
+  const auto& input = ws.template Input<GPUBackend>(0);
+  auto layout = input.GetLayout();
+  dim_desc_ = convolution_utils::ParseAndValidateDim(input.shape().sample_dim(), layout);
+  bool should_expand = SequenceOperator<GPUBackend>::ShouldExpand(ws) && HasPerFrameArgInput(ws);
+  if (should_expand) {
+    assert(dim_desc_.usable_axes_start > 0);
+    dim_desc_.total_axes_count -= dim_desc_.usable_axes_start;
+    dim_desc_.usable_axes_start = 0;
+  }
+  return should_expand;
+}
+
 template <>
 bool GaussianBlur<GPUBackend>::SetupImpl(std::vector<OutputDesc>& output_desc,
                                          const workspace_t<GPUBackend>& ws) {
   const auto& input = ws.template Input<GPUBackend>(0);
-  auto layout = input.GetLayout();
-  auto dim_desc = ParseAndValidateDim(input.shape().sample_dim(), layout);
-  dtype_ = dtype_ != DALI_NO_TYPE ? dtype_ : input.type();
-  DALI_ENFORCE(dtype_ == input.type() || dtype_ == DALI_FLOAT,
+  assert(input.GetLayout().size() == dim_desc_.total_axes_count);
+  auto dtype = dtype_ == DALI_NO_TYPE ? input.type() : dtype_;
+  DALI_ENFORCE(dtype == input.type() || dtype == DALI_FLOAT,
                "Output data type must be same as input, FLOAT or skipped (defaults to input type)");
 
-  if (!impl_ || impl_in_dtype_ != input.type() || impl_dim_desc_ != dim_desc) {
+  if (!impl_ || impl_in_dtype_ != input.type() || impl_dim_desc_ != dim_desc_) {
     impl_in_dtype_ = input.type();
-    impl_dim_desc_ = dim_desc;
+    impl_dim_desc_ = dim_desc_;
 
     // clang-format off
     TYPE_SWITCH(input.type(), type2id, In, GAUSSIAN_BLUR_GPU_SUPPORTED_TYPES, (
-      if (dtype_ == input.type()) {
-        impl_ = GetGaussianBlurGpuImpl<In, In>(&spec_, dim_desc);
+      if (dtype == input.type()) {
+        impl_ = GetGaussianBlurGpuImpl<In, In>(&spec_, dim_desc_);
       } else {
-        impl_ = GetGaussianBlurGpuImpl<float, In>(&spec_, dim_desc);
+        impl_ = GetGaussianBlurGpuImpl<float, In>(&spec_, dim_desc_);
       }
     ), DALI_FAIL(make_string("Unsupported data type: ", input.type())));  // NOLINT
     // clang-format on

--- a/dali/operators/image/convolution/gaussian_blur.h
+++ b/dali/operators/image/convolution/gaussian_blur.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,11 +18,12 @@
 #include <memory>
 #include <vector>
 
-#include "dali/pipeline/operator/operator.h"
-#include "dali/pipeline/util/operator_impl_utils.h"
 #include "dali/operators/image/convolution/convolution_utils.h"
 #include "dali/operators/image/convolution/gaussian_blur_params.h"
 #include "dali/pipeline/operator/common.h"
+#include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/operator/sequence_op.h"
+#include "dali/pipeline/util/operator_impl_utils.h"
 
 namespace dali {
 
@@ -37,15 +38,31 @@ namespace dali {
 #define GAUSSIAN_BLUR_SUPPORTED_AXES (1, 2, 3)
 
 template <typename Backend>
-class GaussianBlur : public Operator<Backend> {
+class GaussianBlur : public SequenceOperator<Backend> {
  public:
   inline explicit GaussianBlur(const OpSpec& spec)
-      : Operator<Backend>(spec), dtype_(spec.GetArgument<DALIDataType>("dtype")) {}
+      : SequenceOperator<Backend>(spec), dtype_(spec.GetArgument<DALIDataType>("dtype")) {}
 
   DISABLE_COPY_MOVE_ASSIGN(GaussianBlur);
 
  protected:
   bool CanInferOutputs() const override {
+    return true;
+  }
+
+  bool ShouldExpandChannels() const override {
+    return true;
+  }
+
+  bool ShouldExpand(const workspace_t<Backend>& ws) override;
+
+  // Overrides unnecessary coalescing
+  bool ProcessOutputDesc(std::vector<OutputDesc>& output_desc, const workspace_t<Backend>& ws,
+                         bool is_inferred) override {
+    assert(is_inferred && output_desc.size() == 1);
+    const auto& input = ws.template Input<Backend>(0);
+    // The shape of data stays untouched
+    output_desc[0].shape = input.shape();
     return true;
   }
 
@@ -58,6 +75,7 @@ class GaussianBlur : public Operator<Backend> {
   USE_OPERATOR_MEMBERS();
   std::unique_ptr<OpImplBase<Backend>> impl_;
   DALIDataType impl_in_dtype_ = DALI_NO_TYPE;
+  convolution_utils::DimDesc dim_desc_ = {};
   convolution_utils::DimDesc impl_dim_desc_ = {};
 };
 

--- a/dali/operators/image/convolution/gaussian_blur.h
+++ b/dali/operators/image/convolution/gaussian_blur.h
@@ -22,7 +22,7 @@
 #include "dali/operators/image/convolution/gaussian_blur_params.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
-#include "dali/pipeline/operator/sequence_op.h"
+#include "dali/pipeline/operator/sequence_operator.h"
 #include "dali/pipeline/util/operator_impl_utils.h"
 
 namespace dali {

--- a/dali/operators/image/convolution/gaussian_blur.h
+++ b/dali/operators/image/convolution/gaussian_blur.h
@@ -50,7 +50,8 @@ class GaussianBlur : public SequenceOperator<Backend> {
     return true;
   }
 
-  bool ShouldExpandChannels() const override {
+  bool ShouldExpandChannels(int input_idx) const override {
+    (void)input_idx;
     return true;
   }
 

--- a/dali/operators/image/convolution/gaussian_blur_gpu.h
+++ b/dali/operators/image/convolution/gaussian_blur_gpu.h
@@ -64,12 +64,10 @@ class GaussianBlurOpGpu : public OpImplBase<GPUBackend> {
     if (is_sequence) {
       processed_shape = collapse_dims(processed_shape, {{0, dim_desc_.usable_axes_start}});
     }
-    constexpr int nthreads = 1;
 
     output_desc.resize(1);
     output_desc[0].type = type2id<Out>::value;
-    // The shape of data stays untouched
-    output_desc[0].shape = input.shape();
+    // Shape is set by ProcessOutputDesc
 
     params_.resize(nsamples);
     windows_.resize(nsamples);
@@ -81,7 +79,7 @@ class GaussianBlurOpGpu : public OpImplBase<GPUBackend> {
       windows.shape.resize(nsamples);
     }
 
-    kmgr_.template Resize<Kernel>(nsamples);
+    kmgr_.template Resize<Kernel>(1);
 
     for (int i = 0; i < nsamples; i++) {
       params_[i] = ObtainSampleParams<axes>(i, spec_, ws);

--- a/dali/operators/image/convolution/laplacian.cc
+++ b/dali/operators/image/convolution/laplacian.cc
@@ -154,7 +154,7 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
     int nsamples = input.num_samples();
 
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
-      const auto& shape = input[sample_idx].shape();
+      const auto& shape = input.tensor_shape(sample_idx);
       auto priority = volume(shape) * args.GetTotalWindowSizes(sample_idx);
 
       thread_pool.AddWork(

--- a/dali/operators/image/convolution/laplacian.cc
+++ b/dali/operators/image/convolution/laplacian.cc
@@ -205,7 +205,7 @@ template <>
 bool Laplacian<CPUBackend>::SetupImpl(std::vector<OutputDesc>& output_desc,
                                       const workspace_t<CPUBackend>& ws) {
   const auto& input = ws.template Input<CPUBackend>(0);
-  assert(input.GetLayout().size() == dim_desc_.total_axes_count);
+  assert(input.GetLayout().empty() || input.GetLayout().size() == dim_desc_.total_axes_count);
   auto dtype = dtype_ == DALI_NO_TYPE ? input.type() : dtype_;
   DALI_ENFORCE(dtype == input.type() || dtype == DALI_FLOAT,
                "Output data type must be same as input, FLOAT or skipped (defaults to input type)");

--- a/dali/operators/image/convolution/laplacian.cc
+++ b/dali/operators/image/convolution/laplacian.cc
@@ -153,12 +153,12 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
     int nsamples = input.num_samples();
 
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
-      const auto& shape = input.tensor_shape(sample_idx);
-      auto priority = volume(shape) * args.GetTotalWindowSizes(sample_idx);
+      auto priority = volume(input.tensor_shape(sample_idx)) * args.GetTotalWindowSizes(sample_idx);
 
       thread_pool.AddWork(
-          [this, &input, &output, sample_idx, shape](int thread_id) {
+          [this, &input, &output, sample_idx](int thread_id) {
             const auto& scales = args.GetScales(sample_idx);
+            const auto& shape = input.tensor_shape(sample_idx);
             auto in_view = TensorView<StorageCPU, const In, ndim>{
                 input.template tensor<In>(sample_idx), shape};
             auto out_view = TensorView<StorageCPU, Out, ndim>{

--- a/dali/operators/image/convolution/laplacian.cc
+++ b/dali/operators/image/convolution/laplacian.cc
@@ -112,8 +112,8 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
    * @param spec  Pointer to a persistent OpSpec object,
    *              which is guaranteed to be alive for the entire lifetime of this object
    */
-  explicit LaplacianOpCpu(const OpSpec* spec, const DimDesc& dim_desc)
-      : spec_{*spec}, args{*spec}, dim_desc_{dim_desc}, lap_windows_{maxWindowSize} {}
+  explicit LaplacianOpCpu(const OpSpec* spec)
+      : spec_{*spec}, args{*spec}, lap_windows_{maxWindowSize} {}
 
   bool SetupImpl(std::vector<OutputDesc>& output_desc, const workspace_t<CPUBackend>& ws) override {
     const auto& input = ws.template Input<CPUBackend>(0);
@@ -122,7 +122,7 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
 
     output_desc.resize(1);
     output_desc[0].type = type2id<Out>::value;
-    output_desc[0].shape.resize(nsamples, input.shape().sample_dim());
+    // Shape is set by ProcessOutputDesc
 
     args.ObtainLaplacianArgs(spec_, ws, nsamples);
     windows_.resize(nsamples);
@@ -140,11 +140,8 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
 
     kmgr_.template Resize<Kernel>(nsamples);
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
-      // We take only last `ndim` siginificant dimensions to handle sequences as well
-      auto elem_shape = input.shape()[sample_idx].template last<ndim>();
-      kmgr_.Setup<Kernel>(sample_idx, ctx_, elem_shape, args.GetWindowSizes(sample_idx));
-      // The shape of data stays untouched
-      output_desc[0].shape.set_tensor_shape(sample_idx, input.tensor_shape(sample_idx));
+      kmgr_.Setup<Kernel>(sample_idx, ctx_, input[sample_idx].shape(),
+                          args.GetWindowSizes(sample_idx));
     }
     return true;
   }
@@ -158,28 +155,19 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
     int nsamples = input.shape().num_samples();
 
     for (int sample_idx = 0; sample_idx < nsamples; sample_idx++) {
-      const auto& shape = input.tensor_shape(sample_idx);
-      auto elem_volume = volume(shape.begin() + dim_desc_.usable_axes_start, shape.end());
-      auto priority = elem_volume * args.GetTotalWindowSizes(sample_idx);
-      int seq_elements = volume(shape.begin(), shape.begin() + dim_desc_.usable_axes_start);
-      int64_t stride = elem_volume;
+      const auto& shape = input[sample_idx].shape();
+      auto priority = volume(shape) * args.GetTotalWindowSizes(sample_idx);
 
-      for (int elem_idx = 0; elem_idx < seq_elements; elem_idx++) {
-        thread_pool.AddWork(
-            [this, &input, &output, sample_idx, elem_idx, stride](int thread_id) {
-              const auto& scales = args.GetScales(sample_idx);
-              auto elem_shape = input[sample_idx].shape().template last<ndim>();
-              auto in_view = TensorView<StorageCPU, const In, ndim>{
-                  input.template tensor<In>(sample_idx) + stride * elem_idx, elem_shape};
-              auto out_view = TensorView<StorageCPU, Out, ndim>{
-                  output.template mutable_tensor<Out>(sample_idx) + stride * elem_idx, elem_shape};
-              // Copy context so that the kernel instance can modify scratchpad
-              auto ctx = ctx_;
-              kmgr_.Run<Kernel>(sample_idx, ctx, out_view, in_view, windows_[sample_idx],
-                                scales);
-            },
-            priority);
-      }
+      thread_pool.AddWork(
+          [this, &input, &output, sample_idx, shape](int thread_id) {
+            const auto& scales = args.GetScales(sample_idx);
+            auto in_view = view<const In, ndim>(input[sample_idx]);
+            auto out_view = view<Out, ndim>(output[sample_idx]);
+            // Copy context so that the kernel instance can modify scratchpad
+            auto ctx = ctx_;
+            kmgr_.Run<Kernel>(sample_idx, ctx, out_view, in_view, windows_[sample_idx], scales);
+          },
+          priority);
     }
     thread_pool.RunAll();
   }
@@ -188,7 +176,6 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
   const OpSpec& spec_;
 
   LaplacianArgs<axes> args;
-  DimDesc dim_desc_;
   kernels::LaplacianWindows<float> lap_windows_;
 
   kernels::KernelManager kmgr_;
@@ -201,28 +188,41 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
 }  // namespace laplacian
 
 template <>
+bool Laplacian<CPUBackend>::ShouldExpand(const workspace_t<CPUBackend>& ws) {
+  const auto& input = ws.template Input<CPUBackend>(0);
+  auto layout = input.GetLayout();
+  dim_desc_ = convolution_utils::ParseAndValidateDim(input.shape().sample_dim(), layout);
+  bool should_expand = SequenceOperator<CPUBackend>::ShouldExpand(ws);
+  if (should_expand) {
+    assert(dim_desc_.usable_axes_start > 0);
+    dim_desc_.total_axes_count -= dim_desc_.usable_axes_start;
+    dim_desc_.usable_axes_start = 0;
+  }
+  return should_expand;
+}
+
+template <>
 bool Laplacian<CPUBackend>::SetupImpl(std::vector<OutputDesc>& output_desc,
                                       const workspace_t<CPUBackend>& ws) {
   const auto& input = ws.template Input<CPUBackend>(0);
-  auto layout = input.GetLayout();
-  auto dim_desc = ParseAndValidateDim(input.shape().sample_dim(), layout);
+  assert(input.GetLayout().size() == dim_desc_.total_axes_count);
   auto dtype = dtype_ == DALI_NO_TYPE ? input.type() : dtype_;
   DALI_ENFORCE(dtype == input.type() || dtype == DALI_FLOAT,
                "Output data type must be same as input, FLOAT or skipped (defaults to input type)");
 
-  if (!impl_ || impl_in_dtype_ != input.type() || impl_dim_desc_ != dim_desc) {
+  if (!impl_ || impl_in_dtype_ != input.type() || impl_dim_desc_ != dim_desc_) {
     impl_in_dtype_ = input.type();
-    impl_dim_desc_ = dim_desc;
+    impl_dim_desc_ = dim_desc_;
 
     TYPE_SWITCH(input.type(), type2id, In, LAPLACIAN_CPU_SUPPORTED_TYPES, (
-      VALUE_SWITCH(dim_desc.usable_axes_count, Axes, LAPLACIAN_SUPPORTED_AXES, (
-        BOOL_SWITCH(dim_desc.is_channel_last(), HasChannels, (
+      VALUE_SWITCH(dim_desc_.usable_axes_count, Axes, LAPLACIAN_SUPPORTED_AXES, (
+        BOOL_SWITCH(dim_desc_.is_channel_last(), HasChannels, (
           if (dtype == input.type()) {
             using LaplacianSame = laplacian::LaplacianOpCpu<In, In, Axes, HasChannels>;
-            impl_ = std::make_unique<LaplacianSame>(&spec_, dim_desc);
+            impl_ = std::make_unique<LaplacianSame>(&spec_);
           } else {
             using LaplacianFloat = laplacian::LaplacianOpCpu<float, In, Axes, HasChannels>;
-            impl_ = std::make_unique<LaplacianFloat>(&spec_, dim_desc);
+            impl_ = std::make_unique<LaplacianFloat>(&spec_);
           }
         )); // NOLINT
       ), DALI_FAIL("Axis count out of supported range."));  // NOLINT

--- a/dali/operators/image/convolution/laplacian.cc
+++ b/dali/operators/image/convolution/laplacian.cc
@@ -80,15 +80,15 @@ Operator uses 32-bit floats as an intermediate type.
                          R"code(Size of derivative window used in convolutions.
 
 Window size must be odd and between 3 and 23.)code",
-                         std::vector<int>{laplacian::defaultWindowSize}, true)
+                         std::vector<int>{laplacian::defaultWindowSize}, true, true)
     .AddOptionalArg<std::vector<int>>(laplacian::smoothingSizeArgName,
                                       R"code(Size of smoothing window used in convolutions.
 
 Smoothing size must be odd and between 1 and 23.)code",
-                                      laplacian::smoothingSizeDefault, true)
+                                      laplacian::smoothingSizeDefault, true, true)
     .AddOptionalArg<float>(laplacian::scaleArgName,
                            "Factors to manually scale partial derivatives.",
-                           std::vector<float>{laplacian::scaleArgDefault}, true)
+                           std::vector<float>{laplacian::scaleArgDefault}, true, true)
     .AddOptionalArg<bool>(
         laplacian::normalizeArgName,
         "If set to True, automatically scales partial derivatives kernels. Must be False "

--- a/dali/operators/image/convolution/laplacian.cc
+++ b/dali/operators/image/convolution/laplacian.cc
@@ -118,7 +118,6 @@ class LaplacianOpCpu : public OpImplBase<CPUBackend> {
   bool SetupImpl(std::vector<OutputDesc>& output_desc, const workspace_t<CPUBackend>& ws) override {
     const auto& input = ws.template Input<CPUBackend>(0);
     int nsamples = input.num_samples();
-    auto nthreads = ws.GetThreadPool().NumThreads();
 
     output_desc.resize(1);
     output_desc[0].type = type2id<Out>::value;

--- a/dali/operators/image/convolution/laplacian.cu
+++ b/dali/operators/image/convolution/laplacian.cu
@@ -89,7 +89,7 @@ template <>
 bool Laplacian<GPUBackend>::SetupImpl(std::vector<OutputDesc>& output_desc,
                                       const workspace_t<GPUBackend>& ws) {
   const auto& input = ws.template Input<GPUBackend>(0);
-  assert(input.GetLayout().size() == dim_desc_.total_axes_count);
+  assert(input.GetLayout().empty() || input.GetLayout().size() == dim_desc_.total_axes_count);
   auto dtype = dtype_ == DALI_NO_TYPE ? input.type() : dtype_;
   DALI_ENFORCE(dtype == input.type() || dtype == DALI_FLOAT,
                "Output data type must be same as input, FLOAT or skipped (defaults to input type)");

--- a/dali/operators/image/convolution/laplacian.cu
+++ b/dali/operators/image/convolution/laplacian.cu
@@ -69,25 +69,40 @@ extern template op_impl_uptr GetLaplacianGpuImpl<float, float>(const OpSpec*,
 
 }  // namespace laplacian
 
+// Passing to the kernel less samples (not split into frames) speeds-up
+// the processing, so expand frames dim only if some argument was specified per-frame
+template <>
+bool Laplacian<GPUBackend>::ShouldExpand(const workspace_t<GPUBackend>& ws) {
+  const auto& input = ws.template Input<GPUBackend>(0);
+  auto layout = input.GetLayout();
+  dim_desc_ = convolution_utils::ParseAndValidateDim(input.shape().sample_dim(), layout);
+  bool should_expand = SequenceOperator<GPUBackend>::ShouldExpand(ws) && HasPerFrameArgInput(ws);
+  if (should_expand) {
+    assert(dim_desc_.usable_axes_start > 0);
+    dim_desc_.total_axes_count -= dim_desc_.usable_axes_start;
+    dim_desc_.usable_axes_start = 0;
+  }
+  return should_expand;
+}
+
 template <>
 bool Laplacian<GPUBackend>::SetupImpl(std::vector<OutputDesc>& output_desc,
                                       const workspace_t<GPUBackend>& ws) {
   const auto& input = ws.template Input<GPUBackend>(0);
-  auto layout = input.GetLayout();
-  auto dim_desc = ParseAndValidateDim(input.shape().sample_dim(), layout);
+  assert(input.GetLayout().size() == dim_desc_.total_axes_count);
   auto dtype = dtype_ == DALI_NO_TYPE ? input.type() : dtype_;
   DALI_ENFORCE(dtype == input.type() || dtype == DALI_FLOAT,
                "Output data type must be same as input, FLOAT or skipped (defaults to input type)");
 
-  if (!impl_ || impl_in_dtype_ != input.type() || impl_dim_desc_ != dim_desc) {
+  if (!impl_ || impl_in_dtype_ != input.type() || impl_dim_desc_ != dim_desc_) {
     impl_in_dtype_ = input.type();
-    impl_dim_desc_ = dim_desc;
+    impl_dim_desc_ = dim_desc_;
 
     TYPE_SWITCH(input.type(), type2id, In, LAPLACIAN_GPU_SUPPORTED_TYPES, (
       if (dtype == input.type()) {
-        impl_ = laplacian::GetLaplacianGpuImpl<In, In>(&spec_, dim_desc);
+        impl_ = laplacian::GetLaplacianGpuImpl<In, In>(&spec_, dim_desc_);
       } else {
-        impl_ = laplacian::GetLaplacianGpuImpl<float, In>(&spec_, dim_desc);
+        impl_ = laplacian::GetLaplacianGpuImpl<float, In>(&spec_, dim_desc_);
       }
     ), DALI_FAIL(make_string("Unsupported data type: ", input.type())));  // NOLINT
   }

--- a/dali/operators/image/convolution/laplacian.cu
+++ b/dali/operators/image/convolution/laplacian.cu
@@ -76,7 +76,7 @@ bool Laplacian<GPUBackend>::ShouldExpand(const workspace_t<GPUBackend>& ws) {
   const auto& input = ws.template Input<GPUBackend>(0);
   auto layout = input.GetLayout();
   dim_desc_ = convolution_utils::ParseAndValidateDim(input.shape().sample_dim(), layout);
-  bool should_expand = SequenceOperator<GPUBackend>::ShouldExpand(ws) && HasPerFrameArgInput(ws);
+  bool should_expand = SequenceOperator<GPUBackend>::ShouldExpand(ws) && HasPerFrameArgInputs(ws);
   if (should_expand) {
     assert(dim_desc_.usable_axes_start > 0);
     dim_desc_.total_axes_count -= dim_desc_.usable_axes_start;

--- a/dali/operators/image/convolution/laplacian.h
+++ b/dali/operators/image/convolution/laplacian.h
@@ -18,11 +18,12 @@
 #include <memory>
 #include <vector>
 
-#include "dali/pipeline/operator/operator.h"
-#include "dali/pipeline/util/operator_impl_utils.h"
-#include "dali/operators/image/convolution/laplacian_params.h"
 #include "dali/operators/image/convolution/convolution_utils.h"
+#include "dali/operators/image/convolution/laplacian_params.h"
 #include "dali/pipeline/operator/common.h"
+#include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/operator/sequence_op.h"
+#include "dali/pipeline/util/operator_impl_utils.h"
 
 namespace dali {
 
@@ -38,15 +39,31 @@ namespace dali {
 
 
 template <typename Backend>
-class Laplacian : public Operator<Backend> {
+class Laplacian : public SequenceOperator<Backend> {
  public:
   inline explicit Laplacian(const OpSpec& spec)
-      : Operator<Backend>(spec), dtype_(spec.GetArgument<DALIDataType>("dtype")) {}
+      : SequenceOperator<Backend>(spec), dtype_(spec.GetArgument<DALIDataType>("dtype")) {}
 
   DISABLE_COPY_MOVE_ASSIGN(Laplacian);
 
  protected:
   bool CanInferOutputs() const override {
+    return true;
+  }
+
+  bool ShouldExpandChannels() const override {
+    return true;
+  }
+
+  bool ShouldExpand(const workspace_t<Backend>& ws) override;
+
+  // Overrides unnecessary coalescing
+  bool ProcessOutputDesc(std::vector<OutputDesc>& output_desc, const workspace_t<Backend>& ws,
+                         bool is_inferred) override {
+    assert(is_inferred && output_desc.size() == 1);
+    const auto& input = ws.template Input<Backend>(0);
+    // The shape of data stays untouched
+    output_desc[0].shape = input.shape();
     return true;
   }
 
@@ -59,6 +76,7 @@ class Laplacian : public Operator<Backend> {
   USE_OPERATOR_MEMBERS();
   std::unique_ptr<OpImplBase<Backend>> impl_;
   DALIDataType impl_in_dtype_ = DALI_NO_TYPE;
+  convolution_utils::DimDesc dim_desc_ = {};
   convolution_utils::DimDesc impl_dim_desc_ = {};
 };
 

--- a/dali/operators/image/convolution/laplacian.h
+++ b/dali/operators/image/convolution/laplacian.h
@@ -51,7 +51,8 @@ class Laplacian : public SequenceOperator<Backend> {
     return true;
   }
 
-  bool ShouldExpandChannels() const override {
+  bool ShouldExpandChannels(int input_idx) const override {
+    (void)input_idx;
     return true;
   }
 

--- a/dali/operators/image/convolution/laplacian.h
+++ b/dali/operators/image/convolution/laplacian.h
@@ -22,7 +22,7 @@
 #include "dali/operators/image/convolution/laplacian_params.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
-#include "dali/pipeline/operator/sequence_op.h"
+#include "dali/pipeline/operator/sequence_operator.h"
 #include "dali/pipeline/util/operator_impl_utils.h"
 
 namespace dali {

--- a/dali/operators/image/convolution/laplacian_gpu.h
+++ b/dali/operators/image/convolution/laplacian_gpu.h
@@ -64,8 +64,7 @@ class LaplacianOpGpu : public OpImplBase<GPUBackend> {
 
     output_desc.resize(1);
     output_desc[0].type = type2id<Out>::value;
-    // The shape of data stays untouched
-    output_desc[0].shape = input.shape();
+    // Shape is set by ProcessOutputDesc
 
     args.ObtainLaplacianArgs(spec_, ws, nsamples);
 

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -280,7 +280,6 @@ OpSchema::FindDefaultValue(const std::string &name, bool local_only, bool includ
   return { nullptr, nullptr };
 }
 
-
 bool OpSchema::IsTensorArgument(const std::string &name) const {
   bool ret = tensor_arguments_.find(name) != tensor_arguments_.end();
   if (ret) {
@@ -291,6 +290,10 @@ bool OpSchema::IsTensorArgument(const std::string &name) const {
     ret = ret || parent.IsTensorArgument(name);
   }
   return ret;
+}
+
+bool OpSchema::ArgSupportsPerFrameInput(const std::string &arg_name) const {
+  return per_frame_arguments_.find(arg_name) != per_frame_arguments_.end();
 }
 
 }  // namespace dali

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -280,20 +280,28 @@ OpSchema::FindDefaultValue(const std::string &name, bool local_only, bool includ
   return { nullptr, nullptr };
 }
 
-bool OpSchema::IsTensorArgument(const std::string &name) const {
-  bool ret = tensor_arguments_.find(name) != tensor_arguments_.end();
-  if (ret) {
-    return ret;
+const TensorArgDesc* OpSchema::FindTensorArgument(const std::string &name) const {
+  auto it = tensor_arguments_.find(name);
+  if (it != tensor_arguments_.end()) {
+    return &it->second;
   }
   for (const auto &p : parents_) {
     const OpSchema &parent = SchemaRegistry::GetSchema(p);
-    ret = ret || parent.IsTensorArgument(name);
+    auto desc = parent.FindTensorArgument(name);
+    if (desc) {
+      return desc;
+    }
   }
-  return ret;
+  return nullptr;
+}
+
+bool OpSchema::IsTensorArgument(const std::string &name) const {
+  return FindTensorArgument(name);
 }
 
 bool OpSchema::ArgSupportsPerFrameInput(const std::string &arg_name) const {
-  return per_frame_arguments_.find(arg_name) != per_frame_arguments_.end();
+  auto arg_desc = FindTensorArgument(arg_name);
+  return arg_desc && arg_desc->supports_per_frame;
 }
 
 }  // namespace dali

--- a/dali/pipeline/operator/sequence_op.h
+++ b/dali/pipeline/operator/sequence_op.h
@@ -1,0 +1,451 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATOR_SEQUENCE_OP_H_
+#define DALI_PIPELINE_OPERATOR_SEQUENCE_OP_H_
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+#include "dali/pipeline/data/tensor.h"
+#include "dali/pipeline/data/views.h"
+#include "dali/pipeline/operator/argument.h"
+#include "dali/pipeline/operator/common.h"
+#include "dali/pipeline/operator/op_spec.h"
+#include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/operator/sequence_shape.h"
+
+namespace dali {
+
+template <typename Backend>
+class SequenceOperator : public Operator<Backend> {
+ public:
+  inline explicit SequenceOperator(const OpSpec &spec) : Operator<Backend>{spec} {}
+
+  using Operator<Backend>::Setup;
+  using Operator<Backend>::Run;
+
+  template <typename InputBackend>
+  using ws_input_t = typename workspace_t<Backend>::template input_t<InputBackend>;
+  template <typename OutputBackend>
+  using ws_output_t = typename workspace_t<Backend>::template output_t<OutputBackend>;
+
+  bool Setup(std::vector<OutputDesc> &output_desc, const workspace_t<Backend> &ws) override {
+    expand_ = ShouldExpand(ws);
+    bool is_inferred;
+    if (!expand_) {
+      is_inferred = Operator<Backend>::Setup(output_desc, ws);
+    } else {
+      SetupSequenceOperator(ws);
+      SetupExpandedWorkspace(expanded_, ws);
+      ExpandInputs(ws);
+      ExpandArguments(ws);
+      is_inferred = Operator<Backend>::Setup(output_desc, expanded_);
+    }
+    return ProcessOutputDesc(output_desc, ws, is_inferred);
+  }
+
+  void Run(workspace_t<Backend> &ws) override {
+    if (!expand_) {
+      Operator<Backend>::Run(ws);
+    } else {
+      ExpandOutputs(ws);
+      Operator<Backend>::Run(expanded_);
+      PostprocessOutputs(ws);
+      Clear();
+    }
+  }
+
+  bool IsExpanded() const {
+    return expand_;
+  }
+
+  virtual bool ShouldExpandChannels() const {
+    return false;
+  }
+
+ protected:
+  virtual bool ShouldExpand(const workspace_t<Backend> &ws) {
+    auto num_inputs = ws.NumInput();
+    for (int input_idx = 0; input_idx < num_inputs; input_idx++) {
+      const auto &layout = GetInputLayout(ws, input_idx);
+      auto layout_desc =
+          ShouldExpandChannels() ? LayoutDesc::FrameAndChannel(layout) : LayoutDesc::Frame(layout);
+      if (layout_desc.NumDims() > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  virtual void SetupSequenceOperator(const workspace_t<Backend> &ws) {
+    auto num_inputs = ws.NumInput();
+    input_expand_desc_.reserve(num_inputs);
+    for (int input_idx = 0; input_idx < num_inputs; input_idx++) {
+      const auto &input_shape = ws.GetInputShape(input_idx);
+      const auto &layout = GetInputLayout(ws, input_idx);
+      DALI_ENFORCE(layout.size() == 0 || layout.size() == input_shape.sample_dim(),
+                   make_string("Layout of input ", input_idx, " has size ", layout.size(),
+                               " which does not match the dimensionality of the input (got input "
+                               "with dimensionality ",
+                               input_shape.sample_dim(), ")."));
+      auto layout_desc =
+          ShouldExpandChannels() ? LayoutDesc::FrameAndChannel(layout) : LayoutDesc::Frame(layout);
+      input_expand_desc_.emplace_back(input_shape, layout_desc);
+    }
+  }
+
+  virtual void ExpandInputs(const workspace_t<Backend> &ws) {
+    for (int input_idx = 0; input_idx < ws.NumInput(); input_idx++) {
+      const auto &expand_desc = GetInputExpandDesc(input_idx);
+      auto num_expand_dims = expand_desc.NumDims();
+      if (ws.template InputIsType<GPUBackend>(input_idx)) {
+        auto expanded_handle = ExpandInputHelper<GPUBackend>(ws, input_idx, num_expand_dims);
+        AddInputHelper<GPUBackend>(expanded_handle);
+      } else {
+        auto expanded_handle = ExpandInputHelper<CPUBackend>(ws, input_idx, num_expand_dims);
+        AddInputHelper<CPUBackend>(expanded_handle);
+      }
+    }
+  }
+
+  virtual void ExpandOutputs(const workspace_t<Backend> &ws) {
+    for (int output_idx = 0; output_idx < ws.NumInput(); output_idx++) {
+      const auto &expand_desc = GetOutputExpandDesc(ws, output_idx);
+      auto num_expand_dims = expand_desc.NumDims();
+      if (ws.template OutputIsType<GPUBackend>(output_idx)) {
+        auto expanded_handle = ExpandOutputHelper<GPUBackend>(ws, output_idx, num_expand_dims);
+        AddOutputHelper<GPUBackend>(expanded_handle);
+      } else {
+        auto expanded_handle = ExpandOutputHelper<CPUBackend>(ws, output_idx, num_expand_dims);
+        AddOutputHelper<CPUBackend>(expanded_handle);
+      }
+    }
+  }
+
+  virtual void PostprocessOutputs(workspace_t<Backend> &ws) {
+    auto num_output = ws.NumOutput();
+    for (int output_idx = 0; output_idx < num_output; output_idx++) {
+      const auto &expand_desc = GetOutputExpandDesc(ws, output_idx);
+      auto layout_prefix = expand_desc.ExpandedLayout();
+      if (ws.template OutputIsType<GPUBackend>(output_idx)) {
+        SetOutputLayoutHelper<GPUBackend>(ws, output_idx, layout_prefix);
+      } else {
+        SetOutputLayoutHelper<CPUBackend>(ws, output_idx, layout_prefix);
+      }
+    }
+  }
+
+  virtual void CoalesceOutputShapes(std::vector<OutputDesc> &output_desc,
+                                    const workspace_t<Backend> &ws) {
+    for (size_t output_idx = 0; output_idx < output_desc.size(); output_idx++) {
+      const auto &expand_desc = GetOutputExpandDesc(ws, output_idx);
+      const auto &shape = output_desc[output_idx].shape;
+      DALI_ENFORCE(shape.num_samples() == expand_desc.NumElements(),
+                   make_string("Unexpected number of frames inferred in the operator for output ",
+                               output_idx, ". Expected ", expand_desc.NumElements(),
+                               " but the operator returned ", shape.num_samples(), "."));
+      output_desc[output_idx].shape = fold_outermost_like(shape, expand_desc.ExpandedShape());
+    }
+  }
+
+  virtual bool ProcessOutputDesc(std::vector<OutputDesc> &output_desc,
+                                 const workspace_t<Backend> &ws, bool is_inferred) {
+    if (is_inferred && expand_) {
+      CoalesceOutputShapes(output_desc, ws);
+    }
+    return is_inferred;
+  }
+
+  virtual void ExpandArgment(const workspace_t<Backend> &ws, const std::string &arg_name,
+                             const TensorVector<CPUBackend> &arg_tensor) {
+    const auto &expand_desc = GetArgExpandDesc(arg_name);
+    auto expanded_arg = ExpandArgumentLike(arg_tensor, arg_name, expand_desc);
+    auto expanded_handle = std::make_shared<TensorVector<CPUBackend>>(std::move(expanded_arg));
+    AddArgumentInputHelper(arg_name, expanded_handle);
+  }
+
+  virtual void ExpandArguments(const workspace_t<Backend> &ws) {
+    for (const auto &arg_input : ws) {
+      auto shared_tvec = arg_input.second.tvec;
+      assert(shared_tvec);
+      ExpandArgment(ws, arg_input.first, *shared_tvec);
+    }
+  }
+
+  virtual const ExpandDesc &GetOutputExpandDesc(const workspace_t<Backend> &ws, int output_idx) {
+    (void)ws;
+    return GetInputExpandDesc(output_idx);
+  }
+
+  virtual const ExpandDesc &GetArgExpandDesc(const std::string &arg_name) {
+    (void)arg_name;
+    return GetInputExpandDesc(0);
+  }
+
+  bool HasPerFrameArgInput(const workspace_t<Backend> &ws) {
+    for (const auto &arg_input : ws) {
+      auto shared_tvec = arg_input.second.tvec;
+      assert(shared_tvec);
+      if (IsPerFrame(*shared_tvec)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool IsPerFrame(const TensorVector<CPUBackend> &arg_tensor) {
+    const auto &layout = arg_tensor.GetLayout();
+    return layout.size() > 0 && layout[0] == 'F';
+  }
+
+  template <typename InputBackend>
+  ws_input_t<InputBackend> ExpandInputHelper(const workspace_t<Backend> &ws, int input_idx,
+                                             int num_expand_dims) {
+    const auto &input = ws.template Input<InputBackend>(input_idx);
+    auto sample_dim = input.shape().sample_dim();
+    DALI_ENFORCE(
+        sample_dim > num_expand_dims,
+        make_string("Cannot flatten the input ", input_idx,
+                    ". Samples should have more dimensions (got ", sample_dim,
+                    ") than requested number of dimensions to unfold: ", num_expand_dims, "."));
+    // TODO(ktokarski) TODO(klecki)
+    // Rework it when TensorList stops being contigious and supports "true sample" mode
+    auto expanded_input = unfold_outer_dims(input, num_expand_dims);
+    const auto &input_layout = input.GetLayout();
+    expanded_input.SetLayout(input_layout.sub(num_expand_dims));
+    return std::make_shared<typename ws_input_t<InputBackend>::element_type>(
+        std::move(expanded_input));
+  }
+
+  template <typename OutputBackend>
+  ws_input_t<OutputBackend> ExpandOutputHelper(const workspace_t<Backend> &ws, int output_idx,
+                                               int num_expand_dims) {
+    const auto &output = ws.template Output<OutputBackend>(output_idx);
+    auto sample_dim = output.shape().sample_dim();
+    DALI_ENFORCE(
+        sample_dim > num_expand_dims,
+        make_string("Cannot flatten the output ", output_idx,
+                    ". Samples should have more dimensions (got ", sample_dim,
+                    ") than requested number of dimensions to unfold: ", num_expand_dims, "."));
+    // TODO(ktokarski) TODO(klecki)
+    // Rework it when TensorList stops being contigious and supports "true sample" mode
+    auto expanded_output = unfold_outer_dims(output, num_expand_dims);
+    return std::make_shared<typename ws_input_t<OutputBackend>::element_type>(
+        std::move(expanded_output));
+  }
+
+  template <typename OutputBackend>
+  void SetOutputLayoutHelper(const workspace_t<Backend> &ws, int output_idx,
+                             TensorLayout layout_prefix) {
+    DALI_ENFORCE(ExpandedOutputIsType<OutputBackend>(output_idx));
+    auto &expanded_output = ExpandedOutput<OutputBackend>(output_idx);
+    auto &output = ws.template Output<OutputBackend>(output_idx);
+    const auto &layout = expanded_output.GetLayout();
+    if (layout.size() == 0) {
+      output.SetLayout(layout);
+    } else {
+      auto expanded_layout = layout_prefix + layout;
+      output.SetLayout(expanded_layout);
+    }
+  }
+
+  const ExpandDesc &GetInputExpandDesc(int input_idx) {
+    DALI_ENFORCE(expand_ && 0 <= input_idx &&
+                 static_cast<size_t>(input_idx) < input_expand_desc_.size());
+    return input_expand_desc_[input_idx];
+  }
+
+  void SetupExpandedWorkspace(workspace_t<CPUBackend> &expanded,
+                              const workspace_t<CPUBackend> &ws) {
+    expanded.SetThreadPool(&ws.GetThreadPool());
+  }
+
+  void SetupExpandedWorkspace(workspace_t<GPUBackend> &expanded,
+                              const workspace_t<GPUBackend> &ws) {
+    if (ws.has_stream()) {
+      expanded.set_stream(ws.stream());
+    }
+  }
+
+  template <typename InputBackend>
+  void AddInputHelper(ws_input_t<InputBackend> input) {
+    expanded_.AddInput(input);
+  }
+
+  void AddArgumentInputHelper(const std::string &arg_name,
+                              std::shared_ptr<TensorVector<CPUBackend>> arg_input) {
+    expanded_.AddArgumentInput(arg_name, arg_input);
+  }
+
+  template <typename OutputBackend>
+  void AddOutputHelper(ws_input_t<OutputBackend> output) {
+    expanded_.AddOutput(output);
+  }
+
+  template <typename InputBackend>
+  bool ExpandedInputIsType(int input_idx) const {
+    return expanded_.template InputIsType<InputBackend>(input_idx);
+  }
+
+  template <typename OutputBackend>
+  bool ExpandedOutputIsType(int output_idx) const {
+    return expanded_.template OutputIsType<OutputBackend>(output_idx);
+  }
+
+  template <typename InputBackend>
+  const auto &ExpandedInput(int intput_idx) {
+    return expanded_.template Input<InputBackend>(intput_idx);
+  }
+
+  template <typename OutputBackend>
+  const auto &ExpandedOutput(int output_idx) {
+    return expanded_.template Output<OutputBackend>(output_idx);
+  }
+
+  void Clear() {
+    expanded_.Clear();
+    input_expand_desc_.clear();
+  }
+
+  TensorVector<CPUBackend> ExpandArgumentLike(const TensorVector<CPUBackend> &arg_tensor,
+                                              const std::string &arg_name,
+                                              const ExpandDesc &expand_desc) {
+    DALI_ENFORCE(static_cast<ptrdiff_t>(arg_tensor.num_samples()) == expand_desc.NumSamples(),
+                 make_string("Number of samples passed for argument ", arg_name, " (got ",
+                             arg_tensor.num_samples(),
+                             ") does not match the number of samples in the input (got ",
+                             expand_desc.NumSamples(), ")."));
+    const auto &arg_layout = arg_tensor.GetLayout();
+    int arg_sample_dim = arg_tensor.sample_dim();
+    DALI_ENFORCE(
+        arg_layout.size() == 0 || arg_sample_dim == arg_layout.size(),
+        make_string("Layout of argument input ", arg_name, " has size ", arg_layout.size(),
+                    " which does not match the dimensionality of the argument (got argument "
+                    "with dimensionality ",
+                    arg_sample_dim, ")."));
+    if (!IsPerFrame(arg_tensor)) {
+      return BroadcastArgumentLike(arg_tensor, expand_desc);
+    }
+    return ExpandFramesLike(arg_tensor, arg_name, expand_desc);
+  }
+
+  TensorVector<CPUBackend> ExpandFramesLike(const TensorVector<CPUBackend> &arg_tensor,
+                                            const std::string &arg_name,
+                                            const ExpandDesc &expand_desc) {
+    DALI_ENFORCE(
+        expand_desc.HasFrames(),
+        make_string(
+            "Tensor input for argument ", arg_name, " is specified per frame (got ",
+            arg_tensor.GetLayout(),
+            " layout), but samples in the input batch do not contain frames (expected input "
+            "layout that starts with 'F', ",
+            ShouldExpandChannels() ? " or 'CF'" : "", ")."));
+    const auto &shape = arg_tensor.shape();
+    int arg_sample_dim = shape.sample_dim();
+    TensorVector<CPUBackend> flat_tensor(expand_desc.NumElements());
+    int num_samples = expand_desc.NumSamples();
+    auto type_info = arg_tensor.type_info();
+    auto type = type_info.id();
+    auto is_pinned = arg_tensor.is_pinned();
+    auto order = arg_tensor.order();
+    int elem_idx = 0;
+    for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
+      const auto &sample_shape = shape[sample_idx];
+      int num_input_frames = expand_desc.NumFrames(sample_idx);
+      int num_arg_frames = sample_shape[0];
+      DALI_ENFORCE(
+          num_arg_frames == 1 || num_input_frames == num_arg_frames,
+          make_string("The tensor argument ", arg_name, " for sample ", sample_idx,
+                      " should either be a single argument to be reused accross all frames in the "
+                      "sample or should be specified per each frame. Got ",
+                      num_arg_frames, " arguments for the sample but there are ", num_input_frames,
+                      " frames in the sample."));
+      auto elem_shape = sample_shape.last(arg_sample_dim - 1);
+      auto elem_volume = volume(elem_shape);
+      uint8_t *base_ptr =
+          const_cast<uint8_t *>(static_cast<const uint8_t *>(arg_tensor.raw_tensor(sample_idx)));
+      auto num_bytes = type_info.size() * elem_volume;
+      if (num_arg_frames == 1) {  // broadcast the sample
+        for (int j = 0; j < expand_desc.NumElements(sample_idx); j++) {
+          flat_tensor[elem_idx++].ShareData(base_ptr, num_bytes, is_pinned, elem_shape, type,
+                                            order);
+        }
+      } else if (!expand_desc.HasChannels()) {  // expand frames dimension
+        assert(num_arg_frames == expand_desc.NumElements(sample_idx));
+        for (int i = 0; i < num_arg_frames; i++, base_ptr += num_bytes) {
+          flat_tensor[elem_idx++].ShareData(base_ptr, num_bytes, is_pinned, elem_shape, type,
+                                            order);
+        }
+      } else {
+        int num_input_channels = expand_desc.NumChannels(sample_idx);
+        assert(num_arg_frames * num_input_channels == expand_desc.NumElements(sample_idx));
+        int inner_stride, outer_stride;
+        if (expand_desc.IsChannelFirst()) {
+          inner_stride = num_input_frames;
+          outer_stride = 1;
+        } else {
+          inner_stride = 1;
+          outer_stride = num_input_channels;
+        }
+        for (int i = 0; i < num_arg_frames; i++, base_ptr += num_bytes) {
+          for (int j = 0; j < num_input_channels; j++) {
+            flat_tensor[elem_idx + i * outer_stride + j * inner_stride].ShareData(
+                base_ptr, num_bytes, is_pinned, elem_shape, type, order);
+          }
+        }
+        elem_idx += num_input_channels * num_input_frames;
+      }
+    }
+    assert(elem_idx == expand_desc.NumElements());
+    return flat_tensor;
+  }
+
+  TensorVector<CPUBackend> BroadcastArgumentLike(const TensorVector<CPUBackend> &arg_tensor,
+                                                 const ExpandDesc &expand_desc) {
+    const auto &shape = arg_tensor.shape();
+    TensorVector<CPUBackend> res(expand_desc.NumElements());
+    int num_samples = expand_desc.NumSamples();
+    auto type_info = arg_tensor.type_info();
+    auto type = type_info.id();
+    auto is_pinned = arg_tensor.is_pinned();
+    auto order = arg_tensor.order();
+    int elem_idx = 0;
+    for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
+      const auto &elem_shape = shape[sample_idx];
+      int num_elements = expand_desc.NumElements(sample_idx);
+      auto num_bytes = type_info.size() * num_elements;
+      uint8_t *ptr =
+          const_cast<uint8_t *>(static_cast<const uint8_t *>(arg_tensor.raw_tensor(sample_idx)));
+      for (int sample_elem_idx = 0; sample_elem_idx < num_elements; sample_elem_idx++) {
+        res[elem_idx++].ShareData(ptr, num_bytes, is_pinned, elem_shape, type, order);
+      }
+    }
+    assert(elem_idx == expand_desc.NumElements());
+    return res;
+  }
+
+  std::vector<ExpandDesc> input_expand_desc_;
+
+ private:
+  bool expand_;
+  workspace_t<Backend> expanded_;
+};
+
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATOR_SEQUENCE_OP_H_

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -173,7 +173,7 @@ class SequenceOperator : public Operator<Backend> {
   }
 
   virtual void ExpandOutputs(const workspace_t<Backend> &ws) {
-    for (int output_idx = 0; output_idx < ws.NumInput(); output_idx++) {
+    for (int output_idx = 0; output_idx < ws.NumOutput(); output_idx++) {
       const auto &expand_desc = GetOutputExpandDesc(ws, output_idx);
       auto num_expand_dims = expand_desc.NumDimsToExpand();
       if (ws.template OutputIsType<GPUBackend>(output_idx)) {

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -50,8 +50,9 @@ class SequenceOperator : public Operator<Backend> {
     if (!IsExpanding()) {
       is_inferred = Operator<Backend>::Setup(output_desc, ws);
     } else {
-      DALI_ENFORCE(ExpandLikeIdx() >= 0 &&
-                   GetInputExpandDesc(ExpandLikeIdx()).NumDimsToExpand() > 0);
+      DALI_ENFORCE(IsExpandable() && GetInputExpandDesc(ExpandLikeIdx()).NumDimsToExpand() > 0,
+                   "Operator requested to expand the sequence-like inputs, but no expandable input "
+                   "was found");
       SetupExpandedWorkspace(expanded_, ws);
       ExpandInputs(ws);
       ExpandArguments(ws);
@@ -75,6 +76,10 @@ class SequenceOperator : public Operator<Backend> {
     return is_expanding_;
   }
 
+  bool IsExpandable() const {
+    return ExpandLikeIdx() >= 0;
+  }
+
   virtual bool ShouldExpandChannels(int input_idx) const {
     (void)input_idx;
     return false;
@@ -82,7 +87,7 @@ class SequenceOperator : public Operator<Backend> {
 
  protected:
   virtual bool ShouldExpand(const workspace_t<Backend> &ws) {
-    return ExpandLikeIdx() >= 0;
+    return IsExpandable();
   }
 
   virtual void ExpandInputs(const workspace_t<Backend> &ws) {

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -219,7 +219,7 @@ class SequenceOperator : public Operator<Backend> {
         VerifyExpansionConsistency(ref_input_idx, ref_expand_desc, input_idx, input_desc);
       }
       ExpandedAddProcessedInput(ws, input_idx, [&](const auto &input) {
-        return UnfoldInput(ws, input, input_idx, input_desc);
+        return UnfoldInput(input, input_idx, input_desc);
       });
     }
   }
@@ -232,7 +232,7 @@ class SequenceOperator : public Operator<Backend> {
   virtual void ExpandOutput(const workspace_t<Backend> &ws, int output_idx) {
     const auto &expand_desc = GetOutputExpandDesc(ws, output_idx);
     ExpandedAddProcessedOutput(ws, output_idx, [&](const auto &output) {
-      return UnfoldOutput(ws, output, output_idx, expand_desc);
+      return UnfoldOutput(output, output_idx, expand_desc);
     });
   }
 
@@ -344,7 +344,7 @@ class SequenceOperator : public Operator<Backend> {
   }
 
   void VerifyExpansionConsistency(int expand_idx, const ExpandDesc &expand_desc, int input_idx,
-                                 const ExpandDesc &input_desc) {
+                                  const ExpandDesc &input_desc) {
     // TODO(ktokarski) consider mix of expansion and broadcasting similar to handling of
     // per-frame arguments for "FC" or "CF" layouts. Consider agreeing "FC" and "CF" inputs.
     DALI_ENFORCE(
@@ -451,8 +451,7 @@ class SequenceOperator : public Operator<Backend> {
   }
 
   template <typename InputType>
-  auto UnfoldInput(const workspace_t<Backend> &ws, const InputType &input, int input_idx,
-                   const ExpandDesc &expand_desc) {
+  auto UnfoldInput(const InputType &input, int input_idx, const ExpandDesc &expand_desc) {
     auto sample_dim = input.shape().sample_dim();
     auto num_expand_dims = expand_desc.NumDimsToExpand();
     DALI_ENFORCE(
@@ -467,8 +466,7 @@ class SequenceOperator : public Operator<Backend> {
   }
 
   template <typename OutputType>
-  auto UnfoldOutput(const workspace_t<Backend> &ws, const OutputType &output, int output_idx,
-                    const ExpandDesc &expand_desc) {
+  auto UnfoldOutput(const OutputType &output, int output_idx, const ExpandDesc &expand_desc) {
     auto sample_dim = output.shape().sample_dim();
     auto num_expand_dims = expand_desc.NumDimsToExpand();
     DALI_ENFORCE(

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -357,7 +357,7 @@ class SequenceOperator : public Operator<Backend> {
   }
 
   void VerifyExpanionConsistency(int expand_idx, const ExpandDesc &expand_desc, int input_idx,
-                                  const ExpandDesc &input_desc) {
+                                 const ExpandDesc &input_desc) {
     // TODO(ktokarski) consider mix of expansion and broadcasting similar to handling of
     // per-frame arguments for "FC" or "CF" layouts. Consider agreeing "FC" and "CF" inputs.
     DALI_ENFORCE(
@@ -537,7 +537,7 @@ class SequenceOperator : public Operator<Backend> {
             "Tensor input for argument ", arg_name, " is specified per frame (got ",
             arg_tensor.GetLayout(),
             " layout), but samples in the input batch do not contain frames (expected input "
-            "layout that starts with 'F', ",
+            "layout that starts with 'F'",
             ShouldExpandChannels(expand_idx) ? " or 'CF'" : "", "). Got layout ",
             expand_desc.Layout(), " for operator intput ", expand_idx, "."));
     const auto &shape = arg_tensor.shape();

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -484,6 +484,7 @@ class SequenceOperator : public Operator<Backend> {
   TensorVector<CPUBackend> ExpandArgumentLikeInput(const TensorVector<CPUBackend> &arg_input,
                                                    const std::string &arg_name, int input_idx) {
     const auto &expand_desc = GetInputExpandDesc(input_idx);
+    assert(expand_desc.NumDimsToExpand() > 0);
     DALI_ENFORCE(arg_input.num_samples() == expand_desc.NumSamples(),
                  make_string("Number of samples passed for argument ", arg_name, " (got ",
                              arg_input.num_samples(),

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -265,7 +265,7 @@ class SequenceOperator : public Operator<Backend> {
     for (size_t output_idx = 0; output_idx < output_desc.size(); output_idx++) {
       const auto &expand_desc = GetOutputExpandDesc(ws, output_idx);
       const auto &shape = output_desc[output_idx].shape;
-      DALI_ENFORCE(static_cast<size_t>(shape.num_samples()) == expand_desc.NumExpanded(),
+      DALI_ENFORCE(shape.num_samples() == expand_desc.NumExpanded(),
                    make_string("Unexpected number of frames inferred in the operator for output ",
                                output_idx, ". Expected ", expand_desc.NumExpanded(),
                                " but the operator returned ", shape.num_samples(), "."));
@@ -356,7 +356,7 @@ class SequenceOperator : public Operator<Backend> {
                     " is expected to either: have no outermost dimensions planned for expanding or "
                     "have exactly the same outermost dimensions to expand. However, got `",
                     input_desc.ExpandedLayout(), "` planned for expanding."));
-    for (size_t sample_idx = 0; sample_idx < expand_desc.NumSamples(); ++sample_idx) {
+    for (int sample_idx = 0; sample_idx < expand_desc.NumSamples(); ++sample_idx) {
       assert(expand_desc.NumExpanded(sample_idx) == input_desc.NumExpanded(sample_idx));
       if (expand_desc.ExpandFrames()) {
         DALI_ENFORCE(expand_desc.NumFrames(sample_idx) == input_desc.NumFrames(sample_idx),
@@ -496,7 +496,7 @@ class SequenceOperator : public Operator<Backend> {
     assert((arg_input.num_samples() == expand_desc.NumSamples()) && expand_desc.ExpandFrames());
     auto tv_builder =
         sequence_utils::tv_builder_like(arg_input, expand_desc.NumExpanded(), ndims_to_unfold);
-    for (size_t sample_idx = 0; sample_idx < expand_desc.NumSamples(); sample_idx++) {
+    for (int sample_idx = 0; sample_idx < expand_desc.NumSamples(); sample_idx++) {
       auto frames_range =
           sequence_utils::unfolded_slice_range(arg_input, sample_idx, ndims_to_unfold);
       auto num_input_frames = expand_desc.NumFrames(sample_idx);
@@ -510,7 +510,7 @@ class SequenceOperator : public Operator<Backend> {
                       " frames in the sample."));
       if (num_arg_frames == 1) {  // broadcast the sample
         auto slice = frames_range[0];
-        for (size_t j = 0; j < expand_desc.NumExpanded(sample_idx); j++) {
+        for (int j = 0; j < expand_desc.NumExpanded(sample_idx); j++) {
           tv_builder.push(slice);
         }
       } else if (!expand_desc.ExpandChannels()) {  // expand frames dimension
@@ -545,7 +545,7 @@ class SequenceOperator : public Operator<Backend> {
     auto tv_builder = sequence_utils::tv_builder_like(arg_input, expand_desc.NumExpanded());
     const auto &type_info = arg_input.type_info();
     assert(expand_desc.NumSamples() == arg_input.num_samples());
-    for (size_t sample_idx = 0; sample_idx < expand_desc.NumSamples(); sample_idx++) {
+    for (int sample_idx = 0; sample_idx < expand_desc.NumSamples(); sample_idx++) {
       const auto &slice_shape = shape[sample_idx];
       int num_elements = expand_desc.NumExpanded(sample_idx);
       uint8_t *ptr =
@@ -564,7 +564,7 @@ class SequenceOperator : public Operator<Backend> {
     auto tv_builder =
         sequence_utils::tv_builder_like(data, expand_desc.NumExpanded(), ndims_to_unfold);
     assert(expand_desc.NumSamples() == data.num_samples());
-    for (size_t sample_idx = 0; sample_idx < expand_desc.NumSamples(); sample_idx++) {
+    for (int sample_idx = 0; sample_idx < expand_desc.NumSamples(); sample_idx++) {
       auto slices_range = sequence_utils::unfolded_slice_range(data, sample_idx, ndims_to_unfold);
       assert(expand_desc.NumExpanded(sample_idx) == slices_range.NumSlices());
       for (auto &&slice : slices_range) {

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -197,6 +197,11 @@ class UnfoldedSliceRange {
   size_t slice_stride_;
 };
 
+
+/**
+ * @brief Utility to build the sharing tensor vector from slices of samples of
+ * another tensor vector.
+ */
 template <typename Backend>
 struct TensorVectorBuilder {
   TensorVectorBuilder(int num_samples, DALIDataType type, int sample_dim, TensorLayout layout,
@@ -215,6 +220,10 @@ struct TensorVectorBuilder {
                         view.shape, tv_.type(), tv_.order(), tv_.GetLayout());
   }
 
+  /**
+   * @brief Returns the created tensor vector: must be called after pusing exactly ``num_samples``.
+   * Calling ``take`` invalidates the ``TensorVectorBuilder`` instance.
+   */
   TensorVector<Backend> take() {
     assert(size == tv_.num_samples());
     return std::move(tv_);

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -22,6 +22,9 @@
 
 namespace dali {
 
+/**
+ * @brief Describes expandable prefix of the layout and of the shape of a batch.
+ */
 class ExpandDesc {
  public:
   inline ExpandDesc(const TensorListShape<> &shape, TensorLayout layout,
@@ -156,7 +159,7 @@ class UnfoldedSliceRange {
   }
 
   inline SliceIterator<UnfoldedSliceRange> end() const {
-    return {*this, num_slices_};
+    return {*this, NumSlices()};
   }
 
   inline SliceViewType operator[](IndexType idx) const {

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -127,11 +127,11 @@ class RangeIterator {
     return range_[idx_];
   }
 
-  bool operator==(const RangeIterator &other) {
+  bool operator==(const RangeIterator &other) const {
     return idx_ == other.idx_;
   }
 
-  bool operator!=(const RangeIterator &other) {
+  bool operator!=(const RangeIterator &other) const {
     return !(*this == other);
   }
 

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -283,6 +283,7 @@ TensorList<Backend> unfold_outer_dims(const TensorList<Backend> &data, int ndims
 
 inline TensorListShape<> fold_outermost_like(const TensorListShape<> &shape,
                                              const TensorListShape<> &unfolded_extents) {
+  assert(shape.num_samples() == unfolded_extents.num_elements());
   if (unfolded_extents.sample_dim() == 0) {
     return shape;
   }

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -107,11 +107,6 @@ class ExpandDesc {
 };
 
 namespace sequence_utils {
-struct SliceView {
-  uint8_t *ptr;
-  TensorShape<> shape;
-  size_t type_size;
-};
 
 template <typename FrameRange>
 class SliceIterator {
@@ -142,6 +137,11 @@ class SliceIterator {
   IndexType idx_;
 };
 
+struct SliceView {
+  uint8_t *ptr;
+  TensorShape<> shape;
+  size_t type_size;
+};
 
 class UnfoldedSliceRange {
  public:
@@ -163,7 +163,7 @@ class UnfoldedSliceRange {
   }
 
   inline SliceViewType operator[](IndexType idx) const {
-    return {view_.ptr + idx * slice_stride_, slice_shape_, view_.type_size};
+    return {view_.ptr + idx * SliceSize(), SliceShape(), view_.type_size};
   }
 
   inline ptrdiff_t NumSlices() const {

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -1,0 +1,200 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OPERATOR_SEQUENCE_SHAPE_H_
+#define DALI_PIPELINE_OPERATOR_SEQUENCE_SHAPE_H_
+
+#include <string>
+#include <type_traits>
+#include <vector>
+#include "dali/pipeline/data/tensor.h"
+#include "dali/pipeline/data/views.h"
+
+namespace dali {
+
+struct LayoutDesc {
+  static inline LayoutDesc FrameAndChannel(const TensorLayout &layout) {
+    int frame_dim = VideoLayoutInfo::FrameDimIndex(layout);
+    int channel_dim = ImageLayoutInfo::ChannelDimIndex(layout);
+    frame_dim = frame_dim > 1 ? -1 : frame_dim;
+    channel_dim = channel_dim > 1 ? -1 : channel_dim;
+    if (frame_dim != 0 && channel_dim != 0) {
+      return {};
+    }
+    return {layout, frame_dim, channel_dim};
+  }
+
+  static inline LayoutDesc Frame(const TensorLayout &layout) {
+    if (VideoLayoutInfo::FrameDimIndex(layout) != 0) {
+      return {};
+    }
+    return {layout, 0};
+  }
+
+  inline int NumDims() const {
+    return (frame_dim >= 0) + (channel_dim >= 0);
+  }
+
+  TensorLayout layout = {};
+  int frame_dim = -1;
+  int channel_dim = -1;
+};
+
+class ExpandDesc {
+ public:
+  inline ExpandDesc(const TensorListShape<> &shape, const LayoutDesc &layout_desc)
+      : layout_desc_{layout_desc},
+        has_channels_{layout_desc_.channel_dim >= 0},
+        has_frames_{layout_desc_.frame_dim >= 0},
+        is_channel_first_{has_channels_ && layout_desc_.channel_dim < layout_desc_.frame_dim},
+        num_dims_{has_channels_ + has_frames_},
+        expanded_shape_{shape.first(num_dims_)},
+        num_elements_{expanded_shape_.num_elements()} {}
+
+  inline bool HasChannels() const {
+    return has_channels_;
+  }
+
+  inline bool HasFrames() const {
+    return has_frames_;
+  }
+
+  inline bool IsChannelFirst() const {
+    return is_channel_first_;
+  }
+
+  inline int NumDims() const {
+    return num_dims_;
+  }
+
+  inline ptrdiff_t NumElements() const {
+    return num_elements_;
+  }
+
+  inline ptrdiff_t NumSamples() const {
+    return expanded_shape_.num_samples();
+  }
+
+  inline int NumElements(int sample_idx) const {
+    return volume(expanded_shape_[sample_idx]);
+  }
+
+  inline int NumFrames(int sample_idx) const {
+    return expanded_shape_[sample_idx][layout_desc_.frame_dim];
+  }
+
+  inline int NumChannels(int sample_idx) const {
+    return expanded_shape_[sample_idx][layout_desc_.channel_dim];
+  }
+
+  const TensorListShape<> &ExpandedShape() const {
+    return expanded_shape_;
+  }
+
+  inline TensorLayout ExpandedLayout() const {
+    return layout_desc_.layout.first(num_dims_);
+  }
+
+ private:
+  LayoutDesc layout_desc_;
+  bool has_channels_;
+  bool has_frames_;
+  bool is_channel_first_;
+  int num_dims_;
+  TensorListShape<> expanded_shape_;
+  ptrdiff_t num_elements_;
+};
+
+
+template <typename Backend>
+TensorVector<Backend> unfold_outer_dims(const TensorVector<Backend> &data, int num_unfold_dims) {
+  const auto &shape = data.shape();
+  auto group_shapes = shape.first(num_unfold_dims);
+  const auto num_unfolded_samples = group_shapes.num_elements();
+  TensorVector<Backend> unfolded_tensor(num_unfolded_samples);
+  int elem_idx = 0;
+  auto type_info = data.type_info();
+  auto type = type_info.id();
+  auto is_pinned = data.is_pinned();
+  auto order = data.order();
+  unfolded_tensor.set_type(type);
+  unfolded_tensor.set_pinned(is_pinned);
+  unfolded_tensor.set_order(order);
+  for (int sample_idx = 0; sample_idx < shape.num_samples(); sample_idx++) {
+    const auto &sample_shape = shape[sample_idx];
+    int num_frames = volume(sample_shape.begin(), sample_shape.begin() + num_unfold_dims);
+    TensorShape<> element_shape{sample_shape.begin() + num_unfold_dims, sample_shape.end()};
+    int element_volume = volume(element_shape);
+    auto num_bytes = type_info.size() * element_volume;
+    uint8_t *base_ptr;
+    base_ptr = const_cast<uint8_t *>(static_cast<const uint8_t *>(data.raw_tensor(sample_idx)));
+    for (int frame_idx = 0; frame_idx < num_frames; ++frame_idx) {
+      uint8_t *ptr = base_ptr + frame_idx * num_bytes;
+      unfolded_tensor[elem_idx++].ShareData(ptr, num_bytes, is_pinned, element_shape, type, order);
+    }
+  }
+  assert(elem_idx == num_unfolded_samples);
+  return unfolded_tensor;
+}
+
+template <typename Backend>
+TensorList<Backend> unfold_outer_dims(const TensorList<Backend> &data, int num_unfold_dims) {
+  const auto &shape = data.shape();
+  TensorList<Backend> tl;
+  tl.ShareData(data);
+  auto expanded_shape = unfold_outer_dims(shape, num_unfold_dims);
+  tl.Resize(expanded_shape, data.type());
+  return tl;
+}
+
+inline TensorListShape<> unfold_outer_dims(const TensorListShape<> &shape, int num_unfold_dims) {
+  if (num_unfold_dims == 0) {
+    return shape;
+  } else if (num_unfold_dims == 1) {
+    return unfold_outer_dim(shape);
+  } else {
+    auto data_shape = collapse_dims(shape, {{0, num_unfold_dims}});
+    return unfold_outer_dim(data_shape);
+  }
+}
+
+inline TensorListShape<> fold_outermost_like(const TensorListShape<> &shape,
+                                             const TensorListShape<> &folded_shape) {
+  if (folded_shape.sample_dim() == 0) {
+    return shape;
+  }
+  auto num_samples = folded_shape.num_samples();
+  TensorListShape<> res(num_samples, folded_shape.sample_dim() + shape.sample_dim());
+  int element_idx = 0;
+  for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
+    auto group_shape = folded_shape[sample_idx];
+    auto num_elements = volume(group_shape);
+    DALI_ENFORCE(num_elements > 0,
+                 make_string("Zero-volume samples are not allowed. Got volume 0 for sample ",
+                             sample_idx, "."));
+    TensorShape<> element_shape = shape[element_idx++];
+    for (int j = 1; j < num_elements; j++) {
+      DALI_ENFORCE(element_shape == shape[element_idx++],
+                   make_string("Frames in the sample must have equal shapes. Got "
+                               "frames of different shape for sample ",
+                               sample_idx, "."));
+    }
+    res.set_tensor_shape(sample_idx, shape_cat(group_shape, element_shape));
+  }
+  return res;
+}
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OPERATOR_SEQUENCE_SHAPE_H_

--- a/dali/pipeline/operator/sequence_shape_test.cc
+++ b/dali/pipeline/operator/sequence_shape_test.cc
@@ -1,0 +1,290 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/operator/sequence_shape.h"
+#include <gtest/gtest.h>
+#include <string>
+#include "dali/core/format.h"
+#include "dali/core/tensor_shape.h"
+#include "dali/test/tensor_test_utils.h"
+
+namespace dali {
+
+namespace sequence_utils_test {
+
+constexpr cudaStream_t cuda_stream = 0;
+
+using namespace sequence_utils;  // NOLINT
+
+TEST(SequenceShapeTest, FoldExtents1Unfolded) {
+  TensorListShape<> frame_shape = {{4, 5}, {4, 5}, {4, 5}, {4, 5}, {4, 5}, {101, 72}, {101, 72}};
+  TensorListShape<> unfolded_extents = {{5}, {2}};
+  TensorListShape<> expected_shape = {{5, 4, 5}, {2, 101, 72}};
+  auto folded_shape = fold_outermost_like(frame_shape, unfolded_extents);
+  EXPECT_EQ(folded_shape, expected_shape);
+}
+
+TEST(SequenceShapeTest, FoldExtents2Unfolded) {
+  TensorListShape<> frame_shape = {{7, 1},    {7, 1},    {7, 1},  {7, 1},  {7, 1},  {7, 1},
+                                   {101, 72}, {101, 72}, {8, 49}, {8, 49}, {8, 49}, {8, 49},
+                                   {8, 49},   {8, 49},   {8, 49}, {8, 49}, {8, 49}, {8, 49},
+                                   {8, 49},   {8, 49},   {5, 7},  {5, 7}};
+  TensorListShape<> unfolded_extents = {{3, 2}, {2, 1}, {3, 4}, {1, 2}};
+  TensorListShape<> expected_shape = {{3, 2, 7, 1}, {2, 1, 101, 72}, {3, 4, 8, 49}, {1, 2, 5, 7}};
+  auto folded_shape = fold_outermost_like(frame_shape, unfolded_extents);
+  EXPECT_EQ(folded_shape, expected_shape);
+}
+
+TEST(SequenceShapeTest, FoldExtents0Unfolded) {
+  TensorListShape<> frame_shape = {{4, 1}, {4, 2}, {4, 3}, {4, 4}, {4, 5}, {101, 72}, {101, 73}};
+  TensorListShape<> unfolded_extents = {{}, {}, {}, {}, {}, {}, {}};
+  auto folded_shape = fold_outermost_like(frame_shape, unfolded_extents);
+  EXPECT_EQ(folded_shape, frame_shape);
+}
+
+TEST(SequenceShapeTest, FoldExtentsSingleFrame) {
+  TensorListShape<> frame_shape = {{4224}};
+  TensorListShape<> unfolded_extents = {{1, 1, 1, 1, 1}};
+  TensorListShape<> expected_shape = {{1, 1, 1, 1, 1, 4224}};
+  auto folded_shape = fold_outermost_like(frame_shape, unfolded_extents);
+  EXPECT_EQ(folded_shape, expected_shape);
+}
+
+TEST(SequenceShapeTest, FoldExtentsZeroExtent) {
+  TensorListShape<> frame_shape = {{1}, {1}, {1}, {1}, {1}};
+  TensorListShape<> unfolded_extents = {{3, 1}, {5, 0}, {2, 1}};
+  EXPECT_THROW(fold_outermost_like(frame_shape, unfolded_extents), std::runtime_error);
+}
+
+TEST(SequenceShapeTest, FoldExtentsNonUniformSample) {
+  TensorListShape<> frame_shape = {{1, 2, 3}, {1, 2, 3}, {1, 2, 3}, {5, 6, 3},
+                                   {5, 6, 3}, {5, 6, 3}, {5, 7, 3}};
+  TensorListShape<> unfolded_extents = {{3, 1}, {2, 2}};
+  EXPECT_THROW(fold_outermost_like(frame_shape, unfolded_extents), std::runtime_error);
+}
+
+void validate_range(UnfoldedSliceRange range, const uint8_t *base_ptr, TensorShape<> slice_shape,
+                    size_t type_size, int num_slices) {
+  auto stride = volume(slice_shape) * type_size;
+  EXPECT_EQ(range.SliceShape(), slice_shape);
+  EXPECT_EQ(range.SliceSize(), stride);
+  ASSERT_EQ(range.NumSlices(), num_slices);
+  int i = 0;
+  for (auto &&slice : range) {
+    EXPECT_EQ(slice.ptr, base_ptr + i++ * stride);
+    EXPECT_EQ(slice.shape, slice_shape);
+    EXPECT_EQ(slice.type_size, type_size);
+  }
+  EXPECT_EQ(i, num_slices);
+}
+
+TEST(SequenceShapeTest, Unfold0Extents) {
+  uint8_t data{};
+  TensorShape<> shape{3, 5, 7};
+  size_t type_size = 4;
+  SliceView view{&data, shape, type_size};
+  validate_range(UnfoldedSliceRange(view, 0), &data, shape, type_size, 1);
+}
+
+TEST(SequenceShapeTest, Unfold1Extent) {
+  uint8_t data{};
+  TensorShape<> shape{3, 5, 7};
+  size_t type_size = 8;
+  SliceView view{&data, shape, type_size};
+  validate_range(UnfoldedSliceRange(view, 1), &data, {5, 7}, type_size, 3);
+}
+
+TEST(SequenceShapeTest, Unfold2Extents) {
+  uint8_t data{};
+  TensorShape<> shape{3, 5, 7};
+  size_t type_size = 1;
+  SliceView view{&data, shape, type_size};
+  validate_range(UnfoldedSliceRange(view, 2), &data, {7}, type_size, 15);
+}
+
+TEST(SequenceShapeTest, Unfold3Extents) {
+  uint8_t data{};
+  TensorShape<> shape{3, 5, 7};
+  size_t type_size = 2;
+  SliceView view{&data, shape, type_size};
+  validate_range(UnfoldedSliceRange(view, 3), &data, {}, type_size, 105);
+}
+
+template <typename ContainerT>
+void check_batch_props(ContainerT &batch, ContainerT &unfolded_batch, int num_slices,
+                       int ndims_to_unfold) {
+  ASSERT_EQ(batch.is_pinned(), unfolded_batch.is_pinned());
+  ASSERT_EQ(batch.order(), unfolded_batch.order());
+  ASSERT_EQ(batch.type(), unfolded_batch.type());
+  ASSERT_EQ(unfolded_batch.num_samples(), num_slices);
+  if (batch.GetLayout().empty()) {
+    ASSERT_EQ(batch.GetLayout(), unfolded_batch.GetLayout());
+  } else {
+    ASSERT_EQ(batch.GetLayout().sub(ndims_to_unfold), unfolded_batch.GetLayout());
+  }
+}
+
+template <typename Backend>
+class SequenceShapeUnfoldTVTest : public ::testing::Test {
+ protected:
+  TensorVector<Backend> CreateTestBatch(DALIDataType dtype, bool is_pinned = false,
+                                        bool is_contigious = false, TensorLayout layout = "ABC",
+                                        TensorListShape<> shape = {
+                                            {3, 5, 7}, {11, 5, 4}, {7, 2, 11}}) {
+    TensorVector<Backend> batch;
+    constexpr bool is_device = std::is_same_v<Backend, GPUBackend>;
+    batch.set_order(is_device ? AccessOrder(cuda_stream) : AccessOrder::host());
+    batch.SetContiguous(is_contigious);
+    batch.set_pinned(is_pinned);
+    batch.Resize(shape, dtype);
+    if (!layout.empty()) {
+      batch.SetLayout(layout);
+    }
+    return std::move(batch);
+  }
+
+  void TestUnfolding(TensorVector<Backend> &batch, int ndims_to_unfold) {
+    const auto &shape = batch.shape();
+    auto groups = shape.first(ndims_to_unfold);
+    auto slice_shapes = shape.last(shape.sample_dim() - ndims_to_unfold);
+    auto num_slices = groups.num_elements();
+    auto tv_builder = tv_builder_like(batch, num_slices, ndims_to_unfold);
+    for (int sample_idx = 0; sample_idx < shape.num_samples(); sample_idx++) {
+      auto range = unfolded_slice_range(batch, sample_idx, ndims_to_unfold);
+      ASSERT_EQ(range.NumSlices(), volume(groups[sample_idx]));
+      for (auto &&slice : unfolded_slice_range(batch, sample_idx, ndims_to_unfold)) {
+        tv_builder.push(slice);
+      }
+    }
+    auto unfolded_batch = tv_builder.take();
+    check_batch_props(batch, unfolded_batch, num_slices, ndims_to_unfold);
+    int slice_idx = 0;
+    size_t type_size = batch.type_info().size();
+    for (int sample_idx = 0; sample_idx < shape.num_samples(); sample_idx++) {
+      auto base_ptr = static_cast<uint8_t *>(batch[sample_idx].raw_mutable_data());
+      size_t stride = type_size * volume(slice_shapes[sample_idx]);
+      for (int i = 0; i < volume(groups[sample_idx]); i++) {
+        auto ptr = static_cast<uint8_t *>(unfolded_batch[slice_idx++].raw_mutable_data());
+        EXPECT_EQ(ptr, base_ptr + stride * i);
+      }
+    }
+  }
+};
+
+using Backends = ::testing::Types<CPUBackend, GPUBackend>;
+
+TYPED_TEST_SUITE(SequenceShapeUnfoldTVTest, Backends);
+
+TYPED_TEST(SequenceShapeUnfoldTVTest, Unfold0Extents) {
+  auto batch = this->CreateTestBatch(DALI_UINT32);
+  this->TestUnfolding(batch, 0);
+}
+
+TYPED_TEST(SequenceShapeUnfoldTVTest, Unfold1Extent) {
+  auto batch = this->CreateTestBatch(DALI_UINT16);
+  this->TestUnfolding(batch, 1);
+}
+
+TYPED_TEST(SequenceShapeUnfoldTVTest, Unfold2Extents) {
+  auto batch = this->CreateTestBatch(DALI_UINT8);
+  this->TestUnfolding(batch, 2);
+}
+
+TYPED_TEST(SequenceShapeUnfoldTVTest, Unfold2ExtentsPinned) {
+  auto batch = this->CreateTestBatch(DALI_UINT8, true, true);
+  this->TestUnfolding(batch, 2);
+}
+
+TYPED_TEST(SequenceShapeUnfoldTVTest, Unfold2ExtentsEmptyLayout) {
+  auto batch = this->CreateTestBatch(DALI_UINT8, false, false, "");
+  this->TestUnfolding(batch, 2);
+}
+
+TYPED_TEST(SequenceShapeUnfoldTVTest, Unfold3Extents) {
+  auto batch = this->CreateTestBatch(DALI_FLOAT);
+  this->TestUnfolding(batch, 3);
+}
+
+template <typename Backend>
+class SequenceShapeUnfoldTLTest : public ::testing::Test {
+ protected:
+  TensorList<Backend> CreateTestBatch(DALIDataType dtype, bool is_pinned = false,
+                                      TensorLayout layout = "ABC",
+                                      TensorListShape<> shape = {
+                                          {3, 5, 7}, {11, 5, 4}, {7, 2, 11}}) {
+    TensorList<Backend> batch;
+    constexpr bool is_device = std::is_same_v<Backend, GPUBackend>;
+    batch.set_order(is_device ? AccessOrder(cuda_stream) : AccessOrder::host());
+    batch.set_pinned(is_pinned);
+    batch.Resize(shape, dtype);
+    if (!layout.empty()) {
+      batch.SetLayout(layout);
+    }
+    return std::move(batch);
+  }
+
+  void TestUnfolding(TensorList<Backend> &batch, int ndims_to_unfold, bool check_layout = true) {
+    const auto &shape = batch.shape();
+    auto groups = shape.first(ndims_to_unfold);
+    auto slice_shapes = shape.last(shape.sample_dim() - ndims_to_unfold);
+    auto num_slices = groups.num_elements();
+    auto unfolded_batch = unfold_outer_dims(batch, ndims_to_unfold);
+    check_batch_props(batch, unfolded_batch, num_slices, ndims_to_unfold);
+    int slice_idx = 0;
+    size_t type_size = batch.type_info().size();
+    for (int sample_idx = 0; sample_idx < shape.num_samples(); sample_idx++) {
+      auto base_ptr = static_cast<uint8_t *>(batch.raw_mutable_tensor(sample_idx));
+      size_t stride = type_size * volume(slice_shapes[sample_idx]);
+      for (int i = 0; i < volume(groups[sample_idx]); i++) {
+        auto ptr = static_cast<uint8_t *>(unfolded_batch.raw_mutable_tensor(slice_idx++));
+        EXPECT_EQ(ptr, base_ptr + stride * i);
+      }
+    }
+  }
+};
+
+TYPED_TEST_SUITE(SequenceShapeUnfoldTLTest, Backends);
+
+TYPED_TEST(SequenceShapeUnfoldTLTest, Unfold0Extents) {
+  auto batch = this->CreateTestBatch(DALI_FLOAT);
+  this->TestUnfolding(batch, 0);
+}
+
+TYPED_TEST(SequenceShapeUnfoldTLTest, Unfold1Extent) {
+  auto batch = this->CreateTestBatch(DALI_UINT8);
+  this->TestUnfolding(batch, 1);
+}
+
+TYPED_TEST(SequenceShapeUnfoldTLTest, Unfold2Extents) {
+  auto batch = this->CreateTestBatch(DALI_UINT32);
+  this->TestUnfolding(batch, 2);
+}
+
+TYPED_TEST(SequenceShapeUnfoldTLTest, Unfold2ExtentsPinned) {
+  auto batch = this->CreateTestBatch(DALI_UINT32, true);
+  this->TestUnfolding(batch, 2);
+}
+
+TYPED_TEST(SequenceShapeUnfoldTLTest, Unfold2ExtentsEmptyLayout) {
+  auto batch = this->CreateTestBatch(DALI_UINT32, false, "");
+  this->TestUnfolding(batch, 2);
+}
+
+TYPED_TEST(SequenceShapeUnfoldTLTest, Unfold3Extents) {
+  auto batch = this->CreateTestBatch(DALI_UINT8);
+  this->TestUnfolding(batch, 3);
+}
+
+}  // namespace sequence_utils_test
+}  // namespace dali

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1825,6 +1825,7 @@ PYBIND11_MODULE(backend_impl, m) {
         "arg_name"_a,
         "local_only"_a = false)
     .def("IsTensorArgument", &OpSchema::IsTensorArgument)
+    .def("ArgSupportsPerFrameInput", &OpSchema::ArgSupportsPerFrameInput)
     .def("IsSequenceOperator", &OpSchema::IsSequenceOperator)
     .def("AllowsSequences", &OpSchema::AllowsSequences)
     .def("SupportsVolumetric", &OpSchema::SupportsVolumetric)

--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -130,6 +130,8 @@ def _get_kwargs(schema):
                     default_value = ast.literal_eval(default_value_string)
                     type_name += ", default = `{}`".format(_default_converter(dtype, default_value))
             doc += schema.GetArgumentDox(arg)
+            if schema.ArgSupportsPerFrameInput(arg):
+                doc += "\n\nSupports per-frame inputs."
             if deprecation_warning:
                 doc += "\n\n" + deprecation_warning
         elif deprecation_warning:

--- a/dali/test/python/sequences_test_utils.py
+++ b/dali/test/python/sequences_test_utils.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import random
+import numpy as np
+
+from nvidia.dali import pipeline_def
+import nvidia.dali.fn as fn
+from nvidia.dali import types
+import nvidia.dali.tensors as _Tensors
+
+from test_utils import get_dali_extra_path, check_batch
+
+
+data_root = get_dali_extra_path()
+images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
+vid_file = os.path.join(data_root, 'db', 'video',
+                        'sintel', 'sintel_trailer-720p.mp4')
+
+
+def as_batch(tensor):
+    if isinstance(tensor, _Tensors.TensorListGPU):
+        tensor = tensor.as_cpu()
+    return [np.array(sample, dtype=types.to_numpy_type(sample.dtype)) for sample in tensor]
+
+
+def dummy_source(batches):
+    def inner():
+        while True:
+            for batch in batches:
+                yield batch
+    return inner
+
+
+def unfold_batch(batch, num_expand):
+    assert(num_expand >= 0)
+    if num_expand == 0:
+        return batch
+    if num_expand > 1:
+        batch = [sample.reshape((-1,) + sample.shape[num_expand:])
+                 for sample in batch]
+    return [frame for sample in batch for frame in sample]
+
+
+def unfold_batches(batches, num_expand):
+    return [unfold_batch(batch, num_expand) for batch in batches]
+
+
+def get_layout_prefix_len(layout, prefix):
+    for i, c in enumerate(layout):
+        if c not in prefix:
+            return i
+    return len(layout)
+
+
+def expand_arg(input_layout, num_expand, arg_has_frames, input_batch, arg_batch):
+    assert(1 <= num_expand <= 2)
+    assert(len(input_batch) == len(arg_batch))
+    expanded_batch = []
+    for input_sample, arg_sample in zip(input_batch, arg_batch):
+        if not arg_has_frames or len(arg_sample) == 1:
+            arg_sample = arg_sample if not arg_has_frames else arg_sample[0]
+            num_frames = np.prod(input_sample.shape[:num_expand])
+            expanded_batch.extend(arg_sample for _ in range(num_frames))
+        else:
+            frame_idx = input_layout[:num_expand].find("F")
+            assert(frame_idx >= 0)
+            assert(len(arg_sample) == input_sample.shape[frame_idx])
+            if num_expand == 1:
+                expanded_batch.extend(
+                    arg_frame for arg_frame in arg_sample)
+            else:
+                channel_idx = 1 - frame_idx
+                assert(input_layout[channel_idx] == "C")
+                if channel_idx > frame_idx:
+                    expanded_batch.extend(frame_arg for frame_arg in arg_sample for _ in range(
+                        input_sample.shape[channel_idx]))
+                else:
+                    expanded_batch.extend(frame_arg for _ in range(
+                        input_sample.shape[channel_idx]) for frame_arg in arg_sample)
+    return expanded_batch
+
+
+def expand_arg_input(input_data, input_layout, expand_channels, arg_data, arg_layout):
+    num_expand = get_layout_prefix_len(
+        input_layout, "FC" if expand_channels else "F")
+    arg_has_frames = arg_layout and arg_layout[0] == "F"
+    ret_arg_layout = arg_layout if not arg_has_frames else arg_layout[1:]
+    assert(len(input_data) == len(arg_data))
+    expanded = [expand_arg(input_layout, num_expand, arg_has_frames, input_batch, arg_batch)
+                for input_batch, arg_batch in zip(input_data, arg_data)]
+    return expanded, ret_arg_layout
+
+
+@pipeline_def
+def vid_pipeline(num_frames, width, height, seq_layout):
+    vid, _ = fn.readers.video_resize(
+        filenames=[vid_file],
+        labels=[],
+        name='video reader',
+        sequence_length=num_frames,
+        file_list_include_preceding_frame=True,
+        device='gpu',
+        seed=42,
+        resize_x=width,
+        resize_y=height)
+    if seq_layout == "FCHW":
+        vid = fn.transpose(vid, perm=[0, 3, 1, 2])
+    elif seq_layout == "CFHW":
+        vid = fn.transpose(vid, perm=[3, 0, 1, 2])
+    else:
+        assert(seq_layout == "FHWC")
+    return vid
+
+
+def vid_source(batch_size, num_batches, num_frames, width, height, seq_layout):
+    pipe = vid_pipeline(
+        num_threads=4, batch_size=batch_size, num_frames=num_frames,
+        width=width, height=height, device_id=0, seq_layout=seq_layout,
+        prefetch_queue_depth=1)
+    pipe.build()
+    batches = []
+    for _ in range(num_batches):
+        (pipe_out,) = pipe.run()
+        batches.append(as_batch(pipe_out))
+    return batches
+
+
+def _test_video(device, expand_channels, operator_fn, fixed_params, input_params,
+                input_layout, input_data, rng):
+    num_iters = 3
+    # compute the arguments data here so that the parameters passed to _test_video are
+    # a bit more readable when printed by nose
+    input_params = get_input_params_data(
+        input_data, input_layout, input_params, rng)
+
+    @pipeline_def
+    def pipeline(input_data, input_layout, input_params):
+        input = fn.external_source(
+            source=dummy_source(input_data), layout=input_layout)
+        if device == "gpu":
+            input = input.gpu()
+        arg_nodes = {
+            arg_name: fn.external_source(
+                source=dummy_source(arg_data), layout=arg_layout)
+            for arg_name, (arg_data, arg_layout) in input_params}
+        output = operator_fn(input, **fixed_params, **arg_nodes)
+        return output
+
+    max_batch_size = max(len(batch) for batch in input_data)
+
+    seq_pipe = pipeline(input_data=input_data, input_layout=input_layout, input_params=input_params,
+                        batch_size=max_batch_size, num_threads=4,
+                        device_id=0)
+
+    num_expand = get_layout_prefix_len(
+        input_layout, "FC" if expand_channels else "F")
+    unfolded_input = unfold_batches(input_data, num_expand)
+    unfolded_input_layout = input_layout[num_expand:]
+    expanded_params = [
+        (arg_name, expand_arg_input(input_data, input_layout,
+         expand_channels, arg_data, arg_layout))
+        for arg_name, (arg_data, arg_layout) in input_params]
+    max_uf_batch_size = max(len(batch) for batch in unfolded_input)
+    baseline_pipe = pipeline(input_data=unfolded_input,
+                             input_layout=unfolded_input_layout,
+                             input_params=expanded_params,
+                             batch_size=max_uf_batch_size, num_threads=4,
+                             device_id=0)
+    seq_pipe.build()
+    baseline_pipe.build()
+
+    for _ in range(num_iters):
+        (seq_batch,) = seq_pipe.run()
+        (baseline_batch,) = baseline_pipe.run()
+        assert(seq_batch.layout()[num_expand:] == baseline_batch.layout())
+        batch = unfold_batch(as_batch(seq_batch), num_expand)
+        baseline_batch = as_batch(baseline_batch)
+        assert(len(batch) == len(baseline_batch))
+        check_batch(batch, baseline_batch, len(batch))
+
+
+max_batch_size = 8
+max_num_frames = 16
+
+
+def get_video_input_cases(seq_layout, rng):
+    cases = []
+    lager = vid_source(max_batch_size, 1, max_num_frames, 512, 288, seq_layout)
+    smaller = vid_source(max_batch_size, 2, max_num_frames,
+                         384, 216, seq_layout)
+    cases.append(smaller)
+    samples = [sample for batch in [smaller[0], lager[0], smaller[1]]
+               for sample in batch]
+    rng.shuffle(samples)
+    case2 = [samples[0:1], samples[1:1 + max_batch_size],
+             samples[1 + max_batch_size:2 * max_batch_size],
+             samples[2 * max_batch_size:3*max_batch_size]]
+    cases.append(case2)
+    frames_idx = seq_layout.find("F")
+    if frames_idx == 0:
+        case3 = [[sample[:rng.randint(1, sample.shape[0])]
+                  for sample in batch] for batch in case2]
+        cases.append(case3)
+    return cases
+
+
+def get_input_params_data(input_data, input_layout, input_params, rng):
+
+    def get_input_arg_per_sample(param_cb):
+        param = [[param_cb(rng) for _ in batch] for batch in input_data]
+        return param, None
+
+    def get_input_arg_per_frame(param_cb):
+        def arg_for_sample(num_frames):
+            if rng.randint(1, 4) == 1:
+                return np.array([param_cb(rng)])
+            return np.array([param_cb(rng) for _ in range(num_frames)])
+        frame_idx = input_layout.find("F")
+        param = [[arg_for_sample(sample.shape[frame_idx])
+                 for sample in batch] for batch in input_data]
+        sample_dim = len(param[0][0].shape)
+        return param, "F" + "*" * (sample_dim - 1)
+
+    return [(param_name, get_input_arg_per_frame(param_cb)) if is_per_frame else
+            (param_name, get_input_arg_per_sample(param_cb))
+            for param_name, param_cb, is_per_frame in input_params]
+
+
+def video_suite_helper(ops_test_cases, expand_channels=False):
+    rng = random.Random(42)
+    layouts = ["FHWC", "FCHW"]
+    if expand_channels:
+        layouts.append("CFHW")
+    input_cases = [
+        (input_layout, input_data)
+        for input_layout in layouts
+        for input_data in get_video_input_cases(input_layout, rng)]
+    for operator_fn, fixed_params, input_params in ops_test_cases:
+        for device in ["cpu", "gpu"]:
+            for (input_layout, input_data) in input_cases:
+                yield _test_video, device, expand_channels, operator_fn, fixed_params, input_params,\
+                    input_layout, input_data, rng

--- a/dali/test/python/sequences_test_utils.py
+++ b/dali/test/python/sequences_test_utils.py
@@ -25,7 +25,6 @@ from test_utils import get_dali_extra_path, check_batch
 
 
 data_root = get_dali_extra_path()
-images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
 vid_file = os.path.join(data_root, 'db', 'video',
                         'sintel', 'sintel_trailer-720p.mp4')
 

--- a/dali/test/python/test_operator_gaussian_blur.py
+++ b/dali/test/python/test_operator_gaussian_blur.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import os
 from nose_utils import assert_raises
 from nose.plugins.attrib import attr
 
+from sequences_test_utils import video_suite_helper
 from test_utils import get_dali_extra_path, check_batch, compare_pipelines, RandomlyShapedDataIterator, dali_type
 
 data_root = get_dali_extra_path()
@@ -336,3 +337,31 @@ def test_fail_gaussian_blur():
           "Kernel window should have odd length, got: \d*\."
     yield check_fail_gaussian_blur, 10, 0.0, 2, (100, 20, 3), "HWC", 3, "gpu", \
           "Even or non-centered windows are not supported yet, got window with even length: [\s\S]* for sample \d*\."
+
+
+def test_per_frame():
+    def window_size(rng):
+        return np.array(2 * rng.randint(1, 15) + 1, dtype=np.int32)
+
+    def per_axis_window_size(rng):
+        return np.array([window_size(rng) for _ in range(2)])
+
+    def sigma(rng):
+        return np.array((rng.random() + 1) * 3., dtype=np.float32)
+
+    def per_axis_sigma(rng):
+        return np.array([sigma(rng) for _ in range(2)])
+
+    video_test_cases = [
+        (fn.gaussian_blur, {}, [("window_size", window_size, True)]),
+        (fn.gaussian_blur, {}, [("window_size", per_axis_window_size, True)]),
+        (fn.gaussian_blur, {}, [("sigma", sigma, True)]),
+        (fn.gaussian_blur, {}, [
+            ("window_size", per_axis_window_size, True),
+            ("sigma", per_axis_sigma, True)]),
+        (fn.gaussian_blur, {}, [
+            ("window_size", per_axis_window_size, False),
+            ("sigma", per_axis_sigma, True)]),
+    ]
+
+    yield from video_suite_helper(video_test_cases, expand_channels=True)

--- a/dali/test/python/test_operator_gaussian_blur.py
+++ b/dali/test/python/test_operator_gaussian_blur.py
@@ -359,7 +359,7 @@ def test_per_frame():
         (fn.gaussian_blur, {}, [
             ("window_size", per_axis_window_size, True),
             ("sigma", per_axis_sigma, True)]),
-        (fn.gaussian_blur, {}, [
+        (fn.gaussian_blur, {'dtype': types.FLOAT}, [
             ("window_size", per_axis_window_size, False),
             ("sigma", per_axis_sigma, True)]),
     ]

--- a/dali/test/python/test_operator_laplacian.py
+++ b/dali/test/python/test_operator_laplacian.py
@@ -23,6 +23,7 @@ import os
 from nose_utils import assert_raises
 from nose.plugins.attrib import attr
 
+from sequences_test_utils import video_suite_helper
 from test_utils import get_dali_extra_path, check_batch, RandomlyShapedDataIterator
 
 
@@ -629,3 +630,35 @@ def test_fail_laplacian():
             yield check_tensor_input_fail, device, 10, (10, 10, 3), "HWC", 5, 5, scale, False, types.FLOAT, \
                 "Argument scale for sample 0 is expected to have 1 or 2 elements, got: {}".format(
                     len(scale))
+
+
+def test_per_frame():
+    def window_size(rng):
+        return np.array(2 * rng.randint(1, 15) + 1, dtype=np.int32)
+
+    def per_axis_window_size(rng):
+        return np.array([window_size(rng) for _ in range(2)])
+
+    def per_axis_smoothing_size(rng):
+        return np.array([2 * rng.randint(0, 15) + 1 for _ in range(2)], dtype=np.int32)
+
+    def per_axis_scale(rng):
+        def scale(rng):
+            k = 2 * rng.randint(0, 15) + 1
+            return np.array(2. ** -k, dtype=np.float32)
+        return np.array([scale(rng) for _ in range(2)])
+
+    video_test_cases = [
+        (fn.laplacian, {}, [("window_size", window_size, True)]),
+        (fn.laplacian, {}, [("window_size", per_axis_window_size, True)]),
+        (fn.laplacian, {}, [("scale", per_axis_scale, True)]),
+        (fn.laplacian, {}, [
+            ("window_size", per_axis_window_size, True),
+            ("smoothing_size", per_axis_smoothing_size, True)]),
+        (fn.laplacian, {}, [
+            ("window_size", per_axis_window_size, True),
+            ("smoothing_size", per_axis_smoothing_size, True),
+            ("scale", per_axis_scale, True)]),
+    ]
+
+    yield from video_suite_helper(video_test_cases, expand_channels=True)

--- a/dali/test/python/test_operator_laplacian.py
+++ b/dali/test/python/test_operator_laplacian.py
@@ -651,7 +651,8 @@ def test_per_frame():
     video_test_cases = [
         (fn.laplacian, {}, [("window_size", window_size, True)]),
         (fn.laplacian, {}, [("window_size", per_axis_window_size, True)]),
-        (fn.laplacian, {}, [("scale", per_axis_scale, True)]),
+        (fn.laplacian, {'dtype': types.FLOAT},
+         [("scale", per_axis_scale, True)]),
         (fn.laplacian, {}, [
             ("window_size", per_axis_window_size, True),
             ("smoothing_size", per_axis_smoothing_size, True)]),


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
**New feature** (*non-breaking change which adds functionality*)
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:

Adds SequenceOperator base class that handles:
  * expanding batch of sequences into batch of frames (layout starting with "F" and optionally, ("C", "FC", "CF")).
  * braodcasting tensor arguments accordingly
  * per-frame tensor arguments (per-frame tensor argument must have layout specified that starts with "F")
  
Applies SequenceOperator to GaussianBlur and Laplacian operators.
Adds Python video per-frame test suite that allows for easy creation of tests for SequenceOperator instances.

Adds a way to mark an argument as supporting per-frame input to operator schema.


<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
* Added SequenceOperator<Backend> that may be used instead of Operator<Backend> in op implementaion.
* Made GaussianBlur and Laplacian use it.
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: GAUBLR.16, GAUBLR.17, LAPL.18, LAPL.19, LAPL.20.
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2565
<!--- DALI-XXXX or NA --->
