### PR TITLE
Fix nan check and unused external source arguments in debug mode

### DIFF
--- a/dali/python/nvidia/dali/_debug_mode.py
+++ b/dali/python/nvidia/dali/_debug_mode.py
@@ -214,7 +214,7 @@ class _ExternalSourceDebug:
 
         def to_data_node_debug(data):
             data = _transform_data_to_tensorlist(data, self._batch_size, layout, self._device_id)
-            
+
             if self._device == 'gpu' and isinstance(data, _tensors.TensorListCPU):
                 data = data._as_gpu()
             elif self._device == 'cpu' and isinstance(data, _tensors.TensorListGPU):
@@ -415,7 +415,8 @@ class _OperatorManager:
             if not isinstance(input, (_tensors.TensorListCPU, _tensors.TensorListGPU)) and \
                     not (isinstance(input, list) and
                          all([isinstance(elem, (_tensors.TensorListCPU, _tensors.TensorListGPU)) for elem in input])):
-                inputs[i] = _transform_data_to_tensorlist(input, len(input), device_id=self._device_id)
+                inputs[i] = _transform_data_to_tensorlist(
+                    input, len(input), device_id=self._device_id)
 
         return self.op_helper._build_input_sets(inputs)
 
@@ -496,7 +497,7 @@ class _PipelineDebug(_pipeline.Pipeline):
         self._operators = {}
         self._operators_built = False
         self._cur_iter_batch_info = _IterBatchInfo(-1, None)  # Used for variable batch sizes.
-        
+
         device_id = self._device_id if self._device_id is not None else _types.CPU_ONLY_DEVICE_ID
         self._pipe = _b.PipelineDebug(
             self._max_batch_size, self._num_threads, device_id, self._set_affinity)
@@ -598,7 +599,8 @@ class _PipelineDebug(_pipeline.Pipeline):
         cur_frame = inspect.currentframe().f_back.f_back
         key = inspect.getframeinfo(cur_frame)[:3] + (self._cur_operator_id,)
         if not self._operators_built:
-            es = _ExternalSourceDebug(batch_size=self._max_batch_size, device_id=self._device_id, name=name, **kwargs)
+            es = _ExternalSourceDebug(batch_size=self._max_batch_size,
+                                      device_id=self._device_id, name=name, **kwargs)
 
             # feed_input all data collected after build and before run
             for (data, fi_kwargs) in self._feed_input_data.pop(name, []):

--- a/dali/python/nvidia/dali/_utils/eager_utils.py
+++ b/dali/python/nvidia/dali/_utils/eager_utils.py
@@ -109,7 +109,8 @@ class _Classification:
                 return is_batch_list, device_list[0], data_list
             if not any(is_batch_list):
                 # Converting to TensorList.
-                return True, device_list[0], _transform_data_to_tensorlist(data_list, len(data_list))
+                return True, device_list[0], _transform_data_to_tensorlist(
+                    data_list, len(data_list))
             else:
                 raise RuntimeError(f'{type_name} has inconsistent batch classification.')
 

--- a/dali/python/nvidia/dali/_utils/eager_utils.py
+++ b/dali/python/nvidia/dali/_utils/eager_utils.py
@@ -17,7 +17,7 @@ from nvidia.dali import types as _types
 from nvidia.dali.external_source import _prep_data_for_feed_input
 
 
-def _transform_data_to_tensorlist(data, batch_size, layout=None, device_id=None):
+def _transform_data_to_tensorlist(data, batch_size, layout=None, device_id=-1):
     data = _prep_data_for_feed_input(data, batch_size, layout, device_id)
 
     if isinstance(data, list):

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -799,8 +799,9 @@ provided memory is copied to the internal buffer.
     # Wrapper around external_source to switch between standard and debug mode.
     current_pipeline = _PipelineDebug.current()
     if getattr(current_pipeline, '_debug_on', False):
-        return current_pipeline._external_source(source=source, num_outputs=num_outputs, cycle=cycle, name=name,
-                                                 layout=layout, batch=batch, **kwargs)
+        return current_pipeline._external_source(
+            source=source, num_outputs=num_outputs, cycle=cycle, name=name, device=device,
+            layout=layout, batch=batch, **kwargs)
     else:
         return _external_source(source, num_outputs, cycle=cycle, name=name, device=device, layout=layout, dtype=dtype,
                                 ndim=ndim, cuda_stream=cuda_stream, use_copy_kernel=use_copy_kernel, batch=batch, **kwargs)

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -56,7 +56,7 @@ def _check_data_batch(data, batch_size, layout):
             raise RuntimeError("The layout '{}' cannot describe {}-dimensional data".format(layout, dim))
 
 
-def _prep_data_for_feed_input(data, batch_size, layout, device_id=-1):
+def _prep_data_for_feed_input(data, batch_size, layout, device_id=None):
     def to_numpy(x):
         if _types._is_mxnet_array(x):
             return x.asnumpy()

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -56,7 +56,7 @@ def _check_data_batch(data, batch_size, layout):
             raise RuntimeError("The layout '{}' cannot describe {}-dimensional data".format(layout, dim))
 
 
-def _prep_data_for_feed_input(data, batch_size, layout, device_id=None):
+def _prep_data_for_feed_input(data, batch_size, layout, device_id=-1):
     def to_numpy(x):
         if _types._is_mxnet_array(x):
             return x.asnumpy()

--- a/dali/test/python/test_pipeline_debug.py
+++ b/dali/test/python/test_pipeline_debug.py
@@ -591,3 +591,41 @@ def test_variable_batch_size():
     pipe = incorrect_variable_batch_size_pipeline()
     pipe.build()
     pipe.run()
+
+
+@pipeline_def(batch_size=8, num_threads=3, device_id=0, seed=47, debug=True)
+def unused_arg_es_pipeline(kwargs):
+    return fn.external_source(np.zeros((2, 8, 1)), **kwargs)
+
+
+def _test_es_unused_args(kwargs):
+    pipe = unused_arg_es_pipeline(kwargs)
+    pipe.build()
+    pipe.run()
+
+
+def test_external_source_unused_args():
+    kwargs_list = [{'parallel': True}, {'foo': 123, 'bar': 'BAR'}]
+    for kwargs in kwargs_list:
+        yield _test_es_unused_args, kwargs
+
+
+@pipeline_def(batch_size=8, num_threads=3, device_id=0, seed=47, debug=True)
+def nan_check_pipeline(source):
+    return fn.constant(fdata=next(source))
+
+
+def _test_nan_check(values):
+    pipe = nan_check_pipeline(iter(values))
+    pipe.build()
+    for _ in range(2):
+        pipe.run()
+
+
+def test_nan_check():
+    err_msg = "Argument 'fdata' for operator 'constant' unexpectedly changed value from*"
+    for values in [[np.nan, 1], [1, np.nan]]:
+        yield raises(RuntimeError, glob=err_msg)(_test_nan_check), values
+
+    for values in [[1, 1], [np.nan, np.nan]]:
+        yield _test_nan_check, values

--- a/dali/test/python/test_pipeline_debug.py
+++ b/dali/test/python/test_pipeline_debug.py
@@ -14,10 +14,10 @@
 
 import numpy as np
 import os
-import torch
 from nose.plugins.attrib import attr
 
 import nvidia.dali.fn as fn
+import nvidia.dali.tensors as tensors
 import nvidia.dali.types as types
 from nvidia.dali.pipeline.experimental import pipeline_def
 from nose_utils import raises
@@ -625,8 +625,8 @@ def _test_es_device_change(source, device):
 
 def test_es_device_change():
     cpu_data = np.zeros((8, 1))
-    gpu_data = torch.zeros((8, 1), device='cuda')
-    for data, device in zip([cpu_data, gpu_data], ['gpu', 'cpu']):
+    gpu_data = tensors.TensorListCPU(cpu_data)._as_gpu()
+    for data, device in zip([gpu_data], ['cpu']):
         yield _test_es_device_change, data, device
 
 


### PR DESCRIPTION
Signed-off-by: ksztenderski <ksztenderski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
Fixes value check in debug mode when `data == nan`. 
Fixes passing of arguments to external source in debug mode. Now it accepts arguments with any name, including unsupported by the standard version.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
`_PipelineDebug`, `_ExternalSourceDebug`


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
Keyword arguments specification for debug mode `external_source`.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
