### PR TITLE
Add sequence processing to warp operator

### DIFF
--- a/dali/operators/image/CMakeLists.txt
+++ b/dali/operators/image/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 add_subdirectory(color)
 add_subdirectory(crop)
 
-# add_subdirectory(convolution)
+add_subdirectory(convolution)
 add_subdirectory(distortion)
 add_subdirectory(resize)
 add_subdirectory(paste)

--- a/dali/operators/image/CMakeLists.txt
+++ b/dali/operators/image/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 add_subdirectory(color)
 add_subdirectory(crop)
 
-add_subdirectory(convolution)
+# add_subdirectory(convolution)
 add_subdirectory(distortion)
 add_subdirectory(resize)
 add_subdirectory(paste)

--- a/dali/operators/image/remap/warp_affine.cc
+++ b/dali/operators/image/remap/warp_affine.cc
@@ -22,7 +22,7 @@ DALI_SCHEMA(WarpAffine)
 )code")
   .NumInput(1, 2)
   .NumOutput(1)
-  .InputLayout(0, { "HWC", "DHWC" })
+  .InputLayout(0, { "HWC", "FHWC", "DHWC", "FDHWC" })
   .SupportVolumetric()
   .AddOptionalArg<float>("matrix",
       R"code(Transform matrix.
@@ -41,7 +41,7 @@ transform and it is inverted before applying the formula above.
 It is equivalent to OpenCV's ``warpAffine`` operation with the ``inverse_map`` argument being
 analog to the ``WARP_INVERSE_MAP`` flag.
 )code",
-      vector<float>(), true)
+      vector<float>(), true, true)
   .AddOptionalArg<bool>("inverse_map", "Set to ``False`` if the given transform is a "
                         "destination to source mapping, ``True`` otherwise.", true, false)
   .AddParent("WarpAttr");

--- a/dali/pipeline/data/type_traits.h
+++ b/dali/pipeline/data/type_traits.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,6 +81,20 @@ static_assert(is_batch_container<TensorVector, GPUBackend>::value, "Test failed"
 static_assert(is_batch_container<TensorList, CPUBackend>::value, "Test failed");
 static_assert(is_batch_container<TensorList, GPUBackend>::value, "Test failed");
 }  // namespace test
+
+
+template <typename BatchType, typename T = void>
+struct BatchBackend;
+
+template <template <typename> class BatchContainer, typename Backend>
+struct BatchBackend<BatchContainer<Backend>,
+                    std::enable_if_t<is_batch_container<BatchContainer, Backend>::value>> {
+  using type = Backend;
+};
+
+template <typename BatchType>
+using batch_backend_t =
+    typename BatchBackend<std::remove_cv_t<std::remove_reference_t<BatchType>>>::type;
 
 }  // namespace dali
 

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -98,7 +98,7 @@ class SampleBroadcasting<GPUBackend> : public SampleBroadcasting<CPUBackend> {
  * resize the outputs.
  */
 template <typename Backend>
-class SequenceOperator : public Operator<Backend>, public SampleBroadcasting<Backend> {
+class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<Backend> {
  public:
   inline explicit SequenceOperator(const OpSpec &spec) : Operator<Backend>{spec} {}
 

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -687,8 +687,8 @@ class SequenceOperator : public Operator<Backend>, public SampleBroadcasting<Bac
   void UnfoldOuterDims(const TensorVector<DataBackend> &batch,
                        TensorVector<DataBackend> &expanded_batch, const ExpandDesc &expand_desc) {
     auto ndims_to_unfold = expand_desc.NumDimsToExpand();
-    assert(expand_desc.NumSamples() == data.num_samples());
-    assert(batch.shape.first(ndims_to_unfold).num_elements() == expand_desc.NumExpanded());
+    assert(expand_desc.NumSamples() == batch.num_samples());
+    assert(batch.shape().first(ndims_to_unfold).num_elements() == expand_desc.NumExpanded());
     sequence_utils::unfold_outer_dims(batch, expanded_batch, expand_desc.NumDimsToExpand(),
                                       expand_desc.NumExpanded());
   }

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -288,7 +288,7 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
       }
       ProcessInput(ws, input_idx, [&](const auto &input) {
         auto &expanded_input = ExpandedInput<batch_backend_t<decltype(input)>>(input_idx);
-        UnfoldBatch(input, expanded_input, ref_expand_desc);
+        UnfoldBatch(input, expanded_input, input_desc);
       });
     }
   }

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -321,6 +321,7 @@ inline void broadcast_samples(TensorList<GPUBackend> &expanded_batch,
   const auto &shape = batch.shape();
   auto broadcast_shape = broadcast_sample_shapes(shape, num_expanded_samples, expand_extents);
   expanded_batch.SetLayout(batch.GetLayout());
+  expanded_batch.set_order(stream);
   expanded_batch.Resize(broadcast_shape, batch.type());
   auto type_size = batch.type_info().size();
   for (int sample_idx = 0, elem_idx = 0; sample_idx < batch.num_samples(); sample_idx++) {

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -225,7 +225,7 @@ std::shared_ptr<Type> expanded_like(const Type &batch) {
  */
 template <typename Backend>
 struct TensorVectorBuilder {
-  TensorVectorBuilder(TensorVector<Backend> &tv) : tv_{tv} {}
+  TensorVectorBuilder(TensorVector<Backend> &tv) : tv_{tv} {}  // NOLINT
 
   void SetNext(const SliceView &view) {
     std::shared_ptr<void> ptr(view.ptr, [](void *) {});  // no deleter

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -303,9 +303,10 @@ inline void broadcast_samples(const TensorList<GPUBackend> &batch,
                               TensorList<GPUBackend> &expanded_batch, const ExpandDesc &expand_desc,
                               kernels::ScatterGatherGPU &sg, cudaStream_t stream) {
   assert(expand_desc.NumSamples() == batch.num_samples());
-  sequence_utils::setup_expanded_like(batch, expanded_batch);
+  expanded_batch.Reset();
+  setup_expanded_like(batch, expanded_batch);
   const auto &shape = batch.shape();
-  auto broadcast_shape = sequence_utils::broadcast_samples(shape, expand_desc);
+  auto broadcast_shape = broadcast_samples(shape, expand_desc);
   expanded_batch.Resize(broadcast_shape, batch.type());
   auto type_size = batch.type_info().size();
   for (int sample_idx = 0, elem_idx = 0; sample_idx < expand_desc.NumSamples(); sample_idx++) {
@@ -322,6 +323,7 @@ inline void broadcast_samples(const TensorList<CPUBackend> &batch,
                               TensorList<CPUBackend> &expanded_batch,
                               const ExpandDesc &expand_desc) {
   assert(expand_desc.NumSamples() == batch.num_samples());
+  expanded_batch.Reset();
   setup_expanded_like(batch, expanded_batch);
   const auto &shape = batch.shape();
   auto broadcast_shape = broadcast_samples(shape, expand_desc);

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -225,9 +225,9 @@ std::shared_ptr<Type> expanded_like(const Type &batch, int ndims_to_unfold) {
   TensorLayout layout = initial_layout.empty() ? "" : initial_layout.last(sample_dim);
   // TODO(ktokarski) TODO(klecki) hack with non-empty batch, so that TV does not complain
   // about setting Layout to an empty batch, change it when TV stores layout by itself
-  Type expanded(1);
-  setup_expanded_like(batch, expanded, batch.sample_dim() - ndims_to_unfold, layout);
-  return std::make_shared<Type>(std::move(expanded));
+  auto expanded_handle = std::make_shared<Type>(1);
+  setup_expanded_like(batch, *expanded_handle, batch.sample_dim() - ndims_to_unfold, layout);
+  return expanded_handle;
 }
 
 /**

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -266,6 +266,19 @@ inline TensorListShape<> unfold_outer_dims(const TensorListShape<> &shape, int n
   }
 }
 
+inline TensorListShape<> broadcast_samples(const TensorListShape<> &shape,
+                                           const ExpandDesc &expand_desc) {
+  assert(shape.num_samples() == expand_desc.NumSamples());
+  TensorListShape<> broadcast(expand_desc.NumExpanded(), shape.sample_dim());
+  for (int sample_idx = 0, elem_idx = 0; sample_idx < expand_desc.NumSamples(); sample_idx++) {
+    const auto &sample_shape = shape[sample_idx];
+    for (int i = 0; i < expand_desc.NumExpanded(sample_idx); i++) {
+      broadcast.set_tensor_shape(elem_idx++, sample_shape);
+    }
+  }
+  return broadcast;
+}
+
 template <typename Backend>
 TensorList<Backend> unfold_outer_dims(const TensorList<Backend> &data, int ndims_to_unfold) {
   // TODO(ktokarski) TODO(klecki)

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -369,9 +369,9 @@ void unfold_outer_dims(const TensorList<Backend> &batch, TensorList<Backend> &ex
   TensorLayout layout = expanded_batch.GetLayout();
   const auto &shape = batch.shape();
   expanded_batch.ShareData(batch);
+  expanded_batch.SetLayout(std::move(layout));
   auto expanded_shape = unfold_outer_dims(shape, ndims_to_unfold);
   expanded_batch.Resize(expanded_shape, batch.type());
-  expanded_batch.SetLayout(std::move(layout));
 }
 
 inline TensorListShape<> fold_outermost_like(const TensorListShape<> &shape,

--- a/dali/pipeline/operator/sequence_shape_test.cc
+++ b/dali/pipeline/operator/sequence_shape_test.cc
@@ -19,24 +19,13 @@
 #include "dali/core/format.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/kernels/common/scatter_gather.h"
+#include "dali/pipeline/data/type_traits.h"
 #include "dali/pipeline/operator/sequence_shape.h"
 #include "dali/test/tensor_test_utils.h"
 
 namespace dali {
 
 namespace sequence_utils_test {
-
-template <typename BatchType>
-struct BatchBackend;
-
-template <template <typename> class BatchContainer, typename Backend>
-struct BatchBackend<BatchContainer<Backend>> {
-  using Type = Backend;
-};
-
-template <typename BatchType>
-using batch_backend_t =
-    typename BatchBackend<std::remove_cv_t<std::remove_reference_t<BatchType>>>::Type;
 
 constexpr cudaStream_t cuda_stream = 0;
 

--- a/dali/pipeline/operator/sequence_shape_test.cc
+++ b/dali/pipeline/operator/sequence_shape_test.cc
@@ -226,6 +226,17 @@ TYPED_TEST(SequenceShapeUnfoldTest, Unfold2Extents3Iters) {
   this->TestUnfolding(*expanded_batch, batch, 2);
 }
 
+TYPED_TEST(SequenceShapeUnfoldTest, UnfoldVarExtents3Iters) {
+  auto [batch, expanded_batch] = this->CreateTestBatch(DALI_UINT8, false, "XYZ");
+  this->TestUnfolding(*expanded_batch, batch, 1);
+  batch.Resize({{2, 2, 6}, {13, 4, 11}}, DALI_FLOAT);
+  batch.SetLayout("XYZ");
+  this->TestUnfolding(*expanded_batch, batch, 2);
+  batch.Resize({{2, 2, 6}, {13, 4, 11}, {13, 4, 11}, {13, 4, 11}}, DALI_FLOAT);
+  batch.SetLayout("XYZ");
+  this->TestUnfolding(*expanded_batch, batch, 3);
+}
+
 TYPED_TEST(SequenceShapeUnfoldTest, Unfold2Extents3ItersNoLayout) {
   auto [batch, expanded_batch] = this->CreateTestBatch(DALI_UINT8, false, "");
   this->TestUnfolding(*expanded_batch, batch, 2);
@@ -235,6 +246,17 @@ TYPED_TEST(SequenceShapeUnfoldTest, Unfold2Extents3ItersNoLayout) {
   batch.Resize({{2, 2, 6}, {13, 4, 11}, {13, 4, 11}, {13, 4, 11}}, DALI_FLOAT);
   batch.SetLayout("");
   this->TestUnfolding(*expanded_batch, batch, 2);
+}
+
+TYPED_TEST(SequenceShapeUnfoldTest, UnfoldVarExtents3ItersNoLayout) {
+  auto [batch, expanded_batch] = this->CreateTestBatch(DALI_UINT8, false, "");
+  this->TestUnfolding(*expanded_batch, batch, 1);
+  batch.Resize({{2, 2, 6}, {13, 4, 11}}, DALI_FLOAT);
+  batch.SetLayout("");
+  this->TestUnfolding(*expanded_batch, batch, 2);
+  batch.Resize({{2, 2, 6}, {13, 4, 11}, {13, 4, 11}, {13, 4, 11}}, DALI_FLOAT);
+  batch.SetLayout("");
+  this->TestUnfolding(*expanded_batch, batch, 3);
 }
 
 TYPED_TEST(SequenceShapeUnfoldTest, Unfold2ExtentsEmptyLayout) {
@@ -396,9 +418,21 @@ TYPED_TEST(SequenceShapeBroadcastTest, Broadcast0Extents) {
   this->template TestBroadcasting<uint32_t>(*expanded_batch, batch, {{}, {}, {}});
 }
 
+TYPED_TEST(SequenceShapeBroadcastTest, Broadcast0ExtentsScalars) {
+  auto [batch, expanded_batch] =
+      this->template CreateTestBatch<uint32_t>(DALI_UINT32, false, "", {{}, {}, {}});
+  this->template TestBroadcasting<uint32_t>(*expanded_batch, batch, {{}, {}, {}});
+}
+
 TYPED_TEST(SequenceShapeBroadcastTest, Broadcast1Extent) {
   auto [batch, expanded_batch] = this->template CreateTestBatch<uint16_t>(DALI_UINT16);
   this->template TestBroadcasting<uint16_t>(*expanded_batch, batch, {{1}, {1}, {1}});
+}
+
+TYPED_TEST(SequenceShapeBroadcastTest, Broadcast1ExtentScalars) {
+  auto [batch, expanded_batch] =
+      this->template CreateTestBatch<uint16_t>(DALI_UINT16, false, "", {{}, {}, {}, {}});
+  this->template TestBroadcasting<uint16_t>(*expanded_batch, batch, {{1}, {1}, {1}, {1}});
 }
 
 TYPED_TEST(SequenceShapeBroadcastTest, Broadcast2Extents) {
@@ -409,6 +443,13 @@ TYPED_TEST(SequenceShapeBroadcastTest, Broadcast2Extents) {
 TYPED_TEST(SequenceShapeBroadcastTest, Broadcast2ExtentsPinned) {
   auto [batch, expanded_batch] = this->template CreateTestBatch<uint8_t>(DALI_UINT8, true);
   this->template TestBroadcasting<uint8_t>(*expanded_batch, batch, {{1, 1}, {7, 0}, {12, 4}});
+}
+
+TYPED_TEST(SequenceShapeBroadcastTest, Broadcast2ExtentsPinnedScalars) {
+  auto [batch, expanded_batch] =
+      this->template CreateTestBatch<uint8_t>(DALI_UINT8, true, "", {{}, {}, {}, {}});
+  this->template TestBroadcasting<uint8_t>(*expanded_batch, batch,
+                                           {{1, 1}, {7, 0}, {12, 4}, {7, 7}});
 }
 
 TYPED_TEST(SequenceShapeBroadcastTest, Broadcast2Extents3Iters) {

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -72,6 +72,10 @@ class ArgumentWorkspace {
     return *it->second.tvec;
   }
 
+  TensorVector<CPUBackend>& UnsafeMutableArgumentInput(const std::string &arg_name) {
+    return const_cast<TensorVector<CPUBackend>&>(ArgumentInput(arg_name));
+  }
+
  protected:
   struct ArgumentInputDesc {
     shared_ptr<TensorVector<CPUBackend>> tvec;

--- a/dali/test/python/sequences_test_utils.py
+++ b/dali/test/python/sequences_test_utils.py
@@ -56,6 +56,21 @@ class ArgDesc:
 
 
 class ArgCb:
+    """
+    Describes a callback to be used as a per-sample/per-frame argument to the operator.
+    ----------
+    `name` : Union[str, int]
+        String with the name of a named argument of the operator or an int if the data
+             should be passed as a positional input.
+    `cb` : Callable[[SampleDesc], np.ndarray]
+        Callback that based on the SampleDesc instance produces a single parameter for specific sample/frame.
+    `is_per_frame` : bool
+        Flag if the cb should be run for every sample (sequence) or for every frame. In the latter case, the
+        argument is passed wrapped in per-frame call to the operator.
+    `dest_device` : str
+        Controls whether the produced data should be passed to the operator in cpu or gpu memory.
+        If set to "gpu", the copy to gpu is added in the pipeline. Applicable only to positional inputs.
+    """
     def __init__(self, name: Union[str, int], cb: Callable[[SampleDesc], np.ndarray], is_per_frame: bool, dest_device: str = "cpu"):
         self.desc = ArgDesc(name, is_per_frame, dest_device)
         self.cb = cb
@@ -406,7 +421,7 @@ def video_suite_helper(ops_test_cases, test_channel_first=True, expand_channels=
         [(fn.operator, {fixed_param_name: fixed_param_value}, [ArgCb(tensor_arg_name, single_arg_cb, is_per_frame, dest_device)])]
         where the first element is ``fn.operator``, the second one is a dictionary of fixed arguments that should
         be passed to the operator and the last one is a list of ArgCb instances describing tensor input arguments
-        (see `ParamsProvider` argument description) or custom params provider instance.
+        or custom params provider instance (see `ParamsProvider`).
     `test_channel_first` : bool
         If True, the "FCHW" layout is tested.
     `expand_channels` : bool


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
**New feature** (*non-breaking change which adds functionality*)
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
Adds FHWC FDHWC processing to the warp affine operator. The transformation matrix can be specified per-frame and provided either as a positional or named argument.




## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
If enabling sequence processing and per-frame named (CPU) matrix argument only, the PR would have 2 lines of code.
However, matrix can be specified as a positional argument that can reside in GPU memory. This required extending the SequenceOperator functionality with broadcasting of per-sample positional arguments. However, for now, we still require GPU batches to be contiguous, which further required the SequenceOperator to actually allocate some tensorlists and perform copies. Further, the workspace is not cleared between iterations now.

The utility for testing sequence processing ops with per-frame args required some changes to specify positional arguments and the intended device:
https://github.com/NVIDIA/DALI/pull/3901

To mark positional GPU argument as per-frame, per-frame operator was extended to work with GPU backend here:
https://github.com/NVIDIA/DALI/pull/3900

The order property of TensorVector is not reflected properly by move assignment/constructor for TensorVector:
https://github.com/NVIDIA/DALI/pull/3899


<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [x] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: WAFFINE.09
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2506
<!--- DALI-XXXX or NA --->
