### PR TITLE
Fix namespace resolution for CUDA and STL math functions

### DIFF
--- a/dali/kernels/mask/grid_mask_cpu.h
+++ b/dali/kernels/mask/grid_mask_cpu.h
@@ -49,7 +49,7 @@ class GridMaskCpu {
       for (int x = 0; x < in.shape[1]; x++) {
         float fx = fxy + x * ca;
         float fy = fyy + x * sa;
-        auto m = (fx - floor(fx) >= ratio) || (fy - floor(fy) >= ratio);
+        auto m = (fx - std::floor(fx) >= ratio) || (fy - std::floor(fy) >= ratio);
         for (int c = 0; c < in.shape[2]; c++)
           *out_ptr++ = *in_ptr++ * m;
       }

--- a/dali/operators/math/expressions/math_overloads.h
+++ b/dali/operators/math/expressions/math_overloads.h
@@ -40,7 +40,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_sqrt(T x) {
 #ifdef __CUDA_ARCH__
-  return sqrt(x);
+  return ::sqrt(x);
 #else
   return std::sqrt(x);
 #endif
@@ -56,7 +56,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_cbrt(T x) {
 #ifdef __CUDA_ARCH__
-  return cbrt(x);
+  return ::cbrt(x);
 #else
   return std::cbrt(x);
 #endif
@@ -66,7 +66,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_exp(T x) {
 #ifdef __CUDA_ARCH__
-  return exp(x);
+  return ::exp(x);
 #else
   return std::exp(x);
 #endif
@@ -76,7 +76,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_log(T x) {
 #ifdef __CUDA_ARCH__
-  return log(x);
+  return ::log(x);
 #else
   return std::log(x);
 #endif
@@ -86,7 +86,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_log2(T x) {
 #ifdef __CUDA_ARCH__
-  return log2(x);
+  return ::log2(x);
 #else
   return std::log2(x);
 #endif
@@ -96,7 +96,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_log10(T x) {
 #ifdef __CUDA_ARCH__
-  return log10(x);
+  return ::log10(x);
 #else
   return std::log10(x);
 #endif
@@ -118,7 +118,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_fabs(T x) {
 #ifdef __CUDA_ARCH__
-  return fabs(x);
+  return ::fabs(x);
 #else
   return std::fabs(x);
 #endif
@@ -128,7 +128,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_floor(T x) {
 #ifdef __CUDA_ARCH__
-  return floor(x);
+  return ::floor(x);
 #else
   return std::floor(x);
 #endif
@@ -138,7 +138,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_ceil(T x) {
 #ifdef __CUDA_ARCH__
-  return ceil(x);
+  return ::ceil(x);
 #else
   return std::ceil(x);
 #endif
@@ -148,7 +148,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_sin(T x) {
 #ifdef __CUDA_ARCH__
-  return sin(x);
+  return ::sin(x);
 #else
   return std::sin(x);
 #endif
@@ -158,7 +158,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_cos(T x) {
 #ifdef __CUDA_ARCH__
-  return cos(x);
+  return ::cos(x);
 #else
   return std::cos(x);
 #endif
@@ -168,7 +168,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_tan(T x) {
 #ifdef __CUDA_ARCH__
-  return tan(x);
+  return ::tan(x);
 #else
   return std::tan(x);
 #endif
@@ -178,7 +178,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_asin(T x) {
 #ifdef __CUDA_ARCH__
-  return asin(x);
+  return ::asin(x);
 #else
   return std::asin(x);
 #endif
@@ -188,7 +188,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_acos(T x) {
 #ifdef __CUDA_ARCH__
-  return acos(x);
+  return ::acos(x);
 #else
   return std::acos(x);
 #endif
@@ -198,7 +198,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_atan(T x) {
 #ifdef __CUDA_ARCH__
-  return atan(x);
+  return ::atan(x);
 #else
   return std::atan(x);
 #endif
@@ -208,7 +208,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_sinh(T x) {
 #ifdef __CUDA_ARCH__
-  return sinh(x);
+  return ::sinh(x);
 #else
   return std::sinh(x);
 #endif
@@ -218,7 +218,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_cosh(T x) {
 #ifdef __CUDA_ARCH__
-  return cosh(x);
+  return ::cosh(x);
 #else
   return std::cosh(x);
 #endif
@@ -228,7 +228,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_tanh(T x) {
 #ifdef __CUDA_ARCH__
-  return tanh(x);
+  return ::tanh(x);
 #else
   return std::tanh(x);
 #endif
@@ -238,7 +238,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_asinh(T x) {
 #ifdef __CUDA_ARCH__
-  return asinh(x);
+  return ::asinh(x);
 #else
   return std::asinh(x);
 #endif
@@ -248,7 +248,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_acosh(T x) {
 #ifdef __CUDA_ARCH__
-  return acosh(x);
+  return ::acosh(x);
 #else
   return std::acosh(x);
 #endif
@@ -258,7 +258,7 @@ DALI_NO_EXEC_CHECK
 template <typename T>
 DALI_HOST_DEV inline T math_atanh(T x) {
 #ifdef __CUDA_ARCH__
-  return atanh(x);
+  return ::atanh(x);
 #else
   return std::atanh(x);
 #endif
@@ -270,7 +270,7 @@ DALI_HOST_DEV inline auto math_pow(
     X x, Y y,
     std::enable_if_t<!std::is_integral<X>::value || !std::is_integral<Y>::value>* = nullptr) {
 #ifdef __CUDA_ARCH__
-  return pow(x, y);
+  return ::pow(x, y);
 #else
   return std::pow(x, y);
 #endif
@@ -299,7 +299,7 @@ DALI_NO_EXEC_CHECK
 template <typename X, typename Y>
 DALI_HOST_DEV inline auto math_atan2(X x, Y y) {
 #ifdef __CUDA_ARCH__
-  return atan2(x, y);
+  return ::atan2(x, y);
 #else
   return std::atan2(x, y);
 #endif

--- a/dali/test/dali_test_resize.h
+++ b/dali/test/dali_test_resize.h
@@ -134,7 +134,7 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
 
         float sy = 0.5f * dy;
         for (int y = 0; y < rsz_h; y++, sy += dy) {
-          int srcy = floor(sy);
+          int srcy = ::floor(sy);
           for (int x = 0; x < rsz_w; x++) {
             // This is a bit lame - i.e. this reproduces exactly what we got in CPU ResampleNN.
             // Proper solution would be to test the output and see if the output pixel is coming
@@ -142,7 +142,7 @@ class GenericResizeTest : public DALISingleOpTest<ImgType> {
             // test from scratch for NN case, as it cannot be tested with a straightforward
             // pixelwise comparison.
             float sx = (x + 0.5f) * dx;
-            int srcx = floor(sx);
+            int srcx = ::floor(sx);
             auto *dst = rsz_img.ptr<uint8_t>(y, x);
             auto *src = input.ptr<uint8_t>(srcy, srcx);
             memcpy(dst, src, elem_sz);


### PR DESCRIPTION
Signed-off-by: szalpal <mszolucha@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:

**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->

**Bug fix** (*non-breaking change which fixes an issue*)
## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
This PR fixes a couple of problems that come from the similar reasons:

When a situation happens, that a `vec.h` file gets included together with a different file, that defines some math-like functions inside `dali` namespace, the CUDA or `std` functions used in this file aren't picked, because of namespace precedence. For example:

`vec.h` defines `vec<N, T> floor(const vec<N, T> &a)` function. Let's consider a following test file:
```c++
#include "vec.h"
#include "math_overloads.h"

namespace dali {

double a = 3.4;
auto b = floor(a);

}
```
The `floor(a)` function will fire a compilation error, because there's no definition for `floor(double)` - the function that actually gets picked is `dali::floor`, which has only `vec<N,T>` arguments.

Similarly the other problem - when `vec.h` is included in directory tree inside `dali` namespace, using `floor(float)` without `std` or `::` namespaces is a compilation error, since the `dali::floor` gets picked - and there's no such function.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
