### PR TITLE
Fix and simplify moving mean squares CPU kernel.

### DIFF
--- a/dali/kernels/signal/moving_mean_square.cc
+++ b/dali/kernels/signal/moving_mean_square.cc
@@ -59,21 +59,19 @@ void CalcMovingMeanSquare(span<float> out, span<const T> in, int length, float m
 
   assert(out.size() == in.size());
   assert(out.size() == length);
-  for (int64_t out_pos = 0; out_pos < length; out_pos++) {
+  int64_t win_begin = -window_size + 1;
+  for (int64_t out_pos = 0; out_pos < length; ) {
     acc_t<T> sumsq = 0;
-    int64_t win_begin = out_pos - window_size + 1;
-    for (int64_t pos = std::max<int64_t>(win_begin, 0); pos <= out_pos; pos++) {
+    assert(win_begin == out_pos - window_size + 1);
+    for (int64_t pos = std::max<int64_t>(win_begin, 0); pos < out_pos; pos++) {
       sumsq += Square(in[pos]);
     }
-    out[out_pos] = sumsq * mean_factor;
     int64_t interval_end = std::min<int64_t>(length, out_pos + reset_interval);
-    for ( ; out_pos < interval_end; ) {
-      out_pos++;
-      win_begin++;
+    for ( ; out_pos < interval_end; out_pos++, win_begin++) {
       sumsq += Square(in[out_pos]);
-      if (win_begin > 0)
-        sumsq -= Square(in[win_begin - 1]);
       out[out_pos] = sumsq * mean_factor;
+      if (win_begin >= 0)
+        sumsq -= Square(in[win_begin]);
     }
   }
 }

--- a/dali/kernels/signal/moving_mean_square_test.cc
+++ b/dali/kernels/signal/moving_mean_square_test.cc
@@ -96,6 +96,7 @@ TYPED_TEST(MovingMeanSquareCpuTest, RunTest) {
   auto reqs = kernel.Setup(ctx, in, {this->window_size_});
 
   auto out_shape = reqs.output_shapes[0][0];
+  EXPECT_EQ(out_shape[0], this->shape_[0]);
   std::vector<float> output;
   output.resize(out_shape.num_elements());
   OutTensorCPU<float, 1> out(output.data(), out_shape.template to_static<1>());


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Fixes out-of-bounds write access one element past the output of Moving Mean Squares kernel.
Along the way, the loops were simplified.

## Additional information:

### Affected modules and functionalities:
Moving mean squares.


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
moving_mean_squares_test.cc:MovingMeanSquareCpuTest

- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
