### PR TITLE
Fix corruption: Change bool to int when querying pointer attributes.

### DIFF
--- a/dali/core/mm/cu_vm_test.cc
+++ b/dali/core/mm/cu_vm_test.cc
@@ -35,7 +35,7 @@ TEST(CUMemAddressRange, Reserve) {
   };
   CUdeviceptr start = 0;
   size_t size = 0;
-  bool mapped = false;
+  int mapped = 0;
   void *data[3] = { &start, &size, &mapped };
   CUDA_CALL(cuPointerGetAttributes(3, attrs, data, range.ptr() + 100));
   EXPECT_EQ(start, range.ptr());
@@ -61,7 +61,7 @@ TEST(CUMemAddressRange, ReserveAndMap) {
   };
   CUdeviceptr start = 0;
   size_t size = 0;
-  bool mapped = false;
+  int mapped = 0;
   void *data[3] = { &start, &size, &mapped };
   void *ptr = cuvm::Map(base, mem);
   EXPECT_EQ(ptr, reinterpret_cast<void*>(base));
@@ -97,7 +97,7 @@ TEST(CUMemAddressRange, ReserveAndMapPiecewise) {
   };
   CUdeviceptr start = 0;
   size_t size = 0;
-  bool mapped = false;
+  int mapped = 0;
   void *data[3] = { &start, &size, &mapped };
   void *ptr1 = cuvm::Map(base, mem1);
   void *ptr2 = cuvm::Map(base + phys_size, mem2);


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
 **Bug fix** (*non-breaking change which fixes an issue*)
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
When querying pointer attributes, the boolean value is actually stored as an int. Passing a pointer to a bool caused stack corruption. This manifested itself in the value of another attribute being corrupted.

The **bug affected tests only**.

## Additional information:

### Affected modules and functionalities:
CUDA vm test



### Key points relevant for the review:
N/A



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
