### PR TITLE
Avoid signed/unsigned comparison in clamp<S, U>.

### DIFF
--- a/dali/core/convert_test.cc
+++ b/dali/core/convert_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dali/core/convert_test.cc
+++ b/dali/core/convert_test.cc
@@ -45,6 +45,15 @@ TEST(ConvertSat, float2int) {
   }
 }
 
+TEST(ConvertSat, int2int) {
+  EXPECT_EQ((ConvertSat<uint8_t, int8_t>(42)), 42);
+  EXPECT_EQ((ConvertSat<uint8_t, int8_t>(-42)), 0);
+  EXPECT_EQ((ConvertSat<int8_t, uint8_t>(200)), 127);
+  EXPECT_EQ((ConvertSat<int32_t, uint64_t>(0x101234567ull)), 0x7fffffff);
+  EXPECT_EQ((ConvertSat<int64_t, uint64_t>(0xc123456701234567ull)), 0x7fffffffffffffffll);
+  EXPECT_EQ((ConvertSat<int32_t, int64_t>(-0x101234567ull)), int32_t(~0x7fffffff));
+}
+
 TEST(ConvertNorm, int2int) {
   EXPECT_EQ((ConvertNorm<uint8_t, uint8_t>(0)), 0);
   EXPECT_EQ((ConvertNorm<uint8_t, int8_t>(127)), 255);

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/dali/core/convert.h
+++ b/include/dali/core/convert.h
@@ -118,7 +118,11 @@ DALI_HOST_DEV constexpr std::enable_if_t<
     needs_clamp<U, T>::value && std::is_unsigned<U>::value,
     T>
 clamp(U value, ret_type<T>) {
-  return value >= max_value<T>() ? max_value<T>() : static_cast<T>(value);
+  // Note: make the right hand side of the comparison unsigned, silencing warnings
+  // Add U(0) - adding simply 0u is not enough if T is larger than `unsigned`.
+  // U is guaranteed to be at least as large as T or the clamping wouldn't be necessary
+  // and this function would have been disabled by `needs_clamp`.
+  return value >= max_value<T>() + U(0) ? max_value<T>() : static_cast<T>(value);
 }
 
 template <typename T, typename U>


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*code hardening?)


## Description:
There was a comparison which, while correctly handled by default, could trigger a warning and resulted in an error in some builds with `-Werror`. This PR forces the right hand side of the comparison (which could be signed) to unsigned.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [X] Other (comments in the function body)
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
