### PR TITLE
Move IsVideoInput() to operator.cc

### DIFF
--- a/dali/operators/input/video_input.h
+++ b/dali/operators/input/video_input.h
@@ -198,14 +198,6 @@ class VideoInput : public VideoDecoderBase<Backend, FramesDecoder>, public Input
   TensorShape<3> pad_frame_shape_ = {};
 };
 
-
-/**
- * Checks, if the operator described by a given Schema is a VideoInput operator.
- */
-inline bool IsVideoInput(const OpSchema& schema) {
-  return schema.name() == "experimental__inputs__Video";
-}
-
 }  // namespace dali
 
 #endif  // DALI_OPERATORS_INPUT_VIDEO_INPUT_H_

--- a/dali/pipeline/operator/operator.cc
+++ b/dali/pipeline/operator/operator.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "dali/operators/input/video_input.h"
 #include "dali/pipeline/operator/builtin/split_merge.h"
 #include "dali/pipeline/operator/operator.h"
 

--- a/dali/pipeline/operator/operator.cc
+++ b/dali/pipeline/operator/operator.cc
@@ -18,6 +18,17 @@
 
 namespace dali {
 
+namespace {
+
+/**
+ * Checks, if the operator described by a given Schema is a VideoInput operator.
+ */
+inline bool IsVideoInput(const OpSchema &schema) {
+  return schema.name() == "experimental__inputs__Video";
+}
+
+}
+
 template <typename Backend>
 void OperatorBase::EnforceUniformInputBatchSize(const Workspace &ws) const {
   // Builtin operators have relaxed checks for the purpose of conditional execution


### PR DESCRIPTION
Signed-off-by: szalpal <mszolucha@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
In Xavier build, the `libavcodec` does not exist. Therefore, when including `video_input.h` to `operator.cc`, Xavier fired build error. This change moves the only function needed from `video_input.h` in `operator.cc`. Therefore we can remove the `#include` dependency and still build for Xavier.

There's a separate PR for this issue: #4534 . Let's pick one.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
