### PR TITLE
Make the copy to the staging area option in the nvJPEG decoder

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -869,7 +869,8 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
       }
 
       CUDA_CALL(cudaEventSynchronize(hw_decode_event_));
-      if (RestrictPinnedMemUsage()) {
+      // if the input is pinned already we don't need to copy to the staging area
+      if (RestrictPinnedMemUsage() || input.is_pinned()) {
         for (size_t k = 0; k < samples_hw_batched_.size(); ++k) {
           in_data_[k] = static_cast<unsigned char*>(tv.raw_mutable_tensor(k));
         }

--- a/dali/test/python/test_operator_decoders_image.py
+++ b/dali/test/python/test_operator_decoders_image.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -362,3 +362,16 @@ def _testimpl_image_decoder_slice_error_oob(device):
 def test_image_decoder_slice_error_oob():
     for device in ['cpu', 'mixed']:
         yield _testimpl_image_decoder_slice_error_oob, device
+
+def test_pinned_input_hw_decoder():
+    file_root = os.path.join(test_data_root, good_path, "jpeg")
+    @pipeline_def(batch_size=128, device_id=0, num_threads=4)
+    def pipe():
+        encoded, _ = fn.readers.file(file_root=file_root)
+        encoded_gpu = encoded.gpu()
+        # encoded.gpu() should make encoded pinned
+        decoded = fn.decoders.image(encoded, device="mixed")
+        return decoded, encoded_gpu
+    p = pipe()
+    p.build()
+    p.run()


### PR DESCRIPTION
- nvJPEG HW backend copied the data directly to the GPU from the
  provided input. So making the input pinned helps a lot. Currently,
  the image decoder operator has an internal pinned staging area
  for that. However, if the input is already in the pinned memory
  copy can be skipped.
- add a python test to cover that

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- nvJPEG HW backend copied the data directly to the GPU from the
  provided input. So making the input pinned helps a lot. Currently,
  the image decoder operator has an internal pinned staging area
  for that. However, if the input is already in the pinned memory
  copy can be skipped.
- add a python test to cover that
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- image decoder with nvJPEG backend
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_pinned_input_hw_decoder
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2493
<!--- DALI-XXXX or NA --->
