### PR TITLE
Make libtar and libsnd root paths customizable.

### DIFF
--- a/cmake/Dependencies.common.cmake
+++ b/cmake/Dependencies.common.cmake
@@ -102,7 +102,7 @@ endif()
 if(BUILD_LIBSND)
   find_library(libsnd_LIBS
           NAMES sndfile libsndfile
-          PATHS ${CMAKE_SYSTEM_PREFIX_PATH} ${LIBSND_ROOT_DIR} "/usr/local"
+          PATHS ${LIBSND_ROOT_DIR} "/usr/local" ${CMAKE_SYSTEM_PREFIX_PATH}
           PATH_SUFFIXES lib lib64)
   if(${libsnd_LIBS} STREQUAL libsnd_LIBS-NOTFOUND)
     message(FATAL_ERROR "libsnd (sndfile) could not be found. Try to specify it's location with `-DLIBSND_ROOT_DIR`.")
@@ -117,7 +117,7 @@ endif()
 if(BUILD_LIBTAR)
   find_library(libtar_LIBS
           NAMES libtar.a tar libtar
-          PATHS ${CMAKE_SYSTEM_PREFIX_PATH} ${LIBTAR_ROOT_DIR} "/usr/local"
+          PATHS ${LIBTAR_ROOT_DIR} "/usr/local" ${CMAKE_SYSTEM_PREFIX_PATH}
           PATH_SUFFIXES lib lib64)
   if(${libtar_LIBS} STREQUAL libtar_LIBS-NOTFOUND)
     message(FATAL_ERROR "libtar could not be found. Try to specify it's location with `-DLIBTAR_ROOT_DIR`.")


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
**Bug fix** (*non-breaking change which fixes an issue*)
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
The library paths for libsnd and libtar could not be customized with `-DLIBTAR_ROOT_DIR` and `-DLIBSND_ROOT_DIR`, because the default system directory was placed first in the list of search paths. This PR changes the order to the following:
1. LIBxxx_ROOT_DIR
2. /usr/local (rationale: that's where your library custom-built libraries will likely land after make install)
3. system default

## Additional information:

### Affected modules and functionalities:
Linkage of libtar and libsndfile


### Key points relevant for the review:
N/A

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
