### PR TITLE
Optimizing `ShiftPixelCenter` kernel configuration

### DIFF
--- a/dali/operators/image/remap/remap.cuh
+++ b/dali/operators/image/remap/remap.cuh
@@ -47,12 +47,12 @@ template<typename T>
 void
 invoke_kernel_per_batch(T **data_buffers, const size_t *sample_sizes, int n_samples, T shift_value,
                         cudaStream_t stream) {
-  static constexpr int kBlockSize = 256;
+  static constexpr int kBlockSize = 1024;
   static constexpr float kOneOverBlockSize = 1.f / static_cast<float>(kBlockSize);
   auto max_sample_size = *std::max_element(sample_sizes, sample_sizes + n_samples);
   auto max_blocks = static_cast<int>((max_sample_size + kBlockSize - 1) * kOneOverBlockSize);
   dim3 block_size(kBlockSize);
-  dim3 grid_size(std::min(max_blocks, 32), std::min(n_samples, 32));
+  dim3 grid_size(std::min(max_blocks, 64), std::min(n_samples, 64));
   shift_pixel_origin_per_batch<<<grid_size, block_size, 0, stream>>>
           (data_buffers, sample_sizes, n_samples, shift_value);
 }


### PR DESCRIPTION
Signed-off-by: szalpal <mszolucha@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Other** (*e.g. Documentation, Tests, Configuration*)

## Description:
This PR upgrades configuration of the kernel that shifts pixel centers.

Profiling gathered with nsight compute:
Before:
```
    Section: GPU Speed Of Light Throughput
    ---------------------------------------------------------------------- --------------- ------------------------------
    DRAM Frequency                                                           cycle/nsecond                           6.47
    SM Frequency                                                             cycle/nsecond                           1.34
    Elapsed Cycles                                                                   cycle                      1,196,204
    Memory [%]                                                                           %                          64.06
    DRAM Throughput                                                                      %                          64.06
    Duration                                                                       usecond                         889.31
    L1/TEX Cache Throughput                                                              %                          22.49
    L2 Cache Throughput                                                                  %                          22.29
    SM Active Cycles                                                                 cycle                   1,105,485.21
    Compute (SM) [%]                                                                     %                          12.94
    ---------------------------------------------------------------------- --------------- ------------------------------

    Section: Launch Statistics
    ---------------------------------------------------------------------- --------------- ------------------------------
    Block Size                                                                                                        256
    Function Cache Configuration                                                                  cudaFuncCachePreferNone
    Grid Size                                                                                                       1,024
    Registers Per Thread                                                   register/thread                             16
    Shared Memory Configuration Size                                                 Kbyte                          32.77
    Driver Shared Memory Per Block                                              byte/block                              0
    Dynamic Shared Memory Per Block                                             byte/block                              0
    Static Shared Memory Per Block                                              byte/block                              0
    Threads                                                                         thread                        262,144
    Waves Per SM                                                                                                     3.56
    ---------------------------------------------------------------------- --------------- ------------------------------

    Section: Occupancy
    ---------------------------------------------------------------------- --------------- ------------------------------
    Block Limit SM                                                                   block                             16
    Block Limit Registers                                                            block                             16
    Block Limit Shared Mem                                                           block                             16
    Block Limit Warps                                                                block                              4
    Theoretical Active Warps per SM                                                   warp                             32
    Theoretical Occupancy                                                                %                            100
    Achieved Occupancy                                                                   %                          88.72
    Achieved Active Warps Per SM                                                      warp                          28.39
    ---------------------------------------------------------------------- --------------- ------------------------------
```
After:
```
    Section: GPU Speed Of Light Throughput
    ---------------------------------------------------------------------- --------------- ------------------------------
    DRAM Frequency                                                           cycle/nsecond                           6.53
    SM Frequency                                                             cycle/nsecond                           1.36
    Elapsed Cycles                                                                   cycle                      1,023,248
    Memory [%]                                                                           %                          74.71
    DRAM Throughput                                                                      %                          74.71
    Duration                                                                       usecond                         750.14
    L1/TEX Cache Throughput                                                              %                          24.73
    L2 Cache Throughput                                                                  %                          26.99
    SM Active Cycles                                                                 cycle                     980,004.56
    Compute (SM) [%]                                                                     %                          15.85
    ---------------------------------------------------------------------- --------------- ------------------------------

    Section: Launch Statistics
    ---------------------------------------------------------------------- --------------- ------------------------------
    Block Size                                                                                                      1,024
    Function Cache Configuration                                                                  cudaFuncCachePreferNone
    Grid Size                                                                                                       4,096
    Registers Per Thread                                                   register/thread                             16
    Shared Memory Configuration Size                                                 Kbyte                          32.77
    Driver Shared Memory Per Block                                              byte/block                              0
    Dynamic Shared Memory Per Block                                             byte/block                              0
    Static Shared Memory Per Block                                              byte/block                              0
    Threads                                                                         thread                      4,194,304
    Waves Per SM                                                                                                    56.89
    ---------------------------------------------------------------------- --------------- ------------------------------

    Section: Occupancy
    ---------------------------------------------------------------------- --------------- ------------------------------
    Block Limit SM                                                                   block                             16
    Block Limit Registers                                                            block                              4
    Block Limit Shared Mem                                                           block                             16
    Block Limit Warps                                                                block                              1
    Theoretical Active Warps per SM                                                   warp                             32
    Theoretical Occupancy                                                                %                            100
    Achieved Occupancy                                                                   %                          96.61
    Achieved Active Warps Per SM                                                      warp                          30.92
    ---------------------------------------------------------------------- --------------- ------------------------------
```
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
