### PR TITLE
Replace Status::OK() with Status() for TF plugin

### DIFF
--- a/dali_tf_plugin/dali_helper.h
+++ b/dali_tf_plugin/dali_helper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -180,7 +180,7 @@ class Batch {
     for (int sample_idx = 0; sample_idx < batch_size(); sample_idx++) {
       ptrs[sample_idx] = GetTensorData(storage[sample_idx]);
     }
-    return tensorflow::Status::OK();
+    return tensorflow::Status();
   }
 
 
@@ -189,7 +189,7 @@ class Batch {
       return tensorflow::errors::Internal("Internal mismatch of batch and per-sample mode.");
     }
     ptr = GetTensorData(storage[0]);
-    return tensorflow::Status::OK();
+    return tensorflow::Status();
   }
 
 
@@ -207,7 +207,7 @@ class Batch {
       return tensorflow::errors::InvalidArgument("Empty batch for input: ", input_idx, ".");
     }
     if (!is_per_sample) {
-      return tensorflow::Status::OK();
+      return tensorflow::Status();
     }
     int ndim = storage[0].dims();
     auto dtype = storage[0].dtype();
@@ -225,7 +225,7 @@ class Batch {
             " dtype.");
       }
     }
-    return tensorflow::Status::OK();
+    return tensorflow::Status();
   }
 
   void clear() {

--- a/dali_tf_plugin/daliop.cc
+++ b/dali_tf_plugin/daliop.cc
@@ -84,7 +84,7 @@ REGISTER_OP("Dali")
         c->set_output(i, passed_shape);
       }
     }
-    return tf::Status::OK();
+    return tf::Status();
   })
   .Doc(R"doc(
 DALI TensorFlow plugin


### PR DESCRIPTION
## Category: **Bug fix**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
TensorFlow introduced a Tensorflow Support Library, where the Status was moved.
https://github.com/tensorflow/tensorflow/commit/6a7f86b78612ed909058b4656b37b761abc2559f removed the Status::OK() static function, advocating the usage of `OkStatus()` or the default constructor `Status()` which is supposed to be backward compatible. As we are targeting TF 1.15 as well, where the `OkStatus` is some TF-lite wrapper, we go with the `Status()` as a replacement.



## Additional information:

### Affected modules and functionalities:
TF



### Key points relevant for the review:
N/A

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
Run the L1 nightly TF test and see if it compiles.
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
