### PR TITLE
Do not call nvcomp with no input

### DIFF
--- a/dali/operators/decoder/inflate/inflate.cc
+++ b/dali/operators/decoder/inflate/inflate.cc
@@ -55,14 +55,14 @@ concatenating compressed frames from the corresponding sequences.::
     .AddArg(inflate::shapeArgName, "The shape of the output (inflated) chunk.", DALI_INT_VEC, true)
     .AddOptionalTypeArg(inflate::dTypeArgName, "The output (inflated) data type.", DALI_UINT8)
     .AddOptionalArg<std::vector<int>>(inflate::offsetArgName,
-                                      R"code("A list of offsets within the input sample
+                                      R"code(A list of offsets within the input sample
 describing where the consecutive chunks begin.
 
 If the ``chunk_sizes`` is not specified, it is assumed that the chunks are densely packed
 in the input tensor and the last chunk ends with the sample's end.)code",
                                       nullptr, true)
     .AddOptionalArg<std::vector<int>>(inflate::sizeArgName,
-                                      R"code("A list of sizes of corresponding input chunks.
+                                      R"code(A list of sizes of corresponding input chunks.
 
 If the ``chunk_offsets`` is not specified, it is assumed that the chunks are densely packed
 in the input tensor and the first chunk starts at the beginning of the sample.)code",

--- a/dali/operators/decoder/inflate/inflate_gpu.cc
+++ b/dali/operators/decoder/inflate/inflate_gpu.cc
@@ -48,13 +48,13 @@ class InflateOpGpuLZ4Impl : public InflateOpImplBase<GPUBackend> {
   void RunImpl(Workspace &ws) override {
     const auto &input = ws.template Input<GPUBackend>(0);
     auto &output = ws.template Output<GPUBackend>(0);
+    output.SetLayout(params_.GetOutputLayout());
     auto total_chunks_num = params_.GetTotalChunkNum();
     // nvCOMP does not like being called with no chunks in the input
     if (total_chunks_num == 0) {
       assert(params_.GetOutputShape().num_elements() == 0);
       return;
     }
-    output.SetLayout(params_.GetOutputLayout());
     SetupInChunks(input);
     SetupOutChunks(output);
     auto stream = ws.stream();

--- a/dali/operators/decoder/inflate/inflate_gpu.cc
+++ b/dali/operators/decoder/inflate/inflate_gpu.cc
@@ -49,6 +49,11 @@ class InflateOpGpuLZ4Impl : public InflateOpImplBase<GPUBackend> {
     const auto &input = ws.template Input<GPUBackend>(0);
     auto &output = ws.template Output<GPUBackend>(0);
     auto total_chunks_num = params_.GetTotalChunkNum();
+    // nvCOMP does not like being called with no chunks in the input
+    if (total_chunks_num == 0) {
+      assert(params_.GetOutputShape().num_elements() == 0);
+      return;
+    }
     output.SetLayout(params_.GetOutputLayout());
     SetupInChunks(input);
     SetupOutChunks(output);

--- a/dali/test/python/operator/test_inflate.py
+++ b/dali/test/python/operator/test_inflate.py
@@ -256,14 +256,15 @@ def test_total_no_chunks(ex_kwargs):
     @pipeline_def
     def pipeline():
         inflate = fn.external_source(source=lambda _: deflated, batch=False)
-        return fn.experimental.inflate(inflate.gpu(), shape=(128, 128, 3), **ex_kwargs)
+        return fn.experimental.inflate(inflate.gpu(), shape=(128, 128, 3), layout="HWC",
+                                       **ex_kwargs)
 
     batch_size = 8
     pipe = pipeline(batch_size=batch_size, num_threads=4, device_id=0)
     pipe.build()
     for _ in range(2):
         (inflated, ) = pipe.run()
-        check_batch(inflated, [baseline] * batch_size, batch_size)
+        check_batch(inflated, [baseline] * batch_size, batch_size, layout="FHWC")
 
 
 def _test_validation(pipeline, error_glob, kwargs=None):

--- a/dali/test/python/operator/test_inflate.py
+++ b/dali/test/python/operator/test_inflate.py
@@ -17,6 +17,7 @@ import numpy as np
 from nvidia.dali import pipeline_def, fn, types
 from test_utils import np_type_to_dali, has_operator, restrict_platform
 from nose_utils import assert_raises
+from nose2.tools import params
 
 
 def sample_to_lz4(sample):
@@ -178,9 +179,10 @@ def seq_source(rng, ndim, dtype, mode, permute, oversized_shape):
         if permute:
             assert mode == "offset_and_size"
             perm = rng.permutation(num_chunks)
-            sample = sample[perm]
-            offsets = offsets[perm]
-            sizes = sizes[perm]
+            subset = rng.choice([True, False], num_chunks)
+            sample = sample[perm][subset]
+            offsets = offsets[perm][subset]
+            sizes = sizes[perm][subset]
         if mode == "offset_only":
             return sample, deflated, reported_shape, offsets
         elif mode == "size_only":
@@ -239,6 +241,29 @@ def test_chunks():
                 yield _test_chunks, seed, batch_size, ndim, dtype, layout, mode, \
                     permute, oversized_shape, sequence_axis_name
                 seed += 1
+
+
+@has_operator("experimental.inflate")
+@restrict_platform(min_compute_cap=6.0, platforms=["x86_64"])
+@params({"chunk_offsets": []}, {"chunk_sizes": []}, {"chunk_offsets": np.array([], dtype=np.int32)},
+        {"chunk_sizes": np.array([], dtype=np.int32)})
+def test_total_no_chunks(ex_kwargs):
+    frame = np.full((128, 128, 3), 42, dtype=np.uint8)
+    chunks = [sample_to_lz4(frame)] * 7
+    deflated = np.concatenate(chunks)
+    baseline = np.array([], dtype=np.uint8).reshape((0, 128, 128, 3))
+
+    @pipeline_def
+    def pipeline():
+        inflate = fn.external_source(source=lambda _: deflated, batch=False)
+        return fn.experimental.inflate(inflate.gpu(), shape=(128, 128, 3), **ex_kwargs)
+
+    batch_size = 8
+    pipe = pipeline(batch_size=batch_size, num_threads=4, device_id=0)
+    pipe.build()
+    for _ in range(2):
+        (inflated, ) = pipe.run()
+        check_batch(inflated, [baseline] * batch_size, batch_size)
 
 
 def _test_validation(pipeline, error_glob, kwargs=None):


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix**/**Other**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
If the user specifies the chunk_sizes/offsets, but they are empty lists for all the samples, there are no chunks for the nvcomp to decompress. Such calls to nvcomp error out, while we can simply return a batch of zero-volume samples according to the logic of the operator.

Alternatively we could forbid specyfing empty list of chunks for any sample. I just prefer having explicit control over this behaviour rather than slightly obsucre error from the lib call.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
