### PR TITLE
Improve documentation for AccessOrder wait and set_order.

### DIFF
--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -285,6 +285,10 @@ class DLL_PUBLIC Buffer {
   /**
    * @brief Sets the associated access order.
    *
+   * @note The caller must ensure that if `order` represents a CUDA stream, that stream
+   *       is alive when this buffer is destroyed. This extends to buffers with which this
+   *       one shares data. Use CUDAStreamPool::instance to get streams with indefinite lifetime.
+   *
    * @param order       The new access order (stream or host). If the new order doesn't have
    *                    a value, the function has no effect.
    * @param synchronize If true, an appropriate synchronization is inserted between the old

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -707,6 +707,10 @@ class DLL_PUBLIC TensorList {
   /**
    * @brief Sets the associated access order.
    *
+   * @note The caller must ensure that if `order` represents a CUDA stream, that stream
+   *       is alive when this buffer is destroyed. This extends to buffers with which this
+   *       one shares data. Use CUDAStreamPool::instance to get streams with indefinite lifetime.
+   *
    * @param order       The new access order (stream or host). If the new order doesn't have
    *                    a value, the function has no effect.
    * @param synchronize If true, an appropriate synchronization is inserted between the old

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -63,6 +63,19 @@ class DLL_PUBLIC TensorVector {
     return tl_->order();
   }
 
+  /**
+   * @brief Sets the associated access order.
+   *
+   * @note The caller must ensure that if `order` represents a CUDA stream, that stream
+   *       is alive when this buffer is destroyed. This extends to buffers with which this
+   *       one shares data. Use CUDAStreamPool::instance to get streams with indefinite lifetime.
+   *
+   * @param order       The new access order (stream or host). If the new order doesn't have
+   *                    a value, the function has no effect.
+   * @param synchronize If true, an appropriate synchronization is inserted between the old
+   *                    and the new order. The caller may specify `false` if appropriate
+   *                    synchronization is guaranteed by other means.
+   */
   void set_order(AccessOrder order, bool synchronize = true);
 
   Tensor<Backend> &operator[](size_t pos) {

--- a/include/dali/core/access_order.h
+++ b/include/dali/core/access_order.h
@@ -103,9 +103,41 @@ class DLL_PUBLIC AccessOrder {
 
   /**
    * @brief Waits in `this` ordering context for the work scheduled in the `other` order.
+   *
+   * Waits for work scheduled in `other` order to complete. If `other` is host, this function
+   * is a no-op.
+   * If either `other` or `this` is a null order, this function has no efect.
+   *
+   * @note `wait` is transitive with a notable exception of null streams, for which the funcion
+   * is a no-op and can break transitivity.
+   *
+   * ```
+   * AccessOrder o1(stream1), o2(stream2), o3(stream3);
+   * o2.wait(o1);
+   * o3.wait(o2);  // o3 is now synchronized with o1
+   * ```
+   * ```
+   * AccessOrder o1(stream1), o2(AccessOrder::host()), o3(stream3);
+   * o2.wait(o1);  // waits for o1 on host
+   * o3.wait(o2);  // no-op, but host is now synchronized with o1, so all new work in o3 will
+   *               // be scheduled after o2.wait(o1);
+   * ```
+   * ```
+   * AccessOrder o1(stream1), o2{}, o3(stream3);
+   * o2.wait(o1);  // no-op
+   * o3.wait(o2);  // no-op - o3 is not synchronized with o1!
+   * ```
    */
   void wait(const AccessOrder &other) const;
 
+  /**
+   * @brief Waits in `this` ordering context for a CUDA event
+   *
+   * This function executes cudaStreamWaitEvent in case `this` is a stream or
+   * `cudaEventSynchronize` if `this` is host-sync.
+   *
+   * @note This function is a no-op if `this` is a null order.
+   */
   void wait(cudaEvent_t event) const;
 
   bool operator==(const AccessOrder &other) const noexcept {

--- a/include/dali/core/access_order.h
+++ b/include/dali/core/access_order.h
@@ -106,7 +106,7 @@ class DLL_PUBLIC AccessOrder {
    *
    * Waits for work scheduled in `other` order to complete. If `other` is host, this function
    * is a no-op.
-   * If either `other` or `this` is a null order, this function has no efect.
+   * If either `other` or `this` is a null order, this function has no effect.
    *
    * @note `wait` is transitive with a notable exception of null streams, for which the funcion
    * is a no-op and can break transitivity.
@@ -133,7 +133,7 @@ class DLL_PUBLIC AccessOrder {
   /**
    * @brief Waits in `this` ordering context for a CUDA event
    *
-   * This function executes cudaStreamWaitEvent in case `this` is a stream or
+   * This function executes `cudaStreamWaitEvent` in case `this` is a stream, or
    * `cudaEventSynchronize` if `this` is host-sync.
    *
    * @note This function is a no-op if `this` is a null order.


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
**Other** - Documentation



## Description:
Improves documentation of `AccessOrder::wait` and `Buffer::set_order`


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
