### PR TITLE
Add GDS-compatible allocator with 4k alignment.

### DIFF
--- a/dali/core/mm/pool_resource_test.cc
+++ b/dali/core/mm/pool_resource_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ void TestPoolResource(int num_iter) {
   test_host_resource upstream;
   {
     auto opt = default_host_pool_opts();
+    opt.max_upstream_alignment = 32;  // force the use of overaligned upstream allocations
     pool_resource_base<memory_kind::host, FreeList, detail::dummy_lock>
       pool(&upstream, opt);
     std::mt19937_64 rng(12345);

--- a/dali/operators/reader/CMakeLists.txt
+++ b/dali/operators/reader/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ list(APPEND DALI_OPERATOR_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/file_reader_op.cc")
 list(APPEND DALI_OPERATOR_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/numpy_reader_op.cc")
 
 if (BUILD_CUFILE)
+  list(APPEND DALI_OPERATOR_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/gds_mem.cc")
   list(APPEND DALI_OPERATOR_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/numpy_reader_gpu_op.cc")
   list(APPEND DALI_OPERATOR_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/numpy_reader_gpu_op_impl.cu")
 endif()

--- a/dali/operators/reader/gds_mem.cc
+++ b/dali/operators/reader/gds_mem.cc
@@ -1,0 +1,51 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <utility>
+#include <vector>
+#include "dali/operators/reader/gds_mem.h"
+#include "dali/core/spinlock.h"
+#include "dali/core/mm/pool_resource.h"
+#include "dali/core/mm/malloc_resource.h"
+#include "dali/core/mm/composite_resource.h"
+
+namespace dali {
+
+GDSAllocator::GDSAllocator() {
+  // Currently, GPUDirect Storage can work only with memory allocated with cudaMalloc and
+  // cuMemAlloc. Since DALI is transitioning to CUDA Virtual Memory Management for memory
+  // allocation, we need a special allocator that's compatible with GDS.
+
+  static auto upstream = std::make_shared<mm::cuda_malloc_memory_resource>();
+  using resource_type = mm::pool_resource_base<
+    mm::memory_kind::device, mm::coalescing_free_tree, spinlock>;
+  auto rsrc = std::make_shared<resource_type>(upstream.get());
+  rsrc_ = make_shared_composite_resource(std::move(rsrc), upstream);
+}
+
+GDSAllocator &GDSAllocator::instance(int device) {
+  static int ndevs = []() {
+    int devs = 0;
+    CUDA_CALL(cudaGetDeviceCount(&devs));
+    return devs;
+  }();
+  static vector<GDSAllocator> instances(ndevs);
+  if (device < 0)
+    CUDA_CALL(cudaGetDevice(&device));
+  assert(device >= 0 && device < ndevs);
+  return instances[device];
+}
+
+}  // namespace dali

--- a/dali/operators/reader/gds_mem.h
+++ b/dali/operators/reader/gds_mem.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_READER_GDS_MEM_H_
+#define DALI_OPERATORS_READER_GDS_MEM_H_
+
+#include <memory>
+#include "dali/core/mm/memory.h"
+
+namespace dali {
+
+class GDSAllocator {
+ public:
+  GDSAllocator();
+
+  mm::memory_resource<mm::memory_kind::device> *resource() const {
+    return rsrc_.get();
+  }
+
+  static GDSAllocator &instance(int device_id = -1);
+ private:
+  std::shared_ptr<mm::memory_resource<mm::memory_kind::device>> rsrc_;
+};
+
+inline std::shared_ptr<uint8_t> gds_alloc(size_t bytes) {
+    return mm::alloc_raw_shared<uint8_t>(GDSAllocator::instance().resource(), bytes, 4096);
+}
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_READER_GDS_MEM_H_

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -17,28 +17,10 @@
 #include "dali/core/mm/memory.h"
 #include "dali/core/mm/malloc_resource.h"
 #include "dali/operators/reader/numpy_reader_gpu_op.h"
+#include "dali/operators/reader/gds_mem.h"
 #include "dali/pipeline/data/views.h"
 
 namespace dali {
-
-namespace {
-
-/**
- * @brief Allocates memory that's suitable for use with GDS / CUfile
- *
- * Currently (CUDA 11.4) GPUDirect Storage can work only with memory allocated with cudaMalloc and
- * cuMemAlloc. Since DALI is transitioning to CUDA Virtual Memory Management for memory
- * allocation, we need a special allocator that's compatible with GDS.
- */
-std::shared_ptr<uint8_t> gds_alloc(size_t bytes) {
-  uint8_t *ptr = nullptr;
-  CUDA_CALL(cudaMalloc(&ptr, bytes));
-  return std::shared_ptr<uint8_t>(ptr, [](void *mem) {
-    CUDA_DTOR_CALL(cudaFree(mem));
-  });
-}
-
-}  // namespace
 
 NumpyReaderGPU::NumpyReaderGPU(const OpSpec& spec)
     : NumpyReader<GPUBackend, NumpyFileWrapperGPU>(spec),


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
**New feature** (*non-breaking change which adds functionality*)
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->

## Description:
GDS is more efficient when mapped memory is aligned to a 4k boundary. It also doesn't work with memory allocated with cuMemCreate.
This PR adds a dedicated GDS memory pool, which is separate and used only for that purpose.
As a preparatory step, pool_resource was extended so it can be informed about maximum supported alignment of the upstream resource and work around that limitation when allocating upstream blocks.


## Additional information:

### Affected modules and functionalities:
* Pool resource
* NumPy reader (GPU)


### Key points relevant for the review:
N/A


<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [X] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2667
<!--- DALI-XXXX or NA --->
