### PR TITLE
Add synchronization with external streams in CopyToExternal

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -552,7 +552,6 @@ void daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx,
   dali::DeviceWorkspace *ws = reinterpret_cast<dali::DeviceWorkspace *>(pipe_handle->ws);
   assert(ws != nullptr);
 
-  auto &type_info = dali::TypeTable::GetTypeInfo(dali::DALIDataType::DALI_UINT8);
   if (ws->OutputIsType<CPUBackend>(output_idx)) {
     AccessOrder order = is_pinned ? AccessOrder(stream) : AccessOrder::host();
     CopyToExternal(dst, dst_mem_kind, ws->Output<CPUBackend>(output_idx),
@@ -581,7 +580,6 @@ void daliOutputCopySamples(daliPipelineHandle *pipe_handle, void **dsts, int out
   dali::DeviceWorkspace *ws = reinterpret_cast<dali::DeviceWorkspace *>(pipe_handle->ws);
   assert(ws != nullptr);
 
-  auto &type_info = dali::TypeTable::GetTypeInfo(dali::DALIDataType::DALI_UINT8);
   if (ws->OutputIsType<CPUBackend>(output_idx)) {
     AccessOrder order = is_pinned ? AccessOrder(stream) : AccessOrder::host();
     if (!is_pinned) {

--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -545,27 +545,30 @@ void daliOutputCopy(daliPipelineHandle *pipe_handle, void *dst, int output_idx,
   dali::DomainTimeRange tr("[DALI][C API] daliOutputCopy", dali::DomainTimeRange::kGreen);
 
   bool is_pinned = flags & DALI_ext_pinned;
-  bool sync = flags & DALI_ext_force_sync;
+  bool host_sync = flags & DALI_ext_force_sync;
   bool use_copy_kernel = flags & DALI_use_copy_kernel;
   auto dst_mem_kind = GetMemKind(dst_type, is_pinned);
 
   dali::DeviceWorkspace *ws = reinterpret_cast<dali::DeviceWorkspace *>(pipe_handle->ws);
   assert(ws != nullptr);
 
+  AccessOrder wait_order = AccessOrder::host();
+  AccessOrder copy_order = AccessOrder::host();
+
   if (ws->OutputIsType<CPUBackend>(output_idx)) {
-    AccessOrder order = is_pinned ? AccessOrder(stream) : AccessOrder::host();
-    CopyToExternal(dst, dst_mem_kind, ws->Output<CPUBackend>(output_idx),
-                   order, use_copy_kernel);
-    if (!is_pinned) {
-      sync = false;
-    }
+    copy_order = is_pinned ? AccessOrder(stream) : AccessOrder::host();
+    auto &src = ws->Output<CPUBackend>(output_idx);
+    CopyToExternal(dst, dst_mem_kind, src, copy_order, use_copy_kernel);
+    if (!host_sync)
+      wait_order = src.order();  // if the copy order is host, then wait will be no-op
   } else {
-    CopyToExternal(dst, dst_mem_kind, ws->Output<GPUBackend>(output_idx),
-                   stream, use_copy_kernel);
+    auto &src = ws->Output<GPUBackend>(output_idx);
+    copy_order = stream;
+    CopyToExternal(dst, dst_mem_kind, src, copy_order, use_copy_kernel);
+    if (!host_sync)
+      wait_order = src.order();
   }
-  if (sync) {
-    CUDA_CALL(cudaStreamSynchronize(stream));
-  }
+  wait_order.wait(copy_order);
 }
 
 void daliOutputCopySamples(daliPipelineHandle *pipe_handle, void **dsts, int output_idx,
@@ -573,27 +576,32 @@ void daliOutputCopySamples(daliPipelineHandle *pipe_handle, void **dsts, int out
   dali::DomainTimeRange tr("[DALI][C API] daliOutputCopySamples", dali::DomainTimeRange::kGreen);
 
   bool is_pinned = flags & DALI_ext_pinned;
-  bool sync = flags & DALI_ext_force_sync;
+  bool host_sync = flags & DALI_ext_force_sync;
   bool use_copy_kernel = flags & DALI_use_copy_kernel;
   auto dst_mem_kind = GetMemKind(dst_type, is_pinned);
 
   dali::DeviceWorkspace *ws = reinterpret_cast<dali::DeviceWorkspace *>(pipe_handle->ws);
   assert(ws != nullptr);
 
+  AccessOrder wait_order = AccessOrder::host();
+  AccessOrder copy_order = AccessOrder::host();
+
   if (ws->OutputIsType<CPUBackend>(output_idx)) {
-    AccessOrder order = is_pinned ? AccessOrder(stream) : AccessOrder::host();
-    if (!is_pinned) {
-      sync = false;
-    }
-    CopyToExternal(dsts, dst_mem_kind, ws->Output<CPUBackend>(output_idx),
-                   order, use_copy_kernel);
+    copy_order = is_pinned ? AccessOrder(stream) : AccessOrder::host();
+    auto & src = ws->Output<CPUBackend>(output_idx);
+    if (!host_sync)
+      wait_order = src.order();  // if the copy order is host, then wait will be no-op
+    CopyToExternal(dsts, dst_mem_kind, src, copy_order, use_copy_kernel);
+    if (!host_sync)
+      wait_order = src.order();  // if the copy order is host, then wait will be no-op
   } else {
-    CopyToExternal(dsts, dst_mem_kind, ws->Output<GPUBackend>(output_idx),
-                   stream, use_copy_kernel);
+    auto &src = ws->Output<GPUBackend>(output_idx);
+    copy_order = stream;
+    CopyToExternal(dsts, dst_mem_kind, src, copy_order, use_copy_kernel);
+    if (!host_sync)
+      wait_order = src.order();
   }
-  if (sync) {
-    CUDA_CALL(cudaStreamSynchronize(stream));
-  }
+  wait_order.wait(copy_order);
 }
 
 

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -843,6 +843,7 @@ void Clear(Tensor<GPUBackend>& tensor) {
   CUDA_CALL(cudaMemset(tensor.raw_mutable_data(), 0, tensor.nbytes()));
 }
 
+
 TYPED_TEST(CApiTest, daliOutputCopySamples) {
   auto pipe_ptr = GetTestPipeline<TypeParam>(true, this->output_device_);
   auto serialized = pipe_ptr->SerializeToProtobuf();

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -19,8 +19,6 @@
 #include <vector>
 
 #include "dali/c_api.h"
-#include "dali/core/cuda_stream_pool.h"
-#include "dali/core/dev_buffer.h"
 #include "dali/pipeline/data/buffer.h"
 #include "dali/pipeline/data/tensor_list.h"
 #include "dali/pipeline/data/views.h"

--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -19,13 +19,14 @@
 #include <vector>
 
 #include "dali/c_api.h"
+#include "dali/core/cuda_stream_pool.h"
+#include "dali/core/dev_buffer.h"
 #include "dali/pipeline/data/buffer.h"
 #include "dali/pipeline/data/tensor_list.h"
 #include "dali/pipeline/data/views.h"
 #include "dali/pipeline/pipeline.h"
 #include "dali/test/dali_test_config.h"
 #include "dali/test/tensor_test_utils.h"
-#include "dali/core/cuda_stream_pool.h"
 
 using namespace std::string_literals;  // NOLINT(build/namespaces)
 
@@ -842,85 +843,6 @@ void Clear(Tensor<CPUBackend>& tensor) {
 template <>
 void Clear(Tensor<GPUBackend>& tensor) {
   CUDA_CALL(cudaMemset(tensor.raw_mutable_data(), 0, tensor.nbytes()));
-}
-
-namespace {
-
-struct GPUHog {
-  ~GPUHog() {
-    if (mem) {
-      CUDA_DTOR_CALL(cudaFree(mem));
-      mem = nullptr;
-    }
-  }
-
-  void init() {
-    if (!mem)
-      CUDA_CALL(cudaMalloc(&mem, size));
-  }
-
-  void run(cudaStream_t stream, int count = 1) {
-    for (int i = 0; i < count; i++) {
-      CUDA_CALL(cudaMemsetAsync(mem, i+1, size, stream));
-    }
-  }
-
-  uint8_t *mem = nullptr;
-  size_t size = 16<<20;
-};
-
-}  // namespace
-
-TEST(CApiTest, daliOutputCopy_Async) {
-  dali::Pipeline pipe(8, 4, 0);
-  std::string es_cpu_name = "pipe_in";
-  pipe.AddExternalInput(es_cpu_name, "cpu");
-
-  std::string cont_name = "pipe_out";
-  pipe.AddOperator(OpSpec("MakeContiguous")
-                          .AddArg("device", "mixed")
-                          .AddArg("name", cont_name)
-                          .AddInput(es_cpu_name, "cpu")
-                          .AddOutput(cont_name, "gpu"), cont_name);
-  std::vector<std::pair<std::string, std::string>> outputs = {{"pipe_out", "gpu"}};
-
-  GPUHog hog;
-  std::vector<std::vector<int>> in_data;
-  int sample_size = 1000000;
-  TensorListShape shape = uniform_list_shape(8, {sample_size});
-  in_data.resize(2);
-  for (int i = 0; i < 2; i++) {
-    in_data[i].resize(sample_size);
-    for (int j = 0; j < sample_size; j++)
-      in_data[i][j] = i + j;
-  }
-  std::vector<int> out_data(sample_size);
-
-  CUDAStreamLease stream = CUDAStreamPool::instance::Get();
-  pipe.SetOutputDescs(outputs);
-  std::string ser = pipe.SerializeToProtobuf();
-  daliPipelineHandle handle;
-  daliDeserializeDefault(&handle, ser.c_str(), ser.size());
-  hog.init();
-  daliSetExternalInput(&handle, "pipe_in", CPU, in_data[0], DALI_INT32,
-                       shape.shape.data(), 1, nullptr, 0);
-  daliRun(&handle);
-  daliSetExternalInput(&handle, "pipe_in", CPU, in_data[1], DALI_INT32,
-                       shape.shape.data(), 1, nullptr, 0);
-  daliRun(&handle);  // schedule extra iteration
-  daliOutput(&handle);
-  hog.run(stream, 100);
-  daliOutputCopy(&handle, dst.data(), 0, CPU, stream, 0);
-  daliSetExternalInput(&handle, "pipe_in", CPU, in_data[1], DALI_INT32,
-                       shape.shape.data(), 1, nullptr, 0);
-  daliRun(&handle);
-
-  CUDA_CALL(cudaMemcpyAsync(out_data.data(), out_gpu.data(),
-                            batch_size*sample_size*sizeof(int32_t)));
-
-  for (int i = 0; i <
-
-  daliDeletePipeline(&handle);
 }
 
 TYPED_TEST(CApiTest, daliOutputCopySamples) {

--- a/dali/c_api/c_api_test.cu
+++ b/dali/c_api/c_api_test.cu
@@ -1,0 +1,132 @@
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "dali/c_api.h"
+#include "dali/core/cuda_stream_pool.h"
+#include "dali/core/dev_buffer.h"
+#include "dali/pipeline/data/buffer.h"
+#include "dali/pipeline/data/tensor_list.h"
+#include "dali/pipeline/data/views.h"
+#include "dali/pipeline/pipeline.h"
+#include "dali/test/dali_test_config.h"
+#include "dali/test/tensor_test_utils.h"
+
+
+namespace dali {
+
+
+namespace {
+
+__global__ void hog(float *f, size_t n) {
+  size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n)
+    f[i] = sqrt(f[i]);
+}
+
+struct GPUHog {
+  ~GPUHog() {
+    if (mem) {
+      CUDA_DTOR_CALL(cudaFree(mem));
+      mem = nullptr;
+    }
+  }
+
+  void init() {
+    if (!mem)
+      CUDA_CALL(cudaMalloc(&mem, size * sizeof(float)));
+  }
+
+  void run(cudaStream_t stream, int count = 1) {
+    for (int i = 0; i < count; i++) {
+      CUDA_CALL(cudaMemsetAsync(mem, 1, size * sizeof(float), stream));
+      hog<<<div_ceil(size, 512), 512>>>(mem, size);
+    }
+    CUDA_CALL(cudaGetLastError());
+  }
+
+  float *mem = nullptr;
+  size_t size = 16<<20;
+};
+
+}  // namespace
+
+TEST(CApiTest, daliOutputCopy_Async) {
+  int batch_size = 8;
+  dali::Pipeline pipe(batch_size, 4, 0);
+  std::string es_cpu_name = "pipe_in";
+  pipe.AddExternalInput(es_cpu_name, "cpu");
+
+  std::string cont_name = "pipe_out";
+  pipe.AddOperator(OpSpec("MakeContiguous")
+                          .AddArg("device", "mixed")
+                          .AddArg("name", cont_name)
+                          .AddInput(es_cpu_name, "cpu")
+                          .AddOutput(cont_name, "gpu"), cont_name);
+  std::vector<std::pair<std::string, std::string>> outputs = {{"pipe_out", "gpu"}};
+
+  GPUHog hog;
+  std::vector<std::vector<int>> in_data;
+  int sample_size = 1000000;
+  TensorListShape<> shape = uniform_list_shape(8, {sample_size});
+  in_data.resize(2);
+  for (int i = 0; i < 2; i++) {
+    in_data[i].resize(batch_size*sample_size);
+    for (int j = 0; j < batch_size*sample_size; j++)
+      in_data[i][j] = i + j;
+  }
+  pipe.SetOutputDescs(outputs);
+
+  std::vector<int> out_cpu(batch_size*sample_size);
+  DeviceBuffer<int> out_gpu;
+  out_gpu.resize(batch_size*sample_size);
+  CUDAStreamLease stream = CUDAStreamPool::instance().Get();
+
+  CUDA_CALL(cudaMemsetAsync(out_gpu.data(), -1, out_gpu.size() * sizeof(int), stream));
+  std::string ser = pipe.SerializeToProtobuf();
+  daliPipelineHandle handle;
+  hog.init();
+  hog.run(stream, 10);
+  daliDeserializeDefault(&handle, ser.c_str(), ser.size());
+
+  daliSetExternalInput(&handle, "pipe_in", CPU, in_data[0].data(), ::DALI_INT32,
+                       shape.shapes.data(), 1, nullptr, 0);
+  daliRun(&handle);
+
+  // schedule an extra iteration
+  daliSetExternalInput(&handle, "pipe_in", CPU, in_data[1].data(), ::DALI_INT32,
+                       shape.shapes.data(), 1, nullptr, 0);
+  daliRun(&handle);
+  hog.run(stream, 1000);
+  daliOutput(&handle);
+  daliOutputCopy(&handle, out_gpu.data(), 0, GPU, stream, 0);
+  daliSetExternalInput(&handle, "pipe_in", CPU, in_data[1].data(), ::DALI_INT32,
+                       shape.shapes.data(), 1, nullptr, 0);
+  daliRun(&handle);
+
+  CUDA_CALL(cudaMemcpyAsync(out_cpu.data(), out_gpu.data(), batch_size*sample_size*sizeof(int),
+                            cudaMemcpyDeviceToHost, stream));
+
+  for (int i = 0; i < batch_size * sample_size; i++)
+    ASSERT_EQ(out_cpu[i], in_data[0][i]) << " at index " << i;
+
+  daliDeletePipeline(&handle);
+}
+
+}  // namespace dali

--- a/dali/test/python/test_copy_to_external_torch.py
+++ b/dali/test/python/test_copy_to_external_torch.py
@@ -1,4 +1,3 @@
-import nose_utils  # for Python 3.10 workaround
 import torch
 import numpy as np
 import nvidia.dali as dali

--- a/dali/test/python/test_copy_to_external_torch.py
+++ b/dali/test/python/test_copy_to_external_torch.py
@@ -1,0 +1,95 @@
+import torch
+import numpy as np
+import nvidia.dali as dali
+from nvidia.dali import pipeline_def
+import nvidia.dali.fn as fn
+
+shape = [5000000]
+batch_size = 8
+
+@pipeline_def(batch_size=batch_size, device_id=0, num_threads=8)
+def _test_pipe():
+    get_tensor = lambda si: np.arange(si.idx_in_epoch, si.idx_in_epoch + shape[0], dtype=np.int32)
+    inp = fn.external_source(get_tensor, batch=False)
+    return inp.gpu()
+
+
+from nvidia.dali.backend import TensorGPU, TensorListGPU
+from nvidia.dali.pipeline import Pipeline
+import nvidia.dali.ops as ops
+from nvidia.dali import types
+import torch
+import torch.utils.dlpack as torch_dlpack
+import ctypes
+import numpy as np
+
+to_torch_type = {
+    types.DALIDataType.FLOAT   : torch.float32,
+    types.DALIDataType.FLOAT64 : torch.float64,
+    types.DALIDataType.FLOAT16 : torch.float16,
+    types.DALIDataType.UINT8   : torch.uint8,
+    types.DALIDataType.INT8    : torch.int8,
+    types.DALIDataType.INT16   : torch.int16,
+    types.DALIDataType.INT32   : torch.int32,
+    types.DALIDataType.INT64   : torch.int64
+}
+
+def feed_ndarray(dali_tensor, arr, cuda_stream = None, non_blocking = False):
+    """
+    Copy contents of DALI tensor to PyTorch's Tensor.
+
+    Parameters
+    ----------
+    `dali_tensor` : nvidia.dali.backend.TensorCPU or nvidia.dali.backend.TensorGPU
+                    Tensor from which to copy
+    `arr` : torch.Tensor
+            Destination of the copy
+    `cuda_stream` : torch.cuda.Stream, cudaStream_t or any value that can be cast to cudaStream_t.
+                    CUDA stream to be used for the copy
+                    (if not provided, an internal user stream will be selected)
+                    In most cases, using pytorch's current stream is expected (for example,
+                    if we are copying to a tensor allocated with torch.zeros(...))
+    """
+    dali_type = to_torch_type[dali_tensor.dtype]
+
+    assert dali_type == arr.dtype, ("The element type of DALI Tensor/TensorList"
+            " doesn't match the element type of the target PyTorch Tensor: {} vs {}".format(dali_type, arr.dtype))
+    assert dali_tensor.shape() == list(arr.size()), \
+            ("Shapes do not match: DALI tensor has size {0}"
+            ", but PyTorch Tensor has size {1}".format(dali_tensor.shape(), list(arr.size())))
+    cuda_stream = types._raw_cuda_stream(cuda_stream)
+
+    # turn raw int to a c void pointer
+    c_type_pointer = ctypes.c_void_p(arr.data_ptr())
+    dali_tensor.copy_to_external(c_type_pointer, None if cuda_stream is None else ctypes.c_void_p(cuda_stream), non_blocking)
+    return arr
+
+stream = torch.cuda.Stream(device=0)
+arr = torch.empty([batch_size] + shape, dtype=torch.int32, device="cuda:0")
+num_iters = 20
+
+def ref_tensor(batch_size, sample_shape, start_value):
+    volume = np.prod(sample_shape)
+    sample0 = torch.arange(start_value, start_value + volume, dtype=torch.int32, device="cuda:0").reshape(shape)
+    return torch.stack([sample0 + i for i in range(batch_size)])
+
+def check(arr, ref):
+    return torch.equal(arr, ref)
+
+pipe = _test_pipe(prefetch_queue_depth=4)
+pipe.build()
+ref = [ref_tensor(batch_size, shape, i * batch_size) for i in range(num_iters)]
+pipe.schedule_run()
+pipe.schedule_run()
+pipe.schedule_run()
+pipe.schedule_run()
+out, = pipe.share_outputs()
+feed_ndarray(out.as_tensor(), arr, stream.cuda_stream, True)
+pipe.release_outputs()
+pipe.schedule_run()
+_, = pipe.share_outputs()
+pipe.release_outputs()
+pipe.schedule_run()
+_, = pipe.share_outputs()
+pipe.release_outputs()
+assert check(arr, ref[0])

--- a/qa/TL0_python_self_test_frameworks/test_pytorch.sh
+++ b/qa/TL0_python_self_test_frameworks/test_pytorch.sh
@@ -13,6 +13,7 @@ test_body() {
     nosetests --verbose test_external_source_parallel_pytorch.py
     nosetests --verbose test_backend_impl_torch_dlpack.py
     nosetests --verbose test_dali_fork_torch.py
+    nosetests --verbose test_copy_to_external_torch.py
     nosetests --verbose --attr 'pytorch' test_external_source_impl_utils.py
     nosetests --verbose --attr 'pytorch' test_pipeline_debug.py
     nosetests --verbose --attr 'pytorch' test_functional_api.py


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix**
**Tests**

## Description:
This PR fixes the issue with copy_to_external / daliCopyOutput where not requiring host synchronization introduced a race condition - once ReleaseOutputs was called, the output buffer that is still being copied could be clobbered by the next iteration of the pipeline.
This PR adds a device/device synchronization between the stream associated with the tensor being copied (usually that's the GPU stage's stream) and the user stream. With this change, any work submitted on the GPU stream after copy_to_external exits will be scheduled after the copy.
There are extensive tests with PyTorch CUDA streams and in C API that triggered the issue and a test-driven approach was used to make the issue go away without altering the tests.

## Additional information:
The tests are not 100% reliable, as is always the case with race condition - i.e. there can be false-negatives if the issue reappears.

### Affected modules and functionalities:
bakcend_impl - copy_to_external
C API
C API tests

### Key points relevant for the review:
N/A

### Tests:
test_copy_to_external_torch.py - all tests (it's a new file)
c_api_test.cu - likewise
existing tests - many of these, should check for regressions - these include
c_api_test.cc - tests with daliCopyOutput, daliCopyOutputSamples in their name
framework tests - they use copy_to_external to populate framework tensors

- [X] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [X] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2467
<!--- DALI-XXXX or NA --->
