### PR TITLE
Improve wake-up condition in ThreadPool.

### DIFF
--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -60,20 +60,19 @@ ThreadPool::~ThreadPool() {
 }
 
 void ThreadPool::AddWork(Work work, int64_t priority, bool start_immediately) {
-  bool started_before = false;
+  bool should_start_all = false;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     work_queue_.push({priority, std::move(work)});
     work_complete_ = false;
-    started_before = started_;
     started_ |= start_immediately;
+
+    should_start_all = started_ && work_queue_.size() > 1;
   }
-  if (started_) {
-    if (!started_before)
-      condition_.notify_all();
-    else
-      condition_.notify_one();
-  }
+  if (should_start_all)
+    condition_.notify_all();
+  else
+    condition_.notify_one();
 }
 
 // Blocks until all work issued to the thread pool is complete


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
It seemed that in unfavorable circumstances we would only wake one thread in the threadpool even if multiple work items have been added. I'm not 100% sure it was the case, but the wake-up condition in the new form is more readable and more directly related to the real reason to notify multiple threads.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
Everything that uses ThreadPool, really.

- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
