### PR TITLE
Add restrictions to set_type

### DIFF
--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -322,6 +322,12 @@ class DLL_PUBLIC Buffer {
    */
   inline void set_type(const DALIDataType new_type_id) {
     DALI_ENFORCE(new_type_id != DALI_NO_TYPE, "new_type must be valid type.");
+    DALI_ENFORCE(type_.id() == new_type_id || type_.id() == DALI_NO_TYPE,
+                 make_string("set_type cannot be used to change the current type - it is not "
+                             "allowed to cause allocations. Currently set type: '",
+                             type_.id(), "' trying to set: '", new_type_id,
+                             "'. You may change the current type using Resize or by"
+                             " calling Reset first."));
     if (new_type_id == type_.id()) return;
     const TypeInfo &new_type = TypeTable::GetTypeInfo(new_type_id);
 

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -320,7 +320,7 @@ class DLL_PUBLIC Buffer {
    */
   inline void set_type(const DALIDataType new_type_id) {
     DALI_ENFORCE(new_type_id != DALI_NO_TYPE, "new_type must be valid type.");
-    DALI_ENFORCE(type_.id() == new_type_id || !has_data(),
+    DALI_ENFORCE(type_.id() == new_type_id || (!has_data() || type_.id() == DALI_NO_TYPE),
                  make_string("set_type cannot be used to change the current type - it is not "
                              "allowed to cause allocations. Currently set type: '",
                              type_.id(), "' trying to set: '", new_type_id,

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -309,20 +309,18 @@ class DLL_PUBLIC Buffer {
     order_ = order;
   }
 
-  /**
-   * @brief Sets the type of the buffer. If the buffer has not been
-   * allocated because it does not yet have a type, the calling type
-   * is taken to be the type of the data and the memory is allocated.
+  /** @defgroup SetTypeFunctions Type setting functions.
    *
-   * If the buffer already has a valid type, and the calling type does
-   * not match, the type of the buffer is reset and the underlying
-   * storage is re-allocated if the buffer does not currently own
-   * enough memory to store the current number of elements with the
-   * new data type.
+   * Set the type of the current buffer. It must be set before calling resize(size).
+   * It cannot be used to change the type after allocation happened.
+   *
+   * resize(size, new_type) can be used without prior set_type call or to request a different type
+   * after allocation.
+   * @{
    */
   inline void set_type(const DALIDataType new_type_id) {
     DALI_ENFORCE(new_type_id != DALI_NO_TYPE, "new_type must be valid type.");
-    DALI_ENFORCE(type_.id() == new_type_id || type_.id() == DALI_NO_TYPE,
+    DALI_ENFORCE(type_.id() == new_type_id || !has_data(),
                  make_string("set_type cannot be used to change the current type - it is not "
                              "allowed to cause allocations. Currently set type: '",
                              type_.id(), "' trying to set: '", new_type_id,
@@ -348,6 +346,7 @@ class DLL_PUBLIC Buffer {
   inline void set_type() {
     set_type(TypeTable::GetTypeId<T>());
   }
+  /** @} */  // end of SetTypeFunctions
 
   /**
    * @brief Reserves at least new_num_bytes of storage.

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -309,14 +309,16 @@ class DLL_PUBLIC Buffer {
     order_ = order;
   }
 
-  /** @defgroup SetTypeFunctions Type setting functions.
-   *
-   * Set the type of the current buffer. It must be set before calling resize(size).
+  /**
+   * @name Type setting functions.
+   * @{
+   */
+  /**
+   * @brief Set the type of the current buffer. It must be set before calling resize(Index).
    * It cannot be used to change the type after allocation happened.
    *
-   * resize(size, new_type) can be used without prior set_type call or to request a different type
-   * after allocation.
-   * @{
+   * resize(Index, DALIDataType) can be used without prior set_type call or to request a different
+   * type after allocation.
    */
   inline void set_type(const DALIDataType new_type_id) {
     DALI_ENFORCE(new_type_id != DALI_NO_TYPE, "new_type must be valid type.");
@@ -347,7 +349,7 @@ class DLL_PUBLIC Buffer {
   inline void set_type() {
     set_type(TypeTable::GetTypeId<T>());
   }
-  /** @} */  // end of SetTypeFunctions
+  /** @} */
 
   /**
    * @brief Reserves at least new_num_bytes of storage.

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -320,13 +320,14 @@ class DLL_PUBLIC Buffer {
    */
   inline void set_type(const DALIDataType new_type_id) {
     DALI_ENFORCE(new_type_id != DALI_NO_TYPE, "new_type must be valid type.");
+    if (new_type_id == type_.id())
+      return;
     DALI_ENFORCE(type_.id() == new_type_id || (!has_data() || type_.id() == DALI_NO_TYPE),
                  make_string("set_type cannot be used to change the current type - it is not "
                              "allowed to cause allocations. Currently set type: '",
                              type_.id(), "' trying to set: '", new_type_id,
                              "'. You may change the current type using Resize or by"
                              " calling Reset first."));
-    if (new_type_id == type_.id()) return;
     const TypeInfo &new_type = TypeTable::GetTypeInfo(new_type_id);
 
     size_t new_num_bytes = size_ * new_type.size();

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -646,24 +646,24 @@ class DLL_PUBLIC TensorList {
     return {data_.capacity()};
   }
 
-  /**
-   * @brief Set the type of the TensorList. The type needs to be set before calling
-   * the Resize function that gives the shape. Type can be changed, if the current storage
-   * is not big enough, the memory will be reallocated.
+  /** @defgroup SetTypeFunctions Type setting functions.
+   *
+   * Set the type of the current batch. It must be set before calling Resize(shape).
+   * It cannot be used to change the type after allocation happened.
+   *
+   * Resize(shape, new_type) can be used without prior set_type call or to request a different type
+   * after allocation.
+   * @{
    */
   inline void set_type(const DALIDataType new_type_id) {
     data_.set_type(new_type_id);
   }
 
-  /**
-   * @brief Set the type of the TensorList. The type needs to be set before calling
-   * the Resize function that gives the shape. Type can be changed, if the current storage
-   * is not big enough, the memory will be reallocated.
-   */
   template <typename T>
   inline void set_type() {
     data_.set_type(TypeTable::GetTypeId<T>());
   }
+  /** @} */  // end of SetTypeFunctions
 
   /**
    * @brief Sets the type of allocation (pinned/non-pinned) for CPU TensorList

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -646,14 +646,17 @@ class DLL_PUBLIC TensorList {
     return {data_.capacity()};
   }
 
-  /** @defgroup SetTypeFunctions Type setting functions.
-   *
-   * Set the type of the current batch. It must be set before calling Resize(shape).
-   * It cannot be used to change the type after allocation happened.
-   *
-   * Resize(shape, new_type) can be used without prior set_type call or to request a different type
-   * after allocation.
+  /**
+   * @name Type setting functions.
    * @{
+   */
+  /**
+   * @brief Set the type of the current batch. It must be set before calling
+   * Resize(const TensorListShape<> &). It cannot be used to change the type after allocation
+   * happened.
+   *
+   * Resize(const TensorListShape<> &, DALIDataType) can be used without prior set_type call or to
+   * request a different type after allocation.
    */
   inline void set_type(const DALIDataType new_type_id) {
     data_.set_type(new_type_id);
@@ -663,7 +666,7 @@ class DLL_PUBLIC TensorList {
   inline void set_type() {
     data_.set_type(TypeTable::GetTypeId<T>());
   }
-  /** @} */  // end of SetTypeFunctions
+  /** @} */
 
   /**
    * @brief Sets the type of allocation (pinned/non-pinned) for CPU TensorList

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -442,7 +442,21 @@ TYPED_TEST(TensorListTest, TestCopyEmpty) {
   ASSERT_EQ(tl._num_elements(), tl2._num_elements());
 }
 
-TYPED_TEST(TensorListTest, TestTypeChangeSameSize) {
+TYPED_TEST(TensorListTest, TestTypeChangeError) {
+  TensorList<TypeParam> tensor_list;
+  auto shape = this->GetRandShape();
+
+  tensor_list.set_type(DALI_INT32);
+  tensor_list.Resize(shape);
+  ASSERT_NE(tensor_list.template mutable_tensor<int32_t>(0), nullptr);
+
+  ASSERT_THROW(tensor_list.set_type(DALI_FLOAT), std::runtime_error);
+
+  tensor_list.Resize(shape, DALI_FLOAT);
+  ASSERT_NE(tensor_list.template mutable_tensor<float>(0), nullptr);
+}
+
+TYPED_TEST(TensorListTest, TestTypeChange) {
   TensorList<TypeParam> tensor_list;
 
   // Setup shape and offsets
@@ -450,79 +464,45 @@ TYPED_TEST(TensorListTest, TestTypeChangeSameSize) {
   vector<Index> offsets;
 
   this->SetupTensorList(&tensor_list, shape, &offsets);
+
+  DALIDataType initial_type = DALI_FLOAT;
+  std::array<DALIDataType, 4> types = {DALI_FLOAT, DALI_INT32, DALI_UINT8, DALI_FLOAT64};
+  const auto *base_ptr = unsafe_raw_data(tensor_list);
+  size_t nbytes = shape.num_elements() * sizeof(float);
 
   // Save the pointers
   std::vector<const void *> ptrs;
   for (int i = 0; i < tensor_list.num_samples(); i++) {
     ptrs.push_back(tensor_list.raw_tensor(i));
   }
-  size_t nbytes = tensor_list.nbytes();
 
-  // Change the data type
-  tensor_list.template set_type<int>();
+  for (auto new_type : types) {
+    if (initial_type != new_type) {
+      // Simply changing the type of the buffer is not allowed
+      ASSERT_THROW(tensor_list.set_type(new_type), std::runtime_error);
+      tensor_list.Resize(shape, new_type);
+    }
 
-  // Check the internals
-  ASSERT_EQ(tensor_list.num_samples(), shape.size());
-  for (int i = 0; i < tensor_list.num_samples(); ++i) {
-    ASSERT_EQ(ptrs[i], tensor_list.raw_tensor(i));
-    ASSERT_EQ(tensor_list.tensor_shape(i), shape[i]);
-    ASSERT_EQ(tensor_list.tensor_offset(i), offsets[i]);
+    // Check the internals
+    ASSERT_EQ(tensor_list.num_samples(), shape.num_samples());
+    ASSERT_EQ(tensor_list.shape(), shape);
+    ASSERT_EQ(tensor_list.sample_dim(), shape.sample_dim());
+    ASSERT_EQ(tensor_list.type(), new_type);
+    for (int i = 0; i < tensor_list.num_samples(); ++i) {
+      ASSERT_NE(tensor_list.raw_tensor(i), nullptr);
+      ASSERT_EQ(tensor_list.tensor_shape(i), shape[i]);
+      ASSERT_EQ(tensor_list.tensor_offset(i), offsets[i]);
+    }
+
+    // The side-effects of only reallocating when we need a bigger buffer, we may use padding
+    if (TypeTable::GetTypeInfo(new_type).size() <= TypeTable::GetTypeInfo(initial_type).size()) {
+      ASSERT_EQ(unsafe_raw_data(tensor_list), base_ptr);
+    }
+
+    ASSERT_EQ(nbytes / TypeTable::GetTypeInfo(initial_type).size() *
+                  TypeTable::GetTypeInfo(new_type).size(),
+              tensor_list.nbytes());
   }
-
-  // No memory allocation should have occurred
-  ASSERT_EQ(nbytes, tensor_list.nbytes());
-}
-
-TYPED_TEST(TensorListTest, TestTypeChangeSmaller) {
-  TensorList<TypeParam> tensor_list;
-
-  // Setup shape and offsets
-  auto shape = this->GetRandShape();
-  vector<Index> offsets;
-
-  this->SetupTensorList(&tensor_list, shape, &offsets);
-
-  size_t nbytes = tensor_list.nbytes();
-  const auto *base_ptr = unsafe_raw_data(tensor_list);
-
-  // Change the data type to something smaller
-  tensor_list.template set_type<uint8>();
-
-  // Check the internals
-  ASSERT_EQ(tensor_list.num_samples(), shape.size());
-  for (int i = 0; i < tensor_list.num_samples(); ++i) {
-    ASSERT_EQ(unsafe_raw_data(tensor_list), base_ptr);
-    ASSERT_EQ(tensor_list.tensor_shape(i), shape[i]);
-    ASSERT_EQ(tensor_list.tensor_offset(i), offsets[i]);
-  }
-
-  // nbytes should have reduced by a factor of 4
-  ASSERT_EQ(nbytes / sizeof(float) * sizeof(uint8), tensor_list.nbytes());
-}
-
-TYPED_TEST(TensorListTest, TestTypeChangeLarger) {
-  TensorList<TypeParam> tensor_list;
-
-  // Setup shape and offsets
-  auto shape = this->GetRandShape();
-  vector<Index> offsets;
-
-  this->SetupTensorList(&tensor_list, shape, &offsets);
-
-  size_t nbytes = tensor_list.nbytes();
-
-  // Change the data type to something larger
-  tensor_list.template set_type<double>();
-
-  // Check the internals
-  ASSERT_EQ(tensor_list.num_samples(), shape.size());
-  for (int i = 0; i < tensor_list.num_samples(); ++i) {
-    ASSERT_EQ(tensor_list.tensor_shape(i), shape[i]);
-    ASSERT_EQ(tensor_list.tensor_offset(i), offsets[i]);
-  }
-
-  // nbytes should have increased by a factor of 2
-  ASSERT_EQ(nbytes / sizeof(float) * sizeof(double), tensor_list.nbytes());
 }
 
 TYPED_TEST(TensorListTest, DeviceIdPropagationMultiGPU) {

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -446,6 +446,8 @@ TYPED_TEST(TensorListTest, TestTypeChangeError) {
   TensorList<TypeParam> tensor_list;
   auto shape = this->GetRandShape();
 
+  tensor_list.set_type(DALI_UINT8);
+  tensor_list.set_type(DALI_FLOAT);
   tensor_list.set_type(DALI_INT32);
   tensor_list.Resize(shape);
   ASSERT_NE(tensor_list.template mutable_tensor<int32_t>(0), nullptr);

--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -618,6 +618,8 @@ TYPED_TEST(TensorTest, TestTypeChangeError) {
   Tensor<TypeParam> tensor;
   TensorShape<> shape = { 200, 300, 3 };
 
+  tensor.set_type(DALI_UINT8);
+  tensor.set_type(DALI_FLOAT);
   tensor.set_type(DALI_INT32);
   tensor.Resize(shape);
   ASSERT_NE(tensor.template mutable_data<int32_t>(), nullptr);

--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include <numeric>
+#include <stdexcept>
 
 #include "dali/core/common.h"
 #include "dali/core/mm/malloc_resource.h"
@@ -171,21 +172,13 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeNoAlloc) {
   ASSERT_TRUE(IsType<NoType>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
-  t.template set_type<int16>();
+  t.template set_type<float>();
 
   ASSERT_EQ(t.raw_data(), source_data.data());
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
   ASSERT_EQ(t.shape(), empty_tensor_shape());
-  ASSERT_TRUE(IsType<int16>(t.type()));
-  ASSERT_TRUE(t.shares_data());
-
-  // Kind of exception safety test
-  ASSERT_EQ(t.raw_data(), source_data.data());
-  ASSERT_EQ(t.size(), 0);
-  ASSERT_EQ(t.nbytes(), 0);
-  ASSERT_EQ(t.shape(), empty_tensor_shape());
-  ASSERT_TRUE(IsType<int16>(t.type()));
+  ASSERT_TRUE(IsType<float>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
   t.template set_type<float>();
@@ -198,7 +191,17 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeNoAlloc) {
   ASSERT_TRUE(IsType<float>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
+  t.Resize(shape, DALI_INT16);
+
+  ASSERT_EQ(t.raw_data(), source_data.data());
+  ASSERT_EQ(t.size(), size);
+  ASSERT_EQ(t.nbytes(), size*sizeof(int16_t));
+  ASSERT_EQ(t.shape(), shape);
+  ASSERT_TRUE(IsType<int16_t>(t.type()));
+  ASSERT_TRUE(t.shares_data());
+
   t.Reset();
+
   ASSERT_EQ(t.raw_data(), nullptr);
   ASSERT_EQ(t.size(), 0);
   ASSERT_EQ(t.nbytes(), 0);
@@ -245,8 +248,8 @@ TYPED_TEST(TensorTest, TestGetBytesTypeSizeAlloc) {
   ASSERT_TRUE(IsType<double>(t.type()));
   ASSERT_TRUE(t.shares_data());
 
-  t.template set_type<float>();
-  t.Resize(shape);
+  // We still can Resize to this allocation
+  t.Resize(shape, DALI_FLOAT);
 
   ASSERT_EQ(t.raw_data(), source_data.data());
   ASSERT_EQ(t.size(), size);
@@ -611,6 +614,20 @@ TYPED_TEST(TensorTest, TestResizeZeroSize) {
   ASSERT_EQ(tensor.ndim(), shape.size());
 }
 
+TYPED_TEST(TensorTest, TestTypeChangeError) {
+  Tensor<TypeParam> tensor;
+  TensorShape<> shape = { 200, 300, 3 };
+
+  tensor.set_type(DALI_INT32);
+  tensor.Resize(shape);
+  ASSERT_NE(tensor.template mutable_data<int32_t>(), nullptr);
+
+  ASSERT_THROW(tensor.set_type(DALI_FLOAT), std::runtime_error);
+
+  tensor.Resize(shape, DALI_FLOAT);
+  ASSERT_NE(tensor.template mutable_data<float>(), nullptr);
+}
+
 TYPED_TEST(TensorTest, TestTypeChange) {
   Tensor<TypeParam> tensor;
 
@@ -618,58 +635,34 @@ TYPED_TEST(TensorTest, TestTypeChange) {
   TensorShape<> shape = { 4, 480, 640, 3 };
   tensor.Resize(shape, DALI_FLOAT);
 
-  // Verify the settings
-  ASSERT_NE(tensor.template mutable_data<float>(), nullptr);
-  size_t num_elements = volume(shape);
-  ASSERT_EQ(tensor.size(), volume(shape));
-  ASSERT_EQ(tensor.ndim(), shape.size());
-  for (int i = 0; i < shape.size(); ++i) {
-    ASSERT_EQ(tensor.dim(i), shape[i]);
+  DALIDataType current_type = DALI_FLOAT;
+  std::array<DALIDataType, 4> types = {DALI_FLOAT, DALI_INT32, DALI_UINT8, DALI_FLOAT64};
+  const auto *ptr = tensor.raw_data();
+
+  for (auto new_type : types) {
+    if (current_type != new_type) {
+      // Simply changing the type of the buffer is not allowed
+      ASSERT_THROW(tensor.set_type(new_type), std::runtime_error);
+      tensor.Resize(shape, new_type);
+      current_type = new_type;
+    }
+
+    // The side-effects of only reallocating when we need a bigger buffer, but we may use padding
+    if (TypeTable::GetTypeInfo(current_type).size() <= sizeof(float)) {
+      ASSERT_EQ(ptr, tensor.raw_data());
+    }
+
+    // Verify the settings
+    ASSERT_NE(tensor.raw_data(), nullptr);
+    ASSERT_EQ(tensor.shape(), shape);
+    ASSERT_EQ(tensor.size(), volume(shape));
+    ASSERT_EQ(tensor.ndim(), shape.size());
+    ASSERT_EQ(tensor.type(), current_type);
+    for (int i = 0; i < shape.size(); ++i) {
+      ASSERT_EQ(tensor.dim(i), shape[i]);
+    }
+    ASSERT_EQ(volume(shape) * TypeTable::GetTypeInfo(current_type).size(), tensor.nbytes());
   }
-  ASSERT_EQ(num_elements * sizeof(float), tensor.nbytes());
-
-  // Save the pointer
-  const void *source_data = tensor.raw_data();
-
-  // Change the type of the buffer
-  tensor.template set_type<int>();
-
-  // Verify the settings
-  ASSERT_EQ(tensor.size(), volume(shape));
-  ASSERT_EQ(tensor.ndim(), shape.size());
-  for (int i = 0; i < shape.size(); ++i) {
-    ASSERT_EQ(tensor.dim(i), shape[i]);
-  }
-
-  // No re-allocation should have occured
-  ASSERT_EQ(source_data, tensor.raw_data());
-  ASSERT_EQ(num_elements * sizeof(int), tensor.nbytes());
-
-  // Change the type to a smaller type
-  tensor.template set_type<uint8>();
-
-  // Verify the settings
-  ASSERT_EQ(tensor.size(), volume(shape));
-  ASSERT_EQ(tensor.ndim(), shape.size());
-  for (int i = 0; i < shape.size(); ++i) {
-    ASSERT_EQ(tensor.dim(i), shape[i]);
-  }
-
-  // No re-allocation should have occured
-  ASSERT_EQ(source_data, tensor.raw_data());
-  ASSERT_EQ(num_elements * sizeof(uint8), tensor.nbytes());
-
-  // Change the type to a larger type
-  tensor.template set_type<double>();
-
-  // Verify the settings
-  ASSERT_EQ(tensor.size(), volume(shape));
-  ASSERT_EQ(tensor.ndim(), shape.size());
-  for (int i = 0; i < shape.size(); ++i) {
-    ASSERT_EQ(tensor.dim(i), shape[i]);
-  }
-
-  ASSERT_EQ(num_elements * sizeof(double), tensor.nbytes());
 }
 
 TYPED_TEST(TensorTest, TestSubspaceTensor) {

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -314,7 +314,7 @@ void TensorVector<Backend>::SetSize(int new_size) {
 template <typename Backend>
 void TensorVector<Backend>::set_type(DALIDataType new_type_id) {
   DALI_ENFORCE(new_type_id != DALI_NO_TYPE, "new_type must be valid type.");
-  DALI_ENFORCE(type_.id() == new_type_id || !has_data(),
+  DALI_ENFORCE(type_.id() == new_type_id || (!has_data() || type_.id() == DALI_NO_TYPE),
                make_string("set_type cannot be used to change the current type - it is not "
                            "allowed to cause allocations. Currently set type: '",
                            type_.id(), "' trying to set: '", new_type_id,

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -314,7 +314,7 @@ void TensorVector<Backend>::SetSize(int new_size) {
 template <typename Backend>
 void TensorVector<Backend>::set_type(DALIDataType new_type_id) {
   DALI_ENFORCE(new_type_id != DALI_NO_TYPE, "new_type must be valid type.");
-  DALI_ENFORCE(type_.id() == new_type_id || type_.id() == DALI_NO_TYPE,
+  DALI_ENFORCE(type_.id() == new_type_id || !has_data(),
                make_string("set_type cannot be used to change the current type - it is not "
                            "allowed to cause allocations. Currently set type: '",
                            type_.id(), "' trying to set: '", new_type_id,

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -314,14 +314,14 @@ void TensorVector<Backend>::SetSize(int new_size) {
 template <typename Backend>
 void TensorVector<Backend>::set_type(DALIDataType new_type_id) {
   DALI_ENFORCE(new_type_id != DALI_NO_TYPE, "new_type must be valid type.");
+  if (type_.id() == new_type_id)
+    return;
   DALI_ENFORCE(type_.id() == new_type_id || (!has_data() || type_.id() == DALI_NO_TYPE),
                make_string("set_type cannot be used to change the current type - it is not "
                            "allowed to cause allocations. Currently set type: '",
                            type_.id(), "' trying to set: '", new_type_id,
                            "'. You may change the current type using Resize or by"
                            " calling Reset first."));
-  if (type_.id() == new_type_id)
-    return;
   type_ = TypeTable::GetTypeInfo(new_type_id);
   tl_->set_type(new_type_id);
   for (auto t : tensors_) {

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -239,14 +239,13 @@ class DLL_PUBLIC TensorVector {
    */
   void SetSize(int new_size);
 
-   /** @defgroup SetupLikeFunctions Cloning setup functions.
-   *
-   * Setup all the batch properties of this TensorVector the same way as the provided tensor:
+  /**
+   * @name Setup all the batch properties of this TensorVector the same way as the provided tensor:
    *
    * Precondition: the TensorVector should not have data.
    * Configures: type, layout, pinned, order and dimensionality.
-   * @{
    */
+  // @{
   void SetupLike(const Tensor<Backend> &sample) {
     SetupLikeImpl(sample);
   }
@@ -258,16 +257,19 @@ class DLL_PUBLIC TensorVector {
   void SetupLike(const TensorList<Backend> &other) {
     SetupLikeImpl(other);
   }
-  /** @} */  // end of SetupLikeFunctions
+  // @}
 
-  /** @defgroup SetTypeFunctions Type setting functions.
-   *
-   * Set the type of the current batch. The type needs to be set before calling
-   * the Resize(shape) function. It cannot be used to change the type after allocation happened.
-   *
-   * Resize(shape, new_type) can be used without prior set_type call or to request a different type
-   * after allocation.
+  /**
+   * @name Type setting functions.
    * @{
+   */
+  /**
+   * @brief Set the type of the current batch. The type needs to be set before calling
+   * the Resize(const TensorListShape<> &) function. It cannot be used to change the type after
+   * allocation happened.
+   *
+   * Resize(const TensorListShape<> &, DALIDataType) can be used without prior set_type call or to
+   * request a different type after allocation.
    */
   void set_type(DALIDataType new_type);
 
@@ -275,7 +277,7 @@ class DLL_PUBLIC TensorVector {
   void set_type() {
     set_type(TypeTable::GetTypeId<T>());
   }
-  /** @} */  // end of SetTypeFunctions
+  /** @} */
 
 
   DALIDataType type() const;

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -239,13 +239,14 @@ class DLL_PUBLIC TensorVector {
    */
   void SetSize(int new_size);
 
-  /**
-   * @name Setup all the batch properties of this TensorVector the same way as the provided tensor:
+   /** @defgroup SetupLikeFunctions Cloning setup functions.
+   *
+   * Setup all the batch properties of this TensorVector the same way as the provided tensor:
    *
    * Precondition: the TensorVector should not have data.
    * Configures: type, layout, pinned, order and dimensionality.
+   * @{
    */
-  // @{
   void SetupLike(const Tensor<Backend> &sample) {
     SetupLikeImpl(sample);
   }
@@ -257,14 +258,25 @@ class DLL_PUBLIC TensorVector {
   void SetupLike(const TensorList<Backend> &other) {
     SetupLikeImpl(other);
   }
-  // @}
+  /** @} */  // end of SetupLikeFunctions
 
+  /** @defgroup SetTypeFunctions Type setting functions.
+   *
+   * Set the type of the current batch. The type needs to be set before calling
+   * the Resize(shape) function. It cannot be used to change the type after allocation happened.
+   *
+   * Resize(shape, new_type) can be used without prior set_type call or to request a different type
+   * after allocation.
+   * @{
+   */
   void set_type(DALIDataType new_type);
 
   template <typename T>
   void set_type() {
     set_type(TypeTable::GetTypeId<T>());
   }
+  /** @} */  // end of SetTypeFunctions
+
 
   DALIDataType type() const;
 


### PR DESCRIPTION
## Category: Refactoring, Breaking Change
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Disallow using set_type to change the underlying
type of existing allocation in the buffer. 
It was possible to cause a new allocation to happen
this way (when changing to bigger type), and it is
now disallowed.
Type can still be changed when explicitly requesting
both new shape and new type via Resize.
The type changing behaviour can be found only in tests.

## Additional information:

### Affected modules and functionalities:
TensorVector, Buffer and subclasses.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
    - the tests for changing types were adjusted to expect error.
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
