### PR TITLE
Update broadcasting shape simplification logic

### DIFF
--- a/dali/operators/math/expressions/broadcasting.cc
+++ b/dali/operators/math/expressions/broadcasting.cc
@@ -329,6 +329,7 @@ void SimplifyShapesForBroadcasting(span<TensorShape<> *> shapes) {
   }
 
   if (d < ndim) {
+    group_start = d;
     for (int i = 0; i < n; i++)
       volumes[i] *= get(i, d);
 

--- a/dali/operators/math/expressions/broadcasting.cc
+++ b/dali/operators/math/expressions/broadcasting.cc
@@ -350,11 +350,17 @@ SmallVector<std::pair<int, int>, 5> SimplifyShapesForBroadcasting(span<TensorSha
       add_group(d);
     }
     add_group(d);
+  }
 
-    if (modify_shapes) {
-      for (int i = 0; i < n; i++) {
-        *shapes[i] = outs[i];
-      }
+  for (int i = 0; i < n; i++) {
+    if (volume(outs[i]) == 1) {
+      outs[i] = {};
+    }
+  }
+
+  if (modify_shapes) {
+    for (int i = 0; i < n; i++) {
+      *shapes[i] = outs[i];
     }
   }
 

--- a/dali/operators/math/expressions/broadcasting.cc
+++ b/dali/operators/math/expressions/broadcasting.cc
@@ -377,12 +377,4 @@ void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b, TensorSha
   (void) SimplifyShapesForBroadcasting(make_span(arr), true);
 }
 
-bool IsBroadcastingEnabled() {
-  static bool value = []() {
-    const char *env = std::getenv("DALI_BROADCASTING_ENABLED");
-    return env && atoi(env);
-  }();
-  return value;
-}
-
 }  // namespace dali

--- a/dali/operators/math/expressions/broadcasting.cc
+++ b/dali/operators/math/expressions/broadcasting.cc
@@ -274,157 +274,101 @@ void ExpandToNDims(TensorShape<> &sh, int ndim) {
   sh = shape_cat(TensorShape<>(std::vector<int64_t>(ndim - sh.sample_dim(), 1)), sh);
 }
 
+SmallVector<std::pair<int, int>, 5> SimplifyShapesForBroadcasting(span<TensorShape<> *> shapes,
+                                                                  bool modify_shapes) {
+  int n = shapes.size();
+  SmallVector<TensorShape<>, 3> outs;
+  outs.resize(n);
 
-SmallVector<std::pair<int, int>, 5> SimplifiedShapeCollapseGroups(span<TensorShape<>*> shapes) {
-  SmallVector<std::pair<int, int>, 5> group_dims;
-  int full_ndim = shapes[0]->sample_dim();
-  for (int i = 1; i < shapes.size(); i++) {
-    full_ndim = std::max(full_ndim, shapes[i]->sample_dim());
-  }
-  if (shapes.size() < 2) {  // Unary operator, can simply collapse to 1D
-    if (full_ndim > 1)
-      group_dims.emplace_back(0, full_ndim);
-    return group_dims;
-  }
-  // First, if needed expand dimensions
-  for (auto *sh : shapes) {
-    ExpandToNDims(*sh, full_ndim);
-  }
+  int ndim = shapes[0]->size();
+  for (int i = 1; i < n; i++)
+    if (static_cast<int>(shapes[i]->size()) > ndim)
+      ndim = shapes[i]->size();
 
-  // True if all dim-th extents are equal
-  auto all_same = [=](int dim) {
-    int64_t extent = -1;
-    for (int k = 0; k < shapes.size(); k++) {
-      if (extent == -1) {
-        extent = (*shapes[k])[dim];
-      } else if (extent != (*shapes[k])[dim]) {
+  auto get = [&](int shape, int dim) -> int64_t {
+    auto &s = *shapes[shape];
+    dim -= ndim - s.size();  // add leading unit dims
+    if (dim < 0)
+      return 1;  // implicit unit dim
+    return s[dim];
+  };
+
+  auto should_skip = [&](int d) {
+    for (int i = 0; i < n; i++)
+      if (get(i, d) != 1)
         return false;
-      }
+    return true;
+  };
+
+  SmallVector<int64_t, 3> volumes;
+  volumes.resize(n, 1);
+
+  SmallVector<std::pair<int, int>, 6> groups;
+  int group_start = 0;
+
+  auto can_collapse = [&](int d) {
+    for (int i = 0; i < n; i++) {
+      bool prev_b = get(i, group_start) == 1;
+      bool curr_b = get(i, d) == 1;
+      if (prev_b != curr_b)
+        return false;
     }
     return true;
   };
 
-  // True if all dim-th extents are one
-  auto all_ones = [=](int dim) {
-    for (int k = 0; k < shapes.size(); k++) {
-      if (1 != (*shapes[k])[dim]) {
-        return false;
-      }
-    }
-    return true;
-  };
-
-  // True if all dim-th extents are the same, or equal to one
-  auto all_same_or_one = [=](int dim) {
-    int64_t extent = -1;
-    for (int k = 0; k < shapes.size(); k++) {
-      int64_t value = (*shapes[k])[dim];
-      if (value == 1)
-        continue;
-      if (extent == -1) {
-        extent = value;
-      } else if (extent != value) {
-        return false;
-      }
-    }
-    return true;
-  };
-
-  // Can collapse dimensions with ones
-  // when there is no transition from or to an 'odd' one
-  // (meaning that the rest of the extents are not all one
-  // in the two dimensions)
-  // Examples:
-  // 1. Can collapse even if we have transition from 2 to 1,
-  //    because there are only ones on the second dimension
-  // {2 1} -> {2}
-  // {1 1} -> {1}
-  // 2. Can NOT collapse because there is a transition to 1
-  // {2 1} -> {2 1}
-  // {2 2} -> {2 2}
-  auto can_merge_ones = [=](int dim) {
-    for (int k = 0; k < shapes.size(); k++) {
-      auto &sh = *shapes[k];
-      if ((sh[dim] != 1 && sh[dim + 1] == 1 && !all_ones(dim + 1)) ||
-          (sh[dim] == 1 && !all_ones(dim) && sh[dim + 1] != 1)) {
-        return false;
-      }
-    }
-    return true;
-  };
-
-  // We can merge a dimension with the next if any of the following conditions apply:
-  // 1. All extents on that dimension and the next are the same (that also includes all ones)
-  // 2. All extents on that dimension and the next are the same or one,
-  //    and the ones are either present or not present in both dimensions
-  auto can_merge_next = [=](int dim) {
-    if (all_same(dim) && all_same(dim + 1))
-      return true;
-    else if (all_same_or_one(dim) && all_same_or_one(dim + 1) && can_merge_ones(dim))
-      return true;
+  auto add_group = [&](int d) {
+    if (groups.empty())  // there were leading degenerate dims
+      groups.emplace_back(0, d);
     else
-      return false;
+      groups.emplace_back(group_start, d);
+    group_start = d;
+    for (int i = 0; i < n; i++) {
+      outs[i].shape.push_back(volumes[i]);
+      volumes[i] = get(i, d);
+    }
   };
 
-  // Updates the volumes with the new dimension and returns true if the resulting volumes are
-  // compatible (all the same except for 1s)
-  auto compatible_vol = [=](SmallVector<int64_t, kMaxArity>& volumes, int dim) {
-    int64_t curr_vol = -1;
-    for (int k = 0; k < shapes.size(); k++) {
-      volumes[k] *= (*shapes[k])[dim];
-      if (volumes[k] == 1)
-        continue;  // always compatible
-      else if (curr_vol == -1)
-        curr_vol = volumes[k];
-      else if (curr_vol != volumes[k])
-        return false;  // not compatible
-    }
-    return true;
-  };
-
-  int i = 0;
-  SmallVector<int64_t, kMaxArity> volumes;
-  volumes.resize(shapes.size(), 1);
-  for (; i < full_ndim - 1;) {
-    if (compatible_vol(volumes, i)) {
-      int j = i + 1;
-      for (; j < full_ndim;) {
-        if (compatible_vol(volumes, j) && can_merge_next(j - 1)) {
-          j++;
-        } else {
-          break;
-        }
-      }
-      int group_sz = j - i;
-      if (group_sz > 1) {
-        group_dims.emplace_back(i, group_sz);
-      }
-      i = j;
-    } else {
-      i++;
-    }
-    // clean accumulated volumes
-    volumes.clear();
-    volumes.resize(shapes.size(), 1);
+  int d = 0;
+  for (; d < ndim; d++) {
+    if (!should_skip(d))
+      break;
   }
-  return group_dims;
-}
 
-void SimplifyShapesForBroadcasting(span<TensorShape<>*> shapes) {
-  auto group_dims = SimplifiedShapeCollapseGroups(shapes);
-  for (auto *sh : shapes) {
-    *sh = collapse_dims(*sh, group_dims);
+  if (d < ndim) {
+    for (int i = 0; i < n; i++)
+      volumes[i] *= get(i, d);
+
+    for (d++; d < ndim; d++) {
+      if (should_skip(d))
+        continue;
+      if (can_collapse(d)) {
+        for (int i = 0; i < n; i++)
+          volumes[i] *= get(i, d);
+        continue;
+      }
+
+      add_group(d);
+    }
+    add_group(d);
+
+    if (modify_shapes) {
+      for (int i = 0; i < n; i++) {
+        *shapes[i] = outs[i];
+      }
+    }
   }
+
+  return groups;
 }
 
 void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b) {
   std::array<TensorShape<>*, 2> arr = {&a, &b};
-  SimplifyShapesForBroadcasting(make_span(arr));
+  (void) SimplifyShapesForBroadcasting(make_span(arr), true);
 }
 
 void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b, TensorShape<>& c) {
   std::array<TensorShape<>*, 3> arr = {&a, &b, &c};
-  SimplifyShapesForBroadcasting(make_span(arr));
+  (void) SimplifyShapesForBroadcasting(make_span(arr), true);
 }
 
 bool IsBroadcastingEnabled() {

--- a/dali/operators/math/expressions/broadcasting.h
+++ b/dali/operators/math/expressions/broadcasting.h
@@ -122,16 +122,12 @@ DLL_PUBLIC void ExpandToNDims(TensorShape<> &sh, int ndim);
 
 /**
  * @brief It simplifies shapes for arithmetic op execution with broadcasting.
- *        It detects and collapses adjacent dimensions that are not broadcasted.
+ *        It detects and collapses adjacent dimensions into groups of dimensions
+ *        that either broadcasted or not.
  * @param shapes span of shapes to broadcast
- * @param modify_shapes if True, the shapes will be modified, otherwise, only the groups
- *        of dimensions to be collapsed are returned.
  * @remarks For shapes that don't need broadcasting, it results in a 1D shape.
- * @return pair of dimensions [d0, d1) to be collapsed
  */
-using GroupDims = ::std::pair<int, int>;
-DLL_PUBLIC SmallVector<GroupDims, 5> SimplifyShapesForBroadcasting(span<TensorShape<> *> shapes,
-                                                          bool modify_shapes = true);
+void SimplifyShapesForBroadcasting(span<TensorShape<> *> shapes);
 DLL_PUBLIC void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b);
 DLL_PUBLIC void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b, TensorShape<> &c);
 

--- a/dali/operators/math/expressions/broadcasting.h
+++ b/dali/operators/math/expressions/broadcasting.h
@@ -135,10 +135,6 @@ DLL_PUBLIC SmallVector<GroupDims, 5> SimplifyShapesForBroadcasting(span<TensorSh
 DLL_PUBLIC void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b);
 DLL_PUBLIC void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b, TensorShape<> &c);
 
-/**
- * @brief Check whether broadcasting should be enabled (via env variable)
- */
-DLL_PUBLIC bool IsBroadcastingEnabled();
 
 }  // namespace dali
 

--- a/dali/operators/math/expressions/broadcasting.h
+++ b/dali/operators/math/expressions/broadcasting.h
@@ -120,11 +120,27 @@ DLL_PUBLIC TensorShape<> StridesForBroadcasting(const TensorShape<> &out_sh,
 DLL_PUBLIC void ExpandToNDims(TensorShape<> &sh, int ndim);
 
 /**
+ * @brief Simplifies shapes by collapsing dimensions that are the same in all shapes
+ *
+ * @param shapes span of shapes to broadcast
+ * @return SmallVector<std::pair<int, int>, 5> groups of dimensions to collapse [i, j)
+ */
+DLL_PUBLIC SmallVector<std::pair<int, int>, 5> SimplifiedShapeCollapseGroups(
+    span<TensorShape<> *> shapes);
+
+/**
  * @brief It simplifies a shape for arithmetic op execution with broadcasting.
  *        It detects and collapses adjacent dimensions that are not broadcasted
  * @remarks For shapes that don't need broadcasting, it results in a 1D shape.
  */
-DLL_PUBLIC void SimplifyShapesForBroadcasting(TensorShape<>& lhs, TensorShape<> &rhs);
+DLL_PUBLIC void SimplifyShapesForBroadcasting(span<TensorShape<>*> shapes);
+DLL_PUBLIC void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b);
+DLL_PUBLIC void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b, TensorShape<>& c);
+
+/**
+ * @brief Check whether broadcasting should be enabled (via env variable)
+ */
+DLL_PUBLIC bool IsBroadcastingEnabled();
 
 }  // namespace dali
 

--- a/dali/operators/math/expressions/broadcasting.h
+++ b/dali/operators/math/expressions/broadcasting.h
@@ -16,6 +16,7 @@
 #define DALI_OPERATORS_MATH_EXPRESSIONS_BROADCASTING_H_
 
 #include <utility>
+#include "dali/core/small_vector.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/core/tensor_shape_print.h"
 
@@ -120,22 +121,19 @@ DLL_PUBLIC TensorShape<> StridesForBroadcasting(const TensorShape<> &out_sh,
 DLL_PUBLIC void ExpandToNDims(TensorShape<> &sh, int ndim);
 
 /**
- * @brief Simplifies shapes by collapsing dimensions that are the same in all shapes
- *
+ * @brief It simplifies shapes for arithmetic op execution with broadcasting.
+ *        It detects and collapses adjacent dimensions that are not broadcasted.
  * @param shapes span of shapes to broadcast
- * @return SmallVector<std::pair<int, int>, 5> groups of dimensions to collapse [i, j)
- */
-DLL_PUBLIC SmallVector<std::pair<int, int>, 5> SimplifiedShapeCollapseGroups(
-    span<TensorShape<> *> shapes);
-
-/**
- * @brief It simplifies a shape for arithmetic op execution with broadcasting.
- *        It detects and collapses adjacent dimensions that are not broadcasted
+ * @param modify_shapes if True, the shapes will be modified, otherwise, only the groups
+ *        of dimensions to be collapsed are returned.
  * @remarks For shapes that don't need broadcasting, it results in a 1D shape.
+ * @return pair of dimensions [d0, d1) to be collapsed
  */
-DLL_PUBLIC void SimplifyShapesForBroadcasting(span<TensorShape<>*> shapes);
+using GroupDims = ::std::pair<int, int>;
+DLL_PUBLIC SmallVector<GroupDims, 5> SimplifyShapesForBroadcasting(span<TensorShape<> *> shapes,
+                                                          bool modify_shapes = true);
 DLL_PUBLIC void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b);
-DLL_PUBLIC void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b, TensorShape<>& c);
+DLL_PUBLIC void SimplifyShapesForBroadcasting(TensorShape<> &a, TensorShape<> &b, TensorShape<> &c);
 
 /**
  * @brief Check whether broadcasting should be enabled (via env variable)

--- a/dali/operators/math/expressions/broadcasting_test.cc
+++ b/dali/operators/math/expressions/broadcasting_test.cc
@@ -244,6 +244,20 @@ TEST(ArithmeticOpsBroadcastingTest, SimplifyShapesForBroadcasting) {
     EXPECT_EQ(simple_b, b);
     EXPECT_EQ(simple_c, c);
   }
+
+  // Simulating putting out shape as one of the shapes
+  {
+    TensorShape<> a = {1, 2, 64};
+    TensorShape<> b = {1, 2, 64};
+    TensorShape<> c = {1};
+    SimplifyShapesForBroadcasting(a, b, c);
+    TensorShape<> simple_a = {1 * 2 * 64};
+    TensorShape<> simple_b = {1 * 2 * 64};
+    TensorShape<> simple_c = {};
+    EXPECT_EQ(simple_a, a);
+    EXPECT_EQ(simple_b, b);
+    EXPECT_EQ(simple_c, c);
+  }
 }
 
 

--- a/dali/operators/math/expressions/broadcasting_test.cc
+++ b/dali/operators/math/expressions/broadcasting_test.cc
@@ -125,6 +125,85 @@ TEST(ArithmeticOpsBroadcastingTest, SimplifyShapesForBroadcasting) {
     EXPECT_EQ(simple_a, a);
     EXPECT_EQ(simple_b, b);
   }
+
+  // Any shape and a scalar should reduce to one dim
+  {
+    TensorShape<> a = {2, 1, 10, 2, 1, 3};
+    TensorShape<> b = {};
+    SimplifyShapesForBroadcasting(a, b);
+    TensorShape<> simple_a = {120};
+    TensorShape<> simple_b = {1};
+    EXPECT_EQ(simple_a, a);
+    EXPECT_EQ(simple_b, b);
+  }
+
+  // Any shape and a scalar-like should reduce to one dim
+  {
+    TensorShape<> a = {2, 1, 10, 2, 1, 3};
+    TensorShape<> b = {1};
+    SimplifyShapesForBroadcasting(a, b);
+    TensorShape<> simple_a = {120};
+    TensorShape<> simple_b = {1};
+    EXPECT_EQ(simple_a, a);
+    EXPECT_EQ(simple_b, b);
+  }
+
+  // Group of ones can always be collapsed
+  {
+    TensorShape<> a = {2, 1, 10, 2, 1, 3};
+    TensorShape<> b = {1, 1,  1, 1, 1, 1};
+    SimplifyShapesForBroadcasting(a, b);
+    TensorShape<> simple_a = {120};
+    TensorShape<> simple_b = {1};
+    EXPECT_EQ(simple_a, a);
+    EXPECT_EQ(simple_b, b);
+  }
+
+  {
+    TensorShape<> a = {4, 3, 16};
+    TensorShape<> b = {1, 1, 1};
+    SimplifyShapesForBroadcasting(a, b);
+    TensorShape<> simple_a = {4 * 3 * 16};
+    TensorShape<> simple_b = {1};
+    EXPECT_EQ(simple_a, a);
+    EXPECT_EQ(simple_b, b);
+  }
+
+  {
+    TensorShape<> a = {2, 3, 4, 1, 1, 1};
+    TensorShape<> b = {1, 1, 1, 2, 3, 4};
+    SimplifyShapesForBroadcasting(a, b);
+    TensorShape<> simple_a = {24,  1};
+    TensorShape<> simple_b = { 1, 24};
+    EXPECT_EQ(simple_a, a);
+    EXPECT_EQ(simple_b, b);
+  }
+
+  // 3 arg broadcasting
+  {
+    TensorShape<> a = {1024, 1024};
+    TensorShape<> b = {1, 1};
+    TensorShape<> c = {1024, 1024};
+    SimplifyShapesForBroadcasting(a, b, c);
+    TensorShape<> simple_a = {1024 * 1024};
+    TensorShape<> simple_b = {1};
+    TensorShape<> simple_c = {1024 * 1024};
+    EXPECT_EQ(simple_a, a);
+    EXPECT_EQ(simple_b, b);
+    EXPECT_EQ(simple_c, c);
+  }
+  {
+    TensorShape<> a = {1024, 1024};
+    TensorShape<> b = {};
+    TensorShape<> c = {1024, 1024};
+    SimplifyShapesForBroadcasting(a, b, c);
+    TensorShape<> simple_a = {1024 * 1024};
+    TensorShape<> simple_b = {1};
+    TensorShape<> simple_c = {1024 * 1024};
+    EXPECT_EQ(simple_a, a);
+    EXPECT_EQ(simple_b, b);
+    EXPECT_EQ(simple_c, c);
+  }
 }
 
 

--- a/dali/operators/math/expressions/broadcasting_test.cc
+++ b/dali/operators/math/expressions/broadcasting_test.cc
@@ -230,6 +230,20 @@ TEST(ArithmeticOpsBroadcastingTest, SimplifyShapesForBroadcasting) {
     EXPECT_EQ(simple_b, b);
     EXPECT_EQ(simple_c, c);
   }
+
+  // Adjacent ones in the middle
+  {
+    TensorShape<> a = {2, 4, 5, 6, 3};
+    TensorShape<> b = {2, 1, 1, 1, 3};
+    TensorShape<> c = {2, 1, 1, 1, 3};
+    SimplifyShapesForBroadcasting(a, b, c);
+    TensorShape<> simple_a = {2, 4 * 5 * 6, 3};
+    TensorShape<> simple_b = {2,         1, 3};
+    TensorShape<> simple_c = {2,         1, 3};
+    EXPECT_EQ(simple_a, a);
+    EXPECT_EQ(simple_b, b);
+    EXPECT_EQ(simple_c, c);
+  }
 }
 
 

--- a/dali/operators/math/expressions/broadcasting_test.cc
+++ b/dali/operators/math/expressions/broadcasting_test.cc
@@ -132,7 +132,7 @@ TEST(ArithmeticOpsBroadcastingTest, SimplifyShapesForBroadcasting) {
     TensorShape<> b = {};
     SimplifyShapesForBroadcasting(a, b);
     TensorShape<> simple_a = {120};
-    TensorShape<> simple_b = {1};
+    TensorShape<> simple_b = {};
     EXPECT_EQ(simple_a, a);
     EXPECT_EQ(simple_b, b);
   }
@@ -140,10 +140,10 @@ TEST(ArithmeticOpsBroadcastingTest, SimplifyShapesForBroadcasting) {
   // Any shape and a scalar-like should reduce to one dim
   {
     TensorShape<> a = {2, 1, 10, 2, 1, 3};
-    TensorShape<> b = {1};
+    TensorShape<> b = {};
     SimplifyShapesForBroadcasting(a, b);
     TensorShape<> simple_a = {120};
-    TensorShape<> simple_b = {1};
+    TensorShape<> simple_b = {};
     EXPECT_EQ(simple_a, a);
     EXPECT_EQ(simple_b, b);
   }
@@ -154,7 +154,7 @@ TEST(ArithmeticOpsBroadcastingTest, SimplifyShapesForBroadcasting) {
     TensorShape<> b = {1, 1,  1, 1, 1, 1};
     SimplifyShapesForBroadcasting(a, b);
     TensorShape<> simple_a = {120};
-    TensorShape<> simple_b = {1};
+    TensorShape<> simple_b = {};
     EXPECT_EQ(simple_a, a);
     EXPECT_EQ(simple_b, b);
   }
@@ -164,7 +164,7 @@ TEST(ArithmeticOpsBroadcastingTest, SimplifyShapesForBroadcasting) {
     TensorShape<> b = {1, 1, 1};
     SimplifyShapesForBroadcasting(a, b);
     TensorShape<> simple_a = {4 * 3 * 16};
-    TensorShape<> simple_b = {1};
+    TensorShape<> simple_b = {};
     EXPECT_EQ(simple_a, a);
     EXPECT_EQ(simple_b, b);
   }
@@ -186,7 +186,7 @@ TEST(ArithmeticOpsBroadcastingTest, SimplifyShapesForBroadcasting) {
     TensorShape<> c = {1024, 1024};
     SimplifyShapesForBroadcasting(a, b, c);
     TensorShape<> simple_a = {1024 * 1024};
-    TensorShape<> simple_b = {1};
+    TensorShape<> simple_b = {};
     TensorShape<> simple_c = {1024 * 1024};
     EXPECT_EQ(simple_a, a);
     EXPECT_EQ(simple_b, b);
@@ -198,8 +198,34 @@ TEST(ArithmeticOpsBroadcastingTest, SimplifyShapesForBroadcasting) {
     TensorShape<> c = {1024, 1024};
     SimplifyShapesForBroadcasting(a, b, c);
     TensorShape<> simple_a = {1024 * 1024};
-    TensorShape<> simple_b = {1};
+    TensorShape<> simple_b = {};
     TensorShape<> simple_c = {1024 * 1024};
+    EXPECT_EQ(simple_a, a);
+    EXPECT_EQ(simple_b, b);
+    EXPECT_EQ(simple_c, c);
+  }
+
+  // All ones
+  {
+    TensorShape<> a = {1, 1, 1, 1, 1, 1};
+    TensorShape<> b = {};
+    TensorShape<> c = {1, 1};
+    SimplifyShapesForBroadcasting(a, b, c);
+    TensorShape<> simple_a = {};
+    TensorShape<> simple_b = {};
+    TensorShape<> simple_c = {};
+    EXPECT_EQ(simple_a, a);
+    EXPECT_EQ(simple_b, b);
+    EXPECT_EQ(simple_c, c);
+  }
+  {
+    TensorShape<> a = {1, 1, 1};
+    TensorShape<> b = {1, 1, 1};
+    TensorShape<> c = {1, 1, 1};
+    SimplifyShapesForBroadcasting(a, b, c);
+    TensorShape<> simple_a = {};
+    TensorShape<> simple_b = {};
+    TensorShape<> simple_c = {};
     EXPECT_EQ(simple_a, a);
     EXPECT_EQ(simple_b, b);
     EXPECT_EQ(simple_c, c);


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature**  / **Refactoring**

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
- It extends the shape simplification utils for broadcasting, to cover few cases that were incorrect
- For example, collapsing adjacent ones
{2, 3, 4} and {1, 1, 4} can be simplified to {6, 4} and {1, 4} before execution
- Added more test-cases to cover some interesting examples
- Extended the utilities to work with ternary operators (actually, the utils now support any number of arguments)
- Decoupled the selection of collapsible groups from the rest. This way we can calculate the groups to be collapsed on the arguments and apply the same transformation to the output shape (usage like this is part of the next PR).
- Note: To see this utils in context, see the working prototype of arithmetic operator broadcasting: https://github.com/NVIDIA/DALI/pull/4282/

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
broadcasting.* utils


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
Can we make the algorithm in SimplifiedShapeCollapseGroups any simpler? 

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A
ArithmeticOpsBroadcastingTest.SimplifyShapesForBroadcasting

<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [x] Other (comments in the code)
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3063
<!--- DALI-XXXX or NA --->
