### PR TITLE
Add support for variable batch size debug mode and NVTX ranges

### DIFF
--- a/dali/pipeline/pipeline_debug.h
+++ b/dali/pipeline/pipeline_debug.h
@@ -44,6 +44,7 @@ class DLL_PUBLIC PipelineDebug {
 
   DLL_PUBLIC void AddOperator(OpSpec &spec, int logical_id) {
     FillOpSpec(spec);
+    std::string op_name = "__debug__" + spec.name() + "_" + std::to_string(logical_id);
     AddOperatorImpl(spec, logical_id);
   }
 
@@ -60,7 +61,8 @@ class DLL_PUBLIC PipelineDebug {
   template <typename InBackend, typename OutBackend>
   DLL_PUBLIC std::vector<std::shared_ptr<TensorList<OutBackend>>> RunOperator(
       int logical_id, const std::vector<std::shared_ptr<TensorList<InBackend>>> &inputs,
-      const std::unordered_map<std::string, std::shared_ptr<TensorList<CPUBackend>>> &kwargs) {
+      const std::unordered_map<std::string, std::shared_ptr<TensorList<CPUBackend>>> &kwargs,
+      int batch_size = -1) {
     DALI_FAIL("Unsupported backends in PipelineDebug.RunOperator().");
   }
 
@@ -72,14 +74,15 @@ class DLL_PUBLIC PipelineDebug {
   }
 
   void AddOperatorImpl(OpSpec &spec, int logical_id) {
+    std::string name = "__debug__" + spec.name() + "_" + std::to_string(logical_id);
     std::string device = spec.GetArgument<std::string>("device");
 
     if (device == "gpu") {
-      gpu_operators_.insert({logical_id, EagerOperator<GPUBackend>(spec)});
+      gpu_operators_.insert({logical_id, EagerOperator<GPUBackend>(spec, name)});
     } else if (device == "cpu") {
-      cpu_operators_.insert({logical_id, EagerOperator<CPUBackend>(spec)});
+      cpu_operators_.insert({logical_id, EagerOperator<CPUBackend>(spec, name)});
     } else if (device == "mixed") {
-      mixed_operators_.insert({logical_id, EagerOperator<MixedBackend>(spec)});
+      mixed_operators_.insert({logical_id, EagerOperator<MixedBackend>(spec, name)});
     }
   }
 
@@ -96,28 +99,31 @@ class DLL_PUBLIC PipelineDebug {
 template <>
 std::vector<std::shared_ptr<TensorList<CPUBackend>>> PipelineDebug::RunOperator(
     int logical_id, const std::vector<std::shared_ptr<TensorList<CPUBackend>>> &inputs,
-    const std::unordered_map<std::string, std::shared_ptr<TensorList<CPUBackend>>> &kwargs) {
+    const std::unordered_map<std::string, std::shared_ptr<TensorList<CPUBackend>>> &kwargs,
+    int batch_size) {
   auto op = cpu_operators_.find(logical_id);
   DALI_ENFORCE(op != cpu_operators_.end(), "Failed to acquire CPU Operator in PipelineDebug.");
-  return op->second.template Run<CPUBackend, CPUBackend>(inputs, kwargs, &thread_pool_);
+  return op->second.template Run<CPUBackend, CPUBackend>(inputs, kwargs, &thread_pool_, batch_size);
 }
 
 template <>
 std::vector<std::shared_ptr<TensorList<GPUBackend>>> PipelineDebug::RunOperator(
     int logical_id, const std::vector<std::shared_ptr<TensorList<GPUBackend>>> &inputs,
-    const std::unordered_map<std::string, std::shared_ptr<TensorList<CPUBackend>>> &kwargs) {
+    const std::unordered_map<std::string, std::shared_ptr<TensorList<CPUBackend>>> &kwargs,
+    int batch_size) {
   auto op = gpu_operators_.find(logical_id);
   DALI_ENFORCE(op != gpu_operators_.end(), "Failed to acquire GPU Operator in PipelineDebug.");
-  return op->second.template Run<GPUBackend, GPUBackend>(inputs, kwargs, cuda_stream_);
+  return op->second.template Run<GPUBackend, GPUBackend>(inputs, kwargs, cuda_stream_, batch_size);
 }
 
 template <>
 std::vector<std::shared_ptr<TensorList<GPUBackend>>> PipelineDebug::RunOperator(
     int logical_id, const std::vector<std::shared_ptr<TensorList<CPUBackend>>> &inputs,
-    const std::unordered_map<std::string, std::shared_ptr<TensorList<CPUBackend>>> &kwargs) {
+    const std::unordered_map<std::string, std::shared_ptr<TensorList<CPUBackend>>> &kwargs,
+    int batch_size) {
   auto op = mixed_operators_.find(logical_id);
   DALI_ENFORCE(op != mixed_operators_.end(), "Failed to acquire Mixed Operator in PipelineDebug.");
-  return op->second.template Run<CPUBackend, GPUBackend>(inputs, kwargs, cuda_stream_);
+  return op->second.template Run<CPUBackend, GPUBackend>(inputs, kwargs, cuda_stream_, batch_size);
 }
 
 }  // namespace dali

--- a/dali/pipeline/pipeline_debug.h
+++ b/dali/pipeline/pipeline_debug.h
@@ -44,7 +44,6 @@ class DLL_PUBLIC PipelineDebug {
 
   DLL_PUBLIC void AddOperator(OpSpec &spec, int logical_id) {
     FillOpSpec(spec);
-    std::string op_name = "__debug__" + spec.name() + "_" + std::to_string(logical_id);
     AddOperatorImpl(spec, logical_id);
   }
 

--- a/dali/python/nvidia/dali/_debug_mode.py
+++ b/dali/python/nvidia/dali/_debug_mode.py
@@ -15,7 +15,6 @@
 import inspect
 import traceback
 from queue import Queue
-from cv2 import trace
 
 import nvidia.dali.backend as _b
 import nvidia.dali.ops as _ops

--- a/dali/python/nvidia/dali/_debug_mode.py
+++ b/dali/python/nvidia/dali/_debug_mode.py
@@ -336,22 +336,25 @@ class _IterBatchInfo:
 
     def check_input(self, other_size, other_context, op_name, input_idx):
         if not self.set_if_empty(other_size, other_context) and self._size != other_size:
-            raise RuntimeError(("Batch size must be uniform across an iteration. Input {} for operator '{}' "
-                                "has batch size = {}. Expected batch size = {} from:\n{}")
+            raise RuntimeError(("Batch size must be uniform across an iteration. Input {} for operator '{}' has batch "
+                                "size = {}. Expected batch size = {} from:\n{}")
                                .format(input_idx, op_name, other_size, self._size, self._source_context))
 
     def check_external_source(self, other_size, other_context, output_idx=-1):
         if not self.set_if_empty(other_size, other_context) and self._size != other_size:
             if self._source_context == other_context and output_idx > 0:
-                raise RuntimeError(("External source must return outputs with consistent batch size. Output {} "
-                                    "has batch size = {}, previous batch size = {}")
+                raise RuntimeError(("External source must return outputs with consistent batch size. Output {} has "
+                                    "batch size = {}, previous batch size = {}")
                                    .format(output_idx, other_size, self._size))
             else:
-                raise RuntimeError(
-                    ("Batch size must be uniform across an iteration. External Source operator returned batch "
-                        "size: {}, expected: {}.\nIf you want to use batch size returned by "
-                        "external source it has to be the first operator in the pipeline. It should be before:\n{}")
-                    .format(other_size, self._size, self._source_context))
+                raise RuntimeError(("Batch size must be uniform across an iteration. External Source operator returned"
+                                    " batch size: {}, expected: {}.\nIf you want to use variable batch size (that is "
+                                    "different batch size in each iteration) you must call all the external source "
+                                    "operators at the beginning of your debug pipeline, before other DALI operators. "
+                                    "All the external source operators are expected to return the same batch size in "
+                                    "a given iteration, but it can change between the iterations. Other operators will"
+                                    " use that batch size for processing.")
+                                   .format(other_size, self._size))
 
 
 class _OperatorManager:

--- a/dali/test/python/test_pipeline_debug.py
+++ b/dali/test/python/test_pipeline_debug.py
@@ -457,7 +457,6 @@ def cpu_after_gpu_pipeline():
     jpegs, labels = fn.readers.file(
         file_root=file_root, shard_id=0, num_shards=2, random_shuffle=True)
     images = fn.decoders.image(jpegs, output_type=types.RGB, device='mixed')
-
     output = fn.random_resized_crop(images, size=(224, 224), device='cpu')
     return labels, output
 
@@ -465,22 +464,6 @@ def cpu_after_gpu_pipeline():
 @raises(RuntimeError, glob='Cannot call * operator * with * input *')
 def test_cpu_operator_after_gpu():
     pipe = cpu_after_gpu_pipeline()
-    pipe.build()
-    pipe.run()
-
-
-@pipeline_def(batch_size=8, num_threads=3, device_id=0, seed=47, debug=True)
-def variable_batch_size_pipeline():
-    jpegs, labels = fn.readers.file(file_root=file_root)
-    images = fn.decoders.image(jpegs)
-    images = [images.get()[i] for i in range(6)]
-    output = fn.random_resized_crop(images, size=(224, 224))
-    return labels, output
-
-
-@raises(RuntimeError, glob='Variable batch size is not supported in debug mode.*')
-def test_variable_batch_size():
-    pipe = variable_batch_size_pipeline()
     pipe.build()
     pipe.run()
 
@@ -533,3 +516,70 @@ def test_multiple_input_sets():
     pipe_standard = multiple_input_sets_pipeline()
     pipe_debug = multiple_input_sets_pipeline(debug=True)
     compare_pipelines(pipe_standard, pipe_debug, 8, 10)
+
+
+@pipeline_def(batch_size=8, num_threads=3, device_id=0, seed=47, debug=True)
+def variable_batch_size_from_external_source_pipeline(variable_batch_size):
+    src_data = np.zeros((1, variable_batch_size, 64, 64, 3), dtype=np.uint8)
+    images = fn.external_source(src_data)
+    assert len(images.get()) == variable_batch_size
+
+    output = fn.random_resized_crop(images, size=(32, 32))
+    assert len(output.get()) == variable_batch_size
+
+    return output,
+
+
+def test_variable_batch_size_from_external_source():
+    batch_size = 6
+    pipe = variable_batch_size_from_external_source_pipeline(batch_size)
+    pipe.build()
+    output, = pipe.run()
+    assert len(output) == batch_size
+
+
+@pipeline_def(batch_size=8, num_threads=3, device_id=0, seed=47, debug=True)
+def incorrect_variable_batch_size_from_es_pipeline():
+    rng = fn.random.coin_flip(probability=0.5)
+    src_data = np.zeros((1, 6, 64, 64, 3), dtype=np.uint8)
+    images = fn.external_source(src_data)
+    return images,
+
+
+@raises(RuntimeError, glob='Batch size must be uniform across an iteration. External Source operator returned batch with size*')
+def test_incorrect_variable_batch_size_from_es():
+    pipe = incorrect_variable_batch_size_from_es_pipeline()
+    pipe.build()
+    pipe.run()
+
+
+@pipeline_def(batch_size=8, num_threads=3, device_id=0, seed=47, debug=True)
+def incorrect_variable_batch_size_inside_es_pipeline():
+    src_data = [[[np.ones((120, 120, 3), dtype=np.uint8)]*8,
+                 [np.ones((120, 120, 3), dtype=np.float32)]*6]]
+    out1, out2 = fn.external_source(source=src_data, num_outputs=2,
+                                    dtype=[types.DALIDataType.UINT8, types.DALIDataType.FLOAT])
+    return out1, out2
+
+
+@raises(RuntimeError, glob='External source must return outputs with consistent batch size.*')
+def test_incorrect_variable_batch_size_inside_es():
+    pipe = incorrect_variable_batch_size_inside_es_pipeline()
+    pipe.build()
+    pipe.run()
+
+
+@pipeline_def(batch_size=8, num_threads=3, device_id=0, seed=47, debug=True)
+def incorrect_variable_batch_size_pipeline():
+    jpegs, labels = fn.readers.file(file_root=file_root)
+    images = fn.decoders.image(jpegs)
+    images = [images.get()[i] for i in range(6)]
+    output = fn.random_resized_crop(images, size=(224, 224))
+    return labels, output
+
+
+@raises(RuntimeError, glob='Batch size must be uniform across an iteration. Input*')
+def test_variable_batch_size():
+    pipe = incorrect_variable_batch_size_pipeline()
+    pipe.build()
+    pipe.run()


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
**New feature** (*non-breaking change which adds functionality*)
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

Adds support for NVTX ranges in eager operators.
Adds support for iteration batch size based on outputs from `external_source`.
The support is limited to cases when `external_source` is the first operator in the pipeline.

Why is it impossible/inconvenient to support `external_source` that is defined later?

For this to work we would have to have similar execution flow to the one from standard mode (fetching data from `external_source` at the start of each run). This means we would have to first build the pipeline to save all `external_source` callbacks. The problem with this approach is that because debug mode allows to access and modify the data inside the pipeline during the build we have to operate on the actual data, we cannot have some placeholders like in standard build.

Why can we not run the pipeline once to build the graph and collect `external_source` operators?

- We cannot do this in the pipeline build because `external_source` may not be fed with data.
- In the first iteration we could run the pipeline twice, once to build the graph and collect ESs, and then a regular run. That way we would introduce some possible garbage outputs from the build phase and would have to account for all possible iteration-based states (maybe someone uses some clear python code inside our pipeline that is dependent on the number of executions) and it would probably be impossible to actually catch all of these cases.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
debug mode pipeline


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [x] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
