### PR TITLE
Don't look for duplicate arguments in parent schemas.

### DIFF
--- a/dali/CMakeLists.txt
+++ b/dali/CMakeLists.txt
@@ -100,7 +100,7 @@ if (BUILD_DALI_PIPELINE AND BUILD_TEST)
   adjust_source_file_language_property("${DALI_TEST_SRCS}")
   add_executable(dali_test "${DALI_TEST_SRCS}")
 
-  target_link_libraries(dali_test PUBLIC dali dali_core dali_kernels dali_operators ${DALI_LIBS} gtest)
+  target_link_libraries(dali_test PUBLIC dali dali_core dali_kernels ${DALI_LIBS} gtest)
   target_link_libraries(dali_test PRIVATE dynlink_cuda ${CUDART_LIB})
   if (BUILD_NVML)
     target_link_libraries(dali_test PRIVATE dynlink_nvml)

--- a/dali/pipeline/operator/op_schema.cc
+++ b/dali/pipeline/operator/op_schema.cc
@@ -699,7 +699,7 @@ void OpSchema::CheckArgs(const OpSpec &spec) const {
 }
 
 
-bool OpSchema::HasRequiredArgument(const std::string &name, const bool local_only) const {
+bool OpSchema::HasRequiredArgument(const std::string &name, bool local_only) const {
   bool ret = arguments_.find(name) != arguments_.end();
   if (ret || local_only) {
     return ret;
@@ -712,7 +712,7 @@ bool OpSchema::HasRequiredArgument(const std::string &name, const bool local_onl
 }
 
 
-bool OpSchema::HasOptionalArgument(const std::string &name, const bool local_only) const {
+bool OpSchema::HasOptionalArgument(const std::string &name, bool local_only) const {
   bool ret = optional_arguments_.find(name) != optional_arguments_.end();
   if (ret || local_only) {
     return ret;
@@ -725,7 +725,7 @@ bool OpSchema::HasOptionalArgument(const std::string &name, const bool local_onl
 }
 
 
-bool OpSchema::HasInternalArgument(const std::string &name, const bool local_only) const {
+bool OpSchema::HasInternalArgument(const std::string &name, bool local_only) const {
   bool ret = internal_arguments_.find(name) != internal_arguments_.end();
   if (ret || local_only) {
     return ret;
@@ -848,7 +848,7 @@ const TensorArgDesc *OpSchema::FindTensorArgument(const std::string &name) const
 
 
 void OpSchema::CheckArgument(const std::string &s) {
-  DALI_ENFORCE(!HasArgument(s), "Argument \"" + s + "\" already added to the schema");
+  DALI_ENFORCE(!HasArgument(s, false, true), "Argument \"" + s + "\" already added to the schema");
   DALI_ENFORCE(internal_arguments_.find(s) == internal_arguments_.end(),
                "Argument name \"" + s + "\" is reserved for internal use");
 }
@@ -936,8 +936,10 @@ std::pair<const OpSchema *, const Value *> OpSchema::FindDefaultValue(const std:
 }
 
 
-bool OpSchema::HasArgument(const std::string &name, bool include_internal) const {
-  return HasRequiredArgument(name) || HasOptionalArgument(name) ||
+bool OpSchema::HasArgument(const std::string &name,
+                           bool include_internal,
+                           bool local_only) const {
+  return HasRequiredArgument(name, local_only) || HasOptionalArgument(name, local_only) ||
          (include_internal && HasInternalArgument(name, true));
 }
 

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -636,11 +636,11 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
   template <typename T>
   DLL_PUBLIC inline T GetDefaultValueForArgument(const std::string &s) const;
 
-  DLL_PUBLIC bool HasRequiredArgument(const std::string &name, const bool local_only = false) const;
+  DLL_PUBLIC bool HasRequiredArgument(const std::string &name, bool local_only = false) const;
 
-  DLL_PUBLIC bool HasOptionalArgument(const std::string &name, const bool local_only = false) const;
+  DLL_PUBLIC bool HasOptionalArgument(const std::string &name, bool local_only = false) const;
 
-  DLL_PUBLIC bool HasInternalArgument(const std::string &name, const bool local_only = false) const;
+  DLL_PUBLIC bool HasInternalArgument(const std::string &name, bool local_only = false) const;
 
   /**
    * @brief Finds default value for a given argument
@@ -649,7 +649,14 @@ used with DALIDataType, to avoid confusion with `AddOptionalArg<type>(name, doc,
   DLL_PUBLIC std::pair<const OpSchema *, const Value *> FindDefaultValue(
       const std::string &arg_name, bool local_only = false, bool include_internal = true) const;
 
-  DLL_PUBLIC bool HasArgument(const std::string &name, bool include_internal = false) const;
+  /**
+   * @brief Checks whether the schema defines an argument with the given name
+   * @param include_internal - returns `true` also for internal/implicit arugments
+   * @param local_only       - doesn't look in parent schemas
+   */
+  DLL_PUBLIC bool HasArgument(const std::string &name,
+                              bool include_internal = false,
+                              bool local_only = false) const;
 
   /**
    * @brief Get docstring for operator argument of given name (Python Operator Kwargs).

--- a/dali/pipeline/operator/op_schema.h
+++ b/dali/pipeline/operator/op_schema.h
@@ -791,10 +791,11 @@ inline T OpSchema::GetDefaultValueForArgument(const std::string &s) const {
                make_string("The argument \"", s, "\" doesn't have a default value in schema \"",
                            name(), "\"."));
 
-  const ValueInst<T> *vT = dynamic_cast<const ValueInst<T> *>(v);
-  DALI_ENFORCE(vT != nullptr, "Unexpected type of the default value for argument \"" + s +
+  using S = argument_storage_t<T>;
+  const ValueInst<S> *vS = dynamic_cast<const ValueInst<S> *>(v);
+  DALI_ENFORCE(vS != nullptr, "Unexpected type of the default value for argument \"" + s +
                                   "\" of schema \"" + this->name() + "\"");
-  return vT->Get();
+  return static_cast<T>(vS->Get());
 }
 
 #define DALI_SCHEMA_REG(OpName)                         \

--- a/dali/pipeline/operator/op_schema_test.cc
+++ b/dali/pipeline/operator/op_schema_test.cc
@@ -73,10 +73,10 @@ TEST(OpSchemaTest, OptionalArgumentDefaultValue) {
 
 DALI_SCHEMA(Dummy4)
   .NumInput(1).NumOutput(1)
-  .AddParent("Dummy3");
+  .AddParent("Dummy3")
   .AddOptionalArg("bar", "var", 17.f)
   .AddOptionalArg("foo", "foo", 2)  // shadow an argument from a parent
-  .AddOptionalArg<bool>("no_default2", "argument without default", nullptr)
+  .AddOptionalArg<bool>("no_default2", "argument without default", nullptr);
 
 TEST(OpSchemaTest, OptionalArgumentDefaultValueInheritance) {
   auto spec = OpSpec("Dummy4");
@@ -101,10 +101,11 @@ TEST(OpSchemaTest, OptionalArgumentDefaultValueInheritance) {
 
 DALI_SCHEMA(Dummy5)
   .DocStr("Foo")
+  .AddParent("Dummy4")
   .NumInput(1)
   .NumOutput(1)
-  .AddOptionalArg("baz", "baz", 2.f)
-  .AddParent("Dummy4");
+  .AddOptionalArg("foo", "foo", 1.50f)  // shadow an argument from a parent
+  .AddOptionalArg("baz", "baz", 2.f);
 
 TEST(OpSchemaTest, OptionalArgumentDefaultValueMultipleInheritance) {
   auto spec = OpSpec("Dummy5");

--- a/dali/pipeline/operator/op_schema_test.cc
+++ b/dali/pipeline/operator/op_schema_test.cc
@@ -49,6 +49,20 @@ TEST(OpSchemaTest, OutputFNTest) {
   ASSERT_EQ(schema.CalculateOutputs(spec), 2);
 }
 
+DALI_SCHEMA(DummForwardRefParent)
+  .AddParent("Dummy3")  // not yet defined
+  .AddOptionalArg("foo", "foo", 2);
+
+TEST(OpSchemaTest, InitalizationOrder) {
+  auto spec = OpSpec("DummForwardRefParent");
+  auto &schema = SchemaRegistry::GetSchema("DummForwardRefParent");
+  EXPECT_EQ(&spec.GetSchema(), &schema);
+  EXPECT_EQ(schema.GetDefaultValueForArgument<int>("foo"), 2);
+  EXPECT_NO_THROW(
+    EXPECT_EQ(spec.GetArgument<int>("foo"), 2);
+  );  // NOLINT
+}
+
 DALI_SCHEMA(Dummy3)
   .NumInput(1).NumOutput(1)
   .AddOptionalArg("foo", "foo", 1.5f)

--- a/dali/pipeline/operator/op_schema_test.cc
+++ b/dali/pipeline/operator/op_schema_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2017-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -73,16 +73,17 @@ TEST(OpSchemaTest, OptionalArgumentDefaultValue) {
 
 DALI_SCHEMA(Dummy4)
   .NumInput(1).NumOutput(1)
-  .AddOptionalArg("bar", "var", 17.f)
-  .AddOptionalArg<bool>("no_default2", "argument without default", nullptr)
   .AddParent("Dummy3");
+  .AddOptionalArg("bar", "var", 17.f)
+  .AddOptionalArg("foo", "foo", 2)  // shadow an argument from a parent
+  .AddOptionalArg<bool>("no_default2", "argument without default", nullptr)
 
 TEST(OpSchemaTest, OptionalArgumentDefaultValueInheritance) {
   auto spec = OpSpec("Dummy4");
   auto &schema = SchemaRegistry::GetSchema("Dummy4");
 
   ASSERT_TRUE(schema.HasOptionalArgument("foo"));
-  ASSERT_EQ(schema.GetDefaultValueForArgument<float>("foo"), 1.5f);
+  ASSERT_EQ(schema.GetDefaultValueForArgument<int>("foo"), 2);
   ASSERT_EQ(schema.GetDefaultValueForArgument<float>("bar"), 17);
 
   ASSERT_TRUE(schema.HasOptionalArgument("no_default"));


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
Prior to this change, AddParent had to be the last command, so that AddArgument didn't look at the parents. Failure to do so could result in:
- failure to look up the parent because of undefined order of initialization of globals in different translation units
- order-dependent behaviour
- if AddParent was first, otherwise legal argument shadowing became illegal.

Additionally, a bug in `GetDefaultValueForArgument` was fixed. Prior to this change, `GetDefaultValueForArgument` tried to dynamic-cast a Value to `Value<T>` instead of `Value<argument_storage_t<T>>`, which always failed for types as simple as `int` (which is stored as `int64_t`).

A dependence of dali_test on libdali_operators has been removed - it's not necessary and prolongs the build. This has already been done once, but the dependence was somehow reintroduced.

## Additional information:

### Affected modules and functionalities:
* Schema
* dali_test

### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
Modified a test for AddParent, complete with shadowing

- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
