### PR TITLE
Improve handling of "dtype" arguments in OpSchema/OpSpec

### DIFF
--- a/dali/operators/audio/preemphasis_filter_op.cc
+++ b/dali/operators/audio/preemphasis_filter_op.cc
@@ -39,7 +39,7 @@ The value of ``X_border`` depends on the ``border`` argument::
     .NumInput(1)
     .NumOutput(detail::kNumOutputs)
     .AddOptionalArg(detail::kCoeff, R"code(Preemphasis coefficient ``coeff``.)code", 0.97f, true)
-    .AddOptionalArg(arg_names::kDtype, R"code(Data type for the output.)code", DALI_FLOAT)
+    .AddOptionalTypeArg(arg_names::kDtype, R"code(Data type for the output.)code", DALI_FLOAT)
     .AddOptionalArg(detail::kBorder,
       R"(Border value policy. Possible values are \"zero\", \"clamp\", \"reflect\".)",
       "clamp");

--- a/dali/operators/decoder/audio/audio_decoder_op.cc
+++ b/dali/operators/decoder/audio/audio_decoder_op.cc
@@ -36,7 +36,7 @@ This operator produces the following outputs:
 
 If downmixing is turned on, the decoder output is 1D.
 If downmixing is turned off, it produces 2D output with interleaved channels.)code", false)
-  .AddOptionalArg("dtype", R"code(Output data type.
+  .AddOptionalTypeArg("dtype", R"code(Output data type.
 
 Supported types: ``INT16``, ``INT32``, ``FLOAT``.)code", DALI_FLOAT)
   .AddOptionalArg("sample_rate",

--- a/dali/operators/generic/cast.cc
+++ b/dali/operators/generic/cast.cc
@@ -71,6 +71,6 @@ DALI_SCHEMA(Cast)
     .NumOutput(1)
     .AllowSequences()
     .SupportVolumetric()
-    .AddArg("dtype", R"code(Output data type.)code", DALI_DATA_TYPE);
+    .AddTypeArg("dtype", R"code(Output data type.)code");
 
 }  // namespace dali

--- a/dali/operators/generic/constant.cc
+++ b/dali/operators/generic/constant.cc
@@ -58,12 +58,10 @@ the ``shape`` and ``dtype``, will be taken from the array.
 .. note::
     ``fdata`` and ``idata`` are mutually exclusive, and one of them is required.)code",
                   std::vector<int>())
-  .AddOptionalArg("dtype",
-                  R"code(Output data type.
+  .AddOptionalTypeArg("dtype", R"code(Output data type.
 
 If this value is not set, the output is float if the fdata argument is used and
-int if idata is used.)code",
-                  DALI_NO_TYPE)
+int if idata is used.)code")
   .AddOptionalArg("layout",
                   R"code(Layout info.
 

--- a/dali/operators/generic/constant.h
+++ b/dali/operators/generic/constant.h
@@ -35,7 +35,6 @@ class Constant : public Operator<Backend> {
   explicit Constant(const OpSpec &spec) : Operator<Backend>(spec) {
     bool has_shape = spec.ArgumentDefined("shape");
     spec.TryGetRepeatedArgument(shape_arg_, "shape");
-    output_type_ = spec.GetArgument<DALIDataType>("dtype");
     if (spec.HasArgument("fdata")) {
       DALI_ENFORCE(!spec.HasArgument("idata"), "Constant node: `fdata` and `idata` arguments are "
         "mutually exclusive");
@@ -47,14 +46,12 @@ class Constant : public Operator<Backend> {
           "The number of values does not match the shape specified");
       }
 
-      if (!spec.HasArgument("dtype"))
-        output_type_ = DALI_FLOAT;
+      output_type_ = DALI_FLOAT;
     } else {
       DALI_ENFORCE(spec.HasArgument("idata"),
           "Constant node: either `fdata` or `idata` must be present.");
 
-      if (!spec.HasArgument("dtype"))
-        output_type_ = DALI_INT32;
+      output_type_ = DALI_INT32;
 
       idata_ = spec.GetRepeatedArgument<int>("idata");
       if (!has_shape) {
@@ -64,6 +61,8 @@ class Constant : public Operator<Backend> {
           "The number of values does not match the shape specified");
       }
     }
+    spec.TryGetArgument(output_type_, "dtype");
+
     layout_ = spec.GetArgument<TensorLayout>("layout");
     if (!layout_.empty()) {
       DALI_ENFORCE(layout_.size() == static_cast<int>(shape_arg_.size()), make_string(

--- a/dali/operators/generic/lookup_table.cc
+++ b/dali/operators/generic/lookup_table.cc
@@ -99,7 +99,7 @@ Here is a practical example, considering the table defined above::
   .NumOutput(1)
   .AllowSequences()
   .SupportVolumetric()
-  .AddOptionalArg("dtype",
+  .AddOptionalTypeArg("dtype",
     R"code(Output data type.)code",
     DALI_FLOAT)
   .DeprecateArgInFavorOf("output_dtype", "dtype")  // deprecated since 0.24dev

--- a/dali/operators/generic/one_hot.cc
+++ b/dali/operators/generic/one_hot.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ as scalars is not supported if ``axis`` argument is specified.)code")
   .AddOptionalArg<int>("axis", R"code(Dimension to place the one-hot encoding axis of `num_classes`
 size. By default it's appended as the last dimension for non-scalar inputs. For scalar inputs,
 it becomes the only dimension.)code", -1)
-  .AddOptionalArg(arg_names::kDtype, R"code(Output data type.)code", DALI_FLOAT)
+  .AddOptionalTypeArg(arg_names::kDtype, R"code(Output data type.)code", DALI_FLOAT)
   .AddOptionalArg("on_value",
                   R"code(Value that will be used to fill the output to indicate given class
 in the corresponding input coordinate.

--- a/dali/operators/generic/reduce/reduce.cc
+++ b/dali/operators/generic/reduce/reduce.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,9 +40,8 @@ layout `"FHWC"` is equivalent to specifying ``axes=[1,2]``. This argument cannot
     false);
 
 DALI_SCHEMA(ReduceWithOutputType)
-  .AddOptionalArg("dtype",
-    R"code(Output data type. This type is used to accumulate the result.)code",
-    DALI_NO_TYPE)
+  .AddOptionalTypeArg("dtype",
+    R"code(Output data type. This type is used to accumulate the result.)code")
   .AddParent("ReduceBase");
 
   DALI_SCHEMA(ReduceWithMeanInput)

--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -92,11 +92,11 @@ The buffer contents are not copied.)")
   .PassThrough({{0, 0}})
   .AllowSequences()
   .SupportVolumetric()
-  .AddOptionalArg("dtype", R"code(Output data type.
+  .AddOptionalTypeArg("dtype", R"code(Output data type.
 
 The total size, in bytes, of the output must match the input. If no shape is provided,
 the innermost dimension is adjusted accordingly. If the byte size of the innermost
-dimension is not divisible by the size of the target type, an error occurs.)code", DALI_NO_TYPE)
+dimension is not divisible by the size of the target type, an error occurs.)code")
   .AddParent("Reshape");
 
 template <typename Backend>

--- a/dali/operators/generic/shapes.cc
+++ b/dali/operators/generic/shapes.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ DALI_SCHEMA(Shapes)
     .NumOutput(1)
     .AllowSequences()
     .SupportVolumetric()
-    .AddOptionalArg("dtype", R"code(Data type to which the sizes are converted.)code", DALI_INT64)
+    .AddOptionalTypeArg("dtype", "Data type to which the sizes are converted.", DALI_INT64)
     .DeprecateArgInFavorOf("type", "dtype");  // deprecated since 0.27dev
 
 DALI_REGISTER_OPERATOR(Shapes, Shapes<CPUBackend>, CPU);

--- a/dali/operators/generic/slice/slice_base.cc
+++ b/dali/operators/generic/slice/slice_base.cc
@@ -22,12 +22,12 @@ namespace dali {
 DALI_SCHEMA(SliceBase)
     .DocStr(R"code(Base implementation for `Slice`, `Crop` and related operators)code")
     .MakeInternal()
-    .AddOptionalArg("dtype",
+    .AddOptionalTypeArg("dtype",
             R"code(Output data type.
 
 Supported types: ``FLOAT``, ``FLOAT16``, and ``UINT8``.
 
-If not set, the input type is used.)code", DALI_NO_TYPE)
+If not set, the input type is used.)code")
     .DeprecateArgInFavorOf("output_dtype", "dtype");  // deprecated since 0.24dev
 
 template <typename OutputType, typename InputType, int Dims>

--- a/dali/operators/generic/slice/slice_base.h
+++ b/dali/operators/generic/slice/slice_base.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,8 +44,8 @@ class SliceBase : public Operator<Backend> {
  public:
   explicit inline SliceBase(const OpSpec &spec)
       : Operator<Backend>(spec),
-        output_type_(spec.GetArgument<DALIDataType>("dtype")),
         out_of_bounds_policy_(GetOutOfBoundsPolicy(spec)) {
+    spec.TryGetArgument(output_type_, "dtype");
     if (out_of_bounds_policy_ == OutOfBoundsPolicy::Pad) {
       fill_values_ = spec.GetRepeatedArgument<float>("fill_values");
     }

--- a/dali/operators/geometry/coord_transform.cc
+++ b/dali/operators/geometry/coord_transform.cc
@@ -40,7 +40,8 @@ This operator can be used for many operations. Here's the (incomplete) list:
   .AddOptionalTypeArg("dtype", R"(Data type of the output coordinates.
 
 If an integral type is used, the output values are rounded to the nearest integer and clamped
-to the dynamic range of this type.)")
+to the dynamic range of this type.)",
+    DALI_FLOAT)
   .AddParent("MTTransformAttr");
 
 template <>

--- a/dali/operators/geometry/coord_transform.cc
+++ b/dali/operators/geometry/coord_transform.cc
@@ -37,12 +37,10 @@ This operator can be used for many operations. Here's the (incomplete) list:
 )")
   .NumInput(1)
   .NumOutput(1)
-  .AddOptionalArg("dtype", R"(Data type of the output coordinates.
+  .AddOptionalTypeArg("dtype", R"(Data type of the output coordinates.
 
 If an integral type is used, the output values are rounded to the nearest integer and clamped
-to the dynamic range of this type.)",
-    DALI_FLOAT,
-    false)
+to the dynamic range of this type.)")
   .AddParent("MTTransformAttr");
 
 template <>

--- a/dali/operators/geometry/coord_transform.h
+++ b/dali/operators/geometry/coord_transform.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ template <typename Backend>
 class CoordTransform : public Operator<Backend>, private MTTransformAttr {
  public:
   explicit CoordTransform(const OpSpec &spec) : Operator<Backend>(spec), MTTransformAttr(spec) {
-    dtype_ = spec_.template GetArgument<DALIDataType>("dtype");
+    spec_.TryGetArgument(dtype_, "dtype");
   }
 
   bool CanInferOutputs() const override { return true; }
@@ -130,7 +130,7 @@ class CoordTransform : public Operator<Backend>, private MTTransformAttr {
   template <typename OutputType, typename InputType, int out_dim, int in_dim>
   void RunTyped(workspace_t<Backend> &ws);
 
-  DALIDataType dtype_;
+  DALIDataType dtype_ = DALI_NO_TYPE;
 
   kernels::KernelManager kmgr_;
 };

--- a/dali/operators/geometry/coord_transform.h
+++ b/dali/operators/geometry/coord_transform.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ template <typename Backend>
 class CoordTransform : public Operator<Backend>, private MTTransformAttr {
  public:
   explicit CoordTransform(const OpSpec &spec) : Operator<Backend>(spec), MTTransformAttr(spec) {
-    spec_.TryGetArgument(dtype_, "dtype");
+    dtype_ = spec_.template GetArgument<DALIDataType>("dtype");
   }
 
   bool CanInferOutputs() const override { return true; }
@@ -130,7 +130,7 @@ class CoordTransform : public Operator<Backend>, private MTTransformAttr {
   template <typename OutputType, typename InputType, int out_dim, int in_dim>
   void RunTyped(workspace_t<Backend> &ws);
 
-  DALIDataType dtype_ = DALI_NO_TYPE;
+  DALIDataType dtype_;
 
   kernels::KernelManager kmgr_;
 };

--- a/dali/operators/image/color/brightness_contrast.cc
+++ b/dali/operators/image/color/brightness_contrast.cc
@@ -37,10 +37,10 @@ This operator can also change the type of data.)code")
 For signed types, 1.0 represents the maximum positive value that can be represented by
 the type.)code",
                     kDefaultBrightnessShift, true)
-    .AddOptionalArg("dtype",
+    .AddOptionalTypeArg("dtype",
                     R"code(Output data type.
 
-If not set, the input type is used.)code", DALI_NO_TYPE)
+If not set, the input type is used.)code")
     .AllowSequences()
     .SupportVolumetric()
     .InputLayout({"FHWC", "DHWC", "HWC"});
@@ -63,10 +63,10 @@ the uniform grey.)code",
 This is the value that all pixels assume when the contrast is zero. When not set,
 the half of the input type's positive range (or 0.5 for ``float``) is used.)code",
                     brightness_contrast::HalfRange<float>(), false)
-    .AddOptionalArg("dtype",
+    .AddOptionalTypeArg("dtype",
                     R"code(Output data type.
 
-If not set, the input type is used.)code", DALI_NO_TYPE)
+If not set, the input type is used.)code")
     .AllowSequences()
     .SupportVolumetric()
     .InputLayout({"FHWC", "DHWC", "HWC"});

--- a/dali/operators/image/color/brightness_contrast.h
+++ b/dali/operators/image/color/brightness_contrast.h
@@ -62,9 +62,9 @@ class BrightnessContrastOp : public Operator<Backend> {
  protected:
   explicit BrightnessContrastOp(const OpSpec &spec)
       : Operator<Backend>(spec),
-        output_type_arg_(spec.GetArgument<DALIDataType>("dtype")),
         output_type_(DALI_NO_TYPE),
         input_type_(DALI_NO_TYPE) {
+    spec.TryGetArgument(output_type_arg_, "dtype");
     if (spec.HasArgument("contrast_center"))
       contrast_center_ = spec.GetArgument<float>("contrast_center");
 
@@ -139,7 +139,9 @@ class BrightnessContrastOp : public Operator<Backend> {
 
   USE_OPERATOR_MEMBERS();
   std::vector<float> brightness_, brightness_shift_, contrast_;
-  DALIDataType output_type_arg_, output_type_, input_type_;
+  DALIDataType output_type_arg_ = DALI_NO_TYPE;
+  DALIDataType output_type_ = DALI_NO_TYPE;
+  DALIDataType input_type_ = DALI_NO_TYPE;
   float contrast_center_ = std::nanf("");
   kernels::KernelManager kernel_manager_;
 };

--- a/dali/operators/image/color/color_twist.cc
+++ b/dali/operators/image/color/color_twist.cc
@@ -44,7 +44,7 @@ they would in case of rotation.)code",
     .AddOptionalArg(color::kValue,
                     R"code(The value multiplier.)code",
                     1.0f, true)
-    .AddOptionalArg(color::kOutputType, R"code(The output data type.
+    .AddOptionalTypeArg(color::kOutputType, R"code(The output data type.
 
 If a value is not set, the input type is used.)code",
                     DALI_UINT8)
@@ -55,7 +55,7 @@ DALI_SCHEMA(ColorTransformBase)
     .DocStr(R"code(Base Schema for color transformations operators.)code")
     .AddOptionalArg("image_type",
         R"code(The color space of the input and the output image.)code", DALI_RGB)
-    .AddOptionalArg(color::kOutputType, R"code(Output data type.
+    .AddOptionalTypeArg(color::kOutputType, R"code(Output data type.
 
 If not set, the input type is used.)code",
                     DALI_UINT8)

--- a/dali/operators/image/color/color_twist.h
+++ b/dali/operators/image/color/color_twist.h
@@ -94,8 +94,8 @@ class ColorTwistBase : public Operator<Backend> {
  protected:
   explicit ColorTwistBase(const OpSpec &spec)
       : Operator<Backend>(spec),
-        output_type_arg_(spec.GetArgument<DALIDataType>(color::kOutputType)),
         output_type_(DALI_NO_TYPE) {
+    spec.TryGetArgument(output_type_arg_, color::kOutputType);
     if (std::is_same<Backend, GPUBackend>::value) {
       kernel_manager_.Resize(1);
     } else {
@@ -187,7 +187,7 @@ class ColorTwistBase : public Operator<Backend> {
   std::vector<float> hue_, saturation_, value_, brightness_, contrast_;
   std::vector<mat3> tmatrices_;
   std::vector<vec3> toffsets_;
-  DALIDataType output_type_arg_, output_type_;
+  DALIDataType output_type_arg_ = DALI_NO_TYPE, output_type_ = DALI_NO_TYPE;
   kernels::KernelManager kernel_manager_;
 };
 

--- a/dali/operators/image/convolution/gaussian_blur.cc
+++ b/dali/operators/image/convolution/gaussian_blur.cc
@@ -66,11 +66,9 @@ The same input can be provided as per-sample tensors.
                          std::vector<int>{0}, true, true)
     .AddOptionalArg<float>(kSigmaArgName, "Sigma value for the Gaussian Kernel.",
                            std::vector<float>{0.f}, true, true)
-    .AddOptionalArg(
-        "dtype", R"code(Output data type.
+    .AddOptionalTypeArg("dtype", R"code(Output data type.
 
-Supported type: `FLOAT`. If not set, the input type is used.)code",
-        DALI_NO_TYPE);
+Supported type: `FLOAT`. If not set, the input type is used.)code");
 
 
 namespace gaussian_blur {

--- a/dali/operators/image/convolution/gaussian_blur.h
+++ b/dali/operators/image/convolution/gaussian_blur.h
@@ -41,7 +41,9 @@ template <typename Backend>
 class GaussianBlur : public SequenceOperator<Backend> {
  public:
   inline explicit GaussianBlur(const OpSpec& spec)
-      : SequenceOperator<Backend>(spec), dtype_(spec.GetArgument<DALIDataType>("dtype")) {}
+      : SequenceOperator<Backend>(spec) {
+    spec.TryGetArgument(dtype_, "dtype");
+  }
 
   DISABLE_COPY_MOVE_ASSIGN(GaussianBlur);
 

--- a/dali/operators/image/convolution/laplacian.cc
+++ b/dali/operators/image/convolution/laplacian.cc
@@ -94,10 +94,9 @@ Smoothing size must be odd and between 1 and 23.)code",
         "If set to True, automatically scales partial derivatives kernels. Must be False "
         "if ``scale`` is specified.",
         laplacian::normalizeArgDefault)
-    .AddOptionalArg("dtype", R"code(Output data type.
+    .AddOptionalTypeArg("dtype", R"code(Output data type.
 
-Supported type: `FLOAT`. If not set, the input type is used.)code",
-                    DALI_NO_TYPE);
+Supported type: `FLOAT`. If not set, the input type is used.)code");
 
 
 namespace laplacian {

--- a/dali/operators/image/convolution/laplacian.h
+++ b/dali/operators/image/convolution/laplacian.h
@@ -42,7 +42,9 @@ template <typename Backend>
 class Laplacian : public SequenceOperator<Backend> {
  public:
   inline explicit Laplacian(const OpSpec& spec)
-      : SequenceOperator<Backend>(spec), dtype_(spec.GetArgument<DALIDataType>("dtype")) {}
+      : SequenceOperator<Backend>(spec) {
+    spec.TryGetArgument(dtype_, "dtype");
+  }
 
   DISABLE_COPY_MOVE_ASSIGN(Laplacian);
 
@@ -73,7 +75,7 @@ class Laplacian : public SequenceOperator<Backend> {
   void RunImpl(workspace_t<Backend>& ws) override;
 
  private:
-  DALIDataType dtype_;
+  DALIDataType dtype_ = DALI_NO_TYPE;
   USE_OPERATOR_MEMBERS();
   std::unique_ptr<OpImplBase<Backend>> impl_;
   DALIDataType impl_in_dtype_ = DALI_NO_TYPE;

--- a/dali/operators/image/crop/crop_mirror_normalize.cc
+++ b/dali/operators/image/crop/crop_mirror_normalize.cc
@@ -42,7 +42,7 @@ Normalization takes the input images and produces the output by using the follow
   .SupportVolumetric()
   .AddOptionalArg<DALIImageType>("image_type", "Image type", nullptr)
   .DeprecateArg("image_type")  // deprecated since 0.24dev
-  .AddOptionalArg("dtype",
+  .AddOptionalTypeArg("dtype",
        R"code(Output data type.
 
 Supported types: ``FLOAT``, ``FLOAT16``, ``INT8``, ``UINT8``.

--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -54,8 +54,8 @@ data, excluding channels.
 If not provided, all anchors are zero.)code", nullptr, true)
 .AddArg("output_size",
 R"code(Shape of the output.)code", DALI_INT_VEC, true)
-.AddOptionalArg("dtype",
-R"code(Output data type. If not set, the input type is used.)code", DALI_NO_TYPE)
+.AddOptionalTypeArg("dtype",
+R"code(Output data type. If not set, the input type is used.)code")
 .NumOutput(1);
 
 template <typename OutputType, typename InputType>

--- a/dali/operators/image/paste/multipaste.h
+++ b/dali/operators/image/paste/multipaste.h
@@ -67,7 +67,6 @@ class MultiPasteOp : public Operator<Backend> {
 
   explicit MultiPasteOp(const OpSpec &spec)
       : Operator<Backend>(spec)
-      , output_type_arg_(spec.GetArgument<DALIDataType>("dtype"))
       , output_type_(DALI_NO_TYPE)
       , input_type_(DALI_NO_TYPE)
       , output_size_("output_size", spec)
@@ -75,6 +74,7 @@ class MultiPasteOp : public Operator<Backend> {
       , in_anchors_("in_anchors", spec)
       , shapes_("shapes", spec)
       , out_anchors_("out_anchors", spec) {
+    spec.TryGetArgument(output_type_arg_, "dtype");
     if (std::is_same<Backend, GPUBackend>::value) {
       kernel_manager_.Resize(1);
     } else {
@@ -280,7 +280,9 @@ class MultiPasteOp : public Operator<Backend> {
   }
 
   USE_OPERATOR_MEMBERS();
-  DALIDataType output_type_arg_, output_type_, input_type_;
+  DALIDataType output_type_arg_ = DALI_NO_TYPE;
+  DALIDataType output_type_ = DALI_NO_TYPE;
+  DALIDataType input_type_ = DALI_NO_TYPE;
 
   ArgValue<int, 1> output_size_;
 

--- a/dali/operators/image/peek_shape/peek_image_shape.cc
+++ b/dali/operators/image/peek_shape/peek_image_shape.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@ DALI_SCHEMA(PeekImageShape)
   .DocStr(R"code(Obtains the shape of the encoded image.)code")
   .NumInput(1)
   .NumOutput(1)
-  .AddOptionalArg("type", R"code(Data type, to which the sizes are converted.)code", DALI_INT64);
+  .AddOptionalTypeArg("dtype",
+    R"code(Data type, to which the sizes are converted.)code", DALI_INT64)
+  .DeprecateArgInFavorOf("type", "dtype");  // deprecated since 1.16dev
 
 DALI_REGISTER_OPERATOR(PeekImageShape, PeekImageShape, CPU);
 

--- a/dali/operators/image/peek_shape/peek_image_shape.h
+++ b/dali/operators/image/peek_shape/peek_image_shape.h
@@ -30,7 +30,7 @@ class PeekImageShape : public Operator<CPUBackend> {
   PeekImageShape(const PeekImageShape &) = delete;
 
   explicit PeekImageShape(const OpSpec &spec) : Operator<CPUBackend>(spec) {
-    output_type_ = spec.GetArgument<DALIDataType>("type");
+    output_type_ = spec.GetArgument<DALIDataType>("dtype");
     switch (output_type_) {
     case DALI_INT32:
     case DALI_UINT32:

--- a/dali/operators/image/remap/warp_attr.cc
+++ b/dali/operators/image/remap/warp_attr.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,15 +26,15 @@ Non-integer sizes are rounded to nearest integer. The channel dimension should
 be excluded (for example, for RGB images, specify ``(480,640)``, not ``(480,640,3)``.
 )code",
       vector<float>(), true)
-  .AddOptionalArg("fill_value", R"code(Value used to fill areas that are outside the source image.
+  .AddOptionalArg<float>("fill_value",
+                         R"code(Value used to fill areas that are outside the source image.
 
 If a value is not specified, the source coordinates are clamped and the border pixel is
-repeated.)code", DALI_FLOAT)
-  .AddOptionalArg("dtype",
+repeated.)code", nullptr)
+  .AddOptionalTypeArg("dtype",
       R"code(Output data type.
 
-If not set, the input type is used.)code",
-      DALI_NO_TYPE)
+If not set, the input type is used.)code")
   .DeprecateArgInFavorOf("output_dtype", "dtype")  // deprecated since 0.24dev
   .AddOptionalArg("interp_type",
       R"code(Type of interpolation used.)code",

--- a/dali/operators/math/normalize/normalize.cc
+++ b/dali/operators/math/normalize/normalize.cc
@@ -113,7 +113,7 @@ The variance is estimated by using the following formula::
   sum(Xi - mean)**2 / (N - ddof).
 
 This argument is ignored when an externally supplied standard deviation is used.)code", 0, false)
-  .AddOptionalArg("dtype", R"code(Output data type.
+  .AddOptionalTypeArg("dtype", R"code(Output data type.
 
 When using integral types, use ``shift`` and ``scale`` to improve the usage of the output
 type's dynamic range. If ``dtype`` is an integral type, out of range values are clamped,

--- a/dali/operators/reader/nemo_asr_reader_op.cc
+++ b/dali/operators/reader/nemo_asr_reader_op.cc
@@ -85,7 +85,7 @@ This reader produces between 1 and 3 outputs:
     "If True, downmix all input channels to mono. "
     "If downmixing is turned on, decoder will produce always 1-D output",
     true)
-  .AddOptionalArg("dtype",
+  .AddOptionalTypeArg("dtype",
     R"code(Output data type.
 
 Supported types: ``INT16``, ``INT32``, and ``FLOAT``.)code",

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -143,7 +143,7 @@ This parameter can be used to trade off memory usage with performance.)code",
   .AddOptionalArg("image_type",
       R"(The color space of the output frames (RGB or YCbCr).)",
       DALI_RGB)
-  .AddOptionalArg("dtype",
+  .AddOptionalTypeArg("dtype",
       R"(Output data type.
 
 Supported types: ``UINT8`` or ``FLOAT``.)",

--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -92,13 +92,13 @@ For the CPU, the provided memory can be one contiguous buffer or a list of conti
 For the GPU, to avoid extra copy, the provided buffer must be contiguous. If you provide a list
 of separate Tensors, there will be an additional copy made internally, consuming both memory
 and bandwidth.)code", false)
-  .AddOptionalArg("dtype", R"code(Input data type.
+  .AddOptionalTypeArg("dtype", R"code(Input data type.
 
 The operator will validate that the fetched data is of the provided type.
 If the argument is omitted or ``DALIDataType.NO_TYPE`` is passed, the operator will infer
 the type based on the provided data.
 
-This argument will be required starting from DALI 2.0.)code", DALI_NO_TYPE)
+This argument will be required starting from DALI 2.0.)code")
   .AddOptionalArg<int>("ndim", R"code(Number of dimensions in the input.
 
 The dimensionality of the data provided to the operator will be verified against this value.

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -221,11 +221,11 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
         blocking_(spec.GetArgument<bool>("blocking")),
         no_copy_(spec.GetArgument<bool>("no_copy")),
         device_id_(spec.GetArgument<int>("device_id")),
-        dtype_(spec.GetArgument<DALIDataType>("dtype")),
         previous_dtype_(DALIDataType::DALI_NO_TYPE),
         ndim_(-1),
         layout_(),
         sync_worker_(device_id_, false, "ExternalSource syncworker") {
+    spec.TryGetArgument(dtype_, "dtype");
     if (spec.TryGetArgument(ndim_, "ndim")) {
       DALI_ENFORCE(ndim_ >= 0, make_string("Incorrect number of dimensions (", ndim_,
                    "). Use positive values for tensors or 0 for scalars."));
@@ -612,8 +612,8 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
   bool blocking_ = true;
   bool no_copy_ = false;
   int device_id_;
-  DALIDataType dtype_;
-  DALIDataType previous_dtype_;
+  DALIDataType dtype_ = DALI_NO_TYPE;
+  DALIDataType previous_dtype_ = DALI_NO_TYPE;
   int ndim_;
   TensorLayout layout_;
 

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -514,7 +514,7 @@ graph even if its outputs are not used.)code", false);
                  bool enable_tensor_input = false,
                  bool support_per_frame_input = false) {
     static_assert(!std::is_same<T, DALIDataType>::value,
-      R"(`Use `AddOptionalTypeArg` instead. AddOptionalArg` with a default value should not be
+      R"(Use `AddOptionalTypeArg` instead. `AddOptionalArg` with a default value should not be
 used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc, nullptr)`)");
     CheckArgument(s);
     auto to_store = Value::construct(default_value);

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -368,6 +368,15 @@ graph even if its outputs are not used.)code", false);
     return *this;
   }
 
+
+  /**
+   * @brief Adds a required argument of type DALIDataType
+   */
+  DLL_PUBLIC inline OpSchema& AddTypeArg(const std::string &s,
+                                         const std::string &doc) {
+    return AddArg(s, doc, DALI_DATA_TYPE);
+  }
+
   /**
    * @brief Sets input layout constraints and default for given input.
    *
@@ -504,6 +513,9 @@ graph even if its outputs are not used.)code", false);
                  T default_value,
                  bool enable_tensor_input = false,
                  bool support_per_frame_input = false) {
+    static_assert(!std::is_same<T, DALIDataType>::value,
+      R"(`Use `AddOptionalTypeArg` instead. AddOptionalArg` with a default value should not be
+used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc, nullptr)`)");
     CheckArgument(s);
     auto to_store = Value::construct(default_value);
     optional_arguments_[s] = {doc, type2id<T>::value, to_store.get()};
@@ -512,6 +524,29 @@ graph even if its outputs are not used.)code", false);
       tensor_arguments_[s] = {support_per_frame_input};
     }
     return *this;
+  }
+
+
+
+  /**
+   * @brief Adds an optional argument of type DALIDataType with a default value
+   */
+  DLL_PUBLIC inline OpSchema &AddOptionalTypeArg(const std::string &s,
+                                                const std::string &doc,
+                                                DALIDataType default_value) {
+    CheckArgument(s);
+    auto to_store = Value::construct(default_value);
+    optional_arguments_[s] = {doc, DALI_DATA_TYPE, to_store.get()};
+    optional_arguments_unq_.push_back(std::move(to_store));
+    return *this;
+  }
+
+  /**
+   * @brief Adds an optional argument of type DALIDataType without a default value
+   */
+  DLL_PUBLIC inline OpSchema &AddOptionalTypeArg(const std::string &s,
+                                                 const std::string &doc) {
+    return AddOptionalArg<DALIDataType>(s, doc, nullptr);
   }
 
   DLL_PUBLIC inline OpSchema &AddOptionalArg(const std::string &s,

--- a/dali/test/python/test_operator_color_twist.py
+++ b/dali/test/python/test_operator_color_twist.py
@@ -36,7 +36,7 @@ def dali_type_to_np(dtype):
 
 
 @pipeline_def()
-def ColorTwistPipeline(data_iterator, is_input_float, out_dtype):
+def ColorTwistPipeline(data_iterator, is_input_float, inp_dtype, out_dtype):
     imgs = fn.external_source(source=data_iterator)
     o_dtype = dali_type_to_np(out_dtype)
     # converting float inputs to integer outs leads to binary images as input is in -1 to 1 range in such case
@@ -46,8 +46,13 @@ def ColorTwistPipeline(data_iterator, is_input_float, out_dtype):
     S = fn.random.uniform(range=[0, 2])
     brightness = fn.random.uniform(range=[0, 2])
     contrast = fn.random.uniform(range=[0, 2])
-    out_cpu = fn.color_twist(imgs, hue=H, saturation=S, brightness=brightness, contrast=contrast, dtype=out_dtype)
-    out_gpu = fn.color_twist(imgs.gpu(), hue=H, saturation=S, brightness=brightness, contrast=contrast, dtype=out_dtype)
+
+    out_dtype_arg = out_dtype if out_dtype != inp_dtype else None
+    out_cpu, out_gpu = (fn.color_twist(input,
+                                       hue=H, saturation=S,
+                                       brightness=brightness, contrast=contrast,
+                                       dtype=out_dtype_arg)
+                        for input in (imgs, imgs.gpu()))
     return imgs, out_cpu, out_gpu, H, S, brightness, contrast
 
 
@@ -112,10 +117,16 @@ def check_ref(inp_dtype, out_dtype, has_3_dims):
     batch_size = 32
     n_iters = 8
     shape = (128, 32, 3) if not has_3_dims else (random.randint(2, 5), 128, 32, 3)
-    in_dtype = dali_type_to_np(inp_dtype)
-    ri1 = RandomDataIterator(batch_size, shape=shape, dtype=in_dtype)
-    pipe = ColorTwistPipeline(seed=2139, batch_size=batch_size, num_threads=4, device_id=0, data_iterator=ri1,
-                              is_input_float=np.issubdtype(in_dtype, np.floating), out_dtype=out_dtype)
+    inp_dtype = dali_type_to_np(inp_dtype)
+    ri1 = RandomDataIterator(batch_size, shape=shape, dtype=inp_dtype)
+    pipe = ColorTwistPipeline(seed=2139,
+                              batch_size=batch_size,
+                              num_threads=4,
+                              device_id=0,
+                              data_iterator=ri1,
+                              is_input_float=np.issubdtype(inp_dtype, np.floating),
+                              inp_dtype=inp_dtype,
+                              out_dtype=out_dtype)
     pipe.build()
     for _ in range(n_iters):
         inp, out_cpu, out_gpu, H, S, B, C = pipe.run()

--- a/dali/test/python/test_operator_gaussian_blur.py
+++ b/dali/test/python/test_operator_gaussian_blur.py
@@ -186,6 +186,7 @@ def check_generic_gaussian_blur(
         batch_size, min_shape=min_shape, max_shape=shape, dtype=in_dtype)
     # Extract the numpy type from DALI, we can have float32 or the same as input
     if out_dtype == types.NO_TYPE:
+        out_dtype = None
         result_type = in_dtype
     elif dali_type(in_dtype) == out_dtype:
         result_type = in_dtype

--- a/dali/test/python/test_operator_laplacian.py
+++ b/dali/test/python/test_operator_laplacian.py
@@ -139,6 +139,8 @@ def laplacian_pipe(device, window_size, in_type, out_type, normalize, grayscale)
         imgs = fn.cast(imgs, dtype=in_type)
     if device == "gpu":
         imgs = imgs.gpu()
+    if out_type == in_type:
+        out_type = None
     edges = fn.laplacian(imgs, window_size=window_size, smoothing_size=smoothing_size,
                          normalized_kernel=normalize, dtype=out_type, device=device)
     return edges, imgs

--- a/dali/test/python/test_operator_warp.py
+++ b/dali/test/python/test_operator_warp.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import nose_utils
 from nvidia.dali.pipeline import Pipeline
 import nvidia.dali.ops as ops
 import nvidia.dali.fn as fn
@@ -260,7 +261,7 @@ def test_gpu_vs_cpu():
                                             inv_map=inv_map)
                 gpu_pipeline.build()
 
-                compare(cpu_pipeline, gpu_pipeline, 1)
+                compare(cpu_pipeline, gpu_pipeline, 1.0001)
 
 
 def _test_extremely_large_data(device):

--- a/dali/test/python/test_pipeline_segmentation.py
+++ b/dali/test/python/test_pipeline_segmentation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ def check_bbox_random_crop_adjust_polygons(file_root, annotations_file, batch_si
         out_vertices = fn.coord_transform(sel_vertices, MT=MT)
 
         # Converting to absolute coordinates (demo purposes)
-        image_shape = fn.peek_image_shape(inputs, type=types.FLOAT)
+        image_shape = fn.peek_image_shape(inputs, dtype=types.FLOAT)
         h = fn.slice(image_shape, 0, 1, axes=[0])
         w = fn.slice(image_shape, 1, 1, axes=[0])
 

--- a/docs/examples/use_cases/tensorflow/efficientdet/pipeline/dali/ops_util.py
+++ b/docs/examples/use_cases/tensorflow/efficientdet/pipeline/dali/ops_util.py
@@ -88,7 +88,7 @@ def input_coco(
         output_type=dali.types.RGB,
     )
 
-    shape = dali.fn.peek_image_shape(encoded, type=dali.types.FLOAT)
+    shape = dali.fn.peek_image_shape(encoded, dtype=dali.types.FLOAT)
     heights = shape[0]
     widths = shape[1]
 


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

## Description:
Bug:
removing a default value from `AddOptionalArg("name", "doc", value, TYPE_ID)` resulted in adding an argument of type DALIDataType and the default value TYPE_ID. This happened in "fill_value" argument to WarpAttr. This PR fixes that.

Refactoring:
- The type arguments added with AddOptionalArg are now added with AddOptionalTypeArg.
- Mandatory "dtype" arguments are added with AddTypeArg
- The problemantic overload was blocked with a static assertion and replaced with a dedicated AddOptionalTypeArg (and AddTypeArg) which is always of type DALIDataType.
- The default value DALI_NO_TYPE was removed from existing operators - now it's simply "not present".
- The GetArgument was replaced with TryGetArgument in places where the default value was removed and relied upon


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Existing tests: all over the place
New tests: test_operator_warp - added floating point fill value

- [X] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
