### PR TITLE
Fix large mini-batch handling in parallel external source

### DIFF
--- a/dali/python/nvidia/dali/_multiproc/messages.py
+++ b/dali/python/nvidia/dali/_multiproc/messages.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,15 +29,15 @@ class ShmMessageDesc(Structure):
         -1 in case of a main process.
     `shm_chunk_id` : int
         Integer identifying shm chunk that contains pickled data to be read by the receiver
-    `shm_capacity` : int
+    `shm_capacity` : unsigned long long int
         Size of the `shm_chunk_id` chunk, receiver should resize the mapping if the chunk
         was resized by the writer.
-    `offset` : int
+    `offset` : unsigned long long int
         Offset in the shm chunk where the serialized message starts
-    `num_bytes` : int
+    `num_bytes` : unsigned long long int
         Size in bytes of the serialized message
     """
-    _fields = ("worker_id", "i"), ("shm_chunk_id", "i"), ("shm_capacity", "i"), ("offset", "i"), ("num_bytes", "i")
+    _fields = ("worker_id", "i"), ("shm_chunk_id", "i"), ("shm_capacity", "Q"), ("offset", "Q"), ("num_bytes", "Q")
 
 
 

--- a/dali/python/nvidia/dali/_multiproc/struct_message.py
+++ b/dali/python/nvidia/dali/_multiproc/struct_message.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,7 +53,14 @@ class Structure:
         return tuple(getattr(self, field_name) for field_name, _ in self._fields)
 
     def pack_into(self, buf, offset):
-        return self._struct.pack_into(buf, offset, *self.get_values())
+        try:
+            values = self.get_values()
+            return self._struct.pack_into(buf, offset, *values)
+        except struct.error as e:
+            raise RuntimeError(
+                "Failed to serialize object as C-like structure. "
+                "Tried to populate following fields: `{}` with respective values: `{}` ".format(
+                    self._fields, self.get_values())) from e
 
     def unpack_from(self, buf, offset):
         values = self._struct.unpack_from(buf, offset)

--- a/dali/test/python/test_external_source_parallel_large_sample.py
+++ b/dali/test/python/test_external_source_parallel_large_sample.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from nose.tools import with_setup
+
+from nvidia.dali import pipeline_def
+import nvidia.dali.fn as fn
+
+from test_external_source_parallel_utils import setup_function, teardown_function, capture_processes
+
+
+def large_sample_cb(sample_info):
+    return np.full((512, 1024, 1024), sample_info.idx_in_epoch, dtype=np.int32)
+
+
+@with_setup(setup_function, teardown_function)
+def _test_large_sample(start_method):
+
+    @pipeline_def
+    def create_pipeline():
+        large = fn.external_source(
+            large_sample_cb, batch=False, parallel=True, prefetch_queue_depth=1)
+        return large
+
+    pipe = create_pipeline(batch_size=1, py_num_workers=2, py_start_method=start_method,
+                           prefetch_queue_depth=1, num_threads=2, device_id=0)
+    pipe.build()
+    capture_processes(pipe._py_pool)
+    for _ in range(8):
+        pipe.run()
+
+
+def test_large_sample():
+    for start_method in ("fork", "spawn"):
+        yield _test_large_sample, start_method

--- a/dali/test/python/test_external_source_parallel_large_sample.py
+++ b/dali/test/python/test_external_source_parallel_large_sample.py
@@ -41,7 +41,7 @@ def _test_large_sample(start_method):
                            prefetch_queue_depth=1, num_threads=2, device_id=0)
     pipe.build()
     capture_processes(pipe._py_pool)
-    for batch_idx in range(5):
+    for batch_idx in range(8):
         (out,) = pipe.run()
         for idx_in_batch in range(batch_size):
             idx_in_epoch = batch_size * batch_idx + idx_in_batch

--- a/dali/test/python/test_external_source_parallel_shared_batch.py
+++ b/dali/test/python/test_external_source_parallel_shared_batch.py
@@ -16,7 +16,7 @@
 import os
 import multiprocessing
 import socket
-from contextlib import closing
+from contextlib import closing, contextmanager
 import numpy as np
 
 from nvidia.dali._multiproc.shared_batch import BufShmChunk, SharedBatchWriter, SharedBatchMeta, deserialize_batch
@@ -66,6 +66,7 @@ def worker(start_method, sock, task_queue, res_queue, worker_cb, worker_params):
             break
 
 
+@contextmanager
 def setup_queue_and_worker(start_method, capacity, worker_cb, worker_params):
     mp = multiprocessing.get_context(start_method)
     task_queue = ShmQueue(mp, capacity)
@@ -76,11 +77,18 @@ def setup_queue_and_worker(start_method, capacity, worker_cb, worker_params):
         socket_r = None
     proc = mp.Process(target=worker, args=(start_method, socket_r, task_queue, res_queue, worker_cb, worker_params))
     proc.start()
-    if start_method == "spawn":
-        pid = os.getppid()
-        multiprocessing.reduction.send_handle(socket_w, task_queue.shm.handle, pid)
-        multiprocessing.reduction.send_handle(socket_w, res_queue.shm.handle, pid)
-    return proc, task_queue, res_queue
+    try:
+        if start_method == "spawn":
+            pid = os.getppid()
+            multiprocessing.reduction.send_handle(socket_w, task_queue.shm.handle, pid)
+            multiprocessing.reduction.send_handle(socket_w, res_queue.shm.handle, pid)
+        yield task_queue, res_queue
+    finally:
+        if not proc.exitcode:
+            res_queue.close()
+            task_queue.close()
+        proc.join()
+        assert proc.exitcode == 0
 
 
 def _put_msgs(queue, msgs, one_by_one):
@@ -115,8 +123,7 @@ def _test_queue_recv(start_method, worker_params, capacity, send_msgs, recv_msgs
         nonlocal count
         count += 1
         return count
-    proc, task_queue, res_queue = setup_queue_and_worker(start_method, capacity, copy_callback, worker_params)
-    try:
+    with setup_queue_and_worker(start_method, capacity, copy_callback, worker_params) as (task_queue, res_queue):
         all_msgs = []
         received = 0
         for send_msg, recv_msg in zip(send_msgs, recv_msgs):
@@ -130,11 +137,6 @@ def _test_queue_recv(start_method, worker_params, capacity, send_msgs, recv_msgs
                 recv_msg_values = recv_msg.get_values()
                 assert len(msg_values) == len(recv_msg_values)
                 assert all(msg_value == recv_msg_value for msg_value, recv_msg_value in zip(msg_values, recv_msg_values))
-    finally:
-        if not proc.exitcode:
-            task_queue.close()
-        proc.join()
-    assert proc.exitcode == 0
 
 
 def test_queue_recv():
@@ -149,9 +151,9 @@ def test_queue_recv():
 
 
 def _test_queue_large(start_method, msg_values):
-    proc, task_queue, res_queue = setup_queue_and_worker(
-        start_method, len(msg_values), copy_callback, {'num_samples': None})
-    try:
+    with setup_queue_and_worker(
+            start_method, len(msg_values), copy_callback,
+            {'num_samples': None}) as (task_queue, res_queue):
         msg_instances = [ShmMessageDesc(*values) for values in msg_values]
         _put_msgs(task_queue, msg_instances, False)
         for values in msg_values:
@@ -160,11 +162,6 @@ def _test_queue_large(start_method, msg_values):
             assert len(values) == len(recv_msg_values)
             assert all(msg_value == recv_msg_value for msg_value,
                     recv_msg_value in zip(values, recv_msg_values))
-    finally:
-        if not proc.exitcode:
-            task_queue.close()
-        proc.join()
-    assert proc.exitcode == 0
 
 
 def test_queue_large():

--- a/qa/TL0_python-self-test-readers-decoders/test_body.sh
+++ b/qa/TL0_python-self-test-readers-decoders/test_body.sh
@@ -13,6 +13,7 @@ test_nose() {
       test_external_source_parallel_garbage_collection_order.py \
       test_external_source_parallel_custom_serialization.py \
       test_pool.py test_external_source_parallel.py test_external_source_parallel_shared_batch.py \
+      test_external_source_parallel_large_sample.py \
       | sed "/$FILTER_PATTERN/d"); do
         nosetests --verbose --attr '!slow,!pytorch,!mxnet,!cupy' ${test_script}
     done

--- a/qa/TL0_python-self-test_xavier/test_body.sh
+++ b/qa/TL0_python-self-test_xavier/test_body.sh
@@ -13,7 +13,7 @@ test_nose() {
         "caffe"
     )
 
-    for test_script in $(ls test_operator_*.py test_pipeline*.py test_pool.py test_external_source_dali.py test_external_source_numpy.py test_external_source_parallel.py test_external_source_parallel_shared_batch.py test_functional_api.py test_backend_impl.py); do
+    for test_script in $(ls test_operator_*.py test_pipeline*.py test_pool.py test_external_source_dali.py test_external_source_numpy.py test_external_source_parallel.py test_external_source_parallel_shared_batch.py test_external_source_parallel_large_sample.py test_functional_api.py test_backend_impl.py); do
         status=0
         for exclude in "${EXCLUDE_PACKAGES[@]}"; do
             grep -qiE ${exclude} ${test_script} && status=$((status+1))


### PR DESCRIPTION
## Category:
<!--- Please pick one from below: --->
**Bug fix** (*non-breaking change which fixes an issue*)
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
Parallel external source passes data from workers to the main process through shared memory buffers.
If the capacity of a buffer exceeds `max_int`, worker process fails to serialize the minibatch meta-data (which includes the capacity) when it is written into C-like structure (python's `struct` package).

This PR:
1. Makes serialization error message more verbose, so that it contains values that the worker attempted to put in the struct.
2. Changes size-related members to be `unsigned long long int` instead of `int`.
3. Adds test for shared queue class if it handles the values properly
4. Adds a test that uses samples of 2GB in parallel external source.



## Additional information:

### Affected modules and functionalities:
1. `_multiproc` module and tests.



### Key points relevant for the review:
1. Maybe `unsigned long long int` is too much and simply unsigned `int` there will be good enough?



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2679
