### PR TITLE
Add image decoder registry.

### DIFF
--- a/dali/imgcodec/decoders/libjpeg_turbo.cc
+++ b/dali/imgcodec/decoders/libjpeg_turbo.cc
@@ -16,6 +16,7 @@
 #include "dali/imgcodec/decoders/jpeg/jpeg_mem.h"
 #include "dali/imgcodec/parsers/jpeg.h"
 #include "dali/imgcodec/util/convert.h"
+#include "dali/imgcodec/registry.h"
 #include "dali/core/common.h"
 
 namespace dali {
@@ -81,6 +82,8 @@ DecodeResult LibJpegTurboDecoderInstance::Decode(DecodeContext ctx,
 
   return res;
 }
+
+REGISTER_DECODER("JPEG", LibJpegTurboDecoderFactory, HostDecoderPriority);
 
 }  // namespace imgcodec
 }  // namespace dali

--- a/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
+++ b/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
@@ -19,6 +19,7 @@
 #include "dali/kernels/common/utils.h"
 #include "dali/core/static_switch.h"
 #include "dali/kernels/dynamic_scratchpad.h"
+#include "dali/imgcodec/registry.h"
 
 #define LIBTIFF_CALL_SUCCESS 1
 #define LIBTIFF_CALL(call)                                \
@@ -327,6 +328,8 @@ DecodeResult LibTiffDecoderInstance::Decode(DecodeContext ctx,
 
   return {true, nullptr};
 }
+
+REGISTER_DECODER("TIFF", LibTiffDecoderFactory, HostDecoderPriority);
 
 }  // namespace imgcodec
 }  // namespace dali

--- a/dali/imgcodec/decoders/nvjpeg/nvjpeg.h
+++ b/dali/imgcodec/decoders/nvjpeg/nvjpeg.h
@@ -111,6 +111,7 @@ class NvJpegDecoderFactory : public ImageDecoderFactory {
     ImageDecoderProperties props;
     props.supports_partial_decoding = false;
     props.supported_input_kinds = InputKind::HostMemory;
+    props.gpu_output = true;
     props.fallback = true;
 
     return props;

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
@@ -21,6 +21,7 @@
 #include "dali/imgcodec/decoders/nvjpeg/permute_layout.h"
 #include "dali/imgcodec/util/convert_gpu.h"
 #include "dali/core/static_switch.h"
+#include "dali/imgcodec/registry.h"
 
 namespace dali {
 namespace imgcodec {
@@ -263,6 +264,8 @@ DecodeResult NvJpeg2000DecoderInstance::DecodeImplTask(int thread_idx,
 
   return result;
 }
+
+REGISTER_DECODER("JPEG2000", NvJpeg2000DecoderFactory, CUDADecoderPriority);
 
 }  // namespace imgcodec
 }  // namespace dali

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.h
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.h
@@ -186,6 +186,7 @@ class NvJpeg2000DecoderFactory : public ImageDecoderFactory {
       ImageDecoderProperties props;
       props.supported_input_kinds = InputKind::HostMemory;
       props.supports_partial_decoding = false;  // roi support requires decoding the whole file
+      props.gpu_output = true;
       props.fallback = true;
       return props;
     }();

--- a/dali/imgcodec/decoders/opencv_fallback.cc
+++ b/dali/imgcodec/decoders/opencv_fallback.cc
@@ -16,6 +16,7 @@
 #include <opencv2/imgproc.hpp>
 #include "dali/imgcodec/decoders/opencv_fallback.h"
 #include "dali/imgcodec/util/convert.h"
+#include "dali/imgcodec/registry.h"
 
 namespace dali {
 namespace imgcodec {
@@ -123,6 +124,7 @@ DecodeResult OpenCVDecoderInstance::DecodeImplTask(int thread_idx,
   return res;
 }
 
+REGISTER_DECODER("*", OpenCVDecoderFactory, FallbackDecoderPriority);
 
 }  // namespace imgcodec
 }  // namespace dali

--- a/dali/imgcodec/init.cc
+++ b/dali/imgcodec/init.cc
@@ -1,0 +1,52 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <memory>
+#include "dali/imgcodec/image_format.h"
+#include "dali/imgcodec/image_decoder_interfaces.h"
+
+#include "dali/imgcodec/parsers/bmp.h"
+#include "dali/imgcodec/parsers/jpeg.h"
+#include "dali/imgcodec/parsers/jpeg2000.h"
+#include "dali/imgcodec/parsers/png.h"
+#include "dali/imgcodec/parsers/pnm.h"
+#include "dali/imgcodec/parsers/tiff.h"
+#include "dali/imgcodec/parsers/webp.h"
+
+using std::shared_ptr;
+using std::make_shared;
+
+namespace dali {
+namespace imgcodec {
+
+template <typename Parser>
+std::shared_ptr<ImageFormat> make_format(const char *name) {
+  return make_shared<ImageFormat>(name, make_shared<Parser>());
+}
+
+void InitFormats(ImageFormatRegistry &reg) {
+  shared_ptr<ImageFormat> format;
+
+  reg.RegisterFormat(make_format<BmpParser>("BMP"));
+  reg.RegisterFormat(make_format<JpegParser>("JPEG"));
+  reg.RegisterFormat(make_format<Jpeg2000Parser>("JPEG2000"));
+  reg.RegisterFormat(make_format<PngParser>("PNG"));
+  reg.RegisterFormat(make_format<PnmParser>("PNM"));
+  reg.RegisterFormat(make_format<TiffParser>("TIFF"));
+  reg.RegisterFormat(make_format<WebpParser>("WebP"));
+}
+
+}  // namespace imgcodec
+}  // namespace dali

--- a/dali/imgcodec/registry.h
+++ b/dali/imgcodec/registry.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_IMGCODEC_REGISTRY_H_
+#define DALI_IMGCODEC_REGISTRY_H_
+
+#include <memory>
+#include "dali/imgcodec/image_format.h"
+
+namespace dali {
+namespace imgcodec {
+
+template <typename Factory>
+void RegisterDecoder(const char *format_name, float priority) {
+  if (format_name[0] == '*') {
+    auto factory = std::make_shared<Factory>();
+    for (ImageFormat *format : ImageFormatRegistry::instance().Formats())
+          format->RegisterDecoder(factory, priority);
+  } else {
+    auto *format = ImageFormatRegistry::instance().GetImageFormat(format_name);
+    assert(format != nullptr);
+    format->RegisterDecoder(std::make_shared<Factory>(), priority);
+  }
+}
+
+
+template <typename Factory>
+struct ImageDecoderRegisterer {
+  ImageDecoderRegisterer(const char *format_name, float priority) {
+    RegisterDecoder<Factory>(format_name, priority);
+  }
+};
+
+#define REGISTER_DECODER(FormatName, Factory, Priority) \
+static auto &RegisterDecoder_##Factory() { \
+  static ImageDecoderRegisterer<Factory> reg(FormatName, Priority); \
+  return reg; \
+} \
+static auto &_##Factory##_registerer = RegisterDecoder_##Factory();
+
+static constexpr float HighestDecoderPriority = 0;
+/// @brief The decoder has a dedicated hardware unit and thus, is preferred
+static constexpr float HWDecoderPriority = 10;
+/// @brief The decoder runs on a GPU, utilizing normal CUDA cores
+static constexpr float CUDADecoderPriority = 100;
+/// @brief The decoder runs on the CPU
+static constexpr float HostDecoderPriority = 1000;
+/// @brief Use if nothing better is found
+static constexpr float FallbackDecoderPriority = 1e+30;
+
+}  // namespace imgcodec
+}  // namespace dali
+
+#endif  // DALI_IMGCODEC_REGISTRY_H_

--- a/dali/imgcodec/registry_test.cc
+++ b/dali/imgcodec/registry_test.cc
@@ -1,0 +1,47 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <typeinfo>
+#include "dali/imgcodec/registry.h"
+#include "dali/imgcodec/image_decoder_interfaces.h"
+
+namespace dali {
+namespace imgcodec {
+
+TEST(DecoderRegistryTest, BasicTest) {
+  for (const char *name : { "JPEG", "JPEG2000", "TIFF", "PNG", "BMP", "WebP" }) {
+    const ImageFormat *f = ImageFormatRegistry::instance().GetImageFormat(name);
+    EXPECT_NE(f, nullptr) << name << " format not found.";
+    if (!f)
+      continue;
+    EXPECT_GT(f->Decoders().size(), 0) << "No decoder found format: " << name;
+  }
+}
+
+TEST(DecoderRegistryTest, Fallback) {
+  for (auto *format : ImageFormatRegistry::instance().Formats()) {
+    bool found = false;
+    for (auto *factory : format->Decoders()) {
+      if (strstr(typeid(*factory).name(), "OpenCV")) {
+        found = true;
+        break;
+      }
+    }
+    ASSERT_TRUE(found) <<  "Fallback decoder not registered for a format";
+  }
+}
+
+}  // namespace imgcodec
+}  // namespace dali

--- a/include/dali/imgcodec/image_decoder_interfaces.h
+++ b/include/dali/imgcodec/image_decoder_interfaces.h
@@ -79,7 +79,7 @@ struct ROI {
 
 struct ImageDecoderProperties {
   /**
-   * @brief Whether the codec can decode a region of interest without decoding the entire image
+   * @brief Whether the decoder can decode a region of interest without decoding the entire image
    */
   bool supports_partial_decoding = false;
 
@@ -87,6 +87,11 @@ struct ImageDecoderProperties {
    * @brief A mask of supported input kinds
    */
   InputKind supported_input_kinds;
+
+  /**
+   * @brief Whether the output of the decoder is in GPU memory
+   */
+  bool gpu_output = false;
 
   /**
    * @brief if true and the codec fails to decode an image,

--- a/include/dali/imgcodec/image_format.h
+++ b/include/dali/imgcodec/image_format.h
@@ -57,7 +57,7 @@ class DLL_PUBLIC ImageParser {
   size_t ReadHeader(uint8_t *buffer, ImageSource *encoded, size_t n) const;
 };
 
-class ImageDecoder;
+class ImageDecoderFactory;
 
 class DLL_PUBLIC ImageFormat {
  public:
@@ -71,7 +71,7 @@ class DLL_PUBLIC ImageFormat {
   /**
    * @brief Gets a pointer to the image parser
    */
-  const ImageParser* Parser() const;
+  const ImageParser *Parser() const;
 
   /**
    * @brief Returns a string representing the name of the format
@@ -79,24 +79,26 @@ class DLL_PUBLIC ImageFormat {
   const std::string& Name() const;
 
   /**
-   * @brief Returns a set of decoders associated with this format
+   * @brief Returns a set of decoder factories associated with this format
    */
-  span<ImageDecoder* const> Decoders() const;
+  span<ImageDecoderFactory *const> Decoders() const;
 
   /**
    * @brief Registers a new decoder associated with this format, with a set priority
    *
-   * @param decoder   A decoder
+   * A decoder is registered via a factory.
+   *
+   * @param factory   A decoder factory
    * @param priority  A float representing the priority of this codec.
    *                  The lower the number, the higher priority the codec has.
    */
-  void RegisterDecoder(std::shared_ptr<ImageDecoder> decoder, float priority);
+  void RegisterDecoder(std::shared_ptr<ImageDecoderFactory> factory, float priority);
 
  private:
   std::string name_;
   std::shared_ptr<ImageParser> parser_;
-  std::multimap<float, std::shared_ptr<ImageDecoder>> decoders_;
-  std::vector<ImageDecoder*> decoder_ptrs_;
+  std::multimap<float, std::shared_ptr<ImageDecoderFactory>> decoders_;
+  std::vector<ImageDecoderFactory*> decoder_ptrs_;
 };
 
 class DLL_PUBLIC ImageFormatRegistry {
@@ -116,16 +118,24 @@ class DLL_PUBLIC ImageFormatRegistry {
    * @param image
    * @return const ImageFormat*
    */
-  const ImageFormat* GetImageFormat(ImageSource *image) const;
+  const ImageFormat *GetImageFormat(ImageSource *image) const;
+
+  /**
+   * @brief Gets a format by name by which it was registered.
+   */
+  ImageFormat *GetImageFormat(const char *name);
 
   /**
    * @brief Returns all registered image formats
    */
-  span<ImageFormat* const> Formats() const;
+  span<ImageFormat *const> Formats() const;
+
+  static ImageFormatRegistry &instance();
 
  private:
   std::vector<std::shared_ptr<ImageFormat>> formats_;
   std::vector<ImageFormat*> format_ptrs_;
+  std::map<std::string, std::shared_ptr<ImageFormat>> by_name_;
 };
 
 }  // namespace imgcodec


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:
The purpose of this change is to make it possible to use all of the available image decoders without enumerating them by hand at use site (which is at odds with the goal of abstracting away the particular decoders from their usage).

- `ImageFormatRegistry` is now a singleton.
- `ImageFormatRegistry` has a format lookup by name
- a mutable `ImageFormat` can be obtained from the registry
- There's a registration macro for decoders, which registers a decoder factory in the (now global) `ImageFormatRegistry`.

## Additional information:

### Affected modules and functionalities:
- image format
- image format registry
- imgcodec/decoders (to a small extent)

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-2984
<!--- DALI-XXXX or NA --->
