### PR TITLE
Add pipeline inputs to pipeline_def

### DIFF
--- a/dali/python/__init__.py.in
+++ b/dali/python/__init__.py.in
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2017-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,5 +27,5 @@ from . import tfrecord
 from . import types
 from . import plugin_manager
 from . import sysconfig
-from .pipeline import Pipeline, pipeline_def
+from .pipeline import Pipeline, pipeline_def, Input
 from .data_node import newaxis

--- a/dali/test/python/test_pipeline.py
+++ b/dali/test/python/test_pipeline.py
@@ -1904,3 +1904,13 @@ def test_double_output_dtype_ndim():
         create_test_package(output_dtype=int)
     with assert_raises(ValueError, glob="*types.NO_TYPE*"):
         create_test_package(output_dtype=types.NO_TYPE)
+
+
+def test_pipeline_def_with_inputs():
+    @pipeline_def()
+    def my_pipe(x: dali.Input, y: dali.Input):
+        return x + y
+
+    pipe = my_pipe(batch_size=1, device_id=None, num_threads=1)
+    out, = pipe.run(x=[np.array([1, 2, 3])], y=[np.float32(42)])
+    assert np.array_equal(out[0], np.float32([43, 44, 45]))


### PR DESCRIPTION
Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**New feature** (*non-breaking change which adds functionality*)

## Description:
This PR adds a feature that allows the user to specify external inputs in pipeline def.
Also, it makes the pipeline build itself upon first call to `run` (no need to call `build` explicitly).

Usage:
```Python
@pipeline_def()
def my_pipe(x: dali.Input, y: dali.Input):
    return x + y

pipe = my_pipe(batch_size=1, device_id=None, num_threads=1)

out, = pipe.run(x=[np.array([1, 2, 3])], y=[np.float32(42)])
```

Limitations:
- the inputs are always batch
- no support for parallelism
- it only produces sane results with prefetch_queue_depth of 1 (and it actively sets it so or errors out if the user specifies a different value manually)



## Additional information:

### Affected modules and functionalities:
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
*TODO* More tests needed!

- [ ] Existing tests apply
- [X] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
*TODO*
- [ ] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [X] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
