### PR TITLE
Add AsTensor and related APIs to Tensor Vector

### DIFF
--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -828,6 +828,14 @@ class DLL_PUBLIC TensorList {
     return {tl.data_.get_data_ptr(), tl.raw_mutable_tensor(sample_idx)};
   }
 
+  /**
+   * @brief Return the shared pointer, that we can use to correctly share the ownership of the batch
+   * with -- in typical scenarios it is equivalent to unsafe_sample_owner(tl, 0);
+   */
+  friend shared_ptr<void> unsafe_owner(TensorList<Backend> &tl) {
+    return tl.data_.get_data_ptr();
+  }
+
   /** @} */  // end of ContiguousAccessorFunctions
 };
 

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -816,8 +816,7 @@ Tensor<Backend> TensorVector<Backend>::AsReshapedTensor(const TensorShape<> &new
     ptr = nullptr;
   }
 
-  result.ShareData(ptr, capacity(), is_pinned(), new_shape, type(),
-                   device_id(), order());
+  result.ShareData(ptr, capacity(), is_pinned(), new_shape, type(), device_id(), order());
 
   auto result_layout = GetLayout();
   if (result_layout.ndim() + 1 == new_shape.sample_dim()) {

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -173,14 +173,12 @@ void CopyImpl(DstBatch<DstBackend> &dst, const SrcBatch<SrcBackend> &src, const 
 
 template <typename Backend>
 TensorVector<Backend>::TensorVector()
-    : views_count_(0), curr_num_tensors_(0), tl_(std::make_shared<TensorList<Backend>>()) {}
+    : curr_num_tensors_(0), tl_(std::make_shared<TensorList<Backend>>()) {}
 
 
 template <typename Backend>
 TensorVector<Backend>::TensorVector(int batch_size)
-    : views_count_(0),
-      curr_num_tensors_(0),
-      tl_(std::make_shared<TensorList<Backend>>(batch_size)) {
+    : curr_num_tensors_(0), tl_(std::make_shared<TensorList<Backend>>(batch_size)) {
   resize_tensors(batch_size);
 }
 
@@ -193,15 +191,8 @@ TensorVector<Backend>::TensorVector(TensorVector<Backend> &&other) noexcept {
   tl_ = std::move(other.tl_);
   type_ = std::move(other.type_);
   sample_dim_ = other.sample_dim_;
-  views_count_ = other.views_count_.load();
   tensors_ = std::move(other.tensors_);
-  for (auto &t : tensors_) {
-    if (t) {
-      if (auto *del = std::get_deleter<ViewRefDeleter>(t->data_)) del->ref = &views_count_;
-    }
-  }
 
-  other.views_count_ = 0;
   other.curr_num_tensors_ = 0;
   other.tensors_.clear();
   other.sample_dim_ = -1;
@@ -628,7 +619,7 @@ void TensorVector<Backend>::reserve(size_t bytes_per_sample, int batch_size) {
 
 template <typename Backend>
 bool TensorVector<Backend>::IsContiguous() const noexcept {
-  return state_ == State::contiguous && views_count_ == num_samples();
+  return state_ == State::contiguous;
 }
 
 
@@ -649,7 +640,6 @@ void TensorVector<Backend>::Reset() {
   type_ = {};
   sample_dim_ = -1;
   if (IsContiguous()) {
-    views_count_ = 0;
     tl_->Reset();
   }
 }
@@ -741,7 +731,6 @@ void TensorVector<Backend>::ShareData(const TensorVector<Backend> &tv) {
   sample_dim_ = tv.sample_dim_;
   state_ = tv.state_;
   pinned_ = tv.is_pinned();
-  views_count_ = 0;
   if (tv.state_ == State::contiguous) {
     ShareData(*tv.tl_);
   } else {
@@ -766,19 +755,76 @@ TensorVector<Backend> &TensorVector<Backend>::operator=(TensorVector<Backend> &&
     tl_ = std::move(other.tl_);
     type_ = other.type_;
     sample_dim_ = other.sample_dim_;
-    views_count_ = other.views_count_.load();
     tensors_ = std::move(other.tensors_);
-    for (auto &t : tensors_) {
-      if (t) {
-        if (auto *del = std::get_deleter<ViewRefDeleter>(t->data_)) del->ref = &views_count_;
-      }
-    }
 
-    other.views_count_ = 0;
     other.curr_num_tensors_ = 0;
     other.tensors_.clear();
   }
   return *this;
+}
+
+
+// This is to check if we are actually laid down in contiguous memory
+// TODO(klecki): make this internal and name it something like: IsContiguouslyStored?
+template <typename Backend>
+bool TensorVector<Backend>::IsContiguousTensor() const {
+  if (num_samples() == 0 || shape().num_elements() == 0) {
+    return true;
+  }
+  // If we are using contiguous representation in this case we can safely return
+  if (IsContiguous()) {
+    return true;
+  }
+  const uint8_t *base_ptr = static_cast<const uint8_t *>(tensors_[0]->raw_data());
+  size_t size = type_info().size();
+
+  for (int i = 0; i < num_samples(); ++i) {
+    if (base_ptr != tensors_[i]->raw_data()) {
+      return false;
+    }
+    base_ptr += tensors_[i]->shape().num_elements() * size;
+  }
+  return true;
+}
+
+
+template <typename Backend>
+bool TensorVector<Backend>::IsDenseTensor() const {
+  return IsContiguous() && is_uniform(shape());
+}
+
+
+template <typename Backend>
+Tensor<Backend> TensorVector<Backend>::AsReshapedTensor(const TensorShape<> &new_shape) {
+  DALI_ENFORCE(num_samples() > 0,
+               "To create a view Tensor, the batch must have at least 1 element.");
+  DALI_ENFORCE(IsValidType(type()),
+               "To create a view Tensor, the batch must have a valid data type.");
+  DALI_ENFORCE(
+      shape().num_elements() == new_shape.num_elements(),
+      make_string("To create a view Tensor, requested shape need to have the same volume as the "
+                  "batch, requested: ",
+                  new_shape.num_elements(), " expected: ", shape().num_elements()));
+  Tensor<Backend> result;
+  result.ShareData(unsafe_sample_owner(*tl_, 0), tl_->capacity(),
+                   tl_->is_pinned(), new_shape, type(), device_id(), order());
+  auto result_layout = GetLayout();
+  if (!GetLayout().empty()) {
+    result_layout = TensorLayout("N") + result_layout;
+  }
+  result.SetLayout(result_layout);
+  return result;
+}
+
+
+template <typename Backend>
+Tensor<Backend> TensorVector<Backend>::AsTensor() {
+  DALI_ENFORCE(IsDenseTensor(),
+               "The batch must be representable tensor - it must has uniform shape and be "
+               "allocated in contiguous memory.");
+  DALI_ENFORCE(shape().num_samples() > 0,
+               "To create a view Tensor, the batch must have at least 1 element.");
+  return AsReshapedTensor(shape_cat(shape().num_samples(), shape()[0]));
 }
 
 
@@ -792,7 +838,6 @@ void TensorVector<Backend>::UpdateViews() {
 
   assert(curr_num_tensors_ == tl_->num_samples());
 
-  views_count_ = curr_num_tensors_;
   for (int i = 0; i < curr_num_tensors_; i++) {
     update_view(i);
   }
@@ -880,7 +925,7 @@ void TensorVector<Backend>::update_view(int idx) {
   // TODO(klecki): deleter that reduces views_count or just noop sharing?
   // tensors_[i]->ShareData(tl_.get(), static_cast<int>(idx));
   if (tensors_[idx]->raw_data() != ptr || tensors_[idx]->shape() != shape) {
-    tensors_[idx]->ShareData(std::shared_ptr<void>(ptr, ViewRefDeleter{&views_count_}),
+    tensors_[idx]->ShareData(unsafe_sample_owner(*tl_, idx),
                              volume(tl_->tensor_shape(idx)) * tl_->type_info().size(),
                              tl_->is_pinned(), shape, tl_->type(), tl_->device_id(), order());
   } else if (IsValidType(tl_->type())) {

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -347,6 +347,32 @@ class DLL_PUBLIC TensorVector {
 
   void UpdateViews();
 
+  /**
+   * @brief Checks whether the batch container is contiguous. It returns true if and only if
+   * all of the stored individual tensors are densely packed in memory.
+   */
+  bool IsContiguousTensor() const;
+
+  /**
+   * @brief Checks whether the batch container can be converted to a dense Tensor. It returns true
+   * if and only if all of the stored tensors have the same shape and they are densely packed in
+   * memory.
+   */
+  bool IsDenseTensor() const;
+
+  /**
+   * @brief Returns a pointer to Tensor which shares the data with this batch object and give it the
+   * provided shape. Batch and the Tensor share the memory allocation. The tensor obtained through
+   * this function stays valid for as long as TensorList data is unchanged.
+   * The batch must be representable as DenseTensor.
+   */
+  DLL_PUBLIC Tensor<Backend> AsReshapedTensor(const TensorShape<> &new_shape);
+
+  /**
+   * @brief Return a Dense Tensor representation of the underlying memory if possible.
+   */
+  DLL_PUBLIC Tensor<Backend> AsTensor();
+
  private:
   enum class State { contiguous, noncontiguous };
 
@@ -386,16 +412,10 @@ class DLL_PUBLIC TensorVector {
 
   bool has_data() const;
 
-  struct ViewRefDeleter {
-    void operator()(void*) { --*ref; }
-    std::atomic<int> *ref;
-  };
-
   void resize_tensors(int size);
 
   void update_view(int idx);
 
-  std::atomic<int> views_count_;
   std::vector<std::shared_ptr<Tensor<Backend>>> tensors_;
   int curr_num_tensors_;
   std::shared_ptr<TensorList<Backend>> tl_;

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -351,7 +351,7 @@ class DLL_PUBLIC TensorVector {
    * @brief Checks whether the batch container is contiguous. It returns true if and only if
    * all of the stored individual tensors are densely packed in memory.
    */
-  bool IsContiguousTensor() const;
+  bool IsContiguousInMemory() const;
 
   /**
    * @brief Checks whether the batch container can be converted to a dense Tensor. It returns true
@@ -361,7 +361,7 @@ class DLL_PUBLIC TensorVector {
   bool IsDenseTensor() const;
 
   /**
-   * @brief Returns a pointer to Tensor which shares the data with this batch object and give it the
+   * @brief Returns a Tensor which shares the data with this batch object and give it the
    * provided shape. Batch and the Tensor share the memory allocation. The tensor obtained through
    * this function stays valid for as long as TensorList data is unchanged.
    * The batch must be representable as DenseTensor.
@@ -470,6 +470,18 @@ class DLL_PUBLIC TensorVector {
     } else {
       return batch.tensors_[sample_idx]->get_data_ptr();
     }
+  }
+
+  /**
+   * @brief Return the shared pointer, that we can use to correctly share the ownership of batch
+   * with.
+   * Only allowed for contiguous batch, in typical scenario it is equivalent to
+   * unsafe_sample_owner(batch, 0)
+   */
+  friend shared_ptr<void> unsafe_owner(TensorVector<Backend> &batch) {
+    DALI_ENFORCE(batch.IsContiguous(),
+                 "Data owner pointer can be obtain only for contiguous TensorVector.");
+    return unsafe_owner(*batch.tl_);
   }
 
   /** @} */  // end of AccessorFunctions

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -241,6 +241,19 @@ struct TensorShape<DynamicDimensions>
     return shape;
   }
 
+  /**
+   * @brief Return empty shape of specified dimensionality
+   */
+  static TensorShape<> empty_shape(int dim) {
+    assert(dim > 0);
+    TensorShape<> result;
+    result.resize(dim);
+    for (auto &elem : result) {
+      elem = 0;
+    }
+    return result;
+  }
+
   void resize(typename Base::size_type count) { shape.resize(count); }
 };
 
@@ -300,6 +313,19 @@ struct TensorShape : public TensorShapeBase<DeviceArray<int64_t, ndim>, ndim> {
   DALI_NO_EXEC_CHECK
   DALI_HOST_DEV void resize(typename Base::size_type count) {
     assert(count == ndim && "Not supported for count other than statically defined");
+  }
+
+  /**
+   * @brief Return empty shape of specified dimensionality
+   */
+  static TensorShape<> empty_shape(int dim = ndim) {
+    assert(dim == ndim && "Not supported for count other than statically defined");
+    TensorShape<> result;
+    result.resize(dim);
+    for (auto &elem : result) {
+      elem = 0;
+    }
+    return result;
   }
 
   static_assert(ndim >= 0, "TensorShape dimension should not be negative");


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **New feature**, **Refactoring** 
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Add to the TensorVector the set of APIs already
present in TensorList:
* IsContiguousTensor
* IsDenseTensor
* AsReshapedTensor
* AsTensor

The APIs allow to access the memory of the contiguous
batch through the API of the Tensor. They are exposed
through the Python APIs for TensorList and the conversion
is valid as long as the allocation of the source object
is not changed.
Caching the returned Tensors is not replicated to simplify
the API.

The atomic counter of current internal "view" Tensors 
(the elements of tensors_) is removed - it use was insignificant
and the propagation of samples with such counter might
have strange side effects.  

Either way, the followups also remove the counter.

## Additional information:

### Affected modules and functionalities:
TensorVector introducing TensorList APIs to prepare
for the replacement.


### Key points relevant for the review:
There is a difference with how the Tensors are returned 
to Python:
In the TensorList version the Tensor is kept by the
TensorList object. We pass to Python the pointer 
to the cached Tensor instance with 
`py::return_value_policy::reference_internal`
(which keeps the TL alive as long as we use Tensor).

If we kept the reference to the old instance of such Tensor
and the TensorList cleared the cache of the Tensor objects,
for example due to Resize or Reset call, accessing that
Tensor would cause a segfault.

In the TensorVector version, we return a regular Tensor object,
whose allocation has a shared pointer to the same allocation
as the TensorVector. The TensorVector may be destroyed
by Python, and the Tensor would survive.

The lifetime of such Tensor is still problematic now
so I am open to any suggestion. Both of those API mention
that those are only views, and will both be problematic
if we allow Resizing the batch from Python, 
and a bit weird if we allow in-place modification of 
batch object in Python.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
