### PR TITLE
[WIP] Verify shapes/sizes when reading from the cache.

### DIFF
--- a/dali/operators/decoder/cache/cached_decoder_impl.h
+++ b/dali/operators/decoder/cache/cached_decoder_impl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class CachedDecoderImpl {
 
   bool CacheLoad(
     const std::string& file_name,
-    uint8_t *output_data,
+    const TensorView<StorageGPU, uint8_t> &out,
     cudaStream_t stream);
 
   void CacheStore(
@@ -44,7 +44,7 @@ class CachedDecoderImpl {
     const ImageCache::ImageShape& data_shape,
     cudaStream_t stream);
 
-  bool DeferCacheLoad(const std::string& file_name, uint8_t *output_data);
+  bool DeferCacheLoad(const std::string& file_name, const TensorView<StorageGPU, uint8_t> &out);
 
   void LoadDeferred(cudaStream_t stream);
 

--- a/dali/operators/decoder/cache/image_cache.h
+++ b/dali/operators/decoder/cache/image_cache.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,11 +47,13 @@ class DLL_PUBLIC ImageCache {
      * @brief Try to read from cache
      * @param image_key key representing the image in cache
      * @param destination_data destination buffer
+     * @param buffer_size size, in bytes, of the destination buffer
      * @param stream cuda stream
      * @return true if successful cache read, false otherwise
      */
     DLL_PUBLIC virtual bool Read(const ImageKey& image_key,
                                  void* destination_data,
+                                 size_t buffer_size,
                                  cudaStream_t stream) const = 0;
 
   /**

--- a/dali/operators/decoder/cache/image_cache_blob.h
+++ b/dali/operators/decoder/cache/image_cache_blob.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ class DLL_PUBLIC ImageCacheBlob : public ImageCache {
 
     bool Read(const ImageKey& image_key,
               void* destination_data,
+              size_t buffer_size,
               cudaStream_t stream) const override;
 
     const ImageShape& GetShape(const ImageKey& image_key) const override;

--- a/dali/operators/decoder/cache/image_cache_blob_test.cc
+++ b/dali/operators/decoder/cache/image_cache_blob_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,13 +47,13 @@ TEST_F(ImageCacheBlobTest, Add) {
   cache_->Add(kKey1, &kValue1[0], kShape1, 0);
   EXPECT_TRUE(cache_->IsCached(kKey1));
   std::vector<uint8_t> cachedData(kValue1.size());
-  EXPECT_TRUE(cache_->Read(kKey1, &cachedData[0], 0));
+  EXPECT_TRUE(cache_->Read(kKey1, cachedData.data(), cachedData.size(), 0));
   EXPECT_EQ(kValue1, cachedData);
 }
 
 TEST_F(ImageCacheBlobTest, ErrorReadNonExistent) {
   std::vector<uint8_t> cachedData(kValue1.size());
-  EXPECT_FALSE(cache_->Read(kKey1, &cachedData[0], 0));
+  EXPECT_FALSE(cache_->Read(kKey1, cachedData.data(), cachedData.size(), 0));
 }
 
 TEST_F(ImageCacheBlobTest, AddExistingIgnored) {

--- a/dali/operators/decoder/cache/image_cache_largest_test.cc
+++ b/dali/operators/decoder/cache/image_cache_largest_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ TEST_F(ImageCacheLargestTest, ReadWorks) {
   EXPECT_TRUE(IsCached(4));
 
   std::vector<uint8_t> dst(4, 0x00);
-  cache_->Read("4", &dst[0], 0);
+  cache_->Read("4", dst.data(), dst.size(), 0);
   CUDA_CALL(cudaStreamSynchronize(0));
   EXPECT_EQ(data_[4].second, dst);
 }

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -716,9 +716,9 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     auto& output = ws.Output<GPUBackend>(0);
     for (auto *sample : samples_cache_) {
       assert(sample);
-      auto i = sample->sample_idx;
-      auto *output_data = output.mutable_tensor<uint8_t>(i);
-      DALI_ENFORCE(DeferCacheLoad(sample->file_name, output_data));
+      int i = sample->sample_idx;
+      auto out_view = view<uint8_t>(output[i]);
+      DALI_ENFORCE(DeferCacheLoad(sample->file_name, out_view));
     }
     LoadDeferred(ws.stream());
   }


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>


## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)



## Description:
This PR adds more checks when getting data from the image cache.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
