### PR TITLE
Allow negative axes in reductions module

### DIFF
--- a/dali/kernels/reduce/reduce_cpu.h
+++ b/dali/kernels/reduce/reduce_cpu.h
@@ -238,8 +238,8 @@ struct ReduceBaseCPU {
   void InitAxes(span<const int> _axes) {
     for (int axis : _axes) {
       if (axis < -ndim() || axis >= ndim()) {
-        throw std::range_error(
-            make_string("Axis index out of range: ", axis, " not in ", -ndim(), "..", ndim() - 1));
+        throw std::range_error(make_string("Axis index out of range: ", axis, " not in range [",
+                                           -ndim(), "..", ndim() - 1, "]"));
       }
     }
 

--- a/dali/kernels/reduce/reduce_gpu_impl_test.cu
+++ b/dali/kernels/reduce/reduce_gpu_impl_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -206,10 +206,22 @@ TEST(ReduceImpl, TestCheckAxes) {
   int axes_01[] = { 0, 1 };
   int axes_2[] = { 2 };
   int axes_010[] = { 0, 1, 0 };
+  int axes_neg1[] = { -1 };
+  int axes_neg2[] = { -2 };
+  int axes_neg12[] = { -2, -1 };
+  int axes_neg121[] = {-2, -1, -2 };
+  int axes_pos0_neg1[] = {0, -1};
   EXPECT_NO_THROW(CheckAxes(make_span(axes_0), 1));
   EXPECT_NO_THROW(CheckAxes(make_span(axes_01), 2));
+  EXPECT_NO_THROW(CheckAxes(make_span(axes_neg1), 1));
+  EXPECT_NO_THROW(CheckAxes(make_span(axes_neg2), 2));
+  EXPECT_NO_THROW(CheckAxes(make_span(axes_neg12), 2));
+  EXPECT_NO_THROW(CheckAxes(make_span(axes_pos0_neg1), 2));
+  EXPECT_THROW(CheckAxes(make_span(axes_neg2), 1), std::out_of_range);
   EXPECT_THROW(CheckAxes(make_span(axes_2), 2), std::out_of_range);
   EXPECT_THROW(CheckAxes(make_span(axes_010), 2), std::invalid_argument);
+  EXPECT_THROW(CheckAxes(make_span(axes_neg121), 2), std::invalid_argument);
+  EXPECT_THROW(CheckAxes(make_span(axes_pos0_neg1), 1), std::invalid_argument);
 }
 
 TEST(ReduceImpl, TestCheckBatchReduce) {

--- a/dali/kernels/reduce/reduce_setup_utils.h
+++ b/dali/kernels/reduce/reduce_setup_utils.h
@@ -149,7 +149,8 @@ inline void CheckAxes(span<const int> axes, int ndim) {
   uint64_t mask = 0;
   for (auto a : axes) {
     if (a < -ndim || a >= ndim)
-      throw std::out_of_range(make_string("Axis index out of range: ", a, " not in ", -ndim, "..", ndim-1));
+      throw std::out_of_range(make_string("Axis index out of range: ", a, " not in range [", -ndim,
+                                          "..", ndim - 1, "]"));
     if (a < 0)
       a += ndim;
     uint64_t amask = 1_u64 << a;

--- a/dali/kernels/reduce/reduce_setup_utils.h
+++ b/dali/kernels/reduce/reduce_setup_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -148,12 +148,30 @@ inline void CheckAxes(span<const int> axes, int ndim) {
   assert(ndim >= 0 && ndim <= 64);
   uint64_t mask = 0;
   for (auto a : axes) {
-    if (a < 0 || a >= ndim)
-      throw std::out_of_range(make_string("Axis index out of range: ", a, " not in 0..", ndim-1));
+    if (a < -ndim || a >= ndim)
+      throw std::out_of_range(make_string("Axis index out of range: ", a, " not in ", -ndim, "..", ndim-1));
+    if (a < 0)
+      a += ndim;
     uint64_t amask = 1_u64 << a;
     if (mask & amask)
       throw std::invalid_argument(make_string("Duplicate axis index ", a));
     mask |= amask;
+  }
+}
+
+
+/**
+ * @brief Adjusts negative axis indices to the positive range.
+ *        Negative indices are counted from the back.
+ *
+ * @param axes list of axis indices
+ * @param ndim dimensionality of the tensor(list) to which axes refer
+ */
+inline void AdjustAxes(span<int> axes, int ndim) {
+  for (auto& a : axes) {
+    assert(a >= -ndim && a < ndim);
+    if (a < 0)
+      a += ndim;
   }
 }
 

--- a/dali/operators/generic/reduce/reduce.cc
+++ b/dali/operators/generic/reduce/reduce.cc
@@ -27,6 +27,8 @@ DALI_SCHEMA(ReduceBase)
     "axes",
     R"code(Axis or axes along which reduction is performed.
 
+Accepted range is [-ndim, ndim-1]. Negative indices are counted from the back.
+
 Not providing any axis results in reduction of all elements.)code",
    nullptr)
   .AddOptionalArg<TensorLayout>("axis_names", R"code(Name(s) of the axis or axes along which the reduction is performed.

--- a/dali/operators/generic/reduce/reduce.h
+++ b/dali/operators/generic/reduce/reduce.h
@@ -52,6 +52,11 @@ class AxesHelper {
       axes_.resize(sample_dim);
       std::iota(axes_.begin(), axes_.end(), 0);
     }
+
+    // checks range and duplicates
+    kernels::reduce_impl::CheckAxes(make_cspan(axes_), sample_dim);
+    // adjusts negative indices to positive range
+    kernels::reduce_impl::AdjustAxes(make_span(axes_), sample_dim);
   }
 
   bool has_axes_arg_;

--- a/dali/test/python/operator/test_reduce.py
+++ b/dali/test/python/operator/test_reduce.py
@@ -19,6 +19,7 @@ from nose.tools import nottest
 import numpy as np
 
 from test_utils import np_type_to_dali
+from nose_utils import assert_raises
 
 
 class Batch:
@@ -96,6 +97,7 @@ class Batch3DOverflow(Batch3D):
         for batch in self._data:
             for sample in batch:
                 sample *= 100000
+
 
 class Batch3DNegativeAxes(Batch3D):
     def valid_axes(self):
@@ -230,6 +232,7 @@ def test_reduce():
                 for type_id in types:
                     yield run_reduce, keep_dims, reduction_name, batch_gen, type_id
 
+
 def test_reduce_negative_axes():
     reductions = ["sum", "max"]
     type = np.uint8
@@ -237,6 +240,20 @@ def test_reduce_negative_axes():
     for keep_dims in [False, True]:
         for reduction_name in reductions:
             yield run_reduce, keep_dims, reduction_name, Batch3DNegativeAxes, type
+
+
+def test_reduce_invalid_axes():
+    class Batch3DInvalidAxes(Batch3D):
+        def valid_axes(self):  # Invalid axes
+            return [-100, (100, 0)]
+
+    batch_fn = Batch3DInvalidAxes(np.uint8)
+    dali_reduce_fn, numpy_reduce_fn = reduce_fns["sum"]
+
+    for axes in batch_fn.valid_axes():
+        with assert_raises(RuntimeError, glob="Axis index out of range"):
+            dali_res_cpu, dali_res_gpu = run_dali(
+                dali_reduce_fn, batch_fn, keep_dims=False, axes=axes, output_type=np.uint8)
 
 
 def test_reduce_with_promotion():

--- a/dali/test/python/operator/test_reduce.py
+++ b/dali/test/python/operator/test_reduce.py
@@ -17,7 +17,8 @@ from nvidia.dali.pipeline import Pipeline
 from nose.tools import nottest
 
 import numpy as np
-
+import random
+import itertools
 from test_utils import np_type_to_dali
 
 
@@ -41,6 +42,21 @@ class Batch:
         self._index = 0
 
 
+def get_valid_axes(ndim, positive_only=True):
+    out = [None]
+    valid_axes = [a for a in range(ndim)]
+    for naxes in range(ndim + 1):
+        candidates = itertools.combinations(valid_axes, naxes)
+        if positive_only:
+            out += candidates
+        else:
+            # Randomly choose positive or negative representation of the axis
+            for axes in candidates:
+                new_axes = tuple(random.choice([a, a - ndim]) for a in axes)
+                out.append(new_axes)
+    return out
+
+
 class Batch1D(Batch):
     def __init__(self, data_type):
         super().__init__(data_type)
@@ -54,7 +70,7 @@ class Batch1D(Batch):
             ]]
 
     def valid_axes(self):
-        return [None, (), 0]
+        return get_valid_axes(1, positive_only=False)
 
 
 class Batch2D(Batch):
@@ -70,7 +86,7 @@ class Batch2D(Batch):
             ]]
 
     def valid_axes(self):
-        return [None, (), 0, 1, (0, 1)]
+        return get_valid_axes(2, positive_only=False)
 
 
 class Batch3D(Batch):
@@ -86,7 +102,7 @@ class Batch3D(Batch):
             ]]
 
     def valid_axes(self):
-        return [None, (), 0, 1, 2, (0, 1), (0, 2), (1, 2), (0, 1, 2)]
+        return get_valid_axes(3, positive_only=False)
 
 
 class Batch3DOverflow(Batch3D):


### PR DESCRIPTION
Signed-off-by: Joaquin Anton <janton@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature**

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
- Adds support for negative indices in the `axes` argument of reduction operators
- Accepted range is [-ndim, ndim-1]
- Negative indices are counted from the back.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->
reductions.* ops


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->
Everything

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
test_reduce.test_reduce
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [x] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: REDUCE.05
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3139
<!--- DALI-XXXX or NA --->
