### PR TITLE
Extend and relax TensorList sample APIs

### DIFF
--- a/dali/pipeline/data/tensor_list.cc
+++ b/dali/pipeline/data/tensor_list.cc
@@ -597,8 +597,6 @@ void TensorList<Backend>::ResizeSample(int sample_idx, const TensorShape<> &new_
   assert(sample_idx >= 0 && sample_idx < curr_num_tensors_);
   // Resizing any individual sample converts the batch to non-contiguous mode
   MakeNoncontiguous();
-  if (tensors_[sample_idx].capacity() >= volume(new_shape) * type_.size())
-    return;
   shape_.set_tensor_shape(sample_idx, new_shape);
   tensors_[sample_idx].Resize(new_shape);
 }

--- a/dali/pipeline/data/tensor_list.cc
+++ b/dali/pipeline/data/tensor_list.cc
@@ -850,7 +850,8 @@ void TensorList<Backend>::Copy(const TensorList<SrcBackend> &src, AccessOrder or
                                bool use_copy_kernel) {
   auto copy_order = copy_impl::SyncBefore(this->order(), src.order(), order);
 
-  if (!src.has_data() && !IsValidType(src.type())) {
+  if (!IsValidType(src.type())) {
+    assert(!src.has_data() && "It is not possible to have data without valid type.");
     Reset();
     SetLayout(src.GetLayout());
     // no copying to do

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -509,7 +509,7 @@ TYPED_TEST(TensorListTest, TestCopy) {
 
 TYPED_TEST(TensorListTest, TestCopyEmpty) {
   using Backend = std::tuple_element_t<0, TypeParam>;
-  TensorList<Backend> tl;
+  TensorList<Backend> tl, uninitialized;
   tl.SetContiguity(this->kContiguity);
 
   tl.template set_type<float>();
@@ -524,6 +524,13 @@ TYPED_TEST(TensorListTest, TestCopyEmpty) {
     ASSERT_EQ(tl.type(), tl2.type());
     ASSERT_EQ(tl._num_elements(), tl2._num_elements());
     ASSERT_EQ(tl.GetLayout(), tl2.GetLayout());
+
+    tl2.Copy(uninitialized);
+    ASSERT_FALSE(tl2.has_data());
+    ASSERT_EQ(uninitialized.num_samples(), tl2.num_samples());
+    ASSERT_EQ(uninitialized.type(), tl2.type());
+    ASSERT_EQ(uninitialized._num_elements(), tl2._num_elements());
+    ASSERT_EQ(uninitialized.GetLayout(), tl2.GetLayout());
   }
 }
 
@@ -954,10 +961,6 @@ std::vector<std::pair<std::string, std::function<void(TensorList<Backend> &)>>> 
       {"layout", [layout](TensorList<Backend> &t) { t.SetLayout(layout); }},
       {"device id", [device_id](TensorList<Backend> &t) { t.set_device_id(device_id); }},
       {"pinned", [pinned](TensorList<Backend> &t) { t.set_pinned(pinned); }},
-      {"order",
-       [device_id](TensorList<Backend> &t) {
-         t.set_order(AccessOrder(cuda_stream, device_id));
-       }},
   };
 }
 
@@ -1324,6 +1327,55 @@ TYPED_TEST(TensorListSuite, NoncontiguousResize) {
     EXPECT_EQ(tv[i].type(), DALI_FLOAT);
     CompareWithNumber(tv[i], 2.f);
   }
+}
+
+
+TYPED_TEST(TensorListSuite, ResizeSample) {
+  TensorList<TypeParam> tv;
+  tv.SetContiguity(BatchContiguity::Automatic);
+
+  auto new_shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
+  tv.Resize(new_shape, DALI_FLOAT, BatchContiguity::Contiguous);
+  EXPECT_TRUE(tv.IsContiguous());
+
+  for (int i = 0; i < 3; i++) {
+    FillWithNumber(tv[i], 1 + i * 1.f);
+  }
+
+  for (int i = 0; i < 3; i++) {
+    EXPECT_NE(tv[i].raw_data(), nullptr);
+    EXPECT_EQ(tv[i].shape(), new_shape[i]);
+    EXPECT_EQ(tv[i].type(), DALI_FLOAT);
+    CompareWithNumber(tv[i], 1 + i * 1.f);
+  }
+
+  auto new_sample_shape = TensorShape<>{10, 10, 3};
+  new_shape.set_tensor_shape(1, new_sample_shape);
+
+  tv.ResizeSample(1, new_sample_shape);
+
+  EXPECT_FALSE(tv.IsContiguous());
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(tv[i].shape(), new_shape[i]);
+  }
+
+  FillWithNumber(tv[1], 42.f);
+
+  EXPECT_EQ(tv[1].shape(), new_sample_shape);
+  EXPECT_EQ(tv[1].type(), DALI_FLOAT);
+  CompareWithNumber(tv[1], 42.f);
+}
+
+
+TYPED_TEST(TensorListSuite, ResizeSampleProhibited) {
+  TensorList<TypeParam> tv;
+  auto sample_shape = TensorShape<>{10, 10};
+  tv.SetContiguity(BatchContiguity::Automatic);
+  EXPECT_THROW(tv.ResizeSample(0, sample_shape), std::runtime_error);
+  auto shape = TensorListShape<>{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}};
+  tv.Resize(shape, DALI_FLOAT, BatchContiguity::Contiguous);
+
+  EXPECT_THROW(tv.ResizeSample(1, sample_shape), std::runtime_error);
 }
 
 

--- a/dali/pipeline/data/tensor_list_test.cc
+++ b/dali/pipeline/data/tensor_list_test.cc
@@ -1364,6 +1364,22 @@ TYPED_TEST(TensorListSuite, ResizeSample) {
   EXPECT_EQ(tv[1].shape(), new_sample_shape);
   EXPECT_EQ(tv[1].type(), DALI_FLOAT);
   CompareWithNumber(tv[1], 42.f);
+
+  auto new_smaller_sample_shape = TensorShape<>{5, 5, 3};
+  new_shape.set_tensor_shape(1, new_smaller_sample_shape);
+
+  tv.ResizeSample(1, new_smaller_sample_shape);
+
+  EXPECT_FALSE(tv.IsContiguous());
+  for (int i = 0; i < 3; i++) {
+    EXPECT_EQ(tv[i].shape(), new_shape[i]);
+  }
+
+  FillWithNumber(tv[1], 42.f);
+
+  EXPECT_EQ(tv[1].shape(), new_smaller_sample_shape);
+  EXPECT_EQ(tv[1].type(), DALI_FLOAT);
+  CompareWithNumber(tv[1], 42.f);
 }
 
 


### PR DESCRIPTION

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **New feature**, **Bug fix**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Add ResizeSample that allows to resize individual samples. Automatically converts the batch into non-contiguous mode, same as SetSample.

SetSample no longer requires the order between the batch and new sample to match - instead it waits for the incoming order in the order of current batch, so the access in the batch order will be correct.

Fix a problem that prohibited copying from empty batch that had no samples nor type set. Now it resets the current batch to similar state.

Those features are useful for implementing the Split and Merge operators.

## Additional information:

### Affected modules and functionalities:
TensorList 

### Key points relevant for the review:
If the parameters to order::wait are in correct order.

### Tests:
- [ ] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [x] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
