### PR TITLE
Fix pad_last_batch in GPU NumpyReader

### DIFF
--- a/dali/operators/reader/loader/numpy_loader_gpu.h
+++ b/dali/operators/reader/loader/numpy_loader_gpu.h
@@ -49,7 +49,7 @@ struct NumpyFileWrapperGPU {
   TensorShape<> shape;
   DALIDataType type;
   DALIMeta meta;
-  int source_sample_idx;
+  int source_sample_idx = -1;
 
   std::unique_ptr<CUFileStream> file_stream;
   bool read_ahead = false;

--- a/dali/operators/reader/loader/numpy_loader_gpu.h
+++ b/dali/operators/reader/loader/numpy_loader_gpu.h
@@ -49,6 +49,7 @@ struct NumpyFileWrapperGPU {
   TensorShape<> shape;
   DALIDataType type;
   DALIMeta meta;
+  int source_sample_idx;
 
   std::unique_ptr<CUFileStream> file_stream;
   bool read_ahead = false;

--- a/dali/operators/reader/numpy_reader_gpu_op.cc
+++ b/dali/operators/reader/numpy_reader_gpu_op.cc
@@ -99,13 +99,9 @@ void NumpyReaderGPU::Prefetch() {
       if (first_padded < 0) {
         first_padded = data_idx;
       }
-    } else {
-      ScheduleChunkedRead(sample, *curr_batch[data_idx]);
-    }
-    if (first_padded > 0) {
-      // connect padded samples with the original data idx
       curr_batch[data_idx]->source_sample_idx = first_padded - 1;
     } else {
+      ScheduleChunkedRead(sample, *curr_batch[data_idx]);
       curr_batch[data_idx]->source_sample_idx = data_idx;
     }
   }

--- a/dali/operators/reader/numpy_reader_gpu_op.h
+++ b/dali/operators/reader/numpy_reader_gpu_op.h
@@ -81,6 +81,7 @@ class NumpyReaderGPU : public NumpyReader<GPUBackend, NumpyFileWrapperGPU> {
   gds::GDSStagingEngine staging_;
   CUDAStreamLease staging_stream_;
   CUDAEvent staging_ready_;
+  std::vector<int> source_data_index_;
 };
 
 }  // namespace dali

--- a/dali/operators/reader/numpy_reader_gpu_op_impl.cu
+++ b/dali/operators/reader/numpy_reader_gpu_op_impl.cu
@@ -59,14 +59,14 @@ void NumpyReaderGPU::RunImplTyped(DeviceWorkspace &ws) {
   }
 
   if (nsamples_copy) {
-    bool no_padded = true;
+    bool is_padded = false;
     for (int i = 0; i < nsamples; ++i) {
       if (source_data_index_[i] != i) {
-        no_padded = false;
+        is_padded = true;
         break;
       }
     }
-    if (nsamples_copy == nsamples && no_padded) {
+    if (nsamples_copy == nsamples && !is_padded) {
       std::swap(output, prefetched_batch_tensors_[curr_batch_consumer_]);
       return;
     }

--- a/dali/operators/reader/numpy_reader_gpu_op_impl.cu
+++ b/dali/operators/reader/numpy_reader_gpu_op_impl.cu
@@ -34,7 +34,9 @@ void NumpyReaderGPU::RunImplTyped(DeviceWorkspace &ws) {
   auto out_view = view<T>(output);
   auto curr_batch = GetCurrBatchView<T, Dims>();
   const auto &dtype = TypeTable::GetTypeInfo<T>();
-
+  int batch_size = GetCurrBatchSize();
+  source_data_index_.clear();
+  source_data_index_.resize(batch_size);
 
   CUDA_CALL(cudaStreamWaitEvent(ws.stream(), staging_ready_, 0));
 
@@ -53,10 +55,18 @@ void NumpyReaderGPU::RunImplTyped(DeviceWorkspace &ws) {
       nsamples_transpose++;
     if (!need_slice_[i] && !need_transpose_[i])
       nsamples_copy++;
+    source_data_index_[i] = GetSample(i).source_sample_idx;
   }
 
   if (nsamples_copy) {
-    if (nsamples_copy == nsamples) {
+    bool no_padded = true;
+    for (int i = 0; i < nsamples; ++i) {
+      if (source_data_index_[i] != i) {
+        no_padded = false;
+        break;
+      }
+    }
+    if (nsamples_copy == nsamples && no_padded) {
       std::swap(output, prefetched_batch_tensors_[curr_batch_consumer_]);
       return;
     }
@@ -64,7 +74,8 @@ void NumpyReaderGPU::RunImplTyped(DeviceWorkspace &ws) {
       if (need_slice_[i] || need_transpose_[i])
         continue;
       auto sz = out_sh.tensor_size(i) * sizeof(T);
-      sg_.AddCopy(out_view.data[i], curr_batch.data[i], sz);
+      int src_idx = source_data_index_[i];
+      sg_.AddCopy(out_view.data[i], curr_batch.data[src_idx], sz);
     }
     sg_.Run(ws.stream());
   }
@@ -100,8 +111,9 @@ void NumpyReaderGPU::RunImplTyped(DeviceWorkspace &ws) {
       args.fill_values.clear();
       args.fill_values.push_back(ConvertSat<T>(fill_value_));
 
-      from.data[j] = curr_batch.data[i];
-      from.shape.set_tensor_shape(j, curr_batch.shape[i]);
+      int src_idx = source_data_index_[i];
+      from.data[j] = curr_batch.data[src_idx];
+      from.shape.set_tensor_shape(j, curr_batch.shape[src_idx]);
 
       if (need_transpose_[i]) {
         // slice to an intermediate buffer
@@ -140,7 +152,8 @@ void NumpyReaderGPU::RunImplTyped(DeviceWorkspace &ws) {
         k++;
       } else {
         // directly from the input
-        from.data[j] = curr_batch.data[i];
+        int src_idx = source_data_index_[i];
+        from.data[j] = curr_batch.data[src_idx];
         from.shape.set_tensor_shape(j, curr_batch.tensor_shape(i));
       }
       to.data[j] = out_view[i].data;

--- a/dali/test/python/test_operator_readers_numpy.py
+++ b/dali/test/python/test_operator_readers_numpy.py
@@ -588,17 +588,17 @@ def check_pad_last_sample(device):
             filenames.append(filename)
             create_numpy_file(filename, (5, 2, 8), np.float32, False)
             arr_np_list.append(np.load(filename))
-        for _ in range(num_samples, batch_size):
+        while len(arr_np_list) < batch_size:
             arr_np_list.append(np.load(last_file_name))
         pipe = NumpyReaderPipeline(path=test_data_root,
-                                files=filenames,
-                                file_list=None,
-                                file_filter=None,
-                                device=device,
-                                batch_size=batch_size,
-                                num_threads=4,
-                                device_id=0,
-                                pad_last_batch=True)
+                                   files=filenames,
+                                   file_list=None,
+                                   file_filter=None,
+                                   device=device,
+                                   batch_size=batch_size,
+                                   num_threads=4,
+                                   device_id=0,
+                                   pad_last_batch=True)
         pipe.build()
 
         for _ in range(2):

--- a/dali/test/python/test_operator_readers_numpy.py
+++ b/dali/test/python/test_operator_readers_numpy.py
@@ -460,7 +460,7 @@ def test_numpy_reader_roi():
         ([1, 2], None, [20, 9], None, None, None, [0, 1], "trim_to_shape"),
         ([-10, 2], None, [8, 9], None, None, None, [0, 1], "trim_to_shape"),
         (fn.random.uniform(range=(0, 2), shape=(2, ), dtype=types.INT32), None,
-         fn.random.uniform(range=(7, 10), shape=(2, ),dtype=types.INT32),
+         fn.random.uniform(range=(7, 10), shape=(2, ), dtype=types.INT32),
          None, None, None, (0, 1), None),
         (fn.random.uniform(range=(0, 2), shape=(1, ), dtype=types.INT32), None,
          fn.random.uniform(range=(7, 10), shape=(1, ), dtype=types.INT32),
@@ -574,6 +574,7 @@ def test_numpy_reader_roi_error():
                     rel_roi_end, roi_shape, rel_roi_shape, roi_axes, out_of_bounds_policy, \
                     fill_value
 
+
 def check_pad_last_sample(device):
     with tempfile.TemporaryDirectory(prefix=gds_data_root) as test_data_root:
         # create files
@@ -607,6 +608,7 @@ def check_pad_last_sample(device):
                 pipe_arr = to_array(pipe_out[0][i])
                 ref_arr = arr_np_list[i]
                 assert_array_equal(pipe_arr, ref_arr)
+
 
 def test_pad_last_sample():
     for device in ["cpu", "gpu"]:

--- a/dali/test/python/test_operator_readers_numpy.py
+++ b/dali/test/python/test_operator_readers_numpy.py
@@ -574,7 +574,7 @@ def test_numpy_reader_roi_error():
                     rel_roi_end, roi_shape, rel_roi_shape, roi_axes, out_of_bounds_policy, \
                     fill_value
 
-def check_test_pad_last_sample(device):
+def check_pad_last_sample(device):
     with tempfile.TemporaryDirectory(prefix=gds_data_root) as test_data_root:
         # create files
         num_samples = 2
@@ -601,12 +601,13 @@ def check_test_pad_last_sample(device):
                                 pad_last_batch=True)
         pipe.build()
 
-        pipe_out = pipe.run()
-        for i in range(batch_size):
-            pipe_arr = to_array(pipe_out[0][i])
-            ref_arr = arr_np_list[i]
-            assert_array_equal(pipe_arr, ref_arr)
+        for _ in range(2):
+            pipe_out = pipe.run()
+            for i in range(batch_size):
+                pipe_arr = to_array(pipe_out[0][i])
+                ref_arr = arr_np_list[i]
+                assert_array_equal(pipe_arr, ref_arr)
 
 def test_pad_last_sample():
     for device in ["cpu", "gpu"]:
-        yield check_test_pad_last_sample, device
+        yield check_pad_last_sample, device

--- a/dali/test/python/test_operator_readers_numpy.py
+++ b/dali/test/python/test_operator_readers_numpy.py
@@ -67,7 +67,7 @@ def delete_numpy_file(filename):
 
 def NumpyReaderPipeline(path, batch_size, device="cpu", file_list=None, files=None,
                         file_filter="*.npy", num_threads=1, device_id=0,
-                        cache_header_information=False):
+                        cache_header_information=False, pad_last_batch=False):
     pipe = Pipeline(batch_size=batch_size, num_threads=num_threads, device_id=device_id)
     data = fn.readers.numpy(device=device,
                             file_list=file_list,
@@ -76,7 +76,8 @@ def NumpyReaderPipeline(path, batch_size, device="cpu", file_list=None, files=No
                             file_filter=file_filter,
                             shard_id=0,
                             num_shards=1,
-                            cache_header_information=cache_header_information)
+                            cache_header_information=cache_header_information,
+                            pad_last_batch=pad_last_batch)
     pipe.set_outputs(data)
     return pipe
 
@@ -572,3 +573,40 @@ def test_numpy_reader_roi_error():
                     device, fortran_order, file_filter, roi_start, rel_roi_start, roi_end, \
                     rel_roi_end, roi_shape, rel_roi_shape, roi_axes, out_of_bounds_policy, \
                     fill_value
+
+def check_test_pad_last_sample(device):
+    with tempfile.TemporaryDirectory(prefix=gds_data_root) as test_data_root:
+        # create files
+        num_samples = 2
+        batch_size = 5
+        filenames = []
+        arr_np_list = []
+        last_file_name = None
+        for index in range(0, num_samples):
+            filename = os.path.join(test_data_root, "test_{:02d}.npy".format(index))
+            last_file_name = filename
+            filenames.append(filename)
+            create_numpy_file(filename, (5, 2, 8), np.float32, False)
+            arr_np_list.append(np.load(filename))
+        for _ in range(num_samples, batch_size):
+            arr_np_list.append(np.load(last_file_name))
+        pipe = NumpyReaderPipeline(path=test_data_root,
+                                files=filenames,
+                                file_list=None,
+                                file_filter=None,
+                                device=device,
+                                batch_size=batch_size,
+                                num_threads=4,
+                                device_id=0,
+                                pad_last_batch=True)
+        pipe.build()
+
+        pipe_out = pipe.run()
+        for i in range(batch_size):
+            pipe_arr = to_array(pipe_out[0][i])
+            ref_arr = arr_np_list[i]
+            assert_array_equal(pipe_arr, ref_arr)
+
+def test_pad_last_sample():
+    for device in ["cpu", "gpu"]:
+        yield check_test_pad_last_sample, device


### PR DESCRIPTION
- fixes a crash in the numpy reader when pad_last_batch is set and more
  then one thread is used by DALI
- when pad_last_batch is set the padding duplicates the last valid sample.
  In the case of numpy reader, it means duplication of structure with a file
  descriptor. As samples within the batch are read in parallel it leads to
  two threads reading the same file with the same file descriptor which causes
  unexpected changes in the offset inside the file during reading. This patch
  adds logic that handles padded samples.

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- fixes a crash in the numpy reader when pad_last_batch is set and more
  then one thread is used by DALI
- when pad_last_batch is set the padding duplicates the last valid sample.
  In the case of numpy reader, it means duplication of structure with a file
  descriptor. As samples within the batch are read in parallel it leads to
  two threads reading the same file with the same file descriptor which causes
  unexpected changes in the offset inside the file during reading. This patch
  adds logic that handles padded samples.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- GPU numpy reader
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- logic
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_operator_readers_numpy.py:test_pad_last_sample
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
