### PR TITLE
Fix lack of reset when `iter()` is called on the DALI framework iterator

### DIFF
--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -332,6 +332,7 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
             self._descriptors_populated = True
 
     def __next__(self):
+        self._ever_consumed = True
         if self._first_batch is not None:
             batch = self._first_batch
             self._first_batch = None

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -727,6 +727,7 @@ class DALIGluonIterator(_DALIMXNetIteratorBase):
                        "greater than the shard size."
 
     def __next__(self):
+        self._ever_consumed = True
         if self._first_batch is not None:
             batch = self._first_batch
             self._first_batch = None

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -267,6 +267,7 @@ class DALIGenericIterator(_DaliBaseIterator):
                        "greater than the shard size."
 
     def __next__(self):
+        self._ever_consumed = True
         if self._first_batch is not None:
             batch = self._first_batch
             self._first_batch = None

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -203,6 +203,7 @@ class DALIGenericIterator(_DaliBaseIterator):
                        "greater than the shard size."
 
     def __next__(self):
+        self._ever_consumed = True
         if self._first_batch is not None:
             batch = self._first_batch
             self._first_batch = None

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -1728,9 +1728,9 @@ def check_autoreset_iter(fw_iterator, extract_data, auto_reset_op):
 
     loader = fw_iterator(pipeline, reader_name="reader", auto_reset=auto_reset_op)
     for _ in range(2):
-        loader = iter(loader)
-        for i in range(len(loader)):
-            data = next(loader)
+        loader_iter = iter(loader)
+        for i in range(len(loader_iter)):
+            data = next(loader_iter)
             for j, d in enumerate(extract_data(data[0])):
                 assert d[0] == i * batch_size + j, f"{d[0]} { i * batch_size + j}"
 

--- a/dali/test/python/test_fw_iterators.py
+++ b/dali/test/python/test_fw_iterators.py
@@ -1728,7 +1728,9 @@ def check_autoreset_iter(fw_iterator, extract_data, auto_reset_op):
 
     loader = fw_iterator(pipeline, reader_name="reader", auto_reset=auto_reset_op)
     for _ in range(2):
-        for i, data in enumerate(loader):
+        loader = iter(loader)
+        for i in range(len(loader)):
+            data = next(loader)
             for j, d in enumerate(extract_data(data[0])):
                 assert d[0] == i * batch_size + j, f"{d[0]} { i * batch_size + j}"
 


### PR DESCRIPTION
- the DALI framework iterator when `iter()` is called checks if any
  data has been consumed yet. If it hasn't it doesn't reset to prevent
  improper operation when DALI FW iterator prefetches the first batch after
  creation, and invocation of something like `enumerate(iterator)`,
  would reset the iterator and extend the length of the first epoch
  (prefetched data in the FW iterator would be added to the freshly
  reset iterator). The flag that is set when any data has been consumed
  was set only in the `next()` method and not `__next__()`. This PR
  fixes this problem and adjusts the test

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- the DALI framework iterator when `iter()` is called checks if any
  data has been consumed yet. If it hasn't it doesn't reset to prevent
  improper operation when DALI FW iterator prefetches the first batch after
  creation, and invocation of something like `enumerate(iterator)`,
  would reset the iterator and extend the length of the first epoch
  (prefetched data in the FW iterator would be added to the freshly
  reset iterator). The flag that is set when any data has been consumed
  was set only in the `next()` method and not `__next__()`. This PR
  fixes this problem and adjusts the test
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - test_fw_iterators.py:test_*_autoreset_iter()
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
