### PR TITLE
Fix invalid destruction order in decoder test helper

### DIFF
--- a/dali/imgcodec/decoders/decoder_test_helper.h
+++ b/dali/imgcodec/decoders/decoder_test_helper.h
@@ -315,10 +315,10 @@ class DecoderTestBase : public ::testing::Test {
     return roi;
   }
 
+  ThreadPool tp_;  // we want the thread pool to outlive the decoder instance
   std::shared_ptr<ImageDecoderInstance> decoder_ = nullptr;
   std::shared_ptr<ImageParser> parser_ = nullptr;
   kernels::TestTensorList<OutputType> output_;
-  ThreadPool tp_;
 };
 
 


### PR DESCRIPTION
Signed-off-by: Michał Staniewski <m.staniewzki@gmail.com>

## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
`ThreadPool` pointer is passed to `ImageDecoderInstace` and must be kept alive for it's lifetime. In `decoder_test_helper.h`, 
the order of fields was wrong, resulting in an invalid destruction order - `ThreadPool` is destroyed first, then the `ImageDecoderInstance`. This PR fixes this issue.


## Additional information:

### Affected modules and functionalities:
N/A

### Key points relevant for the review:
N/A

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
