### PR TITLE
Fix missing `#include <optional>`

### DIFF
--- a/dali/operators/decoder/video/video_decoder_base.h
+++ b/dali/operators/decoder/video/video_decoder_base.h
@@ -17,6 +17,7 @@
 
 #include <vector>
 #include <memory>
+#include <optional>
 #include "dali/kernels/common/copy.h"
 #include "dali/pipeline/operator/common.h"
 


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
The file uses `std::optional` but doesn't include the header. Depending on the compiler/STL version, this breaks compilation (e.g. on Ubuntu 22.04, CUDA 11.8 + GCC 11.3).


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
