### PR TITLE
Improve CropMirrorNormalize operator performance

### DIFF
--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -123,7 +123,7 @@ class SliceFlipNormalizePermutePadGpu {
       block_count_ += number_of_blocks - block_remainder;
     }
     block_size_ = div_ceil(all_sample_sizes, block_count_);
-    
+
     block_count_ = 0;
     for (auto &elem : args) {
       size_t sample_size = volume(elem.shape);

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -24,6 +24,7 @@
 #include "dali/core/dev_array.h"
 #include "dali/core/error_handling.h"
 #include "dali/core/static_switch.h"
+#include "dali/core/cuda_utils.h"
 #include "dali/kernels/common/copy.h"
 #include "dali/kernels/kernel.h"
 #include "dali/kernels/slice/slice_flip_normalize_permute_pad_common.h"
@@ -35,8 +36,8 @@ namespace kernels {
 template <typename OutputType, typename InputType, int Dims>
 class SliceFlipNormalizePermutePadGpu {
  private:
-  static constexpr size_t kBlockDim = 512;
-  static constexpr size_t kBlockSize = 64 * kBlockDim;
+  static constexpr size_t kBlockDim = 256;
+  size_t kBlockSize = 32 * kBlockDim;
   size_t block_count_ = 0;
 
   using ProcessedArgs = detail::SliceFlipNormalizePermutePadProcessedArgs<Dims>;
@@ -101,13 +102,27 @@ class SliceFlipNormalizePermutePadGpu {
     se.add<mm::memory_kind::pinned, detail::SampleDesc<Dims>>(num_samples);
     se.add<mm::memory_kind::device, detail::SampleDesc<Dims>>(num_samples);
 
+    int blocks_per_sm_;
+    CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_sm_,
+      detail::SliceFlipNormalizePermutePadKernel<false, false, false, OutputType, InputType, Dims>, 
+      kBlockDim, 
+      0));
+
     block_count_ = 0;
+    auto number_of_blocks = GetSmCount() * blocks_per_sm_;
+    size_t all_sample_sizes = 0;
     for (auto &elem : args) {
       size_t sample_size = volume(elem.shape);
+      all_sample_sizes += sample_size;
       block_count_ += std::ceil(
         sample_size / static_cast<float>(kBlockSize));
     }
-
+    if (block_count_ % number_of_blocks != 0) {
+      block_count_ += (number_of_blocks - (block_count_ % number_of_blocks));
+    }
+    kBlockSize = div_ceil(all_sample_sizes, block_count_);
+    block_count_ = std::ceil(all_sample_sizes / static_cast<float>(kBlockSize));
+    
     se.add<mm::memory_kind::pinned, detail::BlockDesc>(block_count_);
     se.add<mm::memory_kind::device, detail::BlockDesc>(block_count_);
     req.scratch_sizes = se.sizes;
@@ -149,11 +164,6 @@ class SliceFlipNormalizePermutePadGpu {
           norm_mul_data[d] = sample_args.inv_stddev[d];
         }
       }
-
-      std::tie(norm_add_gpu, norm_mul_gpu) = context.scratchpad->ToContiguousGPU(
-          context.gpu.stream,
-          make_span(norm_add_cpu, num_samples * norm_args_size_),
-          make_span(norm_mul_cpu, num_samples * norm_args_size_));
     }
 
     assert(nfill_values_ > 0);
@@ -165,8 +175,12 @@ class SliceFlipNormalizePermutePadGpu {
       for (int d = 0; d < nfill_values_; d++)
         fill_values[d] = sample_args.fill_values[d];
     }
-    OutputType *fill_values_gpu = context.scratchpad->ToGPU(
-        context.gpu.stream, make_span(fill_values_cpu, num_samples * nfill_values_));
+    OutputType *fill_values_gpu;
+    std::tie(norm_add_gpu, norm_mul_gpu, fill_values_gpu) = context.scratchpad->ToContiguousGPU(
+      context.gpu.stream, 
+      make_span(norm_add_cpu, num_samples * norm_args_size_),
+      make_span(norm_mul_cpu, num_samples * norm_args_size_),
+      make_span(fill_values_cpu, num_samples * nfill_values_));
 
     auto *sample_descs_cpu =
         context.scratchpad->AllocatePinned<detail::SampleDesc<Dims>>(num_samples);

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -104,8 +104,8 @@ class SliceFlipNormalizePermutePadGpu {
 
     int blocks_per_sm_;
     CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_sm_,
-      detail::SliceFlipNormalizePermutePadKernel<false, false, false, OutputType, InputType, Dims>, 
-      kBlockDim, 
+      detail::SliceFlipNormalizePermutePadKernel<false, false, false, OutputType, InputType, Dims>,
+      kBlockDim,
       0));
 
     block_count_ = 0;
@@ -122,7 +122,7 @@ class SliceFlipNormalizePermutePadGpu {
     }
     kBlockSize = div_ceil(all_sample_sizes, block_count_);
     block_count_ = std::ceil(all_sample_sizes / static_cast<float>(kBlockSize));
-    
+
     se.add<mm::memory_kind::pinned, detail::BlockDesc>(block_count_);
     se.add<mm::memory_kind::device, detail::BlockDesc>(block_count_);
     req.scratch_sizes = se.sizes;
@@ -177,7 +177,7 @@ class SliceFlipNormalizePermutePadGpu {
     }
     OutputType *fill_values_gpu;
     std::tie(norm_add_gpu, norm_mul_gpu, fill_values_gpu) = context.scratchpad->ToContiguousGPU(
-      context.gpu.stream, 
+      context.gpu.stream,
       make_span(norm_add_cpu, num_samples * norm_args_size_),
       make_span(norm_mul_cpu, num_samples * norm_args_size_),
       make_span(fill_values_cpu, num_samples * nfill_values_));


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)



## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

Work's main motivation was to improve throughput for small batch sizes of data.

Change improves throughput of CropMirrorNormalize operator for all batch sizes, measured in GB/s. Below shown plotted results of improvements for different batch sizes.

- _CMN_original_ - current behaviour of CropMirrorNormalize
- _CMN_block_256_ - throughput with change of kBlockDim from 512 to 256 
- _CMN_blockSize_sm_ - throughput with change of _CMN_block_256_ and change of kBlockSize to adaptive values, described below in detail
- _CMN_merged_copy_ - throughput with changes of _CMN_block_256_ and _CMN_blockSize_sm_ and merge of two seperate calls to memcpy into one

![image](https://user-images.githubusercontent.com/62378433/160791219-bbd07dac-b54d-4683-bbc9-d97796d21936.png)

![image](https://user-images.githubusercontent.com/62378433/160791154-39a978a7-dc82-4914-b15a-f860e33fc2fd.png)


**Detailed change description:**
- Experimentally found new value of kBlockDim through plotting throughput with many different values of kBlockDim using existing CropMirrorNormalize benchmark
- Out of three separate calls to copy from Host to Device in slice_flip_normal_permute_pad_gpu.h two were merged into one resulting in slightly higher throughput for small batch sizes
- **Adaptive value of kBlockSize:**

   Nvidia Nsight Compute measurement results for original CropMirrorNormalize kernel:
--- **0,3 full waves** across all SMs
--- **24,03 %** of achieved occupancy (max 75%)
--- **76 blocks** launched (80 SMs available, limit of 6 blocks per SM)

   Nvidia Nsight Compute measurement results for improved CropMirrorNormalize kernel (measurements include all improvements from this PR):
--- **1 full wave** across all SMs
--- **53,55 %** of achieved occupancy (max 75%)
--- **480 blocks** launched (80 SMs available, limit of 6 blocks per SM, so value of 80*6)

   Value of kBlockSize is being set to such that there will be number of blocks divisible by **x** = (number of SMs times block limit per SM). Because number of blocks is found based on blockSize, first we count the blocks as in original CropMirrorNormalize code with kBlockSize set to 32 (originally 64, 32 behaved better in testing different values of kBlockDim), then we round block_count up to become divisible by **x**, and finally we adjust kBlockSize to count the blocks once more, now based on new kBlockSize.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
slice_flip_normalize_pad_gpu.h


<!--- ### Key points relevant for the review: --->
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
