### PR TITLE
Enable JPEG fancy upsampling for mixed image decoder

### DIFF
--- a/dali/imgcodec/decoders/nvjpeg/nvjpeg.cc
+++ b/dali/imgcodec/decoders/nvjpeg/nvjpeg.cc
@@ -49,11 +49,12 @@ NvJpegDecoderInstance(int device_id, const std::map<std::string, any> &params)
 , device_allocator_(nvjpeg_memory::GetDeviceAllocator())
 , pinned_allocator_(nvjpeg_memory::GetPinnedAllocator()) {
   SetParams(params);
-#ifdef NVJPEG_FLAGS_UPSAMPLING_WITH_INTERPOLATION
-  unsigned int nvjpeg_flags = use_jpeg_fancy_upsampling_ && nvjpegGetVersion() >= 12001 ?
-                                NVJPEG_FLAGS_UPSAMPLING_WITH_INTERPOLATION : 0;
-#else
+
   unsigned int nvjpeg_flags = 0;
+#ifdef NVJPEG_FLAGS_UPSAMPLING_WITH_INTERPOLATION
+  if (use_jpeg_fancy_upsampling_ && nvjpegGetVersion() >= 12001) {
+    nvjpeg_flags |= NVJPEG_FLAGS_UPSAMPLING_WITH_INTERPOLATION;
+  }
 #endif
 
   DeviceGuard dg(device_id_);

--- a/dali/imgcodec/decoders/nvjpeg/nvjpeg.h
+++ b/dali/imgcodec/decoders/nvjpeg/nvjpeg.h
@@ -70,6 +70,7 @@ class DLL_PUBLIC NvJpegDecoderInstance : public BatchParallelDecoderImpl {
   size_t host_memory_padding_ = 0;
   nvjpegDevAllocator_t device_allocator_;
   nvjpegPinnedAllocator_t pinned_allocator_;
+  bool use_jpeg_fancy_upsampling_;
 
   struct DecoderData {
     nvjpegJpegDecoder_t decoder = nullptr;

--- a/dali/imgcodec/decoders/nvjpeg/nvjpeg.h
+++ b/dali/imgcodec/decoders/nvjpeg/nvjpeg.h
@@ -70,7 +70,7 @@ class DLL_PUBLIC NvJpegDecoderInstance : public BatchParallelDecoderImpl {
   size_t host_memory_padding_ = 0;
   nvjpegDevAllocator_t device_allocator_;
   nvjpegPinnedAllocator_t pinned_allocator_;
-  bool use_jpeg_fancy_upsampling_;
+  bool use_jpeg_fancy_upsampling_ = false;
 
   struct DecoderData {
     nvjpegJpegDecoder_t decoder = nullptr;

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -147,7 +147,7 @@ with little reduction in quality.)code",
   .AddOptionalArg("jpeg_fancy_upsampling",
       R"code(Make the ``mixed`` backend use the same chroma upsampling approach as the ``cpu`` one.
 
-The option corresponds to the `JPEG fancy upsampling` avialable in libjpegturbo or
+The option corresponds to the `JPEG fancy upsampling` available in libjpegturbo or
 ImageMagick.)code",
       false)
   .AddOptionalArg("memory_stats",

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -147,7 +147,8 @@ with little reduction in quality.)code",
   .AddOptionalArg("jpeg_fancy_upsampling",
       R"code(Make the ``mixed`` backend use the same chroma upsampling approach as the ``cpu`` one.
 
-The option corresponds to the `JPEG fancy upsampling`.)code",
+The option corresponds to the `JPEG fancy upsampling` avialable in libjpegturbo or
+ImageMagick.)code",
       false)
   .AddOptionalArg("memory_stats",
       R"code(Applies **only** to the ``mixed`` backend type.

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -144,6 +144,11 @@ the GPU implementation.
 According to the libjpeg-turbo documentation, decompression performance is improved by up to 14%
 with little reduction in quality.)code",
       false)
+  .AddOptionalArg("use_jpegturbo_upsampling",
+      R"code(Make the ``mixed`` backend use the same chroma upsampling approach as the ``cpu`` one.
+
+The option corresponds to the `JPEG fancy upsampling`.)code",
+      false)
   .AddOptionalArg("memory_stats",
       R"code(Applies **only** to the ``mixed`` backend type.
 

--- a/dali/operators/decoder/image_decoder.cc
+++ b/dali/operators/decoder/image_decoder.cc
@@ -144,7 +144,7 @@ the GPU implementation.
 According to the libjpeg-turbo documentation, decompression performance is improved by up to 14%
 with little reduction in quality.)code",
       false)
-  .AddOptionalArg("use_jpegturbo_upsampling",
+  .AddOptionalArg("jpeg_fancy_upsampling",
       R"code(Make the ``mixed`` backend use the same chroma upsampling approach as the ``cpu`` one.
 
 The option corresponds to the `JPEG fancy upsampling`.)code",

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -64,7 +64,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     output_image_type_(spec.GetArgument<DALIImageType>("output_type")),
     hybrid_huffman_threshold_(spec.GetArgument<unsigned int>("hybrid_huffman_threshold")),
     use_fast_idct_(spec.GetArgument<bool>("use_fast_idct")),
-    use_jpegturbo_upsampling_(spec.GetArgument<bool>("jpeg_fancy_upsampling")),
+    use_jpeg_fancy_upsampling_(spec.GetArgument<bool>("jpeg_fancy_upsampling")),
     output_shape_(max_batch_size_, kOutputDim),
     pinned_buffers_(num_threads_*2),
     jpeg_streams_(num_threads_*2),
@@ -97,7 +97,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     // adjust NVJPEG to (full capacity of) H100
     (void) num_hw_engines_;
 #ifdef NVJPEG_FLAGS_UPSAMPLING_WITH_INTERPOLATION
-    unsigned int nvjpeg_flags = use_jpegturbo_upsampling_ ?
+    unsigned int nvjpeg_flags = use_jpeg_fancy_upsampling_ && nvjpegGetVersion() >= 12001 ?
                                   NVJPEG_FLAGS_UPSAMPLING_WITH_INTERPOLATION : 0;
 #else
     unsigned int nvjpeg_flags = 0;
@@ -1073,7 +1073,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
   unsigned int hybrid_huffman_threshold_;
   bool use_fast_idct_;
-  bool use_jpegturbo_upsampling_;
+  bool use_jpeg_fancy_upsampling_;
 
   TensorListShape<> output_shape_;
 

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -113,7 +113,8 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     }
 
     if (try_init_hw_decoder &&
-        nvjpegCreateEx(NVJPEG_BACKEND_HARDWARE, NULL, NULL, nvjpeg_flags, &handle_) == NVJPEG_STATUS_SUCCESS) {
+        nvjpegCreateEx(NVJPEG_BACKEND_HARDWARE, NULL, NULL, nvjpeg_flags, &handle_)
+                                                                        == NVJPEG_STATUS_SUCCESS) {
     // disable HW decoder for drivers < 455.x as the memory pool for it is not available
     // and multi GPU performance is far from perfect due to frequent memory allocations
 #if NVML_ENABLED

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -64,6 +64,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     output_image_type_(spec.GetArgument<DALIImageType>("output_type")),
     hybrid_huffman_threshold_(spec.GetArgument<unsigned int>("hybrid_huffman_threshold")),
     use_fast_idct_(spec.GetArgument<bool>("use_fast_idct")),
+    use_jpegturbo_upsampling_(spec.GetArgument<bool>("use_jpegturbo_upsampling")),
     output_shape_(max_batch_size_, kOutputDim),
     pinned_buffers_(num_threads_*2),
     jpeg_streams_(num_threads_*2),
@@ -95,6 +96,12 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     // TODO(ktokarski) TODO(jlisiecki) For now it is unused,
     // adjust NVJPEG to (full capacity of) H100
     (void) num_hw_engines_;
+#ifdef NVJPEG_FLAGS_UPSAMPLING_WITH_INTERPOLATION
+    unsigned int nvjpeg_flags = use_jpegturbo_upsampling_ ?
+                                  NVJPEG_FLAGS_UPSAMPLING_WITH_INTERPOLATION : 0;
+#else
+    unsigned int nvjpeg_flags = 0;
+#endif
 #if IS_HW_DECODER_COMPATIBLE
     // if hw_decoder_load is not present in the schema (crop/sliceDecoder) then it is not supported
     bool try_init_hw_decoder = false;
@@ -106,7 +113,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     }
 
     if (try_init_hw_decoder &&
-        nvjpegCreate(NVJPEG_BACKEND_HARDWARE, NULL, &handle_) == NVJPEG_STATUS_SUCCESS) {
+        nvjpegCreateEx(NVJPEG_BACKEND_HARDWARE, NULL, NULL, nvjpeg_flags, &handle_) == NVJPEG_STATUS_SUCCESS) {
     // disable HW decoder for drivers < 455.x as the memory pool for it is not available
     // and multi GPU performance is far from perfect due to frequent memory allocations
 #if NVML_ENABLED
@@ -117,7 +124,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
         hw_decoder_load_ = 0;
         CUDA_CALL(nvjpegDestroy(handle_));
         LOG_LINE << "NVJPEG_BACKEND_HARDWARE is disabled due to performance reason" << std::endl;
-        CUDA_CALL(nvjpegCreateSimple(&handle_));
+        CUDA_CALL(nvjpegCreateEx(NVJPEG_BACKEND_DEFAULT, NULL, NULL, nvjpeg_flags, &handle_));
         DALI_WARN("Due to performance reason HW NVJPEG decoder is disabled for the driver "
                   "older than 455.x");
       } else {
@@ -182,10 +189,10 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 #endif
     } else {
       LOG_LINE << "NVJPEG_BACKEND_HARDWARE is either disabled or not supported" << std::endl;
-      CUDA_CALL(nvjpegCreateSimple(&handle_));
+      CUDA_CALL(nvjpegCreateEx(NVJPEG_BACKEND_DEFAULT, NULL, NULL, nvjpeg_flags, &handle_));
     }
 #else
-    CUDA_CALL(nvjpegCreateSimple(&handle_));
+    CUDA_CALL(nvjpegCreateEx(NVJPEG_BACKEND_DEFAULT, NULL, NULL, nvjpeg_flags, &handle_));
 #endif
 
     size_t device_memory_padding = spec.GetArgument<Index>("device_memory_padding");
@@ -1065,6 +1072,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
 
   unsigned int hybrid_huffman_threshold_;
   bool use_fast_idct_;
+  bool use_jpegturbo_upsampling_;
 
   TensorListShape<> output_shape_;
 

--- a/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
+++ b/dali/operators/decoder/nvjpeg/nvjpeg_decoder_decoupled_api.h
@@ -64,7 +64,7 @@ class nvJPEGDecoder : public Operator<MixedBackend>, CachedDecoderImpl {
     output_image_type_(spec.GetArgument<DALIImageType>("output_type")),
     hybrid_huffman_threshold_(spec.GetArgument<unsigned int>("hybrid_huffman_threshold")),
     use_fast_idct_(spec.GetArgument<bool>("use_fast_idct")),
-    use_jpegturbo_upsampling_(spec.GetArgument<bool>("use_jpegturbo_upsampling")),
+    use_jpegturbo_upsampling_(spec.GetArgument<bool>("jpeg_fancy_upsampling")),
     output_shape_(max_batch_size_, kOutputDim),
     pinned_buffers_(num_threads_*2),
     jpeg_streams_(num_threads_*2),

--- a/dali/operators/imgcodec/decoder.cc
+++ b/dali/operators/imgcodec/decoder.cc
@@ -140,7 +140,8 @@ with little reduction in quality.)code",
   .AddOptionalArg("jpeg_fancy_upsampling",
       R"code(Make the ``mixed`` backend use the same chroma upsampling approach as the ``cpu`` one.
 
-The option corresponds to the `JPEG fancy upsampling`.)code",
+The option corresponds to the `JPEG fancy upsampling` avialable in libjpegturbo or
+ImageMagick.)code",
       false)
   .AddOptionalArg("memory_stats",
       R"code(Applies **only** to the ``mixed`` backend type.

--- a/dali/operators/imgcodec/decoder.cc
+++ b/dali/operators/imgcodec/decoder.cc
@@ -140,7 +140,7 @@ with little reduction in quality.)code",
   .AddOptionalArg("jpeg_fancy_upsampling",
       R"code(Make the ``mixed`` backend use the same chroma upsampling approach as the ``cpu`` one.
 
-The option corresponds to the `JPEG fancy upsampling` avialable in libjpegturbo or
+The option corresponds to the `JPEG fancy upsampling` available in libjpegturbo or
 ImageMagick.)code",
       false)
   .AddOptionalArg("memory_stats",

--- a/dali/operators/imgcodec/decoder.cc
+++ b/dali/operators/imgcodec/decoder.cc
@@ -137,6 +137,11 @@ the GPU implementation.
 According to the libjpeg-turbo documentation, decompression performance is improved by up to 14%
 with little reduction in quality.)code",
       false)
+  .AddOptionalArg("jpeg_fancy_upsampling",
+      R"code(Make the ``mixed`` backend use the same chroma upsampling approach as the ``cpu`` one.
+
+The option corresponds to the `JPEG fancy upsampling`.)code",
+      false)
   .AddOptionalArg("memory_stats",
       R"code(Applies **only** to the ``mixed`` backend type.
 

--- a/dali/operators/imgcodec/decoder.h
+++ b/dali/operators/imgcodec/decoder.h
@@ -75,6 +75,7 @@ class DecoderBase : public Operator<Backend> {
     GetDecoderSpecificArgument<size_t>(spec, "preallocate_width_hint");
     GetDecoderSpecificArgument<size_t>(spec, "preallocate_height_hint");
     GetDecoderSpecificArgument<bool>(spec, "use_fast_idct");
+    GetDecoderSpecificArgument<bool>(spec, "jpeg_fancy_upsampling");
     GetDecoderSpecificArgument<int>(spec, "num_threads");
 
     if (decoder_params_.count("nvjpeg_num_threads") == 0)

--- a/dali/test/python/decoder/test_image.py
+++ b/dali/test/python/decoder/test_image.py
@@ -47,10 +47,10 @@ def get_img_files(data_path, subdir='*', ext=None):
 
 
 @pipeline_def
-def decoder_pipe(data_path, device, use_fast_idct=False, memory_stats=False):
+def decoder_pipe(data_path, device, use_fast_idct=False, memory_stats=False, **kwargs):
     inputs, labels = fn.readers.file(file_root=data_path, shard_id=0, num_shards=1, name="Reader")
     decoded = fn.decoders.image(inputs, device=device, output_type=types.RGB,
-                                use_fast_idct=use_fast_idct, memory_stats=memory_stats)
+                                use_fast_idct=use_fast_idct, memory_stats=memory_stats, **kwargs)
 
     return decoded, labels
 
@@ -202,6 +202,24 @@ def test_FastDCT():
         for batch_size in {1, 8}:
             for img_type in test_good_path:
                 yield check_FastDCT_body, batch_size, img_type, device
+
+
+def check_fancy_upsampling_body(batch_size, img_type, device):
+    data_path = os.path.join(test_data_root, good_path, img_type)
+    compare_pipelines(
+        decoder_pipe(data_path=data_path, batch_size=batch_size, num_threads=3,
+                     device_id=0, device=device, use_jpegturbo_upsampling=True),
+        decoder_pipe(data_path=data_path, batch_size=batch_size, num_threads=3,
+                     device_id=0, device='cpu'),
+        batch_size=batch_size, N_iterations=3, eps=1)
+
+
+def test_fancy_upsampling():
+    if nvidia.dali.backend.GetNvjpegVersion() < 12000:
+        from nose import SkipTest
+        raise SkipTest("nvJPEG doesn't support fancy upsampling in this version")
+    for batch_size in {1, 8}:
+        yield check_fancy_upsampling_body, batch_size, 'jpeg', 'mixed'
 
 
 def test_image_decoder_memory_stats():

--- a/dali/test/python/decoder/test_imgcodec.py
+++ b/dali/test/python/decoder/test_imgcodec.py
@@ -49,10 +49,11 @@ def get_img_files(data_path, subdir='*', ext=None):
 
 
 @pipeline_def
-def decoder_pipe(data_path, device, use_fast_idct=False, **kwargs):
+def decoder_pipe(data_path, device, use_fast_idct=False, jpeg_fancy_upsampling=False):
     inputs, labels = fn.readers.file(file_root=data_path, shard_id=0, num_shards=1, name="Reader")
     decoded = fn.experimental.decoders.image(inputs, device=device, output_type=types.RGB,
-                                             use_fast_idct=use_fast_idct, **kwargs)
+                                             use_fast_idct=use_fast_idct,
+                                             jpeg_fancy_upsampling=jpeg_fancy_upsampling)
 
     return decoded, labels
 
@@ -211,14 +212,14 @@ def check_fancy_upsampling_body(batch_size, img_type, device):
     data_path = os.path.join(test_data_root, good_path, img_type)
     compare_pipelines(
         decoder_pipe(data_path=data_path, batch_size=batch_size, num_threads=3,
-                     device_id=0, device=device, use_jpegturbo_upsampling=True),
+                     device_id=0, device=device, jpeg_fancy_upsampling=True),
         decoder_pipe(data_path=data_path, batch_size=batch_size, num_threads=3,
                      device_id=0, device='cpu'),
         batch_size=batch_size, N_iterations=3, eps=1)
 
 
 def test_fancy_upsampling():
-    if nvidia.dali.backend.GetNvjpegVersion() < 12000:
+    if nvidia.dali.backend.GetNvjpegVersion() < 12001:
         from nose import SkipTest
         raise SkipTest("nvJPEG doesn't support fancy upsampling in this version")
     for batch_size in {1, 8}:

--- a/dali/test/python/decoder/test_imgcodec.py
+++ b/dali/test/python/decoder/test_imgcodec.py
@@ -49,10 +49,10 @@ def get_img_files(data_path, subdir='*', ext=None):
 
 
 @pipeline_def
-def decoder_pipe(data_path, device, use_fast_idct=False):
+def decoder_pipe(data_path, device, use_fast_idct=False, **kwargs):
     inputs, labels = fn.readers.file(file_root=data_path, shard_id=0, num_shards=1, name="Reader")
     decoded = fn.experimental.decoders.image(inputs, device=device, output_type=types.RGB,
-                                             use_fast_idct=use_fast_idct)
+                                             use_fast_idct=use_fast_idct, **kwargs)
 
     return decoded, labels
 
@@ -205,6 +205,24 @@ def test_FastDCT():
         for batch_size in {1, 8}:
             for img_type in test_good_path:
                 yield check_FastDCT_body, batch_size, img_type, device
+
+
+def check_fancy_upsampling_body(batch_size, img_type, device):
+    data_path = os.path.join(test_data_root, good_path, img_type)
+    compare_pipelines(
+        decoder_pipe(data_path=data_path, batch_size=batch_size, num_threads=3,
+                     device_id=0, device=device, use_jpegturbo_upsampling=True),
+        decoder_pipe(data_path=data_path, batch_size=batch_size, num_threads=3,
+                     device_id=0, device='cpu'),
+        batch_size=batch_size, N_iterations=3, eps=1)
+
+
+def test_fancy_upsampling():
+    if nvidia.dali.backend.GetNvjpegVersion() < 12000:
+        from nose import SkipTest
+        raise SkipTest("nvJPEG doesn't support fancy upsampling in this version")
+    for batch_size in {1, 8}:
+        yield check_fancy_upsampling_body, batch_size, 'jpeg', 'mixed'
 
 
 batch_size_test = 16


### PR DESCRIPTION
 - the most recent nvJPEG provides an ability to enable similar
   upsampling method to the libjpegturbo so the CPU and GPU decoding
   results should be more aligned

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
 - the most recent nvJPEG provides an ability to enable similar
   upsampling method to the libjpegturbo so the CPU and GPU decoding
   results should be more aligned
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- nvJPEG image decoder
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- see https://docs.nvidia.com/cuda/nvjpeg/index.html#nvjpeg-flags
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [ ] Existing tests apply
- [ ] New tests added
  - [x] Python tests
    - test_image:test_fancy_upsampling
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [x] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
