### PR TITLE
Fix to enable leading underscore in op name

### DIFF
--- a/dali/python/nvidia/dali/fn.py
+++ b/dali/python/nvidia/dali/fn.py
@@ -44,7 +44,8 @@ def _to_snake_case(pascal):
             if nupper == 0:
                 out += c
             else:
-                if len(out) > 0:
+                # do not add another leading underscore
+                if len(out) > 0 and out[-1] != '_':
                     out += '_'
                 if nupper > 1:
                     out += pascal[start:i - 1].lower() + '_'

--- a/dali/test/python/test_functional_api.py
+++ b/dali/test/python/test_functional_api.py
@@ -191,6 +191,10 @@ def test_to_snake_case_impl():
         ('COCOReader', 'coco_reader'),
         ('DLTensorPythonFunction', 'dl_tensor_python_function'),
         ('TFRecordReader', 'tfrecord_reader'),
+        ('_Leading', '_leading'),
+        ('_LEADing', '_lea_ding'),
+        ('_LeAdIng', '_le_ad_ing'),
+        ('_L_Eading', '_l_eading'),
     ]
 
     for inp, out in fn_name_tests:


### PR DESCRIPTION
## Category: **Bug fix**
<!---
Please pick one from below:
 (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Leading underscores in operator and module names were doubled.

Extracted from #4359 where leading underscore is actually used in module/operator name.

## Additional information:

### Affected modules and functionalities:
A bit of CamelCase to snake_case conversion.



### Key points relevant for the review:
N/A

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
