### PR TITLE
Split cuda utils.h & fix includes

### DIFF
--- a/dali/core/cuda_event.cc
+++ b/dali/core/cuda_event.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "dali/core/cuda_event.h"
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_error.h"
 #include "dali/core/device_guard.h"
 
 namespace dali {

--- a/dali/core/cuda_stream.cc
+++ b/dali/core/cuda_stream.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "dali/core/cuda_stream.h"
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_error.h"
 #include "dali/core/device_guard.h"
 
 namespace dali {

--- a/dali/core/device_guard.cc
+++ b/dali/core/device_guard.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "dali/core/device_guard.h"
-#include "dali/core/error_handling.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 

--- a/dali/core/device_guard_test.cc
+++ b/dali/core/device_guard_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 
 #include <gtest/gtest.h>
 #include "dali/core/dynlink_cuda.h"
-#include "dali/core/cuda_utils.h"
 #include "dali/core/device_guard.h"
 #include "dali/core/cuda_error.h"
 #include "dali/core/unique_handle.h"

--- a/dali/core/error_test.cc
+++ b/dali/core/error_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #include <gtest/gtest.h>
 #include "dali/core/dynlink_cuda.h"
 #include "dali/core/cuda_utils.h"
-#include "dali/core/error_handling.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 

--- a/dali/core/error_test.cc
+++ b/dali/core/error_test.cc
@@ -14,7 +14,6 @@
 
 #include <gtest/gtest.h>
 #include "dali/core/dynlink_cuda.h"
-#include "dali/core/cuda_utils.h"
 #include "dali/core/cuda_error.h"
 
 namespace dali {

--- a/dali/core/small_vector_test.cc
+++ b/dali/core/small_vector_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
 #include "dali/core/small_vector.h"
+#include <gtest/gtest.h>
 
 namespace dali {
 

--- a/dali/imgcodec/image_orientation.cc
+++ b/dali/imgcodec/image_orientation.cc
@@ -14,6 +14,7 @@
 
 #include "dali/imgcodec/image_format.h"
 #include <string>
+#include "dali/core/error_handling.h"
 
 namespace dali {
 namespace imgcodec {

--- a/dali/imgcodec/parsers/bmp.cc
+++ b/dali/imgcodec/parsers/bmp.cc
@@ -15,6 +15,7 @@
 #include <stdexcept>
 #include "dali/imgcodec/parsers/bmp.h"
 #include "dali/core/byte_io.h"
+#include "dali/core/error_handling.h"
 #include "dali/core/format.h"
 #include "dali/core/small_vector.h"
 #include "dali/core/endian_util.h"

--- a/dali/imgcodec/parsers/jpeg.cc
+++ b/dali/imgcodec/parsers/jpeg.cc
@@ -14,6 +14,7 @@
 
 #include <vector>
 #include "third_party/opencv/exif/exif.h"
+#include "dali/core/error_handling.h"
 #include "dali/imgcodec/parsers/jpeg.h"
 #include "dali/core/byte_io.h"
 

--- a/dali/imgcodec/parsers/jpeg2000.cc
+++ b/dali/imgcodec/parsers/jpeg2000.cc
@@ -14,6 +14,7 @@
 
 #include "dali/imgcodec/parsers/jpeg2000.h"
 #include "dali/core/byte_io.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 namespace imgcodec {

--- a/dali/imgcodec/parsers/png.cc
+++ b/dali/imgcodec/parsers/png.cc
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 #include "dali/core/byte_io.h"
+#include "dali/core/error_handling.h"
 #include "dali/imgcodec/parsers/png.h"
 #include "dali/imgcodec/util/tag.h"
 #include "third_party/opencv/exif/exif.h"

--- a/dali/imgcodec/parsers/tiff.cc
+++ b/dali/imgcodec/parsers/tiff.cc
@@ -14,6 +14,7 @@
 
 #include "dali/imgcodec/parsers/tiff.h"
 #include "dali/core/byte_io.h"
+#include "dali/core/error_handling.h"
 #include "dali/imgcodec/image_orientation.h"
 
 namespace dali {

--- a/dali/imgcodec/parsers/webp.cc
+++ b/dali/imgcodec/parsers/webp.cc
@@ -19,6 +19,7 @@
 #include "dali/imgcodec/util/tag.h"
 #include "dali/core/byte_io.h"
 #include "dali/core/endian_util.h"
+#include "dali/core/error_handling.h"
 #include "third_party/opencv/exif/exif.h"
 
 namespace dali {

--- a/dali/kernels/common/copy.h
+++ b/dali/kernels/common/copy.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <cuda_runtime.h>
 #include <cstring>
 #include <utility>
+#include "dali/core/cuda_error.h"
 #include "dali/core/traits.h"
 #include "dali/core/mm/memory.h"
 #include "dali/core/backend_tags.h"

--- a/dali/kernels/common/copy_test.cu
+++ b/dali/kernels/common/copy_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 #include "dali/kernels/common/copy.h"
+#include "dali/core/cuda_error.h"
 #include "dali/core/mm/memory.h"
 #include "dali/test/tensor_test_utils.h"
 

--- a/dali/kernels/dynamic_scratchpad_test.cc
+++ b/dali/kernels/dynamic_scratchpad_test.cc
@@ -20,7 +20,7 @@
 #include <random>
 #include <string>
 #include <vector>
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_error.h"
 #include "dali/core/cuda_stream_pool.h"
 #include "dali/core/mm/memory.h"
 

--- a/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
+++ b/dali/kernels/imgproc/color_manipulation/color_space_conversion_kernel.cuh
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <cuda_runtime_api.h>
 #include <utility>
 #include "dali/kernels/imgproc/color_manipulation/color_space_conversion_impl.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/imgproc/roi.h
+++ b/dali/kernels/imgproc/roi.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <vector>
 #include "dali/core/geom/box.h"
 #include "dali/core/tensor_shape.h"
+#include "dali/core/error_handling.h"  // TODO(michalz): remove DALI_ENFORCE from this file
 
 namespace dali {
 namespace kernels {
@@ -193,8 +194,8 @@ Roi<spatial_dims> AdjustRoi(const Roi<spatial_dims> *roi, const TensorShape <ndi
 template <int ndims, int spatial_dims = ndims - 1>
 std::vector<Roi<spatial_dims>>
 AdjustRoi(span<const Roi<spatial_dims>> rois, const TensorListShape <ndims> &shapes) {
-  DALI_ENFORCE(rois.empty() || rois.size() == shapes.num_samples(),
-               "Either provide `rois` for every corresponding `shape`, or none.");
+  if (rois.empty() || rois.size() == shapes.num_samples())
+    throw std::invalid_argument("Either provide `rois` for every corresponding `shape`, or none.");
   std::vector<Roi<spatial_dims>> ret(shapes.num_samples());
 
   if (rois.empty()) {

--- a/dali/kernels/imgproc/roi.h
+++ b/dali/kernels/imgproc/roi.h
@@ -194,8 +194,8 @@ Roi<spatial_dims> AdjustRoi(const Roi<spatial_dims> *roi, const TensorShape <ndi
 template <int ndims, int spatial_dims = ndims - 1>
 std::vector<Roi<spatial_dims>>
 AdjustRoi(span<const Roi<spatial_dims>> rois, const TensorListShape <ndims> &shapes) {
-  if (rois.empty() || rois.size() == shapes.num_samples())
-    throw std::invalid_argument("Either provide `rois` for every corresponding `shape`, or none.");
+  DALI_ENFORCE(rois.empty() || rois.size() == shapes.num_samples(),
+               "Either provide `rois` for every corresponding `shape`, or none.");
   std::vector<Roi<spatial_dims>> ret(shapes.num_samples());
 
   if (rois.empty()) {

--- a/dali/kernels/imgproc/sampler_test.h
+++ b/dali/kernels/imgproc/sampler_test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #include "dali/core/mm/memory.h"
 #include "dali/kernels/imgproc/sampler.h"
 #include "dali/kernels/imgproc/surface.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/normalize/normalize_gpu_impl.cuh
+++ b/dali/kernels/normalize/normalize_gpu_impl.cuh
@@ -19,6 +19,7 @@
 #include <utility>
 #include <string>
 #include "dali/core/convert.h"
+#include "dali/core/cuda_rt_utils.h"
 #include "dali/core/format.h"
 #include "dali/core/small_vector.h"
 #include "dali/core/tensor_shape_print.h"

--- a/dali/kernels/reduce/reduce_gpu_impl.cuh
+++ b/dali/kernels/reduce/reduce_gpu_impl.cuh
@@ -30,7 +30,7 @@
 #include "dali/kernels/reduce/reductions.h"
 #include "dali/kernels/reduce/reduce_setup_utils.h"
 #include "dali/core/convert.h"
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_rt_utils.h"
 #include "dali/core/format.h"
 #include "dali/core/small_vector.h"
 #include "dali/core/span.h"

--- a/dali/kernels/reduce/reductions.h
+++ b/dali/kernels/reduce/reductions.h
@@ -23,7 +23,6 @@
 #include "dali/core/util.h"
 #include "dali/core/convert.h"
 #include "dali/core/geom/vec.h"
-#include "dali/core/cuda_utils.h"
 
 namespace dali {
 namespace kernels {

--- a/dali/kernels/scratch_copy_impl.h
+++ b/dali/kernels/scratch_copy_impl.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include "dali/core/traits.h"
 #include "dali/core/mm/memory.h"
+#include "dali/core/cuda_error.h"
 #include "dali/kernels/context.h"
 
 namespace dali {

--- a/dali/kernels/signal/moving_mean_square_gpu.cu
+++ b/dali/kernels/signal/moving_mean_square_gpu.cu
@@ -18,7 +18,7 @@
 #include <numeric>
 #include <vector>
 #include "dali/core/convert.h"
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_rt_utils.h"
 #include "dali/core/util.h"
 #include "dali/kernels/signal/moving_mean_square.h"
 #include "dali/kernels/signal/moving_mean_square_gpu.h"

--- a/dali/kernels/signal/resampling_test.cc
+++ b/dali/kernels/signal/resampling_test.cc
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "dali/kernels/signal/resampling_cpu.h"
 #include <gtest/gtest.h>
 #include <vector>
 #include <numeric>
-#include "dali/kernels/signal/resampling_cpu.h"
+#include "dali/core/cuda_error.h"
 #include "dali/kernels/signal/resampling_test.h"
 
 namespace dali {

--- a/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
+++ b/dali/kernels/slice/slice_flip_normalize_permute_pad_gpu.h
@@ -24,7 +24,7 @@
 #include "dali/core/dev_array.h"
 #include "dali/core/error_handling.h"
 #include "dali/core/static_switch.h"
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_rt_utils.h"
 #include "dali/kernels/common/copy.h"
 #include "dali/kernels/kernel.h"
 #include "dali/kernels/slice/slice_flip_normalize_permute_pad_common.h"

--- a/dali/kernels/slice/slice_gpu.cuh
+++ b/dali/kernels/slice/slice_gpu.cuh
@@ -21,6 +21,7 @@
 #include "dali/core/common.h"
 #include "dali/core/convert.h"
 #include "dali/core/cuda_error.h"
+#include "dali/core/cuda_rt_utils.h"
 #include "dali/core/dev_array.h"
 #include "dali/core/error_handling.h"
 #include "dali/core/fast_div.h"

--- a/dali/kernels/transpose/transpose_gpu.cu
+++ b/dali/kernels/transpose/transpose_gpu.cu
@@ -17,6 +17,7 @@
 #include <memory>
 #include <vector>
 #include "dali/core/util.h"
+#include "dali/core/cuda_rt_utils.h"
 #include "dali/kernels/common/type_erasure.h"
 #include "dali/kernels/transpose/transpose_gpu_def.h"
 #include "dali/kernels/transpose/transpose_gpu_impl.cuh"

--- a/dali/kernels/transpose/transpose_gpu_setup.cuh
+++ b/dali/kernels/transpose/transpose_gpu_setup.cuh
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 #define DALI_KERNELS_TRANSPOSE_TRANSPOSE_GPU_SETUP_CUH_
 
 #include <cuda_runtime.h>
+#include <algorithm>
 #include <utility>
-#include "dali/core/tensor_view.h"
+#include "dali/core/api_helper.h"
 #include "dali/core/fast_div.h"
+#include "dali/core/tensor_view.h"
 #include "dali/kernels/common/utils.h"
 #include "dali/kernels/transpose/transpose_gpu_impl.cuh"
 #include "dali/kernels/transpose/transpose_util.h"

--- a/dali/kernels/transpose/transpose_gpu_test.cc
+++ b/dali/kernels/transpose/transpose_gpu_test.cc
@@ -15,6 +15,7 @@
 #include "dali/kernels/transpose/transpose_gpu.h"  // NOLINT
 #include <gtest/gtest.h>
 #include <random>
+#include <algorithm>
 #include "dali/test/tensor_test_utils.h"
 #include "dali/test/test_tensors.h"
 #include "dali/kernels/transpose/transpose_test.h"

--- a/dali/operators/decoder/nvjpeg/nvjpeg_allocator.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_allocator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,7 @@
 #include <vector>
 
 #include "dali/core/common.h"
-#include "dali/core/error_handling.h"
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 

--- a/dali/operators/image/color/color_space_conversion_test.cc
+++ b/dali/operators/image/color/color_space_conversion_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "dali/test/dali_test_conversion.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 

--- a/dali/operators/math/expressions/arithmetic_meta.h
+++ b/dali/operators/math/expressions/arithmetic_meta.h
@@ -21,7 +21,6 @@
 #include <type_traits>
 #include <utility>
 
-#include "dali/core/cuda_utils.h"
 #include "dali/core/math_util.h"
 #include "dali/core/small_vector.h"
 #include "dali/core/static_switch.h"

--- a/dali/operators/math/expressions/broadcasting.h
+++ b/dali/operators/math/expressions/broadcasting.h
@@ -16,6 +16,7 @@
 #define DALI_OPERATORS_MATH_EXPRESSIONS_BROADCASTING_H_
 
 #include <utility>
+#include "dali/core/api_helper.h"
 #include "dali/core/small_vector.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/core/tensor_shape_print.h"

--- a/dali/operators/reader/loader/video/frames_decoder_gpu.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_gpu.cc
@@ -22,7 +22,7 @@
 #include <iomanip>
 
 #include "dali/core/error_handling.h"
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_error.h"
 #include "dali/pipeline/data/backend.h"
 #include "dali/pipeline/data/tensor.h"
 #include "dali/operators/reader/loader/video/nvdecode/color_space.h"

--- a/dali/operators/reader/nvdecoder/cuvideoparser.h
+++ b/dali/operators/reader/nvdecoder/cuvideoparser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 
 #include "dali/operators/reader/nvdecoder/dynlink_nvcuvid.h"
 #include "dali/core/error_handling.h"
-#include "dali/core/cuda_utils.h"
 
 
 namespace dali {

--- a/dali/operators/reader/nvdecoder/dynlink_nvcuvid.h
+++ b/dali/operators/reader/nvdecoder/dynlink_nvcuvid.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #define DALI_OPERATORS_READER_NVDECODER_DYNLINK_NVCUVID_H_
 
 #include <string>
+#include "dali/core/cuda_error.h"
 #include "dali/operators/reader/nvdecoder/nvcuvid.h"
 
 #define NVCUVID_CALL(arg) CUDA_CALL(arg)

--- a/dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_adapter_test.cc
+++ b/dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_adapter_test.cc
@@ -17,7 +17,7 @@
 
 #include "dali/core/backend_tags.h"
 #include "dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_stub.h"
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 namespace optical_flow {

--- a/dali/operators/ssd/box_encoder.h
+++ b/dali/operators/ssd/box_encoder.h
@@ -19,7 +19,7 @@
 #include <cstring>
 #include <vector>
 #include <utility>
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_error.h"
 #include "dali/core/tensor_shape.h"
 #include "dali/pipeline/operator/operator.h"
 #include "dali/pipeline/util/bounding_box_utils.h"

--- a/dali/operators/util/randomizer.cu
+++ b/dali/operators/util/randomizer.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "dali/operators/util/randomizer.cuh"
+#include "dali/core/cuda_error.h"
 #include "dali/core/cuda_stream.h"
 #include "dali/core/util.h"
 #include "dali/core/mm/memory.h"

--- a/dali/operators/util/randomizer.cuh
+++ b/dali/operators/util/randomizer.cuh
@@ -17,6 +17,7 @@
 #define DALI_OPERATORS_UTIL_RANDOMIZER_CUH_
 
 #include <math.h>
+#include <cassert>
 #include <memory>
 #include "dali/core/host_dev.h"
 #include "dali/core/device_guard.h"

--- a/dali/operators/util/randomizer.cuh
+++ b/dali/operators/util/randomizer.cuh
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 #include <math.h>
 #include <memory>
+#include "dali/core/host_dev.h"
 #include "dali/core/device_guard.h"
 #include <curand_kernel.h>  // NOLINT
 

--- a/dali/pipeline/data/buffer.h
+++ b/dali/pipeline/data/buffer.h
@@ -26,7 +26,7 @@
 
 #include "dali/core/common.h"
 #include "dali/core/device_guard.h"
-#include "dali/core/error_handling.h"
+#include "dali/core/cuda_error.h"
 #include "dali/core/util.h"
 #include "dali/pipeline/data/types.h"
 #include "dali/core/format.h"

--- a/dali/pipeline/data/types.h
+++ b/dali/pipeline/data/types.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,7 @@
 #include "dali/core/common.h"
 #include "dali/core/spinlock.h"
 #include "dali/core/float16.h"
-#include "dali/core/cuda_utils.h"
-#include "dali/core/error_handling.h"
+#include "dali/core/cuda_error.h"
 #include "dali/core/tensor_layout.h"
 
 #ifdef DALI_BUILD_PROTO3

--- a/dali/pipeline/util/thread_pool.cc
+++ b/dali/pipeline/util/thread_pool.cc
@@ -19,7 +19,7 @@
 #include "dali/util/nvml.h"
 #endif
 #include "dali/core/format.h"
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_error.h"
 #include "dali/core/device_guard.h"
 #include "dali/core/nvtx.h"
 

--- a/dali/python/backend_impl.cc
+++ b/dali/python/backend_impl.cc
@@ -15,6 +15,7 @@
 #include <cuda_runtime_api.h>
 #include <dlfcn.h>
 #include <sstream>
+#include <cstring>
 #include "dali/core/common.h"
 #include "dali/core/cuda_utils.h"
 #include "dali/core/device_guard.h"

--- a/dali/test/dali_cuda_finalize_test.h
+++ b/dali/test/dali_cuda_finalize_test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,7 @@
 
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
-
-#include "dali/core/cuda_utils.h"
+#include "dali/core/cuda_error.h"
 
 namespace dali {
 

--- a/dali/test/device_test.h
+++ b/dali/test/device_test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 
 #include <gtest/gtest.h>
 #include <cuda_runtime.h>
-#include "dali/core/cuda_utils.h"
 #include "dali/core/dev_string.h"
 
 #define MAX_DEVICE_ERROR_MESSAGES 100

--- a/dali/test/test_tensors.h
+++ b/dali/test/test_tensors.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include <cuda_runtime_api.h>
 #include <memory>
 #include <utility>
+#include "dali/core/cuda_error.h"
 #include "dali/core/tensor_view.h"
 #include "dali/core/backend_tags.h"
 #include "dali/core/mm/memory.h"

--- a/dali/util/nvml.h
+++ b/dali/util/nvml.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@
 #include <mutex>
 #include <vector>
 #include <string>
-#include "dali/core/cuda_utils.h"
 #include "dali/util/nvml_wrap.h"
 #include "dali/core/cuda_error.h"
 #include "dali/core/format.h"

--- a/include/dali/core/cuda_rt_utils.h
+++ b/include/dali/core/cuda_rt_utils.h
@@ -56,7 +56,7 @@ inline const cudaDeviceProp &GetDeviceProperties(int device_id = -1) {
   static std::vector<bool> read(dev_count, false);
   static std::vector<cudaDeviceProp> properties(dev_count);
   if (!read[device_id]) {
-    CUDA_CALL(cudaGetDeviceProperties(&properties[device_id], 0));
+    CUDA_CALL(cudaGetDeviceProperties(&properties[device_id], device_id));
     read[device_id] = true;
   }
   return properties[device_id];

--- a/include/dali/core/cuda_rt_utils.h
+++ b/include/dali/core/cuda_rt_utils.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_CORE_CUDA_RT_UTILS_H_
+#define DALI_CORE_CUDA_RT_UTILS_H_
+
+// Host-side utilities go into this file.
+// For device code utilities, see cuda_utils.h
+
+#include <cuda_runtime_api.h>  // for __align__ & CUDART_VERSION
+#include <cassert>
+#include <vector>
+#include "dali/core/dynlink_cuda.h"
+#include "dali/core/cuda_error.h"
+
+namespace dali {
+
+/**
+ * @brief Gets the maximum number of threads per block for given kernel function on current device
+ */
+template <typename KernelFunction>
+int MaxThreadsPerBlock(KernelFunction *f) {
+  static constexpr int kMaxDevices = 1024;
+  static int max_block_size[kMaxDevices] = {};
+  int device = 0;
+  CUDA_CALL(cudaGetDevice(&device));
+  assert(device >= 0 && device < kMaxDevices);
+  if (!max_block_size[device]) {
+    cudaFuncAttributes attr = {};
+    CUDA_CALL(cudaFuncGetAttributes(&attr, f));
+    max_block_size[device] = attr.maxThreadsPerBlock;
+  }
+  return max_block_size[device];
+}
+
+inline const cudaDeviceProp &GetDeviceProperties(int device_id = -1) {
+  if (device_id < 0) {
+    CUDA_CALL(cudaGetDevice(&device_id));
+  }
+  static int dev_count = []() {
+    int ndevs = 0;
+    CUDA_CALL(cudaGetDeviceCount(&ndevs));
+    return ndevs;
+  }();
+  static std::vector<bool> read(dev_count, false);
+  static std::vector<cudaDeviceProp> properties(dev_count);
+  if (!read[device_id]) {
+    CUDA_CALL(cudaGetDeviceProperties(&properties[device_id], 0));
+    read[device_id] = true;
+  }
+  return properties[device_id];
+}
+
+inline int GetSmCount(int device_id = -1) {
+  const auto &props = GetDeviceProperties(device_id);
+  return props.multiProcessorCount;
+}
+
+inline int GetSharedMemPerBlock(int device_id = -1) {
+  const auto &props = GetDeviceProperties(device_id);
+  return props.sharedMemPerBlock;
+}
+
+}  // namespace dali
+
+#endif  // DALI_CORE_CUDA_RT_UTILS_H_

--- a/include/dali/core/device_guard.h
+++ b/include/dali/core/device_guard.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 #ifndef DALI_CORE_DEVICE_GUARD_H_
 #define DALI_CORE_DEVICE_GUARD_H_
 
-#include "dali/core/cuda_utils.h"
-#include "dali/core/error_handling.h"
+#include <cuda.h>
+#include "dali/core/api_helper.h"
 
 namespace dali {
 

--- a/include/dali/core/dynlink_cufile.h
+++ b/include/dali/core/dynlink_cufile.h
@@ -17,7 +17,6 @@
 
 #include <cufile.h>
 #include <string>
-#include "dali/core/cuda_utils.h"
 #include "dali/core/cuda_error.h"
 #include "dali/core/format.h"
 

--- a/include/dali/core/mm/async_pool.h
+++ b/include/dali/core/mm/async_pool.h
@@ -25,6 +25,7 @@
 #include "dali/core/small_vector.h"
 #include "dali/core/cuda_event_pool.h"
 #include "dali/core/cuda_stream.h"
+#include "dali/core/cuda_error.h"
 #include "dali/core/device_guard.h"
 
 #ifndef DEBUG_ASYNC_POOL_CHECK_CONSISTENCY

--- a/include/dali/core/small_vector.h
+++ b/include/dali/core/small_vector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #define DALI_CORE_SMALL_VECTOR_H_
 
 #include <cuda_runtime.h>
+#include <cstring>
 #include <utility>
 #include <memory>
 #include <vector>

--- a/include/dali/core/tensor_shape.h
+++ b/include/dali/core/tensor_shape.h
@@ -27,7 +27,6 @@
 #include "dali/core/permute.h"
 #include "dali/core/small_vector.h"
 #include "dali/core/dev_array.h"
-#include "dali/core/cuda_utils.h"
 #include "dali/core/format.h"
 
 namespace dali {

--- a/include/dali/core/tensor_shape_print.h
+++ b/include/dali/core/tensor_shape_print.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,14 +42,14 @@ std::ostream &operator<<(std::ostream &os, const TensorListShape<ndim> &shape) {
 }
 
 template <int ndim>
-inline string to_string(const TensorShape<ndim> &shape) {
+inline std::string to_string(const TensorShape<ndim> &shape) {
   std::stringstream ss;
   ss << shape;
   return ss.str();
 }
 
 template <int ndim>
-inline string to_string(const TensorListShape<ndim> &shape) {
+inline std::string to_string(const TensorListShape<ndim> &shape) {
   std::stringstream ss;
   ss << shape;
   return ss.str();


### PR DESCRIPTION
## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

## Description:
The file cuda_utils.h mixed concerns. It's now split into cuda_util.h and cuda_rt_utils.h
cuda_utils.h was include excessively instead of other, more appropriate headers. This is now fixed.

## Additional information:

### Affected modules and functionalities:
No functionality is affected.

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
This is just code movement, tests should not be affected and aren't needed.
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
