### PR TITLE
Enable ROI adjustment for multi-frame inputs + some cleanup

### DIFF
--- a/dali/imgcodec/image_decoder_test.cc
+++ b/dali/imgcodec/image_decoder_test.cc
@@ -49,7 +49,7 @@ struct ImageBuffer {
   ImageSource src;
   explicit ImageBuffer(const std::string &filename)
   : buffer(read_file(filename))
-  , src(ImageSource::FromHostMem(buffer.data(), buffer.size())) {}
+  , src(ImageSource::FromHostMem(buffer.data(), buffer.size(), filename)) {}
 };
 
 struct test_sample {

--- a/dali/imgcodec/util/output_shape.h
+++ b/dali/imgcodec/util/output_shape.h
@@ -21,7 +21,7 @@ namespace dali {
 namespace imgcodec {
 
 template <typename OutShape>
-void DLL_PUBLIC OutputShape(OutShape &&out_shape,
+void OutputShape(OutShape &&out_shape,
                  const ImageInfo &info, const DecodeParams &params, const ROI &roi) {
   int ndim = info.shape.sample_dim();
   resize_if_possible(out_shape, ndim);

--- a/dali/imgcodec/util/output_shape_test.cc
+++ b/dali/imgcodec/util/output_shape_test.cc
@@ -224,5 +224,24 @@ TEST(PreOrientationRoiTest, Rotate270) {
   EXPECT_EQ(roi.end[1], 5);
 }
 
+TEST(PreOrientationRoiTest, MirrorHorizontalRotate90WithoutChannel) {
+  ImageInfo info = {{4, 5},
+                    FromExifOrientation(ExifOrientation::MIRROR_HORIZONTAL_ROTATE_90_CW)};
+  auto roi = PreOrientationRoi(info, {{0, 1}, {2, 2}});
+  EXPECT_EQ(roi.begin[0], 2);
+  EXPECT_EQ(roi.begin[1], 3);
+  EXPECT_EQ(roi.end[0], 3);
+  EXPECT_EQ(roi.end[1], 5);
+}
+
+TEST(PreOrientationRoiTest, Rotate270WithExtraDim) {
+  ImageInfo info = {{10, 4, 5, 3}, FromExifOrientation(ExifOrientation::ROTATE_270_CW)};
+  auto roi = PreOrientationRoi(info, {{0, 1}, {2, 2}});
+  EXPECT_EQ(roi.begin[0], 1);
+  EXPECT_EQ(roi.begin[1], 3);
+  EXPECT_EQ(roi.end[0], 2);
+  EXPECT_EQ(roi.end[1], 5);
+}
+
 }  // namespace imgcodec
 }  // namespace dali

--- a/include/dali/imgcodec/image_source.h
+++ b/include/dali/imgcodec/image_source.h
@@ -134,7 +134,7 @@ class DLL_PUBLIC ImageSource {
   const char *Filename() const {
     if (kind_ != InputKind::Filename)
       throw std::logic_error("This image source doesn't have a filename.");
-    return name_.c_str();
+    return name_.empty() ? nullptr : name_.c_str();
   }
 
   /**
@@ -144,7 +144,7 @@ class DLL_PUBLIC ImageSource {
    * or some compound identifier, like a name of a container file accompanied by
    * a record id or an offset,
    */
-  const char *SourceInfo() const { return name_.c_str(); }
+  const char *SourceInfo() const { return name_.empty() ? nullptr : name_.c_str(); }
 
   /**
    * @brief Opens the image source, returning an input stream


### PR DESCRIPTION

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)


## Description:
- The calculation of pre-orientation ROI supports extra outer dimensions.
- Removed unnecessary DLL_PUBLIC on an inline template function
- ImageSource::SourceInfo() and Filename now return a null pointer if the string is empty
- Add filename as a source info in ImageCodec tests


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
