### PR TITLE
Improve cast operator performance

### DIFF
--- a/dali/kernels/common/cast.cuh
+++ b/dali/kernels/common/cast.cuh
@@ -26,15 +26,46 @@ struct CastSampleDesc {
   const void *input;
 };
 
+struct CastSampleBlockDesc {
+  int first_block;
+  int sample_size;
+};
+
+template <typename OType, typename IType>
+__device__ __forceinline__ void CastKernelInternal(const CastSampleDesc& sample,
+                                                   int block_start, int block_end) {
+  auto *out = static_cast<OType *>(sample.output);
+  const auto *in = static_cast<const IType *>(sample.input);
+  for (int x = threadIdx.x + block_start; x < block_end; x += blockDim.x) {
+    out[x] = ConvertSat<OType>(in[x]);
+  }
+}
+
 template <typename OType, typename IType>
 __global__ void BatchedCastKernel(const CastSampleDesc *samples, const BlockDesc<1> *blocks) {
   const auto &block = blocks[blockIdx.x];
   const auto &sample = samples[block.sample_idx];
-  auto *out = static_cast<OType *>(sample.output);
-  const auto *in = static_cast<const IType *>(sample.input);
-  for (int x = threadIdx.x + block.start.x; x < block.end.x; x += blockDim.x) {
-    out[x] = ConvertSat<OType>(in[x]);
+  CastKernelInternal<OType, IType>(sample, block.start.x, block.end.x);
+}
+
+template <typename OType, typename IType>
+__global__ void BinSearchCastKernel(const CastSampleDesc *samples,
+                                    const CastSampleBlockDesc *params,
+                                    int nsamples, int block_volume_scale) {
+  int i = 0;
+  for (int jump = (1 << (32 - __clz(nsamples) - 1)); jump; jump /= 2) {
+    if (i + jump < nsamples && params[i + jump].first_block <= blockIdx.x)
+      i += jump;
   }
+  CastSampleDesc sample = samples[i];
+  int size = params[i].sample_size;
+  int block_offset = blockIdx.x - params[i].first_block;
+
+  int block_size = block_volume_scale * blockDim.x;
+  int block_start = block_offset * block_size;
+  int block_end = block_start + block_size <= size ? block_start + block_size : size;
+
+  CastKernelInternal<OType, IType>(sample, block_start, block_end);
 }
 
 }  // namespace kernels

--- a/dali/kernels/common/cast.cuh
+++ b/dali/kernels/common/cast.cuh
@@ -36,7 +36,7 @@ __device__ __forceinline__ void CastKernelInternal(const CastSampleDesc& sample,
                                                    unsigned block_start, unsigned block_end) {
   auto *out = static_cast<OType *>(sample.output);
   const auto *in = static_cast<const IType *>(sample.input);
-  for (int x = threadIdx.x + block_start; x < block_end; x += blockDim.x) {
+  for (unsigned x = threadIdx.x + block_start; x < block_end; x += blockDim.x) {
     out[x] = ConvertSat<OType>(in[x]);
   }
 }

--- a/dali/kernels/common/cast.cuh
+++ b/dali/kernels/common/cast.cuh
@@ -27,7 +27,7 @@ struct CastSampleDesc {
 };
 
 struct CastSampleBlockDesc {
-  unsigned first_block; // Id of the earliest block that should process given sample
+  unsigned first_block;  // Id of the earliest block that should process given sample
   unsigned sample_size;
 };
 
@@ -55,7 +55,7 @@ __global__ void BinSearchCastKernel(const CastSampleDesc *samples,
   unsigned i = 0;
   for (unsigned jump = (1 << (32 - __clz(nsamples) - 1)); jump; jump >>= 1) {
     if (i + jump < nsamples && params[i + jump].first_block <= blockIdx.x)
-      i += jump; // Binary search to find sample that this block should process
+      i += jump;  // Binary search to find sample that this block should process
   }
   CastSampleDesc sample = samples[i];
   auto size = params[i].sample_size;

--- a/dali/operators/generic/cast.cu
+++ b/dali/operators/generic/cast.cu
@@ -84,6 +84,7 @@ void CastGPU::RunImpl(DeviceWorkspace &ws) {
   }
 
   auto blocks = block_setup_.Blocks();
+  // Calculate id of the earliest block that should process given sample
   for (int block_id = 0, sample_id = -1; block_id < blocks.size(); block_id++) {
     if (blocks[block_id].sample_idx != sample_id) {
       sample_id++;

--- a/dali/operators/generic/cast.cu
+++ b/dali/operators/generic/cast.cu
@@ -29,7 +29,7 @@ namespace dali {
 
 class CastGPU : public Cast<GPUBackend> {
  public:
-  explicit CastGPU(const OpSpec &spec) : Cast<GPUBackend>{spec} {}
+  explicit CastGPU(const OpSpec &spec) : Cast<GPUBackend>{spec}, block_setup_{block_volume_scale} {}
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const DeviceWorkspace &ws) override;
   void RunImpl(DeviceWorkspace &ws) override;
@@ -38,6 +38,8 @@ class CastGPU : public Cast<GPUBackend> {
 
  protected:
   void PrepareBlocks(const DeviceWorkspace &ws);
+
+  static const int block_volume_scale = 4;
 
  private:
   using GpuBlockSetup = kernels::BlockSetup<1, -1>;
@@ -76,18 +78,32 @@ void CastGPU::RunImpl(DeviceWorkspace &ws) {
     samples_[sample_id].input = input.raw_tensor(sample_id);
   }
 
-  GpuBlockSetup::BlockDesc *blocks_dev;
+  std::vector<kernels::CastSampleBlockDesc> params_host(num_samples);
+  for (int sample_id = 0; sample_id < num_samples; sample_id++) {
+    params_host[sample_id].sample_size = volume(input.tensor_shape(sample_id));
+  }
+
+  auto blocks = block_setup_.Blocks();
+  for (int block_id = 0, sample_id = -1; block_id < blocks.size(); block_id++) {
+    if (blocks[block_id].sample_idx != sample_id) {
+      sample_id++;
+      params_host[sample_id].first_block = block_id;
+    }
+  }
+
+  kernels::CastSampleBlockDesc *params_dev;
   kernels::CastSampleDesc *samples_dev;
-  std::tie(blocks_dev, samples_dev) = scratchpad.ToContiguousGPU(ws.stream(),
-    block_setup_.Blocks(), samples_);
+  std::tie(params_dev, samples_dev) = scratchpad.ToContiguousGPU(ws.stream(),
+                                                                 params_host, samples_);
 
   DALIDataType itype = input.type();
   dim3 grid_dim = block_setup_.GridDim();
   dim3 block_dim = block_setup_.BlockDim();
   TYPE_SWITCH(output_type_, type2id, OType, CAST_ALLOWED_TYPES, (
     TYPE_SWITCH(itype, type2id, IType, CAST_ALLOWED_TYPES, (
-      kernels::BatchedCastKernel<OType, IType>
-          <<<grid_dim, block_dim, 0, ws.stream()>>>(samples_dev, blocks_dev);
+      kernels::BinSearchCastKernel<OType, IType>
+          <<<grid_dim, block_dim, 0, ws.stream()>>>(samples_dev, params_dev,
+            num_samples, block_volume_scale);
     ), DALI_FAIL(make_string("Invalid input type: ", itype)););  // NOLINT(whitespace/parens)
   ), DALI_FAIL(make_string("Invalid output type: ", output_type_)););  // NOLINT(whitespace/parens)
 }


### PR DESCRIPTION
Signed-off-by: Konrad Litwiński <klitwinski41418@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
**Refactoring** (*Redesign of existing code that doesn't affect functionality*) 
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

Work's main motivation was to improve throughput for small batch sizes of data for **Cast**.

Originally running Cast kernel (BatchedCastKernel) required copying two arrays to GPU - 
- samples array (with descriptors of placement of samples in memory) - it used  8 * samples_number bytes.
- blocks array (with descriptors of what should be done for each threads block) - it used 20 * number_of_blocks bytes 
As there was a linear relationship between data size and number of blocks (number of blocks was around 1024 times smaller then data size) copying second array was a big cost of running Cast kernel. 

The idea of this optimization is to instead of copying block array, create an array with information of how big the samples are, and which block is the first one to parse every sample, copy it to GPU and then - in the kernel - calculate which sample should the block work on. To calculate that efficiently we use binary search over sample descriptors.   

## Additional information:

For image size 1000x1000 we achieved following improvement
![image](https://user-images.githubusercontent.com/55670462/161379657-198cf932-93ed-47e6-b052-c8bead7db068.png)


### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

cast.cuh
cast.cu

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
The key changes are in the newly added BinSearchCastKernel kernel.


<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
