### PR TITLE
Silence some constexpr-related warnings in NVCC 10.

### DIFF
--- a/include/dali/core/geom/mat.h
+++ b/include/dali/core/geom/mat.h
@@ -101,7 +101,7 @@ struct mat {
   #if MAT_LAYOUT_ROW_MAJOR
     return m[r];
   #else
-    vec<cols, Element> ret = {};
+    vec<cols, Element> ret{};
     for (int j = 0; j < cols; j++)
       ret[j] = at(r, j);
     return ret;
@@ -111,7 +111,7 @@ struct mat {
   DALI_HOST_DEV DALI_FORCEINLINE
   constexpr auto col(int c) const {
   #if MAT_LAYOUT_ROW_MAJOR
-    vec<rows, Element> ret = {};
+    vec<rows, Element> ret{};
     for (int i = 0; i < rows; i++)
       ret[i] = at(i, c);
     return ret;
@@ -170,7 +170,7 @@ struct mat {
 
   DALI_HOST_DEV
   constexpr mat<cols, rows, Element> T() const {
-    mat<cols, rows, Element> retval = {};
+    mat<cols, rows, Element> retval{};
     MAT_ELEMENT_LOOP(i, j)
       retval(j, i) = at(i, j);
     return retval;
@@ -179,7 +179,7 @@ struct mat {
   template <typename U>
   DALI_HOST_DEV
   constexpr mat<rows, cols, U> cast() const {
-    mat<rows, cols, U> result = {};
+    mat<rows, cols, U> result{};
     MAT_ELEMENT_LOOP(i, j)
       result(i, j) = static_cast<U>(at(i, j));
     return result;
@@ -261,7 +261,7 @@ struct mat {
   DALI_HOST_DEV
   inline auto operator*(const mat<cols, rhs_cols, U> &rhs) const {
     using R = promote_vec_t<Element, U>;
-    mat<rows, rhs_cols, R> result = {};
+    mat<rows, rhs_cols, R> result{};
   #if MAT_LAYOUT_ROW_MAJOR
     for (int i = 0; i < rows; i++) {
       for (int j = 0; j < rhs_cols; j++) {
@@ -280,10 +280,10 @@ struct mat {
 
   template <typename U>
   DALI_HOST_DEV
-  inline auto operator*(const vec<cols, U> &v) const {
+  constexpr auto operator*(const vec<cols, U> &v) const {
     using R = promote_vec_t<Element, U>;
   #if MAT_LAYOUT_ROW_MAJOR
-    vec<rows, R> result;
+    vec<rows, R> result{};
     for (int i = 0; i < rows; i++) {
       R s = m[i][0] * v[0];
       for (int j = 1; j < cols; j++)
@@ -337,7 +337,7 @@ constexpr bool operator!=(const mat<rows, cols, T> &a, const mat<rows, cols, U> 
 template <int rows, int cols, int in_rows, int in_cols, typename Element>
 DALI_HOST_DEV DALI_FORCEINLINE
 constexpr auto sub(const mat<in_rows, in_cols, Element> &m, int r = 0, int c = 0) {
-  mat<rows, cols, Element> result = {};
+  mat<rows, cols, Element> result{};
   MAT_ELEMENT_LOOP(i, j)
     result(i, j) = m(i+r, j+c);
   return result;
@@ -349,7 +349,7 @@ constexpr auto sub(const mat<in_rows, in_cols, Element> &m, int r = 0, int c = 0
   constexpr auto operator op(const mat<rows, cols, T1> &a,    \
                              const mat<rows, cols, T2> &b) {  \
     using R = promote_vec_t<T1, T2>;                          \
-    mat<rows, cols, R> result;                                \
+    mat<rows, cols, R> result{};                              \
     MAT_ELEMENT_LOOP(i, j)                                    \
       result(i, j) = a(i, j) op b(i, j);                      \
     return result;                                            \
@@ -361,7 +361,7 @@ constexpr auto sub(const mat<in_rows, in_cols, Element> &m, int r = 0, int c = 0
   DALI_HOST_DEV                                                         \
   constexpr std::enable_if_t<is_scalar<T2>::value, mat<rows, cols, R>>  \
     operator op(const mat<rows, cols, T1> &a, const T2 &b) {            \
-    mat<rows, cols, R> result;                                          \
+    mat<rows, cols, R> result{};                                        \
     MAT_ELEMENT_LOOP(i, j)                                              \
       result(i, j) = a(i, j) op b;                                      \
     return result;                                                      \
@@ -373,7 +373,7 @@ constexpr auto sub(const mat<in_rows, in_cols, Element> &m, int r = 0, int c = 0
   DALI_HOST_DEV                                                         \
   constexpr std::enable_if_t<is_scalar<T1>::value, mat<rows, cols, R>>  \
   operator op(const T1 &a, const mat<rows, cols, T2> &b) {              \
-    mat<rows, cols, R> result;                                          \
+    mat<rows, cols, R> result{};                                        \
     MAT_ELEMENT_LOOP(i, j)                                              \
       result(i, j) = a op b(i, j);                                      \
     return result;                                                      \

--- a/include/dali/core/geom/mat.h
+++ b/include/dali/core/geom/mat.h
@@ -259,7 +259,7 @@ struct mat {
 
   template <typename U, int rhs_cols>
   DALI_HOST_DEV
-  inline auto operator*(const mat<cols, rhs_cols, U> &rhs) const {
+  constexpr auto operator*(const mat<cols, rhs_cols, U> &rhs) const {
     using R = promote_vec_t<Element, U>;
     mat<rows, rhs_cols, R> result{};
   #if MAT_LAYOUT_ROW_MAJOR


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
--->


## Description:
The default constructor for `mat` is a defaulted no-op, so constexpr functions that return mat objects should construct use `{}` or some other zeroing construction syntax. This PR fixes that.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [X] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
