### PR TITLE
docs fix typos in iterator last_batch_policy argument description

### DIFF
--- a/dali/python/nvidia/dali/plugin/base_iterator.py
+++ b/dali/python/nvidia/dali/plugin/base_iterator.py
@@ -96,8 +96,8 @@ class _DaliBaseIterator(object):
                 of self._num_gpus * self.batch_size entries which exceeds 'size'.
                 Setting this flag to False will cause the iterator to return
                 exactly 'size' entries.
-    last_batch_policy, optional, default = LastBatchPolicy.FILL
-                What to do with the last batch when there is no enough samples in the epoch
+    last_batch_policy: optional, default = LastBatchPolicy.FILL
+                What to do with the last batch when there are not enough samples in the epoch
                 to fully fill it. See :meth:`nvidia.dali.plugin.base_iterator.LastBatchPolicy`
     last_batch_padded : bool, optional, default = False
                 Whether the last batch provided by DALI is padded with the last sample

--- a/dali/python/nvidia/dali/plugin/mxnet.py
+++ b/dali/python/nvidia/dali/plugin/mxnet.py
@@ -200,8 +200,8 @@ class DALIGenericIterator(_DALIMXNetIteratorBase):
                 of self._num_gpus * self.batch_size entries which exceeds 'size'.
                 Setting this flag to False will cause the iterator to return
                 exactly 'size' entries.
-    last_batch_policy, optional, default = LastBatchPolicy.FILL
-                What to do with the last batch when there is no enough samples in the epoch
+    last_batch_policy: optional, default = LastBatchPolicy.FILL
+                What to do with the last batch when there are not enough samples in the epoch
                 to fully fill it. See :meth:`nvidia.dali.plugin.base_iterator.LastBatchPolicy`.
                 Both ``FILL`` and ``PARTIAL`` would return a full batch but the ``pad`` property
                 value of the returned array would differ.
@@ -507,8 +507,8 @@ class DALIClassificationIterator(DALIGenericIterator):
                 of self._num_gpus * self.batch_size entries which exceeds 'size'.
                 Setting this flag to False will cause the iterator to return
                 exactly 'size' entries.
-    last_batch_policy, optional, default = LastBatchPolicy.FILL
-                What to do with the last batch when there is no enough samples in the epoch
+    last_batch_policy: optional, default = LastBatchPolicy.FILL
+                What to do with the last batch when there are not enough samples in the epoch
                 to fully fill it. See :meth:`nvidia.dali.plugin.base_iterator.LastBatchPolicy`.
                 Both ``FILL`` and ``PARTIAL`` would return a full batch but the ``pad`` property
                 value of the returned array would differ.
@@ -645,8 +645,8 @@ class DALIGluonIterator(_DALIMXNetIteratorBase):
                 of self._num_gpus * self.batch_size entries which exceeds 'size'.
                 Setting this flag to False will cause the iterator to return
                 exactly 'size' entries.
-    last_batch_policy, optional, default = LastBatchPolicy.FILL
-                What to do with the last batch when there is no enough samples in the epoch
+    last_batch_policy: optional, default = LastBatchPolicy.FILL
+                What to do with the last batch when there are not enough samples in the epoch
                 to fully fill it. See :meth:`nvidia.dali.plugin.base_iterator.LastBatchPolicy`
     last_batch_padded : bool, optional, default = False
                 Whether the last batch provided by DALI is padded with the last sample

--- a/dali/python/nvidia/dali/plugin/paddle.py
+++ b/dali/python/nvidia/dali/plugin/paddle.py
@@ -176,8 +176,8 @@ class DALIGenericIterator(_DaliBaseIterator):
                 of self._num_gpus * self.batch_size entries which exceeds 'size'.
                 Setting this flag to False will cause the iterator to return
                 exactly 'size' entries.
-    last_batch_policy, optional, default = LastBatchPolicy.FILL
-                What to do with the last batch when there is no enough samples in the epoch
+    last_batch_policy: optional, default = LastBatchPolicy.FILL
+                What to do with the last batch when there are not enough samples in the epoch
                 to fully fill it. See :meth:`nvidia.dali.plugin.base_iterator.LastBatchPolicy`
     last_batch_padded : bool, optional, default = False
                 Whether the last batch provided by DALI is padded with the last sample
@@ -440,8 +440,8 @@ class DALIClassificationIterator(DALIGenericIterator):
                 of self._num_gpus * self.batch_size entries which exceeds 'size'.
                 Setting this flag to False will cause the iterator to return
                 exactly 'size' entries.
-    last_batch_policy, optional, default = LastBatchPolicy.FILL
-                What to do with the last batch when there is no enough samples in the epoch
+    last_batch_policy: optional, default = LastBatchPolicy.FILL
+                What to do with the last batch when there are not enough samples in the epoch
                 to fully fill it. See :meth:`nvidia.dali.plugin.base_iterator.LastBatchPolicy`
     last_batch_padded : bool, optional, default = False
                 Whether the last batch provided by DALI is padded with the last sample

--- a/dali/python/nvidia/dali/plugin/pytorch.py
+++ b/dali/python/nvidia/dali/plugin/pytorch.py
@@ -123,8 +123,8 @@ class DALIGenericIterator(_DaliBaseIterator):
                 of self._num_gpus * self.batch_size entries which exceeds 'size'.
                 Setting this flag to False will cause the iterator to return
                 exactly 'size' entries.
-    last_batch_policy, optional, default = LastBatchPolicy.FILL
-                What to do with the last batch when there is no enough samples in the epoch
+    last_batch_policy: optional, default = LastBatchPolicy.FILL
+                What to do with the last batch when there are not enough samples in the epoch
                 to fully fill it. See :meth:`nvidia.dali.plugin.base_iterator.LastBatchPolicy`
     last_batch_padded : bool, optional, default = False
                 Whether the last batch provided by DALI is padded with the last sample
@@ -358,8 +358,8 @@ class DALIClassificationIterator(DALIGenericIterator):
                 of self._num_gpus * self.batch_size entries which exceeds 'size'.
                 Setting this flag to False will cause the iterator to return
                 exactly 'size' entries.
-    last_batch_policy, optional, default = LastBatchPolicy.FILL
-                What to do with the last batch when there is no enough samples in the epoch
+    last_batch_policy: optional, default = LastBatchPolicy.FILL
+                What to do with the last batch when there are not enough samples in the epoch
                 to fully fill it. See :meth:`nvidia.dali.plugin.base_iterator.LastBatchPolicy`
     last_batch_padded : bool, optional, default = False
                 Whether the last batch provided by DALI is padded with the last sample


### PR DESCRIPTION
## Category:
**Other** Documentation


## Description:
Fixes a few typos in the docstring for the `last_batch_policy` argument to the iterators

## Additional information:

### Affected modules and functionalities:
small modifications to doc strings in a handful of .py files

### Key points relevant for the review:
These doc strings get published on read_the_docs pages like: https://docs.nvidia.com/deeplearning/dali/user-guide/docs/plugins/pytorch_plugin_api.html

### Tests:
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A



## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
