### PR TITLE
Refactor Tensor Vector

### DIFF
--- a/dali/operators/generic/constant.cc
+++ b/dali/operators/generic/constant.cc
@@ -72,7 +72,7 @@ namespace {
 template <typename Dst, typename Src>
 void FillTensorVector(
   TensorVector<CPUBackend> &dst, const TensorListShape<> &shape, const std::vector<Src> &src) {
-  dst.SetContiguous(BatchState::Noncontiguous);
+  dst.SetBatchState(BatchState::Noncontiguous);
   dst.set_type<Dst>();
   dst.Resize(shape);
   assert(is_uniform(shape));

--- a/dali/operators/generic/constant.cc
+++ b/dali/operators/generic/constant.cc
@@ -72,7 +72,7 @@ namespace {
 template <typename Dst, typename Src>
 void FillTensorVector(
   TensorVector<CPUBackend> &dst, const TensorListShape<> &shape, const std::vector<Src> &src) {
-  dst.SetContiguous(false);
+  dst.SetContiguous(BatchState::Noncontiguous);
   dst.set_type<Dst>();
   dst.Resize(shape);
   assert(is_uniform(shape));

--- a/dali/operators/generic/constant.cc
+++ b/dali/operators/generic/constant.cc
@@ -72,7 +72,7 @@ namespace {
 template <typename Dst, typename Src>
 void FillTensorVector(
   TensorVector<CPUBackend> &dst, const TensorListShape<> &shape, const std::vector<Src> &src) {
-  dst.SetBatchState(BatchState::Noncontiguous);
+  dst.SetContiguity(BatchContiguity::Noncontiguous);
   dst.set_type<Dst>();
   dst.Resize(shape);
   assert(is_uniform(shape));

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -37,6 +37,22 @@ namespace dali {
 class GPUBackend;
 class CPUBackend;
 
+/**
+ * @brief State of a batch object. Can be used to pin the state to one of the two contiguous /
+ * noncontiguous modes or to change the mode when resizing, if it was not pinned.
+ * See TensorVector::Resize for detailed behaviour.
+ * * Default - means we are leaving it to the Batch to decide when to coalesce the allocation,
+ *   or keep the current one unchanged.
+ * Contiguous and Noncontiguous allow to request one backing allocation or separate ones for each
+ * sample.
+ */
+enum class BatchState {
+  Default = 0,
+  Contiguous = 1,
+  Noncontiguous = 2,
+};
+
+
 
 DLL_PUBLIC shared_ptr<uint8_t> AllocBuffer(size_t bytes,
                                            bool pinned, int device_id,
@@ -578,8 +594,20 @@ class DLL_PUBLIC Buffer {
     num_bytes_ = 0;
   }
 
+  /**
+   * @brief Clear the ShareData flag of the buffer. It will still hold (and co-own) the data due
+   * to the shared_ptr semantics, but it is allowed to call resize() on it.
+   * Intended to be used by the Batch object only.
+   */
+  void detach() {
+    shares_data_ = false;
+  }
+
   template <typename>
   friend class TensorList;
+
+  template <typename>
+  friend class TensorVector;
 
   static double growth_factor_;
   static double shrink_threshold_;

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -38,7 +38,7 @@ class GPUBackend;
 class CPUBackend;
 
 /**
- * @brief State of a batch object. Can be used to pin the state to one of the two contiguous /
+ * @brief State of a batch object. Can be used to force the state to one of the two contiguous /
  * noncontiguous modes or to change the mode when resizing, if it was not pinned.
  * See TensorVector::Resize for detailed behaviour.
  * * Automatic - means we are leaving it to the Batch to decide when to coalesce the allocation,

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -41,13 +41,13 @@ class CPUBackend;
  * @brief State of a batch object. Can be used to pin the state to one of the two contiguous /
  * noncontiguous modes or to change the mode when resizing, if it was not pinned.
  * See TensorVector::Resize for detailed behaviour.
- * * Default - means we are leaving it to the Batch to decide when to coalesce the allocation,
+ * * Automatic - means we are leaving it to the Batch to decide when to coalesce the allocation,
  *   or keep the current one unchanged.
  * Contiguous and Noncontiguous allow to request one backing allocation or separate ones for each
  * sample.
  */
-enum class BatchState {
-  Default = 0,
+enum class BatchContiguity {
+  Automatic = 0,
   Contiguous = 1,
   Noncontiguous = 2,
 };

--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -147,6 +147,8 @@ class SampleViewBase {
   ~SampleViewBase() = default;
 };
 
+template <typename Backend>
+class ConstSampleView;
 
 template <typename Backend>
 class SampleView : public SampleViewBase<Backend, void *> {
@@ -158,6 +160,7 @@ class SampleView : public SampleViewBase<Backend, void *> {
   using Base::data_;
   using Base::shape_;
   using Base::type_id_;
+  friend class ConstSampleView<Backend>;
 };
 
 
@@ -182,14 +185,12 @@ class ConstSampleView : public SampleViewBase<Backend, const void *> {
   }
 
   ConstSampleView &operator=(SampleView<Backend> &&other) {
-    if (this != &other) {
-      data_ = other.data_;
-      other.data_ = nullptr;
-      shape_ = std::move(other.shape_);
-      other.shape_ = {0};
-      type_id_ = other.type_id_;
-      other.type_id_ = DALI_NO_TYPE;
-    }
+    data_ = other.data_;
+    other.data_ = nullptr;
+    shape_ = std::move(other.shape_);
+    other.shape_ = {0};
+    type_id_ = other.type_id_;
+    other.type_id_ = DALI_NO_TYPE;
     return *this;
   }
 

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -183,7 +183,7 @@ class Tensor : public Buffer<Backend> {
    * @brief Tensor is always backed by contiguous buffer
    *        Cannot be set to noncontiguous
    */
-  void SetContiguous(bool contiguous) {
+  void SetBatchState(bool contiguous) {
     DALI_ENFORCE(contiguous, "Tensor cannot be made noncontiguous");
   }
 

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -183,7 +183,7 @@ class Tensor : public Buffer<Backend> {
    * @brief Tensor is always backed by contiguous buffer
    *        Cannot be set to noncontiguous
    */
-  void SetBatchState(bool contiguous) {
+  void SetContiguity(bool contiguous) {
     DALI_ENFORCE(contiguous, "Tensor cannot be made noncontiguous");
   }
 

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -183,8 +183,8 @@ class Tensor : public Buffer<Backend> {
    * @brief Tensor is always backed by contiguous buffer
    *        Cannot be set to noncontiguous
    */
-  void SetContiguity(bool contiguous) {
-    DALI_ENFORCE(contiguous, "Tensor cannot be made noncontiguous");
+  void SetContiguity(BatchContiguity state) {
+    DALI_ENFORCE(state != BatchContiguity::Noncontiguous, "Tensor cannot be made noncontiguous");
   }
 
   using Buffer<Backend>::reserve;

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -360,7 +360,7 @@ class DLL_PUBLIC TensorList {
    * @brief TensorList is always backed by contiguous buffer
    *        Cannot be set to noncontiguous
    */
-  void SetContiguous(BatchState state) {
+  void SetBatchState(BatchState state) {
     DALI_ENFORCE(BatchState::Noncontiguous != state, "TensorList cannot be made noncontiguous");
   }
 

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -360,8 +360,8 @@ class DLL_PUBLIC TensorList {
    * @brief TensorList is always backed by contiguous buffer
    *        Cannot be set to noncontiguous
    */
-  void SetContiguous(bool contiguous) {
-    DALI_ENFORCE(contiguous, "TensorList cannot be made noncontiguous");
+  void SetContiguous(BatchState state) {
+    DALI_ENFORCE(BatchState::Noncontiguous != state, "TensorList cannot be made noncontiguous");
   }
 
   /**
@@ -837,6 +837,13 @@ class DLL_PUBLIC TensorList {
   }
 
   /** @} */  // end of ContiguousAccessorFunctions
+
+
+
+  // Next change removes the TensorList and replaces it by TensorVector. Heaving short lived
+  // access to the internals won't cause much coupling
+  template <typename InBackend>
+  friend class TensorVector;
 };
 
 }  // namespace dali

--- a/dali/pipeline/data/tensor_list.h
+++ b/dali/pipeline/data/tensor_list.h
@@ -360,8 +360,9 @@ class DLL_PUBLIC TensorList {
    * @brief TensorList is always backed by contiguous buffer
    *        Cannot be set to noncontiguous
    */
-  void SetBatchState(BatchState state) {
-    DALI_ENFORCE(BatchState::Noncontiguous != state, "TensorList cannot be made noncontiguous");
+  void SetContiguity(BatchContiguity state) {
+    DALI_ENFORCE(BatchContiguity::Noncontiguous != state,
+                 "TensorList cannot be made noncontiguous");
   }
 
   /**

--- a/dali/pipeline/data/tensor_list_as_tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_list_as_tensor_vector_test.cc
@@ -43,7 +43,7 @@ namespace test {
  * Remove APIs that will be not ported: tensor_offset
  * Tests were generalized over contiguous/noncontiguous option (see the pairs in
    TensorVectorBackendContiguous)
- * SetBatchState(true) was added in few places, as there is a difference in defaults between
+ * SetContiguity(true) was added in few places, as there is a difference in defaults between
    current TensorVector and TensorList.
  **************************************************************************************************/
 
@@ -132,7 +132,7 @@ TYPED_TEST_SUITE(TensorVectorTest, TensorVectorBackendContiguous);
 TYPED_TEST(TensorVectorTest, TestGetTypeSizeBytes) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetBatchState(this->kState);
+  tl.SetContiguity(this->kState);
 
   // Give the tensor a type
   tl.template set_type<float>();
@@ -217,7 +217,7 @@ TYPED_TEST(TensorVectorTest, TestReserveResize) {
 TYPED_TEST(TensorVectorTest, TestResizeWithoutType) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetBatchState(this->kState);
+  tl.SetContiguity(this->kState);
 
   // Give the tensor a size - setting shape on non-typed TL is invalid and results in an error
   auto shape = this->GetRandShape();
@@ -228,7 +228,7 @@ TYPED_TEST(TensorVectorTest, TestSetNoType) {
   // After type is set we cannot revert to DALI_NO_TYPE
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetBatchState(this->kState);
+  tl.SetContiguity(this->kState);
 
   tl.set_type(DALI_FLOAT);
   ASSERT_THROW(tl.set_type(DALI_NO_TYPE), std::runtime_error);
@@ -240,7 +240,7 @@ TYPED_TEST(TensorVectorTest, TestSetNoType) {
 TYPED_TEST(TensorVectorTest, TestGetContiguousPointer) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetBatchState(BatchState::Contiguous);
+  tl.SetContiguity(BatchContiguity::Contiguous);
 
   // Give the tensor a size and a type - uniform allocation
   auto shape = this->GetRandShape();
@@ -261,10 +261,10 @@ TYPED_TEST(TensorVectorTest, TestGetContiguousPointer) {
 TYPED_TEST(TensorVectorTest, TestGetBytesThenAccess) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetBatchState(this->kState);
+  tl.SetContiguity(this->kState);
   TensorVector<Backend> sharers[2];
-  sharers[0].SetBatchState(this->kState);
-  sharers[1].SetBatchState(!this->kState);
+  sharers[0].SetContiguity(this->kState);
+  sharers[1].SetContiguity(!this->kState);
 
   // Allocate the sharer
   for (auto &sharer : sharers) {
@@ -304,7 +304,7 @@ TYPED_TEST(TensorVectorTest, TestGetBytesThenAccess) {
 TYPED_TEST(TensorVectorTest, TestZeroSizeResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetBatchState(this->kState);
+  tensor_list.SetContiguity(this->kState);
 
   TensorListShape<> shape;
   tensor_list.template set_type<float>();
@@ -319,7 +319,7 @@ TYPED_TEST(TensorVectorTest, TestZeroSizeResize) {
 TYPED_TEST(TensorVectorTest, TestMultipleZeroSizeResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetBatchState(this->kState);
+  tensor_list.SetContiguity(this->kState);
 
   int num_tensor = this->RandInt(0, 128);
   auto shape = uniform_list_shape(num_tensor, TensorShape<>{ 0 });
@@ -341,7 +341,7 @@ TYPED_TEST(TensorVectorTest, TestMultipleZeroSizeResize) {
 TYPED_TEST(TensorVectorTest, TestFakeScalarResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetBatchState(this->kState);
+  tensor_list.SetContiguity(this->kState);
 
   int num_scalar = this->RandInt(1, 128);
   auto shape = uniform_list_shape(num_scalar, {1});  // {1} on purpose
@@ -362,7 +362,7 @@ TYPED_TEST(TensorVectorTest, TestFakeScalarResize) {
 TYPED_TEST(TensorVectorTest, TestTrueScalarResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetBatchState(this->kState);
+  tensor_list.SetContiguity(this->kState);
 
   int num_scalar = this->RandInt(1, 128);
   auto shape = uniform_list_shape(num_scalar, TensorShape<>{});
@@ -383,7 +383,7 @@ TYPED_TEST(TensorVectorTest, TestTrueScalarResize) {
 TYPED_TEST(TensorVectorTest, TestResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetBatchState(this->kState);
+  tensor_list.SetContiguity(this->kState);
 
   // Setup shape and offsets
   auto shape = this->GetRandShape();
@@ -396,7 +396,7 @@ TYPED_TEST(TensorVectorTest, TestResize) {
 TYPED_TEST(TensorVectorTest, TestMultipleResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetBatchState(this->kState);
+  tensor_list.SetContiguity(this->kState);
 
   int rand = this->RandInt(1, 20);
   TensorListShape<> shape;
@@ -431,7 +431,7 @@ TYPED_TEST(TensorVectorTest, TestMultipleResize) {
 TYPED_TEST(TensorVectorTest, TestCopy) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetBatchState(this->kState);
+  tl.SetContiguity(this->kState);
 
   tl.template set_type<float>();
 
@@ -444,8 +444,8 @@ TYPED_TEST(TensorVectorTest, TestCopy) {
   tl.SetLayout(std::string(shape.sample_dim(), 'X'));
 
   TensorVector<Backend> tl2s[2];
-  tl2s[0].SetBatchState(this->kState);
-  tl2s[1].SetBatchState(!this->kState);
+  tl2s[0].SetContiguity(this->kState);
+  tl2s[1].SetContiguity(!this->kState);
   for (auto &tl2 : tl2s) {
     tl2.Copy(tl);
 
@@ -465,14 +465,14 @@ TYPED_TEST(TensorVectorTest, TestCopy) {
 TYPED_TEST(TensorVectorTest, TestCopyEmpty) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetBatchState(this->kState);
+  tl.SetContiguity(this->kState);
 
   tl.template set_type<float>();
   tl.SetLayout("XX");
 
   TensorVector<Backend> tl2s[2];
-  tl2s[0].SetBatchState(this->kState);
-  tl2s[1].SetBatchState(!this->kState);
+  tl2s[0].SetContiguity(this->kState);
+  tl2s[1].SetContiguity(!this->kState);
   for (auto &tl2 : tl2s) {
     tl2.Copy(tl);
     ASSERT_EQ(tl.num_samples(), tl2.num_samples());
@@ -485,7 +485,7 @@ TYPED_TEST(TensorVectorTest, TestCopyEmpty) {
 TYPED_TEST(TensorVectorTest, TestTypeChangeError) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetBatchState(this->kState);
+  tensor_list.SetContiguity(this->kState);
   auto shape = this->GetRandShape();
 
   tensor_list.set_type(DALI_UINT8);
@@ -504,7 +504,7 @@ TYPED_TEST(TensorVectorTest, TestTypeChangeError) {
 TYPED_TEST(TensorVectorTest, TestTypeChange) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetBatchState(this->kState);
+  tensor_list.SetContiguity(this->kState);
 
   // Setup shape and offsets
   auto shape = this->GetRandShape();
@@ -571,7 +571,7 @@ TYPED_TEST(TensorVectorTest, DeviceIdPropagationMultiGPU) {
   TensorListShape<> shape{{42}};
   for (int device_id = 0; device_id < num_devices; device_id++) {
     TensorVector<Backend> batch;
-    batch.SetBatchState(BatchState::Default);
+    batch.SetContiguity(BatchContiguity::Automatic);
     DeviceGuard dg(device_id);
     batch.set_order(order);
     void *data_ptr;
@@ -594,7 +594,7 @@ TYPED_TEST(TensorVectorTest, DeviceIdPropagationMultiGPU) {
 TYPED_TEST(TensorVectorTest, TestShareData) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetBatchState(this->kState);
+  tensor_list.SetContiguity(this->kState);
 
   // Setup shape and offsets
   auto shape = this->GetRandShape();
@@ -604,8 +604,8 @@ TYPED_TEST(TensorVectorTest, TestShareData) {
 
   // Create a new tensor_list w/ a smaller data type
   TensorVector<Backend> tensor_lists[2];
-  tensor_lists[0].SetBatchState(this->kState);
-  tensor_lists[1].SetBatchState(!this->kState);
+  tensor_lists[0].SetContiguity(this->kState);
+  tensor_lists[1].SetContiguity(!this->kState);
 
   for (auto &tensor_list2 : tensor_lists) {
     // Share the data

--- a/dali/pipeline/data/tensor_list_as_tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_list_as_tensor_vector_test.cc
@@ -119,6 +119,354 @@ using TensorVectorBackendContiguous =
 
 TYPED_TEST_SUITE(TensorVectorTest, TensorVectorBackendContiguous);
 
+// Note: A TensorVector in a valid state has a type. To get to a valid state, we
+// can either set:
+// type -> shape : setting shape triggers allocation
+// shape & type : Resize triggers allocation
+//
+// Additionally, `reserve` can be called at any point.
+//
+// The following tests attempt to verify the correct behavior for all of
+// these cases
+
+TYPED_TEST(TensorVectorTest, TestGetTypeSizeBytes) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tl;
+  tl.SetContiguous(this->kState);
+
+  // Give the tensor a type
+  tl.template set_type<float>();
+
+  ASSERT_EQ(tl._num_elements(), 0);
+  ASSERT_EQ(tl.nbytes(), 0);
+  ASSERT_FALSE(tl.has_data());
+
+  // Give the tensor list a size. This
+  // should trigger an allocation
+  auto shape = this->GetRandShape();
+  tl.Resize(shape);
+
+  int num_tensor = shape.size();
+  vector<Index> offsets;
+  Index size = 0;
+  for (int i = 0; i < shape.size(); i++) {
+    offsets.push_back(size);
+    size += volume(shape[i]);
+  }
+
+  // Validate the internals
+  ASSERT_TRUE(tl.has_data());
+  ASSERT_EQ(tl.num_samples(), num_tensor);
+  ASSERT_EQ(tl._num_elements(), size);
+  ASSERT_EQ(tl.nbytes(), size*sizeof(float));
+  ASSERT_TRUE(IsType<float>(tl.type()));
+
+  tl.reserve(shape.num_elements() * sizeof(float));
+
+  for (int i = 0; i < num_tensor; ++i) {
+    ASSERT_NE(tl.raw_tensor(i), nullptr);
+  }
+}
+
+TYPED_TEST(TensorVectorTest, TestReserveResize) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tl;
+
+  auto shape = this->GetRandShape();
+  tl.reserve(shape.num_elements() * sizeof(float));  // This reserve already makes it contiguous
+  ASSERT_THROW(tl.set_pinned(true), std::runtime_error);
+
+  ASSERT_TRUE(tl.has_data());
+  ASSERT_EQ(tl.capacity(), shape.num_elements() * sizeof(float));
+  ASSERT_EQ(tl.nbytes(), 0);
+  ASSERT_EQ(tl._num_elements(), 0);
+  ASSERT_NE(unsafe_raw_data(tl), nullptr);
+
+  // Give the tensor a type
+  tl.template set_type<float>();
+
+  ASSERT_EQ(tl._num_elements(), 0);
+  ASSERT_EQ(tl.nbytes(), 0);
+  ASSERT_TRUE(tl.has_data());
+
+  // We already had the allocation, just give it a shape and a type
+  tl.Resize(shape, DALI_FLOAT);
+
+  int num_tensor = shape.size();
+  vector<Index> offsets;
+  Index size = 0;
+  for (int i = 0; i < shape.size(); i++) {
+    offsets.push_back(size);
+    size += volume(shape[i]);
+  }
+
+  // Validate the internals
+  ASSERT_TRUE(tl.has_data());
+  ASSERT_EQ(tl.num_samples(), num_tensor);
+  ASSERT_EQ(tl._num_elements(), size);
+  ASSERT_EQ(tl.nbytes(), size*sizeof(float));
+  ASSERT_TRUE(IsType<float>(tl.type()));
+
+
+  for (int i = 0; i < num_tensor; ++i) {
+    ASSERT_NE(tl.raw_tensor(i), nullptr);
+  }
+}
+
+TYPED_TEST(TensorVectorTest, TestResizeWithoutType) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tl;
+  tl.SetContiguous(this->kState);
+
+  // Give the tensor a size - setting shape on non-typed TL is invalid and results in an error
+  auto shape = this->GetRandShape();
+  ASSERT_THROW(tl.Resize(shape), std::runtime_error);
+}
+
+TYPED_TEST(TensorVectorTest, TestSetNoType) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tl;
+  tl.SetContiguous(this->kState);
+
+  tl.set_type(DALI_FLOAT);
+  ASSERT_THROW(tl.set_type(DALI_NO_TYPE), std::runtime_error);
+
+  auto shape = this->GetRandShape();
+  ASSERT_THROW(tl.Resize(shape, DALI_NO_TYPE), std::runtime_error);
+}
+
+TYPED_TEST(TensorVectorTest, TestGetContiguousPointer) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tl;
+  tl.SetContiguous(BatchState::Contiguous);
+
+  // Give the tensor a size and a type - uniform allocation
+  auto shape = this->GetRandShape();
+  tl.Resize(shape, DALI_UINT32);
+
+  int num_tensor = shape.size();
+  int64_t volume = shape.num_elements();
+
+  // Verify the internals
+  ASSERT_EQ(tl._num_elements(), volume);
+  ASSERT_EQ(tl.num_samples(), num_tensor);
+  ASSERT_EQ(tl.nbytes(), volume * sizeof(uint32_t));
+  ASSERT_EQ(tl.type(), DALI_UINT32);
+  ASSERT_TRUE(tl.IsContiguous());
+  ASSERT_NE(unsafe_raw_data(tl), nullptr);
+}
+
+TYPED_TEST(TensorVectorTest, TestGetBytesThenNoAlloc) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tl;
+  tl.SetContiguous(this->kState);
+  TensorVector<Backend> sharers[2];
+  sharers[0].SetContiguous(this->kState);
+  sharers[1].SetContiguous(!this->kState);
+
+  // Allocate the sharer
+  for (auto &sharer : sharers) {
+    sharer.template set_type<float>();
+    auto shape = this->GetRandShape();
+    sharer.Resize(shape);
+
+    // Share the data to give the tl bytes
+    tl.ShareData(sharer);
+
+    int num_tensor = shape.size();
+    vector<Index> offsets;
+    Index size = 0;
+    for (int i = 0; i < shape.size(); i++) {
+      offsets.push_back(size);
+      size += volume(shape[i]);
+    }
+
+    // Verify the internals
+    for (int i = 0; i < tl.num_samples(); i++) {
+      ASSERT_EQ(tl.raw_tensor(i), sharer.raw_tensor(i));
+    }
+    ASSERT_EQ(tl._num_elements(), size);
+    ASSERT_EQ(tl.nbytes(), size*sizeof(float));
+    ASSERT_EQ(tl.type(), sharer.type());
+    ASSERT_EQ(tl.num_samples(), num_tensor);
+    ASSERT_TRUE(tl.shares_data());
+
+    // Give the buffer a type smaller than float.
+    // Although we should have enough shared bytes,
+    // we don't allow for a partial access to data
+    ASSERT_THROW(tl.template mutable_tensor<int16>(0), std::runtime_error);
+  }
+}
+
+TYPED_TEST(TensorVectorTest, TestGetBytesThenAlloc) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tl;
+  tl.SetContiguous(this->kState);
+  TensorVector<Backend> sharers[2];
+  sharers[0].SetContiguous(this->kState);
+  sharers[1].SetContiguous(!this->kState);
+
+  // Allocate the sharer
+  for (auto &sharer : sharers) {
+    sharer.template set_type<float>();
+    auto shape = this->GetRandShape();
+    sharer.Resize(shape);
+
+    // Share the data to give the tl bytes
+    tl.ShareData(sharer);
+
+    int num_tensor = shape.size();
+    vector<Index> offsets;
+    Index size = 0;
+    for (int i = 0; i < shape.size(); i++) {
+      offsets.push_back(size);
+      size += volume(shape[i]);
+    }
+
+    // Verify the internals
+    for (int i = 0; i < tl.num_samples(); i++) {
+      ASSERT_EQ(tl.raw_tensor(i), sharer.raw_tensor(i));
+    }
+    ASSERT_EQ(tl._num_elements(), size);
+    ASSERT_EQ(tl.nbytes(), size*sizeof(float));
+    ASSERT_EQ(tl.type(), sharer.type());
+    ASSERT_EQ(tl.num_samples(), num_tensor);
+    ASSERT_TRUE(tl.shares_data());
+
+    // Give the buffer a type bigger than float.
+    // This normally would cause a reallocation,
+    // but we that's forbidden when using shared data.
+    ASSERT_THROW(tl.template mutable_tensor<double>(0), std::runtime_error);
+  }
+}
+
+TYPED_TEST(TensorVectorTest, TestZeroSizeResize) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tensor_list;
+  tensor_list.SetContiguous(this->kState);
+
+  TensorListShape<> shape;
+  tensor_list.template set_type<float>();
+  tensor_list.Resize(shape);
+
+  ASSERT_FALSE(tensor_list.has_data());
+  ASSERT_EQ(tensor_list.nbytes(), 0);
+  ASSERT_EQ(tensor_list._num_elements(), 0);
+  ASSERT_FALSE(tensor_list.shares_data());
+}
+
+TYPED_TEST(TensorVectorTest, TestMultipleZeroSizeResize) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tensor_list;
+  tensor_list.SetContiguous(this->kState);
+
+  int num_tensor = this->RandInt(0, 128);
+  auto shape = uniform_list_shape(num_tensor, TensorShape<>{ 0 });
+  tensor_list.Resize(shape, DALI_FLOAT);
+
+  ASSERT_FALSE(tensor_list.has_data());
+  ASSERT_EQ(tensor_list.nbytes(), 0);
+  ASSERT_EQ(tensor_list.num_samples(), num_tensor);
+  ASSERT_EQ(tensor_list._num_elements(), 0);
+  ASSERT_FALSE(tensor_list.shares_data());
+
+  ASSERT_EQ(tensor_list.num_samples(), num_tensor);
+  for (int i = 0; i < num_tensor; ++i) {
+    ASSERT_EQ(tensor_list.template tensor<float>(i), nullptr);
+    ASSERT_EQ(tensor_list.tensor_shape(i), TensorShape<>{ 0 });
+  }
+}
+
+TYPED_TEST(TensorVectorTest, TestFakeScalarResize) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tensor_list;
+  tensor_list.SetContiguous(this->kState);
+
+  int num_scalar = this->RandInt(1, 128);
+  auto shape = uniform_list_shape(num_scalar, {1});  // {1} on purpose
+  tensor_list.template set_type<float>();
+  tensor_list.Resize(shape);
+
+  ASSERT_TRUE(tensor_list.has_data());
+  ASSERT_EQ(tensor_list.nbytes(), num_scalar*sizeof(float));
+  ASSERT_EQ(tensor_list._num_elements(), num_scalar);
+  ASSERT_FALSE(tensor_list.shares_data());
+
+  for (int i = 0; i < num_scalar; ++i) {
+    ASSERT_NE(tensor_list.raw_tensor(i), nullptr);
+    ASSERT_EQ(tensor_list.tensor_shape(i), TensorShape<>{1});  // {1} on purpose
+  }
+}
+
+TYPED_TEST(TensorVectorTest, TestTrueScalarResize) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tensor_list;
+  tensor_list.SetContiguous(this->kState);
+
+  int num_scalar = this->RandInt(1, 128);
+  auto shape = uniform_list_shape(num_scalar, TensorShape<>{});
+  tensor_list.template set_type<float>();
+  tensor_list.Resize(shape);
+
+  ASSERT_TRUE(tensor_list.has_data());
+  ASSERT_EQ(tensor_list.nbytes(), num_scalar*sizeof(float));
+  ASSERT_EQ(tensor_list._num_elements(), num_scalar);
+  ASSERT_FALSE(tensor_list.shares_data());
+
+  for (int i = 0; i < num_scalar; ++i) {
+    ASSERT_NE(tensor_list.raw_tensor(i), nullptr);
+    ASSERT_EQ(tensor_list.tensor_shape(i), TensorShape<>{});
+  }
+}
+
+TYPED_TEST(TensorVectorTest, TestResize) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tensor_list;
+  tensor_list.SetContiguous(this->kState);
+
+  // Setup shape and offsets
+  auto shape = this->GetRandShape();
+  vector<Index> offsets;
+
+  // resize + check called in SetupTensorVector
+  this->SetupTensorVector(&tensor_list, shape, &offsets);
+}
+
+TYPED_TEST(TensorVectorTest, TestMultipleResize) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tensor_list;
+  tensor_list.SetContiguous(this->kState);
+
+  int rand = this->RandInt(1, 20);
+  TensorListShape<> shape;
+  vector<Index> offsets;
+  int num_tensor = 0;
+  for (int i = 0; i < rand; ++i) {
+    offsets.clear();
+    // Setup shape and offsets
+    shape = this->GetRandShape();
+    num_tensor = shape.size();
+    Index offset = 0;
+    for (int i = 0; i < shape.size(); i++) {
+      offsets.push_back(offset);
+      offset += volume(shape[i]);
+    }
+  }
+
+  // Resize the buffer
+  tensor_list.Resize(shape, DALI_FLOAT);
+
+  // Neither of the accessors can cause the allocation
+  ASSERT_THROW(tensor_list.template mutable_tensor<double>(0), std::runtime_error);
+  ASSERT_TRUE(tensor_list.has_data());
+  ASSERT_NE(tensor_list.template mutable_tensor<float>(0), nullptr);
+
+  ASSERT_EQ(tensor_list.num_samples(), num_tensor);
+  for (int i = 0; i < num_tensor; ++i) {
+    ASSERT_NE(tensor_list.raw_tensor(i), nullptr);
+    ASSERT_EQ(tensor_list.tensor_shape(i), shape[i]);
+  }
+}
 TYPED_TEST(TensorVectorTest, TestCopy) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
@@ -159,9 +507,7 @@ TYPED_TEST(TensorVectorTest, TestCopyEmpty) {
   tl.SetContiguous(this->kState);
 
   tl.template set_type<float>();
-  // TODO(klecki): Empty noncontiugous TV has no notion of layout, remove the if when supported
-  if (this->kState)
-    tl.SetLayout("XX");
+  tl.SetLayout("XX");
 
   TensorVector<Backend> tl2s[2];
   tl2s[0].SetContiguous(this->kState);
@@ -170,12 +516,178 @@ TYPED_TEST(TensorVectorTest, TestCopyEmpty) {
     tl2.Copy(tl);
     ASSERT_EQ(tl.num_samples(), tl2.num_samples());
     ASSERT_EQ(tl.type(), tl2.type());
-    ASSERT_EQ(tl.shape().num_elements(), tl2.shape().num_elements());
+    ASSERT_EQ(tl._num_elements(), tl2._num_elements());
+    ASSERT_EQ(tl.GetLayout(), tl2.GetLayout());
+  }
+}
 
-    // TODO(klecki): Empty noncontiugous TV has no notion of layout, remove the if when supported
-    if (tl2.IsContiguous()) {
-      ASSERT_EQ(tl.GetLayout(), tl2.GetLayout());
+TYPED_TEST(TensorVectorTest, TestTypeChangeError) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tensor_list;
+  tensor_list.SetContiguous(this->kState);
+  auto shape = this->GetRandShape();
+
+  tensor_list.set_type(DALI_UINT8);
+  tensor_list.set_type(DALI_FLOAT);
+  tensor_list.set_type(DALI_INT32);
+  tensor_list.Resize(shape);
+  ASSERT_NE(tensor_list.template mutable_tensor<int32_t>(0), nullptr);
+
+  ASSERT_THROW(tensor_list.set_type(DALI_FLOAT), std::runtime_error);
+
+  tensor_list.Resize(shape, DALI_FLOAT);
+  ASSERT_NE(tensor_list.template mutable_tensor<float>(0), nullptr);
+}
+
+TYPED_TEST(TensorVectorTest, TestTypeChange) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tensor_list;
+  tensor_list.SetContiguous(this->kState);
+
+  // Setup shape and offsets
+  auto shape = this->GetRandShape();
+  vector<Index> offsets;
+
+  this->SetupTensorVector(&tensor_list, shape, &offsets);
+
+  DALIDataType initial_type = DALI_FLOAT;
+  std::array<DALIDataType, 4> types = {DALI_FLOAT, DALI_INT32, DALI_UINT8, DALI_FLOAT64};
+  const auto *base_ptr = this->kState ? unsafe_raw_data(tensor_list) : nullptr;
+  size_t nbytes = shape.num_elements() * sizeof(float);
+
+  // Save the pointers
+  std::vector<const void *> ptrs;
+  for (int i = 0; i < tensor_list.num_samples(); i++) {
+    ptrs.push_back(tensor_list.raw_tensor(i));
+  }
+
+  for (auto new_type : types) {
+    if (initial_type != new_type) {
+      // Simply changing the type of the buffer is not allowed
+      ASSERT_THROW(tensor_list.set_type(new_type), std::runtime_error);
+      tensor_list.Resize(shape, new_type);
     }
+
+    // Check the internals
+    ASSERT_EQ(tensor_list.num_samples(), shape.num_samples());
+    ASSERT_EQ(tensor_list.shape(), shape);
+    ASSERT_EQ(tensor_list.sample_dim(), shape.sample_dim());
+    ASSERT_EQ(tensor_list.type(), new_type);
+    for (int i = 0; i < tensor_list.num_samples(); ++i) {
+      ASSERT_NE(tensor_list.raw_tensor(i), nullptr);
+      ASSERT_EQ(tensor_list.tensor_shape(i), shape[i]);
+    }
+
+    // The side-effects of only reallocating when we need a bigger buffer, we may use padding
+    if (TypeTable::GetTypeInfo(new_type).size() <= TypeTable::GetTypeInfo(initial_type).size()) {
+      if (this->kState) {
+        ASSERT_EQ(unsafe_raw_data(tensor_list), base_ptr);
+      } else {
+        for (int i = 0; i < tensor_list.num_samples(); ++i) {
+          ASSERT_EQ(tensor_list.raw_tensor(i), ptrs[i]);
+        }
+      }
+    }
+
+    ASSERT_EQ(nbytes / TypeTable::GetTypeInfo(initial_type).size() *
+                  TypeTable::GetTypeInfo(new_type).size(),
+              tensor_list.nbytes());
+  }
+}
+
+TYPED_TEST(TensorVectorTest, DeviceIdPropagationMultiGPU) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  // This test doesn't pin state to Noncontiguous as it prohibits sharing noncontiguous data
+  int num_devices = 0;
+  CUDA_CALL(cudaGetDeviceCount(&num_devices));
+  if (num_devices < 2) {
+    GTEST_SKIP() << "At least 2 devices needed for the test\n";
+  }
+  constexpr bool is_device = std::is_same_v<Backend, GPUBackend>;
+  constexpr bool is_pinned = !is_device;
+  AccessOrder order = AccessOrder::host();
+  TensorListShape<> shape{{42}};
+  for (int device_id = 0; device_id < num_devices; device_id++) {
+    TensorVector<Backend> batch;
+    batch.SetContiguous(BatchState::Default);
+    DeviceGuard dg(device_id);
+    batch.set_order(order);
+    void *data_ptr;
+    std::shared_ptr<void> ptr;
+    if (is_device) {
+      CUDA_CALL(cudaMalloc(&data_ptr, shape.num_elements() * sizeof(uint8_t)));
+      ptr = std::shared_ptr<void>(data_ptr, [](void *ptr) { cudaFree(ptr); });
+    } else {
+      CUDA_CALL(cudaMallocHost(&data_ptr, shape.num_elements() * sizeof(uint8_t)));
+      ptr = std::shared_ptr<void>(data_ptr, [](void *ptr) { cudaFreeHost(ptr); });
+    }
+    batch.ShareData(ptr, shape.num_elements() * sizeof(uint8_t), is_pinned, shape, DALI_UINT8,
+                    device_id, order);
+    ASSERT_EQ(batch.device_id(), device_id);
+    ASSERT_EQ(batch.order().device_id(), AccessOrder::host().device_id());
+    ASSERT_NE(batch.order().device_id(), batch.device_id());
+  }
+}
+
+TYPED_TEST(TensorVectorTest, TestShareData) {
+  using Backend = std::tuple_element_t<0, TypeParam>;
+  TensorVector<Backend> tensor_list;
+  tensor_list.SetContiguous(this->kState);
+
+  // Setup shape and offsets
+  auto shape = this->GetRandShape();
+  vector<Index> offsets;
+
+  this->SetupTensorVector(&tensor_list, shape, &offsets);
+
+  // Create a new tensor_list w/ a smaller data type
+  TensorVector<Backend> tensor_lists[2];
+  tensor_lists[0].SetContiguous(this->kState);
+  tensor_lists[1].SetContiguous(!this->kState);
+
+  for (auto &tensor_list2 : tensor_lists) {
+    // Share the data
+    tensor_list2.ShareData(tensor_list);
+    ASSERT_EQ(tensor_list2.is_pinned(), tensor_list.is_pinned());
+    ASSERT_EQ(tensor_list2.order(), tensor_list.order());
+    // We need to use the same size as the underlying buffer
+    // N.B. using other type is UB in most cases
+    auto flattened_shape = collapse_dims(shape, {std::make_pair(0, shape.sample_dim())});
+    tensor_list2.template set_type<float>();
+    tensor_list2.Resize(flattened_shape);
+
+    // Make sure the pointers match
+    for (int i = 0; i < tensor_list.num_samples(); ++i) {
+      ASSERT_EQ(tensor_list.raw_tensor(i), tensor_list2.raw_tensor(i));
+    }
+    ASSERT_TRUE(tensor_list2.shares_data());
+
+    // Verify the default dims of the tensor_list 2
+    ASSERT_EQ(tensor_list2._num_elements(), tensor_list._num_elements());
+
+    // Resize the tensor_list2 to match the shape of tensor_list
+    tensor_list2.Resize(shape);
+
+    // Check the internals
+    ASSERT_TRUE(tensor_list2.shares_data());
+    ASSERT_EQ(tensor_list2.nbytes(), tensor_list.nbytes());
+    ASSERT_EQ(tensor_list2.num_samples(), tensor_list.num_samples());
+    ASSERT_EQ(tensor_list2._num_elements(), tensor_list._num_elements());
+    for (int i = 0; i < tensor_list.num_samples(); ++i) {
+      ASSERT_EQ(tensor_list.raw_tensor(i), tensor_list2.raw_tensor(i));
+      ASSERT_EQ(tensor_list2.tensor_shape(i), shape[i]);
+    }
+
+    // Trigger allocation through buffer API, verify we cannot do that
+    ASSERT_THROW(tensor_list2.template mutable_tensor<double>(0), std::runtime_error);
+    tensor_list2.Reset();
+    ASSERT_FALSE(tensor_list2.shares_data());
+
+    // Check the internals
+    ASSERT_EQ(tensor_list2._num_elements(), 0);
+    ASSERT_EQ(tensor_list2.nbytes(), 0);
+    ASSERT_EQ(tensor_list2.num_samples(), 0);
+    ASSERT_EQ(tensor_list2.shape(), TensorListShape<>());
   }
 }
 

--- a/dali/pipeline/data/tensor_list_as_tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_list_as_tensor_vector_test.cc
@@ -43,7 +43,7 @@ namespace test {
  * Remove APIs that will be not ported: tensor_offset
  * Tests were generalized over contiguous/noncontiguous option (see the pairs in
    TensorVectorBackendContiguous)
- * SetContiguous(true) was added in few places, as there is a difference in defaults between
+ * SetBatchState(true) was added in few places, as there is a difference in defaults between
    current TensorVector and TensorList.
  **************************************************************************************************/
 
@@ -132,7 +132,7 @@ TYPED_TEST_SUITE(TensorVectorTest, TensorVectorBackendContiguous);
 TYPED_TEST(TensorVectorTest, TestGetTypeSizeBytes) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetContiguous(this->kState);
+  tl.SetBatchState(this->kState);
 
   // Give the tensor a type
   tl.template set_type<float>();
@@ -217,7 +217,7 @@ TYPED_TEST(TensorVectorTest, TestReserveResize) {
 TYPED_TEST(TensorVectorTest, TestResizeWithoutType) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetContiguous(this->kState);
+  tl.SetBatchState(this->kState);
 
   // Give the tensor a size - setting shape on non-typed TL is invalid and results in an error
   auto shape = this->GetRandShape();
@@ -228,7 +228,7 @@ TYPED_TEST(TensorVectorTest, TestSetNoType) {
   // After type is set we cannot revert to DALI_NO_TYPE
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetContiguous(this->kState);
+  tl.SetBatchState(this->kState);
 
   tl.set_type(DALI_FLOAT);
   ASSERT_THROW(tl.set_type(DALI_NO_TYPE), std::runtime_error);
@@ -240,7 +240,7 @@ TYPED_TEST(TensorVectorTest, TestSetNoType) {
 TYPED_TEST(TensorVectorTest, TestGetContiguousPointer) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetContiguous(BatchState::Contiguous);
+  tl.SetBatchState(BatchState::Contiguous);
 
   // Give the tensor a size and a type - uniform allocation
   auto shape = this->GetRandShape();
@@ -261,10 +261,10 @@ TYPED_TEST(TensorVectorTest, TestGetContiguousPointer) {
 TYPED_TEST(TensorVectorTest, TestGetBytesThenAccess) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetContiguous(this->kState);
+  tl.SetBatchState(this->kState);
   TensorVector<Backend> sharers[2];
-  sharers[0].SetContiguous(this->kState);
-  sharers[1].SetContiguous(!this->kState);
+  sharers[0].SetBatchState(this->kState);
+  sharers[1].SetBatchState(!this->kState);
 
   // Allocate the sharer
   for (auto &sharer : sharers) {
@@ -304,7 +304,7 @@ TYPED_TEST(TensorVectorTest, TestGetBytesThenAccess) {
 TYPED_TEST(TensorVectorTest, TestZeroSizeResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetContiguous(this->kState);
+  tensor_list.SetBatchState(this->kState);
 
   TensorListShape<> shape;
   tensor_list.template set_type<float>();
@@ -319,7 +319,7 @@ TYPED_TEST(TensorVectorTest, TestZeroSizeResize) {
 TYPED_TEST(TensorVectorTest, TestMultipleZeroSizeResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetContiguous(this->kState);
+  tensor_list.SetBatchState(this->kState);
 
   int num_tensor = this->RandInt(0, 128);
   auto shape = uniform_list_shape(num_tensor, TensorShape<>{ 0 });
@@ -341,7 +341,7 @@ TYPED_TEST(TensorVectorTest, TestMultipleZeroSizeResize) {
 TYPED_TEST(TensorVectorTest, TestFakeScalarResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetContiguous(this->kState);
+  tensor_list.SetBatchState(this->kState);
 
   int num_scalar = this->RandInt(1, 128);
   auto shape = uniform_list_shape(num_scalar, {1});  // {1} on purpose
@@ -362,7 +362,7 @@ TYPED_TEST(TensorVectorTest, TestFakeScalarResize) {
 TYPED_TEST(TensorVectorTest, TestTrueScalarResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetContiguous(this->kState);
+  tensor_list.SetBatchState(this->kState);
 
   int num_scalar = this->RandInt(1, 128);
   auto shape = uniform_list_shape(num_scalar, TensorShape<>{});
@@ -383,7 +383,7 @@ TYPED_TEST(TensorVectorTest, TestTrueScalarResize) {
 TYPED_TEST(TensorVectorTest, TestResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetContiguous(this->kState);
+  tensor_list.SetBatchState(this->kState);
 
   // Setup shape and offsets
   auto shape = this->GetRandShape();
@@ -396,7 +396,7 @@ TYPED_TEST(TensorVectorTest, TestResize) {
 TYPED_TEST(TensorVectorTest, TestMultipleResize) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetContiguous(this->kState);
+  tensor_list.SetBatchState(this->kState);
 
   int rand = this->RandInt(1, 20);
   TensorListShape<> shape;
@@ -431,7 +431,7 @@ TYPED_TEST(TensorVectorTest, TestMultipleResize) {
 TYPED_TEST(TensorVectorTest, TestCopy) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetContiguous(this->kState);
+  tl.SetBatchState(this->kState);
 
   tl.template set_type<float>();
 
@@ -444,8 +444,8 @@ TYPED_TEST(TensorVectorTest, TestCopy) {
   tl.SetLayout(std::string(shape.sample_dim(), 'X'));
 
   TensorVector<Backend> tl2s[2];
-  tl2s[0].SetContiguous(this->kState);
-  tl2s[1].SetContiguous(!this->kState);
+  tl2s[0].SetBatchState(this->kState);
+  tl2s[1].SetBatchState(!this->kState);
   for (auto &tl2 : tl2s) {
     tl2.Copy(tl);
 
@@ -465,14 +465,14 @@ TYPED_TEST(TensorVectorTest, TestCopy) {
 TYPED_TEST(TensorVectorTest, TestCopyEmpty) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tl;
-  tl.SetContiguous(this->kState);
+  tl.SetBatchState(this->kState);
 
   tl.template set_type<float>();
   tl.SetLayout("XX");
 
   TensorVector<Backend> tl2s[2];
-  tl2s[0].SetContiguous(this->kState);
-  tl2s[1].SetContiguous(!this->kState);
+  tl2s[0].SetBatchState(this->kState);
+  tl2s[1].SetBatchState(!this->kState);
   for (auto &tl2 : tl2s) {
     tl2.Copy(tl);
     ASSERT_EQ(tl.num_samples(), tl2.num_samples());
@@ -485,7 +485,7 @@ TYPED_TEST(TensorVectorTest, TestCopyEmpty) {
 TYPED_TEST(TensorVectorTest, TestTypeChangeError) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetContiguous(this->kState);
+  tensor_list.SetBatchState(this->kState);
   auto shape = this->GetRandShape();
 
   tensor_list.set_type(DALI_UINT8);
@@ -504,7 +504,7 @@ TYPED_TEST(TensorVectorTest, TestTypeChangeError) {
 TYPED_TEST(TensorVectorTest, TestTypeChange) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetContiguous(this->kState);
+  tensor_list.SetBatchState(this->kState);
 
   // Setup shape and offsets
   auto shape = this->GetRandShape();
@@ -571,7 +571,7 @@ TYPED_TEST(TensorVectorTest, DeviceIdPropagationMultiGPU) {
   TensorListShape<> shape{{42}};
   for (int device_id = 0; device_id < num_devices; device_id++) {
     TensorVector<Backend> batch;
-    batch.SetContiguous(BatchState::Default);
+    batch.SetBatchState(BatchState::Default);
     DeviceGuard dg(device_id);
     batch.set_order(order);
     void *data_ptr;
@@ -594,7 +594,7 @@ TYPED_TEST(TensorVectorTest, DeviceIdPropagationMultiGPU) {
 TYPED_TEST(TensorVectorTest, TestShareData) {
   using Backend = std::tuple_element_t<0, TypeParam>;
   TensorVector<Backend> tensor_list;
-  tensor_list.SetContiguous(this->kState);
+  tensor_list.SetBatchState(this->kState);
 
   // Setup shape and offsets
   auto shape = this->GetRandShape();
@@ -604,8 +604,8 @@ TYPED_TEST(TensorVectorTest, TestShareData) {
 
   // Create a new tensor_list w/ a smaller data type
   TensorVector<Backend> tensor_lists[2];
-  tensor_lists[0].SetContiguous(this->kState);
-  tensor_lists[1].SetContiguous(!this->kState);
+  tensor_lists[0].SetBatchState(this->kState);
+  tensor_lists[1].SetBatchState(!this->kState);
 
   for (auto &tensor_list2 : tensor_lists) {
     // Share the data

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <cstdint>
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "dali/core/tensor_shape.h"
 #include "dali/pipeline/data/backend.h"
@@ -481,12 +485,6 @@ TYPED_TEST(TensorListTest, TestTypeChange) {
   const auto *base_ptr = unsafe_raw_data(tensor_list);
   size_t nbytes = shape.num_elements() * sizeof(float);
 
-  // Save the pointers
-  std::vector<const void *> ptrs;
-  for (int i = 0; i < tensor_list.num_samples(); i++) {
-    ptrs.push_back(tensor_list.raw_tensor(i));
-  }
-
   for (auto new_type : types) {
     if (initial_type != new_type) {
       // Simply changing the type of the buffer is not allowed
@@ -502,7 +500,6 @@ TYPED_TEST(TensorListTest, TestTypeChange) {
     for (int i = 0; i < tensor_list.num_samples(); ++i) {
       ASSERT_NE(tensor_list.raw_tensor(i), nullptr);
       ASSERT_EQ(tensor_list.tensor_shape(i), shape[i]);
-      ASSERT_EQ(tensor_list.tensor_offset(i), offsets[i]);
     }
 
     // The side-effects of only reallocating when we need a bigger buffer, we may use padding

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -211,13 +211,10 @@ TensorVector<Backend>::TensorVector() : curr_num_tensors_(0) {}
 
 template <typename Backend>
 TensorVector<Backend>::TensorVector(int batch_size) : curr_num_tensors_(0) {
-  // We don't use negative
-  // This is why we can't have nice things as `dim = 0` is already occupied
-  // by competing functionality, we need to guard ourself from thinking we have some scalar
-  // allocation where in fact we just have empty samples.
-  // So instead we set the dim to 1, and the resize_tensor will cause the shape to be resized
-  // to appropriate number of samples and 0-initialized, so copy from batch to batch,
-  // using this as (empty) source still works. Maybe there is a better solution to this problem.
+  // We don't use negative batch size through DALI, and by default we wanted batch to
+  // not do any initial allocation unless actual shape is provided.
+  // As the -1 and 0 sample dims (the latter being reserved for scalar case already),
+  // we use `dim=1` and end up with samples of shape {0}.
   set_sample_dim(1);
   resize_tensors(batch_size);
 }

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -752,7 +752,7 @@ void TensorVector<Backend>::recreate_views() {
 
 
 template <typename Backend>
-void TensorVector<Backend>::SetContiguous(BatchState state) {
+void TensorVector<Backend>::SetBatchState(BatchState state) {
   if (state == BatchState::Default) {
     // remove the force, keep the current state information
     state_.Setup(state_.Get(), false);
@@ -765,8 +765,8 @@ void TensorVector<Backend>::SetContiguous(BatchState state) {
 
 
 template <typename Backend>
-void TensorVector<Backend>::SetContiguous(bool state) {
-  SetContiguous(state ? BatchState::Contiguous : BatchState::Noncontiguous);
+void TensorVector<Backend>::SetBatchState(bool contiguous) {
+  SetBatchState(contiguous ? BatchState::Contiguous : BatchState::Noncontiguous);
 }
 
 

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -211,6 +211,7 @@ TensorVector<Backend>::TensorVector() : curr_num_tensors_(0) {}
 
 template <typename Backend>
 TensorVector<Backend>::TensorVector(int batch_size) : curr_num_tensors_(0) {
+  // We don't use negative
   // This is why we can't have nice things as `dim = 0` is already occupied
   // by competing functionality, we need to guard ourself from thinking we have some scalar
   // allocation where in fact we just have empty samples.
@@ -671,6 +672,9 @@ const DALIMeta &TensorVector<Backend>::GetMeta(int idx) const {
 template <typename Backend>
 void TensorVector<Backend>::SetMeta(int idx, const DALIMeta &meta) {
   assert(idx < curr_num_tensors_);
+  DALI_ENFORCE(GetLayout() == meta.GetLayout(),
+               make_string("Sample must have the same layout as the target batch, current: ",
+                           GetLayout(), " new: ", meta.GetLayout(), " for sample ", idx, "."));
   tensors_[idx].SetMeta(meta);
 }
 

--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -14,12 +14,46 @@
 
 #include <string>
 
+#include "dali/core/access_order.h"
 #include "dali/core/common.h"
 #include "dali/core/error_handling.h"
+#include "dali/core/tensor_layout.h"
+#include "dali/core/tensor_shape.h"
 #include "dali/pipeline/data/tensor_vector.h"
 #include "dali/pipeline/data/types.h"
 
 namespace dali {
+
+namespace {
+
+/**
+ * @brief Check if both shared pointers have the same managed pointer (not the one returned by
+ * .get())
+ */
+bool same_owner(const std::shared_ptr<void> &x, const std::shared_ptr<void> &y) {
+  if (x.owner_before(y) || y.owner_before(x))
+    return false;
+  return true;
+}
+
+
+bool same_owner(const std::weak_ptr<void> &x, const std::shared_ptr<void> &y) {
+  if (x.owner_before(y) || y.owner_before(x))
+    return false;
+  return true;
+}
+
+// TODO(klecki): move this to the class?
+TensorShape<> empty_shape(int dim) {
+  TensorShape<> result;
+  result.resize(dim);
+  for (auto &elem : result) {
+    elem = 0;
+  }
+  return result;
+}
+
+}  // namespace
 
 namespace copy_impl {
 
@@ -172,153 +206,220 @@ void CopyImpl(DstBatch<DstBackend> &dst, const SrcBatch<SrcBackend> &src, const 
 }  // namespace copy_impl
 
 template <typename Backend>
-TensorVector<Backend>::TensorVector()
-    : curr_num_tensors_(0), tl_(std::make_shared<TensorList<Backend>>()) {}
+TensorVector<Backend>::TensorVector() : curr_num_tensors_(0) {}
 
 
 template <typename Backend>
-TensorVector<Backend>::TensorVector(int batch_size)
-    : curr_num_tensors_(0), tl_(std::make_shared<TensorList<Backend>>(batch_size)) {
+TensorVector<Backend>::TensorVector(int batch_size) : curr_num_tensors_(0) {
+  // This is why we can't have nice things as `dim = 0` is already occupied
+  // by competing functionality, we need to guard ourself from thinking we have some scalar
+  // allocation where in fact we just have empty samples.
+  // So instead we set the dim to 1, and the resize_tensor will cause the shape to be resized
+  // to appropriate number of samples and 0-initialized, so copy from batch to batch,
+  // using this as (empty) source still works. Maybe there is a better solution to this problem.
+  set_sample_dim(1);
   resize_tensors(batch_size);
 }
 
+
 template <typename Backend>
 TensorVector<Backend>::TensorVector(TensorVector<Backend> &&other) noexcept {
-  state_ = other.state_;
-  pinned_ = other.pinned_;
-  order_ = other.order_;
-  curr_num_tensors_ = other.curr_num_tensors_;
-  tl_ = std::move(other.tl_);
-  type_ = std::move(other.type_);
-  sample_dim_ = other.sample_dim_;
-  tensors_ = std::move(other.tensors_);
-
-  other.curr_num_tensors_ = 0;
-  other.tensors_.clear();
-  other.sample_dim_ = -1;
+  *this = std::move(other);
 }
+
+
+template <typename Backend>
+TensorVector<Backend> &TensorVector<Backend>::operator=(TensorVector<Backend> &&other) noexcept {
+  if (&other != this) {
+    contiguous_buffer_ = std::move(other.contiguous_buffer_);
+    buffer_bkp_ = std::move(other.buffer_bkp_);
+    tensors_ = std::move(other.tensors_);
+
+    state_ = other.state_;
+    curr_num_tensors_ = other.curr_num_tensors_;
+    type_ = other.type_;
+    sample_dim_ = other.sample_dim_;
+    shape_ = std::move(other.shape_);
+    layout_ = std::move(other.layout_);
+    pinned_ = other.pinned_;
+    order_ = other.order_;
+    device_ = other.device_;
+
+    other.Reset();
+  }
+  return *this;
+}
+
+
+template <typename Backend>
+void TensorVector<Backend>::VerifySampleShareConformance(DALIDataType type, int sample_dim,
+                                                         TensorLayout layout, bool pinned,
+                                                         AccessOrder order, int device_id,
+                                                         const std::string &error_suffix) {
+  // Checks in the order of class members
+  DALI_ENFORCE(this->type() == type,
+               make_string("Sample must have the same type as the target batch, current: ",
+                           this->type(), ", new: ", type, error_suffix));
+
+  DALI_ENFORCE(this->sample_dim() == sample_dim,
+               make_string("Sample must have the same sample dim as the target batch, current: ",
+                           this->sample_dim(), ", new: ", sample_dim, error_suffix));
+
+  DALI_ENFORCE(this->GetLayout() == layout || layout.empty(),
+               make_string("Sample must have the same layout as the target batch current: ",
+                           this->GetLayout(), ", new: ", layout, " or come with empty layout ",
+                           error_suffix));
+
+  DALI_ENFORCE(this->is_pinned() == pinned,
+               make_string("Sample must have the same pinned status as target batch, current: ",
+                           this->is_pinned(), ", new: ", pinned, error_suffix));
+
+  DALI_ENFORCE(this->order() == order,
+               make_string("Sample must have the same order as the target batch", error_suffix));
+
+  DALI_ENFORCE(this->device_id() == device_id,
+               make_string("Sample must have the same device id as target batch, current: ",
+                           this->device_id(), ", new: ", device_id, error_suffix));
+}
+
 
 template <typename Backend>
 void TensorVector<Backend>::UnsafeSetSample(int sample_idx, const TensorVector<Backend> &src,
                                             int src_sample_idx) {
-  // TODO(klecki): more consistency checks, contiguous -> non-contiguous removes shares_data from
-  // samples
   // Bounds check
   assert(sample_idx >= 0 && sample_idx < curr_num_tensors_);
   assert(src_sample_idx >= 0 && src_sample_idx < src.curr_num_tensors_);
-  DALI_ENFORCE(type() == src.type(),
-               make_string("Sample must have the same type as a target batch, current: ", type(),
-                           " new: ", src.type(), " for ", sample_idx, " <- ", src_sample_idx, "."));
-  DALI_ENFORCE(sample_dim() == src.shape().sample_dim(),
-               make_string("Sample must have the same dimensionality as a target batch, current: ",
-                           sample_dim(), " new: ", src.shape().sample_dim(), " for ", sample_idx,
-                           " <- ", src_sample_idx, "."));
-  DALI_ENFORCE(this->order() == src.order(), "Sample must have the same order as a target batch");
-  DALI_ENFORCE(
-      GetLayout() == src.GetLayout(),
-      make_string("Sample must have the same layout as a target batch current: ", GetLayout(),
-                  " new: ", src.GetLayout(), " for ", sample_idx, " <- ", src_sample_idx, "."));
-  DALI_ENFORCE(
-      is_pinned() == src.is_pinned(),
-      make_string("Sample must have the same pinned status as target batch, current: ", is_pinned(),
-                  " new: ", src.is_pinned(), " for ", sample_idx, " <- ", src_sample_idx, "."));
+  // Setting any individual sample converts the batch to non-contiguous mode
+  MakeNoncontiguous();
+  if (&src.tensors_[src_sample_idx] == &tensors_[sample_idx])
+    return;
+  VerifySampleShareConformance(src.type(), src.shape().sample_dim(), src.GetLayout(),
+                               src.is_pinned(), src.order(), src.device_id(),
+                               make_string(" for ", sample_idx, " <- ", src_sample_idx, "."));
 
-  SetContiguous(false);
+  shape_.set_tensor_shape(sample_idx, src.shape()[src_sample_idx]);
+
   // Setting a new share overwrites the previous one - so we can safely assume that even if
   // we had a sample sharing into TL, it will be overwritten
-  tensors_[sample_idx]->ShareData(*src.tensors_[src_sample_idx]);
-  tl_->Reset();
+  tensors_[sample_idx].ShareData(src.tensors_[src_sample_idx]);
+
+  if (src.GetLayout().empty() && !GetLayout().empty()) {
+    tensors_[sample_idx].SetLayout(GetLayout());
+  }
 }
+
 
 template <typename Backend>
 void TensorVector<Backend>::UnsafeSetSample(int sample_idx, const Tensor<Backend> &owner) {
-  // TODO(klecki): more consistency checks, contiguous -> non-contiguous removes shares_data from
-  // samples
   // Bounds check
   assert(sample_idx >= 0 && sample_idx < curr_num_tensors_);
-  DALI_ENFORCE(type() == owner.type(),
-               make_string("Sample must have the same type as a target batch, current: ", type(),
-                           " new: ", owner.type(), " for ", sample_idx, "."));
-  DALI_ENFORCE(
-      sample_dim() == owner.shape().sample_dim(),
-      make_string("Sample must have the same dimensionality as a target batch, current: ",
-                  sample_dim(), " new: ", owner.shape().sample_dim(), " for ", sample_idx, "."));
-  DALI_ENFORCE(this->order() == owner.order(), "Sample must have the same order as a target batch");
-  DALI_ENFORCE(GetLayout() == owner.GetLayout(),
-               make_string("Sample must have the same layout as a target batch current: ",
-                           GetLayout(), " new: ", owner.GetLayout(), " for ", sample_idx, "."));
-  DALI_ENFORCE(
-      is_pinned() == owner.is_pinned(),
-      make_string("Sample must have the same pinned status as target batch, current: ", is_pinned(),
-                  " new: ", owner.is_pinned(), " for ", sample_idx, "."));
-  SetContiguous(false);
+  // Setting any individual sample converts the batch to non-contiguous mode
+  MakeNoncontiguous();
+  VerifySampleShareConformance(owner.type(), owner.shape().sample_dim(), owner.GetLayout(),
+                               owner.is_pinned(), owner.order(), owner.device_id(),
+                               make_string(" for ", sample_idx, "."));
+
+  shape_.set_tensor_shape(sample_idx, owner.shape());
+
   // Setting a new share overwrites the previous one - so we can safely assume that even if
   // we had a sample sharing into TL, it will be overwritten
-  tensors_[sample_idx]->ShareData(owner);
-  tl_->Reset();
+  tensors_[sample_idx].ShareData(owner);
+
+  if (owner.GetLayout().empty() && !GetLayout().empty()) {
+    tensors_[sample_idx].SetLayout(GetLayout());
+  }
 }
+
 
 template <typename Backend>
 void TensorVector<Backend>::UnsafeSetSample(int sample_idx, const shared_ptr<void> &ptr,
                                             size_t bytes, bool pinned, const TensorShape<> &shape,
                                             DALIDataType type, int device_id, AccessOrder order,
                                             const TensorLayout &layout) {
+  // Bounds check
   assert(sample_idx >= 0 && sample_idx < curr_num_tensors_);
-  DALI_ENFORCE(this->type() == type,
-               make_string("Sample must have the same type as a target batch, current: ",
-                           this->type(), " new: ", type, " for ", sample_idx, "."));
-  DALI_ENFORCE(sample_dim() == shape.sample_dim(),
-               make_string("Sample must have the same dimensionality as a target batch, current: ",
-                           sample_dim(), " new: ", shape.sample_dim(), " for ", sample_idx, "."));
-  DALI_ENFORCE(this->device_id() == device_id,
-               make_string("Sample must have the same device id as a target batch, current: ",
-                           this->device_id(), " new: ", device_id, " for ", sample_idx, "."));
-  DALI_ENFORCE(this->order() == order, "Sample must have the same order as a target batch");
-  DALI_ENFORCE(GetLayout() == layout,
-               make_string("Sample must have the same layout as a target batch current: ",
-                           GetLayout(), " new: ", layout, " for ", sample_idx, "."));
-  DALI_ENFORCE(is_pinned() == pinned,
-               make_string("Sample must have the same pinned status as target batch, current: ",
-                           is_pinned(), " new: ", pinned, " for ", sample_idx, "."));
-  SetContiguous(false);
+  // Setting any individual sample converts the batch to non-contiguous mode
+  MakeNoncontiguous();
+  VerifySampleShareConformance(type, shape.sample_dim(), layout, pinned, order, device_id,
+                               make_string(" for ", sample_idx, "."));
+
+  DALI_ENFORCE(!IsContiguous());
+  shape_.set_tensor_shape(sample_idx, shape);
+
   // Setting a new share overwrites the previous one - so we can safely assume that even if
   // we had a sample sharing into TL, it will be overwritten
-  tensors_[sample_idx]->ShareData(ptr, bytes, pinned, shape, type, device_id, order);
-  tl_->Reset();
+  tensors_[sample_idx].ShareData(ptr, bytes, pinned, shape, type, device_id, order);
+
+  if (layout.empty() && !GetLayout().empty()) {
+    tensors_[sample_idx].SetLayout(GetLayout());
+  }
 }
+
+
+template <typename Backend>
+void TensorVector<Backend>::VerifySampleCopyConformance(DALIDataType type, int sample_dim,
+                                                        TensorLayout layout,
+                                                        const TensorShape<> &current_shape,
+                                                        const TensorShape<> &new_shape,
+                                                        const std::string &error_suffix) {
+  // Checks in the order of class members
+  DALI_ENFORCE(this->type() == type,
+               make_string("Sample must have the same type as the target batch, current: ",
+                           this->type(), ", new: ", type, error_suffix));
+
+  DALI_ENFORCE(this->sample_dim() == sample_dim,
+               make_string("Sample must have the same sample dim as the target batch, current: ",
+                           this->sample_dim(), ", new: ", sample_dim, error_suffix));
+
+  if (IsContiguous()) {
+    DALI_ENFORCE(
+        current_shape.num_elements() == new_shape.num_elements(),
+        make_string("Sample volume must match when copying to a contiguous batch, current: ",
+                    current_shape.num_elements(), ", new: ", new_shape.num_elements(),
+                    error_suffix));
+  }
+
+  DALI_ENFORCE(this->GetLayout() == layout || layout.empty(),
+               make_string("Sample must have the same layout as the target batch current: ",
+                           this->GetLayout(), ", new: ", layout, " or come with empty layout ",
+                           error_suffix));
+}
+
 
 template <typename Backend>
 void TensorVector<Backend>::UnsafeCopySample(int sample_idx, const TensorVector<Backend> &src,
                                              int src_sample_idx, AccessOrder order) {
-  // TODO(klecki): more consistency checks, contiguous -> non-contiguous removes shares_data from
-  // samples
   // Bounds check
   assert(sample_idx >= 0 && sample_idx < curr_num_tensors_);
   assert(src_sample_idx >= 0 && src_sample_idx < src.curr_num_tensors_);
-  DALI_ENFORCE(type() == src.type(),
-               make_string("Sample must have the same type as a target batch, current: ", type(),
-                           " new: ", src.type(), " for ", sample_idx, " <- ", src_sample_idx, "."));
-  DALI_ENFORCE(sample_dim() == src.shape().sample_dim(),
-               make_string("Sample must have the same dimensionality as a target batch, current: ",
-                           sample_dim(), " new: ", src.shape().sample_dim(), " for ", sample_idx,
-                           " <- ", src_sample_idx, "."));
-  DALI_ENFORCE(
-      GetLayout() == src.GetLayout(),
-      make_string("Sample must have the same layout as a target batch current: ", GetLayout(),
-                  " new: ", src.GetLayout(), " for ", sample_idx, " <- ", src_sample_idx, "."));
+  VerifySampleCopyConformance(src.type(), src.shape().sample_dim(), src.GetLayout(),
+                              shape()[sample_idx], src.shape()[src_sample_idx],
+                              make_string(" for ", sample_idx, " <- ", src_sample_idx, "."));
 
-  // Either the shape matches and we can copy data as is or the target is just an individual sample
-  bool can_copy = tensors_[sample_idx]->shape() == src.tensors_[src_sample_idx]->shape() ||
-                  (!tl_->has_data() && state_ == State::noncontiguous);
-
-  DALI_ENFORCE(
-      can_copy,
-      "Copying samples into TensorVector can happen either for exact shape match or when the "
-      "TensorVector is truly non contiguous. Either Resize first to the desired shape or reset the "
-      "TensorVector and SetSize for desired number of samples in non-contiguous mode.");
-
-  tensors_[sample_idx]->Copy(*src.tensors_[src_sample_idx], order);
+  shape_.set_tensor_shape(sample_idx, src.shape()[src_sample_idx]);
+  tensors_[sample_idx].Copy(src.tensors_[src_sample_idx], order);
+  if (src.GetLayout().empty() && !GetLayout().empty()) {
+    tensors_[sample_idx].SetLayout(GetLayout());
+  }
 }
+
+
+template <typename Backend>
+void TensorVector<Backend>::UnsafeCopySample(int sample_idx, const Tensor<Backend> &src,
+                                             AccessOrder order) {
+  // Bounds check
+  assert(sample_idx >= 0 && sample_idx < curr_num_tensors_);
+  VerifySampleCopyConformance(src.type(), src.shape().sample_dim(), src.GetLayout(),
+                              shape()[sample_idx], src.shape(),
+                              make_string(" for ", sample_idx, "."));
+
+  shape_.set_tensor_shape(sample_idx, src.shape());
+  tensors_[sample_idx].Copy(src, order);
+  if (src.GetLayout().empty() && !GetLayout().empty()) {
+    tensors_[sample_idx].SetLayout(GetLayout());
+  }
+}
+
 
 template <typename Backend>
 void TensorVector<Backend>::set_sample_dim(int sample_dim) {
@@ -326,17 +427,19 @@ void TensorVector<Backend>::set_sample_dim(int sample_dim) {
       !has_data(),
       "Setting sample dim is not allowed when batch is already allocated, use Resize instead.");
   sample_dim_ = sample_dim;
+  shape_.resize(shape_.num_samples(), sample_dim);
 }
+
 
 template <typename Backend>
 size_t TensorVector<Backend>::nbytes() const noexcept {
-  if (state_ == State::contiguous) {
-    return tl_->nbytes();
+  if (IsContiguous()) {
+    return contiguous_buffer_.nbytes();
   }
   // else
   size_t nbytes = 0;
   for (const auto &t : tensors_) {
-    nbytes += t->nbytes();
+    nbytes += t.nbytes();
   }
   return nbytes;
 }
@@ -344,26 +447,27 @@ size_t TensorVector<Backend>::nbytes() const noexcept {
 
 template <typename Backend>
 size_t TensorVector<Backend>::capacity() const noexcept {
-  if (state_ == State::contiguous) {
-    return tl_->capacity();
+  if (IsContiguous()) {
+    return contiguous_buffer_.capacity();
   }
   // else
   size_t capacity = 0;
   for (const auto &t : tensors_) {
-    capacity += t->capacity();
+    capacity += t.capacity();
   }
   return capacity;
 }
 
+
 template <typename Backend>
 std::vector<size_t> TensorVector<Backend>::_chunks_nbytes() const {
-  if (state_ == State::contiguous) {
-    return {tl_->nbytes()};
+  if (IsContiguous()) {
+    return {contiguous_buffer_.nbytes()};
   }
   // else
   std::vector<size_t> result(tensors_.size());
   for (size_t i = 0; i < tensors_.size(); i++) {
-    result[i] = tensors_[i]->nbytes();
+    result[i] = tensors_[i].nbytes();
   }
   return result;
 }
@@ -371,41 +475,32 @@ std::vector<size_t> TensorVector<Backend>::_chunks_nbytes() const {
 
 template <typename Backend>
 std::vector<size_t> TensorVector<Backend>::_chunks_capacity() const {
-  if (state_ == State::contiguous) {
-    return {tl_->capacity()};
+  if (IsContiguous()) {
+    return {contiguous_buffer_.capacity()};
   }
   // else
   std::vector<size_t> result(tensors_.size());
   for (size_t i = 0; i < tensors_.size(); i++) {
-    result[i] = tensors_[i]->capacity();
+    result[i] = tensors_[i].capacity();
   }
   return result;
 }
 
 
 template <typename Backend>
-TensorListShape<> TensorVector<Backend>::shape() const {
-  if (state_ == State::contiguous) {
-    return tl_->shape();
-  }
-  if (curr_num_tensors_ == 0) {
-    return {};
-  }
-  TensorListShape<> result(curr_num_tensors_, tensors_[0]->ndim());
-  for (int i = 0; i < curr_num_tensors_; i++) {
-    result.set_tensor_shape(i, tensors_[i]->shape());
-  }
-  return result;
+const TensorListShape<> &TensorVector<Backend>::shape() const & {
+  return shape_;
 }
+
 
 template <typename Backend>
 void TensorVector<Backend>::set_order(AccessOrder order, bool synchronize) {
   // Optimization: synchronize only once, if needed.
   if (this->order().is_device() && order && synchronize) {
-    bool need_sync = tl_->has_data();
+    bool need_sync = contiguous_buffer_.has_data();
     if (!need_sync) {
-      for (auto &t : tensors_) {
-        if (t->has_data()) {
+      for (const auto &t : tensors_) {
+        if (t.has_data()) {
           need_sync = true;
           break;
         }
@@ -414,35 +509,86 @@ void TensorVector<Backend>::set_order(AccessOrder order, bool synchronize) {
     if (need_sync)
       this->order().wait(order);
   }
-  tl_->set_order(order, false);
+  contiguous_buffer_.set_order(order, false);
   for (auto &t : tensors_)
-    t->set_order(order, false);
+    t.set_order(order, false);
   order_ = order;
 }
 
+
 template <typename Backend>
-void TensorVector<Backend>::Resize(const TensorListShape<> &new_shape, DALIDataType new_type) {
+SampleView<Backend> TensorVector<Backend>::operator[](size_t pos) {
+  DALI_ENFORCE(pos < static_cast<size_t>(curr_num_tensors_), "Out of bounds access");
+  return {tensors_[pos].raw_mutable_data(), shape().tensor_shape_span(pos), tensors_[pos].type()};
+}
+
+
+template <typename Backend>
+ConstSampleView<Backend> TensorVector<Backend>::operator[](size_t pos) const {
+  DALI_ENFORCE(pos < static_cast<size_t>(curr_num_tensors_), "Out of bounds access");
+  return {tensors_[pos].raw_data(), shape().tensor_shape_span(pos), tensors_[pos].type()};
+}
+
+
+template <typename Backend>
+void TensorVector<Backend>::Resize(const TensorListShape<> &new_shape, DALIDataType new_type,
+                                   BatchState state) {
   DALI_ENFORCE(IsValidType(new_type),
-                "TensorVector cannot be resized with invalid type. To zero out the TensorVector "
-                "Reset() can be used.");
+               "TensorVector cannot be resized with invalid type. To zero out the TensorVector "
+               "Reset() can be used.");
+  if (state_.Update(state)) {
+    if (!state_.IsContiguous()) {
+      // As we updated the state to noncontiguous, we need to detach the buffers
+      DoMakeNoncontiguous();
+    }
+  }
   resize_tensors(new_shape.num_samples());
-  if (state_ == State::contiguous) {
-    tl_->Resize(new_shape, new_type);
-    UpdateViews();
+  if (type_.id() != new_type) {
+    type_ = TypeTable::GetTypeInfo(new_type);
+    // calling appropriate resize and/or recreate_views propagates type to individual samples
+  }
+
+  bool should_coalesce = [&]() {
+    if (!state_.IsContiguous() && state_.IsForced()) {
+      return false;  // someone needs non-contiguous data
+    }
+    if (state_.IsContiguous()) {
+      return false;  // already coalesced
+    }
+    if (state == BatchState::Noncontiguous) {
+      return false;  // we were requested to keep it non-contiguous
+    }
+    // TODO(klecki): as an alternative, coalesce every time?
+    for (int i = 0; i < curr_num_tensors_; i++) {
+      if (tensors_[i].capacity() < volume(new_shape.tensor_shape_span(i)) * type_.size()) {
+        return true;  // we will be reallocating either way, let's coalesce
+      }
+    }
+    return false;
+  }();
+
+  sample_dim_ = new_shape.sample_dim();
+  shape_ = new_shape;
+
+  if (should_coalesce) {
+    state_.Update(BatchState::Contiguous);
+  }
+
+  if (state_.IsContiguous()) {
+    contiguous_buffer_.resize(new_shape.num_elements(), new_type);
+    order_ = contiguous_buffer_.order();  // propagate order after allocation, it might have changed
+    device_ = contiguous_buffer_.device_;
+    recreate_views();
     return;
   }
 
   for (int i = 0; i < curr_num_tensors_; i++) {
-    tensors_[i]->Resize(new_shape[i], new_type);
+    tensors_[i].Resize(new_shape[i], new_type);
   }
-  if (type_.id() != new_type) {
-    type_ = TypeTable::GetTypeInfo(new_type);
-    if (state_ == State::noncontiguous) {
-      tl_->Reset();
-      tl_->set_type(new_type);
-    }
+  if (curr_num_tensors_ > 0) {
+    order_ = tensors_[0].order();
+    device_ = tensors_[0].device_id();
   }
-  sample_dim_ = new_shape.sample_dim();
 }
 
 
@@ -464,107 +610,78 @@ void TensorVector<Backend>::set_type(DALIDataType new_type_id) {
                            type_.id(), "' trying to set: '", new_type_id,
                            "'. You may change the current type using Resize or by"
                            " calling Reset first."));
+  contiguous_buffer_.set_type(new_type_id);
   type_ = TypeTable::GetTypeInfo(new_type_id);
-  tl_->set_type(new_type_id);
-  for (auto t : tensors_) {
-    t->set_type(new_type_id);
-  }
-  if (state_ == State::contiguous) {
-    UpdateViews();
+  if (state_.IsContiguous()) {
+    recreate_views();
+  } else {
+    for (auto &t : tensors_) {
+      t.set_type(new_type_id);
+    }
   }
 }
 
 
 template <typename Backend>
 DALIDataType TensorVector<Backend>::type() const {
-  if (state_ == State::contiguous) {
-    return tl_->type();
-  }
-  if (curr_num_tensors_ == 0) {
-    return type_.id();
-  }
-  for (int i = 1; i < curr_num_tensors_; i++) {
-    assert(tensors_[0]->type() == tensors_[i]->type());
-  }
-  return tensors_[0]->type();
+  return type_.id();
 }
+
 
 template <typename Backend>
 const TypeInfo &TensorVector<Backend>::type_info() const {
-  if (state_ == State::contiguous) {
-    return tl_->type_info();
-  }
-  if (curr_num_tensors_ == 0) {
-    return type_;
-  }
-  for (int i = 1; i < curr_num_tensors_; i++) {
-    assert(tensors_[0]->type() == tensors_[i]->type());
-  }
-  return tensors_[0]->type_info();
+  return type_;
 }
 
 
 template <typename Backend>
 void TensorVector<Backend>::SetLayout(const TensorLayout &layout) {
-  if (state_ == State::noncontiguous) {
-    DALI_ENFORCE(!tensors_.empty(), "Layout cannot be set uniformly for empty batch");
+  for (auto &t : tensors_) {
+    t.SetLayout(layout);
   }
-  tl_->SetLayout(layout);
-  for (auto t : tensors_) {
-    t->SetLayout(layout);
-  }
+  layout_ = layout;
 }
 
 
 template <typename Backend>
 void TensorVector<Backend>::SetSkipSample(int idx, bool skip_sample) {
-  tensors_[idx]->SetSkipSample(skip_sample);
+  tensors_[idx].SetSkipSample(skip_sample);
 }
 
 
 template <typename Backend>
-void TensorVector<Backend>::SetSourceInfo(int idx, const std::string& source_info) {
-  tensors_[idx]->SetSourceInfo(source_info);
+void TensorVector<Backend>::SetSourceInfo(int idx, const std::string &source_info) {
+  tensors_[idx].SetSourceInfo(source_info);
 }
 
 
 template <typename Backend>
 TensorLayout TensorVector<Backend>::GetLayout() const {
-  if (state_ == State::contiguous) {
-    auto layout = tl_->GetLayout();
-    if (!layout.empty()) return layout;
-  }
-  if (curr_num_tensors_ > 0) {
-    auto layout = tensors_[0]->GetLayout();
-    for (int i = 1; i < curr_num_tensors_; i++) assert(layout == tensors_[i]->GetLayout());
-    return layout;
-  }
-  return {};
+  return layout_;
 }
 
 
 template <typename Backend>
 const DALIMeta &TensorVector<Backend>::GetMeta(int idx) const {
   assert(idx < curr_num_tensors_);
-  return tensors_[idx]->GetMeta();
+  return tensors_[idx].GetMeta();
 }
 
 
 template <typename Backend>
 void TensorVector<Backend>::SetMeta(int idx, const DALIMeta &meta) {
   assert(idx < curr_num_tensors_);
-  tensors_[idx]->SetMeta(meta);
+  tensors_[idx].SetMeta(meta);
 }
 
 
 template <typename Backend>
 void TensorVector<Backend>::set_pinned(bool pinned) {
-  // Store the value, in case we pin empty vector and later call Resize
-  pinned_ = pinned;
-  tl_->set_pinned(pinned);
+  contiguous_buffer_.set_pinned(pinned);
   for (auto &t : tensors_) {
-    t->set_pinned(pinned);
+    t.set_pinned(pinned);
   }
+  pinned_ = pinned;
 }
 
 
@@ -576,191 +693,258 @@ bool TensorVector<Backend>::is_pinned() const {
 
 template <typename Backend>
 void TensorVector<Backend>::set_device_id(int device_id) {
-  tl_->set_device_id(device_id);
+  contiguous_buffer_.set_device_id(device_id);
   for (auto &t : tensors_) {
-    t->set_device_id(device_id);
+    t.set_device_id(device_id);
   }
+  device_ = device_id;
 }
 
 
 template <typename Backend>
 int TensorVector<Backend>::device_id() const {
-  if (IsContiguous()) {
-    return tl_->device_id();
-  } else if (!tensors_.empty()) {
-    return tensors_[0]->device_id();
-  }
-  return CPU_ONLY_DEVICE_ID;
+  return device_;
 }
 
 
 template <typename Backend>
 void TensorVector<Backend>::reserve(size_t total_bytes) {
-  if (state_ == State::noncontiguous) {
+  int batch_size_bkp = curr_num_tensors_;
+  if (!state_.IsContiguous()) {
     tensors_.clear();
-    curr_num_tensors_ = 0;
+    resize_tensors(0);
   }
-  state_ = State::contiguous;
-  tl_->reserve(total_bytes);
-  UpdateViews();
+  state_.Setup(BatchState::Contiguous);
+  contiguous_buffer_.reserve(total_bytes);
+  if (IsValidType(type_)) {
+    resize_tensors(batch_size_bkp);
+    recreate_views();
+  }
 }
 
 
 template <typename Backend>
 void TensorVector<Backend>::reserve(size_t bytes_per_sample, int batch_size) {
   assert(batch_size > 0);
-  state_ = State::noncontiguous;
+  state_.Setup(BatchState::Noncontiguous);
   resize_tensors(batch_size);
   for (int i = 0; i < curr_num_tensors_; i++) {
-    tensors_[i]->reserve(bytes_per_sample);
+    tensors_[i].reserve(bytes_per_sample);
   }
 }
 
 
 template <typename Backend>
 bool TensorVector<Backend>::IsContiguous() const noexcept {
-  return state_ == State::contiguous;
+  return state_.IsContiguous();
 }
 
 
 template <typename Backend>
-void TensorVector<Backend>::SetContiguous(bool contiguous) {
-  if (contiguous) {
-    state_ = State::contiguous;
-  } else {
-    state_ = State::noncontiguous;
+void TensorVector<Backend>::recreate_views() {
+  // precondition: type, shape are configured
+  uint8_t *base_ptr = static_cast<uint8_t *>(contiguous_buffer_.raw_mutable_data());
+  int64_t num_samples = shape().num_samples();
+  for (int64_t i = 0; i < num_samples; i++) {
+    // or any other way
+    auto tensor_size = shape().tensor_size(i);
+
+    std::shared_ptr<void> sample_alias(contiguous_buffer_.get_data_ptr(), base_ptr);
+    tensors_[i].ShareData(sample_alias, tensor_size * type_info().size(), is_pinned(), shape()[i],
+                          type(), device_id(), order());
+    tensors_[i].set_device_id(device_id());
+    base_ptr += tensor_size * type_info().size();
+  }
+}
+
+
+template <typename Backend>
+void TensorVector<Backend>::SetContiguous(BatchState state) {
+  if (state == BatchState::Default) {
+    // remove the force, keep the current state information
+    state_.Setup(state_.Get(), false);
+    return;
+  }
+  DALI_ENFORCE(state_.Get() == state || !has_data(),
+               "Contiguous or non-contiguous mode cannot be set to already allocated buffer.");
+  state_.Setup(state, true);
+}
+
+
+template <typename Backend>
+void TensorVector<Backend>::SetContiguous(bool state) {
+  SetContiguous(state ? BatchState::Contiguous : BatchState::Noncontiguous);
+}
+
+
+template <typename Backend>
+void TensorVector<Backend>::MakeContiguous(std::weak_ptr<void> owner) {
+  if (state_.IsContiguous()) {
+    return;
+  }
+  DALI_FAIL("Don't know how to coalesce the buffer yet");
+}
+
+
+template <typename Backend>
+void TensorVector<Backend>::MakeNoncontiguous() {
+  if (!state_.IsContiguous()) {
+    return;
+  }
+
+  state_.Update(BatchState::Noncontiguous);
+  DoMakeNoncontiguous();
+}
+
+
+template <typename Backend>
+void TensorVector<Backend>::DoMakeNoncontiguous() {
+  // We clear the contiguous_buffer_, as we are now non-contiguous.
+  buffer_bkp_ = contiguous_buffer_.get_data_ptr();
+  contiguous_buffer_.reset();
+  for (auto &t : tensors_) {
+    // If the Tensor was aliasing the contiguous buffer, mark it as not sharing any data.
+    // This will allow for the individual buffers to be resized.
+    // The downside of this is we may keep the big contiguous buffer until all individual
+    // samples are replaced.
+    if (same_owner(buffer_bkp_, t.data_)) {
+      t.detach();
+    }
   }
 }
 
 
 template <typename Backend>
 void TensorVector<Backend>::Reset() {
+  if (IsContiguous()) {
+    contiguous_buffer_.reset();
+  }
+  buffer_bkp_.reset();
+  // TODO(klecki): Is there any benefit to call Reset on all?
   tensors_.clear();
+
   curr_num_tensors_ = 0;
   type_ = {};
   sample_dim_ = -1;
-  if (IsContiguous()) {
-    tl_->Reset();
-  }
+  shape_ = {};
+  layout_ = "";
+  // N.B. state_, pinned_, order_ and device_ are not reset here, as they might be previously set
+  // up via the executor - TODO(klecki) - consider if we want to keep this behaviour
 }
 
 
 template <typename Backend>
 template <typename SrcBackend>
-void TensorVector<Backend>::Copy(const TensorList<SrcBackend> &in_tl, AccessOrder order) {
+void TensorVector<Backend>::Copy(const TensorList<SrcBackend> &src, AccessOrder order) {
   // This variant will be removed with the removal of TensorList.
-  SetContiguous(true);
 
-  auto copy_order = copy_impl::SyncBefore(this->order(), in_tl.order(), order);
+  auto copy_order = copy_impl::SyncBefore(this->order(), src.order(), order);
 
-
-  tl_->Resize(in_tl.shape(), in_tl.type());
-  type_ = in_tl.type_info();
-  sample_dim_ = in_tl.shape().sample_dim();
-
-  copy_impl::SyncAfterResize(this->order(), copy_order);
-
-  // Update the metadata
-  type_ = in_tl.type_info();
-  sample_dim_ = in_tl.shape().sample_dim();
-
-  // Here both batches are contiguous
-  type_info().template Copy<Backend, SrcBackend>(
-      unsafe_raw_mutable_data(*tl_), unsafe_raw_data(in_tl), in_tl.shape().num_elements(),
-      copy_order.stream(), false);
-  copy_impl::SyncAfter(this->order(), copy_order);
-
-  resize_tensors(tl_->num_samples());
-
-  // Update the metadata in internal TL, and let them be copied to the Tensors
-  SetLayout(in_tl.GetLayout());
-  for (int i = 0; i < curr_num_tensors_; i++) {
-    tl_->SetMeta(i, in_tl.GetMeta(i));
-  }
-  UpdateViews();
-}
-
-
-template <typename Backend>
-template <typename SrcBackend>
-void TensorVector<Backend>::Copy(const TensorVector<SrcBackend> &in_tv, AccessOrder order) {
-  auto copy_order = copy_impl::SyncBefore(this->order(), in_tv.order(), order);
-
-  Resize(in_tv.shape(), in_tv.type());
+  Resize(src.shape(), src.type());
   // After resize the state_, curr_num_tensors_, type_, sample_dim_, shape_ (and pinned)
   // postconditions are met, as well as the buffers are correctly adjusted.
+
   copy_impl::SyncAfterResize(this->order(), copy_order);
 
   bool use_copy_kernel = false;
+  use_copy_kernel &= (std::is_same<SrcBackend, GPUBackend>::value || src.is_pinned()) &&
+                     (std::is_same<Backend, GPUBackend>::value || this->is_pinned());
 
-  copy_impl::CopyImpl(*this, in_tv, this->type_info(), copy_order, use_copy_kernel);
+  copy_impl::CopyImpl(*this, src, this->type_info(), copy_order, use_copy_kernel);
 
   // Update the layout and other metadata
-  // TODO(klecki): Remove the check, when we have `layout_` member and the non-contiguous
-  // batch can remember the layout
-  if (state_ != State::noncontiguous || !tensors_.empty()) {
-    SetLayout(in_tv.GetLayout());
-  }
-  if (state_ == State::contiguous) {
-    for (int i = 0; i < curr_num_tensors_; i++) {
-      tl_->SetMeta(i, in_tv.GetMeta(i));
-    }
-  }
+  SetLayout(src.GetLayout());
   for (int i = 0; i < curr_num_tensors_; i++) {
-    tensors_[i]->SetMeta(in_tv.GetMeta(i));
+    SetMeta(i, src.GetMeta(i));
   }
+
   copy_impl::SyncAfter(this->order(), copy_order);
 }
 
 
 template <typename Backend>
+template <typename SrcBackend>
+void TensorVector<Backend>::Copy(const TensorVector<SrcBackend> &src, AccessOrder order,
+                                 bool use_copy_kernel) {
+  auto copy_order = copy_impl::SyncBefore(this->order(), src.order(), order);
+
+  Resize(src.shape(), src.type());
+  // After resize the state_, curr_num_tensors_, type_, sample_dim_, shape_ (and pinned)
+  // postconditions are met, as well as the buffers are correctly adjusted.
+
+  copy_impl::SyncAfterResize(this->order(), copy_order);
+
+  use_copy_kernel &= (std::is_same<SrcBackend, GPUBackend>::value || src.is_pinned()) &&
+                     (std::is_same<Backend, GPUBackend>::value || this->is_pinned());
+
+  copy_impl::CopyImpl(*this, src, this->type_info(), copy_order, use_copy_kernel);
+
+  // Update the layout and other metadata
+  SetLayout(src.GetLayout());
+  for (int i = 0; i < curr_num_tensors_; i++) {
+    SetMeta(i, src.GetMeta(i));
+  }
+
+  copy_impl::SyncAfter(this->order(), copy_order);
+}
+
+template <typename Backend>
 void TensorVector<Backend>::ShareData(const TensorList<Backend> &in_tl) {
-  SetContiguous(true);
+  Reset();
+
+  state_.Setup(BatchState::Contiguous);
+  curr_num_tensors_ = in_tl.num_samples();
   type_ = in_tl.type_info();
   sample_dim_ = in_tl.shape().sample_dim();
+  shape_ = in_tl.shape();
+  layout_ = in_tl.GetLayout();
   pinned_ = in_tl.is_pinned();
-  tl_->ShareData(in_tl);
+  order_ = in_tl.order();
+  device_ = in_tl.device_id();
 
-  resize_tensors(in_tl.num_samples());
-  UpdateViews();
+  contiguous_buffer_.ShareData(in_tl.data_);
+  // Create empty tensors by hand so we do not allocate twice as the shape is already set
+  tensors_.resize(in_tl.num_samples());
+  // recrete the aliases
+  recreate_views();
+
+  SetLayout(in_tl.GetLayout());
+  for (int i = 0; i < curr_num_tensors_; i++) {
+    SetMeta(i, in_tl.GetMeta(i));
+  }
 }
+
 
 template <typename Backend>
 void TensorVector<Backend>::ShareData(const TensorVector<Backend> &tv) {
+  Reset();
+
+  state_ = tv.state_;
+  curr_num_tensors_ = tv.curr_num_tensors_;
   type_ = tv.type_;
   sample_dim_ = tv.sample_dim_;
-  state_ = tv.state_;
-  pinned_ = tv.is_pinned();
-  if (tv.state_ == State::contiguous) {
-    ShareData(*tv.tl_);
+  shape_ = tv.shape_;
+  layout_ = tv.layout_;
+  pinned_ = tv.pinned_;
+  order_ = tv.order_;
+  device_ = tv.device_;
+
+  if (tv.IsContiguous()) {
+    contiguous_buffer_.ShareData(tv.contiguous_buffer_);
+    tensors_.resize(shape().num_samples());
+    recreate_views();
   } else {
-    state_ = State::noncontiguous;
-    tl_->Reset();
     int batch_size = tv.num_samples();
+    tensors_.resize(shape().num_samples());
     for (int i = 0; i < batch_size; i++) {
-      resize_tensors(batch_size);
-      tensors_[i]->ShareData(*(tv.tensors_[i]));
+      tensors_[i].ShareData(tv.tensors_[i]);
     }
   }
-}
 
-
-template <typename Backend>
-TensorVector<Backend> &TensorVector<Backend>::operator=(TensorVector<Backend> &&other) noexcept {
-  if (&other != this) {
-    state_ = other.state_;
-    pinned_ = other.pinned_;
-    order_ = other.order_;
-    curr_num_tensors_ = other.curr_num_tensors_;
-    tl_ = std::move(other.tl_);
-    type_ = other.type_;
-    sample_dim_ = other.sample_dim_;
-    tensors_ = std::move(other.tensors_);
-
-    other.curr_num_tensors_ = 0;
-    other.tensors_.clear();
+  SetLayout(tv.GetLayout());
+  for (int i = 0; i < curr_num_tensors_; i++) {
+    SetMeta(i, tv.GetMeta(i));
   }
-  return *this;
 }
 
 
@@ -774,14 +958,14 @@ bool TensorVector<Backend>::IsContiguousInMemory() const {
   if (IsContiguous()) {
     return true;
   }
-  const uint8_t *base_ptr = static_cast<const uint8_t *>(tensors_[0]->raw_data());
+  const uint8_t *base_ptr = static_cast<const uint8_t *>(tensors_[0].raw_data());
   size_t size = type_info().size();
 
   for (int i = 0; i < num_samples(); ++i) {
-    if (base_ptr != tensors_[i]->raw_data()) {
+    if (base_ptr != tensors_[i].raw_data()) {
       return false;
     }
-    base_ptr += tensors_[i]->shape().num_elements() * size;
+    base_ptr += shape_[i].num_elements() * size;
   }
   return true;
 }
@@ -804,14 +988,16 @@ Tensor<Backend> TensorVector<Backend>::AsReshapedTensor(const TensorShape<> &new
       make_string("To create a view Tensor, requested shape need to have the same volume as the "
                   "batch, requested: ",
                   new_shape.num_elements(), " expected: ", shape().num_elements()));
+  DALI_ENFORCE(IsContiguousInMemory(),
+               "To create a view Tensor, the butch must be laid down in contiguous memory.");
 
   Tensor<Backend> result;
 
   shared_ptr<void> ptr;
   if (num_samples() > 0) {
-    ptr = unsafe_sample_owner(*tl_, 0);
+    ptr = unsafe_sample_owner(*this, 0);
   } else if (IsContiguous()) {
-    ptr = unsafe_owner(*tl_);
+    ptr = unsafe_owner(*this);
   } else {
     ptr = nullptr;
   }
@@ -842,118 +1028,145 @@ Tensor<Backend> TensorVector<Backend>::AsTensor() {
 
 
 template <typename Backend>
-void TensorVector<Backend>::UpdateViews() {
-  // Return if we do not have a valid allocation
-  if (!IsValidType(tl_->type())) return;
-  // we need to be able to share empty view as well so don't check if tl_ has any data
-  type_ = tl_->type_info();
-  sample_dim_ = tl_->shape().sample_dim();
+void TensorVector<Backend>::ShareData(const shared_ptr<void> &ptr, size_t bytes, bool pinned,
+                                      const TensorListShape<> &shape, DALIDataType type,
+                                      int device_id, AccessOrder order,
+                                      const TensorLayout &layout) {
+  contiguous_buffer_.set_backing_allocation(ptr, bytes, pinned, type, shape.num_elements(),
+                                            device_id, order);
+  buffer_bkp_.reset();
+  tensors_.clear();
+  tensors_.resize(shape.num_samples());
 
-  assert(curr_num_tensors_ == tl_->num_samples());
-
-  for (int i = 0; i < curr_num_tensors_; i++) {
-    update_view(i);
-  }
+  state_.Update(BatchState::Contiguous);
+  curr_num_tensors_ = shape.num_samples();
+  type_ = TypeTable::GetTypeInfo(type);
+  sample_dim_ = shape.sample_dim();
+  shape_ = shape;
+  layout_ = layout;
+  pinned_ = pinned;
+  device_ = device_id;
+  order_ = order;
+  recreate_views();
 }
 
 
 template <typename Backend>
 void TensorVector<Backend>::resize_tensors(int new_size) {
-  if (static_cast<size_t>(new_size) > tensors_.size()) {
+  // This doesn't update with the same order as the class members are listed
+  // We need to make sure everything is updated for the tensors that come back into scope
+  // and we start with the pinned and order properties as they might impact future allocations.
+  // next we make sure the type is consistent, and if so, introduce empty shape
+  shape_.resize(new_size);
+  if (new_size > curr_num_tensors_) {
     auto old_size = curr_num_tensors_;
     tensors_.resize(new_size);
     for (int i = old_size; i < new_size; i++) {
-      if (!tensors_[i]) {
-        tensors_[i] = std::make_shared<Tensor<Backend>>();
-        tensors_[i]->set_pinned(is_pinned());
-        tensors_[i]->set_order(order());
+      // TODO(klecki) same validation as when updating properties - or reset
+      if (!tensors_[i].has_data()) {
+        tensors_[i].set_pinned(is_pinned());
+      } else {
+        DALI_ENFORCE(tensors_[i].is_pinned() == is_pinned());
       }
+      tensors_[i].set_order(order());
+      tensors_[i].set_device_id(device_id());
+      if (type() != DALI_NO_TYPE) {
+        tensors_[i].set_type(type());
+        if (sample_dim_ >= 0) {
+          tensors_[i].Resize(empty_shape(sample_dim()));
+          shape_.set_tensor_shape(i, empty_shape(sample_dim()));
+        }
+      }
+      tensors_[i].SetLayout(GetLayout());
     }
   } else if (new_size < curr_num_tensors_) {
+    // TODO(klecki): Do not keep the invalidated tensors - this prevents memory hogging but
+    // also gets rid of reserved memory. For now keeping the old behaviour.
     for (int i = new_size; i < curr_num_tensors_; i++) {
-      if (tensors_[i]->shares_data()) {
-        tensors_[i]->Reset();
+      if (tensors_[i].shares_data()) {
+        tensors_[i].Reset();
       }
     }
-    // TODO(klecki): Do not keep the invalidated tensors - this prevents memory hogging but
-    // also gets rid of reserved memory.
-    // tensors_.resize(new_size);
   }
   curr_num_tensors_ = new_size;
 }
 
+
 template <typename Backend>
 void TensorVector<Backend>::UpdatePropertiesFromSamples(bool contiguous) {
-  // TODO(klecki): This is mostly simple consistency check, but most of the metadata will be moved
-  // to the batch object for consitency and easier use in checks. It should allow for shape()
-  // to be ready to use as well as easy verification for SetSample/CopySample.
-  SetContiguous(contiguous);
+  state_.Update(contiguous ? BatchState::Contiguous : BatchState::Noncontiguous);
   // assume that the curr_num_tensors_ is valid
-  DALI_ENFORCE(curr_num_tensors_ > 0, "Unexpected empty output of operator. Internal DALI error.");
-  type_ = tensors_[0]->type_info();
-  sample_dim_ = tensors_[0]->shape().sample_dim();
-  pinned_ = tensors_[0]->is_pinned();
-  order_ = tensors_[0]->order();
-  tl_->set_order(order_);
+  DALI_ENFORCE(curr_num_tensors_ > 0,
+               "Unexpected empty output of per-sample operator. Internal DALI error.");
+  type_ = tensors_[0].type_info();
+  sample_dim_ = tensors_[0].shape().sample_dim();
+  shape_.resize(curr_num_tensors_, sample_dim_);
+  layout_ = tensors_[0].GetMeta().GetLayout();
+  pinned_ = tensors_[0].is_pinned();
+  order_ = tensors_[0].order();
+  device_ = tensors_[0].device_id();
+  contiguous_buffer_.set_order(order_);
   for (int i = 0; i < curr_num_tensors_; i++) {
-    DALI_ENFORCE(type() == tensors_[i]->type(),
+    DALI_ENFORCE(type() == tensors_[i].type(),
                  make_string("Samples must have the same type, expected: ", type(),
-                             " got: ", tensors_[i]->type(), " at ", i, "."));
-    DALI_ENFORCE(sample_dim() == tensors_[i]->shape().sample_dim(),
+                             " got: ", tensors_[i].type(), " at ", i, "."));
+    DALI_ENFORCE(sample_dim() == tensors_[i].shape().sample_dim(),
                  make_string("Samples must have the same dimensionality, expected: ", sample_dim(),
-                             " got: ", tensors_[i]->shape().sample_dim(), " at ", i, "."));
-    DALI_ENFORCE(order() == tensors_[i]->order(),
-                 make_string("Samples must have the same order, expected: ", order().get(), " ",
-                             order().device_id(), " got: ", tensors_[i]->order().get(), " ",
-                             tensors_[i]->order().device_id(), " at ", i, "."));
-    DALI_ENFORCE(GetLayout() == tensors_[i]->GetLayout(),
+                             " got: ", tensors_[i].shape().sample_dim(), " at ", i, "."));
+    DALI_ENFORCE(GetLayout() == tensors_[i].GetLayout(),
                  make_string("Samples must have the same layout, expected: ", GetLayout(),
-                             " got: ", tensors_[i]->GetLayout(), " at ", i, "."));
+                             " got: ", tensors_[i].GetLayout(), " at ", i, "."));
+    DALI_ENFORCE(is_pinned() == tensors_[i].is_pinned(),
+                 make_string("Samples must have the same pinned status, expected: ", is_pinned(),
+                             " got: ", tensors_[i].is_pinned(), " at ", i, "."));
+    DALI_ENFORCE(order() == tensors_[i].order(),
+                 make_string("Samples must have the same order, expected: ", order().get(), " ",
+                             order().device_id(), " got: ", tensors_[i].order().get(), " ",
+                             tensors_[i].order().device_id(), " at ", i, "."));
+    DALI_ENFORCE(device_id() == tensors_[i].device_id(),
+                 make_string("Samples must have the same device id, expected: ", device_id(),
+                             " got: ", tensors_[i].device_id(), " at ", i, "."));
+    shape_.set_tensor_shape(i, tensors_[i].shape());
   }
 }
 
+
 template <typename Backend>
 bool TensorVector<Backend>::has_data() const {
-  if (state_ == State::contiguous) {
-    return tl_->has_data();
+  if (IsContiguous()) {
+    return contiguous_buffer_.has_data();
   }
   for (const auto &tensor : tensors_) {
-    if (tensor->has_data()) {
+    if (tensor.has_data()) {
       return true;
     }
   }
   return false;
 }
 
+
 template <typename Backend>
-void TensorVector<Backend>::update_view(int idx) {
-  assert(idx < curr_num_tensors_);
-  assert(idx < tl_->num_samples());
-
-  auto *ptr = tl_->raw_mutable_tensor(idx);
-
-  TensorShape<> shape = tl_->tensor_shape(idx);
-
-  tensors_[idx]->Reset();
-  // TODO(klecki): deleter that reduces views_count or just noop sharing?
-  // tensors_[i]->ShareData(tl_.get(), static_cast<int>(idx));
-  if (tensors_[idx]->raw_data() != ptr || tensors_[idx]->shape() != shape) {
-    tensors_[idx]->ShareData(unsafe_sample_owner(*tl_, idx),
-                             volume(tl_->tensor_shape(idx)) * tl_->type_info().size(),
-                             tl_->is_pinned(), shape, tl_->type(), tl_->device_id(), order());
-  } else if (IsValidType(tl_->type())) {
-    tensors_[idx]->set_type(tl_->type());
+bool TensorVector<Backend>::shares_data() const {
+  // TODO(klecki): I would like to get rid of some of this
+  if (IsContiguous()) {
+    return contiguous_buffer_.shares_data();
   }
-  tensors_[idx]->SetMeta(tl_->GetMeta(idx));
+  for (const auto &tensor : tensors_) {
+    if (tensor.shares_data() && !same_owner(contiguous_buffer_.get_data_ptr(),
+                                            tensor.get_data_ptr())) {
+      return true;
+    }
+  }
+  return false;
 }
 
 
 template class DLL_PUBLIC TensorVector<CPUBackend>;
 template class DLL_PUBLIC TensorVector<GPUBackend>;
-template void TensorVector<CPUBackend>::Copy<CPUBackend>(const TensorVector<CPUBackend>&, AccessOrder);  // NOLINT
-template void TensorVector<CPUBackend>::Copy<GPUBackend>(const TensorVector<GPUBackend>&, AccessOrder);  // NOLINT
-template void TensorVector<GPUBackend>::Copy<CPUBackend>(const TensorVector<CPUBackend>&, AccessOrder);  // NOLINT
-template void TensorVector<GPUBackend>::Copy<GPUBackend>(const TensorVector<GPUBackend>&, AccessOrder);  // NOLINT
+template void TensorVector<CPUBackend>::Copy<CPUBackend>(const TensorVector<CPUBackend>&, AccessOrder, bool);  // NOLINT
+template void TensorVector<CPUBackend>::Copy<GPUBackend>(const TensorVector<GPUBackend>&, AccessOrder, bool);  // NOLINT
+template void TensorVector<GPUBackend>::Copy<CPUBackend>(const TensorVector<CPUBackend>&, AccessOrder, bool);  // NOLINT
+template void TensorVector<GPUBackend>::Copy<GPUBackend>(const TensorVector<GPUBackend>&, AccessOrder, bool);  // NOLINT
 template void TensorVector<CPUBackend>::Copy<CPUBackend>(const TensorList<CPUBackend>&, AccessOrder);  // NOLINT
 template void TensorVector<CPUBackend>::Copy<GPUBackend>(const TensorList<GPUBackend>&, AccessOrder);  // NOLINT
 template void TensorVector<GPUBackend>::Copy<CPUBackend>(const TensorList<CPUBackend>&, AccessOrder);  // NOLINT

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -391,18 +391,18 @@ class DLL_PUBLIC TensorVector {
   bool IsContiguous() const noexcept;
 
   /**
-   * @brief Set the current state for further allocating calls like Resize() or set_type
-   *        to use contiguous or noncontiguous backing memory
+   * @brief Pin the current state for further allocating calls like Resize() or set_type
+   *        to use contiguous or noncontiguous backing memory.
    *        Setting BatchState::Default allows to change it with every call to Resize().
    */
-  void SetContiguous(BatchState state);
+  void SetBatchState(BatchState state);
 
   /**
    * @brief Set the contiguity state for further allocations. Convenient overload accepting boolean.
    *
-   * @param state - pins the state to either Contiguous (true) or Noncontiguous (false)
+   * @param contiguous - pins the state to either Contiguous (true) or Noncontiguous (false)
    */
-  void SetContiguous(bool state);
+  void SetBatchState(bool contiguous);
 
   /**
    * @brief Coalesce from individual samples to a contiguous buffer if the conditions are met.

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -145,7 +145,7 @@ class DLL_PUBLIC TensorVector {
 
   /**
    * @name Sample access
-   * @{}
+   * @{
    */
   /**
    * @brief Get the view for the sample at given position
@@ -161,7 +161,7 @@ class DLL_PUBLIC TensorVector {
    * @brief Returns a typed pointer to the tensor with the given index.
    */
   template <typename T>
-  DLL_PUBLIC inline T* mutable_tensor(int idx) {
+  DLL_PUBLIC inline T *mutable_tensor(int idx) {
     return tensors_[idx].template mutable_data<T>();
   }
 
@@ -169,22 +169,22 @@ class DLL_PUBLIC TensorVector {
    * @brief Returns a const typed pointer to the tensor with the given index.
    */
   template <typename T>
-  DLL_PUBLIC inline const T* tensor(int idx) const {
+  DLL_PUBLIC inline const T *tensor(int idx) const {
     return tensors_[idx].template data<T>();
   }
 
   /**
    * @brief Returns a raw pointer to the tensor with the given index.
    */
-  DLL_PUBLIC inline void* raw_mutable_tensor(int idx) {
+  DLL_PUBLIC inline void *raw_mutable_tensor(int idx) {
     return tensors_[idx].raw_mutable_data();
   }
 
   /**
    * @brief Returns a const raw pointer to the tensor with the given index.
    */
-  DLL_PUBLIC inline const void* raw_tensor(int idx) const {
-    return  tensors_[idx].raw_data();
+  DLL_PUBLIC inline const void *raw_tensor(int idx) const {
+    return tensors_[idx].raw_data();
   }
   /** @} */
 
@@ -290,13 +290,13 @@ class DLL_PUBLIC TensorVector {
 
   /**
    * @brief Get the type of samples in the batch.
-   *
-   * @note Using DALIDataType is recommended over accessing type_info().
    */
   DALIDataType type() const;
 
   /**
    * @brief Get the TypeInfo of samples in the batch.
+   *
+   * @note Using DALIDataType via type() is recommended over accessing type_info().
    */
   const TypeInfo &type_info() const;
   /** @} */
@@ -398,11 +398,9 @@ class DLL_PUBLIC TensorVector {
   void SetContiguity(BatchContiguity state);
 
   /**
-   * @brief Set the contiguity state for further allocations. Convenient overload accepting boolean.
-   *
-   * @param contiguous - pins the state to either Contiguous (true) or Noncontiguous (false)
+   * @brief Check the batch contiguity state.
    */
-  void SetContiguity(bool contiguous);
+  BatchContiguity GetContiguity() const noexcept;
 
   /**
    * @brief Coalesce from individual samples to a contiguous buffer if the conditions are met.
@@ -507,11 +505,14 @@ class DLL_PUBLIC TensorVector {
   TensorLayout GetLayout() const;
 
   /**
-   * @brief Set uniform layout for all samples in the batch
+   * @brief Set cache metadata for given sample
    */
   void SetSkipSample(int idx, bool skip_sample);
 
-  void SetSourceInfo(int idx, const std::string& source_info);
+  /**
+   * @brief Set source information for given sample
+   */
+  void SetSourceInfo(int idx, const std::string &source_info);
 
   /**
    * @brief Get the metadata for given sample
@@ -566,8 +567,8 @@ class DLL_PUBLIC TensorVector {
     State(BatchContiguity state, bool forced) {
       Setup(state, forced);
     }
-    State(const State&) = default;
-    State &operator=(const State&) = default;
+    State(const State &) = default;
+    State &operator=(const State &) = default;
 
     /**
      * @brief Override current state.
@@ -632,18 +633,18 @@ class DLL_PUBLIC TensorVector {
                              int data_idx, int thread_idx);
   friend void FixBatchPropertiesConsistency(class HostWorkspace &ws, bool contiguous);
 
-  auto& tensor_handle(size_t pos) {
+  auto &tensor_handle(size_t pos) {
     return tensors_[pos];
   }
 
-  auto& tensor_handle(size_t pos) const {
+  auto &tensor_handle(size_t pos) const {
     return tensors_[pos];
   }
 
   template <typename T>
   void SetupLikeImpl(const T &other) {
     DALI_ENFORCE(!has_data(),
-                "Batch object can be initialized this way only when it isn't allocated.");
+                 "Batch object can be initialized this way only when it isn't allocated.");
     set_type(other.type());
     set_sample_dim(other.shape().sample_dim());
     SetLayout(other.GetLayout());
@@ -682,9 +683,9 @@ class DLL_PUBLIC TensorVector {
    *
    * @param error_suffix Additional description added to the error message
    */
-  void VerifySampleShareConformance(DALIDataType type, int sample_dim, TensorLayout layout,
-                                    bool pinned, AccessOrder order, int device_id,
-                                    const std::string &error_suffix = ".");
+  void VerifySampleShareCompatibility(DALIDataType type, int sample_dim, TensorLayout layout,
+                                      bool pinned, AccessOrder order, int device_id,
+                                      const std::string &error_suffix = ".");
 
   /**
    * @brief Check if the metadata provided for new sample match the ones currently set for the batch
@@ -696,10 +697,10 @@ class DLL_PUBLIC TensorVector {
    *
    * @param error_suffix Additional description added to the error message
    */
-  void VerifySampleCopyConformance(DALIDataType type, int sample_dim, TensorLayout layout,
-                                   const TensorShape<> &current_shape,
-                                   const TensorShape<> &new_shape,
-                                   const std::string &error_suffix = ".");
+  void VerifySampleCopyCompatibility(DALIDataType type, int sample_dim, TensorLayout layout,
+                                     const TensorShape<> &current_shape,
+                                     const TensorShape<> &new_shape,
+                                     const std::string &error_suffix = ".");
 
   // Memory backing
   Buffer<Backend> contiguous_buffer_;
@@ -735,7 +736,7 @@ class DLL_PUBLIC TensorVector {
    */
   /**
    * @brief Return an un-typed pointer to the underlying storage.
-   * The TensorList must be either empty or have a valid type and be contiguous.
+   * The TensorVector must be either empty or have a valid type and be contiguous.
    */
   friend void *unsafe_raw_mutable_data(TensorVector<Backend> &batch) {
     DALI_ENFORCE(batch.IsContiguous(), "Data pointer can be obtain only for contiguous batch.");

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -23,11 +23,15 @@
 #include <vector>
 
 #include "dali/core/access_order.h"
+#include "dali/core/error_handling.h"
+#include "dali/core/tensor_layout.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/pipeline/data/backend.h"
+#include "dali/pipeline/data/buffer.h"
 #include "dali/pipeline/data/sample_view.h"
 #include "dali/pipeline/data/tensor.h"
 #include "dali/pipeline/data/tensor_list.h"
+#include "dali/pipeline/data/types.h"
 
 
 namespace dali {
@@ -39,12 +43,8 @@ namespace dali {
  * Propagates Buffer calls to every tensor uniformly
  *
  * TODO(klecki): Expected improvements to TensorVector
- * 1. Remove superfluous indirection via shared_ptr to samples.
- * 2. Keep metadata (shape, sample_dim, layout, order) at batch level like we already do with type
- * 3. Detect and convert between contiguous and non-contiguous when possible:
+ * 1. Detect and convert between contiguous and non-contiguous when possible:
  *    a. CopySample of bigger size
- *    b. Resize with coalesce option
- * 4. Contiguity check
  * @tparam Backend
  */
 template <typename Backend>
@@ -86,16 +86,22 @@ class DLL_PUBLIC TensorVector {
    */
   void set_order(AccessOrder order, bool synchronize = true);
 
-  SampleView<Backend> operator[](size_t pos) {
-    return {tensors_[pos]->raw_mutable_data(), tensors_[pos]->shape(), tensors_[pos]->type()};
-  }
+  SampleView<Backend> operator[](size_t pos);
 
-  ConstSampleView<Backend> operator[](size_t pos) const {
-    return {tensors_[pos]->raw_data(), tensors_[pos]->shape(), tensors_[pos]->type()};
-  }
+  ConstSampleView<Backend> operator[](size_t pos) const;
 
   int num_samples() const noexcept {
     return curr_num_tensors_;
+  }
+
+  /**
+   * @brief Number of elements in Tensor List.
+   *
+   * Note: The usage of this member function is intended to be reworked in following updates.
+   * For this purpose the name is distinct so we can easily search and replace.
+   */
+  int64_t _num_elements() const {
+    return shape().num_elements();
   }
 
   void set_sample_dim(int sample_dim);
@@ -120,10 +126,14 @@ class DLL_PUBLIC TensorVector {
    */
   std::vector<size_t> _chunks_capacity() const;
 
-  TensorListShape<> shape() const;
+  const TensorListShape<> &shape() const &;
 
-  const TensorShape<> &tensor_shape(int idx) const {
-    return tensors_[idx]->shape();
+  const TensorShape<> &tensor_shape(int idx) const & {
+    return tensors_[idx].shape();
+  }
+
+  inline span<const int64_t> tensor_shape_span(int idx) const & {
+    return shape_.tensor_shape_span(idx);
   }
 
   /**
@@ -131,7 +141,7 @@ class DLL_PUBLIC TensorVector {
    */
   template <typename T>
   DLL_PUBLIC inline T* mutable_tensor(int idx) {
-    return tensors_[idx]->template mutable_data<T>();
+    return tensors_[idx].template mutable_data<T>();
   }
 
   /**
@@ -139,21 +149,21 @@ class DLL_PUBLIC TensorVector {
    */
   template <typename T>
   DLL_PUBLIC inline const T* tensor(int idx) const {
-    return tensors_[idx]->template data<T>();
+    return tensors_[idx].template data<T>();
   }
 
   /**
    * @brief Returns a raw pointer to the tensor with the given index.
    */
   DLL_PUBLIC inline void* raw_mutable_tensor(int idx) {
-    return tensors_[idx]->raw_mutable_data();
+    return tensors_[idx].raw_mutable_data();
   }
 
   /**
    * @brief Returns a const raw pointer to the tensor with the given index.
    */
   DLL_PUBLIC inline const void* raw_tensor(int idx) const {
-    return  tensors_[idx]->raw_data();
+    return  tensors_[idx].raw_data();
   }
 
   /**
@@ -163,8 +173,8 @@ class DLL_PUBLIC TensorVector {
    * After this operation the TensorVector is converted into non-contiguous.
    *
    * Warning: If the TensorVector was contiguous, the samples that weren't overwritten by this
-   * function would still report that they are sharing data. It is assumed that all samples are
-   * replaced this way - TODO(klecki): this might be adjusted in follow-up.
+   * function would still report that they are sharing data. It is advised that all samples are
+   * replaced this way otherwise the contiguous allocation would be kept alive.
    *
    * @param sample_idx index of sample to be set
    * @param src owner of source sample
@@ -180,8 +190,8 @@ class DLL_PUBLIC TensorVector {
    * After this operation the TensorVector is converted into non-contiguous.
    *
    * Warning: If the TensorVector was contiguous, the samples that weren't overwritten by this
-   * function would still report that they are sharing data. It is assumed that all samples are
-   * replaced this way - TODO(klecki): this might be adjusted in follow-up.
+   * function would still report that they are sharing data. It is advised that all samples are
+   * replaced this way otherwise the contiguous allocation would be kept alive.
    *
    * @param sample_idx index of sample to be set
    * @param src sample owner
@@ -223,6 +233,9 @@ class DLL_PUBLIC TensorVector {
   DLL_PUBLIC void UnsafeCopySample(int sample_idx, const TensorVector<Backend> &src,
                                    int src_sample_idx, AccessOrder order = {});
 
+  DLL_PUBLIC void UnsafeCopySample(int sample_idx, const Tensor<Backend> &src,
+                                   AccessOrder order = {});
+
   DLL_PUBLIC void Resize(const TensorListShape<> &new_shape) {
     DALI_ENFORCE(IsValidType(type()),
                  "TensorVector has no type, 'set_type<T>()' or Resize(shape, type) must be called "
@@ -230,7 +243,25 @@ class DLL_PUBLIC TensorVector {
     return Resize(new_shape, type());
   }
 
-  DLL_PUBLIC void Resize(const TensorListShape<> &new_shape, DALIDataType new_type);
+  /**
+   * @brief Resize the batch to fit the new shape. It is possible to change the type and
+   * dimensionality this way, as well as specify if we want the allocation to happen for individual
+   * samples or contiguous one for all samples. If the currently allocated memory is enough for the
+   * requested shape, no allocation would be made. In non-contiguous mode (or when switching to it),
+   * each sample would be resized individually.
+   *
+   * Resizing samples that are using external backing allocation (sharing data via SetSample)
+   * is not allowed to cause new allocation.
+   * @param new_shape requested shape
+   * @param new_type requested type
+   * @param state Optional change of contiguity mode.
+   *    * Default keeps the current one,
+   *    * Contiguous forces the allocation to be contiguous
+   *    * Noncontiguous - detach all samples, and use them separately, the contiguous buffer
+   *      might still be used as backing storage until new allocations are needed for all samples
+   */
+  DLL_PUBLIC void Resize(const TensorListShape<> &new_shape, DALIDataType new_type,
+                         BatchState state = BatchState::Default);
 
   /**
    * Change the number of tensors that can be accessed as samples without the need to
@@ -326,10 +357,27 @@ class DLL_PUBLIC TensorVector {
   bool IsContiguous() const noexcept;
 
   /**
-   * @brief Set the current state if further calls like Resize() or set_type
-   *        should use TensorList or std::vector<Tensor> as backing memory
+   * @name Configure contiguity of allocations
+   * @{
    */
-  void SetContiguous(bool contiguous);
+  /**
+   * @brief Set the current state for further allocating calls like Resize() or set_type
+   *        to use contiguous or noncontiguous backing memory
+   *        Setting BatchState::Default allows to change it with every call to Resize().
+   */
+  void SetContiguous(BatchState state);
+
+  /**
+   * @brief Convenient overload accepting boolean.
+   *
+   * @param state - pins the state to either Contiguous (true) or Noncontiguous (false)
+   */
+  void SetContiguous(bool state);
+  /** @} */
+
+  void MakeContiguous(std::weak_ptr<void> owner = {});
+
+  void MakeNoncontiguous();
 
   void Reset();
 
@@ -337,15 +385,21 @@ class DLL_PUBLIC TensorVector {
   void Copy(const TensorList<SrcBackend> &in_tl, AccessOrder order = {});
 
   template <typename SrcBackend>
-  void Copy(const TensorVector<SrcBackend> &in_tv, AccessOrder order = {});
+  void Copy(const TensorVector<SrcBackend> &in_tv, AccessOrder order = {},
+            bool use_copy_kernel = false);
 
   void ShareData(const TensorList<Backend> &in_tl);
+
+  DLL_PUBLIC void ShareData(const shared_ptr<void> &ptr, size_t bytes, bool pinned,
+                            const TensorListShape<> &shape, DALIDataType type, int device_id,
+                            AccessOrder order = {}, const TensorLayout &layout = "");
 
   void ShareData(const TensorVector<Backend> &tv);
 
   TensorVector<Backend> &operator=(TensorVector<Backend> &&other) noexcept;
 
-  void UpdateViews();
+  bool has_data() const;
+  bool shares_data() const;
 
   /**
    * @brief Checks whether the batch container is contiguous. It returns true if and only if
@@ -374,18 +428,102 @@ class DLL_PUBLIC TensorVector {
   DLL_PUBLIC Tensor<Backend> AsTensor();
 
  private:
-  enum class State { contiguous, noncontiguous };
+  /**
+   * @brief Tracking the contiguous/noncontiguous state of the batch.
+   * By default we keep what was previously set when resizing and can change it during Resize
+   * unless it is enforced.
+   */
+  class State {
+   public:
+    // TODO(klecki): Any sensible defaults?
+    State() : contiguous_(false), forced_(false) {}
+    State(BatchState state, bool forced) {
+      DALI_ENFORCE(state != BatchState::Default);
+      Setup(state, forced);
+    }
+    State(const State&) = default;
+    State &operator=(const State&) = default;
+
+    /**
+     * @brief Override current state.
+     */
+    void Setup(BatchState state, bool forced = false) {
+      if (forced) {
+        DALI_ENFORCE(state == BatchState::Contiguous || state == BatchState::Noncontiguous,
+                     "Only specific state can be enforced");
+      }
+      if (state != BatchState::Default) {
+        contiguous_ = state == BatchState::Contiguous;
+      }
+      forced_ = forced;
+    }
+
+    /**
+     * @brief Update current state obeying the enforced state.
+     * BatchState::Default is always allowed and does not change the state
+     *
+     * State can be changed unless it is enforced, in that case it will raise an error.
+     *
+     * @return true if the state changed.
+     */
+    bool Update(BatchState requested_state) {
+      if (requested_state == BatchState::Default) {
+        return false;
+      }
+      if (forced_) {
+        DALI_ENFORCE(Get() == requested_state,
+                     make_string("State cannot be changed as it is enforced to ",
+                                 contiguous_ ? "contiguous." : "noncontiguous."));
+      }
+      if (Get() == requested_state) {
+        return false;
+      }
+      contiguous_ = !contiguous_;
+      return true;
+    }
+
+    /**
+     * @brief Returns true if the requested state changes the current state
+     * Validates if the enforced state is not broken
+     */
+    bool IsStateUpdate(BatchState requested_state) {
+      if (requested_state == BatchState::Default) {
+        return false;
+      }
+      if (forced_) {
+        DALI_ENFORCE(requested_state == Get(), "The state is enforced and cannot be changed");
+      }
+      return Get() != requested_state;
+    }
+
+    bool IsContiguous() const {
+      return contiguous_;
+    }
+
+    bool IsForced() const {
+      return forced_;
+    }
+
+    BatchState Get() const {
+      return contiguous_ ? BatchState::Contiguous : BatchState::Noncontiguous;
+    }
+
+   private:
+    bool contiguous_ = false;
+    bool forced_ = false;
+  };
+
 
   // Forward declarations in signature, beware
   friend void MakeSampleView(class SampleWorkspace &sample, class HostWorkspace &batch,
                              int data_idx, int thread_idx);
   friend void FixBatchPropertiesConsistency(class HostWorkspace &ws, bool contiguous);
 
-  auto tensor_handle(size_t pos) {
+  auto& tensor_handle(size_t pos) {
     return tensors_[pos];
   }
 
-  auto tensor_handle(size_t pos) const {
+  auto& tensor_handle(size_t pos) const {
     return tensors_[pos];
   }
 
@@ -396,9 +534,16 @@ class DLL_PUBLIC TensorVector {
     set_type(other.type());
     set_sample_dim(other.shape().sample_dim());
     SetLayout(other.GetLayout());
-    set_order(other.order());
     set_pinned(other.is_pinned());
+    set_order(other.order());
+    set_device_id(other.device_id());
   }
+
+  /**
+   * @brief Internal change of contiguity. Unconditionally make the batch non-contiguous.
+   * Assumes that the state_ will be adjusted separately
+   */
+  void DoMakeNoncontiguous();
 
   /**
    * @brief After RunImpl(SampleWorkspace&) operated on individual samples without propagating
@@ -410,20 +555,57 @@ class DLL_PUBLIC TensorVector {
    */
   void UpdatePropertiesFromSamples(bool contiguous);
 
-  bool has_data() const;
-
   void resize_tensors(int size);
 
-  void update_view(int idx);
+  void recreate_views();
 
-  std::vector<std::shared_ptr<Tensor<Backend>>> tensors_;
+  /**
+   * @brief Check if the metadata provided for new sample match the ones currently set for the batch
+   *
+   * When setting new sample, the source shape doesn't matter as it is adjusted for individual
+   * sample.
+   *
+   * When setting new sample the `shape_` must be adjusted.
+   *
+   * @param error_suffix Additional description added to the error message
+   */
+  void VerifySampleShareConformance(DALIDataType type, int sample_dim, TensorLayout layout,
+                                    bool pinned, AccessOrder order, int device_id,
+                                    const std::string &error_suffix = ".");
+
+  /**
+   * @brief Check if the metadata provided for new sample match the ones currently set for the batch
+   *
+   * When copying new sample, pinned status and order of source and destination buffer can be
+   * different. Necessary synchronization is handled by the copy itself.
+   *
+   * When copying new sample the `shape_` must be adjusted.
+   *
+   * @param error_suffix Additional description added to the error message
+   */
+  void VerifySampleCopyConformance(DALIDataType type, int sample_dim, TensorLayout layout,
+                                   const TensorShape<> &current_shape,
+                                   const TensorShape<> &new_shape,
+                                   const std::string &error_suffix = ".");
+
+  // Memory backing
+  Buffer<Backend> contiguous_buffer_;
+  std::weak_ptr<void> buffer_bkp_;
+  // Memory, sample aliases and metadata
+  // TODO(klecki): Remove SampleWorkspace and swap to plain Buffer instead of using actual Tensors.
+  std::vector<Tensor<Backend>> tensors_;
+
+  // State and metadata that should be uniform regardless of the contiguity state.
+  // Sample aliases should match the information stored below.
+  State state_;
   int curr_num_tensors_;
-  std::shared_ptr<TensorList<Backend>> tl_;
-  State state_ = State::noncontiguous;
-  // pinned status and type info should be uniform
-  bool pinned_ = true;
   TypeInfo type_{};
   int sample_dim_ = -1;
+  TensorListShape<> shape_;
+  TensorLayout layout_;
+
+  bool pinned_ = true;
+  int device_ = CPU_ONLY_DEVICE_ID;
   AccessOrder order_;
 
   // So we can access the members of other TensorVectors
@@ -437,25 +619,23 @@ class DLL_PUBLIC TensorVector {
    * for pipeline outputs).
    * @{
    */
-
   /**
    * @brief Return an un-typed pointer to the underlying storage.
-   * The TensorVector must be either empty or have a valid type and be contiguous.
+   * The TensorList must be either empty or have a valid type and be contiguous.
    */
-  friend void *unsafe_raw_mutable_data(TensorVector<Backend> &tv) {
-    DALI_ENFORCE(tv.IsContiguous(), "Data pointer can be obtain only for contiguous TensorVector.");
-    return unsafe_raw_mutable_data(*tv.tl_);
+  friend void *unsafe_raw_mutable_data(TensorVector<Backend> &batch) {
+    DALI_ENFORCE(batch.IsContiguous(), "Data pointer can be obtain only for contiguous batch.");
+    return batch.contiguous_buffer_.raw_mutable_data();
   }
 
   /**
    * @brief Return an un-typed const pointer to the underlying storage.
    * The TensorVector must be either empty or have a valid type and be contiguous.
    */
-  friend const void *unsafe_raw_data(const TensorVector<Backend> &tv) {
-    DALI_ENFORCE(tv.IsContiguous(), "Data pointer can be obtain only for contiguous TensorVector.");
-    return unsafe_raw_data(*tv.tl_);
+  friend const void *unsafe_raw_data(const TensorVector<Backend> &batch) {
+    DALI_ENFORCE(batch.IsContiguous(), "Data pointer can be obtain only for contiguous batch.");
+    return batch.contiguous_buffer_.raw_data();
   }
-
 
   /**
    * @brief Return the shared pointer, that we can use to correctly share the ownership of sample
@@ -466,9 +646,9 @@ class DLL_PUBLIC TensorVector {
     // create new aliasing pointer to current data allocation, so we share the use count
     // and the deleter correctly.
     if (batch.IsContiguous()) {
-      return {unsafe_sample_owner(*batch.tl_, 0), batch.raw_mutable_tensor(sample_idx)};
+      return {batch.contiguous_buffer_.get_data_ptr(), batch.raw_mutable_tensor(sample_idx)};
     } else {
-      return batch.tensors_[sample_idx]->get_data_ptr();
+      return batch.tensors_[sample_idx].get_data_ptr();
     }
   }
 
@@ -481,7 +661,7 @@ class DLL_PUBLIC TensorVector {
   friend shared_ptr<void> unsafe_owner(TensorVector<Backend> &batch) {
     DALI_ENFORCE(batch.IsContiguous(),
                  "Data owner pointer can be obtain only for contiguous TensorVector.");
-    return unsafe_owner(*batch.tl_);
+    return batch.contiguous_buffer_.get_data_ptr();
   }
 
   /** @} */  // end of AccessorFunctions

--- a/dali/pipeline/data/tensor_vector.h
+++ b/dali/pipeline/data/tensor_vector.h
@@ -669,8 +669,22 @@ class DLL_PUBLIC TensorVector {
    */
   void UpdatePropertiesFromSamples(bool contiguous);
 
+  /**
+   * @brief Adjust the tensors_ member size, so they can be used with setters for individual
+   * tensors. Bring them back to scope while preserving the allocation (if possible) in a manner
+   * that is compatible with the current batch state (like type and dimensionality).
+   */
   void resize_tensors(int size);
 
+  /**
+   * @brief When bringing the tensors_ back to scope, fill it with correct allocation metadata
+   */
+  void setup_tensor_allocation(int index);
+
+  /**
+   * @brief When using one contiguous allocation, rebuild the view Tensors (sharing part of the
+   * contiguous buffer) that represent samples.
+   */
   void recreate_views();
 
   /**

--- a/dali/pipeline/data/tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_vector_test.cc
@@ -130,6 +130,63 @@ TYPED_TEST(TensorVectorSuite, SetupAndSetSizeNoncontiguous) {
   EXPECT_THROW(tv.Resize(uniform_list_shape(3, {10, 12, 3})), std::runtime_error);
 }
 
+TYPED_TEST(TensorVectorSuite, ResizeWithRecreate) {
+  // Check if the tensors that get back to the scope are correctly typed
+  for (auto contiguity : {BatchContiguity::Contiguous, BatchContiguity::Noncontiguous}) {
+    TensorVector<TypeParam> tv;
+    tv.SetContiguity(contiguity);
+    tv.set_pinned(true);
+    auto shape0 = TensorListShape<>({{1, 2, 3}, {2, 3, 4}, {3, 4, 5}});
+    tv.Resize(shape0, DALI_UINT8);
+    EXPECT_EQ(tv.shape().num_samples(), 3);
+    for (int i = 0; i < 3; i++) {
+      EXPECT_EQ(tv[i].type(), DALI_UINT8);
+      EXPECT_EQ(tv[i].shape(), shape0[i]);
+    }
+
+    auto shape1 = TensorListShape<>({{1, 2}, {3, 4}});
+    tv.Resize(shape1, DALI_FLOAT);
+    EXPECT_EQ(tv.shape().num_samples(), 2);
+    for (int i = 0; i < 2; i++) {
+      EXPECT_EQ(tv[i].type(), DALI_FLOAT);
+      EXPECT_EQ(tv[i].shape(), shape1[i]);
+    }
+
+    auto shape2 = TensorListShape<>({{2, 3}, {4, 5}, {5, 6}, {6, 7}, {7, 8}});
+    tv.Resize(shape2, DALI_FLOAT64);
+    EXPECT_EQ(tv.shape().num_samples(), 5);
+    for (int i = 0; i < 5; i++) {
+      EXPECT_EQ(tv[i].type(), DALI_FLOAT64);
+      EXPECT_EQ(tv[i].shape(), shape2[i]);
+    }
+
+    auto shape3 = TensorListShape<>({{2, 3}, {4, 5}, {5, 6}});
+    tv.SetSize(3);
+    EXPECT_EQ(tv.shape().num_samples(), 3);
+    for (int i = 0; i < 3; i++) {
+      EXPECT_EQ(tv[i].type(), DALI_FLOAT64);
+      EXPECT_EQ(tv[i].shape(), shape3[i]);
+    }
+
+    auto shape4 = TensorListShape<>({{1, 2, 3}, {2, 3, 4}, {3, 4, 5}});
+    tv.Resize(shape4, DALI_UINT8);
+    EXPECT_EQ(tv.shape().num_samples(), 3);
+    for (int i = 0; i < 3; i++) {
+      EXPECT_EQ(tv[i].type(), DALI_UINT8);
+      EXPECT_EQ(tv[i].shape(), shape4[i]);
+    }
+
+    auto shape5 =
+        TensorListShape<>({{1, 2, 3}, {2, 3, 4}, {3, 4, 5}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}});
+    tv.SetSize(6);
+    EXPECT_EQ(tv.shape().num_samples(), 6);
+    for (int i = 0; i < 6; i++) {
+      EXPECT_EQ(tv[i].type(), DALI_UINT8);
+      EXPECT_EQ(tv[i].shape(), shape5[i]);
+    }
+  }
+}
+
 
 TYPED_TEST(TensorVectorSuite, SetupLikeMultiGPU) {
   int ndev = 0;

--- a/dali/pipeline/data/tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_vector_test.cc
@@ -13,13 +13,22 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <numeric>
+#include <sstream>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 #include "dali/core/access_order.h"
+#include "dali/core/common.h"
 #include "dali/core/format.h"
+#include "dali/core/tensor_layout.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/pipeline/data/backend.h"
+#include "dali/pipeline/data/buffer.h"
+#include "dali/pipeline/data/sample_view.h"
+#include "dali/pipeline/data/tensor_list.h"
 #include "dali/pipeline/data/tensor_vector.h"
 #include "dali/pipeline/data/types.h"
 #include "dali/pipeline/data/views.h"
@@ -27,8 +36,6 @@
 
 namespace dali {
 namespace test {
-
-
 
 template <typename T>
 class TensorVectorSuite : public ::testing::Test {
@@ -51,6 +58,633 @@ typedef ::testing::Types<CPUBackend, GPUBackend> Backends;
 constexpr cudaStream_t cuda_stream = 0;
 
 TYPED_TEST_SUITE(TensorVectorSuite, Backends);
+
+TYPED_TEST(TensorVectorSuite, SetupAndSetSizeNoncontiguous) {
+  constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
+  const auto order = is_device ? AccessOrder(cuda_stream) : AccessOrder::host();
+  TensorVector<TypeParam> tv;
+  tv.set_pinned(false);
+  tv.set_order(order);
+  tv.set_sample_dim(2);
+  tv.SetLayout("XY");
+  tv.SetContiguous(BatchState::Noncontiguous);
+  tv.SetSize(3);
+
+
+  auto empty_2d = TensorShape<>{0, 0};
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), empty_2d);
+    EXPECT_EQ(tv[i].type(), DALI_NO_TYPE);
+  }
+
+  // Setting just the type
+  tv.set_type(DALI_INT32);
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), empty_2d);
+    EXPECT_EQ(tv[i].type(), DALI_INT32);
+  }
+
+  Tensor<TypeParam> t;
+  t.set_pinned(false);
+  t.Resize({2, 3}, DALI_INT32);
+  t.SetLayout("XY");
+
+  // We need to propagate device id and order
+  tv.set_device_id(t.device_id());
+  tv.set_order(t.order());
+
+  for (int i = 0; i < 3; i++) {
+    tv.UnsafeSetSample(i, t);
+    EXPECT_EQ(tv[i].raw_data(), t.raw_data());
+    EXPECT_EQ(tv[i].shape(), t.shape());
+    EXPECT_EQ(tv[i].type(), t.type());
+  }
+
+  tv.SetSize(4);
+  // New one should be empty
+  EXPECT_EQ(tv[3].raw_data(), nullptr);
+  EXPECT_EQ(tv[3].shape(), empty_2d);
+  EXPECT_EQ(tv[3].type(), DALI_INT32);
+
+  tv.SetSize(2);
+  tv.SetSize(3);
+  for (int i = 0; i < 2; i++) {
+    EXPECT_EQ(tv[i].raw_data(), t.raw_data());
+    EXPECT_EQ(tv[i].shape(), t.shape());
+    EXPECT_EQ(tv[i].type(), t.type());
+  }
+
+  // As we were sharing, the share is removed and no allocation should happen
+  for (int i = 2; i < 3; i++) {
+    EXPECT_EQ(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), empty_2d);
+    EXPECT_EQ(tv[i].type(), DALI_INT32);
+  }
+
+  // There should be no access to the out of bounds one
+  EXPECT_THROW(tv[3], std::runtime_error);
+
+  // We are sharing, no way to make it bigger
+  EXPECT_THROW(tv.Resize(uniform_list_shape(3, {10, 12, 3})), std::runtime_error);
+}
+
+
+TYPED_TEST(TensorVectorSuite, SetupLikeMultiGPU) {
+  int ndev = 0;
+  CUDA_CALL(cudaGetDeviceCount(&ndev));
+  if (ndev < 2)
+    GTEST_SKIP() << "This test requires at least 2 CUDA devices";
+  constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
+  constexpr int device = 1;
+  const auto order = is_device ? AccessOrder(cuda_stream, device) : AccessOrder::host();
+  Tensor<TypeParam> t;
+  t.set_device_id(device);
+  t.set_order(order);
+  t.set_pinned(true);
+  t.Resize({3, 4, 5}, DALI_INT32);
+  t.SetLayout("HWC");
+
+  TensorVector<TypeParam> tv_like_t;
+  tv_like_t.SetupLike(t);
+
+  EXPECT_EQ(t.device_id(), tv_like_t.device_id());
+  EXPECT_EQ(t.order(), tv_like_t.order());
+  EXPECT_EQ(t.is_pinned(), tv_like_t.is_pinned());
+  EXPECT_EQ(t.shape().sample_dim(), tv_like_t.sample_dim());
+  EXPECT_EQ(t.GetLayout(), tv_like_t.GetLayout());
+
+  TensorVector<TypeParam> tv_like_tv;
+  tv_like_tv.SetupLike(tv_like_t);
+
+  EXPECT_EQ(tv_like_t.device_id(), tv_like_tv.device_id());
+  EXPECT_EQ(tv_like_t.order(), tv_like_tv.order());
+  EXPECT_EQ(tv_like_t.is_pinned(), tv_like_tv.is_pinned());
+  EXPECT_EQ(tv_like_t.sample_dim(), tv_like_tv.sample_dim());
+  EXPECT_EQ(tv_like_t.GetLayout(), tv_like_tv.GetLayout());
+}
+
+template <typename Backend>
+std::vector<std::pair<std::string, std::function<void(TensorVector<Backend> &)>>>
+SetRequiredSetters(int sample_dim, DALIDataType type, TensorLayout layout, bool pinned,
+                   int device_id) {
+  return {
+    {"sample dim", [sample_dim](TensorVector<Backend> &t) {
+      t.set_sample_dim(sample_dim);
+    }},
+    {"type", [type](TensorVector<Backend> &t) {
+      t.set_type(type);
+    }},
+    {"layout", [layout](TensorVector<Backend> &t) {
+      t.SetLayout(layout);
+    }},
+    {"device id", [device_id](TensorVector<Backend> &t) {
+      t.set_device_id(device_id);
+    }},
+    {"pinned", [pinned](TensorVector<Backend> &t) {
+      t.set_pinned(pinned);
+    }},
+    {"order", [device_id](TensorVector<Backend> &t) {
+      constexpr bool is_device = std::is_same_v<Backend, GPUBackend>;
+      const auto order = is_device ? AccessOrder(cuda_stream, device_id) : AccessOrder::host();
+      t.set_order(order);
+    }},
+  };
+}
+
+TYPED_TEST(TensorVectorSuite, PartialSetupSetMultiGPU) {
+  int ndev = 0;
+  CUDA_CALL(cudaGetDeviceCount(&ndev));
+  if (ndev < 2)
+    GTEST_SKIP() << "This test requires at least 2 CUDA devices";
+  constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
+  constexpr int device = 1;
+  const auto order = is_device ? AccessOrder(cuda_stream, device) : AccessOrder::host();
+  Tensor<TypeParam> t;
+  t.set_device_id(device);
+  t.set_order(order);
+  t.set_pinned(true);
+  t.Resize({3, 4, 5}, DALI_INT32);
+  t.SetLayout("HWC");
+
+  // set size to be checked. Copy doesn't make sense
+  auto setups = SetRequiredSetters<TypeParam>(3, DALI_INT32, "HWC", true, device);
+  for (size_t excluded = 0; excluded < setups.size(); excluded++) {
+    std::vector<size_t> idxs(setups.size());
+    std::iota(idxs.begin(), idxs.end(), 0);
+    do {
+      TensorVector<TypeParam> tv;
+      tv.SetContiguous(BatchState::Noncontiguous);
+      tv.SetSize(4);
+      tv.set_pinned(false);
+      for (auto idx : idxs) {
+        if (idx == excluded) {
+          continue;
+        }
+        setups[idx].second(tv);
+      }
+      try {
+        tv.UnsafeSetSample(0, t);
+        FAIL() << "Exception was expected with excluded: " << setups[excluded].first;
+      } catch(std::runtime_error &e) {
+        auto expected = "Sample must have the same " + setups[excluded].first;
+        EXPECT_NE(std::string(e.what()).rfind(expected), std::string::npos)
+            << expected << "\n====\nvs\n====\n"
+            << e.what();
+      } catch (...) {
+        FAIL() << "Unexpected exception";
+      }
+    } while (std::next_permutation(idxs.begin(), idxs.end()));
+  }
+}
+
+
+template <typename Backend>
+std::vector<std::pair<std::string, std::function<void(TensorVector<Backend> &)>>>
+CopyRequiredSetters(int sample_dim, DALIDataType type, TensorLayout layout) {
+  return {
+    {"sample dim", [sample_dim](TensorVector<Backend> &t) {
+      t.set_sample_dim(sample_dim);
+    }},
+    {"type", [type](TensorVector<Backend> &t) {
+      t.set_type(type);
+    }},
+    {"layout", [layout](TensorVector<Backend> &t) {
+      t.SetLayout(layout);
+    }}
+  };
+}
+
+
+TYPED_TEST(TensorVectorSuite, PartialSetupCopyMultiGPU) {
+  int ndev = 0;
+  CUDA_CALL(cudaGetDeviceCount(&ndev));
+  if (ndev < 2)
+    GTEST_SKIP() << "This test requires at least 2 CUDA devices";
+  constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
+  constexpr int device = 1;
+  const auto order = is_device ? AccessOrder(cuda_stream, device) : AccessOrder::host();
+  Tensor<TypeParam> t;
+  t.set_device_id(device);
+  t.set_order(order);
+  t.set_pinned(true);
+  t.Resize({3, 4, 5}, DALI_INT32);
+  t.SetLayout("HWC");
+
+  // set size to be checked. Copy doesn't make sense
+  auto setups = CopyRequiredSetters<TypeParam>(3, DALI_INT32, "HWC");
+  for (size_t excluded = 0; excluded < setups.size(); excluded++) {
+    std::vector<size_t> idxs(setups.size());
+    std::iota(idxs.begin(), idxs.end(), 0);
+    do {
+      TensorVector<TypeParam> tv;
+      tv.SetContiguous(BatchState::Noncontiguous);
+      tv.SetSize(4);
+      for (auto idx : idxs) {
+        if (idx == excluded) {
+          continue;
+        }
+        setups[idx].second(tv);
+      }
+      try {
+        tv.UnsafeCopySample(0, t);
+        FAIL() << "Exception was expected with excluded: " << setups[excluded].first;
+      } catch(std::runtime_error &e) {
+        auto expected = "Sample must have the same " + setups[excluded].first;
+        EXPECT_NE(std::string(e.what()).rfind(expected), std::string::npos)
+            << expected << "\n====\nvs\n====\n"
+            << e.what();
+      } catch (...) {
+        FAIL() << "Unexpected exception";
+      }
+    } while (std::next_permutation(idxs.begin(), idxs.end()));
+  }
+}
+
+
+TYPED_TEST(TensorVectorSuite, FullSetupSetMultiGPU) {
+  int ndev = 0;
+  CUDA_CALL(cudaGetDeviceCount(&ndev));
+  if (ndev < 2)
+    GTEST_SKIP() << "This test requires at least 2 CUDA devices";
+  constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
+  constexpr int device = 1;
+  const auto order = is_device ? AccessOrder(cuda_stream, device) : AccessOrder::host();
+  Tensor<TypeParam> t;
+  t.set_device_id(device);
+  t.set_order(order);
+  t.set_pinned(true);
+  t.Resize({3, 4, 5}, DALI_INT32);
+  t.SetLayout("HWC");
+
+  // set size to be checked. Copy doesn't make sense
+  auto setups = SetRequiredSetters<TypeParam>(3, DALI_INT32, "HWC", true, device);
+  std::vector<size_t> idxs(setups.size());
+  std::iota(idxs.begin(), idxs.end(), 0);
+  do {
+    TensorVector<TypeParam> tv;
+    tv.SetContiguous(BatchState::Noncontiguous);
+    tv.SetSize(4);
+    for (auto idx : idxs) {
+      setups[idx].second(tv);
+    }
+    tv.UnsafeSetSample(0, t);
+    EXPECT_EQ(tv[0].raw_data(), t.raw_data());
+  } while (std::next_permutation(idxs.begin(), idxs.end()));
+}
+
+
+namespace {
+
+void FillWithNumber(TensorVector<CPUBackend> &tv, uint8_t number) {
+  for (int i = 0; i < tv.shape().num_elements(); i++) {
+    // We utilize the contiguity of the TensorVector
+    tv.mutable_tensor<uint8_t>(0)[i] = number;
+  }
+}
+
+template <typename T>
+void FillWithNumber(SampleView<CPUBackend> sample, T number) {
+  for (int i = 0; i < sample.shape().num_elements(); i++) {
+    // We utilize the contiguity of the TensorVector
+    sample.mutable_data<T>()[i] = number;
+  }
+}
+
+void FillWithNumber(TensorVector<GPUBackend> &tv, uint8_t number) {
+  // We utilize the contiguity of the TensorVector
+  cudaMemset(tv.mutable_tensor<uint8_t>(0), number, tv.shape().num_elements());
+}
+
+template <typename T>
+void FillWithNumber(SampleView<GPUBackend> sample, T number) {
+  std::vector<T> buffer(sample.shape().num_elements(), number);
+  cudaMemcpy(sample.mutable_data<T>(), buffer.data(), sample.shape().num_elements() * sizeof(T),
+             cudaMemcpyHostToDevice);
+}
+
+
+void CompareWithNumber(Tensor<CPUBackend> &t, uint8_t number) {
+  for (int i = 0; i < t.shape().num_elements(); i++) {
+    EXPECT_EQ(t.data<uint8_t>()[i], number);
+  }
+}
+
+template <typename T>
+void CompareWithNumber(ConstSampleView<CPUBackend> t, T number) {
+  for (int i = 0; i < t.shape().num_elements(); i++) {
+    EXPECT_EQ(t.data<T>()[i], number);
+  }
+}
+
+
+void CompareWithNumber(Tensor<GPUBackend> &t, uint8_t number) {
+  std::vector<uint8_t> buffer(t.shape().num_elements());
+  cudaMemcpy(buffer.data(), t.data<uint8_t>(), t.shape().num_elements(), cudaMemcpyDeviceToHost);
+  for (auto b : buffer) {
+    EXPECT_EQ(b, number);
+  }
+}
+
+template <typename T>
+void CompareWithNumber(ConstSampleView<GPUBackend> sample, T number) {
+  std::vector<T> buffer(sample.shape().num_elements());
+  cudaMemcpy(buffer.data(), sample.data<T>(), sample.shape().num_elements() * sizeof(T),
+             cudaMemcpyDeviceToHost);
+  for (auto b : buffer) {
+    EXPECT_EQ(b, number);
+  }
+}
+
+template <typename Backend>
+Tensor<Backend> ReturnTvAsTensor(uint8_t number) {
+  TensorVector<Backend> tv;
+  tv.SetContiguous(true);
+  tv.Resize(uniform_list_shape(4, {1, 2, 3}), DALI_UINT8);
+  tv.SetLayout("HWC");
+  FillWithNumber(tv, number);
+  return tv.AsTensor();
+}
+
+}  // namespace
+
+TYPED_TEST(TensorVectorSuite, ResizeSetSize) {
+  constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
+  const auto order = is_device ? AccessOrder(cuda_stream) : AccessOrder::host();
+  TensorVector<TypeParam> tv;
+  tv.set_pinned(false);
+  tv.set_order(order);
+  tv.set_sample_dim(2);
+  tv.SetLayout("XY");
+  tv.SetContiguous(BatchState::Contiguous);
+  tv.SetSize(3);
+
+
+  auto empty_2d = TensorShape<>{0, 0};
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), empty_2d);
+    EXPECT_EQ(tv[i].type(), DALI_NO_TYPE);
+  }
+
+  // Setting just the type
+  tv.set_type(DALI_INT32);
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), empty_2d);
+    EXPECT_EQ(tv[i].type(), DALI_INT32);
+  }
+  auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
+  tv.Resize(new_shape);
+  tv.SetLayout("HWC");
+
+  const auto *base = static_cast<const uint8_t*>(unsafe_sample_owner(tv, 0).get());
+
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(tv[i].raw_data(), base);
+    EXPECT_EQ(tv[i].shape(), new_shape[i]);
+    EXPECT_EQ(tv[i].type(), DALI_INT32);
+    base += sizeof(int32_t) * new_shape[i].num_elements();
+  }
+
+  tv.SetSize(4);
+  EXPECT_TRUE(tv.IsContiguous());
+
+  auto empty_3d = TensorShape<>{0, 0, 0};
+
+  // New one should be empty
+  EXPECT_EQ(tv[3].raw_data(), nullptr);
+  EXPECT_EQ(tv[3].shape(), empty_3d);
+  EXPECT_EQ(tv[3].type(), DALI_INT32);
+
+  tv.SetSize(2);
+  tv.SetSize(3);
+  EXPECT_TRUE(tv.IsContiguous());
+
+  base = static_cast<const uint8_t*>(unsafe_sample_owner(tv, 0).get());
+
+  for (int i = 0; i < 2; i++) {
+    EXPECT_EQ(tv[i].raw_data(), base);
+    EXPECT_EQ(tv[i].shape(), new_shape[i]);
+    EXPECT_EQ(tv[i].type(), DALI_INT32);
+    base += sizeof(int32_t) * new_shape[i].num_elements();
+  }
+
+  // As we are contiguous, thus we are sharing the contiguous buffer via every sample,
+  // the share is removed and no allocation should happen when we made the size bigger
+  for (int i = 2; i < 3; i++) {
+    EXPECT_EQ(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), empty_3d);
+    EXPECT_EQ(tv[i].type(), DALI_INT32);
+  }
+}
+
+
+TYPED_TEST(TensorVectorSuite, NoForcedChangeContiguousToNoncontiguous) {
+  constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
+  TensorVector<TypeParam> tv;
+  tv.SetContiguous(BatchState::Contiguous);
+  auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
+  EXPECT_THROW(tv.Resize(new_shape, DALI_FLOAT, BatchState::Noncontiguous), std::runtime_error);
+}
+
+TYPED_TEST(TensorVectorSuite, NoForcedChangeNoncontiguousToContiguous) {
+  constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
+  TensorVector<TypeParam> tv;
+  tv.SetContiguous(BatchState::Noncontiguous);
+  auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
+  EXPECT_THROW(tv.Resize(new_shape, DALI_FLOAT, BatchState::Contiguous), std::runtime_error);
+}
+
+
+TYPED_TEST(TensorVectorSuite, ContiguousResize) {
+  constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
+  const auto order = is_device ? AccessOrder(cuda_stream) : AccessOrder::host();
+  TensorVector<TypeParam> tv;
+  tv.set_order(order);
+  tv.SetContiguous(BatchState::Contiguous);
+  auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
+  tv.Resize(new_shape, DALI_FLOAT);
+  EXPECT_TRUE(tv.IsContiguous());
+
+  for (int i = 0; i < 3; i++) {
+    FillWithNumber(tv[i], 1 + i * 1.f);
+  }
+
+  for (int i = 0; i < 3; i++) {
+    tv.UnsafeCopySample(i, tv, i);
+  }
+
+  const auto *base = static_cast<const uint8_t*>(unsafe_sample_owner(tv, 0).get());
+
+  EXPECT_TRUE(tv.IsContiguous());
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(tv[i].raw_data(), base);
+    EXPECT_EQ(tv[i].shape(), new_shape[i]);
+    EXPECT_EQ(tv[i].type(), DALI_FLOAT);
+    base += sizeof(float) * new_shape[i].num_elements();
+    CompareWithNumber(tv[i], 1 + i * 1.f);
+  }
+
+  // Cannot copy without exact shape match when contiguous
+  EXPECT_THROW(tv.UnsafeCopySample(0, tv, 1), std::runtime_error);
+  EXPECT_THROW(tv.UnsafeCopySample(2, tv, 1), std::runtime_error);
+}
+
+
+TYPED_TEST(TensorVectorSuite, NoncontiguousResize) {
+  constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
+  const auto order = is_device ? AccessOrder(cuda_stream) : AccessOrder::host();
+  TensorVector<TypeParam> tv;
+  tv.set_order(order);
+  tv.SetContiguous(BatchState::Noncontiguous);
+  auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
+  tv.Resize(new_shape, DALI_FLOAT);
+  EXPECT_FALSE(tv.IsContiguous());
+
+  for (int i = 0; i < 3; i++) {
+    FillWithNumber(tv[i], 1 + i * 1.f);
+  }
+
+  for (int i = 0; i < 3; i++) {
+    EXPECT_NE(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), new_shape[i]);
+    EXPECT_EQ(tv[i].type(), DALI_FLOAT);
+    CompareWithNumber(tv[i], 1 + i * 1.f);
+  }
+
+  // Cannot copy without exact shape match when contiguous
+  tv.UnsafeCopySample(0, tv, 1);
+  tv.UnsafeCopySample(2, tv, 1);
+
+  EXPECT_FALSE(tv.IsContiguous());
+  for (int i = 0; i < 3; i++) {
+    EXPECT_NE(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), new_shape[1]);
+    EXPECT_EQ(tv[i].type(), DALI_FLOAT);
+    CompareWithNumber(tv[i], 2.f);
+  }
+}
+
+
+TYPED_TEST(TensorVectorSuite, BreakContiguity) {
+  TensorVector<TypeParam> tv;
+  // anything goes
+  tv.SetContiguous(BatchState::Default);
+
+  auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
+  tv.Resize(new_shape, DALI_FLOAT, BatchState::Contiguous);
+  EXPECT_TRUE(tv.IsContiguous());
+
+  for (int i = 0; i < 3; i++) {
+    FillWithNumber(tv[i], 1 + i * 1.f);
+  }
+
+  for (int i = 0; i < 3; i++) {
+    EXPECT_NE(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), new_shape[i]);
+    EXPECT_EQ(tv[i].type(), DALI_FLOAT);
+    CompareWithNumber(tv[i], 1 + i * 1.f);
+  }
+
+  Tensor<TypeParam> t;
+  t.Resize({2, 3, 4}, DALI_FLOAT);
+  SampleView<TypeParam> v{t.template mutable_data<float>(), t.shape(), DALI_FLOAT};
+  FillWithNumber(v, 42.f);
+
+  tv.UnsafeSetSample(1, t);
+  EXPECT_FALSE(tv.IsContiguous());
+
+  EXPECT_NE(tv[1].raw_data(), nullptr);
+  EXPECT_EQ(tv[1].shape(), t.shape());
+  EXPECT_EQ(tv[1].type(), DALI_FLOAT);
+  CompareWithNumber(tv[1], 42.f);
+}
+
+
+TYPED_TEST(TensorVectorSuite, CoalescingAllocation) {
+  TensorVector<TypeParam> tv;
+  // anything goes
+  tv.SetContiguous(BatchState::Default);
+
+  auto first_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
+  tv.Resize(first_shape, DALI_FLOAT, BatchState::Noncontiguous);
+  EXPECT_FALSE(tv.IsContiguous());
+
+  for (int i = 0; i < 3; i++) {
+    EXPECT_NE(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), first_shape[i]);
+    EXPECT_EQ(tv[i].type(), DALI_FLOAT);
+  }
+
+  auto smaller_shape = TensorListShape<>{{1, 2, 1}, {1, 3, 1}, {3, 4, 1}};
+  tv.Resize(smaller_shape, DALI_FLOAT, BatchState::Noncontiguous);
+  EXPECT_FALSE(tv.IsContiguous());
+
+  for (int i = 0; i < 3; i++) {
+    EXPECT_NE(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), smaller_shape[i]);
+    EXPECT_EQ(tv[i].type(), DALI_FLOAT);
+  }
+
+  // Second and third sample are significantly bigger, reallocate and coalesce
+  auto bigger_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 40}, {3, 4, 50}};
+  tv.Resize(bigger_shape, DALI_FLOAT);
+  EXPECT_TRUE(tv.IsContiguous());
+
+  for (int i = 0; i < 3; i++) {
+    EXPECT_NE(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), bigger_shape[i]);
+    EXPECT_EQ(tv[i].type(), DALI_FLOAT);
+  }
+
+  // Go back
+  tv.Resize(bigger_shape, DALI_FLOAT, BatchState::Noncontiguous);
+  EXPECT_FALSE(tv.IsContiguous());
+
+  for (int i = 0; i < 3; i++) {
+    EXPECT_NE(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), bigger_shape[i]);
+    EXPECT_EQ(tv[i].type(), DALI_FLOAT);
+  }
+
+  // Go back again
+  tv.Resize(bigger_shape, DALI_FLOAT, BatchState::Contiguous);
+  EXPECT_TRUE(tv.IsContiguous());
+
+  for (int i = 0; i < 3; i++) {
+    EXPECT_NE(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), bigger_shape[i]);
+    EXPECT_EQ(tv[i].type(), DALI_FLOAT);
+  }
+
+  // Just stay
+  tv.Resize(bigger_shape, DALI_FLOAT);
+  EXPECT_TRUE(tv.IsContiguous());
+}
+
+
+TYPED_TEST(TensorVectorSuite, Reserve) {
+  // Verify that we still keep the memory reserved in sample mode
+  TensorVector<TypeParam> tv;
+  tv.SetContiguous(BatchState::Default);
+  tv.reserve(100, 4);
+
+  auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 50}};
+  tv.Resize(new_shape, DALI_FLOAT, BatchState::Noncontiguous);
+
+  EXPECT_FALSE(tv.IsContiguous());
+
+  tv.SetSize(4);
+  auto capacity = tv._chunks_capacity();
+
+  for (int i = 0; i < 4; i++) {
+    auto expected_capacity =
+        std::max<int>(100, i < 3 ? sizeof(float) * new_shape[i].num_elements() : 0);
+    EXPECT_EQ(capacity[i], expected_capacity);
+  }
+}
 
 // Check if interleaving any of
 // * set_pinned
@@ -123,54 +757,11 @@ TYPED_TEST(TensorVectorSuite, PinnedBeforeResizeNoncontiguous) {
   }
 }
 
-namespace {
-
-const uint8_t kMagicNumber = 42;
-
-void FillWithMagicNumber(TensorVector<CPUBackend> &tv) {
-  for (int i = 0; i < tv.shape().num_elements(); i++) {
-    // We utilize the contiguity of the TensorVector
-    tv.mutable_tensor<uint8_t>(0)[i] = kMagicNumber;
-  }
-}
-
-void FillWithMagicNumber(TensorVector<GPUBackend> &tv) {
-  // We utilize the contiguity of the TensorVector
-  cudaMemset(tv.mutable_tensor<uint8_t>(0), kMagicNumber, tv.shape().num_elements());
-}
-
-
-void CompareWithMagicNumber(Tensor<CPUBackend> &t) {
-  for (int i = 0; i < t.shape().num_elements(); i++) {
-    EXPECT_EQ(t.data<uint8_t>()[i], kMagicNumber);
-  }
-}
-
-void CompareWithMagicNumber(Tensor<GPUBackend> &t) {
-  uint8_t *ptr;
-  std::vector<uint8_t> buffer(t.shape().num_elements());
-  cudaMemcpy(buffer.data(), t.data<uint8_t>(), t.shape().num_elements(), cudaMemcpyDeviceToHost);
-  for (auto b : buffer) {
-    EXPECT_EQ(b, kMagicNumber);
-  }
-}
-
-
-template <typename Backend>
-Tensor<Backend> ReturnTvAsTensor() {
-  TensorVector<Backend> tv;
-  tv.SetContiguous(true);
-  tv.Resize(uniform_list_shape(4, {1, 2, 3}), DALI_UINT8);
-  tv.SetLayout("HWC");
-  FillWithMagicNumber(tv);
-  return tv.AsTensor();
-}
-
-}  // namespace
 
 
 TYPED_TEST(TensorVectorSuite, TensorVectorAsTensorAccess) {
   TensorVector<TypeParam> tv;
+  constexpr uint8_t kMagicNumber = 42;
   tv.SetContiguous(true);
   auto shape = TensorListShape<>{{1, 2, 3}, {1, 2, 4}};
   tv.Resize(shape, DALI_INT32);
@@ -201,12 +792,12 @@ TYPED_TEST(TensorVectorSuite, TensorVectorAsTensorAccess) {
 
   {
     // Verify that we can convert and touch the data after TV is already released
-    auto tensor = ReturnTvAsTensor<TypeParam>();
+    auto tensor = ReturnTvAsTensor<TypeParam>(kMagicNumber);
     auto expected_shape = TensorShape<>{4, 1, 2, 3};
     EXPECT_EQ(tensor.shape(), expected_shape);
     EXPECT_EQ(tensor.type(), DALI_UINT8);
     EXPECT_EQ(tensor.GetLayout(), "NHWC");
-    CompareWithMagicNumber(tensor);
+    CompareWithNumber(tensor, kMagicNumber);
   }
 }
 
@@ -310,7 +901,7 @@ TYPED_TEST(TensorVectorSuite, VariableBatchResizeUp) {
 
 TYPED_TEST(TensorVectorSuite, EmptyShareContiguous) {
   TensorVector<TypeParam> tv;
-  tv.SetContiguous(true);
+  tv.SetContiguous(BatchState::Contiguous);
   TensorListShape<> shape = {{100, 0, 0}, {42, 0, 0}};
   tv.Resize(shape, DALI_UINT8);
   for (int i = 0; i < shape.num_samples(); i++) {
@@ -331,7 +922,7 @@ TYPED_TEST(TensorVectorSuite, EmptyShareContiguous) {
 
 TYPED_TEST(TensorVectorSuite, EmptyShareNonContiguous) {
   TensorVector<TypeParam> tv;
-  tv.SetContiguous(false);
+  tv.SetContiguous(BatchState::Noncontiguous);
   TensorListShape<> shape = {{100, 0, 0}, {42, 0, 0}};
   tv.Resize(shape, DALI_UINT8);
   for (int i = 0; i < shape.num_samples(); i++) {

--- a/dali/pipeline/data/tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_vector_test.cc
@@ -67,7 +67,7 @@ TYPED_TEST(TensorVectorSuite, SetupAndSetSizeNoncontiguous) {
   tv.set_order(order);
   tv.set_sample_dim(2);
   tv.SetLayout("XY");
-  tv.SetContiguous(BatchState::Noncontiguous);
+  tv.SetBatchState(BatchState::Noncontiguous);
   tv.SetSize(3);
 
 
@@ -215,7 +215,7 @@ TYPED_TEST(TensorVectorSuite, PartialSetupSetMultiGPU) {
     std::iota(idxs.begin(), idxs.end(), 0);
     do {
       TensorVector<TypeParam> tv;
-      tv.SetContiguous(BatchState::Noncontiguous);
+      tv.SetBatchState(BatchState::Noncontiguous);
       tv.SetSize(4);
       tv.set_pinned(false);
       for (auto idx : idxs) {
@@ -279,7 +279,7 @@ TYPED_TEST(TensorVectorSuite, PartialSetupCopyMultiGPU) {
     std::iota(idxs.begin(), idxs.end(), 0);
     do {
       TensorVector<TypeParam> tv;
-      tv.SetContiguous(BatchState::Noncontiguous);
+      tv.SetBatchState(BatchState::Noncontiguous);
       tv.SetSize(4);
       for (auto idx : idxs) {
         if (idx == excluded) {
@@ -324,7 +324,7 @@ TYPED_TEST(TensorVectorSuite, FullSetupSetMultiGPU) {
   std::iota(idxs.begin(), idxs.end(), 0);
   do {
     TensorVector<TypeParam> tv;
-    tv.SetContiguous(BatchState::Noncontiguous);
+    tv.SetBatchState(BatchState::Noncontiguous);
     tv.SetSize(4);
     for (auto idx : idxs) {
       setups[idx].second(tv);
@@ -400,7 +400,7 @@ void CompareWithNumber(ConstSampleView<GPUBackend> sample, T number) {
 template <typename Backend>
 Tensor<Backend> ReturnTvAsTensor(uint8_t number) {
   TensorVector<Backend> tv;
-  tv.SetContiguous(true);
+  tv.SetBatchState(true);
   tv.Resize(uniform_list_shape(4, {1, 2, 3}), DALI_UINT8);
   tv.SetLayout("HWC");
   FillWithNumber(tv, number);
@@ -417,7 +417,7 @@ TYPED_TEST(TensorVectorSuite, ResizeSetSize) {
   tv.set_order(order);
   tv.set_sample_dim(2);
   tv.SetLayout("XY");
-  tv.SetContiguous(BatchState::Contiguous);
+  tv.SetBatchState(BatchState::Contiguous);
   tv.SetSize(3);
 
 
@@ -484,7 +484,7 @@ TYPED_TEST(TensorVectorSuite, ResizeSetSize) {
 TYPED_TEST(TensorVectorSuite, NoForcedChangeContiguousToNoncontiguous) {
   constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
   TensorVector<TypeParam> tv;
-  tv.SetContiguous(BatchState::Contiguous);
+  tv.SetBatchState(BatchState::Contiguous);
   auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
   // State was forced to be contiguous, cannot change it with just Resize.
   EXPECT_THROW(tv.Resize(new_shape, DALI_FLOAT, BatchState::Noncontiguous), std::runtime_error);
@@ -493,7 +493,7 @@ TYPED_TEST(TensorVectorSuite, NoForcedChangeContiguousToNoncontiguous) {
 TYPED_TEST(TensorVectorSuite, NoForcedChangeNoncontiguousToContiguous) {
   constexpr bool is_device = std::is_same_v<TypeParam, GPUBackend>;
   TensorVector<TypeParam> tv;
-  tv.SetContiguous(BatchState::Noncontiguous);
+  tv.SetBatchState(BatchState::Noncontiguous);
   auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
   // State was forced to be noncontiguous, cannot change it with just Resize.
   EXPECT_THROW(tv.Resize(new_shape, DALI_FLOAT, BatchState::Contiguous), std::runtime_error);
@@ -505,7 +505,7 @@ TYPED_TEST(TensorVectorSuite, ContiguousResize) {
   const auto order = is_device ? AccessOrder(cuda_stream) : AccessOrder::host();
   TensorVector<TypeParam> tv;
   tv.set_order(order);
-  tv.SetContiguous(BatchState::Contiguous);
+  tv.SetBatchState(BatchState::Contiguous);
   auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
   tv.Resize(new_shape, DALI_FLOAT);
   EXPECT_TRUE(tv.IsContiguous());
@@ -540,7 +540,7 @@ TYPED_TEST(TensorVectorSuite, NoncontiguousResize) {
   const auto order = is_device ? AccessOrder(cuda_stream) : AccessOrder::host();
   TensorVector<TypeParam> tv;
   tv.set_order(order);
-  tv.SetContiguous(BatchState::Noncontiguous);
+  tv.SetBatchState(BatchState::Noncontiguous);
   auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
   tv.Resize(new_shape, DALI_FLOAT);
   EXPECT_FALSE(tv.IsContiguous());
@@ -573,7 +573,7 @@ TYPED_TEST(TensorVectorSuite, NoncontiguousResize) {
 TYPED_TEST(TensorVectorSuite, BreakContiguity) {
   TensorVector<TypeParam> tv;
   // anything goes
-  tv.SetContiguous(BatchState::Default);
+  tv.SetBatchState(BatchState::Default);
 
   auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
   tv.Resize(new_shape, DALI_FLOAT, BatchState::Contiguous);
@@ -608,7 +608,7 @@ TYPED_TEST(TensorVectorSuite, BreakContiguity) {
 TYPED_TEST(TensorVectorSuite, CoalescingAllocation) {
   TensorVector<TypeParam> tv;
   // anything goes
-  tv.SetContiguous(BatchState::Default);
+  tv.SetBatchState(BatchState::Default);
 
   auto first_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
   tv.Resize(first_shape, DALI_FLOAT, BatchState::Noncontiguous);
@@ -670,7 +670,7 @@ TYPED_TEST(TensorVectorSuite, CoalescingAllocation) {
 TYPED_TEST(TensorVectorSuite, Reserve) {
   // Verify that we still keep the memory reserved in sample mode
   TensorVector<TypeParam> tv;
-  tv.SetContiguous(BatchState::Default);
+  tv.SetBatchState(BatchState::Default);
   tv.reserve(100, 4);
 
   auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 50}};
@@ -768,7 +768,7 @@ TYPED_TEST(TensorVectorSuite, PinnedBeforeResizeNoncontiguous) {
 TYPED_TEST(TensorVectorSuite, TensorVectorAsTensorAccess) {
   TensorVector<TypeParam> tv;
   constexpr uint8_t kMagicNumber = 42;
-  tv.SetContiguous(true);
+  tv.SetBatchState(true);
   auto shape = TensorListShape<>{{1, 2, 3}, {1, 2, 4}};
   tv.Resize(shape, DALI_INT32);
   EXPECT_TRUE(tv.IsContiguousInMemory());
@@ -809,7 +809,7 @@ TYPED_TEST(TensorVectorSuite, TensorVectorAsTensorAccess) {
 
 TYPED_TEST(TensorVectorSuite, EmptyTensorVectorAsTensorAccess) {
   TensorVector<TypeParam> tv;
-  tv.SetContiguous(true);
+  tv.SetBatchState(true);
   tv.set_type(DALI_INT32);
   EXPECT_TRUE(tv.IsContiguousInMemory());
   EXPECT_TRUE(tv.IsDenseTensor());
@@ -851,7 +851,7 @@ TYPED_TEST(TensorVectorSuite, EmptyTensorVectorAsTensorAccess) {
 
 TYPED_TEST(TensorVectorSuite, EmptyTensorVectorWithDimAsTensorAccess) {
   TensorVector<TypeParam> tv;
-  tv.SetContiguous(true);
+  tv.SetBatchState(true);
   tv.set_type(DALI_INT32);
   EXPECT_TRUE(tv.IsContiguousInMemory());
   EXPECT_TRUE(tv.IsDenseTensor());
@@ -909,7 +909,7 @@ TYPED_TEST(TensorVectorSuite, VariableBatchResizeUp) {
 
 TYPED_TEST(TensorVectorSuite, EmptyShareContiguous) {
   TensorVector<TypeParam> tv;
-  tv.SetContiguous(BatchState::Contiguous);
+  tv.SetBatchState(BatchState::Contiguous);
   TensorListShape<> shape = {{100, 0, 0}, {42, 0, 0}};
   tv.Resize(shape, DALI_UINT8);
   for (int i = 0; i < shape.num_samples(); i++) {
@@ -930,7 +930,7 @@ TYPED_TEST(TensorVectorSuite, EmptyShareContiguous) {
 
 TYPED_TEST(TensorVectorSuite, EmptyShareNonContiguous) {
   TensorVector<TypeParam> tv;
-  tv.SetContiguous(BatchState::Noncontiguous);
+  tv.SetBatchState(BatchState::Noncontiguous);
   TensorListShape<> shape = {{100, 0, 0}, {42, 0, 0}};
   tv.Resize(shape, DALI_UINT8);
   for (int i = 0; i < shape.num_samples(); i++) {

--- a/dali/pipeline/data/tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_vector_test.cc
@@ -400,7 +400,7 @@ void CompareWithNumber(ConstSampleView<GPUBackend> sample, T number) {
 template <typename Backend>
 Tensor<Backend> ReturnTvAsTensor(uint8_t number) {
   TensorVector<Backend> tv;
-  tv.SetContiguity(true);
+  tv.SetContiguity(BatchContiguity::Contiguous);
   tv.Resize(uniform_list_shape(4, {1, 2, 3}), DALI_UINT8);
   tv.SetLayout("HWC");
   FillWithNumber(tv, number);
@@ -769,7 +769,7 @@ TYPED_TEST(TensorVectorSuite, PinnedBeforeResizeNoncontiguous) {
 TYPED_TEST(TensorVectorSuite, TensorVectorAsTensorAccess) {
   TensorVector<TypeParam> tv;
   constexpr uint8_t kMagicNumber = 42;
-  tv.SetContiguity(true);
+  tv.SetContiguity(BatchContiguity::Contiguous);
   auto shape = TensorListShape<>{{1, 2, 3}, {1, 2, 4}};
   tv.Resize(shape, DALI_INT32);
   EXPECT_TRUE(tv.IsContiguousInMemory());
@@ -810,7 +810,7 @@ TYPED_TEST(TensorVectorSuite, TensorVectorAsTensorAccess) {
 
 TYPED_TEST(TensorVectorSuite, EmptyTensorVectorAsTensorAccess) {
   TensorVector<TypeParam> tv;
-  tv.SetContiguity(true);
+  tv.SetContiguity(BatchContiguity::Contiguous);
   tv.set_type(DALI_INT32);
   EXPECT_TRUE(tv.IsContiguousInMemory());
   EXPECT_TRUE(tv.IsDenseTensor());
@@ -852,7 +852,7 @@ TYPED_TEST(TensorVectorSuite, EmptyTensorVectorAsTensorAccess) {
 
 TYPED_TEST(TensorVectorSuite, EmptyTensorVectorWithDimAsTensorAccess) {
   TensorVector<TypeParam> tv;
-  tv.SetContiguity(true);
+  tv.SetContiguity(BatchContiguity::Contiguous);
   tv.set_type(DALI_INT32);
   EXPECT_TRUE(tv.IsContiguousInMemory());
   EXPECT_TRUE(tv.IsDenseTensor());

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -738,7 +738,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::PresizeData(
               reserve_batch(storage, *node.op, hint, max_batch_size_);
             }
             if (node.op->CanInferOutputs()) {
-              storage->SetContiguous(BatchState::Contiguous);
+              storage->SetBatchState(BatchState::Contiguous);
             }
           }
         ), DALI_FAIL("Invalid StorageDevice"));  // NOLINT(whitespace/parens)

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -738,7 +738,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::PresizeData(
               reserve_batch(storage, *node.op, hint, max_batch_size_);
             }
             if (node.op->CanInferOutputs()) {
-              storage->SetContiguous(true);
+              storage->SetContiguous(BatchState::Contiguous);
             }
           }
         ), DALI_FAIL("Invalid StorageDevice"));  // NOLINT(whitespace/parens)

--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -738,7 +738,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::PresizeData(
               reserve_batch(storage, *node.op, hint, max_batch_size_);
             }
             if (node.op->CanInferOutputs()) {
-              storage->SetBatchState(BatchState::Contiguous);
+              storage->SetContiguity(BatchContiguity::Contiguous);
             }
           }
         ), DALI_FAIL("Invalid StorageDevice"));  // NOLINT(whitespace/parens)

--- a/dali/pipeline/operator/eager_operator.h
+++ b/dali/pipeline/operator/eager_operator.h
@@ -72,7 +72,7 @@ void ResizeImpl(TensorList<Backend> &batch, const TensorListShape<> &shape, DALI
 
 template <typename Backend>
 void ResizeImpl(TensorVector<Backend> &batch, const TensorListShape<> &shape, DALIDataType type) {
-  batch.Resize(shape, type, BatchState::Contiguous);
+  batch.Resize(shape, type, BatchContiguity::Contiguous);
 }
 /** @} */  // end of WarResizeContiguous
 

--- a/dali/pipeline/operator/sequence_shape.h
+++ b/dali/pipeline/operator/sequence_shape.h
@@ -216,6 +216,7 @@ template <typename BatchType>
 void setup_expanded_like(BatchType &expanded_batch, const BatchType &batch) {
   expanded_batch.set_pinned(batch.is_pinned());
   expanded_batch.set_order(batch.order());
+  expanded_batch.set_device_id(batch.device_id());
 }
 
 template <typename BatchType>

--- a/dali/pipeline/operator/sequence_shape_test.cc
+++ b/dali/pipeline/operator/sequence_shape_test.cc
@@ -144,7 +144,8 @@ template <typename ContainerContiguous>
 class SequenceShapeUnfoldTest : public ::testing::Test {
  protected:
   using Container = std::tuple_element_t<0, ContainerContiguous>;
-  static constexpr bool kContiguous = std::tuple_element_t<1, ContainerContiguous>::value;
+  static constexpr auto kContiguous = std::tuple_element_t<1, ContainerContiguous>::value;
+
   std::tuple<Container, std::shared_ptr<Container>> CreateTestBatch(
       DALIDataType dtype, bool is_pinned = false, TensorLayout layout = "ABC",
       TensorListShape<> shape = {{3, 5, 7}, {11, 5, 4}, {7, 2, 11}}) {
@@ -194,12 +195,19 @@ class SequenceShapeUnfoldTest : public ::testing::Test {
   }
 };
 
-using Containers = ::testing::Types<std::pair<TensorVector<CPUBackend>, std::true_type>,
-                                    std::pair<TensorVector<CPUBackend>, std::false_type>,
-                                    std::pair<TensorVector<GPUBackend>, std::true_type>,
-                                    std::pair<TensorVector<GPUBackend>, std::false_type>,
-                                    std::pair<TensorList<CPUBackend>, std::false_type>,
-                                    std::pair<TensorList<GPUBackend>, std::false_type>>;
+using Containers = ::testing::Types<
+    std::pair<TensorVector<CPUBackend>,
+              std::integral_constant<BatchContiguity, BatchContiguity::Contiguous>>,
+    std::pair<TensorVector<CPUBackend>,
+              std::integral_constant<BatchContiguity, BatchContiguity::Noncontiguous>>,
+    std::pair<TensorVector<GPUBackend>,
+              std::integral_constant<BatchContiguity, BatchContiguity::Contiguous>>,
+    std::pair<TensorVector<GPUBackend>,
+              std::integral_constant<BatchContiguity, BatchContiguity::Noncontiguous>>,
+    std::pair<TensorList<CPUBackend>,
+              std::integral_constant<BatchContiguity, BatchContiguity::Noncontiguous>>,
+    std::pair<TensorList<GPUBackend>,
+              std::integral_constant<BatchContiguity, BatchContiguity::Noncontiguous>>>;
 
 TYPED_TEST_SUITE(SequenceShapeUnfoldTest, Containers);
 
@@ -281,9 +289,10 @@ TYPED_TEST(SequenceShapeUnfoldTest, Unfold3Extents) {
 template <typename Backend>
 class SequenceShapeBroadcastTest;
 
-template <typename Backend>
-class SequenceShapeBroadcastTest<TensorVector<Backend>> : public ::testing::Test {
+template <typename Backend, typename BoolType>
+class SequenceShapeBroadcastTest<std::pair<TensorVector<Backend>, BoolType>> : public ::testing::Test {
  protected:
+  static constexpr auto kContiguous = BoolType::value;
   template <typename Dummy>
   std::tuple<TensorVector<Backend>, std::shared_ptr<TensorVector<Backend>>> CreateTestBatch(
       DALIDataType dtype, bool is_pinned = false, TensorLayout layout = "ABC",
@@ -292,6 +301,7 @@ class SequenceShapeBroadcastTest<TensorVector<Backend>> : public ::testing::Test
     constexpr bool is_device = std::is_same_v<Backend, GPUBackend>;
     batch.set_order(is_device ? AccessOrder(cuda_stream) : AccessOrder::host());
     batch.set_pinned(is_pinned);
+    batch.SetContiguity(kContiguous);
     batch.Resize(shape, dtype);
     if (!layout.empty()) {
       batch.SetLayout(layout);
@@ -375,8 +385,8 @@ class TensorListBroadcastTestBase<GPUBackend> {
 };
 
 
-template <typename Backend>
-class SequenceShapeBroadcastTest<TensorList<Backend>>
+template <typename Backend, typename BoolType>
+class SequenceShapeBroadcastTest<std::pair<TensorList<Backend>, BoolType>>
     : public ::testing::Test, public TensorListBroadcastTestBase<Backend> {
  protected:
   template <typename T>

--- a/dali/pipeline/operator/sequence_shape_test.cc
+++ b/dali/pipeline/operator/sequence_shape_test.cc
@@ -205,9 +205,9 @@ using Containers = ::testing::Types<
     std::pair<TensorVector<GPUBackend>,
               std::integral_constant<BatchContiguity, BatchContiguity::Noncontiguous>>,
     std::pair<TensorList<CPUBackend>,
-              std::integral_constant<BatchContiguity, BatchContiguity::Noncontiguous>>,
+              std::integral_constant<BatchContiguity, BatchContiguity::Contiguous>>,
     std::pair<TensorList<GPUBackend>,
-              std::integral_constant<BatchContiguity, BatchContiguity::Noncontiguous>>>;
+              std::integral_constant<BatchContiguity, BatchContiguity::Contiguous>>>;
 
 TYPED_TEST_SUITE(SequenceShapeUnfoldTest, Containers);
 

--- a/dali/pipeline/operator/sequence_shape_test.cc
+++ b/dali/pipeline/operator/sequence_shape_test.cc
@@ -148,7 +148,7 @@ class SequenceShapeUnfoldTest : public ::testing::Test {
     Container batch;
     constexpr bool is_device = std::is_same_v<batch_backend_t<Container>, GPUBackend>;
     batch.set_order(is_device ? AccessOrder(cuda_stream) : AccessOrder::host());
-    batch.SetContiguous(BatchState::Contiguous);  // TODO(klecki): or BatchState::Noncontiguous
+    batch.SetBatchState(BatchState::Contiguous);  // TODO(klecki): or BatchState::Noncontiguous
     batch.set_pinned(is_pinned);
     batch.Resize(shape, dtype);
     if (!layout.empty()) {

--- a/dali/pipeline/operator/sequence_shape_test.cc
+++ b/dali/pipeline/operator/sequence_shape_test.cc
@@ -290,7 +290,8 @@ template <typename Backend>
 class SequenceShapeBroadcastTest;
 
 template <typename Backend, typename BoolType>
-class SequenceShapeBroadcastTest<std::pair<TensorVector<Backend>, BoolType>> : public ::testing::Test {
+class SequenceShapeBroadcastTest<std::pair<TensorVector<Backend>, BoolType>>
+    : public ::testing::Test {
  protected:
   static constexpr auto kContiguous = BoolType::value;
   template <typename Dummy>

--- a/dali/pipeline/operator/sequence_shape_test.cc
+++ b/dali/pipeline/operator/sequence_shape_test.cc
@@ -148,6 +148,7 @@ class SequenceShapeUnfoldTest : public ::testing::Test {
     Container batch;
     constexpr bool is_device = std::is_same_v<batch_backend_t<Container>, GPUBackend>;
     batch.set_order(is_device ? AccessOrder(cuda_stream) : AccessOrder::host());
+    batch.SetContiguous(BatchState::Contiguous);  // TODO(klecki): or BatchState::Noncontiguous
     batch.set_pinned(is_pinned);
     batch.Resize(shape, dtype);
     if (!layout.empty()) {

--- a/dali/pipeline/workspace/sample_workspace.cc
+++ b/dali/pipeline/workspace/sample_workspace.cc
@@ -25,10 +25,10 @@ void MakeSampleView(SampleWorkspace& sample, HostWorkspace& batch, int data_idx,
   for (int i = 0; i < num_inputs; i++) {
     if (batch.InputIsType<CPUBackend>(i)) {
       auto &input_ref = batch.UnsafeMutableInput<CPUBackend>(i);
-      sample.AddInput(input_ref.tensor_handle(data_idx).get());
+      sample.AddInput(&input_ref.tensor_handle(data_idx));
     } else {
       auto &input_ref = batch.UnsafeMutableInput<GPUBackend>(i);
-      sample.AddInput(input_ref.tensor_handle(data_idx).get());
+      sample.AddInput(&input_ref.tensor_handle(data_idx));
     }
   }
 
@@ -36,10 +36,10 @@ void MakeSampleView(SampleWorkspace& sample, HostWorkspace& batch, int data_idx,
   for (int i = 0; i < num_outputs; i++) {
     if (batch.OutputIsType<CPUBackend>(i)) {
       auto &output_ref = batch.Output<CPUBackend>(i);
-      sample.AddOutput(output_ref.tensor_handle(data_idx).get());
+      sample.AddOutput(&output_ref.tensor_handle(data_idx));
     } else {
       auto &output_ref = batch.Output<GPUBackend>(i);
-      sample.AddOutput(output_ref.tensor_handle(data_idx).get());
+      sample.AddOutput(&output_ref.tensor_handle(data_idx));
     }
   }
   for (auto& arg_pair : batch) {


### PR DESCRIPTION
## Category: **Refactoring** 
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Refactor TensorVector with intention of using it as the only batch object through DALI.

Main changes:
1. Batch is the source of truth. 
This breaks away from the design, where depending on the case (contiguous vs noncontiguous) our metadata were kept in the member TensorList or in the first Tensor respectively. This is enabled thanks to better encapsulation where the internal allocation cannot be changed from the outside.

3. When modifying the batch, care was taken to update the properties (now stored in batch) in the same order as they are defined. There are some exception. 

4. Now setting and copying samples can be verified against all the properties of the batch - they must match. 

5. There are now three options when deciding if the batch should use contiguous allocation.
We can either pin the contiguous or noncontiguous modes or allow buffer to change depending on the needs.
In the last case, it can be specifically requested during Resize to change to one of the modes. 

4. When Resizing the batch, and a new allocation is needed, we try to use one big allocation if allowed by the selected mode. It yields smaller memory fragmentation 

6. When we convert the buffer to non-contiguous and it had a contiguous backing allocation, we mark the tensors_ that were pointing to that allocation as not sharing, but still aliasing - so we can call Resize() and get a new allocation without the error that we try to reallocate something that shares data

5. Contents of `tensor_list_as_tensor_vector_test.cc` are copied from `tensor_list_test.cc` and adjusted to handle both contiguous and noncontiguous cases.
It is necessary to verify the TensorVector conformance to the TensorList requirements but the code is almost identical to the already existing one. 

**Note**: The third commit does some grouping and reordering of the member functions to hopefully allow for better documentation.

If this is inconvenient I can split it into another PR.

Small bugfix for SampleView constructor was included here, I can factor it out as well.


## Additional information:

### Affected modules and functionalities:
TensorVector


### Key points relevant for the review:
TensorVector

### Tests:
YES - both new tests added and old tests ported to test the TensorVector as if it was a TensorList.
- [x] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: DALI-2689
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-2689 or NA --->
