### PR TITLE
Fix numpy reader crash

### DIFF
--- a/dali/core/dynlink_cufile.cc
+++ b/dali/core/dynlink_cufile.cc
@@ -49,3 +49,7 @@ void *CufileLoadSymbol(const char *name) {
   void *ret = cufileDrvLib ? dlsym(cufileDrvLib, name) : nullptr;
   return ret;
 }
+
+bool cuFileIsSymbolAvailable(const char *symbol) {
+  return CufileLoadSymbol(symbol) != nullptr;
+}

--- a/dali/core/dynlink_cufile.inl
+++ b/dali/core/dynlink_cufile.inl
@@ -1,0 +1,1 @@
+#undef cuFileDriverClose

--- a/dali/imgcodec/decoders/memory_pool.h
+++ b/dali/imgcodec/decoders/memory_pool.h
@@ -16,6 +16,7 @@
 #define DALI_IMGCODEC_DECODERS_MEMORY_POOL_H_
 
 #include <atomic>
+#include <array>
 #include <shared_mutex>
 #include <thread>
 #include <map>

--- a/dali/operators/reader/gds_mem.cc
+++ b/dali/operators/reader/gds_mem.cc
@@ -81,19 +81,8 @@ void UnregisterChunks(void *start, int chunks, size_t chunk_size) {
 ///////////////////////////////////////////////////////////////////////////////
 // GDSRegisteredResource
 
-namespace {
-  struct CUFileDriverScope {
-    CUFileDriverScope() {
-      CUDA_CALL(cuFileDriverOpen());
-    }
-    ~CUFileDriverScope() {
-      CUDA_CALL(cuFileDriverClose());  // termination on exception is expected
-    }
-  };
-}  // namespace
-
 class GDSRegisteredResource : public mm::memory_resource<mm::memory_kind::device> {
-  CUFileDriverScope driver_scope_;
+  cufile::CUFileDriverScope driver_scope_;
 
   void adjust_params(size_t &size, size_t &alignment) {
     if (alignment < chunk_size_) {

--- a/dali/operators/reader/gds_mem.cc
+++ b/dali/operators/reader/gds_mem.cc
@@ -81,7 +81,20 @@ void UnregisterChunks(void *start, int chunks, size_t chunk_size) {
 ///////////////////////////////////////////////////////////////////////////////
 // GDSRegisteredResource
 
+namespace {
+  struct CUFileDriverScope {
+    CUFileDriverScope() {
+      CUDA_CALL(cuFileDriverOpen());
+    }
+    ~CUFileDriverScope() {
+      CUDA_CALL(cuFileDriverClose());  // termination on exception is expected
+    }
+  };
+}  // namespace
+
 class GDSRegisteredResource : public mm::memory_resource<mm::memory_kind::device> {
+  CUFileDriverScope driver_scope_;
+
   void adjust_params(size_t &size, size_t &alignment) {
     if (alignment < chunk_size_) {
       // Both chunk size and alignment are powers of 2, so if chunk_size_ is larger than

--- a/dali/test/python/reader/test_numpy.py
+++ b/dali/test/python/reader/test_numpy.py
@@ -31,7 +31,7 @@ if not os.path.isdir(gds_data_root):
     gds_data_root = os.getcwd() + "/scratch/"
     if not os.path.isdir(gds_data_root):
         os.mkdir(gds_data_root)
-        assert(os.path.isdir(gds_data_root))
+        assert os.path.isdir(gds_data_root)
 
 
 # GDS beta is supported only on x86_64 and compute cap 6.0 >=0

--- a/dali/util/mmaped_file.cc
+++ b/dali/util/mmaped_file.cc
@@ -147,6 +147,11 @@ MmapedFileStream::MmapedFileStream(const std::string& path, bool read_ahead) :
   DALI_ENFORCE(p_ != nullptr, "Could not open file " + path + ": " + std::strerror(errno));
 }
 
+MmapedFileStream::~MmapedFileStream() {
+  Close();
+}
+
+
 void MmapedFileStream::Close() {
   // Not doing any munmap right now, since Buffer objects might still
   // reference the memory range of the mapping.
@@ -156,6 +161,7 @@ void MmapedFileStream::Close() {
   length_ = 0;
   pos_ = 0;
 }
+
 
 inline uint8_t* ReadAheadHelper(std::shared_ptr<void> &p, size_t &pos,
                                  size_t &n_bytes, bool read_ahead) {

--- a/dali/util/mmaped_file.h
+++ b/dali/util/mmaped_file.h
@@ -36,11 +36,11 @@ class MmapedFileStream : public FileStream {
   int64 TellRead() const override;
   size_t Size() const override;
 
-  ~MmapedFileStream() override {
-    Close();
-  }
+  ~MmapedFileStream() override;
 
  private:
+  MmapedFileStream(const MmapedFileStream &) = delete;
+  MmapedFileStream(MmapedFileStream &&) = delete;
   std::shared_ptr<void> p_;
   size_t length_;
   size_t pos_;

--- a/dali/util/std_cufile.cc
+++ b/dali/util/std_cufile.cc
@@ -67,6 +67,7 @@ static void cufile_open(cufile::CUFileHandle& fh, size_t& length, const char* pa
   memset(&descr, 0, sizeof(CUfileDescr_t));
   descr.handle.fd = fh.fdd;
   descr.type = CU_FILE_HANDLE_TYPE_OPAQUE_FD;
+
   CUfileError_t status = cuFileHandleRegister(&(fh.cufh), &descr);
   if (status.err != CU_FILE_SUCCESS) {
     DALI_FAIL("CUFile import failed: " + path + ". " +
@@ -79,10 +80,14 @@ namespace dali {
 StdCUFileStream::StdCUFileStream(const std::string& path) : CUFileStream(path) {
   // open file
   cufile_open(f_, length_, path.c_str());
-
   // set the path to current path
   path_ = path;
 }
+
+StdCUFileStream::~StdCUFileStream() {
+  Close();
+}
+
 
 void StdCUFileStream::Close() {
   // do not deallocate here, since

--- a/dali/util/std_cufile.h
+++ b/dali/util/std_cufile.h
@@ -42,11 +42,13 @@ class StdCUFileStream : public CUFileStream {
   void HandleIOError(int64 ret) const;
   size_t Size() const override;
 
-  ~StdCUFileStream() override {
-    Close();
-  }
+  ~StdCUFileStream() override;
 
  private:
+  StdCUFileStream(const StdCUFileStream &) = delete;
+  StdCUFileStream(StdCUFileStream &&) = delete;
+  StdCUFileStream &operator=(const StdCUFileStream &) = delete;
+  StdCUFileStream &operator=(StdCUFileStream &&) = delete;
   cufile::CUFileHandle f_ = {};
   size_t length_ = 0;
   size_t pos_ = 0;

--- a/dali/util/std_file.cc
+++ b/dali/util/std_file.cc
@@ -29,6 +29,11 @@ StdFileStream::StdFileStream(const std::string& path) : FileStream(path) {
   DALI_ENFORCE(fp_ != nullptr, "Could not open file " + path + ": " + std::strerror(errno));
 }
 
+StdFileStream::~StdFileStream() {
+  Close();
+}
+
+
 void StdFileStream::Close() {
   if (fp_ != nullptr) {
     std::fclose(fp_);

--- a/dali/util/std_file.h
+++ b/dali/util/std_file.h
@@ -34,9 +34,7 @@ class StdFileStream : public FileStream {
   ptrdiff_t TellRead() const override;
   size_t Size() const override;
 
-  ~StdFileStream() override {
-    Close();
-  }
+  ~StdFileStream() override;
 
  private:
   FILE * fp_;

--- a/include/dali/core/dynlink_cufile.h
+++ b/include/dali/core/dynlink_cufile.h
@@ -20,6 +20,8 @@
 #include "dali/core/cuda_error.h"
 #include "dali/core/format.h"
 
+DLL_PUBLIC bool cuFileIsSymbolAvailable(const char *symbol);
+
 namespace dali {
 
 class CUFileError : public std::runtime_error {

--- a/include/dali/core/dynlink_cufile.h
+++ b/include/dali/core/dynlink_cufile.h
@@ -20,7 +20,7 @@
 #include "dali/core/cuda_error.h"
 #include "dali/core/format.h"
 
-DLL_PUBLIC bool cuFileIsSymbolAvailable(const char *symbol);
+bool cuFileIsSymbolAvailable(const char *symbol);
 
 namespace dali {
 

--- a/tools/stub_generator/cufile.json
+++ b/tools/stub_generator/cufile.json
@@ -1,8 +1,6 @@
 {
    "extra_include":[
       "<cufile.h>",
-      "<stdio.h>",
-      "<assert.h>",
       "\"dali/core/dynlink_cufile.inl\""
    ],
    "return_type":"CUfileError_t",

--- a/tools/stub_generator/cufile.json
+++ b/tools/stub_generator/cufile.json
@@ -1,6 +1,9 @@
 {
    "extra_include":[
-      "<cufile.h>"
+      "<cufile.h>",
+      "<stdio.h>",
+      "<assert.h>",
+      "\"dali/core/dynlink_cufile.inl\""
    ],
    "return_type":"CUfileError_t",
    "calling_conv":"",
@@ -18,6 +21,11 @@
          "not_found_error":"-1"
       },
       "cuFileDriverOpen": {},
-      "cuFileDriverClose_v2": {}
+      "cuFileDriverClose": {},
+      "cuFileDriverClose_v2": {},
+      "cuFileUseCount": {
+         "return_type":"long",
+         "not_found_error":"-1"
+      }
    }
 }

--- a/tools/stub_generator/cufile.json
+++ b/tools/stub_generator/cufile.json
@@ -18,6 +18,6 @@
          "not_found_error":"-1"
       },
       "cuFileDriverOpen": {},
-      "cuFileDriverClose": {}
+      "cuFileDriverClose_v2": {}
    }
 }

--- a/tools/stub_generator/nvml.json
+++ b/tools/stub_generator/nvml.json
@@ -17,8 +17,8 @@
       "nvmlDeviceClearCpuAffinity": {},
       "nvmlDeviceGetCpuAffinity": {},
       "nvmlErrorString": {
-         "return_type":"char*",
-         "not_found_error":"const_cast<char *>(\"\")"
+         "return_type":"const char*",
+         "not_found_error":"\"\""
       },
       "nvmlDeviceGetCpuAffinityWithinScope": {},
       "nvmlDeviceGetBrand": {},


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
The new libcufile doesn't exit cleanly (for some reasons) and has problems with library use count tracking.
This PR does the following:
- it improves the stub generator to support functions that are redefined with C macros
- it adds support for cuFileDriverClose_v2
- it uses library reference counting when the new library is detected - it happens in GDSMem and in NumpyReaderGPU
- it deletes the pipelines in the test so that the pipeline doesn't linger when the temporary directory with the test data goes out of scope and is deleted




## Additional information:

### Affected modules and functionalities:
NumpyReaderGPU
dynlink stubs


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
GDSMemTest (GTest)
NumpyReader tests (reader/test_numpy.py)

- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A



## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
