### PR TITLE
[imgcodec] Fix normalization when running GPU color space conversion

### DIFF
--- a/dali/imgcodec/util/convert_gpu.cu
+++ b/dali/imgcodec/util/convert_gpu.cu
@@ -106,7 +106,7 @@ void ConvertImpl(SampleView<GPUBackend> out, TensorLayout out_layout, DALIImageT
   intermediate_shape[channel_dim] = NumberOfChannels(in_format, intermediate_shape[channel_dim]);
 
   // Normalize by changing the multiplier
-  multiplier *= ConvertNorm<float>(static_cast<Input>(1)) / 
+  multiplier *= ConvertNorm<float>(static_cast<Input>(1)) /
                 ConvertNorm<float>(static_cast<Output>(1));
 
   auto size = volume(intermediate_shape);


### PR DESCRIPTION
Signed-off-by: Michał Staniewski <m.staniewzki@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
Currently, when running color space conversion in the GPU Convert, no normalization happens (I thought that the color space conversion kernel handles it...). This PR fixes the issue.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
