### PR TITLE
Support higher TIFF bitdepths 

### DIFF
--- a/DALI_EXTRA_VERSION
+++ b/DALI_EXTRA_VERSION
@@ -1,2 +1,1 @@
-ac33ab4bb04b17960f150d2fdb9378ebc84891d3
-
+TODO

--- a/DALI_EXTRA_VERSION
+++ b/DALI_EXTRA_VERSION
@@ -1,1 +1,2 @@
-TODO
+bb687385d4f9fbf8a2be9a74100fe1c99cc75841
+

--- a/dali/imgcodec/decoders/decoder_test_helper.h
+++ b/dali/imgcodec/decoders/decoder_test_helper.h
@@ -229,7 +229,7 @@ class DecoderTestBase : public ::testing::Test {
     VALUE_SWITCH(ndim, Dims, (2, 3, 4), (
       TYPE_SWITCH(input.type(), type2id, InputType, (IMGCODEC_TYPES), (
         return Crop(view<const InputType, Dims>(input), roi, input.GetLayout());
-      ), DALI_FAIL(make_string("Unsupported type ", input.type())););
+      ), DALI_FAIL(make_string("Unsupported type ", input.type())););  // NOLINT
     ), DALI_FAIL(make_string("Unsupported number of dimensions: ", ndim)););  // NOLINT
   }
 

--- a/dali/imgcodec/decoders/decoder_test_helper.h
+++ b/dali/imgcodec/decoders/decoder_test_helper.h
@@ -226,7 +226,6 @@ class DecoderTestBase : public ::testing::Test {
 
   Tensor<CPUBackend> Crop(const Tensor<CPUBackend> &input, const ROI &roi) {
     int ndim = input.shape().sample_dim();
-
     VALUE_SWITCH(ndim, Dims, (2, 3, 4), (
       TYPE_SWITCH(input.type(), type2id, InputType, (IMGCODEC_TYPES), (
         return Crop(view<const InputType, Dims>(input), roi, input.GetLayout());

--- a/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
+++ b/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
@@ -142,6 +142,7 @@ TiffInfo GetTiffInfo(TIFF *tiffptr) {
 
 template <int depth>
 struct depth2type;
+
 template <>
 struct depth2type<8> {
   using type = uint8_t;

--- a/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
+++ b/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
@@ -231,7 +231,7 @@ DecodeResult LibTiffDecoderInstance::Decode(SampleView<CPUBackend> out, ImageSou
         LIBTIFF_CALL(TIFFReadScanline(tiff.get(), row_in, roi.begin[0] + roi_y, 0));
         Convert(img_out + (roi_y * out_row_stride), out_line_strides.data(), 1, opts.format,
                 row_in + roi.begin[1] * info.channels, in_line_strides.data(), 1, in_format,
-                out_line_shape.data(), 2);
+                out_line_shape.data(), 2);  // ndim = 2 because we convert a single row
       }
     ), DALI_FAIL(make_string("Unsupported bit depth: ", info.bit_depth)););  // NOLINT
   ), DALI_FAIL(make_string("Unsupported output type: ", out.type())));  // NOLINT

--- a/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
+++ b/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
@@ -228,9 +228,9 @@ DecodeResult LibTiffDecoderInstance::Decode(SampleView<CPUBackend> out, ImageSou
       using InputType = detail::depth2type<Depth>::type;
       auto *row_in  = static_cast<InputType *>(row_buf.get());
       OutType *const img_out = out.mutable_data<OutType>();
-      for (int64_t roi_y = 0; roi_y < roi.shape()[0]; roi_y++) {
-        LIBTIFF_CALL(TIFFReadScanline(tiff.get(), row_in, roi.begin[0] + roi_y, 0));
-        Convert(img_out + (roi_y * out_row_stride), out_line_strides.data(), 1, opts.format,
+      for (int64_t y = 0; y < roi.shape()[0]; y++) {
+        LIBTIFF_CALL(TIFFReadScanline(tiff.get(), row_in, roi.begin[0] + y, 0));
+        Convert(img_out + (y * out_row_stride), out_line_strides.data(), 1, opts.format,
                 row_in + roi.begin[1] * info.channels, in_line_strides.data(), 1, in_format,
                 out_line_shape.data(), 2);  // ndim = 2 because we convert a single row
       }

--- a/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
+++ b/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
@@ -163,6 +163,10 @@ DecodeResult LibTiffDecoderInstance::Decode(SampleView<CPUBackend> out, ImageSou
   auto tiff = detail::OpenTiff(in);
   auto info = detail::GetTiffInfo(tiff.get());
 
+  if (info.bit_depth != 8 && info.bit_depth != 16 && info.bit_depth != 32)
+    return {false, make_exception_ptr(std::logic_error(
+                      make_string("Unsupported bit depth: ", info.bit_depth)))};
+
   // TODO(skarpinski) Support palette images
   if (info.is_palette)
     return {false, make_exception_ptr(std::logic_error("Palette images are not yet supported"))};

--- a/dali/imgcodec/decoders/libtiff/tiff_libtiff_test.cc
+++ b/dali/imgcodec/decoders/libtiff/tiff_libtiff_test.cc
@@ -121,13 +121,13 @@ TYPED_TEST(LibTiffDecoderTest, GrayToRgb) {
 
   EXPECT_EQ(img.shape, TensorShape<-1>({ref.shape()[0], ref.shape()[1], 3}));
 
-  auto red = this->Crop(img.template to_static<3>(), {{0, 0, 0}, {img.shape[0], img.shape[1], 1}});
-  auto green = this->Crop(img.template to_static<3>(), {{0, 0, 1}, {img.shape[0], img.shape[1], 2}});
-  auto blue = this->Crop(img.template to_static<3>(), {{0, 0, 2}, {img.shape[0], img.shape[1], 3}});
+  auto r = this->Crop(img.template to_static<3>(), {{0, 0, 0}, {img.shape[0], img.shape[1], 1}});
+  auto g = this->Crop(img.template to_static<3>(), {{0, 0, 1}, {img.shape[0], img.shape[1], 2}});
+  auto b = this->Crop(img.template to_static<3>(), {{0, 0, 2}, {img.shape[0], img.shape[1], 3}});
 
-  this->AssertEqualSatNorm(red, ref);
-  this->AssertEqualSatNorm(green, ref);
-  this->AssertEqualSatNorm(blue, ref);
+  this->AssertEqualSatNorm(r, ref);
+  this->AssertEqualSatNorm(g, ref);
+  this->AssertEqualSatNorm(b, ref);
 }
 
 TYPED_TEST(LibTiffDecoderTest, MultichannelToRgb) {

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_test.cc
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_test.cc
@@ -59,7 +59,7 @@ auto gen_batch_input() {
   std::vector<std::string> image_names, ref_names;
   for (size_t i = 0; i < images.size(); i++) {
     image_names.push_back(join(img_dir, "0", images[i]) + ".jp2");
-    ref_names.push_back(join(ref_dir, images[i]) + ".npy");
+    ref_names.push_back(join(ref_dir, "0", images[i]) + ".npy");
   }
   return std::make_pair(image_names, ref_names);
 }
@@ -108,7 +108,7 @@ class NvJpeg2000DecoderTest : public NumpyDecoderTestBase<GPUBackend, OutputType
   void RunSingleTest(std::string image_name, std::string ref_name) {
     ImageBuffer image(join(img_dir, "0", images[0]) + ".jp2");
     auto decoded = this->Decode(&image.src, this->GetParams());
-    auto ref = this->ReadReferenceFrom(join(ref_dir, images[0]) + ".npy");
+    auto ref = this->ReadReferenceFrom(join(ref_dir, "0", images[0]) + ".npy");
     this->AssertEqualSatNorm(decoded, ref);
   }
 

--- a/dali/imgcodec/util/convert.cc
+++ b/dali/imgcodec/util/convert.cc
@@ -20,8 +20,6 @@
 #include "dali/kernels/common/utils.h"
 #include "dali/core/tensor_shape_print.h"
 
-#define IMG_CONVERT_TYPES uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, float, float16
-
 namespace dali {
 namespace imgcodec {
 
@@ -63,7 +61,7 @@ void Convert(SampleView<CPUBackend> out, TensorLayout out_layout, DALIImageType 
 
   auto UnsupportedType = [](const char *which_type, DALIDataType type_id) {
     DALI_FAIL(make_string("Unsupported ", which_type, " type: ", type_id,
-                          ListTypeNames<IMG_CONVERT_TYPES>()));
+                          ListTypeNames<IMGCODEC_TYPES>()));
   };
 
   TensorShape<> out_strides = kernels::GetStrides(out_shape);
@@ -76,8 +74,8 @@ void Convert(SampleView<CPUBackend> out, TensorLayout out_layout, DALIImageType 
     in_offset += in_strides_no_channel[d] * roi_start[d];
   }
 
-  TYPE_SWITCH(out.type(), type2id, Out, (IMG_CONVERT_TYPES),
-    TYPE_SWITCH(in.type(), type2id, In, (IMG_CONVERT_TYPES),
+  TYPE_SWITCH(out.type(), type2id, Out, (IMGCODEC_TYPES),
+    TYPE_SWITCH(in.type(), type2id, In, (IMGCODEC_TYPES),
       (Convert(out.mutable_data<Out>(), out_strides.data(), out_channel_dim, out_format,
                in.data<In>() + in_offset, in_strides.data(), in_channel_dim, in_format,
                out_shape.data(), ndim)),

--- a/dali/imgcodec/util/convert.h
+++ b/dali/imgcodec/util/convert.h
@@ -249,7 +249,7 @@ void Convert(Out *out, const int64_t *out_strides, int out_channel_dim, DALIImag
 /**
  * @brief Converts an image stored in `in` and stores it in `out`.
  *
-* The function converts data type (normalizing) and color space.
+ * The function converts data type (normalizing) and color space.
  * When roi_start or roi_end is empty, it is assumed to be the lower bound and upport bound
  * of the spatial extent. Channel dimension must not be included in ROI specification.
  */

--- a/dali/imgcodec/util/convert.h
+++ b/dali/imgcodec/util/convert.h
@@ -23,6 +23,9 @@
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/sample_view.h"
 #include "dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h"
+
+#define IMGCODEC_TYPES uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, float, float16
+
 namespace dali {
 namespace imgcodec {
 
@@ -246,7 +249,7 @@ void Convert(Out *out, const int64_t *out_strides, int out_channel_dim, DALIImag
 /**
  * @brief Converts an image stored in `in` and stores it in `out`.
  *
- * The function converts data type (normalizing) and color space.
+* The function converts data type (normalizing) and color space.
  * When roi_start or roi_end is empty, it is assumed to be the lower bound and upport bound
  * of the spatial extent. Channel dimension must not be included in ROI specification.
  */


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** (*non-breaking change which adds functionality*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

Original TIFF parser only supported 8-bit images. This PR adds support for 16- and 32-bit files.

## Additional information:

### Affected modules and functionalities:
Apart from changes in `tiff_libtiff.cc`, which was modified to support different input and output types and different bit-depths, the following things were changed:
- `LibTiffDecoderTypes` in `tiff_libtiff_test.cc` was turned into `TYPED_TEST_SUITE` and now tests on `uint8_t`, `uint16_t` and `uint32_t`.
- `IMG_CONVERT_TYPES`, defined in `convert.cc` was made public as `IMGCODEC_TYPES`.
- `Crop` in `decoder_test_helper.h` was fixed to allow cropping tensors of types other than `OutputType`

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
Tests require images from https://github.com/NVIDIA/DALI_extra/pull/98

- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2925
<!--- DALI-XXXX or NA --->
