### PR TITLE
Support scalars in readers.tfrecord

### DIFF
--- a/dali/operators/reader/parser/tfrecord_parser.h
+++ b/dali/operators/reader/parser/tfrecord_parser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,17 +81,13 @@ class TFRecordParser : public Parser<Tensor<CPUBackend>> {
           break;
       }
       if (it == feature.end()) {
-        output.Resize({0});
+        output.Resize({});
         output.SetSourceInfo(data.GetSourceInfo());
         continue;
       }
       auto& encoded_feature = it->second;
       if (f.HasShape() && f.GetType() != FeatureType::string) {
-        if (f.Shape().empty()) {
-          output.Resize({1});
-        } else {
-          output.Resize(f.Shape());
-        }
+        output.Resize(f.Shape());
       }
       ssize_t number_of_elms = 0;
       switch (f.GetType()) {

--- a/dali/test/python/test_operator_readers_index.py
+++ b/dali/test/python/test_operator_readers_index.py
@@ -193,3 +193,24 @@ def test_tfrecord_reader_alias2():
         data = np.array(tensor)
         assert len(data) == 0
         assert data.dtype == np.float32
+
+def test_tfrecord_reader_scalars():
+    test_dummy_data_path = os.path.join(get_dali_extra_path(), 'db', 'coco_dummy')
+
+    @pipeline_def(batch_size=batch_size_alias_test, device_id=0, num_threads=4)
+    def tfrecord_pipe_scalars():
+        data = fn.readers.tfrecord(
+            path=os.path.join(test_dummy_data_path, 'small_coco.tfrecord'),
+            index_path=os.path.join(test_dummy_data_path, 'small_coco_index.idx'),
+            features={
+                'image/height': tfrec.FixedLenFeature((), tfrec.int64, -1),
+            })
+        return data['image/height']
+    pipe = tfrecord_pipe_scalars()
+    pipe.build()
+    out = pipe.run()
+
+    for tensor in out[0]:
+        data = np.array(tensor)
+        assert data.dtype == np.int64
+        assert data.shape == (), f"Unexpected shape. Expected scalar, got {data.shape}"

--- a/dali/test/python/test_operator_readers_index.py
+++ b/dali/test/python/test_operator_readers_index.py
@@ -125,7 +125,7 @@ def test_wrong_feature_shape():
     assert_raises(RuntimeError,
                   pipe.run,
                   glob="Error when executing CPU operator*readers*tfrecord*"
-                  "Output tensor shape is too small*1*Expected at least 4 elements")
+                  "Output tensor shape is too small*[]*Expected at least 4 elements")
 
 
 batch_size_alias_test = 64
@@ -187,11 +187,11 @@ def test_tfrecord_reader_alias2():
         assert data.dtype == np.uint8
     for tensor in out[1]:
         data = np.array(tensor)
-        assert len(data) == 0
+        assert len(data.shape) == 0
         assert data.dtype == np.int64
     for tensor in out[2]:
         data = np.array(tensor)
-        assert len(data) == 0
+        assert len(data.shape) == 0
         assert data.dtype == np.float32
 
 def test_tfrecord_reader_scalars():


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
Bug fix / Breaking change


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
Fixes https://github.com/NVIDIA/DALI/issues/4021
TFRecord treats (incorrectly) scalars as `shape=(1,)`. This PR fixes that


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
TFRecord reader


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
NA

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A
test_tfrecord_reader_scalars

<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
