### PR TITLE
Stop exposing internal contiguous TV storage

### DIFF
--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -62,8 +62,6 @@ class DLL_PUBLIC TensorVector {
    */
   explicit TensorVector(int batch_size);
 
-  explicit TensorVector(std::shared_ptr<TensorList<Backend>> tl);
-
   TensorVector(const TensorVector &) = delete;
   TensorVector &operator=(const TensorVector &) = delete;
 
@@ -329,8 +327,6 @@ class DLL_PUBLIC TensorVector {
   TensorVector<Backend> &operator=(TensorVector<Backend> &&other) noexcept;
 
   void UpdateViews();
-
-  shared_ptr<TensorList<Backend>> AsTensorList(bool check_contiguity = true);
 
  private:
   enum class State { contiguous, noncontiguous };

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -391,6 +391,26 @@ class DLL_PUBLIC TensorVector {
   // with different template types
   template <typename InBackend>
   friend class TensorVector;
+
+  /** @defgroup ContiguousAccessorFunctions Fallback contiguous accessors
+   * Fallback access to contiguous data or samples of the batch. It should not be used for regular
+   * processing, and can be used only for batches that were made sure to be contiguous (mainly
+   * for pipeline outputs).
+   * @{
+   */
+
+  /**
+   * @brief Return the shared pointer, that we can use to correctly share the ownership of sample
+   * with.
+   * Sample 0 is aliased with the whole buffer.
+   */
+  friend shared_ptr<void> unsafe_sample_owner(TensorVector<Backend> &batch, int sample_idx) {
+    // create new aliasing pointer to current data allocation, so we share the use count
+    // and the deleter correctly.
+    return {unsafe_sample_owner(*batch.tl_, 0), batch.raw_mutable_tensor(sample_idx)};
+  }
+
+  /** @} */  // end of ContiguousAccessorFunctions
 };
 
 }  // namespace dali

--- a/dali/pipeline/executor/executor_test.cc
+++ b/dali/pipeline/executor/executor_test.cc
@@ -110,7 +110,7 @@ TYPED_TEST(ExecutorTest, TestPruneBasicGraph) {
 
   graph.AddOp(this->PrepareSpec(
           OpSpec("MakeContiguous")
-          .AddArg("device", "cpu")
+          .AddArg("device", "mixed")
           .AddInput("data3", "cpu")
           .AddOutput("data3_cont", "cpu")), "");
 
@@ -127,8 +127,8 @@ TYPED_TEST(ExecutorTest, TestPruneBasicGraph) {
   // Validate the graph - op 3 should
   // have been pruned as its outputs
   // are unused.
-  ASSERT_EQ(graph.NumOp(OpType::CPU), 3);
-  ASSERT_EQ(graph.NumOp(OpType::MIXED), 0);
+  ASSERT_EQ(graph.NumOp(OpType::CPU), 2);
+  ASSERT_EQ(graph.NumOp(OpType::MIXED), 1);
   ASSERT_EQ(graph.NumOp(OpType::GPU), 0);
 
   // Validate the source op
@@ -176,7 +176,7 @@ TYPED_TEST(ExecutorTest, TestPruneMultiple) {
 
   graph.AddOp(this->PrepareSpec(
           OpSpec("MakeContiguous")
-          .AddArg("device", "cpu")
+          .AddArg("device", "mixed")
           .AddInput("data1", "cpu")
           .AddOutput("data1_cont", "cpu")), "");
 
@@ -207,8 +207,8 @@ TYPED_TEST(ExecutorTest, TestPruneMultiple) {
   // Validate the graph - op 2&3 should
   // have been pruned.
   // Op 4 should not be pruned
-  ASSERT_EQ(graph.NumOp(OpType::CPU), 3);
-  ASSERT_EQ(graph.NumOp(OpType::MIXED), 0);
+  ASSERT_EQ(graph.NumOp(OpType::CPU), 2);
+  ASSERT_EQ(graph.NumOp(OpType::MIXED), 1);
   ASSERT_EQ(graph.NumOp(OpType::GPU), 0);
 
   // Validate the source op
@@ -248,7 +248,7 @@ TYPED_TEST(ExecutorTest, TestPruneRecursive) {
 
   graph.AddOp(this->PrepareSpec(
           OpSpec("MakeContiguous")
-          .AddArg("device", "cpu")
+          .AddArg("device", "mixed")
           .AddInput("data1", "cpu")
           .AddOutput("data1_cont", "cpu")), "");
 
@@ -271,8 +271,8 @@ TYPED_TEST(ExecutorTest, TestPruneRecursive) {
 
   // Validate the graph - op 2&3 should
   // have been pruned
-  ASSERT_EQ(graph.NumOp(OpType::CPU), 2);
-  ASSERT_EQ(graph.NumOp(OpType::MIXED), 0);
+  ASSERT_EQ(graph.NumOp(OpType::CPU), 1);
+  ASSERT_EQ(graph.NumOp(OpType::MIXED), 1);
   ASSERT_EQ(graph.NumOp(OpType::GPU), 0);
 
   // Validate the source op
@@ -406,7 +406,7 @@ TYPED_TEST(ExecutorTest, TestRunBasicGraph) {
 
   graph.AddOp(this->PrepareSpec(
           OpSpec("MakeContiguous")
-          .AddArg("device", "cpu")
+          .AddArg("device", "mixed")
           .AddInput("images", "cpu")
           .AddOutput("final_images", "cpu")), "");
 
@@ -452,7 +452,7 @@ TYPED_TEST(ExecutorTest, TestRunBasicGraphWithCB) {
 
   graph.AddOp(this->PrepareSpec(
           OpSpec("MakeContiguous")
-          .AddArg("device", "cpu")
+          .AddArg("device", "mixed")
           .AddInput("images", "cpu")
           .AddOutput("final_images", "cpu")), "");
 

--- a/dali/pipeline/graph/op_graph_verifier.h
+++ b/dali/pipeline/graph/op_graph_verifier.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ template <>
 struct parent_constraints<OpType::GPU> {
   static constexpr OpType allowed_parents[] = {OpType::GPU, OpType::MIXED, OpType::CPU};
   static constexpr StorageDevice allowed_input_tensors[] = {StorageDevice::CPU, StorageDevice::GPU};
-  static constexpr OpType allowed_input_ops[] = {OpType::MIXED, OpType::GPU, OpType::CPU};
+  static constexpr OpType allowed_input_ops[] = {OpType::MIXED, OpType::GPU};
   static constexpr bool supports_argument_inputs = true;
 };
 

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -435,11 +435,13 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
     std::lock_guard<std::mutex> busy_lock(busy_m_);
     auto tl_elm = tl_data_.GetEmpty();
     bool copied_shared_data = false;
-    if (batch.IsContiguous()) {
-      auto &in_tl = *const_cast<TensorVector<Backend> &>(batch).AsTensorList();
-      tl_elm.front()->ShareData(in_tl);
-      zero_copy_noncontiguous_gpu_input_ = true;
-    } else {
+
+    // TODO(klecki): Add missing optimization
+    // if (batch.IsContiguous()) {
+    //   auto &in_tl = *const_cast<TensorVector<Backend> &>(batch).AsTensorList();
+    //   tl_elm.front()->ShareData(in_tl);
+    //   zero_copy_noncontiguous_gpu_input_ = true;
+    // } else {
       // it is not contiguous so we need to copy
       tl_elm.front()->Copy(batch, order, use_copy_kernel);
       std::list<uptr_cuda_event_type> copy_to_storage_event;
@@ -453,7 +455,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
                   "of memory would be trashed.");
       }
       copied_shared_data = true;
-    }
+    // }
     state_.push_back({copied_shared_data, true});
     tl_data_.PushBack(tl_elm);
   }

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -439,7 +439,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
     if (batch.IsContiguous()) {
       auto batch_owner = unsafe_sample_owner(const_cast<TensorVector<SrcBackend> &>(batch), 0);
       tl_elm.front()->ShareData(batch_owner, batch.nbytes(), batch.is_pinned(), batch.shape(),
-                                batch.type(), batch.order());
+                                batch.type(), batch.device_id(), batch.order());
       zero_copy_noncontiguous_gpu_input_ = true;
     } else {
       // it is not contiguous so we need to copy

--- a/dali/pipeline/operator/builtin/make_contiguous.cc
+++ b/dali/pipeline/operator/builtin/make_contiguous.cc
@@ -32,7 +32,6 @@ void MakeContiguousCPU::RunImpl(HostWorkspace &ws) {
   thread_pool.RunAll();
 }
 
-DALI_REGISTER_OPERATOR(MakeContiguous, MakeContiguousCPU, CPU);
 
 DALI_SCHEMA(MakeContiguous)
   .DocStr(R"code(Move input batch to a contiguous representation, more suitable for execution on the GPU)code")

--- a/dali/pipeline/operator/eager_operator.h
+++ b/dali/pipeline/operator/eager_operator.h
@@ -43,7 +43,7 @@ std::shared_ptr<TensorList<Backend>> AsTensorList(std::shared_ptr<TensorList<Bac
 
 template <typename Backend>
 std::shared_ptr<TensorList<Backend>> AsTensorList(std::shared_ptr<TensorVector<Backend>> in) {
-  // TODO(klecki): Add missing optimization
+  // TODO(klecki): [BatchObject] Add missing optimization
   // if (in->IsContiguous()) {
   //   // Filled contiguous TensorVector, we can return TensorList directly.
   //   auto tl = in->AsTensorList(false);
@@ -301,7 +301,7 @@ EagerOperator<Backend>::RunImpl(
   }
 
   for (auto &arg : kwargs) {
-    // TODO(klecki): Remove the wrapping of TensorList -> TensorVector.
+    // TODO(klecki): [BatchObject] Remove the wrapping of TensorList -> TensorVector.
     // We wrap it once before call, so that the run won't do it again. Remove when we do not
     // have distinct batch types.
     auto tmp = std::make_shared<TensorVector<CPUBackend>>();

--- a/dali/pipeline/operator/eager_operator.h
+++ b/dali/pipeline/operator/eager_operator.h
@@ -43,13 +43,14 @@ std::shared_ptr<TensorList<Backend>> AsTensorList(std::shared_ptr<TensorList<Bac
 
 template <typename Backend>
 std::shared_ptr<TensorList<Backend>> AsTensorList(std::shared_ptr<TensorVector<Backend>> in) {
-  if (in->IsContiguous()) {
-    // Filled contiguous TensorVector, we can return TensorList directly.
-    auto tl = in->AsTensorList(false);
-    // Explicitly set layout (it could be empty in case of per-sample operators).
-    tl->SetLayout(in->GetLayout());
-    return tl;
-  }
+  // TODO(klecki): Add missing optimization
+  // if (in->IsContiguous()) {
+  //   // Filled contiguous TensorVector, we can return TensorList directly.
+  //   auto tl = in->AsTensorList(false);
+  //   // Explicitly set layout (it could be empty in case of per-sample operators).
+  //   tl->SetLayout(in->GetLayout());
+  //   return tl;
+  // }
 
   auto tl = std::make_shared<TensorList<Backend>>();
   tl->Copy(*in);
@@ -300,7 +301,12 @@ EagerOperator<Backend>::RunImpl(
   }
 
   for (auto &arg : kwargs) {
-    ws_.AddArgumentInput(arg.first, arg.second);
+    // TODO(klecki): Remove the wrapping of TensorList -> TensorVector.
+    // We wrap it once before call, so that the run won't do it again. Remove when we do not
+    // have distinct batch types.
+    auto tmp = std::make_shared<TensorVector<CPUBackend>>();
+    tmp->ShareData(*arg.second);
+    ws_.AddArgumentInput(arg.first, tmp);
   }
 
   std::vector<OutputDesc> output_desc{};

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -499,7 +499,7 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
         // Add a make contiguous op to produce this output
         OpSpec spec =
           OpSpec("MakeContiguous")
-          .AddArg("device", "cpu")
+          .AddArg("device", "mixed")
           .AddInput(name, "cpu")
           .AddOutput("contiguous_" + name, "cpu");
         PrepareOpSpec(&spec, GetNextInternalLogicalId());
@@ -645,7 +645,7 @@ void Pipeline::SetupCPUInput(std::map<string, EdgeMeta>::iterator it, int input_
   if (!it->second.has_contiguous) {
     OpSpec make_contiguous_spec =
       OpSpec("MakeContiguous")
-      .AddArg("device", "cpu")
+      .AddArg("device", "mixed")
       .AddInput(it->first, "cpu")
       .AddOutput("contiguous_" + it->first, "cpu");
     // don't put it into op_specs_for_serialization_, only op_specs_


### PR DESCRIPTION
## Category: Refactoring
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->

There are few todos, look at the description.


## Description:
Remove from TensorVector the AsTensorList method
and constructor from external shared_ptr<TensorList>

Both allowed to observe the internal state of TensorVector
from the outside, breaking the encapsulation.

Most of those changes can be removed with the replacement
of TensorVector and TensorList as one common TensorBatch
object.
This refactoring is needed, so that replacement can be
done in two separate steps: refactoring the TensorVector
into the targeted TensorBatch class (one of the steps
is reduce the number of nested shared_ptrs),
and next replacing the TensorList by the refactored
class.

Adjust few places that relied on the changes of internal
state to be externally visible:
* Initializing the data graph in workspaces.
  The TV -> TL conversion is done vie Mixed stage.
* ArgumentInputs that are produced as TensorList
  need to be resynced by ShareData instead.

This reverts some changes from #2165:
  - CPU stage cannot be used as direct outputs
    due to the TensorList/TensorVector mismatch,
    we can only share data downwards, but we
    cannot share and preemptivelly expect the allocation
    to be mirrored.
  - CPU-only stage still uses Mixed stage, but just
    with MakeContigous constrained to CPU outputs.

Workspace initialization now takes the CPU_ONLY_DEVICE_ID
into consideration and does not set the stream (resulting
in has_stream() being false, which in turn keeps the
AccessOrder used in Mixed ops `RunImpl` as HostOrder only).

Just for the time of tests two optimizations with
contiguous TensorVector -> TensorList were disabled.

TODO:
Sharing contiguous TV into TL - will be made obsolete by follow up PRs.   


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
