### PR TITLE
Change how samples are owned

### DIFF
--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -21,13 +21,12 @@ namespace dali {
 
 template <typename Backend>
 TensorVector<Backend>::TensorVector()
-    : views_count_(0), curr_num_tensors_(0), tl_(std::make_shared<TensorList<Backend>>()) {}
+    : curr_num_tensors_(0), tl_(std::make_shared<TensorList<Backend>>()) {}
 
 
 template <typename Backend>
 TensorVector<Backend>::TensorVector(int batch_size)
-    : views_count_(0),
-      curr_num_tensors_(0),
+    : curr_num_tensors_(0),
       tl_(std::make_shared<TensorList<Backend>>(batch_size)) {
   resize_tensors(batch_size);
 }
@@ -35,7 +34,7 @@ TensorVector<Backend>::TensorVector(int batch_size)
 
 template <typename Backend>
 TensorVector<Backend>::TensorVector(std::shared_ptr<TensorList<Backend>> tl)
-    : views_count_(0), curr_num_tensors_(0), tl_(std::move(tl)) {
+    : curr_num_tensors_(0), tl_(std::move(tl)) {
   assert(tl_ && "Construction with null TensorList is illegal");
   pinned_ = tl_->is_pinned();
   type_ = tl_->type_info();
@@ -55,15 +54,8 @@ TensorVector<Backend>::TensorVector(TensorVector<Backend> &&other) noexcept {
   tl_ = std::move(other.tl_);
   type_ = std::move(other.type_);
   sample_dim_ = other.sample_dim_;
-  views_count_ = other.views_count_.load();
   tensors_ = std::move(other.tensors_);
-  for (auto &t : tensors_) {
-    if (t) {
-      if (auto *del = std::get_deleter<ViewRefDeleter>(t->data_)) del->ref = &views_count_;
-    }
-  }
 
-  other.views_count_ = 0;
   other.curr_num_tensors_ = 0;
   other.tensors_.clear();
   other.sample_dim_ = -1;
@@ -466,7 +458,7 @@ void TensorVector<Backend>::reserve(size_t bytes_per_sample, int batch_size) {
 
 template <typename Backend>
 bool TensorVector<Backend>::IsContiguous() const noexcept {
-  return state_ == State::contiguous && views_count_ == num_samples();
+  return state_ == State::contiguous;
 }
 
 
@@ -487,7 +479,6 @@ void TensorVector<Backend>::Reset() {
   type_ = {};
   sample_dim_ = -1;
   if (IsContiguous()) {
-    views_count_ = 0;
     tl_->Reset();
   }
 }
@@ -537,7 +528,6 @@ void TensorVector<Backend>::ShareData(const TensorVector<Backend> &tv) {
   sample_dim_ = tv.sample_dim_;
   state_ = tv.state_;
   pinned_ = tv.is_pinned();
-  views_count_ = 0;
   if (tv.state_ == State::contiguous) {
     ShareData(*tv.tl_);
   } else {
@@ -562,19 +552,79 @@ TensorVector<Backend> &TensorVector<Backend>::operator=(TensorVector<Backend> &&
     tl_ = std::move(other.tl_);
     type_ = other.type_;
     sample_dim_ = other.sample_dim_;
-    views_count_ = other.views_count_.load();
     tensors_ = std::move(other.tensors_);
-    for (auto &t : tensors_) {
-      if (t) {
-        if (auto *del = std::get_deleter<ViewRefDeleter>(t->data_)) del->ref = &views_count_;
-      }
-    }
-
-    other.views_count_ = 0;
     other.curr_num_tensors_ = 0;
     other.tensors_.clear();
   }
   return *this;
+}
+
+
+template <typename Backend>
+bool TensorVector<Backend>::IsContiguousTensor() const {
+  if (num_samples() == 0 || shape().num_elements() == 0) {
+    return true;
+  }
+  // if we are using contiguous representation we assume we can safely return
+  if (IsContiguous()) {
+    return true;
+  }
+  const uint8_t *base_ptr = static_cast<const uint8_t *>(tensors_[0]->raw_data());
+  size_t size = type_info().size();
+
+  for (int i = 0; i < shape().num_samples(); ++i) {
+    if (base_ptr != tensors_[i]->raw_data()) {
+      return false;
+    }
+    base_ptr += shape()[i].num_elements() * size;
+  }
+  return true;
+}
+
+
+template <typename Backend>
+bool TensorVector<Backend>::IsDenseTensor() const {
+  return IsContiguousTensor() && is_uniform(shape());
+}
+
+
+template <typename Backend>
+Tensor<Backend> TensorVector<Backend>::AsReshapedTensor(const TensorShape<> &new_shape) {
+  DALI_ENFORCE(num_samples() > 0,
+               "To create a view Tensor, the batch must have at least 1 element.");
+  DALI_ENFORCE(IsValidType(type()),
+               "To create a view Tensor, the batch must have a valid data type.");
+  DALI_ENFORCE(has_data(), "To create a view Tensor, the batch must have a valid data allocation.");
+  DALI_ENFORCE(
+      IsContiguousTensor(),
+      "The batch must be representable as tensor - it must be allocated in contiguous memory.");
+  DALI_ENFORCE(
+      shape().num_elements() == new_shape.num_elements(),
+      make_string("To create a view Tensor, requested shape need to have the same volume as the "
+                  "batch, requested: ",
+                  new_shape.num_elements(), " expected: ", shape().num_elements()));
+  Tensor<Backend> result;
+  result.ShareData(unsafe_sample_owner(*tl_, 0), tl_->capacity(), tl_->is_pinned(), new_shape,
+                   type(), order());
+  result.set_device_id(device_id());
+  auto result_layout = GetLayout();
+  if (!GetLayout().empty()) {
+    result_layout = TensorLayout("N") + result_layout;
+  }
+  result.SetLayout(result_layout);
+  return result;
+}
+
+
+template <typename Backend>
+Tensor<Backend> TensorVector<Backend>::AsTensor() {
+  DALI_ENFORCE(IsDenseTensor(),
+               "The batch must be representable as tensor - it must has uniform shape and be "
+               "allocated in contiguous memory.");
+  DALI_ENFORCE(shape().num_samples() > 0,
+               "To create a view Tensor, the batch must have at least 1 element.");
+  DALI_ENFORCE(shape()[0].num_elements() > 0, "To create a view Tensor, sample must not be empty.");
+  return AsReshapedTensor(shape_cat(shape().num_samples(), shape()[0]));
 }
 
 
@@ -588,7 +638,6 @@ void TensorVector<Backend>::UpdateViews() {
 
   assert(curr_num_tensors_ == tl_->num_samples());
 
-  views_count_ = curr_num_tensors_;
   for (int i = 0; i < curr_num_tensors_; i++) {
     update_view(i);
   }
@@ -689,7 +738,7 @@ void TensorVector<Backend>::update_view(int idx) {
   // TODO(klecki): deleter that reduces views_count or just noop sharing?
   // tensors_[i]->ShareData(tl_.get(), static_cast<int>(idx));
   if (tensors_[idx]->raw_data() != ptr || tensors_[idx]->shape() != shape) {
-    tensors_[idx]->ShareData(std::shared_ptr<void>(ptr, ViewRefDeleter{&views_count_}),
+    tensors_[idx]->ShareData(unsafe_sample_owner(*tl_, idx),
                              volume(tl_->tensor_shape(idx)) * tl_->type_info().size(),
                              tl_->is_pinned(),
                              shape, tl_->type(),

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -313,6 +313,32 @@ class DLL_PUBLIC TensorVector {
 
   TensorVector<Backend> &operator=(TensorVector<Backend> &&other) noexcept;
 
+  /**
+   * @brief Checks whether the batch container is contiguous. It returns true if and only if
+   * all of the stored individual tensors are densely packed in memory.
+   */
+  bool IsContiguousTensor() const;
+
+  /**
+   * @brief Checks whether the batch container can be converted to a dense Tensor. It returns true
+   * if and only if all of the stored tensors have the same shape and they are densely packed in
+   * memory.
+   */
+  bool IsDenseTensor() const;
+
+  /**
+   * @brief Returns a pointer to Tensor which shares the data with this batch object and give it the
+   * provided shape. Batch and the Tensor share the memory allocation. The tensor obtained through
+   * this function stays valid for as long as TensorList data is unchanged.
+   * The batch must be representable as DenseTensor.
+   */
+  DLL_PUBLIC Tensor<Backend> AsReshapedTensor(const TensorShape<> &new_shape);
+
+  /**
+   * @brief Return a Dense Tensor representation of the underlying memory if possible.
+   */
+  DLL_PUBLIC Tensor<Backend> AsTensor();
+
   void UpdateViews();
 
   shared_ptr<TensorList<Backend>> AsTensorList(bool check_contiguity = true);
@@ -365,7 +391,6 @@ class DLL_PUBLIC TensorVector {
 
   void update_view(int idx);
 
-  std::atomic<int> views_count_;
   std::vector<std::shared_ptr<Tensor<Backend>>> tensors_;
   int curr_num_tensors_;
   std::shared_ptr<TensorList<Backend>> tl_;

--- a/dali/pipeline/data/tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_vector_test.cc
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <cstdint>
 #include <string>
+#include <type_traits>
 
 #include "dali/core/format.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/pipeline/data/tensor_vector.h"
+#include "dali/pipeline/data/types.h"
 #include "dali/pipeline/data/views.h"
 #include "dali/test/tensor_test_utils.h"
 
@@ -114,6 +117,93 @@ TYPED_TEST(TensorVectorSuite, PinnedBeforeResizeNoncontiguous) {
   EXPECT_EQ(tv.is_pinned(), false);
   for (int i = 0; i < tv.num_samples(); i++) {
     EXPECT_EQ(tv[i].type(), DALI_INT32);
+  }
+}
+
+namespace {
+
+const uint8_t kMagicNumber = 42;
+
+void FillWithMagicNumber(TensorVector<CPUBackend> &tv) {
+  for (int i = 0; i < tv.shape().num_elements(); i++) {
+    // We utilize the contiguity of the TensorVector
+    tv.mutable_tensor<uint8_t>(0)[i] = kMagicNumber;
+  }
+}
+
+void FillWithMagicNumber(TensorVector<GPUBackend> &tv) {
+  // We utilize the contiguity of the TensorVector
+  cudaMemset(tv.mutable_tensor<uint8_t>(0), kMagicNumber, tv.shape().num_elements());
+}
+
+
+void CompareWithMagicNumber(Tensor<CPUBackend> &t) {
+  for (int i = 0; i < t.shape().num_elements(); i++) {
+    EXPECT_EQ(t.data<uint8_t>()[i], kMagicNumber);
+  }
+}
+
+void CompareWithMagicNumber(Tensor<GPUBackend> &t) {
+  uint8_t *ptr;
+  std::vector<uint8_t> buffer(t.shape().num_elements());
+  cudaMemcpy(buffer.data(), t.data<uint8_t>(), t.shape().num_elements(), cudaMemcpyDeviceToHost);
+  for (auto b : buffer) {
+    EXPECT_EQ(b, kMagicNumber);
+  }
+}
+
+
+template <typename Backend>
+Tensor<Backend> ReturnTvAsTensor() {
+  TensorVector<Backend> tv;
+  tv.SetContiguous(true);
+  tv.Resize(uniform_list_shape(4, {1, 2, 3}), DALI_UINT8);
+  tv.SetLayout("HWC");
+  FillWithMagicNumber(tv);
+  return tv.AsTensor();
+}
+
+}  // namespace
+
+
+TYPED_TEST(TensorVectorSuite, TensorVectorAsTensorAccess) {
+  TensorVector<TypeParam> tv;
+  tv.SetContiguous(true);
+  auto shape = TensorListShape<>{{1, 2, 3}, {1, 2, 4}};
+  tv.Resize(shape, DALI_INT32);
+  EXPECT_TRUE(tv.IsContiguousTensor());
+  EXPECT_FALSE(tv.IsDenseTensor());
+
+  {
+    auto tensor_shape = TensorShape<>{2, 7};
+    auto tensor = tv.AsReshapedTensor(tensor_shape);
+    EXPECT_EQ(tensor.shape(), tensor_shape);
+    EXPECT_EQ(tensor.type(), DALI_INT32);
+    EXPECT_EQ(tensor.raw_data(), tv.raw_tensor(0));
+  }
+  tv.Resize(uniform_list_shape(3, {2, 3, 4}));
+  tv.SetLayout("HWC");
+
+  EXPECT_TRUE(tv.IsContiguousTensor());
+  EXPECT_TRUE(tv.IsDenseTensor());
+
+  {
+    auto expected_shape = TensorShape<>{3, 2, 3, 4};
+    auto tensor = tv.AsTensor();
+    EXPECT_EQ(tensor.shape(), expected_shape);
+    EXPECT_EQ(tensor.type(), DALI_INT32);
+    EXPECT_EQ(tensor.GetLayout(), "NHWC");
+    EXPECT_EQ(tensor.raw_data(), tv.raw_tensor(0));
+  }
+
+  {
+    // Verify that we can convert and touch the data after TV is already released
+    auto tensor = ReturnTvAsTensor<TypeParam>();
+    auto expected_shape = TensorShape<>{4, 1, 2, 3};
+    EXPECT_EQ(tensor.shape(), expected_shape);
+    EXPECT_EQ(tensor.type(), DALI_UINT8);
+    EXPECT_EQ(tensor.GetLayout(), "NHWC");
+    CompareWithMagicNumber(tensor);
   }
 }
 


### PR DESCRIPTION
## Category: **New feature**, **Refactoring**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Add to the TensorVector the set of APIs already
present in TensorList:
* IsContiguousTensor
* IsDenseTensor
* AsReshapedTensor
* AsTensor

The APIs allow to access the memory of the contiguous
batch through the API of the Tensor. They are exposed
through the Python APIs for TensorList and the conversion
is valid as long as the allocation of the source object
is not changed.
Caching the returned Tensors is not replicated to simplify
the API.

The atomic counter of current internal "view" Tensors 
(the elements of tensors_) is removed - it use was insignificant
and the deleter appearing in the Tensors created via
the new API could mess it up as it kept the old allocation
and current counter.

Either way, the followups also remove the counter.

## Additional information:

### Affected modules and functionalities:
TensorVector introducing TensorList APIs to prepare
for the replacement.

### Key points relevant for the review:
There is a difference with how the Tensors are returned 
to Python: instead of returning then via pointer to a cached
Tensor instance with `py::return_value_policy::reference_internal`
(which keeps the TL alive as long as we use Tensor)
we just return the object and rely on the allocation being
kept by the shared_ptr.

If we kept the pointer to the old instance of such Tensor
and DALI destroyed that Tensor (for example with ::Reset())
it would cause a crash. 

The lifetime of such Tensor is still problematic now
so I am open to any suggestion. This API may be really
problematic if we allow in-place modification of TL or similar.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
