### PR TITLE
Add `output_dtype` and `output_ndim` arguments to Pipeline constructor

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -512,6 +512,16 @@ size_t daliMaxDimTensors(daliPipelineHandle* pipe_handle, int n) {
   }
 }
 
+size_t daliGetDeclaredOutputNdim(daliPipelineHandle *pipe_handle, int n) {
+  dali::Pipeline *pipeline = reinterpret_cast<dali::Pipeline *>(pipe_handle->pipe);
+  return pipeline->output_ndim(n);
+}
+
+dali_data_type_t daliGetDeclaredOutputDtype(daliPipelineHandle *pipe_handle, int n) {
+  dali::Pipeline *pipeline = reinterpret_cast<dali::Pipeline *>(pipe_handle->pipe);
+  return static_cast<dali_data_type_t>(static_cast<int>(pipeline->output_dtype(n)));
+}
+
 unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle) {
   dali::Pipeline *pipeline = reinterpret_cast<dali::Pipeline *>(pipe_handle->pipe);
   return pipeline->num_outputs();

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -122,7 +122,7 @@ std::unique_ptr<Pipeline> GetTestPipeline(bool is_file_reader, const std::string
 
   std::vector<std::pair<std::string, std::string>> outputs = {{output_name, output_device}};
 
-  pipe.SetOutputNames(outputs);
+  pipe.SetOutputDescs(outputs);
   return pipe_ptr;
 }
 
@@ -149,7 +149,7 @@ std::unique_ptr<Pipeline> GetExternalSourcePipeline(bool no_copy, const std::str
 
   std::vector<std::pair<std::string, std::string>> outputs = {{output_name, device}};
 
-  pipe.SetOutputNames(outputs);
+  pipe.SetOutputDescs(outputs);
   return pipe_ptr;
 }
 
@@ -239,7 +239,7 @@ TYPED_TEST(CApiTest, GetOutputNameTest) {
   std::vector<std::pair<std::string, std::string>> outputs = {{output0_name, "cpu"},
                                                               {output1_name, "cpu"}};
 
-  pipe.SetOutputNames(outputs);
+  pipe.SetOutputDescs(outputs);
 
   auto serialized = pipe.SerializeToProtobuf();
 
@@ -989,7 +989,7 @@ TEST(CApiTest, CpuOnlyTest) {
   dali::Pipeline pipe(1, 1, dali::CPU_ONLY_DEVICE_ID);
   pipe.AddExternalInput("dummy");
   std::vector<std::pair<std::string, std::string>> outputs = {{"dummy", "cpu"}};
-  pipe.SetOutputNames(outputs);
+  pipe.SetOutputDescs(outputs);
   std::string ser = pipe.SerializeToProtobuf();
   daliPipelineHandle handle;
   daliDeserializeDefault(&handle, ser.c_str(), ser.size());
@@ -1010,7 +1010,7 @@ TEST(CApiTest, GetBackendTest) {
                           .AddOutput(cont_name, "gpu"), cont_name);
   std::vector<std::pair<std::string, std::string>> outputs = {{es_gpu_name, "gpu"},
                                                               {cont_name, "gpu"}};
-  pipe.SetOutputNames(outputs);
+  pipe.SetOutputDescs(outputs);
   std::string ser = pipe.SerializeToProtobuf();
   daliPipelineHandle handle;
   daliDeserializeDefault(&handle, ser.c_str(), ser.size());

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -1054,12 +1054,29 @@ TEST(CApiTest, GetMaxBatchSizeTest) {
   const int BS = 13;
   dali::Pipeline pipe(BS, 1, 0);
   pipe.AddExternalInput("INPUT", "cpu", DALI_FLOAT16, 3, "HWC");
-  pipe.SetOutputNames({{"INPUT", "cpu"}});
+  pipe.SetOutputDescs({{"INPUT", "cpu"}});
   std::string ser = pipe.SerializeToProtobuf();
   daliPipelineHandle handle;
   daliDeserializeDefault(&handle, ser.c_str(), ser.size());
 
   EXPECT_EQ(daliGetMaxBatchSize(&handle), BS);
+
+  daliDeletePipeline(&handle);
+}
+
+TEST(CApiTest, GetDeclaredOutputDtypeNdimTest) {
+  const DALIDataType dtype = DALIDataType::DALI_UINT8;
+  const dali_data_type_t ref_dtype = dali_data_type_t::DALI_UINT8;
+  const int ndim = 2;
+  dali::Pipeline pipe(13, 1, 0);
+  pipe.AddExternalInput("INPUT", "cpu", DALI_FLOAT16, 3, "HWC");
+  pipe.SetOutputDescs({{"INPUT", "cpu", dtype, ndim}});
+  std::string ser = pipe.SerializeToProtobuf();
+  daliPipelineHandle handle;
+  daliDeserializeDefault(&handle, ser.c_str(), ser.size());
+
+  EXPECT_EQ(daliGetDeclaredOutputDtype(&handle, 0), ref_dtype);
+  EXPECT_EQ(daliGetDeclaredOutputNdim(&handle, 0), ndim);
 
   daliDeletePipeline(&handle);
 }

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -1026,7 +1026,7 @@ TEST(CApiTest, GetESDetailsTest) {
   pipe.AddExternalInput("INPUT1", "gpu", DALI_UINT32, -1, "NHWC");
   pipe.AddExternalInput("INPUT2", "cpu");
 
-  pipe.SetOutputNames({{"INPUT3", "cpu"}, {"INPUT1", "gpu"}, {"INPUT2", "cpu"}});
+  pipe.SetOutputDescs({{"INPUT3", "cpu"}, {"INPUT1", "gpu"}, {"INPUT2", "cpu"}});
   std::string ser = pipe.SerializeToProtobuf();
   daliPipelineHandle handle;
   daliDeserializeDefault(&handle, ser.c_str(), ser.size());

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -214,6 +214,68 @@ inline const char *GetBuiltinTypeName(DALIDataType t) {
   }
 }
 
+inline DALIDataType GetBuiltinDataType(const std::string &type_name) {
+  if (type_name == "<no_type>")
+    return DALI_NO_TYPE;
+  if (type_name == "uint8")
+    return DALI_UINT8;
+  if (type_name == "uint16")
+    return DALI_UINT16;
+  if (type_name == "uint32")
+    return DALI_UINT32;
+  if (type_name == "uint64")
+    return DALI_UINT64;
+  if (type_name == "int8")
+    return DALI_INT8;
+  if (type_name == "int16")
+    return DALI_INT16;
+  if (type_name == "int32")
+    return DALI_INT32;
+  if (type_name == "int64")
+    return DALI_INT64;
+  if (type_name == "float16")
+    return DALI_FLOAT16;
+  if (type_name == "float")
+    return DALI_FLOAT;
+  if (type_name == "double")
+    return DALI_FLOAT64;
+  if (type_name == "bool")
+    return DALI_BOOL;
+  if (type_name == "string")
+    return DALI_STRING;
+  if (type_name == "list of bool")
+    return DALI_BOOL_VEC;
+  if (type_name == "list of int")
+    return DALI_INT_VEC;
+  if (type_name == "list of string")
+    return DALI_STRING_VEC;
+  if (type_name == "list of float")
+    return DALI_FLOAT_VEC;
+#ifdef DALI_BUILD_PROTO3
+  if (type_name == "TFUtil::Feature")
+    return DALI_TF_FEATURE;
+  if (type_name == "list of TFUtil::Feature")
+    return DALI_TF_FEATURE_VEC;
+  if (type_name == "dictionary of TFUtil::Feature")
+    return DALI_TF_FEATURE_DICT;
+#endif  // DALI_BUILD_PROTO3
+  if (type_name == "DALIImageType")
+    return DALI_IMAGE_TYPE;
+  if (type_name == "DALIDataType")
+    return DALI_DATA_TYPE;
+  if (type_name == "DALIInterpType")
+    return DALI_INTERP_TYPE;
+  if (type_name == "TensorLayout")
+    return DALI_TENSOR_LAYOUT;
+  if (type_name == "Python object")
+    return DALI_PYTHON_OBJECT;
+  if (type_name == "list of TensorLayout")
+    return DALI_TENSOR_LAYOUT_VEC;
+  if (type_name == "list of DALIDataType")
+    return DALI_DATA_TYPE_VEC;
+  return DALI_NO_TYPE;
+}
+
 inline std::string to_string(DALIDataType dtype);
 inline std::ostream &operator<<(std::ostream &, DALIDataType dtype);
 

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -87,6 +87,11 @@ inline Copier GetCopier() {
 /**
  * @brief Enum identifiers for the different data types that
  * the pipeline can output.
+ *
+ * IMPORTANT: This enum is used for serialization of DALI Pipeline. Therefore, any change made to
+ * this enum must retain backward compatibility. If the backward compatibility is broken
+ * (e.g. values of enumerations are shuffled), the already serialized pipelines
+ * around the globe will stop working correctly.
  */
 enum DALIDataType : int {
   DALI_NO_TYPE           = -1,
@@ -212,68 +217,6 @@ inline const char *GetBuiltinTypeName(DALIDataType t) {
     default:
       return nullptr;
   }
-}
-
-inline DALIDataType GetBuiltinDataType(const std::string &type_name) {
-  if (type_name == "<no_type>")
-    return DALI_NO_TYPE;
-  if (type_name == "uint8")
-    return DALI_UINT8;
-  if (type_name == "uint16")
-    return DALI_UINT16;
-  if (type_name == "uint32")
-    return DALI_UINT32;
-  if (type_name == "uint64")
-    return DALI_UINT64;
-  if (type_name == "int8")
-    return DALI_INT8;
-  if (type_name == "int16")
-    return DALI_INT16;
-  if (type_name == "int32")
-    return DALI_INT32;
-  if (type_name == "int64")
-    return DALI_INT64;
-  if (type_name == "float16")
-    return DALI_FLOAT16;
-  if (type_name == "float")
-    return DALI_FLOAT;
-  if (type_name == "double")
-    return DALI_FLOAT64;
-  if (type_name == "bool")
-    return DALI_BOOL;
-  if (type_name == "string")
-    return DALI_STRING;
-  if (type_name == "list of bool")
-    return DALI_BOOL_VEC;
-  if (type_name == "list of int")
-    return DALI_INT_VEC;
-  if (type_name == "list of string")
-    return DALI_STRING_VEC;
-  if (type_name == "list of float")
-    return DALI_FLOAT_VEC;
-#ifdef DALI_BUILD_PROTO3
-  if (type_name == "TFUtil::Feature")
-    return DALI_TF_FEATURE;
-  if (type_name == "list of TFUtil::Feature")
-    return DALI_TF_FEATURE_VEC;
-  if (type_name == "dictionary of TFUtil::Feature")
-    return DALI_TF_FEATURE_DICT;
-#endif  // DALI_BUILD_PROTO3
-  if (type_name == "DALIImageType")
-    return DALI_IMAGE_TYPE;
-  if (type_name == "DALIDataType")
-    return DALI_DATA_TYPE;
-  if (type_name == "DALIInterpType")
-    return DALI_INTERP_TYPE;
-  if (type_name == "TensorLayout")
-    return DALI_TENSOR_LAYOUT;
-  if (type_name == "Python object")
-    return DALI_PYTHON_OBJECT;
-  if (type_name == "list of TensorLayout")
-    return DALI_TENSOR_LAYOUT_VEC;
-  if (type_name == "list of DALIDataType")
-    return DALI_DATA_TYPE_VEC;
-  return DALI_NO_TYPE;
 }
 
 inline std::string to_string(DALIDataType dtype);

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -425,6 +425,10 @@ void Pipeline::PropagateMemoryHint(OpNode &node) {
   }
 }
 
+void Pipeline::Build() {
+  Build(this->output_descs_);
+}
+
 void Pipeline::Build(const vector<std::pair<string, string>>& output_names) {
   std::vector<PipelineOutputDesc> output_descs = {output_names.begin(), output_names.end()};
   this->Build(output_descs);

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -545,17 +545,14 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
   built_ = true;
 }
 
-void Pipeline::SetOutputNames(const vector<std::pair<string, string>> &output_names) {
-  DALI_ENFORCE(output_descs_.empty() || output_descs_.size() == output_names.size());
-  if (output_descs_.empty()) {
-    output_descs_ = {output_names.begin(), output_names.end()};
-  } else {
-    assert(output_descs_.size() == output_names.size());
-    for (size_t i = 0; i < output_names.size(); i++) {
-      output_descs_[i].name = output_names[i].first;
-      output_descs_[i].device = output_names[i].second;
-    }
-  }
+
+void Pipeline::SetOutputDescs(const vector<std::pair<string, string>> &output_names) {
+  DALI_ENFORCE(output_descs_.empty(), "Resetting output_descs_ is forbidden.");
+  output_descs_ = {output_names.begin(), output_names.end()};
+}
+
+void Pipeline::SetOutputDescs(std::vector<PipelineOutputDesc> output_descs) {
+  output_descs_ = std::move(output_descs);
 }
 
 void Pipeline::RunCPU() {
@@ -761,11 +758,6 @@ string Pipeline::SerializeToProtobuf() const {
   pipe.set_device_id(this->device_id_);
   string output = pipe.SerializeAsString();
 
-#ifndef NDEBUG
-  // print out debug string
-  printf("%s\n", pipe.DebugString().c_str());
-#endif
-
   return output;
 }
 
@@ -887,6 +879,10 @@ int Pipeline::num_inputs() const {
 int Pipeline::num_outputs() const {
   DALI_ENFORCE(built_, "\"Build()\" must be called prior to calling \"num_outputs()\".");
   return output_descs_.size();
+}
+
+std::vector<PipelineOutputDesc> Pipeline::output_descs() const {
+  return output_descs_;
 }
 
 void Pipeline::SaveGraphToDotFile(const std::string &filename, bool show_tensors, bool show_ids,

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -548,7 +548,6 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
 
 void Pipeline::SetOutputNames(const vector<std::pair<string, string>> &output_names) {
   DALI_ENFORCE(output_descs_.empty() || output_descs_.size() == output_names.size());
-  // TODO DALI ENFORMCE assert
   if (output_descs_.empty()) {
     output_descs_ = {output_names.begin(), output_names.end()};
   } else {

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -94,8 +94,7 @@ void DeserializeOpSpec(const dali_proto::OpDef &def, OpSpec *spec) {
 Pipeline::Pipeline(const string &serialized_pipe, int batch_size, int num_threads, int device_id,
                    bool pipelined_execution, int prefetch_queue_depth, bool async_execution,
                    size_t bytes_per_sample_hint, bool set_affinity, int max_num_stream,
-                   int default_cuda_stream_priority, const std::vector<DALIDataType> &output_dtype,
-                   const std::vector<int> &output_ndim, int64_t seed)
+                   int default_cuda_stream_priority, int64_t seed)
     : built_(false), separated_execution_(false) {
   dali_proto::PipelineDef def;
   DALI_ENFORCE(DeserializePipeline(serialized_pipe, def), "Error parsing serialized pipeline.");

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -550,11 +550,18 @@ void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
 
 
 void Pipeline::SetOutputDescs(const vector<std::pair<string, string>> &output_names) {
-  DALI_ENFORCE(output_descs_.empty(), "Resetting output_descs_ is forbidden.");
+  DALI_ENFORCE(
+      output_descs_.empty(),
+      "Resetting output_descs_ providing only name and device is forbidden. If you want to reset "
+      "the output_descs_, please use the `SetOutputDescs(vector<PipelineOutputDesc>)`.");
   output_descs_ = {output_names.begin(), output_names.end()};
 }
 
 void Pipeline::SetOutputDescs(std::vector<PipelineOutputDesc> output_descs) {
+  DALI_ENFORCE(output_descs_.empty() || output_descs_ == output_descs,
+               make_string("Once set, changing values of `output_descs_` is forbidden. "
+                           "`SetOutputDescs` may be invoked multiple times, with the argument "
+                           "equal to existing `output_descs_`.\nReceived:\n", output_descs));
   output_descs_ = std::move(output_descs);
 }
 

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -94,9 +94,8 @@ void DeserializeOpSpec(const dali_proto::OpDef &def, OpSpec *spec) {
 Pipeline::Pipeline(const string &serialized_pipe, int batch_size, int num_threads, int device_id,
                    bool pipelined_execution, int prefetch_queue_depth, bool async_execution,
                    size_t bytes_per_sample_hint, bool set_affinity, int max_num_stream,
-                   int default_cuda_stream_priority, int64_t seed,
-                   const std::vector<DALIDataType> &output_dtype,
-                   const std::vector<int> &output_ndim)
+                   int default_cuda_stream_priority, const std::vector<DALIDataType> &output_dtype,
+                   const std::vector<int> &output_ndim, int64_t seed)
     : built_(false), separated_execution_(false) {
   dali_proto::PipelineDef def;
   DALI_ENFORCE(DeserializePipeline(serialized_pipe, def), "Error parsing serialized pipeline.");
@@ -147,7 +146,7 @@ Pipeline::Pipeline(const string &serialized_pipe, int batch_size, int num_thread
     // output names
     for (auto &output : def.pipe_outputs()) {
       this->output_descs_.emplace_back(output.name(), output.device(),
-                                       GetBuiltinDataType(output.dtype()), output.ndim());
+                                       static_cast<DALIDataType>(output.dtype()), output.ndim());
     }
 }
 
@@ -756,7 +755,7 @@ string Pipeline::SerializeToProtobuf() const {
     out->set_name(output.name);
     out->set_device(output.device);
     out->set_is_argument_input(false);
-    out->set_dtype(GetBuiltinTypeName(output.dtype));
+    out->set_dtype(output.dtype);
     out->set_ndim(output.ndim);
   }
   pipe.set_device_id(this->device_id_);

--- a/dali/pipeline/pipeline.cc
+++ b/dali/pipeline/pipeline.cc
@@ -432,7 +432,7 @@ void Pipeline::Build(const vector<std::pair<string, string>>& output_names) {
 
 void Pipeline::Build(std::vector<PipelineOutputDesc> output_descs) {
   DeviceGuard d(device_id_);
-  output_descs_ = std::move(output_descs);
+  SetOutputDescs(std::move(output_descs));
   DALI_ENFORCE(!built_, "\"Build()\" can only be called once.");
   auto num_outputs = output_descs_.size();
   DALI_ENFORCE(num_outputs > 0,
@@ -572,21 +572,18 @@ void Pipeline::SetCompletionCallback(ExecutorBase::ExecutorCallback cb) {
 }
 
 bool Pipeline::ValidateOutputs(const DeviceWorkspace &ws) const {
-  DALI_ENFORCE(
-      ws.NumOutput() == static_cast<int>(output_descs_.size()),
-      make_string("Inconsistent output description. Number of outputs does not match. Expected: ",
-                  output_descs_.size(), ". Received: ", ws.NumOutput(), "."));
+  DALI_ENFORCE(ws.NumOutput() == static_cast<int>(output_descs_.size()),
+               make_string("Number of outputs does not match. Expected: ", output_descs_.size(),
+                           ". Received: ", ws.NumOutput(), "."));
   for (int i = 0; i < ws.NumOutput(); i++) {
-    DALI_ENFORCE(
-        ws.GetOutputDim(i) == output_descs_[i].ndim || output_descs_[i].ndim == -1,
-        make_string("Inconsistent output description. Number of dimensions in the output_idx=", i,
-                    " does not match. Expected: ", output_descs_[i].ndim,
-                    ". Received: ", ws.GetOutputDim(i), "."));
+    DALI_ENFORCE(ws.GetOutputDim(i) == output_descs_[i].ndim || output_descs_[i].ndim == -1,
+                 make_string("Number of dimensions in the output_idx=", i,
+                             " does not match. Expected: ", output_descs_[i].ndim,
+                             ". Received: ", ws.GetOutputDim(i), "."));
     DALI_ENFORCE(
         ws.GetOutputDataType(i) == output_descs_[i].dtype || output_descs_[i].dtype == DALI_NO_TYPE,
-        make_string("Inconsistent output description. Data type of int the output_idx=", i,
-                    " does not match. Expected: ", output_descs_[i].dtype,
-                    ". Received: ", ws.GetOutputDataType(i), "."));
+        make_string("Data type in the output_idx=", i, " does not match. Expected: ",
+                    output_descs_[i].dtype, ". Received: ", ws.GetOutputDataType(i), "."));
   }
   return true;
 }

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -273,9 +273,7 @@ class DLL_PUBLIC Pipeline {
   /**
    * @brief Build a pipeline from deserialized output (name, device) pairs
    */
-  DLL_PUBLIC void Build() {
-    Build(this->output_descs_);
-  }
+  DLL_PUBLIC void Build();
 
   /**
    * @brief Set execution characteristics for this Pipeline

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -105,8 +105,8 @@ class DLL_PUBLIC Pipeline {
                       int prefetch_queue_depth = 2, bool async_execution = true,
                       size_t bytes_per_sample_hint = 0, bool set_affinity = false,
                       int max_num_stream = -1, int default_cuda_stream_priority = 0,
-                      int64_t seed = -1, const std::vector<DALIDataType> &output_dtype = {},
-                      const std::vector<int> &output_ndim = {});
+                      const std::vector<DALIDataType> &output_dtype = {},
+                      const std::vector<int> &output_ndim = {}, int64_t seed = -1);
 
   DLL_PUBLIC ~Pipeline();
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -91,9 +91,7 @@ class DLL_PUBLIC Pipeline {
                              bool pipelined_execution = true, int prefetch_queue_depth = 2,
                              bool async_execution = true, size_t bytes_per_sample_hint = 0,
                              bool set_affinity = false, int max_num_stream = -1,
-                             int default_cuda_stream_priority = 0,
-                             const std::vector<DALIDataType> &output_dtype = {},
-                             const std::vector<int> &output_ndim = {})
+                             int default_cuda_stream_priority = 0)
       : built_(false), separated_execution_{false} {
     Init(max_batch_size, num_threads, device_id, seed, pipelined_execution, separated_execution_,
          async_execution, bytes_per_sample_hint, set_affinity, max_num_stream,
@@ -105,8 +103,7 @@ class DLL_PUBLIC Pipeline {
                       int prefetch_queue_depth = 2, bool async_execution = true,
                       size_t bytes_per_sample_hint = 0, bool set_affinity = false,
                       int max_num_stream = -1, int default_cuda_stream_priority = 0,
-                      const std::vector<DALIDataType> &output_dtype = {},
-                      const std::vector<int> &output_ndim = {}, int64_t seed = -1);
+                      int64_t seed = -1);
 
   DLL_PUBLIC ~Pipeline();
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -338,11 +338,19 @@ class DLL_PUBLIC Pipeline {
     prefetch_queue_depth_ = QueueSizes(cpu_size, gpu_size);
   }
 
-  /*
-   * @brief Set name output_names of the pipeline. Used to update the graph without
-   * running the executor.
+  ///@{
+  /**
+   * @brief Set descriptors of the outputs of the pipeline. Used to update the graph without
+   * running the executor and for pipeline serialization.
    */
-  void SetOutputNames(const vector<std::pair<string, string>> &output_names);
+  void SetOutputDescs(std::vector<PipelineOutputDesc> output_descs);
+  /**
+   * Convenience overload. Set only the name and device of an output, since the dtype and ndim
+   * are not always necessary. This function can't reset the output descriptors. If they were already
+   * set, the function will fail.
+   */
+  void SetOutputDescs(const vector<std::pair<string /* name */, string /* device */>> &out_names);
+  ///@}
 
   /**
    * @brief Run the cpu portion of the pipeline.
@@ -478,6 +486,11 @@ class DLL_PUBLIC Pipeline {
    * @brief Returns number of dimensions in the output specified by given id.
    */
   DLL_PUBLIC int output_ndim(int id) const;
+
+  /**
+   * @brief Returns output descriptors for all outputs.
+   */
+  DLL_PUBLIC std::vector<PipelineOutputDesc> output_descs() const;
 
   /**
    * Checks, if a provided pipeline can be deserialized, according to the Pipeline protobuf

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -277,7 +277,7 @@ class DLL_PUBLIC Pipeline {
    * @brief Build a pipeline from deserialized output (name, device) pairs
    */
   DLL_PUBLIC void Build() {
-    Build(this->output_names_);
+    Build(this->output_descs_);
   }
 
   /**
@@ -587,9 +587,9 @@ class DLL_PUBLIC Pipeline {
   std::vector<OpDefinition> op_specs_;
   std::vector<OpDefinition> op_specs_for_serialization_;
 
-  std::vector<PipelineOutputDesc> output_names_;
+  std::vector<PipelineOutputDesc> output_descs_;
 
-  // Mapping between logical id and index in op_spces_;
+  // Mapping between logical id and index in op_specs_
   std::map<int, std::vector<size_t>> logical_ids_;
   std::map<int, int64_t> logical_id_to_seed_;
 

--- a/dali/pipeline/pipeline_output_desc.h
+++ b/dali/pipeline/pipeline_output_desc.h
@@ -36,12 +36,29 @@ struct PipelineOutputDesc {
   PipelineOutputDesc(std::string name, std::string device, DALIDataType dtype, int ndim)
       : name(std::move(name)), device(std::move(device)), dtype(dtype), ndim(ndim) {}
 
-  PipelineOutputDesc(const std::pair<std::string, std::string> &name_and_device)  // NOLINT
+  PipelineOutputDesc(const std::pair<std::string, std::string>& name_and_device)  // NOLINT
       : name(name_and_device.first),
         device(name_and_device.second),
         dtype(DALI_NO_TYPE),
         ndim(-1) {}
+
+  bool operator==(const PipelineOutputDesc& other) const {
+    return name == other.name && device == other.device && dtype == other.dtype &&
+           ndim == other.ndim;
+  }
 };
+
+inline std::ostream& operator<<(std::ostream& os, const PipelineOutputDesc& pod) {
+  return os << "[Name: " << pod.name << "\tDevice: " << pod.device << "\tDtype: " << pod.dtype
+            << "\tNdim: " << pod.ndim << "]";
+}
+
+inline std::ostream& operator<<(std::ostream& os, const std::vector<PipelineOutputDesc>& pod) {
+  for (size_t i = 0; i < pod.size(); i++) {
+    os << "Output " << i << ": " << pod[i];
+  }
+  return os;
+}
 
 }  // namespace dali
 

--- a/dali/pipeline/pipeline_output_desc.h
+++ b/dali/pipeline/pipeline_output_desc.h
@@ -12,13 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DALI_PIPELINE_OUTPUT_DESC_H
-#define DALI_PIPELINE_OUTPUT_DESC_H
+#ifndef DALI_PIPELINE_PIPELINE_OUTPUT_DESC_H_
+#define DALI_PIPELINE_PIPELINE_OUTPUT_DESC_H_
+
 #include <string>
 #include <vector>
 #include "dali/pipeline/data/types.h"
 
 namespace dali {
+
+/**
+ * Descriptor for an output, used by the Pipeline.
+ *
+ * Note: the Executor also has an output descriptor inside. It is different than this one.
+ */
 struct PipelineOutputDesc {
   std::string name, device;
   DALIDataType dtype;
@@ -35,6 +42,7 @@ struct PipelineOutputDesc {
         dtype(DALI_NO_TYPE),
         ndim(-1) {}
 };
+
 }  // namespace dali
 
-#endif  // DALI_PIPELINE_OUTPUT_DESC_H
+#endif  // DALI_PIPELINE_PIPELINE_OUTPUT_DESC_H_

--- a/dali/pipeline/pipeline_output_desc.h
+++ b/dali/pipeline/pipeline_output_desc.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_OUTPUT_DESC_H
+#define DALI_PIPELINE_OUTPUT_DESC_H
+#include <string>
+#include <vector>
+#include "dali/pipeline/data/types.h"
+
+namespace dali {
+struct PipelineOutputDesc {
+  std::string name, device;
+  DALIDataType dtype;
+  int ndim;
+
+  PipelineOutputDesc() = default;
+
+  PipelineOutputDesc(std::string name, std::string device, DALIDataType dtype, int ndim)
+      : name(std::move(name)), device(std::move(device)), dtype(dtype), ndim(ndim) {}
+
+  PipelineOutputDesc(const std::pair<std::string, std::string> &name_and_device)  // NOLINT
+      : name(name_and_device.first),
+        device(name_and_device.second),
+        dtype(DALI_NO_TYPE),
+        ndim(-1) {}
+};
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_OUTPUT_DESC_H

--- a/dali/pipeline/pipeline_output_desc.h
+++ b/dali/pipeline/pipeline_output_desc.h
@@ -33,7 +33,7 @@ struct PipelineOutputDesc {
 
   PipelineOutputDesc() = default;
 
-  PipelineOutputDesc(std::string name, std::string device, DALIDataType dtype, int ndim)
+  PipelineOutputDesc(std::string name, std::string device, DALIDataType dtype,int ndim )
       : name(std::move(name)), device(std::move(device)), dtype(dtype), ndim(ndim) {}
 
   PipelineOutputDesc(const std::pair<std::string, std::string> &name_and_device)  // NOLINT

--- a/dali/pipeline/pipeline_output_desc.h
+++ b/dali/pipeline/pipeline_output_desc.h
@@ -33,7 +33,7 @@ struct PipelineOutputDesc {
 
   PipelineOutputDesc() = default;
 
-  PipelineOutputDesc(std::string name, std::string device, DALIDataType dtype,int ndim )
+  PipelineOutputDesc(std::string name, std::string device, DALIDataType dtype, int ndim)
       : name(std::move(name)), device(std::move(device)), dtype(dtype), ndim(ndim) {}
 
   PipelineOutputDesc(const std::pair<std::string, std::string> &name_and_device)  // NOLINT

--- a/dali/pipeline/proto/dali.proto
+++ b/dali/pipeline/proto/dali.proto
@@ -35,7 +35,7 @@ message InputOutput {
   required string device = 2;
   required bool is_argument_input = 3 [default = false];
   optional string arg_name = 4;
-  optional string dtype = 5;
+  optional int32 dtype = 5 [default = -1];  // @ref DALIDataType
   optional int32 ndim = 6 [default = -1];
 }
 

--- a/dali/pipeline/proto/dali.proto
+++ b/dali/pipeline/proto/dali.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ message InputOutput {
   required string device = 2;
   required bool is_argument_input = 3 [default = false];
   optional string arg_name = 4;
+  optional string dtype = 5;
+  optional int32 ndim = 6 [default = -1];
 }
 
 // stores info about a single operator

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -247,18 +247,16 @@ class WorkspaceBase : public ArgumentWorkspace {
   }
 
   /**
-   * Returns number of dimensions for a given output
+   * @return Type of the data in the output with given index.
    */
   DALIDataType GetOutputDataType(int output_idx) const {
     DALI_ENFORCE(NumOutput() > 0, "No outputs found");
     DALI_ENFORCE(
         output_idx >= 0 && output_idx < NumOutput(),
-        make_string("Invalid output index: ", output_idx, "; while NumOutput: ", NumInput()));
+        make_string("Invalid output index: ", output_idx, "; while NumOutput: ", NumOutput()));
     if (OutputIsType<GPUBackend>(output_idx)) {
-      cout << Output<GPUBackend>(output_idx).type() << endl;
       return Output<GPUBackend>(output_idx).type();
     } else {
-      cout << Output<CPUBackend>(output_idx).type() << endl;
       return Output<CPUBackend>(output_idx).type();
     }
   }
@@ -274,21 +272,6 @@ class WorkspaceBase : public ArgumentWorkspace {
       return Input<GPUBackend>(input_idx).num_samples();
     } else {
       return Input<CPUBackend>(input_idx).num_samples();
-    }
-  }
-
-  /**
-   * Returns number of dimensions for a given output
-   */
-  int GetOutputBatchSize(int output_idx) const {
-    DALI_ENFORCE(NumOutput() > 0, "No outputs found");
-    DALI_ENFORCE(
-        output_idx >= 0 && output_idx < NumOutput(),
-        make_string("Invalid output index: ", output_idx, "; while NumOutput: ", NumInput()));
-    if (OutputIsType<GPUBackend>(output_idx)) {
-      return Output<GPUBackend>(output_idx).sample_dim();
-    } else {
-      return Output<CPUBackend>(output_idx).sample_dim();
     }
   }
 
@@ -313,7 +296,7 @@ class WorkspaceBase : public ArgumentWorkspace {
     DALI_ENFORCE(NumOutput() > 0, "No outputs found");
     DALI_ENFORCE(
         output_idx >= 0 && output_idx < NumOutput(),
-        make_string("Invalid output index: ", output_idx, "; while NumOutput: ", NumInput()));
+        make_string("Invalid output index: ", output_idx, "; while NumOutput: ", NumOutput()));
     if (OutputIsType<GPUBackend>(output_idx)) {
       return Output<GPUBackend>(output_idx).sample_dim();
     } else {

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -247,6 +247,23 @@ class WorkspaceBase : public ArgumentWorkspace {
   }
 
   /**
+   * Returns number of dimensions for a given output
+   */
+  DALIDataType GetOutputDataType(int output_idx) const {
+    DALI_ENFORCE(NumOutput() > 0, "No outputs found");
+    DALI_ENFORCE(
+        output_idx >= 0 && output_idx < NumOutput(),
+        make_string("Invalid output index: ", output_idx, "; while NumOutput: ", NumInput()));
+    if (OutputIsType<GPUBackend>(output_idx)) {
+      cout << Output<GPUBackend>(output_idx).type() << endl;
+      return Output<GPUBackend>(output_idx).type();
+    } else {
+      cout << Output<CPUBackend>(output_idx).type() << endl;
+      return Output<CPUBackend>(output_idx).type();
+    }
+  }
+
+  /**
    * Returns batch size for a given input
    */
   int GetInputBatchSize(int input_idx) const {
@@ -261,6 +278,21 @@ class WorkspaceBase : public ArgumentWorkspace {
   }
 
   /**
+   * Returns number of dimensions for a given output
+   */
+  int GetOutputBatchSize(int output_idx) const {
+    DALI_ENFORCE(NumOutput() > 0, "No outputs found");
+    DALI_ENFORCE(
+        output_idx >= 0 && output_idx < NumOutput(),
+        make_string("Invalid output index: ", output_idx, "; while NumOutput: ", NumInput()));
+    if (OutputIsType<GPUBackend>(output_idx)) {
+      return Output<GPUBackend>(output_idx).sample_dim();
+    } else {
+      return Output<CPUBackend>(output_idx).sample_dim();
+    }
+  }
+
+  /**
    * Returns number of dimensions for a given input
    */
   int GetInputDim(int input_idx) const {
@@ -271,6 +303,21 @@ class WorkspaceBase : public ArgumentWorkspace {
       return Input<GPUBackend>(input_idx).sample_dim();
     } else {
       return Input<CPUBackend>(input_idx).sample_dim();
+    }
+  }
+
+  /**
+   * Returns number of dimensions for a given output
+   */
+  int GetOutputDim(int output_idx) const {
+    DALI_ENFORCE(NumOutput() > 0, "No outputs found");
+    DALI_ENFORCE(
+        output_idx >= 0 && output_idx < NumOutput(),
+        make_string("Invalid output index: ", output_idx, "; while NumOutput: ", NumInput()));
+    if (OutputIsType<GPUBackend>(output_idx)) {
+      return Output<GPUBackend>(output_idx).sample_dim();
+    } else {
+      return Output<CPUBackend>(output_idx).sample_dim();
     }
   }
 

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1569,13 +1569,24 @@ PYBIND11_MODULE(backend_impl, m) {
                                       (&Pipeline::AddOperator))
     .def("GetOperatorNode", &Pipeline::GetOperatorNode)
     .def("Build",
-        [](Pipeline *p, const std::vector<std::pair<string, string>>& outputs) {
-          p->Build(outputs);
-          })
+         [](Pipeline *p, const std::vector<std::pair<string, string>> &outputs) {
+             p->Build(outputs);
+         })
     .def("Build",
-        [](Pipeline *p) {
-          p->Build();
-          })
+         [](Pipeline *p, const std::vector<
+                           std::tuple<std::string  /* name */,
+                                      std::string  /* device */,
+                                      DALIDataType /* dtype */,
+                                      int          /* ndim */>
+                                            > &outputs) {
+             //TODO ładniej
+             std::vector<PipelineOutputDesc> build_args;
+             for (auto& o : outputs) {
+               build_args.emplace_back(to_struct<PipelineOutputDesc>(o));
+             }
+             p->Build(build_args);
+           } )
+    .def("Build", [](Pipeline *p) { p->Build(); } )
     .def("SetExecutionTypes",
         [](Pipeline *p, bool exec_pipelined, bool exec_separated, bool exec_async) {
           p->SetExecutionTypes(exec_pipelined, exec_separated, exec_async);

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1661,7 +1661,7 @@ PYBIND11_MODULE(backend_impl, m) {
          [](Pipeline *p) {
              auto descs = p->output_descs();
              std::vector<DALIDataType> ret(descs.size());
-             for (int i=0;i<descs.size();i++) {
+             for (size_t i = 0; i < descs.size(); i++) {
                ret[i] = descs[i].dtype;
              }
              return ret;
@@ -1669,11 +1669,11 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("output_ndim",
          [](Pipeline *p) {
            auto descs = p->output_descs();
-           std::vector<int> ret(descs.size());
-           for (int i=0;i<descs.size();i++) {
-             ret[i] = descs[i].ndim;
-           }
-           return ret;
+             std::vector<int> ret(descs.size());
+             for (size_t i = 0; i < descs.size(); i++) {
+               ret[i] = descs[i].ndim;
+             }
+             return ret;
          })
     .def("SetExternalTLInput",
         [](Pipeline *p, const string &name, const TensorList<CPUBackend> &tl,

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -283,6 +283,14 @@ void ExposeTensorLayout(py::module &m) {
 // Placeholder enum for defining __call__ on dtype member of Tensor (to be deprecated).
 enum DALIDataTypePlaceholder {};
 
+/**
+ * Pipeline output descriptor.
+ */
+using OutputDesc = std::tuple<std::string  /* name */,
+                              std::string  /* device */,
+                              DALIDataType /* dtype */,
+                              int          /* ndim */>;
+
 void ExposeTensor(py::module &m) {
   m.def("CheckDLPackCapsule",
         [](py::object &p) {
@@ -1573,12 +1581,7 @@ PYBIND11_MODULE(backend_impl, m) {
              p->Build(outputs);
          })
     .def("Build",
-         [](Pipeline *p, const std::vector<
-                           std::tuple<std::string  /* name */,
-                                      std::string  /* device */,
-                                      DALIDataType /* dtype */,
-                                      int          /* ndim */>
-                                            > &outputs) {
+         [](Pipeline *p, const std::vector<OutputDesc> &outputs) {
              std::vector<PipelineOutputDesc> build_args;
              for (auto& out : outputs) {
                build_args.emplace_back(to_struct<PipelineOutputDesc>(out));
@@ -1607,10 +1610,14 @@ PYBIND11_MODULE(backend_impl, m) {
         [](Pipeline *p, int cpu_size, int gpu_size) {
           p->SetQueueSizes(cpu_size, gpu_size);
         })
-    .def("SetOutputNames",
-        [](Pipeline *p, const std::vector<std::pair<string, string>>& outputs) {
-          p->SetOutputNames(outputs);
-          })
+    .def("SetOutputDescs",
+        [](Pipeline *p, const std::vector<OutputDesc>& outputs) {
+          std::vector<PipelineOutputDesc> out_desc;
+          for (auto& out : outputs) {
+            out_desc.emplace_back(to_struct<PipelineOutputDesc>(out));
+          }
+          p->SetOutputDescs(out_desc);
+        })
     .def("RunCPU", &Pipeline::RunCPU, py::call_guard<py::gil_scoped_release>())
     .def("RunGPU", &Pipeline::RunGPU)
     .def("Outputs",
@@ -1650,6 +1657,24 @@ PYBIND11_MODULE(backend_impl, m) {
     .def("batch_size", &Pipeline::batch_size)
     .def("num_threads", &Pipeline::num_threads)
     .def("device_id", &Pipeline::device_id)
+    .def("output_dtype",
+         [](Pipeline *p) {
+             auto descs = p->output_descs();
+             std::vector<DALIDataType> ret(descs.size());
+             for (int i=0;i<descs.size();i++) {
+               ret[i] = descs[i].dtype;
+             }
+             return ret;
+         })
+    .def("output_ndim",
+         [](Pipeline *p) {
+           auto descs = p->output_descs();
+           std::vector<int> ret(descs.size());
+           for (int i=0;i<descs.size();i++) {
+             ret[i] = descs[i].ndim;
+           }
+           return ret;
+         })
     .def("SetExternalTLInput",
         [](Pipeline *p, const string &name, const TensorList<CPUBackend> &tl,
            py::object /*cuda_stream*/, bool /*use_copy_kernel*/) {

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1579,13 +1579,12 @@ PYBIND11_MODULE(backend_impl, m) {
                                       DALIDataType /* dtype */,
                                       int          /* ndim */>
                                             > &outputs) {
-             //TODO ładniej
              std::vector<PipelineOutputDesc> build_args;
-             for (auto& o : outputs) {
-               build_args.emplace_back(to_struct<PipelineOutputDesc>(o));
+             for (auto& out : outputs) {
+               build_args.emplace_back(to_struct<PipelineOutputDesc>(out));
              }
              p->Build(build_args);
-           } )
+         })
     .def("Build", [](Pipeline *p) { p->Build(); } )
     .def("SetExecutionTypes",
         [](Pipeline *p, bool exec_pipelined, bool exec_separated, bool exec_async) {
@@ -1899,7 +1898,7 @@ PYBIND11_MODULE(backend_impl, m) {
         return new TFFeature(converted_type, converted_default_value, partial_shape);
       });
 #endif  // DALI_BUILD_PROTO3
-}
+}  // NOLINT(readability/fn_size)
 
 }  // namespace python
 }  // namespace dali

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1577,10 +1577,6 @@ PYBIND11_MODULE(backend_impl, m) {
                                       (&Pipeline::AddOperator))
     .def("GetOperatorNode", &Pipeline::GetOperatorNode)
     .def("Build",
-         [](Pipeline *p, const std::vector<std::pair<string, string>> &outputs) {
-             p->Build(outputs);
-         })
-    .def("Build",
          [](Pipeline *p, const std::vector<OutputDesc> &outputs) {
              std::vector<PipelineOutputDesc> build_args;
              for (auto& out : outputs) {

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -152,8 +152,24 @@ Parameters
     by decorating them with `@dali.pickling.pickle_by_value`. It may be especially useful when
     working with Jupyter notebook to work around the issue of worker process being unable to import
     the callback defined as a global function inside the notebook.
-`output_dtype` : TODO
-`output_ndim` : TODO
+`output_dtype` : nvidia.dali.types or list of those, default = None
+    With this argument, you may declare, what data type you expect in the given output. You shall
+    pass a list of values from module:`nvidia.dali.types`, each element in the list corresponding to
+    one output from the pipeline. Additionally, you can pass ``None`` as a wildcard. The outputs,
+    after each iteration, will be validated against the types you passed to this argument. If any
+    output does not match the provided type, RuntimeError will be raised.
+
+    If the ``output_dtype`` value is a single value (not a list), it will be broadcast to the
+    number of outputs from the pipeline.
+`output_ndim` : int or list of ints, default = None
+    With this argument, you may declare, how many dimensions you expect in the given output. You shall
+    pass a list of integers, each element in the list corresponding to one output from the pipeline.
+    Additionally, you can pass ``None`` as a wildcard. The outputs, after each iteration, will be
+    validated against the numbers of dimensions you passed to this argument. If the dimensionality
+    of any output does not match the provided ``ndim``, RuntimeError will be raised.
+
+    If the ``output_ndim`` value is a single value (not a list), it will be broadcast to the
+    number of outputs from the pipeline.
 """
     def __init__(self, batch_size = -1, num_threads = -1, device_id = -1, seed = -1,
                  exec_pipelined=True, prefetch_queue_depth=2,

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -239,28 +239,28 @@ Parameters
         # Assign and validate output_dtype
         if isinstance(output_dtype, (list, tuple)):
             for dtype in output_dtype:
-                if not(isinstance(dtype, (types.DALIDataType, type(None)))):
+                if not isinstance(dtype, (types.DALIDataType, type(None))):
                     raise TypeError(
                         f"`output_dtype` must be either: a value from nvidia.dali.types.DALIDataType, a list of these or None. Found type {type(dtype)} in the list.")
-                if dtype is not None and dtype == types.NO_TYPE:
+                if dtype == types.NO_TYPE:
                     raise ValueError(f"`output_dtype` can't be a types.NO_TYPE. Found {dtype} in the list.")
-        elif not(isinstance(output_dtype, (types.DALIDataType, type(None)))):
+        elif not isinstance(output_dtype, (types.DALIDataType, type(None))):
             raise TypeError(
                 f"`output_dtype` must be either: a value from nvidia.dali.types.DALIDataType, a list of these or None. Found type: {type(output_dtype)}.")
-        elif output_dtype is not None and output_dtype == types.NO_TYPE:
+        elif output_dtype == types.NO_TYPE:
             raise ValueError(f"`output_dtype` can't be a types.NO_TYPE. Found value: {output_dtype}")
         self._output_dtype = output_dtype
 
         # Assign and validate output_ndim
         if isinstance(output_ndim, (list, tuple)):
             for ndim in output_ndim:
-                if not(isinstance(ndim, (int, type(None)))):
+                if not isinstance(ndim, (int, type(None))):
                     raise TypeError(
                         f"`output_ndim` must be either: an int, a list of ints or None. Found type {type(ndim)} in the list.")
                 if ndim is not None and ndim < 0:
                     raise ValueError(
                         f"`output_ndim` must be non-negative. Found value {ndim} in the list.")
-        elif not(isinstance(output_ndim, (int, type(None)))):
+        elif not isinstance(output_ndim, (int, type(None))):
             raise TypeError(
                 f"`output_ndim` must be either: an int, a list of ints or None. Found type: {type(output_ndim)}.")
         elif output_ndim is not None and output_ndim < 0:

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -1262,7 +1262,6 @@ Parameters
         pass
 
     def _generate_build_args(self):
-        # ret = []
         num_outputs = len(self._names_and_devices)
         dtypes = [self._output_dtype] * num_outputs if type(
             self._output_dtype) is not list else self._output_dtype
@@ -1273,9 +1272,6 @@ Parameters
                 f"Lengths of provided output descriptions do not match. \n"
                 f"Expected num_outputs={num_outputs}.\nReceived:\noutput_dtype={dtypes}\noutput_ndim={ndims}")
 
-        # for (name, dev), dtype, ndim in zip(self._names_and_devices, dtypes, ndims):
-        #     ret.append((name, dev, types.NO_TYPE if dtype is None else dtype,
-        #                 -1 if ndim is None else ndim))
         return [(name, dev, types.NO_TYPE if dtype is None else dtype, -1 if ndim is None else ndim)
                 for (name, dev), dtype, ndim in zip(self._names_and_devices, dtypes, ndims)]
 

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -345,6 +345,16 @@ Parameters
         """The number of iterations processed ahead by the GPU stage."""
         return self._gpu_queue_size
 
+    @property
+    def output_ndim(self):
+        """Number of dimensions expected at the given output."""
+        return self._output_ndim
+
+    @property
+    def output_dtype(self):
+        """Data type expected at the given output."""
+        return self._output_dtype
+
     def epoch_size(self, name = None):
         """Epoch size of a pipeline.
 

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -235,7 +235,7 @@ Parameters
             for ndim in output_ndim:
                 assert type(ndim) is int or ndim is None, \
                     f"`output_ndim` must be either: an int, a list of ints or None. Found type {type(ndim)} in the list."
-                assert ndim >= 0 or ndim is None, f"`output_ndim` must be non-negative. Found value {ndim} in the list."
+                assert ndim is None or ndim >= 0, f"`output_ndim` must be non-negative. Found value {ndim} in the list."
         elif type(output_ndim) is not int and output_ndim is not None:
             raise TypeError(
                 f"`output_ndim` must be either: an int, a list of ints or None. Found type: {type(output_ndim)}.")
@@ -1234,7 +1234,10 @@ Parameters
         output_dtype = [output_dtype] * num_outputs if type(
             output_dtype) is not list else output_dtype
         output_ndim = [output_ndim] * num_outputs if type(output_ndim) is not list else output_ndim
-        assert len(output_dtype) == len(output_ndim) == num_outputs
+        if not (len(output_dtype) == len(output_ndim) == num_outputs):
+            raise RuntimeError(
+                f"Inconsistent output description. Length of provided output descriptions do not match. \n"
+                f"Expected num_outputs={num_outputs}.\nReceived:\noutput_dtype={output_dtype}\noutput_ndim={output_ndim}")
 
         for nd, dtype, ndim in zip(self._names_and_devices, output_dtype, output_ndim):
             ret.append((nd[0], nd[1], types.NO_TYPE if dtype is None else dtype, -1 if ndim is None else ndim))

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -241,12 +241,12 @@ Parameters
             for dtype in output_dtype:
                 if not(isinstance(dtype, (types.DALIDataType, type(None)))):
                     raise TypeError(
-                        f"`output_dtype` must be either: a type from nvidia.dali.types.DALIDataType, a list of these or None. Found type {type(dtype)} in the list.")
+                        f"`output_dtype` must be either: a value from nvidia.dali.types.DALIDataType, a list of these or None. Found type {type(dtype)} in the list.")
                 if dtype is not None and dtype == types.NO_TYPE:
                     raise ValueError(f"`output_dtype` can't be a types.NO_TYPE. Found {dtype} in the list.")
         elif not(isinstance(output_dtype, (types.DALIDataType, type(None)))):
             raise TypeError(
-                f"`output_dtype` must be either: a type from nvidia.dali.types.DALIDataType, a list of these or None. Found type: {type(output_dtype)}.")
+                f"`output_dtype` must be either: a value from nvidia.dali.types.DALIDataType, a list of these or None. Found type: {type(output_dtype)}.")
         elif output_dtype is not None and output_dtype == types.NO_TYPE:
             raise ValueError(f"`output_dtype` can't be a types.NO_TYPE. Found value: {output_dtype}")
         self._output_dtype = output_dtype

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -152,9 +152,9 @@ Parameters
     by decorating them with `@dali.pickling.pickle_by_value`. It may be especially useful when
     working with Jupyter notebook to work around the issue of worker process being unable to import
     the callback defined as a global function inside the notebook.
-`output_dtype` : nvidia.dali.types or list of those, default = None
+`output_dtype` : ``nvidia.dali.types.DALIDataType`` or list of those, default = None
     With this argument, you may declare, what data type you expect in the given output. You shall
-    pass a list of values from module:`nvidia.dali.types`, each element in the list corresponding to
+    pass a list of mod:`types.DALIDataType`, each element in the list corresponding to
     one output from the pipeline. Additionally, you can pass ``None`` as a wildcard. The outputs,
     after each iteration, will be validated against the types you passed to this argument. If any
     output does not match the provided type, RuntimeError will be raised.
@@ -241,10 +241,10 @@ Parameters
             for dtype in output_dtype:
                 if type(dtype) is not types.DALIDataType and dtype is not None:
                     raise TypeError(
-                        f"`output_dtype` must be either: a type from nvidia.dali.types module, a list of these or None. Found type {type(dtype)} in the list.")
+                        f"`output_dtype` must be either: a type from nvidia.dali.types.DALIDataType, a list of these or None. Found type {type(dtype)} in the list.")
         elif type(output_dtype) is not types.DALIDataType and output_dtype is not None:
             raise TypeError(
-                f"`output_dtype` must be either: a type from nvidia.dali.types module, a list of these or None. Found type: {type(output_dtype)}.")
+                f"`output_dtype` must be either: a type from nvidia.dali.types.DALIDataType, a list of these or None. Found type: {type(output_dtype)}.")
         self._output_dtype = output_dtype
 
         # Assign and validate output_ndim
@@ -752,7 +752,7 @@ Parameters
             self._init_pipeline_backend()
         self._setup_pipe_pool_dependency()
 
-        self._pipe.Build(self._generate_build_args(self._output_dtype, self._output_ndim))
+        self._pipe.Build(self._generate_build_args())
         self._built = True
 
     def _feed_input(self, name, data, layout=None, cuda_stream=None, use_copy_kernel=False):
@@ -1091,7 +1091,7 @@ Parameters
         if not self._backend_prepared:
             self._init_pipeline_backend()
             self._pipe.SetOutputDescs(
-                self._generate_build_args(self._output_dtype, self._output_ndim))
+                self._generate_build_args())
         ret = self._pipe.SerializeToProtobuf()
         if filename is not None:
             with open(filename, 'wb') as pipeline_file:
@@ -1257,19 +1257,19 @@ Parameters
         data from NumPy arrays."""
         pass
 
-    def _generate_build_args(self, output_dtype, output_ndim):
+    def _generate_build_args(self):
         ret = []
         num_outputs = len(self._names_and_devices)
-        output_dtype = [output_dtype] * num_outputs if type(
-            output_dtype) is not list else output_dtype
-        output_ndim = [output_ndim] * num_outputs if type(output_ndim) is not list else output_ndim
-        if not (len(output_dtype) == len(output_ndim) == num_outputs):
+        dtype = [self._output_dtype] * num_outputs if type(
+            self._output_dtype) is not list else self._output_dtype
+        ndim = [self._output_ndim] * num_outputs if type(self._output_ndim) is not list else self._output_ndim
+        if not (len(dtype) == len(ndim) == num_outputs):
             raise RuntimeError(
                 f"Inconsistent output description. Length of provided output descriptions do not match. \n"
-                f"Expected num_outputs={num_outputs}.\nReceived:\noutput_dtype={output_dtype}\noutput_ndim={output_ndim}")
+                f"Expected num_outputs={num_outputs}.\nReceived:\noutput_dtype={dtype}\noutput_ndim={ndim}")
 
-        for (name, dev), dtype, ndim in zip(self._names_and_devices, output_dtype, output_ndim):
-            ret.append((name, dev, types.NO_TYPE if dtype is None else dtype, -1 if ndim is None else ndim))
+        for (name, dev), dt, nd in zip(self._names_and_devices, dtype, ndim):
+            ret.append((name, dev, types.NO_TYPE if dt is None else dt, -1 if nd is None else nd))
         return ret
 
 

--- a/dali/test/python/test_operator_decoders_audio.py
+++ b/dali/test/python/test_operator_decoders_audio.py
@@ -50,16 +50,19 @@ create_test_files()
 rate1 = 16000
 rate2 = 12999
 
+
 class DecoderPipeline(Pipeline):
   def __init__(self):
-    super(DecoderPipeline, self).__init__(batch_size=8, num_threads=3, device_id=0,
-                                          exec_async=True, exec_pipelined=True)
+    super().__init__(batch_size=8, num_threads=3, device_id=0, exec_async=True, exec_pipelined=True,
+                     output_dtype=[types.INT16, types.INT16, types.INT16, types.FLOAT,
+                                   types.FLOAT, types.FLOAT, types.FLOAT, types.FLOAT],
+                     output_ndim=[2, 2, 1, 1, 0, 0, 0, 0])
     self.file_source = ops.ExternalSource()
-    self.plain_decoder = ops.decoders.Audio(dtype = types.INT16)
-    self.resampling_decoder = ops.decoders.Audio(sample_rate=rate1, dtype = types.INT16)
-    self.downmixing_decoder = ops.decoders.Audio(downmix=True, dtype = types.INT16)
+    self.plain_decoder = ops.decoders.Audio(dtype=types.INT16)
+    self.resampling_decoder = ops.decoders.Audio(sample_rate=rate1, dtype=types.INT16)
+    self.downmixing_decoder = ops.decoders.Audio(downmix=True, dtype=types.INT16)
     self.resampling_downmixing_decoder = ops.decoders.Audio(sample_rate=rate2, downmix=True,
-                                                            quality=50, dtype = types.FLOAT)
+                                                            quality=50, dtype=types.FLOAT)
 
   def define_graph(self):
     self.raw_file = self.file_source()

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1659,12 +1659,7 @@ def test_invoke_serialize_error_handling_not_string():
 def check_dtype_ndim(dali_pipeline, output_dtype, output_ndim, n_outputs):
     def ndim_dtype_matches(test_value, ref_value):
         ref_value = ref_value if isinstance(ref_value, (list, tuple)) else [ref_value] * n_outputs
-        if len(ref_value) != len(test_value):
-            return False
-        for tv, ref in zip(test_value, ref_value):
-            if tv != ref:
-                return False
-        return True
+        return ref_value == test_value
 
     import tempfile
     with tempfile.NamedTemporaryFile() as f:

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1717,9 +1717,8 @@ def test_one_output_dtype_ndim():
     correct_dtypes_but_too_many = create_test_package(output_dtype=[types.UINT8, types.UINT8])
     correct_ndims_but_too_many = create_test_package(output_ndim=[3, 3])
     all_wildcards = create_test_package()
-    all_backend_wildcards = create_test_package(output_dtype=types.NO_TYPE, output_ndim=None)
     correct_test_packages = [both_correct, ndim_correct_dtype_wildcard, dtype_correct_ndim_wildcard,
-                             both_correct_one_list, all_wildcards, all_backend_wildcards]
+                             both_correct_one_list, all_wildcards]
     test_ndim_packages_with_raise = [ndim_incorrect]
     test_dtype_packages_with_raise = [dtype_incorrect]
     test_packages_length_mismatch = [too_many_dtypes, correct_dtypes_but_too_many,
@@ -1781,5 +1780,6 @@ def test_double_output_dtype_ndim():
         create_test_package(output_ndim=-1)
         create_test_package(output_ndim=-2137)
     with assert_raises(TypeError, glob="*must be either*"):
-        create_test_package(output_dtype=types.NO_TYPE)
         create_test_package(output_dtype=int)
+    with assert_raises(ValueError, glob="*types.NO_TYPE*"):
+        create_test_package(output_dtype=types.NO_TYPE)

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1656,20 +1656,33 @@ def test_invoke_serialize_error_handling_not_string():
     _identity_pipe().serialize(42)
 
 
-def check_dtype_ndim(dali_pipeline):
+def check_dtype_ndim(dali_pipeline, output_dtype, output_ndim):
+    def ndim_dtype_matches(test_value, ref_value):
+        ref_value = ref_value if type(ref_value) is list else [ref_value]
+        for tv, ref in zip(test_value, ref_value):
+            if ref is None:
+                if tv != -1:
+                    return False
+            else:
+                if tv != ref:
+                    return False
+        return True
+
     import tempfile
     with tempfile.NamedTemporaryFile() as f:
         dali_pipeline.serialize(filename=f.name)
         deserialized_pipeline = Pipeline.deserialize(filename=f.name)
         deserialized_pipeline.build()
+        assert ndim_dtype_matches(deserialized_pipeline.output_ndim(), output_ndim), f"`output_ndim` is not serialized properly. {deserialized_pipeline.output_ndim()} vs {output_ndim}."
+        assert ndim_dtype_matches(deserialized_pipeline.output_dtype(), output_dtype), f"`output_dtype` is not serialized properly. {deserialized_pipeline.output_dtype()} vs {output_dtype}."
         deserialized_pipeline.run()
     dali_pipeline.build()
     dali_pipeline.run()
 
 
 @raises(RuntimeError, glob="Inconsistent output description.*")
-def check_dtype_ndim_with_raise(dali_pipeline):
-    check_dtype_ndim(dali_pipeline=dali_pipeline)
+def check_dtype_ndim_with_raise(dali_pipeline, output_dtype, output_ndim):
+    check_dtype_ndim(dali_pipeline, output_dtype, output_ndim)
 
 
 def test_one_output_dtype_ndim():
@@ -1680,29 +1693,29 @@ def test_one_output_dtype_ndim():
         decoded = fn.decoders.image(inputs, device="mixed", output_type=types.RGB)
         return decoded
 
-    def create_pipe(output_dtype=None, output_ndim=None):
+    def create_test_package(output_dtype=None, output_ndim=None):
         return pipe(batch_size=1, num_threads=1, device_id=0, output_dtype=output_dtype,
-                    output_ndim=output_ndim)
+                    output_ndim=output_ndim), output_dtype, output_ndim
 
-    both_correct = create_pipe(output_dtype=[types.UINT8], output_ndim=[3])
-    ndim_correct_dtype_wildcard = create_pipe(output_dtype=[None], output_ndim=[3])
-    dtype_correct_ndim_wildcard = create_pipe(output_dtype=types.UINT8)
-    dtype_incorrect = create_pipe(output_dtype=[types.FLOAT], output_ndim=[3])
-    ndim_incorrect = create_pipe(output_dtype=types.UINT8, output_ndim=0)
-    both_correct_one_list = create_pipe(output_dtype=types.UINT8, output_ndim=[3])
-    too_many_dtypes = create_pipe(output_dtype=[types.UINT8, types.FLOAT])
-    correct_dtypes_but_too_many = create_pipe(output_dtype=[types.UINT8, types.UINT8])
-    correct_ndims_but_too_many = create_pipe(output_ndim=[3, 3])
-    all_wildcards = create_pipe()
-    correct_pipes = [both_correct, ndim_correct_dtype_wildcard, dtype_correct_ndim_wildcard,
+    both_correct = create_test_package(output_dtype=[types.UINT8], output_ndim=[3])
+    ndim_correct_dtype_wildcard = create_test_package(output_dtype=[None], output_ndim=[3])
+    dtype_correct_ndim_wildcard = create_test_package(output_dtype=types.UINT8)
+    dtype_incorrect = create_test_package(output_dtype=[types.FLOAT], output_ndim=[3])
+    ndim_incorrect = create_test_package(output_dtype=types.UINT8, output_ndim=0)
+    both_correct_one_list = create_test_package(output_dtype=types.UINT8, output_ndim=[3])
+    too_many_dtypes = create_test_package(output_dtype=[types.UINT8, types.FLOAT])
+    correct_dtypes_but_too_many = create_test_package(output_dtype=[types.UINT8, types.UINT8])
+    correct_ndims_but_too_many = create_test_package(output_ndim=[3, 3])
+    all_wildcards = create_test_package()
+    correct_test_packages = [both_correct, ndim_correct_dtype_wildcard, dtype_correct_ndim_wildcard,
                      both_correct_one_list, all_wildcards]
-    pipes_that_raise = [dtype_incorrect, ndim_incorrect, too_many_dtypes,
+    test_packages_that_raise = [dtype_incorrect, ndim_incorrect, too_many_dtypes,
                         correct_dtypes_but_too_many, correct_ndims_but_too_many]
 
-    for pipe_under_test in correct_pipes:
-        yield check_dtype_ndim, pipe_under_test
-    for pipe_under_test in pipes_that_raise:
-        yield check_dtype_ndim_with_raise, pipe_under_test
+    for pipe_under_test, dtype, ndim in correct_test_packages:
+        yield check_dtype_ndim, pipe_under_test, dtype, ndim
+    for pipe_under_test, dtype, ndim in test_packages_that_raise:
+        yield check_dtype_ndim_with_raise, pipe_under_test, dtype, ndim
 
 
 def test_double_output_dtype_ndim():
@@ -1714,28 +1727,29 @@ def test_double_output_dtype_ndim():
         labels_casted = fn.cast(labels, dtype=types.UINT8)
         return decoded, labels_casted if cast_labels else labels
 
-    def create_pipe(output_dtype=None, output_ndim=None, cast_labels=False):
+    def create_test_package(output_dtype=None, output_ndim=None, cast_labels=False):
         return pipe(batch_size=1, num_threads=1, device_id=0, output_dtype=output_dtype,
-                    output_ndim=output_ndim, cast_labels=cast_labels)
+                    output_ndim=output_ndim, cast_labels=cast_labels), output_dtype, output_ndim
 
-    both_correct = create_pipe(output_dtype=[types.UINT8, types.INT32], output_ndim=[3, 1])
-    ndim_correct_dtype_wildcard = create_pipe(output_dtype=[None, None], output_ndim=[3, 1])
-    dtype_correct_ndim_wildcard = create_pipe(output_dtype=[types.UINT8, types.UINT8],
+    both_correct = create_test_package(output_dtype=[types.UINT8, types.INT32], output_ndim=[3, 1])
+    ndim_correct_dtype_wildcard = create_test_package(output_dtype=[None, None], output_ndim=[3, 1])
+    dtype_correct_ndim_wildcard = create_test_package(output_dtype=[types.UINT8, types.UINT8],
                                               cast_labels=True)
-    dtype_incorrect = create_pipe(output_dtype=[types.UINT8, types.FLOAT])
-    ndim_incorrect = create_pipe(output_ndim=[3, 3])
-    dtype_broadcast = create_pipe(output_dtype=types.UINT8, cast_labels=True)
-    wildcard_in_dtype = create_pipe(output_dtype=[types.UINT8, None])
-    wildcard_in_ndim = create_pipe(output_ndim=[3, None])
-    not_enough_dtypes = create_pipe(output_dtype=[types.UINT8])
-    not_enough_ndim = create_pipe(output_ndim=[1])
-    all_wildcards = create_pipe()
-    all_wildcards_but_shapes_dont_match = create_pipe(output_dtype=[None, None], output_ndim=[None])
-    correct_pipes = [both_correct, ndim_correct_dtype_wildcard, dtype_correct_ndim_wildcard,
+    dtype_incorrect = create_test_package(output_dtype=[types.UINT8, types.FLOAT])
+    ndim_incorrect = create_test_package(output_ndim=[3, 3])
+    dtype_broadcast = create_test_package(output_dtype=types.UINT8, cast_labels=True)
+    wildcard_in_dtype = create_test_package(output_dtype=[types.UINT8, None])
+    wildcard_in_ndim = create_test_package(output_ndim=[3, None])
+    not_enough_dtypes = create_test_package(output_dtype=[types.UINT8])
+    not_enough_ndim = create_test_package(output_ndim=[1])
+    all_wildcards = create_test_package()
+    all_wildcards_but_shapes_dont_match = create_test_package(output_dtype=[None, None], output_ndim=[None])
+    correct_test_packages = [both_correct, ndim_correct_dtype_wildcard, dtype_correct_ndim_wildcard,
                      dtype_broadcast, wildcard_in_dtype, wildcard_in_ndim, all_wildcards]
-    pipes_that_raise = [dtype_incorrect, ndim_incorrect, not_enough_dtypes, not_enough_ndim,
+    test_packages_that_raise = [dtype_incorrect, ndim_incorrect, not_enough_dtypes, not_enough_ndim,
                         all_wildcards_but_shapes_dont_match]
-    for pipe_under_test in correct_pipes:
-        yield check_dtype_ndim, pipe_under_test
-    for pipe_under_test in pipes_that_raise:
-        yield check_dtype_ndim_with_raise, pipe_under_test
+
+    for pipe_under_test, dtype, ndim in correct_test_packages:
+        yield check_dtype_ndim, pipe_under_test, dtype, ndim
+    for pipe_under_test, dtype, ndim in test_packages_that_raise:
+        yield check_dtype_ndim_with_raise, pipe_under_test, dtype, ndim

--- a/dali/util/pybind.h
+++ b/dali/util/pybind.h
@@ -231,5 +231,36 @@ static DLMTensorPtr DLMTensorPtrFromCapsule(py::capsule &capsule) {
   return {DLMTensorRawPtrFromCapsule(capsule), DLMTensorPtrDeleter};
 }
 
+
+/**
+ * @see to_struct
+ */
+template <typename Struct, std::size_t... Idx, typename Tuple>
+Struct to_struct_helper(std::index_sequence<Idx...>, Tuple &&tuple) {
+  return {std::get<Idx>(std::forward<Tuple>(tuple))...};
+}
+
+
+/**
+ * Converts Tuple to Struct by calling a Struct's brace-initializer
+ * with every Tuple's argument, retaining its order. E.g.
+ *
+ *
+ * tuple<int, string, float> tt;
+ * struct Foo {
+ *     int a; string b; float c;
+ * }
+ *
+ * auto f = to_struct<Foo>(tt)  <=>  Foo f = {get<0>(tt), get<1>(tt), get<2>(tt)}
+ *
+ * @return
+ */
+template <typename Struct, typename Tuple>
+Struct to_struct(Tuple &&tuple) {
+  using T = std::remove_reference_t<Tuple>;
+  return to_struct_helper<Struct>(std::make_index_sequence<std::tuple_size<T>{}>{},
+                                  std::forward<Tuple>(tuple));
+}
+
 }  // namespace dali
 #endif  // DALI_UTIL_PYBIND_H_

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -432,6 +432,26 @@ DLL_PUBLIC size_t daliTensorSize(daliPipelineHandle *pipe_handle, int n);
 DLL_PUBLIC size_t daliMaxDimTensors(daliPipelineHandle *pipe_handle, int n);
 
 /**
+ * @brief Check, what is the declared number of dimensions in the given output.
+ *
+ * Declared number of dimensions is a number, which user can optionally provide
+ * at the pipeline definition stage.
+ *
+ * @param n Index of the output, at which the check is performed.
+ */
+DLL_PUBLIC size_t daliGetDeclaredOutputNdim(daliPipelineHandle *pipe_handle, int n);
+
+/**
+ * @brief Check, what is the declared data type in the given output.
+ *
+ * Declared data type is a type, which user can optionally provide
+ * at the pipeline definition stage.
+ *
+ * @param n Index of the output, at which the check is performed.
+ */
+DLL_PUBLIC dali_data_type_t daliGetDeclaredOutputDtype(daliPipelineHandle *pipe_handle, int n);
+
+/**
  * @brief Returns number of DALI pipeline outputs
  */
 DLL_PUBLIC unsigned daliGetNumOutput(daliPipelineHandle *pipe_handle);


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
**New feature** (*non-breaking change which adds functionality*)
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
In order to push forward the autoconfig feature in the DALI Backend, we need `output_ndim` and `output_dtype` arguments. The reason is that DALI Backend needs a way to determine these two parameters. A better solution would be a type and dimensionality inference in DALI, but this is a big feature.

`output_ndim` defines, how many dimensions each output might have. `output_dtype` define, what is its type. For more information on how these two arguments work, please refer to their documentation in `pipeline.py` file.

This PR adds the two arguments and all the code necessary to pipe them through Python layer into the Pipeline class. I'm modifying the output descriptor, which previously was a `pair<string, string>`, denoting name of the output and the device of the output. After the change it is a `PipelineOutputDesc` with all the data. It's named `Pipeline...`, because Executor also has its own output descriptor, but it is limited to the output name.

The two parameters needed to be included in the proto definition, since we want them to be accessible after serialization and deserialization.

Lastly, I've added `output_dtype` and `output_ndim` to the AudioDecoder test, so that it has bigger coverage and more real-life scenario than the unit tests in `test_pipeline.py`.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
`pipeline.py`, python bindings, protobuf definition, Pipeline & Workspace classes, tests



### Key points relevant for the review:
1. Documentation (is it sufficient?)
2. Protobuf record for the `dtype`. Could it be applied in a more elegant way?
3. Tests in `pipeline.py`. Did I covered all necessary cases? Shall any other test case be added?



<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
