### PR TITLE
Fix @autoserialize problem with unknown module

### DIFF
--- a/dali/python/nvidia/dali/_utils/autoserialize.py
+++ b/dali/python/nvidia/dali/_utils/autoserialize.py
@@ -32,7 +32,7 @@ def _discover_autoserialize(module, visited):
     ret = []
     try:
         module_members = inspect.getmembers(module)
-    except ModuleNotFoundError as e:
+    except ModuleNotFoundError:
         # If any module can't be inspected, DALI will not be able to find the @autoserialize
         # anyway. We can just skip this module.
         return ret

--- a/dali/python/nvidia/dali/_utils/autoserialize.py
+++ b/dali/python/nvidia/dali/_utils/autoserialize.py
@@ -30,7 +30,12 @@ def _discover_autoserialize(module, visited):
     """
     assert module is not None
     ret = []
-    module_members = inspect.getmembers(module)
+    try:
+        module_members = inspect.getmembers(module)
+    except ModuleNotFoundError as e:
+        # If any module can't be inspected, DALI will not be able to find the @autoserialize
+        # anyway. We can just skip this module.
+        return ret
     modules = []
     for name, path in module_members:
         obj = getattr(module, name, None)

--- a/dali/test/python/autoserialize_test/custom_module_inside.py
+++ b/dali/test/python/autoserialize_test/custom_module_inside.py
@@ -1,0 +1,9 @@
+from nvidia.dali.plugin.triton import autoserialize
+from nvidia.dali import pipeline_def
+
+
+@autoserialize
+@pipeline_def(batch_size=1, num_threads=1, device_id=0)
+def func_under_test():
+    import numpy as np  # noqa: F401
+    return 42

--- a/dali/test/python/test_triton_autoserialize.py
+++ b/dali/test/python/test_triton_autoserialize.py
@@ -38,3 +38,8 @@ def test_double_decorated_functions():
 def test_improper_decorated_function():
     from autoserialize_test import improper_decorated_function
     invoke_autoserialize(improper_decorated_function, serialized_filename)
+
+
+def test_custom_module():
+    from autoserialize_test import custom_module_inside
+    invoke_autoserialize(custom_module_inside, serialized_filename)


### PR DESCRIPTION
Signed-off-by: szalpal <mszolucha@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
When `autograph` has been introduced to DALI, we've faced the problem with autoserialization. Turns out, that `autograph` in runtime swaps the modules using `six` - probably to maintain compatibility between Python2 and Python3. Therefore, when traversing the module tree in search for `@autoserialize` decorator, inspect has not been able to find some modules and was prompting an error.

The solution is that if given module is unavailable, it is not traversed any more. DALI won't be able to retrieve `@autoserialize` from there anyhow, so no harm done.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
