### PR TITLE
Add support for memory video file in FramesDecoder

### DIFF
--- a/dali/operators/reader/loader/video/frames_decoder.cc
+++ b/dali/operators/reader/loader/video/frames_decoder.cc
@@ -173,6 +173,8 @@ FramesDecoder::FramesDecoder(char *memory_file, int memory_file_size)
   av_state_->ctx_->pb = av_io_context;
 
   int ret = avformat_open_input(&av_state_->ctx_, "", nullptr, nullptr);
+  DALI_ENFORCE(ret == 0, make_string("Failed to open video file from memory due to ",
+                                     detail::av_error_string(ret)));
 
   FindVideoStream();
   DALI_ENFORCE(

--- a/dali/operators/reader/loader/video/frames_decoder.cc
+++ b/dali/operators/reader/loader/video/frames_decoder.cc
@@ -127,7 +127,7 @@ void FramesDecoder::FindVideoStream() {
     }
   }
 
-  DALI_FAIL(make_string("Could not find a valid video stream in a file ", filename_));
+  DALI_FAIL(make_string("Could not find a valid video stream in a file ", Filename()));
 }
 
 FramesDecoder::FramesDecoder(const std::string &filename)
@@ -138,8 +138,8 @@ FramesDecoder::FramesDecoder(const std::string &filename)
   av_state_->ctx_ = avformat_alloc_context();
   DALI_ENFORCE(av_state_->ctx_, "Could not alloc avformat context");
 
-  int ret = avformat_open_input(&av_state_->ctx_, filename.c_str(), nullptr, nullptr);
-  DALI_ENFORCE(ret == 0, make_string("Failed to open video file at path ", filename, "due to ",
+  int ret = avformat_open_input(&av_state_->ctx_, Filename().c_str(), nullptr, nullptr);
+  DALI_ENFORCE(ret == 0, make_string("Failed to open video file ", Filename(), "due to ",
                                      detail::av_error_string(ret)));
 
   FindVideoStream();
@@ -148,7 +148,7 @@ FramesDecoder::FramesDecoder(const std::string &filename)
     make_string(
       "Unsupported video codec: ",
       av_state_->codec_->name,
-      " in file: ", filename,
+      " in file: ", Filename(),
       " Supported codecs: h264, HEVC."));
   InitAvState();
   BuildIndex();
@@ -179,7 +179,7 @@ FramesDecoder::FramesDecoder(const char *memory_file, int memory_file_size)
   av_state_->ctx_->pb = av_io_context;
 
   int ret = avformat_open_input(&av_state_->ctx_, "", nullptr, nullptr);
-  DALI_ENFORCE(ret == 0, make_string("Failed to open video file from memory due to ",
+  DALI_ENFORCE(ret == 0, make_string("Failed to open video file ", Filename(), "due to ",
                                      detail::av_error_string(ret)));
 
   FindVideoStream();
@@ -335,7 +335,7 @@ void FramesDecoder::Reset() {
     ret >= 0,
     make_string(
       "Could not seek to the first frame of video ",
-      filename_,
+      Filename(),
       "due to",
       detail::av_error_string(ret)));
   avcodec_flush_buffers(av_state_->codec_ctx_);
@@ -372,7 +372,7 @@ void FramesDecoder::SeekFrame(int frame_id) {
       "with keyframe",
       keyframe_id,
       "in video ",
-      filename_,
+      Filename(),
       "due to ",
       detail::av_error_string(ret)));
 

--- a/dali/operators/reader/loader/video/frames_decoder.cc
+++ b/dali/operators/reader/loader/video/frames_decoder.cc
@@ -169,7 +169,6 @@ FramesDecoder::FramesDecoder(char *memory_file, int memory_file_size)
     detail::read_memory_video_file,
     nullptr,
     detail::seek_memory_video_file);
-    // nullptr);
 
   av_state_->ctx_->pb = av_io_context;
 

--- a/dali/operators/reader/loader/video/frames_decoder.cc
+++ b/dali/operators/reader/loader/video/frames_decoder.cc
@@ -19,6 +19,35 @@
 
 
 namespace dali {
+int MemoryVideoFile::Read(unsigned char *buffer, int buffer_size) {
+  int left_in_file = size_ - position_;
+  if (left_in_file == 0) {
+    return AVERROR_EOF;
+  }
+
+  int to_read = std::min(left_in_file, buffer_size);
+  std::copy(data_ + position_, data_ + position_ + to_read, buffer);
+  position_ += to_read;
+  return to_read;
+}
+
+int64_t MemoryVideoFile::Seek(int64_t new_position, int origin) {
+  switch (origin) {
+  case SEEK_SET:
+    position_ = new_position;
+    break;
+  case AVSEEK_SIZE:
+    return size_;
+
+  default:
+    DALI_FAIL(
+      make_string(
+        "Unsupported seeking method in FramesDecoder from memory file. Seeking method: ",
+        origin));
+  }
+
+  return position_;
+}
 
 namespace detail {
 std::string av_error_string(int ret) {
@@ -26,7 +55,20 @@ std::string av_error_string(int ret) {
     memset(msg, 0, sizeof(msg));
     return std::string(av_make_error_string(msg, AV_ERROR_MAX_STRING_SIZE, ret));
 }
+
+int read_memory_video_file(void *data_ptr, uint8_t *av_io_buffer, int av_io_buffer_size) {
+  MemoryVideoFile *memory_video_file = static_cast<MemoryVideoFile *>(data_ptr);
+
+  return memory_video_file->Read(av_io_buffer, av_io_buffer_size);
 }
+
+int64_t seek_memory_video_file(void *data_ptr, int64_t new_position, int origin) {
+  MemoryVideoFile *memory_video_file = static_cast<MemoryVideoFile *>(data_ptr);
+
+  return memory_video_file->Seek(new_position, origin);
+}
+
+}   // namespace detail
 
 using AVPacketScope = std::unique_ptr<AVPacket, decltype(&av_packet_unref)>;
 
@@ -101,6 +143,45 @@ FramesDecoder::FramesDecoder(const std::string &filename)
       av_state_->codec_->name,
       " in file: ", filename,
       " Supported codecs: h264, HEVC."));
+  InitAvState();
+  BuildIndex();
+  DetectVfr();
+}
+
+
+
+FramesDecoder::FramesDecoder(char *memory_file, int memory_file_size)
+  : av_state_(std::make_unique<AvState>()),
+    memory_video_file_(MemoryVideoFile(memory_file, memory_file_size)) {
+  av_log_set_level(AV_LOG_ERROR);
+
+  av_state_->ctx_ = avformat_alloc_context();
+  DALI_ENFORCE(av_state_->ctx_, "Could not alloc avformat context");
+
+  const int av_io_buffer_size = 32768;
+  uint8_t *av_io_buffer = static_cast<uint8_t *>(av_malloc(av_io_buffer_size));
+
+  AVIOContext *av_io_context = avio_alloc_context(
+    av_io_buffer,
+    av_io_buffer_size,
+    0,
+    &memory_video_file_.value(),
+    detail::read_memory_video_file,
+    nullptr,
+    detail::seek_memory_video_file);
+    // nullptr);
+
+  av_state_->ctx_->pb = av_io_context;
+
+  int ret = avformat_open_input(&av_state_->ctx_, "", nullptr, nullptr);
+
+  FindVideoStream();
+  DALI_ENFORCE(
+    CheckCodecSupport(),
+    make_string(
+      "Unsupported video codec: ",
+      av_state_->codec_->name,
+      ". Supported codecs: h264, HEVC."));
   InitAvState();
   BuildIndex();
   DetectVfr();

--- a/dali/operators/reader/loader/video/frames_decoder.h
+++ b/dali/operators/reader/loader/video/frames_decoder.h
@@ -76,15 +76,15 @@ struct AvState {
  * 
  */
 struct MemoryVideoFile {
-  explicit MemoryVideoFile(char *data, int64_t size)
+  MemoryVideoFile(const char *data, int64_t size)
     : data_(data), size_(size), position_(0) {}
 
   int Read(unsigned char *buffer, int buffer_size);
 
   int64_t Seek(int64_t new_position, int origin);
 
-  char *data_;
-  int64_t size_;
+  const char *data_;
+  const int64_t size_;
   int64_t position_;
 };
 
@@ -108,9 +108,12 @@ class DLL_PUBLIC FramesDecoder {
    * @brief Construct a new FramesDecoder object.
    * 
    * @param memory_file Pointer to memory with video file data.
-   * @param memory_file_size Size of memory_file.
+   * @param memory_file_size Size of memory_file in bytes.
+   * 
+   * @note This constructor assumes that the `memory_file` and
+   * `memory_file_size` arguments cover the entire video file, including the header.
    */
-  explicit FramesDecoder(char *memory_file, int memory_file_size);
+  FramesDecoder(const char *memory_file, int memory_file_size);
 
   /**
    * @brief Number of frames in the video
@@ -246,6 +249,9 @@ class DLL_PUBLIC FramesDecoder {
 
   std::string filename_ = "";
   std::optional<MemoryVideoFile> memory_video_file_ = {};
+
+  // Default size of the buffer used to load video files from memory to FFMPEG
+  const int default_av_buffer_size = (1 << 15);
 };
 
 }  // namespace dali

--- a/dali/operators/reader/loader/video/frames_decoder.h
+++ b/dali/operators/reader/loader/video/frames_decoder.h
@@ -25,6 +25,7 @@ extern "C" {
 #include <vector>
 #include <string>
 #include <memory>
+#include <optional>
 
 #include "dali/core/common.h"
 
@@ -70,6 +71,17 @@ struct AvState {
   }
 };
 
+struct MemoryVideoFile {
+  explicit MemoryVideoFile(char *data, int64_t size)
+    : data_(data), size_(size), position_(0) {}
+  int Read(unsigned char *buffer, int buffer_size);
+  int64_t Seek(int64_t new_position, int origin);
+
+  char *data_;
+  int64_t size_;
+  int64_t position_;
+};
+
 /**
  * @brief Object representing a video file. Allows access to frames and seeking.
  * 
@@ -84,6 +96,15 @@ class DLL_PUBLIC FramesDecoder {
    * @param filename Path to a video file.
    */
   explicit FramesDecoder(const std::string &filename);
+
+
+  /**
+   * @brief Construct a new FramesDecoder object.
+   * 
+   * @param memory_file Pointer to memory with video file data.
+   * @param memory_file_size Size of memory_file.
+   */
+  explicit FramesDecoder(char *memory_file, int memory_file_size);
 
   /**
    * @brief Number of frames in the video
@@ -215,9 +236,12 @@ class DLL_PUBLIC FramesDecoder {
 
   int channels_ = 3;
   bool flush_state_ = false;
-  std::string filename_;
   bool is_vfr_ = false;
+
+  std::string filename_;
+  std::optional<MemoryVideoFile> memory_video_file_ = {};
 };
+
 }  // namespace dali
 
 #endif  // DALI_OPERATORS_READER_LOADER_VIDEO_FRAMES_DECODER_H_

--- a/dali/operators/reader/loader/video/frames_decoder.h
+++ b/dali/operators/reader/loader/video/frames_decoder.h
@@ -71,10 +71,16 @@ struct AvState {
   }
 };
 
+/**
+ * @brief Helper representing video file kept in memory. Allows reading and seeking.
+ * 
+ */
 struct MemoryVideoFile {
   explicit MemoryVideoFile(char *data, int64_t size)
     : data_(data), size_(size), position_(0) {}
+
   int Read(unsigned char *buffer, int buffer_size);
+
   int64_t Seek(int64_t new_position, int origin);
 
   char *data_;
@@ -238,7 +244,7 @@ class DLL_PUBLIC FramesDecoder {
   bool flush_state_ = false;
   bool is_vfr_ = false;
 
-  std::string filename_;
+  std::string filename_ = "";
   std::optional<MemoryVideoFile> memory_video_file_ = {};
 };
 

--- a/dali/operators/reader/loader/video/frames_decoder.h
+++ b/dali/operators/reader/loader/video/frames_decoder.h
@@ -243,11 +243,15 @@ class DLL_PUBLIC FramesDecoder {
 
   void DetectVfr();
 
+  std::string Filename() {
+    return filename_.has_value() ? filename_.value() : "memory file";
+  }
+
   int channels_ = 3;
   bool flush_state_ = false;
   bool is_vfr_ = false;
 
-  std::string filename_ = "";
+  std::optional<const std::string> filename_ = {};
   std::optional<MemoryVideoFile> memory_video_file_ = {};
 
   // Default size of the buffer used to load video files from memory to FFMPEG

--- a/dali/operators/reader/loader/video/frames_decoder_gpu.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_gpu.cc
@@ -77,56 +77,67 @@ cudaVideoCodec FramesDecoderGpu::GetCodecType() {
   return cudaVideoCodec_H264;
 }
 
+void FramesDecoderGpu::InitGpuDecoder() {
+  nvdecode_state_ = std::make_unique<NvDecodeState>();
+
+  InitBitStreamFilter();
+
+  filtered_packet_ = av_packet_alloc();
+  DALI_ENFORCE(filtered_packet_, "Could not allocate av packet");
+
+  auto codec_type = GetCodecType();
+
+  // Create nv decoder
+  CUVIDDECODECREATEINFO decoder_info;
+  memset(&decoder_info, 0, sizeof(CUVIDDECODECREATEINFO));
+
+  decoder_info.bitDepthMinus8 = 0;
+  decoder_info.ChromaFormat = cudaVideoChromaFormat_420;
+  decoder_info.CodecType = codec_type;
+  decoder_info.ulHeight = Height();
+  decoder_info.ulWidth = Width();
+  decoder_info.ulMaxHeight = Height();
+  decoder_info.ulMaxWidth = Width();
+  decoder_info.ulTargetHeight = Height();
+  decoder_info.ulTargetWidth = Width();
+  decoder_info.ulNumDecodeSurfaces = num_decode_surfaces_;
+  decoder_info.ulNumOutputSurfaces = 2;
+
+  CUDA_CALL(cuvidCreateDecoder(&nvdecode_state_->decoder, &decoder_info));
+
+  // Create nv parser
+  CUVIDPARSERPARAMS parser_info;
+  memset(&parser_info, 0, sizeof(CUVIDPARSERPARAMS));
+  parser_info.CodecType = codec_type;
+  parser_info.ulMaxNumDecodeSurfaces = num_decode_surfaces_;
+  parser_info.ulMaxDisplayDelay = 0;
+  parser_info.pUserData = this;
+  parser_info.pfnSequenceCallback = detail::process_video_sequence;
+  parser_info.pfnDecodePicture = detail::process_picture_decode;
+  parser_info.pfnDisplayPicture = nullptr;
+
+  CUDA_CALL(cuvidCreateVideoParser(&nvdecode_state_->parser, &parser_info));
+
+  // Init internal frame buffer
+  // TODO(awolant): Check, if continuous buffer would be faster
+  for (size_t i = 0; i < frame_buffer_.size(); ++i) {
+    frame_buffer_[i].frame_.resize(FrameSize());
+    frame_buffer_[i].pts_ = -1;
+  }
+}
+
 FramesDecoderGpu::FramesDecoderGpu(const std::string &filename, cudaStream_t stream) :
     FramesDecoder(filename),
     frame_buffer_(num_decode_surfaces_),
     stream_(stream) {
-    nvdecode_state_ = std::make_unique<NvDecodeState>();
+    InitGpuDecoder();
+}
 
-    InitBitStreamFilter();
-
-    filtered_packet_ = av_packet_alloc();
-    DALI_ENFORCE(filtered_packet_, "Could not allocate av packet");
-
-    auto codec_type = GetCodecType();
-
-    // Create nv decoder
-    CUVIDDECODECREATEINFO decoder_info;
-    memset(&decoder_info, 0, sizeof(CUVIDDECODECREATEINFO));
-
-    decoder_info.bitDepthMinus8 = 0;
-    decoder_info.ChromaFormat = cudaVideoChromaFormat_420;
-    decoder_info.CodecType = codec_type;
-    decoder_info.ulHeight = Height();
-    decoder_info.ulWidth = Width();
-    decoder_info.ulMaxHeight = Height();
-    decoder_info.ulMaxWidth = Width();
-    decoder_info.ulTargetHeight = Height();
-    decoder_info.ulTargetWidth = Width();
-    decoder_info.ulNumDecodeSurfaces = num_decode_surfaces_;
-    decoder_info.ulNumOutputSurfaces = 2;
-
-    CUDA_CALL(cuvidCreateDecoder(&nvdecode_state_->decoder, &decoder_info));
-
-    // Create nv parser
-    CUVIDPARSERPARAMS parser_info;
-    memset(&parser_info, 0, sizeof(CUVIDPARSERPARAMS));
-    parser_info.CodecType = codec_type;
-    parser_info.ulMaxNumDecodeSurfaces = num_decode_surfaces_;
-    parser_info.ulMaxDisplayDelay = 0;
-    parser_info.pUserData = this;
-    parser_info.pfnSequenceCallback = detail::process_video_sequence;
-    parser_info.pfnDecodePicture = detail::process_picture_decode;
-    parser_info.pfnDisplayPicture = nullptr;
-
-    CUDA_CALL(cuvidCreateVideoParser(&nvdecode_state_->parser, &parser_info));
-
-    // Init internal frame buffer
-    // TODO(awolant): Check, if continuous buffer would be faster
-    for (size_t i = 0; i < frame_buffer_.size(); ++i) {
-      frame_buffer_[i].frame_.resize(FrameSize());
-      frame_buffer_[i].pts_ = -1;
-    }
+FramesDecoderGpu::FramesDecoderGpu(char *memory_file, int memory_file_size, cudaStream_t stream) :
+    FramesDecoder(memory_file, memory_file_size),
+    frame_buffer_(num_decode_surfaces_),
+    stream_(stream) {
+    InitGpuDecoder();
 }
 
 int FramesDecoderGpu::ProcessPictureDecode(void *user_data, CUVIDPICPARAMS *picture_params) {

--- a/dali/operators/reader/loader/video/frames_decoder_gpu.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_gpu.cc
@@ -133,11 +133,12 @@ FramesDecoderGpu::FramesDecoderGpu(const std::string &filename, cudaStream_t str
     InitGpuDecoder();
 }
 
-FramesDecoderGpu::FramesDecoderGpu(const char *memory_file, int memory_file_size, cudaStream_t stream) :
-    FramesDecoder(memory_file, memory_file_size),
-    frame_buffer_(num_decode_surfaces_),
-    stream_(stream) {
-    InitGpuDecoder();
+FramesDecoderGpu::FramesDecoderGpu(
+  const char *memory_file, int memory_file_size, cudaStream_t stream) :
+  FramesDecoder(memory_file, memory_file_size),
+  frame_buffer_(num_decode_surfaces_),
+  stream_(stream) {
+  InitGpuDecoder();
 }
 
 int FramesDecoderGpu::ProcessPictureDecode(void *user_data, CUVIDPICPARAMS *picture_params) {

--- a/dali/operators/reader/loader/video/frames_decoder_gpu.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_gpu.cc
@@ -133,7 +133,7 @@ FramesDecoderGpu::FramesDecoderGpu(const std::string &filename, cudaStream_t str
     InitGpuDecoder();
 }
 
-FramesDecoderGpu::FramesDecoderGpu(char *memory_file, int memory_file_size, cudaStream_t stream) :
+FramesDecoderGpu::FramesDecoderGpu(const char *memory_file, int memory_file_size, cudaStream_t stream) :
     FramesDecoder(memory_file, memory_file_size),
     frame_buffer_(num_decode_surfaces_),
     stream_(stream) {

--- a/dali/operators/reader/loader/video/frames_decoder_gpu.h
+++ b/dali/operators/reader/loader/video/frames_decoder_gpu.h
@@ -58,6 +58,14 @@ class DLL_PUBLIC FramesDecoderGpu : public FramesDecoder {
    */
   explicit FramesDecoderGpu(const std::string &filename, cudaStream_t stream = 0);
 
+  /**
+ * @brief Construct a new FramesDecoder object.
+ * 
+ * @param memory_file Pointer to memory with video file data.
+ * @param memory_file_size Size of memory_file.
+ */
+  explicit FramesDecoderGpu(char *memory_file, int memory_file_size, cudaStream_t stream = 0);
+
   bool ReadNextFrame(uint8_t *data, bool copy_to_output = true) override;
 
   void SeekFrame(int frame_id) override;
@@ -100,6 +108,8 @@ class DLL_PUBLIC FramesDecoderGpu : public FramesDecoder {
   void InitBitStreamFilter();
 
   cudaVideoCodec GetCodecType();
+
+  void InitGpuDecoder();
 };
 
 }  // namespace dali

--- a/dali/operators/reader/loader/video/frames_decoder_gpu.h
+++ b/dali/operators/reader/loader/video/frames_decoder_gpu.h
@@ -62,9 +62,12 @@ class DLL_PUBLIC FramesDecoderGpu : public FramesDecoder {
  * @brief Construct a new FramesDecoder object.
  * 
  * @param memory_file Pointer to memory with video file data.
- * @param memory_file_size Size of memory_file.
+ * @param memory_file_size Size of memory_file in bytes.
+ * 
+ * @note This constructor assumes that the `memory_file` and
+ * `memory_file_size` arguments cover the entire video file, including the header.
  */
-  explicit FramesDecoderGpu(char *memory_file, int memory_file_size, cudaStream_t stream = 0);
+  FramesDecoderGpu(const char *memory_file, int memory_file_size, cudaStream_t stream = 0);
 
   bool ReadNextFrame(uint8_t *data, bool copy_to_output = true) override;
 

--- a/dali/operators/reader/loader/video/frames_decoder_test.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_test.cc
@@ -179,7 +179,7 @@ TEST_F(FramesDecoderTest_CpuOnlyTests, InvalidPath) {
 
   RunConstructorFailureTest(
     path,
-    make_string("Failed to open video file at path ", path));
+    make_string("Failed to open video file ", path));
 }
 
 TEST_F(FramesDecoderTest_CpuOnlyTests, NoVideoStream) {

--- a/dali/operators/reader/loader/video/frames_decoder_test.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_test.cc
@@ -236,18 +236,46 @@ TEST_F(FramesDecoderGpuTest, VariableFrameRateHevc) {
   RunTest(decoder, vfr_hevc_videos_[1]);
 }
 
-TEST_F(FramesDecoderTest_CpuOnlyTests, InMemoryVideo) {
-  std::ifstream video_file(cfr_videos_paths_[1], std::ios::binary | std::ios::ate);
-  auto size = video_file.tellg();
-  video_file.seekg(0, std::ios::beg);
+TEST_F(FramesDecoderTest_CpuOnlyTests, InMemoryCfrVideo) {
+  auto memory_video = MemoryVideo(cfr_videos_paths_[1]);
 
-  std::vector<char> memory_video_file(size);
-  if (!video_file.read(memory_video_file.data(), size)) {
-    FAIL() << "Could not load video file to memory";
-  }
-
-  FramesDecoder decoder(memory_video_file.data(), memory_video_file.size());
+  FramesDecoder decoder(memory_video.data(), memory_video.size());
   RunTest(decoder, cfr_videos_[1]);
+}
+
+TEST_F(FramesDecoderGpuTest, InMemoryCfrVideo) {
+  auto memory_video = MemoryVideo(cfr_videos_paths_[0]);
+
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
+  RunTest(decoder, cfr_videos_[0]);
+}
+
+TEST_F(FramesDecoderTest_CpuOnlyTests, InMemoryVfrVideo) {
+  auto memory_video = MemoryVideo(vfr_videos_paths_[1]);
+
+  FramesDecoder decoder(memory_video.data(), memory_video.size());
+  RunTest(decoder, vfr_videos_[1]);
+}
+
+TEST_F(FramesDecoderGpuTest, InMemoryVfrVideo) {
+  auto memory_video = MemoryVideo(vfr_videos_paths_[0]);
+
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
+  RunTest(decoder, vfr_videos_[0]);
+}
+
+TEST_F(FramesDecoderTest_CpuOnlyTests, InMemoryVfrHevcVideo) {
+  auto memory_video = MemoryVideo(vfr_videos_paths_[0]);
+
+  FramesDecoder decoder(memory_video.data(), memory_video.size());
+  RunTest(decoder, vfr_videos_[0]);
+}
+
+TEST_F(FramesDecoderGpuTest, InMemoryVfrVfrHevcVideo) {
+  auto memory_video = MemoryVideo(vfr_hevc_videos_paths_[1]);
+
+  FramesDecoderGpu decoder(memory_video.data(), memory_video.size());
+  RunTest(decoder, vfr_hevc_videos_[1]);
 }
 
 }  // namespace dali

--- a/dali/operators/reader/loader/video/frames_decoder_test.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_test.cc
@@ -236,4 +236,18 @@ TEST_F(FramesDecoderGpuTest, VariableFrameRateHevc) {
   RunTest(decoder, vfr_hevc_videos_[1]);
 }
 
+TEST_F(FramesDecoderTest_CpuOnlyTests, InMemoryVideo) {
+  std::ifstream video_file(cfr_videos_paths_[1], std::ios::binary | std::ios::ate);
+  auto size = video_file.tellg();
+  video_file.seekg(0, std::ios::beg);
+
+  std::vector<char> memory_video_file(size);
+  if (!video_file.read(memory_video_file.data(), size)) {
+    FAIL() << "Could not load video file to memory";
+  }
+
+  FramesDecoder decoder(memory_video_file.data(), memory_video_file.size());
+  RunTest(decoder, cfr_videos_[1]);
+}
+
 }  // namespace dali

--- a/dali/operators/reader/loader/video/video_test_base.cc
+++ b/dali/operators/reader/loader/video/video_test_base.cc
@@ -155,4 +155,18 @@ void VideoTestBase::RunFailureTest(std::function<void()> body, std::string expec
   }
 }
 
+std::vector<char> VideoTestBase::MemoryVideo(std::string &path) {
+  std::ifstream video_file(path, std::ios::binary | std::ios::ate);
+  auto size = video_file.tellg();
+  video_file.seekg(0, std::ios::beg);
+
+  std::vector<char> memory_video(size);
+  if (!video_file.read(memory_video.data(), size)) {
+    // We can't use FAIL() because this function returns value
+    throw ::testing::AssertionFailure() << "Could not load video file to memory.";
+  }
+
+  return memory_video;
+}
+
 }  // namespace dali

--- a/dali/operators/reader/loader/video/video_test_base.cc
+++ b/dali/operators/reader/loader/video/video_test_base.cc
@@ -155,7 +155,7 @@ void VideoTestBase::RunFailureTest(std::function<void()> body, std::string expec
   }
 }
 
-std::vector<char> VideoTestBase::MemoryVideo(std::string &path) {
+std::vector<char> VideoTestBase::MemoryVideo(const std::string &path) const {
   std::ifstream video_file(path, std::ios::binary | std::ios::ate);
   auto size = video_file.tellg();
   video_file.seekg(0, std::ios::beg);

--- a/dali/operators/reader/loader/video/video_test_base.h
+++ b/dali/operators/reader/loader/video/video_test_base.h
@@ -74,7 +74,7 @@ class VideoTestBase : public ::testing::Test {
     return std::max(cfr_videos_[0].FrameSize(), cfr_videos_[1].FrameSize());
   }
 
-  std::vector<char> MemoryVideo(std::string &path);
+  std::vector<char> MemoryVideo(const std::string &path) const;
 
   /**
    * @brief Utility to save decoded frame as a PNG file.

--- a/dali/operators/reader/loader/video/video_test_base.h
+++ b/dali/operators/reader/loader/video/video_test_base.h
@@ -74,6 +74,8 @@ class VideoTestBase : public ::testing::Test {
     return std::max(cfr_videos_[0].FrameSize(), cfr_videos_[1].FrameSize());
   }
 
+  std::vector<char> MemoryVideo(std::string &path);
+
   /**
    * @brief Utility to save decoded frame as a PNG file.
    * Frame is saved to the folder given as an argument.


### PR DESCRIPTION
Signed-off-by: Albert Wolant <awolant@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->

New feature

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

Add support for video files kept in memory for `FramesDecoder` and `FramesDecoderGpu`.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

`FramesDecoder`, `FramesDecoderGpu` and video tests

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

Is this functionality enough for video inference plan?

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2957
<!--- DALI-XXXX or NA --->
