### PR TITLE
Fix sanitizer error: memory & pipeline leaks

### DIFF
--- a/dali/c_api/c_api.cc
+++ b/dali/c_api/c_api.cc
@@ -702,6 +702,7 @@ void daliDeletePipeline(daliPipelineHandle* pipe_handle) {
   dali::Pipeline *pipeline = reinterpret_cast<dali::Pipeline *>(pipe_handle->pipe);
   dali::Workspace *ws = reinterpret_cast<dali::Workspace *>(pipe_handle->ws);
   auto *bs_map = reinterpret_cast<batch_size_map_t *>(pipe_handle->batch_size_map);
+  auto *di_map = reinterpret_cast<data_id_map_t *>(pipe_handle->data_id_map);
   DALI_ENFORCE(pipeline != nullptr && ws != nullptr, "Pipeline already deleted");
   if (pipe_handle->copy_stream) {
     CUDA_CALL(cudaStreamSynchronize(pipe_handle->copy_stream));
@@ -711,9 +712,11 @@ void daliDeletePipeline(daliPipelineHandle* pipe_handle) {
   delete ws;
   delete pipeline;
   delete bs_map;
+  delete di_map;
   pipe_handle->ws = nullptr;
   pipe_handle->pipe = nullptr;
   pipe_handle->batch_size_map = nullptr;
+  pipe_handle->data_id_map = nullptr;
 }
 
 void daliLoadLibrary(const char* lib_path) {

--- a/dali/operators/input/video_input_test.cc
+++ b/dali/operators/input/video_input_test.cc
@@ -225,6 +225,7 @@ TEST_F(VideoInputNextOutputDataIdTest, VideoInputNextOutputDataIdTest) {
   daliDeserializeDefault(&h, serialized_pipeline_.c_str(),
                          static_cast<int>(serialized_pipeline_.length()));
   DoTest(&h, 0);
+  daliDeletePipeline(&h);
 }
 
 
@@ -237,6 +238,7 @@ TEST_F(VideoInputNextOutputDataIdTest, OneInputFileSplitUniformlyTest) {
   daliDeserializeDefault(&h, serialized_pipeline_.c_str(),
                          static_cast<int>(serialized_pipeline_.length()));
   DoTest(&h, 1);
+  daliDeletePipeline(&h);
 }
 
 
@@ -250,6 +252,7 @@ TEST_F(VideoInputNextOutputDataIdTest, OneInputFileSplitUniformlyNoDataIdTest) {
   daliDeserializeDefault(&h, serialized_pipeline_.c_str(),
                          static_cast<int>(serialized_pipeline_.length()));
   DoTest(&h, 2);
+  daliDeletePipeline(&h);
 }
 
 
@@ -262,6 +265,7 @@ TEST_F(VideoInputNextOutputDataIdTest, TwoInputFilesSeparatedTest) {
                          static_cast<int>(serialized_pipeline_.length()));
   DoTest(&h, 0);
   DoTest(&h, 2);
+  daliDeletePipeline(&h);
 }
 
 
@@ -274,6 +278,7 @@ TEST_F(VideoInputNextOutputDataIdTest, TwoInputFilesSeparatedTest2) {
                          static_cast<int>(serialized_pipeline_.length()));
   DoTest(&h, 2);
   DoTest(&h, 1);
+  daliDeletePipeline(&h);
 }
 
 
@@ -289,6 +294,7 @@ TEST_F(VideoInputNextOutputDataIdTest, MultipleFilesSeparatedTest) {
   DoTest(&h, 2);
   DoTest(&h, 0);
   DoTest(&h, 2);
+  daliDeletePipeline(&h);
 }
 
 
@@ -345,6 +351,7 @@ TEST_F(VideoInputNextOutputDataIdTest, MultipleInputFilesParallelTest) {
   daliRun(&h);
   daliOutput(&h);
   EXPECT_EQ(daliHasOperatorTrace(&h, video_input_name_.c_str(), trace_name_.c_str()), 0);
+  daliDeletePipeline(&h);
 }
 
 }  // namespace dali::test


### PR DESCRIPTION
Signed-off-by: szalpal <mszolucha@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->
This PR fixes an error found by a sanitizer. There was a `data_id_map` leak, since it has not been deleted properly. Also, in one test, DALI Pipeline has not been destroyed properly.


## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
