### PR TITLE
Fix parsing of grayscale bitmaps

### DIFF
--- a/dali/imgcodec/image_format_test.cc
+++ b/dali/imgcodec/image_format_test.cc
@@ -196,7 +196,7 @@ TEST_F(ImageFormatTest, ReadHeaderStream) {
   EXPECT_EQ(0, buffer[3]);
 }
 
-TEST_F(CompatibilityTest, DISABLED_Png) {
+TEST_F(CompatibilityTest, Png) {
   RunOnDirectory(testing::dali_extra_path() + "/db/single/png/", "png", {".png"});
 }
 
@@ -208,20 +208,20 @@ TEST_F(CompatibilityTest, Tiff) {
   RunOnDirectory(testing::dali_extra_path() + "/db/single/tiff/", "tiff", {".tiff"});
 }
 
-TEST_F(CompatibilityTest, DISABLED_Pnm) {
+TEST_F(CompatibilityTest, Pnm) {
   RunOnDirectory(testing::dali_extra_path() + "/db/single/pnm/", "pnm",
                  {".pnm", ".ppm", ".pgm", ".pbm"});
 }
 
-TEST_F(CompatibilityTest, DISABLED_Jpeg2000) {
+TEST_F(CompatibilityTest, Jpeg2000) {
   RunOnDirectory(testing::dali_extra_path() + "/db/single/jpeg2k/", "jpeg2000", {".jp2"});
 }
 
-TEST_F(CompatibilityTest, DISABLED_WebP) {
+TEST_F(CompatibilityTest, WebP) {
   RunOnDirectory(testing::dali_extra_path() + "/db/single/webp/", "webp", {".webp"});
 }
 
-TEST_F(CompatibilityTest, DISABLED_Jpeg) {
+TEST_F(CompatibilityTest, Jpeg) {
   RunOnDirectory(testing::dali_extra_path() + "/db/single/jpeg/", "jpeg", {".jpg", ".jpeg"});
 }
 

--- a/dali/imgcodec/image_format_test.cc
+++ b/dali/imgcodec/image_format_test.cc
@@ -200,7 +200,7 @@ TEST_F(CompatibilityTest, DISABLED_Png) {
   RunOnDirectory(testing::dali_extra_path() + "/db/single/png/", "png", {".png"});
 }
 
-TEST_F(CompatibilityTest, DISABLED_Bmp) {
+TEST_F(CompatibilityTest, Bmp) {
   RunOnDirectory(testing::dali_extra_path() + "/db/single/bmp/", "bmp", {".bmp"});
 }
 

--- a/dali/imgcodec/image_format_test.cc
+++ b/dali/imgcodec/image_format_test.cc
@@ -142,7 +142,7 @@ TEST_F(ImageFormatTest, Png) {
        TensorShape<>(425, 640, 3));
 }
 
-TEST_F(ImageFormatTest, DISABLED_Bmp) {
+TEST_F(ImageFormatTest, Bmp) {
   Test(testing::dali_extra_path() + "/db/single/bmp/0/cat-1046544_640.bmp", "bmp",
        TensorShape<>(475, 640, 3));
 }

--- a/dali/imgcodec/parsers/bmp.cc
+++ b/dali/imgcodec/parsers/bmp.cc
@@ -126,6 +126,7 @@ ImageInfo BmpParser::GetInfo(ImageSource *encoded) const {
   } else if (length >= 50 && header_size >= 40) {
     BitmapInfoHeader header = {};
     stream->ReadAll(&header, 1);
+    stream->Skip(header_size - sizeof(header));  // Skip the ignored part of header
     from_little_endian(header);
     w = abs(header.width);
     h = abs(header.heigth);

--- a/dali/imgcodec/parsers/bmp_test.cc
+++ b/dali/imgcodec/parsers/bmp_test.cc
@@ -82,7 +82,7 @@ TEST_F(BmpParserTest, CheckInfoValidBmp) {
 TEST_F(BmpParserTest, CheckInfoValidBmpGray) {
   LoadFileStream("/db/single/bmp/0/cat-111793_640_grayscale.bmp");
   auto info = GetInfo(valid_bmp_);
-  TensorShape<> expected_shape = {426, 640, 3};
+  TensorShape<> expected_shape = {426, 640, 1};
   ASSERT_EQ(info.shape, expected_shape);
 }
 
@@ -96,7 +96,7 @@ TEST_F(BmpParserTest, CheckInfoValidBmpPalette8bit) {
 TEST_F(BmpParserTest, CheckInfoValidBmpPalette1bit) {
   LoadFileStream("/db/single/bmp/0/cat-111793_640_palette_1bit.bmp");
   auto info = GetInfo(valid_bmp_);
-  TensorShape<> expected_shape = {426, 640, 3};
+  TensorShape<> expected_shape = {426, 640, 1};
   ASSERT_EQ(info.shape, expected_shape);
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->

**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

While trying to enable imgcodec's compatibility tests (https://github.com/NVIDIA/DALI/pull/4057) for all formats, @staniewzki noticed that the compatibility tests for BMP parser were failing for grayscale images, which were reported to have 3 channels.

It turned out that when reading a header, the parser only read the interesting part of it, but didn't skip the remaining part. This resulted in parser interpreting the remaining part of the header as a color palette, leading to wrong results of colorspace detection.

Also, the existing tests for grayscale images were wrong, probably due to a copy-paste error, as they expected 3 channels from grayscale images.

In this PR I fix the bug and the tests.

## Additional information:

### Affected modules and functionalities:
I also took the opportunity to enable compatibility tests for other formats.

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply (with fixes)
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2947