### PR TITLE
Fix an issue with improper hint grid size in OpticalFlow

### DIFF
--- a/dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_adapter.h
+++ b/dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_adapter.h
@@ -25,6 +25,15 @@ namespace dali {
 namespace optical_flow {
 
 struct OpticalFlowParams {
+  OpticalFlowParams(float arg_perf_quality_factor, int arg_out_grid_size,
+                    bool arg_enable_temporal_hints, bool arg_enable_external_hints):
+                      perf_quality_factor(arg_perf_quality_factor),
+                      out_grid_size(arg_out_grid_size),
+                      enable_temporal_hints(arg_enable_temporal_hints),
+                      enable_external_hints(enable_external_hints) {
+    // use default hint value when the hint is not used
+    if (!enable_temporal_hints) hint_grid_size = -1;
+  }
   float perf_quality_factor;  /// 0..1, where 0 is best quality, lowest performance
   int out_grid_size;
   int hint_grid_size;

--- a/dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_adapter.h
+++ b/dali/operators/sequence/optical_flow/optical_flow_adapter/optical_flow_adapter.h
@@ -25,11 +25,12 @@ namespace dali {
 namespace optical_flow {
 
 struct OpticalFlowParams {
-  OpticalFlowParams(float arg_perf_quality_factor, int arg_out_grid_size,
-                    bool arg_enable_temporal_hints, bool arg_enable_external_hints):
-                      perf_quality_factor(arg_perf_quality_factor),
-                      out_grid_size(arg_out_grid_size),
-                      enable_temporal_hints(arg_enable_temporal_hints),
+  OpticalFlowParams(float perf_quality_factor = 0, int out_grid_size = -1, int hint_grid_size = -1,
+                    bool enable_temporal_hints = false, bool enable_external_hints = false):
+                      perf_quality_factor(perf_quality_factor),
+                      out_grid_size(out_grid_size),
+                      hint_grid_size(hint_grid_size),
+                      enable_temporal_hints(enable_temporal_hints),
                       enable_external_hints(enable_external_hints) {
     // use default hint value when the hint is not used
     if (!enable_temporal_hints) hint_grid_size = -1;

--- a/dali/operators/sequence/optical_flow/optical_flow_impl/optical_flow_impl.cc
+++ b/dali/operators/sequence/optical_flow/optical_flow_impl/optical_flow_impl.cc
@@ -181,7 +181,7 @@ void OpticalFlowImpl::CreateOf() {
 
 void OpticalFlowImpl::DestroyOf() {
   if (of_handle_) {
-    // it is not possible to release all driver allocated data strucutres by calling nvOFDestroy
+    // it is not possible to release all driver allocated data structures by calling nvOFDestroy
     // if nvOFInit was not successfully called before, so run init with the default args just
     // to successfully call nvOFDestroy
     if (!is_initialized_) {
@@ -293,7 +293,14 @@ void OpticalFlowImpl::SetInitParams(dali::optical_flow::OpticalFlowParams api_pa
   init_params_.height = static_cast<uint32_t>(height_);
 
   init_params_.outGridSize = OutGridSizeToEnum(api_params.out_grid_size);
-  init_params_.hintGridSize = HintGridSizeToEnum(api_params.hint_grid_size);
+  init_params_.enableExternalHints = of_params_.enable_external_hints ? NV_OF_TRUE : NV_OF_FALSE;
+  // in driver 520.x.y only NV_OF_HINT_VECTOR_GRID_SIZE_UNDEFINED can be provided if the hint
+  // is not used
+  if (of_params_.enable_external_hints) {
+    init_params_.hintGridSize = HintGridSizeToEnum(api_params.hint_grid_size);
+  } else {
+    init_params_.hintGridSize = HintGridSizeToEnum(-1);
+  }
 
   default_init_params_.hintGridSize = NV_OF_HINT_VECTOR_GRID_SIZE_UNDEFINED;
 
@@ -311,7 +318,6 @@ void OpticalFlowImpl::SetInitParams(dali::optical_flow::OpticalFlowParams api_pa
   }
   default_init_params_.perfLevel = NV_OF_PERF_LEVEL_SLOW;
 
-  init_params_.enableExternalHints = of_params_.enable_external_hints ? NV_OF_TRUE : NV_OF_FALSE;
   init_params_.enableOutputCost = NV_OF_FALSE;
   init_params_.hPrivData = NULL;
   init_params_.disparityRange = NV_OF_STEREO_DISPARITY_RANGE_UNDEFINED;


### PR DESCRIPTION
- in the 520.x.y driver the optical flow enforces that
  the only valid hint grid size enum value should be
  NV_OF_HINT_VECTOR_GRID_SIZE_UNDEFINED if the hint is
  not used

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- in the 520.x.y driver the optical flow enforces that
  the only valid hint grid size enum value should be
  NV_OF_HINT_VECTOR_GRID_SIZE_UNDEFINED if the hint is
  not used
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- OpticalFlow
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - OpticalFlowTest.*
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
