### PR TITLE
[imgcodec] Add thread index and cuda stream to Decode APIs

### DIFF
--- a/dali/imgcodec/decoders/decoder_impl.h
+++ b/dali/imgcodec/decoders/decoder_impl.h
@@ -64,23 +64,20 @@ class DLL_PUBLIC ImageDecoderImpl : public ImageDecoderInstance {
   /**
    * @brief To be overriden by a GPU/mixed codec implementation
    */
-  DecodeResult Decode(SampleView<GPUBackend> out, ImageSource *in,
-                      DecodeParams opts, const ROI &roi,
-                      cudaStream_t stream) override {
+  DecodeResult Decode(cudaStream_t stream, SampleView<GPUBackend> out, ImageSource *in,
+                      DecodeParams opts, const ROI &roi) override {
     throw std::logic_error("Backend not supported");
   }
 
-  std::vector<DecodeResult> Decode(span<SampleView<GPUBackend>> out,
-                                   cspan<ImageSource *> in,
-                                   DecodeParams opts,
-                                   cspan<ROI> rois,
-                                   cudaStream_t stream) override {
+  std::vector<DecodeResult> Decode(cudaStream_t stream, span<SampleView<GPUBackend>> out,
+                                   cspan<ImageSource *> in, DecodeParams opts,
+                                   cspan<ROI> rois) override {
     assert(out.size() == in.size());
     assert(rois.empty() || rois.size() == in.size());
     std::vector<DecodeResult> ret(out.size());
     ROI no_roi;
     for (int i = 0 ; i < in.size(); i++)
-      ret[i] = Decode(out[i], in[i], opts, rois.empty() ? no_roi : rois[i], stream);
+      ret[i] = Decode(stream, out[i], in[i], opts, rois.empty() ? no_roi : rois[i]);
     return ret;
   }
 

--- a/dali/imgcodec/decoders/decoder_impl.h
+++ b/dali/imgcodec/decoders/decoder_impl.h
@@ -65,20 +65,22 @@ class DLL_PUBLIC ImageDecoderImpl : public ImageDecoderInstance {
    * @brief To be overriden by a GPU/mixed codec implementation
    */
   DecodeResult Decode(SampleView<GPUBackend> out, ImageSource *in,
-                      DecodeParams opts, const ROI &roi) override {
+                      DecodeParams opts, const ROI &roi,
+                      cudaStream_t stream) override {
     throw std::logic_error("Backend not supported");
   }
 
   std::vector<DecodeResult> Decode(span<SampleView<GPUBackend>> out,
                                    cspan<ImageSource *> in,
                                    DecodeParams opts,
-                                   cspan<ROI> rois) override {
+                                   cspan<ROI> rois,
+                                   cudaStream_t stream) override {
     assert(out.size() == in.size());
     assert(rois.empty() || rois.size() == in.size());
     std::vector<DecodeResult> ret(out.size());
     ROI no_roi;
     for (int i = 0 ; i < in.size(); i++)
-      ret[i] = Decode(out[i], in[i], opts, rois.empty() ? no_roi : rois[i]);
+      ret[i] = Decode(out[i], in[i], opts, rois.empty() ? no_roi : rois[i], stream);
     return ret;
   }
 

--- a/dali/imgcodec/decoders/decoder_parallel_impl.h
+++ b/dali/imgcodec/decoders/decoder_parallel_impl.h
@@ -82,7 +82,7 @@ class DLL_PUBLIC BatchParallelDecoderImpl : public ImageDecoderImpl {
                       const ROI &roi) override {
     DecodeResult ret;
     tp_->AddWork([&](int tid) {
-      ret = DecodeImplTask(stream, tid, out, in, opts, roi);
+      ret = DecodeImplTask(tid, stream, out, in, opts, roi);
     }, volume(out.shape()));
     tp_->RunAll();
     return ret;
@@ -116,7 +116,7 @@ class DLL_PUBLIC BatchParallelDecoderImpl : public ImageDecoderImpl {
     ROI no_roi;
     for (int i = 0; i < in.size(); i++) {
       tp_->AddWork([&, i](int tid) {
-        ret[i] = DecodeImplTask(stream, tid, out[i], in[i], opts, rois.empty() ? no_roi : rois[i]);
+        ret[i] = DecodeImplTask(tid, stream, out[i], in[i], opts, rois.empty() ? no_roi : rois[i]);
       }, volume(out[i].shape()));
     }
     tp_->RunAll();

--- a/dali/imgcodec/decoders/decoder_parallel_impl.h
+++ b/dali/imgcodec/decoders/decoder_parallel_impl.h
@@ -144,16 +144,16 @@ class DLL_PUBLIC BatchParallelDecoderImpl : public ImageDecoderImpl {
   /**
    * @brief Single image decode GPU implementation, executed in a thread pool context.
    * 
-   * @param stream CUDA stream to synchronize with
    * @param thread_idx thread index in the thread pool
+   * @param stream CUDA stream to synchronize with
    * @param out output sample view
    * @param in encoded image source
    * @param opts decoding parameters
    * @param roi region-of-interest
    * @return std::vector<DecodeResult> 
    */
-  virtual DecodeResult DecodeImplTask(cudaStream_t stream,
-                                      int thread_idx,
+  virtual DecodeResult DecodeImplTask(int thread_idx,
+                                      cudaStream_t stream,
                                       SampleView<GPUBackend> out,
                                       ImageSource *in,
                                       DecodeParams opts,

--- a/dali/imgcodec/decoders/opencv_fallback.cc
+++ b/dali/imgcodec/decoders/opencv_fallback.cc
@@ -41,10 +41,12 @@ inline DALIDataType CV2DaliType(int cv_type_id) {
   }
 }
 
-DecodeResult OpenCVDecoderInstance::Decode(SampleView<CPUBackend> out,
-                                           ImageSource *in,
-                                           DecodeParams opts,
-                                           const ROI &roi) {
+DecodeResult OpenCVDecoderInstance::DecodeImplTask(SampleView<CPUBackend> out,
+                                                   ImageSource *in,
+                                                   DecodeParams opts,
+                                                   const ROI &roi,
+                                                   int thread_idx) {
+  (void) thread_idx;  // this implementation doesn't use per-thread resources
   int flags = 0;
   bool adjust_orientation = false;
 

--- a/dali/imgcodec/decoders/opencv_fallback.cc
+++ b/dali/imgcodec/decoders/opencv_fallback.cc
@@ -41,11 +41,11 @@ inline DALIDataType CV2DaliType(int cv_type_id) {
   }
 }
 
-DecodeResult OpenCVDecoderInstance::DecodeImplTask(SampleView<CPUBackend> out,
+DecodeResult OpenCVDecoderInstance::DecodeImplTask(int thread_idx,
+                                                   SampleView<CPUBackend> out,
                                                    ImageSource *in,
                                                    DecodeParams opts,
-                                                   const ROI &roi,
-                                                   int thread_idx) {
+                                                   const ROI &roi) {
   (void) thread_idx;  // this implementation doesn't use per-thread resources
   int flags = 0;
   bool adjust_orientation = false;

--- a/dali/imgcodec/decoders/opencv_fallback.h
+++ b/dali/imgcodec/decoders/opencv_fallback.h
@@ -30,10 +30,8 @@ class DLL_PUBLIC OpenCVDecoderInstance : public BatchParallelDecoderImpl {
   using Base = BatchParallelDecoderImpl;
   OpenCVDecoderInstance(int device_id, ThreadPool *tp) : Base(device_id, tp) {}
 
-  using Base::Decode;
-
-  DecodeResult Decode(SampleView<CPUBackend> out, ImageSource *in,
-                      DecodeParams opts, const ROI &roi) override;
+  DecodeResult DecodeImplTask(SampleView<CPUBackend> out, ImageSource *in,
+                              DecodeParams opts, const ROI &roi, int thread_idx) override;
 };
 
 class OpenCVDecoder : public ImageDecoder {

--- a/dali/imgcodec/decoders/opencv_fallback.h
+++ b/dali/imgcodec/decoders/opencv_fallback.h
@@ -30,8 +30,11 @@ class DLL_PUBLIC OpenCVDecoderInstance : public BatchParallelDecoderImpl {
   using Base = BatchParallelDecoderImpl;
   OpenCVDecoderInstance(int device_id, ThreadPool *tp) : Base(device_id, tp) {}
 
-  DecodeResult DecodeImplTask(SampleView<CPUBackend> out, ImageSource *in,
-                              DecodeParams opts, const ROI &roi, int thread_idx) override;
+  DecodeResult DecodeImplTask(int thread_idx,
+                              SampleView<CPUBackend> out,
+                              ImageSource *in,
+                              DecodeParams opts,
+                              const ROI &roi) override;
 };
 
 class OpenCVDecoder : public ImageDecoder {

--- a/include/dali/imgcodec/image_decoder.h
+++ b/include/dali/imgcodec/image_decoder.h
@@ -134,20 +134,20 @@ class DLL_PUBLIC ImageDecoderInstance {
   /**
    * @brief Decodes a single image to a device buffer
    */
-  virtual DecodeResult Decode(SampleView<GPUBackend> out,
+  virtual DecodeResult Decode(cudaStream_t stream,
+                              SampleView<GPUBackend> out,
                               ImageSource *in,
                               DecodeParams opts,
-                              const ROI &roi = {},
-                              cudaStream_t stream = 0) = 0;
+                              const ROI &roi = {}) = 0;
 
   /**
    * @brief Decodes a single image to device buffers
    */
-  virtual std::vector<DecodeResult> Decode(span<SampleView<GPUBackend>> out,
+  virtual std::vector<DecodeResult> Decode(cudaStream_t stream,
+                                           span<SampleView<GPUBackend>> out,
                                            cspan<ImageSource *> in,
                                            DecodeParams opts,
-                                           cspan<ROI> rois = {},
-                                           cudaStream_t stream = 0) = 0;
+                                           cspan<ROI> rois = {}) = 0;
   /**
    * @brief Sets a codec-specific parameter
    */

--- a/include/dali/imgcodec/image_decoder.h
+++ b/include/dali/imgcodec/image_decoder.h
@@ -137,7 +137,8 @@ class DLL_PUBLIC ImageDecoderInstance {
   virtual DecodeResult Decode(SampleView<GPUBackend> out,
                               ImageSource *in,
                               DecodeParams opts,
-                              const ROI &roi = {}) = 0;
+                              const ROI &roi = {},
+                              cudaStream_t stream = 0) = 0;
 
   /**
    * @brief Decodes a single image to device buffers
@@ -145,7 +146,8 @@ class DLL_PUBLIC ImageDecoderInstance {
   virtual std::vector<DecodeResult> Decode(span<SampleView<GPUBackend>> out,
                                            cspan<ImageSource *> in,
                                            DecodeParams opts,
-                                           cspan<ROI> rois = {}) = 0;
+                                           cspan<ROI> rois = {},
+                                           cudaStream_t stream = 0) = 0;
   /**
    * @brief Sets a codec-specific parameter
    */


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** 

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
- It adds a thread_idx to BatchParallelDecoderImpl Decode API, so that decoders can have per-thread resources and refer to them via thread_idx.
- It adds a cuda stream to all GPU Decode APIs, so that the work can be either scheduled on that stream or we can synchronize with it


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
decoder_parallel_impl.h


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
NA

### Tests:
<!--- Describe the test coverage of the introduced change.
NA

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [x] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
