### PR TITLE
Execute whole Keras code in the expected device scope

### DIFF
--- a/dali/test/python/test_dali_tf_dataset_mnist.py
+++ b/dali/test/python/test_dali_tf_dataset_mnist.py
@@ -110,14 +110,14 @@ def run_keras_single_device(device='cpu', device_id=0):
         model = keras_model()
         train_dataset = get_dataset(device, device_id)
 
-    model.fit(
-        train_dataset,
-        epochs=EPOCHS,
-        steps_per_epoch=ITERATIONS)
+        model.fit(
+            train_dataset,
+            epochs=EPOCHS,
+            steps_per_epoch=ITERATIONS)
 
-    assert model.evaluate(
-        train_dataset,
-        steps=ITERATIONS)[1] > TARGET
+        assert model.evaluate(
+            train_dataset,
+            steps=ITERATIONS)[1] > TARGET
 
 
 def graph_model(images, reuse, is_training):

--- a/dali/test/python/test_dali_tf_dataset_mnist_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_mnist_eager.py
@@ -21,6 +21,7 @@ from nose_utils import raises
 
 tf.compat.v1.enable_eager_execution()
 
+
 def test_keras_single_gpu():
     mnist.run_keras_single_device('gpu', 0)
 

--- a/dali/test/python/test_dali_tf_dataset_mnist_eager.py
+++ b/dali/test/python/test_dali_tf_dataset_mnist_eager.py
@@ -21,7 +21,6 @@ from nose_utils import raises
 
 tf.compat.v1.enable_eager_execution()
 
-
 def test_keras_single_gpu():
     mnist.run_keras_single_device('gpu', 0)
 
@@ -41,10 +40,10 @@ def test_keras_wrong_placement_gpu():
         model = mnist.keras_model()
         train_dataset = mnist.get_dataset('gpu', 0)
 
-    model.fit(
-        train_dataset,
-        epochs=mnist.EPOCHS,
-        steps_per_epoch=mnist.ITERATIONS)
+        model.fit(
+            train_dataset,
+            epochs=mnist.EPOCHS,
+            steps_per_epoch=mnist.ITERATIONS)
 
 
 @with_setup(skip_for_incompatible_tf)
@@ -54,10 +53,10 @@ def test_keras_wrong_placement_cpu():
         model = mnist.keras_model()
         train_dataset = mnist.get_dataset('cpu', 0)
 
-    model.fit(
-        train_dataset,
-        epochs=mnist.EPOCHS,
-        steps_per_epoch=mnist.ITERATIONS)
+        model.fit(
+            train_dataset,
+            epochs=mnist.EPOCHS,
+            steps_per_epoch=mnist.ITERATIONS)
 
 
 @with_setup(skip_for_incompatible_tf)

--- a/dali/test/python/test_dali_tf_dataset_mnist_graph.py
+++ b/dali/test/python/test_dali_tf_dataset_mnist_graph.py
@@ -22,14 +22,17 @@ from nose_utils import raises
 mnist.tf.compat.v1.disable_eager_execution()
 
 
+@with_setup(tf.keras.backend.clear_session)
 def test_keras_single_gpu():
     mnist.run_keras_single_device('gpu', 0)
 
 
+@with_setup(tf.keras.backend.clear_session)
 def test_keras_single_other_gpu():
     mnist.run_keras_single_device('gpu', 1)
 
 
+@with_setup(tf.keras.backend.clear_session)
 def test_keras_single_cpu():
     mnist.run_keras_single_device('cpu', 0)
 

--- a/dali/test/python/test_dali_tf_dataset_mnist_graph.py
+++ b/dali/test/python/test_dali_tf_dataset_mnist_graph.py
@@ -40,7 +40,7 @@ def test_keras_wrong_placement_gpu():
         model = mnist.keras_model()
         train_dataset = mnist.get_dataset('gpu', 0)
 
-    model.fit(train_dataset, epochs=mnist.EPOCHS, steps_per_epoch=mnist.ITERATIONS)
+        model.fit(train_dataset, epochs=mnist.EPOCHS, steps_per_epoch=mnist.ITERATIONS)
 
 
 @raises(Exception, "TF device and DALI device mismatch. TF*: GPU, DALI*: CPU for output")
@@ -49,7 +49,7 @@ def test_keras_wrong_placement_cpu():
         model = mnist.keras_model()
         train_dataset = mnist.get_dataset('cpu', 0)
 
-    model.fit(train_dataset, epochs=mnist.EPOCHS, steps_per_epoch=mnist.ITERATIONS)
+        model.fit(train_dataset, epochs=mnist.EPOCHS, steps_per_epoch=mnist.ITERATIONS)
 
 
 @with_setup(tf.compat.v1.reset_default_graph)


### PR DESCRIPTION
## Category: Bug fix
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
TL;DR: move `model.fit` under `with tf.device`.

In newer TF version, when the model.fit is executed without explicit scope (which gives it default placement) we may encounter transfers between the device on which we defined the model and inputs to the device which executes the model - which is not supported. Adjust those tests to both be defined and execute on the desired device - so all the tensors/variables placements are uniform.

Additionally some cleanup code is added for Keras tests so the graph placement doesn't collide with other tests - @with_setup(tf.keras.backend.clear_session) - after the previous change, on my machine running all graph tests in sequence caused subsequent tests to fail with allocation error.

## Additional information:

### Affected modules and functionalities:
TF Tests



### Key points relevant for the review:
I am not sure why the previous one worked (as the offending variables are defined in the internal TF code) and if we might want to keep the old behavior of running model.fit without device scope.

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
This is a fix for test_dali_tf_dataset_mnist_eager.py 
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
