### PR TITLE
Add bulk parameter passing to decoders and factories.

### DIFF
--- a/dali/imgcodec/decoders/decoder_impl.h
+++ b/dali/imgcodec/decoders/decoder_impl.h
@@ -15,6 +15,8 @@
 #ifndef DALI_IMGCODEC_DECODERS_DECODER_IMPL_H_
 #define DALI_IMGCODEC_DECODERS_DECODER_IMPL_H_
 
+#include <map>
+#include <string>
 #include <vector>
 #include "dali/core/format.h"
 #include "dali/imgcodec/image_decoder_interfaces.h"
@@ -25,8 +27,8 @@ namespace imgcodec {
 
 class DLL_PUBLIC ImageDecoderImpl : public ImageDecoderInstance {
  public:
-  explicit ImageDecoderImpl(int device_id) : device_id_(device_id) {
-  }
+  explicit ImageDecoderImpl(int device_id, const std::map<std::string, any> &)
+  : device_id_(device_id) {}
 
   bool CanDecode(DecodeContext ctx, ImageSource *in, DecodeParams opts, const ROI &roi) override {
     return true;
@@ -92,6 +94,13 @@ class DLL_PUBLIC ImageDecoderImpl : public ImageDecoderInstance {
 
   any GetParam(const char *key) const override {
     return {};
+  }
+
+  int SetParams(const std::map<std::string, any> &params) override {
+    int ret = 0;
+    for (auto &[key, value] : params)
+      ret += SetParam(key.c_str(), value);
+    return ret;
   }
 
  protected:

--- a/dali/imgcodec/decoders/decoder_parallel_impl.h
+++ b/dali/imgcodec/decoders/decoder_parallel_impl.h
@@ -15,9 +15,11 @@
 #ifndef DALI_IMGCODEC_DECODERS_DECODER_PARALLEL_IMPL_H_
 #define DALI_IMGCODEC_DECODERS_DECODER_PARALLEL_IMPL_H_
 
+#include <map>
 #include <memory>
 #include <utility>
 #include <vector>
+#include <string>
 #include <thread>
 #include "dali/core/format.h"
 #include "dali/imgcodec/decoders/decoder_impl.h"
@@ -33,8 +35,8 @@ namespace imgcodec {
  */
 class DLL_PUBLIC BatchParallelDecoderImpl : public ImageDecoderImpl {
  public:
-  explicit BatchParallelDecoderImpl(int device_id)
-  : ImageDecoderImpl(device_id) {}
+  explicit BatchParallelDecoderImpl(int device_id, const std::map<std::string, any> &params)
+  : ImageDecoderImpl(device_id, params) {}
 
   using ImageDecoderImpl::CanDecode;
   std::vector<bool> CanDecode(DecodeContext ctx,

--- a/dali/imgcodec/decoders/libjpeg_turbo.h
+++ b/dali/imgcodec/decoders/libjpeg_turbo.h
@@ -15,6 +15,7 @@
 #ifndef DALI_IMGCODEC_DECODERS_LIBJPEG_TURBO_H_
 #define DALI_IMGCODEC_DECODERS_LIBJPEG_TURBO_H_
 
+#include <map>
 #include <memory>
 #include <string>
 #include "dali/imgcodec/image_decoder_interfaces.h"
@@ -28,8 +29,10 @@ namespace imgcodec {
  */
 class DLL_PUBLIC LibJpegTurboDecoderInstance : public BatchParallelDecoderImpl {
  public:
-  explicit LibJpegTurboDecoderInstance(int device_id)
-  : BatchParallelDecoderImpl(device_id) {}
+  explicit LibJpegTurboDecoderInstance(int device_id, const std::map<std::string, any> &params)
+  : BatchParallelDecoderImpl(device_id, params) {
+    SetParams(params);
+  }
 
   using BatchParallelDecoderImpl::Decode;
   DecodeResult Decode(DecodeContext ctx,
@@ -76,8 +79,9 @@ class LibJpegTurboDecoderFactory : public ImageDecoderFactory {
     return device_id < 0;
   }
 
-  std::shared_ptr<ImageDecoderInstance> Create(int device_id) const override {
-    return std::make_shared<LibJpegTurboDecoderInstance>(device_id);
+  std::shared_ptr<ImageDecoderInstance> Create(
+          int device_id, const std::map<std::string, any> &params = {}) const override {
+    return std::make_shared<LibJpegTurboDecoderInstance>(device_id, params);
   }
 };
 

--- a/dali/imgcodec/decoders/libtiff/tiff_libtiff.h
+++ b/dali/imgcodec/decoders/libtiff/tiff_libtiff.h
@@ -15,7 +15,9 @@
 #ifndef DALI_IMGCODEC_DECODERS_LIBTIFF_TIFF_LIBTIFF_H_
 #define DALI_IMGCODEC_DECODERS_LIBTIFF_TIFF_LIBTIFF_H_
 
+#include <map>
 #include <memory>
+#include <string>
 #include "dali/imgcodec/image_decoder_interfaces.h"
 #include "dali/imgcodec/decoders/decoder_parallel_impl.h"
 
@@ -25,7 +27,10 @@ namespace imgcodec {
 class DLL_PUBLIC LibTiffDecoderInstance : public BatchParallelDecoderImpl {
  public:
   using Base = BatchParallelDecoderImpl;
-  explicit LibTiffDecoderInstance(int device_id) : Base(device_id) {}
+  explicit LibTiffDecoderInstance(int device_id, const std::map<std::string, any> &params)
+  : Base(device_id, params) {
+    SetParams(params);
+  }
 
   using Base::Decode;
   DecodeResult Decode(DecodeContext ctx,
@@ -51,8 +56,9 @@ class LibTiffDecoderFactory : public ImageDecoderFactory {
     return device_id < 0;
   }
 
-  std::shared_ptr<ImageDecoderInstance> Create(int device_id) const override {
-    return std::make_shared<LibTiffDecoderInstance>(device_id);
+  std::shared_ptr<ImageDecoderInstance> Create(
+        int device_id, const std::map<std::string, any> &params = {}) const override {
+    return std::make_shared<LibTiffDecoderInstance>(device_id, params);
   }
 };
 

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <map>
 #include <string>
 #include <vector>
 #include "dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.h"
@@ -36,11 +37,12 @@ bool check_status(nvjpeg2kStatus_t status, ImageSource *in) {
 }
 }  // namespace
 
-NvJpeg2000DecoderInstance::NvJpeg2000DecoderInstance(int device_id)
-: BatchParallelDecoderImpl(device_id)
+NvJpeg2000DecoderInstance::NvJpeg2000DecoderInstance(
+    int device_id, const std::map<std::string, any> &params)
+: BatchParallelDecoderImpl(device_id, params)
 , nvjpeg2k_dev_alloc_(nvjpeg_memory::GetDeviceAllocatorNvJpeg2k())
 , nvjpeg2k_pin_alloc_(nvjpeg_memory::GetPinnedAllocatorNvJpeg2k()) {
-  // TODO(staniewzki): pass params at construction
+  SetParams(params);
   any num_threads_any = GetParam("nvjpeg2k_num_threads");
   int num_threads = num_threads_any.has_value() ? any_cast<int>(num_threads_any) : 4;
   tp_ = std::make_unique<ThreadPool>(num_threads, device_id, true, "NvJpeg2000DecoderInstance");

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.h
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.h
@@ -16,7 +16,9 @@
 #define DALI_IMGCODEC_DECODERS_NVJPEG2K_NVJPEG2K_H_
 
 #include <nvjpeg.h>
+#include <map>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 #include "dali/imgcodec/decoders/decoder_parallel_impl.h"
@@ -33,7 +35,7 @@ namespace imgcodec {
  */
 class DLL_PUBLIC NvJpeg2000DecoderInstance : public BatchParallelDecoderImpl {
  public:
-  explicit NvJpeg2000DecoderInstance(int device_id);
+  explicit NvJpeg2000DecoderInstance(int device_id, const std::map<std::string, any> &params);
   ~NvJpeg2000DecoderInstance();
 
   using BatchParallelDecoderImpl::CanDecode;
@@ -201,8 +203,9 @@ class NvJpeg2000DecoderFactory : public ImageDecoderFactory {
     return device_id >= 0;
   }
 
-  std::shared_ptr<ImageDecoderInstance> Create(int device_id) const override {
-    return std::make_shared<NvJpeg2000DecoderInstance>(device_id);
+  std::shared_ptr<ImageDecoderInstance> Create(
+        int device_id, const std::map<std::string, any> &params = {}) const override {
+    return std::make_shared<NvJpeg2000DecoderInstance>(device_id, params);
   }
 };
 

--- a/dali/imgcodec/decoders/opencv_fallback.h
+++ b/dali/imgcodec/decoders/opencv_fallback.h
@@ -15,7 +15,9 @@
 #ifndef DALI_IMGCODEC_DECODERS_OPENCV_FALLBACK_H_
 #define DALI_IMGCODEC_DECODERS_OPENCV_FALLBACK_H_
 
+#include <map>
 #include <memory>
+#include <string>
 #include "dali/imgcodec/image_decoder_interfaces.h"
 #include "dali/imgcodec/decoders/decoder_parallel_impl.h"
 
@@ -28,7 +30,10 @@ namespace imgcodec {
 class DLL_PUBLIC OpenCVDecoderInstance : public BatchParallelDecoderImpl {
  public:
   using Base = BatchParallelDecoderImpl;
-  explicit OpenCVDecoderInstance(int device_id) : Base(device_id) {}
+  explicit OpenCVDecoderInstance(int device_id, const std::map<std::string, any> &params)
+  : Base(device_id, params) {
+    SetParams(params);
+  }
 
   DecodeResult DecodeImplTask(int thread_idx,
                               SampleView<CPUBackend> out,
@@ -55,8 +60,9 @@ class OpenCVDecoderFactory : public ImageDecoderFactory {
     return device_id < 0;
   }
 
-  std::shared_ptr<ImageDecoderInstance> Create(int device_id) const override {
-    return std::make_shared<OpenCVDecoderInstance>(device_id);
+  std::shared_ptr<ImageDecoderInstance> Create(
+        int device_id, const std::map<std::string, any> &params = {}) const override {
+    return std::make_shared<OpenCVDecoderInstance>(device_id, params);
   }
 };
 

--- a/include/dali/imgcodec/image_decoder_interfaces.h
+++ b/include/dali/imgcodec/image_decoder_interfaces.h
@@ -15,9 +15,11 @@
 #ifndef DALI_IMGCODEC_IMAGE_DECODER_INTERFACES_H_
 #define DALI_IMGCODEC_IMAGE_DECODER_INTERFACES_H_
 
+#include <map>
 #include <memory>
 #include <utility>
 #include <stdexcept>
+#include <string>
 #include <vector>
 #include "dali/core/any.h"
 #include "dali/core/span.h"
@@ -193,8 +195,24 @@ class DLL_PUBLIC ImageDecoderInstance {
                                              cspan<ROI> rois = {}) = 0;
   /**
    * @brief Sets a codec-specific parameter
+   *
+   * @return  true, if the parameter is relevant for this decoder, false otherwise
+   *
+   * @remarks The function may throw if the parameter name is valid for this decoder, but
+   *          the value is incorrect.
    */
   virtual bool SetParam(const char *key, const any &value) = 0;
+
+  /**
+   * @brief Sets codec-specific parameters.
+   *
+   * @return  The number of parameters that were relevant for this decoder.
+   *
+   * @remarks The function may throw if the parameter name is valid for this decoder, but
+   *          the value is incorrect.
+   */
+  virtual int SetParams(const std::map<std::string, any> &params) = 0;
+
   /**
    * @brief Gets a codec-specific parameter
    */
@@ -231,10 +249,9 @@ class DLL_PUBLIC ImageDecoderFactory {
 
   /**
    * @brief Creates an instance of a codec
-   *
-   * Note: For decoders that carry no state, this may just increase reference count on a singleton.
    */
-  virtual std::shared_ptr<ImageDecoderInstance> Create(int device_id) const = 0;
+  virtual std::shared_ptr<ImageDecoderInstance>
+  Create(int device_id, const std::map<std::string, any> &params = {}) const = 0;
 };
 
 }  // namespace imgcodec


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
Prior to this change, there was no possibility to pass codec-specific arguments at decoder construction.
This PR changes that. To reduce the amount of boilerplate code, it also adds a bulk-setter for a dictionary of parameters.

## Additional information:

### Affected modules and functionalities:
Decoders, factories.

### Key points relevant for the review:
N/A

### Tests:
TODO
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2983
<!--- DALI-XXXX or NA --->
