### PR TITLE
Use actual batch size instead of max bat chsize in cropattr.

### DIFF
--- a/dali/operators/image/crop/crop_attr.h
+++ b/dali/operators/image/crop/crop_attr.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -165,9 +165,10 @@ class CropAttr {
     return anchor;
   }
 
-  void ProcessArguments(const OpSpec &spec, const ArgumentWorkspace &ws) {
-    auto max_batch_size = static_cast<size_t>(spec.GetArgument<int>("max_batch_size"));
-    for (std::size_t data_idx = 0; data_idx < max_batch_size; data_idx++) {
+  template <typename Workspace>
+  void ProcessArguments(const OpSpec &spec, const Workspace &ws) {
+    int batch_size = ws.GetInputBatchSize(0);
+    for (int data_idx = 0; data_idx < batch_size; data_idx++) {
       ProcessArguments(spec, &ws, data_idx);
     }
   }


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Fixes out-of-range access in CropAttr when actual batch size is smaller than max. batch size.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A
TODO

<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
