### PR TITLE
Fix TensorList copy ordering issues

### DIFF
--- a/dali/c_api/c_api_test.cc
+++ b/dali/c_api/c_api_test.cc
@@ -592,7 +592,9 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocDifferentBackendsTest) {
   for (int i = 0; i < prefetch_queue_depth; i++) {
     SequentialFill(view<uint8_t>(input_cpu), 42 * i);
     // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-    input.Copy(input_cpu, this->order_);
+    input.Copy(input_cpu, std::is_same_v<DataBackend, CPUBackend>
+                          ? AccessOrder::host()
+                          : this->order_);
     CUDA_CALL(cudaStreamSynchronize(cuda_stream));
     pipe_ptr->SetExternalInput(input_name, input, cuda_stream);
     daliSetExternalInputTensors(&handle, input_name.c_str(),
@@ -614,7 +616,9 @@ TYPED_TEST(CApiTest, ExternalSourceMultipleAllocDifferentBackendsTest) {
 
   SequentialFill(view<uint8_t>(input_cpu), 42 * prefetch_queue_depth);
   // Unnecessary copy in case of CPUBackend, makes the code generic across Backends
-  input.Copy(input_cpu, this->order_);
+  input.Copy(input_cpu, std::is_same_v<DataBackend, CPUBackend>
+                        ? AccessOrder::host()
+                        : this->order_);
   CUDA_CALL(cudaStreamSynchronize(cuda_stream));
   pipe_ptr->SetExternalInput(input_name, input, cuda_stream);
   daliSetExternalInputTensors(&handle, input_name.c_str(),

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -81,9 +81,10 @@ class Tensor : public Buffer<Backend> {
   inline void Copy(const vector<T> &data, AccessOrder order = {}) {
     this->Resize({(Index)data.size()}, TypeTable::GetTypeId<T>());
     if (!order)
-      order = order_;
-    else
-      order.wait(order_);
+      order = std::is_same<Backend, CPUBackend>::value ? AccessOrder::host() : order_;
+
+    order.wait(order_);
+
     type_.template Copy<Backend, CPUBackend>(this->raw_mutable_data(),
         data.data(), this->size(), order.stream());
     order_.wait(order);
@@ -97,9 +98,9 @@ class Tensor : public Buffer<Backend> {
     using U = remove_const_t<T>;
     this->Resize({(Index)data.size()}, TypeTable::GetTypeId<U>());
     if (!order)
-      order = order_;
-    else
-      order.wait(order_);
+      order = std::is_same<Backend, CPUBackend>::value ? AccessOrder::host() : order_;
+
+    order.wait(order_);
     type_.template Copy<Backend, CPUBackend>(this->raw_mutable_data(),
         data.data(), this->size(), order.stream());
     order_.wait(order);
@@ -110,8 +111,16 @@ class Tensor : public Buffer<Backend> {
    */
   template <typename InBackend>
   inline void Copy(const Tensor<InBackend> &other, AccessOrder order = {}) {
-    if (!order)
-      order = other.order() ? other.order() : order_;
+    bool is_host_to_host = std::is_same<Backend, CPUBackend>::value &&
+                           std::is_same<InBackend, CPUBackend>::value;
+    if (!order) {
+      if (is_host_to_host)
+        order = AccessOrder::host();
+      else
+        order = other.order() ? other.order() : order_;
+    }
+    DALI_ENFORCE(!is_host_to_host || !order.is_device(),
+                 "Cannot issue a host-to-host copy on a device stream.");
     this->Resize(other.shape(), other.type());
     order.wait(order_);
     this->SetLayout(other.GetLayout());

--- a/dali/pipeline/data/tensor.h
+++ b/dali/pipeline/data/tensor.h
@@ -111,8 +111,8 @@ class Tensor : public Buffer<Backend> {
    */
   template <typename InBackend>
   inline void Copy(const Tensor<InBackend> &other, AccessOrder order = {}) {
-    bool is_host_to_host = std::is_same<Backend, CPUBackend>::value &&
-                           std::is_same<InBackend, CPUBackend>::value;
+    constexpr bool is_host_to_host = std::is_same<Backend, CPUBackend>::value &&
+                                     std::is_same<InBackend, CPUBackend>::value;
     if (!order) {
       if (is_host_to_host)
         order = AccessOrder::host();

--- a/dali/pipeline/data/tensor_list.cc
+++ b/dali/pipeline/data/tensor_list.cc
@@ -470,6 +470,10 @@ const TensorListShape<> &TensorList<Backend>::shape() const & {
 template <typename Backend>
 void TensorList<Backend>::set_order(AccessOrder order, bool synchronize) {
   DALI_ENFORCE(order, "Resetting order to an empty one is not supported");
+
+  if (this->order() == order)
+    return;
+
   // Optimization: synchronize only once, if needed.
   if (this->order().is_device() && order && synchronize) {
     bool need_sync = contiguous_buffer_.has_data();

--- a/dali/pipeline/data/tensor_list.cc
+++ b/dali/pipeline/data/tensor_list.cc
@@ -53,18 +53,12 @@ AccessOrder SyncBefore(AccessOrder dst_order, AccessOrder src_order, AccessOrder
   if (!order)
     order = src_order ? src_order : dst_order;
 
-  // Wait on the order on which we will run the copy for the work to finish on the dst
+  // The destination buffer must be ready to be overwritten
   order.wait(dst_order);
+  // The source buffer must be ready to cosume
+  order.wait(src_order);
 
   return order;
-}
-
-
-/**
- * @brief Wait for the reallocation to happen in the copy order, so we can actually proceed.
- */
-void SyncAfterResize(AccessOrder dst_order, AccessOrder copy_order) {
-  copy_order.wait(dst_order);
 }
 
 
@@ -848,8 +842,6 @@ template <typename Backend>
 template <typename SrcBackend>
 void TensorList<Backend>::Copy(const TensorList<SrcBackend> &src, AccessOrder order,
                                bool use_copy_kernel) {
-  auto copy_order = copy_impl::SyncBefore(this->order(), src.order(), order);
-
   if (!IsValidType(src.type())) {
     assert(!src.has_data() && "It is not possible to have data without valid type.");
     Reset();
@@ -857,12 +849,19 @@ void TensorList<Backend>::Copy(const TensorList<SrcBackend> &src, AccessOrder or
     // no copying to do
     return;
   }
+  if (std::is_same_v<Backend, CPUBackend> &&
+      std::is_same_v<SrcBackend, CPUBackend>) {
+    DALI_ENFORCE(!order.is_device(),
+      "Cannot run a host-to-host copy on a device stream.");
+    if (!order)
+      order = AccessOrder::host();
+  }
 
   Resize(src.shape(), src.type());
   // After resize the state_, curr_num_tensors_, type_, sample_dim_, shape_ (and pinned)
   // postconditions are met, as well as the buffers are correctly adjusted.
 
-  copy_impl::SyncAfterResize(this->order(), copy_order);
+  auto copy_order = copy_impl::SyncBefore(this->order(), src.order(), order);
 
   use_copy_kernel &= (std::is_same<SrcBackend, GPUBackend>::value || src.is_pinned()) &&
                      (std::is_same<Backend, GPUBackend>::value || this->is_pinned());

--- a/dali/pipeline/data/types.cc
+++ b/dali/pipeline/data/types.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -93,6 +93,9 @@ void TypeInfo::Copy(void *dst,
     return;
 
   if (is_host_to_host) {
+    if (stream)
+      throw std::logic_error("Cannot issue a H2H copy on a stream");
+
     // Call our copy function
     copier_(dst, src, n);
   } else if (use_copy_kernel) {

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -407,6 +407,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunHelper(OpNode &op_node, Workspac
     op.Run(ws);
   }
 
+  /* TODO(michalz): Find a way to make this valid in presence of passthrough between stages
   // Set the output order to the stage's stream
   for (int i = 0; i < ws.NumOutput(); i++) {
     if (ws.OutputIsType<CPUBackend>(i)) {
@@ -415,6 +416,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunHelper(OpNode &op_node, Workspac
       ws.Output<GPUBackend>(i).set_order(ws_order);
     }
   }
+  */
 
   for (int i : empty_layout_in_idxs) {
     if (ws.InputIsType<CPUBackend>(i)) {

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -296,21 +296,33 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunHelper(OpNode &op_node, Workspac
   const auto &schema = spec.GetSchema();
   SmallVector<int, 16> empty_layout_in_idxs;
 
-  cudaStream_t prev_stage_stream = ws.has_stream() && ws.stream() == gpu_op_stream_
-    ? mixed_op_stream_ : gpu_op_stream_;
 
-  auto order = ws.has_stream() ? AccessOrder(ws.stream()) : AccessOrder::host();
-  auto set_order = [&](auto &output) {
-    // NOTE: the stage streams are synchronized by the executor
-    bool need_sync = output.order().stream() != prev_stage_stream;
+  auto ws_order = ws.has_stream() ? AccessOrder(ws.stream()) : AccessOrder::host();
+
+  // Try to infer from which stage the buffer comes from
+  auto order_to_stage_index = [&](AccessOrder order) {
+    if (!order || order == AccessOrder::host())
+      return 0;
+    else if (order == mixed_op_stream_)
+      return 1;
+    else if (order == gpu_op_stream_)
+      return 2;
+    else
+      return 3;  // foreign order, comes last
+  };
+
+  auto set_order = [&](auto &output, AccessOrder order) {
+    // Check if this stage (identified by ws_order) is already synchronized with the output's
+    // order. If yes, we're implicitly synchronized and we can skip sync.
+    bool need_sync = order_to_stage_index(output.order()) > order_to_stage_index(ws_order);
     output.set_order(order, need_sync);
   };
 
   for (int i = 0; i < ws.NumOutput(); i++) {
     if (ws.OutputIsType<CPUBackend>(i)) {
-      set_order(ws.Output<CPUBackend>(i));
+      set_order(ws.Output<CPUBackend>(i), AccessOrder::host());
     } else {
-      set_order(ws.Output<GPUBackend>(i));
+      set_order(ws.Output<GPUBackend>(i), ws_order);
     }
   }
 
@@ -393,6 +405,15 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunHelper(OpNode &op_node, Workspac
   {
     DomainTimeRange tr("[DALI][Executor] Run");
     op.Run(ws);
+  }
+
+  // Set the output order to the stage's stream
+  for (int i = 0; i < ws.NumOutput(); i++) {
+    if (ws.OutputIsType<CPUBackend>(i)) {
+      ws.Output<CPUBackend>(i).set_order(ws_order);
+    } else {
+      ws.Output<GPUBackend>(i).set_order(ws_order);
+    }
   }
 
   for (int i : empty_layout_in_idxs) {

--- a/dali/pipeline/operator/builtin/external_source.h
+++ b/dali/pipeline/operator/builtin/external_source.h
@@ -449,7 +449,10 @@ class ExternalSource : public Operator<Backend>, virtual public BatchSizeProvide
       tl_elm.front()->Reset();
       tl_elm.front()->set_pinned(batch.is_pinned());
     }
-    tl_elm.front()->Copy(batch, order);
+    AccessOrder copy_order = std::is_same<SrcBackend, CPUBackend>::value
+        ? AccessOrder::host()  // do not use a device order for a host to host copy
+        : order;
+    tl_elm.front()->Copy(batch, copy_order);
     {
       std::lock_guard<std::mutex> busy_lock(busy_m_);
       tl_data_.PushBack(tl_elm);

--- a/dali/pipeline/operator/builtin/make_contiguous.cu
+++ b/dali/pipeline/operator/builtin/make_contiguous.cu
@@ -47,7 +47,7 @@ void MakeContiguousMixed::Run(Workspace &ws) {
       output.ShareData(input);
       output.set_order(out_order, false);
     } else {
-      output.Copy(input, ws.has_stream() ? AccessOrder(ws.stream()) : AccessOrder());
+      output.Copy(input);
     }
   } else {
     assert(!IsPassThrough() &&


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**Breaking change** (C++ API only)


## Description:
When a buffer has a stream ordering set, it could happen that it was allocated in stream order, but then copied _actually_ in host order (even though device order was specified). This PR changes several things:
- it makes it an error to specify a device order for H2H copy (breaking change in C++ API)
- it uses host order when copying between CPUBackend Tensors and TensorLists
- it changes the management of orders in the executor, so that the CPUBackend outputs are visible as having host order (it's only changed to the stage's stream after the operator.Run completes)

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
