### PR TITLE
Accept negative axis in Cat and Stack operators

### DIFF
--- a/dali/operators/generic/join.cc
+++ b/dali/operators/generic/join.cc
@@ -29,7 +29,9 @@ DALI_SCHEMA(Cat)
   .DocStr(R"(Joins the input tensors along an existing axis.
 
 The shapes of the inputs must match in all dimensions except the concatenation axis.)")
-  .AddOptionalArg<int>("axis", "Axis along which the input tensors are concatenated.", 0, false)
+  .AddOptionalArg<int>("axis", R"code(Axis along which the input tensors are concatenated.
+
+Accepted range is [-ndim, ndim-1], with negative indices are counted from the back.)code", 0, false)
   .AddOptionalArg<string>("axis_name", R"(Name of the axis along which the tensors are concatenated.
 
 This argument is mutually exclusive with ``axis``.
@@ -42,11 +44,13 @@ DALI_SCHEMA(Stack)
   .DocStr(R"(Joins the input tensors along a new axis.
 
 The shapes of respective tensors in the inputs must match.)")
-  .AddOptionalArg<int>("axis", R"(The axis in the output tensor along which the inputs are stacked.
+  .AddOptionalArg<int>("axis", R"code(The axis in the output tensor along which the inputs are stacked.
 
 The axis is inserted before a corresponding axis in the inputs. A value of 0 indicates that whole
 tensors are stacked. Specifying ``axis`` equal to the number of dimensions in the inputs causes
-the values from the inputs to be interleaved)", 0, false)
+the values from the inputs to be interleaved).
+
+Accepted range is [-ndim, ndim], with negative indices are counted from the back.)code", 0, false)
   .AddOptionalArg<string>("axis_name", R"(Name of the new axis to be inserted.
 
 A one-character string that will denote the new axis in the output layout. The output layout will be
@@ -62,28 +66,33 @@ the output layout "CHW")", nullptr, false)
 template <typename Backend, bool new_axis>
 bool TensorJoin<Backend, new_axis>::SetupImpl(
         vector<OutputDesc> &outputs, const Workspace &ws) {
+  const auto &input0 = ws.Input<Backend>(0);
+  auto dtype = input0.type();
+  int ndim = input0.shape().sample_dim();
   int njoin = this->spec_.NumRegularInput();
-  outputs.resize(1);
-  outputs[0].type = ws.Input<Backend>(0).type();
-  auto &output_shape = outputs[0].shape;
 
-  // Check that all inputs have the same type
-  DALIDataType out_type = outputs[0].type;
+  // Check that all inputs have the same type and number of dimensions
   for (int i = 1; i < njoin; i++) {
-    DALIDataType type_id = ws.Input<Backend>(i).type();
-    DALI_ENFORCE(type_id == out_type, make_string(
-        "All inputs must have the same type.\nType of input #0: ", out_type,
-        "\nType of input #", i, ": ", type_id));
+    const auto& input_i = ws.Input<Backend>(i);
+    DALI_ENFORCE(
+        input_i.type() == dtype && input_i.shape().sample_dim() == ndim,
+        make_string(
+            "All inputs must have the same type and number of dimensions.\ninput #0: ", dtype, ", ",
+            ndim, "-D\n", "\ninput #", i, ": ", input_i.type(), ", ", ndim, "-D."));
   }
 
   GetInputLayout(ws);
-  SetupAxis();
+  SetupAxis(ndim);
   SetOutputLayout(ws);
 
+  outputs.resize(1);
+  outputs[0].type = dtype;
+  auto &output_shape = outputs[0].shape;
+
   // Run over the inputs and store them in a vector
-  TYPE_SWITCH(out_type, type2id, T, TENSOR_JOIN_TYPES, (
+  TYPE_SWITCH(dtype, type2id, T, TENSOR_JOIN_TYPES, (
     SetupTyped<T>(output_shape, ws);
-  ), (DALI_FAIL(make_string("The element type ", out_type, " is not supported."))));  // NOLINT
+  ), (DALI_FAIL(make_string("The element type ", dtype, " is not supported."))));  // NOLINT
   return true;
 }
 
@@ -158,7 +167,7 @@ void TensorJoin<Backend, new_axis>::SetOutputLayout(const Workspace &ws) {
 }
 
 template <typename Backend, bool new_axis>
-void TensorJoin<Backend, new_axis>::SetupAxis() {
+void TensorJoin<Backend, new_axis>::SetupAxis(int ndim) {
   // axis_name indicates the join axis for concatenation only;
   // for stacking, it's the name of the new axis
   if (has_axis_name_ && !new_axis) {
@@ -168,6 +177,16 @@ void TensorJoin<Backend, new_axis>::SetupAxis() {
   } else {
     axis_ = axis_arg_;  // this will be validated by the Setup routine
   }
+
+  int max_axis = new_axis ? ndim : ndim - 1;
+  if (axis_ < -ndim || axis_ > max_axis) {
+    DALI_FAIL(make_string("Invalid axis argument, ", axis_, " for ", ndim,
+                          "-D tensors. Accepted range is [ ", -ndim, ", ", max_axis,
+                          "], with negative indices "
+                          "being counted from the back."));
+  }
+  if (axis_ < 0)
+    axis_ += max_axis + 1;
 }
 
 template <typename Backend, bool new_axis>

--- a/dali/operators/generic/join.cc
+++ b/dali/operators/generic/join.cc
@@ -31,7 +31,7 @@ DALI_SCHEMA(Cat)
 The shapes of the inputs must match in all dimensions except the concatenation axis.)")
   .AddOptionalArg<int>("axis", R"code(Axis along which the input tensors are concatenated.
 
-Accepted range is [-ndim, ndim-1], with negative indices are counted from the back.)code", 0, false)
+Accepted range is [-ndim, ndim-1]. Negative indices are counted from the back.)code", 0, false)
   .AddOptionalArg<string>("axis_name", R"(Name of the axis along which the tensors are concatenated.
 
 This argument is mutually exclusive with ``axis``.
@@ -50,7 +50,7 @@ The axis is inserted before a corresponding axis in the inputs. A value of 0 ind
 tensors are stacked. Specifying ``axis`` equal to the number of dimensions in the inputs causes
 the values from the inputs to be interleaved).
 
-Accepted range is [-ndim, ndim], with negative indices are counted from the back.)code", 0, false)
+Accepted range is [-ndim, ndim]. Negative indices are counted from the back.)code", 0, false)
   .AddOptionalArg<string>("axis_name", R"(Name of the new axis to be inserted.
 
 A one-character string that will denote the new axis in the output layout. The output layout will be

--- a/dali/operators/generic/join.h
+++ b/dali/operators/generic/join.h
@@ -74,7 +74,7 @@ class TensorJoin : public Operator<Backend> {
   void RunTyped(const TensorListView<Storage, T> &out, Workspace &ws, GPUBackend);
 
   void GetInputLayout(const Workspace &ws);
-  void SetupAxis();
+  void SetupAxis(int ndim);
   void SetOutputLayout(const Workspace &ws);
 
   any inputs_;

--- a/dali/test/python/operator/test_join.py
+++ b/dali/test/python/operator/test_join.py
@@ -153,7 +153,7 @@ def _run_test_cat(num_inputs, layout, ndim, axis, axis_name):
         ndim = len(layout)
 
     ref_axis = layout.find(axis_name) if axis_name is not None else axis if axis is not None else 0
-    assert ref_axis >= 0
+    assert ref_axis >= -ndim and ref_axis < ndim
 
     axis_arg = None if axis_name else axis
 
@@ -181,9 +181,11 @@ def _run_test_stack(num_inputs, layout, ndim, axis, axis_name):
         ndim = len(layout)
 
     ref_axis = axis if axis is not None else 0
+    assert ref_axis >= -ndim and ref_axis <= ndim
 
     if axis_name:
-        ref_layout = layout[:axis] + axis_name + layout[axis:] if layout else axis_name
+        axis_pos = axis + ndim + 1 if axis < 0 else axis
+        ref_layout = layout[:axis_pos] + axis_name + layout[axis_pos:] if layout else axis_name
     else:
         ref_layout = ""
 
@@ -209,7 +211,7 @@ def test_cat():
         for layout, ndim in [
             (None, 0), (None, 1), ('A', 1), (None, 2), ('HW', 2), (None, 3), ('DHW', 3)
         ]:
-            for axis in range(ndim):
+            for axis in range(-ndim, ndim):
                 axis_name = layout[axis] if layout else None
                 yield _run_test_cat, num_inputs, layout, ndim, axis, axis_name
 
@@ -219,7 +221,7 @@ def test_stack():
         for layout, ndim in [
             (None, 0), (None, 1), ('A', 1), (None, 2), ('HW', 2), (None, 3), ('DHW', 3)
         ]:
-            for axis in range(ndim + 1):
+            for axis in range(-ndim, ndim + 1):
                 axis_names = [None] if layout is None and ndim > 0 else [None, 'C']
                 for axis_name in axis_names:
                     yield _run_test_stack, num_inputs, layout, ndim, axis, axis_name


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature**

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
- It enables negative axis values for Cat and Stack operators, similarly to what's supported in Numpy
- Negative axes are counted from the back


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
Cat, Stack


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
Documentation?

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
test_join.test_cat
test_join.test_stack
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [x] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: CAT.05, STACK.05
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3137
<!--- DALI-XXXX or NA --->
