### PR TITLE
Fix video decoder test for aarch64

### DIFF
--- a/dali/operators/reader/loader/video/frames_decoder_test.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_test.cc
@@ -31,7 +31,7 @@
 namespace dali {
 class FramesDecoderTestBase : public VideoTestBase {
  public:
-  void RunSequentialTest(FramesDecoder &decoder, TestVideo &ground_truth, double eps = 1.0) {
+  virtual void RunSequentialTest(FramesDecoder &decoder, TestVideo &ground_truth, double eps = 1.0) {
     // Iterate through the whole video in order
     for (int i = 0; i < decoder.NumFrames(); ++i) {
       ASSERT_EQ(decoder.NextFrameIdx(), i);
@@ -52,7 +52,7 @@ class FramesDecoderTestBase : public VideoTestBase {
     ASSERT_EQ(decoder.NextFrameIdx(), -1);
   }
 
-  void RunTest(FramesDecoder &decoder, TestVideo &ground_truth, double eps = 1.0) {
+  virtual void RunTest(FramesDecoder &decoder, TestVideo &ground_truth, double eps = 1.0) {
     ASSERT_EQ(decoder.Height(), ground_truth.Height());
     ASSERT_EQ(decoder.Width(), ground_truth.Width());
     ASSERT_EQ(decoder.Channels(), ground_truth.NumChannels());
@@ -115,6 +115,16 @@ class FramesDecoderTestBase : public VideoTestBase {
 
 class FramesDecoderTest_CpuOnlyTests : public FramesDecoderTestBase {
  public:
+  // due to difference in CPU postprocessing on different CPUs eps is 10
+  void RunSequentialTest(FramesDecoder &decoder, TestVideo &ground_truth, double eps = 10.) {
+    FramesDecoderTestBase::RunSequentialTest(decoder, ground_truth, eps);
+  }
+
+  // due to difference in CPU postprocessing on different CPUs eps is 10
+  void RunTest(FramesDecoder &decoder, TestVideo &ground_truth, double eps = 10.0) {
+    FramesDecoderTestBase::RunTest(decoder, ground_truth, eps);
+  }
+
   void AssertFrame(uint8_t *frame, int index, TestVideo& ground_truth, double eps = 1.0) override {
     ground_truth.CompareFrame(index, frame, eps);
   }
@@ -143,6 +153,14 @@ class FramesDecoderGpuTest : public FramesDecoderTestBase {
     VideoTestBase::SetUpTestSuite();
     DeviceGuard(0);
     CUDA_CALL(cudaDeviceSynchronize());
+  }
+
+  void RunSequentialTest(FramesDecoder &decoder, TestVideo &ground_truth, double eps = 1.) {
+    FramesDecoderTestBase::RunSequentialTest(decoder, ground_truth, eps);
+  }
+
+  void RunTest(FramesDecoder &decoder, TestVideo &ground_truth, double eps = 1.0) {
+    FramesDecoderTestBase::RunTest(decoder, ground_truth, eps);
   }
 
   void AssertFrame(uint8_t *frame, int index, TestVideo& ground_truth, double eps = 1.0) override {

--- a/dali/operators/reader/loader/video/frames_decoder_test.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_test.cc
@@ -31,7 +31,8 @@
 namespace dali {
 class FramesDecoderTestBase : public VideoTestBase {
  public:
-  virtual void RunSequentialTest(FramesDecoder &decoder, TestVideo &ground_truth, double eps = 1.0) {
+  virtual void RunSequentialTest(FramesDecoder &decoder, TestVideo &ground_truth,
+                                 double eps = 1.0) {
     // Iterate through the whole video in order
     for (int i = 0; i < decoder.NumFrames(); ++i) {
       ASSERT_EQ(decoder.NextFrameIdx(), i);


### PR DESCRIPTION
- after the test rework when mpeg4 decoding was enabled the
   CPU accuracy test eps was by mistake reduced from 10 to 1.
   This PR fixes that

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- after the test rework when mpeg4 decoding was enabled the
   CPU accuracy test eps was by mistake reduced from 10 to 1.
   This PR fixes that
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- frames_decoder_test.cc
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - FramesDecoderTest_CpuOnlyTests*
  - FramesDecoderGpuTest*
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
