### PR TITLE
Remove video reader warning that a frame has been seen twice

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -525,8 +525,6 @@ void VideoLoader::read_file() {
   seek(file, req.frame);
 
   auto nonkey_frame_count = 0;
-  int frames_left = req.count;
-  std::vector<bool> frames_read(frames_left, false);
 
   bool is_first_frame = true;
   int last_key_frame = -1;
@@ -605,18 +603,6 @@ void VideoLoader::read_file() {
           last_key_frame = -1;
         }
         continue;
-    }
-
-    if (frame >= req.frame && frame < req.frame + req.count) {
-      if (frames_read[frame - req.frame]) {
-        ERROR_LOG << "Frame " << frame << " appeared twice\n";
-      } else {
-        frames_read[frame - req.frame] = true;
-        frames_left--;
-        LOG_LINE << "Frames left: " << frames_left << "\n";
-      }
-    } else {
-      LOG_LINE << "Frame " << frame << " not in the interesting range.\n";
     }
 
     LOG_LINE << device_id_ << ": Sending " << (key ? "  key " : "nonkey")


### PR DESCRIPTION
- the NVVL that the DALI video reader is based on, reports
  a warning when a video packet with the same timestamp has
  been seen already
- recently introduced heuristics allows the reader to rewind
  to the previous key frame as FFmpeg doesn't differentiate
  between IDR and non-IDR keyframes, while NVDEC cannot resume
  decoding from a non-IDR keyframe. This functionality makes
  the mentioned warning an expected behavior in some usaceses

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- the NVVL that the DALI video reader is based on, reports
  a warning when a video packet with the same timestamp has
  been seen already
- recently introduced heuristics allows the reader to rewind
  to the previous key frame as FFmpeg doesn't differentiate
  between IDR and non-IDR keyframes, while NVDEC cannot resume
  decoding from a non-IDR keyframe. This functionality makes
  the mentioned warning an expected behavior in some usaceses

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- video reader
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - test_video_pipeline.py
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
