### PR TITLE
Fix Layout propagation in TensorVector

### DIFF
--- a/dali/pipeline/data/tensor_vector.cc
+++ b/dali/pipeline/data/tensor_vector.cc
@@ -764,6 +764,7 @@ void TensorVector<Backend>::recreate_views() {
     std::shared_ptr<void> sample_alias(contiguous_buffer_.get_data_ptr(), sample_ptr);
     tensors_[i].ShareData(sample_alias, tensor_size * type_info().size(), is_pinned(), shape()[i],
                           type(), device_id(), order());
+    tensors_[i].SetLayout(GetLayout());
     sample_ptr += tensor_size * type_info().size();
   }
 }

--- a/dali/pipeline/data/tensor_vector_test.cc
+++ b/dali/pipeline/data/tensor_vector_test.cc
@@ -135,6 +135,7 @@ TYPED_TEST(TensorVectorSuite, ResizeWithRecreate) {
   for (auto contiguity : {BatchContiguity::Contiguous, BatchContiguity::Noncontiguous}) {
     TensorVector<TypeParam> tv;
     tv.SetContiguity(contiguity);
+    tv.SetLayout("HWC");
     tv.set_pinned(true);
     auto shape0 = TensorListShape<>({{1, 2, 3}, {2, 3, 4}, {3, 4, 5}});
     tv.Resize(shape0, DALI_UINT8);
@@ -142,14 +143,17 @@ TYPED_TEST(TensorVectorSuite, ResizeWithRecreate) {
     for (int i = 0; i < 3; i++) {
       EXPECT_EQ(tv[i].type(), DALI_UINT8);
       EXPECT_EQ(tv[i].shape(), shape0[i]);
+      EXPECT_EQ(tv.GetMeta(i).GetLayout(), "HWC");
     }
 
     auto shape1 = TensorListShape<>({{1, 2}, {3, 4}});
     tv.Resize(shape1, DALI_FLOAT);
+    tv.SetLayout("WC");
     EXPECT_EQ(tv.shape().num_samples(), 2);
     for (int i = 0; i < 2; i++) {
       EXPECT_EQ(tv[i].type(), DALI_FLOAT);
       EXPECT_EQ(tv[i].shape(), shape1[i]);
+      EXPECT_EQ(tv.GetMeta(i).GetLayout(), "WC");
     }
 
     auto shape2 = TensorListShape<>({{2, 3}, {4, 5}, {5, 6}, {6, 7}, {7, 8}});
@@ -158,6 +162,7 @@ TYPED_TEST(TensorVectorSuite, ResizeWithRecreate) {
     for (int i = 0; i < 5; i++) {
       EXPECT_EQ(tv[i].type(), DALI_FLOAT64);
       EXPECT_EQ(tv[i].shape(), shape2[i]);
+      EXPECT_EQ(tv.GetMeta(i).GetLayout(), "WC");
     }
 
     auto shape3 = TensorListShape<>({{2, 3}, {4, 5}, {5, 6}});
@@ -166,14 +171,17 @@ TYPED_TEST(TensorVectorSuite, ResizeWithRecreate) {
     for (int i = 0; i < 3; i++) {
       EXPECT_EQ(tv[i].type(), DALI_FLOAT64);
       EXPECT_EQ(tv[i].shape(), shape3[i]);
+      EXPECT_EQ(tv.GetMeta(i).GetLayout(), "WC");
     }
 
     auto shape4 = TensorListShape<>({{1, 2, 3}, {2, 3, 4}, {3, 4, 5}});
+    tv.SetLayout("HWC");
     tv.Resize(shape4, DALI_UINT8);
     EXPECT_EQ(tv.shape().num_samples(), 3);
     for (int i = 0; i < 3; i++) {
       EXPECT_EQ(tv[i].type(), DALI_UINT8);
       EXPECT_EQ(tv[i].shape(), shape4[i]);
+      EXPECT_EQ(tv.GetMeta(i).GetLayout(), "HWC");
     }
 
     auto shape5 =
@@ -183,6 +191,7 @@ TYPED_TEST(TensorVectorSuite, ResizeWithRecreate) {
     for (int i = 0; i < 6; i++) {
       EXPECT_EQ(tv[i].type(), DALI_UINT8);
       EXPECT_EQ(tv[i].shape(), shape5[i]);
+      EXPECT_EQ(tv.GetMeta(i).GetLayout(), "HWC");
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->

Extracted from #4189 


## Category: **Bug fix**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Propagate layout to new view Tensors, when the batch is resized after
the layout was already set.

The bug happened when SetSample was used, and the validation of  layout failed
for a TensorVector that already had the layout set.

## Additional information:

### Affected modules and functionalities:
TensorVector



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
Test extended with the scenario of SetLayout -> Resize to different batch size
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
