### PR TITLE
Use pointer in NVDECLease. Store owner pointer in NVDECLease.

### DIFF
--- a/dali/operators/reader/loader/video/frames_decoder_gpu.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_gpu.cc
@@ -17,7 +17,7 @@
 #include <string>
 #include <memory>
 #include <iomanip>
-#include <unordered_map>
+#include <map>
 #include <mutex>
 #include "dali/core/error_handling.h"
 #include "dali/core/cuda_error.h"
@@ -91,11 +91,11 @@ class NVDECCache {
       return GetCache(device_id).GetDecoder(video_format, device_id);
     }
 
-    void ReturnDecoder(DecInstance &decoder) {
+    void ReturnDecoder(DecInstance *decoder) {
       std::unique_lock lock(access_lock);
-      auto range = dec_cache.equal_range(decoder.codec_type);
+      auto range = dec_cache.equal_range(decoder->codec_type);
       for (auto it = range.first; it != range.second; ++it) {
-        if (it->second.decoder == decoder.decoder) {
+        if (&it->second == decoder) {
           it->second.used = false;
           return;
         }
@@ -137,7 +137,7 @@ class NVDECCache {
             it->second.bit_depth_luma_minus8 == bit_depth_luma_minus8) {
           it->second.used = true;
           assert(it->second.device_id == device_id);
-          return NVDECLease(it->second);
+          return NVDECLease(this, &it->second);
         }
       }
       // reconfigure needs ulTargetHeight and ulTargetWidth set to the upper bound of the video
@@ -237,7 +237,7 @@ class NVDECCache {
       decoder_inst.device_id = device_id;
 
       lock.lock();
-      dec_cache.insert({codec_type, decoder_inst});
+      auto inserted = dec_cache.insert({codec_type, decoder_inst});
       if (dec_cache.size() > CACHE_SIZE_LIMIT) {
         for (auto it = dec_cache.begin(); it != dec_cache.end(); ++it) {
           if (it->second.used == false) {
@@ -249,19 +249,21 @@ class NVDECCache {
           }
         }
       }
-      return NVDECLease(decoder_inst);
+      return NVDECLease(this, &inserted->second);
     }
 
-    using codec_map = std::unordered_multimap<cudaVideoCodec, DecInstance>;
+    using codec_map = std::multimap<cudaVideoCodec, DecInstance>;
     codec_map dec_cache;
     std::mutex access_lock;
 
     static constexpr int CACHE_SIZE_LIMIT = 100;
 };
 
-NVDECLease::~NVDECLease() {
-  if (decoder.used) {
-    frame_dec_gpu_impl::NVDECCache::GetCache(decoder.device_id).ReturnDecoder(decoder);
+void NVDECLease::Return() {
+  if (decoder) {
+    owner->ReturnDecoder(decoder);
+    owner = nullptr;
+    decoder = nullptr;
   }
 }
 

--- a/dali/operators/reader/loader/video/frames_decoder_gpu.cc
+++ b/dali/operators/reader/loader/video/frames_decoder_gpu.cc
@@ -157,7 +157,7 @@ class NVDECCache {
         best_match->second.width = width;
         best_match->second.num_decode_surfaces = num_decode_surfaces;
         CUDA_CALL(cuvidReconfigureDecoder(best_match->second.decoder, &reconfigParams));
-        return NVDECLease(best_match->second);
+        return NVDECLease(this, &best_match->second);
       }
 #endif
       lock.unlock();


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

## Category:
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)

## Description:
Use a pointer instead of a copy of a structure in NVDECLease.
Store the pointer to the owning cache object in NVDECLease, so it's returned exactly to the same owner, not to a singleton instance with a matching device_id (this may be useful in tests, should we add more).

## Additional information:

### Affected modules and functionalities:
NVDECCache


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
decoders/test_video

- [X] Existing tests apply
- [ ] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
