### PR TITLE
Fix AssertClose bug in Imgcodec tests

### DIFF
--- a/dali/imgcodec/decoders/decoder_test_helper.h
+++ b/dali/imgcodec/decoders/decoder_test_helper.h
@@ -181,7 +181,7 @@ class DecoderTestBase : public ::testing::Test {
                    const Tensor<CPUBackend> &ref,
                    float eps) {
     TYPE_SWITCH(ref.type(), type2id, RefType, NUMPY_ALLOWED_TYPES, (
-      Check(img, view<const RefType>(ref), EqualConvertNorm(eps));
+      AssertClose(img, view<const RefType>(ref), eps);
     ), DALI_FAIL(make_string("Unsupported reference type: ", ref.type())));  // NOLINT
   }
 
@@ -189,7 +189,7 @@ class DecoderTestBase : public ::testing::Test {
                    const Tensor<CPUBackend> &ref,
                    float eps) {
     TYPE_SWITCH(ref.type(), type2id, RefType, NUMPY_ALLOWED_TYPES, (
-      Check(view<const OutputType>(img), view<const RefType>(ref), EqualConvertNorm(eps));
+      AssertClose(view<const OutputType>(img), view<const RefType>(ref), eps);
     ), DALI_FAIL(make_string("Unsupported reference type: ", ref.type())));  // NOLINT
   }
 

--- a/dali/imgcodec/decoders/libjpeg_turbo_test.cc
+++ b/dali/imgcodec/decoders/libjpeg_turbo_test.cc
@@ -93,6 +93,15 @@ class LibJpegTurboDecoderTest : public NumpyDecoderTestBase<CPUBackend, OutputTy
     opts.dtype = dtype;
     return opts;
   }
+
+  float GetEps() {
+    if (std::is_floating_point_v<OutputType>) {
+      return 0.01f;
+    } else {
+      // Adjusting the epsilon to OutputType
+      return 0.01 * max_value<OutputType>();
+    }
+  }
 };
 
 using DecodeOutputTypes = ::testing::Types<uint8_t, int16_t, float>;
@@ -118,7 +127,7 @@ TYPED_TEST(LibJpegTurboDecoderTest, DecodeYCbCr) {
   params.format = DALI_YCbCr;
   auto decoded = this->Decode(&image.src, params);
   auto ref = this->ReadReferenceFrom(make_string(ref_prefix, "_ycbcr.npy"));
-  this->AssertClose(decoded, ref, 0.01);
+  this->AssertClose(decoded, ref, this->GetEps());
 }
 
 }  // namespace test

--- a/dali/imgcodec/decoders/nvjpeg/nvjpeg_test.cc
+++ b/dali/imgcodec/decoders/nvjpeg/nvjpeg_test.cc
@@ -75,7 +75,7 @@ class NvJpegDecoderTest : public NumpyDecoderTestBase<GPUBackend, OutputType> {
   /**
    * @brief Checks if the image is similar to the reference.
    *
-   * Checks if 1) max error is lower than 30% 2) mean squared error is lower than 1%.
+   * Checks if 1) max error is lower than 30% 2) mean squared error is lower than 2%.
    */
   void AssertSimilar(const TensorView<StorageCPU, const OutputType> &img,
                      const Tensor<CPUBackend> &ref_tensor) {
@@ -85,16 +85,16 @@ class NvJpegDecoderTest : public NumpyDecoderTestBase<GPUBackend, OutputType> {
       float eps = ConvertSatNorm<OutputType>(0.3);
       Check(img, ref, EqualConvertNorm(eps));
 
-      double mean_error = 0;
+      double mean_square_error = 0;
       uint64_t size = volume(img.shape);
       for (size_t i = 0; i < size; i++) {
         double img_value = ConvertSatNorm<double>(img.data[i]);
         double ref_value = ConvertSatNorm<double>(ref.data[i]);
-        double error = abs(img_value - ref_value);
-        mean_error += error;
+        double error = img_value - ref_value;
+        mean_square_error += error * error;
       }
-      mean_error /= size;
-      EXPECT_LT(mean_error, 0.01);
+      mean_square_error = sqrt(mean_square_error / size);
+      EXPECT_LT(mean_square_error, 0.02);
     ), DALI_FAIL(make_string("Unsupported reference type: ", ref_tensor.type())));  // NOLINT
   }
 

--- a/dali/imgcodec/decoders/nvjpeg/nvjpeg_test.cc
+++ b/dali/imgcodec/decoders/nvjpeg/nvjpeg_test.cc
@@ -72,6 +72,32 @@ class NvJpegDecoderTest : public NumpyDecoderTestBase<GPUBackend, OutputType> {
     return std::make_shared<JpegParser>();
   }
 
+  /**
+   * @brief Checks if the image is similar to the reference.
+   *
+   * Checks if 1) max error is lower than 30% 2) mean squared error is lower than 1%.
+   */
+  void AssertSimilar(const TensorView<StorageCPU, const OutputType> &img,
+                     const Tensor<CPUBackend> &ref_tensor) {
+    TYPE_SWITCH(ref_tensor.type(), type2id, RefType, NUMPY_ALLOWED_TYPES, (
+      auto ref = view<const RefType>(ref_tensor);
+
+      float eps = ConvertSatNorm<OutputType>(0.3);
+      Check(img, ref, EqualConvertNorm(eps));
+
+      double mean_error = 0;
+      uint64_t size = volume(img.shape);
+      for (size_t i = 0; i < size; i++) {
+        double img_value = ConvertSatNorm<double>(img.data[i]);
+        double ref_value = ConvertSatNorm<double>(ref.data[i]);
+        double error = abs(img_value - ref_value);
+        mean_error += error;
+      }
+      mean_error /= size;
+      EXPECT_LT(mean_error, 0.01);
+    ), DALI_FAIL(make_string("Unsupported reference type: ", ref_tensor.type())));  // NOLINT
+  }
+
   DecodeParams GetParams() {
     DecodeParams opts{};
     opts.dtype = dtype;
@@ -84,8 +110,7 @@ class NvJpegDecoderTest : public NumpyDecoderTestBase<GPUBackend, OutputType> {
     auto ref = this->ReadReferenceFrom(
       from_dali_extra("db/single/reference/jpeg/site-1534685_1280.npy"));
 
-    float eps = 1;
-    this->AssertClose(decoded, ref, eps);
+    this->AssertSimilar(decoded, ref);
   }
 
   void RunSingleYCbCrTest() {
@@ -98,8 +123,7 @@ class NvJpegDecoderTest : public NumpyDecoderTestBase<GPUBackend, OutputType> {
     auto ref = this->ReadReferenceFrom(
       from_dali_extra("db/single/reference/jpeg/site-1534685_1280_ycbcr.npy"));
 
-    float eps = 1;
-    this->AssertClose(decoded, ref, eps);
+    this->AssertSimilar(decoded, ref);
   }
 };
 


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
There were three versions of `AssertClose` in Imgcodec's decoder test helper:
https://github.com/NVIDIA/DALI/blob/edbac3ce6875fee4a405a252e802ce9cb9d2c274/dali/imgcodec/decoders/decoder_test_helper.h#L172-L194

Only one of those interpreted the `eps` as being in dynamic range of the output type (and that's what the doc promised). As a result, `eps=1`, which should mean "we allow +/-1 error in `uint8` image" was interpreted as "we allow +/-1.0 error in **float** image". And, as floats have dynamic range 0.0-1.0, this effectively meant "we allow **any** error".

In this PR I fix the behaviour of the buggy overloads.

The fix is simply making those two overloads call the correct versions of `AssertClose` instead of calling `Check` directly.

## Additional information:

This required adjusting some tests:
- In LibJpegTurbo adjusting the eps was required
- In NvJpeg fixing `AssertClose` revealed another problem: reference images were generated using libjpegturbo, resulting in high (but local) differences. I created a new method `AssertSimilar`, which has a very liberal `eps` (=30%), but also requires the mean error to be relatively small (<1%).

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
