### PR TITLE
Make sure that ulMaxWidth is aligned to 32 bytes in the video decoder

### DIFF
--- a/dali/operators/reader/loader/video_loader.h
+++ b/dali/operators/reader/loader/video_loader.h
@@ -318,8 +318,8 @@ class VideoLoader : public Loader<GPUBackend, SequenceWrapper> {
                                                image_type_,
                                                dtype_,
                                                normalized_,
-                                               ALIGN16(max_height_),
-                                               ALIGN16(max_width_),
+                                               ALIGN32(max_height_),
+                                               ALIGN32(max_width_),
                                                additional_decode_surfaces_);
 
     if (shuffle_) {

--- a/dali/operators/reader/nvdecoder/nvdecoder.cc
+++ b/dali/operators/reader/nvdecoder/nvdecoder.cc
@@ -502,7 +502,7 @@ NvDecoder::get_textures(uint8_t* input, unsigned int input_pitch,
 
 void NvDecoder::convert_frame(const MappedFrame& frame, SequenceWrapper& sequence,
                               int index) {
-  auto input_width = ALIGN16(decoder_.width());
+  auto input_width = ALIGN32(decoder_.width());
   auto input_height = decoder_.height();
 
   auto output_idx = index;

--- a/dali/operators/reader/nvdecoder/nvdecoder.h
+++ b/dali/operators/reader/nvdecoder/nvdecoder.h
@@ -47,7 +47,7 @@ struct AVCodecContext;
 using CodecParameters = AVCodecContext;
 #endif
 
-#define ALIGN16(value) ((((value) + 15) >> 4) << 4)
+#define ALIGN32(value) ((((value) + 31) >> 5) << 5)
 
 namespace dali {
 


### PR DESCRIPTION
- when the video decoder instance is created the ulMaxWidth should
  be aligned to 32 instead of 16

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>

Related to https://github.com/NVIDIA/DALI/issues/4620

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- when the video decoder instance is created the ulMaxWidth should
  be aligned to 32 instead of 16

<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- dali/operators/reader/loader/video_loader.h
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - all video tests
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
