### PR TITLE
Fix a bug in AccessOrder when synchronizing with a default stream on the same device, which is not the current device.

### DIFF
--- a/dali/core/access_order_test.cu
+++ b/dali/core/access_order_test.cu
@@ -1,0 +1,66 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/core/access_order.h"
+#include "dali/core/cuda_stream.h"
+#include "dali/core/cuda_error.h"
+
+namespace dali {
+
+TEST(AccessOrder, ProperStream_MultiGPU) {
+  int ndev = 0;
+  CUDA_CALL(cudaGetDeviceCount(&ndev));
+  if (ndev < 2) {
+    GTEST_SKIP() << "At least 2 devices needed for the test\n";
+  }
+
+  CUDAStream s0 = CUDAStream::Create(true, 0);
+  CUDAStream s1 = CUDAStream::Create(true, 1);
+  AccessOrder o0(s0, 0);
+  AccessOrder o1(s1, 1);
+  EXPECT_NO_THROW(o0.wait(o1));
+  EXPECT_NO_THROW(o1.wait(o0));
+}
+
+TEST(AccessOrder, DefaultStream_MultiGPU) {
+  int ndev = 0;
+  CUDA_CALL(cudaGetDeviceCount(&ndev));
+  if (ndev < 2) {
+    GTEST_SKIP() << "At least 2 devices needed for the test\n";
+  }
+
+  CUDAStream s0 = CUDAStream::Create(true, 0);
+  CUDAStream s1 = CUDAStream::Create(true, 1);
+  AccessOrder named_dev0(s0, 0);
+  AccessOrder named_dev1(s1, 1);
+  AccessOrder default_dev0(0, 0);
+  AccessOrder default_dev1(0, 1);
+  EXPECT_NO_THROW(named_dev0.wait(default_dev0));
+  EXPECT_NO_THROW(named_dev1.wait(default_dev1));
+  EXPECT_NO_THROW(named_dev0.wait(default_dev1));
+  EXPECT_NO_THROW(named_dev1.wait(default_dev0));
+
+  EXPECT_NO_THROW(default_dev0.wait(named_dev0));
+  EXPECT_NO_THROW(default_dev0.wait(named_dev1));
+  EXPECT_NO_THROW(default_dev1.wait(named_dev0));
+  EXPECT_NO_THROW(default_dev1.wait(named_dev1));
+
+  EXPECT_NO_THROW(default_dev0.wait(default_dev0));
+  EXPECT_NO_THROW(default_dev0.wait(default_dev1));
+  EXPECT_NO_THROW(default_dev1.wait(default_dev0));
+  EXPECT_NO_THROW(default_dev1.wait(default_dev1));
+}
+
+}  // namespace dali


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Fixes a bug in AccessOrder when synchronizing with a different stream on the same device, which is not the current device.

Example:
- synchronize stream S on device 1 with stream 0 on device 1 when the current device (set by cudaSetDevice) is 0.

Symptoms:
- CUDA error: invalid resource handle.

Explanation:
if the both devices (this and other) where the same, there was no call to cudaSetDevice, and there should be to make the use of a default stream meaningful.


## Additional information:
N/A


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
