### PR TITLE
Fix fusing the dimensions in SliceFlipNormalizePermutePadGpu

### DIFF
--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_cuda_impl.cuh
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_cuda_impl.cuh
@@ -122,7 +122,12 @@ __device__ void SliceFlipNormalizePermutePadFunc(
       out_of_bounds |= is_out_of_bounds(in_i_d, in_shape[d]);
     }
 
-    in_idx += in_strides[d] < 0 ? -i_d : i_d;  // abs(in_strides[d]) is 1 but we care about the sign
+    if (AllDims) {
+      in_idx += i_d * in_strides[d];
+    } else {
+      // abs(in_strides[d]) is 1 but we care about the sign
+      in_idx += in_strides[d] < 0 ? -i_d : i_d;
+    }
 
     if (NeedPad && out_of_bounds) {
       out[out_idx] = fill_values[i_c];

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -223,7 +223,7 @@ class SliceFlipNormalizePermutePadGpu {
       // We fuse the last dimension with the previous IF:
       // 1. There are at least 2 dimensions
       // 2. Last dimension is not sliced/padded/permuted
-      //    - if out_stride[last_dim] == abs(in_stride[last_dim]), then it is not permuted
+      //    - if out_stride[last_dim] == in_stride[last_dim], then it is not permuted
       //    - if anchor[last_dim] == 0 && out_shape[last_dim] == in_shape[last_dim],
       //      then it is not sliced/padded
       // 3. Last dimension is not the channel dimension

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -225,6 +225,7 @@ class SliceFlipNormalizePermutePadGpu {
       // 2. Last dimension is not sliced/padded/permuted
       // 3. Last dimension is not the channel dimension
       // 4. The last two dimensions are either both flipped or not flipped
+      // 5. (???) The strides of last and the former channel align
       int last_dim = Dims - 1;
       while (last_dim > 0 &&
              sample_desc.out_strides[last_dim] ==
@@ -232,7 +233,9 @@ class SliceFlipNormalizePermutePadGpu {
              sample_desc.anchor[last_dim] == 0 &&
              sample_desc.out_shape[last_dim] == sample_desc.in_shape[last_dim] &&
              sample_desc.channel_dim != last_dim &&
-             (sample_desc.in_strides[last_dim] < 0) == (sample_desc.in_strides[last_dim - 1] < 0)) {
+             (sample_desc.in_strides[last_dim] < 0) == (sample_desc.in_strides[last_dim - 1] < 0) &&
+             sample_desc.in_strides[last_dim] * sample_desc.in_shape[last_dim] ==
+                 sample_desc.in_strides[last_dim - 1]) {
         last_dim--;
       }
 

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -149,25 +149,26 @@ class SliceFlipNormalizePermutePadGpu {
 
   bool CanCollapseLastDim(detail::SampleDesc<Dims> &sample_desc, int last_dim) {
     // We fuse the last dimension with the previous IF:
-    // 1. There are at least 2 dimensions
-    // 2. Last dimension is not sliced/padded/permuted
-    //    - if out_stride[last_dim] == abs(in_stride[last_dim]), then it is not permuted
-    //    - if anchor[last_dim] == 0 && out_shape[last_dim] == in_shape[last_dim],
-    //      then it is not sliced/padded
-    // 3. Neither of the two dimensions to be merged are the channel dimension
-    // 4. The in_strides of the last dimension and the former one align
-    //    - in_strides[last_dim] * in_shape[last_dim] == in_strides[last_dim - 1]
-    //      (this check also makes sure that we collapse dims that have the same sign of strides
-    //       meaning we can merge two dimensions if they are either not flipped or both of them
-    //       are)
-    return last_dim > 0 &&
-           sample_desc.out_strides[last_dim] ==
-               static_cast<uint64_t>(abs(sample_desc.in_strides[last_dim])) &&
-           sample_desc.anchor[last_dim] == 0 &&
-           sample_desc.out_shape[last_dim] == sample_desc.in_shape[last_dim] &&
-           sample_desc.channel_dim != last_dim && sample_desc.channel_dim != (last_dim - 1) &&
-           sample_desc.in_strides[last_dim] * sample_desc.in_shape[last_dim] ==
-               sample_desc.in_strides[last_dim - 1];
+    // There are at least 2 dimensions
+    bool at_least_2_dims = last_dim > 0;
+    // Last dimension is not sliced/padded/permuted
+    // if out_stride[last_dim] == abs(in_stride[last_dim]), then it is not permuted
+    // if anchor[last_dim] == 0 && out_shape[last_dim] == in_shape[last_dim],
+    // then it is not sliced/padded
+    bool no_permute = sample_desc.out_strides[last_dim] ==
+                      static_cast<uint64_t>(abs(sample_desc.in_strides[last_dim]));
+    bool no_sliced_or_pad = sample_desc.anchor[last_dim] == 0 &&
+                            sample_desc.out_shape[last_dim] == sample_desc.in_shape[last_dim];
+    // Neither of the two dimensions to be merged are the channel dimension
+    bool no_channel_dim =
+        sample_desc.channel_dim != last_dim && sample_desc.channel_dim != (last_dim - 1);
+    // The in_strides of the last dimension and the former one align
+    // in_strides[last_dim] * in_shape[last_dim] == in_strides[last_dim - 1]
+    // (this check also makes sure that we collapse dims that have the same sign of strides
+    // meaning we can merge two dimensions if they are either not flipped or both of them are)
+    bool can_collapse = sample_desc.in_strides[last_dim] * sample_desc.in_shape[last_dim] ==
+                        sample_desc.in_strides[last_dim - 1];
+    return at_least_2_dims && no_permute && no_sliced_or_pad && no_channel_dim && can_collapse;
   }
 
   void Run(KernelContext &context,

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -226,7 +226,7 @@ class SliceFlipNormalizePermutePadGpu {
       //    - if out_stride[last_dim] == in_stride[last_dim], then it is not permuted
       //    - if anchor[last_dim] == 0 && out_shape[last_dim] == in_shape[last_dim],
       //      then it is not sliced/padded
-      // 3. Last dimension is not the channel dimension
+      // 3. Neither of the two dimensions to be merged are the channel dimension
       // 4. The in_strides of the last dimension and the former one align
       //    - in_strides[last_dim] * in_shape[last_dim] == in_strides[last_dim - 1]
       int last_dim = Dims - 1;
@@ -236,6 +236,7 @@ class SliceFlipNormalizePermutePadGpu {
              sample_desc.anchor[last_dim] == 0 &&
              sample_desc.out_shape[last_dim] == sample_desc.in_shape[last_dim] &&
              sample_desc.channel_dim != last_dim &&
+             sample_desc.channel_dim != (last_dim-1) &&
              sample_desc.in_strides[last_dim] * sample_desc.in_shape[last_dim] ==
                  sample_desc.in_strides[last_dim - 1]) {
         last_dim--;

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_kernel_test.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_kernel_test.h
@@ -434,6 +434,16 @@ struct ArgsGen_SliceNormalizeFlip_PadChannels {
   }
 };
 
+template <typename OutputType, int Dims = 3>
+struct ArgsGen_SwapXY {
+  SliceFlipNormalizePermutePadArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims> args(input_shape, input_shape);
+    for (int i = 0; i < Dims; i++)
+      args.permuted_dims[i] = (i < 2 ? 1 - i : i);
+    return args;
+  }
+};
+
 using SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES = ::testing::Types<
     SliceTestArgs<int, float, 3, 1, 2,
       SliceFlipNormPermArgsGen_CopyOnly<float, 3>>,
@@ -508,7 +518,9 @@ using SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES = ::testing::Types<
     SliceTestArgs<int, float, 3, 1, 10,
       ArgsGen_SingleValuePad_PermuteHWC2CHW<float, 3>, 10, 10>,
     SliceTestArgs<int, float, 3, 1, 10,
-      ArgsGen_SliceNormalizeFlip_PadChannels<float, 3>, 10, 10>
+      ArgsGen_SliceNormalizeFlip_PadChannels<float, 3>, 10, 10>,
+    SliceTestArgs<uint8_t, uint8_t, 3, 1, 3,
+      ArgsGen_SwapXY<uint8_t, 3>, 3, 3, 3>
 >;
 
 using SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES_CPU_ONLY = ::testing::Types<

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_kernel_test.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_kernel_test.h
@@ -435,11 +435,24 @@ struct ArgsGen_SliceNormalizeFlip_PadChannels {
 };
 
 template <typename OutputType, int Dims = 3>
-struct ArgsGen_SwapXY {
+struct SliceFlipNormPermArgsGen_SwapXY {
   SliceFlipNormalizePermutePadArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
     SliceFlipNormalizePermutePadArgs<Dims> args(input_shape, input_shape);
+    static_assert(Dims >= 2);
     for (int i = 0; i < Dims; i++)
       args.permuted_dims[i] = (i < 2 ? 1 - i : i);
+    return args;
+  }
+};
+
+template <typename OutputType, int Dims = 3>
+struct SliceFlipNormPermArgsGen_FlipYZ_ChannelFirst {
+  SliceFlipNormalizePermutePadArgs<Dims> Get(const TensorShape<Dims>& input_shape) {
+    SliceFlipNormalizePermutePadArgs<Dims> args(input_shape, input_shape);
+    static_assert(Dims >= 3);
+    args.flip[1] = args.flip[2] = true;
+    args.channel_dim = 0;
+    args.fill_values.resize(args.shape[0]);
     return args;
   }
 };
@@ -520,7 +533,9 @@ using SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES = ::testing::Types<
     SliceTestArgs<int, float, 3, 1, 10,
       ArgsGen_SliceNormalizeFlip_PadChannels<float, 3>, 10, 10>,
     SliceTestArgs<uint8_t, uint8_t, 3, 1, 3,
-      ArgsGen_SwapXY<uint8_t, 3>, 3, 3, 3>
+      SliceFlipNormPermArgsGen_SwapXY<uint8_t, 3>, 3, 3, 3>,
+    SliceTestArgs<uint8_t, uint8_t, 3, 1, 3,
+      SliceFlipNormPermArgsGen_FlipYZ_ChannelFirst<uint8_t, 3>, 3, 3, 3>
 >;
 
 using SLICE_FLIP_NORMALIZE_PERMUTE_TEST_TYPES_CPU_ONLY = ::testing::Types<


### PR DESCRIPTION
Signed-off-by: Michał Staniewski <m.staniewzki@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
While working on https://github.com/NVIDIA/DALI/pull/4232, I found a bug in the `SliceFlipNormalizePermutePad` kernel. I added a failing test for an easy reproduction, and a fix that for that. I believe, that the condition I've added is mandatory for the fusing to make any sense, so there should be no regression.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
N/A

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
The condition in the while loop could probably be optimized/rewritten in a better way.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
