### PR TITLE
Add little-endian and big-endian read functions for InputStreams

### DIFF
--- a/dali/core/byte_io_test.cc
+++ b/dali/core/byte_io_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019, 2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/core/byte_io_test.cc
+++ b/dali/core/byte_io_test.cc
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 #include "dali/core/byte_io.h"
+#include "dali/core/stream.h"
 
 namespace dali {
 
@@ -45,7 +46,7 @@ TEST(byte_io, read_value_signed_int) {
   EXPECT_EQ(-1234, ReadValueBE<int32_t>(minus_data));
   EXPECT_EQ(-1234, ReadValueLE<int32_t>(minus_data_le));
 
-  // nbytes < sizeo(T)
+  // nbytes < sizeof(T)
   EXPECT_EQ(1234, (ReadValueBE<int32_t, 3>(plus_data+1)));
   EXPECT_EQ(1234, (ReadValueLE<int32_t, 3>(plus_data_le)));
   EXPECT_EQ(-1234, (ReadValueBE<int32_t, 3>(minus_data+1)));
@@ -57,6 +58,28 @@ TEST(byte_io, read_value_float) {
   const uint8_t data_le[] = {0x00, 0x00, 0x80, 0x3f};
   EXPECT_EQ(1.0f, ReadValueBE<float>(data));
   EXPECT_EQ(1.0f, ReadValueLE<float>(data_le));
+}
+
+TEST(byte_io, read_value_unsigned_int_input_stream) {
+  const uint8_t data[] = {0x04, 0xd2, 0x1e, 0x61}; // dec 7777 = hex 0x1E61
+  const uint8_t data_le[] = {0xd2, 0x04, 0x61, 0x1e};
+  MemInputStream mis(data, sizeof(data));
+  MemInputStream mis_le(data_le, sizeof(data_le));
+  
+  EXPECT_EQ(1234, (ReadValueBE<uint32_t, 2>(mis)));
+  EXPECT_EQ(1234, (ReadValueLE<uint32_t, 2>(mis_le)));
+  EXPECT_EQ(7777, ReadValueBE<uint16_t>(mis));
+  EXPECT_EQ(7777, ReadValueLE<uint16_t>(mis_le));
+}
+
+TEST(byte_io, read_value_float_input_stream) {
+  const uint8_t data[] = {0x3f, 0x80, 0x00, 0x00};
+  const uint8_t data_le[] = {0x00, 0x00, 0x80, 0x3f};
+  MemInputStream mis(data, sizeof(data));
+  MemInputStream mis_le(data_le, sizeof(data_le));
+
+  EXPECT_EQ(1.0f, ReadValueBE<float>(mis));
+  EXPECT_EQ(1.0f, ReadValueLE<float>(mis_le));
 }
 
 }  // namespace test

--- a/dali/core/byte_io_test.cc
+++ b/dali/core/byte_io_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019, 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,11 +61,11 @@ TEST(byte_io, read_value_float) {
 }
 
 TEST(byte_io, read_value_unsigned_int_input_stream) {
-  const uint8_t data[] = {0x04, 0xd2, 0x1e, 0x61}; // dec 7777 = hex 0x1E61
+  const uint8_t data[] = {0x04, 0xd2, 0x1e, 0x61};  // dec 7777 = hex 0x1E61
   const uint8_t data_le[] = {0xd2, 0x04, 0x61, 0x1e};
   MemInputStream mis(data, sizeof(data));
   MemInputStream mis_le(data_le, sizeof(data_le));
-  
+
   EXPECT_EQ(1234, (ReadValueBE<uint32_t, 2>(mis)));
   EXPECT_EQ(1234, (ReadValueLE<uint32_t, 2>(mis_le)));
   EXPECT_EQ(7777, ReadValueBE<uint16_t>(mis));

--- a/dali/core/byte_io_test.cc
+++ b/dali/core/byte_io_test.cc
@@ -21,64 +21,64 @@ namespace dali {
 namespace test {
 
 TEST(byte_io, read_value_unsigned_int) {
-  const uint8_t data[] = {0x04, 0xd2};  // dec 1234 = hex 0x04D2
+  const uint8_t data_be[] = {0x04, 0xd2};  // dec 1234 = hex 0x04D2
   const uint8_t data_le[] = {0xd2, 0x04};
   // 1-byte, doesn't matter if it is BE/LE
-  EXPECT_EQ(4, ReadValueBE<uint8_t>(data));
-  EXPECT_EQ(4, ReadValueLE<uint8_t>(data));
-  EXPECT_EQ(1234, ReadValueBE<uint16_t>(data));
+  EXPECT_EQ(4, ReadValueBE<uint8_t>(data_be));
+  EXPECT_EQ(4, ReadValueLE<uint8_t>(data_be));
+  EXPECT_EQ(1234, ReadValueBE<uint16_t>(data_be));
   EXPECT_EQ(1234, ReadValueLE<uint16_t>(data_le));
 
   // Using nbytes < sizeof(T)
-  EXPECT_EQ(1234, (ReadValueBE<uint32_t, 2>(data)));
+  EXPECT_EQ(1234, (ReadValueBE<uint32_t, 2>(data_be)));
   EXPECT_EQ(1234, (ReadValueLE<uint32_t, 2>(data_le)));
 }
 
 TEST(byte_io, read_value_signed_int) {
-  const uint8_t plus_data[] = {0x00, 0x00, 0x04, 0xd2};
+  const uint8_t plus_data_be[] = {0x00, 0x00, 0x04, 0xd2};
   const uint8_t plus_data_le[] = {0xd2, 0x04, 0x00, 0x00};
-  EXPECT_EQ(1234, ReadValueBE<int32_t>(plus_data));
+  EXPECT_EQ(1234, ReadValueBE<int32_t>(plus_data_be));
   EXPECT_EQ(1234, ReadValueLE<int32_t>(plus_data_le));
 
   // dec -1234 = 0xfffffb2e
-  const uint8_t minus_data[] = {0xff, 0xff, 0xfb, 0x2e};
+  const uint8_t minus_data_be[] = {0xff, 0xff, 0xfb, 0x2e};
   const uint8_t minus_data_le[] = {0x2e, 0xfb, 0xff, 0xff};
-  EXPECT_EQ(-1234, ReadValueBE<int32_t>(minus_data));
+  EXPECT_EQ(-1234, ReadValueBE<int32_t>(minus_data_be));
   EXPECT_EQ(-1234, ReadValueLE<int32_t>(minus_data_le));
 
   // nbytes < sizeof(T)
-  EXPECT_EQ(1234, (ReadValueBE<int32_t, 3>(plus_data+1)));
+  EXPECT_EQ(1234, (ReadValueBE<int32_t, 3>(plus_data_be+1)));
   EXPECT_EQ(1234, (ReadValueLE<int32_t, 3>(plus_data_le)));
-  EXPECT_EQ(-1234, (ReadValueBE<int32_t, 3>(minus_data+1)));
+  EXPECT_EQ(-1234, (ReadValueBE<int32_t, 3>(minus_data_be+1)));
   EXPECT_EQ(-1234, (ReadValueLE<int32_t, 3>(minus_data_le)));
 }
 
 TEST(byte_io, read_value_float) {
-  const uint8_t data[] = {0x3f, 0x80, 0x00, 0x00};
+  const uint8_t data_be[] = {0x3f, 0x80, 0x00, 0x00};
   const uint8_t data_le[] = {0x00, 0x00, 0x80, 0x3f};
-  EXPECT_EQ(1.0f, ReadValueBE<float>(data));
+  EXPECT_EQ(1.0f, ReadValueBE<float>(data_be));
   EXPECT_EQ(1.0f, ReadValueLE<float>(data_le));
 }
 
 TEST(byte_io, read_value_unsigned_int_input_stream) {
-  const uint8_t data[] = {0x04, 0xd2, 0x1e, 0x61};  // dec 7777 = hex 0x1E61
+  const uint8_t data_be[] = {0x04, 0xd2, 0x1e, 0x61};  // dec 7777 = hex 0x1E61
   const uint8_t data_le[] = {0xd2, 0x04, 0x61, 0x1e};
-  MemInputStream mis(data, sizeof(data));
+  MemInputStream mis_be(data_be, sizeof(data_be));
   MemInputStream mis_le(data_le, sizeof(data_le));
 
-  EXPECT_EQ(1234, (ReadValueBE<uint32_t, 2>(mis)));
+  EXPECT_EQ(1234, (ReadValueBE<uint32_t, 2>(mis_be)));
   EXPECT_EQ(1234, (ReadValueLE<uint32_t, 2>(mis_le)));
-  EXPECT_EQ(7777, ReadValueBE<uint16_t>(mis));
+  EXPECT_EQ(7777, ReadValueBE<uint16_t>(mis_be));
   EXPECT_EQ(7777, ReadValueLE<uint16_t>(mis_le));
 }
 
 TEST(byte_io, read_value_float_input_stream) {
-  const uint8_t data[] = {0x3f, 0x80, 0x00, 0x00};
+  const uint8_t data_be[] = {0x3f, 0x80, 0x00, 0x00};
   const uint8_t data_le[] = {0x00, 0x00, 0x80, 0x3f};
-  MemInputStream mis(data, sizeof(data));
+  MemInputStream mis_be(data_be, sizeof(data_be));
   MemInputStream mis_le(data_le, sizeof(data_le));
 
-  EXPECT_EQ(1.0f, ReadValueBE<float>(mis));
+  EXPECT_EQ(1.0f, ReadValueBE<float>(mis_be));
   EXPECT_EQ(1.0f, ReadValueLE<float>(mis_le));
 }
 

--- a/include/dali/core/byte_io.h
+++ b/include/dali/core/byte_io.h
@@ -15,6 +15,8 @@
 #ifndef DALI_CORE_BYTE_IO_H_
 #define DALI_CORE_BYTE_IO_H_
 
+#include "dali/core/stream.h"
+
 namespace dali {
 
 namespace detail {
@@ -41,6 +43,13 @@ void ReadValueImpl(float &value, const uint8_t* data) {
   memcpy(&value, &tmp, sizeof(float));
 }
 
+template <int nbytes, bool is_little_endian, typename T>
+void ReadValueImpl(T &value, InputStream &stream) {
+  uint8_t data[nbytes];
+  stream.ReadBytes(data, nbytes);
+  return ReadValueImpl<nbytes, is_little_endian>(value, data);
+}
+
 }  // namespace detail
 
 
@@ -61,6 +70,26 @@ template <typename T, int nbytes = sizeof(T)>
 T ReadValueBE(const uint8_t* data) {
   T ret;
   detail::ReadValueImpl<nbytes, false>(ret, data);
+  return ret;
+}
+
+/**
+ * @brief Reads value of size `nbytes` from an InputStream (little-endian)
+ */
+template <typename T, int nbytes = sizeof(T)>
+T ReadValueLE(InputStream &stream) {
+  T ret;
+  detail::ReadValueImpl<nbytes, true>(ret, stream);
+  return ret;
+}
+
+/**
+ * @brief Reads value of size `nbytes` from an InputStream (big-endian)
+ */
+template <typename T, int nbytes = sizeof(T)>
+T ReadValueBE(InputStream &stream) {
+  T ret;
+  detail::ReadValueImpl<nbytes, false>(ret, stream);
   return ret;
 }
 

--- a/include/dali/core/byte_io.h
+++ b/include/dali/core/byte_io.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019, 2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/dali/core/byte_io.h
+++ b/include/dali/core/byte_io.h
@@ -43,9 +43,9 @@ void ReadValueImpl(float &value, const uint8_t* data) {
   memcpy(&value, &tmp, sizeof(float));
 }
 
-template <int kNbytes, bool is_little_endian, typename T>
+template <int nbytes, bool is_little_endian, typename T>
 void ReadValueImpl(T &value, InputStream &stream) {
-  uint8_t data[kNbytes];
+  uint8_t data[nbytes];  // NOLINT [runtime/arrays]
   stream.ReadBytes(data, nbytes);
   return ReadValueImpl<nbytes, is_little_endian>(value, data);
 }

--- a/include/dali/core/byte_io.h
+++ b/include/dali/core/byte_io.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2022, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019, 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,9 +43,9 @@ void ReadValueImpl(float &value, const uint8_t* data) {
   memcpy(&value, &tmp, sizeof(float));
 }
 
-template <int nbytes, bool is_little_endian, typename T>
+template <int kNbytes, bool is_little_endian, typename T>
 void ReadValueImpl(T &value, InputStream &stream) {
-  uint8_t data[nbytes];
+  uint8_t data[kNbytes];
   stream.ReadBytes(data, nbytes);
   return ReadValueImpl<nbytes, is_little_endian>(value, data);
 }


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** (*non-breaking change which adds functionality*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
This PR adds thin overloads of `ReadValueLE`/`ReadValueBE` allowing to read data of different endianness directly from `InputStreams`. This will be needed for parsing TIFFs.

## Additional information:

### Affected modules and functionalities:
`core/byte_io.h`

### Key points relevant for the review:

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

New tests are `byte_io_test`: `read_value_unsigned_int_input_stream`, `read_value_float_input_stream` which also check if the stream pos is moving forward on `ReadValueBE/LE`.

<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2862
<!--- DALI-XXXX or NA --->
