### PR TITLE
Unify buffers caching in CPU/GPU external source

### DIFF
--- a/dali/pipeline/operator/builtin/external_source.cc
+++ b/dali/pipeline/operator/builtin/external_source.cc
@@ -19,10 +19,10 @@ namespace dali {
 
 template <>
 void ExternalSource<CPUBackend>::RunImpl(HostWorkspace &ws) {
-  std::list<uptr_tv_type> tensor_list_elm;
+  std::list<uptr_tl_type> tensor_list_elm;
   {
     std::unique_lock<std::mutex> busy_lock(busy_m_);
-    tensor_list_elm = tv_data_.PopFront();
+    tensor_list_elm = tl_data_.PopFront();
     state_.pop_front();
   }
   auto &output = ws.template Output<CPUBackend>(0);

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -320,7 +320,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
     output_desc.resize(1);
     output_desc[0].shape = tl_data_.PeekFront()->shape();
     output_desc[0].type = tl_data_.PeekFront()->type();
-    // unconditionally disabled, still we can provide share but we don't want to allocate anything
+    // unconditionally disabled, still we can provide shape but we don't want to allocate anything
     return false;
   }
 

--- a/dali/test/python/test_external_source_cupy.py
+++ b/dali/test/python/test_external_source_cupy.py
@@ -22,7 +22,7 @@ from nose.plugins.attrib import attr
 from test_external_source_impl import *  # noqa:F403, F401
 from test_external_source_impl import use_cupy
 from test_utils import check_output, check_output_pattern
-from nvidia.dali import Pipeline
+from nvidia.dali import Pipeline, pipeline_def
 import nvidia.dali.fn as fn
 from nvidia.dali.tensors import TensorGPU
 import numpy as np
@@ -111,3 +111,55 @@ def test_cross_device():
             for dst in [0, 1]:
                 for use_dali_tensor in [True, False]:
                     yield _test_cross_device, src, dst, use_dali_tensor
+
+
+def _test_memory_consumption(device, test_case):
+    batch_size = 32
+    num_iters = 128
+
+    if device == "cpu":
+        import numpy as np
+        fw = np
+    else:
+        fw = cp
+
+    def no_copy_sample():
+        batch = [fw.full((1024, 1024, 4), i, dtype=fw.int32) for i in range(batch_size)]
+
+        def cb(sample_info):
+            return batch[sample_info.idx_in_batch]
+        return cb
+
+    def copy_sample():
+
+        def cb(sample_info):
+            return fw.full((1024, 1024, 4), sample_info.idx_in_batch, dtype=fw.int32)
+        return cb
+
+    def copy_batch():
+
+        def cb():
+            return fw.full((batch_size, 1024, 1024, 4), 42, dtype=fw.int32)
+        return cb
+
+    cases = {
+        'no_copy_sample': (no_copy_sample, True, False),
+        'copy_sample': (copy_sample, False, False),
+        'copy_batch': (copy_batch, False, True)
+    }
+
+    cb, no_copy, batch_mode = cases[test_case]
+
+    @pipeline_def
+    def pipeline():
+        return fn.external_source(source=cb(), device=device, batch=batch_mode, no_copy=no_copy)
+    pipe = pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+    pipe.build()
+    for _ in range(num_iters):
+        pipe.run()
+
+
+def test_memory_consumption():
+    for device in ["cpu", "gpu"]:
+        for test_case in ["no_copy_sample", "copy_sample", "copy_batch"]:
+            yield _test_memory_consumption, device, test_case


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
External source had two `CachingList` for buffers, one with tensor lists, one with tensor vectors. Replacing TV and TL with a single common container lead to a bug in GPU external source op: data was fed through tl caching list but the buffers consumed by the operator `RunImpl` were put back to the tv caching list and were left there indefinitely. Effectively, it lead to each iteration to hog memory until OOM.

The issue was introduced in: https://github.com/NVIDIA/DALI/pull/4189
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
CC implementation of ExternalSource.
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
Were the two separate cache lists as members of a single op ever needed? It seems only one was ever used based on the op Backend. If that is really the case, the changes from the PR should be fine. Otherwise we may need to keep them both and assure we pick the recycle place correctly.
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3019
<!--- DALI-XXXX or NA --->
