### PR TITLE
Fix libtiff error handling

### DIFF
--- a/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
+++ b/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
@@ -97,7 +97,8 @@ std::unique_ptr<TIFF, void (*)(TIFF *)> OpenTiff(ImageSource *in) {
     else
       mapproc = nullptr;
 
-    tiffptr = TIFFClientOpen("", "r", reinterpret_cast<thandle_t>(new DecoderHelper(in)),
+    DecoderHelper *helper = new DecoderHelper(in);
+    tiffptr = TIFFClientOpen("", "r", reinterpret_cast<thandle_t>(helper),
                              &DecoderHelper::read,
                              &DecoderHelper::write,
                              &DecoderHelper::seek,
@@ -105,6 +106,7 @@ std::unique_ptr<TIFF, void (*)(TIFF *)> OpenTiff(ImageSource *in) {
                              &DecoderHelper::size,
                              mapproc,
                              /* unmap */ 0);
+    if (!tiffptr) delete helper;
   }
 
   DALI_ENFORCE(tiffptr != nullptr, make_string("Unable to open TIFF image: ", in->SourceInfo()));

--- a/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
+++ b/dali/imgcodec/decoders/libtiff/tiff_libtiff.cc
@@ -51,8 +51,12 @@ class DecoderHelper {
 
   static toff_t seek(thandle_t handle, toff_t offset, int whence) {
     DecoderHelper *helper = reinterpret_cast<DecoderHelper *>(handle);
-    helper->stream_->SeekRead(offset, whence);
-    return helper->stream_->TellRead();
+    try {
+      helper->stream_->SeekRead(offset, whence);
+      return helper->stream_->TellRead();
+    } catch (...) {
+      return -1;
+    }
   }
 
   static int map(thandle_t handle, void **base, toff_t *size) {


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
In this PR I fix two bugs:
### Throwing in C code
This one was spotted by @mzient. Thank you!

When using libtiff, I was passing a set of helper functions (`read`, `seek` etc.) for it to read the input. When invalid offset was passed to `seek`, it was throwing an exception. However, the libtiff is a C library, so throwing there was UB.

In this PR I wrap the seek in a `try-catch` to fix that.

### Leaking memory on failed open
When `TIFFClientOpen` failed, the allocated `DecoderHelper` was not deleted, causing a leak.

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
