### PR TITLE
Add pass-through tracking to auto-pinning buffers

### DIFF
--- a/dali/pipeline/executor/executor.h
+++ b/dali/pipeline/executor/executor.h
@@ -605,7 +605,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::SetupOutputInfo(OpGraph &graph) {
   pipeline_outputs_ = graph.GetOutputs(output_names_);
 
 
-  graph.SetupMakeContiguousPassThrough(output_names_);
+  graph.SetupMakeContiguousPassThrough();
 
   // If there are GPU outputs from given stages, we have to wait for them
   auto has_gpu_output = [] (OpType stage_type, const auto &pipeline_outputs,
@@ -670,6 +670,22 @@ void Executor<WorkspacePolicy, QueuePolicy>::PrepinData(
     }
     return;
   }
+
+  auto pin_cpu_passthrough = [](std::vector<tensor_data_store_queue_t> &tensor_to_store_queue,
+                                const OpGraph &graph, int tid, bool pinned) {
+    auto origin_group = graph.GetTensorOrigin(tid);
+    // For all tensors that are forming a pass through group ...
+    for (auto &origin_tensor_id : origin_group) {
+      // (we do this only for CPU data produced in CPU nodes)
+      auto &parent_tensor_queue =
+          get_queue<OpType::CPU, StorageDevice::CPU>(tensor_to_store_queue[origin_tensor_id]);
+      for (auto &batch : parent_tensor_queue) {
+        // ... mark all executor buffer queues as `pinned`
+        batch->set_pinned(pinned);
+      }
+    }
+  };
+
   // We only pin what we need:
   // The inputs of mixed ops are potentially used for H2D copies...
   for (int i = 0; i < graph.NumOp(OpType::MIXED); i++) {
@@ -679,11 +695,8 @@ void Executor<WorkspacePolicy, QueuePolicy>::PrepinData(
     for (int j = 0; j < node.spec.NumInput(); ++j) {
       auto tid = node.parent_tensors[j];
       // Use pinned memory only when it is useful
-      auto &parent_tensor_queue =
-          get_queue<OpType::CPU, StorageDevice::CPU>(tensor_to_store_queue_[tid]);
-      for (auto &tensor : parent_tensor_queue) {
-        tensor->set_pinned(node.spec.OutputDevice(0) == "gpu" && !RestrictPinnedMemUsage());
-      }
+      auto should_pin = node.spec.OutputDevice(0) == "gpu" && !RestrictPinnedMemUsage();
+      pin_cpu_passthrough(tensor_to_store_queue, graph, tid, should_pin);
     }
   }
 
@@ -693,11 +706,8 @@ void Executor<WorkspacePolicy, QueuePolicy>::PrepinData(
     for (int j = 0; j < node.spec.NumInput(); ++j) {
       auto tid = node.parent_tensors[j];
       if (graph.Tensor(tid).producer.storage_device == StorageDevice::CPU) {
-        auto &parent_tensor_queue =
-            get_queue<OpType::CPU, StorageDevice::CPU>(tensor_to_store_queue_[tid]);
-        for (auto &tensor : parent_tensor_queue) {
-          tensor->set_pinned(node.spec.OutputDevice(0) == "gpu" && !RestrictPinnedMemUsage());
-        }
+        auto should_pin = node.spec.OutputDevice(0) == "gpu" && !RestrictPinnedMemUsage();
+        pin_cpu_passthrough(tensor_to_store_queue, graph, tid, should_pin);
       }
     }
   }

--- a/dali/pipeline/executor/executor_test.cc
+++ b/dali/pipeline/executor/executor_test.cc
@@ -612,70 +612,68 @@ TYPED_TEST(ExecutorTest, TestPinning) {
 
   // Build a basic cpu->gpu graph
   OpGraph graph;
-  graph.AddOp(this->PrepareSpec(
-          OpSpec("ExternalSource")
-          .AddArg("device", "cpu")
-          .AddArg("device_id", 0)
-          .AddOutput("data_0", "cpu")), "ExternalSource_0");
+  graph.AddOp(this->PrepareSpec(OpSpec("ExternalSource")
+                                    .AddArg("device", "cpu")
+                                    .AddArg("device_id", 0)
+                                    .AddOutput("data_0", "cpu")),
+              "ExternalSource_0");
 
   // First set of Copy + Copy and Pass Through
-  graph.AddOp(this->PrepareSpec(
-          OpSpec("Copy")
-          .AddArg("device", "cpu")
-          .AddInput("data_0", "cpu")
-          .AddOutput("copy_0", "cpu")), "Copy_0");
+  graph.AddOp(this->PrepareSpec(OpSpec("Copy")
+                                    .AddArg("device", "cpu")
+                                    .AddInput("data_0", "cpu")
+                                    .AddOutput("copy_0", "cpu")),
+              "Copy_0");
 
-  graph.AddOp(this->PrepareSpec(
-          OpSpec("Copy")
-          .AddArg("device", "cpu")
-          .AddInput("data_0", "cpu")
-          .AddOutput("copy_1", "cpu")), "Copy_1");
+  graph.AddOp(this->PrepareSpec(OpSpec("Copy")
+                                    .AddArg("device", "cpu")
+                                    .AddInput("data_0", "cpu")
+                                    .AddOutput("copy_1", "cpu")),
+              "Copy_1");
 
-  graph.AddOp(this->PrepareSpec(
-          OpSpec("Reshape")
-          .AddArg("device", "cpu")
-          .AddArg("layout", "")
-          .AddInput("copy_0", "cpu")
-          .AddOutput("pass_through_0", "cpu")), "PassThrough_0");
+  graph.AddOp(this->PrepareSpec(OpSpec("Reshape")
+                                    .AddArg("device", "cpu")
+                                    .AddArg("layout", "")
+                                    .AddInput("copy_0", "cpu")
+                                    .AddOutput("pass_through_0", "cpu")),
+              "PassThrough_0");
 
   // Trigger pinning of first set when it moves CPU -> GPU
-  graph.AddOp(this->PrepareSpec(
-          OpSpec("MakeContiguous")
-          .AddArg("device", "mixed")
-          .AddInput("pass_through_0", "cpu")
-          .AddOutput("out_0", "gpu")), "MakeContiguous_0");
+  graph.AddOp(this->PrepareSpec(OpSpec("MakeContiguous")
+                                    .AddArg("device", "mixed")
+                                    .AddInput("pass_through_0", "cpu")
+                                    .AddOutput("out_0", "gpu")),
+              "MakeContiguous_0");
 
   // but not the Copy_1 to compare against
-  graph.AddOp(this->PrepareSpec(
-          OpSpec("MakeContiguous")
-          .AddArg("device", "mixed")
-          .AddInput("copy_1", "cpu")
-          .AddOutput("out_1", "cpu")), "MakeContiguous_1");
+  graph.AddOp(this->PrepareSpec(OpSpec("MakeContiguous")
+                                    .AddArg("device", "mixed")
+                                    .AddInput("copy_1", "cpu")
+                                    .AddOutput("out_1", "cpu")),
+              "MakeContiguous_1");
 
 
   // Second set of Copy and Pass Through
-  graph.AddOp(this->PrepareSpec(
-          OpSpec("Copy")
-          .AddArg("device", "cpu")
-          .AddInput("data_0", "cpu")
-          .AddOutput("copy_2", "cpu")), "Copy_2");
+  graph.AddOp(this->PrepareSpec(OpSpec("Copy")
+                                    .AddArg("device", "cpu")
+                                    .AddInput("data_0", "cpu")
+                                    .AddOutput("copy_2", "cpu")),
+              "Copy_2");
 
-  graph.AddOp(this->PrepareSpec(
-          OpSpec("Reshape")
-          .AddArg("device", "cpu")
-          .AddArg("layout", "")
-          .AddInput("copy_2", "cpu")
-          .AddOutput("pass_through_1", "cpu")), "PassThrough_1");
+  graph.AddOp(this->PrepareSpec(OpSpec("Reshape")
+                                    .AddArg("device", "cpu")
+                                    .AddArg("layout", "")
+                                    .AddInput("copy_2", "cpu")
+                                    .AddOutput("pass_through_1", "cpu")),
+              "PassThrough_1");
 
   // Check pinning argument inputs to operators in GPU stage
-  graph.AddOp(this->PrepareSpec(
-          OpSpec("random__CoinFlip")
-          .AddArg("device", "gpu")
-          .AddArgumentInput("probability", "pass_through_1")
-          .AddOutput("out_2", "gpu")), "CoinFlip");
+  graph.AddOp(this->PrepareSpec(OpSpec("random__CoinFlip")
+                                    .AddArg("device", "gpu")
+                                    .AddArgumentInput("probability", "pass_through_1")
+                                    .AddOutput("out_2", "gpu")),
+              "CoinFlip");
 
-
-  graph.SaveToDotFile("cheating.dot", true, true, true);
   vector<string> outputs = {"copy_0_cpu",         "copy_1_cpu", "pass_through_0_cpu", "copy_2_cpu",
                             "pass_through_1_cpu", "out_0_gpu",  "out_1_cpu",          "out_2_gpu"};
 

--- a/dali/pipeline/executor/executor_test.cc
+++ b/dali/pipeline/executor/executor_test.cc
@@ -17,6 +17,8 @@
 #include <chrono>
 #include <future>
 
+#include "dali/core/tensor_shape.h"
+#include "dali/pipeline/data/backend.h"
 #include "dali/test/dali_test_decoder.h"
 #include "dali/pipeline/executor/executor.h"
 #include "dali/pipeline/executor/pipelined_executor.h"
@@ -601,6 +603,108 @@ TYPED_TEST(ExecutorSyncTest, TestPrefetchedExecution) {
   ASSERT_EQ(cb_counter, 2);
 
   test::CheckResults(ws, batch_size, 1, tl);
+}
+
+
+TYPED_TEST(ExecutorTest, TestPinning) {
+  auto exe = this->GetExecutor(this->batch_size_, this->num_threads_, 0, 1);
+  exe->Init();
+
+  // Build a basic cpu->gpu graph
+  OpGraph graph;
+  graph.AddOp(this->PrepareSpec(
+          OpSpec("ExternalSource")
+          .AddArg("device", "cpu")
+          .AddArg("device_id", 0)
+          .AddOutput("data_0", "cpu")), "ExternalSource_0");
+
+  // First set of Copy + Copy and Pass Through
+  graph.AddOp(this->PrepareSpec(
+          OpSpec("Copy")
+          .AddArg("device", "cpu")
+          .AddInput("data_0", "cpu")
+          .AddOutput("copy_0", "cpu")), "Copy_0");
+
+  graph.AddOp(this->PrepareSpec(
+          OpSpec("Copy")
+          .AddArg("device", "cpu")
+          .AddInput("data_0", "cpu")
+          .AddOutput("copy_1", "cpu")), "Copy_1");
+
+  graph.AddOp(this->PrepareSpec(
+          OpSpec("Reshape")
+          .AddArg("device", "cpu")
+          .AddArg("layout", "")
+          .AddInput("copy_0", "cpu")
+          .AddOutput("pass_through_0", "cpu")), "PassThrough_0");
+
+  // Trigger pinning of first set when it moves CPU -> GPU
+  graph.AddOp(this->PrepareSpec(
+          OpSpec("MakeContiguous")
+          .AddArg("device", "mixed")
+          .AddInput("pass_through_0", "cpu")
+          .AddOutput("out_0", "gpu")), "MakeContiguous_0");
+
+  // but not the Copy_1 to compare against
+  graph.AddOp(this->PrepareSpec(
+          OpSpec("MakeContiguous")
+          .AddArg("device", "mixed")
+          .AddInput("copy_1", "cpu")
+          .AddOutput("out_1", "cpu")), "MakeContiguous_1");
+
+
+  // Second set of Copy and Pass Through
+  graph.AddOp(this->PrepareSpec(
+          OpSpec("Copy")
+          .AddArg("device", "cpu")
+          .AddInput("data_0", "cpu")
+          .AddOutput("copy_2", "cpu")), "Copy_2");
+
+  graph.AddOp(this->PrepareSpec(
+          OpSpec("Reshape")
+          .AddArg("device", "cpu")
+          .AddArg("layout", "")
+          .AddInput("copy_2", "cpu")
+          .AddOutput("pass_through_1", "cpu")), "PassThrough_1");
+
+  // Check pinning argument inputs to operators in GPU stage
+  graph.AddOp(this->PrepareSpec(
+          OpSpec("random__CoinFlip")
+          .AddArg("device", "gpu")
+          .AddArgumentInput("probability", "pass_through_1")
+          .AddOutput("out_2", "gpu")), "CoinFlip");
+
+
+  graph.SaveToDotFile("cheating.dot", true, true, true);
+  vector<string> outputs = {"copy_0_cpu",         "copy_1_cpu", "pass_through_0_cpu", "copy_2_cpu",
+                            "pass_through_1_cpu", "out_0_gpu",  "out_1_cpu",          "out_2_gpu"};
+
+  exe->Build(&graph, outputs);
+
+  // Set the data for the external source
+  auto *src_op = dynamic_cast<ExternalSource<CPUBackend> *>(graph.Node(OpType::CPU, 0).op.get());
+  TensorList<CPUBackend> tl;
+  tl.Resize(uniform_list_shape(this->batch_size_, TensorShape<>{}), DALI_FLOAT);
+  src_op->SetDataSource(tl);
+
+  exe->RunCPU();
+  exe->RunMixed();
+  exe->RunGPU();
+
+  DeviceWorkspace ws;
+  exe->Outputs(&ws);
+
+  // Utilize the fact that the outputs are shared from the executor, so we can check if they are
+  // pinned in a way we expect
+  // Currently we expect to pin anything that is CPU argument input into GPU operator, and
+  // is a CPU -> GPU copy (not via a decoder), so CPU input to Mixed operator that returns GPU data.
+  // The whole pass-through group should be pinned as well.
+
+  EXPECT_TRUE(ws.Output<CPUBackend>(0).is_pinned());   // copy_0_cpu
+  EXPECT_FALSE(ws.Output<CPUBackend>(1).is_pinned());  // copy_1_cpu
+  EXPECT_TRUE(ws.Output<CPUBackend>(2).is_pinned());   // pass_through_0_cpu
+  EXPECT_TRUE(ws.Output<CPUBackend>(3).is_pinned());   // copy_2_cpu
+  EXPECT_TRUE(ws.Output<CPUBackend>(4).is_pinned());   // pass_through_1_cpu
 }
 
 }  // namespace dali

--- a/dali/pipeline/graph/op_graph.h
+++ b/dali/pipeline/graph/op_graph.h
@@ -345,7 +345,7 @@ class DLL_PUBLIC OpGraph {
    * We need to calculate it ahead of time to allow for correct allocation of prefetch queues
    * (the PassThrough information is static).
    */
-  DLL_PUBLIC void SetupMakeContiguousPassThrough(const std::vector<string>& output_names);
+  DLL_PUBLIC void SetupMakeContiguousPassThrough();
 
   /**
    * @brief Return a TensorNodeId or a set of those, where the memory for the target_node
@@ -374,7 +374,7 @@ class DLL_PUBLIC OpGraph {
   bool IsAlwaysContiguous(TensorNodeId tensor_id) const;
 
   /**
-   * @brief Find the parent tensor id that were used to produce the `passed_through` tensor by
+   * @brief Find the parent tensor id that was used to produce the `passed_through` tensor by
    * the op.
    * This is just one step up the graph.
    * @param op Id of op node possibly doing the pass through

--- a/dali/pipeline/pipeline_test.cc
+++ b/dali/pipeline/pipeline_test.cc
@@ -463,8 +463,8 @@ TEST_F(PipelineTestOnce, TestPresize) {
   // we should not presize CPU buffers if they are not pinned
   ASSERT_EQ(*(ws.Output<CPUBackend>(0).tensor<size_t>(0)), 0);
 
-  // this one is also going through make contiguous first
-  ASSERT_EQ(*(ws.Output<CPUBackend>(1).tensor<size_t>(0)), 0);
+  // this one is also going through mixed CPU -> GPU operator, so it is pinned and presized
+  ASSERT_EQ(*(ws.Output<CPUBackend>(1).tensor<size_t>(0)), presize_val_CPU);
 
   size_t tmp[2];
   CUDA_CALL(cudaDeviceSynchronize());


### PR DESCRIPTION
## Category: **New feature**, **Refactoring**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Small refactor in executor - extract the backtracking of pass-through in the graph.
Originally it was used to obtain the group of tensor nodes that need to be treated
as outputs and buffered accordingly.

Use the functionality to pin the whole pass-through group when pinning a tensor.

## Additional information:

### Affected modules and functionalities:
Executor, graph

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  #3728 didn't introduce additional tests for pinning, and I am not aware if we had any. 
  I'm not sure if we can easily observe the status of the outputs buffers outside of the operators or executor.
  ~~I might try to do something tomorrow, otherwise we will just have to observe the perf.~~
 I think I managed to write such test, inspecting the outputs of the executor for their pinnedness.
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
