### PR TITLE
Add decoder test framework

### DIFF
--- a/dali/imgcodec/decoders/decoder_test_helper.h
+++ b/dali/imgcodec/decoders/decoder_test_helper.h
@@ -1,0 +1,230 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_IMGCODEC_DECODERS_DECODER_TEST_HELPER_H_
+#define DALI_IMGCODEC_DECODERS_DECODER_TEST_HELPER_H_
+
+#include <string>
+#include <memory>
+#include <vector>
+#include "dali/pipeline/data/tensor.h"
+#include "dali/core/static_switch.h"
+#include "dali/pipeline/data/views.h"
+#include "dali/imgcodec/image_format.h"
+#include "dali/imgcodec/image_decoder.h"
+#include "dali/test/dali_test.h"
+#include "dali/kernels/slice/slice_cpu.h"
+#include "dali/core/stream.h"
+#include "dali/util/file.h"
+#include "dali/util/numpy.h"
+
+namespace dali {
+namespace imgcodec {
+namespace test {
+
+/**
+* @brief Base class template for tests comparing decoder's results with reference images.
+*
+* @tparam OutputType Type, to which the image should be decoded.
+*/
+template<typename OutputType>
+class CpuDecoderTestBase : public ::testing::Test {
+ public:
+  CpuDecoderTestBase() : tp_(4, CPU_ONLY_DEVICE_ID, false, "Decoder test") {}
+
+  /**
+  * @brief Decodes an image and returns the result as a tensor.
+  */
+  Tensor<CPUBackend> Decode(ImageSource *src, const DecodeParams &opts = {}) {
+    EXPECT_TRUE(Parser()->CanParse(src));
+    ImageInfo info = Parser()->GetInfo(src);
+
+    Tensor<CPUBackend> result;
+    EXPECT_TRUE(Decoder()->CanDecode(src, opts));
+    TensorShape<> shape = (opts.use_roi ? opts.roi.shape() : info.shape);
+    result.Resize(shape, type2id<OutputType>::value);
+
+    SampleView<CPUBackend> view(result.raw_mutable_data(), result.shape(), result.type());
+    DecodeResult decode_result = Decoder()->Decode(view, src, opts);
+    EXPECT_TRUE(decode_result.success);
+
+    return result;
+  }
+
+  /**
+  * @brief Checks if two tensors are equal.
+  */
+  void AssertEqual(const Tensor<CPUBackend> &img, const Tensor<CPUBackend> &ref) {
+    EXPECT_EQ(img.shape(), ref.shape()) << "Different shapes";
+    auto img_view = view<const OutputType>(img), ref_view = view<const OutputType>(ref);
+    for (int i = 0; i < volume(img.shape()); i++) {
+      // TODO(skarpinski) Pretty-print position on error
+      ASSERT_EQ(img_view.data[i], ref_view.data[i]) << "at " << PrettyPosition(i, img.shape());
+    }
+  }
+
+  /**
+  * @brief Crops a tensor to specified roi_shape, anchored at roi_begin.
+  * Does not support padding.
+  */
+  Tensor<CPUBackend> Crop(const Tensor<CPUBackend> &input,
+                          const TensorShape<> &roi_begin, const TensorShape<> &roi_shape) {
+    int ndim = input.shape().sample_dim();
+    Tensor<CPUBackend> output;
+    output.Resize(roi_shape, type2id<OutputType>::value);
+
+    VALUE_SWITCH(ndim, Dims, (2, 3, 4), (
+      auto out_view = view<OutputType, Dims>(output);
+      auto in_view = view<const OutputType, Dims>(input);
+      kernels::SliceCPU<OutputType, OutputType, Dims> kernel;
+      kernels::SliceArgs<OutputType, Dims> args;
+      args.anchor = roi_begin;
+      args.shape = roi_shape;
+      kernels::KernelContext ctx;
+      // no need to run Setup (we already know the output shape)
+      kernel.Schedule(ctx, out_view, in_view, args, tp_);
+      tp_.RunAll();
+    ), DALI_FAIL(make_string("Unsupported number of dimensions: ", ndim)););  // NOLINT
+
+    return output;
+  }
+
+  /**
+  * @brief Returns the parser used.
+  */
+  std::shared_ptr<ImageParser> Parser() {
+    if (!parser_) parser_ = CreateParser();
+    return parser_;
+  }
+
+  /**
+  * @brief Returns the decoder used.
+  */
+  std::shared_ptr<ImageDecoderInstance> Decoder() {
+    if (!decoder_) decoder_ = CreateDecoder(tp_);
+    return decoder_;
+  }
+
+  /**
+  * @brief Reads the reference image from specified path and returns it as a tensor.
+  */
+  Tensor<CPUBackend> ReadReferenceFrom(const std::string &reference_path) {
+    auto src = FileStream::Open(reference_path, false, false);
+    return ReadReference(src.get());
+  }
+
+  /**
+  * @brief Reads the reference image from specified stream.
+  */
+  virtual Tensor<CPUBackend> ReadReference(InputStream *src) = 0;
+
+ protected:
+  /**
+  * @brief Creates a decoder instance, working on a specified thread pool.
+  */
+  virtual std::shared_ptr<ImageDecoderInstance> CreateDecoder(ThreadPool &tp) = 0;
+
+  /**
+  * @brief Creates a parser to be used.
+  */
+  virtual std::shared_ptr<ImageParser> CreateParser() = 0;
+
+ private:
+  std::string PrettyPosition(size_t index, TensorShape<> shape) const {
+    std::vector<int> pos(shape.size());
+    for (size_t i = pos.size() - 1; i > 0; i--) {
+      pos[i] = index % shape[i];
+      index /= shape[i];
+    }
+
+    std::ostringstream result;
+    result << "(";
+    for (size_t i = 0; i < pos.size(); i++) {
+      result << pos[i];
+      if (i < pos.size() - 1)
+        result << ", ";
+      else
+        result << ")";
+    }
+    return result.str();
+  }
+
+  std::shared_ptr<ImageDecoderInstance> decoder_ = nullptr;
+  std::shared_ptr<ImageParser> parser_ = nullptr;
+  ThreadPool tp_;
+};
+
+
+/**
+* @brief Base class template for tests comparing decoder's results with numpy files.
+*
+* @tparam OutputType Type, to which the image should be decoded.
+*/
+template<typename OutputType>
+class NumpyDecoderTestBase : public CpuDecoderTestBase<OutputType> {
+ private:
+  /**
+  * @brief Converts a tensor to OutputType.
+  */
+  template<typename InputType>
+  Tensor<CPUBackend> Convert(const Tensor<CPUBackend> &in) {
+    Tensor<CPUBackend> out;
+    out.Resize(in.shape(), type2id<OutputType>::value);
+    auto in_view = view<const InputType>(in), out_view = view<OutputType>(out);
+    for (int i = 0; i < volume(in.shape()); i++) {
+      out_view.data[i] = ConvertSatNorm<OutputType>(in_view.data[i]);
+    }
+    return out;
+  }
+
+  /**
+  * @brief Reads a tensor from numpy file.
+  */
+  Tensor<CPUBackend> ReadNumpy(InputStream *src) {
+    numpy::HeaderData header = numpy::ParseHeader(src);
+    src->SeekRead(header.data_offset, SEEK_SET);
+
+    Tensor<CPUBackend> data;
+    data.Resize(header.shape, header.type());
+    Index ret = src->Read(static_cast<uint8_t*>(data.raw_mutable_data()), header.nbytes());
+    EXPECT_EQ(ret, (Index)header.nbytes()) << "Failed to read reference numpy file";
+
+    if (header.fortran_order) {
+      Tensor<CPUBackend> transposed;
+      transposed.Resize(data.shape(), data.type());
+      SampleView<CPUBackend> input(data.raw_mutable_data(), data.shape(), data.type());
+      SampleView<CPUBackend> output(transposed.raw_mutable_data(), transposed.shape(),
+                                    transposed.type());
+      numpy::FromFortranOrder(output, input);
+      return transposed;
+    }
+    return data;
+  }
+
+ public:
+  Tensor<CPUBackend> ReadReference(InputStream *src) override {
+    Tensor<CPUBackend> ref = ReadNumpy(src);
+
+    DALIDataType output_type = type2id<OutputType>::value;
+    TYPE_SWITCH(ref.type(), type2id, InputType, NUMPY_ALLOWED_TYPES, (
+      return Convert<InputType>(ref);
+    ), DALI_FAIL(make_string("Unsupported numpy reference type: ", ref.type())));  // NOLINT
+  }
+};
+
+}  // namespace test
+}  // namespace imgcodec
+}  // namespace dali
+
+#endif  // DALI_IMGCODEC_DECODERS_DECODER_TEST_HELPER_H_

--- a/dali/imgcodec/decoders/decoder_test_helper.h
+++ b/dali/imgcodec/decoders/decoder_test_helper.h
@@ -28,6 +28,7 @@
 #include "dali/core/stream.h"
 #include "dali/util/file.h"
 #include "dali/util/numpy.h"
+#include "dali/test/tensor_test_utils.h"
 
 namespace dali {
 namespace imgcodec {
@@ -66,12 +67,16 @@ class CpuDecoderTestBase : public ::testing::Test {
   * @brief Checks if two tensors are equal.
   */
   void AssertEqual(const Tensor<CPUBackend> &img, const Tensor<CPUBackend> &ref) {
-    EXPECT_EQ(img.shape(), ref.shape()) << "Different shapes";
-    auto img_view = view<const OutputType>(img), ref_view = view<const OutputType>(ref);
-    for (int i = 0; i < volume(img.shape()); i++) {
-      // TODO(skarpinski) Pretty-print position on error
-      ASSERT_EQ(img_view.data[i], ref_view.data[i]) << "at " << PrettyPosition(i, img.shape());
-    }
+    Check(view<const OutputType>(img), view<const OutputType>(ref));
+  }
+
+  /**
+  * @brief Checks if two tensors are equal after converting the second tensor with ConvertSatNorm
+  */
+  void AssertEqualSatNorm(const Tensor<CPUBackend> &img, const Tensor<CPUBackend> &ref) {
+    TYPE_SWITCH(ref.type(), type2id, RefType, NUMPY_ALLOWED_TYPES, (
+      Check(view<const OutputType>(img), view<const RefType>(ref), EqualConvertSatNorm());
+    ), DALI_FAIL(make_string("Unsupported reference type: ", ref.type())));  // NOLINT
   }
 
   /**
@@ -140,25 +145,6 @@ class CpuDecoderTestBase : public ::testing::Test {
   virtual std::shared_ptr<ImageParser> CreateParser() = 0;
 
  private:
-  std::string PrettyPosition(size_t index, TensorShape<> shape) const {
-    std::vector<int> pos(shape.size());
-    for (size_t i = pos.size() - 1; i > 0; i--) {
-      pos[i] = index % shape[i];
-      index /= shape[i];
-    }
-
-    std::ostringstream result;
-    result << "(";
-    for (size_t i = 0; i < pos.size(); i++) {
-      result << pos[i];
-      if (i < pos.size() - 1)
-        result << ", ";
-      else
-        result << ")";
-    }
-    return result.str();
-  }
-
   std::shared_ptr<ImageDecoderInstance> decoder_ = nullptr;
   std::shared_ptr<ImageParser> parser_ = nullptr;
   ThreadPool tp_;
@@ -173,20 +159,6 @@ class CpuDecoderTestBase : public ::testing::Test {
 template<typename OutputType>
 class NumpyDecoderTestBase : public CpuDecoderTestBase<OutputType> {
  private:
-  /**
-  * @brief Converts a tensor to OutputType.
-  */
-  template<typename InputType>
-  Tensor<CPUBackend> Convert(const Tensor<CPUBackend> &in) {
-    Tensor<CPUBackend> out;
-    out.Resize(in.shape(), type2id<OutputType>::value);
-    auto in_view = view<const InputType>(in), out_view = view<OutputType>(out);
-    for (int i = 0; i < volume(in.shape()); i++) {
-      out_view.data[i] = ConvertSatNorm<OutputType>(in_view.data[i]);
-    }
-    return out;
-  }
-
   /**
   * @brief Reads a tensor from numpy file.
   */
@@ -214,12 +186,7 @@ class NumpyDecoderTestBase : public CpuDecoderTestBase<OutputType> {
 
  public:
   Tensor<CPUBackend> ReadReference(InputStream *src) override {
-    Tensor<CPUBackend> ref = ReadNumpy(src);
-
-    DALIDataType output_type = type2id<OutputType>::value;
-    TYPE_SWITCH(ref.type(), type2id, InputType, NUMPY_ALLOWED_TYPES, (
-      return Convert<InputType>(ref);
-    ), DALI_FAIL(make_string("Unsupported numpy reference type: ", ref.type())));  // NOLINT
+    return ReadNumpy(src);
   }
 };
 

--- a/dali/imgcodec/decoders/decoder_test_helper.h
+++ b/dali/imgcodec/decoders/decoder_test_helper.h
@@ -158,35 +158,9 @@ class CpuDecoderTestBase : public ::testing::Test {
 */
 template<typename OutputType>
 class NumpyDecoderTestBase : public CpuDecoderTestBase<OutputType> {
- private:
-  /**
-  * @brief Reads a tensor from numpy file.
-  */
-  Tensor<CPUBackend> ReadNumpy(InputStream *src) {
-    numpy::HeaderData header;
-    numpy::ParseHeader(header, src);
-    src->SeekRead(header.data_offset, SEEK_SET);
-
-    Tensor<CPUBackend> data;
-    data.Resize(header.shape, header.type());
-    Index ret = src->Read(static_cast<uint8_t*>(data.raw_mutable_data()), header.nbytes());
-    EXPECT_EQ(ret, (Index)header.nbytes()) << "Failed to read reference numpy file";
-
-    if (header.fortran_order) {
-      Tensor<CPUBackend> transposed;
-      transposed.Resize(data.shape(), data.type());
-      SampleView<CPUBackend> input(data.raw_mutable_data(), data.shape(), data.type());
-      SampleView<CPUBackend> output(transposed.raw_mutable_data(), transposed.shape(),
-                                    transposed.type());
-      numpy::FromFortranOrder(output, input);
-      return transposed;
-    }
-    return data;
-  }
-
  public:
   Tensor<CPUBackend> ReadReference(InputStream *src) override {
-    return ReadNumpy(src);
+    return numpy::ReadTensor(src);
   }
 };
 

--- a/dali/test/tensor_test_utils.h
+++ b/dali/test/tensor_test_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2019, 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -224,6 +224,21 @@ struct EqualUlp {
   }
 
   int ulp_ = 4;
+};
+
+
+/**
+ * @brief Functor for comparing value after converting the reference with ConvertSatNorm
+ *
+ * @remark Be aware, that when using this functor in `Check()`, order of arguments matters!
+ */
+struct EqualConvertSatNorm {
+  EqualConvertSatNorm() = default;
+
+  template <typename Output, typename Reference>
+  bool operator()(Output out, Reference ref) {
+    return out == ConvertSatNorm<Output>(ref);
+  }
 };
 
 

--- a/dali/util/numpy.cc
+++ b/dali/util/numpy.cc
@@ -222,7 +222,7 @@ Tensor<CPUBackend> ReadTensor(InputStream *src) {
   Tensor<CPUBackend> data;
   data.Resize(header.shape, header.type());
   Index ret = src->Read(static_cast<uint8_t*>(data.raw_mutable_data()), header.nbytes());
-  DALI_ENFORCE(ret == (Index)header.nbytes(), "Failed to read reference numpy file");
+  DALI_ENFORCE(ret == (Index)header.nbytes(), "Failed to read numpy file");
 
   if (header.fortran_order) {
     Tensor<CPUBackend> transposed;

--- a/dali/util/numpy.cc
+++ b/dali/util/numpy.cc
@@ -221,8 +221,8 @@ Tensor<CPUBackend> ReadTensor(InputStream *src) {
 
   Tensor<CPUBackend> data;
   data.Resize(header.shape, header.type());
-  Index ret = src->Read(static_cast<uint8_t*>(data.raw_mutable_data()), header.nbytes());
-  DALI_ENFORCE(ret == (Index)header.nbytes(), "Failed to read numpy file");
+  auto ret = src->Read(static_cast<uint8_t*>(data.raw_mutable_data()), header.nbytes());
+  DALI_ENFORCE(ret == header.nbytes(), "Failed to read numpy file");
 
   if (header.fortran_order) {
     Tensor<CPUBackend> transposed;

--- a/dali/util/numpy.cc
+++ b/dali/util/numpy.cc
@@ -214,5 +214,27 @@ size_t HeaderData::nbytes() const {
   return type_info ? type_info->size() * size() : 0_uz;
 }
 
+Tensor<CPUBackend> ReadTensor(InputStream *src) {
+  numpy::HeaderData header;
+  numpy::ParseHeader(header, src);
+  src->SeekRead(header.data_offset, SEEK_SET);
+
+  Tensor<CPUBackend> data;
+  data.Resize(header.shape, header.type());
+  Index ret = src->Read(static_cast<uint8_t*>(data.raw_mutable_data()), header.nbytes());
+  DALI_ENFORCE(ret == (Index)header.nbytes(), "Failed to read reference numpy file");
+
+  if (header.fortran_order) {
+    Tensor<CPUBackend> transposed;
+    transposed.Resize(data.shape(), data.type());
+    SampleView<CPUBackend> input(data.raw_mutable_data(), data.shape(), data.type());
+    SampleView<CPUBackend> output(transposed.raw_mutable_data(), transposed.shape(),
+                                  transposed.type());
+    numpy::FromFortranOrder(output, input);
+    return transposed;
+  }
+  return data;
+}
+
 }  // namespace numpy
 }  // namespace dali

--- a/dali/util/numpy.h
+++ b/dali/util/numpy.h
@@ -21,6 +21,7 @@
 #include "dali/core/stream.h"
 #include "dali/pipeline/data/sample_view.h"
 #include "dali/pipeline/data/backend.h"
+#include "dali/pipeline/data/tensor.h"
 #include "dali/core/static_switch.h"
 #include "dali/kernels/transpose/transpose.h"
 
@@ -50,6 +51,8 @@ DLL_PUBLIC void ParseHeader(HeaderData &parsed_header, InputStream *src);
 DLL_PUBLIC void FromFortranOrder(SampleView<CPUBackend> output, ConstSampleView<CPUBackend> input);
 
 DLL_PUBLIC void ParseHeaderContents(HeaderData& target, const std::string &header);
+
+DLL_PUBLIC Tensor<CPUBackend> ReadTensor(InputStream *src);
 
 }  // namespace numpy
 }  // namespace dali


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->

**New feature** (*non-breaking change which adds functionality*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

This PR adds a framework for testing imgcodec's decoders. It allows comparing results of decoding with reference image stored in [numpy format](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html). The general idea is that reference numpy files with decoded images will be stored in `DALI_extra`.

**Why numpy format?** Files in numpy format are universal, self-contained, easy to create and view, and we already have C++ reader code. Another alternative would be comparing against trusted (?) library such as OpenCV, but this would give us no control over the reference output and could lead to situations where tests stop working because of breaking OpenCV change.

### Future work:
The following things are out of scope of this PR:
- At some point we'd like to generalize it for GPU codecs

### Example:

When writing a test for decoder, one should override two methods, which would instantiate the parser and decoder. The example usage, taken from https://github.com/NVIDIA/DALI/pull/4109 is presented below.

```cpp
auto img_ref_path = dali_extra + "/db/single/reference/tiff/0/cat-111793_640.tiff.npy";
auto img_path = dali_extra + "/db/single/tiff/0/cat-111793_640.tiff";

class LibTiffDecoderTest : public NumpyDecoderTestBase<uint8_t> {
 protected:
  std::shared_ptr<ImageDecoderInstance> CreateDecoder(ThreadPool &tp) override {
    LibTiffDecoder decoder;
    return decoder.Create(CPU_ONLY_DEVICE_ID, tp);
  }
  std::shared_ptr<ImageParser> CreateParser() override {
    return std::make_shared<TiffParser>();
  }
};

TEST_F(LibTiffDecoderTest, Test) {
  auto ref = ReadReferenceFrom(img_ref_path);
  auto src = ImageSource::FromFilename(img_path);
  auto img = Decode(&src);
  AssertEqual(img, ref);
}

TEST_F(LibTiffDecoderTest, TestROI) {
  auto ref = ReadReferenceFrom(img_ref_path);
  auto src = ImageSource::FromFilename(img_path);
  auto info = Parser()->GetInfo(&src);

  ROI roi = {{13, 17, 0}, {info.shape[0] - 55, info.shape[1] - 10, 3}};
  auto img = Decode(&src, {}, roi);
  AssertEqual(img, Crop(ref, roi));
}
```


## Additional information:

### Affected modules and functionalities:
- The framework lives in `decoder_test_helper.h` and provides the `NumpyDecoderTestBase` class template

### Key points relevant for the review:
This PR is kind of a blocker for PRs with codecs. I'd be happy to add any missing features or improve the efficiency of the tests, but I'd prefer to do so in follow-up PRs, to letothers write their codecs.

<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A

<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2908
<!--- DALI-XXXX or NA --->
