### PR TITLE
Add bytes_per_sample_hint parameter to parallel external source

### DIFF
--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -1558,7 +1558,7 @@ PYBIND11_MODULE(backend_impl, m) {
 #if SHM_WRAPPER_ENABLED
 
   py::class_<SharedMem>(m, "SharedMem")
-      .def(py::init<int, int>())
+      .def(py::init<int, uint64_t>())
       .def_property_readonly("size", &SharedMem::size)
       .def_property_readonly("handle", &SharedMem::handle)
       .def("buf",

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -520,17 +520,18 @@ Keyword Args
         Python process, but due to their state it is not possible to calculate more
         than one batch at a time.
 
-`prefetch_queue_depth` : int, option, default = 1
+`prefetch_queue_depth` : int, optional, default = 1
     When run in ``parallel=True`` mode, specifies the number of batches to be computed in
     advance and stored in the internal buffer, otherwise parameter is ignored.
 
-`bytes_per_sample_hint`: int, option, default = None
+`bytes_per_sample_hint`: int, optional, default = None
     If specified in ``parallel=True`` mode, the value serves as a hint when
     calculating initial capacity of shared memory slots used by the worker processes to pass
-    parallel external source outputs to the pipeline. Setting a value large enough to
-    accommodate the incoming data can prevent DALI from reallocation of shared memory
-    during the pipeline's run. Furthermore, providing the hint manually can prevent DALI from
-    overestimating the necessary shared memory capacity.
+    parallel external source outputs to the pipeline. The argument is ignored in non-parallel mode.
+
+    Setting a value large enough to accommodate the incoming data can prevent DALI from
+    reallocation of shared memory during the pipeline's run. Furthermore, providing the
+    hint manually can prevent DALI from overestimating the necessary shared memory capacity.
 
     The value must be a positive integer.
     Please note that the samples in shared memory are accompanied by some internal meta-data,

--- a/dali/python/nvidia/dali/external_source.py
+++ b/dali/python/nvidia/dali/external_source.py
@@ -525,12 +525,22 @@ Keyword Args
     advance and stored in the internal buffer, otherwise parameter is ignored.
 
 `bytes_per_sample_hint`: int, option, default = None
-    If specified in ``parallel=True`` mode, the value is used as a hint when
+    If specified in ``parallel=True`` mode, the value serves as a hint when
     calculating initial capacity of shared memory slots used by the worker processes to pass
-    parallel external source outputs to the pipeline. It may help to avoid reallocation
-    of shared memory during pipeline run, which in turn can improve performance and prevent
-    DALI from overestimation of the needed virtual memory capacity.
+    parallel external source outputs to the pipeline. Setting a value large enough to
+    accommodate the incoming data can prevent DALI from reallocation of shared memory
+    during the pipeline's run. Furthermore, providing the hint manually can prevent DALI from
+    overestimating the necessary shared memory capacity.
+
     The value must be a positive integer.
+    Please note that the samples in shared memory are accompanied by some internal meta-data,
+    thus, the actual demand for the shared memory is slightly higher than just the size
+    of binary data produced by the external source. The actual meta-data size depends on
+    the number of factors and, for example, may change between Python or DALI
+    releases without notice.
+
+    Please refer to pipeline's ``external_source_shm_statistics`` for inspecting how much
+    shared memory is allocated for data produced by the pipeline's parallel external sources.
 """
 
     def __init__(self, source=None, num_outputs=None, *, cycle=None, layout=None, dtype=None,

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -434,6 +434,13 @@ Parameters
             raise RuntimeError("Pipeline must be built first.")
         return self._pipe.executor_statistics()
 
+    def external_source_shm_statistics(self):
+        """Returns a list of sizes of shared memory chunks allocated for data produced
+        by parallel external source."""
+        if self._py_pool is None:
+            return []
+        return [shm for context in self._py_pool.contexts for shm in context.shm_manager.shm_pool]
+
     def reader_meta(self, name=None):
         """Returns provided reader metadata as a dictionary. If no name is provided if provides
         a dictionary with data for all readers as {reader_name : meta}

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -435,11 +435,14 @@ Parameters
         return self._pipe.executor_statistics()
 
     def external_source_shm_statistics(self):
-        """Returns a list of sizes of shared memory chunks allocated for data produced
-        by parallel external source."""
+        """Returns a list of sizes (in bytes) of shared memory slots allocated for data produced
+        by the parallel external source. To tune the initial size of the chunks, please refer
+        to external source's `bytes_per_sample_hint` parameter."""
         if self._py_pool is None:
             return []
-        return [shm for context in self._py_pool.contexts for shm in context.shm_manager.shm_pool]
+        return [
+            shm.capacity for context in self._py_pool.contexts
+            for shm in context.shm_manager.shm_pool]
 
     def reader_meta(self, name=None):
         """Returns provided reader metadata as a dictionary. If no name is provided if provides

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -680,6 +680,7 @@ Parameters
             return
         self._py_pool = WorkerPool.from_groups(self._parallel_input_callbacks,
                                                self._prefetch_queue_depth,
+                                               self._max_batch_size,
                                                self._py_start_method,
                                                self._py_num_workers,
                                                py_callback_pickler=self._py_callback_pickler)

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -439,10 +439,13 @@ Parameters
         by the parallel external source. To tune the initial size of the chunks, please refer
         to external source's ``bytes_per_sample_hint`` parameter."""
         if self._py_pool is None:
-            return []
-        return [
-            shm.capacity for context in self._py_pool.contexts
-            for shm in context.shm_manager.shm_pool]
+            capacities = []
+        else:
+            capacities = [
+                shm.capacity for context in self._py_pool.contexts
+                for shm in context.shm_manager.shm_pool
+            ]
+        return {"capacities": capacities}
 
     def reader_meta(self, name=None):
         """Returns provided reader metadata as a dictionary. If no name is provided if provides

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -442,10 +442,10 @@ Parameters
               accommodate data produced by the parallel external source.
 
             * ``per_sample_capacities`` - a list of sizes (in bytes) of shared memory slots
-              divided by the mini-batch size, i.e. the maximal number of samples stored in such a slot.
-              This value corresponds to external source's ``bytes_per_sample_hint`` parameter,
-              i.e. if the hint is big enough and the external source does not need to reallocate the memory,
-              the values should be equal.
+              divided by the mini-batch size, i.e. the maximal number of samples stored in
+              such a slot. This value corresponds to external source's ``bytes_per_sample_hint``
+              parameter, i.e., if the hint is big enough and the external source does not need
+              to reallocate the memory, the values should be equal.
         """
         if self._py_pool is None:
             capacities, per_sample_capacities = [], []

--- a/dali/python/nvidia/dali/pipeline.py
+++ b/dali/python/nvidia/dali/pipeline.py
@@ -437,7 +437,7 @@ Parameters
     def external_source_shm_statistics(self):
         """Returns a list of sizes (in bytes) of shared memory slots allocated for data produced
         by the parallel external source. To tune the initial size of the chunks, please refer
-        to external source's `bytes_per_sample_hint` parameter."""
+        to external source's ``bytes_per_sample_hint`` parameter."""
         if self._py_pool is None:
             return []
         return [

--- a/dali/test/python/test_external_source_parallel.py
+++ b/dali/test/python/test_external_source_parallel.py
@@ -732,3 +732,130 @@ def test_permute_dataset():
             for reader_queue_depth in (1, 5):
                 yield _test_permute_dataset, batch_size, epoch_size, trailing_samples, \
                       cb, 4, 1, reader_queue_depth
+
+
+def per_iter_shape_cb(shapes):
+
+    def cb(sample_info):
+        batch_idx = sample_info.iteration
+        shape = shapes[batch_idx % len(shapes)]
+        return np.full(shape, sample_info.idx_in_epoch, dtype=np.uint8)
+
+    return cb
+
+
+def per_iter_shape_pipeline(shapes, py_num_workers=4, batch_size=4, parallel=True,
+                            bytes_per_sample_hint=None):
+    @dali.pipeline_def
+    def pipeline():
+        return dali.fn.external_source(
+            per_iter_shape_cb(shapes),
+            batch=False, parallel=parallel,
+            bytes_per_sample_hint=bytes_per_sample_hint)
+    pipe = pipeline(
+        batch_size=batch_size, py_num_workers=py_num_workers,
+        device_id=0, num_threads=4, py_start_method="spawn")
+    pipe.build()
+    return pipe
+
+
+def test_no_parallel_no_shm():
+    shapes = [(4, 1024, 1024)]
+    pipe = per_iter_shape_pipeline(shapes, parallel=False)
+    for _ in range(5):
+        pipe.run()
+    assert pipe.external_source_shm_statistics() == []
+
+
+def test_default_shm_size():
+    default_shm_size = 1024 * 1024
+    shapes = [(16, 1024, 1024)]
+
+    pipe_default = per_iter_shape_pipeline(shapes)
+    default_sizes = pipe_default.external_source_shm_statistics()
+    assert len(default_sizes) > 0
+    for size in default_sizes:
+        assert size == default_shm_size, (
+            f"Expected initial size to be {default_shm_size}, got {size}.")
+
+    pipe_too_small_hint = per_iter_shape_pipeline(
+        shapes, bytes_per_sample_hint=1024)
+    sizes = pipe_too_small_hint.external_source_shm_statistics()
+    assert len(sizes) > 0
+    for size in sizes:
+        assert size == default_shm_size, (
+            f"Expected initial size to be {default_shm_size}, got {size}.")
+
+
+def test_initial_hint():
+    sample_size = 32 * 1024 * 1024
+    shapes = [(32, 1024, 1024)]
+    # make the initial size still smaller than necessary to check if reallocation works
+    bytes_per_sample_hint = 4 * 1024 * 1024
+    batch_size = 7
+    num_workers = 3
+    min_samples_in_mini_batch = batch_size // num_workers
+    max_samples_in_mini_batch = (batch_size + num_workers - 1) // num_workers
+    initial_shm_size = max_samples_in_mini_batch * bytes_per_sample_hint
+    expected_min_chunk_size = min_samples_in_mini_batch * sample_size
+
+    pipe = per_iter_shape_pipeline(
+        shapes, bytes_per_sample_hint=bytes_per_sample_hint,
+        batch_size=batch_size, py_num_workers=num_workers)
+    sizes = pipe.external_source_shm_statistics()
+    assert len(sizes) > 0
+    for size in sizes:
+        assert size == initial_shm_size, (
+            f"Expected initial size to be {initial_shm_size}, got {size}.")
+
+    for _ in range(5):
+        pipe.run()
+
+    sizes = pipe.external_source_shm_statistics()
+    assert len(sizes) > 0
+    for size in sizes:
+        assert size >= expected_min_chunk_size, (
+            f"Expected the size to be at least {expected_min_chunk_size}, got {size}.")
+
+
+def test_variable_sample_size():
+    shapes = [(31, 1024, 1024), (32, 1024, 1024)]
+    # make the initial enough to hold samples of any of the two shapes
+    bytes_per_sample_hint = 32 * 1024 * 1024
+    # add some extra bytes to accommodate meta-data (we purposely do not stipulate
+    # the exact number, as 1. we may want to modify the exact meta-data stored,
+    # 2. they are pickled, so that could change with pickle itself)
+    bytes_per_sample_hint += 4096
+    batch_size = 8
+    num_workers = 4
+    max_samples_in_mini_batch = batch_size // num_workers
+    initial_shm_size = max_samples_in_mini_batch * bytes_per_sample_hint
+
+    pipe = per_iter_shape_pipeline(
+        shapes, bytes_per_sample_hint=bytes_per_sample_hint,
+        batch_size=batch_size, py_num_workers=num_workers)
+    no_hint_pipe = per_iter_shape_pipeline(
+        shapes, batch_size=batch_size, py_num_workers=num_workers)
+    sizes = pipe.external_source_shm_statistics()
+    assert len(sizes) > 0
+    for size in sizes:
+        assert size == initial_shm_size, (
+            f"Expected initial size to be {initial_shm_size}, got {size}.")
+
+    for _ in range(5):
+        pipe.run()
+        no_hint_pipe.run()
+
+    sizes = pipe.external_source_shm_statistics()
+    assert len(sizes) > 0
+    for size in sizes:
+        assert size >= initial_shm_size, (
+            f"Expected the size to be unchanged and equal {initial_shm_size}, got {size}.")
+
+    # This demonstrates that providing a hint can improve memory usage, but if one day
+    # DALI changes strategy of dynamic shm reallocation it can be simply removed
+    no_hint_pipe_shm_size = min(no_hint_pipe.external_source_shm_statistics())
+    sizes = pipe.external_source_shm_statistics()
+    for size in sizes:
+        assert size < no_hint_pipe_shm_size, (
+            f"Expected the size to be less than {no_hint_pipe_shm_size}, got {size}.")

--- a/dali/test/python/test_external_source_parallel.py
+++ b/dali/test/python/test_external_source_parallel.py
@@ -764,7 +764,7 @@ def test_no_parallel_no_shm():
     pipe = per_iter_shape_pipeline(shapes, parallel=False)
     for _ in range(5):
         pipe.run()
-    assert pipe.external_source_shm_statistics() == []
+    assert pipe.external_source_shm_statistics()["capacities"] == []
 
 
 def test_default_shm_size():
@@ -772,7 +772,7 @@ def test_default_shm_size():
     shapes = [(16, 1024, 1024)]
 
     pipe_default = per_iter_shape_pipeline(shapes)
-    default_sizes = pipe_default.external_source_shm_statistics()
+    default_sizes = pipe_default.external_source_shm_statistics()["capacities"]
     assert len(default_sizes) > 0
     for size in default_sizes:
         assert size == default_shm_size, (
@@ -780,7 +780,7 @@ def test_default_shm_size():
 
     pipe_too_small_hint = per_iter_shape_pipeline(
         shapes, bytes_per_sample_hint=1024)
-    sizes = pipe_too_small_hint.external_source_shm_statistics()
+    sizes = pipe_too_small_hint.external_source_shm_statistics()["capacities"]
     assert len(sizes) > 0
     for size in sizes:
         assert size == default_shm_size, (
@@ -802,7 +802,7 @@ def test_initial_hint():
     pipe = per_iter_shape_pipeline(
         shapes, bytes_per_sample_hint=bytes_per_sample_hint,
         batch_size=batch_size, py_num_workers=num_workers)
-    sizes = pipe.external_source_shm_statistics()
+    sizes = pipe.external_source_shm_statistics()["capacities"]
     assert len(sizes) > 0
     for size in sizes:
         assert size == initial_shm_size, (
@@ -811,7 +811,7 @@ def test_initial_hint():
     for _ in range(5):
         pipe.run()
 
-    sizes = pipe.external_source_shm_statistics()
+    sizes = pipe.external_source_shm_statistics()["capacities"]
     assert len(sizes) > 0
     for size in sizes:
         assert size >= expected_min_chunk_size, (
@@ -838,7 +838,7 @@ def test_variable_sample_size():
         batch_size=batch_size, py_num_workers=num_workers)
     no_hint_pipe = per_iter_shape_pipeline(
         shapes, batch_size=batch_size, py_num_workers=num_workers)
-    sizes = pipe.external_source_shm_statistics()
+    sizes = pipe.external_source_shm_statistics()["capacities"]
     assert len(sizes) > 0
     for size in sizes:
         assert size == initial_shm_size, (
@@ -848,7 +848,7 @@ def test_variable_sample_size():
         pipe.run()
         no_hint_pipe.run()
 
-    sizes = pipe.external_source_shm_statistics()
+    sizes = pipe.external_source_shm_statistics()["capacities"]
     assert len(sizes) > 0
     for size in sizes:
         assert size >= initial_shm_size, (
@@ -856,8 +856,8 @@ def test_variable_sample_size():
 
     # This demonstrates that providing a hint can improve memory usage, but if one day
     # DALI changes strategy of dynamic shm reallocation it can be simply removed
-    no_hint_pipe_shm_size = min(no_hint_pipe.external_source_shm_statistics())
-    sizes = pipe.external_source_shm_statistics()
+    no_hint_pipe_shm_size = min(no_hint_pipe.external_source_shm_statistics()["capacities"])
+    sizes = pipe.external_source_shm_statistics()["capacities"]
     for size in sizes:
         assert size < no_hint_pipe_shm_size, (
             f"Expected the size to be less than {no_hint_pipe_shm_size}, got {size}.")

--- a/dali/test/python/test_external_source_parallel.py
+++ b/dali/test/python/test_external_source_parallel.py
@@ -854,6 +854,12 @@ def test_variable_sample_size():
         assert size >= initial_shm_size, (
             f"Expected the size to be unchanged and equal {initial_shm_size}, got {size}.")
 
+    per_sample_sizes = pipe.external_source_shm_statistics()["per_sample_capacities"]
+    assert len(sizes) == len(per_sample_sizes)
+    for size in per_sample_sizes:
+        assert size == bytes_per_sample_hint, (
+            f"Expected initial per sample size to be {bytes_per_sample_hint}, got {size}.")
+
     # This demonstrates that providing a hint can improve memory usage, but if one day
     # DALI changes strategy of dynamic shm reallocation it can be simply removed
     no_hint_pipe_shm_size = min(no_hint_pipe.external_source_shm_statistics()["capacities"])

--- a/dali/test/python/test_external_source_parallel.py
+++ b/dali/test/python/test_external_source_parallel.py
@@ -823,8 +823,10 @@ def test_variable_sample_size():
     # make the initial enough to hold samples of any of the two shapes
     bytes_per_sample_hint = 32 * 1024 * 1024
     # add some extra bytes to accommodate meta-data (we purposely do not stipulate
-    # the exact number, as 1. we may want to modify the exact meta-data stored,
-    # 2. they are pickled, so that could change with pickle itself)
+    # the exact number in the docs, as
+    # 1. we may want to modify the exact meta-data stored,
+    # 2. they are pickled, so the serialized data size could change with pickle itself,
+    # 3. there are things like idx_in_epoch serialized that are truly unbound in Python)
     bytes_per_sample_hint += 4096
     batch_size = 8
     num_workers = 4

--- a/dali/test/python/test_pool.py
+++ b/dali/test/python/test_pool.py
@@ -56,15 +56,17 @@ class IteratorCb:
 
 class MockGroup:
 
-    def __init__(self, source_desc, batch, prefetch_queue_depth):
+    def __init__(self, source_desc, batch, prefetch_queue_depth, bytes_per_sample_hint):
         self.source_desc = source_desc
         self.batch = batch
         self.prefetch_queue_depth = prefetch_queue_depth
+        self.bytes_per_sample_hint = bytes_per_sample_hint
 
     @classmethod
-    def from_callback(cls, callback, batch=False, prefetch_queue_depth=1):
+    def from_callback(cls, callback, batch=False, prefetch_queue_depth=1,
+                      bytes_per_sample_hint=None):
         _, source_desc = get_callback_from_source(callback, cycle=None)
-        return cls(source_desc, batch, prefetch_queue_depth)
+        return cls(source_desc, batch, prefetch_queue_depth, bytes_per_sample_hint)
 
 
 def create_pool(groups, keep_alive_queue_size=1, num_workers=1, start_method="fork"):


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Adds a new parameter to parallel external source to enable user to provide a hint as to the sample size. This way parallel external source can precompute more resonalbe estimation of the required shared memory size and prevent DALI from reallocating the memory during pipeline run. When adjusting shm size, DALI at least doubles the size of a given chunk, so providing more accurate size explicitly can result in less memory consumption.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2960
<!--- DALI-XXXX or NA --->
