### PR TITLE
Prevent excessive synchronization in MakeContiguous.

### DIFF
--- a/dali/pipeline/operator/builtin/make_contiguous.cu
+++ b/dali/pipeline/operator/builtin/make_contiguous.cu
@@ -38,7 +38,7 @@ void MakeContiguousMixed::Run(MixedWorkspace &ws) {
     auto &output = ws.Output<CPUBackend>(0);
     DomainTimeRange tr("[DALI][MakeContiguousMixed] H2H non coalesced", DomainTimeRange::kGreen);
     // use ws.stream() to prevent waiting on host for the mixed stage stream
-    output.Copy(input, ws.stream());
+    output.Copy(input, ws.has_stream() ? AccessOrder(ws.stream()) : AccessOrder());
   } else {
     auto &output = ws.Output<GPUBackend>(0);
     if (coalesced) {

--- a/dali/pipeline/operator/builtin/make_contiguous.cu
+++ b/dali/pipeline/operator/builtin/make_contiguous.cu
@@ -37,7 +37,8 @@ void MakeContiguousMixed::Run(MixedWorkspace &ws) {
   if (ws.OutputIsType<CPUBackend>(0)) {
     auto &output = ws.Output<CPUBackend>(0);
     DomainTimeRange tr("[DALI][MakeContiguousMixed] H2H non coalesced", DomainTimeRange::kGreen);
-    output.Copy(input);
+    // use ws.stream() to prevent waiting on host for the mixed stage stream
+    output.Copy(input, ws.stream());
   } else {
     auto &output = ws.Output<GPUBackend>(0);
     if (coalesced) {


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
A H2H copy in MakeContiguous caused synchronization to prevent the device-ordered buffer from being clobbered. This clobbering should not be possible thanks to inter-stage multiple buffering and the synchronization is, in fact, excessive.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Pretty much everything....
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
