### PR TITLE
Fix imgcodec fallback and error handling

### DIFF
--- a/dali/imgcodec/image_decoder.cc
+++ b/dali/imgcodec/image_decoder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -665,33 +665,33 @@ void ImageDecoder::InitWorkers(bool lazy_init) {
 void ImageDecoder::move_to_fallback(ScheduledWork *fb,
                                     ScheduledWork &work,
                                     const vector<bool> &keep) {
-    int moved = 0;
+  int moved = 0;
 
-    int n = work.sources.size();
+  int n = work.sources.size();
 
-    for (int i = 0; i < n; i++) {
-      if (keep[i]) {
-        if (moved) {
-          // compact
-          if (!work.cpu_outputs.empty())
-            work.cpu_outputs[i - moved] = std::move(work.cpu_outputs[i]);
-          if (!work.gpu_outputs.empty())
-            work.gpu_outputs[i - moved] = std::move(work.gpu_outputs[i]);
-          if (!work.temp_buffers.empty())
-            work.temp_buffers[i - moved] = std::move(work.temp_buffers[i]);
-          if (!work.rois[i])
-            work.rois[i - moved] = std::move(work.rois[i]);
-          work.sources[i - moved] = work.sources[i];
-          work.indices[i - moved] = work.indices[i];
-        }
-      } else {
-        if (fb)
-          fb->move_entry(work, i);
-        moved++;
+  for (int i = 0; i < n; i++) {
+    if (keep[i]) {
+      if (moved) {
+        // compact
+        if (!work.cpu_outputs.empty())
+          work.cpu_outputs[i - moved] = std::move(work.cpu_outputs[i]);
+        if (!work.gpu_outputs.empty())
+          work.gpu_outputs[i - moved] = std::move(work.gpu_outputs[i]);
+        if (!work.temp_buffers.empty())
+          work.temp_buffers[i - moved] = std::move(work.temp_buffers[i]);
+        if (!work.rois[i])
+          work.rois[i - moved] = std::move(work.rois[i]);
+        work.sources[i - moved] = work.sources[i];
+        work.indices[i - moved] = work.indices[i];
       }
+    } else {
+      if (fb)
+        fb->move_entry(work, i);
+      moved++;
     }
-    if (fb)
-      fb->resize(fb->num_samples() - moved);
+  }
+  if (moved)
+    work.resize(n - moved);
 }
 
 

--- a/dali/operators/imgcodec/decoder.cc
+++ b/dali/operators/imgcodec/decoder.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -323,7 +323,10 @@ void ImgcodecHostDecoder::RunImpl(Workspace &ws) {
   auto results = decoder->Decode(ctx, output, make_span(src_ptrs_), opts_, make_span(rois_));
   for (const auto &result : results) {
     if (!result.success) {
-      std::rethrow_exception(result.exception);
+      if (result.exception)
+        std::rethrow_exception(result.exception);
+      else
+        DALI_FAIL(make_string("Unknown error while decoding ", src_ptrs_[0]->SourceInfo()));
     }
   }
 }
@@ -357,7 +360,10 @@ void ImgcodecMixedDecoder::Run(Workspace &ws) {
   auto results = decoder->Decode(ctx, output, make_span(src_ptrs_), opts_, make_span(rois_));
   for (const auto &result : results) {
     if (!result.success) {
-      std::rethrow_exception(result.exception);
+      if (result.exception)
+        std::rethrow_exception(result.exception);
+      else
+        DALI_FAIL(make_string("Unknown error while decoding ", src_ptrs_[0]->SourceInfo()));
     }
   }
 }

--- a/dali/test/python/decoder/test_imgcodec.py
+++ b/dali/test/python/decoder/test_imgcodec.py
@@ -404,17 +404,3 @@ def test_peek_shape():
         'tiff/0/kitty-2948404_640.tiff', (433, 640, 1), types.GRAY, True
     yield _testimpl_image_decoder_peek_shape, \
         'bmp/0/cat-111793_640_grayscale.bmp', (426, 640, 3), types.RGB, True
-
-def test_lossless():
-    @pipeline_def
-    def my_pipe():
-        files, _ = fn.readers.file(file_root="/home/michalz/Projects/work/lossless_jpeg",
-                                   files=[
-                                        "dicom_2294x1914_16bit.jpg",
-                                        "dicom_3328x4096.jpg",
-                                        "dicom_5928x4728_16bit.jpg"])
-        return fn.experimental.decoders.image(files, device="mixed")
-
-    pipe = my_pipe(batch_size=1, num_threads=1, device_id=0)
-    pipe.build()
-    pipe.run()

--- a/dali/test/python/decoder/test_imgcodec.py
+++ b/dali/test/python/decoder/test_imgcodec.py
@@ -404,3 +404,17 @@ def test_peek_shape():
         'tiff/0/kitty-2948404_640.tiff', (433, 640, 1), types.GRAY, True
     yield _testimpl_image_decoder_peek_shape, \
         'bmp/0/cat-111793_640_grayscale.bmp', (426, 640, 3), types.RGB, True
+
+def test_lossless():
+    @pipeline_def
+    def my_pipe():
+        files, _ = fn.readers.file(file_root="/home/michalz/Projects/work/lossless_jpeg",
+                                   files=[
+                                        "dicom_2294x1914_16bit.jpg",
+                                        "dicom_3328x4096.jpg",
+                                        "dicom_5928x4728_16bit.jpg"])
+        return fn.experimental.decoders.image(files, device="mixed")
+
+    pipe = my_pipe(batch_size=1, num_threads=1, device_id=0)
+    pipe.build()
+    pipe.run()


### PR DESCRIPTION
## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
This PR fixes two issues:
- incorrect resizing of work object in imgcodec aggregating decoder
- attempt to rethrow null exception pointer in imgcodec-based decoder operator

## Additional information:

### Affected modules and functionalities:
- imgcodec decoder

### Tests:
So far no decoder returns `false` from CanDecode, so a test is not possible. It will be added with lossless NVJPEG.

- [ ] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [X] N/A



## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
