### PR TITLE
Use deprecated PIL resampling import for Python 3.6, due to lack of availability of a newer version of PIL

### DIFF
--- a/dali/test/python/operator/test_resize.py
+++ b/dali/test/python/operator/test_resize.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import PIL.Image
 import cv2
 import functools
 import math
@@ -23,14 +22,20 @@ import nvidia.dali.types as types
 import os.path
 from nvidia.dali import Pipeline, pipeline_def
 from nvidia.dali.data_node import DataNode as _DataNode
-
 from test_utils import check_batch, get_dali_extra_path, as_array
 
+import PIL.Image
+try:
+    from PIL.Image.Resampling import NEAREST, BILINEAR, BICUBIC, LANCZOS
+except Exception:
+    # Deprecated import, needed for Python 3.6
+    from PIL.Image import NEAREST, BILINEAR, BICUBIC, LANCZOS
+
 resample_dali2pil = {
-    types.INTERP_NN: PIL.Image.Resampling.NEAREST,
-    types.INTERP_TRIANGULAR: PIL.Image.Resampling.BILINEAR,
-    types.INTERP_CUBIC: PIL.Image.Resampling.BICUBIC,
-    types.INTERP_LANCZOS3: PIL.Image.Resampling.LANCZOS
+    types.INTERP_NN:         NEAREST,
+    types.INTERP_TRIANGULAR: BILINEAR,
+    types.INTERP_CUBIC:      BICUBIC,
+    types.INTERP_LANCZOS3:   LANCZOS
 }
 
 test_data_root = get_dali_extra_path()
@@ -95,7 +100,7 @@ def resize2D_PIL(input, size, roi_start, roi_end, dtype, channel_first, resample
 
     box = list(roi_start) + list(roi_end)
 
-    has_overshoot = resample in (PIL.Image.Resampling.LANCZOS, PIL.Image.Resampling.BICUBIC)
+    has_overshoot = resample in (LANCZOS, BICUBIC)
     if has_overshoot:
         # compress dynamic range to allow for overshoot
         input = (64 + input * 0.5).round().astype(np.uint8)
@@ -119,7 +124,7 @@ def resize3D_PIL(input, size, roi_start, roi_end, dtype, channel_first, resample
     if channel_first:
         input = input.transpose([1, 2, 3, 0])
 
-    has_overshoot = resample in (PIL.Image.Resampling.LANCZOS, PIL.Image.Resampling.BICUBIC)
+    has_overshoot = resample in (LANCZOS, BICUBIC)
     if has_overshoot:
         # compress dynamic range to allow for overshoot
         input = (64 + input * 0.5).round().astype(np.uint8)

--- a/dali/test/python/operator/test_resize_seq.py
+++ b/dali/test/python/operator/test_resize_seq.py
@@ -17,8 +17,13 @@ import nvidia.dali.fn as fn
 import nvidia.dali.types as types
 import numpy as np
 import os.path
-import PIL.Image
 from test_utils import check_batch
+import PIL.Image
+try:
+    from PIL.Image.Resampling import NEAREST, BILINEAR, BICUBIC, LANCZOS
+except Exception:
+    # Deprecated import, needed for Python 3.6
+    from PIL.Image import NEAREST, BILINEAR, BICUBIC, LANCZOS
 
 
 def init_video_data():
@@ -61,10 +66,10 @@ def GetSequences(channel_first, length, batch_size):
 
 
 resample_dali2pil = {
-    types.INTERP_NN:         PIL.Image.Resampling.NEAREST,
-    types.INTERP_TRIANGULAR: PIL.Image.Resampling.BILINEAR,
-    types.INTERP_CUBIC:      PIL.Image.Resampling.BICUBIC,
-    types.INTERP_LANCZOS3:   PIL.Image.Resampling.LANCZOS
+    types.INTERP_NN:         NEAREST,
+    types.INTERP_TRIANGULAR: BILINEAR,
+    types.INTERP_CUBIC:      BICUBIC,
+    types.INTERP_LANCZOS3:   LANCZOS
 }
 
 


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Other** (bugfix in tests for Python 3.6)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
- A previous PR replaced the usage of PIL.Image.* for interpolation types (NEARES, BICUBIC, ...) to suppress a deprecation warning, and changed to use the new PIL.Image.Resampling.* module:
https://github.com/NVIDIA/DALI/pull/4195
- Nightly tests showed that Python 3.6 has an older version of Pillow, not including the new module.
- This PRs offers a fallback when PIL.Image.Resampling.* can't be imported, to be compatible with Python 3.6



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
NA


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
NA
### Tests:
<!--- Describe the test coverage of the introduced change.
NA
If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
