### PR TITLE
Crop rounding argument to control the conversion of anchors to integral values

### DIFF
--- a/dali/operators/image/crop/crop_attr.cc
+++ b/dali/operators/image/crop/crop_attr.cc
@@ -128,12 +128,12 @@ CropAttr::CropAttr(const OpSpec& spec) {
 
   auto rounding = spec.GetArgument<std::string>("rounding");
   if (rounding == "round") {
-    round_fn_ = [](float x) {
-      return std::roundf(x);
+    round_fn_ = [](double x) {
+      return static_cast<int64_t>(std::round(x));
     };
   } else if (rounding == "truncate") {
-    round_fn_ = [](float x) {
-      return static_cast<int>(x);
+    round_fn_ = [](double x) {
+      return static_cast<int64_t>(x);
     };
   } else {
     DALI_FAIL(make_string("``rounding`` value ", rounding,
@@ -231,7 +231,7 @@ TensorShape<> CropAttr::CalculateAnchor(const span<float>& anchor_norm,
     DALI_ENFORCE(anchor_norm[dim] >= 0.0f && anchor_norm[dim] <= 1.0f,
                  "Anchor for dimension " + std::to_string(dim) + " (" +
                      std::to_string(anchor_norm[dim]) + ") is out of range [0.0, 1.0]");
-    float anchor_f = anchor_norm[dim] * (input_shape[dim] - crop_shape[dim]);
+    auto anchor_f = static_cast<double>(anchor_norm[dim]) * (input_shape[dim] - crop_shape[dim]);
     anchor[dim] = round_fn_(anchor_f);
   }
 

--- a/dali/operators/image/crop/crop_attr.cc
+++ b/dali/operators/image/crop/crop_attr.cc
@@ -31,28 +31,31 @@ Providing crop argument is incompatible with providing separate arguments such a
         "crop_pos_x", R"code(Normalized (0.0 - 1.0) horizontal position of the cropping window
 (upper left corner).
 
-The actual position is calculated as ``crop_x = crop_x_norm * (W - crop_W)``, where
-``crop_x_norm`` is the normalized position, ``W`` is the width of the image, and ``crop_W`` is the
-width of the cropping window. See ``bias`` argument, for more details on the how ``crop_x`` is
-converted to an integral value.)code",
+The actual position is calculated as ``crop_x = crop_x_norm * (W - crop_W)``, where `crop_x_norm`
+is the normalized position, ``W`` is the width of the image, and ``crop_W`` is the width of the
+cropping window.
+
+See ``rounding`` argument for more details on how ``crop_x`` is converted to an integral value.)code",
         0.5f, true)
     .AddOptionalArg(
          "crop_pos_y", R"code(Normalized (0.0 - 1.0) vertical position of the start of
 the cropping window (typically, the upper left corner).
 
-The actual position is calculated as ``crop_y = round_fn(crop_y_norm * (H - crop_H))``, where
-``crop_y_norm`` is the normalized position, `H` is the height of the image, and ``crop_H`` is the
-height of the cropping window. See ``bias`` argument, for more details on the how ``crop_y`` is
-converted to an integral value.)code",
+The actual position is calculated as ``crop_y = crop_y_norm * (H - crop_H)``, where ``crop_y_norm``
+is the normalized position, `H` is the height of the image, and ``crop_H`` is the height of the
+cropping window.
+
+See ``rounding`` argument for more details on how ``crop_y`` is converted to an integral value.)code",
         0.5f, true)
     .AddOptionalArg(
         "crop_pos_z", R"code(Applies **only** to volumetric inputs.
 
 Normalized (0.0 - 1.0) normal position of the cropping window (front plane).
-The actual position is calculated as ``crop_z = round_fn(crop_z_norm * (D - crop_D))``, where
-``crop_z_norm`` is the normalized position, ``D`` is the depth of the image and ``crop_D`` is the
-depth of the cropping window. See ``bias`` argument, for more details on the how ``crop_z`` is
-converted to an integral value.)code",
+The actual position is calculated as ``crop_z = crop_z_norm * (D - crop_D)``, where ``crop_z_norm``
+is the normalized position, ``D`` is the depth of the image and ``crop_D`` is the depth of the
+cropping window.
+
+See ``rounding`` argument for more details on how ``crop_z`` is converted to an integral value.)code",
         0.5f, true)
     .AddOptionalArg(
         "crop_w", R"code(Cropping window width (in pixels).
@@ -74,17 +77,14 @@ for ``crop_w``, ``crop_h``, and ``crop_d`` is incompatible with providing the fi
 window dimensions (argument `crop`).)code",
         0.0f, true)
     .AddOptionalArg(
-        "bias", R"code(Determines the window placement when an extent is an odd number.
+        "rounding", R"code(Determines the rounding function used to convert the starting coordinate
+of the window to an integral value (see ``crop_pos_x``, ``crop_pos_y``, ``crop_pos_z``).
 
 Possible values are:
 
-* | ``"right"`` - The placement of the cropping window is biased towards the right.
-  | This approach uses both ``round`` for both positive and negative numbers when converting the anchor
-    value to an integral number
-* | ``"left"`` - The placement of the cropping window is biased towards the left.
-  | This approach converts values to an integral number using ``floor`` for positive numbers
-    and ``ceil`` for negative numbers.)code",
-        "right");
+* | ``"round"`` - Rounds to the nearest integer value, with halfway cases rounded away from zero.
+* | ``"truncate"`` - Discards the fractional part of the number (truncates towards zero).)code",
+        "round");
 
 CropAttr::CropAttr(const OpSpec& spec) {
   auto max_batch_size = spec.GetArgument<int>("max_batch_size");
@@ -126,19 +126,18 @@ CropAttr::CropAttr(const OpSpec& spec) {
   crop_z_norm_.resize(max_batch_size, 0.0f);
   crop_window_generators_.resize(max_batch_size, {});
 
-  auto bias = spec.GetArgument<std::string>("bias");
-  if (bias == "right") {
+  auto rounding = spec.GetArgument<std::string>("rounding");
+  if (rounding == "round") {
     round_fn_ = [](float x) {
       return std::roundf(x);
     };
-  } else if (bias == "left") {
+  } else if (rounding == "truncate") {
     round_fn_ = [](float x) {
-      return x < 0 ? ceilf(x) : floorf(x);
+      return static_cast<int>(x);
     };
   } else {
-    DALI_FAIL(
-        make_string("``bias`` value ", bias,
-                    " is not supported. Supported values are \"left\", or \"right\"."));
+    DALI_FAIL(make_string("``rounding`` value ", rounding,
+                          " is not supported. Supported values are \"round\", or \"truncate\"."));
   }
 }
 

--- a/dali/operators/image/crop/crop_attr.h
+++ b/dali/operators/image/crop/crop_attr.h
@@ -58,7 +58,7 @@ class CropAttr {
   std::vector<float> crop_z_norm_;
   std::vector<CropWindowGenerator> crop_window_generators_;
   bool is_whole_image_ = false;
-  std::function<float(float)> round_fn_;
+  std::function<int64_t(double)> round_fn_;
 };
 
 }  // namespace dali

--- a/dali/operators/image/crop/crop_attr.h
+++ b/dali/operators/image/crop/crop_attr.h
@@ -58,6 +58,7 @@ class CropAttr {
   std::vector<float> crop_z_norm_;
   std::vector<CropWindowGenerator> crop_window_generators_;
   bool is_whole_image_ = false;
+  std::function<float(float)> round_fn_;
 };
 
 }  // namespace dali

--- a/dali/test/python/operator/test_crop.py
+++ b/dali/test/python/operator/test_crop.py
@@ -598,8 +598,8 @@ def test_crop_arg_input(device, layout):
         assert expected == actual, f"{expected} != {actual}"
 
 
-@params(*itertools.product(('cpu', 'gpu'), ('left', 'right')))
-def test_crop_bias_arg(device, bias):
+@params(*itertools.product(('cpu', 'gpu'), ('round', 'truncate')))
+def test_crop_rounding(device, rounding):
     # Checking window placement when the cropping window extent is an odd number
     input_shape = (20, 8, 3)
     crop = (11, 9)
@@ -610,7 +610,7 @@ def test_crop_bias_arg(device, bias):
         if device == 'gpu':
             data = data.gpu()
         data = fn.reshape(data, layout='HWC')
-        cropped = fn.crop(data, crop=crop, out_of_bounds_policy='pad', bias=bias)
+        cropped = fn.crop(data, crop=crop, out_of_bounds_policy='pad', rounding=rounding)
         return data, cropped
 
     p = pipe(batch_size=1, num_threads=1, device_id=0)
@@ -618,9 +618,9 @@ def test_crop_bias_arg(device, bias):
     input_data, cropped_data = p.run()
     data = as_array(input_data[0])
     cropped = as_array(cropped_data[0])
-    if bias == 'left':
+    if rounding == 'truncate':
         # padding happens to the right of the input
         np.testing.assert_array_equal(data[4:15, :, :], cropped[:, 0:8, :])
-    elif bias == 'right':
+    elif rounding == 'round':
         # padding happens to the left of the input
         np.testing.assert_array_equal(data[5:16, :, :], cropped[:, 1:9, :])


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature**


## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
- Adds a `rounding` argument to Crop operator, to control how the anchors are converted to an integral number
- Two modes, truncate and round (default). 

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
- Crop family


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
- Documentation

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- test_crop.py: test_crop_rounding
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [x] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: CROP.10
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
