### PR TITLE
Fix inconsistent tensor recreation in TensorList

### DIFF
--- a/dali/pipeline/data/tensor_list.cc
+++ b/dali/pipeline/data/tensor_list.cc
@@ -1032,7 +1032,7 @@ void TensorList<Backend>::resize_tensors(int new_size) {
         if (sample_dim_ >= 0) {
           // We can't have empty scalar.
           const auto &emptyish_shape = sample_dim() > 0 ? TensorShape<>::empty_shape(sample_dim()) :
-                                                          TensorShape<>(TensorShape<0>());
+                                                          TensorShape<>();
           tensors_[i].Resize(emptyish_shape, type());
           shape_.set_tensor_shape(i, emptyish_shape);
         } else if (type() != tensors_[i].type()) {

--- a/dali/pipeline/data/tensor_list.cc
+++ b/dali/pipeline/data/tensor_list.cc
@@ -1030,10 +1030,11 @@ void TensorList<Backend>::resize_tensors(int new_size) {
       setup_tensor_allocation(i);
       if (type() != DALI_NO_TYPE) {
         if (sample_dim_ >= 0) {
-          tensors_[i].Resize(
-              sample_dim() > 0 ? TensorShape<>::empty_shape(sample_dim()) : TensorShape<>({}),
-              type());
-          shape_.set_tensor_shape(i, TensorShape<>::empty_shape(sample_dim()));
+          // We can't have empty scalar.
+          const auto &emptyish_shape = sample_dim() > 0 ? TensorShape<>::empty_shape(sample_dim()) :
+                                                          TensorShape<>(TensorShape<0>());
+          tensors_[i].Resize(emptyish_shape, type());
+          shape_.set_tensor_shape(i, emptyish_shape);
         } else if (type() != tensors_[i].type()) {
           tensors_[i].Reset();
           tensors_[i].set_type(type());

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -828,6 +828,52 @@ TYPED_TEST(TensorListSuite, ResizeWithRecreate) {
 }
 
 
+TYPED_TEST(TensorListSuite, ResizeWithRecreate0d) {
+  // Check if the tensors that get back to the scope are correctly typed
+  // Scalar values cannot exist as 0-volume tensors, so they always have some allocation
+  for (auto contiguity : {BatchContiguity::Contiguous, BatchContiguity::Noncontiguous}) {
+    TensorList<TypeParam> tv;
+    tv.SetContiguity(contiguity);
+    tv.set_pinned(true);
+    auto shape0 = uniform_list_shape(3, TensorShape<0>{});
+    tv.Resize(shape0, DALI_UINT8);
+    EXPECT_EQ(tv.shape().num_samples(), 3);
+    EXPECT_EQ(tv.shape().sample_dim(), 0);
+    for (int i = 0; i < 3; i++) {
+      EXPECT_EQ(tv[i].type(), DALI_UINT8);
+      EXPECT_EQ(tv[i].shape(), TensorShape<0>{});
+      EXPECT_NE(tv[i].raw_data(), nullptr);
+    }
+
+    tv.SetSize(4);
+
+    EXPECT_EQ(tv.shape().num_samples(), 4);
+    EXPECT_EQ(tv.shape().sample_dim(), 0);
+
+    for (int i = 0; i < 4; i++) {
+      EXPECT_EQ(tv[i].type(), DALI_UINT8);
+      EXPECT_EQ(tv[i].shape(), TensorShape<0>{});
+      EXPECT_NE(tv[i].raw_data(), nullptr);
+    }
+
+    auto shape1 = uniform_list_shape(5, TensorShape<2>{1, 2});
+    tv.Resize(shape1);
+    EXPECT_EQ(tv.shape().num_samples(), 5);
+    EXPECT_EQ(tv.shape().sample_dim(), 2);
+
+    auto shape2 = uniform_list_shape(6, TensorShape<0>{});
+    tv.Resize(shape2, DALI_UINT8);
+    tv.SetSize(6);
+    EXPECT_EQ(tv.shape().num_samples(), 6);
+    for (int i = 0; i < 6; i++) {
+      EXPECT_EQ(tv[i].type(), DALI_UINT8);
+      EXPECT_EQ(tv[i].shape(), TensorShape<0>{});
+      EXPECT_NE(tv[i].raw_data(), nullptr);
+    }
+  }
+}
+
+
 TYPED_TEST(TensorListSuite, SetupLikeMultiGPU) {
   int ndev = 0;
   CUDA_CALL(cudaGetDeviceCount(&ndev));


### PR DESCRIPTION


<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Bug fix**
<!---
Please pick one from below:
 (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Use the same shape for the internal tensor that gets back into the scope when the size of the TensorList is changed. empty_shape can be only used for non-zero dimensional samples, as 0d samples can't have 0 volume.

The code uses an explicit TensorShape<0> converted to one of dynamic dimension, as the brace default constructed TensorShape<> had size 1 for some reason.

This clears up potential asserts that could hit in debug builds: specifically calling empty_shape for dim = 0.

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>


## Additional information:

### Affected modules and functionalities:
TensorList


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
