### PR TITLE
Specialized Cast GPU kernel for smaller batch sizes

### DIFF
--- a/dali/kernels/common/cast.cuh
+++ b/dali/kernels/common/cast.cuh
@@ -26,15 +26,46 @@ struct CastSampleDesc {
   const void *input;
 };
 
+struct CastSampleBlockDesc {
+  int first_block;
+  int sample_size;
+};
+
+template <typename OType, typename IType>
+__device__ __forceinline__ void CastKernelInternal(const CastSampleDesc& sample,
+                                                   int block_start, int block_end) {
+  auto *out = static_cast<OType *>(sample.output);
+  const auto *in = static_cast<const IType *>(sample.input);
+  for (int x = threadIdx.x + block_start; x < block_end; x += blockDim.x) {
+    out[x] = ConvertSat<OType>(in[x]);
+  }
+}
+
 template <typename OType, typename IType>
 __global__ void BatchedCastKernel(const CastSampleDesc *samples, const BlockDesc<1> *blocks) {
   const auto &block = blocks[blockIdx.x];
   const auto &sample = samples[block.sample_idx];
-  auto *out = static_cast<OType *>(sample.output);
-  const auto *in = static_cast<const IType *>(sample.input);
-  for (int x = threadIdx.x + block.start.x; x < block.end.x; x += blockDim.x) {
-    out[x] = ConvertSat<OType>(in[x]);
+  CastKernelInternal<OType, IType>(sample, block.start.x, block.end.x);
+}
+
+template <typename OType, typename IType>
+__global__ void BinSearchCastKernel(const CastSampleDesc *samples,
+                                    const CastSampleBlockDesc *params,
+                                    int nsamples, int block_volume_scale) {
+  int i = 0;
+  for (int jump = (1 << (32 - __clz(nsamples) - 1)); jump; jump /= 2) {
+    if (i + jump < nsamples && params[i + jump].first_block <= blockIdx.x)
+      i += jump;
   }
+  CastSampleDesc sample = samples[i];
+  int size = params[i].sample_size;
+  int block_offset = blockIdx.x - params[i].first_block;
+
+  int block_size = block_volume_scale * blockDim.x;
+  int block_start = block_offset * block_size;
+  int block_end = block_start + block_size <= size ? block_start + block_size : size;
+
+  CastKernelInternal<OType, IType>(sample, block_start, block_end);
 }
 
 }  // namespace kernels

--- a/dali/operators/generic/cast.cu
+++ b/dali/operators/generic/cast.cu
@@ -29,7 +29,7 @@ namespace dali {
 
 class CastGPU : public Cast<GPUBackend> {
  public:
-  explicit CastGPU(const OpSpec &spec) : Cast<GPUBackend>{spec} {}
+  explicit CastGPU(const OpSpec &spec) : Cast<GPUBackend>{spec}, block_setup_{block_volume_scale} {}
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const DeviceWorkspace &ws) override;
   void RunImpl(DeviceWorkspace &ws) override;
@@ -38,6 +38,8 @@ class CastGPU : public Cast<GPUBackend> {
 
  protected:
   void PrepareBlocks(const DeviceWorkspace &ws);
+
+  static const int block_volume_scale = 4;
 
  private:
   using GpuBlockSetup = kernels::BlockSetup<1, -1>;
@@ -76,18 +78,32 @@ void CastGPU::RunImpl(DeviceWorkspace &ws) {
     samples_[sample_id].input = input.raw_tensor(sample_id);
   }
 
-  GpuBlockSetup::BlockDesc *blocks_dev;
+  std::vector<kernels::CastSampleBlockDesc> params_host(num_samples);
+  for (int sample_id = 0; sample_id < num_samples; sample_id++) {
+    params_host[sample_id].sample_size = volume(input.tensor_shape(sample_id));
+  }
+
+  auto blocks = block_setup_.Blocks();
+  for (int block_id = 0, sample_id = -1; block_id < blocks.size(); block_id++) {
+    if (blocks[block_id].sample_idx != sample_id) {
+      sample_id++;
+      params_host[sample_id].first_block = block_id;
+    }
+  }
+
+  kernels::CastSampleBlockDesc *params_dev;
   kernels::CastSampleDesc *samples_dev;
-  std::tie(blocks_dev, samples_dev) = scratchpad.ToContiguousGPU(ws.stream(),
-    block_setup_.Blocks(), samples_);
+  std::tie(params_dev, samples_dev) = scratchpad.ToContiguousGPU(ws.stream(),
+                                                                 params_host, samples_);
 
   DALIDataType itype = input.type();
   dim3 grid_dim = block_setup_.GridDim();
   dim3 block_dim = block_setup_.BlockDim();
   TYPE_SWITCH(output_type_, type2id, OType, CAST_ALLOWED_TYPES, (
     TYPE_SWITCH(itype, type2id, IType, CAST_ALLOWED_TYPES, (
-      kernels::BatchedCastKernel<OType, IType>
-          <<<grid_dim, block_dim, 0, ws.stream()>>>(samples_dev, blocks_dev);
+      kernels::BinSearchCastKernel<OType, IType>
+          <<<grid_dim, block_dim, 0, ws.stream()>>>(samples_dev, params_dev,
+            num_samples, block_volume_scale);
     ), DALI_FAIL(make_string("Invalid input type: ", itype)););  // NOLINT(whitespace/parens)
   ), DALI_FAIL(make_string("Invalid output type: ", output_type_)););  // NOLINT(whitespace/parens)
 }


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:

This PR is an extension of https://github.com/NVIDIA/DALI/pull/3783 and depends on it. Once https://github.com/NVIDIA/DALI/pull/3783 gets merged, I'll turn this PR from "draft" to "ready". By now, it's probably easiest to check out the diff between this PR and #3783 [here](https://github.com/szkarpinski/DALI/compare/d89def579edc92fd50bb3ff9f037197cd5910156...szkarpinski:cast-direct-experimental).

The https://github.com/NVIDIA/DALI/pull/3783 aims to improve Cast performance by reducing the size of host to device `cudaMemcpy` needed. For smaller batch sizes it is possible to remove *all* host to device `cudaMemcpy`'s, because all data needed fits in the 4KB parameter buffer. In this PR we introduce a specialized `DirectCastKernel` for batches of 8 samples and smaller, in which sample descriptor arrays are passed by value instead of by pointer.

We have mixed feelings about this idea, because it will add some complexity to DALI's code and we are not sure if it's worth it. The main purpose of this PR is to ask for your opinion.

### Why we **don't** need this PR
- Adds yet another kernel.
- Assumes that passing data parameter buffer via parameter buffer is (and will always be) faster.
- Assumes that the size description of single Cast sample will not exceed 512B.

### Why we need this PR
- Throughput gain, especially for single images, is huge! (see below)

## Additional information:

### Masurements
The following plot shows the throughput improvement for casting 1000x1000x3 images from `uint8` to `float`. This was measured of Titan V GPU with `cast_bench.cc`.
![image](https://user-images.githubusercontent.com/34919255/161423379-8102d152-2f66-466f-841d-26b452814ce8.png)

### Affected modules and functionalities:
- New `DirectCastKernel` added, together with `DirectCastKernelParamPack` structure to hold its parameters.

### Key points relevant for the review:
- As mentioned above, we are not certain if this idea fits "performance vs maintainablity" guidelines of DALI

<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
