### PR TITLE
Improve error reporting on partially unused output of external source

### DIFF
--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -165,7 +165,7 @@ class _ExternalSourceGroup(object):
         if len(pruned_mask) != len(self.instances):
             raise RuntimeError(
                 f"Mask of the pruned outputs of the external source must have the length matching "
-                f"the number of outputs of the external source. The external source node have "
+                f"the number of outputs of the external source. The external source node has "
                 f"{len(self.instances)} outputs, but received mask of length {len(pruned_mask)}.")
         self.utilized_instances = [
             instance for instance, is_pruned

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -702,9 +702,9 @@ Parameters
                 else:
                     pruned_str = f"output at the index {pruned_idx_str} is"
                 warnings.warn(
-                    f"The external source '{source_str}' produces {num_outputs} outputs, but "
-                    f"the {pruned_str} not used. For best performance, adjust your callback so "
-                    "that it computes only the needed outputs.",
+                    f"The external source node '{source_str}' produces {num_outputs} outputs, "
+                    f"but the {pruned_str} not used. For best performance, adjust your "
+                    f"callback so that it computes only the needed outputs.",
                     Warning
                 )
 

--- a/dali/test/python/nose_utils.py
+++ b/dali/test/python/nose_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,46 @@ import re
 import fnmatch
 
 
+def glob_to_regex(glob):
+    if not isinstance(glob, str):
+        raise ValueError("Glob pattern must be a string")
+    pattern = fnmatch.translate(glob)
+    # fnmatch adds special character to match the end of the string, so that when used
+    # with re.match it, by default, matches the whole string. Here, it's going to be used
+    # with re.search so it would be weird to enforce matching the suffix, but not the prefix.
+    if pattern[-2:] == r"\Z":
+        pattern = pattern[:-2]
+    return pattern
+
+
+def get_pattern(glob=None, regex=None, match_case=None):
+    assert glob is not None or regex is not None
+
+    if glob is not None and regex is not None:
+        raise ValueError(
+            "You should specify at most one of `glob` and `regex` parameters but not both")
+
+    if glob is not None:
+        pattern = glob_to_regex(glob)
+    else:  # regex is not None
+        if match_case is not None and not isinstance(regex, str):
+            raise ValueError(
+                "Regex must be a string if `match_case` is specified when "
+                "calling assert_raises_pattern")
+        pattern = regex
+
+    if isinstance(pattern, str) and not match_case:  # ignore case by default
+        pattern = re.compile(pattern, re.IGNORECASE)
+
+    return pattern
+
+
 def assert_raises(exception, *args, glob=None, regex=None, match_case=None, **kwargs):
 
     """
     Wrapper combining `nose.tools.assert_raises` and `nose.tools.assert_raises_regex`.
-    Specify ``regex=pattern`` or ``glob=pattern`` to check error message of expected exception against the pattern.
+    Specify ``regex=pattern`` or ``glob=pattern`` to check error message of expected exception
+    against the pattern.
     Value for `glob` must be a string, `regex` can be either a literal or compiled regex pattern.
     By default, the check will ignore case, if called with `glob` or a literal for `regex`.
     To enforce case sensitive check pass ``match_case=True``.
@@ -31,27 +66,17 @@ def assert_raises(exception, *args, glob=None, regex=None, match_case=None, **kw
     if glob is None and regex is None:
         return tools.assert_raises(exception, *args, **kwargs)
 
-    if glob is not None and regex is not None:
-        raise ValueError("You should specify at most one of `glob` and `regex` parameters but not both")
-
-    if glob is not None:
-        if not isinstance(glob, str):
-            raise ValueError("Glob pattern must be a string")
-        pattern = fnmatch.translate(glob)
-        # fnmatch adds special character to match the end of the string, so that when used
-        # with re.match it, by default, matches the whole string. Here, it's going to be used
-        # with re.search so it would be weird to enforce matching the suffix, but not the prefix.
-        if pattern[-2:] == r"\Z":
-            pattern = pattern[:-2]
-    else: # regex is not None
-        if match_case is not None and not isinstance(regex, str):
-            raise ValueError("Regex must be a string if `match_case` is specified when calling assert_raises_pattern")
-        pattern = regex
-
-    if isinstance(pattern, str) and not match_case: # ignore case by default
-        pattern = re.compile(pattern, re.IGNORECASE)
-
+    pattern = get_pattern(glob, regex, match_case)
     return tools.assert_raises_regex(exception, pattern, *args, **kwargs)
+
+
+def assert_warns(exception=Warning, *args, glob=None, regex=None, match_case=None, **kwargs):
+
+    if glob is None and regex is None:
+        return tools.assert_warns(exception, *args, **kwargs)
+
+    pattern = get_pattern(glob, regex, match_case)
+    return tools.assert_warns_regex(exception, pattern, *args, **kwargs)
 
 
 def raises(exception, glob=None, regex=None, match_case=None):


### PR DESCRIPTION
Improve error reporting on partially unused output of external source

Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->

## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
If one creates external source (and provides the source to the operator) with multiple outputs, but does not use some of the outputs, it results in vague error on feed_input that tries to feed input to non-existing operator. ~~Catch that early (in pipeline.build()) and provide clearer error.~~

Find instances of partially unused external source groups during the Python pipeline build and explicitly disable the unused instances in the relevant ExternalSourceGroup, so that the group skips feeding the pruned external source nodes during the run. Emit relevant warning.


## Additional information:

### Affected modules and functionalities:
Python pipeline wrapper.

Nose utility module: added assert_warns mirroring asser_raises, extracted common code.
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
Given the number of ways to define functioning pipeline, please think if the check does not interrupt some valid use case of external source that would work otherwise (I don't think it can, but it would be good to double check it with someone else).
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2802
<!--- DALI-XXXX or NA --->
