### PR TITLE
Fix classification of argument input-only operators in AutoGraph

### DIFF
--- a/dali/python/nvidia/dali/ops.py
+++ b/dali/python/nvidia/dali/ops.py
@@ -669,7 +669,7 @@ def python_op_factory(name, schema_name=None):
             if _conditionals.conditionals_enabled():
                 if len(op_instances) != 1:
                     raise ValueError("Multiple input sets are not supported with conditionals.")
-                _conditionals.register_data_nodes(result, input_sets[0])
+                _conditionals.register_data_nodes(result, input_sets[0], kwargs)
             return result
 
         # Check if any of inputs is a list

--- a/dali/test/python/conditionals/test_pipeline_conditionals.py
+++ b/dali/test/python/conditionals/test_pipeline_conditionals.py
@@ -535,6 +535,81 @@ def test_dot_gpu():
     compare_pipelines(*pipes, bs, iters)
 
 
+# Test if operators without positional inputs but with argument inputs are correctly handled
+# in the split/merge - so they are tracked in the local scope.
+
+
+def test_arg_inputs_scoped_tracking():
+    test_data_root = get_dali_extra_path()
+    caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
+
+    bs = 10
+    iters = 5
+    kwargs = {"batch_size": bs, "num_threads": 4, "device_id": 0, "seed": 42}
+
+    @experimental.pipeline_def(enable_conditionals=True, **kwargs)
+    def global_transform_pipe():
+        encoded, _ = fn.readers.caffe(path=caffe_db_folder)
+        decoded = fn.decoders.image(encoded, device="mixed")
+        pred = fn.random.coin_flip(dtype=types.DALIDataType.BOOL)
+        angle = fn.random.uniform(values=[10, 20, 30])
+        rotate_transform = fn.transforms.rotation(angle=angle)
+        if pred:
+            output = fn.warp_affine(decoded, matrix=rotate_transform)
+        else:
+            output = decoded
+        return output
+
+    @experimental.pipeline_def(enable_conditionals=True, **kwargs)
+    def scoped_transform_pipe():
+        encoded, _ = fn.readers.caffe(path=caffe_db_folder)
+        decoded = fn.decoders.image(encoded, device="mixed")
+        pred = fn.random.coin_flip(dtype=types.DALIDataType.BOOL)
+        angle = fn.random.uniform(values=[10, 20, 30])
+        if pred:
+            # This is the crux of the test, the transforms.rotate has no positional inputs,
+            # but it has a DataNode argument input - it should detect it as produced in this scope.
+            rotate_transform = fn.transforms.rotation(angle=angle)
+            output = fn.warp_affine(decoded, matrix=rotate_transform)
+        else:
+            output = decoded
+        return output
+
+    pipes = [global_transform_pipe(), scoped_transform_pipe()]
+    for pipe in pipes:
+        pipe.build()
+    compare_pipelines(*pipes, bs, iters)
+
+
+def test_arg_inputs_scoped_uninitialized():
+    test_data_root = get_dali_extra_path()
+    caffe_db_folder = os.path.join(test_data_root, 'db', 'lmdb')
+    bs = 10
+    kwargs = {"batch_size": bs, "num_threads": 4, "device_id": 0}
+
+    @experimental.pipeline_def(enable_conditionals=True, **kwargs)
+    def scoped_transform_pipe():
+        encoded, _ = fn.readers.caffe(path=caffe_db_folder)
+        decoded = fn.decoders.image(encoded, device="mixed")
+        pred = fn.random.coin_flip(dtype=types.DALIDataType.BOOL)
+        angle = fn.random.uniform(values=[10, 20, 30])
+        if pred:
+            rotate_transform = fn.transforms.rotation(angle=angle)
+            output = fn.warp_affine(decoded, matrix=rotate_transform)
+        else:
+            output = decoded
+        # Check that the rotate_transform is indeed local to the branch by trying to return it
+        # and generating uninitialized error.
+        return output, rotate_transform
+
+    with assert_raises(
+            RuntimeError, glob=("Encountered inconsistent outputs out of the `if/else` control flow"
+                                " statement. Variables need to be initialized in every code path"
+                                " (both `if` branches). Variable 'rotate_transform' must also be"
+                                " initialized in the `else` branch.")):
+        scoped_transform_pipe()
+
+
 # Unified return tests - TODO(klecki)
 
 # Generator tests, remove the random predicate to test the same predicate in both pipelines.

--- a/dali/test/python/conditionals/test_pipeline_conditionals.py
+++ b/dali/test/python/conditionals/test_pipeline_conditionals.py
@@ -551,8 +551,8 @@ def test_arg_inputs_scoped_tracking():
     def global_transform_pipe():
         encoded, _ = fn.readers.caffe(path=caffe_db_folder)
         decoded = fn.decoders.image(encoded, device="mixed")
-        pred = fn.random.coin_flip(dtype=types.DALIDataType.BOOL)
-        angle = fn.random.uniform(values=[10, 20, 30])
+        pred = fn.random.coin_flip(dtype=types.DALIDataType.BOOL, seed=6)
+        angle = fn.random.uniform(values=[10, 20, 30], seed=7)
         rotate_transform = fn.transforms.rotation(angle=angle)
         if pred:
             output = fn.warp_affine(decoded, matrix=rotate_transform)
@@ -564,8 +564,8 @@ def test_arg_inputs_scoped_tracking():
     def scoped_transform_pipe():
         encoded, _ = fn.readers.caffe(path=caffe_db_folder)
         decoded = fn.decoders.image(encoded, device="mixed")
-        pred = fn.random.coin_flip(dtype=types.DALIDataType.BOOL)
-        angle = fn.random.uniform(values=[10, 20, 30])
+        pred = fn.random.coin_flip(dtype=types.DALIDataType.BOOL, seed=6)
+        angle = fn.random.uniform(values=[10, 20, 30], seed=7)
         if pred:
             # This is the crux of the test, the transforms.rotate has no positional inputs,
             # but it has a DataNode argument input - it should detect it as produced in this scope.


### PR DESCRIPTION
<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category: **Bug fix**
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Follow up for the #4617. 
Currently, an operator without inputs is considered a generator and is registered in the global scope - it will always produce full batch, and each use will insert appropriate split nodes - as there is no way of signaling the requested batch size from the pipeline definition level and some generators do not support variable batch size at all.
Some operators can have 0 positional inputs while having some argument inputs. Now they would be classified as generator and relegated to the global scope.
Include detection of argument inputs when registering the outputs of the operator - if the operator has any input or *argument input* it can detect the batch size of the input and infer the size of the output. This makes it usable in an `if` scope and doesn't require placing such operators in global scope. Placing them in the global scope results in unnecessary splits to be inserted, even though the produced batch size is correct for given scope.

## Additional information:

### Affected modules and functionalities:
Conditionals/AutoGraph


### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [x] New tests added
  - [x] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
