### PR TITLE
Utils and prerequisities for `NppRemapKernel` implementation

### DIFF
--- a/dali/core/tensor_view_test.cc
+++ b/dali/core/tensor_view_test.cc
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 #include <numeric>
+#include <random>
 #include <utility>
 
 #include "dali/core/tensor_shape.h"
@@ -516,6 +517,90 @@ TEST(TensorListView, Reshape) {
   EXPECT_EQ(r7.shape, shape7);
   for (int i = 0; i < 3; i++)
     EXPECT_EQ(r7.data[i], reinterpret_cast<uint16_t*>(tlv.data[i]));
+}
+
+
+class TensorListViewFromVectorOfTensorViewTest : public ::testing::Test {
+ protected:
+  using T = uint8_t;
+  using Backend = StorageCPU;
+
+
+  template<int ndim>
+  void PrepareTestData(const std::vector<TensorShape<ndim>> &shapes) {
+    std::uniform_int_distribution<> idist(0, 255);
+    auto irng = [&]() { return idist(mt_); };
+    size_t batch_size = shapes.size();
+
+    test_data_.resize(batch_size);
+    for (size_t i = 0; i < batch_size; i++) {
+      test_data_[i].resize(volume(shapes[i]));
+      generate(test_data_[i].begin(), test_data_[i].end(), irng);
+      data_pointers_.emplace_back(test_data_[i].data());
+    }
+  }
+
+
+  template<typename Backend, typename T, int ndim>
+  bool compare(TensorListView<Backend, T, ndim> lhs, TensorListView<Backend, T, ndim> rhs) {
+    if (lhs.shape != rhs.shape)
+      return false;
+    if (lhs.data != rhs.data)
+      return false;
+    return true;
+  }
+
+
+  std::vector<std::vector<T>> test_data_;
+  std::vector<T *> data_pointers_;
+  std::mt19937 mt_;
+};
+
+TEST_F(TensorListViewFromVectorOfTensorViewTest, StaticDimTest) {
+  constexpr int ndim = 3;
+
+  std::vector<TensorShape<ndim>> shapes{
+          {1080, 1920, 3},
+          {480,  640,  3},
+          {24,   24,   24},
+  };
+
+  PrepareTestData(shapes);
+
+  size_t batch_size = shapes.size();
+  std::vector<TensorView<Backend, T, ndim>> tvs;
+  for (size_t i = 0; i < batch_size; i++) {
+    tvs.emplace_back(this->test_data_[i].data(), shapes[i]);
+  }
+
+  auto tl_from_tvs = make_tensor_list(tvs);
+  TensorListView<Backend, T, ndim> tl_from_data_pointers(this->data_pointers_.data(), shapes);
+
+  EXPECT_TRUE(this->compare(tl_from_tvs, tl_from_data_pointers));
+}
+
+
+TEST_F(TensorListViewFromVectorOfTensorViewTest, DynamicDimTest) {
+  constexpr int ndim = -1;
+
+  std::vector<TensorShape<ndim>> shapes{
+          {1080, 1920, 3},
+          {480,  640,  3},
+          {24,   24,   24},
+  };
+
+  PrepareTestData(shapes);
+
+  size_t batch_size = shapes.size();
+  std::vector<TensorView<Backend, T, ndim>> tvs;
+  for (size_t i = 0; i < batch_size; i++) {
+    tvs.emplace_back(this->test_data_[i].data(), shapes[i]);
+  }
+
+  auto tl_from_tvs = make_tensor_list(tvs);
+  TensorListView<Backend, T, ndim> tl_from_data_pointers(this->data_pointers_.data(), shapes);
+
+  EXPECT_TRUE(this->compare(tl_from_tvs, tl_from_data_pointers));
 }
 
 }  // namespace kernels

--- a/dali/kernels/imgproc/geom/remap.h
+++ b/dali/kernels/imgproc/geom/remap.h
@@ -15,24 +15,26 @@
 #ifndef DALI_KERNELS_IMGPROC_GEOM_REMAP_H_
 #define DALI_KERNELS_IMGPROC_GEOM_REMAP_H_
 
+#include <vector>
 #include <optional>
 #include "dali/core/common.h"
+#include "dali/kernels/imgproc/roi.h"
 #include "dali/kernels/kernel.h"
 #include "include/dali/core/boundary.h"
 #include "include/dali/core/geom/box.h"
 
-namespace dali {
-namespace kernels {
+namespace dali::kernels::remap {
 
 
 /**
  * API for Remap operation. Remap applies a generic geometrical transformation to an image.
- * @tparam Backend
- * @tparam T
+ * @tparam Backend Storage backend for data.
+ * @tparam T Type of input and output data.
  */
 template <typename Backend, typename T>
 struct RemapKernel {
   using Border = boundary::Boundary<T>;
+  using MapType = float;
   /**
    * Perform remap algorithm. This function allows to apply a different transformation to every
    * sample in a batch. For a special case, where the same transformation is applied for every
@@ -64,25 +66,26 @@ struct RemapKernel {
    * @param borders Determines, how to handle pixels on a border on an image (or ROI). If empty,
    *                it is assumed that every sample is processed with REFLECT_101.
    */
-  void Run(KernelContext &context, TensorListView<Backend, T> output,
-           TensorListView<Backend, const T> input, TensorListView<Backend, const float, 2> mapsx,
-           TensorListView<Backend, const float, 2> mapsy, span<Box<2, int64_t>> output_rois = {},
-           span<Box<2, int64_t>> input_rois = {}, span<DALIInterpType> interpolations = {},
-           span<Border> borders = {}) = 0;
+  virtual void Run(KernelContext &context, TensorListView<Backend, T> output,
+                   TensorListView<Backend, const T> input,
+                   TensorListView<Backend, const MapType, 2> mapsx,
+                   TensorListView<Backend, const MapType, 2> mapsy,
+                   span<const Roi<2>> output_rois = {}, span<const Roi<2>> input_rois = {},
+                   span<DALIInterpType> interpolations = {}, span<Border> borders = {}) = 0;
 
 
   /**
    * Convenient overload. This function shall be used when the transformation parameters are the
    * same for every sample in an input batch.
    */
-  void Run(KernelContext &context, TensorListView<Backend, T> output,
-           TensorListView<Backend, const T> input, TensorView<Backend, const float, 2> mapx,
-           TensorView<Backend, const float, 2> mapy, Box<2, int64_t> output_roi = {},
-           Box<2, int64_t> input_roi = {}, DALIInterpType interpolation = DALI_INTERP_LINEAR,
-           Border border = {}) = 0;
+  virtual void Run(KernelContext &context, TensorListView<Backend, T> output,
+                   TensorListView<Backend, const T> input,
+                   TensorView<Backend, const MapType, 2> mapx,
+                   TensorView<Backend, const MapType, 2> mapy,
+                   Roi<2> output_roi = {}, Roi<2> input_roi = {},
+                   DALIInterpType interpolation = DALI_INTERP_LINEAR, Border border = {}) = 0;
 };
 
-}  // namespace kernels
-}  // namespace dali
+}  // namespace dali::kernels::remap
 
 #endif  // DALI_KERNELS_IMGPROC_GEOM_REMAP_H_

--- a/dali/kernels/imgproc/roi.h
+++ b/dali/kernels/imgproc/roi.h
@@ -89,6 +89,7 @@ Roi<spatial_dims> WholeImage(const TensorShape <ndims> &shape) {
 }  // namespace detail
 
 
+///@{
 /**
  * Defines TensorShape corresponding to provided Roi.
  *
@@ -127,6 +128,38 @@ TensorListShape<ndims> ShapeFromRoi(span<const Roi<spatial_dims>> rois, int ncha
   }
   return ret;
 }
+
+
+/**
+ * Overload for the case, when the memory layout is *HW,
+ * as the 1-channel image might be expressed in such layout.
+ */
+template <int ndims>
+TensorShape<ndims> ShapeFromRoi(const Roi<ndims> &roi) {
+  DALI_ENFORCE(all_coords(roi.hi >= roi.lo), "Cannot create a TensorShape from an invalid Roi");
+  TensorShape<ndims> ret;
+  auto e = roi.extent();
+  auto ridx = ndims;
+  for (size_t idx = 0; idx < ndims; idx++) {
+    ret[--ridx] = e[idx];
+  }
+  return ret;
+}
+
+
+/**
+ * Convenient overload for batch processing (creating TensorListShape)
+ */
+template <int ndims>
+TensorListShape<ndims> ShapeFromRoi(span<const Roi<ndims>> rois) {
+  TensorListShape<ndims> ret(rois.size());
+  size_t i = 0;
+  for (const auto &roi : rois) {
+    ret.set_tensor_shape(i++, ShapeFromRoi(roi));
+  }
+  return ret;
+}
+///@}
 
 
 /**

--- a/dali/kernels/imgproc/roi_test.cc
+++ b/dali/kernels/imgproc/roi_test.cc
@@ -47,6 +47,30 @@ TEST(RoiTest, roi_to_TensorShape) {
 }
 
 
+TEST(RoiTest, roi_to_TensorShape_HW) {
+  {
+    Roi roi{0, 3};
+    auto sh = ::dali::kernels::ShapeFromRoi(roi);
+    TensorShape<2> ref_sh = {3, 3};
+    EXPECT_EQ(ref_sh, sh);
+  }
+  {
+    Roi roi{{0, 2},
+            {5, 6}};
+    auto sh = ::dali::kernels::ShapeFromRoi(roi);
+    TensorShape<2> ref_sh = {4, 5};
+    EXPECT_EQ(ref_sh, sh);
+  }
+  {
+    Roi roi{{0, 0},
+            {0, 0}};
+    auto sh = ::dali::kernels::ShapeFromRoi(roi);
+    TensorShape<2> ref_sh = {0, 0};
+    EXPECT_EQ(ref_sh, sh);
+  }
+}
+
+
 TEST(RoiTest, roi_to_TensorListShape) {
   using Rois = std::vector<Roi>;
   constexpr int nchannels = 3;
@@ -61,6 +85,23 @@ TEST(RoiTest, roi_to_TensorListShape) {
                                       {4, 5, nchannels},
                                       {0, 0, nchannels}};
   auto shs = ShapeFromRoi(make_cspan(rois), nchannels);
+  EXPECT_EQ(shs, TensorListShape<-1>(ref));
+}
+
+
+TEST(RoiTest, roi_to_TensorListShape_HW) {
+  using Rois = std::vector<Roi>;
+  Roi roi1{0, 3};
+  Roi roi2{{0, 2},
+           {5, 6}};
+  Roi roi3{{0, 0},
+           {0, 0}};
+  Rois rois = {roi1, roi2, roi3};
+
+  std::vector<TensorShape<-1>> ref = {{3, 3},
+                                      {4, 5},
+                                      {0, 0}};
+  auto shs = ShapeFromRoi(make_cspan(rois));
   EXPECT_EQ(shs, TensorListShape<-1>(ref));
 }
 

--- a/dali/test/cv_mat_utils.h
+++ b/dali/test/cv_mat_utils.h
@@ -27,9 +27,10 @@
 namespace dali {
 namespace testing {
 
-template <int _ndim, class T>
-cv::Mat tensor_to_mat(const TensorView<StorageCPU, T, _ndim> &tensor,
+template <typename Storage, int _ndim, class T>
+cv::Mat tensor_to_mat(const TensorView<Storage, T, _ndim> &tensor,
                       bool has_channels = true, bool convert_to_BGR = true) {
+  static_assert(is_cpu_accessible<Storage>::value, "The data has to be CPU accessible.");
   int ndim = tensor.dim();
   int nch = has_channels ? tensor.shape[ndim - 1] : 1;
   int spatial_ndim = ndim - has_channels;

--- a/include/dali/core/tuple_helpers.h
+++ b/include/dali/core/tuple_helpers.h
@@ -233,6 +233,34 @@ using tuple_generator_t = typename tuple_generator_type<type_generator, Sequence
 using detail::apply;
 using detail::apply_all;
 
+
+namespace detail {
+
+template<typename T, typename Tuple>
+struct contains;
+
+template<typename T>
+struct contains<T, std::tuple<>> : std::false_type {};
+
+template<typename T, typename U, typename... Ts>
+struct contains<T, std::tuple<U, Ts...>> : contains<T, std::tuple<Ts...>> {};
+
+template<typename T, typename... Ts>
+struct contains<T, std::tuple<T, Ts...>> : std::true_type {};
+
+}  // namespace detail
+
+/**
+ * Checks, if the Tuple contains a given type T.
+ *
+ * Usage example:
+ * using Tup = std::tuple<int, double, MyType>;
+ * static_assert(contains_v<double, Tup>);  // this will pass
+ * static_assert(contains_v<float,  Tup>);  // this will fail
+ */
+template<typename T, typename Tuple>
+constexpr bool contains_v = detail::contains<T, Tuple>::type::value;
+
 }  // namespace dali
 
 #endif  // DALI_CORE_TUPLE_HELPERS_H_


### PR DESCRIPTION
Signed-off-by: szalpal <mszolucha@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)

**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)


--->
**New feature** (*non-breaking change which adds functionality*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
Since the #4365 PR grew significantly in size, I decided to extract parts of it into the separate PR to enhance review quality. This PR includes some utilities I've used for `NppRemapKernel` implementation. Specifically:

1. Additional convenient `make_tensor_list` functions: creating `TensorListView` from a `TensorView` (just wrapping it) and form `vector<TensorView>`. The latter overload is possible, since we changed from contiguous memory pattern to non-contiguous one. The tests are included in `tensor_view_test.cc`.
2. `contains_v` - convenient trait, that checks if a tuple has a given type. Surprisingly, such thing doesn't exist in `std`...
3. Small update in `tensor_to_mat` function. It doesn't need `StorageCPU`. It just needs, that the memory is CPU-accessible.
4. Refactoring Remap API and updating documentation.
5. Utility functions `ShapeFromRoi` that return `TensorShape` that can be associated with given `Roi`. The functions that are already there don't cover the case, when there is no channel dimension. And such situation might happen for 1-channel images - channel dimension doesn't have to exist.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [x] New tests added
  - [ ] Python tests
  - [x] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [x] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
