### PR TITLE
Use std::exchange in move operator for Tensors

### DIFF
--- a/dali/pipeline/data/sample_view.h
+++ b/dali/pipeline/data/sample_view.h
@@ -112,12 +112,9 @@ class SampleViewBase {
 
   SampleViewBase &operator=(SampleViewBase &&other) {
     if (this != &other) {
-      data_ = other.data_;
-      other.data_ = nullptr;
-      shape_ = std::move(other.shape_);
-      other.shape_ = {0};
-      type_id_ = other.type_id_;
-      other.type_id_ = DALI_NO_TYPE;
+      data_ = std::exchange(other.data_, nullptr);
+      shape_ = std::exchange(other.shape_, {0});
+      type_id_ = std::exchange(other.type_id_, DALI_NO_TYPE);
     }
     return *this;
   }
@@ -185,12 +182,9 @@ class ConstSampleView : public SampleViewBase<Backend, const void *> {
   }
 
   ConstSampleView &operator=(SampleView<Backend> &&other) {
-    data_ = other.data_;
-    other.data_ = nullptr;
-    shape_ = std::move(other.shape_);
-    other.shape_ = {0};
-    type_id_ = other.type_id_;
-    other.type_id_ = DALI_NO_TYPE;
+    data_ = std::exchange(other.data_, nullptr);
+    shape_ = std::exchange(other.shape_, {0});
+    type_id_ = std::exchange(other.type_id_, DALI_NO_TYPE);
     return *this;
   }
 

--- a/dali/pipeline/data/sample_view_test.cc
+++ b/dali/pipeline/data/sample_view_test.cc
@@ -82,6 +82,10 @@ TEST(SampleView, Constructors) {
   ConstSampleView<CPUBackend> const_from_moved_const;
   const_from_moved_const = std::move(const_from_ptr);
   compare(const_from_moved_const, &cdata, {1, 2, 3}, DALI_INT32);
+
+  ConstSampleView<CPUBackend> const_from_moved_nonconst;
+  const_from_moved_nonconst = std::move(nonconst_from_moved_nonconst);
+  compare(const_from_moved_nonconst, &data, {1, 2, 3}, DALI_INT32);
 }
 
 

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -413,22 +413,13 @@ class Tensor : public Buffer<Backend> {
   Tensor<Backend>& operator=(const Tensor<Backend>&) = delete;
 
   Tensor<Backend>(Tensor<Backend> &&t) noexcept {
-    // Steal all data and set input to default state
-    shape_ = std::move(t.shape_);
-    meta_ = std::move(t.meta_);
-
-    t.shape_ = TensorShape<>();
-    t.meta_ = {};
-    move_buffer(std::move(t));
+    *this = std::move(t);
   }
 
   Tensor<Backend>& operator=(Tensor<Backend> &&t) noexcept {
     if (&t != this) {
-      shape_ = std::move(t.shape_);
-      meta_ = std::move(t.meta_);
-
-      t.shape_ = TensorShape<>();
-      t.meta_ = {};
+      shape_ = std::exchange(t.shape_, {0});
+      meta_ = std::exchange(t.meta_, {});
       move_buffer(std::move(t));
     }
     return *this;

--- a/dali/pipeline/data/tensor_test.cc
+++ b/dali/pipeline/data/tensor_test.cc
@@ -68,6 +68,35 @@ typedef ::testing::Types<CPUBackend,
                          GPUBackend> Backends;
 TYPED_TEST_SUITE(TensorTest, Backends);
 
+TYPED_TEST(TensorTest, Move) {
+  Tensor<TypeParam> t;
+
+  // Give the tensor a type
+  t.template set_type<float>();
+  auto shape = this->GetRandShape();
+  t.Resize(shape);
+  t.SetSourceInfo("test");
+
+  Tensor<TypeParam> target_move_assign;
+  target_move_assign = std::move(t);
+
+  ASSERT_TRUE(target_move_assign.has_data());
+  ASSERT_NE(target_move_assign.raw_data(), nullptr);
+  ASSERT_EQ(target_move_assign.size(), volume(shape));
+  ASSERT_EQ(target_move_assign.shape(), shape);
+  ASSERT_TRUE(IsType<float>(target_move_assign.type()));
+  ASSERT_EQ(target_move_assign.GetSourceInfo(), "test");
+
+
+  Tensor<TypeParam> target_move_construct(std::move(target_move_assign));
+  ASSERT_TRUE(target_move_construct.has_data());
+  ASSERT_NE(target_move_construct.raw_data(), nullptr);
+  ASSERT_EQ(target_move_construct.size(), volume(shape));
+  ASSERT_EQ(target_move_construct.shape(), shape);
+  ASSERT_TRUE(IsType<float>(target_move_construct.type()));
+  ASSERT_EQ(target_move_construct.GetSourceInfo(), "test");
+}
+
 // Sharing data from a raw pointer resets a Tensor to
 // and invalid state (no type). To get to a valid state
 // we can acquire a type and size in the following orders:

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -795,9 +795,8 @@ struct TensorListShape<DynamicDimensions>
   TensorListShape &operator=(const TensorListShape &) = default;
   TensorListShape &operator=(TensorListShape &&other) {
     shapes = std::move(other.shapes);
-    nsamples = other.size();
-    ndim = other.sample_dim();
-    other.nsamples = 0;
+    nsamples = std::exchange(other.nsamples, 0);
+    ndim = other.sample_dim();  // Sample dim could be static, and it is valid to not zero it.
     return *this;
   }
 
@@ -812,9 +811,8 @@ struct TensorListShape<DynamicDimensions>
   template <int other_sample_ndim>
   TensorListShape &operator=(TensorListShape<other_sample_ndim> &&other) {
     shapes = std::move(other.shapes);
-    nsamples = other.size();
-    ndim = other.sample_dim();
-    other.nsamples = 0;
+    nsamples = std::exchange(other.nsamples, 0);
+    ndim = other.sample_dim();  // Sample dim could be static, and it is valid to not zero it.
     return *this;
   }
 
@@ -894,8 +892,7 @@ struct TensorListShape : TensorListShapeBase<TensorListShape<sample_ndim>, sampl
   TensorListShape &operator=(const TensorListShape &) = default;
   TensorListShape &operator=(TensorListShape &&other) {
     shapes = std::move(other.shapes);
-    nsamples = other.size();
-    other.nsamples = 0;
+    nsamples = std::exchange(other.nsamples, 0);
     return *this;
   }
 


### PR DESCRIPTION
## Category: **Refactoring**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Use the std::exchange in move operators,
to have single statement:
```x_ = std::exchange(other.x_, 0);```
instead of multiple separate lines:
```
x_ = other.x_;
other.x_ = 0;
``` 

This adjusts Tensor and SampleView types,
so they both have the empty {0} shape after
move.
Previously it left the Tensor with a scalar shape
that could indicate existing allocation after
move.

As the use after move shouldn't be practised,
this change should not impact anything.

TensorViews and TensorShapes are left mostly
unaffected as the static_dim doesn't compose
nicely with forcing {0} shape or clearing
the dimensionality. For a TensorView, it is
valid to have a shape and a nullptr,
for the shapes they can have dimensionality
and no samples.




## Additional information:

### Affected modules and functionalities:
Tensor, SampleView.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
Sample View already has std::move tests.
TensorListShape tests invoke the move constructor.
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2966
<!--- DALI-2966 or NA --->
