### PR TITLE
Fix bug in CPU Convert

### DIFF
--- a/dali/imgcodec/util/convert.h
+++ b/dali/imgcodec/util/convert.h
@@ -206,6 +206,12 @@ template <typename Out, typename In>
 void Convert(Out *out, const int64_t *out_strides, int out_channel_dim, DALIImageType out_format,
              const In *in, const int64_t *in_strides, int in_channel_dim, DALIImageType in_format,
              const int64_t *size, int ndim) {
+  if (out_format == DALI_ANY_DATA && in_format == DALI_ANY_DATA) {
+    // When converting ANY -> ANY, we simply ignore the color conversion and rewrite the data
+    Convert(out, out_strides, in, in_strides, size, ndim, ConvertPixelDType<Out, In, 1>{1, 1});
+    return;
+  }
+
   ptrdiff_t in_channel_stride = in_strides[in_channel_dim];
   ptrdiff_t out_channel_stride = out_strides[out_channel_dim];
 


### PR DESCRIPTION

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->

Imgcodec's `Convert` has an ability to convert between color spaces, but it turns out that it failed (i.e. reported "conversion not supported) on `DALI_ANY_DATA -> DALI_ANY_DATA` conversion. In this PR I add a special case to handle such conversion.

## Additional information:

The tests required a small adjustment to work. Previously, the number of output channels was inferred from the formats, which is impossible for `DALI_ANY_DATA -> DALI_ANY_DATA`. I added `channels_hint` argument to the test method to allow specifying the number of channels in this case.

### Affected modules and functionalities:
Imgcodec's Convert + its tests


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
