### PR TITLE
Expose device_id in ShareData and SetSample APIs

### DIFF
--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "dali/c_api.h"
+#include "dali/core/common.h"
 #include "dali/pipeline/data/buffer.h"
 #include "dali/pipeline/data/tensor_list.h"
 #include "dali/pipeline/data/views.h"
@@ -335,7 +336,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
     SequentialFill(TensorListView<StorageCPU, uint8_t>(input_cpu.get(), input_shape), 42 * i);
     CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
     input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
-                            false, input_shape, DALI_UINT8);
+                            false, input_shape, DALI_UINT8, this->device_id_);
     pipe_ptr->SetExternalInput(input_name, input_wrapper);
     daliSetExternalInputBatchSize(&handle, input_name.c_str(), input_shape.num_samples());
     daliSetExternalInputAsync(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
@@ -359,7 +360,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocPipe) {
   // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
   CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
   input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
-                          false, input_shape, DALI_UINT8);
+                          false, input_shape, DALI_UINT8, this->device_id_);
   pipe_ptr->SetExternalInput(input_name, input_wrapper);
   daliSetExternalInputAsync(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
                             input.get(), dali_data_type_t::DALI_UINT8, input_shape.data(),
@@ -406,7 +407,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocVariableBatchSizePipe) {
       // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
       CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
       input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
-                              false, input_shape, DALI_UINT8);
+                              false, input_shape, DALI_UINT8, this->device_id_);
       pipe_ptr->SetExternalInput(input_name, input_wrapper);
       daliSetExternalInputBatchSize(&handle, input_name.c_str(), input_shape.num_samples());
       daliSetExternalInputAsync(&handle, input_name.c_str(),
@@ -523,7 +524,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocDifferentBackendsTest) {
     CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
     CUDA_CALL(cudaStreamSynchronize(cuda_stream));
     input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
-                            false, input_shape, DALI_UINT8);
+                            false, input_shape, DALI_UINT8, this->device_id_);
     pipe_ptr->SetExternalInput(input_name, input_wrapper);
     daliSetExternalInput(&handle, input_name.c_str(), backend_to_device_type<DataBackend>::value,
                          input.get(), dali_data_type_t::DALI_UINT8, input_shape.data(),
@@ -547,7 +548,7 @@ TYPED_TEST(CApiTest, ExternalSourceSingleAllocDifferentBackendsTest) {
   CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
   CUDA_CALL(cudaStreamSynchronize(cuda_stream));
   input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
-                          false, input_shape, DALI_UINT8);
+                          false, input_shape, DALI_UINT8, this->device_id_);
   pipe_ptr->SetExternalInput(input_name, input_wrapper);
   daliSetExternalInput(&handle, input_name.c_str(), backend_to_device_type<DataBackend>::value,
                         input.get(), dali_data_type_t::DALI_UINT8, input_shape.data(),
@@ -685,7 +686,8 @@ TYPED_TEST(CApiTest, UseCopyKernel) {
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
     CopyIfDifferent(input.get(), input_cpu.get(), num_elems, cuda_stream);
     input_wrapper.ShareData(std::static_pointer_cast<void>(input), num_elems,
-                            std::is_same_v<TypeParam, CPUBackend>, input_shape, DALI_UINT8);
+                            std::is_same_v<TypeParam, CPUBackend>, input_shape, DALI_UINT8,
+                            this->device_id_);
     pipe_ptr->SetExternalInput(input_name, input_wrapper);
     daliSetExternalInputAsync(&handle, input_name.c_str(), backend_to_device_type<TypeParam>::value,
                               input.get(), dali_data_type_t::DALI_UINT8, input_shape.data(),
@@ -782,7 +784,7 @@ void TestForceFlagRun(bool ext_src_no_copy, unsigned int flag_to_test, int devic
       MemCopy(data[i].get(), input_cpu.get(), num_elems, cuda_stream);
 
     input_wrapper[i].ShareData(std::static_pointer_cast<void>(data[i]), num_elems,
-                               false, input_shape, DALI_UINT8);
+                               false, input_shape, DALI_UINT8, device_id);
     pipe_ptr->SetExternalInput(input_name, input_wrapper[i]);
     if (flag_to_test == DALI_ext_force_no_copy) {
       // for no copy, we just pass the view to data

--- a/dali/operators/generic/flip_test.cc
+++ b/dali/operators/generic/flip_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "dali/core/common.h"
 #include "dali/pipeline/data/tensor.h"
 #include "dali/test/dali_operator_test.h"
 #include "dali/test/dali_operator_test_utils.h"
@@ -100,17 +101,17 @@ TEST_P(FlipTest, BasicTest) {
   auto data_size = kDataWidth * kDataHeight * kDataChannels * sizeof(float);
   TensorList<CPUBackend> tl;
   if (hwc) {
-    tl.ShareData(nhwc_tensor_list_data.ptr(), 2 * data_size);
+    auto shape = TensorListShape<>{
+        {{kDataHeight, kDataWidth, kDataChannels}, {kDataHeight, kDataWidth, kDataChannels}}};
+    tl.ShareData(nhwc_tensor_list_data.ptr(), 2 * data_size, false, shape, DALI_FLOAT,
+                 CPU_ONLY_DEVICE_ID);
     tl.SetLayout("HWC");
-    auto shape = TensorListShape<>{{
-        {kDataHeight, kDataWidth, kDataChannels},
-        {kDataHeight, kDataWidth, kDataChannels}}};
-    tl.Resize(shape, DALI_FLOAT);
   } else {
-    tl.ShareData(nchw_tensor_list_data.ptr(), 2 * data_size);
+    auto shape = TensorListShape<>{
+        {{kDataChannels, kDataHeight, kDataWidth}, {kDataChannels, kDataHeight, kDataWidth}}};
+    tl.ShareData(nchw_tensor_list_data.ptr(), 2 * data_size, false, shape, DALI_FLOAT,
+                 CPU_ONLY_DEVICE_ID);
     tl.SetLayout("CHW");
-    tl.Resize({{{kDataChannels, kDataHeight, kDataWidth},
-              {kDataChannels, kDataHeight, kDataWidth}}}, DALI_FLOAT);
   }
   TensorListWrapper tlout;
   this->RunTest(&tl, tlout, args, FlipVerify);

--- a/dali/operators/reader/loader/file_label_loader.cc
+++ b/dali/operators/reader/loader/file_label_loader.cc
@@ -64,7 +64,7 @@ void FileLabelLoader::ReadSample(ImageLabelWrapper &image_label) {
     auto p = current_image->Get(image_size);
     DALI_ENFORCE(p != nullptr, make_string("Failed to read file: ", image_pair.first));
     // Wrap the raw data in the Tensor object.
-    image_label.image.ShareData(p, image_size, false, {image_size}, DALI_UINT8);
+    image_label.image.ShareData(p, image_size, false, {image_size}, DALI_UINT8, CPU_ONLY_DEVICE_ID);
   }
 
   // close the file handle

--- a/dali/operators/reader/loader/indexed_file_loader.h
+++ b/dali/operators/reader/loader/indexed_file_loader.h
@@ -75,7 +75,7 @@ class IndexedFileLoader : public Loader<CPUBackend, Tensor<CPUBackend>> {
       auto p = current_file_->Get(size);
       DALI_ENFORCE(p != nullptr, "Error reading from a file " + uris_[current_file_index_]);
       // Wrap the raw data in the Tensor object.
-      tensor.ShareData(p, size, false, {size}, DALI_UINT8);
+      tensor.ShareData(p, size, false, {size}, DALI_UINT8, CPU_ONLY_DEVICE_ID);
     } else {
       if (tensor.shares_data()) {
         tensor.Reset();

--- a/dali/operators/reader/loader/numpy_loader.cc
+++ b/dali/operators/reader/loader/numpy_loader.cc
@@ -272,7 +272,7 @@ void NumpyLoader::ReadSample(NumpyFileWrapper& target) {
     auto p = current_file->Get(nbytes);
     DALI_ENFORCE(p != nullptr, make_string("Failed to read file: ", filename));
     // Wrap the raw data in the Tensor object.
-    target.data.ShareData(p, nbytes, false, {nbytes}, header.type());
+    target.data.ShareData(p, nbytes, false, {nbytes}, header.type(), CPU_ONLY_DEVICE_ID);
     target.data.Resize(header.shape, header.type());
   }
 

--- a/dali/operators/reader/loader/recordio_loader.h
+++ b/dali/operators/reader/loader/recordio_loader.h
@@ -127,7 +127,7 @@ class RecordIOLoader : public IndexedFileLoader {
         } else {
           n_read = size;
           // Wrap the raw data in the Tensor object.
-          tensor.ShareData(p, size, false, {size}, DALI_UINT8);
+          tensor.ShareData(p, size, false, {size}, DALI_UINT8, CPU_ONLY_DEVICE_ID);
           next_seek_pos_ = seek_pos + size;
         }
       }

--- a/dali/operators/reader/loader/sequence_loader.cc
+++ b/dali/operators/reader/loader/sequence_loader.cc
@@ -15,6 +15,7 @@
 #include <glob.h>
 #include <algorithm>
 #include <map>
+#include "dali/core/common.h"
 #include "dali/image/image.h"
 #include "dali/operators/reader/loader/sequence_loader.h"
 #include "dali/operators/reader/loader/utils.h"
@@ -146,7 +147,7 @@ void SequenceLoader::LoadFrame(const std::vector<std::string> &s, Index frame_id
     auto p = frame->Get(frame_size);
     DALI_ENFORCE(p != nullptr, make_string("Failed to read file: ", frame_filename));
     // Wrap the raw data in the Tensor object.
-    target->ShareData(p, frame_size, false, {frame_size}, DALI_UINT8);
+    target->ShareData(p, frame_size, false, {frame_size}, DALI_UINT8, CPU_ONLY_DEVICE_ID);
   }
   target->SetMeta(meta);
   frame->Close();

--- a/dali/operators/reader/video_reader_op.cc
+++ b/dali/operators/reader/video_reader_op.cc
@@ -49,7 +49,8 @@ void VideoReader::Prefetch() {
     auto sample_shared_ptr = unsafe_sample_owner(curr_tensor_list, data_idx);
     sample->sequence.ShareData(sample_shared_ptr, curr_tensor_list.capacity(),
                                curr_tensor_list.is_pinned(), curr_tensor_list.shape()[data_idx],
-                               curr_tensor_list.type(), curr_tensor_list.order());
+                               curr_tensor_list.type(), curr_tensor_list.device_id(),
+                               curr_tensor_list.order());
     sample->sequence.set_device_id(curr_tensor_list.device_id());
     sample->sequence.SetMeta(curr_tensor_list.GetMeta(data_idx));
     sample->read_sample_f();

--- a/dali/operators/reader/video_reader_resize_op.h
+++ b/dali/operators/reader/video_reader_resize_op.h
@@ -59,7 +59,7 @@ class VideoReaderResize : public VideoReader,
     TensorListShape<> shape = uniform_list_shape(1, seq_shape);
     const auto &type = batch_output.type_info();
     single_output.ShareData(raw_output, shape.num_elements() * type.size(),
-                            batch_output.is_pinned(), shape, type.id());
+                            batch_output.is_pinned(), shape, type.id(), batch_output.device_id());
   }
 
   void ProcessVideo(
@@ -72,8 +72,8 @@ class VideoReaderResize : public VideoReader,
       input_shape.set_tensor_shape(0, video_batch.tensor_shape(data_idx));
       input.ShareData(video_batch.raw_mutable_tensor(data_idx),
                       volume(video_batch.tensor_shape(data_idx)) * video_batch.type_info().size(),
-                      video_batch.is_pinned(),
-                      input_shape, video_batch.type());
+                      video_batch.is_pinned(), input_shape, video_batch.type(),
+                      video_batch.device_id());
 
       TensorList<GPUBackend> output;
       ShareSingleOutputAsTensorList(data_idx, video_output, output);

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -458,11 +458,10 @@ class DLL_PUBLIC Buffer {
    *
    * Current Buffer will be marked as sharing data, and reallocation of memory will be
    * prohibited until reset() is called.
-   *
-   * For GPU memory, it is assumed to be associated with current device.
    */
   inline void set_backing_allocation(const shared_ptr<void> &ptr, size_t bytes, bool pinned,
-                                     DALIDataType type = DALI_NO_TYPE, size_t size = 0) {
+                                     DALIDataType type, size_t size, int device_id,
+                                     AccessOrder order = {}) {
     free_storage();
     type_ = TypeTable::GetTypeInfo(type);
     data_ = ptr;
@@ -471,12 +470,8 @@ class DLL_PUBLIC Buffer {
     shares_data_ = data_ != nullptr;
     num_bytes_ = bytes;
     pinned_ = pinned;
-    // setting the allocation, get the device
-    if ((std::is_same<Backend, GPUBackend>::value || pinned_) && device_ == CPU_ONLY_DEVICE_ID) {
-      CUDA_CALL(cudaGetDevice(&device_));
-    } else {
-      device_ = CPU_ONLY_DEVICE_ID;
-    }
+    device_ = device_id;
+    set_order(order);
   }
 
   static void SetGrowthFactor(double factor) {

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -231,8 +231,7 @@ class Tensor : public Buffer<Backend> {
    * Size can be set to 0 and type to NoType as intermediate step.
    */
   inline void ShareData(const shared_ptr<void> &ptr, size_t bytes, bool pinned,
-                        const TensorShape<> &shape,
-                        DALIDataType type = DALI_NO_TYPE,
+                        const TensorShape<> &shape, DALIDataType type, int device_id,
                         AccessOrder order = {}) {
     Index new_size = volume(shape);
     DALI_ENFORCE(new_size == 0 || type != DALI_NO_TYPE,
@@ -246,16 +245,18 @@ class Tensor : public Buffer<Backend> {
       this->set_order(order);
 
     // Save our new pointer and bytes. Reset our type, shape, and size
-    data_ = ptr;
-    num_bytes_ = bytes;
-    pinned_ = pinned;
     type_ = TypeTable::GetTypeInfo(type);
-    shape_ = shape;
+    data_ = ptr;
     size_ = new_size;
+    num_bytes_ = bytes;
+    device_ = device_id;
 
     // If the input pointer stores a non-zero size allocation, mark
     // that we are sharing our underlying data
     shares_data_ = num_bytes_ > 0 ? true : false;
+    pinned_ = pinned;
+
+    shape_ = shape;
   }
 
   /**
@@ -275,8 +276,8 @@ class Tensor : public Buffer<Backend> {
    * in use by the Tensor.
    */
   inline void ShareData(void *ptr, size_t bytes, bool pinned, const TensorShape<> &shape,
-                        DALIDataType type = DALI_NO_TYPE, AccessOrder order = {}) {
-    ShareData(shared_ptr<void>(ptr, [](void *) {}), bytes, pinned, shape, type, order);
+                        DALIDataType type, int device_id, AccessOrder order = {}) {
+    ShareData(shared_ptr<void>(ptr, [](void *) {}), bytes, pinned, shape, type, device_id, order);
   }
 
   /**
@@ -296,10 +297,9 @@ class Tensor : public Buffer<Backend> {
    * manage the lifetime of the allocation such that it persist while it is
    * in use by the Tensor.
    */
-  inline void ShareData(void *ptr, size_t bytes, bool pinned = false,
-                        DALIDataType type = DALI_NO_TYPE,
+  inline void ShareData(void *ptr, size_t bytes, bool pinned, DALIDataType type, int device_id,
                         AccessOrder order = {}) {
-    ShareData(ptr, bytes, pinned, { 0 }, type, order);
+    ShareData(ptr, bytes, pinned, { 0 }, type, device_id, order);
   }
 
   inline void Reset(AccessOrder order = {}) {

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -22,6 +22,7 @@
 #include <list>
 #include <memory>
 #include <utility>
+#include "dali/core/access_order.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/buffer.h"
@@ -256,7 +257,7 @@ class DLL_PUBLIC TensorList {
    * Size can be set to 0 and type to NoType as intermediate step.
    */
   inline void ShareData(const shared_ptr<void> &ptr, size_t bytes, bool pinned,
-                        const TensorListShape<> &shape, DALIDataType type = DALI_NO_TYPE,
+                        const TensorListShape<> &shape, DALIDataType type, int device_id,
                         AccessOrder order = {}) {
     // Free the underlying storage.
     data_.free_storage();
@@ -265,7 +266,7 @@ class DLL_PUBLIC TensorList {
     this->set_order(order);
 
     // Save our new pointer and bytes. Reset our type, shape, and size
-    data_.set_backing_allocation(ptr, bytes, pinned, type, shape.num_elements());
+    data_.set_backing_allocation(ptr, bytes, pinned, type, shape.num_elements(), device_id, order);
     shape_ = {};
     offsets_.clear();
 
@@ -296,29 +297,8 @@ class DLL_PUBLIC TensorList {
    */
   DLL_PUBLIC inline void ShareData(void *ptr, size_t bytes, bool pinned,
                                    const TensorListShape<> &shape,
-                                   DALIDataType type = DALI_NO_TYPE) {
-    ShareData(shared_ptr<void>(ptr, [](void *) {}), bytes, pinned, shape, type);
-  }
-
-  /**
-   * @brief Interprets a raw allocation as a tensor list with given shape.
-   *
-   * If the size of the allocation is zero, the TensorList is reset to a default
-   * state and is NOT marked as sharing data.
-   *
-   * After calling this function any following call to `set_type` and `Resize`
-   * must not exceed the total size of underlying allocation (`num_bytes_`) of
-   * shared data or the call will fail.
-   * Size can be set to 0 and type to NoType as intermediate step.
-   *
-   * The TensorList object assumes no ownership of the input allocation, and will
-   * not de-allocate it when it is done using it. It is up to the user to
-   * manage the lifetime of the allocation such that it persist while it is
-   * in use by the TensorList.
-   */
-  DLL_PUBLIC inline void ShareData(void *ptr, size_t bytes, bool pinned = false,
-                                   const DALIDataType type = DALI_NO_TYPE) {
-    ShareData(shared_ptr<void>(ptr, [](void *) {}), bytes, pinned, TensorListShape<>{}, type);
+                                   DALIDataType type, int device_id, AccessOrder order = {}) {
+    ShareData(shared_ptr<void>(ptr, [](void *) {}), bytes, pinned, shape, type, device_id, order);
   }
 
   DLL_PUBLIC void Reset(AccessOrder order = {}) {
@@ -545,9 +525,8 @@ class DLL_PUBLIC TensorList {
     tensor_views_.emplace_back();
     auto &tensor = tensor_views_.back();
 
-    tensor.set_device_id(device_id());
     tensor.ShareData(data_.get_data_ptr(), data_.capacity(), data_.is_pinned(),
-                     new_shape, type(), order());
+                     new_shape, type(), device_id(), order());
 
     return &tensor;
   }

--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -12,18 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/pipeline/data/tensor.h"
-#include "dali/pipeline/data/tensor_vector.h"
 
 #include <gtest/gtest.h>
 
 #include <numeric>
 
+#include "dali/core/common.h"
+#include "dali/core/mm/malloc_resource.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/buffer.h"
+#include "dali/pipeline/data/tensor.h"
+#include "dali/pipeline/data/tensor_vector.h"
+#include "dali/pipeline/data/types.h"
 #include "dali/test/dali_test.h"
-#include "dali/core/mm/malloc_resource.h"
 
 namespace dali {
 
@@ -160,7 +162,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeNoAlloc) {
   std::vector<float> source_data(size);
 
   // Wrap the allocation
-  t.ShareData(source_data.data(), size*sizeof(float));
+  t.ShareData(source_data.data(), size*sizeof(float), false, DALI_NO_TYPE, CPU_ONLY_DEVICE_ID);
 
   // Verify internals
   ASSERT_EQ(t.size(), 0);
@@ -214,7 +216,7 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeAlloc) {
   std::vector<float> source_data(size);
 
   // Wrap the allocation
-  t.ShareData(source_data.data(), size*sizeof(float));
+  t.ShareData(source_data.data(), size*sizeof(float), false, DALI_NO_TYPE, CPU_ONLY_DEVICE_ID);
 
   // Verify internals
   ASSERT_EQ(t.size(), 0);
@@ -271,7 +273,7 @@ TYPED_TEST(TensorTest, TestGetBytesSizeTypeNoAlloc) {
   std::vector<float> source_data(size);
 
   // Wrap the allocation
-  t.ShareData(source_data.data(), size*sizeof(float));
+  t.ShareData(source_data.data(), size*sizeof(float), false, DALI_NO_TYPE, CPU_ONLY_DEVICE_ID);
 
   // Verify internals
   ASSERT_EQ(t.size(), 0);
@@ -313,7 +315,7 @@ TYPED_TEST(TensorTest, TestGetBytesSizeTypeAlloc) {
   std::vector<float> source_data(size);
 
   // Wrap the allocation
-  t.ShareData(source_data.data(), size*sizeof(float));
+  t.ShareData(source_data.data(), size*sizeof(float), false, DALI_NO_TYPE, CPU_ONLY_DEVICE_ID);
 
   // Verify internals
   ASSERT_EQ(t.size(), 0);
@@ -362,8 +364,7 @@ TYPED_TEST(TensorTest, TestShareData) {
     // TODO(klecki): Rework this with proper sample-based tensor batch data structure
     auto sample_shared_ptr = unsafe_sample_owner(tl, i);
     tensor.ShareData(sample_shared_ptr, tl.capacity(), tl.is_pinned(), tl.shape()[i],
-                     tl.type());
-    tensor.set_device_id(tl.device_id());
+                     tl.type(), tl.device_id());
     tensor.SetMeta(tl.GetMeta(i));
 
     // Verify the internals

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -193,7 +193,8 @@ class DLL_PUBLIC TensorVector {
 
   DLL_PUBLIC void UnsafeSetSample(int sample_idx, const shared_ptr<void> &ptr, size_t bytes,
                                   bool pinned, const TensorShape<> &shape, DALIDataType type,
-                                  AccessOrder order = {}, const TensorLayout &layout = "");
+                                  int device_id, AccessOrder order = {},
+                                  const TensorLayout &layout = "");
 
   /**
    * @brief Analogue of TensorVector[sample_idx].Copy(src[src_sample_idx]);
@@ -275,6 +276,8 @@ class DLL_PUBLIC TensorVector {
   void set_pinned(bool pinned);
 
   bool is_pinned() const;
+
+  void set_device_id(int device_id);
 
   int device_id() const;
 

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -237,7 +237,7 @@ struct TensorVectorBuilder {
     assert(NextSampleIdx() < tv_.num_samples());
     std::shared_ptr<void> ptr(view.ptr, [](void *) {});  // no deleter
     tv_.UnsafeSetSample(next_++, ptr, view.type_size * volume(view.shape), tv_.is_pinned(),
-                        view.shape, tv_.type(), tv_.order(), tv_.GetLayout());
+                        view.shape, tv_.type(), tv_.device_id(), tv_.order(), tv_.GetLayout());
   }
 
   int NextSampleIdx() const {

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -15,6 +15,7 @@
 #include <cuda_runtime_api.h>
 #include <dlfcn.h>
 #include <sstream>
+#include "dali/core/common.h"
 #include "dali/core/cuda_utils.h"
 #include "dali/core/device_guard.h"
 #if SHM_WRAPPER_ENABLED
@@ -188,20 +189,22 @@ void FillTensorFromDlPack(py::capsule capsule, SourceDataType<SrcBackend> *batch
   // shared ptr is destroyed
   auto typed_shape = ConvertShape(shape, batch);
   bool is_pinned = dl_tensor.device.device_type == kDLCUDAHost;
-  batch->ShareData(shared_ptr<void>(dl_tensor.data,
-                                    [dlm_tensor_ptr = move(dlm_tensor_ptr)](void*) {}),
-                                    bytes, is_pinned, typed_shape, dali_type.id());
-
+  int device_id = CPU_ONLY_DEVICE_ID;
   // according to the docs kDLCUDAHost = kDLCPU | kDLCUDA so test it as a the first option
   if (dl_tensor.device.device_type == kDLCUDAHost) {
-    batch->set_device_id(-1);
+    device_id = CPU_ONLY_DEVICE_ID;
   } else if (dl_tensor.device.device_type == kDLCPU) {
-    batch->set_device_id(-1);
+    device_id = CPU_ONLY_DEVICE_ID;
   } else if (dl_tensor.device.device_type == kDLCUDA) {
-    batch->set_device_id(dl_tensor.device.device_id);
+    device_id = dl_tensor.device.device_id;
   } else {
     DALI_FAIL(make_string("Not supported DLPack device type: ", dl_tensor.device.device_type, "."));
   }
+
+  batch->ShareData(shared_ptr<void>(dl_tensor.data,
+                                    [dlm_tensor_ptr = move(dlm_tensor_ptr)](void*) {}),
+                                    bytes, is_pinned, typed_shape, dali_type.id(), device_id);
+
 
   batch->SetLayout(layout);
 }
@@ -244,17 +247,16 @@ void FillTensorFromCudaArray(const py::object object, TensorType *batch, int dev
   auto typed_shape = ConvertShape(shape, batch);
   auto *ptr = PyLong_AsVoidPtr(cu_a_interface["data"].cast<py::tuple>()[0].ptr());
 
-  // Keep a copy of the input object ref in the deleter, so its refcount is increased
-  // while this shared_ptr is alive (and the data should be kept alive)
-  // We set the type and shape even before the set_device_id as we only wrap the allocation
-  batch->ShareData(shared_ptr<void>(ptr, [obj_ref = object](void *) {}),
-                   bytes, false, typed_shape, type.id());
-  batch->SetLayout(layout);
   // it is for __cuda_array_interface__ so device_id < 0 is not a valid value
   if (device_id < 0) {
     CUDA_CALL(cudaGetDevice(&device_id));
   }
-  batch->set_device_id(device_id);
+
+  // Keep a copy of the input object ref in the deleter, so its refcount is increased
+  // while this shared_ptr is alive (and the data should be kept alive)
+  batch->ShareData(shared_ptr<void>(ptr, [obj_ref = object](void *) {}),
+                   bytes, false, typed_shape, type.id(), device_id);
+  batch->SetLayout(layout);
 }
 
 void ExposeTensorLayout(py::module &m) {
@@ -453,13 +455,20 @@ void ExposeTensor(py::module &m) {
           // Validate the stride
           CheckContiguousTensor(info.strides, info.shape, info.itemsize);
 
+          // TODO(klecki): Extend the constructor with stream and device_id
+          // Assume that we cannot use pinned memory in CPU_ONLY mode
+          int device_id = CPU_ONLY_DEVICE_ID;
+          if (is_pinned) {
+            CUDA_CALL(cudaGetDevice(&device_id));
+          }
+
           // Create the Tensor and wrap the data
           auto t = std::make_unique<Tensor<CPUBackend>>();
           const TypeInfo &type = TypeFromFormatStr(info.format);
           // Keep a copy of the input buffer ref in the deleter, so its refcount is increased
           // while this shared_ptr is alive (and the data should be kept alive)
           t->ShareData(shared_ptr<void>(info.ptr, [buf_ref = b](void *) {}),
-                       bytes, is_pinned, i_shape, type.id());
+                       bytes, is_pinned, i_shape, type.id(), device_id);
           t->SetLayout(layout);
           return t.release();
         }),
@@ -692,7 +701,8 @@ std::unique_ptr<Tensor<Backend> > TensorListGetItemImpl(TensorList<Backend> &t, 
   auto ptr = std::make_unique<Tensor<Backend>>();
   // TODO(klecki): Rework this with proper sample-based tensor batch data structure
   auto sample_shared_ptr = unsafe_sample_owner(t, id);
-  ptr->ShareData(sample_shared_ptr, t.capacity(), t.is_pinned(), t.shape()[id], t.type());
+  ptr->ShareData(sample_shared_ptr, t.capacity(), t.is_pinned(), t.shape()[id], t.type(),
+                 t.device_id(), t.order());
   ptr->set_device_id(t.device_id());
   ptr->SetMeta(t.GetMeta(id));
   return ptr;
@@ -853,13 +863,20 @@ void ExposeTensorList(py::module &m) {
         // Validate the stride
         CheckContiguousTensor(info.strides, info.shape, info.itemsize);
 
+        // TODO(klecki): Extend the constructor with stream and device_id
+        // Assume that we cannot use pinned memory in CPU_ONLY mode
+        int device_id = CPU_ONLY_DEVICE_ID;
+        if (is_pinned) {
+          CUDA_CALL(cudaGetDevice(&device_id));
+        }
+
         // Create the Tensor and wrap the data
         auto t = std::make_shared<TensorList<CPUBackend>>();
         const TypeInfo &type = TypeFromFormatStr(info.format);
         // Keep a copy of the input buffer ref in the deleter, so its refcount is increased
         // while this shared_ptr is alive (and the data should be kept alive)
         t->ShareData(shared_ptr<void>(info.ptr, [buf_ref = b](void *){}),
-                     bytes, false, i_shape, type.id());
+                     bytes, false, i_shape, type.id(), device_id);
         t->SetLayout(layout);
         return t;
       }),


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Refactoring**, **Breaking Change**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
The device_id is necessary metadata when accepting
external memory via pointers.

The device_id can differ from the one that is
present in the order. device_id represents the
location of memory, the order tracks the necessary
synchronization - the provided memory can in theory
depend on a work being done on another device.

Adjust the ShareData/SetSample APIs, so the device_id
is provided in one go with the allocation.

Assume that the C API memory is provided on the
device of the current Pipeline.

TODO:
* Add the above mention to docstrings
* Add a test that checks Python Tensor/TensorList
    constructors in their current state (conversion from CuPy?)
* Mention the requirements of device_id in C API.

## Additional information:

### Affected modules and functionalities:
Setting external memory.

### Key points relevant for the review:
If the CPU_ONLY_DEVICE_ID is not used instead
of the proper device.

### Tests:
TODO

<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
TODO

- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
