### PR TITLE
Add proper validation for empty batch in External Source

### DIFF
--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -491,6 +491,10 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
         make_string("Data list provided to ExternalSource needs to have batch_size <= ",
                     OperatorBase::max_batch_size_, ", found ", batch.num_samples(), " samples."));
 
+    DALI_ENFORCE(batch.num_samples() > 0,
+                 "ExternalSource expects non-empty batches to be provided as the input. Got batch "
+                 "with 0 samples.");
+
     DALI_ENFORCE(
         dtype_ == DALI_NO_TYPE || dtype_ == batch.type(),
         make_string("ExternalSource expected data of type ", TypeTable::GetTypeInfo(dtype_).name(),

--- a/dali/test/python/test_external_source_dali.py
+++ b/dali/test/python/test_external_source_dali.py
@@ -16,10 +16,11 @@ import random
 import nvidia.dali.fn as fn
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
+import nvidia.dali.tensors as tensors
 import numpy as np
 from nvidia.dali import Pipeline, pipeline_def
 from test_utils import check_batch
-from nose_utils import raises, assert_warns
+from nose_utils import raises, assert_warns, assert_raises
 from nvidia.dali.types import DALIDataType
 
 
@@ -562,3 +563,20 @@ def test_non_utilized_external_source_pruning():
     # if all outputs are unused, ES should simply be pruned not preventing pipeline from operation
     for num_outputs in (None, 1, 2, 3, 4):
         yield _test_non_utilized_external_source_pruning, num_outputs
+
+
+def test_empty_es():
+    max_batch_size = 16
+
+    @pipeline_def
+    def pipeline():
+        return fn.external_source(source=lambda: [])
+
+    # Providing an empty batch was legal, but it failed on MakeContiguous node.
+    # This checks proper validation in External Source which is the only way that could provide
+    # empty batch as input into DALI graph.
+    with assert_raises(RuntimeError, glob="*ExternalSource expects non-empty batches*"):
+        pipe = pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
+        pipe.build()
+        pipe.run()
+

--- a/dali/test/python/test_external_source_dali.py
+++ b/dali/test/python/test_external_source_dali.py
@@ -16,7 +16,6 @@ import random
 import nvidia.dali.fn as fn
 import nvidia.dali.ops as ops
 import nvidia.dali.types as types
-import nvidia.dali.tensors as tensors
 import numpy as np
 from nvidia.dali import Pipeline, pipeline_def
 from test_utils import check_batch

--- a/dali/test/python/test_external_source_dali.py
+++ b/dali/test/python/test_external_source_dali.py
@@ -578,4 +578,3 @@ def test_empty_es():
         pipe = pipeline(batch_size=max_batch_size, num_threads=4, device_id=0)
         pipe.build()
         pipe.run()
-


### PR DESCRIPTION

Signed-off-by: Krzysztof Lecki <klecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Bug fix**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
The Pipeline doesn't work with empty inputs and errors out when one tries to return them.
As the only place we can get empty input from (for now) is External Source, instead of erroring
in the executor we now check the input batch and error out early.

Previous error:
```
Error when executing Mixed operator MakeContiguous encountered:
[/home/klecki/work/salvador/dali/dali/pipeline/data/tensor_list.cc:519] Assert on "IsValidType(new_type)" failed: TensorList cannot be resized with invalid type. To zero out the TensorList Reset() can be used.
```

New error:
```
RuntimeError: [/home/klecki/work/salvador/dali/dali/pipeline/operator/builtin/external_source.h:496] Assert on "batch.num_samples() > 0" failed: ExternalSource expects non-empty batches to be provided as
the input. Got batch with 0 samples.
```




## Additional information:

### Affected modules and functionalities:
ES



### Key points relevant for the review:
N/A

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
