### PR TITLE
Allow 1-off GPU vs CPU discrepancies in the equalize op

### DIFF
--- a/dali/kernels/imgproc/color_manipulation/equalize/lut_test.cc
+++ b/dali/kernels/imgproc/color_manipulation/equalize/lut_test.cc
@@ -49,7 +49,9 @@ class EqualizeLutGpuTest : public ::testing::Test {
     auto out_view_cpu = out_.cpu(cuda_stream);
     CUDA_CALL(cudaStreamSynchronize(cuda_stream));
     auto baseline_view = baseline_.cpu();
-    Check(out_view_cpu, baseline_view);
+    // there may be rounding discrepancies as computation is carried with doubles
+    // then converted to uint8's, thus the `EqualEps(1)`
+    Check(out_view_cpu, baseline_view, EqualEps(1));
   }
 
   void RandomUniformHist(std::vector<std::vector<int>> num_leading_zeros_per_channel) {

--- a/dali/test/python/operator_2/test_equalize.py
+++ b/dali/test/python/operator_2/test_equalize.py
@@ -66,4 +66,4 @@ def test_image_pipeline(layout, batch_size):
         imgs = [np.array(img) for img in imgs.as_cpu()]
         assert len(equalized) == len(imgs)
         baseline = [equalize_cv_baseline(img, layout) for img in imgs]
-        check_batch(equalized, baseline)
+        check_batch(equalized, baseline, max_allowed_error=1)


### PR DESCRIPTION
Signed-off-by: Kamil Tokarski <ktokarski@nvidia.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** / **Bug fix**

<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Allow for 1 off discrepancies in the lookup table construction kernel, as it uses doubles as the intermediate step that are then converted to uint8s. If there are disrepancies in the lookup table, they can propagate to the end result, so I adjusted the python tests accordingly.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
C++ equalize lookup table tests and equalize op python tests
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [x] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
