### PR TITLE
`reshape`: restore the support for trailing wildcard in `rel_shape`

### DIFF
--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -61,6 +61,7 @@ For example, an input of shape ``[480, 640, 3]`` and a ``rel_shape = [0.5, -1]``
 the output shape ``[240, 3840]``.
 
 The number of dimensions is subject to the following restrictions:
+
 - if ``src_dims`` argument is used, the number of elements in ``src_dims``
   and ``rel_shape`` must match
 - otherwise, the length of ``rel_shape`` must not exceed the number of dimensions in the input

--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -31,7 +31,7 @@ The buffer contents are not copied.)code")
   .NumInput(1, 2)
   .NumOutput(1)
   .InputDox(0, "data", "TensorList", "Data to be reshaped")
-  .InputDox(1, "shape_input", "1D TensorList of integers", "Same as `shape` keyword argument")
+  .InputDox(1, "shape_input", "1D TensorList of integers", "Same as ``shape`` keyword argument")
   .PassThrough({{0, 0}})
   .AllowSequences()
   .SupportVolumetric()
@@ -47,7 +47,7 @@ results in the output shape ``[240, 3840]``.
                   std::vector<int>(), true)
   .AddOptionalArg<float>("rel_shape", R"code(The relative shape of the output.
 
-The output shape is calculated by multiplying the input shape by `rel_shape`::
+The output shape is calculated by multiplying the input shape by ``rel_shape``::
 
   out_shape[i] = in_shape[i] * rel_shape[i]
 
@@ -61,14 +61,14 @@ For example, an input of shape ``[480, 640, 3]`` and a ``rel_shape = [0.5, -1]``
 the output shape ``[240, 3840]``.
 
 The number of dimensions is subject to the following restrictions:
-- if `src_dims` argument is used, the number of elements in `src_dims`
-  and `rel_shape` must match
-- otherwise, the length of `rel_shape` must not exceed the number of dimensions in the input
-  except when the last element in `rel_shape` is negative, in which case an extra dimension at
+- if ``src_dims`` argument is used, the number of elements in ``src_dims``
+  and ``rel_shape`` must match
+- otherwise, the length of ``rel_shape`` must not exceed the number of dimensions in the input
+  except when the last element in ``rel_shape`` is negative, in which case an extra dimension at
   the end will be added
 
 .. note::
-  `rel_shape` and `shape` are mutually exclusive.
+  ``rel_shape`` and ``shape`` are mutually exclusive.
 )code",
                   std::vector<float>(), true)
   .AddOptionalArg("layout", R"code(New layout for the data.
@@ -88,7 +88,7 @@ argument ``[-1, 1, 0]`` produces an output shape ``[1, 200, 300]``. A leading di
 extent 1 is inserted at the beginning, followed by the first original dimensions but in reverse
 order. The last dimension is removed.
 
-The `src_dims` argument can be used together with `rel_shape`, in which case the relative
+The ``src_dims`` argument can be used together with `rel_shape`, in which case the relative
 extents in `rel_shape` describe to the target dimensions. In the example above, specifying
 ``rel_shape = [-1, 0.5, 2]`` would result in the output shape ``[1, 100, 600]``.
 
@@ -102,7 +102,7 @@ The buffer contents are not copied.)")
   .NumInput(1, 2)
   .NumOutput(1)
   .InputDox(0, "data", "TensorList", "Data to be reshaped")
-  .InputDox(1, "shape_input", "1D TensorList of integers", "Same as `shape` keyword argument")
+  .InputDox(1, "shape_input", "1D TensorList of integers", "Same as ``shape`` keyword argument")
   .PassThrough({{0, 0}})
   .AllowSequences()
   .SupportVolumetric()
@@ -239,15 +239,15 @@ void Reshape<Backend>::ValidateRelativeShapeNDim(int ndim, bool last_dim_inferre
   if (use_src_dims_) {
     if (ndim + 0_uz != src_dims_.size()) {
       DALI_FAIL(make_string(
-        "``src_dims`` and ``rel_shape`` have different lengths: ",
+        "`src_dims` and `rel_shape` have different lengths: ",
         src_dims_.size(), " vs ", ndim));
     }
   } else {
     if (ndim > input_shape_.sample_dim() + last_dim_inferred) {
       DALI_FAIL(make_string(
-        "``rel_shape`` has more elements (", ndim, ") than "
+        "`rel_shape` has more elements (", ndim, ") than "
         "there are dimensions in the input (", input_shape_.sample_dim(), "). "
-        "To add new dimensions, use ``src_dims`` to specify the mapping between "
+        "To add new dimensions, use `src_dims` to specify the mapping between "
         "input and output dimensions."));
     }
   }
@@ -505,9 +505,9 @@ void Reshape<Backend>::CheckSrcDims(const Workspace &ws) {
   const int ndim = input_shape.sample_dim();
   for (size_t d = 0; d < src_dims_.size(); d++) {
     DALI_ENFORCE(-1 <= src_dims_[d] && src_dims_[d] < ndim,
-      make_string("``src_dims[", d, "]`` == ", src_dims_[d], " is out of bounds.\n"
-      "The indices in ``src_dims`` should be either valid dimension indices in "
-      "range [0..", ndim-1, "] or -1 to insert a new dimension."));
+      make_string("`src_dims[", d, "] == ", src_dims_[d], "` is out of bounds.\n"
+        "The indices in `src_dims` should be either valid dimension indices in "
+        "range [0..", ndim-1, "] or -1 to insert a new dimension."));
   }
 }
 

--- a/dali/operators/generic/reshape.h
+++ b/dali/operators/generic/reshape.h
@@ -82,7 +82,7 @@ class Reshape : public Operator<Backend> {
   };
   ShapeSource shape_source_ = ShapeSource::None;
 
-  void ValidateRelativeShapeNDim(int ndim) const;
+  void ValidateRelativeShapeNDim(int ndim, bool last_dim_inferred) const;
 
   template <bool relative, typename TensorListLike>
   void ShapeFromInput(const TensorListLike &tl, std::bool_constant<relative>);

--- a/dali/test/python/operator_2/test_reshape.py
+++ b/dali/test/python/operator_2/test_reshape.py
@@ -363,7 +363,7 @@ def test_reshape_src_dims_arg():
      r"The volume of the new shape should match the one of the original shape\. "
      r"Requested a shape with \d* elements but the original shape has \d* elements\."),
     ([2, 0, 1], [1, -1], [[1, 2, 3]],
-     r"``src_dims`` and ``rel_shape`` have different lengths: \d* vs \d*"),
+     r"`src_dims` and `rel_shape` have different lengths: \d* vs \d*"),
     ([0, 1, 3], None, [1, 2, 3], ".*is out of bounds.*"),
 )
 def test_reshape_src_dims_throw_error(src_dims, rel_shape, shapes, err_regex):
@@ -391,8 +391,8 @@ def test_invalid_wildcard(rel_shape):
     pipe = reshape_pipe(batch_size=len(shapes), num_threads=1, device_id=0, shapes=shapes,
                         rel_shape=rel_shape)
     pipe.build()
-    err_glob = "*``rel_shape`` has more elements (3) than*dimensions in the input (2)*" \
-               "use ``src_dims``*"
+    err_glob = "*`rel_shape` has more elements (3) than*dimensions in the input (2)*" \
+               "use `src_dims`*"
     with assert_raises(RuntimeError, glob=err_glob):
         pipe.run()
 

--- a/dali/test/python/operator_2/test_reshape.py
+++ b/dali/test/python/operator_2/test_reshape.py
@@ -374,6 +374,17 @@ def test_reshape_src_dims_throw_error(src_dims, rel_shape, shapes, err_regex):
         pipe.run()
 
 
+@params([1, 1, -1], np.float32([1, 1, -1]))
+def test_trailing_wildcard(rel_shape):
+    shapes = [[480, 640], [320, 240]]
+    pipe = reshape_pipe(batch_size=len(shapes), num_threads=1, device_id=0, shapes=shapes,
+                        rel_shape=rel_shape)
+    pipe.build()
+    out, = pipe.run()
+    assert out[0].shape() == [480, 640, 1]
+    assert out[1].shape() == [320, 240, 1]
+
+
 @params([1, -1, 1], np.float32([1, -1, 1]))
 def test_invalid_wildcard(rel_shape):
     shapes = [[480, 640], [320, 240]]


### PR DESCRIPTION
Signed-off-by: Michal Zientkiewicz <michalz@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)


## Description:
There was a buggy and undocumented feature that allowed the user to specify rel_shape that exceeded the input dimensionality provided that the last element was a wildcard (<0). This PR restores and documents that behavior and adds proper validation (i.e. it will fail if the trailing dim is not <0, but for that special case the old behavior is preserved).

## Additional information:

### Affected modules and functionalities:
`reshape` operator



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [X] New tests added
  - [X] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [X] Documentation updated
  - [X] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
