### PR TITLE
Fix handling of TIFFs with palette

### DIFF
--- a/DALI_EXTRA_VERSION
+++ b/DALI_EXTRA_VERSION
@@ -1,1 +1,2 @@
-TODO
+65c7ecc81a574e2eae0894d61f41a2b96beb38f2
+

--- a/DALI_EXTRA_VERSION
+++ b/DALI_EXTRA_VERSION
@@ -1,1 +1,1 @@
-b1e5b56708faedcab7f8626ea954e455e6b7d98a
+TODO

--- a/dali/image/tiff.cc
+++ b/dali/image/tiff.cc
@@ -89,7 +89,7 @@ Image::Shape TiffImage::PeekShapeImpl(const uint8_t *encoded_buffer, size_t leng
         photometric_read = true;
       }
     }
-    if (width_read && height_read && nchannels_read && photometric_read)
+    if (width_read && height_read && photometric_read)
       break;
   }
 

--- a/dali/image/tiff.cc
+++ b/dali/image/tiff.cc
@@ -93,7 +93,7 @@ Image::Shape TiffImage::PeekShapeImpl(const uint8_t *encoded_buffer, size_t leng
       break;
   }
 
-  DALI_ENFORCE(width_read && height_read && (nchannels_read | photometric_read),
+  DALI_ENFORCE(width_read && height_read && (nchannels_read || photometric_read),
     "TIFF image dimensions haven't been peeked properly");
 
   return {height, width, nchannels};

--- a/dali/image/tiff.cc
+++ b/dali/image/tiff.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2018, 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,9 +22,11 @@ constexpr int COUNT_SIZE = 2;
 constexpr int ENTRY_SIZE = 12;
 constexpr int WIDTH_TAG = 256;
 constexpr int HEIGHT_TAG = 257;
+constexpr int PHOTOMETRIC_INTERPRETATION_TAG = 262;
 constexpr int SAMPLESPERPIXEL_TAG = 277;
 constexpr int TYPE_WORD = 3;
 constexpr int TYPE_DWORD = 4;
+constexpr int PHOTOMETRIC_PALETTE = 3;
 
 constexpr std::array<int, 4> le_header = {77, 77, 0, 42};
 
@@ -52,15 +54,14 @@ Image::Shape TiffImage::PeekShapeImpl(const uint8_t *encoded_buffer, size_t leng
 
   const auto ifd_offset = buffer.Read<uint32_t>(4);
   const auto entry_count = buffer.Read<uint16_t>(ifd_offset);
-  bool width_read = false, height_read = false, nchannels_read = false;
+  bool width_read = false, height_read = false, nchannels_read = false, photometric_read = false;
   int64_t width = 0, height = 0, nchannels = 0;
 
-  for (int entry_idx = 0;
-       entry_idx < entry_count && !(width_read && height_read && nchannels_read);
-       entry_idx++) {
+  for (int entry_idx = 0; entry_idx < entry_count; entry_idx++) {
     const auto entry_offset = ifd_offset + COUNT_SIZE + entry_idx * ENTRY_SIZE;
     const auto tag_id = buffer.Read<uint16_t>(entry_offset);
-    if (tag_id == WIDTH_TAG || tag_id == HEIGHT_TAG || tag_id == SAMPLESPERPIXEL_TAG) {
+    if (tag_id == WIDTH_TAG || tag_id == HEIGHT_TAG || tag_id == SAMPLESPERPIXEL_TAG
+        || tag_id == PHOTOMETRIC_INTERPRETATION_TAG) {
       const auto value_type = buffer.Read<uint16_t>(entry_offset + 2);
       const auto value_count = buffer.Read<uint32_t>(entry_offset + 4);
       DALI_ENFORCE(value_count == 1);
@@ -80,15 +81,20 @@ Image::Shape TiffImage::PeekShapeImpl(const uint8_t *encoded_buffer, size_t leng
       } else if (tag_id == HEIGHT_TAG) {
         height = value;
         height_read = true;
-      } else if (tag_id == SAMPLESPERPIXEL_TAG) {
+      } else if (tag_id == SAMPLESPERPIXEL_TAG && !photometric_read) {
         nchannels = value;
         nchannels_read = true;
+      } else if (tag_id == PHOTOMETRIC_INTERPRETATION_TAG && value == PHOTOMETRIC_PALETTE) {
+        nchannels = 3;
+        photometric_read = true;
       }
     }
+    if (width_read && height_read && nchannels_read && photometric_read)
+      break;
   }
 
-  DALI_ENFORCE(width_read && height_read && nchannels_read,
-    "TIFF image dims haven't been peeked properly");
+  DALI_ENFORCE(width_read && height_read && (nchannels_read | photometric_read),
+    "TIFF image dimensions haven't been peeked properly");
 
   return {height, width, nchannels};
 }

--- a/dali/image/tiff_libtiff.cc
+++ b/dali/image/tiff_libtiff.cc
@@ -261,10 +261,10 @@ TiffImage_Libtiff::TiffImage_Libtiff(const uint8_t *encoded_buffer,
   LIBTIFF_CALL(
     TIFFGetFieldDefaulted(tif_.get(), TIFFTAG_COMPRESSION, &compression_));
 
-  uint16_t photometric_interpretatation;
+  uint16_t photometric_interpretation;
   LIBTIFF_CALL(
-    TIFFGetFieldDefaulted(tif_.get(), TIFFTAG_PHOTOMETRIC, &photometric_interpretatation));
-  if (photometric_interpretatation == PHOTOMETRIC_PALETTE) {
+    TIFFGetFieldDefaulted(tif_.get(), TIFFTAG_PHOTOMETRIC, &photometric_interpretation));
+  if (photometric_interpretation == PHOTOMETRIC_PALETTE) {
     shape_[2] = 3;
     palette_ = true;
   }

--- a/dali/image/tiff_libtiff.cc
+++ b/dali/image/tiff_libtiff.cc
@@ -262,9 +262,8 @@ TiffImage_Libtiff::TiffImage_Libtiff(const uint8_t *encoded_buffer,
     TIFFGetFieldDefaulted(tif_.get(), TIFFTAG_COMPRESSION, &compression_));
 
   uint16_t photometric_interpretation;
-  LIBTIFF_CALL(
-    TIFFGetFieldDefaulted(tif_.get(), TIFFTAG_PHOTOMETRIC, &photometric_interpretation));
-  if (photometric_interpretation == PHOTOMETRIC_PALETTE) {
+  if (TIFFGetField(tif_.get(), TIFFTAG_PHOTOMETRIC, &photometric_interpretation) &&
+      photometric_interpretation == PHOTOMETRIC_PALETTE) {
     shape_[2] = 3;
     palette_ = true;
   }

--- a/dali/image/tiff_libtiff.cc
+++ b/dali/image/tiff_libtiff.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019, 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -260,6 +260,14 @@ TiffImage_Libtiff::TiffImage_Libtiff(const uint8_t *encoded_buffer,
     TIFFGetFieldDefaulted(tif_.get(), TIFFTAG_ROWSPERSTRIP, &rows_per_strip_));
   LIBTIFF_CALL(
     TIFFGetFieldDefaulted(tif_.get(), TIFFTAG_COMPRESSION, &compression_));
+
+  uint16_t photometric_interpretatation;
+  LIBTIFF_CALL(
+    TIFFGetFieldDefaulted(tif_.get(), TIFFTAG_PHOTOMETRIC, &photometric_interpretatation));
+  if (photometric_interpretatation == PHOTOMETRIC_PALETTE) {
+    shape_[2] = 3;
+    palette_ = true;
+  }
 }
 
 Image::Shape TiffImage_Libtiff::PeekShapeImpl(const uint8_t *encoded_buffer,
@@ -366,7 +374,8 @@ TiffImage_Libtiff::DecodeImpl(DALIImageType image_type,
 bool TiffImage_Libtiff::CanDecode(DALIImageType image_type) const {
   return !is_tiled_
       && bit_depth_ == 8
-      && orientation_ == ORIENTATION_TOPLEFT;
+      && orientation_ == ORIENTATION_TOPLEFT
+      && !palette_;
 }
 
 }  // namespace dali

--- a/dali/image/tiff_libtiff.cc
+++ b/dali/image/tiff_libtiff.cc
@@ -375,7 +375,7 @@ bool TiffImage_Libtiff::CanDecode(DALIImageType image_type) const {
   return !is_tiled_
       && bit_depth_ == 8
       && orientation_ == ORIENTATION_TOPLEFT
-      && !palette_;
+      && !palette_;  // We don't support decoding palette images in this implementation
 }
 
 }  // namespace dali

--- a/dali/image/tiff_libtiff.h
+++ b/dali/image/tiff_libtiff.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019, 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ class TiffImage_Libtiff : public GenericImage {
   uint16_t orientation_ = ORIENTATION_TOPLEFT;
   uint32_t rows_per_strip_ = 0xFFFFFFFF;
   uint16_t compression_ = COMPRESSION_NONE;
+  bool palette_ = false;
 };
 
 }  // namespace dali

--- a/dali/imgcodec/image_format_test.cc
+++ b/dali/imgcodec/image_format_test.cc
@@ -152,6 +152,11 @@ TEST_F(ImageFormatTest, Tiff) {
        TensorShape<>(423, 640, 3));
 }
 
+TEST_F(ImageFormatTest, Tiff_Palette) {
+  Test(testing::dali_extra_path() + "/db/single/tiff/0/cat-300572_640_palette.tiff", "tiff",
+       TensorShape<>(536, 640, 3));
+}
+
 TEST_F(ImageFormatTest, Pnm) {
   Test(testing::dali_extra_path() + "/db/single/pnm/0/cat-300572_640.pnm", "pnm",
        TensorShape<>(536, 640, 3));


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->

**Bug fix** (*non-breaking change which fixes an issue*)

## Description:

TIFF colors can be encoded with a palette, which is indicated by `PhotometricInterpretation` tag set to `3`. In such encoding, there is an RGB color palette provided and pixel values are just indices of colors in this palette.

DALI was ignoring the existence of palette and treating the indices as colors, producing single-channel, grayscale-like images.

![image](https://user-images.githubusercontent.com/34919255/180972154-11dc52e0-5ef5-4d9b-b2df-0677fd4f77e6.png)

This PR fixes this by:
- Fixing `PeekShapeImpl` in TIFF parsers (both libtiff-based and handwritten one) so that it reports 3 channels for palette images
- Making Libtiff codec fail for palette images, causing a fallback to OpenCV

## Additional information:

### Affected modules and functionalities:

### Key points relevant for the review:
This is the first python test for DALI I ever wrote, so I'd be grateful for any comments on that

### Tests:
Tests use https://github.com/NVIDIA/DALI_extra/pull/89

- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2907




