### PR TITLE
Pinned resource test fix: reset the device buffer on a proper stream.

### DIFF
--- a/dali/core/mm/default_resource_test.cc
+++ b/dali/core/mm/default_resource_test.cc
@@ -44,12 +44,12 @@ TEST(MMDefaultResource, GetResource_Host) {
 TEST(MMDefaultResource, GetResource_Pinned) {
   DeviceBuffer<char> dev;
   dev.resize(1000);
-  CUDA_CALL(cudaMemset(dev, 0, 1000));
 
   auto *rsrc = GetDefaultResource<memory_kind::pinned>();
   ASSERT_NE(rsrc, nullptr);
 
   CUDAStream stream = CUDAStream::Create(true);
+  CUDA_CALL(cudaMemsetAsync(dev, 0, 1000, stream));
   char *mem = static_cast<char*>(rsrc->allocate(1000, 32));
   ASSERT_NE(mem, nullptr);
   EXPECT_TRUE(mm::detail::is_aligned(mem, 32));


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
It issues the cudaMemset that resets the device buffer on a proper stream. Before, there was a race condition between stream 0 and the proper stream used for H2D and D2H copies.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
This is the test. It has been modified.

<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
