### PR TITLE
Propagate SourceInfo (when unambiguous) from inputs to outputs.

### DIFF
--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -92,13 +92,6 @@ void MultiPasteCPU::RunTyped(Workspace &ws) {
       for (int iter = 0; iter < paste_count; iter++) {
         int from_sample = in_idx_[i].data[iter];
         int to_sample = i;
-
-        const auto &in_source_info = images.GetMeta(from_sample).GetSourceInfo();
-        if (!in_source_info.empty()) {
-          if (out_source_info.empty())
-            out_source_info.append(path_delim);
-        }
-
         tp.AddWork(
           [&, i, iter, from_sample, to_sample, in_view, out_view](int thread_id) {
             kernels::KernelContext ctx;

--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -85,13 +85,11 @@ void MultiPasteCPU::RunTyped(Workspace &ws) {
     auto paste_count = in_idx_[i].shape[0];
     memset(out_view[i].data, 0, out_view[i].num_elements() * sizeof(OutputType));
 
-    std::string out_source_info;
-    const char *path_delim = ";";
-
     if (no_intersections_[i]) {
       for (int iter = 0; iter < paste_count; iter++) {
         int from_sample = in_idx_[i].data[iter];
         int to_sample = i;
+
         tp.AddWork(
           [&, i, iter, from_sample, to_sample, in_view, out_view](int thread_id) {
             kernels::KernelContext ctx;

--- a/dali/operators/image/paste/multipaste.cc
+++ b/dali/operators/image/paste/multipaste.cc
@@ -85,10 +85,19 @@ void MultiPasteCPU::RunTyped(Workspace &ws) {
     auto paste_count = in_idx_[i].shape[0];
     memset(out_view[i].data, 0, out_view[i].num_elements() * sizeof(OutputType));
 
+    std::string out_source_info;
+    const char *path_delim = ";";
+
     if (no_intersections_[i]) {
       for (int iter = 0; iter < paste_count; iter++) {
         int from_sample = in_idx_[i].data[iter];
         int to_sample = i;
+
+        const auto &in_source_info = images.GetMeta(from_sample).GetSourceInfo();
+        if (!in_source_info.empty()) {
+          if (out_source_info.empty())
+            out_source_info.append(path_delim);
+        }
 
         tp.AddWork(
           [&, i, iter, from_sample, to_sample, in_view, out_view](int thread_id) {

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -26,6 +26,7 @@
 #include "dali/pipeline/graph/op_graph_storage.h"
 #include "dali/pipeline/operator/common.h"
 #include "dali/pipeline/workspace/workspace_data_factory.h"
+#include "dali/pipeline/executor/source_info_propagation.h"
 
 namespace dali {
 
@@ -406,6 +407,8 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunHelper(OpNode &op_node, Workspac
     DomainTimeRange tr("[DALI][Executor] Run");
     op.Run(ws);
   }
+
+  PropagateSourceInfo(ws);
 
   /* TODO(michalz): Find a way to make this valid in presence of passthrough between stages
   // Set the output order to the stage's stream

--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -403,6 +403,9 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunHelper(OpNode &op_node, Workspac
                     "always return false.");
     }
   }
+
+  ClearOutputSourceInfo(ws);
+
   {
     DomainTimeRange tr("[DALI][Executor] Run");
     op.Run(ws);

--- a/dali/pipeline/executor/source_info_propagation.cc
+++ b/dali/pipeline/executor/source_info_propagation.cc
@@ -54,6 +54,23 @@ inline int GetOutputBatchSize(Workspace &ws, int output_idx) {
   }
 }
 
+template <typename Backend>
+void ClearSourceInfo(TensorList<Backend> &tl) {
+  for (int s = 0; s < tl.num_samples(); s++)
+    tl.SetSourceInfo(s, "");
+}
+
+void ClearOutputSourceInfo(Workspace &ws) {
+  for (int o = 0; o < ws.NumOutput(); o++) {
+    if (ws.OutputIsType<CPUBackend>(o)) {
+      ClearSourceInfo(ws.Output<CPUBackend>(o));
+    } else {
+      assert(ws.OutputIsType<GPUBackend>(o));
+      ClearSourceInfo(ws.Output<GPUBackend>(o));
+    }
+  }
+}
+
 bool PropagateSourceInfo(Workspace &ws) {
   int num_inputs = ws.NumInput();
   int num_outputs = ws.NumOutput();

--- a/dali/pipeline/executor/source_info_propagation.cc
+++ b/dali/pipeline/executor/source_info_propagation.cc
@@ -62,6 +62,8 @@ void ClearSourceInfo(TensorList<Backend> &tl) {
     tl.SetSourceInfo(s, "");
 }
 
+}  // namespace
+
 void ClearOutputSourceInfo(Workspace &ws) {
   for (int o = 0; o < ws.NumOutput(); o++) {
     if (ws.OutputIsType<CPUBackend>(o)) {
@@ -72,8 +74,6 @@ void ClearOutputSourceInfo(Workspace &ws) {
     }
   }
 }
-
-}  // namespace
 
 bool PropagateSourceInfo(Workspace &ws) {
   int num_inputs = ws.NumInput();

--- a/dali/pipeline/executor/source_info_propagation.cc
+++ b/dali/pipeline/executor/source_info_propagation.cc
@@ -23,6 +23,8 @@
 
 namespace dali {
 
+namespace {
+
 template <typename Backend>
 bool SourceInfoDefined(const TensorList<Backend> &tl) {
   for (int s = 0; s < tl.num_samples(); s++)
@@ -70,6 +72,8 @@ void ClearOutputSourceInfo(Workspace &ws) {
     }
   }
 }
+
+}  // namespace
 
 bool PropagateSourceInfo(Workspace &ws) {
   int num_inputs = ws.NumInput();

--- a/dali/pipeline/executor/source_info_propagation.cc
+++ b/dali/pipeline/executor/source_info_propagation.cc
@@ -1,0 +1,133 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/executor/source_info_propagation.h"
+
+#include <cassert>
+#include <functional>
+#include <string>
+
+#include "dali/pipeline/data/tensor_list.h"
+#include "dali/pipeline/workspace/workspace.h"
+
+namespace dali {
+
+template <typename Backend>
+bool SourceInfoDefined(const TensorList<Backend> &tl) {
+  for (int s = 0; s < tl.num_samples(); s++)
+    if (!tl.GetMeta(s).GetSourceInfo().empty())
+      return true;
+  return false;
+}
+
+inline bool OutputSourceInfoDefined(Workspace &ws) {
+  for (int o = 0; o < ws.NumOutput(); o++) {
+    if (ws.OutputIsType<GPUBackend>(o)) {
+      if (SourceInfoDefined(ws.Output<GPUBackend>(o)))
+        return true;
+    } else {
+      assert(ws.OutputIsType<CPUBackend>(o));
+      if (SourceInfoDefined(ws.Output<CPUBackend>(o)))
+        return true;
+    }
+  }
+  return false;
+}
+
+inline int GetOutputBatchSize(Workspace &ws, int output_idx) {
+  if (ws.OutputIsType<CPUBackend>(output_idx)) {
+    return ws.Output<CPUBackend>(output_idx).num_samples();
+  } else {
+    assert(ws.OutputIsType<GPUBackend>(output_idx));
+    return ws.Output<GPUBackend>(output_idx).num_samples();
+  }
+}
+
+bool PropagateSourceInfo(Workspace &ws) {
+  int num_inputs = ws.NumInput();
+  int num_outputs = ws.NumOutput();
+
+  if (num_inputs == 0 || num_outputs == 0)
+    return false;  // there's nothing to propagate
+
+  if (OutputSourceInfoDefined(ws))
+    return false;  // the operator defined the source info, no need to set it
+
+  SmallVector<std::function<const std::string &(int)>, 8> get_src_info;
+  get_src_info.resize(num_inputs);
+  int batch_size = 0;
+  for (int i = 0; i < num_inputs; i++) {
+    auto process_input = [&](auto &input) {
+      // check the batch size
+      if (i == 0)
+        batch_size = input.num_samples();
+      else if (input.num_samples() != batch_size)
+        return false;  // mismatched input batch size - this is a special operator, bailing out
+
+      get_src_info[i] = [&input, i](int sample)->const std::string & {
+        return input.GetMeta(sample).GetSourceInfo();
+      };
+      return true;
+    };
+
+    if (ws.InputIsType<CPUBackend>(i)) {
+      if (!process_input(ws.Input<CPUBackend>(i)))
+        return false;
+    } else {
+      assert(ws.InputIsType<GPUBackend>(i));
+      if (!process_input(ws.Input<GPUBackend>(i)))
+        return false;
+    }
+  }
+
+  for (int o = 0; o < num_outputs; o++) {
+    if (GetOutputBatchSize(ws, o) != batch_size)
+      return false;  // this operator changes the batch size - bailing out
+  }
+
+  BatchVector<const std::string*> source_infos;
+  source_infos.resize(batch_size);
+  for (int s = 0; s < batch_size; s++) {
+    const std::string *sinfo = nullptr;
+    for (int i = 0; i < num_inputs; i++) {
+      auto &si = get_src_info[i](s);
+      if (si.empty())
+        continue;
+      if (sinfo && *sinfo != si)
+        return false;  // inconsistent source info - bailing out
+      sinfo = &si;
+    }
+    source_infos[s] = sinfo;
+  }
+
+  auto set_source_infos = [&](auto &out) {
+    assert(out.num_samples() == batch_size);
+    for (int s = 0; s < batch_size; s++) {
+      if (auto *si = source_infos[s])
+        out.SetSourceInfo(s, *si);
+    }
+  };
+
+  for (int o = 0; o < num_outputs; o++) {
+    if (ws.OutputIsType<CPUBackend>(o)) {
+      set_source_infos(ws.Output<CPUBackend>(o));
+    } else {
+      assert(ws.OutputIsType<GPUBackend>(o));
+      set_source_infos(ws.Output<GPUBackend>(o));
+    }
+  }
+  return true;
+}
+
+}  // namespace dali

--- a/dali/pipeline/executor/source_info_propagation.cc
+++ b/dali/pipeline/executor/source_info_propagation.cc
@@ -92,7 +92,7 @@ bool PropagateSourceInfo(Workspace &ws) {
       else if (input.num_samples() != batch_size)
         return false;  // mismatched input batch size - this is a special operator, bailing out
 
-      get_src_info[i] = [&input, i](int sample)->const std::string & {
+      get_src_info[i] = [&input](int sample)->const std::string & {
         return input.GetMeta(sample).GetSourceInfo();
       };
       return true;

--- a/dali/pipeline/executor/source_info_propagation.h
+++ b/dali/pipeline/executor/source_info_propagation.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DALI_PIPELINE_EXECUTOR_SOURCE_INFO_PROPAGATION_H_
+#define DALI_PIPELINE_EXECUTOR_SOURCE_INFO_PROPAGATION_H_
+
+#include "dali/core/api_helper.h"
+
+namespace dali {
+
+class Workspace;
+
+/**
+ * @brief Propagates the SourceInfo from input(s) to the outputs
+ *
+ * This function propagates the SourceInfo metadata from the source tensors to the destination
+ * tensors under the following conditions:
+ * - none of the outputs has a SourceInfo already set
+ * - all input and output the batch sizes are equal
+ * - the source info for all inputs must be equal or empty (see below)
+ *
+ * Consistent source info
+ *      inp0:    inp1:    inp2:
+ *      'a.jpg', 'a.jpg', <empty>
+ *      'b.jpg', 'b.jpg', <empty>
+ *
+ * Inconsistent source info
+ *      inp0:    inp1:
+ *      'a.jpg', 'a_mask.png'
+ *      'b.jpg', 'b_mask.png'
+ *
+ */
+bool DLL_PUBLIC PropagateSourceInfo(Workspace &ws);
+
+}  // namespace dali
+
+#endif  // DALI_PIPELINE_EXECUTOR_SOURCE_INFO_PROPAGATION_H_

--- a/dali/pipeline/executor/source_info_propagation.h
+++ b/dali/pipeline/executor/source_info_propagation.h
@@ -21,6 +21,8 @@ namespace dali {
 
 class Workspace;
 
+void DLL_PUBLIC ClearOutputSourceInfo(Workspace &ws);
+
 /**
  * @brief Propagates the SourceInfo from input(s) to the outputs
  *

--- a/dali/pipeline/executor/source_info_propagation.h
+++ b/dali/pipeline/executor/source_info_propagation.h
@@ -28,8 +28,9 @@ void DLL_PUBLIC ClearOutputSourceInfo(Workspace &ws);
  *
  * This function propagates the SourceInfo metadata from the source tensors to the destination
  * tensors under the following conditions:
+ * - there's at least one input and at least one output
  * - none of the outputs has a SourceInfo already set
- * - all input and output the batch sizes are equal
+ * - all the input and output batch sizes are equal
  * - the source info for all inputs must be equal or empty (see below)
  *
  * Consistent source info
@@ -42,6 +43,7 @@ void DLL_PUBLIC ClearOutputSourceInfo(Workspace &ws);
  *      'a.jpg', 'a_mask.png'
  *      'b.jpg', 'b_mask.png'
  *
+ * @return true,  if the propagation was successfully performed, false otherwise
  */
 bool DLL_PUBLIC PropagateSourceInfo(Workspace &ws);
 

--- a/dali/pipeline/executor/source_info_propagation_test.cc
+++ b/dali/pipeline/executor/source_info_propagation_test.cc
@@ -1,0 +1,200 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dali/pipeline/executor/source_info_propagation.h"
+#include <gtest/gtest.h>
+#include <cassert>
+#include <memory>
+#include <string>
+#include <vector>
+#include "dali/core/format.h"
+#include "dali/core/span.h"
+#include "dali/pipeline/workspace/workspace.h"
+
+namespace dali {
+namespace test {
+
+
+template <typename Backend, typename T>
+void SetSourceInfo(TensorList<Backend> &tl, T &&infos) {
+  int n = tl.num_samples();
+  assert(static_cast<int>(std::size(infos)) >= n);
+  for (int i = 0; i < n; i++) {
+    tl.SetSourceInfo(i, infos[i]);
+  }
+}
+
+void SetInputSourceInfo(Workspace &ws, int idx, const std::vector<std::string> &infos) {
+  if (ws.InputIsType<CPUBackend>(idx))
+    SetSourceInfo(ws.UnsafeMutableInput<CPUBackend>(idx), infos);
+  else
+    SetSourceInfo(ws.UnsafeMutableInput<GPUBackend>(idx), infos);
+}
+
+void SetOutputSourceInfo(Workspace &ws, int idx, const std::vector<std::string> &infos) {
+  if (ws.OutputIsType<CPUBackend>(idx))
+    SetSourceInfo(ws.Output<CPUBackend>(idx), infos);
+  else
+    SetSourceInfo(ws.Output<GPUBackend>(idx), infos);
+}
+
+template <typename Backend, typename T>
+void CheckSourceInfo(const TensorList<Backend> &tl, T &&infos) {
+  int n = tl.num_samples();
+  assert(static_cast<int>(std::size(infos)) >= n);
+  for (int i = 0; i < n; i++) {
+    EXPECT_EQ(tl.GetMeta(i).GetSourceInfo(), infos[i]);
+  }
+}
+
+void CheckOutputSourceInfo(const Workspace &ws, int idx, const std::vector<std::string> &infos) {
+  if (ws.OutputIsType<CPUBackend>(idx))
+    CheckSourceInfo(ws.Output<CPUBackend>(idx), infos);
+  else
+    CheckSourceInfo(ws.Output<GPUBackend>(idx), infos);
+}
+
+struct BufferDesc {
+  StorageDevice device;
+  int batch_size = 1;
+};
+
+void BuildWorkspace(Workspace &ws,
+                    span<const BufferDesc> input_descs,
+                    span<const BufferDesc> output_descs) {
+  for (const BufferDesc &desc : input_descs) {
+    if (desc.device == StorageDevice::CPU) {
+      ws.AddInput(std::make_shared<TensorList<CPUBackend>>(desc.batch_size));
+    } else {
+      assert(desc.device == StorageDevice::GPU);
+      ws.AddInput(std::make_shared<TensorList<GPUBackend>>(desc.batch_size));
+    }
+  }
+  for (const BufferDesc &desc : output_descs) {
+    if (desc.device == StorageDevice::CPU) {
+      ws.AddOutput(std::make_shared<TensorList<CPUBackend>>(desc.batch_size));
+    } else {
+      assert(desc.device == StorageDevice::GPU);
+      ws.AddOutput(std::make_shared<TensorList<GPUBackend>>(desc.batch_size));
+    }
+  }
+}
+
+void BuildWorkspace(Workspace &ws,
+                    std::vector<BufferDesc> input_descs,
+                    std::vector<BufferDesc> output_descs) {
+  BuildWorkspace(ws, make_cspan(input_descs), make_cspan(output_descs));
+}
+
+
+constexpr auto CPU = StorageDevice::CPU;
+constexpr auto GPU = StorageDevice::GPU;
+
+TEST(SourceInfoPropagationTest, Simple) {
+  Workspace ws;
+  BuildWorkspace(ws, { { GPU, 2 } }, { { GPU, 2 } });
+  SetInputSourceInfo(ws, 0, { "a.jpg", "b.jpg" });
+  ASSERT_TRUE(PropagateSourceInfo(ws));
+  CheckOutputSourceInfo(ws, 0, { "a.jpg", "b.jpg" });
+}
+
+TEST(SourceInfoPropagationTest, Multi) {
+  Workspace ws;
+  BuildWorkspace(ws, { { GPU, 2 }, { CPU, 2 } }, { { GPU, 2 }, { CPU, 2 } });
+  SetInputSourceInfo(ws, 0, { "a.jpg", "b.jpg" });
+  SetInputSourceInfo(ws, 1, { "a.jpg", "b.jpg" });
+  ASSERT_TRUE(PropagateSourceInfo(ws));
+  CheckOutputSourceInfo(ws, 0, { "a.jpg", "b.jpg" });
+  CheckOutputSourceInfo(ws, 1, { "a.jpg", "b.jpg" });
+}
+
+TEST(SourceInfoPropagationTest, OneInputOnly) {
+  for (int input_with_info = 0; input_with_info < 2; input_with_info++) {
+    Workspace ws;
+    BuildWorkspace(ws, { { GPU, 2 }, { CPU, 2 } }, { { GPU, 2 }, { CPU, 2 }, { GPU, 2 } });
+    SetInputSourceInfo(ws, input_with_info, { "a.jpg", "b.jpg" });
+    ASSERT_TRUE(PropagateSourceInfo(ws));
+    CheckOutputSourceInfo(ws, 0, { "a.jpg", "b.jpg" });
+    CheckOutputSourceInfo(ws, 1, { "a.jpg", "b.jpg" });
+    CheckOutputSourceInfo(ws, 2, { "a.jpg", "b.jpg" });
+  }
+}
+
+TEST(SourceInfoPropagationTest, InterleavedBlanks) {
+  Workspace ws;
+  BuildWorkspace(ws, { { GPU, 2 }, { CPU, 2 } }, { { GPU, 2 }, { CPU, 2 }, { GPU, 2 } });
+  SetInputSourceInfo(ws, 0, { "a.jpg", "" });
+  SetInputSourceInfo(ws, 1, { "", "b.jpg" });
+  ASSERT_TRUE(PropagateSourceInfo(ws));
+  CheckOutputSourceInfo(ws, 0, { "a.jpg", "b.jpg" });
+  CheckOutputSourceInfo(ws, 1, { "a.jpg", "b.jpg" });
+  CheckOutputSourceInfo(ws, 2, { "a.jpg", "b.jpg" });
+}
+
+TEST(SourceInfoPropagationTest, PartiallyBlankOutput) {
+  Workspace ws;
+  BuildWorkspace(ws, { { GPU, 4 }, { CPU, 4 }, { GPU, 4 } }, { { CPU, 4 } });
+  SetInputSourceInfo(ws, 0, { "a.jpg", "", "", "" });
+  SetInputSourceInfo(ws, 1, { "", "", "", "d.jpg" });
+  SetInputSourceInfo(ws, 2, { "", "b.jpg", "", "" });
+  ASSERT_TRUE(PropagateSourceInfo(ws));
+  CheckOutputSourceInfo(ws, 0, { "a.jpg", "b.jpg", "", "d.jpg" });
+}
+
+TEST(SourceInfoPropagationTest, Error_AlreadySet) {
+  Workspace ws;
+  BuildWorkspace(ws, { { GPU, 2 }, { CPU, 2 } }, { { CPU, 2 } });
+  SetInputSourceInfo(ws, 0, { "a.jpg", "b.jpg" });
+  SetInputSourceInfo(ws, 1, { "a.jpg", "b.jpg" });
+  SetOutputSourceInfo(ws, 0, { "", "b.jpg" });
+  ASSERT_FALSE(PropagateSourceInfo(ws));
+  CheckOutputSourceInfo(ws, 0, { "", "b.jpg" });
+}
+
+TEST(SourceInfoPropagationTest, Error_DifferentBatchSizes) {
+  {
+    Workspace ws;
+    BuildWorkspace(ws, { { GPU, 3 }, { CPU, 2 } }, { { CPU, 2 } });
+    SetInputSourceInfo(ws, 0, { "a.jpg", "b.jpg", "c.jpg" });
+    SetInputSourceInfo(ws, 1, { "a.jpg", "b.jpg" });
+    ASSERT_FALSE(PropagateSourceInfo(ws));
+  }
+  {
+    Workspace ws;
+    BuildWorkspace(ws, { { GPU, 2 } }, { { CPU, 3 } });
+    SetInputSourceInfo(ws, 0, { "a.jpg", "b.jpg" });
+    ASSERT_FALSE(PropagateSourceInfo(ws));
+  }
+}
+
+TEST(SourceInfoPropagationTest, Error_Clash) {
+  {
+    Workspace ws;
+    BuildWorkspace(ws, { { GPU, 2 }, { CPU, 2 } }, { { CPU, 2 } });
+    SetInputSourceInfo(ws, 0, { "a.jpg", "b.jpg" });
+    SetInputSourceInfo(ws, 1, { "a.jpg", "c.jpg" });
+    ASSERT_FALSE(PropagateSourceInfo(ws));
+  }
+  {
+    Workspace ws;
+    BuildWorkspace(ws, { { GPU, 2 }, { CPU, 2 } }, { { CPU, 2 } });
+    SetInputSourceInfo(ws, 0, { "a.jpg", "b.jpg" });
+    SetInputSourceInfo(ws, 1, { "", "c.jpg" });
+    ASSERT_FALSE(PropagateSourceInfo(ws));
+  }
+}
+
+}  // namespace test
+}  // namespace dali
+

--- a/dali/pipeline/executor/source_info_propagation_test.cc
+++ b/dali/pipeline/executor/source_info_propagation_test.cc
@@ -101,6 +101,15 @@ void BuildWorkspace(Workspace &ws,
 constexpr auto CPU = StorageDevice::CPU;
 constexpr auto GPU = StorageDevice::GPU;
 
+TEST(SourceInfoPropagationTest, Clear) {
+  Workspace ws;
+  BuildWorkspace(ws, { { GPU, 2 } }, { { GPU, 2 } });
+  SetOutputSourceInfo(ws, 0, { "asdf", "b.jpg" });
+  CheckOutputSourceInfo(ws, 0, { "asdf", "b.jpg" });
+  ClearOutputSourceInfo(ws);
+  CheckOutputSourceInfo(ws, 0, { "", "" });
+}
+
 TEST(SourceInfoPropagationTest, Simple) {
   Workspace ws;
   BuildWorkspace(ws, { { GPU, 2 } }, { { GPU, 2 } });

--- a/dali/test/python/decoder/test_imgcodec.py
+++ b/dali/test/python/decoder/test_imgcodec.py
@@ -57,8 +57,8 @@ def decoder_pipe(data_path, device, use_fast_idct=False):
 test_data_root = get_dali_extra_path()
 good_path = 'db/single'
 misnamed_path = 'db/single/missnamed'
-test_good_path = {'jpeg', 'mixed', 'png', 'tiff', 'pnm', 'bmp', 'jpeg2k', 'webp'}
-test_misnamed_path = {'jpeg', 'png', 'tiff', 'pnm', 'bmp'}
+test_good_path = {'jpeg', 'mixed', 'png', 'pnm', 'bmp', 'jpeg2k', 'webp'}
+test_misnamed_path = {'jpeg', 'png', 'pnm', 'bmp'}
 
 
 def run_decode(data_path, batch, device, threads):
@@ -150,9 +150,10 @@ def run_decode_fused(test_fun, path, img_type, batch, device, threads, validatio
     for _ in range(iters):
         out_1, out_2 = pipe.run()
         for img_1, img_2 in zip(out_1, out_2):
-            img_1 = to_array(img_1)
-            img_2 = to_array(img_2)
-            assert validation_fun(img_1, img_2)
+            arr_1 = to_array(img_1)
+            arr_2 = to_array(img_2)
+            assert validation_fun(arr_1, arr_2), \
+                   f"{validation_fun.__name__}\nimage: {img_1.source_info()}"
 
 
 def test_image_decoder_fused():

--- a/dali/test/python/decoder/test_imgcodec.py
+++ b/dali/test/python/decoder/test_imgcodec.py
@@ -57,8 +57,8 @@ def decoder_pipe(data_path, device, use_fast_idct=False):
 test_data_root = get_dali_extra_path()
 good_path = 'db/single'
 misnamed_path = 'db/single/missnamed'
-test_good_path = {'jpeg', 'mixed', 'png', 'pnm', 'bmp', 'jpeg2k', 'webp'}
-test_misnamed_path = {'jpeg', 'png', 'pnm', 'bmp'}
+test_good_path = {'jpeg', 'mixed', 'png', 'tiff', 'pnm', 'bmp', 'jpeg2k', 'webp'}
+test_misnamed_path = {'jpeg', 'png', 'tiff', 'pnm', 'bmp'}
 
 
 def run_decode(data_path, batch, device, threads):

--- a/dali/test/python/operator/test_multipaste.py
+++ b/dali/test/python/operator/test_multipaste.py
@@ -220,6 +220,9 @@ def verify_out_of_bounds(batch_size, in_idx_l, in_anchors_l, shapes_l, out_ancho
 def manual_verify(batch_size, inp, output, in_idx_l, in_anchors_l, shapes_l, out_anchors_l,
                   out_size_l, dtype):
     for i in range(batch_size):
+        ref_source_info = ";".join([inp[idx].source_info() for idx in in_idx_l[i]])
+        assert output[i].source_info() == ref_source_info, \
+               f"{output[i].source_info()} == {ref_source_info}"
         out = output.at(i)
         out_size = out_size_l[i]
         assert out.shape == out_size

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -150,6 +150,8 @@ def test_tensor_cpu_squeeze():
         t_shape = tuple(t.shape())
         assert t_shape == arr_squeeze.shape, f"{t_shape} != {arr_squeeze.shape}"
         assert t.layout() == expected_out_layout, f"{t.layout()} != {expected_out_layout}"
+        assert t.get_property("layout") == expected_out_layout, \
+               f'{t.get_property("layout")} != {expected_out_layout}'
         assert np.allclose(arr_squeeze, np.array(t))
         assert is_squeezed == should_squeeze, f"{is_squeezed} != {should_squeeze}"
 

--- a/dali/test/python/test_backend_impl.py
+++ b/dali/test/python/test_backend_impl.py
@@ -131,6 +131,14 @@ def test_array_interface_types():
         yield check_array_types, t
 
 
+def layout_compatible(a, b):
+    if a is None:
+        a = ""
+    if b is None:
+        b = ""
+    return a == b
+
+
 # TODO(spanev): figure out which return_value_policy to choose
 # def test_tensorlist_getitem_slice():
 #    arr = np.random.rand(3, 5, 6)
@@ -138,7 +146,6 @@ def test_array_interface_types():
 #    two_first_tensors = tensorlist[0:2]
 #    assert type(two_first_tensors) == tuple
 #    assert type(two_first_tensors[0]) == TensorCPU
-
 
 def test_tensor_cpu_squeeze():
     def check_squeeze(shape, dim, in_layout, expected_out_layout):
@@ -150,8 +157,8 @@ def test_tensor_cpu_squeeze():
         t_shape = tuple(t.shape())
         assert t_shape == arr_squeeze.shape, f"{t_shape} != {arr_squeeze.shape}"
         assert t.layout() == expected_out_layout, f"{t.layout()} != {expected_out_layout}"
-        assert t.get_property("layout") == expected_out_layout, \
-               f'{t.get_property("layout")} != {expected_out_layout}'
+        assert layout_compatible(t.get_property("layout"), expected_out_layout), \
+               f'{t.get_property("layout")} doesn\'t match {expected_out_layout}'
         assert np.allclose(arr_squeeze, np.array(t))
         assert is_squeezed == should_squeeze, f"{is_squeezed} != {should_squeeze}"
 

--- a/dali/test/python/test_utils.py
+++ b/dali/test/python/test_utils.py
@@ -204,7 +204,12 @@ def check_batch(batch1, batch2, batch_size=None,
                     error_msg = (f"Mean error: [{err}], Min error: [{min_err}], "
                                  f"Max error: [{max_err}]\n"
                                  f"Total error count: [{total_errors}], "
-                                 f"Tensor size: [{absdiff.size}]")
+                                 f"Tensor size: [{absdiff.size}]\n"
+                                 f"Index in batch: {i}\n")
+                if hasattr(batch1[i], "source_info"):
+                    error_msg += f"\nLHS data source: {batch1[i].source_info()}"
+                if hasattr(batch2[i], "source_info"):
+                    error_msg += f"\nRHS data source: {batch2[i].source_info()}"
                 try:
                     save_image(left, "err_1.png")
                     save_image(right, "err_2.png")


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:
SourceInfo is now propagated from outputs to inputs when it's not ambiguous.
The conditions are:
- batch sizes must match (in all inputs and outputs)
- SourceInfo for all inputs for each sample must either match or be empty
- SourceInfo must not be set for any output sample


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
