### PR TITLE
Update compilation flags for the DALI TensorFlow plugin

### DIFF
--- a/dali_tf_plugin/dali_tf_plugin_install_tool.py
+++ b/dali_tf_plugin/dali_tf_plugin_install_tool.py
@@ -16,7 +16,7 @@ import platform
 from shutil import copyfile
 from dali_tf_plugin_utils import *
 import os
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion, LooseVersion
 from pathlib import Path
 import tempfile
 from stubgen import stubgen
@@ -278,12 +278,14 @@ class InstallerHelper:
             lib_filename = 'libdali_tf_current.so'
             lib_path =  os.path.join(self.plugin_dest_dir, lib_filename)
 
+            # for a newer TF we need to compiler with C++17
+            cpp_ver = "--std=c++14" if self.tf_version < LooseVersion('2.10') else "--std=c++17"
             # Note: DNDEBUG flag is needed due to issue with TensorFlow custom ops:
             # https://github.com/tensorflow/tensorflow/issues/17316
             # Do not remove it.
             # the latest TF in conda needs to include /PREFIX/include
             root_include = "-I" + os.getenv("PREFIX", default="/usr") + "/include"
-            cmd = compiler + ' -Wl,-R,\'$ORIGIN/..\' -Wl,-rpath,\'$ORIGIN\' -std=c++14 -DNDEBUG -shared ' \
+            cmd = compiler + ' -Wl,-R,\'$ORIGIN/..\' -Wl,-rpath,\'$ORIGIN\' ' + cpp_ver + ' -DNDEBUG -shared ' \
                 + plugin_src + ' -o ' + lib_path + ' -fPIC ' + dali_cflags + ' ' \
                 + tf_cflags + ' ' + root_include + ' ' + cuda_cflags + ' ' + dali_lflags + ' ' \
                 + tf_lflags + ' ' + cuda_lflags + ' -O2'


### PR DESCRIPTION
- as the TensroFlow 2.10 is compiled with C++17 support DALI TF plugin
  needs to use the same build configuration as well

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (DALI TF plugin compilation flags)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- as the TensroFlow 2.10 is compiled with C++17 support DALI TF plugin
  needs to use the same build configuration as well
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- DALI TF plugin
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - L1_TF_nightly_basic_check
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
