### PR TITLE
Update error messaging of nvJPEG

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,6 +71,12 @@ class NvjpegError : public std::runtime_error {
         return "Error during the execution of the device tasks.";
       case NVJPEG_STATUS_IMPLEMENTATION_NOT_SUPPORTED:
         return "Not supported.";
+#if NVJPEG_VER_MAJOR > 11 || \
+    (NVJPEG_VER_MAJOR == 11 && (NVJPEG_VER_MINOR > 6 || \
+                               (NVJPEG_VER_MINOR == 6 && NVJPEG_VER_PATCH >= 0)))
+      case NVJPEG_STATUS_INCOMPLETE_BITSTREAM :
+        return "Bitstream input data incomplete.";
+#endif
       default:
         return "< unknown error >";
     }

--- a/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_helper.h
@@ -72,8 +72,7 @@ class NvjpegError : public std::runtime_error {
       case NVJPEG_STATUS_IMPLEMENTATION_NOT_SUPPORTED:
         return "Not supported.";
 #if NVJPEG_VER_MAJOR > 11 || \
-    (NVJPEG_VER_MAJOR == 11 && (NVJPEG_VER_MINOR > 6 || \
-                               (NVJPEG_VER_MINOR == 6 && NVJPEG_VER_PATCH >= 0)))
+    (NVJPEG_VER_MAJOR == 11 && NVJPEG_VER_MINOR >= 6)
       case NVJPEG_STATUS_INCOMPLETE_BITSTREAM :
         return "Bitstream input data incomplete.";
 #endif


### PR DESCRIPTION
- add pretty printing for NVJPEG_STATUS_IMPLEMENTATION_NOT_SUPPORTED
  nvJPEG error status added in CUDA 11.6

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
**Other** (*e.g. Documentation, Tests, Configuration*)



## Description:
- add pretty printing for NVJPEG_STATUS_IMPLEMENTATION_NOT_SUPPORTED
  nvJPEG error status added in CUDA 11.6
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- error pretty printing in nvjpeg_helper.h 
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x/] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
