### PR TITLE
Fix usage of deprecated np.float in tests

### DIFF
--- a/dali/test/python/test_detection_pipeline.py
+++ b/dali/test/python/test_detection_pipeline.py
@@ -90,7 +90,7 @@ def normalize_ref(image):
     normalization_mean = [0.485, 0.456, 0.406]
     normalization_std = [0.229, 0.224, 0.225]
 
-    image = image.astype(dtype=np.float32).transpose((2, 0, 1)) / 255
+    image = image.astype(dtype=np.float64).transpose((2, 0, 1)) / 255
     for plane, (m, s) in zip(range(len(image)), zip(normalization_mean, normalization_std)):
         image[plane] = (image[plane] - m) / s
     return image

--- a/dali/test/python/test_detection_pipeline.py
+++ b/dali/test/python/test_detection_pipeline.py
@@ -90,7 +90,7 @@ def normalize_ref(image):
     normalization_mean = [0.485, 0.456, 0.406]
     normalization_std = [0.229, 0.224, 0.225]
 
-    image = image.astype(dtype=np.float).transpose((2, 0, 1)) / 255
+    image = image.astype(dtype=np.float32).transpose((2, 0, 1)) / 255
     for plane, (m, s) in zip(range(len(image)), zip(normalization_mean, normalization_std)):
         image[plane] = (image[plane] - m) / s
     return image


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Other** 

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
Replaces `np.float` with `np.float32` in tests, as it was deprecated in Numpy 1.20


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
NA


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
NA
### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [x] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
