### PR TITLE
Add debayer operator

### DIFF
--- a/dali/operators/image/color/debayer.cc
+++ b/dali/operators/image/color/debayer.cc
@@ -76,7 +76,7 @@ Currently only ``bilinear_npp`` is supported.
   For green values a bilinear interpolation with chroma correlation is used as explained in
   `NPP documentation <https://docs.nvidia.com/cuda/npp/group__image__color__debayer.html>`_.)code",
         "bilinear_npp")
-    .InputLayout(0, {"HW", "HWC"})
+    .InputLayout(0, {"HW", "HWC", "FHW"})
     .AllowSequences();
 
 }  // namespace dali

--- a/dali/operators/image/color/debayer.cc
+++ b/dali/operators/image/color/debayer.cc
@@ -1,0 +1,82 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/operators/image/color/debayer.h"
+
+namespace dali {
+
+DALI_SCHEMA(experimental__Debayer)
+    .DocStr(R"code(Performs image demosaicing/debayering.
+
+Converts single-channel image to RGB using specified color filter array.
+
+The input images must be 2D tensors (``HW``) or 3D tensors (``HWC``) where the number of channels is 1.
+The supported input types are ``uint8_t`` and ``uint16_t``.
+
+)code")
+    .NumInput(1)
+    .NumOutput(1)
+    .AddArg(debayer::bluePosArgName, R"code(The layout of color filter array/bayer tile.
+
+A position of the blue value in the 2x2 bayer tile.
+The supported values correspond to the following OpenCV bayer layouts:
+
+* ``(0, 0)`` - ``BG``/``BGGR``
+* ``(0, 1)`` - ``GB``/``GBRG``
+* ``(1, 0)`` - ``GR``/``GRBG``
+* ``(1, 1)`` - ``RG``/``RGGB``
+
+The argument follows OpenCV's convention of referring to a 2x2 tile that starts
+in the second row and column of the sensors' matrix.
+
+For example, the ``(0, 0)``/``BG``/``BGGR`` corresponds to the following matrix of sensors:
+
+.. list-table::
+   :header-rows: 0
+
+   * - R
+     - G
+     - R
+     - G
+     - R
+   * - G
+     - **B**
+     - **G**
+     - B
+     - G
+   * - R
+     - **G**
+     - **R**
+     - G
+     - R
+   * - G
+     - B
+     - G
+     - B
+     - G
+)code",
+            DALI_INT_VEC, true, true)
+    .AddOptionalArg(
+        debayer::algArgName,
+        R"code(The algorithm to be used when inferring missing colours for any given pixel.
+Currently only ``bilinear_npp`` is supported.
+
+* The ``bilinear_npp`` algorithm uses bilinear interpolation to infer red and blue values.
+  For green values a bilinear interpolation with chroma correlation is used as explained in
+  `NPP documentation <https://docs.nvidia.com/cuda/npp/group__image__color__debayer.html>`_.)code",
+        "bilinear_npp")
+    .InputLayout(0, {"HW", "HWC"})
+    .AllowSequences();
+
+}  // namespace dali

--- a/dali/operators/image/color/debayer.cc
+++ b/dali/operators/image/color/debayer.cc
@@ -54,7 +54,7 @@ For example, the following snippet presents debayering of batch of image sequenc
 )code")
     .NumInput(1)
     .NumOutput(1)
-    .AddArg(debayer::bluePosArgName, R"code(The layout of color filter array/bayer tile.
+    .AddArg(debayer::kBluePosArgName, R"code(The layout of color filter array/bayer tile.
 
 A position of the blue value in the 2x2 bayer tile.
 The supported values correspond to the following OpenCV bayer layouts:
@@ -95,7 +95,7 @@ For example, the ``(0, 0)``/``BG``/``BGGR`` corresponds to the following matrix 
 )code",
             DALI_INT_VEC, true, true)
     .AddOptionalArg(
-        debayer::algArgName,
+        debayer::kAlgArgName,
         R"code(The algorithm to be used when inferring missing colours for any given pixel.
 Currently only ``bilinear_npp`` is supported.
 

--- a/dali/operators/image/color/debayer.h
+++ b/dali/operators/image/color/debayer.h
@@ -52,7 +52,9 @@ TensorListShape<3> infer_output_shape(const TensorListShape<ndim> &input_shapes)
           make_string("The debayer operator expects grayscale (i.e. single channel) images, "
                       "however the sample at idx ",
                       sample_idx, " has shape ", input_shapes[sample_idx],
-                      ", which, assuming HWC layout, implies ", num_channels, " channels."));
+                      ", which, assuming HWC layout, implies ", num_channels, " channels. ",
+                      "If you are trying to process video or sequences, please make sure to set "
+                      "input's layout to `FHW`. You can use `fn.reshape` to set proper layout."));
     }
   }
   TensorListShape<3> out_shapes(batch_size);

--- a/dali/operators/image/color/debayer.h
+++ b/dali/operators/image/color/debayer.h
@@ -32,8 +32,8 @@ namespace debayer {
 
 using namespace kernels::debayer;  // NOLINT
 
-constexpr static const char *algArgName = "algorithm";
-constexpr static const char *bluePosArgName = "blue_position";
+constexpr static const char *kAlgArgName = "algorithm";
+constexpr static const char *kBluePosArgName = "blue_position";
 
 template <int ndim>
 TensorListShape<3> infer_output_shape(const TensorListShape<ndim> &input_shapes) {
@@ -75,7 +75,7 @@ inline debayer::DALIBayerPattern blue_pos2pattern(span<const int> blue_position)
   DALI_ENFORCE(
       blue_position.size() == 2,
       make_string(
-          "The ", debayer::bluePosArgName,
+          "The ", debayer::kBluePosArgName,
           " must be specified with exactly two values to describe a position within 2D tile. Got ",
           blue_position.size(), " values."));
   int y = blue_position[0];
@@ -83,7 +83,7 @@ inline debayer::DALIBayerPattern blue_pos2pattern(span<const int> blue_position)
   int bayer_enum_val = 2 * y + x;
   DALI_ENFORCE(
       0 <= bayer_enum_val && bayer_enum_val <= 3,
-      make_string("The `", debayer::bluePosArgName,
+      make_string("The `", debayer::kBluePosArgName,
                   "` position must lie within 2x2 tile, got: ", TensorShape<2>{y, x}, "."));
   return static_cast<debayer::DALIBayerPattern>(bayer_enum_val);
 }
@@ -103,10 +103,10 @@ class Debayer : public SequenceOperator<Backend> {
  public:
   explicit Debayer(const OpSpec &spec)
       : SequenceOperator<Backend>(spec),
-        alg_{debayer::parse_algorithm_name(spec.GetArgument<std::string>(debayer::algArgName))} {
-    if (!spec_.HasTensorArgument(debayer::bluePosArgName)) {
+        alg_{debayer::parse_algorithm_name(spec.GetArgument<std::string>(debayer::kAlgArgName))} {
+    if (!spec_.HasTensorArgument(debayer::kBluePosArgName)) {
       std::vector<int> blue_pos;
-      GetSingleOrRepeatedArg(spec_, blue_pos, debayer::bluePosArgName, 2);
+      GetSingleOrRepeatedArg(spec_, blue_pos, debayer::kBluePosArgName, 2);
       static_pattern_ = debayer::blue_pos2pattern(make_span(blue_pos));
     }
   }
@@ -130,10 +130,10 @@ class Debayer : public SequenceOperator<Backend> {
   }
 
   void AcquirePatternArgument(const Workspace &ws, int batch_size) {
-    if (!spec_.HasTensorArgument(debayer::bluePosArgName)) {
+    if (!spec_.HasTensorArgument(debayer::kBluePosArgName)) {
       pattern_.resize(batch_size, static_pattern_);
     } else {
-      const auto &tv = ws.ArgumentInput(debayer::bluePosArgName);
+      const auto &tv = ws.ArgumentInput(debayer::kBluePosArgName);
       auto blue_positions_view = view<const int, 1>(tv);
       pattern_.clear();
       pattern_.reserve(batch_size);

--- a/dali/operators/image/color/debayer.h
+++ b/dali/operators/image/color/debayer.h
@@ -1,0 +1,153 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_OPERATORS_IMAGE_COLOR_DEBAYER_H_
+#define DALI_OPERATORS_IMAGE_COLOR_DEBAYER_H_
+
+#include <string>
+#include <vector>
+
+#include "dali/core/span.h"
+#include "dali/kernels/imgproc/color_manipulation/debayer/debayer.h"
+#include "dali/pipeline/operator/common.h"
+#include "dali/pipeline/operator/op_spec.h"
+#include "dali/pipeline/operator/operator.h"
+#include "dali/pipeline/operator/sequence_operator.h"
+
+#define DEBAYER_SUPPORTED_TYPES_GPU (uint8_t, uint16_t)
+
+namespace dali {
+namespace debayer {
+
+using namespace kernels::debayer;  // NOLINT
+
+constexpr static const char *algArgName = "algorithm";
+constexpr static const char *bluePosArgName = "blue_position";
+
+template <int ndim>
+TensorListShape<3> infer_output_shape(const TensorListShape<ndim> &input_shapes) {
+  int sample_dim = input_shapes.sample_dim();
+  int batch_size = input_shapes.num_samples();
+  DALI_ENFORCE(
+      sample_dim == 2 || sample_dim == 3,
+      make_string(
+          "The debayer operator expects grayscale images, however the input has sample dim ",
+          sample_dim, " which cannot be interpreted as grayscale images."));
+  if (sample_dim == 3) {
+    for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
+      int num_channels = input_shapes[sample_idx][2];
+      DALI_ENFORCE(
+          num_channels == 1,
+          make_string("The debayer operator expects grayscale (i.e. single channel) images, "
+                      "however the sample at idx ",
+                      sample_idx, " has shape ", input_shapes[sample_idx],
+                      ", which, assuming HWC layout, implies ", num_channels, " channels."));
+    }
+  }
+  TensorListShape<3> out_shapes(batch_size);
+  for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
+    auto height = input_shapes[sample_idx][0];
+    auto width = input_shapes[sample_idx][1];
+    DALI_ENFORCE(height % 2 == 0 && width % 2 == 0,
+                 make_string("The height and width of the image to debayer must be even. However, "
+                             "the sample at idx ",
+                             sample_idx, " has shape ", input_shapes[sample_idx], "."));
+    TensorShape<3> out_shape{height, width, 3};
+    out_shapes.set_tensor_shape(sample_idx, out_shape);
+  }
+  return out_shapes;
+}
+
+inline debayer::DALIBayerPattern blue_pos2pattern(span<const int> blue_position) {
+  DALI_ENFORCE(
+      blue_position.size() == 2,
+      make_string(
+          "The ", debayer::bluePosArgName,
+          " must be specified with exactly two values to describe a position within 2D tile. Got ",
+          blue_position.size(), " values."));
+  int y = blue_position[0];
+  int x = blue_position[1];
+  int bayer_enum_val = 2 * y + x;
+  DALI_ENFORCE(
+      0 <= bayer_enum_val && bayer_enum_val <= 3,
+      make_string("The `", debayer::bluePosArgName,
+                  "` position must lie within 2x2 tile, got: ", TensorShape<2>{y, x}, "."));
+  return static_cast<debayer::DALIBayerPattern>(bayer_enum_val);
+}
+
+template <typename Backend>
+class DebayerImplBase {
+ public:
+  virtual ~DebayerImplBase() = default;
+  virtual void RunImpl(Workspace &ws) = 0;
+};
+
+}  // namespace debayer
+
+
+template <typename Backend>
+class Debayer : public SequenceOperator<Backend> {
+ public:
+  explicit Debayer(const OpSpec &spec)
+      : SequenceOperator<Backend>(spec),
+        alg_{debayer::parse_algorithm_name(spec.GetArgument<std::string>(debayer::algArgName))} {
+    if (!spec_.HasTensorArgument(debayer::bluePosArgName)) {
+      std::vector<int> blue_pos;
+      GetSingleOrRepeatedArg(spec_, blue_pos, debayer::bluePosArgName, 2);
+      static_pattern_ = debayer::blue_pos2pattern(make_span(blue_pos));
+    }
+  }
+
+ protected:
+  DISABLE_COPY_MOVE_ASSIGN(Debayer);
+  USE_OPERATOR_MEMBERS();
+
+ protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override {
+    output_desc.resize(1);
+    const auto &input_shape = ws.GetInputShape(0);
+    output_desc[0].type = ws.GetInputDataType(0);
+    output_desc[0].shape = debayer::infer_output_shape(input_shape);
+    AcquirePatternArgument(ws, input_shape.num_samples());
+    return true;
+  }
+
+  bool CanInferOutputs() const override {
+    return true;
+  }
+
+  void AcquirePatternArgument(const Workspace &ws, int batch_size) {
+    if (!spec_.HasTensorArgument(debayer::bluePosArgName)) {
+      pattern_.resize(batch_size, static_pattern_);
+    } else {
+      const auto &tv = ws.ArgumentInput(debayer::bluePosArgName);
+      auto blue_positions_view = view<const int, 1>(tv);
+      pattern_.clear();
+      pattern_.reserve(batch_size);
+      for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {
+        const auto &blue_pos = blue_positions_view[sample_idx];
+        pattern_.push_back(
+            debayer::blue_pos2pattern(make_span(blue_pos.data, blue_pos.num_elements())));
+      }
+    }
+  }
+
+  debayer::DALIBayerPattern static_pattern_ = {};
+  debayer::DALIDebayerAlgorithm alg_;
+  std::vector<debayer::DALIBayerPattern> pattern_;
+};
+
+}  // namespace dali
+
+#endif  // DALI_OPERATORS_IMAGE_COLOR_DEBAYER_H_

--- a/dali/operators/image/color/debayer.h
+++ b/dali/operators/image/color/debayer.h
@@ -80,11 +80,11 @@ inline debayer::DALIBayerPattern blue_pos2pattern(span<const int> blue_position)
           blue_position.size(), " values."));
   int y = blue_position[0];
   int x = blue_position[1];
-  int bayer_enum_val = 2 * y + x;
   DALI_ENFORCE(
-      0 <= bayer_enum_val && bayer_enum_val <= 3,
+      0 <= y && y <= 1 && 0 <= x && x <= 1,
       make_string("The `", debayer::kBluePosArgName,
                   "` position must lie within 2x2 tile, got: ", TensorShape<2>{y, x}, "."));
+  int bayer_enum_val = 2 * y + x;
   return static_cast<debayer::DALIBayerPattern>(bayer_enum_val);
 }
 
@@ -134,7 +134,7 @@ class Debayer : public SequenceOperator<Backend> {
       pattern_.resize(batch_size, static_pattern_);
     } else {
       const auto &tv = ws.ArgumentInput(debayer::kBluePosArgName);
-      auto blue_positions_view = view<const int, 1>(tv);
+      auto blue_positions_view = view<const int>(tv);
       pattern_.clear();
       pattern_.reserve(batch_size);
       for (int sample_idx = 0; sample_idx < batch_size; sample_idx++) {

--- a/dali/operators/image/color/debayer_gpu.cc
+++ b/dali/operators/image/color/debayer_gpu.cc
@@ -1,0 +1,107 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include "dali/core/span.h"
+#include "dali/core/static_switch.h"
+#include "dali/kernels/imgproc/color_manipulation/debayer/debayer.h"
+#include "dali/kernels/imgproc/color_manipulation/debayer/debayer_npp.h"
+#include "dali/kernels/kernel_manager.h"
+#include "dali/operators/image/color/debayer.h"
+
+namespace dali {
+
+namespace debayer {
+
+template <typename InOutT>
+class DebayerImplGPU : public DebayerImplBase<GPUBackend> {
+ public:
+  using Kernel = kernels::debayer::NppDebayerKernel<InOutT>;
+  explicit DebayerImplGPU(const OpSpec &spec, const std::vector<debayer::DALIBayerPattern> &pattern)
+      : pattern_{pattern} {
+    kmgr_.Resize<Kernel>(1, spec.template GetArgument<int>("device_id"));
+  }
+
+  void RunImpl(Workspace &ws) override {
+    auto &output = ws.Output<GPUBackend>(0);
+    output.SetLayout("HWC");
+    ctx_.gpu.stream = ws.stream();
+
+    auto out_view = view<InOutT, 3>(output);
+    auto in_view = GetInView(ws);
+    kmgr_.Run<Kernel>(0, ctx_, out_view, in_view, make_span(pattern_));
+  }
+
+ protected:
+  TensorListView<StorageGPU, const InOutT, 2> GetInView(Workspace &ws) {
+    const auto &input = ws.Input<GPUBackend>(0);
+    const auto &in_shape = input.shape();
+    assert(in_shape.sample_dim() == 2 ||
+           in_shape.sample_dim() == 3);  // by Debayer op's base class setupimpl
+    if (in_shape.sample_dim() == 2) {
+      return view<const InOutT, 2>(input);
+    }
+    assert(([&]() {
+      for (int sample_idx = 0; sample_idx < in_shape.num_samples(); sample_idx++) {
+        if (in_shape[sample_idx][2] != 1) {
+          return false;
+        }
+      }
+      return true;
+    })());  // by Debayer op's base class setupimpl
+    auto collapsed_shape = collapse_dims<2>(in_shape, {{1, 2}});
+    auto in_view = view<const InOutT, 3>(input);
+    return reshape<2>(in_view, collapsed_shape);
+  }
+
+  const std::vector<debayer::DALIBayerPattern> &pattern_;
+  kernels::KernelManager kmgr_;
+  kernels::KernelContext ctx_;
+};
+
+}  // namespace debayer
+
+class DebayerGPU : public Debayer<GPUBackend> {
+ public:
+  explicit DebayerGPU(const OpSpec &spec) : Debayer<GPUBackend>(spec) {}
+
+ protected:
+  bool SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) override;
+  void RunImpl(Workspace &ws) override;
+  std::unique_ptr<debayer::DebayerImplBase<GPUBackend>> impl_ = nullptr;
+};
+
+bool DebayerGPU::SetupImpl(std::vector<OutputDesc> &output_desc, const Workspace &ws) {
+  bool has_inferred = Debayer<GPUBackend>::SetupImpl(output_desc, ws);
+  assert(has_inferred);
+  if (impl_ == nullptr) {
+    assert(alg_ == debayer::DALIDebayerAlgorithm::DALI_DEBAYER_BILINEAR_NPP);
+    const auto type = ws.GetInputDataType(0);
+    TYPE_SWITCH(type, type2id, InT, DEBAYER_SUPPORTED_TYPES_GPU, (
+      impl_ = std::make_unique<debayer::DebayerImplGPU<InT>>(spec_, pattern_);
+    ), DALI_FAIL(make_string("Unsupported input type for debayer operator: ", type,  // NOLINT
+                             ". Only tensors of uint8_t and uint16_t type are supported."));
+    );  // NOLINT
+  }
+  return true;
+}
+
+void DebayerGPU::RunImpl(Workspace &ws) {
+  assert(impl_ != nullptr);
+  impl_->RunImpl(ws);
+}
+
+DALI_REGISTER_OPERATOR(experimental__Debayer, DebayerGPU, GPU);
+
+}  // namespace dali

--- a/dali/test/python/debayer_test_utils.py
+++ b/dali/test/python/debayer_test_utils.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from scipy.signal import convolve2d
+
+
+# note, it uses opencv's convention of naming the pattern after 2x2 tile
+# that starts in the second row and column of the sensors' matrix
+class BayerPattern:
+    BGGR = 0
+    GBRG = 1
+    GRBG = 2
+    RGGB = 3
+
+
+bayer_patterns = [BayerPattern.BGGR, BayerPattern.GBRG, BayerPattern.GRBG, BayerPattern.RGGB]
+
+
+def blue_position(pattern):
+    assert 0 <= pattern <= 3
+    return pattern // 2, pattern % 2
+
+
+def blue_position2pattern(blue_position):
+    y, x = blue_position
+    assert 0 <= x <= 1 and 0 <= y <= 1
+    return 2 * y + x
+
+
+def rgb_bayer_masks(img_shape, pattern):
+    h, w = img_shape
+    assert h % 2 == 0 and w % 2 == 0, f"h: {h}, w: {w}"
+    assert 0 <= pattern <= 3
+
+    def sensor_matrix_00_is_green(pattern):
+        return pattern in (BayerPattern.GRBG, BayerPattern.GBRG)
+
+    def red_is_in_the_first_row(pattern):
+        return pattern in (BayerPattern.BGGR, BayerPattern.GBRG)
+
+    def vec(n, mod=2):
+        return np.arange(0, n, dtype=np.uint8) % mod
+
+    if sensor_matrix_00_is_green(pattern):
+        top_right_mask = np.outer(1 - vec(h), vec(w))
+        bottom_left_mask = np.outer(vec(h), 1 - vec(w))
+        green = 1 - top_right_mask - bottom_left_mask
+        if red_is_in_the_first_row(pattern):
+            return top_right_mask, green, bottom_left_mask
+        return bottom_left_mask, green, top_right_mask
+    else:
+        top_left_mask = np.outer(1 - vec(h), 1 - vec(w))
+        bottom_right_mask = np.outer(vec(h), vec(w))
+        green = 1 - top_left_mask - bottom_right_mask
+        if red_is_in_the_first_row(pattern):
+            return top_left_mask, green, bottom_right_mask
+        return bottom_right_mask, green, top_left_mask
+
+
+def rgb2bayer(img, pattern):
+    h, w, c = img.shape
+    assert c == 3
+    h = h // 2 * 2
+    w = w // 2 * 2
+    r, g, b = rgb_bayer_masks((h, w), pattern)
+    return img[:h, :w, 0] * r + img[:h, :w, 1] * g + img[:h, :w, 2] * b
+
+
+def rgb2bayer_seq(seq, patterns):
+    f, h, w, c = seq.shape
+    assert f == len(patterns)
+    assert c == 3
+    h = h // 2 * 2
+    w = w // 2 * 2
+    bayer_masks = {pattern: rgb_bayer_masks((h, w), pattern) for pattern in bayer_patterns}
+    seq_masks = [bayer_masks[pattern] for pattern in patterns]
+    reds, greens, blues = [np.stack(channel) for channel in zip(*seq_masks)]
+    return seq[:, :h, :w, 0] * reds + seq[:, :h, :w, 1] * greens + seq[:, :h, :w, 2] * blues
+
+
+def conv2d_border101(img, filt):
+    r, s = filt.shape
+    assert r % 2 == 1 and s % 2 == 1
+    padded = np.pad(img, ((r // 2, r // 2), (s // 2, s // 2)), "reflect")
+    return convolve2d(padded, filt, mode="valid")
+
+
+def conv2d_border101_seq(seq, filt):
+    r, s = filt.shape
+    assert r % 2 == 1 and s % 2 == 1
+    padded = np.pad(seq, ((0, 0), (r // 2, r // 2), (s // 2, s // 2)), "reflect")
+    debayered_frames = [convolve2d(frame, filt, mode="valid") for frame in padded]
+    return np.stack(debayered_frames)
+
+
+def debayer_bilinear_npp_masks(img, masks):
+    """
+    Computes the "bilinear with chroma correction for green channel" as
+    defined by the NPP.
+    """
+    in_dtype = img.dtype
+    ndim = len(img.shape)
+    assert ndim in (2, 3)
+    is_seq = ndim == 3
+    conv = conv2d_border101 if not is_seq else conv2d_border101_seq
+    red_mask, green_mask, blue_mask = masks
+    red_signal = img * red_mask
+    green_signal = img * green_mask
+    blue_signal = img * blue_mask
+    # When inferring red color for blue or green base, there are either
+    # four red base neigbours at four corners or two base neigbours in
+    # x or y axis. The blue color case is analogous.
+    rb_filter = np.array([[1, 2, 1], [2, 4, 2], [1, 2, 1]], dtype=np.int32)
+    green_x_filter = np.array([[1, 0, 1]], dtype=np.int32)
+    green_y_filter = green_x_filter.transpose()
+    green_filter = np.array([[0, 1, 0], [1, 4, 1], [0, 1, 0]], dtype=np.int32)
+    red = conv(red_signal, rb_filter) // 4
+    blue = conv(blue_signal, rb_filter) // 4
+    green_bilinear = conv(green_signal, green_filter) // 4
+    green_x = conv(green_signal, green_x_filter) // 2
+    green_y = conv(green_signal, green_y_filter) // 2
+
+    def green_with_chroma_correlation(color_signal):
+        # For red and blue based positions, there are always four
+        # green neighbours (y - 1, x), (y + 1, x), (y, x - 1), (y, x + 1).
+        # NPP does not simply avarage 4 of them to get green intensity.
+        # Insted, it avarages only two in either y or x axis.
+        # The axis is chosen by looking at:
+        # * abs(color(x, y), avg(color(y - 2, x), color(y + 2, x))) and
+        # * abs(color(x, y), avg(color(y, x - 2), color(y, x - 2)))
+        # and choosing the axis where the difference is smaller.
+        # In other words, if we are inferring green color for blue(red)-based
+        # position we check in which axis the blue(red) intensity changes less
+        # and pick that axis.
+        diff_filter_x = np.array([[1, 0, 0, 0, 1]], dtype=np.int32)
+        diff_filter_y = diff_filter_x.transpose()
+        # First compute the average, then the difference. Doing it with a single
+        # conv yields different results (and as this servers as a mask,
+        # it results in substantial differences in the end)
+        x_avg = conv(color_signal, diff_filter_x) // 2
+        y_avg = conv(color_signal, diff_filter_y) // 2
+        diff_x = np.abs(color_signal - x_avg)
+        diff_y = np.abs(color_signal - y_avg)
+        return diff_x < diff_y, diff_x > diff_y
+
+    pick_x_red_based, pick_y_red_based = green_with_chroma_correlation(red_signal)
+    pick_x_blue_based, pick_y_blue_based = green_with_chroma_correlation(blue_signal)
+    pick_x = pick_x_red_based + pick_x_blue_based
+    pick_y = pick_y_red_based + pick_y_blue_based
+    green = pick_x * green_x + pick_y * green_y + (1 - pick_x - pick_y) * green_bilinear
+    return np.stack([red, green, blue], axis=ndim).astype(in_dtype)
+
+
+def debayer_bilinear_npp_pattern(img, pattern):
+    h, w = img.shape
+    masks = rgb_bayer_masks((h, w), pattern)
+    return debayer_bilinear_npp_masks(img, masks)
+
+
+def debayer_bilinear_npp_pattern_seq(seq, patterns):
+    f, h, w = seq.shape
+    assert f == len(patterns)
+    bayer_masks = {pattern: rgb_bayer_masks((h, w), pattern) for pattern in bayer_patterns}
+    seq_masks = [bayer_masks[pattern] for pattern in patterns]
+    reds, greens, blues = [np.stack(channel) for channel in zip(*seq_masks)]
+    return debayer_bilinear_npp_masks(seq, (reds, greens, blues))

--- a/dali/test/python/debayer_test_utils.py
+++ b/dali/test/python/debayer_test_utils.py
@@ -135,9 +135,10 @@ def debayer_bilinear_npp_masks(img, masks):
     def green_with_chroma_correlation(color_signal):
         # For red and blue based positions, there are always four
         # green neighbours (y - 1, x), (y + 1, x), (y, x - 1), (y, x + 1).
-        # NPP does not simply avarage 4 of them to get green intensity.
-        # Insted, it avarages only two in either y or x axis.
-        # The axis is chosen by looking at:
+        # NPP does not simply average 4 of them to get green intensity.
+        # Instead, it averages only two in either y or x axis as explained in
+        # https://docs.nvidia.com/cuda/npp/group__image__color__debayer.html
+        # I.e. the axis is chosen by looking at:
         # * abs(color(x, y), avg(color(y - 2, x), color(y + 2, x))) and
         # * abs(color(x, y), avg(color(y, x - 2), color(y, x - 2)))
         # and choosing the axis where the difference is smaller.

--- a/dali/test/python/operator/test_debayer.py
+++ b/dali/test/python/operator/test_debayer.py
@@ -1,0 +1,405 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import os
+import unittest
+
+import numpy as np
+from scipy.signal import convolve2d
+
+from nvidia.dali import pipeline_def, fn, types
+from test_utils import get_dali_extra_path
+from nose_utils import assert_raises
+from nose2.tools import params
+
+data_root = get_dali_extra_path()
+images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
+vid_dir = os.path.join(data_root, "db", "video", "sintel", "video_files")
+vid_files = ["sintel_trailer-720p_3.mp4"]
+
+
+# note, it uses opencv's convention of naming the pattern after 2x2 tile
+# that starts in the second row and column of the sensors' matrix
+class BayerPattern:
+    BGGR = 0
+    GBRG = 1
+    GRBG = 2
+    RGGB = 3
+
+
+bayer_patterns = [BayerPattern.BGGR, BayerPattern.GBRG, BayerPattern.GRBG, BayerPattern.RGGB]
+
+
+def blue_position(pattern):
+    assert 0 <= pattern <= 3
+    return pattern // 2, pattern % 2
+
+
+def blue_position2pattern(blue_position):
+    y, x = blue_position
+    assert 0 <= x <= 1 and 0 <= y <= 1
+    return 2 * y + x
+
+
+def read_imgs(num_imgs, dtype, seed):
+
+    @pipeline_def
+    def pipeline():
+        input, _ = fn.readers.file(file_root=images_dir, random_shuffle=True, seed=seed)
+        return fn.decoders.image(input, device="cpu", output_type=types.RGB)
+
+    pipe = pipeline(batch_size=num_imgs, device_id=0, num_threads=4)
+    pipe.build()
+    (batch, ) = pipe.run()
+    return [np.array(img, dtype=dtype) for img in batch]
+
+
+def read_video(num_sequences, num_frames, height, width, seed=42):
+    roi_start = (90, 0)
+    roi_end = (630, 1280)
+    vid_filenames = [os.path.join(vid_dir, vid_file) for vid_file in vid_files]
+
+    @pipeline_def
+    def pipeline():
+        video = fn.readers.video_resize(filenames=vid_filenames, name='video reader',
+                                        sequence_length=num_frames,
+                                        file_list_include_preceding_frame=True, device='gpu',
+                                        roi_start=roi_start, roi_end=roi_end, seed=seed,
+                                        resize_x=width, resize_y=height)
+        return video
+
+    pipe = pipeline(batch_size=num_sequences, device_id=0, num_threads=4)
+    pipe.build()
+    (batch, ) = pipe.run()
+    return [np.array(seq) for seq in batch.as_cpu()]
+
+
+def rgb_bayer_masks(img_shape, pattern):
+    h, w = img_shape
+    assert h % 2 == 0 and w % 2 == 0, f"h: {h}, w: {w}"
+    assert 0 <= pattern <= 3
+
+    def sensor_matrix_00_is_green(pattern):
+        return pattern in (BayerPattern.GRBG, BayerPattern.GBRG)
+
+    def red_is_in_the_first_row(pattern):
+        return pattern in (BayerPattern.BGGR, BayerPattern.GBRG)
+
+    def vec(n, mod=2):
+        return np.arange(0, n, dtype=np.uint8) % mod
+
+    if sensor_matrix_00_is_green(pattern):
+        top_right_mask = np.outer(1 - vec(h), vec(w))
+        bottom_left_mask = np.outer(vec(h), 1 - vec(w))
+        green = 1 - top_right_mask - bottom_left_mask
+        if red_is_in_the_first_row(pattern):
+            return top_right_mask, green, bottom_left_mask
+        return bottom_left_mask, green, top_right_mask
+    else:
+        top_left_mask = np.outer(1 - vec(h), 1 - vec(w))
+        bottom_right_mask = np.outer(vec(h), vec(w))
+        green = 1 - top_left_mask - bottom_right_mask
+        if red_is_in_the_first_row(pattern):
+            return top_left_mask, green, bottom_right_mask
+        return bottom_right_mask, green, top_left_mask
+
+
+def rgb2bayer(img, pattern):
+    h, w, c = img.shape
+    assert c == 3
+    h = h // 2 * 2
+    w = w // 2 * 2
+    r, g, b = rgb_bayer_masks((h, w), pattern)
+    return img[:h, :w, 0] * r + img[:h, :w, 1] * g + img[:h, :w, 2] * b
+
+
+def rgb2bayer_seq(seq, patterns):
+    f, h, w, c = seq.shape
+    assert f == len(patterns)
+    assert c == 3
+    h = h // 2 * 2
+    w = w // 2 * 2
+    bayer_masks = {pattern: rgb_bayer_masks((h, w), pattern) for pattern in bayer_patterns}
+    seq_masks = [bayer_masks[pattern] for pattern in patterns]
+    reds, greens, blues = [np.stack(channel) for channel in zip(*seq_masks)]
+    return seq[:, :h, :w, 0] * reds + seq[:, :h, :w, 1] * greens + seq[:, :h, :w, 2] * blues
+
+
+def conv2d_border101(img, filt):
+    r, s = filt.shape
+    assert r % 2 == 1 and s % 2 == 1
+    padded = np.pad(img, ((r // 2, r // 2), (s // 2, s // 2)), "reflect")
+    return convolve2d(padded, filt, mode="valid")
+
+
+def conv2d_border101_seq(seq, filt):
+    r, s = filt.shape
+    assert r % 2 == 1 and s % 2 == 1
+    padded = np.pad(seq, ((0, 0), (r // 2, r // 2), (s // 2, s // 2)), "reflect")
+    debayered_frames = [convolve2d(frame, filt, mode="valid") for frame in padded]
+    return np.stack(debayered_frames)
+
+
+# Computes the "bilinear with chroma correction for green channel" as
+# defined by the NPP.
+def debayer_bilinear_npp_pattern(img, pattern):
+    h, w = img.shape
+    masks = rgb_bayer_masks((h, w), pattern)
+    return debayer_bilinear_npp_masks(img, masks)
+
+
+def debayer_bilinear_npp_masks(img, masks):
+    in_dtype = img.dtype
+    ndim = len(img.shape)
+    assert ndim in (2, 3)
+    is_seq = ndim == 3
+    conv = conv2d_border101 if not is_seq else conv2d_border101_seq
+    red_mask, green_mask, blue_mask = masks
+    red_signal = img * red_mask
+    green_signal = img * green_mask
+    blue_signal = img * blue_mask
+    # When inferring red color for blue or green base, there are either
+    # four red base neigbours at four corners or two base neigbours in
+    # x or y axis. The blue color case is analogous.
+    rb_filter = np.array([[1, 2, 1], [2, 4, 2], [1, 2, 1]], dtype=np.int32)
+    green_x_filter = np.array([[1, 0, 1]], dtype=np.int32)
+    green_y_filter = green_x_filter.transpose()
+    green_filter = np.array([[0, 1, 0], [1, 4, 1], [0, 1, 0]], dtype=np.int32)
+    red = conv(red_signal, rb_filter) // 4
+    blue = conv(blue_signal, rb_filter) // 4
+    green_bilinear = conv(green_signal, green_filter) // 4
+    green_x = conv(green_signal, green_x_filter) // 2
+    green_y = conv(green_signal, green_y_filter) // 2
+
+    def green_with_chroma_correlation(color_signal):
+        # For red and blue based positions, there are always four
+        # green neighbours (y - 1, x), (y + 1, x), (y, x - 1), (y, x + 1).
+        # NPP does not simply avarage 4 of them to get green intensity.
+        # Insted, it avarages only two in either y or x axis.
+        # The axis is chosen by looking at:
+        # * abs(color(x, y), avg(color(y - 2, x), color(y + 2, x))) and
+        # * abs(color(x, y), avg(color(y, x - 2), color(y, x - 2)))
+        # and choosing the axis where the difference is smaller.
+        # In other words, if we are inferring green color for blue(red)-based
+        # position we check in which axis the blue(red) intensity changes less
+        # and pick that axis.
+        diff_filter_x = np.array([[1, 0, 0, 0, 1]], dtype=np.int32)
+        diff_filter_y = diff_filter_x.transpose()
+        # First compute the average, then the difference. Doing it with a single
+        # conv yields different results (and as this servers as a mask,
+        # it results in substantial differences in the end)
+        x_avg = conv(color_signal, diff_filter_x) // 2
+        y_avg = conv(color_signal, diff_filter_y) // 2
+        diff_x = np.abs(color_signal - x_avg)
+        diff_y = np.abs(color_signal - y_avg)
+        return diff_x < diff_y, diff_x > diff_y
+
+    pick_x_red_based, pick_y_red_based = green_with_chroma_correlation(red_signal)
+    pick_x_blue_based, pick_y_blue_based = green_with_chroma_correlation(blue_signal)
+    pick_x = pick_x_red_based + pick_x_blue_based
+    pick_y = pick_y_red_based + pick_y_blue_based
+    green = pick_x * green_x + pick_y * green_y + (1 - pick_x - pick_y) * green_bilinear
+    return np.stack([red, green, blue], axis=ndim).astype(in_dtype)
+
+
+def debayer_bilinear_npp_pattern_seq(seq, patterns):
+    f, h, w = seq.shape
+    assert f == len(patterns)
+    bayer_masks = {pattern: rgb_bayer_masks((h, w), pattern) for pattern in bayer_patterns}
+    seq_masks = [bayer_masks[pattern] for pattern in patterns]
+    reds, greens, blues = [np.stack(channel) for channel in zip(*seq_masks)]
+    return debayer_bilinear_npp_masks(seq, (reds, greens, blues))
+
+
+def prepare_test_imgs(num_samples, dtype):
+    assert dtype in (np.uint8, np.uint16)
+    rng = np.random.default_rng(seed=101)
+    imgs = read_imgs(num_samples, dtype, seed=42 if dtype == np.uint8 else 13)
+    if dtype == np.uint16:
+        imgs = [
+            np.uint16(img) * 256 + np.uint16(rng.uniform(0, 256, size=img.shape)) for img in imgs
+        ]
+    bayered_imgs = {
+        pattern: [rgb2bayer(img, pattern) for img in imgs]
+        for pattern in bayer_patterns
+    }
+    npp_baseline = {
+        pattern: [debayer_bilinear_npp_pattern(img, pattern) for img in imgs]
+        for pattern, imgs in bayered_imgs.items()
+    }
+    return bayered_imgs, npp_baseline
+
+
+class DebayerTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.num_samples = 7
+        cls.bayered_imgs, cls.npp_baseline = prepare_test_imgs(cls.num_samples, dtype=np.uint8)
+        cls.bayered_imgs16t, cls.npp_baseline16t = prepare_test_imgs(cls.num_samples,
+                                                                     dtype=np.uint16)
+
+    @classmethod
+    def get_test_data(cls, dtype):
+        assert dtype in (np.uint8, np.uint16)
+        if dtype == np.uint8:
+            return cls.bayered_imgs, cls.npp_baseline
+        else:
+            return cls.bayered_imgs16t, cls.npp_baseline16t
+
+    @params(*enumerate(itertools.product([1, 64], bayer_patterns)))
+    def test_debayer_fixed_pattern(self, i, args):
+        (batch_size, pattern) = args
+        num_iterations = 3
+        test_hwc_single_channel_input = i % 2 == 1
+        bayered_imgs, npp_baseline = self.get_test_data(np.uint8)
+
+        def source(sample_info):
+            idx = sample_info.idx_in_epoch % self.num_samples
+            img = bayered_imgs[pattern][idx]
+            assert len(img.shape) == 2
+            if test_hwc_single_channel_input:
+                h, w = img.shape
+                img = img.reshape(h, w, 1)
+            return img, np.array(idx, dtype=np.int32)
+
+        @pipeline_def
+        def debayer_pipeline():
+            bayer_imgs, idxs = fn.external_source(source=source, batch=False, num_outputs=2)
+            debayered_imgs = fn.experimental.debayer(bayer_imgs.gpu(),
+                                                     blue_position=blue_position(pattern))
+            return debayered_imgs, idxs
+
+        pipe = debayer_pipeline(batch_size=batch_size, device_id=0, num_threads=4)
+        pipe.build()
+
+        out_batches = []
+        for _ in range(num_iterations):
+            debayered_imgs_dev, idxs = pipe.run()
+            assert debayered_imgs_dev.layout() == "HWC"
+            out_batches.append(
+                ([np.array(img)
+                  for img in debayered_imgs_dev.as_cpu()], [np.array(idx) for idx in idxs]))
+
+        for debayered_imgs, idxs in out_batches:
+            assert len(debayered_imgs) == len(idxs)
+            for img_debayered, idx in zip(debayered_imgs, idxs):
+                baseline = npp_baseline[pattern][idx]
+                assert np.all(img_debayered == baseline)
+
+    @params(*itertools.product([1, 11, 184], [np.uint8, np.uint16]))
+    def test_debayer_per_sample_pattern(self, batch_size, dtype):
+        num_iterations = 3
+        num_patterns = len(bayer_patterns)
+        rng = np.random.default_rng(seed=42 + batch_size)
+        bayered_imgs, npp_baseline = self.get_test_data(dtype)
+
+        def source(sample_info):
+            idx = sample_info.idx_in_epoch % self.num_samples
+            pattern_idx = np.int32(rng.uniform(0, num_patterns))
+            pattern = bayer_patterns[pattern_idx]
+            return bayered_imgs[pattern][idx], \
+                np.array(blue_position(pattern), dtype=np.int32), \
+                np.array(idx, dtype=np.int32)
+
+        @pipeline_def
+        def debayer_pipeline():
+            bayer_imgs, blue_poses, idxs = fn.external_source(source=source, batch=False,
+                                                              num_outputs=3)
+            debayered_imgs = fn.experimental.debayer(bayer_imgs.gpu(), blue_position=blue_poses)
+            return debayered_imgs, blue_poses, idxs
+
+        pipe = debayer_pipeline(batch_size=batch_size, device_id=0, num_threads=4)
+        pipe.build()
+
+        out_batches = []
+        for _ in range(num_iterations):
+            debayered_imgs_dev, blue_poses, idxs = pipe.run()
+            assert debayered_imgs_dev.layout() == "HWC"
+            out_batches.append(
+                ([np.array(img) for img in debayered_imgs_dev.as_cpu()],
+                 [blue_position2pattern(np.array(blue_pos))
+                  for blue_pos in blue_poses], [np.array(idx) for idx in idxs]))
+
+        for debayered_imgs, patterns, idxs in out_batches:
+            assert len(debayered_imgs) == len(patterns) == len(idxs)
+            for img_debayered, pattern, idx in zip(debayered_imgs, patterns, idxs):
+                baseline = npp_baseline[pattern][idx]
+                assert np.all(img_debayered == baseline)
+
+
+def source_full_array(shape, dtype):
+
+    def source(sample_info):
+        return np.full(shape, sample_info.idx_in_epoch, dtype=dtype)
+
+    return source
+
+
+def _test_shape_pipeline(shape, dtype):
+
+    @pipeline_def
+    def pipeline():
+        bayer_imgs = fn.external_source(source_full_array(shape, dtype), batch=False)
+        return fn.experimental.debayer(bayer_imgs.gpu(), blue_position=[0, 0])
+
+    pipe = pipeline(batch_size=8, num_threads=4, device_id=0)
+    pipe.build()
+    pipe.run()
+
+
+def test_odd_size_error():
+    with assert_raises(RuntimeError,
+                       glob="The height and width of the image to debayer must be even"):
+        _test_shape_pipeline((20, 15), np.uint8)
+
+
+def test_too_many_channels():
+    with assert_raises(RuntimeError,
+                       glob=" The debayer operator expects grayscale (i.e. single channel) images"):
+        _test_shape_pipeline((20, 40, 2), np.uint8)
+
+
+def test_wrong_sample_dim():
+    with assert_raises(RuntimeError,
+                       glob="The number of dimensions 4 does not match any of the allowed"):
+        _test_shape_pipeline((20, 5, 5, 5), np.uint8)
+
+
+def test_no_blue_position_specified():
+    with assert_raises(RuntimeError, glob="Not all required arguments were specified"):
+
+        @pipeline_def
+        def pipeline():
+            bayer_imgs = fn.external_source(source_full_array((20, 20), np.uint8), batch=False)
+            return fn.experimental.debayer(bayer_imgs.gpu())
+
+        pipe = pipeline(batch_size=8, num_threads=4, device_id=0)
+        pipe.build()
+        pipe.run()
+
+
+@params(((2, 2), ), ((1, 2), ), ((-1, 0), ))
+def test_blue_position_outside_of_2x2_tile(blue_position):
+    with assert_raises(RuntimeError, glob="The `blue_position` position must lie within 2x2 tile"):
+
+        @pipeline_def
+        def pipeline():
+            bayer_imgs = fn.external_source(source_full_array((20, 20), np.uint8), batch=False)
+            return fn.experimental.debayer(bayer_imgs.gpu(), blue_position=blue_position)
+
+        pipe = pipeline(batch_size=8, num_threads=4, device_id=0)
+        pipe.build()
+        pipe.run()

--- a/dali/test/python/operator/test_debayer.py
+++ b/dali/test/python/operator/test_debayer.py
@@ -17,40 +17,18 @@ import os
 import unittest
 
 import numpy as np
-from scipy.signal import convolve2d
 
 from nvidia.dali import pipeline_def, fn, types
 from test_utils import get_dali_extra_path
 from nose_utils import assert_raises
 from nose2.tools import params
+from debayer_test_utils import bayer_patterns, blue_position, blue_position2pattern, rgb2bayer, \
+    rgb2bayer_seq, debayer_bilinear_npp_pattern, debayer_bilinear_npp_pattern_seq
 
 data_root = get_dali_extra_path()
 images_dir = os.path.join(data_root, 'db', 'single', 'jpeg')
 vid_dir = os.path.join(data_root, "db", "video", "sintel", "video_files")
 vid_files = ["sintel_trailer-720p_3.mp4"]
-
-
-# note, it uses opencv's convention of naming the pattern after 2x2 tile
-# that starts in the second row and column of the sensors' matrix
-class BayerPattern:
-    BGGR = 0
-    GBRG = 1
-    GRBG = 2
-    RGGB = 3
-
-
-bayer_patterns = [BayerPattern.BGGR, BayerPattern.GBRG, BayerPattern.GRBG, BayerPattern.RGGB]
-
-
-def blue_position(pattern):
-    assert 0 <= pattern <= 3
-    return pattern // 2, pattern % 2
-
-
-def blue_position2pattern(blue_position):
-    y, x = blue_position
-    assert 0 <= x <= 1 and 0 <= y <= 1
-    return 2 * y + x
 
 
 def read_imgs(num_imgs, dtype, seed):
@@ -84,143 +62,6 @@ def read_video(num_sequences, num_frames, height, width, seed=42):
     pipe.build()
     (batch, ) = pipe.run()
     return [np.array(seq) for seq in batch.as_cpu()]
-
-
-def rgb_bayer_masks(img_shape, pattern):
-    h, w = img_shape
-    assert h % 2 == 0 and w % 2 == 0, f"h: {h}, w: {w}"
-    assert 0 <= pattern <= 3
-
-    def sensor_matrix_00_is_green(pattern):
-        return pattern in (BayerPattern.GRBG, BayerPattern.GBRG)
-
-    def red_is_in_the_first_row(pattern):
-        return pattern in (BayerPattern.BGGR, BayerPattern.GBRG)
-
-    def vec(n, mod=2):
-        return np.arange(0, n, dtype=np.uint8) % mod
-
-    if sensor_matrix_00_is_green(pattern):
-        top_right_mask = np.outer(1 - vec(h), vec(w))
-        bottom_left_mask = np.outer(vec(h), 1 - vec(w))
-        green = 1 - top_right_mask - bottom_left_mask
-        if red_is_in_the_first_row(pattern):
-            return top_right_mask, green, bottom_left_mask
-        return bottom_left_mask, green, top_right_mask
-    else:
-        top_left_mask = np.outer(1 - vec(h), 1 - vec(w))
-        bottom_right_mask = np.outer(vec(h), vec(w))
-        green = 1 - top_left_mask - bottom_right_mask
-        if red_is_in_the_first_row(pattern):
-            return top_left_mask, green, bottom_right_mask
-        return bottom_right_mask, green, top_left_mask
-
-
-def rgb2bayer(img, pattern):
-    h, w, c = img.shape
-    assert c == 3
-    h = h // 2 * 2
-    w = w // 2 * 2
-    r, g, b = rgb_bayer_masks((h, w), pattern)
-    return img[:h, :w, 0] * r + img[:h, :w, 1] * g + img[:h, :w, 2] * b
-
-
-def rgb2bayer_seq(seq, patterns):
-    f, h, w, c = seq.shape
-    assert f == len(patterns)
-    assert c == 3
-    h = h // 2 * 2
-    w = w // 2 * 2
-    bayer_masks = {pattern: rgb_bayer_masks((h, w), pattern) for pattern in bayer_patterns}
-    seq_masks = [bayer_masks[pattern] for pattern in patterns]
-    reds, greens, blues = [np.stack(channel) for channel in zip(*seq_masks)]
-    return seq[:, :h, :w, 0] * reds + seq[:, :h, :w, 1] * greens + seq[:, :h, :w, 2] * blues
-
-
-def conv2d_border101(img, filt):
-    r, s = filt.shape
-    assert r % 2 == 1 and s % 2 == 1
-    padded = np.pad(img, ((r // 2, r // 2), (s // 2, s // 2)), "reflect")
-    return convolve2d(padded, filt, mode="valid")
-
-
-def conv2d_border101_seq(seq, filt):
-    r, s = filt.shape
-    assert r % 2 == 1 and s % 2 == 1
-    padded = np.pad(seq, ((0, 0), (r // 2, r // 2), (s // 2, s // 2)), "reflect")
-    debayered_frames = [convolve2d(frame, filt, mode="valid") for frame in padded]
-    return np.stack(debayered_frames)
-
-
-# Computes the "bilinear with chroma correction for green channel" as
-# defined by the NPP.
-def debayer_bilinear_npp_pattern(img, pattern):
-    h, w = img.shape
-    masks = rgb_bayer_masks((h, w), pattern)
-    return debayer_bilinear_npp_masks(img, masks)
-
-
-def debayer_bilinear_npp_masks(img, masks):
-    in_dtype = img.dtype
-    ndim = len(img.shape)
-    assert ndim in (2, 3)
-    is_seq = ndim == 3
-    conv = conv2d_border101 if not is_seq else conv2d_border101_seq
-    red_mask, green_mask, blue_mask = masks
-    red_signal = img * red_mask
-    green_signal = img * green_mask
-    blue_signal = img * blue_mask
-    # When inferring red color for blue or green base, there are either
-    # four red base neigbours at four corners or two base neigbours in
-    # x or y axis. The blue color case is analogous.
-    rb_filter = np.array([[1, 2, 1], [2, 4, 2], [1, 2, 1]], dtype=np.int32)
-    green_x_filter = np.array([[1, 0, 1]], dtype=np.int32)
-    green_y_filter = green_x_filter.transpose()
-    green_filter = np.array([[0, 1, 0], [1, 4, 1], [0, 1, 0]], dtype=np.int32)
-    red = conv(red_signal, rb_filter) // 4
-    blue = conv(blue_signal, rb_filter) // 4
-    green_bilinear = conv(green_signal, green_filter) // 4
-    green_x = conv(green_signal, green_x_filter) // 2
-    green_y = conv(green_signal, green_y_filter) // 2
-
-    def green_with_chroma_correlation(color_signal):
-        # For red and blue based positions, there are always four
-        # green neighbours (y - 1, x), (y + 1, x), (y, x - 1), (y, x + 1).
-        # NPP does not simply avarage 4 of them to get green intensity.
-        # Insted, it avarages only two in either y or x axis.
-        # The axis is chosen by looking at:
-        # * abs(color(x, y), avg(color(y - 2, x), color(y + 2, x))) and
-        # * abs(color(x, y), avg(color(y, x - 2), color(y, x - 2)))
-        # and choosing the axis where the difference is smaller.
-        # In other words, if we are inferring green color for blue(red)-based
-        # position we check in which axis the blue(red) intensity changes less
-        # and pick that axis.
-        diff_filter_x = np.array([[1, 0, 0, 0, 1]], dtype=np.int32)
-        diff_filter_y = diff_filter_x.transpose()
-        # First compute the average, then the difference. Doing it with a single
-        # conv yields different results (and as this servers as a mask,
-        # it results in substantial differences in the end)
-        x_avg = conv(color_signal, diff_filter_x) // 2
-        y_avg = conv(color_signal, diff_filter_y) // 2
-        diff_x = np.abs(color_signal - x_avg)
-        diff_y = np.abs(color_signal - y_avg)
-        return diff_x < diff_y, diff_x > diff_y
-
-    pick_x_red_based, pick_y_red_based = green_with_chroma_correlation(red_signal)
-    pick_x_blue_based, pick_y_blue_based = green_with_chroma_correlation(blue_signal)
-    pick_x = pick_x_red_based + pick_x_blue_based
-    pick_y = pick_y_red_based + pick_y_blue_based
-    green = pick_x * green_x + pick_y * green_y + (1 - pick_x - pick_y) * green_bilinear
-    return np.stack([red, green, blue], axis=ndim).astype(in_dtype)
-
-
-def debayer_bilinear_npp_pattern_seq(seq, patterns):
-    f, h, w = seq.shape
-    assert f == len(patterns)
-    bayer_masks = {pattern: rgb_bayer_masks((h, w), pattern) for pattern in bayer_patterns}
-    seq_masks = [bayer_masks[pattern] for pattern in patterns]
-    reds, greens, blues = [np.stack(channel) for channel in zip(*seq_masks)]
-    return debayer_bilinear_npp_masks(seq, (reds, greens, blues))
 
 
 def prepare_test_imgs(num_samples, dtype):
@@ -431,11 +272,15 @@ def test_too_many_channels():
                        glob=" The debayer operator expects grayscale (i.e. single channel) images"):
         _test_shape_pipeline((20, 40, 2), np.uint8)
 
+    with assert_raises(RuntimeError,
+                       glob=" The debayer operator expects grayscale (i.e. single channel) images"):
+        _test_shape_pipeline((20, 40, 2, 2), np.uint8)
+
 
 def test_wrong_sample_dim():
     with assert_raises(RuntimeError,
-                       glob="The number of dimensions 4 does not match any of the allowed"):
-        _test_shape_pipeline((20, 5, 5, 5), np.uint8)
+                       glob="The number of dimensions 5 does not match any of the allowed"):
+        _test_shape_pipeline((1, 1, 1, 1, 1), np.uint8)
 
 
 def test_no_blue_position_specified():

--- a/dali/test/python/test_dali_cpu_only.py
+++ b/dali/test/python/test_dali_cpu_only.py
@@ -1313,8 +1313,9 @@ excluded_methods = [
     "optical_flow",  # not supported for CPU
     "paste",  # not supported for CPU
     "experimental.audio_resample",  # Alias of audio_resample (already tested)
-    "experimental.remap",  # operator is GPU-only
+    "experimental.debayer",  # not supported for CPU
     "experimental.inflate",  # not supported for CPU
+    "experimental.remap",  # operator is GPU-only
 ]
 
 

--- a/qa/TL0_python-self-test-core/test_nofw.sh
+++ b/qa/TL0_python-self-test-core/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages='${python_test_runner_package} numpy>=1.17 opencv-python pillow nvidia-ml-py==11.450.51 numba lz4'
+pip_packages='${python_test_runner_package} numpy>=1.17 opencv-python pillow nvidia-ml-py==11.450.51 numba lz4 scipy'
 
 target_dir=./dali/test/python
 


### PR DESCRIPTION
Add debayer operator
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
* Adds a new operator based on the npp_debayer_kernel
* Operator accepts gpu input (bayered images/videos), the algorithm and one of four possible bayer patterns.
* The only supported algorithm as for now is "bilinear_npp". It is not simply bilinear, because npp does extra "chroma correlation" when inferring green values for blue and red based pixels. I imagine, in the future we may support both: bilinear and bilinear_npp.
* The bayer pattern specification can be done per-sample and per-frame. For this reason, following @mzient suggestion, the pattern is specified through "blue_position" parameter as 2d coordinate of the blue color within bayer 2x2 tile. It is unambigious although a bit weird. However, support for tensor strings is almost non-existent, while using enums is also a bit akward as it requires reinterperet operator along the way.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:


### Affected modules and functionalities:
* New operator, new python tests. Existing funcionalities are unaffected.
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
Around 70% of this PR are tests and documentation. It is a small PR. :)

<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [x] Docstring
  - [x] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [x] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: DEBAYER.02, 03, 04, 07, 08, 09, 11, 12, 13.
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3075