### PR TITLE
Add `release_unused` function to memory pools.

### DIFF
--- a/dali/core/mm/async_pool_test.cu
+++ b/dali/core/mm/async_pool_test.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,6 +145,9 @@ void AsyncPoolTest(Pool &pool, vector<block> &blocks, Mutex &mtx, CUDAStream &st
   int max_hogs = sync_dist(rng);
   CUDAEvent event = CUDAEvent::Create();
   for (int i = 0; i < max_iters; i++) {
+    if (i == max_iters / 2)
+      pool.release_unused();
+
     if (use_hog && hog_dist(rng)) {
       if (hogs++ > max_hogs) {
         CUDA_CALL(cudaStreamSynchronize(stream));

--- a/dali/core/mm/cuda_vm_resource_test.cc
+++ b/dali/core/mm/cuda_vm_resource_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -208,6 +208,41 @@ class VMResourceTest : public ::testing::Test {
     EXPECT_EQ(region.available_blocks, 3);
   }
 
+
+  void TestReleaseUnused() {
+    cuda_vm_resource res;
+    size_t block_size = 4 << 20;  // 4 MiB;
+    res.block_size_ = block_size;
+    void *p1 = res.allocate(block_size);  // allocate one block
+    void *p2 = res.allocate(block_size);  // allocate another block
+    EXPECT_EQ(res.stat_.allocated_blocks, 2);
+    res.deallocate(p1, block_size);       // now free the first block
+    auto &region = res.va_regions_[0];
+    EXPECT_EQ(region.available_blocks, 1);
+    EXPECT_EQ(region.mapped.find(false), 2);    // 2 mapped blocks
+    EXPECT_EQ(region.available.find(true), 0);  // of which the first is available
+    res.release_unused();
+    EXPECT_EQ(region.available_blocks, 0);
+    EXPECT_EQ(region.mapped.find(false), 0);  // the block was unmapped
+    EXPECT_EQ(region.mapped.find(true), 1);   // but the next one wasn't
+    EXPECT_EQ(res.stat_.allocated_blocks, 1);
+    EXPECT_EQ(res.stat_.peak_allocated_blocks, 2);
+
+    void *p3 = res.allocate(block_size);  // allocate one block
+    EXPECT_EQ(res.stat_.allocated_blocks, 2);
+
+    EXPECT_EQ(p1, p3);
+    res.deallocate(p1, block_size);
+    res.deallocate(p2, block_size);
+    EXPECT_EQ(region.available_blocks, 2);
+    res.release_unused();
+    EXPECT_EQ(region.available_blocks, 0);
+    EXPECT_EQ(region.mapped.find(true), region.mapped.ssize());  // no mapped blocks
+    EXPECT_EQ(res.stat_.allocated_blocks, 0);
+    EXPECT_EQ(res.stat_.peak_allocated_blocks, 2);
+  }
+
+
   void TestExceptionSafety() {
     cudaDeviceProp device_prop;
     CUDA_CALL(cudaGetDeviceProperties(&device_prop, 0));
@@ -291,6 +326,12 @@ TEST_F(VMResourceTest, PartialMap) {
   this->TestPartialMap();
 }
 
+TEST_F(VMResourceTest, ReleaseUnused) {
+  if (!cuvm::IsSupported())
+    GTEST_SKIP() << "CUDA Virtual Memory Management not supported on this platform";
+  this->TestReleaseUnused();
+}
+
 std::string format_size(size_t bytes) {
   std::stringstream ss;
   print(ss, bytes, " bytes");
@@ -347,6 +388,83 @@ TEST_F(VMResourceTest, RandomAllocations) {
       allocation a;
       a.size = std::max(1, std::min(size_dist(rng), 256 << 20));  // Limit to 256 MiB
       a.alignment = 1 << align_dist(rng);
+      auto t0 = perfclock::now();
+      a.ptr = pool.allocate(a.size, a.alignment);
+      auto t1 = perfclock::now();
+      alloc_time += t1 - t0;
+      ASSERT_TRUE(detail::is_aligned(a.ptr, a.alignment));
+      CUDA_CALL(cudaMemset(a.ptr, 0, a.size));
+      CUDA_CALL(cudaDeviceSynchronize());  // wait now so the deallocation timing is not affected
+      allocs.push_back(a);
+    }
+  }
+
+  for (auto &a : allocs) {
+    auto t0 = perfclock::now();
+    pool.deallocate(a.ptr, a.size, a.alignment);
+    auto t1 = perfclock::now();
+    dealloc_time += t1 - t0;
+  }
+  allocs.clear();
+
+  auto stat = pool.get_stat();
+  print(std::cerr,
+    "Total allocations:     ", stat.total_allocations, "\n"
+    "Peak allocations:      ", stat.peak_allocations, "\n"
+    "Average time to allocate:   ", microseconds(alloc_time) / stat.total_allocations, " us\n"
+    "Average time to deallocate: ", microseconds(dealloc_time) / stat.total_deallocations, " us\n"
+    "Peak allocations size: ", format_size(stat.peak_allocated), "\n\n"
+    "Peak allocated blocks: ", stat.peak_allocated_blocks, "\n"
+    "Peak allocated physical size: ", format_size(stat.peak_allocated_blocks * pool.block_size()),
+    "\n"
+    "Unmap operations: ", stat.total_unmaps, "\n"
+    "VA size: ", format_size(stat.allocated_va), "\n");
+
+  EXPECT_EQ(stat.curr_allocated, 0u);
+  EXPECT_EQ(stat.curr_allocations, 0u);
+  EXPECT_EQ(stat.total_allocations, stat.total_deallocations);
+}
+
+
+TEST_F(VMResourceTest, RandomAllocationsWithReleaseUnused) {
+  if (!cuvm::IsSupported())
+    GTEST_SKIP() << "CUDA Virtual Memory Management not supported on this platform";
+
+  cuda_vm_resource pool(-1, 4 << 20);  // use small 4 MiB blocks
+  std::mt19937_64 rng(12345);
+  std::bernoulli_distribution is_free(0.5);
+  auto size_dist = [&](auto &rng)->int {  // 1 to 4 blocks
+    return std::uniform_int_distribution<int>(1, 4)(rng) * pool.block_size();
+  };
+  struct allocation {
+    void *ptr;
+    size_t size, alignment;
+  };
+  std::vector<allocation> allocs;
+
+  int num_iter = 10000;
+
+  std::map<uintptr_t, size_t> allocated;
+
+  perfclock::duration alloc_time = {};
+  perfclock::duration dealloc_time = {};
+
+  for (int i = 0; i < num_iter; i++) {
+    if (i == num_iter / 2)
+      pool.release_unused();
+    if (is_free(rng) && !allocs.empty()) {
+      auto idx = rng() % allocs.size();
+      allocation a = allocs[idx];
+      auto t0 = perfclock::now();
+      pool.deallocate(a.ptr, a.size, a.alignment);
+      auto t1 = perfclock::now();
+      dealloc_time += t1 - t0;
+      std::swap(allocs[idx], allocs.back());
+      allocs.pop_back();
+    } else {
+      allocation a;
+      a.size = std::max(1, std::min(size_dist(rng), 256 << 20));  // Limit to 256 MiB
+      a.alignment = alignof(std::max_align_t);
       auto t0 = perfclock::now();
       a.ptr = pool.allocate(a.size, a.alignment);
       auto t1 = perfclock::now();

--- a/dali/core/mm/pool_resource_test.cc
+++ b/dali/core/mm/pool_resource_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,6 +47,8 @@ void TestPoolResource(int num_iter) {
     std::vector<allocation> allocs;
 
     for (int i = 0; i < num_iter; i++) {
+      if (i == num_iter / 2)
+        pool.release_unused();
       if (is_free(rng) && !allocs.empty()) {
         auto idx = rng() % allocs.size();
         allocation a = allocs[idx];

--- a/include/dali/core/mm/async_pool.h
+++ b/include/dali/core/mm/async_pool.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -100,6 +100,14 @@ class async_pool_resource : public async_memory_resource<Kind> {
    */
   void synchronize() {
     synchronize_impl(true);
+  }
+
+  void release_unused() {
+    std::lock_guard<std::mutex> guard(lock_);
+    synchronize_impl(false);
+    for (auto &kv : stream_free_)
+      free_ready(kv.second);
+    global_pool_.release_unused();
   }
 
  private:

--- a/include/dali/core/mm/async_pool.h
+++ b/include/dali/core/mm/async_pool.h
@@ -102,6 +102,12 @@ class async_pool_resource : public async_memory_resource<Kind> {
     synchronize_impl(true);
   }
 
+  /**
+   * @brief Releases unused upstream memory
+   *
+   * Releases any ready per-stream blocks to the global pool and
+   * calls `release_unused` on it.
+   */
   void release_unused() {
     std::lock_guard<std::mutex> guard(lock_);
     synchronize_impl(false);

--- a/include/dali/core/mm/cuda_vm_resource.h
+++ b/include/dali/core/mm/cuda_vm_resource.h
@@ -143,6 +143,11 @@ class cuda_vm_resource : public memory_resource<memory_kind::device> {
     }
   }
 
+  /**
+   * @brief Releases unused physical blocks
+   *
+   * Releases physical blocks that are currently allocated, but fully available.
+   */
   void release_unused() {
     std::vector<cuvm::CUMem> blocks_to_free;
     {

--- a/include/dali/core/mm/pool_resource.h
+++ b/include/dali/core/mm/pool_resource.h
@@ -135,6 +135,12 @@ class pool_resource_base : public memory_resource<Kind> {
     return options_;
   }
 
+  /**
+   * @brief Releases unused memory to the upstream resource
+   *
+   * If there are completely free upstream blocks, they are returned to upstream.
+   * Partially used blocks remain allocated.
+   */
   void release_unused() {
     upstream_lock_guard uguard(upstream_lock_);
 


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)


## Description:
As per user-request, this adds the functionality necessary to implement memory "garbage collection".
Internally, there are three implementations:
1. Regular pool: go over blocks and free any that are completely covered by free regions. This was already used by the pool to reclaim memory and now has just been exposed.
2. Async pool - frees all pending per-stream free blocks to the global pool and then calls `release_unused` on it.
3. CUDA VM resource - goes over all available blocks in all regions and frees them, releasing the physical blocks and removing them from `free_mapped`. The virtual address space is not a concern and is never freed.

**The relevant changes in public APIs are not in the scope of this PR - it just implements the underlying functionality**

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
Existing pool tests were extended by inserting a call to `release_unused` halfway through the test.
`cuda_vm_resource` received a new test, since this functionality is otherwise not tested, whereas other a regular pool may use `release_unused_impl` to reclaim memory before allocating a new block from upstream..
- [X] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [X] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [X] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: DALI-3170