### PR TITLE
Optimize parameter passing for ScatterGather GPU

### DIFF
--- a/dali/kernels/common/scatter_gather.cu
+++ b/dali/kernels/common/scatter_gather.cu
@@ -14,10 +14,12 @@
 
 #include <algorithm>
 #include <cassert>
+#include <utility>
 #include <vector>
 
 #include "dali/core/cuda_error.h"
 #include "dali/kernels/common/scatter_gather.h"
+#include "dali/kernels/dynamic_scratchpad.h"
 
 namespace dali {
 namespace kernels {
@@ -63,8 +65,8 @@ size_t Coalesce(span<CopyRange> ranges) {
 
 }  // namespace detail
 
-size_t ScatterGatherBase::MakeBlocks(std::vector<CopyRange> &blocks,
-                                     const std::vector<CopyRange> &ranges) {
+std::pair<size_t, size_t>
+ScatterGatherBase::BlockCountAndSize(const std::vector<CopyRange> &ranges) const {
   size_t max_size = 0;
 
   for (auto &r : ranges) {
@@ -76,21 +78,26 @@ size_t ScatterGatherBase::MakeBlocks(std::vector<CopyRange> &blocks,
 
   size_t num_blocks = 0;
   for (auto &r : ranges)
-    num_blocks += (r.size + size_per_block - 1) / size_per_block;
+    num_blocks += div_ceil(r.size, size_per_block);
 
-  blocks.clear();
-  blocks.reserve(num_blocks);
-  for (auto &r : ranges) {
-    for (size_t ofs = 0; ofs < r.size; ofs += size_per_block) {
-      blocks.push_back({ r.src + ofs, r.dst + ofs, std::min(r.size - ofs, size_per_block) });
-    }
-  }
-  assert(blocks.size() == num_blocks);
-  return size_per_block;
+  return { num_blocks, size_per_block };
 }
 
-void ScatterGatherGPU::MakeBlocks() {
-  size_per_block_ = ScatterGatherBase::MakeBlocks(blocks_, ranges_);
+
+template <typename BlockCollection>
+void ScatterGatherBase::MakeBlocks(BlockCollection &blocks,
+                                   const std::vector<CopyRange> &ranges,
+                                   size_t size_per_block) {
+  auto nblocks = dali::size(blocks);
+  decltype(nblocks) b = 0;
+
+  for (auto &r : ranges) {
+    for (size_t ofs = 0; ofs < r.size; ofs += size_per_block) {
+      assert(b < nblocks);
+      blocks[b++] = { r.src + ofs, r.dst + ofs, std::min(r.size - ofs, size_per_block) };
+    }
+  }
+  assert(b == nblocks);
 }
 
 void ScatterGatherCPU::MakeBlocks(size_t blocks_lower_limit) {
@@ -122,12 +129,28 @@ void ScatterGatherCPU::MakeBlocks(size_t blocks_lower_limit) {
     std::push_heap(heap_.begin(), heap_.end(), cmp);
   }
 
-  ScatterGatherBase::MakeBlocks(blocks_, heap_);
+  size_t num_blocks, size_per_block;
+  std::tie(num_blocks, size_per_block) = BlockCountAndSize(heap_);
+  blocks_.resize(num_blocks);
+  ScatterGatherBase::MakeBlocks(blocks_, heap_, size_per_block);
 }
-
 
 __global__ void BatchCopy(const ScatterGatherBase::CopyRange *ranges) {
   auto range = ranges[blockIdx.x];
+
+  for (size_t i = threadIdx.x; i < range.size; i += blockDim.x) {
+    range.dst[i] = range.src[i];
+  }
+}
+
+constexpr int kMaxRangesByVal = 2048 / sizeof(ScatterGatherBase::CopyRange);
+
+struct CopyRanges {
+  ScatterGatherBase::CopyRange ranges[kMaxRangesByVal];
+};
+
+__global__ void BatchCopy(CopyRanges ranges) {
+  auto range = ranges.ranges[blockIdx.x];
 
   for (size_t i = threadIdx.x; i < range.size; i += blockDim.x) {
     range.dst[i] = range.src[i];
@@ -148,12 +171,27 @@ void ScatterGatherGPU::Run(cudaStream_t stream, bool reset, ScatterGatherGPU::Me
       CUDA_CALL(cudaMemcpyAsync(r.dst, r.src, r.size, memcpyKind, stream));
     }
   } else {
-    MakeBlocks();
-    blocks_dev_.from_host(blocks_, stream);
+    size_t num_blocks, size_per_block;
+    std::tie(num_blocks, size_per_block) = BlockCountAndSize(ranges_);
+    if (num_blocks > kMaxRangesByVal) {
+      kernels::DynamicScratchpad scratchpad({}, stream);
+      auto *blocks_pinned = scratchpad.Allocate<mm::memory_kind::pinned, CopyRange>(num_blocks);
+      auto blocks = make_span(blocks_pinned, num_blocks);
+      ScatterGatherBase::MakeBlocks(blocks, ranges_, size_per_block);
+      auto *blocks_dev = scratchpad.ToGPU(stream, blocks);
 
-    dim3 grid(blocks_.size());
-    dim3 block(std::min<size_t>(size_per_block_, 1024));
-    BatchCopy<<<grid, block, 0, stream>>>(blocks_dev_.data());
+      dim3 grid(blocks.size());
+      dim3 block(std::min<size_t>(size_per_block, 1024));
+      BatchCopy<<<grid, block, 0, stream>>>(blocks_dev);
+    } else {
+      CopyRanges ranges = {};
+      auto blocks = make_span(ranges.ranges, num_blocks);
+      ScatterGatherBase::MakeBlocks(blocks, ranges_, size_per_block);
+
+      dim3 grid(blocks.size());
+      dim3 block(std::min<size_t>(size_per_block, 1024));
+      BatchCopy<<<grid, block, 0, stream>>>(ranges);
+    }
     CUDA_CALL(cudaGetLastError());
   }
 

--- a/dali/kernels/common/scatter_gather.h
+++ b/dali/kernels/common/scatter_gather.h
@@ -21,12 +21,15 @@
 #include <limits>
 #include <queue>
 #include <vector>
+#include <utility>
 #include "dali/core/api_helper.h"
-#include "dali/core/dev_buffer.h"
 #include "dali/core/span.h"
+#include "dali/core/mm/memory.h"
 
 namespace dali {
 namespace kernels {
+
+class Scratchpad;
 
 namespace detail {
 struct DLL_PUBLIC CopyRange {
@@ -93,14 +96,18 @@ class DLL_PUBLIC ScatterGatherBase {
     ranges_.resize(n);
   }
 
+  std::pair<size_t, size_t> BlockCountAndSize(const std::vector<CopyRange> &ranges) const;
+
   /**
    * @brief Divides ranges so they don't exceed `max_block_size_`
    */
-  size_t MakeBlocks(std::vector<CopyRange> &blocks, const std::vector<CopyRange> &ranges);
+  template <typename BlockCollection>
+  void MakeBlocks(BlockCollection &blocks,
+                  const std::vector<CopyRange> &ranges,
+                  size_t size_per_block);
 
   size_t max_size_per_block_ = kDefaultBlockSize;
 };
-
 
 /**
  * Implements a device-to-device batch copy of multiple sources to multiple destinations
@@ -111,17 +118,7 @@ class DLL_PUBLIC ScatterGatherGPU : public ScatterGatherBase {
 
   ScatterGatherGPU() = default;
 
-  ScatterGatherGPU(size_t max_size_per_block, size_t estimated_num_blocks)
-      : ScatterGatherBase(max_size_per_block) {
-    blocks_.reserve(estimated_num_blocks);
-    blocks_dev_.reserve(estimated_num_blocks);
-  }
-
   explicit ScatterGatherGPU(size_t max_size_per_block) : ScatterGatherBase(max_size_per_block) {}
-
-  ScatterGatherGPU(size_t max_size_per_block, size_t total_size, size_t num_ranges)
-      : ScatterGatherGPU(max_size_per_block, (total_size + num_ranges * (max_size_per_block - 1)) /
-                                                 max_size_per_block) {}
 
   /**
    * @brief Executes the copies
@@ -139,21 +136,9 @@ class DLL_PUBLIC ScatterGatherGPU : public ScatterGatherBase {
    */
   void Reset() {
     ScatterGatherBase::Reset();
-    blocks_.clear();
-    blocks_dev_.clear();
   }
 
   using CopyRange = detail::CopyRange;
-
- private:
-  /**
-   * @brief Divides ranges so they don't exceed `max_block_size_`
-   */
-  void MakeBlocks();
-
-  std::vector<CopyRange> blocks_;
-  DeviceBuffer<CopyRange> blocks_dev_;
-  size_t size_per_block_ = 0;
 };
 
 
@@ -164,17 +149,7 @@ class DLL_PUBLIC ScatterGatherCPU : public ScatterGatherBase {
  public:
   ScatterGatherCPU() = default;
 
-  ScatterGatherCPU(size_t max_size_per_block, size_t estimated_num_blocks)
-      : ScatterGatherBase(max_size_per_block) {
-    heap_.resize(estimated_num_blocks);
-    blocks_.resize(estimated_num_blocks);
-  }
-
   explicit ScatterGatherCPU(size_t max_size_per_block) : ScatterGatherBase(max_size_per_block) {}
-
-  ScatterGatherCPU(size_t max_size_per_block, size_t total_size, size_t num_ranges)
-      : ScatterGatherCPU(max_size_per_block, (total_size + num_ranges * (max_size_per_block - 1)) /
-                                                 max_size_per_block) {}
 
   /**
    * @brief Executes the copies

--- a/dali/operators/decoder/cache/cached_decoder_impl.cc
+++ b/dali/operators/decoder/cache/cached_decoder_impl.cc
@@ -41,8 +41,7 @@ CachedDecoderImpl::CachedDecoderImpl(const OpSpec& spec)
       use_batch_copy_kernel_ = spec.GetArgument<bool>("cache_batch_copy");
       auto batch_size = spec.GetArgument<int>("max_batch_size");
       const size_t kMaxSizePerBlock = 1<<18;  // 256 kB per block
-      scatter_gather_.reset(new kernels::ScatterGatherGPU(
-        kMaxSizePerBlock, cache_size, batch_size));
+      scatter_gather_.reset(new kernels::ScatterGatherGPU(kMaxSizePerBlock));
     }
   }
 }

--- a/dali/operators/generic/permute_batch.h
+++ b/dali/operators/generic/permute_batch.h
@@ -90,7 +90,7 @@ class PermuteBatch<GPUBackend> : public PermuteBatchBase<GPUBackend> {
  public:
   explicit PermuteBatch(const OpSpec &spec)
   : PermuteBatchBase<GPUBackend>(spec)
-  , sg_(1<<18, spec.GetArgument<int>("max_batch_size")) {}
+  , sg_(1<<18) {}
 
 
   void RunImpl(DeviceWorkspace &ws) override;

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -25,7 +25,7 @@ namespace dali {
 NumpyReaderGPU::NumpyReaderGPU(const OpSpec& spec)
     : NumpyReader<GPUBackend, NumpyFileWrapperGPU>(spec),
       thread_pool_(num_threads_, spec.GetArgument<int>("device_id"), false),
-      sg_(1 << 18, spec.GetArgument<int>("max_batch_size")) {
+      sg_(1 << 18) {
   prefetched_batch_tensors_.resize(prefetch_queue_depth_);
 
   for (auto &t : prefetched_batch_tensors_)

--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -46,7 +46,7 @@ ScatterGatherPool& ScatterGatherPoolInstance() {
 
 void ScatterGatherCopy(void **dsts, const void **srcs, const Index *sizes, int n, int element_size,
                        cudaStream_t stream) {
-  auto sc = ScatterGatherPoolInstance().Get(stream, kMaxSizePerBlock, n);
+  auto sc = ScatterGatherPoolInstance().Get(stream, kMaxSizePerBlock);
   for (int i = 0; i < n; i++) {
     sc->AddCopy(dsts[i], srcs[i], sizes[i] * element_size);
   }
@@ -55,7 +55,7 @@ void ScatterGatherCopy(void **dsts, const void **srcs, const Index *sizes, int n
 
 void ScatterGatherCopy(void *dst, const void **srcs, const Index *sizes, int n, int element_size,
                        cudaStream_t stream) {
-  auto sc = ScatterGatherPoolInstance().Get(stream, kMaxSizePerBlock, n);
+  auto sc = ScatterGatherPoolInstance().Get(stream, kMaxSizePerBlock);
   auto *sample_dst = reinterpret_cast<uint8_t*>(dst);
   for (int i = 0; i < n; i++) {
     auto nbytes = sizes[i] * element_size;
@@ -67,7 +67,7 @@ void ScatterGatherCopy(void *dst, const void **srcs, const Index *sizes, int n, 
 
 void ScatterGatherCopy(void **dsts, const void *src, const Index *sizes, int n, int element_size,
                        cudaStream_t stream) {
-  auto sc = ScatterGatherPoolInstance().Get(stream, kMaxSizePerBlock, n);
+  auto sc = ScatterGatherPoolInstance().Get(stream, kMaxSizePerBlock);
   auto *sample_src = reinterpret_cast<const uint8_t*>(src);
   for (int i = 0; i < n; i++) {
     auto nbytes = sizes[i] * element_size;


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!--- Please pick one from below: --->
<!--- **Bug fix** (*non-breaking change which fixes an issue*) --->
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)\
**Other** (*e.g. Documentation, Tests, Configuration*)
Performance optimization


## Description:
ScatterGatherGPU used a temporary host vector to pass arguments to the kernel. This copy from pinned memory might pose problems on some systems, potentially resulting in driver locks. This PR uses a temporary pinned buffer or, if the number of blocks is small, passes them by value, eliminating the copy call entirely.

Since this gets rid of the members blocks_ and blocks_dev_, the size estimates for these are no longer necessary and the relevant constructors and their usages have been removed.

The tests have been adjusted so that both variants (pinned mem and by-value) are used.

## Additional information:

### Affected modules and functionalities:
ScatterGather
ScatterGather tests
Usages of the removed constructors.

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->


<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2788
<!--- DALI-XXXX or NA --->
