### PR TITLE
Document unsupported external source arguments in TF Dataset

### DIFF
--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -91,9 +91,29 @@ This allows TensorFlow DALIDataset to work with most Pipelines that have Externa
     This class is experimental and its API might change without notice.
 
 .. note::
+    External source nodes with ``num_outputs`` specified to any number are not
+    supported - this means that callbacks with multiple (tuple) outputs are not supported.
+
+.. note::
+    External source ``cycle`` policy ``'raise'`` is not supported - the dataset is not restartable.
+
+.. note::
+    External source ``cuda_stream`` parameter is ignored - ``source`` is supposed to return
+    CPU data and tf.data.Dataset inputs are handled internally.
+
+.. note::
+    External source ``use_copy_kernel`` and ``blocking`` parameters are ignored.
+
+.. note::
     Setting ``no_copy`` on the external source nodes when defining the pipeline is considered
     a no-op when used with DALI Dataset. The ``no_copy`` option is handled internally
     and enabled automatically if possible.
+
+.. note::
+    Parallel execution of external source callback provided via ``source`` is not supported.
+    The callback is executed via TensorFlow ``tf.data.Dataset.from_generator`` - the ``parallel``
+    and ``prefetch_queue_depth`` parameters are ignored.
+
 
 The operator adds additional parameters to the ones supported by the
 :class:`~nvidia.dali.plugin.tf.DALIDataset`:

--- a/dali/python/nvidia/dali/plugin/tf.py
+++ b/dali/python/nvidia/dali/plugin/tf.py
@@ -148,7 +148,7 @@ Parameters
             }
 
         are equivalent to following specification using
-            ``nvidia.dali.plugin.tf.experimental.Input``::
+        ``nvidia.dali.plugin.tf.experimental.Input``::
 
             {
                 'input' : nvidia.dali.plugin.tf.experimental.Input(


### PR DESCRIPTION
## Category: **Other**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
 (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
List the arguments to External Source that
are not supported by the experimental DALIDatasetWithInputs.




## Additional information:

### Affected modules and functionalities:
TF Dali Dataset.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [x] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
