### PR TITLE
Optimization of tiled transposition algorithm on small data types

### DIFF
--- a/dali/kernels/transpose/transpose_gpu_impl.cuh
+++ b/dali/kernels/transpose/transpose_gpu_impl.cuh
@@ -16,11 +16,11 @@
 #define DALI_KERNELS_TRANSPOSE_TRANSPOSE_GPU_IMPL_CUH_
 
 #include <cuda_runtime.h>
-#include "dali/core/tensor_view.h"
 #include "dali/core/fast_div.h"
-#include "dali/kernels/transpose/transpose_gpu_def.h"
 #include "dali/core/static_switch.h"
+#include "dali/core/tensor_view.h"
 #include "dali/kernels/common/type_erasure.h"
+#include "dali/kernels/transpose/transpose_gpu_def.h"
 /**
  * @file
  *
@@ -97,25 +97,24 @@ struct TiledTransposeDesc {
 };
 
 namespace transpose_shared {
-  extern __shared__ uint8_t shared_tmp[];
+extern __shared__ uint8_t shared_tmp[];
 }  // namespace transpose_shared
 
 template <int ndim, typename T, typename OldT>
-__device__ inline void TransposeTiledPacked(TiledTransposeDesc<OldT> desc, const unsigned pack_ratio)
-{
+__device__ inline void TransposeTiledPacked(TiledTransposeDesc<OldT> desc,
+                                            const unsigned pack_ratio) {
   unsigned start_tile = blockIdx.x * desc.tiles_per_block;
   unsigned end_tile = min(desc.total_tiles, start_tile + desc.tiles_per_block);
   if (start_tile >= end_tile)
     return;
-  T (*tmp)[kTileSize][kTileSize+1] =
-      reinterpret_cast<T (*)[kTileSize][kTileSize+1]>(transpose_shared::shared_tmp);
+  T(*tmp)
+  [kTileSize][kTileSize + 1] =
+      reinterpret_cast<T(*)[kTileSize][kTileSize + 1]>(transpose_shared::shared_tmp);
 
   int lanes = desc.lanes >> pack_ratio;
 
   unsigned tile_in_slice = start_tile;
-  uint64_t fused_slice = ndim > 2
-    ? div_mod(tile_in_slice, start_tile, desc.tiles_per_slice)
-    : 0;
+  uint64_t fused_slice = ndim > 2 ? div_mod(tile_in_slice, start_tile, desc.tiles_per_slice) : 0;
 
   uint64_t pos[ndim];  // NOLINT
 
@@ -128,36 +127,36 @@ __device__ inline void TransposeTiledPacked(TiledTransposeDesc<OldT> desc, const
   pos[ndim - 1] = tile_x * kTileSize;
   pos[ndim - 2] = tile_y * kTileSize;
 
-  T *out = reinterpret_cast<T*> (desc.out);
-  const T *in = reinterpret_cast<const T*>(desc.in);
+  T *out = reinterpret_cast<T *>(desc.out);
+  const T *in = reinterpret_cast<const T *>(desc.in);
 
   for (uint64_t tile = start_tile;;) {
     uint64_t in_ofs = 0, out_ofs = 0;
-    #pragma unroll
+#pragma unroll
     for (int d = 0; d < ndim - 2; d++) {
-      in_ofs  += desc.in_strides[d]/pack_ratio * pos[d];
-      out_ofs += desc.out_strides[d]/pack_ratio * pos[d];
+      in_ofs += desc.in_strides[d] / pack_ratio * pos[d];
+      out_ofs += desc.out_strides[d] / pack_ratio * pos[d];
     }
-    int64_t in_x  = pos[ndim-1] + threadIdx.x;
-    int64_t in_y  = pos[ndim-2] + threadIdx.y;
-    int64_t out_x = pos[ndim-1] + threadIdx.y;
-    int64_t out_y = pos[ndim-2] + threadIdx.x;
+    int64_t in_x = pos[ndim - 1] + threadIdx.x;
+    int64_t in_y = pos[ndim - 2] + threadIdx.y;
+    int64_t out_x = pos[ndim - 1] + threadIdx.y;
+    int64_t out_y = pos[ndim - 2] + threadIdx.x;
 
-    in_ofs  += desc.in_strides[ndim-2]  * in_y  + desc.in_strides[ndim-1]  * in_x;
-    out_ofs += desc.out_strides[ndim-2] * out_y + desc.out_strides[ndim-1] * out_x;
+    in_ofs += desc.in_strides[ndim - 2] * in_y + desc.in_strides[ndim - 1] * in_x;
+    out_ofs += desc.out_strides[ndim - 2] * out_y + desc.out_strides[ndim - 1] * out_x;
 
     in_ofs >>= pack_ratio;
     out_ofs >>= pack_ratio;
 
-    unsigned tile_w = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim-1] - pos[ndim-1]);
-    unsigned tile_h = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim-2] - pos[ndim-2]);
+    unsigned tile_w = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim - 1] - pos[ndim - 1]);
+    unsigned tile_h = min(static_cast<uint64_t>(kTileSize), desc.shape[ndim - 2] - pos[ndim - 2]);
     unsigned jump = blockDim.y >> pack_ratio;
-    
+
     if (threadIdx.x < tile_w) {
       for (unsigned ty = threadIdx.y, dy = 0; ty < tile_h; ty += blockDim.y, dy += jump) {
-        #pragma unroll 4
+#pragma unroll 4
         for (int lane = 0; lane < lanes; lane++) {
-          tmp[lane][ty][threadIdx.x] = __ldg(&in[in_ofs + desc.in_strides[ndim-2]*dy + lane]);
+          tmp[lane][ty][threadIdx.x] = __ldg(&in[in_ofs + desc.in_strides[ndim - 2] * dy + lane]);
         }
       }
     }
@@ -165,18 +164,18 @@ __device__ inline void TransposeTiledPacked(TiledTransposeDesc<OldT> desc, const
 
     if (threadIdx.x < tile_h) {
       for (unsigned ty = threadIdx.y, dy = 0; ty < tile_w; ty += blockDim.y, dy += jump) {
-        #pragma unroll 4
+#pragma unroll 4
         for (int lane = 0; lane < lanes; lane++)
-          out[out_ofs + desc.out_strides[ndim-1]*dy + lane] = tmp[lane][threadIdx.x][ty];
+          out[out_ofs + desc.out_strides[ndim - 1] * dy + lane] = tmp[lane][threadIdx.x][ty];
       }
     }
 
     if (++tile >= end_tile)
       break;  // avoid advancing the offset and __syncthreads in last tile
 
-    #pragma unroll
+#pragma unroll
     for (int d = ndim - 1; d >= 0; d--) {
-      uint64_t delta = d < ndim-2 ? 1 : kTileSize;  // inner two dimensions are tiled
+      uint64_t delta = d < ndim - 2 ? 1 : kTileSize;  // inner two dimensions are tiled
       pos[d] += delta;
       if (pos[d] < desc.shape[d])
         break;
@@ -188,13 +187,13 @@ __device__ inline void TransposeTiledPacked(TiledTransposeDesc<OldT> desc, const
 
 template <int ndim, typename T>
 __device__ void TransposeTiledStatic(TiledTransposeDesc<T> desc) {
-  if(sizeof(T) == 1 && desc.lanes % 4 == 0 && reinterpret_cast<uintptr_t>(desc.out) % 4 == 0 && 
-      reinterpret_cast<uintptr_t>(desc.in) % 4 == 0 ) {
+  if (sizeof(T) == 1 && desc.lanes % 4 == 0 && reinterpret_cast<uintptr_t>(desc.out) % 4 == 0 &&
+      reinterpret_cast<uintptr_t>(desc.in) % 4 == 0) {
     return TransposeTiledPacked<ndim, type_of_size<4>>(desc, 2);
   }
-  if(sizeof(T) < 4 && desc.lanes % 2 == 0 && reinterpret_cast<uintptr_t>(desc.out) % 2 == 0 && 
+  if (sizeof(T) < 4 && desc.lanes % 2 == 0 && reinterpret_cast<uintptr_t>(desc.out) % 2 == 0 &&
       reinterpret_cast<uintptr_t>(desc.in) % 2 == 0) {
-    if (sizeof(T) == 2) { 
+    if (sizeof(T) == 2) {
       return TransposeTiledPacked<ndim, type_of_size<4>>(desc, 1);
     } else {
       return TransposeTiledPacked<ndim, type_of_size<2>>(desc, 1);
@@ -236,9 +235,9 @@ __device__ void TransposeDeinterleave(const DeinterleaveDesc<T> &desc) {
   const int tid = threadIdx.x;
 
   int ndim = desc.ndim;
-  int lanes = desc.in_strides[ndim-2];
+  int lanes = desc.in_strides[ndim - 2];
 
-  uint64_t lane_stride = desc.out_strides[ndim-1];
+  uint64_t lane_stride = desc.out_strides[ndim - 1];
 
   const uint64_t block_size = blockDim.x;
   uint64_t start_ofs = (blockIdx.x * block_size + tid) * lanes;
@@ -294,7 +293,7 @@ __device__ void TransposeGeneric(const GenericTransposeDesc<T> &desc) {
       uint64_t a = div_mod(tmp_idx, tmp_idx, desc.out_strides[d]);
       in_ofs += a * desc.in_strides[d];
     }
-    in_ofs += tmp_idx * desc.in_strides[ndim-1];
+    in_ofs += tmp_idx * desc.in_strides[ndim - 1];
 
     out[out_ofs] = in[in_ofs];
   }

--- a/dali/kernels/transpose/transpose_gpu_impl_test.cu
+++ b/dali/kernels/transpose/transpose_gpu_impl_test.cu
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/kernels/transpose/transpose_gpu_impl.cuh"   // NOLINT
-#include "dali/kernels/transpose/transpose_gpu_setup.cuh"  // NOLINT
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <numeric>
 #include <vector>
-#include "dali/core/dev_buffer.h"
-#include "dali/kernels/common/utils.h"
-#include "dali/core/tensor_shape_print.h"
-#include "dali/test/test_tensors.h"
 #include "dali/core/cuda_event.h"
+#include "dali/core/dev_buffer.h"
+#include "dali/core/tensor_shape_print.h"
+#include "dali/kernels/common/utils.h"
+#include "dali/kernels/transpose/transpose_gpu_impl.cuh"   // NOLINT
+#include "dali/kernels/transpose/transpose_gpu_setup.cuh"  // NOLINT
 #include "dali/kernels/transpose/transpose_test.h"
+#include "dali/test/test_tensors.h"
 
 namespace dali {
 namespace kernels {
@@ -32,94 +32,87 @@ using namespace transpose_impl;  // NOLINT
 
 
 TEST(SimplifyPermute, NoSimplification) {
-  int64_t shape[] = { 2, 3, 4, 5 };
-  int perm[] = { 0, 3, 2, 1 };
+  int64_t shape[] = {2, 3, 4, 5};
+  int perm[] = {0, 3, 2, 1};
   TensorShape<> s_shape, ref_shape;
   SmallVector<int, 6> s_perm, ref_perm;
   SimplifyPermute(s_shape, s_perm, shape, perm, 4);
-  ref_shape = { 2, 3, 4, 5 };
-  ref_perm = { 0, 3, 2, 1 };
+  ref_shape = {2, 3, 4, 5};
+  ref_perm = {0, 3, 2, 1};
   EXPECT_EQ(s_shape, ref_shape);
   EXPECT_EQ(s_perm, ref_perm);
 }
 
 TEST(SimplifyPermute, CollapseUnitDims) {
-  int64_t shape[] = { 2, 1, 3, 4, 1, 5 };
-  int perm[] = { 0, 5, 1, 3, 2, 4 };
+  int64_t shape[] = {2, 1, 3, 4, 1, 5};
+  int perm[] = {0, 5, 1, 3, 2, 4};
   TensorShape<> s_shape, ref_shape;
   SmallVector<int, 6> s_perm, ref_perm;
   SimplifyPermute(s_shape, s_perm, shape, perm, 6);
-  ref_shape = { 2, 3, 4, 5 };
-  ref_perm = { 0, 3, 2, 1 };
+  ref_shape = {2, 3, 4, 5};
+  ref_perm = {0, 3, 2, 1};
   EXPECT_EQ(s_shape, ref_shape);
   EXPECT_EQ(s_perm, ref_perm);
 }
 
 TEST(SimplifyPermute, Collapse) {
-  int64_t shape[] = { 2, 1, 3, 4, 1, 5 };
-  int perm[] = { 3, 4, 5, 0, 1, 2 };
+  int64_t shape[] = {2, 1, 3, 4, 1, 5};
+  int perm[] = {3, 4, 5, 0, 1, 2};
   TensorShape<> s_shape, ref_shape;
   SmallVector<int, 6> s_perm, ref_perm;
   SimplifyPermute(s_shape, s_perm, shape, perm, 6);
-  ref_shape = { 6, 20 };
-  ref_perm = { 1, 0 };
+  ref_shape = {6, 20};
+  ref_perm = {1, 0};
   EXPECT_EQ(s_shape, ref_shape);
   EXPECT_EQ(s_perm, ref_perm);
 }
 
 TEST(TransposeGPU, GetTransposeMethod) {
   {
-    TensorShape<> shape = { 640*480, 3 };
-    int perm[] = { 1, 0 };
+    TensorShape<> shape = {640 * 480, 3};
+    int perm[] = {1, 0};
     EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 2, sizeof(int)),
               TransposeMethod::Deinterleave);
   }
   {
-    TensorShape<> shape = { 3, 640*480 };
-    int perm[] = { 1, 0 };  // interleave
-    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 2, sizeof(int)),
-              TransposeMethod::Interleave);
+    TensorShape<> shape = {3, 640 * 480};
+    int perm[] = {1, 0};  // interleave
+    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 2, sizeof(int)), TransposeMethod::Interleave);
   }
   {
-    TensorShape<> shape = { 640, 480 };
-    int perm[] = { 1, 0 };  // scalar tiled
-    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 2, sizeof(int)),
-              TransposeMethod::Tiled);
+    TensorShape<> shape = {640, 480};
+    int perm[] = {1, 0};  // scalar tiled
+    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 2, sizeof(int)), TransposeMethod::Tiled);
   }
   {
-    TensorShape<> shape = { 20, 640, 480 };
-    int perm[] = { 1, 2, 0 };  // scalar tiled
-    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 3, sizeof(int)),
-              TransposeMethod::Tiled);
+    TensorShape<> shape = {20, 640, 480};
+    int perm[] = {1, 2, 0};  // scalar tiled
+    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 3, sizeof(int)), TransposeMethod::Tiled);
   }
   {
-    TensorShape<> shape = { 640, 480, 3 };
-    int perm[] = { 1, 0, 2 };  // vectorized tiled
-    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 3, sizeof(int)),
-              TransposeMethod::Tiled);
+    TensorShape<> shape = {640, 480, 3};
+    int perm[] = {1, 0, 2};  // vectorized tiled
+    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 3, sizeof(int)), TransposeMethod::Tiled);
   }
   {
-    TensorShape<> shape = { 640, 3, 480 };
-    int perm[] = { 1, 2, 0 };  // some mess
-    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 3, sizeof(int)),
-              TransposeMethod::Generic);
+    TensorShape<> shape = {640, 3, 480};
+    int perm[] = {1, 2, 0};  // some mess
+    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 3, sizeof(int)), TransposeMethod::Generic);
   }
   {
-    TensorShape<> shape = { 640, 480, 50 };
-    int perm[] = { 1, 0, 2 };  // generic stuff
-    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 3, sizeof(int)),
-              TransposeMethod::Generic);
+    TensorShape<> shape = {640, 480, 50};
+    int perm[] = {1, 0, 2};  // generic stuff
+    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 3, sizeof(int)), TransposeMethod::Generic);
   }
   {
-    TensorShape<> shape = { 640*480 };
-    int perm[] = { 0 };  // identity
-    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 1, sizeof(int)),
-              TransposeMethod::Copy);
+    TensorShape<> shape = {640 * 480};
+    int perm[] = {0};  // identity
+    EXPECT_EQ(GetTransposeMethod(shape.data(), perm, 1, sizeof(int)), TransposeMethod::Copy);
   }
 }
 
 TEST(TransposeTiled, AllPerm4DInnermost) {
-  TensorShape<> shape = { 19, 57, 37, 53 };  // a bunch of primes, just to make it harder
+  TensorShape<> shape = {19, 57, 37, 53};  // a bunch of primes, just to make it harder
   int size = volume(shape);
   vector<int> in_cpu(size), out_cpu(size), ref(size);
   std::iota(in_cpu.begin(), in_cpu.end(), 0);
@@ -137,9 +130,9 @@ TEST(TransposeTiled, AllPerm4DInnermost) {
     if (perm[3] == 3)
       continue;  // innermost dim must be permuted
 
-    std::cerr << "Testing permutation "
-      << perm[0] << " " << perm[1] << " " << perm[2] << " " << perm[3] << "\n";
-    CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
+    std::cerr << "Testing permutation " << perm[0] << " " << perm[1] << " " << perm[2] << " "
+              << perm[3] << "\n";
+    CUDA_CALL(cudaMemset(out_gpu, 0xff, size * sizeof(int)));
 
     TiledTransposeDesc<int> desc;
     memset(&desc, 0xCC, sizeof(desc));
@@ -153,7 +146,8 @@ TEST(TransposeTiled, AllPerm4DInnermost) {
     float time;
     CUDA_CALL(cudaEventElapsedTime(&time, start, end));
     time *= 1e+6;
-    std::cerr << 2*size*sizeof(int) / time << " GB/s" << "\n";
+    std::cerr << 2 * size * sizeof(int) / time << " GB/s"
+              << "\n";
 
     for (int i = 0; i < size; i++) {
       ASSERT_EQ(out_cpu[i], ref[i]) << " at " << i;
@@ -162,17 +156,17 @@ TEST(TransposeTiled, AllPerm4DInnermost) {
 }
 
 TEST(TransposeTiled, BuildDescVectorized) {
-  TensorShape<> shape = { 57, 37, 53, 4 };  // a bunch of primes, just to make it harder
+  TensorShape<> shape = {57, 37, 53, 4};  // a bunch of primes, just to make it harder
   int size = volume(shape);
   vector<int> in_cpu(size), out_cpu(size), ref(size);
   std::iota(in_cpu.begin(), in_cpu.end(), 0);
   DeviceBuffer<int> in_gpu, out_gpu;
   in_gpu.resize(size);
   out_gpu.resize(size);
-  CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
+  CUDA_CALL(cudaMemset(out_gpu, 0xff, size * sizeof(int)));
   copyH2D(in_gpu.data(), in_cpu.data(), size);
 
-  SmallVector<int, 6> perm = { 1, 2, 0, 3 };
+  SmallVector<int, 6> perm = {1, 2, 0, 3};
 
   int grid_size = 1024;
   TiledTransposeDesc<int> desc;
@@ -190,39 +184,39 @@ TEST(TransposeTiled, BuildDescVectorized) {
 }
 
 TEST(TransposeTiled, BuildDescAndForceMisalignment) {
-  TensorShape<> shape = { 57, 37, 53, 4 };  // a bunch of primes, just to make it harder
+  TensorShape<> shape = {57, 37, 53, 4};  // a bunch of primes, just to make it harder
   int size = volume(shape);
   vector<uint8> in_cpu(size), out_cpu(size);
   vector<uint8> ref(size);
-    
+
   DeviceBuffer<uint8> in_gpu, out_gpu;
   in_gpu.resize(size);
   out_gpu.resize(size);
-    
-  for(uintptr_t offset = 0; offset < 4; offset++)
-  {
-    shape = { 57, 37, 53, 4 };
+
+  for (uintptr_t offset = 0; offset < 4; offset++) {
+    shape = {57, 37, 53, 4};
     size = volume(shape);
     std::iota(in_cpu.begin(), in_cpu.end(), 0);
-    CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
-    shape = { 57, 37, 52, 4 };
+    CUDA_CALL(cudaMemset(out_gpu, 0xff, size * sizeof(int)));
+    shape = {57, 37, 52, 4};
     size = volume(shape);
-  
+
     copyH2D(in_gpu.data() + offset, in_cpu.data(), size);
-  
-    SmallVector<int, 6> perm = { 1, 2, 0, 3 };
-  
+
+    SmallVector<int, 6> perm = {1, 2, 0, 3};
+
     int grid_size = 1024;
     TiledTransposeDesc<uint8> desc;
     memset(&desc, 0xCC, sizeof(desc));
-    InitTiledTranspose(desc, shape, make_span(perm), out_gpu.data() + offset, in_gpu.data() + offset, grid_size);
+    InitTiledTranspose(desc, shape, make_span(perm), out_gpu.data() + offset,
+                       in_gpu.data() + offset, grid_size);
     EXPECT_EQ(desc.lanes, 4) << "Lanes not detected";
     EXPECT_EQ(desc.ndim, 3) << "Number of dimensions should have shrunk in favor of lanes";
-  
+
     TransposeTiledSingle<<<grid_size, dim3(32, 16), kTiledTransposeMaxSharedMem>>>(desc);
     copyD2H(out_cpu.data(), out_gpu.data() + offset, size);
     testing::RefTranspose(ref.data(), in_cpu.data(), shape.data(), perm.data(), perm.size());
-    
+
     for (int i = 0; i < size; i++) {
       ASSERT_EQ(out_cpu[i], ref[i]) << " at " << i;
     }
@@ -230,7 +224,7 @@ TEST(TransposeTiled, BuildDescAndForceMisalignment) {
 }
 
 TEST(TransposeTiled, BuildDescVectorized16BitOpt) {
-  TensorShape<> shape = { 57, 37, 53, 4 };  // a bunch of primes, just to make it harder
+  TensorShape<> shape = {57, 37, 53, 4};  // a bunch of primes, just to make it harder
   int size = volume(shape);
   vector<uint16_t> in_cpu(size), out_cpu(size);
   vector<uint16_t> ref(size);
@@ -238,10 +232,10 @@ TEST(TransposeTiled, BuildDescVectorized16BitOpt) {
   DeviceBuffer<uint16_t> in_gpu, out_gpu;
   in_gpu.resize(size);
   out_gpu.resize(size);
-  CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
+  CUDA_CALL(cudaMemset(out_gpu, 0xff, size * sizeof(int)));
   copyH2D(in_gpu.data(), in_cpu.data(), size);
 
-  SmallVector<int, 6> perm = { 1, 2, 0, 3 };
+  SmallVector<int, 6> perm = {1, 2, 0, 3};
 
   int grid_size = 1024;
   TiledTransposeDesc<uint16_t> desc;
@@ -253,7 +247,7 @@ TEST(TransposeTiled, BuildDescVectorized16BitOpt) {
   TransposeTiledSingle<<<grid_size, dim3(32, 16), kTiledTransposeMaxSharedMem>>>(desc);
   copyD2H(out_cpu.data(), out_gpu.data(), size);
   testing::RefTranspose(ref.data(), in_cpu.data(), shape.data(), perm.data(), perm.size());
-  
+
   for (int i = 0; i < size; i++) {
     ASSERT_EQ(out_cpu[i], ref[i]) << " at " << i;
   }
@@ -262,7 +256,7 @@ TEST(TransposeTiled, BuildDescVectorized16BitOpt) {
 
 TEST(TransposeDeinterleave, AllPerm4DInnermost) {
   int channels = 3;
-  TensorShape<> shape = { 19, 157, 137, channels };  // small inner dimension
+  TensorShape<> shape = {19, 157, 137, channels};  // small inner dimension
   int size = volume(shape);
   vector<int> in_cpu(size), out_cpu(size), ref(size);
   std::iota(in_cpu.begin(), in_cpu.end(), 0);
@@ -283,9 +277,9 @@ TEST(TransposeDeinterleave, AllPerm4DInnermost) {
     if (perm[3] == 3)
       continue;  // innermost dim must be permuted
 
-    std::cerr << "Testing permutation "
-      << perm[0] << " " << perm[1] << " " << perm[2] << " " << perm[3] << "\n";
-      CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
+    std::cerr << "Testing permutation " << perm[0] << " " << perm[1] << " " << perm[2] << " "
+              << perm[3] << "\n";
+    CUDA_CALL(cudaMemset(out_gpu, 0xff, size * sizeof(int)));
 
     DeinterleaveDesc<int> desc;
     memset(&desc, 0xCC, sizeof(desc));
@@ -299,7 +293,8 @@ TEST(TransposeDeinterleave, AllPerm4DInnermost) {
     float time;
     CUDA_CALL(cudaEventElapsedTime(&time, start, end));
     time *= 1e+6;
-    std::cerr << 2*size*sizeof(int) / time << " GB/s" << "\n";
+    std::cerr << 2 * size * sizeof(int) / time << " GB/s"
+              << "\n";
 
 
     for (int i = 0; i < size; i++) {
@@ -309,7 +304,7 @@ TEST(TransposeDeinterleave, AllPerm4DInnermost) {
 }
 
 TEST(TransposeGeneric, AllPerm4D) {
-  TensorShape<> shape = { 31, 43, 53, 47 };
+  TensorShape<> shape = {31, 43, 53, 47};
   int size = volume(shape);
   vector<int> in_cpu(size), out_cpu(size), ref(size);
   std::iota(in_cpu.begin(), in_cpu.end(), 0);
@@ -323,10 +318,9 @@ TEST(TransposeGeneric, AllPerm4D) {
   ASSERT_LT(grid_size * block_size, size) << "Weak test error: Grid too large to test grid loop";
 
   for (auto &perm : testing::Permutations4) {
-    std::cerr << "Testing permutation "
-      << perm[0] << " " << perm[1] << " " << perm[2] << " " << perm[3] << "  input shape "
-      << shape << "\n";
-      CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
+    std::cerr << "Testing permutation " << perm[0] << " " << perm[1] << " " << perm[2] << " "
+              << perm[3] << "  input shape " << shape << "\n";
+    CUDA_CALL(cudaMemset(out_gpu, 0xff, size * sizeof(int)));
 
     GenericTransposeDesc<int> desc;
     memset(&desc, 0xCC, sizeof(desc));
@@ -358,7 +352,7 @@ TEST(TransposeGeneric, AllPerm4D) {
     std::cerr << " input shape " << simplified_shape << "\n";
 
     memset(&desc, 0xCC, sizeof(desc));
-    CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
+    CUDA_CALL(cudaMemset(out_gpu, 0xff, size * sizeof(int)));
     InitGenericTranspose(desc, simplified_shape, make_span(simplified_perm), out_gpu, in_gpu);
     TransposeGenericSingle<<<grid_size, block_size>>>(desc);
     copyD2H(out_cpu.data(), out_gpu.data(), size);

--- a/dali/kernels/transpose/transpose_gpu_impl_test.cu
+++ b/dali/kernels/transpose/transpose_gpu_impl_test.cu
@@ -161,7 +161,6 @@ TEST(TransposeTiled, AllPerm4DInnermost) {
   }
 }
 
-
 TEST(TransposeTiled, BuildDescVectorized) {
   TensorShape<> shape = { 57, 37, 53, 4 };  // a bunch of primes, just to make it harder
   int size = volume(shape);
@@ -185,6 +184,76 @@ TEST(TransposeTiled, BuildDescVectorized) {
   copyD2H(out_cpu.data(), out_gpu.data(), size);
   testing::RefTranspose(ref.data(), in_cpu.data(), shape.data(), perm.data(), perm.size());
 
+  for (int i = 0; i < size; i++) {
+    ASSERT_EQ(out_cpu[i], ref[i]) << " at " << i;
+  }
+}
+
+TEST(TransposeTiled, BuildDescAndForceMisalignment) {
+  TensorShape<> shape = { 57, 37, 53, 4 };  // a bunch of primes, just to make it harder
+  int size = volume(shape);
+  vector<uint8> in_cpu(size), out_cpu(size);
+  vector<uint8> ref(size);
+    
+  DeviceBuffer<uint8> in_gpu, out_gpu;
+  in_gpu.resize(size);
+  out_gpu.resize(size);
+    
+  for(uintptr_t offset = 0; offset < 4; offset++)
+  {
+    shape = { 57, 37, 53, 4 };
+    size = volume(shape);
+    std::iota(in_cpu.begin(), in_cpu.end(), 0);
+    CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
+    shape = { 57, 37, 52, 4 };
+    size = volume(shape);
+  
+    copyH2D(in_gpu.data() + offset, in_cpu.data(), size);
+  
+    SmallVector<int, 6> perm = { 1, 2, 0, 3 };
+  
+    int grid_size = 1024;
+    TiledTransposeDesc<uint8> desc;
+    memset(&desc, 0xCC, sizeof(desc));
+    InitTiledTranspose(desc, shape, make_span(perm), out_gpu.data() + offset, in_gpu.data() + offset, grid_size);
+    EXPECT_EQ(desc.lanes, 4) << "Lanes not detected";
+    EXPECT_EQ(desc.ndim, 3) << "Number of dimensions should have shrunk in favor of lanes";
+  
+    TransposeTiledSingle<<<grid_size, dim3(32, 16), kTiledTransposeMaxSharedMem>>>(desc);
+    copyD2H(out_cpu.data(), out_gpu.data() + offset, size);
+    testing::RefTranspose(ref.data(), in_cpu.data(), shape.data(), perm.data(), perm.size());
+    
+    for (int i = 0; i < size; i++) {
+      ASSERT_EQ(out_cpu[i], ref[i]) << " at " << i;
+    }
+  }
+}
+
+TEST(TransposeTiled, BuildDescVectorized16BitOpt) {
+  TensorShape<> shape = { 57, 37, 53, 4 };  // a bunch of primes, just to make it harder
+  int size = volume(shape);
+  vector<uint16_t> in_cpu(size), out_cpu(size);
+  vector<uint16_t> ref(size);
+  std::iota(in_cpu.begin(), in_cpu.end(), 0);
+  DeviceBuffer<uint16_t> in_gpu, out_gpu;
+  in_gpu.resize(size);
+  out_gpu.resize(size);
+  CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
+  copyH2D(in_gpu.data(), in_cpu.data(), size);
+
+  SmallVector<int, 6> perm = { 1, 2, 0, 3 };
+
+  int grid_size = 1024;
+  TiledTransposeDesc<uint16_t> desc;
+  memset(&desc, 0xCC, sizeof(desc));
+  InitTiledTranspose(desc, shape, make_span(perm), out_gpu, in_gpu, grid_size);
+  EXPECT_EQ(desc.lanes, 4) << "Lanes not detected";
+  EXPECT_EQ(desc.ndim, 3) << "Number of dimensions should have shrunk in favor of lanes";
+
+  TransposeTiledSingle<<<grid_size, dim3(32, 16), kTiledTransposeMaxSharedMem>>>(desc);
+  copyD2H(out_cpu.data(), out_gpu.data(), size);
+  testing::RefTranspose(ref.data(), in_cpu.data(), shape.data(), perm.data(), perm.size());
+  
   for (int i = 0; i < size; i++) {
     ASSERT_EQ(out_cpu[i], ref[i]) << " at " << i;
   }

--- a/dali/kernels/transpose/transpose_gpu_impl_test.cu
+++ b/dali/kernels/transpose/transpose_gpu_impl_test.cu
@@ -190,24 +190,20 @@ TEST(TransposeTiled, BuildDescVectorized) {
 }
 
 TEST(TransposeTiled, BuildDescAndForceMisalignment) {
-  TensorShape<> shape = { 57, 37, 53, 4 };  // a bunch of primes, just to make it harder
+  TensorShape<> shape = { 57, 37, 52, 4 };  // a bunch of primes, just to make it harder
   int size = volume(shape);
-  vector<uint8> in_cpu(size), out_cpu(size);
-  vector<uint8> ref(size);
+  vector<uint8> in_cpu(size + 4), out_cpu(size + 4);
+  vector<uint8> ref(size + 4);
     
   DeviceBuffer<uint8> in_gpu, out_gpu;
-  in_gpu.resize(size);
-  out_gpu.resize(size);
+  in_gpu.resize(size + 4);
+  out_gpu.resize(size + 4);
     
   for(uintptr_t offset = 0; offset < 4; offset++)
   {
-    shape = { 57, 37, 53, 4 };
-    size = volume(shape);
     std::iota(in_cpu.begin(), in_cpu.end(), 0);
     CUDA_CALL(cudaMemset(out_gpu, 0xff, size*sizeof(int)));
-    shape = { 57, 37, 52, 4 };
-    size = volume(shape);
-  
+    
     copyH2D(in_gpu.data() + offset, in_cpu.data(), size);
   
     SmallVector<int, 6> perm = { 1, 2, 0, 3 };


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
- [ ] **Bug fix** (*non-breaking change which fixes an issue*)
- [ ] **New feature** (*non-breaking change which adds functionality*)
- [ ] **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
- [x] **Refactoring** (*Redesign of existing code that doesn't affect functionality*)
- [x] **Other** (*e.g. Documentation, Tests, Configuration*)


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
This PR tries to pack continous reads and writes of small data types (smaller than 32bit) to smaller number of reads and writes using bigger data types to fill the memory bus.
Tiled transpose algorithm often has last row not being move from it's place. In old implementation if for example there was transposition of RGBA image (for example 1920x1080x4 with 8bit values), algorithm did 4 8bit reads and writes from global memory and 4 8bit writes and reads from shared memory for every pixel.
With this optimalization if data of picture is aligned to address that is divisible by 4, for picture from example above algorithm does 1 32bit read and write from global memory and 1 32bit write and read from shared memory for every pixel.
In detail if last dim size in tensor is divisable by 4 it's type is 8bit and is properly aligned then algorithm does 4 times less reads and writes, in bit worse case if lasst dim size in tensor is divisable by 2, it's type is at most 16bit and data is properly aligned algorithm does 2 times less reads and writes. 
For benchmark I did transposition of 500x500x4 tensor with uint8 type with batch_size of 256 and 100 iterations (all on Titan V).
- Before optimalizations : 3111 us
- After optimalization : 2552 us

To show value of optimalization I changed tensor to 500x500x3 (representing RGB picture) and got time of 2742us which shows that after optimalization if memory is not a problem user can change shape of tensor to optimalize execution time
  
## Additional information: 

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
- Changed TiledTranspose code in transpose kernel
- Added two tests transpose kernel

<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
