### PR TITLE
Fix TF DALIDataset tests that changed layout between iterations

### DIFF
--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -341,9 +341,9 @@ def test_tf_dataset_layouts():
         yield check_layout, {'layout': layout, 'name': 'in'}, {'in': in_dataset}, layout
         # Captured from pipeline
         yield check_layout, {'layout': layout, 'name': 'in'}, {'in': Input(in_dataset)}, layout
-        # Overridden via experimental.Input
-        yield check_layout, {'layout': 'TO_OVERRIDE', 'name': 'in'}, {'in': Input(in_dataset, layout=layout)}, layout
-
+        # Overridden via experimental.Input, use placeholder layout of equal dimensionality
+        # TODO(banasraf): Adjust when the ability to override layouts in TF Dataset is changed
+        yield check_layout, {'layout': 'x' * len(layout), 'name': 'in'}, {'in': Input(in_dataset, layout=layout)}, layout
 
 
 # Test if the TypeError is raised for unsupported arguments for regular DALIDataset

--- a/dali/test/python/test_dali_tf_dataset_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_eager.py
@@ -341,9 +341,8 @@ def test_tf_dataset_layouts():
         yield check_layout, {'layout': layout, 'name': 'in'}, {'in': in_dataset}, layout
         # Captured from pipeline
         yield check_layout, {'layout': layout, 'name': 'in'}, {'in': Input(in_dataset)}, layout
-        # Overridden via experimental.Input, use placeholder layout of equal dimensionality
-        # TODO(banasraf): Adjust when the ability to override layouts in TF Dataset is changed
-        yield check_layout, {'layout': 'x' * len(layout), 'name': 'in'}, {'in': Input(in_dataset, layout=layout)}, layout
+        # Set via experimental.Input, not specified in external source
+        yield check_layout, {'name': 'in'}, {'in': Input(in_dataset, layout=layout)}, layout
 
 
 # Test if the TypeError is raised for unsupported arguments for regular DALIDataset


### PR DESCRIPTION
## Category: Bug fix
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
DALI assumes that the input will have the dimensionality
inferred from the layout passed to external source operator.

TF DALIDataset allows to specify input and override
the previously specified layout - which could change
the dimensionality. As changing the dimensionality
is not allowed this leads to error in tests.

TODO: Adjust the API by either disallowing
to override the layout or allow it only when initial
layout is empty. Introduce better error checking
that would detect that situation.




## Additional information:

### Affected modules and functionalities:
TF Test



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
