### PR TITLE
Fix memory leak in libjpeg-turbo decoder implementation in case of corrupted images

### DIFF
--- a/dali/image/jpeg.cc
+++ b/dali/image/jpeg.cc
@@ -106,7 +106,7 @@ JpegImage::DecodeImpl(DALIImageType type, const uint8 *jpeg, size_t length) cons
                "Color space not supported by libjpeg-turbo");
   flags.color_space = type;
 
-  std::shared_ptr<uint8_t> decoded_image(jpeg::Uncompress(jpeg, length, flags),
+  std::shared_ptr<uint8_t> decoded_image(jpeg::Uncompress(jpeg, length, flags).release(),
                                          [](uint8_t *data) { delete[] data; });
 
   if (decoded_image == nullptr) {

--- a/dali/image/jpeg.cc
+++ b/dali/image/jpeg.cc
@@ -106,10 +106,8 @@ JpegImage::DecodeImpl(DALIImageType type, const uint8 *jpeg, size_t length) cons
                "Color space not supported by libjpeg-turbo");
   flags.color_space = type;
 
-  std::shared_ptr<uint8_t> decoded_image(
-    jpeg::Uncompress(jpeg, length, flags),
-    [](uint8_t* data){ delete [] data; }
-  );
+  std::shared_ptr<uint8_t> decoded_image(jpeg::Uncompress(jpeg, length, flags),
+                                         [](uint8_t *data) { delete[] data; });
 
   if (decoded_image == nullptr) {
     // Failed to decode, fallback

--- a/dali/image/jpeg.cc
+++ b/dali/image/jpeg.cc
@@ -61,7 +61,6 @@ bool get_jpeg_size(const uint8 *data, size_t data_size, int *height, int *width,
 std::pair<std::shared_ptr<uint8_t>, Image::Shape>
 JpegImage::DecodeImpl(DALIImageType type, const uint8 *jpeg, size_t length) const {
   const auto shape = PeekShapeImpl(jpeg, length);
-  auto target_shape = shape;
   const auto h = shape[0];
   const auto w = shape[1];
   assert(shape[2] <= 3);  // peek shape should clamp to 3 channels
@@ -69,6 +68,7 @@ JpegImage::DecodeImpl(DALIImageType type, const uint8 *jpeg, size_t length) cons
     type = shape[2] == 3 ? DALI_RGB : DALI_GRAY;
   }
   const auto c = NumberOfChannels(type);
+  Image::Shape target_shape{h, w, c};
 
   DALI_ENFORCE(jpeg != nullptr);
   DALI_ENFORCE(length > 0);
@@ -98,8 +98,8 @@ JpegImage::DecodeImpl(DALIImageType type, const uint8 *jpeg, size_t length) cons
     flags.crop_x = crop.anchor[1];
     flags.crop_height = crop.shape[0];
     flags.crop_width = crop.shape[1];
-    target_shape.shape[0] = crop.shape[0];
-    target_shape.shape[1] = crop.shape[1];
+    target_shape[0] = crop.shape[0];
+    target_shape[1] = crop.shape[1];
   }
 
   DALI_ENFORCE(type == DALI_RGB || type == DALI_BGR || type == DALI_GRAY,

--- a/dali/imgcodec/decoders/jpeg/jpeg_mem.cc
+++ b/dali/imgcodec/decoders/jpeg/jpeg_mem.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include <utility>
 #include "dali/imgcodec/decoders/jpeg/jpeg_handle.h"
 #include "dali/core/error_handling.h"
+#include "dali/core/call_at_exit.h"
 
 namespace dali {
 namespace jpeg {
@@ -46,22 +47,16 @@ enum JPEGErrors {
 // arguments in a struct struct.
 class FewerArgsForCompiler {
  public:
-  FewerArgsForCompiler(int datasize, const UncompressFlags& flags, int64* nwarn,
-                       std::function<uint8*(int, int, int)> allocate_output)
+  FewerArgsForCompiler(int datasize, const UncompressFlags& flags)
       : datasize_(datasize),
         flags_(flags),
-        pnwarn_(nwarn),
-        allocate_output_(std::move(allocate_output)),
         height_read_(0),
         height_(0),
         stride_(0) {
-    if (pnwarn_ != nullptr) *pnwarn_ = 0;
   }
 
   const int datasize_;
   const UncompressFlags flags_;
-  int64* const pnwarn_;
-  std::function<uint8*(int, int, int)> allocate_output_;
   int height_read_;  // number of scanline lines successfully read
   int height_;
   int stride_;
@@ -85,7 +80,6 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
   const int ratio = flags.ratio;
   int components = flags.components;
   int stride = flags.stride;              // may be 0
-  int64* const nwarn = argball->pnwarn_;  // may be NULL
   auto color_space = flags.color_space;
 
   // Can't decode if the ratio is not recognized by libjpeg
@@ -102,7 +96,8 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
   if (datasize == 0 || srcdata == nullptr) return nullptr;
 
   // Declare temporary buffer pointer here so that we can free on error paths
-  JSAMPLE* tempdata = nullptr;
+  std::unique_ptr<JSAMPLE[]> temp;
+  JSAMPLE *tempdata = nullptr;
 
   // Initialize libjpeg structures to have a memory source
   // Modify the usual jpeg error manager to catch fatal errors.
@@ -114,11 +109,14 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
   cinfo.client_data = &jpeg_jmpbuf;
   jerr.error_exit = CatchError;
   if (setjmp(jpeg_jmpbuf)) {
-    delete[] tempdata;
     return nullptr;
   }
 
   jpeg_create_decompress(&cinfo);
+  auto destroy_cinfo = AtScopeExit([&cinfo]() {
+    jpeg_destroy_decompress(&cinfo);
+  });
+
   SetSrc(&cinfo, srcdata, datasize, flags.try_recover_truncated_jpeg);
   jpeg_read_header(&cinfo, TRUE);
 
@@ -136,7 +134,6 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
       break;
     default:
       ERROR_LOG << " Invalid components value " << components << std::endl;
-      jpeg_destroy_decompress(&cinfo);
       return nullptr;
   }
 
@@ -164,12 +161,10 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
   if (cinfo.output_width <= 0 || cinfo.output_height <= 0) {
     ERROR_LOG << "Invalid image size: " << cinfo.output_width << " x "
               << cinfo.output_height << std::endl;
-    jpeg_destroy_decompress(&cinfo);
     return nullptr;
   }
   if (total_size >= (1LL << 29)) {
     ERROR_LOG << "Image too large: " << total_size << std::endl;
-    jpeg_destroy_decompress(&cinfo);
     return nullptr;
   }
 
@@ -194,7 +189,6 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
                 << " for image_width: " << cinfo.output_width
                 << " and image_height: " << cinfo.output_height
                 << std::endl;
-      jpeg_destroy_decompress(&cinfo);
       return nullptr;
     }
 
@@ -227,7 +221,6 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
   } else if (stride < min_stride) {
     ERROR_LOG << "Incompatible stride: " << stride
               << " < " << min_stride << std::endl;
-    jpeg_destroy_decompress(&cinfo);
     return nullptr;
   }
 
@@ -235,23 +228,22 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
   argball->height_ = target_output_height;
   argball->stride_ = stride;
 
+
+  std::unique_ptr<uint8[]> dstdata;
 #if !defined(LIBJPEG_TURBO_VERSION)
-  uint8* dstdata = nullptr;
-  if (flags.crop) {
-    dstdata = new JSAMPLE[stride * target_output_height];
-  } else {
-    dstdata = argball->allocate_output_(target_output_width,
-                                        target_output_height, components);
-  }
+  if (flags.crop)
+    dstdata.reset(new JSAMPLE[stride * target_output_height]);
+  else
+    dstdata.reset(new JSAMPLE[target_output_width * target_output_height * components]);
 #else
-  uint8* dstdata = argball->allocate_output_(target_output_width,
-                                             target_output_height, components);
+  dstdata.reset(new JSAMPLE[target_output_width * target_output_height * components]);
 #endif
+   
   if (dstdata == nullptr) {
-    jpeg_destroy_decompress(&cinfo);
     return nullptr;
   }
-  JSAMPLE* output_line = static_cast<JSAMPLE*>(dstdata);
+
+  JSAMPLE* output_line = static_cast<JSAMPLE*>(dstdata.get());
 
   // jpeg_read_scanlines requires the buffers to be allocated based on
   // cinfo.output_width, but the target image width might be different if crop
@@ -265,11 +257,12 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
 
   if (use_cmyk) {
     // Temporary buffer used for CMYK -> RGB conversion.
-    tempdata = new JSAMPLE[cinfo.output_width * 4];
+    temp.reset(new JSAMPLE[cinfo.output_width * 4]);
   } else if (need_realign_cropped_scanline) {
     // Temporary buffer used for MCU-aligned scanline data.
-    tempdata = new JSAMPLE[cinfo.output_width * components];
+    temp.reset(new JSAMPLE[cinfo.output_width * components]);
   }
+  tempdata = temp.get();
 
   // If there is an error reading a line, this aborts the reading.
   // Save the fraction of the image that has been read.
@@ -363,8 +356,7 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
     DALI_ENFORCE(num_lines_read == 1);
     output_line += stride;
   }
-  delete[] tempdata;
-  tempdata = nullptr;
+  temp.reset();
 
 #if defined(LIBJPEG_TURBO_VERSION)
   if (flags.crop && cinfo.output_scanline < cinfo.output_height) {
@@ -383,7 +375,7 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
   if (components == 4) {
     // Start on the last line.
     JSAMPLE* scanlineptr = static_cast<JSAMPLE*>(
-        dstdata + static_cast<int64>(target_output_height - 1) * stride);
+        dstdata.get() + static_cast<int64>(target_output_height - 1) * stride);
     const JSAMPLE kOpaque = -1;  // All ones appropriate for JSAMPLE.
     const int right_rgb = (target_output_width - 1) * 3;
     const int right_rgba = (target_output_width - 1) * 4;
@@ -426,13 +418,7 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
     default:
       // will never happen, should be catched by the previous switch
       ERROR_LOG << "Invalid components value " << components << std::endl;
-      jpeg_destroy_decompress(&cinfo);
       return nullptr;
-  }
-
-  // save number of warnings if requested
-  if (nwarn != nullptr) {
-    *nwarn = cinfo.err->num_warnings;
   }
 
   // Handle errors in JPEG
@@ -465,17 +451,13 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
                 << " for image_width: " << cinfo.output_width
                 << " and image_height: " << cinfo.output_height
                 << std::endl;
-      delete[] dstdata;
-      jpeg_destroy_decompress(&cinfo);
       return nullptr;
     }
 
-    const uint8* full_image = dstdata;
-    dstdata = argball->allocate_output_(target_output_width,
-                                        target_output_height, components);
+    const auto full_image = std::move(dstdata);
+    dstdata = std::unique_ptr<uint8[]>(
+        new JSAMPLE[target_output_width, target_output_height, components]);
     if (dstdata == nullptr) {
-      delete[] full_image;
-      jpeg_destroy_decompress(&cinfo);
       return nullptr;
     }
 
@@ -492,19 +474,17 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
       argball->height_read_ = target_output_height;
     }
     const int crop_offset = flags.crop_x * components * sizeof(JSAMPLE);
-    const uint8* full_image_ptr = full_image + flags.crop_y * full_image_stride;
-    uint8* crop_image_ptr = dstdata;
+    const uint8* full_image_ptr = full_image.get() + flags.crop_y * full_image_stride;
+    uint8* crop_image_ptr = dstdata.get();
     for (int i = 0; i < argball->height_read_; i++) {
       memcpy(crop_image_ptr, full_image_ptr + crop_offset, min_stride);
       crop_image_ptr += stride;
       full_image_ptr += full_image_stride;
     }
-    delete[] full_image;
   }
 #endif
 
-  jpeg_destroy_decompress(&cinfo);
-  return dstdata;
+  return dstdata.release();
 }
 
 }  // anonymous namespace
@@ -518,10 +498,8 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
 //  parameters won't get clobbered by the longjmp.  So we help
 //  it out a little.
 uint8* Uncompress(const void* srcdata, int datasize,
-                  const UncompressFlags& flags, int64* nwarn,
-                  std::function<uint8*(int, int, int)> allocate_output) {
-  FewerArgsForCompiler argball(datasize, flags, nwarn,
-                               std::move(allocate_output));
+                  const UncompressFlags& flags) {
+  FewerArgsForCompiler argball(datasize, flags);
   uint8* const dstdata = UncompressLow(srcdata, &argball);
 
   const float fraction_read =
@@ -544,23 +522,6 @@ uint8* Uncompress(const void* srcdata, int datasize,
   }
 
   return dstdata;
-}
-
-uint8* Uncompress(const void* srcdata, int datasize,
-                  const UncompressFlags& flags, int* pwidth, int* pheight,
-                  int* pcomponents, int64* nwarn) {
-  uint8* buffer = nullptr;
-  uint8* result =
-      Uncompress(srcdata, datasize, flags, nwarn,
-                 [=, &buffer](int width, int height, int components) {
-                   if (pwidth != nullptr) *pwidth = width;
-                   if (pheight != nullptr) *pheight = height;
-                   if (pcomponents != nullptr) *pcomponents = components;
-                   buffer = new uint8[height * width * components];
-                   return buffer;
-                 });
-  if (!result) delete[] buffer;
-  return result;
 }
 
 // ----------------------------------------------------------------------------
@@ -604,197 +565,6 @@ bool GetImageInfo(const void* srcdata, int datasize, int* width, int* height,
 
   jpeg_destroy_decompress(&cinfo);
   return true;
-}
-
-// -----------------------------------------------------------------------------
-// Compression
-
-namespace {
-bool CompressInternal(const uint8* srcdata, int width, int height,
-                      const CompressFlags& flags, string* output) {
-  output->clear();
-  const int components = (static_cast<int>(flags.format) & 0xff);
-
-  int64 total_size = static_cast<int64>(width) * static_cast<int64>(height);
-  // Some of the internal routines do not gracefully handle ridiculously
-  // large images, so fail fast.
-  if (width <= 0 || height <= 0) {
-    ERROR_LOG << "Invalid image size: " << width << " x " << height << std::endl;
-    return false;
-  }
-  if (total_size >= (1_i64 << 29)) {
-    ERROR_LOG << "Image too large: " << total_size << std::endl;
-    return false;
-  }
-
-  int in_stride = flags.stride;
-  if (in_stride == 0) {
-    in_stride = width * (static_cast<int>(flags.format) & 0xff);
-  } else if (in_stride < width * components) {
-    ERROR_LOG << "Incompatible input stride" << std::endl;
-    return false;
-  }
-
-  JOCTET* buffer = nullptr;
-
-  // NOTE: for broader use xmp_metadata should be made a unicode string
-  DALI_ENFORCE(srcdata != nullptr);
-  DALI_ENFORCE(output != nullptr);
-  // This struct contains the JPEG compression parameters and pointers to
-  // working space
-  struct jpeg_compress_struct cinfo;
-  // This struct represents a JPEG error handler.
-  struct jpeg_error_mgr jerr;
-  jmp_buf jpeg_jmpbuf;  // recovery point in case of error
-
-  // Step 1: allocate and initialize JPEG compression object
-  // Use the usual jpeg error manager.
-  cinfo.err = jpeg_std_error(&jerr);
-  cinfo.client_data = &jpeg_jmpbuf;
-  jerr.error_exit = CatchError;
-  if (setjmp(jpeg_jmpbuf)) {
-    output->clear();
-    delete[] buffer;
-    return false;
-  }
-
-  jpeg_create_compress(&cinfo);
-
-  // Step 2: specify data destination
-  // We allocate a buffer of reasonable size. If we have a small image, just
-  // estimate the size of the output using the number of bytes of the input.
-  // If this is getting too big, we will append to the string by chunks of 1MB.
-  // This seems like a reasonable compromise between performance and memory.
-  int bufsize = std::min(width * height * components, 1 << 20);
-  buffer = new JOCTET[bufsize];
-  SetDest(&cinfo, buffer, bufsize, output);
-
-  // Step 3: set parameters for compression
-  cinfo.image_width = width;
-  cinfo.image_height = height;
-  switch (components) {
-    case 1:
-      cinfo.input_components = 1;
-      cinfo.in_color_space = JCS_GRAYSCALE;
-      break;
-    case 3:
-    case 4:
-      cinfo.input_components = 3;
-      cinfo.in_color_space = JCS_RGB;
-      break;
-    default:
-      ERROR_LOG << " Invalid components value " << components << std::endl;
-      output->clear();
-      delete[] buffer;
-      return false;
-  }
-  jpeg_set_defaults(&cinfo);
-  if (flags.optimize_jpeg_size) cinfo.optimize_coding = TRUE;
-
-  cinfo.density_unit = flags.density_unit;  // JFIF code for pixel size units:
-                                            // 1 = in, 2 = cm
-  cinfo.X_density = flags.x_density;        // Horizontal pixel density
-  cinfo.Y_density = flags.y_density;        // Vertical pixel density
-  jpeg_set_quality(&cinfo, flags.quality, TRUE);
-
-  if (flags.progressive) {
-    jpeg_simple_progression(&cinfo);
-  }
-
-  if (!flags.chroma_downsampling) {
-    // Turn off chroma subsampling (it is on by default).  For more details on
-    // chroma subsampling, see http://en.wikipedia.org/wiki/Chroma_subsampling.
-    for (int i = 0; i < cinfo.num_components; ++i) {
-      cinfo.comp_info[i].h_samp_factor = 1;
-      cinfo.comp_info[i].v_samp_factor = 1;
-    }
-  }
-
-  jpeg_start_compress(&cinfo, TRUE);
-
-  // Embed XMP metadata if any
-  if (!flags.xmp_metadata.empty()) {
-    // XMP metadata is embedded in the APP1 tag of JPEG and requires this
-    // namespace header string (null-terminated)
-    const string name_space = "http://ns.adobe.com/xap/1.0/";
-    const int name_space_length = name_space.size();
-    const int metadata_length = flags.xmp_metadata.size();
-    const int packet_length = metadata_length + name_space_length + 1;
-    std::unique_ptr<JOCTET[]> joctet_packet(new JOCTET[packet_length]);
-
-    for (int i = 0; i < name_space_length; i++) {
-      // Conversion char --> JOCTET
-      joctet_packet[i] = name_space[i];
-    }
-    joctet_packet[name_space_length] = 0;  // null-terminate namespace string
-
-    for (int i = 0; i < metadata_length; i++) {
-      // Conversion char --> JOCTET
-      joctet_packet[i + name_space_length + 1] = flags.xmp_metadata[i];
-    }
-    jpeg_write_marker(&cinfo, JPEG_APP0 + 1, joctet_packet.get(),
-                      packet_length);
-  }
-
-  // JSAMPLEs per row in image_buffer
-  std::unique_ptr<JSAMPLE[]> row_temp(
-      new JSAMPLE[width * cinfo.input_components]);
-  while (cinfo.next_scanline < cinfo.image_height) {
-    JSAMPROW row_pointer[1];  // pointer to JSAMPLE row[s]
-    const uint8* r = &srcdata[cinfo.next_scanline * in_stride];
-    uint8* p = static_cast<uint8*>(row_temp.get());
-    switch (flags.format) {
-      case FORMAT_RGBA: {
-        for (int i = 0; i < width; ++i, p += 3, r += 4) {
-          p[0] = r[0];
-          p[1] = r[1];
-          p[2] = r[2];
-        }
-        row_pointer[0] = row_temp.get();
-        break;
-      }
-      case FORMAT_ABGR: {
-        for (int i = 0; i < width; ++i, p += 3, r += 4) {
-          p[0] = r[3];
-          p[1] = r[2];
-          p[2] = r[1];
-        }
-        row_pointer[0] = row_temp.get();
-        break;
-      }
-      default: {
-        row_pointer[0] = reinterpret_cast<JSAMPLE*>(const_cast<JSAMPLE*>(r));
-      }
-    }
-
-    DALI_ENFORCE(
-      jpeg_write_scanlines(&cinfo, row_pointer, 1) == 1u);
-  }
-  jpeg_finish_compress(&cinfo);
-
-  // release JPEG compression object
-  jpeg_destroy_compress(&cinfo);
-  delete[] buffer;
-  return true;
-}
-
-}  // anonymous namespace
-
-// -----------------------------------------------------------------------------
-
-bool Compress(const void* srcdata, int width, int height,
-              const CompressFlags& flags, string* output) {
-  return CompressInternal(static_cast<const uint8*>(srcdata), width, height,
-                          flags, output);
-}
-
-string Compress(const void* srcdata, int width, int height,
-                const CompressFlags& flags) {
-  string temp;
-  CompressInternal(static_cast<const uint8*>(srcdata), width, height, flags,
-                   &temp);
-  // If CompressInternal fails, temp will be empty.
-  return temp;
 }
 
 }  // namespace jpeg

--- a/dali/imgcodec/decoders/jpeg/jpeg_mem.cc
+++ b/dali/imgcodec/decoders/jpeg/jpeg_mem.cc
@@ -238,7 +238,7 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
 #else
   dstdata.reset(new JSAMPLE[target_output_width * target_output_height * components]);
 #endif
-   
+
   if (dstdata == nullptr) {
     return nullptr;
   }
@@ -357,6 +357,7 @@ uint8* UncompressLow(const void* srcdata, FewerArgsForCompiler* argball) {
     output_line += stride;
   }
   temp.reset();
+  tempdata = nullptr;
 
 #if defined(LIBJPEG_TURBO_VERSION)
   if (flags.crop && cinfo.output_scanline < cinfo.output_height) {

--- a/dali/imgcodec/decoders/jpeg/jpeg_mem.h
+++ b/dali/imgcodec/decoders/jpeg/jpeg_mem.h
@@ -79,29 +79,11 @@ struct UncompressFlags {
 
 // Uncompress some raw JPEG data given by the pointer srcdata and the length
 // datasize.
-// - width and height are the address where to store the size of the
-//   uncompressed image in pixels.  May be nullptr.
-// - components is the address where the number of read components are
-//   stored.  This is *output only*: to request a specific number of
-//   components use flags.components.  May be nullptr.
-// - nwarn is the address in which to store the number of warnings.
-//   May be nullptr.
 // The function returns a pointer to the raw uncompressed data or NULL if
 // there was an error. The caller of the function is responsible for
 // freeing the memory (using delete []).
 uint8* Uncompress(const void* srcdata, int datasize,
-                  const UncompressFlags& flags, int* width, int* height,
-                  int* components,  // Output only: useful with autodetect
-                  int64* nwarn);
-
-// Version of Uncompress that allocates memory via a callback.  The callback
-// arguments are (width, height, components).  If the size is known ahead of
-// time this function can return an existing buffer; passing a callback allows
-// the buffer to be shaped based on the JPEG header.  The caller is responsible
-// for freeing the memory *even along error paths*.
-uint8* Uncompress(const void* srcdata, int datasize,
-                  const UncompressFlags& flags, int64* nwarn,
-                  std::function<uint8*(int, int, int)> allocate_output);
+                  const UncompressFlags& flags);
 
 // Read jpeg header and get image information.  Returns true on success.
 // The width, height, and components points may be null.
@@ -146,18 +128,6 @@ struct CompressFlags {
   // used will be this minimal value.
   int stride = 0;
 };
-
-// Compress some raw image given in srcdata, the data is a 2D array of size
-// stride*height with one of the formats enumerated above.
-// The encoded data is returned as a string.
-// If not empty, XMP metadata can be embedded in the image header
-// On error, returns the empty string (which is never a valid jpeg).
-string Compress(const void* srcdata, int width, int height,
-                const CompressFlags& flags);
-
-// On error, returns false and sets output to empty.
-bool Compress(const void* srcdata, int width, int height,
-              const CompressFlags& flags, string* output);
 
 }  // namespace jpeg
 }  // namespace dali

--- a/dali/imgcodec/decoders/jpeg/jpeg_mem.h
+++ b/dali/imgcodec/decoders/jpeg/jpeg_mem.h
@@ -24,6 +24,7 @@ limitations under the License.
 #define DALI_IMGCODEC_DECODERS_JPEG_JPEG_MEM_H_
 
 #include <functional>
+#include <memory>
 #include <string>
 #include "dali/core/common.h"
 #include "dali/imgcodec/decoders/jpeg/jpeg_utils.h"
@@ -79,11 +80,10 @@ struct UncompressFlags {
 
 // Uncompress some raw JPEG data given by the pointer srcdata and the length
 // datasize.
-// The function returns a pointer to the raw uncompressed data or NULL if
-// there was an error. The caller of the function is responsible for
-// freeing the memory (using delete []).
-uint8* Uncompress(const void* srcdata, int datasize,
-                  const UncompressFlags& flags);
+// The function returns a shared pointer to the uncompressed data or a null pointer if
+// there was an error.
+std::unique_ptr<uint8[]> Uncompress(const void* srcdata, int datasize,
+                                    const UncompressFlags& flags);
 
 // Read jpeg header and get image information.  Returns true on success.
 // The width, height, and components points may be null.


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Bug fix**

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
- Fixes the memory leak reported by https://github.com/NVIDIA/DALI/issues/4076
- The issue came from throwing exceptions in code where memory management was handled manually
- The solution is to use unique_ptr's to handle the memory, and `.release()` on the successful path.
- Removed dead code

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
`fn.decoders.image`


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
Replacement of manual memory handling with unique_ptr

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A
Checked memory consumption locally with the dataset provided in the mentioned issue

<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2944
<!--- DALI-2944 or NA --->
