### PR TITLE
Add color conversion support to OpenCV decoder

### DIFF
--- a/dali/imgcodec/decoders/opencv_fallback.cc
+++ b/dali/imgcodec/decoders/opencv_fallback.cc
@@ -47,24 +47,28 @@ DecodeResult OpenCVDecoderInstance::Decode(SampleView<CPUBackend> out,
                                            const ROI &roi) {
   int flags = 0;
   bool adjust_orientation = false;
+  DALIImageType in_format;
 
   switch (opts.format) {
     case DALI_ANY_DATA:
       // Note: IMREAD_UNCHANGED always ignores orientation
       flags |= cv::IMREAD_UNCHANGED;
       adjust_orientation = opts.use_orientation;
+      in_format = DALI_ANY_DATA;
       break;
 
     case DALI_GRAY:
       flags |= cv::IMREAD_GRAYSCALE;
       if (!opts.use_orientation)
         flags |= cv::IMREAD_IGNORE_ORIENTATION;
+      in_format = DALI_GRAY;
       break;
 
     default:
       flags |= cv::IMREAD_COLOR;
       if (!opts.use_orientation)
         flags |= cv::IMREAD_IGNORE_ORIENTATION;
+      in_format = DALI_BGR;
       break;
   }
 
@@ -81,9 +85,6 @@ DecodeResult OpenCVDecoderInstance::Decode(SampleView<CPUBackend> out,
       const auto *raw = static_cast<const uint8_t *>(in->RawData());
       cvimg = cv::imdecode(cv::_InputArray(raw, in->Size()), flags);
     }
-
-    if (flags & cv::IMREAD_COLOR)  // TODO(michalz) - move this to Convert
-      cv::cvtColor(cvimg, cvimg, cv::COLOR_BGR2RGB);
 
     // TODO(michalz): correct the orientation of images loaded with IMREAD_UNCHANGED
     (void)adjust_orientation;
@@ -109,7 +110,7 @@ DecodeResult OpenCVDecoderInstance::Decode(SampleView<CPUBackend> out,
       TensorLayout layout = cvimg.dims == 3 ? "DHWC" : "HWC";
 
       Convert(out, layout, opts.format,
-              in, layout, opts.format,  // TODO(michalz) - use actual format
+              in, layout, in_format,
               roi.begin, roi.end);
     }
   } catch (...) {


### PR DESCRIPTION

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** (*non-breaking change which adds functionality*)


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

The OpenCV decoder was written before the color conversion was implemented in imgcodec (https://github.com/NVIDIA/DALI/pull/4121). This small PR makes the OpenCV decoder use imgcodec's color conversion.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2946
