### PR TITLE
Per frame affine transforms

### DIFF
--- a/dali/operators/geometry/affine_transforms/combine_transforms.cc
+++ b/dali/operators/geometry/affine_transforms/combine_transforms.cc
@@ -46,6 +46,7 @@ Example: combining [T1, T2, T3] is equivalent to T3(T2(T1(...))) for default ord
 )code")
   .NumInput(2, 99)
   .NumOutput(1)
+  .AllowSequences()
   .AddParent("TransformAttr");
 
 class CombineTransformsCPU : public SequenceOperator<CPUBackend> {

--- a/dali/operators/geometry/affine_transforms/combine_transforms.cc
+++ b/dali/operators/geometry/affine_transforms/combine_transforms.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #include "dali/pipeline/operator/op_spec.h"
 #include "dali/pipeline/workspace/workspace.h"
 #include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/operator/sequence_operator.h"
 
 #define TRANSFORM_INPUT_TYPES (float)
 
@@ -47,10 +48,10 @@ Example: combining [T1, T2, T3] is equivalent to T3(T2(T1(...))) for default ord
   .NumOutput(1)
   .AddParent("TransformAttr");
 
-class CombineTransformsCPU : public Operator<CPUBackend> {
+class CombineTransformsCPU : public SequenceOperator<CPUBackend> {
  public:
   explicit CombineTransformsCPU(const OpSpec &spec) :
-      Operator<CPUBackend>(spec),
+      SequenceOperator<CPUBackend>(spec),
       reverse_order_(spec.GetArgument<bool>("reverse_order")) {
   }
 
@@ -149,6 +150,18 @@ class CombineTransformsCPU : public Operator<CPUBackend> {
     TYPE_SWITCH(dtype_, type2id, T, TRANSFORM_INPUT_TYPES, (
       RunImplTyped<T>(ws, SupportedDims());
     ), DALI_FAIL(make_string("Unsupported data type: ", dtype_)));  // NOLINT
+  }
+
+  void PostprocessOutputs(workspace_t<CPUBackend> &ws) override {
+    if (this->IsExpanding()) {
+      auto &out = ws.template Output<CPUBackend>(0);
+      int sample_dim = out.sample_dim();
+      assert(sample_dim > 0);
+      TensorLayout layout;
+      layout.resize(sample_dim, '*');
+      layout[0] = 'F';
+      out.SetLayout(layout);
+    }
   }
 
  private:

--- a/dali/operators/geometry/affine_transforms/transform_base_op.h
+++ b/dali/operators/geometry/affine_transforms/transform_base_op.h
@@ -47,8 +47,8 @@ using affine_mat_t = mat<mat_dim, mat_dim, T>;
  */
 template <typename Backend, typename TransformImpl>
 class TransformBaseOp : public SequenceOperator<Backend, true> {
- using Base = SequenceOperator<Backend, true>;
  public:
+  using Base = SequenceOperator<Backend, true>;
   explicit TransformBaseOp(const OpSpec &spec) :
       Base(spec), reverse_order_(spec.GetArgument<bool>("reverse_order")) {
     matrix_data_.set_pinned(false);

--- a/dali/operators/geometry/affine_transforms/transform_crop.cc
+++ b/dali/operators/geometry/affine_transforms/transform_crop.cc
@@ -70,6 +70,7 @@ If another transform matrix is passed as an input, the operator applies the tran
     false)
   .NumInput(0, 1)
   .NumOutput(1)
+  .AllowSequences()
   .AddParent("TransformAttr");
 
 /**

--- a/dali/operators/geometry/affine_transforms/transform_crop.cc
+++ b/dali/operators/geometry/affine_transforms/transform_crop.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ If another transform matrix is passed as an input, the operator applies the tran
     If left empty, a vector of zeros will be assumed.
     If a single value is provided, it will be repeated to match the number of dimensions
 )code",
-    std::vector<float>{0.0}, true)
+    std::vector<float>{0.0}, true, true)
   .AddOptionalArg(
     "from_end",
     R"code(The upper bound of the original coordinate space.
@@ -45,7 +45,7 @@ If another transform matrix is passed as an input, the operator applies the tran
     If left empty, a vector of ones will be assumed.
     If a single value is provided, it will be repeated to match the number of dimensions
 )code",
-    std::vector<float>{1.0}, true)
+    std::vector<float>{1.0}, true, true)
   .AddOptionalArg(
     "to_start",
     R"code(The lower bound of the destination coordinate space.
@@ -54,7 +54,7 @@ If another transform matrix is passed as an input, the operator applies the tran
     If left empty, a vector of zeros will be assumed.
     If a single value is provided, it will be repeated to match the number of dimensions
 )code",
-    std::vector<float>{0.0}, true)
+    std::vector<float>{0.0}, true, true)
   .AddOptionalArg(
     "to_end",
     R"code(The upper bound of the destination coordinate space.
@@ -63,7 +63,7 @@ If another transform matrix is passed as an input, the operator applies the tran
     If left empty, a vector of ones will be assumed.
     If a single value is provided, it will be repeated to match the number of dimensions
 )code",
-    std::vector<float>{1.0}, true)
+    std::vector<float>{1.0}, true, true)
   .AddOptionalArg(
     "absolute",
     R"code(If set to true, start and end coordinates will be swapped if start > end.)code",

--- a/dali/operators/geometry/affine_transforms/transform_rotation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_rotation.cc
@@ -49,6 +49,7 @@ If provided, the number of elements should match the dimensionality of the trans
     nullptr, true, true)
   .NumInput(0, 1)
   .NumOutput(1)
+  .AllowSequences()
   .AddParent("TransformAttr");
 
 /**

--- a/dali/operators/geometry/affine_transforms/transform_rotation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_rotation.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ The number of dimensions is assumed to be 3 if a rotation axis is provided or 2 
   .AddArg(
     "angle",
     R"code(Angle, in degrees.)code",
-    DALI_FLOAT, true)
+    DALI_FLOAT, true, true)
   .AddOptionalArg<std::vector<float>>(
     "axis",
     R"code(Axis of rotation (applies **only** to 3D transforms).
@@ -40,13 +40,13 @@ The number of dimensions is assumed to be 3 if a rotation axis is provided or 2 
 The vector does not need to be normalized, but it must have a non-zero length.
 
 Reversing the vector is equivalent to changing the sign of ``angle``.)code",
-    nullptr, true)
+    nullptr, true, true)
   .AddOptionalArg<std::vector<float>>(
     "center",
     R"code(The center of the rotation.
 
 If provided, the number of elements should match the dimensionality of the transform.)code",
-    nullptr, true)
+    nullptr, true, true)
   .NumInput(0, 1)
   .NumOutput(1)
   .AddParent("TransformAttr");

--- a/dali/operators/geometry/affine_transforms/transform_scale.cc
+++ b/dali/operators/geometry/affine_transforms/transform_scale.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,13 +30,13 @@ If another transform matrix is passed as an input, the operator applies scaling 
     R"code(The scale factor, per dimension.
 
 The number of dimensions of the transform is inferred from this argument.)code",
-    DALI_FLOAT_VEC, true)
+    DALI_FLOAT_VEC, true, true)
   .AddOptionalArg<std::vector<float>>(
     "center",
     R"code(The center of the scale operation.
 
 If provided, the number of elements should match the one of ``scale`` argument.)code",
-    nullptr, true)
+    nullptr, true, true)
   .AddOptionalArg<int>(
     "ndim",
     R"code(Number of dimensions.

--- a/dali/operators/geometry/affine_transforms/transform_scale.cc
+++ b/dali/operators/geometry/affine_transforms/transform_scale.cc
@@ -47,6 +47,7 @@ when `scale` is a scalar value and there's no input transform.
     nullptr, false)
   .NumInput(0, 1)
   .NumOutput(1)
+  .AllowSequences()
   .AddParent("TransformAttr");
 
 /**

--- a/dali/operators/geometry/affine_transforms/transform_shear.cc
+++ b/dali/operators/geometry/affine_transforms/transform_shear.cc
@@ -71,6 +71,7 @@ If provided, the number of elements should match the dimensionality of the trans
     nullptr, true, true)
   .NumInput(0, 1)
   .NumOutput(1)
+  .AllowSequences()
   .AddParent("TransformAttr");
 
 /**

--- a/dali/operators/geometry/affine_transforms/transform_shear.cc
+++ b/dali/operators/geometry/affine_transforms/transform_shear.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ direction of the second axis.
     This argument is mutually exclusive with ``angles``.
     If provided, the number of dimensions of the transform is inferred from this argument.
 )code",
-    nullptr, true)
+    nullptr, true, true)
   .AddOptionalArg<std::vector<float>>(
     "angles",
     R"code(The shear angles, in degrees.
@@ -62,13 +62,13 @@ A shear angle is translated to a shear factor as follows::
     This argument is mutually exclusive with ``shear``.
     If provided, the number of dimensions of the transform is inferred from this argument.
 )code",
-    nullptr, true)
+    nullptr, true, true)
   .AddOptionalArg<std::vector<float>>(
     "center",
     R"code(The center of the shear operation.
 
 If provided, the number of elements should match the dimensionality of the transform.)code",
-    nullptr, true)
+    nullptr, true, true)
   .NumInput(0, 1)
   .NumOutput(1)
   .AddParent("TransformAttr");

--- a/dali/operators/geometry/affine_transforms/transform_translation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_translation.cc
@@ -33,6 +33,7 @@ The number of dimensions of the transform is inferred from this argument.)code",
     DALI_FLOAT_VEC, true, true)
   .NumInput(0, 1)
   .NumOutput(1)
+  .AllowSequences()
   .AddParent("TransformAttr");
 
 DALI_SCHEMA(TransformTranslation)  // Deprecated in 0.28.0dev

--- a/dali/operators/geometry/affine_transforms/transform_translation.cc
+++ b/dali/operators/geometry/affine_transforms/transform_translation.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ If another transform matrix is passed as an input, the operator applies translat
     R"code(The translation vector.
 
 The number of dimensions of the transform is inferred from this argument.)code",
-    DALI_FLOAT_VEC, true)
+    DALI_FLOAT_VEC, true, true)
   .NumInput(0, 1)
   .NumOutput(1)
   .AddParent("TransformAttr");

--- a/dali/operators/geometry/coord_transform.cc
+++ b/dali/operators/geometry/coord_transform.cc
@@ -42,6 +42,7 @@ This operator can be used for many operations. Here's the (incomplete) list:
 If an integral type is used, the output values are rounded to the nearest integer and clamped
 to the dynamic range of this type.)",
     DALI_FLOAT)
+  .AllowSequences()
   .AddParent("MTTransformAttr");
 
 template <>

--- a/dali/operators/geometry/coord_transform.h
+++ b/dali/operators/geometry/coord_transform.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,8 +20,9 @@
 #include "dali/core/geom/mat.h"
 #include "dali/core/static_switch.h"
 #include "dali/kernels/kernel_manager.h"
-#include "dali/pipeline/operator/operator.h"
 #include "dali/operators/geometry/mt_transform_attr.h"
+#include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/operator/sequence_operator.h"
 
 namespace dali {
 
@@ -29,16 +30,17 @@ namespace dali {
 #define COORD_TRANSFORM_DIMS (1, 2, 3, 4, 5, 6)
 
 template <typename Backend>
-class CoordTransform : public Operator<Backend>, private MTTransformAttr {
+class CoordTransform : public SequenceOperator<Backend, true>, private MTTransformAttr {
  public:
-  explicit CoordTransform(const OpSpec &spec) : Operator<Backend>(spec), MTTransformAttr(spec) {
+  using Base = SequenceOperator<Backend, true>;
+  explicit CoordTransform(const OpSpec &spec) : Base(spec), MTTransformAttr(spec) {
     dtype_ = spec_.template GetArgument<DALIDataType>("dtype");
   }
 
   bool CanInferOutputs() const override { return true; }
 
  protected:
-  using Operator<Backend>::spec_;
+  using Base::spec_;
   bool SetupImpl(std::vector<OutputDesc> &output_descs, const workspace_t<Backend> &ws) override {
     auto &input = ws.template Input<Backend>(0);     // get a reference to the input tensor list
     const auto &input_shape = input.shape();         // get a shape - use const-ref to avoid copying

--- a/dali/operators/geometry/mt_transform_attr.cc
+++ b/dali/operators/geometry/mt_transform_attr.cc
@@ -35,14 +35,14 @@ If a scalar value is provided, ``M`` is assumed to be a square matrix with that 
 diagonal. The size of the matrix is then assumed to match the number of components in the
 input vectors.)",
     nullptr,  // no default value
-    true)
+    true, true)
   .AddOptionalArg<vector<float>>("T", R"(The translation vector.
 
 If left unspecified, no translation is applied unless MT argument is used.
 
 The number of components of this vector must match the number of rows in matrix ``M``.
 If a scalar value is provided, that value is broadcast to all components of ``T`` and the number
-of components is chosen to match the number of rows in ``M``.)", nullptr, true)
+of components is chosen to match the number of rows in ``M``.)", nullptr, true, true)
   .AddOptionalArg<vector<float>>("MT", R"(A block matrix [M T] which combines the arguments
 ``M`` and ``T``.
 
@@ -51,8 +51,7 @@ M and leaving T unspecified.
 
 The number of columns must be one more than the number of components in the input.
 This argument is mutually exclusive with ``M`` and ``T``.)",
-    nullptr,
-    true);
+    nullptr, true, true);
 
 void MTTransformAttr::ProcessMatrixArg(const OpSpec &spec, const ArgumentWorkspace &ws, int N) {
   bool is_fused = HasFusedMT();

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -358,7 +358,7 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
   void SetupSequenceOperator(const workspace_t<Backend> &ws) {
     auto num_inputs = ws.NumInput();
     input_expand_desc_.clear();
-    input_expand_desc_.reserve(num_inputs + 1);
+    input_expand_desc_.reserve(num_inputs);
     for (int input_idx = 0; input_idx < num_inputs; input_idx++) {
       const auto &input_shape = ws.GetInputShape(input_idx);
       const auto &layout = GetInputLayout(ws, input_idx);

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -96,8 +96,14 @@ class SampleBroadcasting<GPUBackend> : public SampleBroadcasting<CPUBackend> {
  *
  * The operator must infer output shapes in the setup stage and must not manually
  * resize the outputs.
+ *
+ * To enter 'expanding' mode, the SequenceOperator needs an input that
+ * contains expandable leading extents that serve as a reference to
+ * unfold/broadcast other inputs and named arguments.
+ * By default, with `allow_named_arg_ref=false,  only positional input can be used as such a
+ * reference.
  */
-template <typename Backend>
+template <typename Backend, bool allow_named_arg_ref = false>
 class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<Backend> {
  public:
   inline explicit SequenceOperator(const OpSpec &spec) : Operator<Backend>{spec} {}
@@ -127,6 +133,7 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
         InitializeExpandedWorkspace(ws);
         is_expanded_ws_initialized_ = true;
       }
+      expanded_.SetBatchSizes(GetReferenceExpandDesc().NumExpanded());
       ExpandInputs(ws);
       ExpandArguments(ws);
       is_inferred = Operator<Backend>::Setup(output_desc, expanded_);
@@ -151,9 +158,8 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
   }
 
   bool IsExpandable() const {
-    auto expand_like_idx = GetReferenceInputIdx();
-    assert(expand_like_idx == -1 || GetInputExpandDesc(expand_like_idx).NumDimsToExpand() > 0);
-    return expand_like_idx >= 0;
+    assert(expand_like_ == nullptr || expand_like_->NumDimsToExpand() > 0);
+    return expand_like_ != nullptr;
   }
 
  protected:
@@ -205,22 +211,14 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
   /**
    * @brief Gets the ExpandDesc instance that describes the expandable prefix of the output layout
    * and corresponding prefixes of the shapes in the batch. By default, the sequence shape and
-   * expandable layout are assumed to be the same for the output and the expandable input. If that's
-   * not the case, the method may be overriden to provide different ExpandDesc instance.
+   * expandable layout are assumed to be the same for the output and the referential expandable
+   * input. If that's not the case, the method may be overriden to provide different ExpandDesc
+   * instance.
    */
   virtual const ExpandDesc &GetOutputExpandDesc(const workspace_t<Backend> &ws,
                                                 int output_idx) const {
     (void)output_idx;
-    return GetInputExpandDesc(GetReferenceInputIdx());
-  }
-
-  /**
-   * @brief Returns the index of the operator input which is expandable and given argument input
-   * should be expanded or broadcast in a manner consistent with the input.
-   */
-  virtual int GetArgExpandDescInputIdx(const std::string &arg_name) const {
-    (void)arg_name;
-    return GetReferenceInputIdx();
+    return GetReferenceExpandDesc();
   }
 
   virtual void InitializeExpandedArgument(const workspace_t<Backend> &ws,
@@ -246,8 +244,8 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
   virtual void ExpandArgument(const ArgumentWorkspace &ws, const std::string &arg_name,
                               const TensorVector<CPUBackend> &arg_input) {
     assert(IsExpandable());
-    auto input_idx = GetArgExpandDescInputIdx(arg_name);
-    ExpandArgumentLikeInput(ExpandedArg(arg_name), arg_input, arg_name, input_idx);
+    const auto &ref_expand_desc = GetReferenceExpandDesc();
+    ExpandArgumentLikeRef(ExpandedArg(arg_name), arg_input, arg_name, ref_expand_desc);
   }
 
   virtual void InitializeExpandedInput(const workspace_t<Backend> &ws, int input_idx) {
@@ -274,8 +272,7 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
    */
   virtual void ExpandInput(const workspace_t<Backend> &ws, int input_idx) {
     assert(IsExpandable());
-    int ref_input_idx = GetReferenceInputIdx();
-    const auto &ref_expand_desc = GetInputExpandDesc(ref_input_idx);
+    const auto &ref_expand_desc = GetReferenceExpandDesc();
     const auto &input_desc = GetInputExpandDesc(input_idx);
     int num_expand_dims = input_desc.NumDimsToExpand();
     if (num_expand_dims == 0) {
@@ -284,8 +281,8 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
         BroadcastBatch(expanded_input, input, ref_expand_desc);
       });
     } else {
-      if (ref_input_idx != input_idx) {
-        VerifyExpansionConsistency(ref_input_idx, ref_expand_desc, input_idx, input_desc);
+      if (ref_expand_desc.SourceInfo().InputIdx() != input_idx) {
+        VerifyExpansionConsistency(ref_expand_desc, input_desc);
       }
       ProcessInput(ws, input_idx, [&](const auto &input) {
         auto &expanded_input = ExpandedInput<batch_backend_t<decltype(input)>>(input_idx);
@@ -361,32 +358,50 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
   void SetupSequenceOperator(const workspace_t<Backend> &ws) {
     auto num_inputs = ws.NumInput();
     input_expand_desc_.clear();
-    input_expand_desc_.reserve(num_inputs);
+    input_expand_desc_.reserve(num_inputs + 1);
     for (int input_idx = 0; input_idx < num_inputs; input_idx++) {
       const auto &input_shape = ws.GetInputShape(input_idx);
       const auto &layout = GetInputLayout(ws, input_idx);
-      input_expand_desc_.emplace_back(input_shape, layout, ShouldExpandChannels(input_idx));
+      input_expand_desc_.emplace_back(input_idx, input_shape, layout,
+                                      ShouldExpandChannels(input_idx));
     }
-    expand_like_idx_ = InferExpandableInputIdx(ws);
+    expand_like_ = InferReferenceExpandDesc(ws);
   }
 
-  int InferExpandableInputIdx(const workspace_t<Backend> &ws) {
-    auto num_inputs = ws.NumInput();
-    for (int input_idx = 0; input_idx < num_inputs; input_idx++) {
-      if (input_expand_desc_[input_idx].NumDimsToExpand() > 0) {
-        return input_idx;
+  const ExpandDesc *InferNamedReferenceExpandDesc(const workspace_t<Backend> &ws) {
+    for (const auto &arg_input : ws) {
+      auto &shared_tvec = arg_input.second.tvec;
+      assert(shared_tvec);
+      const std::string &name = arg_input.first;
+      const auto &batch = *shared_tvec;
+      if (IsPerFrameArg(name, batch)) {
+        input_expand_desc_.emplace_back(name, batch.shape(), batch.GetLayout(), false);
+        return &input_expand_desc_.back();
       }
     }
-    return -1;
+    return nullptr;
+  }
+
+  const ExpandDesc *InferReferenceExpandDesc(const workspace_t<Backend> &ws) {
+    for (const auto &expand_desc : input_expand_desc_) {
+      if (expand_desc.NumDimsToExpand() > 0) {
+        return &expand_desc;
+      }
+    }
+    if (allow_named_arg_ref) {
+      return InferNamedReferenceExpandDesc(ws);
+    }
+    return nullptr;
   }
 
   /**
-   * @brief Returns the index of the operator input which is expandable and other
-   * inputs should be expanded or broadcast in a manner consistent with the
-   * given input. If no input is expandable, returns -1.
+   * @brief Returns referential expansion description of a positional or named input.
+   * I.e. other inputs and arguments should be expanded or broadcast in a manner consistent
+   * with the given input.
    */
-  int GetReferenceInputIdx() const {
-    return expand_like_idx_;
+  const ExpandDesc &GetReferenceExpandDesc() const {
+    assert(IsExpandable());
+    return *expand_like_;
   }
 
   void ExpandInputs(const workspace_t<Backend> &ws) {
@@ -428,36 +443,36 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
     return schema.ArgSupportsPerFrameInput(arg_name) && detail::is_per_frame(arg_input);
   }
 
-  void VerifyExpansionConsistency(int expand_idx, const ExpandDesc &expand_desc, int input_idx,
-                                  const ExpandDesc &input_desc) {
+  void VerifyExpansionConsistency(const ExpandDesc &expand_desc, const ExpandDesc &input_desc) {
     // TODO(ktokarski) consider mix of expansion and broadcasting similar to handling of
     // per-frame arguments for "FC" or "CF" layouts. Consider agreeing "FC" and "CF" inputs.
     DALI_ENFORCE(
         input_desc.ExpandedLayout() == expand_desc.ExpandedLayout(),
-        make_string("Failed to match expanding of sequence-like inputs for multiple-input "
-                    "operator. For the ",
-                    expand_idx, " input with layout ", expand_desc.Layout(),
+        make_string("Failed to match expanding of sequence-like input. For the ",
+                    expand_desc.SourceInfo(), " with layout ", expand_desc.Layout(),
                     " the following outermost dimension(s) should be expanded into samples: `",
-                    expand_desc.ExpandedLayout(), "`. The input ", input_idx, " with layout ",
-                    input_desc.Layout(),
+                    expand_desc.ExpandedLayout(), "`. The ", input_desc.SourceInfo(),
+                    " with layout ", input_desc.Layout(),
                     " is expected to either: have no outermost dimensions planned for expanding or "
                     "have exactly the same outermost dimensions to expand. However, got `",
                     input_desc.ExpandedLayout(), "` planned for expanding."));
     for (int sample_idx = 0; sample_idx < expand_desc.NumSamples(); ++sample_idx) {
       assert(expand_desc.NumExpanded(sample_idx) == input_desc.NumExpanded(sample_idx));
       if (expand_desc.ExpandFrames()) {
-        DALI_ENFORCE(expand_desc.NumFrames(sample_idx) == input_desc.NumFrames(sample_idx),
-                     make_string("Inputs ", expand_idx, " and ", input_idx,
-                                 " have different number of frames for sample ", sample_idx,
-                                 ", respectively: ", expand_desc.NumFrames(sample_idx), " and ",
-                                 input_desc.NumFrames(sample_idx)));
+        DALI_ENFORCE(
+            expand_desc.NumFrames(sample_idx) == input_desc.NumFrames(sample_idx),
+            make_string("The ", expand_desc.SourceInfo(), " and the ", input_desc.SourceInfo(),
+                        " have different number of frames for sample ", sample_idx,
+                        ", respectively: ", expand_desc.NumFrames(sample_idx), " and ",
+                        input_desc.NumFrames(sample_idx)));
       }
       if (expand_desc.ExpandChannels()) {
-        DALI_ENFORCE(expand_desc.NumChannels(sample_idx) == input_desc.NumChannels(sample_idx),
-                     make_string("Inputs ", expand_idx, " and ", input_idx,
-                                 " have different number of channels for sample ", sample_idx,
-                                 ", respectively: ", expand_desc.NumChannels(sample_idx), " and ",
-                                 input_desc.NumChannels(sample_idx)));
+        DALI_ENFORCE(
+            expand_desc.NumChannels(sample_idx) == input_desc.NumChannels(sample_idx),
+            make_string("The ", expand_desc.SourceInfo(), " and the ", input_desc.SourceInfo(),
+                        " have different number of channels for sample ", sample_idx,
+                        ", respectively: ", expand_desc.NumChannels(sample_idx), " and ",
+                        input_desc.NumChannels(sample_idx)));
       }
     }
   }
@@ -583,29 +598,26 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
     BroadcastSamples(expanded_batch, batch, expand_desc, expanded_);
   }
 
-  void ExpandArgumentLikeInput(TensorVector<CPUBackend> &expanded_arg_input,
-                               const TensorVector<CPUBackend> &arg_input,
-                               const std::string &arg_name, int input_idx) {
-    const auto &expand_desc = GetInputExpandDesc(input_idx);
+  /* Expands the arg to match the referential `expand_desc` */
+  void ExpandArgumentLikeRef(TensorVector<CPUBackend> &expanded_arg_input,
+                            const TensorVector<CPUBackend> &arg_input,
+                            const std::string &arg_name, const ExpandDesc &expand_desc) {
     assert(expand_desc.NumDimsToExpand() > 0);
-    DALI_ENFORCE(arg_input.num_samples() == expand_desc.NumSamples(),
-                 make_string("Number of samples passed for argument ", arg_name, " (got ",
-                             arg_input.num_samples(),
-                             ") does not match the number of samples in the input (got ",
-                             expand_desc.NumSamples(), ")."));
+    DALI_ENFORCE(
+        arg_input.num_samples() == expand_desc.NumSamples(),
+        make_string("Number of samples passed for argument ", arg_name, " (got ",
+                    arg_input.num_samples(), ") does not match the number of samples in the ",
+                    expand_desc.SourceInfo(), " (got ", expand_desc.NumSamples(), ")."));
     VerifyExpandedBatchSizeNumericLimit(expand_desc);
     if (!IsPerFrameArg(arg_name, arg_input)) {
       BroadcastSamples(expanded_arg_input, arg_input, expand_desc, expanded_);
     } else {
       DALI_ENFORCE(
           expand_desc.ExpandFrames(),
-          make_string(
-              "Tensor input for argument ", arg_name, " is specified per frame (got ",
-              arg_input.GetLayout(),
-              " layout), but samples in the input batch do not contain frames (expected input "
-              "layout that starts with 'F'",
-              ShouldExpandChannels(input_idx) ? " or 'CF'" : "", "). Got layout ",
-              expand_desc.Layout(), " for operator intput ", input_idx, "."));
+          make_string("Tensor input for argument ", arg_name, " is specified per frame (got ",
+                      arg_input.GetLayout(), " layout). In that case, samples in the ",
+                      expand_desc.SourceInfo(), " must contain frames too. Got layout `",
+                      expand_desc.Layout(), "` that does not contain frames."));
       UnfoldBroadcastArgument(expanded_arg_input, arg_input, arg_name, expand_desc);
     }
   }
@@ -624,11 +636,12 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
       auto num_arg_frames = frames_range.NumSlices();
       DALI_ENFORCE(
           num_arg_frames == 1 || num_input_frames == num_arg_frames,
-          make_string("The tensor argument ", arg_name, " for sample ", sample_idx,
-                      " should either be a single argument to be reused accross all frames in the "
-                      "sample or should be specified per each frame. Got ",
-                      num_arg_frames, " arguments for the sample but there are ", num_input_frames,
-                      " frames in the sample."));
+          make_string("The ", sample_idx, " of tensor argument `", arg_name,
+                      "`should either be a single argument to be reused across all frames in the "
+                      "corresponding sample of ",
+                      expand_desc.SourceInfo(), " or should be specified per each frame. Got ",
+                      num_arg_frames, " arguments in the sample but there are ", num_input_frames,
+                      " frames in the corresponding sample of ", expand_desc.SourceInfo(), "."));
       if (num_arg_frames == 1) {  // broadcast the sample
         auto slice = frames_range[0];
         for (int j = 0; j < expand_desc.NumExpanded(sample_idx); j++) {
@@ -680,7 +693,7 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
   USE_OPERATOR_MEMBERS();
 
  private:
-  int expand_like_idx_ = -1;
+  const ExpandDesc *expand_like_ = nullptr;
   bool is_expanding_ = false;
   bool is_expanded_ws_initialized_ = false;
   workspace_t<Backend> expanded_;

--- a/dali/pipeline/operator/sequence_operator.h
+++ b/dali/pipeline/operator/sequence_operator.h
@@ -600,8 +600,8 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
 
   /* Expands the arg to match the referential `expand_desc` */
   void ExpandArgumentLikeRef(TensorVector<CPUBackend> &expanded_arg_input,
-                            const TensorVector<CPUBackend> &arg_input,
-                            const std::string &arg_name, const ExpandDesc &expand_desc) {
+                             const TensorVector<CPUBackend> &arg_input, const std::string &arg_name,
+                             const ExpandDesc &expand_desc) {
     assert(expand_desc.NumDimsToExpand() > 0);
     DALI_ENFORCE(
         arg_input.num_samples() == expand_desc.NumSamples(),
@@ -636,12 +636,10 @@ class SequenceOperator : public Operator<Backend>, protected SampleBroadcasting<
       auto num_arg_frames = frames_range.NumSlices();
       DALI_ENFORCE(
           num_arg_frames == 1 || num_input_frames == num_arg_frames,
-          make_string("The ", sample_idx, " of tensor argument `", arg_name,
-                      "`should either be a single argument to be reused across all frames in the "
-                      "corresponding sample of ",
-                      expand_desc.SourceInfo(), " or should be specified per each frame. Got ",
-                      num_arg_frames, " arguments in the sample but there are ", num_input_frames,
-                      " frames in the corresponding sample of ", expand_desc.SourceInfo(), "."));
+          make_string("The sample ", sample_idx, " of tensor argument `", arg_name, "` contains ",
+                      num_arg_frames, " per-frame parameters, but there are ", num_input_frames,
+                      " frames in the corresponding sample of ", expand_desc.SourceInfo(),
+                      ". The numbers should match."));
       if (num_arg_frames == 1) {  // broadcast the sample
         auto slice = frames_range[0];
         for (int j = 0; j < expand_desc.NumExpanded(sample_idx); j++) {

--- a/dali/test/python/sequences_test_utils.py
+++ b/dali/test/python/sequences_test_utils.py
@@ -15,7 +15,7 @@
 import os
 import random
 import numpy as np
-from typing import List, Union, Callable
+from typing import List, Union, Callable, Optional
 from dataclasses import dataclass
 
 from nvidia.dali import pipeline_def
@@ -44,11 +44,13 @@ class SampleDesc:
 @dataclass
 class ArgDesc:
     name: Union[str, int]
-    is_per_frame: bool
+    expandable_prefix: str
     dest_device: str
+    layout: Optional[str] = None
 
     def __post_init__(self):
         assert self.is_positional_arg or self.dest_device == "cpu", "Named arguments on GPU are not supported"
+        assert not self.layout or self.layout.startswith(self.expandable_prefix)
 
     @property
     def is_positional_arg(self):
@@ -73,7 +75,7 @@ class ArgCb:
     """
 
     def __init__(self, name: Union[str, int], cb: Callable[[SampleDesc], np.ndarray], is_per_frame: bool, dest_device: str = "cpu"):
-        self.desc = ArgDesc(name, is_per_frame, dest_device)
+        self.desc = ArgDesc(name, "F" if is_per_frame else "", dest_device)
         self.cb = cb
 
     def __repr__(self):
@@ -89,32 +91,38 @@ class ArgData:
 class ParamsProviderBase:
     """
     Computes data to be passed as argument inputs in sequence processing tests, the `compute_params` params
-    should return a lists of ArgData; number of dimensions in the `arg_desc.data` must reflect
-    `arg_data.desc.is_per_frame` argument.
-    The `expand_params` should return corresponding unfolded/expanded ArgData to be used in the
-    baseline pipeline.
+    should return a lists of ArgData describing inputs of the operator, while `expand_params` should return
+    corresponding unfolded/expanded ArgData to be used in the baseline pipeline.
     """
 
     def __init__(self):
         self.input_data = None
-        self.input_layout = None
         self.fixed_params = None
         self.rng = None
-
-        self.num_expand = None
         self.unfolded_input = None
-        self.unfolded_input_layout = None
 
-    def setup(self, input_data, input_layout, fixed_params, rng):
+    def setup(self, input_data: ArgData, fixed_params, rng):
         self.input_data = input_data
-        self.input_layout = input_layout
         self.fixed_params = fixed_params
         self.rng = rng
 
-    def setup_expand(self, num_expand, unfolded_input, unfolded_input_layout):
-        self.num_expand = num_expand
-        self.unfolded_input = unfolded_input
-        self.unfolded_input_layout = unfolded_input_layout
+    def unfold_output(self, batches):
+        num_expand = len(self.input_data.desc.expandable_prefix)
+        return unfold_batch(batches, num_expand)
+
+    def unfold_output_layout(self, layout):
+        num_expand = len(self.input_data.desc.expandable_prefix)
+        return layout if not layout else layout[num_expand:]
+
+    def unfold_input(self) -> ArgData:
+        input_desc = self.input_data.desc
+        num_expand = len(input_desc.expandable_prefix)
+        unfolded_input = unfold_batches(self.input_data.data, num_expand)
+        unfolded_layout = input_desc.layout if not input_desc.layout else input_desc.layout[num_expand:]
+        self.unfolded_input = ArgData(
+            ArgDesc(input_desc.name, "", input_desc.dest_device, unfolded_layout),
+            unfolded_input)
+        return self.unfolded_input
 
     def compute_params(self) -> List[ArgData]:
         raise NotImplementedError
@@ -133,26 +141,25 @@ class ParamsProvider(ParamsProviderBase):
 
     def compute_params(self) -> List[ArgData]:
         self.arg_input_data = compute_input_params_data(
-            self.input_data, self.input_layout, self.rng, self.input_params)
+            self.input_data, self.rng, self.input_params)
         return self.arg_input_data
 
     def expand_params(self) -> List[ArgData]:
         self.expanded_params_data = [
             ArgData(
-                ArgDesc(arg_data.desc.name, False, arg_data.desc.dest_device),
-                expand_arg_input(
-                    self.input_data, self.input_layout, self.num_expand,
-                    arg_data.data, arg_data.desc.is_per_frame))
+                ArgDesc(arg_data.desc.name, "", arg_data.desc.dest_device),
+                expand_arg_input(self.input_data, arg_data))
             for arg_data in self.arg_input_data
         ]
         return self.expanded_params_data
 
 
 def arg_data_node(arg_data: ArgData):
-    node = fn.external_source(dummy_source(arg_data.data))
+    node = fn.external_source(dummy_source(arg_data.data), layout=arg_data.desc.layout)
     if arg_data.desc.dest_device == "gpu":
         node = node.gpu()
-    if arg_data.desc.is_per_frame:
+    expandable_prefix = arg_data.desc.expandable_prefix
+    if expandable_prefix and expandable_prefix[0] == "F":
         node = fn.per_frame(node)
     return node
 
@@ -192,9 +199,11 @@ def get_layout_prefix_len(layout, prefix):
     return len(layout)
 
 
-def expand_arg(input_layout, num_expand, arg_has_frames, input_batch, arg_batch):
-    assert(1 <= num_expand <= 2)
-    assert(len(input_batch) == len(arg_batch))
+def expand_arg(expandable_layout, arg_has_frames, input_batch, arg_batch):
+    num_expand = len(expandable_layout)
+    assert 1 <= num_expand <= 2
+    assert all(c in "FC" for c in expandable_layout)
+    assert len(input_batch) == len(arg_batch)
     expanded_batch = []
     for input_sample, arg_sample in zip(input_batch, arg_batch):
         if not arg_has_frames or len(arg_sample) == 1:
@@ -202,7 +211,7 @@ def expand_arg(input_layout, num_expand, arg_has_frames, input_batch, arg_batch)
             num_frames = np.prod(input_sample.shape[:num_expand])
             expanded_batch.extend(arg_sample for _ in range(num_frames))
         else:
-            frame_idx = input_layout[:num_expand].find("F")
+            frame_idx = expandable_layout.find("F")
             assert(frame_idx >= 0)
             assert(len(arg_sample) == input_sample.shape[frame_idx])
             if num_expand == 1:
@@ -210,7 +219,7 @@ def expand_arg(input_layout, num_expand, arg_has_frames, input_batch, arg_batch)
                     arg_frame for arg_frame in arg_sample)
             else:
                 channel_idx = 1 - frame_idx
-                assert(input_layout[channel_idx] == "C")
+                assert expandable_layout[channel_idx] == "C"
                 if channel_idx > frame_idx:
                     expanded_batch.extend(frame_arg for frame_arg in arg_sample for _ in range(
                         input_sample.shape[channel_idx]))
@@ -220,59 +229,56 @@ def expand_arg(input_layout, num_expand, arg_has_frames, input_batch, arg_batch)
     return expanded_batch
 
 
-def expand_arg_input(input_data, input_layout, num_expand, arg_data, arg_has_frames):
-    assert(len(input_data) == len(arg_data))
-    return [expand_arg(input_layout, num_expand, arg_has_frames, input_batch, arg_batch)
-            for input_batch, arg_batch in zip(input_data, arg_data)]
+def expand_arg_input(input_data: ArgData, arg_data: ArgData):
+    assert arg_data.desc.expandable_prefix in ["F", ""]
+    assert len(input_data.data) == len(arg_data.data)
+    arg_has_frames = arg_data.desc.expandable_prefix == "F"
+    return [expand_arg(input_data.desc.expandable_prefix, arg_has_frames, input_batch, arg_batch)
+            for input_batch, arg_batch in zip(input_data.data, arg_data.data)]
 
 
-def _test_seq_input(device, num_iters, expandable_extents, operator_fn, fixed_params, input_params,
-                    input_layout, input_data, rng):
-
+def _test_seq_input(num_iters, operator_fn, fixed_params, input_params, input_data: ArgData, rng):
     @pipeline_def
-    def pipeline(input_data, input_layout, args_data: List[ArgData]):
-        input = fn.external_source(
-            source=dummy_source(input_data), layout=input_layout)
-        if device == "gpu":
-            input = input.gpu()
+    def pipeline(input_data: ArgData, args_data: List[ArgData]):
         pos_args = [
             arg_data for arg_data in args_data if arg_data.desc.is_positional_arg]
-        pos_nodes = [None] * (len(pos_args) + 1)
+        num_pos_nodes = len(pos_args)
+        if input_data.desc.is_positional_arg:
+            num_pos_nodes += 1
+        pos_nodes = [None] * num_pos_nodes
         for arg_data in pos_args:
             assert 0 <= arg_data.desc.name < len(pos_nodes)
             assert pos_nodes[arg_data.desc.name] is None
             pos_nodes[arg_data.desc.name] = arg_data_node(arg_data)
-        [input_idx] = [i for i, pos_input in enumerate(
-            pos_nodes) if pos_input is None]  # there should be exactly one
-        pos_nodes[input_idx] = input
         named_args = [
             arg_data for arg_data in args_data if not arg_data.desc.is_positional_arg]
         arg_nodes = {
             arg_data.desc.name: arg_data_node(arg_data)
             for arg_data in named_args}
+        if not input_data.desc.is_positional_arg:
+            arg_nodes[input_data.desc.name] = arg_data_node(input_data)
+        else:
+            [input_idx] = [i for i, pos_input in enumerate(
+                pos_nodes) if pos_input is None]  # there should be exactly one
+            pos_nodes[input_idx] = arg_data_node(input_data)
         output = operator_fn(*pos_nodes, **fixed_params, **arg_nodes)
         return output
 
-    max_batch_size = max(len(batch) for batch in input_data)
+    assert num_iters >= len(input_data.data)
+    max_batch_size = max(len(batch) for batch in input_data.data)
 
     params_provider = input_params if isinstance(
         input_params, ParamsProviderBase) else ParamsProvider(input_params)
-    params_provider.setup(input_data, input_layout, fixed_params, rng)
+    params_provider.setup(input_data, fixed_params, rng)
     args_data = params_provider.compute_params()
-    seq_pipe = pipeline(input_data=input_data, input_layout=input_layout,
+    seq_pipe = pipeline(input_data=input_data,
                         args_data=args_data,
                         batch_size=max_batch_size, num_threads=4,
                         device_id=0)
-
-    num_expand = get_layout_prefix_len(input_layout, expandable_extents)
-    unfolded_input = unfold_batches(input_data, num_expand)
-    unfolded_input_layout = input_layout[num_expand:]
-    params_provider.setup_expand(
-        num_expand, unfolded_input, unfolded_input_layout)
+    unfolded_input = params_provider.unfold_input()
     expanded_args_data = params_provider.expand_params()
-    max_uf_batch_size = max(len(batch) for batch in unfolded_input)
+    max_uf_batch_size = max(len(batch) for batch in unfolded_input.data)
     baseline_pipe = pipeline(input_data=unfolded_input,
-                             input_layout=unfolded_input_layout,
                              args_data=expanded_args_data,
                              batch_size=max_uf_batch_size, num_threads=4,
                              device_id=0)
@@ -282,8 +288,8 @@ def _test_seq_input(device, num_iters, expandable_extents, operator_fn, fixed_pa
     for _ in range(num_iters):
         (seq_batch,) = seq_pipe.run()
         (baseline_batch,) = baseline_pipe.run()
-        assert(seq_batch.layout()[num_expand:] == baseline_batch.layout())
-        batch = unfold_batch(as_batch(seq_batch), num_expand)
+        assert params_provider.unfold_output_layout(seq_batch.layout()) == baseline_batch.layout()
+        batch = params_provider.unfold_output(as_batch(seq_batch))
         baseline_batch = as_batch(baseline_batch)
         assert(len(batch) == len(baseline_batch))
         check_batch(batch, baseline_batch, len(batch))
@@ -293,11 +299,12 @@ def get_input_arg_per_sample(input_data, param_cb, rng):
     return [[
         param_cb(SampleDesc(rng, None, sample_idx, batch_idx, sample))
         for sample_idx, sample in enumerate(batch)]
-        for batch_idx, batch in enumerate(input_data)]
+        for batch_idx, batch in enumerate(input_data.data)]
 
 
-def get_input_arg_per_frame(input_data, input_layout, param_cb, rng, check_broadcasting):
-    frame_idx = input_layout.find("F")
+def get_input_arg_per_frame(input_data: ArgData, param_cb, rng, check_broadcasting):
+    frame_idx = input_data.desc.expandable_prefix.find("F")
+    assert(frame_idx >= 0)
 
     def arg_for_sample(sample_idx, batch_idx, sample):
         if check_broadcasting and rng.randint(1, 4) == 1:
@@ -310,32 +317,40 @@ def get_input_arg_per_frame(input_data, input_layout, param_cb, rng, check_broad
     return [[
         arg_for_sample(sample_idx, batch_idx, sample)
         for sample_idx, sample in enumerate(batch)]
-        for batch_idx, batch in enumerate(input_data)]
+        for batch_idx, batch in enumerate(input_data.data)]
 
 
-def compute_input_params_data(input_data, input_layout, rng, input_params: List[ArgCb]):
+def compute_input_params_data(input_data: ArgData, rng, input_params: List[ArgCb]):
     def input_param_data(arg_cb):
-        if arg_cb.desc.is_per_frame:
+        assert(arg_cb.desc.expandable_prefix in ["", "F"])
+        if arg_cb.desc.expandable_prefix == "F":
             return get_input_arg_per_frame(
-                input_data, input_layout, arg_cb.cb, rng, not arg_cb.desc.is_positional_arg)
+                input_data, arg_cb.cb, rng, not arg_cb.desc.is_positional_arg)
         return get_input_arg_per_sample(input_data, arg_cb.cb, rng)
     return [ArgData(arg_cb.desc, input_param_data(arg_cb)) for arg_cb in input_params]
 
 
+def input_desc(layout, batches, expandable_extents, dest_device, input_name=0):
+    num_expand = get_layout_prefix_len(layout, expandable_extents)
+    return ArgData(ArgDesc(input_name, layout[:num_expand], dest_device, layout), batches)
+
+
 def sequence_suite_helper(rng, expandable_extents, input_cases, ops_test_cases, num_iters=4):
     class OpTestCase:
-        def __init__(self, operator_fn, fixed_params, input_params, devices=None):
+        def __init__(self, operator_fn, fixed_params, input_params, devices=None, input_name=0):
             self.operator_fn = operator_fn
             self.fixed_params = fixed_params
             self.input_params = input_params
             self.devices = ["cpu", "gpu"] if devices is None else devices
+            self.input_name = input_name
     for test_case_args in ops_test_cases:
         test_case = OpTestCase(*test_case_args)
         for device in test_case.devices:
-            for (input_layout, input_data) in input_cases:
-                yield _test_seq_input, device, num_iters, expandable_extents, \
-                    test_case.operator_fn, test_case.fixed_params, \
-                    test_case.input_params, input_layout, input_data, rng
+            for (input_layout, input_batches) in input_cases:
+                input_data = input_desc(
+                    input_layout, input_batches, expandable_extents, device, test_case.input_name)
+                yield _test_seq_input, num_iters, test_case.operator_fn, test_case.fixed_params,\
+                    test_case.input_params, input_data, rng
 
 
 def get_video_input_cases(seq_layout, rng, larger_shape=(512, 288), smaller_shape=(384, 216)):

--- a/dali/test/python/test_operator_affine_transforms.py
+++ b/dali/test/python/test_operator_affine_transforms.py
@@ -12,16 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
+import warnings
+
+import numpy as np
+from scipy.spatial.transform import Rotation as scipy_rotate
+
 from nvidia.dali.pipeline import Pipeline
 # Just to verify that import works as expected
 import nvidia.dali.ops.transforms as _unused_import  # noqa:F401
 import nvidia.dali.ops as ops
 import nvidia.dali.fn as fn
-import numpy as np
+from nvidia.dali import pipeline_def
 
-import warnings
-
-from scipy.spatial.transform import Rotation as scipy_rotate
+from sequences_test_utils import sequence_suite_helper, ArgCb, ParamsProvider
+from nose_utils import assert_raises, raises
 
 
 def check_results_sample(T1, mat_ref, T0=None, reverse=False, atol=1e-6):
@@ -534,3 +539,151 @@ def verify_deprecation(callback):
 def test_transform_translation_deprecation():
     verify_deprecation(lambda: fn.transform_translation(offset=(0, 0)))
     verify_deprecation(lambda: ops.TransformTranslation(offset=(0, 0))())
+
+
+def test_sequences():
+    np_rng = np.random.default_rng(12345)
+    rng = random.Random(42)
+    num_iters = 4
+    max_num_frames = 50
+    max_batch_size = 12
+
+    class TransformsParamsProvider(ParamsProvider):
+        def unfold_output_layout(self, layout):
+            unfolded = super().unfold_output_layout(layout)
+            if unfolded == "**":
+                return ""
+            return unfolded
+
+    def rand_range(limit):
+        return range(rng.randint(1, limit) + 1)
+
+    def mt(desc):
+        return np.float32(np_rng.uniform(-20, 20, (2, 3)))
+
+    def scale(desc):
+        return np.array([rng.randint(0, 5), rng.randint(-50, 20)], dtype=np.float32)
+
+    def shift(desc):
+        return np.array([rng.randint(-100, 200), rng.randint(-50, 20)], dtype=np.float32)
+
+    def shear_angles(desc):
+        return np.array([rng.randint(-90, 90), rng.randint(-90, 90)], dtype=np.float32)
+
+    def angle(desc):
+        return np.array(rng.uniform(-180, 180), dtype=np.float32)
+
+    def per_frame_input(frame_cb):
+        return [[
+            np.array([frame_cb(None) for _ in rand_range(max_num_frames)], dtype=np.float32)
+            for _ in rand_range(max_batch_size)]
+            for _ in range(num_iters)]
+
+    mt_seq_input = per_frame_input(mt)
+
+    test_cases = [
+        (fn.transforms.rotation, {}, TransformsParamsProvider(
+            [ArgCb("angle", angle, True)]), ["cpu"]),
+        (fn.transforms.rotation, {'reverse_order': True}, TransformsParamsProvider(
+            [ArgCb("center", shift, True), ArgCb("angle", angle, False)]), ["cpu"]),
+        (fn.transforms.scale, {}, TransformsParamsProvider(
+            [ArgCb("scale", scale, True), ArgCb("center", shift, False)]), ["cpu"]),
+        (fn.transforms.translation, {}, TransformsParamsProvider(
+            [ArgCb("offset", shift, True)]), ["cpu"]),
+        (fn.transforms.shear, {}, TransformsParamsProvider(
+            [ArgCb("angles", shear_angles, True)]), ["cpu"]),
+        (fn.transforms.shear, {}, TransformsParamsProvider(
+            [ArgCb("shear", shift, True)]), ["cpu"]),
+
+    ]
+    only_with_seq_input_cases = [
+        (fn.transforms.combine, {}, TransformsParamsProvider(
+            [ArgCb(1, mt, True), ArgCb(2, mt, True)]), ["cpu"]),
+        (fn.transforms.combine, {}, TransformsParamsProvider(
+            [ArgCb(1, mt, False)]), ["cpu"]),
+        (fn.transforms.translation, {}, TransformsParamsProvider(
+            [ArgCb("offset", shift, False)]), ["cpu"]),
+    ]
+
+    seq_cases = test_cases + only_with_seq_input_cases
+    yield from sequence_suite_helper(rng, "F", [("F**", mt_seq_input)], seq_cases, num_iters)
+
+    # transform the test cases to test the transforms with per-frame args but:
+    # 1. with the positional input that does not contain frames
+    # 2. without the positional input
+    for tested_fn, fixed_params, params_provider, devices in test_cases:
+        [main_source, *rest_cbs] = params_provider.input_params
+        if main_source.desc.expandable_prefix != "F":
+            continue
+        broadcast_test_case = (tested_fn, fixed_params, TransformsParamsProvider(
+            [ArgCb(0, mt, False), *rest_cbs]), devices, main_source.desc.name)
+        no_input_test_case = (tested_fn, fixed_params, TransformsParamsProvider(
+            rest_cbs), devices, main_source.desc.name)
+        per_frame_data = per_frame_input(main_source.cb)
+        data_dim = len(per_frame_data[0][0].shape)
+        assert(data_dim > 0)
+        data_layout = "F" + "*" * (data_dim - 1)
+        cases = [broadcast_test_case, no_input_test_case]
+        main_data_input = [(data_layout, per_frame_data)]
+        yield from sequence_suite_helper(rng, "F", main_data_input, cases, num_iters)
+
+
+def test_combine_shape_mismatch():
+    np_rng = np.random.default_rng(42)
+    batch_size = 8
+    num_frames = 50
+
+    def mt():
+        return np.float32(np_rng.uniform(-100, 250, (num_frames, 2, 3)))
+
+    batch0_inp = [mt() for _ in range(batch_size)]
+    batch1_inp = [mt()[i:] for i in range(batch_size)]
+
+    with assert_raises(RuntimeError, glob="The input 0 and the input 1 have different number of frames for sample 1"):
+        @pipeline_def
+        def pipeline():
+            mts0, mts1 = fn.external_source(lambda _: (batch0_inp, batch1_inp), num_outputs=2)
+            return fn.transforms.combine(fn.per_frame(mts0), fn.per_frame(mts1))
+
+        pipe = pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+        pipe.build()
+        pipe.run()
+
+
+def test_rotate_shape_mismatch():
+    np_rng = np.random.default_rng(42)
+    batch_size = 8
+    num_frames = 50
+
+    def mt():
+        return np.float32(np_rng.uniform(-100, 250, (num_frames, 2, 3)))
+
+    mts_inp = [mt() for _ in range(batch_size)]
+    angles_inp = [np.array([angle for angle in range(num_frames - i)],
+                           dtype=np.float32) for i in range(batch_size)]
+    centers_inp = [np.array([c for c in range(num_frames + i)], dtype=np.float32)
+                   for i in range(batch_size)]
+
+    with assert_raises(RuntimeError, glob="The sample 1 of tensor argument `angle` "
+                       "contains 49 per-frame parameters, but there are 50 frames in "
+                       "the corresponding sample of input 0."):
+        @pipeline_def
+        def pipeline():
+            mts, angles = fn.external_source(lambda _: (mts_inp, angles_inp), num_outputs=2)
+            return fn.transforms.rotation(fn.per_frame(mts), angle=fn.per_frame(angles))
+
+        pipe = pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+        pipe.build()
+        pipe.run()
+
+    with assert_raises(RuntimeError, glob="The sample 1 of tensor argument `center` contains 51 "
+                       "per-frame parameters, but there are 49 frames in the corresponding sample "
+                       "of argument `angle`"):
+        @pipeline_def
+        def pipeline():
+            angles, centers = fn.external_source(lambda _: (angles_inp, centers_inp), num_outputs=2)
+            return fn.transforms.rotation(angle=fn.per_frame(angles), center=fn.per_frame(centers))
+
+        pipe = pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+        pipe.build()
+        pipe.run()

--- a/dali/test/python/test_operator_affine_transforms.py
+++ b/dali/test/python/test_operator_affine_transforms.py
@@ -26,7 +26,7 @@ import nvidia.dali.fn as fn
 from nvidia.dali import pipeline_def
 
 from sequences_test_utils import sequence_suite_helper, ArgCb, ParamsProvider
-from nose_utils import assert_raises, raises
+from nose_utils import assert_raises
 
 
 def check_results_sample(T1, mat_ref, T0=None, reverse=False, atol=1e-6):
@@ -639,7 +639,8 @@ def test_combine_shape_mismatch():
     batch0_inp = [mt() for _ in range(batch_size)]
     batch1_inp = [mt()[i:] for i in range(batch_size)]
 
-    with assert_raises(RuntimeError, glob="The input 0 and the input 1 have different number of frames for sample 1"):
+    expected_msg = "The input 0 and the input 1 have different number of frames for sample 1"
+    with assert_raises(RuntimeError, glob=expected_msg):
         @pipeline_def
         def pipeline():
             mts0, mts1 = fn.external_source(lambda _: (batch0_inp, batch1_inp), num_outputs=2)

--- a/dali/test/python/test_operator_coord_transform.py
+++ b/dali/test/python/test_operator_coord_transform.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import random
 import numpy as np
 import nvidia.dali as dali
 import nvidia.dali.fn as fn
 
 from test_utils import check_batch, dali_type
+from sequences_test_utils import sequence_suite_helper, ArgCb
 
 
 def make_param(kind, shape):
@@ -190,3 +192,47 @@ def _test_empty_input(device):
 def test_empty_input():
     for device in ["cpu", "gpu"]:
         yield _test_empty_input, device
+
+
+def test_sequences():
+    rng = random.Random(42)
+    np_rng = np.random.default_rng(12345)
+    max_batch_size = 64
+    max_num_frames = 50
+    num_points = 30
+    num_iters = 4
+
+    def points():
+        return np_rng.uniform(-100, 250, (num_points, 2))
+
+    def rand_range(limit):
+        return range(rng.randint(1, limit) + 1)
+
+    def m(sample_desc):
+        angles = np_rng.uniform(-np.pi, np.pi, 2)
+        scales = np_rng.uniform(0, 5, 2)
+        c = np.cos(angles[0])
+        s = np.sin(angles[1])
+        return np.array([
+            [c * scales[0], -s],
+            [s,  c * scales[1]]], dtype=np.float32)
+
+    def t(sample_desc):
+        return np.float32(np_rng.uniform(-100, 250, 2))
+
+    def mt(sample_desc):
+        return np.append(m(sample_desc), t(sample_desc).reshape(-1, 1), axis=1)
+
+    input_seq_data = [[np.array([points() for _ in rand_range(max_num_frames)], dtype=np.float32)
+                        for _ in rand_range(max_batch_size)]
+                        for _ in range(num_iters)]
+    input_cases = [
+        (fn.coord_transform, {}, [ArgCb("M", m, True)]),
+        (fn.coord_transform, {}, [ArgCb("T", t, True)]),
+        (fn.coord_transform, {}, [ArgCb("MT", mt, True)]),
+        (fn.coord_transform, {}, [ArgCb("MT", mt, False)]),
+        (fn.coord_transform, {}, [ArgCb("M", m, True), ArgCb("T", t, True)]),
+        (fn.coord_transform, {}, [ArgCb("M", m, False), ArgCb("T", t, True)]),
+    ]
+
+    yield from sequence_suite_helper(rng, "F", [("F**", input_seq_data)], input_cases, num_iters)

--- a/dali/test/python/test_operator_coord_transform.py
+++ b/dali/test/python/test_operator_coord_transform.py
@@ -249,4 +249,5 @@ def test_sequences():
         (fn.coord_transform, {}, [ArgCb(0, lambda _: points(), False, "gpu")], ["cpu"], "MT"),
     ]
 
-    yield from sequence_suite_helper(rng, "F", [("F**", input_mt_data)], input_broadcast_cases, num_iters)
+    yield from sequence_suite_helper(
+        rng, "F", [("F**", input_mt_data)], input_broadcast_cases, num_iters)

--- a/dali/test/python/test_operator_gaussian_blur.py
+++ b/dali/test/python/test_operator_gaussian_blur.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nvidia.dali.pipeline import Pipeline
+from nvidia.dali.pipeline import Pipeline, pipeline_def
 import nvidia.dali.types as types
 import nvidia.dali.fn as fn
+
 
 import numpy as np
 import cv2
 from scipy.ndimage import convolve1d
 import os
-from nose_utils import assert_raises
+from nose_utils import assert_raises, raises
 from nose.plugins.attrib import attr
 
 from sequences_test_utils import video_suite_helper, ArgCb
@@ -391,3 +392,20 @@ def test_per_frame():
     ]
 
     yield from video_suite_helper(video_test_cases, expand_channels=True)
+
+
+# test if SequenceOperator properly errors out on per-frame argument when input is expended only
+# because of channel-first layout (but there are no frames on the input)
+@raises(RuntimeError, "Tensor input for argument window_size is specified per frame (got F layout). "
+        "In that case, samples in the input 0 must contain frames too. "
+        "Got layout `CHW` that does not contain frames.")
+def test_fail_per_frame_no_frames():
+    @pipeline_def
+    def pipeline():
+        blob = fn.random.uniform(range=[0, 1], shape=(3, 200, 100))
+        image = fn.reshape(blob, layout="CHW")
+        per_channel = np.array([3, 5, 7])
+        return fn.gaussian_blur(image, window_size=fn.per_frame(per_channel))
+    pipe = pipeline(batch_size=8, num_threads=4, device_id=0)
+    pipe.build()
+    pipe.run()

--- a/dali/test/python/test_operator_gaussian_blur.py
+++ b/dali/test/python/test_operator_gaussian_blur.py
@@ -396,9 +396,9 @@ def test_per_frame():
 
 # test if SequenceOperator properly errors out on per-frame argument when input is expanded only
 # because of channel-first layout (but there are no frames on the input)
-@raises(RuntimeError, "Tensor input for argument window_size is specified per frame (got F layout). "
-        "In that case, samples in the input 0 must contain frames too. "
-        "Got layout `CHW` that does not contain frames.")
+@raises(RuntimeError, "Tensor input for argument window_size is specified per frame "
+                      "(got F layout). In that case, samples in the input 0 must contain "
+                      "frames too. Got layout `CHW` that does not contain frames.")
 def test_fail_per_frame_no_frames():
     @pipeline_def
     def pipeline():

--- a/dali/test/python/test_operator_gaussian_blur.py
+++ b/dali/test/python/test_operator_gaussian_blur.py
@@ -394,7 +394,7 @@ def test_per_frame():
     yield from video_suite_helper(video_test_cases, expand_channels=True)
 
 
-# test if SequenceOperator properly errors out on per-frame argument when input is expended only
+# test if SequenceOperator properly errors out on per-frame argument when input is expanded only
 # because of channel-first layout (but there are no frames on the input)
 @raises(RuntimeError, "Tensor input for argument window_size is specified per frame (got F layout). "
         "In that case, samples in the input 0 must contain frames too. "

--- a/dali/test/python/test_operator_rotate.py
+++ b/dali/test/python/test_operator_rotate.py
@@ -321,20 +321,23 @@ class RotatePerFrameParamsProvider(ParamsProvider):
         super().__init__(input_params)
 
     def expand_params(self):
-        assert self.num_expand == 1
+        assert self.input_data.desc.expandable_prefix == "F"
         expanded_params = super().expand_params()
         params_dict = {param_data.desc.name: param_data for param_data in expanded_params}
         expanded_angles = params_dict.get('angle')
         expanded_axis = params_dict.get('axis')
         assert (expanded_angles is not None and 'size' not in self.fixed_params
                 and 'size' not in params_dict)
-        sequence_extents = [[sample.shape[0] for sample in input_batch]
-                            for input_batch in self.input_data]
-        output_size_params = (sequence_extents, self.unfolded_input, expanded_angles.data)
+        sequence_extents = [
+          [sample.shape[0] for sample in input_batch]
+          for input_batch in self.input_data.data]
+        output_size_params = (sequence_extents, self.unfolded_input.data, expanded_angles.data)
         if expanded_axis is not None:
-            output_size_params += (expanded_axis.data, )
-        output_sizes = [sequence_batch_output_size(*args) for args in zip(*output_size_params)]
-        expanded_params.append(ArgData(ArgDesc("size", False, "cpu"), output_sizes))
+            output_size_params += (expanded_axis.data,)
+        output_sizes = [
+            sequence_batch_output_size(*args)
+            for args in zip(*output_size_params)]
+        expanded_params.append(ArgData(ArgDesc("size", "", "cpu"), output_sizes))
         return expanded_params
 
     def __repr__(self):

--- a/dali/test/python/test_operator_rotate.py
+++ b/dali/test/python/test_operator_rotate.py
@@ -366,8 +366,11 @@ def test_video():
 
     rng = random.Random(42)
     video_cases = get_video_input_cases("FHWC", rng, larger_shape=(512, 287))
-    input_cases = [("FHWC", input_data) for input_data in video_cases]
-    yield from sequence_suite_helper(rng, "F", input_cases, video_test_cases)
+    input_cases = [
+        ArgData(ArgDesc(0, "F", "", "FHWC"), input_data)
+        for input_data in video_cases
+    ]
+    yield from sequence_suite_helper(rng, input_cases, video_test_cases)
 
 
 def test_3d_sequence():
@@ -386,7 +389,10 @@ def test_3d_sequence():
     def get_random_batch():
         return [get_random_sample() for _ in range(rng.randint(1, max_batch_size))]
 
-    input_cases = [(input_layout, [get_random_batch() for _ in range(num_batches)])]
+    input_cases = [
+        ArgData(desc=ArgDesc(0, "F", "", input_layout),
+                data=[get_random_batch() for _ in range(num_batches)])
+    ]
 
     def random_angle(sample_desc):
         return np.array(sample_desc.rng.uniform(-180., 180.), dtype=np.float32)
@@ -401,4 +407,4 @@ def test_3d_sequence():
       (dali.fn.rotate, {}, RotatePerFrameParamsProvider([ArgCb("angle", random_angle, True),
                                                          ArgCb("axis", random_axis, True)])),
     ]
-    yield from sequence_suite_helper(rng, "F", input_cases, test_cases)
+    yield from sequence_suite_helper(rng, input_cases, test_cases)


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
New feature
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

* Adds support for sequence input to affine transforms and coordinate transforms ops. This should facilitate use cases of the `warp_affine` operator with video. For the same reason, the `coord_transform` operator is extended to support sequences.

* The change required modification of the SequenceOperator so that the named arguments may be treated as a source of truth as to whether the operator processes sequences. This helps in two ways. Firstly, operator may have no positional input but should produce per-frame output, for example `transforms.rotation` may receive per-frame angles as a named argument and should produce per-frame rotation matrices based on that. Secondly, `transforms.rotation` may receive input matrices on per-sample basis (for instance from Constant op) and then compose them with per-frame matrices produced based on per-frame angles.

* Corresponding changes was made in the sequences testing utility. Previously the utility expected sequence-containing batches for the 0-th input of the operator (while the rest of the params was specified as callbacks that the utility used to produce inputs for arguments that matches the shape of the input). Now, you can specify to which argument the provided batches should be fed, effectively making the arbitrary argument "a source of truth" as to the shape of the input sequences.



## Additional information:

### Affected modules and functionalities:
The functionalities of following operators are affected:
* coord_transform
* transforms.combine
* transforms.crop
* transforms.rotation
* transforms.scale
* transforms.shear
* transforms.translation

The `SequenceOperator` is modified to handle transforms. It is already utilized by gaussian blur, laplacian, rotate and warp operators but the change should not affect their functionalities.

~~It duplicates the fix for the tests to pass. 
https://github.com/NVIDIA/DALI/pull/3958
This PR was rebased on that one.~~

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [x] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2795
<!--- DALI-XXXX or NA --->
