### PR TITLE
Fix webdataset python index creation script

### DIFF
--- a/tools/wds2idx.py
+++ b/tools/wds2idx.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ class IndexCreator:
         )  # <type>... <size> <date> <name>
 
         # Extracting
-        for blocks_line, next_blocks_line, types_sizes_line in zip(tar_blocks, tar_blocks[1:],
+        for blocks_line, next_blocks_line, types_sizes_line in zip(tar_blocks, tar_blocks,
                                                                    tar_types_sizes):
             if not blocks_line or not types_sizes_line:
                 continue
@@ -111,14 +111,13 @@ class IndexCreator:
             if entry_type != b"-":
                 continue
 
-            offset = int(
-                next_blocks_line[next_blocks_line.find(b"block") + 6 : next_blocks_line.find(b":")]) * 512  # noqa: E203, E501
+            offset = int(next_blocks_line[next_blocks_line.find(b"block") + 6:
+                                          next_blocks_line.find(b":")])
+            offset = (offset + 1) * 512
 
             size = types_sizes_line[: -len(name)]
             size = size[: size.rfind(b"-") - 8]  # "... <size> 20yy-mm-...."
             size = int(size[size.rfind(b" "):])
-            offset -= size
-            offset -= offset % 512
 
             yield offset, name, size
 

--- a/tools/wds2idx.py
+++ b/tools/wds2idx.py
@@ -100,8 +100,7 @@ class IndexCreator:
         )  # <type>... <size> <date> <name>
 
         # Extracting
-        for blocks_line, next_blocks_line, types_sizes_line in zip(tar_blocks, tar_blocks,
-                                                                   tar_types_sizes):
+        for blocks_line, types_sizes_line in zip(tar_blocks, tar_types_sizes):
             if not blocks_line or not types_sizes_line:
                 continue
 
@@ -111,8 +110,12 @@ class IndexCreator:
             if entry_type != b"-":
                 continue
 
-            offset = int(next_blocks_line[next_blocks_line.find(b"block") + 6:
-                                          next_blocks_line.find(b":")])
+            offset = int(blocks_line[blocks_line.find(b"block") + 6:
+                                     blocks_line.find(b":")])
+            # according to https://www.loc.gov/preservation/digital/formats/fdd/fdd000531.shtml#:~:text=A%20tar%20(tape%20archive)%20file,are%20not%20compressed%20archive%20files. # noqa: E501, W505
+            # each data record is preceded by 512-byte header. `tar --list --block-num --file`
+            # return the position (counted in 512-byte blocks) of the header for a given entry.
+            # So the size of the header needs to be added to get the data offset
             offset = (offset + 1) * 512
 
             size = types_sizes_line[: -len(name)]


### PR DESCRIPTION
- fixes wrong offset calculation in webdataset python
  index creation script. The right formula for the data
  offset calculation should be the output of (`block-number` + 1) * 512
  while it was calculated as (next ``block-number`) * 512 - data size
  (what doesn't work when the first entry is preceded by additional data
  like in POSIX.1-2001 archive

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:.
- fixes wrong offset calculation in webdataset python
  index creation script. The right formula for the data
  offset calculation should be the output of (`block-number` + 1) * 512
  while it was calculated as (next ``block-number`) * 512 - data size
  (what doesn't work when the first entry is preceded by additional data
  like in POSIX.1-2001 archive
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- tools/webdataset index creation script
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_vector_test.cc: TensorVectorVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - [X]
    - test_webdataset_requirements.py (but I don't know how to generate tar file with non-0 offset for the initial entry)
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->

Relates to https://github.com/NVIDIA/DALI/issues/4215