### PR TITLE
Fix and reenable optimized Cast kernel

### DIFF
--- a/dali/operators/generic/cast.cu
+++ b/dali/operators/generic/cast.cu
@@ -43,6 +43,7 @@ class CastGPU : public Cast<GPUBackend> {
 
  private:
   using GpuBlockSetup = kernels::BlockSetup<1, -1>;
+  TensorListShape<1> collapsed_shape_;
 
   GpuBlockSetup block_setup_;
   std::vector<kernels::CastSampleDesc> samples_;
@@ -58,25 +59,28 @@ bool CastGPU::SetupImpl(std::vector<OutputDesc> &output_desc, const DeviceWorksp
 void CastGPU::PrepareBlocks(const DeviceWorkspace &ws) {
   const auto &input = ws.Input<GPUBackend>(0);
   const auto &input_shape = input.shape();
-  TensorListShape<1> collapsed_shape;
   if (input.sample_dim() > 0) {
     std::array<std::pair<int, int>, 1> collapse_groups = {{{0, input_shape.sample_dim()}}};
-    collapsed_shape = collapse_dims<1>(input_shape, collapse_groups);
+    collapsed_shape_ = collapse_dims<1>(input_shape, collapse_groups);
   } else {
-    collapsed_shape = uniform_list_shape(input_shape.num_samples(), TensorShape<1>{1});
+    collapsed_shape_ = uniform_list_shape(input_shape.num_samples(), TensorShape<1>{1});
   }
 
-  block_setup_.SetupBlocks(collapsed_shape, true);
+  block_setup_.SetupBlocks(collapsed_shape_, true);
 }
 
 void CastGPU::RunImpl(DeviceWorkspace &ws) {
   const auto &input = ws.Input<GPUBackend>(0);
-  const auto &input_shape = input.shape();
   auto &output = ws.Output<GPUBackend>(0);
   output.SetLayout(input.GetLayout());
 
   kernels::DynamicScratchpad scratchpad({}, ws.stream());
-  auto num_samples = input_shape.num_samples();
+  auto num_samples = collapsed_shape_.num_samples();
+
+  // Get rid of empty samples at the end of the batch
+  for (; num_samples > 0 && collapsed_shape_[num_samples - 1][0] == 0; num_samples--) {}
+
+
   samples_.resize(num_samples);
   for (int sample_id = 0; sample_id < num_samples; sample_id++) {
     samples_[sample_id].output = output.raw_mutable_tensor(sample_id);
@@ -85,31 +89,17 @@ void CastGPU::RunImpl(DeviceWorkspace &ws) {
 
   std::vector<kernels::CastSampleBlockDesc> params_host(num_samples);
   for (int sample_id = 0; sample_id < num_samples; sample_id++) {
-    params_host[sample_id].sample_size = volume(input.tensor_shape(sample_id));
+    params_host[sample_id].sample_size = collapsed_shape_[sample_id][0];
   }
 
   auto blocks = block_setup_.Blocks();
 
-  kernels::BlockDesc<1> *blocks_dev;
-  kernels::CastSampleDesc *samples_dev;
-  std::tie(blocks_dev, samples_dev) = scratchpad.ToContiguousGPU(ws.stream(),
-                                                                 blocks, samples_);
-
-  DALIDataType itype = input.type();
-  dim3 grid_dim = block_setup_.GridDim();
-  dim3 block_dim = block_setup_.BlockDim();
-  TYPE_SWITCH(output_type_, type2id, OType, CAST_ALLOWED_TYPES, (
-    TYPE_SWITCH(itype, type2id, IType, CAST_ALLOWED_TYPES, (
-      kernels::BatchedCastKernel<OType, IType>
-          <<<grid_dim, block_dim, 0, ws.stream()>>>(samples_dev, blocks_dev);
-    ), DALI_FAIL(make_string("Invalid input type: ", itype)););  // NOLINT(whitespace/parens)
-  ), DALI_FAIL(make_string("Invalid output type: ", output_type_)););  // NOLINT(whitespace/parens)
-
-  /*
-  TODO(michalz): Fix the kernel!
   // Calculate id of the earliest block that should process given sample
   for (int block_id = 0, sample_id = -1; block_id < blocks.size(); block_id++) {
-    if (blocks[block_id].sample_idx != sample_id) {
+    // In case of an empty sample, the block descriptor is not generated for it.
+    // We mark all the empty samples as using currently selected block_id, and the kernel chooses
+    // the latest (rightmost) sample that is marked with its block id for processing.
+    while (sample_id < blocks[block_id].sample_idx) {
       sample_id++;
       params_host[sample_id].first_block = block_id;
     }
@@ -130,7 +120,6 @@ void CastGPU::RunImpl(DeviceWorkspace &ws) {
             num_samples, block_volume_scale);
     ), DALI_FAIL(make_string("Invalid input type: ", itype)););  // NOLINT(whitespace/parens)
   ), DALI_FAIL(make_string("Invalid output type: ", output_type_)););  // NOLINT(whitespace/parens)
-  */
 }
 
 DALI_REGISTER_OPERATOR(Cast, CastGPU, GPU);

--- a/dali/test/python/test_operator_cast.py
+++ b/dali/test/python/test_operator_cast.py
@@ -69,7 +69,7 @@ def replace_with_empty_volumes(rng, input, empty_volume_policy):
         start = 0
         end = rng.integers(1, len(input) // 3)
     elif empty_volume_policy == "right":
-        start = rng.integers(1, len(input) * 2 // 3)
+        start = rng.integers(len(input) * 2 // 3, len(input) - 1)
         end = len(input)
     elif empty_volume_policy == "middle":
         start = rng.integers(1 + len(input) // 3, len(input) * 2 // 3)

--- a/dali/test/python/test_operator_cast.py
+++ b/dali/test/python/test_operator_cast.py
@@ -50,8 +50,8 @@ def replace_with_empty_volumes(rng, input, empty_volume_policy):
     input : List of np.array
         Batch to process
     empty_volume_policy : str
-        one of "left", "right, "middle", "all", to indicate if the batch suffix, prefix, infix
-        or all of them should be randomly replaced with 0-volumed samples
+        one of "left", "right, "middle", "mixed", "all", to indicate if the batch suffix, prefix,
+        infix or all of them should be randomly replaced with 0-volumed samples
 
     Returns
     -------
@@ -61,11 +61,14 @@ def replace_with_empty_volumes(rng, input, empty_volume_policy):
         return input
     if len(input[0].shape) == 0:
         return input
-    if empty_volume_policy == "all":
+    if empty_volume_policy == "mixed":
         left = replace_with_empty_volumes(rng, input, "left")
         left_and_mid = replace_with_empty_volumes(rng, left, "middle")
         return replace_with_empty_volumes(rng, left_and_mid, "right")
-    if empty_volume_policy == "left":
+    if empty_volume_policy == "all":
+        start = 0
+        end = len(input)
+    elif empty_volume_policy == "left":
         start = 0
         end = rng.integers(1, len(input) // 3)
     elif empty_volume_policy == "right":
@@ -169,7 +172,10 @@ def test_operator_cast_empty_volumes():
         for in_type in types:
             for out_type in types:
                 ndim = rng.integers(0, 4)
+
                 batch_size = rng.integers(12, 64)
-                for empty_volume_policy in ["left", "right", "middle", "all"]:
+                for empty_volume_policy in [
+                        rng.choice(["left", "right", "middle", "mixed"]), "all"
+                ]:
                     yield (_test_operator_cast, ndim, batch_size, in_type, out_type, device,
                            empty_volume_policy)

--- a/dali/test/python/test_operator_cast.py
+++ b/dali/test/python/test_operator_cast.py
@@ -38,10 +38,51 @@ def random_shape(rng, ndim: int, max_size: int):
     if ndim == 0:
         return []
     max_size = int(max_size ** (1 / ndim))
-    return list(rng.integers(0, max_size, [ndim]))
+    return list(rng.integers(1, max_size, [ndim]))
+
+def replace_with_empty_volumes(rng, input, empty_volume_policy):
+    """Replaces samples with 0-volumed ones if possible.
+
+    Parameters
+    ----------
+    rng :
+        rng
+    input : List of np.array
+        Batch to process
+    empty_volume_policy : str
+        one of "left", "right, "middle", "all", to indicate if the batch suffix, prefix, infix
+        or all of them should be randomly replaced with 0-volumed samples
+
+    Returns
+    -------
+    List of np.array
+    """
+    if empty_volume_policy is None:
+        return input
+    if len(input[0].shape) == 0:
+        return input
+    if empty_volume_policy == "all":
+        left = replace_with_empty_volumes(rng, input, "left")
+        left_and_mid = replace_with_empty_volumes(rng, left, "middle")
+        return replace_with_empty_volumes(rng, left_and_mid, "right")
+    if empty_volume_policy == "left":
+        start = 0
+        end = rng.integers(1, len(input) // 3)
+    elif empty_volume_policy == "right":
+        start = rng.integers(1, len(input) * 2 // 3)
+        end = len(input)
+    elif empty_volume_policy == "middle":
+        start = rng.integers(1 + len(input) // 3, len(input) * 2 // 3)
+        end = rng.integers(start + 1, len(input) - 1)
+    for i in range(start, end):
+        shape = list(input[i].shape)
+        shape[0] = 0
+        input[i] = np.zeros(dtype=input[i].dtype, shape=shape)
+    return input
 
 
-def generate(rng, ndim: int, batch_size: int, in_dtype: np.dtype, out_dtype: np.dtype):
+def generate(rng, ndim: int, batch_size: int, in_dtype: np.dtype, out_dtype: np.dtype,
+             empty_volume_policy: str):
     lo, hi = -1000, 1000
     if np.issubdtype(out_dtype, np.integer):
         lo = np.iinfo(out_dtype).min
@@ -59,6 +100,7 @@ def generate(rng, ndim: int, batch_size: int, in_dtype: np.dtype, out_dtype: np.
 
     max_size = 100000 // batch_size
     out = [rng.uniform(lo, hi, size=random_shape(rng, ndim, max_size)).astype(in_dtype) for _ in range(batch_size)]
+    out = replace_with_empty_volumes(rng, out, empty_volume_policy)
     if np.issubdtype(in_dtype, np.floating) and np.issubdtype(out_dtype, np.integer):
         for x in out:
             # avoid exactly halfway numbers - rounding is different for CPU and GPU
@@ -71,8 +113,8 @@ rng = np.random.default_rng(1234)
 
 
 @nottest
-def _test_operator_cast(ndim, batch_size, in_dtype, out_dtype, device):
-    src = lambda: generate(rng, ndim, batch_size, in_dtype, out_dtype)
+def _test_operator_cast(ndim, batch_size, in_dtype, out_dtype, device, empty_volume_policy=None):
+    src = lambda: generate(rng, ndim, batch_size, in_dtype, out_dtype, empty_volume_policy)
 
     @pipeline_def(batch_size=batch_size, num_threads=4, device_id=types.CPU_ONLY_DEVICE_ID if device == 'cpu' else 0)
     def cast_pipe():
@@ -119,3 +161,15 @@ def test_operator_cast():
                 ndim = rng.integers(0, 4)
                 batch_size = rng.integers(1, 11)
                 yield _test_operator_cast, ndim, batch_size, in_type, out_type, device
+
+
+def test_operator_cast_empty_volumes():
+    types = [np.uint8, np.int32, np.float32]
+    for device in ['cpu', 'gpu']:
+        for in_type in types:
+            for out_type in types:
+                ndim = rng.integers(0, 4)
+                batch_size = rng.integers(12, 64)
+                for empty_volume_policy in ["left", "right", "middle", "all"]:
+                    yield (_test_operator_cast, ndim, batch_size, in_type, out_type, device,
+                           empty_volume_policy)


### PR DESCRIPTION
## Category: **Bug fix**
<!---
Please pick one from below:
 (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
The bug in binsearch Cast kernel manifested
on empty samples - there was mismatch between
sample that was assigned to a given block
and the block that was assumed by the kernel
due to BlockDescriptos not being generated
for samples with 0 volume.

Now, the empty samples are skipped at the
end of the batch and when assigning the
lowest blockIdx to a given sample.

The binsearch looks for the rightmost
sample when searching the descriptors.

Test was adjusted to not generate empty samples
and another was added to randomly make
selected ranges of samples empty.

The speedup compared to the old implementation
is between 10% and 25%, averaging 16%, depending
on the size of the input.

Additionally the collapsed shape was reused
for the data volume.

## Additional information:

### Affected modules and functionalities:
Cast


### Key points relevant for the review:
Can I assume that there is at least one non-empty sample?
Should I add a check?

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
	- Recently extended Python Cast test was adjusted to not generate 0 samples randomly
	  and another one was added to do that in controlled manner.
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
