### PR TITLE
Prevent unnecessary synchronization in MakeContiguous.

### DIFF
--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -89,6 +89,60 @@ inline bool set_deletion_order(const std::shared_ptr<T> &ptr, AccessOrder order)
 }
 
 /**
+ * @brief Checks whether the underlying managed object of the shared pointers is the same.
+ *
+ * This function may return true for two pointers that do not compare equal if they were created
+ * as aliasing different shared pointers.
+ */
+template <typename T, typename U>
+bool same_managed_object(const std::shared_ptr<T> &a, const std::shared_ptr<U> &b) {
+  return !a.owner_before(b) && !b.owner_before(a);
+}
+
+template <typename T, typename U>
+bool same_managed_object(const std::shared_ptr<T> &a, const std::weak_ptr<U> &b) {
+  return !a.owner_before(b) && !b.owner_before(a);
+}
+
+template <typename T, typename U>
+bool same_managed_object(const std::weak_ptr<T> &a, const std::shared_ptr<U> &b) {
+  return !a.owner_before(b) && !b.owner_before(a);
+}
+
+template <typename T, typename U>
+bool same_managed_object(const std::weak_ptr<T> &a, const std::weak_ptr<U> &b) {
+  return !a.owner_before(b) && !b.owner_before(a);
+}
+
+
+/**
+ * @brief Checks whether two shared pointers are the same
+ *
+ * Unlike `operator==`, this function doesn't just compare the value returned by `get`, but also
+ * checks for equality of the managed object (see `same_managed_object`).
+ */
+template <typename T, typename U>
+bool same_shared_ptr(const std::shared_ptr<T> &a, const std::shared_ptr<U> &b) {
+  return a == b && same_managed_object(a, b);
+}
+
+template <typename T, typename U>
+bool same_shared_ptr(const std::shared_ptr<T> &a, const std::weak_ptr<U> &b) {
+  return a == b && same_managed_object(a, b);
+}
+
+template <typename T, typename U>
+bool same_shared_ptr(const std::weak_ptr<T> &a, const std::shared_ptr<U> &b) {
+  return a == b && same_managed_object(a, b);
+}
+
+template <typename T, typename U>
+bool same_shared_ptr(const std::weak_ptr<T> &a, const std::weak_ptr<U> &b) {
+  return a == b && same_managed_object(a, b);
+}
+
+
+/**
  * @brief Base class to provide common functionality needed by Pipeline data
  * structures. Not meant for use, does not provide methods for allocating
  * any actual storage. The 'Backend' template parameter dictates where the
@@ -466,7 +520,12 @@ class DLL_PUBLIC Buffer {
   }
 
   inline void ShareData(const Buffer<Backend> &other) {
-    free_storage();
+    if (this == &other)
+      return;
+
+    if (!same_managed_object(data_, other.data_))
+      free_storage();
+
     order_ = other.order_;
     data_ = other.data_;
     size_ = other.size_;
@@ -490,7 +549,8 @@ class DLL_PUBLIC Buffer {
   inline void set_backing_allocation(const shared_ptr<void> &ptr, size_t bytes, bool pinned,
                                      DALIDataType type, size_t size, int device_id,
                                      AccessOrder order = {}) {
-    free_storage();
+    if (!same_managed_object(data_, ptr))
+      free_storage();
 
     // Set the new order before replacing the allocation
     set_order(order);

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -189,6 +189,9 @@ class Tensor : public Buffer<Backend> {
    * shared data or the call will fail.
    */
   inline void ShareData(const Tensor<Backend> &t) {
+    if (this == &t)
+      return;
+
     DALI_ENFORCE(IsValidType(t.type()), "To share data, "
         "the input Tensor must have a valid data type.");
 
@@ -222,7 +225,8 @@ class Tensor : public Buffer<Backend> {
       "Only empty tensors can be shared without specifying a type.");
 
     // Free the underlying storage.
-    free_storage();
+    if (!same_managed_object(data_, ptr))
+      free_storage();
 
     // Set the new order, if provided.
     if (order)

--- a/dali/pipeline/data/tensor_list.cc
+++ b/dali/pipeline/data/tensor_list.cc
@@ -23,28 +23,6 @@
 #include "dali/pipeline/data/types.h"
 
 namespace dali {
-
-namespace {
-
-/**
- * @brief Check if both shared pointers have the same managed pointer (not the one returned by
- * .get())
- */
-bool has_same_owner(const std::shared_ptr<void> &x, const std::shared_ptr<void> &y) {
-  if (x.owner_before(y) || y.owner_before(x))
-    return false;
-  return true;
-}
-
-
-bool has_same_owner(const std::weak_ptr<void> &x, const std::shared_ptr<void> &y) {
-  if (x.owner_before(y) || y.owner_before(x))
-    return false;
-  return true;
-}
-
-}  // namespace
-
 namespace copy_impl {
 
 /**
@@ -812,7 +790,7 @@ void TensorList<Backend>::DoMakeNoncontiguous() {
     // This will allow for the individual buffers to be resized.
     // The downside of this is we may keep the big contiguous buffer until all individual
     // samples are replaced.
-    if (has_same_owner(buffer_bkp_, t.data_)) {
+    if (same_managed_object(buffer_bkp_, t.data_)) {
       t.detach();
     }
   }
@@ -864,34 +842,61 @@ void TensorList<Backend>::Copy(const TensorList<SrcBackend> &src, AccessOrder or
 
 
 template <typename Backend>
-void TensorList<Backend>::ShareData(const TensorList<Backend> &tv) {
-  Reset();
+void TensorList<Backend>::ShareData(const TensorList<Backend> &tl) {
+  if (this == &tl)
+    return;
 
-  state_ = tv.state_;
-  curr_num_tensors_ = tv.curr_num_tensors_;
-  type_ = tv.type_;
-  sample_dim_ = tv.sample_dim_;
-  shape_ = tv.shape_;
-  layout_ = tv.layout_;
-  pinned_ = tv.pinned_;
-  order_ = tv.order_;
-  device_ = tv.device_;
+  // We need not just the pointer values, but also the underlying managed objects to be the same
+  // to consider this an identity operation.
 
-  if (tv.IsContiguous()) {
-    contiguous_buffer_.ShareData(tv.contiguous_buffer_);
-    tensors_.resize(shape().num_samples());
-    recreate_views();
-  } else {
-    int batch_size = tv.num_samples();
-    tensors_.resize(shape().num_samples());
-    for (int i = 0; i < batch_size; i++) {
-      tensors_[i].ShareData(tv.tensors_[i]);
+  bool same_data = same_shared_ptr(contiguous_buffer_.data_, tl.contiguous_buffer_.data_);
+  if (!tl.IsContiguous() && same_data) {
+    if (num_samples() == tl.num_samples()) {
+      for (int i = 0; i < num_samples(); i++) {
+        if (!same_shared_ptr(tensors_[i].data_, tl.tensors_[i].data_)) {
+          same_data = false;
+          break;
+        }
+      }
+    } else {
+      same_data = false;
     }
   }
 
-  SetLayout(tv.GetLayout());
+  // if the data is the same, there's no point in resetting the buffer (and possibly synchronizing)
+  if (!same_data)
+    Reset();
+
+  buffer_bkp_.reset();  // TODO(michalz): perhaps we should copy it from the source, too?
+
+  state_ = tl.state_;
+  curr_num_tensors_ = tl.curr_num_tensors_;
+  type_ = tl.type_;
+  sample_dim_ = tl.sample_dim_;
+  shape_ = tl.shape_;
+  layout_ = tl.layout_;
+  pinned_ = tl.pinned_;
+  order_ = tl.order_;
+  device_ = tl.device_;
+
+  if (tl.IsContiguous()) {
+    if (!same_data)
+      contiguous_buffer_.ShareData(tl.contiguous_buffer_);
+    tensors_.resize(shape().num_samples());
+    recreate_views();
+  } else {
+    if (!same_data) {
+      int batch_size = tl.num_samples();
+      tensors_.resize(shape().num_samples());
+      for (int i = 0; i < batch_size; i++) {
+        tensors_[i].ShareData(tl.tensors_[i]);
+      }
+    }
+  }
+
+  SetLayout(tl.GetLayout());
   for (int i = 0; i < curr_num_tensors_; i++) {
-    SetMeta(i, tv.GetMeta(i));
+    SetMeta(i, tl.GetMeta(i));
   }
 }
 
@@ -1110,7 +1115,7 @@ bool TensorList<Backend>::shares_data() const {
   }
   for (const auto &tensor : tensors_) {
     if (tensor.shares_data() &&
-        !has_same_owner(contiguous_buffer_.get_data_ptr(), tensor.get_data_ptr())) {
+        !same_managed_object(contiguous_buffer_.get_data_ptr(), tensor.get_data_ptr())) {
       return true;
     }
   }


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
MakeContiguous may introduce additional, unnecessary synchronization when:
a) copying - this is solved by using the workspace stream to submit the H2D copy
b) sharing the data (when already contiguous).

The latter results in multiple calls to set_order - the workaround is to set the order to that of the source TensorList for the duration of the call to ShareData and restoring the original output order. These orders are guaranteed by the executor to be already synchronized.

Additionally, when ShareData is called with the same data (for TensorList) or the same underlying managaged object (in Tensor and Buffer), there's no call to free_storage, avoiding the synchronization with the deallocation order.

This is just a workaround - having the synchronization isn't entirely wrong, however fixing stream semantics is out of scope of this quick fix.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Regression tests: TensorListTestSuite

New tests: Actual tests for the synchronization are not implementable within current framework.

- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
