### PR TITLE
Support tensor as batch in parallel external source

### DIFF
--- a/dali/python/nvidia/dali/_multiproc/shared_batch.py
+++ b/dali/python/nvidia/dali/_multiproc/shared_batch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -245,8 +245,6 @@ class SharedBatchWriter:
         shared_array.ravel()[:] = np_array.ravel()[:]
 
     def _write_batch(self, batch):
-        if not batch:
-            return
         batch = [_apply_to_sample(lambda x: _sample_to_numpy(x, _sample_error_msg), sample)
                  for sample in batch]
         meta, data_size = self._prepare_samples_meta(batch)

--- a/dali/python/nvidia/dali/_utils/external_source_impl.py
+++ b/dali/python/nvidia/dali/_utils/external_source_impl.py
@@ -78,7 +78,7 @@ _tf_uniform_error_msg = (
 
 def assert_cpu_sample_data_type(sample, error_str="Unsupported callback return type. Got: `{}`."):
     import_numpy()
-    if isinstance(sample, np.ndarray):
+    if isinstance(sample, (np.ndarray, np.generic)):
         return True
     if types._is_mxnet_array(sample):
         if sample.context.device_type != 'cpu':
@@ -113,7 +113,7 @@ def assert_cpu_batch_data_type(batch, error_str="Unsupported callback return typ
 def sample_to_numpy(sample, error_str="Unsupported callback return type. Got: `{}`."):
     import_numpy()
     assert_cpu_sample_data_type(sample, error_str)
-    if isinstance(sample, np.ndarray):
+    if isinstance(sample, (np.ndarray, np.generic)):
         return sample
     if types._is_mxnet_array(sample):
         if sample.context.device_type != 'cpu':

--- a/dali/python/nvidia/dali/_utils/external_source_impl.py
+++ b/dali/python/nvidia/dali/_utils/external_source_impl.py
@@ -78,6 +78,8 @@ _tf_uniform_error_msg = (
 
 def assert_cpu_sample_data_type(sample, error_str="Unsupported callback return type. Got: `{}`."):
     import_numpy()
+    # np.generic is a base type for numpy scalars, they may turn up implicitly from
+    # iterating over 1-dim array treated as a batch
     if isinstance(sample, (np.ndarray, np.generic)):
         return True
     if types._is_mxnet_array(sample):
@@ -113,6 +115,8 @@ def assert_cpu_batch_data_type(batch, error_str="Unsupported callback return typ
 def sample_to_numpy(sample, error_str="Unsupported callback return type. Got: `{}`."):
     import_numpy()
     assert_cpu_sample_data_type(sample, error_str)
+    # np.generic is a base type for numpy scalars, they may turn up implicitly from
+    # iterating over 1-dim array treated as a batch
     if isinstance(sample, (np.ndarray, np.generic)):
         return sample
     if types._is_mxnet_array(sample):


### PR DESCRIPTION
## Category:
**New feature** (*non-breaking change which adds functionality*)
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
* Support specyfing batch as a single numpy array which leading extent is treated as a samples extent of a batch.
* Support returning numpy scalars from a callback

All those cases have already been supported by non-parallel external source.


## Additional information:

### Affected modules and functionalities:
Parallel external source, external source, tensfor flow plugin(?)



### Key points relevant for the review:
* Does it enable something we would not like to enable?

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
