### PR TITLE
Add missing copying of pinned prop when sharing buffer

### DIFF
--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -448,6 +448,7 @@ class DLL_PUBLIC Buffer {
     size_ = other.size_;
     type_ = other.type_;
     num_bytes_ = other.num_bytes_;
+    pinned_ = other.pinned_;
     shares_data_ = num_bytes_ > 0 ? true : false;
     device_ = other.device_id();
   }

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -539,6 +539,8 @@ TYPED_TEST(TensorListTest, TestShareData) {
 
   // Share the data
   tensor_list2.ShareData(tensor_list);
+  ASSERT_EQ(tensor_list2.is_pinned(), tensor_list.is_pinned());
+  ASSERT_EQ(tensor_list2.order(), tensor_list.order());
   // We need to use the same size as the underlying buffer
   // N.B. using other type is UB in most cases
   auto flattened_shape = collapse_dims(shape, {std::make_pair(0, shape.sample_dim())});


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
**Bug fix** (*non-breaking change which fixes an issue*)
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
Adds missing coping of `pinned` property in ShareData of buffer. 



## Additional information:

### Affected modules and functionalities:
Affects TensorList (its ShareData(TensorList&) method).



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2706
<!--- DALI-XXXX or NA --->
