### PR TITLE
Add abstract InputStream. Refactor existing FileStreams to in to use it.

### DIFF
--- a/dali/core/stream_test.cc
+++ b/dali/core/stream_test.cc
@@ -1,0 +1,85 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "dali/core/stream.h"
+
+namespace dali {
+
+TEST(MemInputStreamTest, ReadAndSeek) {
+  char mem[] = "test123";
+
+  MemInputStream mis(mem, 7);
+  char out[8] = {0};
+  EXPECT_EQ(mis.Read(out, 8), 7);
+  EXPECT_STREQ(out, "test123");
+  std::memset(out, 0, sizeof(out));
+  mis.SeekRead(1, SEEK_SET);
+  EXPECT_EQ(mis.TellRead(), 1);
+  mis.SeekRead(1, SEEK_CUR);
+  EXPECT_EQ(mis.TellRead(), 2);
+  EXPECT_EQ(mis.Read(out, 3), 3);
+  EXPECT_STREQ(out, "st1");
+
+  std::memset(out, 0, sizeof(out));
+  mis.SeekRead(-2, SEEK_END);
+  EXPECT_EQ(mis.TellRead(), 5);
+  EXPECT_EQ(mis.Read(out, 3), 2);
+  EXPECT_STREQ(out, "23");
+}
+
+TEST(MemInputStreamTest, ReadBytes) {
+  char mem[] = "test123";
+
+  MemInputStream mis(mem, 7);
+  char out[8] = {0};
+  mis.ReadAll(out, 5);
+  EXPECT_STREQ(out, "test1");
+}
+
+
+TEST(MemInputStreamTest, Errors) {
+  char mem[] = "test123";
+
+  MemInputStream mis(mem, 7);
+  char out[8] = {0};
+  mis.ReadAll(out, 5);
+  EXPECT_THROW(mis.ReadBytes(out, 8), EndOfStream);
+  mis.SeekRead(0);
+  EXPECT_THROW(mis.SeekRead(-1, SEEK_SET), std::out_of_range);
+}
+
+TEST(MemInputStreamTest, ReadTyped) {
+  char mem[32];
+  int ofs = 0;
+  mem[ofs++] = 'x';
+  ofs += sizeof(float);
+  *reinterpret_cast<int *>(mem + ofs) = 0x12345678;
+  ofs += sizeof(int);
+  *reinterpret_cast<uint16_t *>(mem + ofs) = 0x600Du;
+  ofs += sizeof(uint16_t);
+  *reinterpret_cast<uint16_t *>(mem + ofs) = 0xF00Du;
+  ofs += sizeof(uint16_t);
+
+  MemInputStream mis(mem, ofs);
+  EXPECT_EQ((mis.ReadOne<char>()), 'x');
+  mis.Skip<float>();
+  EXPECT_EQ((mis.ReadOne<int>()), 0x12345678);
+  uint16_t s[2];
+  mis.ReadAll(s, 2);
+  EXPECT_EQ(s[0], 0x600Du);
+  EXPECT_EQ(s[1], 0xF00Du);
+}
+
+}  // namespace dali

--- a/dali/operators/reader/loader/indexed_file_loader.h
+++ b/dali/operators/reader/loader/indexed_file_loader.h
@@ -66,7 +66,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
     }
 
     if (should_seek_ || next_seek_pos_ != seek_pos) {
-      current_file_->Seek(seek_pos);
+      current_file_->SeekRead(seek_pos);
       should_seek_ = false;
     }
     next_seek_pos_ = seek_pos + size;
@@ -146,7 +146,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
       current_file_ = FileStream::Open(uris_[file_index], read_ahead_, !copy_read_data_);
       current_file_index_ = file_index;
     }
-    current_file_->Seek(seek_pos);
+    current_file_->SeekRead(seek_pos);
   }
 
   std::vector<std::string> uris_;

--- a/dali/operators/reader/loader/numpy_loader.cc
+++ b/dali/operators/reader/loader/numpy_loader.cc
@@ -183,14 +183,14 @@ void ParseHeader(FileStream *file, NumpyHeaderMeta& parsed_header) {
   // specification: https://numpy.org/neps/nep-0001-npy-format.html
   // while this allocation could be sizable, it is performed on the host.
   token.resize(header_len+1);
-  file->Seek(offset);
+  file->SeekRead(offset);
   nread = file->Read(token.data(), header_len);
   DALI_ENFORCE(nread == header_len, "Can not read header.");
   token[header_len] = '\0';
   header = std::string(reinterpret_cast<const char*>(token.data()));
   DALI_ENFORCE(header.find('{') != std::string::npos, "Header is corrupted.");
   offset += header_len;
-  file->Seek(offset);  // michalz: Why isn't it done when actually reading the payload?
+  file->SeekRead(offset);  // michalz: Why isn't it done when actually reading the payload?
 
   ParseHeaderMetadata(parsed_header, header);
   parsed_header.data_offset = offset;
@@ -248,7 +248,7 @@ void NumpyLoader::ReadSample(NumpyFileWrapper& target) {
   auto ret = header_cache_.GetFromCache(filename, header);
   try {
     if (ret) {
-      current_file->Seek(header.data_offset);
+      current_file->SeekRead(header.data_offset);
     } else {
       detail::ParseHeader(current_file.get(), header);
       header_cache_.UpdateCache(filename, header);

--- a/dali/operators/reader/loader/numpy_loader_gpu.cc
+++ b/dali/operators/reader/loader/numpy_loader_gpu.cc
@@ -35,7 +35,7 @@ void NumpyFileWrapperGPU::ReadHeader(detail::NumpyHeaderCache &cache) {
   bool ret = cache.GetFromCache(filename, header);
   try {
     if (ret) {
-      file_stream->Seek(header.data_offset);
+      file_stream->SeekRead(header.data_offset);
     } else {
       detail::ParseHeader(file_stream.get(), header);
       cache.UpdateCache(filename, header);

--- a/dali/operators/reader/loader/recordio_loader.h
+++ b/dali/operators/reader/loader/recordio_loader.h
@@ -104,7 +104,7 @@ class RecordIOLoader : public IndexedFileLoader {
     }
 
     if (should_seek_ || next_seek_pos_ != seek_pos) {
-      current_file_->Seek(seek_pos);
+      current_file_->SeekRead(seek_pos);
       should_seek_ = false;
     }
 

--- a/dali/operators/reader/loader/webdataset/tar_utils.h
+++ b/dali/operators/reader/loader/webdataset/tar_utils.h
@@ -105,7 +105,7 @@ class DLL_PUBLIC TarArchive {
    * @param count the maximum number of bytes to read
    * @returns the number of bytes actually read to the buffer
    */
-  size_t Read(uint8_t* buffer, size_t count);
+  size_t Read(void *buffer, size_t count);
   /**
    * @brief Returns whether the file cursor is at the end of file.
    */

--- a/dali/operators/reader/loader/webdataset_loader.cc
+++ b/dali/operators/reader/loader/webdataset_loader.cc
@@ -136,7 +136,7 @@ std::tuple<std::string, std::string> split_name(const std::string& filepath) {
 inline void ParseTarFile(std::vector<SampleDesc>& samples_container,
                          std::vector<ComponentDesc>& components_container,
                          std::unique_ptr<FileStream>& tar_file) {
-  int64_t initial_file_pos = tar_file->Tell();
+  int64_t initial_file_pos = tar_file->TellRead();
   TarArchive tar_archive(std::move(tar_file));
 
   std::string last_filename;
@@ -270,7 +270,7 @@ void WebdatasetLoader::ReadSample(vector<Tensor<CPUBackend>>& sample) {
         IndexFileErrMsg(index_paths_[current_sample.wds_shard_index], current_sample.line_number,
                         "offset is outside of the archive file"));
 
-    current_wds_shard->Seek(component.offset);
+    current_wds_shard->SeekRead(component.offset);
 
     // Skipping cached samples
     const std::string sample_key = make_string_delim(':', paths_[current_sample.wds_shard_index],

--- a/dali/util/cufile.h
+++ b/dali/util/cufile.h
@@ -47,7 +47,7 @@ class DLL_PUBLIC CUFileStream : public FileStream {
    * The API is the effect how cufile works - it need to get the base address of the registered
    * buffer and the offset where it should put the data.
    */
-  virtual size_t ReadGPU(uint8_t* buffer, size_t n_bytes, ptrdiff_t buffer_offset = 0) = 0;
+  virtual size_t ReadGPU(void *buffer, size_t n_bytes, ptrdiff_t buffer_offset = 0) = 0;
 
   /**
    * @brief Reads `n_bytes` to the buffer at position `offset` from a given position in the file.
@@ -55,7 +55,7 @@ class DLL_PUBLIC CUFileStream : public FileStream {
    * The file_offset is absolute - the function neither depends on or affects the file pointer.
    * This function is thread-safe.
    */
-  virtual size_t ReadAtGPU(uint8_t* buffer, size_t n_bytes,
+  virtual size_t ReadAtGPU(void *buffer, size_t n_bytes,
                            ptrdiff_t buffer_offset, int64 file_offset) = 0;
 
  protected:

--- a/dali/util/file.h
+++ b/dali/util/file.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,10 +21,11 @@
 
 #include "dali/core/api_helper.h"
 #include "dali/core/common.h"
+#include "dali/core/stream.h"
 
 namespace dali {
 
-class DLL_PUBLIC FileStream {
+class DLL_PUBLIC FileStream : public InputStream {
  public:
   class MappingReserver {
    public:
@@ -71,11 +72,7 @@ class DLL_PUBLIC FileStream {
   static std::unique_ptr<FileStream> Open(const std::string &uri, bool read_ahead, bool use_mmap);
 
   virtual void Close() = 0;
-  virtual size_t Read(uint8_t *buffer, size_t n_bytes) = 0;
   virtual shared_ptr<void> Get(size_t n_bytes) = 0;
-  virtual void Seek(int64 pos) = 0;
-  virtual int64 Tell() const = 0;
-  virtual size_t Size() const = 0;
   virtual ~FileStream() {}
 
  protected:

--- a/dali/util/mmaped_file.cc
+++ b/dali/util/mmaped_file.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -170,12 +170,16 @@ inline uint8_t* ReadAheadHelper(std::shared_ptr<void> &p, size_t &pos,
   return tmp;
 }
 
-void MmapedFileStream::Seek(int64 pos) {
+void MmapedFileStream::SeekRead(ptrdiff_t pos, int whence) {
+  if (whence == SEEK_CUR)
+    pos += pos_;
+  else if (whence == SEEK_END)
+    pos += length_;
   DALI_ENFORCE(pos >= 0 && pos <= (int64)length_, "Invalid seek");
   pos_ = pos;
 }
 
-int64 MmapedFileStream::Tell() const {
+ptrdiff_t MmapedFileStream::TellRead() const {
   return pos_;
 }
 
@@ -200,7 +204,7 @@ shared_ptr<void> MmapedFileStream::Get(size_t n_bytes) {
   return p;
 }
 
-size_t MmapedFileStream::Read(uint8_t * buffer, size_t n_bytes) {
+size_t MmapedFileStream::Read(void *buffer, size_t n_bytes) {
   n_bytes = std::min(n_bytes, length_ - pos_);
   memcpy(buffer, ReadAheadHelper(p_, pos_, n_bytes, !read_ahead_whole_file_), n_bytes);
   pos_ += n_bytes;

--- a/dali/util/mmaped_file.h
+++ b/dali/util/mmaped_file.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,9 +31,9 @@ class MmapedFileStream : public FileStream {
   shared_ptr<void> Get(size_t n_bytes) override;
   static bool ReserveFileMappings(unsigned int num);
   static void FreeFileMappings(unsigned int num);
-  size_t Read(uint8_t * buffer, size_t n_bytes) override;
-  void Seek(int64 pos) override;
-  int64 Tell() const override;
+  size_t Read(void *buffer, size_t n_bytes) override;
+  void SeekRead(ptrdiff_t pos, int whence = SEEK_SET) override;
+  int64 TellRead() const override;
   size_t Size() const override;
 
   ~MmapedFileStream() override {

--- a/dali/util/std_cufile.h
+++ b/dali/util/std_cufile.h
@@ -33,13 +33,12 @@ class StdCUFileStream : public CUFileStream {
   explicit StdCUFileStream(const std::string& path);
   void Close() override;
   shared_ptr<void> Get(size_t n_bytes) override;
-  size_t ReadAtGPU(uint8_t* gpu_buffer, size_t n_bytes,
+  size_t ReadAtGPU(void *gpu_buffer, size_t n_bytes,
                    ptrdiff_t buffer_offset, int64 file_offset) override;
-  size_t ReadGPU(uint8_t * buffer, size_t n_bytes, ptrdiff_t offset = 0) override;
-  size_t Read(uint8_t* cpu_buffer, size_t n_bytes) override;
-  size_t Pos() const;
-  void Seek(int64 pos) override;
-  int64 Tell() const override;
+  size_t ReadGPU(void *buffer, size_t n_bytes, ptrdiff_t offset = 0) override;
+  size_t Read(void *cpu_buffer, size_t n_bytes) override;
+  void SeekRead(ptrdiff_t pos, int whence = SEEK_SET) override;
+  ptrdiff_t TellRead() const override;
   void HandleIOError(int64 ret) const;
   size_t Size() const override;
 

--- a/dali/util/std_file.cc
+++ b/dali/util/std_file.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,16 +36,16 @@ void StdFileStream::Close() {
   }
 }
 
-void StdFileStream::Seek(int64 pos) {
-  DALI_ENFORCE(!std::fseek(fp_, pos, SEEK_SET),
-               "Seek operation did not succeed: " + std::string(std::strerror(errno)));
+void StdFileStream::SeekRead(ptrdiff_t pos, int whence) {
+  DALI_ENFORCE(!std::fseek(fp_, pos, whence), make_string(
+               "Seek operation failed: ", std::strerror(errno)));
 }
 
-int64 StdFileStream::Tell() const {
+ptrdiff_t StdFileStream::TellRead() const {
   return std::ftell(fp_);
 }
 
-size_t StdFileStream::Read(uint8_t* buffer, size_t n_bytes) {
+size_t StdFileStream::Read(void *buffer, size_t n_bytes) {
   size_t n_read = std::fread(buffer, 1, n_bytes, fp_);
   return n_read;
 }

--- a/dali/util/std_file.h
+++ b/dali/util/std_file.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,9 +29,9 @@ class StdFileStream : public FileStream {
   explicit StdFileStream(const std::string& path);
   void Close() override;
   shared_ptr<void>  Get(size_t n_bytes) override;
-  size_t Read(uint8_t * buffer, size_t n_bytes) override;
-  void Seek(int64 pos) override;
-  int64 Tell() const override;
+  size_t Read(void * buffer, size_t n_bytes) override;
+  void SeekRead(ptrdiff_t pos, int whence = SEEK_SET) override;
+  ptrdiff_t TellRead() const override;
   size_t Size() const override;
 
   ~StdFileStream() override {

--- a/include/dali/core/stream.h
+++ b/include/dali/core/stream.h
@@ -146,7 +146,7 @@ class InputStream {
   virtual size_t Size() const = 0;
 
   /**
-   * @brief Returns the size a signed integer.
+   * @brief Returns the size as a signed integer.
    */
   inline ssize_t SSize() const {
     return Size();

--- a/include/dali/core/stream.h
+++ b/include/dali/core/stream.h
@@ -1,0 +1,204 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_STREAM_H_
+#define DALI_CORE_STREAM_H_
+
+#include <cstdio>
+#include <cassert>
+#include <cstring>
+#include <stdexcept>
+#include <type_traits>
+#include "dali/core/api_helper.h"
+
+namespace dali {
+
+using ssize_t = std::make_signed_t<size_t>;
+
+/**
+ * An exception thrown when the stream ended before all requested data could be read.
+ */
+class DLL_PUBLIC EndOfStream : public std::out_of_range {
+ public:
+  explicit EndOfStream(const char *message = "End of stream") : std::out_of_range(message) {}
+};
+
+/**
+ * @brief An abstract file-like interface for reading data.
+ */
+class InputStream {
+ public:
+  virtual ~InputStream() = default;
+
+  /**
+   * @brief Reads all requested data from the stream; if not all of the data can be read,
+   *        an exception is thrown.
+   *
+   * @param buf   the output buffer
+   * @param bytes the number of bytes to read
+   */
+  inline void ReadBytes(void *buf, size_t bytes) {
+    char *b = static_cast<char *>(buf);
+    while (bytes) {
+      ssize_t n = Read(b, bytes);
+      if (n == 0)
+        throw EndOfStream();
+      if (n < 0)
+        throw std::runtime_error("An error occurred while reading data.");
+      b += n;
+      assert(static_cast<size_t>(n) <= bytes);
+      bytes -= n;
+    }
+  }
+
+  /**
+   * @brief Reads one object of given type from the stream
+   *
+   * @tparam T  the type of the object to read; should be trivially copyable or otherwise
+   *            safe to be overwritten with memcpy or similar.
+   */
+  template <typename T>
+  inline T ReadOne() {
+    T t;
+    ReadAll(&t, 1);
+    return t;
+  }
+
+  /**
+   * @brief Reads `count` instances of type T from the stream to the provided buffer
+   *
+   * If the function cannot read the requested number of objects, an exception is thrown
+   *
+   * @tparam T    the type of the object to read; should be trivially copyable or otherwise
+   *              safe to be overwritten with memcpy or similar.
+   * @param buf   the output buffer
+   * @param count the number of objects to read
+   */
+  template <typename T>
+  inline void ReadAll(T *buf, size_t count) {
+    ReadBytes(buf, sizeof(T) * count);
+  }
+
+  /**
+   * @brief Skips `count` objects in the stream
+   *
+   * Skips over the length of `count` objects of given type (by default char,
+   * because sizeof(char) == 1).
+   *
+   * NOTE: Negative skips are allowed.
+   *
+   * @tparam T type of the object to skip; defaults to `char`
+   * @param count the number of objects to skip
+   */
+  template <typename T = char>
+  void Skip(ssize_t count = 1) {
+    SeekRead(count * sizeof(T), SEEK_CUR);
+  }
+
+  /**
+   * @brief Reads data from the stream and advances the read pointer; partial reads are allowed.
+   *
+   * A valid implementation of this function reads up to `bytes` bytes from the stream and
+   * stores them in `buf`. If the function cannot read all of the requested bytes due to
+   * end-of-file, it shall read all it can and return the number of bytes actually read.
+   * When reading from a regular file and the file pointer is already at the end, the function
+   * shall return 0.
+   *
+   * This function does not throw EndOfStream.
+   *
+   * @param buf       the output buffer
+   * @param bytes     the number of bytes to read
+   * @return size _t  the number of bytes actually read or
+   *                  0 in case of end-of-stream condition
+   */
+  virtual size_t Read(void *buf, size_t bytes) = 0;
+
+  /**
+   * @brief Moves the read pointer in the stream.
+   *
+   * If the new pointer would be out of range, the function may either clamp it to a valid range
+   * or throw an error.
+   *
+   * @param pos     the offset to move
+   * @param whence  the beginning - SEEK_SET, SEEK_CUR or SEEK_END
+   */
+  virtual void SeekRead(ptrdiff_t pos, int whence = SEEK_SET) = 0;
+
+  /**
+   * @brief Returns the current read position, in bytes from the beginnging, in the stream.
+   */
+  virtual ssize_t TellRead() const = 0;
+
+  /**
+   * @brief Returns the length, in bytes, of the stream.
+   */
+  virtual size_t Size() const = 0;
+
+  /**
+   * @brief Returns the size a signed integer.
+   */
+  inline ssize_t SSize() const {
+    return Size();
+  }
+};
+
+
+class MemInputStream : public InputStream {
+ public:
+  MemInputStream() = default;
+  ~MemInputStream() = default;
+  MemInputStream(const void *mem, size_t bytes) {
+    start_ = static_cast<const char *>(mem);
+    size_ = bytes;
+  }
+
+  size_t Read(void *buf, size_t bytes) override {
+    ptrdiff_t left = size_ - pos_;
+    if (left < static_cast<ptrdiff_t>(bytes))
+      bytes = left;
+    std::memcpy(buf, start_ + pos_, bytes);
+    pos_ += bytes;
+    return bytes;
+  }
+
+  ssize_t TellRead() const override {
+    return pos_;
+  }
+
+  void SeekRead(ssize_t offset, int whence = SEEK_SET) override {
+    if (whence == SEEK_CUR) {
+      offset += pos_;
+    } else if (whence == SEEK_END) {
+      offset += size_;
+    } else {
+      assert(whence == SEEK_SET);
+    }
+    if (offset < 0 || offset > size_)
+      throw std::out_of_range("The requested position in the stream is out of range");
+    pos_ = offset;
+  }
+
+  size_t Size() const override {
+    return size_;
+  }
+
+ private:
+  const char *start_ = nullptr;
+  ptrdiff_t size_ = 0;
+  ptrdiff_t pos_ = 0;
+};
+
+}  // namespace dali
+
+#endif  // DALI_CORE_STREAM_H_


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
An abstract input stream interface is added; existing streams are refactored to inherit from it.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
