### PR TITLE
Fix default dtype in color twist family of operators

### DIFF
--- a/dali/operators/image/color/color_twist.cc
+++ b/dali/operators/image/color/color_twist.cc
@@ -59,7 +59,7 @@ DALI_SCHEMA(ColorTransformBase)
     .AddOptionalTypeArg(color::kOutputType, R"code(Output data type.
 
 If not set, the input type is used.)code",
-                    DALI_UINT8)
+                        DALI_NO_TYPE)
     .AllowSequences()
     .SupportVolumetric();
 

--- a/dali/operators/image/color/color_twist.cc
+++ b/dali/operators/image/color/color_twist.cc
@@ -58,8 +58,7 @@ DALI_SCHEMA(ColorTransformBase)
         R"code(The color space of the input and the output image.)code", DALI_RGB)
     .AddOptionalTypeArg(color::kOutputType, R"code(Output data type.
 
-If not set, the input type is used.)code",
-                        DALI_NO_TYPE)
+If not set, the input type is used.)code")
     .AllowSequences()
     .SupportVolumetric();
 

--- a/dali/test/python/test_operator_color_twist.py
+++ b/dali/test/python/test_operator_color_twist.py
@@ -21,7 +21,7 @@ import random
 from nvidia.dali import pipeline_def
 
 from sequences_test_utils import ArgCb, video_suite_helper
-from test_utils import RandomDataIterator
+from test_utils import RandomDataIterator, as_array
 
 
 def dali_type_to_np(dtype):
@@ -184,3 +184,46 @@ def test_video():
     ]
 
     yield from video_suite_helper(video_test_cases, test_channel_first=False)
+
+
+def check_ref(inp_dtype, out_dtype, has_3_dims):
+    batch_size = 32
+    n_iters = 8
+    shape = (128, 32, 3) if not has_3_dims else (random.randint(2, 5), 128, 32, 3)
+    inp_dtype = dali_type_to_np(inp_dtype)
+    ri1 = RandomDataIterator(batch_size, shape=shape, dtype=inp_dtype)
+    pipe = ColorTwistPipeline(seed=2139,
+                              batch_size=batch_size,
+                              num_threads=4,
+                              device_id=0,
+                              data_iterator=ri1,
+                              is_input_float=np.issubdtype(inp_dtype, np.floating),
+                              inp_dtype=inp_dtype,
+                              out_dtype=out_dtype)
+    pipe.build()
+    for _ in range(n_iters):
+        inp, out_cpu, out_gpu, H, S, B, C = pipe.run()
+        out_gpu = out_gpu.as_cpu()
+        for i in range(batch_size):
+            h, s, b, c = H.at(i), S.at(i), B.at(i), C.at(i)
+            check(inp.at(i), out_cpu.at(i), out_gpu.at(i), h, s, b, c, dali_type_to_np(out_dtype))
+
+
+def test_color_twist_default_dtype():
+    np_types = [types.FLOAT, types.INT32, types.INT16, types.UINT8]  # Just some types
+
+    def impl(op, device, type):
+        @pipeline_def(batch_size=1, num_threads=3, device_id=0)
+        def pipeline():
+            data = fn.constant(idata=255, shape=(10, 10, 3), dtype=type, device=device)
+            return op(data)
+
+        pipe = pipeline()
+        pipe.build()
+        data, = pipe.run()
+        assert data[0].dtype == type, f"{data[0].dtype} != {type}"
+
+    for device in ['gpu', 'cpu']:
+        for type in np_types:
+            for op in [fn.hue]:
+                yield impl, op, device, type


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Bug fix**

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
- Fixes https://github.com/NVIDIA/DALI/issues/4065
- Default dtype was wrongly set to UINT8 instead of NO_TYPE, which caused the input type inference mechanism not to work properly.
- The PR fixes that and adds a test


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
Color twist family of operators


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
NA

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
