### PR TITLE
Clear operator traces before launching the operator

### DIFF
--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -300,6 +300,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunHelper(OpNode &op_node, Workspac
   SmallVector<int, 16> empty_layout_in_idxs;
 
   ws.InjectOperatorTraces(GetCurrentIterationData(iteration_id).operator_traces);
+  ws.ClearOperatorTraces();
 
   auto ws_order = ws.has_stream() ? AccessOrder(ws.stream()) : AccessOrder::host();
 

--- a/dali/pipeline/workspace/workspace.h
+++ b/dali/pipeline/workspace/workspace.h
@@ -590,6 +590,27 @@ class WorkspaceBase : public ArgumentWorkspace {
   }
 
 
+  /**
+   * Erase the trace value for the current operator.
+   *
+   * Typically, this function shall be called by an operator in RunImpl or SetupImpl.
+   *
+   * @see operator_trace_map_t
+   */
+  DLL_PUBLIC void EraseOperatorTrace(const std::string &trace_key) {
+    (*operator_traces_)[GetOperatorInstanceName()].erase(trace_key);
+  }
+
+
+  /**
+   * Erase all the trace values for the current operator.
+   *
+   * @see operator_trace_map_t
+   */
+  DLL_PUBLIC void ClearOperatorTraces() {
+    (*operator_traces_)[GetOperatorInstanceName()].clear();
+  }
+
 
   /**
    * Get the trace map for a given operator.


### PR DESCRIPTION
Signed-off-by: szalpal <mszolucha@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**New feature** (*non-breaking change which adds functionality*)

## Description:
Since the operator traces are per-iteration, keeping traces from iteration to iteration is useless. Therefore, we may clear them before the operator launch, so that the operator itself wouldn't need to worry about trace leftovers from previous iterations.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [x] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
