### PR TITLE
Separate nvjpeg lib wrapper from the decoder

### DIFF
--- a/dali/CMakeLists.txt
+++ b/dali/CMakeLists.txt
@@ -47,6 +47,10 @@ if (BUILD_DALI_PIPELINE)
   add_subdirectory(c_api)
 endif()
 
+if (BUILD_DALI_OPERATORS OR BUILD_DALI_IMGCODEC)
+  add_subdirectory(nvjpeg)
+endif()
+
 if (BUILD_DALI_OPERATORS)
   add_subdirectory(operators)
 endif()

--- a/dali/imgcodec/CMakeLists.txt
+++ b/dali/imgcodec/CMakeLists.txt
@@ -38,6 +38,11 @@ set(lib_exports "libdali_imgcodec.map")
 configure_file("${DALI_ROOT}/cmake/${lib_exports}.in" "${CMAKE_BINARY_DIR}/${lib_exports}")
 target_link_libraries(dali_imgcodec PRIVATE  -Wl,--version-script=${CMAKE_BINARY_DIR}/${lib_exports})
 
+if (BUILD_NVJPEG AND WITH_DYNAMIC_CUDA_TOOLKIT)
+  target_link_libraries(dali_imgcodec PRIVATE dynlink_nvjpeg)
+  target_link_libraries(dali_imgcodec PRIVATE "-Wl,--exclude-libs,$<TARGET_FILE_NAME:dynlink_nvjpeg>")
+endif(BUILD_NVJPEG AND WITH_DYNAMIC_CUDA_TOOLKIT)
+
 if (BUILD_TEST)
   # TODO(janton): create a test_utils_lib with dali_test_config.cc and other common utilities
   adjust_source_file_language_property("${DALI_IMGCODEC_TEST_SRCS}")

--- a/dali/nvjpeg/CMakeLists.txt
+++ b/dali/nvjpeg/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generate necessary stub for nvjpeg if needed
+
+DETERMINE_GCC_SYSTEM_INCLUDE_DIRS("c++" "${CMAKE_CXX_COMPILER}" "${CMAKE_CXX_FLAGS}" INFERED_COMPILER_INCLUDE)
+
+# transform a list of paths into a list of include directives
+set(DEFAULT_COMPILER_INCLUDE)
+foreach(incl_dir ${INFERED_COMPILER_INCLUDE})
+  set(DEFAULT_COMPILER_INCLUDE "${DEFAULT_COMPILER_INCLUDE} -I${incl_dir}")
+endforeach(incl_dir)
+separate_arguments(DEFAULT_COMPILER_INCLUDE UNIX_COMMAND  "${DEFAULT_COMPILER_INCLUDE}")
+
+if(WITH_DYNAMIC_CUDA_TOOLKIT)
+  set(NVJPEG_GENERATED_STUB "${CMAKE_CURRENT_BINARY_DIR}/dynlink_nvjpeg_gen.cc")
+  add_custom_command(
+    OUTPUT ${NVJPEG_GENERATED_STUB}
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/stub_codegen.py --unique_prefix=Nvjpeg --
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/nvjpeg.json" ${NVJPEG_GENERATED_STUB}
+    "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/nvjpeg.h" "-I${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
+
+    # for some reason QNX fails with 'too many errors emitted' is this is not set
+    "-ferror-limit=0"
+    ${DEFAULT_COMPILER_INCLUDE}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/stub_codegen.py
+    "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/nvjpeg.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/stub_generator/nvjpeg.json"
+    COMMENT "Running nvjpeg.h stub generator"
+    VERBATIM)
+
+  set_source_files_properties(${NVJPEG_GENERATED_STUB} PROPERTIES GENERATED TRUE)
+  add_library(dynlink_nvjpeg STATIC nvjpeg_wrap.cc ${NVJPEG_GENERATED_STUB})
+endif()

--- a/dali/nvjpeg/nvjpeg_wrap.cc
+++ b/dali/nvjpeg/nvjpeg_wrap.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,9 +17,6 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
-
-#include "dali/operators/decoder/nvjpeg/nvjpeg_helper.h"
-
 
 namespace {
 

--- a/dali/operators/decoder/nvjpeg/CMakeLists.txt
+++ b/dali/operators/decoder/nvjpeg/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019, 2021, 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,35 +13,6 @@
 # limitations under the License.
 
 add_subdirectory(fused)
-
-DETERMINE_GCC_SYSTEM_INCLUDE_DIRS("c++" "${CMAKE_CXX_COMPILER}" "${CMAKE_CXX_FLAGS}" INFERED_COMPILER_INCLUDE)
-
-# transform a list of paths into a list of include directives
-set(DEFAULT_COMPILER_INCLUDE)
-foreach(incl_dir ${INFERED_COMPILER_INCLUDE})
-  set(DEFAULT_COMPILER_INCLUDE "${DEFAULT_COMPILER_INCLUDE} -I${incl_dir}")
-endforeach(incl_dir)
-separate_arguments(DEFAULT_COMPILER_INCLUDE UNIX_COMMAND  "${DEFAULT_COMPILER_INCLUDE}")
-
-if (WITH_DYNAMIC_CUDA_TOOLKIT)
-    set(NVJPEG_GENERATED_STUB "${CMAKE_CURRENT_BINARY_DIR}/dynlink_nvjpeg_gen.cc")
-    add_custom_command(
-        OUTPUT ${NVJPEG_GENERATED_STUB}
-        COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/stub_generator/stub_codegen.py --unique_prefix=Nvjpeg --
-                    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/stub_generator/nvjpeg.json" ${NVJPEG_GENERATED_STUB}
-                    "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/nvjpeg.h" "-I${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}"
-                    # for some reason QNX fails with 'too many errors emitted' is this is not set
-                    "-ferror-limit=0"
-                    ${DEFAULT_COMPILER_INCLUDE}
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/stub_generator/stub_codegen.py
-                "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}/nvjpeg.h"
-                "${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/stub_generator/nvjpeg.json"
-        COMMENT "Running nvjpeg.h stub generator"
-        VERBATIM)
-
-    set_source_files_properties(${NVJPEG_GENERATED_STUB} PROPERTIES GENERATED TRUE)
-    add_library(dynlink_nvjpeg STATIC nvjpeg_wrap.cc ${NVJPEG_GENERATED_STUB})
-endif()
 
 collect_headers(DALI_INST_HDRS PARENT_SCOPE)
 collect_sources(DALI_OPERATOR_SRCS PARENT_SCOPE)


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Fixes builds with dynamic cuda linking complaining about lack of nvjpeg symbold in imgcodec module.
Moves dynamic nvjpeg wrapper and necessary stub to a separate top-level dir that may be used both by operator and imgcoded modules.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
