### PR TITLE
Extend the ImageDecoder testing framework to support GPU decoders

### DIFF
--- a/dali/imgcodec/decoders/decoder_test_helper.h
+++ b/dali/imgcodec/decoders/decoder_test_helper.h
@@ -53,7 +53,7 @@ class DecoderTestBase : public ::testing::Test {
   /**
   * @brief Decodes an image and returns the result as a CPU tensor.
   */
-  TensorView<StorageCPU, OutputType> Decode(ImageSource *src, const DecodeParams &opts = {}, 
+  TensorView<StorageCPU, OutputType> Decode(ImageSource *src, const DecodeParams &opts = {},
                                             const ROI &roi = {}) {
     EXPECT_TRUE(Parser()->CanParse(src));
     EXPECT_TRUE(Decoder()->CanDecode(src, opts));
@@ -133,7 +133,8 @@ class DecoderTestBase : public ::testing::Test {
   * @brief Checks if the image and the reference are equal after converting the reference
   * with ConvertSatNorm
   */
-  void AssertEqualSatNorm(const TensorView<StorageCPU, OutputType> &img, const Tensor<CPUBackend> &ref) {
+  void AssertEqualSatNorm(const TensorView<StorageCPU, OutputType> &img,
+                          const Tensor<CPUBackend> &ref) {
     TYPE_SWITCH(ref.type(), type2id, RefType, NUMPY_ALLOWED_TYPES, (
       Check(img, view<const RefType>(ref), EqualConvertSatNorm());
     ), DALI_FAIL(make_string("Unsupported reference type: ", ref.type())));  // NOLINT

--- a/dali/imgcodec/decoders/libjpeg_turbo_test.cc
+++ b/dali/imgcodec/decoders/libjpeg_turbo_test.cc
@@ -69,7 +69,7 @@ TEST(LibJpegTurboDecoderTest, Factory) {
 }
 
 template<typename OutputType>
-class LibJpegTurboDecoderTest : public NumpyDecoderTestBase<OutputType> {
+class LibJpegTurboDecoderTest : public NumpyDecoderTestBase<CPUBackend, OutputType> {
  protected:
   static const auto dtype = type2id<OutputType>::value;
 

--- a/dali/imgcodec/util/convert_test.cc
+++ b/dali/imgcodec/util/convert_test.cc
@@ -52,7 +52,7 @@ std::string image_path(const std::string &name, const std::string &type_name) {
  * @tparam ImageType The type of images to run the test on
  */
 template <typename ImageType>
-class ColorConversionTest : public NumpyDecoderTestBase<ImageType> {
+class ColorConversionTest : public NumpyDecoderTestBase<CPUBackend, ImageType> {
  public:
   /**
    * @brief Checks if the conversion result matches the reference.


### PR DESCRIPTION
Signed-off-by: Michał Staniewski <m.staniewzki@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)


## Description:
Adjusting `decoder_test_helper.h`, replacing `CpuDecoderTestBase` with templated `DecoderTestBase`.

## Additional information:

### Affected modules and functionalities:
N/A

### Key points relevant for the review:
N/A

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
