### PR TITLE
Prune static cuda libraries DALI links with from unused archs

### DIFF
--- a/docker/Dockerfile.cuda102.x86_64.deps
+++ b/docker/Dockerfile.cuda102.x86_64.deps
@@ -10,7 +10,16 @@ RUN curl -LO https://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_
     chmod +x cuda_*.run && \
     # just installing with override on Ubuntu 20:04 doesn't work for some reason so unpack and move
     ./cuda_*.run --extract=/tmp/cuda/ --override && mv /tmp/cuda/cuda-toolkit/ /usr/local/cuda && \
-    rm -f cuda_*.run;
+    rm -f cuda_*.run && \
+    for f in $(find /usr/local/cuda/lib64/ -iname "*.a"); do            \
+        echo $f                                                      && \
+        /usr/local/cuda/bin/nvprune -gencode arch=compute_35,code=sm_35 \
+                                    -gencode arch=compute_50,code=sm_50 \
+                                    -gencode arch=compute_60,code=sm_60 \
+                                    -gencode arch=compute_70,code=sm_70 \
+        $f -o $f;                                                       \
+    done
+
 
 FROM scratch
 COPY --from=cuda /usr/local/cuda /usr/local/cuda

--- a/docker/Dockerfile.cuda118.aarch64.deps
+++ b/docker/Dockerfile.cuda118.aarch64.deps
@@ -9,4 +9,12 @@ RUN apt update && apt install -y libxml2 curl perl gcc && \
 RUN curl -LO https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux_sbsa.run && \
     chmod +x cuda_*.run && \
     ./cuda_*.run --silent --no-opengl-libs --toolkit && \
-    rm -f cuda_*.run;
+    rm -f cuda_*.run && \
+    for f in $(find /usr/local/cuda/lib64/ -iname "*.a"); do            \
+        echo $f                                                      && \
+        /usr/local/cuda/bin/nvprune -gencode arch=compute_70,code=sm_70 \
+                                    -gencode arch=compute_70,code=sm_80 \
+                                    -gencode arch=compute_70,code=sm_90 \
+        $f -o $f;                                                       \
+    done
+

--- a/docker/Dockerfile.cuda118.x86_64.deps
+++ b/docker/Dockerfile.cuda118.x86_64.deps
@@ -23,4 +23,14 @@ RUN NVJPEG2K_VERSION=0.5.0.25-1 && \
     apt-get install libcufile-dev-11-8=${CUFILE_VERSION} -y && \
     cp /usr/include/nvjpeg2k* /usr/local/cuda/include/ && \
     cp /usr/lib/x86_64-linux-gnu/libnvjpeg2k* /usr/local/cuda/lib64/ && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    for f in $(find /usr/local/cuda/lib64/ -iname "*.a"); do            \
+        echo $f                                                      && \
+        /usr/local/cuda/bin/nvprune -gencode arch=compute_35,code=sm_35 \
+                                    -gencode arch=compute_50,code=sm_50 \
+                                    -gencode arch=compute_60,code=sm_60 \
+                                    -gencode arch=compute_70,code=sm_70 \
+                                    -gencode arch=compute_70,code=sm_80 \
+                                    -gencode arch=compute_70,code=sm_90 \
+        $f -o $f;                                                       \
+    done


### PR DESCRIPTION
- prune static cuda libraries DALI links with from unused
  architectures so there is no device code linked with DALI
  other than 35, 50, 60, 70, 80 and 90. In result the DALI wheel
  is a bit smaller
- this PR affects only dockerized builds

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- prune static cuda libraries DALI links with from unused
  architectures so there is no device code linked with DALI
  other than 35, 50, 60, 70, 80 and 90. In result the DALI wheel
  is a bit smaller
- this PR affects only dockerized builds
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- docker/Dockerfile.cuda102.x86_64.deps
- docker/Dockerfile.cuda118.aarch64.deps
- docker/Dockerfile.cuda118.x86_64.deps

<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
