### PR TITLE
Reduce the batch size in RN50 data pipeline tests.

### DIFF
--- a/dali/test/python/test_RN50_data_pipeline.py
+++ b/dali/test/python/test_RN50_data_pipeline.py
@@ -229,8 +229,8 @@ parser.add_argument(
     '-g', '--gpus', default=1, type=int, metavar='N',
     help='number of GPUs run in parallel by this test (default: 1)')
 parser.add_argument(
-    '-b', '--batch', default=1024, type=int, metavar='N',
-    help='batch size (default: 1024)')
+    '-b', '--batch', default=512, type=int, metavar='N',
+    help='batch size (default: 512)')
 parser.add_argument(
     '-p', '--print-freq', default=10, type=int,
     metavar='N', help='print frequency (default: 10)')


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** Test configuration

## Description:
The default batch size in RN50 data pipeline tests is so big that it cannot be run on machines with <12 GB RAM.
This PR halves the batch size.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
