### PR TITLE
Serialize wrapped global functions by value

### DIFF
--- a/dali/python/nvidia/dali/reducers.py
+++ b/dali/python/nvidia/dali/reducers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -112,10 +112,12 @@ class DaliCallbackPickler(pickle.Pickler):
             if isinstance(obj, type(dummy_lambda)) and obj.__name__ == dummy_lambda.__name__ or \
                     getattr(obj, '_dali_pickle_by_value', False):
                 return function_by_value_reducer(obj)
-            if '<locals>' in obj.__qualname__:
-                try:
-                    pickle.dumps(obj)
-                except AttributeError as e:
-                    if "Can't pickle local object" in str(e):
-                        return function_by_value_reducer(obj)
+            try:
+                pickle.dumps(obj)
+            except AttributeError as e:
+                if "Can't pickle local object" in str(e):
+                    return function_by_value_reducer(obj)
+            except pickle.PicklingError as e:
+                if "it's not the same object as" in str(e):
+                    return function_by_value_reducer(obj)
         return NotImplemented


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Extends the idea of serialization by value from local functions to global ones that were manually overwritten.

Fixes an issue with a new ipython notebook env, where `open` (which should be just `io.open`) is replaced with a custom wrapper (https://github.com/ipython/ipython/commit/93992a7ecd086bb24840ba03cd69960daf41575d). This makes serailization by value of any callback that use `open` call fail with the pickle check that the `open is io.open`.

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

Plain python pickler serializes functions by name, just remembering "a path" to the function. However, if the function is not statically available (because it is dynamically created closure or it is global function but in a notebook), this approach fails.
DALI uses sligtly cutomized pickler to handle serialization of local functions and global functions in a notebook mode. The pickler serializes local functions by value (marshalling their bytecode) and serializing recursivelly the dependencies. The same procudure can be applied to a global function if it is marked with `dali.pickling.pikcle_by_value`.

Now, ipython recently added a wrapper around global `open`, which makes it non-serializable with pickle. As a result, serialization by value fails on callbacks that use `open`, because it needs to be serialzied as a dependency. The change in this PR just tries to catch any such cases in advance and apply "by value" mode to them too.

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
