### PR TITLE
Fix support for ANY_DATA in nvJPEG2K

### DIFF
--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
@@ -248,10 +248,8 @@ DecodeResult NvJpeg2000DecoderInstance::DecodeImplTask(int thread_idx,
   result.success = DecodeJpeg2000(in, decode_out.raw_mutable_data(), ctx);
 
   if (is_processing_needed) {
-    DALIImageType out_format = opts.format;
-    if (out_format == DALI_ANY_DATA) out_format = format;
     auto multiplier = calc_bpp_adjustment_multiplier(ctx.bpp, ctx.pixel_type);
-    Convert(out, "HWC", out_format, decode_out, "CHW", format, ctx.cuda_stream,
+    Convert(out, "HWC", opts.format, decode_out, "CHW", format, ctx.cuda_stream,
             {}, {}, multiplier);
   }
 

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k.cc
@@ -248,8 +248,10 @@ DecodeResult NvJpeg2000DecoderInstance::DecodeImplTask(int thread_idx,
   result.success = DecodeJpeg2000(in, decode_out.raw_mutable_data(), ctx);
 
   if (is_processing_needed) {
+    DALIImageType out_format = opts.format;
+    if (out_format == DALI_ANY_DATA) out_format = format;
     auto multiplier = calc_bpp_adjustment_multiplier(ctx.bpp, ctx.pixel_type);
-    Convert(out, "HWC", opts.format, decode_out, "CHW", format, ctx.cuda_stream,
+    Convert(out, "HWC", out_format, decode_out, "CHW", format, ctx.cuda_stream,
             {}, {}, multiplier);
   }
 

--- a/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_test.cc
+++ b/dali/imgcodec/decoders/nvjpeg2k/nvjpeg2k_test.cc
@@ -142,9 +142,12 @@ class NvJpeg2000DecoderTest : public NumpyDecoderTestBase<GPUBackend, OutputType
       AssertEqualSatNorm(img, ref);
   }
 
-  void RunTest(const ImageTestingData &data, std::optional<float> eps = std::nullopt) {
+  void RunTest(const ImageTestingData &data, std::optional<float> eps = std::nullopt,
+               DALIImageType format = DALI_RGB) {
     ImageBuffer image(data.img_path);
-    auto decoded = this->Decode(&image.src, this->GetParams(), data.roi);
+    auto params = this->GetParams();
+    params.format = format;
+    auto decoded = this->Decode(&image.src, params, data.roi);
     auto ref = this->ReadReferenceFrom(data.ref_path);
     AssertEqual(decoded, ref, eps);
   }
@@ -182,6 +185,13 @@ TYPED_TEST(NvJpeg2000DecoderTest, DecodeSingle) {
 TYPED_TEST(NvJpeg2000DecoderTest, DecodeSingleRoi) {
   for (const auto &[name, roi] : roi_images)
     this->RunTest(from_regular_file(name, roi));
+}
+
+TYPED_TEST(NvJpeg2000DecoderTest, DecodeSingleAnyData) {
+  for (const auto &name : images) {
+    SCOPED_TRACE(name);
+    this->RunTest(from_regular_file(name), {}, DALI_ANY_DATA);
+  }
 }
 
 TYPED_TEST(NvJpeg2000DecoderTest, DecodeBatchSingleThread) {

--- a/dali/imgcodec/util/convert.h
+++ b/dali/imgcodec/util/convert.h
@@ -251,7 +251,7 @@ template <typename Out, typename In>
 void Convert(Out *out, const int64_t *out_strides, int out_channel_dim, DALIImageType out_format,
              const In *in, const int64_t *in_strides, int in_channel_dim, DALIImageType in_format,
              const int64_t *size, int ndim) {
-  if (out_format == DALI_ANY_DATA && in_format == DALI_ANY_DATA) {
+  if (out_format == DALI_ANY_DATA) {
     // When converting ANY -> ANY, we simply ignore the color conversion and rewrite the data
     Convert(out, out_strides, in, in_strides, size, ndim, ConvertPixelDType<Out, In, 1>{1, 1});
     return;

--- a/dali/imgcodec/util/convert_gpu.cu
+++ b/dali/imgcodec/util/convert_gpu.cu
@@ -117,6 +117,9 @@ void ConvertImpl(SampleView<GPUBackend> out, TensorLayout out_layout, DALIImageT
     buffer, out_layout, intermediate_shape, in.data<Input>(), in_layout, in.shape(),
     ctx, roi, orientation, multiplier);
 
+  if (out_format == DALI_ANY_DATA) {
+    out_format = in_format;
+  }
   if (out_format != in_format) {
     DALI_ENFORCE(out_layout.find('C') == kDims - 1,
                  "Only channel last layout is supported when running color space conversion");


### PR DESCRIPTION


<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:

**Bug fix** (*non-breaking change which fixes an issue*)

<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
nvJPEG2K decoder was requesting unsupported conversion to `ANY_DATA` from the color conversion kernel. In this PR I adjust the decoder so that it doesn't attempt to convert colorspace in such case


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
