### PR TITLE
Fix OpenCV warning in jpeg compression distortion tests

### DIFF
--- a/dali/test/python/test_operator_jpeg_compression_distortion.py
+++ b/dali/test/python/test_operator_jpeg_compression_distortion.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,15 +31,28 @@ sequence_length = 10
 class InputImagesIter(object):
     def __init__(self, sequence_length):
         self.sequence_length = sequence_length
-        with open(os.path.join(images_dir, 'image_list.txt')) as file:
-            self.files = [line.rstrip() for line in file if line != '']
+
+        # A bunch of images to be used as frames of a sequence
+        filenames = [
+            'cat-3449999_640.tiff',
+            'cat-1046544_640.tiff',
+            'cat-1245673_640.tiff',
+            'cat-300572_640.tiff',
+            'cat-111793_640.tiff',
+            'domestic-cat-726989_640.tiff',
+            'cat-3504008_640.tiff',
+            'cat-3591348_640.tiff',
+            'cat-2184682_640.tiff',
+            'cat-3113513_640.tiff',
+        ]
+        self.files = [os.path.join(images_dir, '0', filename) for filename in filenames]
         shuffle(self.files)
 
     def _load_next(self):
         in_img = None
         # Skip input image if format isn't supported by OpenCV
         while in_img is None:
-            filename, label = self.files[self.i].split(' ')
+            filename = self.files[self.i]
             in_img = cv2.imread(os.path.join(images_dir, filename))
             self.i = (self.i + 1) % len(self.files)
         # Convert to rgb, to match dali channel order


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Other** 


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
Fixes a warning in jpeg compression distortion tests:
- Python OpenCV has no zstd configured
- One of our images in DALI_extra uses that compression format
- We use arbitrary images in those tests to construct a sequence
- There is a warning complaining about the compression method not being supported when using cv2.imread to decode the images to construct a sequence

The solution is to use other images instead


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
Tests


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
NA
### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
`dali/test/python/test_operator_jpeg_compression_distortion.py`
- [x] Existing tests apply
- [ ] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
