### PR TITLE
Make JPEG HW decoder test to fully use HW and not hybrid approach

### DIFF
--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api_test.cc
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -227,7 +227,7 @@ class HwDecoderUtilizationTest : public ::testing::Test {
             OpSpec("ImageDecoder")
                     .AddArg("device", "mixed")
                     .AddArg("output_type", DALI_RGB)
-                    .AddArg("hw_decoder_load", .7f)
+                    .AddArg("hw_decoder_load", 1.f)
                     .AddInput("compressed_images", "cpu")
                     .AddOutput("images", "gpu");
     pipeline_.AddOperator(decoder_spec, decoder_name_);
@@ -260,8 +260,8 @@ TEST_F(HwDecoderUtilizationTest, UtilizationTest) {
   auto nsamples_hw = node->op->GetDiagnostic<int64_t>("nsamples_hw");
   auto nsamples_cuda = node->op->GetDiagnostic<int64_t>("nsamples_cuda");
   auto nsamples_host = node->op->GetDiagnostic<int64_t>("nsamples_host");
-  EXPECT_EQ(nsamples_hw, 35) << "HW Decoder malfunction: incorrect number of images decoded in HW";
-  EXPECT_EQ(nsamples_cuda, 12);
+  EXPECT_EQ(nsamples_hw, 47) << "HW Decoder malfunction: incorrect number of images decoded in HW";
+  EXPECT_EQ(nsamples_cuda, 0);
   EXPECT_EQ(nsamples_host, 0)
                 << "Image decoding malfuntion: all images should've been decoded by CUDA or HW";
 }
@@ -281,7 +281,7 @@ class HwDecoderMemoryPoolTest : public ::testing::Test {
             OpSpec("ImageDecoder")
                     .AddArg("device", "mixed")
                     .AddArg("output_type", DALI_RGB)
-                    .AddArg("hw_decoder_load", .7f)
+                    .AddArg("hw_decoder_load", 1.f)
                     .AddArg("preallocate_width_hint", 400)
                     .AddArg("preallocate_height_hint", 600)
                     .AddInput("compressed_images", "cpu")
@@ -335,7 +335,7 @@ class HwDecoderSliceUtilizationTest : public ::testing::Test {
             OpSpec("ImageDecoderSlice")
                     .AddArg("device", "mixed")
                     .AddArg("output_type", DALI_RGB)
-                    .AddArg("hw_decoder_load", .7f)
+                    .AddArg("hw_decoder_load", 1.f)
                     .AddInput("compressed_images", "cpu")
                     .AddInput("begin_data", "cpu")
                     .AddInput("crop_data", "cpu")
@@ -372,8 +372,8 @@ TEST_F(HwDecoderSliceUtilizationTest, UtilizationTest) {
   auto nsamples_hw = node->op->GetDiagnostic<int64_t>("nsamples_hw");
   auto nsamples_cuda = node->op->GetDiagnostic<int64_t>("nsamples_cuda");
   auto nsamples_host = node->op->GetDiagnostic<int64_t>("nsamples_host");
-  EXPECT_EQ(nsamples_hw, 35) << "HW Decoder malfunction: incorrect number of images decoded in HW";
-  EXPECT_EQ(nsamples_cuda, 12);
+  EXPECT_EQ(nsamples_hw, 47) << "HW Decoder malfunction: incorrect number of images decoded in HW";
+  EXPECT_EQ(nsamples_cuda, 0);
   EXPECT_EQ(nsamples_host, 0)
                 << "Image decoding malfunction: all images should've been decoded by CUDA or HW";
 }
@@ -393,7 +393,7 @@ class HwDecoderCropUtilizationTest : public ::testing::Test {
             OpSpec("ImageDecoderCrop")
                     .AddArg("device", "mixed")
                     .AddArg("output_type", DALI_RGB)
-                    .AddArg("hw_decoder_load", .7f)
+                    .AddArg("hw_decoder_load", 1.f)
                     .AddArg("crop", std::vector<float>{224.0f, 224.0f})
                     .AddInput("compressed_images", "cpu")
                     .AddOutput("images", "gpu");
@@ -425,8 +425,8 @@ TEST_F(HwDecoderCropUtilizationTest, UtilizationTest) {
   auto nsamples_hw = node->op->GetDiagnostic<int64_t>("nsamples_hw");
   auto nsamples_cuda = node->op->GetDiagnostic<int64_t>("nsamples_cuda");
   auto nsamples_host = node->op->GetDiagnostic<int64_t>("nsamples_host");
-  EXPECT_EQ(nsamples_hw, 35) << "HW Decoder malfunction: incorrect number of images decoded in HW";
-  EXPECT_EQ(nsamples_cuda, 12);
+  EXPECT_EQ(nsamples_hw, 47) << "HW Decoder malfunction: incorrect number of images decoded in HW";
+  EXPECT_EQ(nsamples_cuda, 0);
   EXPECT_EQ(nsamples_host, 0)
                 << "Image decoding malfuntion: all images should've been decoded by CUDA or HW";
 }
@@ -447,7 +447,7 @@ class HwDecoderRandomCropUtilizationTest : public ::testing::Test {
             OpSpec("ImageDecoderRandomCrop")
                     .AddArg("device", "mixed")
                     .AddArg("output_type", DALI_RGB)
-                    .AddArg("hw_decoder_load", .7f)
+                    .AddArg("hw_decoder_load", 1.f)
                     .AddInput("compressed_images", "cpu")
                     .AddOutput("images", "gpu");
     pipeline_.AddOperator(decoder_spec, decoder_name_);


### PR DESCRIPTION
- changes hw_decoder_load to 1 to make sure that all samples go to the HW decoder

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- changes hw_decoder_load to 1 to make sure that all samples go to the HW decoder
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- nvjpeg_decoder_decoupled_api_test
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - HwDecoder* test family
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2992
<!--- DALI-XXXX or NA --->
