### PR TITLE
Fix scalar handling in GPU cast

### DIFF
--- a/dali/operators/generic/cast.cu
+++ b/dali/operators/generic/cast.cu
@@ -58,8 +58,13 @@ bool CastGPU::SetupImpl(std::vector<OutputDesc> &output_desc, const DeviceWorksp
 void CastGPU::PrepareBlocks(const DeviceWorkspace &ws) {
   const auto &input = ws.Input<GPUBackend>(0);
   const auto &input_shape = input.shape();
-  std::array<std::pair<int, int>, 1> collapse_groups = {{{0, input_shape.sample_dim()}}};
-  auto collapsed_shape = collapse_dims<1>(input.shape(), collapse_groups);
+  TensorListShape<1> collapsed_shape;
+  if (input.sample_dim() > 0) {
+    std::array<std::pair<int, int>, 1> collapse_groups = {{{0, input_shape.sample_dim()}}};
+    collapsed_shape = collapse_dims<1>(input_shape, collapse_groups);
+  } else {
+    collapsed_shape = uniform_list_shape(input_shape.num_samples(), TensorShape<1>{1});
+  }
 
   block_setup_.SetupBlocks(collapsed_shape, true);
 }


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

## Category:
<!--- Please pick one from below: --->
**Bug fix** (*non-breaking change which fixes an issue*)
<!--- **New feature** (*non-breaking change which adds functionality*) --->
<!--- **Breaking change** (*fix or feature that would cause existing functionality to not work as expected*) --->
<!--- **Refactoring** (*Redesign of existing code that doesn't affect functionality*) --->
<!--- **Other** (*e.g. Documentation, Tests, Configuration*) --->



## Description:
Scalars were not properly handled in operator cast - there was an attempt to collapse the shape, which failed catastrophically (assertion in Debug build and access violation in Release) if the input shape is 0D, in which case it needs to be artificially expanded.
This PR adds special handling for that case.

## Additional information:

### Affected modules and functionalities:
Operator cast.


### Key points relevant for the review:
N/A

**TODO** (separate PR): Add proper tests for operator `cast`.

<!--- 
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Tests
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
