### PR TITLE
`reshape`: Prevent out-of-bounds access with trailing wildcard in `rel_shape`

### DIFF
--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -344,9 +344,10 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
         output_shape_.resize(N, rel_uniform_shape_.size());
         for (int i = 0; i < N; i++) {
           for (int d = 0; d < output_shape_.sample_dim(); d++) {
-            int src_d = use_src_dims_ ? src_dims_[d] : d;
+            int src_d = use_src_dims_ ? src_dims_[d]
+                                      : rel_uniform_shape_[d] < 0 ? -1 : d;
             int out_e = round_int(rel_uniform_shape_[d] *
-              (src_d == -1 ? 1 : input_shape_.tensor_shape_span(i)[src_d]));
+              (src_d < 0 ? 1 : input_shape_.tensor_shape_span(i)[src_d]));
             output_shape_.tensor_shape_span(i)[d] = out_e;
           }
         }

--- a/dali/operators/generic/reshape.cc
+++ b/dali/operators/generic/reshape.cc
@@ -377,7 +377,7 @@ void Reshape<Backend>::CalculateOutputShape(const Workspace &ws) {
         for (size_t d = 0; d < src_dims_.size(); d++) {
           const int src_d = src_dims_[d];
           output_shape_.tensor_shape_span(i)[d] =
-            src_d == -1 ? 1 : input_shape_.tensor_shape_span(i)[src_d];
+            src_d < 0 ? 1 : input_shape_.tensor_shape_span(i)[src_d];
         }
         DALI_ENFORCE(
           output_shape_.tensor_size(i) == input_shape_.tensor_size(i),


### PR DESCRIPTION

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Bug fix** (*non-breaking change which fixes an issue*)

## Description:
The input shape was accessed out-of-bounds by 1 element when rel_shape with a trailing wildcard was used to expand the shape.
TL;DR
```
in_shape  = [480, 640]   X out of bounds
                         ^
                         ^
rel_shape = [  1,   1,  -1]

out_shape = [480, 640,   1]  <--- expected output shape
```
This PR changes the code so that the source shape isn't even accessed at indices with a wildcard dimension (other than for calculating the total volume).

## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
Tested the old code and the new code in Valgrind - the issue was reproduced and the new code fixes it.
- [X] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [X] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
