### PR TITLE
Fix video decoder cache for multiple GPUs

### DIFF
--- a/dali/operators/reader/loader/video/frames_decoder_gpu.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_gpu.cc
@@ -223,7 +223,7 @@ class NVDECCache {
     void ReturnDecoder(DecInstance &decoder) {
       int device_id = 0;
       CUDA_CALL(cudaGetDevice(&device_id));
-        std::unique_lock lock(access_lock[device_id]);
+      std::unique_lock lock(access_lock[device_id]);
       auto range = dec_cache[device_id].equal_range(decoder.codec_type);
       for (auto it = range.first; it != range.second; ++it) {
         if (it->second.decoder == decoder.decoder) {
@@ -245,7 +245,7 @@ class NVDECCache {
     ~NVDECCache() {
       for (size_t i = 0; i < dec_cache.size(); ++i) {
         auto &dec_cache_elm = dec_cache[i];
-        std::scoped_lock lock(access_lock[i]);
+        std::lock_guard lock(access_lock[i]);
         for (auto &it : dec_cache_elm) {
           cuvidDestroyDecoder(it.second.decoder);
         }

--- a/dali/operators/reader/loader/video/frames_decoder_gpu.h
+++ b/dali/operators/reader/loader/video/frames_decoder_gpu.h
@@ -65,6 +65,7 @@ struct DecInstance {
   unsigned max_width = 0;
   unsigned int bit_depth_luma_minus8 = 0;
   bool used = false;
+  int device_id = 0;
 };
 
 class NVDECLease {

--- a/dali/test/python/decoder/test_video.py
+++ b/dali/test/python/decoder/test_video.py
@@ -155,6 +155,7 @@ def test_multi_gpu_video(device):
         raise SkipTest()
 
     batch_size = 1
+
     def input_gen(batch_size):
         filenames = glob.glob(f'{get_dali_extra_path()}/db/video/[cv]fr/*.mp4')
         filenames = filter(lambda filename: 'mpeg4' not in filename, filenames)

--- a/dali/test/python/decoder/test_video.py
+++ b/dali/test/python/decoder/test_video.py
@@ -18,9 +18,11 @@ import numpy as np
 import cv2
 import nvidia.dali.types as types
 import glob
-from test_utils import get_dali_extra_path
+from test_utils import get_dali_extra_path, is_mulit_gpu
 from nvidia.dali.backend import TensorListGPU
 from nose2.tools import params
+from nose import SkipTest
+from nose.plugins.attrib import attr
 
 
 filenames = glob.glob(f'{get_dali_extra_path()}/db/video/[cv]fr/*.mp4')
@@ -145,8 +147,13 @@ def test_full_range_video_in_memory(device):
     absdiff = np.abs(left.astype(int) - right.astype(int))
     assert np.mean(absdiff) < 2
 
+
+@attr('multi_gpu')
 @params('cpu', 'gpu')
 def test_multi_gpu_video(device):
+    if not is_mulit_gpu():
+        raise SkipTest()
+
     @pipeline_def
     def test_pipeline():
         videos = fn.experimental.readers.video(

--- a/dali/test/python/decoder/test_video.py
+++ b/dali/test/python/decoder/test_video.py
@@ -18,12 +18,12 @@ import numpy as np
 import cv2
 import nvidia.dali.types as types
 import glob
+from itertools import cycle
 from test_utils import get_dali_extra_path, is_mulit_gpu
 from nvidia.dali.backend import TensorListGPU
 from nose2.tools import params
 from nose import SkipTest
 from nose.plugins.attrib import attr
-
 
 filenames = glob.glob(f'{get_dali_extra_path()}/db/video/[cv]fr/*.mp4')
 # filter out HEVC because some GPUs do not support it
@@ -149,18 +149,28 @@ def test_full_range_video_in_memory(device):
 
 
 @attr('multi_gpu')
-@params('cpu', 'gpu')
+@params('cpu', 'mixed')
 def test_multi_gpu_video(device):
     if not is_mulit_gpu():
         raise SkipTest()
 
+    batch_size = 1
+    def input_gen(batch_size):
+        filenames = glob.glob(f'{get_dali_extra_path()}/db/video/[cv]fr/*.mp4')
+        filenames = filter(lambda filename: 'mpeg4' not in filename, filenames)
+        filenames = filter(lambda filename: 'hevc' not in filename, filenames)
+        filenames = cycle(filenames)
+        while True:
+            batch = []
+            for _ in range(batch_size):
+                batch.append(np.fromfile(next(filenames), dtype=np.uint8))
+            yield batch
+
     @pipeline_def
     def test_pipeline():
-        videos = fn.experimental.readers.video(
-            device=device,
-            filenames=[get_dali_extra_path() + '/db/video/full_dynamic_range/video.mp4'],
-            sequence_length=1)
-        return videos
+        vid = fn.external_source(device='cpu', source=input_gen(batch_size))
+        seq = fn.experimental.decoders.video(vid, device=device)
+        return seq
 
     video_pipeline_0 = test_pipeline(batch_size=1, num_threads=1, device_id=0)
     video_pipeline_1 = test_pipeline(batch_size=1, num_threads=1, device_id=1)

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -39,6 +39,17 @@ def get_arch(device_id=0):
     return compute_cap
 
 
+def is_mulit_gpu():
+    try:
+        import pynvml
+        pynvml.nvmlInit()
+        is_mulit_gpu_var = pynvml.nvmlDeviceGetCount() != 1
+    except ModuleNotFoundError:
+        print("Python bindings for NVML not found")
+
+    return is_mulit_gpu_var
+
+
 def get_dali_extra_path():
     try:
         dali_extra_path = os.environ['DALI_EXTRA_PATH']

--- a/qa/TL0_multigpu/test_body.sh
+++ b/qa/TL0_multigpu/test_body.sh
@@ -6,7 +6,7 @@ test_py_with_framework() {
 }
 
 test_py() {
-  ${python_new_invoke_test} -s decoder test_video.test_multi_gpu_video
+  ${python_new_invoke_test} -s decoder -A 'multi_gpu'
 }
 
 test_gtest() {

--- a/qa/TL0_multigpu/test_body.sh
+++ b/qa/TL0_multigpu/test_body.sh
@@ -6,8 +6,7 @@ test_py_with_framework() {
 }
 
 test_py() {
-  # placeholder function
-  :
+  ${python_new_invoke_test} -s decoder test_video.test_multi_gpu_video
 }
 
 test_gtest() {

--- a/qa/TL0_multigpu/test_nofw.sh
+++ b/qa/TL0_multigpu/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages='${python_test_runner_package}'
+pip_packages='${python_test_runner_package} numpy>=1.17 opencv-python'
 target_dir=./dali/test/python
 
 # test_body definition is in separate file so it can be used without setup

--- a/qa/TL0_multigpu/test_nofw.sh
+++ b/qa/TL0_multigpu/test_nofw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # used pip packages
-pip_packages='${python_test_runner_package} numpy>=1.17 opencv-python'
+pip_packages='${python_test_runner_package} numpy>=1.17 librosa==0.8.1 scipy nvidia-ml-py==11.450.51 psutil dill cloudpickle opencv-python'
 target_dir=./dali/test/python
 
 # test_body definition is in separate file so it can be used without setup

--- a/qa/TL0_python-self-test-readers-decoders/test_body.sh
+++ b/qa/TL0_python-self-test-readers-decoders/test_body.sh
@@ -3,7 +3,7 @@
 test_py_with_framework() {
     # numpy seems to be extremly slow with sanitizers to dissable it
     if [ -n "$DALI_ENABLE_SANITIZERS" ]; then
-          FILTER_PATTERN="test_external_source_parallel.py\|test_external_source_parallel_custom_serialization\|test_external_source_parallel_garbage_collection_order"
+        FILTER_PATTERN="test_external_source_parallel.py\|test_external_source_parallel_custom_serialization\|test_external_source_parallel_garbage_collection_order"
     else
         FILTER_PATTERN="#"
     fi
@@ -37,7 +37,7 @@ test_py_with_framework() {
       ${python_new_invoke_test} -s reader
     fi
 
-    
+
     ${python_new_invoke_test} -s decoder
 }
 


### PR DESCRIPTION
- the video decoder cache is global and doesn't
  account for multiple GPUs in the system. In the end,
  the decoder created for one GPU can be used in another
  causing failure. This PR adds device_id logic to the
  decoder cache

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- the video decoder cache is global and doesn't
  account for multiple GPUs in the system. In the end,
  the decoder created for one GPU can be used in another
  causing failure. This PR adds device_id logic to the
  decoder cache

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- frames decoder for the GPU
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- performance
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
    - test_video.test_multi_gpu_video
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
