### PR TITLE
Adds a cuda stream synchronization before cuvidUnmapVideoFrame in nvDecoder

### DIFF
--- a/dali/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/operators/reader/nvdecoder/nvdecoder.cc
@@ -427,6 +427,8 @@ void NvDecoder::receive_frames(SequenceWrapper& sequence) {
             nv_time_base_));
       if (stop_) break;
       convert_frame(frame, sequence, i);
+      // synchronize before MappedFrame is destroyed and cuvidUnmapVideoFrame is called
+      cudaStreamSynchronize(stream_);
   }
   if (captured_exception_)
     std::rethrow_exception(captured_exception_);

--- a/dali/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/operators/reader/nvdecoder/nvdecoder.cc
@@ -428,7 +428,7 @@ void NvDecoder::receive_frames(SequenceWrapper& sequence) {
       if (stop_) break;
       convert_frame(frame, sequence, i);
       // synchronize before MappedFrame is destroyed and cuvidUnmapVideoFrame is called
-      cudaStreamSynchronize(stream_);
+      CUDA_CALL(cudaStreamSynchronize(stream_));
   }
   if (captured_exception_)
     std::rethrow_exception(captured_exception_);


### PR DESCRIPTION
- adds a GPU synchronization point before cuvidUnmapVideoFrame in nvDecoder
  similarly to the VideoSdk examples

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- adds a GPU synchronization point before cuvidUnmapVideoFrame in nvDecoder
  similarly to the VideoSdk examples
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- dali/operators/reader/nvdecoder/nvdecoder.cc
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - test_video.py
  - VideoReaderDecoderCompareTest
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
