### PR TITLE
Fix stub generation for dynamic linking

### DIFF
--- a/tools/stub_generator/npp.json
+++ b/tools/stub_generator/npp.json
@@ -11,7 +11,7 @@
          "not_found_error":"0" },
       "nppSetStream": {},
       "nppGetLibVersion": {
-         "return_type":"NppLibraryVersion *",
+         "return_type":"const NppLibraryVersion *",
          "not_found_error":"nullptr" },
       "nppiColorTwist32f_8u_C3R": {},
       "nppiColorTwist32f_8u_C1R": {},

--- a/tools/stub_generator/stub_codegen.py
+++ b/tools/stub_generator/stub_codegen.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import argparse
+import re
 import json
 import clang.cindex
 
@@ -27,18 +28,14 @@ import clang.cindex
 def function_header(return_type, name, args):
     args_expr = []
     for arg_type, arg_name in args:
-        # handle function (or array of) pointer and reference to an array differently as well
-        # int (*)(), int (*[])(), int (&)[5]
-        if "(" in arg_type:
-            pos = arg_type.find("(") + 2
-            type = arg_type[0:pos]
-            args_expr.append(f"{type}{arg_name}{arg_type[pos:]}")
-        # handle array types differently, put size after the name
-        # int[]
-        elif "[" in arg_type:
-            pos = arg_type.find("[")
-            type = arg_type[0:pos]
-            args_expr.append(f"{type} {arg_name}{arg_type[pos:]}")
+        # handle arrays and function (or array of) pointer and reference to an array differently
+        # as well
+        # int[], int (*)(), int (*[])(), int (&)[5]
+        match = re.search(r'\[|\)', arg_type)
+        if match:
+            pos = match.span()[0]
+            print(arg_type[:pos])
+            args_expr.append(f"{arg_type[:pos]} {arg_name}{arg_type[pos:]}")
         else:
             args_expr.append(f"{arg_type} {arg_name}")
 

--- a/tools/stub_generator/stub_codegen.py
+++ b/tools/stub_generator/stub_codegen.py
@@ -25,7 +25,17 @@ import clang.cindex
 
 
 def function_header(return_type, name, args):
-    arg_str = ", ".join([f"{arg_type} {arg_name}" for arg_type, arg_name in args])
+    args_expr = []
+    for arg_type, arg_name in args:
+        # handle array types differently, put size after the name
+        if "[" in arg_type:
+            pos = arg_type.find("[")
+            type = arg_type[0:pos]
+            args_expr.append(f"{type} {arg_name}{arg_type[pos:]}")
+        else:
+            args_expr.append(f"{arg_type} {arg_name}")
+
+    arg_str = ", ".join(args_expr)
     ret = f"{return_type} {name}({arg_str})"
     return ret
 

--- a/tools/stub_generator/stub_codegen.py
+++ b/tools/stub_generator/stub_codegen.py
@@ -27,8 +27,15 @@ import clang.cindex
 def function_header(return_type, name, args):
     args_expr = []
     for arg_type, arg_name in args:
+        # handle function (or array of) pointer and reference to an array differently as well
+        # int (*)(), int (*[])(), int (&)[5]
+        if "(" in arg_type:
+            pos = arg_type.find("(") + 2
+            type = arg_type[0:pos]
+            args_expr.append(f"{type}{arg_name}{arg_type[pos:]}")
         # handle array types differently, put size after the name
-        if "[" in arg_type:
+        # int[]
+        elif "[" in arg_type:
             pos = arg_type.find("[")
             type = arg_type[0:pos]
             args_expr.append(f"{type} {arg_name}{arg_type[pos:]}")


### PR DESCRIPTION
- adds const to return type of nppGetLibVersion in
  the json describing stub
- fixes handling of array argument in stub generator

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- adds const to return type of nppGetLibVersion in
  the json describing stub
- fixes handling of array argument in stub generator
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- tools/stub_generator/npp.json
- tools/stub_generator/stub_codegen.py
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - conda build
  - xavier build
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
