### PR TITLE
Fix trailing newlines in operator arguments docs

### DIFF
--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -129,7 +129,7 @@ def _get_kwargs(schema):
                     default_value_string = schema.GetArgumentDefaultValueString(arg)
                     default_value = ast.literal_eval(default_value_string)
                     type_name += ", default = `{}`".format(_default_converter(dtype, default_value))
-            doc += schema.GetArgumentDox(arg)
+            doc += schema.GetArgumentDox(arg).rstrip("\n")
             if schema.ArgSupportsPerFrameInput(arg):
                 doc += "\n\nSupports :func:`per-frame<nvidia.dali.fn.per_frame>` inputs."
             if deprecation_warning:


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
**Other** (*e.g. Documentation, Tests, Configuration*)



## Description:
Fixes an issue with operators named arguments documentation. If the argument's C++ docstring ends in a new line, the Python code that generates documentation may end up adding too much new lines separating the docstring and auto-generated remarks to the argument, which in effect leads to incorrect parsing of the whole docstring by Sphinx. See the example below:
`Supports per-frame inputs` is appended by Python docs generator to both `angle` and `axis` arguments, but the second one has trailing newlines in C++ definition, which leads to incorrectly parsed docs as in the second picture.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
With the PR:
![fixed](https://user-images.githubusercontent.com/11878086/164778092-276e6c02-6c2e-4d1b-9fdb-852dfddc686a.png)

Without the PR:
![overindented](https://user-images.githubusercontent.com/11878086/164778101-448a5a62-b97f-4a29-a576-dcf399a9d37d.png)




## Additional information:

### Affected modules and functionalities:
It's a one liner in Python docs generating script.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2751
<!--- DALI-XXXX or NA --->
