### PR TITLE
Fix ES synchronization issues in integrated memory devices

### DIFF
--- a/dali/pipeline/operator/builtin/external_source.cu
+++ b/dali/pipeline/operator/builtin/external_source.cu
@@ -44,6 +44,8 @@ void ExternalSource<GPUBackend>::RunImpl(Workspace &ws) {
   }
 
   std::swap(output, *tensor_list_elm.front());
+  output.set_order(ws.stream(), false);
+  tensor_list_elm.front()->set_order(AccessOrder(internal_copy_stream_));
 
   if (!state_info.no_copy || state_info.copied_shared_data) {
     RecycleBuffer(tensor_list_elm, &internal_copy_to_storage);

--- a/dali/pipeline/operator/builtin/external_source.cu
+++ b/dali/pipeline/operator/builtin/external_source.cu
@@ -45,7 +45,7 @@ void ExternalSource<GPUBackend>::RunImpl(Workspace &ws) {
 
   std::swap(output, *tensor_list_elm.front());
   output.set_order(ws.stream(), false);
-  tensor_list_elm.front()->set_order(AccessOrder(internal_copy_stream_));
+  tensor_list_elm.front()->set_order(internal_copy_order_);
 
   if (!state_info.no_copy || state_info.copied_shared_data) {
     RecycleBuffer(tensor_list_elm, &internal_copy_to_storage);

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -629,7 +629,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
 
   WorkerThread sync_worker_;
   CUDAStreamLease internal_copy_stream_ = {};
-  AccessOrder internal_copy_order_ = {};
+  AccessOrder internal_copy_order_ = AccessOrder::host();
 };
 
 }  // namespace dali

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "dali/core/cuda_event.h"
+#include "dali/core/cuda_stream_pool.h"
 #include "dali/core/nvtx.h"
 #include "dali/pipeline/data/type_traits.h"
 #include "dali/pipeline/operator/batch_size_provider.h"
@@ -216,7 +217,8 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
         previous_dtype_(DALIDataType::DALI_NO_TYPE),
         ndim_(-1),
         layout_(),
-        sync_worker_(device_id_, false, "ExternalSource syncworker") {
+        sync_worker_(device_id_, false, "ExternalSource syncworker"),
+        internal_copy_stream_(CUDAStreamPool::instance().Get(device_id_)) {
     spec.TryGetArgument(dtype_, "dtype");
     if (spec.TryGetArgument(ndim_, "ndim")) {
       DALI_ENFORCE(ndim_ >= 0, make_string("Incorrect number of dimensions (", ndim_,
@@ -372,7 +374,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
                 bool /*use_copy_kernel = false*/) {
     std::lock_guard<std::mutex> busy_lock(busy_m_);
     state_.push_back({false, true});
-    auto tl_elm = tl_data_.GetEmpty();
+    auto tl_elm = GetEmptyOutputBatch();
     // set pinned if needed
     if (batch.is_pinned() != tl_elm.front()->is_pinned()) {
       tl_elm.front()->Reset();
@@ -401,7 +403,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
   ShareUserData(const TensorList<SrcBackend> &batch, AccessOrder order = {},
                 bool use_copy_kernel = false) {
     std::lock_guard<std::mutex> busy_lock(busy_m_);
-    auto tl_elm = tl_data_.GetEmpty();
+    auto tl_elm = GetEmptyOutputBatch();
     bool copied_shared_data = false;
 
     if (batch.IsContiguous()) {
@@ -435,7 +437,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
     std::list<uptr_tl_type> tl_elm;
     {
       std::lock_guard<std::mutex> busy_lock(busy_m_);
-      tl_elm = tl_data_.GetEmpty();
+      tl_elm = GetEmptyOutputBatch();
     }
     // set pinned if needed
     tl_elm.front()->set_order(AccessOrder::host());
@@ -459,8 +461,17 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
     std::list<uptr_tl_type> tl_elm;
     {
       std::lock_guard<std::mutex> busy_lock(busy_m_);
-      tl_elm = tl_data_.GetEmpty();
+      tl_elm = GetEmptyOutputBatch();
       copy_to_storage_event = copy_to_storage_events_.GetEmpty();
+    }
+    // If we got a host order, this means that means, we most probably got it via FeedPipeline,
+    // and we are trying to pass the data from CPU to GPU.
+    // As we keep the order in tl_data_ as internal_copy_stream_, we will use an actual stream
+    // for running and synchronizing with the copy. Note that the Copy can be truly asynchronous
+    // if it comes from pinned memory or happens on a device with integrated memory (like Xavier)
+    // where CPU and GPU share the same memory.
+    if (!order.is_device()) {
+      order = tl_elm.front()->order();
     }
     tl_elm.front()->Copy(batch, order, use_copy_kernel);
     CUDA_CALL(cudaEventRecord(*copy_to_storage_event.front(), order.stream()));
@@ -563,6 +574,16 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
     cv_.notify_one();
   }
 
+  /**
+   * @brief Get the empty output batch from tl_data_, first assigning the correct order to it.
+   * @warning User is responsible for holding busy_m_ mutex when calling this function.
+   */
+  std::list<uptr_tl_type> GetEmptyOutputBatch() {
+    auto result = tl_data_.GetEmpty();
+    result.front()->set_order(AccessOrder(internal_copy_stream_));
+    return result;
+  }
+
   string output_name_;
   detail::CachingList<uptr_tl_type> tl_data_;
   detail::CachingList<uptr_cuda_event_type> copy_to_storage_events_;
@@ -604,6 +625,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
   bool zero_copy_noncontiguous_gpu_input_ = false;
 
   WorkerThread sync_worker_;
+  CUDAStreamLease internal_copy_stream_;
 };
 
 }  // namespace dali

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -227,7 +227,7 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
     spec.TryGetArgument(layout_, "layout");
     InferNdim();
     output_name_ = spec.Output(0);
-    if (std::is_same<Backend, CPUBackend>::value) {
+    if (std::is_same<Backend, GPUBackend>::value) {
       internal_copy_stream_ = CUDAStreamPool::instance().Get(device_id_);
       internal_copy_order_ = internal_copy_stream_;
     }

--- a/include/dali/core/access_order.h
+++ b/include/dali/core/access_order.h
@@ -18,6 +18,7 @@
 #include <cuda_runtime.h>
 #include <cstddef>
 #include "dali/core/api_helper.h"
+#include "dali/core/cuda_stream_pool.h"
 
 namespace dali {
 
@@ -32,7 +33,10 @@ class DLL_PUBLIC AccessOrder {
  public:
   constexpr AccessOrder() = default;
   constexpr AccessOrder(cudaStream_t stream, int device_id)
-  : stream_(stream), device_id_(device_id) {}
+      : stream_(stream), device_id_(device_id) {}
+
+  explicit AccessOrder(const CUDAStreamLease &stream_lease)
+      : stream_(stream_lease), device_id_(stream_lease.device_id()) {}
 
   AccessOrder(int) = delete;  // NOLINT  prevent construction from 0
   AccessOrder(std::nullptr_t) = delete;  // NOLINT

--- a/include/dali/core/access_order.h
+++ b/include/dali/core/access_order.h
@@ -18,7 +18,6 @@
 #include <cuda_runtime.h>
 #include <cstddef>
 #include "dali/core/api_helper.h"
-#include "dali/core/cuda_stream_pool.h"
 
 namespace dali {
 
@@ -34,9 +33,6 @@ class DLL_PUBLIC AccessOrder {
   constexpr AccessOrder() = default;
   constexpr AccessOrder(cudaStream_t stream, int device_id)
       : stream_(stream), device_id_(device_id) {}
-
-  explicit AccessOrder(const CUDAStreamLease &stream_lease)
-      : stream_(stream_lease), device_id_(stream_lease.device_id()) {}
 
   AccessOrder(int) = delete;  // NOLINT  prevent construction from 0
   AccessOrder(std::nullptr_t) = delete;  // NOLINT

--- a/include/dali/core/cuda_stream_pool.h
+++ b/include/dali/core/cuda_stream_pool.h
@@ -15,10 +15,11 @@
 #ifndef DALI_CORE_CUDA_STREAM_POOL_H_
 #define DALI_CORE_CUDA_STREAM_POOL_H_
 
-#include <cassert>
 #include <atomic>
-#include <vector>
+#include <cassert>
 #include <utility>
+#include <vector>
+#include "dali/core/access_order.h"
 #include "dali/core/cuda_stream.h"
 #include "dali/core/spinlock.h"
 
@@ -172,6 +173,23 @@ class CUDAStreamLease {
    * to another party.
    */
   operator cudaStream_t() && = delete;
+
+  /**
+   * @brief Conversion to the DALI AccessOrder.
+   */
+  operator AccessOrder() const & noexcept {
+    return {stream_, device_id_};
+  }
+
+  /**
+   * @brief Cannot obtain a valid handle from a temporary CUDAStreamLease
+   *
+   * By the time this function returns, the stream is returned to the pool.
+   * The stream will be alive as long as the owning CUDAStreamPool lives, but it can be leased
+   * to another party.
+   */
+  operator AccessOrder() && = delete;
+
 
   explicit operator bool() const noexcept {
     return stream_;


### PR DESCRIPTION

## Category: **Bug fix**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
When CPU data is fed to GPU external source the data is passed as having
host order (in the backend_impl). This caused the event-based
synchronization to not work on Xavier, where the CPU and GPU use the
same memory and the copies are truly asynchronous.
An additional stream was introduced to external source to schedule the
CPU->GPU copy as we don't get device order to use and don't have access
to workspace at that point.

AccessOrder gets a convenient constructor from CUDAStreamLease.

We need to take care of handling CPU Only mode (so we can't always obtain
the stream from the pool).

## Additional information:

### Affected modules and functionalities:
External source



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
The problem should be triggered in the adjusted feed_input ES test on Xavier.
Sadly, adjusting the loop count doesn't guarantee that the bug is triggered,
so this probably requires more validation (and reversal to the original loop count). 
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
