### PR TITLE
Adjust Doxygen configuration

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -422,7 +422,7 @@ EXTRACT_ALL            = YES
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 
 # If the EXTRACT_PACKAGE tag is set to YES, all members with package or internal
 # scope will be included in the documentation.

--- a/Doxyfile
+++ b/Doxyfile
@@ -341,7 +341,7 @@ IDL_PROPERTY_SUPPORT   = YES
 # all members of a group must be documented explicitly.
 # The default value is: NO.
 
-DISTRIBUTE_GROUP_DOC   = NO
+DISTRIBUTE_GROUP_DOC   = YES
 
 # If one adds a struct or class to a group and this option is enabled, then also
 # any nested class or struct is added to the same group. By default this option
@@ -416,7 +416,7 @@ LOOKUP_CACHE_SIZE      = 0
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.

--- a/dali/kernels/common/join/tensor_join_cpu.h
+++ b/dali/kernels/common/join/tensor_join_cpu.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ ConcatenateTensors(TensorView<StorageCPU, T> output,
  */
 template<typename T, bool new_axis = true, int dims = -1>
 struct TensorJoinCPU {
-  ///@{
+  /** @{ */
   /**
    * @param in_shapes Shapes of input tensors.
    * @param axis Axis, along which tensors will be joined.
@@ -127,6 +127,10 @@ struct TensorJoinCPU {
   }
 
 
+  /**
+   * @param in Input tensors from which shapes are obtained.
+   * @param axis Axis, along which tensors will be joined.
+   */
   KernelRequirements Setup(KernelContext &ctx, span<const InTensorCPU<T, dims>> in, int axis) {
     std::vector<TensorShape<>> in_shapes(in.size());
     for (int i = 0; i < in.size(); i++) {
@@ -134,7 +138,7 @@ struct TensorJoinCPU {
     }
     return Setup(ctx, make_span(in_shapes), axis);
   }
-  ///@}
+  /** @} */
 
   static constexpr int output_dims = (dims == DynamicDimensions ? DynamicDimensions :
                                       (new_axis ? dims + 1 : dims));
@@ -166,7 +170,7 @@ struct TensorJoinCPU {
   TensorShape<dims> output_shape_;
 };
 
-///@{
+/** @{ */
 /**
  * @see TensorJoinCPU
  */
@@ -175,7 +179,7 @@ using TensorStackCPU = TensorJoinCPU<T, true, ndims>;
 
 template<typename T, int ndims = -1>
 using TensorConcatCPU = TensorJoinCPU<T, false, ndims>;
-///@}
+/** @} */
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/normalize/normalize_gpu.h
+++ b/dali/kernels/normalize/normalize_gpu.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ class DLL_PUBLIC NormalizeGPU {
                            bool scalar_scale,
                            bool scale_is_stddev);
 
-  ///@{
+  /** @{ */
   /**
    * @brief Normalizes the data with base and scale given as tensor lists
    *
@@ -149,7 +149,7 @@ class DLL_PUBLIC NormalizeGPU {
            const OutListGPU<Out> &out, const InListGPU<In> &in,
            float base, float scale,
            float global_scale = 1, float shift = 0, float epsilon = 0);
-  ///@}
+  /** @} */
 
  private:
   struct Impl;

--- a/dali/operators/image/remap/warp.h
+++ b/dali/operators/image/remap/warp.h
@@ -229,11 +229,10 @@ class Warp : public SequenceOperator<Backend> {
   const OpSpec &Spec() const { return this->spec_; }
 
  private:
-  /** @defgroup WarpStaticType Dynamic to static type routing */
-
-  /** @addtogroup WarpStaticType */
-  /** @{ */
-
+  /**
+   * @name Dynamic to static type routing
+   * @{
+   */
   template <typename F>
   void ToStaticTypeEx(std::tuple<> &&, F &&functor) {
     DALI_FAIL(make_string("Unsupported input/output types for the operator: ",
@@ -249,6 +248,9 @@ class Warp : public SequenceOperator<Backend> {
       ToStaticTypeEx(std::tuple<TypePairs...>(), std::forward<F>(functor));
   }
 
+  /**
+   * @brief Apply pairs from SupportedTypes list to the functor
+   */
   template <typename F>
   void ToStaticType(F &&functor) {
     using supported_types = typename MyType::SupportedTypes;

--- a/dali/operators/image/remap/warp.h
+++ b/dali/operators/image/remap/warp.h
@@ -229,10 +229,10 @@ class Warp : public SequenceOperator<Backend> {
   const OpSpec &Spec() const { return this->spec_; }
 
  private:
-  /// @defgroup WarpStaticType Dynamic to static type routing
+  /** @defgroup WarpStaticType Dynamic to static type routing */
 
-  /// @addtogroup WarpStaticType
-  /// @{
+  /** @addtogroup WarpStaticType */
+  /** @{ */
 
   template <typename F>
   void ToStaticTypeEx(std::tuple<> &&, F &&functor) {
@@ -255,7 +255,7 @@ class Warp : public SequenceOperator<Backend> {
     ToStaticTypeEx(supported_types(), std::forward<F>(functor));
   }
 
-  /// @}
+  /** @} */
  public:
   explicit Warp(const OpSpec &spec) : SequenceOperator<Backend>(spec) {
     border_clamp_ = !spec.HasArgument("fill_value");

--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -38,8 +38,8 @@ class SampleViewBase {
  public:
   /**
    * @name Get the underlying pointer to data
+   * @{
    */
-  // @{
   /**
    * @brief Return an un-typed pointer to the underlying storage.
    */
@@ -84,7 +84,7 @@ class SampleViewBase {
             ". To set type for the Buffer use 'set_type<T>()' or Resize(shape, type) first."));
     return static_cast<const T *>(data_);
   }
-  //@}
+  /** @} */
 
   /**
    * @brief Get the shape of the sample

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -240,12 +240,17 @@ class DLL_PUBLIC TensorVector {
   void SetSize(int new_size);
 
   /**
-   * @name Setup all the batch properties of this TensorVector the same way as the provided tensor:
+   * @name Configuration cloning
+   * @{
+   */
+  /**
+   * @brief Setup all the batch properties of this TensorVector the same way as the provided tensor
+   * or batch.
    *
    * Precondition: the TensorVector should not have data.
+   *
    * Configures: type, layout, pinned, order and dimensionality.
    */
-  // @{
   void SetupLike(const Tensor<Backend> &sample) {
     SetupLikeImpl(sample);
   }
@@ -257,7 +262,7 @@ class DLL_PUBLIC TensorVector {
   void SetupLike(const TensorList<Backend> &other) {
     SetupLikeImpl(other);
   }
-  // @}
+  /** @} */
 
   void set_type(DALIDataType new_type);
 

--- a/dali/pipeline/pipeline.h
+++ b/dali/pipeline/pipeline.h
@@ -260,7 +260,7 @@ class DLL_PUBLIC Pipeline {
    */
   DLL_PUBLIC OpNode * GetOperatorNode(const std::string& name);
 
-  ///@{
+  /** @{ */
   /**
    * @brief Performs some checks on the user-constructed pipeline, setups data
    * for intermediate results, and marks as ready for execution. The input
@@ -268,7 +268,7 @@ class DLL_PUBLIC Pipeline {
    */
   DLL_PUBLIC void Build(const std::vector<std::pair<string, string>>& output_names);
   DLL_PUBLIC void Build(std::vector<PipelineOutputDesc> output_descs);
-  ///@}
+  /** @} */
 
   /**
    * @brief Build a pipeline from deserialized output (name, device) pairs
@@ -333,7 +333,7 @@ class DLL_PUBLIC Pipeline {
     prefetch_queue_depth_ = QueueSizes(cpu_size, gpu_size);
   }
 
-  ///@{
+  /** @{ */
   /**
    * @brief Set descriptors of the outputs of the pipeline. Used to update the graph without
    * running the executor and for pipeline serialization.
@@ -345,7 +345,7 @@ class DLL_PUBLIC Pipeline {
    * set, the function will fail.
    */
   void SetOutputDescs(const vector<std::pair<string /* name */, string /* device */>> &out_names);
-  ///@}
+  /** @} */
 
   /**
    * @brief Run the cpu portion of the pipeline.
@@ -402,13 +402,13 @@ class DLL_PUBLIC Pipeline {
   DLL_PUBLIC void SaveGraphToDotFile(const std::string &filename, bool show_tensors = false,
                                      bool show_ids = false, bool use_colors = false);
 
-  /// @{
+  /** @{ */
   /**
    * @brief Returns the maximum batch size that can be processed by the Pipeline
    */
   DLL_PUBLIC inline int batch_size() const { return max_batch_size_; }
   DLL_PUBLIC inline int max_batch_size() const { return max_batch_size_; }
-  /// @}
+  /** @} */
 
   /**
    * @brief Returns the map of (node name, reader meta) for all nodes that return a valid meta

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -136,9 +136,9 @@ class ArgumentWorkspace {
   friend const_iterator end(const ArgumentWorkspace&);
 };
 
-/// @{
+/** @{ */
 /**
- * Iterator-handling functions for ArgumentWorkspace
+ * @brief Iterator-handling functions for ArgumentWorkspace
  */
 inline ArgumentWorkspace::const_iterator begin(const ArgumentWorkspace& ws) {
   return ArgumentWorkspace::const_iterator{ws.argument_inputs_.begin()};
@@ -147,7 +147,7 @@ inline ArgumentWorkspace::const_iterator begin(const ArgumentWorkspace& ws) {
 inline ArgumentWorkspace::const_iterator end(const ArgumentWorkspace& ws) {
   return ArgumentWorkspace::const_iterator{ws.argument_inputs_.end()};
 }
-/// @}
+/** @} */
 
 /**
  * @brief WorkspaceBase is a base class of objects
@@ -185,7 +185,7 @@ class WorkspaceBase : public ArgumentWorkspace {
     gpu_outputs_index_.clear();
   }
 
-  /** @defgroup InputOutput Input and output APIs
+  /** @name Input and output APIs
    * Functions used to access inputs and outputs of the operator in its implementation.
    * The inputs are read-only while outputs can be modified.
    * @{
@@ -226,9 +226,9 @@ class WorkspaceBase : public ArgumentWorkspace {
   }
 
 
-  /** @} */  // end of InputOutput
+  /** @} */
 
-  /** @defgroup InputOutputInternal Internal API for input and output access
+  /** @name Internal API for input and output access
    * Functions allowing mutable access to both inputs and outputs that should not be used in
    * operator implementation.
    * @{
@@ -264,7 +264,7 @@ class WorkspaceBase : public ArgumentWorkspace {
     return OutputHandle(idx, Backend{});
   }
 
-  /** @} */  // end of InputOutputInternal
+  /** @} */
 
   /**
    * Returns shape of input at given index

--- a/include/dali/c_api.h
+++ b/include/dali/c_api.h
@@ -101,7 +101,10 @@ typedef struct {
  */
 DLL_PUBLIC void daliInitialize();
 
-/// @{
+/**
+ * @name Create DALI Pipeline via deserialization.
+ * @{
+ */
 /**
  * @brief Create DALI pipeline. Setting max_batch_size,
  * num_threads or device_id here overrides
@@ -124,8 +127,6 @@ DLL_PUBLIC void daliCreatePipeline(daliPipelineHandle *pipe_handle, const char *
 DLL_PUBLIC void daliDeserializeDefault(daliPipelineHandle *pipe_handle,
                                        const char *serialized_pipeline,
                                        int length);
-/// }@
-/// @{
 
 /**
  * Checks, if the pipeline given by the string can be deserialized. It can be assumed that the
@@ -136,7 +137,7 @@ DLL_PUBLIC void daliDeserializeDefault(daliPipelineHandle *pipe_handle,
  * @return 0, if the pipeline is serializable. 1 otherwise.
  */
 DLL_PUBLIC int daliIsDeserializable(const char* serialized_pipeline, int length);
-
+/** @} */
 
 enum {
   DALI_ext_default = 0,
@@ -169,6 +170,10 @@ enum {
 };
 
 /**
+ * @name Input batch size information
+ * @{
+ */
+/**
  * @brief Get the max batch size of a given pipeline.
  *
  * @param pipe_handle Pointer to pipeline handle
@@ -186,7 +191,12 @@ DLL_PUBLIC int daliGetMaxBatchSize(daliPipelineHandle *pipe_handle);
  */
 DLL_PUBLIC void daliSetExternalInputBatchSize(daliPipelineHandle *pipe_handle, const char *name,
                                               int batch_size);
+/** @} */
 
+/**
+ * @name Contiguous inputs
+ * @{
+ */
 /**
  * @brief Feed the data to ExternalSource as contiguous memory.
  *
@@ -236,9 +246,12 @@ daliSetExternalInput(daliPipelineHandle *pipe_handle, const char *name,
                      device_type_t device, const void *data_ptr,
                      dali_data_type_t data_type, const int64_t *shapes,
                      int sample_dim, const char *layout_str, unsigned int flags);
-///@}
-///@{
+/** @} */
 
+/**
+ * @name Sample inputs
+ * @{
+ */
 /**
  * @brief Feed the data to ExternalSource as a set of separate buffers.
  *
@@ -285,7 +298,7 @@ daliSetExternalInputTensors(daliPipelineHandle *pipe_handle, const char *name,
                             device_type_t device, const void *const *data_ptr,
                             dali_data_type_t data_type, const int64_t *shapes,
                             int64_t sample_dim, const char *layout_str, unsigned int flags);
-///@}
+/** @} */
 
 /**
  * @brief Get number of external inputs in the pipeline.

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -663,7 +663,7 @@ struct TensorListShapeBase {
   }
 
 
-  ///@{
+  /** @{ */
   /**
    * Append this TensorListShape with shapes from other TensorListShapes.
    */
@@ -703,7 +703,7 @@ struct TensorListShapeBase {
   void append(const std::vector<TensorListShape<sample_ndim>> &tlss) {
     append(make_cspan(tlss.data(), tlss.size()));
   }
-  ///@}
+  /** @} */
 
  protected:
   int sample_dim() const { return static_cast<const Derived *>(this)->sample_dim(); }

--- a/include/dali/core/tensor_view.h
+++ b/include/dali/core/tensor_view.h
@@ -481,7 +481,7 @@ struct TensorListView<Backend, DataType, DynamicDimensions>
   TensorListView &operator=(const TensorListView &) = default;
   TensorListView &operator=(TensorListView &&) = default;
 
-  //@{
+  /** @{ */
   /** @brief  Construction from contiguous memory */
 
   TensorListView(DataType *data, const std::vector<TensorShape<DynamicDimensions>> &shapes)
@@ -495,9 +495,9 @@ struct TensorListView<Backend, DataType, DynamicDimensions>
   TensorListView(DataType *data, TensorListShape<other_sample_ndim> &&shape)
       : Base(data, std::move(shape)) {}
 
-  //@}
+  /** @} */
 
-  //@{
+  /** @{ */
   /** @brief Construction from non-contiguous memory */
 
   TensorListView(DataType *const *data, const std::vector<TensorShape<DynamicDimensions>> &shapes)
@@ -519,9 +519,9 @@ struct TensorListView<Backend, DataType, DynamicDimensions>
   TensorListView(data_pointers_t &&data, TensorListShape<other_sample_ndim> &&shape)
       : Base(std::move(data), std::move(shape)) {}
 
-  //@}
+  /** @} */
 
-  //@{
+  /** @{ */
   /** @brief Implicit conversion */
 
   template <int other_sample_ndim, typename U>
@@ -536,7 +536,7 @@ struct TensorListView<Backend, DataType, DynamicDimensions>
     detail::check_implicit_conversion<U, DataType>();
   }
 
-  //@}
+  /** @} */
 };
 
 template <typename Backend, typename DataType, int sample_ndim>
@@ -549,7 +549,7 @@ struct TensorListView : TensorListViewBase<Backend, DataType, sample_ndim> {
   TensorListView &operator=(const TensorListView &) = default;
   TensorListView &operator=(TensorListView &&) = default;
 
-  //@{
+  /** @{ */
   /** @brief Construction from contiguous memory */
 
   TensorListView(std::nullptr_t, const std::vector<TensorShape<sample_ndim>> &shapes)
@@ -563,9 +563,9 @@ struct TensorListView : TensorListViewBase<Backend, DataType, sample_ndim> {
   TensorListView(std::nullptr_t, TensorListShape<other_sample_ndim> &&shape)
       : Base(std::move(shape)) {}
 
-  //@}
+  /** @} */
 
-  //@{
+  /** @{ */
   /** @brief Construction from contiguous memory */
 
   TensorListView(DataType *data, const std::vector<TensorShape<sample_ndim>> &shapes)
@@ -579,9 +579,9 @@ struct TensorListView : TensorListViewBase<Backend, DataType, sample_ndim> {
   TensorListView(DataType *data, TensorListShape<other_sample_ndim> &&shape)
       : Base(data, std::move(shape)) {}
 
-  //@}
+  /** @} */
 
-  //@{
+  /** @{ */
   /** @brief Construction from non-contiguous memory */
 
   TensorListView(DataType *const *data, const std::vector<TensorShape<sample_ndim>> &shapes)
@@ -601,9 +601,9 @@ struct TensorListView : TensorListViewBase<Backend, DataType, sample_ndim> {
   TensorListView(data_pointers_t &&data, TensorListShape<sample_ndim> &&shape)
       : Base(std::move(data), std::move(shape)) {}
 
-  //@}
+  /** @} */
 
-  //@{
+  /** @{ */
   /** @brief Implicit conversion */
 
   template <typename U, int other_sample_ndim>
@@ -619,7 +619,7 @@ struct TensorListView : TensorListViewBase<Backend, DataType, sample_ndim> {
     detail::check_implicit_conversion<U, DataType>();
   }
 
-  //@}
+  /** @} */
 };
 
 struct StorageCPU;
@@ -700,8 +700,8 @@ TensorListView<StorageGPU, T, ndim> make_tensor_list_gpu(T *const *data,
   return { data, std::move(shape) };
 }
 
+/** @{ */
 /**
- * @{
  * @brief Get a subtensor by slicing along the outermost dimension at position `pos`
  *
  * @details Produces a tensor with the outermost extent removed,
@@ -733,9 +733,7 @@ subtensor(TensorView<StorageBackend, DataType, DynamicDimensions> source, int64_
   DataType *data = source.data + pos * volume(shape);
   return make_tensor<StorageBackend>(data, std::move(shape));
 }
-/**
- * @}
- */
+/** @} */
 
 /**
  * @brief Merges a dimension with the next one

--- a/include/dali/operators.h
+++ b/include/dali/operators.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 #define DALI_OPERATORS_H_
 
 #ifdef __cplusplus
-///@{
+
 namespace dali {
 /**
  * @brief Functions to initialize operators in DALI
@@ -44,7 +44,7 @@ int GetNvjpegVersion();
 
 }  // namespace dali
 extern "C" void daliInitOperators();
-///@}
+
 #else
 /**
  * @brief Functions to initialize operators in DALI


### PR DESCRIPTION
## Category: **Other**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Extracted from #4071.

Replace the usage of `///` with `/** */` which is used
across the project.

Unify the usage of grouping directives.
The header should use either just `/** @{ */`
or additionaly @name or @defgroup.

  @name can be used for member functions, groups them,
  and keeps them inlined on class page.

  @defgroup can be used with free function or friend
  definitions, or other top level entities. It generates
  a dedicated page for the group.

The foother should use `/** @} */`

Set DISTRIBUTE_GROUP_DOC = YES - now the first docstring
in a group is replicated in the other members that didn't
provide a docstring.

Set EXTRACT_ALL = YES - now, all entities are automatically
documented - otherwise, for example, free functions were
ignored in file without @file documentation.
This enables most free-functions (for example C API)
and not just Classes and their members to be documented.

Set EXTRACT_PRIVATE = YES - 
The DALI C++ API is an internal backend API,
and the private functions tend to be documented
to aid the developers and the development.
It should be rendered into HTML version,
the method get the dedicated Private section.

## Additional information:

### Affected modules and functionalities:
Docs



### Key points relevant for the review:
:eyes: 

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [X] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
