### PR TITLE
ROI support for nvjpeg2k decoder

### DIFF
--- a/DALI_EXTRA_VERSION
+++ b/DALI_EXTRA_VERSION
@@ -1,2 +1,1 @@
-bb687385d4f9fbf8a2be9a74100fe1c99cc75841
-
+TODO

--- a/DALI_EXTRA_VERSION
+++ b/DALI_EXTRA_VERSION
@@ -1,1 +1,1 @@
-TODO
+bb687385d4f9fbf8a2be9a74100fe1c99cc75841

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
@@ -34,7 +34,7 @@ bool handle_decode_ret_status(nvjpeg2kStatus_t status, ImageSource *in) {
     DALI_FAIL("Unreachable");  // silence a warning
   }
 }
-} // namespace
+}  // namespace
 
 NvJpeg2000DecoderInstance::NvJpeg2000DecoderInstance(int device_id, ThreadPool *tp)
 : BatchParallelDecoderImpl(device_id, tp)
@@ -105,8 +105,8 @@ bool NvJpeg2000DecoderInstance::ParseJpeg2000Info(ImageSource *in, Context &ctx)
   return true;
 }
 
-nvjpeg2kImage_t NvJpeg2000DecoderInstance::PrepareOutputArea(uint8_t *out, 
-                                                             void **pixel_data, 
+nvjpeg2kImage_t NvJpeg2000DecoderInstance::PrepareOutputArea(uint8_t *out,
+                                                             void **pixel_data,
                                                              size_t *pitch_in_bytes,
                                                              int64_t output_offset_x,
                                                              int64_t output_offset_y,
@@ -135,7 +135,7 @@ bool NvJpeg2000DecoderInstance::DecodeJpeg2000(ImageSource *in, uint8_t *out, co
 
   if (!ctx.roi) {
     auto output_image = PrepareOutputArea(out, pixel_data, pitch_in_bytes, 0, 0, ctx);
-    auto ret = nvjpeg2kDecode(nvjpeg2k_handle_, ctx.nvjpeg2k_decode_state, 
+    auto ret = nvjpeg2kDecode(nvjpeg2k_handle_, ctx.nvjpeg2k_decode_state,
                               ctx.nvjpeg2k_stream, &output_image, ctx.cuda_stream);
     return handle_decode_ret_status(ret, in);
   } else {
@@ -186,7 +186,7 @@ bool NvJpeg2000DecoderInstance::DecodeJpeg2000(ImageSource *in, uint8_t *out, co
                                         &output_image,
                                         ctx.cuda_stream);
 
-          if (ret != NVJPEG2K_STATUS_SUCCESS) 
+          if (ret != NVJPEG2K_STATUS_SUCCESS)
             return handle_decode_ret_status(ret, in);
 
           CUDA_CALL(cudaEventRecord(per_tile_ctx.decode_event, ctx.cuda_stream));

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
@@ -24,7 +24,7 @@ namespace dali {
 namespace imgcodec {
 
 namespace {
-bool handle_decode_ret_status(nvjpeg2kStatus_t status, ImageSource *in) {
+bool check_status(nvjpeg2kStatus_t status, ImageSource *in) {
   if (status == NVJPEG2K_STATUS_SUCCESS) {
     return true;
   } else if (status == NVJPEG2K_STATUS_BAD_JPEG || status == NVJPEG2K_STATUS_JPEG_NOT_SUPPORTED) {
@@ -137,7 +137,7 @@ bool NvJpeg2000DecoderInstance::DecodeJpeg2000(ImageSource *in, uint8_t *out, co
     auto output_image = PrepareOutputArea(out, pixel_data, pitch_in_bytes, 0, 0, ctx);
     auto ret = nvjpeg2kDecode(nvjpeg2k_handle_, ctx.nvjpeg2k_decode_state,
                               ctx.nvjpeg2k_stream, &output_image, ctx.cuda_stream);
-    return handle_decode_ret_status(ret, in);
+    return check_status(ret, in);
   } else {
     // Decode tile by tile: nvjpeg2kDecodeImage seems to be bugged
     auto &image_info = ctx.image_info;
@@ -187,7 +187,7 @@ bool NvJpeg2000DecoderInstance::DecodeJpeg2000(ImageSource *in, uint8_t *out, co
                                         ctx.cuda_stream);
 
           if (ret != NVJPEG2K_STATUS_SUCCESS)
-            return handle_decode_ret_status(ret, in);
+            return check_status(ret, in);
 
           CUDA_CALL(cudaEventRecord(per_tile_ctx.decode_event, ctx.cuda_stream));
         }

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.h
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.h
@@ -143,17 +143,17 @@ class DLL_PUBLIC NvJpeg2000DecoderInstance : public BatchParallelDecoderImpl {
 
   /**
    * @brief Sets up nvjpeg2kImage_t, so it points to specific output area
-   * 
+   *
    * @param out memory image is decoded into
    * @param pixel_data memory allocated for nvjpeg2kImage_t::pixel_data
    * @param pitch_in_bytes memory allocated for nvjpeg2kImage_t::pitch_in_bytes
    * @param output_offset_x offset in output memory to decode into
    * @param output_offset_y offset in output memory to decode into
    * @param ctx decoding context
-   * @return nvjpeg2kImage_t 
+   * @return nvjpeg2kImage_t
    */
-  nvjpeg2kImage_t PrepareOutputArea(uint8_t *out, 
-                                    void **pixel_data, 
+  nvjpeg2kImage_t PrepareOutputArea(uint8_t *out,
+                                    void **pixel_data,
                                     size_t *pitch_in_bytes,
                                     int64_t output_offset_x,
                                     int64_t output_offset_y,

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_helper.h
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_helper.h
@@ -129,6 +129,20 @@ struct NvJpeg2kDecodeState : public UniqueHandle<nvjpeg2kDecodeState_t, NvJpeg2k
   }
 };
 
+struct NvJpeg2kDecodeParams : public UniqueHandle<nvjpeg2kDecodeParams_t, NvJpeg2kDecodeParams> {
+  DALI_INHERIT_UNIQUE_HANDLE(nvjpeg2kDecodeParams_t, NvJpeg2kDecodeParams);
+
+  NvJpeg2kDecodeParams() {
+    CUDA_CALL(nvjpeg2kDecodeParamsCreate(&handle_));
+  }
+
+  static constexpr nvjpeg2kDecodeParams_t null_handle() { return nullptr; }
+
+  static void DestroyHandle(nvjpeg2kDecodeParams_t handle) {
+    nvjpeg2kDecodeParamsDestroy(handle);
+  }
+};
+
 }  // namespace imgcodec
 
 template <>

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_test.cc
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_test.cc
@@ -65,7 +65,7 @@ struct ImageTestingData {
   std::string ref_path;
   ROI roi;
 
-  explicit ImageTestingData(std::string filename) 
+  explicit ImageTestingData(std::string filename)
   : img_path(join(img_dir, filename) + ".jp2")
   , ref_path(join(ref_dir, filename) + ".npy")
   , roi() {}

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_test.cc
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_test.cc
@@ -105,10 +105,10 @@ class NvJpeg2000DecoderTest : public NumpyDecoderTestBase<GPUBackend, OutputType
     return opts;
   }
 
-  void RunSingleTest(std::string image_name, std::string ref_name) {
-    ImageBuffer image(join(img_dir, "0", images[0]) + ".jp2");
-    auto decoded = this->Decode(&image.src, this->GetParams());
-    auto ref = this->ReadReferenceFrom(join(ref_dir, "0", images[0]) + ".npy");
+  void RunSingleTest(std::string image_name, std::string ref_name, ROI roi = {}) {
+    ImageBuffer image(image_name);
+    auto decoded = this->Decode(&image.src, this->GetParams(), roi);
+    auto ref = this->ReadReferenceFrom(ref_name);
     this->AssertEqualSatNorm(decoded, ref);
   }
 

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_test.cc
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_test.cc
@@ -39,6 +39,7 @@ std::string join(Args... args) {
 
 std::vector<uint8_t> read_file(const std::string &filename) {
     std::ifstream stream(filename, std::ios::binary);
+    assert(stream.is_open());
     return {std::istreambuf_iterator<char>(stream), std::istreambuf_iterator<char>()};
 }
 
@@ -58,7 +59,10 @@ const std::vector<std::string> images = {"0/cat-1245673_640", "0/cat-2184682_640
 
 const std::vector<std::pair<std::string, ROI>> roi_images = {
   {"0/cat-1245673_640", {{17, 33}, {276, 489}}},
-  {"2/tiled-cat-1046544_640", {{178, 220}, {456, 290}}}};
+  {"2/tiled-cat-1046544_640", {{178, 220}, {456, 290}}},
+  {"2/tiled-cat-111793_640", {{9, 317}, {58, 325}}},
+  {"2/tiled-cat-3113513_640", {{2, 1}, {200, 600}}},
+};
 
 struct ImageTestingData {
   std::string img_path;


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:
Adding ROI support for nvjpeg2k decoder, by using the library's decode parameters.
It seems that the `nvjpeg2kDecodeImage` function is bugged, so decoding is done via `nvjpeg2kDecodeTile`, tile by tile.

## Additional information:

### Affected modules and functionalities:
N/A

### Key points relevant for the review:
Decoding tile by tile in `NvJpeg2000DecoderInstance::DecodeJpeg2000`
Reviewing by commits might be easier.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
