### PR TITLE
Make nvjpeg decoder use its own thread pool

### DIFF
--- a/dali/imgcodec/decoders/nvjpeg/nvjpeg.h
+++ b/dali/imgcodec/decoders/nvjpeg/nvjpeg.h
@@ -37,8 +37,8 @@ class DLL_PUBLIC NvJpegDecoderInstance : public BatchParallelDecoderImpl {
   // one passed by the DecodeContext. Overriding thread pool pointer caried in
   // the context argument of this variant of
   // BatchParallelDecoderImpl::ScheduleDecode is enough to cover all the Decode
-  // and ScheduleDecode function. This is because all that functions eventually
-  // call this variant of ScheduleDecode.
+  // and ScheduleDecode functions. This is because all that functions
+  // eventually call this variant of ScheduleDecode.
   FutureDecodeResults ScheduleDecode(DecodeContext ctx,
                                      span<SampleView<GPUBackend>> out,
                                      cspan<ImageSource *> in,

--- a/dali/imgcodec/decoders/nvjpeg/nvjpeg.h
+++ b/dali/imgcodec/decoders/nvjpeg/nvjpeg.h
@@ -33,6 +33,21 @@ class DLL_PUBLIC NvJpegDecoderInstance : public BatchParallelDecoderImpl {
  public:
   explicit NvJpegDecoderInstance(int device_id, const std::map<std::string, any> &params);
 
+  // NvjpegDecoderInstance has to operate on its own thread pool instead of the
+  // one passed by the DecodeContext. Overriding thread pool pointer caried in
+  // the context argument of this variant of
+  // BatchParallelDecoderImpl::ScheduleDecode is enough to cover all the Decode
+  // and ScheduleDecode function. This is because all that functions eventually
+  // call this variant of ScheduleDecode.
+  FutureDecodeResults ScheduleDecode(DecodeContext ctx,
+                                     span<SampleView<GPUBackend>> out,
+                                     cspan<ImageSource *> in,
+                                     DecodeParams opts,
+                                     cspan<ROI> rois = {}) override {
+    ctx.tp = tp_.get();
+    return BatchParallelDecoderImpl::ScheduleDecode(ctx, out, in, opts, rois);
+  }
+
   DecodeResult DecodeImplTask(int thread_idx,
                               cudaStream_t stream,
                               SampleView<GPUBackend> out,


### PR DESCRIPTION
Signed-off-by: Michał Sala <msala@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Due to recent changes in imgcodec decoder architecture, the nvjpeg decoder started using the thread pool provided in the `DecodingContext` structure instead of using its own. This pull request fixes this behavior.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
