### PR TITLE
Release buffered libaviutil packets

### DIFF
--- a/dali/operators/reader/loader/video_loader.cc
+++ b/dali/operators/reader/loader/video_loader.cc
@@ -382,6 +382,8 @@ VideoFile& VideoLoader::get_or_open_file(const std::string &filename) {
       "Variable frame rate videos are unsupported. This heuristic can yield false positives. "
       "The check can be disabled via the skip_vfr_check flag. Check failed for file: " + filename);
     av_packet_unref(&pkt);
+    // empty the read buffer from av_read_frame to save the memory usage
+    avformat_flush(file.fmt_ctx_.get());
 
     auto duration = stream->duration;
     // if no info in the stream check the container
@@ -685,6 +687,8 @@ void VideoLoader::read_file() {
 
   // flush the decoder
   vid_decoder_->decode_packet(nullptr, 0, {0}, 0);
+  // empty the read buffer from av_read_frame to save the memory usage
+  avformat_flush(file.fmt_ctx_.get());
 }
 
 void VideoLoader::push_sequence_to_read(std::string filename, int frame, int count) {


### PR DESCRIPTION
- certain libaviutils functions that read the video packets
  buffers it for further use. As DALI keeps libaviutils context
  for each video file it processes it may lead to unnecessarily
  high memory consumption. This PR releases the buffered packets
  when the iteration with the file ends.
- relates to https://github.com/NVIDIA/DALI/issues/4675

<!---
Thank you for contributing to NVIDIA DALI! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

We need a few more information from you to proceed.
Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
--->


## Category:
**Other** (*e.g. Documentation, Tests, Configuration*)
<!---
Please pick one from below:
**Bug fix** (*non-breaking change which fixes an issue*)
**New feature** (*non-breaking change which adds functionality*)
**Breaking change** (*fix or feature that would cause existing functionality to not work as expected*)
**Refactoring** (*Redesign of existing code that doesn't affect functionality*)
**Other** (*e.g. Documentation, Tests, Configuration*)
--->


## Description:
- certain libaviutils functions that read the video packets
  buffers it for further use. As DALI keeps libaviutils context
  for each video file it processes it may lead to unnecessarily
  high memory consumption. This PR releases the buffered packets
  when the iteration with the file ends.
<!---
Please explain what kind of change is in this PR and why it is submitted.
Any additional context or description of the solution is welcomed.
Examples:
- It fixes a bug *bug description*
- It adds new feature needed because of *why we need this feature*
- Refactoring to improve *what*
- The *new feature/bugfix* uses *a new data structure/algorithm* to do *X* instead of *Y*.
--->



## Additional information:

### Affected modules and functionalities:
- video reader
<!--- Describe here what was changed, added, removed. --->



### Key points relevant for the review:
- NA
<!--- Describe here what is the most important part that reviewers should focus on. --->

### Tests:
<!--- Describe the test coverage of the introduced change.

If you select `Existing tests apply` option, please list which test cases cover the introduced
functionality. For example:
- test_operator_gaussian_blur.py: test_gaussian*
- tensor_list_test.cc: TensorListVariableBatchSizeTest*
--->
- [x] Existing tests apply
  - test_video_pipeline.py
- [ ] New tests added
  - [ ] Python tests
  - [ ] GTests
  - [ ] Benchmark
  - [ ] Other
- [ ] N/A


<!---
At this point you can hit "Create".
The checklist below shall be filled in the created PR.
--->

## Checklist

### Documentation
- [x] Existing documentation applies
- [ ] Documentation updated
  - [ ] Docstring
  - [ ] Doxygen
  - [ ] RST
  - [ ] Jupyter
  - [ ] Other
- [ ] N/A

### DALI team only

#### Requirements
- [ ] Implements new requirements
- [ ] Affects existing requirements
- [x] N/A

**REQ IDs**: N/A
<!---  Introduce new or affected requirement IDs, if applicable --->

**JIRA TASK**: N/A
<!--- DALI-XXXX or NA --->
