### PR TITLE
Add ReadHeader util to parser baseclass

### DIFF
--- a/dali/imgcodec/image_format.cc
+++ b/dali/imgcodec/image_format.cc
@@ -67,5 +67,19 @@ span<ImageFormat* const> ImageFormatRegistry::Formats() const {
   return make_cspan(format_ptrs_);
 }
 
+size_t ImageParser::ReadHeader(ImageSource *encoded, uint8_t *buffer, size_t n) const {
+  if (encoded->Kind() == InputKind::HostMemory) {
+    if (encoded->Size() < n)
+      n = encoded->Size();
+    std::copy_n(encoded->RawData<char>(), n, buffer);
+  } else {
+    auto stream = encoded->Open();
+    if (stream->Size() < n)
+      n = stream->Size();
+    stream->ReadBytes(buffer, n);
+  }
+  return n;
+}
+
 }  // namespace imgcodec
 }  // namespace dali

--- a/dali/imgcodec/image_format.cc
+++ b/dali/imgcodec/image_format.cc
@@ -67,16 +67,14 @@ span<ImageFormat* const> ImageFormatRegistry::Formats() const {
   return make_cspan(format_ptrs_);
 }
 
-size_t ImageParser::ReadHeader(ImageSource *encoded, uint8_t *buffer, size_t n) const {
+size_t ImageParser::ReadHeader(uint8_t *buffer, ImageSource *encoded, size_t n) const {
   if (encoded->Kind() == InputKind::HostMemory) {
     if (encoded->Size() < n)
       n = encoded->Size();
-    std::copy_n(encoded->RawData<char>(), n, buffer);
+    std::memcpy(buffer, encoded->RawData(), n);
   } else {
     auto stream = encoded->Open();
-    if (stream->Size() < n)
-      n = stream->Size();
-    stream->ReadBytes(buffer, n);
+    return stream->Read(buffer, n);
   }
   return n;
 }

--- a/dali/imgcodec/image_format_test.cc
+++ b/dali/imgcodec/image_format_test.cc
@@ -115,7 +115,7 @@ TEST_F(ImageFormatTest, ReadHeaderHostMem) {
   uint8_t buffer[16];
   auto src = ImageSource::FromHostMem(data, 4);
   DummyParser p;
-  EXPECT_EQ(4, p.ReadHeader(&src, buffer, 5));
+  EXPECT_EQ(4, p.ReadHeader(buffer, &src, 5));
   EXPECT_EQ(0, buffer[0]);
   EXPECT_EQ(1, buffer[1]);
   EXPECT_EQ(2, buffer[2]);
@@ -127,7 +127,7 @@ TEST_F(ImageFormatTest, ReadHeaderStream) {
     testing::dali_extra_path() + "/db/single/tiff/0/cat-1245673_640.tiff");
   uint8_t buffer[4];
   DummyParser p;
-  EXPECT_EQ(4, p.ReadHeader(&src, buffer, 4));
+  EXPECT_EQ(4, p.ReadHeader(buffer, &src, 4));
   EXPECT_EQ('I', buffer[0]);
   EXPECT_EQ('I', buffer[1]);
   EXPECT_EQ(42, buffer[2]);

--- a/dali/imgcodec/image_format_test.cc
+++ b/dali/imgcodec/image_format_test.cc
@@ -59,7 +59,7 @@ class ImageFormatTest : public ::testing::Test {
   }
 
   class DummyParser : public ImageParser {
-  public:
+   public:
     ImageInfo GetInfo(ImageSource *encoded) const override {
       return {};
     }

--- a/dali/imgcodec/image_format_test.cc
+++ b/dali/imgcodec/image_format_test.cc
@@ -110,7 +110,7 @@ TEST_F(ImageFormatTest, DISABLED_Webp) {
        TensorShape<>(423, 640, 3));
 }
 
-TEST_F(ImageFormatTest, ReadHeader) {
+TEST_F(ImageFormatTest, ReadHeaderHostMem) {
   const uint8_t data[] = {0, 1, 2, 3};
   uint8_t buffer[16];
   auto src = ImageSource::FromHostMem(data, 4);
@@ -120,6 +120,18 @@ TEST_F(ImageFormatTest, ReadHeader) {
   EXPECT_EQ(1, buffer[1]);
   EXPECT_EQ(2, buffer[2]);
   EXPECT_EQ(3, buffer[3]);
+}
+
+TEST_F(ImageFormatTest, ReadHeaderStream) {
+  auto src = ImageSource::FromFilename(
+    testing::dali_extra_path() + "/db/single/tiff/0/cat-1245673_640.tiff");
+  uint8_t buffer[4];
+  DummyParser p;
+  EXPECT_EQ(4, p.ReadHeader(&src, buffer, 4));
+  EXPECT_EQ('I', buffer[0]);
+  EXPECT_EQ('I', buffer[1]);
+  EXPECT_EQ(42, buffer[2]);
+  EXPECT_EQ(0, buffer[3]);
 }
 
 }  // namespace test

--- a/dali/imgcodec/image_format_test.cc
+++ b/dali/imgcodec/image_format_test.cc
@@ -58,6 +58,19 @@ class ImageFormatTest : public ::testing::Test {
     ASSERT_EQ(expected_sh, image_info.shape);
   }
 
+  class DummyParser : public ImageParser {
+  public:
+    ImageInfo GetInfo(ImageSource *encoded) const override {
+      return {};
+    }
+
+    bool CanParse(ImageSource *encoded) const override {
+      return false;
+    }
+
+    using ImageParser::ReadHeader;
+  };
+
   ImageFormatRegistry format_registry_;
   std::vector<char> data_;
 };
@@ -97,6 +110,17 @@ TEST_F(ImageFormatTest, DISABLED_Webp) {
        TensorShape<>(423, 640, 3));
 }
 
+TEST_F(ImageFormatTest, ReadHeader) {
+  const uint8_t data[] = {0, 1, 2, 3};
+  uint8_t buffer[16];
+  auto src = ImageSource::FromHostMem(data, 4);
+  DummyParser p;
+  EXPECT_EQ(4, p.ReadHeader(&src, buffer, 5));
+  EXPECT_EQ(0, buffer[0]);
+  EXPECT_EQ(1, buffer[1]);
+  EXPECT_EQ(2, buffer[2]);
+  EXPECT_EQ(3, buffer[3]);
+}
 
 }  // namespace test
 }  // namespace imgcodec

--- a/dali/imgcodec/image_source.cc
+++ b/dali/imgcodec/image_source.cc
@@ -40,6 +40,7 @@ ImageSource ImageSource::FromStream(std::shared_ptr<InputStream> stream, std::st
 std::shared_ptr<InputStream> ImageSource::Open() const {
   switch (kind_) {
     case InputKind::Stream:
+      stream_->SeekRead(0, SEEK_SET);
       return stream_;
     case InputKind::HostMemory:
       return std::make_shared<MemInputStream>(data_, size_);

--- a/dali/imgcodec/image_source_test.cc
+++ b/dali/imgcodec/image_source_test.cc
@@ -1,0 +1,37 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/imgcodec/image_source.h"
+
+#include "dali/test/dali_test.h"
+#include "dali/test/dali_test_config.h"
+
+namespace dali {
+namespace imgcodec {
+namespace test {
+
+TEST(image_source, open_rewind) {
+  const char data[] = {'a', 'b', 'c', 'd'};
+  MemInputStream mis(data, 4);
+  auto src = ImageSource::FromStream(&mis);
+  auto stream = src.Open();
+  EXPECT_EQ('a', (stream->ReadOne<char>()));
+  EXPECT_EQ('b', (stream->ReadOne<char>()));
+  auto stream2 = src.Open();
+  EXPECT_EQ('a', (stream2->ReadOne<char>()));
+}
+
+}  // namespace test
+}  // namespace imgcodec
+}  // namespace dali

--- a/include/dali/imgcodec/image_format.h
+++ b/include/dali/imgcodec/image_format.h
@@ -53,7 +53,7 @@ class DLL_PUBLIC ImageParser {
    */
   virtual bool CanParse(ImageSource *encoded) const = 0;
 
-protected:
+ protected:
   /**
    * @brief Reads first n bytes of the encoded image and returns the number of bytes read.
    */

--- a/include/dali/imgcodec/image_format.h
+++ b/include/dali/imgcodec/image_format.h
@@ -37,7 +37,7 @@ struct ImageInfo {
   } orientation;
 };
 
-class ImageParser {
+class DLL_PUBLIC ImageParser {
  public:
   virtual ~ImageParser() = default;
 
@@ -52,6 +52,12 @@ class ImageParser {
    *        that is, if it's in the format that this parser handles.
    */
   virtual bool CanParse(ImageSource *encoded) const = 0;
+
+protected:
+  /**
+   * @brief Reads first n bytes of the encoded image and returns the number of bytes read.
+   */
+  size_t ReadHeader(ImageSource *encoded, uint8_t *buffer, size_t n) const;
 };
 
 class ImageDecoder;

--- a/include/dali/imgcodec/image_format.h
+++ b/include/dali/imgcodec/image_format.h
@@ -55,9 +55,9 @@ class DLL_PUBLIC ImageParser {
 
  protected:
   /**
-   * @brief Reads first n bytes of the encoded image and returns the number of bytes read.
+   * @brief Reads first n bytes from the beginning of the encoded image
    */
-  size_t ReadHeader(ImageSource *encoded, uint8_t *buffer, size_t n) const;
+  size_t ReadHeader(uint8_t *buffer, ImageSource *encoded, size_t n) const;
 };
 
 class ImageDecoder;

--- a/include/dali/imgcodec/image_source.h
+++ b/include/dali/imgcodec/image_source.h
@@ -149,7 +149,7 @@ class DLL_PUBLIC ImageSource {
   /**
    * @brief Opens the image source, returning an input stream
    *
-   * If the image source already contains a stream, it is returned directly.
+   * If the image source is InputKind::Stream, the stream is rewound and returned directly.
    * Otherwise, a memory stream or a file is opened.
    *
    * @return std::shared_ptr<InputStream>


### PR DESCRIPTION

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->

**New feature** (*non-breaking change which adds functionality*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

When parsing files (especially in `CanParse`) we often need to read a header of the file. For inputs of `HostMem` kind it can be done faster, without opening a stream. This PR adds a small util for doing it.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2862
<!--- DALI-XXXX or NA --->
