### PR TITLE
Make test_dltensor_operator.py consistent when the HW decoder is available

### DIFF
--- a/dali/test/python/test_dltensor_operator.py
+++ b/dali/test/python/test_dltensor_operator.py
@@ -19,6 +19,7 @@ import os
 import random
 from functools import partial
 from nvidia.dali.pipeline import Pipeline
+import nose_utils
 
 test_data_root = os.environ['DALI_EXTRA_PATH']
 images_dir = os.path.join(test_data_root, 'db', 'single', 'jpeg')
@@ -92,7 +93,7 @@ class CommonPipeline(Pipeline):
                          exec_async=False, exec_pipelined=False)
         self.input = ops.readers.File(file_root=images_dir)
         self.decode = ops.decoders.Image(device='mixed' if device == 'gpu' else 'cpu',
-                                         output_type=types.RGB)
+                                         output_type=types.RGB, hw_decoder_load=0)
         self.resize = ops.Resize(resize_x=400, resize_y=400, device=device)
         self.flip = ops.Flip(device=device)
 

--- a/dali/test/python/test_dltensor_operator.py
+++ b/dali/test/python/test_dltensor_operator.py
@@ -19,7 +19,6 @@ import os
 import random
 from functools import partial
 from nvidia.dali.pipeline import Pipeline
-import nose_utils
 
 test_data_root = os.environ['DALI_EXTRA_PATH']
 images_dir = os.path.join(test_data_root, 'db', 'single', 'jpeg')


### PR DESCRIPTION
- when the HW JPEG decoder is available the difference in the distribution
  of samples between HW and SW decoder in reference and test
  pipelines in test_dltensor_operator.py results in discrepancy.
  This PR makes sure that only the hybrid decoder is used to make
  the decoding results aligned

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- when the HW JPEG decoder is available the difference in the distribution
  of samples between HW and SW decoder in reference and test
  pipelines in test_dltensor_operator.py results in discrepancy.
  This PR makes sure that only the hybrid decoder is used to make
  the decoding results aligned
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- test_dltensor_operator.py
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - test_dltensor_operator.py
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
