### PR TITLE
Fix pinned resource test on integrated GPUs

### DIFF
--- a/dali/core/mm/default_resource_test.cc
+++ b/dali/core/mm/default_resource_test.cc
@@ -62,7 +62,8 @@ TEST(MMDefaultResource, GetResource_Pinned) {
   stream = CUDAStream();  // destroy the stream, it should still complete just fine
   char back_copy[1000] = {};
   CUDA_CALL(cudaEventSynchronize(event));
-  CUDA_CALL(cudaMemcpy(back_copy, dev, 1000, cudaMemcpyDeviceToHost));
+  CUDA_CALL(cudaMemcpyAsync(back_copy, dev, 1000, cudaMemcpyDeviceToHost, 0));
+  CUDA_CALL(cudaStreamSynchronize(0));
 
   for (int i = 0; i < 1000; i++)
     EXPECT_EQ(back_copy[i], static_cast<char>(i + 42));


### PR DESCRIPTION
Syncrhonize after the cudaMemcpy D2H - on integrated devices, this copy is asynchronous.

Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Fixes a bug in the pinned resource test - there was missing synchronization, which made the host read the buffer before the D2H copy was finished. The copy happens asynchronously on integrated devices (Tegra).

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
MMDefaultResource.GetResource_Pinned 

- [ X Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
