### PR TITLE
Fix `rel_shape` length validation in `reshape`

### DIFF
--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -338,6 +338,18 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
         // calculate the volume in all other dimensions
         out_sample_shape[wildcard_dim] = 1;
         auto other_dims_volume = volume(out_sample_shape);
+        if (other_dims_volume == 0) {
+          if (wildcard_dim < input_shape_.sample_dim() &&
+              output_shape_.sample_dim() > input_shape_.sample_dim()) {
+            DALI_FAIL(make_string("Cannot infer the extent of dimension ", wildcard_dim,
+              " for ", output_shape_.sample_dim(), "D output and ", input_shape_.sample_dim(),
+              "D input. Use `src_dims` to achieve more complex "
+              "mapping of input to output dimensions."));
+          } else {
+            DALI_FAIL(make_string("Cannot infer the extent of dimension ", wildcard_dim,
+              " when the volume of remaining dimensions is 0. Input shape: ", input_shape_[i]));
+          }
+        }
         // try to make wildcard dim match the input volume - if it fails,
         // volume comparison will fail
         out_sample_shape[wildcard_dim] = (actual_volume * input_element_size) /

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ class Reshape : public Operator<Backend> {
   void ShapeFromInput(const TensorListLike &tl, bool relative);
 
   template <typename Extent>
-  void ShapeFromInput(const TensorListView<StorageCPU, Extent> &shape);
+  void ShapeFromInput(const TensorListView<StorageCPU, const Extent> &shape);
 
   TensorLayout GetOutputLayout(const Workspace &ws) const;
 };

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -82,11 +82,14 @@ class Reshape : public Operator<Backend> {
   };
   ShapeSource shape_source_ = ShapeSource::None;
 
-  template <typename TensorListLike>
-  void ShapeFromInput(const TensorListLike &tl, bool relative);
+  void ValidateRelativeShapeNDim(int ndim) const;
 
-  template <typename Extent>
-  void ShapeFromInput(const TensorListView<StorageCPU, const Extent> &shape);
+  template <bool relative, typename TensorListLike>
+  void ShapeFromInput(const TensorListLike &tl, std::bool_constant<relative>);
+
+  template <bool relative, typename Extent>
+  void ShapeFromInput(const TensorListView<StorageCPU, const Extent> &shape,
+                      std::bool_constant<relative>);
 
   TensorLayout GetOutputLayout(const Workspace &ws) const;
 };

--- a/dali/test/python/operator_2/test_reshape.py
+++ b/dali/test/python/operator_2/test_reshape.py
@@ -379,7 +379,8 @@ def test_invalid_wildcard():
     pipe = reshape_pipe(batch_size=len(shapes), num_threads=1, device_id=0, shapes=shapes,
                         rel_shape=[1, -1, 1])
     pipe.build()
-    err_glob = "*Cannot infer*dimension 1 for 3D output and 2D input*Use `src_dims`*"
+    err_glob = "*``rel_shape`` has more elements (3) than*dimensions in the input (2)*" \
+               "use ``src_dims``*"
     with assert_raises(RuntimeError, glob=err_glob):
         pipe.run()
 

--- a/dali/test/python/operator_2/test_reshape.py
+++ b/dali/test/python/operator_2/test_reshape.py
@@ -352,6 +352,9 @@ def test_reshape_src_dims_arg():
     ]
     for src_dims, rel_shape, shapes, expected_out_shapes in args:
         yield _testimpl_reshape_src_dims_arg, src_dims, rel_shape, shapes, expected_out_shapes
+        if rel_shape is not None:
+            shape_inp = fn.constant(fdata=rel_shape, dtype=types.FLOAT)
+            yield _testimpl_reshape_src_dims_arg, src_dims, shape_inp, shapes, expected_out_shapes
 
 
 def test_reshape_src_dims_throw_error():


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)


## Description:
Bug 1: Prior to this change, `reshape` and `reinterpet` could access out-of-bounds memory when using rel_shape that was larger than the number of dimensions in the input (or src_dims, if used). It could lead to access violation, division by 0 or other hard errors.
Bug 2: Prior to this change, if the shape/rel_shape argument is a tensor, src_dims was not used for reindexing.

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
