### PR TITLE
Enable per-sample `fill_value` argument in Erase operator 

### DIFF
--- a/dali/kernels/erase/erase_gpu.h
+++ b/dali/kernels/erase/erase_gpu.h
@@ -73,7 +73,7 @@ template <typename T, int ndim>
 struct erase_sample_desc {
   const T * __restrict__ in = nullptr;
   T * __restrict__ out = nullptr;
-  const T* __restrict__ fill_values = nullptr;
+  const T* fill_values = nullptr;
   span<const ibox<ndim>> erase_regions = {};
   ivec<ndim> sample_shape;
   ivec<ndim> sample_stride;

--- a/dali/kernels/erase/erase_gpu.h
+++ b/dali/kernels/erase/erase_gpu.h
@@ -17,6 +17,7 @@
 
 #include <vector>
 
+#include "dali/core/convert.h"
 #include "dali/core/dev_array.h"
 #include "dali/core/format.h"
 #include "dali/core/geom/box.h"
@@ -71,6 +72,7 @@ template <typename T, int ndim>
 struct erase_sample_desc {
   const T * __restrict__ in = nullptr;
   T * __restrict__ out = nullptr;
+  const T* __restrict__ fill_values = nullptr;
   span<const ibox<ndim>> erase_regions = {};
   ivec<ndim> sample_shape;
   ivec<ndim> sample_stride;
@@ -118,7 +120,7 @@ constexpr bool is_outer_loops(int ndim, int current_dim, int channel_dim) {
  */
 template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
 __device__ std::enable_if_t<is_outer_loops(ndim, current_dim, channel_dim)>
-erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill_values,
+erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region,
               span<ibox<ndim>> erase_regions = {}, ivec<ndim> coordinate = {},
               int64_t offset_base = 0) {
   constexpr int d = current_dim;
@@ -126,7 +128,7 @@ erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill
   for (int i = region.lo[d]; i < boundary; i++) {
     coordinate[d] = i;
     int64_t offset = offset_base + i * sample.sample_stride[d];
-    erase_generic<Worker, channel_dim, d + 1>(sample, region, fill_values, erase_regions,
+    erase_generic<Worker, channel_dim, d + 1>(sample, region, erase_regions,
                                               coordinate, offset);
   }
 }
@@ -141,7 +143,7 @@ erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill
  */
 template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
 __device__ std::enable_if_t<ndim - current_dim == 2 && channel_dim < ndim - 2>
-erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill_values,
+erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region,
               span<ibox<ndim>> erase_regions = {}, ivec<ndim> coordinate = {},
               int64_t offset_base = 0) {
   constexpr int d = current_dim;
@@ -156,8 +158,7 @@ erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill
     for (int x = region.lo[dX] + threadIdx.x; x < boundary_x; x += blockDim.x) {
       coordinate[dX] = x;
       int64_t offset_x = offset_y + x * sample.sample_stride[dX];
-      Worker::template copy_or_erase<channel_dim>(sample, erase_regions, coordinate, offset_x,
-                                                  fill_values);
+      Worker::template copy_or_erase<channel_dim>(sample, erase_regions, coordinate, offset_x);
     }
   }
 }
@@ -176,7 +177,7 @@ erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill
  */
 template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
 __device__ std::enable_if_t<ndim - current_dim == 3 && channel_dim >= ndim - 2>
-erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill_values,
+erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region,
               span<ibox<ndim>> erase_regions = {}, ivec<ndim> coordinate = {},
               int64_t offset_base = 0) {
   constexpr int d = current_dim;
@@ -208,7 +209,7 @@ erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill
           region.lo[dC] <= coordinate[dC] && coordinate[dC] < boundary_c) {
         int64_t offset_x = offset_y + flat;
         Worker::template copy_or_erase<channel_dim>(sample, erase_regions, coordinate,
-                                                             offset_x, fill_values);
+                                                    offset_x);
       }
     }
   }
@@ -219,7 +220,7 @@ erase_generic(erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill
  */
 template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
 __device__ std::enable_if_t<ndim == 1> erase_generic(erase_sample_desc<T, ndim> sample,
-    ibox<ndim> region, span<T> fill_values, span<ibox<ndim>> erase_regions = {},
+    ibox<ndim> region, span<ibox<ndim>> erase_regions = {},
     ivec<ndim> coordinate = {}, int64_t offset_base = 0) {
   constexpr int d = current_dim;
   int boundary = ::min(region.hi[d], sample.sample_shape[d]);
@@ -228,7 +229,7 @@ __device__ std::enable_if_t<ndim == 1> erase_generic(erase_sample_desc<T, ndim> 
        idx += blockDim.y * blockDim.x) {
     coordinate[d] = idx;
     Worker::template copy_or_erase<channel_dim>(sample, erase_regions, coordinate,
-                                                offset_base + idx, fill_values);
+                                                offset_base + idx);
   }
 }
 
@@ -239,7 +240,7 @@ __device__ std::enable_if_t<ndim == 1> erase_generic(erase_sample_desc<T, ndim> 
  */
 template <typename Worker, int channel_dim, int current_dim = 0, typename T, int ndim>
 __device__ std::enable_if_t<(ndim == 2 && current_dim == 0 && channel_dim >= 0)> erase_generic(
-    erase_sample_desc<T, ndim> sample, ibox<ndim> region, span<T> fill_values,
+    erase_sample_desc<T, ndim> sample, ibox<ndim> region,
     span<ibox<ndim>> erase_regions = {}, ivec<ndim> coordinate = {}, int64_t offset_base = 0) {
   constexpr int d = current_dim;
   constexpr int dC = d + 1;
@@ -252,8 +253,7 @@ __device__ std::enable_if_t<(ndim == 2 && current_dim == 0 && channel_dim >= 0)>
     int64_t offset = offset_base + idx * sample.sample_stride[d];
     for (int c = region.lo[dC]; c < boundary_c; c++) {
       coordinate[dC] = c;
-      Worker::template copy_or_erase<channel_dim>(sample, erase_regions, coordinate, offset + c,
-                                                  fill_values);
+      Worker::template copy_or_erase<channel_dim>(sample, erase_regions, coordinate, offset + c);
     }
   }
 }
@@ -263,10 +263,9 @@ struct do_copy {
   template <int channel_dim, typename T, int ndim>
   __device__ static void copy_or_erase(erase_sample_desc<T, ndim> sample,
                                        span<ibox<ndim>> erase_regions, ivec<ndim> coordinate,
-                                       int64_t offset, span<T> fill_values) {
+                                       int64_t offset) {
     (void)erase_regions;
     (void)coordinate;
-    (void)fill_values;
     sample.out[offset] = sample.in[offset];
   }
 };
@@ -275,12 +274,12 @@ struct do_erase {
   template <int channel_dim, typename T, int ndim>
   __device__ static void copy_or_erase(erase_sample_desc<T, ndim> sample,
                                        span<ibox<ndim>> erase_regions, ivec<ndim> coordinate,
-                                       int64_t offset, span<T> fill_values) {
+                                       int64_t offset) {
     (void)erase_regions;
     if (channel_dim == -1) {
-      sample.out[offset] = fill_values[0];
+      sample.out[offset] = sample.fill_values[0];
     } else {
-      sample.out[offset] = fill_values[coordinate[channel_dim]];
+      sample.out[offset] = sample.fill_values[coordinate[channel_dim]];
     }
   }
 };
@@ -289,15 +288,10 @@ struct do_copy_or_erase {
   template <int channel_dim, typename T, int ndim>
   __device__ static void copy_or_erase(erase_sample_desc<T, ndim> sample,
                                        span<ibox<ndim>> erase_regions, ivec<ndim> coordinate,
-                                       int64_t offset, span<T> fill_values) {
-    auto fill_value = channel_dim == -1 ? fill_values[0] : fill_values[coordinate[channel_dim]];
-    copy_or_erase<channel_dim>(sample, erase_regions, coordinate, offset, fill_value);
-  }
+                                       int64_t offset) {
+    auto fill_value =
+        channel_dim == -1 ? sample.fill_values[0] : sample.fill_values[coordinate[channel_dim]];
 
-  template <int channel_dim, typename T, int ndim>
-  __device__ static void copy_or_erase(erase_sample_desc<T, ndim> sample,
-                                       span<ibox<ndim>> erase_regions, ivec<ndim> coordinate,
-                                       int64_t offset, T fill_value) {
     bool copy = true;
     for (auto &region : erase_regions) {
       if (region.contains(coordinate)) {
@@ -310,7 +304,7 @@ struct do_copy_or_erase {
 
 template <int channel_dim = -1, typename T, int ndim = 2>
 __global__ void erase_gpu_impl(const erase_sample_desc<T, ndim> *samples,
-                               ivec<ndim> region_shape, span<T> fill_values) {
+                               ivec<ndim> region_shape) {
   const auto region_idx = blockIdx.x;
   const auto sample_idx = blockIdx.y;
 
@@ -348,15 +342,15 @@ __global__ void erase_gpu_impl(const erase_sample_desc<T, ndim> *samples,
 
   if (total_erase_regions == 0) {
     // do a full copy
-    erase_generic<do_copy, channel_dim>(sample, region_box, fill_values);
+    erase_generic<do_copy, channel_dim>(sample, region_box);
     return;
   } else if (is_fully_erased) {
     // do a total erase
-    erase_generic<do_erase, channel_dim>(sample, region_box, fill_values,
+    erase_generic<do_erase, channel_dim>(sample, region_box,
                                          make_span(erase_regions, total_erase_regions));
     return;
   } else {
-    erase_generic<do_copy_or_erase, channel_dim>(sample, region_box, fill_values,
+    erase_generic<do_copy_or_erase, channel_dim>(sample, region_box,
                                                  make_span(erase_regions, total_erase_regions));
   }
 }
@@ -377,48 +371,35 @@ struct EraseGpu {
       "Channel dim can either be ignored (for channel_dim = -1) or must be in [0, ndim) interval.");
   using sample_t = erase_sample_desc<T, ndim>;
 
-  KernelRequirements Setup(KernelContext &context,
-                           const InListGPU<T, ndim> &in,
-                           const InListGPU<ibox<ndim>, 1> &erased_regions,
-                           span<const T> fill_values = {}) {
-    const int num_samples = in.num_samples();
+  KernelRequirements Setup(KernelContext &context, const InListGPU<T, ndim> &in) {
+    KernelRequirements req;
+    req.output_shapes = {in.shape};
+    return req;
+  }
 
-    if (channel_dim == -1) {
-      DALI_ENFORCE(fill_values.size() == 1 || fill_values.size() == 0,
-                   make_string("Kernel is unaware of channel dimension, exactly 0 or 1 fill value "
-                               "is expected, got: ",
-                               fill_values.size(), "."));
-    } else {
-      // ensure that dim `channel_dim` in every sample matches fill_values.size();
-      for (int i = 0; i < num_samples; i++) {
-        DALI_ENFORCE(in.shape.tensor_shape_span(i)[channel_dim] == fill_values.size() ||
-                         fill_values.size() == 1 || fill_values.size() == 0,
-                     make_string("Channel dimension in all samples must match the number "
-                                 "of elements provided in `fill_values` or there need to be "
-                                 "exactly 0 or 1 fill values provied. Sample ",
-                                 i, " has ", in.shape.tensor_shape_span(i)[channel_dim],
-                                 " elements, but there are ", fill_values.size(), " fill values."));
+  template <typename TLV>
+  int GetNumFillValues(TLV fill_values, const InListGPU<T, ndim> &in) {
+    int nfill_values = 0;
+    int num_samples = fill_values.num_samples();
+    for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
+      if (nfill_values == 0) {
+        nfill_values = fill_values[sample_idx].shape[0];
+      } else {
+        if (nfill_values != fill_values[sample_idx].shape[0])
+          throw std::invalid_argument(
+              "The number of fill values should be the same for all the samples");
       }
     }
 
-    KernelRequirements req;
-
-    ScratchpadEstimator se;
-
-    se.add<mm::memory_kind::pinned, sample_t>(num_samples);
-    se.add<mm::memory_kind::device, sample_t>(num_samples);
-    if (channel_dim >= 0) {
-      int num_channels = in.shape.tensor_shape_span(0)[channel_dim];
-      se.add<mm::memory_kind::pinned, T>(num_channels);
-      se.add<mm::memory_kind::device, T>(num_channels);
-    } else {
-      se.add<mm::memory_kind::pinned, T>(1);
-      se.add<mm::memory_kind::device, T>(1);
+    if (nfill_values > 1) {
+      for (int sample_idx = 0; sample_idx < num_samples; sample_idx++) {
+        if (nfill_values != in.shape.tensor_shape_span(sample_idx)[channel_dim]) {
+          throw std::invalid_argument(
+              "The number of fill values should match the number of channels in the output slice");
+        }
+      }
     }
-
-    req.output_shapes = {in.shape};
-    req.scratch_sizes = se.sizes;
-    return req;
+    return nfill_values;
   }
 
   /**
@@ -434,18 +415,13 @@ struct EraseGpu {
            OutListGPU<T, ndim> &out,
            const InListGPU<T, ndim> &in,
            const InListGPU<ibox<ndim>, 1> &erased_regions,
-           span<const T> fill_values = {}) {
+           const InListGPU<T, 1> &fill_values) {
     auto stream = ctx.gpu.stream;  // MAYBE some runtime check if it's not used?
     const int num_samples = in.num_samples();
 
-    DeviceArray<T, 1> default_fill = {0};
-
-    if (fill_values.empty()) {
-      fill_values = make_span(default_fill);
-    }
-
-    const int num_fill_values = channel_dim >= 0 ? in.shape.tensor_shape_span(0)[channel_dim] : 1;
-
+    int nfill_values = GetNumFillValues(fill_values, in);
+    DALI_ENFORCE(nfill_values > 0);
+  
     ivec<ndim> region_dim;
 
     // Prepare Dim {2, 2, ..., 2, 64, 64}
@@ -481,7 +457,7 @@ struct EraseGpu {
 
 
     int max_regions = 1;
-    for (int i = 0; i < in.num_samples(); i++) {
+    for (int i = 0; i < num_samples; i++) {
       auto region_cover = div_ceil(to_ivec(in.shape[i]), region_dim);
       auto total_regions = volume(region_cover);
       // std::max was complaining
@@ -490,12 +466,9 @@ struct EraseGpu {
     dim3 grid_dim = {(uint32_t)max_regions, (uint32_t)num_samples, 1};
     dim3 block_dim = {32, 32, 1};  // fixed block dim
 
-    auto* sample_desc_cpu = ctx.scratchpad->AllocatePinned<sample_t>(num_samples);
-    auto* fill_values_cpu = ctx.scratchpad->AllocatePinned<T>(num_fill_values);
+    DeviceArray<T, 1> default_fill_value = {0};
 
-    for (int i = 0; i < num_fill_values; i++) {
-      fill_values_cpu[i] = fill_values.size() == 1 ? fill_values[0] : fill_values[i];
-    }
+    auto* sample_desc_cpu = ctx.scratchpad->AllocatePinned<sample_t>(num_samples);
 
     for (int i = 0; i < num_samples; i++) {
       auto &sample = sample_desc_cpu[i];
@@ -507,19 +480,72 @@ struct EraseGpu {
         sample.sample_shape[dim] = in.tensor_shape_span(i)[dim];
       }
       sample.sample_stride = GetStrides(sample.sample_shape);
+      sample.fill_values = fill_values[i].data;
+      DALI_ENFORCE(fill_values.shape.tensor_shape_span(i)[0] == nfill_values);
     }
 
-    sample_t *sample_desc_gpu;
-    T *fill_values_gpu;
-    std::tie(sample_desc_gpu, fill_values_gpu) =
-      ctx.scratchpad->ToContiguousGPU(stream, make_cspan(sample_desc_cpu, num_samples),
-                                      make_cspan(fill_values_cpu, num_fill_values));
-    auto fill_values_span = make_span(fill_values_gpu, num_fill_values);
+    sample_t *sample_desc_gpu =
+        ctx.scratchpad->ToGPU(ctx.gpu.stream, make_cspan(sample_desc_cpu, num_samples));
 
     erase_gpu_impl<channel_dim><<<grid_dim, block_dim, 0, stream>>>(
-        sample_desc_gpu, region_dim, fill_values_span);
+        sample_desc_gpu, region_dim);
+  }
+
+  void Run(KernelContext &ctx,
+           OutListGPU<T, ndim> &out,
+           const InListGPU<T, ndim> &in,
+           const InListGPU<ibox<ndim>, 1> &erased_regions,
+           span<const float> fill_values) {
+    TensorListView<StorageCPU, const float, 1> fill_values_tlv;
+    fill_values_tlv.resize(in.num_samples());
+    for (int i = 0; i < in.num_samples(); i++) {
+      fill_values_tlv.data[i] = fill_values.data();
+      fill_values_tlv.shape.tensor_shape_span(i)[0] = fill_values.size();
+    }
+    Run(ctx, out, in, erased_regions, fill_values_tlv);
+  }
+
+  template <typename T2>
+  void Run(KernelContext &ctx,
+           OutListGPU<T, ndim> &out,
+           const InListGPU<T, ndim> &in,
+           const InListGPU<ibox<ndim>, 1> &erased_regions,
+           const InListCPU<T2, 1> &fill_values) {
+    int num_samples = fill_values.size();
+    int nfill_values = GetNumFillValues(fill_values, in);
+    bool default_fill_values = false;
+    if (nfill_values == 0) {
+      nfill_values = 1;
+      default_fill_values = true;
+    }
+
+    T *fill_values_cpu = ctx.scratchpad->AllocatePinned<T>(num_samples * nfill_values);
+    for (int i = 0; i < num_samples; i++) {
+      if (default_fill_values) {
+        assert(nfill_values == 1);
+        fill_values_cpu[i] = T{0};
+      } else {
+        auto *sample_fill_values = fill_values_cpu + i * nfill_values;
+        for (int d = 0; d < nfill_values; d++)
+          sample_fill_values[d] = ConvertSat<T>(fill_values[i].data[d]);
+      }
+    }
+
+    T *fill_values_gpu = ctx.scratchpad->ToGPU(
+        ctx.gpu.stream, make_cspan(fill_values_cpu, num_samples * nfill_values));
+    CUDA_CALL(cudaGetLastError());
+
+    TensorListView<StorageGPU, const T, 1> fill_values_gpu_tlv;
+    fill_values_gpu_tlv.resize(num_samples);
+    fill_values_gpu_tlv.shape = uniform_list_shape(num_samples, TensorShape<1>{nfill_values});
+    for (int i = 0; i < num_samples; i++) {
+      fill_values_gpu_tlv.data[i] = fill_values_gpu + i * nfill_values;
+    }
+
+    Run(ctx, out, in, erased_regions, fill_values_gpu_tlv);
   }
 };
+
 
 }  // namespace kernels
 }  // namespace dali

--- a/dali/kernels/erase/erase_gpu_test.cu
+++ b/dali/kernels/erase/erase_gpu_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -195,7 +195,7 @@ struct EraseGpuKernelTest :
 
     auto in_view = input_.gpu();
 
-    auto req = kernel.Setup(ctx, in_view, regions_gpu, make_span(fill_values_));
+    auto req = kernel.Setup(ctx, in_view);
 
     auto out_view = output_.gpu();
 

--- a/dali/operators/generic/erase/erase.cc
+++ b/dali/operators/generic/erase/erase.cc
@@ -129,7 +129,7 @@ refer to dimensions H (height) and W (width) in that particular order.
 Might be specified as one value (for example, 0) or a multi-channel value
 (for example, (200, 210, 220)). If a multi-channel fill value is provided, the input layout should
 contain a channel dimension ``C``.)code",
-    std::vector<float>{0, })
+    std::vector<float>{0, }, true)
   .AddOptionalArg("normalized_anchor",
     R"code(Determines whether the anchor argument should be interpreted as normalized
 (range [0.0, 1.0]) or absolute coordinates.
@@ -167,14 +167,14 @@ class EraseImplCpu : public OpImplBase<CPUBackend> {
    * @param spec  Pointer to a persistent OpSpec object,
    *              which is guaranteed to be alive for the entire lifetime of this object
    */
-  explicit EraseImplCpu(const OpSpec *spec) : spec_(*spec), fill_values_("fill_values", *spec) {}
+  explicit EraseImplCpu(const OpSpec *spec) : spec_(*spec), fill_value_("fill_value", *spec) {}
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<CPUBackend> &ws) override;
   void RunImpl(workspace_t<CPUBackend> &ws) override;
 
  private:
   const OpSpec &spec_;
-  ArgValue<float, 1> fill_values_;
+  ArgValue<float, 1> fill_value_;
   std::vector<int> axes_;
   std::vector<kernels::EraseArgs<T, Dims>> args_;
   kernels::KernelManager kmgr_;
@@ -189,7 +189,7 @@ bool EraseImplCpu<T, Dims>::SetupImpl(std::vector<OutputDesc> &output_desc,
   auto shape = input.shape();
   int nsamples = input.num_samples();
 
-  args_ = detail::GetEraseArgs<T, Dims>(spec_, ws, fill_values_, shape, layout);
+  args_ = detail::GetEraseArgs<T, Dims>(spec_, ws, fill_value_, shape, layout);
 
   kmgr_.Resize<EraseKernel>(nsamples);
   // the setup step is not necessary for this kernel (output and input shapes are the same)

--- a/dali/operators/generic/erase/erase.cc
+++ b/dali/operators/generic/erase/erase.cc
@@ -167,13 +167,14 @@ class EraseImplCpu : public OpImplBase<CPUBackend> {
    * @param spec  Pointer to a persistent OpSpec object,
    *              which is guaranteed to be alive for the entire lifetime of this object
    */
-  explicit EraseImplCpu(const OpSpec *spec) : spec_(*spec) {}
+  explicit EraseImplCpu(const OpSpec *spec) : spec_(*spec), fill_values_("fill_values", *spec) {}
 
   bool SetupImpl(std::vector<OutputDesc> &output_desc, const workspace_t<CPUBackend> &ws) override;
   void RunImpl(workspace_t<CPUBackend> &ws) override;
 
  private:
   const OpSpec &spec_;
+  ArgValue<float, 1> fill_values_;
   std::vector<int> axes_;
   std::vector<kernels::EraseArgs<T, Dims>> args_;
   kernels::KernelManager kmgr_;
@@ -188,7 +189,7 @@ bool EraseImplCpu<T, Dims>::SetupImpl(std::vector<OutputDesc> &output_desc,
   auto shape = input.shape();
   int nsamples = input.num_samples();
 
-  args_ = detail::GetEraseArgs<T, Dims>(spec_, ws, shape, layout);
+  args_ = detail::GetEraseArgs<T, Dims>(spec_, ws, fill_values_, shape, layout);
 
   kmgr_.Resize<EraseKernel>(nsamples);
   // the setup step is not necessary for this kernel (output and input shapes are the same)

--- a/dali/operators/generic/erase/erase.cu
+++ b/dali/operators/generic/erase/erase.cu
@@ -46,7 +46,7 @@ class EraseImplGpu : public OpImplBase<GPUBackend> {
    * @param spec  Pointer to a persistent OpSpec object,
    *              which is guaranteed to be alive for the entire lifetime of this object
    */
-  explicit EraseImplGpu(const OpSpec *spec) : spec_(*spec), fill_values_{"fill_values", *spec} {
+  explicit EraseImplGpu(const OpSpec *spec) : spec_(*spec), fill_value_arg_{"fill_value", *spec} {
     kmgr_.Resize<EraseKernel>(1);
   }
 
@@ -59,9 +59,10 @@ class EraseImplGpu : public OpImplBase<GPUBackend> {
 
     auto in_view = view<const T, Dims>(input);
     kmgr_.Initialize<EraseKernel>();
-    ctx_.gpu.stream = ws.stream();
+    kernels::KernelContext ctx;
+    ctx.gpu.stream = ws.stream();
     auto regions_view = view<kernels::ibox<Dims>, 1>(regions_gpu_);
-    kmgr_.Setup<EraseKernel>(0, ctx_, in_view);
+    kmgr_.Setup<EraseKernel>(0, ctx, in_view);
 
     output_desc.resize(1);
     output_desc[0] = {shape, input.type()};
@@ -73,15 +74,24 @@ class EraseImplGpu : public OpImplBase<GPUBackend> {
     auto &output_ref = ws.template Output<GPUBackend>(0);
     output_ref.SetLayout(input_ref.GetLayout());
     auto input = view<const T, Dims>(input_ref);
+    int nsamples = input.num_samples();
     auto output = view<T, Dims>(output_ref);
     auto regions_view = view<kernels::ibox<Dims>, 1>(regions_gpu_);
-    kmgr_.Run<EraseKernel>(0, ctx_, output, input, regions_view, fill_values_.get());
+    kernels::KernelContext ctx;
+    ctx.gpu.stream = ws.stream();
+
+    if (!fill_value_arg_) {  // default fill values
+      kmgr_.Run<EraseKernel>(0, ctx, output, input, regions_view);
+    } else {
+      auto fill_value_gpu = view<const T, 1>(fill_value_gpu_);
+      kmgr_.Run<EraseKernel>(0, ctx, output, input, regions_view, fill_value_gpu);
+    }
   }
 
   void AcquireArgs(const DeviceWorkspace &ws, TensorListShape<> in_shape,
                    TensorLayout in_layout) {
     auto curr_batch_size = ws.GetInputBatchSize(0);
-    auto args = detail::GetEraseArgs<T, Dims>(spec_, ws, fill_values_, in_shape, in_layout);
+    auto args = detail::GetEraseArgs<T, Dims>(spec_, ws, fill_value_arg_, in_shape, in_layout);
     auto regions_shape = TensorListShape<1>(curr_batch_size);
     for (int i = 0; i < curr_batch_size; ++i) {
       auto n_regions = static_cast<int>(args[i].rois.size());
@@ -99,16 +109,50 @@ class EraseImplGpu : public OpImplBase<GPUBackend> {
       }
     }
     regions_gpu_.Copy(regions_cpu, ws.stream());
+
+    auto read_fill_value = [&]() {
+      int nfill_value = fill_value_arg_[0].shape[0];  // uniform shape already enforced
+      int nchannels = channel_dim >= 0 ? in_shape.tensor_shape_span(0)[channel_dim] : 1;
+      if (nchannels != nfill_value && nfill_value > 1) {
+        throw std::invalid_argument(make_string(
+            "Expected as many fill values as the number of channels. nchannels=", nchannels,
+            ", nfill_value=", nfill_value));
+      }
+
+      fill_value_cpu_.Resize(uniform_list_shape<1>(curr_batch_size, TensorShape<1>{nfill_value}),
+                              type2id<T>::value);
+
+      auto fill_value_tlv = view<T, 1>(fill_value_cpu_);
+      for (int i = 0; i < curr_batch_size; ++i) {
+        auto fill_value_tv = fill_value_tlv[i];
+        auto fill_value_arg_tv = fill_value_arg_[i];
+        for (int c = 0; c < nfill_value; c++) {
+          fill_value_tv.data[c] = ConvertSat<T>(fill_value_arg_tv.data[nfill_value > 1 ? c : 0]);
+        }
+      }
+      fill_value_gpu_.Copy(fill_value_cpu_, ws.stream());
+    };
+
+    if (fill_value_arg_.HasArgumentInput()) {
+      read_fill_value();
+    } else if (fill_value_arg_ && !constant_fill_value_cpu_read_) {
+      // If constant fill values, only read once, next time reuse
+      read_fill_value();
+      constant_fill_value_cpu_read_ = true;
+    }
   }
 
  private:
   const OpSpec &spec_;
-  ArgValue<float, 1> fill_values_;
+  ArgValue<float, 1> fill_value_arg_;
   std::vector<int> axes_;
   std::vector<kernels::EraseArgs<T, Dims>> args_;
   TensorList<GPUBackend> regions_gpu_;
+  TensorList<GPUBackend> fill_value_cpu_;
+  TensorList<GPUBackend> fill_value_gpu_;
   kernels::KernelManager kmgr_;
-  kernels::KernelContext ctx_;
+
+  bool constant_fill_value_cpu_read_ = false;
 };
 
 template <>

--- a/dali/operators/generic/erase/erase_utils.h
+++ b/dali/operators/generic/erase/erase_utils.h
@@ -26,6 +26,7 @@
 #include "dali/kernels/erase/erase_args.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/operator/arg_helper.h"
 
 namespace dali {
 
@@ -51,6 +52,7 @@ static SmallVector<int, 6> GetAxes(const OpSpec &spec, TensorLayout layout) {
 template <typename T, int Dims>
 std::vector<kernels::EraseArgs<T, Dims>> GetEraseArgs(const OpSpec &spec,
                                                       const ArgumentWorkspace &ws,
+                                                      ArgValue<float, 1> &fill_values,
                                                       TensorListShape<> in_shape,
                                                       TensorLayout in_layout) {
   int nsamples = in_shape.num_samples();
@@ -81,11 +83,8 @@ std::vector<kernels::EraseArgs<T, Dims>> GetEraseArgs(const OpSpec &spec,
 
   bool centered_anchor = spec.GetArgument<bool>("centered_anchor");
 
-  auto fill_value = spec.template GetRepeatedArgument<float>("fill_value");
+  fill_values.Acquire(spec, ws, nsamples);
   auto channels_dim = in_layout.find('C');
-  DALI_ENFORCE(channels_dim >= 0 || fill_value.size() <= 1,
-    "If a multi channel fill value is provided, the input layout must have a 'C' dimension");
-
   auto axes = detail::GetAxes(spec, in_layout);
   int naxes = axes.size();
   assert(naxes > 0);
@@ -94,6 +93,15 @@ std::vector<kernels::EraseArgs<T, Dims>> GetEraseArgs(const OpSpec &spec,
   out.resize(nsamples);
 
   for (int i = 0; i < nsamples; i++) {
+    SmallVector<T, 3> fill_values_v;
+    fill_values_v.resize(fill_values[i].shape[0]);
+    for (int k = 0; k < fill_values[i].shape[0]; k++) {
+      fill_values_v[k] = fill_values[i].data[k];
+    }
+
+    DALI_ENFORCE(channels_dim >= 0 || fill_values_v.size() <= 1,
+      "If a multi channel fill value is provided, the input layout must have a 'C' dimension");
+
     if (has_tensor_roi_anchor) {
       auto anchor = view<const float>(ws.ArgumentInput("anchor")[i]);
       assert(anchor.shape.num_elements() > 0);
@@ -119,7 +127,7 @@ std::vector<kernels::EraseArgs<T, Dims>> GetEraseArgs(const OpSpec &spec,
     args.rois.reserve(nregions);
     for (int roi_idx = 0; roi_idx < nregions; roi_idx++) {
       typename kernels::EraseArgs<T, Dims>::ROI roi;
-      roi.fill_values = fill_value;
+      roi.fill_values = fill_values_v;
       roi.channels_dim = channels_dim;
       for (int d = 0; d < Dims; d++) {
         roi.anchor[d] = 0;

--- a/dali/test/python/operator/test_erase.py
+++ b/dali/test/python/operator/test_erase.py
@@ -31,6 +31,14 @@ class ErasePipeline(Pipeline):
         self.layout = layout
         self.iterator = iterator
         self.inputs = ops.ExternalSource()
+
+        if isinstance(fill_value, RandomDataIterator):
+            self.fill_value_iterator = fill_value
+            self.fill_value_inputs = ops.ExternalSource()
+            fill_value = None
+        else:
+            self.fill_value_iterator = None
+
         self.erase = ops.Erase(device=self.device,
                                anchor=anchor,
                                shape=shape,
@@ -43,12 +51,19 @@ class ErasePipeline(Pipeline):
     def define_graph(self):
         self.data = self.inputs()
         random_data = self.data.gpu() if self.device == 'gpu' else self.data
-        out = self.erase(random_data)
+        if self.fill_value_iterator is not None:
+            self.fill_value_data = self.fill_value_inputs()
+            out = self.erase(random_data, fill_value=self.fill_value_data)
+        else:
+            out = self.erase(random_data)
         return out
 
     def iter_setup(self):
         data = self.iterator.next()
         self.feed_input(self.data, data, layout=self.layout)
+        if self.fill_value_iterator is not None:
+            fill_value_data = self.fill_value_iterator.next()
+            self.feed_input(self.fill_value_data, fill_value_data)
 
 
 def get_axes(layout, axis_names):
@@ -87,7 +102,7 @@ def erase_func(anchor, shape, axis_names, axes, layout, fill_value, image):
     if not axes:
         axes = get_axes(layout, axis_names)
 
-    if not fill_value:
+    if fill_value is None:
         fill_value = 0
 
     roi_starts, roi_ends = get_regions(image.shape, axes, anchor, shape)
@@ -119,31 +134,53 @@ class ErasePythonPipeline(Pipeline):
         self.inputs = ops.ExternalSource()
         self.data_layout = data_layout
 
-        function = partial(erase_func, anchor, shape, axis_names, axes, data_layout, fill_value)
+        if isinstance(fill_value, RandomDataIterator):
+            self.fill_value_iterator = fill_value
+            self.fill_value_inputs = ops.ExternalSource()
+            fill_value = None
+            function = partial(erase_func, anchor, shape, axis_names, axes, data_layout)
+        else:
+            self.fill_value_iterator = None
+            function = partial(erase_func, anchor, shape, axis_names, axes, data_layout, fill_value)
 
         self.erase = ops.PythonFunction(function=function, output_layouts=data_layout)
 
     def define_graph(self):
         self.data = self.inputs()
-        out = self.erase(self.data)
+        if self.fill_value_iterator is not None:
+            self.fill_value_data = self.fill_value_inputs()
+            out = self.erase(self.fill_value_data, self.data)
+        else:
+            out = self.erase(self.data)
         return out
 
     def iter_setup(self):
         data = self.iterator.next()
-        self.feed_input(self.data, data, layout=self.data_layout)
+        self.feed_input(self.data, data)
+        if self.fill_value_iterator is not None:
+            fill_value_data = self.fill_value_iterator.next()
+            self.feed_input(self.fill_value_data, fill_value_data)
 
 
 def check_operator_erase_vs_python(device, batch_size, input_shape,
                                    anchor, shape, axis_names, axes, input_layout, fill_value):
     eii1 = RandomDataIterator(batch_size, shape=input_shape, dtype=np.float32)
     eii2 = RandomDataIterator(batch_size, shape=input_shape, dtype=np.float32)
+
+    fill_value_arg1 = fill_value
+    fill_value_arg2 = fill_value
+    if fill_value == 'random':
+        fill_eii1 = RandomDataIterator(batch_size, shape=input_shape[-1:], dtype=np.float32)
+        fill_eii2 = RandomDataIterator(batch_size, shape=input_shape[-1:], dtype=np.float32)
+        fill_value_arg1 = iter(fill_eii1)
+        fill_value_arg2 = iter(fill_eii2)
+
     compare_pipelines(
         ErasePipeline(device, batch_size, input_layout, iter(eii1), anchor=anchor,
-                      shape=shape, axis_names=axis_names, axes=axes, fill_value=fill_value),
+                      shape=shape, axis_names=axis_names, axes=axes, fill_value=fill_value_arg1),
         ErasePythonPipeline(device, batch_size, input_layout, iter(eii2), anchor=anchor,
-                            shape=shape, axis_names=axis_names, axes=axes, fill_value=fill_value),
+                            shape=shape, axis_names=axis_names, axes=axes, fill_value=fill_value_arg2),
         batch_size=batch_size, N_iterations=3, eps=1e-04, expected_layout=input_layout)
-
 
 def test_operator_erase_vs_python():
     # layout, shape, axis_names, axes, anchor, shape, fill_value
@@ -151,16 +188,19 @@ def test_operator_erase_vs_python():
             ("HWC", (60, 80, 3), "HW", None, (4, 10), (40, 50), None),
             ("HWC", (60, 80, 3), "HW", None, (4, 2, 3, 4), (50, 10, 10, 50), -1),
             ("HWC", (60, 80, 3), "HW", None, (4, 2, 3, 4), (50, 10, 10, 50), (118, 185, 0)),
+            ("HWC", (60, 80, 3), "HW", None, (4, 2, 3, 4), (50, 10, 10, 50), "random"),
             ("HWC", (60, 80, 3), "H", None, (4,), (7,), 0),
             ("HWC", (60, 80, 3), "H", None, (4, 15), (7, 8), 0),
             ("HWC", (60, 80, 3), "W", None, (4,), (7,), 0),
             ("HWC", (60, 80, 3), "W", None, (4, 15), (7, 8), 0),
+            ("HWC", (60, 80, 3), "W", None, (4, 15), (7, 8), "random"),
             ("HWC", (60, 80, 3), None, (0, 1), (4, 10), (40, 50), 0),
             ("HWC", (60, 80, 3), None, (0, 1), (4, 2, 3, 4), (50, 10, 10, 50), 0),
             ("HWC", (60, 80, 3), None, (0,), (4,), (7,), 0),
             ("HWC", (60, 80, 3), None, (0,), (4, 15), (7, 8), 0),
             ("HWC", (60, 80, 3), None, (1,), (4,), (7,), 0),
             ("HWC", (60, 80, 3), None, (1,), (4, 15), (7, 8), 0),
+            ("HWC", (60, 80, 3), None, (1,), (4, 15), (7, 8), "random"),
             ("DHWC", (10, 60, 80, 3), "DHW", None, (2, 4, 15), (3, 7, 8), 0),
             ("HWC", (60, 80, 1), "HW", None, (4, 15), (7, 8), 0),
             ("XYZ", (60, 80, 3), "XY", None, (4, 10), (40, 50), -1), ]

--- a/dali/test/python/operator/test_erase.py
+++ b/dali/test/python/operator/test_erase.py
@@ -177,10 +177,13 @@ def check_operator_erase_vs_python(device, batch_size, input_shape,
 
     compare_pipelines(
         ErasePipeline(device, batch_size, input_layout, iter(eii1), anchor=anchor,
-                      shape=shape, axis_names=axis_names, axes=axes, fill_value=fill_value_arg1),
+                      shape=shape, axis_names=axis_names, axes=axes,
+                      fill_value=fill_value_arg1),
         ErasePythonPipeline(device, batch_size, input_layout, iter(eii2), anchor=anchor,
-                            shape=shape, axis_names=axis_names, axes=axes, fill_value=fill_value_arg2),
+                            shape=shape, axis_names=axis_names, axes=axes,
+                            fill_value=fill_value_arg2),
         batch_size=batch_size, N_iterations=3, eps=1e-04, expected_layout=input_layout)
+
 
 def test_operator_erase_vs_python():
     # layout, shape, axis_names, axes, anchor, shape, fill_value


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature**

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
- It enables a new feature in Erase operator. `fill_value` argument can be fed with a tensor argument and not only a constant value
- Adjusted EraseGpu kernel to include the fill values in the sample descriptors
- Modified the Erase operator to support the per-sample argument.
- Added Kernel tests and operator tests
- Added several Run overloads to EraseGpu kernel to support invocation with constant, CPU tensor list view, and GPU tensor list view, for convenience.
- Requested by https://github.com/NVIDIA/DALI/issues/3881

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
Erase operator


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
Changes in the kernel and operator? Can we simplify something?

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
dali/kernels/erase/erase_gpu_test.cu (see testcases with PER_SAMPLE_CPU and PER_SAMPLE_GPU)
dali/test/python/operator/test_erase.py

- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [x] Affects existing requirements
- [ ] N/A
Extended the requirement
**REQ IDs**: ERASE.07
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2969
<!--- DALI-XXXX or NA --->
