### PR TITLE
Support inferring batch size from tensor argument inputs

### DIFF
--- a/dali/pipeline/executor/executor.cc
+++ b/dali/pipeline/executor/executor.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,24 @@
 #include "dali/pipeline/executor/source_info_propagation.h"
 
 namespace dali {
+
+/**
+ * @brief Takes the batch size from any of the op's tensor inputs.
+ *
+ * If no inputs were specified, a batch size inferred from
+ * the stage queue is used instead.
+ */
+inline int InferBatchSizeFromInput(const Workspace &ws, int stage_batch_size) {
+  if (ws.NumInput() > 0) {
+    return ws.GetInputBatchSize(0);
+  }
+  const ArgumentWorkspace &argument_ws = ws;
+  if (begin(argument_ws) != end(argument_ws)) {
+    auto [name, arg] = *begin(argument_ws);
+    return arg.tvec->num_samples();
+  }
+  return stage_batch_size;
+}
 
 template <typename WorkspacePolicy, typename QueuePolicy>
 void Executor<WorkspacePolicy, QueuePolicy>::PreRun() {
@@ -97,7 +115,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunCPUImpl(size_t iteration_id) {
     return;
   }
 
-  auto batch_size = batch_sizes_cpu_.front();
+  int stage_batch_size = batch_sizes_cpu_.front();
   batch_sizes_cpu_.pop();
 
   // Run the cpu-ops in the thread
@@ -106,6 +124,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunCPUImpl(size_t iteration_id) {
     OpNode &op_node = graph_->Node(OpType::CPU, cpu_op_id);
     decltype(auto) ws = ws_policy_.template GetWorkspace<OpType::CPU>(cpu_idxs, *graph_, cpu_op_id);
 
+    int batch_size = InferBatchSizeFromInput(ws, stage_batch_size);
     ws.SetBatchSizes(batch_size);
 
     DomainTimeRange tr("[DALI][CPU op] " + op_node.instance_name, DomainTimeRange::kBlue1);
@@ -143,7 +162,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunMixedImpl(size_t iteration_id) {
   if (device_id_ != CPU_ONLY_DEVICE_ID)
     CUDA_CALL(cudaEventSynchronize(mixed_stage_event_));
 
-  auto batch_size = batch_sizes_mixed_.front();
+  int stage_batch_size = batch_sizes_mixed_.front();
   batch_sizes_mixed_.pop();
 
   for (int i = 0; i < graph_->NumOp(OpType::MIXED) && !exec_error_; ++i) {
@@ -151,6 +170,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunMixedImpl(size_t iteration_id) {
     try {
       decltype(auto) ws = ws_policy_.template GetWorkspace<OpType::MIXED>(mixed_idxs, *graph_, i);
 
+      int batch_size = InferBatchSizeFromInput(ws, stage_batch_size);
       ws.SetBatchSizes(batch_size);
 
       DomainTimeRange tr("[DALI][Mixed op] " + op_node.instance_name, DomainTimeRange::kOrange);
@@ -208,7 +228,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunGPUImpl(size_t iteration_id) {
   // iterations of a stage of the pipeline.
   CUDA_CALL(cudaEventSynchronize(gpu_stage_event_));
 
-  auto batch_size = batch_sizes_gpu_.front();
+  int stage_batch_size = batch_sizes_gpu_.front();
   batch_sizes_gpu_.pop();
 
   for (int i = 0; i < graph_->NumOp(OpType::GPU) && !exec_error_; ++i) {
@@ -216,6 +236,7 @@ void Executor<WorkspacePolicy, QueuePolicy>::RunGPUImpl(size_t iteration_id) {
     try {
       decltype(auto) ws = ws_policy_.template GetWorkspace<OpType::GPU>(gpu_idxs, *graph_, i);
 
+      int batch_size = InferBatchSizeFromInput(ws, stage_batch_size);
       ws.SetBatchSizes(batch_size);
 
       auto parent_events = ws.ParentEvents();


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:s
**New feature** (*non-breaking change which adds functionality*)

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
This PR updates the way executor sets requested batch size. If there are any inputs available, executor assumes the operator expected uniform batch sizes across inputs and outputs and sets requested batch size to any tensor input it can find: either positional or named (argument input). Otherwise, if there are none avialable, the stage queue batch size is used.

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

The common patern introduced with the end2end variable batch size was to look at the regular inputs or, if there were none, resort to `GetRequestedBatchSize`. This PR moves that behaviour to the executor and includes named arguments in the search of batch before resorting to stage batch size. @klecki  updated the autograph layer to reflect that by appropriate "hoisting" of the splits here https://github.com/NVIDIA/DALI/pull/4618

### Affected modules and functionalities:
The regular usages of the operators should not see any difference.



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
