### PR TITLE
Add a check of the decoding progress in the VideoReader

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -566,9 +566,9 @@ void VideoLoader::read_file() {
 
       // if decoding hasn't produced any frames after providing kStartupFrameTreshold frames,
       // or we are at next key frame
-      if (((last_key_frame != -1 && key && last_key_frame != frame)
-            || frame > last_key_frame + kStartupFrameTreshold)
-              && dec_status == VidReqStatus::REQ_NOT_STARTED) {
+      if (last_key_frame != -1 &&
+          ((key && last_key_frame != frame) || frame > last_key_frame + kStartupFrameTreshold) &&
+          dec_status == VidReqStatus::REQ_NOT_STARTED) {
         LOG_LINE << "Decoding not started, seek to preceding key frame, "
                  << "current frame " << frame
                  << ", last key frame " << last_key_frame

--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -568,9 +568,9 @@ void VideoLoader::read_file() {
         last_key_frame = frame;
       }
 
-      // if decoding hasn't produced any frames after providing 10 frames,
+      // if decoding hasn't produced any frames after providing startup_frame_treshold_ frames,
       // or we are at next key frame
-      if (((key && frame != last_key_frame) || frame > last_key_frame + 10)
+      if (((key && frame != last_key_frame) || frame > last_key_frame + startup_frame_treshold_)
             && dec_status == REQ_NOT_STARTED) {
         LOG_LINE << "Decoding not started, seek to preceding key frame, "
                  << "current frame " << frame

--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -536,6 +536,7 @@ void VideoLoader::read_file() {
     std::vector<bool> frames_read(frames_left, false);
 
     bool is_first_frame = true;
+    int last_key_frame = -1;
     bool key = false;
     bool seek_must_succeed = false;
     // how many key frames following the last requested frames we saw so far
@@ -543,6 +544,7 @@ void VideoLoader::read_file() {
     // how many key frames following the last requested frames we need to see before we stop
     // feeding the decoder
     const int key_frames_treshold = 2;
+    VidReqStatus dec_status = REQ_IN_PROGRESS;
 
     while (av_read_frame(file.fmt_ctx_.get(), &raw_pkt) >= 0) {
       auto pkt = pkt_ptr(&raw_pkt, av_packet_unref);
@@ -561,6 +563,24 @@ void VideoLoader::read_file() {
 
       file.last_frame_ = frame;
       key = (pkt->flags & AV_PKT_FLAG_KEY) != 0;
+
+      if (key) {
+        last_key_frame = frame;
+      }
+
+      // if decoding hasn't produced any frames after providing 10 frames,
+      // or we are at next key frame
+      if (((key && frame != last_key_frame) || frame > last_key_frame + 10)
+            && dec_status == REQ_NOT_STARTED) {
+        LOG_LINE << "Decoding not started, seek to preceding key frame, "
+                 << "current frame " << frame
+                 << ", last key frame " << last_key_frame
+                 << ", is_key " << key << std::endl;
+        seek(file, last_key_frame - 1);
+        last_key_frame = -1;
+        continue;
+      }
+
       int pkt_frames = 1;
       if (pkt->duration) {
         pkt_frames = av_rescale_q(pkt->duration, file.stream_base_, file.frame_base_);
@@ -584,37 +604,13 @@ void VideoLoader::read_file() {
           if (req.frame > seek_hack) {
             seek(file, req.frame - seek_hack);
             seek_hack *= 2;
+            last_key_frame = -1;
           } else {
             seek_must_succeed = true;
             seek(file, 0);
+            last_key_frame = -1;
           }
           continue;
-      }
-      if (frame > req.frame) {
-        if (key) {
-          if (!is_first_frame) {
-            nonkey_frame_count = 0;
-            if (frame > req.frame + req.count) {
-              // Found a second key frame past the requested range. We can stop searching
-              // (If there were missing frames in the range they won't be found after
-              // the next key frame)
-              // in case HEVC it seems that preceding frames can appear after a given key frame
-              // but rather not after the next one
-              if (key_frames_count >= key_frames_treshold) {
-                key_frames_count = 0;
-                break;
-              }
-              ++key_frames_count;
-            }
-          }
-          seek_must_succeed = false;
-        } else {
-          nonkey_frame_count += pkt_frames;
-          // A heuristic so we don't go way over... what should "20" be?
-          if (frames_left <= 0 && frame > req.frame + req.count + 20) {
-            break;
-          }
-        }
       }
 
       if (frame >= req.frame && frame < req.frame + req.count) {
@@ -650,7 +646,7 @@ void VideoLoader::read_file() {
         }
         while ((ret = av_bsf_receive_packet(file.bsf_ctx_.get(), &raw_filtered_pkt)) == 0) {
           auto fpkt = pkt_ptr(&raw_filtered_pkt, av_packet_unref);
-          vid_decoder_->decode_packet(fpkt.get(), file.start_time_, file.stream_base_,
+          dec_status = vid_decoder_->decode_packet(fpkt.get(), file.start_time_, file.stream_base_,
                                       codecpar(stream));
         }
         if (ret != AVERROR(EAGAIN)) {
@@ -688,14 +684,18 @@ void VideoLoader::read_file() {
           }
           *pkt.get() = fpkt;
         }
-        vid_decoder_->decode_packet(pkt.get(), file.start_time_, file.stream_base_,
+        dec_status = vid_decoder_->decode_packet(pkt.get(), file.start_time_, file.stream_base_,
                                     codecpar(stream));
 #endif
       } else {
-        vid_decoder_->decode_packet(pkt.get(), file.start_time_, file.stream_base_,
+        dec_status = vid_decoder_->decode_packet(pkt.get(), file.start_time_, file.stream_base_,
                                     codecpar(stream));
       }
       is_first_frame = false;
+      if (dec_status == REQ_READY) {
+        LOG_LINE << "Request completted: " << dec_status << std::endl;
+        break;
+      }
     }
 
     // flush the decoder

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -354,7 +354,7 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   int additional_decode_surfaces_;
   static constexpr int channels_ = 3;
   // 10 is rather an arbitrary decision
-  static constexpr int startup_frame_treshold_ = 10;
+  static constexpr int kStartupFrameTreshold = 10;
   DALIImageType image_type_;
   DALIDataType dtype_;
   bool normalized_;

--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -353,6 +353,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
   int max_width_;
   int additional_decode_surfaces_;
   static constexpr int channels_ = 3;
+  // 10 is rather an arbitrary decision
+  static constexpr int startup_frame_treshold_ = 10;
   DALIImageType image_type_;
   DALIDataType dtype_;
   bool normalized_;

--- a/dali/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/operators/reader/nvdecoder/nvdecoder.h
@@ -73,6 +73,13 @@ enum ScaleMethod {
     ScaleMethod_Linear
 };
 
+
+enum VidReqStatus {
+  REQ_READY = 0,
+  REQ_IN_PROGRESS,
+  REQ_NOT_STARTED,
+};
+
 class NvDecoder {
  public:
   NvDecoder(int device_id,
@@ -101,7 +108,7 @@ class NvDecoder {
   static int handle_decode(void* user_data, CUVIDPICPARAMS* pic_params);
   static int handle_display(void* user_data, CUVIDPARSERDISPINFO* disp_info);
 
-  int decode_packet(AVPacket* pkt, int64_t start_time, AVRational stream_base,
+  VidReqStatus decode_packet(AVPacket* pkt, int64_t start_time, AVRational stream_base,
                     const CodecParameters*);
 
   void push_req(FrameReq req);
@@ -111,7 +118,7 @@ class NvDecoder {
   void finish();
 
  private:
-  int decode_av_packet(AVPacket* pkt, int64_t start_time, AVRational stream_base);
+  VidReqStatus decode_av_packet(AVPacket* pkt, int64_t start_time, AVRational stream_base);
 
   void record_sequence_event_(SequenceWrapper& sequence);
 
@@ -189,6 +196,7 @@ class NvDecoder {
   ThreadSafeQueue<FrameReq> recv_queue_;
   ThreadSafeQueue<CUVIDPARSERDISPINFO*> frame_queue_;
   FrameReq current_recv_;
+  VidReqStatus req_ready_;
 
   using TexID = std::tuple<uint8_t*, ScaleMethod, uint16_t, uint16_t, unsigned int>;
 

--- a/dali/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/operators/reader/nvdecoder/nvdecoder.h
@@ -74,7 +74,7 @@ enum ScaleMethod {
 };
 
 
-enum VidReqStatus {
+enum class VidReqStatus {
   REQ_READY = 0,
   REQ_IN_PROGRESS,
   REQ_NOT_STARTED,
@@ -109,7 +109,7 @@ class NvDecoder {
   static int handle_display(void* user_data, CUVIDPARSERDISPINFO* disp_info);
 
   VidReqStatus decode_packet(AVPacket* pkt, int64_t start_time, AVRational stream_base,
-                    const CodecParameters*);
+                             const CodecParameters*);
 
   void push_req(FrameReq req);
 


### PR DESCRIPTION
- adds a variable that is used to pass the decoding progress
  status from handle_display_ to decode_av_packet. The additional
  variable is needed as the returned value from handle_display_
  is not propagated directly to the cuvidParseVideoData from
  the corresponding callbacks.
- adds an ability to stop decoding when all desired frames from
  the sequence is decoded - it removes the previous heuristic
- adds an ability to indirectly detect when a keyframe is not IDR
  (while FFmpeg can, NVDEC cannot resume decoding from such frame)
  and DALI needs to seek to the previous keyframe in the hope it
  is the IDR one

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
**Other** (*e.g. Documentation, Tests, Configuration*) 



## Description:
- adds a variable that is used to pass the decoding progress
  status from handle_display_ to decode_av_packet. The additional
  variable is needed as the returned value from handle_display_
  is not propagated directly to the cuvidParseVideoData from
  the corresponding callbacks.
- adds an ability to stop decoding when all desired frames from
  the sequence is decoded - it removes the previous heuristic
- adds an ability to indirectly detect when a keyframe is not IDR
  (while FFmpeg can, NVDEC cannot resume decoding from such frame)
  and DALI needs to seek to the previous keyframe in the hope it
  is the IDR one
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- video reader
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- logic flow
<!--- Describe here what is the most important part that reviewers should focus on. --->



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
