### PR TITLE
Add support for fp16 in arithmetic and mathematical ops

### DIFF
--- a/dali/operators/math/expressions/arithmetic_meta.h
+++ b/dali/operators/math/expressions/arithmetic_meta.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -261,10 +261,9 @@ DALI_HOST_DEV constexpr bool IsComparison(ArithmeticOp op) {
   }
 }
 
-
-// TODO(klecki): float16
-#define ARITHMETIC_ALLOWED_TYPES \
-  (bool, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float, double)
+#define ARITHMETIC_ALLOWED_TYPES                                                                   \
+  (bool, uint8_t, uint16_t, uint32_t, uint64_t, int8_t, int16_t, int32_t, int64_t, float16, float, \
+  double)
 
 /**
  * @brief Type promotion rules

--- a/dali/test/python/operator_1/test_arithmetic_ops.py
+++ b/dali/test/python/operator_1/test_arithmetic_ops.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -72,8 +72,7 @@ integer_types = [
     np.bool_, np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64
 ]
 
-# float16 is marked as TODO in backend for gpu
-float_types = [np.float32, np.float64]
+float_types = [np.float16, np.float32, np.float64]
 
 input_types = integer_types + float_types
 

--- a/docs/math.rst
+++ b/docs/math.rst
@@ -65,7 +65,7 @@ The resulting type is calculated in accordance to the table below.
 
 ``T`` stands for any one of the supported numerical types:
 ``bool``, ``int8``, ``int16``, ``int32``, ``int64``, ``uint8``, ``uint16``,
-``uint32``, ``uint64``, ``float32``, and ``float64``.
+``uint32``, ``uint64``, ``float16``, ``float32``, and ``float64``.
 
 ``bool`` type is considered the smallest unsigned integer type and is treated as ``uint1``
 with respect to the table above.


### PR DESCRIPTION
## Category: **New feature*
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
Add support for fp16 in arithmetic and mathematical ops



## Additional information:

### Affected modules and functionalities:
Arithm ops


### Key points relevant for the review:
Any spots where we need to also adjust the config?

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
I added np.float16 to the tested types, the coverage is already pretty extensive.
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [ ] Existing documentation applies
- [x] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [x] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [ ] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
